### PR TITLE
fix(rpc): batch 4 conformance fixes for 3 handlers

### DIFF
--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -4,11 +4,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
+	"time"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
-	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/keylet"
 )
 
 // AMMInfoMethod handles the amm_info RPC method
@@ -131,6 +133,11 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	if tradingFee, ok := decoded["TradingFee"]; ok {
 		ammResult["trading_fee"] = tradingFee
 	}
+
+	// TODO: amount/amount2 currently return the asset issue definitions from the AMM SLE
+	// (sfAsset/sfAsset2), not the actual pool balances. Rippled calls ammPoolHolds() to
+	// get real balances from trust lines, which requires service-layer trust line lookups.
+	// Similarly, asset_frozen/asset2_frozen require isFrozen() calls on trust lines.
 	if asset, ok := decoded["Asset"]; ok {
 		ammResult["amount"] = asset
 	}
@@ -163,35 +170,24 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		}
 	}
 
+	// Resolve parentCloseTime from the ledger for auction slot time_interval computation.
+	// rippled: ammAuctionTimeSlot(ledger->info().parentCloseTime, auctionSlot)
+	var parentCloseTime uint64
+	if ammEntry.LedgerIndex > 0 {
+		if lr, lrErr := types.Services.Ledger.GetLedgerBySequence(ammEntry.LedgerIndex); lrErr == nil && lr != nil {
+			pct := lr.ParentCloseTime()
+			if pct > 0 {
+				parentCloseTime = uint64(pct)
+			}
+		}
+	}
+
 	// Handle auction slot
 	if auctionSlot, ok := decoded["AuctionSlot"].(map[string]interface{}); ok {
-		auction := make(map[string]interface{})
-		if account, ok := auctionSlot["Account"].(string); ok {
-			auction["account"] = account
+		auction := buildAuctionSlot(auctionSlot, parentCloseTime)
+		if auction != nil {
+			ammResult["auction_slot"] = auction
 		}
-		if price, ok := auctionSlot["Price"]; ok {
-			auction["price"] = price
-		}
-		if discountedFee, ok := auctionSlot["DiscountedFee"]; ok {
-			auction["discounted_fee"] = discountedFee
-		}
-		if expiration, ok := auctionSlot["Expiration"]; ok {
-			auction["expiration"] = expiration
-		}
-		if authAccounts, ok := auctionSlot["AuthAccounts"].([]interface{}); ok {
-			auth := make([]map[string]interface{}, 0, len(authAccounts))
-			for _, aa := range authAccounts {
-				if authAccount, ok := aa.(map[string]interface{}); ok {
-					if account, ok := authAccount["Account"].(string); ok {
-						auth = append(auth, map[string]interface{}{"account": account})
-					}
-				}
-			}
-			if len(auth) > 0 {
-				auction["auth_accounts"] = auth
-			}
-		}
-		ammResult["auction_slot"] = auction
 	}
 
 	// Build final response
@@ -206,6 +202,128 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	}
 
 	return response, nil
+}
+
+// Auction slot constants matching rippled's AMMCore.h
+const (
+	totalTimeSlotSecs           = 24 * 3600           // 86400 seconds
+	auctionSlotTimeIntervals    = 20                   // number of intervals
+	auctionSlotIntervalDuration = totalTimeSlotSecs / auctionSlotTimeIntervals // 4320 seconds
+)
+
+// rippleEpochOffset is the number of seconds between Unix epoch (1970-01-01)
+// and Ripple epoch (2000-01-01): 946684800 seconds.
+const rippleEpochOffset = 946684800
+
+// rippleEpochToISO8601 converts a Ripple epoch timestamp to an ISO 8601 string.
+// Matches rippled's to_iso8601() in AMMInfo.cpp.
+func rippleEpochToISO8601(rippleSeconds uint32) string {
+	unixTime := int64(rippleSeconds) + rippleEpochOffset
+	t := time.Unix(unixTime, 0).UTC()
+	return t.Format("2006-01-02T15:04:05+0000")
+}
+
+// ammAuctionTimeSlot computes the current time interval for the auction slot.
+// Returns the interval index (0..19) or auctionSlotTimeIntervals if expired/not started.
+// Matches rippled's ammAuctionTimeSlot() in AMMCore.cpp.
+func ammAuctionTimeSlot(currentParentCloseTime uint64, expiration uint32) uint32 {
+	if expiration >= totalTimeSlotSecs {
+		start := uint64(expiration) - totalTimeSlotSecs
+		if currentParentCloseTime >= start {
+			diff := currentParentCloseTime - start
+			if diff < totalTimeSlotSecs {
+				return uint32(diff / auctionSlotIntervalDuration)
+			}
+		}
+	}
+	return auctionSlotTimeIntervals
+}
+
+// buildAuctionSlot constructs the auction_slot response object from decoded AMM SLE fields.
+// Only includes the slot if it has an Account (rippled checks isFieldPresent(sfAccount)).
+func buildAuctionSlot(auctionSlot map[string]interface{}, parentCloseTime uint64) map[string]interface{} {
+	account, ok := auctionSlot["Account"].(string)
+	if !ok || account == "" {
+		// rippled: only includes auction_slot if auctionSlot.isFieldPresent(sfAccount)
+		return nil
+	}
+
+	auction := make(map[string]interface{})
+	auction["account"] = account
+
+	if price, ok := auctionSlot["Price"]; ok {
+		auction["price"] = price
+	}
+	if discountedFee, ok := auctionSlot["DiscountedFee"]; ok {
+		auction["discounted_fee"] = discountedFee
+	}
+
+	// Convert expiration from Ripple epoch uint32 to ISO 8601 string.
+	// rippled: auction[jss::expiration] = to_iso8601(NetClock::time_point{...})
+	var expirationUint32 uint32
+	if exp, ok := auctionSlot["Expiration"]; ok {
+		expirationUint32 = toUint32(exp)
+		auction["expiration"] = rippleEpochToISO8601(expirationUint32)
+	}
+
+	// Compute time_interval.
+	// rippled: ammAuctionTimeSlot(parentCloseTime, auctionSlot) → interval or AUCTION_SLOT_TIME_INTERVALS
+	auction["time_interval"] = ammAuctionTimeSlot(parentCloseTime, expirationUint32)
+
+	// Handle auth_accounts — each element is wrapped in an AuthAccount inner object:
+	// decoded: [{"AuthAccount": {"Account": "rXXX"}}, ...]
+	// rippled output: [{"account": "rXXX"}, ...]
+	if authAccounts, ok := auctionSlot["AuthAccounts"].([]interface{}); ok {
+		auth := make([]map[string]interface{}, 0, len(authAccounts))
+		for _, aa := range authAccounts {
+			if wrapper, ok := aa.(map[string]interface{}); ok {
+				// Unwrap the AuthAccount inner object
+				inner, ok := wrapper["AuthAccount"].(map[string]interface{})
+				if !ok {
+					// Fallback: try direct Account field (in case codec doesn't wrap)
+					inner = wrapper
+				}
+				if acct, ok := inner["Account"].(string); ok {
+					auth = append(auth, map[string]interface{}{"account": acct})
+				}
+			}
+		}
+		if len(auth) > 0 {
+			auction["auth_accounts"] = auth
+		}
+	}
+
+	return auction
+}
+
+// toUint32 extracts a uint32 from a JSON-decoded numeric value.
+// The binary codec may return float64 or json.Number depending on decode mode.
+func toUint32(v interface{}) uint32 {
+	switch n := v.(type) {
+	case float64:
+		if n >= 0 && n <= math.MaxUint32 {
+			return uint32(n)
+		}
+	case json.Number:
+		if i, err := n.Int64(); err == nil && i >= 0 && i <= math.MaxUint32 {
+			return uint32(i)
+		}
+	case int:
+		if n >= 0 {
+			return uint32(n)
+		}
+	case int64:
+		if n >= 0 && n <= math.MaxUint32 {
+			return uint32(n)
+		}
+	case uint32:
+		return n
+	case uint64:
+		if n <= math.MaxUint32 {
+			return uint32(n)
+		}
+	}
+	return 0
 }
 
 // parseIssue parses an asset/issue from the JSON representation

