### PR TITLE
feat(consensus): validator manifest cache + master-key translation (#265)

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -247,6 +247,11 @@ func runServer(cmd *cobra.Command, args []string) {
 			proposers, convergeTime := engine.GetLastCloseInfo()
 			return proposers, int(convergeTime.Milliseconds())
 		}
+		// Expose the validator-manifest cache to the `manifest` RPC.
+		// The cache is shared — the router writes inbound manifests,
+		// the engine reads for ephemeral→master translation, and this
+		// RPC reads for external queries.
+		types.Services.Manifests = consensusComponents.Manifests
 
 		isValidator := globalConfig.IsValidator()
 		serverLog.Info("Running in consensus mode",

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/inbound"
+	"github.com/LeJamon/goXRPLd/internal/manifest"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 )
@@ -64,6 +65,17 @@ type Router struct {
 	// accelerate selection and produce earlier squelches than rippled
 	// does for the same traffic pattern.
 	messageSeen *messageSuppression
+
+	// manifests is the validator manifest cache. Wired by the
+	// Components bootstrap so the router can apply inbound TMManifests
+	// frames and — on Accepted — relay them to other peers.
+	// May be nil in tests that don't exercise the manifest path.
+	manifests *manifest.Cache
+
+	// overlay is held so the router can relay accepted manifests
+	// directly via Overlay.BroadcastExcept. Nil in tests that
+	// construct a router without manifest support.
+	overlay *peermanagement.Overlay
 }
 
 // messageDedupTTL is how long a proposal/validation hash is
@@ -92,6 +104,15 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManag
 		replayer:    inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
 		messageSeen: newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
 	}
+}
+
+// SetManifestCache installs the validator-manifest cache and the
+// overlay handle used to relay accepted manifests. Calling with a nil
+// cache disables the TMManifests path (the dispatch switch silently
+// drops inbound manifest frames). Safe to call before Run.
+func (r *Router) SetManifestCache(cache *manifest.Cache, overlay *peermanagement.Overlay) {
+	r.manifests = cache
+	r.overlay = overlay
 }
 
 // SetInboundClock overrides the clock used by new inbound replay-delta
@@ -248,9 +269,84 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 		r.handleLedgerData(msg)
 	case message.TypeReplayDeltaResponse:
 		r.handleReplayDeltaResponse(msg)
+	case message.TypeManifests:
+		r.handleManifests(msg)
 	default:
 		// Not a consensus message — ignore
 	}
+}
+
+// handleManifests ingests a TMManifests frame. For each serialized
+// manifest in the list: deserialize, apply to the cache, and — on
+// Accepted — relay the single-manifest frame to every peer except the
+// origin. Matches rippled's OverlayImpl::onManifests at
+// OverlayImpl.cpp:633-686 (minus the DB persistence of UNL-master
+// manifests and the pubManifest subscription — both out of scope for
+// this PR per tasks/pr-manifests-round1.md).
+//
+// Decode failures attribute "manifest-decode" badData to the sender
+// (mirrors rippled charging feeInvalidData on malformed TMManifests at
+// PeerImp.cpp). A mix of valid and invalid entries in the same frame
+// results in the valid ones being applied; the frame isn't rejected
+// wholesale.
+func (r *Router) handleManifests(msg *peermanagement.InboundMessage) {
+	if r.manifests == nil {
+		// Cache not wired (tests or minimal configs) — silently drop.
+		return
+	}
+
+	decoded, err := message.Decode(message.TypeManifests, msg.Payload)
+	if err != nil {
+		r.logger.Warn("failed to decode manifests frame", "error", err, "peer", msg.PeerID)
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "manifests-decode")
+		return
+	}
+	mfs, ok := decoded.(*message.Manifests)
+	if !ok || len(mfs.List) == 0 {
+		return
+	}
+
+	for _, wire := range mfs.List {
+		parsed, err := manifest.Deserialize(wire.STObject)
+		if err != nil {
+			r.logger.Debug("manifest parse failed",
+				"error", err, "peer", msg.PeerID)
+			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "manifest-parse")
+			continue
+		}
+		switch d := r.manifests.ApplyManifest(parsed); d {
+		case manifest.Accepted:
+			r.relayManifest(msg.PeerID, wire.STObject)
+		case manifest.Invalid, manifest.BadMasterKey, manifest.BadEphemeralKey:
+			// Charge the sender — they gave us a manifest that
+			// passed structural parse but failed the cache's
+			// invariants (signature, key reuse, etc.).
+			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "manifest-"+d.String())
+		case manifest.Stale:
+			// Expected and harmless: a peer gossiped a manifest we
+			// already have at equal or higher seq. No action.
+		}
+	}
+}
+
+// relayManifest rebroadcasts a single accepted manifest to every peer
+// except the origin. Wraps the serialized STObject in a TMManifests
+// frame (a list of one) — matching rippled's per-manifest relay
+// (OverlayImpl.cpp:633-686 loops through and relays each one via
+// overlay_.foreach).
+func (r *Router) relayManifest(exceptPeer peermanagement.PeerID, serialized []byte) {
+	if r.overlay == nil {
+		return
+	}
+	relayMsg := &message.Manifests{
+		List: []message.Manifest{{STObject: serialized}},
+	}
+	frame, err := encodeFrame(message.TypeManifests, relayMsg)
+	if err != nil {
+		r.logger.Warn("failed to encode manifest relay frame", "error", err)
+		return
+	}
+	_ = r.overlay.BroadcastExcept(exceptPeer, frame)
 }
 
 // Bounds used to reject malformed TMProposeSet / TMValidation frames

--- a/internal/consensus/adaptor/router_manifests_test.go
+++ b/internal/consensus/adaptor/router_manifests_test.go
@@ -1,0 +1,154 @@
+package adaptor
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/manifest"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+// buildWireManifest produces a valid serialized manifest that the
+// router's handleManifests can apply end-to-end.
+func buildWireManifest(t *testing.T, seq uint32, masterSeed, ephSeed byte) []byte {
+	t.Helper()
+
+	masterSeedBytes := bytes.Repeat([]byte{masterSeed}, ed25519.SeedSize)
+	masterPriv := ed25519.NewKeyFromSeed(masterSeedBytes)
+	masterPub := append([]byte{0xED}, masterPriv.Public().(ed25519.PublicKey)...)
+
+	ephSeedBytes := bytes.Repeat([]byte{ephSeed}, ed25519.SeedSize)
+	ephPriv := ed25519.NewKeyFromSeed(ephSeedBytes)
+	ephPub := append([]byte{0xED}, ephPriv.Public().(ed25519.PublicKey)...)
+
+	j := map[string]any{
+		"PublicKey":     hex.EncodeToString(masterPub),
+		"SigningPubKey": hex.EncodeToString(ephPub),
+		"Sequence":      seq,
+	}
+
+	preimageHex, err := binarycodec.Encode(j)
+	require.NoError(t, err)
+	body, _ := hex.DecodeString(preimageHex)
+	prefix := protocol.HashPrefixManifest
+	preimage := append(prefix[:], body...)
+
+	j["Signature"] = hex.EncodeToString(ed25519.Sign(ephPriv, preimage))
+	j["MasterSignature"] = hex.EncodeToString(ed25519.Sign(masterPriv, preimage))
+
+	encoded, err := binarycodec.Encode(j)
+	require.NoError(t, err)
+	raw, err := hex.DecodeString(encoded)
+	require.NoError(t, err)
+	return raw
+}
+
+// TestRouter_HandleManifests_AppliesAccepted drives an inbound
+// TMManifests frame through the router's Run loop and asserts that
+// after processing the cache contains the master→ephemeral binding
+// and the raw wire bytes round-trip.
+func TestRouter_HandleManifests_AppliesAccepted(t *testing.T) {
+	engine := &mockEngine{}
+	adaptor := newTestAdaptor(t)
+	inbox := make(chan *peermanagement.InboundMessage, 4)
+
+	router := NewRouter(engine, adaptor, nil, inbox)
+	cache := manifest.NewCache()
+	// Pass nil overlay — the relay step is a no-op; we're only
+	// verifying apply.
+	router.SetManifestCache(cache, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go router.Run(ctx)
+
+	serialized := buildWireManifest(t, 3, 0x20, 0x21)
+	frame := &message.Manifests{
+		List: []message.Manifest{{STObject: serialized}},
+	}
+	inbox <- &peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeManifests),
+		Payload: encodePayload(t, frame),
+	}
+
+	parsed, err := manifest.Deserialize(serialized)
+	require.NoError(t, err)
+
+	// Poll until applied or timeout — the router runs async so we
+	// can't assume immediate visibility.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, ok := cache.GetSigningKey(parsed.MasterKey); ok {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if _, ok := cache.GetSigningKey(parsed.MasterKey); !ok {
+		t.Fatal("router did not apply manifest to cache")
+	}
+	stored, ok := cache.GetManifest(parsed.MasterKey)
+	if !ok || !bytes.Equal(stored, serialized) {
+		t.Fatalf("stored manifest bytes mismatch: ok=%v", ok)
+	}
+	if got, _ := cache.GetSequence(parsed.MasterKey); got != 3 {
+		t.Fatalf("stored sequence: got %d want 3", got)
+	}
+}
+
+// TestRouter_HandleManifests_InvalidDoesNotStore drives a
+// parse-valid-but-signature-invalid manifest through the router. The
+// cache must reject it; no state change is the whole guarantee.
+// (The bad-data attribution surface is exercised in
+// router_bad_data_test.go — here we only verify the cache side.)
+func TestRouter_HandleManifests_InvalidDoesNotStore(t *testing.T) {
+	engine := &mockEngine{}
+	adaptor := newTestAdaptor(t)
+	inbox := make(chan *peermanagement.InboundMessage, 4)
+
+	router := NewRouter(engine, adaptor, nil, inbox)
+	cache := manifest.NewCache()
+	router.SetManifestCache(cache, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go router.Run(ctx)
+
+	// Start from a valid manifest and corrupt MasterSignature so
+	// Deserialize succeeds but Verify fails — Cache.ApplyManifest
+	// returns Invalid and the cache stays empty.
+	serialized := buildWireManifest(t, 5, 0x30, 0x31)
+	decoded, err := binarycodec.Decode(hex.EncodeToString(serialized))
+	require.NoError(t, err)
+	bogus := hex.EncodeToString(bytes.Repeat([]byte{0xAA}, ed25519.SignatureSize))
+	decoded["MasterSignature"] = bogus
+	corruptedHex, err := binarycodec.Encode(decoded)
+	require.NoError(t, err)
+	corrupted, err := hex.DecodeString(corruptedHex)
+	require.NoError(t, err)
+
+	parsed, err := manifest.Deserialize(corrupted)
+	require.NoError(t, err)
+
+	frame := &message.Manifests{List: []message.Manifest{{STObject: corrupted}}}
+	inbox <- &peermanagement.InboundMessage{
+		PeerID:  123,
+		Type:    uint16(message.TypeManifests),
+		Payload: encodePayload(t, frame),
+	}
+
+	// Give the router a moment to process the frame.
+	time.Sleep(50 * time.Millisecond)
+
+	if _, ok := cache.GetSigningKey(parsed.MasterKey); ok {
+		t.Fatal("cache stored a manifest whose master signature was corrupted")
+	}
+}

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/consensus/rcl"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
+	"github.com/LeJamon/goXRPLd/internal/manifest"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement"
 )
 
