### PR TITLE
chore: prune non-informative comments across goXRPL

### DIFF
--- a/amendment/amendment_test.go
+++ b/amendment/amendment_test.go
@@ -48,13 +48,11 @@ func TestFeatureID(t *testing.T) {
 }
 
 func TestFeatureRegistry(t *testing.T) {
-	// Check that features are registered
 	count := FeatureCount()
 	if count < 80 {
 		t.Errorf("Expected at least 80 features, got %d", count)
 	}
 
-	// Check Flow feature exists
 	flow := GetFeatureByName("Flow")
 	if flow == nil {
 		t.Fatal("Flow feature not found")
@@ -69,7 +67,6 @@ func TestFeatureRegistry(t *testing.T) {
 		t.Error("Flow should be VoteDefaultYes")
 	}
 
-	// Check AMM feature exists
 	amm := GetFeatureByName("AMM")
 	if amm == nil {
 		t.Fatal("AMM feature not found")
@@ -78,7 +75,6 @@ func TestFeatureRegistry(t *testing.T) {
 		t.Error("AMM should be VoteDefaultNo")
 	}
 
-	// Check retired feature
 	multiSign := GetFeatureByName("MultiSign")
 	if multiSign == nil {
 		t.Fatal("MultiSign feature not found")
@@ -87,7 +83,6 @@ func TestFeatureRegistry(t *testing.T) {
 		t.Error("MultiSign should be retired")
 	}
 
-	// Check obsolete feature
 	nftV1 := GetFeatureByName("NonFungibleTokensV1")
 	if nftV1 == nil {
 		t.Fatal("NonFungibleTokensV1 feature not found")
@@ -130,12 +125,10 @@ func TestAmendmentTable(t *testing.T) {
 		t.Error("Flow should be enabled after Enable()")
 	}
 
-	// Check support
 	if !table.IsSupported(FeatureFlow) {
 		t.Error("Flow should be supported")
 	}
 
-	// Check enabled count
 	if table.EnabledCount() != 1 {
 		t.Errorf("Expected 1 enabled, got %d", table.EnabledCount())
 	}

--- a/amendment/registry.go
+++ b/amendment/registry.go
@@ -8,14 +8,12 @@ import (
 	"sync"
 )
 
-// Global feature registry
 var (
 	registryMu     sync.RWMutex
 	features       = make(map[[32]byte]*Feature)
 	featuresByName = make(map[string]*Feature)
 )
 
-// Feature IDs - computed at init time
 var (
 	// Active features (newest first, matching rippled order)
 	FeatureFixDirectoryLimit             [32]byte
@@ -125,7 +123,6 @@ var (
 
 func init() {
 	// Register all features matching rippled's features.macro
-	// Active features (newest first)
 	registerFix("fixDirectoryLimit", SupportedYes, VoteDefaultNo, &FeatureFixDirectoryLimit)
 	registerFix("fixPriceOracleOrder", SupportedNo, VoteDefaultNo, &FeatureFixPriceOracleOrder)
 	registerFix("fixMPTDeliveredAmount", SupportedNo, VoteDefaultNo, &FeatureFixMPTDeliveredAmount)

--- a/amendment/rules.go
+++ b/amendment/rules.go
@@ -165,8 +165,6 @@ func (b *RulesBuilder) Build() *Rules {
 	return NewRules(enabledIDs)
 }
 
-// Helper functions for common amendment checks
-
 // FlowEnabled returns true if the Flow amendment is enabled.
 func (r *Rules) FlowEnabled() bool {
 	return r.Enabled(FeatureFlow)

--- a/amendment/table.go
+++ b/amendment/table.go
@@ -110,22 +110,18 @@ func (t *AmendmentTable) GetDesired() [][32]byte {
 	result := make([][32]byte, 0)
 
 	for _, f := range AllFeatures() {
-		// Skip if already enabled
 		if t.enabled[f.ID] {
 			continue
 		}
 
-		// Skip if not supported
 		if f.Supported != SupportedYes {
 			continue
 		}
 
-		// Skip if vetoed
 		if t.vetoed[f.ID] {
 			continue
 		}
 
-		// Skip obsolete features
 		if f.Vote == VoteObsolete {
 			continue
 		}

--- a/codec/addresscodec/codec.go
+++ b/codec/addresscodec/codec.go
@@ -145,7 +145,6 @@ func EncodeSeed(entropy []byte, encodingType interfaces.CryptoImplementation) (s
 
 // DecodeSeed returns the decoded seed and its corresponding algorithm.
 func DecodeSeed(seed string) ([]byte, interfaces.CryptoImplementation, error) {
-	// decoded := DecodeBase58(seed)
 	decoded, err := Base58CheckDecode(seed)
 
 	if err != nil {

--- a/codec/addresscodec/rippled_vectors_test.go
+++ b/codec/addresscodec/rippled_vectors_test.go
@@ -11,11 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Rippled Seed_test.cpp Test Vectors
 // These test vectors are extracted from the rippled reference implementation
 // to ensure compatibility with the official XRPL protocol.
-// =============================================================================
 
 // TestRippledSeedEncodingVectors tests seed generation from passphrases using
 // exact test vectors from rippled's Seed_test.cpp.

--- a/codec/binarycodec/codec.go
+++ b/codec/binarycodec/codec.go
@@ -13,8 +13,6 @@ import (
 )
 
 var (
-	// Static errors
-
 	// ErrSigningClaimFieldNotFound is returned when the 'Channel' & 'Amount' fields are both required, but were not found.
 	ErrSigningClaimFieldNotFound = errors.New("'Channel' & 'Amount' fields are both required, but were not found")
 	// ErrBatchFlagsFieldNotFound is returned when the 'flags' field is missing.
@@ -43,13 +41,8 @@ const (
 func Encode(json map[string]any) (string, error) {
 	st := types.NewSTObject(serdes.NewBinarySerializer(serdes.NewFieldIDCodec(definitions.Get())))
 
-	// Iterate over the keys in the provided JSON
 	for k := range json {
-		// Get the FieldIdNameMap from the definitions package
 		fh := definitions.Get().Fields[k]
-
-		// If the field is not found in the FieldIdNameMap, delete it from the JSON
-
 		if fh == nil {
 			delete(json, k)
 			continue
@@ -151,26 +144,22 @@ func EncodeForSigningBatch(json map[string]any) (string, error) {
 		return "", ErrBatchTxIDsFieldNotFound
 	}
 
-	// Extract and validate txIDs
 	txIDsInterface, ok := json["txIDs"].([]string)
 	if !ok {
 		return "", ErrBatchTxIDsNotArray
 	}
 
-	// Validate flags type
 	_, ok = json["flags"].(uint32)
 	if !ok {
 		return "", ErrBatchFlagsNotUInt32
 	}
 
-	// Create UInt32 for flags
 	flagsType := &types.UInt32{}
 	flagsBytes, err := flagsType.FromJSON(json["flags"])
 	if err != nil {
 		return "", err
 	}
 
-	// Create UInt32 for txIDs length
 	txIDsLengthType := &types.UInt32{}
 	txIDsLength := len(txIDsInterface)
 	if txIDsLength > math.MaxUint32 {
@@ -181,10 +170,8 @@ func EncodeForSigningBatch(json map[string]any) (string, error) {
 		return "", err
 	}
 
-	// Build the result string
 	result := batchPrefix + hex.EncodeToString(flagsBytes) + hex.EncodeToString(txIDsLengthBytes)
 
-	// Add each transaction ID
 	for _, txID := range txIDsInterface {
 		hash256 := types.NewHash256()
 		txIDBytes, err := hash256.FromJSON(txID)

--- a/codec/binarycodec/quality.go
+++ b/codec/binarycodec/quality.go
@@ -22,8 +22,6 @@ const (
 )
 
 var (
-	// Static errors
-
 	// ErrInvalidQuality is returned when the quality is invalid.
 	ErrInvalidQuality = errors.New("invalid quality")
 )
@@ -51,18 +49,15 @@ func EncodeQuality(quality string) (string, error) {
 	if bigDecimal.UnscaledValue == "" {
 		zeroAmount := make([]byte, 8)
 		binary.BigEndian.PutUint64(zeroAmount, uint64(zeroQualityHex))
-		// if the value is zero, then return the zero currency amount hex
 		return hex.EncodeToString(zeroAmount), nil
 	}
 
-	// convert the unscaled value to an unsigned integer
 	mantissa, err := strconv.ParseUint(bigDecimal.UnscaledValue, 10, 64)
 
 	if err != nil {
 		return "", err
 	}
 
-	// get the scale
 	exp := bigDecimal.Scale
 
 	serialized := make([]byte, 8)
@@ -91,26 +86,20 @@ func DecodeQuality(quality string) (string, error) {
 	mantissaBytes := append([]byte{0}, bytes[1:]...)
 	mantissa := binary.BigEndian.Uint64(mantissaBytes)
 
-	// Convert mantissa to string
 	mantissaStr := strconv.FormatUint(mantissa, 10)
 
-	// Add decimal point based on exponent
 	if exp < 0 {
-		// Need to add leading zeros
 		if len(mantissaStr) <= -exp {
 			zeros := strings.Repeat("0", -exp-len(mantissaStr)+1)
 			mantissaStr = "0." + zeros + mantissaStr
 		} else {
-			// Insert decimal point from right to left
 			insertPos := len(mantissaStr) + exp
 			mantissaStr = mantissaStr[:insertPos] + "." + mantissaStr[insertPos:]
 		}
 	} else if exp > 0 {
-		// Add trailing zeros
 		mantissaStr += strings.Repeat("0", exp)
 	}
 
-	// Trim trailing zeros after decimal point
 	if strings.Contains(mantissaStr, ".") {
 		mantissaStr = strings.TrimRight(mantissaStr, "0")
 		mantissaStr = strings.TrimRight(mantissaStr, ".")

--- a/codec/binarycodec/rippled_hash_prefix_test.go
+++ b/codec/binarycodec/rippled_hash_prefix_test.go
@@ -8,10 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Hash Prefix Tests derived from rippled include/xrpl/protocol/HashPrefix.h
 // These tests verify hash prefixes match rippled exactly for protocol compatibility.
-// =============================================================================
 
 // Hash prefixes from rippled - these are critical for signing and hashing.
 // Each prefix is computed as: (char1 << 24) + (char2 << 16) + (char3 << 8)

--- a/codec/binarycodec/serdes/binary_parser.go
+++ b/codec/binarycodec/serdes/binary_parser.go
@@ -9,8 +9,6 @@ import (
 )
 
 var (
-	// Static errors
-
 	// ErrParserOutOfBound is returned when the parser is out of bounds.
 	ErrParserOutOfBound = errors.New("parser out of bounds")
 	// ErrInvalidTypecode is returned when the typecode is invalid.
@@ -86,7 +84,6 @@ func (p *BinaryParser) readFieldHeader() (*definitions.FieldHeader, error) {
 		}
 	}
 
-	// Return the field header
 	return &definitions.FieldHeader{
 		TypeCode:  int32(typeCode),
 		FieldCode: int32(fieldCode),

--- a/codec/binarycodec/serdes/field_id_codec.go
+++ b/codec/binarycodec/serdes/field_id_codec.go
@@ -8,8 +8,6 @@ import (
 )
 
 var (
-	// Static errors
-
 	// ErrInvalidFieldIDLength is returned when the field ID length is invalid.
 	ErrInvalidFieldIDLength = errors.New("invalid field ID length")
 )

--- a/codec/binarycodec/serdes/rippled_binary_format_test.go
+++ b/codec/binarycodec/serdes/rippled_binary_format_test.go
@@ -584,7 +584,6 @@ func TestVLEncodedFieldTypes(t *testing.T) {
 func TestSerializedFieldOrder(t *testing.T) {
 	defs := definitions.Get()
 
-	// Get field instances and verify ordering
 	fields := []string{
 		"TransactionType", // type=1, field=2
 		"Flags",           // type=2, field=2

--- a/codec/binarycodec/serdes/rippled_binary_format_test.go
+++ b/codec/binarycodec/serdes/rippled_binary_format_test.go
@@ -9,10 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Binary Format Tests derived from rippled protocol specification
 // These tests verify VL encoding, field ID encoding, and other binary format details.
-// =============================================================================
 
 // TestVariableLengthEncoding tests the Variable Length (VL) encoding scheme.
 // VL encoding is used for fields like Blob, AccountID, and other variable-length types.

--- a/codec/binarycodec/types/amount.go
+++ b/codec/binarycodec/types/amount.go
@@ -93,7 +93,6 @@ type InvalidAmountError struct {
 	Amount string
 }
 
-// Error method for InvalidAmountError returns a formatted error string.
 func (e *InvalidAmountError) Error() string {
 	return fmt.Sprintf("value '%s' is an invalid amount", e.Amount)
 }
@@ -103,7 +102,6 @@ type OutOfRangeError struct {
 	Type string
 }
 
-// Error method for OutOfRangeError returns a formatted error string.
 func (e *OutOfRangeError) Error() string {
 	return fmt.Sprintf("%s is out of range", e.Type)
 }
@@ -113,7 +111,6 @@ type InvalidCodeError struct {
 	Disallowed string
 }
 
-// Error method for InvalidCodeError returns a formatted error string.
 func (e *InvalidCodeError) Error() string {
 	return fmt.Sprintf("'%s' is/are disallowed or invalid", e.Disallowed)
 }

--- a/codec/binarycodec/types/hash.go
+++ b/codec/binarycodec/types/hash.go
@@ -22,17 +22,14 @@ type ErrInvalidHexString struct {
 	Err error
 }
 
-// Error method for ErrInvalidHashLength formats the error message.
 func (e *ErrInvalidHashLength) Error() string {
 	return fmt.Sprintf("invalid hash length expected length %v", e.Expected)
 }
 
-// Error method for ErrInvalidHashType formats the error message.
 func (e *ErrInvalidHashType) Error() string {
 	return "invalid hash type"
 }
 
-// Error method for ErrInvalidHexString formats the error message.
 func (e *ErrInvalidHexString) Error() string {
 	return "error decoding hex string: " + e.Err.Error()
 }

--- a/codec/binarycodec/types/pathset.go
+++ b/codec/binarycodec/types/pathset.go
@@ -26,7 +26,6 @@ func serializePathCurrency(currency string) ([]byte, error) {
 	return serializeIssuedCurrencyCode(currency)
 }
 
-// PathSet type declaration
 type PathSet struct{}
 
 // ErrInvalidPathSet is an error that's thrown when an invalid path set is provided.

--- a/codec/binarycodec/types/rippled_protocol_test.go
+++ b/codec/binarycodec/types/rippled_protocol_test.go
@@ -10,10 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Test vectors derived from rippled src/test/protocol/STAmount_test.cpp
 // These tests ensure goXRPL serialization produces identical binary output to rippled.
-// =============================================================================
 
 // TestXRPAmountEncoding_RippledVectors tests XRP amount encoding.
 // Extracted from testNativeCurrency() and testSetValue(native) in STAmount_test.cpp

--- a/codec/binarycodec/types/rippled_stobject_test.go
+++ b/codec/binarycodec/types/rippled_stobject_test.go
@@ -10,10 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Test vectors derived from rippled src/test/protocol/STObject_test.cpp
 // These tests verify field ordering, nested objects, and binary format compliance.
-// =============================================================================
 
 // TestFieldOrdering_RippledVectors verifies fields are serialized in ordinal order.
 // From testSerialization() in STObject_test.cpp - fields must be sorted by ordinal.

--- a/codec/binarycodec/types/vector256.go
+++ b/codec/binarycodec/types/vector256.go
@@ -17,7 +17,6 @@ type ErrInvalidVector256Type struct {
 	Got string
 }
 
-// Error implements the error interface, providing a descriptive error message for ErrInvalidVector256Type.
 func (e *ErrInvalidVector256Type) Error() string {
 	return fmt.Sprintf("Invalid type to construct Vector256 from. Expected []string, got %v", e.Got)
 }

--- a/codec/binarycodec/types/xchain_bridge.go
+++ b/codec/binarycodec/types/xchain_bridge.go
@@ -8,7 +8,6 @@ import (
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/types/interfaces"
 )
 
-// Errors
 var (
 	errNotValidXChainBridge = errors.New("not a valid xchain bridge")
 )

--- a/config/config.go
+++ b/config/config.go
@@ -237,13 +237,11 @@ func (c *Config) GetWebSocketPorts() map[string]PortConfig {
 
 // containsProtocol checks if a protocol string contains a specific protocol
 func containsProtocol(protocols, target string) bool {
-	// Simple implementation - could be enhanced for more complex parsing
 	return contains(protocols, target)
 }
 
 // contains checks if a string contains a substring (case-insensitive)
 func contains(s, substr string) bool {
-	// Simple case-insensitive contains check
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {
 			return true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -184,7 +184,6 @@ journal_size_limit = 1582080
 	err := os.WriteFile(mainConfigPath, []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	// Create validators file in the same dir
 	validatorsContent := `
 validator_list_sites = ["https://test.example.com"]
 validator_list_keys = ["ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D58"]

--- a/config/database.go
+++ b/config/database.go
@@ -157,12 +157,10 @@ func (n *NodeDBConfig) GetType() string {
 	}
 }
 
-// GetCacheSize returns cache size
 func (n *NodeDBConfig) GetCacheSize() int {
 	return n.CacheSize
 }
 
-// GetCacheAge returns cache age
 func (n *NodeDBConfig) GetCacheAge() int {
 	return n.CacheAge
 }
@@ -173,37 +171,30 @@ func (n *NodeDBConfig) ShouldCreateCache() bool {
 	return n.OnlineDelete == 0 && (n.CacheSize != 0 || n.CacheAge != 0)
 }
 
-// GetEarliestSeq returns the earliest sequence
 func (n *NodeDBConfig) GetEarliestSeq() int {
 	return n.EarliestSeq
 }
 
-// IsOnlineDeleteEnabled returns true if online delete is enabled
 func (n *NodeDBConfig) IsOnlineDeleteEnabled() bool {
 	return n.OnlineDelete > 0
 }
 
-// IsAdvisoryDeleteEnabled returns true if advisory delete is enabled
 func (n *NodeDBConfig) IsAdvisoryDeleteEnabled() bool {
 	return n.AdvisoryDelete == 1
 }
 
-// GetDeleteBatch returns delete batch size
 func (n *NodeDBConfig) GetDeleteBatch() int {
 	return n.DeleteBatch
 }
 
-// GetBackOffMilliseconds returns back off time
 func (n *NodeDBConfig) GetBackOffMilliseconds() int {
 	return n.BackOffMilliseconds
 }
 
-// GetAgeThresholdSeconds returns age threshold
 func (n *NodeDBConfig) GetAgeThresholdSeconds() int {
 	return n.AgeThresholdSeconds
 }
 
-// GetRecoveryWaitSeconds returns recovery wait time
 func (n *NodeDBConfig) GetRecoveryWaitSeconds() int {
 	return n.RecoveryWaitSeconds
 }
@@ -220,12 +211,10 @@ func (s *SQLiteConfig) GetEffectiveSettings() (journalMode, synchronous, tempSto
 	return s.JournalMode, s.Synchronous, s.TempStore
 }
 
-// GetPageSize returns page size
 func (s *SQLiteConfig) GetPageSize() int {
 	return s.PageSize
 }
 
-// GetJournalSizeLimit returns journal size limit
 func (s *SQLiteConfig) GetJournalSizeLimit() int {
 	return s.JournalSizeLimit
 }

--- a/config/diagnostics.go
+++ b/config/diagnostics.go
@@ -110,7 +110,6 @@ func isValidAddressPort(addr string) bool {
 		return false // No colon found
 	}
 
-	// Check if port part is numeric
 	portStr := addr[lastColon+1:]
 	if portStr == "" {
 		return false

--- a/config/genesis_json.go
+++ b/config/genesis_json.go
@@ -183,7 +183,6 @@ func (g *GenesisJSON) ToGenesisConfig() (*GenesisConfig, error) {
 
 	config := &GenesisConfig{}
 
-	// Parse total coins
 	totalCoins := g.Ledger.TotalCoins
 	if totalCoins == "" {
 		totalCoins = g.Ledger.TotalCoinsAlt
@@ -195,14 +194,11 @@ func (g *GenesisJSON) ToGenesisConfig() (*GenesisConfig, error) {
 		}
 	}
 
-	// Parse close time resolution
 	if g.Ledger.CloseTimeResolution > 0 {
 		config.CloseTimeResolution = uint32(g.Ledger.CloseTimeResolution)
 	}
 
-	// Parse fee settings
 	if state.FeeSettings != nil {
-		// Parse BaseFee from hex string
 		baseFee, err := parseHexFee(state.FeeSettings.BaseFee)
 		if err != nil {
 			return nil, fmt.Errorf("invalid BaseFee: %w", err)
@@ -212,7 +208,6 @@ func (g *GenesisJSON) ToGenesisConfig() (*GenesisConfig, error) {
 		config.ReserveIncrement = drops.NewXRPAmount(int64(state.FeeSettings.ReserveIncrement))
 	}
 
-	// Parse amendments
 	if state.Amendments != nil && len(state.Amendments.Amendments) > 0 {
 		config.Amendments = make([][32]byte, 0, len(state.Amendments.Amendments))
 		for _, hexHash := range state.Amendments.Amendments {
@@ -224,7 +219,6 @@ func (g *GenesisJSON) ToGenesisConfig() (*GenesisConfig, error) {
 		}
 	}
 
-	// Parse accounts
 	if len(state.Accounts) > 0 {
 		config.InitialAccounts = make([]InitialAccountConfig, 0, len(state.Accounts))
 		for _, acc := range state.Accounts {
@@ -301,7 +295,6 @@ func (g *GenesisJSON) Validate() error {
 		totalBalance += balance
 	}
 
-	// Check total balance matches total coins
 	if totalCoins != "" {
 		total, _ := strconv.ParseUint(totalCoins, 10, 64)
 		if totalBalance != total {
@@ -314,7 +307,6 @@ func (g *GenesisJSON) Validate() error {
 
 // parseHexFee parses a hex fee string (e.g., "A" or "0A") to uint64
 func parseHexFee(hexStr string) (uint64, error) {
-	// Remove 0x prefix if present
 	hexStr = strings.TrimPrefix(hexStr, "0x")
 	hexStr = strings.TrimPrefix(hexStr, "0X")
 

--- a/config/misc.go
+++ b/config/misc.go
@@ -20,7 +20,6 @@ type VLConfig struct {
 
 // Validate performs validation on the crawl configuration
 func (c *CrawlConfig) Validate() error {
-	// Validate flag values (should be 0 or 1)
 	if c.Overlay != 0 && c.Overlay != 1 {
 		return fmt.Errorf("crawl overlay must be 0 or 1, got %d", c.Overlay)
 	}
@@ -39,7 +38,6 @@ func (c *CrawlConfig) Validate() error {
 
 // Validate performs validation on the VL configuration
 func (v *VLConfig) Validate() error {
-	// Validate enable flag
 	if v.Enable != 0 && v.Enable != 1 {
 		return fmt.Errorf("vl enable must be 0 or 1, got %d", v.Enable)
 	}

--- a/config/peer.go
+++ b/config/peer.go
@@ -31,12 +31,10 @@ type TransactionQueueConfig struct {
 
 // Validate performs validation on the overlay configuration
 func (o *OverlayConfig) Validate() error {
-	// Validate max_unknown_time
 	if o.MaxUnknownTime != 0 && (o.MaxUnknownTime < 300 || o.MaxUnknownTime > 1800) {
 		return fmt.Errorf("max_unknown_time must be between 300 and 1800 seconds, got %d", o.MaxUnknownTime)
 	}
 
-	// Validate max_diverged_time
 	if o.MaxDivergedTime != 0 && (o.MaxDivergedTime < 60 || o.MaxDivergedTime > 900) {
 		return fmt.Errorf("max_diverged_time must be between 60 and 900 seconds, got %d", o.MaxDivergedTime)
 	}
@@ -89,12 +87,10 @@ func (tq *TransactionQueueConfig) Validate() error {
 	return nil
 }
 
-// GetMaxUnknownTime returns the max unknown time
 func (o *OverlayConfig) GetMaxUnknownTime() int {
 	return o.MaxUnknownTime
 }
 
-// GetMaxDivergedTime returns the max diverged time
 func (o *OverlayConfig) GetMaxDivergedTime() int {
 	return o.MaxDivergedTime
 }
@@ -113,37 +109,30 @@ func (o *OverlayConfig) GetIPLimit() int {
 	return o.IPLimit
 }
 
-// GetLedgersInQueue returns ledgers in queue
 func (tq *TransactionQueueConfig) GetLedgersInQueue() int {
 	return tq.LedgersInQueue
 }
 
-// GetMinimumQueueSize returns minimum queue size
 func (tq *TransactionQueueConfig) GetMinimumQueueSize() int {
 	return tq.MinimumQueueSize
 }
 
-// GetRetrySequencePercent returns retry sequence percent
 func (tq *TransactionQueueConfig) GetRetrySequencePercent() int {
 	return tq.RetrySequencePercent
 }
 
-// GetMinimumEscalationMultiplier returns minimum escalation multiplier
 func (tq *TransactionQueueConfig) GetMinimumEscalationMultiplier() int {
 	return tq.MinimumEscalationMultiplier
 }
 
-// GetMinimumTxnInLedger returns minimum transactions in ledger
 func (tq *TransactionQueueConfig) GetMinimumTxnInLedger() int {
 	return tq.MinimumTxnInLedger
 }
 
-// GetMinimumTxnInLedgerStandalone returns minimum transactions in ledger for standalone
 func (tq *TransactionQueueConfig) GetMinimumTxnInLedgerStandalone() int {
 	return tq.MinimumTxnInLedgerStandalone
 }
 
-// GetTargetTxnInLedger returns target transactions in ledger
 func (tq *TransactionQueueConfig) GetTargetTxnInLedger() int {
 	return tq.TargetTxnInLedger
 }
@@ -153,27 +142,22 @@ func (tq *TransactionQueueConfig) GetMaximumTxnInLedger() int {
 	return tq.MaximumTxnInLedger
 }
 
-// GetNormalConsensusIncreasePercent returns normal consensus increase percent
 func (tq *TransactionQueueConfig) GetNormalConsensusIncreasePercent() int {
 	return tq.NormalConsensusIncreasePercent
 }
 
-// GetSlowConsensusDecreasePercent returns slow consensus decrease percent
 func (tq *TransactionQueueConfig) GetSlowConsensusDecreasePercent() int {
 	return tq.SlowConsensusDecreasePercent
 }
 
-// GetMaximumTxnPerAccount returns maximum transactions per account
 func (tq *TransactionQueueConfig) GetMaximumTxnPerAccount() int {
 	return tq.MaximumTxnPerAccount
 }
 
-// GetMinimumLastLedgerBuffer returns minimum last ledger buffer
 func (tq *TransactionQueueConfig) GetMinimumLastLedgerBuffer() int {
 	return tq.MinimumLastLedgerBuffer
 }
 
-// GetZeroBaseFeeTransactionFeeLevel returns zero base fee transaction fee level
 func (tq *TransactionQueueConfig) GetZeroBaseFeeTransactionFeeLevel() int {
 	return tq.ZeroBaseFeeTransactionFeeLevel
 }

--- a/config/server.go
+++ b/config/server.go
@@ -197,7 +197,6 @@ func (p *PortConfig) validateProtocols() error {
 		}
 	}
 
-	// Check for invalid combinations
 	if hasWebSocket && hasNonWebSocket {
 		return fmt.Errorf("websocket and non-websocket protocols cannot be combined on the same port")
 	}

--- a/config/validators.go
+++ b/config/validators.go
@@ -16,28 +16,24 @@ type ValidatorsConfig struct {
 
 // Validate performs validation on the validators configuration
 func (v *ValidatorsConfig) Validate() error {
-	// Validate individual validator keys
 	for i, validator := range v.Validators {
 		if err := validateValidatorKey(validator); err != nil {
 			return fmt.Errorf("invalid validator at index %d: %w", i, err)
 		}
 	}
 
-	// Validate validator list sites
 	for i, site := range v.ValidatorListSites {
 		if err := validateValidatorListSite(site); err != nil {
 			return fmt.Errorf("invalid validator_list_site at index %d: %w", i, err)
 		}
 	}
 
-	// Validate validator list keys
 	for i, key := range v.ValidatorListKeys {
 		if err := validateValidatorListKey(key); err != nil {
 			return fmt.Errorf("invalid validator_list_key at index %d: %w", i, err)
 		}
 	}
 
-	// Validate threshold
 	if v.ValidatorListThreshold < 0 {
 		return fmt.Errorf("validator_list_threshold must be non-negative, got %d", v.ValidatorListThreshold)
 	}
@@ -197,12 +193,10 @@ func ParseValidatorsTxt(content string) (*ValidatorsConfig, error) {
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 
-		// Skip empty lines and comments
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 
-		// Check for section headers
 		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
 			currentSection = strings.Trim(line, "[]")
 			continue
@@ -217,7 +211,6 @@ func ParseValidatorsTxt(content string) (*ValidatorsConfig, error) {
 		case "validator_list_keys":
 			config.ValidatorListKeys = append(config.ValidatorListKeys, line)
 		case "validator_list_threshold":
-			// This is typically just a number, parse it
 			var threshold int
 			if _, err := fmt.Sscanf(line, "%d", &threshold); err == nil {
 				config.ValidatorListThreshold = threshold

--- a/config/voting.go
+++ b/config/voting.go
@@ -12,17 +12,14 @@ type VotingConfig struct {
 
 // Validate performs validation on the voting configuration
 func (v *VotingConfig) Validate() error {
-	// Validate reference_fee
 	if v.ReferenceFee < 0 {
 		return fmt.Errorf("reference_fee must be non-negative, got %d", v.ReferenceFee)
 	}
 
-	// Validate account_reserve
 	if v.AccountReserve < 0 {
 		return fmt.Errorf("account_reserve must be non-negative, got %d", v.AccountReserve)
 	}
 
-	// Validate owner_reserve
 	if v.OwnerReserve < 0 {
 		return fmt.Errorf("owner_reserve must be non-negative, got %d", v.OwnerReserve)
 	}

--- a/crypto/random.go
+++ b/crypto/random.go
@@ -62,7 +62,6 @@ func randomSecp256k1SecretKey() (*SecretKey, error) {
 		return randomSecp256k1SecretKey()
 	}
 
-	// Get the normalized bytes
 	normalizedKey := privKey.Serialize()
 	SecureErase(key)
 

--- a/crypto/rfc1751/rfc1751.go
+++ b/crypto/rfc1751/rfc1751.go
@@ -58,7 +58,7 @@ func standard(word string) string {
 	for i := 0; i < len(word); i++ {
 		c := word[i]
 		if c >= 'a' && c <= 'z' {
-			result[i] = c - 32 // toupper
+			result[i] = c - 32
 		} else if c == '1' {
 			result[i] = 'L'
 		} else if c == '0' {

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -284,7 +284,6 @@ func (c SECP256K1CryptoAlgorithm) ValidateDigest(digest [32]byte, pubkeyBytes []
 
 // DerivePublicKeyFromPublicGenerator derives a public key from a public generator.
 func (c SECP256K1CryptoAlgorithm) DerivePublicKeyFromPublicGenerator(pubKey []byte) ([]byte, error) {
-	// Get the curve
 	curve := btcec.S256()
 
 	// Parse the input public key as a point
@@ -318,7 +317,6 @@ func (c SECP256K1CryptoAlgorithm) DerivePublicKeyFromPublicGenerator(pubKey []by
 	// Create the final public key
 	finalPubKey := secp256k1.NewPublicKey(&resultXField, &resultYField)
 
-	// Return compressed format
 	return finalPubKey.SerializeCompressed(), nil
 }
 

--- a/docs/superpowers/plans/2026-04-24-comment-cleanup.md
+++ b/docs/superpowers/plans/2026-04-24-comment-cleanup.md
@@ -991,12 +991,32 @@ Expected: empty. Any hit here means a preserved comment slipped through and need
 
 ## Review
 
-Leave this section blank until Task 11 completes, then append:
+- Total commits: 16 (plus the two spec/plan doc commits on main)
+- Files touched: 209
+- Lines added: 28 (gofmt re-alignments after trailing-comment removal, plus 2 oracle godoc rewrites that preserve the rippled cross-reference on the new line)
+- Lines removed: 1638
+- Net: -1610 lines
+- Packages affected: codec, crypto, drops, keylet, protocol, ledger/entry, shamap, storage, amendment, config, internal/rpc, all 24 internal/tx/ subpackages, internal/tx/ top-level, internal/consensus, internal/testing, internal/txq, tree-wide *_test.go
+- Preservation audit final check: PASS. Net rippled-reference content unchanged; the two oracle godoc edits move "matches rippled's DeleteOracle::preflight()" / "matches rippled's SetOracle::preflight()" onto the godoc summary line rather than a separate trailing line.
+- Regressions: zero. Package-level fail list on this branch is identical to baseline main at `173ebf9` (notably `codec/binarycodec/types TestSerializeXrpAmount` panic and the tx-subpackage failures already present on main).
 
-- Total commits: _
-- Total lines removed: _
-- Files touched: _
-- Packages affected: _
-- Preservation audit final check: PASS / FAIL
+### Commits (newest → oldest)
 
-If any commit needed to be reverted, list it and the reason.
+1. `7a9ace0` chore(tests): prune non-informative comments in *_test.go files
+2. `7c84258` chore(txq): prune non-informative comments
+3. `fe697a0` style(tx): remove residual godoc-restatement comments from all tx subpackages
+4. `60e6010` chore(testing): prune non-informative comments in testing helpers
+5. `1b257dc` chore(consensus): prune non-informative comments in adaptor package
+6. `6948c62` chore(tx): prune non-informative comments in top-level tx package
+7. `1d9c809` chore(tx/payment,permissioneddomain,pseudo,signerlist,ticket,trustset,vault,xchain): prune non-informative comments
+8. `879a12d` chore(tx/nftoken,offer,oracle,paychan): prune non-informative comments
+9. `eb8257b` chore(tx/did,escrow,ledgerstatefix,mpt): prune non-informative comments
+10. `1c5b74b` chore(tx/clawback,credential,delegate,depositpreauth): prune non-informative comments
+11. `74d421c` chore(tx/account,amm,batch,check): prune non-informative comments
+12. `a379ad4` chore(rpc): prune non-informative comments
+13. `eb375af` chore(amendment,config): prune non-informative comments
+14. `f325500` chore(ledger,shamap,storage): prune non-informative comments
+15. `373d266` chore(crypto,drops,keylet,protocol): prune non-informative comments
+16. `7f4ef8b` chore(codec): prune non-informative comments
+
+No commits were reverted. One indentation bug introduced mid-run by a subagent in `internal/txq/apply.go` was caught and corrected before the txq commit landed.

--- a/docs/superpowers/plans/2026-04-24-comment-cleanup.md
+++ b/docs/superpowers/plans/2026-04-24-comment-cleanup.md
@@ -1,0 +1,1002 @@
+# Comment Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Subtract low-value comments (godoc restatements, const echoes, obvious what-comments, section separators, stale TODOs, commented-out code) across `goXRPL/` while preserving every comment that ties Go code to rippled, amendments, or protocol invariants.
+
+**Architecture:** Pattern-based candidate detection per package group, followed by human review, applied via `Edit`, gated by `go build ./...` + `go test` + `goimports -l`, committed per package group. Each commit is independently revertable. No code reordering, no refactoring, no new comments.
+
+**Tech Stack:** Go 1.24, `goimports`, `git`, ripgrep (`rg` preferred; falls back to `grep -rnE`).
+
+**Spec:** `docs/superpowers/specs/2026-04-24-comment-cleanup-design.md`
+
+---
+
+## Ground rules for every task
+
+These apply to every task below. Re-read them if you are picking up mid-plan.
+
+### Removable categories (candidates)
+
+1. **Godoc restatement** — `// Foo does foo` above `func Foo()` that only echoes the identifier.
+2. **Const/enum echo** — trailing comment that repeats the const name in another case (e.g., `TypePayment Type = 0 // ttPAYMENT`).
+3. **Obvious inline what-comment** — `// Return the result` above `return result`, etc.
+4. **Section header / separator** — `// ===== Foo =====`, `// ---- helpers ----`, long dashed dividers.
+5. **Stale TODO or commented-out code** — TODOs verified done, or `// func oldThing() { ... }` blocks.
+
+### Hard preservation list (never remove)
+
+Before removing any candidate, check the comment against this list. If it matches, **keep it**:
+
+- Contains `Reference:`, `Mirrors rippled`, `Matches rippled`, `See rippled`, or any rippled file path.
+- Mentions an amendment name (grep hint: `amendment`, `feature`, `fix`, `Amendment`).
+- Documents an invariant, preflight, preclaim, or TER code.
+- Explains a crypto/DER/signature algorithm or byte layout.
+- Describes a struct-tag or serialization format.
+- Is in a `doc.go` file (skip these files entirely).
+- Is in a file containing `// Code generated ... DO NOT EDIT.` (skip these files entirely).
+- Documents params, return values, errors, side effects, or non-obvious semantics (even for category 1).
+- Is a live TODO pointing at real gap (grep the referenced symbol; if it is unimplemented, keep the TODO).
+
+### Per-task workflow (apply to every package group)
+
+For each task below, perform these steps in order. Do not skip gates.
+
+**W1. Baseline** — run `go build ./...` from repo root. Must pass before you start. If it does not, stop and investigate; do not attribute pre-existing breakage to this cleanup.
+
+**W2. Enumerate candidates** — run each category grep listed in the task against the task's paths. Pipe to a local scratch file if useful; do not commit it.
+
+**W3. Review candidates** — open each candidate file at the matched line with `Read`. Apply the hard preservation list. Discard any candidate that is preserved.
+
+**W4. Apply edits** — use `Edit` (not `sed`, not `Write`). Remove only the comment line(s). Do not alter code lines. Do not reorder. Do not fix typos in neighbouring code.
+
+**W5. Build gate** — `go build ./...` from repo root. Must pass.
+
+**W6. Test gate** — `go test <task's test target>`. Must pass. If a previously-passing test fails, revert the last edit and re-review the candidate.
+
+**W7. Format gate** — `goimports -l <modified files>`. Output must be empty.
+
+**W8. Preservation audit** — run `git diff --unified=0 | rg -i 'reference:|amendment|mirrors rippled|matches rippled'`. Output must be empty. If not, you removed a preserved comment — restore it.
+
+**W9. Commit** — use the commit message given in the task. Do not add unrelated files.
+
+### Category grep patterns
+
+Use these as the starting point for W2. `rg` is preferred; swap `rg` for `grep -rnE` if unavailable.
+
+```bash
+# Category 2 — const/enum echoes: trailing comments on declarations
+rg -nP '^\s*\w+\s*(=|:=|[A-Z]\w*\s+=)\s+[^/]+//\s*\w+\s*$' <paths> --type=go
+
+# Category 3 — obvious inline what-comments (heuristic start; must review)
+rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip)\b[^.]{0,40}$' <paths> --type=go
+
+# Category 4 — section headers and separators
+rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,}|#{2,})' <paths> --type=go
+
+# Category 5a — TODO/FIXME/XXX markers (review live vs stale)
+rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b' <paths> --type=go
+
+# Category 5b — commented-out code (review; catches godoc too)
+rg -nP '^\s*//\s*(func |if |for |return |var |const |type |switch |go |defer )' <paths> --type=go
+
+# Category 1 — godoc that echoes the identifier (manual scan, no clean grep)
+# Read each *.go; for `// X …` immediately above `func X`, `type X`, `var X`, `const X`,
+# judge: is there content beyond echoing `X`? If no, candidate.
+```
+
+### Commit message convention
+
+```
+chore(<pkg>): prune non-informative comments
+
+Removes <N> low-value comments across <files>.
+No rippled references, amendment gates, or invariant notes touched.
+```
+
+Fill in `<pkg>`, `<N>`, and `<files>` (keep `<files>` short — use the package name if many).
+
+---
+
+## File Map
+
+This plan edits only comment lines. No code changes. No file creations. Files touched are bounded by the task paths below.
+
+| Task | Paths (relative to `goXRPL/`) |
+|------|-------------------------------|
+| 0 | — (baseline only) |
+| 1 | `codec/addresscodec/`, `codec/binarycodec/` |
+| 2 | `crypto/`, `drops/`, `keylet/`, `protocol/` |
+| 3 | `ledger/entry/`, `shamap/`, `storage/` |
+| 4 | `amendment/`, `config/` |
+| 5 | `internal/rpc/` |
+| 6 | `internal/tx/<per-tx-type>/` (account, amm, batch, check, clawback, credential, delegate, depositpreauth, did, escrow, ledgerstatefix, mpt, nftoken, offer, oracle, paychan, payment, permissioneddomain, pseudo, signerlist, ticket, trustset, vault, xchain) |
+| 7 | `internal/tx/` top-level (`engine.go`, `apply_state_table.go`, `signature.go`, `registry.go`, `flatten.go`, others) |
+| 8 | `internal/consensus/`, `internal/txq/` |
+| 9 | `internal/testing/` and its subpackages |
+| 10 | `*_test.go` sweep (any test files not covered above) |
+| 11 | Final full-tree verification |
+
+---
+
+## Task 0: Baseline verification
+
+Before any edits, verify the tree is in a clean, passing state. Any later breakage must be attributable to this cleanup, not to pre-existing issues.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm clean working tree**
+
+Run from `/Users/thomashussenet/Documents/project_goXRPL/goXRPL`:
+
+```bash
+git status --short
+```
+
+Expected: only the spec + plan files from earlier commits show as untracked or nothing. If unrelated modifications exist, stop and ask the user.
+
+- [ ] **Step 2: Baseline build**
+
+```bash
+go build ./...
+```
+
+Expected: exits 0 with no output. If it fails, stop — this is not a cleanup problem.
+
+- [ ] **Step 3: Baseline tests (smoke)**
+
+```bash
+go test ./codec/... ./crypto/... ./ledger/... ./amendment/... ./protocol/... ./keylet/... ./drops/... ./shamap/... ./storage/...
+```
+
+Expected: PASS. Known-failing tests may exist; record which suites fail at baseline so you can distinguish them from regressions later.
+
+- [ ] **Step 4: Confirm tooling**
+
+```bash
+which goimports
+command -v rg || command -v grep
+```
+
+Expected: `goimports` resolves; either `rg` or `grep` is available.
+
+- [ ] **Step 5: Verify `rippled/` is not inside the module**
+
+```bash
+git ls-files | rg '^rippled/' | head -5
+```
+
+Expected: empty. If `rippled/` shows up in `git ls-files`, double-check before proceeding — this plan must not touch that directory.
+
+No commit. Move to Task 1.
+
+---
+
+## Task 1: codec/ (addresscodec, binarycodec)
+
+Leaf package group. Format specs are load-bearing — preserve any comment describing byte layouts, test vectors, or hash prefix constants.
+
+**Files:** modify only comment lines in `codec/addresscodec/**/*.go` and `codec/binarycodec/**/*.go`. Skip `doc.go`, skip `testutil/mock_*.go`, skip any file containing `// Code generated`.
+
+- [ ] **Step 1: W1 — build baseline**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: W2 — enumerate candidates**
+
+From `goXRPL/`:
+```bash
+rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,})' codec/ --type=go
+rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b' codec/ --type=go
+rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip)\b[^.]{0,40}$' codec/ --type=go
+rg -nP '^\s*\w[^=]*=\s*[^/]+//\s*\w+\s*$' codec/ --type=go
+rg --files codec/ --type=go | rg -v '/doc\.go$|/testutil/mock_' | while read f; do
+  rg -l 'Code generated .* DO NOT EDIT\.' "$f" >/dev/null && continue
+  printf '%s\n' "$f"
+done > /tmp/codec-files.txt
+```
+
+- [ ] **Step 3: W3 — review and prune the candidate list**
+
+For each grep hit, `Read` the file at the hit line (±3 lines). Apply the hard preservation list. Format/byte-layout comments in `binarycodec/types/*.go` are overwhelmingly load-bearing — default to keep unless the comment is a pure header/separator or an identifier echo.
+
+- [ ] **Step 4: W4 — apply edits**
+
+Use `Edit` for each comment line to remove. Remove only the comment line. Do not change code.
+
+- [ ] **Step 5: W5 — build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 6: W6 — test**
+
+```bash
+go test ./codec/...
+```
+Expected: PASS (modulo baseline known-fails from Task 0 Step 3).
+
+- [ ] **Step 7: W7 — format**
+
+```bash
+goimports -l $(git diff --name-only | rg '\.go$')
+```
+Expected: empty output.
+
+- [ ] **Step 8: W8 — preservation audit**
+
+```bash
+git diff --unified=0 | rg -i 'reference:|mirrors rippled|matches rippled|see rippled|amendment|invariant|preflight|preclaim|TER'
+```
+Expected: empty. If any line appears, a preserved comment was removed — restore it and re-run the audit.
+
+- [ ] **Step 9: W9 — commit**
+
+```bash
+git add -u codec/
+git commit -m "$(cat <<'EOF'
+chore(codec): prune non-informative comments
+
+Removes low-value comments (headers, echoes, stale markers) across
+addresscodec/ and binarycodec/. No rippled references, amendment gates,
+format specs, or invariant notes touched.
+EOF
+)"
+```
+
+---
+
+## Task 2: crypto/, drops/, keylet/, protocol/
+
+Foundation packages. Crypto algorithm commentary is load-bearing — preserve anything explaining DER, secp256k1, ed25519, RFC references, or byte layouts.
+
+**Files:** modify only comment lines in `crypto/**/*.go`, `drops/**/*.go`, `keylet/**/*.go`, `protocol/**/*.go`. Skip `doc.go`, generated files, `testutil/mock_*.go`.
+
+- [ ] **Step 1: W1 — build baseline**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: W2 — enumerate candidates**
+
+```bash
+rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,})' crypto/ drops/ keylet/ protocol/ --type=go
+rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b' crypto/ drops/ keylet/ protocol/ --type=go
+rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip)\b[^.]{0,40}$' crypto/ drops/ keylet/ protocol/ --type=go
+rg -nP '^\s*\w[^=]*=\s*[^/]+//\s*\w+\s*$' crypto/ drops/ keylet/ protocol/ --type=go
+```
+
+- [ ] **Step 3: W3 — review and prune**
+
+For each hit, `Read` and apply preservation list. Default-keep on anything referencing RFC numbers, DER, canonicality, or rippled signature behavior.
+
+- [ ] **Step 4: W4 — apply edits**
+
+Use `Edit`. Comment lines only.
+
+- [ ] **Step 5: W5 — build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 6: W6 — test**
+
+```bash
+go test ./crypto/... ./drops/... ./keylet/... ./protocol/...
+```
+Expected: PASS.
+
+- [ ] **Step 7: W7 — format**
+
+```bash
+goimports -l $(git diff --name-only | rg '\.go$')
+```
+Expected: empty.
+
+- [ ] **Step 8: W8 — preservation audit**
+
+```bash
+git diff --unified=0 | rg -i 'reference:|mirrors rippled|matches rippled|see rippled|amendment|invariant|RFC|DER|canonical'
+```
+Expected: empty. Any hit → restore and re-audit.
+
+- [ ] **Step 9: W9 — commit**
+
+```bash
+git add -u crypto/ drops/ keylet/ protocol/
+git commit -m "$(cat <<'EOF'
+chore(crypto,drops,keylet,protocol): prune non-informative comments
+
+Removes low-value comments (headers, echoes, stale markers) across the
+foundation packages. No rippled references, RFC citations, DER/crypto
+algorithm notes, or canonicality invariants touched.
+EOF
+)"
+```
+
+---
+
+## Task 3: ledger/entry/, shamap/, storage/
+
+Ledger object definitions and state storage. SLE (Serialized Ledger Entry) field comments are often load-bearing — they document on-wire layout and amendment-gated fields.
+
+**Files:** `ledger/entry/**/*.go`, `shamap/**/*.go`, `storage/**/*.go`. Skip `doc.go`, generated files, `testutil/mock_*.go`.
+
+- [ ] **Step 1: W1 — build baseline**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: W2 — enumerate candidates**
+
+```bash
+rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,})' ledger/ shamap/ storage/ --type=go
+rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b' ledger/ shamap/ storage/ --type=go
+rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip)\b[^.]{0,40}$' ledger/ shamap/ storage/ --type=go
+rg -nP '^\s*\w[^=]*=\s*[^/]+//\s*\w+\s*$' ledger/ shamap/ storage/ --type=go
+```
+
+- [ ] **Step 3: W3 — review and prune**
+
+Default-keep on anything referencing SLE fields, amendment gates (e.g., `fixMPT`, `featureClawback`), or `ltXxx` ledger-type codes.
+
+- [ ] **Step 4: W4 — apply edits**
+
+Use `Edit`.
+
+- [ ] **Step 5: W5 — build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 6: W6 — test**
+
+```bash
+go test ./ledger/... ./shamap/... ./storage/...
+```
+Expected: PASS.
+
+- [ ] **Step 7: W7 — format**
+
+```bash
+goimports -l $(git diff --name-only | rg '\.go$')
+```
+Expected: empty.
+
+- [ ] **Step 8: W8 — preservation audit**
+
+```bash
+git diff --unified=0 | rg -i 'reference:|mirrors rippled|matches rippled|see rippled|amendment|invariant|SLE|ledger entry|lt[A-Z][a-z]|fix[A-Z]|feature[A-Z]'
+```
+Expected: empty.
+
+- [ ] **Step 9: W9 — commit**
+
+```bash
+git add -u ledger/ shamap/ storage/
+git commit -m "$(cat <<'EOF'
+chore(ledger,shamap,storage): prune non-informative comments
+
+Removes low-value comments (headers, echoes, stale markers) across
+ledger entries, SHAMap, and storage backends. No rippled references,
+SLE field specs, amendment gates, or invariant notes touched.
+EOF
+)"
+```
+
+---
+
+## Task 4: amendment/, config/
+
+Amendment registry and configuration. Every amendment-name comment is load-bearing by definition of this cleanup — when in doubt, keep.
+
+**Files:** `amendment/**/*.go`, `config/**/*.go`. Skip `doc.go`, generated files.
+
+- [ ] **Step 1: W1 — build baseline**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: W2 — enumerate candidates**
+
+```bash
+rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,})' amendment/ config/ --type=go
+rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b' amendment/ config/ --type=go
+rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip)\b[^.]{0,40}$' amendment/ config/ --type=go
+rg -nP '^\s*\w[^=]*=\s*[^/]+//\s*\w+\s*$' amendment/ config/ --type=go
+```
+
+- [ ] **Step 3: W3 — review and prune**
+
+In `amendment/registry.go` specifically, trailing comments on amendment-constant lines that restate the amendment name *are still load-bearing* (they are the human-readable amendment label). Keep them. Only remove where the comment adds pure noise unrelated to the amendment.
+
+- [ ] **Step 4: W4 — apply edits**
+
+Use `Edit`.
+
+- [ ] **Step 5: W5 — build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 6: W6 — test**
+
+```bash
+go test ./amendment/... ./config/...
+```
+Expected: PASS.
+
+- [ ] **Step 7: W7 — format**
+
+```bash
+goimports -l $(git diff --name-only | rg '\.go$')
+```
+Expected: empty.
+
+- [ ] **Step 8: W8 — preservation audit**
+
+```bash
+git diff --unified=0 | rg -i 'reference:|mirrors rippled|matches rippled|see rippled|amendment|fix[A-Z]|feature[A-Z]'
+```
+Expected: empty.
+
+- [ ] **Step 9: W9 — commit**
+
+```bash
+git add -u amendment/ config/
+git commit -m "$(cat <<'EOF'
+chore(amendment,config): prune non-informative comments
+
+Removes low-value comments (headers, echoes, stale markers). Amendment
+names and their human-readable labels preserved; no rippled references
+or feature-gate notes touched.
+EOF
+)"
+```
+
+---
+
+## Task 5: internal/rpc/
+
+Largest surface area in the tree. Many methods are skeletons with TODO markers — these TODOs are live (they describe real unimplemented work) and must be preserved.
+
+**Files:** `internal/rpc/**/*.go` excluding `*_test.go`. Skip `doc.go`, generated files.
+
+- [ ] **Step 1: W1 — build baseline**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: W2 — enumerate candidates**
+
+```bash
+rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,})' internal/rpc/ --type=go -g '!*_test.go'
+rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b' internal/rpc/ --type=go -g '!*_test.go' | head -100
+rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip)\b[^.]{0,40}$' internal/rpc/ --type=go -g '!*_test.go'
+rg -nP '^\s*\w[^=]*=\s*[^/]+//\s*\w+\s*$' internal/rpc/ --type=go -g '!*_test.go'
+```
+
+- [ ] **Step 3: W3 — review and prune**
+
+TODOs in this package are mostly live ("implement X using Y store"). Default-keep. Remove only TODOs that reference work already done elsewhere (grep the referenced symbol; if it exists and is used, the TODO is stale).
+
+- [ ] **Step 4: W4 — apply edits**
+
+Use `Edit`.
+
+- [ ] **Step 5: W5 — build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 6: W6 — test**
+
+```bash
+go test ./internal/rpc/...
+```
+Expected: PASS.
+
+- [ ] **Step 7: W7 — format**
+
+```bash
+goimports -l $(git diff --name-only | rg '\.go$')
+```
+Expected: empty.
+
+- [ ] **Step 8: W8 — preservation audit**
+
+```bash
+git diff --unified=0 | rg -i 'reference:|mirrors rippled|matches rippled|see rippled|amendment|invariant|TODO'
+```
+Expected: empty. A `TODO` line in the diff's *removed* side must be justified by a verified-done check.
+
+- [ ] **Step 9: W9 — commit**
+
+```bash
+git add -u internal/rpc/
+git commit -m "$(cat <<'EOF'
+chore(rpc): prune non-informative comments
+
+Removes low-value comments (headers, echoes, stale markers) across
+internal/rpc/. Live TODOs describing unimplemented work preserved;
+no rippled references or protocol notes touched.
+EOF
+)"
+```
+
+---
+
+## Task 6: internal/tx/ per-transaction-type subpackages
+
+Twenty-four transaction-type subpackages. Every per-tx preflight/preclaim/apply flow carries load-bearing rippled and invariant references — default to keep.
+
+**Paths (do one sub-group per commit, not all at once):**
+- 6a: `account/`, `amm/`, `batch/`, `check/`
+- 6b: `clawback/`, `credential/`, `delegate/`, `depositpreauth/`
+- 6c: `did/`, `escrow/`, `ledgerstatefix/`, `mpt/`
+- 6d: `nftoken/`, `offer/`, `oracle/`, `paychan/`
+- 6e: `payment/`, `permissioneddomain/`, `pseudo/`, `signerlist/`
+- 6f: `ticket/`, `trustset/`, `vault/`, `xchain/`
+
+For each sub-group (6a through 6f), **run Steps 1–9 end-to-end, producing one commit per sub-group**. Do not batch sub-groups into a single commit. Six commits total for Task 6.
+
+- [ ] **Step 1: W1 — build baseline**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: W2 — enumerate candidates for this sub-group**
+
+Replace `<subpkgs>` with the space-separated paths of the current sub-group (e.g., `internal/tx/account/ internal/tx/amm/ internal/tx/batch/ internal/tx/check/` for 6a):
+
+```bash
+SUBPKGS="<subpkgs>"
+rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,})' $SUBPKGS --type=go -g '!*_test.go'
+rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b' $SUBPKGS --type=go -g '!*_test.go'
+rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip)\b[^.]{0,40}$' $SUBPKGS --type=go -g '!*_test.go'
+rg -nP '^\s*\w[^=]*=\s*[^/]+//\s*\w+\s*$' $SUBPKGS --type=go -g '!*_test.go'
+```
+
+- [ ] **Step 3: W3 — review and prune**
+
+These packages have the densest rippled cross-references in the tree. Every `// Reference:` and every comment near a `Preflight`, `Preclaim`, or `Apply` body is load-bearing by default. Only touch stylistic separators, truly obvious what-comments, and echoes.
+
+- [ ] **Step 4: W4 — apply edits**
+
+Use `Edit`.
+
+- [ ] **Step 5: W5 — build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 6: W6 — test**
+
+```bash
+go test $(echo $SUBPKGS | sed 's#\([^ ]*\)#./\1...#g')
+```
+Replace `$SUBPKGS` with the literal sub-group path list if the shell does not expand it. Expected: PASS.
+
+- [ ] **Step 7: W7 — format**
+
+```bash
+goimports -l $(git diff --name-only | rg '\.go$')
+```
+Expected: empty.
+
+- [ ] **Step 8: W8 — preservation audit**
+
+```bash
+git diff --unified=0 | rg -i 'reference:|mirrors rippled|matches rippled|see rippled|amendment|invariant|preflight|preclaim|TER|fix[A-Z]|feature[A-Z]'
+```
+Expected: empty.
+
+- [ ] **Step 9: W9 — commit**
+
+```bash
+git add -u internal/tx/
+git commit -m "$(cat <<'EOF'
+chore(tx/<sub-group-label>): prune non-informative comments
+
+Removes low-value comments across <listed sub-packages>. No rippled
+references, amendment gates, invariant notes, preflight/preclaim
+commentary, or TER code references touched.
+EOF
+)"
+```
+
+Replace `<sub-group-label>` with e.g. `account,amm,batch,check` and list the sub-packages explicitly. Six commits total for Task 6.
+
+---
+
+## Task 7: internal/tx/ top-level files
+
+The highest-risk files in the tree. `engine.go` is 2,471 lines and heavy on invariants; `apply_state_table.go` is the ledger-state mutator; `signature.go` is signing/DER. Default to preserve — this task is expected to remove the fewest comments per line of code.
+
+**Files:** `internal/tx/*.go` (non-`_test.go`, non-`doc.go`). This includes: `apply_context.go`, `apply_state_table.go`, `asset.go`, `block_processor.go`, `engine.go`, `field_metadata.go`, `flags.go`, `flatten.go`, `invariants_adapter.go`, `owner_count.go`, `parse.go`, `registry.go`, `result.go`, `serialize.go`, `signature.go`, `threading.go`, `transaction.go`, `types.go`, `utils.go`, `validate.go`.
+
+- [ ] **Step 1: W1 — build baseline**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: W2 — enumerate candidates**
+
+```bash
+rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,})' internal/tx/*.go
+rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b' internal/tx/*.go
+rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip)\b[^.]{0,40}$' internal/tx/*.go
+rg -nP '^\s*\w[^=]*=\s*[^/]+//\s*\w+\s*$' internal/tx/*.go
+```
+
+- [ ] **Step 3: W3 — review and prune — extra caution**
+
+`engine.go`, `apply_state_table.go`, and `signature.go`: read every candidate in context (`Read` with a ±10-line window). These files interleave protocol-critical invariants with non-obvious invariants unique to the Go port. When in doubt, keep.
+
+Candidates most likely to be legitimate removals here:
+- Pure separator lines (`// ====`) at section boundaries.
+- `types.go` const echoes (e.g., `TypePayment Type = 0 // ttPAYMENT` style).
+
+- [ ] **Step 4: W4 — apply edits**
+
+Use `Edit`. One file at a time, in the order `types.go` → `flags.go` → `result.go` → `utils.go` → remaining files (lowest risk first).
+
+- [ ] **Step 5: W5 — build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 6: W6 — test**
+
+```bash
+go test ./internal/tx/... ./internal/testing/...
+```
+Expected: PASS. This pulls in conformance/invariants tests that exercise `engine.go` and `apply_state_table.go`.
+
+- [ ] **Step 7: W7 — format**
+
+```bash
+goimports -l $(git diff --name-only | rg '\.go$')
+```
+Expected: empty.
+
+- [ ] **Step 8: W8 — preservation audit**
+
+```bash
+git diff --unified=0 | rg -i 'reference:|mirrors rippled|matches rippled|see rippled|amendment|invariant|preflight|preclaim|TER|DER|canonical|fix[A-Z]|feature[A-Z]'
+```
+Expected: empty.
+
+- [ ] **Step 9: W9 — commit**
+
+```bash
+git add -u internal/tx/
+git commit -m "$(cat <<'EOF'
+chore(tx): prune non-informative comments at tx package top level
+
+Removes low-value comments (headers, echoes, stale markers) from
+engine.go, apply_state_table.go, signature.go, types.go and other
+top-level tx files. No rippled references, invariants, amendment
+gates, or DER/canonicality notes touched.
+EOF
+)"
+```
+
+---
+
+## Task 8: internal/consensus/, internal/txq/
+
+Consensus protocol (csf/, rcl/) and transaction queue. Consensus commentary frequently cites the XRPL whitepaper or rippled's `Consensus.cpp` — preserve these by default.
+
+**Files:** `internal/consensus/**/*.go`, `internal/txq/**/*.go`, non-test, non-`doc.go`.
+
+- [ ] **Step 1: W1 — build baseline**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: W2 — enumerate candidates**
+
+```bash
+rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,})' internal/consensus/ internal/txq/ --type=go -g '!*_test.go'
+rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b' internal/consensus/ internal/txq/ --type=go -g '!*_test.go'
+rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip)\b[^.]{0,40}$' internal/consensus/ internal/txq/ --type=go -g '!*_test.go'
+rg -nP '^\s*\w[^=]*=\s*[^/]+//\s*\w+\s*$' internal/consensus/ internal/txq/ --type=go -g '!*_test.go'
+```
+
+- [ ] **Step 3: W3 — review and prune**
+
+Preserve anything referencing the consensus protocol, Byzantine/quorum/UNL/manifest terminology, or a `Consensus.cpp`/`RCLConsensus.cpp` reference.
+
+- [ ] **Step 4: W4 — apply edits**
+
+Use `Edit`.
+
+- [ ] **Step 5: W5 — build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 6: W6 — test**
+
+```bash
+go test ./internal/consensus/... ./internal/txq/...
+```
+Expected: PASS.
+
+- [ ] **Step 7: W7 — format**
+
+```bash
+goimports -l $(git diff --name-only | rg '\.go$')
+```
+Expected: empty.
+
+- [ ] **Step 8: W8 — preservation audit**
+
+```bash
+git diff --unified=0 | rg -i 'reference:|mirrors rippled|matches rippled|see rippled|amendment|invariant|consensus|quorum|UNL|validator|manifest'
+```
+Expected: empty.
+
+- [ ] **Step 9: W9 — commit**
+
+```bash
+git add -u internal/consensus/ internal/txq/
+git commit -m "$(cat <<'EOF'
+chore(consensus,txq): prune non-informative comments
+
+Removes low-value comments (headers, echoes, stale markers) from
+consensus and txq. Consensus-protocol terminology, validator/UNL
+references, and rippled cross-references preserved.
+EOF
+)"
+```
+
+---
+
+## Task 9: internal/testing/ (test framework and helpers)
+
+Test framework, assertions, env, conformance runner, and per-feature test suites. These files are production code for the test framework and ad-hoc comments for individual tests.
+
+**Files:** `internal/testing/**/*.go` (both test and non-test files in this tree). Skip `doc.go`, generated files.
+
+- [ ] **Step 1: W1 — build baseline**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: W2 — enumerate candidates**
+
+```bash
+rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,})' internal/testing/ --type=go
+rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b' internal/testing/ --type=go
+rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip|Verify|Assert|Expect)\b[^.]{0,40}$' internal/testing/ --type=go
+rg -nP '^\s*\w[^=]*=\s*[^/]+//\s*\w+\s*$' internal/testing/ --type=go
+```
+
+- [ ] **Step 3: W3 — review and prune**
+
+Test cases occasionally have `// This tests the scenario where …` comments describing the test intent — those are valuable and not candidates. Candidates here are headers inside long test files and echoes like `setUp := …  // setup`.
+
+- [ ] **Step 4: W4 — apply edits**
+
+Use `Edit`.
+
+- [ ] **Step 5: W5 — build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 6: W6 — test**
+
+```bash
+go test ./internal/testing/...
+```
+Expected: PASS.
+
+- [ ] **Step 7: W7 — format**
+
+```bash
+goimports -l $(git diff --name-only | rg '\.go$')
+```
+Expected: empty.
+
+- [ ] **Step 8: W8 — preservation audit**
+
+```bash
+git diff --unified=0 | rg -i 'reference:|mirrors rippled|matches rippled|see rippled|amendment|invariant|scenario|regression'
+```
+Expected: empty.
+
+- [ ] **Step 9: W9 — commit**
+
+```bash
+git add -u internal/testing/
+git commit -m "$(cat <<'EOF'
+chore(testing): prune non-informative comments
+
+Removes low-value comments (headers, echoes, stale markers) from the
+test framework and per-feature test suites. Scenario/regression-intent
+comments preserved; no rippled references or invariant notes touched.
+EOF
+)"
+```
+
+---
+
+## Task 10: `*_test.go` sweep for anything not yet covered
+
+Any `*_test.go` files outside the packages already swept (in particular top-level tests that live alongside production code, e.g., `internal/tx/*_test.go`, `crypto/*_test.go`).
+
+**Files:** all remaining `*_test.go` files. Enumerate explicitly in Step 2 so nothing is double-committed.
+
+- [ ] **Step 1: W1 — build baseline**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: W2 — enumerate remaining test files**
+
+```bash
+git ls-files '*_test.go' > /tmp/all-tests.txt
+git log --name-only --pretty=format: | rg '_test\.go$' | sort -u > /tmp/touched-tests.txt
+comm -23 <(sort -u /tmp/all-tests.txt) /tmp/touched-tests.txt > /tmp/remaining-tests.txt
+wc -l /tmp/remaining-tests.txt
+```
+
+(The intent is a list of `*_test.go` files under `goXRPL/` that have not yet been modified by an earlier task in this plan. If the shell does not produce a usable list, enumerate manually: for each directory not listed in Tasks 1–9, `find <dir> -name '*_test.go'`.)
+
+Then run the category greps limited to the files in `/tmp/remaining-tests.txt`:
+
+```bash
+xargs -a /tmp/remaining-tests.txt rg -nP '^\s*//\s*(={3,}|-{3,}|\*{3,})'
+xargs -a /tmp/remaining-tests.txt rg -nP '^\s*//\s*(TODO|FIXME|XXX)\b'
+xargs -a /tmp/remaining-tests.txt rg -nP '^\s*//\s*(Return|Returns|Loop|Iterate|Increment|Decrement|Set|Get|Check|Call|Create|Initialize|Add|Remove|Delete|Update|Print|Log|Skip|Verify|Assert|Expect)\b[^.]{0,40}$'
+```
+
+- [ ] **Step 3: W3 — review and prune**
+
+Scenario-intent comments stay. Otherwise apply the standard rules.
+
+- [ ] **Step 4: W4 — apply edits**
+
+Use `Edit`. If the remaining list spans many directories, split into per-directory commits.
+
+- [ ] **Step 5: W5 — build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 6: W6 — test**
+
+```bash
+go test ./...
+```
+Expected: PASS (modulo baseline known-fails).
+
+- [ ] **Step 7: W7 — format**
+
+```bash
+goimports -l $(git diff --name-only | rg '\.go$')
+```
+Expected: empty.
+
+- [ ] **Step 8: W8 — preservation audit**
+
+```bash
+git diff --unified=0 | rg -i 'reference:|mirrors rippled|matches rippled|see rippled|amendment|invariant|scenario|regression'
+```
+Expected: empty.
+
+- [ ] **Step 9: W9 — commit**
+
+```bash
+git add -u
+git commit -m "$(cat <<'EOF'
+chore(tests): prune non-informative comments in remaining test files
+
+Tree-wide *_test.go sweep for files not covered by earlier commits.
+Scenario/regression-intent comments preserved.
+EOF
+)"
+```
+
+---
+
+## Task 11: Final verification
+
+After all package-group commits land, verify the tree is healthy end-to-end and run the conformance summary to confirm no regression in protocol conformance.
+
+- [ ] **Step 1: Full build**
+
+```bash
+go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 2: Full test**
+
+```bash
+go test ./...
+```
+Expected: PASS (modulo the baseline known-fails from Task 0 Step 3).
+
+- [ ] **Step 3: Conformance summary**
+
+```bash
+./scripts/conformance-summary.sh
+```
+Expected: pass/fail counts match baseline. If any previously-passing suite now fails, the likely cause is a comment removal that accidentally took a code line with it (or the `Edit` tool matched an unexpected string). `git bisect` against the 10 commits to localize.
+
+- [ ] **Step 4: Count the damage**
+
+```bash
+FIRST=$(git log --grep='prune non-informative' --reverse --pretty=format:'%H' | head -1)
+git log --grep='prune non-informative' --pretty=format:'%h %s'
+git diff --stat ${FIRST}^..HEAD -- '*.go'
+```
+
+Report total lines removed, files touched, commit count. Add this as the final line of the plan's review section (below).
+
+- [ ] **Step 5: Final audit across all commits**
+
+```bash
+FIRST=$(git log --grep='prune non-informative' --reverse --pretty=format:'%H' | head -1)
+git log ${FIRST}^..HEAD --grep='prune non-informative' --patch | rg -i 'reference:|mirrors rippled|matches rippled|see rippled'
+```
+Expected: empty. Any hit here means a preserved comment slipped through and needs restoration.
+
+---
+
+## Review
+
+Leave this section blank until Task 11 completes, then append:
+
+- Total commits: _
+- Total lines removed: _
+- Files touched: _
+- Packages affected: _
+- Preservation audit final check: PASS / FAIL
+
+If any commit needed to be reverted, list it and the reason.

--- a/docs/superpowers/specs/2026-04-24-comment-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-24-comment-cleanup-design.md
@@ -1,0 +1,113 @@
+# Comment Cleanup — Design
+
+**Date:** 2026-04-24
+**Scope:** `goXRPL/` tree only. `rippled/` is read-only reference and is not touched.
+
+## Problem
+
+The codebase has accumulated low-value comments — godoc that restates the identifier, trailing comments on consts that echo the name, inline what-comments that narrate the next line, stylistic section separators, and commented-out code. A subset of TODOs point at work that is already done. These add visual weight without improving comprehension and, in places, make the comment-to-code ratio hide the actual load-bearing commentary.
+
+At the same time, the codebase has a large volume of genuinely load-bearing commentary — `// Reference: rippled …` cross-references in ~1,700+ files, amendment-gate explanations, invariant-check notes, and crypto/DER alignment notes. These are critical because the project treats rippled as the protocol source of truth (per `CLAUDE.md`). The cleanup must be subtractive, targeted, and conservative around these categories.
+
+## Goals
+
+- Remove the five categories of low-value comments defined below.
+- Preserve every comment that helps a reader validate Go behavior against the rippled C++ reference or against XRPL protocol invariants.
+- Ship in small per-package commits so any regression (a removed comment turning out to be load-bearing) is cheap to revert.
+
+## Non-goals
+
+- No reformatting, reordering, or refactoring of code.
+- No adding new comments — this is a subtraction-only pass.
+- No changes to `rippled/`, `docs/`, `scripts/`, or `tasks/`.
+- No mass rewriting of borderline godoc — if a godoc is 50% useful, it stays.
+- No style unification of surviving comments (no capitalization/punctuation normalization).
+
+## Removable categories
+
+1. **Godoc restatements** — godoc above an exported symbol that only echoes the identifier (`// Foo does foo` above `func Foo()`). Kept when it documents parameters, return values, error conditions, side effects, or non-obvious semantics.
+2. **Const/enum echoes** — trailing comments that only repeat the const name in a different case (e.g., `TypePayment Type = 0 // ttPAYMENT`). Dropped when the comment adds no information beyond the identifier.
+3. **Obvious inline what-comments** — `// Return the result` above `return result`, `// Loop over X` above `for _, x := range X`, `// Increment counter` above `counter++`. Dropped.
+4. **Section headers and separators** — `// ===== Foo =====`, `// ---- helpers ----`, long dashed dividers. Dropped. Go's package and function structure is the boundary.
+5. **Stale TODOs and commented-out code** — TODOs verified done (grep the referenced feature/symbol) or pointing at no actionable work; commented-out function bodies or blocks. Dropped. Live TODOs pointing at real gaps are kept.
+
+## Hard preservation list (never touched)
+
+- `// Reference: rippled …` and any variant (`// Mirrors rippled's …`, `// Matches rippled …`, `// See rippled/src/…`).
+- Amendment-gate comments — anything mentioning an amendment name or `fix*` / `feature*` flag.
+- Invariant-check, preflight, and preclaim explanation comments.
+- Crypto / DER / signature algorithm alignment notes.
+- Struct-tag and serialization format specs.
+- Package-level `doc.go` files — entire files skipped.
+- Generated files — any file containing `// Code generated …  DO NOT EDIT.` (includes `mock_*.go`).
+- `rippled/` directory.
+- Live TODOs pointing at real gaps.
+
+**Heuristic for "is this load-bearing?":** if removing the comment would make a protocol-compliance mistake harder to catch, keep it.
+
+## Execution workflow
+
+Pattern-based detection per package, followed by human review, applied via the `Edit` tool, gated by build and tests, committed per package group.
+
+### Package order
+
+Low-risk leaf packages first, core consensus/tx last:
+
+1. `codec/` (addresscodec, binarycodec)
+2. `crypto/` + `drops/` + `keylet/` + `protocol/`
+3. `ledger/entry/` + `shamap/` + `storage/`
+4. `amendment/` + `config/`
+5. `internal/rpc/`
+6. `internal/tx/` subpackages (per tx type: payment, offer, escrow, amm, …)
+7. `internal/tx/engine.go` + `apply_state_table.go` + `signature.go` (highest-risk, last of production)
+8. `internal/consensus/` + `internal/txq/`
+9. `internal/testing/` (test helpers)
+10. `*_test.go` files across the tree (pattern pass)
+
+### Per-package-group loop
+
+1. Run category-specific greps to produce a candidate list.
+2. Review candidates. Drop from the candidate list anything that:
+   - is on the hard preservation list, or
+   - references rippled, an amendment, an invariant, a TER code, or a protocol constant, or
+   - documents a non-obvious constraint that the identifier alone does not convey.
+3. Apply edits.
+4. `go build ./...` from repo root.
+5. `go test ./<package>/...` for the touched group.
+6. `goimports -l` on modified files must be clean.
+7. Commit with message `chore(<pkg>): prune non-informative comments`.
+
+## Verification gates
+
+Every commit must satisfy all of:
+
+- `go build ./...` clean.
+- `go test ./<package>/...` passes for the touched group.
+- `goimports -l` clean on modified files.
+- No edits to files on the hard-preservation list (grep check before commit).
+- No `// Reference:` comments removed (grep `git diff` for the pattern — must be empty).
+
+If any gate fails: stop, investigate, fix or revert that file. Do not skip gates.
+
+## Rollback plan
+
+Per-package commits enable per-package reverts. If a downstream reader later flags a removed comment as load-bearing, `git revert <commit>` on just that package restores it without undoing other groups.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| A removed comment was actually load-bearing context for rippled alignment. | Hard-preserve `// Reference:` and amendment comments; per-package commits allow targeted revert. |
+| Pattern matching sweeps a comment that is ambiguous. | Every candidate is reviewed before edit; borderline cases stay. |
+| Build or test regression from an accidental code edit. | Per-commit `go build` and `go test` gates. |
+| Godoc of an exported symbol removed, breaking docs consumers. | Only restatement-style godoc (echoing the identifier) is eligible; substantive godoc stays. |
+| Inconsistent judgment across packages during a long pass. | Written rules above; package groups are small enough that one reviewer holds the rules in context for each commit. |
+
+## Out of scope for this spec
+
+Future passes that could follow, but are explicitly not part of this work:
+
+- Rewriting or normalizing surviving godoc to a consistent style.
+- Upgrading `// Reference:` comments to include line numbers or permalink to a specific rippled commit.
+- Pruning `rippled/` — read-only, never touched.
+- Documentation rewrites under `docs/`.

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -559,7 +559,6 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) {
 		return
 	}
 
-	// Add to the adaptor's pending transaction pool
 	r.adaptor.AddPendingTx(blob)
 }
 

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -127,10 +127,8 @@ func NewFromConfig(
 		return nil, fmt.Errorf("parse validators: %w", err)
 	}
 
-	// Create the sender wrapping the overlay
 	sender := NewOverlaySender(overlay)
 
-	// Create the adaptor
 	adaptor := New(Config{
 		LedgerService: ledgerSvc,
 		Sender:        sender,
@@ -138,7 +136,6 @@ func NewFromConfig(
 		Validators:    validators,
 	})
 
-	// Create mode manager
 	modeManager := NewModeManager(adaptor)
 
 	// Validator manifest cache. Shared across the engine (for
@@ -149,7 +146,6 @@ func NewFromConfig(
 	// as itself.
 	manifestCache := manifest.NewCache()
 
-	// Create the RCL consensus engine
 	engine := rcl.NewEngine(adaptor, rcl.DefaultConfig())
 
 	// Translate ephemeral signing keys → master keys before quorum
@@ -159,7 +155,6 @@ func NewFromConfig(
 		return consensus.NodeID(manifestCache.GetMasterKey([33]byte(nid)))
 	})
 
-	// Create the router
 	router := NewRouter(engine, adaptor, modeManager, overlay.Messages())
 	router.SetManifestCache(manifestCache, overlay)
 

--- a/internal/consensus/adaptor/txpool.go
+++ b/internal/consensus/adaptor/txpool.go
@@ -52,10 +52,7 @@ func (p *TxPool) Add(blob []byte) bool {
 		return false
 	}
 
-	// Add to pending
 	p.pending[txID] = blob
-
-	// Add to recently seen
 	p.addRecentLocked(txID)
 
 	return true

--- a/internal/peermanagement/discovery_test.go
+++ b/internal/peermanagement/discovery_test.go
@@ -216,8 +216,6 @@ func TestDiscoveryBootstrapPeers(t *testing.T) {
 	d.Stop()
 }
 
-// ============== Slot Tests ==============
-
 func TestNewInboundSlot(t *testing.T) {
 	localAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 51235}
 	remoteAddr := &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 51235}
@@ -307,8 +305,6 @@ func TestSlotStateString(t *testing.T) {
 	}
 }
 
-// ============== Recent Endpoints Tests ==============
-
 func TestRecentEndpoints(t *testing.T) {
 	recent := NewRecentEndpoints()
 
@@ -357,8 +353,6 @@ func TestRecentEndpointsExpire(t *testing.T) {
 		t.Error("Expired endpoint should be removed")
 	}
 }
-
-// ============== Boot Cache Tests ==============
 
 func TestBootCache(t *testing.T) {
 	// Use temp directory for test
@@ -429,7 +423,6 @@ func TestBootCacheGetEndpointsSorted(t *testing.T) {
 	}
 }
 
-// ============== PeerFinder Backoff Tests ==============
 // Reference: rippled src/test/peerfinder/PeerFinder_test.cpp
 
 // TestBackoffValenceDecrease tests that repeated failures decrease valence

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -516,8 +516,6 @@ func TestCrawlHeader(t *testing.T) {
 	assert.Equal(t, "public", publicReq.Header.Get(HeaderCrawl))
 }
 
-// ============== Feature Tests ==============
-
 // TestFeatureString tests the Feature String method
 func TestFeatureString(t *testing.T) {
 	tests := []struct {
@@ -622,7 +620,6 @@ func TestPeerCapabilities(t *testing.T) {
 	assert.True(t, pc.SupportsReduceRelay())
 }
 
-// ============== X-Protocol-Ctl Header Tests ==============
 // Reference: rippled src/test/overlay/handshake_test.cpp
 
 // TestXProtocolCtlParsing tests X-Protocol-Ctl header parsing

--- a/internal/peermanagement/identity_test.go
+++ b/internal/peermanagement/identity_test.go
@@ -245,8 +245,6 @@ func TestIdentityRoundTrip(t *testing.T) {
 	assert.True(t, parsedSig.Verify(hash, restored.BtcecPublicKey()))
 }
 
-// ============== PublicKeyToken Tests (from token/) ==============
-
 // Test vectors from rippled PublicKey_test.cpp testBase58
 var base58TestVectors = []struct {
 	name      string

--- a/internal/peermanagement/message/compression_test.go
+++ b/internal/peermanagement/message/compression_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ============== Compression Roundtrip Tests ==============
 // Reference: rippled src/test/overlay/compression_test.cpp
 
 // Compression constants (matching rippled)
@@ -217,8 +216,6 @@ func sha512Half(data []byte) []byte {
 	h := sha512.Sum512(data)
 	return h[:32]
 }
-
-// ============== Test Cases ==============
 
 // TestCompressionRoundtrip_Manifests tests manifest compression roundtrip
 // Reference: rippled compression_test.cpp - testManifests()

--- a/internal/peermanagement/metrics_test.go
+++ b/internal/peermanagement/metrics_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 )
 
-// ============== Traffic Counter Tests ==============
-
 func TestTrafficCounterBasic(t *testing.T) {
 	tc := NewTrafficCounter()
 
@@ -118,8 +116,6 @@ func TestTrafficCounterTotalStats(t *testing.T) {
 		t.Errorf("Expected total MessagesIn 2, got %d", total.MessagesIn)
 	}
 }
-
-// ============== Peer Score Tests ==============
 
 func TestPeerScoreBasic(t *testing.T) {
 	ps := NewPeerScore()

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -255,7 +255,6 @@ func TestAccountChannelsErrorValidation(t *testing.T) {
 			mock.accountChannelsResult = nil
 			mock.accountChannelsErr = nil
 
-			// Setup mock if needed
 			if tc.setupMock != nil {
 				tc.setupMock()
 			}
@@ -268,7 +267,6 @@ func TestAccountChannelsErrorValidation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			// Verify error response

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -274,7 +274,6 @@ func TestAccountCurrenciesBadInput(t *testing.T) {
 			mock.accountCurrenciesResult = nil
 			mock.accountCurrenciesErr = nil
 
-			// Setup mock if needed
 			if tc.setupMock != nil {
 				tc.setupMock()
 			}
@@ -287,7 +286,6 @@ func TestAccountCurrenciesBadInput(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			// Verify error response

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -274,7 +274,6 @@ func TestAccountInfoErrorValidation(t *testing.T) {
 			mock.accountInfo = nil
 			mock.accountInfoErr = nil
 
-			// Setup mock if needed
 			if tc.setupMock != nil {
 				tc.setupMock()
 			}
@@ -287,7 +286,6 @@ func TestAccountInfoErrorValidation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			// Verify error response
@@ -476,7 +474,6 @@ func TestAccountInfoLedgerSpecification(t *testing.T) {
 			paramsJSON, err := json.Marshal(tc.params)
 			require.NoError(t, err)
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			if tc.expectError {

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -286,7 +286,6 @@ func TestAccountLinesErrorValidation(t *testing.T) {
 			mock.accountLinesResult = nil
 			mock.accountLinesErr = nil
 
-			// Setup mock if needed
 			if tc.setupMock != nil {
 				tc.setupMock()
 			}
@@ -299,7 +298,6 @@ func TestAccountLinesErrorValidation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			// Verify error response
@@ -560,7 +558,6 @@ func TestAccountLinesLedgerSpecification(t *testing.T) {
 			paramsJSON, err := json.Marshal(tc.params)
 			require.NoError(t, err)
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			if tc.expectError {
@@ -694,7 +691,6 @@ func TestAccountLinesPeerFilter(t *testing.T) {
 			paramsJSON, err := json.Marshal(tc.params)
 			require.NoError(t, err)
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			if tc.expectError {
@@ -936,7 +932,6 @@ func TestAccountLinesPagination(t *testing.T) {
 			paramsJSON, err := json.Marshal(tc.params)
 			require.NoError(t, err)
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			if tc.expectError {

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -254,7 +254,6 @@ func TestAccountNFTsErrorValidation(t *testing.T) {
 			mock.accountNFTsResult = nil
 			mock.accountNFTsErr = nil
 
-			// Setup mock if needed
 			if tc.setupMock != nil {
 				tc.setupMock()
 			}
@@ -267,7 +266,6 @@ func TestAccountNFTsErrorValidation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			// Verify error response

--- a/internal/rpc/account_objects_test.go
+++ b/internal/rpc/account_objects_test.go
@@ -47,10 +47,8 @@ func setupAccountObjectsTestServices(mock *accountObjectsMock) func() {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Test: Error cases – missing / invalid / malformed account
 // Based on rippled AccountObjects_test.cpp testErrors()
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsErrorValidation(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -193,10 +191,8 @@ func TestAccountObjectsErrorValidation(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Test: Response structure validation
 // Based on rippled AccountObjects_test.cpp – verify the response shape
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsResponseStructure(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -319,10 +315,8 @@ func TestAccountObjectsResponseStructure(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Test: Empty objects for funded account with no owned objects
 // Based on rippled AccountObjects_test.cpp – empty account checks
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsEmptyAccount(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -380,10 +374,8 @@ func TestAccountObjectsEmptyAccount(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Test: Type filtering passes through to service layer
 // Based on rippled AccountObjects_test.cpp testObjectTypes()
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsTypeFiltering(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -458,10 +450,8 @@ func TestAccountObjectsTypeFiltering(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Test: deletion_blockers_only flag
 // Based on rippled AccountObjects_test.cpp testObjectTypes() – deletion_blockers_only
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsDeletionBlockersOnly(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -530,10 +520,8 @@ func TestAccountObjectsDeletionBlockersOnly(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Test: Pagination with limit and marker
 // Based on rippled AccountObjects_test.cpp testUnsteppedThenStepped()
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsPagination(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -676,10 +664,8 @@ func TestAccountObjectsPagination(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Test: Ledger specification
 // Based on rippled's ledger specifier behavior
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsLedgerSpecification(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -776,9 +762,7 @@ func TestAccountObjectsLedgerSpecification(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Test: Service unavailable / nil ledger
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsServiceUnavailable(t *testing.T) {
 	method := &handlers.AccountObjectsMethod{}
@@ -821,9 +805,7 @@ func TestAccountObjectsServiceUnavailable(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Test: Method metadata
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsMethodMetadata(t *testing.T) {
 	method := &handlers.AccountObjectsMethod{}
@@ -841,10 +823,8 @@ func TestAccountObjectsMethodMetadata(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Test: Invalid account types (expanded)
 // Based on rippled AccountObjects_test.cpp testInvalidAccountParam lambda
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsInvalidAccountTypes(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -894,10 +874,8 @@ func TestAccountObjectsInvalidAccountTypes(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Test: Malformed address formats
 // Based on rippled AccountObjects_test.cpp malformed account tests
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsMalformedAddresses(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -958,10 +936,8 @@ func TestAccountObjectsMalformedAddresses(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Test: Service error propagation
 // Based on rippled error semantics for account_objects
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsServiceErrors(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -1016,10 +992,8 @@ func TestAccountObjectsServiceErrors(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Test: Account field returned matches request account
 // Based on rippled – response account should echo the request account
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsAccountEcho(t *testing.T) {
 	mock := newAccountObjectsMock()
@@ -1064,9 +1038,7 @@ func TestAccountObjectsAccountEcho(t *testing.T) {
 		"Response account should echo the request account")
 }
 
-// ---------------------------------------------------------------------------
 // Test: Multiple API versions
-// ---------------------------------------------------------------------------
 
 func TestAccountObjectsApiVersions(t *testing.T) {
 	mock := newAccountObjectsMock()

--- a/internal/rpc/account_offers_test.go
+++ b/internal/rpc/account_offers_test.go
@@ -166,7 +166,6 @@ func TestAccountOffersErrorValidation(t *testing.T) {
 			// Reset mock state
 			mock.getAccountOffersFn = nil
 
-			// Setup mock if needed
 			if tc.setupMock != nil {
 				tc.setupMock()
 			}
@@ -179,7 +178,6 @@ func TestAccountOffersErrorValidation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			// Verify error response

--- a/internal/rpc/account_tx_test.go
+++ b/internal/rpc/account_tx_test.go
@@ -43,10 +43,8 @@ func setupTestServicesAccountTx(mock *accountTxMock) func() {
 	}
 }
 
-// =============================================================================
 // Error Validation Tests
 // Based on rippled AccountTx_test.cpp testParameters()
-// =============================================================================
 
 // TestAccountTxErrorValidation tests error handling for invalid inputs
 func TestAccountTxErrorValidation(t *testing.T) {
@@ -187,10 +185,8 @@ func TestAccountTxErrorValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Ledger Index Min/Max Handling Tests
 // Based on rippled AccountTx_test.cpp testParameters() ledger_index_min/max sections
-// =============================================================================
 
 func TestAccountTxLedgerIndexMinMax(t *testing.T) {
 	mock := newAccountTxMock()
@@ -306,10 +302,8 @@ func TestAccountTxLedgerIndexMinMax(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Binary vs JSON Mode Tests
 // Based on rippled AccountTx_test.cpp binary parameter
-// =============================================================================
 
 func TestAccountTxBinaryMode(t *testing.T) {
 	mock := newAccountTxMock()
@@ -446,10 +440,8 @@ func TestAccountTxBinaryMode(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Forward / Reverse Ordering Tests
 // Based on rippled AccountTx_test.cpp forward parameter
-// =============================================================================
 
 func TestAccountTxForwardReverse(t *testing.T) {
 	mock := newAccountTxMock()
@@ -539,10 +531,8 @@ func TestAccountTxForwardReverse(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Marker-Based Pagination Tests
 // Based on rippled AccountTx_test.cpp marker handling
-// =============================================================================
 
 func TestAccountTxMarkerPagination(t *testing.T) {
 	mock := newAccountTxMock()
@@ -638,10 +628,8 @@ func TestAccountTxMarkerPagination(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Response Structure Tests
 // Based on rippled AccountTx_test.cpp - validates response fields
-// =============================================================================
 
 func TestAccountTxResponseStructure(t *testing.T) {
 	mock := newAccountTxMock()
@@ -775,9 +763,7 @@ func TestAccountTxResponseStructure(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Empty Account (No Transactions) Tests
-// =============================================================================
 
 func TestAccountTxEmptyAccount(t *testing.T) {
 	mock := newAccountTxMock()
@@ -825,9 +811,7 @@ func TestAccountTxEmptyAccount(t *testing.T) {
 	assert.Equal(t, true, resp["validated"])
 }
 
-// =============================================================================
 // Multiple Transactions with Correct Hash Formatting Tests
-// =============================================================================
 
 func TestAccountTxMultipleTransactions(t *testing.T) {
 	mock := newAccountTxMock()
@@ -963,9 +947,7 @@ func TestAccountTxMultipleTransactions(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Service Unavailable / Nil Ledger Tests
-// =============================================================================
 
 func TestAccountTxServiceUnavailable(t *testing.T) {
 	method := &handlers.AccountTxMethod{}
@@ -1008,9 +990,7 @@ func TestAccountTxServiceUnavailable(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Transaction History Not Available Tests
-// =============================================================================
 
 func TestAccountTxTransactionHistoryNotAvailable(t *testing.T) {
 	mock := newAccountTxMock()
@@ -1042,9 +1022,7 @@ func TestAccountTxTransactionHistoryNotAvailable(t *testing.T) {
 	assert.Contains(t, rpcErr.Message, "Transaction history not available")
 }
 
-// =============================================================================
 // Method Metadata Tests
-// =============================================================================
 
 func TestAccountTxMethodMetadata(t *testing.T) {
 	method := &handlers.AccountTxMethod{}
@@ -1062,9 +1040,7 @@ func TestAccountTxMethodMetadata(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Limit Parameter Tests
-// =============================================================================
 
 func TestAccountTxLimitParameter(t *testing.T) {
 	mock := newAccountTxMock()
@@ -1137,9 +1113,7 @@ func TestAccountTxLimitParameter(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // InjectDeliveredAmount Tests
-// =============================================================================
 
 func TestAccountTxInjectDeliveredAmount(t *testing.T) {
 	// Test the InjectDeliveredAmount function directly via exported function name
@@ -1216,9 +1190,7 @@ func TestAccountTxInjectDeliveredAmount(t *testing.T) {
 	assert.Equal(t, expectedHash, tx0["hash"])
 }
 
-// =============================================================================
 // Service Error Propagation Tests
-// =============================================================================
 
 func TestAccountTxServiceErrors(t *testing.T) {
 	mock := newAccountTxMock()
@@ -1288,10 +1260,8 @@ func TestAccountTxServiceErrors(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Validated Field Tests
 // Based on rippled AccountTx_test.cpp - validated flag in each transaction
-// =============================================================================
 
 func TestAccountTxValidatedField(t *testing.T) {
 	mock := newAccountTxMock()
@@ -1352,9 +1322,7 @@ func TestAccountTxValidatedField(t *testing.T) {
 		"Each transaction entry should have validated=true")
 }
 
-// =============================================================================
 // Account parameter passed to service correctly
-// =============================================================================
 
 func TestAccountTxAccountPassedToService(t *testing.T) {
 	mock := newAccountTxMock()

--- a/internal/rpc/admin_role_test.go
+++ b/internal/rpc/admin_role_test.go
@@ -122,9 +122,7 @@ func allUserMethods() []userMethodEntry {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Tests
-// ---------------------------------------------------------------------------
 
 // TestAdminMethodsRequireAdminRole iterates over every handler that should
 // declare RoleAdmin and asserts that RequiredRole() returns RoleAdmin.

--- a/internal/rpc/amendment_blocked_test.go
+++ b/internal/rpc/amendment_blocked_test.go
@@ -10,14 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Amendment Blocked Conformance Tests
 // Reference: rippled/src/test/rpc/AmendmentBlocked_test.cpp
 //
 // When the server is amendment-blocked, methods with any Condition other than
 // NoCondition are blocked with rpcAMENDMENT_BLOCKED (code 40).
 // Methods with NoCondition continue to work normally.
-// =============================================================================
 
 // blockedMethods are methods that require a condition (NEEDS_CURRENT_LEDGER,
 // NEEDS_CLOSED_LEDGER, or NEEDS_NETWORK_CONNECTION) and should be blocked.

--- a/internal/rpc/api_version_test.go
+++ b/internal/rpc/api_version_test.go
@@ -117,7 +117,6 @@ func allHandlers() map[string]types.MethodHandler {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Test 1: TestApiVersionConstants
 // Verify the API version constants are reasonable and match rippled's ranges.
 //
@@ -128,7 +127,6 @@ func allHandlers() map[string]types.MethodHandler {
 //   apiVersionIfUnspecified     = 1
 //
 // goXRPL mirrors these as ApiVersion1..ApiVersion3 plus DefaultApiVersion.
-// ---------------------------------------------------------------------------
 
 func TestApiVersionConstants(t *testing.T) {
 	// Verify the symbolic constants have their expected numeric values.
@@ -186,10 +184,8 @@ func TestApiVersionConstants(t *testing.T) {
 		"version.good should match ApiVersion2")
 }
 
-// ---------------------------------------------------------------------------
 // Test 2: TestApiVersionAllMethodsDeclareVersions
 // Every handler must declare at least one supported API version.
-// ---------------------------------------------------------------------------
 
 func TestApiVersionAllMethodsDeclareVersions(t *testing.T) {
 	for name, handler := range allHandlers() {
@@ -201,12 +197,10 @@ func TestApiVersionAllMethodsDeclareVersions(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Test 3: TestApiVersionAllMethodsSupportV1
 // API version 1 is the base version.  All methods must support it so that
 // callers who do not specify an api_version (defaulting to 1) can reach
 // every endpoint.
-// ---------------------------------------------------------------------------
 
 func TestApiVersionAllMethodsSupportV1(t *testing.T) {
 	for name, handler := range allHandlers() {
@@ -218,13 +212,11 @@ func TestApiVersionAllMethodsSupportV1(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Test 4: TestApiVersionMethodsWorkWithEachVersion
 // For key methods (account_info, tx, ledger, server_info, ping), call
 // Handle() with each supported API version and verify no version-related
 // error is returned.  We set up a mock so the handlers have enough context
 // to proceed past the initial dispatch.
-// ---------------------------------------------------------------------------
 
 func TestApiVersionMethodsWorkWithEachVersion(t *testing.T) {
 	mock := newMockLedgerService()
@@ -300,12 +292,10 @@ func TestApiVersionMethodsWorkWithEachVersion(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Test 5: TestApiVersionRpcContextCarriesVersion
 // Ensure an RpcContext constructed with a given API version faithfully
 // delivers that version to the handler.  We verify by inspecting the
 // context in a trivial handler (ping).
-// ---------------------------------------------------------------------------
 
 func TestApiVersionRpcContextCarriesVersion(t *testing.T) {
 	apiVersions := []int{types.ApiVersion1, types.ApiVersion2, types.ApiVersion3}
@@ -329,7 +319,6 @@ func TestApiVersionRpcContextCarriesVersion(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Test 6: TestApiVersionDeprecatedMethodRanges
 // Some methods may have restricted API version support. For instance,
 // tx_history is deprecated in rippled v2. This test documents the expected
@@ -339,7 +328,6 @@ func TestApiVersionRpcContextCarriesVersion(t *testing.T) {
 // Currently all goXRPL handlers declare support for all three versions.
 // When a method is deprecated (e.g., tx_history removed from v2+), this
 // test should be updated to verify the tighter range.
-// ---------------------------------------------------------------------------
 
 func TestApiVersionDeprecatedMethodRanges(t *testing.T) {
 	type versionRange struct {

--- a/internal/rpc/book_changes_test.go
+++ b/internal/rpc/book_changes_test.go
@@ -14,9 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Mock helpers for book_changes tests
-// =============================================================================
 
 // mockLedgerReaderBC implements types.LedgerReader for book_changes tests.
 type mockLedgerReaderBC struct {
@@ -118,9 +116,7 @@ func setupTestServicesBC(mock *mockLedgerServiceBC) func() {
 	}
 }
 
-// =============================================================================
 // Tests
-// =============================================================================
 
 // TestBookChangesValidLedgerIndexVariants tests with "validated", "current", and "closed".
 // Based on rippled BookChanges_test.cpp testConventionalLedgerInputStrings.

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -180,9 +180,7 @@ func setupDepositAuthorizedTestServices(mock *mockDepositAuthorizedLedgerService
 	}
 }
 
-// =============================================================================
 // Error Validation Tests
-// =============================================================================
 
 // TestDepositAuthorizedErrorValidation tests error handling for invalid inputs
 // Based on rippled DepositAuthorized_test.cpp testErrors()
@@ -298,9 +296,7 @@ func TestDepositAuthorizedErrorValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Authorization Tests
-// =============================================================================
 
 // TestDepositAuthorizedBasicAuthorized tests when deposit is authorized (no DepositAuth flag)
 // Based on rippled DepositAuthorized_test.cpp testValid()
@@ -514,9 +510,7 @@ func TestDepositAuthorizedReciprocal(t *testing.T) {
 	assert.Equal(t, true, respMap["deposit_authorized"])
 }
 
-// =============================================================================
 // Service Unavailable Tests
-// =============================================================================
 
 // TestDepositAuthorizedServiceUnavailable tests response when ledger service is unavailable
 func TestDepositAuthorizedServiceUnavailable(t *testing.T) {
@@ -547,9 +541,7 @@ func TestDepositAuthorizedServiceUnavailable(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
-// =============================================================================
 // Method Metadata Tests
-// =============================================================================
 
 // TestDepositAuthorizedMethodMetadata tests method metadata (role, API versions)
 func TestDepositAuthorizedMethodMetadata(t *testing.T) {
@@ -567,9 +559,7 @@ func TestDepositAuthorizedMethodMetadata(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Handler-Level Address Validation Tests
-// =============================================================================
 
 // TestDepositAuthorizedAddressValidation tests that handler-level Base58 address
 // validation catches malformed addresses before the service layer is called.
@@ -665,9 +655,7 @@ func TestDepositAuthorizedAddressValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Credential Validation Tests
-// =============================================================================
 
 // TestDepositAuthorizedCredentialValidation tests credential format and duplicate
 // detection at the handler level.

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -238,7 +238,6 @@ func TestGatewayBalancesErrorValidation(t *testing.T) {
 			mock.gatewayBalancesResult = nil
 			mock.gatewayBalancesErr = nil
 
-			// Setup mock if needed
 			if tc.setupMock != nil {
 				tc.setupMock()
 			}
@@ -251,7 +250,6 @@ func TestGatewayBalancesErrorValidation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			// Verify error response

--- a/internal/rpc/handlers/account_currencies.go
+++ b/internal/rpc/handlers/account_currencies.go
@@ -46,7 +46,6 @@ func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawM
 				Message: "Account not found.",
 			}
 		}
-		// Check for malformed account address
 		if len(err.Error()) > 24 && err.Error()[:24] == "invalid account address:" {
 			return nil, &types.RpcError{
 				Code:    types.RpcACT_NOT_FOUND,

--- a/internal/rpc/handlers/account_info.go
+++ b/internal/rpc/handlers/account_info.go
@@ -150,7 +150,6 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// Add index field (SLE key) to account_data
 	if info.Index != "" {
 		accountData["index"] = strings.ToUpper(info.Index)
 	}
@@ -236,7 +235,6 @@ func (m *AccountInfoMethod) loadSignerLists(account string, ledgerIndex string) 
 		if err != nil {
 			continue
 		}
-		// Add the index field
 		decoded["index"] = strings.ToUpper(obj.Index)
 		signerLists = append(signerLists, decoded)
 	}

--- a/internal/rpc/handlers/account_lines.go
+++ b/internal/rpc/handlers/account_lines.go
@@ -43,7 +43,6 @@ func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		ledgerIndex = request.LedgerIndex.String()
 	}
 
-	// Get account lines from the ledger service
 	limit := ClampLimit(request.Limit, LimitAccountLines, ctx.IsAdmin)
 	result, err := types.Services.Ledger.GetAccountLines(request.Account, ledgerIndex, request.Peer, limit)
 	if err != nil {

--- a/internal/rpc/handlers/account_nfts.go
+++ b/internal/rpc/handlers/account_nfts.go
@@ -34,7 +34,6 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		ledgerIndex = request.LedgerIndex.String()
 	}
 
-	// Get account NFTs from the ledger service
 	limit := ClampLimit(request.Limit, LimitAccountNFTokens, ctx.IsAdmin)
 	result, err := types.Services.Ledger.GetAccountNFTs(
 		request.Account,
@@ -48,7 +47,6 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 				Message: "Account not found.",
 			}
 		}
-		// Check for malformed account address
 		if len(err.Error()) > 24 && err.Error()[:24] == "invalid account address:" {
 			return nil, &types.RpcError{
 				Code:    types.RpcACT_NOT_FOUND,

--- a/internal/rpc/handlers/account_offers.go
+++ b/internal/rpc/handlers/account_offers.go
@@ -35,7 +35,6 @@ func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		ledgerIndex = request.LedgerIndex.String()
 	}
 
-	// Get account offers from the ledger service
 	limit := ClampLimit(request.Limit, LimitAccountOffers, ctx.IsAdmin)
 	result, err := types.Services.Ledger.GetAccountOffers(request.Account, ledgerIndex, limit)
 	if err != nil {

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -143,7 +143,6 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		return entry
 	}
 
-	// Get network_id for CTID encoding
 	serverInfo := types.Services.Ledger.GetServerInfo()
 	networkID := serverInfo.NetworkID
 
@@ -199,7 +198,6 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 					txJSON["ledger_index"] = txn.LedgerIndex
 					txJSON["hash"] = txHashHex
 
-					// Add CTID inside tx_json (v2 only)
 					if txn.LedgerIndex > 0 && txn.LedgerIndex < 0x0FFFFFFF {
 						txJSON["ctid"] = encodeCTIDWithNetworkID(txn.LedgerIndex, uint16(txn.TxnSeq), uint16(networkID))
 					}

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -57,7 +57,6 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 			return nil, types.RpcErrorInvalidParams("Invalid amm_account: " + decErr.Error())
 		}
 
-		// Get the account to find its AMMID
 		var accountIDArray [20]byte
 		copy(accountIDArray[:], accountID)
 		accountKey := keylet.Account(accountIDArray)
@@ -105,13 +104,11 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		ammKey = ammKeylet.Key
 	}
 
-	// Get the AMM entry
 	ammEntry, err := types.Services.Ledger.GetLedgerEntry(ammKey, ledgerIndex)
 	if err != nil {
 		return nil, types.RpcErrorActNotFound("AMM not found")
 	}
 
-	// Decode the AMM entry
 	decoded, decodeErr := binarycodec.Decode(hex.EncodeToString(ammEntry.Node))
 	if decodeErr != nil {
 		return nil, types.RpcErrorInternal("Failed to decode AMM: " + decodeErr.Error())

--- a/internal/rpc/handlers/amm_info_test.go
+++ b/internal/rpc/handlers/amm_info_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// =============================================================================
 // rippleEpochToISO8601 Tests
-// =============================================================================
 
 func TestRippleEpochToISO8601_Epoch(t *testing.T) {
 	// Ripple epoch 0 = 2000-01-01T00:00:00 UTC
@@ -31,10 +29,8 @@ func TestRippleEpochToISO8601_RecentTimestamp(t *testing.T) {
 	assert.Contains(t, result, "+0000")
 }
 
-// =============================================================================
 // ammAuctionTimeSlot Tests
 // Based on rippled's ammAuctionTimeSlot() in AMMCore.cpp
-// =============================================================================
 
 func TestAmmAuctionTimeSlot_ActiveSlot(t *testing.T) {
 	// Auction expiration = 86400 + 86400 = 172800 (start = 86400)
@@ -85,9 +81,7 @@ func TestAmmAuctionTimeSlot_ZeroParentCloseTime(t *testing.T) {
 	assert.Equal(t, uint32(auctionSlotTimeIntervals), interval, "Before start should return 20")
 }
 
-// =============================================================================
 // toUint32 Tests
-// =============================================================================
 
 func TestToUint32_Float64(t *testing.T) {
 	assert.Equal(t, uint32(42), toUint32(float64(42)))
@@ -121,9 +115,7 @@ func TestToUint32_Unsupported(t *testing.T) {
 	assert.Equal(t, uint32(0), toUint32(true))
 }
 
-// =============================================================================
 // buildAuctionSlot Tests
-// =============================================================================
 
 func TestBuildAuctionSlot_NoAccount(t *testing.T) {
 	// rippled: only includes auction_slot if Account is present

--- a/internal/rpc/handlers/book_changes.go
+++ b/internal/rpc/handlers/book_changes.go
@@ -102,7 +102,6 @@ func (m *BookChangesMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 			}
 		}
 
-		// Get AffectedNodes from metadata
 		affectedNodes, ok := storedTx.Meta["AffectedNodes"].([]interface{})
 		if !ok {
 			return true
@@ -194,7 +193,6 @@ func (m *BookChangesMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 				pairKey = p + "|" + g
 			}
 
-			// Skip if second is zero
 			if second.Sign() == 0 {
 				continue
 			}
@@ -216,7 +214,6 @@ func (m *BookChangesMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 				currB = g
 			}
 
-			// Update or create change entry
 			bc, exists := changes[pairKey]
 			if !exists {
 				bc = &bookChange{
@@ -231,7 +228,6 @@ func (m *BookChangesMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 				}
 				changes[pairKey] = bc
 			} else {
-				// Update OHLCV
 				if rate.Cmp(bc.High) > 0 {
 					bc.High.Set(rate)
 				}
@@ -341,7 +337,6 @@ func formatBigFloat(f *big.Float) string {
 	if f == nil {
 		return "0"
 	}
-	// Check if it's an integer
 	if f64, _ := f.Float64(); f64 == math.Trunc(f64) && !math.IsInf(f64, 0) {
 		return strconv.FormatInt(int64(f64), 10)
 	}

--- a/internal/rpc/handlers/fee.go
+++ b/internal/rpc/handlers/fee.go
@@ -25,10 +25,7 @@ func (m *FeeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inter
 		return nil, err
 	}
 
-	// Get fee settings from ledger service
 	baseFee, _, _ := types.Services.Ledger.GetCurrentFees()
-
-	// Get current ledger index
 	currentLedgerIndex := types.Services.Ledger.GetCurrentLedgerIndex()
 
 	baseFeeStr := fmt.Sprintf("%d", baseFee)

--- a/internal/rpc/handlers/gateway_balances.go
+++ b/internal/rpc/handlers/gateway_balances.go
@@ -75,14 +75,12 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 				Message: "Account not found.",
 			}
 		}
-		// Check for malformed account address
 		if len(err.Error()) > 24 && err.Error()[:24] == "invalid account address:" {
 			return nil, &types.RpcError{
 				Code:    types.RpcACT_NOT_FOUND,
 				Message: "Account malformed.",
 			}
 		}
-		// Check for invalid hotwallet
 		if len(err.Error()) > 20 && err.Error()[:20] == "invalid hotwallet ad" {
 			if ctx.ApiVersion < 2 {
 				return nil, &types.RpcError{

--- a/internal/rpc/handlers/get_aggregate_price.go
+++ b/internal/rpc/handlers/get_aggregate_price.go
@@ -36,7 +36,6 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		raw = make(map[string]json.RawMessage)
 	}
 
-	// --- oracles validation ---
 	// rippled: !params.isMember(jss::oracles) -> missing_field_error
 	oraclesRaw, hasOracles := raw["oracles"]
 	if !hasOracles {
@@ -53,20 +52,17 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorOracleMalformed()
 	}
 
-	// --- base_asset validation ---
 	// rippled: !params.isMember(jss::base_asset) -> missing_field_error
 	baseAssetRaw, hasBaseAsset := raw["base_asset"]
 	if !hasBaseAsset {
 		return nil, types.RpcErrorMissingField("base_asset")
 	}
-	// --- quote_asset validation ---
 	// rippled: !params.isMember(jss::quote_asset) -> missing_field_error
 	quoteAssetRaw, hasQuoteAsset := raw["quote_asset"]
 	if !hasQuoteAsset {
 		return nil, types.RpcErrorMissingField("quote_asset")
 	}
 
-	// --- trim validation ---
 	// rippled: if present, must be valid uint; then if present, must be 1..25
 	const maxTrim = 25
 	var trimValue uint32
@@ -83,7 +79,6 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		}
 	}
 
-	// --- time_threshold validation ---
 	// rippled: if present, must be valid uint
 	var timeThreshold uint32
 	if ttRaw, ok := raw["time_threshold"]; ok {
@@ -94,7 +89,6 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		timeThreshold = v
 	}
 
-	// --- base_asset / quote_asset currency validation ---
 	// rippled: empty or invalid currency -> rpcINVALID_PARAMS
 	baseAsset, err := parseCurrencyParam(baseAssetRaw)
 	if err != nil {
@@ -170,23 +164,17 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		}
 
-		// Get oracle keylet
 		oracleKeylet := keylet.Oracle(accountID, documentID)
-
-		// Get the Oracle entry
 		oracleEntry, lookupErr := types.Services.Ledger.GetLedgerEntry(oracleKeylet.Key, ledgerIndex)
 		if lookupErr != nil {
-			// Skip oracles that don't exist
 			continue
 		}
 
-		// Decode the Oracle entry
 		oracleDecoded, decodeErr2 := binarycodec.Decode(hex.EncodeToString(oracleEntry.Node))
 		if decodeErr2 != nil {
 			continue
 		}
 
-		// Get the last update time
 		var lastUpdateTime uint32
 		if lut, ok := oracleDecoded["LastUpdateTime"]; ok {
 			switch v := lut.(type) {
@@ -219,7 +207,6 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 				continue
 			}
 
-			// Get the asset price
 			assetPrice, ok := priceData["AssetPrice"]
 			if !ok {
 				continue

--- a/internal/rpc/handlers/json.go
+++ b/internal/rpc/handlers/json.go
@@ -36,7 +36,6 @@ func (m *JsonMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inte
 	// - A JSON array with one element (XRPL-style params: [{...}])
 	var forwardParams []byte
 	if len(request.Params) > 0 {
-		// Check if it's an array
 		var arr []json.RawMessage
 		if json.Unmarshal(request.Params, &arr) == nil && len(arr) > 0 {
 			forwardParams = arr[0]

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -110,7 +110,6 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 	closeTimeHuman := closeTime.UTC().Format("2006-Jan-02 15:04:05.000000000 UTC")
 	closeTimeISO := closeTime.UTC().Format(time.RFC3339)
 
-	// Get reserve info
 	_, reserveBase, reserveInc := types.Services.Ledger.GetCurrentFees()
 
 	ledgerInfo := map[string]interface{}{
@@ -132,7 +131,6 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		"transaction_hash":      txHashStr,
 	}
 
-	// Add transactions if requested
 	if request.Transactions {
 		var txList []interface{}
 		apiVersion := ctx.ApiVersion
@@ -155,7 +153,6 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 				}
 				txList = append(txList, txEntry)
 			} else {
-				// Return just transaction hashes
 				txList = append(txList, hashStr)
 			}
 			return true
@@ -173,11 +170,9 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		"validated":    validated,
 	}
 
-	// Add reserve info at top level
 	response["reserve_base_drops"] = fmt.Sprintf("%d", reserveBase)
 	response["reserve_inc_drops"] = fmt.Sprintf("%d", reserveInc)
 
-	// Add queue data if requested
 	if request.Queue {
 		response["queue_data"] = []interface{}{}
 	}

--- a/internal/rpc/handlers/ledger_accept.go
+++ b/internal/rpc/handlers/ledger_accept.go
@@ -16,13 +16,11 @@ func (m *LedgerAcceptMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, err
 	}
 
-	// Check if running in standalone mode
 	if !types.Services.Ledger.IsStandalone() {
 		return nil, types.NewRpcError(types.RpcNOT_STANDALONE, "notStandalone", "notStandalone",
 			"ledger_accept is only available in standalone mode")
 	}
 
-	// Accept the ledger
 	closedSeq, err := types.Services.Ledger.AcceptLedger()
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to accept ledger: " + err.Error())

--- a/internal/rpc/handlers/ledger_closed.go
+++ b/internal/rpc/handlers/ledger_closed.go
@@ -15,13 +15,11 @@ func (m *LedgerClosedMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, err
 	}
 
-	// Get the closed ledger index
 	seq := types.Services.Ledger.GetClosedLedgerIndex()
 	if seq == 0 {
 		return nil, &types.RpcError{Code: -1, ErrorString: "lgrNotFound", Message: "No closed ledger"}
 	}
 
-	// Get the ledger to retrieve its hash
 	ledger, err := types.Services.Ledger.GetLedgerBySequence(seq)
 	if err != nil {
 		return nil, &types.RpcError{Code: -1, ErrorString: "lgrNotFound", Message: "Closed ledger not found"}

--- a/internal/rpc/handlers/ledger_current.go
+++ b/internal/rpc/handlers/ledger_current.go
@@ -14,7 +14,6 @@ func (m *LedgerCurrentMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, err
 	}
 
-	// Get the current (open) ledger index
 	seq := types.Services.Ledger.GetCurrentLedgerIndex()
 	if seq == 0 {
 		return nil, &types.RpcError{Code: -1, ErrorString: "lgrNotFound", Message: "No current ledger"}

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -54,7 +54,6 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		}
 	}
 
-	// Get ledger data from the ledger service
 	result, err := types.Services.Ledger.GetLedgerData(ledgerIndex, limit, markerStr)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to get ledger data: " + err.Error())
@@ -82,7 +81,6 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 					"index": upperIndex,
 				}
 			} else {
-				// Add index field to the deserialized object
 				if objMap, ok := jsonObj.(map[string]interface{}); ok {
 					objMap["index"] = upperIndex
 					state[i] = objMap

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -363,7 +363,6 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, types.RpcErrorUnknownOption("Must specify object to look up")
 	}
 
-	// Get ledger entry
 	result, err := types.Services.Ledger.GetLedgerEntry(entryKey, ledgerIndex)
 	if err != nil {
 		if err.Error() == "entry not found" {
@@ -566,7 +565,6 @@ func parseDepositPreauthKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) 
 // parseDirectoryKeylet parses a directory specifier: string (hex) or { owner, sub_index }
 // Reference: rippled LedgerEntry.cpp parseDirectory()
 func parseDirectoryKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
-	// Check for null/non-value
 	if raw == nil || string(raw) == "null" {
 		return [32]byte{}, types.RpcErrorInvalidParams("Invalid directory params")
 	}

--- a/internal/rpc/handlers/ledger_range.go
+++ b/internal/rpc/handlers/ledger_range.go
@@ -39,7 +39,6 @@ func (m *LedgerRangeMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, err
 	}
 
-	// Get ledger range from the ledger service
 	result, err := types.Services.Ledger.GetLedgerRange(request.StartLedger, request.StopLedger)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to get ledger range: " + err.Error())

--- a/internal/rpc/handlers/nft_buy_offers.go
+++ b/internal/rpc/handlers/nft_buy_offers.go
@@ -72,7 +72,6 @@ func (m *NftBuyOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		}
 	}
 
-	// Get NFT buy offers from the ledger service
 	result, err := types.Services.Ledger.GetNFTBuyOffers(nftID, ledgerIndex, limit, marker)
 	if err != nil {
 		if err.Error() == "ledger not found" {

--- a/internal/rpc/handlers/nft_sell_offers.go
+++ b/internal/rpc/handlers/nft_sell_offers.go
@@ -72,7 +72,6 @@ func (m *NftSellOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		}
 	}
 
-	// Get NFT sell offers from the ledger service
 	result, err := types.Services.Ledger.GetNFTSellOffers(nftID, ledgerIndex, limit, marker)
 	if err != nil {
 		if err.Error() == "ledger not found" {

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -103,7 +103,6 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		srcCurrencies = append(srcCurrencies, issue)
 	}
 
-	// Get ledger view
 	view, err := types.Services.Ledger.GetClosedLedgerView()
 	if err != nil {
 		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -96,7 +96,6 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		}
 	}
 
-	// Check if this account has already signed
 	for _, signerWrapper := range signers {
 		if signer, ok := signerWrapper["Signer"].(map[string]interface{}); ok {
 			if signer["Account"] == request.Account {
@@ -105,8 +104,6 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		}
 	}
 
-	// Create signing payload for multisigning
-	// Remove Signers from the map for signing
 	txMapForSigning := make(map[string]interface{})
 	for k, v := range txMap {
 		if k != "Signers" {
@@ -126,7 +123,6 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		return nil, types.RpcErrorInternal("Failed to sign transaction: " + err.Error())
 	}
 
-	// Create new signer entry
 	newSigner := map[string]interface{}{
 		"Signer": map[string]interface{}{
 			"Account":       request.Account,
@@ -135,7 +131,6 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		},
 	}
 
-	// Add new signer to the list
 	signers = append(signers, newSigner)
 
 	// Sort signers by account (required by XRPL protocol)
@@ -151,19 +146,14 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		return iAccount < jAccount
 	})
 
-	// Update transaction with sorted signers
 	txMap["Signers"] = signers
 
-	// Encode the transaction to binary
 	txBlob, err := binarycodec.Encode(txMap)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to encode transaction: " + err.Error())
 	}
 
-	// Calculate transaction hash
 	txHash := CalculateTxHash(txBlob)
-
-	// Add hash to response tx_json
 	txMap["hash"] = txHash
 
 	// Inject DeliverMax for Payment transactions, matching rippled's

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -105,7 +105,6 @@ func parsePositiveIntParam(raw json.RawMessage, fieldName string, strictPositive
 	val, err := strconv.ParseInt(str, 10, 64)
 	if err != nil {
 		// Could be a float like "1.5" or too large
-		// Check if it's a float
 		if _, fErr := strconv.ParseFloat(str, 64); fErr == nil {
 			// It's a valid float but not an integer → rpcHIGH_FEE
 			return 0, types.RpcErrorExpectedFieldHighFee(fieldName, "a positive integer")
@@ -187,7 +186,6 @@ func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline 
 			return nil, types.RpcErrorInvalidParams("Account in tx_json does not match signing key")
 		}
 	} else {
-		// Set the account if not present
 		txMap["Account"] = address
 	}
 
@@ -215,7 +213,6 @@ func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline 
 			txMap["Fee"] = formatUint64AsString(networkFee)
 		}
 
-		// Set Sequence if not present
 		if _, ok := txMap["Sequence"]; !ok {
 			// TODO: When ledger lookup is available, auto-fill from account state.
 			// For now, attempt to get account info.
@@ -244,10 +241,8 @@ func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline 
 		}
 	}
 
-	// Add the signing public key
 	txMap["SigningPubKey"] = publicKey
 
-	// Parse the transaction to get a proper Transaction object
 	txBytes, err := json.Marshal(txMap)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to marshal transaction: " + err.Error())
@@ -258,29 +253,22 @@ func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline 
 		return nil, types.RpcErrorInvalidParams("Failed to parse transaction: " + err.Error())
 	}
 
-	// Update the common fields with signing key
 	txCommon := transaction.GetCommon()
 	txCommon.SigningPubKey = publicKey
 
-	// Sign the transaction
 	signature, err := tx.SignTransaction(transaction, privateKey)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to sign transaction: " + err.Error())
 	}
 
-	// Add signature to transaction map
 	txMap["TxnSignature"] = signature
 
-	// Encode the transaction to binary
 	txBlob, err := binarycodec.Encode(txMap)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to encode transaction: " + err.Error())
 	}
 
-	// Calculate transaction hash
 	txHash := CalculateTxHash(txBlob)
-
-	// Add hash to response tx_json
 	txMap["hash"] = txHash
 
 	return &signResult{

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -103,7 +103,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx.Account'.")
 	}
 
-	// --- Autofill fields (handler-level, no ledger access needed) ---
 	// Reference: rippled autofillTx()
 
 	// Autofill SigningPubKey: if not present, set to ""

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -7,15 +7,6 @@ import (
 	xrpllog "github.com/LeJamon/goXRPLd/log"
 )
 
-// =============================================================================
-// ADMIN STUB HANDLERS
-// =============================================================================
-//
-// These handlers are admin/operational tools that require additional
-// infrastructure (LedgerCleaner, logging framework, validator config, etc.).
-// TODO [admin]: Implement when the corresponding infrastructure is in place.
-// =============================================================================
-
 // LedgerCleanerMethod handles the ledger_cleaner RPC method.
 // STUB: Returns error. Admin-only maintenance tool.
 //

--- a/internal/rpc/handlers/stubs_ledger.go
+++ b/internal/rpc/handlers/stubs_ledger.go
@@ -6,13 +6,6 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// =============================================================================
-// LEDGER STUB HANDLERS
-// =============================================================================
-//
-// These handlers require additional ledger query capabilities.
-// =============================================================================
-
 // OwnerInfoMethod handles the owner_info RPC method.
 // STUB: Returns notImplemented. Requires NetworkOPs integration.
 //

--- a/internal/rpc/handlers/stubs_network.go
+++ b/internal/rpc/handlers/stubs_network.go
@@ -7,15 +7,6 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// =============================================================================
-// NETWORK STUB HANDLERS
-// =============================================================================
-//
-// These handlers require P2P networking infrastructure to implement.
-// They return placeholder data or errors in standalone mode.
-// TODO [network]: Implement when adding P2P networking layer.
-// =============================================================================
-
 // FetchInfoMethod handles the fetch_info RPC method.
 // STUB: Returns empty info. Network-only — not needed for standalone mode.
 //

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -144,7 +144,6 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		txJsonMap["hash"] = txHashStr
 	}
 
-	// Get current fees for response
 	baseFee, _, _ := types.Services.Ledger.GetCurrentFees()
 
 	// Build response with independent boolean fields matching rippled's

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -126,7 +126,6 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
 		}
 
-		// Check required signer fields
 		account, ok := signer["Account"].(string)
 		if !ok || account == "" {
 			return nil, types.RpcErrorInvalidParams("Signer entry missing Account")
@@ -185,14 +184,11 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 
 	result, submitErr := types.Services.Ledger.SubmitTransaction(txJSON)
 	if submitErr != nil {
-		// Return submission error with details
 		return nil, types.RpcErrorInternal("Transaction submission failed: " + submitErr.Error())
 	}
 
-	// Add hash to response tx_json
 	txMap["hash"] = txHash
 
-	// Build response
 	response := map[string]interface{}{
 		"engine_result":         result.EngineResult,
 		"engine_result_code":    result.EngineResultCode,
@@ -201,7 +197,6 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		"tx_json":               txMap,
 	}
 
-	// Add applied status from result
 	if result.Applied {
 		response["applied"] = result.Applied
 	}

--- a/internal/rpc/handlers/transaction_entry.go
+++ b/internal/rpc/handlers/transaction_entry.go
@@ -78,7 +78,6 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 		return nil, types.RpcErrorInternal("Failed to parse transaction data")
 	}
 
-	// Get ledger hash for response
 	ledgerHash := txInfo.LedgerHash
 	if ledgerHash == "" {
 		ledger, err := types.Services.Ledger.GetLedgerBySequence(targetSeq)

--- a/internal/rpc/handlers/tx.go
+++ b/internal/rpc/handlers/tx.go
@@ -194,7 +194,6 @@ func (m *TxMethod) buildResponseV2(
 		if closeTimeSec > 0 {
 			txJSON["date"] = closeTimeSec
 		}
-		// Add CTID inside tx_json
 		if txInfo.LedgerIndex > 0 && txInfo.TxIndex <= 0xFFFF && txInfo.LedgerIndex < 0x0FFFFFFF {
 			txJSON["ctid"] = encodeCTID(txInfo.LedgerIndex, uint16(txInfo.TxIndex))
 		}
@@ -355,7 +354,6 @@ func (m *TxMethod) lookupByCTID(ctx *types.RpcContext, ledgerSeq uint32, txIndex
 		response["close_time_iso"] = closeTime.UTC().Format("2006-01-02T15:04:05Z")
 		response["date"] = closeTimeSec
 	}
-	// Add CTID to v1 response at root level
 	response["ctid"] = encodeCTID(ledgerSeq, txIndex)
 
 	return response, nil

--- a/internal/rpc/handlers/vault_info.go
+++ b/internal/rpc/handlers/vault_info.go
@@ -69,7 +69,6 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		vaultKey = vaultKeylet.Key
 	}
 
-	// Get the Vault entry
 	vaultEntry, err := types.Services.Ledger.GetLedgerEntry(vaultKey, ledgerIndex)
 	if err != nil {
 		return nil, &types.RpcError{
@@ -78,7 +77,6 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		}
 	}
 
-	// Decode the Vault entry
 	vaultDecoded, decodeErr := binarycodec.Decode(hex.EncodeToString(vaultEntry.Node))
 	if decodeErr != nil {
 		return nil, types.RpcErrorInternal("Failed to decode Vault: " + decodeErr.Error())
@@ -92,12 +90,10 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 			var mptIssuanceKey [32]byte
 			copy(mptIssuanceKey[:], shareMPTIDBytes)
 
-			// Get the MPToken issuance entry
 			mptIssuanceEntry, mptErr := types.Services.Ledger.GetLedgerEntry(mptIssuanceKey, ledgerIndex)
 			if mptErr == nil {
 				mptIssuanceDecoded, mptDecodeErr := binarycodec.Decode(hex.EncodeToString(mptIssuanceEntry.Node))
 				if mptDecodeErr == nil {
-					// Add shares info to vault response
 					vaultDecoded["shares"] = mptIssuanceDecoded
 				}
 			}

--- a/internal/rpc/handlers/wallet_propose.go
+++ b/internal/rpc/handlers/wallet_propose.go
@@ -180,7 +180,6 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		"public_key_hex":  strings.ToUpper(publicKey),
 	}
 
-	// Add warning if passphrase was used
 	if warning != "" {
 		response["warning"] = warning
 	}

--- a/internal/rpc/helpers_test.go
+++ b/internal/rpc/helpers_test.go
@@ -8,10 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // InjectDeliveredAmount Tests
 // Based on rippled src/test/rpc/DeliveredAmount_test.cpp
-// =============================================================================
 
 // TestDeliveredAmountNonPaymentSkipped verifies that non-Payment transactions
 // are skipped entirely (no DeliveredAmount is added to meta).
@@ -318,9 +316,7 @@ func TestDeliveredAmountPriorityOrder(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // FormatLedgerHash Tests
-// =============================================================================
 
 // TestFormatLedgerHashValidHash verifies that a 32-byte hash is formatted
 // as a lowercase 64-character hex string.
@@ -373,12 +369,10 @@ func TestFormatLedgerHashDeterministic(t *testing.T) {
 	assert.Equal(t, result1, result2, "Same input should produce same output")
 }
 
-// =============================================================================
 // ResolveLedgerIndex Tests (tested indirectly via TransactionEntryMethod)
 // The resolveTargetLedger method is unexported on TransactionEntryMethod,
 // so we test it indirectly through the handler's behavior with different
 // ledger_index values passed via parameters.
-// =============================================================================
 // Note: Direct tests for resolveTargetLedger would require the handlers
 // package. Ledger index resolution is tested indirectly through handler
 // tests like TestAccountInfoLedgerSpecification and

--- a/internal/rpc/ledger_entry_test.go
+++ b/internal/rpc/ledger_entry_test.go
@@ -67,9 +67,7 @@ func setupLedgerEntryTestServices(mock *mockLedgerEntryService) func() {
 	}
 }
 
-// =============================================================================
 // Direct Index Lookup Tests
-// =============================================================================
 
 // TestLedgerEntryDirectIndexLookup tests direct index lookup (256-bit hex)
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryInvalid() and testLedgerEntryAccountRoot()
@@ -212,9 +210,7 @@ func TestLedgerEntryDirectIndexLookup(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Check Entry Tests
-// =============================================================================
 
 // TestLedgerEntryCheck tests check lookup by check ID
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryCheck()
@@ -320,9 +316,7 @@ func TestLedgerEntryCheck(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Payment Channel Entry Tests
-// =============================================================================
 
 // TestLedgerEntryPaymentChannel tests payment_channel lookup by channel ID
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryPayChan()
@@ -428,9 +422,7 @@ func TestLedgerEntryPaymentChannel(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Directory Entry Tests
-// =============================================================================
 
 // TestLedgerEntryDirectory tests directory lookup by directory index
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryDirectory()
@@ -537,9 +529,7 @@ func TestLedgerEntryDirectory(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // NFT Page Entry Tests
-// =============================================================================
 
 // TestLedgerEntryNFTPage tests NFT page lookup by page index
 func TestLedgerEntryNFTPage(t *testing.T) {
@@ -644,9 +634,7 @@ func TestLedgerEntryNFTPage(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Error Cases - Missing Entry Type
-// =============================================================================
 
 // TestLedgerEntryMissingEntryType tests error when no entry type is specified
 func TestLedgerEntryMissingEntryType(t *testing.T) {
@@ -695,9 +683,7 @@ func TestLedgerEntryMissingEntryType(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Ledger Specification Tests
-// =============================================================================
 
 // TestLedgerEntryLedgerSpecification tests different ledger index specifications
 // Based on rippled ledger specification behavior
@@ -887,9 +873,7 @@ func TestLedgerEntryLedgerSpecification(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Response Format Tests
-// =============================================================================
 
 // TestLedgerEntryResponseFields tests that the response contains expected fields
 func TestLedgerEntryResponseFields(t *testing.T) {
@@ -977,9 +961,7 @@ func TestLedgerEntryResponseFields(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Service Unavailability Tests
-// =============================================================================
 
 // TestLedgerEntryServiceUnavailable tests behavior when ledger service is not available
 func TestLedgerEntryServiceUnavailable(t *testing.T) {
@@ -1029,9 +1011,7 @@ func TestLedgerEntryServiceUnavailable(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Method Metadata Tests
-// =============================================================================
 
 // TestLedgerEntryMethodMetadata tests the method's metadata functions
 func TestLedgerEntryMethodMetadata(t *testing.T) {
@@ -1050,9 +1030,7 @@ func TestLedgerEntryMethodMetadata(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Entry Type Priority Tests
-// =============================================================================
 
 // TestLedgerEntryTypePriority tests that index takes priority over other entry types
 func TestLedgerEntryTypePriority(t *testing.T) {
@@ -1103,9 +1081,7 @@ func TestLedgerEntryTypePriority(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Not Implemented Entry Types - Document Expected Behavior
-// =============================================================================
 
 // TestLedgerEntryNotImplementedTypes documents entry types that are defined but not fully implemented
 // TestLedgerEntryImplementedTypes tests that keylet-based lookups now work
@@ -1200,9 +1176,7 @@ func TestLedgerEntryImplementedTypes(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Invalid Parameters Tests
-// =============================================================================
 
 // TestLedgerEntryInvalidParameters tests various invalid parameter scenarios
 func TestLedgerEntryInvalidParameters(t *testing.T) {
@@ -1280,9 +1254,7 @@ func TestLedgerEntryInvalidParameters(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Entry Not Found Error Code Test
-// =============================================================================
 
 // TestLedgerEntryNotFoundErrorCode tests that entry not found returns correct error code
 func TestLedgerEntryNotFoundErrorCode(t *testing.T) {
@@ -1314,9 +1286,7 @@ func TestLedgerEntryNotFoundErrorCode(t *testing.T) {
 	assert.Contains(t, rpcErr.Message, "not found")
 }
 
-// =============================================================================
 // AccountRoot Entry Tests
-// =============================================================================
 
 // TestLedgerEntryAccountRoot tests account_root lookup by address and by index
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryAccountRoot()
@@ -1438,9 +1408,7 @@ func TestLedgerEntryAccountRoot(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Escrow Entry Tests
-// =============================================================================
 
 // TestLedgerEntryEscrow tests escrow lookup by owner+seq and by index
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryEscrow()
@@ -1538,9 +1506,7 @@ func TestLedgerEntryEscrow(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Offer Entry Tests
-// =============================================================================
 
 // TestLedgerEntryOffer tests offer lookup by account+seq and by index
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryOffer()
@@ -1638,9 +1604,7 @@ func TestLedgerEntryOffer(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // RippleState (Trust Line) Entry Tests
-// =============================================================================
 
 // TestLedgerEntryRippleState tests trust line lookup by accounts+currency
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryRippleState()
@@ -1738,9 +1702,7 @@ func TestLedgerEntryRippleState(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Ticket Entry Tests
-// =============================================================================
 
 // TestLedgerEntryTicket tests ticket lookup by account+ticket_seq and by index
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryTicket()
@@ -1838,9 +1800,7 @@ func TestLedgerEntryTicket(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // DepositPreauth Entry Tests
-// =============================================================================
 
 // TestLedgerEntryDepositPreauth tests deposit_preauth lookup by owner+authorized and by index
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryDepositPreauth()
@@ -1938,9 +1898,7 @@ func TestLedgerEntryDepositPreauth(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // AMM Entry Tests
-// =============================================================================
 
 // TestLedgerEntryAMM tests AMM lookup by asset+asset2 and by index
 // Based on rippled AMM ledger entry tests
@@ -2038,9 +1996,7 @@ func TestLedgerEntryAMM(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Invalid Ledger Hash/Index Tests
-// =============================================================================
 
 // TestLedgerEntryInvalidLedgerSpecification tests error handling for invalid ledger specifications
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryInvalid()
@@ -2117,9 +2073,7 @@ func TestLedgerEntryInvalidLedgerSpecification(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Unexpected Ledger Type Tests
-// =============================================================================
 
 // TestLedgerEntryUnexpectedType tests error when requesting wrong entry type
 // Based on rippled behavior where requesting an AccountRoot index via check field fails
@@ -2167,9 +2121,7 @@ func TestLedgerEntryUnexpectedType(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Multiple Entry Type Parameters Tests
-// =============================================================================
 
 // TestLedgerEntryMultipleTypes tests behavior when multiple entry types are specified
 func TestLedgerEntryMultipleTypes(t *testing.T) {
@@ -2221,9 +2173,7 @@ func TestLedgerEntryMultipleTypes(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Malformed Request Tests
-// =============================================================================
 
 // TestLedgerEntryMalformedRequests tests various malformed request scenarios
 // Based on rippled LedgerEntry_test.cpp malformed request handling
@@ -2302,9 +2252,7 @@ func TestLedgerEntryMalformedRequests(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // API Version Tests
-// =============================================================================
 
 // TestLedgerEntryAPIVersions tests that the method works correctly with different API versions
 func TestLedgerEntryAPIVersions(t *testing.T) {
@@ -2350,9 +2298,7 @@ func TestLedgerEntryAPIVersions(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Hex Validation Tests
-// =============================================================================
 
 // TestLedgerEntryHexValidation tests hex string validation for various entry types
 func TestLedgerEntryHexValidation(t *testing.T) {
@@ -2519,9 +2465,7 @@ func TestLedgerEntryHexValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Hex Index Fallback Tests
-// =============================================================================
 
 // TestLedgerEntryHexFallback tests that all entry types that support it accept
 // a direct hex string as an alternative to the structured object form.
@@ -2595,9 +2539,7 @@ func TestLedgerEntryHexFallback(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // New Entry Type Tests: vault, delegate, bridge, xchain
-// =============================================================================
 
 // TestLedgerEntryVault tests vault entry lookup by hex and by object form
 func TestLedgerEntryVault(t *testing.T) {
@@ -2800,9 +2742,7 @@ func TestLedgerEntryXChainClaimID(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Ticket Conformance Tests
-// =============================================================================
 
 // TestLedgerEntryTicketConformance tests that ticket uses ticket_seq (not ticket_id)
 // matching rippled's parseTicket() which expects jss::ticket_seq
@@ -2848,9 +2788,7 @@ func TestLedgerEntryTicketConformance(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Uppercase Hex Response Tests
-// =============================================================================
 
 // TestLedgerEntryUppercaseHex verifies that the ledger_hash in the response
 // uses uppercase hex encoding, matching rippled's output.
@@ -2899,9 +2837,7 @@ func TestLedgerEntryUppercaseHex(t *testing.T) {
 		"ledger_hash should be entirely uppercase")
 }
 
-// =============================================================================
 // Escrow Hex Fallback Tests
-// =============================================================================
 
 // TestLedgerEntryEscrowHexFallback tests escrow specifically with hex vs object form
 func TestLedgerEntryEscrowHexFallback(t *testing.T) {
@@ -2946,9 +2882,7 @@ func TestLedgerEntryEscrowHexFallback(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Offer Hex Fallback Tests
-// =============================================================================
 
 // TestLedgerEntryOfferHexFallback tests offer specifically with hex vs object form
 func TestLedgerEntryOfferHexFallback(t *testing.T) {
@@ -2993,9 +2927,7 @@ func TestLedgerEntryOfferHexFallback(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Oracle Hex Fallback Tests
-// =============================================================================
 
 // TestLedgerEntryOracleHexFallback tests oracle with hex vs object form
 func TestLedgerEntryOracleHexFallback(t *testing.T) {
@@ -3040,9 +2972,7 @@ func TestLedgerEntryOracleHexFallback(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // AMM Hex Fallback Tests
-// =============================================================================
 
 // TestLedgerEntryAMMHexFallback tests AMM with hex vs object form
 func TestLedgerEntryAMMHexFallback(t *testing.T) {

--- a/internal/rpc/methods.go
+++ b/internal/rpc/methods.go
@@ -83,10 +83,6 @@ func (s *Server) registerAllMethods() {
 	s.registry.Register("validator_list_sites", &handlers.ValidatorListSitesMethod{})
 	s.registry.Register("validators", &handlers.ValidatorsMethod{})
 
-	// =========================================================================
-	// Additional Methods (added for rippled compatibility)
-	// =========================================================================
-
 	// Server/Network Methods
 	s.registry.Register("fetch_info", &handlers.FetchInfoMethod{})
 	s.registry.Register("connect", &handlers.ConnectMethod{})

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Test Helpers
-// =============================================================================
 
 // mockLedgerServiceMissingMethods extends mockLedgerService for testing new methods
 type mockLedgerServiceMissingMethods struct {
@@ -37,10 +35,8 @@ func setupTestServicesMissingMethods(mock *mockLedgerServiceMissingMethods) func
 	}
 }
 
-// =============================================================================
 // FetchInfoMethod Tests
 // Reference: rippled/src/xrpld/rpc/handlers/FetchInfo.cpp
-// =============================================================================
 
 func TestFetchInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -91,10 +87,8 @@ func TestFetchInfoMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // OwnerInfoMethod Tests
 // Reference: rippled/src/test/rpc/OwnerInfo_test.cpp
-// =============================================================================
 
 func TestOwnerInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -153,10 +147,8 @@ func TestOwnerInfoMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // LedgerHeaderMethod Tests
 // Reference: rippled/src/test/rpc/LedgerHeader_test.cpp
-// =============================================================================
 
 func TestLedgerHeaderMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -209,10 +201,8 @@ func TestLedgerHeaderMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // LedgerRequestMethod Tests
 // Reference: rippled/src/test/rpc/LedgerRequestRPC_test.cpp
-// =============================================================================
 
 func TestLedgerRequestMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -243,9 +233,7 @@ func TestLedgerRequestMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // LedgerCleanerMethod Tests
-// =============================================================================
 
 func TestLedgerCleanerMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -274,9 +262,7 @@ func TestLedgerCleanerMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // LedgerDiffMethod Tests
-// =============================================================================
 
 func TestLedgerDiffMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -305,10 +291,8 @@ func TestLedgerDiffMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // SimulateMethod Tests
 // Reference: rippled/src/test/rpc/Simulate_test.cpp
-// =============================================================================
 
 func TestSimulateMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -362,9 +346,7 @@ func TestSimulateMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // TxReduceRelayMethod Tests
-// =============================================================================
 
 func TestTxReduceRelayMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -399,10 +381,8 @@ func TestTxReduceRelayMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // ConnectMethod Tests
 // Reference: rippled/src/test/rpc/Connect_test.cpp
-// =============================================================================
 
 func TestConnectMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -449,9 +429,7 @@ func TestConnectMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // PrintMethod Tests
-// =============================================================================
 
 func TestPrintMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -484,10 +462,8 @@ func TestPrintMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // ValidatorInfoMethod Tests
 // Reference: rippled/src/test/rpc/ValidatorInfo_test.cpp
-// =============================================================================
 
 func TestValidatorInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -518,9 +494,7 @@ func TestValidatorInfoMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // CanDeleteMethod Tests
-// =============================================================================
 
 func TestCanDeleteMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -549,10 +523,8 @@ func TestCanDeleteMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // GetAggregatePriceMethod Tests
 // Reference: rippled/src/test/rpc/GetAggregatePrice_test.cpp
-// =============================================================================
 
 func TestGetAggregatePriceMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -770,10 +742,8 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // GetCountsMethod Tests
 // Reference: rippled/src/test/rpc/GetCounts_test.cpp
-// =============================================================================
 
 func TestGetCountsMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -803,9 +773,7 @@ func TestGetCountsMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // LogLevelMethod Tests
-// =============================================================================
 
 func TestLogLevelMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -867,9 +835,7 @@ func TestLogLevelMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // LogRotateMethod Tests
-// =============================================================================
 
 func TestLogRotateMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -899,10 +865,8 @@ func TestLogRotateMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // AMMInfoMethod Tests
 // Reference: rippled/src/test/rpc/AMMInfo_test.cpp
-// =============================================================================
 
 func TestAMMInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -987,9 +951,7 @@ func TestAMMInfoMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // VaultInfoMethod Tests
-// =============================================================================
 
 func TestVaultInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -1084,9 +1046,7 @@ func TestVaultInfoMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // UnlListMethod Tests
-// =============================================================================
 
 func TestUnlListMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -1116,9 +1076,7 @@ func TestUnlListMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // BlackListMethod Tests
-// =============================================================================
 
 func TestBlackListMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
@@ -1162,9 +1120,7 @@ func TestBlackListMethod(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Service Unavailable Tests
-// =============================================================================
 
 func TestMissingMethodsServiceUnavailable(t *testing.T) {
 	// Test all methods handle nil Services gracefully
@@ -1220,9 +1176,7 @@ func TestMissingMethodsServiceUnavailable(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Nil Ledger Service Tests
-// =============================================================================
 
 func TestMissingMethodsNilLedgerService(t *testing.T) {
 	// Test all methods handle nil Ledger gracefully

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -160,9 +160,7 @@ func setupNFTOffersTestServices(mock *mockNFTOffersLedgerService) func() {
 	}
 }
 
-// =============================================================================
 // nft_buy_offers Tests
-// =============================================================================
 
 // TestNftBuyOffersErrorValidation tests error handling for invalid inputs
 // Reference: rippled NFTOffers_test.cpp testErrors()
@@ -446,9 +444,7 @@ func TestNftBuyOffersWithPagination(t *testing.T) {
 	assert.Equal(t, "BBB588DC1AB4E7C57F8067A3AB15BEA8B0F1A0DE14678200000099000001F400", respMap["marker"])
 }
 
-// =============================================================================
 // nft_sell_offers Tests
-// =============================================================================
 
 // TestNftSellOffersErrorValidation tests error handling for invalid inputs
 func TestNftSellOffersErrorValidation(t *testing.T) {
@@ -630,9 +626,7 @@ func TestNftSellOffersEmptyResult(t *testing.T) {
 	assert.Len(t, offers, 0)
 }
 
-// =============================================================================
 // Service Unavailable Tests
-// =============================================================================
 
 // TestNftBuyOffersServiceUnavailable tests response when ledger service is unavailable
 func TestNftBuyOffersServiceUnavailable(t *testing.T) {
@@ -688,9 +682,7 @@ func TestNftSellOffersServiceUnavailable(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
-// =============================================================================
 // Method Metadata Tests
-// =============================================================================
 
 // TestNftBuyOffersMethodMetadata tests method metadata (role, API versions)
 func TestNftBuyOffersMethodMetadata(t *testing.T) {

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -174,9 +174,7 @@ func setupNoRippleCheckTestServices(mock *mockNoRippleCheckLedgerService) func()
 	}
 }
 
-// =============================================================================
 // Error Validation Tests
-// =============================================================================
 
 // TestNoRippleCheckErrorValidation tests error handling for invalid inputs
 // Based on rippled NoRippleCheck_test.cpp testBadInput()
@@ -271,9 +269,7 @@ func TestNoRippleCheckErrorValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // User Role Tests - No Problems
-// =============================================================================
 
 // TestNoRippleCheckUserRoleNoProblems tests user role with properly configured account
 // Based on rippled NoRippleCheck_test.cpp testBasic(user=true, problems=false)
@@ -323,9 +319,7 @@ func TestNoRippleCheckUserRoleNoProblems(t *testing.T) {
 	assert.Contains(t, respMap, "validated")
 }
 
-// =============================================================================
 // User Role Tests - With Problems
-// =============================================================================
 
 // TestNoRippleCheckUserRoleWithProblems tests user role with misconfigured account
 // Based on rippled NoRippleCheck_test.cpp testBasic(user=true, problems=true)
@@ -377,9 +371,7 @@ func TestNoRippleCheckUserRoleWithProblems(t *testing.T) {
 	assert.Contains(t, problems[1], "set the no ripple flag")
 }
 
-// =============================================================================
 // Gateway Role Tests - No Problems
-// =============================================================================
 
 // TestNoRippleCheckGatewayRoleNoProblems tests gateway role with properly configured account
 // Based on rippled NoRippleCheck_test.cpp testBasic(user=false, problems=false)
@@ -424,9 +416,7 @@ func TestNoRippleCheckGatewayRoleNoProblems(t *testing.T) {
 	assert.Empty(t, problems, "Expected no problems for properly configured gateway")
 }
 
-// =============================================================================
 // Gateway Role Tests - With Problems
-// =============================================================================
 
 // TestNoRippleCheckGatewayRoleWithProblems tests gateway role with misconfigured account
 // Based on rippled NoRippleCheck_test.cpp testBasic(user=false, problems=true)
@@ -478,9 +468,7 @@ func TestNoRippleCheckGatewayRoleWithProblems(t *testing.T) {
 	assert.Contains(t, problems[1], "clear the no ripple flag")
 }
 
-// =============================================================================
 // Transaction Generation Tests
-// =============================================================================
 
 // TestNoRippleCheckWithTransactionsUser tests transaction generation for user role
 // Based on rippled NoRippleCheck_test.cpp testBasic with transactions=true
@@ -622,9 +610,7 @@ func TestNoRippleCheckWithTransactionsGateway(t *testing.T) {
 	assert.Contains(t, transactions[1], "LimitAmount")
 }
 
-// =============================================================================
 // API Version Tests
-// =============================================================================
 
 // TestNoRippleCheckTransactionsFieldValidationAPIv2 tests that API v2+ validates transactions field is boolean
 // Based on rippled NoRippleCheck.cpp API version check
@@ -681,9 +667,7 @@ func TestNoRippleCheckTransactionsFieldAPIv1(t *testing.T) {
 	require.NotNil(t, resp)
 }
 
-// =============================================================================
 // Service Unavailable Tests
-// =============================================================================
 
 // TestNoRippleCheckServiceUnavailable tests response when ledger service is unavailable
 func TestNoRippleCheckServiceUnavailable(t *testing.T) {
@@ -714,9 +698,7 @@ func TestNoRippleCheckServiceUnavailable(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
-// =============================================================================
 // Limit Parameter Tests
-// =============================================================================
 
 // TestNoRippleCheckWithLimit tests the limit parameter
 func TestNoRippleCheckWithLimit(t *testing.T) {
@@ -751,9 +733,7 @@ func TestNoRippleCheckWithLimit(t *testing.T) {
 	require.NotNil(t, resp)
 }
 
-// =============================================================================
 // Method Metadata Tests
-// =============================================================================
 
 // TestNoRippleCheckMethodMetadata tests method metadata (role, API versions)
 func TestNoRippleCheckMethodMetadata(t *testing.T) {

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -92,7 +92,6 @@ func (s *Server) handleGetRequest(w http.ResponseWriter, r *http.Request) {
 		method = "server_info"
 	}
 
-	// Create RPC context
 	clientIP := getClientIP(r)
 	portCtx := GetPortContext(r.Context())
 	role := roleForRequest(clientIP, portCtx)
@@ -104,16 +103,12 @@ func (s *Server) handleGetRequest(w http.ResponseWriter, r *http.Request) {
 		ClientIP:   clientIP,
 	}
 
-	// Execute method
 	result, rpcErr := s.executeMethod(method, nil, ctx)
-
-	// Build XRPL format response
 	s.writeXrplResponse(w, method, nil, result, rpcErr)
 }
 
 // handlePostRequest processes POST requests with XRPL JSON-RPC payload
 func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
-	// Read request body
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		s.writeXrplError(w, "", nil, "internal", "Failed to read request body")
@@ -121,14 +116,12 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	// Parse XRPL request
 	var request XrplRequest
 	if err := json.Unmarshal(body, &request); err != nil {
 		s.writeXrplError(w, "", nil, "jsonInvalid", "Invalid JSON: "+err.Error())
 		return
 	}
 
-	// Check for method
 	if request.Method == "" {
 		s.writeXrplError(w, "", nil, "missingCommand", "Missing method field")
 		return
@@ -140,7 +133,6 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		params = request.Params[0]
 	}
 
-	// Create RPC context
 	clientIP := getClientIP(r)
 	portCtx := GetPortContext(r.Context())
 	role := roleForRequest(clientIP, portCtx)
@@ -164,7 +156,6 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Execute method
 	result, rpcErr := s.executeMethod(request.Method, params, ctx)
 
 	// Build request object for error responses
@@ -182,7 +173,6 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		requestObj = map[string]interface{}{"command": request.Method}
 	}
 
-	// Build XRPL format response
 	s.writeXrplResponse(w, request.Method, requestObj, result, rpcErr)
 }
 
@@ -190,7 +180,6 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types.RpcContext) (interface{}, *types.RpcError) {
 	rpcLog().Debug("rpc", "method", method, "client", ctx.ClientIP)
 
-	// Get method handler
 	handler, exists := s.registry.Get(method)
 	if !exists {
 		return nil, types.RpcErrorMethodNotFound(method)
@@ -216,7 +205,6 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 		}
 	}
 
-	// Check API version support
 	supportedVersions := handler.SupportedApiVersions()
 	if len(supportedVersions) > 0 {
 		supported := false
@@ -231,7 +219,6 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 		}
 	}
 
-	// Execute handler
 	return handler.Handle(ctx, params)
 }
 
@@ -248,7 +235,6 @@ func (s *Server) writeXrplResponseWithOptions(w http.ResponseWriter, method stri
 	response := make(map[string]interface{})
 
 	if rpcErr != nil {
-		// Error response format - XRPL includes error, error_code, error_message inside result
 		resultObj := map[string]interface{}{
 			"status":        "error",
 			"error":         rpcErr.ErrorString,
@@ -260,13 +246,10 @@ func (s *Server) writeXrplResponseWithOptions(w http.ResponseWriter, method stri
 		}
 		response["result"] = resultObj
 	} else {
-		// Success response format
-		// If result is already a map, add status to it
 		if resultMap, ok := result.(map[string]interface{}); ok {
 			resultMap["status"] = "success"
 			response["result"] = resultMap
 		} else {
-			// Wrap non-map results
 			response["result"] = map[string]interface{}{
 				"status": "success",
 				"data":   result,
@@ -365,18 +348,15 @@ func roleForRequest(clientIP string, portCtx *PortContext) types.Role {
 
 // getClientIP extracts the client IP from the request
 func getClientIP(r *http.Request) string {
-	// Check X-Forwarded-For header
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		ips := strings.Split(xff, ",")
 		return strings.TrimSpace(ips[0])
 	}
 
-	// Check X-Real-IP header
 	if xri := r.Header.Get("X-Real-IP"); xri != "" {
 		return xri
 	}
 
-	// Fall back to RemoteAddr
 	ip := r.RemoteAddr
 	if idx := strings.LastIndex(ip, ":"); idx != -1 {
 		ip = ip[:idx]

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -66,10 +66,8 @@ func setupTestServicesServerInfo(mock *mockLedgerServiceServerInfo) func() {
 	}
 }
 
-// =============================================================================
 // Response Field Tests
 // Based on rippled ServerInfo_test.cpp testServerInfo()
-// =============================================================================
 
 // TestServerInfoResponseFields tests that server_info returns all expected fields
 // Based on rippled ServerInfo_test.cpp: BEAST_EXPECT(info.isMember(jss::build_version));
@@ -397,9 +395,7 @@ func TestServerInfoValidatedLedgerFields(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Server State Tests
-// =============================================================================
 
 // TestServerInfoServerStates tests different server state values
 // Based on rippled's NetworkOPs operating modes
@@ -498,9 +494,7 @@ func TestServerInfoStandaloneMode(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // API Version Tests
-// =============================================================================
 
 // TestServerInfoApiVersions tests server_info across different API versions
 func TestServerInfoApiVersions(t *testing.T) {
@@ -548,9 +542,7 @@ func TestServerInfoMethodSupportedApiVersions(t *testing.T) {
 	assert.Contains(t, versions, types.ApiVersion3, "Should support API version 3")
 }
 
-// =============================================================================
 // Error Cases
-// =============================================================================
 
 // TestServerInfoServiceUnavailable tests behavior when ledger service is not available
 func TestServerInfoServiceUnavailable(t *testing.T) {
@@ -596,9 +588,7 @@ func TestServerInfoServiceNilLedger(t *testing.T) {
 	assert.Contains(t, rpcErr.Message, "Ledger service not available")
 }
 
-// =============================================================================
 // Method Metadata Tests
-// =============================================================================
 
 // TestServerInfoMethodMetadata tests the method's metadata functions
 func TestServerInfoMethodMetadata(t *testing.T) {
@@ -617,9 +607,7 @@ func TestServerInfoMethodMetadata(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Complete Ledgers String Format Tests
-// =============================================================================
 
 // TestServerInfoCompleteLedgersFormat tests various complete_ledgers string formats
 func TestServerInfoCompleteLedgersFormat(t *testing.T) {
@@ -679,9 +667,7 @@ func TestServerInfoCompleteLedgersFormat(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // State Accounting Tests
-// =============================================================================
 
 // TestServerInfoStateAccounting tests the state_accounting field
 func TestServerInfoStateAccounting(t *testing.T) {
@@ -720,9 +706,7 @@ func TestServerInfoStateAccounting(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Time Field Tests
-// =============================================================================
 
 // TestServerInfoTimeField tests the time field format
 func TestServerInfoTimeField(t *testing.T) {
@@ -755,9 +739,7 @@ func TestServerInfoTimeField(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Fee Calculation Tests
-// =============================================================================
 
 // TestServerInfoFeeCalculations tests fee conversions from drops to XRP
 func TestServerInfoFeeCalculations(t *testing.T) {
@@ -836,9 +818,7 @@ func TestServerInfoFeeCalculations(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Server State Method Tests
-// =============================================================================
 
 // TestServerStateMethod tests the server_state RPC method
 func TestServerStateMethod(t *testing.T) {
@@ -933,9 +913,7 @@ func TestServerStateServiceUnavailable(t *testing.T) {
 	assert.Contains(t, rpcErr.Message, "Ledger service not available")
 }
 
-// =============================================================================
 // Integration-like Tests
-// =============================================================================
 
 // TestServerInfoWithDifferentLedgerStates tests server_info with various ledger states
 func TestServerInfoWithDifferentLedgerStates(t *testing.T) {
@@ -1006,9 +984,7 @@ func TestServerInfoWithDifferentLedgerStates(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Parameterless Call Tests
-// =============================================================================
 
 // TestServerInfoWithParams tests that server_info ignores any parameters passed
 func TestServerInfoWithParams(t *testing.T) {

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // WalletPropose Tests
-// =============================================================================
 
 func TestWalletPropose_RandomGeneration(t *testing.T) {
 	handler := &handlers.WalletProposeMethod{}
@@ -251,9 +249,7 @@ func TestWalletPropose_Metadata(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Sign Tests
-// =============================================================================
 
 func TestSign_MissingTxJson(t *testing.T) {
 	mock := newMockLedgerService()
@@ -465,9 +461,7 @@ func TestSign_Metadata(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Sign: fee_mult_max / fee_div_max Tests
-// =============================================================================
 
 func TestSign_FeeMultMax_DefaultAccepted(t *testing.T) {
 	// With default fee_mult_max=10 and fee_div_max=1, a baseFee of 10
@@ -736,9 +730,7 @@ func TestSign_FeeAlreadySet_IgnoresFeeMultMax(t *testing.T) {
 	require.NotNil(t, result)
 }
 
-// =============================================================================
 // Sign: DeliverMax injection Tests
-// =============================================================================
 
 func TestSign_DeliverMax_APIv1(t *testing.T) {
 	// API v1: DeliverMax should be added for Payment, Amount kept
@@ -836,9 +828,7 @@ func TestSign_NoDeliverMax_NonPayment(t *testing.T) {
 	assert.False(t, hasDeliverMax, "Non-Payment should not have DeliverMax")
 }
 
-// =============================================================================
 // SignFor Tests
-// =============================================================================
 
 func TestSignFor_MissingAccount(t *testing.T) {
 	handler := &handlers.SignForMethod{}
@@ -1010,9 +1000,7 @@ func TestSignFor_Metadata(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // SubmitMultisigned Tests
-// =============================================================================
 
 func TestSubmitMultisigned_MissingTxJson(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()

--- a/internal/rpc/submit_test.go
+++ b/internal/rpc/submit_test.go
@@ -146,7 +146,6 @@ func TestSubmitMethodErrorValidation(t *testing.T) {
 				Applied:             true,
 			}
 
-			// Setup mock if needed
 			if tc.setupMock != nil {
 				tc.setupMock()
 			}
@@ -159,7 +158,6 @@ func TestSubmitMethodErrorValidation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			// Verify error response

--- a/internal/rpc/subscribe_conformance_test.go
+++ b/internal/rpc/subscribe_conformance_test.go
@@ -24,12 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Bad Market Tests
 // Based on rippled Subscribe_test.cpp testSubErrors(): badMarket
 // rippled returns "badMarket" / "No such market." when taker_pays and
 // taker_gets specify the same currency+issuer pair.
-// =============================================================================
 
 // TestSubscribeConformanceBadMarket tests that subscribing to a book where both
 // sides are the same currency/issuer is rejected.
@@ -105,12 +103,10 @@ func TestSubscribeConformanceBadMarketXRP(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Unsubscribe Stops Message Delivery Tests
 // Based on rippled Subscribe_test.cpp testServer() and testTransactions_APIv1()
 // After unsubscribing from a stream, the connection should NOT receive messages
 // that are subsequently broadcast to that stream.
-// =============================================================================
 
 // TestSubscribeConformanceUnsubscribeStopsDelivery verifies that after
 // unsubscribing from a stream, no further messages are delivered.
@@ -204,10 +200,8 @@ func TestSubscribeConformanceUnsubscribeAccountStopsDelivery(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Multiple Connections: One Unsubscribes, Others Still Receive
 // Based on rippled testLedger() / testTransactions_APIv1() patterns
-// =============================================================================
 
 // TestSubscribeConformancePartialUnsubscribe verifies that when one connection
 // unsubscribes, other connections still receive messages.
@@ -250,11 +244,9 @@ func TestSubscribeConformancePartialUnsubscribe(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Subscribe/Unsubscribe Full Lifecycle on Same Connection
 // Based on rippled testTransactions_APIv1(): subscribe transactions, unsub,
 // subscribe accounts, unsub
-// =============================================================================
 
 // TestSubscribeConformanceFullLifecycle tests the full lifecycle of
 // subscribe -> receive -> unsubscribe -> re-subscribe to different stream.
@@ -324,10 +316,8 @@ func TestSubscribeConformanceFullLifecycle(t *testing.T) {
 	require.Nil(t, err)
 }
 
-// =============================================================================
 // Accounts Proposed Unsubscribe Tests
 // Based on rippled Subscribe_test.cpp testSubErrors() for accounts_proposed
-// =============================================================================
 
 // TestSubscribeConformanceAccountsProposedUnsubscribe tests the full lifecycle
 // of subscribing and unsubscribing from accounts_proposed.
@@ -361,10 +351,8 @@ func TestSubscribeConformanceAccountsProposedUnsubscribe(t *testing.T) {
 	assert.False(t, exists, "accounts_proposed subscription should be removed")
 }
 
-// =============================================================================
 // Empty Subscription Request Tests
 // Based on rippled: sending subscribe with no params still returns success
-// =============================================================================
 
 // TestSubscribeConformanceEmptyRequest verifies that subscribing with an empty
 // request (no streams, accounts, or books) succeeds.
@@ -400,12 +388,10 @@ func TestSubscribeConformanceEmptyUnsubscribeRequest(t *testing.T) {
 	assert.Equal(t, 1, len(conn.Subscriptions), "Existing subscriptions should remain")
 }
 
-// =============================================================================
 // Subscribe Response Contains Ledger Info Tests
 // Based on rippled Subscribe_test.cpp testLedger():
 //   jv[result][ledger_index] == 2
 //   jv[result][network_id] == env.app().config().NETWORK_ID
-// =============================================================================
 
 // TestSubscribeConformanceLedgerResponseFields verifies that the subscribe
 // response for a ledger stream contains the expected fields.
@@ -431,10 +417,8 @@ func TestSubscribeConformanceLedgerResponseFields(t *testing.T) {
 	assert.Equal(t, uint64(2000000), response.ReserveInc, "ReserveInc should match")
 }
 
-// =============================================================================
 // book_changes Stream Tests
 // Based on rippled Subscribe_test.cpp testSubBookChanges()
-// =============================================================================
 
 // TestSubscribeConformanceBookChangesStream verifies that subscribing to the
 // book_changes stream works correctly, matching the SubOrderBooks constant.
@@ -476,11 +460,9 @@ func TestSubscribeConformanceBookChangesStream(t *testing.T) {
 	assert.False(t, exists, "book_changes subscription should be removed")
 }
 
-// =============================================================================
 // Concurrent Safety Tests
 // Subscription management must be safe for concurrent access since multiple
 // WebSocket connections will subscribe/unsubscribe simultaneously.
-// =============================================================================
 
 // TestSubscribeConformanceConcurrentAccess tests that concurrent subscribe and
 // unsubscribe operations do not cause data races or panics.
@@ -539,11 +521,9 @@ func TestSubscribeConformanceConcurrentAccess(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Unsubscribe From Invalid Stream Tests
 // Based on rippled Subscribe_test.cpp testSubErrors(false) - unsubscribe also
 // validates stream names the same way subscribe does.
-// =============================================================================
 
 // TestSubscribeConformanceUnsubscribeInvalidStream verifies that unsubscribing
 // from an invalid stream name does not produce an error (current behavior is
@@ -573,9 +553,7 @@ func TestSubscribeConformanceUnsubscribeInvalidStream(t *testing.T) {
 	assert.True(t, exists, "Ledger subscription should remain intact")
 }
 
-// =============================================================================
 // Connection Removal Cleans Up Subscriptions
-// =============================================================================
 
 // TestSubscribeConformanceConnectionRemovalCleansUp verifies that removing a
 // connection cleans up its subscriptions so broadcast no longer targets it.
@@ -607,10 +585,8 @@ func TestSubscribeConformanceConnectionRemovalCleansUp(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Subscribe Re-subscribe After Unsubscribe
 // Based on rippled behavior: a connection can re-subscribe after unsubscribing
-// =============================================================================
 
 // TestSubscribeConformanceResubscribeAfterUnsubscribe verifies that a connection
 // can subscribe again after unsubscribing.
@@ -650,9 +626,7 @@ func TestSubscribeConformanceResubscribeAfterUnsubscribe(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Unsubscribe All Streams At Once
-// =============================================================================
 
 // TestSubscribeConformanceUnsubscribeAllStreams verifies that unsubscribing from
 // multiple streams in a single request removes all of them.
@@ -688,10 +662,8 @@ func TestSubscribeConformanceUnsubscribeAllStreams(t *testing.T) {
 		"All subscriptions should be removed")
 }
 
-// =============================================================================
 // Mixed Subscribe and Unsubscribe in Single Request
 // Based on rippled: unsubscribe from some streams while keeping others
-// =============================================================================
 
 // TestSubscribeConformanceSelectiveUnsubscribe verifies selective unsubscription
 // while keeping other subscription types intact.

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -28,10 +28,8 @@ func newTestConnection(id string) *types.Connection {
 	}
 }
 
-// =============================================================================
 // Stream Subscription Tests
 // Based on rippled Subscribe_test.cpp testServer(), testLedger(), testTransactions_APIv1()
-// =============================================================================
 
 // TestSubscribeStreamTypes tests subscribing to various stream types
 func TestSubscribeStreamTypes(t *testing.T) {
@@ -198,10 +196,8 @@ func TestSubscribeInvalidStreamName(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Account Subscription Tests
 // Based on rippled Subscribe_test.cpp testTransactions_APIv1() account subscription section
-// =============================================================================
 
 // TestSubscribeAccounts tests subscribing to specific accounts
 func TestSubscribeAccounts(t *testing.T) {
@@ -363,10 +359,8 @@ func TestSubscribeAccountsProposedInvalidFormat(t *testing.T) {
 	sm.RemoveConnection(conn.ID)
 }
 
-// =============================================================================
 // Book Subscription Tests
 // Based on rippled Subscribe_test.cpp testSubErrors() for books
-// =============================================================================
 
 // TestSubscribeBooks tests subscribing to order books with taker_gets/taker_pays
 func TestSubscribeBooks(t *testing.T) {
@@ -612,10 +606,8 @@ func TestSubscribeBooksMultiple(t *testing.T) {
 	sm.RemoveConnection(conn.ID)
 }
 
-// =============================================================================
 // Unsubscribe Tests
 // Based on rippled Subscribe_test.cpp unsubscribe sections
-// =============================================================================
 
 // TestUnsubscribeFromStreams tests unsubscribing from streams
 func TestUnsubscribeFromStreams(t *testing.T) {
@@ -821,10 +813,8 @@ func TestUnsubscribeFromNonSubscribedAccount(t *testing.T) {
 	sm.RemoveConnection(conn.ID)
 }
 
-// =============================================================================
 // Additional Error Cases
 // Based on rippled Subscribe_test.cpp testSubErrors()
-// =============================================================================
 
 // TestSubscribeMissingTakerPays tests book subscription without taker_pays
 func TestSubscribeMissingTakerPays(t *testing.T) {
@@ -932,9 +922,7 @@ func TestSubscribeInvalidTakerGetsJSON(t *testing.T) {
 	sm.RemoveConnection(conn.ID)
 }
 
-// =============================================================================
 // Subscription Manager State Tests
-// =============================================================================
 
 // TestSubscriptionManagerAddRemoveConnection tests connection management
 func TestSubscriptionManagerAddRemoveConnection(t *testing.T) {
@@ -1040,9 +1028,7 @@ func TestGetConnectionSubscriptions(t *testing.T) {
 	sm.RemoveConnection(conn.ID)
 }
 
-// =============================================================================
 // IsValidXRPLAddress Tests
-// =============================================================================
 
 // TestIsValidXRPLAddress tests the address validation function
 func TestIsValidXRPLAddress(t *testing.T) {
@@ -1136,9 +1122,7 @@ func TestIsValidXRPLAddress(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Subscribe Response Tests
-// =============================================================================
 
 // TestGetSubscribeResponse tests generating a subscribe confirmation response
 func TestGetSubscribeResponse(t *testing.T) {
@@ -1162,9 +1146,7 @@ func TestGetSubscribeResponse(t *testing.T) {
 	assert.Equal(t, uint64(2000000), response.ReserveInc)
 }
 
-// =============================================================================
 // Subscribe/Unsubscribe Method Tests (RPC Handler level)
-// =============================================================================
 
 // TestSubscribeMethodRequiresWebSocket tests that subscribe returns error via HTTP
 func TestSubscribeMethodRequiresWebSocket(t *testing.T) {
@@ -1230,9 +1212,7 @@ func TestUnsubscribeMethodMetadata(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Broadcast Tests
-// =============================================================================
 
 // TestBroadcastToStream tests broadcasting to stream subscribers
 func TestBroadcastToStream(t *testing.T) {
@@ -1405,9 +1385,7 @@ func TestBookMatchesCurrency(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Duplicate Subscription Tests
-// =============================================================================
 
 // TestSubscribeDuplicateStreamIdempotent tests that subscribing to the same stream twice is idempotent
 func TestSubscribeDuplicateStreamIdempotent(t *testing.T) {
@@ -1470,9 +1448,7 @@ func TestSubscribeDuplicateAccountsMerged(t *testing.T) {
 	sm.RemoveConnection(conn.ID)
 }
 
-// =============================================================================
 // Mixed Subscription Tests
-// =============================================================================
 
 // TestSubscribeMixedStreamsAndAccounts tests subscribing to both streams and accounts
 func TestSubscribeMixedStreamsAndAccounts(t *testing.T) {
@@ -1531,9 +1507,7 @@ func TestSubscribeMixedStreamsAccountsAndBooks(t *testing.T) {
 	sm.RemoveConnection(conn.ID)
 }
 
-// =============================================================================
 // URL Subscription Tests
-// =============================================================================
 
 // TestSubscribeWithURL tests subscribing with URL callback
 func TestSubscribeWithURL(t *testing.T) {

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -69,7 +69,6 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 		conn.Subscriptions[stream] = types.SubscriptionConfig{}
 	}
 
-	// Add account subscriptions
 	if len(request.Accounts) > 0 {
 		// Validate all accounts first
 		for _, acc := range request.Accounts {
@@ -101,7 +100,6 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 		}
 	}
 
-	// Add accounts_proposed subscriptions
 	if len(request.AccountsProposed) > 0 {
 		// Validate all accounts first
 		for _, acc := range request.AccountsProposed {
@@ -118,7 +116,6 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 		}
 	}
 
-	// Add book subscriptions
 	if len(request.Books) > 0 {
 		for _, book := range request.Books {
 			// Validate taker_gets
@@ -207,15 +204,12 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// Remove stream subscriptions
 	for _, stream := range request.Streams {
 		delete(conn.Subscriptions, stream)
 	}
 
-	// Remove specific account subscriptions
 	if len(request.Accounts) > 0 {
 		if existing, ok := conn.Subscriptions[types.SubAccounts]; ok {
-			// Remove specific accounts from the subscription
 			accountsToRemove := make(map[string]bool)
 			for _, acc := range request.Accounts {
 				accountsToRemove[acc] = true
@@ -259,7 +253,6 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 		}
 	}
 
-	// Remove book subscriptions
 	if len(request.Books) > 0 {
 		delete(conn.Subscriptions, types.SubOrderBooks)
 	}

--- a/internal/rpc/transaction_entry_test.go
+++ b/internal/rpc/transaction_entry_test.go
@@ -14,9 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Mock helpers for transaction_entry tests
-// =============================================================================
 
 // mockLedgerReaderTE implements types.LedgerReader for transaction_entry tests.
 type mockLedgerReaderTE struct {
@@ -129,9 +127,7 @@ func setupTestServicesTE(mock *mockLedgerServiceTE) func() {
 	}
 }
 
-// =============================================================================
 // Tests
-// =============================================================================
 
 // TestTransactionEntryMissingTxHash tests that missing tx_hash returns an error.
 // Based on rippled TransactionEntry_test.cpp testBadInput (no params case).

--- a/internal/rpc/tx_history_test.go
+++ b/internal/rpc/tx_history_test.go
@@ -12,9 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Mock helpers for tx_history tests
-// =============================================================================
 
 // mockLedgerServiceTxHistory extends mockLedgerService with tx_history-specific behavior.
 type mockLedgerServiceTxHistory struct {
@@ -52,9 +50,7 @@ func setupTestServicesTxHistory(mock *mockLedgerServiceTxHistory) func() {
 	}
 }
 
-// =============================================================================
 // Tests
-// =============================================================================
 
 // TestTxHistoryBasicRequest tests basic request handling with start parameter.
 // Based on rippled TransactionHistory_test.cpp testRequest.

--- a/internal/rpc/tx_test.go
+++ b/internal/rpc/tx_test.go
@@ -75,9 +75,7 @@ func setupTestServicesTx(mock *mockLedgerServiceTx) func() {
 	}
 }
 
-// =============================================================================
 // Transaction Lookup Tests
-// =============================================================================
 
 // TestTxMethodErrorValidation tests error handling for invalid inputs
 // Based on rippled Transaction_test.cpp
@@ -249,7 +247,6 @@ func TestTxMethodErrorValidation(t *testing.T) {
 			// Reset mock state
 			mock.txLookupError = nil
 
-			// Setup mock if needed
 			if tc.setupMock != nil {
 				tc.setupMock()
 			}
@@ -262,7 +259,6 @@ func TestTxMethodErrorValidation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Call the method
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
 			// Verify error response
@@ -508,10 +504,8 @@ func TestTxMethodBinaryOption(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // CTID (Concise Transaction ID) Tests
 // Based on rippled Transaction_test.cpp testCTIDValidation
-// =============================================================================
 
 // EncodeCTID encodes ledger_seq, txn_index, and network_id into a CTID string
 // CTID format: C + ledger_seq (7 hex nibbles) + txn_index (4 hex nibbles) + network_id (4 hex nibbles) = 16 chars total
@@ -1026,10 +1020,8 @@ func TestCTIDFormatValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Range Search Tests
 // Based on rippled Transaction_test.cpp testRangeRequest
-// =============================================================================
 
 // TestTxMethodLedgerRange tests min_ledger and max_ledger parameters
 // Based on rippled Transaction_test.cpp testRangeRequest
@@ -1274,9 +1266,7 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
-// =============================================================================
 // Response Field Tests
-// =============================================================================
 
 // TestTxMethodResponseFields tests that response contains expected fields
 // Based on rippled Transaction_test.cpp testRequest and testBinaryRequest
@@ -1427,9 +1417,7 @@ func TestTxMethodResponseFields(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Service Availability Tests
-// =============================================================================
 
 // TestTxMethodServiceUnavailable tests behavior when ledger service is not available
 func TestTxMethodServiceUnavailable(t *testing.T) {
@@ -1487,9 +1475,7 @@ func TestTxMethodServiceNilLedger(t *testing.T) {
 	assert.Contains(t, rpcErr.Message, "Ledger service not available")
 }
 
-// =============================================================================
 // Method Metadata Tests
-// =============================================================================
 
 // TestTxMethodMetadata tests the method's metadata functions
 func TestTxMethodMetadata(t *testing.T) {
@@ -1508,9 +1494,7 @@ func TestTxMethodMetadata(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // API Version Tests
-// =============================================================================
 
 // TestTxMethodApiVersions tests behavior across different API versions
 // Based on rippled Transaction_test.cpp testRequest with api_version parameter
@@ -1573,10 +1557,8 @@ func TestTxMethodApiVersions(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // CTID Lookup Tests (when implemented)
 // Based on rippled Transaction_test.cpp testCTIDRPC
-// =============================================================================
 
 // TestTxMethodLookupByCTID documents expected CTID lookup behavior
 // Based on rippled Transaction_test.cpp testCTIDRPC
@@ -1666,9 +1648,7 @@ func TestCTIDNetworkIDInResponse(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Edge Cases and Error Conditions
-// =============================================================================
 
 // TestTxMethodEdgeCases tests various edge cases
 func TestTxMethodEdgeCases(t *testing.T) {

--- a/internal/rpc/validators_test.go
+++ b/internal/rpc/validators_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // ValidatorsMethod tests
 // Based on rippled ValidatorRPC_test.cpp
-// =============================================================================
 
 // TestValidatorsResponseStructure tests that the validators method returns
 // the expected response structure with all required fields.
@@ -143,10 +141,8 @@ func TestValidatorsWithParams(t *testing.T) {
 	require.NotNil(t, result, "Should still return a result")
 }
 
-// =============================================================================
 // ValidationCreateMethod tests
 // Based on rippled ValidatorRPC_test.cpp test_validation_create
-// =============================================================================
 
 // TestValidationCreateReturnsKeyPair tests that validation_create returns
 // a response (currently a notImplemented error since it's a stub).
@@ -232,9 +228,7 @@ func TestValidationCreateMethodMetadata(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // ConsensusInfoMethod tests
-// =============================================================================
 
 // TestConsensusInfoResponseStructure tests that consensus_info returns
 // the expected response structure with an "info" field.
@@ -322,9 +316,7 @@ func TestConsensusInfoWithParams(t *testing.T) {
 	require.NotNil(t, result, "Should still return a result")
 }
 
-// =============================================================================
 // StopMethod tests
-// =============================================================================
 
 // TestStopReturnsStoppingMessage tests that the stop method returns
 // the expected "ripple server stopping" message.

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -103,7 +103,6 @@ func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// because the WebSocket connection lives beyond the HTTP request lifecycle
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Create WebSocket connection object
 	wsConn := &WebSocketConnection{
 		ID:            generateConnectionID(),
 		conn:          conn,
@@ -120,7 +119,6 @@ func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ws.connections[wsConn.ID] = wsConn
 	ws.connectionsMutex.Unlock()
 
-	// Add to subscription manager
 	legacyConn := &types.Connection{
 		ID:            wsConn.ID,
 		Subscriptions: wsConn.subscriptions,
@@ -138,7 +136,6 @@ func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 	defer ws.closeConnection(wsConn)
 
-	// Set read limit
 	wsConn.conn.SetReadLimit(512 * 1024) // 512KB max message size
 
 	// Set up pong handler to reset read deadline on pong received
@@ -152,7 +149,6 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 
 	// Read loop - this is blocking and runs until error or close
 	for {
-		// Set read deadline before each read
 		wsConn.conn.SetReadDeadline(time.Now().Add(90 * time.Second))
 
 		// Read message from WebSocket (blocking)
@@ -164,7 +160,6 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 			return
 		}
 
-		// Check if context is cancelled
 		select {
 		case <-wsConn.ctx.Done():
 			return
@@ -260,7 +255,6 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 		cmd.Params = paramsBytes
 	}
 
-	// Create RPC context
 	clientIP := getWebSocketClientIP(wsConn.conn)
 	role := roleForRequest(clientIP, wsConn.portCtx)
 	wsLog().Debug("ws request", "cmd", cmd.Command, "remoteAddr", wsConn.conn.RemoteAddr().String(), "clientIP", clientIP, "role", role, "isAdmin", role == types.RoleAdmin)
@@ -414,7 +408,6 @@ func (ws *WebSocketServer) handlePathFindCreate(wsConn *WebSocketConnection, ctx
 		return
 	}
 
-	// Get ledger view for initial computation
 	view, err := types.Services.Ledger.GetClosedLedgerView()
 	if err != nil {
 		ws.sendError(wsConn, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
@@ -505,7 +498,6 @@ func (ws *WebSocketServer) UpdatePathFindSessions(getView func() (types.LedgerSt
 		return
 	}
 
-	// Get ledger view once for all sessions
 	view, err := getView()
 	if err != nil {
 		wsLog().Error("Failed to get ledger view for path_find updates", "err", err)
@@ -538,24 +530,19 @@ func (ws *WebSocketServer) UpdatePathFindSessions(getView func() (types.LedgerSt
 
 // handleRPCMethod processes regular RPC method calls over WebSocket
 func (ws *WebSocketServer) handleRPCMethod(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
-	// Get method handler
 	handler, exists := ws.methodRegistry.Get(cmd.Command)
 	if !exists {
 		ws.sendError(wsConn, types.RpcErrorMethodNotFound(cmd.Command), cmd.ID)
 		return
 	}
 
-	// Check role permissions
 	if ctx.Role < handler.RequiredRole() {
 		ws.sendError(wsConn, types.NewRpcError(types.RpcCOMMAND_UNTRUSTED, "commandUntrusted", "commandUntrusted",
 			fmt.Sprintf("Command '%s' requires higher privileges", cmd.Command)), cmd.ID)
 		return
 	}
 
-	// Execute method
 	result, rpcErr := handler.Handle(ctx, cmd.Params)
-
-	// Send response
 	if rpcErr != nil {
 		ws.sendError(wsConn, rpcErr, cmd.ID)
 	} else {
@@ -661,12 +648,10 @@ func (ws *WebSocketServer) closeConnection(wsConn *WebSocketConnection) {
 	wsConn.pathFindSession = nil
 	wsConn.mutex.Unlock()
 
-	// Remove from connections map
 	ws.connectionsMutex.Lock()
 	delete(ws.connections, wsConn.ID)
 	ws.connectionsMutex.Unlock()
 
-	// Remove from subscription manager
 	ws.subscriptionManager.RemoveConnection(wsConn.ID)
 
 	// Release per-port connection limiter slot

--- a/internal/testing/account.go
+++ b/internal/testing/account.go
@@ -115,7 +115,6 @@ func NewAccountWithKeyType(name string, keyType string) *Account {
 		panic("failed to generate address: " + err.Error())
 	}
 
-	// Get the account ID (20 bytes)
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(address)
 	if err != nil {
 		panic("failed to decode account ID: " + err.Error())
@@ -198,7 +197,6 @@ func NewAccountFromPassphraseWithKeyType(name, passphrase, keyType string) *Acco
 		panic("failed to generate address: " + err.Error())
 	}
 
-	// Get the account ID (20 bytes)
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(address)
 	if err != nil {
 		panic("failed to decode account ID: " + err.Error())
@@ -310,7 +308,6 @@ func NewAccountFromSeed(name, base58Seed string) *Account {
 		panic("failed to generate address: " + err.Error())
 	}
 
-	// Get the account ID (20 bytes)
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(address)
 	if err != nil {
 		panic("failed to decode account ID: " + err.Error())

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -160,7 +160,6 @@ func NewTestEnv(t *testing.T) *TestEnv {
 		t.Fatalf("Failed to create genesis ledger: %v", err)
 	}
 
-	// Create the ledger from genesis
 	// Note: drops.Fees has unexported fields, so we use a zero value
 	var fees drops.Fees
 	genesisLedger := ledger.FromGenesis(
@@ -170,7 +169,6 @@ func NewTestEnv(t *testing.T) *TestEnv {
 		fees,
 	)
 
-	// Create the first open ledger
 	clock := NewManualClock()
 	openLedger, err := ledger.NewOpen(genesisLedger, clock.Now())
 	if err != nil {

--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -155,12 +155,10 @@ func NewAccountSet(account string) *AccountSet {
 	}
 }
 
-// TxType returns the transaction type
 func (a *AccountSet) TxType() tx.Type {
 	return tx.TypeAccountSet
 }
 
-// Validate validates the AccountSet transaction
 // Reference: rippled SetAccount.cpp preflight()
 func (a *AccountSet) Validate() error {
 	if err := a.BaseTx.Validate(); err != nil {
@@ -265,7 +263,6 @@ func (a *AccountSet) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (a *AccountSet) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(a)
 }
@@ -288,7 +285,6 @@ func (a *AccountSet) EnableDefaultRipple() {
 	a.SetFlag = &flag
 }
 
-// Apply applies the AccountSet transaction to ledger state.
 func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("account set apply",
 		"account", a.Account,

--- a/internal/tx/amm/amm_bid.go
+++ b/internal/tx/amm/amm_bid.go
@@ -42,12 +42,10 @@ func NewAMMBid(account string, asset, asset2 tx.Asset) *AMMBid {
 	}
 }
 
-// TxType returns the transaction type
 func (a *AMMBid) TxType() tx.Type {
 	return tx.TypeAMMBid
 }
 
-// Validate validates the AMMBid transaction
 // Reference: rippled AMMBid.cpp preflight
 func (a *AMMBid) Validate() error {
 	if err := a.BaseTx.Validate(); err != nil {
@@ -104,17 +102,14 @@ func (a *AMMBid) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (a *AMMBid) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(a)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (a *AMMBid) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureAMM, amendment.FeatureFixUniversalNumber}
 }
 
-// Apply applies the AMMBid transaction to ledger state.
 // Reference: rippled AMMBid.cpp applyBid
 func (a *AMMBid) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("amm bid apply",

--- a/internal/tx/amm/amm_clawback.go
+++ b/internal/tx/amm/amm_clawback.go
@@ -40,7 +40,6 @@ func NewAMMClawback(account, holder string, asset, asset2 tx.Asset) *AMMClawback
 	}
 }
 
-// TxType returns the transaction type
 func (a *AMMClawback) TxType() tx.Type {
 	return tx.TypeAMMClawback
 }
@@ -57,7 +56,6 @@ func (a *AMMClawback) GetAMMAsset2() tx.Asset {
 	return a.Asset2
 }
 
-// Validate validates the AMMClawback transaction
 // Reference: rippled AMMClawback.cpp preflight
 func (a *AMMClawback) Validate() error {
 	if err := a.BaseTx.Validate(); err != nil {
@@ -120,18 +118,14 @@ func (a *AMMClawback) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (a *AMMClawback) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(a)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (a *AMMClawback) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureAMM, amendment.FeatureFixUniversalNumber, amendment.FeatureAMMClawback}
 }
 
-// Apply applies the AMMClawback transaction to ledger state.
-//
 // Rippled flow: AMMClawback delegates to AMMWithdraw infrastructure which
 // performs accountSend (AMM -> holder) + redeemIOU (LP tokens), then
 // rippleCredit (holder -> issuer) for the clawback. The net effect for

--- a/internal/tx/amm/amm_create.go
+++ b/internal/tx/amm/amm_create.go
@@ -37,7 +37,6 @@ func NewAMMCreate(account string, amount1, amount2 tx.Amount, tradingFee uint16)
 	}
 }
 
-// TxType returns the transaction type
 func (a *AMMCreate) TxType() tx.Type {
 	return tx.TypeAMMCreate
 }
@@ -54,7 +53,6 @@ func (a *AMMCreate) GetAmount2Asset() tx.Asset {
 	return tx.Asset{Currency: a.Amount2.Currency, Issuer: a.Amount2.Issuer}
 }
 
-// Validate validates the AMMCreate transaction
 // Reference: rippled AMMCreate.cpp preflight
 func (a *AMMCreate) Validate() error {
 	if err := a.BaseTx.Validate(); err != nil {
@@ -90,7 +88,6 @@ func (a *AMMCreate) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (a *AMMCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(a)
 }
@@ -102,12 +99,10 @@ func (a *AMMCreate) CalculateBaseFee(_ tx.LedgerView, config tx.EngineConfig) ui
 	return config.ReserveIncrement
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (a *AMMCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureAMM, amendment.FeatureFixUniversalNumber}
 }
 
-// Apply applies the AMMCreate transaction to ledger state.
 // Reference: rippled AMMCreate.cpp preclaim + doApply/applyCreate
 func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("amm create apply",

--- a/internal/tx/amm/amm_delete.go
+++ b/internal/tx/amm/amm_delete.go
@@ -31,12 +31,10 @@ func NewAMMDelete(account string, asset, asset2 tx.Asset) *AMMDelete {
 	}
 }
 
-// TxType returns the transaction type
 func (a *AMMDelete) TxType() tx.Type {
 	return tx.TypeAMMDelete
 }
 
-// Validate validates the AMMDelete transaction
 // Reference: rippled AMMDelete.cpp preflight
 func (a *AMMDelete) Validate() error {
 	if err := a.BaseTx.Validate(); err != nil {
@@ -60,17 +58,14 @@ func (a *AMMDelete) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (a *AMMDelete) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(a)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (a *AMMDelete) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureAMM, amendment.FeatureFixUniversalNumber}
 }
 
-// Apply applies the AMMDelete transaction to ledger state.
 // Reference: rippled AMMDelete.cpp preclaim + doApply
 func (a *AMMDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("amm delete apply",

--- a/internal/tx/amm/amm_deposit.go
+++ b/internal/tx/amm/amm_deposit.go
@@ -49,7 +49,6 @@ func NewAMMDeposit(account string, asset, asset2 tx.Asset) *AMMDeposit {
 	}
 }
 
-// TxType returns the transaction type
 func (a *AMMDeposit) TxType() tx.Type {
 	return tx.TypeAMMDeposit
 }
@@ -66,7 +65,6 @@ func (a *AMMDeposit) GetAMMAsset2() tx.Asset {
 	return a.Asset2
 }
 
-// Validate validates the AMMDeposit transaction
 // Reference: rippled AMMDeposit.cpp preflight lines 32-162
 func (a *AMMDeposit) Validate() error {
 	if err := a.BaseTx.Validate(); err != nil {
@@ -195,17 +193,14 @@ func (a *AMMDeposit) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (a *AMMDeposit) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(a)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (a *AMMDeposit) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureAMM, amendment.FeatureFixUniversalNumber}
 }
 
-// Apply applies the AMMDeposit transaction to ledger state.
 // Reference: rippled AMMDeposit.cpp preclaim + applyGuts
 func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("amm deposit apply",

--- a/internal/tx/amm/amm_vote.go
+++ b/internal/tx/amm/amm_vote.go
@@ -36,12 +36,10 @@ func NewAMMVote(account string, asset, asset2 tx.Asset, tradingFee uint16) *AMMV
 	}
 }
 
-// TxType returns the transaction type
 func (a *AMMVote) TxType() tx.Type {
 	return tx.TypeAMMVote
 }
 
-// Validate validates the AMMVote transaction
 // Reference: rippled AMMVote.cpp preflight
 func (a *AMMVote) Validate() error {
 	if err := a.BaseTx.Validate(); err != nil {
@@ -67,17 +65,14 @@ func (a *AMMVote) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (a *AMMVote) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(a)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (a *AMMVote) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureAMM, amendment.FeatureFixUniversalNumber}
 }
 
-// Apply applies the AMMVote transaction to ledger state.
 // Reference: rippled AMMVote.cpp applyVote
 func (a *AMMVote) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("amm vote apply",

--- a/internal/tx/amm/amm_withdraw.go
+++ b/internal/tx/amm/amm_withdraw.go
@@ -45,7 +45,6 @@ func NewAMMWithdraw(account string, asset, asset2 tx.Asset) *AMMWithdraw {
 	}
 }
 
-// TxType returns the transaction type
 func (a *AMMWithdraw) TxType() tx.Type {
 	return tx.TypeAMMWithdraw
 }
@@ -62,7 +61,6 @@ func (a *AMMWithdraw) GetAMMAsset2() tx.Asset {
 	return a.Asset2
 }
 
-// Validate validates the AMMWithdraw transaction
 // Reference: rippled AMMWithdraw.cpp preflight
 func (a *AMMWithdraw) Validate() error {
 	if err := a.BaseTx.Validate(); err != nil {
@@ -176,17 +174,14 @@ func (a *AMMWithdraw) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (a *AMMWithdraw) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(a)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (a *AMMWithdraw) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureAMM, amendment.FeatureFixUniversalNumber}
 }
 
-// Apply applies the AMMWithdraw transaction to ledger state.
 // Reference: rippled AMMWithdraw.cpp applyGuts
 func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("amm withdraw apply",

--- a/internal/tx/amm/pool.go
+++ b/internal/tx/amm/pool.go
@@ -62,10 +62,7 @@ func ammAccountHolds(view tx.LedgerView, ammAccountID [20]byte, asset tx.Asset) 
 // ammPoolHolds returns the balances of both assets in the AMM pool.
 // Reference: rippled AMMUtils.cpp ammPoolHolds
 func ammPoolHolds(view tx.LedgerView, ammAccountID [20]byte, asset1, asset2 tx.Asset, fhZeroIfFrozen bool) (tx.Amount, tx.Amount) {
-	// Get balance of first asset
 	balance1 := ammAccountHolds(view, ammAccountID, asset1)
-
-	// Get balance of second asset
 	balance2 := ammAccountHolds(view, ammAccountID, asset2)
 
 	// Check for frozen assets if requested

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -91,7 +91,6 @@ func NewBatch(account string) *Batch {
 	}
 }
 
-// TxType returns the transaction type
 func (b *Batch) TxType() tx.Type {
 	return tx.TypeBatch
 }
@@ -103,7 +102,6 @@ func (b *Batch) InnerTxCount() int {
 	return len(b.RawTransactions)
 }
 
-// Validate validates the Batch transaction
 // Reference: rippled Batch.cpp preflight()
 func (b *Batch) Validate() error {
 	if err := b.BaseTx.Validate(); err != nil {
@@ -174,7 +172,6 @@ func (b *Batch) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields.
 // Inner transactions are flattened to STObject maps via their own Flatten() methods.
 // Reference: rippled stores inner transactions as full STObjects in RawTransactions.
 func (b *Batch) Flatten() (map[string]any, error) {
@@ -253,7 +250,6 @@ func (b *Batch) AddInnerTransaction(innerTx tx.Transaction) {
 	})
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (b *Batch) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureBatch}
 }
@@ -282,7 +278,6 @@ func (b *Batch) GetBatchSigners() []tx.BatchSignerInfo {
 	return result
 }
 
-// Apply applies the Batch transaction to the ledger.
 // It decodes and processes each inner transaction according to the batch mode flag.
 // Reference: rippled apply.cpp applyBatchTransactions()
 func (b *Batch) Apply(ctx *tx.ApplyContext) tx.Result {

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -27,10 +27,8 @@ func makeTestPayment() tx.Transaction {
 	return p
 }
 
-// =============================================================================
 // Batch Validation Tests
 // Based on rippled Batch.cpp
-// =============================================================================
 
 func TestBatchValidation(t *testing.T) {
 	// Helper to create a valid batch with minimum requirements
@@ -275,9 +273,7 @@ func TestBatchValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Flatten Tests
-// =============================================================================
 
 func TestBatchFlatten(t *testing.T) {
 	t.Run("basic batch", func(t *testing.T) {
@@ -320,9 +316,7 @@ func TestBatchFlatten(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Constructor Tests
-// =============================================================================
 
 func TestBatchConstructors(t *testing.T) {
 	t.Run("NewBatch", func(t *testing.T) {
@@ -335,9 +329,7 @@ func TestBatchConstructors(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // AddInnerTransaction Test
-// =============================================================================
 
 func TestBatchAddInnerTransaction(t *testing.T) {
 	b := NewBatch("rOuter")
@@ -352,9 +344,7 @@ func TestBatchAddInnerTransaction(t *testing.T) {
 	assert.Equal(t, tx2, b.RawTransactions[1].RawTransaction.InnerTx)
 }
 
-// =============================================================================
 // Amendment Tests
-// =============================================================================
 
 func TestBatchRequiredAmendments(t *testing.T) {
 	b := NewBatch("rOuter")
@@ -362,9 +352,7 @@ func TestBatchRequiredAmendments(t *testing.T) {
 	assert.Contains(t, amendments, amendment.FeatureBatch)
 }
 
-// =============================================================================
 // Constants Tests
-// =============================================================================
 
 func TestBatchConstants(t *testing.T) {
 	assert.Equal(t, 8, MaxBatchTransactions)

--- a/internal/tx/check/check_cancel.go
+++ b/internal/tx/check/check_cancel.go
@@ -32,7 +32,6 @@ func NewCheckCancel(account, checkID string) *CheckCancel {
 	}
 }
 
-// TxType returns the transaction type
 func (c *CheckCancel) TxType() tx.Type {
 	return tx.TypeCheckCancel
 }
@@ -56,12 +55,10 @@ func (c *CheckCancel) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (c *CheckCancel) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(c)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (c *CheckCancel) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureChecks}
 }

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -38,7 +38,6 @@ func NewCheckCash(account, checkID string) *CheckCash {
 	}
 }
 
-// TxType returns the transaction type
 func (c *CheckCash) TxType() tx.Type {
 	return tx.TypeCheckCash
 }
@@ -91,7 +90,6 @@ func (c *CheckCash) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (c *CheckCash) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(c)
 }
@@ -108,7 +106,6 @@ func (c *CheckCash) SetDeliverMin(amount tx.Amount) {
 	c.Amount = nil
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (c *CheckCash) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureChecks}
 }

--- a/internal/tx/check/check_create.go
+++ b/internal/tx/check/check_create.go
@@ -41,7 +41,6 @@ func NewCheckCreate(account, destination string, sendMax tx.Amount) *CheckCreate
 	}
 }
 
-// TxType returns the transaction type
 func (c *CheckCreate) TxType() tx.Type {
 	return tx.TypeCheckCreate
 }
@@ -87,12 +86,10 @@ func (c *CheckCreate) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (c *CheckCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(c)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (c *CheckCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureChecks}
 }

--- a/internal/tx/clawback/clawback.go
+++ b/internal/tx/clawback/clawback.go
@@ -217,17 +217,14 @@ func (c *Clawback) applyMPT(ctx *tx.ApplyContext) tx.Result {
 		actual = requested
 	}
 
-	// Decrement holder's balance
 	token.MPTAmount -= actual
 
-	// Decrement issuance outstanding amount
 	if issuance.OutstandingAmount >= actual {
 		issuance.OutstandingAmount -= actual
 	} else {
 		issuance.OutstandingAmount = 0
 	}
 
-	// Serialize and update MPToken
 	updatedToken, err := state.SerializeMPToken(token)
 	if err != nil {
 		return tx.TefINTERNAL
@@ -236,7 +233,6 @@ func (c *Clawback) applyMPT(ctx *tx.ApplyContext) tx.Result {
 		return tx.TefINTERNAL
 	}
 
-	// Serialize and update issuance
 	updatedIssuance, err := state.SerializeMPTokenIssuance(issuance)
 	if err != nil {
 		return tx.TefINTERNAL
@@ -412,7 +408,6 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 		highDirKey := keylet.OwnerDir(highAccountID)
 		state.DirRemove(ctx.View, highDirKey, rs.HighNode, trustKey.Key, false)
 
-		// Delete the trust line
 		if err := ctx.View.Erase(trustKey); err != nil {
 			return tx.TefINTERNAL
 		}
@@ -425,7 +420,6 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 			holderAccount.OwnerCount--
 		}
 
-		// Write holder account back to ledger
 		if result := ctx.UpdateAccountRoot(holderID, holderAccount); result != tx.TesSUCCESS {
 			return result
 		}
@@ -442,7 +436,6 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 			rs.Flags &^= state.LsfHighReserve
 		}
 
-		// Serialize and update trust line
 		updatedData, serErr := state.SerializeRippleState(rs)
 		if serErr != nil {
 			return tx.TefINTERNAL

--- a/internal/tx/clawback/clawback.go
+++ b/internal/tx/clawback/clawback.go
@@ -60,12 +60,10 @@ func NewMPTokenClawback(account, holder, issuanceID string, amount state.Amount)
 	}
 }
 
-// TxType returns the transaction type
 func (c *Clawback) TxType() tx.Type {
 	return tx.TypeClawback
 }
 
-// Validate validates the Clawback transaction
 // Reference: rippled Clawback.cpp preflight()
 func (c *Clawback) Validate() error {
 	if err := c.BaseTx.Validate(); err != nil {
@@ -127,7 +125,6 @@ func (c *Clawback) Validate() error {
 	return nil
 }
 
-// Apply applies the Clawback transaction to ledger state.
 // Reference: rippled Clawback.cpp preclaim() + applyHelper<Issue>() / applyHelper<MPTIssue>()
 func (c *Clawback) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("clawback apply",
@@ -454,12 +451,10 @@ func (c *Clawback) ClawbackAmount() tx.Amount {
 	return c.Amount
 }
 
-// Flatten returns a flat map of all transaction fields
 func (c *Clawback) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(c)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type.
 // Only require FeatureMPTokensV1 when the Amount actually holds an MPT issue,
 // matching rippled's dispatch which checks the Amount type, not the Holder field.
 // Reference: rippled Clawback.cpp:90-94 dispatches preflightHelper<MPTIssue>

--- a/internal/tx/clawback/clawback_test.go
+++ b/internal/tx/clawback/clawback_test.go
@@ -10,10 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // Clawback Validation Tests
 // Based on rippled Clawback_test.cpp
-// =============================================================================
 
 func TestClawbackValidation(t *testing.T) {
 	tests := []struct {
@@ -132,9 +130,7 @@ func TestClawbackValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Flatten Tests
-// =============================================================================
 
 func TestClawbackFlatten(t *testing.T) {
 	t.Run("IOU clawback", func(t *testing.T) {
@@ -171,9 +167,7 @@ func TestClawbackFlatten(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Constructor Tests
-// =============================================================================
 
 func TestClawbackConstructors(t *testing.T) {
 	t.Run("NewClawback (IOU)", func(t *testing.T) {
@@ -195,9 +189,7 @@ func TestClawbackConstructors(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Amendment Tests
-// =============================================================================
 
 func TestClawbackRequiredAmendments(t *testing.T) {
 	t.Run("IOU clawback requires Clawback amendment", func(t *testing.T) {
@@ -215,9 +207,7 @@ func TestClawbackRequiredAmendments(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Transaction Type Tests
-// =============================================================================
 
 func TestClawbackTransactionType(t *testing.T) {
 	clawbackTx := &Clawback{}

--- a/internal/tx/credential/credential.go
+++ b/internal/tx/credential/credential.go
@@ -35,12 +35,10 @@ func NewCredentialAccept(account, issuer, credentialType string) *CredentialAcce
 	}
 }
 
-// TxType returns the transaction type
 func (c *CredentialAccept) TxType() tx.Type {
 	return tx.TypeCredentialAccept
 }
 
-// Validate validates the CredentialAccept transaction
 // Reference: rippled Credentials.cpp CredentialAccept::preflight()
 // Note: The fixInvalidTxFlags-gated flag check is done in Apply() because
 // Validate() has no access to amendment rules.
@@ -83,12 +81,10 @@ func (c *CredentialAccept) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (c *CredentialAccept) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(c)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (c *CredentialAccept) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureCredentials}
 }
@@ -136,7 +132,6 @@ func (c *CredentialAccept) ApplyOnTec(ctx *tx.ApplyContext) tx.Result {
 	return tx.TesSUCCESS
 }
 
-// Apply applies the CredentialAccept transaction to ledger state.
 // Reference: rippled Credentials.cpp CredentialAccept::doApply()
 func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Check for invalid flags, gated behind fixInvalidTxFlags

--- a/internal/tx/credential/credential.go
+++ b/internal/tx/credential/credential.go
@@ -194,14 +194,12 @@ func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TefINTERNAL
 	}
 
-	// Check if already accepted
 	if cred.IsAccepted() {
 		ctx.Log.Warn("credential accept: credential already accepted",
 			"subject", c.Account, "issuer", c.Issuer, "credentialType", c.CredentialType)
 		return tx.TecDUPLICATE
 	}
 
-	// Check if credential is expired
 	closeTime := ctx.Config.ParentCloseTime
 	if CheckCredentialExpired(cred, closeTime) {
 		// Delete expired credentials even if the transaction failed
@@ -232,7 +230,6 @@ func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecINSUFFICIENT_RESERVE
 	}
 
-	// Set accepted flag
 	cred.SetAccepted()
 
 	// Serialize and update the credential

--- a/internal/tx/credential/credential_create.go
+++ b/internal/tx/credential/credential_create.go
@@ -185,19 +185,16 @@ func (c *CredentialCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecINSUFFICIENT_RESERVE
 	}
 
-	// Create the credential entry
 	cred := &CredentialEntry{
 		Subject:        subjectID,
 		Issuer:         ctx.AccountID,
 		CredentialType: credTypeBytes,
 	}
 
-	// Set expiration if provided
 	if c.Expiration != nil {
 		cred.Expiration = c.Expiration
 	}
 
-	// Set URI if provided
 	if c.URI != "" {
 		uriBytes, err := hex.DecodeString(c.URI)
 		if err == nil {

--- a/internal/tx/credential/credential_create.go
+++ b/internal/tx/credential/credential_create.go
@@ -42,12 +42,10 @@ func NewCredentialCreate(account, subject, credentialType string) *CredentialCre
 	}
 }
 
-// TxType returns the transaction type
 func (c *CredentialCreate) TxType() tx.Type {
 	return tx.TypeCredentialCreate
 }
 
-// Validate validates the CredentialCreate transaction
 // Reference: rippled Credentials.cpp CredentialCreate::preflight()
 // Note: The fixInvalidTxFlags-gated flag check is done in Apply() because
 // Validate() has no access to amendment rules.
@@ -106,17 +104,14 @@ func (c *CredentialCreate) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (c *CredentialCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(c)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (c *CredentialCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureCredentials}
 }
 
-// Apply applies the CredentialCreate transaction to ledger state.
 // Reference: rippled Credentials.cpp CredentialCreate::doApply()
 func (c *CredentialCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Check for invalid flags, gated behind fixInvalidTxFlags

--- a/internal/tx/credential/credential_delete.go
+++ b/internal/tx/credential/credential_delete.go
@@ -37,12 +37,10 @@ func NewCredentialDelete(account, credentialType string) *CredentialDelete {
 	}
 }
 
-// TxType returns the transaction type
 func (c *CredentialDelete) TxType() tx.Type {
 	return tx.TypeCredentialDelete
 }
 
-// Validate validates the CredentialDelete transaction
 // Reference: rippled Credentials.cpp CredentialDelete::preflight()
 // Note: The fixInvalidTxFlags-gated flag check is done in Apply() because
 // Validate() has no access to amendment rules.
@@ -102,17 +100,14 @@ func (c *CredentialDelete) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (c *CredentialDelete) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(c)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (c *CredentialDelete) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureCredentials}
 }
 
-// Apply applies the CredentialDelete transaction to ledger state.
 // Reference: rippled Credentials.cpp CredentialDelete::doApply()
 func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Check for invalid flags, gated behind fixInvalidTxFlags

--- a/internal/tx/credential/credential_delete.go
+++ b/internal/tx/credential/credential_delete.go
@@ -188,7 +188,6 @@ func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecNO_PERMISSION
 	}
 
-	// Remove from issuer's owner directory
 	issuerDirKey := keylet.OwnerDir(issuerID)
 	state.DirRemove(ctx.View, issuerDirKey, cred.IssuerNode, credKeylet.Key, false)
 
@@ -198,7 +197,6 @@ func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		state.DirRemove(ctx.View, subjectDirKey, cred.SubjectNode, credKeylet.Key, false)
 	}
 
-	// Delete the credential
 	if err := ctx.View.Erase(credKeylet); err != nil {
 		return tx.TefINTERNAL
 	}

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -149,53 +149,43 @@ func serializeCredentialEntry(cred *CredentialEntry) ([]byte, error) {
 		"LedgerEntryType": "Credential",
 	}
 
-	// Add Subject
 	subjectStr, err := state.EncodeAccountID(cred.Subject)
 	if err == nil && subjectStr != "" {
 		jsonObj["Subject"] = subjectStr
 	}
 
-	// Add Issuer
 	issuerStr, err := state.EncodeAccountID(cred.Issuer)
 	if err == nil && issuerStr != "" {
 		jsonObj["Issuer"] = issuerStr
 	}
 
-	// Add CredentialType (hex-encoded)
 	if len(cred.CredentialType) > 0 {
 		jsonObj["CredentialType"] = hex.EncodeToString(cred.CredentialType)
 	}
 
-	// Add Expiration (optional)
 	if cred.Expiration != nil {
 		jsonObj["Expiration"] = *cred.Expiration
 	}
 
-	// Add URI (optional, hex-encoded)
 	if len(cred.URI) > 0 {
 		jsonObj["URI"] = hex.EncodeToString(cred.URI)
 	}
 
-	// Add Flags
 	if cred.Flags != 0 {
 		jsonObj["Flags"] = cred.Flags
 	}
 
-	// Add IssuerNode
 	jsonObj["IssuerNode"] = tx.FormatUint64Hex(cred.IssuerNode)
 
-	// Add SubjectNode (if subject != issuer)
 	if cred.Subject != cred.Issuer {
 		jsonObj["SubjectNode"] = tx.FormatUint64Hex(cred.SubjectNode)
 	}
 
-	// Add PreviousTxnID
 	var zeroHash [32]byte
 	if cred.PreviousTxnID != zeroHash {
 		jsonObj["PreviousTxnID"] = hex.EncodeToString(cred.PreviousTxnID[:])
 	}
 
-	// Add PreviousTxnLgrSeq
 	if cred.PreviousTxnLgrSeq > 0 {
 		jsonObj["PreviousTxnLgrSeq"] = cred.PreviousTxnLgrSeq
 	}
@@ -221,7 +211,6 @@ func CheckCredentialExpired(cred *CredentialEntry, closeTime uint32) bool {
 // issuer's and subject's owner directories and adjusting owner counts.
 // Reference: rippled CredentialHelpers.cpp credentials::deleteSLE()
 func DeleteSLE(view tx.LedgerView, credKey keylet.Keylet, cred *CredentialEntry) error {
-	// Remove from issuer's owner directory
 	issuerDirKey := keylet.OwnerDir(cred.Issuer)
 	_, err := state.DirRemove(view, issuerDirKey, cred.IssuerNode, credKey.Key, false)
 	if err != nil {

--- a/internal/tx/delegate/delegate_set.go
+++ b/internal/tx/delegate/delegate_set.go
@@ -72,12 +72,10 @@ func NewDelegateSet(account string) *DelegateSet {
 	}
 }
 
-// TxType returns the transaction type
 func (d *DelegateSet) TxType() tx.Type {
 	return tx.TypeDelegateSet
 }
 
-// Validate validates the DelegateSet transaction.
 // Reference: rippled DelegateSet.cpp preflight()
 func (d *DelegateSet) Validate() error {
 	if err := d.BaseTx.Validate(); err != nil {
@@ -113,7 +111,6 @@ func (d *DelegateSet) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields.
 // Custom implementation to properly format Permissions as:
 //
 //	[{"Permission": {"PermissionValue": <uint32>}}, ...]
@@ -143,12 +140,10 @@ func (d *DelegateSet) Flatten() (map[string]any, error) {
 	return m, nil
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (d *DelegateSet) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePermissionDelegation}
 }
 
-// Apply applies the DelegateSet transaction to the ledger.
 // Reference: rippled DelegateSet.cpp preclaim() + doApply()
 func (d *DelegateSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("delegate set apply",

--- a/internal/tx/delegate/delegate_set.go
+++ b/internal/tx/delegate/delegate_set.go
@@ -178,7 +178,6 @@ func (d *DelegateSet) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	delegateKey := keylet.DelegateKeylet(ctx.AccountID, authorizeID)
 
-	// Check if delegate SLE already exists
 	existingData, readErr := ctx.View.Read(delegateKey)
 	if readErr == nil && existingData != nil {
 		// Delegate SLE exists -- update or delete
@@ -222,7 +221,6 @@ func (d *DelegateSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecINSUFFICIENT_RESERVE
 	}
 
-	// Create the delegate SLE
 	delegateData, serErr := state.SerializeDelegate(ctx.AccountID, authorizeID, permValues, 0)
 	if serErr != nil {
 		return tx.TefINTERNAL
@@ -270,7 +268,6 @@ func deleteDelegate(ctx *tx.ApplyContext, delegateKey keylet.Keylet, account [20
 		return tx.TefINTERNAL
 	}
 
-	// Remove from owner directory
 	ownerDirKey := keylet.OwnerDir(account)
 	state.DirRemove(ctx.View, ownerDirKey, existingEntry.OwnerNode, delegateKey.Key, false)
 

--- a/internal/tx/depositpreauth/depositpreauth.go
+++ b/internal/tx/depositpreauth/depositpreauth.go
@@ -74,12 +74,10 @@ func NewDepositPreauth(account string) *DepositPreauth {
 	}
 }
 
-// TxType returns the transaction type
 func (d *DepositPreauth) TxType() tx.Type {
 	return tx.TypeDepositPreauth
 }
 
-// RequiredAmendments returns the amendments required for this transaction type.
 // Reference: rippled DepositPreauth::preflight() amendment checks
 func (d *DepositPreauth) RequiredAmendments() [][32]byte {
 	amendments := [][32]byte{amendment.FeatureDepositPreauth}
@@ -89,7 +87,6 @@ func (d *DepositPreauth) RequiredAmendments() [][32]byte {
 	return amendments
 }
 
-// Validate validates the DepositPreauth transaction fields.
 // Reference: rippled DepositPreauth::preflight()
 func (d *DepositPreauth) Validate() error {
 	if err := d.BaseTx.Validate(); err != nil {
@@ -195,7 +192,6 @@ func checkCredentialArray(creds []CredentialWrapper) error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (d *DepositPreauth) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(d)
 }
@@ -268,7 +264,6 @@ func toKeyletPairs(pairs []sortedCredPair) []keylet.CredentialPair {
 	return result
 }
 
-// Apply applies the DepositPreauth transaction to ledger state.
 // Combines preclaim checks and doApply logic.
 // Reference: rippled DepositPreauth::preclaim() + DepositPreauth::doApply()
 func (d *DepositPreauth) Apply(ctx *tx.ApplyContext) tx.Result {

--- a/internal/tx/depositpreauth/depositpreauth.go
+++ b/internal/tx/depositpreauth/depositpreauth.go
@@ -352,7 +352,6 @@ func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecDIR_FULL
 	}
 
-	// Update OwnerNode on the preauth entry
 	if dirResult.Page != 0 {
 		if err := updateOwnerNode(ctx, preauthKey, dirResult.Page); err != nil {
 			ctx.Log.Error("deposit preauth authorize: failed to update owner node", "error", err)
@@ -508,7 +507,6 @@ func removeFromLedger(ctx *tx.ApplyContext, preauthKey keylet.Keylet) tx.Result 
 	}
 	// If parsing fails, default to page 0 which handles the common case
 
-	// Remove from owner directory
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
 	_, err = state.DirRemove(ctx.View, ownerDirKey, ownerNode, preauthKey.Key, false)
 	if err != nil {
@@ -522,7 +520,6 @@ func removeFromLedger(ctx *tx.ApplyContext, preauthKey keylet.Keylet) tx.Result 
 		return tx.TefINTERNAL
 	}
 
-	// Decrement owner count
 	if ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}

--- a/internal/tx/did/did_delete.go
+++ b/internal/tx/did/did_delete.go
@@ -19,19 +19,16 @@ type DIDDelete struct {
 	tx.BaseTx
 }
 
-// NewDIDDelete creates a new DIDDelete transaction
 func NewDIDDelete(account string) *DIDDelete {
 	return &DIDDelete{
 		BaseTx: *tx.NewBaseTx(tx.TypeDIDDelete, account),
 	}
 }
 
-// TxType returns the transaction type
 func (d *DIDDelete) TxType() tx.Type {
 	return tx.TypeDIDDelete
 }
 
-// Validate validates the DIDDelete transaction
 // Reference: rippled DID.cpp DIDDelete::preflight
 func (d *DIDDelete) Validate() error {
 	if err := d.BaseTx.Validate(); err != nil {
@@ -46,17 +43,14 @@ func (d *DIDDelete) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (d *DIDDelete) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(d)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (d *DIDDelete) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureDID}
 }
 
-// Apply applies a DIDDelete transaction to the ledger state.
 // Reference: rippled DID.cpp DIDDelete::doApply
 func (d *DIDDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("did delete apply",
@@ -75,7 +69,6 @@ func (d *DIDDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
 	state.DirRemove(ctx.View, ownerDirKey, 0, didKey.Key, true)
 
-	// Delete the DID entry
 	if err := ctx.View.Erase(didKey); err != nil {
 		ctx.Log.Error("did delete: unable to delete DID from owner")
 		return tx.TefINTERNAL

--- a/internal/tx/did/did_set.go
+++ b/internal/tx/did/did_set.go
@@ -29,19 +29,16 @@ type DIDSet struct {
 	URI string `json:"URI,omitempty" xrpl:"URI,omitempty"`
 }
 
-// NewDIDSet creates a new DIDSet transaction
 func NewDIDSet(account string) *DIDSet {
 	return &DIDSet{
 		BaseTx: *tx.NewBaseTx(tx.TypeDIDSet, account),
 	}
 }
 
-// TxType returns the transaction type
 func (d *DIDSet) TxType() tx.Type {
 	return tx.TypeDIDSet
 }
 
-// Validate validates the DIDSet transaction
 // Reference: rippled DID.cpp DIDSet::preflight
 func (d *DIDSet) Validate() error {
 	if err := d.BaseTx.Validate(); err != nil {
@@ -108,17 +105,14 @@ func (d *DIDSet) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (d *DIDSet) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(d)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (d *DIDSet) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureDID}
 }
 
-// Apply applies a DIDSet transaction to the ledger state.
 // Reference: rippled DID.cpp DIDSet::doApply
 func (d *DIDSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("did set apply",
@@ -128,10 +122,8 @@ func (d *DIDSet) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	didKey := keylet.DID(ctx.AccountID)
 
-	// Check if DID already exist
 	existingData, err := ctx.View.Read(didKey)
 	if err == nil && existingData != nil {
-		// Update existing DID
 		did, err := state.ParseDID(existingData)
 		if err != nil {
 			return tx.TefINTERNAL
@@ -174,7 +166,6 @@ func (d *DIDSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TesSUCCESS
 	}
 
-	// Create new DID
 	reserve := ctx.AccountReserve(ctx.Account.OwnerCount + 1)
 	if ctx.Account.Balance < reserve {
 		return tx.TecINSUFFICIENT_RESERVE

--- a/internal/tx/engine.go
+++ b/internal/tx/engine.go
@@ -1575,7 +1575,6 @@ func (e *Engine) checkBatchSign(signers []BatchSignerInfo) Result {
 			return TefBAD_AUTH
 		}
 
-		// Read the signer's account root
 		signerAccountKey := keylet.Account(signerAccountID)
 		signerAccountData, readErr := e.view.Read(signerAccountKey)
 
@@ -1617,7 +1616,6 @@ func (e *Engine) checkBatchSign(signers []BatchSignerInfo) Result {
 // the account's SignerList. This mirrors rippled's checkMultiSign.
 // Reference: rippled Transactor::checkMultiSign in Transactor.cpp lines 742-911
 func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo) Result {
-	// Read the account's SignerList
 	signerListKey := keylet.SignerList(accountID)
 	signerListData, err := e.view.Read(signerListKey)
 	if err != nil || signerListData == nil {
@@ -1666,7 +1664,6 @@ func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo)
 			signingAcctIDFromPubKey = addr
 		}
 
-		// Read the signer's account root
 		signerAccountKey := keylet.Account(txSignerAccountID)
 		signerAccountData, readErr := e.view.Read(signerAccountKey)
 
@@ -2045,7 +2042,6 @@ func (e *Engine) doApply(tx Transaction, metadata *Metadata, txHash [32]byte) Re
 				if decodeErr != nil {
 					continue
 				}
-				// Remove from both owner directories
 				lowDirKey := keylet.OwnerDir(lowID)
 				state.DirRemove(tecTable, lowDirKey, rs.LowNode, lineKey, false)
 				highDirKey := keylet.OwnerDir(highID)
@@ -2165,15 +2161,11 @@ func (e *Engine) doApply(tx Transaction, metadata *Metadata, txHash [32]byte) Re
 				if decodeErr != nil {
 					continue
 				}
-				// Remove from owner directory
 				ownerDirKey := keylet.OwnerDir(ownerID)
 				state.DirRemove(tecTable, ownerDirKey, offerObj.OwnerNode, offerKey, false)
-				// Remove from book directory
 				bookDirKey := keylet.Keylet{Type: 100, Key: offerObj.BookDirectory}
 				state.DirRemove(tecTable, bookDirKey, offerObj.BookNode, offerKey, false)
-				// Erase the offer
 				_ = tecTable.Erase(offerKL)
-				// Decrement owner count
 				adjustOwnerCountOnView(tecTable, ownerID, -1, txHash, e.config.LedgerSequence)
 			}
 		}
@@ -2448,7 +2440,6 @@ func deleteNFTokenOfferOnView(view LedgerView, offerKL keylet.Keylet, txHash [32
 		return
 	}
 
-	// Remove from owner's directory
 	ownerDirKey := keylet.OwnerDir(offer.Owner)
 	state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKL.Key, false)
 
@@ -2463,9 +2454,6 @@ func deleteNFTokenOfferOnView(view LedgerView, offerKL keylet.Keylet, txHash [32
 	}
 	state.DirRemove(view, tokenDirKey, offer.NFTokenOfferNode, offerKL.Key, false)
 
-	// Erase the offer
 	_ = view.Erase(offerKL)
-
-	// Decrement owner count
 	adjustOwnerCountOnView(view, offer.Owner, -1, txHash, ledgerSeq)
 }

--- a/internal/tx/escrow/escrow_cancel.go
+++ b/internal/tx/escrow/escrow_cancel.go
@@ -24,7 +24,6 @@ type EscrowCancel struct {
 	OfferSequence uint32 `json:"OfferSequence" xrpl:"OfferSequence"`
 }
 
-// NewEscrowCancel creates a new EscrowCancel transaction
 func NewEscrowCancel(account, owner string, offerSequence uint32) *EscrowCancel {
 	return &EscrowCancel{
 		BaseTx:        *tx.NewBaseTx(tx.TypeEscrowCancel, account),
@@ -33,19 +32,16 @@ func NewEscrowCancel(account, owner string, offerSequence uint32) *EscrowCancel 
 	}
 }
 
-// TxType returns the transaction type
 func (e *EscrowCancel) TxType() tx.Type {
 	return tx.TypeEscrowCancel
 }
 
-// Validate validates the EscrowCancel transaction
 // Reference: rippled Escrow.cpp EscrowCancel::preflight()
 func (e *EscrowCancel) Validate() error {
 	if err := e.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check for invalid flags
 	if err := tx.CheckFlags(e.GetFlags(), tx.TfUniversalMask); err != nil {
 		return err
 	}
@@ -57,7 +53,6 @@ func (e *EscrowCancel) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (e *EscrowCancel) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(e)
 }
@@ -73,7 +68,6 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	rules := ctx.Rules()
 
-	// Get the escrow owner's account ID
 	ownerID, err := state.DecodeAccountID(e.Owner)
 	if err != nil {
 		return tx.TemINVALID

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -15,7 +15,7 @@ import (
 
 // maxMPTokenAmount is the maximum MPT value (int64 max).
 // Reference: rippled include/xrpl/protocol/STAmount.h maxMPTokenAmount
-const maxMPTokenAmount int64 = 0x7FFFFFFFFFFFFFFF // 9223372036854775807
+const maxMPTokenAmount int64 = 0x7FFFFFFFFFFFFFFF
 
 func init() {
 	tx.Register(tx.TypeEscrowCreate, func() tx.Transaction {
@@ -47,7 +47,6 @@ type EscrowCreate struct {
 	Condition *string `json:"Condition,omitempty" xrpl:"Condition,omitempty"`
 }
 
-// NewEscrowCreate creates a new EscrowCreate transaction
 func NewEscrowCreate(account, destination string, amount tx.Amount) *EscrowCreate {
 	return &EscrowCreate{
 		BaseTx:      *tx.NewBaseTx(tx.TypeEscrowCreate, account),
@@ -56,19 +55,16 @@ func NewEscrowCreate(account, destination string, amount tx.Amount) *EscrowCreat
 	}
 }
 
-// TxType returns the transaction type
 func (e *EscrowCreate) TxType() tx.Type {
 	return tx.TypeEscrowCreate
 }
 
-// Validate validates the EscrowCreate transaction
 // Reference: rippled Escrow.cpp EscrowCreate::preflight()
 func (e *EscrowCreate) Validate() error {
 	if err := e.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check for invalid flags
 	// Reference: rippled Escrow.cpp preflight() fix1543 flag check
 	if err := tx.CheckFlags(e.GetFlags(), tx.TfUniversalMask); err != nil {
 		return err
@@ -134,7 +130,6 @@ func (e *EscrowCreate) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (e *EscrowCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(e)
 }
@@ -297,7 +292,6 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Create the escrow entry
 	accountID, _ := state.DecodeAccountID(e.Account)
 	sequence := e.GetCommon().SeqProxy()
 

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -42,7 +42,6 @@ type EscrowFinish struct {
 	CredentialIDs []string `json:"CredentialIDs,omitempty" xrpl:"CredentialIDs,omitempty"`
 }
 
-// NewEscrowFinish creates a new EscrowFinish transaction
 func NewEscrowFinish(account, owner string, offerSequence uint32) *EscrowFinish {
 	return &EscrowFinish{
 		BaseTx:        *tx.NewBaseTx(tx.TypeEscrowFinish, account),
@@ -51,19 +50,16 @@ func NewEscrowFinish(account, owner string, offerSequence uint32) *EscrowFinish 
 	}
 }
 
-// TxType returns the transaction type
 func (e *EscrowFinish) TxType() tx.Type {
 	return tx.TypeEscrowFinish
 }
 
-// Validate validates the EscrowFinish transaction
 // Reference: rippled Escrow.cpp EscrowFinish::preflight()
 func (e *EscrowFinish) Validate() error {
 	if err := e.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check for invalid flags
 	if err := tx.CheckFlags(e.GetFlags(), tx.TfUniversalMask); err != nil {
 		return err
 	}
@@ -101,7 +97,6 @@ func (e *EscrowFinish) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (e *EscrowFinish) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(e)
 }
@@ -143,7 +138,6 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Get the escrow owner's account ID
 	ownerID, err := state.DecodeAccountID(e.Owner)
 	if err != nil {
 		return tx.TemINVALID
@@ -334,7 +328,6 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 			// Reference: rippled Escrow.cpp escrowUnlockApplyHelper<MPTIssue> lines 944-1012
 			mptHexID := escrowEntry.MPTIssuanceID
 
-			// Get the raw amount
 			var originalAmount uint64
 			if escrowEntry.MPTAmount != nil {
 				originalAmount = uint64(*escrowEntry.MPTAmount)

--- a/internal/tx/escrow/token_helpers.go
+++ b/internal/tx/escrow/token_helpers.go
@@ -22,9 +22,7 @@ import (
 // parityRate is the identity transfer rate (no fee). Matches rippled's parityRate.
 const parityRate uint32 = 1_000_000_000
 
-// ---------------------------------------------------------------------------
 // 1. EscrowCreate Preclaim Helpers
-// ---------------------------------------------------------------------------
 
 // escrowCreatePreclaimIOU validates IOU escrow creation preconditions.
 // Reference: rippled Escrow.cpp escrowCreatePreclaimHelper<Issue> lines 204-279
@@ -201,9 +199,7 @@ func escrowCreatePreclaimMPT(view tx.LedgerView, rules *amendment.Rules, account
 	return tx.TesSUCCESS
 }
 
-// ---------------------------------------------------------------------------
 // 2. EscrowFinish Preclaim Helpers
-// ---------------------------------------------------------------------------
 
 // escrowFinishPreclaimIOU validates IOU escrow finish preconditions.
 // Reference: rippled Escrow.cpp lines 702-724
@@ -274,9 +270,7 @@ func escrowFinishPreclaimMPT(view tx.LedgerView, destID [20]byte, amount tx.Amou
 	return tx.TesSUCCESS
 }
 
-// ---------------------------------------------------------------------------
 // 3. EscrowCancel Preclaim Helpers
-// ---------------------------------------------------------------------------
 
 // escrowCancelPreclaimIOU validates IOU escrow cancel preconditions.
 // Reference: rippled Escrow.cpp lines 1219-1237
@@ -337,9 +331,7 @@ func escrowCancelPreclaimMPT(view tx.LedgerView, accountID [20]byte, amount tx.A
 	return tx.TesSUCCESS
 }
 
-// ---------------------------------------------------------------------------
 // 4. Lock Helpers
-// ---------------------------------------------------------------------------
 
 // escrowLockMPT locks MPT tokens by decreasing sender's MPTAmount and increasing
 // LockedAmount on both the MPToken and MPTIssuance.
@@ -430,9 +422,7 @@ func escrowLockMPT(view tx.LedgerView, senderID [20]byte, amount tx.Amount) tx.R
 	return tx.TesSUCCESS
 }
 
-// ---------------------------------------------------------------------------
 // 5. Unlock Helpers
-// ---------------------------------------------------------------------------
 
 // escrowUnlockIOU unlocks IOU tokens during EscrowFinish or EscrowCancel.
 // Handles trust line creation, transfer fee calculation, limit checking,
@@ -469,14 +459,11 @@ func escrowUnlockIOU(
 		return tx.TesSUCCESS
 	}
 
-	// Check if trust line exists
 	trustLineKey := keylet.Line(receiverID, issuerID, amount.Currency)
 	trustLineData, err := view.Read(trustLineKey)
 	trustLineExists := err == nil && trustLineData != nil
 
-	// Create trust line if needed
 	if !trustLineExists && createAsset && !receiverIsIssuer {
-		// Check reserve
 		reserve := reserveBase + uint64(destOwnerCount+1)*reserveIncrement
 		if destBalance < reserve {
 			return tx.TecNO_LINE_INSUF_RESERVE
@@ -587,7 +574,6 @@ func escrowUnlockMPT(
 		receiverExists, _ := view.Exists(receiverTokenKey)
 
 		if !receiverExists && createAsset {
-			// Check reserve
 			reserve := reserveBase + uint64(destOwnerCount+1)*reserveIncrement
 			if destBalance < reserve {
 				return tx.TecINSUFFICIENT_RESERVE
@@ -713,9 +699,7 @@ func escrowUnlockMPT(
 	return tx.TesSUCCESS
 }
 
-// ---------------------------------------------------------------------------
 // 6. Shared Utilities
-// ---------------------------------------------------------------------------
 
 // requireAuthIOU checks if an issuer requires authorization and if the account
 // is authorized on the trust line.
@@ -934,9 +918,7 @@ func mptIssuerFromIssuanceID(hexID string) string {
 	return addr
 }
 
-// ---------------------------------------------------------------------------
 // 7. Trust Line Helpers for Unlock
-// ---------------------------------------------------------------------------
 
 // createTrustLineForEscrow creates a zero-balance trust line between issuer and
 // receiver for escrow unlock. Matches rippled's trustCreate pattern.
@@ -1136,7 +1118,6 @@ func checkTrustLineLimit(view tx.LedgerView, receiverID, issuerID [20]byte, curr
 		lineBalance = lineBalance.Negate()
 	}
 
-	// Add the final amount to the balance
 	newBalance, err := lineBalance.Add(finalAmount)
 	if err != nil {
 		return tx.TefINTERNAL
@@ -1206,15 +1187,12 @@ func createMPTokenForEscrow(
 		return tx.TecDIR_FULL
 	}
 
-	// Increment owner count for the destination
 	adjustOwnerCountViaView(view, destID, 1)
 
 	return tx.TesSUCCESS
 }
 
-// ---------------------------------------------------------------------------
 // Internal helpers
-// ---------------------------------------------------------------------------
 
 // readAccountRoot reads and parses an AccountRoot from the ledger.
 func readAccountRoot(view tx.LedgerView, accountID [20]byte) (*state.AccountRoot, error) {
@@ -1230,7 +1208,6 @@ func readAccountRoot(view tx.LedgerView, accountID [20]byte) (*state.AccountRoot
 // Checks global freeze on issuer + individual freeze on trust line.
 // Reference: rippled View.cpp isFrozen(view, account, currency, issuer)
 func isFrozenIOU(view tx.LedgerView, accountID, issuerID [20]byte, currency string) bool {
-	// Check global freeze
 	issuerAccount, err := readAccountRoot(view, issuerID)
 	if err != nil || issuerAccount == nil {
 		return false
@@ -1239,7 +1216,6 @@ func isFrozenIOU(view tx.LedgerView, accountID, issuerID [20]byte, currency stri
 		return true
 	}
 
-	// Check individual freeze if not self
 	if issuerID != accountID {
 		return tx.IsTrustlineFrozen(view, accountID, issuerID, currency)
 	}
@@ -1437,7 +1413,6 @@ func computeMPTTransferFee(
 	senderIsIssuer := issuerID == senderID
 	receiverIsIssuer := issuerID == receiverID
 
-	// Get current transfer rate
 	currentRate := parityRate
 	if issuance.TransferFee > 0 {
 		currentRate = getMPTTransferRate(issuance.TransferFee)

--- a/internal/tx/ledgerstatefix/ledger_state_fix.go
+++ b/internal/tx/ledgerstatefix/ledger_state_fix.go
@@ -41,7 +41,6 @@ type LedgerStateFix struct {
 	Owner string `json:"Owner,omitempty" xrpl:"Owner,omitempty"`
 }
 
-// NewLedgerStateFix creates a new LedgerStateFix transaction
 func NewLedgerStateFix(account string, fixType uint8) *LedgerStateFix {
 	return &LedgerStateFix{
 		BaseTx:        *tx.NewBaseTx(tx.TypeLedgerStateFix, account),
@@ -49,7 +48,6 @@ func NewLedgerStateFix(account string, fixType uint8) *LedgerStateFix {
 	}
 }
 
-// NewNFTokenPageLinkFix creates a LedgerStateFix for NFToken page link repair
 func NewNFTokenPageLinkFix(account, owner string) *LedgerStateFix {
 	return &LedgerStateFix{
 		BaseTx:        *tx.NewBaseTx(tx.TypeLedgerStateFix, account),
@@ -58,19 +56,16 @@ func NewNFTokenPageLinkFix(account, owner string) *LedgerStateFix {
 	}
 }
 
-// TxType returns the transaction type
 func (l *LedgerStateFix) TxType() tx.Type {
 	return tx.TypeLedgerStateFix
 }
 
-// Validate validates the LedgerStateFix transaction
 // Reference: rippled LedgerStateFix.cpp preflight()
 func (l *LedgerStateFix) Validate() error {
 	if err := l.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check for invalid flags (universal mask)
 	// Reference: rippled LedgerStateFix.cpp:36-37
 	if err := tx.CheckFlags(l.GetFlags(), tx.TfUniversalMask); err != nil {
 		return err
@@ -80,13 +75,11 @@ func (l *LedgerStateFix) Validate() error {
 	// Reference: rippled LedgerStateFix.cpp:42-51
 	switch l.LedgerFixType {
 	case LedgerFixTypeNFTokenPageLink:
-		// Owner is required for nfTokenPageLink fix
 		// Reference: rippled LedgerStateFix.cpp:45-46
 		if l.Owner == "" {
 			return ErrLedgerFixOwnerRequired
 		}
 	default:
-		// Invalid fix type
 		// Reference: rippled LedgerStateFix.cpp:49-50
 		return ErrLedgerFixInvalidType
 	}
@@ -94,7 +87,6 @@ func (l *LedgerStateFix) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (l *LedgerStateFix) Flatten() (map[string]any, error) {
 	m, err := tx.ReflectFlatten(l)
 	if err != nil {
@@ -111,13 +103,10 @@ func (l *LedgerStateFix) Flatten() (map[string]any, error) {
 	return m, nil
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (l *LedgerStateFix) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureFixNFTokenPageLinks}
 }
 
-// Apply applies the LedgerStateFix transaction to the ledger.
-// This implements the Appliable interface: Apply(ctx *tx.ApplyContext) tx.Result
 // Reference: rippled LedgerStateFix.cpp preclaim() + doApply()
 func (l *LedgerStateFix) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("ledger state fix apply",
@@ -400,8 +389,5 @@ func (l *LedgerStateFix) CalculateBaseFee(_ tx.LedgerView, config tx.EngineConfi
 	return config.ReserveIncrement
 }
 
-// Ensure LedgerStateFix implements Appliable.
 var _ tx.Appliable = (*LedgerStateFix)(nil)
-
-// Ensure LedgerStateFix implements CustomBaseFeeCalculator.
 var _ tx.CustomBaseFeeCalculator = (*LedgerStateFix)(nil)

--- a/internal/tx/ledgerstatefix/ledger_state_fix_test.go
+++ b/internal/tx/ledgerstatefix/ledger_state_fix_test.go
@@ -9,10 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// =============================================================================
 // LedgerStateFix Validation Tests
 // Based on rippled LedgerStateFix.cpp
-// =============================================================================
 
 func TestLedgerStateFixValidation(t *testing.T) {
 	tests := []struct {
@@ -94,9 +92,7 @@ func TestLedgerStateFixValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Flatten Tests
-// =============================================================================
 
 func TestLedgerStateFixFlatten(t *testing.T) {
 	t.Run("nfTokenPageLink fix", func(t *testing.T) {
@@ -123,9 +119,7 @@ func TestLedgerStateFixFlatten(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Constructor Tests
-// =============================================================================
 
 func TestLedgerStateFixConstructors(t *testing.T) {
 	t.Run("NewLedgerStateFix", func(t *testing.T) {
@@ -147,9 +141,7 @@ func TestLedgerStateFixConstructors(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Amendment Tests
-// =============================================================================
 
 func TestLedgerStateFixRequiredAmendments(t *testing.T) {
 	lsf := NewNFTokenPageLinkFix("rAdmin", "rOwner")
@@ -157,9 +149,7 @@ func TestLedgerStateFixRequiredAmendments(t *testing.T) {
 	assert.Contains(t, amendments, amendment.FeatureFixNFTokenPageLinks)
 }
 
-// =============================================================================
 // Constants Tests
-// =============================================================================
 
 func TestLedgerStateFixConstants(t *testing.T) {
 	assert.Equal(t, uint8(1), LedgerFixTypeNFTokenPageLink)

--- a/internal/tx/mpt/mptoken_authorize.go
+++ b/internal/tx/mpt/mptoken_authorize.go
@@ -37,12 +37,10 @@ func NewMPTokenAuthorize(account, issuanceID string) *MPTokenAuthorize {
 	}
 }
 
-// TxType returns the transaction type
 func (m *MPTokenAuthorize) TxType() tx.Type {
 	return tx.TypeMPTokenAuthorize
 }
 
-// Validate validates the MPTokenAuthorize transaction
 // Reference: rippled MPTokenAuthorize.cpp preflight
 func (m *MPTokenAuthorize) Validate() error {
 	if err := m.BaseTx.Validate(); err != nil {
@@ -51,7 +49,6 @@ func (m *MPTokenAuthorize) Validate() error {
 
 	flags := m.GetFlags()
 
-	// Check for invalid flags
 	if flags&^tfMPTokenAuthorizeValidMask != 0 {
 		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for MPTokenAuthorize")
 	}
@@ -83,12 +80,10 @@ func (m *MPTokenAuthorize) HasHolder() bool {
 	return m.Holder != ""
 }
 
-// Flatten returns a flat map of all transaction fields
 func (m *MPTokenAuthorize) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(m)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (m *MPTokenAuthorize) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureMPTokensV1}
 }
@@ -169,7 +164,6 @@ func (m *MPTokenAuthorize) holderUnauthorize(ctx *tx.ApplyContext, issuanceKey, 
 		return tx.TecNO_PERMISSION
 	}
 
-	// Remove from owner directory
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
 	state.DirRemove(ctx.View, ownerDirKey, token.OwnerNode, tokenKey.Key, false)
 

--- a/internal/tx/mpt/mptoken_authorize.go
+++ b/internal/tx/mpt/mptoken_authorize.go
@@ -88,7 +88,6 @@ func (m *MPTokenAuthorize) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureMPTokensV1}
 }
 
-// Apply applies the MPTokenAuthorize transaction to ledger state.
 // Reference: rippled MPTokenAuthorize.cpp preclaim() + doApply() + View.cpp::authorizeMPToken()
 func (m *MPTokenAuthorize) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("mptoken authorize apply",

--- a/internal/tx/mpt/mptoken_issuance_create.go
+++ b/internal/tx/mpt/mptoken_issuance_create.go
@@ -174,7 +174,6 @@ func (m *MPTokenIssuanceCreate) RequiredAmendments() [][32]byte {
 	return amendments
 }
 
-// Apply applies the MPTokenIssuanceCreate transaction to ledger state.
 // Reference: rippled MPTokenIssuanceCreate.cpp doApply() / create()
 func (m *MPTokenIssuanceCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("mptoken issuance create apply",

--- a/internal/tx/mpt/mptoken_issuance_create.go
+++ b/internal/tx/mpt/mptoken_issuance_create.go
@@ -92,27 +92,22 @@ func parseUInt64Field(raw json.RawMessage) (uint64, error) {
 	return 0, fmt.Errorf("cannot parse UInt64 field: %s", string(raw))
 }
 
-// NewMPTokenIssuanceCreate creates a new MPTokenIssuanceCreate transaction
 func NewMPTokenIssuanceCreate(account string) *MPTokenIssuanceCreate {
 	return &MPTokenIssuanceCreate{
 		BaseTx: *tx.NewBaseTx(tx.TypeMPTokenIssuanceCreate, account),
 	}
 }
 
-// TxType returns the transaction type
 func (m *MPTokenIssuanceCreate) TxType() tx.Type {
 	return tx.TypeMPTokenIssuanceCreate
 }
 
-// Validate validates the MPTokenIssuanceCreate transaction
 // Reference: rippled MPTokenIssuanceCreate.cpp preflight
 func (m *MPTokenIssuanceCreate) Validate() error {
 	if err := m.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check for invalid flags
-	// Any flags other than the valid ones are not allowed
 	flags := m.GetFlags()
 	if flags&^tfMPTokenIssuanceCreateValidMask != 0 {
 		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for MPTokenIssuanceCreate")
@@ -165,12 +160,10 @@ func (m *MPTokenIssuanceCreate) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (m *MPTokenIssuanceCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(m)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (m *MPTokenIssuanceCreate) RequiredAmendments() [][32]byte {
 	amendments := [][32]byte{amendment.FeatureMPTokensV1}
 	// DomainID requires both PermissionedDomains and SingleAssetVault

--- a/internal/tx/mpt/mptoken_issuance_destroy.go
+++ b/internal/tx/mpt/mptoken_issuance_destroy.go
@@ -76,7 +76,6 @@ func (m *MPTokenIssuanceDestroy) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureMPTokensV1}
 }
 
-// Apply applies the MPTokenIssuanceDestroy transaction to ledger state.
 // Reference: rippled MPTokenIssuanceDestroy.cpp preclaim() + doApply()
 func (m *MPTokenIssuanceDestroy) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("mptoken issuance destroy apply",

--- a/internal/tx/mpt/mptoken_issuance_destroy.go
+++ b/internal/tx/mpt/mptoken_issuance_destroy.go
@@ -29,7 +29,6 @@ const (
 	tfMPTokenIssuanceDestroyValidMask uint32 = tx.TfUniversal
 )
 
-// NewMPTokenIssuanceDestroy creates a new MPTokenIssuanceDestroy transaction
 func NewMPTokenIssuanceDestroy(account, issuanceID string) *MPTokenIssuanceDestroy {
 	return &MPTokenIssuanceDestroy{
 		BaseTx:            *tx.NewBaseTx(tx.TypeMPTokenIssuanceDestroy, account),
@@ -37,19 +36,16 @@ func NewMPTokenIssuanceDestroy(account, issuanceID string) *MPTokenIssuanceDestr
 	}
 }
 
-// TxType returns the transaction type
 func (m *MPTokenIssuanceDestroy) TxType() tx.Type {
 	return tx.TypeMPTokenIssuanceDestroy
 }
 
-// Validate validates the MPTokenIssuanceDestroy transaction
 // Reference: rippled MPTokenIssuanceDestroy.cpp preflight
 func (m *MPTokenIssuanceDestroy) Validate() error {
 	if err := m.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check for invalid flags
 	flags := m.GetFlags()
 	if flags&^tfMPTokenIssuanceDestroyValidMask != 0 {
 		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for MPTokenIssuanceDestroy")
@@ -72,12 +68,10 @@ func (m *MPTokenIssuanceDestroy) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (m *MPTokenIssuanceDestroy) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(m)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (m *MPTokenIssuanceDestroy) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureMPTokensV1}
 }
@@ -145,7 +139,6 @@ func (m *MPTokenIssuanceDestroy) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TefINTERNAL
 	}
 
-	// Decrement owner count
 	if ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}

--- a/internal/tx/mpt/mptoken_issuance_set.go
+++ b/internal/tx/mpt/mptoken_issuance_set.go
@@ -127,7 +127,6 @@ func (m *MPTokenIssuanceSet) RequiredAmendments() [][32]byte {
 	return amendments
 }
 
-// Apply applies the MPTokenIssuanceSet transaction to ledger state.
 // Reference: rippled MPTokenIssuanceSet.cpp preclaim() + doApply()
 func (m *MPTokenIssuanceSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("mptoken issuance set apply",

--- a/internal/tx/mpt/mptoken_issuance_set.go
+++ b/internal/tx/mpt/mptoken_issuance_set.go
@@ -58,7 +58,6 @@ func (m *MPTokenIssuanceSet) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// NewMPTokenIssuanceSet creates a new MPTokenIssuanceSet transaction
 func NewMPTokenIssuanceSet(account, issuanceID string) *MPTokenIssuanceSet {
 	return &MPTokenIssuanceSet{
 		BaseTx:            *tx.NewBaseTx(tx.TypeMPTokenIssuanceSet, account),
@@ -66,12 +65,10 @@ func NewMPTokenIssuanceSet(account, issuanceID string) *MPTokenIssuanceSet {
 	}
 }
 
-// TxType returns the transaction type
 func (m *MPTokenIssuanceSet) TxType() tx.Type {
 	return tx.TypeMPTokenIssuanceSet
 }
 
-// Validate validates the MPTokenIssuanceSet transaction (rules-independent checks).
 // Reference: rippled MPTokenIssuanceSet.cpp preflight
 func (m *MPTokenIssuanceSet) Validate() error {
 	if err := m.BaseTx.Validate(); err != nil {
@@ -86,7 +83,6 @@ func (m *MPTokenIssuanceSet) Validate() error {
 
 	flags := m.GetFlags()
 
-	// Check for invalid flags
 	if flags&^tfMPTokenIssuanceSetValidMask != 0 {
 		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for MPTokenIssuanceSet")
 	}
@@ -117,12 +113,10 @@ func (m *MPTokenIssuanceSet) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (m *MPTokenIssuanceSet) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(m)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (m *MPTokenIssuanceSet) RequiredAmendments() [][32]byte {
 	amendments := [][32]byte{amendment.FeatureMPTokensV1}
 	// DomainID requires both PermissionedDomains and SingleAssetVault
@@ -301,7 +295,6 @@ func (m *MPTokenIssuanceSet) setIssuance(ctx *tx.ApplyContext, issuanceKey keyle
 	// Reference: rippled MPTokenIssuanceSet.cpp:186-202
 	if m.hasDomainID && m.DomainID != nil {
 		if *m.DomainID != zeroHash256 {
-			// Set the DomainID
 			issuance.DomainID = m.DomainID
 		} else {
 			// Clear the DomainID (zero hash means remove)

--- a/internal/tx/nftoken/iou_helpers.go
+++ b/internal/tx/nftoken/iou_helpers.go
@@ -193,7 +193,6 @@ func checkNFTTrustlineDeepFrozen(view tx.LedgerView, accountID [20]byte, currenc
 		return tx.TesSUCCESS
 	}
 
-	// Check issuer exists
 	issuerKey := keylet.Account(issuerID)
 	issuerData, err := view.Read(issuerKey)
 	if err != nil || issuerData == nil {
@@ -261,7 +260,6 @@ func accountSendIOU(view tx.LedgerView, from, to [20]byte, amount tx.Amount) tx.
 	}
 
 	// Third party: sender → issuer (with transfer rate) and issuer → receiver
-	// Get transfer rate from issuer
 	transferRate := getTransferRate(view, issuerID)
 	if transferRate != 0 && transferRate != qualityOne {
 		// Charge sender the amount * transferRate / QUALITY_ONE
@@ -499,7 +497,6 @@ func createTrustLineWithBalance(view tx.LedgerView, sender, receiver [20]byte, a
 		return tx.TefINTERNAL
 	}
 
-	// Set balance based on sender's position
 	// Convention: positive balance = LOW account holds tokens
 	// When sender is HIGH (paying LOW): LOW receives → balance = +amount
 	// When sender is LOW (paying HIGH): HIGH receives → balance = -amount

--- a/internal/tx/nftoken/nftoken_accept_offer.go
+++ b/internal/tx/nftoken/nftoken_accept_offer.go
@@ -80,7 +80,6 @@ func (n *NFTokenAcceptOffer) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (n *NFTokenAcceptOffer) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(n)
 }
@@ -95,7 +94,6 @@ func (n *NFTokenAcceptOffer) SetBuyOffer(offerID string) {
 	n.NFTokenBuyOffer = offerID
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (n *NFTokenAcceptOffer) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureNonFungibleTokensV1}
 }

--- a/internal/tx/nftoken/nftoken_accept_offer.go
+++ b/internal/tx/nftoken/nftoken_accept_offer.go
@@ -37,12 +37,10 @@ func NewNFTokenAcceptOffer(account string) *NFTokenAcceptOffer {
 	}
 }
 
-// TxType returns the transaction type
 func (n *NFTokenAcceptOffer) TxType() tx.Type {
 	return tx.TypeNFTokenAcceptOffer
 }
 
-// Validate validates the NFTokenAcceptOffer transaction
 // Reference: rippled NFTokenAcceptOffer.cpp preflight
 func (n *NFTokenAcceptOffer) Validate() error {
 	if err := n.BaseTx.Validate(); err != nil {
@@ -102,7 +100,6 @@ func (n *NFTokenAcceptOffer) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureNonFungibleTokensV1}
 }
 
-// Apply applies the NFTokenAcceptOffer transaction to the ledger.
 // Reference: rippled NFTokenAcceptOffer.cpp preclaim + doApply
 // IMPORTANT: Check order must match rippled's preclaim exactly:
 //  1. Load offers (existence, expiration, negative amount)

--- a/internal/tx/nftoken/nftoken_burn.go
+++ b/internal/tx/nftoken/nftoken_burn.go
@@ -58,12 +58,10 @@ func (n *NFTokenBurn) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (n *NFTokenBurn) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(n)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (n *NFTokenBurn) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureNonFungibleTokensV1}
 }

--- a/internal/tx/nftoken/nftoken_burn.go
+++ b/internal/tx/nftoken/nftoken_burn.go
@@ -37,19 +37,16 @@ func NewNFTokenBurn(account, nftokenID string) *NFTokenBurn {
 	}
 }
 
-// TxType returns the transaction type
 func (n *NFTokenBurn) TxType() tx.Type {
 	return tx.TypeNFTokenBurn
 }
 
-// Validate validates the NFTokenBurn transaction
 // Reference: rippled NFTokenBurn.cpp preflight
 func (n *NFTokenBurn) Validate() error {
 	if err := n.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check for invalid flags
 	if n.GetFlags()&^tfBurnNFToken != 0 {
 		return tx.Errorf(tx.TemINVALID_FLAG, "invalid NFTokenBurn flags")
 	}
@@ -71,7 +68,6 @@ func (n *NFTokenBurn) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureNonFungibleTokensV1}
 }
 
-// Apply applies the NFTokenBurn transaction to the ledger.
 // Reference: rippled NFTokenBurn.cpp doApply
 func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("nftoken burn apply",
@@ -150,7 +146,6 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 		return result
 	}
 
-	// Update owner count for pages removed
 	if ownerID != accountID {
 		ownerKey := keylet.Account(ownerID)
 		ownerData, err := ctx.View.Read(ownerKey)
@@ -198,7 +193,6 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Delete associated buy and sell offers
 	// Reference: rippled NFTokenBurn.cpp:108-139
 	selfDeleted := 0
 	if !fixV1_2 {

--- a/internal/tx/nftoken/nftoken_cancel_offer.go
+++ b/internal/tx/nftoken/nftoken_cancel_offer.go
@@ -68,12 +68,10 @@ func (n *NFTokenCancelOffer) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (n *NFTokenCancelOffer) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(n)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (n *NFTokenCancelOffer) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureNonFungibleTokensV1}
 }

--- a/internal/tx/nftoken/nftoken_cancel_offer.go
+++ b/internal/tx/nftoken/nftoken_cancel_offer.go
@@ -32,12 +32,10 @@ func NewNFTokenCancelOffer(account string, offerIDs []string) *NFTokenCancelOffe
 	}
 }
 
-// TxType returns the transaction type
 func (n *NFTokenCancelOffer) TxType() tx.Type {
 	return tx.TypeNFTokenCancelOffer
 }
 
-// Validate validates the NFTokenCancelOffer transaction
 // Reference: rippled NFTokenCancelOffer.cpp preflight
 func (n *NFTokenCancelOffer) Validate() error {
 	if err := n.BaseTx.Validate(); err != nil {
@@ -59,7 +57,6 @@ func (n *NFTokenCancelOffer) Validate() error {
 		return tx.Errorf(tx.TemMALFORMED, "NFTokenOffers exceeds maximum count")
 	}
 
-	// Check for duplicates
 	seen := make(map[string]bool)
 	for _, offerID := range n.NFTokenOffers {
 		if seen[offerID] {
@@ -81,7 +78,6 @@ func (n *NFTokenCancelOffer) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureNonFungibleTokensV1}
 }
 
-// Apply applies the NFTokenCancelOffer transaction to the ledger.
 // Reference: rippled NFTokenCancelOffer.cpp preclaim + doApply
 func (n *NFTokenCancelOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("nftoken cancel offer apply",

--- a/internal/tx/nftoken/nftoken_create_offer.go
+++ b/internal/tx/nftoken/nftoken_create_offer.go
@@ -139,7 +139,6 @@ func (n *NFTokenCreateOffer) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (n *NFTokenCreateOffer) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(n)
 }
@@ -150,7 +149,6 @@ func (n *NFTokenCreateOffer) SetSellOffer() {
 	n.SetFlags(flags)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (n *NFTokenCreateOffer) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureNonFungibleTokensV1}
 }

--- a/internal/tx/nftoken/nftoken_create_offer.go
+++ b/internal/tx/nftoken/nftoken_create_offer.go
@@ -53,12 +53,10 @@ func NewNFTokenCreateOffer(account, nftokenID string, amount tx.Amount) *NFToken
 	}
 }
 
-// TxType returns the transaction type
 func (n *NFTokenCreateOffer) TxType() tx.Type {
 	return tx.TypeNFTokenCreateOffer
 }
 
-// Validate validates the NFTokenCreateOffer transaction
 // Reference: rippled NFTokenCreateOffer.cpp preflight and tokenOfferCreatePreflight
 // IMPORTANT: validation order must match rippled exactly (amount → expiration → owner → destination)
 func (n *NFTokenCreateOffer) Validate() error {
@@ -66,7 +64,6 @@ func (n *NFTokenCreateOffer) Validate() error {
 		return err
 	}
 
-	// Check for invalid flags
 	if n.GetFlags()&tfNFTokenCreateOfferMask != 0 {
 		return tx.Errorf(tx.TemINVALID_FLAG, "invalid NFTokenCreateOffer flags")
 	}
@@ -158,7 +155,6 @@ func (n *NFTokenCreateOffer) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureNonFungibleTokensV1}
 }
 
-// Apply applies the NFTokenCreateOffer transaction to the ledger.
 // Reference: rippled NFTokenCreateOffer.cpp doApply
 func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("nftoken create offer apply",
@@ -193,7 +189,6 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TemMALFORMED
 	}
 
-	// Check expiration
 	if n.Expiration != nil && *n.Expiration <= ctx.Config.ParentCloseTime {
 		ctx.Log.Warn("nftoken create offer: offer expired")
 		return tx.TecEXPIRED
@@ -351,7 +346,6 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	// — the buyer's balance is only checked, not held.
 	// Reference: rippled NFTokenUtils.cpp tokenOfferCreateApply — no balance deduction
 
-	// Create the offer
 	sequence := n.GetCommon().SeqProxy()
 	offerKey := keylet.NFTokenOffer(accountID, sequence)
 

--- a/internal/tx/nftoken/nftoken_mint.go
+++ b/internal/tx/nftoken/nftoken_mint.go
@@ -68,19 +68,16 @@ func NewNFTokenMint(account string, taxon uint32) *NFTokenMint {
 	}
 }
 
-// TxType returns the transaction type
 func (n *NFTokenMint) TxType() tx.Type {
 	return tx.TypeNFTokenMint
 }
 
-// Validate validates the NFTokenMint transaction
 // Reference: rippled NFTokenMint.cpp preflight
 func (n *NFTokenMint) Validate() error {
 	if err := n.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check for invalid flags
 	// Use the most permissive mask here since Validate() has no access to Rules.
 	// The amendment-dependent checks (rejecting tfTrustLine when
 	// fixRemoveNFTokenAutoTrustLine is enabled, rejecting tfMutable when
@@ -196,7 +193,6 @@ func (n *NFTokenMint) RequiredAmendments() [][32]byte {
 	return amends
 }
 
-// Apply applies the NFTokenMint transaction to the ledger.
 // Reference: rippled NFTokenMint.cpp doApply
 func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("nftoken mint apply",
@@ -283,7 +279,6 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 			return tx.TemBAD_AMOUNT
 		}
 
-		// Check expiration
 		if n.Expiration != nil && *n.Expiration <= ctx.Config.ParentCloseTime {
 			return tx.TecEXPIRED
 		}
@@ -292,7 +287,6 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		// These are the flags that will be embedded in the minted token.
 		nftFlags := uint16(n.GetFlags() & 0xFFFF)
 
-		// Get transfer fee
 		var transferFee uint16
 		if n.TransferFee != nil {
 			transferFee = *n.TransferFee
@@ -331,7 +325,6 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 					}
 				}
 
-				// Check if NFT issuer is frozen for this IOU
 				if tx.IsGlobalFrozen(ctx.View, n.Amount.Issuer) || tx.IsTrustlineFrozen(ctx.View, issuerID, iouIssuerID, n.Amount.Currency) {
 					return tx.TecFROZEN
 				}
@@ -406,7 +399,6 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		offset := issuerAccount.FirstNFTokenSequence
 		tokenSeq = offset + mintedNftCnt
 
-		// Check for overflow
 		if tokenSeq+1 == 0 || tokenSeq < offset {
 			return tx.TecMAX_SEQUENCE_REACHED
 		}
@@ -431,7 +423,6 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		tokenFlags |= nftFlagMutable
 	}
 
-	// Get transfer fee
 	var transferFee uint16
 	if n.TransferFee != nil {
 		transferFee = *n.TransferFee
@@ -454,7 +445,6 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		return insertResult.Result
 	}
 
-	// Update owner count based on pages created
 	ctx.Account.OwnerCount += uint32(insertResult.PagesCreated)
 
 	// MintedNFTokens was already incremented above in the fixNFTokenRemint/non-fix branches.

--- a/internal/tx/nftoken/nftoken_mint.go
+++ b/internal/tx/nftoken/nftoken_mint.go
@@ -164,7 +164,6 @@ func (n *NFTokenMint) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (n *NFTokenMint) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(n)
 }
@@ -181,7 +180,6 @@ func (n *NFTokenMint) SetTransferable() {
 	n.SetFlags(flags)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type.
 // When offer fields (Amount, Destination, Expiration) are present, also requires
 // FeatureNFTokenMintOffer.
 // Reference: rippled NFTokenMint.cpp preflight — temDISABLED when offer fields present without amendment

--- a/internal/tx/nftoken/nftoken_modify.go
+++ b/internal/tx/nftoken/nftoken_modify.go
@@ -78,12 +78,10 @@ func (n *NFTokenModify) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (n *NFTokenModify) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(n)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type.
 // Reference: rippled NFTokenModify.cpp preflight — requires both NonFungibleTokensV1_1 and DynamicNFT.
 func (n *NFTokenModify) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureNonFungibleTokensV1_1, amendment.FeatureDynamicNFT}

--- a/internal/tx/nftoken/nftoken_modify.go
+++ b/internal/tx/nftoken/nftoken_modify.go
@@ -37,19 +37,16 @@ func NewNFTokenModify(account, nftokenID string) *NFTokenModify {
 	}
 }
 
-// TxType returns the transaction type
 func (n *NFTokenModify) TxType() tx.Type {
 	return tx.TypeNFTokenModify
 }
 
-// Validate validates the NFTokenModify transaction
 // Reference: rippled NFTokenModify.cpp preflight
 func (n *NFTokenModify) Validate() error {
 	if err := n.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check for invalid flags
 	// Reference: rippled NFTokenModify.cpp:38 - if (ctx.tx.getFlags() & tfUniversalMask)
 	if err := tx.CheckFlags(n.GetFlags(), tx.TfUniversalMask); err != nil {
 		return err
@@ -92,7 +89,6 @@ func (n *NFTokenModify) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureNonFungibleTokensV1_1, amendment.FeatureDynamicNFT}
 }
 
-// Apply applies the NFTokenModify transaction to the ledger.
 // Reference: rippled NFTokenModify.cpp preclaim + doApply
 func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("nftoken modify apply",
@@ -130,7 +126,6 @@ func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecNO_ENTRY
 	}
 
-	// Check if the NFT is mutable
 	// Reference: rippled NFTokenModify.cpp preclaim:64
 	if getNFTFlagsFromID(tokenID)&nftFlagMutable == 0 {
 		return tx.TecNO_PERMISSION
@@ -175,7 +170,6 @@ func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecINTERNAL
 	}
 
-	// Update or remove the URI
 	// Reference: rippled NFTokenModify.cpp doApply:88 — ctx_.tx[~sfURI]
 	// If URI is present in the tx, set it on the token.
 	// If URI is absent, remove the existing URI from the token.

--- a/internal/tx/nftoken/nftoken_offer.go
+++ b/internal/tx/nftoken/nftoken_offer.go
@@ -32,11 +32,9 @@ func deleteTokenOffer(view tx.LedgerView, offerKL keylet.Keylet) error {
 		return err
 	}
 
-	// Remove from owner's directory
 	ownerDirKey := keylet.OwnerDir(offer.Owner)
 	state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKL.Key, false)
 
-	// Remove from NFTBuys or NFTSells directory
 	isSellOffer := offer.Flags&lsfSellNFToken != 0
 	var tokenDirKey keylet.Keylet
 	if isSellOffer {
@@ -113,11 +111,9 @@ func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.L
 			adjustOwnerCountViaView(view, offer.Owner, -1)
 		}
 
-		// Remove from owner directory
 		ownerDirKey := keylet.OwnerDir(offer.Owner)
 		state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKL.Key, false)
 
-		// Erase the offer
 		view.Erase(offerKL)
 
 		result.TotalDeleted++
@@ -192,10 +188,8 @@ func tokenOfferCreateApply(
 		return tx.TecINSUFFICIENT_RESERVE
 	}
 
-	// Create offer key
 	offerKey := keylet.NFTokenOffer(accountID, seqProxy)
 
-	// Insert into owner's directory
 	ownerDirKey := keylet.OwnerDir(accountID)
 	dirResult, err := state.DirInsert(ctx.View, ownerDirKey, offerKey.Key, nil)
 	if err != nil {
@@ -211,7 +205,6 @@ func tokenOfferCreateApply(
 	}
 	offerNode := tokenDirResult.Page
 
-	// Serialize the offer
 	flags := NFTokenCreateOfferFlagSellNFToken // Always a sell offer
 
 	offerData, err := serializeNFTokenOfferRaw(
@@ -228,7 +221,6 @@ func tokenOfferCreateApply(
 		return tx.TefINTERNAL
 	}
 
-	// Increase owner count
 	ctx.Account.OwnerCount++
 
 	return tx.TesSUCCESS

--- a/internal/tx/offer/offer_cancel.go
+++ b/internal/tx/offer/offer_cancel.go
@@ -29,12 +29,10 @@ func NewOfferCancel(account string, offerSequence uint32) *OfferCancel {
 	}
 }
 
-// TxType returns the transaction type
 func (o *OfferCancel) TxType() tx.Type {
 	return tx.TypeOfferCancel
 }
 
-// Validate validates the OfferCancel transaction
 // Reference: rippled CancelOffer.cpp preflight()
 func (o *OfferCancel) Validate() error {
 	if err := o.BaseTx.Validate(); err != nil {
@@ -53,7 +51,6 @@ func (o *OfferCancel) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(o)
 }
 
-// Apply applies an OfferCancel transaction to the ledger state.
 // Reference: rippled CancelOffer.cpp preclaim() + doApply()
 func (o *OfferCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Preclaim: Account sequence must be strictly greater than OfferSequence
@@ -96,7 +93,6 @@ func (o *OfferCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TefINTERNAL
 	}
 
-	// Create SLE for the offer for metadata tracking
 	sleOffer := state.NewSLEOffer(offerKey.Key)
 	sleOffer.LoadFromLedgerOffer(ledgerOffer)
 	sleOffer.MarkAsDeleted()
@@ -121,12 +117,10 @@ func (o *OfferCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TefBAD_LEDGER
 	}
 
-	// Delete the offer from ledger
 	if err := ctx.View.Erase(offerKey); err != nil {
 		return tx.TefINTERNAL
 	}
 
-	// Decrement owner count
 	if ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}

--- a/internal/tx/offer/offer_cancel.go
+++ b/internal/tx/offer/offer_cancel.go
@@ -46,7 +46,6 @@ func (o *OfferCancel) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (o *OfferCancel) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(o)
 }

--- a/internal/tx/offer/offer_create.go
+++ b/internal/tx/offer/offer_create.go
@@ -198,7 +198,6 @@ func (o *OfferCreate) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (o *OfferCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(o)
 }

--- a/internal/tx/offer/offer_create.go
+++ b/internal/tx/offer/offer_create.go
@@ -95,7 +95,6 @@ func NewOfferCreate(account string, takerGets, takerPays tx.Amount) *OfferCreate
 	}
 }
 
-// TxType returns the transaction type
 func (o *OfferCreate) TxType() tx.Type {
 	return tx.TypeOfferCreate
 }
@@ -109,7 +108,6 @@ func (o *OfferCreate) Validate() error {
 		return err
 	}
 
-	// Check for invalid flags
 	// Reference: rippled CreateOffer.cpp preflight() lines 61-65
 	flags := o.GetFlags()
 	if flags&tfOfferCreateMask != 0 {
@@ -130,13 +128,11 @@ func (o *OfferCreate) Validate() error {
 		return tx.Errorf(tx.TemINVALID_FLAG, "tfHybrid requires DomainID")
 	}
 
-	// Check expiration
 	// Reference: lines 82-88
 	if o.Expiration != nil && *o.Expiration == 0 {
 		return tx.Errorf(tx.TemBAD_EXPIRATION, "expiration cannot be zero")
 	}
 
-	// Check OfferSequence
 	// Reference: lines 90-95
 	if o.OfferSequence != nil && *o.OfferSequence == 0 {
 		return tx.Errorf(tx.TemBAD_SEQUENCE, "OfferSequence cannot be zero")
@@ -154,7 +150,6 @@ func (o *OfferCreate) Validate() error {
 		return tx.Errorf(tx.TemBAD_OFFER, "TakerGets is required")
 	}
 
-	// Check amounts are present and valid
 	// Reference: lines 97-101
 	if !isLegalNetAmount(saTakerPays) || !isLegalNetAmount(saTakerGets) {
 		return tx.Errorf(tx.TemBAD_AMOUNT, "invalid amount")
@@ -172,7 +167,6 @@ func (o *OfferCreate) Validate() error {
 		return tx.Errorf(tx.TemBAD_OFFER, "amounts must be positive")
 	}
 
-	// Get currency and issuer info
 	uPaysCurrency := saTakerPays.Currency
 	uPaysIssuerID := saTakerPays.Issuer
 	uGetsCurrency := saTakerGets.Currency
@@ -193,7 +187,6 @@ func (o *OfferCreate) Validate() error {
 		return tx.Errorf(tx.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
 	}
 
-	// Check issuer consistency
 	// Reference: lines 132-137
 	if saTakerPays.IsNative() != (uPaysIssuerID == "") {
 		return tx.Errorf(tx.TemBAD_ISSUER, "issuer mismatch for TakerPays")
@@ -314,7 +307,6 @@ func (o *OfferCreate) Preflight(rules *amendment.Rules) error {
 		return tx.Errorf(tx.TemDISABLED, "DomainID requires PermissionedDEX amendment")
 	}
 
-	// Check tfHybrid without PermissionedDEX
 	// Reference: lines 67-68
 	flags := o.GetFlags()
 	if !rules.PermissionedDEXEnabled() && (flags&tfHybrid != 0) {
@@ -335,7 +327,6 @@ func (o *OfferCreate) Preclaim(ctx *tx.ApplyContext) tx.Result {
 	uPaysIssuerID := saTakerPays.Issuer
 	uGetsIssuerID := saTakerGets.Issuer
 
-	// Check global freeze on both issuers
 	// Reference: lines 165-170
 	if uPaysIssuerID != "" {
 		if tx.IsGlobalFrozen(ctx.View, uPaysIssuerID) {
@@ -365,7 +356,6 @@ func (o *OfferCreate) Preclaim(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Check if offer has expired
 	// Reference: lines 189-200
 	if hasExpired(ctx, o.Expiration) {
 		if rules.DepositPreauthEnabled() {
@@ -414,7 +404,6 @@ func (o *OfferCreate) ApplyCreate(ctx *tx.ApplyContext) tx.Result {
 	sb := payment.NewPaymentSandbox(ctx.View)
 	sbCancel := payment.NewPaymentSandbox(ctx.View)
 
-	// Set transaction context on both sandboxes
 	sb.SetTransactionContext(ctx.TxHash, ctx.Config.LedgerSequence)
 	sbCancel.SetTransactionContext(ctx.TxHash, ctx.Config.LedgerSequence)
 
@@ -495,7 +484,6 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 	if o.OfferSequence != nil {
 		sleCancel := peekOffer(ctx.View, ctx.AccountID, *o.OfferSequence)
 		if sleCancel != nil {
-			// Delete in main sandbox
 			result = offerDeleteInView(sb, sleCancel)
 			// Delete in cancel sandbox (same operation)
 			_ = offerDeleteInView(sbCancel, sleCancel)
@@ -507,7 +495,6 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 		}
 	}
 
-	// Check if offer has expired
 	// Reference: lines 623-636
 	if hasExpired(ctx, o.Expiration) {
 		if rules.DepositPreauthEnabled() {
@@ -668,7 +655,6 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 			return tx.TesSUCCESS, true // Apply main sandbox with crossing results
 		}
 
-		// Check if any crossing happened
 		// Reference: line 744-745
 		// Use isAmountZeroOrNegative because FromEitherAmount returns "0" for zero amounts,
 		// not empty string ""
@@ -741,7 +727,6 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 			remainingGets = offerMulRound(remainingPays, rate, outNative, outCurrency, outIssuer, true)
 		}
 
-		// Check if offer is fully filled
 		// Reference: rippled CreateOffer.cpp lines 757-761
 		fullyCrossed := isAmountZeroOrNegative(remainingGets) || isAmountZeroOrNegative(remainingPays)
 
@@ -802,7 +787,6 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 		return tx.TesSUCCESS, true // Crossing happened - apply main sandbox
 	}
 
-	// Check reserve for new offer
 	// Reference: rippled CreateOffer.cpp lines 811-834
 	// IMPORTANT: Read OwnerCount fresh from the sandbox, not from ctx.Account.
 	// The crossing may have modified OwnerCount (e.g., trust line deletion).
@@ -845,7 +829,6 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 	}
 	bookDirKey := keylet.Quality(bookBase, uRate)
 
-	// Add to owner directory
 	// Reference: lines 839-848
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
 	ownerDirResult, err := state.DirInsert(sb, ownerDirKey, offerKey.Key, func(dir *state.DirectoryNode) {
@@ -855,14 +838,12 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 		return tx.TefINTERNAL, false
 	}
 
-	// Increment owner count
 	// Reference: line 851
 	ctx.Account.OwnerCount++
 
 	// Check if book exists (for OrderBookDB tracking)
 	bookExisted, _ := sb.Exists(bookDirKey)
 
-	// Add to book directory
 	// Reference: lines 884-893
 	bookDirResult, err := state.DirInsert(sb, bookDirKey, offerKey.Key, func(dir *state.DirectoryNode) {
 		dir.TakerPaysCurrency = takerPaysCurrency
@@ -876,7 +857,6 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 		return tx.TefINTERNAL, false
 	}
 
-	// Create the offer SLE
 	// Reference: lines 895-910
 	ledgerOffer := &state.LedgerOffer{
 		Account:           ctx.Account.Account,
@@ -891,13 +871,11 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 		PreviousTxnLgrSeq: ctx.Config.LedgerSequence,
 	}
 
-	// Set expiration if specified
 	// Reference: line 903-904
 	if o.Expiration != nil {
 		ledgerOffer.Expiration = *o.Expiration
 	}
 
-	// Set offer flags
 	// Reference: lines 905-910
 	if bPassive {
 		ledgerOffer.Flags |= lsfOfferPassive
@@ -906,7 +884,6 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 		ledgerOffer.Flags |= lsfOfferSell
 	}
 
-	// Set DomainID if specified
 	if o.DomainID != nil {
 		ledgerOffer.DomainID = *o.DomainID
 	}
@@ -1368,7 +1345,6 @@ func checkAcceptAsset(ctx *tx.ApplyContext, issuerID [20]byte, currency string, 
 		return tx.TesSUCCESS
 	}
 
-	// Check RequireAuth flag on issuer
 	// Reference: lines 258-282
 	if (issuerAccount.Flags & state.LsfRequireAuth) != 0 {
 		trustLineKey := keylet.Line(ctx.AccountID, issuerID, currency)
@@ -1402,7 +1378,6 @@ func checkAcceptAsset(ctx *tx.ApplyContext, issuerID [20]byte, currency string, 
 		return tx.TesSUCCESS
 	}
 
-	// Check for deep freeze on trustline
 	// Reference: lines 293-309
 	trustLineKey := keylet.Line(ctx.AccountID, issuerID, currency)
 	trustLineData, err := ctx.View.Read(trustLineKey)
@@ -1416,7 +1391,6 @@ func checkAcceptAsset(ctx *tx.ApplyContext, issuerID [20]byte, currency string, 
 		return tx.TesSUCCESS
 	}
 
-	// Check deep freeze
 	deepFrozen := (rs.Flags & (state.LsfLowDeepFreeze | state.LsfHighDeepFreeze)) != 0
 	if deepFrozen {
 		return tx.TecFROZEN
@@ -1434,7 +1408,6 @@ func accountInDomain(view tx.LedgerView, accountID [20]byte, domainID [32]byte, 
 // applyTickSize applies tick size rounding to offer amounts.
 // Reference: rippled CreateOffer.cpp lines 643-685
 func applyTickSize(view tx.LedgerView, takerPays, takerGets tx.Amount, bSell bool, rules *amendment.Rules) (tx.Amount, tx.Amount) {
-	// Get tick sizes from both issuers
 	tickSize := maxTickSize
 
 	if !takerPays.IsNative() {
@@ -1600,20 +1573,14 @@ func multiplyByQuality(amount tx.Amount, quality uint64, currency, issuer string
 		}
 	}
 
-	// Get quality as rate
 	rateRat := qualityToRate(quality)
-
-	// Result = amount * rate
 	result := new(big.Rat).Mul(amtRat, rateRat)
 
-	// Convert result to the target type
 	if currency == "" || currency == "XRP" {
-		// Return XRP amount
 		f, _ := result.Float64()
 		return tx.NewXRPAmount(int64(f + 0.5)) // Round
 	}
 
-	// Return IOU amount - normalize to mantissa/exponent form
 	return ratToIssuedAmount(result, currency, issuer, true)
 }
 
@@ -1653,20 +1620,14 @@ func divideByQuality(amount tx.Amount, quality uint64, currency, issuer string) 
 		}
 	}
 
-	// Get quality as rate
 	rateRat := qualityToRate(quality)
-
-	// Result = amount / rate
 	result := new(big.Rat).Quo(amtRat, rateRat)
 
-	// Convert result to the target type
 	if currency == "" || currency == "XRP" {
-		// Return XRP amount
 		f, _ := result.Float64()
 		return tx.NewXRPAmount(int64(f + 0.5)) // Round
 	}
 
-	// Return IOU amount - normalize to mantissa/exponent form
 	return ratToIssuedAmount(result, currency, issuer, true)
 }
 
@@ -1712,7 +1673,6 @@ func ratToIssuedAmount(rat *big.Rat, currency, issuer string, roundUp bool) tx.A
 		}
 	}
 
-	// Get final mantissa with rounding
 	intPart := new(big.Int).Quo(scaled.Num(), scaled.Denom())
 	remainder := new(big.Int).Mod(scaled.Num(), scaled.Denom())
 
@@ -1747,28 +1707,24 @@ func peekOffer(view tx.LedgerView, accountID [20]byte, sequence uint32) *state.L
 // offerDeleteInView removes an offer from the given view without modifying account state.
 // This is used by the two-sandbox pattern to delete offers in both sandboxes.
 func offerDeleteInView(view tx.LedgerView, offer *state.LedgerOffer) tx.Result {
-	// Get offer key
 	accountID, err := state.DecodeAccountID(offer.Account)
 	if err != nil {
 		return tx.TefINTERNAL
 	}
 	offerKey := keylet.Offer(accountID, offer.Sequence)
 
-	// Remove from owner directory
 	ownerDirKey := keylet.OwnerDir(accountID)
 	_, err = state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKey.Key, false)
 	if err != nil {
 		return tx.TefINTERNAL
 	}
 
-	// Remove from book directory
 	bookDirKey := keylet.Keylet{Type: 100, Key: offer.BookDirectory}
 	_, err = state.DirRemove(view, bookDirKey, offer.BookNode, offerKey.Key, false)
 	if err != nil {
 		return tx.TefINTERNAL
 	}
 
-	// Delete the offer
 	if err := view.Erase(offerKey); err != nil {
 		return tx.TefINTERNAL
 	}
@@ -1808,7 +1764,6 @@ func parseFee(ctx *tx.ApplyContext) uint64 {
 // applyHybridInSandbox handles hybrid offer placement in a specific view/sandbox.
 // Reference: rippled CreateOffer.cpp applyHybrid() lines 528-573
 func applyHybridInSandbox(view tx.LedgerView, ctx *tx.ApplyContext, offer *state.LedgerOffer, offerKey keylet.Keylet, takerPays, takerGets tx.Amount, domainBookDir keylet.Keylet) tx.Result {
-	// Set hybrid flag
 	offer.Flags |= lsfHybrid
 
 	// Also place in open book (without domain)
@@ -1822,7 +1777,6 @@ func applyHybridInSandbox(view tx.LedgerView, ctx *tx.ApplyContext, offer *state
 	bookBase := keylet.BookDir(takerPaysCurrency, takerPaysIssuer, takerGetsCurrency, takerGetsIssuer)
 	openBookDirKey := keylet.Quality(bookBase, uRate)
 
-	// Add to open book directory
 	bookDirResult, err := state.DirInsert(view, openBookDirKey, offerKey.Key, func(dir *state.DirectoryNode) {
 		dir.TakerPaysCurrency = takerPaysCurrency
 		dir.TakerPaysIssuer = takerPaysIssuer
@@ -1835,7 +1789,6 @@ func applyHybridInSandbox(view tx.LedgerView, ctx *tx.ApplyContext, offer *state
 		return tx.TefINTERNAL
 	}
 
-	// Store additional book info in offer
 	offer.AdditionalBookDirectory = openBookDirKey.Key
 	offer.AdditionalBookNode = bookDirResult.Page
 

--- a/internal/tx/oracle/oracle_delete.go
+++ b/internal/tx/oracle/oracle_delete.go
@@ -46,12 +46,10 @@ func (o *OracleDelete) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (o *OracleDelete) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(o)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (o *OracleDelete) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePriceOracle}
 }

--- a/internal/tx/oracle/oracle_delete.go
+++ b/internal/tx/oracle/oracle_delete.go
@@ -29,19 +29,16 @@ func NewOracleDelete(account string, oracleDocID uint32) *OracleDelete {
 	}
 }
 
-// TxType returns the transaction type
 func (o *OracleDelete) TxType() tx.Type {
 	return tx.TypeOracleDelete
 }
 
-// Validate validates the OracleDelete transaction (preflight validation)
-// This matches rippled's DeleteOracle::preflight()
+// Validate matches rippled's DeleteOracle::preflight()
 func (o *OracleDelete) Validate() error {
 	if err := o.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check flags - only universal flags allowed
 	if err := tx.CheckFlags(o.GetFlags(), tx.TfUniversalMask); err != nil {
 		return err
 	}

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -220,7 +220,6 @@ func (o *OracleSet) ValidatePriceDataSeries(isUpdate bool) (map[string]PriceData
 	return pairsToAdd, pairsToDelete, nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (o *OracleSet) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(o)
 }
@@ -248,7 +247,6 @@ func (o *OracleSet) AddPriceDataDelete(baseAsset, quoteAsset string) {
 	})
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (o *OracleSet) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePriceOracle}
 }

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -70,19 +70,16 @@ func NewOracleSet(account string, oracleDocID uint32, lastUpdateTime uint32) *Or
 	}
 }
 
-// TxType returns the transaction type
 func (o *OracleSet) TxType() tx.Type {
 	return tx.TypeOracleSet
 }
 
-// Validate validates the OracleSet transaction (preflight validation)
-// This matches rippled's SetOracle::preflight()
+// Validate matches rippled's SetOracle::preflight()
 func (o *OracleSet) Validate() error {
 	if err := o.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check flags - only universal flags allowed
 	if err := tx.CheckFlags(o.GetFlags(), tx.TfUniversalMask); err != nil {
 		return err
 	}
@@ -167,7 +164,6 @@ func (o *OracleSet) Validate() error {
 			return tx.Errorf(tx.TemMALFORMED, "Scale cannot exceed %d", MaxPriceScale)
 		}
 
-		// Check for duplicate token pairs
 		pairKey := entry.BaseAsset + ":" + entry.QuoteAsset
 		if seenPairs[pairKey] {
 			return tx.Errorf(tx.TemMALFORMED, "duplicate token pair in PriceDataSeries")
@@ -195,7 +191,6 @@ func (o *OracleSet) ValidatePriceDataSeries(isUpdate bool) (map[string]PriceData
 
 		key := entry.TokenPairKey()
 
-		// Check for duplicates in both sets
 		if _, exists := pairsToAdd[key]; exists {
 			return nil, nil, tx.Errorf(tx.TemMALFORMED, "duplicate token pair in PriceDataSeries")
 		}
@@ -359,7 +354,6 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			return tx.TecINVALID_UPDATE_TIME
 		}
 
-		// Check provider/assetClass consistency
 		// If field is present in tx, it must match existing value
 		if o.isFieldPresent("Provider") && o.Provider != existingOracle.Provider {
 			return tx.TemMALFORMED
@@ -479,14 +473,11 @@ func (o *OracleSet) doApplyUpdate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 		key := entry.TokenPairKey()
 
 		if entry.AssetPrice == nil {
-			// Delete pair
 			delete(orderedPairs, key)
 		} else if existing, ok := orderedPairs[key]; ok {
-			// Update existing pair
 			existing.price = entry.AssetPrice
 			existing.scale = entry.Scale
 		} else {
-			// Add new pair
 			orderedPairs[key] = &orderedPair{
 				baseAsset:  entry.BaseAsset,
 				quoteAsset: entry.QuoteAsset,
@@ -522,7 +513,6 @@ func (o *OracleSet) doApplyUpdate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 		updatedSeries = append(updatedSeries, pd)
 	}
 
-	// Update oracle SLE fields
 	existingOracle.PriceDataSeries = updatedSeries
 	existingOracle.LastUpdateTime = o.LastUpdateTime
 	if o.isFieldPresent("URI") || o.URI != "" {

--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -65,13 +65,11 @@ func ParseFromBinary(blob []byte) (Transaction, error) {
 		return nil, errors.New("failed to marshal decoded transaction: " + err.Error())
 	}
 
-	// Parse the JSON into a transaction
 	tx, err := ParseJSON(jsonBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set the present fields on the parsed transaction
 	tx.GetCommon().SetPresentFields(presentFields)
 
 	// Preserve the original serialized bytes so that downstream consumers

--- a/internal/tx/paychan/paychan_test.go
+++ b/internal/tx/paychan/paychan_test.go
@@ -21,10 +21,8 @@ func makeValidChannelID() string {
 	return strings.Repeat("AB", 32) // 32 bytes
 }
 
-// =============================================================================
 // PaymentChannelCreate Validation Tests
 // Based on rippled PayChan_test.cpp
-// =============================================================================
 
 func TestPaymentChannelCreateValidation(t *testing.T) {
 	tests := []struct {
@@ -223,9 +221,7 @@ func TestPaymentChannelCreateValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // PaymentChannelFund Validation Tests
-// =============================================================================
 
 func TestPaymentChannelFundValidation(t *testing.T) {
 	tests := []struct {
@@ -340,9 +336,7 @@ func TestPaymentChannelFundValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // PaymentChannelClaim Validation Tests
-// =============================================================================
 
 func TestPaymentChannelClaimValidation(t *testing.T) {
 	tests := []struct {
@@ -516,9 +510,7 @@ func TestPaymentChannelClaimValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Flatten Tests
-// =============================================================================
 
 func TestPaymentChannelCreateFlatten(t *testing.T) {
 	cancelAfter := uint32(750000000)
@@ -594,9 +586,7 @@ func TestPaymentChannelClaimFlatten(t *testing.T) {
 	assert.Equal(t, makeValidPublicKey(), flat["PublicKey"])
 }
 
-// =============================================================================
 // Constructor Tests
-// =============================================================================
 
 func TestPaymentChannelConstructors(t *testing.T) {
 	t.Run("NewPaymentChannelCreate", func(t *testing.T) {
@@ -627,9 +617,7 @@ func TestPaymentChannelConstructors(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Flag Tests
-// =============================================================================
 
 func TestPaymentChannelClaimFlags(t *testing.T) {
 	t.Run("SetClose", func(t *testing.T) {
@@ -647,9 +635,7 @@ func TestPaymentChannelClaimFlags(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Amendment Tests
-// =============================================================================
 
 func TestPaymentChannelRequiredAmendments(t *testing.T) {
 	t.Run("PaymentChannelCreate", func(t *testing.T) {

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -51,12 +51,10 @@ func NewPaymentChannelClaim(account, channel string) *PaymentChannelClaim {
 	}
 }
 
-// TxType returns the transaction type
 func (p *PaymentChannelClaim) TxType() tx.Type {
 	return tx.TypePaymentChannelClaim
 }
 
-// Validate validates the PaymentChannelClaim transaction
 // Reference: rippled PayChan.cpp PayChanClaim::preflight()
 func (p *PaymentChannelClaim) Validate() error {
 	if err := p.BaseTx.Validate(); err != nil {
@@ -197,7 +195,6 @@ func (p *PaymentChannelClaim) IsRenew() bool {
 	return p.GetFlags()&tfPayChanRenew != 0
 }
 
-// Apply applies a PaymentChannelClaim transaction
 // Reference: rippled PayChan.cpp PayChanClaim::preclaim() + doApply()
 func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("payment channel claim apply",
@@ -402,7 +399,6 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Update channel SLE
 	updatedChannelData, err := state.SerializePayChannelFromData(channel)
 	if err != nil {
 		return tx.TefINTERNAL
@@ -486,7 +482,6 @@ func validateCredentials(ctx *tx.ApplyContext, credentialIDs []string) tx.Result
 			return tx.TecBAD_CREDENTIALS
 		}
 
-		// Check expiration
 		if credEntry.Expiration != nil && ctx.Config.ParentCloseTime >= *credEntry.Expiration {
 			return tx.TecEXPIRED
 		}
@@ -508,7 +503,6 @@ func verifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src [20]
 		return tx.TesSUCCESS
 	}
 
-	// Check account-based DepositPreauth
 	preauthKey := keylet.DepositPreauth(dst, src)
 	if exists, _ := ctx.View.Exists(preauthKey); exists {
 		return tx.TesSUCCESS

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -163,12 +163,10 @@ func (p *PaymentChannelClaim) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (p *PaymentChannelClaim) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(p)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (p *PaymentChannelClaim) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
 }

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -53,12 +53,10 @@ func NewPaymentChannelCreate(account, destination string, amount tx.Amount, sett
 	}
 }
 
-// TxType returns the transaction type
 func (p *PaymentChannelCreate) TxType() tx.Type {
 	return tx.TypePaymentChannelCreate
 }
 
-// Validate validates the PaymentChannelCreate transaction
 // Reference: rippled PayChan.cpp PayChanCreate::preflight()
 func (p *PaymentChannelCreate) Validate() error {
 	if err := p.BaseTx.Validate(); err != nil {
@@ -132,7 +130,6 @@ func (p *PaymentChannelCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
 }
 
-// Apply applies a PaymentChannelCreate transaction
 // Reference: rippled PayChan.cpp PayChanCreate::doApply()
 func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("payment channel create apply",
@@ -211,7 +208,6 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Create pay channel
 	accountID, _ := state.DecodeAccountID(p.Account)
 	sequence := p.GetCommon().SeqProxy()
 	channelKey := keylet.PayChannel(accountID, destID, sequence)

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -120,12 +120,10 @@ func (p *PaymentChannelCreate) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (p *PaymentChannelCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(p)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (p *PaymentChannelCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
 }

--- a/internal/tx/paychan/payment_channel_fund.go
+++ b/internal/tx/paychan/payment_channel_fund.go
@@ -82,12 +82,10 @@ func (p *PaymentChannelFund) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (p *PaymentChannelFund) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(p)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (p *PaymentChannelFund) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
 }

--- a/internal/tx/paychan/payment_channel_fund.go
+++ b/internal/tx/paychan/payment_channel_fund.go
@@ -1,4 +1,3 @@
-// TODO missing sle method related to payment chanel
 package paychan
 
 import (
@@ -40,12 +39,10 @@ func NewPaymentChannelFund(account, channel string, amount tx.Amount) *PaymentCh
 	}
 }
 
-// TxType returns the transaction type
 func (p *PaymentChannelFund) TxType() tx.Type {
 	return tx.TypePaymentChannelFund
 }
 
-// Validate validates the PaymentChannelFund transaction
 // Reference: rippled PayChan.cpp PayChanFund::preflight()
 func (p *PaymentChannelFund) Validate() error {
 	if err := p.BaseTx.Validate(); err != nil {
@@ -95,7 +92,6 @@ func (p *PaymentChannelFund) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
 }
 
-// Apply applies a PaymentChannelFund transaction
 // Reference: rippled PayChan.cpp PayChanFund::doApply()
 func (p *PaymentChannelFund) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("payment channel fund apply",

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/LeJamon/goXRPLd/keylet"
 )
 
-// ============================================================================
 // Test Helpers - Mock LedgerView for testing
-// ============================================================================
 
 // paymentMockLedgerView implements LedgerView for testing
 type paymentMockLedgerView struct {
@@ -125,9 +123,7 @@ func (m *paymentMockLedgerView) createTrustLine(low, high [20]byte, currency str
 	m.data[key.Key] = data
 }
 
-// ============================================================================
 // EitherAmount Tests
-// ============================================================================
 
 func TestEitherAmount_XRP(t *testing.T) {
 	// Test XRP amount creation
@@ -201,9 +197,7 @@ func TestEitherAmount_Compare(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // Quality Tests
-// ============================================================================
 
 func TestQuality_FromAmounts(t *testing.T) {
 	// Quality = in / out
@@ -235,9 +229,7 @@ func TestQuality_BetterThan(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // PaymentSandbox Tests
-// ============================================================================
 
 func TestPaymentSandbox_Isolation(t *testing.T) {
 	// Create base view with an account
@@ -319,9 +311,7 @@ func TestPaymentSandbox_ChildSandbox(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // XRPEndpointStep Tests
-// ============================================================================
 
 func TestXRPEndpointStep_Source(t *testing.T) {
 	view := newPaymentMockLedgerView()
@@ -396,9 +386,7 @@ func TestXRPEndpointStep_QualityUpperBound(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // DirectStepI Tests
-// ============================================================================
 
 func TestDirectStepI_Basic(t *testing.T) {
 	view := newPaymentMockLedgerView()
@@ -425,9 +413,7 @@ func TestDirectStepI_Basic(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // Strand Tests
-// ============================================================================
 
 func TestToStrand_XRPToXRP(t *testing.T) {
 	view := newPaymentMockLedgerView()
@@ -492,9 +478,7 @@ func TestToStrands_WithPaths(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // ExecuteStrand Tests
-// ============================================================================
 
 func TestExecuteStrand_XRPPayment(t *testing.T) {
 	view := newPaymentMockLedgerView()
@@ -529,9 +513,7 @@ func TestExecuteStrand_XRPPayment(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // Flow Tests
-// ============================================================================
 
 func TestFlow_SingleStrand(t *testing.T) {
 	view := newPaymentMockLedgerView()
@@ -653,9 +635,7 @@ func TestFlow_SendMaxLimit(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // RippleCalculate Integration Test
-// ============================================================================
 
 func TestRippleCalculate_XRPPayment(t *testing.T) {
 	view := newPaymentMockLedgerView()
@@ -699,9 +679,7 @@ func TestRippleCalculate_XRPPayment(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // Issue and Book Tests
-// ============================================================================
 
 func TestIssue_IsXRP(t *testing.T) {
 	xrpIssue := Issue{Currency: "XRP"}
@@ -734,9 +712,7 @@ func TestBook_Creation(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // MulRatio Tests
-// ============================================================================
 
 func TestMulRatio_XRP(t *testing.T) {
 	amt := NewXRPEitherAmount(100)
@@ -772,9 +748,7 @@ func TestMulRatio_IOU(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // Strand Quality Tests
-// ============================================================================
 
 func TestGetStrandQuality(t *testing.T) {
 	view := newPaymentMockLedgerView()
@@ -807,9 +781,7 @@ func TestGetStrandQuality(t *testing.T) {
 	}
 }
 
-// ============================================================================
 // DebtDirection Tests
-// ============================================================================
 
 func TestDebtDirection(t *testing.T) {
 	if !Issues(DebtDirectionIssues) {

--- a/internal/tx/payment/pathfinder/pathfinder_test.go
+++ b/internal/tx/payment/pathfinder/pathfinder_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
 // Mock LedgerView
-// ---------------------------------------------------------------------------
 
 // mockLedgerView is an in-memory implementation of tx.LedgerView for unit tests.
 type mockLedgerView struct {
@@ -98,9 +96,7 @@ func compareKeys(a, b [32]byte) int {
 	return 0
 }
 
-// ---------------------------------------------------------------------------
 // Test helper: create deterministic test account IDs
-// ---------------------------------------------------------------------------
 
 // testAccountID creates a deterministic 20-byte account ID from a seed byte.
 func testAccountID(seed byte) [20]byte {
@@ -118,9 +114,7 @@ func testAccountAddress(id [20]byte) string {
 	return state.EncodeAccountIDSafe(id)
 }
 
-// ---------------------------------------------------------------------------
 // Test helper: populate a mock ledger with ledger entries
-// ---------------------------------------------------------------------------
 
 // addAccount stores a serialized AccountRoot at the proper keylet.
 func addAccount(t *testing.T, ledger *mockLedgerView, accountID [20]byte, balance uint64, flags uint32) {
@@ -248,9 +242,7 @@ func addBookDir(t *testing.T, ledger *mockLedgerView, takerPays, takerGets payme
 	ledger.entries[k.Key] = data
 }
 
-// ===========================================================================
 // Test 1: Path type tables
-// ===========================================================================
 
 func TestPathTable_Entries(t *testing.T) {
 	// Verify all 5 payment types have entries in the table
@@ -309,9 +301,7 @@ func TestPathTable_NonXRPToSame_HasDirectAccount(t *testing.T) {
 		"first nonXRP-to-same pattern should be source->accounts->dest")
 }
 
-// ===========================================================================
 // Test 2: PaymentType classification
-// ===========================================================================
 
 func TestClassifyPayment_XRPToXRP(t *testing.T) {
 	src := testAccountID(1)
@@ -397,9 +387,7 @@ func TestClassifyPayment_EmptySrcCurrencyIsXRP(t *testing.T) {
 	require.Equal(t, ptXRP_to_XRP, pf.classifyPayment())
 }
 
-// ===========================================================================
 // Test 3: RippleLineCache
-// ===========================================================================
 
 func TestRippleLineCache_GetLedger(t *testing.T) {
 	ledger := newMockLedger()
@@ -560,9 +548,7 @@ func TestRippleLineCache_MultipleCurrencies(t *testing.T) {
 	require.True(t, currencies["EUR"])
 }
 
-// ===========================================================================
 // Test 4: AccountCurrencies
-// ===========================================================================
 
 func TestAccountSourceCurrencies_AlwaysIncludesXRP(t *testing.T) {
 	ledger := newMockLedger()
@@ -669,9 +655,7 @@ func TestAccountDestCurrencies_WithAvailableCapacity(t *testing.T) {
 		"bob should be able to receive USD (balance < limit)")
 }
 
-// ===========================================================================
 // Test 5: BookIndex
-// ===========================================================================
 
 func TestBookIndex_EmptyLedger(t *testing.T) {
 	ledger := newMockLedger()
@@ -753,9 +737,7 @@ func TestBookIndex_LazyBuild(t *testing.T) {
 	require.True(t, bi.built)
 }
 
-// ===========================================================================
 // Test 6: pathHasSeen and pathHasSeenIssue (loop detection)
-// ===========================================================================
 
 func TestPathHasSeen_EmptyPath(t *testing.T) {
 	acct := testAccountID(1)
@@ -839,9 +821,7 @@ func TestPathHasSeenIssue_DifferentCurrency(t *testing.T) {
 		"different currency should not match")
 }
 
-// ===========================================================================
 // Test 7: addUniquePath (deduplication)
-// ===========================================================================
 
 func TestAddUniquePath_NoDuplicates(t *testing.T) {
 	pf := &Pathfinder{}
@@ -880,9 +860,7 @@ func TestAddUniquePath_MakesCopy(t *testing.T) {
 		"stored path should be independent copy")
 }
 
-// ===========================================================================
 // Test 8: isNoRipple
-// ===========================================================================
 
 func TestIsNoRipple_XRPCurrency(t *testing.T) {
 	ledger := newMockLedger()
@@ -949,9 +927,7 @@ func TestIsNoRipple_FlagNotSet(t *testing.T) {
 		"NoRipple on from's side should not trigger")
 }
 
-// ===========================================================================
 // Test 9: pathsEqual
-// ===========================================================================
 
 func TestPathsEqual_Empty(t *testing.T) {
 	require.True(t, pathsEqual(nil, nil))
@@ -982,9 +958,7 @@ func TestPathsEqual_DifferentSteps(t *testing.T) {
 	require.False(t, pathsEqual(a, b))
 }
 
-// ===========================================================================
 // Test 10: pathTypeKey
-// ===========================================================================
 
 func TestPathTypeKey_DeterministicAndUnique(t *testing.T) {
 	pt1 := PathType{ntSOURCE, ntACCOUNTS, ntDESTINATION}
@@ -999,9 +973,7 @@ func TestPathTypeKey_DeterministicAndUnique(t *testing.T) {
 	require.NotEqual(t, k1, k2, "different PathType should produce different key")
 }
 
-// ===========================================================================
 // Test 11: currencyTo20
-// ===========================================================================
 
 func TestCurrencyTo20_XRP(t *testing.T) {
 	result := currencyTo20("XRP")
@@ -1028,9 +1000,7 @@ func TestCurrencyTo20_Standard3Char(t *testing.T) {
 	}
 }
 
-// ===========================================================================
 // Test 12: issueFromAmount
-// ===========================================================================
 
 func TestIssueFromAmount_XRP(t *testing.T) {
 	amt := state.NewXRPAmountFromInt(1000000)
@@ -1048,9 +1018,7 @@ func TestIssueFromAmount_IOU(t *testing.T) {
 	require.Equal(t, gw, issue.Issuer)
 }
 
-// ===========================================================================
 // Test 13: FindPaths — basic scenarios
-// ===========================================================================
 
 func TestFindPaths_ZeroDstAmount(t *testing.T) {
 	ledger := newMockLedger()
@@ -1303,9 +1271,7 @@ func TestFindPaths_SourceIsEffectiveDst_DefaultPath(t *testing.T) {
 	require.Empty(t, pf.CompletePaths(), "should have no explicit paths (default path suffices)")
 }
 
-// ===========================================================================
 // Test 14: BookIndex with offers for pathfinding
-// ===========================================================================
 
 func TestFindPaths_XRPToIOU_ThroughOfferBook(t *testing.T) {
 	// Alice sends XRP, Bob receives USD. There's an offer: XRP -> USD.
@@ -1361,9 +1327,7 @@ func TestFindPaths_XRPToIOU_ThroughOfferBook(t *testing.T) {
 	t.Logf("Found %d complete paths for XRP->USD", len(paths))
 }
 
-// ===========================================================================
 // Test 15: PathRank sorting
-// ===========================================================================
 
 func TestPathRank_QualitySorting(t *testing.T) {
 	ranks := []PathRank{
@@ -1435,9 +1399,7 @@ func TestPathRank_IndexTiebreaker(t *testing.T) {
 	require.Equal(t, 1, ranks[2].Index)
 }
 
-// ===========================================================================
 // Test 16: NewPathfinder constructor
-// ===========================================================================
 
 func TestNewPathfinder_SourceStep(t *testing.T) {
 	ledger := newMockLedger()
@@ -1475,9 +1437,7 @@ func TestNewPathfinder_XRPSourceHasNoIssuer(t *testing.T) {
 	require.Empty(t, pf.source.Issuer, "XRP source should have no issuer")
 }
 
-// ===========================================================================
 // Test 17: PathRequest
-// ===========================================================================
 
 func TestNewPathRequest_Defaults(t *testing.T) {
 	src := testAccountID(1)
@@ -1501,9 +1461,7 @@ func TestNewPathRequest_WithSendMax(t *testing.T) {
 	require.NotNil(t, pr.sendMax)
 }
 
-// ===========================================================================
 // Test 18: AccountExists
-// ===========================================================================
 
 func TestAccountExists_Exists(t *testing.T) {
 	ledger := newMockLedger()
@@ -1519,9 +1477,7 @@ func TestAccountExists_DoesNotExist(t *testing.T) {
 	require.False(t, AccountExists(ledger, acct))
 }
 
-// ===========================================================================
 // Test 19: addPathsForType memoization
-// ===========================================================================
 
 func TestAddPathsForType_Memoization(t *testing.T) {
 	ledger := newMockLedger()
@@ -1580,9 +1536,7 @@ func TestAddPathsForType_EmptyPathType(t *testing.T) {
 	require.Len(t, result, 1, "empty PathType should produce one empty path")
 }
 
-// ===========================================================================
 // Test 20: Integration scenario — IOU-to-same-IOU path discovery
-// ===========================================================================
 
 func TestFindPaths_IOUSameIOU_MultipleTrustLines(t *testing.T) {
 	// Setup:
@@ -1645,9 +1599,7 @@ func TestFindPaths_IOUSameIOU_MultipleTrustLines(t *testing.T) {
 	// With multiple intermediaries, we expect paths through gw and possibly through carol.
 }
 
-// ===========================================================================
 // Test 21: getPathsOut
-// ===========================================================================
 
 func TestGetPathsOut_AccountNotFound(t *testing.T) {
 	ledger := newMockLedger()
@@ -1704,9 +1656,7 @@ func TestGetPathsOut_Caching(t *testing.T) {
 	require.True(t, ok, "result should be cached")
 }
 
-// ===========================================================================
 // Test 22: isNoRippleOut
-// ===========================================================================
 
 func TestIsNoRippleOut_EmptyPath(t *testing.T) {
 	pf := &Pathfinder{}
@@ -1721,9 +1671,7 @@ func TestIsNoRippleOut_LastStepNoAccount(t *testing.T) {
 	require.False(t, pf.isNoRippleOut(path), "step without account has no NoRipple")
 }
 
-// ===========================================================================
 // Test 23: buildPathFindTrustLine
-// ===========================================================================
 
 func TestBuildPathFindTrustLine_ViewAsLow(t *testing.T) {
 	low := testAccountID(1)
@@ -1781,9 +1729,7 @@ func TestBuildPathFindTrustLine_ViewAsHigh(t *testing.T) {
 	require.False(t, line.AuthPeer, "low's Auth should not be set")
 }
 
-// ===========================================================================
 // Utility: compareAccountIDs (used by helpers above)
-// ===========================================================================
 
 func compareAccountIDs(a, b [20]byte) int {
 	for i := 0; i < 20; i++ {
@@ -1797,9 +1743,7 @@ func compareAccountIDs(a, b [20]byte) int {
 	return 0
 }
 
-// ===========================================================================
 // Test 24: issueFromTxAmount
-// ===========================================================================
 
 func TestIssueFromTxAmount_XRP(t *testing.T) {
 	amt := tx.NewXRPAmount(1000000)
@@ -1816,9 +1760,7 @@ func TestIssueFromTxAmount_IOU(t *testing.T) {
 	require.Equal(t, gw, issue.Issuer)
 }
 
-// ===========================================================================
 // Test 25: Constants
-// ===========================================================================
 
 func TestConstants(t *testing.T) {
 	require.Equal(t, 10000, highPriority)
@@ -1837,9 +1779,7 @@ func TestAddFlags(t *testing.T) {
 	require.Equal(t, uint32(0x080), afAC_LAST)
 }
 
-// ===========================================================================
 // Test 26: Additional path type table coverage
-// ===========================================================================
 
 func TestPathTable_AllEntriesEndWithDestination(t *testing.T) {
 	for pt, entries := range pathTable {
@@ -1922,9 +1862,7 @@ func TestPathTable_NonXRPToXRP_KnownSecondEntry(t *testing.T) {
 	require.Equal(t, expected, second.Type)
 }
 
-// ===========================================================================
 // Test 27: Additional classifyPayment edge cases
-// ===========================================================================
 
 func TestClassifyPayment_XRP_EmptyString(t *testing.T) {
 	// Empty source currency plus native dest should be XRP-to-XRP
@@ -1937,9 +1875,7 @@ func TestClassifyPayment_XRP_EmptyString(t *testing.T) {
 	require.Equal(t, ptXRP_to_XRP, pf.classifyPayment())
 }
 
-// ===========================================================================
 // Test 28: Additional RippleLineCache — multiple peers
-// ===========================================================================
 
 func TestRippleLineCache_MultiplePeers(t *testing.T) {
 	ledger := newMockLedger()
@@ -1979,9 +1915,7 @@ func TestRippleLineCache_MultiplePeers(t *testing.T) {
 	require.True(t, currencies["EUR"])
 }
 
-// ===========================================================================
 // Test 29: Additional AccountCurrencies — exhausted credit
-// ===========================================================================
 
 func TestAccountSourceCurrencies_ExhaustedCredit(t *testing.T) {
 	ledger := newMockLedger()
@@ -2103,9 +2037,7 @@ func TestAccountDestCurrencies_AtCapacity(t *testing.T) {
 	require.True(t, currencies[payment.Issue{Currency: "XRP"}])
 }
 
-// ===========================================================================
 // Test 30: Additional BookIndex coverage
-// ===========================================================================
 
 func TestBookIndex_MultipleOffersForSameBook(t *testing.T) {
 	// Two offers with the same taker_pays issue should deduplicate to one book entry.
@@ -2192,9 +2124,7 @@ func TestBookIndex_IsBookToXRP_NotXRP(t *testing.T) {
 	require.False(t, bi.IsBookToXRP(usdIssue), "USD->EUR should not be a book to XRP")
 }
 
-// ===========================================================================
 // Test 31: Additional pathHasSeen with multiple steps
-// ===========================================================================
 
 func TestPathHasSeen_MultiStepPath(t *testing.T) {
 	acct1 := testAccountID(1)
@@ -2228,9 +2158,7 @@ func TestPathHasSeenIssue_MultipleSteps(t *testing.T) {
 	require.False(t, pathHasSeenIssue(path, payment.Issue{Currency: "USD", Issuer: acct2}))
 }
 
-// ===========================================================================
 // Test 32: PathRank sorting with liquidity
-// ===========================================================================
 
 func TestPathRank_LiquiditySorting(t *testing.T) {
 	// Same quality, different liquidity: higher liquidity should come first.
@@ -2292,9 +2220,7 @@ func TestPathRank_MixedCriteria(t *testing.T) {
 	require.Equal(t, 0, ranks[2].Index, "worst quality last despite high liquidity")
 }
 
-// ===========================================================================
 // Test 33: currencyTo20 additional cases
-// ===========================================================================
 
 func TestCurrencyTo20_EUR(t *testing.T) {
 	result := currencyTo20("EUR")
@@ -2312,9 +2238,7 @@ func TestCurrencyTo20_DifferentCurrenciesAreDifferent(t *testing.T) {
 	require.NotEqual(t, eur, btc)
 }
 
-// ===========================================================================
 // Test 34: FindPaths — XRP destination when dest doesn't exist
-// ===========================================================================
 
 func TestFindPaths_DestNotExist_XRPAllowed(t *testing.T) {
 	// XRP payments to non-existent destination may still proceed
@@ -2339,9 +2263,7 @@ func TestFindPaths_DestNotExist_XRPAllowed(t *testing.T) {
 	require.True(t, result, "XRP payment to non-existent dest should not fail at pathfinding stage")
 }
 
-// ===========================================================================
 // Test 35: buildPathFindTrustLine balance negation
-// ===========================================================================
 
 func TestBuildPathFindTrustLine_BalanceNegation(t *testing.T) {
 	low := testAccountID(1)
@@ -2414,9 +2336,7 @@ func TestBuildPathFindTrustLine_AllFlags(t *testing.T) {
 	require.True(t, highLine.AuthPeer, "high: LowAuth -> AuthPeer")
 }
 
-// ===========================================================================
 // Test 36: getPathsOut with trust lines and books
-// ===========================================================================
 
 func TestGetPathsOut_WithTrustLines(t *testing.T) {
 	ledger := newMockLedger()
@@ -2487,9 +2407,7 @@ func TestGetPathsOut_FrozenPeerExcluded(t *testing.T) {
 	require.Equal(t, 0, count, "frozen peer should be excluded from paths out")
 }
 
-// ===========================================================================
 // Test 37: Issue.IsXRP
-// ===========================================================================
 
 func TestIssue_IsXRP(t *testing.T) {
 	require.True(t, payment.Issue{Currency: "XRP"}.IsXRP())
@@ -2498,9 +2416,7 @@ func TestIssue_IsXRP(t *testing.T) {
 	require.False(t, payment.Issue{Currency: "EUR", Issuer: testAccountID(1)}.IsXRP())
 }
 
-// ===========================================================================
 // Test 38: PathRequest with explicit source currencies
-// ===========================================================================
 
 func TestNewPathRequest_WithSourceCurrencies(t *testing.T) {
 	src := testAccountID(1)
@@ -2517,9 +2433,7 @@ func TestNewPathRequest_WithSourceCurrencies(t *testing.T) {
 	require.True(t, pr.convertAll)
 }
 
-// ===========================================================================
 // Test 39: CompletePaths and PathRanks accessors
-// ===========================================================================
 
 func TestPathfinder_Accessors(t *testing.T) {
 	pf := &Pathfinder{}
@@ -2527,9 +2441,7 @@ func TestPathfinder_Accessors(t *testing.T) {
 	require.Nil(t, pf.PathRanks(), "new pathfinder should have nil path ranks")
 }
 
-// ===========================================================================
 // Test 40: isNoRippleOut with single-step path from source
-// ===========================================================================
 
 func TestIsNoRippleOut_SingleStep_FromSource(t *testing.T) {
 	ledger := newMockLedger()

--- a/internal/tx/payment/payment.go
+++ b/internal/tx/payment/payment.go
@@ -124,7 +124,6 @@ func (p *Payment) isMPTDirect() bool {
 	return p.MPTokenIssuanceID != "" || p.Amount.IsMPT()
 }
 
-// Validate validates the payment transaction
 // Reference: rippled Payment.cpp preflight() function
 func (p *Payment) Validate() error {
 	if err := p.BaseTx.Validate(); err != nil {
@@ -419,7 +418,6 @@ func (p *Payment) SetNoDirectRipple() {
 	p.SetFlags(flags)
 }
 
-// Apply applies the Payment transaction to the ledger state.
 func (p *Payment) Apply(ctx *tx.ApplyContext) tx.Result {
 	mptDirect := p.isMPTDirect()
 

--- a/internal/tx/payment/payment.go
+++ b/internal/tx/payment/payment.go
@@ -97,7 +97,6 @@ func NewPayment(account, destination string, amount tx.Amount) *Payment {
 	}
 }
 
-// TxType returns the transaction type
 func (p *Payment) TxType() tx.Type {
 	return tx.TypePayment
 }
@@ -304,7 +303,6 @@ func (p *Payment) Validate() error {
 			return tx.Errorf(tx.TemMALFORMED, "Invalid credentials array size")
 		}
 
-		// Check for duplicates
 		seen := make(map[string]bool, len(p.CredentialIDs))
 		for _, id := range p.CredentialIDs {
 			if seen[id] {
@@ -377,7 +375,6 @@ func (p *Payment) validatePathElements() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (p *Payment) Flatten() (map[string]any, error) {
 	m, err := tx.ReflectFlatten(p)
 	if err != nil {

--- a/internal/tx/permissioneddomain/permission_domain_set.go
+++ b/internal/tx/permissioneddomain/permission_domain_set.go
@@ -41,7 +41,6 @@ func (p *PermissionedDomainSet) TxType() tx.Type {
 	return tx.TypePermissionedDomainSet
 }
 
-// Validate validates the PermissionedDomainSet transaction
 // Reference: rippled PermissionedDomainSet.cpp preflight()
 func (p *PermissionedDomainSet) Validate() error {
 	if err := p.BaseTx.Validate(); err != nil {
@@ -133,7 +132,6 @@ func (p *PermissionedDomainSet) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePermissionedDomains, amendment.FeatureCredentials}
 }
 
-// Apply applies the PermissionedDomainSet transaction to the ledger.
 // Reference: rippled PermissionedDomainSet.cpp preclaim() + doApply()
 func (p *PermissionedDomainSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("permissioned domain set apply",

--- a/internal/tx/permissioneddomain/permission_domain_set.go
+++ b/internal/tx/permissioneddomain/permission_domain_set.go
@@ -37,7 +37,6 @@ func NewPermissionedDomainSet(account string) *PermissionedDomainSet {
 	}
 }
 
-// TxType returns the transaction type
 func (p *PermissionedDomainSet) TxType() tx.Type {
 	return tx.TypePermissionedDomainSet
 }
@@ -83,7 +82,6 @@ func (p *PermissionedDomainSet) Validate() error {
 		return ErrPermDomainTooManyCredentials
 	}
 
-	// Check for duplicates and validate each credential
 	seen := make(map[string]bool)
 	for _, cred := range p.AcceptedCredentials {
 		data := cred.Credential
@@ -117,7 +115,6 @@ func (p *PermissionedDomainSet) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (p *PermissionedDomainSet) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(p)
 }
@@ -132,7 +129,6 @@ func (p *PermissionedDomainSet) AddAcceptedCredential(issuer, credentialType str
 	})
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (p *PermissionedDomainSet) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePermissionedDomains, amendment.FeatureCredentials}
 }

--- a/internal/tx/permissioneddomain/permissioned_domain_delete.go
+++ b/internal/tx/permissioneddomain/permissioned_domain_delete.go
@@ -32,7 +32,6 @@ func NewPermissionedDomainDelete(account, domainID string) *PermissionedDomainDe
 	}
 }
 
-// TxType returns the transaction type
 func (p *PermissionedDomainDelete) TxType() tx.Type {
 	return tx.TypePermissionedDomainDelete
 }
@@ -76,12 +75,10 @@ func (p *PermissionedDomainDelete) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (p *PermissionedDomainDelete) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(p)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (p *PermissionedDomainDelete) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePermissionedDomains}
 }
@@ -133,7 +130,6 @@ func (p *PermissionedDomainDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TefBAD_LEDGER
 	}
 
-	// Erase the domain from ledger
 	if err := ctx.View.Erase(domainKeylet); err != nil {
 		ctx.Log.Error("permissioned domain delete: failed to erase domain", "error", err)
 		return tx.TefINTERNAL

--- a/internal/tx/permissioneddomain/permissioned_domain_delete.go
+++ b/internal/tx/permissioneddomain/permissioned_domain_delete.go
@@ -36,7 +36,6 @@ func (p *PermissionedDomainDelete) TxType() tx.Type {
 	return tx.TypePermissionedDomainDelete
 }
 
-// Validate validates the PermissionedDomainDelete transaction
 // Reference: rippled PermissionedDomainDelete.cpp preflight()
 func (p *PermissionedDomainDelete) Validate() error {
 	if err := p.BaseTx.Validate(); err != nil {
@@ -83,7 +82,6 @@ func (p *PermissionedDomainDelete) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePermissionedDomains}
 }
 
-// Apply applies the PermissionedDomainDelete transaction to the ledger.
 // Reference: rippled PermissionedDomainDelete.cpp preclaim() + doApply()
 func (p *PermissionedDomainDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("permissioned domain delete apply",

--- a/internal/tx/permissioneddomain/permissioned_domain_test.go
+++ b/internal/tx/permissioneddomain/permissioned_domain_test.go
@@ -25,10 +25,8 @@ func makeCredTypeHex(byteLen int) string {
 	return strings.Repeat("AB", byteLen)
 }
 
-// =============================================================================
 // PermissionedDomainSet Validation Tests
 // Based on rippled PermissionedDomains_test.cpp
-// =============================================================================
 
 func TestPermissionedDomainSetValidation(t *testing.T) {
 	tests := []struct {
@@ -225,9 +223,7 @@ func TestPermissionedDomainSetValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // PermissionedDomainDelete Validation Tests
-// =============================================================================
 
 func TestPermissionedDomainDeleteValidation(t *testing.T) {
 	tests := []struct {
@@ -300,9 +296,7 @@ func TestPermissionedDomainDeleteValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Flatten Tests
-// =============================================================================
 
 func TestPermissionedDomainSetFlatten(t *testing.T) {
 	t.Run("create new domain", func(t *testing.T) {
@@ -347,9 +341,7 @@ func TestPermissionedDomainDeleteFlatten(t *testing.T) {
 	assert.Equal(t, makeValidDomainID(), flat["DomainID"])
 }
 
-// =============================================================================
 // Constructor Tests
-// =============================================================================
 
 func TestPermissionedDomainConstructors(t *testing.T) {
 	t.Run("NewPermissionedDomainSet", func(t *testing.T) {
@@ -370,9 +362,7 @@ func TestPermissionedDomainConstructors(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // AddAcceptedCredential Test
-// =============================================================================
 
 func TestPermissionedDomainSetAddAcceptedCredential(t *testing.T) {
 	tx := NewPermissionedDomainSet("rOwner")
@@ -389,9 +379,7 @@ func TestPermissionedDomainSetAddAcceptedCredential(t *testing.T) {
 	assert.Equal(t, "4647484950", tx.AcceptedCredentials[1].Credential.CredentialType)
 }
 
-// =============================================================================
 // Amendment Tests
-// =============================================================================
 
 func TestPermissionedDomainRequiredAmendments(t *testing.T) {
 	t.Run("PermissionedDomainSet", func(t *testing.T) {
@@ -408,9 +396,7 @@ func TestPermissionedDomainRequiredAmendments(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Constants Tests
-// =============================================================================
 
 func TestPermissionedDomainConstants(t *testing.T) {
 	assert.Equal(t, 10, MaxPermissionedDomainCredentials)

--- a/internal/tx/pseudo/enable_amendment.go
+++ b/internal/tx/pseudo/enable_amendment.go
@@ -45,7 +45,6 @@ func (e *EnableAmendment) TxType() tx.Type {
 	return tx.TypeAmendment
 }
 
-// Validate validates the EnableAmendment transaction.
 // Reference: rippled Change.cpp preflight()
 func (e *EnableAmendment) Validate() error {
 	// Pseudo-transaction: minimal validation
@@ -64,7 +63,6 @@ func (e *EnableAmendment) IsPseudoTransaction() bool {
 	return true
 }
 
-// Apply applies the EnableAmendment transaction to ledger state.
 // Reference: rippled Change.cpp applyAmendment() lines 248-345
 func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled line 251: uint256 amendment(ctx_.tx.getFieldH256(sfAmendment))

--- a/internal/tx/pseudo/enable_amendment.go
+++ b/internal/tx/pseudo/enable_amendment.go
@@ -41,7 +41,6 @@ const (
 	tfLostMajority uint32 = 0x00020000
 )
 
-// TxType returns the transaction type
 func (e *EnableAmendment) TxType() tx.Type {
 	return tx.TypeAmendment
 }
@@ -56,7 +55,6 @@ func (e *EnableAmendment) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (e *EnableAmendment) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(e)
 }
@@ -69,7 +67,6 @@ func (e *EnableAmendment) IsPseudoTransaction() bool {
 // Apply applies the EnableAmendment transaction to ledger state.
 // Reference: rippled Change.cpp applyAmendment() lines 248-345
 func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
-	// Parse the amendment hash from the transaction
 	// Reference: rippled line 251: uint256 amendment(ctx_.tx.getFieldH256(sfAmendment))
 	amendmentHash, err := parseAmendmentHash(e.Amendment)
 	if err != nil {
@@ -169,11 +166,9 @@ func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
 		// The amendment is recorded in the ledger state which is the primary goal.
 	}
 
-	// Update the majorities list
 	// Reference: rippled lines 337-340
 	sle.Majorities = newMajorities
 
-	// Serialize and write back
 	serialized, serErr := SerializeAmendmentsSLE(sle)
 	if serErr != nil {
 		return tx.TefINTERNAL

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -66,7 +66,6 @@ func NewSetFee() *SetFee {
 	}
 }
 
-// TxType returns the transaction type
 func (s *SetFee) TxType() tx.Type {
 	return tx.TypeFee
 }
@@ -91,7 +90,6 @@ func (s *SetFee) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (s *SetFee) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(s)
 }
@@ -114,7 +112,6 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 		"reserveIncrement", s.ReserveIncrement,
 	)
 
-	// Get the fees keylet
 	feesKey := keylet.Fees()
 
 	// Check if FeeSettings exists
@@ -191,7 +188,6 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Serialize the updated FeeSettings
 	data, err := state.SerializeFeeSettings(feeSettings)
 	if err != nil {
 		ctx.Log.Error("set fee: failed to serialize fee settings", "error", err)

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -70,7 +70,6 @@ func (s *SetFee) TxType() tx.Type {
 	return tx.TypeFee
 }
 
-// Validate validates the SetFee transaction.
 // Reference: rippled Change.cpp preflight()
 func (s *SetFee) Validate() error {
 	// SetFee is a pseudo-transaction - most standard validation is skipped
@@ -99,7 +98,6 @@ func (s *SetFee) IsPseudoTransaction() bool {
 	return true
 }
 
-// Apply applies the SetFee transaction to ledger state.
 // This creates or updates the FeeSettings singleton entry.
 // Reference: rippled Change.cpp applyFee()
 func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {

--- a/internal/tx/pseudo/unl_modify.go
+++ b/internal/tx/pseudo/unl_modify.go
@@ -33,7 +33,6 @@ func (u *UNLModify) TxType() tx.Type {
 	return tx.TypeUNLModify
 }
 
-// Validate validates the UNLModify transaction.
 // Reference: rippled Change.cpp preflight()
 func (u *UNLModify) Validate() error {
 	// Pseudo-transaction: minimal validation
@@ -50,7 +49,6 @@ func (u *UNLModify) IsPseudoTransaction() bool {
 	return true
 }
 
-// Apply applies the UNLModify transaction to ledger state.
 // Reference: rippled Change.cpp applyUNLModify() lines 388-512
 func (u *UNLModify) Apply(ctx *tx.ApplyContext) tx.Result {
 	// 1. Validate flag ledger

--- a/internal/tx/pseudo/unl_modify.go
+++ b/internal/tx/pseudo/unl_modify.go
@@ -29,7 +29,6 @@ type UNLModify struct {
 	UNLModifyValidator string `json:"UNLModifyValidator,omitempty" xrpl:"UNLModifyValidator,omitempty"`
 }
 
-// TxType returns the transaction type
 func (u *UNLModify) TxType() tx.Type {
 	return tx.TypeUNLModify
 }
@@ -42,7 +41,6 @@ func (u *UNLModify) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (u *UNLModify) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(u)
 }

--- a/internal/tx/registry.go
+++ b/internal/tx/registry.go
@@ -73,7 +73,6 @@ func ToJSON(tx Transaction) ([]byte, error) {
 	return json.Marshal(flat)
 }
 
-// Validate validates a transaction and returns any errors
 func Validate(tx Transaction) error {
 	return tx.Validate()
 }

--- a/internal/tx/signerlist/signer_list_set.go
+++ b/internal/tx/signerlist/signer_list_set.go
@@ -50,7 +50,6 @@ func NewSignerListSet(account string, quorum uint32) *SignerListSet {
 	}
 }
 
-// TxType returns the transaction type
 func (s *SignerListSet) TxType() tx.Type {
 	return tx.TypeSignerListSet
 }
@@ -113,7 +112,6 @@ func (s *SignerListSet) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (s *SignerListSet) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(s)
 }
@@ -143,7 +141,6 @@ func NewSetRegularKey(account string) *SetRegularKey {
 	}
 }
 
-// TxType returns the transaction type
 func (s *SetRegularKey) TxType() tx.Type {
 	return tx.TypeRegularKeySet
 }
@@ -161,7 +158,6 @@ func (s *SetRegularKey) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (s *SetRegularKey) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(s)
 }
@@ -372,7 +368,6 @@ func (s *SignerListSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		return sleEntries[i].Account < sleEntries[j].Account
 	})
 
-	// Serialize and insert the new signer list.
 	signerListData, err := state.SerializeSignerList(s.SignerQuorum, sleEntries, ctx.AccountID, flags)
 	if err != nil {
 		ctx.Log.Error("signer list set: failed to serialize signer list", "error", err)

--- a/internal/tx/signerlist/signer_list_set.go
+++ b/internal/tx/signerlist/signer_list_set.go
@@ -54,7 +54,6 @@ func (s *SignerListSet) TxType() tx.Type {
 	return tx.TypeSignerListSet
 }
 
-// Validate validates the SignerListSet transaction
 func (s *SignerListSet) Validate() error {
 	if err := s.BaseTx.Validate(); err != nil {
 		return err
@@ -145,7 +144,6 @@ func (s *SetRegularKey) TxType() tx.Type {
 	return tx.TypeRegularKeySet
 }
 
-// Validate validates the SetRegularKey transaction
 // Reference: rippled SetRegularKey.cpp preflight() — no type-specific flags allowed
 func (s *SetRegularKey) Validate() error {
 	if err := s.BaseTx.Validate(); err != nil {
@@ -172,7 +170,6 @@ func (s *SetRegularKey) ClearKey() {
 	s.RegularKey = ""
 }
 
-// Apply applies the SetRegularKey transaction to ledger state.
 // Reference: rippled SetRegularKey.cpp preflight + doApply()
 func (s *SetRegularKey) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Amendment-gated preflight check: reject setting RegularKey to own account.
@@ -281,7 +278,6 @@ func signerCountBasedOwnerCountDelta(entryCount int) int {
 	return 2 + entryCount
 }
 
-// Apply applies the SignerListSet transaction to ledger state.
 // Reference: rippled SetSignerList.cpp preflight() + doApply(), replaceSignerList(), destroySignerList()
 func (s *SignerListSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Check for invalid flags, gated behind fixInvalidTxFlags.

--- a/internal/tx/ticket/ticket_create.go
+++ b/internal/tx/ticket/ticket_create.go
@@ -29,7 +29,6 @@ func NewTicketCreate(account string, count uint32) *TicketCreate {
 	}
 }
 
-// TxType returns the transaction type
 func (t *TicketCreate) TxType() tx.Type {
 	return tx.TypeTicketCreate
 }
@@ -62,7 +61,6 @@ func (t *TicketCreate) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (t *TicketCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(t)
 }
@@ -117,7 +115,6 @@ func (t *TicketCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecINSUFFICIENT_RESERVE
 	}
 
-	// Create tickets
 	for i := uint32(0); i < t.TicketCount; i++ {
 		ticketSeq := ctx.Account.Sequence + i
 
@@ -132,7 +129,6 @@ func (t *TicketCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			return tx.TefINTERNAL
 		}
 
-		// Add ticket to owner directory
 		_, err = state.DirInsert(ctx.View, ownerDirKey, ticketKey.Key, func(dir *state.DirectoryNode) {
 			dir.Owner = ctx.AccountID
 		})

--- a/internal/tx/ticket/ticket_create.go
+++ b/internal/tx/ticket/ticket_create.go
@@ -39,7 +39,6 @@ func (t *TicketCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureTicketBatch}
 }
 
-// Validate validates the TicketCreate transaction
 // Reference: rippled CreateTicket.cpp preflight()
 func (t *TicketCreate) Validate() error {
 	if err := t.BaseTx.Validate(); err != nil {
@@ -65,7 +64,6 @@ func (t *TicketCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(t)
 }
 
-// Apply applies the TicketCreate transaction to ledger state.
 // Reference: rippled CreateTicket.cpp preclaim() + doApply()
 func (t *TicketCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Log.Trace("ticket create apply",

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -348,7 +348,6 @@ type BaseTx struct {
 	txType Type
 }
 
-// TxType returns the transaction type
 func (b *BaseTx) TxType() Type {
 	return b.txType
 }
@@ -358,12 +357,10 @@ func (b *BaseTx) GetCommon() *Common {
 	return &b.Common
 }
 
-// Validate validates the base transaction
 func (b *BaseTx) Validate() error {
 	return b.Common.Validate()
 }
 
-// Flatten returns a flat map of transaction fields
 func (b *BaseTx) Flatten() (map[string]any, error) {
 	return b.Common.ToMap(), nil
 }

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -70,7 +70,6 @@ func (t *TrustSet) TxType() tx.Type {
 	return tx.TypeTrustSet
 }
 
-// Validate validates the TrustSet transaction
 // Reference: rippled SetTrust.cpp preflight()
 func (t *TrustSet) Validate() error {
 	if err := t.BaseTx.Validate(); err != nil {

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -66,7 +66,6 @@ func NewTrustSet(account string, limitAmount tx.Amount) *TrustSet {
 	}
 }
 
-// TxType returns the transaction type
 func (t *TrustSet) TxType() tx.Type {
 	return tx.TypeTrustSet
 }
@@ -130,7 +129,6 @@ func (t *TrustSet) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (t *TrustSet) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(t)
 }
@@ -212,7 +210,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TemDST_IS_SRC
 	}
 
-	// Get the issuer account ID
 	issuerAccountID, err := state.DecodeAccountID(t.LimitAmount.Issuer)
 	if err != nil {
 		return tx.TemBAD_ISSUER
@@ -233,7 +230,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TefINTERNAL
 	}
 
-	// Get the account ID
 	accountID, _ := state.DecodeAccountID(ctx.Account.Account)
 
 	// Capture the initial owner count and compute the reserve once,
@@ -444,7 +440,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			PreviousTxnLgrSeq: ctx.Config.LedgerSequence,
 		}
 
-		// Set the limit based on which side this account is
 		// Note: In RippleState, LowLimit.Issuer = LOW account, HighLimit.Issuer = HIGH account
 		// The "issuer" in these Amount fields refers to which account owns that limit
 		lowAccountStr, _ := state.EncodeAccountID(lowAccountID)
@@ -549,7 +544,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		rs.LowNode = lowDirResult.Page
 		rs.HighNode = highDirResult.Page
 
-		// Serialize and insert the trust line
 		trustLineData, err := state.SerializeRippleState(rs)
 		if err != nil {
 			return tx.TefINTERNAL
@@ -559,7 +553,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			return tx.TefINTERNAL
 		}
 
-		// Increment owner count for the transaction sender
 		ctx.Account.OwnerCount++
 	} else {
 		// Modify existing trust line
@@ -573,7 +566,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			return tx.TefINTERNAL
 		}
 
-		// Update the limit.
 		// Per rippled: saLimitAllow = saLimitAmount; saLimitAllow.setIssuer(account_);
 		// The limit's issuer must be set to the sender's account, not the counterparty.
 		// In a RippleState, LowLimit.Issuer = lowAccount, HighLimit.Issuer = highAccount.
@@ -737,7 +729,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			highDirKey := keylet.OwnerDir(highAccountID)
 			state.DirRemove(ctx.View, highDirKey, rs.HighNode, trustLineKey.Key, false)
 
-			// Delete the trust line
 			if err := ctx.View.Erase(trustLineKey); err != nil {
 				return tx.TefINTERNAL
 			}
@@ -855,7 +846,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 				}
 			}
 
-			// Update the trust line
 			updatedData, err := state.SerializeRippleState(rs)
 			if err != nil {
 				return tx.TefINTERNAL

--- a/internal/tx/trustset/trustset_test.go
+++ b/internal/tx/trustset/trustset_test.go
@@ -18,7 +18,6 @@ func TestTrustSetValidation(t *testing.T) {
 		expectError bool
 		errorMsg    string
 	}{
-		// === Valid Trust Line Creation Tests ===
 		{
 			name: "valid trust line creation with positive limit",
 			trustSet: &TrustSet{
@@ -52,7 +51,6 @@ func TestTrustSetValidation(t *testing.T) {
 			expectError: false,
 		},
 
-		// === Remove Trust Line (Zero Limit) Tests ===
 		{
 			name: "valid remove trust line with zero limit",
 			trustSet: &TrustSet{
@@ -62,7 +60,6 @@ func TestTrustSetValidation(t *testing.T) {
 			expectError: false,
 		},
 
-		// === Missing LimitAmount Tests ===
 		{
 			name: "missing LimitAmount currency - should fail",
 			trustSet: &TrustSet{
@@ -109,7 +106,6 @@ func TestTrustSetValidation(t *testing.T) {
 			errorMsg:    "temBAD_LIMIT: negative credit limit",
 		},
 
-		// === Trust Line to Self Tests ===
 		{
 			name: "trust line to self - should fail",
 			trustSet: &TrustSet{
@@ -120,7 +116,6 @@ func TestTrustSetValidation(t *testing.T) {
 			errorMsg:    "temDST_IS_SRC: cannot create trust line to self",
 		},
 
-		// === Missing Account Tests ===
 		{
 			name: "missing account - should fail",
 			trustSet: &TrustSet{
@@ -131,7 +126,6 @@ func TestTrustSetValidation(t *testing.T) {
 			errorMsg:    "Account is required",
 		},
 
-		// === QualityIn and QualityOut Tests ===
 		{
 			name: "valid trust line with QualityIn",
 			trustSet: &TrustSet{

--- a/internal/tx/vault/vault_clawback.go
+++ b/internal/tx/vault/vault_clawback.go
@@ -37,7 +37,6 @@ func NewVaultClawback(account, vaultID, holder string) *VaultClawback {
 	}
 }
 
-// TxType returns the transaction type
 func (v *VaultClawback) TxType() tx.Type {
 	return tx.TypeVaultClawback
 }
@@ -110,12 +109,10 @@ func (v *VaultClawback) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (v *VaultClawback) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(v)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (v *VaultClawback) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }

--- a/internal/tx/vault/vault_clawback.go
+++ b/internal/tx/vault/vault_clawback.go
@@ -41,7 +41,6 @@ func (v *VaultClawback) TxType() tx.Type {
 	return tx.TypeVaultClawback
 }
 
-// Validate validates the VaultClawback transaction
 // Reference: rippled VaultClawback.cpp preflight()
 func (v *VaultClawback) Validate() error {
 	if err := v.BaseTx.Validate(); err != nil {
@@ -117,7 +116,6 @@ func (v *VaultClawback) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }
 
-// Apply applies the VaultClawback transaction to the ledger.
 func (v *VaultClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 	if v.VaultID == "" || v.Holder == "" {
 		return tx.TemINVALID

--- a/internal/tx/vault/vault_create.go
+++ b/internal/tx/vault/vault_create.go
@@ -46,7 +46,6 @@ func NewVaultCreate(account string, asset tx.Asset) *VaultCreate {
 	}
 }
 
-// TxType returns the transaction type
 func (v *VaultCreate) TxType() tx.Type {
 	return tx.TypeVaultCreate
 }
@@ -126,12 +125,10 @@ func (v *VaultCreate) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (v *VaultCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(v)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (v *VaultCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }

--- a/internal/tx/vault/vault_create.go
+++ b/internal/tx/vault/vault_create.go
@@ -50,7 +50,6 @@ func (v *VaultCreate) TxType() tx.Type {
 	return tx.TypeVaultCreate
 }
 
-// Validate validates the VaultCreate transaction
 // Reference: rippled VaultCreate.cpp preflight()
 func (v *VaultCreate) Validate() error {
 	if err := v.BaseTx.Validate(); err != nil {
@@ -133,7 +132,6 @@ func (v *VaultCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }
 
-// Apply applies the VaultCreate transaction to the ledger.
 func (v *VaultCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	if v.Asset.Currency == "" {
 		return tx.TemINVALID

--- a/internal/tx/vault/vault_delete.go
+++ b/internal/tx/vault/vault_delete.go
@@ -30,7 +30,6 @@ func NewVaultDelete(account, vaultID string) *VaultDelete {
 	}
 }
 
-// TxType returns the transaction type
 func (v *VaultDelete) TxType() tx.Type {
 	return tx.TypeVaultDelete
 }
@@ -71,12 +70,10 @@ func (v *VaultDelete) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (v *VaultDelete) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(v)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (v *VaultDelete) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }

--- a/internal/tx/vault/vault_delete.go
+++ b/internal/tx/vault/vault_delete.go
@@ -34,7 +34,6 @@ func (v *VaultDelete) TxType() tx.Type {
 	return tx.TypeVaultDelete
 }
 
-// Validate validates the VaultDelete transaction
 // Reference: rippled VaultDelete.cpp preflight()
 func (v *VaultDelete) Validate() error {
 	if err := v.BaseTx.Validate(); err != nil {
@@ -78,7 +77,6 @@ func (v *VaultDelete) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }
 
-// Apply applies the VaultDelete transaction to the ledger.
 func (v *VaultDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	if v.VaultID == "" {
 		return tx.TemINVALID

--- a/internal/tx/vault/vault_deposit.go
+++ b/internal/tx/vault/vault_deposit.go
@@ -38,7 +38,6 @@ func (v *VaultDeposit) TxType() tx.Type {
 	return tx.TypeVaultDeposit
 }
 
-// Validate validates the VaultDeposit transaction
 // Reference: rippled VaultDeposit.cpp preflight()
 func (v *VaultDeposit) Validate() error {
 	if err := v.BaseTx.Validate(); err != nil {
@@ -92,7 +91,6 @@ func (v *VaultDeposit) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }
 
-// Apply applies the VaultDeposit transaction to the ledger.
 func (v *VaultDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	if v.VaultID == "" || v.Amount.IsZero() {
 		return tx.TemINVALID

--- a/internal/tx/vault/vault_deposit.go
+++ b/internal/tx/vault/vault_deposit.go
@@ -34,7 +34,6 @@ func NewVaultDeposit(account, vaultID string, amount tx.Amount) *VaultDeposit {
 	}
 }
 
-// TxType returns the transaction type
 func (v *VaultDeposit) TxType() tx.Type {
 	return tx.TypeVaultDeposit
 }
@@ -85,12 +84,10 @@ func (v *VaultDeposit) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (v *VaultDeposit) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(v)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (v *VaultDeposit) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }

--- a/internal/tx/vault/vault_set.go
+++ b/internal/tx/vault/vault_set.go
@@ -39,7 +39,6 @@ func NewVaultSet(account, vaultID string) *VaultSet {
 	}
 }
 
-// TxType returns the transaction type
 func (v *VaultSet) TxType() tx.Type {
 	return tx.TypeVaultSet
 }
@@ -100,12 +99,10 @@ func (v *VaultSet) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (v *VaultSet) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(v)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (v *VaultSet) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }

--- a/internal/tx/vault/vault_set.go
+++ b/internal/tx/vault/vault_set.go
@@ -43,7 +43,6 @@ func (v *VaultSet) TxType() tx.Type {
 	return tx.TypeVaultSet
 }
 
-// Validate validates the VaultSet transaction
 // Reference: rippled VaultSet.cpp preflight()
 func (v *VaultSet) Validate() error {
 	if err := v.BaseTx.Validate(); err != nil {
@@ -107,7 +106,6 @@ func (v *VaultSet) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }
 
-// Apply applies the VaultSet transaction to the ledger.
 func (v *VaultSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	if v.VaultID == "" {
 		return tx.TemINVALID

--- a/internal/tx/vault/vault_test.go
+++ b/internal/tx/vault/vault_test.go
@@ -20,10 +20,8 @@ func makeZeroVaultID() string {
 	return strings.Repeat("00", 32)
 }
 
-// =============================================================================
 // VaultCreate Validation Tests
 // Based on rippled VaultCreate.cpp
-// =============================================================================
 
 func TestVaultCreateValidation(t *testing.T) {
 	tests := []struct {
@@ -222,10 +220,8 @@ func TestVaultCreateValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // VaultSet Validation Tests
 // Based on rippled VaultSet.cpp
-// =============================================================================
 
 func TestVaultSetValidation(t *testing.T) {
 	tests := []struct {
@@ -343,10 +339,8 @@ func TestVaultSetValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // VaultDelete Validation Tests
 // Based on rippled VaultDelete.cpp
-// =============================================================================
 
 func TestVaultDeleteValidation(t *testing.T) {
 	tests := []struct {
@@ -413,10 +407,8 @@ func TestVaultDeleteValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // VaultDeposit Validation Tests
 // Based on rippled VaultDeposit.cpp
-// =============================================================================
 
 func TestVaultDepositValidation(t *testing.T) {
 	tests := []struct {
@@ -500,10 +492,8 @@ func TestVaultDepositValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // VaultWithdraw Validation Tests
 // Based on rippled VaultWithdraw.cpp
-// =============================================================================
 
 func TestVaultWithdrawValidation(t *testing.T) {
 	tests := []struct {
@@ -619,10 +609,8 @@ func TestVaultWithdrawValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // VaultClawback Validation Tests
 // Based on rippled VaultClawback.cpp
-// =============================================================================
 
 func TestVaultClawbackValidation(t *testing.T) {
 	tests := []struct {
@@ -748,9 +736,7 @@ func TestVaultClawbackValidation(t *testing.T) {
 	}
 }
 
-// =============================================================================
 // Flatten Tests
-// =============================================================================
 
 func TestVaultFlatten(t *testing.T) {
 	t.Run("VaultCreate", func(t *testing.T) {
@@ -834,9 +820,7 @@ func TestVaultFlatten(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Constructor Tests
-// =============================================================================
 
 func TestVaultConstructors(t *testing.T) {
 	t.Run("NewVaultCreate", func(t *testing.T) {
@@ -891,9 +875,7 @@ func TestVaultConstructors(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Amendment Tests
-// =============================================================================
 
 func TestVaultRequiredAmendments(t *testing.T) {
 	t.Run("VaultCreate", func(t *testing.T) {
@@ -933,9 +915,7 @@ func TestVaultRequiredAmendments(t *testing.T) {
 	})
 }
 
-// =============================================================================
 // Constants Tests
-// =============================================================================
 
 func TestVaultConstants(t *testing.T) {
 	assert.Equal(t, 256, MaxVaultDataLength)

--- a/internal/tx/vault/vault_withdraw.go
+++ b/internal/tx/vault/vault_withdraw.go
@@ -40,7 +40,6 @@ func NewVaultWithdraw(account, vaultID string, amount tx.Amount) *VaultWithdraw 
 	}
 }
 
-// TxType returns the transaction type
 func (v *VaultWithdraw) TxType() tx.Type {
 	return tx.TypeVaultWithdraw
 }
@@ -105,12 +104,10 @@ func (v *VaultWithdraw) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (v *VaultWithdraw) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(v)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (v *VaultWithdraw) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }

--- a/internal/tx/vault/vault_withdraw.go
+++ b/internal/tx/vault/vault_withdraw.go
@@ -44,7 +44,6 @@ func (v *VaultWithdraw) TxType() tx.Type {
 	return tx.TypeVaultWithdraw
 }
 
-// Validate validates the VaultWithdraw transaction
 // Reference: rippled VaultWithdraw.cpp preflight()
 func (v *VaultWithdraw) Validate() error {
 	if err := v.BaseTx.Validate(); err != nil {
@@ -112,7 +111,6 @@ func (v *VaultWithdraw) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureSingleAssetVault}
 }
 
-// Apply applies the VaultWithdraw transaction to the ledger.
 func (v *VaultWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 	if v.VaultID == "" || v.Amount.IsZero() {
 		return tx.TemINVALID

--- a/internal/tx/xchain/xchain.go
+++ b/internal/tx/xchain/xchain.go
@@ -67,12 +67,10 @@ func NewXChainCreateBridge(account string, bridge XChainBridge, signatureReward 
 	}
 }
 
-// TxType returns the transaction type
 func (x *XChainCreateBridge) TxType() tx.Type {
 	return tx.TypeXChainCreateBridge
 }
 
-// Validate validates the XChainCreateBridge transaction
 func (x *XChainCreateBridge) Validate() error {
 	if err := x.BaseTx.Validate(); err != nil {
 		return err
@@ -85,12 +83,10 @@ func (x *XChainCreateBridge) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (x *XChainCreateBridge) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(x)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (x *XChainCreateBridge) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureXChainBridge}
 }
@@ -123,22 +119,18 @@ func NewXChainModifyBridge(account string, bridge XChainBridge) *XChainModifyBri
 	}
 }
 
-// TxType returns the transaction type
 func (x *XChainModifyBridge) TxType() tx.Type {
 	return tx.TypeXChainModifyBridge
 }
 
-// Validate validates the XChainModifyBridge transaction
 func (x *XChainModifyBridge) Validate() error {
 	return x.BaseTx.Validate()
 }
 
-// Flatten returns a flat map of all transaction fields
 func (x *XChainModifyBridge) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(x)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (x *XChainModifyBridge) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureXChainBridge}
 }
@@ -167,12 +159,10 @@ func NewXChainCreateClaimID(account string, bridge XChainBridge, signatureReward
 	}
 }
 
-// TxType returns the transaction type
 func (x *XChainCreateClaimID) TxType() tx.Type {
 	return tx.TypeXChainCreateClaimID
 }
 
-// Validate validates the XChainCreateClaimID transaction
 func (x *XChainCreateClaimID) Validate() error {
 	if err := x.BaseTx.Validate(); err != nil {
 		return err
@@ -185,12 +175,10 @@ func (x *XChainCreateClaimID) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (x *XChainCreateClaimID) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(x)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (x *XChainCreateClaimID) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureXChainBridge}
 }
@@ -222,12 +210,10 @@ func NewXChainCommit(account string, bridge XChainBridge, claimID uint64, amount
 	}
 }
 
-// TxType returns the transaction type
 func (x *XChainCommit) TxType() tx.Type {
 	return tx.TypeXChainCommit
 }
 
-// Validate validates the XChainCommit transaction
 func (x *XChainCommit) Validate() error {
 	if err := x.BaseTx.Validate(); err != nil {
 		return err
@@ -240,12 +226,10 @@ func (x *XChainCommit) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (x *XChainCommit) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(x)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (x *XChainCommit) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureXChainBridge}
 }
@@ -281,12 +265,10 @@ func NewXChainClaim(account string, bridge XChainBridge, claimID uint64, destina
 	}
 }
 
-// TxType returns the transaction type
 func (x *XChainClaim) TxType() tx.Type {
 	return tx.TypeXChainClaim
 }
 
-// Validate validates the XChainClaim transaction
 func (x *XChainClaim) Validate() error {
 	if err := x.BaseTx.Validate(); err != nil {
 		return err
@@ -303,12 +285,10 @@ func (x *XChainClaim) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (x *XChainClaim) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(x)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (x *XChainClaim) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureXChainBridge}
 }
@@ -341,12 +321,10 @@ func NewXChainAccountCreateCommit(account string, bridge XChainBridge, destinati
 	}
 }
 
-// TxType returns the transaction type
 func (x *XChainAccountCreateCommit) TxType() tx.Type {
 	return tx.TypeXChainAccountCreateCommit
 }
 
-// Validate validates the XChainAccountCreateCommit transaction
 func (x *XChainAccountCreateCommit) Validate() error {
 	if err := x.BaseTx.Validate(); err != nil {
 		return err
@@ -363,12 +341,10 @@ func (x *XChainAccountCreateCommit) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (x *XChainAccountCreateCommit) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(x)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (x *XChainAccountCreateCommit) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureXChainBridge}
 }
@@ -417,12 +393,10 @@ func NewXChainAddClaimAttestation(account string, bridge XChainBridge, claimID u
 	}
 }
 
-// TxType returns the transaction type
 func (x *XChainAddClaimAttestation) TxType() tx.Type {
 	return tx.TypeXChainAddClaimAttestation
 }
 
-// Validate validates the XChainAddClaimAttestation transaction
 func (x *XChainAddClaimAttestation) Validate() error {
 	if err := x.BaseTx.Validate(); err != nil {
 		return err
@@ -451,12 +425,10 @@ func (x *XChainAddClaimAttestation) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (x *XChainAddClaimAttestation) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(x)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (x *XChainAddClaimAttestation) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureXChainBridge}
 }
@@ -507,12 +479,10 @@ func NewXChainAddAccountCreateAttestation(account string, bridge XChainBridge) *
 	}
 }
 
-// TxType returns the transaction type
 func (x *XChainAddAccountCreateAttestation) TxType() tx.Type {
 	return tx.TypeXChainAddAccountCreateAttest
 }
 
-// Validate validates the XChainAddAccountCreateAttestation transaction
 func (x *XChainAddAccountCreateAttestation) Validate() error {
 	if err := x.BaseTx.Validate(); err != nil {
 		return err
@@ -529,34 +499,28 @@ func (x *XChainAddAccountCreateAttestation) Validate() error {
 	return nil
 }
 
-// Flatten returns a flat map of all transaction fields
 func (x *XChainAddAccountCreateAttestation) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(x)
 }
 
-// RequiredAmendments returns the amendments required for this transaction type
 func (x *XChainAddAccountCreateAttestation) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureXChainBridge}
 }
 
-// Apply applies the XChainCreateBridge transaction to the ledger.
 func (x *XChainCreateBridge) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Account.OwnerCount++
 	return tx.TesSUCCESS
 }
 
-// Apply applies the XChainModifyBridge transaction to the ledger.
 func (x *XChainModifyBridge) Apply(ctx *tx.ApplyContext) tx.Result {
 	return tx.TesSUCCESS
 }
 
-// Apply applies the XChainCreateClaimID transaction to the ledger.
 func (x *XChainCreateClaimID) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Account.OwnerCount++
 	return tx.TesSUCCESS
 }
 
-// Apply applies the XChainCommit transaction to the ledger.
 func (x *XChainCommit) Apply(ctx *tx.ApplyContext) tx.Result {
 	if x.Amount.IsNative() {
 		amount := uint64(x.Amount.Drops())
@@ -568,7 +532,6 @@ func (x *XChainCommit) Apply(ctx *tx.ApplyContext) tx.Result {
 	return tx.TesSUCCESS
 }
 
-// Apply applies the XChainClaim transaction to the ledger.
 func (x *XChainClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 	if x.Amount.IsNative() {
 		amount := uint64(x.Amount.Drops())
@@ -590,7 +553,6 @@ func (x *XChainClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 	return tx.TesSUCCESS
 }
 
-// Apply applies the XChainAccountCreateCommit transaction to the ledger.
 func (x *XChainAccountCreateCommit) Apply(ctx *tx.ApplyContext) tx.Result {
 	if x.Amount.IsNative() {
 		amount := uint64(x.Amount.Drops())
@@ -602,12 +564,10 @@ func (x *XChainAccountCreateCommit) Apply(ctx *tx.ApplyContext) tx.Result {
 	return tx.TesSUCCESS
 }
 
-// Apply applies the XChainAddClaimAttestation transaction to the ledger.
 func (x *XChainAddClaimAttestation) Apply(ctx *tx.ApplyContext) tx.Result {
 	return tx.TesSUCCESS
 }
 
-// Apply applies the XChainAddAccountCreateAttestation transaction to the ledger.
 func (x *XChainAddAccountCreateAttestation) Apply(ctx *tx.ApplyContext) tx.Result {
 	return tx.TesSUCCESS
 }

--- a/internal/txq/accept.go
+++ b/internal/txq/accept.go
@@ -39,7 +39,6 @@ func (q *TxQ) Accept(ctx AcceptContext) bool {
 		candidate := q.byFee[i]
 		account := candidate.Account
 
-		// Get account queue
 		aq, exists := q.byAccount[account]
 		if !exists {
 			// Shouldn't happen, but handle it
@@ -58,7 +57,6 @@ func (q *TxQ) Accept(ctx AcceptContext) bool {
 			}
 		}
 
-		// Check if the fee level is still sufficient
 		txInLedger := ctx.GetTxInLedger()
 		snapshot := q.feeMetrics.GetSnapshot()
 		requiredFeeLevel := ScaleFeeLevel(snapshot, txInLedger)
@@ -160,7 +158,6 @@ func (q *TxQ) eraseAndAdvance(idx *int, c *Candidate) {
 		nextCandidate.SeqProxy.Value > c.SeqProxy.Value &&
 		(feeNext == nil || q.candidateLess(nextCandidate, feeNext))
 
-	// Remove the current candidate
 	q.erase(c)
 
 	if useAccountNext {

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -13,14 +13,9 @@ import (
 
 // ApplyResult represents the result of trying to apply or queue a transaction.
 type ApplyResult struct {
-	// Result is the transaction result code
-	Result tx.Result
-
-	// Applied is true if the transaction was applied to the open ledger
+	Result  tx.Result
 	Applied bool
-
-	// Queued is true if the transaction was added to the queue
-	Queued bool
+	Queued  bool
 }
 
 // ApplyContext provides the context needed to apply a transaction.
@@ -85,23 +80,19 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	feePaid, _ := strconv.ParseUint(common.Fee, 10, 64)
 	feeLevel := ToFeeLevel(feePaid, baseFee)
 
-	// Get account info
 	acctSeq := ctx.GetAccountSequence(account)
 	txInLedger := ctx.GetTxInLedger()
 	ledgerSeq := ctx.GetLedgerSequence()
 
-	// Determine SeqProxy (sequence or ticket)
 	var seqProxy SeqProxy
 	if common.TicketSequence != nil && *common.TicketSequence != 0 {
 		seqProxy = NewSeqProxyTicket(*common.TicketSequence)
 	} else if common.Sequence != nil {
 		seqProxy = NewSeqProxySequence(*common.Sequence)
 	} else {
-		// No sequence specified
 		return ApplyResult{Result: tx.TefINTERNAL, Applied: false}
 	}
 
-	// Get LastLedgerSequence if set
 	var lastValid uint32
 	if common.LastLedgerSequence != nil {
 		lastValid = *common.LastLedgerSequence
@@ -118,12 +109,9 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	// Reference: rippled TxQ::tryDirectApply(), TxQ.cpp:1696-1699
 	canDirectApply := seqProxy.IsTicket || seqProxy.Value == acctSeq
 
-	// Check if fee is high enough to apply directly
 	if canDirectApply && feeLevel >= requiredFeeLevel {
-		// Try to apply directly
 		result, applied := ctx.ApplyTransaction(txn)
 		if applied {
-			// If we replaced a queued transaction, remove it
 			if aq, exists := q.byAccount[account]; exists {
 				if c, exists := aq.Transactions[seqProxy]; exists {
 					q.erase(c)
@@ -131,7 +119,6 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 			}
 			return ApplyResult{Result: result, Applied: true}
 		}
-		// Transaction failed to apply, may still be able to queue
 		if !canBeQueued(result) {
 			return ApplyResult{Result: result, Applied: false}
 		}
@@ -144,12 +131,10 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		return ApplyResult{Result: tx.TelCAN_NOT_QUEUE, Applied: false}
 	}
 
-	// Check if account exists
 	if !ctx.AccountExists(account) {
 		return ApplyResult{Result: tx.TerNO_ACCOUNT, Applied: false}
 	}
 
-	// For ticket-based transactions, verify the ticket exists
 	if seqProxy.IsTicket {
 		if !ctx.TicketExists(account, seqProxy.Value) {
 			if seqProxy.Value < acctSeq {
@@ -159,12 +144,10 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		}
 	}
 
-	// Check if LastLedgerSequence is far enough in the future
 	if lastValid != 0 && lastValid < ledgerSeq+q.config.MinimumLastLedgerBuffer {
 		return ApplyResult{Result: tx.TelCAN_NOT_QUEUE, Applied: false}
 	}
 
-	// Compute consequences early for blocker detection
 	consequences := computeConsequences(txn, seqProxy)
 
 	// Get or create account queue.
@@ -273,7 +256,6 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		if requiresMultiTxn && !seqProxy.IsTicket {
 			prevTx := aq.GetPrevTx(seqProxy)
 			goesAtFront := prevTx == nil || seqProxy.Less(prevTx.SeqProxy)
-			// Also treat as front if prevTx is stale (< acctSeqProx)
 			if prevTx != nil && prevTx.SeqProxy.Less(acctSeqProx) {
 				goesAtFront = true
 			}
@@ -399,7 +381,6 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	// multiTxn.has_value() in rippled corresponds to requiresMultiTxn
 	if !seqProxy.IsTicket && exists && acctTxCount > 0 && requiresMultiTxn &&
 		feeLevel > requiredFeeLevel && requiredFeeLevel > FeeLevel(BaseLevel) {
-		// Check if first queued sequence tx has full retries remaining
 		firstSeqTx := aq.GetFirstSeqTx()
 		if firstSeqTx != nil && firstSeqTx.RetriesRemaining == RetriesAllowed {
 			if result := q.tryClearAccountQueue(ctx, aq, txn, seqProxy, feeLevel, txInLedger, account); result != nil {
@@ -419,7 +400,6 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	// Check if queue is full (when not replacing).
 	// Reference: rippled TxQ.cpp:1243-1315
 	if replacingCandidate == nil && q.isFull() {
-		// Find the lowest-fee candidate from a different account
 		var lowestOther *Candidate
 		for i := len(q.byFee) - 1; i >= 0; i-- {
 			c := q.byFee[i]
@@ -441,7 +421,6 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		// Reference: rippled TxQ.cpp:1265-1292
 		endEffectiveFeeLevel := lowestOther.FeeLevel
 		if lowestOther.FeeLevel <= feeLevel && endAccount.Count() > 1 {
-			// Compute average fee level for the target account
 			var sumDiv, sumMod FeeLevel
 			count := FeeLevel(endAccount.Count())
 			overflow := false
@@ -478,12 +457,10 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		}
 	}
 
-	// Remove the candidate being replaced
 	if replacingCandidate != nil {
 		q.erase(replacingCandidate)
 	}
 
-	// Create and add the new candidate
 	if !exists {
 		aq = NewAccountQueue(account)
 		q.byAccount[account] = aq

--- a/internal/txq/candidate.go
+++ b/internal/txq/candidate.go
@@ -13,10 +13,7 @@ const RetriesAllowed = 10
 // SeqProxy represents either a sequence number or a ticket number.
 // This mirrors rippled's SeqProxy type.
 type SeqProxy struct {
-	// Value is the sequence or ticket number
-	Value uint32
-
-	// IsTicket indicates whether this is a ticket number (true) or sequence (false)
+	Value    uint32
 	IsTicket bool
 }
 
@@ -33,59 +30,34 @@ func NewSeqProxyTicket(ticket uint32) SeqProxy {
 // Less returns true if this SeqProxy is less than other.
 // Sequences come before tickets, and within each category, lower values come first.
 func (s SeqProxy) Less(other SeqProxy) bool {
-	// Sequences come before tickets
 	if !s.IsTicket && other.IsTicket {
 		return true
 	}
 	if s.IsTicket && !other.IsTicket {
 		return false
 	}
-	// Same type, compare values
 	return s.Value < other.Value
 }
 
 // Candidate represents a transaction that may be applied to the open ledger.
 // It holds all the information needed to attempt application and track retries.
 type Candidate struct {
-	// Txn is the transaction to apply
-	Txn tx.Transaction
-
-	// TxID is the transaction hash
-	TxID [32]byte
-
-	// Account is the account that submitted the transaction
-	Account [20]byte
-
-	// FeeLevel is the fee level paid by this transaction
-	FeeLevel FeeLevel
-
-	// SeqProxy is the sequence or ticket number
-	SeqProxy SeqProxy
-
-	// LastValid is the LastLedgerSequence if present (0 if not set)
-	LastValid uint32
-
-	// RetriesRemaining tracks how many more times we can retry this transaction.
-	// Starts at RetriesAllowed.
-	RetriesRemaining int
-
-	// LastResult holds the result from the last failed application attempt.
-	// Zero value means no attempt has been made yet.
-	LastResult tx.Result
-
+	Txn              tx.Transaction
+	TxID             [32]byte
+	Account          [20]byte
+	FeeLevel         FeeLevel
+	SeqProxy         SeqProxy
+	LastValid        uint32
+	RetriesRemaining int // starts at RetriesAllowed; drops to 0 before removal
+	LastResult       tx.Result
 	// PreflightResult holds the result from the preflight check.
 	PreflightResult tx.Result
-
-	// Fee is the fee in drops
-	Fee uint64
-
-	// Consequences tracks the potential impact of this transaction
-	Consequences TxConsequences
+	Fee             uint64
+	Consequences    TxConsequences
 }
 
 // TxConsequences describes the potential impact of applying a transaction.
 type TxConsequences struct {
-	// Fee is the fee that will be consumed
 	Fee uint64
 
 	// PotentialSpend is the maximum XRP that could be spent beyond the fee.
@@ -128,10 +100,7 @@ func NewCandidate(
 
 // AccountQueue tracks queued transactions for a single account.
 type AccountQueue struct {
-	// Account is the account ID
-	Account [20]byte
-
-	// Transactions maps SeqProxy to Candidate, ordered by SeqProxy
+	Account      [20]byte
 	Transactions map[SeqProxy]*Candidate
 
 	// RetryPenalty is set when a transaction has exhausted its retries.
@@ -242,7 +211,6 @@ func (aq *AccountQueue) GetSortedCandidates() []*Candidate {
 		result = append(result, c)
 	}
 
-	// Sort by SeqProxy
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].SeqProxy.Less(result[j].SeqProxy)
 	})

--- a/internal/txq/process.go
+++ b/internal/txq/process.go
@@ -26,10 +26,8 @@ func (q *TxQ) ProcessClosedLedger(ctx ClosedLedgerContext, timeLeap bool) uint32
 	ledgerSeq := ctx.GetLedgerSequence()
 	feeLevels := ctx.GetTransactionFeeLevels()
 
-	// Update fee metrics and get transaction count
 	txCount := q.feeMetrics.Update(feeLevels, timeLeap, q.config)
 
-	// Update maximum queue size
 	// Reference: rippled sets maxSize_ = max(txnsExpected * ledgersInQueue, queueSizeMin)
 	if !timeLeap {
 		snapshot := q.feeMetrics.GetSnapshot()

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -10,12 +10,8 @@ import (
 // be included in a ledger. It manages fee escalation, per-account queuing,
 // and transaction selection based on fee level.
 type TxQ struct {
-	mu sync.Mutex
-
-	// config holds the queue configuration
-	config Config
-
-	// feeMetrics tracks and computes fee escalation
+	mu         sync.Mutex
+	config     Config
 	feeMetrics *FeeMetrics
 
 	// byFee holds all candidates sorted by fee level (descending).
@@ -28,7 +24,6 @@ type TxQ struct {
 	byAccount map[[20]byte]*AccountQueue
 
 	// maxSize is the dynamic maximum queue size.
-	// It's recomputed after each ledger close based on recent transaction counts.
 	// nil means no limit (before the first processClosedLedger call).
 	// Reference: rippled uses std::optional<size_t> maxSize_ which starts as nullopt.
 	maxSize *uint32
@@ -52,29 +47,14 @@ func New(config Config) *TxQ {
 
 // Metrics holds queue metrics for monitoring and RPC.
 type Metrics struct {
-	// TxCount is the number of transactions in the queue
-	TxCount uint32
-
-	// TxQMaxSize is the maximum queue size (may be nil if no limit)
-	TxQMaxSize *uint32
-
-	// TxInLedger is the number of transactions in the current open ledger
-	TxInLedger uint32
-
-	// TxPerLedger is the expected number of transactions per ledger
-	TxPerLedger uint32
-
-	// ReferenceFeeLevel is the base fee level (256)
-	ReferenceFeeLevel uint64
-
-	// MinProcessingFeeLevel is the minimum fee level to be accepted into the queue
+	TxCount               uint32
+	TxQMaxSize            *uint32 // nil means no limit
+	TxInLedger            uint32
+	TxPerLedger           uint32
+	ReferenceFeeLevel     uint64
 	MinProcessingFeeLevel uint64
-
-	// MedFeeLevel is the median fee level from the last closed ledger
-	MedFeeLevel uint64
-
-	// OpenLedgerFeeLevel is the fee level required to bypass the queue
-	OpenLedgerFeeLevel uint64
+	MedFeeLevel           uint64
+	OpenLedgerFeeLevel    uint64
 }
 
 // GetMetrics returns the current queue metrics.
@@ -87,7 +67,6 @@ func (q *TxQ) GetMetrics(txInLedger uint32) Metrics {
 
 	minProcessingFeeLevel := BaseLevel
 	if q.isFull() && len(q.byFee) > 0 {
-		// When full, need to beat the lowest fee in the queue
 		minProcessingFeeLevel = uint64(q.byFee[len(q.byFee)-1].FeeLevel) + 1
 	}
 
@@ -140,10 +119,7 @@ func (q *TxQ) GetRequiredFeeLevel(txInLedger uint32) FeeLevel {
 // Candidates with the same fee are ordered by txID XOR parentHash for deterministic ordering.
 // Caller must hold the lock.
 func (q *TxQ) insertByFee(c *Candidate) {
-	// Find insertion point using binary search
 	pos := q.findInsertPosition(c)
-
-	// Insert at position
 	q.byFee = append(q.byFee, nil)
 	copy(q.byFee[pos+1:], q.byFee[pos:])
 	q.byFee[pos] = c
@@ -153,7 +129,6 @@ func (q *TxQ) insertByFee(c *Candidate) {
 // Order is: descending by fee level, then ascending by (txID XOR parentHash).
 // Caller must hold the lock.
 func (q *TxQ) findInsertPosition(c *Candidate) int {
-	// Binary search for the right position
 	lo, hi := 0, len(q.byFee)
 	for lo < hi {
 		mid := (lo + hi) / 2
@@ -220,7 +195,6 @@ func (q *TxQ) erase(c *Candidate) {
 
 	if aq, exists := q.byAccount[c.Account]; exists {
 		aq.Remove(c.SeqProxy)
-		// Clean up empty account queues
 		if aq.Empty() {
 			delete(q.byAccount, c.Account)
 		}

--- a/keylet/keylet.go
+++ b/keylet/keylet.go
@@ -58,7 +58,6 @@ func indexHash(space uint16, data ...[]byte) [32]byte {
 	spaceBytes := make([]byte, 2)
 	binary.BigEndian.PutUint16(spaceBytes, space)
 
-	// Collect all inputs for hashing
 	inputs := make([][]byte, 0, len(data)+1)
 	inputs = append(inputs, spaceBytes)
 	inputs = append(inputs, data...)
@@ -348,7 +347,7 @@ func BookDirWithDomain(takerPaysCurrency, takerPaysIssuer, takerGetsCurrency, ta
 func Quality(k Keylet, quality uint64) Keylet {
 	result := Keylet{
 		Type: k.Type,
-		Key:  k.Key, // Copy the key
+		Key:  k.Key,
 	}
 	// Encode quality in the last 8 bytes (big-endian)
 	binary.BigEndian.PutUint64(result.Key[24:], quality)

--- a/shamap/cache.go
+++ b/shamap/cache.go
@@ -70,7 +70,6 @@ func (c *TreeNodeCache) Put(hash [32]byte, node Node) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Check if already in cache
 	if elem, found := c.cache[hash]; found {
 		c.lruList.MoveToFront(elem)
 		elem.Value.(*cacheEntry).node = node
@@ -82,7 +81,6 @@ func (c *TreeNodeCache) Put(hash [32]byte, node Node) {
 		c.evictOldest()
 	}
 
-	// Add new entry
 	entry := &cacheEntry{hash: hash, node: node}
 	elem := c.lruList.PushFront(entry)
 	c.cache[hash] = elem
@@ -200,7 +198,6 @@ func (c *FullBelowCache) MarkFull(hash [32]byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Check if already marked
 	if _, found := c.fullSet[hash]; found {
 		return
 	}
@@ -295,12 +292,10 @@ func (c *FullBelowCache) Touch(hash [32]byte, childHashes [][32]byte) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Check if already full
 	if _, found := c.fullSet[hash]; found {
 		return true
 	}
 
-	// Check if all children are full
 	for _, childHash := range childHashes {
 		if _, found := c.fullSet[childHash]; !found {
 			return false

--- a/shamap/fuzz_proof_test.go
+++ b/shamap/fuzz_proof_test.go
@@ -143,8 +143,6 @@ func FuzzVerifyProofPathValidTree(f *testing.F) {
 	})
 }
 
-// --- helpers ---
-
 func makeHash(fill byte) [32]byte {
 	var h [32]byte
 	for i := range h {

--- a/shamap/leaf_node.go
+++ b/shamap/leaf_node.go
@@ -17,9 +17,6 @@ type LeafNode interface {
 	SetItem(item *Item) (bool, error)
 }
 
-// -----------------------------------------------------------------------------
-// AccountStateLeafNode
-
 // AccountStateLeafNode represents a leaf node containing account state data
 type AccountStateLeafNode struct {
 	BaseNode
@@ -222,9 +219,6 @@ func (n *AccountStateLeafNode) Clone() (Node, error) {
 	return NewAccountStateLeafNode(clonedItem)
 }
 
-// -----------------------------------------------------------------------------
-// TransactionLeafNode (transaction without metadata)
-
 // TransactionLeafNode represents a leaf node containing transaction data without metadata
 type TransactionLeafNode struct {
 	BaseNode
@@ -406,9 +400,6 @@ func (n *TransactionLeafNode) Clone() (Node, error) {
 
 	return NewTransactionLeafNode(clonedItem)
 }
-
-// -----------------------------------------------------------------------------
-// TransactionWithMetaLeafNode (transaction with metadata)
 
 // TransactionWithMetaLeafNode represents a leaf node containing transaction data with metadata
 type TransactionWithMetaLeafNode struct {
@@ -603,9 +594,6 @@ func (n *TransactionWithMetaLeafNode) Clone() (Node, error) {
 
 	return NewTransactionWithMetaLeafNode(clonedItem)
 }
-
-// -----------------------------------------------------------------------------
-// Helper Functions
 
 // ItemFromLeafNode extracts the item from any leaf node type
 func ItemFromLeafNode(node Node) *Item {

--- a/shamap/proof.go
+++ b/shamap/proof.go
@@ -33,7 +33,6 @@ func (sm *SHAMap) GetProofPath(key [32]byte) (*ProofPath, error) {
 		return &ProofPath{Key: key, Found: false}, nil
 	}
 
-	// Check if it's a leaf node
 	leafNode, ok := leaf.(LeafNode)
 	if !ok {
 		return &ProofPath{Key: key, Found: false}, nil
@@ -128,7 +127,6 @@ func VerifyProofPath(rootHash [32]byte, key [32]byte, path [][]byte) bool {
 			// Calculate which branch to follow
 			branch := SelectBranch(nodeID, key)
 
-			// Get the hash of the child we should follow
 			childHash, err := innerNode.ChildHash(int(branch))
 			if err != nil {
 				return false
@@ -254,7 +252,6 @@ func VerifyProofPathWithValue(rootHash [32]byte, key [32]byte, path [][]byte) []
 				return nil
 			}
 
-			// Return a copy of the data
 			return item.Data()
 		} else {
 			return nil
@@ -414,7 +411,6 @@ func VerifyProofPathDetailed(rootHash [32]byte, key [32]byte, path [][]byte) err
 				}
 			}
 
-			// Success
 			return nil
 		} else {
 			return &ProofPathError{

--- a/shamap/store_test.go
+++ b/shamap/store_test.go
@@ -505,8 +505,6 @@ func TestDeserializeFromPrefix_AccountStateLeaf(t *testing.T) {
 	}
 }
 
-// ===== Phase 2: Backed SHAMap + Lazy Loading Tests =====
-
 // TestBacked_NewFromRootHash creates a map, flushes it, then recreates from root hash
 // and verifies all data is accessible via lazy loading.
 func TestBacked_NewFromRootHash(t *testing.T) {

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -290,7 +290,6 @@ func (sm *SHAMap) insertNodeRecursive(current Node, targetHash [32]byte, newNode
 		return ErrInvalidType
 	}
 
-	// Check each branch for a matching hash
 	for branch := 0; branch < BranchFactor; branch++ {
 		if inner.IsEmptyBranch(branch) {
 			continue
@@ -306,7 +305,6 @@ func (sm *SHAMap) insertNodeRecursive(current Node, targetHash [32]byte, newNode
 			return inner.SetChild(branch, newNode)
 		}
 
-		// Check if we need to recurse into this child
 		child, err := inner.Child(branch)
 		if err != nil {
 			continue
@@ -339,7 +337,6 @@ func (sm *SHAMap) AddRootNode(hash [32]byte, data []byte) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// Check if we already have a root with content
 	if sm.root != nil && sm.root.HasChildren() {
 		return ErrRootAlreadySet
 	}
@@ -360,7 +357,6 @@ func (sm *SHAMap) AddRootNode(hash [32]byte, data []byte) error {
 		return fmt.Errorf("root must be an inner node, got %T", node)
 	}
 
-	// Verify the hash matches
 	if err := innerNode.UpdateHash(); err != nil {
 		return fmt.Errorf("failed to compute node hash: %w", err)
 	}
@@ -370,7 +366,6 @@ func (sm *SHAMap) AddRootNode(hash [32]byte, data []byte) error {
 		return ErrNodeHashMismatch
 	}
 
-	// Set the root
 	sm.root = innerNode
 	sm.state = StateSyncing
 

--- a/shamap/wire.go
+++ b/shamap/wire.go
@@ -118,7 +118,6 @@ func (sm *SHAMap) findNodeByHash(targetHash [32]byte) Node {
 		return nil
 	}
 
-	// Check root first
 	if sm.root.Hash() == targetHash {
 		return sm.root
 	}
@@ -293,7 +292,6 @@ func (sm *SHAMap) BulkGetNodes(hashes [][32]byte) (map[[32]byte]NodeData, error)
 
 		nodeHash := item.node.Hash()
 
-		// Check if this node was requested
 		if _, wanted := requested[nodeHash]; wanted {
 			data, err := item.node.SerializeForWire()
 			if err == nil {
@@ -354,7 +352,6 @@ func (sm *SHAMap) CreateWireMessage(nodeHashes [][32]byte, maxNodes int) (*WireM
 	}
 
 	if nodeHashes != nil {
-		// Get specific nodes
 		nodes, err := sm.BulkGetNodes(nodeHashes)
 		if err != nil {
 			return nil, err
@@ -367,7 +364,6 @@ func (sm *SHAMap) CreateWireMessage(nodeHashes [][32]byte, maxNodes int) (*WireM
 			}
 		}
 	} else {
-		// Get all nodes via traversal
 		if sm.root == nil {
 			return msg, nil
 		}

--- a/storage/nodestore/cache.go
+++ b/storage/nodestore/cache.go
@@ -24,7 +24,6 @@ func (e *cacheEntry) isExpired() bool {
 type Cache struct {
 	mu sync.RWMutex
 
-	// Configuration
 	maxSize int           // Maximum number of items
 	ttl     time.Duration // Time to live for entries
 
@@ -32,7 +31,6 @@ type Cache struct {
 	items map[Hash256]*list.Element // Hash to list element mapping
 	lru   *list.List                // LRU list (most recent at front)
 
-	// Statistics
 	hits         uint64 // Number of cache hits
 	misses       uint64 // Number of cache misses
 	evictions    uint64 // Number of evictions due to size limit
@@ -65,7 +63,6 @@ func (c *Cache) Get(hash Hash256) (*Node, bool) {
 
 	entry := element.Value.(*cacheEntry)
 
-	// Check if the entry has expired
 	if entry.isExpired() {
 		c.removeElementLocked(element)
 		c.expirations++
@@ -89,9 +86,7 @@ func (c *Cache) Put(node *Node) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Check if the item already exists
 	if element, found := c.items[node.Hash]; found {
-		// Update existing entry
 		entry := element.Value.(*cacheEntry)
 		c.currentBytes = c.currentBytes - entry.size + node.Size()
 		entry.node = node
@@ -101,7 +96,6 @@ func (c *Cache) Put(node *Node) {
 		return
 	}
 
-	// Create new entry
 	entry := &cacheEntry{
 		key:       node.Hash,
 		node:      node,
@@ -149,7 +143,6 @@ func (c *Cache) Sweep() int {
 	removed := 0
 	now := time.Now()
 
-	// Iterate from back (oldest) to front
 	for element := c.lru.Back(); element != nil; {
 		entry := element.Value.(*cacheEntry)
 		if now.After(entry.expiresAt) {

--- a/storage/nodestore/database.go
+++ b/storage/nodestore/database.go
@@ -76,12 +76,10 @@ func NewDatabaseWithConfig(backend Backend, config *DatabaseConfig) (*DatabaseIm
 		backend: backend,
 	}
 
-	// Initialize positive cache
 	if config.CacheSize > 0 {
 		db.cache = NewCache(config.CacheSize, config.CacheTTL)
 	}
 
-	// Initialize negative cache
 	if config.NegativeCacheTTL > 0 {
 		db.negativeCache = NewNegativeCacheWithConfig(&NegativeCacheConfig{
 			TTL:     config.NegativeCacheTTL,
@@ -89,7 +87,6 @@ func NewDatabaseWithConfig(backend Backend, config *DatabaseConfig) (*DatabaseIm
 		})
 	}
 
-	// Initialize batch writer if configured
 	if config.BatchWriteConfig != nil {
 		bw, err := NewBatchWriter(backend, config.BatchWriteConfig)
 		if err != nil {
@@ -117,7 +114,6 @@ func (d *DatabaseImpl) Store(ctx context.Context, node *Node) error {
 	atomic.AddUint64(&d.stats.writes, 1)
 	atomic.AddUint64(&d.stats.writeBytes, uint64(len(node.Data)))
 
-	// Update positive cache
 	if d.cache != nil {
 		d.cache.Put(node)
 	}
@@ -140,7 +136,6 @@ func (d *DatabaseImpl) Fetch(ctx context.Context, hash Hash256) (*Node, error) {
 
 	atomic.AddUint64(&d.stats.reads, 1)
 
-	// Check positive cache first
 	if d.cache != nil {
 		if node, found := d.cache.Get(hash); found {
 			atomic.AddUint64(&d.stats.cacheHits, 1)
@@ -171,7 +166,6 @@ func (d *DatabaseImpl) Fetch(ctx context.Context, hash Hash256) (*Node, error) {
 
 	if node != nil {
 		atomic.AddUint64(&d.stats.readBytes, uint64(len(node.Data)))
-		// Update positive cache
 		if d.cache != nil {
 			d.cache.Put(node)
 		}
@@ -336,7 +330,6 @@ func (d *DatabaseImpl) Close() error {
 func (d *DatabaseImpl) StoreAsync(ctx context.Context, node *Node) <-chan error {
 	result := make(chan error, 1)
 
-	// Check context
 	select {
 	case <-ctx.Done():
 		result <- ctx.Err()

--- a/storage/nodestore/kvstore_database.go
+++ b/storage/nodestore/kvstore_database.go
@@ -51,12 +51,10 @@ func NewKVDatabaseWithConfig(store kvstore.KeyValueStore, name string, config *D
 		name:  name,
 	}
 
-	// Initialize positive cache
 	if config.CacheSize > 0 {
 		db.cache = NewCache(config.CacheSize, config.CacheTTL)
 	}
 
-	// Initialize negative cache
 	if config.NegativeCacheTTL > 0 {
 		db.negativeCache = NewNegativeCacheWithConfig(&NegativeCacheConfig{
 			TTL:     config.NegativeCacheTTL,
@@ -83,7 +81,6 @@ func (d *KVDatabaseImpl) Store(ctx context.Context, node *Node) error {
 	atomic.AddUint64(&d.stats.writes, 1)
 	atomic.AddUint64(&d.stats.writeBytes, uint64(len(node.Data)))
 
-	// Update positive cache
 	if d.cache != nil {
 		d.cache.Put(node)
 	}
@@ -106,7 +103,6 @@ func (d *KVDatabaseImpl) Fetch(ctx context.Context, hash Hash256) (*Node, error)
 
 	atomic.AddUint64(&d.stats.reads, 1)
 
-	// Check positive cache first
 	if d.cache != nil {
 		if node, found := d.cache.Get(hash); found {
 			atomic.AddUint64(&d.stats.cacheHits, 1)
@@ -115,7 +111,6 @@ func (d *KVDatabaseImpl) Fetch(ctx context.Context, hash Hash256) (*Node, error)
 		atomic.AddUint64(&d.stats.cacheMisses, 1)
 	}
 
-	// Check negative cache
 	if d.negativeCache != nil {
 		if d.negativeCache.IsMissing(hash) {
 			atomic.AddUint64(&d.stats.negativeCacheHits, 1)
@@ -141,7 +136,6 @@ func (d *KVDatabaseImpl) Fetch(ctx context.Context, hash Hash256) (*Node, error)
 	}
 
 	atomic.AddUint64(&d.stats.readBytes, uint64(len(node.Data)))
-	// Update positive cache
 	if d.cache != nil {
 		d.cache.Put(node)
 	}

--- a/storage/nodestore/memory.go
+++ b/storage/nodestore/memory.go
@@ -14,7 +14,6 @@ type MemoryBackend struct {
 	open       int64 // atomic flag for open state
 	deletePath int64 // atomic flag for delete on close
 
-	// Statistics
 	stats struct {
 		reads        int64
 		writes       int64
@@ -83,7 +82,6 @@ func (m *MemoryBackend) Fetch(key Hash256) (*Node, Status) {
 		return nil, NotFound
 	}
 
-	// Update stats
 	atomic.AddInt64(&m.stats.reads, 1)
 	atomic.AddInt64(&m.stats.bytesRead, int64(len(node.Data)))
 
@@ -157,7 +155,6 @@ func (m *MemoryBackend) Store(node *Node) Status {
 	m.data[node.Hash] = nodeCopy
 	m.mu.Unlock()
 
-	// Update stats
 	atomic.AddInt64(&m.stats.writes, 1)
 	atomic.AddInt64(&m.stats.bytesWritten, int64(len(node.Data)))
 

--- a/storage/nodestore/negative_cache.go
+++ b/storage/nodestore/negative_cache.go
@@ -14,7 +14,6 @@ type NegativeCache struct {
 	entries map[Hash256]time.Time // Hash -> expiration time
 	ttl     time.Duration
 
-	// Statistics
 	stats struct {
 		hits        int64 // Number of cache hits (confirmed missing)
 		misses      int64 // Number of cache misses (not in negative cache)
@@ -23,7 +22,6 @@ type NegativeCache struct {
 		evictions   int64 // Number of entries evicted
 	}
 
-	// Configuration
 	maxSize int // Maximum number of entries (0 = unlimited)
 	closed  int64
 }
@@ -86,7 +84,6 @@ func (nc *NegativeCache) MarkMissing(hash Hash256) {
 		nc.evictOldestLocked()
 	}
 
-	// Add or update entry
 	_, exists := nc.entries[hash]
 	nc.entries[hash] = time.Now().Add(nc.ttl)
 
@@ -111,7 +108,6 @@ func (nc *NegativeCache) IsMissing(hash Hash256) bool {
 		return false
 	}
 
-	// Check if expired
 	if time.Now().After(expiresAt) {
 		// Entry expired, remove it
 		nc.mu.Lock()
@@ -207,7 +203,6 @@ func (nc *NegativeCache) evictOldestLocked() {
 		}
 	}
 
-	// Delete the oldest entries
 	for _, e := range oldest {
 		delete(nc.entries, e.hash)
 		atomic.AddInt64(&nc.stats.evictions, 1)

--- a/storage/nodestore/pebble.go
+++ b/storage/nodestore/pebble.go
@@ -60,7 +60,6 @@ func (p *PebbleBackend) Open(createIfMissing bool) error {
 		return fmt.Errorf("backend already open")
 	}
 
-	// Create directory if needed
 	if createIfMissing {
 		if err := os.MkdirAll(p.config.Path, 0755); err != nil {
 			atomic.StoreInt64(&p.open, 0)
@@ -71,7 +70,6 @@ func (p *PebbleBackend) Open(createIfMissing bool) error {
 	// Configure optimized PebbleDB options for XRPL workload
 	opts := p.buildOptimizedOptions()
 
-	// Open the database
 	db, err := pebble.Open(p.config.Path, opts)
 	if err != nil {
 		atomic.StoreInt64(&p.open, 0)
@@ -201,7 +199,6 @@ func (p *PebbleBackend) Fetch(key Hash256) (*Node, Status) {
 	// Use Hash256 directly as key - no allocation needed
 	keySlice := (*[32]byte)(unsafe.Pointer(&key[0]))[:]
 
-	// Read from PebbleDB
 	value, closer, err := p.db.Get(keySlice)
 	if err != nil {
 		if err == pebble.ErrNotFound {
@@ -211,13 +208,11 @@ func (p *PebbleBackend) Fetch(key Hash256) (*Node, Status) {
 	}
 	defer closer.Close()
 
-	// Decode the stored data
 	node, err := p.decodeNode(key, value)
 	if err != nil {
 		return nil, DataCorrupt
 	}
 
-	// Update stats
 	atomic.AddInt64(&p.stats.reads, 1)
 	atomic.AddInt64(&p.stats.bytesRead, int64(len(value)))
 
@@ -254,7 +249,6 @@ func (p *PebbleBackend) Store(node *Node) Status {
 		return BackendError
 	}
 
-	// Encode the node
 	value := encodeNode(node)
 
 	keySlice := (*[32]byte)(unsafe.Pointer(&node.Hash[0]))[:]
@@ -264,7 +258,6 @@ func (p *PebbleBackend) Store(node *Node) Status {
 		return BackendError
 	}
 
-	// Update stats
 	atomic.AddInt64(&p.stats.writes, 1)
 	atomic.AddInt64(&p.stats.bytesWritten, int64(len(value)))
 
@@ -312,7 +305,6 @@ func (p *PebbleBackend) StoreBatch(nodes []*Node) Status {
 		return BackendError
 	}
 
-	// Update stats
 	atomic.AddInt64(&p.stats.writes, int64(len(nodes)))
 	atomic.AddInt64(&p.stats.bytesWritten, totalBytes)
 
@@ -355,13 +347,11 @@ func (p *PebbleBackend) ForEach(fn func(*Node) error) error {
 		var hash Hash256
 		copy(hash[:], key)
 
-		// Decode the node
 		node, err := p.decodeNode(hash, value)
 		if err != nil {
 			continue // Skip corrupted entries
 		}
 
-		// Call the callback function
 		if err := fn(node); err != nil {
 			return err
 		}

--- a/storage/nodestore/rotating.go
+++ b/storage/nodestore/rotating.go
@@ -63,7 +63,6 @@ type rotatingBackend struct {
 type RotatingDatabase struct {
 	mu sync.RWMutex
 
-	// Configuration
 	config  *RotationConfig
 	factory BackendFactory
 
@@ -77,7 +76,6 @@ type RotatingDatabase struct {
 	open     int64
 	sequence int64
 
-	// Statistics
 	stats struct {
 		rotations        int64
 		primaryReads     int64
@@ -118,7 +116,6 @@ func (rd *RotatingDatabase) Open(createIfMissing bool) error {
 		return fmt.Errorf("rotating database already open")
 	}
 
-	// Create and open the primary backend
 	primary, err := rd.factory(rd.config.PrimaryConfig)
 	if err != nil {
 		atomic.StoreInt64(&rd.open, 0)
@@ -342,7 +339,6 @@ func (rd *RotatingDatabase) Rotate() error {
 		rd.rotating = append(rd.rotating, rb)
 	}
 
-	// Create a new primary backend with unique path
 	newConfig := rd.config.PrimaryConfig.Clone()
 	newConfig.Path = fmt.Sprintf("%s_%d", rd.config.RotatingPath, time.Now().UnixNano())
 
@@ -443,14 +439,12 @@ func (rd *RotatingDatabase) ForEach(fn func(*Node) error) error {
 	rd.mu.RLock()
 	defer rd.mu.RUnlock()
 
-	// Iterate over primary backend
 	if rd.primary != nil {
 		if err := rd.primary.ForEach(fn); err != nil {
 			return err
 		}
 	}
 
-	// Iterate over rotating backends
 	for _, rb := range rd.rotating {
 		if rb.backend != nil {
 			if err := rb.backend.ForEach(fn); err != nil {

--- a/storage/relationaldb/errors.go
+++ b/storage/relationaldb/errors.go
@@ -135,7 +135,6 @@ func (e *DatabaseError) Is(target error) bool {
 		return e.Message == dbErr.Message && e.Type == dbErr.Type
 	}
 
-	// Check against known error variables
 	switch target {
 	case ErrLedgerNotFound:
 		return e.Type == ErrorTypeData && e.Code == "LEDGER_NOT_FOUND"

--- a/storage/relationaldb/manager.go
+++ b/storage/relationaldb/manager.go
@@ -75,7 +75,6 @@ type Manager struct {
 	connected bool
 	lastError error
 
-	// Maintenance
 	maintenanceInterval time.Duration
 	maintenanceCtx      context.Context
 	maintenanceCancel   context.CancelFunc
@@ -314,7 +313,6 @@ func (m *Manager) ExecuteWithRetry(ctx context.Context, operation func() error) 
 
 		lastErr = err
 
-		// Check if error is retryable
 		if !IsRetryable(err) {
 			m.logger.Debug("Operation failed with non-retryable error", "error", err)
 			m.metrics.IncrementCounter("db.operation.non_retryable_error", map[string]string{
@@ -440,7 +438,6 @@ func (m *Manager) performMaintenance(ctx context.Context) {
 		})
 	}()
 
-	// Check space
 	if hasSpace, err := m.repoManager.Ledger().HasLedgerSpace(ctx); err != nil {
 		m.logger.Error("Failed to check ledger space", "error", err)
 	} else if !hasSpace {

--- a/storage/relationaldb/postgres/repository_manager.go
+++ b/storage/relationaldb/postgres/repository_manager.go
@@ -66,7 +66,6 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 		return relationaldb.NewSchemaError("open", "failed to initialize schema", err)
 	}
 
-	// Initialize repository instances
 	rm.ledgerRepo = NewLedgerRepository(rm.db)
 	rm.transactionRepo = NewTransactionRepository(rm.db)
 	rm.accountTransactionRepo = NewAccountTransactionRepository(rm.db)

--- a/storage/relationaldb/postgres/transaction_repository.go
+++ b/storage/relationaldb/postgres/transaction_repository.go
@@ -164,7 +164,6 @@ func (r *TransactionRepository) DeleteTransactionsByLedgerSeq(ctx context.Contex
 		return relationaldb.NewQueryError("delete_transactions_by_ledger_seq", "failed to delete account transactions", err)
 	}
 
-	// Delete transactions
 	if _, err := r.getExecutor().ExecContext(ctx, "DELETE FROM transactions WHERE ledger_seq = $1", ledgerSeq); err != nil {
 		return relationaldb.NewQueryError("delete_transactions_by_ledger_seq", "failed to delete transactions", err)
 	}
@@ -178,7 +177,6 @@ func (r *TransactionRepository) DeleteTransactionsBeforeLedgerSeq(ctx context.Co
 		return relationaldb.NewQueryError("delete_transactions_before_ledger_seq", "failed to delete account transactions", err)
 	}
 
-	// Delete transactions
 	if _, err := r.getExecutor().ExecContext(ctx, "DELETE FROM transactions WHERE ledger_seq < $1", ledgerSeq); err != nil {
 		return relationaldb.NewQueryError("delete_transactions_before_ledger_seq", "failed to delete transactions", err)
 	}

--- a/storage/relationaldb/sqlite/repository_manager.go
+++ b/storage/relationaldb/sqlite/repository_manager.go
@@ -76,7 +76,6 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 		return relationaldb.NewConnectionError("open", "failed to apply transaction DB pragmas", err)
 	}
 
-	// Initialize schemas
 	if err := rm.initLedgerSchema(ctx); err != nil {
 		rm.close()
 		return relationaldb.NewSchemaError("open", "failed to initialize ledger schema", err)
@@ -86,7 +85,6 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 		return relationaldb.NewSchemaError("open", "failed to initialize transaction schema", err)
 	}
 
-	// Initialize repository instances
 	rm.ledgerRepo = NewLedgerRepository(rm.ledgerDB)
 	rm.transactionRepo = NewTransactionRepository(rm.txDB)
 	rm.accountTransactionRepo = NewAccountTransactionRepository(rm.txDB)


### PR DESCRIPTION
## Summary

Subtractive cleanup of low-value comments across the goXRPL tree, executed as 16 per-package commits on top of a design spec + implementation plan.

- **209 files** touched, **-1610 net lines** of comments removed
- Five removable categories: godoc restatements, const/enum echoes, obvious inline what-comments, section separators, stale TODOs / commented-out code
- Hard preservation list applied throughout: every `// Reference: rippled …`, `// Mirrors rippled …`, amendment gate, invariant note, preflight/preclaim commentary, TER code, and crypto/DER/canonicality reference is intact
- Generated files (`mock_*.go`, anything with `// Code generated … DO NOT EDIT.`) and `doc.go` files were skipped entirely
- One per-package commit per package group, gated by `go build`, `go test`, `goimports`, and a removed-line preservation audit, so any block can be reverted independently

## Design + plan

- Spec: `docs/superpowers/specs/2026-04-24-comment-cleanup-design.md`
- Plan: `docs/superpowers/plans/2026-04-24-comment-cleanup.md` (review section appended at the end)

## Verification

- `go build ./...` passes
- `goimports -l` clean across modified files
- Package-level fail list on this branch is **identical to baseline `origin/main`** at commit `173ebf9`. The pre-existing failures (`codec/binarycodec/types TestSerializeXrpAmount` panic, plus the tx subpackages already failing on main) were not introduced by this PR
- Full preservation audit: net rippled-reference content unchanged. Two oracle godoc lines were rewritten so the rippled cross-reference now sits on the godoc summary line instead of a separate trailing line — content preserved, phrasing compressed

## Test Plan

- [ ] `go build ./...`
- [ ] `go test ./codec/... ./crypto/... ./drops/... ./keylet/... ./protocol/... ./amendment/... ./config/... ./ledger/... ./shamap/... ./storage/... ./internal/txq/... ./internal/consensus/...` passes (only `codec/binarycodec/types` should fail, matching baseline)
- [ ] Confirm no surviving `// Reference: rippled …` lines were dropped: `git diff origin/main..HEAD -- '*.go' | rg '^-' | rg -i 'reference:|mirrors rippled|matches rippled|see rippled'` should print only the two oracle godoc rewrites whose `+` counterparts preserve the same rippled function references