### PR TITLE
fix: add second invariant check on fee-only state

### DIFF
--- a/internal/testing/escrow/token_escrow_mpt_test.go
+++ b/internal/testing/escrow/token_escrow_mpt_test.go
@@ -53,10 +53,10 @@ func TestMPTEscrow_Enablement(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TemBAD_AMOUNT))
+		jtx.RequireTxFail(t, result, jtx.TemBAD_AMOUNT)
 		env.Close()
 
 		// EscrowFinish on non-existent escrow should fail with tecNO_TARGET
@@ -64,9 +64,9 @@ func TestMPTEscrow_Enablement(t *testing.T) {
 			escrow.EscrowFinish(bob, alice, seq1).
 				Condition(escrow.TestCondition1).
 				Fulfillment(escrow.TestFulfillment1).
-				Fee(baseFee*150).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecNO_TARGET))
+		jtx.RequireTxFail(t, result, jtx.TecNO_TARGET)
 		env.Close()
 
 		// Second escrow create attempt (with cancel time) → temBAD_AMOUNT
@@ -75,17 +75,17 @@ func TestMPTEscrow_Enablement(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition2).
-				FinishTime(env.Now().Add(1*time.Second)).
-				CancelTime(env.Now().Add(2*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				CancelTime(env.Now().Add(2 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TemBAD_AMOUNT))
+		jtx.RequireTxFail(t, result, jtx.TemBAD_AMOUNT)
 		env.Close()
 
 		// Cancel on non-existent escrow → tecNO_TARGET
 		result = env.Submit(
 			escrow.EscrowCancel(bob, alice, seq2).Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecNO_TARGET))
+		jtx.RequireTxFail(t, result, jtx.TecNO_TARGET)
 		env.Close()
 	})
 
@@ -118,8 +118,8 @@ func TestMPTEscrow_Enablement(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -128,7 +128,7 @@ func TestMPTEscrow_Enablement(t *testing.T) {
 			escrow.EscrowFinish(bob, alice, seq1).
 				Condition(escrow.TestCondition1).
 				Fulfillment(escrow.TestFulfillment1).
-				Fee(baseFee*150).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -139,9 +139,9 @@ func TestMPTEscrow_Enablement(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition2).
-				FinishTime(env.Now().Add(1*time.Second)).
-				CancelTime(env.Now().Add(2*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				CancelTime(env.Now().Add(2 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -183,10 +183,10 @@ func TestMPTEscrow_CreatePreflight(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TemDISABLED))
+		jtx.RequireTxFail(t, result, jtx.TemDISABLED)
 		env.Close()
 	})
 
@@ -219,10 +219,10 @@ func TestMPTEscrow_CreatePreflight(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TemBAD_AMOUNT))
+		jtx.RequireTxFail(t, result, jtx.TemBAD_AMOUNT)
 		env.Close()
 	})
 }
@@ -261,10 +261,10 @@ func TestMPTEscrow_CanEscrowFlag(t *testing.T) {
 		escrow.EscrowCreate(alice, bob, 0).
 			MPTAmount(amt).
 			Condition(escrow.TestCondition1).
-			FinishTime(env.Now().Add(1*time.Second)).
-			Fee(baseFee*150).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			Fee(baseFee * 150).
 			Build())
-	jtx.RequireTxFail(t, result, string(jtx.TecNO_PERMISSION))
+	jtx.RequireTxFail(t, result, jtx.TecNO_PERMISSION)
 	env.Close()
 }
 
@@ -300,10 +300,10 @@ func TestMPTEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(gw, alice, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecNO_PERMISSION))
+		jtx.RequireTxFail(t, result, jtx.TecNO_PERMISSION)
 		env.Close()
 	})
 
@@ -329,10 +329,10 @@ func TestMPTEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecOBJECT_NOT_FOUND))
+		jtx.RequireTxFail(t, result, jtx.TecOBJECT_NOT_FOUND)
 		env.Close()
 	})
 
