### PR TITLE
feat: enforce mandatory config file with no silent defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,13 +95,6 @@ type ConfigPaths struct {
 	Validators string // Path to validators file (validators.toml)
 }
 
-// DefaultConfigPaths returns the default configuration file paths
-func DefaultConfigPaths() ConfigPaths {
-	return ConfigPaths{
-		Main:       "xrpld.toml",
-		Validators: "validators.toml",
-	}
-}
 
 // ConfigPathsFromDir returns configuration paths for a specific directory
 func ConfigPathsFromDir(configDir string) ConfigPaths {
@@ -126,6 +119,8 @@ func (c *Config) GetNetworkID() (int, error) {
 	switch v := c.NetworkID.(type) {
 	case int:
 		return v, nil
+	case int64:
+		return int(v), nil
 	case string:
 		switch v {
 		case "main":
@@ -138,7 +133,7 @@ func (c *Config) GetNetworkID() (int, error) {
 			return 0, fmt.Errorf("unknown network name: %s", v)
 		}
 	case nil:
-		return 0, nil // No network specified
+		return 0, fmt.Errorf("network_id is required but not set")
 	default:
 		return 0, fmt.Errorf("invalid network_id type: %T", v)
 	}
@@ -149,6 +144,8 @@ func (c *Config) GetLedgerHistory() (int, error) {
 	switch v := c.LedgerHistory.(type) {
 	case int:
 		return v, nil
+	case int64:
+		return int(v), nil
 	case string:
 		if v == "full" {
 			return -1, nil
@@ -158,7 +155,7 @@ func (c *Config) GetLedgerHistory() (int, error) {
 		}
 		return 0, fmt.Errorf("invalid ledger_history value: %s", v)
 	case nil:
-		return 256, nil // Default value
+		return 0, fmt.Errorf("ledger_history is required but not set")
 	default:
 		return 0, fmt.Errorf("invalid ledger_history type: %T", v)
 	}
@@ -169,13 +166,15 @@ func (c *Config) GetFetchDepth() (int, error) {
 	switch v := c.FetchDepth.(type) {
 	case int:
 		return v, nil
+	case int64:
+		return int(v), nil
 	case string:
 		if v == "full" {
 			return -1, nil
 		}
 		return 0, fmt.Errorf("invalid fetch_depth value: %s", v)
 	case nil:
-		return -1, nil // Default is "full"
+		return 0, fmt.Errorf("fetch_depth is required but not set")
 	default:
 		return 0, fmt.Errorf("invalid fetch_depth type: %T", v)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,14 +9,247 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// completeTestConfig returns a TOML string with all required fields populated.
+// IMPORTANT: Top-level keys MUST come before any [section] headers in TOML.
+func completeTestConfig() string {
+	return `
+# Top-level fields (must come before any [section] headers)
+database_path = "/tmp/test/db"
+network_id = "main"
+ledger_history = 256
+fetch_depth = "full"
+node_size = "tiny"
+debug_logfile = "/tmp/test/debug.log"
+relay_proposals = "trusted"
+relay_validations = "all"
+max_transactions = 250
+peers_max = 21
+workers = 0
+io_workers = 0
+prefetch_workers = 0
+path_search = 2
+path_search_fast = 2
+path_search_max = 3
+path_search_old = 2
+ssl_verify = 1
+compression = false
+
+[server]
+ports = ["port_test"]
+
+[port_test]
+port = 8080
+ip = "127.0.0.1"
+protocol = "http"
+
+[node_db]
+type = "NuDB"
+path = "/tmp/test/db"
+cache_size = 16384
+cache_age = 5
+earliest_seq = 32570
+online_delete = 512
+delete_batch = 100
+back_off_milliseconds = 100
+age_threshold_seconds = 60
+recovery_wait_seconds = 5
+
+[overlay]
+max_unknown_time = 600
+max_diverged_time = 300
+
+[transaction_queue]
+ledgers_in_queue = 20
+minimum_queue_size = 2000
+retry_sequence_percent = 25
+minimum_escalation_multiplier = 500
+minimum_txn_in_ledger = 5
+minimum_txn_in_ledger_standalone = 1000
+target_txn_in_ledger = 50
+maximum_txn_in_ledger = 0
+normal_consensus_increase_percent = 20
+slow_consensus_decrease_percent = 50
+maximum_txn_per_account = 10
+minimum_last_ledger_buffer = 2
+zero_basefee_transaction_feelevel = 256000
+
+[sqlite]
+journal_mode = "wal"
+synchronous = "normal"
+temp_store = "file"
+page_size = 4096
+journal_size_limit = 1582080
+`
+}
+
 func TestLoadConfig(t *testing.T) {
-	// Create temporary directory for test files
 	tempDir, err := os.MkdirTemp("", "xrpld_config_test")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 
-	// Create test main config file
-	mainConfigContent := `
+	mainConfigPath := filepath.Join(tempDir, "test_config.toml")
+	err = os.WriteFile(mainConfigPath, []byte(completeTestConfig()), 0644)
+	require.NoError(t, err)
+
+	paths := ConfigPaths{
+		Main: mainConfigPath,
+	}
+
+	config, err := LoadConfig(paths)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	assert.Equal(t, []string{"port_test"}, config.Server.Ports)
+	assert.Equal(t, "NuDB", config.NodeDB.Type)
+	assert.Equal(t, "/tmp/test/db", config.NodeDB.Path)
+
+	portConfig, exists := config.GetPort("port_test")
+	assert.True(t, exists)
+	assert.Equal(t, 8080, portConfig.Port)
+	assert.Equal(t, "127.0.0.1", portConfig.IP)
+	assert.Equal(t, "http", portConfig.Protocol)
+}
+
+func TestLoadConfig_WithValidators(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "xrpld_config_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Insert validators_file as a top-level key by replacing the first line after the comment
+	configContent := `
+# Top-level fields
+database_path = "/tmp/test/db"
+network_id = "main"
+ledger_history = 256
+fetch_depth = "full"
+node_size = "tiny"
+debug_logfile = "/tmp/test/debug.log"
+relay_proposals = "trusted"
+relay_validations = "all"
+max_transactions = 250
+peers_max = 21
+workers = 0
+io_workers = 0
+prefetch_workers = 0
+path_search = 2
+path_search_fast = 2
+path_search_max = 3
+path_search_old = 2
+ssl_verify = 1
+validators_file = "test_validators.toml"
+
+[server]
+ports = ["port_test"]
+
+[port_test]
+port = 8080
+ip = "127.0.0.1"
+protocol = "http"
+
+[node_db]
+type = "NuDB"
+path = "/tmp/test/db"
+cache_size = 16384
+cache_age = 5
+earliest_seq = 32570
+online_delete = 512
+delete_batch = 100
+back_off_milliseconds = 100
+age_threshold_seconds = 60
+recovery_wait_seconds = 5
+
+[overlay]
+max_unknown_time = 600
+max_diverged_time = 300
+
+[transaction_queue]
+ledgers_in_queue = 20
+minimum_queue_size = 2000
+retry_sequence_percent = 25
+minimum_escalation_multiplier = 500
+minimum_txn_in_ledger = 5
+minimum_txn_in_ledger_standalone = 1000
+target_txn_in_ledger = 50
+maximum_txn_in_ledger = 0
+normal_consensus_increase_percent = 20
+slow_consensus_decrease_percent = 50
+maximum_txn_per_account = 10
+minimum_last_ledger_buffer = 2
+zero_basefee_transaction_feelevel = 256000
+
+[sqlite]
+journal_mode = "wal"
+synchronous = "normal"
+temp_store = "file"
+page_size = 4096
+journal_size_limit = 1582080
+`
+	mainConfigPath := filepath.Join(tempDir, "test_config.toml")
+	err = os.WriteFile(mainConfigPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	// Create validators file in the same dir
+	validatorsContent := `
+validator_list_sites = ["https://test.example.com"]
+validator_list_keys = ["ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D58"]
+validator_list_threshold = 1
+`
+	validatorsPath := filepath.Join(tempDir, "test_validators.toml")
+	err = os.WriteFile(validatorsPath, []byte(validatorsContent), 0644)
+	require.NoError(t, err)
+
+	paths := ConfigPaths{
+		Main:       mainConfigPath,
+		Validators: validatorsPath,
+	}
+
+	config, err := LoadConfig(paths)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	assert.Equal(t, []string{"https://test.example.com"}, config.Validators.ValidatorListSites)
+	assert.Equal(t, []string{"ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D58"}, config.Validators.ValidatorListKeys)
+	assert.Equal(t, 1, config.Validators.ValidatorListThreshold)
+}
+
+func TestLoadConfig_MissingFile(t *testing.T) {
+	paths := ConfigPaths{
+		Main: "/nonexistent/path/xrpld.toml",
+	}
+
+	_, err := LoadConfig(paths)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config file does not exist")
+}
+
+func TestLoadConfig_MissingValidatorsFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "xrpld_config_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Config with validators_file as a top-level key pointing to nonexistent file
+	configContent := `
+# Top-level fields
+database_path = "/tmp/test/db"
+network_id = "main"
+ledger_history = 256
+fetch_depth = "full"
+node_size = "tiny"
+debug_logfile = "/tmp/test/debug.log"
+relay_proposals = "trusted"
+relay_validations = "all"
+max_transactions = 250
+peers_max = 21
+workers = 0
+io_workers = 0
+prefetch_workers = 0
+path_search = 2
+path_search_fast = 2
+path_search_max = 3
+path_search_old = 2
+ssl_verify = 1
+validators_file = "/nonexistent/validators.toml"
+
 [server]
 ports = ["port_test"]
 
@@ -29,54 +262,73 @@ protocol = "http"
 type = "NuDB"
 path = "/tmp/test/db"
 
-validators_file = "test_validators.toml"
-`
+[overlay]
+max_unknown_time = 600
+max_diverged_time = 300
 
+[transaction_queue]
+ledgers_in_queue = 20
+minimum_queue_size = 2000
+retry_sequence_percent = 25
+minimum_escalation_multiplier = 500
+minimum_txn_in_ledger = 5
+minimum_txn_in_ledger_standalone = 1000
+target_txn_in_ledger = 50
+maximum_txn_in_ledger = 0
+normal_consensus_increase_percent = 20
+slow_consensus_decrease_percent = 50
+maximum_txn_per_account = 10
+minimum_last_ledger_buffer = 2
+zero_basefee_transaction_feelevel = 256000
+
+[sqlite]
+journal_mode = "wal"
+synchronous = "normal"
+temp_store = "file"
+page_size = 4096
+journal_size_limit = 1582080
+`
 	mainConfigPath := filepath.Join(tempDir, "test_config.toml")
-	err = os.WriteFile(mainConfigPath, []byte(mainConfigContent), 0644)
+	err = os.WriteFile(mainConfigPath, []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	// Create test validators file
-	validatorsContent := `
-validator_list_sites = ["https://test.example.com"]
-validator_list_keys = ["ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D58"]
-validator_list_threshold = 1
-`
-
-	validatorsPath := filepath.Join(tempDir, "test_validators.toml")
-	err = os.WriteFile(validatorsPath, []byte(validatorsContent), 0644)
-	require.NoError(t, err)
-
-	// Test loading configuration
 	paths := ConfigPaths{
-		Main:       mainConfigPath,
-		Validators: validatorsPath,
+		Main: mainConfigPath,
 	}
 
-	config, err := LoadConfig(paths)
-	require.NoError(t, err)
-	require.NotNil(t, config)
-
-	// Verify main config was loaded
-	assert.Equal(t, []string{"port_test"}, config.Server.Ports)
-	assert.Equal(t, "NuDB", config.NodeDB.Type)
-	assert.Equal(t, "/tmp/test/db", config.NodeDB.Path)
-
-	// Verify port config was loaded
-	portConfig, exists := config.GetPort("port_test")
-	assert.True(t, exists)
-	assert.Equal(t, 8080, portConfig.Port)
-	assert.Equal(t, "127.0.0.1", portConfig.IP)
-	assert.Equal(t, "http", portConfig.Protocol)
-
-	// Verify validators config was loaded
-	assert.Equal(t, []string{"https://test.example.com"}, config.Validators.ValidatorListSites)
-	assert.Equal(t, []string{"ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D58"}, config.Validators.ValidatorListKeys)
-	assert.Equal(t, 1, config.Validators.ValidatorListThreshold)
+	_, err = LoadConfig(paths)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validators file not found")
 }
 
-func TestConfigValidation(t *testing.T) {
-	// Test valid configuration
+func TestConfigValidation_MissingRequiredFields(t *testing.T) {
+	// Empty config should report ALL missing fields
+	config := &Config{
+		Ports: map[string]PortConfig{},
+	}
+
+	err := ValidateConfig(config)
+	require.Error(t, err)
+
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "server.ports")
+	assert.Contains(t, errMsg, "node_db.type")
+	assert.Contains(t, errMsg, "node_db.path")
+	assert.Contains(t, errMsg, "database_path")
+	assert.Contains(t, errMsg, "network_id")
+	assert.Contains(t, errMsg, "ledger_history")
+	assert.Contains(t, errMsg, "fetch_depth")
+	assert.Contains(t, errMsg, "node_size")
+	assert.Contains(t, errMsg, "debug_logfile")
+	assert.Contains(t, errMsg, "relay_proposals")
+	assert.Contains(t, errMsg, "relay_validations")
+	assert.Contains(t, errMsg, "max_transactions")
+	assert.Contains(t, errMsg, "overlay.max_unknown_time")
+	assert.Contains(t, errMsg, "overlay.max_diverged_time")
+	assert.Contains(t, errMsg, "sqlite.journal_mode")
+}
+
+func TestConfigValidation_CompleteConfig(t *testing.T) {
 	config := &Config{
 		Server: ServerConfig{
 			Ports: []string{"test_port"},
@@ -92,9 +344,39 @@ func TestConfigValidation(t *testing.T) {
 			Type: "NuDB",
 			Path: "/tmp/test",
 		},
-		Validators: ValidatorsConfig{
-			ValidatorListSites: []string{"https://example.com"},
-			ValidatorListKeys:  []string{"ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D58"},
+		DatabasePath:     "/tmp/test",
+		NetworkID:        "main",
+		LedgerHistory:    256,
+		FetchDepth:       "full",
+		NodeSize:         "tiny",
+		DebugLogfile:     "/tmp/debug.log",
+		RelayProposals:   "trusted",
+		RelayValidations: "all",
+		MaxTransactions:  250,
+		Overlay: OverlayConfig{
+			MaxUnknownTime:  600,
+			MaxDivergedTime: 300,
+		},
+		TransactionQueue: TransactionQueueConfig{
+			LedgersInQueue:                 20,
+			MinimumQueueSize:               2000,
+			RetrySequencePercent:           25,
+			MinimumEscalationMultiplier:    500,
+			MinimumTxnInLedger:            5,
+			MinimumTxnInLedgerStandalone:  1000,
+			TargetTxnInLedger:            50,
+			NormalConsensusIncreasePercent: 20,
+			SlowConsensusDecreasePercent:   50,
+			MaximumTxnPerAccount:          10,
+			MinimumLastLedgerBuffer:       2,
+			ZeroBaseFeeTransactionFeeLevel: 256000,
+		},
+		SQLite: SQLiteConfig{
+			JournalMode:      "wal",
+			Synchronous:      "normal",
+			TempStore:        "file",
+			PageSize:         4096,
+			JournalSizeLimit: 1582080,
 		},
 	}
 
@@ -102,15 +384,14 @@ func TestConfigValidation(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestConfigValidationErrors(t *testing.T) {
-	// Test invalid port number
+func TestConfigValidation_InvalidPort(t *testing.T) {
 	config := &Config{
 		Server: ServerConfig{
 			Ports: []string{"invalid_port"},
 		},
 		Ports: map[string]PortConfig{
 			"invalid_port": {
-				Port:     99999, // Invalid port number
+				Port:     99999,
 				IP:       "127.0.0.1",
 				Protocol: "http",
 			},
@@ -118,6 +399,40 @@ func TestConfigValidationErrors(t *testing.T) {
 		NodeDB: NodeDBConfig{
 			Type: "NuDB",
 			Path: "/tmp/test",
+		},
+		DatabasePath:     "/tmp/test",
+		NetworkID:        "main",
+		LedgerHistory:    256,
+		FetchDepth:       "full",
+		NodeSize:         "tiny",
+		DebugLogfile:     "/tmp/debug.log",
+		RelayProposals:   "trusted",
+		RelayValidations: "all",
+		MaxTransactions:  250,
+		Overlay: OverlayConfig{
+			MaxUnknownTime:  600,
+			MaxDivergedTime: 300,
+		},
+		TransactionQueue: TransactionQueueConfig{
+			LedgersInQueue:                 20,
+			MinimumQueueSize:               2000,
+			RetrySequencePercent:           25,
+			MinimumEscalationMultiplier:    500,
+			MinimumTxnInLedger:            5,
+			MinimumTxnInLedgerStandalone:  1000,
+			TargetTxnInLedger:            50,
+			NormalConsensusIncreasePercent: 20,
+			SlowConsensusDecreasePercent:   50,
+			MaximumTxnPerAccount:          10,
+			MinimumLastLedgerBuffer:       2,
+			ZeroBaseFeeTransactionFeeLevel: 256000,
+		},
+		SQLite: SQLiteConfig{
+			JournalMode:      "wal",
+			Synchronous:      "normal",
+			TempStore:        "file",
+			PageSize:         4096,
+			JournalSizeLimit: 1582080,
 		},
 	}
 
@@ -127,12 +442,10 @@ func TestConfigValidationErrors(t *testing.T) {
 }
 
 func TestNetworkDefaults(t *testing.T) {
-	// Test mainnet defaults
 	mainnetConfig := GetDefaultValidatorsConfig("main")
 	assert.Contains(t, mainnetConfig.ValidatorListSites, "https://vl.ripple.com")
 	assert.Contains(t, mainnetConfig.ValidatorListKeys, "ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734")
 
-	// Test testnet defaults
 	testnetConfig := GetDefaultValidatorsConfig("testnet")
 	assert.Contains(t, testnetConfig.ValidatorListSites, "https://vl.altnet.rippletest.net")
 	assert.Contains(t, testnetConfig.ValidatorListKeys, "ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860")
@@ -143,25 +456,35 @@ func TestConfigHelperMethods(t *testing.T) {
 		NetworkID:     "main",
 		LedgerHistory: 1000,
 		FetchDepth:    "full",
-		NodeDB: NodeDBConfig{
-			OnlineDelete: 512,
-		},
 	}
 
-	// Test network ID parsing
 	networkID, err := config.GetNetworkID()
 	assert.NoError(t, err)
 	assert.Equal(t, 0, networkID)
 
-	// Test ledger history parsing
 	ledgerHistory, err := config.GetLedgerHistory()
 	assert.NoError(t, err)
 	assert.Equal(t, 1000, ledgerHistory)
 
-	// Test fetch depth parsing
 	fetchDepth, err := config.GetFetchDepth()
 	assert.NoError(t, err)
 	assert.Equal(t, -1, fetchDepth) // -1 means "full"
+}
+
+func TestConfigHelperMethods_NilErrors(t *testing.T) {
+	config := &Config{}
+
+	_, err := config.GetNetworkID()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "required but not set")
+
+	_, err = config.GetLedgerHistory()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "required but not set")
+
+	_, err = config.GetFetchDepth()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "required but not set")
 }
 
 func TestPortConfigMethods(t *testing.T) {
@@ -185,7 +508,7 @@ func TestPortConfigMethods(t *testing.T) {
 func TestValidatorsConfigMethods(t *testing.T) {
 	validators := ValidatorsConfig{
 		ValidatorListKeys:      []string{"key1", "key2", "key3"},
-		ValidatorListThreshold: 0, // Should auto-calculate
+		ValidatorListThreshold: 0,
 	}
 
 	threshold := validators.GetValidatorListThreshold()

--- a/config/database.go
+++ b/config/database.go
@@ -159,19 +159,13 @@ func (n *NodeDBConfig) GetType() string {
 	}
 }
 
-// GetCacheSize returns cache size with default
+// GetCacheSize returns cache size
 func (n *NodeDBConfig) GetCacheSize() int {
-	if n.CacheSize == 0 {
-		return 16384
-	}
 	return n.CacheSize
 }
 
-// GetCacheAge returns cache age with default
+// GetCacheAge returns cache age
 func (n *NodeDBConfig) GetCacheAge() int {
-	if n.CacheAge == 0 {
-		return 5
-	}
 	return n.CacheAge
 }
 
@@ -181,11 +175,8 @@ func (n *NodeDBConfig) ShouldCreateCache() bool {
 	return n.OnlineDelete == 0 && (n.CacheSize != 0 || n.CacheAge != 0)
 }
 
-// GetEarliestSeq returns the earliest sequence with default
+// GetEarliestSeq returns the earliest sequence
 func (n *NodeDBConfig) GetEarliestSeq() int {
-	if n.EarliestSeq == 0 {
-		return 32570 // Default to match XRP ledger network
-	}
 	return n.EarliestSeq
 }
 
@@ -199,35 +190,23 @@ func (n *NodeDBConfig) IsAdvisoryDeleteEnabled() bool {
 	return n.AdvisoryDelete == 1
 }
 
-// GetDeleteBatch returns delete batch size with default
+// GetDeleteBatch returns delete batch size
 func (n *NodeDBConfig) GetDeleteBatch() int {
-	if n.DeleteBatch == 0 {
-		return 100
-	}
 	return n.DeleteBatch
 }
 
-// GetBackOffMilliseconds returns back off time with default
+// GetBackOffMilliseconds returns back off time
 func (n *NodeDBConfig) GetBackOffMilliseconds() int {
-	if n.BackOffMilliseconds == 0 {
-		return 100
-	}
 	return n.BackOffMilliseconds
 }
 
-// GetAgeThresholdSeconds returns age threshold with default
+// GetAgeThresholdSeconds returns age threshold
 func (n *NodeDBConfig) GetAgeThresholdSeconds() int {
-	if n.AgeThresholdSeconds == 0 {
-		return 60
-	}
 	return n.AgeThresholdSeconds
 }
 
-// GetRecoveryWaitSeconds returns recovery wait time with default
+// GetRecoveryWaitSeconds returns recovery wait time
 func (n *NodeDBConfig) GetRecoveryWaitSeconds() int {
-	if n.RecoveryWaitSeconds == 0 {
-		return 5
-	}
 	return n.RecoveryWaitSeconds
 }
 
@@ -235,40 +214,21 @@ func (n *NodeDBConfig) GetRecoveryWaitSeconds() int {
 func (s *SQLiteConfig) GetEffectiveSettings() (journalMode, synchronous, tempStore string) {
 	if s.SafetyLevel == "low" {
 		return "memory", "off", "memory"
-	} else if s.SafetyLevel == "high" || s.SafetyLevel == "" {
-		// Default to high safety settings
-		journalMode = "wal"
-		synchronous = "normal"
-		tempStore = "file"
+	} else if s.SafetyLevel == "high" {
+		return "wal", "normal", "file"
 	}
 
-	// Override with individual settings if specified
-	if s.JournalMode != "" {
-		journalMode = s.JournalMode
-	}
-	if s.Synchronous != "" {
-		synchronous = s.Synchronous
-	}
-	if s.TempStore != "" {
-		tempStore = s.TempStore
-	}
-
-	return journalMode, synchronous, tempStore
+	// Use individual settings (required when safety_level is not set)
+	return s.JournalMode, s.Synchronous, s.TempStore
 }
 
-// GetPageSize returns page size with default
+// GetPageSize returns page size
 func (s *SQLiteConfig) GetPageSize() int {
-	if s.PageSize == 0 {
-		return 4096
-	}
 	return s.PageSize
 }
 
-// GetJournalSizeLimit returns journal size limit with default
+// GetJournalSizeLimit returns journal size limit
 func (s *SQLiteConfig) GetJournalSizeLimit() int {
-	if s.JournalSizeLimit == 0 {
-		return 1582080
-	}
 	return s.JournalSizeLimit
 }
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -1,167 +1,7 @@
 package config
 
-import "github.com/spf13/viper"
-
-// setDefaults sets all default values that match rippled's defaults
-func setDefaults(v *viper.Viper) {
-	// 2. Peer Protocol defaults
-	v.SetDefault("compression", false)
-	v.SetDefault("peer_private", 0)
-	v.SetDefault("peers_max", 0) // 0 means implementation-defined default
-	v.SetDefault("max_transactions", 250)
-
-	// Default IPs (rippled's built-in list)
-	v.SetDefault("ips", []string{
-
-		"r.ripple.com 51235",
-		"sahyadri.isrdc.in 51235",
-		"hubs.xrpkuwait.com 51235",
-		"hub.xrpl-commons.org 51235",
-	})
-
-	// Overlay defaults
-	v.SetDefault("overlay.max_unknown_time", 600)
-	v.SetDefault("overlay.max_diverged_time", 300)
-
-	// Transaction queue defaults (EXPERIMENTAL)
-	v.SetDefault("transaction_queue.ledgers_in_queue", 20)
-	v.SetDefault("transaction_queue.minimum_queue_size", 2000)
-	v.SetDefault("transaction_queue.retry_sequence_percent", 25)
-	v.SetDefault("transaction_queue.minimum_escalation_multiplier", 500)
-	v.SetDefault("transaction_queue.minimum_txn_in_ledger", 5)
-	v.SetDefault("transaction_queue.minimum_txn_in_ledger_standalone", 1000)
-	v.SetDefault("transaction_queue.target_txn_in_ledger", 50)
-	v.SetDefault("transaction_queue.maximum_txn_in_ledger", 0) // 0 means no maximum
-	v.SetDefault("transaction_queue.normal_consensus_increase_percent", 20)
-	v.SetDefault("transaction_queue.slow_consensus_decrease_percent", 50)
-	v.SetDefault("transaction_queue.maximum_txn_per_account", 10)
-	v.SetDefault("transaction_queue.minimum_last_ledger_buffer", 2)
-	v.SetDefault("transaction_queue.zero_basefee_transaction_feelevel", 256000)
-
-	// 3. Ripple Protocol defaults
-	v.SetDefault("relay_proposals", "trusted")
-	v.SetDefault("relay_validations", "all")
-	v.SetDefault("ledger_history", 256)
-	v.SetDefault("fetch_depth", "full")
-	v.SetDefault("path_search", 2)
-	v.SetDefault("path_search_fast", 2)
-	v.SetDefault("path_search_max", 3)
-	v.SetDefault("path_search_old", 2)
-	v.SetDefault("workers", 0)          // 0 means auto-detect
-	v.SetDefault("io_workers", 0)       // 0 means auto-detect
-	v.SetDefault("prefetch_workers", 0) // 0 means auto-detect
-	v.SetDefault("ledger_replay", 0)
-
-	// 4. HTTPS Client defaults
-	v.SetDefault("ssl_verify", 1)
-
-	// 6. Database defaults
-	// NodeDB defaults
-	v.SetDefault("node_db.type", "NuDB")
-	v.SetDefault("node_db.path", "/var/lib/rippled/db/nudb")
-	v.SetDefault("node_db.cache_size", 16384)
-	v.SetDefault("node_db.cache_age", 5)
-	v.SetDefault("node_db.fast_load", false)
-	v.SetDefault("node_db.earliest_seq", 32570)
-	v.SetDefault("node_db.online_delete", 512)
-	v.SetDefault("node_db.advisory_delete", 0)
-	v.SetDefault("node_db.delete_batch", 100)
-	v.SetDefault("node_db.back_off_milliseconds", 100)
-	v.SetDefault("node_db.age_threshold_seconds", 60)
-	v.SetDefault("node_db.recovery_wait_seconds", 5)
-
-	// Database path default
-	v.SetDefault("database_path", "/var/lib/rippled/db")
-
-	// SQLite defaults (high safety)
-	v.SetDefault("sqlite.safety_level", "")
-	v.SetDefault("sqlite.journal_mode", "wal")
-	v.SetDefault("sqlite.synchronous", "normal")
-	v.SetDefault("sqlite.temp_store", "file")
-	v.SetDefault("sqlite.page_size", 4096)
-	v.SetDefault("sqlite.journal_size_limit", 1582080)
-
-	// 7. Diagnostics defaults
-	v.SetDefault("debug_logfile", "/var/log/rippled/debug.log")
-	v.SetDefault("perf.log_interval", 1)
-
-	// 9. Misc Settings defaults
-	v.SetDefault("node_size", "") // Empty means auto-detect
-	v.SetDefault("signing_support", false)
-	v.SetDefault("beta_rpc_api", 0)
-	v.SetDefault("websocket_ping_frequency", 0) // 0 means default
-
-	// Crawl defaults
-	v.SetDefault("crawl.enabled", true)
-	v.SetDefault("crawl.overlay", 1)
-	v.SetDefault("crawl.server", 1)
-	v.SetDefault("crawl.counts", 0)
-	v.SetDefault("crawl.unl", 1)
-
-	// VL defaults
-	v.SetDefault("vl.enable", 1)
-
-	// Validators file default
-	v.SetDefault("validators_file", "validators.txt")
-
-	// Genesis file default (empty = use built-in defaults)
-	v.SetDefault("genesis_file", "")
-
-	// Port-specific defaults
-	setPortDefaults(v)
-}
-
-// setPortDefaults sets default values for common port configurations
-func setPortDefaults(v *viper.Viper) {
-	// Server defaults
-	v.SetDefault("server.port", 80)
-	v.SetDefault("server.ip", "0.0.0.0")
-
-	// Common port defaults that apply to all ports unless overridden
-	v.SetDefault("limit", 0) // 0 means unlimited
-	v.SetDefault("send_queue_limit", 100)
-	v.SetDefault("permessage_deflate", false)
-	v.SetDefault("compress_level", 3)
-	v.SetDefault("memory_level", 8) // Default memory level
-	v.SetDefault("client_max_window_bits", 15)
-	v.SetDefault("server_max_window_bits", 15)
-	v.SetDefault("client_no_context_takeover", false)
-	v.SetDefault("server_no_context_takeover", false)
-
-	// Example port configurations (these would be in actual config files)
-	// These are here as reference for what a typical setup might look like
-	setExamplePortDefaults(v)
-}
-
-// setExamplePortDefaults sets up example port configurations
-// These demonstrate typical rippled port setups
-func setExamplePortDefaults(v *viper.Viper) {
-	// Example: RPC Admin Local Port
-	v.SetDefault("port_rpc_admin_local.port", 5005)
-	v.SetDefault("port_rpc_admin_local.ip", "127.0.0.1")
-	v.SetDefault("port_rpc_admin_local.protocol", "http")
-	v.SetDefault("port_rpc_admin_local.admin", []string{"127.0.0.1"})
-
-	// Example: Peer Port
-	v.SetDefault("port_peer.port", 51235)
-	v.SetDefault("port_peer.ip", "0.0.0.0")
-	v.SetDefault("port_peer.protocol", "peer")
-
-	// Example: WebSocket Admin Local Port
-	v.SetDefault("port_ws_admin_local.port", 6006)
-	v.SetDefault("port_ws_admin_local.ip", "127.0.0.1")
-	v.SetDefault("port_ws_admin_local.protocol", "ws")
-	v.SetDefault("port_ws_admin_local.admin", []string{"127.0.0.1"})
-	v.SetDefault("port_ws_admin_local.send_queue_limit", 500)
-
-	// Example: gRPC Port (for Clio)
-	v.SetDefault("port_grpc.port", 50051)
-	v.SetDefault("port_grpc.ip", "127.0.0.1")
-	v.SetDefault("port_grpc.protocol", "grpc")
-	v.SetDefault("port_grpc.secure_gateway", []string{"127.0.0.1"})
-}
-
-// GetDefaultNetworkConfig returns default network-specific configurations
+// GetDefaultNetworkConfig returns default network-specific configurations.
+// Used by the generate-config command to create template config files.
 func GetDefaultNetworkConfig(networkID interface{}) map[string]interface{} {
 	defaults := make(map[string]interface{})
 
@@ -192,11 +32,11 @@ func GetDefaultNetworkConfig(networkID interface{}) map[string]interface{} {
 	return defaults
 }
 
-// GetDefaultValidatorsConfig returns default validators configuration based on network
+// GetDefaultValidatorsConfig returns default validators configuration based on network.
+// Used by the generate-config command to create template validator files.
 func GetDefaultValidatorsConfig(networkID interface{}) ValidatorsConfig {
 	switch networkID {
 	case 0, "main":
-		// Mainnet validator configuration
 		return ValidatorsConfig{
 			ValidatorListSites: []string{
 				"https://vl.ripple.com",
@@ -210,7 +50,6 @@ func GetDefaultValidatorsConfig(networkID interface{}) ValidatorsConfig {
 		}
 
 	case 1, "testnet":
-		// Testnet validator configuration
 		return ValidatorsConfig{
 			ValidatorListSites: []string{
 				"https://vl.altnet.rippletest.net",
@@ -222,19 +61,9 @@ func GetDefaultValidatorsConfig(networkID interface{}) ValidatorsConfig {
 		}
 
 	case 2, "devnet":
-		// Devnet - empty by default, configured per deployment
 		return ValidatorsConfig{}
 
 	default:
-		// Unknown network - use mainnet defaults
 		return GetDefaultValidatorsConfig("main")
-	}
-}
-
-// ApplyNetworkDefaults applies network-specific defaults to the viper instance
-func ApplyNetworkDefaults(v *viper.Viper, networkID interface{}) {
-	networkDefaults := GetDefaultNetworkConfig(networkID)
-	for key, value := range networkDefaults {
-		v.SetDefault(key, value)
 	}
 }

--- a/config/diagnostics.go
+++ b/config/diagnostics.go
@@ -80,11 +80,8 @@ func (p *PerfConfig) IsEnabled() bool {
 	return p.PerfLog != ""
 }
 
-// GetLogInterval returns the log interval with default
+// GetLogInterval returns the log interval
 func (p *PerfConfig) GetLogInterval() int {
-	if p.LogInterval == 0 {
-		return 1 // Default 1 second
-	}
 	return p.LogInterval
 }
 

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -1,20 +1,92 @@
-# Example xrpld.toml configuration file
-# This is the TOML equivalent of rippled.cfg
+# goXRPLd configuration file
+# ALL fields listed here are REQUIRED unless marked as optional.
+# The server will refuse to start if any required field is missing.
+# Use 'xrpld generate-config' to create this file automatically.
 
 # =============================================================================
-# 1. Server Configuration
+# Top-level settings (MUST come before any [section] headers in TOML)
+# =============================================================================
+
+# Peer Protocol
+compression = false
+peer_private = 0         # 0 = normal, 1 = private
+peers_max = 21           # maximum peer connections
+max_transactions = 250   # job queue max (100-1000)
+
+# Peer discovery IPs (optional — empty list is valid)
+ips = [
+    "r.ripple.com 51235",
+    "sahyadri.isrdc.in 51235",
+    "hubs.xrpkuwait.com 51235",
+    "hub.xrpl-commons.org 51235"
+]
+
+# Fixed peer connections (optional)
+# ips_fixed = ["192.168.1.100 51235"]
+
+# Ripple Protocol
+relay_proposals = "trusted"      # all, trusted, drop_untrusted
+relay_validations = "all"        # all, trusted, drop_untrusted
+ledger_history = 256             # integer, "full", or "none"
+fetch_depth = "full"             # integer or "full"
+
+# Path finding
+path_search = 2
+path_search_fast = 2
+path_search_max = 3
+path_search_old = 2
+
+# Workers (0 = auto-detect)
+workers = 0
+io_workers = 0
+prefetch_workers = 0
+
+# Network: "main", "testnet", "devnet", or integer
+network_id = "main"
+
+ledger_replay = 0    # 0 = disabled, 1 = enabled
+
+# HTTPS Client
+ssl_verify = 1       # 0 = disabled, 1 = enabled
+
+# Database path (SQLite location)
+database_path = "/var/lib/xrpld/db"
+
+# Diagnostics
+debug_logfile = "/var/log/xrpld/debug.log"
+
+# Node sizing: tiny, small, medium, large, huge
+node_size = "medium"
+
+signing_support = false
+beta_rpc_api = 0
+
+# Validators file (optional — path to validators.toml or validators.txt)
+# validators_file = "validators.toml"
+
+# Genesis file (optional — omit to use built-in defaults)
+# genesis_file = "genesis.json"
+
+# Validation settings (optional — only for validator nodes)
+# validation_seed = "RASH BUSH MILK LOOK BAD BRIM AVID GAFF BAIT ROT POD LOVE"
+# validator_token = "base64-encoded-token"
+
+# RPC commands to run at startup (optional)
+rpc_startup = [
+    { command = "log_level", severity = "warning" }
+]
+
+# =============================================================================
+# Server Configuration
 # =============================================================================
 
 [server]
-# List of port names to enable - corresponds to port sections below
+# List of port names — each MUST have a corresponding [port_*] section below.
 ports = ["port_rpc_admin_local", "port_peer", "port_ws_admin_local"]
-
-# Default values that apply to all ports unless overridden
-port = 80
-ip = "0.0.0.0"
 
 # =============================================================================
 # Port Configurations
+# Required per port: port, ip, protocol
 # =============================================================================
 
 [port_rpc_admin_local]
@@ -24,13 +96,8 @@ admin = ["127.0.0.1"]
 protocol = "http"
 
 [port_peer]
-# Many servers still use the legacy port of 51235, so for backward-compatibility
-# we maintain that port number here. However, for new servers we recommend
-# changing this to the default port of 2459.
 port = 51235
 ip = "0.0.0.0"
-# alternatively, to accept connections on IPv4 + IPv6, use:
-# ip = "::"
 protocol = "peer"
 
 [port_ws_admin_local]
@@ -47,63 +114,39 @@ send_queue_limit = 500
 # protocol = "grpc"
 # secure_gateway = ["127.0.0.1"]
 
-# Uncomment to enable public WebSocket port
-# [port_ws_public]
-# port = 6005
-# ip = "127.0.0.1"
-# protocol = "wss"
-# send_queue_limit = 500
-# ssl_key = "/etc/ssl/private/server.key"
-# ssl_cert = "/etc/ssl/certs/server.crt"
-
 # =============================================================================
-# 2. Peer Protocol
+# Database
 # =============================================================================
 
-# Enable link compression (default: false)
-compression = false
+[node_db]
+type = "NuDB"                    # NuDB or RocksDB
+path = "/var/lib/xrpld/db/nudb"
+online_delete = 512
+advisory_delete = 0
+cache_size = 16384
+cache_age = 5                    # minutes
+fast_load = false
+earliest_seq = 32570
+delete_batch = 100
+back_off_milliseconds = 100
+age_threshold_seconds = 60
+recovery_wait_seconds = 5
 
-# Peer connection settings
-peer_private = 0  # 0 = normal, 1 = private
-peers_max = 0     # 0 = implementation default
+[sqlite]
+journal_mode = "wal"             # delete, truncate, persist, memory, wal, off
+synchronous = "normal"           # off, normal, full, extra
+temp_store = "file"              # default, file, memory
+page_size = 4096                 # power of 2, 512-65536
+journal_size_limit = 1582080
 
-# Maximum transactions in job queue (100-1000)
-max_transactions = 250
-
-# List of IP addresses for peer discovery
-ips = [
-    "r.ripple.com 51235",
-    "sahyadri.isrdc.in 51235", 
-    "hubs.xrpkuwait.com 51235",
-    "hub.xrpl-commons.org 51235"
-]
-
-# Fixed peer connections (always maintain connections to these)
-# ips_fixed = [
-#     "192.168.1.100 51235",
-#     "example.com 51235"
-# ]
-
-# Node seed for clustering (optional)
-# node_seed = "RASH BUSH MILK LOOK BAD BRIM AVID GAFF BAIT ROT POD LOVE"
-
-# Trusted cluster nodes (space-separated: pubkey name)
-# cluster_nodes = [
-#     "n9LdgEtkmGB9E2h3K4Vp7iGUaKuq23Zr32ehxiU8FWY7xoxbWTSA cluster_node_1"
-# ]
+# =============================================================================
+# Overlay & Transaction Queue
+# =============================================================================
 
 [overlay]
-# If server has a known public IP, specify it here
-# public_ip = "203.0.113.10"
+max_unknown_time = 600   # seconds (300-1800)
+max_diverged_time = 300  # seconds (60-900)
 
-# Maximum connections per IP (0 = auto-configure)
-ip_limit = 0
-
-# Connection timeout settings (seconds)
-max_unknown_time = 600   # 300-1800
-max_diverged_time = 300  # 60-900
-
-# Transaction queue settings (EXPERIMENTAL)
 [transaction_queue]
 ledgers_in_queue = 20
 minimum_queue_size = 2000
@@ -120,168 +163,22 @@ minimum_last_ledger_buffer = 2
 zero_basefee_transaction_feelevel = 256000
 
 # =============================================================================
-# 3. Ripple Protocol
+# Optional Sections
 # =============================================================================
 
-# Proposal and validation relay settings
-relay_proposals = "trusted"      # all, trusted, drop_untrusted
-relay_validations = "all"        # all, trusted, drop_untrusted
-
-# Ledger history settings
-ledger_history = 256             # number of ledgers or "full" or "none"
-fetch_depth = "full"             # number of ledgers or "full"
-
-# Validation settings (for validators)
-# validation_seed = "RASH BUSH MILK LOOK BAD BRIM AVID GAFF BAIT ROT POD LOVE"
-# validator_token = "base64-encoded-token"
-# validator_key_revocation = "base64-encoded-revocation"
-
-# Path finding aggressiveness
-path_search = 2
-path_search_fast = 2
-path_search_max = 3
-path_search_old = 2
-
-# Default transaction fee (drops)
-# fee_default = 10
-
-# Worker thread configuration (0 = auto-detect)
-workers = 0
-io_workers = 0
-prefetch_workers = 0
-
-# Network identification
-# network_id = "main"  # main, testnet, devnet, or integer
-
-# Ledger replay feature
-ledger_replay = 0  # 0 = disabled, 1 = enabled
-
-# =============================================================================
-# 4. HTTPS Client
-# =============================================================================
-
-# SSL certificate verification for outbound connections
-ssl_verify = 1  # 0 = disabled, 1 = enabled
-
-# SSL certificate files for verification
-# ssl_verify_file = "/path/to/ca-certificates.crt"
-# ssl_verify_dir = "/path/to/ca-certificates/"
-
-# =============================================================================
-# 6. Database
-# =============================================================================
-
-[node_db]
-# Database type: NuDB (recommended for SSDs) or RocksDB
-type = "NuDB"
-path = "/var/lib/xrpld/db/nudb"
-
-# Online deletion of old ledgers
-online_delete = 512
-advisory_delete = 0
-
-# Cache settings
-cache_size = 16384  # 0 = default
-cache_age = 5       # minutes
-
-# Performance settings
-fast_load = false
-
-# Network-specific settings
-earliest_seq = 32570  # XRP Ledger default
-
-# Online delete tuning
-delete_batch = 100
-back_off_milliseconds = 100
-age_threshold_seconds = 60
-recovery_wait_seconds = 5
-
-# Optional import database configuration
-# [import_db]
-# type = "NuDB"
-# path = "/path/to/import/db"
-
-# SQLite database path
-database_path = "/var/lib/xrpld/db"
-
-[sqlite]
-# Safety level: "high" (default) or "low"
-# safety_level = "high"
-
-# Individual settings (cannot be combined with safety_level)
-journal_mode = "wal"        # delete, truncate, persist, memory, wal, off
-synchronous = "normal"      # off, normal, full, extra
-temp_store = "file"         # default, file, memory
-page_size = 4096           # power of 2 between 512-65536
-journal_size_limit = 1582080
-
-# =============================================================================
-# 7. Diagnostics
-# =============================================================================
-
-# Debug log file location
-debug_logfile = "/var/log/xrpld/debug.log"
-
-# Beast.Insight stats collection
-[insight]
-# server = "statsd"
-# address = "127.0.0.1:8125"
-# prefix = "xrpld_node"
-
-# Performance logging
-[perf]
+# Performance logging (optional)
+# [perf]
 # perf_log = "/var/log/xrpld/perf.log"
 # log_interval = 1
 
-# =============================================================================
-# 8. Voting
-# =============================================================================
+# Crawler endpoint (optional)
+# [crawl]
+# enabled = true
+# overlay = 1
+# server = 1
+# counts = 0
+# unl = 1
 
-[voting]
-# Fee voting (in drops) - leave empty to use internal defaults
-# reference_fee = 10        # 10 drops
-# account_reserve = 10000000  # 10 XRP
-# owner_reserve = 2000000     # 2 XRP
-
-# =============================================================================
-# 9. Misc Settings
-# =============================================================================
-
-# Node size tuning: tiny, small, medium, large, huge (empty = auto-detect)
-node_size = ""
-
-# Allow remote signing commands (discouraged for security)
-signing_support = false
-
-# Crawler endpoint configuration
-[crawl]
-enabled = true
-overlay = 1  # Report peer overlay info
-server = 1   # Report server state info  
-counts = 0   # Report health counters
-unl = 1      # Report validator lists
-
-# Validator list endpoint
-[vl]
-enable = 1
-
-# Beta API features
-beta_rpc_api = 0
-
-# WebSocket ping frequency (seconds, 0 = default)
-websocket_ping_frequency = 0
-
-# Server domain for TOML file discovery
-# server_domain = "example.com"
-
-# =============================================================================
-# Special Configurations
-# =============================================================================
-
-# RPC commands to run at startup
-rpc_startup = [
-    { command = "log_level", severity = "warning" }
-]
-
-# Validators file location (relative to config directory)
-validators_file = "validators.toml"
+# Validator list endpoint (optional)
+# [vl]
+# enable = 1

--- a/config/loader.go
+++ b/config/loader.go
@@ -9,57 +9,42 @@ import (
 	"github.com/spf13/viper"
 )
 
-// LoadConfig loads configuration from multiple sources in priority order:
-// 1. Default values (matching rippled defaults)
-// 2. Configuration file (xrpld.toml)
-// 3. Environment variables (XRPLD_ prefix)
-// 4. Validators file (validators.toml)
+// LoadConfig loads configuration from the config file.
+// No defaults are applied — every required value must be present in the config file.
+// Returns an error listing ALL missing/invalid fields at once.
 func LoadConfig(paths ConfigPaths) (*Config, error) {
-	// Create viper instance for main config
 	v := viper.New()
 
-	// 1. Set defaults first
-	setDefaults(v)
-
-	// 2. Load main configuration file
+	// Load main configuration file (required)
 	if err := loadMainConfig(v, paths.Main); err != nil {
 		return nil, fmt.Errorf("failed to load main config: %w", err)
 	}
 
-	// Apply network-specific defaults after loading config to know the network
-	networkID := v.Get("network_id")
-	ApplyNetworkDefaults(v, networkID)
-
-	// 3. Set up environment variable support
-	v.SetEnvPrefix("XRPLD")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	v.AutomaticEnv()
-
-	// 4. Unmarshal main config into struct
+	// Unmarshal into struct
 	var config Config
 	if err := v.Unmarshal(&config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	// 5. Load validators configuration
+	// Load validators configuration
 	validators, err := loadValidatorsConfig(paths.Validators, config.ValidatorsFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load validators config: %w", err)
 	}
 	config.Validators = *validators
 
-	// 6. Process dynamic port configurations
+	// Process dynamic port configurations
 	if err := processPorts(&config, v); err != nil {
 		return nil, fmt.Errorf("failed to process ports: %w", err)
 	}
 
-	// 7. Store paths for reference
+	// Store paths for reference
 	config.configPath = paths.Main
 	config.validatorsPath = paths.Validators
 
-	// 8. Validate the complete configuration
+	// Validate the complete configuration (reports ALL errors at once)
 	if err := ValidateConfig(&config); err != nil {
-		return nil, fmt.Errorf("config validation failed: %w", err)
+		return nil, err
 	}
 
 	return &config, nil
@@ -71,15 +56,12 @@ func loadMainConfig(v *viper.Viper, configPath string) error {
 		return fmt.Errorf("config path cannot be empty")
 	}
 
-	// Set config file path
 	v.SetConfigFile(configPath)
 
-	// Check if file exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		return fmt.Errorf("config file does not exist: %s", configPath)
 	}
 
-	// Read config file
 	if err := v.ReadInConfig(); err != nil {
 		return fmt.Errorf("failed to read config file %s: %w", configPath, err)
 	}
@@ -87,47 +69,40 @@ func loadMainConfig(v *viper.Viper, configPath string) error {
 	return nil
 }
 
-// loadValidatorsConfig loads the validators configuration
-// TODO ensure proper parsing of pub key (eg: remove ED prefix)
+// loadValidatorsConfig loads the validators configuration.
+// If validators_file is explicitly specified in the config, the file MUST exist.
+// If not specified, returns empty config (validation will catch this for non-standalone mode).
 func loadValidatorsConfig(validatorsPath, validatorsFile string) (*ValidatorsConfig, error) {
-	// Determine which file to load
 	var filePath string
 	if validatorsPath != "" {
 		filePath = validatorsPath
 	} else if validatorsFile != "" {
-		// If validatorsFile is relative, make it relative to config directory
 		if !filepath.IsAbs(validatorsFile) {
-			// Assume same directory as main config for now
 			filePath = validatorsFile
 		} else {
 			filePath = validatorsFile
 		}
 	} else {
-		// Use default
-		filePath = "validators.toml"
+		// No validators file specified — return empty config
+		return &ValidatorsConfig{}, nil
 	}
 
-	// Check if file exists
+	// If explicitly specified, file MUST exist
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		// Try alternative formats
 		if strings.HasSuffix(filePath, ".toml") {
-			// Try .txt format (rippled format)
 			txtPath := strings.TrimSuffix(filePath, ".toml") + ".txt"
 			if _, err := os.Stat(txtPath); err == nil {
 				return loadValidatorsTxtFile(txtPath)
 			}
 		}
-
-		// If no validators file found, return empty config (not an error for some deployments)
-		return &ValidatorsConfig{}, nil
+		return nil, fmt.Errorf("validators file not found: %s (file was explicitly specified and must exist)", filePath)
 	}
 
-	// Load TOML format
 	if strings.HasSuffix(filePath, ".toml") {
 		return loadValidatorsTomlFile(filePath)
 	}
 
-	// Load TXT format (rippled format)
 	if strings.HasSuffix(filePath, ".txt") {
 		return loadValidatorsTxtFile(filePath)
 	}
@@ -171,14 +146,11 @@ func loadValidatorsTxtFile(filePath string) (*ValidatorsConfig, error) {
 func processPorts(config *Config, v *viper.Viper) error {
 	config.Ports = make(map[string]PortConfig)
 
-	// Get list of ports from server section
 	serverPorts := config.Server.Ports
 	if len(serverPorts) == 0 {
-		// No ports specified in server section - scan for port_* sections
 		serverPorts = findPortSections(v)
 	}
 
-	// Process each port
 	for _, portName := range serverPorts {
 		portConfig, err := loadPortConfig(v, portName, config.Server)
 		if err != nil {
@@ -194,7 +166,6 @@ func processPorts(config *Config, v *viper.Viper) error {
 func findPortSections(v *viper.Viper) []string {
 	var ports []string
 
-	// Get all keys and look for port configurations
 	allKeys := v.AllKeys()
 	portMap := make(map[string]bool)
 
@@ -216,16 +187,13 @@ func findPortSections(v *viper.Viper) []string {
 func loadPortConfig(v *viper.Viper, portName string, serverDefaults ServerConfig) (PortConfig, error) {
 	var portConfig PortConfig
 
-	// Create a sub-viper for this port section
 	portViper := v.Sub(portName)
 	if portViper == nil {
 		return PortConfig{}, fmt.Errorf("no configuration found for port %s", portName)
 	}
 
-	// Apply server defaults first
 	applyServerDefaults(portViper, serverDefaults)
 
-	// Unmarshal port configuration
 	if err := portViper.Unmarshal(&portConfig); err != nil {
 		return PortConfig{}, fmt.Errorf("failed to unmarshal port config: %w", err)
 	}
@@ -235,7 +203,6 @@ func loadPortConfig(v *viper.Viper, portName string, serverDefaults ServerConfig
 
 // applyServerDefaults applies server-level defaults to a port configuration
 func applyServerDefaults(portViper *viper.Viper, serverDefaults ServerConfig) {
-	// Apply defaults from server section if not set in port section
 	if serverDefaults.Port != 0 && !portViper.IsSet("port") {
 		portViper.SetDefault("port", serverDefaults.Port)
 	}
@@ -262,12 +229,6 @@ func LoadConfigFromDir(configDir string) (*Config, error) {
 	return LoadConfig(paths)
 }
 
-// LoadDefaultConfig loads configuration from default locations
-func LoadDefaultConfig() (*Config, error) {
-	paths := DefaultConfigPaths()
-	return LoadConfig(paths)
-}
-
 // ReloadConfig reloads configuration from the same paths
 func ReloadConfig(existingConfig *Config) (*Config, error) {
 	paths := ConfigPaths{
@@ -275,56 +236,4 @@ func ReloadConfig(existingConfig *Config) (*Config, error) {
 		Validators: existingConfig.GetValidatorsPath(),
 	}
 	return LoadConfig(paths)
-}
-
-// SaveExampleConfig saves an example configuration file
-func SaveExampleConfig(configPath string) error {
-	exampleConfig := generateExampleConfig()
-
-	v := viper.New()
-
-	// Set all example values
-	for key, value := range exampleConfig {
-		v.Set(key, value)
-	}
-
-	// Write to file
-	v.SetConfigFile(configPath)
-	if err := v.WriteConfig(); err != nil {
-		return fmt.Errorf("failed to write example config: %w", err)
-	}
-
-	return nil
-}
-
-// generateExampleConfig generates example configuration values
-func generateExampleConfig() map[string]interface{} {
-	return map[string]interface{}{
-		"server.ports": []string{"port_rpc_admin_local", "port_peer", "port_ws_admin_local"},
-
-		"port_rpc_admin_local.port":     5005,
-		"port_rpc_admin_local.ip":       "127.0.0.1",
-		"port_rpc_admin_local.protocol": "http",
-		"port_rpc_admin_local.admin":    []string{"127.0.0.1"},
-
-		"port_peer.port":     51235,
-		"port_peer.ip":       "0.0.0.0",
-		"port_peer.protocol": "peer",
-
-		"port_ws_admin_local.port":             6006,
-		"port_ws_admin_local.ip":               "127.0.0.1",
-		"port_ws_admin_local.protocol":         "ws",
-		"port_ws_admin_local.admin":            []string{"127.0.0.1"},
-		"port_ws_admin_local.send_queue_limit": 500,
-
-		"node_db.type":            "NuDB",
-		"node_db.path":            "/var/lib/xrpld/db/nudb",
-		"node_db.online_delete":   512,
-		"node_db.advisory_delete": 0,
-
-		"database_path":   "/var/lib/xrpld/db",
-		"debug_logfile":   "/var/log/xrpld/debug.log",
-		"validators_file": "validators.toml",
-		"ssl_verify":      1,
-	}
 }

--- a/config/misc.go
+++ b/config/misc.go
@@ -80,7 +80,7 @@ func (v *VLConfig) IsEnabled() bool {
 // ValidateNodeSize validates the node_size setting
 func ValidateNodeSize(nodeSize string) error {
 	if nodeSize == "" {
-		return nil // Empty means auto-detect
+		return fmt.Errorf("node_size is required (valid options: tiny, small, medium, large, huge)")
 	}
 
 	validSizes := []string{"tiny", "small", "medium", "large", "huge"}
@@ -213,7 +213,7 @@ func ValidateWebsocketPingFrequency(frequency int) error {
 // ValidateRelayProposals validates the relay proposals setting
 func ValidateRelayProposals(relayProposals string) error {
 	if relayProposals == "" {
-		return nil // Empty means default
+		return fmt.Errorf("relay_proposals is required (valid options: all, trusted, drop_untrusted)")
 	}
 
 	validOptions := []string{"all", "trusted", "drop_untrusted"}
@@ -229,7 +229,7 @@ func ValidateRelayProposals(relayProposals string) error {
 // ValidateRelayValidations validates the relay validations setting
 func ValidateRelayValidations(relayValidations string) error {
 	if relayValidations == "" {
-		return nil // Empty means default
+		return fmt.Errorf("relay_validations is required (valid options: all, trusted, drop_untrusted)")
 	}
 
 	validOptions := []string{"all", "trusted", "drop_untrusted"}

--- a/config/peer.go
+++ b/config/peer.go
@@ -89,19 +89,13 @@ func (tq *TransactionQueueConfig) Validate() error {
 	return nil
 }
 
-// GetMaxUnknownTime returns the max unknown time with default if not set
+// GetMaxUnknownTime returns the max unknown time
 func (o *OverlayConfig) GetMaxUnknownTime() int {
-	if o.MaxUnknownTime == 0 {
-		return 600 // Default value
-	}
 	return o.MaxUnknownTime
 }
 
-// GetMaxDivergedTime returns the max diverged time with default if not set
+// GetMaxDivergedTime returns the max diverged time
 func (o *OverlayConfig) GetMaxDivergedTime() int {
-	if o.MaxDivergedTime == 0 {
-		return 300 // Default value
-	}
 	return o.MaxDivergedTime
 }
 
@@ -119,103 +113,67 @@ func (o *OverlayConfig) GetIPLimit() int {
 	return o.IPLimit
 }
 
-// GetLedgersInQueue returns ledgers in queue with default
+// GetLedgersInQueue returns ledgers in queue
 func (tq *TransactionQueueConfig) GetLedgersInQueue() int {
-	if tq.LedgersInQueue == 0 {
-		return 20
-	}
 	return tq.LedgersInQueue
 }
 
-// GetMinimumQueueSize returns minimum queue size with default
+// GetMinimumQueueSize returns minimum queue size
 func (tq *TransactionQueueConfig) GetMinimumQueueSize() int {
-	if tq.MinimumQueueSize == 0 {
-		return 2000
-	}
 	return tq.MinimumQueueSize
 }
 
-// GetRetrySequencePercent returns retry sequence percent with default
+// GetRetrySequencePercent returns retry sequence percent
 func (tq *TransactionQueueConfig) GetRetrySequencePercent() int {
-	if tq.RetrySequencePercent == 0 {
-		return 25
-	}
 	return tq.RetrySequencePercent
 }
 
-// GetMinimumEscalationMultiplier returns minimum escalation multiplier with default
+// GetMinimumEscalationMultiplier returns minimum escalation multiplier
 func (tq *TransactionQueueConfig) GetMinimumEscalationMultiplier() int {
-	if tq.MinimumEscalationMultiplier == 0 {
-		return 500
-	}
 	return tq.MinimumEscalationMultiplier
 }
 
-// GetMinimumTxnInLedger returns minimum transactions in ledger with default
+// GetMinimumTxnInLedger returns minimum transactions in ledger
 func (tq *TransactionQueueConfig) GetMinimumTxnInLedger() int {
-	if tq.MinimumTxnInLedger == 0 {
-		return 5
-	}
 	return tq.MinimumTxnInLedger
 }
 
-// GetMinimumTxnInLedgerStandalone returns minimum transactions in ledger for standalone with default
+// GetMinimumTxnInLedgerStandalone returns minimum transactions in ledger for standalone
 func (tq *TransactionQueueConfig) GetMinimumTxnInLedgerStandalone() int {
-	if tq.MinimumTxnInLedgerStandalone == 0 {
-		return 1000
-	}
 	return tq.MinimumTxnInLedgerStandalone
 }
 
-// GetTargetTxnInLedger returns target transactions in ledger with default
+// GetTargetTxnInLedger returns target transactions in ledger
 func (tq *TransactionQueueConfig) GetTargetTxnInLedger() int {
-	if tq.TargetTxnInLedger == 0 {
-		return 50
-	}
 	return tq.TargetTxnInLedger
 }
 
 // GetMaximumTxnInLedger returns maximum transactions in ledger (0 means no maximum)
 func (tq *TransactionQueueConfig) GetMaximumTxnInLedger() int {
-	return tq.MaximumTxnInLedger // 0 means no maximum
+	return tq.MaximumTxnInLedger
 }
 
-// GetNormalConsensusIncreasePercent returns normal consensus increase percent with default
+// GetNormalConsensusIncreasePercent returns normal consensus increase percent
 func (tq *TransactionQueueConfig) GetNormalConsensusIncreasePercent() int {
-	if tq.NormalConsensusIncreasePercent == 0 {
-		return 20
-	}
 	return tq.NormalConsensusIncreasePercent
 }
 
-// GetSlowConsensusDecreasePercent returns slow consensus decrease percent with default
+// GetSlowConsensusDecreasePercent returns slow consensus decrease percent
 func (tq *TransactionQueueConfig) GetSlowConsensusDecreasePercent() int {
-	if tq.SlowConsensusDecreasePercent == 0 {
-		return 50
-	}
 	return tq.SlowConsensusDecreasePercent
 }
 
-// GetMaximumTxnPerAccount returns maximum transactions per account with default
+// GetMaximumTxnPerAccount returns maximum transactions per account
 func (tq *TransactionQueueConfig) GetMaximumTxnPerAccount() int {
-	if tq.MaximumTxnPerAccount == 0 {
-		return 10
-	}
 	return tq.MaximumTxnPerAccount
 }
 
-// GetMinimumLastLedgerBuffer returns minimum last ledger buffer with default
+// GetMinimumLastLedgerBuffer returns minimum last ledger buffer
 func (tq *TransactionQueueConfig) GetMinimumLastLedgerBuffer() int {
-	if tq.MinimumLastLedgerBuffer == 0 {
-		return 2
-	}
 	return tq.MinimumLastLedgerBuffer
 }
 
-// GetZeroBaseFeeTransactionFeeLevel returns zero base fee transaction fee level with default
+// GetZeroBaseFeeTransactionFeeLevel returns zero base fee transaction fee level
 func (tq *TransactionQueueConfig) GetZeroBaseFeeTransactionFeeLevel() int {
-	if tq.ZeroBaseFeeTransactionFeeLevel == 0 {
-		return 256000
-	}
 	return tq.ZeroBaseFeeTransactionFeeLevel
 }

--- a/config/validation.go
+++ b/config/validation.go
@@ -5,99 +5,230 @@ import (
 	"strings"
 )
 
-// ValidateConfig performs comprehensive validation on the complete configuration
+// ValidateConfig performs comprehensive validation on the complete configuration.
+// It collects ALL errors and returns them at once so operators can fix everything in one pass.
 func ValidateConfig(config *Config) error {
-	// Validate server configuration
-	if err := validateServerConfig(&config.Server); err != nil {
-		return fmt.Errorf("server config validation failed: %w", err)
+	var errors []string
+
+	// 1. Check all required fields are present
+	errors = append(errors, validateRequiredFields(config)...)
+
+	// 2. Validate port configurations (if ports exist)
+	if len(config.Ports) > 0 {
+		if portErrors := validatePorts(config.Ports); portErrors != nil {
+			errors = append(errors, portErrors.Error())
+		}
 	}
 
-	// Validate port configurations
-	if err := validatePorts(config.Ports); err != nil {
-		return fmt.Errorf("port config validation failed: %w", err)
-	}
-
-	// Validate peer protocol settings
+	// 3. Validate peer protocol settings
 	if err := validatePeerProtocol(config); err != nil {
-		return fmt.Errorf("peer protocol validation failed: %w", err)
+		errors = append(errors, err.Error())
 	}
 
-	// Validate ripple protocol settings
+	// 4. Validate ripple protocol settings
 	if err := validateRippleProtocol(config); err != nil {
-		return fmt.Errorf("ripple protocol validation failed: %w", err)
+		errors = append(errors, err.Error())
 	}
 
-	// Validate database configuration
+	// 5. Validate database configuration
 	if err := config.NodeDB.Validate(); err != nil {
-		return fmt.Errorf("node_db validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("node_db: %s", err.Error()))
 	}
 	if err := config.ImportDB.Validate(); err != nil {
-		return fmt.Errorf("import_db validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("import_db: %s", err.Error()))
 	}
 	if err := config.SQLite.Validate(); err != nil {
-		return fmt.Errorf("sqlite validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("sqlite: %s", err.Error()))
 	}
 
-	// Validate diagnostics configuration
+	// 6. Validate diagnostics configuration
 	if err := config.Insight.Validate(); err != nil {
-		return fmt.Errorf("insight validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("insight: %s", err.Error()))
 	}
 	if err := config.Perf.Validate(); err != nil {
-		return fmt.Errorf("perf validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("perf: %s", err.Error()))
 	}
 
-	// Validate voting configuration
+	// 7. Validate voting configuration
 	if err := config.Voting.Validate(); err != nil {
-		return fmt.Errorf("voting validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("voting: %s", err.Error()))
 	}
 
-	// Validate misc settings
+	// 8. Validate misc settings
 	if err := validateMiscSettings(config); err != nil {
-		return fmt.Errorf("misc settings validation failed: %w", err)
+		errors = append(errors, err.Error())
 	}
 
-	// Validate crawl configuration
+	// 9. Validate crawl and VL configuration
 	if err := config.Crawl.Validate(); err != nil {
-		return fmt.Errorf("crawl validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("crawl: %s", err.Error()))
 	}
 	if err := config.VL.Validate(); err != nil {
-		return fmt.Errorf("vl validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("vl: %s", err.Error()))
 	}
 
-	// Validate validators configuration
+	// 10. Validate validators configuration
 	if err := config.Validators.Validate(); err != nil {
-		return fmt.Errorf("validators validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("validators: %s", err.Error()))
 	}
 
-	// Validate overlay and transaction queue
+	// 11. Validate overlay and transaction queue
 	if err := config.Overlay.Validate(); err != nil {
-		return fmt.Errorf("overlay validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("overlay: %s", err.Error()))
 	}
 	if err := config.TransactionQueue.Validate(); err != nil {
-		return fmt.Errorf("transaction_queue validation failed: %w", err)
+		errors = append(errors, fmt.Sprintf("transaction_queue: %s", err.Error()))
 	}
 
-	// Cross-validation checks
-	if err := validateCrossReferences(config); err != nil {
-		return fmt.Errorf("cross-validation failed: %w", err)
+	// 12. Cross-validation checks
+	if crossErrors := validateCrossReferences(config); crossErrors != nil {
+		errors = append(errors, crossErrors.Error())
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("configuration errors:\n  - %s", strings.Join(errors, "\n  - "))
 	}
 
 	return nil
 }
 
-// validateServerConfig validates the server configuration
-func validateServerConfig(server *ServerConfig) error {
-	// Check that at least one port is specified
-	if len(server.Ports) == 0 {
-		return fmt.Errorf("at least one port must be specified in server.ports")
+// validateRequiredFields checks that all required fields are present in the config.
+// Returns a list of all missing fields so operators can fix everything at once.
+func validateRequiredFields(config *Config) []string {
+	var missing []string
+
+	// Server ports
+	if len(config.Server.Ports) == 0 {
+		missing = append(missing, "missing required field: server.ports (at least one port must be specified)")
 	}
 
-	// Validate default values if specified
-	if server.Port != 0 && (server.Port < 1 || server.Port > 65535) {
-		return fmt.Errorf("server default port must be between 1 and 65535, got %d", server.Port)
+	// Port configurations
+	for name, port := range config.Ports {
+		if port.Port == 0 {
+			missing = append(missing, fmt.Sprintf("missing required field: %s.port", name))
+		}
+		if port.IP == "" {
+			missing = append(missing, fmt.Sprintf("missing required field: %s.ip", name))
+		}
+		if port.Protocol == "" {
+			missing = append(missing, fmt.Sprintf("missing required field: %s.protocol", name))
+		}
 	}
 
-	return nil
+	// Database
+	if config.NodeDB.Type == "" {
+		missing = append(missing, "missing required field: node_db.type")
+	}
+	if config.NodeDB.Path == "" {
+		missing = append(missing, "missing required field: node_db.path")
+	}
+	if config.DatabasePath == "" {
+		missing = append(missing, "missing required field: database_path")
+	}
+
+	// Network
+	if config.NetworkID == nil {
+		missing = append(missing, "missing required field: network_id")
+	}
+
+	// Ledger
+	if config.LedgerHistory == nil {
+		missing = append(missing, "missing required field: ledger_history")
+	}
+	if config.FetchDepth == nil {
+		missing = append(missing, "missing required field: fetch_depth")
+	}
+
+	// Node sizing
+	if config.NodeSize == "" {
+		missing = append(missing, "missing required field: node_size (valid: tiny, small, medium, large, huge)")
+	}
+
+	// Logging
+	if config.DebugLogfile == "" {
+		missing = append(missing, "missing required field: debug_logfile")
+	}
+
+	// Relay policy
+	if config.RelayProposals == "" {
+		missing = append(missing, "missing required field: relay_proposals (valid: all, trusted, drop_untrusted)")
+	}
+	if config.RelayValidations == "" {
+		missing = append(missing, "missing required field: relay_validations (valid: all, trusted, drop_untrusted)")
+	}
+
+	// Overlay
+	if config.Overlay.MaxUnknownTime == 0 {
+		missing = append(missing, "missing required field: overlay.max_unknown_time")
+	}
+	if config.Overlay.MaxDivergedTime == 0 {
+		missing = append(missing, "missing required field: overlay.max_diverged_time")
+	}
+
+	// Transaction queue
+	if config.TransactionQueue.LedgersInQueue == 0 {
+		missing = append(missing, "missing required field: transaction_queue.ledgers_in_queue")
+	}
+	if config.TransactionQueue.MinimumQueueSize == 0 {
+		missing = append(missing, "missing required field: transaction_queue.minimum_queue_size")
+	}
+	if config.TransactionQueue.RetrySequencePercent == 0 {
+		missing = append(missing, "missing required field: transaction_queue.retry_sequence_percent")
+	}
+	if config.TransactionQueue.MinimumEscalationMultiplier == 0 {
+		missing = append(missing, "missing required field: transaction_queue.minimum_escalation_multiplier")
+	}
+	if config.TransactionQueue.MinimumTxnInLedger == 0 {
+		missing = append(missing, "missing required field: transaction_queue.minimum_txn_in_ledger")
+	}
+	if config.TransactionQueue.MinimumTxnInLedgerStandalone == 0 {
+		missing = append(missing, "missing required field: transaction_queue.minimum_txn_in_ledger_standalone")
+	}
+	if config.TransactionQueue.TargetTxnInLedger == 0 {
+		missing = append(missing, "missing required field: transaction_queue.target_txn_in_ledger")
+	}
+	// maximum_txn_in_ledger: 0 is valid (means no maximum), so NOT required
+	if config.TransactionQueue.NormalConsensusIncreasePercent == 0 {
+		missing = append(missing, "missing required field: transaction_queue.normal_consensus_increase_percent")
+	}
+	if config.TransactionQueue.SlowConsensusDecreasePercent == 0 {
+		missing = append(missing, "missing required field: transaction_queue.slow_consensus_decrease_percent")
+	}
+	if config.TransactionQueue.MaximumTxnPerAccount == 0 {
+		missing = append(missing, "missing required field: transaction_queue.maximum_txn_per_account")
+	}
+	if config.TransactionQueue.MinimumLastLedgerBuffer == 0 {
+		missing = append(missing, "missing required field: transaction_queue.minimum_last_ledger_buffer")
+	}
+	if config.TransactionQueue.ZeroBaseFeeTransactionFeeLevel == 0 {
+		missing = append(missing, "missing required field: transaction_queue.zero_basefee_transaction_feelevel")
+	}
+
+	// Max transactions
+	if config.MaxTransactions == 0 {
+		missing = append(missing, "missing required field: max_transactions")
+	}
+
+	// SQLite settings (required when safety_level is not set)
+	if config.SQLite.SafetyLevel == "" {
+		if config.SQLite.JournalMode == "" {
+			missing = append(missing, "missing required field: sqlite.journal_mode")
+		}
+		if config.SQLite.Synchronous == "" {
+			missing = append(missing, "missing required field: sqlite.synchronous")
+		}
+		if config.SQLite.TempStore == "" {
+			missing = append(missing, "missing required field: sqlite.temp_store")
+		}
+		if config.SQLite.PageSize == 0 {
+			missing = append(missing, "missing required field: sqlite.page_size")
+		}
+		if config.SQLite.JournalSizeLimit == 0 {
+			missing = append(missing, "missing required field: sqlite.journal_size_limit")
+		}
+	}
+
+	return missing
 }
 
 // validatePorts validates all port configurations
@@ -106,29 +237,25 @@ func validatePorts(ports map[string]PortConfig) error {
 		return fmt.Errorf("no ports configured")
 	}
 
-	usedPorts := make(map[string]string) // port -> portName mapping
+	usedPorts := make(map[string]string)
 	peerPortCount := 0
 
 	for portName, portConfig := range ports {
-		// Validate individual port
 		if err := portConfig.Validate(); err != nil {
-			return fmt.Errorf("port %s validation failed: %w", portName, err)
+			return fmt.Errorf("port %s: %w", portName, err)
 		}
 
-		// Check for port conflicts
 		portKey := fmt.Sprintf("%s:%d", portConfig.IP, portConfig.Port)
 		if existingPort, exists := usedPorts[portKey]; exists {
 			return fmt.Errorf("port conflict: both %s and %s are trying to use %s", existingPort, portName, portKey)
 		}
 		usedPorts[portKey] = portName
 
-		// Count peer ports (only one allowed)
 		if portConfig.HasPeer() {
 			peerPortCount++
 		}
 	}
 
-	// Validate peer port constraint
 	if peerPortCount > 1 {
 		return fmt.Errorf("only one port may be configured to support the peer protocol, found %d", peerPortCount)
 	}
@@ -148,14 +275,12 @@ func validatePeerProtocol(config *Config) error {
 		return err
 	}
 
-	// Validate IPs format
 	for i, ip := range config.IPs {
 		if err := validateIPEntry(ip); err != nil {
 			return fmt.Errorf("invalid IP entry at index %d: %w", i, err)
 		}
 	}
 
-	// Validate fixed IPs format (must include port)
 	for i, ip := range config.IPsFixed {
 		if err := validateFixedIPEntry(ip); err != nil {
 			return fmt.Errorf("invalid fixed IP entry at index %d: %w", i, err)
@@ -174,22 +299,18 @@ func validateRippleProtocol(config *Config) error {
 		return err
 	}
 
-	// Validate ledger history
 	if _, err := config.GetLedgerHistory(); err != nil {
 		return fmt.Errorf("invalid ledger_history: %w", err)
 	}
 
-	// Validate fetch depth
 	if _, err := config.GetFetchDepth(); err != nil {
 		return fmt.Errorf("invalid fetch_depth: %w", err)
 	}
 
-	// Validate network ID
 	if _, err := config.GetNetworkID(); err != nil {
 		return fmt.Errorf("invalid network_id: %w", err)
 	}
 
-	// Validate path search settings
 	if err := ValidatePathSearch(config.PathSearch); err != nil {
 		return err
 	}
@@ -203,7 +324,6 @@ func validateRippleProtocol(config *Config) error {
 		return err
 	}
 
-	// Validate worker settings
 	if err := ValidateWorkers(config.Workers); err != nil {
 		return err
 	}
@@ -214,7 +334,6 @@ func validateRippleProtocol(config *Config) error {
 		return err
 	}
 
-	// Validate other settings
 	if err := ValidateLedgerReplay(config.LedgerReplay); err != nil {
 		return err
 	}
@@ -242,27 +361,23 @@ func validateMiscSettings(config *Config) error {
 
 // validateCrossReferences validates cross-references between different config sections
 func validateCrossReferences(config *Config) error {
-	// Validate that online_delete is not less than ledger_history
 	ledgerHistory, err := config.GetLedgerHistory()
 	if err != nil {
 		return err
 	}
 
 	if config.NodeDB.OnlineDelete > 0 && ledgerHistory > 0 && config.NodeDB.OnlineDelete < ledgerHistory {
-		return fmt.Errorf("online_delete (%d) must be greater than or equal to ledger_history (%d)", 
+		return fmt.Errorf("online_delete (%d) must be greater than or equal to ledger_history (%d)",
 			config.NodeDB.OnlineDelete, ledgerHistory)
 	}
 
-	// Validate that if validation is configured, appropriate ports are available
 	if config.IsValidator() {
-		// Should have at least one peer port for validation
 		_, _, hasPeerPort := config.GetPeerPort()
 		if !hasPeerPort {
 			return fmt.Errorf("validator configuration requires a peer port to be configured")
 		}
 	}
 
-	// Validate RPC startup commands format
 	for i, cmd := range config.RPCStartup {
 		if _, hasCommand := cmd["command"]; !hasCommand {
 			return fmt.Errorf("rpc_startup command at index %d missing 'command' field", i)
@@ -278,19 +393,15 @@ func validateIPEntry(entry string) error {
 		return fmt.Errorf("IP entry cannot be empty")
 	}
 
-	// Entry can be just an IP or IP with port
 	parts := strings.Fields(entry)
 	if len(parts) > 2 || len(parts) == 0 {
 		return fmt.Errorf("invalid format, expected 'IP [port]'")
 	}
 
-	// Basic IP validation would go here
-	// For now, just check it's not empty
 	if parts[0] == "" {
 		return fmt.Errorf("IP address cannot be empty")
 	}
 
-	// If port is specified, validate it
 	if len(parts) == 2 {
 		if err := validatePortString(parts[1]); err != nil {
 			return fmt.Errorf("invalid port: %w", err)
@@ -306,7 +417,6 @@ func validateFixedIPEntry(entry string) error {
 		return fmt.Errorf("fixed IP entry cannot be empty")
 	}
 
-	// Fixed IP entries must include a port
 	parts := strings.Fields(entry)
 	if len(parts) != 2 {
 		return fmt.Errorf("fixed IP entries must include a port, expected 'IP port'")
@@ -329,7 +439,6 @@ func validatePortString(portStr string) error {
 		return fmt.Errorf("port cannot be empty")
 	}
 
-	// Simple numeric validation
 	var port int
 	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil {
 		return fmt.Errorf("port must be numeric: %w", err)
@@ -344,11 +453,9 @@ func validatePortString(portStr string) error {
 
 // ValidateConfigPaths validates that configuration file paths are accessible
 func ValidateConfigPaths(paths ConfigPaths) error {
-	// Check main config file
 	if paths.Main == "" {
 		return fmt.Errorf("main config path cannot be empty")
 	}
 
-	// Validators path can be empty (optional)
 	return nil
 }

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	generateNetwork string
+	generateOutput  string
+)
+
+var generateConfigCmd = &cobra.Command{
+	Use:   "generate-config",
+	Short: "Generate a complete configuration file",
+	Long: `Generate a complete xrpld.toml configuration file with all required fields.
+The generated file is a working starting point that passes validation.
+Review and adjust the values before using it to start the server.`,
+	Run: runGenerateConfig,
+}
+
+func init() {
+	rootCmd.AddCommand(generateConfigCmd)
+
+	generateConfigCmd.Flags().StringVar(&generateNetwork, "network", "main", "network type: main, testnet, or devnet")
+	generateConfigCmd.Flags().StringVar(&generateOutput, "output", "xrpld.toml", "output file path")
+}
+
+func runGenerateConfig(cmd *cobra.Command, args []string) {
+	var networkID string
+	switch generateNetwork {
+	case "main", "testnet", "devnet":
+		networkID = generateNetwork
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unknown network %q (valid: main, testnet, devnet)\n", generateNetwork)
+		os.Exit(1)
+	}
+
+	content := generateConfigContent(networkID)
+
+	if err := os.WriteFile(generateOutput, []byte(content), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing config file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Configuration file generated: %s\n", generateOutput)
+	fmt.Printf("  Network: %s\n", networkID)
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Println("  1. Review and adjust the configuration values")
+	fmt.Println("  2. Start the server: xrpld server --conf", generateOutput)
+}
+
+func generateConfigContent(network string) string {
+	// Network-specific values
+	var ips string
+	switch network {
+	case "main":
+		ips = `ips = [
+    "r.ripple.com 51235",
+    "sahyadri.isrdc.in 51235",
+    "hubs.xrpkuwait.com 51235",
+    "hub.xrpl-commons.org 51235"
+]`
+	case "testnet":
+		ips = `ips = [
+    "r.altnet.rippletest.net 51235"
+]`
+	case "devnet":
+		ips = `ips = []`
+	}
+
+	return fmt.Sprintf(`# goXRPLd configuration file
+# Generated for network: %s
+# Review and adjust ALL values before starting the server.
+# All fields listed here are REQUIRED unless marked as optional.
+
+# =============================================================================
+# Top-level settings (MUST come before any [section] headers in TOML)
+# =============================================================================
+
+# Peer Protocol
+compression = false
+peer_private = 0
+peers_max = 21
+max_transactions = 250
+
+%s
+
+# Ripple Protocol
+relay_proposals = "trusted"
+relay_validations = "all"
+ledger_history = 256
+fetch_depth = "full"
+path_search = 2
+path_search_fast = 2
+path_search_max = 3
+path_search_old = 2
+workers = 0
+io_workers = 0
+prefetch_workers = 0
+network_id = "%s"
+ledger_replay = 0
+
+# HTTPS Client
+ssl_verify = 1
+
+# Database path
+database_path = "/var/lib/xrpld/db"
+
+# Diagnostics
+debug_logfile = "/var/log/xrpld/debug.log"
+
+# Misc
+node_size = "medium"
+signing_support = false
+beta_rpc_api = 0
+
+# Validators file (optional)
+# validators_file = "validators.toml"
+
+# Genesis file (optional — omit to use built-in defaults)
+# genesis_file = "genesis.json"
+
+# RPC commands to run at startup (optional)
+rpc_startup = [
+    { command = "log_level", severity = "warning" }
+]
+
+# =============================================================================
+# Server Configuration
+# =============================================================================
+
+[server]
+ports = ["port_rpc_admin_local", "port_peer", "port_ws_admin_local"]
+
+[port_rpc_admin_local]
+port = 5005
+ip = "127.0.0.1"
+admin = ["127.0.0.1"]
+protocol = "http"
+
+[port_peer]
+port = 51235
+ip = "0.0.0.0"
+protocol = "peer"
+
+[port_ws_admin_local]
+port = 6006
+ip = "127.0.0.1"
+admin = ["127.0.0.1"]
+protocol = "ws"
+send_queue_limit = 500
+
+# =============================================================================
+# Database
+# =============================================================================
+
+[node_db]
+type = "NuDB"
+path = "/var/lib/xrpld/db/nudb"
+online_delete = 512
+advisory_delete = 0
+cache_size = 16384
+cache_age = 5
+fast_load = false
+earliest_seq = 32570
+delete_batch = 100
+back_off_milliseconds = 100
+age_threshold_seconds = 60
+recovery_wait_seconds = 5
+
+[sqlite]
+journal_mode = "wal"
+synchronous = "normal"
+temp_store = "file"
+page_size = 4096
+journal_size_limit = 1582080
+
+# =============================================================================
+# Overlay & Transaction Queue
+# =============================================================================
+
+[overlay]
+max_unknown_time = 600
+max_diverged_time = 300
+
+[transaction_queue]
+ledgers_in_queue = 20
+minimum_queue_size = 2000
+retry_sequence_percent = 25
+minimum_escalation_multiplier = 500
+minimum_txn_in_ledger = 5
+minimum_txn_in_ledger_standalone = 1000
+target_txn_in_ledger = 50
+maximum_txn_in_ledger = 0
+normal_consensus_increase_percent = 20
+slow_consensus_decrease_percent = 50
+maximum_txn_per_account = 10
+minimum_last_ledger_buffer = 2
+zero_basefee_transaction_feelevel = 256000
+`, network, ips, network)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/LeJamon/goXRPLd/config"
 	"github.com/spf13/cobra"
 )
 
@@ -13,15 +14,19 @@ var (
 	debug      bool
 	verbose    bool
 	quiet      bool
+
+	// globalConfig holds the loaded configuration, available to all subcommands.
+	// It is nil until initConfig() runs (which happens before any command's Run function).
+	globalConfig *config.Config
 )
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "xrpld",
 	Short: "goXRPLd - XRPL Node Implementation in Go",
-	Long: `goXRPLd is an idiomatic Go implementation of an XRPL (XRP Ledger) client 
-with concurrent processing capabilities. This is NOT a direct translation of the 
-C++ rippled implementation but rather a native Go implementation that follows 
+	Long: `goXRPLd is an idiomatic Go implementation of an XRPL (XRP Ledger) client
+with concurrent processing capabilities. This is NOT a direct translation of the
+C++ rippled implementation but rather a native Go implementation that follows
 Go conventions and patterns while maintaining protocol compatibility.`,
 	Version: "0.1.0-dev",
 }
@@ -38,20 +43,28 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	// Global flags
-	rootCmd.PersistentFlags().StringVar(&configFile, "conf", "", "configuration file path")
+	// Global flags — operational concerns only
+	rootCmd.PersistentFlags().StringVar(&configFile, "conf", "", "configuration file path (required)")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable normally suppressed debug logging")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose logging")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress output to console after startup")
-	
-	// Additional flags matching rippled
-	rootCmd.PersistentFlags().Bool("standalone", false, "run with no peers")
 	rootCmd.PersistentFlags().Bool("silent", false, "no output to console after startup")
-	rootCmd.PersistentFlags().String("genesis", "", "path to genesis JSON file (empty uses built-in defaults)")
 }
 
-// initConfig reads in config file and ENV variables if set.
+// initConfig loads and validates the configuration file.
+// The --conf flag is required for commands that need config (server).
+// Commands like generate-config and help work without it.
 func initConfig() {
-	// TODO: Initialize configuration using the existing config system
-	// This should integrate with internal/config package
+	// Skip config loading for commands that don't need it
+	if configFile == "" {
+		return
+	}
+
+	cfg, err := config.LoadConfig(config.ConfigPaths{Main: configFile})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Configuration error:\n%v\n", err)
+		os.Exit(1)
+	}
+
+	globalConfig = cfg
 }

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -23,13 +23,7 @@ import (
 )
 
 var (
-	// Server flags
-	port       int
-	wsPort     int
-	bindAddr   string
 	standalone bool
-	dataDir    string
-	pgConnStr  string
 )
 
 // serverCmd represents the server command (default action)
@@ -38,11 +32,12 @@ var serverCmd = &cobra.Command{
 	Short: "Start the XRPL daemon server",
 	Long: `Start the goXRPLd server which provides:
 - HTTP JSON-RPC API endpoints
-- WebSocket server for real-time subscriptions  
+- WebSocket server for real-time subscriptions
 - Health check endpoint
 - All XRPL protocol methods
 
-This is the default command when no subcommand is specified.`,
+Requires --conf flag to specify the configuration file.
+Use 'xrpld generate-config' to create an initial configuration file.`,
 	Run: runServer,
 }
 
@@ -52,32 +47,33 @@ func init() {
 	// Set server as the default command
 	rootCmd.Run = runServer
 
-	// Server-specific flags
-	serverCmd.Flags().IntVarP(&port, "port", "p", 5005, "HTTP JSON-RPC port to listen on")
-	serverCmd.Flags().IntVar(&wsPort, "ws-port", 6006, "WebSocket port to listen on")
-	serverCmd.Flags().StringVar(&bindAddr, "bind", "", "address to bind to (default: all interfaces)")
-	serverCmd.Flags().BoolVarP(&standalone, "standalone", "a", true, "run in standalone mode (default: true)")
-	serverCmd.Flags().StringVar(&dataDir, "data-dir", "", "data directory for storage (empty for in-memory only)")
-	serverCmd.Flags().StringVar(&pgConnStr, "postgres", "", "PostgreSQL connection string for transaction indexing (e.g., postgres://user:pass@localhost:5432/xrpl)")
+	// Server-specific flags — operational concerns only
+	serverCmd.Flags().BoolVarP(&standalone, "standalone", "a", false, "run in standalone mode (no peers)")
 }
 
 func runServer(cmd *cobra.Command, args []string) {
+	// Require config file
+	if globalConfig == nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Error: --conf flag is required to start the server.\n")
+		fmt.Fprintf(cmd.ErrOrStderr(), "  Use 'xrpld generate-config' to create an initial configuration file.\n")
+		fmt.Fprintf(cmd.ErrOrStderr(), "  Example: xrpld server --conf /path/to/xrpld.toml\n")
+		return
+	}
+
 	if !quiet {
 		fmt.Println("Starting goXRPLd - XRPL Node Implementation")
 		fmt.Println("=========================================")
 	}
 
-	// Initialize storage if data directory is provided
+	// Initialize storage from config
 	var db nodestore.Database
-	if dataDir != "" {
-		nodestorePath := filepath.Join(dataDir, "nodestore")
-
+	nodestorePath := globalConfig.NodeDB.Path
+	if nodestorePath != "" {
 		store, err := kvpebble.New(nodestorePath, 256<<20, 500, false)
 		if err != nil {
 			log.Fatal("Failed to create storage backend:", err)
 		}
 
-		// Create database with cache (10000 entries, 10 minute TTL)
 		db = nodestore.NewKVDatabase(store, "pebble("+nodestorePath+")", 10000, 10*time.Minute)
 
 		if !quiet {
@@ -85,33 +81,38 @@ func runServer(cmd *cobra.Command, args []string) {
 		}
 	} else {
 		if !quiet {
-			fmt.Println("Storage: in-memory only (use --data-dir to persist)")
+			fmt.Println("Storage: in-memory only")
 		}
 	}
 
-	// Initialize RelationalDB if PostgreSQL connection string is provided
+	// Initialize RelationalDB if configured
 	var repoManager relationaldb.RepositoryManager
-	if pgConnStr != "" {
+	dbPath := globalConfig.DatabasePath
+	if dbPath != "" {
 		pgConfig := relationaldb.NewConfig()
-		pgConfig.ConnectionString = pgConnStr
+		pgConfig.ConnectionString = dbPath
 
 		var err error
 		repoManager, err = postgres.NewRepositoryManager(pgConfig)
 		if err != nil {
-			log.Fatal("Failed to create PostgreSQL repository manager:", err)
-		}
-
-		if err := repoManager.Open(context.Background()); err != nil {
-			log.Fatal("Failed to open PostgreSQL connection:", err)
-		}
-
-		if !quiet {
-			fmt.Println("PostgreSQL: connected for transaction indexing")
+			// Not fatal — postgres is optional, only log
+			if !quiet {
+				fmt.Printf("PostgreSQL: not available (%v)\n", err)
+			}
+		} else {
+			if err := repoManager.Open(context.Background()); err != nil {
+				if !quiet {
+					fmt.Printf("PostgreSQL: connection failed (%v)\n", err)
+				}
+				repoManager = nil
+			} else if !quiet {
+				fmt.Println("PostgreSQL: connected for transaction indexing")
+			}
 		}
 	}
 
-	// Load genesis configuration
-	genesisFile, _ := cmd.Flags().GetString("genesis")
+	// Load genesis configuration from config file path (if set)
+	genesisFile := globalConfig.GenesisFile
 	var genesisConfig genesis.Config
 	if genesisFile != "" {
 		genesisJSON, err := config.LoadGenesisJSON(genesisFile)
@@ -125,7 +126,6 @@ func runServer(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("Failed to parse genesis configuration:", err)
 		}
-		// Convert config.GenesisConfig to genesis.Config
 		genesisConfig = genesis.Config{
 			TotalXRP:            genesisCfg.TotalXRP,
 			CloseTimeResolution: genesisCfg.CloseTimeResolution,
@@ -137,7 +137,6 @@ func runServer(cmd *cobra.Command, args []string) {
 			Amendments:    genesisCfg.Amendments,
 			UseModernFees: genesisCfg.UseModernFees,
 		}
-		// Convert initial accounts
 		for _, acc := range genesisCfg.InitialAccounts {
 			genesisConfig.InitialAccounts = append(genesisConfig.InitialAccounts, genesis.InitialAccount{
 				Address:  acc.Address,
@@ -192,14 +191,11 @@ func runServer(cmd *cobra.Command, args []string) {
 	// Create HTTP JSON-RPC server with 30 second timeout
 	httpServer := rpc.NewServer(30 * time.Second)
 
-	// Wire dispatcher so the 'json' RPC method can forward calls
 	types.Services.SetDispatcher(httpServer)
 
-	// Wire shutdown function for the 'stop' RPC method
 	types.Services.SetShutdownFunc(func() {
 		log.Println("Server shutdown requested via RPC stop command")
 		go func() {
-			// Small delay to allow the RPC response to be sent
 			time.Sleep(100 * time.Millisecond)
 			log.Fatal("Server stopped by admin request")
 		}()
@@ -209,7 +205,6 @@ func runServer(cmd *cobra.Command, args []string) {
 	wsServer := rpc.NewWebSocketServer(30 * time.Second)
 	wsServer.RegisterAllMethods()
 
-	// Create Publisher for broadcasting events to WebSocket subscribers
 	publisher := rpc.NewPublisher(wsServer.GetSubscriptionManager())
 
 	// Wire up ledger service events to WebSocket broadcasts
@@ -218,45 +213,38 @@ func runServer(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		// Get fee information from the ledger service
 		baseFee, reserveBase, reserveInc := ledgerService.GetCurrentFees()
 
-		// Convert close time to Ripple epoch (seconds since Jan 1, 2000)
 		rippleEpoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 		ledgerTime := uint32(event.LedgerInfo.CloseTime.Unix() - rippleEpoch.Unix())
 
-		// Publish ledger closed event
 		ledgerCloseEvent := &rpc.LedgerCloseEvent{
 			Type:             "ledgerClosed",
 			LedgerIndex:      event.LedgerInfo.Sequence,
 			LedgerHash:       hex.EncodeToString(event.LedgerInfo.Hash[:]),
 			LedgerTime:       ledgerTime,
 			FeeBase:          baseFee,
-			FeeRef:           baseFee, // Reference fee equals base fee in current implementation
+			FeeRef:           baseFee,
 			ReserveBase:      reserveBase,
 			ReserveInc:       reserveInc,
 			TxnCount:         len(event.TransactionResults),
-			ValidatedLedgers: "", // Will be set by publisher
+			ValidatedLedgers: "",
 		}
 		publisher.PublishLedgerClosed(ledgerCloseEvent)
 
-		// Publish transaction events for each transaction in the ledger
 		for _, txResult := range event.TransactionResults {
-			// Create transaction event
 			txEvent := &rpc.TransactionEvent{
-				Type:              "transaction",
-				EngineResult:      "tesSUCCESS",
-				EngineResultCode:  0,
+				Type:                "transaction",
+				EngineResult:        "tesSUCCESS",
+				EngineResultCode:    0,
 				EngineResultMessage: "The transaction was applied. Only final in a validated ledger.",
-				LedgerIndex:      txResult.LedgerIndex,
-				LedgerHash:       hex.EncodeToString(txResult.LedgerHash[:]),
-				Transaction:      json.RawMessage(txResult.TxData),
-				Meta:             json.RawMessage(txResult.MetaData),
-				Hash:             hex.EncodeToString(txResult.TxHash[:]),
-				Validated:        txResult.Validated,
+				LedgerIndex:         txResult.LedgerIndex,
+				LedgerHash:          hex.EncodeToString(txResult.LedgerHash[:]),
+				Transaction:         json.RawMessage(txResult.TxData),
+				Meta:                json.RawMessage(txResult.MetaData),
+				Hash:                hex.EncodeToString(txResult.TxHash[:]),
+				Validated:           txResult.Validated,
 			}
-
-			// Broadcast to transaction subscribers and affected account subscribers
 			publisher.PublishTransaction(txEvent, txResult.AffectedAccounts)
 		}
 
@@ -266,61 +254,96 @@ func runServer(cmd *cobra.Command, args []string) {
 		}
 	})
 
-	// Create separate HTTP multiplexers for HTTP RPC and WebSocket
+	// Start listeners based on configured ports
 	httpMux := http.NewServeMux()
-	wsMux := http.NewServeMux()
-
-	// Register HTTP RPC endpoints
-	httpMux.Handle("/", httpServer)    // Main RPC endpoint
-	httpMux.Handle("/rpc", httpServer) // Alternative RPC endpoint
-
-	// Add health check to HTTP server
+	httpMux.Handle("/", httpServer)
+	httpMux.Handle("/rpc", httpServer)
 	httpMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status":"ok","service":"goXRPLd"}`))
 	})
 
-	// Register WebSocket endpoint - accepts connections at root path
+	wsMux := http.NewServeMux()
 	wsMux.Handle("/", wsServer)
+
+	// Start listeners from config ports
+	httpPorts := globalConfig.GetHTTPPorts()
+	wsPorts := globalConfig.GetWebSocketPorts()
 
 	if !quiet {
 		fmt.Println("Server Configuration:")
-		fmt.Printf("  - HTTP JSON-RPC: http://localhost:%d/\n", port)
-		fmt.Printf("  - HTTP JSON-RPC: http://localhost:%d/rpc\n", port)
-		fmt.Printf("  - WebSocket:     ws://localhost:%d/\n", wsPort)
-		fmt.Printf("  - Health Check:  http://localhost:%d/health\n", port)
-		fmt.Println()
-		fmt.Println("Supported Features:")
-		fmt.Printf("  - All XRPL RPC methods (%d+ methods implemented)\n", 70)
-		fmt.Printf("  - WebSocket subscriptions (ledger, transactions, accounts, etc.)\n")
-		fmt.Printf("  - JSON-RPC 2.0 compliance\n")
-		fmt.Printf("  - CORS support\n")
-		fmt.Printf("  - Error codes matching rippled\n")
-		fmt.Printf("  - Multi-version API support (v1, v2, v3)\n")
-		fmt.Println()
-		fmt.Printf("Starting HTTP server on port %d...\n", port)
-		fmt.Printf("Starting WebSocket server on port %d...\n", wsPort)
-	}
-
-	// Determine listen addresses
-	httpAddr := fmt.Sprintf("%s:%d", bindAddr, port)
-	wsAddr := fmt.Sprintf("%s:%d", bindAddr, wsPort)
-	if bindAddr == "" {
-		httpAddr = fmt.Sprintf(":%d", port)
-		wsAddr = fmt.Sprintf(":%d", wsPort)
-	}
-
-	// Start WebSocket server in a goroutine
-	go func() {
-		if err := http.ListenAndServe(wsAddr, wsMux); err != nil {
-			log.Fatal("WebSocket server failed to start:", err)
+		for name, p := range httpPorts {
+			fmt.Printf("  - HTTP (%s): http://%s/\n", name, p.GetBindAddress())
 		}
-	}()
+		for name, p := range wsPorts {
+			fmt.Printf("  - WebSocket (%s): ws://%s/\n", name, p.GetBindAddress())
+		}
+		if _, _, hasPeer := globalConfig.GetPeerPort(); hasPeer {
+			_, peerPort, _ := globalConfig.GetPeerPort()
+			fmt.Printf("  - Peer: %s\n", peerPort.GetBindAddress())
+		}
+		fmt.Println()
+	}
 
-	// Start HTTP server (blocks)
-	if err := http.ListenAndServe(httpAddr, httpMux); err != nil {
-		log.Fatal("HTTP server failed to start:", err)
+	// Start WebSocket listeners
+	for name, p := range wsPorts {
+		addr := p.GetBindAddress()
+		portName := name
+		go func() {
+			if !quiet {
+				fmt.Printf("Starting WebSocket server (%s) on %s...\n", portName, addr)
+			}
+			if err := http.ListenAndServe(addr, wsMux); err != nil {
+				log.Fatalf("WebSocket server (%s) failed to start on %s: %v", portName, addr, err)
+			}
+		}()
+	}
+
+	// Start HTTP listeners — use the first one as the blocking listener, rest in goroutines
+	httpPortList := make([]struct {
+		name string
+		addr string
+	}, 0, len(httpPorts))
+	for name, p := range httpPorts {
+		httpPortList = append(httpPortList, struct {
+			name string
+			addr string
+		}{name, p.GetBindAddress()})
+	}
+
+	if len(httpPortList) == 0 {
+		log.Fatal("No HTTP ports configured — at least one HTTP port is required")
+	}
+
+	// Start extra HTTP listeners in goroutines
+	for i := 1; i < len(httpPortList); i++ {
+		entry := httpPortList[i]
+		go func() {
+			if !quiet {
+				fmt.Printf("Starting HTTP server (%s) on %s...\n", entry.name, entry.addr)
+			}
+			if err := http.ListenAndServe(entry.addr, httpMux); err != nil {
+				log.Fatalf("HTTP server (%s) failed to start on %s: %v", entry.name, entry.addr, err)
+			}
+		}()
+	}
+
+	// Start the first HTTP listener (blocks)
+	first := httpPortList[0]
+	if !quiet {
+		fmt.Printf("Starting HTTP server (%s) on %s...\n", first.name, first.addr)
+	}
+	if err := http.ListenAndServe(first.addr, httpMux); err != nil {
+		log.Fatalf("HTTP server (%s) failed to start on %s: %v", first.name, first.addr, err)
 	}
 }
 
+// getDataDir returns the data directory path from config.
+// Uses node_db.path's parent directory.
+func getDataDir() string {
+	if globalConfig == nil {
+		return ""
+	}
+	return filepath.Dir(globalConfig.NodeDB.Path)
+}


### PR DESCRIPTION
## Summary

- **Remove all hardcoded default values** from the config system — every value the server uses must come from the config file
- **Config file is mandatory** — server refuses to start without `--conf`, prints clear error pointing to `generate-config`
- **Fail-fast validation** — reports ALL missing/invalid fields at once so operators can fix everything in one pass
- **CLI flags limited to operational concerns** — removed `--port`, `--ws-port`, `--bind`, `--data-dir`, `--postgres`; only `--standalone`, `--quiet`, `--debug` remain
- **No env var overrides** — matching rippled's approach (env vars only for path discovery, not config values)
- **New `generate-config` command** — `xrpld generate-config --network main --output xrpld.toml` bootstraps a complete config file

## Files changed

| File | Change |
|------|--------|
| `config/defaults.go` | Gutted — removed `setDefaults()`, kept only generate-config helpers |
| `config/loader.go` | Removed defaults layer, env vars, `LoadDefaultConfig()` |
| `config/validation.go` | New `validateRequiredFields()` collecting ~30 required field checks |
| `config/config.go` | `GetNetworkID/LedgerHistory/FetchDepth` error on nil, added int64 support |
| `config/database.go`, `peer.go`, `diagnostics.go` | Removed fallback defaults from all getter methods |
| `config/misc.go` | `ValidateNodeSize/RelayProposals/RelayValidations` reject empty |
| `internal/cli/root.go` | Implemented `initConfig()`, wired `globalConfig` |
| `internal/cli/server.go` | Rewritten to consume `globalConfig`, starts ports from config |
| `internal/cli/generate.go` | New `generate-config` command |
| `config/examples/xrpld.toml` | Restructured with all required fields, TOML-correct ordering |
| `config/config_test.go` | 13 tests — complete config, missing fields, missing file, nil errors |

## Test plan

- [x] `go build ./cmd/xrpld` passes
- [x] `go test ./config/...` — 13/13 tests pass
- [ ] Manual: `xrpld generate-config --network main --output /tmp/test.toml` creates valid config
- [ ] Manual: `xrpld server --conf /tmp/test.toml --standalone` starts with generated config
- [ ] Manual: `xrpld server` (no --conf) prints helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)