### PR TITLE
Add 3-byte VL-length decoding in getLedgerEntryType

### DIFF
--- a/internal/tx/apply_state_table.go
+++ b/internal/tx/apply_state_table.go
@@ -791,7 +791,15 @@ func getLedgerEntryType(data []byte) string {
 			}
 			length := int(data[offset])
 			offset++
-			if length > 192 {
+			if length > 240 {
+				// 3-byte range (241-254): length 12481-918744
+				if offset+1 >= len(data) {
+					return "Unknown"
+				}
+				length = 12481 + ((length-241)<<16 | int(data[offset])<<8 | int(data[offset+1]))
+				offset += 2
+			} else if length > 192 {
+				// 2-byte range (193-240): length 193-12480
 				if offset >= len(data) {
 					return "Unknown"
 				}
@@ -806,7 +814,15 @@ func getLedgerEntryType(data []byte) string {
 			}
 			length := int(data[offset])
 			offset++
-			if length > 192 {
+			if length > 240 {
+				// 3-byte range (241-254): length 12481-918744
+				if offset+1 >= len(data) {
+					return "Unknown"
+				}
+				length = 12481 + ((length-241)<<16 | int(data[offset])<<8 | int(data[offset+1]))
+				offset += 2
+			} else if length > 192 {
+				// 2-byte range (193-240): length 193-12480
 				if offset >= len(data) {
 					return "Unknown"
 				}


### PR DESCRIPTION
## Summary

- Add the missing 3-byte VL-length decoding range (byte values 241-254, lengths 12481-918744) to the binary field parser in `getLedgerEntryType`
- Fixed in both the Blob (type 7) and AccountID (type 8) VL-length decoders
- Matches rippled's `Serializer.cpp:316-325`: `length = 12481 + ((b1-241)*65536) + (b2*256) + b3`

Closes #235

## Test plan

- [x] `go build ./internal/tx/...` compiles cleanly
- [x] `go test ./internal/tx/` — all tests pass
- [x] Verified formula against rippled's `Serializer.cpp` and goXRPL's `binary_parser.go` (which already had the correct 3-range implementation)