@@ -20,6 +21,12 @@ type Components struct {
 	Adaptor     *Adaptor
 	Router      *Router
 	ModeManager *ModeManager
+
+	// Manifests is the validator-manifest cache shared by the router
+	// (wire ingest), the consensus engine (ephemeral→master
+	// translation), and the RPC layer (manifest method). Always
+	// non-nil — starts empty and fills as peers gossip manifests.
+	Manifests *manifest.Cache
 
 	// cancel functions for background goroutines
 	overlayCancel context.CancelFunc
@@ -126,11 +133,27 @@ func NewFromConfig(
 	// Create mode manager
 	modeManager := NewModeManager(adaptor)
 
+	// Validator manifest cache. Shared across the engine (for
+	// ephemeral→master translation in ValidationTracker), the router
+	// (for ingesting + relaying TMManifests), and the RPC layer (for
+	// the `manifest` method). Peers gossip manifests; until one
+	// arrives the cache is empty and every ephemeral key round-trips
+	// as itself.
+	manifestCache := manifest.NewCache()
+
 	// Create the RCL consensus engine
 	engine := rcl.NewEngine(adaptor, rcl.DefaultConfig())
 
+	// Translate ephemeral signing keys → master keys before quorum
+	// arithmetic. Mirrors rippled RCLValidations.cpp:165-186's
+	// calcNodeID(getTrustedKey(signingKey) ?? signingKey).
+	engine.SetManifestResolver(func(nid consensus.NodeID) consensus.NodeID {
+		return consensus.NodeID(manifestCache.GetMasterKey([33]byte(nid)))
+	})
+
 	// Create the router
 	router := NewRouter(engine, adaptor, modeManager, overlay.Messages())
+	router.SetManifestCache(manifestCache, overlay)
 
 	// Plumb peer disconnect notifications back through the router so
 	// per-peer state (peerStates for catch-up, peerLCLs for the
@@ -156,6 +179,7 @@ func NewFromConfig(
 		Adaptor:     adaptor,
 		Router:      router,
 		ModeManager: modeManager,
+		Manifests:   manifestCache,
 	}, nil
 }
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -76,6 +76,13 @@ type Engine struct {
 	// Stats
 	roundCount     uint64
 	consensusCount uint64
+
+	// manifestResolver is set (once, at bootstrap) to the validator
+	// manifest cache's GetMasterKey function, so the ValidationTracker
+	// can translate ephemeral signing keys → master keys before
+	// quorum arithmetic. Nil means "no translation" (default identity
+	// function inside the tracker). See SetManifestResolver.
+	manifestResolver func(consensus.NodeID) consensus.NodeID
 }
 
 // avalancheState tracks the close time voting threshold escalation.
@@ -119,6 +126,20 @@ func NewEngine(adaptor consensus.Adaptor, config Config) *Engine {
 	}
 }
 
+// SetManifestResolver installs the validator-manifest resolver used by
+// the ValidationTracker to translate ephemeral signing keys to master
+// keys. Safe to call before or after Start; if the tracker isn't yet
+// constructed, the resolver is staged on the engine and applied when
+// Start builds the tracker.
+func (e *Engine) SetManifestResolver(fn func(consensus.NodeID) consensus.NodeID) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.manifestResolver = fn
+	if e.validationTracker != nil {
+		e.validationTracker.SetManifestResolver(fn)
+	}
+}
+
 // Start begins the consensus engine.
 func (e *Engine) Start(ctx context.Context) error {
 	e.mu.Lock()
@@ -139,6 +160,9 @@ func (e *Engine) Start(ctx context.Context) error {
 	// flips the ledger service's validated_ledger pointer.
 	e.validationTracker = NewValidationTracker(e.adaptor.GetQuorum(), 5*time.Minute)
 	e.validationTracker.SetTrusted(e.adaptor.GetTrustedValidators())
+	if e.manifestResolver != nil {
+		e.validationTracker.SetManifestResolver(e.manifestResolver)
+	}
 	// Use the adaptor's network-adjusted clock for freshness checks.
 	// Rippled's Validations::isCurrent uses app_.timeKeeper().closeTime()
 	// — matching here avoids rejecting our own just-signed validation

--- a/internal/consensus/rcl/manifest_resolver_test.go
+++ b/internal/consensus/rcl/manifest_resolver_test.go
@@ -1,0 +1,90 @@
+package rcl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// TestConsensus_EphemeralSigningKey_TranslatedForQuorum — acceptance
+// test from issue #265. A validation signed by an ephemeral key whose
+// manifest maps to a UNL master key must count toward quorum as if it
+// came from the master.
+func TestConsensus_EphemeralSigningKey_TranslatedForQuorum(t *testing.T) {
+	masterKey := consensus.NodeID{0xEE, 0x01}
+	ephemeralKey := consensus.NodeID{0xEE, 0x02}
+
+	vt := NewValidationTracker(1, 5*time.Minute)
+	vt.SetTrusted([]consensus.NodeID{masterKey})
+
+	// Wire the resolver: ephemeral → master. Anything else
+	// returns its input unchanged (so a non-rotated validator still
+	// works).
+	vt.SetManifestResolver(func(n consensus.NodeID) consensus.NodeID {
+		if n == ephemeralKey {
+			return masterKey
+		}
+		return n
+	})
+
+	ledger := consensus.LedgerID{0x42}
+	var fired bool
+	vt.SetFullyValidatedCallback(func(id consensus.LedgerID, _ uint32) {
+		if id == ledger {
+			fired = true
+		}
+	})
+
+	v := &consensus.Validation{
+		LedgerID:  ledger,
+		LedgerSeq: 100,
+		NodeID:    ephemeralKey, // signed with the ephemeral key
+		SignTime:  time.Now(),
+		Full:      true,
+	}
+
+	if !vt.Add(v) {
+		t.Fatal("Add: validation rejected")
+	}
+	if !fired {
+		t.Fatal("fully-validated callback did not fire — ephemeral key was not translated to master for quorum")
+	}
+	if count := vt.GetTrustedValidationCount(ledger); count != 1 {
+		t.Fatalf("GetTrustedValidationCount: got %d want 1", count)
+	}
+	if !vt.IsFullyValidated(ledger) {
+		t.Fatal("IsFullyValidated returned false")
+	}
+	if got := vt.ProposersValidated(ledger); got != 1 {
+		t.Fatalf("ProposersValidated: got %d want 1", got)
+	}
+}
+
+// TestConsensus_NoResolver_EphemeralNotTrusted — baseline: without a
+// manifest resolver, a validation signed by an ephemeral key whose
+// master is in the UNL must NOT count toward quorum. This guards
+// against a regression where the resolver is accidentally reversed or
+// applied in the wrong direction.
+func TestConsensus_NoResolver_EphemeralNotTrusted(t *testing.T) {
+	masterKey := consensus.NodeID{0xEE, 0x10}
+	ephemeralKey := consensus.NodeID{0xEE, 0x11}
+
+	vt := NewValidationTracker(1, 5*time.Minute)
+	vt.SetTrusted([]consensus.NodeID{masterKey})
+	// No SetManifestResolver call — default identity.
+
+	v := &consensus.Validation{
+		LedgerID:  consensus.LedgerID{0x43},
+		LedgerSeq: 101,
+		NodeID:    ephemeralKey,
+		SignTime:  time.Now(),
+		Full:      true,
+	}
+	if !vt.Add(v) {
+		t.Fatal("Add should still accept the validation (untrusted ones are tracked)")
+	}
+	if count := vt.GetTrustedValidationCount(consensus.LedgerID{0x43}); count != 0 {
+		t.Fatalf("untrusted validation counted as trusted: got %d", count)
+	}
+}

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -54,6 +54,17 @@ type ValidationTracker struct {
 	// Caller (the engine) advances minSeq as ledgers accept.
 	minSeq uint32
 
+	// resolver translates a validator's signing public key to its
+	// master public key via the manifest cache. Applied at Add() so
+	// every internal map is keyed by master — matching rippled's
+	// RCLValidations.cpp:165-186 which calls calcNodeID(masterKey ??
+	// signingKey) before handing off to Validations::add. When the
+	// signing key has no manifest mapping the resolver returns the
+	// input unchanged, so non-validator peers still round-trip
+	// correctly. Default is the identity function (tests that never
+	// wire a cache keep working).
+	resolver func(consensus.NodeID) consensus.NodeID
+
 	// callbacks
 	onFullyValidated func(ledgerID consensus.LedgerID, ledgerSeq uint32)
 }
@@ -72,7 +83,24 @@ func NewValidationTracker(quorum int, freshness time.Duration) *ValidationTracke
 		quorum:      quorum,
 		freshness:   freshness,
 		fired:       make(map[consensus.LedgerID]struct{}),
+		resolver:    func(n consensus.NodeID) consensus.NodeID { return n },
 	}
+}
+
+// SetManifestResolver installs a function that translates a validator's
+// signing public key to its master public key. Applied at Add() before
+// the NodeID is used as a map key, so quorum / trusted-set / negUNL
+// lookups operate on master keys even when the validator has rotated
+// its ephemeral signing key. Pass nil to reset to the identity
+// function (no translation). Safe to call at any time.
+func (vt *ValidationTracker) SetManifestResolver(fn func(consensus.NodeID) consensus.NodeID) {
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
+	if fn == nil {
+		vt.resolver = func(n consensus.NodeID) consensus.NodeID { return n }
+		return
+	}
+	vt.resolver = fn
 }
 
 // SetNow replaces the clock used by isCurrent for freshness checks.
