### PR TITLE
feat: conformance sandbox for xrpl-fixtures test vectors

### DIFF
--- a/internal/testing/conformance/conformance_test.go
+++ b/internal/testing/conformance/conformance_test.go
@@ -1,0 +1,57 @@
+package conformance
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fixturesRoot is the path to the xrpl-fixtures directory relative to this test file.
+// Adjust this if the fixtures are located elsewhere.
+const fixturesRoot = "../../../../xrpl-fixtures/rippled-2.6.2"
+
+func TestConformance(t *testing.T) {
+	root, err := filepath.Abs(fixturesRoot)
+	if err != nil {
+		t.Fatalf("Failed to resolve fixtures root: %v", err)
+	}
+
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		t.Skipf("Fixtures directory not found at %s — skipping conformance tests", root)
+	}
+
+	// Walk the fixtures directory and create a subtest per fixture file
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+
+		// Build test name from relative path: "app/Escrow/Lockup"
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		testName := strings.TrimSuffix(rel, ".json")
+
+		fixturePath := path
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("PANIC: %v", fmt.Sprintf("%v", r))
+				}
+			}()
+			RunFixture(t, fixturePath)
+		})
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to walk fixtures directory: %v", err)
+	}
+}

--- a/internal/testing/conformance/runner.go
+++ b/internal/testing/conformance/runner.go
@@ -1,0 +1,295 @@
+// Package conformance provides a test runner for xrpl-fixtures test vectors.
+// It replays rippled test vectors against the goXRPL transaction engine and
+// validates that TER codes and post-state match the reference implementation.
+package conformance
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
+	jtx "github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	_ "github.com/LeJamon/goXRPLd/internal/tx/all"
+	"github.com/LeJamon/goXRPLd/internal/tx/trustset"
+)
+
+// Fixture represents a single xrpl-fixtures test vector file.
+type Fixture struct {
+	RippledVersion string  `json:"rippled_version"`
+	Suite          string  `json:"suite"`
+	Testcase       string  `json:"testcase"`
+	Env            EnvConfig `json:"env"`
+	Steps          []Step  `json:"steps"`
+}
+
+// EnvConfig holds the ledger environment configuration.
+type EnvConfig struct {
+	AmendmentsEnabled []string `json:"amendments_enabled"`
+	BaseFee           uint64   `json:"base_fee"`
+	ReserveBase       uint64   `json:"reserve_base"`
+	ReserveIncrement  uint64   `json:"reserve_increment"`
+}
+
+// Step represents a single operation in a fixture.
+type Step struct {
+	Op               string          `json:"op"`
+	Account          string          `json:"account,omitempty"`
+	Address          string          `json:"address,omitempty"`
+	Amount           json.RawMessage `json:"amount,omitempty"`
+	SetDefaultRipple *bool           `json:"set_default_ripple,omitempty"`
+	LimitAmount      *LimitAmount    `json:"limit_amount,omitempty"`
+	TxBlob           string          `json:"tx_blob,omitempty"`
+	TxJSON           json.RawMessage `json:"tx_json,omitempty"`
+	ExpectTER        string          `json:"expect_ter,omitempty"`
+	PostState        *PostState      `json:"post_state,omitempty"`
+	Env              *EnvConfig      `json:"env,omitempty"`
+	Amendment        string          `json:"amendment,omitempty"`
+}
+
+// LimitAmount is an IOU amount for trust line setup.
+type LimitAmount struct {
+	Currency string `json:"currency"`
+	Issuer   string `json:"issuer"`
+	Value    string `json:"value"`
+}
+
+// PostState holds expected post-transaction account states.
+type PostState struct {
+	Accounts []AccountState `json:"accounts"`
+}
+
+// AccountState holds expected account state after a transaction.
+type AccountState struct {
+	Name       string `json:"name"`
+	Address    string `json:"address"`
+	XRPBalance string `json:"xrp_balance"`
+	OwnerCount uint32 `json:"owner_count"`
+}
+
+// runner holds the state for executing a single fixture.
+type runner struct {
+	t        *testing.T
+	env      *jtx.TestEnv
+	accounts map[string]*jtx.Account // name -> account
+}
+
+// RunFixture loads and executes a single fixture file.
+func RunFixture(t *testing.T, fixturePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("Failed to read fixture %s: %v", fixturePath, err)
+	}
+
+	var fixture Fixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("Failed to parse fixture %s: %v", fixturePath, err)
+	}
+
+	r := &runner{
+		t:        t,
+		accounts: make(map[string]*jtx.Account),
+	}
+
+	// Create initial environment
+	r.setupEnv(fixture.Env)
+
+	// Execute steps sequentially
+	for i, step := range fixture.Steps {
+		switch step.Op {
+		case "fund":
+			r.execFund(i, step)
+		case "trust":
+			r.execTrust(i, step)
+		case "close":
+			r.env.Close()
+		case "tx":
+			r.execTx(i, step)
+		case "env_reset":
+			r.execEnvReset(i, step)
+		case "enable_amendment":
+			r.env.EnableFeature(step.Amendment)
+		default:
+			t.Fatalf("Step %d: unknown op %q", i, step.Op)
+		}
+	}
+}
+
+// setupEnv creates a TestEnv with the given configuration.
+func (r *runner) setupEnv(cfg EnvConfig) {
+	genCfg := genesis.DefaultConfig()
+	genCfg.Fees.BaseFee = drops.NewXRPAmount(int64(cfg.BaseFee))
+	genCfg.Fees.ReserveBase = drops.XRPAmount(cfg.ReserveBase)
+	genCfg.Fees.ReserveIncrement = drops.XRPAmount(cfg.ReserveIncrement)
+
+	r.env = jtx.NewTestEnvWithConfig(r.t, genCfg)
+	r.env.SetAmendments(cfg.AmendmentsEnabled)
+
+	// Register master account
+	master := jtx.MasterAccount()
+	r.accounts["master"] = master
+
+	// Match rippled's Env constructor: advance ledger once
+	r.env.Close()
+}
+
+// execFund handles a "fund" step.
+func (r *runner) execFund(stepIdx int, step Step) {
+	amount, err := parseDropsAmount(step.Amount)
+	if err != nil {
+		r.t.Fatalf("Step %d (fund): invalid amount: %v", stepIdx, err)
+	}
+
+	acc := jtx.NewAccountWithAddress(step.Account, step.Address)
+	r.accounts[step.Account] = acc
+
+	setRipple := step.SetDefaultRipple == nil || *step.SetDefaultRipple
+	if setRipple {
+		r.env.FundAmount(acc, amount)
+	} else {
+		r.env.FundAmountNoRipple(acc, amount)
+	}
+}
+
+// execTrust handles a "trust" step.
+func (r *runner) execTrust(stepIdx int, step Step) {
+	acc, ok := r.accounts[step.Account]
+	if !ok {
+		r.t.Fatalf("Step %d (trust): unknown account %q", stepIdx, step.Account)
+	}
+
+	if step.LimitAmount == nil {
+		r.t.Fatalf("Step %d (trust): missing limit_amount", stepIdx)
+	}
+
+	value, err := strconv.ParseFloat(step.LimitAmount.Value, 64)
+	if err != nil {
+		r.t.Fatalf("Step %d (trust): invalid limit value %q: %v", stepIdx, step.LimitAmount.Value, err)
+	}
+
+	limitAmount := tx.NewIssuedAmountFromFloat64(value, step.LimitAmount.Currency, step.LimitAmount.Issuer)
+
+	ts := trustset.NewTrustSet(acc.Address, limitAmount)
+	ts.Fee = strconv.FormatUint(r.env.BaseFee(), 10)
+	seq := r.env.Seq(acc)
+	ts.Sequence = &seq
+
+	result := r.env.Submit(ts)
+	if !result.Success {
+		r.t.Fatalf("Step %d (trust): TrustSet failed for %s: %s", stepIdx, acc.Name, result.Code)
+	}
+
+	// Reimburse the fee directly in the ledger (matching rippled's test framework)
+	r.env.ReimburseFeeDirect(acc)
+}
+
+// execTx handles a "tx" step.
+func (r *runner) execTx(stepIdx int, step Step) {
+	blob, err := hex.DecodeString(step.TxBlob)
+	if err != nil {
+		r.t.Fatalf("Step %d (tx): invalid tx_blob hex: %v", stepIdx, err)
+	}
+
+	parsed, err := tx.ParseFromBinary(blob)
+	if err != nil {
+		r.t.Fatalf("Step %d (tx): failed to parse tx_blob: %v", stepIdx, err)
+	}
+
+	result := r.env.Submit(parsed)
+
+	// Assert TER code
+	if result.Code != step.ExpectTER {
+		txType := "unknown"
+		if step.TxJSON != nil {
+			var txj map[string]interface{}
+			if json.Unmarshal(step.TxJSON, &txj) == nil {
+				if tt, ok := txj["TransactionType"].(string); ok {
+					txType = tt
+				}
+			}
+		}
+		r.t.Errorf("Step %d (tx %s): TER mismatch: got %q, want %q",
+			stepIdx, txType, result.Code, step.ExpectTER)
+		return
+	}
+
+	// Assert post-state
+	if step.PostState != nil {
+		r.assertPostState(stepIdx, step.PostState)
+	}
+}
+
+// execEnvReset handles an "env_reset" step.
+func (r *runner) execEnvReset(stepIdx int, step Step) {
+	if step.Env == nil {
+		r.t.Fatalf("Step %d (env_reset): missing env config", stepIdx)
+	}
+
+	// Clear accounts (keep only master which is re-registered in setupEnv)
+	r.accounts = make(map[string]*jtx.Account)
+
+	// Create fresh environment
+	r.setupEnv(*step.Env)
+}
+
+// assertPostState validates account states against expected values.
+func (r *runner) assertPostState(stepIdx int, ps *PostState) {
+	for _, expected := range ps.Accounts {
+		acc, ok := r.accounts[expected.Name]
+		if !ok {
+			// Create a temporary account reference for lookup
+			acc = jtx.NewAccountWithAddress(expected.Name, expected.Address)
+			r.accounts[expected.Name] = acc
+		}
+
+		// Check XRP balance
+		expectedBalance, err := strconv.ParseUint(expected.XRPBalance, 10, 64)
+		if err != nil {
+			r.t.Errorf("Step %d: invalid expected balance %q for %s: %v",
+				stepIdx, expected.XRPBalance, expected.Name, err)
+			continue
+		}
+
+		gotBalance := r.env.Balance(acc)
+		if gotBalance != expectedBalance {
+			r.t.Errorf("Step %d: balance mismatch for %s: got %d, want %d (diff: %d)",
+				stepIdx, expected.Name, gotBalance, expectedBalance,
+				int64(gotBalance)-int64(expectedBalance))
+		}
+
+		// Check owner count
+		gotOwnerCount := r.env.OwnerCount(acc)
+		if gotOwnerCount != expected.OwnerCount {
+			r.t.Errorf("Step %d: owner_count mismatch for %s: got %d, want %d",
+				stepIdx, expected.Name, gotOwnerCount, expected.OwnerCount)
+		}
+	}
+}
+
+// parseDropsAmount parses a JSON amount field (can be string or number) into drops.
+func parseDropsAmount(raw json.RawMessage) (uint64, error) {
+	if len(raw) == 0 {
+		return 0, fmt.Errorf("empty amount")
+	}
+
+	// Try as string first (quoted number)
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return strconv.ParseUint(s, 10, 64)
+	}
+
+	// Try as number
+	var n uint64
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n, nil
+	}
+
+	return 0, fmt.Errorf("cannot parse amount: %s", string(raw))
+}

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -2836,3 +2836,43 @@ func (e *TestEnv) SetDelegate(owner, authorized *Account, permissions []string) 
 		e.t.Fatalf("SetDelegate(%s -> %s, %v): %s: %s", owner.Name, authorized.Name, permissions, result.Code, result.Message)
 	}
 }
