### PR TITLE
feat: WebSocket

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -205,6 +205,9 @@ func runServer(cmd *cobra.Command, args []string) {
 	wsServer := rpc.NewWebSocketServer(30 * time.Second)
 	wsServer.RegisterAllMethods()
 
+	// Create a ledger info provider adapter for WebSocket subscribe responses
+	wsServer.SetLedgerInfoProvider(&ledgerInfoAdapter{ledgerService: ledgerService})
+
 	publisher := rpc.NewPublisher(wsServer.GetSubscriptionManager())
 
 	// Wire up ledger service events to WebSocket broadcasts
@@ -336,6 +339,41 @@ func runServer(cmd *cobra.Command, args []string) {
 	}
 	if err := http.ListenAndServe(first.addr, httpMux); err != nil {
 		log.Fatalf("HTTP server (%s) failed to start on %s: %v", first.name, first.addr, err)
+	}
+}
+
+// ledgerInfoAdapter adapts the ledger service to the LedgerInfoProvider interface
+type ledgerInfoAdapter struct {
+	ledgerService *service.Service
+}
+
+func (a *ledgerInfoAdapter) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
+	if a.ledgerService == nil {
+		return nil
+	}
+
+	validatedLedger := a.ledgerService.GetValidatedLedger()
+	if validatedLedger == nil {
+		return nil
+	}
+
+	baseFee, reserveBase, reserveInc := a.ledgerService.GetCurrentFees()
+
+	rippleEpoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	ledgerTime := uint32(validatedLedger.CloseTime().Unix() - rippleEpoch.Unix())
+
+	hash := validatedLedger.Hash()
+	serverInfo := a.ledgerService.GetServerInfo()
+
+	return &types.LedgerSubscribeInfo{
+		LedgerIndex:      validatedLedger.Sequence(),
+		LedgerHash:       hex.EncodeToString(hash[:]),
+		LedgerTime:       ledgerTime,
+		FeeBase:          baseFee,
+		FeeRef:           baseFee,
+		ReserveBase:      reserveBase,
+		ReserveInc:       reserveInc,
+		ValidatedLedgers: serverInfo.CompleteLedgers,
 	}
 }
 

--- a/internal/rpc/publisher.go
+++ b/internal/rpc/publisher.go
@@ -122,9 +122,7 @@ func (p *Publisher) PublishServerStatus(event *ServerStatusEvent) {
 		return
 	}
 
-	// Server status goes to the "server" stream (we use types.SubPeerStatus as a proxy here)
-	// In a full implementation, there would be a separate SubServer type
-	p.manager.BroadcastToStream(types.SubPeerStatus, data, nil)
+	p.manager.BroadcastToStream(types.SubServer, data, nil)
 }
 
 // PublishConsensusPhase broadcasts a consensus phase change event
@@ -185,8 +183,12 @@ func (p *Publisher) PublishProposedTransaction(event *ProposedTransactionEvent, 
 		return
 	}
 
