### PR TITLE
feat: enforce per-port admin access control, connection limits, and W…

### DIFF
--- a/config/admin_nets_test.go
+++ b/config/admin_nets_test.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"net"
+	"testing"
+)
+
+func TestParseAdminNets_BareIPv4(t *testing.T) {
+	p := PortConfig{Admin: []string{"127.0.0.1"}}
+	nets, err := p.ParseAdminNets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nets) != 1 {
+		t.Fatalf("expected 1 net, got %d", len(nets))
+	}
+	ones, _ := nets[0].Mask.Size()
+	if ones != 32 {
+		t.Fatalf("expected /32, got /%d", ones)
+	}
+}
+
+func TestParseAdminNets_BareIPv6(t *testing.T) {
+	p := PortConfig{Admin: []string{"::1"}}
+	nets, err := p.ParseAdminNets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nets) != 1 {
+		t.Fatalf("expected 1 net, got %d", len(nets))
+	}
+	ones, _ := nets[0].Mask.Size()
+	if ones != 128 {
+		t.Fatalf("expected /128, got /%d", ones)
+	}
+}
+
+func TestParseAdminNets_CIDR(t *testing.T) {
+	p := PortConfig{Admin: []string{"10.0.0.0/8", "fe80::/10"}}
+	nets, err := p.ParseAdminNets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nets) != 2 {
+		t.Fatalf("expected 2 nets, got %d", len(nets))
+	}
+}
+
+func TestParseAdminNets_Empty(t *testing.T) {
+	p := PortConfig{Admin: nil}
+	nets, err := p.ParseAdminNets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nets) != 0 {
+		t.Fatalf("expected 0 nets, got %d", len(nets))
+	}
+}
+
+func TestParseAdminNets_Invalid(t *testing.T) {
+	p := PortConfig{Admin: []string{"not-an-ip"}}
+	_, err := p.ParseAdminNets()
+	if err == nil {
+		t.Fatal("expected error for invalid IP")
+	}
+}
+
+func TestParseAdminNets_SkipsBlank(t *testing.T) {
+	p := PortConfig{Admin: []string{"", "  ", "127.0.0.1"}}
+	nets, err := p.ParseAdminNets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nets) != 1 {
+		t.Fatalf("expected 1 net, got %d", len(nets))
+	}
+}
+
+func TestIPInNets_Match(t *testing.T) {
+	_, cidr, _ := net.ParseCIDR("10.0.0.0/8")
+	if !IPInNets(net.ParseIP("10.1.2.3"), []net.IPNet{*cidr}) {
+		t.Fatal("expected 10.1.2.3 to match 10.0.0.0/8")
+	}
+}
+
+func TestIPInNets_NoMatch(t *testing.T) {
+	_, cidr, _ := net.ParseCIDR("10.0.0.0/8")
+	if IPInNets(net.ParseIP("192.168.1.1"), []net.IPNet{*cidr}) {
+		t.Fatal("expected 192.168.1.1 NOT to match 10.0.0.0/8")
+	}
+}
+
+func TestIPInNets_IPv4Mapped(t *testing.T) {
+	// ::ffff:127.0.0.1 should match 127.0.0.0/8
+	_, cidr, _ := net.ParseCIDR("127.0.0.0/8")
+	// net.ParseIP("::ffff:127.0.0.1") returns a 16-byte IP
+	ip := net.ParseIP("::ffff:127.0.0.1")
+	if !IPInNets(ip, []net.IPNet{*cidr}) {
+		t.Fatal("expected ::ffff:127.0.0.1 to match 127.0.0.0/8 after normalization")
+	}
+}
+
+func TestIPInNets_EmptyNets(t *testing.T) {
+	if IPInNets(net.ParseIP("127.0.0.1"), nil) {
+		t.Fatal("expected no match with nil nets")
+	}
+}
+
+func TestIPInNets_IPv6(t *testing.T) {
+	_, cidr, _ := net.ParseCIDR("fe80::/10")
+	if !IPInNets(net.ParseIP("fe80::1"), []net.IPNet{*cidr}) {
+		t.Fatal("expected fe80::1 to match fe80::/10")
+	}
+	if IPInNets(net.ParseIP("2001:db8::1"), []net.IPNet{*cidr}) {
+		t.Fatal("expected 2001:db8::1 NOT to match fe80::/10")
+	}
+}

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -82,12 +82,22 @@ rpc_startup = [
 
 [server]
 # List of port names — each MUST have a corresponding [port_*] section below.
-ports = ["port_rpc_admin_local", "port_peer", "port_ws_admin_local"]
+ports = ["port_rpc_admin_local", "port_rpc_public", "port_peer", "port_ws_admin_local", "port_ws_public"]
 
 # =============================================================================
 # Port Configurations
 # Required per port: port, ip, protocol
+#
+# Admin vs public:
+#   - admin = ["127.0.0.1"]  → only listed IPs get admin role (CIDR supported)
+#   - no admin field          → public port, all clients get guest role
+#
+# Optional fields:
+#   - limit             → max concurrent connections (0 = unlimited)
+#   - send_queue_limit  → WS send buffer per connection (default 100)
 # =============================================================================
+
+# --- Admin ports (localhost only) ---
 
 [port_rpc_admin_local]
 port = 5005
@@ -95,17 +105,34 @@ ip = "127.0.0.1"
 admin = ["127.0.0.1"]
 protocol = "http"
 
-[port_peer]
-port = 51235
-ip = "0.0.0.0"
-protocol = "peer"
-
 [port_ws_admin_local]
 port = 6006
 ip = "127.0.0.1"
 admin = ["127.0.0.1"]
 protocol = "ws"
 send_queue_limit = 500
+
+# --- Public ports (open to all interfaces, no admin access) ---
+
+[port_rpc_public]
+port = 5555
+ip = "0.0.0.0"
+protocol = "http"
+limit = 500
+
+[port_ws_public]
+port = 6005
+ip = "0.0.0.0"
+protocol = "ws"
+limit = 300
+send_queue_limit = 100
+
+# --- Peer port ---
+
+[port_peer]
+port = 51235
+ip = "0.0.0.0"
+protocol = "peer"
 
 # Uncomment to enable gRPC port for Clio integration
 # [port_grpc]

--- a/config/server.go
+++ b/config/server.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"strings"
 )
 
