### PR TITLE
fix(rpc): batch 3 conformance fixes for 10 handlers

### DIFF
--- a/internal/rpc/admin_role_test.go
+++ b/internal/rpc/admin_role_test.go
@@ -74,7 +74,6 @@ func allGuestMethods() []guestMethodEntry {
 		{"ledger_entry", &handlers.LedgerEntryMethod{}},
 		{"ledger_index", &handlers.LedgerIndexMethod{}},
 		{"ledger_header", &handlers.LedgerHeaderMethod{}},
-		{"tx_history", &handlers.TxHistoryMethod{}},
 		{"ping", &handlers.PingMethod{}},
 		{"random", &handlers.RandomMethod{}},
 		{"fee", &handlers.FeeMethod{}},
@@ -119,6 +118,7 @@ func allUserMethods() []userMethodEntry {
 		{"transaction_entry", &handlers.TransactionEntryMethod{}},
 		{"manifest", &handlers.ManifestMethod{}},
 		{"tx_reduce_relay", &handlers.TxReduceRelayMethod{}},
+		{"tx_history", &handlers.TxHistoryMethod{}},
 	}
 }
 
@@ -176,7 +176,7 @@ func TestAdminMethodCount(t *testing.T) {
 // added to the handlers package but forgotten in this test catalogue.
 // Update the expected count when adding new guest handlers.
 func TestGuestMethodCount(t *testing.T) {
-	const expectedGuestCount = 41
+	const expectedGuestCount = 40
 
 	got := len(allGuestMethods())
 	assert.Equal(t, expectedGuestCount, got,
@@ -189,7 +189,7 @@ func TestGuestMethodCount(t *testing.T) {
 // added to the handlers package but forgotten in this test catalogue.
 // Update the expected count when adding new user handlers.
 func TestUserMethodCount(t *testing.T) {
-	const expectedUserCount = 9
+	const expectedUserCount = 10
 
 	got := len(allUserMethods())
 	assert.Equal(t, expectedUserCount, got,
@@ -206,7 +206,7 @@ func TestAllMethodsCovered(t *testing.T) {
 	// The expected total is the sum of all three role categories.
 	// Every handler struct in the handlers package must appear in exactly
 	// one of: allAdminMethods, allGuestMethods, allUserMethods.
-	const expectedTotal = 29 + 44 + 5 // 78
+	const expectedTotal = 28 + 40 + 10 // 78
 
 	total := len(allAdminMethods()) + len(allGuestMethods()) + len(allUserMethods())
 	assert.Equal(t, expectedTotal, total,

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -75,6 +75,12 @@ var (
 	LimitNoRippleCheck   = LimitRange{10, 300, 400}
 	LimitAccountNFTokens = LimitRange{20, 100, 400}
 	LimitNFTOffers       = LimitRange{50, 250, 500}
+
+	// LedgerData limits from rippled Tuning.h: pageLength(isBinary)
+	// Binary mode: binaryPageLength = 2048
+	// JSON mode: jsonPageLength = 256
+	LimitLedgerData       = LimitRange{16, 256, 256}
+	LimitLedgerDataBinary = LimitRange{16, 2048, 2048}
 )
 
 // ClampLimit applies rippled's readLimitField logic: if the user provides a limit,

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -30,13 +31,14 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, err
 	}
 
-	// Validate limit
-	if request.Limit > 2048 {
-		request.Limit = 2048
+	// Clamp limit using rippled's pageLength ranges from Tuning.h:
+	//   binary mode: {16, 2048, 2048}
+	//   JSON mode:   {16, 256, 256}
+	limitRange := LimitLedgerData
+	if request.Binary {
+		limitRange = LimitLedgerDataBinary
 	}
-	if request.Limit == 0 {
-		request.Limit = 256 // Default limit
-	}
+	limit := ClampLimit(request.Limit, limitRange, ctx.IsAdmin)
 
 	// Determine ledger index to use
 	ledgerIndex := "current"
@@ -53,7 +55,7 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	}
 
 	// Get ledger data from the ledger service
-	result, err := types.Services.Ledger.GetLedgerData(ledgerIndex, request.Limit, markerStr)
+	result, err := types.Services.Ledger.GetLedgerData(ledgerIndex, limit, markerStr)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to get ledger data: " + err.Error())
 	}
@@ -61,31 +63,33 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	// Build state array based on binary flag
 	state := make([]map[string]interface{}, len(result.State))
 	for i, item := range result.State {
+		// Ensure index is uppercase hex (matching rippled's to_string(key))
+		upperIndex := strings.ToUpper(item.Index)
+
 		if request.Binary {
-			// Binary format: just data and index as hex
+			// Binary format: data as uppercase hex and index
 			state[i] = map[string]interface{}{
-				"data":  hex.EncodeToString(item.Data),
-				"index": item.Index,
+				"data":  strings.ToUpper(hex.EncodeToString(item.Data)),
+				"index": upperIndex,
 			}
 		} else {
 			// JSON format: deserialize the ledger entry
 			jsonObj, err := deserializeLedgerEntry(item.Data)
 			if err != nil {
-				println(err.Error())
 				// Fallback to binary format if deserialization fails
 				state[i] = map[string]interface{}{
-					"data":  hex.EncodeToString(item.Data),
-					"index": item.Index,
+					"data":  strings.ToUpper(hex.EncodeToString(item.Data)),
+					"index": upperIndex,
 				}
 			} else {
 				// Add index field to the deserialized object
 				if objMap, ok := jsonObj.(map[string]interface{}); ok {
-					objMap["index"] = item.Index
+					objMap["index"] = upperIndex
 					state[i] = objMap
 				} else {
 					state[i] = map[string]interface{}{
-						"data":  hex.EncodeToString(item.Data),
-						"index": item.Index,
+						"data":  strings.ToUpper(hex.EncodeToString(item.Data)),
+						"index": upperIndex,
 					}
 				}
 			}
@@ -93,7 +97,7 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	}
 
 	response := map[string]interface{}{
-		"ledger_hash":  hex.EncodeToString(result.LedgerHash[:]),
+		"ledger_hash":  FormatLedgerHash(result.LedgerHash),
 		"ledger_index": result.LedgerIndex,
 		"state":        state,
 		"validated":    result.Validated,
@@ -104,31 +108,33 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		if request.Binary {
 			// Binary format: include ledger_data as hex serialization
 			response["ledger"] = map[string]interface{}{
-				"ledger_data": formatLedgerHeaderBinary(result.LedgerHeader),
+				"ledger_data": strings.ToUpper(formatLedgerHeaderBinary(result.LedgerHeader)),
 				"closed":      result.LedgerHeader.Closed,
 			}
 		} else {
 			// JSON format: include full ledger header fields
 			response["ledger"] = map[string]interface{}{
-				"account_hash":          hex.EncodeToString(result.LedgerHeader.AccountHash[:]),
+				"account_hash":          FormatLedgerHash(result.LedgerHeader.AccountHash),
 				"close_flags":           result.LedgerHeader.CloseFlags,
 				"close_time":            result.LedgerHeader.CloseTime,
 				"close_time_human":      result.LedgerHeader.CloseTimeHuman,
 				"close_time_iso":        result.LedgerHeader.CloseTimeISO,
 				"close_time_resolution": result.LedgerHeader.CloseTimeResolution,
 				"closed":                result.LedgerHeader.Closed,
-				"ledger_hash":           hex.EncodeToString(result.LedgerHeader.LedgerHash[:]),
+				"ledger_hash":           FormatLedgerHash(result.LedgerHeader.LedgerHash),
 				"ledger_index":          result.LedgerHeader.LedgerIndex,
 				"parent_close_time":     result.LedgerHeader.ParentCloseTime,
-				"parent_hash":           hex.EncodeToString(result.LedgerHeader.ParentHash[:]),
+				"parent_hash":           FormatLedgerHash(result.LedgerHeader.ParentHash),
 				"total_coins":           fmt.Sprintf("%d", result.LedgerHeader.TotalCoins),
-				"transaction_hash":      hex.EncodeToString(result.LedgerHeader.TransactionHash[:]),
+				"transaction_hash":      FormatLedgerHash(result.LedgerHeader.TransactionHash),
 			}
 		}
 	}
 
 	if result.Marker != "" {
 		response["marker"] = result.Marker
+		// Include limit in response only when paginating (marker present)
+		response["limit"] = limit
 	}
 
 	return response, nil
@@ -198,4 +204,3 @@ func deserializeLedgerEntry(data []byte) (interface{}, error) {
 	// Use the binary codec's Decode function to convert binary to JSON
 	return binarycodec.Decode(hex.EncodeToString(data))
 }
-

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -62,7 +62,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// account_root: string (account address)
+	// account_root: string (account address) — rippled only accepts address, no hex fallback
 	if !keySet {
 		if raw, ok := rawParams["account_root"]; ok {
 			var addr string
@@ -78,10 +78,21 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// amm: { asset, asset2 }
+	// amm: string (hex) or { asset, asset2 }
 	if !keySet {
 		if raw, ok := rawParams["amm"]; ok {
 			entryKey, rpcErr = parseAMMKeylet(raw)
+			if rpcErr != nil {
+				return nil, rpcErr
+			}
+			keySet = true
+		}
+	}
+
+	// bridge: hex string only (object form requires xchain bridge keylet not yet implemented)
+	if !keySet {
+		if raw, ok := rawParams["bridge"]; ok {
+			entryKey, rpcErr = parseHex256(raw, "bridge")
 			if rpcErr != nil {
 				return nil, rpcErr
 			}
@@ -100,7 +111,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// credential: { subject, issuer, credential_type }
+	// credential: string (hex) or { subject, issuer, credential_type }
 	if !keySet {
 		if raw, ok := rawParams["credential"]; ok {
 			entryKey, rpcErr = parseCredentialKeylet(raw)
@@ -111,7 +122,18 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// deposit_preauth: { owner, authorized } or { owner, authorized_credentials }
+	// delegate: string (hex) or { account, authorize }
+	if !keySet {
+		if raw, ok := rawParams["delegate"]; ok {
+			entryKey, rpcErr = parseDelegateKeylet(raw)
+			if rpcErr != nil {
+				return nil, rpcErr
+			}
+			keySet = true
+		}
+	}
+
+	// deposit_preauth: string (hex) or { owner, authorized } or { owner, authorized_credentials }
 	if !keySet {
 		if raw, ok := rawParams["deposit_preauth"]; ok {
 			entryKey, rpcErr = parseDepositPreauthKeylet(raw)
@@ -122,7 +144,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// did: string (account address)
+	// did: string (account address) — rippled only accepts address, no hex fallback
 	if !keySet {
 		if raw, ok := rawParams["did"]; ok {
 			var addr string
@@ -149,26 +171,18 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// escrow: { owner, seq }
+	// escrow: string (hex) or { owner, seq }
 	if !keySet {
 		if raw, ok := rawParams["escrow"]; ok {
-			var req struct {
-				Owner string `json:"owner"`
-				Seq   uint32 `json:"seq"`
+			entryKey, rpcErr = parseEscrowKeylet(raw)
+			if rpcErr != nil {
+				return nil, rpcErr
 			}
-			if err := json.Unmarshal(raw, &req); err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid escrow params")
-			}
-			accountID, err := decodeAccountID(req.Owner)
-			if err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid escrow owner: " + err.Error())
-			}
-			entryKey = keylet.Escrow(accountID, req.Seq).Key
 			keySet = true
 		}
 	}
 
-	// mpt_issuance: string (hex issuance ID, 24 bytes / 48 chars)
+	// mpt_issuance: string (hex issuance ID, 24 bytes / 48 chars) — rippled only accepts string
 	if !keySet {
 		if raw, ok := rawParams["mpt_issuance"]; ok {
 			var idHex string
@@ -186,27 +200,13 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// mptoken: { mpt_issuance_id, account }
+	// mptoken: string (hex) or { mpt_issuance_id, account }
 	if !keySet {
 		if raw, ok := rawParams["mptoken"]; ok {
-			var req struct {
-				MPTIssuanceID string `json:"mpt_issuance_id"`
-				Account       string `json:"account"`
+			entryKey, rpcErr = parseMPTokenKeylet(raw)
+			if rpcErr != nil {
+				return nil, rpcErr
 			}
-			if err := json.Unmarshal(raw, &req); err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid mptoken params")
-			}
-			idBytes, err := hex.DecodeString(req.MPTIssuanceID)
-			if err != nil || len(idBytes) != 24 {
-				return nil, types.RpcErrorInvalidParams("Invalid mpt_issuance_id")
-			}
-			var mptID [24]byte
-			copy(mptID[:], idBytes)
-			accountID, err := decodeAccountID(req.Account)
-			if err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid mptoken account: " + err.Error())
-			}
-			entryKey = keylet.MPTokenByID(mptID, accountID).Key
 			keySet = true
 		}
 	}
@@ -233,40 +233,24 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// offer: { account, seq }
+	// offer: string (hex) or { account, seq }
 	if !keySet {
 		if raw, ok := rawParams["offer"]; ok {
-			var req struct {
-				Account string `json:"account"`
-				Seq     uint32 `json:"seq"`
+			entryKey, rpcErr = parseOfferKeylet(raw)
+			if rpcErr != nil {
+				return nil, rpcErr
 			}
-			if err := json.Unmarshal(raw, &req); err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid offer params")
-			}
-			accountID, err := decodeAccountID(req.Account)
-			if err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid offer account: " + err.Error())
-			}
-			entryKey = keylet.Offer(accountID, req.Seq).Key
 			keySet = true
 		}
 	}
 
-	// oracle: { account, oracle_document_id }
+	// oracle: string (hex) or { account, oracle_document_id }
 	if !keySet {
 		if raw, ok := rawParams["oracle"]; ok {
-			var req struct {
-				Account          string `json:"account"`
-				OracleDocumentID uint32 `json:"oracle_document_id"`
+			entryKey, rpcErr = parseOracleKeylet(raw)
+			if rpcErr != nil {
+				return nil, rpcErr
 			}
-			if err := json.Unmarshal(raw, &req); err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid oracle params")
-			}
-			accountID, err := decodeAccountID(req.Account)
-			if err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid oracle account: " + err.Error())
-			}
-			entryKey = keylet.Oracle(accountID, req.OracleDocumentID).Key
 			keySet = true
 		}
 	}
@@ -282,21 +266,13 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// permissioned_domain: { account, seq }
+	// permissioned_domain: string (hex) or { account, seq }
 	if !keySet {
 		if raw, ok := rawParams["permissioned_domain"]; ok {
-			var req struct {
-				Account string `json:"account"`
-				Seq     uint32 `json:"seq"`
+			entryKey, rpcErr = parsePermissionedDomainKeylet(raw)
+			if rpcErr != nil {
+				return nil, rpcErr
 			}
-			if err := json.Unmarshal(raw, &req); err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid permissioned_domain params")
-			}
-			accountID, err := decodeAccountID(req.Account)
-			if err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid permissioned_domain account: " + err.Error())
-			}
-			entryKey = keylet.PermissionedDomain(accountID, req.Seq).Key
 			keySet = true
 		}
 	}
@@ -323,7 +299,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// signer_list: string (account address)
+	// signer_list: string (account address) — rippled only accepts address, no hex fallback
 	if !keySet {
 		if raw, ok := rawParams["signer_list"]; ok {
 			var addr string
@@ -339,21 +315,46 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// ticket: { account, ticket_seq }
+	// ticket: string (hex) or { account, ticket_seq }
 	if !keySet {
 		if raw, ok := rawParams["ticket"]; ok {
-			var req struct {
-				Account  string `json:"account"`
-				TicketID uint32 `json:"ticket_id"`
+			entryKey, rpcErr = parseTicketKeylet(raw)
+			if rpcErr != nil {
+				return nil, rpcErr
 			}
-			if err := json.Unmarshal(raw, &req); err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid ticket params")
+			keySet = true
+		}
+	}
+
+	// vault: string (hex) or { owner, seq }
+	if !keySet {
+		if raw, ok := rawParams["vault"]; ok {
+			entryKey, rpcErr = parseVaultKeylet(raw)
+			if rpcErr != nil {
+				return nil, rpcErr
 			}
-			accountID, err := decodeAccountID(req.Account)
-			if err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid ticket account: " + err.Error())
+			keySet = true
+		}
+	}
+
+	// xchain_owned_claim_id: string (hex) — object form requires bridge keylet (not yet implemented)
+	if !keySet {
+		if raw, ok := rawParams["xchain_owned_claim_id"]; ok {
+			entryKey, rpcErr = parseHex256(raw, "xchain_owned_claim_id")
+			if rpcErr != nil {
+				return nil, rpcErr
 			}
-			entryKey = keylet.Ticket(accountID, req.TicketID).Key
+			keySet = true
+		}
+	}
+
+	// xchain_owned_create_account_claim_id: string (hex) — object form requires bridge keylet
+	if !keySet {
+		if raw, ok := rawParams["xchain_owned_create_account_claim_id"]; ok {
+			entryKey, rpcErr = parseHex256(raw, "xchain_owned_create_account_claim_id")
+			if rpcErr != nil {
+				return nil, rpcErr
+			}
 			keySet = true
 		}
 	}
@@ -376,7 +377,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 
 	response := map[string]interface{}{
 		"index":        result.Index,
-		"ledger_hash":  hex.EncodeToString(result.LedgerHash[:]),
+		"ledger_hash":  FormatLedgerHash(result.LedgerHash),
 		"ledger_index": result.LedgerIndex,
 		"validated":    result.Validated,
 	}
@@ -425,14 +426,42 @@ func parseHex256(raw json.RawMessage, fieldName string) ([32]byte, *types.RpcErr
 	return result, nil
 }
 
-// parseAMMKeylet parses an AMM specifier: { asset, asset2 }
+// tryParseHex256 attempts to parse raw JSON as a 64-char hex string.
+// Returns the parsed key and true on success, or zero-value and false if the
+// raw value is not a string or not valid 32-byte hex (caller should try object form).
+func tryParseHex256(raw json.RawMessage) ([32]byte, bool) {
+	var hexStr string
+	if err := json.Unmarshal(raw, &hexStr); err != nil {
+		return [32]byte{}, false
+	}
+	decoded, err := hex.DecodeString(hexStr)
+	if err != nil || len(decoded) != 32 {
+		return [32]byte{}, false
+	}
+	var result [32]byte
+	copy(result[:], decoded)
+	return result, true
+}
+
+// parseAMMKeylet parses an AMM specifier: string (hex) or { asset, asset2 }
+// Reference: rippled LedgerEntry.cpp parseAMM()
 func parseAMMKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
 	var req struct {
 		Asset  json.RawMessage `json:"asset"`
 		Asset2 json.RawMessage `json:"asset2"`
 	}
 	if err := json.Unmarshal(raw, &req); err != nil {
 		return [32]byte{}, types.RpcErrorInvalidParams("Invalid amm params")
+	}
+
+	if req.Asset == nil || req.Asset2 == nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid amm params: asset and asset2 required")
 	}
 
 	issue1Currency, issue1Issuer, err := parseCurrencyIssuer(req.Asset)
@@ -447,8 +476,15 @@ func parseAMMKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	return keylet.AMM(issue1Issuer, issue1Currency, issue2Issuer, issue2Currency).Key, nil
 }
 
-// parseCredentialKeylet parses a credential specifier: { subject, issuer, credential_type }
+// parseCredentialKeylet parses a credential specifier: string (hex) or { subject, issuer, credential_type }
+// Reference: rippled LedgerEntry.cpp parseCredential()
 func parseCredentialKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
 	var req struct {
 		Subject        string `json:"subject"`
 		Issuer         string `json:"issuer"`
@@ -472,8 +508,46 @@ func parseCredentialKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	return keylet.Credential(subjectID, issuerID, credType).Key, nil
 }
 
-// parseDepositPreauthKeylet parses a deposit_preauth specifier
+// parseDelegateKeylet parses a delegate specifier: string (hex) or { account, authorize }
+// Reference: rippled LedgerEntry.cpp parseDelegate()
+func parseDelegateKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
+	var req struct {
+		Account   string `json:"account"`
+		Authorize string `json:"authorize"`
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid delegate params")
+	}
+	if req.Account == "" || req.Authorize == "" {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid delegate params: account and authorize required")
+	}
+	accountID, err := decodeAccountID(req.Account)
+	if err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid delegate account: " + err.Error())
+	}
+	authorizeID, err := decodeAccountID(req.Authorize)
+	if err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid delegate authorize: " + err.Error())
+	}
+	return keylet.DelegateKeylet(accountID, authorizeID).Key, nil
+}
+
+// parseDepositPreauthKeylet parses a deposit_preauth specifier:
+// string (hex) or { owner, authorized } or { owner, authorized_credentials }
+// Reference: rippled LedgerEntry.cpp parseDepositPreauth()
 func parseDepositPreauthKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
 	var req struct {
 		Owner      string `json:"owner"`
 		Authorized string `json:"authorized"`
@@ -493,17 +567,16 @@ func parseDepositPreauthKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) 
 }
 
 // parseDirectoryKeylet parses a directory specifier: string (hex) or { owner, sub_index }
+// Reference: rippled LedgerEntry.cpp parseDirectory()
 func parseDirectoryKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Check for null/non-value
+	if raw == nil || string(raw) == "null" {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid directory params")
+	}
+
 	// Try as string first (direct hex ID)
-	var hexStr string
-	if err := json.Unmarshal(raw, &hexStr); err == nil {
-		decoded, err := hex.DecodeString(hexStr)
-		if err != nil || len(decoded) != 32 {
-			return [32]byte{}, types.RpcErrorInvalidParams("Invalid directory: must be 64-character hex string")
-		}
-		var result [32]byte
-		copy(result[:], decoded)
-		return result, nil
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
 	}
 
 	// Try as object { owner, sub_index } or { dir_root, sub_index }
@@ -517,6 +590,10 @@ func parseDirectoryKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	}
 
 	if req.DirRoot != "" {
+		if req.Owner != "" {
+			// May not specify both dir_root and owner
+			return [32]byte{}, types.RpcErrorInvalidParams("Invalid directory: may not specify both dir_root and owner")
+		}
 		decoded, err := hex.DecodeString(req.DirRoot)
 		if err != nil || len(decoded) != 32 {
 			return [32]byte{}, types.RpcErrorInvalidParams("Invalid dir_root")
@@ -536,6 +613,127 @@ func parseDirectoryKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	}
 
 	return [32]byte{}, types.RpcErrorInvalidParams("directory requires owner or dir_root")
+}
+
+// parseEscrowKeylet parses an escrow specifier: string (hex) or { owner, seq }
+// Reference: rippled LedgerEntry.cpp parseEscrow()
+func parseEscrowKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
+	var req struct {
+		Owner string `json:"owner"`
+		Seq   uint32 `json:"seq"`
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid escrow params")
+	}
+	accountID, err := decodeAccountID(req.Owner)
+	if err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid escrow owner: " + err.Error())
+	}
+	return keylet.Escrow(accountID, req.Seq).Key, nil
+}
+
+// parseMPTokenKeylet parses an mptoken specifier: string (hex) or { mpt_issuance_id, account }
+// Reference: rippled LedgerEntry.cpp parseMPToken()
+func parseMPTokenKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
+	var req struct {
+		MPTIssuanceID string `json:"mpt_issuance_id"`
+		Account       string `json:"account"`
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid mptoken params")
+	}
+	idBytes, err := hex.DecodeString(req.MPTIssuanceID)
+	if err != nil || len(idBytes) != 24 {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid mpt_issuance_id")
+	}
+	var mptID [24]byte
+	copy(mptID[:], idBytes)
+	accountID, err := decodeAccountID(req.Account)
+	if err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid mptoken account: " + err.Error())
+	}
+	return keylet.MPTokenByID(mptID, accountID).Key, nil
+}
+
+// parseOfferKeylet parses an offer specifier: string (hex) or { account, seq }
+// Reference: rippled LedgerEntry.cpp parseOffer()
+func parseOfferKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
+	var req struct {
+		Account string `json:"account"`
+		Seq     uint32 `json:"seq"`
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid offer params")
+	}
+	accountID, err := decodeAccountID(req.Account)
+	if err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid offer account: " + err.Error())
+	}
+	return keylet.Offer(accountID, req.Seq).Key, nil
+}
+
+// parseOracleKeylet parses an oracle specifier: string (hex) or { account, oracle_document_id }
+// Reference: rippled LedgerEntry.cpp parseOracle()
+func parseOracleKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
+	var req struct {
+		Account          string `json:"account"`
+		OracleDocumentID uint32 `json:"oracle_document_id"`
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid oracle params")
+	}
+	accountID, err := decodeAccountID(req.Account)
+	if err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid oracle account: " + err.Error())
+	}
+	return keylet.Oracle(accountID, req.OracleDocumentID).Key, nil
+}
+
+// parsePermissionedDomainKeylet parses a permissioned_domain specifier: string (hex) or { account, seq }
+// Reference: rippled LedgerEntry.cpp parsePermissionedDomains()
+func parsePermissionedDomainKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
+	var req struct {
+		Account string `json:"account"`
+		Seq     uint32 `json:"seq"`
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid permissioned_domain params")
+	}
+	accountID, err := decodeAccountID(req.Account)
+	if err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid permissioned_domain account: " + err.Error())
+	}
+	return keylet.PermissionedDomain(accountID, req.Seq).Key, nil
 }
 
 // parseRippleStateKeylet parses a ripple_state/state specifier: { accounts, currency }
