### PR TITLE
fix: decode VL-encoded binary blobs in RPC handlers (#157)

### DIFF
--- a/internal/rpc/handlers/book_changes.go
+++ b/internal/rpc/handlers/book_changes.go
@@ -69,9 +69,9 @@ func (m *BookChangesMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	changes := make(map[string]*bookChange)
 
 	targetLedger.ForEachTransaction(func(txHash [32]byte, txData []byte) bool {
-		// Try to parse as StoredTransaction (JSON format from submit handler)
-		var storedTx StoredTransaction
-		if err := json.Unmarshal(txData, &storedTx); err != nil {
+		// Decode VL-encoded binary blob (or JSON fallback)
+		storedTx, err := decodeTxBlob(txData)
+		if err != nil {
 			return true // skip, continue
 		}
 

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"strings"
 
+	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/internal/tx"
 )
 
 // RequireLedgerService checks that the ledger service is available.
@@ -121,6 +123,38 @@ func (AdminHandler) SupportedApiVersions() []int {
 	return []int{types.ApiVersion1, types.ApiVersion2, types.ApiVersion3}
 }
 func (AdminHandler) RequiredCondition() types.Condition { return types.NoCondition }
+
+// decodeTxBlob decodes transaction data that may be in one of two formats:
+//  1. VL-encoded binary blob: [VL-prefix][tx_bytes][VL-prefix][meta_bytes]
+//     (produced by tx.CreateTxWithMetaBlob, stored via AddTransactionWithMeta)
+//  2. JSON-marshaled StoredTransaction: {"tx_json":{...},"meta":{...}}
+//     (produced by the submit handler)
+//
+// It tries VL binary decode first, then falls back to JSON unmarshal.
+func decodeTxBlob(data []byte) (StoredTransaction, error) {
+	// Try VL-encoded binary format first
+	txBytes, metaBytes, err := tx.SplitTxWithMetaBlob(data)
+	if err == nil {
+		txJSON, decErr := binarycodec.Decode(hex.EncodeToString(txBytes))
+		if decErr == nil {
+			st := StoredTransaction{TxJSON: txJSON}
+			if len(metaBytes) > 0 {
+				metaJSON, metaErr := binarycodec.Decode(hex.EncodeToString(metaBytes))
+				if metaErr == nil {
+					st.Meta = metaJSON
+				}
+			}
+			return st, nil
+		}
+	}
+
+	// Fall back to JSON format
+	var st StoredTransaction
+	if jsonErr := json.Unmarshal(data, &st); jsonErr != nil {
+		return StoredTransaction{}, jsonErr
+	}
+	return st, nil
+}
 
 // InjectDeliveredAmount adds DeliveredAmount to metadata for Payment transactions.
 // If meta has a "DeliveredAmount" field already, it is left as-is.

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -187,9 +187,7 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 }
 
 // expandTransaction builds an expanded transaction object from raw txData.
-// It handles two storage formats:
-//  1. JSON StoredTransaction: {"tx_json": {...}, "meta": {...}}
-//  2. Raw binary blob (decoded via binarycodec)
+// It handles VL-encoded binary blobs and JSON StoredTransaction format.
 //
 // The output format varies by API version:
 //   - API v1: tx fields at top level + "metaData" for metadata
@@ -198,14 +196,16 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 // For binary mode, tx_blob and meta_blob/meta are returned as hex strings.
 // Reference: rippled LedgerToJson.cpp fillJsonTx()
 func expandTransaction(txData []byte, hashStr string, binary bool, apiVersion int) map[string]interface{} {
-	// Try JSON StoredTransaction format first (used by submit handler)
-	var storedTx StoredTransaction
-	if err := json.Unmarshal(txData, &storedTx); err == nil && storedTx.TxJSON != nil {
+	storedTx, err := decodeTxBlob(txData)
+	if err == nil && storedTx.TxJSON != nil {
 		return expandStoredTransaction(storedTx, hashStr, binary, apiVersion)
 	}
 
-	// Fall back to raw binary blob
-	return expandBinaryTransaction(txData, hashStr, binary, apiVersion)
+	// Cannot decode: return raw blob
+	txEntry := map[string]interface{}{}
+	txEntry["tx_blob"] = strings.ToUpper(hex.EncodeToString(txData))
+	txEntry["hash"] = hashStr
+	return txEntry
 }
 
 // expandStoredTransaction formats a JSON-stored transaction for the response.
@@ -251,38 +251,6 @@ func expandStoredTransaction(storedTx StoredTransaction, hashStr string, binary 
 			InjectDeliveredAmount(storedTx.TxJSON, storedTx.Meta)
 			txEntry["metaData"] = storedTx.Meta
 		}
-	}
-	return txEntry
-}
-
-// expandBinaryTransaction formats a raw binary transaction blob for the response.
-func expandBinaryTransaction(txData []byte, hashStr string, binary bool, apiVersion int) map[string]interface{} {
-	txEntry := map[string]interface{}{}
-
-	if binary {
-		txEntry["tx_blob"] = strings.ToUpper(hex.EncodeToString(txData))
-		txEntry["hash"] = hashStr
-		return txEntry
-	}
-
-	// Try to decode binary blob via binarycodec
-	txHex := hex.EncodeToString(txData)
-	decoded, err := binarycodec.Decode(txHex)
-	if err != nil {
-		// Cannot decode: return raw blob
-		txEntry["tx_blob"] = strings.ToUpper(txHex)
-		txEntry["hash"] = hashStr
-		return txEntry
-	}
-
-	if apiVersion > 1 {
-		txEntry["tx_json"] = decoded
-		txEntry["hash"] = hashStr
-	} else {
-		for k, v := range decoded {
-			txEntry[k] = v
-		}
-		txEntry["hash"] = hashStr
 	}
 	return txEntry
 }

--- a/internal/rpc/handlers/transaction_entry.go
+++ b/internal/rpc/handlers/transaction_entry.go
@@ -72,9 +72,9 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 		}
 	}
 
