### PR TITLE
fix(rpc): batch 5 conformance fixes for final 3 handlers

### DIFF
--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -216,11 +216,10 @@ func TestDepositAuthorizedErrorValidation(t *testing.T) {
 				"source_account":      "rG1QQv2nh2gr7RCZ!P8YYcBUKCCN633jCn",
 				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			},
-			setupMock: func() {
-				mock.depositAuthorizedErr = errors.New("invalid source_account address: invalid character")
-			},
+			// No setupMock needed — handler-level ValidateAccount catches this
+			// before the service is called.
 			expectError:   true,
-			expectedError: "Account malformed.",
+			expectedError: "Malformed account.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -229,11 +228,10 @@ func TestDepositAuthorizedErrorValidation(t *testing.T) {
 				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 				"destination_account": "rP6P9ypfAmc!pw8SZHNwM4nvZHFXDraQas",
 			},
-			setupMock: func() {
-				mock.depositAuthorizedErr = errors.New("invalid destination_account address: invalid character")
-			},
+			// No setupMock needed — handler-level ValidateAccount catches this
+			// before the service is called.
 			expectError:   true,
-			expectedError: "Account malformed.",
+			expectedError: "Malformed account.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -559,4 +557,237 @@ func TestDepositAuthorizedMethodMetadata(t *testing.T) {
 		assert.Contains(t, versions, types.ApiVersion2)
 		assert.Contains(t, versions, types.ApiVersion3)
 	})
+}
+
+// =============================================================================
+// Handler-Level Address Validation Tests
+// =============================================================================
+
+// TestDepositAuthorizedAddressValidation tests that handler-level Base58 address
+// validation catches malformed addresses before the service layer is called.
+// Reference: rippled DepositAuthorized.cpp — parseBase58 → rpcACT_MALFORMED
+func TestDepositAuthorizedAddressValidation(t *testing.T) {
+	mock := newMockDepositAuthorizedLedgerService()
+	cleanup := setupDepositAuthorizedTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.DepositAuthorizedMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	tests := []struct {
+		name          string
+		params        map[string]interface{}
+		expectedError string
+		expectedCode  int
+	}{
+		{
+			name: "source_account with special characters",
+			params: map[string]interface{}{
+				"source_account":      "rG1QQv2nh2gr7RCZ!P8YYcBUKCCN633jCn",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			},
+			expectedError: "Malformed account.",
+			expectedCode:  types.RpcACT_MALFORMED,
+		},
+		{
+			name: "destination_account with special characters",
+			params: map[string]interface{}{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rP6P9ypfAmc!pw8SZHNwM4nvZHFXDraQas",
+			},
+			expectedError: "Malformed account.",
+			expectedCode:  types.RpcACT_MALFORMED,
+		},
+		{
+			name: "source_account too short",
+			params: map[string]interface{}{
+				"source_account":      "rHb9",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			},
+			expectedError: "Malformed account.",
+			expectedCode:  types.RpcACT_MALFORMED,
+		},
+		{
+			name: "destination_account too short",
+			params: map[string]interface{}{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "r",
+			},
+			expectedError: "Malformed account.",
+			expectedCode:  types.RpcACT_MALFORMED,
+		},
+		{
+			name: "source_account random string",
+			params: map[string]interface{}{
+				"source_account":      "not_a_valid_address",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			},
+			expectedError: "Malformed account.",
+			expectedCode:  types.RpcACT_MALFORMED,
+		},
+		{
+			name: "both accounts malformed — source caught first",
+			params: map[string]interface{}{
+				"source_account":      "INVALID",
+				"destination_account": "ALSO_INVALID",
+			},
+			expectedError: "Malformed account.",
+			expectedCode:  types.RpcACT_MALFORMED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset mock — these errors should be caught before hitting the service
+			mock.depositAuthorizedErr = nil
+			mock.depositAuthorizedResult = nil
+
+			paramsJSON, _ := json.Marshal(tt.params)
+			resp, err := method.Handle(ctx, paramsJSON)
+
+			require.NotNil(t, err, "Expected an error but got none")
+			assert.Equal(t, tt.expectedError, err.Message)
+			assert.Equal(t, tt.expectedCode, err.Code)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+// =============================================================================
+// Credential Validation Tests
+// =============================================================================
+
+// TestDepositAuthorizedCredentialValidation tests credential format and duplicate
+// detection at the handler level.
+// Reference: rippled DepositAuthorized.cpp — credential parsing loop + sorted.emplace()
+func TestDepositAuthorizedCredentialValidation(t *testing.T) {
+	mock := newMockDepositAuthorizedLedgerService()
+	cleanup := setupDepositAuthorizedTestServices(mock)
+	defer cleanup()
+
+	method := &handlers.DepositAuthorizedMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+	}
+
+	validCred1 := "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2"
+	validCred2 := "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF"
+
+	tests := []struct {
+		name          string
+		params        map[string]interface{}
+		expectedError string
+		expectedCode  int
+	}{
+		{
+			name: "Duplicate credentials — exact same hash",
+			params: map[string]interface{}{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{validCred1, validCred1},
+			},
+			expectedError: "duplicates in credentials.",
+			expectedCode:  types.RpcBAD_CREDENTIALS,
+		},
+		{
+			name: "Duplicate credentials — case-insensitive match",
+			params: map[string]interface{}{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials": []string{
+					"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+					"A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2",
+				},
+			},
+			expectedError: "duplicates in credentials.",
+			expectedCode:  types.RpcBAD_CREDENTIALS,
+		},
+		{
+			name: "Duplicate credentials — three entries with duplicate",
+			params: map[string]interface{}{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{validCred1, validCred2, validCred1},
+			},
+			expectedError: "duplicates in credentials.",
+			expectedCode:  types.RpcBAD_CREDENTIALS,
+		},
+		{
+			name: "Credential too short",
+			params: map[string]interface{}{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{"ABCD"},
+			},
+			expectedError: "Invalid field 'credentials', an array of CredentialID(hash256).",
+			expectedCode:  types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "Credential not valid hex",
+			params: map[string]interface{}{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{"ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"},
+			},
+			expectedError: "Invalid field 'credentials', an array of CredentialID(hash256).",
+			expectedCode:  types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "Too many credentials",
+			params: map[string]interface{}{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials": []string{
+					"0000000000000000000000000000000000000000000000000000000000000001",
+					"0000000000000000000000000000000000000000000000000000000000000002",
+					"0000000000000000000000000000000000000000000000000000000000000003",
+					"0000000000000000000000000000000000000000000000000000000000000004",
+					"0000000000000000000000000000000000000000000000000000000000000005",
+					"0000000000000000000000000000000000000000000000000000000000000006",
+					"0000000000000000000000000000000000000000000000000000000000000007",
+					"0000000000000000000000000000000000000000000000000000000000000008",
+					"0000000000000000000000000000000000000000000000000000000000000009",
+				},
+			},
+			expectedError: "Invalid field 'credentials', array too long.",
+			expectedCode:  types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "Valid credentials — no duplicates",
+			params: map[string]interface{}{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{validCred1, validCred2},
+			},
+			// No error expected — this case should pass through to the service
+			expectedError: "",
+			expectedCode:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock.depositAuthorizedErr = nil
+			mock.depositAuthorizedResult = nil
+
+			paramsJSON, _ := json.Marshal(tt.params)
+			resp, err := method.Handle(ctx, paramsJSON)
+
+			if tt.expectedError != "" {
+				require.NotNil(t, err, "Expected an error but got none")
+				assert.Equal(t, tt.expectedError, err.Message)
+				assert.Equal(t, tt.expectedCode, err.Code)
+				assert.Nil(t, resp)
+			} else {
+				require.Nil(t, err, "Unexpected error: %v", err)
+				require.NotNil(t, resp)
+			}
+		})
+	}
 }

