### PR TITLE
Fix NetworkID not plumbed through GetServerInfo

### DIFF
--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -756,6 +756,7 @@ func (s *Service) GetServerInfo() ServerInfo {
 		Standalone:      s.config.Standalone,
 		ServerState:     serverState,
 		CompleteLedgers: "",
+		NetworkID:       s.config.NetworkID,
 	}
 
 	if s.openLedger != nil {
@@ -804,6 +805,7 @@ type ServerInfo struct {
 	ValidatedLedgerSeq  uint32
 	ValidatedLedgerHash [32]byte
 	CompleteLedgers     string
+	NetworkID           uint32
 }
 
 // GetLedgerInfo returns information about a specific ledger

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -69,6 +69,7 @@ func (a *LedgerServiceAdapter) GetServerInfo() types.LedgerServerInfo {
 		ValidatedLedgerSeq:  info.ValidatedLedgerSeq,
 		ValidatedLedgerHash: info.ValidatedLedgerHash,
 		CompleteLedgers:     info.CompleteLedgers,
+		NetworkID:           info.NetworkID,
 	}
 }
 


### PR DESCRIPTION
The auto-fill for NetworkID in submit/sign handlers reads from GetServerInfo().NetworkID, but neither the service-level ServerInfo struct nor the LedgerServiceAdapter mapped NetworkID from the config. This caused NetworkID to always be 0, so the auto-fill condition (NetworkID > 1024) never triggered, resulting in telREQUIRES_NETWORK_ID for all transactions on networks with ID > 1024.

- Add NetworkID field to service.ServerInfo struct
- Set it from s.config.NetworkID in Service.GetServerInfo()
- Map it through LedgerServiceAdapter.GetServerInfo()