### PR TITLE
fix: handle BuildTxSet error in consensus closeLedger

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -837,13 +837,30 @@ func (e *Engine) phaseOpen() {
 }
 
 // closeLedger transitions from open to establish phase.
+// Reference: rippled Consensus.h closeLedger() (~line 1434)
 func (e *Engine) closeLedger() {
 	// Build our transaction set from pending transactions
 	txs := e.adaptor.GetPendingTxs()
 	txSet, err := e.adaptor.BuildTxSet(txs)
 	if err != nil {
-		// TODO: handle error
-		return
+		slog.Error("Failed to build tx set, falling back to empty set",
+			"t", "Consensus",
+			"round", e.state.Round,
+			"pending_txs", len(txs),
+			"err", err,
+		)
+
+		// Fall back to an empty tx set so consensus can still advance.
+		txSet, err = e.adaptor.BuildTxSet(nil)
+		if err != nil {
+			slog.Error("Failed to build empty tx set, cannot close ledger",
+				"t", "Consensus",
+				"round", e.state.Round,
+				"err", err,
+			)
+			e.setMode(consensus.ModeObserving)
+			return
+		}
 	}
 	e.ourTxSet = txSet
 


### PR DESCRIPTION
## Summary

- Log the `BuildTxSet` error with round number, pending tx count, and error message via `slog.Error`
- Fall back to an empty tx set (`BuildTxSet(nil)`) so consensus can still advance rather than silently returning and leaving the engine stuck in `PhaseOpen`
- If building the empty set also fails, transition to `ModeObserving` (publishes a `ModeChangedEvent` for monitoring) and return

This matches rippled's approach where `closeLedger` always advances to the establish phase — it never silently aborts.

Closes #259

## Test plan

- [x] `go build ./internal/consensus/...` — compiles cleanly
- [x] `go test ./internal/consensus/...` — all tests pass (adaptor, csf, rcl)
- [x] `golangci-lint run ./internal/consensus/...` — 0 issues