### PR TITLE
Add centralized version package targeting rippled 2.6.2

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/LeJamon/goXRPLd/config"
+	"github.com/LeJamon/goXRPLd/version"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +29,7 @@ var rootCmd = &cobra.Command{
 with concurrent processing capabilities. This is NOT a direct translation of the
 C++ rippled implementation but rather a native Go implementation that follows
 Go conventions and patterns while maintaining protocol compatibility.`,
-	Version: "0.1.0-dev",
+	Version: version.Version,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
+	"github.com/LeJamon/goXRPLd/version"
 	kvpebble "github.com/LeJamon/goXRPLd/storage/kvstore/pebble"
 	"github.com/LeJamon/goXRPLd/storage/nodestore"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
@@ -80,7 +81,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	xrpllog.SetRootConfig(&logCfg)
 	serverLog := rootLogger.Named(xrpllog.PartitionServer)
 
-	serverLog.Info("Starting goXRPLd", "version", "0.1.0-dev")
+	serverLog.Info("Starting goXRPLd", "version", version.Version)
 
 	// Initialize storage from config
 	var db nodestore.Database

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -8,14 +8,14 @@ import (
 	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/version"
 )
 
 // serverStartTime tracks when the server started for uptime calculation
 var serverStartTime = time.Now()
 
 // BuildVersion is the reported build version for server_info/server_state.
-// It can be overridden at build time via ldflags.
-var BuildVersion = "2.0.0-goXRPLd"
+var BuildVersion = version.Version
 
 // cachedHostID is resolved once at startup to avoid repeated syscalls.
 var cachedHostID = resolveHostID()

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+// Version is set at build time via:
+//
+//	go build -ldflags "-X github.com/LeJamon/goXRPLd/version.Version=x.y.z"
+var Version = "2.6.2"


### PR DESCRIPTION
Create version/ package with a single Version var (overridable via ldflags) and replace all hardcoded version strings in cli/root.go, cli/server.go, and rpc/handlers/server_info.go.