--- a/internal/rpc/handlers/amm_info_test.go
+++ b/internal/rpc/handlers/amm_info_test.go
@@ -1,0 +1,235 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// =============================================================================
+// rippleEpochToISO8601 Tests
+// =============================================================================
+
+func TestRippleEpochToISO8601_Epoch(t *testing.T) {
+	// Ripple epoch 0 = 2000-01-01T00:00:00 UTC
+	result := rippleEpochToISO8601(0)
+	assert.Equal(t, "2000-01-01T00:00:00+0000", result)
+}
+
+func TestRippleEpochToISO8601_KnownTimestamp(t *testing.T) {
+	// 86400 seconds = 1 day after Ripple epoch = 2000-01-02T00:00:00 UTC
+	result := rippleEpochToISO8601(86400)
+	assert.Equal(t, "2000-01-02T00:00:00+0000", result)
+}
+
+func TestRippleEpochToISO8601_RecentTimestamp(t *testing.T) {
+	// 776000030 seconds after Ripple epoch = approx 2024
+	result := rippleEpochToISO8601(776000030)
+	// Just check it's a valid format, not empty
+	assert.NotEmpty(t, result)
+	assert.Contains(t, result, "T")
+	assert.Contains(t, result, "+0000")
+}
+
+// =============================================================================
+// ammAuctionTimeSlot Tests
+// Based on rippled's ammAuctionTimeSlot() in AMMCore.cpp
+// =============================================================================
+
+func TestAmmAuctionTimeSlot_ActiveSlot(t *testing.T) {
+	// Auction expiration = 86400 + 86400 = 172800 (start = 86400)
+	// parentCloseTime = 86400 + 4320 = 90720 (interval 1)
+	expiration := uint32(172800) // start + totalTimeSlotSecs
+	pct := uint64(90720)        // start + 1 interval
+	interval := ammAuctionTimeSlot(pct, expiration)
+	assert.Equal(t, uint32(1), interval)
+}
+
+func TestAmmAuctionTimeSlot_FirstInterval(t *testing.T) {
+	expiration := uint32(172800) // start=86400
+	pct := uint64(86400)        // exactly at start
+	interval := ammAuctionTimeSlot(pct, expiration)
+	assert.Equal(t, uint32(0), interval)
+}
+
+func TestAmmAuctionTimeSlot_LastInterval(t *testing.T) {
+	expiration := uint32(172800)             // start=86400
+	pct := uint64(172800 - 1)                // just before expiration
+	interval := ammAuctionTimeSlot(pct, expiration)
+	assert.Equal(t, uint32(19), interval, "Last valid interval should be 19")
+}
+
+func TestAmmAuctionTimeSlot_Expired(t *testing.T) {
+	expiration := uint32(172800)
+	pct := uint64(172800) // at expiration = diff == totalTimeSlotSecs → not < totalTimeSlotSecs
+	interval := ammAuctionTimeSlot(pct, expiration)
+	assert.Equal(t, uint32(auctionSlotTimeIntervals), interval, "Expired should return 20")
+}
+
+func TestAmmAuctionTimeSlot_NotStarted(t *testing.T) {
+	expiration := uint32(172800)
+	pct := uint64(86399) // before start
+	interval := ammAuctionTimeSlot(pct, expiration)
+	assert.Equal(t, uint32(auctionSlotTimeIntervals), interval, "Not started should return 20")
+}
+
+func TestAmmAuctionTimeSlot_ExpirationTooSmall(t *testing.T) {
+	// If expiration < totalTimeSlotSecs, return auctionSlotTimeIntervals
+	interval := ammAuctionTimeSlot(100, 100)
+	assert.Equal(t, uint32(auctionSlotTimeIntervals), interval)
+}
+
+func TestAmmAuctionTimeSlot_ZeroParentCloseTime(t *testing.T) {
+	expiration := uint32(172800) // start=86400
+	interval := ammAuctionTimeSlot(0, expiration)
+	assert.Equal(t, uint32(auctionSlotTimeIntervals), interval, "Before start should return 20")
+}
+
+// =============================================================================
+// toUint32 Tests
+// =============================================================================
+
+func TestToUint32_Float64(t *testing.T) {
+	assert.Equal(t, uint32(42), toUint32(float64(42)))
+	assert.Equal(t, uint32(0), toUint32(float64(-1)))
+	assert.Equal(t, uint32(0), toUint32(float64(5000000000))) // > MaxUint32
+}
+
+func TestToUint32_Int(t *testing.T) {
+	assert.Equal(t, uint32(100), toUint32(int(100)))
+	assert.Equal(t, uint32(0), toUint32(int(-1)))
+}
+
+func TestToUint32_Int64(t *testing.T) {
+	assert.Equal(t, uint32(200), toUint32(int64(200)))
+	assert.Equal(t, uint32(0), toUint32(int64(-1)))
+	assert.Equal(t, uint32(0), toUint32(int64(5000000000))) // > MaxUint32
+}
+
+func TestToUint32_Uint32(t *testing.T) {
+	assert.Equal(t, uint32(300), toUint32(uint32(300)))
+}
+
+func TestToUint32_Uint64(t *testing.T) {
+	assert.Equal(t, uint32(400), toUint32(uint64(400)))
+	assert.Equal(t, uint32(0), toUint32(uint64(5000000000))) // > MaxUint32
+}
+
+func TestToUint32_Unsupported(t *testing.T) {
+	assert.Equal(t, uint32(0), toUint32("string"))
+	assert.Equal(t, uint32(0), toUint32(nil))
+	assert.Equal(t, uint32(0), toUint32(true))
+}
+
+// =============================================================================
+// buildAuctionSlot Tests
+// =============================================================================
+
+func TestBuildAuctionSlot_NoAccount(t *testing.T) {
+	// rippled: only includes auction_slot if Account is present
+	slot := map[string]interface{}{
+		"Price":         map[string]interface{}{"value": "0", "currency": "03000000000000000000000000000000000000C0", "issuer": "rSomeAddr"},
+		"DiscountedFee": float64(0),
+		"Expiration":    float64(172800),
+	}
+	result := buildAuctionSlot(slot, 100000)
+	assert.Nil(t, result, "No Account should return nil")
+}
+
+func TestBuildAuctionSlot_WithAccount(t *testing.T) {
+	slot := map[string]interface{}{
+		"Account":       "rTestAccount123",
+		"Price":         map[string]interface{}{"value": "100", "currency": "LPT", "issuer": "rIssuer"},
+		"DiscountedFee": float64(50),
+		"Expiration":    float64(172800),
+	}
+
+	result := buildAuctionSlot(slot, 90720) // interval 1
+
+	assert.NotNil(t, result)
+	assert.Equal(t, "rTestAccount123", result["account"])
+	assert.NotNil(t, result["price"])
+	assert.Equal(t, float64(50), result["discounted_fee"])
+	// Expiration should be ISO 8601 string, not raw number
+	expStr, ok := result["expiration"].(string)
+	assert.True(t, ok, "expiration should be a string")
+	assert.Contains(t, expStr, "T")
+	assert.Contains(t, expStr, "+0000")
+	// time_interval should be computed
+	assert.Equal(t, uint32(1), result["time_interval"])
+}
+
+func TestBuildAuctionSlot_AuthAccountsUnwrapped(t *testing.T) {
+	// Binary codec returns: [{"AuthAccount": {"Account": "rXXX"}}]
+	slot := map[string]interface{}{
+		"Account":    "rSlotHolder",
+		"Expiration": float64(172800),
+		"AuthAccounts": []interface{}{
+			map[string]interface{}{
+				"AuthAccount": map[string]interface{}{
+					"Account": "rAuth1",
+				},
+			},
+			map[string]interface{}{
+				"AuthAccount": map[string]interface{}{
+					"Account": "rAuth2",
+				},
+			},
+		},
+	}
+
+	result := buildAuctionSlot(slot, 0)
+	assert.NotNil(t, result)
+
+	auth, ok := result["auth_accounts"].([]map[string]interface{})
+	assert.True(t, ok, "auth_accounts should be present")
+	assert.Len(t, auth, 2)
+	assert.Equal(t, "rAuth1", auth[0]["account"])
+	assert.Equal(t, "rAuth2", auth[1]["account"])
+}
+
+func TestBuildAuctionSlot_AuthAccountsFallback(t *testing.T) {
+	// Edge case: codec returns flat structure without AuthAccount wrapper
+	slot := map[string]interface{}{
+		"Account":    "rSlotHolder",
+		"Expiration": float64(172800),
+		"AuthAccounts": []interface{}{
+			map[string]interface{}{
+				"Account": "rAuth1",
+			},
+		},
+	}
+
+	result := buildAuctionSlot(slot, 0)
+	assert.NotNil(t, result)
+
+	auth, ok := result["auth_accounts"].([]map[string]interface{})
+	assert.True(t, ok, "auth_accounts should be present via fallback")
+	assert.Len(t, auth, 1)
+	assert.Equal(t, "rAuth1", auth[0]["account"])
+}
+
+func TestBuildAuctionSlot_ExpirationISO8601(t *testing.T) {
+	// Verify the exact ISO 8601 format for a known timestamp
+	// Ripple epoch 86400 = 2000-01-02T00:00:00 UTC
+	slot := map[string]interface{}{
+		"Account":    "rTest",
+		"Expiration": float64(86400),
+	}
+
+	result := buildAuctionSlot(slot, 0)
+	assert.NotNil(t, result)
+	assert.Equal(t, "2000-01-02T00:00:00+0000", result["expiration"])
+}
+
+func TestBuildAuctionSlot_TimeIntervalExpired(t *testing.T) {
+	// parentCloseTime well past expiration
+	slot := map[string]interface{}{
+		"Account":    "rTest",
+		"Expiration": float64(172800),
+	}
+
+	result := buildAuctionSlot(slot, 300000)
+	assert.NotNil(t, result)
+	assert.Equal(t, uint32(20), result["time_interval"], "Expired auction should return 20")
+}

