### PR TITLE
Fix RPC error codes and handler behavior for hive conformance

### DIFF
--- a/internal/rpc/handlers/account_channels.go
+++ b/internal/rpc/handlers/account_channels.go
@@ -52,10 +52,7 @@ func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMes
 	)
 	if err != nil {
 		if err.Error() == "account not found" {
-			return nil, &types.RpcError{
-				Code:    types.RpcACT_NOT_FOUND,
-				Message: "Account not found.",
-			}
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		// Handle malformed destination_account address
 		if len(err.Error()) > 32 && err.Error()[:32] == "invalid destination_account addr" {

--- a/internal/rpc/handlers/account_info.go
+++ b/internal/rpc/handlers/account_info.go
@@ -101,10 +101,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	info, err := types.Services.Ledger.GetAccountInfo(request.Account, ledgerIndex)
 	if err != nil {
 		if err.Error() == "account not found" {
-			return nil, &types.RpcError{
-				Code:    19,
-				Message: "Account not found.",
-			}
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		return nil, types.RpcErrorInternal("Failed to get account info: " + err.Error())
 	}

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -108,10 +108,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	// Get the AMM entry
 	ammEntry, err := types.Services.Ledger.GetLedgerEntry(ammKey, ledgerIndex)
 	if err != nil {
-		return nil, &types.RpcError{
-			Code:    19,
-			Message: "AMM not found",
-		}
+		return nil, types.RpcErrorActNotFound("AMM not found")
 	}
 
 	// Decode the AMM entry

--- a/internal/rpc/handlers/book_changes.go
+++ b/internal/rpc/handlers/book_changes.go
@@ -62,6 +62,16 @@ func (m *BookChangesMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 
 	targetLedger, err := types.Services.Ledger.GetLedgerBySequence(ledgerSeq)
 	if err != nil {
+		// For the current (open) ledger, return empty changes since no
+		// transactions have been finalized yet.
+		li := request.LedgerIndex.String()
+		if li == "current" || li == "" {
+			return map[string]interface{}{
+				"type":         "bookChanges",
+				"ledger_index": ledgerSeq,
+				"changes":      []interface{}{},
+			}, nil
+		}
 		return nil, types.RpcErrorLgrNotFound("Ledger not found")
 	}
 

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/hex"
 	"encoding/json"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -40,6 +41,14 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	takerPays, err := ParseAmountFromJSON(request.TakerPays)
 	if err != nil {
 		return nil, types.RpcErrorInvalidParams("Invalid taker_pays: " + err.Error())
+	}
+
+	// Validate currencies (rippled rejects non-standard currency codes)
+	if rpcErr := validateCurrency(takerPays.Currency); rpcErr != nil {
+		return nil, rpcErr
+	}
+	if rpcErr := validateCurrency(takerGets.Currency); rpcErr != nil {
+		return nil, rpcErr
 	}
 
 	// Determine ledger index to use
@@ -102,4 +111,22 @@ func ParseAmountFromJSON(data json.RawMessage) (types.Amount, error) {
 		Issuer:   iouAmount.Issuer,
 		Value:    iouAmount.Value,
 	}, nil
+}
+
+// validateCurrency checks that a currency code is valid per rippled rules:
+// empty or "XRP" (native), exactly 3 characters (ISO), or exactly 40 hex characters.
+// Reference: rippled UintTypes.cpp to_currency()
+func validateCurrency(currency string) *types.RpcError {
+	if currency == "" || currency == "XRP" {
+		return nil
+	}
+	if len(currency) == 3 {
+		return nil
+	}
+	if len(currency) == 40 {
+		if _, err := hex.DecodeString(currency); err == nil {
+			return nil
+		}
+	}
+	return types.RpcErrorSrcCurMalformed("Source currency is malformed.")
 }

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -360,17 +360,14 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	}
 
 	if !keySet {
-		return nil, types.RpcErrorInvalidParams("Must specify object to look up")
+		return nil, types.RpcErrorUnknownOption("Must specify object to look up")
 	}
 
 	// Get ledger entry
 	result, err := types.Services.Ledger.GetLedgerEntry(entryKey, ledgerIndex)
 	if err != nil {
 		if err.Error() == "entry not found" {
-			return nil, &types.RpcError{
-				Code:    21,
-				Message: "Requested ledger entry not found.",
-			}
+			return nil, types.RpcErrorEntryNotFound("Requested ledger entry not found.")
 		}
 		return nil, types.RpcErrorInternal("Failed to get ledger entry: " + err.Error())
 	}

--- a/internal/rpc/handlers/ledger_header.go
+++ b/internal/rpc/handlers/ledger_header.go
@@ -60,6 +60,11 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		case "current":
 			seq := types.Services.Ledger.GetCurrentLedgerIndex()
 			targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+			if lookupErr != nil {
+				// Open ledger may not be in history yet; fall back to closed ledger.
+				seq = types.Services.Ledger.GetClosedLedgerIndex()
+				targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+			}
 		default:
 			var seq uint32
 			if _, scanErr := fmt.Sscanf(ledgerIndexStr, "%d", &seq); scanErr == nil {

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	"github.com/LeJamon/goXRPLd/internal/tx/payment"
 	"github.com/LeJamon/goXRPLd/internal/tx/payment/pathfinder"
+	"github.com/LeJamon/goXRPLd/keylet"
 )
 
 // ripplePathFindRequest represents the ripple_path_find RPC request params.
@@ -52,8 +53,7 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 
 	// Validate required fields
 	if request.SourceAccount == "" {
-		return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
-			"Missing field 'source_account'")
+		return nil, types.RpcErrorSrcActMissing("Source account not provided.")
 	}
 	if request.DestinationAccount == "" {
 		return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
@@ -108,6 +108,15 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	if err != nil {
 		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
 			"No closed ledger available")
+	}
+
+	// Check destination account exists for non-XRP destination amounts.
+	// Reference: rippled PathRequest.cpp lines 199-206
+	if !dstAmount.IsNative() {
+		exists, _ := view.Exists(keylet.Account(dstAccount))
+		if !exists {
+			return nil, types.RpcErrorActNotFound("Destination account not found.")
+		}
 	}
 
 	// Run pathfinding

--- a/internal/rpc/handlers/transaction_entry.go
+++ b/internal/rpc/handlers/transaction_entry.go
@@ -31,7 +31,7 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 	}
 
 	if request.TxHash == "" {
-		return nil, types.RpcErrorInvalidParams("Missing required parameter: tx_hash")
+		return nil, types.NewRpcError(-1, "fieldNotFoundTransaction", "fieldNotFoundTransaction", "Missing field 'tx_hash'.")
 	}
 
 	if err := RequireLedgerService(); err != nil {

--- a/internal/rpc/handlers/tx.go
+++ b/internal/rpc/handlers/tx.go
@@ -48,7 +48,7 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interf
 	// Parse the transaction hash
 	txHashBytes, err := hex.DecodeString(request.Transaction)
 	if err != nil || len(txHashBytes) != 32 {
-		return nil, types.RpcErrorInvalidParams("Invalid transaction hash")
+		return nil, types.RpcErrorNotImpl()
 	}
 
 	var txHash [32]byte

--- a/internal/rpc/handlers/wallet_propose.go
+++ b/internal/rpc/handlers/wallet_propose.go
@@ -10,6 +10,7 @@ import (
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/crypto/common"
 	"github.com/LeJamon/goXRPLd/crypto/ed25519"
+	"github.com/LeJamon/goXRPLd/crypto/rfc1751"
 	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -151,12 +152,14 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, types.RpcErrorInternal("Failed to encode public key: " + err.Error())
 	}
 
+	// Encode seed as RFC-1751 human-readable words (master_key)
+	masterKey, _ := rfc1751.SeedToEnglish(entropy)
+
 	// Add passphrase warning matching rippled logic
 	// rippled skips warning if passphrase equals any seed encoding
 	seedHexStr := strings.ToUpper(hex.EncodeToString(entropy))
 	if passphraseUsed {
-		// TODO: add master_key (RFC1751) comparison when rfc1751 dictionary is complete
-		if request.Passphrase != encodedSeed && request.Passphrase != seedHexStr {
+		if request.Passphrase != encodedSeed && request.Passphrase != seedHexStr && request.Passphrase != masterKey {
 			entropyBits := estimateEntropy(request.Passphrase)
 			if entropyBits < 80.0 {
 				warning = "This wallet was generated using a user-supplied passphrase that has low entropy and is vulnerable to brute-force attacks."
@@ -168,9 +171,9 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 
 	// Build response matching rippled format
 	response := map[string]interface{}{
-		"account_id": accountID,
-		"key_type":   keyType,
-		// TODO: "master_key" (RFC1751 encoding) — requires rfc1751 dictionary to be complete
+		"account_id":      accountID,
+		"key_type":        keyType,
+		"master_key":      masterKey,
 		"master_seed":     encodedSeed,
 		"master_seed_hex": seedHexStr,
 		"public_key":      encodedPublicKey,

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -278,3 +278,33 @@ func RpcErrorNotImpl() *RpcError {
 func RpcErrorOracleMalformed() *RpcError {
 	return NewRpcError(RpcORACLE_MALFORMED, "oracleMalformed", "oracleMalformed", "Oracle request is malformed.")
 }
+
+// RpcErrorEntryNotFound returns an error when a ledger entry is not found
+// (matches rippled "entryNotFound", code 21).
+func RpcErrorEntryNotFound(message string) *RpcError {
+	return NewRpcError(RpcACT_CHANNELS, "entryNotFound", "entryNotFound", message)
+}
+
+// RpcErrorUnknownOption returns an error when no valid selector is provided
+// (matches rippled "unknownOption", code -1).
+func RpcErrorUnknownOption(message string) *RpcError {
+	return NewRpcError(RpcUNKNOWN, "unknownOption", "unknownOption", message)
+}
+
+// RpcErrorSrcActMissing returns an error when the source account is not provided
+// (matches rippled rpcSRC_ACT_MISSING, code 51, token "srcActMissing").
+func RpcErrorSrcActMissing(message string) *RpcError {
+	return NewRpcError(RpcSRC_ACT_NOT_FOUND, "srcActMissing", "srcActMissing", message)
+}
+
+// RpcErrorSrcCurMalformed returns an error when a source currency is malformed
+// (matches rippled "srcCurMalformed").
+func RpcErrorSrcCurMalformed(message string) *RpcError {
+	return NewRpcError(RpcUNKNOWN, "srcCurMalformed", "srcCurMalformed", message)
+}
+
+// RpcErrorDstActNotFound returns an error when the destination account is not found
+// (matches rippled rpcDST_ACT_NOT_FOUND, code 52, token "dstActNotFound").
+func RpcErrorDstActNotFound(message string) *RpcError {
+	return NewRpcError(RpcDST_ACT_NOT_FOUND, "dstActNotFound", "dstActNotFound", message)
+}


### PR DESCRIPTION
- Use error constructors (RpcErrorActNotFound, etc.) instead of raw RpcError structs to ensure error string tokens are populated
- Fix error codes: unknownOption for ledger_entry missing selector, srcActMissing for ripple_path_find, fieldNotFoundTransaction for transaction_entry, notImpl for tx invalid hash
- Add currency validation in book_offers (reject non-ISO/non-hex codes)
- Handle current ledger gracefully in book_changes and ledger_header
- Check destination account exists in ripple_path_find for non-XRP amounts
- Add master_key (RFC-1751) to wallet_propose response
- Add new error constructors: EntryNotFound, UnknownOption, SrcActMissing, SrcCurMalformed, DstActNotFound