### PR TITLE
Verify checksum in decodeBase58Check

### DIFF
--- a/internal/tx/threading.go
+++ b/internal/tx/threading.go
@@ -1,7 +1,9 @@
 package tx
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"strings"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -208,5 +210,14 @@ func decodeBase58Check(input string) ([]byte, error) {
 		return nil, nil
 	}
 
-	return result[:len(result)-4], nil
+	payload := result[:len(result)-4]
+	checksum := result[len(result)-4:]
+
+	h1 := sha256.Sum256(payload)
+	h2 := sha256.Sum256(h1[:])
+	if h2[0] != checksum[0] || h2[1] != checksum[1] || h2[2] != checksum[2] || h2[3] != checksum[3] {
+		return nil, fmt.Errorf("invalid base58check checksum")
+	}
+
+	return payload, nil
 }


### PR DESCRIPTION
## Summary

- Add double-SHA256 checksum verification to `decodeBase58Check` in `internal/tx/threading.go`
- Previously the function stripped the 4-byte checksum but never verified it, silently accepting corrupted input

Closes #236

## Test plan

- [x] `go build ./internal/tx/...` compiles cleanly
- [x] `go test ./internal/tx/` — all tests pass