--- a/internal/rpc/handlers/sign.go
+++ b/internal/rpc/handlers/sign.go
@@ -11,6 +11,13 @@ import (
 type SignMethod struct{}
 
 func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
+	// Parse fee_mult_max / fee_div_max first with proper type validation,
+	// matching rippled's checkFee() in TransactionSign.cpp.
+	feeOpts, rpcErr := parseFeeOptions(params)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
 	var request struct {
 		TxJson     json.RawMessage `json:"tx_json"`
 		Secret     string          `json:"secret,omitempty"`
@@ -20,8 +27,6 @@ func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inte
 		KeyType    string          `json:"key_type,omitempty"`
 		Offline    bool            `json:"offline,omitempty"`
 		BuildPath  bool            `json:"build_path,omitempty"`
-		FeeMultMax uint32          `json:"fee_mult_max,omitempty"`
-		FeeDivMax  uint32          `json:"fee_div_max,omitempty"`
 	}
 
 	if params != nil {
@@ -41,14 +46,26 @@ func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inte
 		SeedHex:    request.SeedHex,
 		Passphrase: request.Passphrase,
 		KeyType:    request.KeyType,
-	}, request.Offline, ctx.ApiVersion)
+	}, request.Offline, ctx.ApiVersion, feeOpts)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
 
+	// Inject DeliverMax for Payment transactions, matching rippled's
+	// RPC::insertDeliverMax in transactionFormatResultImpl.
+	injectDeliverMax(signed.TxMap, ctx.ApiVersion)
+
 	response := map[string]interface{}{
 		"tx_blob": signed.TxBlob,
 		"tx_json": signed.TxMap,
+	}
+
+	// API v2+: add hash at root level of response, matching rippled's
+	// transactionFormatResultImpl in TransactionSign.cpp.
+	if ctx.ApiVersion > 1 {
+		if hash, ok := signed.TxMap["hash"].(string); ok {
+			response["hash"] = hash
+		}
 	}
 
 	return response, nil

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -166,9 +166,19 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	// Add hash to response tx_json
 	txMap["hash"] = txHash
 
+	// Inject DeliverMax for Payment transactions, matching rippled's
+	// RPC::insertDeliverMax in transactionFormatResultImpl.
+	injectDeliverMax(txMap, ctx.ApiVersion)
+
 	response := map[string]interface{}{
 		"tx_blob": txBlob,
 		"tx_json": txMap,
+	}
+
+	// API v2+: add hash at root level of response, matching rippled's
+	// transactionFormatResultImpl in TransactionSign.cpp.
+	if ctx.ApiVersion > 1 {
+		response["hash"] = txHash
 	}
 
 	return response, nil

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -1,7 +1,11 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -19,6 +23,119 @@ type signCredentials struct {
 	KeyType    string
 }
 
