### PR TITLE
Remove redundant sender account ID decoding in XRP payment

### DIFF
--- a/internal/tx/payment/payment_xrp.go
+++ b/internal/tx/payment/payment_xrp.go
@@ -83,12 +83,8 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 		// This allows accounts to indicate they don't want to receive XRP
 		// Reference: this matches rippled behavior for direct XRP payments
 		if (destAccount.Flags & state.LsfDisallowXRP) != 0 {
-			senderAccountID, err := state.DecodeAccountID(ctx.Account.Account)
-			if err != nil {
-				return tx.TefINTERNAL
-			}
 			// Only reject if sender is not the destination (self-payments are allowed)
-			if senderAccountID != destAccountID {
+			if ctx.AccountID != destAccountID {
 				return tx.TecNO_TARGET
 			}
 		}


### PR DESCRIPTION
## Summary

- Remove redundant `state.DecodeAccountID(ctx.Account.Account)` call in XRP payment preclaim
- Use `ctx.AccountID` which already holds the decoded sender account ID

Closes #239

## Test plan

- [x] `go build ./internal/tx/payment/...` compiles cleanly
- [x] `go test ./internal/tx/payment/...` — pathfinder tests pass; one pre-existing failure unrelated to this change