### PR TITLE
Fix byte order in deriveScalar to match rippled (big-endian)

### DIFF
--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -69,19 +69,19 @@ func (c SECP256K1CryptoAlgorithm) deriveScalar(bytes []byte, discrim *big.Int) *
 
 		if discrim != nil {
 			discrimBytes := make([]byte, 4)
-			discrimBytes[0] = byte(discrim.Uint64())
-			discrimBytes[1] = byte(discrim.Uint64() >> 8)
-			discrimBytes[2] = byte(discrim.Uint64() >> 16)
-			discrimBytes[3] = byte(discrim.Uint64() >> 24)
+			discrimBytes[0] = byte(discrim.Uint64() >> 24)
+			discrimBytes[1] = byte(discrim.Uint64() >> 16)
+			discrimBytes[2] = byte(discrim.Uint64() >> 8)
+			discrimBytes[3] = byte(discrim.Uint64())
 
 			hash.Write(discrimBytes)
 		}
 
 		shiftBytes := make([]byte, 4)
-		shiftBytes[0] = byte(i)
-		shiftBytes[1] = byte(i >> 8)
-		shiftBytes[2] = byte(i >> 16)
-		shiftBytes[3] = byte(i >> 24)
+		shiftBytes[0] = byte(i >> 24)
+		shiftBytes[1] = byte(i >> 16)
+		shiftBytes[2] = byte(i >> 8)
+		shiftBytes[3] = byte(i)
 
 		hash.Write(shiftBytes)
 


### PR DESCRIPTION
## Summary

- Fix `deriveScalar` to write discriminator and shift bytes in big-endian order, matching rippled's `copy_uint32` (SecretKey.cpp:77-83)
- Previously used little-endian, which is incorrect per the XRPL key derivation spec

## Impact Assessment

**No practical impact on current behavior.** All callers use `discrim=nil` or `discrim=0`, and the loop counter `i` is always `0` on the first iteration — zero bytes are endianness-invariant. The existing test vectors (which match rippled's output) continue to pass. However, the code was incorrect by specification and would produce wrong keys for any non-zero discriminator or retry iteration.

The "critical severity" label on #228 overstates the real-world impact — this is a correctness fix, not a live bug.

Closes #228

## Test plan

- [x] `go test ./crypto/secp256k1/` — all tests pass (keypair derivation, signing, validation, public generator)
- [x] Verified test vectors still match rippled output
- [x] Confirmed rippled uses big-endian via `copy_uint32` at SecretKey.cpp:77-83