### PR TITLE
Fix ripple_path_find panic on IOUAmount overflow

### DIFF
--- a/internal/ledger/state/ripple_state.go
+++ b/internal/ledger/state/ripple_state.go
@@ -263,6 +263,24 @@ func ParseIOUAmountBinary(data []byte) (Amount, error) {
 		mantissa = -mantissa
 	}
 
+	// Validate bounds before calling NewIssuedAmountFromValue, which panics
+	// on overflow (matching rippled's Throw<std::overflow_error>). When parsing
+	// binary data from the ledger, a panic would crash the server. Return an
+	// error instead for out-of-range values that normalization cannot fix.
+	//
+	// The raw 54-bit mantissa can be up to ~1.8e16. Normalization divides by 10
+	// until mantissa <= MaxMantissa (9.999e15), incrementing exponent each time.
+	// If mantissa > MaxMantissa and exponent >= MaxExponent, normalization would
+	// need to increment exponent past MaxExponent, causing overflow. Similarly,
+	// if exponent already exceeds MaxExponent, it will always overflow.
+	absMantissa := mantissa
+	if absMantissa < 0 {
+		absMantissa = -absMantissa
+	}
+	if absMantissa != 0 && (exponent > MaxExponent || (exponent >= MaxExponent && absMantissa > MaxMantissa)) {
+		return Amount{}, fmt.Errorf("IOU amount overflow: mantissa %d exponent %d exceeds representable range", mantissa, exponent)
+	}
+
 	return NewIssuedAmountFromValue(mantissa, exponent, currency, issuer), nil
 }
 

--- a/internal/tx/payment/pathfinder/book_index.go
+++ b/internal/tx/payment/pathfinder/book_index.go
@@ -34,9 +34,19 @@ func (bi *BookIndex) Build() {
 	}
 	bi.built = true
 
-	// Walk all ledger entries looking for offers
+	// Walk all ledger entries looking for offers.
+	// The recover() safety net ensures that if any ledger entry causes a panic
+	// during parsing (e.g., IOUAmount overflow from malformed data), the entry
+	// is skipped rather than crashing the entire RPC handler goroutine.
 	seen := make(map[[2]payment.Issue]bool)
-	_ = bi.ledger.ForEach(func(key [32]byte, data []byte) bool {
+	_ = bi.ledger.ForEach(func(key [32]byte, data []byte) (cont bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				// Skip this entry — malformed data should not crash the server
+				cont = true
+			}
+		}()
+
 		offer, err := state.ParseLedgerOffer(data)
 		if err != nil {
 			return true // not an offer, continue


### PR DESCRIPTION
## Summary

- Add bounds validation in `ParseIOUAmountBinary` to return an error instead of allowing `normalize()` to panic on overflow
- Add `recover()` safety net in `BookIndex.Build` to skip malformed ledger entries instead of crashing the RPC handler

Closes #220

## Details

`normalize()` panics with `IOUAmount overflow` (matching rippled's `Throw<std::overflow_error>`), which is fine inside the transaction engine but fatal when triggered from data-parsing paths like `BookIndex.Build()` → `ParseLedgerOfferFromBytes` → `ParseIOUAmountBinary` → `NewIssuedAmountFromValue` → `normalize()`.

The fix validates the parsed mantissa/exponent bounds in `ParseIOUAmountBinary` **before** calling the constructor, returning a descriptive error for values that normalization cannot handle. The `recover()` in `BookIndex.Build` is a belt-and-suspenders safety net for any other unexpected panics from ledger data parsing.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/ledger/state/...` passes
- [x] `go test ./internal/tx/payment/pathfinder/...` passes
- [ ] Run xrpl-hive `rpccompat-stateful` — `ripple_path_find_no_path` and `ripple_path_find_with_paths` should pass