### PR TITLE
feat(consensus/rcl): wire per-tx dispute tracking through convergence (E2)

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -44,13 +44,22 @@ type NetworkSender interface {
 	// to other peers, subject to the per-peer squelch filter and
 	// excluding exceptPeer (the originator). Pass 0 for exceptPeer to
 	// broadcast to all peers unfiltered — used only by synthetic test
-	// paths.
+	// paths. Proposal.SuppressionHash / Validation.SuppressionHash
+	// (populated by the consensus router) is used by the overlay to
+	// record each recipient under that key so a later duplicate from a
+	// different peer can look up the whole known-haver set and feed
+	// the reduce-relay slot with all of them (B3,
+	// PeerImp.cpp:3010-3017 / 3044-3054).
 	RelayProposal(proposal *consensus.Proposal, exceptPeer uint64) error
 	RelayValidation(validation *consensus.Validation, exceptPeer uint64) error
 	// UpdateRelaySlot feeds the reduce-relay slot for validatorKey with
-	// a message from peerID. Drives the mtSQUELCH selection logic.
-	// Mirrors rippled's PeerImp::updateSlotAndSquelch.
-	UpdateRelaySlot(validatorKey []byte, peerID uint64)
+	// originPeer AND every peer in seenPeers (peers known to already
+	// have the message per the overlay's reverse index). Drives the
+	// mtSQUELCH selection logic. Mirrors rippled's
+	// PeerImp::updateSlotAndSquelch with the full haveMessage set at
+	// PeerImp.cpp:3013-3017. Implementations dedupe originPeer from
+	// seenPeers to avoid double-counting.
+	UpdateRelaySlot(validatorKey []byte, originPeer uint64, seenPeers []uint64)
 	RequestTxSet(id consensus.TxSetID) error
 	RequestLedger(id consensus.LedgerID) error
 	RequestLedgerByHashAndSeq(hash [32]byte, seq uint32) error
@@ -78,6 +87,14 @@ type NetworkSender interface {
 	// response (replay delta, ledger data, etc.) fails. Safe no-op for
 	// unknown peers. `reason` is a short stable label for logs.
 	IncPeerBadData(peerID uint64, reason string)
+	// PeersThatHave returns the set of peer IDs the overlay knows have
+	// the message whose router-level suppression hash is
+	// suppressionHash (populated during outbound relay). Returns nil if
+	// unknown or the bucket has aged out. B3: the router uses this to
+	// feed the reduce-relay slot with all known-havers on a duplicate
+	// arrival, matching rippled's haveMessage set semantics
+	// (PeerImp.cpp:3010-3017).
+	PeersThatHave(suppressionHash [32]byte) []uint64
 }
 
 // noopSender is a no-op NetworkSender for standalone or test use.
@@ -88,7 +105,7 @@ func (n *noopSender) BroadcastValidation(*consensus.Validation) error          {
 func (n *noopSender) BroadcastStatusChange(*message.StatusChange) error        { return nil }
 func (n *noopSender) RelayProposal(*consensus.Proposal, uint64) error          { return nil }
 func (n *noopSender) RelayValidation(*consensus.Validation, uint64) error      { return nil }
-func (n *noopSender) UpdateRelaySlot([]byte, uint64)                           {}
+func (n *noopSender) UpdateRelaySlot([]byte, uint64, []uint64)                 {}
 func (n *noopSender) RequestTxSet(consensus.TxSetID) error                     { return nil }
 func (n *noopSender) RequestLedger(consensus.LedgerID) error                   { return nil }
 func (n *noopSender) RequestLedgerByHashAndSeq([32]byte, uint32) error         { return nil }
@@ -99,6 +116,7 @@ func (n *noopSender) SendToPeer(uint64, []byte) error                          {
 func (n *noopSender) PeerSupportsReplay(uint64) bool                           { return false }
 func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64       { return nil }
 func (n *noopSender) IncPeerBadData(uint64, string)                            {}
+func (n *noopSender) PeersThatHave([32]byte) []uint64                          { return nil }
 
 // Compile-time interface check.
 var _ consensus.Adaptor = (*Adaptor)(nil)
@@ -312,26 +330,41 @@ func (a *Adaptor) BroadcastValidation(validation *consensus.Validation) error {
 	return a.sender.BroadcastValidation(validation)
 }
 
+// PeersThatHave returns the set of peer IDs the overlay knows have
+// the message whose suppression-hash is `suppressionHash`. Thin
+// delegate to NetworkSender.PeersThatHave so higher layers (the
+// consensus router) can query without pulling in the overlay import.
+func (a *Adaptor) PeersThatHave(suppressionHash [32]byte) []uint64 {
+	return a.sender.PeersThatHave(suppressionHash)
+}
+
 // RelayProposal forwards a peer-originated proposal to other peers,
 // excluding exceptPeer (the originator). Pass 0 for exceptPeer to
-// forward to everyone.
+// forward to everyone. Uses proposal.SuppressionHash (populated by
+// the consensus router) so the overlay can record each recipient in
+// its reverse index — queried by the router on later duplicates to
+// feed the full known-haver set into the reduce-relay slot (B3).
 func (a *Adaptor) RelayProposal(proposal *consensus.Proposal, exceptPeer uint64) error {
 	return a.sender.RelayProposal(proposal, exceptPeer)
 }
 
 // RelayValidation forwards a peer-originated validation to other peers,
-// excluding exceptPeer (the originator). Mirrors RelayProposal; used
-// by the engine's OnValidation to implement gossip forward.
+// excluding exceptPeer (the originator). Mirrors RelayProposal; uses
+// validation.SuppressionHash for the reverse-index record.
 func (a *Adaptor) RelayValidation(validation *consensus.Validation, exceptPeer uint64) error {
 	return a.sender.RelayValidation(validation, exceptPeer)
 }
 
-// UpdateRelaySlot feeds the reduce-relay slot for validatorKey with an
-// inbound message from peerID. Called by the consensus router on every
-// trusted proposal/validation to keep the squelch selection logic
-// moving. Mirrors rippled's PeerImp::updateSlotAndSquelch.
-func (a *Adaptor) UpdateRelaySlot(validatorKey []byte, peerID uint64) {
-	a.sender.UpdateRelaySlot(validatorKey, peerID)
+// UpdateRelaySlot feeds the reduce-relay slot for validatorKey with
+// originPeer AND every peer in seenPeers (known-havers). Called by
+// the consensus router on every trusted proposal/validation duplicate
+// to keep the squelch selection logic moving. Mirrors rippled's
+// PeerImp::updateSlotAndSquelch with the full haveMessage set at
+// PeerImp.cpp:3013-3017 — feeding multiple known-havers per
+// duplicate is what lets selection converge at the same rate rippled
+// does (B3).
+func (a *Adaptor) UpdateRelaySlot(validatorKey []byte, originPeer uint64, seenPeers []uint64) {
+	a.sender.UpdateRelaySlot(validatorKey, originPeer, seenPeers)
 }
 
 func (a *Adaptor) RequestTxSet(id consensus.TxSetID) error {

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -854,15 +854,15 @@ func (r *Router) handleReplayDeltaResponse(msg *peermanagement.InboundMessage) {
 // LedgerDeltaAcquire.cpp:209 which installs the peer-provided tx-blob
 // tree alongside the state map.
 //
-// R5.17 follow-up: rippled's LedgerMaster::tryAdvance cascades
-// follow-on adoptions when an out-of-order replay-delta arrival
-// unblocks a previously-held child ledger. goXRPL does not yet
-// maintain a held-ledgers queue, so out-of-order arrivals simply
-// wait for the next statusChange / replay-delta cycle to re-trigger.
-// This is a catchup-speed issue, not a safety issue. A full
-// tryAdvance port is tracked separately (requires a new held-ledgers
-// map in internal/ledger/service plus signaling from the router to
-// the service on each adoption).
+// F6: routed through SubmitHeldAdoption rather than AdoptLedgerWithState.
+// This gives us rippled's tryAdvance behavior for free: if the awaited
+// parent seq is already in history and its hash matches the verified
+// ledger's ParentHash, SubmitHeldAdoption fast-paths into the immediate
+// adopt (same call-shape as before). If the parent hasn't landed yet
+// — i.e. the replay-delta arrived out of order — the ledger is stashed
+// in the held-adoptions map keyed by its awaited parent seq, and
+// cascade-promoted automatically from inside the parent's eventual
+// adopt. The router no longer needs to observe ordering.
 func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
@@ -881,7 +881,7 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
 	if err != nil {
 		return fmt.Errorf("snapshot tx map: %w", err)
 	}
-	if err := svc.AdoptLedgerWithState(&hdr, stateMap, txMap); err != nil {
+	if err := svc.SubmitHeldAdoption(&hdr, stateMap, txMap); err != nil {
 		return fmt.Errorf("adopt with state: %w", err)
 	}
 	if r.adaptor.GetOperatingMode() < consensus.OpModeTracking {
@@ -1151,10 +1151,17 @@ func (r *Router) completeInboundLedger() {
 
 	// Legacy header+state catchup path: no per-ledger tx tree is
 	// fetched in this mode (only the header and state map), so pass
-	// nil and let AdoptLedgerWithState install the genesis-shaped
-	// empty tx map. The replay-delta path at adoptVerifiedLedger
-	// (below) passes the verified tx map — see R5.1.
-	if err := svc.AdoptLedgerWithState(h, stateMap, nil); err != nil {
+	// nil and let the service install the genesis-shaped empty tx
+	// map. The replay-delta path at adoptVerifiedLedger (above)
+	// passes the verified tx map — see R5.1.
+	//
+	// F6: same as the replay-delta path, route through
+	// SubmitHeldAdoption so out-of-order catchup arrivals either
+	// fast-path (parent already present) or stash for cascade when
+	// the awaited parent lands. Legacy mtGET_LEDGER is sequential at
+	// the wire level today, but nothing in the protocol forbids
+	// interleaving — the held-queue is the correct seam regardless.
+	if err := svc.SubmitHeldAdoption(h, stateMap, nil); err != nil {
 		r.logger.Warn("inbound ledger: failed to adopt with state", "error", err)
 		return
 	}

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -412,9 +412,18 @@ func validateProposeBounds(p *message.ProposeSet) (string, bool) {
 	if n := len(p.Signature); n < signatureMinLen || n > signatureMaxLen {
 		return "sig-size", false
 	}
-	// Node pubkey is always a 33-byte compressed secp256k1 point.
+	// Proposal pubkeys must be compressed secp256k1 (0x02/0x03 prefix).
+	// ed25519 validators (0xED prefix) are not allowed in propose-set
+	// per rippled PeerImp.cpp:1679-1680
+	// (publicKeyType(...) != KeyType::secp256k1). The length-only check
+	// would pass a 33-byte ed25519 key (0xED || 32 bytes), letting the
+	// peer slip through without attribution, so the prefix gate runs
+	// alongside the size gate.
 	if len(p.NodePubKey) != 33 {
 		return "pubkey-size", false
+	}
+	if p.NodePubKey[0] != 0x02 && p.NodePubKey[0] != 0x03 {
+		return "pubkey-type", false
 	}
 	return "", true
 }

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -293,9 +293,13 @@ func (r *Router) handleProposal(msg *peermanagement.InboundMessage) {
 	originPeer := uint64(msg.PeerID)
 
 	// Record duplicate-status + last-sighting BEFORE OnProposal.
-	// Hash the raw payload: rippled's HashRouter semantics — same
-	// bytes from different peers => "duplicate".
-	firstSeen, lastSeen := r.messageSeen.observe(hashPayload(msg.Payload))
+	// Hash the DECODED fields via hashProposalSuppression (matches
+	// rippled's proposalUniqueId at RCLCxPeerPos.cpp:66-83). Hashing
+	// the raw protobuf envelope would desync dedup from rippled peers
+	// that see the same message with different optional-field framing
+	// (e.g., deprecated `hops` included or omitted) — same semantic
+	// proposal, but different byte payload.
+	firstSeen, lastSeen := r.messageSeen.observe(hashProposalSuppression(proposal))
 
 	if err := r.engine.OnProposal(proposal, originPeer); err != nil {
 		r.logger.Debug("engine rejected proposal", "error", err, "peer", msg.PeerID)
@@ -346,9 +350,16 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 
 	originPeer := uint64(msg.PeerID)
 
-	// Observe-before-engine for consistent duplicate accounting —
-	// same rationale as handleProposal.
-	firstSeen, lastSeen := r.messageSeen.observe(hashPayload(msg.Payload))
+	// Observe-before-engine for consistent duplicate accounting. Hash
+	// the INNER STValidation blob carried in TMValidation.validation —
+	// matches rippled's PeerImp.cpp:2374 (`sha512Half(makeSlice(
+	// m->validation()))`). Hashing the TMValidation envelope instead
+	// would desync dedup from rippled peers the same way handleProposal
+	// would if it hashed the TMProposeSet envelope: deprecated outer
+	// fields vary, inner canonical blob does not. We use the raw
+	// inbound bytes here — NOT a re-serialized copy — so a lossy or
+	// reordered round-trip can't silently diverge the hash.
+	firstSeen, lastSeen := r.messageSeen.observe(hashValidationSuppression(val.Validation))
 
 	if err := r.engine.OnValidation(validation, originPeer); err != nil {
 		r.logger.Debug("engine rejected validation", "error", err, "peer", msg.PeerID)

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -299,7 +299,13 @@ func (r *Router) handleProposal(msg *peermanagement.InboundMessage) {
 	// that see the same message with different optional-field framing
 	// (e.g., deprecated `hops` included or omitted) — same semantic
 	// proposal, but different byte payload.
-	firstSeen, lastSeen := r.messageSeen.observe(hashProposalSuppression(proposal))
+	//
+	// B3: stash the hash on the Proposal so the downstream relay path
+	// can thread it to Overlay's reverse index without recomputing
+	// (matches rippled's RCLCxPeerPos::suppressionID() instance member).
+	suppressionHash := hashProposalSuppression(proposal)
+	proposal.SuppressionHash = suppressionHash
+	firstSeen, lastSeen := r.messageSeen.observe(suppressionHash)
 
 	if err := r.engine.OnProposal(proposal, originPeer); err != nil {
 		r.logger.Debug("engine rejected proposal", "error", err, "peer", msg.PeerID)
@@ -314,8 +320,16 @@ func (r *Router) handleProposal(msg *peermanagement.InboundMessage) {
 	// (trust-specific branching happens later for relay decisions).
 	// Gating on trust pre-R5.7 under-squelched untrusted gossip
 	// vs. what the rest of the network does.
+	//
+	// B3: feed the slot with the FULL set of known-havers, not just
+	// originPeer. seenPeers is the overlay's reverse-index entry
+	// populated when we previously relayed this message outward —
+	// matching rippled's haveMessage set from overlay_.relay
+	// (PeerImp.cpp:3010-3017) which is then passed whole to
+	// updateSlotAndSquelch.
 	if !firstSeen && time.Since(lastSeen) < peermanagement.Idled {
-		r.adaptor.UpdateRelaySlot(proposal.NodeID[:], originPeer)
+		seenPeers := r.adaptor.PeersThatHave(suppressionHash)
+		r.adaptor.UpdateRelaySlot(proposal.NodeID[:], originPeer, seenPeers)
 	}
 }
 
@@ -359,7 +373,13 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 	// fields vary, inner canonical blob does not. We use the raw
 	// inbound bytes here — NOT a re-serialized copy — so a lossy or
 	// reordered round-trip can't silently diverge the hash.
-	firstSeen, lastSeen := r.messageSeen.observe(hashValidationSuppression(val.Validation))
+	// B3: stash the hash on the Validation so the downstream relay
+	// path can thread it to Overlay's reverse index without
+	// recomputing (matches rippled's pattern of computing
+	// sha512Half(m->validation()) once per inbound and carrying it).
+	suppressionHash := hashValidationSuppression(val.Validation)
+	validation.SuppressionHash = suppressionHash
+	firstSeen, lastSeen := r.messageSeen.observe(suppressionHash)
 
 	if err := r.engine.OnValidation(validation, originPeer); err != nil {
 		r.logger.Debug("engine rejected validation", "error", err, "peer", msg.PeerID)
@@ -367,9 +387,11 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 	}
 
 	// Same IDLED-gated, no-trust-gate feeding as handleProposal.
-	// Mirrors rippled's TMValidation path at PeerImp.cpp:2385.
+	// Mirrors rippled's TMValidation path at PeerImp.cpp:2385 and the
+	// B3 haveMessage expansion at PeerImp.cpp:3049-3054.
 	if !firstSeen && time.Since(lastSeen) < peermanagement.Idled {
-		r.adaptor.UpdateRelaySlot(validation.NodeID[:], originPeer)
+		seenPeers := r.adaptor.PeersThatHave(suppressionHash)
+		r.adaptor.UpdateRelaySlot(validation.NodeID[:], originPeer, seenPeers)
 	}
 }
 

--- a/internal/consensus/adaptor/router_dedup.go
+++ b/internal/consensus/adaptor/router_dedup.go
@@ -1,21 +1,132 @@
 package adaptor
 
 import (
+	"encoding/binary"
 	"sync"
 	"time"
 
 	"github.com/LeJamon/goXRPLd/crypto/common"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
 )
 
-// hashPayload returns the sha512Half of payload bytes — the same hash
-// function rippled uses for HashRouter suppression keys. Using
-// sha512Half here (vs. a cheaper sha256) keeps the hash function
-// consistent with the rest of the protocol and rules out the
-// theoretical case where a crafted payload produces the same
-// sha256-truncated hash as a legitimate one. The 32-byte output keys
-// the dedup map directly.
-func hashPayload(payload []byte) [32]byte {
-	return common.Sha512Half(payload)
+// xrplEpochUnixOffset is the delta between Unix epoch (1970-01-01) and
+// XRPL NetClock epoch (2000-01-01). The proposal close-time field on
+// the wire — and in rippled's proposalUniqueId hash input — is seconds
+// since the XRPL epoch, NOT seconds since Unix epoch. Keeping this
+// separate from the converter.go alias documents intent at the call
+// site where the difference matters most (divergent hashes = dedup
+// desync across mixed Go/rippled peers).
+const xrplEpochUnixOffset int64 = 946684800
+
+// hashProposalSuppression returns the suppression key for a proposal,
+// matching rippled's proposalUniqueId at
+// rippled/src/xrpld/app/consensus/RCLCxPeerPos.cpp:66-83:
+//
+//	Serializer s(512);
+//	s.addBitString(proposeHash);
+//	s.addBitString(previousLedger);
+//	s.add32(proposeSeq);
+//	s.add32(closeTime.time_since_epoch().count());
+//	s.addVL(publicKey);
+//	s.addVL(signature);
+//	return s.getSHA512Half();
+//
+// Key layout properties mirrored here:
+//   - `addBitString` writes raw bytes (no length prefix, fixed-size hash).
+//   - `add32` is BIG-endian 4 bytes.
+//   - `add32(closeTime.time_since_epoch().count())` feeds the XRPL
+//     NetClock count — seconds since the XRPL epoch (2000-01-01 UTC),
+//     NOT Unix epoch. We derive that count from Proposal.CloseTime via
+//     `Unix() - xrplEpochUnixOffset`, exactly matching the converter's
+//     wire-format convention.
+//   - `addVL` writes rippled's variable-length length prefix (1–3 bytes,
+//     see Serializer::addEncoded) followed by the raw bytes. For the
+//     33-byte compressed pubkey and 64–72-byte DER signature we'll
+//     always use, the length prefix is a single byte (<=192).
+//
+// Why this matters (B2): rippled computes the suppression key from
+// these structured fields. A Go peer that hashes the raw TMProposeSet
+// protobuf envelope instead would compute a different key for the same
+// proposal — breaking HashRouter parity across mixed-implementation
+// peer sets (semantically-identical messages with different protobuf
+// framing would be registered twice on one side and once on the other,
+// desynchronizing reduce-relay slot feeding).
+func hashProposalSuppression(p *consensus.Proposal) [32]byte {
+	// Fixed-size segments totalling 72 bytes (32 + 32 + 4 + 4) plus the
+	// VL-encoded pubkey (1 + 33 = 34) and signature (1 + up to 72 = up
+	// to 73). Preallocate 180 — one allocation, no resizing on the
+	// common path.
+	buf := make([]byte, 0, 180)
+
+	// addBitString(proposeHash) — 32 raw bytes, no length prefix.
+	buf = append(buf, p.TxSet[:]...)
+	// addBitString(previousLedger) — 32 raw bytes.
+	buf = append(buf, p.PreviousLedger[:]...)
+	// add32(proposeSeq) — big-endian uint32.
+	buf = binary.BigEndian.AppendUint32(buf, p.Position)
+	// add32(closeTime.time_since_epoch().count()) — big-endian uint32
+	// of the XRPL NetClock count (seconds since 2000-01-01).
+	// Negative pre-epoch times cannot occur for a well-formed proposal
+	// (signing time is always post-epoch); clamp at zero so a bogus
+	// pre-epoch Time still produces a deterministic hash rather than
+	// wrapping to a large positive uint32.
+	var closeTimeSec uint32
+	if ct := p.CloseTime.Unix() - xrplEpochUnixOffset; ct > 0 {
+		closeTimeSec = uint32(ct)
+	}
+	buf = binary.BigEndian.AppendUint32(buf, closeTimeSec)
+	// addVL(publicKey) — length prefix + NodeID (33-byte compressed key).
+	buf = appendVLPrefix(buf, len(p.NodeID))
+	buf = append(buf, p.NodeID[:]...)
+	// addVL(signature) — length prefix + raw signature bytes.
+	buf = appendVLPrefix(buf, len(p.Signature))
+	buf = append(buf, p.Signature...)
+
+	return common.Sha512Half(buf)
+}
+
+// hashValidationSuppression returns the suppression key for a
+// validation, matching rippled's PeerImp.cpp:2374:
+//
+//	auto key = sha512Half(makeSlice(m->validation()));
+//
+// The input is the inner, canonical STValidation blob as carried in
+// the `validation` field of the TMValidation protobuf — NOT the
+// protobuf envelope itself. Callers must pass the decoded inner blob
+// (`*message.Validation.Validation`), and MUST NOT re-serialize it
+// from the parsed consensus.Validation struct: STValidation field
+// ordering rules mean a round-trip can produce different bytes even
+// for a semantically-identical validation, which would re-introduce
+// the exact desync B2 is fixing.
+func hashValidationSuppression(serializedSTValidation []byte) [32]byte {
+	return common.Sha512Half(serializedSTValidation)
+}
+
+// appendVLPrefix writes rippled's variable-length length prefix
+// matching Serializer::addEncoded (libxrpl/protocol/Serializer.cpp:222).
+// For lengths up to 192 the prefix is a single byte equal to the
+// length; for 193-12480 two bytes; for 12481-918744 three bytes.
+// Proposal pubkeys (33 B) and signatures (64-72 B) always fit in the
+// single-byte range — but keeping the full encoder ensures we can't
+// silently desync if a future caller passes a larger slice.
+func appendVLPrefix(buf []byte, n int) []byte {
+	switch {
+	case n <= 192:
+		return append(buf, byte(n))
+	case n <= 12480:
+		v := n - 193
+		return append(buf, byte(193+(v>>8)), byte(v&0xff))
+	case n <= 918744:
+		v := n - 12481
+		return append(buf, byte(241+(v>>16)), byte((v>>8)&0xff), byte(v&0xff))
+	}
+	// Caller error — rippled throws here; in Go we record the overflow
+	// by producing a sentinel prefix that will make the resulting hash
+	// differ from anything rippled would emit. This is "loud failure"
+	// by design: a suppression hash for a 900KB+ field cannot exist in
+	// any real proposal/validation, so any mismatch downstream will
+	// surface the misuse immediately.
+	return append(buf, 0xFF, 0xFF, 0xFF, 0xFF)
 }
 
 // messageSuppression tracks recently-seen proposal/validation message

--- a/internal/consensus/adaptor/router_propose_pubkey_test.go
+++ b/internal/consensus/adaptor/router_propose_pubkey_test.go
@@ -1,0 +1,92 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeValidProposeSet returns a ProposeSet whose non-pubkey fields sit
+// comfortably inside the bounds validateProposeBounds enforces, so tests
+// that only mutate NodePubKey can isolate that axis without tripping
+// other checks.
+func makeValidProposeSet() *message.ProposeSet {
+	return &message.ProposeSet{
+		ProposeSeq:     1,
+		CurrentTxHash:  make([]byte, 32),
+		NodePubKey:     nil, // caller fills
+		CloseTime:      timeToXrplEpoch(time.Unix(1_700_000_000, 0)),
+		Signature:      make([]byte, signatureMinLen),
+		PreviousLedger: make([]byte, 32),
+	}
+}
+
+// TestValidateProposeBounds_RejectsEd25519Prefix pins the B6 rippled
+// parity rule: proposal pubkeys MUST be compressed secp256k1 (0x02/0x03
+// prefix). A 33-byte ed25519 key (0xED || 32 bytes) has the correct
+// length, so a length-only check would let it through — but rippled
+// explicitly rejects it at PeerImp.cpp:1679-1680 via
+// `publicKeyType(...) != KeyType::secp256k1`. The malformed-bounds
+// charge path must attribute this to the peer specifically as a type
+// error, not a size error.
+func TestValidateProposeBounds_RejectsEd25519Prefix(t *testing.T) {
+	p := makeValidProposeSet()
+	// ed25519: 0xED prefix followed by 32 bytes of key material. Length
+	// is 33 — the same as a compressed secp256k1 point — so only a
+	// prefix check catches it.
+	p.NodePubKey = make([]byte, 33)
+	p.NodePubKey[0] = 0xED
+
+	field, ok := validateProposeBounds(p)
+	assert.False(t, ok, "ed25519-prefixed pubkey must be rejected")
+	assert.Equal(t, "pubkey-type", field,
+		"reason must be pubkey-type (not pubkey-size) so the peer is charged with the right class of violation")
+}
+
+// TestValidateProposeBounds_AcceptsSecp256k1Prefix verifies that valid
+// compressed secp256k1 pubkey prefixes (0x02 and 0x03) both pass. This
+// is the happy-path counterpart to the ed25519 rejection above, and
+// guards against an over-tight prefix check (e.g. accepting only one of
+// 0x02/0x03).
+func TestValidateProposeBounds_AcceptsSecp256k1Prefix(t *testing.T) {
+	for _, prefix := range []byte{0x02, 0x03} {
+		p := makeValidProposeSet()
+		p.NodePubKey = make([]byte, 33)
+		p.NodePubKey[0] = prefix
+
+		field, ok := validateProposeBounds(p)
+		assert.True(t, ok, "secp256k1 prefix %#x must be accepted", prefix)
+		assert.Equal(t, "", field, "no bad_field should be reported for a valid pubkey")
+	}
+}
+
+// TestHandleProposal_Ed25519PubKeyChargesPeer is the end-to-end guard:
+// a TMProposeSet whose NodePubKey has an ed25519 prefix must be dropped
+// BEFORE the engine sees it, and the peer must be attributed a bad-data
+// event with reason "proposal-malformed-pubkey-type". Mirrors rippled's
+// PeerImp feeInvalidSignature charge path at PeerImp.cpp:1682-1686.
+func TestHandleProposal_Ed25519PubKeyChargesPeer(t *testing.T) {
+	r, rs := makeRouterWithBadDataRecorder(t)
+
+	p := makeValidProposeSet()
+	p.NodePubKey = make([]byte, 33)
+	p.NodePubKey[0] = 0xED // ed25519 prefix, length 33 — passes size check
+
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  77,
+		Type:    uint16(message.TypeProposeLedger),
+		Payload: encodePayload(t, p),
+	})
+
+	calls := rs.getBadDataCalls()
+	require.Len(t, calls, 1,
+		"ed25519-prefixed proposal must trigger exactly one IncPeerBadData call")
+	assert.Equal(t, uint64(77), calls[0].peerID,
+		"bad-data must be attributed to the peer that sent the disallowed pubkey")
+	assert.Equal(t, "proposal-malformed-pubkey-type", calls[0].reason,
+		"reason label must be proposal-malformed-pubkey-type so the diagnostic distinguishes the prefix violation from a size violation")
+}

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -595,3 +595,147 @@ func TestRouter_IgnoresUnsolicitedReplayDeltaResponse(t *testing.T) {
 
 	assert.Equal(t, 0, r.replayer.Count(), "unsolicited response must not arm the verifier")
 }
+
+// buildSuccessorAgainstParent is the same close-and-serialize dance as
+// buildEmptyClosedSuccessorResponse, but against an arbitrary parent
+// Ledger object rather than svc.GetClosedLedger(). This lets the F6
+// cascade test construct a two-link chain (N+1, N+2) where N+1 is
+// held in-memory rather than installed in svc history — exactly the
+// situation the router must handle when a replay-delta for N+2
+// arrives ahead of N+1.
+func buildSuccessorAgainstParent(t *testing.T, parent *ledger.Ledger) (*message.ReplayDeltaResponse, *ledger.Ledger, [32]byte, uint32) {
+	t.Helper()
+	// Offset by seq so each ledger in a chain has a distinct close time
+	// — the hash derivation consumes close time, so identical values
+	// would make chained successors collide.
+	closeTime := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC).Add(time.Duration(parent.Sequence()) * time.Second)
+	open, err := ledger.NewOpen(parent, closeTime)
+	require.NoError(t, err)
+	require.NoError(t, open.Close(closeTime, 0))
+	hdr := open.Header()
+
+	hdrBytes, err := header.AddRaw(hdr, false)
+	require.NoError(t, err)
+
+	resp := &message.ReplayDeltaResponse{
+		LedgerHash:   hdr.Hash[:],
+		LedgerHeader: hdrBytes,
+		Transactions: nil,
+	}
+	return resp, open, hdr.Hash, hdr.LedgerIndex
+}
+
+// TestRouter_ReplayDelta_CascadesOutOfOrderArrival is the F6 integration
+// test. It wires the replay-delta path end-to-end (acquisition →
+// response → Apply → adopt) and drives an OUT-OF-ORDER arrival: the
+// seq N+2 response reaches the router before the seq N+1 response.
+// The router is expected to route both through SubmitHeldAdoption,
+// which stashes N+2 until N+1 lands and then cascade-promotes it.
+//
+// Without the F6 wiring this test would fail at two points:
+//  1. On delivery of the N+2 response, AdoptLedgerWithState would
+//     return an error (parent-hash mismatch against the then-current
+//     closedLedger at seq N) and the derived ledger would be lost —
+//     svc's closedLedger never advances past N+1 even after N+1
+//     arrives.
+//  2. svc.GetLedgerByHash(N+2) would stay error-returning because no
+//     second acquisition round retries N+2.
+func TestRouter_ReplayDelta_CascadesOutOfOrderArrival(t *testing.T) {
+	r, a, _, svc := makeRouter(t)
+
+	// Step svc past genesis once so we have a real N-at-seq-2 parent
+	// whose hash is consistent with a Close()-derived successor at
+	// seq 3 (the genesis ledger's skip-list is a special case — same
+	// reasoning as TestRouter_ReplayDeltaApply_AdoptsDerivedLedger).
+	_, err := svc.AcceptLedger()
+	require.NoError(t, err)
+
+	parentN := svc.GetClosedLedger()
+	require.NotNil(t, parentN)
+	parentSeq := parentN.Sequence()
+
+	// Build the N+1 response against parentN AND keep the N+1 ledger
+	// object in-memory so we can chain N+2 off of it. N+1 is NOT
+	// installed in svc history yet — the whole point of this test is
+	// to deliver N+2 before N+1 is adopted.
+	respN1, ledgerN1, hashN1, seqN1 := buildSuccessorAgainstParent(t, parentN)
+	respN2, _, hashN2, seqN2 := buildSuccessorAgainstParent(t, ledgerN1)
+	require.Equal(t, parentSeq+1, seqN1)
+	require.Equal(t, parentSeq+2, seqN2)
+	require.NotEqual(t, hashN1, hashN2, "chained successors must have distinct hashes")
+
+	// --- Out-of-order delivery: N+2 arrives first ---
+	//
+	// Arm an acquisition for N+2 with ledgerN1 as the parent object.
+	// startReplayDeltaAcquisition takes the parent Ledger directly, so
+	// we can supply an in-memory N+1 that svc doesn't yet know about.
+	// Apply will use it to derive N+2's post-state; the router then
+	// hands the derived ledger to SubmitHeldAdoption, which must stash
+	// because svc has no N+1 in ledgerHistory.
+	require.NoError(t, r.startReplayDeltaAcquisition(seqN2, hashN2, 7, ledgerN1))
+	payloadN2, err := message.Encode(respN2)
+	require.NoError(t, err)
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeReplayDeltaResponse),
+		Payload: payloadN2,
+	})
+
+	// N+2's acquisition has completed (verified + applied), but the
+	// adopt was stashed — not persisted to history.
+	require.Equal(t, 0, r.replayer.Count(),
+		"N+2 acquisition must be cleared once the response is verified and adopt routed")
+	_, err = svc.GetLedgerByHash(hashN2)
+	require.Error(t, err,
+		"N+2 must NOT be in svc history yet — parent seq N+1 has not arrived, so SubmitHeldAdoption must stash")
+	assert.Equal(t, parentSeq, svc.GetClosedLedger().Sequence(),
+		"closedLedger must not advance when the replay-delta is stashed")
+
+	// --- In-order arrival: N+1 lands and cascades N+2 ---
+	//
+	// Arm and deliver N+1. Its ParentHash matches parentN.Hash()
+	// (parentN IS in svc history), so SubmitHeldAdoption fast-paths
+	// into the adopt, which then runs cascadeHeldAdoptionsLocked and
+	// finds the N+2 entry keyed by seqN1. N+2's ParentHash ==
+	// hashN1, so the cascade promotes it.
+	require.NoError(t, r.startReplayDeltaAcquisition(seqN1, hashN1, 9, parentN))
+	payloadN1, err := message.Encode(respN1)
+	require.NoError(t, err)
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  9,
+		Type:    uint16(message.TypeReplayDeltaResponse),
+		Payload: payloadN1,
+	})
+
+	require.Equal(t, 0, r.replayer.Count(),
+		"N+1 adoption should clear the acquisition")
+
+	// Both N+1 AND N+2 must be in svc history. This is the F6
+	// contract: a single AdoptLedgerWithState at the parent seq
+	// drains every held child whose ParentHash matches.
+	gotN1, err := svc.GetLedgerByHash(hashN1)
+	require.NoError(t, err, "N+1 must be adopted by its own response")
+	assert.Equal(t, hashN1, gotN1.Hash())
+
+	gotN2, err := svc.GetLedgerByHash(hashN2)
+	require.NoError(t, err,
+		"N+2 must be cascade-adopted when its awaited parent N+1 lands — this fails without F6 wiring")
+	assert.Equal(t, hashN2, gotN2.Hash())
+
+	// closedLedger must advance to the cascade tip (N+2), not stop
+	// at N+1. This is the observable signal that the cascade ran
+	// end-to-end through the router — half-cascades (stop at N+1)
+	// leave the node visibly behind until the inbound loop retries.
+	assert.Equal(t, hashN2, svc.GetClosedLedger().Hash(),
+		"closedLedger must advance to the cascade tip N+2")
+	assert.Equal(t, seqN2, svc.GetClosedLedger().Sequence())
+
+	// Cascade-driven adoption still advances operating mode to
+	// Tracking. Router's adoptVerifiedLedger only runs the
+	// SetOperatingMode branch for the outer ledger (N+1); N+2 is
+	// promoted from inside the service and the router never sees it.
+	// But the N+1 adoption already did the Tracking transition, so
+	// the final state must be >= Tracking regardless.
+	assert.True(t, a.GetOperatingMode() >= consensus.OpModeTracking,
+		"operating mode must be at least Tracking after cascade (was %s)", a.GetOperatingMode())
+}

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -250,24 +250,50 @@ func TestRouterStopsOnContextCancel(t *testing.T) {
 
 // countingSender wraps noopSender with a counter on UpdateRelaySlot
 // so router tests can assert how many times the reduce-relay slot
-// was fed.
+// was fed. B3: also captures the seenPeers argument so tests can
+// verify the slot is fed with the full known-haver set from the
+// overlay's reverse index, not just the duplicate's originator.
 type countingSender struct {
 	noopSender
-	mu    sync.Mutex
-	calls []countingRelaySlotCall
+	mu             sync.Mutex
+	calls          []countingRelaySlotCall
+	peersThatHave  map[[32]byte][]uint64
 }
 
 type countingRelaySlotCall struct {
-	Validator []byte
-	PeerID    uint64
+	Validator  []byte
+	OriginPeer uint64
+	SeenPeers  []uint64
 }
 
-func (s *countingSender) UpdateRelaySlot(validator []byte, peer uint64) {
+func (s *countingSender) UpdateRelaySlot(validator []byte, originPeer uint64, seenPeers []uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	cp := make([]byte, len(validator))
 	copy(cp, validator)
-	s.calls = append(s.calls, countingRelaySlotCall{Validator: cp, PeerID: peer})
+	seenCp := append([]uint64(nil), seenPeers...)
+	s.calls = append(s.calls, countingRelaySlotCall{Validator: cp, OriginPeer: originPeer, SeenPeers: seenCp})
+}
+
+// PeersThatHave returns the preconfigured set for suppressionHash.
+// Router tests seed this to simulate the overlay having already
+// relayed a message to a known peer set.
+func (s *countingSender) PeersThatHave(suppressionHash [32]byte) []uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.peersThatHave == nil {
+		return nil
+	}
+	return append([]uint64(nil), s.peersThatHave[suppressionHash]...)
+}
+
+func (s *countingSender) setPeersThatHave(suppressionHash [32]byte, peers []uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.peersThatHave == nil {
+		s.peersThatHave = make(map[[32]byte][]uint64)
+	}
+	s.peersThatHave[suppressionHash] = append([]uint64(nil), peers...)
 }
 
 func (s *countingSender) getCalls() []countingRelaySlotCall {
@@ -348,7 +374,7 @@ func TestRouter_UpdateRelaySlot_DuplicatesOnly(t *testing.T) {
 	calls := sender.getCalls()
 	require.Len(t, calls, 1,
 		"duplicate proposal from a second peer must fire exactly one UpdateRelaySlot call")
-	assert.Equal(t, uint64(2), calls[0].PeerID,
+	assert.Equal(t, uint64(2), calls[0].OriginPeer,
 		"UpdateRelaySlot must be fed with the DUPLICATE peer's ID (the second arrival)")
 }
 
@@ -404,7 +430,173 @@ func TestRouter_UpdateRelaySlot_UntrustedValidator(t *testing.T) {
 	calls := sender.getCalls()
 	require.Len(t, calls, 1,
 		"untrusted-validator duplicate MUST still fire UpdateRelaySlot (rippled fires regardless of trust)")
-	assert.Equal(t, uint64(2), calls[0].PeerID)
+	assert.Equal(t, uint64(2), calls[0].OriginPeer)
+}
+
+// TestRelay_DuplicateArrivalFeedsAllKnownRelayers pins B3: when a
+// duplicate proposal arrives from peer C, and the overlay's reverse
+// index already maps the proposal's suppression hash to peers {A, B}
+// (from a prior outbound relay), UpdateRelaySlot must be fed with
+// the full set {A, B, C} — not just C. Matches rippled's
+// overlay_.relay returning haveMessage and PeerImp passing it whole
+// to updateSlotAndSquelch (PeerImp.cpp:3010-3017 for proposals).
+//
+// Regression guard: a mutation that feeds only originPeer — the
+// pre-B3 behavior — would register exactly one peer in the seenPeers
+// slice (C), under-counting multi-path delivery evidence and slowing
+// selection convergence vs. rippled.
+func TestRelay_DuplicateArrivalFeedsAllKnownRelayers(t *testing.T) {
+	engine := &mockEngine{}
+	svc := newTestLedgerService(t)
+
+	pubKey := make([]byte, 33)
+	pubKey[0] = 0x02
+	for i := 1; i < 33; i++ {
+		pubKey[i] = byte(0x40 | i) // distinct from the other B3 tests
+	}
+	var nodeID consensus.NodeID
+	copy(nodeID[:], pubKey)
+
+	sender := &countingSender{}
+	adaptor := New(Config{
+		LedgerService: svc,
+		Sender:        sender,
+		Validators:    []consensus.NodeID{nodeID},
+	})
+
+	inbox := make(chan *peermanagement.InboundMessage, 10)
+	router := NewRouter(engine, adaptor, nil, inbox)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go router.Run(ctx)
+
+	proposeSet := &message.ProposeSet{
+		ProposeSeq:     1,
+		CurrentTxHash:  make([]byte, 32),
+		NodePubKey:     pubKey,
+		CloseTime:      timeToXrplEpoch(time.Unix(1_700_000_002, 0)),
+		Signature:      make([]byte, signatureMinLen),
+		PreviousLedger: make([]byte, 32),
+	}
+	payload := encodePayload(t, proposeSet)
+
+	// First delivery from peer A establishes the dedup entry; no
+	// slot-feeding yet (first-seen gate).
+	inbox <- &peermanagement.InboundMessage{
+		PeerID:  1,
+		Type:    uint16(message.TypeProposeLedger),
+		Payload: payload,
+	}
+	time.Sleep(30 * time.Millisecond)
+	require.Empty(t, sender.getCalls(), "first-seen proposal must not feed the slot")
+
+	// Seed the overlay reverse index: the proposal's suppression key
+	// maps to peers {A=1, B=2} — as if we had already relayed it to
+	// them after the first-seen arrival. The proposal's suppression
+	// hash is computed from its decoded fields via
+	// hashProposalSuppression, so we reconstruct a matching Proposal
+	// to produce the same key the router will compute on the
+	// duplicate arrival below.
+	seedProposal := ProposalFromMessage(proposeSet)
+	seedHash := hashProposalSuppression(seedProposal)
+	sender.setPeersThatHave(seedHash, []uint64{1, 2})
+
+	// Duplicate delivery from peer C=3: UpdateRelaySlot must fire
+	// with originPeer=3 AND seenPeers containing 1 and 2 — the full
+	// set of peers the network believes already have this message.
+	inbox <- &peermanagement.InboundMessage{
+		PeerID:  3,
+		Type:    uint16(message.TypeProposeLedger),
+		Payload: payload,
+	}
+	time.Sleep(30 * time.Millisecond)
+
+	calls := sender.getCalls()
+	require.Len(t, calls, 1, "duplicate proposal must fire exactly one UpdateRelaySlot call")
+	call := calls[0]
+	assert.Equal(t, uint64(3), call.OriginPeer,
+		"UpdateRelaySlot must be fed with the DUPLICATE peer's ID as originPeer")
+
+	// seenPeers must contain peers 1 and 2 (the known-havers from
+	// the reverse index). Order is not fixed (it's a set walk).
+	seenSet := make(map[uint64]struct{}, len(call.SeenPeers))
+	for _, p := range call.SeenPeers {
+		seenSet[p] = struct{}{}
+	}
+	assert.Contains(t, seenSet, uint64(1), "seenPeers must include peer A (prior known-haver)")
+	assert.Contains(t, seenSet, uint64(2), "seenPeers must include peer B (prior known-haver)")
+}
+
+// TestRelay_FirstSeenMessageDoesNotFeedSlot pins the other half of
+// B3: for a first-seen message — no prior entry in the suppression
+// cache — UpdateRelaySlot must NOT fire, regardless of what the
+// overlay's reverse index says about `suppressionHash`. Matches
+// rippled PeerImp.cpp:1730's `!added` branch: first-seen arrivals go
+// to the HashRouter but don't drive the squelch slot.
+//
+// Regression guard: a mutation that inverted the gate would
+// accelerate selection 2x (every first-seen counted as duplicate),
+// producing earlier squelches than the rest of the network.
+func TestRelay_FirstSeenMessageDoesNotFeedSlot(t *testing.T) {
+	engine := &mockEngine{}
+	svc := newTestLedgerService(t)
+
+	pubKey := make([]byte, 33)
+	pubKey[0] = 0x02
+	for i := 1; i < 33; i++ {
+		pubKey[i] = byte(0x20 | i) // distinct seed from the other tests
+	}
+	var nodeID consensus.NodeID
+	copy(nodeID[:], pubKey)
+
+	sender := &countingSender{}
+	adaptor := New(Config{
+		LedgerService: svc,
+		Sender:        sender,
+		Validators:    []consensus.NodeID{nodeID},
+	})
+
+	inbox := make(chan *peermanagement.InboundMessage, 4)
+	router := NewRouter(engine, adaptor, nil, inbox)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go router.Run(ctx)
+
+	// Construct a proposal and PRE-SEED the overlay's reverse index
+	// with a non-empty known-haver set for its suppression hash. If
+	// the gate were inverted, this test would exercise a code path
+	// that feeds seenPeers into the slot even on a first-seen
+	// arrival — exactly the regression we're pinning against.
+	proposeSet := &message.ProposeSet{
+		ProposeSeq:     7,
+		CurrentTxHash:  make([]byte, 32),
+		NodePubKey:     pubKey,
+		CloseTime:      timeToXrplEpoch(time.Unix(1_700_000_003, 0)),
+		Signature:      make([]byte, signatureMinLen),
+		PreviousLedger: make([]byte, 32),
+	}
+	payload := encodePayload(t, proposeSet)
+
+	seedProposal := ProposalFromMessage(proposeSet)
+	seedHash := hashProposalSuppression(seedProposal)
+	sender.setPeersThatHave(seedHash, []uint64{11, 22, 33})
+
+	// Deliver the message exactly once — from a fresh peer, no prior
+	// observation. This is the rippled `!added == false` branch in
+	// HashRouter::addSuppressionPeer: entry is CREATED, not matched.
+	// Slot must NOT fire.
+	inbox <- &peermanagement.InboundMessage{
+		PeerID:  99,
+		Type:    uint16(message.TypeProposeLedger),
+		Payload: payload,
+	}
+	time.Sleep(30 * time.Millisecond)
+
+	calls := sender.getCalls()
+	assert.Empty(t, calls,
+		"first-seen message must NOT feed UpdateRelaySlot, even if the reverse index has entries for its suppression hash")
 }
 
 func TestRouterStopsOnChannelClose(t *testing.T) {

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -50,31 +50,52 @@ func (s *OverlaySender) BroadcastValidation(validation *consensus.Validation) er
 // pubkey (so peers that have signaled they no longer need that
 // validator's gossip are skipped) and excluding the originating peer
 // itself. Mirrors rippled's OverlayImpl::relay for TMProposeSet.
+//
+// proposal.SuppressionHash is the router-level dedup key (populated
+// by the consensus router from the canonical proposalUniqueId hash at
+// parse time). The overlay registers each recipient against that key
+// in its reverse index; the index is queried by the consensus router
+// on a later duplicate arrival so the slot is fed with the full set
+// of known-havers (B3, PeerImp.cpp:3010-3017).
 func (s *OverlaySender) RelayProposal(proposal *consensus.Proposal, exceptPeer uint64) error {
 	msg := ProposalToMessage(proposal)
 	frame, err := encodeFrame(message.TypeProposeLedger, msg)
 	if err != nil {
 		return fmt.Errorf("encode proposal: %w", err)
 	}
-	return s.overlay.RelayFromValidator(proposal.NodeID[:], peermanagement.PeerID(exceptPeer), frame)
+	return s.overlay.RelayFromValidator(proposal.NodeID[:], proposal.SuppressionHash, peermanagement.PeerID(exceptPeer), frame)
 }
 
 // RelayValidation forwards a peer-originated validation to other peers
-// with the same filter semantics as RelayProposal.
+// with the same filter semantics as RelayProposal. Uses
+// validation.SuppressionHash for the reverse-index record.
 func (s *OverlaySender) RelayValidation(validation *consensus.Validation, exceptPeer uint64) error {
 	msg := ValidationToMessage(validation)
 	frame, err := encodeFrame(message.TypeValidation, msg)
 	if err != nil {
 		return fmt.Errorf("encode validation: %w", err)
 	}
-	return s.overlay.RelayFromValidator(validation.NodeID[:], peermanagement.PeerID(exceptPeer), frame)
+	return s.overlay.RelayFromValidator(validation.NodeID[:], validation.SuppressionHash, peermanagement.PeerID(exceptPeer), frame)
 }
 
 // UpdateRelaySlot feeds the overlay's reduce-relay state machine with
 // an inbound validator message. Mirrors rippled's
 // PeerImp::updateSlotAndSquelch call in onMessage(TMProposeSet/TMValidation).
-func (s *OverlaySender) UpdateRelaySlot(validatorKey []byte, peerID uint64) {
-	s.overlay.OnValidatorMessage(validatorKey, peermanagement.PeerID(peerID))
+//
+// seenPeers is the set of peers already known to have this message
+// (from Overlay.PeersThatHave). Rippled's overlay_.relay returns that
+// set as haveMessage and PeerImp passes it whole to
+// updateSlotAndSquelch (PeerImp.cpp:3013-3017) so multi-path delivery
+// evidence is counted — not just the current duplicate's origin. We
+// dedupe originPeer out of seenPeers so no peer is double-counted.
+func (s *OverlaySender) UpdateRelaySlot(validatorKey []byte, originPeer uint64, seenPeers []uint64) {
+	s.overlay.OnValidatorMessage(validatorKey, peermanagement.PeerID(originPeer))
+	for _, p := range seenPeers {
+		if p == originPeer {
+			continue
+		}
+		s.overlay.OnValidatorMessage(validatorKey, peermanagement.PeerID(p))
+	}
 }
 
 func (s *OverlaySender) RequestTxSet(id consensus.TxSetID) error {
@@ -184,6 +205,24 @@ func (s *OverlaySender) ReplayCapablePeersExcluding(excluded []uint64, max int) 
 // peers.
 func (s *OverlaySender) IncPeerBadData(peerID uint64, reason string) {
 	s.overlay.IncPeerBadData(peermanagement.PeerID(peerID), reason)
+}
+
+// PeersThatHave returns the peer IDs the overlay knows have the
+// message with this suppression hash. Populated by the overlay as
+// messages are relayed outward (see Overlay.RelayFromValidator); the
+// consensus router queries this on duplicate arrivals so the
+// reduce-relay slot gets fed with every known-haver (B3,
+// PeerImp.cpp:3010-3017).
+func (s *OverlaySender) PeersThatHave(suppressionHash [32]byte) []uint64 {
+	raw := s.overlay.PeersThatHave(suppressionHash)
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]uint64, len(raw))
+	for i, p := range raw {
+		out[i] = uint64(p)
+	}
+	return out
 }
 
 // RequestReplayDelta asks a specific peer for a fast-catchup replay delta

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -79,8 +79,25 @@ func NewFromConfig(
 	appCfg *config.Config,
 	ledgerSvc *service.Service,
 ) (*Components, error) {
+	// Create validator identity first (nil if not a validator) so we can
+	// pass its pubkey into the overlay for the self-target TMSquelch
+	// filter (Task 4.2 / G3: without this a peer could silence our own
+	// validator's traffic on the RelayFromValidator path).
+	var identity *ValidatorIdentity
+	if appCfg.ValidationSeed != "" {
+		var err error
+		identity, err = NewValidatorIdentity(appCfg.ValidationSeed)
+		if err != nil {
+			return nil, fmt.Errorf("create validator identity: %w", err)
+		}
+	}
+
 	// Build overlay options from app config
 	overlayOpts := OverlayOptionsFromConfig(appCfg)
+	if identity != nil && len(identity.PublicKey) == 33 {
+		overlayOpts = append(overlayOpts,
+			peermanagement.WithLocalValidatorPubKey(identity.PublicKey))
+	}
 
 	overlay, err := peermanagement.New(overlayOpts...)
 	if err != nil {
@@ -96,15 +113,6 @@ func NewFromConfig(
 	// internal/ledger, so the adapter installed here lets both layers
 	// reach the ledger without breaking that layering boundary.
 	overlay.LedgerSync().SetProvider(NewLedgerProvider(ledgerSvc))
-
-	// Create validator identity (nil if not a validator)
-	var identity *ValidatorIdentity
-	if appCfg.ValidationSeed != "" {
-		identity, err = NewValidatorIdentity(appCfg.ValidationSeed)
-		if err != nil {
-			return nil, fmt.Errorf("create validator identity: %w", err)
-		}
-	}
 
 	// Load UNL from config
 	validators, err := ParseValidatorKeys(appCfg)

--- a/internal/consensus/adaptor/suppression_hash_test.go
+++ b/internal/consensus/adaptor/suppression_hash_test.go
@@ -1,0 +1,277 @@
+// Copyright (c) goXRPLd contributors.
+//
+// Tests for B2 (PR #264 Round-7): suppression-hash domain must match
+// rippled's proposalUniqueId (sha512Half of an STObject-style serializer
+// over the decoded proposal fields) and sha512Half(val->serialized) for
+// validations (inner STValidation blob, not the TMValidation envelope).
+//
+// These tests are the TDD scaffolding for the replacement of hashPayload
+// in router.go. The key insight being pinned: semantically-equivalent
+// protobuf payloads MUST produce the same suppression hash, so mixed
+// Go/rippled peer dedup doesn't desynchronize just because one peer
+// re-marshaled the TMProposeSet / TMValidation envelope with different
+// framing.
+
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pb "google.golang.org/protobuf/proto"
+)
+
+// buildSuppressionTestProposal returns a *consensus.Proposal with stable
+// field values suitable for hashing. All inputs that contribute to
+// proposalUniqueId are set explicitly so the expected hash is a function
+// only of those fields — not of Timestamp, Round, or any engine-internal
+// bookkeeping.
+func buildSuppressionTestProposal() *consensus.Proposal {
+	var txSet consensus.TxSetID
+	for i := range txSet {
+		txSet[i] = byte(0x40 + i)
+	}
+	var prevLedger consensus.LedgerID
+	for i := range prevLedger {
+		prevLedger[i] = byte(0x80 + i)
+	}
+	var nodeID consensus.NodeID
+	nodeID[0] = 0x02 // valid compressed secp256k1 prefix
+	for i := 1; i < len(nodeID); i++ {
+		nodeID[i] = byte(i)
+	}
+	sig := make([]byte, 70)
+	for i := range sig {
+		sig[i] = byte(0xA0 ^ i)
+	}
+	return &consensus.Proposal{
+		Position:       7,
+		TxSet:          txSet,
+		PreviousLedger: prevLedger,
+		CloseTime:      time.Unix(1_700_000_000, 0),
+		NodeID:         nodeID,
+		Signature:      sig,
+	}
+}
+
+// TestSuppression_ProposalHash_DeterministicOnFields pins that the
+// proposal suppression hash is a pure function of the fields rippled
+// feeds into proposalUniqueId. Two proposals with identical contributing
+// fields but different non-contributing fields (Round, Timestamp) MUST
+// produce the same hash.
+func TestSuppression_ProposalHash_DeterministicOnFields(t *testing.T) {
+	p1 := buildSuppressionTestProposal()
+	p2 := buildSuppressionTestProposal()
+
+	// Perturb fields NOT fed into proposalUniqueId. If the
+	// implementation wrongly hashed these, the hashes would diverge.
+	p1.Timestamp = time.Unix(1, 0)
+	p2.Timestamp = time.Unix(2_000_000_000, 0)
+	p1.Round = consensus.RoundID{Seq: 1, ParentHash: p1.PreviousLedger}
+	p2.Round = consensus.RoundID{Seq: 999, ParentHash: p2.PreviousLedger}
+
+	h1 := hashProposalSuppression(p1)
+	h2 := hashProposalSuppression(p2)
+
+	assert.Equal(t, h1, h2,
+		"proposal suppression hash must depend only on fields fed into rippled's proposalUniqueId")
+}
+
+// TestSuppression_ProposalHash_FieldsMatter pins that changing ANY
+// contributing field flips the hash. A regression that ignores a field
+// would merge distinct proposals into the same suppression key — a
+// subtle dedup bug that'd silently drop legitimate traffic.
+func TestSuppression_ProposalHash_FieldsMatter(t *testing.T) {
+	base := buildSuppressionTestProposal()
+
+	mutations := []struct {
+		name string
+		mut  func(*consensus.Proposal)
+	}{
+		{"Position", func(p *consensus.Proposal) { p.Position++ }},
+		{"TxSet", func(p *consensus.Proposal) { p.TxSet[0] ^= 0xFF }},
+		{"PreviousLedger", func(p *consensus.Proposal) { p.PreviousLedger[31] ^= 0xFF }},
+		{"CloseTime", func(p *consensus.Proposal) { p.CloseTime = p.CloseTime.Add(1 * time.Second) }},
+		{"NodeID", func(p *consensus.Proposal) { p.NodeID[32] ^= 0x01 }},
+		{"Signature", func(p *consensus.Proposal) { p.Signature[0] ^= 0x01 }},
+	}
+
+	baseHash := hashProposalSuppression(base)
+	for _, m := range mutations {
+		t.Run(m.name, func(t *testing.T) {
+			mut := *base // shallow copy
+			// Clone slices / arrays that mutate below.
+			mut.Signature = append([]byte(nil), base.Signature...)
+			m.mut(&mut)
+			got := hashProposalSuppression(&mut)
+			assert.NotEqual(t, baseHash, got,
+				"mutating %s must flip the suppression hash", m.name)
+		})
+	}
+}
+
+// TestSuppression_ProposalSemanticIdentity_SameHash is the headline
+// regression test for B2. It builds TWO protobuf payloads that decode
+// to the same *consensus.Proposal but differ byte-for-byte on the wire
+// (one includes deprecated field `hops`, the other doesn't). Pre-fix:
+// hashing the raw protobuf payload made these two hashes differ, so a
+// Go peer would register them as distinct suppression keys and feed
+// the reduce-relay slot on both — desyncing dedup from rippled peers
+// that only see one suppression entry.
+func TestSuppression_ProposalSemanticIdentity_SameHash(t *testing.T) {
+	// Build a ProposeSet, marshal it, then construct a SECOND
+	// byte-different marshal that decodes to the identical ProposeSet
+	// by including the deprecated `hops` field (proto field #12). The
+	// adaptor's fromProto for TMProposeSet does NOT copy Hops into the
+	// exported ProposeSet struct (see serialize_proto.go:414-425), so
+	// both byte streams round-trip to the same in-memory message.
+	pubKey := make([]byte, 33)
+	pubKey[0] = 0x02
+	for i := 1; i < 33; i++ {
+		pubKey[i] = byte(i)
+	}
+	sig := make([]byte, 70)
+	for i := range sig {
+		sig[i] = byte(i)
+	}
+
+	set := &message.ProposeSet{
+		ProposeSeq:     5,
+		CurrentTxHash:  make([]byte, 32),
+		NodePubKey:     pubKey,
+		CloseTime:      timeToXrplEpoch(time.Unix(1_700_000_000, 0)),
+		Signature:      sig,
+		PreviousLedger: make([]byte, 32),
+	}
+	for i := range set.CurrentTxHash {
+		set.CurrentTxHash[i] = byte(0x40 + i)
+	}
+	for i := range set.PreviousLedger {
+		set.PreviousLedger[i] = byte(0x80 + i)
+	}
+
+	// Payload A: no deprecated field.
+	payloadA, err := message.Encode(set)
+	require.NoError(t, err)
+
+	// Payload B: same fields plus `hops=7` (deprecated, not read by
+	// fromProto) — bytes differ but the round-trip produces the same
+	// ProposeSet struct.
+	protoB := &proto.TMProposeSet{
+		ProposeSeq:     pb.Uint32(set.ProposeSeq),
+		CurrentTxHash:  set.CurrentTxHash,
+		NodePubKey:     set.NodePubKey,
+		CloseTime:      pb.Uint32(set.CloseTime),
+		Signature:      set.Signature,
+		PreviousLedger: set.PreviousLedger,
+		Hops:           7,
+	}
+	payloadB, err := pb.Marshal(protoB)
+	require.NoError(t, err)
+
+	require.NotEqual(t, payloadA, payloadB,
+		"test setup error: payloads must differ byte-for-byte to prove the property")
+
+	// Decode both — verify they produce the same consensus.Proposal.
+	decodedA, err := message.Decode(message.TypeProposeLedger, payloadA)
+	require.NoError(t, err)
+	proposeA, ok := decodedA.(*message.ProposeSet)
+	require.True(t, ok)
+
+	decodedB, err := message.Decode(message.TypeProposeLedger, payloadB)
+	require.NoError(t, err)
+	proposeB, ok := decodedB.(*message.ProposeSet)
+	require.True(t, ok)
+
+	propA := ProposalFromMessage(proposeA)
+	propB := ProposalFromMessage(proposeB)
+
+	// Round, Timestamp contribute nothing to the hash — normalize for
+	// struct equality readability.
+	propA.Timestamp = time.Time{}
+	propB.Timestamp = time.Time{}
+	require.Equal(t, propA, propB,
+		"the two byte-different payloads must decode to identical *consensus.Proposal")
+
+	// Same decoded fields => same suppression hash.
+	hA := hashProposalSuppression(propA)
+	hB := hashProposalSuppression(propB)
+	assert.Equal(t, hA, hB,
+		"semantically-identical proposals must hash to the same suppression key — "+
+			"regression guard for B2 (router_dedup was hashing raw protobuf payload)")
+}
+
+// TestSuppression_ValidationHash_OfSerializedBlob pins that the
+// validation suppression hash is sha512Half of the inner STValidation
+// blob — matching rippled's `sha512Half(makeSlice(m->validation()))`
+// at PeerImp.cpp:2374. NOT the TMValidation protobuf envelope.
+func TestSuppression_ValidationHash_OfSerializedBlob(t *testing.T) {
+	val := buildTestValidation()
+	blob := serializeSTValidation(val)
+
+	got := hashValidationSuppression(blob)
+
+	// The contract: identical to a direct sha512Half(blob).
+	// Any deviation (e.g., hashing a TMValidation envelope, adding a
+	// prefix, using SHA256) would break dedup parity with rippled.
+	require.NotEqual(t, [32]byte{}, got,
+		"suppression hash over a nonempty blob must not be zero")
+
+	// Hashing the same blob twice must return the same value (purity).
+	again := hashValidationSuppression(blob)
+	assert.Equal(t, got, again, "hashValidationSuppression must be a pure function")
+}
+
+// TestSuppression_ValidationInnerBlobDomain_SameHash is the headline
+// regression test for B2 on the validation side. It constructs two
+// TMValidation protobuf envelopes that carry the SAME inner STValidation
+// blob but differ byte-for-byte on the outer envelope (one sets the
+// deprecated `hops` field, the other doesn't). Pre-fix: hashing the raw
+// TMValidation payload bytes would produce different suppression keys;
+// post-fix: hashing the inner serialized blob produces the SAME key —
+// matching rippled.
+func TestSuppression_ValidationInnerBlobDomain_SameHash(t *testing.T) {
+	v := buildTestValidation()
+	blob := serializeSTValidation(v)
+
+	// Envelope A: the minimal TMValidation our Encode path emits.
+	envelopeA, err := message.Encode(&message.Validation{Validation: blob})
+	require.NoError(t, err)
+
+	// Envelope B: same inner blob, plus deprecated `hops=3`. fromProto
+	// (serialize_proto.go:447-449) reads only the `validation` field,
+	// so both envelopes round-trip to an identical inner blob.
+	envelopeB, err := pb.Marshal(&proto.TMValidation{
+		Validation: blob,
+		Hops:       3,
+	})
+	require.NoError(t, err)
+
+	require.NotEqual(t, envelopeA, envelopeB,
+		"test setup error: envelopes must differ byte-for-byte to prove the property")
+
+	// Decode both envelopes and recover the inner blob.
+	decodedA, err := message.Decode(message.TypeValidation, envelopeA)
+	require.NoError(t, err)
+	innerA := decodedA.(*message.Validation).Validation
+
+	decodedB, err := message.Decode(message.TypeValidation, envelopeB)
+	require.NoError(t, err)
+	innerB := decodedB.(*message.Validation).Validation
+
+	require.Equal(t, innerA, innerB,
+		"the two byte-different envelopes must decode to the same inner STValidation blob")
+
+	// Same inner blob => same suppression hash, irrespective of outer
+	// envelope framing. That's the rippled-parity invariant.
+	hA := hashValidationSuppression(innerA)
+	hB := hashValidationSuppression(innerB)
+	assert.Equal(t, hA, hB,
+		"semantically-identical validations must hash to the same suppression key — "+
+			"regression guard for B2 (router_dedup was hashing raw protobuf payload)")
+}

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -47,6 +47,17 @@ func (ts *TxSetImpl) Txs() [][]byte {
 	return result
 }
 
+func (ts *TxSetImpl) TxIDs() []consensus.TxID {
+	// Return in the same order as Txs() so callers can zip the two
+	// slices. ts.index maps id→position into ts.txs, so the reverse
+	// walk writes each id at its canonical slot.
+	result := make([]consensus.TxID, len(ts.txs))
+	for id, idx := range ts.index {
+		result[idx] = id
+	}
+	return result
+}
+
 func (ts *TxSetImpl) Contains(id consensus.TxID) bool {
 	_, ok := ts.index[id]
 	return ok

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -78,23 +78,34 @@ type Adaptor interface {
 	// the per-peer squelch filter and excluding the originating peer
 	// (exceptPeer). Pass 0 for exceptPeer to send to all peers (e.g.
 	// for tests that synthesize a relay without an origin).
+	// Proposal.SuppressionHash is used by the overlay to record each
+	// recipient in its reverse index for a later duplicate-arrival
+	// lookup (B3) — callers must ensure the field is populated for
+	// peer-forwarded proposals.
 	RelayProposal(proposal *Proposal, exceptPeer uint64) error
 
 	// RelayValidation forwards a peer's validation to other peers,
 	// honoring the per-peer squelch filter and excluding the
-	// originating peer (exceptPeer). Same semantics as RelayProposal.
-	// Mirrors rippled's gossip-forward path for TMValidation in
-	// OverlayImpl::relay.
+	// originating peer (exceptPeer). Same semantics as RelayProposal;
+	// uses Validation.SuppressionHash for the reverse-index record.
 	RelayValidation(validation *Validation, exceptPeer uint64) error
 
 	// UpdateRelaySlot feeds the reduce-relay state machine with an
-	// inbound validator message from peerID. Mirrors rippled's
-	// PeerImp::onMessage(TMProposeSet/TMValidation) calling
-	// updateSlotAndSquelch — this is what drives the reduce-relay
-	// selection logic to emit mtSQUELCH once peer activity crosses
-	// the configured thresholds. Router calls this on every trusted
-	// inbound proposal/validation.
-	UpdateRelaySlot(validatorKey []byte, peerID uint64)
+	// inbound validator message from originPeer AND every peer in
+	// seenPeers (known-havers from the overlay's reverse index).
+	// Mirrors rippled's PeerImp::onMessage(TMProposeSet/TMValidation)
+	// calling updateSlotAndSquelch with the full haveMessage set
+	// (PeerImp.cpp:3013-3017, 3049-3054) — feeding multi-path
+	// delivery evidence per duplicate is what lets selection converge
+	// at the same rate rippled does. Router calls this on every
+	// trusted inbound proposal/validation duplicate.
+	UpdateRelaySlot(validatorKey []byte, originPeer uint64, seenPeers []uint64)
+
+	// PeersThatHave returns peer IDs known to have the message with
+	// suppressionHash. Populated at outbound relay and queried on
+	// inbound duplicates so UpdateRelaySlot can be fed the whole
+	// known-haver set (B3). Returns nil when unknown or aged out.
+	PeersThatHave(suppressionHash [32]byte) []uint64
 
 	// RequestTxSet requests a transaction set from peers.
 	RequestTxSet(id TxSetID) error

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -341,6 +341,12 @@ type TxSet interface {
 	// Txs returns the transactions in the set.
 	Txs() [][]byte
 
+	// TxIDs returns the hashes of every transaction in the set, in
+	// the same order as Txs() so callers can zip the two slices
+	// together. Used by consensus dispute tracking to diff two tx
+	// sets without re-deriving tx IDs from blobs.
+	TxIDs() []TxID
+
 	// Contains checks if a transaction is in the set.
 	Contains(id TxID) bool
 

--- a/internal/consensus/ledger_timing.go
+++ b/internal/consensus/ledger_timing.go
@@ -1,0 +1,121 @@
+package consensus
+
+// This file ports rippled's close-time-resolution binning from
+// src/xrpld/consensus/LedgerTiming.h (in particular
+// getNextLedgerTimeResolution at lines 80-122).
+//
+// Algorithm recap (rippled LedgerTiming.h:55-122):
+//
+//   - Resolutions are drawn from a fixed ordered bin set
+//     (ledgerPossibleTimeResolutions): 10s, 20s, 30s, 60s, 90s, 120s.
+//     Index 0 is the FINEST (most precise) bin; index len-1 is the
+//     COARSEST (widest bin).
+//   - Each new ledger starts from the parent's resolution. Depending
+//     on whether the prior round agreed on close time, and the new
+//     ledger's sequence number, we optionally step one slot coarser
+//     (towards index len-1, wider bins — "decreasing resolution" in
+//     the common-english sense of the header comments) or one slot
+//     finer (towards index 0, narrower bins — "increasing
+//     resolution").
+//   - If !previousAgree && seq % decreaseLedgerTimeResolutionEvery (1)
+//     == 0: try to step coarser (++iter in rippled). This widens the
+//     rounding bin so that peers with slightly different clocks are
+//     more likely to round to the same value and agree.
+//   - If previousAgree && seq % increaseLedgerTimeResolutionEvery (8)
+//     == 0: try to step finer (--iter in rippled). Peers were
+//     agreeing; see if we can tighten the bin.
+//   - At the extremes (iter == begin / end), the step is refused and
+//     previousResolution is returned unchanged.
+//
+// The terminology is confusing: rippled comments use "increase
+// resolution" in the human sense (finer → smaller seconds), but the
+// array is sorted by seconds-per-bin ascending, so "finer" means
+// moving to a smaller array index. We preserve rippled's constant
+// names (increaseLedgerTimeResolutionEvery / decreaseLedger...)
+// exactly so cross-references to LedgerTiming.h are unambiguous.
+//
+// Rippled parity test (LedgerTiming_test.cpp):
+//   - Starting at idx 2 (30s), previousAgree=false for 10 rounds:
+//     expect 3 steps coarser (→ 60s, 90s, 120s), then 7 rounds
+//     equal (saturates at max).
+//
+// Reference: rippled/src/xrpld/consensus/LedgerTiming.h:30-122.
+
+// ledgerPossibleTimeResolutions lists the valid close-time-resolution
+// bin widths, in seconds, finest (smallest) to coarsest (largest).
+// Matches rippled LedgerTiming.h:35-41.
+var ledgerPossibleTimeResolutions = []uint32{10, 20, 30, 60, 90, 120}
+
+// LedgerDefaultTimeResolution is the starting resolution for an
+// unconstrained ledger (rippled's ledgerPossibleTimeResolutions[2]).
+const LedgerDefaultTimeResolution uint32 = 30
+
+// LedgerGenesisTimeResolution is the resolution used for the genesis
+// ledger (rippled's ledgerPossibleTimeResolutions[0]).
+const LedgerGenesisTimeResolution uint32 = 10
+
+// increaseLedgerTimeResolutionEvery: every N ledgers, if the prior
+// round agreed, try to step to a FINER bin (smaller seconds).
+// Matches rippled LedgerTiming.h:50.
+const increaseLedgerTimeResolutionEvery uint32 = 8
+
+// decreaseLedgerTimeResolutionEvery: every N ledgers, if the prior
+// round did NOT agree, try to step to a COARSER bin (larger
+// seconds). Matches rippled LedgerTiming.h:53.
+const decreaseLedgerTimeResolutionEvery uint32 = 1
+
+// GetNextLedgerTimeResolution returns the close-time resolution, in
+// seconds, for the ledger at sequence newLedgerSeq, given the parent
+// ledger's resolution and whether the prior consensus round agreed
+// on close time.
+//
+// Contract:
+//   - parentResolution MUST be one of the valid bin widths in
+//     ledgerPossibleTimeResolutions. If it isn't (bug or corruption),
+//     parentResolution is returned unchanged — matching rippled's
+//     "precaution" branch at LedgerTiming.h:100-101.
+//   - newLedgerSeq MUST be non-zero. Rippled asserts this at
+//     LedgerTiming.h:85-87; in Go we silently tolerate it (returning
+//     the parent resolution), since the helper is pure and the
+//     constraint is enforced by callers (new ledgers always have
+//     seq ≥ 2 — genesis is seq 1 and never passes through here).
+//
+// Parity: rippled LedgerTiming.h:78-122.
+func GetNextLedgerTimeResolution(parentResolution uint32, previousAgree bool, newLedgerSeq uint32) uint32 {
+	if newLedgerSeq == 0 {
+		return parentResolution
+	}
+
+	// Locate parentResolution in the bin array. If not found, bail out
+	// with parentResolution (rippled LedgerTiming.h:100-101).
+	idx := -1
+	for i, r := range ledgerPossibleTimeResolutions {
+		if r == parentResolution {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return parentResolution
+	}
+
+	// Previous round did NOT agree: try to step coarser (larger bin).
+	// rippled LedgerTiming.h:105-110.
+	if !previousAgree && newLedgerSeq%decreaseLedgerTimeResolutionEvery == 0 {
+		if idx+1 < len(ledgerPossibleTimeResolutions) {
+			return ledgerPossibleTimeResolutions[idx+1]
+		}
+	}
+
+	// Previous round DID agree: try to step finer (smaller bin).
+	// rippled LedgerTiming.h:113-119. Note: if idx == 0 (already
+	// finest), rippled's post-decrement "iter-- != begin" check
+	// fails and we fall through, preserving the parent resolution.
+	if previousAgree && newLedgerSeq%increaseLedgerTimeResolutionEvery == 0 {
+		if idx > 0 {
+			return ledgerPossibleTimeResolutions[idx-1]
+		}
+	}
+
+	return parentResolution
+}

--- a/internal/consensus/ledger_timing_test.go
+++ b/internal/consensus/ledger_timing_test.go
@@ -1,0 +1,141 @@
+package consensus
+
+import "testing"
+
+// TestGetNextLedgerTimeResolution_ParityTable mirrors rippled's
+// LedgerTiming_test.cpp::testGetNextLedgerTimeResolution exactly,
+// iterating the helper across rounds and counting how many rounds
+// stepped coarser (rippled's "increase"), finer ("decrease"), or
+// stayed the same ("equal"). The rippled test asserts:
+//
+//   run(previousAgree=false, rounds=10):
+//     increase = 3, decrease = 0, equal = 7
+//   run(previousAgree=false, rounds=100):  // test repeats false
+//     increase = 3, decrease = 0, equal = 97
+//
+// The `increase`/`decrease` names follow rippled's test source
+// comparing by seconds-per-bin: "nextCloseResolution > closeResolution"
+// counts as an increase (coarser bin; LARGER seconds).
+//
+// Reference: rippled src/test/consensus/LedgerTiming_test.cpp:29-75.
+func TestGetNextLedgerTimeResolution_ParityTable(t *testing.T) {
+	type counts struct{ decrease, equal, increase int }
+
+	run := func(previousAgree bool, rounds uint32) counts {
+		var res counts
+		closeResolution := LedgerDefaultTimeResolution
+		var round uint32
+		for round = 1; round <= rounds; round++ {
+			next := GetNextLedgerTimeResolution(closeResolution, previousAgree, round)
+			switch {
+			case next < closeResolution:
+				res.decrease++
+			case next > closeResolution:
+				res.increase++
+			default:
+				res.equal++
+			}
+			closeResolution = next
+		}
+		return res
+	}
+
+	// Rippled's first case: run(false, 10). Starting at 30s, each
+	// round steps coarser (seq % 1 == 0 always), hitting 60/90/120
+	// in rounds 1/2/3, then saturating.
+	got := run(false, 10)
+	if got.increase != 3 || got.decrease != 0 || got.equal != 7 {
+		t.Errorf("run(false, 10): got %+v, want {decrease:0 equal:7 increase:3}", got)
+	}
+
+	// Rippled's second case: run(false, 100). Comment says
+	// "If we always agree" but the code passes false. We replicate
+	// the actual code path.
+	got = run(false, 100)
+	if got.increase != 3 || got.decrease != 0 || got.equal != 97 {
+		t.Errorf("run(false, 100): got %+v, want {decrease:0 equal:97 increase:3}", got)
+	}
+
+	// Additional parity: if we always agree, we should be able to
+	// step FINER at seq 8 (30 → 20) and seq 16 (20 → 10), then
+	// saturate at the finest bin for all remaining rounds.
+	got = run(true, 100)
+	// From 30s (idx 2): at seq 8 step to 20s (idx 1, decrease). At
+	// seq 16 step to 10s (idx 0, decrease). seq 24/32/... no further
+	// step possible (at finest). Every other seq: equal.
+	if got.decrease != 2 || got.increase != 0 || got.equal != 98 {
+		t.Errorf("run(true, 100): got %+v, want {decrease:2 equal:98 increase:0}", got)
+	}
+}
+
+// TestGetNextLedgerTimeResolution_SingleStep covers specific
+// (parentRes, previousAgree, newSeq) tuples that the parity table
+// does not directly expose, anchoring the plan's stated expectation
+// ("parent at 30s, previousAgree=true, newSeq=8 → 20s") and the
+// symmetric disagreement case.
+func TestGetNextLedgerTimeResolution_SingleStep(t *testing.T) {
+	cases := []struct {
+		name          string
+		parentRes     uint32
+		previousAgree bool
+		newSeq        uint32
+		want          uint32
+	}{
+		// --- previousAgree=true: step FINER at seq % 8 == 0 ---
+		{"agree,30s,seq8→20s (finer)", 30, true, 8, 20},
+		{"agree,30s,seq16→20s (finer)", 30, true, 16, 20},
+		{"agree,30s,seq7→30s (no step; seq%8!=0)", 30, true, 7, 30},
+		{"agree,30s,seq1→30s (no step; seq%8!=0)", 30, true, 1, 30},
+		{"agree,20s,seq8→10s (finer)", 20, true, 8, 10},
+		{"agree,10s,seq8→10s (saturated finest)", 10, true, 8, 10},
+		{"agree,10s,seq16→10s (saturated finest)", 10, true, 16, 10},
+
+		// --- previousAgree=false: step COARSER at seq % 1 == 0 (always) ---
+		{"disagree,30s,seq1→60s (coarser)", 30, false, 1, 60},
+		{"disagree,60s,seq2→90s (coarser)", 60, false, 2, 90},
+		{"disagree,90s,seq3→120s (coarser)", 90, false, 3, 120},
+		{"disagree,120s,seq4→120s (saturated coarsest)", 120, false, 4, 120},
+
+		// --- Edge cases ---
+		{"newSeq=0 returns parent unchanged", 30, true, 0, 30},
+		{"invalid parentRes passes through", 45, true, 8, 45},
+		{"invalid parentRes passes through (disagree)", 45, false, 1, 45},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetNextLedgerTimeResolution(tc.parentRes, tc.previousAgree, tc.newSeq)
+			if got != tc.want {
+				t.Errorf("GetNextLedgerTimeResolution(%d, %v, %d) = %d, want %d",
+					tc.parentRes, tc.previousAgree, tc.newSeq, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGetNextLedgerTimeResolution_BinArray pins the exact bin set to
+// rippled's (10, 20, 30, 60, 90, 120) so a future edit to the array
+// fails noisily.
+func TestGetNextLedgerTimeResolution_BinArray(t *testing.T) {
+	want := []uint32{10, 20, 30, 60, 90, 120}
+	if len(ledgerPossibleTimeResolutions) != len(want) {
+		t.Fatalf("bin count mismatch: got %d want %d", len(ledgerPossibleTimeResolutions), len(want))
+	}
+	for i, v := range want {
+		if ledgerPossibleTimeResolutions[i] != v {
+			t.Errorf("bin[%d]: got %d want %d", i, ledgerPossibleTimeResolutions[i], v)
+		}
+	}
+	if LedgerDefaultTimeResolution != 30 {
+		t.Errorf("LedgerDefaultTimeResolution: got %d want 30", LedgerDefaultTimeResolution)
+	}
+	if LedgerGenesisTimeResolution != 10 {
+		t.Errorf("LedgerGenesisTimeResolution: got %d want 10", LedgerGenesisTimeResolution)
+	}
+	if increaseLedgerTimeResolutionEvery != 8 {
+		t.Errorf("increaseLedgerTimeResolutionEvery: got %d want 8", increaseLedgerTimeResolutionEvery)
+	}
+	if decreaseLedgerTimeResolutionEvery != 1 {
+		t.Errorf("decreaseLedgerTimeResolutionEvery: got %d want 1", decreaseLedgerTimeResolutionEvery)
+	}
+}

--- a/internal/consensus/rcl/disputes_test.go
+++ b/internal/consensus/rcl/disputes_test.go
@@ -1,0 +1,405 @@
+package rcl
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// makeTxID returns a deterministic TxID seeded from a single byte so
+// tests can refer to disputed txs as "tx A", "tx B", etc.
+func makeTxID(seed byte) consensus.TxID {
+	var id consensus.TxID
+	id[0] = seed
+	return id
+}
+
+// makeTxSetID returns a deterministic TxSetID seeded from a single byte.
+func makeTxSetID(seed byte) consensus.TxSetID {
+	var id consensus.TxSetID
+	id[0] = seed
+	return id
+}
+
+// buildMockTxSet constructs a mockTxSet that correctly answers TxIDs
+// and Contains for an arbitrary set of tx hashes. Used by dispute-
+// integration tests that rely on TxSet membership behaving like a
+// real tx set (unlike the legacy Contains-always-false mock).
+func buildMockTxSet(id consensus.TxSetID, txIDs ...consensus.TxID) *mockTxSet {
+	contains := make(map[consensus.TxID]bool, len(txIDs))
+	blobs := make([][]byte, 0, len(txIDs))
+	ids := make([]consensus.TxID, 0, len(txIDs))
+	for _, txID := range txIDs {
+		contains[txID] = true
+		blob := make([]byte, 32)
+		copy(blob, txID[:])
+		blobs = append(blobs, blob)
+		ids = append(ids, txID)
+	}
+	return &mockTxSet{
+		id:          id,
+		txs:         blobs,
+		txIDs:       ids,
+		containsTxs: contains,
+	}
+}
+
+// TestConsensus_OverlappingDisjointProposals_Converges drives the
+// overlapping-proposal case from issue #266: peer positions diverge
+// in the symmetric difference, and the engine must dispute both
+// outliers and vote them into the final tx set once the avalanche
+// threshold is cleared.
+//
+// To actually cross the 50% init threshold (rippled's minCONSENSUS_PCT
+// at init — see ConsensusParms.h:146), the weight
+// (yays*100 + ourVote*100) / (yays + nays + 1) must be strictly
+// greater than 50. The natural rippled-world condition for that is
+// "more than half of peers hold the disputed tx" — which happens
+// when a supermajority of the network observes both outliers (e.g.
+// peers proposing {A,B,C,D}).
+//
+// Acceptance criterion: issue #266 — "peers propose {A,B,C} and
+// {A,B,D}; engine disputes C and D, votes both in after threshold
+// ramps."
+func TestConsensus_OverlappingDisjointProposals_Converges(t *testing.T) {
+	adaptor := newMockAdaptor()
+
+	selfNode := adaptor.nodeID
+	// Two peers each hold ABC / ABD (the canonical issue statement);
+	// plus three peers with ABCD to tip both disputes past 50%.
+	peerABC1 := consensus.NodeID{0xA1}
+	peerABC2 := consensus.NodeID{0xA2}
+	peerABD1 := consensus.NodeID{0xA3}
+	peerABD2 := consensus.NodeID{0xA4}
+	peerABCD1 := consensus.NodeID{0xA5}
+	peerABCD2 := consensus.NodeID{0xA6}
+	peerABCD3 := consensus.NodeID{0xA7}
+	adaptor.setTrusted([]consensus.NodeID{
+		selfNode, peerABC1, peerABC2, peerABD1, peerABD2,
+		peerABCD1, peerABCD2, peerABCD3,
+	})
+
+	txA := makeTxID(0xA)
+	txB := makeTxID(0xB)
+	txC := makeTxID(0xC)
+	txD := makeTxID(0xD)
+
+	setAB := buildMockTxSet(makeTxSetID(0x30), txA, txB)
+	setABC := buildMockTxSet(makeTxSetID(0x31), txA, txB, txC)
+	setABD := buildMockTxSet(makeTxSetID(0x32), txA, txB, txD)
+	setABCD := buildMockTxSet(makeTxSetID(0x33), txA, txB, txC, txD)
+
+	for _, ts := range []*mockTxSet{setAB, setABC, setABD, setABCD} {
+		adaptor.txSets[ts.ID()] = ts
+	}
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+	engine.parms = consensus.DefaultConsensusParms()
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+
+	engine.mu.Lock()
+	engine.ourTxSet = setAB
+	engine.acquiredTxSets[setAB.ID()] = setAB
+	engine.acquiredTxSets[setABC.ID()] = setABC
+	engine.acquiredTxSets[setABD.ID()] = setABD
+	engine.acquiredTxSets[setABCD.ID()] = setABCD
+	engine.state.OurPosition = &consensus.Proposal{
+		Round:     round,
+		NodeID:    selfNode,
+		Position:  0,
+		TxSet:     setAB.ID(),
+		CloseTime: adaptor.Now(),
+	}
+	engine.setPhase(consensus.PhaseEstablish)
+	engine.mu.Unlock()
+
+	now := adaptor.Now()
+	proposals := []struct {
+		node consensus.NodeID
+		set  *mockTxSet
+	}{
+		{peerABC1, setABC},
+		{peerABC2, setABC},
+		{peerABD1, setABD},
+		{peerABD2, setABD},
+		{peerABCD1, setABCD},
+		{peerABCD2, setABCD},
+		{peerABCD3, setABCD},
+	}
+	for _, p := range proposals {
+		prop := &consensus.Proposal{
+			Round:          round,
+			NodeID:         p.node,
+			Position:       0,
+			TxSet:          p.set.ID(),
+			CloseTime:      now,
+			PreviousLedger: consensus.LedgerID{1},
+			Timestamp:      now,
+		}
+		if err := engine.OnProposal(prop, 0); err != nil {
+			t.Fatalf("OnProposal(%x): %v", p.node, err)
+		}
+	}
+
+	engine.mu.RLock()
+	dC := engine.disputeTracker.GetDispute(txC)
+	dD := engine.disputeTracker.GetDispute(txD)
+	engine.mu.RUnlock()
+	if dC == nil {
+		t.Fatal("expected dispute for tx C after feeding peer proposals")
+	}
+	if dD == nil {
+		t.Fatal("expected dispute for tx D after feeding peer proposals")
+	}
+	// C: ABC1, ABC2, ABCD1/2/3 YES (5); ABD1, ABD2 NO (2).
+	// D: ABD1, ABD2, ABCD1/2/3 YES (5); ABC1, ABC2 NO (2).
+	if dC.Yays != 5 || dC.Nays != 2 {
+		t.Errorf("dispute C peer tally = %d/%d, want 5/2", dC.Yays, dC.Nays)
+	}
+	if dD.Yays != 5 || dD.Nays != 2 {
+		t.Errorf("dispute D peer tally = %d/%d, want 5/2", dD.Yays, dD.Nays)
+	}
+	if dC.OurVote || dD.OurVote {
+		t.Errorf("our initial vote on each dispute should be false (txs not in our set)")
+	}
+
+	// Drive updatePosition. Weight = (5*100 + 0)/(5+2+1) = 62.5 > 50
+	// at AvalancheInit — both disputes flip to yes in a single call.
+	engine.mu.Lock()
+	engine.updatePosition()
+	engine.mu.Unlock()
+
+	engine.mu.RLock()
+	dC = engine.disputeTracker.GetDispute(txC)
+	dD = engine.disputeTracker.GetDispute(txD)
+	outSet := engine.ourTxSet
+	engine.mu.RUnlock()
+
+	if !dC.OurVote {
+		t.Errorf("after avalanche ramp, ourVote on tx C should be true")
+	}
+	if !dD.OurVote {
+		t.Errorf("after avalanche ramp, ourVote on tx D should be true")
+	}
+	if outSet == nil {
+		t.Fatal("ourTxSet should not be nil after updatePosition")
+	}
+	if !outSet.Contains(txA) || !outSet.Contains(txB) ||
+		!outSet.Contains(txC) || !outSet.Contains(txD) {
+		t.Errorf("final tx set should include A,B,C,D; got A=%v B=%v C=%v D=%v",
+			outSet.Contains(txA), outSet.Contains(txB),
+			outSet.Contains(txC), outSet.Contains(txD))
+	}
+}
+
+// TestConsensus_BowOut_UnVotesDisputes seeds a dispute that peer X
+// has voted YES on, then drives a bow-out proposal from X. The
+// dispute's Yay count must drop by one and X must be gone from the
+// per-peer vote map.
+//
+// Acceptance criterion: issue #266 — "node X votes C=yes, bows out;
+// C's Yay count decreases by one."
+func TestConsensus_BowOut_UnVotesDisputes(t *testing.T) {
+	adaptor := newMockAdaptor()
+	selfNode := adaptor.nodeID
+	bowingNode := consensus.NodeID{0x77}
+	anotherNode := consensus.NodeID{0x88}
+	adaptor.setTrusted([]consensus.NodeID{selfNode, bowingNode, anotherNode})
+
+	txC := makeTxID(0xC)
+	txD := makeTxID(0xD)
+
+	setWithC := buildMockTxSet(makeTxSetID(0x41), txC)
+	setWithD := buildMockTxSet(makeTxSetID(0x42), txD)
+	setEmpty := buildMockTxSet(makeTxSetID(0x43))
+
+	for _, ts := range []*mockTxSet{setWithC, setWithD, setEmpty} {
+		adaptor.txSets[ts.ID()] = ts
+	}
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+
+	engine.mu.Lock()
+	engine.ourTxSet = setEmpty
+	engine.acquiredTxSets[setEmpty.ID()] = setEmpty
+	engine.acquiredTxSets[setWithC.ID()] = setWithC
+	engine.acquiredTxSets[setWithD.ID()] = setWithD
+	engine.state.OurPosition = &consensus.Proposal{
+		Round: round, NodeID: selfNode, TxSet: setEmpty.ID(),
+	}
+	engine.setPhase(consensus.PhaseEstablish)
+	engine.mu.Unlock()
+
+	now := adaptor.Now()
+	if err := engine.OnProposal(&consensus.Proposal{
+		Round: round, NodeID: bowingNode, Position: 0,
+		TxSet: setWithC.ID(), CloseTime: now,
+		PreviousLedger: consensus.LedgerID{1}, Timestamp: now,
+	}, 0); err != nil {
+		t.Fatalf("OnProposal bowingNode: %v", err)
+	}
+	if err := engine.OnProposal(&consensus.Proposal{
+		Round: round, NodeID: anotherNode, Position: 0,
+		TxSet: setWithD.ID(), CloseTime: now,
+		PreviousLedger: consensus.LedgerID{1}, Timestamp: now,
+	}, 0); err != nil {
+		t.Fatalf("OnProposal anotherNode: %v", err)
+	}
+
+	engine.mu.RLock()
+	preC := engine.disputeTracker.GetDispute(txC)
+	preD := engine.disputeTracker.GetDispute(txD)
+	engine.mu.RUnlock()
+	if preC == nil {
+		t.Fatal("expected dispute for tx C after bowingNode's proposal")
+	}
+	// bowingNode has C → YES on C, NO on D (if dispute D exists yet).
+	// anotherNode has D → NO on C, YES on D.
+	if preC.Yays != 1 || preC.Nays != 1 {
+		t.Fatalf("pre-bow-out tx C tally = %d/%d, want 1/1", preC.Yays, preC.Nays)
+	}
+	if _, has := preC.Votes[bowingNode]; !has {
+		t.Fatal("pre-bow-out: bowingNode should have a vote on tx C")
+	}
+	if preC.Votes[bowingNode] != true {
+		t.Fatal("pre-bow-out: bowingNode should vote YES on tx C")
+	}
+	if preD != nil && (preD.Yays != 1 || preD.Nays != 1) {
+		t.Fatalf("pre-bow-out tx D tally = %d/%d, want 1/1", preD.Yays, preD.Nays)
+	}
+
+	bowOut := &consensus.Proposal{
+		Round: round, NodeID: bowingNode, Position: 0xFFFFFFFF,
+		TxSet: setWithC.ID(), CloseTime: now,
+		PreviousLedger: consensus.LedgerID{1}, Timestamp: now,
+	}
+	if err := engine.OnProposal(bowOut, 0); err != nil {
+		t.Fatalf("bow-out OnProposal: %v", err)
+	}
+
+	engine.mu.RLock()
+	postC := engine.disputeTracker.GetDispute(txC)
+	postD := engine.disputeTracker.GetDispute(txD)
+	_, stillInProposals := engine.proposals[bowingNode]
+	_, isDead := engine.deadNodes[bowingNode]
+	engine.mu.RUnlock()
+
+	if stillInProposals {
+		t.Error("bowingNode should be evicted from proposals")
+	}
+	if !isDead {
+		t.Error("bowingNode should be recorded in deadNodes")
+	}
+	if postC.Yays != 0 {
+		t.Errorf("tx C yays after bow-out = %d, want 0", postC.Yays)
+	}
+	if postC.Nays != 1 {
+		t.Errorf("tx C nays after bow-out = %d, want 1", postC.Nays)
+	}
+	if _, has := postC.Votes[bowingNode]; has {
+		t.Error("bowingNode should be gone from tx C votes map after unvote")
+	}
+	if postD != nil {
+		if postD.Yays != 1 {
+			t.Errorf("tx D yays after bow-out = %d, want 1 (anotherNode stays)", postD.Yays)
+		}
+		if postD.Nays != 0 {
+			t.Errorf("tx D nays after bow-out = %d, want 0", postD.Nays)
+		}
+		if _, has := postD.Votes[bowingNode]; has {
+			t.Error("bowingNode should be gone from tx D votes map after unvote")
+		}
+	}
+}
+
+// TestConsensus_AvalancheThresholdRamp drives a single dispute
+// through the four avalanche states (50 → 65 → 70 → 95) and asserts
+// the required pct ConsensusParms.NeededWeight reports at each
+// state. Uses a 3-yay/1-nay peer split with ourVote=true — weight
+// is 80%, which holds steady through Init/Mid/Late but loses at
+// Stuck (95%) so we can also confirm the flip-at-Stuck path.
+//
+// Acceptance criterion: issue #266 — "threshold rises 50 → 65 → 70 → 95
+// as avalanche state advances."
+func TestConsensus_AvalancheThresholdRamp(t *testing.T) {
+	dt := NewDisputeTracker()
+	parms := consensus.DefaultConsensusParms()
+
+	txID := makeTxID(0xC)
+	dt.CreateDispute(txID, []byte("tx"), true)
+	// 3 peers vote YES, 1 NO. ourVote = true. Weight = (3*100+100)/(3+1+1) = 80.
+	// This stays above Init/Mid/Late thresholds but below Stuck's 95%.
+	for i, yes := range []bool{true, true, true, false} {
+		var p consensus.NodeID
+		p[0] = 0x10 + byte(i)
+		dt.SetVote(txID, p, yes)
+	}
+
+	d := dt.GetDispute(txID)
+	if d.AvalancheState != consensus.AvalancheInit {
+		t.Fatalf("start AvalancheState = %v, want Init", d.AvalancheState)
+	}
+	if reqPct, _ := parms.NeededWeight(d.AvalancheState, 0, 0, parms.MinRounds); reqPct != 50 {
+		t.Errorf("Init required pct = %d, want 50", reqPct)
+	}
+
+	// Call 1 at percentTime=0: MinRounds guard blocks advance.
+	dt.UpdateOurVote(0, true, parms)
+	if d.AvalancheState != consensus.AvalancheInit {
+		t.Errorf("after 1 tick: state = %v, want Init (min-rounds guard)", d.AvalancheState)
+	}
+	if d.OurVote != true {
+		t.Errorf("weight 80 > Init threshold 50: ourVote should stay true, got %v", d.OurVote)
+	}
+
+	// Call 2 at percentTime=60 with counter>=MinRounds: advance to Mid.
+	dt.UpdateOurVote(60, true, parms)
+	if d.AvalancheState != consensus.AvalancheMid {
+		t.Errorf("after percentTime=60, 2nd tick: state = %v, want Mid", d.AvalancheState)
+	}
+	if reqPct, _ := parms.NeededWeight(d.AvalancheState, 60, d.AvalancheCounter, parms.MinRounds); reqPct != 65 {
+		t.Errorf("Mid required pct = %d, want 65", reqPct)
+	}
+
+	// Stay in Mid for MinRounds before advancing. Current counter
+	// resets to 0 on state change; drive two more ticks.
+	dt.UpdateOurVote(60, true, parms) // counter=1, guard blocks
+	dt.UpdateOurVote(90, true, parms) // counter=2, percentTime crosses 85 → advance to Late
+	if d.AvalancheState != consensus.AvalancheLate {
+		t.Errorf("after percentTime=90: state = %v, want Late", d.AvalancheState)
+	}
+	if reqPct, _ := parms.NeededWeight(d.AvalancheState, 90, d.AvalancheCounter, parms.MinRounds); reqPct != 70 {
+		t.Errorf("Late required pct = %d, want 70", reqPct)
+	}
+
+	// Advance to Stuck.
+	dt.UpdateOurVote(210, true, parms) // counter=1, guard blocks
+	dt.UpdateOurVote(210, true, parms) // counter=2, crosses 200 → advance to Stuck
+	if d.AvalancheState != consensus.AvalancheStuck {
+		t.Errorf("after percentTime=210: state = %v, want Stuck", d.AvalancheState)
+	}
+	if reqPct, _ := parms.NeededWeight(d.AvalancheState, 210, d.AvalancheCounter, parms.MinRounds); reqPct != 95 {
+		t.Errorf("Stuck required pct = %d, want 95", reqPct)
+	}
+	// At Stuck threshold 95, weight 80 no longer holds → our vote
+	// should flip to false. Depending on exact round count the flip
+	// happens on the entry-into-Stuck tick or the one after. Assert
+	// it flipped within one more tick.
+	if d.OurVote {
+		dt.UpdateOurVote(210, true, parms)
+	}
+	if d.OurVote {
+		t.Errorf("at Stuck (95%% threshold), weight 80%% should flip our vote to false; got OurVote=%v", d.OurVote)
+	}
+}

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1275,7 +1275,7 @@ func (e *Engine) checkConvergence() {
 	// round consensus are separate gates — conflating them here pinned
 	// the threshold at validation-quorum (3) even when that exceeded
 	// the available participants. Use pure percentage of participants.
-	threshold := (trustedProposals*e.thresholds.MinConsensusPct + 99) / 100
+	threshold := (trustedProposals*e.thresholds.EarlyConvergencePct + 99) / 100
 	if threshold < 1 {
 		threshold = 1
 	}
@@ -1292,7 +1292,7 @@ func (e *Engine) checkConvergence() {
 			}
 
 			// Check if we have TX consensus
-			if count >= (trustedProposals*e.thresholds.MaxConsensusPct)/100 {
+			if count >= (trustedProposals*e.thresholds.MinConsensusPct)/100 {
 				// Also need close time consensus before accepting
 				// (matching rippled Consensus.h:1406-1411)
 				if !e.haveCloseTimeConsensus {

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -53,7 +53,43 @@ type Engine struct {
 	validationTracker *ValidationTracker
 
 	// Dispute tracking
-	disputes map[consensus.TxID]*consensus.DisputedTx
+	//
+	// disputeTracker owns the per-tx DisputedTx entries and the
+	// per-peer vote map, matching rippled's Result::disputes. It is
+	// written by createDisputesAgainst / OnProposal / OnTxSet /
+	// UpdateOurPositions and read during checkConvergence.
+	disputeTracker *DisputeTracker
+
+	// acquiredTxSets caches peer tx sets we have in memory, keyed
+	// by TxSetID. Populated by our own BuildTxSet output and by
+	// OnTxSet. Matches rippled's acquired_ (Consensus.h:606) — the
+	// dispute wiring reads this to learn which txs a peer's
+	// position actually contains.
+	acquiredTxSets map[consensus.TxSetID]consensus.TxSet
+
+	// comparesTxSets dedupes createDisputes. Matches rippled's
+	// Result::compares (Consensus.h:1829) — once we have diffed
+	// against a given peer tx set, the set is recorded here so
+	// subsequent repeats are cheap no-ops.
+	comparesTxSets map[consensus.TxSetID]struct{}
+
+	// parms holds the avalanche-threshold parameters used by
+	// DisputedTx::updateVote (per-tx re-voting). Mirrors rippled's
+	// ConsensusParms.
+	parms consensus.ConsensusParms
+
+	// peerUnchangedCounter counts consecutive phaseEstablish ticks
+	// during which NO peer flipped a dispute vote. Matches rippled's
+	// peerUnchangedCounter_ (Consensus.h) — used by stall detection
+	// on disputes.
+	peerUnchangedCounter int
+
+	// establishCounter counts phaseEstablish ticks since closeLedger,
+	// mirroring rippled's establishCounter_ (Consensus.h). Currently
+	// surfaced only as the per-dispute AvalancheCounter floor; kept
+	// here for parity and so future stall-expiration logic can gate
+	// ResultExpired on "minimum rounds at each avalanche level".
+	establishCounter int
 
 	// Heartbeat ticker — single global timer matching rippled's ledgerGRANULARITY.
 	heartbeat *time.Ticker
@@ -131,7 +167,10 @@ func NewEngine(adaptor consensus.Adaptor, config Config) *Engine {
 		phase:           consensus.PhaseAccepted,
 		proposals:       make(map[consensus.NodeID]*consensus.Proposal),
 		validations:     make(map[consensus.NodeID]*consensus.Validation),
-		disputes:        make(map[consensus.TxID]*consensus.DisputedTx),
+		disputeTracker:  NewDisputeTracker(),
+		acquiredTxSets:  make(map[consensus.TxSetID]consensus.TxSet),
+		comparesTxSets:  make(map[consensus.TxSetID]struct{}),
+		parms:           consensus.DefaultConsensusParms(),
 		recentProposals: make(map[consensus.NodeID][]*consensus.Proposal),
 		deadNodes:       make(map[consensus.NodeID]struct{}),
 	}
@@ -237,7 +276,11 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 
 	// Reset tracking maps
 	e.proposals = make(map[consensus.NodeID]*consensus.Proposal)
-	e.disputes = make(map[consensus.TxID]*consensus.DisputedTx)
+	e.disputeTracker = NewDisputeTracker()
+	e.acquiredTxSets = make(map[consensus.TxSetID]consensus.TxSet)
+	e.comparesTxSets = make(map[consensus.TxSetID]struct{})
+	e.peerUnchangedCounter = 0
+	e.establishCounter = 0
 	// deadNodes is scoped to a single consensus round — a validator that
 	// bowed out of the prior round is free to rejoin in the new one.
 	// Matches rippled's Consensus.h:722 (startRoundInternal clears
@@ -361,20 +404,20 @@ func (e *Engine) OnProposal(proposal *consensus.Proposal, originPeer uint64) err
 	// counting it for the rest of the round. Mirrors rippled's
 	// ConsensusProposal.h:68,154-156 and the handling in
 	// Consensus.h:804-817: erase the current position, record the node
-	// as dead, and (when E2/per-tx dispute tracking lands) un-vote its
-	// contribution from every active dispute. Without this gate the
-	// final seqLeave position would persist in e.proposals and keep
-	// "voting" forever, skewing convergence and tie-break logic.
+	// as dead, and un-vote its contribution from every active dispute.
+	// Without this gate the final seqLeave position would persist in
+	// e.proposals and keep "voting" forever, skewing convergence and
+	// tie-break logic.
 	const seqLeave = uint32(0xFFFFFFFF)
 	if proposal.Position == seqLeave {
 		delete(e.proposals, proposal.NodeID)
 		e.deadNodes[proposal.NodeID] = struct{}{}
-		// TODO(E2 per-tx dispute tracking): iterate e.disputes here and
-		// unvote proposal.NodeID from each entry, matching rippled's
-		// Consensus.h:809-811 (for each dispute: it.second.unVote(peerID)).
-		// The current DisputedTx carries aggregate Yays/Nays counts only,
-		// so there's nothing to unvote yet; adding the per-node vote set
-		// is the E2 task.
+		// Strip this peer's contribution from every active dispute
+		// so its (now-final) vote stops counting toward convergence.
+		// Matches rippled Consensus.h:807-811.
+		if e.disputeTracker != nil {
+			e.disputeTracker.UnVote(proposal.NodeID)
+		}
 		return nil
 	}
 
@@ -407,9 +450,33 @@ func (e *Engine) OnProposal(proposal *consensus.Proposal, originPeer uint64) err
 		e.adaptor.RelayProposal(proposal, originPeer)
 	}
 
-	// Check if we need the transaction set
-	if _, err := e.adaptor.GetTxSet(proposal.TxSet); err != nil {
+	// Check if we need the transaction set. If the adaptor already
+	// has it, cache it locally for dispute wiring — rippled's
+	// gotTxSet(Consensus.h:843-844) fires eagerly in the same
+	// scenario.
+	if peerSet, err := e.adaptor.GetTxSet(proposal.TxSet); err == nil && peerSet != nil {
+		if _, already := e.acquiredTxSets[proposal.TxSet]; !already {
+			e.acquiredTxSets[proposal.TxSet] = peerSet
+		}
+	} else {
 		e.adaptor.RequestTxSet(proposal.TxSet)
+	}
+
+	// If we already hold the peer's tx set (either from our own
+	// closeLedger, a prior OnTxSet, or the GetTxSet above), run the
+	// create/update-disputes loop for this position. Matches rippled's
+	// peerProposal path at Consensus.h:836-852: if the proposal's
+	// position is in acquired_, updateDisputes(nodeID, txSet);
+	// otherwise acquireTxSet is fired and the update happens later in
+	// gotTxSet. Self-originated proposals are gated out because we
+	// already seeded them in closeLedger.
+	if e.ourTxSet != nil && proposal.TxSet != e.ourTxSet.ID() {
+		if peerSet, ok := e.acquiredTxSets[proposal.TxSet]; ok {
+			e.createDisputesAgainst(peerSet)
+			if e.disputeTracker.UpdateDisputes(proposal.NodeID, peerSet) {
+				e.peerUnchangedCounter = 0
+			}
+		}
 	}
 
 	// If in establish phase, check for convergence
@@ -489,12 +556,115 @@ func (e *Engine) OnTxSet(id consensus.TxSetID, txs [][]byte) error {
 		return fmt.Errorf("tx set ID mismatch: expected %x, got %x", id, txSet.ID())
 	}
 
+	// Cache for dispute wiring. Matches rippled's gotTxSet arm at
+	// Consensus.h:906 (acquired_.emplace). Late-arriving tx sets
+	// retroactively populate any dispute whose disputed tx appears
+	// in the new set for some peer.
+	if _, already := e.acquiredTxSets[id]; !already {
+		e.acquiredTxSets[id] = txSet
+		if e.ourTxSet != nil && id != e.ourTxSet.ID() {
+			e.createDisputesAgainst(txSet)
+			for nodeID, p := range e.proposals {
+				if p.TxSet == id {
+					if e.disputeTracker.UpdateDisputes(nodeID, txSet) {
+						e.peerUnchangedCounter = 0
+					}
+				}
+			}
+		}
+	}
+
 	// If in establish phase, check for convergence
 	if e.phase == consensus.PhaseEstablish {
 		e.checkConvergence()
 	}
 
 	return nil
+}
+
+// createDisputesAgainst diffs a peer's tx set against our current
+// proposed tx set and creates a DisputedTx entry for every tx found
+// in only one side of the symmetric difference. For each new dispute
+// it back-fills per-peer votes from acquired peer positions so the
+// count starts out correct.
+//
+// Matches rippled's createDisputes (Consensus.h:1821-1888). Caller
+// must hold e.mu.
+func (e *Engine) createDisputesAgainst(peerTxSet consensus.TxSet) {
+	if e.ourTxSet == nil || peerTxSet == nil {
+		return
+	}
+	id := peerTxSet.ID()
+	if _, seen := e.comparesTxSets[id]; seen {
+		return
+	}
+	e.comparesTxSets[id] = struct{}{}
+
+	if id == e.ourTxSet.ID() {
+		return
+	}
+
+	ourIDs := e.ourTxSet.TxIDs()
+	peerIDs := peerTxSet.TxIDs()
+
+	ours := make(map[consensus.TxID]struct{}, len(ourIDs))
+	for _, txID := range ourIDs {
+		ours[txID] = struct{}{}
+	}
+	peers := make(map[consensus.TxID]struct{}, len(peerIDs))
+	for _, txID := range peerIDs {
+		peers[txID] = struct{}{}
+	}
+
+	// txs only in our set: seed ourVote=true and peer-vote=false.
+	ourBlobs := e.ourTxSet.Txs()
+	for idx, txID := range ourIDs {
+		if _, also := peers[txID]; also {
+			continue
+		}
+		if e.disputeTracker.Has(txID) {
+			continue
+		}
+		var blob []byte
+		if idx < len(ourBlobs) {
+			blob = ourBlobs[idx]
+		}
+		dispute := e.disputeTracker.CreateDispute(txID, blob, true)
+		e.seedDisputeVotes(dispute.TxID)
+	}
+
+	// txs only in peer's set: seed ourVote=false.
+	peerBlobs := peerTxSet.Txs()
+	for idx, txID := range peerIDs {
+		if _, also := ours[txID]; also {
+			continue
+		}
+		if e.disputeTracker.Has(txID) {
+			continue
+		}
+		var blob []byte
+		if idx < len(peerBlobs) {
+			blob = peerBlobs[idx]
+		}
+		dispute := e.disputeTracker.CreateDispute(txID, blob, false)
+		e.seedDisputeVotes(dispute.TxID)
+	}
+}
+
+// seedDisputeVotes walks every known peer proposal with an acquired
+// tx set and records that peer's vote on the new dispute. Runs once
+// when a dispute is created (rippled Consensus.h:1874-1881).
+// Caller must hold e.mu.
+func (e *Engine) seedDisputeVotes(txID consensus.TxID) {
+	for nodeID, p := range e.proposals {
+		peerSet, ok := e.acquiredTxSets[p.TxSet]
+		if !ok {
+			continue
+		}
+		if e.disputeTracker.SetVote(txID, nodeID, peerSet.Contains(txID)) {
+			e.peerUnchangedCounter = 0
+		}
+	}
 }
 
 // OnLedger handles receiving a ledger we were missing.
@@ -887,7 +1057,11 @@ func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID) {
 	// (only if this is a new target ledger)
 	if e.prevLedger == nil || netLedgerID != e.prevLedger.ID() {
 		e.proposals = make(map[consensus.NodeID]*consensus.Proposal)
-		e.disputes = make(map[consensus.TxID]*consensus.DisputedTx)
+		e.disputeTracker = NewDisputeTracker()
+		e.acquiredTxSets = make(map[consensus.TxSetID]consensus.TxSet)
+		e.comparesTxSets = make(map[consensus.TxSetID]struct{})
+		e.peerUnchangedCounter = 0
+		e.establishCounter = 0
 		e.converged = false
 		e.haveCloseTimeConsensus = false
 		if e.state != nil {
@@ -1108,6 +1282,11 @@ func (e *Engine) closeLedger() {
 		}
 	}
 	e.ourTxSet = txSet
+	// Our own tx set is immediately "acquired" — matches rippled's
+	// closeLedger at Consensus.h:1449 (acquired_.emplace after
+	// adaptor_.onClose). Dispute wiring reads this to recognize
+	// proposals that reference our position.
+	e.acquiredTxSets[txSet.ID()] = txSet
 
 	// Use raw now — rippled sets rawCloseTimes_.self = now_ (Consensus.h:1441).
 	// Rounding only happens later via effCloseTime() at acceptance.
@@ -1132,6 +1311,15 @@ func (e *Engine) closeLedger() {
 				e.state.OurPosition = proposal
 				e.adaptor.BroadcastProposal(proposal)
 			}
+		}
+	}
+
+	// Seed disputes against every peer position whose tx set we
+	// already hold. Matches rippled's closeLedger loop at
+	// Consensus.h:1461-1467.
+	for _, p := range e.proposals {
+		if peerSet, ok := e.acquiredTxSets[p.TxSet]; ok {
+			e.createDisputesAgainst(peerSet)
 		}
 	}
 
@@ -1199,6 +1387,12 @@ func (e *Engine) phaseEstablish() {
 		return
 	}
 
+	// Increment round counters used by dispute stall detection and
+	// avalanche minimum-rounds gating. Matches rippled's
+	// phaseEstablish at Consensus.h:1373-1374.
+	e.establishCounter++
+	e.peerUnchangedCounter++
+
 	// Update positions and check convergence
 	if e.mode == consensus.ModeProposing && e.state.OurPosition != nil {
 		e.updatePosition()
@@ -1236,7 +1430,15 @@ func (e *Engine) abandonDeadlineExceeded(roundTime time.Duration) bool {
 	return roundTime > deadline
 }
 
-// checkConvergence checks if proposals have converged.
+// checkConvergence drives the accept gate. Matches rippled's
+// phaseEstablish → haveConsensus flow (Consensus.h:1400-1422):
+// once we've spent ledgerMIN_CONSENSUS in establish and enough peers
+// match our position, we accept. The popularity-of-whole-tx-set vote
+// that previously lived here was strictly coarser than per-tx
+// re-voting and would strand a node whose position differed from
+// every peer in the small-set symmetric-difference case (issue #266).
+// Per-tx migration now happens in updatePosition, driven by the
+// dispute tracker.
 func (e *Engine) checkConvergence() {
 	if e.phase != consensus.PhaseEstablish {
 		return
@@ -1248,117 +1450,241 @@ func (e *Engine) checkConvergence() {
 		return
 	}
 
-	// Count proposals for each tx set. We include ourselves as a
-	// participant when proposing, mirroring rippled's checkConsensus
-	// (agreeing/total both include count_self). Without this, a 3-node
-	// UNL whose threshold uses quorum=3 can never converge: peers
-	// contribute at most 2 trusted proposals, the winning set never
-	// reaches 3, and every round hits LedgerMaxClose (10s timeout).
-	txSetCounts := make(map[consensus.TxSetID]int)
-	trustedProposals := 0
-
-	for nodeID, proposal := range e.proposals {
-		if e.adaptor.IsTrusted(nodeID) {
-			txSetCounts[proposal.TxSet]++
-			trustedProposals++
-		}
+	agree, disagree := e.countAgreement()
+	total := agree + disagree
+	if total == 0 {
+		return
 	}
 
-	// Add our own position to the count if we're a proposing validator.
-	if e.mode == consensus.ModeProposing && e.ourTxSet != nil {
-		txSetCounts[e.ourTxSet.ID()]++
-		trustedProposals++
+	// EarlyConvergencePct is a goXRPL-local gate for flagging a round
+	// as "converged" for observability (e.g., server_info). Acceptance
+	// uses MinConsensusPct (rippled's minCONSENSUS_PCT=80).
+	if agree*100 >= total*e.thresholds.EarlyConvergencePct {
+		e.converged = true
+		e.state.Converged = true
 	}
 
-	// Round-level convergence is a percentage of participants, not a
-	// validation-quorum check. Rippled's LedgerMaster::checkAccept and
-	// round consensus are separate gates — conflating them here pinned
-	// the threshold at validation-quorum (3) even when that exceeded
-	// the available participants. Use pure percentage of participants.
-	threshold := (trustedProposals*e.thresholds.EarlyConvergencePct + 99) / 100
-	if threshold < 1 {
-		threshold = 1
+	if agree*100 < total*e.thresholds.MinConsensusPct {
+		return
 	}
 
-	for txSetID, count := range txSetCounts {
-		if count >= threshold {
-			e.converged = true
-			e.state.Converged = true
-
-			// If it's not our tx set, we should adopt it
-			if e.ourTxSet == nil || e.ourTxSet.ID() != txSetID {
-				// Request the winning tx set if we don't have it
-				e.adaptor.RequestTxSet(txSetID)
-			}
-
-			// Check if we have TX consensus
-			if count >= (trustedProposals*e.thresholds.MinConsensusPct)/100 {
-				// Also need close time consensus before accepting
-				// (matching rippled Consensus.h:1406-1411)
-				if !e.haveCloseTimeConsensus {
-					// Update close time position — this may establish CT consensus.
-					e.updateCloseTimePosition()
-					if !e.haveCloseTimeConsensus {
-						return // Keep going until CT consensus is reached
-					}
-				}
-				e.acceptLedger(consensus.ResultSuccess)
-			}
+	// Close-time consensus is required before accepting — match
+	// rippled Consensus.h:1406-1411.
+	if !e.haveCloseTimeConsensus {
+		e.updateCloseTimePosition()
+		if !e.haveCloseTimeConsensus {
 			return
 		}
 	}
 
-	// Update our position (tx set + close time) if proposing and not converged
-	if e.mode == consensus.ModeProposing && e.state.OurPosition != nil {
-		e.updatePosition()
-	}
-
-	// Always update close time position during establish phase
-	e.updateCloseTimePosition()
+	e.acceptLedger(consensus.ResultSuccess)
 }
 
-// updatePosition updates our proposal position based on peer proposals.
+// countAgreement returns the number of participating proposers whose
+// current position matches ours (agree) and the number whose
+// position differs (disagree). When we are proposing, we count
+// ourselves as an agreeing participant, matching rippled's
+// haveConsensus where currPeerPositions_ excludes self and the
+// threshold denominator adds +1 for the proposer. (Our e.proposals
+// map likewise excludes self.)
+//
+// Matches rippled's haveConsensus tally (Consensus.h:1688-1707).
+// Caller must hold e.mu.
+func (e *Engine) countAgreement() (agree, disagree int) {
+	var ourTxSet consensus.TxSetID
+	haveOurs := false
+	if e.state != nil && e.state.OurPosition != nil {
+		ourTxSet = e.state.OurPosition.TxSet
+		haveOurs = true
+	} else if e.ourTxSet != nil {
+		ourTxSet = e.ourTxSet.ID()
+		haveOurs = true
+	}
+	if !haveOurs {
+		// Observer without a position: count peer-peer agreement on
+		// the most popular tx set. This preserves the pre-E2 behavior
+		// for non-proposing nodes that still need a convergence
+		// signal for acceptLedger.
+		counts := make(map[consensus.TxSetID]int)
+		for nodeID, p := range e.proposals {
+			if e.adaptor.IsTrusted(nodeID) {
+				counts[p.TxSet]++
+			}
+		}
+		var best int
+		for _, c := range counts {
+			if c > best {
+				best = c
+			}
+		}
+		agree = best
+		for _, c := range counts {
+			if c != best {
+				disagree += c
+			}
+		}
+		return agree, disagree
+	}
+
+	for nodeID, p := range e.proposals {
+		if !e.adaptor.IsTrusted(nodeID) {
+			continue
+		}
+		if p.TxSet == ourTxSet {
+			agree++
+		} else {
+			disagree++
+		}
+	}
+	if e.mode == consensus.ModeProposing {
+		agree++
+	}
+	return agree, disagree
+}
+
+// updatePosition runs the per-tx dispute re-vote and, if any
+// dispute flipped our vote, rebuilds our tx set from the inclusion
+// decisions and rebroadcasts the new position.
+//
+// Matches rippled's updateOurPositions TX arm (Consensus.h:1492-1678):
+// stale-proposal pruning with unVote, disputeTracker.UpdateOurVote,
+// rebuild ourTxSet via ± the flipped disputes, sign/propose, and
+// ripple the new position through updateDisputes for peers matching.
+//
+// Caller must hold e.mu.
 func (e *Engine) updatePosition() {
-	// Find the most popular tx set among trusted validators
-	txSetCounts := make(map[consensus.TxSetID]int)
-	for nodeID, proposal := range e.proposals {
-		if e.adaptor.IsTrusted(nodeID) {
-			txSetCounts[proposal.TxSet]++
+	if e.state == nil {
+		return
+	}
+
+	// Prune stale peer proposals. A peer that stops proposing within
+	// a round loses its votes on every dispute so it can't coast.
+	// Matches rippled Consensus.h:1509-1528.
+	cutoff := e.adaptor.Now().Add(-e.timing.ProposeFreshness)
+	for nodeID, p := range e.proposals {
+		if p.Timestamp.IsZero() {
+			continue
+		}
+		if p.Timestamp.Before(cutoff) {
+			delete(e.proposals, nodeID)
+			if e.disputeTracker != nil {
+				e.disputeTracker.UnVote(nodeID)
+			}
 		}
 	}
 
-	var bestTxSet consensus.TxSetID
-	bestCount := 0
-	for txSetID, count := range txSetCounts {
-		if count > bestCount {
-			bestTxSet = txSetID
-			bestCount = count
+	if e.disputeTracker == nil || e.ourTxSet == nil {
+		return
+	}
+
+	// Re-vote each dispute given the current converge percent. Only
+	// proposing nodes can shift their own position; observers still
+	// run the state-machine bookkeeping so avalanche levels are
+	// consistent across the round, but we gate flips on proposing.
+	proposing := e.mode == consensus.ModeProposing
+	changed := e.disputeTracker.UpdateOurVote(e.convergePercent(), proposing, e.parms)
+	if !proposing || len(changed) == 0 {
+		return
+	}
+
+	// Rebuild our proposed tx set from the dispute decisions. We
+	// start from the current ourTxSet blob list + txID index, then
+	// for each changed dispute: if the new vote is yes, add the tx
+	// blob (from the dispute); otherwise drop it.
+	currentBlobs := e.ourTxSet.Txs()
+	currentIDs := e.ourTxSet.TxIDs()
+	idSet := make(map[consensus.TxID]int, len(currentIDs))
+	for idx, id := range currentIDs {
+		idSet[id] = idx
+	}
+
+	newBlobs := make([][]byte, 0, len(currentBlobs)+len(changed))
+	keep := make(map[consensus.TxID]bool, len(currentIDs))
+	for _, id := range currentIDs {
+		keep[id] = true
+	}
+	for _, txID := range changed {
+		dispute := e.disputeTracker.GetDispute(txID)
+		if dispute == nil {
+			continue
+		}
+		if dispute.OurVote {
+			if !keep[txID] {
+				keep[txID] = true
+			}
+		} else {
+			keep[txID] = false
+		}
+	}
+	// Preserve original order for txs we keep that were already in
+	// ours, then append newly-voted-in disputes.
+	for idx, id := range currentIDs {
+		if keep[id] {
+			newBlobs = append(newBlobs, currentBlobs[idx])
+		}
+	}
+	for _, txID := range changed {
+		if _, already := idSet[txID]; already {
+			continue
+		}
+		if !keep[txID] {
+			continue
+		}
+		dispute := e.disputeTracker.GetDispute(txID)
+		if dispute == nil || dispute.Tx == nil {
+			continue
+		}
+		newBlobs = append(newBlobs, dispute.Tx)
+	}
+
+	newTxSet, err := e.adaptor.BuildTxSet(newBlobs)
+	if err != nil || newTxSet == nil {
+		slog.Warn("updatePosition: failed to rebuild tx set after dispute re-vote",
+			"err", err,
+		)
+		return
+	}
+
+	// No-op if rebuilding produced the same set (all flips cancelled
+	// each other out, or BuildTxSet deduped).
+	if newTxSet.ID() == e.ourTxSet.ID() {
+		return
+	}
+
+	e.ourTxSet = newTxSet
+	e.acquiredTxSets[newTxSet.ID()] = newTxSet
+	// Broadcasting a new position requires BOTH the current OurPosition
+	// (for the Position sequence bump) and a prevLedger (for the
+	// PreviousLedger field). A unit-test harness that seeds the engine
+	// without calling Start() has prevLedger == nil — we still want
+	// ourTxSet to update so the per-tx re-vote is observable, we just
+	// can't emit a proposal in that scenario.
+	if e.state.OurPosition != nil && e.prevLedger != nil {
+		nodeID, _ := e.adaptor.GetValidatorKey()
+		proposal := &consensus.Proposal{
+			Round:          e.state.Round,
+			NodeID:         nodeID,
+			Position:       e.state.OurPosition.Position + 1,
+			TxSet:          newTxSet.ID(),
+			CloseTime:      e.state.OurPosition.CloseTime,
+			PreviousLedger: e.prevLedger.ID(),
+			Timestamp:      e.adaptor.Now(),
+		}
+		if err := e.adaptor.SignProposal(proposal); err == nil {
+			e.state.OurPosition = proposal
+			e.adaptor.BroadcastProposal(proposal)
 		}
 	}
 
-	// If the best is different from ours, consider changing
-	if e.ourTxSet != nil && bestTxSet != e.ourTxSet.ID() && bestCount > len(e.proposals)/2 {
-		// Adopt the popular tx set
-		txSet, err := e.adaptor.GetTxSet(bestTxSet)
-		if err == nil {
-			e.ourTxSet = txSet
-
-			// Broadcast new position
-			nodeID, _ := e.adaptor.GetValidatorKey()
-			proposal := &consensus.Proposal{
-				Round:          e.state.Round,
-				NodeID:         nodeID,
-				Position:       e.state.OurPosition.Position + 1,
-				TxSet:          txSet.ID(),
-				CloseTime:      e.state.OurPosition.CloseTime,
-				PreviousLedger: e.prevLedger.ID(),
-				Timestamp:      e.adaptor.Now(),
-			}
-
-			if err := e.adaptor.SignProposal(proposal); err == nil {
-				e.state.OurPosition = proposal
-				e.adaptor.BroadcastProposal(proposal)
-			}
+	// Refresh per-peer votes for peers whose position matches the
+	// new set — rippled's Consensus.h:1665-1670 path after
+	// result_->position change.
+	for nodeID, p := range e.proposals {
+		if p.TxSet != newTxSet.ID() {
+			continue
+		}
+		if e.disputeTracker.UpdateDisputes(nodeID, newTxSet) {
+			e.peerUnchangedCounter = 0
 		}
 	}
 }

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1607,36 +1607,43 @@ func (e *Engine) sendValidation(ledger consensus.Ledger) {
 
 	full := e.mode == consensus.ModeProposing
 
-	cookie := e.adaptor.GetCookie()
-	serverVersion := e.adaptor.GetServerVersion()
-
-	// R5.10 guards — enforce invariants that the serializer relies
-	// on (it gates emission on non-zero) AND that rippled expects
-	// present (RCLConsensus.cpp:803-818 populates both unconditionally
-	// under HardenedValidations). A future refactor that accidentally
-	// zeros either should fail loudly here rather than silently
-	// ship malformed validations.
-	if cookie == 0 {
-		slog.Warn("sendValidation: cookie is zero — adaptor must generate one at boot (R5.10 invariant violated); emitting without cookie")
-	}
-	if serverVersion == 0 {
-		slog.Warn("sendValidation: serverVersion is zero — adaptor must advertise a build tag (R5.10 invariant violated); emitting without serverVersion")
-	}
-
 	validation := &consensus.Validation{
-		LedgerID:      ledger.ID(),
-		LedgerSeq:     ledger.Seq(),
-		NodeID:        nodeID,
-		SignTime:      e.adaptor.Now(),
-		SeenTime:      e.adaptor.Now(),
-		Full:          full,
-		Cookie:        cookie,
-		ServerVersion: serverVersion,
+		LedgerID:  ledger.ID(),
+		LedgerSeq: ledger.Seq(),
+		NodeID:    nodeID,
+		SignTime:  e.adaptor.Now(),
+		SeenTime:  e.adaptor.Now(),
+		Full:      full,
 		// R6b.5b: emit local load_fee (sfLoadFee) — rippled
 		// RCLConsensus.cpp:851 always populates this under
 		// HardenedValidations. Zero means "no load info",
 		// serializer omits the field.
 		LoadFee: e.adaptor.GetLoadFee(),
+	}
+
+	// B1: sfCookie and sfServerVersion are scoped inside rippled's
+	// `if (rules().enabled(featureHardenedValidations))` block at
+	// RCLConsensus.cpp:853-867. Before HV is active (pre-2020 on
+	// mainnet, any modern testnet/standalone on old rules) peers
+	// reject validations that carry these fields because the preimage
+	// they compute for signature verification omits them. sfCookie
+	// emits on every HV-enabled validation; sfServerVersion emits
+	// ONLY on voting ledgers within the same block (cpp:864-866 —
+	// "Report our server version every flag ledger").
+	if e.adaptor.IsFeatureEnabled("HardenedValidations") {
+		cookie := e.adaptor.GetCookie()
+		if cookie == 0 {
+			slog.Warn("sendValidation: cookie is zero under HardenedValidations — adaptor must generate one at boot; emitting without cookie")
+		}
+		validation.Cookie = cookie
+
+		if isVotingLedger(ledger.Seq()) {
+			serverVersion := e.adaptor.GetServerVersion()
+			if serverVersion == 0 {
+				slog.Warn("sendValidation: serverVersion is zero on voting ledger under HardenedValidations — adaptor must advertise a build tag; emitting without serverVersion")
+			}
+			validation.ServerVersion = serverVersion
+		}
 	}
 
 	// Fee vote + amendment vote emission is gated on isVotingLedger.

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -35,6 +35,14 @@ type Engine struct {
 	ourTxSet  consensus.TxSet
 	converged bool
 
+	// deadNodes tracks validators that have bowed out of the current
+	// consensus round by sending a proposal with Position == seqLeave
+	// (0xFFFFFFFF). Matches rippled's deadNodes_ set (Consensus.h:632).
+	// Any further proposal from a dead node is dropped until the next
+	// round clears the set (startRoundLocked), mirroring rippled's
+	// Consensus.h:722.
+	deadNodes map[consensus.NodeID]struct{}
+
 	// Validation tracking
 	validations map[consensus.NodeID]*consensus.Validation
 
@@ -116,6 +124,7 @@ func NewEngine(adaptor consensus.Adaptor, config Config) *Engine {
 		validations:     make(map[consensus.NodeID]*consensus.Validation),
 		disputes:        make(map[consensus.TxID]*consensus.DisputedTx),
 		recentProposals: make(map[consensus.NodeID][]*consensus.Proposal),
+		deadNodes:       make(map[consensus.NodeID]struct{}),
 	}
 }
 
@@ -220,6 +229,11 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	// Reset tracking maps
 	e.proposals = make(map[consensus.NodeID]*consensus.Proposal)
 	e.disputes = make(map[consensus.TxID]*consensus.DisputedTx)
+	// deadNodes is scoped to a single consensus round — a validator that
+	// bowed out of the prior round is free to rejoin in the new one.
+	// Matches rippled's Consensus.h:722 (startRoundInternal clears
+	// deadNodes_ alongside currPeerPositions_).
+	e.deadNodes = make(map[consensus.NodeID]struct{})
 	e.converged = false
 	e.ourTxSet = nil
 	e.haveCloseTimeConsensus = false
@@ -321,6 +335,37 @@ func (e *Engine) OnProposal(proposal *consensus.Proposal, originPeer uint64) err
 	// Reject proposals referencing a different previous ledger.
 	// Matches rippled Consensus.h:776-781.
 	if e.prevLedger != nil && proposal.PreviousLedger != e.prevLedger.ID() {
+		return nil
+	}
+
+	// Ignore proposals from nodes already marked dead this round. This
+	// guard must come before the bow-out arm below: rippled's
+	// Consensus.h:785-789 drops the message outright before it ever
+	// reaches the position-update code, so a node that's already dead
+	// cannot keep re-inserting itself by repeatedly sending seqLeave.
+	if _, dead := e.deadNodes[proposal.NodeID]; dead {
+		return nil
+	}
+
+	// isBowOut: a validator bowing out of consensus sets ProposeSeq to
+	// seqLeave (0xFFFFFFFF) on its final position so peers know to stop
+	// counting it for the rest of the round. Mirrors rippled's
+	// ConsensusProposal.h:68,154-156 and the handling in
+	// Consensus.h:804-817: erase the current position, record the node
+	// as dead, and (when E2/per-tx dispute tracking lands) un-vote its
+	// contribution from every active dispute. Without this gate the
+	// final seqLeave position would persist in e.proposals and keep
+	// "voting" forever, skewing convergence and tie-break logic.
+	const seqLeave = uint32(0xFFFFFFFF)
+	if proposal.Position == seqLeave {
+		delete(e.proposals, proposal.NodeID)
+		e.deadNodes[proposal.NodeID] = struct{}{}
+		// TODO(E2 per-tx dispute tracking): iterate e.disputes here and
+		// unvote proposal.NodeID from each entry, matching rippled's
+		// Consensus.h:809-811 (for each dispute: it.second.unVote(peerID)).
+		// The current DisputedTx carries aggregate Yays/Nays counts only,
+		// so there's nothing to unvote yet; adding the per-node vote set
+		// is the E2 task.
 		return nil
 	}
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1146,8 +1146,50 @@ func (e *Engine) closeLedger() {
 func (e *Engine) phaseEstablish() {
 	roundTime := time.Since(e.roundStartTime)
 
-	// Hard timeout: force accept after LedgerMaxClose
-	if roundTime >= e.timing.LedgerMaxClose {
+	// Absolute hard ceiling: abandon the round once we exceed the
+	// ledgerABANDON_CONSENSUS clamp. Rippled treats this state as
+	// ConsensusState::Expired (Consensus.cpp:253-263) and responds by
+	// calling leaveConsensus() (Consensus.h:1760-1785): bow out of
+	// proposing, then fall through to accept — do NOT restart the round
+	// with an empty set. We mirror that here: setMode(Observing) if we
+	// were proposing, then accept with ResultAbandoned so higher layers
+	// can distinguish a hard abandon from the soft LedgerMaxConsensus
+	// force-accept below.
+	if e.timing.LedgerAbandonConsensus > 0 && e.abandonDeadlineExceeded(roundTime) {
+		slog.Warn("consensus taken too long, abandoning round",
+			"t", "Consensus",
+			"round", e.state.Round,
+			"round_time", roundTime,
+			"prev_round_time", e.prevRoundTime,
+			"max_consensus", e.timing.LedgerMaxConsensus,
+			"abandon_consensus", e.timing.LedgerAbandonConsensus,
+		)
+		e.eventBus.Publish(&consensus.TimerFiredEvent{
+			Timer:     consensus.TimerRoundTimeout,
+			Round:     e.state.Round,
+			Timestamp: e.adaptor.Now(),
+		})
+		// Rippled's leaveConsensus: stop proposing if we were.
+		if e.mode == consensus.ModeProposing {
+			e.setMode(consensus.ModeObserving)
+		}
+		e.acceptLedger(consensus.ResultAbandoned)
+		return
+	}
+
+	// Soft timeout: force accept after LedgerMaxConsensus.
+	// Pre-E3 this gated on the goXRPL-only LedgerMaxClose=10s; it is
+	// now rippled's ledgerMAX_CONSENSUS=15s, keeping the same force-
+	// accept action but pushed out to match rippled's deadline. The
+	// legacy LedgerMaxClose field is still honored for source-compat
+	// when set smaller than LedgerMaxConsensus — it takes precedence
+	// so tests can dial the trigger down without also having to reset
+	// LedgerMaxConsensus.
+	softDeadline := e.timing.LedgerMaxConsensus
+	if e.timing.LedgerMaxClose > 0 && e.timing.LedgerMaxClose < softDeadline {
+		softDeadline = e.timing.LedgerMaxClose
+	}
+	if softDeadline > 0 && roundTime >= softDeadline {
 		e.eventBus.Publish(&consensus.TimerFiredEvent{
 			Timer:     consensus.TimerRoundTimeout,
 			Round:     e.state.Round,
@@ -1163,6 +1205,35 @@ func (e *Engine) phaseEstablish() {
 	}
 	e.updateCloseTimePosition()
 	e.checkConvergence()
+}
+
+// abandonDeadlineExceeded reports whether the current round has run
+// past the ledgerABANDON_CONSENSUS clamp. The effective hard deadline
+// is std::clamp(prevRoundTime * factor, LedgerMaxConsensus,
+// LedgerAbandonConsensus) — see Consensus.cpp:253-258.
+// Caller must hold e.mu.
+func (e *Engine) abandonDeadlineExceeded(roundTime time.Duration) bool {
+	lo := e.timing.LedgerMaxConsensus
+	hi := e.timing.LedgerAbandonConsensus
+	if hi <= 0 {
+		return false
+	}
+	// Rippled's clamp(maxAgreeTime, lo, hi): factor×previous, clamped
+	// to [lo, hi]. Factor 0 (not configured) disables the scaling and
+	// falls back to the absolute ceiling.
+	var deadline time.Duration
+	if e.timing.LedgerAbandonConsensusFactor > 0 && e.prevRoundTime > 0 {
+		deadline = e.prevRoundTime * time.Duration(e.timing.LedgerAbandonConsensusFactor)
+	} else {
+		deadline = hi
+	}
+	if lo > 0 && deadline < lo {
+		deadline = lo
+	}
+	if deadline > hi {
+		deadline = hi
+	}
+	return roundTime > deadline
 }
 
 // checkConvergence checks if proposals have converged.

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -81,6 +81,15 @@ type Engine struct {
 	// while in ModeWrongLedger. Prevents spamming handleWrongLedger.
 	wrongLedgerID consensus.LedgerID
 
+	// lastSignTime is the monotonic floor for emitted validation
+	// SignTime. If the adaptor clock regresses (NTP step, leap-second
+	// correction, VM pause/resume), sendValidation bumps SignTime to
+	// lastSignTime + 1s so peers never see a non-monotonic sequence of
+	// validations from the same node. Matches rippled's
+	// RCLConsensus::Adaptor::lastValidationTime_ (RCLConsensus.cpp:825-828).
+	// Protected by e.mu (same lock as sendValidation's other state).
+	lastSignTime time.Time
+
 	// Stats
 	roundCount     uint64
 	consensusCount uint64
@@ -1652,12 +1661,25 @@ func (e *Engine) sendValidation(ledger consensus.Ledger) {
 
 	full := e.mode == consensus.ModeProposing
 
+	// Compute SignTime under a monotonic floor. If the adaptor clock
+	// regresses (NTP step, leap-second correction, VM pause/resume) the
+	// emitted SignTime could be older than the prior validation from
+	// this node, so peers would reject it as stale. Bump to
+	// lastSignTime + 1s in that case to preserve monotonicity. Matches
+	// rippled RCLConsensus.cpp:825-828. SeenTime mirrors SignTime (as
+	// before) so the two remain equal on emission.
+	signTime := e.adaptor.Now()
+	if !e.lastSignTime.IsZero() && !signTime.After(e.lastSignTime) {
+		signTime = e.lastSignTime.Add(1 * time.Second)
+	}
+	e.lastSignTime = signTime
+
 	validation := &consensus.Validation{
 		LedgerID:  ledger.ID(),
 		LedgerSeq: ledger.Seq(),
 		NodeID:    nodeID,
-		SignTime:  e.adaptor.Now(),
-		SeenTime:  e.adaptor.Now(),
+		SignTime:  signTime,
+		SeenTime:  signTime,
 		Full:      full,
 		// R6b.5b: emit local load_fee (sfLoadFee) — rippled
 		// RCLConsensus.cpp:851 always populates this under

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -1327,3 +1327,171 @@ func TestSendValidation_FeeVoteOnlyOnFlagLedger(t *testing.T) {
 		t.Errorf("flag ledger must carry Amendments vote: got %d IDs", len(flag.Amendments))
 	}
 }
+
+// TestSendValidation_PreHardenedValidations_OmitsCookieAndServerVersion
+// pins B1: with featureHardenedValidations DISABLED, sendValidation
+// must leave Cookie and ServerVersion zero on the emitted validation.
+// Rippled RCLConsensus.cpp:853-867 scopes both fields inside the
+// `if (rules().enabled(featureHardenedValidations))` block, so a node
+// running against pre-HardenedValidations rules MUST omit them or
+// peers on the old rules compute a different preimage and reject the
+// signature.
+func TestSendValidation_PreHardenedValidations_OmitsCookieAndServerVersion(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	// Give the adaptor explicit non-zero Cookie/ServerVersion so we can
+	// prove the engine itself (not the mock) is suppressing them.
+	adaptor.cookie = 0xDEADBEEF_CAFEBABE
+	adaptor.serverVersion = 0x4000_0000_DEAD_BEEF
+
+	// Disable HardenedValidations so the gate should zero out both
+	// fields regardless of whether we're on a voting ledger.
+	adaptor.disabledFeatures = map[string]bool{"HardenedValidations": true}
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	round := consensus.RoundID{Seq: 100, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	adaptor.mu.Lock()
+	adaptor.validationsBroadcast = nil
+	adaptor.mu.Unlock()
+
+	// Use a voting-ledger seq (255+1=256) to prove the voting-ledger
+	// path also respects the HardenedValidations gate — rippled emits
+	// sfServerVersion only inside the HV block AND only on voting
+	// ledgers; if HV is off, neither condition matters.
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xCA}, seq: 255})
+	engine.mu.Unlock()
+
+	// Verify the struct itself (what the adaptor sees pre-sign).
+	adaptor.mu.RLock()
+	defer adaptor.mu.RUnlock()
+	if len(adaptor.validationsBroadcast) != 1 {
+		t.Fatalf("want one validation, got %d", len(adaptor.validationsBroadcast))
+	}
+	v := adaptor.validationsBroadcast[0]
+	if v.Cookie != 0 {
+		t.Errorf("pre-HardenedValidations: Cookie must be zero, got %x", v.Cookie)
+	}
+	if v.ServerVersion != 0 {
+		t.Errorf("pre-HardenedValidations: ServerVersion must be zero, got %x", v.ServerVersion)
+	}
+}
+
+// TestSendValidation_HardenedValidations_NonVotingLedger_OmitsServerVersion
+// pins the rippled voting-ledger scope for sfServerVersion
+// (RCLConsensus.cpp:864-866). With HardenedValidations ON but a
+// non-voting ledger sequence, Cookie must be populated but
+// ServerVersion must stay zero. Rippled gates sfServerVersion on
+// BOTH HV enabled AND ledger.isVotingLedger() — miss either side and
+// the field is omitted.
+func TestSendValidation_HardenedValidations_NonVotingLedger_OmitsServerVersion(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	adaptor.cookie = 0x1234_5678_9ABC_DEF0
+	adaptor.serverVersion = 0x4000_0000_1111_2222
+
+	// HardenedValidations enabled (default mock behavior) — don't set
+	// disabledFeatures.
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	round := consensus.RoundID{Seq: 100, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	adaptor.mu.Lock()
+	adaptor.validationsBroadcast = nil
+	adaptor.mu.Unlock()
+
+	// seq=100 → (100+1)%256 != 0 — non-voting ledger. Cookie must
+	// still emit (unconditional under HV), ServerVersion must not.
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xBB}, seq: 100})
+	engine.mu.Unlock()
+
+	adaptor.mu.RLock()
+	defer adaptor.mu.RUnlock()
+	if len(adaptor.validationsBroadcast) != 1 {
+		t.Fatalf("want one validation, got %d", len(adaptor.validationsBroadcast))
+	}
+	v := adaptor.validationsBroadcast[0]
+	if v.Cookie != 0x1234_5678_9ABC_DEF0 {
+		t.Errorf("HardenedValidations enabled: Cookie must carry adaptor value, got %x", v.Cookie)
+	}
+	if v.ServerVersion != 0 {
+		t.Errorf("non-voting ledger: ServerVersion must be zero, got %x", v.ServerVersion)
+	}
+}
+
+// TestSendValidation_HardenedValidations_VotingLedger_EmitsBoth pins
+// the positive case of B1: HardenedValidations ON and isVotingLedger()
+// true (the only branch where rippled RCLConsensus.cpp:861-866 sets
+// both sfCookie AND sfServerVersion). Also asserts that the full
+// serialized validation carries the sfServerVersion field code
+// (type=3, field=11), not just the struct value — defense-in-depth
+// check against the serializer short-circuiting on zero.
+func TestSendValidation_HardenedValidations_VotingLedger_EmitsBoth(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	adaptor.cookie = 0xAAAA_BBBB_CCCC_DDDD
+	adaptor.serverVersion = 0x4000_0000_DEAD_FEED
+
+	// HardenedValidations enabled (default mock behavior).
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	round := consensus.RoundID{Seq: 100, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	adaptor.mu.Lock()
+	adaptor.validationsBroadcast = nil
+	adaptor.mu.Unlock()
+
+	// seq=255 → (255+1)%256 == 0 — voting ledger. Both fields must
+	// be present.
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xCC}, seq: 255})
+	engine.mu.Unlock()
+
+	adaptor.mu.RLock()
+	defer adaptor.mu.RUnlock()
+	if len(adaptor.validationsBroadcast) != 1 {
+		t.Fatalf("want one validation, got %d", len(adaptor.validationsBroadcast))
+	}
+	v := adaptor.validationsBroadcast[0]
+	if v.Cookie != 0xAAAA_BBBB_CCCC_DDDD {
+		t.Errorf("voting-ledger HV: Cookie must carry adaptor value, got %x", v.Cookie)
+	}
+	if v.ServerVersion != 0x4000_0000_DEAD_FEED {
+		t.Errorf("voting-ledger HV: ServerVersion must carry adaptor value, got %x", v.ServerVersion)
+	}
+}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -1849,3 +1849,217 @@ func TestSendValidation_ClockMonotonic_NormalCase(t *testing.T) {
 			second.SignTime, second.SeenTime)
 	}
 }
+
+// TestConsensus_MaxConsensusSoftTimeoutTransitions pins the behavior
+// of the E3 soft deadline: once a round exceeds LedgerMaxConsensus
+// (rippled's ledgerMAX_CONSENSUS = 15s, ConsensusParms.h:95), the
+// engine force-accepts the round with ResultTimeout and transitions
+// from Establish → Accepted. This is the rename-migrated action
+// that, pre-E3, fired at the goXRPL-only LedgerMaxClose=10s. It must
+// NOT trigger a bow-out (that is reserved for the hard abandon
+// branch at 120s, covered by TestConsensus_AbandonHardTimeout).
+func TestConsensus_MaxConsensusSoftTimeoutTransitions(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+
+	// Default 15s soft / 120s hard. Override LedgerMaxClose to match
+	// LedgerMaxConsensus exactly so the legacy alias doesn't preempt
+	// the soft-deadline check.
+	config := DefaultConfig()
+	config.Timing.LedgerMaxConsensus = 15 * time.Second
+	config.Timing.LedgerMaxClose = 15 * time.Second
+	config.Timing.LedgerAbandonConsensus = 120 * time.Second
+	config.Timing.LedgerAbandonConsensusFactor = 10
+
+	engine := NewEngine(adaptor, config)
+
+	subscriber := &testSubscriber{events: make(chan consensus.Event, 32)}
+	engine.Subscribe(subscriber)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	// Force the engine into Establish with a known roundStartTime
+	// 16s in the past — just past the 15s soft deadline but before
+	// the factor-scaled hard abandon ceiling (see prevRoundTime
+	// below). This mirrors rippled's window between ledgerMAX_
+	// CONSENSUS and the std::clamp'd ledgerABANDON_CONSENSUS:
+	// currentAgreeTime > ledgerMAX_CONSENSUS (relaxes threshold)
+	// but currentAgreeTime <= clamp(prevRoundTime * factor,
+	// ledgerMAX_CONSENSUS, ledgerABANDON_CONSENSUS) (no abandon).
+	engine.mu.Lock()
+	engine.setPhase(consensus.PhaseEstablish)
+	engine.roundStartTime = time.Now().Add(-16 * time.Second)
+	// prevRoundTime × factor = 2s × 10 = 20s. std::clamp pins the
+	// hard deadline to 20s (between the 15s low and the 120s high).
+	// At 16s we are past the soft (15s) but short of the hard (20s),
+	// so the hard branch must NOT fire.
+	engine.prevRoundTime = 2 * time.Second
+	engine.phaseEstablish()
+	phaseAfter := engine.phase
+	modeAfter := engine.mode
+	engine.mu.Unlock()
+
+	// Soft timeout force-accepts → phase must have transitioned out
+	// of Establish (to Accepted). The exact target depends on the
+	// auto-advance in acceptLedger; either Accepted or Open (next
+	// round) is acceptable, as long as we left Establish.
+	if phaseAfter == consensus.PhaseEstablish {
+		t.Errorf("soft timeout: phase should have transitioned out of Establish, got %v", phaseAfter)
+	}
+
+	// Soft timeout MUST NOT bow out a proposing validator — that's
+	// the hard-abandon semantic, not the soft one.
+	if modeAfter == consensus.ModeObserving {
+		t.Errorf("soft timeout must NOT bow out (mode=Observing); got mode=%v — that is the hard-abandon behavior", modeAfter)
+	}
+
+	// Drain events and assert we saw a ConsensusReachedEvent with
+	// ResultTimeout, not ResultAbandoned.
+	sawTimeout := false
+	sawAbandoned := false
+	deadline := time.After(500 * time.Millisecond)
+drain:
+	for {
+		select {
+		case ev := <-subscriber.events:
+			if cre, ok := ev.(*consensus.ConsensusReachedEvent); ok {
+				switch cre.Result {
+				case consensus.ResultTimeout:
+					sawTimeout = true
+				case consensus.ResultAbandoned:
+					sawAbandoned = true
+				}
+			}
+		case <-deadline:
+			break drain
+		}
+	}
+	if !sawTimeout {
+		t.Errorf("expected ConsensusReachedEvent with ResultTimeout from soft deadline")
+	}
+	if sawAbandoned {
+		t.Errorf("soft timeout must not emit ResultAbandoned")
+	}
+}
+
+// TestConsensus_AbandonHardTimeout pins the behavior of the E3 hard
+// deadline: once a round exceeds the ledgerABANDON_CONSENSUS clamp
+// (rippled's 15s..120s clamp, ConsensusParms.h:113), the engine
+// abandons the round. Per rippled Consensus.cpp:253-263 + Consensus.h:
+// 1760-1785, this means:
+//
+//  1. We treat the state as ConsensusState::Expired.
+//  2. leaveConsensus() is called — if we were proposing, we bow out
+//     to Observing (Consensus.h:1802-1817).
+//  3. The accept step still runs with a distinct Result so callers
+//     can tell a hard abandon from a soft force-accept.
+//
+// goXRPL surfaces (3) as ResultAbandoned.
+func TestConsensus_AbandonHardTimeout(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+
+	config := DefaultConfig()
+	config.Timing.LedgerMaxConsensus = 15 * time.Second
+	config.Timing.LedgerMaxClose = 15 * time.Second
+	config.Timing.LedgerAbandonConsensus = 120 * time.Second
+	config.Timing.LedgerAbandonConsensusFactor = 10
+
+	engine := NewEngine(adaptor, config)
+
+	subscriber := &testSubscriber{events: make(chan consensus.Event, 32)}
+	engine.Subscribe(subscriber)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	// Confirm the engine entered ModeProposing — the abandon branch
+	// must demote a proposing validator (rippled leaveConsensus).
+	engine.mu.Lock()
+	if engine.mode != consensus.ModeProposing {
+		engine.mu.Unlock()
+		t.Fatalf("setup: expected ModeProposing after StartRound, got %v", engine.mode)
+	}
+	// Force the engine into Establish with a roundStartTime 121s in
+	// the past — past the absolute 120s hard ceiling. Set
+	// prevRoundTime high so the factor×clamp would produce a huge
+	// deadline; the hard abandon ceiling must still fire.
+	engine.setPhase(consensus.PhaseEstablish)
+	engine.roundStartTime = time.Now().Add(-121 * time.Second)
+	engine.prevRoundTime = 60 * time.Second // factor×60s=600s, clamped down to 120s
+	engine.phaseEstablish()
+	phaseAfter := engine.phase
+	modeAfter := engine.mode
+	engine.mu.Unlock()
+
+	// Hard abandon must transition out of Establish.
+	if phaseAfter == consensus.PhaseEstablish {
+		t.Errorf("hard abandon: phase should have transitioned out of Establish, got %v", phaseAfter)
+	}
+
+	// Hard abandon bows a proposing validator out to Observing
+	// (rippled leaveConsensus). After auto-advance in acceptLedger
+	// we may re-promote, but at minimum we must NOT still be
+	// ModeProposing on the same round — the round was abandoned.
+	// Accept either Observing (bow-out held through the new round
+	// setup) or the post-advance promotion back to Proposing if the
+	// new round re-promoted cleanly. What we assert is that the
+	// bow-out step ran: the adaptor.modeChanges transcript must
+	// contain an Observing transition.
+	adaptor.mu.RLock()
+	sawObserving := false
+	for _, m := range adaptor.modeChanges {
+		if m == consensus.ModeObserving {
+			sawObserving = true
+			break
+		}
+	}
+	adaptor.mu.RUnlock()
+	if !sawObserving {
+		t.Errorf("hard abandon: expected bow-out to ModeObserving (rippled leaveConsensus), modeChanges=%v, final mode=%v", adaptor.modeChanges, modeAfter)
+	}
+
+	// Drain events and assert ResultAbandoned was emitted.
+	sawAbandoned := false
+	sawTimeout := false
+	deadline := time.After(500 * time.Millisecond)
+drain:
+	for {
+		select {
+		case ev := <-subscriber.events:
+			if cre, ok := ev.(*consensus.ConsensusReachedEvent); ok {
+				switch cre.Result {
+				case consensus.ResultAbandoned:
+					sawAbandoned = true
+				case consensus.ResultTimeout:
+					sawTimeout = true
+				}
+			}
+		case <-deadline:
+			break drain
+		}
+	}
+	if !sawAbandoned {
+		t.Errorf("expected ConsensusReachedEvent with ResultAbandoned from hard abandon")
+	}
+	if sawTimeout {
+		t.Errorf("hard abandon must not emit ResultTimeout (that is the soft branch)")
+	}
+}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -791,12 +791,12 @@ func TestDefaultConfig(t *testing.T) {
 		t.Error("LedgerMaxClose should not be zero")
 	}
 
-	if config.Thresholds.MinConsensusPct == 0 {
-		t.Error("MinConsensusPct should not be zero")
+	if config.Thresholds.EarlyConvergencePct == 0 {
+		t.Error("EarlyConvergencePct should not be zero")
 	}
 
-	if config.Thresholds.MaxConsensusPct == 0 {
-		t.Error("MaxConsensusPct should not be zero")
+	if config.Thresholds.MinConsensusPct == 0 {
+		t.Error("MinConsensusPct should not be zero")
 	}
 }
 

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -25,19 +25,53 @@ func (l *mockLedger) CloseTime() time.Time         { return l.closeTime }
 func (l *mockLedger) TxSetID() consensus.TxSetID   { return l.txSetID }
 func (l *mockLedger) Bytes() []byte                { return nil }
 
-// mockTxSet implements consensus.TxSet for testing
+// mockTxSet implements consensus.TxSet for testing. containsTxs, if
+// non-nil, drives Contains(id); otherwise Contains always returns
+// false (matching the legacy behavior some older tests rely on).
+// txIDs is kept in insertion order, parallel to txs, so TxIDs() and
+// Txs() can be zipped — matching the documented contract on the
+// interface.
 type mockTxSet struct {
-	id  consensus.TxSetID
-	txs [][]byte
+	id          consensus.TxSetID
+	txs         [][]byte
+	txIDs       []consensus.TxID
+	containsTxs map[consensus.TxID]bool
 }
 
-func (ts *mockTxSet) ID() consensus.TxSetID           { return ts.id }
-func (ts *mockTxSet) Txs() [][]byte                   { return ts.txs }
-func (ts *mockTxSet) Size() int                       { return len(ts.txs) }
-func (ts *mockTxSet) Contains(id consensus.TxID) bool { return false }
-func (ts *mockTxSet) Add(tx []byte) error             { ts.txs = append(ts.txs, tx); return nil }
-func (ts *mockTxSet) Remove(id consensus.TxID) error  { return nil }
-func (ts *mockTxSet) Bytes() []byte                   { return nil }
+func (ts *mockTxSet) ID() consensus.TxSetID { return ts.id }
+func (ts *mockTxSet) Txs() [][]byte         { return ts.txs }
+func (ts *mockTxSet) Size() int             { return len(ts.txs) }
+func (ts *mockTxSet) TxIDs() []consensus.TxID {
+	if ts.txIDs != nil {
+		out := make([]consensus.TxID, len(ts.txIDs))
+		copy(out, ts.txIDs)
+		return out
+	}
+	// Fallback for legacy construction sites that populate only
+	// containsTxs — iteration order is non-deterministic here but
+	// the legacy tests that follow this path don't care.
+	result := make([]consensus.TxID, 0, len(ts.containsTxs))
+	for id, ok := range ts.containsTxs {
+		if ok {
+			result = append(result, id)
+		}
+	}
+	return result
+}
+func (ts *mockTxSet) Contains(id consensus.TxID) bool {
+	if ts.containsTxs != nil {
+		return ts.containsTxs[id]
+	}
+	return false
+}
+func (ts *mockTxSet) Add(tx []byte) error { ts.txs = append(ts.txs, tx); return nil }
+func (ts *mockTxSet) Remove(id consensus.TxID) error {
+	if ts.containsTxs != nil {
+		delete(ts.containsTxs, id)
+	}
+	return nil
+}
+func (ts *mockTxSet) Bytes() []byte { return nil }
 
 // mockAdaptor implements consensus.Adaptor for testing
 type mockAdaptor struct {
@@ -229,8 +263,28 @@ func (a *mockAdaptor) GetTxSet(id consensus.TxSetID) (consensus.TxSet, error) {
 }
 
 func (a *mockAdaptor) BuildTxSet(txs [][]byte) (consensus.TxSet, error) {
-	txSet := &mockTxSet{txs: txs}
-	// Generate a simple ID based on length
+	// Derive per-tx IDs from the blob prefix so the resulting TxSet
+	// reports Contains/TxIDs correctly. Dispute-integration tests
+	// build blobs as the tx ID padded to 32 bytes; legacy tests pass
+	// nil or empty blobs and only care about the set ID, so they
+	// still get a valid (if all-zero-id) mockTxSet.
+	ids := make([]consensus.TxID, 0, len(txs))
+	contains := make(map[consensus.TxID]bool, len(txs))
+	for _, blob := range txs {
+		var id consensus.TxID
+		if len(blob) >= len(id) {
+			copy(id[:], blob[:len(id)])
+		}
+		ids = append(ids, id)
+		contains[id] = true
+	}
+	txSet := &mockTxSet{
+		txs:         txs,
+		txIDs:       ids,
+		containsTxs: contains,
+	}
+	// Keep the length-based TxSetID for backward-compat: older tests
+	// reference it as {byte(len(txs)), 0,...}.
 	txSet.id = consensus.TxSetID{byte(len(txs))}
 	a.mu.Lock()
 	a.txSets[txSet.id] = txSet

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -1694,3 +1694,158 @@ func TestStartRound_ClearsDeadNodes(t *testing.T) {
 		t.Errorf("expected rejoined proposal from %v to be accepted in the new round", bowingNode)
 	}
 }
+
+// Task 2.5 (B5): tests for monotonic SignTime on emitted validations.
+// Rippled reference: RCLConsensus.cpp:825-828 — if the wall clock regresses
+// (NTP step, leap-second correction, VM pause/resume), the validation sign
+// time is bumped to lastValidationTime_ + 1s so peers never see a non-
+// monotonic sequence of validations from the same node.
+
+// TestSendValidation_ClockRegressionPreservesMonotonic drives sendValidation
+// twice with a regressing fake clock and asserts the second SignTime is
+// exactly first + 1s (NOT the regressed adaptor.Now() value). Without this
+// guard, peers treat the second validation as stale and drop it — matching
+// rippled's behavior where older-than-last validations are rejected.
+func TestSendValidation_ClockRegressionPreservesMonotonic(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	round := consensus.RoundID{Seq: 100, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	adaptor.mu.Lock()
+	adaptor.validationsBroadcast = nil
+	// Pin the clock to a known value so both observations are deterministic.
+	baseTime := time.Unix(1_700_000_000, 0).UTC()
+	adaptor.now = baseTime
+	adaptor.mu.Unlock()
+
+	// First emission — SignTime should equal the fake clock.
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xA1}, seq: 101})
+	engine.mu.Unlock()
+
+	adaptor.mu.RLock()
+	if len(adaptor.validationsBroadcast) != 1 {
+		adaptor.mu.RUnlock()
+		t.Fatalf("want one validation after first send, got %d", len(adaptor.validationsBroadcast))
+	}
+	first := adaptor.validationsBroadcast[0]
+	adaptor.mu.RUnlock()
+
+	if !first.SignTime.Equal(baseTime) {
+		t.Errorf("first SignTime: want %v, got %v", baseTime, first.SignTime)
+	}
+	if !first.SeenTime.Equal(first.SignTime) {
+		t.Errorf("first SeenTime must equal SignTime: got SignTime=%v SeenTime=%v",
+			first.SignTime, first.SeenTime)
+	}
+
+	// Regress the clock by 5 seconds (simulates NTP step / VM pause-resume).
+	adaptor.mu.Lock()
+	adaptor.now = baseTime.Add(-5 * time.Second)
+	adaptor.mu.Unlock()
+
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xA2}, seq: 102})
+	engine.mu.Unlock()
+
+	adaptor.mu.RLock()
+	if len(adaptor.validationsBroadcast) != 2 {
+		adaptor.mu.RUnlock()
+		t.Fatalf("want two validations after second send, got %d", len(adaptor.validationsBroadcast))
+	}
+	second := adaptor.validationsBroadcast[1]
+	adaptor.mu.RUnlock()
+
+	// Second SignTime must be first + 1s, NOT the regressed adaptor.Now().
+	want := first.SignTime.Add(1 * time.Second)
+	if !second.SignTime.Equal(want) {
+		t.Errorf("clock regressed: second SignTime: want %v (first + 1s), got %v",
+			want, second.SignTime)
+	}
+	if !second.SeenTime.Equal(second.SignTime) {
+		t.Errorf("second SeenTime must equal SignTime: got SignTime=%v SeenTime=%v",
+			second.SignTime, second.SeenTime)
+	}
+}
+
+// TestSendValidation_ClockMonotonic_NormalCase confirms the monotonic floor
+// does NOT inject an artificial step when the adaptor clock advances
+// normally. With a 3-second forward step, the second SignTime should be
+// exactly adaptor.Now() (first + 3s), not first + 1s.
+func TestSendValidation_ClockMonotonic_NormalCase(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	round := consensus.RoundID{Seq: 100, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	adaptor.mu.Lock()
+	adaptor.validationsBroadcast = nil
+	baseTime := time.Unix(1_700_000_000, 0).UTC()
+	adaptor.now = baseTime
+	adaptor.mu.Unlock()
+
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xB1}, seq: 201})
+	engine.mu.Unlock()
+
+	adaptor.mu.RLock()
+	first := adaptor.validationsBroadcast[0]
+	adaptor.mu.RUnlock()
+
+	// Advance the clock 3 seconds forward — normal progression.
+	adaptor.mu.Lock()
+	adaptor.now = baseTime.Add(3 * time.Second)
+	adaptor.mu.Unlock()
+
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xB2}, seq: 202})
+	engine.mu.Unlock()
+
+	adaptor.mu.RLock()
+	if len(adaptor.validationsBroadcast) != 2 {
+		adaptor.mu.RUnlock()
+		t.Fatalf("want two validations, got %d", len(adaptor.validationsBroadcast))
+	}
+	second := adaptor.validationsBroadcast[1]
+	adaptor.mu.RUnlock()
+
+	// The difference must be exactly 3s — no artificial +1s step.
+	diff := second.SignTime.Sub(first.SignTime)
+	if diff != 3*time.Second {
+		t.Errorf("normal clock advance: want SignTime difference 3s, got %v", diff)
+	}
+	// Second SignTime must equal adaptor.Now() — NOT the monotonic floor.
+	want := baseTime.Add(3 * time.Second)
+	if !second.SignTime.Equal(want) {
+		t.Errorf("second SignTime: want %v (adaptor.Now), got %v", want, second.SignTime)
+	}
+	if !second.SeenTime.Equal(second.SignTime) {
+		t.Errorf("second SeenTime must equal SignTime: got SignTime=%v SeenTime=%v",
+			second.SignTime, second.SeenTime)
+	}
+}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -1499,3 +1499,198 @@ func TestSendValidation_HardenedValidations_VotingLedger_EmitsBoth(t *testing.T)
 		t.Errorf("voting-ledger HV: ServerVersion must carry adaptor value, got %x", v.ServerVersion)
 	}
 }
+
+// Task 2.4 (B4): tests for isBowOut (seqLeave == 0xFFFFFFFF) detection.
+// Rippled reference: ConsensusProposal.h:68,154-156 and Consensus.h:804-817.
+// A validator bowing out sets ProposeSeq to seqLeave so peers know to stop
+// counting them for the remainder of the round. We must evict their current
+// position and refuse further proposals until the next round clears the set.
+
+// TestOnProposal_BowOutEvictsNode feeds a valid proposal from node X, then
+// a seqLeave proposal from X, and asserts that the stored position for X is
+// cleared. Mirrors rippled's Consensus.h:812-814 where peerPositions gets
+// erase(peerID) on bow-out and the nodeID is inserted into deadNodes_.
+func TestOnProposal_BowOutEvictsNode(t *testing.T) {
+	adaptor := newMockAdaptor()
+	bowingNode := consensus.NodeID{2}
+	adaptor.setTrusted([]consensus.NodeID{bowingNode, {3}})
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+
+	// Initial proposal — should be stored.
+	first := &consensus.Proposal{
+		Round:          round,
+		NodeID:         bowingNode,
+		Position:       0,
+		TxSet:          consensus.TxSetID{1},
+		CloseTime:      time.Now(),
+		PreviousLedger: consensus.LedgerID{1},
+		Timestamp:      time.Now(),
+	}
+	if err := engine.OnProposal(first, 0); err != nil {
+		t.Fatalf("first OnProposal: %v", err)
+	}
+
+	engine.mu.RLock()
+	_, stored := engine.proposals[bowingNode]
+	engine.mu.RUnlock()
+	if !stored {
+		t.Fatalf("precondition: first proposal from bowingNode should have been stored")
+	}
+
+	// Bow-out proposal — Position == seqLeave (0xFFFFFFFF).
+	bowOut := &consensus.Proposal{
+		Round:          round,
+		NodeID:         bowingNode,
+		Position:       0xFFFFFFFF,
+		TxSet:          consensus.TxSetID{2},
+		CloseTime:      time.Now(),
+		PreviousLedger: consensus.LedgerID{1},
+		Timestamp:      time.Now(),
+	}
+	if err := engine.OnProposal(bowOut, 0); err != nil {
+		t.Fatalf("bow-out OnProposal: %v", err)
+	}
+
+	engine.mu.RLock()
+	_, stillStored := engine.proposals[bowingNode]
+	_, dead := engine.deadNodes[bowingNode]
+	engine.mu.RUnlock()
+
+	if stillStored {
+		t.Errorf("expected bowed-out node %v to be evicted from proposals map", bowingNode)
+	}
+	if !dead {
+		t.Errorf("expected bowed-out node %v to be recorded in deadNodes set", bowingNode)
+	}
+}
+
+// TestOnProposal_DeadNodeLaterProposalIgnored verifies that once a node
+// bows out, any subsequent proposal it sends in the same round is ignored.
+// Matches rippled's Consensus.h:785-789 guard.
+func TestOnProposal_DeadNodeLaterProposalIgnored(t *testing.T) {
+	adaptor := newMockAdaptor()
+	bowingNode := consensus.NodeID{2}
+	adaptor.setTrusted([]consensus.NodeID{bowingNode, {3}})
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+
+	bowOut := &consensus.Proposal{
+		Round:          round,
+		NodeID:         bowingNode,
+		Position:       0xFFFFFFFF,
+		TxSet:          consensus.TxSetID{2},
+		CloseTime:      time.Now(),
+		PreviousLedger: consensus.LedgerID{1},
+		Timestamp:      time.Now(),
+	}
+	if err := engine.OnProposal(bowOut, 0); err != nil {
+		t.Fatalf("bow-out OnProposal: %v", err)
+	}
+
+	// A "normal" proposal after bow-out must be silently dropped.
+	followUp := &consensus.Proposal{
+		Round:          round,
+		NodeID:         bowingNode,
+		Position:       1,
+		TxSet:          consensus.TxSetID{3},
+		CloseTime:      time.Now(),
+		PreviousLedger: consensus.LedgerID{1},
+		Timestamp:      time.Now(),
+	}
+	if err := engine.OnProposal(followUp, 0); err != nil {
+		t.Fatalf("follow-up OnProposal: %v", err)
+	}
+
+	engine.mu.RLock()
+	_, stored := engine.proposals[bowingNode]
+	engine.mu.RUnlock()
+	if stored {
+		t.Errorf("expected follow-up proposal from dead node %v to be ignored, but it was stored", bowingNode)
+	}
+}
+
+// TestStartRound_ClearsDeadNodes verifies that a new round clears the
+// deadNodes set so a validator can rejoin consensus in the next round.
+// Matches rippled's Consensus.h:722 (startRoundInternal clears deadNodes_).
+func TestStartRound_ClearsDeadNodes(t *testing.T) {
+	adaptor := newMockAdaptor()
+	bowingNode := consensus.NodeID{2}
+	adaptor.setTrusted([]consensus.NodeID{bowingNode, {3}})
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	round1 := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round1, true); err != nil {
+		t.Fatalf("StartRound round1: %v", err)
+	}
+
+	// Bow out in round 1.
+	bowOut := &consensus.Proposal{
+		Round:          round1,
+		NodeID:         bowingNode,
+		Position:       0xFFFFFFFF,
+		TxSet:          consensus.TxSetID{2},
+		CloseTime:      time.Now(),
+		PreviousLedger: consensus.LedgerID{1},
+		Timestamp:      time.Now(),
+	}
+	if err := engine.OnProposal(bowOut, 0); err != nil {
+		t.Fatalf("bow-out OnProposal: %v", err)
+	}
+
+	engine.mu.RLock()
+	_, deadAfterBow := engine.deadNodes[bowingNode]
+	engine.mu.RUnlock()
+	if !deadAfterBow {
+		t.Fatalf("precondition: bowingNode should be marked dead after bow-out")
+	}
+
+	// Start the next round — deadNodes must reset.
+	round2 := consensus.RoundID{Seq: 102, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round2, true); err != nil {
+		t.Fatalf("StartRound round2: %v", err)
+	}
+
+	engine.mu.RLock()
+	_, stillDead := engine.deadNodes[bowingNode]
+	engine.mu.RUnlock()
+	if stillDead {
+		t.Fatalf("expected deadNodes to be cleared after StartRound, but %v is still marked dead", bowingNode)
+	}
+
+	// And a fresh proposal from the previously-bowed node must be accepted
+	// again in the new round.
+	rejoin := &consensus.Proposal{
+		Round:          round2,
+		NodeID:         bowingNode,
+		Position:       0,
+		TxSet:          consensus.TxSetID{5},
+		CloseTime:      time.Now(),
+		PreviousLedger: consensus.LedgerID{1},
+		Timestamp:      time.Now(),
+	}
+	if err := engine.OnProposal(rejoin, 0); err != nil {
+		t.Fatalf("rejoin OnProposal: %v", err)
+	}
+
+	engine.mu.RLock()
+	_, stored := engine.proposals[bowingNode]
+	engine.mu.RUnlock()
+	if !stored {
+		t.Errorf("expected rejoined proposal from %v to be accepted in the new round", bowingNode)
+	}
+}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -152,7 +152,11 @@ func (a *mockAdaptor) RelayValidation(validation *consensus.Validation, _ uint64
 	return nil
 }
 
-func (a *mockAdaptor) UpdateRelaySlot(_ []byte, _ uint64) {}
+func (a *mockAdaptor) UpdateRelaySlot(_ []byte, _ uint64, _ []uint64) {}
+
+// PeersThatHave returns nil — the rcl engine tests never query the
+// overlay's reverse index since they go through a mockAdaptor.
+func (a *mockAdaptor) PeersThatHave(_ [32]byte) []uint64 { return nil }
 
 func (a *mockAdaptor) GetValidatedLedgerHash() consensus.LedgerID {
 	// Test mock: no validated ledger tracking by default. Tests that

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -267,26 +267,30 @@ func (pt *ProposalTracker) Clear() {
 	pt.byTxSet = make(map[consensus.TxSetID]map[consensus.NodeID]bool)
 }
 
-// DisputeTracker tracks disputed transactions during consensus.
+// DisputeTracker tracks disputed transactions and their per-peer
+// votes during a consensus round. Mirrors the role of rippled's
+// Result::disputes map plus the DisputedTx<> mutation API
+// (rippled/src/xrpld/consensus/DisputedTx.h).
 type DisputeTracker struct {
 	mu sync.RWMutex
 
-	// disputes maps tx ID to dispute info
 	disputes map[consensus.TxID]*consensus.DisputedTx
-
-	// ourVotes tracks our votes on disputes
-	ourVotes map[consensus.TxID]bool
 }
 
 // NewDisputeTracker creates a new dispute tracker.
 func NewDisputeTracker() *DisputeTracker {
 	return &DisputeTracker{
 		disputes: make(map[consensus.TxID]*consensus.DisputedTx),
-		ourVotes: make(map[consensus.TxID]bool),
 	}
 }
 
-// CreateDispute creates a new disputed transaction.
+// CreateDispute registers a new disputed transaction. If the dispute
+// already exists, the existing entry is returned unchanged. OurVote
+// is seeded from the caller (it should be set to whether the tx is
+// in our current proposed tx set).
+//
+// Matches the construction arm of rippled's createDisputes
+// (Consensus.h:1867-1884).
 func (dt *DisputeTracker) CreateDispute(txID consensus.TxID, tx []byte, ourVote bool) *consensus.DisputedTx {
 	dt.mu.Lock()
 	defer dt.mu.Unlock()
@@ -296,40 +300,191 @@ func (dt *DisputeTracker) CreateDispute(txID consensus.TxID, tx []byte, ourVote 
 	}
 
 	dispute := &consensus.DisputedTx{
-		TxID:    txID,
-		Tx:      tx,
-		OurVote: ourVote,
-		Yays:    0,
-		Nays:    0,
+		TxID:           txID,
+		Tx:             tx,
+		OurVote:        ourVote,
+		Votes:          make(map[consensus.NodeID]bool),
+		AvalancheState: consensus.AvalancheInit,
 	}
-
-	if ourVote {
-		dispute.Yays = 1
-	} else {
-		dispute.Nays = 1
-	}
-
 	dt.disputes[txID] = dispute
-	dt.ourVotes[txID] = ourVote
-
 	return dispute
 }
 
-// AddVote records a vote on a disputed transaction.
-func (dt *DisputeTracker) AddVote(txID consensus.TxID, include bool) {
+// SetVote records a peer's yes/no vote on a disputed transaction.
+// Returns true iff the vote was newly inserted OR changed from a
+// previous value; returns false if the peer already held this exact
+// vote (no count adjustment needed).
+//
+// The returned bool matches rippled's DisputedTx::setVote contract:
+// callers use it to reset peerUnchangedCounter_ (Consensus.h:1879,
+// 1906) to detect rounds where some peer is still actively updating.
+func (dt *DisputeTracker) SetVote(txID consensus.TxID, peerID consensus.NodeID, yes bool) bool {
 	dt.mu.Lock()
 	defer dt.mu.Unlock()
 
 	dispute, exists := dt.disputes[txID]
 	if !exists {
-		return
+		return false
 	}
 
-	if include {
+	prev, had := dispute.Votes[peerID]
+	switch {
+	case !had:
+		dispute.Votes[peerID] = yes
+		if yes {
+			dispute.Yays++
+		} else {
+			dispute.Nays++
+		}
+		return true
+	case prev == yes:
+		return false
+	case yes:
+		dispute.Votes[peerID] = true
+		dispute.Nays--
 		dispute.Yays++
-	} else {
+		return true
+	default:
+		dispute.Votes[peerID] = false
+		dispute.Yays--
 		dispute.Nays++
+		return true
 	}
+}
+
+// UnVote removes a peer's contribution from every active dispute.
+// Called when the peer bows out of the round (isBowOut), when its
+// last-known proposal ages past proposeFRESHNESS, or when it is
+// otherwise forcibly removed from currPeerPositions_.
+//
+// Matches rippled's bow-out loop at Consensus.h:807-811 and the
+// stale-proposal loop at Consensus.h:1517-1520.
+func (dt *DisputeTracker) UnVote(peerID consensus.NodeID) {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+
+	for _, dispute := range dt.disputes {
+		vote, had := dispute.Votes[peerID]
+		if !had {
+			continue
+		}
+		delete(dispute.Votes, peerID)
+		if vote {
+			dispute.Yays--
+		} else {
+			dispute.Nays--
+		}
+	}
+}
+
+// UpdateDisputes records a peer's position across every active
+// dispute: for each dispute, the peer votes YES iff the disputed tx
+// appears in peerTxSet, else NO. Returns true iff any vote changed.
+//
+// Matches rippled's updateDisputes (Consensus.h:1892-1908).
+func (dt *DisputeTracker) UpdateDisputes(peerID consensus.NodeID, peerTxSet consensus.TxSet) bool {
+	if peerTxSet == nil {
+		return false
+	}
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+
+	changed := false
+	for txID, dispute := range dt.disputes {
+		yes := peerTxSet.Contains(txID)
+		prev, had := dispute.Votes[peerID]
+		switch {
+		case !had:
+			dispute.Votes[peerID] = yes
+			if yes {
+				dispute.Yays++
+			} else {
+				dispute.Nays++
+			}
+			changed = true
+		case prev == yes:
+			// no-op
+		case yes:
+			dispute.Votes[peerID] = true
+			dispute.Nays--
+			dispute.Yays++
+			changed = true
+		default:
+			dispute.Votes[peerID] = false
+			dispute.Yays--
+			dispute.Nays++
+			changed = true
+		}
+	}
+	return changed
+}
+
+// UpdateOurVote re-evaluates our vote on every dispute given the
+// current convergePercent and avalanche thresholds, mirroring
+// rippled's DisputedTx::updateVote (DisputedTx.h:278-338) applied
+// across all disputes as in updateOurPositions (Consensus.h:1536-1564).
+//
+// For each dispute:
+//   - If we already agree with the peer tally (ourVote=yes && nays==0,
+//     or ourVote=no && yays==0), skip.
+//   - Advance the dispute's avalanche state if allowed by percentTime
+//     and MinRounds.
+//   - When proposing, compute weight = (yays*100 + (ourVote ? 100 : 0))
+//     / (yays + nays + 1); flip our vote iff weight > requiredPct.
+//   - When not proposing, flip iff yays > nays (observer rule — we
+//     don't outweigh proposers, just recognize consensus).
+//
+// Returns the list of TxIDs whose OurVote flipped this call. The
+// engine uses that list to rebuild the proposed tx set.
+func (dt *DisputeTracker) UpdateOurVote(percentTime int, proposing bool, parms consensus.ConsensusParms) []consensus.TxID {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+
+	var changed []consensus.TxID
+	for txID, dispute := range dt.disputes {
+		if dispute.OurVote && dispute.Nays == 0 {
+			continue
+		}
+		if !dispute.OurVote && dispute.Yays == 0 {
+			continue
+		}
+
+		dispute.AvalancheCounter++
+		requiredPct, newState := parms.NeededWeight(
+			dispute.AvalancheState,
+			percentTime,
+			dispute.AvalancheCounter,
+			parms.MinRounds,
+		)
+		if newState != nil {
+			dispute.AvalancheState = *newState
+			dispute.AvalancheCounter = 0
+		}
+
+		var newVote bool
+		if proposing {
+			ownContribution := 0
+			if dispute.OurVote {
+				ownContribution = 100
+			}
+			weight := (dispute.Yays*100 + ownContribution) /
+				(dispute.Yays + dispute.Nays + 1)
+			newVote = weight > requiredPct
+		} else {
+			// Observer: just recognize the majority, don't try to
+			// add our own weight.
+			newVote = dispute.Yays > dispute.Nays
+		}
+
+		if newVote == dispute.OurVote {
+			dispute.CurrentVoteCounter++
+			continue
+		}
+		dispute.CurrentVoteCounter = 0
+		dispute.OurVote = newVote
+		changed = append(changed, txID)
+	}
+	return changed
 }
 
 // GetDispute returns a disputed transaction.
@@ -337,6 +492,14 @@ func (dt *DisputeTracker) GetDispute(txID consensus.TxID) *consensus.DisputedTx 
 	dt.mu.RLock()
 	defer dt.mu.RUnlock()
 	return dt.disputes[txID]
+}
+
+// Has reports whether a dispute exists for the given TxID.
+func (dt *DisputeTracker) Has(txID consensus.TxID) bool {
+	dt.mu.RLock()
+	defer dt.mu.RUnlock()
+	_, ok := dt.disputes[txID]
+	return ok
 }
 
 // GetAll returns all disputed transactions.
@@ -349,64 +512,6 @@ func (dt *DisputeTracker) GetAll() []*consensus.DisputedTx {
 		result = append(result, d)
 	}
 	return result
-}
-
-// Resolve determines which transactions should be included.
-// Returns (include, exclude) lists.
-func (dt *DisputeTracker) Resolve(threshold float64) ([]consensus.TxID, []consensus.TxID) {
-	dt.mu.RLock()
-	defer dt.mu.RUnlock()
-
-	var include, exclude []consensus.TxID
-
-	for txID, dispute := range dt.disputes {
-		total := dispute.Yays + dispute.Nays
-		if total == 0 {
-			continue
-		}
-
-		if float64(dispute.Yays)/float64(total) >= threshold {
-			include = append(include, txID)
-		} else {
-			exclude = append(exclude, txID)
-		}
-	}
-
-	return include, exclude
-}
-
-// UpdateOurVote updates our vote on a dispute.
-func (dt *DisputeTracker) UpdateOurVote(txID consensus.TxID, include bool) {
-	dt.mu.Lock()
-	defer dt.mu.Unlock()
-
-	dispute, exists := dt.disputes[txID]
-	if !exists {
-		return
-	}
-
-	oldVote, hadVote := dt.ourVotes[txID]
-	if hadVote && oldVote == include {
-		return // No change
-	}
-
-	// Update vote counts
-	if hadVote {
-		if oldVote {
-			dispute.Yays--
-		} else {
-			dispute.Nays--
-		}
-	}
-
-	if include {
-		dispute.Yays++
-	} else {
-		dispute.Nays++
-	}
-
-	dispute.OurVote = include
-	dt.ourVotes[txID] = include
 }
 
 // Count returns the number of disputes.
@@ -422,5 +527,4 @@ func (dt *DisputeTracker) Clear() {
 	defer dt.mu.Unlock()
 
 	dt.disputes = make(map[consensus.TxID]*consensus.DisputedTx)
-	dt.ourVotes = make(map[consensus.TxID]bool)
 }

--- a/internal/consensus/rcl/proposals_test.go
+++ b/internal/consensus/rcl/proposals_test.go
@@ -332,7 +332,7 @@ func TestDisputeTracker_UpdateDisputes(t *testing.T) {
 	// Peer's tx set contains tx1 but not tx2. UpdateDisputes should
 	// yield Yays=1 on tx1 and Nays=1 on tx2.
 	peerTxSet := &mockTxSet{
-		id:       consensus.TxSetID{1},
+		id:          consensus.TxSetID{1},
 		containsTxs: map[consensus.TxID]bool{tx1: true},
 	}
 

--- a/internal/consensus/rcl/proposals_test.go
+++ b/internal/consensus/rcl/proposals_test.go
@@ -218,93 +218,226 @@ func TestDisputeTracker_CreateAndVote(t *testing.T) {
 	txID := consensus.TxID{1}
 	tx := []byte("test tx")
 
-	// Create dispute
+	// Create dispute. Yays/Nays count peer votes only; our stance
+	// lives on OurVote, matching rippled's DisputedTx constructor.
 	dispute := dt.CreateDispute(txID, tx, true)
 	if dispute == nil {
 		t.Fatal("Dispute should be created")
 	}
-
-	if dispute.Yays != 1 || dispute.Nays != 0 {
-		t.Errorf("Initial vote should be 1 yay, 0 nay; got %d/%d", dispute.Yays, dispute.Nays)
+	if dispute.Yays != 0 || dispute.Nays != 0 {
+		t.Errorf("Peer counts should start at 0/0; got %d/%d", dispute.Yays, dispute.Nays)
+	}
+	if !dispute.OurVote {
+		t.Error("OurVote should track the seeded stance")
 	}
 
-	// Add votes
-	dt.AddVote(txID, true)
-	dt.AddVote(txID, true)
-	dt.AddVote(txID, false)
+	peerA := consensus.NodeID{0xA}
+	peerB := consensus.NodeID{0xB}
+	peerC := consensus.NodeID{0xC}
+	peerD := consensus.NodeID{0xD}
+
+	// Three peers vote yes, one no.
+	if !dt.SetVote(txID, peerA, true) {
+		t.Error("new peer vote should report changed")
+	}
+	if !dt.SetVote(txID, peerB, true) {
+		t.Error("new peer vote should report changed")
+	}
+	if !dt.SetVote(txID, peerC, true) {
+		t.Error("new peer vote should report changed")
+	}
+	if !dt.SetVote(txID, peerD, false) {
+		t.Error("new peer vote should report changed")
+	}
 
 	dispute = dt.GetDispute(txID)
 	if dispute.Yays != 3 || dispute.Nays != 1 {
 		t.Errorf("Expected 3 yays, 1 nay; got %d/%d", dispute.Yays, dispute.Nays)
 	}
+
+	// Re-asserting the same vote is a no-op and reports unchanged.
+	if dt.SetVote(txID, peerA, true) {
+		t.Error("re-asserting same vote should report unchanged")
+	}
+
+	// Flipping an existing vote swaps one count and reports changed.
+	if !dt.SetVote(txID, peerA, false) {
+		t.Error("flipped vote should report changed")
+	}
+	dispute = dt.GetDispute(txID)
+	if dispute.Yays != 2 || dispute.Nays != 2 {
+		t.Errorf("After flip expected 2/2; got %d/%d", dispute.Yays, dispute.Nays)
+	}
 }
 
-func TestDisputeTracker_Resolve(t *testing.T) {
+func TestDisputeTracker_UnVote(t *testing.T) {
 	dt := NewDisputeTracker()
 
 	tx1 := consensus.TxID{1}
 	tx2 := consensus.TxID{2}
-
-	// Create disputes
 	dt.CreateDispute(tx1, []byte("tx1"), true)
 	dt.CreateDispute(tx2, []byte("tx2"), false)
 
-	// Add votes for tx1 (should be included)
-	dt.AddVote(tx1, true)
-	dt.AddVote(tx1, true)
-	dt.AddVote(tx1, false)
+	peerX := consensus.NodeID{0xA}
+	peerY := consensus.NodeID{0xB}
 
-	// Add votes for tx2 (should be excluded)
-	dt.AddVote(tx2, false)
-	dt.AddVote(tx2, false)
-	dt.AddVote(tx2, true)
+	dt.SetVote(tx1, peerX, true)
+	dt.SetVote(tx1, peerY, true)
+	dt.SetVote(tx2, peerX, false)
 
-	// Resolve at 60% threshold
-	include, exclude := dt.Resolve(0.6)
-
-	// tx1 has 4 yays, 1 nay = 80% yay -> include
-	foundTx1Include := false
-	for _, id := range include {
-		if id == tx1 {
-			foundTx1Include = true
-		}
+	// Before: tx1 has 2 yays, tx2 has 1 nay.
+	if d := dt.GetDispute(tx1); d.Yays != 2 {
+		t.Fatalf("tx1 pre-unvote yays = %d, want 2", d.Yays)
 	}
-	if !foundTx1Include {
-		t.Error("tx1 should be included")
+	if d := dt.GetDispute(tx2); d.Nays != 1 {
+		t.Fatalf("tx2 pre-unvote nays = %d, want 1", d.Nays)
 	}
 
-	// tx2 has 1 yay, 3 nay = 25% yay -> exclude
-	foundTx2Exclude := false
-	for _, id := range exclude {
-		if id == tx2 {
-			foundTx2Exclude = true
-		}
+	// UnVote removes peerX from every dispute but not peerY.
+	dt.UnVote(peerX)
+
+	tx1Disp := dt.GetDispute(tx1)
+	if tx1Disp.Yays != 1 {
+		t.Errorf("tx1 post-unvote yays = %d, want 1", tx1Disp.Yays)
 	}
-	if !foundTx2Exclude {
-		t.Error("tx2 should be excluded")
+	if _, has := tx1Disp.Votes[peerX]; has {
+		t.Error("peerX should be gone from tx1 votes")
+	}
+	if _, has := tx1Disp.Votes[peerY]; !has {
+		t.Error("peerY should remain in tx1 votes")
+	}
+
+	tx2Disp := dt.GetDispute(tx2)
+	if tx2Disp.Nays != 0 {
+		t.Errorf("tx2 post-unvote nays = %d, want 0", tx2Disp.Nays)
+	}
+
+	// UnVote for a peer that never voted is a no-op.
+	dt.UnVote(consensus.NodeID{0xFE})
+	if d := dt.GetDispute(tx1); d.Yays != 1 {
+		t.Errorf("unknown-peer unvote mutated tx1; yays = %d", d.Yays)
 	}
 }
 
-func TestDisputeTracker_UpdateOurVote(t *testing.T) {
+func TestDisputeTracker_UpdateDisputes(t *testing.T) {
 	dt := NewDisputeTracker()
 
+	tx1 := consensus.TxID{1}
+	tx2 := consensus.TxID{2}
+	dt.CreateDispute(tx1, []byte("tx1"), true)
+	dt.CreateDispute(tx2, []byte("tx2"), false)
+
+	peerID := consensus.NodeID{0xA}
+
+	// Peer's tx set contains tx1 but not tx2. UpdateDisputes should
+	// yield Yays=1 on tx1 and Nays=1 on tx2.
+	peerTxSet := &mockTxSet{
+		id:       consensus.TxSetID{1},
+		containsTxs: map[consensus.TxID]bool{tx1: true},
+	}
+
+	if !dt.UpdateDisputes(peerID, peerTxSet) {
+		t.Error("first UpdateDisputes should report changes")
+	}
+	if d := dt.GetDispute(tx1); d.Yays != 1 || d.Nays != 0 {
+		t.Errorf("tx1 after UpdateDisputes = %d/%d, want 1/0", d.Yays, d.Nays)
+	}
+	if d := dt.GetDispute(tx2); d.Yays != 0 || d.Nays != 1 {
+		t.Errorf("tx2 after UpdateDisputes = %d/%d, want 0/1", d.Yays, d.Nays)
+	}
+
+	// Calling again with the same set is a no-op.
+	if dt.UpdateDisputes(peerID, peerTxSet) {
+		t.Error("repeat UpdateDisputes should report no changes")
+	}
+}
+
+func TestDisputeTracker_UpdateOurVote_AvalancheRamp(t *testing.T) {
+	dt := NewDisputeTracker()
+	parms := consensus.DefaultConsensusParms()
+
 	txID := consensus.TxID{1}
-	dt.CreateDispute(txID, []byte("tx"), true) // Initial: yay
+	// Seed ourVote = false so disputes with any yays are candidates
+	// for flipping.
+	dt.CreateDispute(txID, []byte("tx"), false)
 
-	dispute := dt.GetDispute(txID)
-	if dispute.Yays != 1 || dispute.Nays != 0 {
-		t.Errorf("Initial should be 1/0, got %d/%d", dispute.Yays, dispute.Nays)
+	// Give the dispute 3 yays out of 4 peers = 75% support.
+	peers := []consensus.NodeID{{1}, {2}, {3}, {4}}
+	dt.SetVote(txID, peers[0], true)
+	dt.SetVote(txID, peers[1], true)
+	dt.SetVote(txID, peers[2], true)
+	dt.SetVote(txID, peers[3], false)
+
+	// At init (50% threshold), 75% agreement flips our vote.
+	changed := dt.UpdateOurVote(0, true, parms)
+	if len(changed) != 1 || changed[0] != txID {
+		t.Fatalf("expected dispute to flip at init state; got %v", changed)
+	}
+	if d := dt.GetDispute(txID); !d.OurVote {
+		t.Error("OurVote should now be true")
 	}
 
-	// Change our vote to nay
-	dt.UpdateOurVote(txID, false)
-
-	dispute = dt.GetDispute(txID)
-	if dispute.Yays != 0 || dispute.Nays != 1 {
-		t.Errorf("After update should be 0/1, got %d/%d", dispute.Yays, dispute.Nays)
+	// Reset to the opposite stance so the next calls can flip again.
+	// Build a fresh dispute with the same peer split so we can
+	// observe state progression without the "already agree" shortcut.
+	txID2 := consensus.TxID{2}
+	dt.CreateDispute(txID2, []byte("tx2"), true)
+	for _, p := range peers {
+		dt.SetVote(txID2, p, false)
 	}
 
-	if dispute.OurVote != false {
-		t.Error("OurVote should be false")
+	// 4 no, 0 yes → under any threshold we should flip to false.
+	changed = dt.UpdateOurVote(0, true, parms)
+	if len(changed) != 1 || changed[0] != txID2 {
+		t.Fatalf("expected unanimous opposition to flip our vote; got %v", changed)
+	}
+	d := dt.GetDispute(txID2)
+	if d.OurVote {
+		t.Error("OurVote should have flipped to false")
+	}
+
+	// Drive the avalanche state machine forward on a still-disputed
+	// dispute. Create one with a 2/2 split: at the init 50% threshold,
+	// weight=(2*100+100)/(2+2+1)=60 > 50 so we'd flip YES; to exercise
+	// the ramp, start from a "yes, with nays>0" stance and check
+	// state transitions via percentTime alone.
+	rampID := consensus.TxID{3}
+	dt.CreateDispute(rampID, []byte("tx3"), true)
+	for _, p := range peers[:2] {
+		dt.SetVote(rampID, p, true)
+	}
+	for _, p := range peers[2:] {
+		dt.SetVote(rampID, p, false)
+	}
+
+	ramp := dt.GetDispute(rampID)
+	if ramp.AvalancheState != consensus.AvalancheInit {
+		t.Fatalf("ramp dispute should start at AvalancheInit; got %v", ramp.AvalancheState)
+	}
+
+	// avMIN_ROUNDS=2: first call stays in init (counter=1 < 2).
+	dt.UpdateOurVote(60, true, parms)
+	if ramp.AvalancheState != consensus.AvalancheInit {
+		t.Errorf("after 1 round at 60%%, state = %v, want Init (min-rounds guard)", ramp.AvalancheState)
+	}
+
+	// Second call with percentTime>=50 and counter>=2: advance to Mid.
+	dt.UpdateOurVote(60, true, parms)
+	if ramp.AvalancheState != consensus.AvalancheMid {
+		t.Errorf("after 2 rounds at 60%%, state = %v, want Mid", ramp.AvalancheState)
+	}
+
+	// Drive to Late (cutoff 85%).
+	dt.UpdateOurVote(90, true, parms)
+	dt.UpdateOurVote(90, true, parms)
+	if ramp.AvalancheState != consensus.AvalancheLate {
+		t.Errorf("after 90%% time, state = %v, want Late", ramp.AvalancheState)
+	}
+
+	// Drive to Stuck (cutoff 200%).
+	dt.UpdateOurVote(210, true, parms)
+	dt.UpdateOurVote(210, true, parms)
+	if ramp.AvalancheState != consensus.AvalancheStuck {
+		t.Errorf("after 210%% time, state = %v, want Stuck", ramp.AvalancheState)
 	}
 }

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -282,7 +282,35 @@ type Validation struct {
 	SuppressionHash [32]byte
 }
 
+// AvalancheState tracks per-dispute threshold escalation during
+// establish phase. Matches rippled's ConsensusParms::AvalancheState
+// enum (ConsensusParms.h:134).
+type AvalancheState int
+
+const (
+	// AvalancheInit requires 50% agreement. This is the starting state
+	// for every new dispute.
+	AvalancheInit AvalancheState = iota
+	// AvalancheMid requires 65%. Triggered once the round has run
+	// past 50% of the previous round's duration.
+	AvalancheMid
+	// AvalancheLate requires 70%. Triggered at 85%.
+	AvalancheLate
+	// AvalancheStuck requires 95%. Triggered at 200% (i.e., the round
+	// is taking twice as long as the previous one).
+	AvalancheStuck
+)
+
 // DisputedTx represents a transaction that validators disagree on.
+//
+// During consensus, a DisputedTx exists for every tx found in the
+// symmetric difference between our proposed tx set and any peer's
+// proposed tx set. The struct tracks per-peer votes so we can
+// correctly re-vote (one peer changing its vote does not double-count)
+// and strip a bowed-out peer's contribution via unVote.
+//
+// Matches rippled's DisputedTx template class
+// (rippled/src/xrpld/consensus/DisputedTx.h).
 type DisputedTx struct {
 	// TxID is the transaction hash.
 	TxID TxID
@@ -293,11 +321,33 @@ type DisputedTx struct {
 	// OurVote is whether we think this tx should be included.
 	OurVote bool
 
-	// Yays is the count of validators who voted to include.
+	// Yays is the count of validators (not including us) who voted to
+	// include. Cached from Votes; SetVote/UnVote keep it in sync.
 	Yays int
 
-	// Nays is the count of validators who voted to exclude.
+	// Nays is the count of validators (not including us) who voted to
+	// exclude. Cached from Votes; SetVote/UnVote keep it in sync.
 	Nays int
+
+	// Votes tracks per-peer yes/no votes on this transaction. A peer
+	// without an entry has not yet reported a position that lets us
+	// count it. Maintained by DisputeTracker.SetVote / UnVote.
+	Votes map[NodeID]bool
+
+	// AvalancheState is the current threshold bracket for this
+	// dispute's re-vote logic. It advances monotonically through
+	// init/mid/late/stuck as consensus duration progresses.
+	AvalancheState AvalancheState
+
+	// AvalancheCounter counts phaseEstablish ticks spent in the
+	// current AvalancheState. Rippled's getNeededWeight uses this to
+	// enforce avMIN_ROUNDS before advancing.
+	AvalancheCounter int
+
+	// CurrentVoteCounter counts phaseEstablish ticks since we last
+	// changed OurVote. Rippled's stalled() check uses this together
+	// with peerUnchangedCounter to detect dead-locked disputes.
+	CurrentVoteCounter int
 }
 
 // CloseTimes tracks proposed close times from validators.
@@ -446,4 +496,90 @@ func DefaultThresholds() Thresholds {
 		IncreaseConsensusPct: 5,
 		MinConsensusPct:      80,
 	}
+}
+
+// AvalancheCutoff is one row in the avalanche cutoff table. Matches
+// rippled's ConsensusParms::AvalancheCutoff (ConsensusParms.h:135-140).
+type AvalancheCutoff struct {
+	// ConsensusTime is the convergePercent threshold at which this
+	// state activates (e.g., 50 means "once we're 50% of the way
+	// through a normal round, advance to this state").
+	ConsensusTime int
+
+	// ConsensusPct is the agreement percentage required while in this
+	// state for a dispute to flip our vote.
+	ConsensusPct int
+
+	// Next is the state this one advances to once ConsensusTime of the
+	// successor has been reached. Stuck loops back to itself.
+	Next AvalancheState
+}
+
+// ConsensusParms holds the avalanche-threshold cutoffs and the
+// min/stalled round counts that drive per-tx dispute re-voting.
+// Matches rippled's ConsensusParms (ConsensusParms.h:38-170) for the
+// subset used by DisputedTx::updateVote.
+type ConsensusParms struct {
+	// AvalancheCutoffs maps each state to its activation time,
+	// required agreement percentage, and next state. Rippled uses
+	// {init:(0,50,mid), mid:(50,65,late), late:(85,70,stuck),
+	//  stuck:(200,95,stuck)}.
+	AvalancheCutoffs map[AvalancheState]AvalancheCutoff
+
+	// MinRounds is the minimum number of phaseEstablish ticks that
+	// must be spent in a given avalanche state before advancing.
+	// Matches rippled's avMIN_ROUNDS = 2.
+	MinRounds int
+
+	// StalledRounds is the number of rounds without any vote change
+	// after which a dispute is considered stalled.
+	// Matches rippled's avSTALLED_ROUNDS = 4.
+	StalledRounds int
+
+	// MinConsensusPct is the stall threshold: a dispute with more
+	// than MinConsensusPct agreement one way or the other is
+	// considered stuck. Matches rippled's minCONSENSUS_PCT = 80.
+	MinConsensusPct int
+}
+
+// DefaultConsensusParms returns the avalanche parameters matching
+// rippled's defaults (ConsensusParms.h:146-157,165,169).
+func DefaultConsensusParms() ConsensusParms {
+	return ConsensusParms{
+		AvalancheCutoffs: map[AvalancheState]AvalancheCutoff{
+			AvalancheInit:  {ConsensusTime: 0, ConsensusPct: 50, Next: AvalancheMid},
+			AvalancheMid:   {ConsensusTime: 50, ConsensusPct: 65, Next: AvalancheLate},
+			AvalancheLate:  {ConsensusTime: 85, ConsensusPct: 70, Next: AvalancheStuck},
+			AvalancheStuck: {ConsensusTime: 200, ConsensusPct: 95, Next: AvalancheStuck},
+		},
+		MinRounds:       2,
+		StalledRounds:   4,
+		MinConsensusPct: 80,
+	}
+}
+
+// NeededWeight computes the agreement percentage required for a
+// dispute at the current avalanche state, and optionally the next
+// state to advance into.
+//
+// Matches rippled's getNeededWeight free function
+// (ConsensusParms.h:172-199): we may advance to the next state iff
+// the current state is not terminal, at least minimumRounds have
+// passed in this state, and enough round-percent time has elapsed to
+// cross the next cutoff.
+func (p ConsensusParms) NeededWeight(
+	state AvalancheState,
+	percentTime int,
+	currentRounds int,
+	minimumRounds int,
+) (int, *AvalancheState) {
+	current := p.AvalancheCutoffs[state]
+	if current.Next != state && currentRounds >= minimumRounds {
+		next := p.AvalancheCutoffs[current.Next]
+		if percentTime >= next.ConsensusTime {
+			advanced := current.Next
+			return next.ConsensusPct, &advanced
+		}
+	}
+	return current.ConsensusPct, nil
 }

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -157,6 +157,16 @@ type Proposal struct {
 
 	// Timestamp is when this proposal was created.
 	Timestamp time.Time
+
+	// SuppressionHash is the router-level dedup key for this proposal,
+	// computed via the canonical proposalUniqueId scheme
+	// (RCLCxPeerPos.cpp:66-83). Mirrors rippled's
+	// RCLCxPeerPos::suppressionID() carried on the peer-position
+	// instance so later relay + slot-feeding code doesn't have to
+	// recompute it. Populated by the consensus router on inbound
+	// messages; zero on self-originated proposals (Broadcast skips the
+	// reverse index anyway).
+	SuppressionHash [32]byte
 }
 
 // Validation represents a validation message from a validator.
@@ -254,6 +264,14 @@ type Validation struct {
 	// nil — SignValidation synthesizes its own preimage from the
 	// struct fields at sign time.
 	SigningData []byte
+
+	// SuppressionHash is the router-level dedup key for this validation.
+	// Computed as sha512Half(innerSTValidationBlob) — matches rippled
+	// PeerImp.cpp:2374 (`sha512Half(makeSlice(m->validation()))`).
+	// Populated by the consensus router on inbound validations so later
+	// relay + slot-feeding code doesn't have to recompute it. Zero on
+	// self-originated validations (Broadcast skips the reverse index).
+	SuppressionHash [32]byte
 }
 
 // DisputedTx represents a transaction that validators disagree on.

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -409,22 +409,41 @@ func DefaultTiming() Timing {
 }
 
 // Thresholds holds consensus threshold parameters.
+//
+// Note on terminology: rippled defines a single consensus percentage,
+// minCONSENSUS_PCT = 80 (see rippled/src/xrpld/consensus/ConsensusParms.h:79),
+// which is the threshold above which consensus may be declared. goXRPL
+// layers an additional lower gate (EarlyConvergencePct) used to mark a
+// round as "converged" earlier than the accept threshold — this is a
+// goXRPL-local construct and has no direct rippled counterpart. The
+// accept threshold itself (MinConsensusPct below) is arithmetically
+// identical to rippled's minCONSENSUS_PCT.
 type Thresholds struct {
-	// MinConsensusPct is the minimum percentage for initial consensus.
-	MinConsensusPct int
+	// EarlyConvergencePct is the percentage of trusted proposals that must
+	// agree on a tx set for a round to be marked "converged" (but not yet
+	// accepted). This is a goXRPL-local early-convergence gate and has no
+	// direct equivalent in rippled.
+	EarlyConvergencePct int
 
 	// IncreaseConsensusPct is the percentage increase per round.
 	IncreaseConsensusPct int
 
-	// MaxConsensusPct is the maximum consensus percentage required.
-	MaxConsensusPct int
+	// MinConsensusPct is the minimum percentage of trusted proposals that
+	// must agree on a tx set before consensus may be declared. This
+	// corresponds directly to rippled's minCONSENSUS_PCT = 80 (see
+	// rippled/src/xrpld/consensus/ConsensusParms.h:79).
+	MinConsensusPct int
 }
 
 // DefaultThresholds returns the default consensus thresholds.
+//
+// MinConsensusPct = 80 matches rippled's minCONSENSUS_PCT
+// (rippled/src/xrpld/consensus/ConsensusParms.h:79). EarlyConvergencePct
+// is a goXRPL-local earlier gate used to flag convergence before accept.
 func DefaultThresholds() Thresholds {
 	return Thresholds{
-		MinConsensusPct:      50,
+		EarlyConvergencePct:  50,
 		IncreaseConsensusPct: 5,
-		MaxConsensusPct:      80,
+		MinConsensusPct:      80,
 	}
 }

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -92,6 +92,12 @@ const (
 
 	// ResultFail means consensus failed for this round.
 	ResultFail
+
+	// ResultAbandoned means the round was hard-abandoned because its
+	// duration exceeded the ledgerABANDON_CONSENSUS clamp (15s..120s).
+	// Matches rippled's ConsensusState::Expired (ConsensusTypes.h:191),
+	// which triggers leaveConsensus() to bow out before the accept step.
+	ResultAbandoned
 )
 
 // String returns the string representation of the result.
@@ -105,6 +111,8 @@ func (r Result) String() string {
 		return "movedOn"
 	case ResultFail:
 		return "fail"
+	case ResultAbandoned:
+		return "abandoned"
 	default:
 		return "unknown"
 	}
@@ -342,7 +350,11 @@ type Timing struct {
 	// LedgerMinClose is minimum time a ledger stays open.
 	LedgerMinClose time.Duration
 
-	// LedgerMaxClose is maximum time before forcing close.
+	// LedgerMaxClose is a legacy alias for LedgerMaxConsensus kept for
+	// source compatibility. New code should read LedgerMaxConsensus.
+	// Prior to E3 this was a goXRPL-only 10s hard timeout that did not
+	// correspond to any rippled constant — DefaultTiming now pins it to
+	// LedgerMaxConsensus (15s) so call-sites retain matching semantics.
 	LedgerMaxClose time.Duration
 
 	// LedgerIdleInterval is time between ledgers when idle.
@@ -351,6 +363,24 @@ type Timing struct {
 	// LedgerMinConsensus is the minimum time to remain in the establish phase
 	// before accepting consensus. Matches rippled's ledgerMIN_CONSENSUS (1950ms).
 	LedgerMinConsensus time.Duration
+
+	// LedgerMaxConsensus is the soft deadline for the establish phase.
+	// After this duration the engine forces acceptance (ResultTimeout)
+	// rather than waiting further. Matches rippled's ledgerMAX_CONSENSUS
+	// (ConsensusParms.h:95 = 15s).
+	LedgerMaxConsensus time.Duration
+
+	// LedgerAbandonConsensus is the absolute hard ceiling for a
+	// consensus round. If the round exceeds this duration it is
+	// abandoned — we bow out and emit ResultAbandoned. Matches
+	// rippled's ledgerABANDON_CONSENSUS (ConsensusParms.h:113 = 120s).
+	LedgerAbandonConsensus time.Duration
+
+	// LedgerAbandonConsensusFactor scales the previous round's duration
+	// to produce the actual abandon clamp. The effective hard deadline
+	// is clamp(prevRoundTime * factor, LedgerMaxConsensus, LedgerAbandonConsensus).
+	// Matches rippled's ledgerABANDON_CONSENSUS_FACTOR (ConsensusParms.h:105 = 10).
+	LedgerAbandonConsensusFactor int
 
 	// LedgerGranularity is the close time resolution.
 	LedgerGranularity time.Duration
@@ -365,13 +395,16 @@ type Timing struct {
 // DefaultTiming returns the default consensus timing parameters.
 func DefaultTiming() Timing {
 	return Timing{
-		LedgerMinClose:      2 * time.Second,
-		LedgerMaxClose:      10 * time.Second,
-		LedgerMinConsensus:  1950 * time.Millisecond,
-		LedgerIdleInterval:  15 * time.Second,
-		LedgerGranularity:   10 * time.Second,
-		ProposeFreshness:    20 * time.Second,
-		ValidationFreshness: 20 * time.Second,
+		LedgerMinClose:               2 * time.Second,
+		LedgerMaxConsensus:           15 * time.Second,
+		LedgerMaxClose:               15 * time.Second, // legacy alias, kept in sync with LedgerMaxConsensus
+		LedgerAbandonConsensus:       120 * time.Second,
+		LedgerAbandonConsensusFactor: 10,
+		LedgerMinConsensus:           1950 * time.Millisecond,
+		LedgerIdleInterval:           15 * time.Second,
+		LedgerGranularity:            10 * time.Second,
+		ProposeFreshness:             20 * time.Second,
+		ValidationFreshness:          20 * time.Second,
 	}
 }
 

--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -31,11 +31,18 @@ var (
 	// Either a peer fork or wire corruption that escaped GotResponse.
 	ErrReplayTxParse = errors.New("replay delta: parse tx failed")
 
-	// ErrReplayTxDiverged signals the engine returned a non-success,
-	// non-tec, non-retry result code (tef/tem/tel) on a tx that
-	// rippled successfully applied. State-hash arbitration at the end
-	// of Apply may still save the adoption, but the Apply caller
-	// typically fails the replay-delta and falls back to legacy.
+	// ErrReplayTxDiverged signals the engine returned a non-applied
+	// result (terRETRY / tef* / tem* / tel*) on a tx that rippled
+	// successfully applied (the peer served it in the delta, so its
+	// canonical ledger embedded it). Rippled's BuildLedger.cpp:246 +
+	// Transactor.cpp:1108,1215-1267 only rawTxInsert's the tx leaf
+	// when applied==true (tes / tec); anything else drops the tx from
+	// the view. Installing the peer-supplied leaf on non-applied
+	// branches was a goXRPL-only divergence (see R6.4) that papered
+	// over a real engine disagreement — when the engine rejects a tx
+	// that rippled accepted, AccountHash will diverge regardless, so
+	// preserving the leaf bought nothing and obscured the root cause.
+	// Fail loudly instead so the replay falls back to legacy catchup.
 	ErrReplayTxDiverged = errors.New("replay delta: tx result diverges from peer")
 
 	// ErrReplayLeafInstall wraps SHAMap AddTransactionWithMeta
@@ -624,55 +631,40 @@ func (r *ReplayDelta) Apply(engineCfg tx.EngineConfig) (*ledger.Ledger, error) {
 			}
 		}
 
-		switch {
-		case result.Result.IsSuccess(), result.Result.IsTec():
-			// Both produce ledger entries and consume a TransactionIndex.
-			// Anchor the verified leaf blob (peer's tx + peer's metadata,
-			// already verified by GotResponse) into the child's tx map so
-			// the resulting TxHash matches header.TxHash exactly. Using
-			// our locally-generated metadata would diverge byte-for-byte
-			// from the peer's even when the AffectedNodes are
-			// semantically equivalent.
-			if err := child.AddTransactionWithMeta(dtx.Hash, dtx.LeafBlob); err != nil {
-				return nil, fmt.Errorf("%w: tx %x: %w", ErrReplayLeafInstall, dtx.Hash[:8], err)
-			}
-		case result.Result.ShouldRetry():
-			// Rippled's BuildLedger.cpp:246 DISCARDS the ApplyResult
-			// during replay — a terRETRY during canonical-input replay
-			// is silently ignored rather than escalated. Parity: log,
-			// install the tx leaf (state-hash arbitration will catch
-			// a genuine engine divergence at the end of Apply), and
-			// continue. The pre-R5.11 hard-fail triggered spurious
-			// legacy-catchup fallbacks whenever goXRPL's engine had
-			// any small behavioral difference, even on semantically
-			// correct ledgers.
-			r.logger.Warn("replay tx returned ShouldRetry; continuing (matches rippled BuildLedger.cpp:246)",
+		// D5 — install the peer-supplied leaf only on applied==true
+		// (tes / tec), matching rippled's Transactor.cpp:1108 +
+		// 1215-1267 + BuildLedger.cpp:246. Anything else (ter / tef /
+		// tem / tel) means the engine DROPPED the tx from the view;
+		// rippled never rawTxInsert's such txs, so neither do we. If
+		// the peer's canonical ledger contains that tx, AccountHash
+		// will diverge at the post-Close check — but we fail here
+		// instead, so the error message points at the actual engine
+		// disagreement rather than a downstream hash symptom.
+		//
+		// Historical note: the pre-D5 switch (R5.11 + R6.4) tried to
+		// paper over engine disagreements by installing the peer leaf
+		// anyway and letting the AccountHash safety net catch genuine
+		// divergence. The reasoning was that small preflight differences
+		// were producing false-positive legacy-catchup fallbacks. That
+		// trade-off was wrong — if the engine disagrees on whether a
+		// tx applies, the state the peer claims we should reach is
+		// unreachable from our engine regardless, so preserving the
+		// leaf bought nothing and obscured the real divergence.
+		if !result.Result.IsApplied() {
+			r.logger.Warn("replay tx returned non-applied result — engine diverges from peer",
 				"tx", fmt.Sprintf("%x", dtx.Hash[:8]),
 				"ter", result.Result.String(),
+				"note", "rippled only rawTxInsert's when applied==true (Transactor.cpp:1108,1215-1267)",
 			)
-			if err := child.AddTransactionWithMeta(dtx.Hash, dtx.LeafBlob); err != nil {
-				return nil, fmt.Errorf("%w: tx %x after ShouldRetry: %w", ErrReplayLeafInstall, dtx.Hash[:8], err)
-			}
-		default:
-			// tef*, tem*, tel* during replay — rippled's
-			// BuildLedger.cpp:244-247 DISCARDS the ApplyResult during
-			// replay, so these codes are silently ignored just like
-			// terRETRY (see R5.11). Parity: log, install the peer-
-			// supplied leaf blob so the tx map root still matches
-			// header.TxHash, and continue. State-hash arbitration at
-			// the end of Apply will catch a genuine AffectedNodes
-			// divergence. The pre-R6.4 hard-fail here triggered
-			// legacy-catchup fallbacks on semantically-correct
-			// ledgers where our engine returned tem* due to a minor
-			// preflight difference — same class of false-positive as
-			// R5.11 fixed for terRETRY.
-			r.logger.Warn("replay tx returned tef/tem/tel; continuing (matches rippled BuildLedger.cpp:244-247)",
-				"tx", fmt.Sprintf("%x", dtx.Hash[:8]),
-				"ter", result.Result.String(),
-			)
-			if err := child.AddTransactionWithMeta(dtx.Hash, dtx.LeafBlob); err != nil {
-				return nil, fmt.Errorf("%w: tx %x after tef/tem/tel: %w", ErrReplayLeafInstall, dtx.Hash[:8], err)
-			}
+			return nil, fmt.Errorf("%w: tx %x returned %s; rippled only embeds tes/tec txs",
+				ErrReplayTxDiverged, dtx.Hash[:8], result.Result.String())
+		}
+		// Applied path (tes / tec): anchor the verified peer leaf so the
+		// rebuilt TxHash matches header.TxHash byte-for-byte. Using our
+		// locally-generated metadata would diverge even when the
+		// AffectedNodes are semantically equivalent.
+		if err := child.AddTransactionWithMeta(dtx.Hash, dtx.LeafBlob); err != nil {
+			return nil, fmt.Errorf("%w: tx %x: %w", ErrReplayLeafInstall, dtx.Hash[:8], err)
 		}
 	}
 

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/crypto/common"
 	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
 	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
 	"github.com/LeJamon/goXRPLd/keylet"
@@ -138,13 +139,29 @@ func NewOpen(parent *Ledger, closeTime time.Time) (*Ledger, error) {
 		return nil, errors.New("failed to create tx map: " + err.Error())
 	}
 
+	// Compute the child's close-time resolution dynamically. Rippled
+	// adjusts the bin width each close based on whether the prior
+	// round agreed (LedgerTiming.h:78-122, invoked from Ledger.cpp:291).
+	// The parent's CloseFlags already encode previousAgree via
+	// sLCF_NoConsensusTime (header.GetCloseAgree). Keeping the
+	// computation in the ledger constructor matches rippled exactly
+	// and lets every NewOpen callsite (consensus, service, replay,
+	// test env) pick up the dynamic binning without plumbing
+	// previousAgree through their signatures.
+	newLedgerSeq := parent.header.LedgerIndex + 1
+	newResolution := consensus.GetNextLedgerTimeResolution(
+		parent.header.CloseTimeResolution,
+		parent.header.GetCloseAgree(),
+		newLedgerSeq,
+	)
+
 	// Create new header based on parent
 	newHeader := header.LedgerHeader{
-		LedgerIndex:         parent.header.LedgerIndex + 1,
+		LedgerIndex:         newLedgerSeq,
 		ParentHash:          parent.header.Hash,
 		ParentCloseTime:     parent.header.CloseTime,
 		CloseTime:           closeTime,
-		CloseTimeResolution: parent.header.CloseTimeResolution,
+		CloseTimeResolution: newResolution,
 		Drops:               parent.header.Drops,
 		// Hash, TxHash, AccountHash will be set when closed
 	}

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -1,0 +1,148 @@
+package ledger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+)
+
+// newParentAt builds a closed parent ledger with the requested
+// (seq, resolution, closeAgree) — synthesized from genesis and a
+// chain of no-op Close()s so we get valid hashes/maps for free.
+// Returns a closed parent ready to be passed into NewOpen.
+//
+// The seq argument is the parent's LedgerIndex. Because rippled's
+// bin-step predicate fires on the CHILD's seq (child = parent+1),
+// the parent seq must be chosen so parent+1 matches the desired
+// step boundary.
+func newParentAt(t *testing.T, parentSeq uint32, resolution uint32, closeAgree bool) *Ledger {
+	t.Helper()
+
+	res, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatalf("genesis.Create: %v", err)
+	}
+	parent := FromGenesis(res.Header, res.StateMap, res.TxMap, drops.Fees{})
+
+	// Walk forward until we hit parentSeq. Genesis is seq 1.
+	for parent.Sequence() < parentSeq {
+		child, err := NewOpen(parent, parent.CloseTime().Add(10*time.Second))
+		if err != nil {
+			t.Fatalf("NewOpen at seq %d: %v", parent.Sequence()+1, err)
+		}
+		if err := child.Close(parent.CloseTime().Add(10*time.Second), 0); err != nil {
+			t.Fatalf("Close at seq %d: %v", child.Sequence(), err)
+		}
+		parent = child
+	}
+
+	// Stamp the header fields the test actually cares about. We do
+	// this directly rather than re-closing because we need a
+	// specific resolution + closeAgree pair, and the bin-step
+	// algorithm would otherwise interfere.
+	h := parent.header
+	h.CloseTimeResolution = resolution
+	if closeAgree {
+		h.CloseFlags &^= header.LCFNoConsensusTime
+	} else {
+		h.CloseFlags |= header.LCFNoConsensusTime
+	}
+	parent.header = h
+	return parent
+}
+
+// TestLedger_Close_UsesDynamicResolution exercises the primary
+// integration path: when a child ledger is opened on a parent at
+// resolution=30s with previousAgree=true and the child's seq lands
+// on the increase-every boundary (seq%8 == 0), the child's header
+// must bind to the FINER bin (20s), not inherit 30s statically.
+//
+// Before task 3.1, NewOpen copied parent.header.CloseTimeResolution
+// verbatim — this test would have observed 30s.
+func TestLedger_Close_UsesDynamicResolution(t *testing.T) {
+	// parent at seq=7 so child=8 (seq % 8 == 0).
+	parent := newParentAt(t, 7, 30, true)
+
+	closeTime := parent.CloseTime().Add(10 * time.Second)
+	child, err := NewOpen(parent, closeTime)
+	if err != nil {
+		t.Fatalf("NewOpen: %v", err)
+	}
+
+	if got, want := child.Sequence(), uint32(8); got != want {
+		t.Fatalf("child seq: got %d want %d", got, want)
+	}
+	if got, want := child.CloseTimeResolution(), uint32(20); got != want {
+		t.Errorf("child CloseTimeResolution: got %d want %d (expected step 30→20 at seq=8 agree=true)", got, want)
+	}
+}
+
+// TestLedger_Close_DynamicResolution_Disagree verifies the
+// symmetric path: when the parent's CloseFlags carry
+// sLCF_NoConsensusTime (previousAgree=false) and the child seq is on
+// the decrease-every boundary (always, since seqMod 1 == 0), the
+// child must step COARSER.
+func TestLedger_Close_DynamicResolution_Disagree(t *testing.T) {
+	// parent seq=4, previousAgree=false → child seq=5 steps coarser.
+	parent := newParentAt(t, 4, 30, false)
+
+	child, err := NewOpen(parent, parent.CloseTime().Add(10*time.Second))
+	if err != nil {
+		t.Fatalf("NewOpen: %v", err)
+	}
+	if got, want := child.CloseTimeResolution(), uint32(60); got != want {
+		t.Errorf("disagree child resolution: got %d want %d", got, want)
+	}
+}
+
+// TestLedger_Close_DynamicResolution_NoStep covers the "stay" case:
+// parent resolution is preserved on rounds where neither predicate
+// fires (previousAgree=true but seq is not on the increase-every
+// boundary).
+func TestLedger_Close_DynamicResolution_NoStep(t *testing.T) {
+	// parent seq=6 → child seq=7; 7 % 8 != 0; agree=true;
+	// expect no step.
+	parent := newParentAt(t, 6, 30, true)
+
+	child, err := NewOpen(parent, parent.CloseTime().Add(10*time.Second))
+	if err != nil {
+		t.Fatalf("NewOpen: %v", err)
+	}
+	if got, want := child.CloseTimeResolution(), uint32(30); got != want {
+		t.Errorf("no-step child resolution: got %d want %d", got, want)
+	}
+}
+
+// TestLedger_Close_DynamicResolution_AgreeSaturatedAtFinest covers
+// the saturation edge: parent already at 10s (finest), agree=true,
+// seq=8. rippled stops stepping at the begin() of the bin array, so
+// the child resolution should remain 10s.
+func TestLedger_Close_DynamicResolution_AgreeSaturatedAtFinest(t *testing.T) {
+	parent := newParentAt(t, 7, 10, true)
+
+	child, err := NewOpen(parent, parent.CloseTime().Add(10*time.Second))
+	if err != nil {
+		t.Fatalf("NewOpen: %v", err)
+	}
+	if got, want := child.CloseTimeResolution(), uint32(10); got != want {
+		t.Errorf("saturated finest: got %d want %d", got, want)
+	}
+}
+
+// TestLedger_Close_DynamicResolution_DisagreeSaturatedAtCoarsest
+// covers the symmetric edge: parent at 120s (coarsest), disagree,
+// any seq → no coarser step available.
+func TestLedger_Close_DynamicResolution_DisagreeSaturatedAtCoarsest(t *testing.T) {
+	parent := newParentAt(t, 3, 120, false)
+
+	child, err := NewOpen(parent, parent.CloseTime().Add(10*time.Second))
+	if err != nil {
+		t.Fatalf("NewOpen: %v", err)
+	}
+	if got, want := child.CloseTimeResolution(), uint32(120); got != want {
+		t.Errorf("saturated coarsest: got %d want %d", got, want)
+	}
+}

--- a/internal/ledger/service/adopt_hooks_test.go
+++ b/internal/ledger/service/adopt_hooks_test.go
@@ -1,0 +1,307 @@
+package service
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdoptLedgerWithState_FiresOnLedgerClosedHook pins F3: peer-adopted
+// ledgers must fire hooks.OnLedgerClosed so WebSocket `ledger` stream
+// subscribers see a ledger-closed event for every ledger the node adopts
+// from peers. Without this, the `ledger` stream silently skips every
+// peer-adopted ledger — an observable divergence from rippled where
+// pubLedger fires for both consensus-closed and sync-adopted ledgers.
+func TestAdoptLedgerWithState_FiresOnLedgerClosedHook(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	// Capture OnLedgerClosed invocations.
+	var (
+		mu               sync.Mutex
+		callCount        int
+		capturedInfo     *LedgerInfo
+		capturedTxCount  int
+		capturedValRange string
+	)
+	done := make(chan struct{}, 1)
+
+	hooks := DefaultEventHooks()
+	hooks.OnLedgerClosed = func(info *LedgerInfo, txCount int, validatedLedgers string) {
+		mu.Lock()
+		callCount++
+		capturedInfo = info
+		capturedTxCount = txCount
+		capturedValRange = validatedLedgers
+		mu.Unlock()
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+	svc.SetEventHooks(hooks)
+
+	// Build a tx map with 2 txs so txCount assertion is meaningful.
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	blob1, id1 := makeTxMetaBlobForTest(t, []byte("hook-tx-blob-A-padding-padpad"), 0)
+	blob2, id2 := makeTxMetaBlobForTest(t, []byte("hook-tx-blob-B-padding-padpad"), 1)
+	require.NoError(t, txMap.PutWithNodeType(id1, blob1, shamap.NodeTypeTransactionWithMeta))
+	require.NoError(t, txMap.PutWithNodeType(id2, blob2, shamap.NodeTypeTransactionWithMeta))
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	var adoptedHash [32]byte
+	adoptedHash[0] = 0xF3
+	adoptedSeq := svc.GetClosedLedgerIndex() + 1
+	hdr := &header.LedgerHeader{
+		LedgerIndex: adoptedSeq,
+		Hash:        adoptedHash,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+		CloseTime:   time.Unix(1700000000, 0),
+	}
+
+	require.NoError(t, svc.AdoptLedgerWithState(hdr, stateMap, txMap))
+
+	// Wait for the goroutine-dispatched hook to fire.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnLedgerClosed hook never fired for adopted ledger")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, callCount, "OnLedgerClosed must fire exactly once")
+	require.NotNil(t, capturedInfo, "OnLedgerClosed must receive a non-nil LedgerInfo")
+	assert.Equal(t, adoptedSeq, capturedInfo.Sequence, "LedgerInfo.Sequence must match adopted ledger seq")
+	assert.Equal(t, adoptedHash, capturedInfo.Hash, "LedgerInfo.Hash must match adopted ledger hash")
+	assert.Equal(t, 2, capturedTxCount, "txCount must match the number of txs in the adopted tx map")
+	assert.NotEmpty(t, capturedValRange, "validatedLedgers range must be populated")
+}
+
+// TestAdoptLedgerWithState_FiresOnTransactionHook pins F3: peer-adopted
+// ledgers must fire hooks.OnTransaction for every tx in the installed tx
+// map so WebSocket `transactions` stream subscribers see every adopted
+// tx. Matches rippled's pubValidatedTransactions which emits for every tx
+// in a newly-published ledger regardless of whether it was consensus-
+// closed locally or adopted from a peer.
+func TestAdoptLedgerWithState_FiresOnTransactionHook(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	var txCallCount int32
+	seenHashes := &sync.Map{}
+	done := make(chan struct{}, 4)
+
+	hooks := DefaultEventHooks()
+	hooks.OnTransaction = func(txi TransactionInfo, result TxResult, seq uint32, hash [32]byte, closeTime time.Time) {
+		atomic.AddInt32(&txCallCount, 1)
+		seenHashes.Store(txi.Hash, struct{}{})
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+	svc.SetEventHooks(hooks)
+
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	blob1, id1 := makeTxMetaBlobForTest(t, []byte("hook-onTx-blob-A-padding-padp"), 0)
+	blob2, id2 := makeTxMetaBlobForTest(t, []byte("hook-onTx-blob-B-padding-padp"), 1)
+	require.NoError(t, txMap.PutWithNodeType(id1, blob1, shamap.NodeTypeTransactionWithMeta))
+	require.NoError(t, txMap.PutWithNodeType(id2, blob2, shamap.NodeTypeTransactionWithMeta))
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	var adoptedHash [32]byte
+	adoptedHash[0] = 0xF4
+	hdr := &header.LedgerHeader{
+		LedgerIndex: svc.GetClosedLedgerIndex() + 1,
+		Hash:        adoptedHash,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+	require.NoError(t, svc.AdoptLedgerWithState(hdr, stateMap, txMap))
+
+	// Wait for both tx dispatches.
+	deadline := time.After(2 * time.Second)
+	for i := 0; i < 2; i++ {
+		select {
+		case <-done:
+		case <-deadline:
+			t.Fatalf("OnTransaction did not fire for all adopted txs (got %d of 2)", atomic.LoadInt32(&txCallCount))
+		}
+	}
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&txCallCount),
+		"OnTransaction must fire exactly once per adopted tx")
+	for _, id := range [][32]byte{id1, id2} {
+		_, ok := seenHashes.Load(id)
+		assert.Truef(t, ok, "OnTransaction must fire for tx %x", id[:4])
+	}
+}
+
+// TestAdoptLedgerWithState_StashesLegacyEventUntilValidated pins F3: the
+// legacy eventCallback must NOT fire at adopt time (the adopted ledger
+// isn't yet trust-validated), but the event must be stashed so a later
+// SetValidatedLedger for the same hash drains it exactly once. Matches
+// the consensus-close path's stash/drain pattern.
+func TestAdoptLedgerWithState_StashesLegacyEventUntilValidated(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	var (
+		mu            sync.Mutex
+		callbackCount int
+		lastEvent     *LedgerAcceptedEvent
+	)
+	done := make(chan struct{}, 1)
+
+	svc.SetEventCallback(func(event *LedgerAcceptedEvent) {
+		mu.Lock()
+		callbackCount++
+		lastEvent = event
+		mu.Unlock()
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	})
+
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	blob1, id1 := makeTxMetaBlobForTest(t, []byte("stash-tx-blob-A-padding-padpd"), 0)
+	require.NoError(t, txMap.PutWithNodeType(id1, blob1, shamap.NodeTypeTransactionWithMeta))
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	var adoptedHash [32]byte
+	adoptedHash[0] = 0xF5
+	adoptedSeq := svc.GetClosedLedgerIndex() + 1
+	hdr := &header.LedgerHeader{
+		LedgerIndex: adoptedSeq,
+		Hash:        adoptedHash,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+	require.NoError(t, svc.AdoptLedgerWithState(hdr, stateMap, txMap))
+
+	// Give any erroneously-dispatched callback a chance to run.
+	select {
+	case <-done:
+		t.Fatal("eventCallback must NOT fire at adopt time — adopted ledger is not yet trust-validated")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	mu.Lock()
+	assert.Equal(t, 0, callbackCount,
+		"eventCallback must NOT fire at adopt time")
+	mu.Unlock()
+
+	// The event must be stashed keyed by hash so SetValidatedLedger can drain it.
+	svc.mu.RLock()
+	_, stashed := svc.pendingValidation[adoptedHash]
+	svc.mu.RUnlock()
+	assert.True(t, stashed,
+		"adopt must stash a LedgerAcceptedEvent keyed by the adopted ledger hash")
+
+	// When the validation tracker confirms this ledger, SetValidatedLedger
+	// must drain the stashed event and fire eventCallback exactly once.
+	svc.SetValidatedLedger(adoptedSeq, adoptedHash)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("eventCallback did not fire after SetValidatedLedger drained the stashed event")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, callbackCount,
+		"eventCallback must fire exactly once after SetValidatedLedger")
+	require.NotNil(t, lastEvent)
+	require.NotNil(t, lastEvent.LedgerInfo)
+	assert.Equal(t, adoptedSeq, lastEvent.LedgerInfo.Sequence,
+		"drained event must carry the adopted ledger's seq")
+	assert.Equal(t, adoptedHash, lastEvent.LedgerInfo.Hash,
+		"drained event must carry the adopted ledger's hash")
+	assert.Len(t, lastEvent.TransactionResults, 1,
+		"drained event must carry the adopted tx results")
+
+	// The stash must be empty after drain.
+	svc.mu.RLock()
+	_, stillStashed := svc.pendingValidation[adoptedHash]
+	svc.mu.RUnlock()
+	assert.False(t, stillStashed,
+		"SetValidatedLedger must remove the stashed event after firing")
+}
+
+// TestAdoptLedgerWithState_NoHooksInstalled_IsQuiet verifies that the
+// adopt path doesn't panic or otherwise misbehave when neither hooks nor
+// eventCallback are installed. The production wiring installs both, but
+// tests and embedders may run without either; the helper must tolerate
+// that.
+func TestAdoptLedgerWithState_NoHooksInstalled_IsQuiet(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	// Deliberately: no SetEventHooks, no SetEventCallback.
+
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	var adoptedHash [32]byte
+	adoptedHash[0] = 0xF6
+	hdr := &header.LedgerHeader{
+		LedgerIndex: svc.GetClosedLedgerIndex() + 1,
+		Hash:        adoptedHash,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+	require.NoError(t, svc.AdoptLedgerWithState(hdr, stateMap, txMap),
+		"adopt must succeed even when no hooks or eventCallback are installed")
+
+	// No pending stash entry should exist when there is no eventCallback.
+	svc.mu.RLock()
+	_, stashed := svc.pendingValidation[adoptedHash]
+	svc.mu.RUnlock()
+	assert.False(t, stashed,
+		"no eventCallback means nothing to stash")
+}

--- a/internal/ledger/service/adopt_with_state_test.go
+++ b/internal/ledger/service/adopt_with_state_test.go
@@ -1,13 +1,62 @@
 package service
 
 import (
+	"context"
+	"encoding/hex"
 	"testing"
 
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/crypto/common"
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/shamap"
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+	sqlitedb "github.com/LeJamon/goXRPLd/storage/relationaldb/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// encodeVLForTest mirrors tx.EncodeVL — duplicated locally so this test
+// file stays free of cross-package test-helper imports.
+func encodeVLForTest(length int) []byte {
+	switch {
+	case length <= 192:
+		return []byte{byte(length)}
+	case length <= 12480:
+		l := length - 193
+		return []byte{byte((l >> 8) + 193), byte(l & 0xFF)}
+	default:
+		l := length - 12481
+		return []byte{byte((l >> 16) + 241), byte((l >> 8) & 0xFF), byte(l & 0xFF)}
+	}
+}
+
+// makeTxMetaBlobForTest builds a SHAMap-formatted tx+meta leaf blob
+// (VL(tx) + VL(meta)) with the supplied tx bytes. Metadata carries only
+// TransactionResult + TransactionIndex, enough for persistToRelationalDB
+// to extract txn_seq without mattering to the index build.
+// Returns (blob, txID) where txID is the canonical XRPL tx hash used as
+// the SHAMap key.
+func makeTxMetaBlobForTest(t *testing.T, txBytes []byte, txIndex uint32) ([]byte, [32]byte) {
+	t.Helper()
+
+	metaHex, err := binarycodec.Encode(map[string]any{
+		"TransactionResult": "tesSUCCESS",
+		"TransactionIndex":  txIndex,
+	})
+	require.NoError(t, err)
+	metaBytes, err := hex.DecodeString(metaHex)
+	require.NoError(t, err)
+
+	txID := common.Sha512Half(protocol.HashPrefixTransactionID[:], txBytes)
+
+	blob := make([]byte, 0, len(txBytes)+len(metaBytes)+4)
+	blob = append(blob, encodeVLForTest(len(txBytes))...)
+	blob = append(blob, txBytes...)
+	blob = append(blob, encodeVLForTest(len(metaBytes))...)
+	blob = append(blob, metaBytes...)
+	return blob, txID
+}
 
 // TestAdoptLedgerWithState_PreservesTxMap pins R5.1: the verified
 // replay-delta tx map must be installed into the adopted ledger, not
@@ -24,19 +73,17 @@ func TestAdoptLedgerWithState_PreservesTxMap(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, svc.Start())
 
-	// Build a non-empty tx map: 2 distinct tx leaves with deterministic
-	// content so the SHAMap root is stable across runs.
+	// Build a non-empty tx map: 2 distinct tx leaves with proper
+	// VL(tx)+VL(meta) shape so persistLedger and collectTransactionResults
+	// can parse them. Keys are canonical XRPL tx hashes so the in-memory
+	// tx-index assertion below is meaningful.
 	txMap, err := shamap.New(shamap.TypeTransaction)
 	require.NoError(t, err)
 
-	var key1, key2 [32]byte
-	for i := range key1 {
-		key1[i] = byte(i + 1)
-		key2[i] = byte(i + 100)
-	}
-	// SHAMap leaf values must be ≥12 bytes.
-	require.NoError(t, txMap.Put(key1, []byte("tx-blob-content-1")))
-	require.NoError(t, txMap.Put(key2, []byte("tx-blob-content-2")))
+	blob1, id1 := makeTxMetaBlobForTest(t, []byte("adopt-tx-blob-A-padding-padding"), 0)
+	blob2, id2 := makeTxMetaBlobForTest(t, []byte("adopt-tx-blob-B-padding-padding"), 1)
+	require.NoError(t, txMap.PutWithNodeType(id1, blob1, shamap.NodeTypeTransactionWithMeta))
+	require.NoError(t, txMap.PutWithNodeType(id2, blob2, shamap.NodeTypeTransactionWithMeta))
 
 	expectedTxRoot, err := txMap.Hash()
 	require.NoError(t, err)
@@ -71,6 +118,17 @@ func TestAdoptLedgerWithState_PreservesTxMap(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expectedTxRoot, gotTxRoot,
 		"adopted ledger must carry the supplied tx map, not genesis's empty one")
+
+	// The in-memory tx-index must now contain exactly the 2 hashes that
+	// were installed. Pins F2: without collectTransactionResults being
+	// invoked on adopt, hash lookups against adopted ledgers silently
+	// fail in the `tx` RPC path.
+	assert.Len(t, svc.txIndex, 2,
+		"txIndex must contain one entry per adopted tx")
+	assert.Equal(t, hdr.LedgerIndex, svc.txIndex[id1],
+		"txIndex must map tx1 hash to the adopted ledger's seq")
+	assert.Equal(t, hdr.LedgerIndex, svc.txIndex[id2],
+		"txIndex must map tx2 hash to the adopted ledger's seq")
 }
 
 // TestAdoptLedgerWithState_NilTxMapFallsBackToEmpty verifies the
@@ -114,4 +172,127 @@ func TestAdoptLedgerWithState_NilTxMapFallsBackToEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, emptyTxRoot, gotTxRoot,
 		"nil txMap must fall back to the genesis-shaped empty tx map")
+}
+
+// TestAdoptLedgerWithState_PersistsToRelationalDB pins F1: adopting a
+// ledger with a tx map must flush those transactions to the
+// RelationalDB so `tx`, `account_tx`, `tx_history`, and
+// `transaction_entry` RPCs can answer queries against peer-adopted
+// ledgers. Before F1, the adopt path never called persistLedger and
+// every adopted ledger's txs were invisible to RPC consumers that hit
+// the DB instead of in-memory state.
+//
+// Mirrors rippled's setFullLedger -> pendSaveValidated chain
+// (LedgerMaster.cpp:831).
+func TestAdoptLedgerWithState_PersistsToRelationalDB(t *testing.T) {
+	ctx := context.Background()
+
+	// Spin up an on-disk (temp-dir) SQLite repository manager — sqlite
+	// is the supported test backend; there is no in-memory variant.
+	rm, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, rm.Open(ctx))
+	t.Cleanup(func() { _ = rm.Close(ctx) })
+
+	cfg := DefaultConfig()
+	cfg.RelationalDB = rm
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	// Two txs with canonical-hash keys so the DB row's trans_id column
+	// matches the hash we query for.
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	blob1, id1 := makeTxMetaBlobForTest(t, []byte("persist-tx-blob-A-padding-pad"), 0)
+	blob2, id2 := makeTxMetaBlobForTest(t, []byte("persist-tx-blob-B-padding-pad"), 1)
+	require.NoError(t, txMap.PutWithNodeType(id1, blob1, shamap.NodeTypeTransactionWithMeta))
+	require.NoError(t, txMap.PutWithNodeType(id2, blob2, shamap.NodeTypeTransactionWithMeta))
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	var adoptedHash [32]byte
+	adoptedHash[0] = 0xC1
+	hdr := &header.LedgerHeader{
+		LedgerIndex: svc.GetClosedLedgerIndex() + 1,
+		Hash:        adoptedHash,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+
+	require.NoError(t, svc.AdoptLedgerWithState(hdr, stateMap, txMap))
+
+	// Both adopted transactions must now be retrievable from the DB.
+	for _, wantID := range [][32]byte{id1, id2} {
+		var dbHash relationaldb.Hash
+		copy(dbHash[:], wantID[:])
+		got, search, err := rm.Transaction().GetTransaction(ctx, dbHash, nil)
+		require.NoError(t, err, "GetTransaction must not error for adopted tx")
+		require.Equal(t, relationaldb.TxSearchAll, search,
+			"adopted tx must be found in the RelationalDB")
+		require.NotNil(t, got, "adopted tx row must not be nil")
+		assert.Equal(t, relationaldb.LedgerIndex(hdr.LedgerIndex), got.LedgerSeq,
+			"adopted tx must be filed under the adopted ledger's seq")
+	}
+
+	// And the adopted ledger row itself must be persisted.
+	ledgerInfo, err := rm.Ledger().GetLedgerInfoBySeq(ctx, relationaldb.LedgerIndex(hdr.LedgerIndex))
+	require.NoError(t, err)
+	require.NotNil(t, ledgerInfo, "adopted ledger metadata must be persisted")
+}
+
+// TestAdoptLedgerWithState_PopulatesTxIndex pins F2: adopting a ledger
+// must populate s.txIndex for every tx in the installed tx map so
+// hash-lookup RPCs (tx, transaction_entry) can resolve hash -> seq
+// without touching the DB. Before F2, adopted ledgers were
+// invisible to the in-memory index and hash lookups fell off the
+// fast path.
+func TestAdoptLedgerWithState_PopulatesTxIndex(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+
+	blob1, id1 := makeTxMetaBlobForTest(t, []byte("idx-tx-blob-A-padding-padpad"), 0)
+	blob2, id2 := makeTxMetaBlobForTest(t, []byte("idx-tx-blob-B-padding-padpad"), 1)
+	blob3, id3 := makeTxMetaBlobForTest(t, []byte("idx-tx-blob-C-padding-padpad"), 2)
+	require.NoError(t, txMap.PutWithNodeType(id1, blob1, shamap.NodeTypeTransactionWithMeta))
+	require.NoError(t, txMap.PutWithNodeType(id2, blob2, shamap.NodeTypeTransactionWithMeta))
+	require.NoError(t, txMap.PutWithNodeType(id3, blob3, shamap.NodeTypeTransactionWithMeta))
+
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	var adoptedHash [32]byte
+	adoptedHash[0] = 0xF2
+	hdr := &header.LedgerHeader{
+		LedgerIndex: svc.GetClosedLedgerIndex() + 1,
+		Hash:        adoptedHash,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+
+	require.NoError(t, svc.AdoptLedgerWithState(hdr, stateMap, txMap))
+
+	for _, id := range [][32]byte{id1, id2, id3} {
+		seq, ok := svc.txIndex[id]
+		assert.True(t, ok, "txIndex must contain every adopted tx hash")
+		assert.Equal(t, hdr.LedgerIndex, seq,
+			"txIndex must map hash -> adopted ledger seq")
+	}
+	assert.Len(t, svc.txIndex, 3,
+		"txIndex must contain exactly the adopted txs, nothing more")
 }

--- a/internal/ledger/service/fix_mismatch_test.go
+++ b/internal/ledger/service/fix_mismatch_test.go
@@ -1,0 +1,347 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeStubLedger constructs a Ledger with an explicit seq/hash/parentHash
+// triple, backed by an empty state and tx map. The hash does not need to
+// match the canonical computed hash for this test — we exercise the
+// parent-hash chain check, which consumes the *stored* header values.
+func makeStubLedger(t *testing.T, seq uint32, hash, parentHash [32]byte) *ledger.Ledger {
+	t.Helper()
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	hdr := header.LedgerHeader{
+		LedgerIndex: seq,
+		Hash:        hash,
+		ParentHash:  parentHash,
+	}
+	return ledger.NewFromHeader(hdr, stateMap, txMap, drops.Fees{})
+}
+
+// TestAdoptLedgerWithState_FixMismatchInvalidatesDivergedTail pins F5:
+// when the adopted ledger's parent hash does NOT match the hash of the
+// prev-seq entry in ledgerHistory, the diverged slot (and every
+// orphaned forward entry) must be purged before the adopt installs
+// the new ledger.
+//
+// Seed chain: genesis (Start-installed) + stub A at seq S, stub B at
+// seq S+1 (child of A), stub C at seq S+2 (child of B). Adopt D at
+// seq S+1 whose parentHash != A.Hash(). F5 must:
+//   - Remove B from ledgerHistory (mismatched prev) and C (orphaned forward).
+//   - Install D in their place.
+//   - Leave A untouched (it's at a different seq than the one adopted;
+//     the adopted header pins seq S+1 only, so seqs < S+1 that do not
+//     chain to D's parent are not rewritten here).
+//
+// Regression guard: before F5, the old B3 would be silently overwritten
+// and C3 would linger as an orphan on the wrong fork.
+func TestAdoptLedgerWithState_FixMismatchInvalidatesDivergedTail(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	// Build a 3-ledger fork chain in history: A@S, B@S+1 (child of A),
+	// C@S+2 (child of B). S starts one above the closed ledger Start installed.
+	baseSeq := svc.GetClosedLedgerIndex() + 1
+
+	var hashA, hashB, hashC [32]byte
+	hashA[0] = 0xAA
+	hashB[0] = 0xBB
+	hashC[0] = 0xCC
+
+	// parentHash of A is immaterial — we do not adopt at seq A.
+	var zero [32]byte
+	ledA := makeStubLedger(t, baseSeq, hashA, zero)
+	ledB := makeStubLedger(t, baseSeq+1, hashB, hashA) // B chains to A
+	ledC := makeStubLedger(t, baseSeq+2, hashC, hashB) // C chains to B
+
+	// Seed the in-memory history directly. Bypass AdoptLedgerWithState
+	// to isolate the F5 path under test.
+	svc.mu.Lock()
+	svc.ledgerHistory[ledA.Sequence()] = ledA
+	svc.ledgerHistory[ledB.Sequence()] = ledB
+	svc.ledgerHistory[ledC.Sequence()] = ledC
+	// Simulate state where closedLedger advanced to C — the adoptLedger
+	// path will reassign closedLedger to the adopted D, but fixMismatch
+	// must also recognize when closedLedger points at an invalidated
+	// slot.
+	svc.closedLedger = ledC
+	svc.mu.Unlock()
+
+	// Build the divergent D at seq S+1. Its parentHash is NOT hashA,
+	// so it does NOT chain to our stored A — this must trip fixMismatch.
+	var hashD [32]byte
+	hashD[0] = 0xDD
+	var divergentParent [32]byte
+	divergentParent[0] = 0xFF // deliberately != hashA
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	hdrD := &header.LedgerHeader{
+		LedgerIndex: baseSeq + 1,
+		Hash:        hashD,
+		ParentHash:  divergentParent,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+
+	require.NoError(t, svc.AdoptLedgerWithState(hdrD, stateMap, txMap))
+
+	svc.mu.RLock()
+	defer svc.mu.RUnlock()
+
+	// D must be installed at seq S+1.
+	gotD, okD := svc.ledgerHistory[baseSeq+1]
+	require.True(t, okD, "adopted ledger D must be installed at its seq")
+	assert.Equal(t, hashD, gotD.Hash(), "seq S+1 must now hold D, not the purged B")
+
+	// B was on a divergent chain at the same seq as D — it's been
+	// overwritten by installing D. That is inherent to the map write,
+	// not F5's contribution. F5's job is the *forward* and *parent*
+	// sweeps. C must be purged (orphaned forward entry).
+	_, okC := svc.ledgerHistory[baseSeq+2]
+	assert.False(t, okC, "orphaned forward ledger C (> adoptedSeq) must be purged by fixMismatch")
+
+	// closedLedger must point to D after the adopt (adopt reassigns it),
+	// not at the invalidated C.
+	require.NotNil(t, svc.closedLedger)
+	assert.Equal(t, hashD, svc.closedLedger.Hash(),
+		"closedLedger must track the adopted ledger after a fork-switch adopt")
+}
+
+// TestAdoptLedgerWithState_NoMismatchNoOp pins the happy path:
+// if the adopted ledger's parentHash matches the hash of the prev-seq
+// entry in ledgerHistory, fixMismatch must leave history alone.
+//
+// Seed: A@S, B@S+1 (child of A). Adopt D@S+2 whose parentHash == B.Hash().
+// After adopt: A, B, D must all remain in history, D is new.
+func TestAdoptLedgerWithState_NoMismatchNoOp(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	baseSeq := svc.GetClosedLedgerIndex() + 1
+
+	var hashA, hashB [32]byte
+	hashA[0] = 0xA1
+	hashB[0] = 0xB1
+	var zero [32]byte
+	ledA := makeStubLedger(t, baseSeq, hashA, zero)
+	ledB := makeStubLedger(t, baseSeq+1, hashB, hashA)
+
+	svc.mu.Lock()
+	svc.ledgerHistory[ledA.Sequence()] = ledA
+	svc.ledgerHistory[ledB.Sequence()] = ledB
+	svc.closedLedger = ledB
+	svc.mu.Unlock()
+
+	// D at seq S+2 correctly chains to B.
+	var hashD [32]byte
+	hashD[0] = 0xD1
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	hdrD := &header.LedgerHeader{
+		LedgerIndex: baseSeq + 2,
+		Hash:        hashD,
+		ParentHash:  hashB, // chains correctly to B
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+
+	require.NoError(t, svc.AdoptLedgerWithState(hdrD, stateMap, txMap))
+
+	svc.mu.RLock()
+	defer svc.mu.RUnlock()
+
+	// A, B, D must all be present — no invalidation.
+	gotA, okA := svc.ledgerHistory[baseSeq]
+	require.True(t, okA, "A must remain: happy-path adopt does not invalidate")
+	assert.Equal(t, hashA, gotA.Hash())
+
+	gotB, okB := svc.ledgerHistory[baseSeq+1]
+	require.True(t, okB, "B must remain: its hash matches D.parentHash")
+	assert.Equal(t, hashB, gotB.Hash())
+
+	gotD, okD := svc.ledgerHistory[baseSeq+2]
+	require.True(t, okD)
+	assert.Equal(t, hashD, gotD.Hash())
+}
+
+// TestAdoptLedgerWithState_FixMismatchValidatedLedgerInvalidationLogsError
+// pins the escalation behavior: if fixMismatch invalidates a ledger that
+// was already quorum-validated, it MUST NOT silently reset
+// s.validatedLedger. A validated-ledger invalidation indicates a genuine
+// fork between our local quorum and the peer-adopted chain — that is
+// an operational alert, not a run-of-the-mill history rewrite.
+//
+// Verification strategy: confirm that s.validatedLedger retains its
+// prior pointer after fixMismatch runs on a validated-prev case.
+// The ERROR log itself is observed through the exercised code path;
+// verifying the log message text is brittle and is not checked here.
+func TestAdoptLedgerWithState_FixMismatchValidatedLedgerInvalidationLogsError(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	baseSeq := svc.GetClosedLedgerIndex() + 1
+
+	// Seed B at seq S+0; makeStubLedger's NewFromHeader already marks
+	// the ledger as validated (state=StateValidated). Adopt D at seq
+	// S+1 whose parentHash does not equal B.Hash() — fixMismatch must
+	// purge B and log ERROR. The validatedLedger pointer must not
+	// silently flip.
+	var hashB [32]byte
+	hashB[0] = 0x42
+	var zero [32]byte
+	ledB := makeStubLedger(t, baseSeq, hashB, zero)
+	require.True(t, ledB.IsValidated(),
+		"stub ledger via NewFromHeader must be in validated state")
+
+	svc.mu.Lock()
+	svc.ledgerHistory[ledB.Sequence()] = ledB
+	svc.closedLedger = ledB
+	prevValidated := svc.validatedLedger
+	svc.mu.Unlock()
+
+	var hashD [32]byte
+	hashD[0] = 0xD4
+	var divergentParent [32]byte
+	divergentParent[0] = 0xAB
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	hdrD := &header.LedgerHeader{
+		LedgerIndex: baseSeq + 1,
+		Hash:        hashD,
+		ParentHash:  divergentParent,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+
+	require.NoError(t, svc.AdoptLedgerWithState(hdrD, stateMap, txMap))
+
+	svc.mu.RLock()
+	defer svc.mu.RUnlock()
+	assert.Equal(t, prevValidated, svc.validatedLedger,
+		"validatedLedger must NOT be silently reset by fixMismatch — "+
+			"a validated-ledger invalidation is an operational alert and "+
+			"requires operator action, not silent rewrite")
+}
+
+// TestAdoptLedgerWithState_FixMismatchPurgesTxIndex pins that when a
+// ledger is invalidated by fixMismatch, any tx-index entries pointing
+// at it are removed too. Otherwise `tx` RPCs would keep resolving tx
+// hashes to a ledger slot whose contents were just discarded.
+func TestAdoptLedgerWithState_FixMismatchPurgesTxIndex(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	baseSeq := svc.GetClosedLedgerIndex() + 1
+
+	var hashA, hashB, hashC [32]byte
+	hashA[0] = 0x1A
+	hashB[0] = 0x1B
+	hashC[0] = 0x1C
+	var zero [32]byte
+	ledA := makeStubLedger(t, baseSeq, hashA, zero)
+	ledB := makeStubLedger(t, baseSeq+1, hashB, hashA)
+	ledC := makeStubLedger(t, baseSeq+2, hashC, hashB)
+
+	// Fake tx-index entries for the ledgers we expect to get purged.
+	var txInB, txInC [32]byte
+	txInB[0] = 0x0B
+	txInC[0] = 0x0C
+
+	svc.mu.Lock()
+	svc.ledgerHistory[ledA.Sequence()] = ledA
+	svc.ledgerHistory[ledB.Sequence()] = ledB
+	svc.ledgerHistory[ledC.Sequence()] = ledC
+	svc.closedLedger = ledC
+	svc.txIndex[txInB] = ledB.Sequence()
+	svc.txPositionIndex[txInB] = 0
+	svc.txIndex[txInC] = ledC.Sequence()
+	svc.txPositionIndex[txInC] = 0
+	svc.mu.Unlock()
+
+	// Divergent D at seq S+1.
+	var hashD [32]byte
+	hashD[0] = 0x1D
+	var divergentParent [32]byte
+	divergentParent[0] = 0xEE
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	hdrD := &header.LedgerHeader{
+		LedgerIndex: baseSeq + 1,
+		Hash:        hashD,
+		ParentHash:  divergentParent,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+
+	require.NoError(t, svc.AdoptLedgerWithState(hdrD, stateMap, txMap))
+
+	svc.mu.RLock()
+	defer svc.mu.RUnlock()
+
+	// The tx from the orphaned C must be purged from the tx-index.
+	_, okC := svc.txIndex[txInC]
+	assert.False(t, okC, "tx-index must drop entries for orphaned forward ledgers")
+	_, okCPos := svc.txPositionIndex[txInC]
+	assert.False(t, okCPos, "tx-position-index must drop entries for orphaned forward ledgers")
+
+	// The tx from B is subtler: B's slot is being overwritten by D (seq
+	// collision), but the *contents* of B are gone. Any tx-index entry
+	// that still resolved to baseSeq+1 would now dereference D's empty
+	// tx map and return nothing. So entries for invalidated B must also
+	// be dropped — unless the adopted D carries the same hash, which it
+	// doesn't here.
+	_, okB := svc.txIndex[txInB]
+	assert.False(t, okB, "tx-index must drop entries for a prev-seq ledger that mismatched the adopted parent")
+}

--- a/internal/ledger/service/held_adoption_test.go
+++ b/internal/ledger/service/held_adoption_test.go
@@ -1,0 +1,354 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// heldAdoptionFixture bundles the three inputs AdoptLedgerWithState needs
+// (header + state map + tx map) so the cascade tests can build a chain of
+// ledgers without repeating boilerplate.
+type heldAdoptionFixture struct {
+	hdr      *header.LedgerHeader
+	stateMap *shamap.SHAMap
+	txMap    *shamap.SHAMap
+}
+
+// buildHeldAdoptionInputs fabricates a header + fresh empty state/tx maps
+// with matching TxHash/AccountHash so AdoptLedgerWithState does not trip
+// over hash-consistency checks downstream. The caller supplies seq, hash,
+// and parentHash — the cascade logic cares only about those.
+func buildHeldAdoptionInputs(t *testing.T, seq uint32, hash, parentHash [32]byte) heldAdoptionFixture {
+	t.Helper()
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	hdr := &header.LedgerHeader{
+		LedgerIndex: seq,
+		Hash:        hash,
+		ParentHash:  parentHash,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+	return heldAdoptionFixture{hdr: hdr, stateMap: stateMap, txMap: txMap}
+}
+
+// TestAdoptLedgerWithState_CascadesHeldOrphan pins F6: when a replay-delta
+// for seq N+2 arrives before seq N+1 (out-of-order completion), the
+// service stashes the N+2 ledger as a held orphan keyed by its awaited
+// parent (seq N+1). Once seq N+1 is adopted and its hash equals the
+// stashed parent-hash reference, the cascade must promote the held N+2
+// in the same AdoptLedgerWithState call — no second external trigger.
+//
+// Without the cascade, the out-of-order replay-delta stalls until the
+// inbound loop happens to re-request N+2, delaying catch-up.
+func TestAdoptLedgerWithState_CascadesHeldOrphan(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	baseSeq := svc.GetClosedLedgerIndex() + 1
+
+	// seq 101 (= baseSeq) is the "awaited parent" for seq 102. Build 101
+	// first so we know its hash, then build 102 chaining to that hash.
+	var hash101, hash102 [32]byte
+	hash101[0] = 0xAA
+	hash102[0] = 0xBB
+
+	// Parent of 101 can be anything — we're not exercising the fixMismatch
+	// chain on 101 itself, just the held-cascade onto 102.
+	var parent101 [32]byte
+	fx101 := buildHeldAdoptionInputs(t, baseSeq, hash101, parent101)
+	fx102 := buildHeldAdoptionInputs(t, baseSeq+1, hash102, hash101) // 102 chains to 101
+
+	// Submit 102 as a held adoption. 101 is not yet in history so it
+	// must stash, not adopt immediately.
+	require.NoError(t, svc.SubmitHeldAdoption(fx102.hdr, fx102.stateMap, fx102.txMap))
+
+	svc.mu.RLock()
+	_, held := svc.heldAdoptions[baseSeq] // keyed by awaited-parent seq
+	svc.mu.RUnlock()
+	require.True(t, held, "102 must be stashed under key = awaited parent seq (101)")
+
+	_, err = svc.GetLedgerByHash(hash102)
+	require.Error(t, err, "102 must not be in history before 101 arrives")
+
+	// Now adopt 101 directly. Its hash matches the stashed parent
+	// reference on 102, so the cascade must promote 102 in the same
+	// call.
+	require.NoError(t, svc.AdoptLedgerWithState(fx101.hdr, fx101.stateMap, fx101.txMap))
+
+	// Both 101 and 102 must be installed in history.
+	got101, err := svc.GetLedgerByHash(hash101)
+	require.NoError(t, err)
+	require.NotNil(t, got101)
+	assert.Equal(t, hash101, got101.Hash())
+
+	got102, err := svc.GetLedgerByHash(hash102)
+	require.NoError(t, err, "cascade must have adopted 102 after 101 landed")
+	require.NotNil(t, got102)
+	assert.Equal(t, hash102, got102.Hash())
+
+	// closedLedger must have advanced to 102 (the tip of the cascade).
+	assert.Equal(t, hash102, svc.GetClosedLedger().Hash(),
+		"closedLedger must advance to the cascade tip, not stop at the parent")
+
+	// The stash must be empty after the successful cascade.
+	svc.mu.RLock()
+	_, stillHeld := svc.heldAdoptions[baseSeq]
+	svc.mu.RUnlock()
+	assert.False(t, stillHeld, "successful cascade must remove the held entry")
+}
+
+// TestAdoptLedgerWithState_OrphanMismatchDropped pins F6 safety: if the
+// held orphan's ParentHash field does NOT match the hash of the ledger
+// that just adopted at the parent seq, the orphan is from a divergent
+// fork. It must be dropped (not silently promoted onto the wrong chain)
+// and must not linger in the stash to re-fire later.
+func TestAdoptLedgerWithState_OrphanMismatchDropped(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	baseSeq := svc.GetClosedLedgerIndex() + 1
+
+	// 101 will adopt with hash Y.
+	var hashY, hashX, hash102 [32]byte
+	hashY[0] = 0xA1
+	hashX[0] = 0xFF // deliberately != hashY — the "other fork" parent
+	hash102[0] = 0x02
+
+	var parent101 [32]byte
+	fx101 := buildHeldAdoptionInputs(t, baseSeq, hashY, parent101)
+
+	// 102 says its parent is X (a different fork), not Y.
+	fx102 := buildHeldAdoptionInputs(t, baseSeq+1, hash102, hashX)
+
+	require.NoError(t, svc.SubmitHeldAdoption(fx102.hdr, fx102.stateMap, fx102.txMap))
+
+	// Adopt 101 with hash Y. 102's ParentHash is X ≠ Y → drop 102.
+	require.NoError(t, svc.AdoptLedgerWithState(fx101.hdr, fx101.stateMap, fx101.txMap))
+
+	// 101 is installed.
+	_, err = svc.GetLedgerByHash(hashY)
+	require.NoError(t, err)
+
+	// 102 is NOT installed — parent-hash mismatch means it was on a
+	// different fork from the one we just adopted.
+	_, err = svc.GetLedgerByHash(hash102)
+	require.Error(t, err, "102 must NOT be adopted when its ParentHash ≠ adopted hash at the parent seq")
+
+	// And the stash must be empty — the mismatched entry was dropped,
+	// not left to re-fire if 101 is re-adopted.
+	svc.mu.RLock()
+	_, stillHeld := svc.heldAdoptions[baseSeq]
+	svc.mu.RUnlock()
+	assert.False(t, stillHeld, "mismatched held entry must be dropped, not retained")
+}
+
+// TestSubmitHeldAdoption_ParentAlreadyPresent verifies the fast path:
+// if the awaited parent is already in ledgerHistory AND its hash matches
+// the caller-supplied ParentHash, SubmitHeldAdoption adopts immediately
+// rather than pointlessly stashing.
+func TestSubmitHeldAdoption_ParentAlreadyPresent(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	baseSeq := svc.GetClosedLedgerIndex() + 1
+
+	var hash101, hash102 [32]byte
+	hash101[0] = 0xC1
+	hash102[0] = 0xC2
+	var parent101 [32]byte
+
+	fx101 := buildHeldAdoptionInputs(t, baseSeq, hash101, parent101)
+	require.NoError(t, svc.AdoptLedgerWithState(fx101.hdr, fx101.stateMap, fx101.txMap))
+
+	fx102 := buildHeldAdoptionInputs(t, baseSeq+1, hash102, hash101)
+	require.NoError(t, svc.SubmitHeldAdoption(fx102.hdr, fx102.stateMap, fx102.txMap))
+
+	// 102 must be installed immediately (parent already present).
+	got102, err := svc.GetLedgerByHash(hash102)
+	require.NoError(t, err)
+	assert.Equal(t, hash102, got102.Hash())
+
+	// Nothing must be stashed — the fast path took over.
+	svc.mu.RLock()
+	_, stashed := svc.heldAdoptions[baseSeq]
+	svc.mu.RUnlock()
+	assert.False(t, stashed, "fast path must not stash when parent is already present")
+}
+
+// TestSubmitHeldAdoption_ParentPresentButHashMismatch pins the fork
+// check in SubmitHeldAdoption's fast path: if the awaited parent seq is
+// in ledgerHistory but its hash differs from ParentHash, the submission
+// is on a divergent fork and must be stashed (not applied onto the wrong
+// chain). The stashed entry will be dropped later when the actual fork's
+// parent seq is adopted at a different hash — or will TTL-out.
+//
+// Rationale: silently adopting onto a mismatched parent would corrupt
+// history. Stashing-then-dropping lets the correct-fork adopt land first
+// without noise.
+func TestSubmitHeldAdoption_ParentPresentButHashMismatch(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	baseSeq := svc.GetClosedLedgerIndex() + 1
+
+	var hash101Present, hash101Wanted, hash102 [32]byte
+	hash101Present[0] = 0xAA
+	hash101Wanted[0] = 0xBB
+	hash102[0] = 0x02
+	var parent101 [32]byte
+
+	// Adopt 101 with hash AA.
+	fx101 := buildHeldAdoptionInputs(t, baseSeq, hash101Present, parent101)
+	require.NoError(t, svc.AdoptLedgerWithState(fx101.hdr, fx101.stateMap, fx101.txMap))
+
+	// Submit 102 claiming parent BB (≠ AA). Must not adopt onto the
+	// mismatched chain; it must be refused as a no-op from the ledger-
+	// history perspective.
+	fx102 := buildHeldAdoptionInputs(t, baseSeq+1, hash102, hash101Wanted)
+	require.NoError(t, svc.SubmitHeldAdoption(fx102.hdr, fx102.stateMap, fx102.txMap))
+
+	// 102 must NOT be in history — neither adopted nor cascaded.
+	_, err = svc.GetLedgerByHash(hash102)
+	require.Error(t, err, "divergent-parent submissions must not be adopted onto the existing chain")
+}
+
+// TestAdoptLedgerWithState_HeldAdoptionExpires verifies the 60s TTL: a
+// held entry older than heldAdoptionTTL must be evicted on the next
+// adopt call and must NOT cascade even if the parent hash matches.
+// The evicted entry's cascade is prevented to avoid promoting a ledger
+// whose peer-source context is stale (the replay-delta may have been
+// superseded by a later round).
+func TestAdoptLedgerWithState_HeldAdoptionExpires(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	baseSeq := svc.GetClosedLedgerIndex() + 1
+
+	var hash101, hash102 [32]byte
+	hash101[0] = 0xE1
+	hash102[0] = 0xE2
+	var parent101 [32]byte
+
+	fx101 := buildHeldAdoptionInputs(t, baseSeq, hash101, parent101)
+	fx102 := buildHeldAdoptionInputs(t, baseSeq+1, hash102, hash101)
+
+	// Manually stash 102 with a stale `at` to simulate age > TTL.
+	svc.mu.Lock()
+	svc.heldAdoptions[baseSeq] = &pendingAdopt{
+		header:   fx102.hdr,
+		stateMap: fx102.stateMap,
+		txMap:    fx102.txMap,
+		at:       time.Now().Add(-2 * heldAdoptionTTL),
+	}
+	svc.mu.Unlock()
+
+	// Adopt 101. Even though the hash matches 102's ParentHash, 102 is
+	// expired and must be evicted without cascading.
+	require.NoError(t, svc.AdoptLedgerWithState(fx101.hdr, fx101.stateMap, fx101.txMap))
+
+	_, err = svc.GetLedgerByHash(hash102)
+	require.Error(t, err, "expired held entry must NOT cascade — 102 must stay out of history")
+
+	svc.mu.RLock()
+	_, stillHeld := svc.heldAdoptions[baseSeq]
+	svc.mu.RUnlock()
+	assert.False(t, stillHeld, "expired entry must be evicted from the stash")
+}
+
+// TestAdoptLedgerWithState_MultiLevelCascade pins that a chain of held
+// orphans (102 waiting on 101, 103 waiting on 102) promotes in one
+// AdoptLedgerWithState(101) call. The cascade walks forward until the
+// stash has no match at the next-seq key.
+//
+// Two-hop cascade is the realistic upper bound for goXRPL's replay-delta
+// stream: the 256-level cap exists to guard against pathological inputs,
+// but real cascades are short.
+func TestAdoptLedgerWithState_MultiLevelCascade(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	baseSeq := svc.GetClosedLedgerIndex() + 1
+
+	var hash101, hash102, hash103 [32]byte
+	hash101[0] = 0x01
+	hash102[0] = 0x02
+	hash103[0] = 0x03
+	var parent101 [32]byte
+
+	fx101 := buildHeldAdoptionInputs(t, baseSeq, hash101, parent101)
+	fx102 := buildHeldAdoptionInputs(t, baseSeq+1, hash102, hash101)
+	fx103 := buildHeldAdoptionInputs(t, baseSeq+2, hash103, hash102)
+
+	// Submit 103 before 102 — both stash.
+	require.NoError(t, svc.SubmitHeldAdoption(fx103.hdr, fx103.stateMap, fx103.txMap))
+	require.NoError(t, svc.SubmitHeldAdoption(fx102.hdr, fx102.stateMap, fx102.txMap))
+
+	svc.mu.RLock()
+	_, has102Parent := svc.heldAdoptions[baseSeq]     // 102 waits on 101
+	_, has103Parent := svc.heldAdoptions[baseSeq+1]   // 103 waits on 102
+	svc.mu.RUnlock()
+	require.True(t, has102Parent, "102 must stash under parent-seq 101")
+	require.True(t, has103Parent, "103 must stash under parent-seq 102")
+
+	// Adopt 101 — cascade must flush both 102 and 103.
+	require.NoError(t, svc.AdoptLedgerWithState(fx101.hdr, fx101.stateMap, fx101.txMap))
+
+	for _, h := range [][32]byte{hash101, hash102, hash103} {
+		got, err := svc.GetLedgerByHash(h)
+		require.NoError(t, err, "cascade must adopt 101, 102, and 103")
+		require.NotNil(t, got)
+	}
+
+	assert.Equal(t, hash103, svc.GetClosedLedger().Hash(),
+		"closedLedger must track the cascade tip (103), not stop mid-cascade")
+
+	// Stash must be empty.
+	svc.mu.RLock()
+	remaining := len(svc.heldAdoptions)
+	svc.mu.RUnlock()
+	assert.Zero(t, remaining, "multi-level cascade must drain every matching held entry")
+}
+
+// TestSubmitHeldAdoption_RejectsNil pins basic input validation: nil
+// header or nil state map must not be stashed (they would cause a panic
+// later on cascade). txMap may be nil (legacy catchup path).
+func TestSubmitHeldAdoption_RejectsNil(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	assert.Error(t, svc.SubmitHeldAdoption(nil, nil, nil),
+		"nil header must be rejected")
+
+	hdr := &header.LedgerHeader{LedgerIndex: 42}
+	assert.Error(t, svc.SubmitHeldAdoption(hdr, nil, nil),
+		"nil state map must be rejected")
+}

--- a/internal/ledger/service/pending_ledger_validation_test.go
+++ b/internal/ledger/service/pending_ledger_validation_test.go
@@ -1,0 +1,201 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetValidatedLedger_StashesWhenSeqMissing_FiresOnAdopt pins F4:
+// when SetValidatedLedger fires for a seq whose ledger has not yet been
+// inserted into ledgerHistory (validation tracker leads the peer-adopt
+// loop), the (seq, expectedHash) pair must be stashed and later promoted
+// when the adopt path installs that ledger with a matching hash.
+//
+// Without this, a trusted validation for seq N that races ahead of the
+// peer-adoption of N is silently dropped and validatedLedger never
+// advances — the observable symptom is server_info.validated_ledger
+// lagging behind closed_ledger indefinitely despite quorum being met.
+func TestSetValidatedLedger_StashesWhenSeqMissing_FiresOnAdopt(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	// Build a header+state that we intend to adopt shortly.
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	var adoptedHash [32]byte
+	adoptedHash[0] = 0xA1
+	adoptedSeq := svc.GetClosedLedgerIndex() + 1
+	hdr := &header.LedgerHeader{
+		LedgerIndex: adoptedSeq,
+		Hash:        adoptedHash,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+
+	// Validation races ahead of adopt: call SetValidatedLedger *before*
+	// the seq exists in ledgerHistory. Must NOT promote yet — just stash.
+	startValidated := svc.GetValidatedLedgerIndex()
+	svc.SetValidatedLedger(adoptedSeq, adoptedHash)
+
+	assert.Equal(t, startValidated, svc.GetValidatedLedgerIndex(),
+		"SetValidatedLedger must not advance validatedLedger when seq is not yet in history")
+
+	// The stash must hold this seq pending a future adopt.
+	svc.mu.RLock()
+	pending, stashed := svc.pendingLedgerValidations[adoptedSeq]
+	svc.mu.RUnlock()
+	require.True(t, stashed,
+		"SetValidatedLedger must stash (seq, expectedHash) when seq is not yet in history")
+	assert.Equal(t, adoptedHash, pending.expectedHash)
+
+	// When the adopt path installs this ledger, the stashed validation
+	// must be drained and validatedLedger promoted to the adopted ledger.
+	require.NoError(t, svc.AdoptLedgerWithState(hdr, stateMap, txMap))
+
+	assert.Equal(t, adoptedSeq, svc.GetValidatedLedgerIndex(),
+		"AdoptLedgerWithState must drain the stashed validation and promote validatedLedger")
+
+	// Drain must remove the entry.
+	svc.mu.RLock()
+	_, stillStashed := svc.pendingLedgerValidations[adoptedSeq]
+	svc.mu.RUnlock()
+	assert.False(t, stillStashed,
+		"adopt-drain must remove the stashed entry")
+}
+
+// TestSetValidatedLedger_StashExpires pins F4: a stashed validation older
+// than pendingValidationTTL must be discarded on drain and must NOT
+// promote the adopted ledger to validated. An expired stash is a staleness
+// signal — by the time we adopt, the quorum gossip that produced the
+// original validation is too old to trust without a fresh re-confirmation.
+func TestSetValidatedLedger_StashExpires(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	var adoptedHash [32]byte
+	adoptedHash[0] = 0xB2
+	adoptedSeq := svc.GetClosedLedgerIndex() + 1
+	hdr := &header.LedgerHeader{
+		LedgerIndex: adoptedSeq,
+		Hash:        adoptedHash,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+
+	startValidated := svc.GetValidatedLedgerIndex()
+
+	// Stash a validation for this seq, then backdate `at` past the TTL.
+	svc.SetValidatedLedger(adoptedSeq, adoptedHash)
+
+	svc.mu.Lock()
+	entry, ok := svc.pendingLedgerValidations[adoptedSeq]
+	require.True(t, ok, "setup: stash must exist before backdate")
+	entry.at = time.Now().Add(-2 * pendingValidationTTL)
+	svc.pendingLedgerValidations[adoptedSeq] = entry
+	svc.mu.Unlock()
+
+	// Adopt — the drain must see the stale entry and refuse to promote.
+	require.NoError(t, svc.AdoptLedgerWithState(hdr, stateMap, txMap))
+
+	assert.Equal(t, startValidated, svc.GetValidatedLedgerIndex(),
+		"expired stash must NOT promote validatedLedger on adopt")
+
+	// The stale entry must be cleaned up regardless of promotion outcome.
+	svc.mu.RLock()
+	_, stillStashed := svc.pendingLedgerValidations[adoptedSeq]
+	svc.mu.RUnlock()
+	assert.False(t, stillStashed,
+		"drain must delete expired entries even when refusing to promote")
+}
+
+// TestSetValidatedLedger_StashHashMismatch pins F4: a stashed validation
+// for hash A must NOT promote an adopted ledger whose hash is B. This is
+// the fork-safety guard — if peers validated a different hash at that seq
+// than the one we adopted locally, our adopted ledger is on the wrong
+// fork and silently promoting it to validated would be a correctness bug.
+// Mirrors the inline-hash-match guard SetValidatedLedger already applies
+// when the seq IS present in history.
+func TestSetValidatedLedger_StashHashMismatch(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	// Peer-adoption path will install hash B.
+	var adoptedHashB [32]byte
+	adoptedHashB[0] = 0xC3
+
+	// But trusted validation arrived earlier referencing hash A.
+	var validatedHashA [32]byte
+	validatedHashA[0] = 0xC4
+
+	adoptedSeq := svc.GetClosedLedgerIndex() + 1
+	hdr := &header.LedgerHeader{
+		LedgerIndex: adoptedSeq,
+		Hash:        adoptedHashB,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+
+	startValidated := svc.GetValidatedLedgerIndex()
+
+	// Stash validation for A.
+	svc.SetValidatedLedger(adoptedSeq, validatedHashA)
+
+	svc.mu.RLock()
+	entry, stashed := svc.pendingLedgerValidations[adoptedSeq]
+	svc.mu.RUnlock()
+	require.True(t, stashed, "setup: stash must exist before adopt")
+	require.Equal(t, validatedHashA, entry.expectedHash)
+
+	// Adopt B. Must NOT promote — fork signal.
+	require.NoError(t, svc.AdoptLedgerWithState(hdr, stateMap, txMap))
+
+	assert.Equal(t, startValidated, svc.GetValidatedLedgerIndex(),
+		"hash mismatch between stashed validation and adopted ledger must NOT promote")
+
+	// The stale-hash entry must be cleaned up so it can't accidentally
+	// match a later adopt at the same seq.
+	svc.mu.RLock()
+	_, stillStashed := svc.pendingLedgerValidations[adoptedSeq]
+	svc.mu.RUnlock()
+	assert.False(t, stillStashed,
+		"drain must delete hash-mismatched entries on the seq-adopt side")
+}

--- a/internal/ledger/service/pending_ledger_validation_test.go
+++ b/internal/ledger/service/pending_ledger_validation_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -198,4 +199,235 @@ func TestSetValidatedLedger_StashHashMismatch(t *testing.T) {
 	svc.mu.RUnlock()
 	assert.False(t, stillStashed,
 		"drain must delete hash-mismatched entries on the seq-adopt side")
+}
+
+// TestAdoptLedgerWithState_EventCallbackFiresAfterValidationFirstRace pins
+// the validation-first race fix: when SetValidatedLedger arrives BEFORE the
+// adopt path installs the ledger, the subsequent adopt's F4 drain promotes
+// validatedLedger in-line — but nothing will ever call SetValidatedLedger
+// again for that hash, so the hash-keyed LedgerAcceptedEvent stash would
+// never drain. The legacy eventCallback (wired to the WebSocket
+// ledgerClosed + transaction streams) must therefore fire inline when F4
+// drain returns true, and the hash-keyed stash must NOT be populated in
+// that case (no one will drain it). Skipping the stash also prevents a
+// double-fire hazard if a late duplicate SetValidatedLedger arrives.
+func TestAdoptLedgerWithState_EventCallbackFiresAfterValidationFirstRace(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	var (
+		mu            sync.Mutex
+		callbackCount int
+		lastEvent     *LedgerAcceptedEvent
+	)
+	done := make(chan struct{}, 1)
+
+	svc.SetEventCallback(func(event *LedgerAcceptedEvent) {
+		mu.Lock()
+		callbackCount++
+		lastEvent = event
+		mu.Unlock()
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	})
+
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	blob1, id1 := makeTxMetaBlobForTest(t, []byte("race-tx-blob-A-padding-padpad"), 0)
+	require.NoError(t, txMap.PutWithNodeType(id1, blob1, shamap.NodeTypeTransactionWithMeta))
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	var adoptedHash [32]byte
+	adoptedHash[0] = 0xE1
+	adoptedSeq := svc.GetClosedLedgerIndex() + 1
+	hdr := &header.LedgerHeader{
+		LedgerIndex: adoptedSeq,
+		Hash:        adoptedHash,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+
+	// Validation-first race: trusted-validation quorum gossip reaches us
+	// before the peer-adopt loop installs seq N. This stashes in
+	// pendingLedgerValidations keyed by seq.
+	svc.SetValidatedLedger(adoptedSeq, adoptedHash)
+
+	// Sanity: the seq-keyed stash must be populated and validatedLedger
+	// must NOT have advanced yet (the seq isn't in history).
+	svc.mu.RLock()
+	_, seqStashed := svc.pendingLedgerValidations[adoptedSeq]
+	svc.mu.RUnlock()
+	require.True(t, seqStashed,
+		"setup: SetValidatedLedger must stash (seq, hash) when seq not in history")
+
+	// Now adopt. F4 drain inside adoptLedgerWithStateLocked sees the
+	// matching-hash, non-expired stash and promotes validatedLedger
+	// to the adopted ledger. Because no SetValidatedLedger will arrive
+	// later for this hash, the legacy eventCallback MUST fire inline.
+	require.NoError(t, svc.AdoptLedgerWithState(hdr, stateMap, txMap))
+
+	assert.Equal(t, adoptedSeq, svc.GetValidatedLedgerIndex(),
+		"F4 drain must promote validatedLedger on matching adopt")
+
+	// Wait for the inline-dispatched eventCallback.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("eventCallback must fire inline when F4 drain promotes the adopted ledger — " +
+			"no later SetValidatedLedger will arrive to drain the hash-keyed stash")
+	}
+
+	mu.Lock()
+	assert.Equal(t, 1, callbackCount,
+		"eventCallback must fire exactly once on the validation-first race path")
+	require.NotNil(t, lastEvent)
+	require.NotNil(t, lastEvent.LedgerInfo)
+	assert.Equal(t, adoptedSeq, lastEvent.LedgerInfo.Sequence,
+		"fired event must carry the adopted ledger's seq")
+	assert.Equal(t, adoptedHash, lastEvent.LedgerInfo.Hash,
+		"fired event must carry the adopted ledger's hash")
+	assert.Len(t, lastEvent.TransactionResults, 1,
+		"fired event must carry the adopted tx results")
+	mu.Unlock()
+
+	// The hash-keyed stash must NOT have been populated — firing inline
+	// supersedes stashing. Leaving a stash here would cause a double-fire
+	// if a late duplicate SetValidatedLedger arrived for the same hash.
+	svc.mu.RLock()
+	_, hashStashed := svc.pendingValidation[adoptedHash]
+	svc.mu.RUnlock()
+	assert.False(t, hashStashed,
+		"pendingValidation[hash] must NOT be populated when F4 drain fires inline — "+
+			"the event has already been consumed")
+
+	// Defense-in-depth: a second SetValidatedLedger call for the same
+	// (seq, hash) must be a no-op (seq is in history and already validated)
+	// and MUST NOT fire eventCallback again.
+	svc.SetValidatedLedger(adoptedSeq, adoptedHash)
+
+	select {
+	case <-done:
+		t.Fatal("eventCallback must not fire twice — no late-duplicate stash should remain")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, callbackCount,
+		"late-duplicate SetValidatedLedger must not cause a second eventCallback dispatch")
+}
+
+// TestAcceptConsensusResult_EventCallbackFiresAfterValidationFirstRace pins
+// the same fix for the consensus-close path. When a trusted-validation
+// gossip for seq N arrives before the local consensus round closes seq N,
+// AcceptConsensusResult's F4 drain promotes validatedLedger in-line — and
+// likewise no later SetValidatedLedger will arrive to drain the hash-keyed
+// stash. The eventCallback must fire inline.
+func TestAcceptConsensusResult_EventCallbackFiresAfterValidationFirstRace(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	var (
+		mu            sync.Mutex
+		callbackCount int
+		lastEvent     *LedgerAcceptedEvent
+	)
+	done := make(chan struct{}, 1)
+
+	svc.SetEventCallback(func(event *LedgerAcceptedEvent) {
+		mu.Lock()
+		callbackCount++
+		lastEvent = event
+		mu.Unlock()
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	})
+
+	// Predict the hash that AcceptConsensusResult will compute so we can
+	// stash a matching validation. The openLedger already chains off the
+	// current closedLedger via Start() — closing it with (closeTime, 0)
+	// and no txs is deterministic, so we can snapshot+close a clone to
+	// derive the exact hash. Simpler alternative: stash the *seq* with a
+	// wrong hash first to verify validation-first no-ops, then do the
+	// real-race test below. But the cleanest form is to perform the close
+	// twice: once discarded to capture the hash, then re-close for real.
+	//
+	// Even simpler: do the real close first, observe the produced hash,
+	// then drive AcceptConsensusResult on a fresh service where we can
+	// pre-stash that hash. That keeps the test free of internal cloning.
+	probeSvc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, probeSvc.Start())
+
+	parent := probeSvc.GetClosedLedger()
+	require.NotNil(t, parent)
+	expectedSeq := parent.Sequence() + 1
+	closeTime := time.Unix(1700000000, 0)
+	_, err = probeSvc.AcceptConsensusResult(parent, nil, closeTime)
+	require.NoError(t, err)
+
+	// Capture the hash that the deterministic close produced.
+	probeSvc.mu.RLock()
+	expectedHash := probeSvc.closedLedger.Hash()
+	probeSvc.mu.RUnlock()
+	require.NotEqual(t, [32]byte{}, expectedHash)
+
+	// Back to the real svc: stash the validation BEFORE AcceptConsensusResult.
+	parentReal := svc.GetClosedLedger()
+	require.NotNil(t, parentReal)
+	require.Equal(t, parent.Sequence(), parentReal.Sequence(),
+		"probe and real service must start from the same closedLedger seq")
+
+	svc.SetValidatedLedger(expectedSeq, expectedHash)
+
+	svc.mu.RLock()
+	_, seqStashed := svc.pendingLedgerValidations[expectedSeq]
+	svc.mu.RUnlock()
+	require.True(t, seqStashed,
+		"setup: SetValidatedLedger must stash (seq, hash) when seq not in history")
+
+	// Close the consensus ledger. F4 drain sees the matching-hash,
+	// non-expired stash and promotes validatedLedger. eventCallback MUST
+	// fire inline because no later SetValidatedLedger will arrive.
+	closedSeq, err := svc.AcceptConsensusResult(parentReal, nil, closeTime)
+	require.NoError(t, err)
+	require.Equal(t, expectedSeq, closedSeq)
+
+	assert.Equal(t, expectedSeq, svc.GetValidatedLedgerIndex(),
+		"F4 drain must promote validatedLedger on matching consensus close")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("eventCallback must fire inline when F4 drain promotes the closed ledger")
+	}
+
+	mu.Lock()
+	assert.Equal(t, 1, callbackCount,
+		"eventCallback must fire exactly once on the consensus-close validation-first race path")
+	require.NotNil(t, lastEvent)
+	require.NotNil(t, lastEvent.LedgerInfo)
+	assert.Equal(t, expectedSeq, lastEvent.LedgerInfo.Sequence)
+	assert.Equal(t, expectedHash, lastEvent.LedgerInfo.Hash)
+	mu.Unlock()
+
+	svc.mu.RLock()
+	_, hashStashed := svc.pendingValidation[expectedHash]
+	svc.mu.RUnlock()
+	assert.False(t, hashStashed,
+		"pendingValidation[hash] must NOT be populated when F4 drain fires inline")
 }

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -699,7 +699,12 @@ func (s *Service) getValidatedLedgersRange() string {
 }
 
 // collectTransactionResults gathers transaction data from the closed ledger
-// and records each transaction's position within the ledger.
+// and records each transaction's position within the ledger. It also
+// populates s.txIndex (hash -> ledger seq) so tx-hash RPC lookups
+// resolve to this ledger. For the local-close path s.txIndex is also
+// written at Apply time; repeating the write here is idempotent and is
+// the sole index population site for the peer-adopt path, which has no
+// Apply step.
 func (s *Service) collectTransactionResults(l *ledger.Ledger, ledgerSeq uint32, ledgerHash [32]byte) []TransactionResultEvent {
 	var results []TransactionResultEvent
 
@@ -714,6 +719,7 @@ func (s *Service) collectTransactionResults(l *ledger.Ledger, ledgerSeq uint32, 
 		}
 		result.AffectedAccounts = extractAffectedAccounts(txData)
 
+		s.txIndex[txHash] = ledgerSeq
 		s.txPositionIndex[txHash] = txIndex
 		txIndex++
 
@@ -1433,6 +1439,23 @@ func (s *Service) AdoptLedgerWithState(h *header.LedgerHeader, stateMap *shamap.
 	s.closedLedger = adopted
 	s.ledgerHistory[h.LedgerIndex] = adopted
 	s.needsInitialSync = false
+
+	// Persist the adopted ledger exactly as the local close path does so
+	// tx/account_tx/tx_history/transaction_entry RPCs can answer queries
+	// against it. Matches LedgerMaster::setFullLedger -> pendSaveValidated.
+	if err := s.persistLedger(adopted); err != nil {
+		// Degrade gracefully: the in-memory state is still correct and the
+		// next consensus close will re-try persistence. Log loudly because
+		// a persistent failure breaks tx RPCs silently.
+		s.logger.Error("Failed to persist adopted ledger", "seq", h.LedgerIndex, "err", err)
+	}
+
+	// Populate the in-memory tx-index so tx-hash lookups resolve to this
+	// seq. collectTransactionResults walks the tx map and writes to
+	// s.txIndex + s.txPositionIndex as a side effect; we don't need the
+	// returned results here (no subscribers to dispatch to yet — that's
+	// Task 1.2).
+	_ = s.collectTransactionResults(adopted, h.LedgerIndex, h.Hash)
 
 	// Create new open ledger on top
 	openLedger, err := ledger.NewOpen(adopted, time.Now())

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -152,6 +152,21 @@ type Service struct {
 	// pendingValidationOrder tracks insertion order for LRU eviction.
 	pendingValidationOrder [][32]byte
 
+	// pendingLedgerValidations stashes trusted-validation notifications
+	// keyed by ledger *sequence* when SetValidatedLedger arrives ahead of
+	// the peer-adoption of that seq. On every subsequent insertion into
+	// ledgerHistory for a matching seq, the stash is drained and the
+	// ledger promoted to validated if the hash matches and the entry
+	// has not expired. Distinct from pendingValidation, which is keyed
+	// by *hash* and stashes full accepted events — this map stashes
+	// validation notifications in the opposite race (validation before
+	// close/adopt, not close/adopt before validation).
+	pendingLedgerValidations map[uint32]pendingValidationEntry
+
+	// pendingLedgerValidationsOrder tracks insertion order for LRU
+	// eviction of pendingLedgerValidations.
+	pendingLedgerValidationsOrder []uint32
+
 	// hooks provides event callbacks for external subscribers
 	hooks *EventHooks
 
@@ -171,14 +186,15 @@ func New(cfg Config) (*Service, error) {
 		logger = xrpllog.Discard()
 	}
 	s := &Service{
-		config:            cfg,
-		logger:            logger.Named(xrpllog.PartitionLedger),
-		nodeStore:         cfg.NodeStore,
-		relationalDB:      cfg.RelationalDB,
-		ledgerHistory:     make(map[uint32]*ledger.Ledger),
-		txIndex:           make(map[[32]byte]uint32),
-		txPositionIndex:   make(map[[32]byte]uint32),
-		pendingValidation: make(map[[32]byte]*LedgerAcceptedEvent),
+		config:                   cfg,
+		logger:                   logger.Named(xrpllog.PartitionLedger),
+		nodeStore:                cfg.NodeStore,
+		relationalDB:             cfg.RelationalDB,
+		ledgerHistory:            make(map[uint32]*ledger.Ledger),
+		txIndex:                  make(map[[32]byte]uint32),
+		txPositionIndex:          make(map[[32]byte]uint32),
+		pendingValidation:        make(map[[32]byte]*LedgerAcceptedEvent),
+		pendingLedgerValidations: make(map[uint32]pendingValidationEntry),
 	}
 
 	return s, nil
@@ -598,6 +614,12 @@ func (s *Service) AcceptLedger() (uint32, error) {
 	s.closedLedger = s.openLedger
 	s.validatedLedger = s.openLedger
 	s.ledgerHistory[closedSeq] = s.openLedger
+
+	// Standalone already promotes to validated above, so any stashed
+	// validation at this seq is redundant — but drain it so the entry
+	// doesn't linger and accidentally match a later re-close at the
+	// same seq. No-op when nothing is stashed.
+	s.drainPendingLedgerValidationLocked(closedSeq, s.closedLedger)
 
 	// Collect transaction results for event callbacks/hooks
 	var txResults []TransactionResultEvent
@@ -1127,6 +1149,10 @@ func (s *Service) AcceptConsensusResult(parent *ledger.Ledger, txBlobs [][]byte,
 	s.closedLedger = s.openLedger
 	s.ledgerHistory[closedSeq] = s.openLedger
 
+	// Drain any validation that arrived before this close (validation
+	// tracker leading the consensus close). Fail-safe on expired/mismatch.
+	s.drainPendingLedgerValidationLocked(closedSeq, s.closedLedger)
+
 	// Collect transaction results for event callbacks/hooks
 	var txResults []TransactionResultEvent
 	if s.eventCallback != nil || (s.hooks != nil && (s.hooks.OnLedgerClosed != nil || s.hooks.OnTransaction != nil)) {
@@ -1215,6 +1241,14 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	s.mu.Lock()
 	l, ok := s.ledgerHistory[seq]
 	if !ok {
+		// Validation tracker raced ahead of the peer-adoption loop:
+		// quorum was reached for seq N before our local adopt/close
+		// installed seq N into ledgerHistory. Stash the (seq, hash)
+		// pair so the next insertion at that seq can promote to
+		// validated if the hash matches. Without this stash, the
+		// validation is dropped and server_info.validated_ledger
+		// lags closed_ledger indefinitely.
+		s.stashPendingLedgerValidationLocked(seq, expectedHash)
 		s.mu.Unlock()
 		return
 	}
@@ -1288,6 +1322,97 @@ func (s *Service) drainPendingValidationLocked(hash [32]byte) *LedgerAcceptedEve
 		}
 	}
 	return event
+}
+
+// pendingValidationEntry records a trusted-validation notification that
+// arrived for a ledger sequence not yet present in ledgerHistory. The
+// `at` timestamp TTL-guards the entry: if the adopt/close path races
+// far enough behind the validation tracker that quorum gossip has gone
+// stale, the entry is discarded on drain rather than silently promoting.
+type pendingValidationEntry struct {
+	expectedHash [32]byte
+	at           time.Time
+}
+
+// pendingValidationTTL bounds how long a stashed validation is considered
+// fresh enough to promote on later adopt/close. 30s is comfortably larger
+// than the quorum-gossip window (a few seconds in practice) but small
+// enough that a truly stale validation — one where the adopt path is
+// lagging minutes behind — fails safe by refusing promotion.
+const pendingValidationTTL = 30 * time.Second
+
+// stashPendingLedgerValidationLocked stores a (seq, expectedHash, at) entry
+// for later drain when ledgerHistory[seq] is populated. LRU-evicts the
+// oldest entry if the stash would exceed pendingValidationMaxLen.
+// Caller must hold s.mu.
+func (s *Service) stashPendingLedgerValidationLocked(seq uint32, expectedHash [32]byte) {
+	if _, exists := s.pendingLedgerValidations[seq]; !exists {
+		s.pendingLedgerValidationsOrder = append(s.pendingLedgerValidationsOrder, seq)
+	}
+	s.pendingLedgerValidations[seq] = pendingValidationEntry{
+		expectedHash: expectedHash,
+		at:           time.Now(),
+	}
+
+	for len(s.pendingLedgerValidationsOrder) > pendingValidationMaxLen {
+		oldest := s.pendingLedgerValidationsOrder[0]
+		s.pendingLedgerValidationsOrder = s.pendingLedgerValidationsOrder[1:]
+		// Silently losing the oldest pending validation when the cap is
+		// hit means a ledger that later adopts at this seq won't be
+		// promoted to validated by this (already-delivered) quorum
+		// notification. Log via the service's configured logger at warn
+		// level so an operator noticing a stuck-validation issue can see
+		// it; keep the cap in place so a node where adoption never
+		// catches up (disconnected peer, partition) can't leak memory.
+		if s.logger != nil {
+			s.logger.Warn("pendingLedgerValidations LRU drop — validation lost for this seq",
+				"seq", oldest,
+				"cap", pendingValidationMaxLen,
+			)
+		}
+		delete(s.pendingLedgerValidations, oldest)
+	}
+}
+
+// drainPendingLedgerValidationLocked checks for a stashed validation at
+// the given seq and, if present, removes it. If the entry matches the
+// adopted hash AND has not exceeded pendingValidationTTL, the adopted
+// ledger is promoted to validated and the promotion is reflected in
+// s.validatedLedger. Returns true when a promotion occurred so callers
+// can log / emit events accordingly. Caller must hold s.mu.
+//
+// Expired or hash-mismatched entries are always deleted — leaving them
+// in place would let a later adopt at the same seq accidentally match
+// a stale notification.
+func (s *Service) drainPendingLedgerValidationLocked(seq uint32, adopted *ledger.Ledger) bool {
+	entry, ok := s.pendingLedgerValidations[seq]
+	if !ok {
+		return false
+	}
+	delete(s.pendingLedgerValidations, seq)
+	for i, q := range s.pendingLedgerValidationsOrder {
+		if q == seq {
+			s.pendingLedgerValidationsOrder = append(s.pendingLedgerValidationsOrder[:i], s.pendingLedgerValidationsOrder[i+1:]...)
+			break
+		}
+	}
+
+	if time.Since(entry.at) >= pendingValidationTTL {
+		// Expired: gossip is too old to trust. A fresh SetValidatedLedger
+		// call will re-stash / re-promote if the validation is still
+		// current on the trusted-validation tracker's side.
+		return false
+	}
+	if adopted.Hash() != entry.expectedHash {
+		// Fork signal: peers validated a different hash at this seq
+		// than the one we just adopted. Refuse to promote; the adopted
+		// ledger is on the wrong fork from the quorum's perspective.
+		return false
+	}
+
+	_ = adopted.SetValidated()
+	s.validatedLedger = adopted
+	return true
 }
 
 // NeedsInitialSync returns true if the node hasn't yet adopted a ledger from peers.
@@ -1467,6 +1592,12 @@ func (s *Service) AdoptLedgerWithState(h *header.LedgerHeader, stateMap *shamap.
 	s.closedLedger = adopted
 	s.ledgerHistory[h.LedgerIndex] = adopted
 	s.needsInitialSync = false
+
+	// If a trusted validation for this seq arrived before we got here
+	// (validation tracker leading the adopt loop), drain the stash and
+	// promote on match. The drain is fail-safe: expired or
+	// hash-mismatched entries are deleted without promoting.
+	s.drainPendingLedgerValidationLocked(h.LedgerIndex, adopted)
 
 	// Persist the adopted ledger exactly as the local close path does so
 	// tx/account_tx/tx_history/transaction_entry RPCs can answer queries

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -780,6 +780,173 @@ func (s *Service) collectTransactionResults(l *ledger.Ledger, ledgerSeq uint32, 
 	return results
 }
 
+// fixMismatchLocked invalidates the tail of ledgerHistory when the
+// adopted ledger does not chain to whatever we already have at
+// `adopted.Sequence()-1`. Mirrors rippled's setFullLedger parent-hash
+// sanity check + fixMismatch() call (LedgerMaster.cpp:749-801, 849-862).
+//
+// Trigger: prev := ledgerHistory[adoptedSeq-1] exists AND
+// prev.Hash() != adopted.ParentHash(). When that happens:
+//
+//  1. Delete the prev-seq slot (wrong fork at adoptedSeq-1).
+//  2. Delete every seq > adoptedSeq — those entries chained to the
+//     now-discarded prev or to a sibling of `adopted`, and so their
+//     parent lineage no longer resolves.
+//  3. Purge s.txIndex / s.txPositionIndex entries for the removed
+//     ledgers — otherwise `tx` / `transaction_entry` RPCs keep
+//     resolving to a seq whose contents were discarded.
+//  4. Clear s.closedLedger if it was pointing at an invalidated slot.
+//     AdoptLedgerWithState reassigns closedLedger to `adopted` right
+//     after this returns, so the clear is a defense-in-depth belt.
+//  5. If the invalidated prev-seq entry was marked validated, log ERROR
+//     — silently resetting a validated ledger would mask a serious
+//     fork. We do NOT reset s.validatedLedger silently; operator
+//     attention is required.
+//
+// Caller must hold s.mu (write lock). Called from AdoptLedgerWithState
+// before the new entry is written. No-op on the happy path (parent
+// chain matches or no prev entry exists), so the hot path is a single
+// map lookup + hash compare.
+//
+// Scope note: rippled's fixMismatch walks the LedgerHashes skiplist
+// backward further than the immediate parent and tries to "close the
+// seam" by finding the deepest still-consistent ancestor. This Go
+// implementation only invalidates the immediate prev-seq mismatch and
+// the forward orphans — deeper history is left untouched. Rationale:
+// the skiplist walk requires hashOfSeq reconstruction against the
+// adopted state, which is deferred. The common case (single-ledger
+// fork at the tip) is fully covered; multi-ledger divergences lower
+// in history will be re-tripped on each subsequent adopt as they
+// re-become the prev-seq.
+func (s *Service) fixMismatchLocked(adopted *ledger.Ledger) {
+	adoptedSeq := adopted.Sequence()
+	if adoptedSeq == 0 {
+		return
+	}
+
+	prev, havePrev := s.ledgerHistory[adoptedSeq-1]
+	if !havePrev {
+		// No prev-seq entry to mismatch against — nothing to do.
+		return
+	}
+	if prev.Hash() == adopted.ParentHash() {
+		// Happy path: the adopted ledger chains correctly.
+		return
+	}
+
+	// Mismatch. Collect the set of seqs to purge:
+	//   (a) the mismatched prev-seq itself,
+	//   (b) every seq strictly greater than adoptedSeq (orphaned
+	//       forward entries — their ancestry passes through prev-seq
+	//       or a sibling of `adopted`, both now invalid).
+	//
+	// Note: seq == adoptedSeq is also purged implicitly because the
+	// caller overwrites that slot with `adopted` right after we return.
+	// We still collect any tx-index entries associated with it so
+	// orphaned tx-hash lookups from the stale ledger don't linger.
+	var toRemove []uint32
+	toRemove = append(toRemove, adoptedSeq-1)
+	if sameSeq, ok := s.ledgerHistory[adoptedSeq]; ok && sameSeq.Hash() != adopted.Hash() {
+		toRemove = append(toRemove, adoptedSeq)
+	}
+	for seq := range s.ledgerHistory {
+		if seq > adoptedSeq {
+			toRemove = append(toRemove, seq)
+		}
+	}
+
+	// Collect diagnostic info before mutation for the WARN log. A
+	// fixMismatch hit is rare and operationally significant —
+	// operators should be able to reconstruct exactly which history
+	// slots were purged from a single log line.
+	type purged struct {
+		Seq       uint32
+		Hash      string
+		Validated bool
+	}
+	purgedDetails := make([]purged, 0, len(toRemove))
+	validatedSeqPurged := uint32(0)
+	validatedHashPurged := [32]byte{}
+	hitValidated := false
+
+	for _, seq := range toRemove {
+		l, ok := s.ledgerHistory[seq]
+		if !ok {
+			continue
+		}
+		h := l.Hash()
+		purgedDetails = append(purgedDetails, purged{
+			Seq:       seq,
+			Hash:      fmt.Sprintf("%x", h[:8]),
+			Validated: l.IsValidated(),
+		})
+		if l.IsValidated() {
+			hitValidated = true
+			validatedSeqPurged = seq
+			validatedHashPurged = h
+		}
+
+		// Drop tx-index entries that resolve to this invalidated seq.
+		// Iteration order over a Go map is randomized; that is fine
+		// here because we mutate only entries whose value equals `seq`.
+		for txHash, txSeq := range s.txIndex {
+			if txSeq == seq {
+				delete(s.txIndex, txHash)
+				delete(s.txPositionIndex, txHash)
+			}
+		}
+
+		delete(s.ledgerHistory, seq)
+	}
+
+	// Defense-in-depth: if closedLedger was pointing at one of the
+	// purged slots, clear it. The caller (AdoptLedgerWithState) is
+	// about to reassign closedLedger = adopted anyway, but clearing
+	// here ensures any intermediate read (e.g., a deferred logger
+	// access) does not dereference a ledger we just invalidated.
+	if s.closedLedger != nil {
+		closedSeq := s.closedLedger.Sequence()
+		if _, purged := s.ledgerHistory[closedSeq]; !purged && closedSeq != adoptedSeq {
+			// closedLedger points at a seq we removed from history.
+			if closedSeq == adoptedSeq-1 || closedSeq > adoptedSeq {
+				s.closedLedger = nil
+			}
+		}
+	}
+
+	// Validated-ledger handling: we do NOT silently reset it. A
+	// validated ledger getting invalidated by a parent-hash mismatch
+	// means the node previously quorum-validated a hash that the
+	// peer-adopted chain now contradicts — a serious fork that
+	// requires operator attention. Log ERROR and leave the pointer
+	// in place; downstream consumers will observe the divergence
+	// (e.g., validatedLedger > adoptedSeq) and either re-sync or
+	// surface a visible alert.
+	if hitValidated {
+		s.logger.Error("fixMismatch purged a validated ledger — possible fork detected",
+			"adopted_seq", adoptedSeq,
+			"adopted_hash", fmt.Sprintf("%x", adopted.Hash()),
+			"adopted_parent_hash", fmt.Sprintf("%x", adopted.ParentHash()),
+			"prev_seq", adoptedSeq-1,
+			"prev_hash", fmt.Sprintf("%x", prev.Hash()),
+			"purged_validated_seq", validatedSeqPurged,
+			"purged_validated_hash", fmt.Sprintf("%x", validatedHashPurged),
+		)
+	}
+
+	adoptedHash := adopted.Hash()
+	adoptedParent := adopted.ParentHash()
+	prevHash := prev.Hash()
+	s.logger.Warn("fixMismatch invalidated diverged history tail",
+		"adopted_seq", adoptedSeq,
+		"adopted_hash", fmt.Sprintf("%x", adoptedHash[:8]),
+		"adopted_parent_hash", fmt.Sprintf("%x", adoptedParent[:8]),
+		"stored_prev_hash", fmt.Sprintf("%x", prevHash[:8]),
+		"purged_count", len(purgedDetails),
+		"purged", purgedDetails,
+	)
+}
+
 // extractAffectedAccounts extracts account addresses affected by a transaction.
 // Parses the binary transaction blob and extracts Account (sender),
 // Destination (for payments, escrows, checks, etc.), and any other
@@ -1586,6 +1753,16 @@ func (s *Service) AdoptLedgerWithState(h *header.LedgerHeader, stateMap *shamap.
 	}
 
 	adopted := ledger.NewFromHeader(*h, stateMap, txMap, drops.Fees{})
+
+	// F5: before installing the adopted ledger into history, check
+	// whether it chains to whatever we already have at seq-1. If the
+	// parent-hash doesn't match, we're on a divergent fork relative to
+	// what the peer served — invalidate the tail (prev-seq + every
+	// orphaned forward entry) so subsequent RPCs don't resolve against
+	// stale state. Mirrors rippled LedgerMaster::setFullLedger's
+	// parent-hash sanity check and fixMismatch() call at
+	// LedgerMaster.cpp:849-862.
+	s.fixMismatchLocked(adopted)
 
 	// Same reasoning as ReAdoptLedgerHeader: peer-adopted ledgers advance
 	// closedLedger but not validatedLedger. The quorum gate owns that.

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -167,6 +167,22 @@ type Service struct {
 	// eviction of pendingLedgerValidations.
 	pendingLedgerValidationsOrder []uint32
 
+	// heldAdoptions stashes replay-delta adoptions that arrived out of
+	// order (child seq before parent seq). Keyed by the *awaited parent
+	// seq* so a successful adopt at seq N can pop the child at seq N+1
+	// in O(1) and cascade-adopt it without a second external trigger.
+	//
+	// Flat (single-hop) by design: replay-delta is single-ledger-per-
+	// request, so multi-ledger backward walks are out of scope here
+	// (tracked separately as D6). Multi-level chains of held children
+	// do cascade via recursion at adopt time, bounded by
+	// heldAdoptionCascadeMax to cap fork-storm recursion.
+	//
+	// Distinct from pendingValidation (hash-keyed accepted events) and
+	// pendingLedgerValidations (seq-keyed validation notifications) —
+	// this map holds the *ledger payload itself* awaiting its parent.
+	heldAdoptions map[uint32]*pendingAdopt
+
 	// hooks provides event callbacks for external subscribers
 	hooks *EventHooks
 
@@ -195,6 +211,7 @@ func New(cfg Config) (*Service, error) {
 		txPositionIndex:          make(map[[32]byte]uint32),
 		pendingValidation:        make(map[[32]byte]*LedgerAcceptedEvent),
 		pendingLedgerValidations: make(map[uint32]pendingValidationEntry),
+		heldAdoptions:            make(map[uint32]*pendingAdopt),
 	}
 
 	return s, nil
@@ -1582,6 +1599,175 @@ func (s *Service) drainPendingLedgerValidationLocked(seq uint32, adopted *ledger
 	return true
 }
 
+// pendingAdopt is the payload of a held replay-delta adoption waiting
+// for its parent seq to land. Carries the exact inputs
+// AdoptLedgerWithState needs so the cascade can apply the held ledger
+// without re-fetching anything.
+type pendingAdopt struct {
+	header   *header.LedgerHeader
+	stateMap *shamap.SHAMap
+	txMap    *shamap.SHAMap
+	at       time.Time
+}
+
+// heldAdoptionTTL bounds how long a held adoption is kept before
+// eviction. 60s comfortably spans the worst-case replay-delta round-
+// trip (typically <5s) while still ensuring a stale fork or a
+// disconnected-peer response can't linger indefinitely and re-fire
+// against an unrelated adopted ledger that happens to land at the
+// awaited parent seq much later.
+const heldAdoptionTTL = 60 * time.Second
+
+// heldAdoptionCascadeMax caps the cascade recursion depth. Real-world
+// cascades are 1-2 hops deep (replay-delta is single-ledger-per-
+// request). The cap is purely a DoS guard: a malicious peer-stream that
+// seeded a deep chain of held orphans pre-adoption would otherwise
+// push arbitrary stack depth into the adopt path. 256 is two orders of
+// magnitude above any legitimate cascade length.
+const heldAdoptionCascadeMax = 256
+
+// SubmitHeldAdoption routes a fetched replay-delta either to immediate
+// adoption (when the awaited parent seq is already in history and its
+// hash matches the supplied ParentHash) or to the held-orphan stash
+// (keyed by the awaited parent seq = h.LedgerIndex - 1). Stashed
+// entries are cascade-adopted later, from inside AdoptLedgerWithState
+// at the parent seq, when the adopted hash matches ParentHash.
+//
+// Safe to call concurrently. Nil header or nil stateMap is rejected;
+// nil txMap is allowed (legacy catchup path — AdoptLedgerWithState
+// falls back to the genesis-shaped empty tx map).
+//
+// Mirrors rippled's tryAdvance cascade shape, flattened to single-hop
+// (see comment on heldAdoptions for the scope trade-off).
+func (s *Service) SubmitHeldAdoption(h *header.LedgerHeader, stateMap *shamap.SHAMap, txMap *shamap.SHAMap) error {
+	if h == nil {
+		return errors.New("SubmitHeldAdoption: nil header")
+	}
+	if stateMap == nil {
+		return errors.New("SubmitHeldAdoption: nil state map")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Evict stale entries on every submission so an operator that
+	// repeatedly submits orphans doesn't keep a stale entry alive.
+	s.evictExpiredHeldAdoptionsLocked()
+
+	// Fast path: if the awaited parent is already in history at the
+	// expected hash, adopt immediately rather than stashing for a
+	// cascade that will never re-fire. Genesis (seq 1) has no parent,
+	// so the fast path is skipped for seq <= 1; the adopt itself will
+	// error downstream if anything is wrong.
+	if h.LedgerIndex > 1 {
+		parentSeq := h.LedgerIndex - 1
+		if parent, ok := s.ledgerHistory[parentSeq]; ok {
+			parentHash := parent.Hash()
+			if parentHash == h.ParentHash {
+				return s.adoptLedgerWithStateLocked(h, stateMap, txMap, 0)
+			}
+			// Parent seq present but on a different fork. Stashing would
+			// create a never-draining entry (the real fork's parent-seq
+			// adopt is not expected to arrive at this node). Drop
+			// quietly so we don't leak memory on divergent-fork gossip.
+			s.logger.Warn("SubmitHeldAdoption dropping divergent-parent submission",
+				"seq", h.LedgerIndex,
+				"parent_have", fmt.Sprintf("%x", parentHash[:8]),
+				"parent_want", fmt.Sprintf("%x", h.ParentHash[:8]),
+			)
+			return nil
+		}
+	}
+
+	// Parent not yet present — stash.
+	s.heldAdoptions[h.LedgerIndex-1] = &pendingAdopt{
+		header:   h,
+		stateMap: stateMap,
+		txMap:    txMap,
+		at:       time.Now(),
+	}
+	return nil
+}
+
+// cascadeHeldAdoptionsLocked promotes a held child whose awaited parent
+// seq (h.LedgerIndex for the child's key) just finished adopting. If the
+// held entry's ParentHash matches the adopted hash, it is removed from
+// the stash and adopted via adoptLedgerWithStateLocked — which itself
+// re-invokes cascadeHeldAdoptionsLocked, giving a bounded recursive
+// walk through any chain of pre-stashed orphans.
+//
+// Entries older than heldAdoptionTTL are evicted on every call (not
+// just on the matched key) so a pathological peer that seeds a stash
+// full of stale forks can't defer eviction forever.
+//
+// Caller must hold s.mu (write).
+func (s *Service) cascadeHeldAdoptionsLocked(adopted *ledger.Ledger, depth int) {
+	// Purge stale entries first so a single adopt sweeps them all out.
+	s.evictExpiredHeldAdoptionsLocked()
+
+	if depth >= heldAdoptionCascadeMax {
+		s.logger.Warn("cascadeHeldAdoptions: hit recursion cap — refusing further promotion",
+			"cap", heldAdoptionCascadeMax,
+			"seq", adopted.Sequence(),
+		)
+		return
+	}
+
+	parentSeq := adopted.Sequence()
+	held, ok := s.heldAdoptions[parentSeq]
+	if !ok {
+		return
+	}
+	delete(s.heldAdoptions, parentSeq)
+
+	adoptedHash := adopted.Hash()
+	if held.header.ParentHash != adoptedHash {
+		// The held orphan expected a different parent hash at this seq
+		// — it was on a divergent fork. Drop it rather than adopting
+		// onto the wrong chain.
+		s.logger.Warn("cascadeHeldAdoptions: dropping fork-mismatched held entry",
+			"seq", held.header.LedgerIndex,
+			"parent_have", fmt.Sprintf("%x", adoptedHash[:8]),
+			"parent_want", fmt.Sprintf("%x", held.header.ParentHash[:8]),
+		)
+		return
+	}
+
+	s.logger.Info("cascadeHeldAdoptions: promoting held orphan",
+		"seq", held.header.LedgerIndex,
+		"hash", fmt.Sprintf("%x", held.header.Hash[:8]),
+		"depth", depth+1,
+	)
+	if err := s.adoptLedgerWithStateLocked(held.header, held.stateMap, held.txMap, depth+1); err != nil {
+		// Adoption of the held entry failed (e.g. persistence error on
+		// the cascade hop). Log and stop — the outer adopt already
+		// succeeded, so we do not surface the cascade error upwards.
+		s.logger.Error("cascadeHeldAdoptions: held-entry adopt failed",
+			"seq", held.header.LedgerIndex,
+			"err", err,
+		)
+	}
+}
+
+// evictExpiredHeldAdoptionsLocked removes held entries whose `at`
+// timestamp is older than heldAdoptionTTL. Caller must hold s.mu.
+func (s *Service) evictExpiredHeldAdoptionsLocked() {
+	if len(s.heldAdoptions) == 0 {
+		return
+	}
+	now := time.Now()
+	for key, held := range s.heldAdoptions {
+		if now.Sub(held.at) >= heldAdoptionTTL {
+			s.logger.Warn("heldAdoption TTL eviction",
+				"parent_seq", key,
+				"child_seq", held.header.LedgerIndex,
+				"age", now.Sub(held.at),
+			)
+			delete(s.heldAdoptions, key)
+		}
+	}
+}
+
 // NeedsInitialSync returns true if the node hasn't yet adopted a ledger from peers.
 func (s *Service) NeedsInitialSync() bool {
 	s.mu.RLock()
@@ -1735,7 +1921,19 @@ func (s *Service) ReAdoptLedgerHeader(h *header.LedgerHeader) error {
 func (s *Service) AdoptLedgerWithState(h *header.LedgerHeader, stateMap *shamap.SHAMap, txMap *shamap.SHAMap) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.adoptLedgerWithStateLocked(h, stateMap, txMap, 0)
+}
 
+// adoptLedgerWithStateLocked is the lock-free core of AdoptLedgerWithState.
+// Caller must hold s.mu (write). `cascadeDepth` is the current recursion
+// depth of the held-orphan cascade (F6); the public entrypoints pass 0
+// and the cascade helper recurses with depth+1 until heldAdoptionCascadeMax.
+func (s *Service) adoptLedgerWithStateLocked(
+	h *header.LedgerHeader,
+	stateMap *shamap.SHAMap,
+	txMap *shamap.SHAMap,
+	cascadeDepth int,
+) error {
 	if s.genesisLedger == nil {
 		return errors.New("no genesis ledger available")
 	}
@@ -1841,6 +2039,13 @@ func (s *Service) AdoptLedgerWithState(h *header.LedgerHeader, stateMap *shamap.
 		"hash", fmt.Sprintf("%x", h.Hash[:8]),
 		"account_hash", fmt.Sprintf("%x", h.AccountHash[:8]),
 	)
+
+	// F6: cascade any held adoption that was waiting on this ledger to
+	// land. Out-of-order replay-delta completions (seq N+2 arriving
+	// before seq N+1) otherwise stall until the inbound loop happens to
+	// re-request them. Also evicts entries older than heldAdoptionTTL so
+	// the stash doesn't accumulate stale forks across adopt calls.
+	s.cascadeHeldAdoptionsLocked(adopted, cascadeDepth)
 
 	return nil
 }

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -626,33 +626,11 @@ func (s *Service) AcceptLedger() (uint32, error) {
 	// Calculate validated ledgers range string
 	validatedLedgers := s.getValidatedLedgersRange()
 
-	// Fire event hooks after state is updated
-	if s.hooks != nil && s.hooks.OnLedgerClosed != nil {
-		txCount := len(txResults)
-		hooks := s.hooks
-		info := ledgerInfo
-		vl := validatedLedgers
-		go hooks.OnLedgerClosed(info, txCount, vl)
-	}
-
-	// Fire transaction hooks for each transaction
-	if s.hooks != nil && s.hooks.OnTransaction != nil {
-		hooks := s.hooks
-		closeTimeVal := closeTime
-		for _, txResult := range txResults {
-			txInfo := TransactionInfo{
-				Hash:             txResult.TxHash,
-				TxBlob:           txResult.TxData,
-				AffectedAccounts: txResult.AffectedAccounts,
-			}
-			result := TxResult{
-				Applied:  txResult.Validated,
-				Metadata: txResult.MetaData,
-				TxIndex:  s.txPositionIndex[txResult.TxHash],
-			}
-			go hooks.OnTransaction(txInfo, result, closedSeq, closedLedgerHash, closeTimeVal)
-		}
-	}
+	// Fire structured event hooks for the newly-closed ledger. In the
+	// standalone path the ledger is already validated (line above sets
+	// s.validatedLedger), so the legacy eventCallback fires immediately
+	// rather than being stashed for SetValidatedLedger to drain.
+	s.fireLedgerClosedHooksLocked(ledgerInfo, txResults, closeTime, validatedLedgers)
 
 	// Fire legacy event callback for backward compatibility
 	if s.eventCallback != nil {
@@ -673,6 +651,56 @@ func (s *Service) AcceptLedger() (uint32, error) {
 	)
 
 	return closedSeq, nil
+}
+
+// fireLedgerClosedHooksLocked fires hooks.OnLedgerClosed and
+// hooks.OnTransaction for a ledger that has transitioned to closed.
+// Each hook dispatch runs on its own goroutine so subscriber callbacks
+// cannot block the ledger service or deadlock against s.mu. Safe to
+// call with s.hooks == nil or individual hook fields nil.
+//
+// Caller must hold s.mu. Shared by the standalone close path and the
+// peer-adopt path so WebSocket `ledger` and `transactions` streams see
+// every closed ledger regardless of whether it was closed locally or
+// adopted from a peer — a silent divergence from rippled before F3
+// where peer-adopted ledgers never reached stream subscribers.
+func (s *Service) fireLedgerClosedHooksLocked(
+	info *LedgerInfo,
+	txResults []TransactionResultEvent,
+	closeTime time.Time,
+	validatedLedgers string,
+) {
+	if s.hooks == nil {
+		return
+	}
+
+	if s.hooks.OnLedgerClosed != nil {
+		txCount := len(txResults)
+		hooks := s.hooks
+		capturedInfo := info
+		capturedRange := validatedLedgers
+		go hooks.OnLedgerClosed(capturedInfo, txCount, capturedRange)
+	}
+
+	if s.hooks.OnTransaction != nil {
+		hooks := s.hooks
+		ledgerSeq := info.Sequence
+		ledgerHash := info.Hash
+		closeTimeVal := closeTime
+		for _, txResult := range txResults {
+			txInfo := TransactionInfo{
+				Hash:             txResult.TxHash,
+				TxBlob:           txResult.TxData,
+				AffectedAccounts: txResult.AffectedAccounts,
+			}
+			result := TxResult{
+				Applied:  txResult.Validated,
+				Metadata: txResult.MetaData,
+				TxIndex:  s.txPositionIndex[txResult.TxHash],
+			}
+			go hooks.OnTransaction(txInfo, result, ledgerSeq, ledgerHash, closeTimeVal)
+		}
+	}
 }
 
 // getValidatedLedgersRange returns a string representation of validated ledger range
@@ -1450,12 +1478,12 @@ func (s *Service) AdoptLedgerWithState(h *header.LedgerHeader, stateMap *shamap.
 		s.logger.Error("Failed to persist adopted ledger", "seq", h.LedgerIndex, "err", err)
 	}
 
-	// Populate the in-memory tx-index so tx-hash lookups resolve to this
-	// seq. collectTransactionResults walks the tx map and writes to
-	// s.txIndex + s.txPositionIndex as a side effect; we don't need the
-	// returned results here (no subscribers to dispatch to yet — that's
-	// Task 1.2).
-	_ = s.collectTransactionResults(adopted, h.LedgerIndex, h.Hash)
+	// Populate the in-memory tx-index and capture per-tx event records
+	// so hooks.OnTransaction + stream subscribers see every adopted tx.
+	// collectTransactionResults walks the tx map and writes to s.txIndex
+	// + s.txPositionIndex as a side effect AND returns the per-tx
+	// TransactionResultEvent slice that hook dispatch needs.
+	txResults := s.collectTransactionResults(adopted, h.LedgerIndex, h.Hash)
 
 	// Create new open ledger on top
 	openLedger, err := ledger.NewOpen(adopted, time.Now())
@@ -1463,6 +1491,42 @@ func (s *Service) AdoptLedgerWithState(h *header.LedgerHeader, stateMap *shamap.
 		return fmt.Errorf("failed to create open ledger: %w", err)
 	}
 	s.openLedger = openLedger
+
+	// Fire hooks.OnLedgerClosed + hooks.OnTransaction so WebSocket
+	// `ledger` and `transactions` stream subscribers see peer-adopted
+	// ledgers. Without this, the streams silently skip every ledger
+	// the node catches up to — an observable divergence from rippled,
+	// whose pubLedger path fires for both consensus-closed and sync-
+	// adopted ledgers.
+	ledgerInfo := &LedgerInfo{
+		Sequence:   h.LedgerIndex,
+		Hash:       h.Hash,
+		ParentHash: adopted.ParentHash(),
+		CloseTime:  adopted.CloseTime(),
+		TotalDrops: adopted.TotalDrops(),
+		Validated:  adopted.IsValidated(),
+		Closed:     adopted.IsClosed(),
+	}
+	validatedLedgers := s.getValidatedLedgersRange()
+	// Peer-adopted ledgers carry a close time from the adopted header,
+	// not from local consensus — use adopted.CloseTime() so downstream
+	// subscribers see the network-agreed close time (matches the Header
+	// field that was just populated by NewFromHeader).
+	s.fireLedgerClosedHooksLocked(ledgerInfo, txResults, adopted.CloseTime(), validatedLedgers)
+
+	// The legacy eventCallback is meant to fire on *validated*, not
+	// *closed*. Peer-adopted ledgers advance s.closedLedger but not
+	// s.validatedLedger (the quorum gate at SetValidatedLedger owns
+	// that transition). Stash the event keyed by hash so the next
+	// SetValidatedLedger(seq, hash) for this ledger drains it —
+	// the exact same pattern AcceptConsensusResult uses.
+	if s.eventCallback != nil {
+		event := &LedgerAcceptedEvent{
+			LedgerInfo:         ledgerInfo,
+			TransactionResults: txResults,
+		}
+		s.stashPendingValidationLocked(h.Hash, event)
+	}
 
 	s.logger.Info("Adopted ledger with full state from peer",
 		"seq", h.LedgerIndex,

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1335,7 +1335,12 @@ func (s *Service) AcceptConsensusResult(parent *ledger.Ledger, txBlobs [][]byte,
 
 	// Drain any validation that arrived before this close (validation
 	// tracker leading the consensus close). Fail-safe on expired/mismatch.
-	s.drainPendingLedgerValidationLocked(closedSeq, s.closedLedger)
+	// Capture the return: when drain returns true, the adopted ledger was
+	// promoted to validated in-line from the pre-stashed (seq, hash)
+	// notification — no later SetValidatedLedger will arrive to fire the
+	// legacy eventCallback, so we must fire it inline below (and skip
+	// the hash-keyed stash, which would never be drained).
+	promotedByDrain := s.drainPendingLedgerValidationLocked(closedSeq, s.closedLedger)
 
 	// Collect transaction results for event callbacks/hooks
 	var txResults []TransactionResultEvent
@@ -1394,12 +1399,29 @@ func (s *Service) AcceptConsensusResult(parent *ledger.Ledger, txBlobs [][]byte,
 	// reached, keeping WebSocket ledgerClosed events in lockstep with
 	// server_info.validated_ledger. Rippled publishes both from the
 	// same quorum-gated point (pubLedger / checkAccept).
+	//
+	// Validation-first race exception: when the drain above promoted
+	// validatedLedger in-line, the trusted validation has ALREADY arrived
+	// (pre-stashed by an earlier SetValidatedLedger call). No future
+	// SetValidatedLedger will land for this hash, so stashing the event
+	// would orphan it forever — WebSocket `ledgerClosed` + `transaction`
+	// subscribers (wired through SetEventCallback) would miss the ledger.
+	// Fire the callback inline instead, matching SetValidatedLedger's own
+	// drain-then-dispatch shape.
 	if s.eventCallback != nil {
 		event := &LedgerAcceptedEvent{
 			LedgerInfo:         ledgerInfo,
 			TransactionResults: txResults,
 		}
-		s.stashPendingValidationLocked(closedLedgerHash, event)
+		if promotedByDrain {
+			// Fire on a goroutine so subscriber callbacks can't reach
+			// back into s.mu (which is still held via the deferred
+			// Unlock) and deadlock the service.
+			callback := s.eventCallback
+			go callback(event)
+		} else {
+			s.stashPendingValidationLocked(closedLedgerHash, event)
+		}
 	}
 
 	s.logger.Info("Consensus ledger accepted",
@@ -1971,8 +1993,11 @@ func (s *Service) adoptLedgerWithStateLocked(
 	// If a trusted validation for this seq arrived before we got here
 	// (validation tracker leading the adopt loop), drain the stash and
 	// promote on match. The drain is fail-safe: expired or
-	// hash-mismatched entries are deleted without promoting.
-	s.drainPendingLedgerValidationLocked(h.LedgerIndex, adopted)
+	// hash-mismatched entries are deleted without promoting. Capture the
+	// return: when drain returns true, the hash-keyed eventCallback stash
+	// below must be skipped and the callback fired inline — see the
+	// comment at the callback-dispatch block for the full rationale.
+	promotedByDrain := s.drainPendingLedgerValidationLocked(h.LedgerIndex, adopted)
 
 	// Persist the adopted ledger exactly as the local close path does so
 	// tx/account_tx/tx_history/transaction_entry RPCs can answer queries
@@ -2026,12 +2051,30 @@ func (s *Service) adoptLedgerWithStateLocked(
 	// that transition). Stash the event keyed by hash so the next
 	// SetValidatedLedger(seq, hash) for this ledger drains it —
 	// the exact same pattern AcceptConsensusResult uses.
+	//
+	// Validation-first race exception: when the F4 drain above promoted
+	// validatedLedger in-line from a pre-stashed (seq, hash) notification,
+	// no future SetValidatedLedger will arrive for this hash. Stashing
+	// here would orphan the event forever — WebSocket `ledgerClosed` +
+	// `transaction` subscribers (wired through SetEventCallback) would
+	// silently miss the ledger. Fire the callback inline instead, matching
+	// SetValidatedLedger's own drain-then-dispatch shape. Skipping the
+	// stash also prevents a double-fire if a late-duplicate
+	// SetValidatedLedger arrives for the same hash.
 	if s.eventCallback != nil {
 		event := &LedgerAcceptedEvent{
 			LedgerInfo:         ledgerInfo,
 			TransactionResults: txResults,
 		}
-		s.stashPendingValidationLocked(h.Hash, event)
+		if promotedByDrain {
+			// Fire on a goroutine so subscriber callbacks can't reach
+			// back into s.mu (still held via the caller's defer) and
+			// deadlock the service.
+			callback := s.eventCallback
+			go callback(event)
+		} else {
+			s.stashPendingValidationLocked(h.Hash, event)
+		}
 	}
 
 	s.logger.Info("Adopted ledger with full state from peer",

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -74,6 +74,15 @@ type Config struct {
 	EnableCompression   bool
 	EnableLedgerReplay  bool
 
+	// LocalValidatorPubKey is the compressed secp256k1 public key (33
+	// bytes) of the local validator identity, when this node is acting
+	// as a validator. Nil/empty for observer nodes. Used by
+	// handleSquelchMessage to drop inbound TMSquelch frames that target
+	// our own validator — otherwise a hostile peer could silence our
+	// own proposals/validations on the RelayFromValidator path.
+	// Matches rippled PeerImp.cpp:2715-2721.
+	LocalValidatorPubKey []byte
+
 	// Clock function for testing
 	Clock func() time.Time
 }
@@ -226,6 +235,24 @@ func WithLedgerReplay(enabled bool) Option {
 func WithClock(clock func() time.Time) Option {
 	return func(c *Config) {
 		c.Clock = clock
+	}
+}
+
+// WithLocalValidatorPubKey sets the compressed secp256k1 public key
+// (33 bytes) of the local validator identity, so inbound TMSquelch
+// frames targeting our own validator can be dropped. Observer nodes
+// should omit this option (the filter becomes a no-op). Matches
+// rippled PeerImp.cpp:2715-2721 which ignores TMSquelch addressed to
+// app_.getValidationPublicKey().
+func WithLocalValidatorPubKey(key []byte) Option {
+	return func(c *Config) {
+		if len(key) == 0 {
+			c.LocalValidatorPubKey = nil
+			return
+		}
+		// Defensive copy so callers cannot mutate config state after
+		// construction.
+		c.LocalValidatorPubKey = append([]byte(nil), key...)
 	}
 }
 

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -61,6 +61,16 @@ type Config struct {
 	// peers know which optional protocol extensions we speak. Matches
 	// rippled's compr / vprr / txrr / ledgerreplay feature toggles.
 	//
+	// All three reduce-relay flags default to false to match rippled
+	// (Config.h:248 sets VP_REDUCE_RELAY_BASE_SQUELCH_ENABLE=false,
+	// Config.h:258 sets TX_REDUCE_RELAY_ENABLE=false, Config.cpp:755-762
+	// preserves false when the cfg omits the section). Reduce-relay
+	// is opt-in: an operator must explicitly set one of these flags
+	// (or WithReduceRelay(true)) to advertise vprr/txrr and activate
+	// the slot-squelching engine. Shipping with the flags on would
+	// cause a stock goXRPL node to squelch traffic on a stock rippled
+	// network where the peer majority does not reciprocate.
+	//
 	// EnableReduceRelay is a legacy alias that enables BOTH vprr and
 	// txrr at once. New code should set EnableVPReduceRelay and
 	// EnableTxReduceRelay independently so an operator can run one
@@ -105,9 +115,15 @@ func DefaultConfig() Config {
 		MessageBufferSize: DefaultMessageBufferSize,
 		SendBufferSize:    DefaultSendBufferSize,
 
-		EnableReduceRelay:  true,
-		EnableCompression:  true,
-		EnableLedgerReplay: true,
+		// Reduce-relay is opt-in; rippled defaults all three to false
+		// (Config.h:248, Config.h:258, Config.cpp:755-762). Leaving
+		// these zero-valued avoids advertising vprr/txrr on a stock
+		// rippled network where peers don't reciprocate.
+		EnableReduceRelay:   false,
+		EnableVPReduceRelay: false,
+		EnableTxReduceRelay: false,
+		EnableCompression:   true,
+		EnableLedgerReplay:  true,
 
 		Clock: time.Now,
 	}
@@ -208,6 +224,11 @@ func WithIdleTimeout(d time.Duration) Option {
 }
 
 // WithReduceRelay enables or disables reduce-relay optimization.
+// Reduce-relay is opt-in and defaults to false to match rippled
+// (Config.h:248, Config.cpp:755-762). Setting this to true activates
+// both vprr and txrr via the Validate() cascade; callers who need
+// one without the other should set EnableVPReduceRelay or
+// EnableTxReduceRelay directly on the Config instead.
 func WithReduceRelay(enabled bool) Option {
 	return func(c *Config) {
 		c.EnableReduceRelay = enabled
@@ -296,7 +317,11 @@ func (c *Config) Validate() error {
 	// Legacy EnableReduceRelay propagates to both specific flags when
 	// the caller hasn't set them independently. Matches rippled's
 	// behavior where enabling "reduce-relay" as a whole turns on both
-	// vprr and txrr.
+	// vprr and txrr. The default is false (see DefaultConfig), so this
+	// cascade only fires when an operator explicitly opts into
+	// reduce-relay via the legacy omnibus flag (either in the config
+	// file or via WithReduceRelay(true)). It remains load-bearing for
+	// that opt-in path.
 	if c.EnableReduceRelay {
 		c.EnableVPReduceRelay = true
 		c.EnableTxReduceRelay = true

--- a/internal/peermanagement/config_test.go
+++ b/internal/peermanagement/config_test.go
@@ -1,0 +1,56 @@
+package peermanagement
+
+import "testing"
+
+// TestDefaultConfig_ReduceRelayOptIn pins Task 4.4 (G5): rippled ships
+// with reduce-relay disabled by default — `Config.h:248` sets
+// `VP_REDUCE_RELAY_BASE_SQUELCH_ENABLE = false`, `Config.h:258` sets
+// `TX_REDUCE_RELAY_ENABLE = false`, and `Config.cpp:755-762` preserves
+// that default when the .cfg lacks the section. Pre-G5, goXRPL shipped
+// with `EnableReduceRelay: true` in DefaultConfig(), which the
+// Validate() cascade propagated to both EnableVPReduceRelay and
+// EnableTxReduceRelay. A stock goXRPL node joining a stock rippled
+// network would therefore advertise vprr+txrr in the handshake and
+// engage slot squelching aggressively while every other peer sat
+// silent — a deployment-parity hazard.
+//
+// This test locks in the rippled-matching opt-in posture: all three
+// fields must be false out of DefaultConfig(). If a future change
+// flips any of them back on, a reviewer sees why that matters via
+// this test name.
+func TestDefaultConfig_ReduceRelayOptIn(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.EnableReduceRelay {
+		t.Errorf("EnableReduceRelay default = true, want false (rippled Config.h:248 defaults reduce-relay off)")
+	}
+	if cfg.EnableVPReduceRelay {
+		t.Errorf("EnableVPReduceRelay default = true, want false (rippled VP_REDUCE_RELAY_BASE_SQUELCH_ENABLE defaults to false)")
+	}
+	if cfg.EnableTxReduceRelay {
+		t.Errorf("EnableTxReduceRelay default = true, want false (rippled TX_REDUCE_RELAY_ENABLE defaults to false)")
+	}
+}
+
+// TestDefaultConfig_ReduceRelayCascadePreservedForExplicitOptIn pins
+// the operator path: once a caller explicitly sets the legacy
+// EnableReduceRelay flag, Validate() must still propagate it to both
+// specific toggles. The cascade is dead code in the default path
+// (since the default is now false) but is load-bearing for anyone
+// who opts in via the legacy knob — either a config file using the
+// old single-bool or a WithReduceRelay(true) option call.
+func TestDefaultConfig_ReduceRelayCascadePreservedForExplicitOptIn(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EnableReduceRelay = true
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+
+	if !cfg.EnableVPReduceRelay {
+		t.Errorf("legacy EnableReduceRelay=true did not cascade to EnableVPReduceRelay")
+	}
+	if !cfg.EnableTxReduceRelay {
+		t.Errorf("legacy EnableReduceRelay=true did not cascade to EnableTxReduceRelay")
+	}
+}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -95,6 +95,16 @@ func BadDataWeight(reason string) int {
 	// Malformed requests: decode failures, bad hashes, wrong-field
 	// requests. Rippled: feeMalformedRequest at PeerImp.cpp:1693 for
 	// "bad hashes" and at PeerImp.cpp:1476 for bad requests.
+	//
+	// "squelch-ignored" lives here (G4): a peer that keeps relaying a
+	// validator's messages after being squelched is mis-behaving at
+	// the protocol level, but a single event is not catastrophic —
+	// sustained ignore (many per decay window) accumulates toward
+	// eviction while a one-off (packet already in flight when the
+	// squelch landed) decays below threshold. Rippled's upstream only
+	// increments a traffic counter here (OverlayImpl.cpp:1435-1437);
+	// goXRPL additionally charges reputation so repeat offenders are
+	// actually evicted rather than just counted.
 	case "proposal-malformed-prev-ledger-size",
 		"proposal-malformed-txset-size",
 		"validation-malformed-ledger-hash-zero",
@@ -113,7 +123,8 @@ func BadDataWeight(reason string) int {
 		"proposal-decode",
 		"validation-decode",
 		"validation-parse",
-		"ledger-data-decode":
+		"ledger-data-decode",
+		"squelch-ignored":
 		return weightMalformedReq
 	// A peer that didn't respond or returned benign "no data" — lowest.
 	case "no-reply":
@@ -305,7 +316,6 @@ func New(opts ...Option) (*Overlay, error) {
 		cfg:           cfg,
 		identity:      identity,
 		discovery:     NewDiscovery(&cfg, events),
-		relay:         NewRelay(&cfg, nil), // squelch callback set below
 		ledgerSync:    NewLedgerSyncHandler(events),
 		peers:         make(map[PeerID]*Peer),
 		events:        events,
@@ -314,10 +324,31 @@ func New(opts ...Option) (*Overlay, error) {
 		clockForIndex: time.Now,
 	}
 
-	// Set squelch callback for reduce-relay
-	o.relay.onSquelch = o.handleSquelch
+	// Wire reduce-relay callbacks. The squelch callback constructs and
+	// dispatches TMSquelch frames to individual peers; the ignored-
+	// squelch callback charges a peer's bad-data balance whenever it
+	// keeps relaying a validator's messages after being squelched.
+	// Both are set at construction — Relay never swaps them at runtime.
+	// Mirrors rippled's OverlayImpl wiring where SquelchHandler +
+	// ignored_squelch_callback are passed into Slot at construction
+	// (Slot.h:121-132 + Slot.h:112-113).
+	o.relay = NewRelayWithIgnoredCallback(&cfg, o.handleSquelch, o.chargeIgnoredSquelch)
 
 	return o, nil
+}
+
+// chargeIgnoredSquelch is the Relay-layer callback fired when a peer
+// keeps relaying a validator's messages despite being squelched. We
+// charge the peer's bad-data balance under a stable reason label so
+// operators watching bad-data metrics can attribute the increase to
+// squelch-ignored behavior specifically. Per rippled Slot.h:329-331,
+// this is the only place we learn that a peer ignored our TMSquelch
+// — there is no separate protocol signal.
+//
+// Non-blocking; safe to invoke from the hot receive path because
+// IncPeerBadData is a single map lookup + atomic add.
+func (o *Overlay) chargeIgnoredSquelch(peerID PeerID) {
+	o.IncPeerBadData(peerID, "squelch-ignored")
 }
 
 // loadOrCreateIdentity loads existing identity or creates a new one.

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -2,6 +2,7 @@ package peermanagement
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -207,6 +208,16 @@ type Overlay struct {
 // higher layer (e.g., consensus startup) can wire a LedgerProvider that
 // imports internal/ledger packages — which this layer cannot.
 func (o *Overlay) LedgerSync() *LedgerSyncHandler { return o.ledgerSync }
+
+// localValidatorPubKey returns the compressed secp256k1 public key of
+// the local validator, or nil when this node is not acting as a
+// validator. Used as a cheap passthrough by handleSquelchMessage so
+// the self-target filter doesn't need to reach into cfg directly.
+// Kept unexported — higher layers plumb the pubkey in via
+// WithLocalValidatorPubKey at overlay construction.
+func (o *Overlay) localValidatorPubKey() []byte {
+	return o.cfg.LocalValidatorPubKey
+}
 
 // IncPeerBadData records an invalid-data event attributed to the peer
 // with the given PeerID. Returns the new cumulative count, or 0 when
@@ -872,6 +883,19 @@ func (o *Overlay) handleSquelchMessage(evt Event) {
 		slog.Debug("Squelch malformed pubkey",
 			"t", "Overlay", "peer", evt.PeerID, "len", len(sq.ValidatorPubKey))
 		o.IncPeerBadData(evt.PeerID, "squelch-malformed-pubkey")
+		return
+	}
+
+	// Rippled PeerImp.cpp:2715-2721 drops any inbound squelch whose
+	// target pubkey is our own validator — otherwise a peer could
+	// silence our own traffic on the RelayFromValidator path
+	// (self-silencing DoS). goXRPL additionally charges the sending
+	// peer a bad-data event so repeated attempts feed the eviction
+	// threshold; rippled just logs-and-returns there.
+	if ownPubKey := o.localValidatorPubKey(); len(ownPubKey) == 33 && bytes.Equal(sq.ValidatorPubKey, ownPubKey) {
+		slog.Debug("Squelch dropped: targets local validator",
+			"t", "Overlay", "peer", evt.PeerID)
+		o.IncPeerBadData(evt.PeerID, "squelch-targets-self")
 		return
 	}
 

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -995,6 +995,17 @@ func (o *Overlay) maintenanceLoop(ctx context.Context) error {
 	decayTicker := time.NewTicker(badDataDecayInterval)
 	defer decayTicker.Stop()
 
+	// idleSweepTicker drives the reduce-relay idle-peer sweep (G2).
+	// Cadence is Idled/2 (4s) so no relay peer stays referenced more
+	// than ~1.5x the idle threshold before being evicted — matches
+	// rippled's OverlayImpl.cpp:107-111 which triggers
+	// Slots::deleteIdlePeers every 4 timer ticks of its 1s timer
+	// (Tuning::checkIdlePeers=4). Without this sweep, r.slots only
+	// shrinks on explicit RemovePeer and accumulates stale entries
+	// for validators we no longer see.
+	idleSweepTicker := time.NewTicker(Idled / 2)
+	defer idleSweepTicker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -1003,6 +1014,10 @@ func (o *Overlay) maintenanceLoop(ctx context.Context) error {
 			o.performMaintenance()
 		case <-decayTicker.C:
 			o.decayBadData()
+		case now := <-idleSweepTicker.C:
+			if o.relay != nil {
+				o.relay.deleteIdlePeers(now)
+			}
 		}
 	}
 }

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -710,22 +710,26 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		return
 	}
 
-	// Handle TMSquelch at the transport level — update per-peer squelch
-	// state and do not forward to external consumers. Mirrors rippled's
-	// PeerImp::onMessage(TMSquelch) at PeerImp.cpp:2691-2732, which
-	// applies every inbound TMSquelch unconditionally. Feature
-	// negotiation governs what WE SEND (we only emit TMSquelch to peers
-	// who advertised reduce-relay), not what we accept: a squelch
-	// directive is harmless if applied — it only suppresses what we
-	// send next — and rejecting it creates a not-actually-rippled
-	// attack surface where a hostile peer could advertise one capability
-	// set to us and another to a neighbor to desync squelch state.
+	// Inbound TMSquelch is accepted UNCONDITIONALLY. Rippled
+	// PeerImp::onMessage(TMSquelch) at PeerImp.cpp:2684-2721 does the
+	// same — there is no per-peer gating on vpReduceRelay for incoming
+	// squelches. Feature negotiation governs what WE SEND (we only
+	// emit TMSquelch to peers who advertised reduce-relay), not what
+	// we accept: a squelch directive is harmless when applied — it
+	// only suppresses what we send next — and rejecting it creates a
+	// not-actually-rippled attack surface where a hostile peer could
+	// advertise one capability set to us and another to a neighbor
+	// to desync squelch state.
+	//
+	// C3 note: an earlier round-2 commit message claimed this path
+	// gated on vpReduceRelay and charged-then-dropped peers that
+	// hadn't negotiated it. The code has always accepted
+	// unconditionally, matching rippled — the commit message was
+	// inaccurate and this comment is the canonical statement of
+	// intended behavior.
 	if msgType == message.TypeSquelch {
-		// TMSquelch is a validator-proposal concept (VPRR). We log,
-		// not drop, a squelch from a peer that didn't negotiate vprr —
-		// rippled applies the squelch regardless of feature gate.
 		if !o.PeerSupports(evt.PeerID, FeatureVpReduceRelay) {
-			slog.Debug("TMSquelch from peer without vprr feature; applying anyway (parity with rippled)",
+			slog.Debug("TMSquelch from peer without vprr feature; accepting (matches rippled)",
 				"t", "Overlay", "peer", evt.PeerID)
 		}
 		o.handleSquelchMessage(evt)

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -122,6 +122,28 @@ func BadDataWeight(reason string) int {
 	}
 }
 
+// RelayedIndexTTL bounds how long a suppression-key → peers entry is
+// kept in the reverse index. Must match the consensus router's
+// messageDedupTTL so that a hash remains queryable for as long as the
+// router may observe duplicates for it. If the index expired before
+// the dedup window, a duplicate hitting router.handleProposal could
+// find no "peers that have the message" entry and under-feed the
+// slot — the exact bug B3 was filed to fix.
+const RelayedIndexTTL = 30 * time.Second
+
+// RelayedIndexMaxEntries caps memory for the reverse index under
+// adversarial traffic. Sized to match the adaptor's dedup cap so both
+// age out together under sustained churn.
+const RelayedIndexMaxEntries = 4096
+
+// relayedEntry is one bucket in the reverse index — the set of peers
+// we know "have" a given suppression-key, plus the last-update time
+// for TTL reaping.
+type relayedEntry struct {
+	peers  map[PeerID]struct{}
+	seenAt time.Time
+}
+
 // Overlay is the central orchestrator for XRPL peer-to-peer networking.
 // It manages peer connections, discovery, message routing, and the reduce-relay system.
 type Overlay struct {
@@ -137,6 +159,18 @@ type Overlay struct {
 	peers   map[PeerID]*Peer
 	peersMu sync.RWMutex
 	nextID  atomic.Uint64
+
+	// relayedIndex maps suppression-hash → set of peers known to have
+	// that message. Populated as we forward a validator message (each
+	// recipient joins the set) and queried by the consensus router on
+	// duplicate arrivals so ALL known-havers feed the reduce-relay
+	// slot — not just the peer that delivered the current duplicate.
+	// Matches rippled's overlay().relay returning the haveMessage set
+	// that is then passed to updateSlotAndSquelch
+	// (PeerImp.cpp:3010-3017 for proposals, 3044-3054 for validations).
+	relayedIndex   map[[32]byte]*relayedEntry
+	relayedIndexMu sync.Mutex
+	clockForIndex  func() time.Time
 
 	// Coordination channels
 	events   chan Event
@@ -257,14 +291,16 @@ func New(opts ...Option) (*Overlay, error) {
 	events := make(chan Event, 256)
 
 	o := &Overlay{
-		cfg:        cfg,
-		identity:   identity,
-		discovery:  NewDiscovery(&cfg, events),
-		relay:      NewRelay(&cfg, nil), // squelch callback set below
-		ledgerSync: NewLedgerSyncHandler(events),
-		peers:      make(map[PeerID]*Peer),
-		events:     events,
-		messages:   make(chan *InboundMessage, 256),
+		cfg:           cfg,
+		identity:      identity,
+		discovery:     NewDiscovery(&cfg, events),
+		relay:         NewRelay(&cfg, nil), // squelch callback set below
+		ledgerSync:    NewLedgerSyncHandler(events),
+		peers:         make(map[PeerID]*Peer),
+		events:        events,
+		messages:      make(chan *InboundMessage, 256),
+		relayedIndex:  make(map[[32]byte]*relayedEntry),
+		clockForIndex: time.Now,
 	}
 
 	// Set squelch callback for reduce-relay
@@ -1181,15 +1217,27 @@ func (o *Overlay) Broadcast(msg []byte) error {
 // excluding the originating peer (exceptPeer). Pass 0 for exceptPeer
 // when no peer should be excluded (e.g. tests that synthesize a relay).
 //
+// suppressionHash is the consensus-router suppression key for this
+// message (same [32]byte used by the dedup cache). Every peer we
+// actually send to is recorded in the reverse index so a later
+// duplicate arrival from ANOTHER peer can query
+// Overlay.PeersThatHave(suppressionHash) and feed the reduce-relay
+// slot with the full set of known-havers — matching rippled's
+// haveMessage return from overlay_.relay at PeerImp.cpp:3010-3017 /
+// 3044-3054.
+//
 // Mirrors rippled's gossip-forward path in OverlayImpl::relay: the
 // squelch is consulted before each outbound send (PeerImp.cpp:240-256)
 // and expired squelches auto-clear via Peer.ExpireSquelch. Self-origin
 // is handled by a separate code path (see Broadcast) that skips the
 // filter entirely.
-func (o *Overlay) RelayFromValidator(validator []byte, exceptPeer PeerID, msg []byte) error {
-	o.peersMu.RLock()
-	defer o.peersMu.RUnlock()
+func (o *Overlay) RelayFromValidator(validator []byte, suppressionHash [32]byte, exceptPeer PeerID, msg []byte) error {
+	// Collect the set of peers we actually forwarded to, under the
+	// peer-map RLock. Record into the reverse index AFTER releasing
+	// that lock so we never nest index-mutex inside peers-mutex.
+	var forwarded []PeerID
 
+	o.peersMu.RLock()
 	for id, peer := range o.peers {
 		if id == exceptPeer {
 			continue
@@ -1201,8 +1249,108 @@ func (o *Overlay) RelayFromValidator(validator []byte, exceptPeer PeerID, msg []
 			continue
 		}
 		peer.Send(msg)
+		forwarded = append(forwarded, id)
+	}
+	o.peersMu.RUnlock()
+
+	if len(forwarded) > 0 {
+		o.recordRelayedPeers(suppressionHash, forwarded)
 	}
 	return nil
+}
+
+// recordRelayedPeers adds peerIDs to the reverse-index bucket for
+// suppressionHash, trimming expired buckets if we hit the size cap.
+// Safe for concurrent callers.
+func (o *Overlay) recordRelayedPeers(suppressionHash [32]byte, peerIDs []PeerID) {
+	if o.relayedIndex == nil {
+		return
+	}
+	clock := o.clockForIndex
+	if clock == nil {
+		clock = time.Now
+	}
+	now := clock()
+
+	o.relayedIndexMu.Lock()
+	defer o.relayedIndexMu.Unlock()
+
+	// Trim if we're at capacity. A cheap TTL sweep rather than a
+	// formal LRU — the index is a cache, not a hot path.
+	if len(o.relayedIndex) >= RelayedIndexMaxEntries {
+		cutoff := now.Add(-RelayedIndexTTL)
+		for h, e := range o.relayedIndex {
+			if e.seenAt.Before(cutoff) {
+				delete(o.relayedIndex, h)
+			}
+		}
+		// If that didn't free enough space (adversarial churn), drop
+		// half the map — bounded worst case, same shape as the
+		// messageSuppression eviction in the consensus router.
+		if len(o.relayedIndex) >= RelayedIndexMaxEntries {
+			i := 0
+			for h := range o.relayedIndex {
+				if i >= RelayedIndexMaxEntries/2 {
+					break
+				}
+				delete(o.relayedIndex, h)
+				i++
+			}
+		}
+	}
+
+	entry, ok := o.relayedIndex[suppressionHash]
+	if !ok {
+		entry = &relayedEntry{peers: make(map[PeerID]struct{})}
+		o.relayedIndex[suppressionHash] = entry
+	}
+	for _, id := range peerIDs {
+		entry.peers[id] = struct{}{}
+	}
+	entry.seenAt = now
+}
+
+// PeersThatHave returns the set of peer IDs known to have the message
+// whose suppression-hash is `suppressionHash`. Entries are populated
+// when we relay a validator message outward (RelayFromValidator) and
+// expire after RelayedIndexTTL.
+//
+// Returns nil when the hash is unknown or the bucket has aged out —
+// callers treat both equivalently (nothing to feed the slot with
+// beyond the current originPeer).
+//
+// Thread-safe. The returned slice is a private copy the caller may
+// mutate freely.
+func (o *Overlay) PeersThatHave(suppressionHash [32]byte) []PeerID {
+	if o.relayedIndex == nil {
+		return nil
+	}
+	clock := o.clockForIndex
+	if clock == nil {
+		clock = time.Now
+	}
+
+	o.relayedIndexMu.Lock()
+	defer o.relayedIndexMu.Unlock()
+
+	entry, ok := o.relayedIndex[suppressionHash]
+	if !ok {
+		return nil
+	}
+	// Lazy-expire: if the bucket is older than TTL, drop it and report
+	// "unknown". Keeps queries from returning stale peers after the
+	// dedup window has elapsed (which would feed the slot with
+	// counters the rest of the network would have dropped long ago).
+	if clock().Sub(entry.seenAt) >= RelayedIndexTTL {
+		delete(o.relayedIndex, suppressionHash)
+		return nil
+	}
+
+	out := make([]PeerID, 0, len(entry.peers))
+	for id := range entry.peers {
+		out = append(out, id)
+	}
+	return out
 }
 
 // OnValidatorMessage is called by the consensus router on every inbound

--- a/internal/peermanagement/relay.go
+++ b/internal/peermanagement/relay.go
@@ -220,6 +220,98 @@ func (s *ValidatorSlot) DeletePeer(validator []byte, peerID PeerID, erase bool) 
 	}
 }
 
+// deleteIdlePeers evicts every peer in this slot whose LastMessage is
+// older than Idled from `now`, and — if the remaining peer count drops
+// below maxSelectedPeers while the slot was in RelaySlotSelected —
+// demotes the slot back to RelaySlotCounting so future Updates can
+// retry selection.
+//
+// Mirrors rippled's Slot::deleteIdlePeer (Slot.h:262-283). The
+// per-peer eviction path reuses the DeletePeer logic under this
+// slot's own lock to keep the peer-map transitions consistent with
+// the normal disconnect path (Selected-peer removal cascades into
+// unsquelching the rest of the slot and resetting slot state).
+//
+// Called under Relay.mu write-lock by Relay.deleteIdlePeers, but
+// takes this slot's own mu independently — the two locks always
+// nest in the order (relay, slot) just as RemovePeer does.
+func (s *ValidatorSlot) deleteIdlePeers(validator []byte, now time.Time) {
+	s.mu.Lock()
+
+	// First pass: collect the IDs to evict under lock. We cannot call
+	// DeletePeer (which takes s.mu) while holding it, so do the per-
+	// peer eviction inline here mirroring DeletePeer's semantics.
+	var toEvict []PeerID
+	for id, peer := range s.peers {
+		if now.Sub(peer.LastMessage) > Idled {
+			toEvict = append(toEvict, id)
+		}
+	}
+
+	// Track whether any Selected peer was among the evicted — if so,
+	// rippled's deletePeer cascade unsquelches the rest of the slot
+	// and resets state. We collect the unsquelch callbacks to fire
+	// AFTER we release s.mu, matching the DeletePeer ordering above.
+	type unsquelchCall struct{ peerID PeerID }
+	var unsquelches []unsquelchCall
+
+	for _, id := range toEvict {
+		peer, exists := s.peers[id]
+		if !exists {
+			continue
+		}
+
+		if peer.State == RelayPeerSelected {
+			// Cascade: unsquelch all other Squelched peers, reset
+			// every remaining peer to Counting, and demote the slot.
+			// Matches rippled Slot.h:457-471.
+			for k, v := range s.peers {
+				if k == id {
+					continue
+				}
+				if v.State == RelayPeerSquelched {
+					unsquelches = append(unsquelches, unsquelchCall{peerID: k})
+				}
+				v.State = RelayPeerCounting
+				v.Count = 0
+				v.Expire = now
+			}
+			s.considered = make(map[PeerID]struct{})
+			s.reachedThreshold = 0
+			s.state = RelaySlotCounting
+		} else if _, inConsidered := s.considered[id]; inConsidered {
+			if peer.Count > MaxMessageThreshold {
+				s.reachedThreshold--
+			}
+			delete(s.considered, id)
+		}
+
+		peer.Count = 0
+		peer.LastMessage = now
+		delete(s.peers, id)
+	}
+
+	// Safety-net per G2 spec: if the slot was still in Selected state
+	// after the walk (e.g., only Squelched peers were evicted) and the
+	// remaining peer count dropped below maxSelectedPeers, demote to
+	// Counting so the selection state machine can retry with whatever
+	// peers are left.
+	if s.state == RelaySlotSelected && len(s.peers) < s.maxSelectedPeers {
+		s.initCounting()
+	}
+
+	callback := s.onSquelch
+	s.mu.Unlock()
+
+	// Fire unsquelch callbacks outside the lock — matches rippled's
+	// "after peers_.erase(it)" ordering at Slot.h:485-487.
+	if callback != nil {
+		for _, u := range unsquelches {
+			callback(validator, u.peerID, false, 0)
+		}
+	}
+}
+
 // GetSelected returns the selected peer IDs.
 func (s *ValidatorSlot) GetSelected() []PeerID {
 	s.mu.RLock()
@@ -324,6 +416,40 @@ func (r *Relay) RemovePeer(peerID PeerID) {
 
 	for key, slot := range r.slots {
 		slot.DeletePeer([]byte(key), peerID, true)
+	}
+}
+
+// deleteIdlePeers is the periodic sweep that evicts peers whose
+// last-message timestamp is older than Idled from every validator
+// slot, demotes slots that dropped below MaxSelectedPeers while in
+// Selected state back to Counting, and drops slots that lost all
+// peers entirely.
+//
+// Mirrors rippled's Slot::deleteIdlePeer (Slot.h:262-283) + its
+// aggregator Slots::deleteIdlePeers (Slot.h:821-839). Without this
+// sweep r.slots only shrinks on explicit RemovePeer — a selected peer
+// that silently stops relaying is never demoted back to Counting, so
+// the slot permanently points at a dead source and the relay never
+// retries selection for that validator.
+//
+// Takes `now` explicitly so tests can drive the sweep clock
+// deterministically; callers in production pass time.Now().
+func (r *Relay) deleteIdlePeers(now time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for key, slot := range r.slots {
+		slot.deleteIdlePeers([]byte(key), now)
+
+		// After the per-slot walk, drop the slot entirely if it has
+		// zero peers left — otherwise r.slots would leak entries for
+		// validators we no longer hear from.
+		slot.mu.RLock()
+		empty := len(slot.peers) == 0
+		slot.mu.RUnlock()
+		if empty {
+			delete(r.slots, key)
+		}
 	}
 }
 

--- a/internal/peermanagement/relay.go
+++ b/internal/peermanagement/relay.go
@@ -51,6 +51,23 @@ type RelayPeerInfo struct {
 // SquelchCallback is called when a peer should be squelched/unsquelched.
 type SquelchCallback func(validator []byte, peerID PeerID, squelch bool, duration time.Duration)
 
+// IgnoredSquelchCallback is called when a peer keeps relaying a
+// validator's messages after being placed in the Squelched state —
+// i.e., the peer is ignoring a TMSquelch we previously sent it.
+//
+// Mirrors rippled's ignored_squelch_callback at Slot.h:112-113,
+// invoked inside Slot::update at Slot.h:329-331. The overlay uses
+// this signal to charge the offending peer's reputation (bad-data
+// balance) so sustained squelch-violations eventually evict the peer
+// rather than leaving squelch enforcement purely advisory.
+//
+// Invoked from the hot receive path, OUTSIDE any slot mutex —
+// implementations must be non-blocking. The callback carries only the
+// peerID because the charge is per-peer: a peer can ignore the squelch
+// for multiple validators, and each event should land on the same
+// peer's balance.
+type IgnoredSquelchCallback func(peerID PeerID)
+
 // ValidatorSlot manages peer selection for a specific validator.
 type ValidatorSlot struct {
 	mu sync.RWMutex
@@ -62,6 +79,15 @@ type ValidatorSlot struct {
 	state            RelaySlotState
 	maxSelectedPeers int
 	onSquelch        SquelchCallback
+
+	// onIgnoredSquelch is fired when an incoming validator message
+	// originates from a peer currently in RelayPeerSquelched state —
+	// i.e., the peer is ignoring a TMSquelch we previously sent it.
+	// Set once at slot construction by Relay.OnMessage (which
+	// propagates it from Overlay wiring); leaving it nil simply
+	// disables the charge. Invoked OUTSIDE s.mu to avoid inverting
+	// lock order with the overlay's peers map.
+	onIgnoredSquelch IgnoredSquelchCallback
 }
 
 // NewValidatorSlot creates a new reduce-relay slot for a validator.
@@ -81,8 +107,22 @@ func NewValidatorSlot(maxSelected int, onSquelch SquelchCallback) *ValidatorSlot
 
 // Update processes a message from a peer.
 func (s *ValidatorSlot) Update(validator []byte, peerID PeerID) {
+	// ignoredSquelch is set under s.mu when we detect the peer is
+	// still Squelched, then invoked AFTER releasing the lock. Lock
+	// ordering: never call into overlay-registered callbacks while
+	// holding the slot mutex — the overlay's IncPeerBadData takes its
+	// own peers map lock and we must not invert that order.
+	var (
+		fireIgnoredSquelch bool
+		ignoredCb          IgnoredSquelchCallback
+	)
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	defer func() {
+		s.mu.Unlock()
+		if fireIgnoredSquelch && ignoredCb != nil {
+			ignoredCb(peerID)
+		}
+	}()
 
 	now := time.Now()
 	peer, exists := s.peers[peerID]
@@ -99,6 +139,11 @@ func (s *ValidatorSlot) Update(validator []byte, peerID PeerID) {
 	}
 
 	if peer.State == RelayPeerSquelched && now.After(peer.Expire) {
+		// Squelch window has elapsed — transition the peer back to
+		// Counting and return. No ignored-squelch charge: the peer
+		// isn't ignoring us anymore, the squelch simply expired on its
+		// own schedule. Matches rippled Slot.h:307-314 where the
+		// callback is NOT invoked on expired-squelch traffic.
 		peer.State = RelayPeerCounting
 		peer.LastMessage = now
 		s.initCounting()
@@ -106,6 +151,17 @@ func (s *ValidatorSlot) Update(validator []byte, peerID PeerID) {
 	}
 
 	peer.LastMessage = now
+
+	// G4: the peer is still Squelched and the squelch has NOT expired
+	// — yet it relayed a validator message anyway. Mirrors rippled's
+	// Slot::update at Slot.h:329-331 which calls the
+	// ignored_squelch_callback here. Stage the invocation; the defer
+	// above fires it after we release s.mu so the callback can freely
+	// take the overlay's peers map lock without risking inversion.
+	if peer.State == RelayPeerSquelched {
+		fireIgnoredSquelch = true
+		ignoredCb = s.onIgnoredSquelch
+	}
 
 	if s.state != RelaySlotCounting || peer.State == RelayPeerSquelched {
 		return
@@ -359,22 +415,40 @@ type Relay struct {
 	cfg   *Config
 	clock func() time.Time
 
-	onSquelch SquelchCallback
-	startTime time.Time
+	onSquelch        SquelchCallback
+	onIgnoredSquelch IgnoredSquelchCallback
+	startTime        time.Time
 }
 
-// NewRelay creates a new Relay manager.
+// NewRelay creates a new Relay manager with no ignored-squelch
+// callback. Equivalent to NewRelayWithIgnoredCallback(cfg, onSquelch,
+// nil). Existing callers (and tests that don't exercise G4) keep
+// using this.
 func NewRelay(cfg *Config, onSquelch SquelchCallback) *Relay {
+	return NewRelayWithIgnoredCallback(cfg, onSquelch, nil)
+}
+
+// NewRelayWithIgnoredCallback creates a Relay that additionally
+// invokes onIgnoredSquelch(peerID) every time a peer in the Squelched
+// state relays a validator's message. The callback is propagated to
+// every ValidatorSlot the Relay creates. Pass nil to disable the
+// charge (falls back to NewRelay semantics).
+func NewRelayWithIgnoredCallback(
+	cfg *Config,
+	onSquelch SquelchCallback,
+	onIgnoredSquelch IgnoredSquelchCallback,
+) *Relay {
 	clock := time.Now
 	if cfg.Clock != nil {
 		clock = cfg.Clock
 	}
 	return &Relay{
-		slots:     make(map[string]*ValidatorSlot),
-		cfg:       cfg,
-		clock:     clock,
-		onSquelch: onSquelch,
-		startTime: clock(),
+		slots:            make(map[string]*ValidatorSlot),
+		cfg:              cfg,
+		clock:            clock,
+		onSquelch:        onSquelch,
+		onIgnoredSquelch: onIgnoredSquelch,
+		startTime:        clock(),
 	}
 }
 
@@ -402,6 +476,11 @@ func (r *Relay) OnMessage(validatorKey []byte, peerID PeerID) {
 	slot, exists := r.slots[keyHex]
 	if !exists {
 		slot = NewValidatorSlot(MaxSelectedPeers, r.onSquelch)
+		// Propagate the ignored-squelch callback so every slot this
+		// Relay hands out shares one reputation-charge sink. Set
+		// before Update is called so even the first inbound message
+		// from a (hypothetically pre-squelched) peer lands on it.
+		slot.onIgnoredSquelch = r.onIgnoredSquelch
 		r.slots[keyHex] = slot
 	}
 	r.mu.Unlock()

--- a/internal/peermanagement/relay_test.go
+++ b/internal/peermanagement/relay_test.go
@@ -311,3 +311,121 @@ func TestValidatorSlotGetSelected(t *testing.T) {
 		t.Errorf("Expected 2 selected peers, got %d", len(selected))
 	}
 }
+
+// TestRelay_DeleteIdlePeers_EvictsStaleEntries pins G2: the periodic
+// sweep must evict peers whose lastMessage is older than Idled, and
+// drop the slot entirely when no peers remain. Without this, r.slots
+// only shrinks on explicit RemovePeer and leaks entries for validators
+// we no longer see.
+//
+// Mirrors rippled's Slot::deleteIdlePeer + Slots::deleteIdlePeers
+// (Slot.h:262-283, 821-839). Rippled drives the sweep every 4s from
+// the once-per-second overlay timer (OverlayImpl.cpp:107-111 +
+// Tuning::checkIdlePeers=4).
+func TestRelay_DeleteIdlePeers_EvictsStaleEntries(t *testing.T) {
+	cfg := &Config{
+		EnableReduceRelay: true,
+		Clock:             time.Now,
+	}
+	mock := newMockSquelchCallback()
+	relay := NewRelay(cfg, mock.callback)
+	relay.startTime = time.Now().Add(-WaitOnBootup - time.Minute)
+
+	validator := []byte("test-validator-idle")
+
+	// Seed a single peer so a slot is created with exactly one entry.
+	relay.OnMessage(validator, PeerID(1))
+
+	relay.mu.RLock()
+	slot, ok := relay.slots[string(validator)]
+	relay.mu.RUnlock()
+	if !ok {
+		t.Fatalf("slot was not created by OnMessage")
+	}
+
+	// Precondition: peer is present.
+	slot.mu.RLock()
+	_, exists := slot.peers[PeerID(1)]
+	slot.mu.RUnlock()
+	if !exists {
+		t.Fatalf("precondition: PeerID(1) should exist before sweep")
+	}
+
+	// Advance the sweep clock past Idled from the peer's lastMessage.
+	// The slot stored peer.LastMessage ~= time.Now() inside OnMessage.
+	// Passing a now that is Idled+1s in the future triggers eviction.
+	sweepNow := time.Now().Add(Idled + time.Second)
+	relay.deleteIdlePeers(sweepNow)
+
+	// The slot had exactly one peer, and that peer was idle — the slot
+	// should have been deleted from r.slots after the sweep.
+	relay.mu.RLock()
+	_, stillThere := relay.slots[string(validator)]
+	slotCount := len(relay.slots)
+	relay.mu.RUnlock()
+	if stillThere {
+		t.Fatalf("slot should have been deleted after its only peer idled out; %d slots remain", slotCount)
+	}
+}
+
+// TestRelay_DeleteIdlePeers_DemotesSelectedBelowQuorum pins G2's
+// safety rule: if a slot was in Selected state and the sweep reduces
+// the remaining peer count below MaxSelectedPeers, the slot must be
+// demoted back to Counting so future updates can re-select. Without
+// this, a slot stays "Selected" pointing at peers that have all gone
+// silent, and the relay never retries selection for that validator.
+func TestRelay_DeleteIdlePeers_DemotesSelectedBelowQuorum(t *testing.T) {
+	mock := newMockSquelchCallback()
+	slot := NewValidatorSlot(5, mock.callback)
+
+	// Install 5 peers directly as Selected (bypassing the counting
+	// state machine) so the slot starts in RelaySlotSelected. Use a
+	// recent lastMessage for 2 of them and a stale lastMessage for 3
+	// so the sweep evicts three and leaves two.
+	now := time.Now()
+	fresh := now.Add(-time.Second)             // within Idled window
+	stale := now.Add(-(Idled + 2*time.Second)) // past Idled
+
+	slot.mu.Lock()
+	slot.peers[PeerID(1)] = &RelayPeerInfo{State: RelayPeerSelected, LastMessage: fresh}
+	slot.peers[PeerID(2)] = &RelayPeerInfo{State: RelayPeerSelected, LastMessage: fresh}
+	slot.peers[PeerID(3)] = &RelayPeerInfo{State: RelayPeerSelected, LastMessage: stale}
+	slot.peers[PeerID(4)] = &RelayPeerInfo{State: RelayPeerSelected, LastMessage: stale}
+	slot.peers[PeerID(5)] = &RelayPeerInfo{State: RelayPeerSelected, LastMessage: stale}
+	slot.state = RelaySlotSelected
+	slot.mu.Unlock()
+
+	// Register the slot in a Relay so we exercise the aggregator path.
+	cfg := &Config{
+		EnableReduceRelay: true,
+		Clock:             time.Now,
+	}
+	relay := NewRelay(cfg, mock.callback)
+	validator := []byte("test-validator-demote")
+	relay.mu.Lock()
+	relay.slots[string(validator)] = slot
+	relay.mu.Unlock()
+
+	relay.deleteIdlePeers(now)
+
+	// Slot must still exist (two fresh peers remain) but must have
+	// been demoted to Counting: 2 < MaxSelectedPeers=5.
+	relay.mu.RLock()
+	_, stillThere := relay.slots[string(validator)]
+	relay.mu.RUnlock()
+	if !stillThere {
+		t.Fatalf("slot should remain: 2 fresh peers were not evicted")
+	}
+
+	slot.mu.RLock()
+	state := slot.state
+	remaining := len(slot.peers)
+	slot.mu.RUnlock()
+
+	if remaining != 2 {
+		t.Fatalf("expected 2 remaining peers after sweep, got %d", remaining)
+	}
+	if state != RelaySlotCounting {
+		t.Fatalf("slot state = %v; want RelaySlotCounting after dropping below MaxSelectedPeers", state)
+	}
+}

--- a/internal/peermanagement/relay_test.go
+++ b/internal/peermanagement/relay_test.go
@@ -368,6 +368,242 @@ func TestRelay_DeleteIdlePeers_EvictsStaleEntries(t *testing.T) {
 	}
 }
 
+// TestSlot_IgnoredSquelch_FiresCallback pins G4: when a peer in
+// RelayPeerSquelched state continues to relay a validator's messages,
+// the slot must invoke its ignored-squelch callback with the offending
+// peer's ID so the overlay can charge reputation. Mirrors rippled's
+// Slot::update firing the ignored_squelch_callback at Slot.h:329-331.
+//
+// Without this the only enforcement of squelch is advisory — a peer
+// that ignores our TMSquelch frames keeps wasting bandwidth with zero
+// accountability.
+func TestSlot_IgnoredSquelch_FiresCallback(t *testing.T) {
+	mock := newMockSquelchCallback()
+	slot := NewValidatorSlot(3, mock.callback)
+
+	var (
+		charges   []PeerID
+		chargesMu sync.Mutex
+	)
+	slot.onIgnoredSquelch = func(peerID PeerID) {
+		chargesMu.Lock()
+		defer chargesMu.Unlock()
+		charges = append(charges, peerID)
+	}
+
+	validator := []byte("test-validator-squelch-ignored")
+
+	// Install PeerID(7) directly in RelayPeerSquelched state with an
+	// Expire far in the future so Update does NOT treat it as
+	// expired-and-return-to-counting. LastMessage set to now so the
+	// is-fresh check succeeds.
+	now := time.Now()
+	slot.mu.Lock()
+	slot.peers[PeerID(7)] = &RelayPeerInfo{
+		State:       RelayPeerSquelched,
+		Expire:      now.Add(10 * time.Minute),
+		LastMessage: now,
+	}
+	slot.mu.Unlock()
+
+	// Feed a message from the squelched peer. Update must fire the
+	// ignored-squelch callback exactly once, attributed to PeerID(7).
+	slot.Update(validator, PeerID(7))
+
+	chargesMu.Lock()
+	defer chargesMu.Unlock()
+	if len(charges) != 1 {
+		t.Fatalf("expected exactly 1 ignored-squelch charge, got %d: %v", len(charges), charges)
+	}
+	if charges[0] != PeerID(7) {
+		t.Fatalf("charge attributed to wrong peer: got %v, want PeerID(7)", charges[0])
+	}
+}
+
+// TestSlot_UnsquelchedRelay_DoesNotCharge pins the negative baseline
+// for G4: a peer NOT in RelayPeerSquelched state must never trigger
+// the ignored-squelch callback, regardless of slot state or message
+// volume. Guards against a latent bug where the charge path fires on
+// every incoming message and inflates bad-data balances for well-
+// behaved peers.
+func TestSlot_UnsquelchedRelay_DoesNotCharge(t *testing.T) {
+	mock := newMockSquelchCallback()
+	slot := NewValidatorSlot(3, mock.callback)
+
+	var chargeCount int
+	slot.onIgnoredSquelch = func(peerID PeerID) {
+		chargeCount++
+	}
+
+	validator := []byte("test-validator-ok")
+
+	// Drive a handful of messages from a single unsquelched peer —
+	// the Update path transitions RelayPeerCounting → considered →
+	// (not enough peers to select) but never enters Squelched for
+	// this peer. Charge must stay at 0.
+	for i := 0; i < 5; i++ {
+		slot.Update(validator, PeerID(1))
+	}
+
+	if chargeCount != 0 {
+		t.Fatalf("unsquelched peer must not trigger ignored-squelch callback; got %d calls", chargeCount)
+	}
+
+	// Also verify a Selected peer does not trigger the callback.
+	// Install PeerID(2) directly in RelayPeerSelected state.
+	now := time.Now()
+	slot.mu.Lock()
+	slot.peers[PeerID(2)] = &RelayPeerInfo{
+		State:       RelayPeerSelected,
+		LastMessage: now,
+	}
+	slot.state = RelaySlotSelected
+	slot.mu.Unlock()
+
+	slot.Update(validator, PeerID(2))
+	if chargeCount != 0 {
+		t.Fatalf("selected peer must not trigger ignored-squelch callback; got %d calls", chargeCount)
+	}
+}
+
+// TestSlot_IgnoredSquelch_ExpiredDoesNotCharge pins G4's expired-
+// squelch behavior matching rippled Slot.h:307-314: when a squelched
+// peer's Expire has passed, Update must transition it back to
+// Counting and NOT fire the ignored-squelch callback — the squelch
+// window itself is over, so the relay is no longer "ignored."
+func TestSlot_IgnoredSquelch_ExpiredDoesNotCharge(t *testing.T) {
+	mock := newMockSquelchCallback()
+	slot := NewValidatorSlot(3, mock.callback)
+
+	var chargeCount int
+	slot.onIgnoredSquelch = func(peerID PeerID) {
+		chargeCount++
+	}
+
+	validator := []byte("test-validator-expired")
+
+	// Squelched with Expire already in the past.
+	now := time.Now()
+	slot.mu.Lock()
+	slot.peers[PeerID(9)] = &RelayPeerInfo{
+		State:       RelayPeerSquelched,
+		Expire:      now.Add(-time.Second),
+		LastMessage: now,
+	}
+	slot.mu.Unlock()
+
+	slot.Update(validator, PeerID(9))
+
+	if chargeCount != 0 {
+		t.Fatalf("expired-squelch relay must not charge; got %d calls", chargeCount)
+	}
+
+	// Peer should have transitioned to Counting.
+	slot.mu.RLock()
+	state := slot.peers[PeerID(9)].State
+	slot.mu.RUnlock()
+	if state != RelayPeerCounting {
+		t.Fatalf("expected peer state Counting after expiry, got %v", state)
+	}
+}
+
+// TestRelay_SquelchedPeerRelayChargesPeer is the overlay-level G4
+// assertion: when the Relay layer sees a message from a peer it has
+// already marked Squelched for a given validator, it must propagate
+// that event to the overlay-supplied ignored-squelch callback so the
+// peer's bad-data balance rises.
+func TestRelay_SquelchedPeerRelayChargesPeer(t *testing.T) {
+	var now time.Time
+	start := time.Now()
+	now = start
+	clock := func() time.Time { return now }
+
+	cfg := &Config{
+		EnableVPReduceRelay: true,
+		Clock:               clock,
+	}
+
+	var (
+		charges   []PeerID
+		chargesMu sync.Mutex
+	)
+	ignoredCb := func(peerID PeerID) {
+		chargesMu.Lock()
+		defer chargesMu.Unlock()
+		charges = append(charges, peerID)
+	}
+
+	mock := newMockSquelchCallback()
+	relay := NewRelayWithIgnoredCallback(cfg, mock.callback, ignoredCb)
+
+	// Advance past bootup so OnMessage is active.
+	now = start.Add(WaitOnBootup + time.Minute)
+
+	validator := []byte("test-validator-charge")
+
+	// Seed a slot with PeerID(42) already in Squelched state with an
+	// Expire far in the future so Update's expired-squelch branch
+	// doesn't mask the ignored-relay callback.
+	relay.OnMessage(validator, PeerID(42))
+
+	relay.mu.RLock()
+	slot := relay.slots[string(validator)]
+	relay.mu.RUnlock()
+	if slot == nil {
+		t.Fatalf("slot was not created by OnMessage")
+	}
+	slot.mu.Lock()
+	slot.peers[PeerID(42)] = &RelayPeerInfo{
+		State:       RelayPeerSquelched,
+		Expire:      now.Add(10 * time.Minute),
+		LastMessage: now,
+	}
+	slot.mu.Unlock()
+
+	// The squelched peer keeps relaying. Expect exactly one charge.
+	relay.OnMessage(validator, PeerID(42))
+
+	chargesMu.Lock()
+	defer chargesMu.Unlock()
+	if len(charges) != 1 || charges[0] != PeerID(42) {
+		t.Fatalf("expected one charge for PeerID(42), got: %v", charges)
+	}
+}
+
+// TestRelay_UnsquelchedPeerRelayDoesNotCharge is the negative G4
+// baseline at the Relay level: routine traffic from an unsquelched
+// peer must never trigger the ignored-squelch callback.
+func TestRelay_UnsquelchedPeerRelayDoesNotCharge(t *testing.T) {
+	var now time.Time
+	start := time.Now()
+	now = start
+	clock := func() time.Time { return now }
+
+	cfg := &Config{
+		EnableVPReduceRelay: true,
+		Clock:               clock,
+	}
+
+	var charges int
+	ignoredCb := func(peerID PeerID) { charges++ }
+
+	mock := newMockSquelchCallback()
+	relay := NewRelayWithIgnoredCallback(cfg, mock.callback, ignoredCb)
+
+	now = start.Add(WaitOnBootup + time.Minute)
+
+	validator := []byte("test-validator-ok")
+
+	// A handful of messages from one unsquelched peer.
+	for i := 0; i < 5; i++ {
+		relay.OnMessage(validator, PeerID(1))
+	}
+
+	if charges != 0 {
+		t.Fatalf("unsquelched peer must not be charged; got %d calls", charges)
+	}
+}
+
 // TestRelay_DeleteIdlePeers_DemotesSelectedBelowQuorum pins G2's
 // safety rule: if a slot was in Selected state and the sweep reduces
 // the remaining peer count below MaxSelectedPeers, the slot must be

--- a/internal/peermanagement/relayed_index_test.go
+++ b/internal/peermanagement/relayed_index_test.go
@@ -1,0 +1,111 @@
+package peermanagement
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOverlay_PeersThatHave_PopulatedByRelayForward is the core B3
+// contract: when the overlay forwards a validator message to peers,
+// Overlay.PeersThatHave(suppressionHash) must return the set of
+// recipients so a later duplicate arrival from a DIFFERENT peer can
+// feed the reduce-relay slot with every known-haver. Mirrors
+// rippled's haveMessage return from overlay_.relay
+// (PeerImp.cpp:3010-3017 / 3044-3054).
+func TestOverlay_PeersThatHave_PopulatedByRelayForward(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	o := &Overlay{
+		peers:         make(map[PeerID]*Peer),
+		events:        make(chan Event, 8),
+		relayedIndex:  make(map[[32]byte]*relayedEntry),
+		clockForIndex: time.Now,
+	}
+
+	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
+	peerA := NewPeer(PeerID(1), endpoint, false, id, make(chan Event, 1))
+	peerB := NewPeer(PeerID(2), endpoint, false, id, make(chan Event, 1))
+	peerC := NewPeer(PeerID(3), endpoint, false, id, make(chan Event, 1))
+	peerA.setState(PeerStateConnected)
+	peerB.setState(PeerStateConnected)
+	peerC.setState(PeerStateConnected)
+	o.peers[peerA.ID()] = peerA
+	o.peers[peerB.ID()] = peerB
+	o.peers[peerC.ID()] = peerC
+
+	validator := []byte("validator-B3")
+	hash := [32]byte{0xAB, 0xCD}
+	payload := []byte("signed-proposal-bytes")
+
+	// Relay from peer C (origin): A and B must receive the payload,
+	// and the reverse index must record {A, B} against `hash`. C is
+	// excluded as origin and must NOT appear in the index.
+	require.NoError(t, o.RelayFromValidator(validator, hash, peerC.ID(), payload))
+
+	got := o.PeersThatHave(hash)
+	require.NotNil(t, got, "PeersThatHave must return a non-nil set after a relay-forward")
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	assert.Equal(t, []PeerID{peerA.ID(), peerB.ID()}, got,
+		"reverse index must contain exactly the peers we forwarded to (A, B); origin C must be excluded")
+
+	// A second forward for the SAME hash but to a disjoint set (say
+	// we learn about a new peer D later) must UNION in, not replace.
+	peerD := NewPeer(PeerID(4), endpoint, false, id, make(chan Event, 1))
+	peerD.setState(PeerStateConnected)
+	o.peers[peerD.ID()] = peerD
+	// Exclude A, B, C this time so only D is the recipient.
+	require.NoError(t, o.RelayFromValidator(validator, hash, peerA.ID(), payload))
+
+	got2 := o.PeersThatHave(hash)
+	gotSet := make(map[PeerID]struct{}, len(got2))
+	for _, p := range got2 {
+		gotSet[p] = struct{}{}
+	}
+	for _, want := range []PeerID{peerB.ID(), peerC.ID(), peerD.ID()} {
+		_, ok := gotSet[want]
+		assert.True(t, ok, "reverse index must retain peer %d after a second relay-forward with a different exceptPeer", want)
+	}
+}
+
+// TestOverlay_PeersThatHave_TTLExpiry pins the lazy TTL: once the
+// bucket is older than RelayedIndexTTL, PeersThatHave returns nil and
+// the bucket is dropped. This must match the consensus router's
+// messageDedupTTL so the index doesn't outlive the dedup cache — a
+// stale entry would feed the slot with counters for peers the rest of
+// the network has already aged out.
+func TestOverlay_PeersThatHave_TTLExpiry(t *testing.T) {
+	var nowVal time.Time
+	o := &Overlay{
+		peers:        make(map[PeerID]*Peer),
+		events:       make(chan Event, 8),
+		relayedIndex: make(map[[32]byte]*relayedEntry),
+	}
+	o.clockForIndex = func() time.Time { return nowVal }
+
+	// Seed the index directly so we don't need a real peer map.
+	hash := [32]byte{0x01}
+	nowVal = time.Unix(1_700_000_000, 0)
+	o.recordRelayedPeers(hash, []PeerID{PeerID(7)})
+
+	// Immediate query returns the set.
+	got := o.PeersThatHave(hash)
+	require.Len(t, got, 1)
+	assert.Equal(t, PeerID(7), got[0])
+
+	// Advance past TTL: query must return nil (lazy expiry).
+	nowVal = nowVal.Add(RelayedIndexTTL + time.Second)
+	got = o.PeersThatHave(hash)
+	assert.Nil(t, got, "bucket older than RelayedIndexTTL must be reaped on query")
+
+	// Bucket must also be physically removed from the map so the
+	// next query path is O(1) on the cold-miss.
+	o.relayedIndexMu.Lock()
+	_, present := o.relayedIndex[hash]
+	o.relayedIndexMu.Unlock()
+	assert.False(t, present, "expired bucket must be deleted from the index, not just hidden")
+}

--- a/internal/peermanagement/squelch_test.go
+++ b/internal/peermanagement/squelch_test.go
@@ -190,7 +190,10 @@ func TestRelayFromValidator_SkipsSquelchedPeers(t *testing.T) {
 	payload := []byte("validation-frame")
 	// exceptPeer = 0 means no peer is excluded by origin — this test
 	// exercises only the squelch filter, not the origin-exclusion.
-	require.NoError(t, o.RelayFromValidator(validator, PeerID(0), payload))
+	// The suppressionHash is unused by this test (reverse-index is
+	// populated but never read), so any sentinel value works.
+	var hash [32]byte
+	require.NoError(t, o.RelayFromValidator(validator, hash, PeerID(0), payload))
 
 	// `allowed` must have received exactly the payload.
 	select {

--- a/internal/peermanagement/squelch_test.go
+++ b/internal/peermanagement/squelch_test.go
@@ -307,6 +307,116 @@ func TestOverlay_InboundSquelch_MalformedPubkey_Charges(t *testing.T) {
 		"malformed-pubkey squelch must not have installed a squelch entry")
 }
 
+// TestHandleSquelchMessage_DropsSelfTargetingSquelch pins Task 4.2 (G3):
+// an inbound TMSquelch whose ValidatorPubKey equals the local validator
+// pubkey must be dropped WITHOUT installing a squelch — otherwise a
+// hostile peer could silence our own validator's traffic on the
+// RelayFromValidator path. Matches rippled PeerImp.cpp:2715-2721.
+// The peer is charged "squelch-targets-self" so repeat offenders evict.
+func TestHandleSquelchMessage_DropsSelfTargetingSquelch(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	// Configure the local validator pubkey P (33-byte compressed).
+	localValidator := make([]byte, 33)
+	for i := range localValidator {
+		localValidator[i] = byte(0xAA)
+	}
+
+	o := &Overlay{
+		cfg:    Config{LocalValidatorPubKey: localValidator},
+		peers:  make(map[PeerID]*Peer),
+		events: make(chan Event, 8),
+	}
+
+	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
+	peer := NewPeer(PeerID(99), endpoint, false, id, make(chan Event, 1))
+	o.peers[peer.ID()] = peer
+
+	// Peer sends a TMSquelch targeting OUR validator pubkey.
+	sq := &message.Squelch{
+		Squelch:         true,
+		ValidatorPubKey: localValidator,
+		SquelchDuration: uint32(MinUnsquelchExpire / time.Second),
+	}
+	payload, err := message.Encode(sq)
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(0), peer.BadDataCount(),
+		"peer must start at zero bad-data")
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeSquelch),
+		Payload:     payload,
+	})
+
+	// AddSquelch must NOT have been called — ExpireSquelch returns true
+	// for any validator we have not squelched.
+	assert.True(t, peer.ExpireSquelch(localValidator),
+		"self-targeted squelch must not have installed a squelch entry")
+
+	// Peer is charged for attempting to silence our own validator.
+	// "squelch-targets-self" falls through to weightDefaultBadData (100).
+	assert.Equal(t, uint32(weightDefaultBadData), peer.BadDataCount(),
+		"self-targeting TMSquelch must charge bad-data (squelch-targets-self)")
+}
+
+// TestHandleSquelchMessage_AllowsOtherValidatorSquelch is the
+// companion regression guard: a TMSquelch targeting a validator pubkey
+// Q ≠ P (our local validator) must still be applied normally. Ensures
+// the G3 filter does not clobber the common case.
+func TestHandleSquelchMessage_AllowsOtherValidatorSquelch(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	// Local validator pubkey P.
+	localValidator := make([]byte, 33)
+	for i := range localValidator {
+		localValidator[i] = byte(0xAA)
+	}
+
+	// Other validator pubkey Q, distinct from P.
+	otherValidator := make([]byte, 33)
+	for i := range otherValidator {
+		otherValidator[i] = byte(0xBB)
+	}
+
+	o := &Overlay{
+		cfg:    Config{LocalValidatorPubKey: localValidator},
+		peers:  make(map[PeerID]*Peer),
+		events: make(chan Event, 8),
+	}
+
+	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
+	peer := NewPeer(PeerID(100), endpoint, false, id, make(chan Event, 1))
+	o.peers[peer.ID()] = peer
+
+	sq := &message.Squelch{
+		Squelch:         true,
+		ValidatorPubKey: otherValidator,
+		SquelchDuration: uint32(MinUnsquelchExpire / time.Second),
+	}
+	payload, err := message.Encode(sq)
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeSquelch),
+		Payload:     payload,
+	})
+
+	// AddSquelch must have run — ExpireSquelch returns false while the
+	// squelch is active.
+	assert.False(t, peer.ExpireSquelch(otherValidator),
+		"other-validator squelch must have been installed")
+
+	// No bad-data charge: applying a squelch for another validator is
+	// the normal, valid case.
+	assert.Equal(t, uint32(0), peer.BadDataCount(),
+		"applying a squelch for a different validator must not charge bad-data")
+}
+
 // TestOverlay_InboundSquelch_FromUnnegotiatedPeer verifies that an
 // inbound TMSquelch from a peer that did NOT negotiate reduce-relay is
 // still applied (parity with rippled PeerImp.cpp:2691-2732). Feature

--- a/internal/testing/p2p/replay_delta_apply_integration_test.go
+++ b/internal/testing/p2p/replay_delta_apply_integration_test.go
@@ -120,20 +120,26 @@ func TestReplayDelta_Apply_Integration(t *testing.T) {
 	assert.Equal(t, wantTx, gotTx, "derived TxHash must match successor's")
 }
 
-// TestReplayDelta_Apply_DivergenceFromTef verifies the tef-result
-// divergence error: when Apply replays a tx that the engine rejects
-// with a tef* result (here: a duplicate tx, triggering tefALREADY),
-// it no longer hard-fails — R6.4 brings parity with rippled's
-// BuildLedger.cpp:244-247 which DISCARDS the ApplyResult during
-// replay. tef/tem/tel are log-and-continue; the state-hash check at
-// the end of Apply catches real divergence.
+// TestReplay_TefTxDoesNotInstallPeerLeaf verifies D5 — the apply
+// switch installs the peer-supplied tx leaf only when the engine
+// returned applied==true (tes / tec). On tef / tem / tel / ter, the
+// leaf is DROPPED and replay fails loudly with ErrReplayTxDiverged.
 //
-// We still build a duplicate-tx scenario because it's a reliable way
-// to trigger tef, but the assertion flips: Apply must NOT return
-// ErrReplayTxDiverged. Whatever error surfaces (or nil + wrong
-// state hash) must originate from a later arbitration stage, not
-// the pre-R6.4 hard-fail in the apply switch.
-func TestReplayDelta_Apply_TefDuringReplay_IsSilentlySkipped(t *testing.T) {
+// This reverses the earlier R6.4 "preserve peer leaf on all branches
+// and let the AccountHash check be the safety net" policy. Rippled's
+// Transactor.cpp:1108 + 1215-1267 sets applied = isTesSuccess(result)
+// (tec claims also promote to applied at :1215), and
+// BuildLedger.cpp:246 calls rawTxInsert only when applied==true —
+// everything else silently drops the tx from the view. Preserving
+// the leaf was a goXRPL-only divergence: if the engine disagrees
+// with the peer on whether a tx applies, AccountHash diverges
+// regardless, so the leaf-preservation bought nothing and obscured
+// the real disagreement.
+//
+// We trigger tef by replaying a duplicate tx (engine returns
+// tefALREADY on the second apply). That's a reliable, real-engine
+// path to a tef result during replay.
+func TestReplay_TefTxDoesNotInstallPeerLeaf(t *testing.T) {
 	env := xrplgoTesting.NewTestEnv(t)
 	env.VerifySignatures = true
 
@@ -168,11 +174,11 @@ func TestReplayDelta_Apply_TefDuringReplay_IsSilentlySkipped(t *testing.T) {
 	require.NoError(t, err)
 	successorHash := successor.Hash()
 
-	// Wire response carrying ONE tx (legitimate). GotResponse builds
-	// r.txs from this. We then poke a second DecodedTx with the same
-	// hash + blob into r.txs to simulate a divergent peer feeding us
-	// a duplicate — the engine produces tefALREADY on the second
-	// apply, which Apply must surface as an explicit divergence error.
+	// Wire response carries ONE legitimate tx; GotResponse builds r.txs
+	// from it. We then force-inject a second DecodedTx with the same
+	// hash + blob to simulate a divergent delta — the engine returns
+	// tefALREADY on the duplicate apply, which D5 must surface as
+	// ErrReplayTxDiverged instead of silently installing the peer leaf.
 	resp := &message.ReplayDeltaResponse{
 		LedgerHash:   successorHash[:],
 		LedgerHeader: hdrBytes,
@@ -181,10 +187,7 @@ func TestReplayDelta_Apply_TefDuringReplay_IsSilentlySkipped(t *testing.T) {
 	rd := inbound.NewReplayDelta(successorHash, 7, parent, nil)
 	require.NoError(t, rd.GotResponse(resp))
 
-	// Force-inject a second copy of the same DecodedTx — equivalent to
-	// receiving a delta whose tx set contains the same hash twice.
-	// The package-level helper below (in the same package since this
-	// test lives in p2p/) reaches into ReplayDelta to mutate r.txs.
+	// Duplicate hash in the replay set → tefALREADY on the second apply.
 	injectDuplicateTx(rd)
 
 	_, err = rd.Apply(tx.EngineConfig{
@@ -193,14 +196,9 @@ func TestReplayDelta_Apply_TefDuringReplay_IsSilentlySkipped(t *testing.T) {
 		ReserveIncrement:          50_000_000,
 		SkipSignatureVerification: false,
 	})
-	// R6.4: tef* during replay must NOT surface as ErrReplayTxDiverged.
-	// Any other error (or success with a later state-hash mismatch)
-	// is acceptable — the critical guarantee is that we no longer
-	// hard-fail here, which the pre-R6.4 behavior did.
-	if err != nil {
-		assert.NotErrorIs(t, err, inbound.ErrReplayTxDiverged,
-			"tef during replay must no longer produce ErrReplayTxDiverged (rippled parity — BuildLedger.cpp:244-247 discards ApplyResult)")
-	}
+	require.Error(t, err, "tef during replay must fail the replay loudly (D5 — only applied==true installs peer leaf)")
+	assert.ErrorIs(t, err, inbound.ErrReplayTxDiverged,
+		"tef during replay must surface as ErrReplayTxDiverged rather than silently continuing")
 }
 
 // injectDuplicateTx appends a duplicate of r.txs[0] to r.txs so Apply

--- a/tasks/pr-dispute-tracking.md
+++ b/tasks/pr-dispute-tracking.md
@@ -1,0 +1,226 @@
+# Issue #266 — E2: per-tx dispute tracking through consensus convergence
+
+**Branch:** `feature/dispute-tracking-266` off `feature/p2p-todos`
+**Scope:** Wire per-peer dispute votes into the consensus engine; replace whole-set popularity voting with per-tx re-voting ramping through 50/65/70/95% avalanche thresholds; implement `unVote` for bow-out.
+
+**Rippled references:**
+- `rippled/src/xrpld/consensus/DisputedTx.h` — per-peer Map_t votes_, avalanche state, updateVote
+- `rippled/src/xrpld/consensus/ConsensusParms.h` — avalanche cutoffs (init/mid/late/stuck)
+- `rippled/src/xrpld/consensus/Consensus.h:createDisputes(1821), updateDisputes(1892)` — wiring into peerProposal/gotTxSet/closeLedger
+- `rippled/src/xrpld/consensus/Consensus.h:updateOurPositions(1492), haveConsensus(1682)` — per-tx vote migration + accept gate
+- `rippled/src/xrpld/consensus/Consensus.h:804-817` — bow-out → unVote on every dispute
+
+---
+
+## Phase 1 — Data model
+
+### 1.1 Extend `consensus.DisputedTx` (`internal/consensus/types.go:259`)
+
+Add per-peer vote tracking + per-dispute avalanche state:
+```go
+type AvalancheState int
+const (
+    AvalancheInit AvalancheState = iota   // 50%
+    AvalancheMid                           // 65%
+    AvalancheLate                          // 70%
+    AvalancheStuck                         // 95%
+)
+
+type DisputedTx struct {
+    TxID TxID
+    Tx   []byte
+    OurVote bool
+    Yays int
+    Nays int
+    // Per-peer votes. Yays/Nays are cached counts derived from this map.
+    Votes map[NodeID]bool
+    // Avalanche state for the per-tx threshold ramp.
+    AvalancheState     AvalancheState
+    AvalancheCounter   int // rounds at current avalanche state
+    CurrentVoteCounter int // rounds since we last changed our vote
+}
+```
+
+### 1.2 Add `ConsensusParms` type in `consensus/types.go`
+
+Mirror rippled's avalanche cutoff table + avMIN_ROUNDS / avSTALLED_ROUNDS. Export `GetNeededWeight(state, percentTime, rounds, minRounds) -> (pct int, nextState *AvalancheState)` helper matching rippled's `getNeededWeight`.
+
+Integrate with the existing `Thresholds` (don't duplicate `MinConsensusPct = 80`).
+
+---
+
+## Phase 2 — DisputeTracker rework (`internal/consensus/rcl/proposals.go`)
+
+Replace the naïve Yays/Nays-only tracker with the rippled-style one.
+
+### 2.1 `CreateDispute(txID, tx, ourVote, numPeers)` — preserve backward signature (drop `numPeers` arg unused today, or add it as an optional hint).
+
+### 2.2 `SetVote(txID, peerID, yes bool) bool`
+- Insert or update peer's vote.
+- On insert, increment Yays or Nays.
+- On change, swap one count.
+- Returns true iff a vote was inserted or changed (caller uses this to reset `peerUnchangedCounter`).
+
+### 2.3 `UnVote(peerID NodeID)`
+- Iterate every dispute.
+- If peer had a vote there, decrement the count and remove the entry.
+- No-op on disputes where peer has no vote.
+
+### 2.4 `UpdateDisputes(peerID, peerTxSet TxSet) (anyChanged bool)`
+- For every existing dispute, call `SetVote(txID, peerID, peerTxSet.Contains(txID))`.
+- Tracks whether any vote changed.
+
+### 2.5 `UpdateOurVote(percentTime int, proposing bool, parms ConsensusParms) (changedTxs []TxID)`
+- For every dispute, run `updateVote` logic matching `DisputedTx.h:updateVote`:
+  - Short-circuit if we already align with the peer tally (yours=yes && nays==0 etc.).
+  - Call `GetNeededWeight` to advance avalanche state.
+  - If proposing: `weight = (yays*100 + (ourVote?100:0)) / (yays + nays + 1)`; newPosition = weight > requiredPct.
+  - Else: newPosition = yays > nays (read-only observer).
+  - If newPosition differs from ourVote: flip ourVote, reset CurrentVoteCounter, swap one count, append to changedTxs.
+  - Else: bump CurrentVoteCounter.
+
+### 2.6 Deprecate `AddVote` and the old `Resolve`
+Keep them for now as convenience wrappers + update proposals_test.go to use new API (per-peer). Do NOT leave dead code in final PR; delete old Resolve.
+
+---
+
+## Phase 3 — Engine wiring (`internal/consensus/rcl/engine.go`)
+
+### 3.1 Engine state changes
+- Replace `disputes map[TxID]*DisputedTx` field with `disputeTracker *DisputeTracker`.
+- Add `acquiredTxSets map[TxSetID]TxSet` — matches rippled's `acquired_`. Populated from both our own `BuildTxSet` and successful `OnTxSet`/`GetTxSet` lookups.
+- Add `peerUnchangedCounter int` — rounds since any peer flipped a vote (for stall detection).
+- Add `establishCounter int` — rounds spent in establish phase (for avalanche minMaxRounds check).
+
+### 3.2 `startRoundLocked` — reset
+Reset disputeTracker, acquiredTxSets, peerUnchangedCounter, establishCounter on round start.
+
+### 3.3 `closeLedger` — seed disputes
+After `ourTxSet` is built and proposal broadcast, iterate current peer positions:
+- For each peer whose proposal has an acquired tx set different from ours:
+  - `createDisputes(peerTxSet)` → builds DisputedTx for every tx in symmetric difference; seeds ourVote = `ourTxSet.Contains(txID)`; calls SetVote for every peer whose acquired set is known.
+
+Helper `createDisputesLocked(peerTxSet TxSet)` mirrors rippled's `createDisputes(o)` — the `compares_` set to avoid re-diffing the same tx set.
+
+Add `comparesTxSets map[TxSetID]struct{}` to engine state to dedupe.
+
+### 3.4 `OnProposal` — update disputes when position is known
+After storing the updated position:
+- If `peerTxSet := e.acquiredTxSets[proposal.TxSet]; peerTxSet != nil`:
+  - `createDisputesLocked(peerTxSet)`
+  - `disputeTracker.UpdateDisputes(proposal.NodeID, peerTxSet)`
+
+### 3.5 `OnTxSet` — back-fill disputes when tx set arrives late
+When a tx set is acquired:
+- Store in `acquiredTxSets`.
+- For every peer whose stored proposal position == this tx set ID: `createDisputesLocked + UpdateDisputes`.
+
+### 3.6 Bow-out arm — replace TODO(E2) with `disputeTracker.UnVote(peerID)` (`engine.go:372-377`).
+
+---
+
+## Phase 4 — Convergence rewrite
+
+### 4.1 Add `updateOurPositions` method
+Matches rippled's `updateOurPositions(1492-1678)` for the TX side (close-time logic stays in `updateCloseTimePosition`):
+
+1. `convergePercent_` — ratio of current-round duration to previous round, clamped by `avMIN_CONSENSUS_TIME=5s`. Already computed by `convergePercent()`.
+2. Stale proposal pruning: iterate `e.proposals`; drop stale ones; `disputeTracker.UnVote(peerID)` for each dropped peer.
+3. `changedTxs := disputeTracker.UpdateOurVote(convergePercent, proposing, parms)`.
+4. If non-empty, rebuild `ourTxSet` from old set ± changedTxs (mutate through adaptor `BuildTxSet` with the adjusted blob list), bump position counter, re-sign, broadcast.
+5. If we updated our position and are proposing: `disputeTracker.UpdateDisputes(selfNodeID, ourTxSet)` and also call `UpdateDisputes` for every peer whose acquired set matches the new position.
+
+### 4.2 Rewrite `checkConvergence` (`engine.go:1132-1184`)
+Remove the whole-set popularity block. New logic:
+
+```
+if now - phaseStart <= LedgerMinConsensus: return
+updateOurPositions(parms)   // may change our position
+updateCloseTimePosition()
+if !haveConsensus(): return
+if !haveCloseTimeConsensus: return
+acceptLedger(ResultSuccess)
+```
+
+### 4.3 Add `haveConsensus` helper
+Matches rippled's `haveConsensus(1682)`:
+- `agree := count of peers whose proposal.TxSet == ourPosition.TxSet` (+ self if proposing)
+- `disagree := count of peers whose proposal.TxSet != ourPosition.TxSet`
+- accept iff `agree * 100 >= (agree + disagree) * MinConsensusPct`
+
+Also handle stall detection (all disputes `stalled()`) for future expiration — but E3 already added the hard-timeout so we can defer stall fallback. Document as out-of-scope for #266.
+
+### 4.4 Increment `establishCounter` / `peerUnchangedCounter` on each `phaseEstablish` tick.
+
+---
+
+## Phase 5 — Tests (internal/consensus/rcl/ — new test file `disputes_test.go`)
+
+### 5.1 `TestConsensus_OverlappingDisjointProposals_Converges`
+- 5 trusted validators (our node + 4 peers).
+- Configure 2 peers to propose {A,B,C}, 2 peers to propose {A,B,D}; our initial set = {A,B}.
+- Drive rounds: each `phaseEstablish` tick, advance `adaptor.now` past LedgerMinConsensus; iterate.
+- Assert: eventually ourTxSet = {A,B,C,D} (both in after threshold ramps), engine reaches `PhaseAccepted`, `disputeTracker` created disputes for C and D.
+
+### 5.2 `TestConsensus_BowOut_UnVotesDisputes`
+- Set up 3 peers; create dispute on tx C; peer X votes yes (via an acquired peer tx set containing C).
+- Assert Yays == 1 (plus maybe ourVote yes).
+- Send a bow-out proposal (Position = seqLeave) from X.
+- Assert: X no longer in `e.proposals`, X in `e.deadNodes`, dispute C's Yay count decremented, X not in `dispute.Votes`.
+
+### 5.3 `TestConsensus_AvalancheThresholdRamp`
+- Create a single dispute with a known split vote (e.g. 2 yay / 2 nay out of 5 participants).
+- Call `UpdateOurVote` repeatedly with increasing `percentTime`:
+  - percentTime=0, 2 rounds → still init (50%)
+  - percentTime=60 → advances to mid (65%)
+  - percentTime=90 → advances to late (70%)
+  - percentTime=210 → advances to stuck (95%)
+- Assert dispute's avalanche state field and the threshold the next updateVote call requires.
+
+### 5.4 Update `proposals_test.go` for the new API
+- Replace `AddVote(id, bool)` calls with `SetVote(id, peerID, bool)`.
+- Update `Resolve` test OR delete Resolve entirely (rippled has no equivalent API; the engine now drives inclusion via `UpdateOurVote`).
+
+---
+
+## Phase 6 — Acceptance verification
+- `go build ./...`
+- `go test ./internal/consensus/...` — all existing tests plus the three new ones pass
+- Confirm `TestOnProposal_BowOutEvictsNode` still passes with the B4→E2 handoff in place
+
+## Out of scope (explicitly defer)
+- Stall-based ResultExpired return (already covered by E3 ledgerABANDON_CONSENSUS).
+- Full `adaptor_.share(tx)` rebroadcast on new disputes — goXRPL's gossip layer doesn't have per-tx share hooks yet; the tx is already gossiped via the normal mempool.
+- Peer UnchangedCounter decay across rounds — rippled resets it per-round; we do too.
+
+---
+
+## Review — completed 2026-04-24
+
+### Files touched
+
+- `internal/consensus/types.go` — `DisputedTx` extended with `Votes map[NodeID]bool` + per-dispute avalanche state fields; new `AvalancheState` enum; new `ConsensusParms` + `DefaultConsensusParms()` + `NeededWeight()` helper mirroring rippled's `ConsensusParms::getNeededWeight`.
+- `internal/consensus/engine.go` — `TxSet` interface gained `TxIDs() []TxID` (documented to zip with `Txs()`).
+- `internal/consensus/adaptor/txset.go` — `TxSetImpl.TxIDs()` returns IDs in the same order as `Txs()`.
+- `internal/consensus/rcl/proposals.go` — `DisputeTracker` reworked: `CreateDispute` now seeds an empty peer-vote map; new `SetVote(txID, peerID, yes) bool`, `UnVote(peerID)`, `UpdateDisputes(peerID, peerTxSet)`, `UpdateOurVote(percentTime, proposing, parms) []TxID`. Old `AddVote`, `Resolve`, and legacy `UpdateOurVote(txID, include)` were removed — they assumed Yays/Nays counted ourVote, which rippled does not do.
+- `internal/consensus/rcl/engine.go` — Engine now owns a `disputeTracker`, `acquiredTxSets`, `comparesTxSets`, `parms`, `peerUnchangedCounter`, `establishCounter`. New helpers: `createDisputesAgainst`, `seedDisputeVotes`, `countAgreement`. `updatePosition` rewritten from whole-set popularity to per-tx dispute re-vote + rebuild. `checkConvergence` rewritten to use `countAgreement` (rippled's `haveConsensus`). `OnProposal` / `OnTxSet` / `closeLedger` wire dispute create + update. Bow-out arm now calls `disputeTracker.UnVote(peerID)` — the issue's TODO(E2) pointer is resolved. `handleWrongLedger` resets the new tracker fields alongside the old ones.
+- `internal/consensus/rcl/proposals_test.go` — Replaced `TestDisputeTracker_CreateAndVote`, `TestDisputeTracker_Resolve`, `TestDisputeTracker_UpdateOurVote` with four tests covering the new API: `TestDisputeTracker_CreateAndVote`, `TestDisputeTracker_UnVote`, `TestDisputeTracker_UpdateDisputes`, `TestDisputeTracker_UpdateOurVote_AvalancheRamp`.
+- `internal/consensus/rcl/engine_test.go` — `mockTxSet` gained `txIDs` slice for insertion-order `TxIDs()`; `mockAdaptor.BuildTxSet` now derives per-tx IDs from blob prefixes (32-byte) so round-trip tests see correct `Contains` behavior.
+- `internal/consensus/rcl/disputes_test.go` **(new)** — Three acceptance tests:
+  - `TestConsensus_OverlappingDisjointProposals_Converges`
+  - `TestConsensus_BowOut_UnVotesDisputes`
+  - `TestConsensus_AvalancheThresholdRamp`
+
+### Acceptance criteria — all met
+
+- **TestConsensus_OverlappingDisjointProposals_Converges** ✅ — peers split between {A,B,C} and {A,B,D} with enough ABCD-proposing peers for weight > 50%. Engine creates disputes C and D, `updatePosition` flips both to yes, final tx set is {A,B,C,D}.
+- **TestConsensus_BowOut_UnVotesDisputes** ✅ — bowingNode votes YES on C, bows out via seqLeave; C's Yay count drops from 1 to 0 and bowingNode is gone from `Votes[bowingNode]`.
+- **TestConsensus_AvalancheThresholdRamp** ✅ — `NeededWeight` returns 50 → 65 → 70 → 95 as percentTime advances past the cutoffs; the dispute's state advances accordingly with MinRounds enforced.
+
+Bonus: `TestOnProposal_BowOutEvictsNode` and siblings (the B4 work) all still pass with the TODO(E2) resolved.
+
+### Test status
+
+- `go test ./internal/consensus/...` — all green (including the 3 new integration + 4 new unit + all prior tests).
+- `go build ./...` — clean.
+- Pre-existing failures on `feature/p2p-todos` (confirmed unchanged): `codec/binarycodec/types`, `internal/rpc`, `internal/tx/payment`, `internal/tx/vault`, `internal/testing/consensus::TestClusterNodesHaveSameGenesis`. None of these touch consensus or the TxSet interface.

--- a/tasks/pr264-round7-fixes.md
+++ b/tasks/pr264-round7-fixes.md
@@ -1,0 +1,624 @@
+# PR #264 Round-7 Fix Plan — External code-review remediation
+
+**Branch:** `feature/p2p-todos`
+**Input:** Independent external code review of the PR against `rippled` source, cross-verified task-by-task against the current worktree.
+**Goal:** Address every merge-blocker and clear-scope divergence the review flagged, leaving only the genuinely large architectural items (manifests, per-tx dispute tracking, validation archive, TLS 1.2 session-sig) to dedicated follow-up plans.
+
+---
+
+## Scope
+
+### In scope (this PR)
+
+Five phases, ~19 concrete fixes, no new subsystems. Every fix either changes behavior on an existing code path or adds a localized enforcement check.
+
+| Phase | Subsystem | Items | Severity |
+|-------|-----------|-------|----------|
+| 1     | F — ledger service adopt path | F1–F6 | HIGH (F1/F2 are the merge-blockers that undermine R5.1) |
+| 2     | B — consensus adaptor wire format | B1, B2, B3, B4, B5, B6 | MEDIUM-HIGH (wire/suppression interop) |
+| 3     | E — consensus engine | E1, E3, E6 | MEDIUM (E1 causes LedgerHash divergence on bin transitions) |
+| 4     | G — reduce-relay hardening | G2, G3, G4, G5 | MEDIUM (G3 is a self-silencing DoS surface) |
+| 5     | Cleanups | D5, C3 | LOW (mild + doc) |
+
+### Out of scope (documented, deferred to dedicated plans)
+
+| Item | Reason | Follow-up plan |
+|------|--------|----------------|
+| B7 / RPC manifest handler | Validator manifest / master-key infrastructure is multi-file, touches consensus + overlay + RPC + SLE + crypto. Needs its own spec. | `pr-manifests-round1.md` |
+| E2 per-tx dispute tracking | `DisputeTracker` already exists and is unit-tested — wiring it into `Engine.updateOurPositions` is a substantial port of `Consensus.cpp::updateOurPositions`. Separate plan. | `pr-dispute-tracking.md` |
+| E4 on-disk validation archive | DB schema change + `onStale`/`doStaleWrite` port. Separate plan. | `pr-validation-archive.md` |
+| E5 full LedgerTrie `getPreferred` | Intentional simplification documented in-code. Port is self-contained and has its own failure modes. | `pr-ledgertrie.md` |
+| C2 TLS 1.2 session-signature | Requires either a forked crypto/tls or a post-handshake protocol-level signature exchange. Documented in `handshake.go:101-111` as pre-existing. | `pr-handshake-session-sig.md` |
+| C4 remaining handshake headers (Instance-Cookie, Server-Domain, Closed-Ledger, Previous-Ledger, Remote-IP, Local-IP) | Each is individually low-impact; batch them. | `pr-handshake-headers.md` |
+| D6 SkipListAcquire + LedgerReplayTask | Catch-up speed only, not correctness. | `pr-multi-ledger-replay.md` |
+
+---
+
+## Phase 1 — Ledger service adopt path (F1–F6) [MERGE BLOCKER]
+
+The two HIGH-severity findings (F1, F2) sit in one function: `Service.AdoptLedgerWithState` at `internal/ledger/service/service.go:1409-1451`. The review established that the PR's advertised R5.1 fix (thread the tx map through peer-adopted ledgers) only reaches in-memory `ledger.Ledger`, never the RelationalDB or the txPositionIndex. Tx / account_tx / tx_history / transaction_entry RPCs silently miss every peer-adopted ledger when a relational DB is configured. R5.1's pinning test (`adopt_with_state_test.go`) only asserts the in-memory TxMap hash, which is how the gap escaped review.
+
+All six F-items touch the same function; fix them as one cohesive change.
+
+**Files:**
+- Modify: `internal/ledger/service/service.go:1409-1451` (`AdoptLedgerWithState`)
+- Modify: `internal/ledger/service/service.go:1170-1204` (`SetValidatedLedger`)
+- Modify: `internal/ledger/service/service.go` — add `tryAdvance` and `fixMismatch` helpers
+- Reference: `rippled/src/xrpld/app/ledger/detail/LedgerMaster.cpp:804-864` (`setFullLedger`), `LedgerMaster.cpp:426-427, 694, 1008` (`tryAdvance` call-sites), `LedgerMaster.cpp:849-862` (fixMismatch)
+- Test: `internal/ledger/service/adopt_with_state_test.go`
+
+### Task 1.1 (F1 + F2) — Persist peer-adopted ledgers and populate tx-index
+
+**Verified state:** The existing happy-path close at `service.go:580-593` calls `persistLedger` and `collectTransactionResults` (the latter populates `s.txIndex` + `s.txPositionIndex` via `service.go:706-722`). `AdoptLedgerWithState` ends at `return nil` (line 1450) without touching either. Rippled's `setFullLedger` at `LedgerMaster.cpp:831` calls `pendSaveValidated` and the tx-index is written as a consequence.
+
+**Fix:** After `s.ledgerHistory[h.LedgerIndex] = adopted` at line 1434, and BEFORE creating the new open ledger on top:
+
+```go
+// Persist the adopted ledger exactly as the local close path does so
+// tx/account_tx/tx_history/transaction_entry RPCs can answer queries
+// against it. Matches LedgerMaster::setFullLedger -> pendSaveValidated.
+if err := s.persistLedger(adopted); err != nil {
+    // Degrade gracefully: the in-memory state is still correct and the
+    // next consensus close will re-try persistence. Log loudly because
+    // a persistent failure breaks tx RPCs silently.
+    s.logger.Error("Failed to persist adopted ledger", "seq", h.LedgerIndex, "err", err)
+}
+
+// Populate the in-memory tx-index so tx-hash lookups resolve to this
+// seq. collectTransactionResults walks the tx map and writes to
+// s.txIndex + s.txPositionIndex as a side effect; we don't need the
+// returned results here (no subscribers to dispatch to yet — that's
+// Task 1.2).
+_ = s.collectTransactionResults(adopted, h.LedgerIndex, h.Hash)
+```
+
+**Verification (new test):**
+- `TestAdoptLedgerWithState_PersistsToRelationalDB` — configure an in-memory RelationalDB, adopt a ledger with 2 payment tx, assert `relationaldb.GetTransaction(hash)` returns both records.
+- `TestAdoptLedgerWithState_PopulatesTxIndex` — adopt a ledger with 3 tx, assert `s.txIndex[hash]` == seq for each of the 3 hashes.
+- Strengthen `adopt_with_state_test.go:62` (the existing `TxMap hash` pin) to also assert `len(s.txIndex) == N` after adoption.
+
+### Task 1.2 (F3) — Fire `eventCallback` + `hooks.OnLedgerClosed` on adopt
+
+**Verified state:** The close path at `service.go:604-655` collects `txResults` and fires both the new-style `hooks.OnLedgerClosed`/`OnTransaction` and the legacy `s.eventCallback` when the ledger transitions to closed+validated. `AdoptLedgerWithState` skips both. WebSocket `ledger` + `transactions` streams and the RPC subscription machinery see nothing for peer-adopted ledgers.
+
+**Fix:** Extract the existing hook-fire block at `service.go:629-670` into a helper `fireLedgerClosedHooksLocked(l *ledger.Ledger, txResults []TransactionResultEvent, closeTime uint32)` and call it from both `CloseLedger` and `AdoptLedgerWithState`. Peer-adopted ledgers do not have a `closeTime` from local consensus — use `adopted.CloseTime()` (already populated from the header).
+
+Key constraint: the legacy `eventCallback` is meant to fire on `validated`, not `closed`. Peer-adopted ledgers advance `closedLedger` but not `validatedLedger` (see the comment at `service.go:1431-1433`). So the adopt path:
+- Fire `hooks.OnLedgerClosed` + `hooks.OnTransaction` immediately (matches real-time progress)
+- Stash the `LedgerAcceptedEvent` in `pendingValidation` keyed by hash so `SetValidatedLedger` drains it when the ledger crosses quorum — this is the existing pattern at `service.go:1194-1203`
+
+**Verification:**
+- `TestAdoptLedgerWithState_FiresOnLedgerClosedHook` — install a mock `Hooks`, adopt, assert hook called exactly once with the expected `(info, txCount, validatedRange)`.
+- `TestAdoptLedgerWithState_StashesLegacyEventUntilValidated` — install `eventCallback`, adopt + SetValidatedLedger, assert callback fires exactly once after SetValidatedLedger.
+
+### Task 1.3 (F4) — Buffer late-arriving validations when seq not yet adopted
+
+**Verified state:** `SetValidatedLedger` at `service.go:1180-1190` does `l, ok := s.ledgerHistory[seq]; if !ok { return }`. A trusted validation for seq N that races ahead of the peer-adoption of N is silently dropped with no retry queue. Windows are small in practice but nonzero when the validation tracker leads the adoption loop.
+
+**Fix:** Introduce `s.pendingLedgerValidations map[uint32]pendingValidationEntry` where `pendingValidationEntry` stores `(expectedHash [32]byte, at time.Time)`. On `SetValidatedLedger`'s `!ok` branch, stash the (seq, expectedHash) pair with a TTL of 30s (tunable; rippled's equivalent window is the quorum gossip lag — a few seconds is enough). On every `AdoptLedgerWithState` / `CloseLedger` that inserts into `ledgerHistory`, check if `pendingLedgerValidations[seq]` is set; if so and the hash matches, promote the ledger to validated and fire the stashed event. Cap the map at 16 entries (same as the existing `pendingValidationMaxLen`) and LRU-drop.
+
+```go
+// On stash (inside SetValidatedLedger's !ok branch):
+s.pendingLedgerValidations[seq] = pendingValidationEntry{
+    expectedHash: expectedHash,
+    at:           time.Now(),
+}
+if len(s.pendingLedgerValidations) > pendingValidationMaxLen {
+    s.evictOldestPendingLedgerValidationLocked()
+}
+
+// On drain (at end of AdoptLedgerWithState and CloseLedger success):
+if pending, ok := s.pendingLedgerValidations[seq]; ok {
+    delete(s.pendingLedgerValidations, seq)
+    if time.Since(pending.at) < pendingValidationTTL &&
+        adopted.Hash() == pending.expectedHash {
+        _ = adopted.SetValidated()
+        s.validatedLedger = adopted
+        // Drain any event the stashing path couldn't fire
+        // (SetValidatedLedger only stashes in pendingValidation
+        // when the ledger is already present — the adopt-first
+        // path doesn't need a separate event).
+    }
+}
+```
+
+**Verification:**
+- `TestSetValidatedLedger_StashesWhenSeqMissing_FiresOnAdopt` — call SetValidatedLedger(100, h), then AdoptLedgerWithState for seq=100 hash=h, assert validatedLedger == seq 100.
+- `TestSetValidatedLedger_StashExpires` — stash with a fake clock, advance past TTL, adopt, assert validatedLedger NOT promoted.
+- `TestSetValidatedLedger_StashHashMismatch` — stash hash A, adopt hash B at same seq, assert NOT promoted.
+
+### Task 1.4 (F5) — `fixMismatch` equivalent for adopted-ledger parent-hash drift
+
+**Verified state:** `service.go:1434` does `s.ledgerHistory[h.LedgerIndex] = adopted` unconditionally. If the slot already held a different ledger (e.g., we closed locally and the network adopted a different one), the old entry is blindly overwritten. Rippled's `setFullLedger` at `LedgerMaster.cpp:849-862` compares `prevLedger.hash()` to `ledger.parentHash()` and calls `fixMismatch` to invalidate the tail of the history when they diverge.
+
+**Fix:** Add `func (s *Service) fixMismatchLocked(adopted *ledger.Ledger)` that:
+1. If `prev := s.ledgerHistory[adopted.Sequence()-1]` exists and `prev.Hash() != adopted.ParentHash()`, walk backward from `adopted.Sequence()-1` deleting entries until we find a prefix whose forward chain is consistent with `adopted`.
+2. Before the walk, log a WARN with all deleted seqs + hashes — a fixMismatch hit is rare and operationally significant.
+
+Call `fixMismatchLocked(adopted)` from `AdoptLedgerWithState` BEFORE the `s.ledgerHistory[h.LedgerIndex] = adopted` assignment.
+
+**Verification:**
+- `TestAdoptLedgerWithState_FixMismatchInvalidatesDivergedTail` — seed ledgerHistory with a 3-ledger chain {A1,B2,C3}, adopt a ledger D3 whose parentHash is a hash not equal to B2.Hash(), assert B2 and C3 are purged from history and D3 is installed.
+- `TestAdoptLedgerWithState_NoMismatchNoOp` — adopt a ledger whose parent exists with matching hash, assert history unchanged apart from the new seq.
+
+### Task 1.5 (F6) — `tryAdvance` cascade after adoption
+
+**Verified state:** `tasks/pr264-round5-fixes.md:426` already carries an internal TODO acknowledging this gap. Out-of-order replay-delta completions (seq N+2 arriving before seq N+1) cannot trigger follow-on adoption today — each ledger must be explicitly delivered by the inbound replay loop in order.
+
+**Fix:** Add an orphan map `s.heldAdoptions map[uint32]*pendingAdopt` keyed by the awaited **parent** seq (i.e., `seq-1`). When `AdoptLedgerWithState` succeeds for seq N, look up `s.heldAdoptions[N]` and recurse (bounded to 256 levels to cap fork storms). Entries older than 60s are evicted on every adopt call. Entries whose parent hash doesn't match the just-adopted ledger's hash are dropped.
+
+The orphan queue is deliberately flat (no multi-hop): replay-delta is single-ledger-per-request; multi-ledger backward walks are out of scope (D6).
+
+**Verification:**
+- `TestAdoptLedgerWithState_CascadesHeldOrphan` — submit seq=102 parent-of-101 as held, then adopt seq=101 whose hash matches the held parent reference, assert 102 is adopted in the same call.
+- `TestAdoptLedgerWithState_OrphanMismatchDropped` — submit seq=102 parent=X, adopt seq=101 hash=Y (≠X), assert 102 is dropped and not re-adopted.
+
+---
+
+## Phase 2 — Consensus adaptor wire format (B1–B6)
+
+### Task 2.1 (B1) — Gate sfCookie / sfServerVersion on `featureHardenedValidations`
+
+**Files:**
+- Modify: `internal/consensus/rcl/engine.go:1602-1698` (`sendValidation`)
+- Modify: `internal/consensus/adaptor/stvalidation.go:308-319` (serializer gates)
+- Reference: `rippled/src/xrpld/app/consensus/RCLConsensus.cpp:853-867`
+
+**Verified state:** `rcl/engine.go:1610-1611, 1633-1634` always populates `Cookie` and `ServerVersion`. The serializer at `stvalidation.go:309, 317` emits whenever non-zero. Rippled only emits both under HardenedValidations, and ServerVersion additionally only on voting-ledgers. On any pre-HardenedValidations ruleset a goXRPL validation's signing preimage differs byte-for-byte from an equivalent rippled validation.
+
+**Fix:** In `sendValidation`, replace the unconditional population at lines 1633-1634 with:
+
+```go
+if e.adaptor.IsFeatureEnabled("HardenedValidations") {
+    validation.Cookie = cookie
+    if isVotingLedger(ledger.Seq()) {
+        validation.ServerVersion = serverVersion
+    }
+}
+```
+
+Remove the `if cookie == 0` / `if serverVersion == 0` warn-on-violation blocks at lines 1619-1624 — the R5.10 invariant no longer applies; zero is legitimate when HardenedValidations is off. Adjust the warning text + move it to the HardenedValidations branch so we warn when HV is on but values are still zero.
+
+The serializer already short-circuits on zero, so no change there is strictly needed. Keep both gates (caller + serializer) — defense in depth.
+
+**Verification:**
+- `TestSendValidation_PreHardenedValidations_OmitsCookieAndServerVersion` — feature disabled, assert `validation.Cookie == 0` and `validation.ServerVersion == 0` on the emitted struct (serializer will omit).
+- `TestSendValidation_HardenedValidations_NonVotingLedger_OmitsServerVersion` — feature enabled, seq=100 (non-voting), assert Cookie set, ServerVersion zero.
+- `TestSendValidation_HardenedValidations_VotingLedger_EmitsBoth` — feature enabled, seq=255 (voting), assert both populated.
+
+### Task 2.2 (B2) — Change suppression-hash domain to match rippled's `proposalUniqueId` / `sha512Half(val->serialized)`
+
+**Files:**
+- Modify: `internal/consensus/adaptor/router_dedup.go:17` (`hashPayload`)
+- Modify: `internal/consensus/adaptor/router.go` — call sites that feed hashPayload (grep for `hashPayload(` — proposal + validation handlers)
+- Reference: `rippled/src/xrpld/overlay/detail/PeerImp.cpp:1722-1728` (proposal), `PeerImp.cpp:2374` (validation)
+
+**Verified state:** `hashPayload` takes the raw decompressed protobuf payload and sha512Half's it. Rippled:
+- Proposal: `sha512Half(proposalUniqueId(proposeHash, prevLedger, proposeSeq, closeTime, pubkey, sig))` — a tuple of the *decoded* semantic fields, not the wire bytes.
+- Validation: `sha512Half(val->serialized)` — the canonical STValidation blob *inside* the TMValidation, NOT the TMValidation protobuf envelope.
+
+In practice: any semantically-identical message whose protobuf serializer reorders optional fields or includes/omits a default-valued field produces a different `hashPayload` in Go but the same rippled suppression key. Across mixed Go/rippled peers the dedup desynchronizes.
+
+**Fix:** Replace `hashPayload` with two specialized hash functions:
+
+```go
+// hashProposalSuppression returns the suppression key for a TMProposeSet.
+// Matches rippled proposalUniqueId: sha512Half(proposeHash || prevLedger
+// || proposeSeq || closeTime || pubkey || sig).
+func hashProposalSuppression(p *consensus.Proposal) [32]byte {
+    h := common.NewSha512Half()
+    h.Write(p.Position[:])
+    h.Write(p.PreviousLedger[:])
+    binary.Write(h, binary.BigEndian, p.ProposeSeq)
+    binary.Write(h, binary.BigEndian, p.CloseTime.Unix())
+    h.Write(p.NodePubKey)
+    h.Write(p.Signature)
+    return h.Sum()
+}
+
+// hashValidationSuppression returns the suppression key for a
+// TMValidation. Matches rippled sha512Half(val->serialized) — the
+// hash of the canonical STValidation blob, NOT the TMValidation
+// protobuf envelope.
+func hashValidationSuppression(serializedSTValidation []byte) [32]byte {
+    return common.Sha512Half(serializedSTValidation)
+}
+```
+
+Then update `handleProposal` / `handleValidation` in `router.go` to call the appropriate function with the *decoded* fields (proposal) or the inner serialized blob (validation) rather than `msg.Payload`.
+
+**Verification:**
+- `TestSuppression_ProposalSemanticIdentity_SameHash` — construct two protobuf payloads that round-trip to the same Proposal struct but differ byte-for-byte (e.g., optional `load_fee` omitted vs present-and-default); assert hashProposalSuppression returns the same value.
+- `TestSuppression_ValidationInnerBlobDomain_SameHash` — same logic for validations.
+- Cross-check against a captured rippled proposal/validation pair (fixture): assert hash matches rippled's expected value.
+
+### Task 2.3 (B3) — Feed reduce-relay slot with full relay target set
+
+**Files:**
+- Modify: `internal/consensus/adaptor/router.go:313-315, 360-362` (`UpdateRelaySlot` call sites)
+- Modify: `internal/peermanagement/relay.go` — extend `UpdateRelaySlot` signature to accept a set of peer IDs
+- Reference: `rippled/src/xrpld/overlay/detail/PeerImp.cpp:3010-3054`
+
+**Verified state:** `UpdateRelaySlot(nodeID, originPeer)` feeds one peer per received message. Rippled computes `haveMessage := overlay().relay(msg, suppressionKey)` and passes the whole set to `updateSlotAndSquelch` so peers that already claimed to have the message also count as "evidence of multi-path delivery" for selection purposes. Reduce-relay selection on goXRPL converges more slowly as a result.
+
+**Fix:**
+1. Change `UpdateRelaySlot` from `(validator NodeID, peer PeerID)` to `(validator NodeID, originPeer PeerID, seenPeers []PeerID)`.
+2. In `router.go`, after observing a duplicate (the `firstSeen == false` branch of `messageSuppression.observe`), also enumerate the `peermanagement.Overlay.PeersThatHave(suppressionKey)` call — this is new; implement it as a reverse index from suppressionKey → peerIDs in `overlay.go`, populated during the relay-forward pass (where we already know which peers the message went to).
+3. Pass that slice into `UpdateRelaySlot`. Slot.Update iterates the set and calls the counter increment per peer.
+
+**Verification:**
+- `TestRelay_DuplicateArrivalFeedsAllKnownRelayers` — seed the overlay with a "seen" entry mapping suppressionKey K → peers {A,B}, receive the same message from peer C; assert validator's slot has incremented counters for A, B, and C.
+- `TestRelay_FirstSeenMessageDoesNotFeedSlot` — receive a message with no prior suppression entry; assert slot is not fed (matches rippled PeerImp.cpp:1730's `!added` branch).
+
+### Task 2.4 (B4) — Detect `isBowOut` (seqLeave == 0xFFFFFFFF) and evict bowed-out validators
+
+**Files:**
+- Modify: `internal/consensus/rcl/engine.go:295-367` (`OnProposal`)
+- Modify: `internal/consensus/rcl/engine.go` — add `deadNodes` field + eviction hook
+- Reference: `rippled/src/xrpld/consensus/Consensus.h:804-817`, `rippled/src/xrpld/consensus/ConsensusProposal.h:68,154-156`
+
+**Verified state:** No bowOut/seqLeave/deadNodes anywhere in goXRPL. A validator that bows out by emitting a position with `seqJoin == 0xFFFFFFFF` (rippled's `seqLeave` constant) has its final position persisted in the proposal map forever — it keeps "voting" on every subsequent round until the node restarts.
+
+**Fix:** In `OnProposal`, after bounds checks and before storing:
+
+```go
+// isBowOut: rippled ConsensusProposal.h:154-156. A validator bowing
+// out sets ProposeSeq to seqLeave (0xFFFFFFFF) on its final position
+// so peers know to stop counting them.
+const seqLeave = uint32(0xFFFFFFFF)
+if proposal.ProposeSeq == seqLeave {
+    e.peerProposals.Delete(proposal.NodeID)
+    e.deadNodes[proposal.NodeID] = struct{}{}
+    // Un-vote this node's contributions from any active disputes —
+    // placeholder for when E2 (per-tx dispute tracking) lands.
+    return
+}
+if _, dead := e.deadNodes[proposal.NodeID]; dead {
+    // Defer any further proposals from this node until the next
+    // consensus round clears deadNodes.
+    return
+}
+```
+
+Clear `e.deadNodes` in `Engine.startRound` alongside the existing position resets.
+
+**Verification:**
+- `TestOnProposal_BowOutEvictsNode` — feed a valid proposal from node X, then feed a seqLeave proposal from X; assert `peerProposals.Get(X)` is nil.
+- `TestOnProposal_DeadNodeLaterProposalIgnored` — after bow-out, feed a normal proposal from X; assert it's not stored.
+- `TestStartRound_ClearsDeadNodes` — after bow-out, call StartRound, feed a proposal; assert it IS accepted.
+
+### Task 2.5 (B5) — Enforce monotonic signTime
+
+**Files:**
+- Modify: `internal/consensus/rcl/engine.go:1602-1640` (`sendValidation`)
+- Reference: `rippled/src/xrpld/app/consensus/RCLConsensus.cpp:825-828`
+
+**Verified state:** `SignTime = e.adaptor.Now()` is set directly. If the adaptor clock regresses (NTP step, leap-second correction, VM pause/resume) the emitted signTime can be older than the previous validation from the same node, causing peers to treat it as stale (`rcl/validations.go:184`).
+
+**Fix:** Add `lastSignTime` field to `Engine`:
+
+```go
+type Engine struct {
+    // ... existing fields ...
+    lastSignTime time.Time // monotonic floor for sendValidation
+}
+
+// Inside sendValidation, after computing signTime:
+signTime := e.adaptor.Now()
+if !e.lastSignTime.IsZero() && !signTime.After(e.lastSignTime) {
+    // Clock regressed — step forward 1s from the prior emission to
+    // preserve monotonicity. Matches RCLConsensus.cpp:826.
+    signTime = e.lastSignTime.Add(1 * time.Second)
+}
+e.lastSignTime = signTime
+validation.SignTime = signTime
+validation.SeenTime = signTime // (was also Now()); keep them equal as today
+```
+
+**Verification:**
+- `TestSendValidation_ClockRegressionPreservesMonotonic` — use a fake clock, call sendValidation, step clock backward 5s, call again; assert the second SignTime == first + 1s.
+- `TestSendValidation_ClockMonotonic_NormalCase` — fake clock forward 3s between two calls, assert SignTime difference is 3s (no artificial step).
+
+### Task 2.6 (B6) — Explicitly reject non-secp256k1 (ed25519 / 0xED) pubkey on TMProposeSet
+
+**Files:**
+- Modify: `internal/consensus/adaptor/router.go:370-387` (`validateProposeBounds`)
+- Reference: `rippled/src/xrpld/overlay/detail/PeerImp.cpp:1679-1680`
+
+**Verified state:** The length check at line 383 passes both 33-byte secp256k1 compressed points AND 33-byte ed25519 points (0xED prefix + 32-byte key). VerifyProposal may still reject, but the malformed-bounds fee-charge path currently lets the peer slip through without attribution.
+
+**Fix:** Replace the length-only check with a KeyType check:
+
+```go
+// Proposal pubkeys must be compressed secp256k1 (0x02/0x03 prefix).
+// ed25519 validators (0xED prefix) are not allowed in propose-set
+// per rippled PeerImp.cpp:1679 (publicKeyType != KeyType::secp256k1).
+if len(p.NodePubKey) != 33 {
+    return "pubkey-size", false
+}
+if p.NodePubKey[0] != 0x02 && p.NodePubKey[0] != 0x03 {
+    return "pubkey-type", false
+}
+```
+
+**Verification:**
+- `TestValidateProposeBounds_RejectsEd25519Prefix` — construct a Proposal with NodePubKey = 0xED || 32 bytes; assert `("pubkey-type", false)`.
+- `TestValidateProposeBounds_AcceptsSecp256k1Prefix` — 0x02/0x03 prefix + 32 bytes; assert `("", true)`.
+- `TestHandleProposal_Ed25519PubKeyChargesPeer` — end-to-end: feed a TMProposeSet with ed25519 pubkey, assert `IncPeerBadData` was called with `"propose-pubkey-type"`.
+
+---
+
+## Phase 3 — Consensus engine (E1, E3, E6)
+
+### Task 3.1 (E1) — Dynamic `getNextLedgerTimeResolution`
+
+**Files:**
+- Modify: `internal/ledger/ledger.go:147` (static `CloseTimeResolution: parent.header.CloseTimeResolution`)
+- Add: `internal/consensus/ledger_timing.go` — new file hosting `getNextLedgerTimeResolution`
+- Reference: `rippled/src/xrpld/consensus/LedgerTiming.h:80-122`
+
+**Verified state:** goXRPL inherits the parent's resolution unchanged on every close. Rippled steps the resolution up/down based on `ledgerSeq % decreaseLedgerTimeResolutionEvery` and whether `previousAgree` was true. At bin transitions (every N ledgers) the resolution changes; goXRPL peers compute a different CloseTime (truncated to a different resolution) and the resulting LedgerHash diverges from mainnet/testnet rippled peers.
+
+**Fix:** Port `getNextLedgerTimeResolution`:
+
+```go
+// ledger_timing.go
+package consensus
+
+import "time"
+
+// Possible resolutions in seconds, ordered coarsest first. Matches
+// rippled LedgerTiming.h:35 ledgerPossibleTimeResolutions.
+var possibleTimeResolutions = []uint32{10, 20, 30, 60, 90, 120}
+
+const (
+    // Every N seqs, try to step the resolution in the direction
+    // chosen by whether the previous round agreed.
+    increaseLedgerTimeResolutionEvery = 8
+    decreaseLedgerTimeResolutionEvery = 1
+)
+
+// GetNextLedgerTimeResolution returns the close-time resolution to
+// use for (parent.LedgerSeq+1) given whether the previous round
+// agreed. Matches rippled LedgerTiming.h:80-122.
+func GetNextLedgerTimeResolution(parentRes uint32, previousAgree bool, newLedgerSeq uint32) uint32 {
+    idx := 0
+    for i, r := range possibleTimeResolutions {
+        if r == parentRes {
+            idx = i
+            break
+        }
+    }
+    if !previousAgree && newLedgerSeq%decreaseLedgerTimeResolutionEvery == 0 {
+        if idx+1 < len(possibleTimeResolutions) {
+            idx++ // coarser (slower convergence tolerated)
+        }
+    }
+    if previousAgree && newLedgerSeq%increaseLedgerTimeResolutionEvery == 0 {
+        if idx > 0 {
+            idx-- // finer (tighter convergence required)
+        }
+    }
+    return possibleTimeResolutions[idx]
+}
+```
+
+Then at `ledger.go:147`, pass `previousAgree` through from the consensus adaptor (it's tracked in the engine) and call `GetNextLedgerTimeResolution(parent.CloseTimeResolution, previousAgree, newLedgerSeq)`.
+
+**Verification (cross-reference tests):**
+- `TestGetNextLedgerTimeResolution_ParityTable` — parameterize against the exact same (parentRes, previousAgree, newSeq) tuples rippled unit tests use; assert identical output.
+- `TestLedger_Close_UsesDynamicResolution` — build a parent at res=30 with previousAgree=true and newSeq=8; assert child's CloseTimeResolution is 20.
+
+### Task 3.2 (E3) — Add `LedgerABANDON_CONSENSUS` hard timeout
+
+**Files:**
+- Modify: `internal/consensus/types.go:351` (constants)
+- Modify: `internal/consensus/rcl/engine.go:1095-1103` (consensus phase timeout check)
+- Reference: `rippled/src/xrpld/consensus/ConsensusParms.h:95,105,113`, `rippled/src/xrpld/consensus/Consensus.cpp:254-258`
+
+**Verified state:** Only hard timeout is `LedgerMaxClose = 10s`. Rippled has BOTH `ledgerMAX_CONSENSUS=15s` (soft) and `ledgerABANDON_CONSENSUS=120s` (hard, with `ledgerABANDON_CONSENSUS_FACTOR=10` multiplier). goXRPL drops out of establish 5s earlier than rippled's 15s-soft and doesn't have a 120s abandon safety net at all.
+
+**Fix:**
+1. In `types.go:351`, add:
+   ```go
+   LedgerMaxConsensus       = 15 * time.Second  // was LedgerMaxClose=10s; keep LedgerMaxClose as the old alias for now
+   LedgerAbandonConsensus   = 120 * time.Second
+   LedgerAbandonConsensusFactor = 10
+   ```
+   Keep `LedgerMaxClose` as an alias but migrate its call-sites to `LedgerMaxConsensus`.
+2. In the consensus phase timer in `rcl/engine.go`, add a second branch: if `now - phaseStart > LedgerAbandonConsensus` or `> LedgerMaxConsensus * LedgerAbandonConsensusFactor`, mark the consensus as abandoned — the engine transitions to a new round with an empty set instead of attempting to close on stale state.
+
+**Verification:**
+- `TestConsensus_MaxConsensusSoftTimeoutTransitions` — simulate time past LedgerMaxConsensus (15s), assert phase transitions (no hard abort).
+- `TestConsensus_AbandonHardTimeout` — simulate 121s, assert abandonment state entered.
+
+### Task 3.3 (E6) — Rename `MinConsensusPct` / `MaxConsensusPct` to match rippled terminology
+
+**Files:**
+- Modify: `internal/consensus/types.go:375-377`
+- Modify: call-sites in `internal/consensus/rcl/engine.go:1153, 1170`
+- Reference: `rippled/src/xrpld/consensus/ConsensusParms.h:79`
+
+**Verified state:** Rippled has a single `minCONSENSUS_PCT = 80`. goXRPL has two constants:
+- `MinConsensusPct = 50` (early convergence gate)
+- `MaxConsensusPct = 80` (accept gate)
+
+The review calls this "inverted" — strictly, it's "renamed plus an extra lower threshold". The 80% accept gate is arithmetically identical to rippled.
+
+**Fix:** Rename to clarify the two-threshold nature without implying an inversion relative to rippled:
+- `MinConsensusPct` → `EarlyConvergencePct` (the 50% threshold)
+- `MaxConsensusPct` → `MinConsensusPct` (the 80% threshold, matching rippled's `minCONSENSUS_PCT`)
+
+Update both call sites. This is a mechanical rename; the arithmetic is unchanged.
+
+**Verification:** Existing consensus tests must continue to pass. Add a doc comment at the constant declarations citing rippled's `minCONSENSUS_PCT = 80` so the relationship is explicit.
+
+---
+
+## Phase 4 — Reduce-relay hardening (G2–G5)
+
+### Task 4.1 (G2) — Periodic `deleteIdlePeers` sweep
+
+**Files:**
+- Modify: `internal/peermanagement/relay.go` — add ticker + sweep method
+- Modify: `internal/peermanagement/overlay.go` — start the ticker in `Overlay.Start`
+- Reference: `rippled/src/xrpld/overlay/Slot.h:264-283`, `rippled/src/xrpld/overlay/detail/OverlayImpl.cpp:1472-1479`
+
+**Verified state:** `r.slots` only shrinks on explicit `RemovePeer` (disconnect). Selected peers that stop relaying are never demoted back to Counting; slots accumulate entries for validators we no longer see.
+
+**Fix:** Add `func (r *Relay) deleteIdlePeers(now time.Time)` that iterates `r.slots`, and inside each slot:
+- Walks peers, removes any with `now - lastMessage > Idled` (8s, existing constant `reduce_relay_common.go`).
+- If the slot transitions to fewer peers than `MaxSelectedPeers` and was in Selected state, demote to Counting.
+- After the walk, if the slot has zero peers, delete it from `r.slots`.
+
+Wire a `time.Ticker` at `Idled/2` cadence (4s) in `Overlay.Start` that calls `r.deleteIdlePeers(time.Now())`. Stop the ticker in `Overlay.Stop`.
+
+**Verification:**
+- `TestRelay_DeleteIdlePeers_EvictsStaleEntries` — add a peer, advance fake clock past Idled, call deleteIdlePeers, assert peer removed.
+- `TestRelay_DeleteIdlePeers_DemotesSelectedBelowQuorum` — add 5 selected peers, idle 3 of them out, call deleteIdlePeers, assert slot state transitioned from Selected to Counting.
+
+### Task 4.2 (G3) — Filter inbound TMSquelch targeting our own validator pubkey
+
+**Files:**
+- Modify: `internal/peermanagement/overlay.go:820-857` (`handleSquelchMessage`)
+- Reference: `rippled/src/xrpld/overlay/detail/PeerImp.cpp:2715-2721`
+
+**Verified state:** No comparison between `sq.ValidatorPubKey` and the local validator pubkey. A peer can send us a TMSquelch targeting our own validator pubkey, and we'll obediently stop relaying our own validator's proposals/validations — a self-silencing DoS surface.
+
+**Fix:** Right after the 33-byte length check at line 835, add:
+
+```go
+// Rippled PeerImp.cpp:2715-2721 drops any inbound squelch whose
+// target pubkey is our own validator — otherwise a peer could
+// silence our own traffic on our RelayFromValidator path.
+if ownPubKey := o.localValidatorPubKey(); len(ownPubKey) == 33 && bytes.Equal(sq.ValidatorPubKey, ownPubKey) {
+    slog.Debug("Squelch dropped: targets local validator",
+        "t", "Overlay", "peer", evt.PeerID)
+    o.IncPeerBadData(evt.PeerID, "squelch-targets-self")
+    return
+}
+```
+
+Add `localValidatorPubKey()` as a passthrough to the existing validator identity (already threaded through the adaptor for signing).
+
+**Verification:**
+- `TestHandleSquelchMessage_DropsSelfTargetingSquelch` — configure local validator pubkey P, feed a TMSquelch with ValidatorPubKey=P; assert peer charged with `"squelch-targets-self"` and AddSquelch NOT called.
+- `TestHandleSquelchMessage_AllowsOtherValidatorSquelch` — same test but ValidatorPubKey=Q (≠P); assert AddSquelch called.
+
+### Task 4.3 (G4) — Charge peers that keep relaying after being squelched
+
+**Files:**
+- Modify: `internal/peermanagement/relay.go:83-130` (`ValidatorSlot.Update` — extend signature to accept a charge callback)
+- Modify: `internal/peermanagement/overlay.go` — wire the callback to `IncPeerBadData(peer, "squelch-ignored")`
+- Reference: `rippled/src/xrpld/overlay/Slot.h:113,158,291,329-331`
+
+**Verified state:** `ValidatorSlot.Update` returns silently at `relay.go:110` when the peer's state is `RelayPeerSquelched`. Rippled invokes an `ignored_squelch_callback` at `Slot.h:329-331` that wires into `feeUselessData`-style reputation charges — a peer that ignores our squelch bleeds reputation until it's disconnected.
+
+**Fix:**
+1. Extend `ValidatorSlot.Update` to accept `ignoredCallback func(peerID PeerID)`.
+2. At the `peer.State == RelayPeerSquelched` branch (relay.go:110), call `ignoredCallback(peerID)` before returning.
+3. In `Relay.OnMessage` / its callers in `overlay.go`, pass a closure that calls `o.IncPeerBadData(peer, "squelch-ignored")`.
+
+**Verification:**
+- `TestRelay_SquelchedPeerRelayChargesPeer` — squelch peer P, feed a validator message from P; assert `IncPeerBadData(P, "squelch-ignored")` called exactly once.
+- `TestRelay_UnsquelchedPeerRelayDoesNotCharge` — baseline: unsquelched peer relaying does not trigger the charge.
+
+### Task 4.4 (G5) — Change `EnableReduceRelay` default to `false`
+
+**Files:**
+- Modify: `internal/peermanagement/config.go:99,273-275` (default + cascade)
+- Reference: `rippled/src/xrpld/core/Config.h:248`, `rippled/src/xrpld/core/detail/Config.cpp:758-762`
+
+**Verified state:** `config.go:99` sets `EnableReduceRelay: true` in DefaultConfig, cascading to `EnableVPReduceRelay=true` + `EnableTxReduceRelay=true`. Rippled defaults all three to `false`. Stock goXRPL on a stock rippled network will advertise vprr+txrr and engage slot squelching aggressively, diverging from default peer behavior.
+
+**Fix:**
+1. Flip the three defaults in `DefaultConfig` to `false`.
+2. Update any integration / E2E test that depended on the old default — search with `grep -r "EnableReduceRelay" internal/` and explicitly set `true` where the test is meant to exercise reduce-relay.
+3. Update the CLI / config-file documentation to note that reduce-relay is opt-in.
+
+**Verification:**
+- `TestDefaultConfig_ReduceRelayOptIn` — construct DefaultConfig(), assert all three fields are false.
+- Grep for existing tests that silently relied on the default and confirm they either explicitly enable or don't care about reduce-relay behavior.
+
+---
+
+## Phase 5 — Cleanups (D5, C3)
+
+### Task 5.1 (D5) — Install peer-supplied leaf only on `applied==true`
+
+**Files:**
+- Modify: `internal/ledger/inbound/replay_delta.go:627-676` (apply switch)
+- Reference: `rippled/src/xrpld/app/tx/detail/Transactor.cpp:1108,1215-1267`, `rippled/src/xrpld/app/ledger/detail/BuildLedger.cpp:246`
+
+**Verified state:** The review's mild-accidental finding: the switch at lines 627-676 installs the peer-supplied tx+meta leaf on tes / tec / terRETRY / tef / tem / tel alike. Rippled only `rawTxInsert`s when `applied == true` (i.e., tes or tec). On tef/tem/tel/ter, rippled silently drops the tx from the view's txs_; goXRPL preserves it to keep TxHash == header.TxHash. The AccountHash invariant check at line 708 is a safety net.
+
+This is a genuine divergence but catches on the AccountHash check in practice. Tightening it removes the safety-net dependency.
+
+**Fix:** Restructure the switch so only tes/tec install the peer leaf from the engine path. For tef/tem/tel/ter, compare the peer-supplied leaf hash to what the engine would have produced (empty); if they differ, log a WARN and fail the whole replay so the AccountHash check's safety-net role shrinks to AccountHash-only.
+
+The honest option: if the engine disagrees with the peer on whether a tx applies at all, the AccountHash will diverge anyway — we gain nothing by preserving the tx leaf. Drop it.
+
+**Verification:**
+- `TestReplay_TefTxDoesNotInstallPeerLeaf` — construct a replay scenario where the peer's tx map has a tx the engine rejects with tef; assert replay fails loudly (hash mismatch logged) rather than silently succeeding via the peer-leaf path.
+- Confirm existing replay success tests still pass (tes / tec unchanged).
+
+### Task 5.2 (C3) — Fix round-2 commit message / TMSquelch gating comment
+
+**Files:**
+- Modify: `internal/peermanagement/overlay.go:636-644` (comment block)
+- Optional: Amend commit `1bf57e3` message via a new revert-and-re-commit OR add a clarifying commit on top
+
+**Verified state:** Commit `1bf57e3` message says "Inbound TMSquelch gated on vpReduceRelay; unnegotiated peers charged and dropped". The code at `overlay.go:645-654` accepts unconditionally; the comment above even acknowledges the contradiction with the commit.
+
+**Fix:** Reconcile code-with-intent. The right answer is the unconditional-accept one (rippled accepts unconditionally too), so the commit message is what's wrong:
+1. Rewrite the comment block at lines 636-644 to state plainly: "Inbound TMSquelch is accepted unconditionally. Rippled PeerImp.cpp:2684-2721 does the same — there is no per-peer gating on vpReduceRelay for incoming squelches. The round-2 commit message was inaccurate and this comment documents the correct behavior."
+2. In the PR description, add a clarification noting the commit message inaccuracy.
+
+No tests needed; this is a comment-only change.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- F1–F6 → Phase 1 (five tasks)
+- B1, B2, B3, B4, B5, B6 → Phase 2 (six tasks)
+- E1, E3, E6 → Phase 3 (three tasks)
+- G2, G3, G4, G5 → Phase 4 (four tasks)
+- D5, C3 → Phase 5 (two tasks)
+- B7, E2, E4, E5, C2, C4 (partial), D6 → explicitly deferred, listed in Scope with follow-up plan references
+
+**Placeholders:** None. Every fix includes concrete code or concrete enumeration of what changes where.
+
+**Type consistency:** Renames in 3.3 (MinConsensusPct → EarlyConvergencePct, MaxConsensusPct → MinConsensusPct) must be applied simultaneously in all three locations listed. The `pendingValidationEntry` introduced in 1.3 is only used in 1.3. `deadNodes` introduced in 2.4 is only used in 2.4. `hashProposalSuppression` / `hashValidationSuppression` in 2.2 replace a single `hashPayload` callsite.
+
+**Execution order:** Phase 1 is the merge-blocker and should land first. Phases 2–4 are independent of each other and can interleave. Phase 5 can land alongside any of them. Within Phase 1, Task 1.1 (persist + tx-index) is the critical one; 1.2–1.5 can batch into a second commit.
+
+---
+
+## Commit strategy
+
+Per `goXRPL/CLAUDE.md`: "Never mention yourself when committing."
+
+Proposed commit series (one per task, to match the existing PR-audit cadence):
+
+1. `feat(ledger/service): persist peer-adopted ledgers and populate tx index (F1,F2)`
+2. `feat(ledger/service): fire OnLedgerClosed hooks on peer adoption (F3)`
+3. `feat(ledger/service): buffer late validations until adopt (F4)`
+4. `feat(ledger/service): invalidate history tail on adopt parent-hash mismatch (F5)`
+5. `feat(ledger/service): cascade held adoptions after parent arrives (F6)`
+6. `fix(consensus/adaptor): gate sfCookie/sfServerVersion on HardenedValidations (B1)`
+7. `fix(consensus/adaptor): hash suppression keys in rippled's domain (B2)`
+8. `feat(consensus/adaptor): feed relay slot with full seen-peer set (B3)`
+9. `feat(consensus/rcl): evict bowed-out validators (B4)`
+10. `fix(consensus/rcl): enforce monotonic signTime (B5)`
+11. `fix(consensus/adaptor): reject ed25519 pubkey on proposals (B6)`
+12. `feat(consensus): dynamic getNextLedgerTimeResolution (E1)`
+13. `feat(consensus): add ledgerABANDON_CONSENSUS hard timeout (E3)`
+14. `refactor(consensus): rename consensus-pct constants to match rippled (E6)`
+15. `feat(peermanagement/relay): periodic deleteIdlePeers sweep (G2)`
+16. `fix(peermanagement/overlay): drop squelches targeting our own validator (G3)`
+17. `feat(peermanagement/relay): charge peers that ignore our squelch (G4)`
+18. `fix(peermanagement/config): default reduce-relay off to match rippled (G5)`
+19. `fix(ledger/inbound): install peer leaf only on applied==true (D5)`
+20. `docs(peermanagement): reconcile TMSquelch gating comment with code (C3)`


### PR DESCRIPTION
## Summary

Wires the consensus engine's dispute tracker end-to-end so overlapping-but-different proposed tx sets converge via rippled-style per-tx re-voting instead of the whole-set popularity gate that previously lived in `checkConvergence`. Resolves the TODO(E2) left by the B4 bow-out commit.

Closes #266.

- `DisputedTx` gains a per-peer `Votes` map + per-dispute avalanche state; `DisputeTracker` reworked around the rippled contract (`SetVote`, `UnVote`, `UpdateDisputes`, `UpdateOurVote`).
- New `ConsensusParms` with the `{init:50, mid:65, late:70, stuck:95}` cutoff table and `NeededWeight` helper.
- `Engine` now owns `acquiredTxSets` / `comparesTxSets` / `peerUnchangedCounter` / `establishCounter`, plus the dispute tracker; `closeLedger`, `OnProposal`, `OnTxSet` wire dispute create/update; `updatePosition` rewritten to re-vote each dispute and rebuild our tx set from the current set ± flips; `checkConvergence` now uses rippled's `haveConsensus` position-agreement tally.
- Bow-out arm calls `disputeTracker.UnVote(peerID)`.
- `TxSet` interface gains `TxIDs()` (documented to zip with `Txs()`).

## Test plan

Acceptance tests from issue #266 (in `internal/consensus/rcl/disputes_test.go`):

- [x] `TestConsensus_OverlappingDisjointProposals_Converges` — peers split between `{A,B,C}` and `{A,B,D}`; engine disputes C and D, votes both in after threshold ramps, final `ourTxSet` is `{A,B,C,D}`.
- [x] `TestConsensus_BowOut_UnVotesDisputes` — node X votes YES on C, sends `seqLeave`; C's Yay count decrements by one and X is gone from the per-dispute `Votes` map.
- [x] `TestConsensus_AvalancheThresholdRamp` — `NeededWeight` returns `50 → 65 → 70 → 95` as `percentTime` crosses the cutoffs.

Unit tests for the reworked `DisputeTracker` (`proposals_test.go`):

- [x] `TestDisputeTracker_CreateAndVote`, `TestDisputeTracker_UnVote`, `TestDisputeTracker_UpdateDisputes`, `TestDisputeTracker_UpdateOurVote_AvalancheRamp`.

Regression:

- [x] `go build ./...` clean.
- [x] `go test ./internal/consensus/...` all green (new tests + every prior rcl test, including the `TestOnProposal_BowOut*` suite from B4).

Pre-existing failures on `feature/p2p-todos` in `codec/binarycodec/types`, `internal/rpc`, `internal/tx/{payment,vault}`, and `internal/testing/consensus::TestClusterNodesHaveSameGenesis` are unrelated and continue to fail identically on this branch.

## References

- `rippled/src/xrpld/consensus/DisputedTx.h` — per-peer `Map_t votes_`, avalanche state, `updateVote`, `setVote`, `unVote`.
- `rippled/src/xrpld/consensus/ConsensusParms.h` — avalanche cutoffs, `getNeededWeight`.
- `rippled/src/xrpld/consensus/Consensus.h` — `createDisputes`, `updateDisputes`, `updateOurPositions`, `haveConsensus`, `isBowOut`/`unVote` handling at 804-817.

Plan: [`tasks/pr-dispute-tracking.md`](tasks/pr-dispute-tracking.md).