@@ -206,6 +207,53 @@ func (p *PortConfig) validateProtocols() error {
 	}
 
 	return nil
+}
+
+// ParseAdminNets parses the Admin field entries into net.IPNet values.
+// Bare IPs (without CIDR suffix) get /32 for IPv4 or /128 for IPv6.
+// This matches rippled's parse_Port() in Port.cpp.
+func (p *PortConfig) ParseAdminNets() ([]net.IPNet, error) {
+	var nets []net.IPNet
+	for _, entry := range p.Admin {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		// Append CIDR suffix if not present
+		if !strings.Contains(entry, "/") {
+			ip := net.ParseIP(entry)
+			if ip == nil {
+				return nil, fmt.Errorf("invalid admin IP: %s", entry)
+			}
+			if ip.To4() != nil {
+				entry += "/32"
+			} else {
+				entry += "/128"
+			}
+		}
+		_, ipNet, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid admin CIDR %q: %w", entry, err)
+		}
+		nets = append(nets, *ipNet)
+	}
+	return nets, nil
+}
+
+// IPInNets returns true if ip is contained in any of the given networks.
+// Handles IPv4-mapped IPv6 addresses by normalizing to IPv4 first.
+// This matches rippled's ipAllowed() in Role.cpp.
+func IPInNets(ip net.IP, nets []net.IPNet) bool {
+	// Normalize IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) to plain IPv4
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // parseProtocols parses a comma-separated protocol string

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -280,7 +280,11 @@ func runServer(cmd *cobra.Command, args []string) {
 		)
 	})
 
-	// Start listeners based on configured ports
+	// Shared connection limiter for all ports
+	connLimiter := rpc.NewConnLimiter()
+	wsServer.SetConnLimiter(connLimiter)
+
+	// Build the base HTTP mux (shared handler logic, wrapped per-port below)
 	httpMux := http.NewServeMux()
 	httpMux.Handle("/", httpServer)
 	httpMux.Handle("/rpc", httpServer)
