### PR TITLE
feat: implement LedgerStateFix, EnableAmendment, and UNLModify transa…

### DIFF
--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -642,6 +642,43 @@ func (e *TestEnv) Submit(transaction interface{}) TxResult {
 	}
 }
 
+// SubmitPseudo submits a pseudo-transaction (EnableAmendment, SetFee, UNLModify)
+// directly to the engine. Pseudo-transactions bypass account lookup, sequence
+// auto-fill, fee deduction, and signature verification.
+// Reference: rippled Change.cpp — pseudo-txs have zero account, zero fee, no sigs.
+func (e *TestEnv) SubmitPseudo(transaction interface{}) TxResult {
+	e.t.Helper()
+
+	txn, ok := transaction.(tx.Transaction)
+	if !ok {
+		e.t.Fatalf("Transaction does not implement tx.Transaction interface")
+		return TxResult{Code: "temINVALID", Success: false, Message: "Invalid transaction type"}
+	}
+
+	parentCloseTime := uint32(e.clock.Now().Unix() - 946684800)
+	engineConfig := tx.EngineConfig{
+		BaseFee:                   e.baseFee,
+		ReserveBase:               e.reserveBase,
+		ReserveIncrement:          e.reserveIncrement,
+		LedgerSequence:            e.ledger.Sequence(),
+		SkipSignatureVerification: true,
+		Rules:                     e.rulesBuilder.Build(),
+		ParentCloseTime:           parentCloseTime,
+		NetworkID:                 e.networkID,
+		ParentHash:                e.ledger.ParentHash(),
+	}
+
+	engine := tx.NewEngine(e.ledger, engineConfig)
+	applyResult := engine.Apply(txn)
+
+	return TxResult{
+		Code:     applyResult.Result.String(),
+		Success:  applyResult.Result.IsSuccess(),
+		Message:  applyResult.Message,
+		Metadata: applyResult.Metadata,
+	}
+}
+
 // Balance returns the XRP balance of an account in drops.
 func (e *TestEnv) Balance(acc *Account) uint64 {
 	e.t.Helper()

--- a/internal/testing/nft/fix_nftoken_page_links_test.go
+++ b/internal/testing/nft/fix_nftoken_page_links_test.go
@@ -12,8 +12,12 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/nftoken"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/stretchr/testify/require"
+
 	jtx "github.com/LeJamon/goXRPLd/internal/testing"
 	"github.com/LeJamon/goXRPLd/internal/testing/nft"
 )
@@ -51,6 +55,53 @@ func genPackedTokensForOwner(env *jtx.TestEnv, owner, minter *jtx.Account) []str
 
 	sort.Strings(nfts)
 	return nfts
+}
+
+// genPackedTokens generates 96 NFTs packed into three pages of 32 each.
+// The owner mints the NFTs directly (matching rippled's genPackedTokens).
+// Returns a sorted list of NFT IDs.
+func genPackedTokens(env *jtx.TestEnv, owner *jtx.Account) []string {
+	nfts := make([]string, 0, 96)
+
+	for i := uint32(0); i < 96; i++ {
+		intTaxon := (i / 16)
+		if i&0b10000 != 0 {
+			intTaxon += 2
+		}
+
+		tokenSeq := env.MintedCount(owner)
+		extTaxon := nftoken.CipheredTaxon(tokenSeq, intTaxon)
+
+		flags := nftoken.NFTokenFlagTransferable
+		nftID := nft.GetNextNFTokenID(env, owner, extTaxon, flags, 0)
+		env.Submit(nft.NFTokenMint(owner, extTaxon).Transferable().Build())
+		env.Close()
+
+		nfts = append(nfts, nftID)
+	}
+
+	sort.Strings(nfts)
+	return nfts
+}
+
+// readNFTokenPage reads and parses an NFTokenPage at the given keylet.
+// Returns nil if the page does not exist.
+func readNFTokenPage(t *testing.T, env *jtx.TestEnv, kl keylet.Keylet) *state.NFTokenPageData {
+	t.Helper()
+	data, err := env.LedgerEntry(kl)
+	if err != nil || data == nil {
+		return nil
+	}
+	page, parseErr := state.ParseNFTokenPage(data)
+	if parseErr != nil {
+		return nil
+	}
+	return page
+}
+
+// nftPageKeylet constructs an NFTokenPage keylet from a base (min) and a page key.
+func nftPageKeylet(base keylet.Keylet, pageKey [32]byte) keylet.Keylet {
+	return keylet.NFTokenPageForToken(base, pageKey)
 }
 
 // ===========================================================================
@@ -139,11 +190,21 @@ func TestLedgerStateFixErrors(t *testing.T) {
 
 	// Preclaim: Owner account must exist in ledger.
 	// Reference: rippled FixNFTokenPageLinks_test.cpp:192-197
-	// In rippled, preclaim checks Owner account exists → tecOBJECT_NOT_FOUND.
-	// The Go LedgerStateFix does not implement Appliable (no ApplyContext param),
-	// so the engine cannot perform preclaim checks on the Owner field.
+	// In rippled, preclaim checks Owner account exists -> tecOBJECT_NOT_FOUND.
+	// Now that Apply() has ApplyContext, we can perform preclaim checks.
 	t.Run("tecOBJECT_NOT_FOUND when Owner does not exist", func(t *testing.T) {
-		t.Skip("Go LedgerStateFix does not implement preclaim Owner check (no Appliable interface)")
+		env := jtx.NewTestEnv(t)
+		env.Fund(alice)
+		env.Close()
+
+		// carol is known but not funded (equivalent to rippled's env.memoize(carol))
+		carol := jtx.NewAccount("carol")
+
+		linkFixFee := env.ReserveIncrement()
+		result := env.Submit(
+			nft.LedgerStateFixNFTPageLinks(alice, carol).Fee(linkFixFee).Build(),
+		)
+		jtx.RequireTxFail(t, result, "tecOBJECT_NOT_FOUND")
 	})
 }
 
