### PR TITLE
Full LedgerTrie getPreferred (replace flat hash-count approximation)

### DIFF
--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -188,6 +188,15 @@ func NewFromConfig(
 		engine.SetInMemoryLedgers(archCfg.InMemoryLedgers)
 	}
 
+	// Wire the LedgerTrie's ancestry provider to the local ledger
+	// service. The trie uses this on every trusted validation Add()
+	// to walk the ledger's ParentHash chain and roll tip support up
+	// into branchSupport — replacing the flat-count approximation
+	// the ValidationTracker fell back on when no provider was
+	// present.
+	engine.SetLedgerAncestryProvider(rcl.NewLedgerProvider(ledgerSvc))
+
+	// Create the router
 	router := NewRouter(engine, adaptor, modeManager, overlay.Messages())
 	router.SetManifestCache(manifestCache, overlay)
 

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -188,12 +188,6 @@ func NewFromConfig(
 		engine.SetInMemoryLedgers(archCfg.InMemoryLedgers)
 	}
 
-	// Wire the LedgerTrie's ancestry provider to the local ledger
-	// service. The trie uses this on every trusted validation Add()
-	// to walk the ledger's ParentHash chain and roll tip support up
-	// into branchSupport — replacing the flat-count approximation
-	// the ValidationTracker fell back on when no provider was
-	// present.
 	engine.SetLedgerAncestryProvider(rcl.NewLedgerProvider(ledgerSvc))
 
 	// Create the router

--- a/internal/consensus/ledgertrie/span.go
+++ b/internal/consensus/ledgertrie/span.go
@@ -17,11 +17,6 @@ func newSpanFromLedger(l Ledger) span {
 	return span{start: 0, end: l.Seq() + 1, ledger: l}
 }
 
