### PR TITLE
feat: implement ledger persistence recovery

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	standalone bool
+	startFresh bool
 )
 
 // serverCmd represents the server command (default action)
@@ -51,6 +52,7 @@ func init() {
 
 	// Server-specific flags — operational concerns only
 	serverCmd.Flags().BoolVarP(&standalone, "standalone", "a", false, "run in standalone mode (no peers)")
+	serverCmd.Flags().BoolVar(&startFresh, "start", false, "start fresh (ignore persisted ledger state)")
 }
 
 func runServer(cmd *cobra.Command, args []string) {
@@ -179,6 +181,9 @@ func runServer(cmd *cobra.Command, args []string) {
 		Standalone:   standalone,
 		NodeStore:    db,
 		RelationalDB: repoManager,
+	}
+	if startFresh {
+		cfg.StartupMode = service.StartupFresh
 	}
 	if standalone {
 		cfg.GenesisConfig = genesisConfig

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -577,6 +577,34 @@ func (l *Ledger) SetStateMapFamily(family shamap.Family) {
 	l.stateMap.SetFamily(family)
 }
 
+// SetTxMapFamily sets the Family on the transaction map, enabling backed mode
+// with lazy loading and efficient snapshots.
+func (l *Ledger) SetTxMapFamily(family shamap.Family) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.txMap.SetFamily(family)
+}
+
+// FlushDirtyNodes flushes all dirty SHAMap nodes (both state and tx maps)
+// and returns the batches. This must be called before persisting to the NodeStore
+// so that inner nodes are also stored (not just leaves).
+func (l *Ledger) FlushDirtyNodes() (*shamap.NodeBatch, *shamap.NodeBatch, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	stateBatch, err := l.stateMap.FlushDirty(false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	txBatch, err := l.txMap.FlushDirty(false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return stateBatch, txBatch, nil
+}
+
 // SerializeHeader returns the serialized ledger header bytes
 func (l *Ledger) SerializeHeader() []byte {
 	l.mu.RLock()

--- a/internal/ledger/service/persistence.go
+++ b/internal/ledger/service/persistence.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/shamap"
 	"github.com/LeJamon/goXRPLd/storage/nodestore"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
@@ -30,30 +32,35 @@ func (s *Service) persistLedger(l *ledger.Ledger) error {
 	return nil
 }
 
-// persistToNodeStore writes ledger state to the nodestore
+// persistToNodeStore writes ledger state to the nodestore.
+// This stores both the SHAMap inner nodes and leaf nodes in prefix-serialized
+// format so that NewFromRootHash() can reconstruct the tree via lazy loading.
 func (s *Service) persistToNodeStore(ctx context.Context, l *ledger.Ledger, seq uint32) error {
-	// Collect nodes to store in batch
-	var nodes []*nodestore.Node
+	// Ensure the SHAMaps have a Family set so FlushDirty knows how to serialize
+	family := s.getOrCreateFamily()
 
-	// Persist state map entries
-	err := l.ForEach(func(key [32]byte, data []byte) bool {
-		node := &nodestore.Node{
-			Type:      nodestore.NodeAccount,
-			Hash:      nodestore.Hash256(key),
-			Data:      data,
-			LedgerSeq: seq,
-		}
-		nodes = append(nodes, node)
-		return true
-	})
+	l.SetStateMapFamily(family)
+	l.SetTxMapFamily(family)
+
+	// Flush all dirty SHAMap nodes (inner + leaf) in prefix-serialized format.
+	// This is critical for recovery: NewFromRootHash() needs inner nodes in the
+	// NodeStore for lazy loading to work.
+	stateBatch, txBatch, err := l.FlushDirtyNodes()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to flush dirty nodes: %w", err)
 	}
 
-	// Store nodes in batch for efficiency
-	if len(nodes) > 0 {
-		if err := s.nodeStore.StoreBatch(ctx, nodes); err != nil {
-			return err
+	// Store state map nodes
+	if len(stateBatch.Entries) > 0 {
+		if err := family.StoreBatch(stateBatch.Entries); err != nil {
+			return fmt.Errorf("failed to store state map nodes: %w", err)
+		}
+	}
+
+	// Store transaction map nodes
+	if len(txBatch.Entries) > 0 {
+		if err := family.StoreBatch(txBatch.Entries); err != nil {
+			return fmt.Errorf("failed to store tx map nodes: %w", err)
 		}
 	}
 
@@ -66,11 +73,21 @@ func (s *Service) persistToNodeStore(ctx context.Context, l *ledger.Ledger, seq 
 		LedgerSeq: seq,
 	}
 	if err := s.nodeStore.Store(ctx, headerNode); err != nil {
-		return err
+		return fmt.Errorf("failed to store ledger header: %w", err)
 	}
 
 	// Sync to ensure durability
 	return s.nodeStore.Sync()
+}
+
+// getOrCreateFamily returns the NodeStoreFamily for this service.
+// It wraps the existing nodeStore database.
+func (s *Service) getOrCreateFamily() *shamap.NodeStoreFamily {
+	if s.family != nil {
+		return s.family
+	}
+	s.family = shamap.NewNodeStoreFamily(s.nodeStore)
+	return s.family
 }
 
 // persistToRelationalDB writes ledger metadata to the relational database

--- a/internal/ledger/service/recovery.go
+++ b/internal/ledger/service/recovery.go
@@ -1,0 +1,191 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/shamap"
+	"github.com/LeJamon/goXRPLd/storage/nodestore"
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+// latestLedgerHash finds the hash of the latest persisted ledger.
+// It first checks RelationalDB (if configured), then falls back to scanning
+// the NodeStore for ledger header nodes.
+// Returns the hash, whether a ledger was found, and any error.
+func latestLedgerHash(ctx context.Context, relDB relationaldb.RepositoryManager, ns nodestore.Database) (hash [32]byte, found bool, err error) {
+	// Try RelationalDB first — it has an index for fast lookup
+	if relDB != nil {
+		info, err := relDB.Ledger().GetNewestLedgerInfo(ctx)
+		if err == nil && info != nil {
+			return [32]byte(info.Hash), true, nil
+		}
+		// Not found or error — fall through to NodeStore
+	}
+
+	// Fall back to NodeStore: scan for NodeLedger entries
+	// The NodeStore doesn't have an index by sequence, so we scan all entries
+	// and pick the one with the highest sequence number.
+	if ns != nil {
+		var bestSeq uint32
+		var bestHash [32]byte
+		foundAny := false
+
+		// Use ForEach on the backend if it's a KV database
+		if kvDB, ok := ns.(*nodestore.KVDatabaseImpl); ok {
+			_ = kvDB.ForEach(func(node *nodestore.Node) error {
+				if node.Type == nodestore.NodeLedger {
+					// Deserialize header to get sequence
+					hdr, err := header.DeserializeHeader(node.Data, true)
+					if err != nil {
+						return nil // skip corrupt entries
+					}
+					if !foundAny || hdr.LedgerIndex > bestSeq {
+						bestSeq = hdr.LedgerIndex
+						bestHash = [32]byte(node.Hash)
+						foundAny = true
+					}
+				}
+				return nil
+			})
+		}
+
+		if foundAny {
+			return bestHash, true, nil
+		}
+	}
+
+	return [32]byte{}, false, nil
+}
+
+// loadLedger reconstructs a Ledger from a persisted ledger header hash.
+// It fetches the header from the NodeStore, deserializes it, then creates
+// backed SHAMaps from the stored root hashes for lazy loading of state.
+func (s *Service) loadLedger(ctx context.Context, ledgerHash [32]byte) (*ledger.Ledger, error) {
+	if s.nodeStore == nil {
+		return nil, fmt.Errorf("cannot load ledger: no NodeStore configured")
+	}
+
+	// 1. Fetch the ledger header node from NodeStore
+	headerNode, err := s.nodeStore.Fetch(ctx, nodestore.Hash256(ledgerHash))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch ledger header: %w", err)
+	}
+	if headerNode == nil {
+		return nil, fmt.Errorf("ledger header %x not found in NodeStore", ledgerHash[:8])
+	}
+
+	// 2. Deserialize the header
+	hdr, err := header.DeserializeHeader(headerNode.Data, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize ledger header: %w", err)
+	}
+
+	// 3. Create a NodeStoreFamily from the existing nodeStore
+	family := s.getOrCreateFamily()
+
+	// 4. Reconstruct state SHAMap from the persisted root hash
+	var stateMap *shamap.SHAMap
+	if isZero(hdr.AccountHash) {
+		stateMap, err = shamap.NewBacked(shamap.TypeState, family)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create empty state map: %w", err)
+		}
+	} else {
+		stateMap, err = shamap.NewFromRootHash(shamap.TypeState, hdr.AccountHash, family)
+		if err != nil {
+			return nil, fmt.Errorf("failed to reconstruct state map from hash %x: %w", hdr.AccountHash[:8], err)
+		}
+	}
+
+	// 5. Reconstruct tx SHAMap from the persisted root hash.
+	// An empty tx map (genesis or ledger with no transactions) has a zero hash.
+	var txMap *shamap.SHAMap
+	if isZero(hdr.TxHash) {
+		txMap, err = shamap.New(shamap.TypeTransaction)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create empty tx map: %w", err)
+		}
+	} else {
+		txMap, err = shamap.NewFromRootHash(shamap.TypeTransaction, hdr.TxHash, family)
+		if err != nil {
+			return nil, fmt.Errorf("failed to reconstruct tx map from hash %x: %w", hdr.TxHash[:8], err)
+		}
+	}
+
+	// 6. Mark maps as immutable (loaded ledger is validated/closed)
+	if err := stateMap.SetImmutable(); err != nil {
+		return nil, fmt.Errorf("failed to set state map immutable: %w", err)
+	}
+	if err := txMap.SetImmutable(); err != nil {
+		return nil, fmt.Errorf("failed to set tx map immutable: %w", err)
+	}
+
+	// 7. Assemble the Ledger using the same pattern as FromGenesis
+	loaded := ledger.FromGenesis(
+		header.LedgerHeader{
+			LedgerIndex:         hdr.LedgerIndex,
+			ParentCloseTime:     hdr.ParentCloseTime,
+			Hash:                hdr.Hash,
+			TxHash:              hdr.TxHash,
+			AccountHash:         hdr.AccountHash,
+			ParentHash:          hdr.ParentHash,
+			Drops:               hdr.Drops,
+			Validated:           true,
+			Accepted:            true,
+			CloseFlags:          hdr.CloseFlags,
+			CloseTimeResolution: hdr.CloseTimeResolution,
+			CloseTime:           hdr.CloseTime,
+		},
+		stateMap,
+		txMap,
+		// Fees will be read from the FeeSettings SLE dynamically
+		drops.Fees{},
+	)
+
+	return loaded, nil
+}
+
+// createGenesis creates a genesis ledger using the service config
+func (s *Service) createGenesis() error {
+	genesisResult, err := genesis.Create(s.config.GenesisConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create genesis ledger: %w", err)
+	}
+
+	genesisLedger := ledger.FromGenesis(
+		genesisResult.Header,
+		genesisResult.StateMap,
+		genesisResult.TxMap,
+		drops.Fees{},
+	)
+
+	s.genesisLedger = genesisLedger
+	s.closedLedger = genesisLedger
+	s.validatedLedger = genesisLedger
+	s.ledgerHistory[genesisLedger.Sequence()] = genesisLedger
+
+	// Create the first open ledger (ledger 2)
+	openLedger, err := ledger.NewOpen(genesisLedger, time.Now())
+	if err != nil {
+		return fmt.Errorf("failed to create open ledger: %w", err)
+	}
+	s.openLedger = openLedger
+
+	return nil
+}
+
+// isZero returns true if hash is all zeros.
+func isZero(hash [32]byte) bool {
+	for _, b := range hash {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"sync"
@@ -10,22 +11,43 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/shamap"
 	"github.com/LeJamon/goXRPLd/storage/nodestore"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
+// StartupMode controls how the service initializes its ledger state.
+type StartupMode int
+
+const (
+	// StartupNormal attempts to load the latest persisted ledger.
+	// If no persisted state is found, it creates a fresh genesis ledger.
+	StartupNormal StartupMode = iota
+
+	// StartupFresh always creates a new genesis ledger, ignoring any persisted state.
+	StartupFresh
+
+	// StartupLoad requires persisted state to exist. Returns an error if none is found.
+	StartupLoad
+)
+
 // Common errors
 var (
-	ErrNotStandalone  = errors.New("operation only valid in standalone mode")
-	ErrNoOpenLedger   = errors.New("no open ledger")
-	ErrNoClosedLedger = errors.New("no closed ledger")
-	ErrLedgerNotFound = errors.New("ledger not found")
+	ErrNotStandalone      = errors.New("operation only valid in standalone mode")
+	ErrNoOpenLedger       = errors.New("no open ledger")
+	ErrNoClosedLedger     = errors.New("no closed ledger")
+	ErrLedgerNotFound     = errors.New("ledger not found")
+	ErrNoPersistedLedger  = errors.New("no persisted ledger found (required by StartupLoad)")
 )
 
 // Config holds configuration for the LedgerService
 type Config struct {
 	// Standalone indicates whether the node is running in standalone mode
 	Standalone bool
+
+	// StartupMode controls how the service initializes ledger state.
+	// Default is StartupNormal: load from storage if available, else create genesis.
+	StartupMode StartupMode
 
 	// GenesisConfig is the configuration for creating the genesis ledger
 	GenesisConfig genesis.Config
@@ -91,6 +113,9 @@ type Service struct {
 
 	// NodeStore for persistent storage (nil if in-memory only)
 	nodeStore nodestore.Database
+
+	// family wraps nodeStore for SHAMap backed operations (lazy set on first use)
+	family *shamap.NodeStoreFamily
 
 	// RelationalDB for transaction indexing (nil if not configured)
 	relationalDB relationaldb.RepositoryManager
@@ -158,36 +183,58 @@ func (s *Service) GetEventHooks() *EventHooks {
 	return s.hooks
 }
 
-// Start initializes the service with a genesis ledger
+// Start initializes the service based on StartupMode:
+//   - StartupFresh: always creates a new genesis ledger
+//   - StartupNormal: loads from storage if available, else creates genesis
+//   - StartupLoad: requires persisted state, returns error if none found
 func (s *Service) Start() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Create genesis ledger
-	genesisResult, err := genesis.Create(s.config.GenesisConfig)
+	switch s.config.StartupMode {
+	case StartupFresh:
+		return s.createGenesis()
+
+	case StartupLoad:
+		ctx := context.Background()
+		hash, found, err := latestLedgerHash(ctx, s.relationalDB, s.nodeStore)
+		if err != nil {
+			return errors.New("failed to find persisted ledger: " + err.Error())
+		}
+		if !found {
+			return ErrNoPersistedLedger
+		}
+		return s.resumeFromLedger(ctx, hash)
+
+	default: // StartupNormal
+		ctx := context.Background()
+		hash, found, err := latestLedgerHash(ctx, s.relationalDB, s.nodeStore)
+		if err != nil {
+			return errors.New("failed to find persisted ledger: " + err.Error())
+		}
+		if found {
+			return s.resumeFromLedger(ctx, hash)
+		}
+		return s.createGenesis()
+	}
+}
+
+// resumeFromLedger loads a persisted ledger and sets up the service to continue
+// from where it left off.
+func (s *Service) resumeFromLedger(ctx context.Context, ledgerHash [32]byte) error {
+	loaded, err := s.loadLedger(ctx, ledgerHash)
 	if err != nil {
-		return errors.New("failed to create genesis ledger: " + err.Error())
+		return errors.New("failed to load persisted ledger: " + err.Error())
 	}
 
-	// Convert genesis to Ledger.
-	// Fee values are read dynamically from the FeeSettings SLE in the state map
-	// by readFeesFromLedger() whenever they are needed.
-	genesisLedger := ledger.FromGenesis(
-		genesisResult.Header,
-		genesisResult.StateMap,
-		genesisResult.TxMap,
-		drops.Fees{},
-	)
+	s.closedLedger = loaded
+	s.validatedLedger = loaded
+	s.ledgerHistory[loaded.Sequence()] = loaded
 
-	s.genesisLedger = genesisLedger
-	s.closedLedger = genesisLedger
-	s.validatedLedger = genesisLedger
-	s.ledgerHistory[genesisLedger.Sequence()] = genesisLedger
-
-	// Create the first open ledger (ledger 2)
-	openLedger, err := ledger.NewOpen(genesisLedger, time.Now())
+	// Create the next open ledger
+	openLedger, err := ledger.NewOpen(loaded, time.Now())
 	if err != nil {
-		return errors.New("failed to create open ledger: " + err.Error())
+		return errors.New("failed to create open ledger from loaded state: " + err.Error())
 	}
 	s.openLedger = openLedger
 

--- a/internal/testing/persistence/persistence_test.go
+++ b/internal/testing/persistence/persistence_test.go
@@ -1,0 +1,364 @@
+package persistence_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service"
+	"github.com/LeJamon/goXRPLd/storage/kvstore/memorydb"
+	"github.com/LeJamon/goXRPLd/storage/nodestore"
+)
+
+// newMemoryNodeStore creates an in-memory nodestore for testing.
+func newMemoryNodeStore() nodestore.Database {
+	store := memorydb.New()
+	return nodestore.NewKVDatabase(store, "test-memory", 2000, time.Hour)
+}
+
+// newSharedMemoryStore returns the raw memorydb and a nodestore wrapping it.
+// Multiple nodestore.Database instances can be created from the same memorydb
+// to simulate service restarts.
+func newSharedMemoryStore() (*memorydb.MemDatabase, nodestore.Database) {
+	store := memorydb.New()
+	db := nodestore.NewKVDatabase(store, "test-memory", 2000, time.Hour)
+	return store, db
+}
+
+// newNodeStoreFromMemDB wraps an existing MemDatabase with a fresh nodestore.
+func newNodeStoreFromMemDB(store *memorydb.MemDatabase) nodestore.Database {
+	return nodestore.NewKVDatabase(store, "test-memory", 2000, time.Hour)
+}
+
+// TestStartupNormal_FreshDB verifies that StartupNormal with no existing
+// state creates a genesis ledger at sequence 1.
+func TestStartupNormal_FreshDB(t *testing.T) {
+	db := newMemoryNodeStore()
+	cfg := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupNormal,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+	}
+
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	if seq := svc.GetValidatedLedgerIndex(); seq != 1 {
+		t.Errorf("expected validated ledger seq 1, got %d", seq)
+	}
+
+	if seq := svc.GetCurrentLedgerIndex(); seq != 2 {
+		t.Errorf("expected open ledger seq 2, got %d", seq)
+	}
+}
+
+// TestStartupNormal_ExistingState persists several ledgers, then creates a
+// new service with StartupNormal and verifies it resumes from the latest.
+func TestStartupNormal_ExistingState(t *testing.T) {
+	memStore, db := newSharedMemoryStore()
+
+	// Phase 1: create and advance ledgers
+	cfg := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupFresh,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+	}
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	// Accept 3 ledgers (closes ledgers 2, 3, 4)
+	for i := 0; i < 3; i++ {
+		if _, err := svc.AcceptLedger(); err != nil {
+			t.Fatalf("AcceptLedger() %d failed: %v", i, err)
+		}
+	}
+
+	lastValidatedSeq := svc.GetValidatedLedgerIndex()
+	lastValidatedHash := svc.GetValidatedLedger().Hash()
+	if lastValidatedSeq != 4 {
+		t.Fatalf("expected validated seq 4, got %d", lastValidatedSeq)
+	}
+
+	// Phase 2: create a new service from the same store
+	db2 := newNodeStoreFromMemDB(memStore)
+	cfg2 := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupNormal,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db2,
+	}
+	svc2, err := service.New(cfg2)
+	if err != nil {
+		t.Fatalf("New() for recovery failed: %v", err)
+	}
+	if err := svc2.Start(); err != nil {
+		t.Fatalf("Start() for recovery failed: %v", err)
+	}
+
+	// Verify recovery
+	if seq := svc2.GetValidatedLedgerIndex(); seq != lastValidatedSeq {
+		t.Errorf("expected recovered validated seq %d, got %d", lastValidatedSeq, seq)
+	}
+	if hash := svc2.GetValidatedLedger().Hash(); hash != lastValidatedHash {
+		t.Errorf("expected recovered validated hash %x, got %x", lastValidatedHash[:8], hash[:8])
+	}
+	// Open ledger should be lastValidatedSeq+1
+	if seq := svc2.GetCurrentLedgerIndex(); seq != lastValidatedSeq+1 {
+		t.Errorf("expected open ledger seq %d, got %d", lastValidatedSeq+1, seq)
+	}
+}
+
+// TestStartupFresh_ExistingState persists ledgers, then creates a new service
+// with StartupFresh and verifies it resets to genesis (seq 1).
+func TestStartupFresh_ExistingState(t *testing.T) {
+	memStore, db := newSharedMemoryStore()
+
+	// Phase 1: create and advance ledgers
+	cfg := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupFresh,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+	}
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := svc.AcceptLedger(); err != nil {
+			t.Fatalf("AcceptLedger() %d failed: %v", i, err)
+		}
+	}
+
+	// Phase 2: create a new service with StartupFresh — should ignore stored state
+	db2 := newNodeStoreFromMemDB(memStore)
+	cfg2 := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupFresh,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db2,
+	}
+	svc2, err := service.New(cfg2)
+	if err != nil {
+		t.Fatalf("New() for fresh start failed: %v", err)
+	}
+	if err := svc2.Start(); err != nil {
+		t.Fatalf("Start() for fresh start failed: %v", err)
+	}
+
+	if seq := svc2.GetValidatedLedgerIndex(); seq != 1 {
+		t.Errorf("expected fresh genesis seq 1, got %d", seq)
+	}
+	if seq := svc2.GetCurrentLedgerIndex(); seq != 2 {
+		t.Errorf("expected fresh open seq 2, got %d", seq)
+	}
+}
+
+// TestStartupLoad_NoState verifies that StartupLoad with an empty DB returns
+// an error.
+func TestStartupLoad_NoState(t *testing.T) {
+	db := newMemoryNodeStore()
+	cfg := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupLoad,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+	}
+
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	err = svc.Start()
+	if err == nil {
+		t.Fatal("expected error from StartupLoad with no persisted state")
+	}
+	t.Logf("StartupLoad error (expected): %v", err)
+}
+
+// TestStartupLoad_ExistingState persists ledgers, then creates a new service
+// with StartupLoad and verifies it loads correctly.
+func TestStartupLoad_ExistingState(t *testing.T) {
+	memStore, db := newSharedMemoryStore()
+
+	// Phase 1: create and advance ledgers
+	cfg := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupFresh,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+	}
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := svc.AcceptLedger(); err != nil {
+			t.Fatalf("AcceptLedger() %d failed: %v", i, err)
+		}
+	}
+
+	lastValidatedSeq := svc.GetValidatedLedgerIndex()
+
+	// Phase 2: create a new service with StartupLoad
+	db2 := newNodeStoreFromMemDB(memStore)
+	cfg2 := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupLoad,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db2,
+	}
+	svc2, err := service.New(cfg2)
+	if err != nil {
+		t.Fatalf("New() for load failed: %v", err)
+	}
+	if err := svc2.Start(); err != nil {
+		t.Fatalf("Start() for load failed: %v", err)
+	}
+
+	if seq := svc2.GetValidatedLedgerIndex(); seq != lastValidatedSeq {
+		t.Errorf("expected loaded validated seq %d, got %d", lastValidatedSeq, seq)
+	}
+}
+
+// TestFeeRecovery verifies that fees are correctly restored from the loaded
+// ledger's FeeSettings SLE.
+func TestFeeRecovery(t *testing.T) {
+	memStore, db := newSharedMemoryStore()
+
+	// Phase 1: create service and advance
+	cfg := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupFresh,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+	}
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	// Read fees from original service
+	origBaseFee, origReserveBase, origReserveInc := svc.GetCurrentFees()
+	if origBaseFee == 0 || origReserveBase == 0 || origReserveInc == 0 {
+		t.Fatalf("original fees should be non-zero: baseFee=%d reserveBase=%d reserveInc=%d",
+			origBaseFee, origReserveBase, origReserveInc)
+	}
+
+	// Accept a ledger to persist
+	if _, err := svc.AcceptLedger(); err != nil {
+		t.Fatalf("AcceptLedger() failed: %v", err)
+	}
+
+	// Phase 2: recover and check fees
+	db2 := newNodeStoreFromMemDB(memStore)
+	cfg2 := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupNormal,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db2,
+	}
+	svc2, err := service.New(cfg2)
+	if err != nil {
+		t.Fatalf("New() for recovery failed: %v", err)
+	}
+	if err := svc2.Start(); err != nil {
+		t.Fatalf("Start() for recovery failed: %v", err)
+	}
+
+	// Fees should match (read dynamically from the FeeSettings SLE)
+	baseFee, reserveBase, reserveInc := svc2.GetCurrentFees()
+	if baseFee != origBaseFee {
+		t.Errorf("baseFee: expected %d, got %d", origBaseFee, baseFee)
+	}
+	if reserveBase != origReserveBase {
+		t.Errorf("reserveBase: expected %d, got %d", origReserveBase, reserveBase)
+	}
+	if reserveInc != origReserveInc {
+		t.Errorf("reserveInc: expected %d, got %d", origReserveInc, reserveInc)
+	}
+}
+
+// TestContinueAfterRecovery verifies that a recovered service can continue
+// accepting new ledgers.
+func TestContinueAfterRecovery(t *testing.T) {
+	memStore, db := newSharedMemoryStore()
+
+	// Phase 1: create and advance to ledger 4
+	cfg := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupFresh,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+	}
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := svc.AcceptLedger(); err != nil {
+			t.Fatalf("AcceptLedger() %d failed: %v", i, err)
+		}
+	}
+
+	// Phase 2: recover and continue
+	db2 := newNodeStoreFromMemDB(memStore)
+	cfg2 := service.Config{
+		Standalone:    true,
+		StartupMode:   service.StartupNormal,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db2,
+	}
+	svc2, err := service.New(cfg2)
+	if err != nil {
+		t.Fatalf("New() for recovery failed: %v", err)
+	}
+	if err := svc2.Start(); err != nil {
+		t.Fatalf("Start() for recovery failed: %v", err)
+	}
+
+	// Accept 2 more ledgers (should produce ledger 5, 6)
+	for i := 0; i < 2; i++ {
+		closedSeq, err := svc2.AcceptLedger()
+		if err != nil {
+			t.Fatalf("AcceptLedger() after recovery %d failed: %v", i, err)
+		}
+		expectedSeq := uint32(5 + i)
+		if closedSeq != expectedSeq {
+			t.Errorf("expected closed seq %d, got %d", expectedSeq, closedSeq)
+		}
+	}
+
+	if seq := svc2.GetValidatedLedgerIndex(); seq != 6 {
+		t.Errorf("expected validated seq 6, got %d", seq)
+	}
+	if seq := svc2.GetCurrentLedgerIndex(); seq != 7 {
+		t.Errorf("expected open seq 7, got %d", seq)
+	}
+}

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -1203,6 +1203,13 @@ func (sm *SHAMap) flushNode(node Node, releaseChildren bool, batch *NodeBatch) e
 
 	// For inner nodes: flush children first (post-order)
 	if inner, ok := node.(*InnerNode); ok {
+		// Skip empty inner nodes (e.g., root of an empty SHAMap).
+		// Their hash is zero and they don't need to be stored.
+		if inner.BranchCount() == 0 {
+			node.SetDirty(false)
+			return nil
+		}
+
 		inner.mu.Lock()
 		for i := 0; i < BranchFactor; i++ {
 			child := inner.children[i]

--- a/storage/nodestore/kvstore_database.go
+++ b/storage/nodestore/kvstore_database.go
@@ -275,5 +275,31 @@ func (d *KVDatabaseImpl) Close() error {
 	return lastErr
 }
 
+// ForEach iterates over all stored nodes, decoding each entry.
+// The callback receives a fully decoded Node. Return a non-nil error
+// from fn to stop iteration early.
+func (d *KVDatabaseImpl) ForEach(fn func(*Node) error) error {
+	iter := d.store.NewIterator(nil, nil)
+	defer iter.Release()
+
+	for iter.Next() {
+		key := iter.Key()
+		if len(key) != 32 {
+			continue // skip non-hash keys
+		}
+		var hash Hash256
+		copy(hash[:], key)
+
+		node, err := decodeNodeData(hash, iter.Value())
+		if err != nil {
+			continue // skip corrupt entries
+		}
+		if err := fn(node); err != nil {
+			return err
+		}
+	}
+	return iter.Error()
+}
+
 // Ensure KVDatabaseImpl implements Database at compile time.
 var _ Database = (*KVDatabaseImpl)(nil)


### PR DESCRIPTION
Closes #126

## Summary

- Add `StartupMode` enum (`Fresh` / `Normal` / `Load`) to `service.Config` mirroring rippled's `Config::START_UP`
- Add `--start` CLI flag (sets `StartupFresh`, same semantics as rippled's `--start`)
- Add `internal/ledger/service/recovery.go`: `latestLedgerHash()` queries RelationalDB then scans NodeStore; `loadLedger()` reconstructs a `Ledger` from a persisted header + lazy SHAMaps via `shamap.NewFromRootHash()`
- Fix `persistence.go` to call `FlushDirty()` on both SHAMaps so inner nodes are stored — required for `NewFromRootHash()` lazy-loading to work at recovery time
- Add `SetTxMapFamily()` and `FlushDirtyNodes()` to `Ledger`
- Add `ForEach()` to `KVDatabaseImpl` for NodeStore header scanning
- Fix `shamap.flushNode()` to skip empty inner nodes

## Startup mode behaviour

| Mode | CLI | Behaviour |
|------|-----|-----------|
| `StartupFresh` | `--start` | Always wipe and create new genesis (previous behaviour) |
| `StartupNormal` | _(default)_ | Load latest ledger from storage if present, else create genesis |
| `StartupLoad` | — | Require existing state, error if absent |

## Test plan

- [x] `TestStartupNormal_FreshDB` — no existing state → genesis seq 1
- [x] `TestStartupNormal_ExistingState` — persist N ledgers, restart → resumes from seq N
- [x] `TestStartupFresh_ExistingState` — persist N ledgers, `--start` → resets to seq 1
- [x] `TestStartupLoad_NoState` — empty DB → returns error
- [x] `TestStartupLoad_ExistingState` — persist N ledgers → resumes from seq N
- [x] `TestFeeRecovery` — fees restored correctly from FeeSettings SLE
- [x] `TestContinueAfterRecovery` — recovered service continues accepting new ledgers
- [x] Full `go test ./...` — no regressions vs `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)