### PR TITLE
fix: derive genesis FeeSettings format from amendments, matching rippled

### DIFF
--- a/config/genesis_json.go
+++ b/config/genesis_json.go
@@ -99,7 +99,6 @@ type GenesisConfig struct {
 	BaseFee          drops.XRPAmount
 	ReserveBase      drops.XRPAmount
 	ReserveIncrement drops.XRPAmount
-	UseModernFees    bool
 
 	// Amendments to enable (32-byte hashes)
 	Amendments [][32]byte
@@ -182,9 +181,7 @@ func (g *GenesisJSON) ToGenesisConfig() (*GenesisConfig, error) {
 		return nil, fmt.Errorf("failed to parse genesis state: %w", err)
 	}
 
-	config := &GenesisConfig{
-		UseModernFees: true, // Default to modern fees
-	}
+	config := &GenesisConfig{}
 
 	// Parse total coins
 	totalCoins := g.Ledger.TotalCoins
@@ -213,11 +210,6 @@ func (g *GenesisJSON) ToGenesisConfig() (*GenesisConfig, error) {
 		config.BaseFee = drops.NewXRPAmount(int64(baseFee))
 		config.ReserveBase = drops.NewXRPAmount(int64(state.FeeSettings.ReserveBase))
 		config.ReserveIncrement = drops.NewXRPAmount(int64(state.FeeSettings.ReserveIncrement))
-
-		// Detect if using legacy fees (has ReferenceFeeUnits)
-		if state.FeeSettings.ReferenceFeeUnits > 0 {
-			config.UseModernFees = false
-		}
 	}
 
 	// Parse amendments
@@ -361,7 +353,8 @@ func parseAmendmentHash(hexHash string) ([32]byte, error) {
 	return hash, nil
 }
 
-// DefaultGenesisConfig returns a default genesis configuration matching rippled defaults
+// DefaultGenesisConfig returns a default genesis configuration matching rippled defaults.
+// Fee format is derived from amendments: legacy when XRPFees is absent, modern when present.
 func DefaultGenesisConfig() *GenesisConfig {
 	return &GenesisConfig{
 		TotalXRP:            100_000_000_000 * 1_000_000, // 100 billion XRP
@@ -369,7 +362,6 @@ func DefaultGenesisConfig() *GenesisConfig {
 		BaseFee:             drops.NewXRPAmount(10), // 10 drops
 		ReserveBase:         drops.DropsPerXRP * 10, // 10 XRP
 		ReserveIncrement:    drops.DropsPerXRP * 2,  // 2 XRP
-		UseModernFees:       true,
 		Amendments:          nil,
 		InitialAccounts:     nil, // Will use master passphrase account
 	}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -154,8 +154,7 @@ func runServer(cmd *cobra.Command, args []string) {
 				ReserveBase:      genesisCfg.ReserveBase,
 				ReserveIncrement: genesisCfg.ReserveIncrement,
 			},
-			Amendments:    genesisCfg.Amendments,
-			UseModernFees: genesisCfg.UseModernFees,
+			Amendments: genesisCfg.Amendments,
 		}
 		for _, acc := range genesisCfg.InitialAccounts {
 			genesisConfig.InitialAccounts = append(genesisConfig.InitialAccounts, genesis.InitialAccount{

--- a/internal/ledger/genesis/genesis.go
+++ b/internal/ledger/genesis/genesis.go
@@ -9,6 +9,7 @@ import (
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/crypto/common"
 	secp256k1 "github.com/LeJamon/goXRPLd/crypto/secp256k1"
 	"github.com/LeJamon/goXRPLd/drops"
@@ -23,8 +24,9 @@ const (
 	// InitialXRP is the total XRP in existence (100 billion XRP in drops)
 	InitialXRP = 100_000_000_000 * 1_000_000
 
-	// GenesisTimeResolution is the close time resolution for the genesis ledger
-	GenesisTimeResolution = 30
+	// GenesisTimeResolution is the close time resolution for the genesis ledger.
+	// Reference: rippled LedgerTiming.h ledgerGenesisTimeResolution = ledgerPossibleTimeResolutions[0] = 10s
+	GenesisTimeResolution = 10
 
 	// GenesisLedgerSequence is the sequence number of the genesis ledger
 	GenesisLedgerSequence = 1
@@ -68,9 +70,6 @@ type Config struct {
 	// Amendments to enable at genesis (empty for standard genesis)
 	Amendments [][32]byte
 
-	// UseModernFees indicates whether to use XRPFees amendment format
-	UseModernFees bool
-
 	// InitialAccounts specifies additional accounts to create at genesis
 	// The balance for these is deducted from the genesis account
 	InitialAccounts []InitialAccount
@@ -84,7 +83,10 @@ type InitialAccount struct {
 	Flags    uint32
 }
 
-// DefaultConfig returns the default genesis configuration
+// DefaultConfig returns the default genesis configuration.
+// Fee format (modern vs legacy) is automatically derived from whether
+// the XRPFees amendment is in the Amendments list, matching rippled's
+// genesis behavior (Ledger.cpp:168-229).
 func DefaultConfig() Config {
 	return Config{
 		TotalXRP:            InitialXRP,
@@ -92,9 +94,20 @@ func DefaultConfig() Config {
 		CloseTimeResolution: GenesisTimeResolution,
 		Fees:                StandardFees(),
 		Amendments:          nil,
-		UseModernFees:       true,
 		InitialAccounts:     nil,
 	}
+}
+
+// hasXRPFeesAmendment checks if the XRPFees amendment is in the amendments list.
+// This determines whether to use modern (Amount) or legacy (UInt32/UInt64) fee fields.
+// Reference: rippled Ledger.cpp checks for featureXRPFees in the amendments vector.
+func hasXRPFeesAmendment(amendments [][32]byte) bool {
+	for _, a := range amendments {
+		if a == amendment.FeatureXRPFees {
+			return true
+		}
+	}
+	return false
 }
 
 // GenesisLedger represents a freshly created genesis ledger
@@ -331,10 +344,13 @@ func createInitialAccount(stateMap *shamap.SHAMap, accountID [20]byte, balance u
 }
 
 // createFeeSettings creates the fee settings entry.
+// The fee format is derived from the amendments list: modern (Amount fields)
+// if XRPFees is present, legacy (UInt32/UInt64) otherwise.
+// Reference: rippled Ledger.cpp checks featureXRPFees in the amendments vector.
 func createFeeSettings(stateMap *shamap.SHAMap, cfg Config) error {
 	var feeSettings *ledgerentries.FeeSettings
 
-	if cfg.UseModernFees {
+	if hasXRPFeesAmendment(cfg.Amendments) {
 		feeSettings = ledgerentries.NewFeeSettings(
 			cfg.Fees.BaseFee,
 			cfg.Fees.ReserveBase,

--- a/internal/ledger/genesis/genesis_test.go
+++ b/internal/ledger/genesis/genesis_test.go
@@ -1,8 +1,10 @@
 package genesis
 
 import (
+	"encoding/hex"
 	"testing"
 
+	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/drops"
 )
 
@@ -105,10 +107,10 @@ func TestCreateGenesisLedgerWithAmendments(t *testing.T) {
 }
 
 func TestCreateGenesisLedgerLegacyFees(t *testing.T) {
+	// No amendments → legacy fee format (XRPFees not present)
 	cfg := Config{
-		Fees:          StandardFees(),
-		UseModernFees: false, // Use legacy fee format
-		Amendments:    nil,
+		Fees:       StandardFees(),
+		Amendments: nil,
 	}
 
 	genesis, err := Create(cfg)
@@ -122,6 +124,40 @@ func TestCreateGenesisLedgerLegacyFees(t *testing.T) {
 	}
 
 	t.Logf("Genesis with legacy fees created successfully")
+}
+
+func TestCreateGenesisLedgerModernFees(t *testing.T) {
+	// Include XRPFees amendment → modern fee format
+	cfg := Config{
+		Fees:       StandardFees(),
+		Amendments: [][32]byte{amendment.FeatureXRPFees},
+	}
+
+	genesis, err := Create(cfg)
+	if err != nil {
+		t.Fatalf("Create genesis with modern fees failed: %v", err)
+	}
+
+	if genesis.Header.Drops != InitialXRP {
+		t.Errorf("Genesis XRP mismatch: got %d, expected %d",
+			genesis.Header.Drops, InitialXRP)
+	}
+
+	// Hash should differ from legacy format genesis
+	legacyCfg := Config{
+		Fees:       StandardFees(),
+		Amendments: nil,
+	}
+	legacyGenesis, err := Create(legacyCfg)
+	if err != nil {
+		t.Fatalf("Create genesis with legacy fees failed: %v", err)
+	}
+
+	if genesis.Header.Hash == legacyGenesis.Header.Hash {
+		t.Error("Modern fees genesis should produce different hash than legacy fees genesis")
+	}
+
+	t.Logf("Genesis with modern fees created successfully")
 }
 
 func TestStandardFees(t *testing.T) {
@@ -159,4 +195,89 @@ func TestCalculateLedgerHash(t *testing.T) {
 		t.Errorf("Recalculated hash mismatch: got %x, expected %x",
 			recalculatedHash, genesis.Header.Hash)
 	}
+}
+
+func TestHasXRPFeesAmendment(t *testing.T) {
+	// No amendments → false
+	if hasXRPFeesAmendment(nil) {
+		t.Error("Expected false for nil amendments")
+	}
+
+	// Empty amendments → false
+	if hasXRPFeesAmendment([][32]byte{}) {
+		t.Error("Expected false for empty amendments")
+	}
+
+	// Unrelated amendment → false
+	fakeAmendment := [32]byte{1, 2, 3}
+	if hasXRPFeesAmendment([][32]byte{fakeAmendment}) {
+		t.Error("Expected false for unrelated amendment")
+	}
+
+	// XRPFees present → true
+	if !hasXRPFeesAmendment([][32]byte{amendment.FeatureXRPFees}) {
+		t.Error("Expected true when XRPFees amendment is present")
+	}
+
+	// XRPFees among others → true
+	amendments := [][32]byte{fakeAmendment, amendment.FeatureXRPFees, {9, 8, 7}}
+	if !hasXRPFeesAmendment(amendments) {
+		t.Error("Expected true when XRPFees is among multiple amendments")
+	}
+}
+
+// TestGenesisHashConformance verifies that the genesis hash matches what rippled
+// would produce for the same configuration. This catches serialization regressions.
+//
+// rippled test env: START_UP=NORMAL → no amendments → legacy FeeSettings format.
+// Reference: rippled Application.cpp:1707-1712, Ledger.cpp:168-229.
+func TestGenesisHashConformance(t *testing.T) {
+	t.Run("StandardDefaults_NoAmendments", func(t *testing.T) {
+		// Standard genesis: no amendments, standard fees (10 drops, 10 XRP reserve, 2 XRP increment)
+		cfg := DefaultConfig()
+		gen, err := Create(cfg)
+		if err != nil {
+			t.Fatalf("genesis creation failed: %v", err)
+		}
+
+		// These are the verified hashes for standard genesis with legacy fees
+		expectedAccountHash := "ec2f822edfbc6f2f4de5aa7c8aff128f27db2c194315fd727445a4967dafd018"
+		expectedLedgerHash := "b06f8e90df67b6a383e692a12963425b0e5fa6fbf0704370c137fce71d88a2d8"
+
+		gotAccountHash := hex.EncodeToString(gen.Header.AccountHash[:])
+		gotLedgerHash := hex.EncodeToString(gen.Header.Hash[:])
+
+		if gotAccountHash != expectedAccountHash {
+			t.Errorf("AccountHash mismatch:\n  got:  %s\n  want: %s", gotAccountHash, expectedAccountHash)
+		}
+		if gotLedgerHash != expectedLedgerHash {
+			t.Errorf("LedgerHash mismatch:\n  got:  %s\n  want: %s", gotLedgerHash, expectedLedgerHash)
+		}
+	})
+
+	t.Run("TestEnvConfig_NoAmendments", func(t *testing.T) {
+		// rippled test env config: 200 XRP reserve, 50 XRP increment, no amendments
+		cfg := DefaultConfig()
+		cfg.Fees.ReserveBase = drops.DropsPerXRP * 200
+		cfg.Fees.ReserveIncrement = drops.DropsPerXRP * 50
+
+		gen, err := Create(cfg)
+		if err != nil {
+			t.Fatalf("genesis creation failed: %v", err)
+		}
+
+		// Verified hashes for test env config with legacy fees
+		expectedAccountHash := "bd8a3d72ca73dde887ad63666ec2bad07875cba997a102579b5b95ecdffeaed8"
+		expectedLedgerHash := "3020eb9e7be24ef7d7a060cb051583ec117384636d1781afb5b87f3e348da489"
+
+		gotAccountHash := hex.EncodeToString(gen.Header.AccountHash[:])
+		gotLedgerHash := hex.EncodeToString(gen.Header.Hash[:])
+
+		if gotAccountHash != expectedAccountHash {
+			t.Errorf("AccountHash mismatch:\n  got:  %s\n  want: %s", gotAccountHash, expectedAccountHash)
+		}
+		if gotLedgerHash != expectedLedgerHash {
+			t.Errorf("LedgerHash mismatch:\n  got:  %s\n  want: %s", gotLedgerHash, expectedLedgerHash)
+		}
+	})
 }


### PR DESCRIPTION
The genesis ledger hash diverged from rippled because goXRPL hardcoded UseModernFees=true regardless of amendments. Rippled derives the fee format from whether featureXRPFees is in the genesis amendments list (Ledger.cpp:168-229). Since the test env passes no amendments at genesis, rippled uses legacy FeeSettings format — goXRPL was incorrectly using modern format, producing different SLE bytes and cascading hash divergence.

- Remove UseModernFees from genesis.Config and config.GenesisConfig
- Derive fee format from amendments list via hasXRPFeesAmendment()
- Fix GenesisTimeResolution from 30 to 10 (matching rippled)
- Add conformance tests with hardcoded expected genesis hashes

Fixes #159