-// newSpan constructs a span directly; start must be < end.
-func newSpan(start, end uint32, l Ledger) span {
-	return span{start: start, end: end, ledger: l}
-}
-
 // clamp forces val into [start, end].
 func (s span) clamp(val uint32) uint32 {
 	if val < s.start {
@@ -91,11 +86,6 @@ type node struct {
 // newEmptyNode is the genesis-root node used by an empty trie.
 func newEmptyNode(genesis Ledger) *node {
 	return &node{s: span{start: 0, end: 1, ledger: genesis}}
-}
-
-// newNodeFromLedger creates a leaf node covering the ledger's full span.
-func newNodeFromLedger(l Ledger) *node {
-	return &node{s: newSpanFromLedger(l), tipSupport: 1, branchSupport: 1}
 }
 
 // newNodeFromSpan wraps an existing span into a node. tipSupport and

--- a/internal/consensus/ledgertrie/span.go
+++ b/internal/consensus/ledgertrie/span.go
@@ -3,8 +3,7 @@ package ledgertrie
 import "github.com/LeJamon/goXRPLd/internal/consensus"
 
 // span is the half-open interval [start, end) of a ledger's ancestry,
-// always non-empty. Port of ledger_trie_detail::Span<Ledger>
-// (LedgerTrie.h:77-198).
+// always non-empty.
 type span struct {
 	start  uint32
 	end    uint32
@@ -40,18 +39,15 @@ func (s span) before(spot uint32) (span, bool) { return s.sub(s.start, spot) }
 
 func (s span) startID() consensus.LedgerID { return s.ledger.Ancestor(s.start) }
 
-// diff is Span::diff (LedgerTrie.h:144-148).
 func (s span) diff(o Ledger) uint32 { return s.clamp(Mismatch(s.ledger, o)) }
 
-// tip is Span::tip (LedgerTrie.h:151-156).
 func (s span) tip() SpanTip {
 	tipSeq := s.end - 1
 	return SpanTip{Seq: tipSeq, ID: s.ledger.Ancestor(tipSeq), ledger: s.ledger}
 }
 
 // mergeSpans combines two adjacent spans, taking the ledger from the
-// higher-end span so the tip resolves correctly. Port of free `merge`
-// (LedgerTrie.h:189-197).
+// higher-end span so the tip resolves correctly.
 func mergeSpans(a, b span) span {
 	lo := a.start
 	if b.start < lo {
@@ -63,8 +59,7 @@ func mergeSpans(a, b span) span {
 	return span{start: lo, end: a.end, ledger: a.ledger}
 }
 
-// node is a trie node. Port of ledger_trie_detail::Node<Ledger>
-// (LedgerTrie.h:201-269).
+// node is a trie node.
 type node struct {
 	s             span
 	tipSupport    uint32
@@ -79,8 +74,7 @@ func newEmptyNode(genesis Ledger) *node {
 
 func newNodeFromSpan(s span) *node { return &node{s: s} }
 
-// eraseChild swap-pops child from n.children. Mirrors Node::erase
-// (LedgerTrie.h:227-239).
+// eraseChild swap-pops child from n.children.
 func (n *node) eraseChild(child *node) {
 	for i, c := range n.children {
 		if c == child {

--- a/internal/consensus/ledgertrie/span.go
+++ b/internal/consensus/ledgertrie/span.go
@@ -2,22 +2,20 @@ package ledgertrie
 
 import "github.com/LeJamon/goXRPLd/internal/consensus"
 
-// span is the half-open interval [start, end) of a ledger's ancestry.
-// Spans are always non-empty (start < end). Port of rippled's
-// ledger_trie_detail::Span<Ledger> (LedgerTrie.h:77-198).
+// span is the half-open interval [start, end) of a ledger's ancestry,
+// always non-empty. Port of ledger_trie_detail::Span<Ledger>
+// (LedgerTrie.h:77-198).
 type span struct {
 	start  uint32
 	end    uint32
-	ledger Ledger // interpreted as "the ledger we're sitting in for this span"
+	ledger Ledger
 }
 
-// newSpanFromLedger produces [0, ledger.Seq()+1) — the span that
-// covers the ledger's entire ancestry up to and including itself.
+// newSpanFromLedger returns [0, l.Seq()+1).
 func newSpanFromLedger(l Ledger) span {
 	return span{start: 0, end: l.Seq() + 1, ledger: l}
 }
 
-// clamp forces val into [start, end].
 func (s span) clamp(val uint32) uint32 {
 	if val < s.start {
 		return s.start
@@ -28,7 +26,6 @@ func (s span) clamp(val uint32) uint32 {
 	return val
 }
 
-// sub returns the span over [from, to), or (zero, false) if empty.
 func (s span) sub(from, to uint32) (span, bool) {
 	nf := s.clamp(from)
 	nt := s.clamp(to)
@@ -38,30 +35,23 @@ func (s span) sub(from, to uint32) (span, bool) {
 	return span{}, false
 }
 
-// from returns the sub-span [spot, end).
-func (s span) from(spot uint32) (span, bool) { return s.sub(spot, s.end) }
-
-// before returns the sub-span [start, spot).
+func (s span) from(spot uint32) (span, bool)   { return s.sub(spot, s.end) }
 func (s span) before(spot uint32) (span, bool) { return s.sub(s.start, spot) }
 
-// startID is the ID of the ledger at sequence start. For a non-genesis
-// span this is an ancestor of s.ledger.
 func (s span) startID() consensus.LedgerID { return s.ledger.Ancestor(s.start) }
 
-// diff returns the first sequence where s.ledger and o disagree,
-// clamped into [start, end]. Port of Span::diff (LedgerTrie.h:144-148).
+// diff is Span::diff (LedgerTrie.h:144-148).
 func (s span) diff(o Ledger) uint32 { return s.clamp(Mismatch(s.ledger, o)) }
 
-// tip returns a read-only view of the last ledger in the span
-// (seq = end-1). Port of Span::tip (LedgerTrie.h:151-156).
+// tip is Span::tip (LedgerTrie.h:151-156).
 func (s span) tip() SpanTip {
 	tipSeq := s.end - 1
 	return SpanTip{Seq: tipSeq, ID: s.ledger.Ancestor(tipSeq), ledger: s.ledger}
 }
 
-// merge combines two overlapping/adjacent spans, using the ledger
-// from the one with the higher end (so the combined tip resolves
-// correctly). Port of free `merge` (LedgerTrie.h:189-197).
+// mergeSpans combines two adjacent spans, taking the ledger from the
+// higher-end span so the tip resolves correctly. Port of free `merge`
+// (LedgerTrie.h:189-197).
 func mergeSpans(a, b span) span {
 	lo := a.start
 	if b.start < lo {
@@ -83,17 +73,14 @@ type node struct {
 	parent        *node
 }
 
-// newEmptyNode is the genesis-root node used by an empty trie.
 func newEmptyNode(genesis Ledger) *node {
 	return &node{s: span{start: 0, end: 1, ledger: genesis}}
 }
 
-// newNodeFromSpan wraps an existing span into a node. tipSupport and
-// branchSupport remain zero; the caller sets them.
 func newNodeFromSpan(s span) *node { return &node{s: s} }
 
-// eraseChild unlinks child from n.children. Swap-with-last-and-pop
-// mirrors rippled's Node::erase (LedgerTrie.h:227-239).
+// eraseChild swap-pops child from n.children. Mirrors Node::erase
+// (LedgerTrie.h:227-239).
 func (n *node) eraseChild(child *node) {
 	for i, c := range n.children {
 		if c == child {

--- a/internal/consensus/ledgertrie/span.go
+++ b/internal/consensus/ledgertrie/span.go
@@ -1,0 +1,117 @@
+package ledgertrie
+
+import "github.com/LeJamon/goXRPLd/internal/consensus"
+
+// span is the half-open interval [start, end) of a ledger's ancestry.
+// Spans are always non-empty (start < end). Port of rippled's
+// ledger_trie_detail::Span<Ledger> (LedgerTrie.h:77-198).
+type span struct {
+	start  uint32
+	end    uint32
+	ledger Ledger // interpreted as "the ledger we're sitting in for this span"
+}
+
+// newSpanFromLedger produces [0, ledger.Seq()+1) — the span that
+// covers the ledger's entire ancestry up to and including itself.
+func newSpanFromLedger(l Ledger) span {
+	return span{start: 0, end: l.Seq() + 1, ledger: l}
+}
+
+// newSpan constructs a span directly; start must be < end.
+func newSpan(start, end uint32, l Ledger) span {
+	return span{start: start, end: end, ledger: l}
+}
+
+// clamp forces val into [start, end].
+func (s span) clamp(val uint32) uint32 {
+	if val < s.start {
+		return s.start
+	}
+	if val > s.end {
+		return s.end
+	}
+	return val
+}
+
+// sub returns the span over [from, to), or (zero, false) if empty.
+func (s span) sub(from, to uint32) (span, bool) {
+	nf := s.clamp(from)
+	nt := s.clamp(to)
+	if nf < nt {
+		return span{start: nf, end: nt, ledger: s.ledger}, true
+	}
+	return span{}, false
+}
+
+// from returns the sub-span [spot, end).
+func (s span) from(spot uint32) (span, bool) { return s.sub(spot, s.end) }
+
+// before returns the sub-span [start, spot).
+func (s span) before(spot uint32) (span, bool) { return s.sub(s.start, spot) }
+
+// startID is the ID of the ledger at sequence start. For a non-genesis
+// span this is an ancestor of s.ledger.
+func (s span) startID() consensus.LedgerID { return s.ledger.Ancestor(s.start) }
+
+// diff returns the first sequence where s.ledger and o disagree,
+// clamped into [start, end]. Port of Span::diff (LedgerTrie.h:144-148).
+func (s span) diff(o Ledger) uint32 { return s.clamp(Mismatch(s.ledger, o)) }
+
+// tip returns a read-only view of the last ledger in the span
+// (seq = end-1). Port of Span::tip (LedgerTrie.h:151-156).
+func (s span) tip() SpanTip {
+	tipSeq := s.end - 1
+	return SpanTip{Seq: tipSeq, ID: s.ledger.Ancestor(tipSeq), ledger: s.ledger}
+}
+
+// merge combines two overlapping/adjacent spans, using the ledger
+// from the one with the higher end (so the combined tip resolves
+// correctly). Port of free `merge` (LedgerTrie.h:189-197).
+func mergeSpans(a, b span) span {
+	lo := a.start
+	if b.start < lo {
+		lo = b.start
+	}
+	if a.end < b.end {
+		return span{start: lo, end: b.end, ledger: b.ledger}
+	}
+	return span{start: lo, end: a.end, ledger: a.ledger}
+}
+
+// node is a trie node. Port of ledger_trie_detail::Node<Ledger>
+// (LedgerTrie.h:201-269).
+type node struct {
+	s             span
+	tipSupport    uint32
+	branchSupport uint32
+	children      []*node
+	parent        *node
+}
+
+// newEmptyNode is the genesis-root node used by an empty trie.
+func newEmptyNode(genesis Ledger) *node {
+	return &node{s: span{start: 0, end: 1, ledger: genesis}}
+}
+
+// newNodeFromLedger creates a leaf node covering the ledger's full span.
+func newNodeFromLedger(l Ledger) *node {
+	return &node{s: newSpanFromLedger(l), tipSupport: 1, branchSupport: 1}
+}
+
+// newNodeFromSpan wraps an existing span into a node. tipSupport and
+// branchSupport remain zero; the caller sets them.
+func newNodeFromSpan(s span) *node { return &node{s: s} }
+
+// eraseChild unlinks child from n.children. Swap-with-last-and-pop
+// mirrors rippled's Node::erase (LedgerTrie.h:227-239).
+func (n *node) eraseChild(child *node) {
+	for i, c := range n.children {
+		if c == child {
+			last := len(n.children) - 1
+			n.children[i] = n.children[last]
+			n.children[last] = nil
+			n.children = n.children[:last]
+			return
+		}
+	}
+}

--- a/internal/consensus/ledgertrie/testledger.go
+++ b/internal/consensus/ledgertrie/testledger.go
@@ -1,0 +1,108 @@
+package ledgertrie
+
+import (
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// TestLedger is a deterministic in-memory ledger useful for unit
+// tests of the trie and any future consensus components that need
+// ancestry. It stores its full ancestor chain so Ancestor(s) is O(1).
+//
+// Modeled on rippled's csf::Ledger (src/test/csf/ledgers.h) which
+// serves the same purpose for the C++ test harness.
+type TestLedger struct {
+	id        consensus.LedgerID
+	seq       uint32
+	ancestors []consensus.LedgerID // ancestors[i] is the ID at seq i; ancestors[seq] == id
+}
+
+// ID implements Ledger.
+func (l *TestLedger) ID() consensus.LedgerID { return l.id }
+
+// Seq implements Ledger.
+func (l *TestLedger) Seq() uint32 { return l.seq }
+
+// Ancestor implements Ledger. Callers must supply s <= Seq().
+func (l *TestLedger) Ancestor(s uint32) consensus.LedgerID {
+	if s > l.seq {
+		// Defensive: mirror rippled's XRPL_ASSERT panic-on-misuse.
+		panic("TestLedger.Ancestor: s > seq")
+	}
+	return l.ancestors[s]
+}
+
+// TestLedgerBuilder constructs TestLedger instances from short string
+// notation. Each call to Build("abc") returns a ledger with ancestors
+// genesis → 'a' → 'b' → 'c' (seq 3). Repeated characters in the same
+// position are supported — "ab" and "abc" share "ab" prefix. Mirrors
+// rippled's LedgerHistoryHelper (LedgerTrie_test.cpp:~96) which does
+// the same via `h["abc"]`.
+//
+// IDs are derived by zero-padding the path bytes themselves into the
+// 32-byte LedgerID, so lexicographic byte-order on IDs matches
+// lexicographic rune-order on paths. That preserves rippled tests'
+// implicit assumption that `h["abce"].id() > h["abcd"].id()`. Only
+// ASCII paths shorter than 32 bytes are supported — plenty for the
+// tests we port.
+type TestLedgerBuilder struct {
+	genesis *TestLedger
+	// children maps (parent.id, next-rune) -> child
+	children map[childKey]*TestLedger
+}
+
+type childKey struct {
+	parent consensus.LedgerID
+	r      rune
+}
+
+// NewTestLedgerBuilder returns a builder whose genesis ledger is the
+// all-zero-ID seq-0 ledger.
+func NewTestLedgerBuilder() *TestLedgerBuilder {
+	genesis := &TestLedger{
+		seq:       0,
+		ancestors: []consensus.LedgerID{{}}, // genesis ID is 32 zero bytes
+	}
+	return &TestLedgerBuilder{
+		genesis:  genesis,
+		children: make(map[childKey]*TestLedger),
+	}
+}
+
+// Genesis returns the builder's genesis ledger (seq 0, zero ID).
+func (b *TestLedgerBuilder) Genesis() *TestLedger { return b.genesis }
+
+// Build returns the ledger identified by the given string. Each rune
+// selects the child of the previous ledger; identical strings always
+// return the same *TestLedger (memoized). Empty string returns genesis.
+func (b *TestLedgerBuilder) Build(s string) *TestLedger {
+	if len(s) >= 32 {
+		panic("TestLedgerBuilder: path too long for 32-byte ID encoding")
+	}
+	curr := b.genesis
+	for i, r := range s {
+		key := childKey{parent: curr.id, r: r}
+		child, ok := b.children[key]
+		if !ok {
+			child = b.extend(curr, r, i)
+			b.children[key] = child
+		}
+		curr = child
+	}
+	return curr
+}
+
+// extend produces a new ledger one step past `parent`. ID is the
+// parent ID with byte `depth` overwritten to r. Since genesis ID is
+// all zeros, the resulting IDs spell out the path in the high bytes,
+// making lexicographic comparison on IDs agree with lexicographic
+// comparison on paths.
+func (b *TestLedgerBuilder) extend(parent *TestLedger, r rune, depth int) *TestLedger {
+	var id consensus.LedgerID
+	copy(id[:], parent.id[:])
+	id[depth] = byte(r)
+
+	ancestors := make([]consensus.LedgerID, parent.seq+2)
+	copy(ancestors, parent.ancestors)
+	ancestors[parent.seq+1] = id
+	return &TestLedger{id: id, seq: parent.seq + 1, ancestors: ancestors}
+}

--- a/internal/consensus/ledgertrie/testledger.go
+++ b/internal/consensus/ledgertrie/testledger.go
@@ -22,11 +22,16 @@ func (l *TestLedger) ID() consensus.LedgerID { return l.id }
 // Seq implements Ledger.
 func (l *TestLedger) Seq() uint32 { return l.seq }
 
-// Ancestor implements Ledger. Callers must supply s <= Seq().
+// MinSeq implements Ledger. TestLedger retains its full ancestry, so
+// it can answer Ancestor(s) for any s in [0, Seq()].
+func (l *TestLedger) MinSeq() uint32 { return 0 }
+
+// Ancestor implements Ledger. For s outside [MinSeq(), Seq()] returns
+// the zero LedgerID, mirroring rippled's RCLValidatedLedger::operator[]
+// out-of-range fallback (RCLValidations.cpp:79-95).
 func (l *TestLedger) Ancestor(s uint32) consensus.LedgerID {
 	if s > l.seq {
-		// Defensive: mirror rippled's XRPL_ASSERT panic-on-misuse.
-		panic("TestLedger.Ancestor: s > seq")
+		return consensus.LedgerID{}
 	}
 	return l.ancestors[s]
 }

--- a/internal/consensus/ledgertrie/testledger.go
+++ b/internal/consensus/ledgertrie/testledger.go
@@ -5,7 +5,6 @@ import (
 )
 
 // TestLedger is a deterministic in-memory ledger for unit tests.
-// Modeled on rippled's csf::Ledger (src/test/csf/ledgers.h).
 type TestLedger struct {
 	id        consensus.LedgerID
 	seq       uint32
@@ -14,12 +13,8 @@ type TestLedger struct {
 
 func (l *TestLedger) ID() consensus.LedgerID { return l.id }
 func (l *TestLedger) Seq() uint32            { return l.seq }
+func (l *TestLedger) MinSeq() uint32         { return 0 }
 
-// MinSeq is 0; TestLedger retains its full ancestry.
-func (l *TestLedger) MinSeq() uint32 { return 0 }
-
-// Ancestor returns the zero LedgerID for s outside [MinSeq, Seq],
-// mirroring RCLValidatedLedger::operator[] (RCLValidations.cpp:79-95).
 func (l *TestLedger) Ancestor(s uint32) consensus.LedgerID {
 	if s > l.seq {
 		return consensus.LedgerID{}
@@ -28,13 +23,10 @@ func (l *TestLedger) Ancestor(s uint32) consensus.LedgerID {
 }
 
 // TestLedgerBuilder constructs TestLedgers from path strings: Build("abc")
-// is genesis → 'a' → 'b' → 'c' (seq 3); "ab" and "abc" share the "ab"
-// prefix. Mirrors LedgerHistoryHelper (LedgerTrie_test.cpp).
-//
-// Each path rune is written into byte `depth` of the LedgerID, so
-// lexicographic byte-order on IDs agrees with rune-order on paths —
-// preserving the implicit ordering rippled tests rely on. Limited to
-// ASCII paths shorter than 32 bytes.
+// is genesis → 'a' → 'b' → 'c'; "ab" and "abc" share the "ab" prefix.
+// Each path rune is written into byte `depth` of the LedgerID so
+// lexicographic byte-order on IDs agrees with rune-order on paths.
+// Limited to ASCII paths shorter than 32 bytes.
 type TestLedgerBuilder struct {
 	genesis  *TestLedger
 	children map[childKey]*TestLedger
@@ -58,7 +50,7 @@ func NewTestLedgerBuilder() *TestLedgerBuilder {
 
 func (b *TestLedgerBuilder) Genesis() *TestLedger { return b.genesis }
 
-// Build returns the (memoized) ledger for s. Empty s returns genesis.
+// Build returns the memoized ledger for s; empty s returns genesis.
 func (b *TestLedgerBuilder) Build(s string) *TestLedger {
 	if len(s) >= 32 {
 		panic("TestLedgerBuilder: path too long for 32-byte ID encoding")

--- a/internal/consensus/ledgertrie/testledger.go
+++ b/internal/consensus/ledgertrie/testledger.go
@@ -4,31 +4,22 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 )
 
-// TestLedger is a deterministic in-memory ledger useful for unit
-// tests of the trie and any future consensus components that need
-// ancestry. It stores its full ancestor chain so Ancestor(s) is O(1).
-//
-// Modeled on rippled's csf::Ledger (src/test/csf/ledgers.h) which
-// serves the same purpose for the C++ test harness.
+// TestLedger is a deterministic in-memory ledger for unit tests.
+// Modeled on rippled's csf::Ledger (src/test/csf/ledgers.h).
 type TestLedger struct {
 	id        consensus.LedgerID
 	seq       uint32
-	ancestors []consensus.LedgerID // ancestors[i] is the ID at seq i; ancestors[seq] == id
+	ancestors []consensus.LedgerID
 }
 
-// ID implements Ledger.
 func (l *TestLedger) ID() consensus.LedgerID { return l.id }
+func (l *TestLedger) Seq() uint32            { return l.seq }
 
-// Seq implements Ledger.
-func (l *TestLedger) Seq() uint32 { return l.seq }
-
-// MinSeq implements Ledger. TestLedger retains its full ancestry, so
-// it can answer Ancestor(s) for any s in [0, Seq()].
+// MinSeq is 0; TestLedger retains its full ancestry.
 func (l *TestLedger) MinSeq() uint32 { return 0 }
 
-// Ancestor implements Ledger. For s outside [MinSeq(), Seq()] returns
-// the zero LedgerID, mirroring rippled's RCLValidatedLedger::operator[]
-// out-of-range fallback (RCLValidations.cpp:79-95).
+// Ancestor returns the zero LedgerID for s outside [MinSeq, Seq],
+// mirroring RCLValidatedLedger::operator[] (RCLValidations.cpp:79-95).
 func (l *TestLedger) Ancestor(s uint32) consensus.LedgerID {
 	if s > l.seq {
 		return consensus.LedgerID{}
@@ -36,22 +27,16 @@ func (l *TestLedger) Ancestor(s uint32) consensus.LedgerID {
 	return l.ancestors[s]
 }
 
-// TestLedgerBuilder constructs TestLedger instances from short string
-// notation. Each call to Build("abc") returns a ledger with ancestors
-// genesis → 'a' → 'b' → 'c' (seq 3). Repeated characters in the same
-// position are supported — "ab" and "abc" share "ab" prefix. Mirrors
-// rippled's LedgerHistoryHelper (LedgerTrie_test.cpp:~96) which does
-// the same via `h["abc"]`.
+// TestLedgerBuilder constructs TestLedgers from path strings: Build("abc")
+// is genesis → 'a' → 'b' → 'c' (seq 3); "ab" and "abc" share the "ab"
+// prefix. Mirrors LedgerHistoryHelper (LedgerTrie_test.cpp).
 //
-// IDs are derived by zero-padding the path bytes themselves into the
-// 32-byte LedgerID, so lexicographic byte-order on IDs matches
-// lexicographic rune-order on paths. That preserves rippled tests'
-// implicit assumption that `h["abce"].id() > h["abcd"].id()`. Only
-// ASCII paths shorter than 32 bytes are supported — plenty for the
-// tests we port.
+// Each path rune is written into byte `depth` of the LedgerID, so
+// lexicographic byte-order on IDs agrees with rune-order on paths —
+// preserving the implicit ordering rippled tests rely on. Limited to
+// ASCII paths shorter than 32 bytes.
 type TestLedgerBuilder struct {
-	genesis *TestLedger
-	// children maps (parent.id, next-rune) -> child
+	genesis  *TestLedger
 	children map[childKey]*TestLedger
 }
 
@@ -60,12 +45,10 @@ type childKey struct {
 	r      rune
 }
 
-// NewTestLedgerBuilder returns a builder whose genesis ledger is the
-// all-zero-ID seq-0 ledger.
 func NewTestLedgerBuilder() *TestLedgerBuilder {
 	genesis := &TestLedger{
 		seq:       0,
-		ancestors: []consensus.LedgerID{{}}, // genesis ID is 32 zero bytes
+		ancestors: []consensus.LedgerID{{}},
 	}
 	return &TestLedgerBuilder{
 		genesis:  genesis,
@@ -73,12 +56,9 @@ func NewTestLedgerBuilder() *TestLedgerBuilder {
 	}
 }
 
-// Genesis returns the builder's genesis ledger (seq 0, zero ID).
 func (b *TestLedgerBuilder) Genesis() *TestLedger { return b.genesis }
 
-// Build returns the ledger identified by the given string. Each rune
-// selects the child of the previous ledger; identical strings always
-// return the same *TestLedger (memoized). Empty string returns genesis.
+// Build returns the (memoized) ledger for s. Empty s returns genesis.
 func (b *TestLedgerBuilder) Build(s string) *TestLedger {
 	if len(s) >= 32 {
 		panic("TestLedgerBuilder: path too long for 32-byte ID encoding")
@@ -96,11 +76,6 @@ func (b *TestLedgerBuilder) Build(s string) *TestLedger {
 	return curr
 }
 
-// extend produces a new ledger one step past `parent`. ID is the
-// parent ID with byte `depth` overwritten to r. Since genesis ID is
-// all zeros, the resulting IDs spell out the path in the high bytes,
-// making lexicographic comparison on IDs agree with lexicographic
-// comparison on paths.
 func (b *TestLedgerBuilder) extend(parent *TestLedger, r rune, depth int) *TestLedger {
 	var id consensus.LedgerID
 	copy(id[:], parent.id[:])

--- a/internal/consensus/ledgertrie/trie.go
+++ b/internal/consensus/ledgertrie/trie.go
@@ -1,0 +1,445 @@
+// Package ledgertrie is a Go port of rippled's LedgerTrie<Ledger>
+// (src/xrpld/consensus/LedgerTrie.h). The trie maintains validation
+// support of recent ledgers based on their ancestry so that
+// consensus can pick a preferred branch by branchSupport rather than
+// by flat hash-count.
+package ledgertrie
+
+import (
+	"sort"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// Ledger is the interface the trie needs. Ledgers have a unique-history
+// invariant: if a[s] == b[s] then a[p] == b[p] for all p < s.
+type Ledger interface {
+	// ID returns the ledger's own identifier (== Ancestor(Seq())).
+	ID() consensus.LedgerID
+	// Seq returns this ledger's sequence number.
+	Seq() uint32
+	// Ancestor returns the ID of the ancestor at sequence s. s must be
+	// <= Seq(); Ancestor(0) is the genesis ID.
+	Ancestor(s uint32) consensus.LedgerID
+}
+
+// Mismatch returns the first sequence number at which a and b's
+// ancestries differ. If one is a strict ancestor of the other it
+// returns min(a.Seq(), b.Seq())+1. Port of the free `mismatch`
+// function expected by LedgerTrie.h:329-332.
+func Mismatch(a, b Ledger) uint32 {
+	lo := a.Seq()
+	if b.Seq() < lo {
+		lo = b.Seq()
+	}
+	// Binary search over [0, lo] for the first s with a[s] != b[s].
+	// Unique-history makes the predicate monotone.
+	hi := lo
+	var low uint32 = 0
+	for low < hi {
+		mid := low + (hi-low)/2
+		if a.Ancestor(mid) == b.Ancestor(mid) {
+			low = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	// At this point low == hi; if a[low]==b[low] then they agree up
+	// to sequence `lo`, so the first mismatch (if any) is at lo+1.
+	if low == lo && a.Ancestor(low) == b.Ancestor(low) {
+		return lo + 1
+	}
+	return low
+}
+
+// SpanTip is the public read-only view of the tip of a span. Port of
+// rippled's SpanTip<Ledger> (LedgerTrie.h:39-73).
+type SpanTip struct {
+	Seq    uint32
+	ID     consensus.LedgerID
+	ledger Ledger
+}
+
+// Ancestor returns the ID of the ancestor at sequence s (s <= Seq).
+func (t SpanTip) Ancestor(s uint32) consensus.LedgerID { return t.ledger.Ancestor(s) }
+
+// Trie is the ancestry trie. The zero value is not usable — call New.
+type Trie struct {
+	root *node
+	// genesis is captured at construction so an empty root always has
+	// a concrete Ledger to resolve Ancestor(0) against.
+	genesis Ledger
+
+	// seqSupport[seq] is the number of ledgers at sequence `seq` that
+	// currently hold tip support. Rippled uses std::map for ordered
+	// iteration; we mirror that with a side-sorted slice of keys.
+	seqSupport map[uint32]uint32
+	seqKeys    []uint32 // sorted ascending
+}
+
+// New constructs an empty trie. genesis is used as the placeholder
+// ledger for the root node and must satisfy Seq() == 0.
+func New(genesis Ledger) *Trie {
+	return &Trie{
+		root:       newEmptyNode(genesis),
+		genesis:    genesis,
+		seqSupport: make(map[uint32]uint32),
+	}
+}
+
+// Empty reports whether the trie has any support recorded.
+func (t *Trie) Empty() bool { return t.root == nil || t.root.branchSupport == 0 }
+
+// --- find ---
+
+// find locates the node with the longest common ancestry prefix of
+// `l` and returns (node, diffSeq). Port of LedgerTrie::find
+// (LedgerTrie.h:371-401).
+func (t *Trie) find(l Ledger) (*node, uint32) {
+	curr := t.root
+	pos := curr.s.diff(l)
+
+	done := false
+	for !done && pos == curr.s.end {
+		done = true
+		for _, child := range curr.children {
+			childPos := child.s.diff(l)
+			if childPos > pos {
+				done = false
+				pos = childPos
+				curr = child
+				break
+			}
+		}
+	}
+	return curr, pos
+}
+
+// findByLedgerID does an O(n) walk looking for an exact ID match.
+// Port of LedgerTrie::findByLedgerID (LedgerTrie.h:409-423).
+func (t *Trie) findByLedgerID(l Ledger) *node {
+	return findByIDWalk(t.root, l.ID())
+}
+
+func findByIDWalk(curr *node, id consensus.LedgerID) *node {
+	if curr == nil {
+		return nil
+	}
+	if curr.s.tip().ID == id {
+		return curr
+	}
+	for _, child := range curr.children {
+		if hit := findByIDWalk(child, id); hit != nil {
+			return hit
+		}
+	}
+	return nil
+}
+
+// --- seqSupport helpers ---
+
+func (t *Trie) seqSupportAdd(seq uint32, delta uint32) {
+	if _, ok := t.seqSupport[seq]; !ok {
+		// insert seq into sorted key list
+		idx := sort.Search(len(t.seqKeys), func(i int) bool { return t.seqKeys[i] >= seq })
+		t.seqKeys = append(t.seqKeys, 0)
+		copy(t.seqKeys[idx+1:], t.seqKeys[idx:])
+		t.seqKeys[idx] = seq
+	}
+	t.seqSupport[seq] += delta
+}
+
+func (t *Trie) seqSupportSub(seq uint32, delta uint32) {
+	cur, ok := t.seqSupport[seq]
+	if !ok || cur < delta {
+		return // caller validated; defensive no-op
+	}
+	cur -= delta
+	if cur == 0 {
+		delete(t.seqSupport, seq)
+		idx := sort.Search(len(t.seqKeys), func(i int) bool { return t.seqKeys[i] >= seq })
+		if idx < len(t.seqKeys) && t.seqKeys[idx] == seq {
+			t.seqKeys = append(t.seqKeys[:idx], t.seqKeys[idx+1:]...)
+		}
+		return
+	}
+	t.seqSupport[seq] = cur
+}
+
+// --- Insert ---
+
+// Insert adds `count` units of support for ledger l. The ledger's
+// ancestry is walked from genesis to l itself; branchSupport is
+// incremented along the spine and tipSupport is incremented on the
+// node that owns l. Port of LedgerTrie::insert (LedgerTrie.h:452-531).
+func (t *Trie) Insert(l Ledger, count uint32) {
+	if count == 0 {
+		return
+	}
+	loc, diffSeq := t.find(l)
+
+	incNode := loc
+
+	prefix, hasPrefix := loc.s.before(diffSeq)
+	oldSuffix, hasOldSuffix := loc.s.from(diffSeq)
+	newSuffix, hasNewSuffix := newSpanFromLedger(l).from(diffSeq)
+
+	if hasOldSuffix {
+		// Split: loc keeps the prefix; a new node takes over loc's
+		// tip/branch support and its children (which are the suffix
+		// continuation). Then loc's tipSupport resets to zero.
+		_ = hasPrefix // prefix must be present whenever oldSuffix is (see LedgerTrie.h:500)
+		sfx := newNodeFromSpan(oldSuffix)
+		sfx.tipSupport = loc.tipSupport
+		sfx.branchSupport = loc.branchSupport
+		sfx.children = loc.children
+		loc.children = nil
+		for _, c := range sfx.children {
+			c.parent = sfx
+		}
+
+		loc.s = prefix
+		sfx.parent = loc
+		loc.children = append(loc.children, sfx)
+		loc.tipSupport = 0
+	}
+
+	if hasNewSuffix {
+		nn := newNodeFromSpan(newSuffix)
+		nn.parent = loc
+		incNode = nn
+		loc.children = append(loc.children, nn)
+	}
+
+	incNode.tipSupport += count
+	for cur := incNode; cur != nil; cur = cur.parent {
+		cur.branchSupport += count
+	}
+
+	t.seqSupportAdd(l.Seq(), count)
+}
+
+// --- Remove ---
+
+// Remove decreases support for l by up to `count`, compacting the
+// trie when a node's tipSupport falls to zero. Returns true when a
+// matching node was found. Port of LedgerTrie::remove
+// (LedgerTrie.h:540-589).
+func (t *Trie) Remove(l Ledger, count uint32) bool {
+	loc := t.findByLedgerID(l)
+	if loc == nil || loc.tipSupport == 0 {
+		return false
+	}
+	if count > loc.tipSupport {
+		count = loc.tipSupport
+	}
+	if count == 0 {
+		return false
+	}
+
+	loc.tipSupport -= count
+	t.seqSupportSub(l.Seq(), count)
+
+	for cur := loc; cur != nil; cur = cur.parent {
+		cur.branchSupport -= count
+	}
+
+	for loc.tipSupport == 0 && loc != t.root {
+		parent := loc.parent
+		switch len(loc.children) {
+		case 0:
+			parent.eraseChild(loc)
+		case 1:
+			child := loc.children[0]
+			child.s = mergeSpans(loc.s, child.s)
+			child.parent = parent
+			parent.children = append(parent.children, child)
+			parent.eraseChild(loc)
+		default:
+			// Can't compact further — 0-tip node with >1 children is
+			// a valid compressed-trie node.
+			return true
+		}
+		loc = parent
+	}
+	return true
+}
+
+// --- Support queries ---
+
+// TipSupport returns the tip support for the exact ledger l (0 if
+// not in the trie).
+func (t *Trie) TipSupport(l Ledger) uint32 {
+	if loc := t.findByLedgerID(l); loc != nil {
+		return loc.tipSupport
+	}
+	return 0
+}
+
+// BranchSupport returns the branch support rooted at l: tip of l
+// plus all descendants of l. If l is a proper prefix of a trie span,
+// returns the enclosing node's branchSupport. Port of
+// LedgerTrie::branchSupport (LedgerTrie.h:610-623).
+func (t *Trie) BranchSupport(l Ledger) uint32 {
+	loc := t.findByLedgerID(l)
+	if loc == nil {
+		candidate, diffSeq := t.find(l)
+		if diffSeq > l.Seq() && l.Seq() < candidate.s.end {
+			loc = candidate
+		}
+	}
+	if loc == nil {
+		return 0
+	}
+	return loc.branchSupport
+}
+
+// --- GetPreferred ---
+
+// GetPreferred returns the preferred ledger's SpanTip and true, or a
+// zero SpanTip and false when the trie is empty. Port of
+// LedgerTrie::getPreferred (LedgerTrie.h:684-778).
+func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
+	if t.Empty() {
+		return SpanTip{}, false
+	}
+
+	curr := t.root
+	uncommitted := uint32(0)
+	uncommittedIdx := 0 // index into t.seqKeys
+
+	for curr != nil {
+		// --- within-span advancement ---
+
+		// Absorb uncommitted support for sequences earlier than
+		// max(curr.start+1, largestIssued).
+		nextSeq := curr.s.start + 1
+		floor := nextSeq
+		if largestIssued > floor {
+			floor = largestIssued
+		}
+		for uncommittedIdx < len(t.seqKeys) && t.seqKeys[uncommittedIdx] < floor {
+			uncommitted += t.seqSupport[t.seqKeys[uncommittedIdx]]
+			uncommittedIdx++
+		}
+
+		// Advance nextSeq along the span while branchSupport > uncommitted.
+		for nextSeq < curr.s.end && curr.branchSupport > uncommitted {
+			if uncommittedIdx < len(t.seqKeys) && t.seqKeys[uncommittedIdx] < curr.s.end {
+				nextSeq = t.seqKeys[uncommittedIdx] + 1
+				uncommitted += t.seqSupport[t.seqKeys[uncommittedIdx]]
+				uncommittedIdx++
+			} else {
+				nextSeq = curr.s.end
+			}
+		}
+
+		if nextSeq < curr.s.end {
+			// Preferred sits strictly inside the current span.
+			sub, ok := curr.s.before(nextSeq)
+			if !ok {
+				return curr.s.tip(), true
+			}
+			return sub.tip(), true
+		}
+
+		// --- between-spans: pick the best child ---
+		var best *node
+		var margin uint32
+		switch len(curr.children) {
+		case 0:
+			best = nil
+		case 1:
+			best = curr.children[0]
+			margin = best.branchSupport
+		default:
+			// partial_sort top-2 by (branchSupport desc, startID desc).
+			// With small N a full sort is fine.
+			sorted := make([]*node, len(curr.children))
+			copy(sorted, curr.children)
+			sort.Slice(sorted, func(i, j int) bool {
+				if sorted[i].branchSupport != sorted[j].branchSupport {
+					return sorted[i].branchSupport > sorted[j].branchSupport
+				}
+				return ledgerIDGreater(sorted[i].s.startID(), sorted[j].s.startID())
+			})
+			best = sorted[0]
+			second := sorted[1]
+			margin = best.branchSupport - second.branchSupport
+			// Tie-break bonus: if best's startID sorts first it needs
+			// one extra unit of ambiguity to lose. Matches the
+			// `if (best->span.startID() > curr->children[1]->span.startID())
+			//     margin++;`
+			// at LedgerTrie.h:766-767 — comparing against the ORIGINAL
+			// second child (index 1 after partial_sort), not the best.
+			if ledgerIDGreater(best.s.startID(), second.s.startID()) {
+				margin++
+			}
+		}
+
+		if best != nil && (margin > uncommitted || uncommitted == 0) {
+			curr = best
+			continue
+		}
+		break
+	}
+	return curr.s.tip(), true
+}
+
+// ledgerIDGreater returns a > b in lexicographic byte order.
+func ledgerIDGreater(a, b consensus.LedgerID) bool {
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return a[i] > b[i]
+		}
+	}
+	return false
+}
+
+// --- Invariants ---
+
+// CheckInvariants returns true when the compressed-trie invariants
+// hold:
+//   - every non-root 0-tip node has ≥2 children
+//   - branchSupport == tipSupport + sum(child.branchSupport)
+//   - parent pointers are consistent
+//   - seqSupport matches the sum of tip supports at each sequence
+//
+// Port of LedgerTrie::checkInvariants (LedgerTrie.h:811-849).
+func (t *Trie) CheckInvariants() bool {
+	expected := make(map[uint32]uint32)
+	stack := []*node{t.root}
+	for len(stack) > 0 {
+		curr := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if curr == nil {
+			continue
+		}
+		if curr != t.root && curr.tipSupport == 0 && len(curr.children) < 2 {
+			return false
+		}
+		support := curr.tipSupport
+		if curr.tipSupport != 0 {
+			expected[curr.s.end-1] += curr.tipSupport
+		}
+		for _, c := range curr.children {
+			if c.parent != curr {
+				return false
+			}
+			support += c.branchSupport
+			stack = append(stack, c)
+		}
+		if support != curr.branchSupport {
+			return false
+		}
+	}
+	if len(expected) != len(t.seqSupport) {
+		return false
+	}
+	for k, v := range expected {
+		if t.seqSupport[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/consensus/ledgertrie/trie.go
+++ b/internal/consensus/ledgertrie/trie.go
@@ -1,8 +1,6 @@
-// Package ledgertrie is a Go port of rippled's LedgerTrie<Ledger>
-// (src/xrpld/consensus/LedgerTrie.h). The trie maintains validation
-// support of recent ledgers based on their ancestry so that
-// consensus can pick a preferred branch by branchSupport rather than
-// by flat hash-count.
+// Package ledgertrie ports rippled's LedgerTrie<Ledger>
+// (src/xrpld/consensus/LedgerTrie.h): branchSupport-based preferred-
+// ledger selection over a compressed ancestry trie.
 package ledgertrie
 
 import (
@@ -12,15 +10,9 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 )
 
-// Ledger is the interface the trie needs. Ledgers have a unique-history
-// invariant: if a[s] == b[s] then a[p] == b[p] for all p < s within
-// each ledger's known-ancestor range.
-//
-// Production ledgers (rippled's RCLValidatedLedger / our providerLedger)
-// only carry the most recent ~256 ancestors via the keylet::skip SLE.
-// MinSeq() reports the earliest seq for which Ancestor() returns a
-// real ID; below it Ancestor() returns the zero LedgerID to signal
-// "out of range". Test ledgers that cache the full chain return 0.
+// Ledger is the interface the trie needs. Unique-history invariant:
+// a[s] == b[s] implies a[p] == b[p] for all p < s in the overlap.
+// Ancestor returns the zero LedgerID for s outside [MinSeq, Seq].
 type Ledger interface {
 	ID() consensus.LedgerID
 	Seq() uint32
@@ -28,12 +20,10 @@ type Ledger interface {
 	Ancestor(s uint32) consensus.LedgerID
 }
 
-// Mismatch returns the first sequence at which a and b diverge,
-// restricted to the overlap [max(MinSeq), min(Seq)]. Returns 1 when
-// the ranges don't overlap or the overlap mismatches at its floor —
-// the "assume post-genesis divergence" fallback from
-// RCLValidations.cpp:99-114. Returns min(Seq)+1 when the overlap
-// agrees throughout.
+// Mismatch returns the first sequence at which a and b diverge.
+// Returns 1 when the overlap doesn't exist or mismatches at its floor
+// (rippled's "assume post-genesis divergence" fallback,
+// RCLValidations.cpp:99-114).
 func Mismatch(a, b Ledger) uint32 {
 	upper := a.Seq()
 	if b.Seq() < upper {
@@ -47,8 +37,7 @@ func Mismatch(a, b Ledger) uint32 {
 		return 1
 	}
 
-	// Unique-history makes the match predicate monotone within the
-	// overlap; binary search over [lower, upper].
+	// Unique-history makes the predicate monotone; binary search.
 	low := lower
 	hi := upper + 1
 	for low < hi {
@@ -60,14 +49,12 @@ func Mismatch(a, b Ledger) uint32 {
 		}
 	}
 	if low == lower {
-		// Divergence is below our visibility — fall back to 1.
 		return 1
 	}
 	return low
 }
 
-// SpanTip is the read-only view of a span's tip. Port of rippled's
-// SpanTip<Ledger> (LedgerTrie.h:39-73).
+// SpanTip is the read-only view of a span's tip.
 type SpanTip struct {
 	Seq    uint32
 	ID     consensus.LedgerID
@@ -82,8 +69,7 @@ type Trie struct {
 	root    *node
 	genesis Ledger
 
-	// seqSupport[seq] is the count of ledgers at `seq` with tip support.
-	// seqKeys mirrors std::map's ordered iteration as a sorted key list.
+	// seqKeys is the sorted-key view over seqSupport (std::map analogue).
 	seqSupport map[uint32]uint32
 	seqKeys    []uint32
 }
@@ -100,9 +86,8 @@ func New(genesis Ledger) *Trie {
 // Empty reports whether the trie holds any support.
 func (t *Trie) Empty() bool { return t.root == nil || t.root.branchSupport == 0 }
 
-// find returns the node sharing the longest common ancestry prefix of
-// l and the sequence at which they diverge. Port of LedgerTrie::find
-// (LedgerTrie.h:371-401).
+// find returns the node sharing the longest common prefix with l and
+// the sequence at which they diverge.
 func (t *Trie) find(l Ledger) (*node, uint32) {
 	curr := t.root
 	pos := curr.s.diff(l)
@@ -123,8 +108,7 @@ func (t *Trie) find(l Ledger) (*node, uint32) {
 	return curr, pos
 }
 
-// findByLedgerID is an O(n) walk for an exact ID match. Port of
-// LedgerTrie::findByLedgerID (LedgerTrie.h:409-423).
+// findByLedgerID is an O(n) walk for an exact ID match.
 func (t *Trie) findByLedgerID(l Ledger) *node {
 	return findByIDWalk(t.root, l.ID())
 }
@@ -152,8 +136,7 @@ func (t *Trie) seqSupportAdd(seq uint32, delta uint32) {
 	t.seqSupport[seq] += delta
 }
 
-// seqSupportSub panics on under-subtract, matching the XRPL_ASSERT at
-// LedgerTrie.h:553-555.
+// seqSupportSub panics on under-subtract (XRPL_ASSERT, LedgerTrie.h:553).
 func (t *Trie) seqSupportSub(seq uint32, delta uint32) {
 	cur, ok := t.seqSupport[seq]
 	if !ok || cur < delta {
@@ -170,10 +153,8 @@ func (t *Trie) seqSupportSub(seq uint32, delta uint32) {
 	t.seqSupport[seq] = cur
 }
 
-// Insert adds `count` support for l along its ancestry. count must be
-// > 0; rippled's contract is undefined for 0 (it would corrupt
-// seqSupport and reset existing tipSupport on a split). Port of
-// LedgerTrie::insert (LedgerTrie.h:452-531).
+// Insert adds count support for l along its ancestry. count must be > 0
+// — 0 corrupts seqSupport and resets existing tipSupport on a split.
 func (t *Trie) Insert(l Ledger, count uint32) {
 	loc, diffSeq := t.find(l)
 
@@ -184,10 +165,6 @@ func (t *Trie) Insert(l Ledger, count uint32) {
 	newSuffix, hasNewSuffix := newSpanFromLedger(l).from(diffSeq)
 
 	if hasOldSuffix {
-		// Split: loc keeps prefix; a new node inherits loc's
-		// tip/branch support and children. Mirrors XRPL_ASSERT at
-		// LedgerTrie.h:500 — !hasPrefix means a corrupt input
-		// (e.g. genesis disagreement).
 		if !hasPrefix {
 			panic("ledgertrie: Insert: prefix missing despite oldSuffix")
 		}
@@ -221,9 +198,8 @@ func (t *Trie) Insert(l Ledger, count uint32) {
 	t.seqSupportAdd(l.Seq(), count)
 }
 
-// Remove decreases l's tip support by up to `count`, compacting the
-// trie when tipSupport reaches zero. Returns true if l was in the
-// trie. Port of LedgerTrie::remove (LedgerTrie.h:540-589).
+// Remove decreases l's tip support by up to count, compacting the trie
+// when tipSupport reaches zero. Returns true if l was in the trie.
 func (t *Trie) Remove(l Ledger, count uint32) bool {
 	loc := t.findByLedgerID(l)
 	if loc == nil || loc.tipSupport == 0 {
@@ -270,8 +246,7 @@ func (t *Trie) TipSupport(l Ledger) uint32 {
 
 // BranchSupport returns tipSupport(l) plus the branchSupport of all
 // descendants. When l is a proper prefix of a trie span, returns the
-// enclosing node's branchSupport. Port of LedgerTrie::branchSupport
-// (LedgerTrie.h:610-623).
+// enclosing node's branchSupport.
 func (t *Trie) BranchSupport(l Ledger) uint32 {
 	loc := t.findByLedgerID(l)
 	if loc == nil {
@@ -287,10 +262,8 @@ func (t *Trie) BranchSupport(l Ledger) uint32 {
 }
 
 // GetPreferred returns the preferred ledger's tip, or false when the
-// trie is empty. largestIssued is the highest sequence this node has
-// already validated; uncommitted support from earlier sequences is
-// seeded so ancient validations cannot retroactively swing preference.
-// Port of LedgerTrie::getPreferred (LedgerTrie.h:684-778).
+// trie is empty. largestIssued seeds uncommitted support from earlier
+// sequences so ancient validations cannot retroactively swing preference.
 func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 	if t.Empty() {
 		return SpanTip{}, false
@@ -325,7 +298,8 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 		if nextSeq < curr.s.end {
 			sub, ok := curr.s.before(nextSeq)
 			if !ok {
-				return curr.s.tip(), true
+				// nextSeq > curr.s.start by construction; this is unreachable.
+				panic("ledgertrie: GetPreferred: before(nextSeq) yielded empty span")
 			}
 			return sub.tip(), true
 		}
@@ -339,8 +313,7 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 			best = curr.children[0]
 			margin = best.branchSupport
 		default:
-			// Inline top-2 by (branchSupport, startID) desc — equivalent
-			// to rippled's partial_sort at LedgerTrie.h:746.
+			// Inline top-2 by (branchSupport, startID) desc.
 			var second *node
 			for _, c := range curr.children {
 				if best == nil || nodeOutranks(c, best) {
@@ -350,7 +323,6 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 				}
 			}
 			margin = best.branchSupport - second.branchSupport
-			// Tie-break bonus from LedgerTrie.h:766-767.
 			if ledgerIDGreater(best.s.startID(), second.s.startID()) {
 				margin++
 			}
@@ -365,14 +337,12 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 	return curr.s.tip(), true
 }
 
-// ledgerIDGreater compares LedgerIDs as big-endian byte sequences,
-// matching rippled's base_uint::operator> (memcmp on the buffer).
+// ledgerIDGreater matches rippled's base_uint::operator> (big-endian memcmp).
 func ledgerIDGreater(a, b consensus.LedgerID) bool {
 	return bytes.Compare(a[:], b[:]) > 0
 }
 
-// nodeOutranks orders nodes by (branchSupport, startID) descending —
-// the order used at LedgerTrie.h:751-757.
+// nodeOutranks orders nodes by (branchSupport, startID) descending.
 func nodeOutranks(a, b *node) bool {
 	if a.branchSupport != b.branchSupport {
 		return a.branchSupport > b.branchSupport
@@ -380,13 +350,9 @@ func nodeOutranks(a, b *node) bool {
 	return ledgerIDGreater(a.s.startID(), b.s.startID())
 }
 
-// CheckInvariants returns true when:
-//   - every non-root 0-tip node has ≥2 children
-//   - branchSupport == tipSupport + sum(child.branchSupport)
-//   - parent pointers are consistent
-//   - seqSupport matches the sum of tip supports at each sequence
-//
-// Port of LedgerTrie::checkInvariants (LedgerTrie.h:811-849).
+// CheckInvariants verifies: non-root 0-tip nodes have ≥2 children,
+// branchSupport == tipSupport + Σ child.branchSupport, parent pointers
+// are consistent, and seqSupport matches the sum of tip supports.
 func (t *Trie) CheckInvariants() bool {
 	expected := make(map[uint32]uint32)
 	stack := []*node{t.root}

--- a/internal/consensus/ledgertrie/trie.go
+++ b/internal/consensus/ledgertrie/trie.go
@@ -6,7 +6,8 @@
 package ledgertrie
 
 import (
-	"sort"
+	"bytes"
+	"slices"
 
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 )
@@ -21,26 +22,18 @@ import (
 // real ID; below it Ancestor() returns the zero LedgerID to signal
 // "out of range". Test ledgers that cache the full chain return 0.
 type Ledger interface {
-	// ID returns the ledger's own identifier (== Ancestor(Seq())).
 	ID() consensus.LedgerID
-	// Seq returns this ledger's sequence number.
 	Seq() uint32
-	// MinSeq returns the lowest seq for which Ancestor returns a
-	// non-zero ID. 0 for ledgers that retain their full ancestry.
 	MinSeq() uint32
-	// Ancestor returns the ID of the ancestor at sequence s. For s
-	// outside [MinSeq(), Seq()] the implementation returns the zero
-	// LedgerID. Ancestor(0) is the genesis ID for unbounded ledgers.
 	Ancestor(s uint32) consensus.LedgerID
 }
 
-// Mismatch returns the first sequence number at which a and b's
-// ancestries differ, restricted to the overlap of their known ranges
-// [max(a.MinSeq, b.MinSeq), min(a.Seq, b.Seq)]. When the entire
-// overlap mismatches — or there is no overlap — returns 1, matching
-// rippled's RCLValidations.cpp:99-114 fallback ("assume divergence
-// post-genesis"). When ancestries agree throughout the overlap,
-// returns min(a.Seq, b.Seq)+1.
+// Mismatch returns the first sequence at which a and b diverge,
+// restricted to the overlap [max(MinSeq), min(Seq)]. Returns 1 when
+// the ranges don't overlap or the overlap mismatches at its floor —
+// the "assume post-genesis divergence" fallback from
+// RCLValidations.cpp:99-114. Returns min(Seq)+1 when the overlap
+// agrees throughout.
 func Mismatch(a, b Ledger) uint32 {
 	upper := a.Seq()
 	if b.Seq() < upper {
@@ -51,14 +44,11 @@ func Mismatch(a, b Ledger) uint32 {
 		lower = bm
 	}
 	if lower > upper {
-		// No overlap of known ranges; assume divergence is post-genesis.
 		return 1
 	}
 
-	// Binary search in [lower, upper] for the first seq where a[s]
-	// disagrees with b[s]. Unique-history makes the "match" predicate
-	// monotone within the overlap (matches above s implies matches at
-	// every p in [lower, s]).
+	// Unique-history makes the match predicate monotone within the
+	// overlap; binary search over [lower, upper].
 	low := lower
 	hi := upper + 1
 	for low < hi {
@@ -70,40 +60,35 @@ func Mismatch(a, b Ledger) uint32 {
 		}
 	}
 	if low == lower {
-		// Mismatch at the lowest known seq — divergence is below our
-		// visibility. Per the rippled fallback, return 1.
+		// Divergence is below our visibility — fall back to 1.
 		return 1
 	}
 	return low
 }
 
-// SpanTip is the public read-only view of the tip of a span. Port of
-// rippled's SpanTip<Ledger> (LedgerTrie.h:39-73).
+// SpanTip is the read-only view of a span's tip. Port of rippled's
+// SpanTip<Ledger> (LedgerTrie.h:39-73).
 type SpanTip struct {
 	Seq    uint32
 	ID     consensus.LedgerID
 	ledger Ledger
 }
 
-// Ancestor returns the ID of the ancestor at sequence s (s <= Seq).
+// Ancestor returns the ID at sequence s; s must be <= Seq.
 func (t SpanTip) Ancestor(s uint32) consensus.LedgerID { return t.ledger.Ancestor(s) }
 
 // Trie is the ancestry trie. The zero value is not usable — call New.
 type Trie struct {
-	root *node
-	// genesis is captured at construction so an empty root always has
-	// a concrete Ledger to resolve Ancestor(0) against.
+	root    *node
 	genesis Ledger
 
-	// seqSupport[seq] is the number of ledgers at sequence `seq` that
-	// currently hold tip support. Rippled uses std::map for ordered
-	// iteration; we mirror that with a side-sorted slice of keys.
+	// seqSupport[seq] is the count of ledgers at `seq` with tip support.
+	// seqKeys mirrors std::map's ordered iteration as a sorted key list.
 	seqSupport map[uint32]uint32
-	seqKeys    []uint32 // sorted ascending
+	seqKeys    []uint32
 }
 
-// New constructs an empty trie. genesis is used as the placeholder
-// ledger for the root node and must satisfy Seq() == 0.
+// New constructs an empty trie. genesis must satisfy Seq() == 0.
 func New(genesis Ledger) *Trie {
 	return &Trie{
 		root:       newEmptyNode(genesis),
@@ -112,13 +97,11 @@ func New(genesis Ledger) *Trie {
 	}
 }
 
-// Empty reports whether the trie has any support recorded.
+// Empty reports whether the trie holds any support.
 func (t *Trie) Empty() bool { return t.root == nil || t.root.branchSupport == 0 }
 
-// --- find ---
-
-// find locates the node with the longest common ancestry prefix of
-// `l` and returns (node, diffSeq). Port of LedgerTrie::find
+// find returns the node sharing the longest common ancestry prefix of
+// l and the sequence at which they diverge. Port of LedgerTrie::find
 // (LedgerTrie.h:371-401).
 func (t *Trie) find(l Ledger) (*node, uint32) {
 	curr := t.root
@@ -140,8 +123,8 @@ func (t *Trie) find(l Ledger) (*node, uint32) {
 	return curr, pos
 }
 
-// findByLedgerID does an O(n) walk looking for an exact ID match.
-// Port of LedgerTrie::findByLedgerID (LedgerTrie.h:409-423).
+// findByLedgerID is an O(n) walk for an exact ID match. Port of
+// LedgerTrie::findByLedgerID (LedgerTrie.h:409-423).
 func (t *Trie) findByLedgerID(l Ledger) *node {
 	return findByIDWalk(t.root, l.ID())
 }
@@ -161,46 +144,37 @@ func findByIDWalk(curr *node, id consensus.LedgerID) *node {
 	return nil
 }
 
-// --- seqSupport helpers ---
-
 func (t *Trie) seqSupportAdd(seq uint32, delta uint32) {
 	if _, ok := t.seqSupport[seq]; !ok {
-		// insert seq into sorted key list
-		idx := sort.Search(len(t.seqKeys), func(i int) bool { return t.seqKeys[i] >= seq })
-		t.seqKeys = append(t.seqKeys, 0)
-		copy(t.seqKeys[idx+1:], t.seqKeys[idx:])
-		t.seqKeys[idx] = seq
+		idx, _ := slices.BinarySearch(t.seqKeys, seq)
+		t.seqKeys = slices.Insert(t.seqKeys, idx, seq)
 	}
 	t.seqSupport[seq] += delta
 }
 
+// seqSupportSub panics on under-subtract, matching the XRPL_ASSERT at
+// LedgerTrie.h:553-555.
 func (t *Trie) seqSupportSub(seq uint32, delta uint32) {
 	cur, ok := t.seqSupport[seq]
 	if !ok || cur < delta {
-		return // caller validated; defensive no-op
+		panic("ledgertrie: seqSupport invariant violation")
 	}
 	cur -= delta
 	if cur == 0 {
 		delete(t.seqSupport, seq)
-		idx := sort.Search(len(t.seqKeys), func(i int) bool { return t.seqKeys[i] >= seq })
-		if idx < len(t.seqKeys) && t.seqKeys[idx] == seq {
-			t.seqKeys = append(t.seqKeys[:idx], t.seqKeys[idx+1:]...)
+		if idx, found := slices.BinarySearch(t.seqKeys, seq); found {
+			t.seqKeys = slices.Delete(t.seqKeys, idx, idx+1)
 		}
 		return
 	}
 	t.seqSupport[seq] = cur
 }
 
-// --- Insert ---
-
-// Insert adds `count` units of support for ledger l. The ledger's
-// ancestry is walked from genesis to l itself; branchSupport is
-// incremented along the spine and tipSupport is incremented on the
-// node that owns l. Port of LedgerTrie::insert (LedgerTrie.h:452-531).
+// Insert adds `count` support for l along its ancestry. count must be
+// > 0; rippled's contract is undefined for 0 (it would corrupt
+// seqSupport and reset existing tipSupport on a split). Port of
+// LedgerTrie::insert (LedgerTrie.h:452-531).
 func (t *Trie) Insert(l Ledger, count uint32) {
-	if count == 0 {
-		return
-	}
 	loc, diffSeq := t.find(l)
 
 	incNode := loc
@@ -210,10 +184,13 @@ func (t *Trie) Insert(l Ledger, count uint32) {
 	newSuffix, hasNewSuffix := newSpanFromLedger(l).from(diffSeq)
 
 	if hasOldSuffix {
-		// Split: loc keeps the prefix; a new node takes over loc's
-		// tip/branch support and its children (which are the suffix
-		// continuation). Then loc's tipSupport resets to zero.
-		_ = hasPrefix // prefix must be present whenever oldSuffix is (see LedgerTrie.h:500)
+		// Split: loc keeps prefix; a new node inherits loc's
+		// tip/branch support and children. Mirrors XRPL_ASSERT at
+		// LedgerTrie.h:500 — !hasPrefix means a corrupt input
+		// (e.g. genesis disagreement).
+		if !hasPrefix {
+			panic("ledgertrie: Insert: prefix missing despite oldSuffix")
+		}
 		sfx := newNodeFromSpan(oldSuffix)
 		sfx.tipSupport = loc.tipSupport
 		sfx.branchSupport = loc.branchSupport
@@ -244,12 +221,9 @@ func (t *Trie) Insert(l Ledger, count uint32) {
 	t.seqSupportAdd(l.Seq(), count)
 }
 
-// --- Remove ---
-
-// Remove decreases support for l by up to `count`, compacting the
-// trie when a node's tipSupport falls to zero. Returns true when a
-// matching node was found. Port of LedgerTrie::remove
-// (LedgerTrie.h:540-589).
+// Remove decreases l's tip support by up to `count`, compacting the
+// trie when tipSupport reaches zero. Returns true if l was in the
+// trie. Port of LedgerTrie::remove (LedgerTrie.h:540-589).
 func (t *Trie) Remove(l Ledger, count uint32) bool {
 	loc := t.findByLedgerID(l)
 	if loc == nil || loc.tipSupport == 0 {
@@ -257,9 +231,6 @@ func (t *Trie) Remove(l Ledger, count uint32) bool {
 	}
 	if count > loc.tipSupport {
 		count = loc.tipSupport
-	}
-	if count == 0 {
-		return false
 	}
 
 	loc.tipSupport -= count
@@ -281,8 +252,7 @@ func (t *Trie) Remove(l Ledger, count uint32) bool {
 			parent.children = append(parent.children, child)
 			parent.eraseChild(loc)
 		default:
-			// Can't compact further — 0-tip node with >1 children is
-			// a valid compressed-trie node.
+			// 0-tip node with >1 children is valid; can't compact.
 			return true
 		}
 		loc = parent
@@ -290,10 +260,7 @@ func (t *Trie) Remove(l Ledger, count uint32) bool {
 	return true
 }
 
-// --- Support queries ---
-
-// TipSupport returns the tip support for the exact ledger l (0 if
-// not in the trie).
+// TipSupport returns the exact tip support for l, or 0 if not present.
 func (t *Trie) TipSupport(l Ledger) uint32 {
 	if loc := t.findByLedgerID(l); loc != nil {
 		return loc.tipSupport
@@ -301,10 +268,10 @@ func (t *Trie) TipSupport(l Ledger) uint32 {
 	return 0
 }
 
-// BranchSupport returns the branch support rooted at l: tip of l
-// plus all descendants of l. If l is a proper prefix of a trie span,
-// returns the enclosing node's branchSupport. Port of
-// LedgerTrie::branchSupport (LedgerTrie.h:610-623).
+// BranchSupport returns tipSupport(l) plus the branchSupport of all
+// descendants. When l is a proper prefix of a trie span, returns the
+// enclosing node's branchSupport. Port of LedgerTrie::branchSupport
+// (LedgerTrie.h:610-623).
 func (t *Trie) BranchSupport(l Ledger) uint32 {
 	loc := t.findByLedgerID(l)
 	if loc == nil {
@@ -319,11 +286,11 @@ func (t *Trie) BranchSupport(l Ledger) uint32 {
 	return loc.branchSupport
 }
 
-// --- GetPreferred ---
-
-// GetPreferred returns the preferred ledger's SpanTip and true, or a
-// zero SpanTip and false when the trie is empty. Port of
-// LedgerTrie::getPreferred (LedgerTrie.h:684-778).
+// GetPreferred returns the preferred ledger's tip, or false when the
+// trie is empty. largestIssued is the highest sequence this node has
+// already validated; uncommitted support from earlier sequences is
+// seeded so ancient validations cannot retroactively swing preference.
+// Port of LedgerTrie::getPreferred (LedgerTrie.h:684-778).
 func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 	if t.Empty() {
 		return SpanTip{}, false
@@ -331,13 +298,10 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 
 	curr := t.root
 	uncommitted := uint32(0)
-	uncommittedIdx := 0 // index into t.seqKeys
+	uncommittedIdx := 0
 
 	for curr != nil {
-		// --- within-span advancement ---
-
-		// Absorb uncommitted support for sequences earlier than
-		// max(curr.start+1, largestIssued).
+		// Absorb uncommitted support for seqs < max(curr.start+1, largestIssued).
 		nextSeq := curr.s.start + 1
 		floor := nextSeq
 		if largestIssued > floor {
@@ -348,7 +312,6 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 			uncommittedIdx++
 		}
 
-		// Advance nextSeq along the span while branchSupport > uncommitted.
 		for nextSeq < curr.s.end && curr.branchSupport > uncommitted {
 			if uncommittedIdx < len(t.seqKeys) && t.seqKeys[uncommittedIdx] < curr.s.end {
 				nextSeq = t.seqKeys[uncommittedIdx] + 1
@@ -360,7 +323,6 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 		}
 
 		if nextSeq < curr.s.end {
-			// Preferred sits strictly inside the current span.
 			sub, ok := curr.s.before(nextSeq)
 			if !ok {
 				return curr.s.tip(), true
@@ -368,7 +330,6 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 			return sub.tip(), true
 		}
 
-		// --- between-spans: pick the best child ---
 		var best *node
 		var margin uint32
 		switch len(curr.children) {
@@ -378,25 +339,18 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 			best = curr.children[0]
 			margin = best.branchSupport
 		default:
-			// partial_sort top-2 by (branchSupport desc, startID desc).
-			// With small N a full sort is fine.
-			sorted := make([]*node, len(curr.children))
-			copy(sorted, curr.children)
-			sort.Slice(sorted, func(i, j int) bool {
-				if sorted[i].branchSupport != sorted[j].branchSupport {
-					return sorted[i].branchSupport > sorted[j].branchSupport
+			// Inline top-2 by (branchSupport, startID) desc — equivalent
+			// to rippled's partial_sort at LedgerTrie.h:746.
+			var second *node
+			for _, c := range curr.children {
+				if best == nil || nodeOutranks(c, best) {
+					second, best = best, c
+				} else if second == nil || nodeOutranks(c, second) {
+					second = c
 				}
-				return ledgerIDGreater(sorted[i].s.startID(), sorted[j].s.startID())
-			})
-			best = sorted[0]
-			second := sorted[1]
+			}
 			margin = best.branchSupport - second.branchSupport
-			// Tie-break bonus: if best's startID sorts first it needs
-			// one extra unit of ambiguity to lose. Matches the
-			// `if (best->span.startID() > curr->children[1]->span.startID())
-			//     margin++;`
-			// at LedgerTrie.h:766-767 — comparing against the ORIGINAL
-			// second child (index 1 after partial_sort), not the best.
+			// Tie-break bonus from LedgerTrie.h:766-767.
 			if ledgerIDGreater(best.s.startID(), second.s.startID()) {
 				margin++
 			}
@@ -411,20 +365,22 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 	return curr.s.tip(), true
 }
 
-// ledgerIDGreater returns a > b in lexicographic byte order.
+// ledgerIDGreater compares LedgerIDs as big-endian byte sequences,
+// matching rippled's base_uint::operator> (memcmp on the buffer).
 func ledgerIDGreater(a, b consensus.LedgerID) bool {
-	for i := 0; i < len(a); i++ {
-		if a[i] != b[i] {
-			return a[i] > b[i]
-		}
-	}
-	return false
+	return bytes.Compare(a[:], b[:]) > 0
 }
 
-// --- Invariants ---
+// nodeOutranks orders nodes by (branchSupport, startID) descending —
+// the order used at LedgerTrie.h:751-757.
+func nodeOutranks(a, b *node) bool {
+	if a.branchSupport != b.branchSupport {
+		return a.branchSupport > b.branchSupport
+	}
+	return ledgerIDGreater(a.s.startID(), b.s.startID())
+}
 
-// CheckInvariants returns true when the compressed-trie invariants
-// hold:
+// CheckInvariants returns true when:
 //   - every non-root 0-tip node has ≥2 children
 //   - branchSupport == tipSupport + sum(child.branchSupport)
 //   - parent pointers are consistent

--- a/internal/consensus/ledgertrie/trie.go
+++ b/internal/consensus/ledgertrie/trie.go
@@ -153,9 +153,13 @@ func (t *Trie) seqSupportSub(seq uint32, delta uint32) {
 	t.seqSupport[seq] = cur
 }
 
-// Insert adds count support for l along its ancestry. count must be > 0
-// — 0 corrupts seqSupport and resets existing tipSupport on a split.
+// Insert adds count support for l along its ancestry. A zero count is a
+// no-op: a 0-count insert that takes the newSuffix branch would create a
+// 0-tip leaf and break the compressed-trie invariant.
 func (t *Trie) Insert(l Ledger, count uint32) {
+	if count == 0 {
+		return
+	}
 	loc, diffSeq := t.find(l)
 
 	incNode := loc

--- a/internal/consensus/ledgertrie/trie.go
+++ b/internal/consensus/ledgertrie/trie.go
@@ -12,30 +12,55 @@ import (
 )
 
 // Ledger is the interface the trie needs. Ledgers have a unique-history
-// invariant: if a[s] == b[s] then a[p] == b[p] for all p < s.
+// invariant: if a[s] == b[s] then a[p] == b[p] for all p < s within
+// each ledger's known-ancestor range.
+//
+// Production ledgers (rippled's RCLValidatedLedger / our providerLedger)
+// only carry the most recent ~256 ancestors via the keylet::skip SLE.
+// MinSeq() reports the earliest seq for which Ancestor() returns a
+// real ID; below it Ancestor() returns the zero LedgerID to signal
+// "out of range". Test ledgers that cache the full chain return 0.
 type Ledger interface {
 	// ID returns the ledger's own identifier (== Ancestor(Seq())).
 	ID() consensus.LedgerID
 	// Seq returns this ledger's sequence number.
 	Seq() uint32
-	// Ancestor returns the ID of the ancestor at sequence s. s must be
-	// <= Seq(); Ancestor(0) is the genesis ID.
+	// MinSeq returns the lowest seq for which Ancestor returns a
+	// non-zero ID. 0 for ledgers that retain their full ancestry.
+	MinSeq() uint32
+	// Ancestor returns the ID of the ancestor at sequence s. For s
+	// outside [MinSeq(), Seq()] the implementation returns the zero
+	// LedgerID. Ancestor(0) is the genesis ID for unbounded ledgers.
 	Ancestor(s uint32) consensus.LedgerID
 }
 
 // Mismatch returns the first sequence number at which a and b's
-// ancestries differ. If one is a strict ancestor of the other it
-// returns min(a.Seq(), b.Seq())+1. Port of the free `mismatch`
-// function expected by LedgerTrie.h:329-332.
+// ancestries differ, restricted to the overlap of their known ranges
+// [max(a.MinSeq, b.MinSeq), min(a.Seq, b.Seq)]. When the entire
+// overlap mismatches — or there is no overlap — returns 1, matching
+// rippled's RCLValidations.cpp:99-114 fallback ("assume divergence
+// post-genesis"). When ancestries agree throughout the overlap,
+// returns min(a.Seq, b.Seq)+1.
 func Mismatch(a, b Ledger) uint32 {
-	lo := a.Seq()
-	if b.Seq() < lo {
-		lo = b.Seq()
+	upper := a.Seq()
+	if b.Seq() < upper {
+		upper = b.Seq()
 	}
-	// Binary search over [0, lo] for the first s with a[s] != b[s].
-	// Unique-history makes the predicate monotone.
-	hi := lo
-	var low uint32 = 0
+	lower := a.MinSeq()
+	if bm := b.MinSeq(); bm > lower {
+		lower = bm
+	}
+	if lower > upper {
+		// No overlap of known ranges; assume divergence is post-genesis.
+		return 1
+	}
+
+	// Binary search in [lower, upper] for the first seq where a[s]
+	// disagrees with b[s]. Unique-history makes the "match" predicate
+	// monotone within the overlap (matches above s implies matches at
+	// every p in [lower, s]).
+	low := lower
+	hi := upper + 1
 	for low < hi {
 		mid := low + (hi-low)/2
 		if a.Ancestor(mid) == b.Ancestor(mid) {
@@ -44,10 +69,10 @@ func Mismatch(a, b Ledger) uint32 {
 			hi = mid
 		}
 	}
-	// At this point low == hi; if a[low]==b[low] then they agree up
-	// to sequence `lo`, so the first mismatch (if any) is at lo+1.
-	if low == lo && a.Ancestor(low) == b.Ancestor(low) {
-		return lo + 1
+	if low == lower {
+		// Mismatch at the lowest known seq — divergence is below our
+		// visibility. Per the rippled fallback, return 1.
+		return 1
 	}
 	return low
 }

--- a/internal/consensus/ledgertrie/trie_test.go
+++ b/internal/consensus/ledgertrie/trie_test.go
@@ -36,33 +36,10 @@ func newTestTrie() (*Trie, *TestLedgerBuilder) {
 // support at each named ledger. After every op we verify the trie's
 // own invariants.
 
-type trieOp struct {
-	kind  string // "insert" | "remove"
-	path  string // ledger string; "" = genesis
-	count uint32
-}
-
 type trieAssertion struct {
-	path     string
-	tip      uint32
-	branch   uint32
-	hasEntry bool // if false: tip/branch asserted to be 0
-}
-
-// applyOp runs a single op against the trie. Returns the Remove
-// result (only meaningful for "remove").
-func applyOp(t *testing.T, trie *Trie, b *TestLedgerBuilder, op trieOp) bool {
-	t.Helper()
-	l := b.Build(op.path)
-	switch op.kind {
-	case "insert":
-		trie.Insert(l, op.count)
-		return true
-	case "remove":
-		return trie.Remove(l, op.count)
-	}
-	t.Fatalf("unknown op kind %q", op.kind)
-	return false
+	path   string
+	tip    uint32
+	branch uint32
 }
 
 func assertSupport(t *testing.T, trie *Trie, b *TestLedgerBuilder, a trieAssertion) {

--- a/internal/consensus/ledgertrie/trie_test.go
+++ b/internal/consensus/ledgertrie/trie_test.go
@@ -1,0 +1,806 @@
+package ledgertrie
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// idGreater reports whether a > b in lexicographic byte order. Local
+// helper for tests that would otherwise need to slice unaddressable
+// array returns.
+func idGreater(a, b consensus.LedgerID) bool {
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return a[i] > b[i]
+		}
+	}
+	return false
+}
+
+// newTestTrie constructs an empty trie paired with a fresh builder.
+// The genesis ledger for the trie is builder's genesis so ID matching
+// works naturally.
+func newTestTrie() (*Trie, *TestLedgerBuilder) {
+	b := NewTestLedgerBuilder()
+	return New(b.Genesis()), b
+}
+
+// --- TestLedgerTrie_ParityTable --------------------------------------
+//
+// Ports the state-assertion tests from rippled's
+// src/test/consensus/LedgerTrie_test.cpp — testInsert, testRemove,
+// testEmpty, testSupport — as table-driven subtests. Each subtest runs
+// a sequence of trie operations and asserts expected tip/branch
+// support at each named ledger. After every op we verify the trie's
+// own invariants.
+
+type trieOp struct {
+	kind  string // "insert" | "remove"
+	path  string // ledger string; "" = genesis
+	count uint32
+}
+
+type trieAssertion struct {
+	path     string
+	tip      uint32
+	branch   uint32
+	hasEntry bool // if false: tip/branch asserted to be 0
+}
+
+// applyOp runs a single op against the trie. Returns the Remove
+// result (only meaningful for "remove").
+func applyOp(t *testing.T, trie *Trie, b *TestLedgerBuilder, op trieOp) bool {
+	t.Helper()
+	l := b.Build(op.path)
+	switch op.kind {
+	case "insert":
+		trie.Insert(l, op.count)
+		return true
+	case "remove":
+		return trie.Remove(l, op.count)
+	}
+	t.Fatalf("unknown op kind %q", op.kind)
+	return false
+}
+
+func assertSupport(t *testing.T, trie *Trie, b *TestLedgerBuilder, a trieAssertion) {
+	t.Helper()
+	l := b.Build(a.path)
+	if got := trie.TipSupport(l); got != a.tip {
+		t.Errorf("TipSupport(%q) = %d, want %d", a.path, got, a.tip)
+	}
+	if got := trie.BranchSupport(l); got != a.branch {
+		t.Errorf("BranchSupport(%q) = %d, want %d", a.path, got, a.branch)
+	}
+}
+
+// TestLedgerTrie_ParityTable consolidates the testInsert / testRemove /
+// testSupport scenarios from rippled's LedgerTrie_test.cpp as a single
+// table-driven test. Each subtest is run in isolation via t.Run for
+// per-scenario diagnostics. testEmpty, testGetPreferred, testRootRelated
+// and testStress have their own top-level tests below.
+func TestLedgerTrie_ParityTable(t *testing.T) {
+	t.Run("Insert/Simple", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("abc"), 1)
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken after first insert")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 1})
+
+		trie.Insert(b.Build("abc"), 1)
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken after duplicate insert")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 2, branch: 2})
+	})
+
+	t.Run("Insert/SuffixExtension", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("abc"), 1)
+		trie.Insert(b.Build("abcd"), 1)
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 2})
+		assertSupport(t, trie, b, trieAssertion{path: "abcd", tip: 1, branch: 1})
+
+		trie.Insert(b.Build("abce"), 1)
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 3})
+		assertSupport(t, trie, b, trieAssertion{path: "abcd", tip: 1, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "abce", tip: 1, branch: 1})
+	})
+
+	t.Run("Insert/UncommittedPrefix", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("abcd"), 1)
+		trie.Insert(b.Build("abcdf"), 1)
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abcd", tip: 1, branch: 2})
+		assertSupport(t, trie, b, trieAssertion{path: "abcdf", tip: 1, branch: 1})
+
+		trie.Insert(b.Build("abc"), 1)
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 3})
+		assertSupport(t, trie, b, trieAssertion{path: "abcd", tip: 1, branch: 2})
+		assertSupport(t, trie, b, trieAssertion{path: "abcdf", tip: 1, branch: 1})
+	})
+
+	t.Run("Insert/SuffixAndUncommitted", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("abcd"), 1)
+		trie.Insert(b.Build("abce"), 1)
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 0, branch: 2})
+		assertSupport(t, trie, b, trieAssertion{path: "abcd", tip: 1, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "abce", tip: 1, branch: 1})
+	})
+
+	t.Run("Insert/SuffixAndUncommittedWithChild", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("abcd"), 1)
+		trie.Insert(b.Build("abcde"), 1)
+		trie.Insert(b.Build("abcf"), 1)
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 0, branch: 3})
+		assertSupport(t, trie, b, trieAssertion{path: "abcd", tip: 1, branch: 2})
+		assertSupport(t, trie, b, trieAssertion{path: "abcf", tip: 1, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "abcde", tip: 1, branch: 1})
+	})
+
+	t.Run("Insert/MultipleCounts", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("ab"), 4)
+		assertSupport(t, trie, b, trieAssertion{path: "ab", tip: 4, branch: 4})
+		assertSupport(t, trie, b, trieAssertion{path: "a", tip: 0, branch: 4})
+
+		trie.Insert(b.Build("abc"), 2)
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 2, branch: 2})
+		assertSupport(t, trie, b, trieAssertion{path: "ab", tip: 4, branch: 6})
+		assertSupport(t, trie, b, trieAssertion{path: "a", tip: 0, branch: 6})
+	})
+
+	t.Run("Remove/NotInTrie", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("abc"), 1)
+		if trie.Remove(b.Build("ab"), 1) {
+			t.Errorf("Remove(ab) unexpectedly returned true")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		if trie.Remove(b.Build("a"), 1) {
+			t.Errorf("Remove(a) unexpectedly returned true")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+	})
+
+	t.Run("Remove/ZeroTip", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("abcd"), 1)
+		trie.Insert(b.Build("abce"), 1)
+		if trie.Remove(b.Build("abc"), 1) {
+			t.Errorf("Remove on 0-tip node should return false")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 0, branch: 2})
+	})
+
+	t.Run("Remove/HighTip", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("abc"), 2)
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 2, branch: 2})
+		if !trie.Remove(b.Build("abc"), 1) {
+			t.Fatal("Remove(abc, 1) should return true")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 1})
+
+		trie.Insert(b.Build("abc"), 1)
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 2, branch: 2})
+		if !trie.Remove(b.Build("abc"), 2) {
+			t.Fatal("Remove(abc, 2) should return true")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 0, branch: 0})
+
+		trie.Insert(b.Build("abc"), 3)
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 3, branch: 3})
+		// Over-subtract: clamp to tipSupport.
+		if !trie.Remove(b.Build("abc"), 300) {
+			t.Fatal("Remove(abc, 300) should return true")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 0, branch: 0})
+	})
+
+	t.Run("Remove/LeafCompaction", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("ab"), 1)
+		trie.Insert(b.Build("abc"), 1)
+		assertSupport(t, trie, b, trieAssertion{path: "ab", tip: 1, branch: 2})
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 1})
+
+		if !trie.Remove(b.Build("abc"), 1) {
+			t.Fatal("Remove(abc) should return true")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "ab", tip: 1, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 0, branch: 0})
+	})
+
+	t.Run("Remove/SingleChildMerge", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("ab"), 1)
+		trie.Insert(b.Build("abc"), 1)
+		trie.Insert(b.Build("abcd"), 1)
+
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 2})
+
+		if !trie.Remove(b.Build("abc"), 1) {
+			t.Fatal("Remove(abc) should return true")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken after single-child merge")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 0, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "abcd", tip: 1, branch: 1})
+	})
+
+	t.Run("Remove/MultiChildNoCompact", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("ab"), 1)
+		trie.Insert(b.Build("abc"), 1)
+		trie.Insert(b.Build("abcd"), 1)
+		trie.Insert(b.Build("abce"), 1)
+
+		if !trie.Remove(b.Build("abc"), 1) {
+			t.Fatal("Remove(abc) should return true")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 0, branch: 2})
+	})
+
+	t.Run("Remove/ParentCompaction", func(t *testing.T) {
+		trie, b := newTestTrie()
+		trie.Insert(b.Build("ab"), 1)
+		trie.Insert(b.Build("abc"), 1)
+		trie.Insert(b.Build("abd"), 1)
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken")
+		}
+		if !trie.Remove(b.Build("ab"), 1) {
+			t.Fatal("Remove(ab) should return true")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken after ab removal")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "abd", tip: 1, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "ab", tip: 0, branch: 2})
+
+		if !trie.Remove(b.Build("abd"), 1) {
+			t.Fatal("Remove(abd) should return true")
+		}
+		if !trie.CheckInvariants() {
+			t.Fatal("invariants broken after abd removal")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "ab", tip: 0, branch: 1})
+	})
+
+	t.Run("Support", func(t *testing.T) {
+		trie, b := newTestTrie()
+		assertSupport(t, trie, b, trieAssertion{path: "a", tip: 0, branch: 0})
+		assertSupport(t, trie, b, trieAssertion{path: "axy", tip: 0, branch: 0})
+
+		trie.Insert(b.Build("abc"), 1)
+		assertSupport(t, trie, b, trieAssertion{path: "a", tip: 0, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "ab", tip: 0, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "abcd", tip: 0, branch: 0})
+
+		trie.Insert(b.Build("abe"), 1)
+		assertSupport(t, trie, b, trieAssertion{path: "a", tip: 0, branch: 2})
+		assertSupport(t, trie, b, trieAssertion{path: "ab", tip: 0, branch: 2})
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 1, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "abe", tip: 1, branch: 1})
+
+		if !trie.Remove(b.Build("abc"), 1) {
+			t.Fatal("Remove(abc) should return true")
+		}
+		assertSupport(t, trie, b, trieAssertion{path: "a", tip: 0, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "ab", tip: 0, branch: 1})
+		assertSupport(t, trie, b, trieAssertion{path: "abc", tip: 0, branch: 0})
+		assertSupport(t, trie, b, trieAssertion{path: "abe", tip: 1, branch: 1})
+	})
+}
+
+func TestLedgerTrie_Empty(t *testing.T) {
+	trie, b := newTestTrie()
+	if !trie.Empty() {
+		t.Fatal("new trie should be empty")
+	}
+
+	trie.Insert(b.Build(""), 1) // genesis
+	if trie.Empty() {
+		t.Fatal("trie with genesis support should not be empty")
+	}
+	if !trie.Remove(b.Build(""), 1) {
+		t.Fatal("Remove(genesis) should return true")
+	}
+	if !trie.Empty() {
+		t.Fatal("trie should be empty after genesis removal")
+	}
+
+	trie.Insert(b.Build("abc"), 1)
+	if trie.Empty() {
+		t.Fatal("trie with abc should not be empty")
+	}
+	if !trie.Remove(b.Build("abc"), 1) {
+		t.Fatal("Remove(abc) should return true")
+	}
+	if !trie.Empty() {
+		t.Fatal("trie should be empty after abc removal")
+	}
+}
+
+// --- getPreferred parity tests ---------------------------------------
+
+// idOf is a small convenience helper for the getPreferred tests below.
+func idOf(b *TestLedgerBuilder, path string) string { // returns hex-like
+	id := b.Build(path).ID()
+	return string(id[:])
+}
+
+// getPreferredID returns the preferred ID or "" if no preferred ledger.
+func getPreferredID(trie *Trie, largestIssued uint32) string {
+	tip, ok := trie.GetPreferred(largestIssued)
+	if !ok {
+		return ""
+	}
+	return string(tip.ID[:])
+}
+
+func TestLedgerTrie_GetPreferred_Empty(t *testing.T) {
+	trie, _ := newTestTrie()
+	if _, ok := trie.GetPreferred(0); ok {
+		t.Fatal("empty trie should return (_, false)")
+	}
+	if _, ok := trie.GetPreferred(2); ok {
+		t.Fatal("empty trie should return (_, false) at any seq")
+	}
+}
+
+func TestLedgerTrie_GetPreferred_Genesis(t *testing.T) {
+	trie, b := newTestTrie()
+	genesis := b.Build("")
+	trie.Insert(genesis, 1)
+	if got := getPreferredID(trie, 0); got != idOf(b, "") {
+		t.Fatalf("genesis insert: got != genesis ID")
+	}
+	if !trie.Remove(genesis, 1) {
+		t.Fatal("Remove(genesis) should return true")
+	}
+	if _, ok := trie.GetPreferred(0); ok {
+		t.Fatal("empty after remove should return false")
+	}
+}
+
+func TestLedgerTrie_GetPreferred_SingleNoChildren(t *testing.T) {
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("abc"), 1)
+	if got := getPreferredID(trie, 3); got != idOf(b, "abc") {
+		t.Fatalf("want abc, got different")
+	}
+}
+
+func TestLedgerTrie_GetPreferred_SingleSmallerChild(t *testing.T) {
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("abc"), 1)
+	trie.Insert(b.Build("abcd"), 1)
+	if got := getPreferredID(trie, 3); got != idOf(b, "abc") {
+		t.Fatalf("want abc @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "abc") {
+		t.Fatalf("want abc @4")
+	}
+}
+
+func TestLedgerTrie_GetPreferred_SingleLargerChild(t *testing.T) {
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("abc"), 1)
+	trie.Insert(b.Build("abcd"), 2)
+	if got := getPreferredID(trie, 3); got != idOf(b, "abcd") {
+		t.Fatalf("want abcd @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "abcd") {
+		t.Fatalf("want abcd @4")
+	}
+}
+
+func TestLedgerTrie_GetPreferred_SingleSmallerChildrenSupport(t *testing.T) {
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("abc"), 1)
+	trie.Insert(b.Build("abcd"), 1)
+	trie.Insert(b.Build("abce"), 1)
+	if got := getPreferredID(trie, 3); got != idOf(b, "abc") {
+		t.Fatalf("want abc @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "abc") {
+		t.Fatalf("want abc @4")
+	}
+
+	trie.Insert(b.Build("abc"), 1)
+	if got := getPreferredID(trie, 3); got != idOf(b, "abc") {
+		t.Fatalf("want abc @3 after tie-breaker vote")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "abc") {
+		t.Fatalf("want abc @4 after tie-breaker vote")
+	}
+}
+
+func TestLedgerTrie_GetPreferred_SingleLargerChildren(t *testing.T) {
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("abc"), 1)
+	trie.Insert(b.Build("abcd"), 2)
+	trie.Insert(b.Build("abce"), 1)
+	if got := getPreferredID(trie, 3); got != idOf(b, "abc") {
+		t.Fatalf("want abc @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "abc") {
+		t.Fatalf("want abc @4")
+	}
+
+	trie.Insert(b.Build("abcd"), 1)
+	if got := getPreferredID(trie, 3); got != idOf(b, "abcd") {
+		t.Fatalf("want abcd @3 after extra vote")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "abcd") {
+		t.Fatalf("want abcd @4 after extra vote")
+	}
+}
+
+func TestLedgerTrie_GetPreferred_TieBreakerByID(t *testing.T) {
+	// IDs in our TestLedgerBuilder are sha256-derived and thus
+	// unpredictable. We compute which sibling has the larger ID at
+	// seq 4 and steer assertions accordingly — mirroring rippled's
+	// test which does the same with an explicit `>` check.
+	trie, b := newTestTrie()
+	abcd := b.Build("abcd")
+	abce := b.Build("abce")
+	var larger, smaller string
+	if idGreater(abce.ID(), abcd.ID()) {
+		larger, smaller = "abce", "abcd"
+	} else {
+		larger, smaller = "abcd", "abce"
+	}
+
+	trie.Insert(b.Build(smaller), 2)
+	trie.Insert(b.Build(larger), 2)
+	if got := getPreferredID(trie, 4); got != idOf(b, larger) {
+		t.Fatalf("2-2 tie should go to the larger-ID sibling")
+	}
+
+	// Add one more to the smaller-ID side → 3 vs 2: still needs the
+	// tie-breaker against uncommitted; preferred backs up to the
+	// common ancestor.
+	trie.Insert(b.Build(smaller), 1)
+	if got := getPreferredID(trie, 4); got != idOf(b, smaller) {
+		t.Fatalf("3-2 should go to the larger-branchSupport sibling")
+	}
+}
+
+func TestLedgerTrie_GetPreferred_TieBreakerNotNeeded(t *testing.T) {
+	trie, b := newTestTrie()
+	abcd := b.Build("abcd")
+	abce := b.Build("abce")
+	var larger, smaller string
+	if idGreater(abce.ID(), abcd.ID()) {
+		larger, smaller = "abce", "abcd"
+	} else {
+		larger, smaller = "abcd", "abce"
+	}
+
+	trie.Insert(b.Build("abc"), 1)
+	trie.Insert(b.Build(smaller), 1)
+	trie.Insert(b.Build(larger), 2)
+	// larger has margin of 1 but owns tie-breaker
+	if got := getPreferredID(trie, 3); got != idOf(b, larger) {
+		t.Fatalf("want larger @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, larger) {
+		t.Fatalf("want larger @4")
+	}
+
+	trie.Remove(b.Build(larger), 1)
+	trie.Insert(b.Build(smaller), 1)
+	if got := getPreferredID(trie, 3); got != idOf(b, "abc") {
+		t.Fatalf("after switch: want abc @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "abc") {
+		t.Fatalf("after switch: want abc @4")
+	}
+}
+
+func TestLedgerTrie_GetPreferred_LargerGrandchild(t *testing.T) {
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("abc"), 1)
+	trie.Insert(b.Build("abcd"), 2)
+	trie.Insert(b.Build("abcde"), 4)
+	if got := getPreferredID(trie, 3); got != idOf(b, "abcde") {
+		t.Fatalf("want abcde @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "abcde") {
+		t.Fatalf("want abcde @4")
+	}
+	if got := getPreferredID(trie, 5); got != idOf(b, "abcde") {
+		t.Fatalf("want abcde @5")
+	}
+}
+
+func TestLedgerTrie_GetPreferred_CompetingBranchesUncommitted(t *testing.T) {
+	// Motivating example from issue #268: if competing branches are
+	// tied and the spectator's validation is still out at a later
+	// sequence, the uncommitted support prevents descending into a
+	// tied branch. This is exactly the scenario the flat hash-count
+	// approximation mis-calls.
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("abc"), 1)
+	trie.Insert(b.Build("abcde"), 2)
+	trie.Insert(b.Build("abcfg"), 2)
+	// de and fg are tied without abc's vote
+	if got := getPreferredID(trie, 3); got != idOf(b, "abc") {
+		t.Fatalf("want abc @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "abc") {
+		t.Fatalf("want abc @4")
+	}
+	if got := getPreferredID(trie, 5); got != idOf(b, "abc") {
+		t.Fatalf("want abc @5")
+	}
+
+	trie.Remove(b.Build("abc"), 1)
+	trie.Insert(b.Build("abcd"), 1)
+
+	// de branch has 3 to 2; seq 3/4 queries see it as preferred
+	if got := getPreferredID(trie, 3); got != idOf(b, "abcde") {
+		t.Fatalf("want abcde @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "abcde") {
+		t.Fatalf("want abcde @4")
+	}
+	// At seq 5 the querier's own validation is still unaccounted,
+	// so abc remains preferred.
+	if got := getPreferredID(trie, 5); got != idOf(b, "abc") {
+		t.Fatalf("want abc @5")
+	}
+}
+
+// TestGetPreferred_PrefersDeepestSharedAncestor is the scenario
+// called out directly by the issue: a minority near-tip should not
+// outrank a majority-further-back branch.
+func TestGetPreferred_PrefersDeepestSharedAncestor(t *testing.T) {
+	//          /-> C        (tip 1)
+	//     root-> B
+	//          \-> D -> E   (tip 2 at E)
+	//
+	// Expected: the trie picks E because branchSupport(D) = 2 and
+	// branchSupport(C) = 1.
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("bc"), 1)
+	trie.Insert(b.Build("bde"), 2)
+
+	// At seq 3 (E's seq) the trie should pick E (largestIssued=3).
+	if got := getPreferredID(trie, 3); got != idOf(b, "bde") {
+		t.Fatalf("deepest-shared-ancestor: want bde @3")
+	}
+	// At seq 2, the root-of-fork 'b' is preferred because descending
+	// to D still exceeds C's branchSupport.
+	if got := getPreferredID(trie, 2); got != idOf(b, "bde") {
+		t.Fatalf("deepest-shared-ancestor: want bde @2 (branchSupport 2>1)")
+	}
+}
+
+// TestGetPreferred_MinSeqRespected — rippled calls the parameter
+// largestIssued; the test here mirrors the "Too much uncommitted
+// support" case at LedgerTrie_test.cpp:480-504 where a local validator
+// waiting on a Seq-5 commitment is not allowed to descend past the
+// common ancestor even when a branch appears to lead.
+func TestGetPreferred_MinSeqRespected(t *testing.T) {
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("abc"), 1)
+	trie.Insert(b.Build("abcde"), 2)
+	trie.Insert(b.Build("abcfg"), 2)
+
+	// Without our own vote, any largestIssued keeps abc preferred.
+	for _, seq := range []uint32{3, 4, 5} {
+		if got := getPreferredID(trie, seq); got != idOf(b, "abc") {
+			t.Fatalf("minSeq parity: want abc @%d", seq)
+		}
+	}
+
+	// Adding a vote for abcd breaks the tie on the de branch.
+	trie.Remove(b.Build("abc"), 1)
+	trie.Insert(b.Build("abcd"), 1)
+
+	// At seq 5 the local validator has effectively committed at seq
+	// 5; uncommitted support from seq<5 is NOT replayed as evidence
+	// for the de branch, so abc remains preferred.
+	if got := getPreferredID(trie, 5); got != idOf(b, "abc") {
+		t.Fatalf("minSeq parity: want abc @5 despite 3-2 lead on de")
+	}
+}
+
+// TestLedgerTrie_GetPreferred_ChangingLargestIssued is the multi-step
+// scenario from LedgerTrie_test.cpp:506-591 ("Changing largestSeq
+// perspective changes preferred branch").
+func TestLedgerTrie_GetPreferred_ChangingLargestIssued(t *testing.T) {
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("ab"), 1)
+	trie.Insert(b.Build("ac"), 1)
+	trie.Insert(b.Build("acf"), 1)
+	trie.Insert(b.Build("abde"), 2)
+
+	// B has more branch support; seq 1/2 queries pick ab.
+	if got := getPreferredID(trie, 1); got != idOf(b, "ab") {
+		t.Fatalf("want ab @1")
+	}
+	if got := getPreferredID(trie, 2); got != idOf(b, "ab") {
+		t.Fatalf("want ab @2")
+	}
+	// Seq 3/4 queriers haven't heard enough to prefer any branch.
+	if got := getPreferredID(trie, 3); got != idOf(b, "a") {
+		t.Fatalf("want a @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "a") {
+		t.Fatalf("want a @4")
+	}
+
+	// E -> G: nothing changes because we simply extend the E tip.
+	trie.Remove(b.Build("abde"), 1)
+	trie.Insert(b.Build("abdeg"), 1)
+	if got := getPreferredID(trie, 1); got != idOf(b, "ab") {
+		t.Fatalf("E→G want ab @1")
+	}
+	if got := getPreferredID(trie, 2); got != idOf(b, "ab") {
+		t.Fatalf("E→G want ab @2")
+	}
+	if got := getPreferredID(trie, 3); got != idOf(b, "a") {
+		t.Fatalf("E→G want a @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "a") {
+		t.Fatalf("E→G want a @4")
+	}
+	if got := getPreferredID(trie, 5); got != idOf(b, "a") {
+		t.Fatalf("E→G want a @5")
+	}
+
+	// C vacates, H picks up → seq 3 query advances to ab.
+	trie.Remove(b.Build("ac"), 1)
+	trie.Insert(b.Build("abh"), 1)
+	if got := getPreferredID(trie, 1); got != idOf(b, "ab") {
+		t.Fatalf("C→H want ab @1")
+	}
+	if got := getPreferredID(trie, 2); got != idOf(b, "ab") {
+		t.Fatalf("C→H want ab @2")
+	}
+	if got := getPreferredID(trie, 3); got != idOf(b, "ab") {
+		t.Fatalf("C→H want ab @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "a") {
+		t.Fatalf("C→H want a @4")
+	}
+	if got := getPreferredID(trie, 5); got != idOf(b, "a") {
+		t.Fatalf("C→H want a @5")
+	}
+
+	// F migrates to E, now E has 2 tip support; preferred ledger at
+	// early seqs descends to abde.
+	trie.Remove(b.Build("acf"), 1)
+	trie.Insert(b.Build("abde"), 1)
+	if got := getPreferredID(trie, 1); got != idOf(b, "abde") {
+		t.Fatalf("F→E want abde @1")
+	}
+	if got := getPreferredID(trie, 2); got != idOf(b, "abde") {
+		t.Fatalf("F→E want abde @2")
+	}
+	if got := getPreferredID(trie, 3); got != idOf(b, "abde") {
+		t.Fatalf("F→E want abde @3")
+	}
+	if got := getPreferredID(trie, 4); got != idOf(b, "ab") {
+		t.Fatalf("F→E want ab @4")
+	}
+	if got := getPreferredID(trie, 5); got != idOf(b, "ab") {
+		t.Fatalf("F→E want ab @5")
+	}
+}
+
+// TestLedgerTrie_RootRelated ports testRootRelated from
+// LedgerTrie_test.cpp:594-621.
+func TestLedgerTrie_RootRelated(t *testing.T) {
+	trie, b := newTestTrie()
+	if trie.Remove(b.Build(""), 1) {
+		t.Fatal("Remove(genesis) on empty trie should return false")
+	}
+	assertSupport(t, trie, b, trieAssertion{path: "", tip: 0, branch: 0})
+
+	trie.Insert(b.Build("a"), 1)
+	if !trie.CheckInvariants() {
+		t.Fatal("invariants broken after insert(a)")
+	}
+	assertSupport(t, trie, b, trieAssertion{path: "", tip: 0, branch: 1})
+
+	trie.Insert(b.Build("e"), 1)
+	if !trie.CheckInvariants() {
+		t.Fatal("invariants broken after insert(e)")
+	}
+	assertSupport(t, trie, b, trieAssertion{path: "", tip: 0, branch: 2})
+
+	if !trie.Remove(b.Build("e"), 1) {
+		t.Fatal("Remove(e) should return true")
+	}
+	if !trie.CheckInvariants() {
+		t.Fatal("invariants broken after remove(e)")
+	}
+	assertSupport(t, trie, b, trieAssertion{path: "", tip: 0, branch: 1})
+}
+
+// --- Invariant stress test -------------------------------------------
+
+func TestLedgerTrie_Stress_InvariantsHold(t *testing.T) {
+	trie, b := newTestTrie()
+	r := rand.New(rand.NewSource(42))
+
+	// Pre-build a small pool of ledgers via short path strings.
+	pool := []string{
+		"a", "ab", "abc", "abd", "abcd", "abce",
+		"abcde", "abcdf", "abcfg", "ac", "acf", "abh", "abde", "abdeg",
+	}
+
+	inserted := map[string]uint32{}
+	for i := 0; i < 2000; i++ {
+		path := pool[r.Intn(len(pool))]
+		if inserted[path] > 0 && r.Intn(2) == 0 {
+			cnt := uint32(1 + r.Intn(int(inserted[path])))
+			if !trie.Remove(b.Build(path), cnt) {
+				t.Fatalf("Remove(%q, %d) returned false (inserted=%d)", path, cnt, inserted[path])
+			}
+			inserted[path] -= cnt
+		} else {
+			cnt := uint32(1 + r.Intn(3))
+			trie.Insert(b.Build(path), cnt)
+			inserted[path] += cnt
+		}
+		if !trie.CheckInvariants() {
+			t.Fatalf("invariants broken at iter %d after %s(%q)", i, "op", path)
+		}
+	}
+}

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -148,11 +148,8 @@ type Engine struct {
 	// archive via OnStale. Zero disables auto-expiry.
 	inMemoryLedgers uint32
 
-	// ledgerAncestry is the provider the ValidationTracker uses to
-	// resolve LedgerID → ancestry for the LedgerTrie. Staged here by
-	// the startup wiring (which has access to the concrete ledger
-	// service) and applied to the tracker in Start. Nil means the
-	// tracker keeps its flat-count semantics. See SetLedgerAncestryProvider.
+	// ledgerAncestry is staged by startup wiring and applied to the
+	// tracker in Start. Nil keeps flat-count semantics.
 	ledgerAncestry LedgerAncestryProvider
 }
 
@@ -254,11 +251,8 @@ func (e *Engine) SetInMemoryLedgers(n uint32) {
 	e.inMemoryLedgers = n
 }
 
-// SetLedgerAncestryProvider installs the provider the ValidationTracker
-// uses to resolve LedgerID → ancestry for the LedgerTrie. Safe to call
-// before or after Start; when called before Start, the provider is
-// staged and applied to the tracker at Start time. Pass nil to drop
-// back to flat-count support.
+// SetLedgerAncestryProvider installs the trie's ancestry provider.
+// Safe before or after Start; nil reverts to flat-count support.
 func (e *Engine) SetLedgerAncestryProvider(p LedgerAncestryProvider) {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -147,6 +147,13 @@ type Engine struct {
 	// below (S - inMemoryLedgers) are dropped and streamed into the
 	// archive via OnStale. Zero disables auto-expiry.
 	inMemoryLedgers uint32
+
+	// ledgerAncestry is the provider the ValidationTracker uses to
+	// resolve LedgerID → ancestry for the LedgerTrie. Staged here by
+	// the startup wiring (which has access to the concrete ledger
+	// service) and applied to the tracker in Start. Nil means the
+	// tracker keeps its flat-count semantics. See SetLedgerAncestryProvider.
+	ledgerAncestry LedgerAncestryProvider
 }
 
 // ValidationArchive is the subset of the archive API the consensus engine
@@ -247,6 +254,20 @@ func (e *Engine) SetInMemoryLedgers(n uint32) {
 	e.inMemoryLedgers = n
 }
 
+// SetLedgerAncestryProvider installs the provider the ValidationTracker
+// uses to resolve LedgerID → ancestry for the LedgerTrie. Safe to call
+// before or after Start; when called before Start, the provider is
+// staged and applied to the tracker at Start time. Pass nil to drop
+// back to flat-count support.
+func (e *Engine) SetLedgerAncestryProvider(p LedgerAncestryProvider) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.ledgerAncestry = p
+	if e.validationTracker != nil {
+		e.validationTracker.SetLedgerAncestryProvider(p)
+	}
+}
+
 // Start begins the consensus engine.
 func (e *Engine) Start(ctx context.Context) error {
 	e.mu.Lock()
@@ -269,6 +290,9 @@ func (e *Engine) Start(ctx context.Context) error {
 	e.validationTracker.SetTrusted(e.adaptor.GetTrustedValidators())
 	if e.manifestResolver != nil {
 		e.validationTracker.SetManifestResolver(e.manifestResolver)
+	}
+	if e.ledgerAncestry != nil {
+		e.validationTracker.SetLedgerAncestryProvider(e.ledgerAncestry)
 	}
 	// Use the adaptor's network-adjusted clock for freshness checks.
 	// Rippled's Validations::isCurrent uses app_.timeKeeper().closeTime()

--- a/internal/consensus/rcl/ledger_provider.go
+++ b/internal/consensus/rcl/ledger_provider.go
@@ -1,6 +1,7 @@
 package rcl
 
 import (
+	"container/list"
 	"sync"
 
 	"github.com/LeJamon/goXRPLd/internal/consensus"
@@ -8,6 +9,17 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
 )
+
+// maxProviderAncestors caps how far back buildChain walks. Mirrors
+// rippled's RCLValidatedLedger which exposes only the past 256 hashes
+// via the keylet::skip SLE — ledgers separated by more than this are
+// treated as diverging post-genesis (RCLValidations.h:155).
+const maxProviderAncestors = uint32(256)
+
+// providerCacheCapacity caps the number of ledgers retained in the
+// LRU. Each entry holds at most maxProviderAncestors hashes (32 bytes
+// each), so the cache is bounded at ~8MB regardless of mainnet seq.
+const providerCacheCapacity = 1024
 
 // LedgerHeader is the narrow slice of *ledger.Ledger the provider
 // reads. Exposed as an interface so unit tests can stub it without
@@ -28,28 +40,35 @@ var _ LedgerHeader = (*ledger.Ledger)(nil)
 type hashLookupFunc func(hash [32]byte) (LedgerHeader, error)
 
 // LedgerProvider satisfies LedgerAncestryProvider by resolving a
-// LedgerID via the ledger service and materializing the ledger's full
-// ancestor chain on demand.
+// LedgerID via the ledger service and materializing the ledger's
+// recent ancestor chain on demand.
 //
 // The trie calls Ancestor(s) many times per insert (binary search in
 // ledgertrie.Mismatch plus the span operations). Walking back via
-// ParentHash on every call would be O(depth²) with the service's
-// current O(n) hash scan — so we materialize the ancestor slice once
-// per (LedgerID) query and cache the result. Ancestor slices are
-// immutable once a ledger is closed, so the cache needs no
-// invalidation.
+// ParentHash on every call would be O(depth²) — so we materialize
+// the ancestor slice once per (LedgerID) query and cache the result.
+// Ancestor slices are immutable once a ledger is closed, so cached
+// entries never need invalidation; the cache is sized purely to bound
+// memory and is evicted in LRU order when full.
 //
-// Ancestry walk terminates when it reaches sequence 1 (genesis per
-// XRPL convention) or when a parent lookup fails. On a failed parent
-// lookup partway up the chain, LedgerByID returns (nil, false): we
-// cannot produce a correct trie-insertable ledger without the full
-// chain. The tracker then silently skips the trie insert and the
-// validation still lands in byNode / flat-count.
+// Ancestry depth is capped at maxProviderAncestors (256). On a fresh
+// node missing earlier history the walk truncates at the first
+// missing parent, leaving a partial chain — Mismatch then treats the
+// region below the truncated minSeq as unknown and returns 1, which
+// is the same behaviour rippled exhibits when ledgers fall outside
+// the keylet::skip window.
 type LedgerProvider struct {
 	lookup hashLookupFunc
 
-	mu    sync.Mutex
-	cache map[consensus.LedgerID]*providerLedger
+	mu       sync.Mutex
+	maxItems int
+	cache    map[consensus.LedgerID]*list.Element
+	lru      *list.List // front=most recent, back=least recent
+}
+
+type cacheEntry struct {
+	id consensus.LedgerID
+	pl *providerLedger
 }
 
 // NewLedgerProvider wraps the production ledger service into a
@@ -59,7 +78,7 @@ type LedgerProvider struct {
 // call site.
 func NewLedgerProvider(svc *service.Service) *LedgerProvider {
 	if svc == nil {
-		return &LedgerProvider{cache: make(map[consensus.LedgerID]*providerLedger)}
+		return newLedgerProviderFromLookup(nil)
 	}
 	return newLedgerProviderFromLookup(func(hash [32]byte) (LedgerHeader, error) {
 		l, err := svc.GetLedgerByHash(hash)
@@ -75,8 +94,10 @@ func NewLedgerProvider(svc *service.Service) *LedgerProvider {
 // (pass a closure backed by a fake header map).
 func newLedgerProviderFromLookup(fn hashLookupFunc) *LedgerProvider {
 	return &LedgerProvider{
-		lookup: fn,
-		cache:  make(map[consensus.LedgerID]*providerLedger),
+		lookup:   fn,
+		maxItems: providerCacheCapacity,
+		cache:    make(map[consensus.LedgerID]*list.Element),
+		lru:      list.New(),
 	}
 }
 
@@ -85,37 +106,57 @@ func (p *LedgerProvider) LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger, b
 	if p == nil || p.lookup == nil {
 		return nil, false
 	}
-	p.mu.Lock()
-	if cached, ok := p.cache[id]; ok {
-		p.mu.Unlock()
+	if cached, ok := p.cacheGet(id); ok {
 		return cached, true
 	}
-	p.mu.Unlock()
 
 	built := p.buildChain(id)
 	if built == nil {
 		return nil, false
 	}
 
-	p.mu.Lock()
-	// Double-check: another goroutine may have populated concurrently.
-	if cached, ok := p.cache[id]; ok {
-		p.mu.Unlock()
-		return cached, true
-	}
-	p.cache[id] = built
-	p.mu.Unlock()
+	p.cachePut(id, built)
 	return built, true
 }
 
-// buildChain walks parent hashes from `id` back to seq 1, producing
-// a fully-populated ancestor slice. Returns nil when any link in the
-// chain is missing from the store.
-//
-// Returned ancestors[0] is the all-zero LedgerID (pre-genesis
-// placeholder — the trie's root span expects this). ancestors[s]
-// for s >= 1 is the hash of the ledger at that sequence on the
-// chain ending at `id`.
+func (p *LedgerProvider) cacheGet(id consensus.LedgerID) (*providerLedger, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	elem, ok := p.cache[id]
+	if !ok {
+		return nil, false
+	}
+	p.lru.MoveToFront(elem)
+	return elem.Value.(*cacheEntry).pl, true
+}
+
+func (p *LedgerProvider) cachePut(id consensus.LedgerID, pl *providerLedger) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if elem, ok := p.cache[id]; ok {
+		// Race: another goroutine populated concurrently. Bump LRU and
+		// drop the duplicate build; either is correct.
+		p.lru.MoveToFront(elem)
+		return
+	}
+	elem := p.lru.PushFront(&cacheEntry{id: id, pl: pl})
+	p.cache[id] = elem
+	for p.lru.Len() > p.maxItems {
+		old := p.lru.Back()
+		if old == nil {
+			break
+		}
+		oldEntry := old.Value.(*cacheEntry)
+		delete(p.cache, oldEntry.id)
+		p.lru.Remove(old)
+	}
+}
+
+// buildChain walks parent hashes backwards from `id`, collecting up
+// to maxProviderAncestors links. Returns nil only when the tip itself
+// is unresolvable; partial chains (walk failed midway) are returned
+// with a higher minSeq, matching rippled's behaviour for ledgers
+// older than the keylet::skip window.
 func (p *LedgerProvider) buildChain(id consensus.LedgerID) *providerLedger {
 	tip, err := p.lookup([32]byte(id))
 	if err != nil || tip == nil {
@@ -124,37 +165,64 @@ func (p *LedgerProvider) buildChain(id consensus.LedgerID) *providerLedger {
 	tipSeq := tip.Sequence()
 	if tipSeq == 0 {
 		// Seq-0 is our pre-genesis fiction; a real ledger must have
-		// seq >= 1. If the service somehow returned a seq-0 ledger
-		// we cannot represent it faithfully.
+		// seq >= 1.
 		return nil
 	}
 
-	ancestors := make([]consensus.LedgerID, tipSeq+1)
-	// ancestors[0] stays zero by construction.
-	ancestors[tipSeq] = consensus.LedgerID(tip.Hash())
+	// Target: ancestors at seqs [tipSeq-targetDepth, tipSeq-1].
+	targetDepth := tipSeq - 1
+	if targetDepth > maxProviderAncestors {
+		targetDepth = maxProviderAncestors
+	}
+	if targetDepth == 0 {
+		// tipSeq == 1: only the tip itself, no ancestors.
+		return &providerLedger{id: id, seq: tipSeq, minSeq: tipSeq}
+	}
 
-	// Walk back: each iteration populates ancestors[s-1] and then
-	// loads the ledger whose hash is ancestors[s-1] so its ParentHash
-	// gives the next seat.
+	ancestors := make([]consensus.LedgerID, targetDepth)
+	// ancestors[i] is the ID at seq (tipSeq - targetDepth + i) — i.e.
+	// ancestors[targetDepth-1] is the immediate parent.
+
 	curr := tip
-	for s := tipSeq; s > 1; s-- {
-		parentHash := consensus.LedgerID(curr.ParentHash())
-		ancestors[s-1] = parentHash
+	filled := uint32(0)
+	myMinSeq := tipSeq - targetDepth
 
-		// If a cached ancestor already has ancestors materialized
-		// back to seq 0/1, splice its prefix in rather than walking
-		// the rest of the chain.
-		p.mu.Lock()
-		cachedParent, hit := p.cache[parentHash]
-		p.mu.Unlock()
-		if hit && uint32(len(cachedParent.ancestors)) >= s {
-			copy(ancestors[:s], cachedParent.ancestors[:s])
+	for filled < targetDepth {
+		parentHash := consensus.LedgerID(curr.ParentHash())
+		idx := targetDepth - 1 - filled
+		ancestors[idx] = parentHash
+		filled++
+
+		if filled >= targetDepth {
+			break
+		}
+
+		// Cache splice: if the parent's chain is already cached,
+		// borrow its ancestor entries for the seqs they cover.
+		if cached, hit := p.cacheGet(parentHash); hit {
+			for j := uint32(0); j < idx; j++ {
+				wantSeq := myMinSeq + j
+				if wantSeq >= cached.minSeq && wantSeq < cached.seq {
+					ancestors[j] = cached.ancestors[wantSeq-cached.minSeq]
+				}
+			}
+			// If the cached chain starts above our myMinSeq, the
+			// leading slots are zero — narrow our minSeq to skip them.
+			if cached.minSeq > myMinSeq {
+				gap := cached.minSeq - myMinSeq
+				ancestors = ancestors[gap:]
+				myMinSeq = cached.minSeq
+			}
 			break
 		}
 
 		parent, err := p.lookup([32]byte(parentHash))
 		if err != nil || parent == nil {
-			return nil
+			// Partial chain — we couldn't reach further. Truncate to
+			// the populated suffix and bump minSeq accordingly.
+			ancestors = ancestors[idx:]
+			myMinSeq = tipSeq - filled
+			break
 		}
 		curr = parent
 	}
@@ -162,28 +230,36 @@ func (p *LedgerProvider) buildChain(id consensus.LedgerID) *providerLedger {
 	return &providerLedger{
 		id:        id,
 		seq:       tipSeq,
+		minSeq:    myMinSeq,
 		ancestors: ancestors,
 	}
 }
 
-// providerLedger is the trie's view of a production ledger: just the
-// (id, seq, ancestors) triple. Satisfies ledgertrie.Ledger.
+// providerLedger is the trie's view of a production ledger:
+// (id, seq, minSeq, ancestors). Satisfies ledgertrie.Ledger.
+//
+// ancestors[i] is the ID at seq (minSeq + i). The ledger's own ID at
+// seq=tipSeq is `id` and is NOT stored in the slice.
 type providerLedger struct {
 	id        consensus.LedgerID
 	seq       uint32
+	minSeq    uint32
 	ancestors []consensus.LedgerID
 }
 
 func (l *providerLedger) ID() consensus.LedgerID { return l.id }
 func (l *providerLedger) Seq() uint32            { return l.seq }
+func (l *providerLedger) MinSeq() uint32         { return l.minSeq }
 
-// Ancestor returns the ID of the ancestor at sequence s. Panics when
-// s is beyond the chain — matches the TestLedger contract and the
-// trie's expectation (LedgerTrie.h:SpanTip::ancestor uses XRPL_ASSERT
-// for s <= seq).
+// Ancestor returns the ID of the ancestor at sequence s. For s
+// outside [minSeq, seq] returns the zero LedgerID, matching rippled's
+// RCLValidatedLedger::operator[] (RCLValidations.cpp:79-95).
 func (l *providerLedger) Ancestor(s uint32) consensus.LedgerID {
-	if s > l.seq {
-		panic("providerLedger.Ancestor: s > seq")
+	if s == l.seq {
+		return l.id
 	}
-	return l.ancestors[s]
+	if s < l.minSeq || s > l.seq {
+		return consensus.LedgerID{}
+	}
+	return l.ancestors[s-l.minSeq]
 }

--- a/internal/consensus/rcl/ledger_provider.go
+++ b/internal/consensus/rcl/ledger_provider.go
@@ -10,53 +10,27 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
 )
 
-// maxProviderAncestors caps how far back buildChain walks. Mirrors
-// rippled's RCLValidatedLedger which exposes only the past 256 hashes
-// via the keylet::skip SLE — ledgers separated by more than this are
-// treated as diverging post-genesis (RCLValidations.h:155).
+// maxProviderAncestors mirrors rippled's keylet::skip window — ledgers
+// further back are treated as diverging post-genesis.
 const maxProviderAncestors = uint32(256)
 
-// providerCacheCapacity caps the number of ledgers retained in the
-// LRU. Each entry holds at most maxProviderAncestors hashes (32 bytes
-// each), so the cache is bounded at ~8MB regardless of mainnet seq.
 const providerCacheCapacity = 1024
 
-// LedgerHeader is the narrow slice of *ledger.Ledger the provider
-// reads. Exposed as an interface so unit tests can stub it without
-// constructing a full ledger. *ledger.Ledger satisfies it.
+// LedgerHeader is the narrow slice of *ledger.Ledger the provider needs.
 type LedgerHeader interface {
 	Sequence() uint32
 	Hash() [32]byte
 	ParentHash() [32]byte
 }
 
-// Static assertion that *ledger.Ledger satisfies LedgerHeader.
 var _ LedgerHeader = (*ledger.Ledger)(nil)
 
-// hashLookupFunc resolves a ledger hash to its header. Returning an
-// interface (rather than the concrete *ledger.Ledger) is what lets
-// tests inject fake lookups; the production constructor adapts
-// *service.Service.GetLedgerByHash into this shape.
 type hashLookupFunc func(hash [32]byte) (LedgerHeader, error)
 
-// LedgerProvider satisfies LedgerAncestryProvider by resolving a
-// LedgerID via the ledger service and materializing the ledger's
-// recent ancestor chain on demand.
-//
-// The trie calls Ancestor(s) many times per insert (binary search in
-// ledgertrie.Mismatch plus the span operations). Walking back via
-// ParentHash on every call would be O(depth²) — so we materialize
-// the ancestor slice once per (LedgerID) query and cache the result.
-// Ancestor slices are immutable once a ledger is closed, so cached
-// entries never need invalidation; the cache is sized purely to bound
-// memory and is evicted in LRU order when full.
-//
-// Ancestry depth is capped at maxProviderAncestors (256). On a fresh
-// node missing earlier history the walk truncates at the first
-// missing parent, leaving a partial chain — Mismatch then treats the
-// region below the truncated minSeq as unknown and returns 1, which
-// is the same behaviour rippled exhibits when ledgers fall outside
-// the keylet::skip window.
+// LedgerProvider satisfies LedgerAncestryProvider. It materialises a
+// ledger's ancestor slice once per LedgerID and caches it in an LRU,
+// avoiding O(depth²) ParentHash walks across the trie's many
+// Ancestor(s) calls. Cached chains are immutable so never invalidated.
 type LedgerProvider struct {
 	lookup hashLookupFunc
 
@@ -71,11 +45,8 @@ type cacheEntry struct {
 	pl *providerLedger
 }
 
-// NewLedgerProvider wraps the production ledger service into a
-// provider suitable for ValidationTracker.SetLedgerAncestryProvider.
-// nil svc yields a provider that always returns (nil, false) —
-// useful as a disabled placeholder without special-casing at the
-// call site.
+// NewLedgerProvider wraps the ledger service. A nil svc returns a
+// disabled provider that always reports (nil, false).
 func NewLedgerProvider(svc *service.Service) *LedgerProvider {
 	if svc == nil {
 		return newLedgerProviderFromLookup(nil)
@@ -89,9 +60,6 @@ func NewLedgerProvider(svc *service.Service) *LedgerProvider {
 	})
 }
 
-// newLedgerProviderFromLookup is the internal constructor used by
-// production (NewLedgerProvider wraps *service.Service) and by tests
-// (pass a closure backed by a fake header map).
 func newLedgerProviderFromLookup(fn hashLookupFunc) *LedgerProvider {
 	return &LedgerProvider{
 		lookup:   fn,
@@ -134,8 +102,7 @@ func (p *LedgerProvider) cachePut(id consensus.LedgerID, pl *providerLedger) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if elem, ok := p.cache[id]; ok {
-		// Race: another goroutine populated concurrently. Bump LRU and
-		// drop the duplicate build; either is correct.
+		// Race: another goroutine populated concurrently.
 		p.lru.MoveToFront(elem)
 		return
 	}
@@ -152,11 +119,9 @@ func (p *LedgerProvider) cachePut(id consensus.LedgerID, pl *providerLedger) {
 	}
 }
 
-// buildChain walks parent hashes backwards from `id`, collecting up
-// to maxProviderAncestors links. Returns nil only when the tip itself
-// is unresolvable; partial chains (walk failed midway) are returned
-// with a higher minSeq, matching rippled's behaviour for ledgers
-// older than the keylet::skip window.
+// buildChain walks parent hashes backwards from id, up to
+// maxProviderAncestors links. Returns nil if the tip is unresolvable;
+// partial chains are returned with a higher minSeq.
 func (p *LedgerProvider) buildChain(id consensus.LedgerID) *providerLedger {
 	tip, err := p.lookup([32]byte(id))
 	if err != nil || tip == nil {
@@ -164,25 +129,20 @@ func (p *LedgerProvider) buildChain(id consensus.LedgerID) *providerLedger {
 	}
 	tipSeq := tip.Sequence()
 	if tipSeq == 0 {
-		// Seq-0 is our pre-genesis fiction; a real ledger must have
-		// seq >= 1.
 		return nil
 	}
 
-	// Target: ancestors at seqs [tipSeq-targetDepth, tipSeq-1].
 	targetDepth := tipSeq - 1
 	if targetDepth > maxProviderAncestors {
 		targetDepth = maxProviderAncestors
 	}
 	if targetDepth == 0 {
-		// tipSeq == 1: only the tip itself, no ancestors.
 		return &providerLedger{id: id, seq: tipSeq, minSeq: tipSeq}
 	}
 
-	ancestors := make([]consensus.LedgerID, targetDepth)
-	// ancestors[i] is the ID at seq (tipSeq - targetDepth + i) — i.e.
+	// ancestors[i] is the ID at seq (tipSeq - targetDepth + i);
 	// ancestors[targetDepth-1] is the immediate parent.
-
+	ancestors := make([]consensus.LedgerID, targetDepth)
 	curr := tip
 	filled := uint32(0)
 	myMinSeq := tipSeq - targetDepth
@@ -197,8 +157,7 @@ func (p *LedgerProvider) buildChain(id consensus.LedgerID) *providerLedger {
 			break
 		}
 
-		// Cache splice: if the parent's chain is already cached,
-		// borrow its ancestor entries for the seqs they cover.
+		// If parent's chain is already cached, borrow its entries.
 		if cached, hit := p.cacheGet(parentHash); hit {
 			for j := uint32(0); j < idx; j++ {
 				wantSeq := myMinSeq + j
@@ -206,8 +165,6 @@ func (p *LedgerProvider) buildChain(id consensus.LedgerID) *providerLedger {
 					ancestors[j] = cached.ancestors[wantSeq-cached.minSeq]
 				}
 			}
-			// If the cached chain starts above our myMinSeq, the
-			// leading slots are zero — narrow our minSeq to skip them.
 			if cached.minSeq > myMinSeq {
 				gap := cached.minSeq - myMinSeq
 				ancestors = ancestors[gap:]
@@ -218,8 +175,7 @@ func (p *LedgerProvider) buildChain(id consensus.LedgerID) *providerLedger {
 
 		parent, err := p.lookup([32]byte(parentHash))
 		if err != nil || parent == nil {
-			// Partial chain — we couldn't reach further. Truncate to
-			// the populated suffix and bump minSeq accordingly.
+			// Partial chain — truncate to the populated suffix.
 			ancestors = ancestors[idx:]
 			myMinSeq = tipSeq - filled
 			break
@@ -235,11 +191,8 @@ func (p *LedgerProvider) buildChain(id consensus.LedgerID) *providerLedger {
 	}
 }
 
-// providerLedger is the trie's view of a production ledger:
-// (id, seq, minSeq, ancestors). Satisfies ledgertrie.Ledger.
-//
-// ancestors[i] is the ID at seq (minSeq + i). The ledger's own ID at
-// seq=tipSeq is `id` and is NOT stored in the slice.
+// providerLedger satisfies ledgertrie.Ledger. ancestors[i] is the ID
+// at seq (minSeq + i); the ledger's own ID at seq=tipSeq is not stored.
 type providerLedger struct {
 	id        consensus.LedgerID
 	seq       uint32
@@ -251,9 +204,6 @@ func (l *providerLedger) ID() consensus.LedgerID { return l.id }
 func (l *providerLedger) Seq() uint32            { return l.seq }
 func (l *providerLedger) MinSeq() uint32         { return l.minSeq }
 
-// Ancestor returns the ID of the ancestor at sequence s. For s
-// outside [minSeq, seq] returns the zero LedgerID, matching rippled's
-// RCLValidatedLedger::operator[] (RCLValidations.cpp:79-95).
 func (l *providerLedger) Ancestor(s uint32) consensus.LedgerID {
 	if s == l.seq {
 		return l.id

--- a/internal/consensus/rcl/ledger_provider.go
+++ b/internal/consensus/rcl/ledger_provider.go
@@ -1,0 +1,189 @@
+package rcl
+
+import (
+	"sync"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/ledgertrie"
+	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service"
+)
+
+// LedgerHeader is the narrow slice of *ledger.Ledger the provider
+// reads. Exposed as an interface so unit tests can stub it without
+// constructing a full ledger. *ledger.Ledger satisfies it.
+type LedgerHeader interface {
+	Sequence() uint32
+	Hash() [32]byte
+	ParentHash() [32]byte
+}
+
+// Static assertion that *ledger.Ledger satisfies LedgerHeader.
+var _ LedgerHeader = (*ledger.Ledger)(nil)
+
+// hashLookupFunc resolves a ledger hash to its header. Returning an
+// interface (rather than the concrete *ledger.Ledger) is what lets
+// tests inject fake lookups; the production constructor adapts
+// *service.Service.GetLedgerByHash into this shape.
+type hashLookupFunc func(hash [32]byte) (LedgerHeader, error)
+
+// LedgerProvider satisfies LedgerAncestryProvider by resolving a
+// LedgerID via the ledger service and materializing the ledger's full
+// ancestor chain on demand.
+//
+// The trie calls Ancestor(s) many times per insert (binary search in
+// ledgertrie.Mismatch plus the span operations). Walking back via
+// ParentHash on every call would be O(depth²) with the service's
+// current O(n) hash scan — so we materialize the ancestor slice once
+// per (LedgerID) query and cache the result. Ancestor slices are
+// immutable once a ledger is closed, so the cache needs no
+// invalidation.
+//
+// Ancestry walk terminates when it reaches sequence 1 (genesis per
+// XRPL convention) or when a parent lookup fails. On a failed parent
+// lookup partway up the chain, LedgerByID returns (nil, false): we
+// cannot produce a correct trie-insertable ledger without the full
+// chain. The tracker then silently skips the trie insert and the
+// validation still lands in byNode / flat-count.
+type LedgerProvider struct {
+	lookup hashLookupFunc
+
+	mu    sync.Mutex
+	cache map[consensus.LedgerID]*providerLedger
+}
+
+// NewLedgerProvider wraps the production ledger service into a
+// provider suitable for ValidationTracker.SetLedgerAncestryProvider.
+// nil svc yields a provider that always returns (nil, false) —
+// useful as a disabled placeholder without special-casing at the
+// call site.
+func NewLedgerProvider(svc *service.Service) *LedgerProvider {
+	if svc == nil {
+		return &LedgerProvider{cache: make(map[consensus.LedgerID]*providerLedger)}
+	}
+	return newLedgerProviderFromLookup(func(hash [32]byte) (LedgerHeader, error) {
+		l, err := svc.GetLedgerByHash(hash)
+		if err != nil {
+			return nil, err
+		}
+		return l, nil
+	})
+}
+
+// newLedgerProviderFromLookup is the internal constructor used by
+// production (NewLedgerProvider wraps *service.Service) and by tests
+// (pass a closure backed by a fake header map).
+func newLedgerProviderFromLookup(fn hashLookupFunc) *LedgerProvider {
+	return &LedgerProvider{
+		lookup: fn,
+		cache:  make(map[consensus.LedgerID]*providerLedger),
+	}
+}
+
+// LedgerByID implements LedgerAncestryProvider.
+func (p *LedgerProvider) LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger, bool) {
+	if p == nil || p.lookup == nil {
+		return nil, false
+	}
+	p.mu.Lock()
+	if cached, ok := p.cache[id]; ok {
+		p.mu.Unlock()
+		return cached, true
+	}
+	p.mu.Unlock()
+
+	built := p.buildChain(id)
+	if built == nil {
+		return nil, false
+	}
+
+	p.mu.Lock()
+	// Double-check: another goroutine may have populated concurrently.
+	if cached, ok := p.cache[id]; ok {
+		p.mu.Unlock()
+		return cached, true
+	}
+	p.cache[id] = built
+	p.mu.Unlock()
+	return built, true
+}
+
+// buildChain walks parent hashes from `id` back to seq 1, producing
+// a fully-populated ancestor slice. Returns nil when any link in the
+// chain is missing from the store.
+//
+// Returned ancestors[0] is the all-zero LedgerID (pre-genesis
+// placeholder — the trie's root span expects this). ancestors[s]
+// for s >= 1 is the hash of the ledger at that sequence on the
+// chain ending at `id`.
+func (p *LedgerProvider) buildChain(id consensus.LedgerID) *providerLedger {
+	tip, err := p.lookup([32]byte(id))
+	if err != nil || tip == nil {
+		return nil
+	}
+	tipSeq := tip.Sequence()
+	if tipSeq == 0 {
+		// Seq-0 is our pre-genesis fiction; a real ledger must have
+		// seq >= 1. If the service somehow returned a seq-0 ledger
+		// we cannot represent it faithfully.
+		return nil
+	}
+
+	ancestors := make([]consensus.LedgerID, tipSeq+1)
+	// ancestors[0] stays zero by construction.
+	ancestors[tipSeq] = consensus.LedgerID(tip.Hash())
+
+	// Walk back: each iteration populates ancestors[s-1] and then
+	// loads the ledger whose hash is ancestors[s-1] so its ParentHash
+	// gives the next seat.
+	curr := tip
+	for s := tipSeq; s > 1; s-- {
+		parentHash := consensus.LedgerID(curr.ParentHash())
+		ancestors[s-1] = parentHash
+
+		// If a cached ancestor already has ancestors materialized
+		// back to seq 0/1, splice its prefix in rather than walking
+		// the rest of the chain.
+		p.mu.Lock()
+		cachedParent, hit := p.cache[parentHash]
+		p.mu.Unlock()
+		if hit && uint32(len(cachedParent.ancestors)) >= s {
+			copy(ancestors[:s], cachedParent.ancestors[:s])
+			break
+		}
+
+		parent, err := p.lookup([32]byte(parentHash))
+		if err != nil || parent == nil {
+			return nil
+		}
+		curr = parent
+	}
+
+	return &providerLedger{
+		id:        id,
+		seq:       tipSeq,
+		ancestors: ancestors,
+	}
+}
+
+// providerLedger is the trie's view of a production ledger: just the
+// (id, seq, ancestors) triple. Satisfies ledgertrie.Ledger.
+type providerLedger struct {
+	id        consensus.LedgerID
+	seq       uint32
+	ancestors []consensus.LedgerID
+}
+
+func (l *providerLedger) ID() consensus.LedgerID { return l.id }
+func (l *providerLedger) Seq() uint32            { return l.seq }
+
+// Ancestor returns the ID of the ancestor at sequence s. Panics when
+// s is beyond the chain — matches the TestLedger contract and the
+// trie's expectation (LedgerTrie.h:SpanTip::ancestor uses XRPL_ASSERT
+// for s <= seq).
+func (l *providerLedger) Ancestor(s uint32) consensus.LedgerID {
+	if s > l.seq {
+		panic("providerLedger.Ancestor: s > seq")
+	}
+	return l.ancestors[s]
+}

--- a/internal/consensus/rcl/ledger_provider_test.go
+++ b/internal/consensus/rcl/ledger_provider_test.go
@@ -82,10 +82,17 @@ func TestLedgerProvider_BuildsFullAncestry(t *testing.T) {
 	}
 }
 
-func TestLedgerProvider_MissingLinkFailsCleanly(t *testing.T) {
+func TestLedgerProvider_MissingLinkTruncates(t *testing.T) {
+	// When the walk-back hits a missing parent, buildChain returns a
+	// partial chain rather than failing. MinSeq advances to the lowest
+	// seq still reachable; below that Ancestor returns zero. Mirrors
+	// rippled's behaviour for ledgers older than the keylet::skip
+	// window (RCLValidations.cpp:79-95 / 99-114).
 	tip, byHash := buildChain(5, 'b')
-	// Delete the seq-3 header from the lookup so the walk-back fails
-	// when it reaches the seq-4 ledger and tries to load its parent.
+	// Delete the seq-3 header. The walk captures seq-3's hash from
+	// seq-4's ParentHash, then tries to load seq-3's record to read
+	// its own ParentHash — that lookup fails and the walk truncates.
+	// Result: ancestors cover seqs [3,4], MinSeq=3.
 	var s3Hash [32]byte
 	for h, lh := range byHash {
 		if lh.Sequence() == 3 {
@@ -96,8 +103,126 @@ func TestLedgerProvider_MissingLinkFailsCleanly(t *testing.T) {
 	delete(byHash, s3Hash)
 
 	p := newTestProvider(byHash)
-	if _, ok := p.LedgerByID(consensus.LedgerID(tip.hash)); ok {
-		t.Fatal("LedgerByID should fail when chain has a gap")
+	lgr, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("LedgerByID should succeed for partial chain")
+	}
+	if lgr.Seq() != 5 {
+		t.Errorf("Seq: got %d, want 5", lgr.Seq())
+	}
+	if lgr.MinSeq() != 3 {
+		t.Errorf("MinSeq: got %d, want 3 (truncated at seq-3 — seq-2 lookup failed)", lgr.MinSeq())
+	}
+	if lgr.Ancestor(2) != (consensus.LedgerID{}) {
+		t.Errorf("Ancestor(2) below MinSeq should be zero")
+	}
+	if lgr.Ancestor(5) != consensus.LedgerID(tip.hash) {
+		t.Errorf("Ancestor(5) should equal tip ID")
+	}
+	// Within [MinSeq, Seq] the entries match.
+	if lgr.Ancestor(3)[1] != 'b' {
+		t.Errorf("Ancestor(3) tag should be 'b'")
+	}
+}
+
+func TestLedgerProvider_BoundedAtMaxAncestors(t *testing.T) {
+	// Walk depth is capped at maxProviderAncestors (256). For a tip at
+	// seq 1000, MinSeq must be 1000-256=744 — not 0 — and the cache
+	// entry must hold exactly 256 ancestors regardless of available
+	// chain depth.
+	const tipSeq = uint32(1000)
+	tip, byHash := buildChain(tipSeq, 'e')
+
+	p := newTestProvider(byHash)
+	lgr, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("LedgerByID should succeed")
+	}
+	if lgr.Seq() != tipSeq {
+		t.Errorf("Seq: got %d, want %d", lgr.Seq(), tipSeq)
+	}
+	wantMin := tipSeq - maxProviderAncestors
+	if lgr.MinSeq() != wantMin {
+		t.Errorf("MinSeq: got %d, want %d (256-ancestor cap)", lgr.MinSeq(), wantMin)
+	}
+	// Below MinSeq Ancestor returns zero — no panic.
+	if lgr.Ancestor(100) != (consensus.LedgerID{}) {
+		t.Errorf("Ancestor(100) below MinSeq should be zero")
+	}
+	// Within range entries are real.
+	if lgr.Ancestor(wantMin)[1] != 'e' {
+		t.Errorf("Ancestor(%d) tag should be 'e'", wantMin)
+	}
+	if lgr.Ancestor(tipSeq - 1)[1] != 'e' {
+		t.Errorf("Ancestor(%d) tag should be 'e'", tipSeq-1)
+	}
+}
+
+func TestLedgerProvider_AncestorOutOfRangeReturnsZero(t *testing.T) {
+	// Defensive parity with rippled's RCLValidatedLedger::operator[]
+	// (RCLValidations.cpp:79-95): Ancestor of an out-of-range seq must
+	// return the zero LedgerID rather than panicking.
+	tip, byHash := buildChain(5, 'f')
+	p := newTestProvider(byHash)
+	lgr, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("LedgerByID should succeed")
+	}
+	if lgr.Ancestor(999) != (consensus.LedgerID{}) {
+		t.Errorf("Ancestor(s > seq) should return zero")
+	}
+}
+
+func TestLedgerProvider_LRUEvicts(t *testing.T) {
+	// Filling the cache beyond providerCacheCapacity must evict the
+	// oldest entries; the cache stays bounded.
+	tag := byte('g')
+	p := newLedgerProviderFromLookup(func(h [32]byte) (LedgerHeader, error) {
+		// Synthesize headers on demand so we don't need to materialize
+		// thousands up front.
+		seq := uint32(h[0]) | uint32(h[1])<<8 | uint32(h[2])<<16
+		if seq == 0 || h[31] != tag {
+			return nil, errors.New("not found")
+		}
+		var parent [32]byte
+		if seq > 1 {
+			parent[0] = byte((seq - 1) & 0xff)
+			parent[1] = byte(((seq - 1) >> 8) & 0xff)
+			parent[2] = byte(((seq - 1) >> 16) & 0xff)
+			parent[31] = tag
+		}
+		return &fakeHeader{seq: seq, hash: h, parent: parent}, nil
+	})
+
+	// Insert providerCacheCapacity+50 distinct ledger IDs.
+	makeID := func(seq uint32) consensus.LedgerID {
+		var id consensus.LedgerID
+		id[0] = byte(seq & 0xff)
+		id[1] = byte((seq >> 8) & 0xff)
+		id[2] = byte((seq >> 16) & 0xff)
+		id[31] = tag
+		return id
+	}
+	for s := uint32(1); s <= providerCacheCapacity+50; s++ {
+		if _, ok := p.LedgerByID(makeID(s)); !ok {
+			t.Fatalf("insert seq=%d should succeed", s)
+		}
+	}
+
+	p.mu.Lock()
+	cacheLen := p.lru.Len()
+	mapLen := len(p.cache)
+	p.mu.Unlock()
+
+	if cacheLen > providerCacheCapacity {
+		t.Errorf("LRU not bounded: got %d entries, want ≤%d", cacheLen, providerCacheCapacity)
+	}
+	if cacheLen != mapLen {
+		t.Errorf("LRU/map size mismatch: %d vs %d", cacheLen, mapLen)
+	}
+	// First-inserted entry should have been evicted.
+	if _, ok := p.cacheGet(makeID(1)); ok {
+		t.Errorf("oldest entry (seq=1) should have been evicted")
 	}
 }
 

--- a/internal/consensus/rcl/ledger_provider_test.go
+++ b/internal/consensus/rcl/ledger_provider_test.go
@@ -1,0 +1,191 @@
+package rcl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// fakeHeader is a minimal LedgerHeader for unit tests. We build a
+// contiguous chain genesis(seq 1) → seq 2 → ... by feeding the parent
+// hash forward; each child picks a synthetic hash derived from the
+// parent hash and the sequence.
+type fakeHeader struct {
+	seq    uint32
+	hash   [32]byte
+	parent [32]byte
+}
+
+func (h *fakeHeader) Sequence() uint32    { return h.seq }
+func (h *fakeHeader) Hash() [32]byte      { return h.hash }
+func (h *fakeHeader) ParentHash() [32]byte { return h.parent }
+
+// buildChain produces headers seq 1..n, each with a deterministic
+// hash (byte 0 = seq, byte 1 = tag to distinguish forks). Returns
+// the tip header and the full {hash → header} map.
+func buildChain(n uint32, tag byte) (*fakeHeader, map[[32]byte]LedgerHeader) {
+	byHash := make(map[[32]byte]LedgerHeader)
+	var prevHash [32]byte // zero = pre-genesis
+	var tip *fakeHeader
+	for s := uint32(1); s <= n; s++ {
+		h := &fakeHeader{seq: s, parent: prevHash}
+		h.hash[0] = byte(s)
+		h.hash[1] = tag
+		byHash[h.hash] = h
+		prevHash = h.hash
+		tip = h
+	}
+	return tip, byHash
+}
+
+// newTestProvider constructs a provider backed by a byHash map. Any
+// missing lookup returns a sentinel error.
+func newTestProvider(byHash map[[32]byte]LedgerHeader) *LedgerProvider {
+	return newLedgerProviderFromLookup(func(h [32]byte) (LedgerHeader, error) {
+		if lh, ok := byHash[h]; ok {
+			return lh, nil
+		}
+		return nil, errors.New("not found")
+	})
+}
+
+func TestLedgerProvider_BuildsFullAncestry(t *testing.T) {
+	tip, byHash := buildChain(5, 'a')
+	p := newTestProvider(byHash)
+
+	lgr, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("LedgerByID should succeed for tip of complete chain")
+	}
+	if lgr.Seq() != 5 {
+		t.Errorf("Seq: got %d, want 5", lgr.Seq())
+	}
+	if lgr.ID() != consensus.LedgerID(tip.hash) {
+		t.Errorf("ID mismatch")
+	}
+	// Ancestor(0) is the pre-genesis zero.
+	var zero consensus.LedgerID
+	if lgr.Ancestor(0) != zero {
+		t.Errorf("Ancestor(0): want zero, got %x", lgr.Ancestor(0))
+	}
+	// Ancestor(N) is the ledger itself.
+	if lgr.Ancestor(5) != consensus.LedgerID(tip.hash) {
+		t.Errorf("Ancestor(5) should equal tip ID")
+	}
+	// Mid-chain seqs check out.
+	for s := uint32(1); s <= 5; s++ {
+		got := lgr.Ancestor(s)
+		if got[0] != byte(s) || got[1] != 'a' {
+			t.Errorf("Ancestor(%d): got %x, expected byte0=%d byte1='a'", s, got, s)
+		}
+	}
+}
+
+func TestLedgerProvider_MissingLinkFailsCleanly(t *testing.T) {
+	tip, byHash := buildChain(5, 'b')
+	// Delete the seq-3 header from the lookup so the walk-back fails
+	// when it reaches the seq-4 ledger and tries to load its parent.
+	var s3Hash [32]byte
+	for h, lh := range byHash {
+		if lh.Sequence() == 3 {
+			s3Hash = h
+			break
+		}
+	}
+	delete(byHash, s3Hash)
+
+	p := newTestProvider(byHash)
+	if _, ok := p.LedgerByID(consensus.LedgerID(tip.hash)); ok {
+		t.Fatal("LedgerByID should fail when chain has a gap")
+	}
+}
+
+func TestLedgerProvider_CachesRepeatedQueries(t *testing.T) {
+	tip, byHash := buildChain(10, 'c')
+
+	var calls int
+	p := newLedgerProviderFromLookup(func(h [32]byte) (LedgerHeader, error) {
+		calls++
+		if lh, ok := byHash[h]; ok {
+			return lh, nil
+		}
+		return nil, errors.New("not found")
+	})
+
+	_, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("first lookup should succeed")
+	}
+	firstCalls := calls
+
+	// Second query for the same ID should be a pure cache hit.
+	_, ok = p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("second lookup should succeed")
+	}
+	if calls != firstCalls {
+		t.Errorf("second lookup should not call into svc: got %d extra calls", calls-firstCalls)
+	}
+}
+
+func TestLedgerProvider_SplicesCachedPrefix(t *testing.T) {
+	_, byHash := buildChain(10, 'd')
+
+	// Locate seq-5 as an intermediate tip we'll warm the cache with.
+	var seq5 *fakeHeader
+	for _, lh := range byHash {
+		if lh.Sequence() == 5 {
+			seq5 = lh.(*fakeHeader)
+			break
+		}
+	}
+
+	var calls int
+	p := newLedgerProviderFromLookup(func(h [32]byte) (LedgerHeader, error) {
+		calls++
+		if lh, ok := byHash[h]; ok {
+			return lh, nil
+		}
+		return nil, errors.New("not found")
+	})
+
+	// Warm cache at seq 5: five lookups (tip + 4 walk-back steps).
+	if _, ok := p.LedgerByID(consensus.LedgerID(seq5.hash)); !ok {
+		t.Fatal("warm lookup should succeed")
+	}
+	warmCalls := calls
+
+	// Lookup seq 10. The walk must halt at seq 5 (whose ancestors are
+	// already cached) and splice the prefix instead of walking 9 steps.
+	// Expected extra calls: 1 (tip) + 5 (walk back to seq 5) = 6.
+	// Without the splice it would be 1 + 9 = 10.
+	var seq10 *fakeHeader
+	for _, lh := range byHash {
+		if lh.Sequence() == 10 {
+			seq10 = lh.(*fakeHeader)
+			break
+		}
+	}
+	if _, ok := p.LedgerByID(consensus.LedgerID(seq10.hash)); !ok {
+		t.Fatal("cold lookup should succeed")
+	}
+	extra := calls - warmCalls
+	if extra > 6 {
+		t.Errorf("splice didn't short-circuit: extra lookups = %d (expected ≤6)", extra)
+	}
+}
+
+func TestLedgerProvider_NilServiceDisables(t *testing.T) {
+	p := NewLedgerProvider(nil)
+	if _, ok := p.LedgerByID(consensus.LedgerID{0x01}); ok {
+		t.Fatal("nil-service provider should always return false")
+	}
+}
+
+func TestLedgerProvider_NilReceiverSafe(t *testing.T) {
+	var p *LedgerProvider
+	if _, ok := p.LedgerByID(consensus.LedgerID{0x01}); ok {
+		t.Fatal("nil receiver should return false without panicking")
+	}
+}

--- a/internal/consensus/rcl/ledger_provider_test.go
+++ b/internal/consensus/rcl/ledger_provider_test.go
@@ -111,7 +111,7 @@ func TestLedgerProvider_MissingLinkTruncates(t *testing.T) {
 		t.Errorf("Seq: got %d, want 5", lgr.Seq())
 	}
 	if lgr.MinSeq() != 3 {
-		t.Errorf("MinSeq: got %d, want 3 (truncated at seq-3 — seq-2 lookup failed)", lgr.MinSeq())
+		t.Errorf("MinSeq: got %d, want 3 (truncated at seq-3 — seq-3 record lookup failed)", lgr.MinSeq())
 	}
 	if lgr.Ancestor(2) != (consensus.LedgerID{}) {
 		t.Errorf("Ancestor(2) below MinSeq should be zero")

--- a/internal/consensus/rcl/ledger_provider_test.go
+++ b/internal/consensus/rcl/ledger_provider_test.go
@@ -17,8 +17,8 @@ type fakeHeader struct {
 	parent [32]byte
 }
 
-func (h *fakeHeader) Sequence() uint32    { return h.seq }
-func (h *fakeHeader) Hash() [32]byte      { return h.hash }
+func (h *fakeHeader) Sequence() uint32     { return h.seq }
+func (h *fakeHeader) Hash() [32]byte       { return h.hash }
 func (h *fakeHeader) ParentHash() [32]byte { return h.parent }
 
 // buildChain produces headers seq 1..n, each with a deterministic

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/ledgertrie"
 )
 
 // ValidationTracker tracks validations and determines ledger finality.
@@ -74,6 +75,24 @@ type ValidationTracker struct {
 	// writer's channel send) may do I/O without risking lock-order
 	// inversion. Nil means "no archive wired."
 	onStale func(*consensus.Validation)
+
+	// ancestry resolves a LedgerID to a ledger carrying its ancestor
+	// chain so the trie can walk from genesis → tip on insert. May be
+	// nil — when unset, the tracker falls back to the flat trusted
+	// hash-count for support queries. See SetLedgerAncestryProvider
+	// in validations_trie.go.
+	ancestry LedgerAncestryProvider
+
+	// trie maintains branchSupport for the latest trusted validation
+	// of every (trusted, not negUNL) validator. Populated on Add()
+	// only when ancestry is set. nil means "trie disabled".
+	trie *ledgertrie.Trie
+
+	// trieTips tracks which ledger each trusted validator currently
+	// holds in the trie, so a newer validation from the same node can
+	// remove the old tip before inserting the new one. Matches
+	// rippled's lastValidations map (Validations.h:366-371).
+	trieTips map[consensus.NodeID]ledgertrie.Ledger
 }
 
 // NewValidationTracker creates a new validation tracker.
@@ -127,6 +146,12 @@ func (vt *ValidationTracker) SetNow(fn func() time.Time) {
 }
 
 // SetTrusted updates the set of trusted validators.
+//
+// If the ancestry trie is wired, rebuilds trie membership from the
+// current byNode / negUNL state so newly-trusted validators contribute
+// their latest tip and de-trusted ones no longer count. Mirrors
+// rippled's Validations::trustChanged (Validations.h:472-499) which
+// calls updateTrie on every trust flip.
 func (vt *ValidationTracker) SetTrusted(nodes []consensus.NodeID) {
 	vt.mu.Lock()
 	defer vt.mu.Unlock()
@@ -135,6 +160,7 @@ func (vt *ValidationTracker) SetTrusted(nodes []consensus.NodeID) {
 	for _, node := range nodes {
 		vt.trusted[node] = true
 	}
+	vt.rebuildTrieLocked()
 }
 
 // SetQuorum updates the quorum requirement.
@@ -157,6 +183,7 @@ func (vt *ValidationTracker) SetNegativeUNL(nodes []consensus.NodeID) {
 	for _, n := range nodes {
 		vt.negUNL[n] = true
 	}
+	vt.rebuildTrieLocked()
 }
 
 // SetMinSeq advances the sequence floor below which incoming
@@ -343,6 +370,13 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	}
 	ledgerVals[resolvedID] = validation
 
+	// Maintain the ancestry trie: trusted-and-not-negUNL validators'
+	// latest tip feeds branchSupport. Only fires when a provider is
+	// wired — see SetLedgerAncestryProvider.
+	if vt.trusted[resolvedID] && !vt.negUNL[resolvedID] {
+		vt.updateTrieLocked(resolvedID, validation.LedgerID)
+	}
+
 	// Capture the fire-tuple under the lock; the deferred dispatcher
 	// invokes onFullyValidated after vt.mu.Unlock has run.
 	fireID, fireSeq, shouldFire = vt.checkFullValidationLocked(validation.LedgerID)
@@ -474,16 +508,54 @@ func (vt *ValidationTracker) countTrustedExcludingNegUNLLocked(
 	return count
 }
 
-// GetTrustedSupport is an alias for GetTrustedValidationCount named for
-// the LedgerTrie-style preference heuristic used in checkLedger. Rippled
-// picks a network ledger via vals.getPreferred() (RCLConsensus.cpp:301)
-// which returns the ledger with the most validation SUPPORT on its
-// ancestor chain — we approximate "support" with a flat trusted-count
-// at the exact ledger ID. Good enough when trusted validators broadly
-// agree; a full LedgerTrie port is a follow-up item. Inherits the
-// negUNL filter from GetTrustedValidationCount.
+// GetTrustedSupport returns the "support" for a ledger ID the way
+// rippled's vals.getPreferred() sees it — the count of trusted
+// validators whose latest validation commits to this ledger OR ANY
+// DESCENDANT of it on the ancestry trie. Mirrors LedgerTrie::
+// branchSupport (LedgerTrie.h:610-623).
+//
+// When a LedgerAncestryProvider is wired and resolves the ledger,
+// returns the trie's branchSupport. Otherwise falls back to the flat
+// trusted-count at the exact ID (via GetTrustedValidationCount) —
+// production nodes without an ancestry provider and tests that
+// construct bare ValidationTrackers keep their existing behaviour.
+//
+// Inherits the negUNL filter: validators on the negative-UNL never
+// enter the trie, so their validations don't contribute support.
 func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int {
+	vt.mu.RLock()
+	if vt.trie != nil && vt.ancestry != nil {
+		if lgr, ok := vt.ancestry.LedgerByID(ledgerID); ok {
+			n := vt.trie.BranchSupport(lgr)
+			vt.mu.RUnlock()
+			return int(n)
+		}
+	}
+	vt.mu.RUnlock()
 	return vt.GetTrustedValidationCount(ledgerID)
+}
+
+// GetPreferred returns the network-preferred ledger ID (and its
+// sequence) as decided by the ancestry trie. The second return is
+// true when a trie-based decision was made; false when the trie is
+// not wired, is empty, or lacks ancestry for the relevant ledgers.
+//
+// Port of rippled's Validations::getPreferred (Validations.h, called
+// at RCLConsensus.cpp:301). Mirrors the same largestIssued semantics:
+// pass the highest sequence number for which this node has already
+// issued a validation so the trie can seed uncommitted support from
+// earlier sequences.
+func (vt *ValidationTracker) GetPreferred(largestIssued uint32) (consensus.LedgerID, uint32, bool) {
+	vt.mu.RLock()
+	defer vt.mu.RUnlock()
+	if vt.trie == nil {
+		return consensus.LedgerID{}, 0, false
+	}
+	tip, ok := vt.trie.GetPreferred(largestIssued)
+	if !ok {
+		return consensus.LedgerID{}, 0, false
+	}
+	return tip.ID, tip.Seq, true
 }
 
 // IsFullyValidated returns true if the ledger has reached full

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -76,22 +76,16 @@ type ValidationTracker struct {
 	// inversion. Nil means "no archive wired."
 	onStale func(*consensus.Validation)
 
-	// ancestry resolves a LedgerID to a ledger carrying its ancestor
-	// chain so the trie can walk from genesis → tip on insert. May be
-	// nil — when unset, the tracker falls back to the flat trusted
-	// hash-count for support queries. See SetLedgerAncestryProvider
-	// in validations_trie.go.
+	// ancestry resolves LedgerID → ancestry for the trie. nil disables
+	// the trie; the tracker then falls back to flat hash-count support.
 	ancestry LedgerAncestryProvider
 
-	// trie maintains branchSupport for the latest trusted validation
-	// of every (trusted, not negUNL) validator. Populated on Add()
-	// only when ancestry is set. nil means "trie disabled".
+	// trie holds branchSupport for trusted-and-not-negUNL validators'
+	// latest tips. nil when ancestry is unset.
 	trie *ledgertrie.Trie
 
-	// trieTips tracks which ledger each trusted validator currently
-	// holds in the trie, so a newer validation from the same node can
-	// remove the old tip before inserting the new one. Matches
-	// rippled's lastValidations map (Validations.h:366-371).
+	// trieTips records each validator's current trie tip so a newer
+	// validation can remove the old before inserting the new.
 	trieTips map[consensus.NodeID]ledgertrie.Ledger
 }
 
@@ -145,13 +139,8 @@ func (vt *ValidationTracker) SetNow(fn func() time.Time) {
 	vt.now = fn
 }
 
-// SetTrusted updates the set of trusted validators.
-//
-// If the ancestry trie is wired, rebuilds trie membership from the
-// current byNode / negUNL state so newly-trusted validators contribute
-// their latest tip and de-trusted ones no longer count. Mirrors
-// rippled's Validations::trustChanged (Validations.h:472-499) which
-// calls updateTrie on every trust flip.
+// SetTrusted updates the set of trusted validators and rebuilds the
+// trie if wired so de-trusted validators stop contributing support.
 func (vt *ValidationTracker) SetTrusted(nodes []consensus.NodeID) {
 	vt.mu.Lock()
 	defer vt.mu.Unlock()
@@ -315,12 +304,8 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 		}
 	}()
 
-	// Pre-resolve the validation's ledger ancestry without holding
-	// vt.mu. ancestry.LedgerByID may walk ParentHash on a cold LRU; if
-	// we did this under the write lock every concurrent Add() would
-	// serialise behind us. updateTrieLocked re-checks the resolved ID
-	// matches and falls back to a lock-bound resolve on a rare race
-	// (provider swapped between here and the lock acquire).
+	// Pre-resolve ancestry outside vt.mu — cold-LRU walks would
+	// otherwise serialise concurrent Add()s behind us.
 	vt.mu.RLock()
 	ancestrySnap := vt.ancestry
 	trieEnabled := vt.trie != nil
@@ -387,9 +372,6 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	}
 	ledgerVals[resolvedID] = validation
 
-	// Maintain the ancestry trie: trusted-and-not-negUNL validators'
-	// latest tip feeds branchSupport. Only fires when a provider is
-	// wired — see SetLedgerAncestryProvider.
 	if vt.trusted[resolvedID] && !vt.negUNL[resolvedID] {
 		vt.updateTrieLocked(resolvedID, validation.LedgerID, preResolvedLedger)
 	}
@@ -525,27 +507,13 @@ func (vt *ValidationTracker) countTrustedExcludingNegUNLLocked(
 	return count
 }
 
-// GetTrustedSupport returns the "support" for a ledger ID the way
-// rippled's vals.getPreferred() sees it — the count of trusted
-// validators whose latest validation commits to this ledger OR ANY
-// DESCENDANT of it on the ancestry trie. Mirrors LedgerTrie::
-// branchSupport (LedgerTrie.h:610-623).
-//
-// When a LedgerAncestryProvider is wired and resolves the ledger,
-// returns the trie's branchSupport. Otherwise falls back to the flat
-// trusted-count at the exact ID (via GetTrustedValidationCount) —
-// production nodes without an ancestry provider and tests that
-// construct bare ValidationTrackers keep their existing behaviour.
-//
-// Inherits the negUNL filter: validators on the negative-UNL never
-// enter the trie, so their validations don't contribute support.
+// GetTrustedSupport returns the trie's branchSupport for ledgerID —
+// the count of trusted-and-not-negUNL validators committing to this
+// ledger or any descendant. Falls back to the flat trusted count when
+// the trie or ancestry is unavailable.
 func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int {
-	// Snapshot trie+ancestry pointers under vt.mu, then drop the lock
-	// before resolving the ledger. The ancestry provider has its own
-	// internal synchronisation; on a cold LRU the parent walk may take
-	// long enough that holding vt.mu would serialise every concurrent
-	// Add() behind us. Re-acquire vt.mu only for the trie query itself,
-	// which is cheap.
+	// Snapshot pointers, drop the lock for ancestry resolution, then
+	// re-acquire for the cheap trie query.
 	vt.mu.RLock()
 	trie := vt.trie
 	ancestry := vt.ancestry
@@ -562,9 +530,7 @@ func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int 
 
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()
-	// SetLedgerAncestryProvider may have swapped the trie out while we
-	// were resolving ancestry. The trie's internal state is only
-	// mutated under vt.mu, so a stable pointer is safe to query.
+	// Trie may have been swapped while we resolved ancestry.
 	if vt.trie != trie {
 		ledgerVals, exists := vt.validations[ledgerID]
 		if !exists {
@@ -575,16 +541,10 @@ func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int 
 	return int(trie.BranchSupport(lgr))
 }
 
-// GetPreferred returns the network-preferred ledger ID (and its
-// sequence) as decided by the ancestry trie. The second return is
-// true when a trie-based decision was made; false when the trie is
-// not wired, is empty, or lacks ancestry for the relevant ledgers.
-//
-// Port of rippled's Validations::getPreferred (Validations.h, called
-// at RCLConsensus.cpp:301). Mirrors the same largestIssued semantics:
-// pass the highest sequence number for which this node has already
-// issued a validation so the trie can seed uncommitted support from
-// earlier sequences.
+// GetPreferred returns the network-preferred ledger ID and sequence
+// as decided by the ancestry trie. ok is false when the trie is not
+// wired or empty. largestIssued is the highest sequence this node has
+// already validated; it seeds uncommitted support from earlier seqs.
 func (vt *ValidationTracker) GetPreferred(largestIssued uint32) (consensus.LedgerID, uint32, bool) {
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()
@@ -664,22 +624,9 @@ func (vt *ValidationTracker) GetCurrentValidators() []consensus.NodeID {
 	return result
 }
 
-// ExpireOld drops validations whose LedgerSeq is below minSeq from every
-// internal index, then fires onStale (if set) for each dropped validation
-// outside the mutex. All validations for a given ledger share a LedgerSeq,
-// so the staleness decision is taken from any one sample per ledger.
-//
-// When a validator's latest validation is dropped, its trie tip is also
-// removed (and trieTips entry cleared) so phantom branchSupport doesn't
-// linger on the now-stale tip. Mirrors rippled's
-// Validations::removeTrie call before erasing from current_
-// (Validations.h:519-523). Without this the ancestor of the stale tip
-// would over-count in GetTrustedSupport until the same validator
-// submitted a fresh validation.
-//
-// Fixes a prior bug where byNode entries survived deletion — the node's
-// latest-validation pointer was kept pointing at a Validation removed from
-// the per-ledger map.
+// ExpireOld drops validations below minSeq from every index and fires
+// onStale outside the mutex. Trie tips for dropped validators are also
+// removed so phantom branchSupport doesn't linger on stale ancestors.
 func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 	vt.mu.Lock()
 
@@ -699,9 +646,6 @@ func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 			stale = append(stale, v)
 			if latest, ok := vt.byNode[nodeID]; ok && latest == v {
 				delete(vt.byNode, nodeID)
-				// Drop the validator's trie tip too — without this its
-				// support phantom-counts on ancestors of the stale tip
-				// until the validator submits a fresh validation.
 				if vt.trie != nil {
 					if prev, ok := vt.trieTips[nodeID]; ok {
 						vt.trie.Remove(prev, 1)

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -669,6 +669,14 @@ func (vt *ValidationTracker) GetCurrentValidators() []consensus.NodeID {
 // outside the mutex. All validations for a given ledger share a LedgerSeq,
 // so the staleness decision is taken from any one sample per ledger.
 //
+// When a validator's latest validation is dropped, its trie tip is also
+// removed (and trieTips entry cleared) so phantom branchSupport doesn't
+// linger on the now-stale tip. Mirrors rippled's
+// Validations::removeTrie call before erasing from current_
+// (Validations.h:519-523). Without this the ancestor of the stale tip
+// would over-count in GetTrustedSupport until the same validator
+// submitted a fresh validation.
+//
 // Fixes a prior bug where byNode entries survived deletion — the node's
 // latest-validation pointer was kept pointing at a Validation removed from
 // the per-ledger map.
@@ -691,6 +699,15 @@ func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 			stale = append(stale, v)
 			if latest, ok := vt.byNode[nodeID]; ok && latest == v {
 				delete(vt.byNode, nodeID)
+				// Drop the validator's trie tip too — without this its
+				// support phantom-counts on ancestors of the stale tip
+				// until the validator submits a fresh validation.
+				if vt.trie != nil {
+					if prev, ok := vt.trieTips[nodeID]; ok {
+						vt.trie.Remove(prev, 1)
+						delete(vt.trieTips, nodeID)
+					}
+				}
 			}
 		}
 		delete(vt.validations, ledgerID)

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -315,6 +315,23 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 		}
 	}()
 
+	// Pre-resolve the validation's ledger ancestry without holding
+	// vt.mu. ancestry.LedgerByID may walk ParentHash on a cold LRU; if
+	// we did this under the write lock every concurrent Add() would
+	// serialise behind us. updateTrieLocked re-checks the resolved ID
+	// matches and falls back to a lock-bound resolve on a rare race
+	// (provider swapped between here and the lock acquire).
+	vt.mu.RLock()
+	ancestrySnap := vt.ancestry
+	trieEnabled := vt.trie != nil
+	vt.mu.RUnlock()
+	var preResolvedLedger ledgertrie.Ledger
+	if trieEnabled && ancestrySnap != nil {
+		if l, ok := ancestrySnap.LedgerByID(validation.LedgerID); ok {
+			preResolvedLedger = l
+		}
+	}
+
 	vt.mu.Lock()
 	defer vt.mu.Unlock()
 
@@ -374,7 +391,7 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	// latest tip feeds branchSupport. Only fires when a provider is
 	// wired — see SetLedgerAncestryProvider.
 	if vt.trusted[resolvedID] && !vt.negUNL[resolvedID] {
-		vt.updateTrieLocked(resolvedID, validation.LedgerID)
+		vt.updateTrieLocked(resolvedID, validation.LedgerID, preResolvedLedger)
 	}
 
 	// Capture the fire-tuple under the lock; the deferred dispatcher
@@ -523,16 +540,39 @@ func (vt *ValidationTracker) countTrustedExcludingNegUNLLocked(
 // Inherits the negUNL filter: validators on the negative-UNL never
 // enter the trie, so their validations don't contribute support.
 func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int {
+	// Snapshot trie+ancestry pointers under vt.mu, then drop the lock
+	// before resolving the ledger. The ancestry provider has its own
+	// internal synchronisation; on a cold LRU the parent walk may take
+	// long enough that holding vt.mu would serialise every concurrent
+	// Add() behind us. Re-acquire vt.mu only for the trie query itself,
+	// which is cheap.
 	vt.mu.RLock()
-	if vt.trie != nil && vt.ancestry != nil {
-		if lgr, ok := vt.ancestry.LedgerByID(ledgerID); ok {
-			n := vt.trie.BranchSupport(lgr)
-			vt.mu.RUnlock()
-			return int(n)
-		}
-	}
+	trie := vt.trie
+	ancestry := vt.ancestry
 	vt.mu.RUnlock()
-	return vt.GetTrustedValidationCount(ledgerID)
+
+	if trie == nil || ancestry == nil {
+		return vt.GetTrustedValidationCount(ledgerID)
+	}
+
+	lgr, ok := ancestry.LedgerByID(ledgerID)
+	if !ok {
+		return vt.GetTrustedValidationCount(ledgerID)
+	}
+
+	vt.mu.RLock()
+	defer vt.mu.RUnlock()
+	// SetLedgerAncestryProvider may have swapped the trie out while we
+	// were resolving ancestry. The trie's internal state is only
+	// mutated under vt.mu, so a stable pointer is safe to query.
+	if vt.trie != trie {
+		ledgerVals, exists := vt.validations[ledgerID]
+		if !exists {
+			return 0
+		}
+		return vt.countTrustedExcludingNegUNLLocked(ledgerVals)
+	}
+	return int(trie.BranchSupport(lgr))
 }
 
 // GetPreferred returns the network-preferred ledger ID (and its

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -676,6 +676,7 @@ func (vt *ValidationTracker) Clear() {
 	vt.validations = make(map[consensus.LedgerID]map[consensus.NodeID]*consensus.Validation)
 	vt.byNode = make(map[consensus.NodeID]*consensus.Validation)
 	vt.fired = make(map[consensus.LedgerID]struct{})
+	vt.rebuildTrieLocked()
 }
 
 // Stats returns statistics about tracked validations.

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -6,22 +6,15 @@ import (
 )
 
 // LedgerAncestryProvider resolves a LedgerID to a ledgertrie.Ledger
-// carrying its full ancestry. Returns (nil, false) when the ledger's
-// history is not locally known — e.g. a validation arrived for a
-// ledger we haven't acquired yet. Callers (the ValidationTracker)
-// silently skip trie insertion in that case and fall back to the
-// flat-count approximation via the byNode map.
+// carrying its ancestry. Returns (nil, false) when the ledger's
+// history is not locally known.
 type LedgerAncestryProvider interface {
 	LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger, bool)
 }
 
 // SetLedgerAncestryProvider installs a provider and enables the trie.
-// Passing nil disables the trie and discards any tip support currently
-// tracked — the ValidationTracker reverts to flat-count support.
-//
-// Safe to call at any time: the trie is rebuilt from the current
-// byNode / trusted / negUNL state so a late-bound provider still
-// reflects everything the tracker has already accepted.
+// Passing nil disables the trie and reverts to flat-count support.
+// The trie is rebuilt from the current byNode / trusted / negUNL state.
 func (vt *ValidationTracker) SetLedgerAncestryProvider(p LedgerAncestryProvider) {
 	vt.mu.Lock()
 	defer vt.mu.Unlock()
@@ -36,11 +29,12 @@ func (vt *ValidationTracker) SetLedgerAncestryProvider(p LedgerAncestryProvider)
 	vt.rebuildTrieLocked()
 }
 
-// rebuildTrieLocked resets the trie and reseeds it from the current
-// byNode / trusted / negUNL state. Called when the trust set, negUNL,
-// or ancestry provider change — any of those can alter which
-// validators contribute which ledgers. Caller must hold vt.mu (write).
-// No-op when the ancestry provider is not set.
+// rebuildTrieLocked resets the trie and reseeds it from byNode.
+// Caller must hold vt.mu (write); no-op if ancestry is unset.
+//
+// Resolution runs under vt.mu — admin-only path (trust rotation,
+// negUNL change, provider swap). Add() relies on the trie staying
+// consistent with byNode while the lock is held.
 func (vt *ValidationTracker) rebuildTrieLocked() {
 	if vt.ancestry == nil {
 		return
@@ -48,9 +42,6 @@ func (vt *ValidationTracker) rebuildTrieLocked() {
 	vt.trie = ledgertrie.New(genesisLedger{})
 	vt.trieTips = make(map[consensus.NodeID]ledgertrie.Ledger)
 
-	// Seed the trie with current byNode state. Mirrors rippled's
-	// Validations::updateTrie which walks lastValidations on
-	// reconfigure (Validations.h:415-470).
 	for nodeID, v := range vt.byNode {
 		if !vt.trusted[nodeID] || vt.negUNL[nodeID] {
 			continue
@@ -64,49 +55,24 @@ func (vt *ValidationTracker) rebuildTrieLocked() {
 	}
 }
 
-// updateTrieLocked applies a trusted validator's latest validation to
-// the trie: removes the validator's previous tip (if any) and inserts
-// the new one. Silent no-op when the trie is not wired or ancestry
-// for newLedgerID is unavailable.
+// updateTrieLocked replaces nodeID's previous trie tip (if any) with
+// newLedgerID's tip. Silent no-op if ancestry is unavailable.
 //
-// preResolved is an optional pre-walked ancestry chain captured by the
-// caller before taking vt.mu — Add() resolves outside the lock so a
-// cold-LRU walk does not serialise concurrent inserts. When nil, this
-// function falls back to ancestry.LedgerByID under the lock (the rare
-// race path where the provider was swapped between resolve and lock).
+// preResolved is the ledger Add() walked outside vt.mu to avoid
+// serialising cold-LRU lookups; if nil or stale we resolve under lock.
 //
-// Mirrors rippled's Validations::updateTrie (Validations.h:415-470)
-// but keyed off the pre-computed trieTips map rather than re-reading
-// lastValidations.
-//
-// Caller must hold vt.mu (write).
+// Precondition: caller holds vt.mu (write) and has verified nodeID is
+// trusted and not on negUNL.
 func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, newLedgerID consensus.LedgerID, preResolved ledgertrie.Ledger) {
 	if vt.trie == nil || vt.ancestry == nil {
-		return
-	}
-	// Validator is trusted and not on negUNL — those checks live at
-	// the Add() call site. We still guard defensively.
-	if !vt.trusted[nodeID] || vt.negUNL[nodeID] {
-		// Validator lost trust or moved onto negUNL between the
-		// snapshot and here — remove its prior tip if any.
-		if prev, ok := vt.trieTips[nodeID]; ok {
-			vt.trie.Remove(prev, 1)
-			delete(vt.trieTips, nodeID)
-		}
 		return
 	}
 
 	lgr := preResolved
 	if lgr == nil || lgr.ID() != newLedgerID {
-		// Either the caller didn't pre-resolve (rebuildTrieLocked path)
-		// or the provider was swapped between resolve and lock. Resolve
-		// fresh — accepting the contention cost in this rare path.
 		var ok bool
 		lgr, ok = vt.ancestry.LedgerByID(newLedgerID)
 		if !ok {
-			// We don't know the new ledger's ancestry. Leave any existing
-			// trie entry for this validator in place; flat-count semantics
-			// will at least still reflect the prior tip.
 			return
 		}
 	}
@@ -118,9 +84,8 @@ func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, newLedger
 	vt.trieTips[nodeID] = lgr
 }
 
-// genesisLedger is the placeholder ledger used as the root of the
-// trie. The trie only reads Ancestor(0) from it (via Span.startID for
-// the root) and Seq()==0 for the MakeGenesis invariant check.
+// genesisLedger is the trie's root placeholder. The trie only reads
+// Ancestor(0) and Seq()==0 from it.
 type genesisLedger struct{}
 
 func (genesisLedger) ID() consensus.LedgerID               { return consensus.LedgerID{} }

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -1,0 +1,116 @@
+package rcl
+
+import (
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/ledgertrie"
+)
+
+// LedgerAncestryProvider resolves a LedgerID to a ledgertrie.Ledger
+// carrying its full ancestry. Returns (nil, false) when the ledger's
+// history is not locally known — e.g. a validation arrived for a
+// ledger we haven't acquired yet. Callers (the ValidationTracker)
+// silently skip trie insertion in that case and fall back to the
+// flat-count approximation via the byNode map.
+type LedgerAncestryProvider interface {
+	LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger, bool)
+}
+
+// SetLedgerAncestryProvider installs a provider and enables the trie.
+// Passing nil disables the trie and discards any tip support currently
+// tracked — the ValidationTracker reverts to flat-count support.
+//
+// Safe to call at any time: the trie is rebuilt from the current
+// byNode / trusted / negUNL state so a late-bound provider still
+// reflects everything the tracker has already accepted.
+func (vt *ValidationTracker) SetLedgerAncestryProvider(p LedgerAncestryProvider) {
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
+
+	if p == nil {
+		vt.ancestry = nil
+		vt.trie = nil
+		vt.trieTips = nil
+		return
+	}
+	vt.ancestry = p
+	vt.rebuildTrieLocked()
+}
+
+// rebuildTrieLocked resets the trie and reseeds it from the current
+// byNode / trusted / negUNL state. Called when the trust set, negUNL,
+// or ancestry provider change — any of those can alter which
+// validators contribute which ledgers. Caller must hold vt.mu (write).
+// No-op when the ancestry provider is not set.
+func (vt *ValidationTracker) rebuildTrieLocked() {
+	if vt.ancestry == nil {
+		return
+	}
+	vt.trie = ledgertrie.New(genesisLedger{})
+	vt.trieTips = make(map[consensus.NodeID]ledgertrie.Ledger)
+
+	// Seed the trie with current byNode state. Mirrors rippled's
+	// Validations::updateTrie which walks lastValidations on
+	// reconfigure (Validations.h:415-470).
+	for nodeID, v := range vt.byNode {
+		if !vt.trusted[nodeID] || vt.negUNL[nodeID] {
+			continue
+		}
+		lgr, ok := vt.ancestry.LedgerByID(v.LedgerID)
+		if !ok {
+			continue
+		}
+		vt.trie.Insert(lgr, 1)
+		vt.trieTips[nodeID] = lgr
+	}
+}
+
+// updateTrieLocked applies a trusted validator's latest validation to
+// the trie: removes the validator's previous tip (if any) and inserts
+// the new one. Silent no-op when the trie is not wired or ancestry
+// for newLedgerID is unavailable.
+//
+// Mirrors rippled's Validations::updateTrie (Validations.h:415-470)
+// but keyed off the pre-computed trieTips map rather than re-reading
+// lastValidations — which Go's locking forces us to do lock-free in
+// a hot path.
+//
+// Caller must hold vt.mu (write).
+func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, newLedgerID consensus.LedgerID) {
+	if vt.trie == nil || vt.ancestry == nil {
+		return
+	}
+	// Validator is trusted and not on negUNL — those checks live at
+	// the Add() call site. We still guard defensively.
+	if !vt.trusted[nodeID] || vt.negUNL[nodeID] {
+		// Validator lost trust or moved onto negUNL between the
+		// snapshot and here — remove its prior tip if any.
+		if prev, ok := vt.trieTips[nodeID]; ok {
+			vt.trie.Remove(prev, 1)
+			delete(vt.trieTips, nodeID)
+		}
+		return
+	}
+
+	lgr, ok := vt.ancestry.LedgerByID(newLedgerID)
+	if !ok {
+		// We don't know the new ledger's ancestry. Leave any existing
+		// trie entry for this validator in place; flat-count semantics
+		// will at least still reflect the prior tip.
+		return
+	}
+
+	if prev, existed := vt.trieTips[nodeID]; existed {
+		vt.trie.Remove(prev, 1)
+	}
+	vt.trie.Insert(lgr, 1)
+	vt.trieTips[nodeID] = lgr
+}
+
+// genesisLedger is the placeholder ledger used as the root of the
+// trie. The trie only reads Ancestor(0) from it (via Span.startID for
+// the root) and Seq()==0 for the MakeGenesis invariant check.
+type genesisLedger struct{}
+
+func (genesisLedger) ID() consensus.LedgerID               { return consensus.LedgerID{} }
+func (genesisLedger) Seq() uint32                          { return 0 }
+func (genesisLedger) Ancestor(s uint32) consensus.LedgerID { return consensus.LedgerID{} }

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -125,4 +125,5 @@ type genesisLedger struct{}
 
 func (genesisLedger) ID() consensus.LedgerID               { return consensus.LedgerID{} }
 func (genesisLedger) Seq() uint32                          { return 0 }
+func (genesisLedger) MinSeq() uint32                       { return 0 }
 func (genesisLedger) Ancestor(s uint32) consensus.LedgerID { return consensus.LedgerID{} }

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -69,13 +69,18 @@ func (vt *ValidationTracker) rebuildTrieLocked() {
 // the new one. Silent no-op when the trie is not wired or ancestry
 // for newLedgerID is unavailable.
 //
+// preResolved is an optional pre-walked ancestry chain captured by the
+// caller before taking vt.mu — Add() resolves outside the lock so a
+// cold-LRU walk does not serialise concurrent inserts. When nil, this
+// function falls back to ancestry.LedgerByID under the lock (the rare
+// race path where the provider was swapped between resolve and lock).
+//
 // Mirrors rippled's Validations::updateTrie (Validations.h:415-470)
 // but keyed off the pre-computed trieTips map rather than re-reading
-// lastValidations — which Go's locking forces us to do lock-free in
-// a hot path.
+// lastValidations.
 //
 // Caller must hold vt.mu (write).
-func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, newLedgerID consensus.LedgerID) {
+func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, newLedgerID consensus.LedgerID, preResolved ledgertrie.Ledger) {
 	if vt.trie == nil || vt.ancestry == nil {
 		return
 	}
@@ -91,12 +96,19 @@ func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, newLedger
 		return
 	}
 
-	lgr, ok := vt.ancestry.LedgerByID(newLedgerID)
-	if !ok {
-		// We don't know the new ledger's ancestry. Leave any existing
-		// trie entry for this validator in place; flat-count semantics
-		// will at least still reflect the prior tip.
-		return
+	lgr := preResolved
+	if lgr == nil || lgr.ID() != newLedgerID {
+		// Either the caller didn't pre-resolve (rebuildTrieLocked path)
+		// or the provider was swapped between resolve and lock. Resolve
+		// fresh — accepting the contention cost in this rare path.
+		var ok bool
+		lgr, ok = vt.ancestry.LedgerByID(newLedgerID)
+		if !ok {
+			// We don't know the new ledger's ancestry. Leave any existing
+			// trie entry for this validator in place; flat-count semantics
+			// will at least still reflect the prior tip.
+			return
+		}
 	}
 
 	if prev, existed := vt.trieTips[nodeID]; existed {

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -1,0 +1,243 @@
+package rcl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/ledgertrie"
+)
+
+// mapAncestryProvider is a tiny LedgerAncestryProvider backed by a
+// map, used to wire ledgertrie.TestLedger instances into the
+// ValidationTracker for these tests.
+type mapAncestryProvider struct {
+	byID map[consensus.LedgerID]ledgertrie.Ledger
+}
+
+func newMapAncestryProvider() *mapAncestryProvider {
+	return &mapAncestryProvider{byID: make(map[consensus.LedgerID]ledgertrie.Ledger)}
+}
+
+func (m *mapAncestryProvider) add(l ledgertrie.Ledger) { m.byID[l.ID()] = l }
+
+func (m *mapAncestryProvider) LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger, bool) {
+	l, ok := m.byID[id]
+	return l, ok
+}
+
+// makeTrustedValidation constructs a trusted validation at the given
+// seq from nodeID pointing at ledgerID. Close enough to the isCurrent
+// window that Add() will accept it with SetNow(time.Now).
+func makeTrustedValidation(nodeID consensus.NodeID, ledgerID consensus.LedgerID, seq uint32, now time.Time) *consensus.Validation {
+	return &consensus.Validation{
+		LedgerID:  ledgerID,
+		LedgerSeq: seq,
+		NodeID:    nodeID,
+		SignTime:  now,
+		SeenTime:  now,
+		Full:      true,
+	}
+}
+
+// TestValidationTracker_TrieDeepestSharedAncestor exercises the core
+// scenario from issue #268: a near-tip minority branch should NOT
+// outrank a deeper-shared-ancestor majority when the trie is wired.
+//
+// Topology:
+//
+//	genesis --> ab --> abc  (1 validator)
+//	              \-> abd --> abde  (2 validators at abde)
+//
+// Flat hash-count says: abc has 1, abde has 2. Under the flat
+// approximation GetTrustedSupport(abde) = 2 > GetTrustedSupport(abd) = 0,
+// and abd would lose to abc. Under the trie: branchSupport(abd) = 2 >
+// branchSupport(abc) = 1, so the majority-deeper branch correctly
+// wins.
+func TestValidationTracker_TrieDeepestSharedAncestor(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	ab := b.Build("ab")
+	abc := b.Build("abc")
+	abd := b.Build("abd")
+	abde := b.Build("abde")
+
+	provider := newMapAncestryProvider()
+	provider.add(b.Build(""))
+	provider.add(b.Build("a"))
+	provider.add(ab)
+	provider.add(abc)
+	provider.add(abd)
+	provider.add(abde)
+
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	n3 := consensus.NodeID{3}
+	vt.SetTrusted([]consensus.NodeID{n1, n2, n3})
+	vt.SetLedgerAncestryProvider(provider)
+
+	if !vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now)) {
+		t.Fatal("Add(n1->abc) should succeed")
+	}
+	if !vt.Add(makeTrustedValidation(n2, abde.ID(), abde.Seq(), now)) {
+		t.Fatal("Add(n2->abde) should succeed")
+	}
+	if !vt.Add(makeTrustedValidation(n3, abde.ID(), abde.Seq(), now)) {
+		t.Fatal("Add(n3->abde) should succeed")
+	}
+
+	// Flat count: abc has 1, abd has 0, abde has 2.
+	// Trie branchSupport: abc=1, abd=2 (via abde), abde=2.
+	if got := vt.GetTrustedSupport(abd.ID()); got != 2 {
+		t.Errorf("GetTrustedSupport(abd) via trie: got %d, want 2 (branchSupport)", got)
+	}
+	if got := vt.GetTrustedSupport(abde.ID()); got != 2 {
+		t.Errorf("GetTrustedSupport(abde): got %d, want 2", got)
+	}
+	if got := vt.GetTrustedSupport(abc.ID()); got != 1 {
+		t.Errorf("GetTrustedSupport(abc): got %d, want 1", got)
+	}
+
+	// Unknown ancestry falls back to flat count (zero here).
+	unknown := consensus.LedgerID{0xff}
+	if got := vt.GetTrustedSupport(unknown); got != 0 {
+		t.Errorf("GetTrustedSupport(unknown) should fall back to 0, got %d", got)
+	}
+}
+
+// TestValidationTracker_TrieNewerValidationReplacesOld verifies the
+// "most recent trusted validation per node" rule: when n1 moves from
+// abc to abde, the trie must remove abc's tip and insert abde's, so
+// branchSupport reflects the actual current network state.
+func TestValidationTracker_TrieNewerValidationReplacesOld(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abc := b.Build("abc")
+	abde := b.Build("abde")
+
+	provider := newMapAncestryProvider()
+	provider.add(abc)
+	provider.add(abde)
+
+	n1 := consensus.NodeID{1}
+	vt.SetTrusted([]consensus.NodeID{n1})
+	vt.SetLedgerAncestryProvider(provider)
+
+	if !vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now)) {
+		t.Fatal("first Add should succeed")
+	}
+	if vt.GetTrustedSupport(abc.ID()) != 1 {
+		t.Errorf("abc support after first validation should be 1")
+	}
+
+	// Newer validation from same node at a higher seq.
+	if !vt.Add(makeTrustedValidation(n1, abde.ID(), abde.Seq(), now.Add(time.Second))) {
+		t.Fatal("newer Add should succeed")
+	}
+
+	// abc's tip should have been removed; only abde contributes.
+	if got := vt.GetTrustedSupport(abc.ID()); got != 0 {
+		t.Errorf("abc support after switch: got %d, want 0", got)
+	}
+	if got := vt.GetTrustedSupport(abde.ID()); got != 1 {
+		t.Errorf("abde support after switch: got %d, want 1", got)
+	}
+}
+
+// TestValidationTracker_TrieNegUNLExcluded confirms a validator on
+// the negUNL never enters the trie, matching the flat-count filter.
+func TestValidationTracker_TrieNegUNLExcluded(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abc := b.Build("abc")
+	provider := newMapAncestryProvider()
+	provider.add(abc)
+
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	vt.SetTrusted([]consensus.NodeID{n1, n2})
+	vt.SetNegativeUNL([]consensus.NodeID{n2})
+	vt.SetLedgerAncestryProvider(provider)
+
+	vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now))
+	vt.Add(makeTrustedValidation(n2, abc.ID(), abc.Seq(), now))
+
+	// Only n1 counts; n2 on negUNL is excluded.
+	if got := vt.GetTrustedSupport(abc.ID()); got != 1 {
+		t.Errorf("negUNL validator should not contribute: got %d, want 1", got)
+	}
+}
+
+// TestValidationTracker_TrieGetPreferred runs a simple 2-way
+// competition through the full Add() path and asserts GetPreferred
+// returns the trie's SpanTip.
+func TestValidationTracker_TrieGetPreferred(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abc := b.Build("abc")
+	abde := b.Build("abde")
+	provider := newMapAncestryProvider()
+	provider.add(abc)
+	provider.add(abde)
+
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	n3 := consensus.NodeID{3}
+	vt.SetTrusted([]consensus.NodeID{n1, n2, n3})
+	vt.SetLedgerAncestryProvider(provider)
+
+	vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now))
+	vt.Add(makeTrustedValidation(n2, abde.ID(), abde.Seq(), now))
+	vt.Add(makeTrustedValidation(n3, abde.ID(), abde.Seq(), now))
+
+	id, seq, ok := vt.GetPreferred(0)
+	if !ok {
+		t.Fatal("GetPreferred should return a result with trie wired")
+	}
+	if id != abde.ID() {
+		t.Errorf("GetPreferred: got different ID, want abde")
+	}
+	if seq != abde.Seq() {
+		t.Errorf("GetPreferred seq: got %d, want %d", seq, abde.Seq())
+	}
+}
+
+// TestValidationTracker_TrieDisabled_FallsBack keeps the existing
+// flat-count behaviour when no ancestry provider is installed.
+func TestValidationTracker_TrieDisabled_FallsBack(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abc := b.Build("abc")
+
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	vt.SetTrusted([]consensus.NodeID{n1, n2})
+
+	vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now))
+	vt.Add(makeTrustedValidation(n2, abc.ID(), abc.Seq(), now))
+
+	// Without ancestry provider, GetTrustedSupport returns flat count.
+	if got := vt.GetTrustedSupport(abc.ID()); got != 2 {
+		t.Errorf("without trie: got %d, want 2 (flat count)", got)
+	}
+
+	if _, _, ok := vt.GetPreferred(0); ok {
+		t.Errorf("GetPreferred without trie should return ok=false")
+	}
+}

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -215,6 +215,76 @@ func TestValidationTracker_TrieGetPreferred(t *testing.T) {
 	}
 }
 
+// TestValidationTracker_TrieGetPreferred_LargestIssuedAffectsDescent
+// verifies that a non-zero largestIssued actually changes the descent
+// decision through the full Add() → trie path. Ports the structure of
+// rippled's "Changing largestSeq perspective" case
+// (LedgerTrie_test.cpp:506-591) at the ValidationTracker level.
+//
+// Topology after the 5 validations are accepted:
+//
+//	root -> a -> ab -> abde   (2 trusted at abde)
+//	          \-> ac -> acf   (1 trusted at acf)
+//
+// At largestIssued=1 the trie descends to ab (its 3-2 branchSupport
+// margin against ac exceeds the uncommitted at seq 1).
+//
+// At largestIssued=3 the seq-2 validations seed uncommitted before
+// descent starts, so the same 3-2 margin no longer beats uncommitted
+// and the descent stops at the common ancestor "a".
+func TestValidationTracker_TrieGetPreferred_LargestIssuedAffectsDescent(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	a := b.Build("a")
+	ab := b.Build("ab")
+	ac := b.Build("ac")
+	acf := b.Build("acf")
+	abde := b.Build("abde")
+	provider := newMapAncestryProvider()
+	provider.add(a)
+	provider.add(ab)
+	provider.add(ac)
+	provider.add(acf)
+	provider.add(abde)
+
+	n1 := consensus.NodeID{1} // votes ab
+	n2 := consensus.NodeID{2} // votes ac
+	n3 := consensus.NodeID{3} // votes acf
+	n4 := consensus.NodeID{4} // votes abde
+	n5 := consensus.NodeID{5} // votes abde
+	vt.SetTrusted([]consensus.NodeID{n1, n2, n3, n4, n5})
+	vt.SetLedgerAncestryProvider(provider)
+
+	vt.Add(makeTrustedValidation(n1, ab.ID(), ab.Seq(), now))
+	vt.Add(makeTrustedValidation(n2, ac.ID(), ac.Seq(), now))
+	vt.Add(makeTrustedValidation(n3, acf.ID(), acf.Seq(), now))
+	vt.Add(makeTrustedValidation(n4, abde.ID(), abde.Seq(), now))
+	vt.Add(makeTrustedValidation(n5, abde.ID(), abde.Seq(), now))
+
+	idAt1, _, ok := vt.GetPreferred(1)
+	if !ok {
+		t.Fatal("GetPreferred(1): no result")
+	}
+	if idAt1 != ab.ID() {
+		t.Errorf("GetPreferred(1): want ab (3-2 margin descent), got different ID")
+	}
+
+	idAt3, _, ok := vt.GetPreferred(3)
+	if !ok {
+		t.Fatal("GetPreferred(3): no result")
+	}
+	if idAt3 != a.ID() {
+		t.Errorf("GetPreferred(3): want a (descent halted by uncommitted), got different ID")
+	}
+
+	if idAt1 == idAt3 {
+		t.Errorf("largestIssued must change the descent decision: both queries returned %v", idAt1)
+	}
+}
+
 // TestValidationTracker_TrieDisabled_FallsBack keeps the existing
 // flat-count behaviour when no ancestry provider is installed.
 func TestValidationTracker_TrieDisabled_FallsBack(t *testing.T) {

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -311,3 +311,49 @@ func TestValidationTracker_TrieDisabled_FallsBack(t *testing.T) {
 		t.Errorf("GetPreferred without trie should return ok=false")
 	}
 }
+
+// TestValidationTracker_ExpireOldDropsTrieTip verifies that ExpireOld
+// removes a stale validator's tip from the trie. Without this fix the
+// validator's branchSupport would phantom-count on ancestors of the
+// expired tip until the validator submitted a fresh validation.
+// Mirrors rippled's removeTrie call in Validations::eraseFromCurrent
+// (Validations.h:519-523).
+func TestValidationTracker_ExpireOldDropsTrieTip(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	ab := b.Build("ab")   // seq 2 — common ancestor
+	abc := b.Build("abc") // seq 3
+	abd := b.Build("abd") // seq 3
+	provider := newMapAncestryProvider()
+	provider.add(ab) // GetTrustedSupport(ab) needs ab resolvable
+	provider.add(abc)
+	provider.add(abd)
+
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	vt.SetTrusted([]consensus.NodeID{n1, n2})
+	vt.SetLedgerAncestryProvider(provider)
+
+	vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now))
+	vt.Add(makeTrustedValidation(n2, abd.ID(), abd.Seq(), now))
+
+	// Both validators back the common ancestor "ab" through their tips.
+	if got := vt.GetTrustedSupport(ab.ID()); got != 2 {
+		t.Fatalf("pre-expire branchSupport(ab): got %d, want 2", got)
+	}
+
+	// Expire validations below seq 4 — drops both tips.
+	vt.ExpireOld(4)
+
+	// After expiry the trie must drop both tips. branchSupport on any
+	// ancestor falls to 0 — no phantom support survives.
+	if got := vt.GetTrustedSupport(ab.ID()); got != 0 {
+		t.Errorf("post-expire branchSupport(ab): got %d, want 0 (trie tip leaked)", got)
+	}
+	if got := vt.GetTrustedSupport(abc.ID()); got != 0 {
+		t.Errorf("post-expire branchSupport(abc): got %d, want 0", got)
+	}
+}

--- a/tasks/pr-ledgertrie.md
+++ b/tasks/pr-ledgertrie.md
@@ -1,0 +1,227 @@
+# PR: Full LedgerTrie `getPreferred` (issue #268)
+
+Replace the flat hash-count approximation at
+`internal/consensus/rcl/validations.go:396-406` with a faithful port of
+rippled's `LedgerTrie<Ledger>`.
+
+## Why
+
+`GetTrustedSupport` currently returns the count of trusted validations at
+the *exact* ledger ID. Rippled's `LedgerTrie` instead returns
+**branchSupport** — the sum of support across a ledger and every
+descendant that chains through it. Under an overlapping-ancestor fork
+topology, a minority near-tip otherwise outpolls a majority-further-back
+branch that actually won network-wide, and a catchup node can strand on
+the stale fork.
+
+## Rippled reference
+
+- `rippled/src/xrpld/consensus/LedgerTrie.h` — the whole file (853 LoC;
+  853-line header, all core algorithms inline).
+- `rippled/src/xrpld/consensus/Validations.h::getPreferred` — call-site.
+- `rippled/src/test/consensus/LedgerTrie_test.cpp` — parity tuple
+  tests + `testGetPreferred` (683 LoC).
+- `rippled/src/test/csf/ledgers.h` — the test-only Ledger mock with
+  `operator[](Seq)` ancestry lookup and a string-notation helper
+  (`h["abc"]`).
+
+## Design
+
+### New package `internal/consensus/ledgertrie/`
+
+A self-contained port of the trie, generic over a `Ledger` interface.
+Not tied to the CSF simulator or the RCL ValidationTracker — so both
+real node code and the test ledger can use it.
+
+```go
+package ledgertrie
+
+type Ledger interface {
+    ID() consensus.LedgerID
+    Seq() uint32
+    // Ancestor returns the ID of the ancestor at sequence s; for
+    // s == Seq() it returns ID(); for s == 0 it returns the genesis ID.
+    Ancestor(s uint32) consensus.LedgerID
+}
+
+// Mismatch is the free function from rippled: the first sequence where
+// a and b disagree. Exposed as a package-level func so callers can
+// supply a specialised implementation when they already have ancestry
+// cached.
+func Mismatch(a, b Ledger) uint32
+
+type SpanTip struct {
+    Seq uint32
+    ID  consensus.LedgerID
+    lgr Ledger  // for Ancestor lookup
+}
+
+func (t SpanTip) Ancestor(s uint32) consensus.LedgerID
+
+type Trie struct { ... }  // exported type
+
+func New() *Trie
+func (t *Trie) Insert(l Ledger, count uint32)
+func (t *Trie) Remove(l Ledger, count uint32) bool
+func (t *Trie) TipSupport(l Ledger) uint32
+func (t *Trie) BranchSupport(l Ledger) uint32
+func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool)
+func (t *Trie) Empty() bool
+func (t *Trie) CheckInvariants() bool
+```
+
+Unexported: `span`, `node` structs (mirroring rippled's
+`ledger_trie_detail`).
+
+### Algorithm fidelity
+
+Port verbatim, function-for-function:
+
+- `span.before(spot) / from(spot) / sub(from, to)` → `clamp` + optional
+  non-empty span.
+- `span.diff(other Ledger)` → `clamp(Mismatch(span.ledger, other))`.
+- `span.tip()` → reads ledger.Ancestor(end-1).
+- Compression invariant: "a non-root 0-tip node must have 0 or ≥2
+  children". Enforced in `Remove` via the same while-loop that merges
+  single-child chains up the tree.
+- `Insert` — exact three-suffix case analysis from rippled
+  (`prefix`/`oldSuffix`/`newSuffix`). Rewire parent pointers when old
+  suffix moves under the truncated prefix.
+- `GetPreferred` — within-span advancement over `seqSupport`, then
+  between-spans `partial_sort`(top 2 by branchSupport, tie-break
+  descending by `span.startID()`), descend while `margin > uncommitted`
+  or `uncommitted == 0`.
+
+`seqSupport` uses a `map[uint32]uint32` plus a sorted `[]uint32` of
+keys so `GetPreferred` can walk in order without allocating. (Rippled
+relies on `std::map` ordered iteration; Go's map is unordered so we
+keep the key list sorted on insert/remove.)
+
+Partial_sort of two children: on ≥2 children, copy into a temp slice,
+use `sort.Slice` to fully sort (N ≥ 2 is small in practice; not
+worth a custom partial_sort). Primary key is `branchSupport DESC`;
+tie-break is `startID DESC` (lexicographic on [32]byte).
+
+### Integration with `ValidationTracker`
+
+Add two fields to `ValidationTracker`:
+
+```go
+ancestry LedgerAncestryProvider   // injected; may be nil
+trie     *ledgertrie.Trie         // nil when ancestry is nil
+```
+
+Where:
+
+```go
+// LedgerAncestryProvider resolves a LedgerID to a full Ledger
+// (with ancestry). Returns (nil, false) if the ledger's history
+// is unknown — e.g., validations arrive for ledgers we haven't
+// acquired yet.
+type LedgerAncestryProvider interface {
+    LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger, bool)
+}
+```
+
+- `Add(v *Validation)` — after the existing accept/stale checks, if
+  `trie != nil` and `ancestry.LedgerByID(v.LedgerID)` succeeds, and
+  the validator is trusted, call `trie.Insert(lgr, 1)`. Mirror
+  rippled's `updateTrie` which de-duplicates on (nodeID, ledgerID): we
+  remove the validator's *previous* trusted ledger before inserting
+  the new one. Store a `trieInserted map[NodeID]consensus.LedgerID` to
+  know what to remove.
+- `GetTrustedSupport(id)` — if `trie != nil` and ancestry resolves
+  `id`, return `trie.BranchSupport(lgr)`. Otherwise fall back to the
+  existing flat trusted count (so unit tests and nodes without an
+  ancestry provider still work).
+- New method `GetPreferred(largestIssued uint32) (consensus.LedgerID,
+  uint32, bool)` — thin wrapper around `trie.GetPreferred`; returns
+  `(id, seq, ok=false)` when the trie is empty or not wired.
+
+NegUNL filtering: the trie counts trusted inserts; validators on the
+negUNL are skipped at `Insert` time (same gate as
+`countTrustedExcludingNegUNLLocked`). This matches the existing
+post-filter semantics at the call site.
+
+### Updating `checkLedger` (engine.go:932-938)
+
+Keep the existing compare (`netSupport <= ourSupport`) — but now both
+sides come from `GetTrustedSupport` which consults the trie. No API
+change required at the call site.
+
+## Files to add
+
+- `internal/consensus/ledgertrie/trie.go` (core data structure)
+- `internal/consensus/ledgertrie/span.go` (Span + Node internals)
+- `internal/consensus/ledgertrie/testledger.go` (build-tag-free test
+  helper: `TestLedger` with stored ancestors, `Builder` with `h["abc"]`
+  string notation). Public so rcl tests can reuse it.
+- `internal/consensus/ledgertrie/trie_test.go` (parity tests below)
+
+## Files to modify
+
+- `internal/consensus/rcl/validations.go` — add
+  `LedgerAncestryProvider` field, insert into trie on `Add`, route
+  `GetTrustedSupport` through the trie with fallback, add
+  `GetPreferred`.
+- `internal/consensus/rcl/validations_test.go` — add a case that
+  exercises the trie branch (existing flat-count cases still pass).
+
+## Tests
+
+### Acceptance (required by issue)
+
+1. **`TestLedgerTrie_ParityTable`** — port the tuple-style tests from
+   `LedgerTrie_test.cpp` covering `insert`, `remove`, and simple
+   `tipSupport`/`branchSupport` assertions on small trees. Concretely,
+   port `testInsert`, `testRemove`, `testSupport`, and the
+   invariant-checking cases from the C++ file as sub-tests driven off
+   a table of (operation, ledger-string, expected state) tuples.
+2. **`TestGetPreferred_PrefersDeepestSharedAncestor`** — the motivating
+   scenario from the issue:
+
+   ```
+          /-> C       (1 trusted)
+     G -> B
+          \-> D -> E  (2 trusted at E)
+   ```
+
+   Flat count: C wins with 1 at exact hash (both D and E score 0 at
+   B's sibling), actually rippled's flat alias would pick E (2 >
+   other, but fails to compare at B's level). The trie picks B-through-D
+   at seq 3 because branchSupport(D) = 2 > branchSupport(C) = 1.
+3. **`TestGetPreferred_MinSeqRespected`** — when `largestIssued`
+   skips the seqSupport entries below it, `uncommitted` is seeded
+   from those entries so that ancient support cannot retroactively
+   swing preference. Ported from `testGetPreferred` lines 480-504.
+
+### Additional parity (not strictly required, but cheap)
+
+- `TestInsertCompressionAndSplit` — verifies oldSuffix split leaves
+  parent tipSupport=0 and children correctly rewired.
+- `TestRemoveCompaction` — verifies single-child merge on removal
+  (span.merge behaviour).
+- `TestCheckInvariantsStress` — 1000 random insert/remove ops, each
+  followed by `CheckInvariants()`.
+
+## Out of scope
+
+- WebSocket `path_find` subscription (separate issue).
+- Threading `largestIssued` through `Engine.checkLedger` — the current
+  approximation works off pairwise comparison; a future refactor can
+  switch to `GetPreferred` directly.
+- Populating a real `LedgerAncestryProvider` from the ledger
+  store/manager. For this PR the provider is an injectable interface;
+  default production construction passes `nil` (keeps flat-count
+  behaviour until the ancestry provider is wired in). A follow-up
+  can wire it to `internal/ledger/manager` — non-trivial because
+  validations may reference ledgers the local node has not yet
+  acquired.
+
+## Verification
+
+1. `go build ./...` clean.
+2. `go test ./internal/consensus/ledgertrie/... -count=1 -race`
+3. `go test ./internal/consensus/rcl/... -count=1 -race`
+4. `go test ./... -count=1` with no regression vs main (pre-existing
+   failures logged in `memory/MEMORY.md` remain).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,120 +1,52 @@
-# Ledger Persistence Recovery — Issue #126
+# Issue #268 — Full LedgerTrie `getPreferred`
 
-## Problem
+Replace the flat trusted-count approximation in `internal/consensus/rcl/validations.go`'s `GetTrustedSupport` with a faithful Go port of rippled's `LedgerTrie<Ledger>` (rippled/src/xrpld/consensus/LedgerTrie.h).
 
-Every restart unconditionally calls `genesis.Create()`, discarding all previously accepted ledger state. NodeStore (Pebble) and RelationalDB are written to but never read back. The infrastructure for recovery already exists in the codebase — only the orchestration is missing.
+Design lives in [`pr-ledgertrie.md`](./pr-ledgertrie.md). This file tracks execution.
 
-Reference: https://github.com/LeJamon/go-xrpl/issues/126
+## Plan
 
----
+### Phase 1 — Branch hygiene
+- [x] Save WIP modifications as patch
+- [x] Reset `feature/ledgertrie-268` to `origin/main` (cb373ac)
+- [x] Reapply patch with 3-way merge
+- [x] Resolve conflicts in `startup.go`, `engine.go`, `validations.go`
+- [x] Build clean from worktree
 
-## Rippled reference behavior
+### Phase 2 — Audit implementation vs rippled
+- [x] `Mismatch` (binary search) — matches rippled's `mismatch` (csf/impl/ledgers.cpp:57-83)
+- [x] `Insert` three-suffix case analysis — matches LedgerTrie.h:452-531
+- [x] `Remove` compaction loop — matches LedgerTrie.h:540-589
+- [x] `GetPreferred` within-span advancement + best-child + tie-break +1 margin — matches LedgerTrie.h:684-778
+- [x] `Span` helpers, `node` struct — matches `ledger_trie_detail` (LedgerTrie.h:75-269)
 
-rippled supports a `START_UP` enum with modes:
-- `FRESH` (CLI `--start`) — always wipe and create new genesis
-- `NETWORK` (default) — create genesis only if no ledger in DB
-- `LOAD` — require existing ledger, fail if absent
-- `LOAD_FILE`, `REPLAY` — advanced modes (out of scope)
+### Phase 3 — Test coverage
+- [x] Consolidate Insert/Remove/Support discrete tests into `TestLedgerTrie_ParityTable` with `t.Run` subtests
+- [x] `TestGetPreferred_PrefersDeepestSharedAncestor` (issue-required) — passes
+- [x] `TestGetPreferred_MinSeqRespected` (issue-required) — passes
+- [x] `TestLedgerTrie_Empty` (rippled testEmpty) — kept as top-level
+- [x] `TestLedgerTrie_RootRelated` (rippled testRootRelated) — kept as top-level
+- [x] `TestLedgerTrie_Stress_InvariantsHold` (rippled testStress) — kept as top-level
+- [x] `TestLedgerTrie_GetPreferred_*` (rippled testGetPreferred subscenarios) — kept as discrete tests
 
-See: `rippled/src/xrpld/app/main/Application.cpp:1270-1316`
+### Phase 4 — Integration + regression check
+- [x] `go build ./...` clean
+- [x] `go test ./internal/consensus/ledgertrie/... -count=1 -race` passes
+- [x] `go test ./internal/consensus/rcl/... -count=1 -race` passes
+- [ ] `go test ./... -count=1` — no new regressions vs baseline (in progress)
 
----
+### Phase 5 — Commit + PR
+- [ ] `feat(consensus/ledgertrie): port rippled LedgerTrie<Ledger>`
+- [ ] `feat(consensus/rcl): wire LedgerTrie into ValidationTracker`
+- [ ] `feat(consensus/rcl): expose LedgerTrie via Engine.SetLedgerAncestryProvider`
+- [ ] Push branch and open PR referencing #268
 
-## Implementation Plan
+## Out of scope
 
-### Step 1 — Add `StartupMode` config
+- Threading `largestIssued` through `Engine.checkLedger` — flat-pair compare still works.
+- WebSocket `path_find` subscription — separate issue.
+- Production-path coverage of the ancestry provider beyond `adaptor/startup.go` — wired to `ledgerSvc` already.
 
-- [ ] Define `StartupMode` type in `internal/ledger/service/` with values: `StartupFresh`, `StartupNormal`, `StartupLoad`
-- [ ] Add `StartupMode` field to `service.Config`
-- [ ] Add `--start` CLI flag to `internal/cli/server.go` (sets `StartupFresh`); default is `StartupNormal`
+## Review (filled in after Phase 5)
 
-### Step 2 — Implement `latestLedgerHash()` helper
-
-- [ ] In `internal/ledger/service/`, add `latestLedgerHash(ctx, relDB, nodeStore)` that:
-  - If RelationalDB is configured: query `GetLatestValidatedLedger()` → return its `Hash` field
-  - Else if NodeStore is configured: scan/iterate for `NodeLedger` entries to find the highest sequence
-  - Return `(hash [32]byte, found bool, err error)`
-
-> RelationalDB stores `LedgerInfo{Hash, Sequence, ...}` via `SaveValidatedLedger()`. The simplest recovery anchor is to ask it for the latest sequence+hash.
-
-### Step 3 — Implement `loadLedger()` in service
-
-- [ ] Add `loadLedger(ctx, hash [32]byte) (*Ledger, error)` to service:
-  1. Fetch header node from NodeStore: `nodeStore.Fetch(ctx, hash)` → `Node{Type: NodeLedger, Data: 161 bytes}`
-  2. Deserialize header: `header.DeserializeHeader(node.Data, true)` → `LedgerHeader`
-  3. Create `NodeStoreFamily` from the existing nodeStore: `shamap.NewNodeStoreFamily(nodeStore)`
-  4. Reconstruct state SHAMap: `shamap.NewFromRootHash(header.AccountHash, family, shamap.TypeState)`
-  5. Reconstruct tx SHAMap: `shamap.NewFromRootHash(header.TxHash, family, shamap.TypeTransaction)`
-  6. Assemble `Ledger` from header + both SHAMaps, mark as Validated
-
-> `shamap.NewFromRootHash()` already exists (shamap.go:121-157) and supports lazy-loading of children on demand via `Family.Fetch()` — no need to deserialize the entire tree upfront.
-
-### Step 4 — Update `Start()` to branch on startup mode
-
-- [ ] Modify `service.Start()` to:
-  ```
-  switch config.StartupMode:
-    case StartupFresh:
-      createGenesis()
-    case StartupNormal:
-      hash, found = latestLedgerHash()
-      if found: loadLedger(hash)
-      else: createGenesis()
-    case StartupLoad:
-      hash, found = latestLedgerHash()
-      if !found: return error("no existing ledger state found")
-      loadLedger(hash)
-  ```
-- [ ] After loading, set `genesisLedger`, `closedLedger`, `validatedLedger`, `openLedger` accordingly
-- [ ] Restore `ledgerHistory` with the recovered ledger (sequence → ledger)
-- [ ] Restore `fees` from the loaded ledger's fee SLE
-
-### Step 5 — Ensure SHAMap nodes are flushed on AcceptLedger
-
-- [ ] Verify that `AcceptLedger()` calls `FlushDirty()` on both SHAMaps and passes the batch to `NodeStoreFamily.StoreBatch()` before or alongside `persistLedger()`
-- [ ] If not wired, add the flush step in `persistToNodeStore()` before storing the header node
-
-> Currently `persistToNodeStore()` iterates leaves via `ForEach()` but may not flush inner SHAMap nodes. Inner nodes are required for `NewFromRootHash()` lazy-loading to work at recovery time.
-
-### Step 6 — RelationalDB: add `GetLatestValidatedLedger()`
-
-- [ ] Check if `storage/relationaldb/` already exposes a method to fetch the latest validated ledger by sequence
-- [ ] If not, add it to the `LedgerRepository` interface and implement for both PostgreSQL and SQLite backends
-
-### Step 7 — Tests
-
-- [ ] `TestStartupNormal_FreshDB`: no existing state → creates genesis (seq=1)
-- [ ] `TestStartupNormal_ExistingState`: persist N ledgers, restart with `StartupNormal` → resumes from seq=N
-- [ ] `TestStartupFresh_ExistingState`: persist N ledgers, restart with `StartupFresh` → resets to seq=1
-- [ ] `TestStartupLoad_NoState`: `StartupLoad` with empty DB → returns error
-- [ ] `TestStartupLoad_ExistingState`: persist N ledgers, `StartupLoad` → resumes from seq=N
-- [ ] `TestFeeRecovery`: fees are correctly restored from loaded ledger state SLE
-
----
-
-## Key files to touch
-
-| File | Change |
-|------|--------|
-| `internal/ledger/service/service.go` | Branch `Start()` on startup mode |
-| `internal/ledger/service/persistence.go` | Add SHAMap inner-node flush; ensure completeness |
-| `internal/ledger/service/recovery.go` (new) | `latestLedgerHash()` + `loadLedger()` |
-| `internal/cli/server.go` | Add `--start` flag, pass mode to service.Config |
-| `storage/relationaldb/` | Add `GetLatestValidatedLedger()` if missing |
-| `internal/testing/persistence/` (new) | Recovery integration tests |
-
----
-
-## Infrastructure already in place (no changes needed)
-
-- `shamap.NewFromRootHash()` — reconstructs SHAMap lazily from root hash + Family
-- `header.DeserializeHeader()` — parses 161-byte header binary
-- `nodestore.Database.Fetch()` — retrieves node by hash with caching
-- `shamap.NodeStoreFamily` — bridges SHAMap and NodeStore
-- `nodestore.Node{Type: NodeLedger}` — header stored by `persistToNodeStore()`
-
----
-
-## Review
-
-_To be filled after implementation._
+_TBD_


### PR DESCRIPTION
Closes #268.

## Summary
- Ports rippled's `LedgerTrie<Ledger>` (`src/xrpld/consensus/LedgerTrie.h`) to a new `internal/consensus/ledgertrie` package — compressed-ancestry trie with `tipSupport` + `branchSupport`, `Insert`/`Remove` with span splitting and single-child compaction, and a `GetPreferred(largestIssued)` that does within-span uncommitted-support advancement plus a top-2 partial-sort tie-break.
- Wires the trie into `ValidationTracker`: `GetTrustedSupport` now returns trie `branchSupport` (with a flat-count fallback when no ancestry provider is supplied). New `GetPreferred(largestIssued)` exposes the trie decision directly.
- `LedgerProvider` walks `ParentHash` via the local ledger service to reconstruct ancestry on demand, with a small LRU. Wired in production via `Engine.SetLedgerAncestryProvider` from `adaptor.NewFromConfig`.

## Why this matters
`GetTrustedSupport` previously counted trusted validations at the *exact* ledger ID. Under an overlapping-ancestor fork topology, a minority near-tip outpolled a majority-further-back branch that actually won network-wide — a catchup node could strand on a stale fork. The trie fixes this by rolling tip support up the ancestry chain.

## Tests (all required by the issue)
- `TestLedgerTrie_ParityTable` — table-driven port of rippled's `testInsert` / `testRemove` / `testSupport` as `t.Run` subtests.
- `TestGetPreferred_PrefersDeepestSharedAncestor` — the motivating fork scenario from #268.
- `TestGetPreferred_MinSeqRespected` — `largestIssued` seeds uncommitted support so ancient validations cannot retroactively swing preference.

Plus the full `testGetPreferred` ladder (10 sub-cases), `testEmpty`, `testRootRelated`, and a 2000-iteration random insert/remove stress that asserts `CheckInvariants` after every op. Integration tests cover the trie path through `ValidationTracker.Add` (deepest-shared-ancestor, newer-validation-replaces-old, negUNL exclusion, fallback when ancestry is nil).

## Out of scope
- Threading `largestIssued` through `Engine.checkLedger` — the existing pairwise compare is correct under the new branchSupport semantics.
- WebSocket `path_find` subscription (separate issue).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/consensus/ledgertrie/... -count=1 -race`
- [x] `go test ./internal/consensus/rcl/... -count=1 -race`
- [x] `./scripts/conformance-summary.sh` — no new regressions in consensus-touching suites