### PR TITLE
fix(rpc): use roleForRequest for WebSocket connections

### DIFF
--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -234,12 +234,14 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	}
 
 	// Create RPC context
+	clientIP := getWebSocketClientIP(wsConn.conn)
+	role := roleForRequest(clientIP)
 	rpcCtx := &types.RpcContext{
 		Context:    wsConn.ctx,
-		Role:       types.RoleGuest,
+		Role:       role,
 		ApiVersion: apiVersion,
-		IsAdmin:    false,
-		ClientIP:   getWebSocketClientIP(wsConn.conn),
+		IsAdmin:    role == types.RoleAdmin,
+		ClientIP:   clientIP,
 	}
 
 	// Handle subscription commands specially


### PR DESCRIPTION
## Summary

- WebSocket handler was hardcoding `RoleGuest` for all connections, blocking `submit` (requires `RoleUser`) and `ledger_accept` (requires `RoleAdmin`) even from localhost
- Now calls `roleForRequest(clientIP)` — the same function the HTTP server already uses — granting `RoleAdmin` to localhost connections

Closes #127

## Test plan

- [ ] `go test ./internal/rpc/...` passes
- [ ] `submit` works via WebSocket from localhost
- [ ] `ledger_accept` works via WebSocket from localhost (standalone mode)
- [ ] Remote connections still receive `RoleGuest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)