@@ -250,8 +278,15 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 		return false
 	}
 
+	// Resolve ephemeral signing key to master key via the manifest
+	// resolver so every map below is keyed by master. A validator that
+	// has rotated its ephemeral key still counts as one participant in
+	// trusted / negUNL / quorum arithmetic. Mirrors rippled's
+	// RCLValidations.cpp:165-186 calcNodeID(masterKey ?? signingKey).
+	resolvedID := vt.resolver(validation.NodeID)
+
 	// Check if this is a newer validation from this node
-	existing, hasExisting := vt.byNode[validation.NodeID]
+	existing, hasExisting := vt.byNode[resolvedID]
 	if hasExisting {
 		if validation.LedgerSeq <= existing.LedgerSeq {
 			return false // Not newer, ignore
@@ -259,7 +294,7 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	}
 
 	// Update by-node tracking
-	vt.byNode[validation.NodeID] = validation
+	vt.byNode[resolvedID] = validation
 
 	// Add to ledger validations
 	ledgerVals, exists := vt.validations[validation.LedgerID]
@@ -267,7 +302,7 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 		ledgerVals = make(map[consensus.NodeID]*consensus.Validation)
 		vt.validations[validation.LedgerID] = ledgerVals
 	}
-	ledgerVals[validation.NodeID] = validation
+	ledgerVals[resolvedID] = validation
 
 	// Check for full validation
 	vt.checkFullValidation(validation.LedgerID)

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -1,0 +1,228 @@
+package manifest
+
+import (
+	"sync"
+)
+
+// Disposition reports the outcome of ApplyManifest. Matches rippled's
+// ManifestDisposition enum in Manifest.h.
+type Disposition int
+
+const (
+	// Accepted: the manifest is new, passed verification, and has been
+	// stored. Callers should relay accepted manifests to other peers.
+	Accepted Disposition = iota
+
+	// Stale: the manifest's sequence is not strictly greater than the
+	// cached one for this master key. Not an error — a peer that hasn't
+	// seen our latest will re-gossip older versions.
+	Stale
+
+	// Invalid: signature check failed (master sig, or ephemeral sig on
+	// a non-revoked manifest). Charge the sender.
+	Invalid
+
+	// BadMasterKey: the incoming manifest's master key is already
+	// recorded as another manifest's ephemeral key — a key-reuse
+	// contradiction. Rejecting prevents a confusing ambiguity in
+	// signingToMasterKeys. Rippled Manifest.cpp:436-444.
+	BadMasterKey
+
+	// BadEphemeralKey: the incoming manifest's ephemeral key collides
+	// with either an ephemeral or master key that the cache already
+	// knows for a different master. Rippled Manifest.cpp:459-477.
+	BadEphemeralKey
+)
+
+// String returns a debug-friendly label for the disposition.
+func (d Disposition) String() string {
+	switch d {
+	case Accepted:
+		return "accepted"
+	case Stale:
+		return "stale"
+	case Invalid:
+		return "invalid"
+	case BadMasterKey:
+		return "bad_master_key"
+	case BadEphemeralKey:
+		return "bad_ephemeral_key"
+	default:
+		return "unknown"
+	}
+}
+
+// Cache stores the latest verified manifest per master key and maintains
+// the inverse ephemeral→master lookup so consensus can translate a
+// validation's signing key back to a UNL master key.
+//
+// Safe for concurrent use.
+type Cache struct {
+	mu sync.RWMutex
+
+	// byMaster maps master public key → the latest accepted manifest.
+	// Entries persist across revocations: a revoked manifest is kept so
+	// lookups see Revoked==true and can refuse to treat the master as
+	// trusted.
+	byMaster map[[33]byte]*Manifest
+
+	// signingToMaster maps ephemeral signing key → master key. Cleared
+	// when the master rotates (old ephemeral removed) or revokes
+	// (entry removed so lookups no longer resolve).
+	signingToMaster map[[33]byte][33]byte
+}
+
+// NewCache returns an empty Cache.
+func NewCache() *Cache {
+	return &Cache{
+		byMaster:        make(map[[33]byte]*Manifest),
+		signingToMaster: make(map[[33]byte][33]byte),
+	}
+}
+
+// ApplyManifest ingests a parsed manifest, verifies it, and — if the
+// checks pass — stores it atomically. Returns the disposition so the
+// caller can decide whether to relay (Accepted) or charge the sender
+// (Invalid / BadMasterKey / BadEphemeralKey). Stale is a no-op.
+//
+// Mirrors ManifestCache::applyManifest at rippled Manifest.cpp:382-580,
+// collapsed to a single write-lock path — the two-phase read/write
+// optimization there exists because signature verification is
+// expensive; in our deployments the expected rate of inbound manifests
+// is too low to matter.
+func (c *Cache) ApplyManifest(m *Manifest) Disposition {
+	if m == nil {
+		return Invalid
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if existing, ok := c.byMaster[m.MasterKey]; ok {
+		if m.Sequence <= existing.Sequence {
+			return Stale
+		}
+	}
+
+	// Signature verification happens under the lock so concurrent
+	// callers can't race in two manifests for the same master at the
+	// same sequence. Cost is bounded: O(manifests-per-second) × O(one
+	// ed25519/secp256k1 verify).
+	if err := m.Verify(); err != nil {
+		return Invalid
+	}
+
+	// The manifest's master key must not already be recorded as
+	// another manifest's ephemeral key — otherwise a subsequent
+	// getMasterKey(m.MasterKey) would be ambiguous.
+	if other, ok := c.signingToMaster[m.MasterKey]; ok && other != m.MasterKey {
+		return BadMasterKey
+	}
+
+	if !m.Revoked() {
+		// The ephemeral key must not already be used as ANOTHER
+		// master's ephemeral key (rippled Manifest.cpp:459-468).
+		if other, ok := c.signingToMaster[m.SigningKey]; ok && other != m.MasterKey {
+			return BadEphemeralKey
+		}
+		// Nor may it collide with a known master key (rippled
+		// Manifest.cpp:470-477).
+		if _, ok := c.byMaster[m.SigningKey]; ok {
+			return BadEphemeralKey
+		}
+	}
+
+	// Drop the previous ephemeral mapping (if any) before installing
+	// the new one; otherwise a validation signed with the OLD
+	// ephemeral would still resolve to the master after rotation.
+	if prev, ok := c.byMaster[m.MasterKey]; ok {
+		if !prev.Revoked() {
+			delete(c.signingToMaster, prev.SigningKey)
+		}
+	}
+
+	c.byMaster[m.MasterKey] = m
+	if !m.Revoked() {
+		c.signingToMaster[m.SigningKey] = m.MasterKey
+	}
+	return Accepted
+}
+
+// GetMasterKey returns the master key associated with a signing key.
+// If the signing key is not recorded in any manifest, returns the input
+// unchanged — matching rippled's ManifestCache::getMasterKey
+// (Manifest.cpp:322-332), which lets callers use the return value
+// directly in UNL lookups: a non-validator peer's pubkey maps to itself.
+func (c *Cache) GetMasterKey(signingKey [33]byte) [33]byte {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if m, ok := c.signingToMaster[signingKey]; ok {
+		return m
+	}
+	return signingKey
+}
+
+// GetSigningKey returns the current ephemeral signing key for a master
+// key. The second return is false when the master is unknown or
+// revoked — callers should treat "revoked or unknown" identically
+// (rippled Manifest.cpp:310-320 returns the input key itself in that
+// case, but the caller contexts here — RPC and consensus — want to
+// distinguish "have a valid mapping" from "don't").
+func (c *Cache) GetSigningKey(masterKey [33]byte) ([33]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	m, ok := c.byMaster[masterKey]
+	if !ok || m.Revoked() {
+		return [33]byte{}, false
+	}
+	return m.SigningKey, true
+}
+
+// GetManifest returns the raw serialized manifest bytes for a master
+// key. Second return is false when the master is unknown or revoked.
+func (c *Cache) GetManifest(masterKey [33]byte) ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	m, ok := c.byMaster[masterKey]
+	if !ok || m.Revoked() {
+		return nil, false
+	}
+	return append([]byte(nil), m.Serialized...), true
+}
+
+// GetSequence returns the stored manifest's sequence number. Second
+// return is false on unknown or revoked.
+func (c *Cache) GetSequence(masterKey [33]byte) (uint32, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	m, ok := c.byMaster[masterKey]
+	if !ok || m.Revoked() {
+		return 0, false
+	}
+	return m.Sequence, true
+}
+
+// GetDomain returns the stored manifest's domain string. Second return
+// is false on unknown, revoked, or when no domain was recorded.
+func (c *Cache) GetDomain(masterKey [33]byte) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	m, ok := c.byMaster[masterKey]
+	if !ok || m.Revoked() || m.Domain == "" {
+		return "", false
+	}
+	return m.Domain, true
+}
+
+// Revoked reports whether the cached manifest for masterKey is a
+// revocation. Unknown masters return false — a master we've never seen
+// is not revoked by absence.
+func (c *Cache) Revoked(masterKey [33]byte) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	m, ok := c.byMaster[masterKey]
+	if !ok {
+		return false
+	}
+	return m.Revoked()
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,0 +1,325 @@
+// Package manifest implements validator manifest parsing, verification, and
+// caching — the equivalent of rippled's ValidatorManifests service.
+//
+// A manifest binds a validator's long-term master key to a rotatable
+// ephemeral signing key. Peers gossip manifests so every node on the
+// network can translate an ephemeral signing key used in a validation or
+// proposal back to its master key for UNL / quorum decisions. Without
+// this translation a validator that rotates its ephemeral key appears as
+// a new untrusted node and breaks mainnet quorum arithmetic.
+//
+// Wire format (rippled Manifest.cpp:53-164):
+//
+//	STObject with fields
+//	  PublicKey        (required) — master public key
+//	  MasterSignature  (required) — signature by the master key
+//	  Sequence         (required) — strictly monotonic; MaxUint32 = revoked
+//	  Version          (default 0)
+//	  Domain           (optional)
+//	  SigningPubKey    (optional; absent iff revoked) — ephemeral public key
+//	  Signature        (optional; absent iff revoked) — signature by the ephemeral key
+//
+// Both signatures sign the same preimage: HashPrefix("MAN\0") prepended
+// to the canonical STObject serialization with Signature and
+// MasterSignature removed (the xrpl "isSigningField" filter). The
+// ed25519 path verifies the raw preimage; the secp256k1 path SHA-512Half
+// hashes the preimage first. Both already match that convention in
+// crypto/ed25519 and crypto/secp256k1.
+package manifest
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
+	"github.com/LeJamon/goXRPLd/crypto"
+	"github.com/LeJamon/goXRPLd/crypto/ed25519"
+	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
+	"github.com/LeJamon/goXRPLd/protocol"
+)
+
+// RevokedSequence marks a manifest as a master-key revocation.
+// Rippled: Manifest::revoked returns sequence == numeric_limits::max.
+const RevokedSequence uint32 = math.MaxUint32
+
+// Manifest is a parsed, syntactically-valid validator manifest.
+// Signature verification is separate — callers invoke Verify before
+// trusting the struct's key bindings.
+type Manifest struct {
+	// MasterKey is the 33-byte master public key (ed25519 0xED prefix or
+	// secp256k1 0x02/0x03 prefix).
+	MasterKey [33]byte
+
+	// SigningKey is the 33-byte ephemeral signing key. Zero when Revoked.
+	SigningKey [33]byte
+
+	// Sequence is the manifest's monotonic counter. RevokedSequence
+	// (MaxUint32) indicates master-key revocation; in that case
+	// SigningKey is zero and both Signature and MasterSignature are
+	// present only on the master side.
+	Sequence uint32
+
+	// Domain is the optional TOML domain string.
+	Domain string
+
+	// Serialized is the original wire bytes — kept so the cache can
+	// relay the exact payload peers gossiped and the RPC can return it.
+	Serialized []byte
+}
+
+// Revoked reports whether the manifest revokes its master key.
+func (m *Manifest) Revoked() bool {
+	return m.Sequence == RevokedSequence
+}
+
+// Deserialize parses a wire-format manifest. Returns a non-nil error if
+// the bytes aren't a well-formed STObject, a required field is missing,
+// or the field relationship invariants (revoked ⇒ no ephemeral fields;
+// non-revoked ⇒ ephemeral fields present; signing key != master key;
+// key-type prefix byte valid) are violated.
+//
+// Signatures are NOT verified here — call Verify after parsing.
+func Deserialize(data []byte) (*Manifest, error) {
+	if len(data) == 0 {
+		return nil, errors.New("manifest: empty payload")
+	}
+
+	decoded, err := binarycodec.Decode(hex.EncodeToString(data))
+	if err != nil {
+		return nil, fmt.Errorf("manifest: decode STObject: %w", err)
+	}
+
+	// Version default is 0; anything else is an unsupported manifest
+	// format per rippled Manifest.cpp:92-93.
+	if raw, ok := decoded["Version"]; ok {
+		v, ok := toUint32(raw)
+		if !ok {
+			return nil, errors.New("manifest: Version is not numeric")
+		}
+		if v != 0 {
+			return nil, fmt.Errorf("manifest: unsupported Version %d", v)
+		}
+	}
+
+	masterHex, err := requireHexField(decoded, "PublicKey")
+	if err != nil {
+		return nil, err
+	}
+	master, err := decodeKey(masterHex)
+	if err != nil {
+		return nil, fmt.Errorf("manifest: PublicKey: %w", err)
+	}
+
+	seqRaw, ok := decoded["Sequence"]
+	if !ok {
+		return nil, errors.New("manifest: missing required Sequence")
+	}
+	seq, ok := toUint32(seqRaw)
+	if !ok {
+		return nil, errors.New("manifest: Sequence is not numeric")
+	}
+
+	if _, err := requireHexField(decoded, "MasterSignature"); err != nil {
+		return nil, err
+	}
+
+	m := &Manifest{
+		MasterKey:  master,
+		Sequence:   seq,
+		Serialized: append([]byte(nil), data...),
+	}
+
+	if dom, ok := decoded["Domain"]; ok {
+		if s, ok := dom.(string); ok {
+			// Domain is VL-encoded as bytes; the codec returns a hex
+			// string. Decode it back to the raw UTF-8 text.
+			b, err := hex.DecodeString(s)
+			if err != nil {
+				return nil, fmt.Errorf("manifest: Domain not hex: %w", err)
+			}
+			m.Domain = string(b)
+		}
+	}
+
+	hasSigningKey := hasField(decoded, "SigningPubKey")
+	hasSignature := hasField(decoded, "Signature")
+
+	if m.Revoked() {
+		if hasSigningKey || hasSignature {
+			return nil, errors.New("manifest: revoked manifest must not carry ephemeral fields")
+		}
+		return m, nil
+	}
+
+	if !hasSigningKey || !hasSignature {
+		return nil, errors.New("manifest: non-revoked manifest requires SigningPubKey and Signature")
+	}
+
+	signingHex, _ := requireHexField(decoded, "SigningPubKey")
+	signing, err := decodeKey(signingHex)
+	if err != nil {
+		return nil, fmt.Errorf("manifest: SigningPubKey: %w", err)
+	}
+	if signing == master {
+		return nil, errors.New("manifest: signing key equals master key")
+	}
+	m.SigningKey = signing
+	return m, nil
+}
+
+// Verify checks both the master signature and (for non-revoked
+// manifests) the ephemeral-key signature against the canonical signing
+// preimage: HashPrefix("MAN\0") || STObject(manifest without Signature
+// and MasterSignature). Mirrors Manifest::verify at Manifest.cpp:195-214.
+func (m *Manifest) Verify() error {
+	preimage, err := signingPreimage(m.Serialized)
+	if err != nil {
+		return fmt.Errorf("manifest: build signing preimage: %w", err)
+	}
+	// Re-decode to extract signature fields — small cost, keeps the
+	// Manifest struct free of intermediate parser state.
+	decoded, err := binarycodec.Decode(hex.EncodeToString(m.Serialized))
+	if err != nil {
+		return fmt.Errorf("manifest: re-decode for verify: %w", err)
+	}
+	masterSigHex, _ := decoded["MasterSignature"].(string)
+	if masterSigHex == "" {
+		return errors.New("manifest: MasterSignature missing on verify")
+	}
+	if !verifySignature(m.MasterKey, preimage, masterSigHex) {
+		return errors.New("manifest: master signature invalid")
+	}
+	if !m.Revoked() {
+		sigHex, _ := decoded["Signature"].(string)
+		if sigHex == "" {
+			return errors.New("manifest: Signature missing on verify")
+		}
+		if !verifySignature(m.SigningKey, preimage, sigHex) {
+			return errors.New("manifest: ephemeral signature invalid")
+		}
+	}
+	return nil
+}
+
+// signingPreimage returns HashPrefix("MAN\0") || STObject(manifest
+// without signing fields). Mirrors rippled's ripple::verify pattern
+// (Sign.cpp:47-62) where ss.add32(prefix) precedes
+// st.addWithoutSigningFields(ss).
+func signingPreimage(serialized []byte) ([]byte, error) {
+	decoded, err := binarycodec.Decode(hex.EncodeToString(serialized))
+	if err != nil {
+		return nil, err
+	}
+	for k := range decoded {
+		fi, _ := definitions.Get().GetFieldInstanceByFieldName(k)
+		if fi != nil && !fi.IsSigningField {
+			delete(decoded, k)
+		}
+	}
+	encoded, err := binarycodec.Encode(decoded)
+	if err != nil {
+		return nil, err
+	}
+	body, err := hex.DecodeString(encoded)
+	if err != nil {
+		return nil, err
+	}
+	prefix := protocol.HashPrefixManifest
+	out := make([]byte, 0, len(prefix)+len(body))
+	out = append(out, prefix[:]...)
+	out = append(out, body...)
+	return out, nil
+}
+
+// verifySignature dispatches to the key-type-specific verifier. The raw
+// message bytes are passed as a Go string (the crypto packages treat
+// string as an opaque byte sequence); signature is hex-encoded.
+func verifySignature(pubKey [33]byte, message []byte, sigHex string) bool {
+	pubHex := hex.EncodeToString(pubKey[:])
+	switch crypto.PublicKeyType(pubKey[:]) {
+	case crypto.KeyTypeEd25519:
+		return ed25519.ED25519().Validate(string(message), pubHex, sigHex)
+	case crypto.KeyTypeSecp256k1:
+		// Manifest signatures are not required to be fully canonical
+		// (rippled verifies without the fully-canonical gate at
+		// Sign.cpp:47-62 → PublicKey::verify → secp256k1_ecdsa_verify
+		// with no low-S check). ValidateWithCanonicality(false) matches.
+		return secp256k1.SECP256K1().ValidateWithCanonicality(string(message), pubHex, sigHex, false)
+	default:
+		return false
+	}
+}
+
+func decodeKey(hexStr string) ([33]byte, error) {
+	var out [33]byte
+	b, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return out, err
+	}
+	if len(b) != 33 {
+		return out, fmt.Errorf("expected 33 bytes, got %d", len(b))
+	}
+	if crypto.PublicKeyType(b) == crypto.KeyTypeUnknown {
+		return out, errors.New("unknown key type prefix")
+	}
+	copy(out[:], b)
+	return out, nil
+}
+
+func requireHexField(m map[string]any, name string) (string, error) {
+	raw, ok := m[name]
+	if !ok {
+		return "", fmt.Errorf("manifest: missing required %s", name)
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("manifest: %s is not a string", name)
+	}
+	return s, nil
+}
+
+func hasField(m map[string]any, name string) bool {
+	v, ok := m[name]
+	if !ok {
+		return false
+	}
+	s, ok := v.(string)
+	if !ok {
+		// Non-string fields (numeric) are always "present" if the key
+		// is in the map.
+		return true
+	}
+	return s != ""
+}
+
+// toUint32 accepts the several numeric shapes the JSON map may contain
+// for a UInt32 field (float64 from json.Unmarshal, int / int64 from
+// some codec paths, uint32/uint64 direct).
+func toUint32(v any) (uint32, bool) {
+	switch t := v.(type) {
+	case uint32:
+		return t, true
+	case uint64:
+		return uint32(t), true
+	case int:
+		if t < 0 {
+			return 0, false
+		}
+		return uint32(t), true
+	case int64:
+		if t < 0 {
+			return 0, false
+		}
+		return uint32(t), true
+	case float64:
+		if t < 0 {
+			return 0, false
+		}
+		return uint32(t), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -299,7 +299,7 @@ func TestManifest_Revoked_WithEphemeral_Rejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	decoded["Sequence"] = uint32(manifest.RevokedSequence)
+	decoded["Sequence"] = manifest.RevokedSequence
 	corruptedHex, err := binarycodec.Encode(decoded)
 	if err != nil {
 		t.Fatalf("re-encode: %v", err)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,0 +1,315 @@
+package manifest_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/manifest"
+	"github.com/LeJamon/goXRPLd/protocol"
+)
+
+// buildManifest constructs a serialized manifest with real ed25519
+// signatures. Used by tests that want a valid starting point and then
+// selectively corrupt fields. Returns the serialized manifest bytes and
+// the two public keys (master, ephemeral) so callers can check the
+// stored state after apply.
+func buildManifest(t *testing.T, seq uint32, revoked bool, masterSeed, ephemeralSeed byte) (serialized []byte, masterPub [33]byte, ephemeralPub [33]byte) {
+	t.Helper()
+
+	masterPubBytes, masterPriv := deterministicEd25519Keypair(masterSeed)
+	copy(masterPub[:], masterPubBytes)
+
+	json := map[string]any{
+		"PublicKey": hex.EncodeToString(masterPubBytes),
+		"Sequence":  seq,
+	}
+
+	if !revoked {
+		ephPubBytes, ephPriv := deterministicEd25519Keypair(ephemeralSeed)
+		copy(ephemeralPub[:], ephPubBytes)
+		json["SigningPubKey"] = hex.EncodeToString(ephPubBytes)
+		// Ephemeral signature over the signing preimage.
+		preimage := signingPreimageFromJSON(t, json)
+		ephSig := ed25519.Sign(ed25519.PrivateKey(ephPriv), preimage)
+		json["Signature"] = hex.EncodeToString(ephSig)
+	}
+
+	// Master signature over the same preimage. MasterSignature isn't a
+	// signing field so including it in the JSON we hand to the codec
+	// doesn't affect the preimage — but we compute the preimage from a
+	// copy that also excludes MasterSignature for clarity.
+	preimage := signingPreimageFromJSON(t, json)
+	masterSig := ed25519.Sign(ed25519.PrivateKey(masterPriv), preimage)
+	json["MasterSignature"] = hex.EncodeToString(masterSig)
+
+	encoded, err := binarycodec.Encode(json)
+	if err != nil {
+		t.Fatalf("encode manifest: %v", err)
+	}
+	b, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode built hex: %v", err)
+	}
+	return b, masterPub, ephemeralPub
+}
+
+// signingPreimageFromJSON replicates the preimage construction the
+// manifest package does internally: HashPrefixManifest || Encode(only
+// signing fields). Kept in the test to catch preimage drift — if the
+// package changes the preimage, this helper stays the old one and the
+// test fails loudly.
+func signingPreimageFromJSON(t *testing.T, src map[string]any) []byte {
+	t.Helper()
+	filtered := make(map[string]any, len(src))
+	for k, v := range src {
+		if k == "Signature" || k == "MasterSignature" {
+			continue
+		}
+		filtered[k] = v
+	}
+	encoded, err := binarycodec.Encode(filtered)
+	if err != nil {
+		t.Fatalf("encode signing body: %v", err)
+	}
+	body, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode signing body hex: %v", err)
+	}
+	prefix := protocol.HashPrefixManifest
+	out := make([]byte, 0, len(prefix)+len(body))
+	out = append(out, prefix[:]...)
+	out = append(out, body...)
+	return out
+}
+
+// deterministicEd25519Keypair returns a 33-byte xrpl-style public key
+// (0xED prefix + 32 bytes) and a 64-byte ed25519 private key seeded
+// from `seed`. Tests use a byte seed so they're reproducible and each
+// caller gets a distinct key.
+func deterministicEd25519Keypair(seed byte) (pub33, priv64 []byte) {
+	s := bytes.Repeat([]byte{seed}, ed25519.SeedSize)
+	priv := ed25519.NewKeyFromSeed(s)
+	pub := priv.Public().(ed25519.PublicKey)
+	pub33 = append([]byte{0xED}, pub...)
+	priv64 = priv
+	return
+}
+
+func TestManifest_WireDecode_ValidMasterSig_Accepted(t *testing.T) {
+	serialized, master, ephemeral := buildManifest(t, 1, false, 0x01, 0x02)
+
+	m, err := manifest.Deserialize(serialized)
+	if err != nil {
+		t.Fatalf("Deserialize: %v", err)
+	}
+	if m.MasterKey != master {
+		t.Fatalf("MasterKey mismatch: got %x want %x", m.MasterKey, master)
+	}
+	if m.SigningKey != ephemeral {
+		t.Fatalf("SigningKey mismatch: got %x want %x", m.SigningKey, ephemeral)
+	}
+	if m.Sequence != 1 {
+		t.Fatalf("Sequence: got %d want 1", m.Sequence)
+	}
+	if m.Revoked() {
+		t.Fatal("Revoked: true, want false")
+	}
+
+	if err := m.Verify(); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	c := manifest.NewCache()
+	if d := c.ApplyManifest(m); d != manifest.Accepted {
+		t.Fatalf("ApplyManifest: got %s want accepted", d)
+	}
+
+	gotMaster := c.GetMasterKey(ephemeral)
+	if gotMaster != master {
+		t.Fatalf("GetMasterKey: got %x want %x", gotMaster, master)
+	}
+	gotEph, ok := c.GetSigningKey(master)
+	if !ok || gotEph != ephemeral {
+		t.Fatalf("GetSigningKey: ok=%v got %x want %x", ok, gotEph, ephemeral)
+	}
+	if stored, ok := c.GetManifest(master); !ok || !bytes.Equal(stored, serialized) {
+		t.Fatalf("GetManifest: ok=%v match=%v", ok, bytes.Equal(stored, serialized))
+	}
+	if seq, ok := c.GetSequence(master); !ok || seq != 1 {
+		t.Fatalf("GetSequence: ok=%v seq=%d", ok, seq)
+	}
+}
+
+func TestManifest_WireDecode_BadMasterSig_Rejected(t *testing.T) {
+	serialized, master, _ := buildManifest(t, 1, false, 0x03, 0x04)
+
+	// Re-encode with a bogus MasterSignature: decode → overwrite →
+	// re-encode. Changing the raw bytes directly would misalign the VL
+	// length prefix.
+	decoded, err := binarycodec.Decode(hex.EncodeToString(serialized))
+	if err != nil {
+		t.Fatalf("round-trip decode: %v", err)
+	}
+	badSig := strings.Repeat("AA", ed25519.SignatureSize)
+	decoded["MasterSignature"] = badSig
+	corruptedHex, err := binarycodec.Encode(decoded)
+	if err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+	corrupted, err := hex.DecodeString(corruptedHex)
+	if err != nil {
+		t.Fatalf("re-decode hex: %v", err)
+	}
+
+	m, err := manifest.Deserialize(corrupted)
+	if err != nil {
+		t.Fatalf("Deserialize should succeed (syntax valid): %v", err)
+	}
+	if err := m.Verify(); err == nil {
+		t.Fatal("Verify: got nil, want error (bad master sig)")
+	}
+
+	c := manifest.NewCache()
+	if d := c.ApplyManifest(m); d != manifest.Invalid {
+		t.Fatalf("ApplyManifest: got %s want invalid", d)
+	}
+	if _, ok := c.GetSigningKey(master); ok {
+		t.Fatal("cache stored an invalid manifest")
+	}
+}
+
+func TestManifest_HigherSeq_Overrides(t *testing.T) {
+	seq1Bytes, master, eph1 := buildManifest(t, 1, false, 0x05, 0x06)
+	m1, err := manifest.Deserialize(seq1Bytes)
+	if err != nil {
+		t.Fatalf("Deserialize seq1: %v", err)
+	}
+
+	c := manifest.NewCache()
+	if d := c.ApplyManifest(m1); d != manifest.Accepted {
+		t.Fatalf("seq1 apply: %s", d)
+	}
+
+	// seq 2 rotates to a new ephemeral key (different seed).
+	seq2Bytes, master2, eph2 := buildManifest(t, 2, false, 0x05, 0x07)
+	if master2 != master {
+		t.Fatalf("master keys drifted: test helper bug")
+	}
+	m2, err := manifest.Deserialize(seq2Bytes)
+	if err != nil {
+		t.Fatalf("Deserialize seq2: %v", err)
+	}
+	if d := c.ApplyManifest(m2); d != manifest.Accepted {
+		t.Fatalf("seq2 apply: %s", d)
+	}
+
+	// Old ephemeral should no longer resolve to the master — it's been
+	// rotated out.
+	if got := c.GetMasterKey(eph1); got == master {
+		t.Fatalf("old ephemeral still resolves to master after rotation: got %x", got)
+	}
+	if got := c.GetMasterKey(eph2); got != master {
+		t.Fatalf("new ephemeral doesn't resolve: got %x want %x", got, master)
+	}
+
+	// Re-applying seq1 must be Stale.
+	if d := c.ApplyManifest(m1); d != manifest.Stale {
+		t.Fatalf("stale re-apply: got %s want stale", d)
+	}
+}
+
+func TestManifest_RevokedMasterKey_Rejected(t *testing.T) {
+	// Establish a seq 1 manifest first so we can see revocation
+	// erases the ephemeral lookup.
+	initBytes, master, eph := buildManifest(t, 1, false, 0x08, 0x09)
+	initM, err := manifest.Deserialize(initBytes)
+	if err != nil {
+		t.Fatalf("Deserialize init: %v", err)
+	}
+	c := manifest.NewCache()
+	if d := c.ApplyManifest(initM); d != manifest.Accepted {
+		t.Fatalf("init apply: %s", d)
+	}
+	if _, ok := c.GetSigningKey(master); !ok {
+		t.Fatal("sanity: signing key should resolve pre-revocation")
+	}
+
+	// Revoke. Same master, same master-seed, no ephemeral fields,
+	// seq = MaxUint32.
+	revBytes, master2, _ := buildManifest(t, manifest.RevokedSequence, true, 0x08, 0x00)
+	if master2 != master {
+		t.Fatalf("master keys drifted: test helper bug")
+	}
+	revM, err := manifest.Deserialize(revBytes)
+	if err != nil {
+		t.Fatalf("Deserialize revoke: %v", err)
+	}
+	if !revM.Revoked() {
+		t.Fatal("Revoked() = false, expected true")
+	}
+
+	if d := c.ApplyManifest(revM); d != manifest.Accepted {
+		t.Fatalf("revoke apply: got %s want accepted", d)
+	}
+	if _, ok := c.GetSigningKey(master); ok {
+		t.Fatal("GetSigningKey still returns ok after revocation")
+	}
+	if got := c.GetMasterKey(eph); got == master {
+		t.Fatal("ephemeral still resolves to master after revocation")
+	}
+	if !c.Revoked(master) {
+		t.Fatal("Revoked(master) = false after applying revocation")
+	}
+}
+
+func TestManifest_NonRevoked_MissingEphemeral_Rejected(t *testing.T) {
+	serialized, _, _ := buildManifest(t, 1, false, 0x0A, 0x0B)
+
+	decoded, err := binarycodec.Decode(hex.EncodeToString(serialized))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	delete(decoded, "SigningPubKey")
+	delete(decoded, "Signature")
+	corruptedHex, err := binarycodec.Encode(decoded)
+	if err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+	corrupted, err := hex.DecodeString(corruptedHex)
+	if err != nil {
+		t.Fatalf("re-decode hex: %v", err)
+	}
+
+	if _, err := manifest.Deserialize(corrupted); err == nil {
+		t.Fatal("Deserialize: got nil error, want rejection of non-revoked w/o ephemeral")
+	}
+}
+
+func TestManifest_Revoked_WithEphemeral_Rejected(t *testing.T) {
+	// Build a non-revoked manifest, then swap its sequence to the
+	// revoked sentinel without removing ephemeral fields. The ephemeral
+	// signature will be wrong after this tweak, but we're probing the
+	// structural invariant in Deserialize — and that runs before Verify.
+	serialized, _, _ := buildManifest(t, 1, false, 0x0C, 0x0D)
+	decoded, err := binarycodec.Decode(hex.EncodeToString(serialized))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	decoded["Sequence"] = uint32(manifest.RevokedSequence)
+	corruptedHex, err := binarycodec.Encode(decoded)
+	if err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+	corrupted, err := hex.DecodeString(corruptedHex)
+	if err != nil {
+		t.Fatalf("re-decode hex: %v", err)
+	}
+
+	if _, err := manifest.Deserialize(corrupted); err == nil {
+		t.Fatal("Deserialize: got nil, want rejection of revoked + ephemeral")
+	}
+}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1175,6 +1175,29 @@ func (o *Overlay) Broadcast(msg []byte) error {
 	return nil
 }
 
