### PR TITLE
feat: implement WebSocket path_find with persistent sessions

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -251,6 +251,11 @@ func runServer(cmd *cobra.Command, args []string) {
 			publisher.PublishTransaction(txEvent, txResult.AffectedAccounts)
 		}
 
+		// Update persistent path_find sessions on ledger close
+		wsServer.UpdatePathFindSessions(func() (types.LedgerStateView, error) {
+			return types.Services.Ledger.GetClosedLedgerView()
+		})
+
 		if !quiet {
 			log.Printf("Broadcasted ledger %d with %d transactions to WebSocket subscribers",
 				event.LedgerInfo.Sequence, len(event.TransactionResults))

--- a/internal/rpc/path_find_session.go
+++ b/internal/rpc/path_find_session.go
@@ -1,0 +1,239 @@
+package rpc
+
+import (
+	"encoding/json"
+	"strconv"
+	"sync"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+	tx "github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/payment"
+	"github.com/LeJamon/goXRPLd/internal/tx/payment/pathfinder"
+	rpctypes "github.com/LeJamon/goXRPLd/internal/rpc/types"
+)
+
+// PathFindSession holds the state for a persistent WebSocket path_find session.
+// Each WebSocket connection can have at most one active session (matching rippled).
+// Reference: rippled PathRequest class + PathFind.cpp handler
+type PathFindSession struct {
+	mu sync.Mutex
+
+	// Request parameters (immutable after creation)
+	srcAccount    [20]byte
+	dstAccount    [20]byte
+	dstAmount     tx.Amount
+	sendMax       *tx.Amount
+	srcCurrencies []payment.Issue
+	convertAll    bool
+
+	// Original string representations for response formatting
+	srcAccountStr string
+	dstAccountStr string
+	dstAmountRaw  json.RawMessage
+
+	// Last computed result (updated on each ledger close)
+	lastResult *pathfinder.PathRequestResult
+
+	// Request ID from the original create command
+	id interface{}
+}
+
+// pathFindCreateRequest represents the path_find create subcommand parameters.
+type pathFindCreateRequest struct {
+	Subcommand         string          `json:"subcommand"`
+	SourceAccount      string          `json:"source_account"`
+	DestinationAccount string          `json:"destination_account"`
+	DestinationAmount  json.RawMessage `json:"destination_amount"`
+	SendMax            json.RawMessage `json:"send_max,omitempty"`
+	SourceCurrencies   []struct {
+		Currency string `json:"currency"`
+		Issuer   string `json:"issuer,omitempty"`
+	} `json:"source_currencies,omitempty"`
+}
+
+// ParseAndCreateSession parses a path_find create request and creates a session.
+// Returns the session and initial result, or an RPC error.
+func ParseAndCreateSession(params json.RawMessage, id interface{}) (*PathFindSession, *rpctypes.RpcError) {
+	var request pathFindCreateRequest
+	if err := json.Unmarshal(params, &request); err != nil {
+		return nil, rpctypes.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+	}
+
+	// Validate required fields
+	if request.SourceAccount == "" {
+		return nil, rpctypes.RpcErrorInvalidParams("Missing field 'source_account'.")
+	}
+	if request.DestinationAccount == "" {
+		return nil, rpctypes.RpcErrorInvalidParams("Missing field 'destination_account'.")
+	}
+	if request.DestinationAmount == nil {
+		return nil, rpctypes.RpcErrorInvalidParams("Missing field 'destination_amount'.")
+	}
+
+	// Decode accounts
+	srcAccount, err := state.DecodeAccountID(request.SourceAccount)
+	if err != nil {
+		return nil, rpctypes.NewRpcError(rpctypes.RpcACT_MALFORMED, "srcActMalformed", "invalidParams",
+			"Source account is malformed.")
+	}
+	dstAccount, err := state.DecodeAccountID(request.DestinationAccount)
+	if err != nil {
+		return nil, rpctypes.NewRpcError(rpctypes.RpcACT_MALFORMED, "dstActMalformed", "invalidParams",
+			"Destination account is malformed.")
+	}
+
+	// Parse destination amount
+	dstAmount := parseSessionAmount(request.DestinationAmount)
+
+	// Check for convert_all mode (destination_amount = "-1")
+	convertAll := false
+	var strVal string
+	if json.Unmarshal(request.DestinationAmount, &strVal) == nil && strVal == "-1" {
+		convertAll = true
+	}
+
+	// Parse optional send_max
+	var sendMax *tx.Amount
+	if request.SendMax != nil {
+		amt := parseSessionAmount(request.SendMax)
+		sendMax = &amt
+	}
+
+	// Parse optional source_currencies
+	var srcCurrencies []payment.Issue
+	for _, sc := range request.SourceCurrencies {
+		issue := payment.Issue{Currency: sc.Currency}
+		if sc.Issuer != "" {
+			issuerID, decErr := state.DecodeAccountID(sc.Issuer)
+			if decErr != nil {
+				return nil, rpctypes.NewRpcError(rpctypes.RpcINVALID_PARAMS, "srcIsrMalformed", "invalidParams",
+					"Source issuer is malformed.")
+			}
+			issue.Issuer = issuerID
+		} else if sc.Currency != "XRP" && sc.Currency != "" {
+			issue.Issuer = srcAccount
+		}
+		srcCurrencies = append(srcCurrencies, issue)
+	}
+
+	session := &PathFindSession{
+		srcAccount:    srcAccount,
+		dstAccount:    dstAccount,
+		dstAmount:     dstAmount,
+		sendMax:       sendMax,
+		srcCurrencies: srcCurrencies,
+		convertAll:    convertAll,
+		srcAccountStr: request.SourceAccount,
+		dstAccountStr: request.DestinationAccount,
+		dstAmountRaw:  request.DestinationAmount,
+		id:            id,
+	}
+
+	return session, nil
+}
+
+// Execute runs pathfinding against the given ledger view and stores the result.
+// Returns the formatted PathFindEvent for sending to the client.
+func (s *PathFindSession) Execute(view tx.LedgerView) *PathFindEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	pr := pathfinder.NewPathRequest(
+		s.srcAccount, s.dstAccount,
+		s.dstAmount, s.sendMax,
+		s.srcCurrencies, s.convertAll,
+	)
+	result := pr.Execute(view)
+	s.lastResult = result
+
+	return s.buildEvent(result, true)
+}
+
+// GetLastResult returns the last computed result as a PathFindEvent (for status).
+func (s *PathFindSession) GetLastResult() *PathFindEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.lastResult == nil {
+		return s.buildEvent(&pathfinder.PathRequestResult{}, false)
+	}
+	return s.buildEvent(s.lastResult, false)
+}
+
+// buildEvent formats a PathRequestResult into a PathFindEvent for the WebSocket client.
+func (s *PathFindSession) buildEvent(result *pathfinder.PathRequestResult, fullReply bool) *PathFindEvent {
+	alternatives := make([]PathAlternative, 0, len(result.Alternatives))
+	for _, alt := range result.Alternatives {
+		var srcAmtJSON json.RawMessage
+		if alt.SourceAmount.IsNative() {
+			srcAmtJSON, _ = json.Marshal(alt.SourceAmount.Value())
+		} else {
+			srcAmtJSON, _ = json.Marshal(map[string]string{
+				"currency": alt.SourceAmount.Currency,
+				"issuer":   alt.SourceAmount.Issuer,
+				"value":    alt.SourceAmount.Value(),
+			})
+		}
+		alternatives = append(alternatives, PathAlternative{
+			SourceAmount:  srcAmtJSON,
+			PathsComputed: convertToRPCPathSteps(alt.PathsComputed),
+		})
+	}
+
+	return &PathFindEvent{
+		Type:               "path_find",
+		ID:                 s.id,
+		SourceAccount:      s.srcAccountStr,
+		DestinationAccount: s.dstAccountStr,
+		DestinationAmount:  s.dstAmountRaw,
+		FullReply:          fullReply,
+		Alternatives:       alternatives,
+	}
+}
+
+// convertToRPCPathSteps converts payment.PathStep slices to rpctypes.PathStep slices.
+func convertToRPCPathSteps(paths [][]payment.PathStep) [][]rpctypes.PathStep {
+	if len(paths) == 0 {
+		return nil
+	}
+	result := make([][]rpctypes.PathStep, len(paths))
+	for i, path := range paths {
+		steps := make([]rpctypes.PathStep, len(path))
+		for j, step := range path {
+			steps[j] = rpctypes.PathStep{
+				Account:  step.Account,
+				Currency: step.Currency,
+				Issuer:   step.Issuer,
+				Type:     uint8(step.Type),
+				TypeHex:  step.TypeHex,
+			}
+		}
+		result[i] = steps
+	}
+	return result
+}
+
+// parseSessionAmount parses a JSON amount for path finding.
+func parseSessionAmount(raw json.RawMessage) tx.Amount {
+	var strVal string
+	if err := json.Unmarshal(raw, &strVal); err == nil {
+		drops, _ := strconv.ParseInt(strVal, 10, 64)
+		return state.NewXRPAmountFromInt(drops)
+	}
+
+	var iou struct {
+		Currency string `json:"currency"`
+		Issuer   string `json:"issuer"`
+		Value    string `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &iou); err != nil {
+		return state.NewXRPAmountFromInt(0)
+	}
+
+	if iou.Currency == "XRP" || iou.Currency == "" {
+		drops, _ := strconv.ParseInt(iou.Value, 10, 64)
+		return state.NewXRPAmountFromInt(drops)
+	}
+
+	return state.NewIssuedAmountFromDecimalString(iou.Value, iou.Currency, iou.Issuer)
+}

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -99,7 +99,8 @@ const (
 	RpcINVALID_LGR_RANGE      = 45
 
 	// Path finding errors
-	RpcNO_PATH = 46
+	RpcNO_PATH       = 46
+	RpcNO_PF_REQUEST = 53 // No pathfinding request in progress (rippled: rpcNO_PF_REQUEST)
 
 	// Implementation status errors
 	RpcNOT_IMPL      = 47 // Feature not implemented
@@ -187,6 +188,11 @@ func RpcErrorNotEnabled(feature string) *RpcError {
 
 func RpcErrorAmendmentBlocked() *RpcError {
 	return NewRpcError(RpcAMENDMENT_BLOCKED, "amendmentBlocked", "amendmentBlocked", "Amendment blocked, need upgrade.")
+}
+
+// RpcErrorNoPathRequest returns an error when close/status is called without an active path_find session
+func RpcErrorNoPathRequest() *RpcError {
+	return NewRpcError(RpcNO_PF_REQUEST, "noPathRequest", "noPathRequest", "No pathfinding request in progress.")
 }
 
 // RpcErrorObjectNotFound returns an error for object not found (matches rippled rpcOBJECT_NOT_FOUND)

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -26,14 +26,15 @@ type WebSocketServer struct {
 
 // WebSocketConnection represents a single WebSocket connection
 type WebSocketConnection struct {
-	ID            string
-	conn          *websocket.Conn
-	subscriptions map[types.SubscriptionType]types.SubscriptionConfig
-	sendChannel   chan []byte
-	closeChannel  chan struct{}
-	mutex         sync.RWMutex
-	ctx           context.Context
-	cancel        context.CancelFunc
+	ID              string
+	conn            *websocket.Conn
+	subscriptions   map[types.SubscriptionType]types.SubscriptionConfig
+	sendChannel     chan []byte
+	closeChannel    chan struct{}
+	mutex           sync.RWMutex
+	ctx             context.Context
+	cancel          context.CancelFunc
+	pathFindSession *PathFindSession // At most one active path_find session per connection
 }
 
 // NewWebSocketServer creates a new WebSocket server
@@ -345,13 +346,163 @@ func (ws *WebSocketServer) handleUnsubscribe(wsConn *WebSocketConnection, ctx *t
 	ws.sendResponse(wsConn, response)
 }
 
-// handlePathFind processes path_find commands (special WebSocket-only method)
+// handlePathFind processes path_find commands (special WebSocket-only method).
+// Subcommands: "create" (start session), "close" (stop session), "status" (get current paths).
+// Reference: rippled PathFind.cpp
 func (ws *WebSocketServer) handlePathFind(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
-	// TODO: Implement WebSocket path finding
-	// This creates a persistent path-finding session that sends updates
-	// as market conditions change
+	// Parse subcommand
+	var sub struct {
+		Subcommand string `json:"subcommand"`
+	}
+	if len(cmd.Params) > 0 {
+		if err := json.Unmarshal(cmd.Params, &sub); err != nil {
+			ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid parameters: "+err.Error()), cmd.ID)
+			return
+		}
+	}
 
-	ws.sendError(wsConn, types.NewRpcError(types.RpcNOT_SUPPORTED, "notSupported", "notSupported", "path_find not yet implemented"), cmd.ID)
+	switch sub.Subcommand {
+	case "create":
+		ws.handlePathFindCreate(wsConn, ctx, cmd)
+	case "close":
+		ws.handlePathFindClose(wsConn, ctx, cmd)
+	case "status":
+		ws.handlePathFindStatus(wsConn, ctx, cmd)
+	default:
+		ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid field 'subcommand'."), cmd.ID)
+	}
+}
+
+// handlePathFindCreate creates a new persistent pathfinding session.
+// Any existing session on this connection is replaced (matching rippled).
+func (ws *WebSocketServer) handlePathFindCreate(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+	// Parse and validate parameters
+	session, rpcErr := ParseAndCreateSession(cmd.Params, cmd.ID)
+	if rpcErr != nil {
+		ws.sendError(wsConn, rpcErr, cmd.ID)
+		return
+	}
+
+	// Get ledger view for initial computation
+	view, err := types.Services.Ledger.GetClosedLedgerView()
+	if err != nil {
+		ws.sendError(wsConn, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
+			"No closed ledger available"), cmd.ID)
+		return
+	}
+
+	// Run initial pathfinding
+	event := session.Execute(view)
+
+	// Store session on connection (replaces any existing one, matching rippled)
+	wsConn.mutex.Lock()
+	wsConn.pathFindSession = session
+	wsConn.mutex.Unlock()
+
+	// Send initial result as response
+	response := types.WebSocketResponse{
+		Type:       "response",
+		ID:         cmd.ID,
+		Status:     "success",
+		Result:     event,
+		ApiVersion: ctx.ApiVersion,
+	}
+	ws.sendResponse(wsConn, response)
+}
+
+// handlePathFindClose closes the active pathfinding session on this connection.
+func (ws *WebSocketServer) handlePathFindClose(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+	wsConn.mutex.Lock()
+	session := wsConn.pathFindSession
+	wsConn.pathFindSession = nil
+	wsConn.mutex.Unlock()
+
+	if session == nil {
+		ws.sendError(wsConn, types.RpcErrorNoPathRequest(), cmd.ID)
+		return
+	}
+
+	response := types.WebSocketResponse{
+		Type:       "response",
+		ID:         cmd.ID,
+		Status:     "success",
+		Result:     map[string]interface{}{"closed": true},
+		ApiVersion: ctx.ApiVersion,
+	}
+	ws.sendResponse(wsConn, response)
+}
+
+// handlePathFindStatus returns the current status of the active pathfinding session.
+func (ws *WebSocketServer) handlePathFindStatus(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+	wsConn.mutex.RLock()
+	session := wsConn.pathFindSession
+	wsConn.mutex.RUnlock()
+
+	if session == nil {
+		ws.sendError(wsConn, types.RpcErrorNoPathRequest(), cmd.ID)
+		return
+	}
+
+	event := session.GetLastResult()
+
+	response := types.WebSocketResponse{
+		Type:       "response",
+		ID:         cmd.ID,
+		Status:     "success",
+		Result:     event,
+		ApiVersion: ctx.ApiVersion,
+	}
+	ws.sendResponse(wsConn, response)
+}
+
+// UpdatePathFindSessions re-runs pathfinding for all active sessions on ledger close.
+// Called from the ledger close callback in server.go.
+func (ws *WebSocketServer) UpdatePathFindSessions(getView func() (types.LedgerStateView, error)) {
+	ws.connectionsMutex.RLock()
+	// Collect connections with active sessions
+	var activeSessions []*WebSocketConnection
+	for _, conn := range ws.connections {
+		conn.mutex.RLock()
+		if conn.pathFindSession != nil {
+			activeSessions = append(activeSessions, conn)
+		}
+		conn.mutex.RUnlock()
+	}
+	ws.connectionsMutex.RUnlock()
+
+	if len(activeSessions) == 0 {
+		return
+	}
+
+	// Get ledger view once for all sessions
+	view, err := getView()
+	if err != nil {
+		log.Printf("Failed to get ledger view for path_find updates: %v", err)
+		return
+	}
+
+	for _, conn := range activeSessions {
+		conn.mutex.RLock()
+		session := conn.pathFindSession
+		conn.mutex.RUnlock()
+
+		if session == nil {
+			continue
+		}
+
+		event := session.Execute(view)
+
+		data, marshalErr := json.Marshal(event)
+		if marshalErr != nil {
+			continue
+		}
+
+		select {
+		case conn.sendChannel <- data:
+		default:
+			// Channel full, skip this update
+		}
+	}
 }
 
 // handleRPCMethod processes regular RPC method calls over WebSocket
@@ -473,6 +624,11 @@ func (ws *WebSocketServer) sendErrorWithOptions(wsConn *WebSocketConnection, rpc
 func (ws *WebSocketServer) closeConnection(wsConn *WebSocketConnection) {
 	// Cancel context
 	wsConn.cancel()
+
+	// Clear any active path_find session
+	wsConn.mutex.Lock()
+	wsConn.pathFindSession = nil
+	wsConn.mutex.Unlock()
 
 	// Remove from connections map
 	ws.connectionsMutex.Lock()


### PR DESCRIPTION
Hook the pathfinding engine into WebSocket path_find command with create/close/status subcommands. Sessions persist per connection and automatically re-compute paths on every ledger close, matching rippled's PathFind.cpp behavior. One session per connection enforced.