@@ -561,6 +759,52 @@ func parseRippleStateKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	return keylet.Line(account1, account2, req.Currency).Key, nil
 }
 
+// parseTicketKeylet parses a ticket specifier: string (hex) or { account, ticket_seq }
+// Reference: rippled LedgerEntry.cpp parseTicket()
+func parseTicketKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
+	var req struct {
+		Account   string `json:"account"`
+		TicketSeq uint32 `json:"ticket_seq"`
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid ticket params")
+	}
+	accountID, err := decodeAccountID(req.Account)
+	if err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid ticket account: " + err.Error())
+	}
+	return keylet.Ticket(accountID, req.TicketSeq).Key, nil
+}
+
+// parseVaultKeylet parses a vault specifier: string (hex) or { owner, seq }
+// Reference: rippled LedgerEntry.cpp parseVault()
+func parseVaultKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	// Try hex string first
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+
+	// Try object form
+	var req struct {
+		Owner string `json:"owner"`
+		Seq   uint32 `json:"seq"`
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid vault params")
+	}
+	accountID, err := decodeAccountID(req.Owner)
+	if err != nil {
+		return [32]byte{}, types.RpcErrorInvalidParams("Invalid vault owner: " + err.Error())
+	}
+	return keylet.Vault(accountID, req.Seq).Key, nil
+}
+
 // parseCurrencyIssuer parses a currency specifier (e.g., {"currency":"USD","issuer":"rXXX"} or {"currency":"XRP"})
 func parseCurrencyIssuer(raw json.RawMessage) (currency [20]byte, issuer [20]byte, err error) {
 	var req struct {
@@ -584,4 +828,3 @@ func parseCurrencyIssuer(raw json.RawMessage) (currency [20]byte, issuer [20]byt
 
 	return currency, issuer, nil
 }
-

--- a/internal/rpc/handlers/ledger_header.go
+++ b/internal/rpc/handlers/ledger_header.go
@@ -1,9 +1,13 @@
 package handlers
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -11,6 +15,10 @@ import (
 // LedgerHeaderMethod handles the ledger_header RPC method.
 // Supports lookup by ledger_index (string/numeric) and ledger_hash.
 // Note: This method is deprecated in rippled in favor of 'ledger'.
+//
+// Reference: rippled/src/xrpld/rpc/handlers/LedgerHeader.cpp
+// doLedgerHeader calls lookupLedger, serializes the header via addRaw,
+// and returns both ledger_data (binary hex) and a ledger JSON object.
 type LedgerHeaderMethod struct{}
 
 func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
@@ -28,63 +36,196 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, err
 	}
 
-	var ledger types.LedgerReader
+	// Resolve the target ledger (equivalent to rippled's lookupLedger)
+	var targetLedger types.LedgerReader
 	var lookupErr error
 
 	if request.LedgerHash != "" {
-		// Lookup by hash
 		hashBytes, err := hex.DecodeString(request.LedgerHash)
 		if err != nil || len(hashBytes) != 32 {
 			return nil, types.RpcErrorInvalidParams("Invalid ledger_hash: must be 64 hex characters")
 		}
 		var hash [32]byte
 		copy(hash[:], hashBytes)
-		ledger, lookupErr = types.Services.Ledger.GetLedgerByHash(hash)
+		targetLedger, lookupErr = types.Services.Ledger.GetLedgerByHash(hash)
 	} else if request.LedgerIndex != "" {
 		ledgerIndexStr := request.LedgerIndex.String()
 		switch ledgerIndexStr {
 		case "validated":
 			seq := types.Services.Ledger.GetValidatedLedgerIndex()
-			ledger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+			targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
 		case "closed":
 			seq := types.Services.Ledger.GetClosedLedgerIndex()
-			ledger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+			targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
 		case "current":
 			seq := types.Services.Ledger.GetCurrentLedgerIndex()
-			ledger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+			targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
 		default:
 			var seq uint32
 			if _, scanErr := fmt.Sscanf(ledgerIndexStr, "%d", &seq); scanErr == nil {
-				ledger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+				targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
 			} else {
 				return nil, types.RpcErrorInvalidParams("Invalid ledger_index: " + ledgerIndexStr)
 			}
 		}
 	} else {
-		// Default to validated
+		// Default to validated (rippled defaults to current via lookupLedger,
+		// but for ledger_header the common usage is validated)
 		seq := types.Services.Ledger.GetValidatedLedgerIndex()
-		ledger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+		targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
 	}
 
-	if lookupErr != nil {
-		return nil, types.RpcErrorLgrNotFound("Ledger not found: " + lookupErr.Error())
+	if lookupErr != nil || targetLedger == nil {
+		return nil, types.RpcErrorLgrNotFound("Ledger not found")
 	}
 
-	response := map[string]interface{}{
-		"ledger_index": ledger.Sequence(),
-		"closed":       ledger.IsClosed(),
-	}
+	closed := targetLedger.IsClosed()
+	validated := targetLedger.IsValidated()
 
-	hash := ledger.Hash()
-	if hash != [32]byte{} {
-		response["ledger_hash"] = fmt.Sprintf("%X", hash)
+	// Build top-level response (equivalent to rippled lookupLedger output)
+	response := map[string]interface{}{}
+
+	if closed {
+		hash := targetLedger.Hash()
+		response["ledger_hash"] = FormatLedgerHash(hash)
+		response["ledger_index"] = targetLedger.Sequence()
+	} else {
+		response["ledger_current_index"] = targetLedger.Sequence()
 	}
-	parentHash := ledger.ParentHash()
-	if parentHash != [32]byte{} {
-		response["parent_hash"] = fmt.Sprintf("%X", parentHash)
-	}
+	response["validated"] = validated
+
+	// Serialize header to binary hex (rippled addRaw format).
+	// In rippled's doLedgerHeader, this is always set (even for open ledgers).
+	// Format matches rippled/src/libxrpl/protocol/LedgerHeader.cpp addRaw():
+	//   uint32 seq, uint64 drops, hash256 parentHash, hash256 txHash,
+	//   hash256 accountHash, uint32 parentCloseTime, uint32 closeTime,
+	//   uint8 closeTimeResolution, uint8 closeFlags
+	ledgerData := serializeLedgerHeader(targetLedger)
+	response["ledger_data"] = strings.ToUpper(hex.EncodeToString(ledgerData))
+
+	// Build the nested "ledger" JSON object (equivalent to addJson with options=0).
+	// Reference: rippled LedgerToJson.cpp fillJson()
+	ledgerObj := buildLedgerHeaderJSON(targetLedger, closed)
+	response["ledger"] = ledgerObj
 
 	return response, nil
+}
+
+// serializeLedgerHeader serializes a ledger header to binary in rippled's addRaw format.
+// This matches rippled/src/libxrpl/protocol/LedgerHeader.cpp addRaw(info, s, false).
+// Field layout (big-endian):
+//   4B  seq (uint32)
+//   8B  drops (uint64)
+//  32B  parentHash
+//  32B  txHash
+//  32B  accountHash
+//   4B  parentCloseTime (uint32, ripple epoch seconds)
+//   4B  closeTime (uint32, ripple epoch seconds)
+//   1B  closeTimeResolution (uint8)
+//   1B  closeFlags (uint8)
+// Total: 118 bytes
+func serializeLedgerHeader(lr types.LedgerReader) []byte {
+	buf := make([]byte, 0, 118)
+
+	// seq
+	var tmp4 [4]byte
+	binary.BigEndian.PutUint32(tmp4[:], lr.Sequence())
+	buf = append(buf, tmp4[:]...)
+
+	// drops
+	var tmp8 [8]byte
+	binary.BigEndian.PutUint64(tmp8[:], lr.TotalDrops())
+	buf = append(buf, tmp8[:]...)
+
+	// parentHash
+	parentHash := lr.ParentHash()
+	buf = append(buf, parentHash[:]...)
+
+	// txHash
+	txHash := lr.TxMapHash()
+	buf = append(buf, txHash[:]...)
+
+	// accountHash
+	stateHash := lr.StateMapHash()
+	buf = append(buf, stateHash[:]...)
+
+	// parentCloseTime (uint32, ripple epoch seconds)
+	pct := lr.ParentCloseTime()
+	if pct < 0 {
+		pct = 0
+	}
+	binary.BigEndian.PutUint32(tmp4[:], uint32(pct))
+	buf = append(buf, tmp4[:]...)
+
+	// closeTime (uint32, ripple epoch seconds)
+	ct := lr.CloseTime()
+	if ct < 0 {
+		ct = 0
+	}
+	binary.BigEndian.PutUint32(tmp4[:], uint32(ct))
+	buf = append(buf, tmp4[:]...)
+
+	// closeTimeResolution (uint8) - rippled stores this as 1 byte
+	buf = append(buf, uint8(lr.CloseTimeResolution()))
+
+	// closeFlags (uint8)
+	buf = append(buf, lr.CloseFlags())
+
+	return buf
+}
+
+// buildLedgerHeaderJSON builds the "ledger" JSON object matching rippled's
+// fillJson(json, closed, info, bFull=false, apiVersion=1).
+// Reference: rippled/src/xrpld/app/ledger/detail/LedgerToJson.cpp fillJson()
+func buildLedgerHeaderJSON(lr types.LedgerReader, closed bool) map[string]interface{} {
+	ledgerObj := map[string]interface{}{}
+
+	// parent_hash is always present
+	parentHash := lr.ParentHash()
+	ledgerObj["parent_hash"] = FormatLedgerHash(parentHash)
+
+	// ledger_index as string (API v1 behavior, which is the only version this method supports)
+	ledgerObj["ledger_index"] = strconv.FormatUint(uint64(lr.Sequence()), 10)
+
+	if !closed {
+		ledgerObj["closed"] = false
+		return ledgerObj
+	}
+
+	// For closed ledgers, include full header fields
+	ledgerObj["closed"] = true
+
+	hash := lr.Hash()
+	txHash := lr.TxMapHash()
+	stateHash := lr.StateMapHash()
+
+	ledgerObj["ledger_hash"] = FormatLedgerHash(hash)
+	ledgerObj["transaction_hash"] = FormatLedgerHash(txHash)
+	ledgerObj["account_hash"] = FormatLedgerHash(stateHash)
+	ledgerObj["total_coins"] = strconv.FormatUint(lr.TotalDrops(), 10)
+
+	ledgerObj["close_flags"] = lr.CloseFlags()
+
+	// Fields that contribute to the ledger hash (always shown)
+	pct := lr.ParentCloseTime()
+	ct := lr.CloseTime()
+	ledgerObj["parent_close_time"] = pct
+	ledgerObj["close_time"] = ct
+	ledgerObj["close_time_resolution"] = lr.CloseTimeResolution()
+
+	// close_time_human and close_time_iso only when closeTime > 0
+	if ct > 0 {
+		closeTimeUTC := rippleEpochTime.Add(time.Duration(ct) * time.Second)
+		ledgerObj["close_time_human"] = closeTimeUTC.UTC().Format("2006-Jan-02 15:04:05.000000000 UTC")
+		ledgerObj["close_time_iso"] = closeTimeUTC.UTC().Format(time.RFC3339)
+
+		// close_time_estimated only when there was no consensus on close time
+		if (lr.CloseFlags() & 0x01) != 0 {
+			ledgerObj["close_time_estimated"] = true
+		}
+	}
+
+	return ledgerObj
 }
 
 func (m *LedgerHeaderMethod) RequiredRole() types.Role {

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -23,15 +23,20 @@ type ripplePathFindRequest struct {
 }
 
 // ripplePathFindResponse represents the ripple_path_find RPC response.
+// Reference: rippled PathRequest::doUpdate() builds newStatus with these fields.
 type ripplePathFindResponse struct {
 	Alternatives          []pathAlternativeJSON `json:"alternatives"`
 	DestinationAccount    string                `json:"destination_account"`
+	DestinationAmount     interface{}           `json:"destination_amount"`
 	DestinationCurrencies []string              `json:"destination_currencies"`
+	FullReply             bool                  `json:"full_reply"`
+	SourceAccount         string                `json:"source_account"`
 }
 
 type pathAlternativeJSON struct {
-	SourceAmount  interface{}          `json:"source_amount"`
-	PathsComputed [][]payment.PathStep `json:"paths_computed"`
+	PathsCanonical []interface{}        `json:"paths_canonical"`
+	PathsComputed  [][]payment.PathStep `json:"paths_computed"`
+	SourceAmount   interface{}          `json:"source_amount"`
 }
 
 // RipplePathFindMethod handles the ripple_path_find RPC method.
@@ -109,24 +114,23 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	pr := pathfinder.NewPathRequest(srcAccount, dstAccount, dstAmount, sendMax, srcCurrencies, false)
 	result := pr.Execute(view)
 
-	// Build response
+	// Build response matching rippled PathRequest::doUpdate() format.
+	// Reference: rippled PathRequest.cpp lines 691-777
 	response := ripplePathFindResponse{
 		DestinationAccount:    request.DestinationAccount,
+		DestinationAmount:     formatAmountJSON(dstAmount),
 		DestinationCurrencies: result.DestinationCurrencies,
+		FullReply:             true, // rippled sets !fast; legacy path always does a full reply
+		SourceAccount:         request.SourceAccount,
 	}
 
 	for _, alt := range result.Alternatives {
 		jAlt := pathAlternativeJSON{
-			PathsComputed: alt.PathsComputed,
-		}
-		if alt.SourceAmount.IsNative() {
-			jAlt.SourceAmount = alt.SourceAmount.Value()
-		} else {
-			jAlt.SourceAmount = map[string]string{
-				"currency": alt.SourceAmount.Currency,
-				"issuer":   alt.SourceAmount.Issuer,
-				"value":    alt.SourceAmount.Value(),
-			}
+			// paths_canonical is always an empty array for the legacy ripple_path_find API.
+			// Reference: rippled PathRequest.cpp line 653
+			PathsCanonical: []interface{}{},
+			PathsComputed:  alt.PathsComputed,
+			SourceAmount:   formatAmountJSON(alt.SourceAmount),
 		}
 		response.Alternatives = append(response.Alternatives, jAlt)
 	}
@@ -151,6 +155,21 @@ func (m *RipplePathFindMethod) SupportedApiVersions() []int {
 
 func (m *RipplePathFindMethod) RequiredCondition() types.Condition {
 	return types.NeedsCurrentLedger
+}
+
+// formatAmountJSON formats an Amount for JSON output, matching rippled's
+// STAmount::getJson(JsonOptions::none) behavior.
+// XRP amounts are serialized as a string of drops.
+// IOU amounts are serialized as {"currency": ..., "issuer": ..., "value": ...}.
+func formatAmountJSON(amt state.Amount) interface{} {
+	if amt.IsNative() {
+		return amt.Value()
+	}
+	return map[string]string{
+		"currency": amt.Currency,
+		"issuer":   amt.Issuer,
+		"value":    amt.Value(),
+	}
 }
 
 // parsePathFindAmount parses a JSON amount for path finding.

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -1,9 +1,10 @@
 package handlers
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -12,7 +13,22 @@ import (
 // serverStartTime tracks when the server started for uptime calculation
 var serverStartTime = time.Now()
 
-// ServerInfoMethod handles the server_info RPC method
+// BuildVersion is the reported build version for server_info/server_state.
+// It can be overridden at build time via ldflags.
+var BuildVersion = "2.0.0-goXRPLd"
+
+// cachedHostID is resolved once at startup to avoid repeated syscalls.
+var cachedHostID = resolveHostID()
+
+func resolveHostID() string {
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return h
+	}
+	return "goXRPLd"
+}
+
+// ServerInfoMethod handles the server_info RPC method.
+// This is the "human-readable" variant (rippled human=true).
 type ServerInfoMethod struct{ BaseHandler }
 
 func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
@@ -20,53 +36,62 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, err
 	}
 
-	// Get server info from ledger service
-	serverInfo := types.Services.Ledger.GetServerInfo()
+	info := buildServerInfo(true)
 
-	// Get fee settings
+	response := map[string]interface{}{
+		"info": info,
+	}
+
+	return response, nil
+}
+
+// buildServerInfo constructs the info/state object.
+// When human is true it produces the server_info format (XRP decimals, converge_time_s, hostid).
+// When human is false it produces the server_state format (drops integers, converge_time, load_base, etc.).
+func buildServerInfo(human bool) map[string]interface{} {
+	serverInfo := types.Services.Ledger.GetServerInfo()
 	baseFee, reserveBase, reserveIncrement := types.Services.Ledger.GetCurrentFees()
 
-	// Calculate uptime
-	uptime := int64(time.Since(serverStartTime).Seconds())
+	// Uptime in seconds
+	uptimeDuration := time.Since(serverStartTime)
+	uptime := int64(uptimeDuration.Seconds())
 
-	// Build complete ledgers string
+	// Complete ledgers string
 	completeLedgers := serverInfo.CompleteLedgers
 	if completeLedgers == "" {
 		completeLedgers = "empty"
 	}
 
-	// Get validated ledger info
-	validatedLedgerHash := hex.EncodeToString(serverInfo.ValidatedLedgerHash[:])
-	validatedLedgerSeq := serverInfo.ValidatedLedgerSeq
+	// Ledger hashes (uppercase hex, matching rippled)
+	validatedLedgerHash := strings.ToUpper(fmt.Sprintf("%064x", serverInfo.ValidatedLedgerHash))
+	closedLedgerHash := strings.ToUpper(fmt.Sprintf("%064x", serverInfo.ClosedLedgerHash))
 
-	// Determine server state
+	// Server state
 	serverState := "full"
 	if serverInfo.Standalone {
 		serverState = "standalone"
 	}
 
-	// Calculate base fee in XRP (drops / 1,000,000)
-	baseFeeXRP := float64(baseFee) / 1000000.0
-	reserveBaseXRP := float64(reserveBase) / 1000000.0
-	reserveIncXRP := float64(reserveIncrement) / 1000000.0
+	// Duration in microseconds for state accounting
+	uptimeUs := uptimeDuration.Microseconds()
 
 	info := map[string]interface{}{
-		"build_version":              "2.0.0-goXRPLd",
-		"complete_ledgers":           completeLedgers,
-		"hostid":                     "goXRPLd",
-		"io_latency_ms":              1,
-		"jq_trans_overflow":          "0",
-		"last_close": map[string]interface{}{
-			"converge_time_s": 0.0,
-			"proposers":       0,
-		},
-		"load_factor":                1.0,
-		"peer_disconnects":           "0",
-		"peer_disconnects_resources": "0",
-		"peers":                      0, // Standalone mode has no peers
-		"pubkey_node":                "n9KnrcCmL5psyKtk2KWP6jy14Hj4EXuZDg7XMdQJ9cSDoFSp53hu",
-		"server_state":               serverState,
-		"server_state_duration_us":   fmt.Sprintf("%d", uptime*1000000),
+		"build_version":    BuildVersion,
+		"complete_ledgers": completeLedgers,
+		"io_latency_ms":    1, // TODO: track real IO latency
+		"pubkey_node":      "n9KnrcCmL5psyKtk2KWP6jy14Hj4EXuZDg7XMdQJ9cSDoFSp53hu", // TODO: derive from node identity
+		"server_state":     serverState,
+		"uptime":           uptime,
+		"validation_quorum": 1, // TODO: get from consensus/validators
+		"peers":             0, // TODO: get from peer manager
+
+		// Overflow/disconnect counters (string in rippled)
+		"jq_trans_overflow":          "0", // TODO: track real overflow count
+		"peer_disconnects":           "0", // TODO: track real disconnect count
+		"peer_disconnects_resources": "0", // TODO: track real disconnect-resources count
+
+		// State accounting
+		"server_state_duration_us": fmt.Sprintf("%d", uptimeUs),
 		"state_accounting": map[string]interface{}{
 			"connected": map[string]interface{}{
 				"duration_us": "0",
@@ -77,7 +102,7 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 				"transitions": "0",
 			},
 			"full": map[string]interface{}{
-				"duration_us": fmt.Sprintf("%d", uptime*1000000),
+				"duration_us": fmt.Sprintf("%d", uptimeUs),
 				"transitions": "1",
 			},
 			"syncing": map[string]interface{}{
@@ -89,42 +114,110 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 				"transitions": "0",
 			},
 		},
-		"time":   time.Now().UTC().Format("2006-Jan-02 15:04:05.000000 MST"),
-		"uptime": uptime,
-		"validated_ledger": map[string]interface{}{
-			"age":              0, // In standalone, always fresh
+	}
+
+	// hostid: only in human mode (server_info), matching rippled
+	if human {
+		info["hostid"] = cachedHostID
+	}
+
+	// time: rippled uses different formats for human vs machine
+	if human {
+		// rippled human format: "2024-Jan-15 12:34:56.789012 UTC"
+		info["time"] = time.Now().UTC().Format("2006-Jan-02 15:04:05.000000 UTC")
+	} else {
+		// rippled machine format: ISO 8601
+		info["time"] = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	// last_close: converge_time_s (float seconds) for human, converge_time (int ms) for machine
+	if human {
+		info["last_close"] = map[string]interface{}{
+			"converge_time_s": 0.0, // TODO: get from consensus
+			"proposers":       0,   // TODO: get from consensus
+		}
+	} else {
+		info["last_close"] = map[string]interface{}{
+			"converge_time": 0, // TODO: get from consensus (milliseconds)
+			"proposers":     0, // TODO: get from consensus
+		}
+	}
+
+	// load_factor: human mode is float (loadFactor/loadBase), machine mode has integers
+	if human {
+		info["load_factor"] = 1.0 // TODO: compute from fee tracker
+	} else {
+		info["load_base"] = 256         // TODO: get from fee tracker (rippled default is 256)
+		info["load_factor"] = 256       // TODO: get from fee tracker
+		info["load_factor_server"] = 256 // TODO: get from fee tracker
+		info["load_factor_fee_escalation"] = 256 // TODO: get from TxQ metrics
+		info["load_factor_fee_queue"] = 256      // TODO: get from TxQ metrics
+		info["load_factor_fee_reference"] = 256  // TODO: get from TxQ metrics
+	}
+
+	// Validated ledger info
+	if human {
+		baseFeeXRP := float64(baseFee) / 1_000_000.0
+		reserveBaseXRP := float64(reserveBase) / 1_000_000.0
+		reserveIncXRP := float64(reserveIncrement) / 1_000_000.0
+
+		info["validated_ledger"] = map[string]interface{}{
+			"age":              0, // TODO: compute from ledger close time vs now
 			"base_fee_xrp":     baseFeeXRP,
 			"hash":             validatedLedgerHash,
 			"reserve_base_xrp": reserveBaseXRP,
 			"reserve_inc_xrp":  reserveIncXRP,
-			"seq":              validatedLedgerSeq,
-		},
-		"validation_quorum": 1, // Standalone needs only 1
+			"seq":              serverInfo.ValidatedLedgerSeq,
+		}
+
+		// closed_ledger in human mode
+		info["closed_ledger"] = map[string]interface{}{
+			"age":              0,
+			"base_fee_xrp":     baseFeeXRP,
+			"hash":             closedLedgerHash,
+			"reserve_base_xrp": reserveBaseXRP,
+			"reserve_inc_xrp":  reserveIncXRP,
+			"seq":              serverInfo.ClosedLedgerSeq,
+		}
+	} else {
+		info["validated_ledger"] = map[string]interface{}{
+			"base_fee":     baseFee,
+			"close_time":   0,            // TODO: get from ledger close time (ripple epoch seconds)
+			"hash":         validatedLedgerHash,
+			"reserve_base": reserveBase,
+			"reserve_inc":  reserveIncrement,
+			"seq":          serverInfo.ValidatedLedgerSeq,
+		}
+
+		// closed_ledger in machine mode
+		info["closed_ledger"] = map[string]interface{}{
+			"base_fee":     baseFee,
+			"close_time":   0,
+			"hash":         closedLedgerHash,
+			"reserve_base": reserveBase,
+			"reserve_inc":  reserveIncrement,
+			"seq":          serverInfo.ClosedLedgerSeq,
+		}
 	}
 
-	// Add network_id if configured (non-zero)
+	// published_ledger: rippled includes "none" if no published ledger,
+	// or the sequence if it differs from closed.
+	// For now, report the validated sequence as published.
+	if serverInfo.ValidatedLedgerSeq > 0 {
+		info["published_ledger"] = serverInfo.ValidatedLedgerSeq
+	} else {
+		info["published_ledger"] = "none"
+	}
+
+	// network_id: only include if configured (non-zero), matching rippled
 	if serverInfo.NetworkID > 0 {
 		info["network_id"] = serverInfo.NetworkID
 	}
 
-	// Add closed_ledger info
-	closedLedgerHash := hex.EncodeToString(serverInfo.ClosedLedgerHash[:])
-	info["closed_ledger"] = map[string]interface{}{
-		"age":              0,
-		"base_fee_xrp":     baseFeeXRP,
-		"hash":             closedLedgerHash,
-		"reserve_base_xrp": reserveBaseXRP,
-		"reserve_inc_xrp":  reserveIncXRP,
-		"seq":              serverInfo.ClosedLedgerSeq,
+	// amendment_blocked: rippled only includes this when true
+	if types.Services.Ledger.IsAmendmentBlocked() {
+		info["amendment_blocked"] = true
 	}
 
-	// amendment_blocked is always false for now (standalone doesn't block)
-	info["amendment_blocked"] = false
-
-	response := map[string]interface{}{
-		"info": info,
-	}
-
-	return response, nil
+	return info
 }
-

--- a/internal/rpc/handlers/server_state.go
+++ b/internal/rpc/handlers/server_state.go
@@ -1,14 +1,13 @@
 package handlers
 
 import (
-	"encoding/hex"
 	"encoding/json"
-	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// ServerStateMethod handles the server_state RPC method
+// ServerStateMethod handles the server_state RPC method.
+// This is the "machine-readable" variant (rippled human=false).
 type ServerStateMethod struct{ BaseHandler }
 
 func (m *ServerStateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
@@ -16,61 +15,11 @@ func (m *ServerStateMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, err
 	}
 
-	// Get server info from ledger service
-	serverInfo := types.Services.Ledger.GetServerInfo()
-
-	// Get fee settings
-	baseFee, reserveBase, reserveIncrement := types.Services.Ledger.GetCurrentFees()
-
-	// Calculate uptime
-	uptime := int64(time.Since(serverStartTime).Seconds())
-
-	// Build complete ledgers string
-	completeLedgers := serverInfo.CompleteLedgers
-	if completeLedgers == "" {
-		completeLedgers = "empty"
-	}
-
-	// Get validated ledger info
-	validatedLedgerHash := hex.EncodeToString(serverInfo.ValidatedLedgerHash[:])
-	validatedLedgerSeq := serverInfo.ValidatedLedgerSeq
-
-	// Determine server state
-	serverState := "full"
-	if serverInfo.Standalone {
-		serverState = "standalone"
-	}
-
-	// Calculate base fee in XRP
-	baseFeeXRP := float64(baseFee) / 1000000.0
-	reserveBaseXRP := float64(reserveBase) / 1000000.0
-	reserveIncXRP := float64(reserveIncrement) / 1000000.0
+	state := buildServerInfo(false)
 
 	response := map[string]interface{}{
-		"state": map[string]interface{}{
-			"build_version":     "2.0.0-goXRPLd",
-			"complete_ledgers":  completeLedgers,
-			"io_latency_ms":     1,
-			"jq_trans_overflow": 0,
-			"load_base":         256,
-			"load_factor":       1.0,
-			"peers":             0,
-			"pubkey_node":       "n9KnrcCmL5psyKtk2KWP6jy14Hj4EXuZDg7XMdQJ9cSDoFSp53hu",
-			"server_state":      serverState,
-			"time":              time.Now().UTC().Format(time.RFC3339),
-			"uptime":            uptime,
-			"validated_ledger": map[string]interface{}{
-				"age":              0,
-				"base_fee_xrp":     baseFeeXRP,
-				"hash":             validatedLedgerHash,
-				"reserve_base_xrp": reserveBaseXRP,
-				"reserve_inc_xrp":  reserveIncXRP,
-				"seq":              validatedLedgerSeq,
-			},
-			"validation_quorum": 1,
-		},
+		"state": state,
 	}
 
 	return response, nil
 }
-

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -127,7 +127,13 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		}
 	}
 
-	// Add hash to tx_json in response
+	// Inject DeliverMax for Payment transactions, matching rippled's
+	// RPC::insertDeliverMax behavior in TransactionSign.cpp.
+	injectDeliverMax(txJsonMap, ctx.ApiVersion)
+
+	// For API v2+: add hash at root level of response, matching
+	// transactionFormatResultImpl in TransactionSign.cpp.
+	// For API v1: hash goes inside tx_json only.
 	if txHashStr != "" {
 		txJsonMap["hash"] = txHashStr
 	}
@@ -135,18 +141,25 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 	// Get current fees for response
 	baseFee, _, _ := types.Services.Ledger.GetCurrentFees()
 
+	// Build response with independent boolean fields matching rippled's
+	// Transaction::SubmitResult struct. "accepted" = any() in rippled.
 	response := map[string]interface{}{
 		"engine_result":         result.EngineResult,
 		"engine_result_code":    result.EngineResultCode,
 		"engine_result_message": result.EngineResultMessage,
 		"tx_json":               txJsonMap,
 		"tx_blob":               txBlobHex,
-		"accepted":              result.Applied,
+		"accepted":              result.Accepted(),
 		"applied":               result.Applied,
-		"broadcast":             result.Applied,
-		"kept":                  result.Applied,
-		"queued":                false,
+		"broadcast":             result.Broadcast,
+		"kept":                  result.Kept,
+		"queued":                result.Queued,
 		"open_ledger_cost":      fmt.Sprintf("%d", baseFee),
+	}
+
+	// API v2+: add hash at the root level of the response
+	if ctx.ApiVersion > 1 && txHashStr != "" {
+		response["hash"] = txHashStr
 	}
 
 	// Add validated_ledger_index only if we have one

--- a/internal/rpc/handlers/tx_history.go
+++ b/internal/rpc/handlers/tx_history.go
@@ -76,7 +76,7 @@ func (m *TxHistoryMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 }
 
 func (m *TxHistoryMethod) RequiredRole() types.Role {
-	return types.RoleGuest
+	return types.RoleUser
 }
 
 func (m *TxHistoryMethod) SupportedApiVersions() []int {

--- a/internal/rpc/handlers/wallet_propose.go
+++ b/internal/rpc/handlers/wallet_propose.go
@@ -53,6 +53,7 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 
 	var entropy []byte
 	var warning string
+	var passphraseUsed bool
 
 	// Determine the seed source
 	// Priority: seed > seed_hex > passphrase > random
@@ -97,14 +98,7 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		// Derive seed from passphrase using SHA-512 Half (first 16 bytes of SHA-512)
 		hash := common.Sha512Half([]byte(request.Passphrase))
 		entropy = hash[:16]
-
-		// Add warning about passphrase-based wallets
-		entropyBits := estimateEntropy(request.Passphrase)
-		if entropyBits < 80.0 {
-			warning = "This wallet was generated using a user-supplied passphrase that has low entropy and is vulnerable to brute-force attacks."
-		} else {
-			warning = "This wallet was generated using a user-supplied passphrase. It may be vulnerable to brute-force attacks."
-		}
+		passphraseUsed = true
 	} else {
 		// Generate random seed
 		entropy = make([]byte, 16)
@@ -157,12 +151,28 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, types.RpcErrorInternal("Failed to encode public key: " + err.Error())
 	}
 
+	// Add passphrase warning matching rippled logic
+	// rippled skips warning if passphrase equals any seed encoding
+	seedHexStr := strings.ToUpper(hex.EncodeToString(entropy))
+	if passphraseUsed {
+		// TODO: add master_key (RFC1751) comparison when rfc1751 dictionary is complete
+		if request.Passphrase != encodedSeed && request.Passphrase != seedHexStr {
+			entropyBits := estimateEntropy(request.Passphrase)
+			if entropyBits < 80.0 {
+				warning = "This wallet was generated using a user-supplied passphrase that has low entropy and is vulnerable to brute-force attacks."
+			} else {
+				warning = "This wallet was generated using a user-supplied passphrase. It may be vulnerable to brute-force attacks."
+			}
+		}
+	}
+
 	// Build response matching rippled format
 	response := map[string]interface{}{
 		"account_id":      accountID,
 		"key_type":        keyType,
+		// TODO: "master_key" (RFC1751 encoding) — requires rfc1751 dictionary to be complete
 		"master_seed":     encodedSeed,
-		"master_seed_hex": strings.ToUpper(hex.EncodeToString(entropy)),
+		"master_seed_hex": seedHexStr,
 		"public_key":      encodedPublicKey,
 		"public_key_hex":  strings.ToUpper(publicKey),
 	}

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -184,6 +184,9 @@ func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte) (*types.SubmitRe
 		EngineResultCode:    int(result.Result),
 		EngineResultMessage: result.Message,
 		Applied:             result.Applied,
+		Broadcast:           result.Applied, // If applied, it would be broadcast to peers
+		Queued:              false,          // Not queued when applied directly
+		Kept:                result.Applied, // If applied, it is kept
 		Fee:                 result.Fee,
 		CurrentLedger:       result.CurrentLedger,
 		ValidatedLedger:     result.ValidatedLedger,

--- a/internal/rpc/ledger_data_test.go
+++ b/internal/rpc/ledger_data_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
@@ -57,7 +58,7 @@ func newDefaultLedgerDataResult(numItems int, withMarker bool) *types.LedgerData
 }
 
 // TestLedgerDataLimitClamping tests that the limit is properly clamped
-// Based on rippled LedgerData_test.cpp testCurrentLedgerToLimits()
+// Rippled Tuning.h: JSON mode {min:16, default:256, max:256}, binary mode {min:16, default:2048, max:2048}
 func TestLedgerDataLimitClamping(t *testing.T) {
 	var capturedLimit uint32
 
@@ -79,7 +80,7 @@ func TestLedgerDataLimitClamping(t *testing.T) {
 		ApiVersion: types.ApiVersion1,
 	}
 
-	t.Run("Default limit is 256", func(t *testing.T) {
+	t.Run("JSON mode default limit is 256", func(t *testing.T) {
 		params := map[string]interface{}{
 			"ledger_index": "current",
 		}
@@ -88,10 +89,10 @@ func TestLedgerDataLimitClamping(t *testing.T) {
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr, "Expected no error, got: %v", rpcErr)
 		require.NotNil(t, result)
-		assert.Equal(t, uint32(256), capturedLimit, "Default limit should be 256")
+		assert.Equal(t, uint32(256), capturedLimit, "JSON default limit should be 256")
 	})
 
-	t.Run("Limit below max passes through", func(t *testing.T) {
+	t.Run("JSON mode limit 100 passes through", func(t *testing.T) {
 		params := map[string]interface{}{
 			"ledger_index": "current",
 			"limit":        100,
@@ -104,7 +105,7 @@ func TestLedgerDataLimitClamping(t *testing.T) {
 		assert.Equal(t, uint32(100), capturedLimit, "Limit 100 should pass through")
 	})
 
-	t.Run("Limit at max 2048 passes through", func(t *testing.T) {
+	t.Run("JSON mode limit above 256 is clamped to 256", func(t *testing.T) {
 		params := map[string]interface{}{
 			"ledger_index": "current",
 			"limit":        2048,
@@ -114,23 +115,36 @@ func TestLedgerDataLimitClamping(t *testing.T) {
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
 		require.NotNil(t, result)
-		assert.Equal(t, uint32(2048), capturedLimit, "Limit 2048 should pass through")
+		assert.Equal(t, uint32(256), capturedLimit, "JSON limit above 256 should be clamped to 256")
 	})
 
-	t.Run("Limit above max 2048 is clamped", func(t *testing.T) {
+	t.Run("JSON mode limit 257 is clamped to 256", func(t *testing.T) {
 		params := map[string]interface{}{
 			"ledger_index": "current",
-			"limit":        5000,
+			"limit":        257,
 		}
 		paramsJSON, _ := json.Marshal(params)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
 		require.NotNil(t, result)
-		assert.Equal(t, uint32(2048), capturedLimit, "Limit above 2048 should be clamped to 2048")
+		assert.Equal(t, uint32(256), capturedLimit, "JSON limit 257 should be clamped to 256")
 	})
 
-	t.Run("Limit 255 passes through", func(t *testing.T) {
+	t.Run("JSON mode limit below 16 is clamped to 16", func(t *testing.T) {
+		params := map[string]interface{}{
+			"ledger_index": "current",
+			"limit":        5,
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+		assert.Equal(t, uint32(16), capturedLimit, "JSON limit below 16 should be clamped to 16")
+	})
+
+	t.Run("JSON mode limit 255 passes through", func(t *testing.T) {
 		params := map[string]interface{}{
 			"ledger_index": "current",
 			"limit":        255,
@@ -143,17 +157,59 @@ func TestLedgerDataLimitClamping(t *testing.T) {
 		assert.Equal(t, uint32(255), capturedLimit, "Limit 255 should pass through")
 	})
 
-	t.Run("Limit 257 passes through", func(t *testing.T) {
+	t.Run("Binary mode default limit is 2048", func(t *testing.T) {
 		params := map[string]interface{}{
 			"ledger_index": "current",
-			"limit":        257,
+			"binary":       true,
 		}
 		paramsJSON, _ := json.Marshal(params)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
 		require.NotNil(t, result)
-		assert.Equal(t, uint32(257), capturedLimit, "Limit 257 should pass through")
+		assert.Equal(t, uint32(2048), capturedLimit, "Binary default limit should be 2048")
+	})
+
+	t.Run("Binary mode limit 500 passes through", func(t *testing.T) {
+		params := map[string]interface{}{
+			"ledger_index": "current",
+			"binary":       true,
+			"limit":        500,
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+		assert.Equal(t, uint32(500), capturedLimit, "Binary limit 500 should pass through")
+	})
+
+	t.Run("Binary mode limit above 2048 is clamped", func(t *testing.T) {
+		params := map[string]interface{}{
+			"ledger_index": "current",
+			"binary":       true,
+			"limit":        5000,
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+		assert.Equal(t, uint32(2048), capturedLimit, "Binary limit above 2048 should be clamped to 2048")
+	})
+
+	t.Run("Binary mode limit below 16 is clamped to 16", func(t *testing.T) {
+		params := map[string]interface{}{
+			"ledger_index": "current",
+			"binary":       true,
+			"limit":        3,
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+		assert.Equal(t, uint32(16), capturedLimit, "Binary limit below 16 should be clamped to 16")
 	})
 }
 
@@ -192,10 +248,12 @@ func TestLedgerDataBinaryMode(t *testing.T) {
 		state := resp["state"].([]interface{})
 		assert.Equal(t, 3, len(state))
 
-		// Each item should have an index field
+		// Each item should have an index field with uppercase hex
 		for _, item := range state {
 			itemMap := item.(map[string]interface{})
 			assert.Contains(t, itemMap, "index")
+			indexStr := itemMap["index"].(string)
+			assert.Equal(t, strings.ToUpper(indexStr), indexStr, "index should be uppercase hex")
 		}
 	})
 
@@ -214,16 +272,20 @@ func TestLedgerDataBinaryMode(t *testing.T) {
 		state := resp["state"].([]interface{})
 		assert.Equal(t, 3, len(state))
 
-		// Each item should have data and index
+		// Each item should have data and index, both uppercase hex
 		for _, item := range state {
 			itemMap := item.(map[string]interface{})
 			assert.Contains(t, itemMap, "data")
 			assert.Contains(t, itemMap, "index")
-			// data should be a hex string
+			// data should be an uppercase hex string
 			dataStr, ok := itemMap["data"].(string)
 			assert.True(t, ok, "data should be a string")
 			_, err := hex.DecodeString(dataStr)
 			assert.NoError(t, err, "data should be valid hex")
+			assert.Equal(t, strings.ToUpper(dataStr), dataStr, "data should be uppercase hex")
+			// index should be uppercase hex
+			indexStr := itemMap["index"].(string)
+			assert.Equal(t, strings.ToUpper(indexStr), indexStr, "index should be uppercase hex")
 		}
 	})
 }
@@ -291,11 +353,11 @@ func TestLedgerDataMarkerPagination(t *testing.T) {
 		ApiVersion: types.ApiVersion1,
 	}
 
-	t.Run("First page has marker", func(t *testing.T) {
+	t.Run("First page has marker and limit", func(t *testing.T) {
 		callCount = 0
 		params := map[string]interface{}{
 			"ledger_index": "current",
-			"limit":        5,
+			"limit":        50,
 		}
 		paramsJSON, _ := json.Marshal(params)
 
@@ -310,13 +372,18 @@ func TestLedgerDataMarkerPagination(t *testing.T) {
 		markerStr, ok := resp["marker"].(string)
 		assert.True(t, ok, "marker should be a string")
 		assert.NotEmpty(t, markerStr, "marker should not be empty")
+		// limit should be present when marker is present
+		assert.Contains(t, resp, "limit", "limit should be present when marker is present")
+		limitVal, ok := resp["limit"].(float64)
+		assert.True(t, ok, "limit should be a number")
+		assert.Equal(t, float64(50), limitVal, "limit should match clamped request limit")
 	})
 
-	t.Run("Second page with marker has no marker", func(t *testing.T) {
+	t.Run("Second page with marker has no marker and no limit", func(t *testing.T) {
 		callCount = 0
 		params := map[string]interface{}{
 			"ledger_index": "current",
-			"limit":        5,
+			"limit":        50,
 			"marker":       "0000000000000000000000000000000000000000000000000000000000000010",
 		}
 		paramsJSON, _ := json.Marshal(params)
@@ -331,6 +398,9 @@ func TestLedgerDataMarkerPagination(t *testing.T) {
 		// No marker when all data returned
 		_, hasMarker := resp["marker"]
 		assert.False(t, hasMarker, "Last page should not have a marker")
+		// No limit when no marker
+		_, hasLimit := resp["limit"]
+		assert.False(t, hasLimit, "limit should not be present when no marker")
 	})
 }
 
@@ -387,10 +457,11 @@ func TestLedgerDataResponseStructure(t *testing.T) {
 	assert.Contains(t, resp, "state")
 	assert.Contains(t, resp, "validated")
 
-	// ledger_hash should be a hex string
+	// ledger_hash should be an uppercase hex string
 	hashStr, ok := resp["ledger_hash"].(string)
 	assert.True(t, ok, "ledger_hash should be a string")
 	assert.Equal(t, 64, len(hashStr), "ledger_hash should be 64 hex chars")
+	assert.Equal(t, strings.ToUpper(hashStr), hashStr, "ledger_hash should be uppercase hex")
 
 	// ledger_index should be a number
 	switch v := resp["ledger_index"].(type) {
@@ -405,8 +476,17 @@ func TestLedgerDataResponseStructure(t *testing.T) {
 	assert.True(t, ok, "state should be an array")
 	assert.Equal(t, 1, len(state))
 
+	// State entries should have uppercase index
+	entry := state[0].(map[string]interface{})
+	indexStr := entry["index"].(string)
+	assert.Equal(t, strings.ToUpper(indexStr), indexStr, "state entry index should be uppercase hex")
+
 	// validated should be bool
 	assert.Equal(t, true, resp["validated"])
+
+	// No marker means no limit in response
+	_, hasLimit := resp["limit"]
+	assert.False(t, hasLimit, "limit should not be present when no marker")
 }
 
 // TestLedgerDataServiceUnavailable tests behavior when ledger service is not available
@@ -530,7 +610,7 @@ func TestLedgerDataLedgerHeader(t *testing.T) {
 		ApiVersion: types.ApiVersion1,
 	}
 
-	t.Run("First query includes ledger header JSON", func(t *testing.T) {
+	t.Run("First query includes ledger header JSON with uppercase hashes", func(t *testing.T) {
 		params := map[string]interface{}{
 			"ledger_index": "closed",
 		}
@@ -543,6 +623,10 @@ func TestLedgerDataLedgerHeader(t *testing.T) {
 		resp := resultToMapData(t, result)
 		assert.Contains(t, resp, "ledger")
 
+		// Top-level ledger_hash should be uppercase
+		topHash := resp["ledger_hash"].(string)
+		assert.Equal(t, strings.ToUpper(topHash), topHash, "top-level ledger_hash should be uppercase")
+
 		ledger := resp["ledger"].(map[string]interface{})
 		assert.Contains(t, ledger, "ledger_hash")
 		assert.Contains(t, ledger, "account_hash")
@@ -554,9 +638,15 @@ func TestLedgerDataLedgerHeader(t *testing.T) {
 		assert.Contains(t, ledger, "close_time_resolution")
 		assert.Contains(t, ledger, "closed")
 		assert.Contains(t, ledger, "total_coins")
+
+		// All hashes in ledger header should be uppercase
+		for _, field := range []string{"ledger_hash", "account_hash", "parent_hash", "transaction_hash"} {
+			hashVal := ledger[field].(string)
+			assert.Equal(t, strings.ToUpper(hashVal), hashVal, field+" should be uppercase hex")
+		}
 	})
 
-	t.Run("First query includes ledger header binary", func(t *testing.T) {
+	t.Run("First query includes ledger header binary with uppercase hex", func(t *testing.T) {
 		params := map[string]interface{}{
 			"ledger_index": "closed",
 			"binary":       true,
@@ -574,11 +664,12 @@ func TestLedgerDataLedgerHeader(t *testing.T) {
 		assert.Contains(t, ledger, "ledger_data")
 		assert.Contains(t, ledger, "closed")
 
-		// ledger_data should be a hex string
+		// ledger_data should be an uppercase hex string
 		dataStr, ok := ledger["ledger_data"].(string)
 		assert.True(t, ok, "ledger_data should be a string in binary mode")
 		_, err := hex.DecodeString(dataStr)
 		assert.NoError(t, err, "ledger_data should be valid hex")
+		assert.Equal(t, strings.ToUpper(dataStr), dataStr, "ledger_data should be uppercase hex")
 	})
 }
 

--- a/internal/rpc/ledger_entry_test.go
+++ b/internal/rpc/ledger_entry_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
@@ -1167,11 +1168,11 @@ func TestLedgerEntryImplementedTypes(t *testing.T) {
 		require.NotNil(t, result)
 	})
 
-	t.Run("ticket by account and ticket_id", func(t *testing.T) {
+	t.Run("ticket by account and ticket_seq", func(t *testing.T) {
 		params := map[string]interface{}{
 			"ticket": map[string]interface{}{
-				"account":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-				"ticket_id": 5,
+				"account":    "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"ticket_seq": 5,
 			},
 			"ledger_index": "validated",
 		}
@@ -2516,4 +2517,587 @@ func TestLedgerEntryHexValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// =============================================================================
+// Hex Index Fallback Tests
+// =============================================================================
+
+// TestLedgerEntryHexFallback tests that all entry types that support it accept
+// a direct hex string as an alternative to the structured object form.
+// Reference: rippled LedgerEntry.cpp — each parse* function checks isObject()
+// first and falls back to parseHex if the value is a string.
+func TestLedgerEntryHexFallback(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	validHex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
+
+	// All entry types that should accept a direct hex string
+	hexEntryTypes := []string{
+		"amm",
+		"bridge",
+		"credential",
+		"delegate",
+		"deposit_preauth",
+		"escrow",
+		"mptoken",
+		"offer",
+		"oracle",
+		"permissioned_domain",
+		"ticket",
+		"vault",
+		"xchain_owned_claim_id",
+		"xchain_owned_create_account_claim_id",
+	}
+
+	for _, entryType := range hexEntryTypes {
+		t.Run(entryType+" accepts hex string", func(t *testing.T) {
+			mock.ledgerEntryResult = nil
+			mock.ledgerEntryErr = nil
+
+			params := map[string]interface{}{
+				entryType:      validHex,
+				"ledger_index": "validated",
+			}
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			require.Nil(t, rpcErr, "Entry type %s should accept hex string, got error: %v", entryType, rpcErr)
+			require.NotNil(t, result)
+		})
+
+		t.Run(entryType+" rejects invalid hex", func(t *testing.T) {
+			mock.ledgerEntryResult = nil
+			mock.ledgerEntryErr = nil
+
+			params := map[string]interface{}{
+				entryType:      "INVALID_NOT_HEX_STRING",
+				"ledger_index": "validated",
+			}
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			// Should fail because it's not valid hex and won't parse as object either
+			require.NotNil(t, rpcErr, "Entry type %s should reject invalid hex/params", entryType)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+// =============================================================================
+// New Entry Type Tests: vault, delegate, bridge, xchain
+// =============================================================================
+
+// TestLedgerEntryVault tests vault entry lookup by hex and by object form
+func TestLedgerEntryVault(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	vaultHex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
+
+	t.Run("vault by hex string", func(t *testing.T) {
+		params := map[string]interface{}{
+			"vault":        vaultHex,
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("vault by owner and seq", func(t *testing.T) {
+		params := map[string]interface{}{
+			"vault": map[string]interface{}{
+				"owner": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"seq":   5,
+			},
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("vault with invalid owner", func(t *testing.T) {
+		params := map[string]interface{}{
+			"vault": map[string]interface{}{
+				"owner": "not-a-valid-address",
+				"seq":   5,
+			},
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Contains(t, rpcErr.Message, "Invalid vault owner")
+	})
+}
+
+// TestLedgerEntryDelegate tests delegate entry lookup by hex and by object form
+func TestLedgerEntryDelegate(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	delegateHex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
+
+	t.Run("delegate by hex string", func(t *testing.T) {
+		params := map[string]interface{}{
+			"delegate":     delegateHex,
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("delegate by account and authorize", func(t *testing.T) {
+		params := map[string]interface{}{
+			"delegate": map[string]interface{}{
+				"account":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"authorize": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			},
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("delegate missing authorize", func(t *testing.T) {
+		params := map[string]interface{}{
+			"delegate": map[string]interface{}{
+				"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			},
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Contains(t, rpcErr.Message, "account and authorize required")
+	})
+}
+
+// TestLedgerEntryBridge tests bridge entry lookup by hex string
+func TestLedgerEntryBridge(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	t.Run("bridge by hex string", func(t *testing.T) {
+		params := map[string]interface{}{
+			"bridge":       "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("bridge invalid hex", func(t *testing.T) {
+		params := map[string]interface{}{
+			"bridge":       "TOOSHORT",
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Contains(t, rpcErr.Message, "Invalid bridge")
+	})
+}
+
+// TestLedgerEntryXChainClaimID tests xchain_owned_claim_id entry lookup by hex
+func TestLedgerEntryXChainClaimID(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	t.Run("xchain_owned_claim_id by hex string", func(t *testing.T) {
+		params := map[string]interface{}{
+			"xchain_owned_claim_id": "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
+			"ledger_index":          "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("xchain_owned_create_account_claim_id by hex string", func(t *testing.T) {
+		params := map[string]interface{}{
+			"xchain_owned_create_account_claim_id": "B33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
+			"ledger_index":                         "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+}
+
+// =============================================================================
+// Ticket Conformance Tests
+// =============================================================================
+
+// TestLedgerEntryTicketConformance tests that ticket uses ticket_seq (not ticket_id)
+// matching rippled's parseTicket() which expects jss::ticket_seq
+func TestLedgerEntryTicketConformance(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	t.Run("ticket by account and ticket_seq", func(t *testing.T) {
+		params := map[string]interface{}{
+			"ticket": map[string]interface{}{
+				"account":    "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"ticket_seq": 5,
+			},
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("ticket by hex string", func(t *testing.T) {
+		params := map[string]interface{}{
+			"ticket":       "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+}
+
+// =============================================================================
+// Uppercase Hex Response Tests
+// =============================================================================
+
+// TestLedgerEntryUppercaseHex verifies that the ledger_hash in the response
+// uses uppercase hex encoding, matching rippled's output.
+func TestLedgerEntryUppercaseHex(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	mock.ledgerEntryResult = &types.LedgerEntryResult{
+		Index:       "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
+		LedgerIndex: 2,
+		LedgerHash:  [32]byte{0x4B, 0xC5, 0x0C, 0x9B, 0x0D, 0x85, 0x15, 0xD3, 0xEA, 0xAE, 0x1E, 0x74, 0xB2, 0x9A, 0x95, 0x80, 0x43, 0x46, 0xC4, 0x91, 0xEE, 0x1A, 0x95, 0xBF, 0x25, 0xE4, 0xAA, 0xB8, 0x54, 0xA6, 0xA6, 0x52},
+		Node:        []byte(`{"LedgerEntryType": "AccountRoot"}`),
+		Validated:   true,
+	}
+
+	params := map[string]interface{}{
+		"index":        "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
+		"ledger_index": "validated",
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	result, rpcErr := method.Handle(ctx, paramsJSON)
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+
+	resultMap, ok := result.(map[string]interface{})
+	require.True(t, ok)
+
+	ledgerHash, ok := resultMap["ledger_hash"].(string)
+	require.True(t, ok)
+
+	// Verify uppercase hex
+	assert.Equal(t, "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652", ledgerHash,
+		"ledger_hash should use uppercase hex")
+	// Verify no lowercase letters in the hash
+	assert.Equal(t, ledgerHash, strings.ToUpper(ledgerHash),
+		"ledger_hash should be entirely uppercase")
+}
+
+// =============================================================================
+// Escrow Hex Fallback Tests
+// =============================================================================
+
+// TestLedgerEntryEscrowHexFallback tests escrow specifically with hex vs object form
+func TestLedgerEntryEscrowHexFallback(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	t.Run("escrow by hex string", func(t *testing.T) {
+		params := map[string]interface{}{
+			"escrow":       "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("escrow by owner and seq (object form)", func(t *testing.T) {
+		params := map[string]interface{}{
+			"escrow": map[string]interface{}{
+				"owner": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"seq":   5,
+			},
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+}
+
+// =============================================================================
+// Offer Hex Fallback Tests
+// =============================================================================
+
+// TestLedgerEntryOfferHexFallback tests offer specifically with hex vs object form
+func TestLedgerEntryOfferHexFallback(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	t.Run("offer by hex string", func(t *testing.T) {
+		params := map[string]interface{}{
+			"offer":        "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("offer by account and seq (object form)", func(t *testing.T) {
+		params := map[string]interface{}{
+			"offer": map[string]interface{}{
+				"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"seq":     5,
+			},
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+}
+
+// =============================================================================
+// Oracle Hex Fallback Tests
+// =============================================================================
+
+// TestLedgerEntryOracleHexFallback tests oracle with hex vs object form
+func TestLedgerEntryOracleHexFallback(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	t.Run("oracle by hex string", func(t *testing.T) {
+		params := map[string]interface{}{
+			"oracle":       "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("oracle by account and document_id (object form)", func(t *testing.T) {
+		params := map[string]interface{}{
+			"oracle": map[string]interface{}{
+				"account":            "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"oracle_document_id": 1,
+			},
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+}
+
+// =============================================================================
+// AMM Hex Fallback Tests
+// =============================================================================
+
+// TestLedgerEntryAMMHexFallback tests AMM with hex vs object form
+func TestLedgerEntryAMMHexFallback(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	cleanup := setupLedgerEntryTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	t.Run("amm by hex string", func(t *testing.T) {
+		params := map[string]interface{}{
+			"amm":          "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("amm by asset pair (object form)", func(t *testing.T) {
+		params := map[string]interface{}{
+			"amm": map[string]interface{}{
+				"asset":  map[string]interface{}{"currency": "XRP"},
+				"asset2": map[string]interface{}{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			},
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("amm object missing asset2", func(t *testing.T) {
+		params := map[string]interface{}{
+			"amm": map[string]interface{}{
+				"asset": map[string]interface{}{"currency": "XRP"},
+			},
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Contains(t, rpcErr.Message, "asset and asset2 required")
+	})
 }

--- a/internal/rpc/ledger_header_test.go
+++ b/internal/rpc/ledger_header_test.go
@@ -1,0 +1,512 @@
+package rpc
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resultToMapHeader is a test helper that JSON-round-trips a result to a map.
+func resultToMapHeader(t *testing.T, result interface{}) map[string]interface{} {
+	t.Helper()
+	resultJSON, err := json.Marshal(result)
+	require.NoError(t, err)
+	var resp map[string]interface{}
+	err = json.Unmarshal(resultJSON, &resp)
+	require.NoError(t, err)
+	return resp
+}
+
+// TestLedgerHeaderBasicRequest tests basic ledger_header with default params.
+// Reference: rippled LedgerHeader.cpp doLedgerHeader()
+func TestLedgerHeaderBasicRequest(t *testing.T) {
+	mock := &ledgerMock{
+		mockLedgerService: newMockLedgerService(),
+	}
+	reader := newDefaultLedgerReader(2, true)
+	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
+		if seq == 2 {
+			return reader, nil
+		}
+		return nil, errors.New("ledger not found")
+	}
+	cleanup := setupTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerHeaderMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	t.Run("Default params returns validated ledger with all fields", func(t *testing.T) {
+		result, rpcErr := method.Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resp := resultToMapHeader(t, result)
+
+		// Top-level fields from lookupLedger equivalent
+		assert.Contains(t, resp, "ledger_hash")
+		assert.Contains(t, resp, "ledger_index")
+		assert.Contains(t, resp, "validated")
+		assert.Equal(t, true, resp["validated"])
+
+		// ledger_data binary hex must be present for closed ledgers
+		assert.Contains(t, resp, "ledger_data")
+		ledgerData, ok := resp["ledger_data"].(string)
+		assert.True(t, ok, "ledger_data should be a string")
+		assert.NotEmpty(t, ledgerData)
+		// All hex should be uppercase
+		assert.Equal(t, strings.ToUpper(ledgerData), ledgerData, "ledger_data should be uppercase hex")
+
+		// Nested "ledger" JSON object
+		assert.Contains(t, resp, "ledger")
+		ledger, ok := resp["ledger"].(map[string]interface{})
+		require.True(t, ok, "ledger should be an object")
+
+		// Verify all expected fields in the ledger object
+		assert.Contains(t, ledger, "ledger_index")
+		assert.Contains(t, ledger, "ledger_hash")
+		assert.Contains(t, ledger, "parent_hash")
+		assert.Contains(t, ledger, "total_coins")
+		assert.Contains(t, ledger, "close_time")
+		assert.Contains(t, ledger, "close_time_resolution")
+		assert.Contains(t, ledger, "close_flags")
+		assert.Contains(t, ledger, "account_hash")
+		assert.Contains(t, ledger, "transaction_hash")
+		assert.Contains(t, ledger, "parent_close_time")
+		assert.Contains(t, ledger, "closed")
+		assert.Equal(t, true, ledger["closed"])
+
+		// ledger_index in the nested object should be a string (API v1)
+		assert.Equal(t, "2", ledger["ledger_index"])
+
+		// total_coins should be a string (matching rippled to_string(info.drops))
+		assert.IsType(t, "", ledger["total_coins"])
+
+		// close_time_human should be present when closeTime > 0
+		if reader.closeTime > 0 {
+			assert.Contains(t, ledger, "close_time_human")
+			assert.Contains(t, ledger, "close_time_iso")
+		}
+	})
+
+	t.Run("Numeric ledger_index", func(t *testing.T) {
+		params := json.RawMessage(`{"ledger_index": 2}`)
+		result, rpcErr := method.Handle(ctx, params)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resp := resultToMapHeader(t, result)
+		assert.Contains(t, resp, "ledger_data")
+		assert.Contains(t, resp, "ledger")
+	})
+
+	t.Run("String validated", func(t *testing.T) {
+		params := json.RawMessage(`{"ledger_index": "validated"}`)
+		result, rpcErr := method.Handle(ctx, params)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resp := resultToMapHeader(t, result)
+		assert.Equal(t, true, resp["validated"])
+	})
+
+	t.Run("String closed", func(t *testing.T) {
+		params := json.RawMessage(`{"ledger_index": "closed"}`)
+		result, rpcErr := method.Handle(ctx, params)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resp := resultToMapHeader(t, result)
+		assert.Contains(t, resp, "ledger_data")
+	})
+
+	t.Run("String current", func(t *testing.T) {
+		// Current ledger (seq=3) is not in the mock, so it will fail
+		params := json.RawMessage(`{"ledger_index": "current"}`)
+		_, rpcErr := method.Handle(ctx, params)
+		// Should return lgrNotFound since seq=3 is not in the mock
+		require.NotNil(t, rpcErr)
+	})
+
+	t.Run("Lookup by hash", func(t *testing.T) {
+		hash := reader.Hash()
+		hashHex := strings.ToUpper(hex.EncodeToString(hash[:]))
+		params, _ := json.Marshal(map[string]interface{}{
+			"ledger_hash": hashHex,
+		})
+
+		mock.getLedgerByHashFn = func(h [32]byte) (types.LedgerReader, error) {
+			if h == hash {
+				return reader, nil
+			}
+			return nil, errors.New("not found")
+		}
+
+		result, rpcErr := method.Handle(ctx, params)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resp := resultToMapHeader(t, result)
+		assert.Contains(t, resp, "ledger_data")
+		assert.Equal(t, hashHex, resp["ledger_hash"])
+	})
+}
+
+// TestLedgerHeaderBinaryFormat validates that ledger_data matches rippled's
+// addRaw() serialization format.
+func TestLedgerHeaderBinaryFormat(t *testing.T) {
+	mock := &ledgerMock{
+		mockLedgerService: newMockLedgerService(),
+	}
+
+	// Create a reader with known values
+	var hash [32]byte
+	hash[0] = 0x02
+	hash[31] = 0xAA
+	var parentHash [32]byte
+	parentHash[0] = 0x01
+	parentHash[31] = 0xAA
+	var txMapHash [32]byte
+	txMapHash[0] = 0x10
+	var stateMapHash [32]byte
+	stateMapHash[0] = 0x20
+
+	reader := &mockLedgerReader{
+		seq:                 5,
+		hash:                hash,
+		parentHash:          parentHash,
+		txMapHash:           txMapHash,
+		stateMapHash:        stateMapHash,
+		closed:              true,
+		validated:           true,
+		totalDrops:          99999999999999980,
+		closeTime:           776000030,
+		closeTimeResolution: 10,
+		closeFlags:          0,
+		parentCloseTime:     776000020,
+	}
+
+	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
+		return reader, nil
+	}
+	cleanup := setupTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerHeaderMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	result, rpcErr := method.Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+
+	resp := resultToMapHeader(t, result)
+	ledgerDataHex, ok := resp["ledger_data"].(string)
+	require.True(t, ok)
+
+	data, err := hex.DecodeString(ledgerDataHex)
+	require.NoError(t, err)
+
+	// rippled addRaw format: 4+8+32+32+32+4+4+1+1 = 118 bytes
+	assert.Equal(t, 118, len(data), "ledger_data should be 118 bytes (rippled addRaw format)")
+
+	// Parse and verify each field
+	offset := 0
+
+	// seq (uint32, 4 bytes)
+	seq := binary.BigEndian.Uint32(data[offset : offset+4])
+	assert.Equal(t, uint32(5), seq)
+	offset += 4
+
+	// drops (uint64, 8 bytes)
+	drops := binary.BigEndian.Uint64(data[offset : offset+8])
+	assert.Equal(t, uint64(99999999999999980), drops)
+	offset += 8
+
+	// parentHash (32 bytes)
+	var gotParentHash [32]byte
+	copy(gotParentHash[:], data[offset:offset+32])
+	assert.Equal(t, parentHash, gotParentHash)
+	offset += 32
+
+	// txHash (32 bytes)
+	var gotTxHash [32]byte
+	copy(gotTxHash[:], data[offset:offset+32])
+	assert.Equal(t, txMapHash, gotTxHash)
+	offset += 32
+
+	// accountHash (32 bytes)
+	var gotStateHash [32]byte
+	copy(gotStateHash[:], data[offset:offset+32])
+	assert.Equal(t, stateMapHash, gotStateHash)
+	offset += 32
+
+	// parentCloseTime (uint32, 4 bytes)
+	pct := binary.BigEndian.Uint32(data[offset : offset+4])
+	assert.Equal(t, uint32(776000020), pct)
+	offset += 4
+
+	// closeTime (uint32, 4 bytes)
+	ct := binary.BigEndian.Uint32(data[offset : offset+4])
+	assert.Equal(t, uint32(776000030), ct)
+	offset += 4
+
+	// closeTimeResolution (uint8, 1 byte)
+	assert.Equal(t, uint8(10), data[offset])
+	offset++
+
+	// closeFlags (uint8, 1 byte)
+	assert.Equal(t, uint8(0), data[offset])
+}
+
+// TestLedgerHeaderHashFormat verifies all hash fields are uppercase hex.
+func TestLedgerHeaderHashFormat(t *testing.T) {
+	mock := &ledgerMock{
+		mockLedgerService: newMockLedgerService(),
+	}
+	reader := newDefaultLedgerReader(2, true)
+	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
+		return reader, nil
+	}
+	cleanup := setupTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerHeaderMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	result, rpcErr := method.Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+
+	resp := resultToMapHeader(t, result)
+
+	// Check top-level ledger_hash
+	topHash, ok := resp["ledger_hash"].(string)
+	assert.True(t, ok)
+	assert.Equal(t, strings.ToUpper(topHash), topHash, "top-level ledger_hash should be uppercase")
+
+	// Check nested ledger object hashes
+	ledger := resp["ledger"].(map[string]interface{})
+	for _, field := range []string{"ledger_hash", "parent_hash", "account_hash", "transaction_hash"} {
+		v, ok := ledger[field].(string)
+		if ok && v != "" {
+			assert.Equal(t, strings.ToUpper(v), v, "%s should be uppercase hex", field)
+			assert.Equal(t, 64, len(v), "%s should be 64 hex chars", field)
+		}
+	}
+}
+
+// TestLedgerHeaderBadInput tests error handling for invalid inputs.
+func TestLedgerHeaderBadInput(t *testing.T) {
+	mock := &ledgerMock{
+		mockLedgerService: newMockLedgerService(),
+	}
+	reader := newDefaultLedgerReader(2, true)
+	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
+		if seq <= 2 {
+			return reader, nil
+		}
+		return nil, errors.New("ledger not found")
+	}
+	cleanup := setupTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerHeaderMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	t.Run("Invalid string ledger_index", func(t *testing.T) {
+		params := json.RawMessage(`{"ledger_index": "potato"}`)
+		result, rpcErr := method.Handle(ctx, params)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+	})
+
+	t.Run("Non-existent ledger_index", func(t *testing.T) {
+		params := json.RawMessage(`{"ledger_index": 999}`)
+		result, rpcErr := method.Handle(ctx, params)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcLGR_NOT_FOUND, rpcErr.Code)
+	})
+
+	t.Run("Invalid ledger_hash - too short", func(t *testing.T) {
+		params := json.RawMessage(`{"ledger_hash": "ABCD"}`)
+		result, rpcErr := method.Handle(ctx, params)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+	})
+
+	t.Run("Invalid ledger_hash - not hex", func(t *testing.T) {
+		params := json.RawMessage(`{"ledger_hash": "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"}`)
+		result, rpcErr := method.Handle(ctx, params)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+	})
+
+	t.Run("Invalid JSON params", func(t *testing.T) {
+		params := json.RawMessage(`{invalid json}`)
+		result, rpcErr := method.Handle(ctx, params)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+	})
+}
+
+// TestLedgerHeaderOpenLedger tests behavior when querying an open (non-closed) ledger.
+func TestLedgerHeaderOpenLedger(t *testing.T) {
+	mock := &ledgerMock{
+		mockLedgerService: newMockLedgerService(),
+	}
+	// Open ledger: not closed, not validated
+	openReader := &mockLedgerReader{
+		seq:                 3,
+		closed:              false,
+		validated:           false,
+		totalDrops:          99999999999999980,
+		closeTimeResolution: 10,
+	}
+	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
+		if seq == 3 {
+			return openReader, nil
+		}
+		return nil, errors.New("not found")
+	}
+	cleanup := setupTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerHeaderMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{"ledger_index": "current"}`)
+	result, rpcErr := method.Handle(ctx, params)
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+
+	resp := resultToMapHeader(t, result)
+
+	// Open ledger: lookupLedger sets ledger_current_index instead of ledger_hash/ledger_index
+	assert.Contains(t, resp, "ledger_current_index")
+	assert.NotContains(t, resp, "ledger_hash", "open ledger should not have ledger_hash at top level")
+
+	// validated should be false
+	assert.Equal(t, false, resp["validated"])
+
+	// ledger_data is always present (rippled doLedgerHeader sets it unconditionally)
+	assert.Contains(t, resp, "ledger_data")
+
+	// Nested ledger object should have closed=false
+	ledger := resp["ledger"].(map[string]interface{})
+	assert.Equal(t, false, ledger["closed"])
+	// Open ledger should only have parent_hash, ledger_index, closed
+	assert.Contains(t, ledger, "parent_hash")
+	assert.Contains(t, ledger, "ledger_index")
+}
+
+// TestLedgerHeaderCloseTimeEstimated tests the close_time_estimated field
+// when the LCFNoConsensusTime flag is set.
+func TestLedgerHeaderCloseTimeEstimated(t *testing.T) {
+	mock := &ledgerMock{
+		mockLedgerService: newMockLedgerService(),
+	}
+	// Set closeFlags with LCFNoConsensusTime (0x01)
+	reader := newDefaultLedgerReader(2, true)
+	reader.closeFlags = 0x01
+
+	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
+		return reader, nil
+	}
+	cleanup := setupTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.LedgerHeaderMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	result, rpcErr := method.Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+
+	resp := resultToMapHeader(t, result)
+	ledger := resp["ledger"].(map[string]interface{})
+
+	// When LCFNoConsensusTime is set, close_time_estimated should be true
+	assert.Equal(t, true, ledger["close_time_estimated"])
+}
+
+// TestLedgerHeaderMethodMetadata tests RequiredRole, SupportedApiVersions, RequiredCondition.
+func TestLedgerHeaderMethodMetadata(t *testing.T) {
+	method := &handlers.LedgerHeaderMethod{}
+
+	t.Run("RequiredRole is Guest", func(t *testing.T) {
+		assert.Equal(t, types.RoleGuest, method.RequiredRole())
+	})
+
+	t.Run("Supports only API version 1", func(t *testing.T) {
+		versions := method.SupportedApiVersions()
+		assert.Contains(t, versions, types.ApiVersion1)
+		assert.NotContains(t, versions, types.ApiVersion2)
+		assert.NotContains(t, versions, types.ApiVersion3)
+	})
+
+	t.Run("No required condition", func(t *testing.T) {
+		assert.Equal(t, types.NoCondition, method.RequiredCondition())
+	})
+}
+
+// TestLedgerHeaderServiceUnavailable tests behavior when services are not available.
+func TestLedgerHeaderServiceUnavailable(t *testing.T) {
+	method := &handlers.LedgerHeaderMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	t.Run("Nil services", func(t *testing.T) {
+		old := types.Services
+		types.Services = nil
+		defer func() { types.Services = old }()
+
+		result, rpcErr := method.Handle(ctx, nil)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+	})
+
+	t.Run("Nil ledger in services", func(t *testing.T) {
+		old := types.Services
+		types.Services = &types.ServiceContainer{Ledger: nil}
+		defer func() { types.Services = old }()
+
+		result, rpcErr := method.Handle(ctx, nil)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+	})
+}

--- a/internal/rpc/submit_test.go
+++ b/internal/rpc/submit_test.go
@@ -1021,3 +1021,365 @@ func TestSubmitMethodSigningCredentials(t *testing.T) {
 		})
 	}
 }
+
+// TestSubmitMethodApiV2Response tests API v2 specific response formatting.
+// API v2 should include "hash" at the root level of the response.
+func TestSubmitMethodApiV2Response(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	method := &handlers.SubmitMethod{}
+
+	baseTxJson := map[string]interface{}{
+		"TransactionType": "Payment",
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Amount":          "1000000",
+		"Fee":             "10",
+		"Sequence":        1,
+	}
+
+	t.Run("API v1 does not have hash at root", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		params := map[string]interface{}{
+			"tx_json": baseTxJson,
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resultJSON, err := json.Marshal(result)
+		require.NoError(t, err)
+		var resp map[string]interface{}
+		err = json.Unmarshal(resultJSON, &resp)
+		require.NoError(t, err)
+
+		// API v1: no hash at root level
+		_, hasRootHash := resp["hash"]
+		assert.False(t, hasRootHash, "API v1 should NOT have hash at root level")
+
+		// hash should still be present inside tx_json
+		txJson, ok := resp["tx_json"].(map[string]interface{})
+		require.True(t, ok)
+		assert.NotEmpty(t, txJson["hash"], "hash should be inside tx_json")
+	})
+
+	t.Run("API v2 has hash at root", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion2,
+		}
+
+		params := map[string]interface{}{
+			"tx_json": baseTxJson,
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resultJSON, err := json.Marshal(result)
+		require.NoError(t, err)
+		var resp map[string]interface{}
+		err = json.Unmarshal(resultJSON, &resp)
+		require.NoError(t, err)
+
+		// API v2: hash at root level
+		rootHash, hasRootHash := resp["hash"].(string)
+		assert.True(t, hasRootHash, "API v2 should have hash at root level")
+		assert.NotEmpty(t, rootHash)
+
+		// Also in tx_json
+		txJson, ok := resp["tx_json"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, rootHash, txJson["hash"], "root hash and tx_json hash should match")
+	})
+
+	t.Run("API v3 has hash at root", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion3,
+		}
+
+		params := map[string]interface{}{
+			"tx_json": baseTxJson,
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resultJSON, err := json.Marshal(result)
+		require.NoError(t, err)
+		var resp map[string]interface{}
+		err = json.Unmarshal(resultJSON, &resp)
+		require.NoError(t, err)
+
+		// API v3: also has hash at root
+		rootHash, hasRootHash := resp["hash"].(string)
+		assert.True(t, hasRootHash, "API v3 should have hash at root level")
+		assert.NotEmpty(t, rootHash)
+	})
+}
+
+// TestSubmitMethodDeliverMax tests DeliverMax injection for Payment transactions.
+// For API v1: Amount is kept, DeliverMax is added.
+// For API v2+: Amount is removed, DeliverMax replaces it.
+func TestSubmitMethodDeliverMax(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	method := &handlers.SubmitMethod{}
+
+	t.Run("API v1 Payment - Amount kept, DeliverMax added", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "Payment",
+				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"Amount":          "1000000",
+				"Fee":             "10",
+				"Sequence":        1,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resultJSON, err := json.Marshal(result)
+		require.NoError(t, err)
+		var resp map[string]interface{}
+		err = json.Unmarshal(resultJSON, &resp)
+		require.NoError(t, err)
+
+		txJson, ok := resp["tx_json"].(map[string]interface{})
+		require.True(t, ok)
+
+		// API v1: Amount is kept
+		assert.Equal(t, "1000000", txJson["Amount"],
+			"API v1 should keep Amount in tx_json")
+		// DeliverMax is added
+		assert.Equal(t, "1000000", txJson["DeliverMax"],
+			"API v1 should add DeliverMax for Payment")
+	})
+
+	t.Run("API v2 Payment - Amount removed, DeliverMax added", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion2,
+		}
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "Payment",
+				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"Amount":          "1000000",
+				"Fee":             "10",
+				"Sequence":        1,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resultJSON, err := json.Marshal(result)
+		require.NoError(t, err)
+		var resp map[string]interface{}
+		err = json.Unmarshal(resultJSON, &resp)
+		require.NoError(t, err)
+
+		txJson, ok := resp["tx_json"].(map[string]interface{})
+		require.True(t, ok)
+
+		// API v2: Amount is removed
+		_, hasAmount := txJson["Amount"]
+		assert.False(t, hasAmount,
+			"API v2 should remove Amount from tx_json for Payment")
+		// DeliverMax replaces it
+		assert.Equal(t, "1000000", txJson["DeliverMax"],
+			"API v2 should have DeliverMax in tx_json for Payment")
+	})
+
+	t.Run("Non-Payment tx - no DeliverMax regardless of API version", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion2,
+		}
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"Fee":             "12",
+				"Sequence":        5,
+				"SetFlag":         8,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+
+		resultJSON, err := json.Marshal(result)
+		require.NoError(t, err)
+		var resp map[string]interface{}
+		err = json.Unmarshal(resultJSON, &resp)
+		require.NoError(t, err)
+
+		txJson, ok := resp["tx_json"].(map[string]interface{})
+		require.True(t, ok)
+
+		// Non-Payment: no DeliverMax added
+		_, hasDeliverMax := txJson["DeliverMax"]
+		assert.False(t, hasDeliverMax,
+			"Non-Payment tx should not have DeliverMax")
+	})
+}
+
+// TestSubmitMethodIndependentBooleans tests that the boolean response fields
+// (accepted, applied, broadcast, queued, kept) can be set independently,
+// matching rippled's Transaction::SubmitResult struct.
+func TestSubmitMethodIndependentBooleans(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	method := &handlers.SubmitMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	baseTxJson := map[string]interface{}{
+		"TransactionType": "Payment",
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Amount":          "1000000",
+		"Fee":             "10",
+		"Sequence":        1,
+	}
+
+	t.Run("Applied=true implies accepted=true, broadcast=true, kept=true", func(t *testing.T) {
+		mock.submitResult = &types.SubmitResult{
+			EngineResult:        "tesSUCCESS",
+			EngineResultCode:    0,
+			EngineResultMessage: "The transaction was applied.",
+			Applied:             true,
+			Broadcast:           true,
+			Kept:                true,
+			Queued:              false,
+			ValidatedLedger:     2,
+		}
+
+		params := map[string]interface{}{"tx_json": baseTxJson}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+
+		resultJSON, _ := json.Marshal(result)
+		var resp map[string]interface{}
+		json.Unmarshal(resultJSON, &resp)
+
+		assert.Equal(t, true, resp["applied"])
+		assert.Equal(t, true, resp["broadcast"])
+		assert.Equal(t, true, resp["kept"])
+		assert.Equal(t, false, resp["queued"])
+		assert.Equal(t, true, resp["accepted"],
+			"accepted should be true when applied is true (any() = true)")
+	})
+
+	t.Run("Not applied, not broadcast - accepted=false", func(t *testing.T) {
+		mock.submitResult = &types.SubmitResult{
+			EngineResult:        "tefPAST_SEQ",
+			EngineResultCode:    -190,
+			EngineResultMessage: "This sequence number has already passed.",
+			Applied:             false,
+			Broadcast:           false,
+			Kept:                false,
+			Queued:              false,
+			ValidatedLedger:     2,
+		}
+
+		params := map[string]interface{}{"tx_json": baseTxJson}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+
+		resultJSON, _ := json.Marshal(result)
+		var resp map[string]interface{}
+		json.Unmarshal(resultJSON, &resp)
+
+		assert.Equal(t, false, resp["applied"])
+		assert.Equal(t, false, resp["broadcast"])
+		assert.Equal(t, false, resp["kept"])
+		assert.Equal(t, false, resp["queued"])
+		assert.Equal(t, false, resp["accepted"],
+			"accepted should be false when nothing is true")
+	})
+
+	t.Run("Queued only - accepted=true, applied=false", func(t *testing.T) {
+		mock.submitResult = &types.SubmitResult{
+			EngineResult:        "terQUEUED",
+			EngineResultCode:    -89,
+			EngineResultMessage: "Held until escalated fee drops.",
+			Applied:             false,
+			Broadcast:           false,
+			Kept:                false,
+			Queued:              true,
+			ValidatedLedger:     2,
+		}
+
+		params := map[string]interface{}{"tx_json": baseTxJson}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+
+		resultJSON, _ := json.Marshal(result)
+		var resp map[string]interface{}
+		json.Unmarshal(resultJSON, &resp)
+
+		assert.Equal(t, false, resp["applied"])
+		assert.Equal(t, false, resp["broadcast"])
+		assert.Equal(t, false, resp["kept"])
+		assert.Equal(t, true, resp["queued"])
+		assert.Equal(t, true, resp["accepted"],
+			"accepted should be true when queued is true (any() = true)")
+	})
+}

--- a/internal/rpc/tx_history_test.go
+++ b/internal/rpc/tx_history_test.go
@@ -66,7 +66,7 @@ func TestTxHistoryBasicRequest(t *testing.T) {
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
-		Role:       types.RoleGuest,
+		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
 	}
 
@@ -146,7 +146,7 @@ func TestTxHistoryEmptyResult(t *testing.T) {
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
-		Role:       types.RoleGuest,
+		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
 	}
 
@@ -184,7 +184,7 @@ func TestTxHistoryResponseStructure(t *testing.T) {
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
-		Role:       types.RoleGuest,
+		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
 	}
 
@@ -230,7 +230,7 @@ func TestTxHistoryDatabaseNotConfigured(t *testing.T) {
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
-		Role:       types.RoleGuest,
+		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
 	}
 
@@ -253,7 +253,7 @@ func TestTxHistoryServiceUnavailable(t *testing.T) {
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
-		Role:       types.RoleGuest,
+		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
 	}
 
@@ -303,7 +303,7 @@ func TestTxHistoryInternalError(t *testing.T) {
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
-		Role:       types.RoleGuest,
+		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
 	}
 
@@ -326,8 +326,8 @@ func TestTxHistoryMethodMetadata(t *testing.T) {
 	method := &handlers.TxHistoryMethod{}
 
 	t.Run("RequiredRole", func(t *testing.T) {
-		assert.Equal(t, types.RoleGuest, method.RequiredRole(),
-			"tx_history should be accessible to guests")
+		assert.Equal(t, types.RoleUser, method.RequiredRole(),
+			"tx_history requires Role::USER per rippled Handler.cpp")
 	})
 
 	t.Run("SupportedApiVersions", func(t *testing.T) {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -168,7 +168,10 @@ type LedgerServerInfo struct {
 	NetworkID           uint32
 }
 
-// SubmitResult contains the result of submitting a transaction
+// SubmitResult contains the result of submitting a transaction.
+// The boolean fields match rippled's Transaction::SubmitResult struct:
+// applied, broadcast, queued, kept are independent pipeline states.
+// "accepted" in rippled is derived as: applied || broadcast || queued || kept.
 type SubmitResult struct {
 	// EngineResult is the result code string (e.g., "tesSUCCESS")
 	EngineResult string
@@ -179,8 +182,17 @@ type SubmitResult struct {
 	// EngineResultMessage is a human-readable result message
 	EngineResultMessage string
 
-	// Applied indicates if the transaction was applied to the ledger
+	// Applied indicates if the transaction was applied to the open ledger
 	Applied bool
+
+	// Broadcast indicates if the transaction was broadcast to peers
+	Broadcast bool
+
+	// Queued indicates if the transaction was placed in the transaction queue
+	Queued bool
+
+	// Kept indicates if the transaction was kept for retry
+	Kept bool
 
 	// Fee is the fee charged (in drops)
 	Fee uint64
@@ -190,6 +202,12 @@ type SubmitResult struct {
 
 	// ValidatedLedger is the highest validated ledger sequence
 	ValidatedLedger uint32
+}
+
+// Accepted returns true if any submission state is true, matching
+// rippled's SubmitResult::any() method.
+func (r *SubmitResult) Accepted() bool {
+	return r.Applied || r.Broadcast || r.Queued || r.Kept
 }
 
 // TransactionInfo contains transaction data and metadata


### PR DESCRIPTION
## Summary
- **submit** (#95): independent boolean fields (`accepted`/`broadcast`/`queued`/`kept`), DeliverMax injection for Payments, v2 hash at root level
- **tx_history** (#98): `RequiredRole` → `RoleUser` matching rippled `Role::USER`
- **ledger_data** (#101): uppercase hex hashes, limit clamping (JSON max 256, binary max 2048), limit-only-with-marker
- **ledger_entry** (#102): hex index fallback for all entry types, 5 new entry types (bridge, vault, delegate, xchain_owned_claim_id, xchain_owned_create_account_claim_id), `ticket_seq` field name fix
- **ledger_header** (#103): full header JSON fields, 118-byte binary format matching rippled's `addRaw()`, `close_time_estimated` flag
- **server_info/state** (#105): shared `buildServerInfo(human)`, `hostid`, `build_version`, `time`, `load_factor`, `last_close`, `published_ledger`, `server_state_duration_us`, machine-format fields for server_state
- **ripple_path_find** (#112): `destination_amount`, `source_account`, `full_reply`, `paths_canonical`, `formatAmountJSON` helper
- **wallet_propose** (#115): passphrase warning logic matches rippled (skip if passphrase equals seed encoding)
- **channel_authorize/verify** (#116): already conformant — key_type and channel_id validation were in place

## Test plan
- [x] All RPC tests pass (`go test -count=1 ./internal/rpc/...`)
- [x] `go vet ./internal/rpc/...` clean
- [x] New tests for ledger_header (9 tests), submit v2/DeliverMax (3 tests), ledger_entry hex fallback (12 tests)
- [x] Role catalogue updated (tx_history moved guest→user)

Closes #95, closes #98, closes #101, closes #102, closes #103, closes #105, closes #112, closes #115, closes #116