### PR TITLE
Use mulDiv in ScaleFeeLevel to prevent uint64 overflow

### DIFF
--- a/internal/txq/fee.go
+++ b/internal/txq/fee.go
@@ -291,13 +291,12 @@ func ScaleFeeLevel(snapshot Snapshot, txInLedger uint32) FeeLevel {
 
 	// Compute escalated fee level:
 	// fee_level = multiplier * (current^2) / (target^2)
+	// Uses mulDiv for overflow-safe 128-bit intermediate arithmetic,
+	// matching rippled's scaleFeeLevel which saturates to max on overflow.
 	current := uint64(txInLedger)
 	target := uint64(snapshot.TxnsExpected)
 
-	numerator := snapshot.EscalationMultiplier * current * current
-	denominator := target * target
-
-	return FeeLevel(numerator / denominator)
+	return FeeLevel(mulDiv(snapshot.EscalationMultiplier, current*current, target*target))
 }
 
 // EscalatedSeriesFeeLevel computes the total fee level required for a series


### PR DESCRIPTION
## Summary

- Replace native `multiplier * current * current` with `mulDiv(multiplier, current*current, target*target)` in `ScaleFeeLevel`
- This matches rippled's `scaleFeeLevel` which uses 128-bit intermediate arithmetic via `mulDiv` and saturates to `uint64_max` on overflow
- The companion `EscalatedSeriesFeeLevel` already used `mulDiv` correctly

Closes #230

## Test plan

- [x] `go build ./internal/txq/...` compiles cleanly
- [x] `go test ./internal/txq/` — all tests pass including `TestScaleFeeLevel`
- [x] Verified rippled uses identical `mulDiv(multiplier, current * current, target * target)` pattern