### PR TITLE
Handle MPT amounts in getLedgerEntryType binary parser

### DIFF
--- a/internal/tx/apply_state_table.go
+++ b/internal/tx/apply_state_table.go
@@ -780,10 +780,15 @@ func getLedgerEntryType(data []byte) string {
 		case 5: // Hash256
 			offset += 32
 		case 6: // Amount
-			if offset < len(data) && (data[offset]&0x80) == 0 {
-				offset += 8 // XRP
-			} else {
+			if offset >= len(data) {
+				return "Unknown"
+			}
+			if (data[offset] & 0x80) != 0 {
 				offset += 48 // IOU
+			} else if (data[offset] & 0x20) != 0 {
+				offset += 33 // MPT (1 header + 8 value + 24 issuance ID)
+			} else {
+				offset += 8 // XRP
 			}
 		case 7: // Blob (variable length)
 			if offset >= len(data) {


### PR DESCRIPTION
## Summary

- Add MPT amount detection (33 bytes) to the binary field parser in `getLedgerEntryType`
- Previously only XRP (8 bytes) and IOU (48 bytes) were handled, causing misalignment when scanning ledger entries containing MPT amount fields
- Matches rippled's deserialization decision tree: bit 7 (0x80) → IOU, bit 5 (0x20) → MPT, else → XRP

Closes #231

## Test plan

- [x] `go build ./internal/tx/...` compiles cleanly
- [x] `go test ./internal/tx/` — all tests pass
- [x] Verified bit patterns against rippled's `STAmount` serialization (`STAmount.cpp:143-223`)