--- a/internal/rpc/handlers/deposit_authorized.go
+++ b/internal/rpc/handlers/deposit_authorized.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"strings"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -26,12 +27,22 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, err
 	}
 
+	// Validate source_account: must be present and a valid Base58 address.
+	// Reference: rippled DepositAuthorized.cpp — parseBase58 → rpcACT_MALFORMED
 	if request.SourceAccount == "" {
 		return nil, types.RpcErrorInvalidParams("Missing field 'source_account'.")
 	}
+	if err := ValidateAccount(request.SourceAccount); err != nil {
+		return nil, err
+	}
 
+	// Validate destination_account: must be present and a valid Base58 address.
+	// Reference: rippled DepositAuthorized.cpp — parseBase58 → rpcACT_MALFORMED
 	if request.DestinationAccount == "" {
 		return nil, types.RpcErrorInvalidParams("Missing field 'destination_account'.")
+	}
+	if err := ValidateAccount(request.DestinationAccount); err != nil {
+		return nil, err
 	}
 
 	// Validate credentials array format before calling the service.
@@ -52,7 +63,14 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		ledgerIndex = request.LedgerIndex.String()
 	}
 
-	// Call the service with credentials for ledger-side validation
+	// Call the service with credentials for ledger-side validation.
+	// TODO: The service layer is responsible for the following ledger-side
+	// credential checks (matching rippled DepositAuthorized.cpp):
+	//   1. Credential existence — read(keylet::credential(credH)) → rpcBAD_CREDENTIALS "credentials don't exist"
+	//   2. Credential accepted — (flags & lsfAccepted) → rpcBAD_CREDENTIALS "credentials aren't accepted"
+	//   3. Credential expiry — checkExpired(sleCred, parentCloseTime) → rpcBAD_CREDENTIALS "credentials are expired"
+	//   4. Credential ownership — sleCred[sfSubject] == srcAcct → rpcBAD_CREDENTIALS "credentials doesn't belong to the root account"
+	//   5. Credential duplicates by (issuer, credentialType) — rpcBAD_CREDENTIALS "duplicates in credentials"
 	result, err := types.Services.Ledger.GetDepositAuthorized(
 		request.SourceAccount,
 		request.DestinationAccount,
@@ -76,22 +94,6 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 			return nil, &types.RpcError{
 				Code:    types.RpcDST_ACT_NOT_FOUND,
 				Message: "Destination account not found.",
-			}
-		}
-
-		// Check for malformed source_account address
-		if len(errMsg) > 32 && errMsg[:32] == "invalid source_account address: " {
-			return nil, &types.RpcError{
-				Code:    types.RpcACT_MALFORMED,
-				Message: "Account malformed.",
-			}
-		}
-
-		// Check for malformed destination_account address
-		if len(errMsg) > 37 && errMsg[:37] == "invalid destination_account address: " {
-			return nil, &types.RpcError{
-				Code:    types.RpcACT_MALFORMED,
-				Message: "Account malformed.",
 			}
 		}
 
@@ -122,9 +124,9 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 }
 
 // validateCredentialsFormat validates the credentials array format at the RPC level.