@@ -289,9 +293,6 @@ func runServer(cmd *cobra.Command, args []string) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status":"ok","service":"goXRPLd"}`))
 	})
-
-	wsMux := http.NewServeMux()
-	wsMux.Handle("/", wsServer)
 
 	// Start listeners from config ports
 	httpPorts := globalConfig.GetHTTPPorts()
@@ -307,31 +308,55 @@ func runServer(cmd *cobra.Command, args []string) {
 		serverLog.Info("Port configured", "protocol", "peer", "addr", peerPort.GetBindAddress())
 	}
 
-	// Start WebSocket listeners with named *http.Server instances
+	// Start WebSocket listeners — each port gets its own mux with PortMiddleware
 	var wsSrvs []*http.Server
 	for name, p := range wsPorts {
-		addr := p.GetBindAddress()
-		portName := name
-		srv := &http.Server{Addr: addr, Handler: wsMux, ReadHeaderTimeout: 10 * time.Second}
+		portCfg := p
+		adminNets, err := portCfg.ParseAdminNets()
+		if err != nil {
+			serverLog.Fatal("Failed to parse admin nets for port", "name", name, "err", err)
+		}
+		pc := &rpc.PortContext{
+			PortName:  name,
+			AdminNets: adminNets,
+			Limit:     portCfg.Limit,
+			SendQueue: portCfg.SendQueueLimit,
+		}
+		mux := http.NewServeMux()
+		mux.Handle("/", rpc.PortMiddleware(pc, connLimiter, wsServer))
+		srv := &http.Server{Addr: portCfg.GetBindAddress(), Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 		wsSrvs = append(wsSrvs, srv)
 		go func(n string, s *http.Server) {
 			serverLog.Info("Listening", "protocol", "ws", "name", n, "addr", s.Addr)
 			if err := s.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				serverLog.Fatal("WebSocket server failed", "name", n, "addr", s.Addr, "err", err)
 			}
-		}(portName, srv)
+		}(name, srv)
 	}
 
