### PR TITLE
Fix genesis hash, live peer count, and duplicate connections

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -186,9 +186,7 @@ func runServer(cmd *cobra.Command, args []string) {
 		RelationalDB: repoManager,
 		Logger:       rootLogger,
 	}
-	if standalone {
-		cfg.GenesisConfig = genesisConfig
-	}
+	cfg.GenesisConfig = genesisConfig
 
 	ledgerService, err := service.New(cfg)
 	if err != nil {
@@ -215,8 +213,9 @@ func runServer(cmd *cobra.Command, args []string) {
 			serverLog.Fatal("Failed to start consensus components", "err", err)
 		}
 
-		// Expose node identity to RPC handlers
+		// Expose node identity and peer count to RPC handlers
 		types.Services.NodePublicKey = consensusComponents.Overlay.Identity().EncodedPublicKey()
+		types.Services.PeerCount = consensusComponents.Overlay.PeerCount
 
 		isValidator := globalConfig.IsValidator()
 		serverLog.Info("Running in consensus mode",

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -248,6 +248,12 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 		return
 	}
 
+	// Reject duplicate: if we already have a connection to this IP.
+	if o.isConnectedTo(endpoint) {
+		conn.Close()
+		return
+	}
+
 	peer.setState(PeerStateConnected)
 	slog.Info("Inbound peer connected", "t", "Overlay", "remote", remoteAddr)
 
@@ -561,6 +567,13 @@ func (o *Overlay) Connect(addr string) error {
 		return err
 	}
 
+	// Re-check after handshake: another goroutine may have connected
+	// to the same host (inbound or outbound) while we were handshaking.
+	if o.isConnectedTo(endpoint) {
+		peer.Close()
+		return ErrAlreadyConnected
+	}
+
 	o.addPeer(peer)
 
 	// Run peer read/write loops
@@ -661,13 +674,17 @@ func (o *Overlay) removePeer(peerID PeerID) {
 	}
 }
 
-// isConnectedTo checks if we're already connected to an endpoint.
+// isConnectedTo checks if we're already connected to a host.
+// Compares by resolved remote IP to handle DNS names vs raw IPs.
 func (o *Overlay) isConnectedTo(endpoint Endpoint) bool {
 	o.peersMu.RLock()
 	defer o.peersMu.RUnlock()
 
 	for _, peer := range o.peers {
-		if peer.Endpoint().String() == endpoint.String() {
+		if peer.RemoteIP() == endpoint.Host {
+			return true
+		}
+		if peer.Endpoint().Host == endpoint.Host {
 			return true
 		}
 	}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -115,6 +115,22 @@ func (p *Peer) Endpoint() Endpoint {
 	return p.endpoint
 }
 
+// RemoteIP returns the resolved remote IP from the actual TCP connection.
+func (p *Peer) RemoteIP() string {
+	p.mu.RLock()
+	conn := p.conn
+	p.mu.RUnlock()
+
+	if conn == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+	if err != nil {
+		return ""
+	}
+	return host
+}
+
 // Inbound returns true if this is an inbound connection.
 func (p *Peer) Inbound() bool {
 	return p.inbound

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -83,7 +83,7 @@ func buildServerInfo(human bool) map[string]interface{} {
 		"server_state":      serverState,
 		"uptime":            uptime,
 		"validation_quorum": 1, // TODO: get from consensus/validators
-		"peers":             0, // TODO: get from peer manager
+		"peers":             getPeerCount(),
 
 		// Overflow/disconnect counters (string in rippled)
 		"jq_trans_overflow":          "0", // TODO: track real overflow count
@@ -220,4 +220,11 @@ func buildServerInfo(human bool) map[string]interface{} {
 	}
 
 	return info
+}
+
+func getPeerCount() int {
+	if types.Services.PeerCount != nil {
+		return types.Services.PeerCount()
+	}
+	return 0
 }

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -30,6 +30,9 @@ type ServiceContainer struct {
 
 	// NodePublicKey is the base58-encoded node identity public key (e.g. "n9...")
 	NodePublicKey string
+
+	// PeerCount returns the number of connected peers (nil when not in consensus mode)
+	PeerCount func() int
 }
 
 // LedgerNavigator provides ledger index navigation and mode queries.


### PR DESCRIPTION
Genesis:
- Pass genesis config to ledger service in all modes, not just standalone. Non-standalone nodes were getting zero-valued fees producing a different genesis hash than rippled.

RPC:
- Wire live peer count from overlay to server_info (was hardcoded 0)
- Add PeerCount func to ServiceContainer

P2P:
- Reject duplicate connections by comparing resolved remote IPs
- Add RemoteIP() to Peer using actual TCP connection address
- Re-check isConnectedTo after outbound handshake completes to handle concurrent connection races