-	// Parse the stored transaction data
-	var storedTx StoredTransaction
-	if err := json.Unmarshal(txInfo.TxData, &storedTx); err != nil {
+	// Parse the stored transaction data (VL-encoded binary or JSON)
+	storedTx, err := decodeTxBlob(txInfo.TxData)
+	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to parse transaction data")
 	}
 

--- a/internal/rpc/handlers/tx.go
+++ b/internal/rpc/handlers/tx.go
@@ -63,9 +63,9 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interf
 		}
 	}
 
-	// Parse the stored transaction data
-	var storedTx StoredTransaction
-	if err := json.Unmarshal(txInfo.TxData, &storedTx); err != nil {
+	// Parse the stored transaction data (VL-encoded binary or JSON)
+	storedTx, err := decodeTxBlob(txInfo.TxData)
+	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to parse transaction data")
 	}
 
@@ -252,11 +252,28 @@ func (m *TxMethod) lookupByCTID(ctx *types.RpcContext, ledgerSeq uint32, txIndex
 	ledgerHash := ledger.Hash()
 	ledgerHashStr := strings.ToUpper(fmt.Sprintf("%x", ledgerHash))
 
+	// Decode the VL-encoded blob into tx + meta
+	storedTx, decodeErr := decodeTxBlob(foundData)
+
 	if binary {
 		response := map[string]interface{}{}
-		response["tx_blob"] = strings.ToUpper(hex.EncodeToString(foundData))
-		if ctx.ApiVersion > 1 {
-			response["meta_blob"] = "" // no separate metadata in raw CTID lookup binary path
+		if decodeErr == nil {
+			txBlob, err := binarycodec.Encode(storedTx.TxJSON)
+			if err == nil {
+				response["tx_blob"] = txBlob
+			}
+			if storedTx.Meta != nil {
+				metaBlob, err := binarycodec.Encode(storedTx.Meta)
+				if err == nil {
+					if ctx.ApiVersion > 1 {
+						response["meta_blob"] = metaBlob
+					} else {
+						response["meta"] = metaBlob
+					}
+				}
+			}
+		} else {
+			response["tx_blob"] = strings.ToUpper(hex.EncodeToString(foundData))
 		}
 		response["hash"] = hashStr
 		response["ledger_index"] = ledgerSeq
@@ -269,14 +286,10 @@ func (m *TxMethod) lookupByCTID(ctx *types.RpcContext, ledgerSeq uint32, txIndex
 		return response, nil
 	}
 
-	// Decode the raw transaction blob to JSON
-	txHex := hex.EncodeToString(foundData)
-	decoded, decodeErr := binarycodec.Decode(txHex)
-
 	if ctx.ApiVersion > 1 {
 		response := map[string]interface{}{}
 		if decodeErr == nil {
-			txJSON := decoded
+			txJSON := storedTx.TxJSON
 			if closeTimeSec > 0 {
 				txJSON["date"] = closeTimeSec
 			}
@@ -284,6 +297,10 @@ func (m *TxMethod) lookupByCTID(ctx *types.RpcContext, ledgerSeq uint32, txIndex
 				txJSON["ctid"] = encodeCTID(ledgerSeq, txIndex)
 			}
 			response["tx_json"] = txJSON
+			if storedTx.Meta != nil {
+				InjectDeliveredAmount(storedTx.TxJSON, storedTx.Meta)
+				response["meta"] = storedTx.Meta
+			}
 		}
 		response["hash"] = hashStr
 		response["ledger_index"] = ledgerSeq
@@ -305,8 +322,12 @@ func (m *TxMethod) lookupByCTID(ctx *types.RpcContext, ledgerSeq uint32, txIndex
 		"ledger_hash":  ledgerHashStr,
 	}
 	if decodeErr == nil {
-		for k, v := range decoded {
+		for k, v := range storedTx.TxJSON {
 			response[k] = v
+		}
+		if storedTx.Meta != nil {
+			InjectDeliveredAmount(storedTx.TxJSON, storedTx.Meta)
+			response["meta"] = storedTx.Meta
 		}
 	}
 	if closeTimeSec > 0 {

--- a/internal/tx/serialize.go
+++ b/internal/tx/serialize.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/codec/binarycodec/serdes"
 )
 
 var (
@@ -22,7 +23,7 @@ func EncodeVL(length int) ([]byte, error) {
 	if length <= 192 {
 		return []byte{byte(length)}, nil
 	}
-	if length < 12480 {
+	if length <= 12480 {
 		length -= 193
 		b1 := byte((length >> 8) + 193)
 		b2 := byte(length & 0xFF)
@@ -172,4 +173,41 @@ func CreateTxWithMetaBlob(txBlob []byte, meta *Metadata) ([]byte, error) {
 	copy(result[len(vlTx):], vlMeta)
 
 	return result, nil
+}
+
+// SplitTxWithMetaBlob splits a combined VL-encoded blob into separate
+// transaction bytes and metadata bytes. This is the inverse of CreateTxWithMetaBlob.
+// The input format is: [VL-length][tx_data][VL-length][metadata_data]
+// Uses the existing BinaryParser.ReadVariableLength from the codec package.
+func SplitTxWithMetaBlob(blob []byte) (txData []byte, metaData []byte, err error) {
+	if len(blob) == 0 {
+		return nil, nil, errors.New("empty blob")
+	}
+
+	parser := serdes.NewBinaryParser(blob, nil)
+
+	// Read tx: VL prefix then data
+	txLen, err := parser.ReadVariableLength()
+	if err != nil {
+		return nil, nil, err
+	}
+	txData, err = parser.ReadBytes(txLen)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Read meta: VL prefix then data (optional)
+	if !parser.HasMore() {
+		return txData, nil, nil
+	}
+	metaLen, err := parser.ReadVariableLength()
+	if err != nil {
+		return nil, nil, err
+	}
+	metaData, err = parser.ReadBytes(metaLen)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return txData, metaData, nil
 }

--- a/internal/tx/serialize_test.go
+++ b/internal/tx/serialize_test.go
@@ -1,0 +1,91 @@
+package tx
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSplitTxWithMetaBlob_RoundTrip(t *testing.T) {
+	txData := []byte("transaction data here")
+	metaData := []byte("metadata bytes here")
+
+	// Manually create the blob the same way CreateTxWithMetaBlob does
+	vlTx, err := EncodeWithVL(txData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vlMeta, err := EncodeWithVL(metaData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob := append(vlTx, vlMeta...)
+
+	// Split it back
+	gotTx, gotMeta, err := SplitTxWithMetaBlob(blob)
+	if err != nil {
+		t.Fatalf("SplitTxWithMetaBlob error: %v", err)
+	}
+	if !bytes.Equal(gotTx, txData) {
+		t.Errorf("tx data mismatch: got %q, want %q", gotTx, txData)
+	}
+	if !bytes.Equal(gotMeta, metaData) {
+		t.Errorf("meta data mismatch: got %q, want %q", gotMeta, metaData)
+	}
+}
+
+func TestSplitTxWithMetaBlob_LargeData(t *testing.T) {
+	// Test with data sizes that cross VL prefix boundaries
+	sizes := []int{192, 193, 500, 12480}
+
+	for _, txSize := range sizes {
+		for _, metaSize := range sizes {
+			txData := bytes.Repeat([]byte{0xAB}, txSize)
+			metaData := bytes.Repeat([]byte{0xCD}, metaSize)
+
+			vlTx, _ := EncodeWithVL(txData)
+			vlMeta, _ := EncodeWithVL(metaData)
+			blob := append(vlTx, vlMeta...)
+
+			gotTx, gotMeta, err := SplitTxWithMetaBlob(blob)
+			if err != nil {
+				t.Fatalf("SplitTxWithMetaBlob(%d,%d) error: %v", txSize, metaSize, err)
+			}
+			if !bytes.Equal(gotTx, txData) {
+				t.Errorf("tx data mismatch for sizes (%d,%d)", txSize, metaSize)
+			}
+			if !bytes.Equal(gotMeta, metaData) {
+				t.Errorf("meta data mismatch for sizes (%d,%d)", txSize, metaSize)
+			}
+		}
+	}
+}
+
+func TestSplitTxWithMetaBlob_TxOnly(t *testing.T) {
+	txData := []byte("just tx, no meta")
+	vlTx, _ := EncodeWithVL(txData)
+
+	gotTx, gotMeta, err := SplitTxWithMetaBlob(vlTx)
+	if err != nil {
+		t.Fatalf("SplitTxWithMetaBlob error: %v", err)
+	}
+	if !bytes.Equal(gotTx, txData) {
+		t.Errorf("tx data mismatch: got %q, want %q", gotTx, txData)
+	}
+	if gotMeta != nil {
+		t.Errorf("expected nil meta, got %q", gotMeta)
+	}
+}
+
+func TestSplitTxWithMetaBlob_Errors(t *testing.T) {
+	// Empty blob
+	_, _, err := SplitTxWithMetaBlob(nil)
+	if err == nil {
+		t.Error("expected error for nil blob")
+	}
+
+	// Truncated tx data (VL says 100 bytes but only 0 follow)
+	_, _, err = SplitTxWithMetaBlob([]byte{100})
+	if err == nil {
+		t.Error("expected error for truncated tx data")
+	}
+}


### PR DESCRIPTION
Multiple RPC handlers incorrectly used json.Unmarshal on transaction data that is VL-encoded binary. Added SplitTxWithMetaBlob (using the existing codec BinaryParser) to split blobs, and a decodeTxBlob helper that tries VL decode first with JSON fallback.

Fixed handlers: tx, transaction_entry, ledger, book_changes. Also fixed EncodeVL boundary (< 12480 → <= 12480) to match rippled.