-	// Start HTTP listeners — use the first one as the blocking listener, rest in goroutines
+	// Start HTTP listeners — each port gets its own mux with PortMiddleware
 	httpPortList := make([]struct {
 		name string
+		pc   *rpc.PortContext
 		addr string
 	}, 0, len(httpPorts))
 	for name, p := range httpPorts {
+		portCfg := p
+		adminNets, err := portCfg.ParseAdminNets()
+		if err != nil {
+			serverLog.Fatal("Failed to parse admin nets for port", "name", name, "err", err)
+		}
+		pc := &rpc.PortContext{
+			PortName:  name,
+			AdminNets: adminNets,
+			Limit:     portCfg.Limit,
+			SendQueue: portCfg.SendQueueLimit,
+		}
 		httpPortList = append(httpPortList, struct {
 			name string
+			pc   *rpc.PortContext
 			addr string
-		}{name, p.GetBindAddress()})
+		}{name, pc, portCfg.GetBindAddress()})
 	}
 
 	if len(httpPortList) == 0 {
@@ -341,12 +366,12 @@ func runServer(cmd *cobra.Command, args []string) {
 	// Collect HTTP servers into a slice
 	var httpSrvs []*http.Server
 
-	// Start extra HTTP listeners in goroutines
-	for i := 1; i < len(httpPortList); i++ {
-		entry := httpPortList[i]
+	for _, entry := range httpPortList {
+		wrappedMux := http.NewServeMux()
+		wrappedMux.Handle("/", rpc.PortMiddleware(entry.pc, connLimiter, httpMux))
 		srv := &http.Server{
 			Addr:         entry.addr,
-			Handler:      httpMux,
+			Handler:      wrappedMux,
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: 30 * time.Second,
 			IdleTimeout:  60 * time.Second,
@@ -359,23 +384,6 @@ func runServer(cmd *cobra.Command, args []string) {
 			}
 		}(entry.name, entry.addr, srv)
 	}
-
-	// Start the first HTTP listener (will block until shutdown)
-	first := httpPortList[0]
-	firstSrv := &http.Server{
-		Addr:         first.addr,
-		Handler:      httpMux,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
-		IdleTimeout:  60 * time.Second,
-	}
-	httpSrvs = append(httpSrvs, firstSrv)
-	serverLog.Info("Listening", "protocol", "http", "name", first.name, "addr", first.addr)
-	go func() {
-		if err := firstSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			serverLog.Fatal("HTTP server failed", "name", first.name, "addr", first.addr, "err", err)
-		}
-	}()
 
 	// Add signal handling and a shared shutdown trigger
 	sigCh := make(chan os.Signal, 1)

--- a/internal/rpc/connlimit.go
+++ b/internal/rpc/connlimit.go
@@ -1,0 +1,44 @@
+package rpc
+
+import "sync"
+
+// ConnLimiter tracks concurrent connections per port name and enforces
+// per-port connection limits. Matches rippled's ServerHandler onAccept/onClose
+// counter pattern.
+type ConnLimiter struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+// NewConnLimiter creates a new ConnLimiter.
+func NewConnLimiter() *ConnLimiter {
+	return &ConnLimiter{counts: make(map[string]int)}
+}
+
+// TryAcquire attempts to reserve a connection slot for the given port.
+// Returns false if limit > 0 and the port is already at capacity.
+func (cl *ConnLimiter) TryAcquire(portName string, limit int) bool {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	if limit > 0 && cl.counts[portName] >= limit {
+		return false
+	}
+	cl.counts[portName]++
+	return true
+}
+
+// Release frees a connection slot for the given port.
+func (cl *ConnLimiter) Release(portName string) {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	if cl.counts[portName] > 0 {
+		cl.counts[portName]--
+	}
+}
+
+// Count returns the current connection count for a port (for testing).
+func (cl *ConnLimiter) Count(portName string) int {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	return cl.counts[portName]
+}

--- a/internal/rpc/connlimit_test.go
+++ b/internal/rpc/connlimit_test.go
@@ -1,0 +1,69 @@
+package rpc
+
+import "testing"
+
+func TestConnLimiter_Unlimited(t *testing.T) {
+	cl := NewConnLimiter()
+	// limit=0 means unlimited
+	for i := 0; i < 1000; i++ {
+		if !cl.TryAcquire("port1", 0) {
+			t.Fatalf("TryAcquire should always succeed with limit=0, failed at i=%d", i)
+		}
+	}
+}
+
+func TestConnLimiter_EnforcesLimit(t *testing.T) {
+	cl := NewConnLimiter()
+	if !cl.TryAcquire("port1", 2) {
+		t.Fatal("first acquire should succeed")
+	}
+	if !cl.TryAcquire("port1", 2) {
+		t.Fatal("second acquire should succeed")
+	}
+	if cl.TryAcquire("port1", 2) {
+		t.Fatal("third acquire should fail (limit=2)")
+	}
+}
+
+func TestConnLimiter_ReleaseFreesSlot(t *testing.T) {
+	cl := NewConnLimiter()
+	cl.TryAcquire("port1", 1)
+	if cl.TryAcquire("port1", 1) {
+		t.Fatal("should be at limit")
+	}
+	cl.Release("port1")
+	if !cl.TryAcquire("port1", 1) {
+		t.Fatal("should succeed after release")
+	}
+}
+
+func TestConnLimiter_PerPort(t *testing.T) {
+	cl := NewConnLimiter()
+	cl.TryAcquire("port1", 1)
+	// Different port should not be affected
+	if !cl.TryAcquire("port2", 1) {
+		t.Fatal("port2 should be independent of port1")
+	}
+}
+
+func TestConnLimiter_ReleaseNoUnderflow(t *testing.T) {
+	cl := NewConnLimiter()
+	// Release on empty port should not panic or go negative
+	cl.Release("port1")
+	if cl.Count("port1") != 0 {
+		t.Fatal("count should stay at 0")
+	}
+}
+
+func TestConnLimiter_Count(t *testing.T) {
+	cl := NewConnLimiter()
+	cl.TryAcquire("port1", 0)
+	cl.TryAcquire("port1", 0)
+	if cl.Count("port1") != 2 {
+		t.Fatalf("expected count 2, got %d", cl.Count("port1"))
+	}
+	cl.Release("port1")
+	if cl.Count("port1") != 1 {
+		t.Fatalf("expected count 1, got %d", cl.Count("port1"))
+	}
+}

--- a/internal/rpc/middleware.go
+++ b/internal/rpc/middleware.go
@@ -1,0 +1,39 @@
+package rpc
+
+import (
+	"net/http"
+	"strings"
+)
+
+// PortMiddleware returns an http.Handler that enforces per-port connection
+// limits and injects the PortContext into the request context.
+//
+// For WebSocket upgrade requests the connection slot is NOT released when the
+// middleware returns — WebSocketServer.closeConnection handles that instead.
+// For regular HTTP requests the slot is released when the handler returns.
+func PortMiddleware(pc *PortContext, limiter *ConnLimiter, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Enforce connection limit
+		if limiter != nil && !limiter.TryAcquire(pc.PortName, pc.Limit) {
+			http.Error(w, "Too many connections", http.StatusServiceUnavailable)
+			return
+		}
+
+		isWS := isWebSocketUpgrade(r)
+
+		// For non-WS requests, release the slot when the handler returns.
+		// WS connections are long-lived; their slot is released in closeConnection.
+		if limiter != nil && !isWS {
+			defer limiter.Release(pc.PortName)
+		}
+
+		// Inject PortContext into request context
+		ctx := WithPortContext(r.Context(), pc)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// isWebSocketUpgrade returns true if the request is a WebSocket upgrade.
+func isWebSocketUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
+}

--- a/internal/rpc/portcontext.go
+++ b/internal/rpc/portcontext.go
@@ -1,0 +1,29 @@
+package rpc
+
+import (
+	"context"
+	"net"
+)
+
+type portContextKey struct{}
+
+// PortContext holds per-port configuration attached to each request.
+// It is injected by PortMiddleware and consumed by roleForRequest
+// and WebSocketServer to enforce per-port access control and limits.
+type PortContext struct {
+	PortName  string
+	AdminNets []net.IPNet
+	Limit     int // max concurrent connections; 0 = unlimited
+	SendQueue int // WS send channel buffer size; 0 = use default (100)
+}
+
+// WithPortContext returns a new context carrying the given PortContext.
+func WithPortContext(ctx context.Context, pc *PortContext) context.Context {
+	return context.WithValue(ctx, portContextKey{}, pc)
+}
+
+// GetPortContext extracts the PortContext from a context, or nil if absent.
+func GetPortContext(ctx context.Context) *PortContext {
+	pc, _ := ctx.Value(portContextKey{}).(*PortContext)
+	return pc
+}

--- a/internal/rpc/role_test.go
+++ b/internal/rpc/role_test.go
@@ -1,0 +1,87 @@
+package rpc
+
+import (
+	"net"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+)
+
+func mustParseCIDR(s string) net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return *n
+}
+
+func TestRoleForRequest_WithAdminNets_Match(t *testing.T) {
+	pc := &PortContext{
+		AdminNets: []net.IPNet{mustParseCIDR("10.0.0.0/8")},
+	}
+	role := roleForRequest("10.1.2.3", pc)
+	if role != types.RoleAdmin {
+		t.Fatalf("expected RoleAdmin, got %v", role)
+	}
+}
+
+func TestRoleForRequest_WithAdminNets_NoMatch(t *testing.T) {
+	pc := &PortContext{
+		AdminNets: []net.IPNet{mustParseCIDR("10.0.0.0/8")},
+	}
+	role := roleForRequest("192.168.1.1", pc)
+	if role != types.RoleGuest {
+		t.Fatalf("expected RoleGuest, got %v", role)
+	}
+}
+
+func TestRoleForRequest_NilPortCtx_Localhost(t *testing.T) {
+	role := roleForRequest("127.0.0.1", nil)
+	if role != types.RoleAdmin {
+		t.Fatalf("expected RoleAdmin for localhost with nil portCtx, got %v", role)
+	}
+}
+
+func TestRoleForRequest_NilPortCtx_NonLocal(t *testing.T) {
+	role := roleForRequest("10.0.0.1", nil)
+	if role != types.RoleGuest {
+		t.Fatalf("expected RoleGuest for non-local with nil portCtx, got %v", role)
+	}
+}
+
+func TestRoleForRequest_EmptyAdminNets_FallsBackToLocalhost(t *testing.T) {
+	pc := &PortContext{AdminNets: nil}
+	role := roleForRequest("127.0.0.1", pc)
+	if role != types.RoleAdmin {
+		t.Fatalf("expected RoleAdmin for localhost with empty AdminNets, got %v", role)
+	}
+}
+
+func TestRoleForRequest_IPv6Loopback(t *testing.T) {
+	pc := &PortContext{
+		AdminNets: []net.IPNet{mustParseCIDR("::1/128")},
+	}
+	role := roleForRequest("::1", pc)
+	if role != types.RoleAdmin {
+		t.Fatalf("expected RoleAdmin for ::1, got %v", role)
+	}
+}
+
+func TestRoleForRequest_MultipleNets(t *testing.T) {
+	pc := &PortContext{
+		AdminNets: []net.IPNet{
+			mustParseCIDR("10.0.0.0/8"),
+			mustParseCIDR("172.16.0.0/12"),
+		},
+	}
+	// Should match second net
+	role := roleForRequest("172.20.1.1", pc)
+	if role != types.RoleAdmin {
+		t.Fatalf("expected RoleAdmin, got %v", role)
+	}
+	// Should not match either
+	role = roleForRequest("8.8.8.8", pc)
+	if role != types.RoleGuest {
+		t.Fatalf("expected RoleGuest, got %v", role)
+	}
+}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -3,11 +3,13 @@ package rpc
 import (
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/config"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
 )
@@ -91,7 +93,8 @@ func (s *Server) handleGetRequest(w http.ResponseWriter, r *http.Request) {
 
 	// Create RPC context
 	clientIP := getClientIP(r)
-	role := roleForRequest(clientIP)
+	portCtx := GetPortContext(r.Context())
+	role := roleForRequest(clientIP, portCtx)
 	ctx := &types.RpcContext{
 		Context:    r.Context(),
 		Role:       role,
@@ -138,7 +141,8 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 
 	// Create RPC context
 	clientIP := getClientIP(r)
-	role := roleForRequest(clientIP)
+	portCtx := GetPortContext(r.Context())
+	role := roleForRequest(clientIP, portCtx)
 	ctx := &types.RpcContext{
 		Context:    r.Context(),
 		Role:       role,
@@ -338,10 +342,20 @@ func isLocalhost(ip string) bool {
 	return ip == "127.0.0.1" || ip == "::1"
 }
 
-// roleForRequest determines the Role for an incoming request.
-// In standalone mode (the only mode currently supported), localhost
-// connections are Admin; everything else is Guest.
-func roleForRequest(clientIP string) types.Role {
+// roleForRequest determines the Role for an incoming request based on the
+// client IP and the port's admin network list. When a PortContext with
+// AdminNets is available, it checks the client IP against those networks
+// (matching rippled's requestRole in Role.cpp). Otherwise it falls back to
+// the legacy localhost-only check for backward compatibility.
+func roleForRequest(clientIP string, portCtx *PortContext) types.Role {
+	if portCtx != nil && len(portCtx.AdminNets) > 0 {
+		ip := net.ParseIP(clientIP)
+		if ip != nil && config.IPInNets(ip, portCtx.AdminNets) {
+			return types.RoleAdmin
+		}
+		return types.RoleGuest
+	}
+	// Fallback: no port context or no admin nets configured — use localhost check
 	if isLocalhost(clientIP) {
 		return types.RoleAdmin
 	}

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -18,6 +18,10 @@ import (
 // wsLog is the logger for the WebSocket server.
 var wsLog = xrpllog.Named(xrpllog.PartitionRPC)
 
+// DefaultSendQueueLimit is the default WebSocket send channel buffer size,
+// matching rippled's default ws_queue_limit of 100 (Port.cpp).
+const DefaultSendQueueLimit = 100
+
 // WebSocketServer handles WebSocket connections for real-time subscriptions
 type WebSocketServer struct {
 	upgrader            websocket.Upgrader
@@ -27,6 +31,7 @@ type WebSocketServer struct {
 	connectionsMutex    sync.RWMutex
 	timeout             time.Duration
 	ledgerInfoProvider  types.LedgerInfoProvider
+	connLimiter         *ConnLimiter
 }
 
 // WebSocketConnection represents a single WebSocket connection
@@ -40,6 +45,7 @@ type WebSocketConnection struct {
 	ctx             context.Context
 	cancel          context.CancelFunc
 	pathFindSession *PathFindSession // At most one active path_find session per connection
+	portCtx         *PortContext     // per-port config for role determination
 }
 
 // NewWebSocketServer creates a new WebSocket server
@@ -68,13 +74,28 @@ func (ws *WebSocketServer) SetLedgerInfoProvider(provider types.LedgerInfoProvid
 	ws.ledgerInfoProvider = provider
 }
 
+// SetConnLimiter sets the connection limiter used to release per-port slots
+// when WebSocket connections close.
+func (ws *WebSocketServer) SetConnLimiter(limiter *ConnLimiter) {
+	ws.connLimiter = limiter
+}
+
 // ServeHTTP handles WebSocket upgrade requests
 func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Extract per-port context injected by PortMiddleware
+	portCtx := GetPortContext(r.Context())
+
 	// Upgrade HTTP connection to WebSocket
 	conn, err := ws.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		wsLog.Error("WebSocket upgrade failed", "err", err)
 		return
+	}
+
+	// Determine send queue size from port config, default to 100 (rippled default)
+	sendQueueLimit := DefaultSendQueueLimit
+	if portCtx != nil && portCtx.SendQueue > 0 {
+		sendQueueLimit = portCtx.SendQueue
 	}
 
 	// Create connection context - use Background() not r.Context()
@@ -86,10 +107,11 @@ func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ID:            generateConnectionID(),
 		conn:          conn,
 		subscriptions: make(map[types.SubscriptionType]types.SubscriptionConfig),
-		sendChannel:   make(chan []byte, 256),
+		sendChannel:   make(chan []byte, sendQueueLimit),
 		closeChannel:  make(chan struct{}),
 		ctx:           ctx,
 		cancel:        cancel,
+		portCtx:       portCtx,
 	}
 
 	// Register connection
@@ -239,7 +261,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 
 	// Create RPC context
 	clientIP := getWebSocketClientIP(wsConn.conn)
-	role := roleForRequest(clientIP)
+	role := roleForRequest(clientIP, wsConn.portCtx)
 	wsLog.Debug("ws request", "cmd", cmd.Command, "remoteAddr", wsConn.conn.RemoteAddr().String(), "clientIP", clientIP, "role", role, "isAdmin", role == types.RoleAdmin)
 	rpcCtx := &types.RpcContext{
 		Context:    wsConn.ctx,
@@ -645,6 +667,11 @@ func (ws *WebSocketServer) closeConnection(wsConn *WebSocketConnection) {
 
 	// Remove from subscription manager
 	ws.subscriptionManager.RemoveConnection(wsConn.ID)
+
+	// Release per-port connection limiter slot
+	if ws.connLimiter != nil && wsConn.portCtx != nil {
+		ws.connLimiter.Release(wsConn.portCtx.PortName)
+	}
 
 	// Close WebSocket connection
 	wsConn.conn.Close()


### PR DESCRIPTION
…S send queue (#165)

The WebSocket and HTTP servers now respect the PortConfig fields that were previously parsed but ignored:

- admin: CIDR-based admin IP matching per port (matching rippled Role.cpp)
- limit: per-port concurrent connection cap enforced via ConnLimiter
- send_queue_limit: configurable WS send channel buffer (default 100)

Each listener gets its own PortMiddleware that injects PortContext into the request, enabling roleForRequest to check the port's admin net list instead of only checking for localhost.

The example config now includes public HTTP/WS ports alongside the existing admin-only ports.