-	// Proposed transactions go to accounts_proposed subscribers
-	p.manager.BroadcastToAccountsProposed(data, accounts)
+	// Broadcast to transactions_proposed stream (all proposed txs)
+	p.manager.BroadcastToStream(types.SubTransactionsProposed, data, nil)
+	// Also broadcast to accounts_proposed subscribers for specific accounts
+	if len(accounts) > 0 {
+		p.manager.BroadcastToAccountsProposed(data, accounts)
+	}
 }
 
 // PublishOrderBookChange broadcasts an order book change to book subscribers

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -54,9 +54,15 @@ func TestSubscribeStreamTypes(t *testing.T) {
 		},
 		{
 			name:         "transactions_proposed stream - subscribe to proposed transactions",
-			streamType:   types.SubscriptionType("transactions_proposed"),
+			streamType:   types.SubTransactionsProposed,
 			streamString: "transactions_proposed",
-			expectError:  true, // Not in validStreams map
+			expectError:  false,
+		},
+		{
+			name:         "server stream - subscribe to server status events",
+			streamType:   types.SubServer,
+			streamString: "server",
+			expectError:  false,
 		},
 		{
 			name:         "validations stream - subscribe to validation messages",

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 )
@@ -173,15 +174,17 @@ type WebSocketResponse struct {
 type SubscriptionType string
 
 const (
-	SubLedger       SubscriptionType = "ledger"
-	SubTransactions SubscriptionType = "transactions"
-	SubAccounts     SubscriptionType = "accounts"
-	SubOrderBooks   SubscriptionType = "book_changes"
-	SubValidations  SubscriptionType = "validations"
-	SubManifests    SubscriptionType = "manifests"
-	SubPeerStatus   SubscriptionType = "peer_status"
-	SubConsensus    SubscriptionType = "consensus"
-	SubPath         SubscriptionType = "path_find"
+	SubLedger               SubscriptionType = "ledger"
+	SubTransactions         SubscriptionType = "transactions"
+	SubTransactionsProposed SubscriptionType = "transactions_proposed"
+	SubAccounts             SubscriptionType = "accounts"
+	SubOrderBooks           SubscriptionType = "book_changes"
+	SubValidations          SubscriptionType = "validations"
+	SubManifests            SubscriptionType = "manifests"
+	SubPeerStatus           SubscriptionType = "peer_status"
+	SubServer               SubscriptionType = "server"
+	SubConsensus            SubscriptionType = "consensus"
+	SubPath                 SubscriptionType = "path_find"
 )
 
 // Subscription request structure
@@ -323,6 +326,7 @@ type WebSocketResponseOptions struct {
 // SubscriptionManager manages WebSocket subscriptions
 type SubscriptionManager struct {
 	Connections map[string]*Connection
+	mu          sync.RWMutex
 }
 
 // NewSubscriptionManager creates a new SubscriptionManager
@@ -334,6 +338,8 @@ func NewSubscriptionManager() *SubscriptionManager {
 
 // AddConnection adds a connection to the subscription manager
 func (sm *SubscriptionManager) AddConnection(conn *Connection) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 	if sm.Connections == nil {
 		sm.Connections = make(map[string]*Connection)
 	}
@@ -342,24 +348,31 @@ func (sm *SubscriptionManager) AddConnection(conn *Connection) {
 
 // RemoveConnection removes a connection from the subscription manager
 func (sm *SubscriptionManager) RemoveConnection(connID string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 	delete(sm.Connections, connID)
 }
 
 // validStreams contains the set of valid stream types
 var validStreams = map[SubscriptionType]bool{
-	SubLedger:       true,
-	SubTransactions: true,
-	SubAccounts:     true,
-	SubOrderBooks:   true,
-	SubValidations:  true,
-	SubManifests:    true,
-	SubPeerStatus:   true,
-	SubConsensus:    true,
-	SubPath:         true,
+	SubLedger:               true,
+	SubTransactions:         true,
+	SubTransactionsProposed: true,
+	SubAccounts:             true,
+	SubOrderBooks:           true,
+	SubValidations:          true,
+	SubManifests:            true,
+	SubPeerStatus:           true,
+	SubServer:               true,
+	SubConsensus:            true,
+	SubPath:                 true,
 }
 
 // HandleSubscribe handles a subscribe request for a connection
 func (sm *SubscriptionManager) HandleSubscribe(conn *Connection, request SubscriptionRequest) *RpcError {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
 	// Validate and add stream subscriptions
 	for _, stream := range request.Streams {
 		if !validStreams[stream] {
@@ -506,6 +519,9 @@ func isValidXRPLAddress(addr string) bool {
 
 // HandleUnsubscribe handles an unsubscribe request for a connection
 func (sm *SubscriptionManager) HandleUnsubscribe(conn *Connection, request SubscriptionRequest) *RpcError {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
 	// Remove stream subscriptions
 	for _, stream := range request.Streams {
 		delete(conn.Subscriptions, stream)
@@ -535,6 +551,29 @@ func (sm *SubscriptionManager) HandleUnsubscribe(conn *Connection, request Subsc
 		}
 	}
 
+	// Remove specific accounts_proposed subscriptions
+	if len(request.AccountsProposed) > 0 {
+		if existing, ok := conn.Subscriptions["accounts_proposed"]; ok {
+			accountsToRemove := make(map[string]bool)
+			for _, acc := range request.AccountsProposed {
+				accountsToRemove[acc] = true
+			}
+			var remainingAccounts []string
+			for _, acc := range existing.Accounts {
+				if !accountsToRemove[acc] {
+					remainingAccounts = append(remainingAccounts, acc)
+				}
+			}
+			if len(remainingAccounts) > 0 {
+				conn.Subscriptions["accounts_proposed"] = SubscriptionConfig{
+					Accounts: remainingAccounts,
+				}
+			} else {
+				delete(conn.Subscriptions, "accounts_proposed")
+			}
+		}
+	}
+
 	// Remove book subscriptions
 	if len(request.Books) > 0 {
 		delete(conn.Subscriptions, SubOrderBooks)
@@ -550,6 +589,9 @@ func (sm *SubscriptionManager) HandleUnsubscribe(conn *Connection, request Subsc
 
 // BroadcastToStream sends a message to all connections subscribed to a stream
 func (sm *SubscriptionManager) BroadcastToStream(streamType SubscriptionType, data []byte, _ interface{}) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
 	for _, conn := range sm.Connections {
 		if _, ok := conn.Subscriptions[streamType]; ok {
 			select {
@@ -563,6 +605,9 @@ func (sm *SubscriptionManager) BroadcastToStream(streamType SubscriptionType, da
 
 // BroadcastToAccounts sends a message to all connections subscribed to any of the accounts
 func (sm *SubscriptionManager) BroadcastToAccounts(data []byte, accounts []string) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
 	accountSet := make(map[string]bool)
 	for _, acc := range accounts {
 		accountSet[acc] = true
@@ -586,12 +631,33 @@ func (sm *SubscriptionManager) BroadcastToAccounts(data []byte, accounts []strin
 
 // BroadcastToAccountsProposed sends a message to accounts_proposed subscribers
 func (sm *SubscriptionManager) BroadcastToAccountsProposed(data []byte, accounts []string) {
-	// Similar to BroadcastToAccounts but for proposed transactions
-	sm.BroadcastToAccounts(data, accounts)
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	accountSet := make(map[string]bool)
+	for _, acc := range accounts {
+		accountSet[acc] = true
+	}
+	for _, conn := range sm.Connections {
+		if config, ok := conn.Subscriptions["accounts_proposed"]; ok {
+			for _, subAcc := range config.Accounts {
+				if accountSet[subAcc] {
+					select {
+					case conn.SendChannel <- data:
+					default:
+					}
+					break
+				}
+			}
+		}
+	}
 }
 
 // BroadcastToOrderBook sends a message to order book subscribers
 func (sm *SubscriptionManager) BroadcastToOrderBook(data []byte, takerGets, takerPays CurrencySpec) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
 	for _, conn := range sm.Connections {
 		if config, ok := conn.Subscriptions[SubOrderBooks]; ok {
 			if config.TakerGets != nil && config.TakerPays != nil {
@@ -612,6 +678,9 @@ func (sm *SubscriptionManager) BroadcastToOrderBook(data []byte, takerGets, take
 
 // GetSubscriberCount returns the number of subscribers for a stream type
 func (sm *SubscriptionManager) GetSubscriberCount(streamType SubscriptionType) int {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
 	count := 0
 	for _, conn := range sm.Connections {
 		if _, ok := conn.Subscriptions[streamType]; ok {
@@ -623,16 +692,22 @@ func (sm *SubscriptionManager) GetSubscriberCount(streamType SubscriptionType) i
 
 // ConnectionCount returns the number of active connections
 func (sm *SubscriptionManager) ConnectionCount() int {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
 	return len(sm.Connections)
 }
 
 // GetConnection returns a connection by ID
 func (sm *SubscriptionManager) GetConnection(connID string) *Connection {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
 	return sm.Connections[connID]
 }
 
 // IsSubscribed checks if a connection is subscribed to a stream type
 func (sm *SubscriptionManager) IsSubscribed(connID string, streamType SubscriptionType) bool {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
 	conn := sm.Connections[connID]
 	if conn == nil {
 		return false
@@ -643,6 +718,8 @@ func (sm *SubscriptionManager) IsSubscribed(connID string, streamType Subscripti
 
 // GetConnectionSubscriptions returns the subscriptions for a connection
 func (sm *SubscriptionManager) GetConnectionSubscriptions(connID string) map[SubscriptionType]SubscriptionConfig {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
 	conn := sm.Connections[connID]
 	if conn == nil {
 		return nil
@@ -702,4 +779,30 @@ func BookMatchesCurrency(book BookRequest, specGets, specPays CurrencySpec) bool
 	}
 
 	return true
+}
+
+// LedgerInfoProvider provides current ledger info for subscribe responses
+type LedgerInfoProvider interface {
+	GetCurrentLedgerInfo() *LedgerSubscribeInfo
+}
+
+// LedgerSubscribeInfo contains ledger info returned in subscribe response
+type LedgerSubscribeInfo struct {
+	LedgerIndex      uint32 `json:"ledger_index"`
+	LedgerHash       string `json:"ledger_hash"`
+	LedgerTime       uint32 `json:"ledger_time"`
+	FeeBase          uint64 `json:"fee_base"`
+	FeeRef           uint64 `json:"fee_ref"`
+	ReserveBase      uint64 `json:"reserve_base"`
+	ReserveInc       uint64 `json:"reserve_inc"`
+	ValidatedLedgers string `json:"validated_ledgers,omitempty"`
+	NetworkID        uint32 `json:"network_id,omitempty"`
+}
+
+// ServerSubscribeInfo contains server info returned when subscribing to server stream
+type ServerSubscribeInfo struct {
+	ServerStatus string `json:"server_status"`
+	LoadBase     int    `json:"load_base"`
+	LoadFactor   int    `json:"load_factor"`
+	StandAlone   bool   `json:"stand_alone,omitempty"`
 }

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -21,6 +21,7 @@ type WebSocketServer struct {
 	connections         map[string]*WebSocketConnection
 	connectionsMutex    sync.RWMutex
 	timeout             time.Duration
+	ledgerInfoProvider  types.LedgerInfoProvider
 }
 
 // WebSocketConnection represents a single WebSocket connection
@@ -53,6 +54,12 @@ func NewWebSocketServer(timeout time.Duration) *WebSocketServer {
 		connections:    make(map[string]*WebSocketConnection),
 		timeout:        timeout,
 	}
+}
+
+// SetLedgerInfoProvider sets the provider used to return current ledger info
+// in subscribe responses (e.g., when subscribing to the "ledger" stream).
+func (ws *WebSocketServer) SetLedgerInfoProvider(provider types.LedgerInfoProvider) {
+	ws.ledgerInfoProvider = provider
 }
 
 // ServeHTTP handles WebSocket upgrade requests
@@ -252,81 +259,89 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 
 // handleSubscribe processes subscribe commands
 func (ws *WebSocketServer) handleSubscribe(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
-	// Parse subscription request
 	var request types.SubscriptionRequest
 	if len(cmd.Params) > 0 {
-		// The params are embedded in the command, extract them
-		var cmdWithParams map[string]interface{}
-		if err := json.Unmarshal(cmd.Params, &cmdWithParams); err != nil {
-			// Try to parse the entire command as subscription request
-			if err := json.Unmarshal(cmd.Params, &request); err != nil {
-				ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid subscription parameters"), cmd.ID)
-				return
-			}
-		} else {
-			// Convert map to types.SubscriptionRequest
-			if streamsRaw, ok := cmdWithParams["streams"]; ok {
-				if streams, ok := streamsRaw.([]interface{}); ok {
-					for _, stream := range streams {
-						if streamStr, ok := stream.(string); ok {
-							request.Streams = append(request.Streams, types.SubscriptionType(streamStr))
-						}
-					}
-				}
-			}
-			// TODO: Parse other subscription parameters (accounts, books, etc.)
+		if err := json.Unmarshal(cmd.Params, &request); err != nil {
+			ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid subscription parameters: "+err.Error()), cmd.ID)
+			return
 		}
 	}
 
 	// Handle subscription through subscription manager
-	if err := ws.subscriptionManager.HandleSubscribe(&types.Connection{
+	conn := &types.Connection{
 		ID:            wsConn.ID,
 		Subscriptions: wsConn.subscriptions,
 		SendChannel:   wsConn.sendChannel,
 		CloseChannel:  wsConn.closeChannel,
-	}, request); err != nil {
+	}
+	if err := ws.subscriptionManager.HandleSubscribe(conn, request); err != nil {
 		ws.sendError(wsConn, err, cmd.ID)
 		return
 	}
 
-	// Send success response
+	// Build response - rippled returns ledger info when subscribing to ledger stream
+	result := make(map[string]interface{})
+
+	// Check if subscribing to ledger stream - return current ledger info
+	for _, stream := range request.Streams {
+		if stream == types.SubLedger {
+			if ws.ledgerInfoProvider != nil {
+				info := ws.ledgerInfoProvider.GetCurrentLedgerInfo()
+				if info != nil {
+					result["ledger_index"] = info.LedgerIndex
+					result["ledger_hash"] = info.LedgerHash
+					result["ledger_time"] = info.LedgerTime
+					result["fee_base"] = info.FeeBase
+					result["fee_ref"] = info.FeeRef
+					result["reserve_base"] = info.ReserveBase
+					result["reserve_inc"] = info.ReserveInc
+					if info.ValidatedLedgers != "" {
+						result["validated_ledgers"] = info.ValidatedLedgers
+					}
+				}
+			}
+			break
+		}
+	}
+
 	response := types.WebSocketResponse{
 		Type:       "response",
 		ID:         cmd.ID,
 		Status:     "success",
-		Result:     map[string]interface{}{"subscribed": true},
+		Result:     result,
 		ApiVersion: ctx.ApiVersion,
 	}
-
 	ws.sendResponse(wsConn, response)
 }
 
 // handleUnsubscribe processes unsubscribe commands
 func (ws *WebSocketServer) handleUnsubscribe(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
-	// Parse unsubscription request (similar to subscribe)
 	var request types.SubscriptionRequest
-	// TODO: Parse unsubscription parameters
+	if len(cmd.Params) > 0 {
+		if err := json.Unmarshal(cmd.Params, &request); err != nil {
+			ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid unsubscription parameters: "+err.Error()), cmd.ID)
+			return
+		}
+	}
 
-	// Handle unsubscription through subscription manager
-	if err := ws.subscriptionManager.HandleUnsubscribe(&types.Connection{
+	conn := &types.Connection{
 		ID:            wsConn.ID,
 		Subscriptions: wsConn.subscriptions,
 		SendChannel:   wsConn.sendChannel,
 		CloseChannel:  wsConn.closeChannel,
-	}, request); err != nil {
+	}
+	if err := ws.subscriptionManager.HandleUnsubscribe(conn, request); err != nil {
 		ws.sendError(wsConn, err, cmd.ID)
 		return
 	}
 
-	// Send success response
 	response := types.WebSocketResponse{
 		Type:       "response",
 		ID:         cmd.ID,
 		Status:     "success",
-		Result:     map[string]interface{}{"unsubscribed": true},
+		Result:     map[string]interface{}{},
 		ApiVersion: ctx.ApiVersion,
 	}
-
 	ws.sendResponse(wsConn, response)
 }
 


### PR DESCRIPTION
   subscribe/unsubscribe
   conformance with rippled

   - Add SubServer and SubTransactionsProposed stream types
   - Fix handleSubscribe to parse all params (accounts, books, accounts_proposed)
   - Fix handleUnsubscribe to parse params (was a no-op)
   - Return current ledger info in subscribe response for ledger stream
   - Add thread safety (mutex) to SubscriptionManager
   - Fix PublishServerStatus to broadcast to SubServer instead of SubPeerStatus
   - Fix BroadcastToAccountsProposed to check correct subscription key
   - Wire LedgerInfoProvider into WebSocket server via server.go