### PR TITLE
Stop BlockProcessor from overwriting engine's TransactionIndex

### DIFF
--- a/internal/tx/block_processor.go
+++ b/internal/tx/block_processor.go
@@ -61,8 +61,8 @@ func NewBlockProcessor(engine *Engine) *BlockProcessor {
 // ApplyTransaction applies a single transaction and returns the result.
 // It handles:
 // - Calling the engine to apply the transaction
-// - Assigning the transaction index
 // - Creating the tx+meta blob
+// The engine assigns TransactionIndex in metadata for applied transactions.
 func (bp *BlockProcessor) ApplyTransaction(transaction Transaction, txBlob []byte) (BlockTxResult, error) {
 	result := BlockTxResult{
 		Index:     bp.txIndex,
@@ -87,19 +87,16 @@ func (bp *BlockProcessor) ApplyTransaction(transaction Transaction, txBlob []byt
 	}
 	result.ApplyResult = applyResult
 
-	// Set the transaction index in the metadata
-	if applyResult.Metadata != nil {
-		applyResult.Metadata.TransactionIndex = bp.txIndex
-	}
-
-	// Create the tx+meta blob for the transaction tree
+	// Create the tx+meta blob for the transaction tree.
+	// The engine assigns TransactionIndex in metadata for applied transactions
+	// (matching rippled's txCount-based indexing), so we don't overwrite it here.
 	txWithMetaBlob, err := CreateTxWithMetaBlob(txBlob, applyResult.Metadata)
 	if err != nil {
 		return result, err
 	}
 	result.TxWithMetaBlob = txWithMetaBlob
 
-	// Increment the transaction index for the next transaction
+	// Increment the processing order counter for the next transaction
 	bp.txIndex++
 
 	return result, nil


### PR DESCRIPTION
## Summary

- Remove the BlockProcessor's unconditional overwrite of `metadata.TransactionIndex`
- The engine is the authority on `TransactionIndex`, assigning it via `e.txCount` for applied transactions — matching rippled's `ApplyStateTable::apply` which uses `to.txCount()` (OpenView.cpp:122-126)
- Previously, the BlockProcessor overwrote the engine's index with its own counter that incremented for every transaction (applied or not), causing divergence when non-applied transactions appeared in the sequence

Closes #232

## Test plan

- [x] `go build ./internal/tx/...` compiles cleanly
- [x] `go test ./internal/tx/` — all tests pass
- [x] Verified rippled's index assignment in `ApplyStateTable::apply` (line 277) uses `to.txCount()` set by the engine layer