### PR TITLE
Replace O(n²) bubble sort with sort.Slice in GetSortedCandidates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ xrpld.toml
 # Built binaries
 xrpld
 main
+
+# Worktrees
+.worktrees/

--- a/internal/txq/candidate.go
+++ b/internal/txq/candidate.go
@@ -1,6 +1,8 @@
 package txq
 
 import (
+	"sort"
+
 	"github.com/LeJamon/goXRPLd/internal/tx"
 )
 
@@ -241,13 +243,9 @@ func (aq *AccountQueue) GetSortedCandidates() []*Candidate {
 	}
 
 	// Sort by SeqProxy
-	for i := 0; i < len(result)-1; i++ {
-		for j := i + 1; j < len(result); j++ {
-			if result[j].SeqProxy.Less(result[i].SeqProxy) {
-				result[i], result[j] = result[j], result[i]
-			}
-		}
-	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].SeqProxy.Less(result[j].SeqProxy)
+	})
 
 	return result
 }


### PR DESCRIPTION
## Summary

- Replace nested-loop bubble sort (O(n²)) with `sort.Slice` (O(n log n)) in `AccountQueue.GetSortedCandidates`

Closes #238

## Test plan

- [x] `go build ./internal/txq/...` compiles cleanly
- [x] `go test ./internal/txq/...` — all 10 tests pass