+
+// SetAmendments replaces the current amendment set with exactly the named amendments.
+// This is used by the conformance runner to configure the exact amendment set from fixtures.
+func (e *TestEnv) SetAmendments(names []string) {
+	e.rulesBuilder = amendment.NewRulesBuilder()
+	for _, name := range names {
+		e.rulesBuilder.EnableByName(name)
+	}
+}
+
+// ReimburseFeeDirect directly adds baseFee drops back to an account's balance
+// in the ledger, without submitting a transaction. This matches rippled's test
+// framework behavior where trust line setup reimburses the transaction fee so
+// the account's XRP balance is unchanged.
+func (e *TestEnv) ReimburseFeeDirect(acc *Account) {
+	e.t.Helper()
+
+	accountKey := keylet.Account(acc.ID)
+	data, err := e.ledger.Read(accountKey)
+	if err != nil {
+		e.t.Fatalf("ReimburseFeeDirect: failed to read account %s: %v", acc.Name, err)
+	}
+
+	accountRoot, err := state.ParseAccountRoot(data)
+	if err != nil {
+		e.t.Fatalf("ReimburseFeeDirect: failed to parse account %s: %v", acc.Name, err)
+	}
+
+	accountRoot.Balance += e.baseFee
+
+	updated, err := state.SerializeAccountRoot(accountRoot)
+	if err != nil {
+		e.t.Fatalf("ReimburseFeeDirect: failed to serialize account %s: %v", acc.Name, err)
+	}
+
+	if err := e.ledger.Update(accountKey, updated); err != nil {
+		e.t.Fatalf("ReimburseFeeDirect: failed to update account %s: %v", acc.Name, err)
+	}
+}
+