+// BroadcastExcept sends a message to every connected peer except the
+// one identified by exceptPeer. Used for gossip of peer-originated
+// messages that are NOT per-validator (manifests) — the per-validator
+// squelch filter in RelayFromValidator doesn't apply. Pass 0 for
+// exceptPeer to fall through to a plain Broadcast. Mirrors rippled's
+// OverlayImpl::foreach used to relay TMManifests at
+// OverlayImpl.cpp:633-686.
+func (o *Overlay) BroadcastExcept(exceptPeer PeerID, msg []byte) error {
+	o.peersMu.RLock()
+	defer o.peersMu.RUnlock()
+
+	for id, peer := range o.peers {
+		if id == exceptPeer {
+			continue
+		}
+		if peer.State() != PeerStateConnected {
+			continue
+		}
+		peer.Send(msg)
+	}
+	return nil
+}
+
 // RelayFromValidator forwards a peer-originated validator message
 // (proposal or validation) to other connected peers, applying the
 // per-peer squelch filter on the ORIGINATING validator's pubkey AND

--- a/internal/rpc/handlers/manifest.go
+++ b/internal/rpc/handlers/manifest.go
@@ -1,25 +1,30 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"encoding/json"
 
+	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// ManifestMethod handles the manifest RPC method.
-// STUB: Returns placeholder data. Requires validator manifest infrastructure.
+// ManifestMethod handles the `manifest` RPC method.
 //
