### PR TITLE
Auto-fill NetworkID in submit, sign, and simulate RPC handlers (#216)

### DIFF
--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -231,6 +231,17 @@ func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline 
 			currentLedger := types.Services.Ledger.GetCurrentLedgerIndex()
 			txMap["LastLedgerSequence"] = currentLedger + 4
 		}
+
+		// Auto-fill NetworkID if not present and network ID > 1024.
+		// Matches rippled's transactionPreProcessImpl() in TransactionSign.cpp:
+		// legacy networks (ID <= 1024) must NOT include NetworkID;
+		// new networks (ID > 1024) require it and it is auto-filled here.
+		if _, ok := txMap["NetworkID"]; !ok {
+			serverInfo := types.Services.Ledger.GetServerInfo()
+			if serverInfo.NetworkID > 1024 {
+				txMap["NetworkID"] = serverInfo.NetworkID
+			}
+		}
 	}
 
 	// Add the signing public key

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -161,7 +161,15 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 
 	// TODO: Autofill Sequence from ledger (service-level) — getAutofillSequence
 	// TODO: Autofill Fee from ledger (service-level) — getCurrentNetworkFee
-	// TODO: Autofill NetworkID from config (service-level)
+
+	// Autofill NetworkID if not present and network ID > 1024.
+	// Matches rippled's autofillTx() in Simulate.cpp.
+	if _, ok := txJsonMap["NetworkID"]; !ok {
+		serverInfo := types.Services.Ledger.GetServerInfo()
+		if serverInfo.NetworkID > 1024 {
+			txJsonMap["NetworkID"] = serverInfo.NetworkID
+		}
+	}
 
 	// Reject Batch transaction type.
 	// rippled: if (stTx->getTxnType() == ttBATCH) return RPC::make_error(rpcNOT_IMPL)


### PR DESCRIPTION
When the server's NetworkID > 1024, auto-fill the field from config if not already present in tx_json, matching rippled's behavior in transactionPreProcessImpl() and autofillTx().