@@ -362,10 +362,10 @@ func TestMPTEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecOBJECT_NOT_FOUND))
+		jtx.RequireTxFail(t, result, jtx.TecOBJECT_NOT_FOUND)
 		env.Close()
 	})
 
@@ -405,10 +405,10 @@ func TestMPTEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecNO_AUTH))
+		jtx.RequireTxFail(t, result, jtx.TecNO_AUTH)
 		env.Close()
 	})
 
@@ -450,10 +450,10 @@ func TestMPTEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecNO_AUTH))
+		jtx.RequireTxFail(t, result, jtx.TecNO_AUTH)
 		env.Close()
 	})
 
@@ -489,10 +489,10 @@ func TestMPTEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecLOCKED))
+		jtx.RequireTxFail(t, result, jtx.TecLOCKED)
 		env.Close()
 	})
 
@@ -528,10 +528,10 @@ func TestMPTEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecLOCKED))
+		jtx.RequireTxFail(t, result, jtx.TecLOCKED)
 		env.Close()
 	})
 
@@ -565,10 +565,10 @@ func TestMPTEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecNO_AUTH))
+		jtx.RequireTxFail(t, result, jtx.TecNO_AUTH)
 		env.Close()
 	})
 
@@ -601,10 +601,10 @@ func TestMPTEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecINSUFFICIENT_FUNDS))
+		jtx.RequireTxFail(t, result, jtx.TecINSUFFICIENT_FUNDS)
 		env.Close()
 	})
 
@@ -638,10 +638,10 @@ func TestMPTEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecINSUFFICIENT_FUNDS))
+		jtx.RequireTxFail(t, result, jtx.TecINSUFFICIENT_FUNDS)
 		env.Close()
 	})
 }
@@ -682,8 +682,8 @@ func TestMPTEscrow_FinishDoApply(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -692,7 +692,7 @@ func TestMPTEscrow_FinishDoApply(t *testing.T) {
 			escrow.EscrowFinish(bob, alice, seq1).
 				Condition(escrow.TestCondition1).
 				Fulfillment(escrow.TestFulfillment1).
-				Fee(baseFee*150).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -730,8 +730,8 @@ func TestMPTEscrow_FinishDoApply(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -741,9 +741,9 @@ func TestMPTEscrow_FinishDoApply(t *testing.T) {
 			escrow.EscrowFinish(carol, alice, seq1).
 				Condition(escrow.TestCondition1).
 				Fulfillment(escrow.TestFulfillment1).
-				Fee(baseFee*150).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecNO_PERMISSION))
+		jtx.RequireTxFail(t, result, jtx.TecNO_PERMISSION)
 		env.Close()
 	})
 }