@@ -154,10 +215,48 @@ func TestLedgerStateFixErrors(t *testing.T) {
 // Tests error cases where there is nothing to fix in the owner's NFT pages.
 // ===========================================================================
 func TestTokenPageLinkErrors(t *testing.T) {
-	// These tests require the LedgerStateFix Apply() to actually inspect
-	// NFToken pages and return tecFAILED_PROCESSING when nothing is broken.
-	// The current Go Apply() is a stub that returns tesSUCCESS unconditionally.
-	t.Skip("Requires LedgerStateFix Apply() to inspect NFToken pages (currently a stub)")
+	alice := jtx.NewAccount("alice")
+
+	env := jtx.NewTestEnv(t)
+	env.Fund(alice)
+	env.Close()
+
+	linkFixFee := env.ReserveIncrement()
+
+	// Owner has no pages to fix.
+	// Reference: rippled FixNFTokenPageLinks_test.cpp:218-220
+	t.Run("no pages - tecFAILED_PROCESSING", func(t *testing.T) {
+		result := env.Submit(
+			nft.LedgerStateFixNFTPageLinks(alice, alice).Fee(linkFixFee).Build(),
+		)
+		jtx.RequireTxFail(t, result, "tecFAILED_PROCESSING")
+	})
+
+	// Alice has only one page (undamaged).
+	// Reference: rippled FixNFTokenPageLinks_test.cpp:222-228
+	t.Run("one page undamaged - tecFAILED_PROCESSING", func(t *testing.T) {
+		env.Submit(nft.NFTokenMint(alice, 0).Transferable().Build())
+		env.Close()
+
+		result := env.Submit(
+			nft.LedgerStateFixNFTPageLinks(alice, alice).Fee(linkFixFee).Build(),
+		)
+		jtx.RequireTxFail(t, result, "tecFAILED_PROCESSING")
+	})
+
+	// Alice has at least three pages (undamaged).
+	// Reference: rippled FixNFTokenPageLinks_test.cpp:230-239
+	t.Run("three pages undamaged - tecFAILED_PROCESSING", func(t *testing.T) {
+		for i := uint32(0); i < 64; i++ {
+			env.Submit(nft.NFTokenMint(alice, 0).Transferable().Build())
+			env.Close()
+		}
+
+		result := env.Submit(
+			nft.LedgerStateFixNFTPageLinks(alice, alice).Fee(linkFixFee).Build(),
+		)
+		jtx.RequireTxFail(t, result, "tecFAILED_PROCESSING")
+	})
 }
 
 // ===========================================================================
@@ -170,8 +269,327 @@ func TestTokenPageLinkErrors(t *testing.T) {
 // 3. Links missing in middle of chain (carol)
 // ===========================================================================
 func TestFixNFTokenPageLinks(t *testing.T) {
-	// This test requires the full LedgerStateFix Apply() implementation
-	// which inspects and repairs NFToken page links. The current Go
-	// implementation is a stub that returns tesSUCCESS without modifying state.
-	t.Skip("Requires full LedgerStateFix Apply() implementation (currently a stub)")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	daria := jtx.NewAccount("daria")
+
+	// Start with fixNFTokenPageLinks disabled to create damaged directories
+	env := jtx.NewTestEnv(t)
+	env.DisableFeature("fixNFTokenPageLinks")
+
+	// Fund enough for the massive number of operations.
+	// Each account needs: 96 mints + 96 sells + 96 accepts + reserve + fees
+	// Use generous funding
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.FundAmount(carol, uint64(jtx.XRP(10000)))
+	env.FundAmount(daria, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	// ******************************************************************
+	// Step 1A: Create damaged NFToken directories:
+	//   One where there is only one page, but without the final index.
+	// ******************************************************************
+
+	// alice generates three packed pages
+	aliceNFTs := genPackedTokens(env, alice)
+	require.Equal(t, 96, len(aliceNFTs), "alice should have 96 NFTs")
+	require.Equal(t, uint32(3), env.OwnerCount(alice), "alice should have 3 pages")
+
+	// Get the index of the middle page
+	aliceMaxKl := keylet.NFTokenPageMax(alice.ID)
+	aliceLastPage := readNFTokenPage(t, env, aliceMaxKl)
+	require.NotNil(t, aliceLastPage, "alice's last page should exist")
+	aliceMiddleNFTokenPageIndex := aliceLastPage.PreviousPageMin
+
+	// alice burns all the tokens in the first and last pages
+	// Burn first 32 tokens
+	for i := 0; i < 32; i++ {
+		env.Submit(nft.NFTokenBurn(alice, aliceNFTs[i]).Build())
+		env.Close()
+	}
+	aliceNFTs = aliceNFTs[32:]
+
+	// Burn last 32 tokens
+	for i := 0; i < 32; i++ {
+		env.Submit(nft.NFTokenBurn(alice, aliceNFTs[len(aliceNFTs)-1]).Build())
+		aliceNFTs = aliceNFTs[:len(aliceNFTs)-1]
+		env.Close()
+	}
+	require.Equal(t, uint32(1), env.OwnerCount(alice), "alice should have 1 page after burns")
+	require.Equal(t, 32, len(aliceNFTs), "alice should have 32 remaining NFTs")
+
+	// Removing the last token from the last page deletes the last page.
+	// This is a bug — the contents should have been moved into the last page.
+	require.False(t, env.LedgerEntryExists(aliceMaxKl), "alice's max page should be gone (damaged)")
+
+	// alice's "middle" page is still present, but has no links
+	aliceMiddleKl := nftPageKeylet(keylet.NFTokenPageMin(alice.ID), aliceMiddleNFTokenPageIndex)
+	aliceMiddlePage := readNFTokenPage(t, env, aliceMiddleKl)
+	require.NotNil(t, aliceMiddlePage, "alice's middle page should exist")
+	var emptyHash [32]byte
+	require.Equal(t, emptyHash, aliceMiddlePage.PreviousPageMin, "alice's middle page should have no PreviousPageMin")
+	require.Equal(t, emptyHash, aliceMiddlePage.NextPageMin, "alice's middle page should have no NextPageMin")
+
+	// ******************************************************************
+	// Step 1B: Create damaged NFToken directories:
+	//   One with multiple pages and a missing final page.
+	// ******************************************************************
+
+	// bob generates three packed pages
+	bobNFTs := genPackedTokens(env, bob)
+	require.Equal(t, 96, len(bobNFTs), "bob should have 96 NFTs")
+	require.Equal(t, uint32(3), env.OwnerCount(bob), "bob should have 3 pages")
+
+	// Get the index of the middle page
+	bobMaxKl := keylet.NFTokenPageMax(bob.ID)
+	bobLastPage := readNFTokenPage(t, env, bobMaxKl)
+	require.NotNil(t, bobLastPage, "bob's last page should exist")
+	bobMiddleNFTokenPageIndex := bobLastPage.PreviousPageMin
+
+	// bob burns all the tokens in the very last page
+	for i := 0; i < 32; i++ {
+		env.Submit(nft.NFTokenBurn(bob, bobNFTs[len(bobNFTs)-1]).Build())
+		bobNFTs = bobNFTs[:len(bobNFTs)-1]
+		env.Close()
+	}
+	require.Equal(t, 64, len(bobNFTs), "bob should have 64 remaining NFTs")
+	require.Equal(t, uint32(2), env.OwnerCount(bob), "bob should have 2 pages")
+
+	// Removing the last token from the last page deletes the last page (bug)
+	require.False(t, env.LedgerEntryExists(bobMaxKl), "bob's max page should be gone (damaged)")
+
+	// bob's "middle" page is still present, has PreviousPageMin but lost NextPageMin
+	bobMiddleKl := nftPageKeylet(keylet.NFTokenPageMin(bob.ID), bobMiddleNFTokenPageIndex)
+	bobMiddlePage := readNFTokenPage(t, env, bobMiddleKl)
+	require.NotNil(t, bobMiddlePage, "bob's middle page should exist")
+	require.NotEqual(t, emptyHash, bobMiddlePage.PreviousPageMin, "bob's middle page should have PreviousPageMin")
+	require.Equal(t, emptyHash, bobMiddlePage.NextPageMin, "bob's middle page should have no NextPageMin")
+
+	// ******************************************************************
+	// Step 1C: Create damaged NFToken directories:
+	//   One with links missing in the middle of the chain.
+	// ******************************************************************
+
+	// carol generates three packed pages
+	carolNFTs := genPackedTokens(env, carol)
+	require.Equal(t, 96, len(carolNFTs), "carol should have 96 NFTs")
+	require.Equal(t, uint32(3), env.OwnerCount(carol), "carol should have 3 pages")
+
+	// Get the index of the middle page
+	carolMaxKl := keylet.NFTokenPageMax(carol.ID)
+	carolLastPage := readNFTokenPage(t, env, carolMaxKl)
+	require.NotNil(t, carolLastPage, "carol's last page should exist")
+	carolMiddleNFTokenPageIndex := carolLastPage.PreviousPageMin
+
+	// carol sells all of the tokens in the very last page to daria
+	dariaNFTs := make([]string, 0, 32)
+	for i := 0; i < 32; i++ {
+		lastNFT := carolNFTs[len(carolNFTs)-1]
+
+		offerIndex := nft.GetOfferIndex(env, carol)
+		env.Submit(nft.NFTokenCreateSellOffer(carol, lastNFT, tx.NewXRPAmount(0)).Build())
+		env.Close()
+
+		env.Submit(nft.NFTokenAcceptSellOffer(daria, offerIndex).Build())
+		env.Close()
+
+		dariaNFTs = append(dariaNFTs, lastNFT)
+		carolNFTs = carolNFTs[:len(carolNFTs)-1]
+	}
+	require.Equal(t, 64, len(carolNFTs), "carol should have 64 remaining NFTs")
+	require.Equal(t, uint32(2), env.OwnerCount(carol), "carol should have 2 pages")
+
+	// Removing the last token from the last page deletes the last page (bug)
+	require.False(t, env.LedgerEntryExists(carolMaxKl), "carol's max page should be gone (damaged)")
+
+	// carol's "middle" page is still present, has PreviousPageMin but lost NextPageMin
+	carolMiddleKl := nftPageKeylet(keylet.NFTokenPageMin(carol.ID), carolMiddleNFTokenPageIndex)
+	carolMiddlePage := readNFTokenPage(t, env, carolMiddleKl)
+	require.NotNil(t, carolMiddlePage, "carol's middle page should exist")
+	require.NotEqual(t, emptyHash, carolMiddlePage.PreviousPageMin, "carol's middle page should have PreviousPageMin")
+	require.Equal(t, emptyHash, carolMiddlePage.NextPageMin, "carol's middle page should have no NextPageMin")
+
+	// Now make things more complicated: carol buys back the NFTs from daria.
+	// This re-creates the last page but with broken links.
+	for _, nftID := range dariaNFTs {
+		offerIndex := nft.GetOfferIndex(env, carol)
+		env.Submit(nft.NFTokenCreateBuyOffer(carol, nftID, tx.NewXRPAmount(1), daria).Build())
+		env.Close()
+
+		env.Submit(nft.NFTokenAcceptBuyOffer(daria, offerIndex).Build())
+		env.Close()
+
+		carolNFTs = append(carolNFTs, nftID)
+	}
+
+	// carol actually owns 96 NFTs but only 64 are reported because links are damaged
+	require.Equal(t, uint32(3), env.OwnerCount(carol), "carol should have 3 pages again")
+
+	// carol's "middle" page still has no NextPageMin field
+	carolMiddlePage = readNFTokenPage(t, env, carolMiddleKl)
+	require.NotNil(t, carolMiddlePage, "carol's middle page should still exist")
+	require.NotEqual(t, emptyHash, carolMiddlePage.PreviousPageMin, "carol's middle page should have PreviousPageMin")
+	require.Equal(t, emptyHash, carolMiddlePage.NextPageMin, "carol's middle page should have no NextPageMin")
+
+	// carol's "last" page exists again, but has no PreviousPageMin field
+	carolLastPage = readNFTokenPage(t, env, carolMaxKl)
+	require.NotNil(t, carolLastPage, "carol's max page should exist again")
+	require.Equal(t, emptyHash, carolLastPage.PreviousPageMin, "carol's last page should have no PreviousPageMin")
+	require.Equal(t, emptyHash, carolLastPage.NextPageMin, "carol's last page should have no NextPageMin")
+
+	// ******************************************************************
+	// Step 2: Enable the fixNFTokenPageLinks amendment.
+	// ******************************************************************
+
+	linkFixFee := env.ReserveIncrement()
+
+	// Verify LedgerStateFix is still disabled
+	result := env.Submit(
+		nft.LedgerStateFixNFTPageLinks(daria, alice).Fee(linkFixFee).Build(),
+	)
+	jtx.RequireTxFail(t, result, "temDISABLED")
+
+	// Close several ledgers so the failed tx is not retried
+	for i := 0; i < 15; i++ {
+		env.Close()
+	}
+
+	env.EnableFeature("fixNFTokenPageLinks")
+	env.Close()
+
+	// ******************************************************************
+	// Step 3A: Repair the one-page directory (alice's)
+	// ******************************************************************
+
+	// Verify alice's NFToken directory is still damaged
+	require.False(t, env.LedgerEntryExists(aliceMaxKl), "alice's max page should still be missing")
+
+	aliceMiddlePage = readNFTokenPage(t, env, aliceMiddleKl)
+	require.NotNil(t, aliceMiddlePage, "alice's middle page should still exist")
+	require.Equal(t, emptyHash, aliceMiddlePage.PreviousPageMin, "alice's middle page should still have no PreviousPageMin")
+	require.Equal(t, emptyHash, aliceMiddlePage.NextPageMin, "alice's middle page should still have no NextPageMin")
+
+	// daria's failed nftPageLinks had the same signature, so advance daria's seq
+	env.Noop(daria)
+
+	// daria fixes the links in alice's NFToken directory
+	result = env.Submit(
+		nft.LedgerStateFixNFTPageLinks(daria, alice).Fee(linkFixFee).Build(),
+	)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	// alice's last page should now be present and include no links
+	aliceLastPage = readNFTokenPage(t, env, aliceMaxKl)
+	require.NotNil(t, aliceLastPage, "alice's max page should now exist after repair")
+	require.Equal(t, emptyHash, aliceLastPage.PreviousPageMin, "alice's repaired max page should have no PreviousPageMin")
+	require.Equal(t, emptyHash, aliceLastPage.NextPageMin, "alice's repaired max page should have no NextPageMin")
+
+	// alice's middle page should be gone (moved to max page)
+	require.False(t, env.LedgerEntryExists(aliceMiddleKl), "alice's middle page should be gone after repair")
+
+	require.Equal(t, uint32(1), env.OwnerCount(alice), "alice should have 1 page after repair")
+
+	// ******************************************************************
+	// Step 3B: Repair the two-page directory (bob's)
+	// ******************************************************************
+
+	// Verify bob's NFToken directory is still damaged
+	require.False(t, env.LedgerEntryExists(bobMaxKl), "bob's max page should still be missing")
+
+	bobMiddlePage = readNFTokenPage(t, env, bobMiddleKl)
+	require.NotNil(t, bobMiddlePage, "bob's middle page should still exist")
+	require.NotEqual(t, emptyHash, bobMiddlePage.PreviousPageMin, "bob's middle page should have PreviousPageMin")
+	require.Equal(t, emptyHash, bobMiddlePage.NextPageMin, "bob's middle page should have no NextPageMin")
+
+	// daria fixes the links in bob's NFToken directory
+	result = env.Submit(
+		nft.LedgerStateFixNFTPageLinks(daria, bob).Fee(linkFixFee).Build(),
+	)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	// bob's last page should now be present with a previous link but no next link
+	bobLastPage = readNFTokenPage(t, env, bobMaxKl)
+	require.NotNil(t, bobLastPage, "bob's max page should now exist after repair")
+
+	require.NotEqual(t, emptyHash, bobLastPage.PreviousPageMin, "bob's repaired max page should have PreviousPageMin")
+	// The new PreviousPageMin should NOT be the old middle page index
+	// (the middle page was moved to the max key position)
+	require.NotEqual(t, bobMiddleNFTokenPageIndex, bobLastPage.PreviousPageMin,
+		"bob's max page PreviousPageMin should not point to old middle page")
+	require.Equal(t, emptyHash, bobLastPage.NextPageMin, "bob's repaired max page should have no NextPageMin")
+
+	// The new first page (pointed to by the last page's PreviousPageMin)
+	// should exist and link forward to the last page
+	bobNewFirstKl := nftPageKeylet(keylet.NFTokenPageMin(bob.ID), bobLastPage.PreviousPageMin)
+	bobNewFirstPage := readNFTokenPage(t, env, bobNewFirstKl)
+	require.NotNil(t, bobNewFirstPage, "bob's new first page should exist")
+	require.Equal(t, bobMaxKl.Key, bobNewFirstPage.NextPageMin,
+		"bob's new first page should link to the max page")
+	require.Equal(t, emptyHash, bobNewFirstPage.PreviousPageMin,
+		"bob's new first page should have no PreviousPageMin")
+
+	// bob's old middle page should be gone
+	require.False(t, env.LedgerEntryExists(bobMiddleKl), "bob's old middle page should be gone after repair")
+
+	require.Equal(t, uint32(2), env.OwnerCount(bob), "bob should have 2 pages after repair")
+
+	// ******************************************************************
+	// Step 3C: Repair the three-page directory (carol's)
+	// ******************************************************************
+
+	// Verify carol's NFToken directory is still damaged
+	carolMiddlePage = readNFTokenPage(t, env, carolMiddleKl)
+	require.NotNil(t, carolMiddlePage, "carol's middle page should still exist")
+	require.NotEqual(t, emptyHash, carolMiddlePage.PreviousPageMin, "carol's middle page should have PreviousPageMin")
+	require.Equal(t, emptyHash, carolMiddlePage.NextPageMin, "carol's middle page should have no NextPageMin")
+
+	carolLastPage = readNFTokenPage(t, env, carolMaxKl)
+	require.NotNil(t, carolLastPage, "carol's last page should exist")
+	require.Equal(t, emptyHash, carolLastPage.PreviousPageMin, "carol's last page should have no PreviousPageMin")
+	require.Equal(t, emptyHash, carolLastPage.NextPageMin, "carol's last page should have no NextPageMin")
+
+	// carol fixes their own NFToken directory
+	result = env.Submit(
+		nft.LedgerStateFixNFTPageLinks(carol, carol).Fee(linkFixFee).Build(),
+	)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	// carol's "middle" page should now have a NextPageMin pointing to the last page
+	carolMiddlePage = readNFTokenPage(t, env, carolMiddleKl)
+	require.NotNil(t, carolMiddlePage, "carol's middle page should still exist after repair")
+	require.NotEqual(t, emptyHash, carolMiddlePage.PreviousPageMin,
+		"carol's middle page should have PreviousPageMin after repair")
+	require.Equal(t, carolMaxKl.Key, carolMiddlePage.NextPageMin,
+		"carol's middle page NextPageMin should point to the max page")
+
+	// carol's "last" page should now have a PreviousPageMin pointing to the middle page
+	carolLastPage = readNFTokenPage(t, env, carolMaxKl)
+	require.NotNil(t, carolLastPage, "carol's last page should exist after repair")
+	require.Equal(t, carolMiddleNFTokenPageIndex, carolLastPage.PreviousPageMin,
+		"carol's last page PreviousPageMin should point to the middle page")
+	require.Equal(t, emptyHash, carolLastPage.NextPageMin,
+		"carol's last page should have no NextPageMin")
+
+	// carol's first page should link to the middle page
+	carolFirstKl := nftPageKeylet(keylet.NFTokenPageMin(carol.ID), carolMiddlePage.PreviousPageMin)
+	carolFirstPage := readNFTokenPage(t, env, carolFirstKl)
+	require.NotNil(t, carolFirstPage, "carol's first page should exist")
+	require.Equal(t, carolMiddleNFTokenPageIndex, carolFirstPage.NextPageMin,
+		"carol's first page should link to the middle page")
+	require.Equal(t, emptyHash, carolFirstPage.PreviousPageMin,
+		"carol's first page should have no PreviousPageMin")
+
+	require.Equal(t, uint32(3), env.OwnerCount(carol), "carol should have 3 pages after repair")
+
+	// With the link repair, verify all tokens are accessible by counting page tokens
+	totalCarolTokens := 0
+	totalCarolTokens += len(carolFirstPage.NFTokens)
+	totalCarolTokens += len(carolMiddlePage.NFTokens)
+	totalCarolTokens += len(carolLastPage.NFTokens)
+	require.Equal(t, 96, totalCarolTokens, "carol should have 96 total tokens after repair")
 }

--- a/internal/testing/pseudotx/enable_amendment_test.go
+++ b/internal/testing/pseudotx/enable_amendment_test.go
@@ -1,0 +1,332 @@
+// Package pseudotx_test tests pseudo-transaction handling.
+// Reference: rippled/src/xrpld/app/tx/detail/Change.cpp applyAmendment()
+package pseudotx_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/amendment"
+	jtx "github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/stretchr/testify/require"
+
+	// Import all tx types so they register
+	_ "github.com/LeJamon/goXRPLd/internal/tx/all"
+)
+
+// makeAmendmentHash returns the uppercase hex hash for a known amendment name.
+func makeAmendmentHash(name string) string {
+	feat := amendment.GetFeatureByName(name)
+	if feat != nil {
+		return strings.ToUpper(hex.EncodeToString(feat.ID[:]))
+	}
+	// Fallback: create a simple hash from the name for tests
+	var hash [32]byte
+	copy(hash[:], []byte(name))
+	return strings.ToUpper(hex.EncodeToString(hash[:]))
+}
+
+// newEnableAmendment creates an EnableAmendment pseudo-tx with the given hash and flags.
+// Pseudo-transactions have zero account, zero fee, zero sequence, and no signatures.
+func newEnableAmendment(amendmentHash string, flags uint32) *pseudo.EnableAmendment {
+	ea := &pseudo.EnableAmendment{
+		BaseTx: *tx.NewBaseTx(tx.TypeAmendment, "rrrrrrrrrrrrrrrrrrrrrhoLvTp"), // zero account in base58
+	}
+	ea.Amendment = amendmentHash
+	ea.Common.Fee = "0"
+	ea.Common.SigningPubKey = ""
+	// Set flags on Common — pseudo-txs use flags for gotMajority/lostMajority
+	ea.Common.Flags = &flags
+	// Pseudo-tx: zero sequence
+	seq := uint32(0)
+	ea.Common.Sequence = &seq
+	return ea
+}
+
+// TestEnableAmendment_Enable tests that an amendment with no flags gets enabled.
+// Reference: rippled Change.cpp applyAmendment() lines 318-335
+func TestEnableAmendment_Enable(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	// Use a real amendment hash
+	amendmentHash := makeAmendmentHash("fixNFTokenPageLinks")
+
+	// Enable the amendment (no flags = activation)
+	ea := newEnableAmendment(amendmentHash, 0)
+	result := env.SubmitPseudo(ea)
+	jtx.RequireTxSuccess(t, result)
+
+	// Verify the Amendments SLE was created with the amendment
+	amendmentsKey := keylet.Amendments()
+	data, err := env.Ledger().Read(amendmentsKey)
+	require.NoError(t, err)
+	require.NotNil(t, data, "Amendments SLE should exist after enabling an amendment")
+
+	sle, err := pseudo.ParseAmendmentsSLE(data)
+	require.NoError(t, err)
+	require.Len(t, sle.Amendments, 1, "Should have exactly 1 enabled amendment")
+
+	var expectedHash [32]byte
+	b, _ := hex.DecodeString(amendmentHash)
+	copy(expectedHash[:], b)
+	require.Equal(t, expectedHash, sle.Amendments[0])
+}
+
+// TestEnableAmendment_EnableMultiple tests enabling multiple amendments sequentially.
+func TestEnableAmendment_EnableMultiple(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	hash1 := makeAmendmentHash("fixNFTokenPageLinks")
+	hash2 := makeAmendmentHash("AMM")
+
+	// Enable first amendment
+	result := env.SubmitPseudo(newEnableAmendment(hash1, 0))
+	jtx.RequireTxSuccess(t, result)
+
+	// Enable second amendment
+	result = env.SubmitPseudo(newEnableAmendment(hash2, 0))
+	jtx.RequireTxSuccess(t, result)
+
+	// Verify both are enabled
+	data, err := env.Ledger().Read(keylet.Amendments())
+	require.NoError(t, err)
+	sle, err := pseudo.ParseAmendmentsSLE(data)
+	require.NoError(t, err)
+	require.Len(t, sle.Amendments, 2)
+}
+
+// TestEnableAmendment_AlreadyEnabled tests that enabling an already-enabled amendment
+// returns tefALREADY.
+// Reference: rippled Change.cpp applyAmendment() lines 265-267
+func TestEnableAmendment_AlreadyEnabled(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	amendmentHash := makeAmendmentHash("fixNFTokenPageLinks")
+
+	// Enable the amendment
+	result := env.SubmitPseudo(newEnableAmendment(amendmentHash, 0))
+	jtx.RequireTxSuccess(t, result)
+
+	// Try to enable again → tefALREADY
+	result = env.SubmitPseudo(newEnableAmendment(amendmentHash, 0))
+	jtx.RequireTxFail(t, result, "tefALREADY")
+}
+
+// TestEnableAmendment_GotMajority tests that tfGotMajority adds to the majorities tracking.
+// Reference: rippled Change.cpp applyAmendment() lines 303-317
+func TestEnableAmendment_GotMajority(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	amendmentHash := makeAmendmentHash("fixNFTokenPageLinks")
+
+	// GotMajority flag
+	const tfGotMajority uint32 = 0x00010000
+	result := env.SubmitPseudo(newEnableAmendment(amendmentHash, tfGotMajority))
+	jtx.RequireTxSuccess(t, result)
+
+	// Verify the Amendments SLE has a majority entry
+	data, err := env.Ledger().Read(keylet.Amendments())
+	require.NoError(t, err)
+	sle, err := pseudo.ParseAmendmentsSLE(data)
+	require.NoError(t, err)
+
+	// Should NOT be in the enabled list yet
+	require.Len(t, sle.Amendments, 0, "Amendment should not be enabled yet")
+
+	// Should be in the majorities list
+	require.Len(t, sle.Majorities, 1, "Should have 1 majority entry")
+
+	var expectedHash [32]byte
+	b, _ := hex.DecodeString(amendmentHash)
+	copy(expectedHash[:], b)
+	require.Equal(t, expectedHash, sle.Majorities[0].Amendment)
+	require.Greater(t, sle.Majorities[0].CloseTime, uint32(0), "CloseTime should be set")
+}
+
+// TestEnableAmendment_GotMajorityAlready tests that gotMajority on an amendment
+// already in the majorities list returns tefALREADY.
+// Reference: rippled Change.cpp applyAmendment() lines 288-289
+func TestEnableAmendment_GotMajorityAlready(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	amendmentHash := makeAmendmentHash("fixNFTokenPageLinks")
+	const tfGotMajority uint32 = 0x00010000
+
+	// First gotMajority → success
+	result := env.SubmitPseudo(newEnableAmendment(amendmentHash, tfGotMajority))
+	jtx.RequireTxSuccess(t, result)
+
+	// Second gotMajority → tefALREADY
+	result = env.SubmitPseudo(newEnableAmendment(amendmentHash, tfGotMajority))
+	jtx.RequireTxFail(t, result, "tefALREADY")
+}
+
+// TestEnableAmendment_LostMajority tests that tfLostMajority removes from the majorities list.
+// Reference: rippled Change.cpp applyAmendment() lines 300-301, filtering logic
+func TestEnableAmendment_LostMajority(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	amendmentHash := makeAmendmentHash("fixNFTokenPageLinks")
+	const tfGotMajority uint32 = 0x00010000
+	const tfLostMajority uint32 = 0x00020000
+
+	// First, add to majorities
+	result := env.SubmitPseudo(newEnableAmendment(amendmentHash, tfGotMajority))
+	jtx.RequireTxSuccess(t, result)
+
+	// Then lose majority
+	result = env.SubmitPseudo(newEnableAmendment(amendmentHash, tfLostMajority))
+	jtx.RequireTxSuccess(t, result)
+
+	// Verify the majority entry is gone
+	data, err := env.Ledger().Read(keylet.Amendments())
+	require.NoError(t, err)
+	sle, err := pseudo.ParseAmendmentsSLE(data)
+	require.NoError(t, err)
+	require.Len(t, sle.Majorities, 0, "Majorities should be empty after lostMajority")
+	require.Len(t, sle.Amendments, 0, "Amendment should not be enabled")
+}
+
+// TestEnableAmendment_LostMajorityNotInList tests that lostMajority on an amendment
+// NOT in the majorities list returns tefALREADY.
+// Reference: rippled Change.cpp applyAmendment() lines 300-301
+func TestEnableAmendment_LostMajorityNotInList(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	amendmentHash := makeAmendmentHash("fixNFTokenPageLinks")
+	const tfLostMajority uint32 = 0x00020000
+
+	// LostMajority on a non-existent majority → tefALREADY
+	result := env.SubmitPseudo(newEnableAmendment(amendmentHash, tfLostMajority))
+	jtx.RequireTxFail(t, result, "tefALREADY")
+}
+
+// TestEnableAmendment_BothFlags tests that setting both gotMajority and lostMajority
+// returns temINVALID_FLAG.
+// Reference: rippled Change.cpp applyAmendment() lines 274-275
+func TestEnableAmendment_BothFlags(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	amendmentHash := makeAmendmentHash("fixNFTokenPageLinks")
+	const tfGotMajority uint32 = 0x00010000
+	const tfLostMajority uint32 = 0x00020000
+
+	result := env.SubmitPseudo(newEnableAmendment(amendmentHash, tfGotMajority|tfLostMajority))
+	jtx.RequireTxFail(t, result, "temINVALID_FLAG")
+}
+
+// TestEnableAmendment_GotMajorityOnEnabled tests that gotMajority on an already-enabled
+// amendment returns tefALREADY.
+// Reference: rippled Change.cpp applyAmendment() lines 265-267
+func TestEnableAmendment_GotMajorityOnEnabled(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	amendmentHash := makeAmendmentHash("fixNFTokenPageLinks")
+	const tfGotMajority uint32 = 0x00010000
+
+	// Enable the amendment first
+	result := env.SubmitPseudo(newEnableAmendment(amendmentHash, 0))
+	jtx.RequireTxSuccess(t, result)
+
+	// GotMajority on already-enabled → tefALREADY
+	result = env.SubmitPseudo(newEnableAmendment(amendmentHash, tfGotMajority))
+	jtx.RequireTxFail(t, result, "tefALREADY")
+}
+
+// TestEnableAmendment_LostMajorityOnEnabled tests that lostMajority on an already-enabled
+// amendment returns tefALREADY.
+// Reference: rippled Change.cpp applyAmendment() lines 265-267
+func TestEnableAmendment_LostMajorityOnEnabled(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	amendmentHash := makeAmendmentHash("fixNFTokenPageLinks")
+	const tfLostMajority uint32 = 0x00020000
+
+	// Enable the amendment first
+	result := env.SubmitPseudo(newEnableAmendment(amendmentHash, 0))
+	jtx.RequireTxSuccess(t, result)
+
+	// LostMajority on already-enabled → tefALREADY
+	result = env.SubmitPseudo(newEnableAmendment(amendmentHash, tfLostMajority))
+	jtx.RequireTxFail(t, result, "tefALREADY")
+}
+
+// TestEnableAmendment_FullLifecycle tests the complete amendment lifecycle:
+// gotMajority → lostMajority → gotMajority → enable
+func TestEnableAmendment_FullLifecycle(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	amendmentHash := makeAmendmentHash("fixNFTokenPageLinks")
+	const tfGotMajority uint32 = 0x00010000
+	const tfLostMajority uint32 = 0x00020000
+
+	// Step 1: Got majority
+	result := env.SubmitPseudo(newEnableAmendment(amendmentHash, tfGotMajority))
+	jtx.RequireTxSuccess(t, result)
+
+	// Step 2: Lost majority
+	result = env.SubmitPseudo(newEnableAmendment(amendmentHash, tfLostMajority))
+	jtx.RequireTxSuccess(t, result)
+
+	// Step 3: Got majority again
+	result = env.SubmitPseudo(newEnableAmendment(amendmentHash, tfGotMajority))
+	jtx.RequireTxSuccess(t, result)
+
+	// Step 4: Enable (no flags)
+	result = env.SubmitPseudo(newEnableAmendment(amendmentHash, 0))
+	jtx.RequireTxSuccess(t, result)
+
+	// Verify final state
+	data, err := env.Ledger().Read(keylet.Amendments())
+	require.NoError(t, err)
+	sle, err := pseudo.ParseAmendmentsSLE(data)
+	require.NoError(t, err)
+	require.Len(t, sle.Amendments, 1, "Amendment should be enabled")
+	require.Len(t, sle.Majorities, 0, "No majorities should remain after activation")
+}
+
+// TestEnableAmendment_MajoritiesPassThrough tests that lostMajority only removes
+// the targeted amendment and leaves others intact.
+// Reference: rippled Change.cpp applyAmendment() lines 282-297
+func TestEnableAmendment_MajoritiesPassThrough(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	hash1 := makeAmendmentHash("fixNFTokenPageLinks")
+	hash2 := makeAmendmentHash("AMM")
+	const tfGotMajority uint32 = 0x00010000
+	const tfLostMajority uint32 = 0x00020000
+
+	// Add two amendments to majorities
+	result := env.SubmitPseudo(newEnableAmendment(hash1, tfGotMajority))
+	jtx.RequireTxSuccess(t, result)
+
+	result = env.SubmitPseudo(newEnableAmendment(hash2, tfGotMajority))
+	jtx.RequireTxSuccess(t, result)
+
+	// Verify both are in majorities
+	data, err := env.Ledger().Read(keylet.Amendments())
+	require.NoError(t, err)
+	sle, err := pseudo.ParseAmendmentsSLE(data)
+	require.NoError(t, err)
+	require.Len(t, sle.Majorities, 2)
+
+	// Lose majority for hash1 only
+	result = env.SubmitPseudo(newEnableAmendment(hash1, tfLostMajority))
+	jtx.RequireTxSuccess(t, result)
+
+	// Verify hash2 remains
+	data, err = env.Ledger().Read(keylet.Amendments())
+	require.NoError(t, err)
+	sle, err = pseudo.ParseAmendmentsSLE(data)
+	require.NoError(t, err)
+	require.Len(t, sle.Majorities, 1, "Only hash2 should remain")
+
+	var expectedHash2 [32]byte
+	b, _ := hex.DecodeString(hash2)
+	copy(expectedHash2[:], b)
+	require.Equal(t, expectedHash2, sle.Majorities[0].Amendment)
+}

--- a/internal/testing/pseudotx/unl_modify_test.go
+++ b/internal/testing/pseudotx/unl_modify_test.go
@@ -1,0 +1,279 @@
+// Package pseudotx_test tests UNLModify pseudo-transaction handling.
+// Reference: rippled/src/xrpld/app/tx/detail/Change.cpp applyUNLModify()
+package pseudotx_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	jtx "github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/LeJamon/goXRPLd/internal/tx/all"
+)
+
+// Fake ED25519 validator public key (33 bytes: 0xED prefix + 32 bytes)
+var (
+	validatorKey1 = makeValidatorKey(1)
+	validatorKey2 = makeValidatorKey(2)
+)
+
+func makeValidatorKey(id byte) string {
+	key := make([]byte, 33)
+	key[0] = 0xED // ED25519 prefix
+	key[32] = id
+	return hex.EncodeToString(key)
+}
+
+// newUNLModify creates a UNLModify pseudo-tx.
+// disabling: 1 to disable a validator, 0 to re-enable.
+// seq: must match the current ledger sequence.
+// validatorKey: hex-encoded public key.
+func newUNLModify(disabling uint8, seq uint32, validatorKey string) *pseudo.UNLModify {
+	u := &pseudo.UNLModify{
+		BaseTx: *tx.NewBaseTx(tx.TypeUNLModify, "rrrrrrrrrrrrrrrrrrrrrhoLvTp"),
+	}
+	u.Common.Fee = "0"
+	u.Common.SigningPubKey = ""
+	s := uint32(0)
+	u.Common.Sequence = &s
+	u.UNLModifyDisabling = &disabling
+	u.LedgerSequence = &seq
+	u.UNLModifyValidator = validatorKey
+	return u
+}
+
+// TestUNLModify_NotFlagLedger tests that UNLModify fails when not on a flag ledger.
+// Reference: rippled Change.cpp applyUNLModify() lines 390-396
+func TestUNLModify_NotFlagLedger(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	// Default ledger sequence is typically 2 or 3 (not a flag ledger = multiple of 256)
+	seq := env.Ledger().Sequence()
+	require.NotEqual(t, uint32(0), seq%256, "Test setup: ledger should not be on a flag ledger")
+
+	u := newUNLModify(1, seq, validatorKey1)
+	result := env.SubmitPseudo(u)
+	jtx.RequireTxFail(t, result, "tefFAILURE")
+}
+
+// TestUNLModify_MissingFields tests that UNLModify fails when required fields are missing.
+// Reference: rippled Change.cpp applyUNLModify() lines 397-404
+func TestUNLModify_MissingFields(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	// Advance to a flag ledger (seq % 256 == 0)
+	advanceToFlagLedger(t, env)
+	seq := env.Ledger().Sequence()
+
+	t.Run("missing UNLModifyDisabling", func(t *testing.T) {
+		u := &pseudo.UNLModify{
+			BaseTx: *tx.NewBaseTx(tx.TypeUNLModify, "rrrrrrrrrrrrrrrrrrrrrhoLvTp"),
+		}
+		u.Common.Fee = "0"
+		u.Common.SigningPubKey = ""
+		s := uint32(0)
+		u.Common.Sequence = &s
+		// UNLModifyDisabling is nil
+		u.LedgerSequence = &seq
+		u.UNLModifyValidator = validatorKey1
+		result := env.SubmitPseudo(u)
+		jtx.RequireTxFail(t, result, "tefFAILURE")
+	})
+
+	t.Run("UNLModifyDisabling > 1", func(t *testing.T) {
+		badVal := uint8(2)
+		u := newUNLModify(badVal, seq, validatorKey1)
+		u.UNLModifyDisabling = &badVal
+		result := env.SubmitPseudo(u)
+		jtx.RequireTxFail(t, result, "tefFAILURE")
+	})
+
+	t.Run("wrong LedgerSequence", func(t *testing.T) {
+		u := newUNLModify(1, seq+1, validatorKey1)
+		result := env.SubmitPseudo(u)
+		jtx.RequireTxFail(t, result, "tefFAILURE")
+	})
+
+	t.Run("missing UNLModifyValidator", func(t *testing.T) {
+		u := newUNLModify(1, seq, "")
+		result := env.SubmitPseudo(u)
+		jtx.RequireTxFail(t, result, "tefFAILURE")
+	})
+}
+
+// TestUNLModify_DisableValidator tests successful validator disabling.
+// Reference: rippled Change.cpp applyUNLModify() lines 449-478
+func TestUNLModify_DisableValidator(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	advanceToFlagLedger(t, env)
+	seq := env.Ledger().Sequence()
+
+	u := newUNLModify(1, seq, validatorKey1)
+	result := env.SubmitPseudo(u)
+	jtx.RequireTxSuccess(t, result)
+
+	// Verify NegativeUNL SLE was created with ValidatorToDisable
+	data, err := env.Ledger().Read(keylet.NegativeUNL())
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	sle, err := pseudo.ParseNegativeUNLSLE(data)
+	require.NoError(t, err)
+
+	expectedKey, _ := hex.DecodeString(validatorKey1)
+	require.Equal(t, expectedKey, sle.ValidatorToDisable)
+}
+
+// TestUNLModify_ReEnableValidator tests successful validator re-enabling.
+// Reference: rippled Change.cpp applyUNLModify() lines 479-508
+func TestUNLModify_ReEnableValidator(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	advanceToFlagLedger(t, env)
+	seq := env.Ledger().Sequence()
+
+	// First, we need the validator to be in the disabled list.
+	// Seed the NegativeUNL SLE directly with a disabled validator.
+	seedDisabledValidator(t, env, validatorKey1)
+
+	u := newUNLModify(0, seq, validatorKey1)
+	result := env.SubmitPseudo(u)
+	jtx.RequireTxSuccess(t, result)
+
+	// Verify ValidatorToReEnable was set
+	data, err := env.Ledger().Read(keylet.NegativeUNL())
+	require.NoError(t, err)
+
+	sle, err := pseudo.ParseNegativeUNLSLE(data)
+	require.NoError(t, err)
+
+	expectedKey, _ := hex.DecodeString(validatorKey1)
+	require.Equal(t, expectedKey, sle.ValidatorToReEnable)
+}
+
+// TestUNLModify_AlreadyHasToDisable tests that a second disable request fails.
+// Reference: rippled Change.cpp applyUNLModify() lines 452-456
+func TestUNLModify_AlreadyHasToDisable(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	advanceToFlagLedger(t, env)
+	seq := env.Ledger().Sequence()
+
+	// First disable succeeds
+	result := env.SubmitPseudo(newUNLModify(1, seq, validatorKey1))
+	jtx.RequireTxSuccess(t, result)
+
+	// Second disable fails (already has ValidatorToDisable)
+	result = env.SubmitPseudo(newUNLModify(1, seq, validatorKey2))
+	jtx.RequireTxFail(t, result, "tefFAILURE")
+}
+
+// TestUNLModify_DisableSameAsReEnable tests that trying to disable a validator
+// that is scheduled for re-enable fails.
+// Reference: rippled Change.cpp applyUNLModify() lines 459-466
+func TestUNLModify_DisableSameAsReEnable(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	advanceToFlagLedger(t, env)
+	seq := env.Ledger().Sequence()
+
+	// Seed the disabled list and set up re-enable
+	seedDisabledValidator(t, env, validatorKey1)
+	result := env.SubmitPseudo(newUNLModify(0, seq, validatorKey1))
+	jtx.RequireTxSuccess(t, result)
+
+	// Try to disable the same validator → conflict
+	result = env.SubmitPseudo(newUNLModify(1, seq, validatorKey1))
+	jtx.RequireTxFail(t, result, "tefFAILURE")
+}
+
+// TestUNLModify_DisableAlreadyInList tests that disabling a validator already
+// in the disabled list fails.
+// Reference: rippled Change.cpp applyUNLModify() lines 470-475
+func TestUNLModify_DisableAlreadyInList(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	advanceToFlagLedger(t, env)
+	seq := env.Ledger().Sequence()
+
+	// Seed the disabled list
+	seedDisabledValidator(t, env, validatorKey1)
+
+	// Try to disable again → already in list
+	result := env.SubmitPseudo(newUNLModify(1, seq, validatorKey1))
+	jtx.RequireTxFail(t, result, "tefFAILURE")
+}
+
+// TestUNLModify_ReEnableNotInList tests that re-enabling a validator NOT in
+// the disabled list fails.
+// Reference: rippled Change.cpp applyUNLModify() lines 499-505
+func TestUNLModify_ReEnableNotInList(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	advanceToFlagLedger(t, env)
+	seq := env.Ledger().Sequence()
+
+	// Re-enable without being in the disabled list → fail
+	result := env.SubmitPseudo(newUNLModify(0, seq, validatorKey1))
+	jtx.RequireTxFail(t, result, "tefFAILURE")
+}
+
+// TestUNLModify_AlreadyHasToReEnable tests that a second re-enable request fails.
+// Reference: rippled Change.cpp applyUNLModify() lines 482-486
+func TestUNLModify_AlreadyHasToReEnable(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	advanceToFlagLedger(t, env)
+	seq := env.Ledger().Sequence()
+
+	// Seed two validators in the disabled list
+	seedDisabledValidator(t, env, validatorKey1)
+	seedDisabledValidator(t, env, validatorKey2)
+
+	// First re-enable succeeds
+	result := env.SubmitPseudo(newUNLModify(0, seq, validatorKey1))
+	jtx.RequireTxSuccess(t, result)
+
+	// Second re-enable fails (already has ValidatorToReEnable)
+	result = env.SubmitPseudo(newUNLModify(0, seq, validatorKey2))
+	jtx.RequireTxFail(t, result, "tefFAILURE")
+}
+
+// advanceToFlagLedger advances the test environment to a flag ledger (seq % 256 == 0).
+func advanceToFlagLedger(t *testing.T, env *jtx.TestEnv) {
+	t.Helper()
+	for env.Ledger().Sequence()%256 != 0 {
+		env.Close()
+	}
+}
+
+// seedDisabledValidator inserts a validator into the NegativeUNL's DisabledValidators
+// list by directly inserting/updating the SLE.
+func seedDisabledValidator(t *testing.T, env *jtx.TestEnv, validatorKeyHex string) {
+	t.Helper()
+
+	k := keylet.NegativeUNL()
+	validatorKey, err := hex.DecodeString(validatorKeyHex)
+	require.NoError(t, err)
+
+	var sle *pseudo.NegativeUNLSLE
+
+	data, readErr := env.Ledger().Read(k)
+	if readErr != nil || data == nil {
+		sle = &pseudo.NegativeUNLSLE{}
+	} else {
+		sle, err = pseudo.ParseNegativeUNLSLE(data)
+		require.NoError(t, err)
+	}
+
+	// Add the validator to the disabled list
+	sle.DisabledValidators = append(sle.DisabledValidators, validatorKey)
+
+	serialized, serErr := pseudo.SerializeNegativeUNLSLE(sle)
+	require.NoError(t, serErr)
+
+	if data == nil || readErr != nil {
+		err = env.Ledger().Insert(k, serialized)
+	} else {
+		err = env.Ledger().Update(k, serialized)
+	}
+	require.NoError(t, err)
+}

--- a/internal/tx/ledgerstatefix/ledger_state_fix.go
+++ b/internal/tx/ledgerstatefix/ledger_state_fix.go
@@ -1,11 +1,14 @@
 package ledgerstatefix
 
 import (
+	"bytes"
 	"errors"
 
-	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/nftoken"
+	"github.com/LeJamon/goXRPLd/keylet"
 )
 
 func init() {
@@ -115,12 +118,252 @@ func (l *LedgerStateFix) RequiredAmendments() [][32]byte {
 }
 
 // Apply applies the LedgerStateFix transaction to the ledger.
-func (l *LedgerStateFix) Apply() tx.Result {
-	if l.Owner != "" {
-		_, err := state.DecodeAccountID(l.Owner)
+// This implements the Appliable interface: Apply(ctx *tx.ApplyContext) tx.Result
+// Reference: rippled LedgerStateFix.cpp preclaim() + doApply()
+func (l *LedgerStateFix) Apply(ctx *tx.ApplyContext) tx.Result {
+	switch l.LedgerFixType {
+	case LedgerFixTypeNFTokenPageLink:
+		// Preclaim: verify owner account exists
+		// Reference: rippled LedgerStateFix.cpp preclaim() lines 65-80
+		ownerID, err := state.DecodeAccountID(l.Owner)
 		if err != nil {
-			return tx.TecNO_TARGET
+			return tx.TecOBJECT_NOT_FOUND
+		}
+		ownerAccountKey := keylet.Account(ownerID)
+		exists, existsErr := ctx.View.Exists(ownerAccountKey)
+		if existsErr != nil || !exists {
+			return tx.TecOBJECT_NOT_FOUND
+		}
+
+		// doApply: repair NFToken directory links
+		// Reference: rippled LedgerStateFix.cpp doApply() lines 83-96
+		if !repairNFTokenDirectoryLinks(ctx.View, ownerID) {
+			return tx.TecFAILED_PROCESSING
+		}
+		return tx.TesSUCCESS
+
+	default:
+		// preflight should have caught this
+		return tx.TecINTERNAL
+	}
+}
+
+// repairNFTokenDirectoryLinks repairs the doubly-linked list of NFTokenPages
+// for an account. Returns true if any repairs were made, false if there was
+// nothing to repair or no pages exist.
+// Reference: rippled NFTokenUtils.cpp repairNFTokenDirectoryLinks() lines 717-834
+func repairNFTokenDirectoryLinks(view tx.LedgerView, owner [20]byte) bool {
+	didRepair := false
+
+	last := keylet.NFTokenPageMax(owner)
+	min := keylet.NFTokenPageMin(owner)
+
+	// Find the first page: succ(nftpage_min.key, last.key.next())
+	// In rippled, succ(start, upperBound) returns the first key in [start, upperBound).
+	// Go's Succ(key) returns the first key > key. We start from one less than min
+	// to find entries >= min. But since min has the owner prefix with all-zero low bits,
+	// we actually want to find the first page key >= min. We use Succ with key that is
+	// one less than min.key. However, a simpler approach: use Succ(key) where key is
+	// one byte before min. But NFTokenPage keys are [owner_20 | low_12], so min is
+	// [owner_20 | 0x000...000]. We need the first entry with key >= min and <= last.
+	//
+	// rippled: view.succ(keylet::nftpage_min(owner).key, last.key.next())
+	// This finds the first key >= min.key and < last.key.next().
+	// In Go: we can use Succ with a key that is one less than min to get >= min.
+	// Compute min.key - 1:
+	searchKey := decrementKey(min.Key)
+
+	firstKey, firstData, found, err := view.Succ(searchKey)
+	if err != nil || !found {
+		return didRepair
+	}
+
+	// Check if the found key is within the owner's page range
+	if bytes.Compare(firstKey[:], min.Key[:]) < 0 || bytes.Compare(firstKey[:], last.Key[:]) > 0 {
+		return didRepair
+	}
+
+	// If no page found at this key, fall back to last page
+	// rippled: .value_or(last.key) means use last.key if succ returns nothing
+	pageKey := firstKey
+	pageData := firstData
+
+	// Parse the page
+	page, parseErr := state.ParseNFTokenPage(pageData)
+	if parseErr != nil {
+		return didRepair
+	}
+
+	// Single page case: page key == last key
+	// Reference: rippled lines 731-747
+	if pageKey == last.Key {
+		// There's only one page. It should have no links.
+		var emptyHash [32]byte
+		nextPresent := page.NextPageMin != emptyHash
+		prevPresent := page.PreviousPageMin != emptyHash
+
+		if nextPresent || prevPresent {
+			didRepair = true
+			if prevPresent {
+				page.PreviousPageMin = emptyHash
+			}
+			if nextPresent {
+				page.NextPageMin = emptyHash
+			}
+			if serialized, serErr := nftoken.SerializeNFTokenPage(page); serErr == nil {
+				pageKl := keylet.Keylet{Type: keylet.NFTokenPageMax(owner).Type, Key: pageKey}
+				_ = view.Update(pageKl, serialized)
+			}
+		}
+		return didRepair
+	}
+
+	// Multiple pages case.
+	// First page should not contain a previous link.
+	// Reference: rippled lines 749-757
+	var emptyHash [32]byte
+	if page.PreviousPageMin != emptyHash {
+		didRepair = true
+		page.PreviousPageMin = emptyHash
+		if serialized, serErr := nftoken.SerializeNFTokenPage(page); serErr == nil {
+			pageKl := keylet.Keylet{Type: last.Type, Key: pageKey}
+			_ = view.Update(pageKl, serialized)
 		}
 	}
-	return tx.TesSUCCESS
+
+	// Walk pairs using succ
+	// Reference: rippled lines 759-786
+	var nextPage *state.NFTokenPageData
+	var nextPageKey [32]byte
+	foundNextPage := false
+
+	for {
+		// Find next page: succ(page.key.next(), last.key.next())
+		// In Go: Succ(pageKey) returns first key > pageKey
+		nKey, nData, nFound, nErr := view.Succ(pageKey)
+		if nErr != nil || !nFound {
+			break
+		}
+		// Check upper bound: key must be <= last.key
+		if bytes.Compare(nKey[:], last.Key[:]) > 0 {
+			break
+		}
+
+		nextPageKey = nKey
+		nParsed, nParseErr := state.ParseNFTokenPage(nData)
+		if nParseErr != nil {
+			break
+		}
+		nextPage = nParsed
+		foundNextPage = true
+
+		// Verify page -> nextPage forward link
+		// Reference: rippled lines 765-771
+		if page.NextPageMin != nextPageKey {
+			didRepair = true
+			page.NextPageMin = nextPageKey
+			if serialized, serErr := nftoken.SerializeNFTokenPage(page); serErr == nil {
+				pageKl := keylet.Keylet{Type: last.Type, Key: pageKey}
+				_ = view.Update(pageKl, serialized)
+			}
+		}
+
+		// Verify nextPage -> page backward link
+		// Reference: rippled lines 773-779
+		if nextPage.PreviousPageMin != pageKey {
+			didRepair = true
+			nextPage.PreviousPageMin = pageKey
+			if serialized, serErr := nftoken.SerializeNFTokenPage(nextPage); serErr == nil {
+				nKl := keylet.Keylet{Type: last.Type, Key: nextPageKey}
+				_ = view.Update(nKl, serialized)
+			}
+		}
+
+		// If nextPage is the last page, break out for special handling
+		// Reference: rippled lines 781-783
+		if nextPageKey == last.Key {
+			break
+		}
+
+		// Move forward
+		page = nextPage
+		pageKey = nextPageKey
+	}
+
+	// When we arrive here, nextPage should have the same index as last.
+	// If not, we need to fix it by moving the current last page's contents
+	// to the correct final position.
+	// Reference: rippled lines 790-821
+	if !foundNextPage || nextPageKey != last.Key {
+		// page is the actual last page, but it doesn't have the expected final index.
+		// Move its contents to a new page at the correct last.Key position.
+		didRepair = true
+
+		newLastPage := &state.NFTokenPageData{
+			NFTokens: page.NFTokens,
+		}
+
+		// If page has a PreviousPageMin link, copy it and fix the previous page's
+		// NextPageMin to point to the new last page.
+		// Reference: rippled lines 806-818
+		if page.PreviousPageMin != emptyHash {
+			newLastPage.PreviousPageMin = page.PreviousPageMin
+
+			// Fix up the NextPageMin link in the previous page
+			prevPageKl := keylet.Keylet{Type: last.Type, Key: page.PreviousPageMin}
+			prevData, prevErr := view.Read(prevPageKl)
+			if prevErr != nil {
+				return false
+			}
+			prevPage, prevParseErr := state.ParseNFTokenPage(prevData)
+			if prevParseErr != nil {
+				return false
+			}
+			prevPage.NextPageMin = last.Key
+			if serialized, serErr := nftoken.SerializeNFTokenPage(prevPage); serErr == nil {
+				_ = view.Update(prevPageKl, serialized)
+			}
+		}
+
+		// Erase the old page and insert the new one at the correct position
+		// Reference: rippled lines 819-821
+		oldPageKl := keylet.Keylet{Type: last.Type, Key: pageKey}
+		_ = view.Erase(oldPageKl)
+
+		if serialized, serErr := nftoken.SerializeNFTokenPage(newLastPage); serErr == nil {
+			_ = view.Insert(last, serialized)
+		}
+
+		return didRepair
+	}
+
+	// nextPage is the last page. It should not have a NextPageMin link.
+	// Reference: rippled lines 824-833
+	if nextPage != nil && nextPage.NextPageMin != emptyHash {
+		didRepair = true
+		nextPage.NextPageMin = emptyHash
+		if serialized, serErr := nftoken.SerializeNFTokenPage(nextPage); serErr == nil {
+			nKl := keylet.Keylet{Type: last.Type, Key: nextPageKey}
+			_ = view.Update(nKl, serialized)
+		}
+	}
+
+	return didRepair
 }
+
+// decrementKey returns key - 1 (treating the 32-byte key as a big-endian integer).
+// This is used to find entries >= a given key using Succ (which returns > key).
+func decrementKey(key [32]byte) [32]byte {
+	result := key
+	for i := 31; i >= 0; i-- {
+		if result[i] > 0 {
+			result[i]--
+			return result
+		}
+		result[i] = 0xFF
+	}
+	return result
+}
+
+// Ensure LedgerStateFix implements Appliable.
+var _ tx.Appliable = (*LedgerStateFix)(nil)

--- a/internal/tx/nftoken/helpers.go
+++ b/internal/tx/nftoken/helpers.go
@@ -1454,6 +1454,12 @@ func adjustOwnerCountViaView(view tx.LedgerView, accountID [20]byte, delta int) 
 // Serialization helpers
 // ---------------------------------------------------------------------------
 
+// SerializeNFTokenPage serializes an NFToken page ledger entry.
+// Exported so that LedgerStateFix can use it to repair pages.
+func SerializeNFTokenPage(page *state.NFTokenPageData) ([]byte, error) {
+	return serializeNFTokenPage(page)
+}
+
 // serializeNFTokenPage serializes an NFToken page ledger entry
 func serializeNFTokenPage(page *state.NFTokenPageData) ([]byte, error) {
 	jsonObj := map[string]any{

--- a/internal/tx/pseudo/amendments_sle.go
+++ b/internal/tx/pseudo/amendments_sle.go
@@ -1,0 +1,181 @@
+package pseudo
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+)
+
+// AmendmentsSLE represents the parsed Amendments ledger entry.
+// Reference: rippled SLE with type ltAMENDMENTS (0x0066)
+// Fields: sfAmendments (Vector256), sfMajorities (STArray)
+type AmendmentsSLE struct {
+	// Amendments is the list of fully enabled amendment hashes.
+	Amendments [][32]byte
+
+	// Majorities tracks amendments that have reached majority with their close times.
+	// Each entry has an amendment hash and the close time when majority was achieved.
+	Majorities []MajorityEntry
+}
+
+// MajorityEntry represents a single entry in the sfMajorities array.
+// Reference: rippled STObject with sfAmendment (Hash256) + sfCloseTime (UInt32)
+type MajorityEntry struct {
+	Amendment [32]byte
+	CloseTime uint32
+}
+
+// ParseAmendmentsSLE parses an Amendments SLE from binary data.
+// Returns nil (no entry) if data is nil or empty.
+func ParseAmendmentsSLE(data []byte) (*AmendmentsSLE, error) {
+	if len(data) == 0 {
+		return &AmendmentsSLE{}, nil
+	}
+
+	hexStr := hex.EncodeToString(data)
+	jsonObj, err := binarycodec.Decode(hexStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode Amendments SLE: %w", err)
+	}
+
+	sle := &AmendmentsSLE{}
+
+	// Parse sfAmendments (Vector256 → []string of uppercase hex hashes)
+	if amendments, ok := jsonObj["Amendments"]; ok {
+		switch v := amendments.(type) {
+		case []string:
+			for _, hashHex := range v {
+				var hash [32]byte
+				b, err := hex.DecodeString(hashHex)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode amendment hash: %w", err)
+				}
+				copy(hash[:], b)
+				sle.Amendments = append(sle.Amendments, hash)
+			}
+		case []any:
+			for _, item := range v {
+				s, ok := item.(string)
+				if !ok {
+					continue
+				}
+				var hash [32]byte
+				b, err := hex.DecodeString(s)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode amendment hash: %w", err)
+				}
+				copy(hash[:], b)
+				sle.Amendments = append(sle.Amendments, hash)
+			}
+		}
+	}
+
+	// Parse sfMajorities (STArray → []any of wrapper objects)
+	if majorities, ok := jsonObj["Majorities"]; ok {
+		arr, ok := majorities.([]any)
+		if !ok {
+			return nil, fmt.Errorf("unexpected Majorities type: %T", majorities)
+		}
+		for _, item := range arr {
+			wrapper, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			// Each element is wrapped: {"Majority": {"Amendment": "...", "CloseTime": ...}}
+			inner, ok := wrapper["Majority"]
+			if !ok {
+				continue
+			}
+			innerMap, ok := inner.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			entry := MajorityEntry{}
+
+			if amendHash, ok := innerMap["Amendment"].(string); ok {
+				b, err := hex.DecodeString(amendHash)
+				if err == nil {
+					copy(entry.Amendment[:], b)
+				}
+			}
+
+			if closeTime, ok := innerMap["CloseTime"]; ok {
+				switch v := closeTime.(type) {
+				case float64:
+					entry.CloseTime = uint32(v)
+				case uint32:
+					entry.CloseTime = v
+				case int:
+					entry.CloseTime = uint32(v)
+				case int64:
+					entry.CloseTime = uint32(v)
+				}
+			}
+
+			sle.Majorities = append(sle.Majorities, entry)
+		}
+	}
+
+	return sle, nil
+}
+
+// SerializeAmendmentsSLE serializes an AmendmentsSLE to binary data.
+func SerializeAmendmentsSLE(sle *AmendmentsSLE) ([]byte, error) {
+	jsonObj := map[string]any{
+		"LedgerEntryType": "Amendments",
+		"Flags":           0,
+	}
+
+	// Add sfAmendments (Vector256)
+	if len(sle.Amendments) > 0 {
+		hashes := make([]string, len(sle.Amendments))
+		for i, hash := range sle.Amendments {
+			hashes[i] = strings.ToUpper(hex.EncodeToString(hash[:]))
+		}
+		jsonObj["Amendments"] = hashes
+	}
+
+	// Add sfMajorities (STArray)
+	if len(sle.Majorities) > 0 {
+		arr := make([]any, len(sle.Majorities))
+		for i, entry := range sle.Majorities {
+			arr[i] = map[string]any{
+				"Majority": map[string]any{
+					"Amendment": strings.ToUpper(hex.EncodeToString(entry.Amendment[:])),
+					"CloseTime": entry.CloseTime,
+				},
+			}
+		}
+		jsonObj["Majorities"] = arr
+	}
+
+	hexStr, err := binarycodec.Encode(jsonObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode Amendments SLE: %w", err)
+	}
+
+	return hex.DecodeString(hexStr)
+}
+
+// ContainsAmendment checks if the given amendment hash is in the enabled amendments list.
+func (sle *AmendmentsSLE) ContainsAmendment(hash [32]byte) bool {
+	for _, h := range sle.Amendments {
+		if h == hash {
+			return true
+		}
+	}
+	return false
+}
+
+// FindMajority returns the index of the majority entry for the given amendment, or -1.
+func (sle *AmendmentsSLE) FindMajority(hash [32]byte) int {
+	for i, entry := range sle.Majorities {
+		if entry.Amendment == hash {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/tx/pseudo/enable_amendment.go
+++ b/internal/tx/pseudo/enable_amendment.go
@@ -1,9 +1,12 @@
 package pseudo
 
 import (
+	"encoding/hex"
 	"errors"
+	"strings"
 
 	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/keylet"
 )
 
 var (
@@ -64,17 +67,128 @@ func (e *EnableAmendment) IsPseudoTransaction() bool {
 }
 
 // Apply applies the EnableAmendment transaction to ledger state.
-// Reference: rippled Change.cpp applyAmendment()
-//
-// TODO: Implement full amendment apply logic for network mode:
-//   - Read/create amendments SLE at keylet::amendments()
-//   - If tfGotMajority: add amendment hash to sfMajorities array with close time
-//   - If tfLostMajority: remove amendment hash from sfMajorities array
-//   - If no flags: enable the amendment — add to sfAmendments vector,
-//     call AmendmentTable.enable(), check if supported (block server if not)
-//   - Handle activateTrustLinesToSelfFix() special case
-//   - Serialize and update the amendments SLE
+// Reference: rippled Change.cpp applyAmendment() lines 248-345
 func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
-	// Stub: not needed for standalone mode (no validators voting on amendments)
+	// Parse the amendment hash from the transaction
+	// Reference: rippled line 251: uint256 amendment(ctx_.tx.getFieldH256(sfAmendment))
+	amendmentHash, err := parseAmendmentHash(e.Amendment)
+	if err != nil {
+		return tx.TefINTERNAL
+	}
+
+	// Get or create the Amendments SLE
+	// Reference: rippled lines 253-261
+	k := keylet.Amendments()
+	var sle *AmendmentsSLE
+
+	data, readErr := ctx.View.Read(k)
+	if readErr != nil || data == nil {
+		// Create new empty Amendments SLE
+		sle = &AmendmentsSLE{}
+	} else {
+		sle, err = ParseAmendmentsSLE(data)
+		if err != nil {
+			return tx.TefINTERNAL
+		}
+	}
+
+	isNew := data == nil || readErr != nil
+
+	// Check if amendment is already enabled
+	// Reference: rippled lines 265-267
+	if sle.ContainsAmendment(amendmentHash) {
+		return tx.TefALREADY
+	}
+
+	// Parse flags
+	// Reference: rippled lines 269-275
+	var flags uint32
+	if e.Common.Flags != nil {
+		flags = *e.Common.Flags
+	}
+	gotMajority := (flags & tfGotMajority) != 0
+	lostMajority := (flags & tfLostMajority) != 0
+
+	if gotMajority && lostMajority {
+		return tx.TemINVALID_FLAG
+	}
+
+	// Build new majorities list, filtering out the target amendment
+	// Reference: rippled lines 277-298
+	newMajorities := make([]MajorityEntry, 0, len(sle.Majorities))
+	found := false
+
+	for _, entry := range sle.Majorities {
+		if entry.Amendment == amendmentHash {
+			if gotMajority {
+				// Already in majorities and we're trying to add again
+				return tx.TefALREADY
+			}
+			found = true
+			// Don't copy this entry (it's being removed for lostMajority,
+			// or it will be removed for enable)
+		} else {
+			// Pass through other entries
+			newMajorities = append(newMajorities, entry)
+		}
+	}
+
+	// lostMajority but amendment wasn't in the majorities list
+	// Reference: rippled lines 300-301
+	if !found && lostMajority {
+		return tx.TefALREADY
+	}
+
+	// Handle gotMajority: add new majority entry
+	// Reference: rippled lines 303-317
+	if gotMajority {
+		newMajorities = append(newMajorities, MajorityEntry{
+			Amendment: amendmentHash,
+			CloseTime: ctx.Config.ParentCloseTime,
+		})
+	} else if !lostMajority {
+		// No flags = enable the amendment
+		// Reference: rippled lines 318-335
+		sle.Amendments = append(sle.Amendments, amendmentHash)
+
+		// Note: activateTrustLinesToSelfFix() and AmendmentTable.enable() are
+		// not implemented since they require full network infrastructure.
+		// The amendment is recorded in the ledger state which is the primary goal.
+	}
+
+	// Update the majorities list
+	// Reference: rippled lines 337-340
+	sle.Majorities = newMajorities
+
+	// Serialize and write back
+	serialized, serErr := SerializeAmendmentsSLE(sle)
+	if serErr != nil {
+		return tx.TefINTERNAL
+	}
+
+	if isNew {
+		if insertErr := ctx.View.Insert(k, serialized); insertErr != nil {
+			return tx.TefINTERNAL
+		}
+	} else {
+		if updateErr := ctx.View.Update(k, serialized); updateErr != nil {
+			return tx.TefINTERNAL
+		}
+	}
+
 	return tx.TesSUCCESS
+}
+
+// parseAmendmentHash parses a hex-encoded amendment hash string into [32]byte.
+func parseAmendmentHash(hashStr string) ([32]byte, error) {
+	var hash [32]byte
+	b, err := hex.DecodeString(strings.TrimPrefix(hashStr, "0x"))
+	if err != nil {
+		return hash, err
+	}
+	if len(b) != 32 {
+		return hash, errors.New("amendment hash must be 32 bytes")
+	}
+	copy(hash[:], b)
+	return hash, nil
 }

--- a/internal/tx/pseudo/negative_unl_sle.go
+++ b/internal/tx/pseudo/negative_unl_sle.go
@@ -1,0 +1,147 @@
+package pseudo
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+)
+
+// NegativeUNLSLE represents the parsed NegativeUNL ledger entry.
+// Reference: rippled SLE with type ltNEGATIVE_UNL (0x004e)
+// Fields: sfDisabledValidators (STArray), sfValidatorToDisable (Blob),
+//
+//	sfValidatorToReEnable (Blob)
+type NegativeUNLSLE struct {
+	// DisabledValidators is the list of currently disabled validator public keys.
+	DisabledValidators [][]byte
+
+	// ValidatorToDisable is the validator scheduled for disabling (if any).
+	ValidatorToDisable []byte
+
+	// ValidatorToReEnable is the validator scheduled for re-enabling (if any).
+	ValidatorToReEnable []byte
+}
+
+// ParseNegativeUNLSLE parses a NegativeUNL SLE from binary data.
+func ParseNegativeUNLSLE(data []byte) (*NegativeUNLSLE, error) {
+	if len(data) == 0 {
+		return &NegativeUNLSLE{}, nil
+	}
+
+	hexStr := hex.EncodeToString(data)
+	jsonObj, err := binarycodec.Decode(hexStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode NegativeUNL SLE: %w", err)
+	}
+
+	sle := &NegativeUNLSLE{}
+
+	// Parse sfDisabledValidators (STArray of objects with sfPublicKey)
+	if validators, ok := jsonObj["DisabledValidators"]; ok {
+		arr, ok := validators.([]any)
+		if !ok {
+			return nil, fmt.Errorf("unexpected DisabledValidators type: %T", validators)
+		}
+		for _, item := range arr {
+			wrapper, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			inner, ok := wrapper["DisabledValidator"]
+			if !ok {
+				continue
+			}
+			innerMap, ok := inner.(map[string]any)
+			if !ok {
+				continue
+			}
+			if pubKey, ok := innerMap["PublicKey"].(string); ok {
+				b, err := hex.DecodeString(pubKey)
+				if err == nil {
+					sle.DisabledValidators = append(sle.DisabledValidators, b)
+				}
+			}
+		}
+	}
+
+	// Parse sfValidatorToDisable (Blob)
+	if vtd, ok := jsonObj["ValidatorToDisable"].(string); ok {
+		b, err := hex.DecodeString(vtd)
+		if err == nil {
+			sle.ValidatorToDisable = b
+		}
+	}
+
+	// Parse sfValidatorToReEnable (Blob)
+	if vtr, ok := jsonObj["ValidatorToReEnable"].(string); ok {
+		b, err := hex.DecodeString(vtr)
+		if err == nil {
+			sle.ValidatorToReEnable = b
+		}
+	}
+
+	return sle, nil
+}
+
+// SerializeNegativeUNLSLE serializes a NegativeUNLSLE to binary data.
+func SerializeNegativeUNLSLE(sle *NegativeUNLSLE) ([]byte, error) {
+	jsonObj := map[string]any{
+		"LedgerEntryType": "NegativeUNL",
+		"Flags":           0,
+	}
+
+	// Add sfDisabledValidators (STArray)
+	if len(sle.DisabledValidators) > 0 {
+		arr := make([]any, len(sle.DisabledValidators))
+		for i, key := range sle.DisabledValidators {
+			arr[i] = map[string]any{
+				"DisabledValidator": map[string]any{
+					"PublicKey": strings.ToUpper(hex.EncodeToString(key)),
+				},
+			}
+		}
+		jsonObj["DisabledValidators"] = arr
+	}
+
+	// Add sfValidatorToDisable (Blob)
+	if len(sle.ValidatorToDisable) > 0 {
+		jsonObj["ValidatorToDisable"] = strings.ToUpper(hex.EncodeToString(sle.ValidatorToDisable))
+	}
+
+	// Add sfValidatorToReEnable (Blob)
+	if len(sle.ValidatorToReEnable) > 0 {
+		jsonObj["ValidatorToReEnable"] = strings.ToUpper(hex.EncodeToString(sle.ValidatorToReEnable))
+	}
+
+	hexStr, err := binarycodec.Encode(jsonObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode NegativeUNL SLE: %w", err)
+	}
+
+	return hex.DecodeString(hexStr)
+}
+
+// ContainsValidator checks if a validator key is in the disabled validators list.
+func (sle *NegativeUNLSLE) ContainsValidator(key []byte) bool {
+	for _, k := range sle.DisabledValidators {
+		if bytesEqual(k, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// bytesEqual compares two byte slices for equality.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tx/pseudo/unl_modify.go
+++ b/internal/tx/pseudo/unl_modify.go
@@ -1,7 +1,10 @@
 package pseudo
 
 import (
+	"encoding/hex"
+
 	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/keylet"
 )
 
 func init() {
@@ -50,27 +53,145 @@ func (u *UNLModify) IsPseudoTransaction() bool {
 }
 
 // Apply applies the UNLModify transaction to ledger state.
-// Reference: rippled Change.cpp applyUNLModify()
-//
-// TODO: Implement full UNL modify logic for network mode:
-//   - Verify this is a flag ledger: isFlagLedger(view.seq()) — i.e. (seq % 256 == 0)
-//   - Validate required fields: UNLModifyDisabling (0 or 1), LedgerSequence, UNLModifyValidator
-//   - Verify LedgerSequence matches current ledger sequence
-//   - Validate UNLModifyValidator is a valid public key
-//   - Read/create negative UNL SLE at keylet::negativeUNL()
-//     (needs keylet.NegativeUNL() — not yet implemented)
-//   - If disabling (UNLModifyDisabling == 1):
-//     - Must not already have a ValidatorToDisable
-//     - Must not conflict with ValidatorToReEnable
-//     - Must not already be in the DisabledValidators array
-//     - Set sfValidatorToDisable on the SLE
-//   - If re-enabling (UNLModifyDisabling == 0):
-//     - Must not already have a ValidatorToReEnable
-//     - Must not conflict with ValidatorToDisable
-//     - Must already be in the DisabledValidators array
-//     - Set sfValidatorToReEnable on the SLE
-//   - Update the negative UNL SLE
+// Reference: rippled Change.cpp applyUNLModify() lines 388-512
 func (u *UNLModify) Apply(ctx *tx.ApplyContext) tx.Result {
-	// Stub: not needed for standalone mode (no validators in negative UNL)
+	// 1. Validate flag ledger
+	// Reference: rippled lines 390-395
+	if !isFlagLedger(ctx.Config.LedgerSequence) {
+		return tx.TefFAILURE
+	}
+
+	// 2. Validate required fields
+	// Reference: rippled lines 397-404
+	if u.UNLModifyDisabling == nil || *u.UNLModifyDisabling > 1 {
+		return tx.TefFAILURE
+	}
+	if u.LedgerSequence == nil || u.UNLModifyValidator == "" {
+		return tx.TefFAILURE
+	}
+
+	disabling := *u.UNLModifyDisabling == 1
+	seq := *u.LedgerSequence
+
+	// 3. Verify LedgerSequence matches current ledger
+	// Reference: rippled lines 407-412
+	if seq != ctx.Config.LedgerSequence {
+		return tx.TefFAILURE
+	}
+
+	// 4. Parse and validate the validator public key
+	// Reference: rippled lines 414-419
+	validator, err := hex.DecodeString(u.UNLModifyValidator)
+	if err != nil || len(validator) == 0 {
+		return tx.TefFAILURE
+	}
+	// Validate public key type: ED25519 (0xED prefix, 33 bytes) or secp256k1 (0x02/0x03, 33 bytes)
+	if !isValidPublicKeyType(validator) {
+		return tx.TefFAILURE
+	}
+
+	// 5. Get or create the NegativeUNL SLE
+	// Reference: rippled lines 426-432
+	k := keylet.NegativeUNL()
+	var sle *NegativeUNLSLE
+	isNew := false
+
+	data, readErr := ctx.View.Read(k)
+	if readErr != nil || data == nil {
+		sle = &NegativeUNLSLE{}
+		isNew = true
+	} else {
+		sle, err = ParseNegativeUNLSLE(data)
+		if err != nil {
+			return tx.TefFAILURE
+		}
+	}
+
+	// 6. Check if validator is in the disabled list
+	// Reference: rippled lines 434-447
+	found := sle.ContainsValidator(validator)
+
+	if disabling {
+		// 7. Disabling path
+		// Reference: rippled lines 449-478
+
+		// Cannot have more than one ValidatorToDisable
+		if len(sle.ValidatorToDisable) > 0 {
+			return tx.TefFAILURE
+		}
+
+		// Cannot be the same as ValidatorToReEnable
+		if len(sle.ValidatorToReEnable) > 0 && bytesEqual(sle.ValidatorToReEnable, validator) {
+			return tx.TefFAILURE
+		}
+
+		// Cannot already be in the disabled list
+		if found {
+			return tx.TefFAILURE
+		}
+
+		sle.ValidatorToDisable = validator
+	} else {
+		// 8. Re-enabling path
+		// Reference: rippled lines 479-508
+
+		// Cannot have more than one ValidatorToReEnable
+		if len(sle.ValidatorToReEnable) > 0 {
+			return tx.TefFAILURE
+		}
+
+		// Cannot be the same as ValidatorToDisable
+		if len(sle.ValidatorToDisable) > 0 && bytesEqual(sle.ValidatorToDisable, validator) {
+			return tx.TefFAILURE
+		}
+
+		// Must be in the disabled list
+		if !found {
+			return tx.TefFAILURE
+		}
+
+		sle.ValidatorToReEnable = validator
+	}
+
+	// 9. Serialize and write back
+	// Reference: rippled line 510
+	serialized, serErr := SerializeNegativeUNLSLE(sle)
+	if serErr != nil {
+		return tx.TefFAILURE
+	}
+
+	if isNew {
+		if insertErr := ctx.View.Insert(k, serialized); insertErr != nil {
+			return tx.TefFAILURE
+		}
+	} else {
+		if updateErr := ctx.View.Update(k, serialized); updateErr != nil {
+			return tx.TefFAILURE
+		}
+	}
+
 	return tx.TesSUCCESS
+}
+
+// isFlagLedger returns true if the ledger sequence is a flag ledger (multiple of 256).
+// Reference: rippled isFlagLedger()
+func isFlagLedger(seq uint32) bool {
+	return seq%256 == 0
+}
+
+// isValidPublicKeyType validates that the byte slice is a valid public key.
+// ED25519 keys are 33 bytes with 0xED prefix.
+// secp256k1 keys are 33 bytes with 0x02 or 0x03 prefix.
+func isValidPublicKeyType(key []byte) bool {
+	if len(key) != 33 {
+		return false
+	}
+	switch key[0] {
+	case 0xED: // ED25519
+		return true
+	case 0x02, 0x03: // secp256k1 compressed
+		return true
+	default:
+		return false
+	}
 }

--- a/keylet/keylet.go
+++ b/keylet/keylet.go
@@ -40,6 +40,7 @@ const (
 	spaceMPToken    uint16 = 't' // MPToken
 	spaceCredential uint16 = 'D' // Credential
 	spacePermDomain uint16 = 'b' // Permissioned domain
+	spaceNegativeUNL uint16 = 'N' // Negative UNL (singleton)
 	spaceVault      uint16 = 'V' // Vault
 	spaceDelegate   uint16 = 'E' // Delegate
 )
@@ -88,6 +89,15 @@ func Amendments() Keylet {
 	return Keylet{
 		Type: entry.TypeAmendments,
 		Key:  indexHash(spaceAmendments),
+	}
+}
+
+// NegativeUNL returns the keylet for the singleton negative UNL entry.
+// Reference: rippled Indexes.cpp negativeUNL()
+func NegativeUNL() Keylet {
+	return Keylet{
+		Type: entry.TypeNegativeUNL,
+		Key:  indexHash(spaceNegativeUNL),
 	}
 }
 


### PR DESCRIPTION
…ctions

Replaces stub Apply() implementations with full rippled-conformant logic for all three remaining stub transaction types:

- LedgerStateFix: repairNFTokenDirectoryLinks() matching rippled's NFTokenUtils.cpp (single page, multi-page walk, missing last page cases)
- EnableAmendment: full amendment lifecycle (enable, gotMajority, lostMajority) with Amendments SLE parse/serialize
- UNLModify: flag ledger validation, validator disable/re-enable with NegativeUNL SLE management

Also adds: SubmitPseudo() test helper, keylet.NegativeUNL(), and 34 new tests covering all branches.