### PR TITLE
chore: gofmt three test files (whitespace alignment)

### DIFF
--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -255,9 +255,9 @@ func TestRouterStopsOnContextCancel(t *testing.T) {
 // overlay's reverse index, not just the duplicate's originator.
 type countingSender struct {
 	noopSender
-	mu             sync.Mutex
-	calls          []countingRelaySlotCall
-	peersThatHave  map[[32]byte][]uint64
+	mu            sync.Mutex
+	calls         []countingRelaySlotCall
+	peersThatHave map[[32]byte][]uint64
 }
 
 type countingRelaySlotCall struct {

--- a/internal/consensus/ledger_timing_test.go
+++ b/internal/consensus/ledger_timing_test.go
@@ -8,10 +8,10 @@ import "testing"
 // stepped coarser (rippled's "increase"), finer ("decrease"), or
 // stayed the same ("equal"). The rippled test asserts:
 //
-//   run(previousAgree=false, rounds=10):
-//     increase = 3, decrease = 0, equal = 7
-//   run(previousAgree=false, rounds=100):  // test repeats false
-//     increase = 3, decrease = 0, equal = 97
+//	run(previousAgree=false, rounds=10):
+//	  increase = 3, decrease = 0, equal = 7
+//	run(previousAgree=false, rounds=100):  // test repeats false
+//	  increase = 3, decrease = 0, equal = 97
 //
 // The `increase`/`decrease` names follow rippled's test source
 // comparing by seconds-per-bin: "nextCloseResolution > closeResolution"

--- a/internal/ledger/service/held_adoption_test.go
+++ b/internal/ledger/service/held_adoption_test.go
@@ -311,8 +311,8 @@ func TestAdoptLedgerWithState_MultiLevelCascade(t *testing.T) {
 	require.NoError(t, svc.SubmitHeldAdoption(fx102.hdr, fx102.stateMap, fx102.txMap))
 
 	svc.mu.RLock()
-	_, has102Parent := svc.heldAdoptions[baseSeq]     // 102 waits on 101
-	_, has103Parent := svc.heldAdoptions[baseSeq+1]   // 103 waits on 102
+	_, has102Parent := svc.heldAdoptions[baseSeq]   // 102 waits on 101
+	_, has103Parent := svc.heldAdoptions[baseSeq+1] // 103 waits on 102
 	svc.mu.RUnlock()
 	require.True(t, has102Parent, "102 must stash under parent-seq 101")
 	require.True(t, has103Parent, "103 must stash under parent-seq 102")


### PR DESCRIPTION
## Summary

Three pre-existing test files trigger `goimports` failures under `golangci-lint v2.11.3`:

- \`internal/consensus/adaptor/router_test.go\` (struct-field padding)
- \`internal/consensus/ledger_timing_test.go\` (comment-block tabs vs spaces)
- \`internal/ledger/service/held_adoption_test.go\` (trailing-comment alignment)

All three are pure whitespace nits — no semantic change. \`goimports -w\` brings them in line.

Discovered while running the linter on #282; split out to keep that PR scoped to the validation archive feature.

## Test plan

- [x] \`golangci-lint run\` → \`0 issues\` after the fix
- [x] \`go build ./...\`
- [x] \`go test ./internal/consensus/... ./internal/ledger/service/...\`