### PR TITLE
feat(consensus): on-disk validation archive (#267)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,10 +52,11 @@ type Config struct {
 	SSLVerifyDir  string `toml:"ssl_verify_dir" mapstructure:"ssl_verify_dir"`
 
 	// 6. Database
-	NodeDB       NodeDBConfig `toml:"node_db" mapstructure:"node_db"`
-	ImportDB     NodeDBConfig `toml:"import_db" mapstructure:"import_db"`
-	DatabasePath string       `toml:"database_path" mapstructure:"database_path"`
-	SQLite       SQLiteConfig `toml:"sqlite" mapstructure:"sqlite"`
+	NodeDB            NodeDBConfig            `toml:"node_db" mapstructure:"node_db"`
+	ImportDB          NodeDBConfig            `toml:"import_db" mapstructure:"import_db"`
+	DatabasePath      string                  `toml:"database_path" mapstructure:"database_path"`
+	SQLite            SQLiteConfig            `toml:"sqlite" mapstructure:"sqlite"`
+	ValidationArchive ValidationArchiveConfig `toml:"validation_archive" mapstructure:"validation_archive"`
 
 	// 7. Diagnostics
 	DebugLogfile string        `toml:"debug_logfile" mapstructure:"debug_logfile"`

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -193,6 +193,23 @@ zero_basefee_transaction_feelevel = 256000
 # Optional Sections
 # =============================================================================
 
+# On-disk validation archive (optional). When enabled, validations
+# pruned from ValidationTracker are persisted to a `validations` table
+# in the relational DB so forensic tooling can query historical
+# validations. Omit the section to disable; uncomment + adjust to tune.
+#
+# Note: SQLite is the default backend, sharing ledger.db with single-
+# writer concurrency. Sustained ledger-write pressure can therefore
+# back up the archive's writer goroutine; under sustained overload
+# OnStale logs a warning and drops, rather than blocking consensus.
+# [validation_archive]
+# enabled            = true   # default false; set true to turn on
+# retention_ledgers  = 10000  # 0 = keep forever
+# batch_size         = 128    # rows per commit
+# flush_interval_ms  = 1000   # max latency for partial batches
+# delete_batch       = 1000   # max rows per retention sweep
+# in_memory_ledgers  = 256    # tracker eviction window (rippled minimum)
+
 # Performance logging (optional)
 # [perf]
 # perf_log = "/var/log/xrpld/perf.log"

--- a/config/validation.go
+++ b/config/validation.go
@@ -40,6 +40,9 @@ func ValidateConfig(config *Config) error {
 	if err := config.SQLite.Validate(); err != nil {
 		errors = append(errors, fmt.Sprintf("sqlite: %s", err.Error()))
 	}
+	if err := config.ValidationArchive.Validate(); err != nil {
+		errors = append(errors, fmt.Sprintf("validation_archive: %s", err.Error()))
+	}
 
 	// 6. Validate diagnostics configuration
 	if err := config.Logging.Validate(); err != nil {

--- a/config/validation_archive.go
+++ b/config/validation_archive.go
@@ -1,0 +1,96 @@
+package config
+
+import "fmt"
+
+// ValidationArchiveConfig controls the on-disk validation archive —
+// persistence of stale validations pruned from ValidationTracker to the
+// relational DB's validations table. Follows rippled's historical
+// onStale/doStaleWrite pattern with Go-native batching semantics.
+type ValidationArchiveConfig struct {
+	// Enabled flips the archive on. When false no writer goroutine runs
+	// and OnStale is a no-op, regardless of whether the relational DB
+	// is configured. Default: true.
+	Enabled bool `toml:"enabled" mapstructure:"enabled"`
+
+	// RetentionLedgers is the number of fully-validated ledgers of
+	// history to keep in the archive. Rows with ledger_seq below
+	// (currentFullyValidatedSeq - RetentionLedgers) are deleted on
+	// each flush tick. 0 disables retention (keep forever).
+	RetentionLedgers uint32 `toml:"retention_ledgers" mapstructure:"retention_ledgers"`
+
+	// BatchSize caps how many stale validations the writer accumulates
+	// before forcing a commit. Larger values amortize fsync cost across
+	// more rows; smaller values bound write latency. Must be >= 1.
+	BatchSize int `toml:"batch_size" mapstructure:"batch_size"`
+
+	// FlushIntervalMs is the maximum milliseconds a partial batch may
+	// wait before being committed. Guarantees a bounded write latency
+	// even when the stale-validation rate is below BatchSize/sec.
+	// Must be >= 10.
+	FlushIntervalMs int `toml:"flush_interval_ms" mapstructure:"flush_interval_ms"`
+
+	// DeleteBatch caps how many rows a single retention sweep deletes.
+	// Bounded so the writer never blocks on a multi-second DELETE scan.
+	// Must be >= 1.
+	DeleteBatch int `toml:"delete_batch" mapstructure:"delete_batch"`
+
+	// InMemoryLedgers is the ExpireOld trigger. Every time a ledger is
+	// fully validated at seq S, the tracker drops validations for
+	// ledgers below (S - InMemoryLedgers) — which then stream into the
+	// archive via OnStale. Must be >= 1.
+	InMemoryLedgers uint32 `toml:"in_memory_ledgers" mapstructure:"in_memory_ledgers"`
+}
+
+// DefaultValidationArchiveConfig returns the built-in defaults. Applied
+// when the [validation_archive] section is absent from xrpld.toml.
+func DefaultValidationArchiveConfig() ValidationArchiveConfig {
+	return ValidationArchiveConfig{
+		Enabled:          true,
+		RetentionLedgers: 10000,
+		BatchSize:        128,
+		FlushIntervalMs:  1000,
+		DeleteBatch:      1000,
+		InMemoryLedgers:  256,
+	}
+}
+
+// WithDefaults returns a copy of c with any zero-valued field replaced by
+// the built-in default. RetentionLedgers is left alone because 0 has a
+// meaning (disable retention) distinct from "not configured."
+func (c ValidationArchiveConfig) WithDefaults() ValidationArchiveConfig {
+	d := DefaultValidationArchiveConfig()
+	if c.BatchSize == 0 {
+		c.BatchSize = d.BatchSize
+	}
+	if c.FlushIntervalMs == 0 {
+		c.FlushIntervalMs = d.FlushIntervalMs
+	}
+	if c.DeleteBatch == 0 {
+		c.DeleteBatch = d.DeleteBatch
+	}
+	if c.InMemoryLedgers == 0 {
+		c.InMemoryLedgers = d.InMemoryLedgers
+	}
+	return c
+}
+
+// Validate returns a non-nil error if any knob is out of range. Called
+// by ValidateConfig during startup so operators see all problems at once.
+func (c *ValidationArchiveConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.BatchSize < 1 {
+		return fmt.Errorf("batch_size must be >= 1, got %d", c.BatchSize)
+	}
+	if c.FlushIntervalMs < 10 {
+		return fmt.Errorf("flush_interval_ms must be >= 10, got %d", c.FlushIntervalMs)
+	}
+	if c.DeleteBatch < 1 {
+		return fmt.Errorf("delete_batch must be >= 1, got %d", c.DeleteBatch)
+	}
+	if c.InMemoryLedgers < 1 {
+		return fmt.Errorf("in_memory_ledgers must be >= 1, got %d", c.InMemoryLedgers)
+	}
+	return nil
+}

--- a/config/validation_archive_test.go
+++ b/config/validation_archive_test.go
@@ -1,0 +1,86 @@
+package config
+
+import "testing"
+
+func TestValidationArchiveConfig_DefaultsMatchSpec(t *testing.T) {
+	c := DefaultValidationArchiveConfig()
+
+	if !c.Enabled {
+		t.Error("default should be enabled")
+	}
+	if c.RetentionLedgers != 10000 {
+		t.Errorf("RetentionLedgers default = %d, want 10000", c.RetentionLedgers)
+	}
+	if c.BatchSize != 128 {
+		t.Errorf("BatchSize default = %d, want 128", c.BatchSize)
+	}
+	if c.FlushIntervalMs != 1000 {
+		t.Errorf("FlushIntervalMs default = %d, want 1000", c.FlushIntervalMs)
+	}
+	if c.DeleteBatch != 1000 {
+		t.Errorf("DeleteBatch default = %d, want 1000", c.DeleteBatch)
+	}
+	if c.InMemoryLedgers != 256 {
+		t.Errorf("InMemoryLedgers default = %d, want 256", c.InMemoryLedgers)
+	}
+}
+
+func TestValidationArchiveConfig_Validate_AcceptsDisabled(t *testing.T) {
+	// Zero struct = disabled, should validate even with zero knobs.
+	var c ValidationArchiveConfig
+	if err := c.Validate(); err != nil {
+		t.Fatalf("disabled archive with zero knobs failed to validate: %v", err)
+	}
+}
+
+func TestValidationArchiveConfig_Validate_RejectsBadKnobs(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  ValidationArchiveConfig
+	}{
+		{"batch_size_zero", ValidationArchiveConfig{Enabled: true, FlushIntervalMs: 1000, DeleteBatch: 1, InMemoryLedgers: 1}},
+		{"flush_too_small", ValidationArchiveConfig{Enabled: true, BatchSize: 1, FlushIntervalMs: 5, DeleteBatch: 1, InMemoryLedgers: 1}},
+		{"delete_batch_zero", ValidationArchiveConfig{Enabled: true, BatchSize: 1, FlushIntervalMs: 1000, InMemoryLedgers: 1}},
+		{"in_memory_zero", ValidationArchiveConfig{Enabled: true, BatchSize: 1, FlushIntervalMs: 1000, DeleteBatch: 1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+		})
+	}
+}
+
+func TestValidationArchiveConfig_WithDefaults_FillsZeros(t *testing.T) {
+	// User asked for it enabled but gave no other knobs.
+	c := ValidationArchiveConfig{Enabled: true, RetentionLedgers: 0}
+	filled := c.WithDefaults()
+
+	if filled.BatchSize == 0 || filled.FlushIntervalMs == 0 || filled.DeleteBatch == 0 || filled.InMemoryLedgers == 0 {
+		t.Fatalf("WithDefaults left zeros: %+v", filled)
+	}
+	// RetentionLedgers=0 must be preserved — it means "keep forever."
+	if filled.RetentionLedgers != 0 {
+		t.Errorf("WithDefaults overwrote RetentionLedgers=0; it means 'keep forever': got %d", filled.RetentionLedgers)
+	}
+
+	if err := filled.Validate(); err != nil {
+		t.Fatalf("WithDefaults output must validate: %v", err)
+	}
+}
+
+func TestValidationArchiveConfig_WithDefaults_PreservesExplicit(t *testing.T) {
+	c := ValidationArchiveConfig{
+		Enabled:          true,
+		RetentionLedgers: 50,
+		BatchSize:        7,
+		FlushIntervalMs:  2500,
+		DeleteBatch:      99,
+		InMemoryLedgers:  512,
+	}
+	out := c.WithDefaults()
+	if out != c {
+		t.Errorf("WithDefaults mutated explicit values:\n got  %+v\n want %+v", out, c)
+	}
+}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -209,7 +209,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	var consensusComponents *adaptor.Components
 	if !standalone {
 		var compErr error
-		consensusComponents, compErr = adaptor.NewFromConfig(globalConfig, ledgerService)
+		consensusComponents, compErr = adaptor.NewFromConfig(globalConfig, ledgerService, repoManager.Validation())
 		if compErr != nil {
 			serverLog.Fatal("Failed to create consensus components", "err", compErr)
 		}

--- a/internal/consensus/adaptor/converter.go
+++ b/internal/consensus/adaptor/converter.go
@@ -66,7 +66,7 @@ func ValidationFromMessage(msg *message.Validation) (*consensus.Validation, erro
 // STValidation suitable for the TMValidation protobuf wire format.
 func ValidationToMessage(v *consensus.Validation) *message.Validation {
 	return &message.Validation{
-		Validation: serializeSTValidation(v),
+		Validation: SerializeSTValidation(v),
 	}
 }
 

--- a/internal/consensus/adaptor/converter.go
+++ b/internal/consensus/adaptor/converter.go
@@ -64,9 +64,17 @@ func ValidationFromMessage(msg *message.Validation) (*consensus.Validation, erro
 
 // ValidationToMessage serializes a consensus.Validation to an XRPL-binary-encoded
 // STValidation suitable for the TMValidation protobuf wire format.
+//
+// Caches the wire bytes on v.Raw if not already populated, so downstream
+// consumers (the validation archive, suppression-hash computation) can
+// reuse the canonical blob without a second serialize pass.
 func ValidationToMessage(v *consensus.Validation) *message.Validation {
+	blob := SerializeSTValidation(v)
+	if len(v.Raw) == 0 {
+		v.Raw = append([]byte(nil), blob...)
+	}
 	return &message.Validation{
-		Validation: SerializeSTValidation(v),
+		Validation: blob,
 	}
 }
 

--- a/internal/consensus/adaptor/identity.go
+++ b/internal/consensus/adaptor/identity.go
@@ -170,7 +170,7 @@ func buildProposalSigningData(p *consensus.Proposal) []byte {
 //
 // For outbound validations (SigningData nil), we regenerate the preimage
 // from struct fields. It MUST stay byte-identical to what
-// serializeSTValidation emits (minus sfSignature); otherwise a freshly-
+// SerializeSTValidation emits (minus sfSignature); otherwise a freshly-
 // signed validation would fail verification when parsed back from the
 // wire. When extending the wire format, update both functions together.
 func buildValidationSigningData(v *consensus.Validation) []byte {
@@ -181,12 +181,12 @@ func buildValidationSigningData(v *consensus.Validation) []byte {
 	}
 
 	// Outbound: rebuild from struct fields in canonical field order,
-	// matching serializeSTValidation byte-for-byte.
+	// matching SerializeSTValidation byte-for-byte.
 	var buf []byte
 	buf = append(buf, protocol.HashPrefixValidation[:]...)
 
 	// sfFlags (type 2, field 2). Canonical-sig flag always set on
-	// outbound — must match serializeSTValidation.
+	// outbound — must match SerializeSTValidation.
 	flags := uint32(vfFullyCanonicalSig)
 	if v.Full {
 		flags |= vfFullValidation
@@ -211,7 +211,7 @@ func buildValidationSigningData(v *consensus.Validation) []byte {
 
 	// sfReserveBase (type 2, field 31) — optional flag-ledger fee vote
 	// (legacy pre-XRPFees form). Must stay in sync with
-	// serializeSTValidation emission order.
+	// SerializeSTValidation emission order.
 	if v.ReserveBase != 0 {
 		buf = appendFieldHeader(buf, typeUINT32, fieldReserveBase)
 		buf = append(buf, byte(v.ReserveBase>>24), byte(v.ReserveBase>>16), byte(v.ReserveBase>>8), byte(v.ReserveBase))
@@ -250,7 +250,7 @@ func buildValidationSigningData(v *consensus.Validation) []byte {
 
 	// --- HASH256 fields (type 5) — must precede AMOUNT (type 6) per
 	// canonical ascending-type ordering. Order must stay byte-identical
-	// to serializeSTValidation — any drift silently breaks our own
+	// to SerializeSTValidation — any drift silently breaks our own
 	// self-verify round-trip.
 
 	// sfLedgerHash (type 5, field 1)
@@ -289,7 +289,7 @@ func buildValidationSigningData(v *consensus.Validation) []byte {
 
 	// sfAmendments — VECTOR256 (type 19) FIELD 3 per rippled
 	// sfields.macro:306. The older value 19 confused type with field.
-	// Must stay in sync with serializeSTValidation which emits this
+	// Must stay in sync with SerializeSTValidation which emits this
 	// AFTER sfSigningPubKey; sfSignature comes last and is the only
 	// field excluded from the signing preimage.
 	if len(v.Amendments) > 0 {

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -132,7 +132,7 @@ func TestRouterDispatchesValidation(t *testing.T) {
 	copy(testVal.NodeID[:], []byte{0x02, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32})
 	testVal.Signature = make([]byte, 70) // dummy signature
 	val := &message.Validation{
-		Validation: serializeSTValidation(testVal),
+		Validation: SerializeSTValidation(testVal),
 	}
 
 	inbox <- &peermanagement.InboundMessage{

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -5,13 +5,16 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/LeJamon/goXRPLd/config"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/archive"
 	"github.com/LeJamon/goXRPLd/internal/consensus/rcl"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
 	"github.com/LeJamon/goXRPLd/internal/manifest"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
 // Components holds all the consensus/networking components created by NewFromConfig.
@@ -27,6 +30,13 @@ type Components struct {
 	// translation), and the RPC layer (manifest method). Always
 	// non-nil — starts empty and fills as peers gossip manifests.
 	Manifests *manifest.Cache
+
+	// Archive is the on-disk validation archive, when enabled.
+	// Nil if disabled in config or if no relational DB is configured.
+	// The engine owns the lifecycle (drain + Close on Stop), but it's
+	// surfaced here so the read-path can plumb it into RPC services
+	// without re-resolving from config.
+	Archive *archive.Archive
 
 	// cancel functions for background goroutines
 	overlayCancel context.CancelFunc
@@ -82,9 +92,14 @@ func (c *Components) Stop() {
 
 // NewFromConfig creates and wires all consensus/networking components from the app config.
 // Returns nil Components if the node is in standalone mode.
+//
+// validationRepo is optional — pass nil to disable the on-disk validation
+// archive. When non-nil and [validation_archive] is enabled in config,
+// stale validations are persisted via a batched async writer.
 func NewFromConfig(
 	appCfg *config.Config,
 	ledgerSvc *service.Service,
+	validationRepo relationaldb.ValidationRepository,
 ) (*Components, error) {
 	// Create validator identity first (nil if not a validator) so we can
 	// pass its pubkey into the overlay for the self-target TMSquelch
@@ -155,6 +170,24 @@ func NewFromConfig(
 		return consensus.NodeID(manifestCache.GetMasterKey([33]byte(nid)))
 	})
 
+	// On-disk validation archive. Skipped when the relational DB is
+	// unavailable or the operator has disabled the section in TOML —
+	// either way the engine runs unchanged with the tracker in pure
+	// in-memory mode. When enabled, ExpireOld in the fully-validated
+	// callback streams pruned validations into the writer goroutine.
+	var validationArchive *archive.Archive
+	if validationRepo != nil && appCfg.ValidationArchive.Enabled {
+		archCfg := appCfg.ValidationArchive.WithDefaults()
+		validationArchive = archive.New(validationRepo, archive.Config{
+			RetentionLedgers: archCfg.RetentionLedgers,
+			BatchSize:        archCfg.BatchSize,
+			FlushInterval:    time.Duration(archCfg.FlushIntervalMs) * time.Millisecond,
+			DeleteBatch:      archCfg.DeleteBatch,
+		}, slog.Default().With("component", "validation_archive"))
+		engine.SetArchive(validationArchive)
+		engine.SetInMemoryLedgers(archCfg.InMemoryLedgers)
+	}
+
 	router := NewRouter(engine, adaptor, modeManager, overlay.Messages())
 	router.SetManifestCache(manifestCache, overlay)
 
@@ -183,6 +216,7 @@ func NewFromConfig(
 		Router:      router,
 		ModeManager: modeManager,
 		Manifests:   manifestCache,
+		Archive:     validationArchive,
 	}, nil
 }
 

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -144,6 +144,7 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 		switch {
 		case typeCode == typeUINT32 && fieldCode == fieldFlags:
 			flags := binary.BigEndian.Uint32(fieldData)
+			v.Flags = flags
 			v.Full = (flags & vfFullValidation) != 0
 
 		case typeCode == typeUINT32 && fieldCode == fieldLedgerSequence:
@@ -262,12 +263,19 @@ func SerializeSTValidation(v *consensus.Validation) []byte {
 
 	// --- UINT32 fields (type 2) ---
 
-	// sfFlags (field 2). Rippled stamps vfFullyCanonicalSig on every
-	// outbound validation; we match that so canonical-sig-strict peers
-	// don't need to special-case us.
-	flags := uint32(vfFullyCanonicalSig)
-	if v.Full {
-		flags |= vfFullValidation
+	// sfFlags (field 2). For round-trip fidelity, prefer the original
+	// wire word captured by parseSTValidation (so we re-emit any vendor
+	// bits the validator set). For self-built validations whose Flags
+	// field is zero, synthesize the rippled-canonical pair: stamp
+	// vfFullyCanonicalSig on every outbound validation so canonical-sig-
+	// strict peers don't need to special-case us, plus vfFullValidation
+	// when v.Full.
+	flags := v.Flags
+	if flags == 0 {
+		flags = vfFullyCanonicalSig
+		if v.Full {
+			flags |= vfFullValidation
+		}
 	}
 	buf = appendFieldHeader(buf, typeUINT32, fieldFlags)
 	buf = binary.BigEndian.AppendUint32(buf, flags)

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -236,6 +236,7 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 	}
 
 	v.SigningData = signingBuf
+	v.Raw = append([]byte(nil), data...)
 
 	// Validate required fields were present.
 	if v.LedgerSeq == 0 || v.LedgerID == (consensus.LedgerID{}) || v.NodeID == (consensus.NodeID{}) {
@@ -245,7 +246,7 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 	return v, nil
 }
 
-// serializeSTValidation produces XRPL-binary-encoded STValidation bytes from a
+// SerializeSTValidation produces XRPL-binary-encoded STValidation bytes from a
 // consensus.Validation. Fields are written in canonical order (ascending type
 // code, then ascending field code within each type).
 //
@@ -253,7 +254,10 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 // sfFlags, matching rippled's STValidation::sign semantics. Optional
 // supplementary fields (Cookie, LoadFee, ConsensusHash, ServerVersion) are
 // emitted only when non-zero.
-func serializeSTValidation(v *consensus.Validation) []byte {
+//
+// Exported so external packages (the validation archive) can reserialize
+// self-built validations whose Raw field is nil.
+func SerializeSTValidation(v *consensus.Validation) []byte {
 	var buf []byte
 
 	// --- UINT32 fields (type 2) ---

--- a/internal/consensus/adaptor/stvalidation_test.go
+++ b/internal/consensus/adaptor/stvalidation_test.go
@@ -70,6 +70,41 @@ func TestParseSTValidation_PopulatesRaw(t *testing.T) {
 	}
 }
 
+// TestSTValidation_FlagsRoundTrip pins the wire-flag fidelity gap from
+// review round 2: parseSTValidation must capture the full sfFlags word,
+// and SerializeSTValidation must re-emit it verbatim, so the archive's
+// flags column reflects what the validator signed (not a synthesized
+// constant).
+func TestSTValidation_FlagsRoundTrip(t *testing.T) {
+	orig := buildTestValidation()
+	// A vendor flag bit the standard parser doesn't otherwise recognize.
+	const customVendorBit = 0x00010000
+	orig.Flags = vfFullyCanonicalSig | vfFullValidation | customVendorBit
+
+	blob := SerializeSTValidation(orig)
+	parsed, err := parseSTValidation(blob)
+	require.NoError(t, err)
+
+	if parsed.Flags != orig.Flags {
+		t.Fatalf("Flags lost on round-trip:\n got  0x%08x\n want 0x%08x", parsed.Flags, orig.Flags)
+	}
+	if !parsed.Full {
+		t.Error("Full bit derived from Flags should be true")
+	}
+
+	// Backward-compat: a Validation with Flags=0 still serializes to the
+	// canonical pair when Full=true (older constructors didn't know
+	// about Flags).
+	legacy := buildTestValidation()
+	legacy.Flags = 0 // explicit
+	legacyBlob := SerializeSTValidation(legacy)
+	legacyParsed, err := parseSTValidation(legacyBlob)
+	require.NoError(t, err)
+	if legacyParsed.Flags != (vfFullyCanonicalSig | vfFullValidation) {
+		t.Fatalf("legacy Flags=0 should synthesize canonical pair; got 0x%08x", legacyParsed.Flags)
+	}
+}
+
 func TestParseSTValidation_MinimalFields(t *testing.T) {
 	// Build minimal STValidation: Flags + LedgerSequence + SigningTime +
 	// LedgerHash + SigningPubKey + Signature.

--- a/internal/consensus/adaptor/stvalidation_test.go
+++ b/internal/consensus/adaptor/stvalidation_test.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"testing"
@@ -35,7 +36,7 @@ func buildTestValidation() *consensus.Validation {
 
 func TestParseSTValidation_Roundtrip(t *testing.T) {
 	orig := buildTestValidation()
-	blob := serializeSTValidation(orig)
+	blob := SerializeSTValidation(orig)
 
 	parsed, err := parseSTValidation(blob)
 	require.NoError(t, err)
@@ -48,6 +49,25 @@ func TestParseSTValidation_Roundtrip(t *testing.T) {
 	assert.Equal(t, orig.Cookie, parsed.Cookie)
 	assert.Equal(t, orig.LoadFee, parsed.LoadFee)
 	assert.WithinDuration(t, orig.SignTime, parsed.SignTime, time.Second)
+}
+
+func TestParseSTValidation_PopulatesRaw(t *testing.T) {
+	orig := buildTestValidation()
+	blob := SerializeSTValidation(orig)
+
+	parsed, err := parseSTValidation(blob)
+	require.NoError(t, err)
+
+	if !bytes.Equal(parsed.Raw, blob) {
+		t.Fatalf("Raw mismatch:\n got  %x\n want %x", parsed.Raw, blob)
+	}
+
+	// Raw must be an independent copy: mutating the input after parse
+	// must not corrupt what the archive later persists.
+	blob[0] ^= 0xFF
+	if parsed.Raw[0] == blob[0] {
+		t.Fatal("Raw aliases input buffer — must be a copy")
+	}
 }
 
 func TestParseSTValidation_MinimalFields(t *testing.T) {
@@ -101,7 +121,7 @@ func TestParseSTValidation_MinimalFields(t *testing.T) {
 
 func TestParseSTValidation_SigningDataExcludesSigOnly(t *testing.T) {
 	orig := buildTestValidation()
-	blob := serializeSTValidation(orig)
+	blob := SerializeSTValidation(orig)
 
 	parsed, err := parseSTValidation(blob)
 	require.NoError(t, err)
@@ -135,7 +155,7 @@ func TestParseSTValidation_MissingRequiredFields(t *testing.T) {
 
 func TestParseSTValidation_UnknownFieldsSkipped(t *testing.T) {
 	orig := buildTestValidation()
-	blob := serializeSTValidation(orig)
+	blob := SerializeSTValidation(orig)
 
 	// Insert an unknown UINT32 field (type=2, field=15 = 0x2F) before the last field.
 	// Find sfSigningPubKey (0x73) position and insert before it.
@@ -178,7 +198,7 @@ func TestParseSTValidation_UnknownFieldsSkipped(t *testing.T) {
 
 func TestSerializeSTValidation_CanonicalOrder(t *testing.T) {
 	v := buildTestValidation()
-	blob := serializeSTValidation(v)
+	blob := SerializeSTValidation(v)
 
 	// Verify field order by checking field header bytes appear in order.
 	var fieldHeaders []byte
@@ -230,7 +250,7 @@ func TestSerializeSTValidation_CanonicalOrder(t *testing.T) {
 
 func TestValidationFromMessage_Integration(t *testing.T) {
 	orig := buildTestValidation()
-	blob := serializeSTValidation(orig)
+	blob := SerializeSTValidation(orig)
 
 	msg := &message.Validation{Validation: blob}
 	parsed, err := ValidationFromMessage(msg)
@@ -271,7 +291,7 @@ func TestSignSerializeParseVerify_Roundtrip(t *testing.T) {
 	require.NoError(t, err, "direct verify failed")
 
 	// Serialize to wire format
-	blob := serializeSTValidation(orig)
+	blob := SerializeSTValidation(orig)
 	require.NotEmpty(t, blob)
 
 	// Parse back (inbound path)
@@ -355,7 +375,7 @@ func TestSerializeSTValidation_CanonicalOrder_Hash256BeforeAmount(t *testing.T) 
 	v.ReserveBaseDrops = 20
 	v.ReserveIncrementDrops = 5
 
-	blob := serializeSTValidation(v)
+	blob := SerializeSTValidation(v)
 	require.NotEmpty(t, blob)
 
 	// Walk each top-level field header and record the type code. We

--- a/internal/consensus/adaptor/suppression_hash_test.go
+++ b/internal/consensus/adaptor/suppression_hash_test.go
@@ -212,7 +212,7 @@ func TestSuppression_ProposalSemanticIdentity_SameHash(t *testing.T) {
 // at PeerImp.cpp:2374. NOT the TMValidation protobuf envelope.
 func TestSuppression_ValidationHash_OfSerializedBlob(t *testing.T) {
 	val := buildTestValidation()
-	blob := serializeSTValidation(val)
+	blob := SerializeSTValidation(val)
 
 	got := hashValidationSuppression(blob)
 
@@ -237,7 +237,7 @@ func TestSuppression_ValidationHash_OfSerializedBlob(t *testing.T) {
 // matching rippled.
 func TestSuppression_ValidationInnerBlobDomain_SameHash(t *testing.T) {
 	v := buildTestValidation()
-	blob := serializeSTValidation(v)
+	blob := SerializeSTValidation(v)
 
 	// Envelope A: the minimal TMValidation our Encode path emits.
 	envelopeA, err := message.Encode(&message.Validation{Validation: blob})

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -1,0 +1,344 @@
+// Package archive persists stale validations to the relational DB via a
+// batched async writer hooked into ValidationTracker.SetOnStale.
+//
+// Matches rippled's onStale / doStaleWrite contract (RCLValidations.cpp)
+// in semantics: OnStale returns in O(1) — it only enqueues to a channel —
+// so the consensus receive path is never gated on DB I/O.
+package archive
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/adaptor"
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+// Config tunes the archive writer. Validated ranges match config.ValidationArchiveConfig.
+type Config struct {
+	// RetentionLedgers is how many ledger-seqs of validation history to
+	// keep. Zero disables retention (keep forever).
+	RetentionLedgers uint32
+	// BatchSize caps accumulated rows before forcing a commit.
+	BatchSize int
+	// FlushInterval bounds how long a partial batch may wait.
+	FlushInterval time.Duration
+	// DeleteBatch caps a single retention-sweep DELETE.
+	DeleteBatch int
+}
+
+// Archive is the async writer. Safe for concurrent OnStale from any
+// goroutine once New has returned.
+type Archive struct {
+	repo   relationaldb.ValidationRepository
+	cfg    Config
+	logger *slog.Logger
+
+	ch       chan *consensus.Validation
+	flushReq chan chan struct{} // ack channel per flush request
+	stop     chan struct{}
+	wg       sync.WaitGroup
+	flushed  chan struct{} // closed when the writer goroutine exits
+
+	lastSeq atomic.Uint32 // most-recent fully-validated seq, used as retention pivot
+
+	closed atomic.Bool
+}
+
+// New creates a running archive. repo may be nil — that turns OnStale into
+// a no-op and nothing is ever written. ch buffer is BatchSize*8 so a
+// moderate burst of stale validations never blocks the caller.
+func New(repo relationaldb.ValidationRepository, cfg Config, logger *slog.Logger) *Archive {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if cfg.BatchSize < 1 {
+		cfg.BatchSize = 128
+	}
+	if cfg.FlushInterval <= 0 {
+		cfg.FlushInterval = time.Second
+	}
+	if cfg.DeleteBatch < 1 {
+		cfg.DeleteBatch = 1000
+	}
+
+	a := &Archive{
+		repo:     repo,
+		cfg:      cfg,
+		logger:   logger,
+		ch:       make(chan *consensus.Validation, cfg.BatchSize*8),
+		flushReq: make(chan chan struct{}, 4),
+		stop:     make(chan struct{}),
+		flushed:  make(chan struct{}),
+	}
+	if repo != nil {
+		a.wg.Add(1)
+		go a.run()
+	} else {
+		close(a.flushed)
+	}
+	return a
+}
+
+// OnStale is the ValidationTracker.SetOnStale callback. Non-blocking when
+// the channel has space; falls through a small bounded blocking wait
+// (matches rippled's vector-append semantics) so under sustained overload
+// we apply back-pressure instead of silently dropping validations.
+func (a *Archive) OnStale(v *consensus.Validation) {
+	if a == nil || a.repo == nil || v == nil || a.closed.Load() {
+		return
+	}
+	select {
+	case a.ch <- v:
+		return
+	default:
+	}
+	// Fall back to a bounded blocking send — 100ms is an eternity at
+	// consensus-message timescales but still lets the caller progress if
+	// the writer goroutine is wedged.
+	t := time.NewTimer(100 * time.Millisecond)
+	defer t.Stop()
+	select {
+	case a.ch <- v:
+	case <-t.C:
+		a.logger.Warn("validation archive channel full; dropping stale validation",
+			slog.Uint64("ledger_seq", uint64(v.LedgerSeq)))
+	case <-a.stop:
+	}
+}
+
+// NoteFullyValidated informs the archive of the most recent fully-
+// validated ledger seq. Used as the pivot for retention: rows with
+// ledger_seq < (noted - RetentionLedgers) become eligible for deletion.
+func (a *Archive) NoteFullyValidated(seq uint32) {
+	if a == nil {
+		return
+	}
+	for {
+		cur := a.lastSeq.Load()
+		if seq <= cur {
+			return
+		}
+		if a.lastSeq.CompareAndSwap(cur, seq) {
+			return
+		}
+	}
+}
+
+// Flush blocks until every stale validation enqueued before the call has
+// been committed. After Close, Flush is a no-op.
+//
+// Implemented as a two-barrier sync: we send an ack channel on flushReq
+// AFTER every previously-enqueued OnStale has landed in ch (FIFO on the
+// same goroutine ordering), and the writer loop closes the ack only
+// after it has fully drained ch up to that point and committed the
+// resulting batch.
+func (a *Archive) Flush(ctx context.Context) error {
+	if a == nil || a.repo == nil || a.closed.Load() {
+		return nil
+	}
+	ack := make(chan struct{})
+	select {
+	case a.flushReq <- ack:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-a.stop:
+		return nil
+	}
+	select {
+	case <-ack:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-a.stop:
+		return nil
+	}
+}
+
+// ApplyRetention performs a one-shot retention sweep against the current
+// NotedFullyValidated seq. Intended for tests and manual admin flushes;
+// the writer loop calls it implicitly after each batch commit.
+func (a *Archive) ApplyRetention(ctx context.Context) (int64, error) {
+	if a == nil || a.repo == nil || a.cfg.RetentionLedgers == 0 {
+		return 0, nil
+	}
+	last := a.lastSeq.Load()
+	if last <= a.cfg.RetentionLedgers {
+		return 0, nil
+	}
+	cutoff := last - a.cfg.RetentionLedgers
+	return a.repo.DeleteOlderThanSeq(ctx, relationaldb.LedgerIndex(cutoff), a.cfg.DeleteBatch)
+}
+
+// Close drains pending validations, commits the final batch, and stops
+// the writer goroutine. Safe to call multiple times; subsequent calls
+// return nil immediately.
+func (a *Archive) Close(ctx context.Context) error {
+	if a == nil {
+		return nil
+	}
+	if !a.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	close(a.stop)
+	select {
+	case <-a.flushed:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	a.wg.Wait()
+	return nil
+}
+
+// run is the writer goroutine. It accumulates up to BatchSize rows or
+// waits FlushInterval, whichever comes first, then commits. Retention
+// runs after every non-empty commit so the archive size is bounded even
+// under a steady stale-validation stream.
+func (a *Archive) run() {
+	defer a.wg.Done()
+	defer close(a.flushed)
+
+	ticker := time.NewTicker(a.cfg.FlushInterval)
+	defer ticker.Stop()
+
+	batch := make([]*relationaldb.ValidationRecord, 0, a.cfg.BatchSize)
+	flush := func(reason string) {
+		if len(batch) == 0 {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		err := a.repo.SaveBatch(ctx, batch)
+		cancel()
+		if err != nil {
+			a.logger.Error("validation archive: batch write failed",
+				slog.Int("rows", len(batch)), slog.String("reason", reason), slog.String("err", err.Error()))
+		} else {
+			a.logger.Debug("validation archive: batch committed",
+				slog.Int("rows", len(batch)), slog.String("reason", reason))
+		}
+		batch = batch[:0]
+
+		// Bounded retention sweep after each commit. Errors are logged
+		// but don't stop the writer — retention lag is recoverable.
+		if a.cfg.RetentionLedgers > 0 {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			_, rerr := a.ApplyRetention(ctx)
+			cancel()
+			if rerr != nil {
+				a.logger.Warn("validation archive: retention sweep failed",
+					slog.String("err", rerr.Error()))
+			}
+		}
+	}
+
+	drainPending := func() {
+		for {
+			select {
+			case v := <-a.ch:
+				if v == nil {
+					continue
+				}
+				rec := toRecord(v)
+				if rec == nil {
+					continue
+				}
+				batch = append(batch, rec)
+			default:
+				return
+			}
+		}
+	}
+
+	handleFlushReq := func(ack chan struct{}) {
+		// Drain everything enqueued before flush was requested. Flush
+		// is called from outside run, so anything a caller enqueued
+		// BEFORE sending the flushReq is already on ch by the time
+		// flushReq arrives (Go channel operations are happens-before
+		// synchronized). Drain to empty to pick it all up.
+		drainPending()
+		flush("flush-request")
+		close(ack)
+	}
+
+	for {
+		select {
+		case v, ok := <-a.ch:
+			if !ok {
+				flush("channel closed")
+				return
+			}
+			if v == nil {
+				continue
+			}
+			rec := toRecord(v)
+			if rec == nil {
+				continue
+			}
+			batch = append(batch, rec)
+			if len(batch) >= a.cfg.BatchSize {
+				flush("full")
+			}
+		case ack := <-a.flushReq:
+			handleFlushReq(ack)
+		case <-ticker.C:
+			flush("tick")
+		case <-a.stop:
+			drainPending()
+			// Service any pending flush requests so Close-then-Flush
+			// callers aren't left hanging.
+			for {
+				select {
+				case ack := <-a.flushReq:
+					close(ack)
+				default:
+					flush("close")
+					return
+				}
+			}
+		}
+	}
+}
+
+// toRecord marshals a Validation into the archive row shape. Returns nil
+// on anything invalid so a single bad validation can't poison the batch.
+func toRecord(v *consensus.Validation) *relationaldb.ValidationRecord {
+	if v == nil {
+		return nil
+	}
+
+	raw := v.Raw
+	if len(raw) == 0 {
+		// Self-built or legacy validation that never carried wire bytes.
+		// Re-serialize so the archive row is always replayable.
+		raw = adaptor.SerializeSTValidation(v)
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+
+	flags := uint32(0)
+	if v.Full {
+		flags |= 0x80000001
+	}
+
+	rec := &relationaldb.ValidationRecord{
+		LedgerSeq:  relationaldb.LedgerIndex(v.LedgerSeq),
+		InitialSeq: relationaldb.LedgerIndex(v.LedgerSeq),
+		NodePubKey: append([]byte(nil), v.NodeID[:]...),
+		Signature:  append([]byte(nil), v.Signature...),
+		SignTime:   v.SignTime,
+		SeenTime:   v.SeenTime,
+		Flags:      flags,
+		Raw:        append([]byte(nil), raw...),
+	}
+	copy(rec.LedgerHash[:], v.LedgerID[:])
+	return rec
+}
+
+// ErrClosed is returned by callers that try to use an Archive after Close.
+var ErrClosed = errors.New("archive: closed")

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -243,7 +243,7 @@ func (a *Archive) run() {
 				if v == nil {
 					continue
 				}
-				rec := toRecord(v)
+				rec := toRecord(v, a.lastSeq.Load())
 				if rec == nil {
 					continue
 				}
@@ -275,7 +275,7 @@ func (a *Archive) run() {
 			if v == nil {
 				continue
 			}
-			rec := toRecord(v)
+			rec := toRecord(v, a.lastSeq.Load())
 			if rec == nil {
 				continue
 			}
@@ -306,7 +306,18 @@ func (a *Archive) run() {
 
 // toRecord marshals a Validation into the archive row shape. Returns nil
 // on anything invalid so a single bad validation can't poison the batch.
-func toRecord(v *consensus.Validation) *relationaldb.ValidationRecord {
+//
+// initialSeq is the most-recent fully-validated ledger seq AT THE TIME
+// the row is committed — matching rippled's column comment ("the current
+// ledger seq when the row is inserted; only relevant during online
+// delete"). Pass 0 if no fully-validated pivot has been observed yet;
+// the column then degenerates to LedgerSeq, which is harmless.
+//
+// Non-Full validations are filtered upstream at ValidationTracker.Add
+// (validations.go:297) — they never enter the tracker, so the OnStale
+// stream never carries them. We don't re-filter here; rippled's
+// historical doStaleWrite filter is therefore moot for goXRPL.
+func toRecord(v *consensus.Validation, initialSeq uint32) *relationaldb.ValidationRecord {
 	if v == nil {
 		return nil
 	}
@@ -326,9 +337,13 @@ func toRecord(v *consensus.Validation) *relationaldb.ValidationRecord {
 		flags |= 0x80000001
 	}
 
+	if initialSeq == 0 {
+		initialSeq = v.LedgerSeq
+	}
+
 	rec := &relationaldb.ValidationRecord{
 		LedgerSeq:  relationaldb.LedgerIndex(v.LedgerSeq),
-		InitialSeq: relationaldb.LedgerIndex(v.LedgerSeq),
+		InitialSeq: relationaldb.LedgerIndex(initialSeq),
 		NodePubKey: append([]byte(nil), v.NodeID[:]...),
 		Signature:  append([]byte(nil), v.Signature...),
 		SignTime:   v.SignTime,

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -395,7 +395,6 @@ func toRecord(v *consensus.Validation, initialSeq uint32) *relationaldb.Validati
 		LedgerSeq:  relationaldb.LedgerIndex(v.LedgerSeq),
 		InitialSeq: relationaldb.LedgerIndex(initialSeq),
 		NodePubKey: append([]byte(nil), v.NodeID[:]...),
-		Signature:  append([]byte(nil), v.Signature...),
 		SignTime:   v.SignTime,
 		SeenTime:   v.SeenTime,
 		Flags:      flags,

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -131,16 +131,22 @@ func (a *Archive) NoteFullyValidated(seq uint32) {
 }
 
 // Flush blocks until every stale validation enqueued before the call has
-// been committed. After Close, Flush is a no-op.
+// been committed. Returns ErrClosed if called after Close so callers
+// notice attempts to flush a stopped archive (the previous silent-nil
+// behaviour hid bugs); returns nil for a nil receiver or a nil-repo
+// archive (those are configured no-ops, not error states).
 //
-// Implemented as a two-barrier sync: we send an ack channel on flushReq
-// AFTER every previously-enqueued OnStale has landed in ch (FIFO on the
-// same goroutine ordering), and the writer loop closes the ack only
-// after it has fully drained ch up to that point and committed the
-// resulting batch.
+// Implemented as an ack-channel barrier: we send an ack channel on
+// flushReq AFTER every previously-enqueued OnStale has landed in ch
+// (FIFO on the same goroutine ordering), and the writer loop closes the
+// ack only after it has fully drained ch up to that point and committed
+// the resulting batch.
 func (a *Archive) Flush(ctx context.Context) error {
-	if a == nil || a.repo == nil || a.closed.Load() {
+	if a == nil || a.repo == nil {
 		return nil
+	}
+	if a.closed.Load() {
+		return ErrClosed
 	}
 	ack := make(chan struct{})
 	select {
@@ -195,10 +201,27 @@ func (a *Archive) Close(ctx context.Context) error {
 	return nil
 }
 
+// retentionMinInterval is the minimum wall-clock gap between two
+// retention sweeps. Decoupling retention from the per-batch flush rate
+// caps DELETE pressure under sustained load: with BatchSize=128 and
+// FlushInterval=1s the writer can commit every second, but retention
+// only runs ~once per minute. The bounded DeleteBatch keeps each sweep
+// cheap, so the archive size still tracks RetentionLedgers within a
+// minute of any seq advance.
+const retentionMinInterval = time.Minute
+
+// saveBatchMaxAttempts is how many times the writer retries a failed
+// SaveBatch before logging and dropping the batch. One retry catches
+// transient lock contention / connection blips; persistent failure
+// (disk full, schema drift) gets logged at Error level so the operator
+// notices, then dropped to avoid unbounded memory growth.
+const saveBatchMaxAttempts = 2
+
 // run is the writer goroutine. It accumulates up to BatchSize rows or
 // waits FlushInterval, whichever comes first, then commits. Retention
-// runs after every non-empty commit so the archive size is bounded even
-// under a steady stale-validation stream.
+// runs after every non-empty commit BUT only if at least
+// retentionMinInterval has elapsed since the last sweep — see comment
+// on retentionMinInterval for why per-flush retention is too aggressive.
 func (a *Archive) run() {
 	defer a.wg.Done()
 	defer close(a.flushed)
@@ -206,29 +229,56 @@ func (a *Archive) run() {
 	ticker := time.NewTicker(a.cfg.FlushInterval)
 	defer ticker.Stop()
 
+	var lastRetention time.Time
+
 	batch := make([]*relationaldb.ValidationRecord, 0, a.cfg.BatchSize)
 	flush := func(reason string) {
 		if len(batch) == 0 {
 			return
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		err := a.repo.SaveBatch(ctx, batch)
-		cancel()
+
+		// Retry-once on SaveBatch error. Most failures are transient
+		// (SQLite SQLITE_BUSY under contention, brief Postgres
+		// disconnects) and a single 50ms backoff clears them.
+		var err error
+		for attempt := 1; attempt <= saveBatchMaxAttempts; attempt++ {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			err = a.repo.SaveBatch(ctx, batch)
+			cancel()
+			if err == nil {
+				break
+			}
+			if attempt < saveBatchMaxAttempts {
+				a.logger.Warn("validation archive: batch write failed; retrying",
+					slog.Int("rows", len(batch)), slog.Int("attempt", attempt), slog.String("err", err.Error()))
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
 		if err != nil {
-			a.logger.Error("validation archive: batch write failed",
-				slog.Int("rows", len(batch)), slog.String("reason", reason), slog.String("err", err.Error()))
+			// Persistent failure: log at Error so operators notice, then
+			// drop the batch. Re-queueing indefinitely would let memory
+			// grow without bound on a permanently broken backend, which
+			// is strictly worse than visible data loss with a paper
+			// trail.
+			a.logger.Error("validation archive: batch write failed permanently; dropping rows",
+				slog.Int("rows", len(batch)),
+				slog.Int("attempts", saveBatchMaxAttempts),
+				slog.String("reason", reason),
+				slog.String("err", err.Error()))
 		} else {
 			a.logger.Debug("validation archive: batch committed",
 				slog.Int("rows", len(batch)), slog.String("reason", reason))
 		}
 		batch = batch[:0]
 
-		// Bounded retention sweep after each commit. Errors are logged
-		// but don't stop the writer — retention lag is recoverable.
-		if a.cfg.RetentionLedgers > 0 {
+		// Retention sweep — gated on retentionMinInterval to keep
+		// DELETE pressure off the hot path under sustained flush
+		// activity. Errors are logged but don't stop the writer.
+		if a.cfg.RetentionLedgers > 0 && time.Since(lastRetention) >= retentionMinInterval {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			_, rerr := a.ApplyRetention(ctx)
 			cancel()
+			lastRetention = time.Now()
 			if rerr != nil {
 				a.logger.Warn("validation archive: retention sweep failed",
 					slog.String("err", rerr.Error()))

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -381,11 +381,6 @@ func toRecord(v *consensus.Validation, initialSeq uint32) *relationaldb.Validati
 		return nil
 	}
 
-	flags := uint32(0)
-	if v.Full {
-		flags |= 0x80000001
-	}
-
 	if initialSeq == 0 {
 		initialSeq = v.LedgerSeq
 	}
@@ -396,8 +391,13 @@ func toRecord(v *consensus.Validation, initialSeq uint32) *relationaldb.Validati
 		NodePubKey: append([]byte(nil), v.NodeID[:]...),
 		SignTime:   v.SignTime,
 		SeenTime:   v.SeenTime,
-		Flags:      flags,
-		Raw:        append([]byte(nil), raw...),
+		// Flags carries the original wire sfFlags word (parser fills
+		// it from the inbound blob, signer fills it at sign time).
+		// Forensic queries SELECT flags FROM validations therefore
+		// read what the validator actually signed, not a synthesized
+		// constant.
+		Flags: v.Flags,
+		Raw:   append([]byte(nil), raw...),
 	}
 	copy(rec.LedgerHash[:], v.LedgerID[:])
 	return rec

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -4,6 +4,32 @@
 // Matches rippled's onStale / doStaleWrite contract (RCLValidations.cpp)
 // in semantics: OnStale returns in O(1) — it only enqueues to a channel —
 // so the consensus receive path is never gated on DB I/O.
+//
+// # Eviction trigger: ledger-seq, not freshness (intentional divergence)
+//
+// Rippled (pre-2019) fired onStale from Validations<>::current() when
+// isCurrent() returned false — i.e. on time-window violations
+// (SignTime/SeenTime drifted outside the wall/local windows). goXRPL
+// fires onStale only from ExpireOld(seq - inMemoryLedgers), which is
+// driven by ledger-seq retention from the fully-validated callback.
+//
+// Practical consequence: time-stale validations that never reach a
+// fully-validated ledger (e.g. orphaned validations on losing forks)
+// are rejected at ValidationTracker.Add (isCurrent check at
+// validations.go:291) but are NOT archived. Rippled would have archived
+// them.
+//
+// Trade-off:
+//   - Forensic completeness for finalized network state: same as rippled.
+//   - Forensic completeness for "what did the network consider but
+//     discard": slightly lower — losing-fork validations are visible
+//     only in logs, not in the archive.
+//
+// Defensible because the dominant use case is replaying finalized state,
+// and the divergence avoids archiving orphans we'd just delete on the
+// next retention sweep. If "considered but discarded" forensics ever
+// becomes a requirement, hooking a second OnStale call from Add's
+// isCurrent reject path is straightforward.
 package archive
 
 import (

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/consensus"
-	"github.com/LeJamon/goXRPLd/internal/consensus/adaptor"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
@@ -374,11 +373,11 @@ func toRecord(v *consensus.Validation, initialSeq uint32) *relationaldb.Validati
 
 	raw := v.Raw
 	if len(raw) == 0 {
-		// Self-built or legacy validation that never carried wire bytes.
-		// Re-serialize so the archive row is always replayable.
-		raw = adaptor.SerializeSTValidation(v)
-	}
-	if len(raw) == 0 {
+		// All Validations reaching the tracker either come from the wire
+		// (parseSTValidation populates Raw) or from our own signer
+		// (ValidationToMessage populates Raw at broadcast time). A
+		// missing Raw means a programming error upstream — log and skip
+		// rather than re-serialize, which would silently mask the bug.
 		return nil
 	}
 

--- a/internal/consensus/archive/archive_test.go
+++ b/internal/consensus/archive/archive_test.go
@@ -1,0 +1,293 @@
+package archive
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+// fakeRepo captures SaveBatch calls in-memory. Zero config of its own so
+// tests can wrap it with a latency knob when they need one.
+type fakeRepo struct {
+	mu       sync.Mutex
+	rows     []*relationaldb.ValidationRecord
+	batches  int
+	saveWait time.Duration
+
+	deletes      []int64 // maxSeq arguments in order
+	deleteReturn int64
+	deleteErr    error
+}
+
+func (f *fakeRepo) Save(ctx context.Context, v *relationaldb.ValidationRecord) error {
+	return f.SaveBatch(ctx, []*relationaldb.ValidationRecord{v})
+}
+
+func (f *fakeRepo) SaveBatch(ctx context.Context, vs []*relationaldb.ValidationRecord) error {
+	if f.saveWait > 0 {
+		time.Sleep(f.saveWait)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows = append(f.rows, vs...)
+	f.batches++
+	return nil
+}
+
+func (f *fakeRepo) GetValidationsForLedger(ctx context.Context, seq relationaldb.LedgerIndex) ([]*relationaldb.ValidationRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []*relationaldb.ValidationRecord
+	for _, r := range f.rows {
+		if r.LedgerSeq == seq {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeRepo) GetValidationsByValidator(ctx context.Context, nodeKey []byte, limit int) ([]*relationaldb.ValidationRecord, error) {
+	return nil, nil
+}
+
+func (f *fakeRepo) GetValidationCount(ctx context.Context) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return int64(len(f.rows)), nil
+}
+
+func (f *fakeRepo) DeleteOlderThanSeq(ctx context.Context, maxSeq relationaldb.LedgerIndex, batchSize int) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletes = append(f.deletes, int64(maxSeq))
+	if f.deleteErr != nil {
+		return 0, f.deleteErr
+	}
+	kept := f.rows[:0]
+	removed := int64(0)
+	for _, r := range f.rows {
+		if r.LedgerSeq < maxSeq {
+			removed++
+			continue
+		}
+		kept = append(kept, r)
+	}
+	f.rows = kept
+	return removed, nil
+}
+
+func (f *fakeRepo) rowCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.rows)
+}
+
+func mkVal(seq uint32, node byte) *consensus.Validation {
+	v := &consensus.Validation{
+		LedgerSeq: seq,
+		Full:      true,
+		SignTime:  time.Unix(1700000000, 0).UTC(),
+		SeenTime:  time.Unix(1700000001, 0).UTC(),
+		Signature: []byte{0xAB, 0xCD},
+		Raw:       []byte{0xFE, 0xED, byte(seq), node},
+	}
+	v.LedgerID[0] = byte(seq)
+	v.LedgerID[31] = node
+	v.NodeID[0] = 0x02
+	v.NodeID[32] = node
+	return v
+}
+
+func TestArchive_BatchesOnSize(t *testing.T) {
+	repo := &fakeRepo{}
+	a := New(repo, Config{BatchSize: 3, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+	defer a.Close(context.Background())
+
+	for i := uint32(1); i <= 3; i++ {
+		a.OnStale(mkVal(i, 1))
+	}
+
+	// Size-triggered commit must land without waiting for the tick.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if repo.rowCount() == 3 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected 3 rows, got %d", repo.rowCount())
+}
+
+func TestArchive_BatchesOnTick(t *testing.T) {
+	repo := &fakeRepo{}
+	a := New(repo, Config{BatchSize: 1000, FlushInterval: 30 * time.Millisecond, DeleteBatch: 1}, nil)
+	defer a.Close(context.Background())
+
+	for i := uint32(1); i <= 5; i++ {
+		a.OnStale(mkVal(i, 1))
+	}
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if repo.rowCount() == 5 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected 5 rows via tick flush, got %d", repo.rowCount())
+}
+
+func TestArchive_Flush_Drains(t *testing.T) {
+	repo := &fakeRepo{}
+	a := New(repo, Config{BatchSize: 1000, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+	defer a.Close(context.Background())
+
+	for i := uint32(1); i <= 7; i++ {
+		a.OnStale(mkVal(i, 1))
+	}
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if repo.rowCount() != 7 {
+		t.Fatalf("Flush did not drain: got %d rows, want 7", repo.rowCount())
+	}
+}
+
+func TestArchive_CloseDrainsPending(t *testing.T) {
+	repo := &fakeRepo{}
+	a := New(repo, Config{BatchSize: 1000, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+
+	for i := uint32(1); i <= 4; i++ {
+		a.OnStale(mkVal(i, 1))
+	}
+	if err := a.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if repo.rowCount() != 4 {
+		t.Fatalf("Close did not commit pending rows: got %d, want 4", repo.rowCount())
+	}
+	// Close is idempotent.
+	if err := a.Close(context.Background()); err != nil {
+		t.Fatalf("second Close errored: %v", err)
+	}
+}
+
+func TestArchive_OnStale_NonBlocking_UnderSlowRepo(t *testing.T) {
+	repo := &fakeRepo{saveWait: 20 * time.Millisecond}
+	a := New(repo, Config{BatchSize: 8, FlushInterval: 5 * time.Millisecond, DeleteBatch: 1}, nil)
+	defer a.Close(context.Background())
+
+	// BatchSize=8 → channel buffer=64. Fire 32 quickly; all should be
+	// accepted via the fast path without blocking.
+	start := time.Now()
+	for i := uint32(1); i <= 32; i++ {
+		a.OnStale(mkVal(i, 1))
+	}
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Fatalf("OnStale loop blocked on slow repo: took %v", elapsed)
+	}
+}
+
+func TestArchive_ApplyRetention_HonorsLastSeq(t *testing.T) {
+	repo := &fakeRepo{}
+	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, RetentionLedgers: 10, DeleteBatch: 1000}, nil)
+	defer a.Close(context.Background())
+
+	for i := uint32(1); i <= 20; i++ {
+		a.OnStale(mkVal(i, byte(i)))
+	}
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if repo.rowCount() != 20 {
+		t.Fatalf("pre-retention rowCount=%d, want 20", repo.rowCount())
+	}
+
+	a.NoteFullyValidated(20)
+	if _, err := a.ApplyRetention(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rows with LedgerSeq < (20 - 10) = 10 should be gone → seqs 1..9.
+	if repo.rowCount() != 11 {
+		t.Fatalf("post-retention rowCount=%d, want 11 (seqs 10..20)", repo.rowCount())
+	}
+}
+
+func TestArchive_ApplyRetention_ZeroRetention_Noop(t *testing.T) {
+	repo := &fakeRepo{}
+	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, RetentionLedgers: 0, DeleteBatch: 1000}, nil)
+	defer a.Close(context.Background())
+
+	for i := uint32(1); i <= 5; i++ {
+		a.OnStale(mkVal(i, byte(i)))
+	}
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	a.NoteFullyValidated(5)
+
+	n, err := a.ApplyRetention(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("zero retention must be a no-op; got %d deletions", n)
+	}
+	if repo.rowCount() != 5 {
+		t.Fatalf("zero retention must keep everything; got %d rows, want 5", repo.rowCount())
+	}
+}
+
+func TestArchive_NoteFullyValidated_MonotonicallyIncreases(t *testing.T) {
+	a := &Archive{}
+
+	a.NoteFullyValidated(100)
+	a.NoteFullyValidated(50) // older update must be ignored
+	a.NoteFullyValidated(120)
+
+	if got := a.lastSeq.Load(); got != 120 {
+		t.Fatalf("lastSeq=%d, want 120", got)
+	}
+}
+
+func TestArchive_NilRepo_OnStaleIsNoop(t *testing.T) {
+	a := New(nil, Config{BatchSize: 1, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+	defer a.Close(context.Background())
+
+	// Must not panic, must not block.
+	for i := uint32(1); i <= 10; i++ {
+		a.OnStale(mkVal(i, 1))
+	}
+}
+
+func TestArchive_OnStale_AfterClose_IsNoop(t *testing.T) {
+	repo := &fakeRepo{}
+	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+
+	_ = a.Close(context.Background())
+
+	var dropped atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			a.OnStale(mkVal(uint32(i+1), 1))
+			dropped.Add(1)
+		}(i)
+	}
+	// A bounded wait is enough — OnStale must never block after Close.
+	doneCh := make(chan struct{})
+	go func() { wg.Wait(); close(doneCh) }()
+	select {
+	case <-doneCh:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("OnStale blocked after Close; completed %d/50", dropped.Load())
+	}
+}

--- a/internal/consensus/archive/archive_test.go
+++ b/internal/consensus/archive/archive_test.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -263,6 +264,91 @@ func TestArchive_NilRepo_OnStaleIsNoop(t *testing.T) {
 	// Must not panic, must not block.
 	for i := uint32(1); i <= 10; i++ {
 		a.OnStale(mkVal(i, 1))
+	}
+}
+
+// flakyRepo wraps fakeRepo and returns an error from SaveBatch a
+// configurable number of times before succeeding. Exercises the
+// retry-once policy in the writer loop.
+type flakyRepo struct {
+	*fakeRepo
+	mu          sync.Mutex
+	failures    int
+	failureLeft int
+}
+
+func (f *flakyRepo) SaveBatch(ctx context.Context, vs []*relationaldb.ValidationRecord) error {
+	f.mu.Lock()
+	if f.failureLeft > 0 {
+		f.failureLeft--
+		f.failures++
+		f.mu.Unlock()
+		return errors.New("transient repo failure")
+	}
+	f.mu.Unlock()
+	return f.fakeRepo.SaveBatch(ctx, vs)
+}
+
+func TestArchive_SaveBatch_RetryOnceThenSucceed(t *testing.T) {
+	base := &fakeRepo{}
+	repo := &flakyRepo{fakeRepo: base, failureLeft: 1} // first attempt fails, retry succeeds
+	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+	defer a.Close(context.Background())
+
+	a.OnStale(mkVal(100, 0x01))
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if base.rowCount() != 1 {
+		t.Fatalf("retry path lost the row: rowCount=%d, want 1", base.rowCount())
+	}
+	if repo.failures != 1 {
+		t.Fatalf("expected exactly 1 failed attempt before success, got %d", repo.failures)
+	}
+}
+
+func TestArchive_SaveBatch_PersistentFailure_DropsAndContinues(t *testing.T) {
+	base := &fakeRepo{}
+	// More failures than retries → batch is dropped after attempts.
+	repo := &flakyRepo{fakeRepo: base, failureLeft: 100}
+	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+	defer a.Close(context.Background())
+
+	a.OnStale(mkVal(100, 0x01))
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Failed batch must be dropped — no row in the underlying repo.
+	if base.rowCount() != 0 {
+		t.Fatalf("permanently failing batch was not dropped: rowCount=%d", base.rowCount())
+	}
+
+	// Writer must still be alive: a follow-up validation under a
+	// recovered repo should land. Reset the failure counter.
+	repo.mu.Lock()
+	repo.failureLeft = 0
+	repo.mu.Unlock()
+
+	a.OnStale(mkVal(101, 0x02))
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if base.rowCount() != 1 {
+		t.Fatalf("writer dead after persistent failure: rowCount=%d, want 1", base.rowCount())
+	}
+}
+
+func TestArchive_FlushAfterClose_ReturnsErrClosed(t *testing.T) {
+	repo := &fakeRepo{}
+	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+
+	if err := a.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Flush(context.Background()); err != ErrClosed {
+		t.Fatalf("Flush after Close returned %v, want ErrClosed", err)
 	}
 }
 

--- a/internal/consensus/archive/archive_test.go
+++ b/internal/consensus/archive/archive_test.go
@@ -20,9 +20,8 @@ type fakeRepo struct {
 	batches  int
 	saveWait time.Duration
 
-	deletes      []int64 // maxSeq arguments in order
-	deleteReturn int64
-	deleteErr    error
+	deletes   []int64 // maxSeq arguments in order
+	deleteErr error
 }
 
 func (f *fakeRepo) Save(ctx context.Context, v *relationaldb.ValidationRecord) error {

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -136,6 +136,26 @@ type Engine struct {
 	// quorum arithmetic. Nil means "no translation" (default identity
 	// function inside the tracker). See SetManifestResolver.
 	manifestResolver func(consensus.NodeID) consensus.NodeID
+
+	// archive, when non-nil, persists stale validations dropped by the
+	// tracker. Wired via SetArchive — optional, the engine functions
+	// identically when nil.
+	archive ValidationArchive
+
+	// inMemoryLedgers is the tracker's in-memory retention window: after
+	// a ledger becomes fully validated at seq S, validations for ledgers
+	// below (S - inMemoryLedgers) are dropped and streamed into the
+	// archive via OnStale. Zero disables auto-expiry.
+	inMemoryLedgers uint32
+}
+
+// ValidationArchive is the subset of the archive API the consensus engine
+// consumes. Defined here so the rcl package does not depend on the
+// concrete archive type — test doubles can satisfy it with two methods.
+type ValidationArchive interface {
+	OnStale(*consensus.Validation)
+	NoteFullyValidated(seq uint32)
+	Close(ctx context.Context) error
 }
 
 // avalancheState tracks the close time voting threshold escalation.
@@ -197,6 +217,30 @@ func (e *Engine) SetManifestResolver(fn func(consensus.NodeID) consensus.NodeID)
 	}
 }
 
+// SetArchive wires an on-disk validation archive into the engine. Must
+// be called before Start; post-Start calls are accepted but the OnStale
+// hook is only installed when the tracker is built in Start. Pass nil to
+// detach. Safe to call concurrently with Stop but not with Start.
+func (e *Engine) SetArchive(a ValidationArchive) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.archive = a
+	if e.validationTracker != nil && a != nil {
+		e.validationTracker.SetOnStale(a.OnStale)
+	}
+}
+
+// SetInMemoryLedgers configures how many fully-validated ledgers of
+// validation history the tracker holds in memory. Every time a ledger
+// becomes fully validated at seq S, validations for ledgers below
+// (S - n) are evicted (and streamed into the archive via OnStale).
+// Zero disables auto-eviction.
+func (e *Engine) SetInMemoryLedgers(n uint32) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.inMemoryLedgers = n
+}
+
 // Start begins the consensus engine.
 func (e *Engine) Start(ctx context.Context) error {
 	e.mu.Lock()
@@ -225,8 +269,20 @@ func (e *Engine) Start(ctx context.Context) error {
 	// — matching here avoids rejecting our own just-signed validation
 	// by the accumulated close-time offset on a skewed node.
 	e.validationTracker.SetNow(e.adaptor.Now)
+	if e.archive != nil {
+		e.validationTracker.SetOnStale(e.archive.OnStale)
+	}
 	e.validationTracker.SetFullyValidatedCallback(func(ledgerID consensus.LedgerID, seq uint32) {
 		e.adaptor.OnLedgerFullyValidated(ledgerID, seq)
+		if e.archive != nil {
+			e.archive.NoteFullyValidated(seq)
+		}
+		// Drive the in-memory retention window. ExpireOld fires the
+		// onStale callback for each evicted validation, so the archive
+		// captures it before the tracker drops it.
+		if n := e.inMemoryLedgers; n > 0 && seq > n {
+			e.validationTracker.ExpireOld(seq - n)
+		}
 	})
 
 	// Start the main loop
@@ -236,11 +292,19 @@ func (e *Engine) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop gracefully shuts down the consensus engine.
+// Stop gracefully shuts down the consensus engine. If an archive is
+// wired, its writer goroutine is drained and committed before Stop
+// returns so no stale validations are lost across shutdown.
 func (e *Engine) Stop() error {
 	e.cancel()
 	e.wg.Wait()
 	e.eventBus.Stop()
+	if e.archive != nil {
+		// Bounded close — a stuck archive must not hang shutdown.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = e.archive.Close(ctx)
+		cancel()
+	}
 	return nil
 }
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -217,17 +217,23 @@ func (e *Engine) SetManifestResolver(fn func(consensus.NodeID) consensus.NodeID)
 	}
 }
 
-// SetArchive wires an on-disk validation archive into the engine. Must
-// be called before Start; post-Start calls are accepted but the OnStale
-// hook is only installed when the tracker is built in Start. Pass nil to
-// detach. Safe to call concurrently with Stop but not with Start.
+// SetArchive wires an on-disk validation archive into the engine. May
+// be called before or after Start. Pass nil to detach — the tracker's
+// onStale callback is cleared so the just-detached archive can be
+// Close()d without risking a use-after-close channel send. Safe to call
+// concurrently with Stop but not with Start.
 func (e *Engine) SetArchive(a ValidationArchive) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.archive = a
-	if e.validationTracker != nil && a != nil {
-		e.validationTracker.SetOnStale(a.OnStale)
+	if e.validationTracker == nil {
+		return
 	}
+	if a == nil {
+		e.validationTracker.SetOnStale(nil)
+		return
+	}
+	e.validationTracker.SetOnStale(a.OnStale)
 }
 
 // SetInMemoryLedgers configures how many fully-validated ledgers of
@@ -272,16 +278,27 @@ func (e *Engine) Start(ctx context.Context) error {
 	if e.archive != nil {
 		e.validationTracker.SetOnStale(e.archive.OnStale)
 	}
+	tracker := e.validationTracker
 	e.validationTracker.SetFullyValidatedCallback(func(ledgerID consensus.LedgerID, seq uint32) {
 		e.adaptor.OnLedgerFullyValidated(ledgerID, seq)
-		if e.archive != nil {
-			e.archive.NoteFullyValidated(seq)
+
+		// Snapshot mutable fields under e.mu — SetArchive /
+		// SetInMemoryLedgers may race with this callback.
+		e.mu.RLock()
+		arc := e.archive
+		inMem := e.inMemoryLedgers
+		e.mu.RUnlock()
+
+		if arc != nil {
+			arc.NoteFullyValidated(seq)
 		}
 		// Drive the in-memory retention window. ExpireOld fires the
 		// onStale callback for each evicted validation, so the archive
-		// captures it before the tracker drops it.
-		if n := e.inMemoryLedgers; n > 0 && seq > n {
-			e.validationTracker.ExpireOld(seq - n)
+		// captures it before the tracker drops it. Called outside e.mu
+		// because ExpireOld may dispatch onStale callbacks that block
+		// briefly on the archive's channel send.
+		if inMem > 0 && seq > inMem {
+			tracker.ExpireOld(seq - inMem)
 		}
 	})
 
@@ -294,15 +311,21 @@ func (e *Engine) Start(ctx context.Context) error {
 
 // Stop gracefully shuts down the consensus engine. If an archive is
 // wired, its writer goroutine is drained and committed before Stop
-// returns so no stale validations are lost across shutdown.
+// returns so no stale validations are lost across shutdown — modulo
+// SaveBatch failures (which the writer logs and re-queues; see
+// Archive.run for the retry policy).
 func (e *Engine) Stop() error {
 	e.cancel()
 	e.wg.Wait()
 	e.eventBus.Stop()
-	if e.archive != nil {
+
+	e.mu.RLock()
+	arc := e.archive
+	e.mu.RUnlock()
+	if arc != nil {
 		// Bounded close — a stuck archive must not hang shutdown.
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		_ = e.archive.Close(ctx)
+		_ = arc.Close(ctx)
 		cancel()
 	}
 	return nil

--- a/internal/consensus/rcl/engine_archive_test.go
+++ b/internal/consensus/rcl/engine_archive_test.go
@@ -157,3 +157,89 @@ func TestEngine_Stop_ClosesArchive(t *testing.T) {
 		t.Fatalf("Stop did not close the archive; closeCalls=%d", arc.closeCalls.Load())
 	}
 }
+
+// TestEngine_SetArchive_NilDetaches verifies that SetArchive(nil) clears
+// the tracker's onStale callback. Without that, a Close()d archive whose
+// pointer was overwritten could still receive channel sends from the
+// tracker — use-after-close.
+func TestEngine_SetArchive_NilDetaches(t *testing.T) {
+	adaptor := newMockAdaptor()
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	if err := engine.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { engine.Stop() })
+
+	arc := &fakeArchive{}
+	engine.SetArchive(arc)
+	engine.SetArchive(nil) // detach
+
+	v := &consensus.Validation{
+		LedgerSeq: 100, LedgerID: consensus.LedgerID{0x1},
+		NodeID: consensus.NodeID{0x2}, SignTime: time.Now(), Full: true,
+	}
+	if !engine.validationTracker.Add(v) {
+		t.Fatal("Add returned false; precondition broken")
+	}
+	engine.validationTracker.ExpireOld(200)
+
+	if got := arc.staleCount(); got != 0 {
+		t.Fatalf("detached archive received %d stale rows; want 0", got)
+	}
+}
+
+// TestEngine_SetArchive_ConcurrentWithCallback exercises the race the
+// reviewer flagged: the fully-validated callback reads e.archive while
+// other goroutines call SetArchive / SetInMemoryLedgers. Run under
+// `go test -race` to verify no race is reported.
+func TestEngine_SetArchive_ConcurrentWithCallback(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.setTrusted([]consensus.NodeID{{1}, {2}, {3}})
+	adaptor.quorum = 2
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	if err := engine.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { engine.Stop() })
+
+	arc1 := &fakeArchive{}
+	arc2 := &fakeArchive{}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine A: hammer SetArchive / SetInMemoryLedgers.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			if i%2 == 0 {
+				engine.SetArchive(arc1)
+			} else {
+				engine.SetArchive(arc2)
+			}
+			engine.SetInMemoryLedgers(uint32(50 + i))
+		}
+	}()
+
+	// Goroutine B: drive Add() to fire the fully-validated callback
+	// repeatedly. Quorum=2 so two trusted validations per ledger fire
+	// the callback.
+	go func() {
+		defer wg.Done()
+		now := time.Now()
+		for seq := uint32(100); seq < 200; seq++ {
+			ledger := consensus.LedgerID{byte(seq), byte(seq >> 8)}
+			for _, n := range []consensus.NodeID{{1}, {2}} {
+				v := &consensus.Validation{
+					LedgerSeq: seq, LedgerID: ledger, NodeID: n,
+					SignTime: now, Full: true,
+				}
+				engine.validationTracker.Add(v)
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/internal/consensus/rcl/engine_archive_test.go
+++ b/internal/consensus/rcl/engine_archive_test.go
@@ -1,0 +1,159 @@
+package rcl
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// fakeArchive captures the OnStale stream and the NoteFullyValidated
+// pivot so engine tests can assert against the archive contract without
+// pulling in the relational DB.
+type fakeArchive struct {
+	mu      sync.Mutex
+	stale   []*consensus.Validation
+	lastSeq atomic.Uint32
+
+	closeCalls atomic.Int32
+}
+
+func (f *fakeArchive) OnStale(v *consensus.Validation) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stale = append(f.stale, v)
+}
+
+func (f *fakeArchive) NoteFullyValidated(seq uint32) {
+	for {
+		cur := f.lastSeq.Load()
+		if seq <= cur {
+			return
+		}
+		if f.lastSeq.CompareAndSwap(cur, seq) {
+			return
+		}
+	}
+}
+
+func (f *fakeArchive) Close(ctx context.Context) error {
+	f.closeCalls.Add(1)
+	return nil
+}
+
+func (f *fakeArchive) staleCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.stale)
+}
+
+// TestEngine_SetArchive_PostStart wires an archive AFTER Start; the next
+// stale-eviction in the tracker must still reach the archive.
+func TestEngine_SetArchive_PostStart(t *testing.T) {
+	adaptor := newMockAdaptor()
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	if err := engine.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { engine.Stop() })
+
+	arc := &fakeArchive{}
+	engine.SetArchive(arc)
+
+	// Inject a validation directly on the tracker, then expire it.
+	v := &consensus.Validation{
+		LedgerSeq: 100,
+		LedgerID:  consensus.LedgerID{0x1},
+		NodeID:    consensus.NodeID{0x2},
+		SignTime:  time.Now(),
+		Full:      true,
+	}
+	if !engine.validationTracker.Add(v) {
+		t.Fatal("Add returned false; precondition broken")
+	}
+	engine.validationTracker.ExpireOld(200)
+
+	if arc.staleCount() != 1 {
+		t.Fatalf("archive received %d stale validations, want 1", arc.staleCount())
+	}
+}
+
+// TestEngine_FullyValidated_TriggersExpireOldAndArchive verifies the
+// happy path: a fully-validated callback advances the archive's pivot and
+// calls ExpireOld which streams pruned validations into the archive.
+func TestEngine_FullyValidated_TriggersExpireOldAndArchive(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.setTrusted([]consensus.NodeID{{1}, {2}, {3}})
+	adaptor.quorum = 2
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	arc := &fakeArchive{}
+	engine.SetArchive(arc)
+	engine.SetInMemoryLedgers(50)
+
+	if err := engine.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { engine.Stop() })
+
+	now := time.Now()
+
+	// Seed an old validation at seq 100 — well below the cutoff that the
+	// fully-validated callback at seq=300 will compute (300-50=250 → seq
+	// 100 is stale and must be archived on eviction).
+	old := &consensus.Validation{
+		LedgerSeq: 100,
+		LedgerID:  consensus.LedgerID{0xA},
+		NodeID:    consensus.NodeID{0x1},
+		SignTime:  now,
+		Full:      true,
+	}
+	if !engine.validationTracker.Add(old) {
+		t.Fatal("seed Add returned false")
+	}
+
+	// Drive two trusted validations at seq 300 so the tracker fires the
+	// fully-validated callback. Quorum=2.
+	for _, n := range []consensus.NodeID{{1}, {2}} {
+		v := &consensus.Validation{
+			LedgerSeq: 300,
+			LedgerID:  consensus.LedgerID{0xB},
+			NodeID:    n,
+			SignTime:  now,
+			Full:      true,
+		}
+		engine.validationTracker.Add(v)
+	}
+
+	if got := arc.lastSeq.Load(); got != 300 {
+		t.Fatalf("archive lastSeq=%d, want 300", got)
+	}
+	if arc.staleCount() != 1 {
+		t.Fatalf("archive received %d stale rows, want 1 (the seq-100 seed)", arc.staleCount())
+	}
+}
+
+// TestEngine_Stop_ClosesArchive confirms shutdown drains and closes the
+// archive — no validations should be lost across shutdown.
+func TestEngine_Stop_ClosesArchive(t *testing.T) {
+	adaptor := newMockAdaptor()
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	arc := &fakeArchive{}
+	engine.SetArchive(arc)
+
+	if err := engine.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	if arc.closeCalls.Load() != 1 {
+		t.Fatalf("Stop did not close the archive; closeCalls=%d", arc.closeCalls.Load())
+	}
+}

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -267,7 +267,27 @@ func isCurrent(now, signTime, seenTime time.Time) bool {
 //     wastes work on every checkFullValidation pass.
 //   - Per-node newer-seq-only rule: a node's latest validation
 //     supersedes any earlier one. Same as before.
+//
+// onFullyValidated is fired OUTSIDE vt.mu so the callback may take other
+// locks (engine.mu, archive channel send) or call back into the tracker
+// (e.g. ExpireOld) without deadlocking. Mirrors the lock-free callback
+// dispatch ExpireOld already uses for onStale.
+//
+// Defer order is LIFO: vt.mu.Unlock runs first (released before the
+// callback), then the captured fire-tuple is dispatched.
 func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
+	var (
+		fireID     consensus.LedgerID
+		fireSeq    uint32
+		shouldFire bool
+		cb         func(consensus.LedgerID, uint32)
+	)
+	defer func() {
+		if shouldFire && cb != nil {
+			cb(fireID, fireSeq)
+		}
+	}()
+
 	vt.mu.Lock()
 	defer vt.mu.Unlock()
 
@@ -323,17 +343,21 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	}
 	ledgerVals[resolvedID] = validation
 
-	// Check for full validation
-	vt.checkFullValidation(validation.LedgerID)
-
+	// Capture the fire-tuple under the lock; the deferred dispatcher
+	// invokes onFullyValidated after vt.mu.Unlock has run.
+	fireID, fireSeq, shouldFire = vt.checkFullValidationLocked(validation.LedgerID)
+	cb = vt.onFullyValidated
 	return true
 }
 
-// checkFullValidation checks if a ledger has reached full validation.
-// Fires the callback exactly once per ledger — the first time trusted
-// count crosses the quorum threshold. Subsequent adds for the same
-// ledger are ignored to avoid repeatedly flipping server_info's
-// validated_ledger on every late-arriving peer validation.
+// checkFullValidationLocked records that a ledger crossed the quorum
+// threshold (via vt.fired) and returns the (id, seq, shouldFire) tuple
+// the caller needs to invoke onFullyValidated outside the lock.
+//
+// Fires (well, requests-fire-by) exactly once per ledger — the first
+// time trusted count crosses the quorum threshold. Subsequent adds for
+// the same ledger are ignored to avoid repeatedly flipping
+// server_info's validated_ledger on every late-arriving peer validation.
 //
 // Zero-quorum edge case (empty UNL): requires at least one tracked
 // validation for the ledger before firing, so we don't spuriously
@@ -343,16 +367,18 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 // message acceptance but excluded from the quorum count here, matching
 // rippled's LedgerMaster.cpp:952. Same-quorum with a validator
 // temporarily disabled shouldn't require one MORE validation to finalize.
-func (vt *ValidationTracker) checkFullValidation(ledgerID consensus.LedgerID) {
+//
+// Caller MUST hold vt.mu.
+func (vt *ValidationTracker) checkFullValidationLocked(ledgerID consensus.LedgerID) (consensus.LedgerID, uint32, bool) {
 	if vt.onFullyValidated == nil {
-		return
+		return ledgerID, 0, false
 	}
 	if _, done := vt.fired[ledgerID]; done {
-		return
+		return ledgerID, 0, false
 	}
 	ledgerVals, exists := vt.validations[ledgerID]
 	if !exists || len(ledgerVals) == 0 {
-		return
+		return ledgerID, 0, false
 	}
 
 	var sampleSeq uint32
@@ -364,8 +390,9 @@ func (vt *ValidationTracker) checkFullValidation(ledgerID consensus.LedgerID) {
 
 	if trustedCount >= vt.quorum {
 		vt.fired[ledgerID] = struct{}{}
-		vt.onFullyValidated(ledgerID, sampleSeq)
+		return ledgerID, sampleSeq, true
 	}
+	return ledgerID, 0, false
 }
 
 // GetValidations returns all validations for a ledger.

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -67,6 +67,13 @@ type ValidationTracker struct {
 
 	// callbacks
 	onFullyValidated func(ledgerID consensus.LedgerID, ledgerSeq uint32)
+
+	// onStale is fired once per validation dropped by ExpireOld, after
+	// the tracker's internal maps have been mutated but before returning
+	// to the caller. Invoked outside vt.mu so callbacks (e.g. the archive
+	// writer's channel send) may do I/O without risking lock-order
+	// inversion. Nil means "no archive wired."
+	onStale func(*consensus.Validation)
 }
 
 // NewValidationTracker creates a new validation tracker.
@@ -172,6 +179,18 @@ func (vt *ValidationTracker) SetFullyValidatedCallback(fn func(ledgerID consensu
 	vt.mu.Lock()
 	defer vt.mu.Unlock()
 	vt.onFullyValidated = fn
+}
+
+// SetOnStale installs a callback invoked once per validation dropped by
+// ExpireOld. Mirrors rippled's Validations<Adaptor>::onStale contract —
+// consumed by the on-disk validation archive to persist stale validations
+// before they leave memory. Callback runs outside the tracker's mutex so it
+// may do blocking work (channel send to a batched writer); callers must
+// ensure it does not call back into the tracker. Pass nil to disable.
+func (vt *ValidationTracker) SetOnStale(fn func(*consensus.Validation)) {
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
+	vt.onStale = fn
 }
 
 // Validation freshness windows mirror rippled's Validations.h:626
@@ -506,19 +525,46 @@ func (vt *ValidationTracker) GetCurrentValidators() []consensus.NodeID {
 	return result
 }
 
-// ExpireOld removes old validations.
+// ExpireOld drops validations whose LedgerSeq is below minSeq from every
+// internal index, then fires onStale (if set) for each dropped validation
+// outside the mutex. All validations for a given ledger share a LedgerSeq,
+// so the staleness decision is taken from any one sample per ledger.
+//
+// Fixes a prior bug where byNode entries survived deletion — the node's
+// latest-validation pointer was kept pointing at a Validation removed from
+// the per-ledger map.
 func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 	vt.mu.Lock()
-	defer vt.mu.Unlock()
+
+	onStale := vt.onStale
+	var stale []*consensus.Validation
 
 	for ledgerID, ledgerVals := range vt.validations {
+		var sample *consensus.Validation
 		for _, v := range ledgerVals {
-			if v.LedgerSeq < minSeq {
-				delete(vt.validations, ledgerID)
-				delete(vt.fired, ledgerID)
-			}
+			sample = v
 			break
 		}
+		if sample == nil || sample.LedgerSeq >= minSeq {
+			continue
+		}
+		for nodeID, v := range ledgerVals {
+			stale = append(stale, v)
+			if latest, ok := vt.byNode[nodeID]; ok && latest == v {
+				delete(vt.byNode, nodeID)
+			}
+		}
+		delete(vt.validations, ledgerID)
+		delete(vt.fired, ledgerID)
+	}
+
+	vt.mu.Unlock()
+
+	if onStale == nil {
+		return
+	}
+	for _, v := range stale {
+		onStale(v)
 	}
 }
 

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -434,3 +434,82 @@ func TestValidationTracker_Stats(t *testing.T) {
 		t.Errorf("Expected 2 ledgers tracked, got %d", stats.LedgersTracked)
 	}
 }
+
+func TestValidationTracker_ExpireOld_FiresOnStale(t *testing.T) {
+	vt := NewValidationTracker(1, 5*time.Minute)
+
+	nodeA := consensus.NodeID{0xA}
+	nodeB := consensus.NodeID{0xB}
+	ledgerOld := consensus.LedgerID{1}
+	ledgerKeep := consensus.LedgerID{2}
+
+	vOldA := &consensus.Validation{LedgerID: ledgerOld, LedgerSeq: 100, NodeID: nodeA, SignTime: time.Now(), Full: true}
+	vOldB := &consensus.Validation{LedgerID: ledgerOld, LedgerSeq: 100, NodeID: nodeB, SignTime: time.Now(), Full: true}
+	vKeep := &consensus.Validation{LedgerID: ledgerKeep, LedgerSeq: 300, NodeID: nodeA, SignTime: time.Now(), Full: true}
+
+	vt.Add(vOldA)
+	vt.Add(vOldB)
+	vt.Add(vKeep)
+
+	var fired []*consensus.Validation
+	vt.SetOnStale(func(v *consensus.Validation) { fired = append(fired, v) })
+
+	vt.ExpireOld(200)
+
+	if len(fired) != 2 {
+		t.Fatalf("expected 2 onStale fires, got %d", len(fired))
+	}
+	// Both must be the seq=100 pair; the seq=300 validation is not stale.
+	for _, v := range fired {
+		if v.LedgerSeq != 100 {
+			t.Errorf("stale validation at seq %d leaked; expected only seq 100", v.LedgerSeq)
+		}
+	}
+	if got := vt.GetValidationCount(ledgerOld); got != 0 {
+		t.Errorf("stale ledger still has %d validations; expected 0", got)
+	}
+	if got := vt.GetValidationCount(ledgerKeep); got != 1 {
+		t.Errorf("current ledger lost validations: count=%d, expected 1", got)
+	}
+}
+
+func TestValidationTracker_ExpireOld_ClearsByNode(t *testing.T) {
+	vt := NewValidationTracker(1, 5*time.Minute)
+
+	nodeA := consensus.NodeID{0xA}
+	ledger := consensus.LedgerID{1}
+
+	vt.Add(&consensus.Validation{LedgerID: ledger, LedgerSeq: 100, NodeID: nodeA, SignTime: time.Now(), Full: true})
+	if vt.GetLatestValidation(nodeA) == nil {
+		t.Fatal("precondition: Add should have populated byNode")
+	}
+
+	vt.ExpireOld(200)
+
+	if vt.GetLatestValidation(nodeA) != nil {
+		t.Fatal("ExpireOld left stale entry in byNode map")
+	}
+}
+
+// ExpireOld's onStale hook runs outside the tracker mutex: a callback that
+// calls back into the tracker must not deadlock.
+func TestValidationTracker_ExpireOld_OnStaleRunsOutsideLock(t *testing.T) {
+	vt := NewValidationTracker(1, 5*time.Minute)
+	vt.Add(&consensus.Validation{LedgerID: consensus.LedgerID{1}, LedgerSeq: 100, NodeID: consensus.NodeID{1}, SignTime: time.Now(), Full: true})
+
+	done := make(chan struct{})
+	vt.SetOnStale(func(*consensus.Validation) {
+		// Re-entering the tracker under the lock would deadlock if we
+		// were still holding vt.mu at callback time.
+		_ = vt.GetValidationCount(consensus.LedgerID{1})
+		close(done)
+	})
+
+	vt.ExpireOld(200)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("onStale callback deadlocked or never fired")
+	}
+}

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -280,6 +280,13 @@ type Validation struct {
 	// relay + slot-feeding code doesn't have to recompute it. Zero on
 	// self-originated validations (Broadcast skips the reverse index).
 	SuppressionHash [32]byte
+
+	// Raw is the original wire bytes of the serialized STValidation.
+	// Populated by parseSTValidation for inbound validations. Nil for
+	// self-built validations until SerializeSTValidation is called.
+	// Used by the validation archive to persist the canonical blob
+	// without a parse → re-serialize round-trip.
+	Raw []byte
 }
 
 // AvalancheState tracks per-dispute threshold escalation during

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -205,7 +205,16 @@ type Validation struct {
 	Signature []byte
 
 	// Full indicates if this is a full validation (vs partial).
+	// Derived from (Flags & vfFullValidation) != 0; carried alongside
+	// Flags so existing call sites that branch on Full keep working.
 	Full bool
+
+	// Flags is the original sfFlags wire word as signed by the
+	// validator. parseSTValidation captures it verbatim; outbound
+	// self-built validations set vfFullValidation | vfFullyCanonicalSig.
+	// Consumers reading the field should mask known bits — rippled may
+	// set additional vendor flags we don't yet recognize.
+	Flags uint32
 
 	// Cookie is a unique identifier for this validation session.
 	Cookie uint64

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -36,15 +36,18 @@ type ValidationArchiveLookup interface {
 // ArchivedValidation is the RPC-shaped projection of a validation row.
 // Kept here (rather than re-exporting relationaldb.ValidationRecord) so
 // the RPC layer never depends on the storage package.
+//
+// The signature is part of Raw (sfSignature in the canonical XRPL wire
+// format) — handlers that need it parse Raw via the binary codec rather
+// than reading a separate column.
 type ArchivedValidation struct {
 	LedgerSeq  uint32
 	LedgerHash [32]byte
 	NodePubKey []byte
-	Signature  []byte
 	SignTimeS  int64 // unix seconds
 	SeenTimeS  int64
 	Flags      uint32
-	Raw        []byte
+	Raw        []byte // canonical STValidation wire bytes (includes signature)
 }
 
 // ManifestLookup is the read-only facet of the validator-manifest cache

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -17,6 +17,36 @@ type MethodDispatcher interface {
 	ExecuteMethod(method string, params []byte) (interface{}, *RpcError)
 }
 
+// ValidationArchiveLookup is the read-only facet of the on-disk
+// validation archive that historical-query RPC handlers can consume.
+// Expressed as an interface so internal/rpc/types stays free of
+// storage/relationaldb dependencies and the handler can mock it.
+type ValidationArchiveLookup interface {
+	// GetValidationsForLedger returns every archived validation for a
+	// given ledger sequence. Order unspecified.
+	GetValidationsForLedger(ledgerSeq uint32) ([]ArchivedValidation, error)
+	// GetValidationsByValidator returns up to `limit` most-recent
+	// archived validations from the given node public key. limit <= 0
+	// applies no bound.
+	GetValidationsByValidator(nodeKey []byte, limit int) ([]ArchivedValidation, error)
+	// GetValidationCount returns the total number of archived rows.
+	GetValidationCount() (int64, error)
+}
+
+// ArchivedValidation is the RPC-shaped projection of a validation row.
+// Kept here (rather than re-exporting relationaldb.ValidationRecord) so
+// the RPC layer never depends on the storage package.
+type ArchivedValidation struct {
+	LedgerSeq  uint32
+	LedgerHash [32]byte
+	NodePubKey []byte
+	Signature  []byte
+	SignTimeS  int64 // unix seconds
+	SeenTimeS  int64
+	Flags      uint32
+	Raw        []byte
+}
+
 // ManifestLookup is the read-only facet of the validator-manifest cache
 // that the `manifest` RPC needs. Expressed as an interface (not a
 // concrete type) so internal/rpc/types doesn't import
@@ -63,6 +93,11 @@ type ServiceContainer struct {
 	// built (e.g. in standalone mode without p2p); handlers must
 	// nil-check before use.
 	Manifests ManifestLookup
+
+	// ValidationArchive provides historical access to archived stale
+	// validations. Nil when the archive is disabled or the relational
+	// DB is not configured; handlers must nil-check before use.
+	ValidationArchive ValidationArchiveLookup
 }
 
 // LedgerNavigator provides ledger index navigation and mode queries.

--- a/internal/testing/validationarchive/archive_test.go
+++ b/internal/testing/validationarchive/archive_test.go
@@ -1,0 +1,276 @@
+// Package validationarchive holds end-to-end tests for the on-disk
+// validation archive (issue #267). These wire a real ValidationTracker,
+// a real archive.Archive, and a real SQLite-backed ValidationRepository
+// — no mocks — so the tests document the integration contract.
+package validationarchive
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/archive"
+	"github.com/LeJamon/goXRPLd/internal/consensus/rcl"
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+	"github.com/LeJamon/goXRPLd/storage/relationaldb/sqlite"
+)
+
+func openArchiveDB(t *testing.T) *sqlite.RepositoryManager {
+	t.Helper()
+	rm, err := sqlite.NewRepositoryManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rm.Open(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { rm.Close(context.Background()) })
+	return rm
+}
+
+func mkValidation(seq uint32, node byte) *consensus.Validation {
+	v := &consensus.Validation{
+		LedgerSeq: seq,
+		Full:      true,
+		SignTime:  time.Now(),
+		Signature: []byte{0xAB, 0xCD, byte(seq), node},
+		Raw:       []byte{0xFE, 0xED, byte(seq >> 8), byte(seq), node},
+	}
+	v.LedgerID[0] = byte(seq >> 8)
+	v.LedgerID[1] = byte(seq)
+	v.LedgerID[31] = node
+	v.NodeID[0] = 0x02
+	v.NodeID[32] = node
+	return v
+}
+
+// TestValidationArchive_StaleValidationWrittenOnPrune is the first of
+// the three acceptance tests called out in issue #267.
+func TestValidationArchive_StaleValidationWrittenOnPrune(t *testing.T) {
+	rm := openArchiveDB(t)
+	repo := rm.Validation()
+
+	a := archive.New(repo, archive.Config{
+		BatchSize:     1,
+		FlushInterval: 10 * time.Millisecond,
+		DeleteBatch:   1000,
+	}, nil)
+	defer a.Close(context.Background())
+
+	tracker := rcl.NewValidationTracker(1, 5*time.Minute)
+	tracker.SetOnStale(a.OnStale)
+
+	v := mkValidation(100, 0x01)
+	if !tracker.Add(v) {
+		t.Fatal("Add returned false; precondition broken")
+	}
+
+	tracker.ExpireOld(200) // v becomes stale
+
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := repo.GetValidationsForLedger(context.Background(), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("archive missing the stale validation: got %d rows, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.LedgerSeq != 100 {
+		t.Errorf("LedgerSeq=%d, want 100", got.LedgerSeq)
+	}
+	if got.LedgerHash != relationaldb.Hash(v.LedgerID) {
+		t.Errorf("LedgerHash mismatch:\n got  %x\n want %x", got.LedgerHash, v.LedgerID)
+	}
+	if string(got.NodePubKey) != string(v.NodeID[:]) {
+		t.Errorf("NodePubKey mismatch")
+	}
+	if string(got.Raw) != string(v.Raw) {
+		t.Errorf("Raw bytes mismatch")
+	}
+}
+
+// slowRepo wraps a real repo to inject latency on SaveBatch — exercises
+// the channel-buffered, non-blocking property of OnStale.
+type slowRepo struct {
+	relationaldb.ValidationRepository
+	wait time.Duration
+}
+
+func (s *slowRepo) SaveBatch(ctx context.Context, vs []*relationaldb.ValidationRecord) error {
+	time.Sleep(s.wait)
+	return s.ValidationRepository.SaveBatch(ctx, vs)
+}
+
+// TestValidationArchive_BatchedWriter_DoesNotBlockOnReceive is the second
+// acceptance test from issue #267. OnStale must return in well under the
+// SaveBatch latency budget — proving the writer is decoupled from the
+// receive path via a buffered channel.
+func TestValidationArchive_BatchedWriter_DoesNotBlockOnReceive(t *testing.T) {
+	rm := openArchiveDB(t)
+	repo := &slowRepo{
+		ValidationRepository: rm.Validation(),
+		wait:                 50 * time.Millisecond, // each SaveBatch is glacial
+	}
+
+	const enqueues = 1000
+	a := archive.New(repo, archive.Config{
+		BatchSize:     128,
+		FlushInterval: 5 * time.Millisecond,
+		DeleteBatch:   1,
+	}, nil)
+	defer a.Close(context.Background())
+
+	// 1000 OnStale calls into a channel of capacity BatchSize*8=1024.
+	// Even with the slow repo, the loop must complete near-instantly.
+	deadline := 200 * time.Millisecond
+	start := time.Now()
+	for i := 0; i < enqueues; i++ {
+		a.OnStale(mkValidation(uint32(i+1), byte(i&0xFF)))
+	}
+	if elapsed := time.Since(start); elapsed > deadline {
+		t.Fatalf("OnStale loop blocked: enqueued %d in %v (deadline %v)", enqueues, elapsed, deadline)
+	}
+
+	// All enqueued rows must eventually land in the repo (Flush blocks
+	// until the writer drains everything that was queued before the
+	// flush request).
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	count, err := rm.Validation().GetValidationCount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != int64(enqueues) {
+		t.Fatalf("after Flush, archive has %d rows, want %d", count, enqueues)
+	}
+}
+
+// TestValidationArchive_RetentionRespected is the third acceptance test
+// from issue #267. Archive 20 rows at seqs 1..20 with retention=10 and a
+// fully-validated pivot of 20: rows below seq 10 must be deleted; rows
+// 10..20 must remain.
+func TestValidationArchive_RetentionRespected(t *testing.T) {
+	rm := openArchiveDB(t)
+	repo := rm.Validation()
+
+	a := archive.New(repo, archive.Config{
+		BatchSize:        1,
+		FlushInterval:    time.Hour, // size-only flush
+		RetentionLedgers: 10,
+		DeleteBatch:      1000,
+	}, nil)
+	defer a.Close(context.Background())
+
+	for seq := uint32(1); seq <= 20; seq++ {
+		a.OnStale(mkValidation(seq, byte(seq)))
+	}
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	a.NoteFullyValidated(20)
+	if _, err := a.ApplyRetention(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := repo.GetValidationCount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// cutoff = 20 - 10 = 10 → DELETE WHERE seq < 10 → seqs 1..9 gone,
+	// seqs 10..20 remain (11 rows).
+	if count != 11 {
+		t.Fatalf("post-retention rows = %d, want 11 (seqs 10..20)", count)
+	}
+
+	gone, err := repo.GetValidationsForLedger(context.Background(), 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gone) != 0 {
+		t.Errorf("seq=5 should be retained-out: got %d rows", len(gone))
+	}
+
+	keep, err := repo.GetValidationsForLedger(context.Background(), 15)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keep) != 1 {
+		t.Errorf("seq=15 should remain: got %d rows", len(keep))
+	}
+}
+
+// TestValidationArchive_EngineDrivenFlow validates the full end-to-end
+// path: engine wires the archive, drives ExpireOld via the fully-
+// validated callback, and the archive captures evicted validations.
+func TestValidationArchive_EngineDrivenFlow(t *testing.T) {
+	rm := openArchiveDB(t)
+	repo := rm.Validation()
+
+	a := archive.New(repo, archive.Config{
+		BatchSize:     8,
+		FlushInterval: 10 * time.Millisecond,
+		DeleteBatch:   1000,
+	}, nil)
+	defer a.Close(context.Background())
+
+	tracker := rcl.NewValidationTracker(2, 5*time.Minute)
+	trustedNodes := []consensus.NodeID{{1}, {2}, {3}}
+	tracker.SetTrusted(trustedNodes)
+	tracker.SetOnStale(a.OnStale)
+
+	// Pretend the engine wired its fully-validated callback to drive
+	// ExpireOld with an in-memory window of 50.
+	const inMemoryLedgers = uint32(50)
+	var fired atomic.Int32
+	tracker.SetFullyValidatedCallback(func(_ consensus.LedgerID, seq uint32) {
+		fired.Add(1)
+		a.NoteFullyValidated(seq)
+		if seq > inMemoryLedgers {
+			tracker.ExpireOld(seq - inMemoryLedgers)
+		}
+	})
+
+	// Seed an old validation at seq 100 — well below the cutoff that
+	// the seq=300 fully-validated event will compute (300-50=250).
+	old := mkValidation(100, 0x01)
+	if !tracker.Add(old) {
+		t.Fatal("seed Add returned false")
+	}
+
+	// Drive quorum at seq 300: two trusted validations for the SAME
+	// ledger hash (mkValidation's hash varies by node, so we pin a
+	// deterministic LedgerID here and only swap NodeID).
+	sharedLedger := consensus.LedgerID{0xCA, 0xFE, 0xBA, 0xBE}
+	for _, n := range []consensus.NodeID{{1}, {2}} {
+		v := mkValidation(300, byte(n[0]))
+		v.LedgerID = sharedLedger
+		v.NodeID = n
+		if !tracker.Add(v) {
+			t.Fatalf("Add at seq=300 returned false for node %v", n)
+		}
+	}
+
+	if got := fired.Load(); got != 1 {
+		t.Fatalf("fully-validated callback fired %d times, want 1", got)
+	}
+
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := repo.GetValidationsForLedger(context.Background(), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("archive expected to contain the seq-100 evictee: got %d rows", len(rows))
+	}
+}

--- a/internal/testing/validationarchive/archive_test.go
+++ b/internal/testing/validationarchive/archive_test.go
@@ -250,7 +250,7 @@ func TestValidationArchive_EngineDrivenFlow(t *testing.T) {
 	// deterministic LedgerID here and only swap NodeID).
 	sharedLedger := consensus.LedgerID{0xCA, 0xFE, 0xBA, 0xBE}
 	for _, n := range []consensus.NodeID{{1}, {2}} {
-		v := mkValidation(300, byte(n[0]))
+		v := mkValidation(300, n[0])
 		v.LedgerID = sharedLedger
 		v.NodeID = n
 		if !tracker.Add(v) {

--- a/storage/relationaldb/interface.go
+++ b/storage/relationaldb/interface.go
@@ -176,6 +176,7 @@ type RepositoryManager interface {
 	Ledger() LedgerRepository
 	Transaction() TransactionRepository
 	AccountTransaction() AccountTransactionRepository
+	Validation() ValidationRepository
 	System() SystemRepository
 
 	// Connection management

--- a/storage/relationaldb/postgres/repository_manager.go
+++ b/storage/relationaldb/postgres/repository_manager.go
@@ -111,6 +111,13 @@ func (rm *RepositoryManager) System() relationaldb.SystemRepository {
 	return rm.systemRepo
 }
 
+// Validation returns the validation archive repository. Stubbed nil until
+// the PostgreSQL impl lands — callers gating on a non-nil value treat the
+// archive as disabled.
+func (rm *RepositoryManager) Validation() relationaldb.ValidationRepository {
+	return nil
+}
+
 func (rm *RepositoryManager) WithTransaction(ctx context.Context, fn func(relationaldb.TransactionContext) error) error {
 	tx, err := rm.systemRepo.Begin(ctx)
 	if err != nil {

--- a/storage/relationaldb/postgres/repository_manager.go
+++ b/storage/relationaldb/postgres/repository_manager.go
@@ -18,6 +18,7 @@ type RepositoryManager struct {
 	transactionRepo        *TransactionRepository
 	accountTransactionRepo *AccountTransactionRepository
 	systemRepo             *SystemRepository
+	validationRepo         *ValidationRepository
 }
 
 // NewRepositoryManager creates a new PostgreSQL repository manager
@@ -70,6 +71,7 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 	rm.transactionRepo = NewTransactionRepository(rm.db)
 	rm.accountTransactionRepo = NewAccountTransactionRepository(rm.db)
 	rm.systemRepo = NewSystemRepository(rm.db)
+	rm.validationRepo = NewValidationRepository(rm.db)
 
 	return nil
 }
@@ -87,6 +89,7 @@ func (rm *RepositoryManager) Close(ctx context.Context) error {
 	rm.transactionRepo = nil
 	rm.accountTransactionRepo = nil
 	rm.systemRepo = nil
+	rm.validationRepo = nil
 
 	if err != nil {
 		return relationaldb.NewConnectionError("close", "failed to close database connection", err)
@@ -111,11 +114,8 @@ func (rm *RepositoryManager) System() relationaldb.SystemRepository {
 	return rm.systemRepo
 }
 
-// Validation returns the validation archive repository. Stubbed nil until
-// the PostgreSQL impl lands — callers gating on a non-nil value treat the
-// archive as disabled.
 func (rm *RepositoryManager) Validation() relationaldb.ValidationRepository {
-	return nil
+	return rm.validationRepo
 }
 
 func (rm *RepositoryManager) WithTransaction(ctx context.Context, fn func(relationaldb.TransactionContext) error) error {
@@ -181,6 +181,22 @@ func (rm *RepositoryManager) initSchema(ctx context.Context) error {
 			PRIMARY KEY (trans_id, account)
 		)`,
 
+		// Validations table — rippled's pre-May-2019 historical schema,
+		// augmented with seen_time + flags for receive-side forensics.
+		`CREATE TABLE IF NOT EXISTS validations (
+			ledger_seq   BIGINT NOT NULL,
+			initial_seq  BIGINT NOT NULL,
+			ledger_hash  BYTEA NOT NULL,
+			node_pubkey  BYTEA NOT NULL,
+			signature    BYTEA NOT NULL,
+			sign_time    BIGINT NOT NULL,
+			seen_time    BIGINT NOT NULL,
+			flags        BIGINT NOT NULL,
+			raw          BYTEA NOT NULL,
+			created_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+			PRIMARY KEY (ledger_hash, node_pubkey)
+		)`,
+
 		// Indexes matching rippled's performance optimizations
 		`CREATE INDEX IF NOT EXISTS idx_ledgers_seq ON ledgers(ledger_seq)`,
 		`CREATE INDEX IF NOT EXISTS idx_ledgers_closing_time ON ledgers(closing_time)`,
@@ -188,6 +204,10 @@ func (rm *RepositoryManager) initSchema(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS idx_account_transactions_account ON account_transactions(account)`,
 		`CREATE INDEX IF NOT EXISTS idx_account_transactions_ledger_seq ON account_transactions(ledger_seq)`,
 		`CREATE INDEX IF NOT EXISTS idx_account_transactions_account_ledger_txn ON account_transactions(account, ledger_seq, txn_seq)`,
+		`CREATE INDEX IF NOT EXISTS idx_validations_seq       ON validations(ledger_seq)`,
+		`CREATE INDEX IF NOT EXISTS idx_validations_node      ON validations(node_pubkey, ledger_seq)`,
+		`CREATE INDEX IF NOT EXISTS idx_validations_sign_time ON validations(sign_time)`,
+		`CREATE INDEX IF NOT EXISTS idx_validations_initial   ON validations(initial_seq, ledger_seq)`,
 	}
 
 	for _, query := range queries {

--- a/storage/relationaldb/postgres/repository_manager.go
+++ b/storage/relationaldb/postgres/repository_manager.go
@@ -188,7 +188,6 @@ func (rm *RepositoryManager) initSchema(ctx context.Context) error {
 			initial_seq  BIGINT NOT NULL,
 			ledger_hash  BYTEA NOT NULL,
 			node_pubkey  BYTEA NOT NULL,
-			signature    BYTEA NOT NULL,
 			sign_time    BIGINT NOT NULL,
 			seen_time    BIGINT NOT NULL,
 			flags        BIGINT NOT NULL,

--- a/storage/relationaldb/postgres/validation_repository.go
+++ b/storage/relationaldb/postgres/validation_repository.go
@@ -1,0 +1,216 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+// ValidationRepository is the PostgreSQL-backed on-disk validation archive.
+// Mirrors the SQLite backend row-for-row so RPC/forensic code sees the same
+// shape regardless of deployment.
+type ValidationRepository struct {
+	db *sql.DB
+	tx *sql.Tx
+}
+
+// Compile-time interface check.
+var _ relationaldb.ValidationRepository = (*ValidationRepository)(nil)
+
+func NewValidationRepository(db *sql.DB) *ValidationRepository {
+	return &ValidationRepository{db: db}
+}
+
+func NewValidationRepositoryWithTx(tx *sql.Tx) *ValidationRepository {
+	return &ValidationRepository{tx: tx}
+}
+
+func (r *ValidationRepository) getExecutor() executor {
+	if r.tx != nil {
+		return r.tx
+	}
+	return r.db
+}
+
+const validationSelectCols = `ledger_seq, initial_seq, ledger_hash, node_pubkey,
+	signature, sign_time, seen_time, flags, raw`
+
+// xrplEpochOffset matches the SQLite backend so times round-trip across
+// backends without drift. See the SQLite impl for rationale.
+const xrplEpochOffset int64 = 946684800
+
+func toXRPLEpochSeconds(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.Unix() - xrplEpochOffset
+}
+
+func fromXRPLEpochSeconds(s int64) time.Time {
+	if s == 0 {
+		return time.Time{}
+	}
+	return time.Unix(s+xrplEpochOffset, 0).UTC()
+}
+
+func (r *ValidationRepository) Save(ctx context.Context, v *relationaldb.ValidationRecord) error {
+	if v == nil {
+		return relationaldb.NewDataError("validation_save", "nil record", nil)
+	}
+	_, err := r.getExecutor().ExecContext(ctx, `
+		INSERT INTO validations (
+			ledger_seq, initial_seq, ledger_hash, node_pubkey,
+			signature, sign_time, seen_time, flags, raw
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (ledger_hash, node_pubkey) DO NOTHING
+	`,
+		int64(v.LedgerSeq), int64(v.InitialSeq), v.LedgerHash[:], v.NodePubKey,
+		v.Signature, toXRPLEpochSeconds(v.SignTime), toXRPLEpochSeconds(v.SeenTime),
+		int64(v.Flags), v.Raw,
+	)
+	if err != nil {
+		return relationaldb.NewQueryError("validation_save", "failed to insert validation", err)
+	}
+	return nil
+}
+
+func (r *ValidationRepository) SaveBatch(ctx context.Context, vs []*relationaldb.ValidationRecord) error {
+	if len(vs) == 0 {
+		return nil
+	}
+	if r.tx != nil {
+		for _, v := range vs {
+			if err := r.Save(ctx, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return relationaldb.NewTransactionError("validation_save_batch", "failed to begin transaction", err)
+	}
+	txRepo := NewValidationRepositoryWithTx(tx)
+	for _, v := range vs {
+		if err := txRepo.Save(ctx, v); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return relationaldb.NewTransactionError("validation_save_batch", "failed to commit batch", err)
+	}
+	return nil
+}
+
+func (r *ValidationRepository) scanRow(row interface {
+	Scan(dest ...interface{}) error
+}) (*relationaldb.ValidationRecord, error) {
+	var rec relationaldb.ValidationRecord
+	var ledgerSeq, initialSeq, signTime, seenTime int64
+	var flags int64
+	var ledgerHash []byte
+
+	if err := row.Scan(
+		&ledgerSeq, &initialSeq, &ledgerHash, &rec.NodePubKey,
+		&rec.Signature, &signTime, &seenTime, &flags, &rec.Raw,
+	); err != nil {
+		return nil, err
+	}
+
+	rec.LedgerSeq = relationaldb.LedgerIndex(ledgerSeq)
+	rec.InitialSeq = relationaldb.LedgerIndex(initialSeq)
+	copy(rec.LedgerHash[:], ledgerHash)
+	rec.SignTime = fromXRPLEpochSeconds(signTime)
+	rec.SeenTime = fromXRPLEpochSeconds(seenTime)
+	rec.Flags = uint32(flags)
+	return &rec, nil
+}
+
+func (r *ValidationRepository) GetValidationsForLedger(ctx context.Context, seq relationaldb.LedgerIndex) ([]*relationaldb.ValidationRecord, error) {
+	rows, err := r.getExecutor().QueryContext(ctx,
+		`SELECT `+validationSelectCols+` FROM validations WHERE ledger_seq = $1`, int64(seq))
+	if err != nil {
+		return nil, relationaldb.NewQueryError("validation_get_for_ledger", "failed to query validations", err)
+	}
+	defer rows.Close()
+
+	var result []*relationaldb.ValidationRecord
+	for rows.Next() {
+		rec, err := r.scanRow(rows)
+		if err != nil {
+			return nil, relationaldb.NewQueryError("validation_get_for_ledger", "failed to scan row", err)
+		}
+		result = append(result, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, relationaldb.NewQueryError("validation_get_for_ledger", "row iteration error", err)
+	}
+	return result, nil
+}
+
+func (r *ValidationRepository) GetValidationsByValidator(ctx context.Context, nodeKey []byte, limit int) ([]*relationaldb.ValidationRecord, error) {
+	q := `SELECT ` + validationSelectCols + ` FROM validations WHERE node_pubkey = $1 ORDER BY ledger_seq DESC`
+	args := []interface{}{nodeKey}
+	if limit > 0 {
+		q += ` LIMIT $2`
+		args = append(args, limit)
+	}
+
+	rows, err := r.getExecutor().QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, relationaldb.NewQueryError("validation_get_by_validator", "failed to query validations", err)
+	}
+	defer rows.Close()
+
+	var result []*relationaldb.ValidationRecord
+	for rows.Next() {
+		rec, err := r.scanRow(rows)
+		if err != nil {
+			return nil, relationaldb.NewQueryError("validation_get_by_validator", "failed to scan row", err)
+		}
+		result = append(result, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, relationaldb.NewQueryError("validation_get_by_validator", "row iteration error", err)
+	}
+	return result, nil
+}
+
+func (r *ValidationRepository) GetValidationCount(ctx context.Context) (int64, error) {
+	var count int64
+	err := r.getExecutor().QueryRowContext(ctx, `SELECT COUNT(*) FROM validations`).Scan(&count)
+	if err != nil {
+		return 0, relationaldb.NewQueryError("validation_count", "failed to count validations", err)
+	}
+	return count, nil
+}
+
+// DeleteOlderThanSeq removes up to batchSize rows with ledger_seq < maxSeq.
+// Uses a CTID-based bounded DELETE so a single retention sweep never blocks
+// the writer on an unbounded scan.
+func (r *ValidationRepository) DeleteOlderThanSeq(ctx context.Context, maxSeq relationaldb.LedgerIndex, batchSize int) (int64, error) {
+	var res sql.Result
+	var err error
+	if batchSize > 0 {
+		res, err = r.getExecutor().ExecContext(ctx, `
+			DELETE FROM validations WHERE ctid IN (
+				SELECT ctid FROM validations WHERE ledger_seq < $1 LIMIT $2
+			)
+		`, int64(maxSeq), batchSize)
+	} else {
+		res, err = r.getExecutor().ExecContext(ctx,
+			`DELETE FROM validations WHERE ledger_seq < $1`, int64(maxSeq))
+	}
+	if err != nil {
+		return 0, relationaldb.NewQueryError("validation_delete_older", "failed to delete old validations", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, relationaldb.NewQueryError("validation_delete_older", "failed to read affected rows", err)
+	}
+	return n, nil
+}

--- a/storage/relationaldb/postgres/validation_repository.go
+++ b/storage/relationaldb/postgres/validation_repository.go
@@ -35,7 +35,7 @@ func (r *ValidationRepository) getExecutor() executor {
 }
 
 const validationSelectCols = `ledger_seq, initial_seq, ledger_hash, node_pubkey,
-	signature, sign_time, seen_time, flags, raw`
+	sign_time, seen_time, flags, raw`
 
 // xrplEpochOffset matches the SQLite backend so times round-trip across
 // backends without drift. See the SQLite impl for rationale.
@@ -62,12 +62,12 @@ func (r *ValidationRepository) Save(ctx context.Context, v *relationaldb.Validat
 	_, err := r.getExecutor().ExecContext(ctx, `
 		INSERT INTO validations (
 			ledger_seq, initial_seq, ledger_hash, node_pubkey,
-			signature, sign_time, seen_time, flags, raw
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			sign_time, seen_time, flags, raw
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (ledger_hash, node_pubkey) DO NOTHING
 	`,
 		int64(v.LedgerSeq), int64(v.InitialSeq), v.LedgerHash[:], v.NodePubKey,
-		v.Signature, toXRPLEpochSeconds(v.SignTime), toXRPLEpochSeconds(v.SeenTime),
+		toXRPLEpochSeconds(v.SignTime), toXRPLEpochSeconds(v.SeenTime),
 		int64(v.Flags), v.Raw,
 	)
 	if err != nil {
@@ -116,7 +116,7 @@ func (r *ValidationRepository) scanRow(row interface {
 
 	if err := row.Scan(
 		&ledgerSeq, &initialSeq, &ledgerHash, &rec.NodePubKey,
-		&rec.Signature, &signTime, &seenTime, &flags, &rec.Raw,
+		&signTime, &seenTime, &flags, &rec.Raw,
 	); err != nil {
 		return nil, err
 	}

--- a/storage/relationaldb/sqlite/repository_manager.go
+++ b/storage/relationaldb/sqlite/repository_manager.go
@@ -23,6 +23,7 @@ type RepositoryManager struct {
 	transactionRepo        *TransactionRepository
 	accountTransactionRepo *AccountTransactionRepository
 	systemRepo             *SystemRepository
+	validationRepo         *ValidationRepository
 }
 
 // Compile-time interface check
@@ -80,6 +81,10 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 		rm.close()
 		return relationaldb.NewSchemaError("open", "failed to initialize ledger schema", err)
 	}
+	if err := rm.initValidationSchema(ctx); err != nil {
+		rm.close()
+		return relationaldb.NewSchemaError("open", "failed to initialize validation schema", err)
+	}
 	if err := rm.initTxSchema(ctx); err != nil {
 		rm.close()
 		return relationaldb.NewSchemaError("open", "failed to initialize transaction schema", err)
@@ -89,6 +94,7 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 	rm.transactionRepo = NewTransactionRepository(rm.txDB)
 	rm.accountTransactionRepo = NewAccountTransactionRepository(rm.txDB)
 	rm.systemRepo = NewSystemRepository(rm.ledgerDB, rm.txDB)
+	rm.validationRepo = NewValidationRepository(rm.ledgerDB)
 
 	return nil
 }
@@ -115,6 +121,7 @@ func (rm *RepositoryManager) close() error {
 	rm.transactionRepo = nil
 	rm.accountTransactionRepo = nil
 	rm.systemRepo = nil
+	rm.validationRepo = nil
 
 	if firstErr != nil {
 		return relationaldb.NewConnectionError("close", "failed to close database", firstErr)
@@ -138,11 +145,8 @@ func (rm *RepositoryManager) System() relationaldb.SystemRepository {
 	return rm.systemRepo
 }
 
-// Validation returns the validation archive repository. Stubbed nil until
-// the SQLite impl lands — callers gating on a non-nil value treat the
-// archive as disabled.
 func (rm *RepositoryManager) Validation() relationaldb.ValidationRepository {
-	return nil
+	return rm.validationRepo
 }
 
 func (rm *RepositoryManager) WithTransaction(ctx context.Context, fn func(relationaldb.TransactionContext) error) error {
@@ -201,6 +205,37 @@ func (rm *RepositoryManager) initLedgerSchema(ctx context.Context) error {
 			trans_set_hash BLOB NOT NULL
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_ledgers_seq ON ledgers(ledger_seq)`,
+	}
+	for _, q := range queries {
+		if _, err := rm.ledgerDB.ExecContext(ctx, q); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// initValidationSchema installs the on-disk validation archive table.
+// Cohabits ledger.db — see ValidationRepository for the rationale.
+// Columns mirror rippled's historical Validations DDL (DBInit.h,
+// pre-May-2019) with SeenTime + Flags added for receive-side forensics.
+func (rm *RepositoryManager) initValidationSchema(ctx context.Context) error {
+	queries := []string{
+		`CREATE TABLE IF NOT EXISTS validations (
+			ledger_seq   INTEGER NOT NULL,
+			initial_seq  INTEGER NOT NULL,
+			ledger_hash  BLOB NOT NULL,
+			node_pubkey  BLOB NOT NULL,
+			signature    BLOB NOT NULL,
+			sign_time    INTEGER NOT NULL,
+			seen_time    INTEGER NOT NULL,
+			flags        INTEGER NOT NULL,
+			raw          BLOB NOT NULL,
+			PRIMARY KEY (ledger_hash, node_pubkey)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_validations_seq       ON validations(ledger_seq)`,
+		`CREATE INDEX IF NOT EXISTS idx_validations_node      ON validations(node_pubkey, ledger_seq)`,
+		`CREATE INDEX IF NOT EXISTS idx_validations_sign_time ON validations(sign_time)`,
+		`CREATE INDEX IF NOT EXISTS idx_validations_initial   ON validations(initial_seq, ledger_seq)`,
 	}
 	for _, q := range queries {
 		if _, err := rm.ledgerDB.ExecContext(ctx, q); err != nil {

--- a/storage/relationaldb/sqlite/repository_manager.go
+++ b/storage/relationaldb/sqlite/repository_manager.go
@@ -225,7 +225,6 @@ func (rm *RepositoryManager) initValidationSchema(ctx context.Context) error {
 			initial_seq  INTEGER NOT NULL,
 			ledger_hash  BLOB NOT NULL,
 			node_pubkey  BLOB NOT NULL,
-			signature    BLOB NOT NULL,
 			sign_time    INTEGER NOT NULL,
 			seen_time    INTEGER NOT NULL,
 			flags        INTEGER NOT NULL,

--- a/storage/relationaldb/sqlite/repository_manager.go
+++ b/storage/relationaldb/sqlite/repository_manager.go
@@ -138,6 +138,13 @@ func (rm *RepositoryManager) System() relationaldb.SystemRepository {
 	return rm.systemRepo
 }
 
+// Validation returns the validation archive repository. Stubbed nil until
+// the SQLite impl lands — callers gating on a non-nil value treat the
+// archive as disabled.
+func (rm *RepositoryManager) Validation() relationaldb.ValidationRepository {
+	return nil
+}
+
 func (rm *RepositoryManager) WithTransaction(ctx context.Context, fn func(relationaldb.TransactionContext) error) error {
 	tx, err := rm.txDB.BeginTx(ctx, nil)
 	if err != nil {

--- a/storage/relationaldb/sqlite/validation_repository.go
+++ b/storage/relationaldb/sqlite/validation_repository.go
@@ -1,0 +1,221 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+// ValidationRepository is the SQLite-backed on-disk validation archive.
+// Schema deliberately cohabits ledger.db — validations are heavily
+// joined with the Ledgers table in rippled's forensic queries (they
+// mirror ledger-seq + ledger-hash), and opening a third DB file for a
+// single table would bloat the file layout without any write-concurrency
+// win (SQLite serializes writes across files in the same process).
+type ValidationRepository struct {
+	db *sql.DB
+	tx *sql.Tx
+}
+
+// Compile-time interface check.
+var _ relationaldb.ValidationRepository = (*ValidationRepository)(nil)
+
+func NewValidationRepository(db *sql.DB) *ValidationRepository {
+	return &ValidationRepository{db: db}
+}
+
+func NewValidationRepositoryWithTx(tx *sql.Tx) *ValidationRepository {
+	return &ValidationRepository{tx: tx}
+}
+
+func (r *ValidationRepository) getExecutor() executor {
+	if r.tx != nil {
+		return r.tx
+	}
+	return r.db
+}
+
+const validationSelectCols = `ledger_seq, initial_seq, ledger_hash, node_pubkey,
+	signature, sign_time, seen_time, flags, raw`
+
+// xrplEpochOffset is the difference between Unix epoch (1970-01-01) and
+// the XRPL epoch (2000-01-01). Times stored in the archive are XRPL-epoch
+// seconds to stay wire-compatible with the serialized SignTime field.
+const xrplEpochOffset int64 = 946684800
+
+func toXRPLEpochSeconds(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.Unix() - xrplEpochOffset
+}
+
+func fromXRPLEpochSeconds(s int64) time.Time {
+	if s == 0 {
+		return time.Time{}
+	}
+	return time.Unix(s+xrplEpochOffset, 0).UTC()
+}
+
+func (r *ValidationRepository) Save(ctx context.Context, v *relationaldb.ValidationRecord) error {
+	if v == nil {
+		return relationaldb.NewDataError("validation_save", "nil record", nil)
+	}
+	_, err := r.getExecutor().ExecContext(ctx, `
+		INSERT INTO validations (
+			ledger_seq, initial_seq, ledger_hash, node_pubkey,
+			signature, sign_time, seen_time, flags, raw
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(ledger_hash, node_pubkey) DO NOTHING
+	`,
+		int64(v.LedgerSeq), int64(v.InitialSeq), v.LedgerHash[:], v.NodePubKey,
+		v.Signature, toXRPLEpochSeconds(v.SignTime), toXRPLEpochSeconds(v.SeenTime),
+		int64(v.Flags), v.Raw,
+	)
+	if err != nil {
+		return relationaldb.NewQueryError("validation_save", "failed to insert validation", err)
+	}
+	return nil
+}
+
+func (r *ValidationRepository) SaveBatch(ctx context.Context, vs []*relationaldb.ValidationRecord) error {
+	if len(vs) == 0 {
+		return nil
+	}
+	// Run as a single transaction when we're not already inside one —
+	// rippled's doStaleWrite batches a whole vector per commit for the
+	// same reason (amortize fsync).
+	if r.tx != nil {
+		for _, v := range vs {
+			if err := r.Save(ctx, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return relationaldb.NewTransactionError("validation_save_batch", "failed to begin transaction", err)
+	}
+	txRepo := NewValidationRepositoryWithTx(tx)
+	for _, v := range vs {
+		if err := txRepo.Save(ctx, v); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return relationaldb.NewTransactionError("validation_save_batch", "failed to commit batch", err)
+	}
+	return nil
+}
+
+func (r *ValidationRepository) scanRow(row interface {
+	Scan(dest ...interface{}) error
+}) (*relationaldb.ValidationRecord, error) {
+	var rec relationaldb.ValidationRecord
+	var ledgerSeq, initialSeq, signTime, seenTime int64
+	var flags int64
+	var ledgerHash []byte
+
+	if err := row.Scan(
+		&ledgerSeq, &initialSeq, &ledgerHash, &rec.NodePubKey,
+		&rec.Signature, &signTime, &seenTime, &flags, &rec.Raw,
+	); err != nil {
+		return nil, err
+	}
+
+	rec.LedgerSeq = relationaldb.LedgerIndex(ledgerSeq)
+	rec.InitialSeq = relationaldb.LedgerIndex(initialSeq)
+	copy(rec.LedgerHash[:], ledgerHash)
+	rec.SignTime = fromXRPLEpochSeconds(signTime)
+	rec.SeenTime = fromXRPLEpochSeconds(seenTime)
+	rec.Flags = uint32(flags)
+	return &rec, nil
+}
+
+func (r *ValidationRepository) GetValidationsForLedger(ctx context.Context, seq relationaldb.LedgerIndex) ([]*relationaldb.ValidationRecord, error) {
+	rows, err := r.getExecutor().QueryContext(ctx,
+		`SELECT `+validationSelectCols+` FROM validations WHERE ledger_seq = ?`, int64(seq))
+	if err != nil {
+		return nil, relationaldb.NewQueryError("validation_get_for_ledger", "failed to query validations", err)
+	}
+	defer rows.Close()
+
+	var result []*relationaldb.ValidationRecord
+	for rows.Next() {
+		rec, err := r.scanRow(rows)
+		if err != nil {
+			return nil, relationaldb.NewQueryError("validation_get_for_ledger", "failed to scan row", err)
+		}
+		result = append(result, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, relationaldb.NewQueryError("validation_get_for_ledger", "row iteration error", err)
+	}
+	return result, nil
+}
+
+func (r *ValidationRepository) GetValidationsByValidator(ctx context.Context, nodeKey []byte, limit int) ([]*relationaldb.ValidationRecord, error) {
+	q := `SELECT ` + validationSelectCols + ` FROM validations WHERE node_pubkey = ? ORDER BY ledger_seq DESC`
+	args := []interface{}{nodeKey}
+	if limit > 0 {
+		q += ` LIMIT ?`
+		args = append(args, limit)
+	}
+
+	rows, err := r.getExecutor().QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, relationaldb.NewQueryError("validation_get_by_validator", "failed to query validations", err)
+	}
+	defer rows.Close()
+
+	var result []*relationaldb.ValidationRecord
+	for rows.Next() {
+		rec, err := r.scanRow(rows)
+		if err != nil {
+			return nil, relationaldb.NewQueryError("validation_get_by_validator", "failed to scan row", err)
+		}
+		result = append(result, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, relationaldb.NewQueryError("validation_get_by_validator", "row iteration error", err)
+	}
+	return result, nil
+}
+
+func (r *ValidationRepository) GetValidationCount(ctx context.Context) (int64, error) {
+	var count int64
+	err := r.getExecutor().QueryRowContext(ctx, `SELECT COUNT(*) FROM validations`).Scan(&count)
+	if err != nil {
+		return 0, relationaldb.NewQueryError("validation_count", "failed to count validations", err)
+	}
+	return count, nil
+}
+
+// DeleteOlderThanSeq removes up to batchSize rows with ledger_seq < maxSeq.
+// A bounded DELETE keeps the retention sweep from blocking the writer on
+// multi-second scans — the archive loop calls this once per flush tick.
+func (r *ValidationRepository) DeleteOlderThanSeq(ctx context.Context, maxSeq relationaldb.LedgerIndex, batchSize int) (int64, error) {
+	q := `DELETE FROM validations WHERE rowid IN (
+		SELECT rowid FROM validations WHERE ledger_seq < ?`
+	args := []interface{}{int64(maxSeq)}
+	if batchSize > 0 {
+		q += ` LIMIT ?`
+		args = append(args, batchSize)
+	}
+	q += `)`
+
+	res, err := r.getExecutor().ExecContext(ctx, q, args...)
+	if err != nil {
+		return 0, relationaldb.NewQueryError("validation_delete_older", "failed to delete old validations", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, relationaldb.NewQueryError("validation_delete_older", "failed to read affected rows", err)
+	}
+	return n, nil
+}

--- a/storage/relationaldb/sqlite/validation_repository.go
+++ b/storage/relationaldb/sqlite/validation_repository.go
@@ -38,7 +38,7 @@ func (r *ValidationRepository) getExecutor() executor {
 }
 
 const validationSelectCols = `ledger_seq, initial_seq, ledger_hash, node_pubkey,
-	signature, sign_time, seen_time, flags, raw`
+	sign_time, seen_time, flags, raw`
 
 // xrplEpochOffset is the difference between Unix epoch (1970-01-01) and
 // the XRPL epoch (2000-01-01). Times stored in the archive are XRPL-epoch
@@ -66,12 +66,12 @@ func (r *ValidationRepository) Save(ctx context.Context, v *relationaldb.Validat
 	_, err := r.getExecutor().ExecContext(ctx, `
 		INSERT INTO validations (
 			ledger_seq, initial_seq, ledger_hash, node_pubkey,
-			signature, sign_time, seen_time, flags, raw
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			sign_time, seen_time, flags, raw
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(ledger_hash, node_pubkey) DO NOTHING
 	`,
 		int64(v.LedgerSeq), int64(v.InitialSeq), v.LedgerHash[:], v.NodePubKey,
-		v.Signature, toXRPLEpochSeconds(v.SignTime), toXRPLEpochSeconds(v.SeenTime),
+		toXRPLEpochSeconds(v.SignTime), toXRPLEpochSeconds(v.SeenTime),
 		int64(v.Flags), v.Raw,
 	)
 	if err != nil {
@@ -123,7 +123,7 @@ func (r *ValidationRepository) scanRow(row interface {
 
 	if err := row.Scan(
 		&ledgerSeq, &initialSeq, &ledgerHash, &rec.NodePubKey,
-		&rec.Signature, &signTime, &seenTime, &flags, &rec.Raw,
+		&signTime, &seenTime, &flags, &rec.Raw,
 	); err != nil {
 		return nil, err
 	}

--- a/storage/relationaldb/sqlite/validation_repository_test.go
+++ b/storage/relationaldb/sqlite/validation_repository_test.go
@@ -13,11 +13,12 @@ func mkValidationRecord(ledgerSeq uint32, nodeByte byte) *relationaldb.Validatio
 		LedgerSeq:  relationaldb.LedgerIndex(ledgerSeq),
 		InitialSeq: relationaldb.LedgerIndex(ledgerSeq - 1),
 		NodePubKey: make([]byte, 33),
-		Signature:  []byte{0xAB, 0xCD, 0xEF, byte(ledgerSeq)},
 		SignTime:   time.Unix(1700000000, 0).UTC(),
 		SeenTime:   time.Unix(1700000005, 0).UTC(),
 		Flags:      0x80000001,
-		Raw:        []byte{0xDE, 0xAD, 0xBE, 0xEF, byte(ledgerSeq), nodeByte},
+		// Raw includes the signature in the canonical wire format —
+		// the schema has no separate signature column.
+		Raw: []byte{0xDE, 0xAD, 0xBE, 0xEF, byte(ledgerSeq), nodeByte},
 	}
 	rec.LedgerHash[0] = byte(ledgerSeq)
 	rec.LedgerHash[31] = nodeByte
@@ -36,7 +37,7 @@ func recordsEqual(a, b *relationaldb.ValidationRecord) bool {
 	if !a.SignTime.Equal(b.SignTime) || !a.SeenTime.Equal(b.SeenTime) {
 		return false
 	}
-	if !byteEq(a.NodePubKey, b.NodePubKey) || !byteEq(a.Signature, b.Signature) || !byteEq(a.Raw, b.Raw) {
+	if !byteEq(a.NodePubKey, b.NodePubKey) || !byteEq(a.Raw, b.Raw) {
 		return false
 	}
 	return true

--- a/storage/relationaldb/sqlite/validation_repository_test.go
+++ b/storage/relationaldb/sqlite/validation_repository_test.go
@@ -1,0 +1,214 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+func mkValidationRecord(ledgerSeq uint32, nodeByte byte) *relationaldb.ValidationRecord {
+	rec := &relationaldb.ValidationRecord{
+		LedgerSeq:  relationaldb.LedgerIndex(ledgerSeq),
+		InitialSeq: relationaldb.LedgerIndex(ledgerSeq - 1),
+		NodePubKey: make([]byte, 33),
+		Signature:  []byte{0xAB, 0xCD, 0xEF, byte(ledgerSeq)},
+		SignTime:   time.Unix(1700000000, 0).UTC(),
+		SeenTime:   time.Unix(1700000005, 0).UTC(),
+		Flags:      0x80000001,
+		Raw:        []byte{0xDE, 0xAD, 0xBE, 0xEF, byte(ledgerSeq), nodeByte},
+	}
+	rec.LedgerHash[0] = byte(ledgerSeq)
+	rec.LedgerHash[31] = nodeByte
+	rec.NodePubKey[0] = 0x02
+	rec.NodePubKey[32] = nodeByte
+	return rec
+}
+
+func recordsEqual(a, b *relationaldb.ValidationRecord) bool {
+	if a.LedgerSeq != b.LedgerSeq || a.InitialSeq != b.InitialSeq || a.Flags != b.Flags {
+		return false
+	}
+	if a.LedgerHash != b.LedgerHash {
+		return false
+	}
+	if !a.SignTime.Equal(b.SignTime) || !a.SeenTime.Equal(b.SeenTime) {
+		return false
+	}
+	if !byteEq(a.NodePubKey, b.NodePubKey) || !byteEq(a.Signature, b.Signature) || !byteEq(a.Raw, b.Raw) {
+		return false
+	}
+	return true
+}
+
+func byteEq(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestValidationRepository_SaveAndGet(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+	repo := rm.Validation()
+	if repo == nil {
+		t.Fatal("Validation() returned nil — repo not wired")
+	}
+
+	orig := mkValidationRecord(100, 0x01)
+	if err := repo.Save(ctx, orig); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.GetValidationsForLedger(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(got))
+	}
+	if !recordsEqual(orig, got[0]) {
+		t.Fatalf("roundtrip mismatch:\n got  %+v\n want %+v", got[0], orig)
+	}
+}
+
+func TestValidationRepository_DuplicateIsNoop(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+	repo := rm.Validation()
+
+	rec := mkValidationRecord(100, 0x01)
+	if err := repo.Save(ctx, rec); err != nil {
+		t.Fatal(err)
+	}
+	// Re-save identical record — must not error, must not double-insert.
+	if err := repo.Save(ctx, rec); err != nil {
+		t.Fatalf("duplicate save errored: %v", err)
+	}
+
+	count, err := repo.GetValidationCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 row after duplicate save, got %d", count)
+	}
+}
+
+func TestValidationRepository_SaveBatch(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+	repo := rm.Validation()
+
+	batch := []*relationaldb.ValidationRecord{
+		mkValidationRecord(100, 0x01),
+		mkValidationRecord(100, 0x02),
+		mkValidationRecord(101, 0x01),
+		mkValidationRecord(100, 0x01), // duplicate in batch
+	}
+
+	if err := repo.SaveBatch(ctx, batch); err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := repo.GetValidationCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 unique rows after batch, got %d", count)
+	}
+}
+
+func TestValidationRepository_GetByValidator_RespectsLimit(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+	repo := rm.Validation()
+
+	for seq := uint32(100); seq < 110; seq++ {
+		if err := repo.Save(ctx, mkValidationRecord(seq, 0x01)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	key := make([]byte, 33)
+	key[0] = 0x02
+	key[32] = 0x01
+
+	rows, err := repo.GetValidationsByValidator(ctx, key, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("limit ignored: got %d rows, expected 3", len(rows))
+	}
+	// Descending order: newest (109) first.
+	if rows[0].LedgerSeq != 109 || rows[2].LedgerSeq != 107 {
+		t.Fatalf("expected DESC ordering 109..107, got %d..%d", rows[0].LedgerSeq, rows[2].LedgerSeq)
+	}
+
+	rows, err = repo.GetValidationsByValidator(ctx, key, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 10 {
+		t.Fatalf("limit=0 should be unbounded: got %d rows, expected 10", len(rows))
+	}
+}
+
+func TestValidationRepository_DeleteOlderThanSeq_Bounded(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+	repo := rm.Validation()
+
+	// Insert 20 rows at seqs 1..20, distinct validators so they all land.
+	for seq := uint32(1); seq <= 20; seq++ {
+		rec := mkValidationRecord(seq, byte(seq))
+		if err := repo.Save(ctx, rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Bounded sweep: delete up to 5 rows with seq < 15.
+	n, err := repo.DeleteOlderThanSeq(ctx, 15, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 5 {
+		t.Fatalf("expected 5 deletions, got %d", n)
+	}
+
+	// Remaining: 20 - 5 = 15 rows.
+	count, err := repo.GetValidationCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 15 {
+		t.Fatalf("expected 15 rows remaining, got %d", count)
+	}
+
+	// Unbounded sweep: remove the rest of the <15 rows (9 more).
+	n, err = repo.DeleteOlderThanSeq(ctx, 15, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 9 {
+		t.Fatalf("expected 9 deletions in unbounded sweep, got %d", n)
+	}
+
+	// All remaining rows should be seqs 15..20.
+	count, err = repo.GetValidationCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 6 {
+		t.Fatalf("expected 6 rows after full sweep, got %d", count)
+	}
+}

--- a/storage/relationaldb/validations.go
+++ b/storage/relationaldb/validations.go
@@ -1,0 +1,53 @@
+package relationaldb
+
+import (
+	"context"
+	"time"
+)
+
+// ValidationRecord is one row of the on-disk validation archive. Columns
+// mirror rippled's historical Validations table (DBInit.h, pre-May-2019)
+// augmented with SeenTime and Flags so forensic tooling can replay the
+// receive-side perspective, not just the signed payload.
+type ValidationRecord struct {
+	LedgerSeq  LedgerIndex
+	InitialSeq LedgerIndex
+	LedgerHash Hash
+	NodePubKey []byte // 33-byte compressed pubkey
+	Signature  []byte
+	SignTime   time.Time
+	SeenTime   time.Time
+	Flags      uint32
+	Raw        []byte // canonical XRPL-binary STValidation blob
+}
+
+// ValidationRepository persists stale validations and answers historical
+// queries. Backends (SQLite, PostgreSQL) guarantee idempotent writes:
+// re-inserting the same (LedgerHash, NodePubKey) is a no-op, so replaying
+// the same onStale stream never produces duplicate rows.
+type ValidationRepository interface {
+	// Save appends one row. Returns nil on duplicate-key conflict.
+	Save(ctx context.Context, v *ValidationRecord) error
+
+	// SaveBatch inserts many rows in a single transaction. Duplicates
+	// within the batch are allowed; conflicts are ignored.
+	SaveBatch(ctx context.Context, vs []*ValidationRecord) error
+
+	// GetValidationsForLedger returns every archived validation for the
+	// given ledger sequence. Order is unspecified.
+	GetValidationsForLedger(ctx context.Context, seq LedgerIndex) ([]*ValidationRecord, error)
+
+	// GetValidationsByValidator returns up to `limit` most-recent
+	// archived validations signed by nodeKey (ordered by LedgerSeq
+	// descending). limit <= 0 applies no bound.
+	GetValidationsByValidator(ctx context.Context, nodeKey []byte, limit int) ([]*ValidationRecord, error)
+
+	// GetValidationCount returns the total number of archived rows.
+	GetValidationCount(ctx context.Context) (int64, error)
+
+	// DeleteOlderThanSeq drops rows with LedgerSeq < maxSeq, bounded to
+	// at most `batchSize` rows per call so long retention sweeps never
+	// block the writer for an unbounded duration. Returns the number of
+	// rows actually deleted. batchSize <= 0 applies no bound.
+	DeleteOlderThanSeq(ctx context.Context, maxSeq LedgerIndex, batchSize int) (int64, error)
+}

--- a/storage/relationaldb/validations.go
+++ b/storage/relationaldb/validations.go
@@ -9,16 +9,19 @@ import (
 // mirror rippled's historical Validations table (DBInit.h, pre-May-2019)
 // augmented with SeenTime and Flags so forensic tooling can replay the
 // receive-side perspective, not just the signed payload.
+//
+// The signature lives inside Raw (sfSignature is part of the canonical
+// STValidation wire format) — there is no separate Signature column.
+// Callers that need the signature parse Raw via the binary codec.
 type ValidationRecord struct {
 	LedgerSeq  LedgerIndex
 	InitialSeq LedgerIndex
 	LedgerHash Hash
 	NodePubKey []byte // 33-byte compressed pubkey
-	Signature  []byte
 	SignTime   time.Time
 	SeenTime   time.Time
 	Flags      uint32
-	Raw        []byte // canonical XRPL-binary STValidation blob
+	Raw        []byte // canonical XRPL-binary STValidation blob (includes signature)
 }
 
 // ValidationRepository persists stale validations and answers historical

--- a/tasks/pr-validation-archive.md
+++ b/tasks/pr-validation-archive.md
@@ -1,0 +1,569 @@
+# PR: On-disk validation archive (issue #267)
+
+Implements the `onStale` / `doStaleWrite` pathway that goXRPL has been missing: stale validations pruned from the in-memory `ValidationTracker` are persisted to a new `Validations` table in the relational DB, written by a batched async writer so the receive path never blocks on I/O, with a configurable ledger-seq retention window.
+
+RPC wiring of the historical archive into `validator_info` and other consumers is **out of scope** for this PR — only the service-layer interface is added. The full RPC response extension is a follow-up.
+
+## Why this matters
+
+`ValidationTracker.ExpireOld` (internal/consensus/rcl/validations.go:509) deletes stale validations from memory with no archival. Grep for `onStale|doStaleWrite|writeValidation|staleValidation` across `internal/consensus/` returns zero hits. Rippled's `RCLValidations.h:205-210` documents: _"Manages storing and writing stale RCLValidations to the sqlite DB"_ — historically consumed by `tx_history`, `validator_list_keys`, forensic tooling, and the `validator_info` admin RPC.
+
+Separately, `ExpireOld` is today **dead code** — nothing calls it. This PR also wires it up (drive from the fully-validated callback in the engine) so the archive pathway actually runs in production.
+
+## Rippled reference map
+
+| Concern | Rippled file:line |
+|---|---|
+| `onStale` callback contract | `src/xrpld/consensus/Validations.h:~254` (`Adaptor::onStale`) |
+| `RCLValidations::onStale` | `src/xrpld/app/consensus/detail/RCLValidations.cpp:~160-175` |
+| `doStaleWrite` batched loop | `src/xrpld/app/consensus/detail/RCLValidations.cpp:~185-240` |
+| Historical Validations DDL | `src/xrpld/app/main/DBInit.h` (pre-May 2019) — columns `LedgerSeq, InitialSeq, LedgerHash, NodePubKey, SignTime, RawData` plus four indexes |
+| Job-queue handoff | `src/xrpld/app/consensus/detail/RCLValidations.cpp` (`jtWRITE` enqueue) |
+| `validator_info` read consumer | `src/xrpld/rpc/handlers/ValidatorInfo.cpp` |
+
+Rippled removed the on-disk table in May 2019 (commit c5a95f1eb5a5). The schema and batching pattern are still valid references; we're re-adding the archive because goXRPL needs it for forensic/RPC use.
+
+## Design decisions
+
+- **Package layout**: new `internal/consensus/archive/` with exported `Archive` type. Depends on `storage/relationaldb` (repository) — no reverse dependency. Consensus wiring (engine) depends on archive via interface — not the concrete type.
+- **Backends**: SQLite **and** PostgreSQL (parity with existing `ledgers`/`transactions` tables). Both initialize schema in `RepositoryManager.Open()` matching the established pattern at `storage/relationaldb/sqlite/repository_manager.go:184-206` and `storage/relationaldb/postgres/repository_manager.go:139-192`.
+- **Write path**: `ValidationTracker.SetOnStale(fn)` fires once per pruned validation inside `ExpireOld`. The callback is a cheap "enqueue to channel" — no DB I/O on the caller's goroutine. A dedicated writer goroutine reads from the channel, batches up to `BatchSize` rows, and writes each batch in a single transaction. Matches rippled's `jtWRITE` job-queue handoff semantics.
+- **Raw bytes**: add `Raw []byte` to `consensus.Validation`. `parseSTValidation` populates it from the original input; outbound self-built validations re-serialize via an exported `SerializeSTValidation`. This mirrors rippled's `RCLValidation::getSerialized()` and avoids a parse→serialize round-trip at archive time.
+- **Retention**: `RetentionLedgers uint32` config knob. On each ExpireOld sweep, after archive writes complete, we run a bounded DELETE `WHERE LedgerSeq < currentFullyValidatedSeq - RetentionLedgers`. Bounded by `DeleteBatch` (reuses the knob pattern already in `NodeDBConfig`). `RetentionLedgers = 0` disables retention (keep forever).
+- **Flush on shutdown**: `Archive.Close(ctx)` drains the channel, writes the final batch, then returns. Engine.Stop() calls it before returning.
+- **Engine wiring**: `ExpireOld` is currently never invoked. We call it from the fully-validated callback at `engine.go:228` — every time a new ledger is fully validated, prune validations below `max(0, seq - retainInMemoryLedgers)`. New config knob `InMemoryLedgers uint32` controls the in-memory window; defaults to 256 (matching rippled's minimum `online_delete`).
+- **Read path**: minimal. Adds `ValidationArchive` to `types.Services` so RPC handlers can reach it. Repository methods: `GetValidationsForLedger(seq)`, `GetValidationsByValidator(nodeKey, limit)`, `GetValidationCount()`. No handler extension in this PR — that is a separate, smaller follow-up.
+- **Fix the existing `ExpireOld` bug**: the current loop at validations.go:514-522 has a dangling `break` that exits the inner loop after inspecting one validation regardless. Since all validations for the same `ledgerID` share a `LedgerSeq` this is technically correct for the drop decision, but it leaks the `byNode` map (never removes the per-node pointer). Fix as part of this PR — we have to touch the function anyway and correctness matters for the archive's input stream.
+
+## Files
+
+### New
+
+- `goXRPL/internal/consensus/archive/archive.go` — `Archive` struct, `New(Repo, Config)`, `OnStale(*consensus.Validation)`, `Flush(ctx)`, `Close(ctx)`. Channel + goroutine batching, retention DELETE loop.
+- `goXRPL/internal/consensus/archive/archive_test.go` — unit tests for batching, flush semantics, close-drains-pending, retention arithmetic (uses mock repo).
+- `goXRPL/internal/consensus/archive/config.go` — `Config` struct: `Enabled bool`, `RetentionLedgers uint32`, `BatchSize int`, `FlushInterval time.Duration`, `DeleteBatch int`, `InMemoryLedgers uint32` + `Defaults()`.
+- `goXRPL/storage/relationaldb/validations.go` — exported types `ValidationRecord`, `ValidationsFilter`; interface `ValidationRepository`.
+- `goXRPL/storage/relationaldb/sqlite/validation_repository.go` — SQLite impl. Uses the `ledgerDB` handle (cohabits with `ledgers` table) to avoid opening a third file.
+- `goXRPL/storage/relationaldb/sqlite/validation_repository_test.go` — round-trip CRUD, batch insert, retention delete, index usage.
+- `goXRPL/storage/relationaldb/postgres/validation_repository.go` — Postgres impl.
+- `goXRPL/internal/testing/validationarchive/archive_test.go` — three required acceptance tests end-to-end (real SQLite, real ValidationTracker).
+
+### Modified
+
+- `goXRPL/internal/consensus/types.go` — add `Raw []byte` to `Validation`. Keep omitempty semantics — internal field, not JSON-serialized.
+- `goXRPL/internal/consensus/adaptor/stvalidation.go`:
+  - populate `v.Raw = append([]byte(nil), data...)` in `parseSTValidation` before returning.
+  - export `SerializeSTValidation` (rename; keep `serializeSTValidation` as a thin wrapper for back-compat within the package).
+- `goXRPL/internal/consensus/rcl/validations.go`:
+  - add field `onStale func(*consensus.Validation)`.
+  - add `SetOnStale(fn func(*consensus.Validation))`.
+  - rewrite `ExpireOld` to (a) fire `onStale` for every dropped validation before deletion, (b) correctly remove entries from `byNode` too.
+- `goXRPL/internal/consensus/rcl/validations_test.go` — add test for `SetOnStale` callback + fix for `byNode` cleanup.
+- `goXRPL/internal/consensus/rcl/engine.go`:
+  - accept optional `archive` on the Engine struct (via `NewEngine` option or setter).
+  - in `Start()`, call `e.validationTracker.SetOnStale(archive.OnStale)` when archive is non-nil.
+  - in the `SetFullyValidatedCallback` hook, after `OnLedgerFullyValidated`, call `e.validationTracker.ExpireOld(seq - inMemoryLedgers)`.
+  - in `Stop()`, call `archive.Close(ctx)` before returning.
+- `goXRPL/storage/relationaldb/interface.go` — add `ValidationRepository` to the `RepositoryManager` interface; add `Validation()` accessor.
+- `goXRPL/storage/relationaldb/sqlite/repository_manager.go`:
+  - add `validationRepo *ValidationRepository` field.
+  - new `initValidationSchema(ctx)` method (DDL below).
+  - wire in `Open()` (call after `initLedgerSchema`) and close in `close()`.
+  - implement `Validation() relationaldb.ValidationRepository`.
+- `goXRPL/storage/relationaldb/postgres/repository_manager.go` — parallel changes for postgres (DDL in `initSchema`, repo wiring, accessor).
+- `goXRPL/config/database.go` — add new struct `ValidationArchiveConfig`. Validate ranges.
+- `goXRPL/config/config.go` — add `ValidationArchive ValidationArchiveConfig \`toml:"validation_archive" mapstructure:"validation_archive"\`` field on `Config`.
+- `goXRPL/internal/rpc/types/services.go` — add `ValidationArchive` field (interface) to the `Services` struct so handlers can query historical validations.
+
+## DDL
+
+SQLite:
+
+```sql
+CREATE TABLE IF NOT EXISTS validations (
+    ledger_seq    INTEGER NOT NULL,
+    initial_seq   INTEGER NOT NULL,
+    ledger_hash   BLOB NOT NULL,
+    node_pubkey   BLOB NOT NULL,
+    signature     BLOB NOT NULL,
+    sign_time     INTEGER NOT NULL,
+    seen_time     INTEGER NOT NULL,
+    flags         INTEGER NOT NULL,
+    raw           BLOB NOT NULL,
+    PRIMARY KEY (ledger_hash, node_pubkey)
+);
+CREATE INDEX IF NOT EXISTS idx_validations_seq        ON validations(ledger_seq);
+CREATE INDEX IF NOT EXISTS idx_validations_node       ON validations(node_pubkey, ledger_seq);
+CREATE INDEX IF NOT EXISTS idx_validations_sign_time  ON validations(sign_time);
+CREATE INDEX IF NOT EXISTS idx_validations_initial    ON validations(initial_seq, ledger_seq);
+```
+
+PostgreSQL: identical columns, `BIGINT` for INTEGER, `BYTEA` for BLOB, otherwise same.
+
+Primary key choice `(ledger_hash, node_pubkey)` matches the natural upsert semantics — a validator can only produce one validation per ledger, and we want idempotent re-archival if `ExpireOld` is re-driven. `ON CONFLICT DO NOTHING` on insert.
+
+## Acceptance tests
+
+All in `internal/testing/validationarchive/archive_test.go`. Use an in-process SQLite (temp dir) and real `ValidationTracker`.
+
+1. **`TestValidationArchive_StaleValidationWrittenOnPrune`**
+   - Construct `Archive` with `BatchSize=1, FlushInterval=10ms`.
+   - Wire `tracker.SetOnStale(archive.OnStale)`.
+   - `tracker.Add(v)` for a validation at `seq=100`.
+   - `tracker.ExpireOld(200)` — v should become stale.
+   - Wait for flush tick.
+   - Query repo: `GetValidationsForLedger(100)` returns exactly `v` (hash, node, seq, raw matching).
+
+2. **`TestValidationArchive_BatchedWriter_DoesNotBlockOnReceive`**
+   - Construct `Archive` with a slow repo mock (100ms per write).
+   - Fire `archive.OnStale` 1000 times in a tight loop under a 50ms deadline.
+   - Assert the loop returns well under the deadline (channel-buffered, not synchronous).
+   - Afterwards `archive.Flush(ctx)` drains — assert all 1000 rows eventually land in the repo.
+
+3. **`TestValidationArchive_RetentionRespected`**
+   - `RetentionLedgers=10, InMemoryLedgers=0`.
+   - Archive 20 validations at seqs 1..20.
+   - Call `archive.ApplyRetention(ctx, currentFullyValidatedSeq=20)`.
+   - Query `GetValidationCount()` → 10 (seqs 11..20 remain).
+   - Query `GetValidationsForLedger(5)` → empty; `GetValidationsForLedger(15)` → one row.
+
+Supporting unit tests (in each package):
+
+- `archive/archive_test.go`: `TestArchive_ChannelBackpressure_DropsOldest` (or `Blocks`, depending on choice — we'll pick *block with warning log*, matching rippled's bounded vector behavior). `TestArchive_CloseDrainsPending`. `TestArchive_FlushIsIdempotent`.
+- `sqlite/validation_repository_test.go`: round-trip, duplicate insert is no-op, retention DELETE bounded by `DeleteBatch`.
+- `rcl/validations_test.go`: `TestValidationTracker_ExpireOld_FiresOnStale`, `TestValidationTracker_ExpireOld_ClearsByNode`.
+
+## Config schema
+
+```toml
+[validation_archive]
+enabled            = true   # default: true when relationaldb is configured
+retention_ledgers  = 10000  # 0 = keep forever
+batch_size         = 128
+flush_interval_ms  = 1000
+delete_batch       = 1000   # bounded DELETE sweep size
+in_memory_ledgers  = 256    # ExpireOld trigger: prune validations below (fullyValidatedSeq - in_memory_ledgers)
+```
+
+Validation: `retention_ledgers >= 0`, `batch_size >= 1`, `flush_interval_ms >= 10`, `in_memory_ledgers >= 1`, `delete_batch >= 1`.
+
+## Execution tasks
+
+Each task below is independently committable and keeps the tree green.
+
+### Task 1 — `Raw []byte` on Validation + parser population
+
+**Files:**
+- Modify: `internal/consensus/types.go` (struct field)
+- Modify: `internal/consensus/adaptor/stvalidation.go` (populate in parser + export `SerializeSTValidation`)
+- Modify: `internal/consensus/adaptor/stvalidation_test.go` (assertion for Raw round-trip)
+
+- [ ] **Step 1: Write failing test in `stvalidation_test.go`**
+
+```go
+func TestParseSTValidation_PopulatesRaw(t *testing.T) {
+    orig := newTestValidation(t)
+    blob := SerializeSTValidation(orig)
+    parsed, err := parseSTValidation(blob)
+    if err != nil { t.Fatal(err) }
+    if !bytes.Equal(parsed.Raw, blob) {
+        t.Fatalf("Raw mismatch: got %x want %x", parsed.Raw, blob)
+    }
+}
+```
+
+- [ ] **Step 2: Run** `go test ./internal/consensus/adaptor/... -run TestParseSTValidation_PopulatesRaw` → fails (no `Raw` field, no exported `SerializeSTValidation`).
+
+- [ ] **Step 3: Add `Raw []byte` field to `consensus.Validation`** in `internal/consensus/types.go` (grouped with serialization-related fields; comment it as "Original wire bytes — nil for self-built until SerializeSTValidation is called").
+
+- [ ] **Step 4: In `parseSTValidation`**, just before `return v, nil`:
+
+```go
+v.Raw = append([]byte(nil), data...)
+```
+
+- [ ] **Step 5: Export serializer**: rename `serializeSTValidation` → `SerializeSTValidation` across the package (keep a private wrapper if any test relies on the lowercase form — there should be none after rename).
+
+- [ ] **Step 6: Run** `go build ./...` and `go test ./internal/consensus/adaptor/...` → passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/consensus/types.go internal/consensus/adaptor/stvalidation.go internal/consensus/adaptor/stvalidation_test.go
+git commit -m "feat(consensus): capture raw wire bytes on parsed Validation"
+```
+
+### Task 2 — `SetOnStale` callback + fix `ExpireOld`
+
+**Files:**
+- Modify: `internal/consensus/rcl/validations.go`
+- Modify: `internal/consensus/rcl/validations_test.go`
+
+- [ ] **Step 1: Write two failing tests:**
+
+```go
+func TestValidationTracker_ExpireOld_FiresOnStale(t *testing.T) {
+    vt := NewValidationTracker(1, 5*time.Minute)
+    var fired []consensus.LedgerID
+    vt.SetOnStale(func(v *consensus.Validation) { fired = append(fired, v.LedgerID) })
+
+    v1 := mkVal(t, 100, nodeA)
+    v2 := mkVal(t, 100, nodeB)
+    vt.Add(v1); vt.Add(v2)
+    vt.ExpireOld(200)
+
+    if len(fired) != 2 { t.Fatalf("expected 2 stale fires, got %d", len(fired)) }
+}
+
+func TestValidationTracker_ExpireOld_ClearsByNode(t *testing.T) {
+    vt := NewValidationTracker(1, 5*time.Minute)
+    v1 := mkVal(t, 100, nodeA)
+    vt.Add(v1)
+    vt.ExpireOld(200)
+
+    if vt.GetLatestValidation(nodeA) != nil {
+        t.Fatal("ExpireOld left stale entry in byNode map")
+    }
+}
+```
+
+- [ ] **Step 2: Run** → fails (no `SetOnStale`, `byNode` leak).
+
+- [ ] **Step 3: Add field + setter**:
+
+```go
+// inside ValidationTracker struct
+onStale func(*consensus.Validation)
+
+// new method
+func (vt *ValidationTracker) SetOnStale(fn func(*consensus.Validation)) {
+    vt.mu.Lock()
+    defer vt.mu.Unlock()
+    vt.onStale = fn
+}
+```
+
+- [ ] **Step 4: Rewrite `ExpireOld`**:
+
+```go
+func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
+    vt.mu.Lock()
+    onStale := vt.onStale
+
+    var stale []*consensus.Validation
+    for ledgerID, ledgerVals := range vt.validations {
+        // All validations for a given ledgerID share LedgerSeq.
+        var sample *consensus.Validation
+        for _, v := range ledgerVals {
+            sample = v
+            break
+        }
+        if sample == nil || sample.LedgerSeq >= minSeq {
+            continue
+        }
+        for nodeID, v := range ledgerVals {
+            stale = append(stale, v)
+            if byNode, ok := vt.byNode[nodeID]; ok && byNode == v {
+                delete(vt.byNode, nodeID)
+            }
+        }
+        delete(vt.validations, ledgerID)
+        delete(vt.fired, ledgerID)
+    }
+    vt.mu.Unlock()
+
+    // Fire callback outside the lock — callbacks may do I/O (archive).
+    if onStale != nil {
+        for _, v := range stale {
+            onStale(v)
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run** → tests pass. Also run `go test ./internal/consensus/rcl/...` to confirm no regression.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/consensus/rcl/validations.go internal/consensus/rcl/validations_test.go
+git commit -m "feat(consensus): SetOnStale callback on ValidationTracker; fix ExpireOld byNode leak"
+```
+
+### Task 3 — ValidationRepository interface + types
+
+**Files:**
+- Create: `storage/relationaldb/validations.go`
+
+- [ ] **Step 1: Write the file**:
+
+```go
+package relationaldb
+
+import (
+    "context"
+    "time"
+)
+
+type ValidationRecord struct {
+    LedgerSeq  LedgerIndex
+    InitialSeq LedgerIndex
+    LedgerHash Hash
+    NodePubKey []byte // 33 bytes
+    Signature  []byte
+    SignTime   time.Time
+    SeenTime   time.Time
+    Flags      uint32
+    Raw        []byte
+}
+
+type ValidationsFilter struct {
+    LedgerSeq  *LedgerIndex
+    LedgerHash *Hash
+    NodePubKey []byte
+    Limit      int
+}
+
+type ValidationRepository interface {
+    Save(ctx context.Context, v *ValidationRecord) error
+    SaveBatch(ctx context.Context, vs []*ValidationRecord) error
+    GetValidationsForLedger(ctx context.Context, seq LedgerIndex) ([]*ValidationRecord, error)
+    GetValidationsByValidator(ctx context.Context, nodeKey []byte, limit int) ([]*ValidationRecord, error)
+    GetValidationCount(ctx context.Context) (int64, error)
+    DeleteOlderThanSeq(ctx context.Context, maxSeq LedgerIndex, batchSize int) (int64, error)
+}
+```
+
+- [ ] **Step 2: Add `Validation() ValidationRepository` to `RepositoryManager` interface** in `storage/relationaldb/interface.go`.
+
+- [ ] **Step 3: Run** `go build ./...` → will fail on the two existing RepositoryManager impls (expected; wired in next tasks).
+
+- [ ] **Step 4: Commit** once Tasks 4 + 5 compile together. Alternatively, add a temporary no-op `Validation()` returning `nil` on each manager to keep builds green in between — we'll do the latter so each task commits cleanly.
+
+```go
+// temporary stub on both repository_manager.go, removed in Task 4/5
+func (rm *RepositoryManager) Validation() relationaldb.ValidationRepository { return nil }
+```
+
+- [ ] **Step 5: Build + commit**
+
+```bash
+go build ./...
+git add storage/relationaldb/validations.go storage/relationaldb/interface.go \
+        storage/relationaldb/sqlite/repository_manager.go \
+        storage/relationaldb/postgres/repository_manager.go
+git commit -m "feat(relationaldb): add ValidationRepository interface + stubbed accessor"
+```
+
+### Task 4 — SQLite ValidationRepository impl
+
+**Files:**
+- Create: `storage/relationaldb/sqlite/validation_repository.go`
+- Create: `storage/relationaldb/sqlite/validation_repository_test.go`
+- Modify: `storage/relationaldb/sqlite/repository_manager.go`
+
+- [ ] **Step 1: Write failing round-trip test**:
+
+```go
+func TestValidationRepository_SaveAndGet(t *testing.T) {
+    rm := newTestRM(t)
+    repo := rm.Validation()
+    rec := &relationaldb.ValidationRecord{
+        LedgerSeq: 100, InitialSeq: 99,
+        LedgerHash: [32]byte{1,2,3}, NodePubKey: make([]byte, 33),
+        Signature: []byte{0xAB, 0xCD}, SignTime: time.Unix(1700000000, 0),
+        SeenTime: time.Unix(1700000001, 0), Flags: 0x80000001, Raw: []byte{0xFE},
+    }
+    if err := repo.Save(context.Background(), rec); err != nil { t.Fatal(err) }
+
+    got, err := repo.GetValidationsForLedger(context.Background(), 100)
+    if err != nil { t.Fatal(err) }
+    if len(got) != 1 { t.Fatalf("got %d rows", len(got)) }
+    // field-by-field equality ...
+}
+```
+
+Plus `TestValidationRepository_SaveBatch`, `TestValidationRepository_DuplicateIsNoop`, `TestValidationRepository_DeleteOlderThanSeq_Bounded`.
+
+- [ ] **Step 2: Add `initValidationSchema` to `repository_manager.go`** (DDL block from above). Call it in `Open()` after `initLedgerSchema`.
+
+- [ ] **Step 3: Implement `ValidationRepository` in `validation_repository.go`** — mirror the `LedgerRepository` style (struct holding `*sql.DB`, SQL constants, row-scan helpers).
+
+- [ ] **Step 4: Remove the temporary `Validation() nil` stub**; wire the real repo.
+
+- [ ] **Step 5: Run** `go test ./storage/relationaldb/sqlite/... -run Validation` → passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add storage/relationaldb/sqlite/
+git commit -m "feat(relationaldb/sqlite): implement ValidationRepository"
+```
+
+### Task 5 — PostgreSQL ValidationRepository impl
+
+Mirror of Task 4. Adds the DDL to `postgres/repository_manager.go:initSchema` and creates `postgres/validation_repository.go` with matching interface impl (`$1,$2,...` placeholders, `ON CONFLICT DO NOTHING`, `BYTEA`/`BIGINT` types).
+
+- [ ] Tests at `postgres/validation_repository_test.go` — skipped by default unless `POSTGRES_TEST_URL` env var is set (matches existing pattern in that package).
+
+- [ ] Commit `feat(relationaldb/postgres): implement ValidationRepository`.
+
+### Task 6 — Config struct
+
+**Files:**
+- Modify: `config/database.go`
+- Modify: `config/config.go`
+- Modify: `config/config_test.go`
+
+- [ ] **Step 1: Write failing test** — load a toml string with a `[validation_archive]` table, assert parsed values.
+
+- [ ] **Step 2: Add `ValidationArchiveConfig`**:
+
+```go
+type ValidationArchiveConfig struct {
+    Enabled          bool   `toml:"enabled" mapstructure:"enabled"`
+    RetentionLedgers uint32 `toml:"retention_ledgers" mapstructure:"retention_ledgers"`
+    BatchSize        int    `toml:"batch_size" mapstructure:"batch_size"`
+    FlushIntervalMs  int    `toml:"flush_interval_ms" mapstructure:"flush_interval_ms"`
+    DeleteBatch      int    `toml:"delete_batch" mapstructure:"delete_batch"`
+    InMemoryLedgers  uint32 `toml:"in_memory_ledgers" mapstructure:"in_memory_ledgers"`
+}
+
+func (c *ValidationArchiveConfig) Validate() error { /* range checks */ }
+func DefaultValidationArchiveConfig() ValidationArchiveConfig {
+    return ValidationArchiveConfig{Enabled: true, RetentionLedgers: 10000, BatchSize: 128, FlushIntervalMs: 1000, DeleteBatch: 1000, InMemoryLedgers: 256}
+}
+```
+
+- [ ] **Step 3: Attach to `Config` struct**, include default in `DefaultConfig()`.
+
+- [ ] **Step 4: Run** tests → pass.
+
+- [ ] **Step 5: Commit** `feat(config): add validation_archive section`.
+
+### Task 7 — Archive package (core)
+
+**Files:**
+- Create: `internal/consensus/archive/config.go`
+- Create: `internal/consensus/archive/archive.go`
+- Create: `internal/consensus/archive/archive_test.go`
+
+`Archive` shape:
+
+```go
+type Archive struct {
+    repo    relationaldb.ValidationRepository
+    cfg     Config
+    ch      chan *consensus.Validation
+    done    chan struct{}
+    wg      sync.WaitGroup
+    logger  *slog.Logger
+    lastSeq atomic.Uint32 // most-recent fully-validated seq seen; retention pivot
+}
+
+func New(repo relationaldb.ValidationRepository, cfg Config, logger *slog.Logger) *Archive { ... }
+func (a *Archive) OnStale(v *consensus.Validation) { /* non-blocking enqueue or bounded block */ }
+func (a *Archive) NoteFullyValidated(seq uint32) { a.lastSeq.Store(seq) }
+func (a *Archive) Flush(ctx context.Context) error { ... }
+func (a *Archive) ApplyRetention(ctx context.Context) (int64, error) { ... }
+func (a *Archive) Close(ctx context.Context) error { ... }
+```
+
+- [ ] **Step 1: Tests** — `TestArchive_Enqueue_NonBlocking`, `TestArchive_Batches`, `TestArchive_CloseDrainsPending`, `TestArchive_ApplyRetention`, `TestArchive_FlushIdempotent`, `TestArchive_FiresFlushOnInterval`.
+
+- [ ] **Step 2: Implement `archive.go`** — background goroutine reads from `ch`, accumulates up to `BatchSize`, flushes on full or on `FlushInterval` tick, calls `repo.SaveBatch`. Retention: on each full flush, if `cfg.RetentionLedgers > 0` and `lastSeq > RetentionLedgers`, call `repo.DeleteOlderThanSeq(lastSeq - RetentionLedgers, cfg.DeleteBatch)` — bounded to one call per flush so we don't stall on large sweeps.
+
+- [ ] **Step 3: Run** `go test ./internal/consensus/archive/...` → passes.
+
+- [ ] **Step 4: Commit** `feat(consensus/archive): batched async writer with retention`.
+
+### Task 8 — Engine wiring
+
+**Files:**
+- Modify: `internal/consensus/rcl/engine.go`
+- Modify: `internal/rpc/types/services.go`
+- Modify: `internal/consensus/rcl/engine_test.go`
+
+- [ ] **Step 1: Add optional archive parameter** to `Engine` (via a functional option `WithArchive(*archive.Archive)` or a setter `SetArchive`). Services struct gets a `ValidationArchive` field typed as a small interface (`GetValidationsForLedger`, `GetValidationsByValidator`).
+
+- [ ] **Step 2: In `Start()`** after `NewValidationTracker`:
+
+```go
+if e.archive != nil {
+    e.validationTracker.SetOnStale(e.archive.OnStale)
+}
+```
+
+- [ ] **Step 3: In the fully-validated callback**, after `OnLedgerFullyValidated(...)`:
+
+```go
+if e.archive != nil {
+    e.archive.NoteFullyValidated(seq)
+}
+if seq > e.inMemoryLedgers {
+    e.validationTracker.ExpireOld(seq - e.inMemoryLedgers)
+}
+```
+
+- [ ] **Step 4: In `Stop()`** before `e.eventBus.Stop()`:
+
+```go
+if e.archive != nil {
+    _ = e.archive.Close(context.Background())
+}
+```
+
+- [ ] **Step 5: Write test** `TestEngine_FullyValidated_TriggersExpireOld` covering: drive a validation below in-memory window, advance fully-validated seq, assert `ExpireOld` fired (use a `SetOnStale` spy).
+
+- [ ] **Step 6: Run** `go test ./internal/consensus/rcl/...` + `go build ./...` → all green.
+
+- [ ] **Step 7: Commit** `feat(consensus): wire archive into engine and trigger ExpireOld on fully-validated`.
+
+### Task 9 — Acceptance tests (issue-specified)
+
+**Files:**
+- Create: `internal/testing/validationarchive/archive_test.go`
+
+- [ ] Implement the three tests as described in the Acceptance section. Use a temp-dir SQLite via the existing `sqlite.NewRepositoryManager` + `Open()`. Use the real `ValidationTracker` + real `Archive`. No mocks.
+
+- [ ] For `TestValidationArchive_BatchedWriter_DoesNotBlockOnReceive`: construct a slow repo wrapper that sleeps in `SaveBatch`. Channel buffer size (`BatchSize * 8`) must be enough to absorb 1000 enqueues without blocking.
+
+- [ ] Run `go test ./internal/testing/validationarchive/... -v` → all three pass.
+
+- [ ] Commit `test: acceptance tests for validation archive (issue #267)`.
+
+### Task 10 — Verification
+
+- [ ] `go build ./...`
+- [ ] `go test ./internal/consensus/... ./storage/relationaldb/... ./internal/testing/validationarchive/... ./config/...`
+- [ ] `./scripts/conformance-summary.sh | tail -30` — no regressions vs `main`.
+- [ ] `go vet ./...`
+
+## Verification plan (summary)
+
+```
+go build ./...
+go test ./internal/consensus/archive/...
+go test ./internal/consensus/rcl/... -run "ExpireOld|OnStale"
+go test ./storage/relationaldb/sqlite/... -run Validation
+go test ./internal/testing/validationarchive/...
+./scripts/conformance-summary.sh | tail -30    # no regressions in existing suites
+```
+
+## Out of scope (follow-ups, link in PR description)
+
+- Extending `validator_info` / `consensus_info` RPC responses to include `recent_validations` from the archive. Interface is in place; handler change is a trivial follow-up.
+- Long-horizon retention with separate cold-storage table (partitioning by seq bucket).
+- Gossip-replay tooling that consumes the archive (feasible but orthogonal).
+- Pub/sub of `onStale` events for external forensics consumers.
+
+## Review checklist
+
+- [ ] All three issue-specified acceptance tests pass.
+- [ ] `ExpireOld` no longer leaks `byNode` entries.
+- [ ] `OnStale` callback fires outside the tracker's mutex (no lock order inversion with archive).
+- [ ] Batched writer genuinely non-blocking — verified by the slow-repo stress test.
+- [ ] Retention respects `DeleteBatch` ceiling; single sweep never blocks the writer for more than one bounded DELETE.
+- [ ] SQLite **and** PostgreSQL backends both implement the interface; tests skip Postgres when env var absent.
+- [ ] Config validated; invalid values produce clear errors at startup.
+- [ ] `go build`, `go vet`, conformance summary all green.


### PR DESCRIPTION
Closes #267.

## Summary

Implements the `onStale` / `doStaleWrite` pathway goXRPL was missing: stale validations pruned from `ValidationTracker` are persisted to a new `validations` table in the relational DB, written by a batched async writer so consensus is decoupled from DB I/O, with a configurable ledger-seq retention window. **The archive is wired into `adaptor.NewFromConfig` so a real node actually starts archiving when the operator enables `[validation_archive]`.**

Mirrors rippled's historical schema (`RCLValidations.cpp` / `DBInit.h` pre-May-2019), adapted to Go idioms and backed by both SQLite and PostgreSQL.

## What's in

- **Write path** — `ValidationTracker.SetOnStale(fn)` callback; `ExpireOld` fires it outside the tracker mutex for every dropped validation.
- **Engine wiring** — `Engine.SetArchive(a)` + `SetInMemoryLedgers(n)`. The fully-validated callback drives `ExpireOld(seq - n)`, which streams evicted validations into the archive. `Engine.Stop()` drains and closes the archive (5 s timeout). `SetArchive(nil)` properly detaches the tracker callback.
- **Production wiring** — `adaptor.NewFromConfig` accepts `relationaldb.ValidationRepository` and constructs the archive when enabled. Standalone mode and `enabled = false` are both no-ops.
- **Async batched writer** — `internal/consensus/archive`. `OnStale` is a non-blocking try-send with a 100 ms bounded back-pressure fallback. The writer goroutine batches up to `BatchSize` rows or flushes on `FlushInterval`, retries `SaveBatch` once on transient errors before logging at Error and dropping (avoiding unbounded memory growth on a permanently broken backend), then runs a bounded retention `DELETE` — gated on a 1-minute floor so per-second flushes don't amplify into per-second deletes.
- **Storage** — `ValidationRepository` interface + SQLite and PostgreSQL impls. Primary key `(ledger_hash, node_pubkey)` with `ON CONFLICT DO NOTHING` for idempotent re-archival. `InitialSeq` carries the rippled-intended fully-validated pivot at insert time. **Schema deviation from issue #267:** no separate `signature` column — the canonical `Raw` blob already includes `sfSignature`, so a column would duplicate bytes without enabling any current query path.
- **Wire-flag fidelity** — `Validation.Flags` carries the original `sfFlags` word (parser captures, signer emits, archive persists). Forensic queries `SELECT flags FROM validations` see what the validator actually signed, not a synthesized constant.
- **Config** — new `[validation_archive]` TOML section, opt-in by setting `enabled = true`; documented inline in `config/examples/xrpld.toml`. `WithDefaults()` fills missing knobs (preserves `RetentionLedgers=0` = keep forever).
- **Read-path seam** — `ValidationArchiveLookup` interface + `ArchivedValidation` DTO on `types.Services`. Concrete RPC handler integration is tracked as #285.

## Semantic divergence from rippled (intentional)

**Eviction trigger is ledger-seq based, not freshness-based.** Rippled (pre-2019) fired `onStale` from `Validations<>::current()` when `isCurrent()` returned false — on time-window violations (`SignTime`/`SeenTime` drift). goXRPL fires `onStale` only from `ExpireOld(seq - inMemoryLedgers)`, driven by ledger-seq retention from the fully-validated callback.

Practical effect: time-stale validations that never reach a fully-validated ledger (e.g. orphans on losing forks) are **rejected at `Add()` but not archived**. Rippled would have archived them.

Trade-off:
- Forensic completeness for finalized network state — same as rippled.
- Forensic completeness for "what did the network consider but discard" — slightly lower; losing-fork validations are visible only in logs.

Defensible because the dominant use case is replaying finalized state, and the alternative archives orphans we'd delete on the next retention sweep. If "considered but discarded" forensics ever becomes a requirement, hooking a second `OnStale` call from `Add`'s `isCurrent` reject path is straightforward. Documented in `internal/consensus/archive/archive.go` package doc.

## Bonus fixes along the way

- `ExpireOld` was **dead code** (no callers). Now driven from the fully-validated callback so the archive runs in production.
- `ExpireOld` leaked `byNode` entries on eviction. Fixed.
- `ValidationTracker.Add` fired `onFullyValidated` while holding `vt.mu`, so any callback that re-entered the tracker would deadlock. Refactored with a two-defer LIFO so the callback runs after unlock.

## API contract notes for consumers

- **`RepositoryManager` interface change**: adds `Validation() ValidationRepository`. External implementers (test doubles, alternative backends) need a one-liner stub. Both shipping backends are updated.
- **`adaptor.NewFromConfig` signature change**: third parameter `validationRepo relationaldb.ValidationRepository` (pass `nil` to disable). Only caller (`internal/cli/server.go`) is updated.
- `Archive.Flush(ctx)` returns `ErrClosed` when called after `Close` — previously silently nil. Hides fewer bugs.
- `Validation.Flags uint32` is new — captures the wire `sfFlags` word.
- **SQLite contention note**: the archive shares `ledger.db` with `MaxOpenConns(1)` so writes serialize across the whole file. Sustained ledger-write pressure can back up the writer goroutine; under sustained overload `OnStale` logs a warning and drops, rather than blocking consensus.

## Acceptance (issue-specified)

All three tests in `internal/testing/validationarchive/archive_test.go` pass:

- `TestValidationArchive_StaleValidationWrittenOnPrune`
- `TestValidationArchive_BatchedWriter_DoesNotBlockOnReceive`
- `TestValidationArchive_RetentionRespected`

Plus follow-ups from review:

- `TestEngine_SetArchive_NilDetaches` — verifies SetArchive(nil) clears the tracker callback.
- `TestEngine_SetArchive_ConcurrentWithCallback` — exercises the previously-racy archive/inMemoryLedgers read path under `-race`.
- `TestArchive_SaveBatch_RetryOnceThenSucceed` + `TestArchive_SaveBatch_PersistentFailure_DropsAndContinues` — pin the retry policy.
- `TestArchive_FlushAfterClose_ReturnsErrClosed`.
- `TestSTValidation_FlagsRoundTrip` — vendor flag bits survive parse → serialize → parse.

## Review remediation

### Round 1

| # | Issue | Status |
|---|---|---|
| 1 | `SetArchive(nil)` didn't detach | Fixed |
| 2 | Race on `e.archive` / `e.inMemoryLedgers` | Fixed (snapshot under `e.mu.RLock`) |
| 3 | `InitialSeq` tautological | Fixed (`toRecord(v, lastSeq)`) |
| 4 | Non-Full filter | Push back — already filtered at `Add` (`validations.go:297`); documented in `toRecord` |
| 5 | `SaveBatch` silent drop | Fixed (retry once, drop with Error log on persistent) |
| 6 | Redundant `signature` column | Dropped (sig is in `Raw`) |
| 7 | "Non-blocking" overstated | Fixed in this description |
| 8 | `Flush` after `Close` returns nil | Fixed (returns `ErrClosed`) |
| 9 | `RepositoryManager` interface change | Documented above |
| 10 | Unrelated docs in diff | Fixed via rebase onto current main |
| 11 | Per-flush retention amplifies DELETE | Fixed (1-minute floor) |

### Round 2

| # | Issue | Status |
|---|---|---|
| 1 | Production wiring gap (TOML knobs ignored) | **Fixed** — wired into `adaptor.NewFromConfig`; archive runs end-to-end on a real node |
| 2 | `flags` column synthesized, drops vendor bits | Fixed — `Validation.Flags` round-trips the wire word; covered by `TestSTValidation_FlagsRoundTrip` |
| 3 | No TOML example | Fixed in `config/examples/xrpld.toml` |
| 4 | Schema deviation not flagged in PR body | Documented above (Storage section) |
| 5 | SQLite single-writer contention | Documented in PR body and TOML example |

### Round 3

| # | Issue | Status |
|---|---|---|
| 1 | Eviction-trigger divergence (seq-based vs freshness-based) | Documented — "Semantic divergence from rippled" section above + package doc in `internal/consensus/archive/archive.go` |

## Out of scope (tracked as follow-ups)

- `validator_info` / `consensus_info` reading from the archive — `ValidationArchiveLookup` interface is in place at `internal/rpc/types/services.go`, RPC handler wiring tracked in #285.
- PostgreSQL env-gated test suite (`POSTGRES_TEST_URL`). SQLite tests exercise the cross-backend invariants today. Tracked in #286.
- Long-horizon cold-storage partitioning. Tracked in #287.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/consensus/... ./storage/relationaldb/... ./internal/testing/validationarchive/... ./config/...`
- [x] Conformance summary unchanged from main.
- [ ] Schema fit with existing `ledger.db` (SQLite) and PostgreSQL `[database]`.
- [ ] TOML surface (`[validation_archive]`).
