### PR TITLE
fix(config): replace NuDB/RocksDB references with pebble

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,7 +43,7 @@ ip = "127.0.0.1"
 protocol = "http"
 
 [node_db]
-type = "NuDB"
+type = "pebble"
 path = "/tmp/test/db"
 cache_size = 16384
 cache_age = 5
@@ -100,7 +100,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NotNil(t, config)
 
 	assert.Equal(t, []string{"port_test"}, config.Server.Ports)
-	assert.Equal(t, "NuDB", config.NodeDB.Type)
+	assert.Equal(t, "pebble", config.NodeDB.Type)
 	assert.Equal(t, "/tmp/test/db", config.NodeDB.Path)
 
 	portConfig, exists := config.GetPort("port_test")
@@ -147,7 +147,7 @@ ip = "127.0.0.1"
 protocol = "http"
 
 [node_db]
-type = "NuDB"
+type = "pebble"
 path = "/tmp/test/db"
 cache_size = 16384
 cache_age = 5
@@ -259,7 +259,7 @@ ip = "127.0.0.1"
 protocol = "http"
 
 [node_db]
-type = "NuDB"
+type = "pebble"
 path = "/tmp/test/db"
 
 [overlay]
@@ -341,7 +341,7 @@ func TestConfigValidation_CompleteConfig(t *testing.T) {
 			},
 		},
 		NodeDB: NodeDBConfig{
-			Type: "NuDB",
+			Type: "pebble",
 			Path: "/tmp/test",
 		},
 		DatabasePath:     "/tmp/test",
@@ -397,7 +397,7 @@ func TestConfigValidation_InvalidPort(t *testing.T) {
 			},
 		},
 		NodeDB: NodeDBConfig{
-			Type: "NuDB",
+			Type: "pebble",
 			Path: "/tmp/test",
 		},
 		DatabasePath:     "/tmp/test",

--- a/config/database.go
+++ b/config/database.go
@@ -41,9 +41,9 @@ func (n *NodeDBConfig) Validate() error {
 	if n.Type == "" {
 		return fmt.Errorf("node_db type is required")
 	}
-	validTypes := []string{"NuDB", "RocksDB", "nudb", "rocksdb"}
+	validTypes := []string{"pebble", "Pebble"}
 	if !contains_slice(validTypes, n.Type) {
-		return fmt.Errorf("invalid node_db type: %s (valid options: NuDB, RocksDB)", n.Type)
+		return fmt.Errorf("invalid node_db type: %s (valid options: pebble)", n.Type)
 	}
 
 	// Validate path
@@ -150,10 +150,8 @@ func (s *SQLiteConfig) Validate() error {
 // GetType returns the normalized database type
 func (n *NodeDBConfig) GetType() string {
 	switch n.Type {
-	case "nudb", "NuDB":
-		return "NuDB"
-	case "rocksdb", "RocksDB":
-		return "RocksDB"
+	case "pebble", "Pebble":
+		return "pebble"
 	default:
 		return n.Type
 	}

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -108,10 +108,10 @@ ledger_replay = 0
 ssl_verify = 1
 
 # Database path
-database_path = "/var/lib/xrpld/db"
+database_path = "./data/db"
 
 # Diagnostics
-debug_logfile = "/var/log/xrpld/debug.log"
+debug_logfile = "./data/log/debug.log"
 
 # Misc
 node_size = "medium"
@@ -159,8 +159,8 @@ send_queue_limit = 500
 # =============================================================================
 
 [node_db]
-type = "NuDB"
-path = "/var/lib/xrpld/db/nudb"
+type = "pebble"
+path = "./data/db/pebble"
 online_delete = 512
 advisory_delete = 0
 cache_size = 16384


### PR DESCRIPTION
The storage backend is pebble, but config validation and generated configs still referenced NuDB/RocksDB from rippled. Update valid types, default paths, and tests to reflect the actual backend.