-// TODO [validator]: Implement validator manifest retrieval.
-//   - Requires: ValidatorManifests service (stores master→ephemeral key mappings)
-//   - Reference: rippled Manifest.cpp → context.app.validatorManifests()
-//   - Steps:
-//     1. Parse public_key param (required)
-//     2. Call validatorManifests.getMasterKey(publicKey) to resolve ephemeral→master
-//     3. Call validatorManifests.getManifest(masterKey) to get raw manifest
-//     4. Decode manifest to extract: sequence, master_key, signing_key, domain, signature
-//     5. Return { details: {domain, ephemeral_key, master_key, seq}, manifest: base64, requested: key }
-//   - If key not found, return empty details + "requested" field only
+// Rippled reference: src/xrpld/rpc/handlers/DoManifest.cpp:29-76.
+//
+// Given a base58 node public key (either a master key OR an ephemeral
+// signing key), the handler resolves it to the master key via the
+// cached manifest and returns the stored manifest's details plus the
+// raw serialized manifest as base64. Keys with no recorded manifest
+// return only the `requested` field.
 type ManifestMethod struct{}
+
+// manifestResponse mirrors rippled's DoManifest response shape.
+type manifestResponse struct {
+	Requested string                 `json:"requested"`
+	Manifest  string                 `json:"manifest,omitempty"`
+	Details   map[string]interface{} `json:"details,omitempty"`
+}
 
 func (m *ManifestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
 	var request struct {
@@ -36,12 +41,68 @@ func (m *ManifestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorInvalidParams("Missing required parameter: public_key")
 	}
 
-	// Return empty details (no validator manifest infrastructure yet)
-	response := map[string]interface{}{
-		"requested": request.PublicKey,
+	// Parse the base58 NodePublic key. rippled DoManifest.cpp:36
+	// rejects non-base58 or wrong-type inputs with rpcPUBLIC_MALFORMED.
+	rawKey, err := addresscodec.DecodeNodePublicKey(request.PublicKey)
+	if err != nil {
+		return nil, types.RpcErrorInvalidParams("invalid node public key: " + err.Error())
+	}
+	if len(rawKey) != 33 {
+		return nil, types.RpcErrorInvalidParams("node public key must be 33 bytes")
+	}
+	var keyArr [33]byte
+	copy(keyArr[:], rawKey)
+
+	resp := manifestResponse{Requested: request.PublicKey}
+
+	// Manifest cache isn't wired in standalone / pre-consensus setups
+	// — return the sparse response so clients can still probe the
+	// method without a 500.
+	if types.Services == nil || types.Services.Manifests == nil {
+		return resp, nil
+	}
+	cache := types.Services.Manifests
+
+	// Callers may pass EITHER the master key or its ephemeral signing
+	// key. GetMasterKey collapses both into the master; if the input
+	// was unknown it returns the input unchanged.
+	master := cache.GetMasterKey(keyArr)
+
+	// Try to find a stored manifest under the resolved master.
+	serialized, ok := cache.GetManifest(master)
+	if !ok {
+		// No manifest recorded (or the master is revoked). Rippled
+		// returns requested + empty details in this case.
+		return resp, nil
 	}
 
-	return response, nil
+	ephemeral, ephOK := cache.GetSigningKey(master)
+	seq, _ := cache.GetSequence(master)
+	domain, _ := cache.GetDomain(master)
+
+	masterB58, err := addresscodec.EncodeNodePublicKey(master[:])
+	if err != nil {
+		return nil, types.RpcErrorInternal("encode master key: " + err.Error())
+	}
+
+	details := map[string]interface{}{
+		"master_key": masterB58,
+		"seq":        seq,
+	}
+	if ephOK {
+		ephB58, err := addresscodec.EncodeNodePublicKey(ephemeral[:])
+		if err != nil {
+			return nil, types.RpcErrorInternal("encode ephemeral key: " + err.Error())
+		}
+		details["ephemeral_key"] = ephB58
+	}
+	if domain != "" {
+		details["domain"] = domain
+	}
+
+	resp.Manifest = base64.StdEncoding.EncodeToString(serialized)
+	resp.Details = details
+	return resp, nil
 }
 
 func (m *ManifestMethod) RequiredRole() types.Role {

--- a/internal/rpc/handlers/manifest_test.go
+++ b/internal/rpc/handlers/manifest_test.go
@@ -1,0 +1,221 @@
+package handlers_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/manifest"
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/protocol"
+)
+
+// buildAndApplyManifest installs one valid manifest in a fresh cache
+// and returns both the cache and the raw serialized manifest so the
+// test can compare the base64 body in the RPC response.
+func buildAndApplyManifest(t *testing.T) (*manifest.Cache, [33]byte, [33]byte, []byte) {
+	t.Helper()
+
+	masterPubBytes, masterPriv := deterministicEd25519KeypairRPC(0x11)
+	ephPubBytes, ephPriv := deterministicEd25519KeypairRPC(0x22)
+
+	var master [33]byte
+	var ephemeral [33]byte
+	copy(master[:], masterPubBytes)
+	copy(ephemeral[:], ephPubBytes)
+
+	jsonMap := map[string]any{
+		"PublicKey":     hex.EncodeToString(masterPubBytes),
+		"SigningPubKey": hex.EncodeToString(ephPubBytes),
+		"Sequence":      uint32(7),
+		"Domain":        hex.EncodeToString([]byte("example.org")),
+	}
+	preimage := manifestPreimage(t, jsonMap)
+	jsonMap["Signature"] = hex.EncodeToString(ed25519.Sign(ed25519.PrivateKey(ephPriv), preimage))
+	jsonMap["MasterSignature"] = hex.EncodeToString(ed25519.Sign(ed25519.PrivateKey(masterPriv), preimage))
+
+	encoded, err := binarycodec.Encode(jsonMap)
+	if err != nil {
+		t.Fatalf("encode manifest: %v", err)
+	}
+	serialized, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode hex: %v", err)
+	}
+
+	m, err := manifest.Deserialize(serialized)
+	if err != nil {
+		t.Fatalf("Deserialize: %v", err)
+	}
+	c := manifest.NewCache()
+	if d := c.ApplyManifest(m); d != manifest.Accepted {
+		t.Fatalf("Apply: %s", d)
+	}
+	return c, master, ephemeral, serialized
+}
+
+func manifestPreimage(t *testing.T, src map[string]any) []byte {
+	t.Helper()
+	filtered := make(map[string]any, len(src))
+	for k, v := range src {
+		if k == "Signature" || k == "MasterSignature" {
+			continue
+		}
+		filtered[k] = v
+	}
+	encoded, err := binarycodec.Encode(filtered)
+	if err != nil {
+		t.Fatalf("encode preimage: %v", err)
+	}
+	body, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode preimage: %v", err)
+	}
+	prefix := protocol.HashPrefixManifest
+	out := make([]byte, 0, len(prefix)+len(body))
+	out = append(out, prefix[:]...)
+	out = append(out, body...)
+	return out
+}
+
+func deterministicEd25519KeypairRPC(seed byte) ([]byte, []byte) {
+	s := bytes.Repeat([]byte{seed}, ed25519.SeedSize)
+	priv := ed25519.NewKeyFromSeed(s)
+	pub := priv.Public().(ed25519.PublicKey)
+	return append([]byte{0xED}, pub...), priv
+}
+
+// withServices replaces the global types.Services for the duration of a
+// test and restores it on cleanup.
+func withServices(t *testing.T, cache types.ManifestLookup) {
+	t.Helper()
+	prev := types.Services
+	types.Services = &types.ServiceContainer{Manifests: cache}
+	t.Cleanup(func() { types.Services = prev })
+}
+
+func callManifestRPC(t *testing.T, publicKey string) (map[string]any, *types.RpcError) {
+	t.Helper()
+	var params json.RawMessage
+	if publicKey != "" {
+		p, _ := json.Marshal(map[string]string{"public_key": publicKey})
+		params = p
+	} else {
+		params = json.RawMessage(`{}`)
+	}
+	method := &handlers.ManifestMethod{}
+	result, rpcErr := method.Handle(&types.RpcContext{}, params)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	j, _ := json.Marshal(result)
+	var out map[string]any
+	if err := json.Unmarshal(j, &out); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	return out, nil
+}
+
+func TestRPC_Manifest_ReturnsStoredState_ByMasterKey(t *testing.T) {
+	cache, master, ephemeral, serialized := buildAndApplyManifest(t)
+	withServices(t, cache)
+
+	masterB58, err := addresscodec.EncodeNodePublicKey(master[:])
+	if err != nil {
+		t.Fatalf("encode master: %v", err)
+	}
+	ephemeralB58, err := addresscodec.EncodeNodePublicKey(ephemeral[:])
+	if err != nil {
+		t.Fatalf("encode ephemeral: %v", err)
+	}
+
+	out, rpcErr := callManifestRPC(t, masterB58)
+	if rpcErr != nil {
+		t.Fatalf("rpc error: %v", rpcErr)
+	}
+
+	if out["requested"] != masterB58 {
+		t.Fatalf("requested: got %v want %s", out["requested"], masterB58)
+	}
+	b64, _ := out["manifest"].(string)
+	if b64 == "" {
+		t.Fatal("manifest field empty")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil || !bytes.Equal(decoded, serialized) {
+		t.Fatalf("manifest bytes mismatch: err=%v", err)
+	}
+	details, _ := out["details"].(map[string]any)
+	if details["master_key"] != masterB58 {
+		t.Fatalf("details.master_key: got %v want %s", details["master_key"], masterB58)
+	}
+	if details["ephemeral_key"] != ephemeralB58 {
+		t.Fatalf("details.ephemeral_key: got %v want %s", details["ephemeral_key"], ephemeralB58)
+	}
+	if seq, ok := details["seq"].(float64); !ok || uint32(seq) != 7 {
+		t.Fatalf("details.seq: got %v want 7", details["seq"])
+	}
+	if details["domain"] != "example.org" {
+		t.Fatalf("details.domain: got %v want example.org", details["domain"])
+	}
+}
+
+func TestRPC_Manifest_ByEphemeralKey_ResolvesToMaster(t *testing.T) {
+	cache, master, ephemeral, _ := buildAndApplyManifest(t)
+	withServices(t, cache)
+
+	masterB58, _ := addresscodec.EncodeNodePublicKey(master[:])
+	ephemeralB58, _ := addresscodec.EncodeNodePublicKey(ephemeral[:])
+
+	// Query with the EPHEMERAL key — the handler must resolve up to
+	// the master via GetMasterKey and return the master in details.
+	out, rpcErr := callManifestRPC(t, ephemeralB58)
+	if rpcErr != nil {
+		t.Fatalf("rpc error: %v", rpcErr)
+	}
+	if out["requested"] != ephemeralB58 {
+		t.Fatalf("requested echoed wrong: %v", out["requested"])
+	}
+	details, _ := out["details"].(map[string]any)
+	if details["master_key"] != masterB58 {
+		t.Fatalf("details.master_key not resolved to master: got %v", details["master_key"])
+	}
+}
+
+func TestRPC_Manifest_UnknownKey_ReturnsSparseResponse(t *testing.T) {
+	cache := manifest.NewCache()
+	withServices(t, cache)
+
+	unknownBytes, _ := deterministicEd25519KeypairRPC(0x99)
+	unknownB58, _ := addresscodec.EncodeNodePublicKey(unknownBytes)
+
+	out, rpcErr := callManifestRPC(t, unknownB58)
+	if rpcErr != nil {
+		t.Fatalf("rpc error: %v", rpcErr)
+	}
+	if out["requested"] != unknownB58 {
+		t.Fatalf("requested: %v", out["requested"])
+	}
+	if _, ok := out["manifest"]; ok {
+		t.Fatal("manifest field should be absent for unknown key")
+	}
+	if _, ok := out["details"]; ok {
+		t.Fatal("details field should be absent for unknown key")
+	}
+}
+
+func TestRPC_Manifest_MissingPublicKey_InvalidParams(t *testing.T) {
+	cache := manifest.NewCache()
+	withServices(t, cache)
+
+	_, rpcErr := callManifestRPC(t, "")
+	if rpcErr == nil {
+		t.Fatal("expected error on missing public_key")
+	}
+}

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -17,6 +17,27 @@ type MethodDispatcher interface {
 	ExecuteMethod(method string, params []byte) (interface{}, *RpcError)
 }
 
+// ManifestLookup is the read-only facet of the validator-manifest cache
+// that the `manifest` RPC needs. Expressed as an interface (not a
+// concrete type) so internal/rpc/types doesn't import
+// internal/manifest, avoiding a cycle once the handler grows.
+type ManifestLookup interface {
+	// GetMasterKey resolves an ephemeral signing key to its master
+	// key via the cached manifest. Returns the input unchanged if no
+	// manifest maps it — matches rippled ManifestCache::getMasterKey.
+	GetMasterKey(signingKey [33]byte) [33]byte
+	// GetSigningKey returns the current ephemeral signing key for a
+	// master key, or false if unknown / revoked.
+	GetSigningKey(masterKey [33]byte) ([33]byte, bool)
+	// GetManifest returns the raw serialized manifest bytes for a
+	// master key, or false if unknown / revoked.
+	GetManifest(masterKey [33]byte) ([]byte, bool)
+	// GetSequence returns the stored manifest's sequence number.
+	GetSequence(masterKey [33]byte) (uint32, bool)
+	// GetDomain returns the stored manifest's domain.
+	GetDomain(masterKey [33]byte) (string, bool)
+}
+
 // ServiceContainer holds references to all services needed by RPC handlers
 type ServiceContainer struct {
 	// LedgerService provides ledger operations
@@ -36,6 +57,12 @@ type ServiceContainer struct {
 
 	// LastCloseInfo returns proposer count and convergence time (ms) from the last consensus round
 	LastCloseInfo func() (proposers int, convergeTimeMs int)
+
+	// Manifests is the validator-manifest lookup used by the
+	// `manifest` RPC method. Nil until the consensus components are
+	// built (e.g. in standalone mode without p2p); handlers must
+	// nil-check before use.
+	Manifests ManifestLookup
 }
 
 // LedgerNavigator provides ledger index navigation and mode queries.

--- a/tasks/pr-manifests-round1.md
+++ b/tasks/pr-manifests-round1.md
@@ -1,0 +1,80 @@
+# PR: Validator manifests + master-key translation (issue #265)
+
+Implements the first round of validator manifest infrastructure: ingest/verify/store TMManifests, translate ephemeral signing keys to master keys before UNL / quorum decisions, and back the `manifest` RPC.
+
+Out-of-band manifest publication (validator sites, validators.txt) is out of scope — to be covered in a follow-up PR.
+
+## Rippled reference map
+
+| Concern | Rippled file:line |
+|---|---|
+| STObject parse, revoked / verify | `src/xrpld/app/misc/detail/Manifest.cpp:53-241` |
+| `ManifestCache::applyManifest` | `src/xrpld/app/misc/detail/Manifest.cpp:382-580` |
+| `getMasterKey` / `getSigningKey` | `src/xrpld/app/misc/detail/Manifest.cpp:310-332` |
+| Peer inbound `TMManifests` | `src/xrpld/overlay/detail/PeerImp.cpp:1068-1085` |
+| Overlay batch-apply + gossip relay | `src/xrpld/overlay/detail/OverlayImpl.cpp:633-686` |
+| Ephemeral→master for validations | `src/xrpld/app/consensus/RCLValidations.cpp:165-186` |
+| `getTrustedKey` lookup | `src/xrpld/app/misc/detail/ValidatorList.cpp:1479-1494` |
+| Manifest RPC | `src/xrpld/rpc/handlers/DoManifest.cpp:29-76` |
+| Signing blob for verify | `src/libxrpl/protocol/Sign.cpp:47-62` (`addWithoutSigningFields` + `HashPrefix::manifest`) |
+
+## Design decisions
+
+- **Package**: new `internal/manifest/` with exported type `Cache`. Consumed by the consensus router (ingest), validation tracker (lookup), and RPC handlers. Kept `internal/` until we have a reason to export — nothing else in the tree exports consensus infrastructure.
+- **Decode path**: reuse `codec/binarycodec`. `Decode(hex)` produces a JSON map; re-`Encode` after `removeNonSigningFields` gives the canonical signing preimage — the same path rippled's `addWithoutSigningFields` takes. No new STObject walker needed.
+- **Signature verify**: `HashPrefix::manifest` (0x4D414E00, already defined as `protocol.HashPrefixManifest`) prepended to the signing preimage; dispatch on key-type prefix byte (0xED → ed25519, 0x02/0x03 → secp256k1) via existing `crypto/ed25519` and `crypto/secp256k1` `Validate`. Both already match rippled's hash/no-hash semantics for their respective key types.
+- **Revocation marker**: `sequence == math.MaxUint32`. Revoked manifests must NOT carry SigningPubKey or Signature (rippled Manifest.cpp:120-129).
+- **Higher-seq-wins**: strictly greater than stored seq (rippled uses `<=` reject — so we accept only `new.seq > stored.seq`).
+- **Invariants enforced on apply** (all matching rippled):
+  - master key may not appear as another manifest's ephemeral key (`badMasterKey`);
+  - ephemeral key may not appear as another's ephemeral or master (`badEphemeralKey`);
+  - signing key != master key;
+  - signature must verify before storage.
+- **Relay**: on `accepted` disposition, re-broadcast the raw manifest payload to all peers except the origin. Reuse a small `OverlayBroadcastExcept` helper (add if absent) rather than per-validator squelch — rippled uses overlay-wide foreach for manifests, not the squelch-filtered gossip path.
+- **Translation seam in consensus**: `ValidationTracker.SetManifestResolver(func(NodeID) NodeID)` injected at construction time. `Add()` (and the callers of `IsFullyValidated`/`GetTrustedValidationCount` on the read side) route the signing `NodeID` through the resolver before looking up `trusted[]`. This keeps the manifest dependency one-directional (tracker depends on a function, not on the `manifest` package) and leaves the existing tests unchanged when the resolver is the identity function.
+
+## Files
+
+### New
+- `internal/manifest/manifest.go` — `Manifest` struct (masterKey, signingKey, sequence, domain, serialized, masterSig, ephemeralSig) + `Deserialize([]byte)` + `Verify()` + `Revoked()`.
+- `internal/manifest/cache.go` — `Cache` type, `ApplyManifest(*Manifest) Disposition`, `GetMasterKey(ephemeral [33]byte) [33]byte`, `GetSigningKey(master [33]byte) ([33]byte, bool)`, `GetManifest(master [33]byte) ([]byte, bool)`, `GetSequence(master [33]byte) (uint32, bool)`, `GetDomain(master [33]byte) (string, bool)`, `Revoked(master [33]byte) bool`. `Disposition` enum: `Accepted`, `Stale`, `Invalid`, `BadMasterKey`, `BadEphemeralKey`, `Revoked`.
+- `internal/manifest/manifest_test.go` — wire-decode golden-vector tests; applyManifest sequence / revocation / conflict tests.
+- `internal/consensus/rcl/manifest_resolver_test.go` — asserts `ValidationTracker` routes lookups through the resolver.
+
+### Modified
+- `internal/consensus/rcl/validations.go` — add `resolver func(NodeID) NodeID` field + `SetManifestResolver`; thread resolver through `Add`, `GetTrustedValidations`, `GetTrustedValidationCount`, `ProposersValidated`. Identity default preserves existing behavior.
+- `internal/consensus/adaptor/router.go` — add `handleManifests(msg)`; dispatch from `handleMessage` on `TypeManifests`. Construct & hold `*manifest.Cache` (passed via `NewRouter`).
+- `internal/consensus/adaptor/startup.go` — instantiate cache, pass to `NewRouter`, wire `cache.GetMasterKey` into the tracker via `SetManifestResolver`.
+- `internal/peermanagement/overlay.go` — add `BroadcastExcept(PeerID, []byte)` if not already reachable via existing helper; otherwise call through existing API.
+- `internal/rpc/handlers/manifest.go` — drop stub; accept a `ManifestCache` dependency on the handler and implement the lookup + response shape from DoManifest.cpp.
+- `internal/rpc/types/services.go` — add `ManifestCache` interface (`GetMasterKey`, `GetSigningKey`, `GetManifest`, `GetSequence`, `GetDomain`).
+- `internal/rpc/server.go` (or wherever handlers are registered) — plumb the cache into the context.
+
+## Acceptance tests
+
+All in `internal/testing/manifest/` (matches per-feature directory convention). Use deterministic ed25519 keypairs built from seeded randomness so tests are repro across runs.
+
+1. **`TestManifest_WireDecode_ValidMasterSig_Accepted`** — construct a valid manifest (seq=1), serialize, verify `Deserialize` + `Verify` + `Cache.ApplyManifest` all succeed.
+2. **`TestManifest_WireDecode_BadMasterSig_Rejected`** — flip a byte in the master signature after serialization; `Cache.ApplyManifest` returns `Invalid`; cache is empty after.
+3. **`TestManifest_HigherSeq_Overrides`** — apply seq=1, then seq=2 with a new ephemeral key; `GetSigningKey(master)` returns the seq=2 ephemeral; applying the seq=1 again returns `Stale`.
+4. **`TestManifest_RevokedMasterKey_Rejected`** — apply a revocation manifest (seq=MaxUint32, no ephemeral fields); subsequent `GetSigningKey(master)` returns `!ok` and `GetMasterKey(oldEphemeral)` no longer resolves.
+5. **`TestConsensus_EphemeralSigningKey_TranslatedForQuorum`** — build a `ValidationTracker` with `SetTrusted([master])` and `SetManifestResolver(cache.GetMasterKey)`; `Add` a validation signed by the ephemeral key (so its `NodeID == ephemeral`); assert `IsFullyValidated` fires with quorum=1 even though `ephemeral` is not in `trusted`.
+6. **`TestRPC_Manifest_ReturnsStoredState`** — apply a manifest to the cache; call the RPC with `public_key=ephemeral_base58`; assert response `details.master_key`, `details.ephemeral_key`, `details.seq`, and `manifest` (base64) match the input.
+
+## Out of scope (deferred, will link in follow-up)
+
+- Out-of-band manifest publication (fetching from validator sites / `validators.txt`).
+- Persistence of manifests to disk across restarts (rippled writes to Wallet DB for UNL-member masters).
+- `pubManifest` subscription stream.
+- Emitting our own manifest (we don't rotate ephemeral keys yet).
+
+## Verification plan
+
+```
+go build ./...
+go test ./internal/manifest/...
+go test ./internal/consensus/rcl/... -run ManifestResolver
+go test ./internal/testing/manifest/...
+go test ./internal/rpc/handlers/... -run Manifest
+./scripts/conformance-summary.sh | tail -20    # no regressions in existing suites
+```


### PR DESCRIPTION
## Summary

Implements issue #265 — validator manifest infrastructure so a validator that rotates its ephemeral signing key still counts toward UNL quorum instead of appearing as a new untrusted node.

- **`internal/manifest/`** — `Cache` keyed by master pubkey, STObject deserialize, two-signature verify (`HashPrefix("MAN\0") || canonical body`, ed25519/secp256k1 dispatch), strict higher-seq-wins, revocation at `seq=MaxUint32`, key-reuse invariants.
- **Consensus** — `ValidationTracker.SetManifestResolver` + `Engine.SetManifestResolver`; signing key → master resolved at `Add()` so `trusted`/`negUNL`/`byNode`/quorum all operate on master keys. Mirrors rippled `RCLValidations.cpp:165-186`.
- **Wire** — `Router.handleManifests` ingests `TMManifests`, charges `badData` on invalid/bad-key dispositions, relays `Accepted` via new `Overlay.BroadcastExcept`.
- **RPC** — `manifest` handler returns `{master_key, ephemeral_key, seq, domain}` + base64 manifest, matching rippled `DoManifest.cpp`.
- **Startup** — one shared cache threaded through router + engine + RPC (`types.Services.Manifests`).

Plan file: [`tasks/pr-manifests-round1.md`](../blob/feature/manifests-265/tasks/pr-manifests-round1.md).

## Out of scope (follow-ups)

- Out-of-band manifest publication (validator sites / `validators.txt`).
- Disk persistence across restarts.
- `pubManifest` subscription stream.
- Emitting our own manifest (we don't rotate yet).

## Test plan

All 14 new tests pass locally:

- [x] `TestManifest_WireDecode_ValidMasterSig_Accepted`
- [x] `TestManifest_WireDecode_BadMasterSig_Rejected`
- [x] `TestManifest_HigherSeq_Overrides`
- [x] `TestManifest_RevokedMasterKey_Rejected`
- [x] `TestManifest_NonRevoked_MissingEphemeral_Rejected`
- [x] `TestManifest_Revoked_WithEphemeral_Rejected`
- [x] `TestConsensus_EphemeralSigningKey_TranslatedForQuorum`
- [x] `TestConsensus_NoResolver_EphemeralNotTrusted`
- [x] `TestRouter_HandleManifests_AppliesAccepted`
- [x] `TestRouter_HandleManifests_InvalidDoesNotStore`
- [x] `TestRPC_Manifest_ReturnsStoredState_ByMasterKey`
- [x] `TestRPC_Manifest_ByEphemeralKey_ResolvesToMaster`
- [x] `TestRPC_Manifest_UnknownKey_ReturnsSparseResponse`
- [x] `TestRPC_Manifest_MissingPublicKey_InvalidParams`

Full sweep of modified packages (`internal/manifest`, `internal/consensus/...`, `internal/peermanagement`, `internal/rpc/handlers`, `internal/rpc/types`, `internal/cli`) is green. AMM conformance flakiness (4–7 failing across runs) pre-exists on `main` and is unrelated — no AMM code is touched.

Closes #265.