+// feeOptions holds the fee_mult_max and fee_div_max parameters for auto-fee.
+// These control the maximum fee the auto-fill logic will accept.
+//
+// Defaults match rippled (Tuning.h):
+//   - defaultAutoFillFeeMultiplier = 10
+//   - defaultAutoFillFeeDivisor = 1
+//
+// The auto-filled fee is capped at: baseFee * mult / div
+// If the network fee exceeds that limit, rpcHIGH_FEE is returned.
+type feeOptions struct {
+	Mult int // fee_mult_max (default 10)
+	Div  int // fee_div_max (default 1)
+}
+
+// defaultFeeOptions returns fee options with rippled's defaults.
+func defaultFeeOptions() feeOptions {
+	return feeOptions{Mult: 10, Div: 1}
+}
+
+// parseFeeOptions extracts and validates fee_mult_max and fee_div_max from
+// the raw RPC params. Returns the parsed options or an error matching
+// rippled's exact error codes:
+//   - Non-integer fee_mult_max → rpcHIGH_FEE with expected_field_message
+//   - Negative fee_mult_max    → rpcINVALID_PARAMS with expected_field_message
+//   - Non-integer fee_div_max  → rpcHIGH_FEE with expected_field_message
+//   - Non-positive fee_div_max → rpcINVALID_PARAMS with expected_field_message
+func parseFeeOptions(params json.RawMessage) (feeOptions, *types.RpcError) {
+	opts := defaultFeeOptions()
+
+	if len(params) == 0 {
+		return opts, nil
+	}
+
+	// Parse into a generic map to inspect types
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(params, &raw); err != nil {
+		return opts, nil // If we can't parse, let the main handler catch it
+	}
+
+	// Parse fee_mult_max
+	if multRaw, ok := raw["fee_mult_max"]; ok {
+		mult, err := parsePositiveIntParam(multRaw, "fee_mult_max", false)
+		if err != nil {
+			return opts, err
+		}
+		opts.Mult = mult
+	}
+
+	// Parse fee_div_max
+	if divRaw, ok := raw["fee_div_max"]; ok {
+		div, err := parsePositiveIntParam(divRaw, "fee_div_max", true)
+		if err != nil {
+			return opts, err
+		}
+		opts.Div = div
+	}
+
+	return opts, nil
+}
+
+// parsePositiveIntParam validates a JSON value as a positive integer.
+// strictPositive=true means the value must be > 0 (for fee_div_max);
+// strictPositive=false means the value must be >= 0 (for fee_mult_max).
+//
+// Matches rippled's checkFee() validation:
+//   - If not an integer type → rpcHIGH_FEE
+//   - If negative (or <=0 for strictPositive) → rpcINVALID_PARAMS
+func parsePositiveIntParam(raw json.RawMessage, fieldName string, strictPositive bool) (int, *types.RpcError) {
+	// Try to parse as a number
+	var num json.Number
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&num); err != nil {
+		// Not a valid JSON number → rpcHIGH_FEE
+		return 0, types.RpcErrorExpectedFieldHighFee(fieldName, "a positive integer")
+	}
+
+	// Check if it's an integer (no decimal point, no exponent notation)
+	str := num.String()
+	val, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		// Could be a float like "1.5" or too large
+		// Check if it's a float
+		if _, fErr := strconv.ParseFloat(str, 64); fErr == nil {
+			// It's a valid float but not an integer → rpcHIGH_FEE
+			return 0, types.RpcErrorExpectedFieldHighFee(fieldName, "a positive integer")
+		}
+		// Not a number at all → rpcHIGH_FEE
+		return 0, types.RpcErrorExpectedFieldHighFee(fieldName, "a positive integer")
+	}
+
+	// Range check
+	if val > math.MaxInt32 || val < math.MinInt32 {
+		return 0, types.RpcErrorExpectedFieldHighFee(fieldName, "a positive integer")
+	}
+
+	intVal := int(val)
+
+	if strictPositive {
+		// fee_div_max must be > 0
+		if intVal <= 0 {
+			return 0, types.RpcErrorExpectedField(fieldName, "a positive integer")
+		}
+	} else {
+		// fee_mult_max must be >= 0 (rippled checks mult < 0)
+		if intVal < 0 {
+			return 0, types.RpcErrorExpectedField(fieldName, "a positive integer")
+		}
+	}
+
+	return intVal, nil
+}
+
 // signResult holds the output of the signing operation.
 type signResult struct {
 	TxMap  map[string]interface{} // The transaction JSON map with SigningPubKey, TxnSignature, and hash
@@ -29,7 +146,11 @@ type signResult struct {
 // keypair, auto-fills missing fields (unless offline), signs the transaction,
 // and returns the signed tx map + blob. This is the shared logic used by both
 // the "sign" and "submit" RPC methods.
-func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline bool, apiVersion int) (*signResult, *types.RpcError) {
+//
+// The feeOpts parameter controls auto-fee behavior: if Fee is not present in
+// tx_json and auto-fill is active, the network fee is computed and checked
+// against the limit baseFee * feeOpts.Mult / feeOpts.Div.
+func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline bool, apiVersion int, feeOpts feeOptions) (*signResult, *types.RpcError) {
 	// Check if ledger service is available (needed for auto-filling fields)
 	if !offline && (types.Services == nil || types.Services.Ledger == nil) {
 		return nil, types.RpcErrorInternal("Ledger service not available")
@@ -72,15 +193,32 @@ func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline 
 
 	// Fill in missing fields if not offline
 	if !offline {
-		// Set Fee if not present
+		// Auto-fill Fee if not present, with fee_mult_max/fee_div_max limit check.
+		// This matches rippled's checkFee() in TransactionSign.cpp.
 		if _, ok := txMap["Fee"]; !ok {
 			baseFee, _, _ := types.Services.Ledger.GetCurrentFees()
-			txMap["Fee"] = formatUint64AsString(baseFee)
+
+			// In a full implementation, networkFee would incorporate load-based
+			// fee escalation. For now, networkFee == baseFee.
+			networkFee := baseFee
+
+			// Compute the fee limit: baseFee * mult / div
+			// This matches rippled's mulDiv(feeDefault, mult, div).
+			limit := baseFee * uint64(feeOpts.Mult) / uint64(feeOpts.Div)
+
+			if networkFee > limit {
+				return nil, types.RpcErrorHighFee(
+					fmt.Sprintf("Fee of %d exceeds the requested tx limit of %d",
+						networkFee, limit))
+			}
+
+			txMap["Fee"] = formatUint64AsString(networkFee)
 		}
 
 		// Set Sequence if not present
 		if _, ok := txMap["Sequence"]; !ok {
-			// Get account info to find current sequence
+			// TODO: When ledger lookup is available, auto-fill from account state.
+			// For now, attempt to get account info.
 			info, err := types.Services.Ledger.GetAccountInfo(address, "current")
 			if err != nil {
 				return nil, types.RpcErrorInternal("Failed to get account sequence: " + err.Error())

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -16,6 +16,13 @@ import (
 type SubmitMethod struct{}
 
 func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
+	// Parse fee_mult_max / fee_div_max first with proper type validation,
+	// matching rippled's checkFee() in TransactionSign.cpp.
+	feeOpts, feeErr := parseFeeOptions(params)
+	if feeErr != nil {
+		return nil, feeErr
+	}
+
 	var request struct {
 		TxBlob     string          `json:"tx_blob,omitempty"`
 		TxJson     json.RawMessage `json:"tx_json,omitempty"`
@@ -27,8 +34,6 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		FailHard   bool            `json:"fail_hard,omitempty"`
 		Offline    bool            `json:"offline,omitempty"`
 		BuildPath  bool            `json:"build_path,omitempty"`
-		FeeMultMax uint32          `json:"fee_mult_max,omitempty"`
-		FeeDivMax  uint32          `json:"fee_div_max,omitempty"`
 	}
 
 	if err := ParseParams(params, &request); err != nil {
@@ -73,7 +78,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 			SeedHex:    request.SeedHex,
 			Passphrase: request.Passphrase,
 			KeyType:    request.KeyType,
-		}, request.Offline, ctx.ApiVersion)
+		}, request.Offline, ctx.ApiVersion, feeOpts)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"strconv"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -35,33 +36,94 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorInvalidParams("Invalid tx_json: " + err.Error())
 	}
 
-	// Validate required fields for multi-signed transaction
-	if _, ok := txMap["Account"]; !ok {
-		return nil, types.RpcErrorMissingField("Account")
+	// --- checkMultiSignFields (rippled TransactionSign.cpp:1032-1057) ---
+
+	// Sequence must be present.
+	// Matches rippled: missing_field_error("tx_json.Sequence")
+	if _, ok := txMap["Sequence"]; !ok {
+		return nil, types.RpcErrorMissingField("tx_json.Sequence")
 	}
 
-	// Check that SigningPubKey is empty (required for multi-signed transactions)
-	if signingPubKey, ok := txMap["SigningPubKey"].(string); !ok || signingPubKey != "" {
-		return nil, types.RpcErrorInvalidParams("Multi-signed transactions must have empty SigningPubKey")
+	// Validate that Sequence is a valid number (JSON numbers unmarshal as float64).
+	switch seq := txMap["Sequence"].(type) {
+	case float64:
+		if seq < 0 || seq != float64(int64(seq)) {
+			return nil, types.RpcErrorInvalidField("tx_json.Sequence")
+		}
+	case json.Number:
+		if _, err := seq.Int64(); err != nil {
+			return nil, types.RpcErrorInvalidField("tx_json.Sequence")
+		}
+	default:
+		return nil, types.RpcErrorInvalidField("tx_json.Sequence")
+	}
+
+	// SigningPubKey must be present and empty.
+	// Matches rippled: missing_field_error("tx_json.SigningPubKey") /
+	// "When multi-signing 'tx_json.SigningPubKey' must be empty."
+	signingPubKey, spkPresent := txMap["SigningPubKey"]
+	if !spkPresent {
+		return nil, types.RpcErrorMissingField("tx_json.SigningPubKey")
+	}
+	if spkStr, ok := signingPubKey.(string); !ok || spkStr != "" {
+		return nil, types.RpcErrorInvalidParams("When multi-signing 'tx_json.SigningPubKey' must be empty.")
+	}
+
+	// --- checkTxJsonFields (rippled TransactionSign.cpp:315-375) ---
+
+	// Validate required fields for multi-signed transaction
+	if _, ok := txMap["Account"]; !ok {
+		return nil, types.RpcErrorMissingField("tx_json.Account")
+	}
+
+	// Get the source account address for self-signing detection later.
+	txAccount, _ := txMap["Account"].(string)
+
+	// --- Post-serialization validation (rippled TransactionSign.cpp:1325-1391) ---
+
+	// TxnSignature must NOT be present on a multi-signed transaction.
+	// Matches rippled: rpcError(rpcSIGNING_MALFORMED) -> code 63, "signingMalformed"
+	if _, ok := txMap["TxnSignature"]; ok {
+		return nil, types.RpcErrorSigningMalformed()
+	}
+
+	// Fee must be present, must be XRP drops (string of digits), and must be > 0.
+	// Matches rippled: "Invalid Fee field.  Fees must be specified in XRP." /
+	// "Invalid Fee field.  Fees must be greater than zero."
+	feeVal, feePresent := txMap["Fee"]
+	if !feePresent {
+		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be specified in XRP.")
+	}
+	feeStr, ok := feeVal.(string)
+	if !ok {
+		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be specified in XRP.")
+	}
+	feeDrops, err := strconv.ParseInt(feeStr, 10, 64)
+	if err != nil {
+		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be specified in XRP.")
+	}
+	if feeDrops <= 0 {
+		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be greater than zero.")
 	}
 
 	// Check that Signers array exists and is not empty
 	signers, ok := txMap["Signers"].([]interface{})
 	if !ok || len(signers) == 0 {
-		return nil, types.RpcErrorInvalidParams("Multi-signed transaction must have at least one Signer")
+		return nil, types.RpcErrorInvalidParams("tx_json.Signers array may not be empty.")
 	}
 
-	// Validate signer entries
+	// Validate signer entries and collect accounts for duplicate/self-sign checks
+	seenAccounts := make(map[string]bool, len(signers))
 	var prevAccount string
 	for i, signerEntry := range signers {
 		signerWrapper, ok := signerEntry.(map[string]interface{})
 		if !ok {
-			return nil, types.RpcErrorInvalidParams("Invalid Signer entry format")
+			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
 		}
 
 		signer, ok := signerWrapper["Signer"].(map[string]interface{})
 		if !ok {
-			return nil, types.RpcErrorInvalidParams("Invalid Signer entry format")
+			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
 		}
 
 		// Check required signer fields
@@ -82,28 +144,49 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		if i > 0 && account < prevAccount {
 			return nil, types.RpcErrorInvalidParams("Signers must be sorted by Account")
 		}
+
+		// Duplicate signer detection.
+		// Matches rippled sortAndValidateSigners: "Duplicate Signers:Signer:Account entries (<addr>) are not allowed."
+		if seenAccounts[account] {
+			return nil, types.RpcErrorInvalidParams(
+				"Duplicate Signers:Signer:Account entries (" + account + ") are not allowed.")
+		}
+		seenAccounts[account] = true
+
+		// Self-signing detection: a signer may not be the transaction's Account.
+		// Matches rippled sortAndValidateSigners: "A Signer may not be the transaction's Account (<addr>)."
+		if account == txAccount {
+			return nil, types.RpcErrorInvalidParams(
+				"A Signer may not be the transaction's Account (" + txAccount + ").")
+		}
+
 		prevAccount = account
 	}
 
+	// TODO: Validate source account exists in ledger (needs service layer - rpcSRC_ACT_NOT_FOUND)
+	// TODO: Validate signer list exists on source account (needs service layer)
+	// TODO: Validate quorum threshold is met (needs service layer)
+	// TODO: Validate signer weights against quorum (needs service layer)
+
 	// Encode the transaction to binary
-	txBlob, err := binarycodec.Encode(txMap)
-	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to encode transaction: " + err.Error())
+	txBlob, encErr := binarycodec.Encode(txMap)
+	if encErr != nil {
+		return nil, types.RpcErrorInternal("Failed to encode transaction: " + encErr.Error())
 	}
 
 	// Calculate transaction hash
 	txHash := CalculateTxHash(txBlob)
 
 	// Submit the transaction
-	txJSON, err := json.Marshal(txMap)
-	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to marshal transaction: " + err.Error())
+	txJSON, encErr := json.Marshal(txMap)
+	if encErr != nil {
+		return nil, types.RpcErrorInternal("Failed to marshal transaction: " + encErr.Error())
 	}
 
-	result, err := types.Services.Ledger.SubmitTransaction(txJSON)
-	if err != nil {
+	result, submitErr := types.Services.Ledger.SubmitTransaction(txJSON)
+	if submitErr != nil {
 		// Return submission error with details
-		return nil, types.RpcErrorInternal("Transaction submission failed: " + err.Error())
+		return nil, types.RpcErrorInternal("Transaction submission failed: " + submitErr.Error())
 	}
 
 	// Add hash to response tx_json

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -466,6 +466,377 @@ func TestSign_Metadata(t *testing.T) {
 }
 
 // =============================================================================
+// Sign: fee_mult_max / fee_div_max Tests
+// =============================================================================
+
+func TestSign_FeeMultMax_DefaultAccepted(t *testing.T) {
+	// With default fee_mult_max=10 and fee_div_max=1, a baseFee of 10
+	// should be accepted (10 <= 10*10/1 = 100).
+	mock := newMockLedgerService()
+	cleanup := setupTestServices(mock)
+	defer cleanup()
+
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	// No Fee in tx_json, auto-fill will kick in
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000"
+		},
+		"passphrase": "masterpassphrase",
+		"offline": false
+	}`)
+	result, err := handler.Handle(ctx, params)
+	require.Nil(t, err)
+	require.NotNil(t, result)
+
+	resultMap := result.(map[string]interface{})
+	txJson := resultMap["tx_json"].(map[string]interface{})
+	// Fee should have been auto-filled
+	assert.Equal(t, "10", txJson["Fee"])
+}
+
+func TestSign_FeeMultMax_ZeroRejects(t *testing.T) {
+	// fee_mult_max=0 means limit = baseFee * 0 / 1 = 0.
+	// Since networkFee (10) > 0, should return rpcHIGH_FEE.
+	mock := newMockLedgerService()
+	cleanup := setupTestServices(mock)
+	defer cleanup()
+
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000"
+		},
+		"passphrase": "masterpassphrase",
+		"fee_mult_max": 0
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcHIGH_FEE, err.Code)
+	assert.Contains(t, err.Message, "exceeds the requested tx limit")
+}
+
+func TestSign_FeeDivMax_LargeRejects(t *testing.T) {
+	// fee_div_max=100 means limit = baseFee * 10 / 100 = 1.
+	// Since networkFee (10) > 1, should return rpcHIGH_FEE.
+	mock := newMockLedgerService()
+	cleanup := setupTestServices(mock)
+	defer cleanup()
+
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000"
+		},
+		"passphrase": "masterpassphrase",
+		"fee_div_max": 100
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcHIGH_FEE, err.Code)
+	assert.Contains(t, err.Message, "exceeds the requested tx limit")
+}
+
+func TestSign_FeeMultMax_NegativeRejectsInvalidParams(t *testing.T) {
+	// Negative fee_mult_max should return rpcINVALID_PARAMS.
+	// Matches rippled: mult < 0 -> rpcINVALID_PARAMS
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1,
+			"LastLedgerSequence": 100
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true,
+		"fee_mult_max": -1
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Contains(t, err.Message, "fee_mult_max")
+	assert.Contains(t, err.Message, "a positive integer")
+}
+
+func TestSign_FeeDivMax_ZeroRejectsInvalidParams(t *testing.T) {
+	// fee_div_max=0 should return rpcINVALID_PARAMS (not positive).
+	// Matches rippled: div <= 0 -> rpcINVALID_PARAMS
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1,
+			"LastLedgerSequence": 100
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true,
+		"fee_div_max": 0
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Contains(t, err.Message, "fee_div_max")
+	assert.Contains(t, err.Message, "a positive integer")
+}
+
+func TestSign_FeeDivMax_NegativeRejectsInvalidParams(t *testing.T) {
+	// Negative fee_div_max should return rpcINVALID_PARAMS.
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1,
+			"LastLedgerSequence": 100
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true,
+		"fee_div_max": -5
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Contains(t, err.Message, "fee_div_max")
+}
+
+func TestSign_FeeMultMax_FloatRejectsHighFee(t *testing.T) {
+	// Float fee_mult_max should return rpcHIGH_FEE (not rpcINVALID_PARAMS).
+	// Matches rippled: isInt() false -> rpcHIGH_FEE
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1,
+			"LastLedgerSequence": 100
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true,
+		"fee_mult_max": 1.5
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcHIGH_FEE, err.Code)
+	assert.Contains(t, err.Message, "fee_mult_max")
+	assert.Contains(t, err.Message, "a positive integer")
+}
+
+func TestSign_FeeMultMax_StringRejectsHighFee(t *testing.T) {
+	// String fee_mult_max should return rpcHIGH_FEE.
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1,
+			"LastLedgerSequence": 100
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true,
+		"fee_mult_max": "ten"
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcHIGH_FEE, err.Code)
+	assert.Contains(t, err.Message, "fee_mult_max")
+}
+
+func TestSign_FeeAlreadySet_IgnoresFeeMultMax(t *testing.T) {
+	// When Fee is already set in tx_json, fee_mult_max / fee_div_max
+	// should be ignored (the tx already has a fee).
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	// fee_mult_max=0 would normally reject, but Fee is provided
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1,
+			"LastLedgerSequence": 100
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true,
+		"fee_mult_max": 0
+	}`)
+	result, err := handler.Handle(ctx, params)
+	require.Nil(t, err, "fee_mult_max should be ignored when Fee is in tx_json")
+	require.NotNil(t, result)
+}
+
+// =============================================================================
+// Sign: DeliverMax injection Tests
+// =============================================================================
+
+func TestSign_DeliverMax_APIv1(t *testing.T) {
+	// API v1: DeliverMax should be added for Payment, Amount kept
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1,
+			"LastLedgerSequence": 100
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true
+	}`)
+	result, err := handler.Handle(ctx, params)
+	require.Nil(t, err)
+
+	resultMap := result.(map[string]interface{})
+	txJson := resultMap["tx_json"].(map[string]interface{})
+
+	// API v1: Amount is kept, DeliverMax is added
+	assert.Equal(t, "1000000", txJson["Amount"])
+	assert.Equal(t, "1000000", txJson["DeliverMax"])
+}
+
+func TestSign_DeliverMax_APIv2(t *testing.T) {
+	// API v2: DeliverMax replaces Amount for Payment
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion2,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1,
+			"LastLedgerSequence": 100
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true
+	}`)
+	result, err := handler.Handle(ctx, params)
+	require.Nil(t, err)
+
+	resultMap := result.(map[string]interface{})
+	txJson := resultMap["tx_json"].(map[string]interface{})
+
+	// API v2: Amount removed, DeliverMax added
+	_, hasAmount := txJson["Amount"]
+	assert.False(t, hasAmount, "API v2 should remove Amount for Payment")
+	assert.Equal(t, "1000000", txJson["DeliverMax"])
+
+	// API v2: hash at root level
+	assert.Contains(t, resultMap, "hash")
+}
+
+func TestSign_NoDeliverMax_NonPayment(t *testing.T) {
+	// Non-Payment: no DeliverMax regardless of API version
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "AccountSet",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Fee": "10",
+			"Sequence": 1,
+			"LastLedgerSequence": 100
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true
+	}`)
+	result, err := handler.Handle(ctx, params)
+	require.Nil(t, err)
+
+	resultMap := result.(map[string]interface{})
+	txJson := resultMap["tx_json"].(map[string]interface{})
+	_, hasDeliverMax := txJson["DeliverMax"]
+	assert.False(t, hasDeliverMax, "Non-Payment should not have DeliverMax")
+}
+
+// =============================================================================
 // SignFor Tests
 // =============================================================================
 
@@ -676,6 +1047,8 @@ func TestSubmitMultisigned_MissingAccount(t *testing.T) {
 			"TransactionType": "Payment",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
+			"Fee": "12",
+			"Sequence": 1,
 			"SigningPubKey": "",
 			"Signers": []
 		}
@@ -702,13 +1075,15 @@ func TestSubmitMultisigned_NonEmptySigningPubKey(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
+			"Fee": "12",
+			"Sequence": 1,
 			"SigningPubKey": "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
 			"Signers": []
 		}
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "empty SigningPubKey")
+	assert.Contains(t, err.Message, "SigningPubKey")
 }
 
 func TestSubmitMultisigned_EmptySignersArray(t *testing.T) {
@@ -728,13 +1103,15 @@ func TestSubmitMultisigned_EmptySignersArray(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
+			"Fee": "12",
+			"Sequence": 1,
 			"SigningPubKey": "",
 			"Signers": []
 		}
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "at least one Signer")
+	assert.Contains(t, err.Message, "Signers array may not be empty")
 }
 
 func TestSubmitMultisigned_InvalidSignerFormat(t *testing.T) {
@@ -754,6 +1131,8 @@ func TestSubmitMultisigned_InvalidSignerFormat(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
+			"Fee": "12",
+			"Sequence": 1,
 			"SigningPubKey": "",
 			"Signers": [
 				{
@@ -764,7 +1143,7 @@ func TestSubmitMultisigned_InvalidSignerFormat(t *testing.T) {
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "Signer entry")
+	assert.Contains(t, err.Message, "Signer entr")
 }
 
 func TestSubmitMultisigned_MissingSignerAccount(t *testing.T) {
@@ -784,6 +1163,8 @@ func TestSubmitMultisigned_MissingSignerAccount(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
+			"Fee": "12",
+			"Sequence": 1,
 			"SigningPubKey": "",
 			"Signers": [
 				{
@@ -817,6 +1198,8 @@ func TestSubmitMultisigned_MissingSigningPubKey(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
+			"Fee": "12",
+			"Sequence": 1,
 			"SigningPubKey": "",
 			"Signers": [
 				{
@@ -850,6 +1233,8 @@ func TestSubmitMultisigned_MissingTxnSignature(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
+			"Fee": "12",
+			"Sequence": 1,
 			"SigningPubKey": "",
 			"Signers": [
 				{

--- a/internal/rpc/submit_multisigned_test.go
+++ b/internal/rpc/submit_multisigned_test.go
@@ -1,0 +1,321 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validMultisignedTxJSON returns a minimal valid multi-signed tx_json for testing.
+// Override individual fields to test specific validation failures.
+func validMultisignedTxJSON() map[string]interface{} {
+	return map[string]interface{}{
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"TransactionType": "Payment",
+		"Destination":     "rPMh7Pi9ct699iZUTWzJaUOVnFNaREiPik",
+		"Amount":          "1000000",
+		"Fee":             "12",
+		"Sequence":        float64(1),
+		"SigningPubKey":   "",
+		"Signers": []interface{}{
+			map[string]interface{}{
+				"Signer": map[string]interface{}{
+					"Account":       "rPMh7Pi9ct699iZUTWzJaUOVnFNaREiPik",
+					"SigningPubKey": "0379F17CFA0FFD7518181594BE69FE9A10C2089E0FF0C4AE1DEF230657210000ED",
+					"TxnSignature":  "3045022100DEADBEEF",
+				},
+			},
+		},
+	}
+}
+
+func makeSubmitMultisignedParams(t *testing.T, txJSON map[string]interface{}) json.RawMessage {
+	t.Helper()
+	request := map[string]interface{}{
+		"tx_json": txJSON,
+	}
+	b, err := json.Marshal(request)
+	require.NoError(t, err)
+	return b
+}
+
+// TestSubmitMultisigned_MissingSequence verifies that the handler returns
+// rpcINVALID_PARAMS "Missing field 'tx_json.Sequence'." when Sequence is absent.
+// Matches rippled: checkMultiSignFields -> missing_field_error("tx_json.Sequence")
+func TestSubmitMultisigned_MissingSequence(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	txJSON := validMultisignedTxJSON()
+	delete(txJSON, "Sequence")
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Equal(t, "Missing field 'tx_json.Sequence'.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_InvalidSequenceType verifies that a non-numeric Sequence is rejected.
+func TestSubmitMultisigned_InvalidSequenceType(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	txJSON := validMultisignedTxJSON()
+	txJSON["Sequence"] = "not_a_number"
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Contains(t, rpcErr.Message, "tx_json.Sequence")
+}
+
+// TestSubmitMultisigned_FeeNotPresent verifies that missing Fee is rejected.
+// Matches rippled: "Invalid Fee field.  Fees must be specified in XRP."
+func TestSubmitMultisigned_FeeNotPresent(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	txJSON := validMultisignedTxJSON()
+	delete(txJSON, "Fee")
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Equal(t, "Invalid Fee field.  Fees must be specified in XRP.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_FeeNotString verifies that a non-string Fee is rejected.
+// Fee must be a string of drops.
+func TestSubmitMultisigned_FeeNotString(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	txJSON := validMultisignedTxJSON()
+	txJSON["Fee"] = 12 // numeric, not string
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Equal(t, "Invalid Fee field.  Fees must be specified in XRP.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_FeeZero verifies that Fee "0" is rejected.
+// Matches rippled: "Invalid Fee field.  Fees must be greater than zero."
+func TestSubmitMultisigned_FeeZero(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	txJSON := validMultisignedTxJSON()
+	txJSON["Fee"] = "0"
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Equal(t, "Invalid Fee field.  Fees must be greater than zero.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_FeeNegative verifies that a negative Fee is rejected.
+func TestSubmitMultisigned_FeeNegative(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	txJSON := validMultisignedTxJSON()
+	txJSON["Fee"] = "-10"
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Equal(t, "Invalid Fee field.  Fees must be greater than zero.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_FeeNotNumericString verifies that a non-numeric Fee string is rejected.
+func TestSubmitMultisigned_FeeNotNumericString(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	txJSON := validMultisignedTxJSON()
+	txJSON["Fee"] = "abc"
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Equal(t, "Invalid Fee field.  Fees must be specified in XRP.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_TxnSignaturePresent verifies that a TxnSignature field on the
+// outer tx_json is rejected.
+// Matches rippled: rpcError(rpcSIGNING_MALFORMED) -> code 63, "signingMalformed"
+func TestSubmitMultisigned_TxnSignaturePresent(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	txJSON := validMultisignedTxJSON()
+	txJSON["TxnSignature"] = "DEADBEEF"
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcSIGNING_MALFORMED, rpcErr.Code)
+	assert.Equal(t, "signingMalformed", rpcErr.ErrorString)
+	assert.Equal(t, "Signing of transaction is malformed.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_SelfSigning verifies that a signer whose Account matches the
+// transaction's Account is rejected.
+// Matches rippled sortAndValidateSigners:
+// "A Signer may not be the transaction's Account (<addr>)."
+func TestSubmitMultisigned_SelfSigning(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	txJSON := validMultisignedTxJSON()
+	txAccount := txJSON["Account"].(string)
+
+	// Replace the signer's Account with the transaction source account.
+	signers := txJSON["Signers"].([]interface{})
+	signerWrapper := signers[0].(map[string]interface{})
+	signer := signerWrapper["Signer"].(map[string]interface{})
+	signer["Account"] = txAccount
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Contains(t, rpcErr.Message, "A Signer may not be the transaction's Account")
+	assert.Contains(t, rpcErr.Message, txAccount)
+}
+
+// TestSubmitMultisigned_DuplicateSigners verifies that duplicate signer accounts are rejected.
+// Matches rippled sortAndValidateSigners:
+// "Duplicate Signers:Signer:Account entries (<addr>) are not allowed."
+func TestSubmitMultisigned_DuplicateSigners(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	dupAccount := "rPMh7Pi9ct699iZUTWzJaUOVnFNaREiPik"
+	txJSON := validMultisignedTxJSON()
+	txJSON["Signers"] = []interface{}{
+		map[string]interface{}{
+			"Signer": map[string]interface{}{
+				"Account":       dupAccount,
+				"SigningPubKey": "0379F17CFA0FFD7518181594BE69FE9A10C2089E0FF0C4AE1DEF230657210000ED",
+				"TxnSignature":  "3045022100DEADBEEF",
+			},
+		},
+		map[string]interface{}{
+			"Signer": map[string]interface{}{
+				"Account":       dupAccount,
+				"SigningPubKey": "0279F17CFA0FFD7518181594BE69FE9A10C2089E0FF0C4AE1DEF230657210000EE",
+				"TxnSignature":  "3045022100BEEFDEAD",
+			},
+		},
+	}
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Contains(t, rpcErr.Message, "Duplicate Signers:Signer:Account entries")
+	assert.Contains(t, rpcErr.Message, dupAccount)
+}
+
+// TestSubmitMultisigned_FeeValidPositive verifies that a valid positive Fee passes validation.
+// This test proceeds past Fee validation and hits the binary encoding step.
+func TestSubmitMultisigned_FeeValidPositive(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	txJSON := validMultisignedTxJSON()
+	txJSON["Fee"] = "10"
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	// Should fail at encoding/submission, not at Fee validation.
+	if rpcErr != nil {
+		assert.NotContains(t, rpcErr.Message, "Fee")
+	}
+}
+
+// TestSubmitMultisigned_ValidationOrder_SequenceBeforeTxnSignature verifies that
+// Sequence is checked before TxnSignature.
+func TestSubmitMultisigned_ValidationOrder_SequenceBeforeTxnSignature(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	// Both Sequence missing AND TxnSignature present -- Sequence error should come first.
+	txJSON := validMultisignedTxJSON()
+	delete(txJSON, "Sequence")
+	txJSON["TxnSignature"] = "DEADBEEF"
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "Missing field 'tx_json.Sequence'.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_ValidationOrder_TxnSignatureBeforeFee verifies that
+// TxnSignature is checked before Fee.
+func TestSubmitMultisigned_ValidationOrder_TxnSignatureBeforeFee(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	cleanup := setupTestServicesSubmit(mock)
+	defer cleanup()
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+
+	// Both TxnSignature present AND Fee invalid -- TxnSignature error should come first.
+	txJSON := validMultisignedTxJSON()
+	txJSON["TxnSignature"] = "DEADBEEF"
+	txJSON["Fee"] = "0"
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcSIGNING_MALFORMED, rpcErr.Code)
+}

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -107,12 +107,16 @@ const (
 	RpcNOT_VALIDATOR = 48 // Server is not configured as a validator
 	RpcNOT_SYNCED    = 49 // Not synced to network
 
+	// Fee errors - must match rippled exactly
+	RpcHIGH_FEE = 11 // Current transaction fee exceeds your limit
+
 	// Signing/Key errors - must match rippled exactly
-	RpcBAD_SEED             = 44 // Disallowed seed
-	RpcCHANNEL_MALFORMED    = 45 // Payment channel is malformed
+	RpcBAD_SEED              = 44 // Disallowed seed
+	RpcCHANNEL_MALFORMED     = 45 // Payment channel is malformed
 	RpcCHANNEL_AMT_MALFORMED = 46 // Payment channel amount is malformed
-	RpcPUBLIC_MALFORMED     = 62 // Public key is malformed
-	RpcBAD_KEY_TYPE         = 76 // Bad key type
+	RpcPUBLIC_MALFORMED      = 62 // Public key is malformed
+	RpcSIGNING_MALFORMED     = 63 // Signing of transaction is malformed
+	RpcBAD_KEY_TYPE          = 76 // Bad key type
 
 	// Object errors - must match rippled exactly
 	RpcOBJECT_NOT_FOUND = 92 // Object not found
@@ -210,6 +214,31 @@ func RpcErrorObjectNotFound(message string) *RpcError {
 // RpcErrorBadCredentials returns an error for credential validation failures (matches rippled rpcBAD_CREDENTIALS).
 func RpcErrorBadCredentials(message string) *RpcError {
 	return NewRpcError(RpcBAD_CREDENTIALS, "badCredentials", "badCredentials", message)
+}
+
+// RpcErrorHighFee returns an error when the auto-filled fee exceeds the requested limit (matches rippled rpcHIGH_FEE).
+func RpcErrorHighFee(message string) *RpcError {
+	return NewRpcError(RpcHIGH_FEE, "highFee", "highFee", message)
+}
+
+// RpcErrorExpectedField returns an error for a field that is not of the expected type
+// (matches rippled's expected_field_message: "Invalid field '<name>', not <type>.")
+func RpcErrorExpectedField(field, expectedType string) *RpcError {
+	return NewRpcError(RpcINVALID_PARAMS, "invalidParams", "invalidParams",
+		"Invalid field '"+field+"', not "+expectedType+".")
+}
+
+// RpcErrorExpectedFieldHighFee returns a highFee error for a field that is not of the expected type.
+// rippled returns rpcHIGH_FEE (not rpcINVALID_PARAMS) when fee_mult_max or fee_div_max is not an integer.
+func RpcErrorExpectedFieldHighFee(field, expectedType string) *RpcError {
+	return NewRpcError(RpcHIGH_FEE, "highFee", "highFee",
+		"Invalid field '"+field+"', not "+expectedType+".")
+}
+
+// RpcErrorSigningMalformed returns an error when a transaction's signing is malformed
+// (matches rippled rpcSIGNING_MALFORMED, code 63, token "signingMalformed").
+func RpcErrorSigningMalformed() *RpcError {
+	return NewRpcError(RpcSIGNING_MALFORMED, "signingMalformed", "signingMalformed", "Signing of transaction is malformed.")
 }
 
 // RpcErrorMissingField returns an error for missing required field (matches rippled missing_field_error)


### PR DESCRIPTION
## Summary
- **submit_multisigned** (#96): 5 handler-level validations — Sequence required, Fee > 0, TxnSignature rejection (`rpcSIGNING_MALFORMED` code 63), self-signing detection, duplicate signer detection. TODOs for ledger-dependent checks (account existence, signer list, quorum).
- **sign/sign_for** (#114): `fee_mult_max`/`fee_div_max` auto-fee parameters with rippled-matching type validation (`rpcHIGH_FEE` for non-integer/zero, `rpcINVALID_PARAMS` for negative). DeliverMax injection for Payment transactions. API v2 hash at root level.
- **amm_info** (#117): `auction_slot.time_interval` computed via `ammAuctionTimeSlot()` matching rippled's `AMMCore.cpp`. ISO 8601 expiration formatting. `auth_accounts` unwrapping fix. `buildAuctionSlot` helper. TODO for pool balance lookups via `ammPoolHolds()`.

## Test plan
- [x] All RPC tests pass (`go test -count=1 ./internal/rpc/...`)
- [x] `go vet` clean
- [x] 14 new submit_multisigned tests (validation ordering, each error case)
- [x] 12 new sign tests (fee_mult_max/fee_div_max, DeliverMax)
- [x] 22 new amm_info tests (auction slot, time interval, helpers)

Closes #96, closes #114, closes #117