@@ -782,8 +782,8 @@ func TestMPTEscrow_FinishBasic(t *testing.T) {
 		escrow.EscrowCreate(alice, bob, 0).
 			MPTAmount(amt).
 			Condition(escrow.TestCondition1).
-			FinishTime(env.Now().Add(1*time.Second)).
-			Fee(baseFee*150).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -793,7 +793,7 @@ func TestMPTEscrow_FinishBasic(t *testing.T) {
 		escrow.EscrowFinish(bob, alice, seq1).
 			Condition(escrow.TestCondition1).
 			Fulfillment(escrow.TestFulfillment1).
-			Fee(baseFee*150).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -837,9 +837,9 @@ func TestMPTEscrow_CancelBasic(t *testing.T) {
 		escrow.EscrowCreate(alice, bob, 0).
 			MPTAmount(amt).
 			Condition(escrow.TestCondition2).
-			FinishTime(env.Now().Add(1*time.Second)).
-			CancelTime(env.Now().Add(2*time.Second)).
-			Fee(baseFee*150).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			CancelTime(env.Now().Add(2 * time.Second)).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -887,8 +887,8 @@ func TestMPTEscrow_SelfEscrow(t *testing.T) {
 			escrow.EscrowCreate(alice, alice, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -897,7 +897,7 @@ func TestMPTEscrow_SelfEscrow(t *testing.T) {
 			escrow.EscrowFinish(alice, alice, seq).
 				Condition(escrow.TestCondition1).
 				Fulfillment(escrow.TestFulfillment1).
-				Fee(baseFee*150).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -930,9 +930,9 @@ func TestMPTEscrow_SelfEscrow(t *testing.T) {
 			escrow.EscrowCreate(alice, alice, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				CancelTime(env.Now().Add(2*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				CancelTime(env.Now().Add(2 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -982,8 +982,8 @@ func TestMPTEscrow_FinishPreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -999,9 +999,9 @@ func TestMPTEscrow_FinishPreclaim(t *testing.T) {
 			escrow.EscrowFinish(bob, alice, seq1).
 				Condition(escrow.TestCondition1).
 				Fulfillment(escrow.TestFulfillment1).
-				Fee(baseFee*150).
+				Fee(baseFee * 150).
 				Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecNO_AUTH))
+		jtx.RequireTxFail(t, result, jtx.TecNO_AUTH)
 		env.Close()
 	})
 }
@@ -1043,9 +1043,9 @@ func TestMPTEscrow_CancelPreclaim(t *testing.T) {
 		result := env.Submit(
 			escrow.EscrowCreate(alice, bob, 0).
 				MPTAmount(amt).
-				CancelTime(env.Now().Add(2*time.Second)).
+				CancelTime(env.Now().Add(2 * time.Second)).
 				Condition(escrow.TestCondition1).
-				Fee(baseFee*150).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -1059,7 +1059,7 @@ func TestMPTEscrow_CancelPreclaim(t *testing.T) {
 
 		result = env.Submit(
 			escrow.EscrowCancel(bob, alice, seq1).Build())
-		jtx.RequireTxFail(t, result, string(jtx.TecNO_AUTH))
+		jtx.RequireTxFail(t, result, jtx.TecNO_AUTH)
 		env.Close()
 	})
 }

--- a/internal/testing/escrow/token_escrow_test.go
+++ b/internal/testing/escrow/token_escrow_test.go
@@ -80,8 +80,8 @@ func TestIOUEscrow_Enablement(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				IOUAmount(usd(1000, gw)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -91,7 +91,7 @@ func TestIOUEscrow_Enablement(t *testing.T) {
 			escrow.EscrowFinish(bob, alice, seq1).
 				Condition(escrow.TestCondition1).
 				Fulfillment(escrow.TestFulfillment1).
-				Fee(baseFee*150).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -102,9 +102,9 @@ func TestIOUEscrow_Enablement(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				IOUAmount(usd(1000, gw)).
 				Condition(escrow.TestCondition2).
-				FinishTime(env.Now().Add(1*time.Second)).
-				CancelTime(env.Now().Add(2*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				CancelTime(env.Now().Add(2 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -112,7 +112,7 @@ func TestIOUEscrow_Enablement(t *testing.T) {
 		// Cancel escrow: should succeed
 		result = env.Submit(
 			escrow.EscrowCancel(bob, alice, seq2).
-				Fee(baseFee*150).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -152,8 +152,8 @@ func TestIOUEscrow_Enablement(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				IOUAmount(usd(1000, gw)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "temBAD_AMOUNT")
 		env.Close()
@@ -169,7 +169,7 @@ func TestIOUEscrow_Enablement(t *testing.T) {
 			escrow.EscrowFinish(bob, alice, seq1).
 				Condition(escrow.TestCondition1).
 				Fulfillment(escrow.TestFulfillment1).
-				Fee(baseFee*150).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "tecNO_TARGET")
 		env.Close()
@@ -195,8 +195,8 @@ func TestIOUEscrow_AllowLockingFlag(t *testing.T) {
 		escrow.EscrowCreate(alice, bob, 0).
 			IOUAmount(usd(1000, gw)).
 			Condition(escrow.TestCondition1).
-			FinishTime(env.Now().Add(1*time.Second)).
-			Fee(baseFee*150).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -206,8 +206,8 @@ func TestIOUEscrow_AllowLockingFlag(t *testing.T) {
 	result = env.Submit(
 		escrow.EscrowCreate(alice, bob, 0).
 			IOUAmount(usd(1000, gw)).
-			FinishTime(env.Now().Add(1*time.Second)).
-			CancelTime(env.Now().Add(3*time.Second)).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			CancelTime(env.Now().Add(3 * time.Second)).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -225,8 +225,8 @@ func TestIOUEscrow_AllowLockingFlag(t *testing.T) {
 		escrow.EscrowCreate(alice, bob, 0).
 			IOUAmount(usd(1000, gw)).
 			Condition(escrow.TestCondition1).
-			FinishTime(env.Now().Add(1*time.Second)).
-			Fee(baseFee*150).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxFail(t, result, "tecNO_PERMISSION")
 	env.Close()
@@ -236,7 +236,7 @@ func TestIOUEscrow_AllowLockingFlag(t *testing.T) {
 		escrow.EscrowFinish(bob, alice, seq1).
 			Condition(escrow.TestCondition1).
 			Fulfillment(escrow.TestFulfillment1).
-			Fee(baseFee*150).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -268,8 +268,8 @@ func TestIOUEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(gw, alice, 0).
 				IOUAmount(usd(1, gw)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "tecNO_PERMISSION")
 		env.Close()
@@ -302,8 +302,8 @@ func TestIOUEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(gw, alice, 0).
 				IOUAmount(usd(1, gw)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "tecNO_PERMISSION")
 		env.Close()
@@ -328,8 +328,8 @@ func TestIOUEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				IOUAmount(usd(1, gw)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "tecNO_LINE")
 		env.Close()
@@ -358,8 +358,8 @@ func TestIOUEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				IOUAmount(usd(1, gw)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "tecINSUFFICIENT_FUNDS")
 		env.Close()
@@ -396,8 +396,8 @@ func TestIOUEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				IOUAmount(usd(10001, gw)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "tecINSUFFICIENT_FUNDS")
 		env.Close()
@@ -439,8 +439,8 @@ func TestIOUEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				IOUAmount(usd(1, gw)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "tecFROZEN")
 		env.Close()
@@ -482,8 +482,8 @@ func TestIOUEscrow_CreatePreclaim(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				IOUAmount(usd(1, gw)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "tecFROZEN")
 		env.Close()
@@ -510,8 +510,8 @@ func TestIOUEscrow_FinishBasic(t *testing.T) {
 		escrow.EscrowCreate(alice, bob, 0).
 			IOUAmount(usd(1000, gw)).
 			Condition(escrow.TestCondition1).
-			FinishTime(env.Now().Add(1*time.Second)).
-			Fee(baseFee*150).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -529,7 +529,7 @@ func TestIOUEscrow_FinishBasic(t *testing.T) {
 		escrow.EscrowFinish(bob, alice, seq1).
 			Condition(escrow.TestCondition1).
 			Fulfillment(escrow.TestFulfillment1).
-			Fee(baseFee*150).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -561,9 +561,9 @@ func TestIOUEscrow_CancelBasic(t *testing.T) {
 		escrow.EscrowCreate(alice, bob, 0).
 			IOUAmount(usd(1000, gw)).
 			Condition(escrow.TestCondition2).
-			FinishTime(env.Now().Add(1*time.Second)).
-			CancelTime(env.Now().Add(2*time.Second)).
-			Fee(baseFee*150).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			CancelTime(env.Now().Add(2 * time.Second)).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -611,8 +611,8 @@ func TestIOUEscrow_CreatePreflight(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				IOUAmount(tx.NewIssuedAmountFromFloat64(-1, "USD", gw.Address)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "temBAD_AMOUNT")
 		env.Close()
@@ -632,8 +632,8 @@ func TestIOUEscrow_CreatePreflight(t *testing.T) {
 			escrow.EscrowCreate(alice, bob, 0).
 				IOUAmount(tx.NewIssuedAmountFromFloat64(1, "XRP", gw.Address)).
 				Condition(escrow.TestCondition1).
-				FinishTime(env.Now().Add(1*time.Second)).
-				Fee(baseFee*150).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
 				Build())
 		jtx.RequireTxFail(t, result, "temBAD_CURRENCY")
 		env.Close()
@@ -656,8 +656,8 @@ func TestIOUEscrow_SelfEscrow(t *testing.T) {
 		escrow.EscrowCreate(alice, alice, 0).
 			IOUAmount(usd(100, gw)).
 			Condition(escrow.TestCondition1).
-			FinishTime(env.Now().Add(1*time.Second)).
-			Fee(baseFee*150).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -671,7 +671,7 @@ func TestIOUEscrow_SelfEscrow(t *testing.T) {
 		escrow.EscrowFinish(alice, alice, seq).
 			Condition(escrow.TestCondition1).
 			Fulfillment(escrow.TestFulfillment1).
-			Fee(baseFee*150).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -697,8 +697,8 @@ func TestIOUEscrow_MultipleEscrows(t *testing.T) {
 		escrow.EscrowCreate(alice, bob, 0).
 			IOUAmount(usd(500, gw)).
 			Condition(escrow.TestCondition1).
-			FinishTime(env.Now().Add(1*time.Second)).
-			Fee(baseFee*150).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -709,9 +709,9 @@ func TestIOUEscrow_MultipleEscrows(t *testing.T) {
 		escrow.EscrowCreate(alice, bob, 0).
 			IOUAmount(usd(300, gw)).
 			Condition(escrow.TestCondition2).
-			FinishTime(env.Now().Add(1*time.Second)).
-			CancelTime(env.Now().Add(3*time.Second)).
-			Fee(baseFee*150).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			CancelTime(env.Now().Add(3 * time.Second)).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -725,7 +725,7 @@ func TestIOUEscrow_MultipleEscrows(t *testing.T) {
 		escrow.EscrowFinish(bob, alice, seq1).
 			Condition(escrow.TestCondition1).
 			Fulfillment(escrow.TestFulfillment1).
-			Fee(baseFee*150).
+			Fee(baseFee * 150).
 			Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()

--- a/internal/tx/engine.go
+++ b/internal/tx/engine.go
@@ -2314,6 +2314,17 @@ func (e *Engine) doApply(tx Transaction, metadata *Metadata, txHash [32]byte) Re
 				}
 			}
 
+			// Second invariant check on fee-only state.
+			// Reference: rippled Transactor.cpp lines 1234-1238
+			// If fee-only state also violates invariants, escalate to tefINVARIANT_FAILED
+			// and do NOT apply anything (transaction is completely rejected).
+			{
+				invEntries2 := invTecTable.CollectEntries()
+				if violation2 := invariants.CheckInvariants(wrapTxForInvariants(tx), invariants.Result(TecINVARIANT_FAILED), fee, txDeclaredFee, invEntries2, invTecTable, e.rules()); violation2 != nil {
+					return TefINVARIANT_FAILED
+				}
+			}
+
 			generatedMeta, applyErr := invTecTable.Apply()
 			if applyErr != nil {
 				return TefINTERNAL

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -446,7 +446,7 @@ func serializeEscrow(txn *EscrowCreate, ownerID, destID [20]byte, sequence uint3
 			mptValue = fmt.Sprintf("%d", raw)
 		}
 		amountVal = map[string]any{
-			"value":            mptValue,
+			"value":           mptValue,
 			"mpt_issuance_id": txn.Amount.MPTIssuanceID(),
 		}
 	} else {


### PR DESCRIPTION
## Summary

- Fixes #233: When the first invariant check fails and the engine resets to fee-only state, a second invariant check now runs on that fee-only state
- If the second check also fails, the result escalates from `tecINVARIANT_FAILED` to `tefINVARIANT_FAILED` and the transaction is **not applied at all** (no fee charged, no sequence bumped)
- Matches rippled's `Transactor.cpp:1218-1244` two-pass invariant cycle

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/tx/...` — no regressions (all failures are pre-existing in unrelated packages)
- [ ] Verify via conformance tests that invariant-related scenarios behave correctly