### PR TITLE
Fix database_path incorrectly used as PostgreSQL connection string

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/LeJamon/goXRPLd/config"
@@ -88,7 +89,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	// Initialize RelationalDB if configured
 	var repoManager relationaldb.RepositoryManager
 	dbPath := globalConfig.DatabasePath
-	if dbPath != "" {
+	if strings.HasPrefix(dbPath, "postgres://") || strings.HasPrefix(dbPath, "postgresql://") {
 		pgConfig := relationaldb.NewConfig()
 		pgConfig.ConnectionString = dbPath
 


### PR DESCRIPTION
Guard PostgreSQL initialization so it only runs when database_path starts with postgres:// or postgresql://, preventing filesystem paths from being passed as connection strings.

Closes #72