-// This performs format-only checks (non-empty, max size, valid hex hashes).
-// Ledger-side validation (existence, acceptance, expiry, ownership, duplicates)
-// is done in the service layer.
+// This performs format-only checks: non-empty, max size, valid hex hashes, no duplicates.
+// Ledger-side validation (existence, acceptance, expiry, ownership) is done in the
+// service layer.
 // Reference: rippled DepositAuthorized.cpp credential parsing loop
 func validateCredentialsFormat(credentials []string) *types.RpcError {
 	if len(credentials) == 0 {
@@ -137,6 +139,7 @@ func validateCredentialsFormat(credentials []string) *types.RpcError {
 			"Invalid field 'credentials', array too long.")
 	}
 
+	seen := make(map[string]struct{}, len(credentials))
 	for _, credStr := range credentials {
 		// Each credential must be a valid 64-char hex string (32 bytes / 256 bits)
 		if len(credStr) != 64 {
@@ -147,6 +150,17 @@ func validateCredentialsFormat(credentials []string) *types.RpcError {
 			return types.RpcErrorInvalidParams(
 				"Invalid field 'credentials', an array of CredentialID(hash256).")
 		}
+
+		// Detect duplicate credential hashes.
+		// Reference: rippled DepositAuthorized.cpp — sorted.emplace() → rpcBAD_CREDENTIALS "duplicates in credentials"
+		// Note: rippled's full duplicate detection uses (issuer, credentialType) pairs from the
+		// ledger SLE. Here we catch the simpler case of identical hash strings, which is a strict
+		// subset. The service layer performs the full (issuer, credentialType) dedup with ledger data.
+		normalized := strings.ToUpper(credStr)
+		if _, exists := seen[normalized]; exists {
+			return types.RpcErrorBadCredentials("duplicates in credentials.")
+		}
+		seen[normalized] = struct{}{}
 	}
 
 	return nil

--- a/internal/rpc/handlers/get_aggregate_price.go
+++ b/internal/rpc/handlers/get_aggregate_price.go
@@ -10,8 +10,8 @@ import (
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
-	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/keylet"
 )
 
 // GetAggregatePriceMethod handles the get_aggregate_price RPC method
@@ -24,84 +24,151 @@ type PriceDataPoint struct {
 }
 
 func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	var request struct {
-		types.LedgerSpecifier
-		Oracles       []map[string]interface{} `json:"oracles"`
-		BaseAsset     string                   `json:"base_asset"`
-		QuoteAsset    string                   `json:"quote_asset"`
-		Trim          uint32                   `json:"trim,omitempty"`
-		TimeThreshold uint32                   `json:"time_threshold,omitempty"`
+	// Parse into raw map first for field-presence detection (matching rippled's
+	// isMember() checks which distinguish "absent" from "present but invalid").
+	var raw map[string]json.RawMessage
+	if params != nil {
+		if err := json.Unmarshal(params, &raw); err != nil {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+		}
+	}
+	if raw == nil {
+		raw = make(map[string]json.RawMessage)
 	}
 
-	if err := ParseParams(params, &request); err != nil {
-		return nil, err
+	// --- oracles validation ---
+	// rippled: !params.isMember(jss::oracles) -> missing_field_error
+	oraclesRaw, hasOracles := raw["oracles"]
+	if !hasOracles {
+		return nil, types.RpcErrorMissingField("oracles")
 	}
-
-	// Validate required parameters
-	if len(request.Oracles) == 0 {
-		return nil, types.RpcErrorInvalidParams("Missing required parameter: oracles")
+	// rippled: !isArray() || size()==0 || size()>200 -> rpcORACLE_MALFORMED
+	var oracles []json.RawMessage
+	if err := json.Unmarshal(oraclesRaw, &oracles); err != nil {
+		// Not an array
+		return nil, types.RpcErrorOracleMalformed()
 	}
-	if request.BaseAsset == "" {
-		return nil, types.RpcErrorInvalidParams("Missing required parameter: base_asset")
-	}
-	if request.QuoteAsset == "" {
-		return nil, types.RpcErrorInvalidParams("Missing required parameter: quote_asset")
-	}
-
-	// Validate constraints
 	const maxOracles = 200
-	const maxTrim = 25
-
-	if len(request.Oracles) > maxOracles {
-		return nil, types.RpcErrorInvalidParams("oracles array exceeds maximum size of 200")
+	if len(oracles) == 0 || len(oracles) > maxOracles {
+		return nil, types.RpcErrorOracleMalformed()
 	}
-	if request.Trim > maxTrim {
-		return nil, types.RpcErrorInvalidParams("trim must be between 1 and 25")
+
+	// --- base_asset validation ---
+	// rippled: !params.isMember(jss::base_asset) -> missing_field_error
+	baseAssetRaw, hasBaseAsset := raw["base_asset"]
+	if !hasBaseAsset {
+		return nil, types.RpcErrorMissingField("base_asset")
+	}
+	// --- quote_asset validation ---
+	// rippled: !params.isMember(jss::quote_asset) -> missing_field_error
+	quoteAssetRaw, hasQuoteAsset := raw["quote_asset"]
+	if !hasQuoteAsset {
+		return nil, types.RpcErrorMissingField("quote_asset")
+	}
+
+	// --- trim validation ---
+	// rippled: if present, must be valid uint; then if present, must be 1..25
+	const maxTrim = 25
+	var trimValue uint32
+	hasTrim := false
+	if trimRaw, ok := raw["trim"]; ok {
+		hasTrim = true
+		v, err := parseUintParam(trimRaw)
+		if err != nil {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+		}
+		trimValue = v
+		if trimValue == 0 || trimValue > maxTrim {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+		}
+	}
+
+	// --- time_threshold validation ---
+	// rippled: if present, must be valid uint
+	var timeThreshold uint32
+	if ttRaw, ok := raw["time_threshold"]; ok {
+		v, err := parseUintParam(ttRaw)
+		if err != nil {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+		}
+		timeThreshold = v
+	}
+
+	// --- base_asset / quote_asset currency validation ---
+	// rippled: empty or invalid currency -> rpcINVALID_PARAMS
+	baseAsset, err := parseCurrencyParam(baseAssetRaw)
+	if err != nil {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	quoteAsset, err := parseCurrencyParam(quoteAssetRaw)
+	if err != nil {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 
 	if err := RequireLedgerService(); err != nil {
 		return nil, err
 	}
 
+	// Parse the ledger specifier from the raw params
+	var ledgerSpec struct {
+		types.LedgerSpecifier
+	}
+	if params != nil {
+		_ = json.Unmarshal(params, &ledgerSpec)
+	}
+
 	// Determine ledger index to use
 	ledgerIndex := "validated"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
+	if ledgerSpec.LedgerIndex != "" {
+		ledgerIndex = ledgerSpec.LedgerIndex.String()
 	}
 
 	// Collect prices from all oracles
 	var prices []PriceDataPoint
 
-	for _, oracleSpec := range request.Oracles {
-		accountStr, ok := oracleSpec["account"].(string)
+	for _, oracleRaw := range oracles {
+		var oracleSpec map[string]interface{}
+		if err := json.Unmarshal(oracleRaw, &oracleSpec); err != nil {
+			return nil, types.RpcErrorOracleMalformed()
+		}
+
+		// rippled: missing account or oracle_document_id -> rpcORACLE_MALFORMED
+		accountRaw, hasAccount := oracleSpec["account"]
+		docIDRaw, hasDocID := oracleSpec["oracle_document_id"]
+
+		if !hasAccount || !hasDocID {
+			return nil, types.RpcErrorOracleMalformed()
+		}
+
+		// rippled: invalid oracle_document_id (not uint) -> rpcINVALID_PARAMS
+		documentID, ok := parseOracleDocumentID(docIDRaw)
 		if !ok {
-			return nil, types.RpcErrorInvalidParams("Each oracle must have an account field")
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		}
 
-		documentIDRaw, ok := oracleSpec["oracle_document_id"]
+		// rippled: invalid account (not valid base58) -> rpcINVALID_PARAMS
+		accountStr, ok := accountRaw.(string)
 		if !ok {
-			return nil, types.RpcErrorInvalidParams("Each oracle must have an oracle_document_id field")
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		}
-
-		var documentID uint32
-		switch v := documentIDRaw.(type) {
-		case float64:
-			documentID = uint32(v)
-		case int:
-			documentID = uint32(v)
-		case uint32:
-			documentID = v
-		default:
-			return nil, types.RpcErrorInvalidParams("oracle_document_id must be a number")
-		}
-
-		// Decode account address
-		_, accountBytes, err := addresscodec.DecodeClassicAddressToAccountID(accountStr)
-		if err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid account in oracle: " + err.Error())
+		_, accountBytes, decodeErr := addresscodec.DecodeClassicAddressToAccountID(accountStr)
+		if decodeErr != nil {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		}
 		var accountID [20]byte
 		copy(accountID[:], accountBytes)
+
+		// Check for zero account (rippled rejects account->isZero())
+		allZero := true
+		for _, b := range accountID {
+			if b != 0 {
+				allZero = false
+				break
+			}
+		}
+		if allZero {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+		}
 
 		// Get oracle keylet
 		oracleKeylet := keylet.Oracle(accountID, documentID)
@@ -114,8 +181,8 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		}
 
 		// Decode the Oracle entry
-		oracleDecoded, decodeErr := binarycodec.Decode(hex.EncodeToString(oracleEntry.Node))
-		if decodeErr != nil {
+		oracleDecoded, decodeErr2 := binarycodec.Decode(hex.EncodeToString(oracleEntry.Node))
+		if decodeErr2 != nil {
 			continue
 		}
 
@@ -133,8 +200,8 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		}
 
 		// Find matching price data
-		priceDataSeries, ok := oracleDecoded["PriceDataSeries"].([]interface{})
-		if !ok {
+		priceDataSeries, ok2 := oracleDecoded["PriceDataSeries"].([]interface{})
+		if !ok2 {
 			continue
 		}
 
@@ -145,10 +212,10 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 			}
 
 			// Check if this matches the requested asset pair
-			baseAsset, _ := priceData["BaseAsset"].(string)
-			quoteAsset, _ := priceData["QuoteAsset"].(string)
+			ba, _ := priceData["BaseAsset"].(string)
+			qa, _ := priceData["QuoteAsset"].(string)
 
-			if baseAsset != request.BaseAsset || quoteAsset != request.QuoteAsset {
+			if ba != baseAsset || qa != quoteAsset {
 				continue
 			}
 
@@ -197,11 +264,9 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		}
 	}
 
+	// rippled: prices.empty() -> rpcOBJECT_NOT_FOUND
 	if len(prices) == 0 {
-		return nil, &types.RpcError{
-			Code:    21,
-			Message: "No matching price data found",
-		}
+		return nil, types.RpcErrorObjectNotFound("Object not found.")
 	}
 
 	// Find the latest update time
@@ -213,19 +278,37 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 	}
 
 	// Filter by time threshold if specified
-	if request.TimeThreshold > 0 {
+	if timeThreshold > 0 {
 		var filtered []PriceDataPoint
-		threshold := latestTime - request.TimeThreshold
+		// rippled: upperBound = latestTime > threshold ? (latestTime - threshold) : oldestTime
+		var oldestTime uint32 = math.MaxUint32
 		for _, p := range prices {
-			if p.LastUpdateTime >= threshold {
-				filtered = append(filtered, p)
+			if p.LastUpdateTime < oldestTime {
+				oldestTime = p.LastUpdateTime
 			}
 		}
-		if len(filtered) == 0 {
-			return nil, &types.RpcError{
-				Code:    21,
-				Message: "No price data within time threshold",
+		var upperBound uint32
+		if latestTime > timeThreshold {
+			upperBound = latestTime - timeThreshold
+		} else {
+			upperBound = oldestTime
+		}
+		if upperBound > oldestTime {
+			// Erase entries with LastUpdateTime <= upperBound (rippled erases
+			// from upper_bound(upperBound) to end() in the descending-sorted
+			// left map, which removes all entries with time < upperBound.
+			// Since we're using "strictly less than", we keep entries where
+			// time > upperBound — matching rippled's upper_bound semantics).
+			for _, p := range prices {
+				if p.LastUpdateTime > upperBound {
+					filtered = append(filtered, p)
+				}
 			}
+		} else {
+			filtered = prices
+		}
+		if len(filtered) == 0 {
+			return nil, types.RpcErrorInternal("Internal error.")
 		}
 		prices = filtered
 	}
@@ -247,27 +330,148 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		"time": latestTime,
 		"entire_set": map[string]interface{}{
 			"mean":               fmt.Sprintf("%g", entireMean),
-			"size":               entireSize,
+			"size":               uint16(entireSize),
 			"standard_deviation": fmt.Sprintf("%g", entireSD),
 		},
 		"median": fmt.Sprintf("%g", median),
 	}
 
 	// Calculate trimmed set if requested
-	if request.Trim > 0 && len(prices) > 2 {
-		trimCount := len(prices) * int(request.Trim) / 100
-		if trimCount > 0 && len(prices) > 2*trimCount {
-			trimmedPrices := prices[trimCount : len(prices)-trimCount]
-			trimmedMean, trimmedSD := calculateStats(trimmedPrices)
-			response["trimmed_set"] = map[string]interface{}{
-				"mean":               fmt.Sprintf("%g", trimmedMean),
-				"size":               len(trimmedPrices),
-				"standard_deviation": fmt.Sprintf("%g", trimmedSD),
-			}
+	if hasTrim && trimValue > 0 {
+		trimCount := len(prices) * int(trimValue) / 100
+		trimmedPrices := prices[trimCount : len(prices)-trimCount]
+		trimmedMean, trimmedSD := calculateStats(trimmedPrices)
+		response["trimmed_set"] = map[string]interface{}{
+			"mean":               fmt.Sprintf("%g", trimmedMean),
+			"size":               uint16(len(trimmedPrices)),
+			"standard_deviation": fmt.Sprintf("%g", trimmedSD),
 		}
 	}
 
 	return response, nil
+}
+
+// parseUintParam parses a JSON value as a non-negative uint32.
+// Supports positive int, uint, and numeric string representations.
+// Matches rippled's validUInt lambda in GetAggregatePrice.cpp.
+func parseUintParam(raw json.RawMessage) (uint32, error) {
+	// Try as number first
+	var f float64
+	if err := json.Unmarshal(raw, &f); err == nil {
+		// Reject negative, non-integer, or NaN values
+		if f < 0 || f != math.Floor(f) || math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0, fmt.Errorf("invalid uint")
+		}
+		return uint32(f), nil
+	}
+	// Try as string containing a number
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		v, err := strconv.ParseUint(s, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("invalid uint string")
+		}
+		return uint32(v), nil
+	}
+	return 0, fmt.Errorf("invalid uint type")
+}
+
+// parseCurrencyParam parses and validates a currency code from a JSON raw value.
+// Returns the currency string or an error if invalid.
+// Matches rippled's getCurrency lambda in GetAggregatePrice.cpp.
+func parseCurrencyParam(raw json.RawMessage) (string, error) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", fmt.Errorf("not a string")
+	}
+	if s == "" {
+		return "", fmt.Errorf("empty currency")
+	}
+	if !isValidCurrency(s) {
+		return "", fmt.Errorf("invalid currency")
+	}
+	return s, nil
+}
+
+// isValidCurrency validates a currency code matching rippled's to_currency().
+// Accepts:
+//   - "XRP" (system currency code)
+//   - 3-character ISO-like codes using alphanumeric + special chars
+//   - 40-character hex strings (160-bit currency)
+func isValidCurrency(code string) bool {
+	if code == "XRP" || code == "xrp" {
+		return true
+	}
+	if len(code) == 3 {
+		for _, c := range code {
+			if !isIsoCurrencyChar(c) {
+				return false
+			}
+		}
+		return true
+	}
+	// 40-character hex representation of 160-bit currency
+	if len(code) == 40 {
+		for _, c := range code {
+			if !isHexChar(c) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// isIsoCurrencyChar matches rippled's isoCharSet:
+// abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789<>(){}[]|?!@#$%^&*
+func isIsoCurrencyChar(c rune) bool {
+	if c >= 'a' && c <= 'z' {
+		return true
+	}
+	if c >= 'A' && c <= 'Z' {
+		return true
+	}
+	if c >= '0' && c <= '9' {
+		return true
+	}
+	switch c {
+	case '<', '>', '(', ')', '{', '}', '[', ']', '|', '?', '!', '@', '#', '$', '%', '^', '&', '*':
+		return true
+	}
+	return false
+}
+
+func isHexChar(c rune) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+// parseOracleDocumentID parses an oracle_document_id from a JSON-decoded interface value.
+// Returns (documentID, true) on success or (0, false) if the value is not a valid uint.
+func parseOracleDocumentID(v interface{}) (uint32, bool) {
+	switch val := v.(type) {
+	case float64:
+		// Reject negative, non-integer, NaN
+		if val < 0 || val != math.Floor(val) || math.IsNaN(val) || math.IsInf(val, 0) {
+			return 0, false
+		}
+		return uint32(val), true
+	case int:
+		if val < 0 {
+			return 0, false
+		}
+		return uint32(val), true
+	case uint32:
+		return val, true
+	case string:
+		// rippled: validUInt supports string representation
+		uv, err := strconv.ParseUint(val, 10, 32)
+		if err != nil {
+			return 0, false
+		}
+		return uint32(uv), true
+	default:
+		return 0, false
+	}
 }
 
 // calculateStats calculates mean and standard deviation for a set of prices

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"strconv"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -13,53 +14,165 @@ import (
 type SimulateMethod struct{}
 
 func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	var request struct {
-		TxBlob string                 `json:"tx_blob,omitempty"`
-		TxJSON map[string]interface{} `json:"tx_json,omitempty"`
-		Binary bool                   `json:"binary,omitempty"`
+	// Parse raw params into a generic map first so we can check for forbidden fields
+	// and validate the `binary` field type before standard unmarshalling.
+	var rawParams map[string]json.RawMessage
+	if params != nil {
+		if err := json.Unmarshal(params, &rawParams); err != nil {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+		}
+	} else {
+		rawParams = make(map[string]json.RawMessage)
 	}
 
-	if params != nil {
-		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+	// Validate `binary` field type if present — must be a boolean.
+	// rippled: if context.params.isMember(jss::binary) && !context.params[jss::binary].isBool()
+	var binaryOutput bool
+	if raw, ok := rawParams["binary"]; ok {
+		if err := json.Unmarshal(raw, &binaryOutput); err != nil {
+			// Not a boolean — return invalid_field_error matching rippled
+			return nil, types.RpcErrorInvalidField("binary")
 		}
 	}
 
-	hasTxBlob := request.TxBlob != ""
-	hasTxJSON := request.TxJSON != nil && len(request.TxJSON) > 0
-
-	if hasTxBlob && hasTxJSON {
-		return nil, types.RpcErrorInvalidParams("Can only include one of `tx_blob` and `tx_json`")
+	// Reject forbidden fields: secret, seed, seed_hex, passphrase.
+	// rippled checks these before parsing tx_json/tx_blob.
+	for _, field := range []string{"secret", "seed", "seed_hex", "passphrase"} {
+		if _, ok := rawParams[field]; ok {
+			return nil, types.RpcErrorInvalidField(field)
+		}
 	}
-	if !hasTxBlob && !hasTxJSON {
-		return nil, types.RpcErrorInvalidParams("Neither `tx_blob` nor `tx_json` included")
+
+	// Determine tx source: exactly one of tx_blob or tx_json.
+	_, hasTxBlobRaw := rawParams["tx_blob"]
+	_, hasTxJsonRaw := rawParams["tx_json"]
+
+	if hasTxBlobRaw && hasTxJsonRaw {
+		return nil, types.RpcErrorInvalidParams("Can only include one of `tx_blob` and `tx_json`.")
+	}
+	if !hasTxBlobRaw && !hasTxJsonRaw {
+		return nil, types.RpcErrorInvalidParams("Neither `tx_blob` nor `tx_json` included.")
 	}
 
 	if types.Services == nil || types.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
-	var txJSON []byte
 	var txJsonMap map[string]interface{}
 
-	if hasTxBlob {
-		// Decode tx_blob to get tx_json
-		decoded, err := binarycodec.Decode(request.TxBlob)
+	if hasTxBlobRaw {
+		// Decode tx_blob string
+		var txBlobStr string
+		if err := json.Unmarshal(rawParams["tx_blob"], &txBlobStr); err != nil {
+			return nil, types.RpcErrorInvalidField("tx_blob")
+		}
+		if txBlobStr == "" {
+			return nil, types.RpcErrorInvalidField("tx_blob")
+		}
+		decoded, err := binarycodec.Decode(txBlobStr)
 		if err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid tx_blob: " + err.Error())
+			return nil, types.RpcErrorInvalidField("tx_blob")
 		}
 		txJsonMap = decoded
-		txJSON, err = json.Marshal(decoded)
-		if err != nil {
-			return nil, types.RpcErrorInternal("Failed to marshal decoded tx_blob")
-		}
 	} else {
-		txJsonMap = request.TxJSON
-		var err error
-		txJSON, err = json.Marshal(request.TxJSON)
-		if err != nil {
-			return nil, types.RpcErrorInternal("Failed to marshal tx_json")
+		// Parse tx_json object
+		var txObj map[string]interface{}
+		if err := json.Unmarshal(rawParams["tx_json"], &txObj); err != nil {
+			// tx_json is not an object
+			return nil, types.RpcErrorExpectedField("tx_json", "object")
 		}
+		if len(txObj) == 0 {
+			// Empty tx_json — will fail TransactionType check below
+		}
+		txJsonMap = txObj
+	}
+
+	// Basic sanity checks for transaction shape (matching rippled getTxJsonFromParams).
+	if _, ok := txJsonMap["TransactionType"]; !ok {
+		return nil, types.RpcErrorMissingField("tx.TransactionType")
+	}
+	if _, ok := txJsonMap["Account"]; !ok {
+		return nil, types.RpcErrorMissingField("tx.Account")
+	}
+
+	// Validate Account is a valid Base58 address.
+	// rippled: getAutofillSequence checks parseBase58<AccountID>(accountStr) and returns
+	// rpcSRC_ACT_MALFORMED with message "Invalid field 'tx.Account'."
+	accountStr, ok := txJsonMap["Account"].(string)
+	if !ok || !types.IsValidXRPLAddress(accountStr) {
+		return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx.Account'.")
+	}
+
+	// --- Autofill fields (handler-level, no ledger access needed) ---
+	// Reference: rippled autofillTx()
+
+	// Autofill SigningPubKey: if not present, set to ""
+	if _, ok := txJsonMap["SigningPubKey"]; !ok {
+		txJsonMap["SigningPubKey"] = ""
+	}
+
+	// Validate and autofill Signers array.
+	// rippled checks Signers before TxnSignature.
+	if signersRaw, ok := txJsonMap["Signers"]; ok {
+		signers, ok := signersRaw.([]interface{})
+		if !ok {
+			return nil, types.RpcErrorInvalidField("tx.Signers")
+		}
+		for i, signerEntry := range signers {
+			entryObj, ok := signerEntry.(map[string]interface{})
+			if !ok {
+				return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
+			}
+			signerInner, ok := entryObj["Signer"]
+			if !ok {
+				return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
+			}
+			signerObj, ok := signerInner.(map[string]interface{})
+			if !ok {
+				return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
+			}
+
+			// Autofill SigningPubKey if not present
+			if _, ok := signerObj["SigningPubKey"]; !ok {
+				signerObj["SigningPubKey"] = ""
+			}
+
+			// Autofill TxnSignature if not present; reject if non-empty
+			if txnSig, ok := signerObj["TxnSignature"]; !ok {
+				signerObj["TxnSignature"] = ""
+			} else {
+				sigStr, _ := txnSig.(string)
+				if sigStr != "" {
+					return nil, types.RpcErrorTxSigned()
+				}
+			}
+		}
+	}
+
+	// Autofill TxnSignature: if not present, set to "". If present and non-empty, reject.
+	if txnSig, ok := txJsonMap["TxnSignature"]; !ok {
+		txJsonMap["TxnSignature"] = ""
+	} else {
+		sigStr, _ := txnSig.(string)
+		if sigStr != "" {
+			return nil, types.RpcErrorTxSigned()
+		}
+	}
+
+	// TODO: Autofill Sequence from ledger (service-level) — getAutofillSequence
+	// TODO: Autofill Fee from ledger (service-level) — getCurrentNetworkFee
+	// TODO: Autofill NetworkID from config (service-level)
+
+	// Reject Batch transaction type.
+	// rippled: if (stTx->getTxnType() == ttBATCH) return RPC::make_error(rpcNOT_IMPL)
+	if txType, ok := txJsonMap["TransactionType"].(string); ok && txType == "Batch" {
+		return nil, types.RpcErrorNotImpl()
+	}
+
+	// Marshal tx_json for service call
+	txJSON, err := json.Marshal(txJsonMap)
+	if err != nil {
+		return nil, types.RpcErrorInternal("Failed to marshal tx_json")
 	}
 
 	// Run the transaction in simulation mode (snapshot, no commit)
@@ -76,7 +189,10 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		"ledger_index":          result.CurrentLedger,
 	}
 
-	if request.Binary {
+	// TODO: Include metadata when SubmitResult is extended with a Metadata field.
+	// rippled returns "meta" (JSON) or "meta_blob" (binary) from the simulation result.
+
+	if binaryOutput {
 		if encoded, err := binarycodec.Encode(txJsonMap); err == nil {
 			response["tx_blob"] = encoded
 		}
@@ -98,3 +214,4 @@ func (m *SimulateMethod) SupportedApiVersions() []int {
 func (m *SimulateMethod) RequiredCondition() types.Condition {
 	return types.NeedsCurrentLedger
 }
+

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -561,7 +561,12 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 
 	method := &handlers.GetAggregatePriceMethod{}
 
-	t.Run("Missing oracles parameter returns error", func(t *testing.T) {
+	// Convenience helper to make a valid-looking oracle entry for params
+	// (uses a real-format r-address so account parsing doesn't fail before
+	// the check we actually want to test).
+	validOracle := `{"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", "oracle_document_id": 1}`
+
+	t.Run("Missing oracles parameter returns missing_field_error", func(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
@@ -574,36 +579,190 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+		assert.Equal(t, "Missing field 'oracles'.", rpcErr.Message)
 	})
 
-	t.Run("Missing base_asset returns error", func(t *testing.T) {
+	t.Run("Empty oracles array returns oracleMalformed", func(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
 		}
 
-		params := json.RawMessage(`{"quote_asset": "USD", "oracles": []}`)
+		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": []}`)
 		result, rpcErr := method.Handle(ctx, params)
 
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
-		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, types.RpcORACLE_MALFORMED, rpcErr.Code)
+		assert.Equal(t, "oracleMalformed", rpcErr.ErrorString)
 	})
 
-	t.Run("Missing quote_asset returns error", func(t *testing.T) {
+	t.Run("Oracles not array returns oracleMalformed", func(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
 		}
 
-		params := json.RawMessage(`{"base_asset": "XRP", "oracles": []}`)
+		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": "bad"}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcORACLE_MALFORMED, rpcErr.Code)
+		assert.Equal(t, "oracleMalformed", rpcErr.ErrorString)
+	})
+
+	t.Run("Missing base_asset returns missing_field_error", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		params := json.RawMessage(`{"quote_asset": "USD", "oracles": [` + validOracle + `]}`)
 		result, rpcErr := method.Handle(ctx, params)
 
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Missing field 'base_asset'.", rpcErr.Message)
+	})
+
+	t.Run("Missing quote_asset returns missing_field_error", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		params := json.RawMessage(`{"base_asset": "XRP", "oracles": [` + validOracle + `]}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Missing field 'quote_asset'.", rpcErr.Message)
+	})
+
+	t.Run("Trim=0 returns invalidParams", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": [` + validOracle + `], "trim": 0}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+	})
+
+	t.Run("Trim=26 returns invalidParams", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": [` + validOracle + `], "trim": 26}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+	})
+
+	t.Run("Invalid base_asset returns invalidParams", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		// empty string
+		params := json.RawMessage(`{"base_asset": "", "quote_asset": "USD", "oracles": [` + validOracle + `]}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+
+		// invalid currency (4 chars, not hex)
+		params = json.RawMessage(`{"base_asset": "ABCD", "quote_asset": "USD", "oracles": [` + validOracle + `]}`)
+		result, rpcErr = method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+	})
+
+	t.Run("Oracle entry missing account returns oracleMalformed", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": [{"oracle_document_id": 1}]}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcORACLE_MALFORMED, rpcErr.Code)
+		assert.Equal(t, "oracleMalformed", rpcErr.ErrorString)
+	})
+
+	t.Run("Oracle entry missing oracle_document_id returns oracleMalformed", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": [{"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}]}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcORACLE_MALFORMED, rpcErr.Code)
+		assert.Equal(t, "oracleMalformed", rpcErr.ErrorString)
+	})
+
+	t.Run("Invalid trim type returns invalidParams", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		// float trim
+		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": [` + validOracle + `], "trim": 1.2}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+	})
+
+	t.Run("Invalid time_threshold type returns invalidParams", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+		}
+
+		// non-numeric time_threshold
+		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": [` + validOracle + `], "time_threshold": "none"}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "invalidParams", rpcErr.ErrorString)
 	})
 
 	t.Run("RequiredRole is Guest", func(t *testing.T) {

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -1,0 +1,499 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockLedgerServiceSimulate extends mockLedgerService with simulate-specific behavior.
+type mockLedgerServiceSimulate struct {
+	*mockLedgerService
+	simulateResult *types.SubmitResult
+	simulateError  error
+}
+
+func newMockLedgerServiceSimulate() *mockLedgerServiceSimulate {
+	return &mockLedgerServiceSimulate{
+		mockLedgerService: newMockLedgerService(),
+		simulateResult: &types.SubmitResult{
+			EngineResult:        "tesSUCCESS",
+			EngineResultCode:    0,
+			EngineResultMessage: "The simulated transaction would have been applied.",
+			Applied:             false,
+			CurrentLedger:       3,
+		},
+	}
+}
+
+func (m *mockLedgerServiceSimulate) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
+	if m.simulateError != nil {
+		return nil, m.simulateError
+	}
+	return m.simulateResult, nil
+}
+
+func setupTestServicesSimulate(mock *mockLedgerServiceSimulate) func() {
+	oldServices := types.Services
+	types.Services = &types.ServiceContainer{
+		Ledger: mock,
+	}
+	return func() {
+		types.Services = oldServices
+	}
+}
+
+// validAccountAddress is a well-known XRPL genesis account used in tests.
+const validAccountAddress = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+func TestSimulateMethod_ParamErrors(t *testing.T) {
+	mock := newMockLedgerServiceSimulate()
+	cleanup := setupTestServicesSimulate(mock)
+	defer cleanup()
+
+	method := &handlers.SimulateMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+	}
+
+	tests := []struct {
+		name         string
+		params       interface{}
+		expectedMsg  string
+		expectedCode int
+	}{
+		{
+			name:         "No params — neither tx_blob nor tx_json",
+			params:       map[string]interface{}{},
+			expectedMsg:  "Neither `tx_blob` nor `tx_json` included.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "Both tx_blob and tx_json",
+			params: map[string]interface{}{
+				"tx_blob": "1200",
+				"tx_json": map[string]interface{}{},
+			},
+			expectedMsg:  "Can only include one of `tx_blob` and `tx_json`.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "binary is not a boolean",
+			params: map[string]interface{}{
+				"tx_blob": "1200",
+				"binary":  "100",
+			},
+			expectedMsg:  "Invalid field 'binary'.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "binary is an integer",
+			params: map[string]interface{}{
+				"tx_blob": "1200",
+				"binary":  1,
+			},
+			expectedMsg:  "Invalid field 'binary'.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "secret field included",
+			params: map[string]interface{}{
+				"secret": "doesnt_matter",
+				"tx_json": map[string]interface{}{
+					"TransactionType": "AccountSet",
+					"Account":         validAccountAddress,
+				},
+			},
+			expectedMsg:  "Invalid field 'secret'.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "seed field included",
+			params: map[string]interface{}{
+				"seed": "doesnt_matter",
+				"tx_json": map[string]interface{}{
+					"TransactionType": "AccountSet",
+					"Account":         validAccountAddress,
+				},
+			},
+			expectedMsg:  "Invalid field 'seed'.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "seed_hex field included",
+			params: map[string]interface{}{
+				"seed_hex": "doesnt_matter",
+				"tx_json": map[string]interface{}{
+					"TransactionType": "AccountSet",
+					"Account":         validAccountAddress,
+				},
+			},
+			expectedMsg:  "Invalid field 'seed_hex'.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "passphrase field included",
+			params: map[string]interface{}{
+				"passphrase": "doesnt_matter",
+				"tx_json": map[string]interface{}{
+					"TransactionType": "AccountSet",
+					"Account":         validAccountAddress,
+				},
+			},
+			expectedMsg:  "Invalid field 'passphrase'.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "Empty tx_json — missing TransactionType",
+			params: map[string]interface{}{
+				"tx_json": map[string]interface{}{},
+			},
+			expectedMsg:  "Missing field 'tx.TransactionType'.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "Missing Account field",
+			params: map[string]interface{}{
+				"tx_json": map[string]interface{}{
+					"TransactionType": "Payment",
+				},
+			},
+			expectedMsg:  "Missing field 'tx.Account'.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "Bad Account address",
+			params: map[string]interface{}{
+				"tx_json": map[string]interface{}{
+					"TransactionType": "AccountSet",
+					"Account":         "badAccount",
+				},
+			},
+			expectedMsg:  "Invalid field 'tx.Account'.",
+			expectedCode: types.RpcSRC_ACT_MALFORMED,
+		},
+		{
+			name: "tx_json is not an object (string)",
+			params: map[string]interface{}{
+				"tx_json": "not_an_object",
+			},
+			expectedMsg:  "Invalid field 'tx_json', not object.",
+			expectedCode: types.RpcINVALID_PARAMS,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			paramsJSON, err := json.Marshal(tc.params)
+			require.NoError(t, err)
+
+			_, rpcErr := method.Handle(ctx, paramsJSON)
+			require.NotNil(t, rpcErr, "Expected an error but got nil")
+			assert.Equal(t, tc.expectedCode, rpcErr.Code, "Error code mismatch")
+			assert.Equal(t, tc.expectedMsg, rpcErr.Message, "Error message mismatch")
+		})
+	}
+}
+
+func TestSimulateMethod_TxnSignature(t *testing.T) {
+	mock := newMockLedgerServiceSimulate()
+	cleanup := setupTestServicesSimulate(mock)
+	defer cleanup()
+
+	method := &handlers.SimulateMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+	}
+
+	t.Run("Signed transaction — non-empty TxnSignature", func(t *testing.T) {
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"TxnSignature":    "1200ABCD",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcTX_SIGNED, rpcErr.Code)
+		assert.Equal(t, "transactionSigned", rpcErr.ErrorString)
+		assert.Equal(t, "Transaction should not be signed.", rpcErr.Message)
+	})
+
+	t.Run("Empty TxnSignature — allowed", func(t *testing.T) {
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"TxnSignature":    "",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, rpcErr, "Empty TxnSignature should be allowed")
+		assert.NotNil(t, result)
+	})
+
+	t.Run("Missing TxnSignature — autofilled to empty", func(t *testing.T) {
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, rpcErr, "Missing TxnSignature should be autofilled")
+		require.NotNil(t, result)
+
+		resp, ok := result.(map[string]interface{})
+		require.True(t, ok)
+		txJSON, ok := resp["tx_json"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "", txJSON["TxnSignature"], "TxnSignature should be autofilled to empty string")
+		assert.Equal(t, "", txJSON["SigningPubKey"], "SigningPubKey should be autofilled to empty string")
+	})
+}
+
+func TestSimulateMethod_SignedMultisig(t *testing.T) {
+	mock := newMockLedgerServiceSimulate()
+	cleanup := setupTestServicesSimulate(mock)
+	defer cleanup()
+
+	method := &handlers.SimulateMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+	}
+
+	t.Run("Signed multisig transaction — non-empty signer TxnSignature", func(t *testing.T) {
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"Signers": []interface{}{
+					map[string]interface{}{
+						"Signer": map[string]interface{}{
+							"Account":       validAccountAddress,
+							"SigningPubKey": validAccountAddress,
+							"TxnSignature":  "1200ABCD",
+						},
+					},
+				},
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcTX_SIGNED, rpcErr.Code)
+		assert.Equal(t, "Transaction should not be signed.", rpcErr.Message)
+	})
+
+	t.Run("Invalid Signers field — not an array", func(t *testing.T) {
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"Signers":         "1",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'tx.Signers'.", rpcErr.Message)
+	})
+
+	t.Run("Invalid Signers entry — not an object", func(t *testing.T) {
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"Signers":         []interface{}{"1"},
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'tx.Signers[0]'.", rpcErr.Message)
+	})
+
+	t.Run("Signers autofill — missing SigningPubKey and TxnSignature", func(t *testing.T) {
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"Signers": []interface{}{
+					map[string]interface{}{
+						"Signer": map[string]interface{}{
+							"Account": validAccountAddress,
+						},
+					},
+				},
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, rpcErr, "Valid signers without TxnSignature should pass")
+		require.NotNil(t, result)
+
+		resp, ok := result.(map[string]interface{})
+		require.True(t, ok)
+		txJSON, ok := resp["tx_json"].(map[string]interface{})
+		require.True(t, ok)
+
+		signers, ok := txJSON["Signers"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, signers, 1)
+
+		entry, ok := signers[0].(map[string]interface{})
+		require.True(t, ok)
+		signer, ok := entry["Signer"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "", signer["SigningPubKey"], "Signer SigningPubKey should be autofilled")
+		assert.Equal(t, "", signer["TxnSignature"], "Signer TxnSignature should be autofilled")
+	})
+}
+
+func TestSimulateMethod_BatchRejection(t *testing.T) {
+	mock := newMockLedgerServiceSimulate()
+	cleanup := setupTestServicesSimulate(mock)
+	defer cleanup()
+
+	method := &handlers.SimulateMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+	}
+
+	params := map[string]interface{}{
+		"tx_json": map[string]interface{}{
+			"TransactionType": "Batch",
+			"Account":         validAccountAddress,
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	_, rpcErr := method.Handle(ctx, paramsJSON)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcNOT_IMPL, rpcErr.Code)
+	assert.Equal(t, "notImpl", rpcErr.ErrorString)
+	assert.Equal(t, "Not implemented.", rpcErr.Message)
+}
+
+func TestSimulateMethod_SuccessfulSimulation(t *testing.T) {
+	mock := newMockLedgerServiceSimulate()
+	cleanup := setupTestServicesSimulate(mock)
+	defer cleanup()
+
+	method := &handlers.SimulateMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+	}
+
+	params := map[string]interface{}{
+		"tx_json": map[string]interface{}{
+			"TransactionType": "AccountSet",
+			"Account":         validAccountAddress,
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	result, rpcErr := method.Handle(ctx, paramsJSON)
+	assert.Nil(t, rpcErr, "Expected no error for valid simulation")
+	require.NotNil(t, result)
+
+	resp, ok := result.(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "tesSUCCESS", resp["engine_result"])
+	assert.Equal(t, 0, resp["engine_result_code"])
+	assert.Equal(t, "The simulated transaction would have been applied.", resp["engine_result_message"])
+	assert.Equal(t, false, resp["applied"])
+	assert.Equal(t, uint32(3), resp["ledger_index"])
+
+	// Verify tx_json is returned with autofilled fields
+	txJSON, ok := resp["tx_json"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "AccountSet", txJSON["TransactionType"])
+	assert.Equal(t, validAccountAddress, txJSON["Account"])
+	assert.Equal(t, "", txJSON["SigningPubKey"])
+	assert.Equal(t, "", txJSON["TxnSignature"])
+}
+
+func TestSimulateMethod_SrcActMalformed(t *testing.T) {
+	mock := newMockLedgerServiceSimulate()
+	cleanup := setupTestServicesSimulate(mock)
+	defer cleanup()
+
+	method := &handlers.SimulateMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+	}
+
+	params := map[string]interface{}{
+		"tx_json": map[string]interface{}{
+			"TransactionType": "AccountSet",
+			"Account":         "badAccount",
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	_, rpcErr := method.Handle(ctx, paramsJSON)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcSRC_ACT_MALFORMED, rpcErr.Code)
+	assert.Equal(t, "srcActMalformed", rpcErr.ErrorString)
+	assert.Equal(t, "Invalid field 'tx.Account'.", rpcErr.Message)
+}
+
+func TestSimulateMethod_RequiredRole(t *testing.T) {
+	method := &handlers.SimulateMethod{}
+	assert.Equal(t, types.RoleGuest, method.RequiredRole())
+}
+
+func TestSimulateMethod_RequiredCondition(t *testing.T) {
+	method := &handlers.SimulateMethod{}
+	assert.Equal(t, types.NeedsCurrentLedger, method.RequiredCondition())
+}
+
+func TestSimulateMethod_SupportedApiVersions(t *testing.T) {
+	method := &handlers.SimulateMethod{}
+	versions := method.SupportedApiVersions()
+	assert.Contains(t, versions, types.ApiVersion1)
+	assert.Contains(t, versions, types.ApiVersion2)
+	assert.Contains(t, versions, types.ApiVersion3)
+}

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -81,8 +81,8 @@ const (
 	// Rate limiting
 	RpcSLOW_DOWN_INVALID_IP = 36
 
-	// Oracle errors
-	RpcORACLE_MALFORMED = 37
+	// Oracle errors — must match rippled exactly (rpcORACLE_MALFORMED = 94)
+	RpcORACLE_MALFORMED = 94
 
 	// Amendment and feature errors
 	RpcINVALID_API_VERSION = 38
@@ -123,6 +123,10 @@ const (
 
 	// Credential errors - must match rippled exactly
 	RpcBAD_CREDENTIALS = 95 // Credentials do not exist, are not accepted, or have expired
+
+	// Simulate errors - must match rippled exactly
+	RpcTX_SIGNED        = 96 // Transaction should not be signed (rippled: rpcTX_SIGNED = 96)
+	RpcSRC_ACT_MALFORMED = 65 // Source account is malformed (rippled: rpcSRC_ACT_MALFORMED = 65)
 )
 
 // Standard error constructors
@@ -249,4 +253,28 @@ func RpcErrorMissingField(field string) *RpcError {
 // RpcErrorInvalidField returns an error for invalid field value (matches rippled invalid_field_error)
 func RpcErrorInvalidField(field string) *RpcError {
 	return NewRpcError(RpcINVALID_PARAMS, "invalidParams", "invalidParams", "Invalid field '"+field+"'.")
+}
+
+// RpcErrorTxSigned returns an error when a transaction is pre-signed but should not be
+// (matches rippled rpcTX_SIGNED, code 96, token "transactionSigned").
+func RpcErrorTxSigned() *RpcError {
+	return NewRpcError(RpcTX_SIGNED, "transactionSigned", "transactionSigned", "Transaction should not be signed.")
+}
+
+// RpcErrorSrcActMalformed returns an error when the source account address is malformed
+// (matches rippled rpcSRC_ACT_MALFORMED, code 65, token "srcActMalformed").
+func RpcErrorSrcActMalformed(message string) *RpcError {
+	return NewRpcError(RpcSRC_ACT_MALFORMED, "srcActMalformed", "srcActMalformed", message)
+}
+
+// RpcErrorNotImpl returns an error for unimplemented features
+// (matches rippled rpcNOT_IMPL, code 74, token "notImpl").
+func RpcErrorNotImpl() *RpcError {
+	return NewRpcError(RpcNOT_IMPL, "notImpl", "notImpl", "Not implemented.")
+}
+
+// RpcErrorOracleMalformed returns an error for malformed oracle requests
+// (matches rippled rpcORACLE_MALFORMED, code 94, token "oracleMalformed").
+func RpcErrorOracleMalformed() *RpcError {
+	return NewRpcError(RpcORACLE_MALFORMED, "oracleMalformed", "oracleMalformed", "Oracle request is malformed.")
 }


### PR DESCRIPTION
## Summary
Final batch of RPC conformance handler-level fixes:

- **deposit_authorized** (#111): Handler-level Base58 address validation via `ValidateAccount()`, duplicate credential detection returning `rpcBAD_CREDENTIALS`. TODOs for 5 ledger-side credential checks.
- **get_aggregate_price** (#118): Fixed `rpcORACLE_MALFORMED` error code to 94 (was 37), proper `missing_field_error` for required params, trim=0 rejection, currency validation (3-char ISO + 40-char hex), `rpcOBJECT_NOT_FOUND` for no prices. TODO for float64→STAmount precision.
- **simulate** (#99): Forbidden field rejection (`secret`/`seed`/`seed_hex`/`passphrase`), pre-signed transaction rejection (`rpcTX_SIGNED` code 96), `SigningPubKey`/`TxnSignature` autofill to `""`, Signers array validation, Account Base58 validation (`rpcSRC_ACT_MALFORMED` code 65), Batch tx rejection (`rpcNOT_IMPL`). TODOs for Sequence/Fee/NetworkID autofill.

## Test plan
- [x] All RPC tests pass (`go test -count=1 ./internal/rpc/...`)
- [x] `go build` clean
- [x] 13 new deposit_authorized tests (address validation, credential duplicates)
- [x] 13 new/updated get_aggregate_price tests (error codes, validation)
- [x] 30 new simulate tests (param errors, TxnSignature, multisig, batch rejection)

Closes #99, closes #111, closes #118