### PR DESCRIPTION
## Summary

- Add a Go test runner that replays rippled 2.6.2 test vectors (1,518 fixtures from `xrpl-fixtures/`) against goXRPL's transaction engine
- Validates TER codes and post-state (balance, owner_count) for each `tx` step
- Supports all 6 fixture op types: `fund`, `trust`, `close`, `tx`, `env_reset`, `enable_amendment`
- Baseline results: **480/1,518 pass (31.6%)**

### Fully passing suites
TrustAndBalance (13), PermissionedDomains (6), DID (5), Invariants (21/22), Ticket (7/8), Offer variants (~74% each)

### Key gap categories
- Vault (0/186) — new feature not yet implemented
- NFToken variants (~5-8%) — ParseFromBinary field parsing issues
- Oracle (0/7) — UInt64 hex string codec issue
- EscrowToken (0/34), Credentials (2/42) — newer features

### Files changed
- `internal/testing/conformance/runner.go` — fixture parsing + step execution
- `internal/testing/conformance/conformance_test.go` — test entry point with parallel subtests
- `internal/testing/env.go` — `SetAmendments()` and `ReimburseFeeDirect()` helpers

## Test plan

- [x] `go build ./internal/testing/conformance/` compiles
- [x] Single fixture: `go test ./internal/testing/conformance/... -run TestConformance/app/Escrow/Lockup -v`
- [x] Full suite: `go test ./internal/testing/conformance/... -timeout 10m -v` (480 pass, 1038 fail, 0 panic)
- [x] Gracefully skips when `xrpl-fixtures/` directory is absent