### PR TITLE
C4: remaining handshake headers (Instance-Cookie, Server-Domain, ledger hints, IP self-reports)

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -279,6 +279,9 @@ func runServer(cmd *cobra.Command, args []string) {
 
 	// Create HTTP JSON-RPC server with 30 second timeout
 	httpServer := rpc.NewServer(30 * time.Second)
+	if consensusComponents != nil && consensusComponents.Overlay != nil {
+		httpServer.SetPeerSource(consensusComponents.Overlay)
+	}
 
 	types.Services.SetDispatcher(httpServer)
 

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/consensus/adaptor"
 	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 	"github.com/LeJamon/goXRPLd/internal/rpc"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -223,14 +224,13 @@ func runServer(cmd *cobra.Command, args []string) {
 		overlay := consensusComponents.Overlay
 		consensusAdaptor := consensusComponents.Adaptor
 
-		// Closed-Ledger / Previous-Ledger handshake hints
-		// (Handshake.cpp:219-223).
-		overlay.SetLedgerHintProvider(func() ([32]byte, [32]byte, bool) {
+		// Closed-Ledger / Previous-Ledger hints (Handshake.cpp:219-223).
+		overlay.SetLedgerHintProvider(func() (peermanagement.LedgerHints, bool) {
 			cl := ledgerService.GetClosedLedger()
 			if cl == nil {
-				return [32]byte{}, [32]byte{}, false
+				return peermanagement.LedgerHints{}, false
 			}
-			return cl.Hash(), cl.ParentHash(), true
+			return peermanagement.LedgerHints{Closed: cl.Hash(), Parent: cl.ParentHash()}, true
 		})
 		ledgerAdapter.SetTxBroadcaster(func(txBlob []byte) {
 			txMsg := &message.Transaction{

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -222,6 +222,16 @@ func runServer(cmd *cobra.Command, args []string) {
 		// broadcast it to peers and add to the consensus pending pool.
 		overlay := consensusComponents.Overlay
 		consensusAdaptor := consensusComponents.Adaptor
+
+		// Closed-Ledger / Previous-Ledger handshake hints
+		// (Handshake.cpp:219-223).
+		overlay.SetLedgerHintProvider(func() ([32]byte, [32]byte, bool) {
+			cl := ledgerService.GetClosedLedger()
+			if cl == nil {
+				return [32]byte{}, [32]byte{}, false
+			}
+			return cl.Hash(), cl.ParentHash(), true
+		})
 		ledgerAdapter.SetTxBroadcaster(func(txBlob []byte) {
 			txMsg := &message.Transaction{
 				RawTransaction: txBlob,

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -284,12 +284,18 @@ func WithLocalValidatorPubKey(key []byte) Option {
 	}
 }
 
+// WithServerDomain sets the operator domain emitted in the
+// `Server-Domain` handshake header. An empty value suppresses the
+// header (matching rippled's behavior when no domain is configured).
 func WithServerDomain(domain string) Option {
 	return func(c *Config) {
 		c.ServerDomain = domain
 	}
 }
 
+// WithPublicIP sets the node's observed public address. Used to emit
+// the `Local-IP` handshake header and to validate the peer's
+// `Remote-IP` self-report. A nil or unspecified IP suppresses both.
 func WithPublicIP(ip net.IP) Option {
 	return func(c *Config) {
 		c.PublicIP = ip

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -2,6 +2,7 @@ package peermanagement
 
 import (
 	"errors"
+	"net"
 	"time"
 )
 
@@ -92,6 +93,12 @@ type Config struct {
 	// own proposals/validations on the RelayFromValidator path.
 	// Matches rippled PeerImp.cpp:2715-2721.
 	LocalValidatorPubKey []byte
+
+	// ServerDomain populates the Server-Domain header; "" suppresses it.
+	ServerDomain string
+	// PublicIP populates Local-IP and gates the Remote-IP consistency
+	// check; nil suppresses both.
+	PublicIP net.IP
 
 	// Clock function for testing
 	Clock func() time.Time
@@ -274,6 +281,18 @@ func WithLocalValidatorPubKey(key []byte) Option {
 		// Defensive copy so callers cannot mutate config state after
 		// construction.
 		c.LocalValidatorPubKey = append([]byte(nil), key...)
+	}
+}
+
+func WithServerDomain(domain string) Option {
+	return func(c *Config) {
+		c.ServerDomain = domain
+	}
+}
+
+func WithPublicIP(ip net.IP) Option {
+	return func(c *Config) {
+		c.PublicIP = ip
 	}
 }
 

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -5,8 +5,10 @@ import (
 	"crypto/sha512"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -36,6 +38,10 @@ const (
 	HeaderPreviousLedger   = "Previous-Ledger"
 	HeaderCrawl            = "Crawl"
 	HeaderUserAgent        = "User-Agent"
+	HeaderInstanceCookie   = "Instance-Cookie"
+	HeaderServerDomain     = "Server-Domain"
+	HeaderRemoteIP         = "Remote-IP"
+	HeaderLocalIP          = "Local-IP"
 )
 
 // Time constants.
@@ -63,6 +69,17 @@ type HandshakeConfig struct {
 	EnableCompression   bool
 	EnableVPReduceRelay bool
 	EnableTxReduceRelay bool
+
+	// InstanceCookie is emitted on every handshake; 0 suppresses it.
+	InstanceCookie uint64
+	// ServerDomain is the operator domain; empty suppresses the header.
+	ServerDomain string
+	// PublicIP is our observed public address; nil/unspecified suppresses
+	// Local-IP emission and disables the Remote-IP consistency check.
+	PublicIP net.IP
+	// LedgerHintProvider returns (closed, parent, ok). ok=false suppresses
+	// both Closed-Ledger and Previous-Ledger headers.
+	LedgerHintProvider func() (closed [32]byte, parent [32]byte, ok bool)
 }
 
 // DefaultHandshakeConfig returns default handshake configuration.
@@ -193,6 +210,12 @@ func WriteRawHandshakeRequest(w io.Writer, req *http.Request) error {
 	// like mtREPLAY_DELTA_REQ and mtPROOF_PATH_REQ. Mirrors rippled's
 	// makeHandshakeHeaders writing the same header on outbound.
 	writeHeader(HeaderProtocolCtl)
+	writeHeader(HeaderInstanceCookie)
+	writeHeader(HeaderServerDomain)
+	writeHeader(HeaderClosedLedger)
+	writeHeader(HeaderPreviousLedger)
+	writeHeader(HeaderRemoteIP)
+	writeHeader(HeaderLocalIP)
 	buf.WriteString("\r\n")
 	_, err := w.Write(buf.Bytes())
 	return err
@@ -245,6 +268,96 @@ func addHandshakeHeaders(h http.Header, id *Identity, sharedValue []byte, cfg Ha
 	); ctl != "" {
 		h.Set(HeaderProtocolCtl, ctl)
 	}
+
+	if cfg.InstanceCookie != 0 {
+		h.Set(HeaderInstanceCookie, strconv.FormatUint(cfg.InstanceCookie, 10))
+	}
+	if cfg.ServerDomain != "" {
+		h.Set(HeaderServerDomain, cfg.ServerDomain)
+	}
+	if cfg.LedgerHintProvider != nil {
+		if closed, parent, ok := cfg.LedgerHintProvider(); ok {
+			h.Set(HeaderClosedLedger, hex.EncodeToString(closed[:]))
+			h.Set(HeaderPreviousLedger, hex.EncodeToString(parent[:]))
+		}
+	}
+}
+
+// addAddressHeaders emits Remote-IP / Local-IP per Handshake.cpp:213-217.
+// Per-conn helper (peerRemote isn't available at HandshakeConfig time).
+func addAddressHeaders(h http.Header, cfg HandshakeConfig, peerRemote net.IP) {
+	if peerRemote != nil && isPublicIP(peerRemote) {
+		h.Set(HeaderRemoteIP, peerRemote.String())
+	}
+	if cfg.PublicIP != nil && !cfg.PublicIP.IsUnspecified() {
+		h.Set(HeaderLocalIP, cfg.PublicIP.String())
+	}
+}
+
+// isPublicIP is the Go equivalent of beast::IP::is_public.
+func isPublicIP(ip net.IP) bool {
+	if ip == nil || ip.IsUnspecified() {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsPrivate() {
+		return false
+	}
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return false
+	}
+	if ip.IsMulticast() {
+		return false
+	}
+	return true
+}
+
+// parseLedgerHashHeader: hex (rippled wire format) or 32-byte base64
+// fallback (PeerImp::run accepts both).
+func parseLedgerHashHeader(s string) ([32]byte, error) {
+	var out [32]byte
+	if len(s) == hex.EncodedLen(32) {
+		if _, err := hex.Decode(out[:], []byte(s)); err == nil {
+			return out, nil
+		}
+	}
+	if dec, err := base64.StdEncoding.DecodeString(s); err == nil && len(dec) == 32 {
+		copy(out[:], dec)
+		return out, nil
+	}
+	return out, fmt.Errorf("unrecognised ledger hash %q", s)
+}
+
+// isWellFormedDomain: subset of rippled's isProperlyFormedTomlDomain.
+// Length ≤253, label [A-Za-z0-9-]{1,63}, no leading/trailing hyphen.
+func isWellFormedDomain(s string) bool {
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	if strings.HasSuffix(s, ".") {
+		s = s[:len(s)-1]
+	}
+	if s == "" {
+		return false
+	}
+	for _, label := range strings.Split(s, ".") {
+		if len(label) == 0 || len(label) > 63 {
+			return false
+		}
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for i := 0; i < len(label); i++ {
+			c := label[i]
+			ok := (c >= 'A' && c <= 'Z') ||
+				(c >= 'a' && c <= 'z') ||
+				(c >= '0' && c <= '9') ||
+				c == '-'
+			if !ok {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // VerifyPeerHandshake validates the handshake headers and verifies the session signature.
@@ -667,6 +780,92 @@ func VerifyHandshakeHeadersNoSig(
 	}
 
 	return peerPubKey, nil
+}
+
+// HandshakeExtras carries the headers parsed by ParseHandshakeExtras.
+type HandshakeExtras struct {
+	InstanceCookie uint64
+	ServerDomain   string
+	ClosedLedger   [32]byte
+	PreviousLedger [32]byte
+	HasLedgerHints bool
+	RemoteIPSelf   string // peer's view of our public IP
+	LocalIPSelf    string // peer's view of their own public IP
+}
+
+// ParseHandshakeExtras parses the issue-#270 headers and applies
+// rippled's verifyHandshake checks: Server-Domain validity
+// (Handshake.cpp:235-239), Local-IP / Remote-IP consistency
+// (Handshake.cpp:325-359). Instance-Cookie is stored only — rippled
+// never compares it; self-connection stays pubkey-only at line 322.
+// Closed-Ledger / Previous-Ledger parse failures are tolerated (matches
+// PeerImp::run returning nullopt without aborting).
+// peerRemote == nil short-circuits the IP comparisons.
+func ParseHandshakeExtras(
+	headers http.Header,
+	localPublicIP net.IP,
+	peerRemote net.IP,
+) (HandshakeExtras, error) {
+	var out HandshakeExtras
+
+	if v := headers.Get(HeaderInstanceCookie); v != "" {
+		cookie, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			return out, fmt.Errorf("%w: malformed Instance-Cookie %q: %v",
+				ErrInvalidHandshake, v, err)
+		}
+		out.InstanceCookie = cookie
+	}
+
+	if v := headers.Get(HeaderServerDomain); v != "" {
+		if !isWellFormedDomain(v) {
+			return out, fmt.Errorf("%w: invalid Server-Domain %q",
+				ErrInvalidHandshake, v)
+		}
+		out.ServerDomain = v
+	}
+
+	if v := headers.Get(HeaderClosedLedger); v != "" {
+		if h, err := parseLedgerHashHeader(v); err == nil {
+			out.ClosedLedger = h
+			out.HasLedgerHints = true
+		}
+	}
+	if v := headers.Get(HeaderPreviousLedger); v != "" {
+		if h, err := parseLedgerHashHeader(v); err == nil {
+			out.PreviousLedger = h
+		}
+	}
+
+	if v := headers.Get(HeaderLocalIP); v != "" {
+		localReported := net.ParseIP(v)
+		if localReported == nil {
+			return out, fmt.Errorf("%w: invalid Local-IP %q",
+				ErrInvalidHandshake, v)
+		}
+		out.LocalIPSelf = localReported.String()
+		if peerRemote != nil && isPublicIP(peerRemote) && !peerRemote.Equal(localReported) {
+			return out, fmt.Errorf("%w: Incorrect Local-IP: %s instead of %s",
+				ErrInvalidHandshake, peerRemote.String(), localReported.String())
+		}
+	}
+
+	if v := headers.Get(HeaderRemoteIP); v != "" {
+		remoteReported := net.ParseIP(v)
+		if remoteReported == nil {
+			return out, fmt.Errorf("%w: invalid Remote-IP %q",
+				ErrInvalidHandshake, v)
+		}
+		out.RemoteIPSelf = remoteReported.String()
+		if peerRemote != nil && isPublicIP(peerRemote) &&
+			localPublicIP != nil && !localPublicIP.IsUnspecified() &&
+			!remoteReported.Equal(localPublicIP) {
+			return out, fmt.Errorf("%w: Incorrect Remote-IP: %s instead of %s",
+				ErrInvalidHandshake, localPublicIP.String(), remoteReported.String())
+		}
+	}
+
+	return out, nil
 }
 
 // MakeFeaturesRequestHeader creates the X-Protocol-Ctl header value for a request.

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -766,10 +766,10 @@ func PeerFeatureEnabled(headers http.Header, feature, value string, localEnabled
 //   - Public-Key header present and base58-parseable as a secp256k1
 //     node key (0xED ed25519 prefixes are rejected at parse time).
 //   - Self-connection: peer's Public-Key must differ from localPubKey.
-//   - Network-ID: must match localNetworkID exactly. Unlike the
-//     pre-R6.1 inbound code, a local NetworkID==0 still enforces that
-//     the peer either omits the header OR advertises 0; a testnet
-//     peer's Network-ID=1 is rejected even when we're on mainnet.
+//   - Network-ID: if the peer advertised it, must match localNetworkID
+//     exactly. A missing Network-ID is silently accepted regardless of
+//     localNetworkID, mirroring rippled (Handshake.cpp:241-250 only
+//     enters the comparison branch when the header is present).
 //   - Network-Time: if the peer advertised it, the skew must be
 //     within NetworkClockTolerance of local wall clock.
 //
@@ -801,11 +801,6 @@ func VerifyHandshakeHeadersNoSig(
 		if uint32(netID) != localNetworkID {
 			return nil, fmt.Errorf("%w: peer=%d local=%d", ErrNetworkMismatch, netID, localNetworkID)
 		}
-	} else if localNetworkID != 0 {
-		// Peer omitted Network-ID but we require a non-default
-		// network. Rippled rejects this symmetrically.
-		return nil, fmt.Errorf("%w: peer omitted Network-ID (local expects %d)",
-			ErrNetworkMismatch, localNetworkID)
 	}
 
 	if netTimeStr := headers.Get(HeaderNetworkTime); netTimeStr != "" {
@@ -825,14 +820,17 @@ func VerifyHandshakeHeadersNoSig(
 }
 
 // HandshakeExtras carries the headers parsed by ParseHandshakeExtras.
+// Closed-Ledger and Previous-Ledger track presence independently to
+// match rippled (PeerImp.cpp:198-201).
 type HandshakeExtras struct {
-	InstanceCookie uint64
-	ServerDomain   string
-	ClosedLedger   [32]byte
-	PreviousLedger [32]byte
-	HasLedgerHints bool
-	RemoteIPSelf   string // peer's view of our public IP
-	LocalIPSelf    string // peer's view of their own public IP
+	InstanceCookie    uint64
+	ServerDomain      string
+	ClosedLedger      [32]byte
+	PreviousLedger    [32]byte
+	HasClosedLedger   bool
+	HasPreviousLedger bool
+	RemoteIPSelf      string // peer's view of our public IP
+	LocalIPSelf       string // peer's view of their own public IP
 }
 
 // ValidateServerDomain enforces verifyHandshake's Server-Domain check
@@ -887,9 +885,8 @@ func ParseHandshakeExtras(
 				ErrInvalidHandshake, v, err)
 		}
 		out.ClosedLedger = h
-		out.HasLedgerHints = true
+		out.HasClosedLedger = true
 	}
-	var hasPrevious bool
 	if v := headers.Get(HeaderPreviousLedger); v != "" {
 		h, err := parseLedgerHashHeader(v)
 		if err != nil {
@@ -897,9 +894,9 @@ func ParseHandshakeExtras(
 				ErrInvalidHandshake, v, err)
 		}
 		out.PreviousLedger = h
-		hasPrevious = true
+		out.HasPreviousLedger = true
 	}
-	if hasPrevious && !out.HasLedgerHints {
+	if out.HasPreviousLedger && !out.HasClosedLedger {
 		return out, fmt.Errorf("%w: Previous-Ledger without Closed-Ledger",
 			ErrInvalidHandshake)
 	}

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -294,18 +294,13 @@ func addAddressHeaders(h http.Header, cfg HandshakeConfig, peerRemote net.IP) {
 	}
 }
 
-// isPublicIP is the Go equivalent of beast::IP::is_public.
+// isPublicIP mirrors beast::IP::is_public: !is_private && !is_multicast.
+// beast's is_private = RFC1918 + loopback. Link-local stays public.
 func isPublicIP(ip net.IP) bool {
 	if ip == nil || ip.IsUnspecified() {
 		return false
 	}
-	if ip.IsLoopback() || ip.IsPrivate() {
-		return false
-	}
-	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-		return false
-	}
-	if ip.IsMulticast() {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsMulticast() {
 		return false
 	}
 	return true
@@ -793,14 +788,10 @@ type HandshakeExtras struct {
 	LocalIPSelf    string // peer's view of their own public IP
 }
 
-// ParseHandshakeExtras parses the issue-#270 headers and applies
-// rippled's verifyHandshake checks: Server-Domain validity
-// (Handshake.cpp:235-239), Local-IP / Remote-IP consistency
-// (Handshake.cpp:325-359). Instance-Cookie is stored only — rippled
-// never compares it; self-connection stays pubkey-only at line 322.
-// Closed-Ledger / Previous-Ledger parse failures are tolerated (matches
-// PeerImp::run returning nullopt without aborting).
-// peerRemote == nil short-circuits the IP comparisons.
+// ParseHandshakeExtras enforces verifyHandshake (Server-Domain at 235-239,
+// Local-IP/Remote-IP at 325-359) and PeerImp::run (ledger-hash malformed
+// at 175-191, Previous-without-Closed at 193-194). Instance-Cookie is
+// stored only. peerRemote == nil disables the IP comparisons.
 func ParseHandshakeExtras(
 	headers http.Header,
 	localPublicIP net.IP,
@@ -826,15 +817,27 @@ func ParseHandshakeExtras(
 	}
 
 	if v := headers.Get(HeaderClosedLedger); v != "" {
-		if h, err := parseLedgerHashHeader(v); err == nil {
-			out.ClosedLedger = h
-			out.HasLedgerHints = true
+		h, err := parseLedgerHashHeader(v)
+		if err != nil {
+			return out, fmt.Errorf("%w: malformed Closed-Ledger %q: %v",
+				ErrInvalidHandshake, v, err)
 		}
+		out.ClosedLedger = h
+		out.HasLedgerHints = true
 	}
+	var hasPrevious bool
 	if v := headers.Get(HeaderPreviousLedger); v != "" {
-		if h, err := parseLedgerHashHeader(v); err == nil {
-			out.PreviousLedger = h
+		h, err := parseLedgerHashHeader(v)
+		if err != nil {
+			return out, fmt.Errorf("%w: malformed Previous-Ledger %q: %v",
+				ErrInvalidHandshake, v, err)
 		}
+		out.PreviousLedger = h
+		hasPrevious = true
+	}
+	if hasPrevious && !out.HasLedgerHints {
+		return out, fmt.Errorf("%w: Previous-Ledger without Closed-Ledger",
+			ErrInvalidHandshake)
 	}
 
 	if v := headers.Get(HeaderLocalIP); v != "" {

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -70,7 +70,9 @@ type HandshakeConfig struct {
 	EnableVPReduceRelay bool
 	EnableTxReduceRelay bool
 
-	// InstanceCookie is emitted on every handshake; 0 suppresses it.
+	// InstanceCookie is emitted on every handshake. Production wiring
+	// goes through Overlay where the value is generated non-zero;
+	// callers that build a HandshakeConfig directly own setting it.
 	InstanceCookie uint64
 	// ServerDomain is the operator domain; empty suppresses the header.
 	ServerDomain string
@@ -275,16 +277,16 @@ func addHandshakeHeaders(h http.Header, id *Identity, sharedValue []byte, cfg Ha
 		h.Set(HeaderProtocolCtl, ctl)
 	}
 
-	if cfg.InstanceCookie != 0 {
-		h.Set(HeaderInstanceCookie, strconv.FormatUint(cfg.InstanceCookie, 10))
-	}
+	// Always emitted (rippled Handshake.cpp:208).
+	h.Set(HeaderInstanceCookie, strconv.FormatUint(cfg.InstanceCookie, 10))
 	if cfg.ServerDomain != "" {
 		h.Set(HeaderServerDomain, cfg.ServerDomain)
 	}
 	if cfg.LedgerHintProvider != nil {
 		if hints, ok := cfg.LedgerHintProvider(); ok {
-			h.Set(HeaderClosedLedger, hex.EncodeToString(hints.Closed[:]))
-			h.Set(HeaderPreviousLedger, hex.EncodeToString(hints.Parent[:]))
+			// Uppercase to match rippled's strHex.
+			h.Set(HeaderClosedLedger, strings.ToUpper(hex.EncodeToString(hints.Closed[:])))
+			h.Set(HeaderPreviousLedger, strings.ToUpper(hex.EncodeToString(hints.Parent[:])))
 		}
 	}
 }
@@ -298,6 +300,37 @@ func addAddressHeaders(h http.Header, cfg HandshakeConfig, peerRemote net.IP) {
 	if cfg.PublicIP != nil && !cfg.PublicIP.IsUnspecified() {
 		h.Set(HeaderLocalIP, cfg.PublicIP.String())
 	}
+}
+
+// ipFamilyEqual compares two IPs taking address family into account
+// (v4 vs v6) to mirror boost::asio::ip::address::operator==, which
+// treats ::ffff:1.2.3.4 and 1.2.3.4 as distinct because their family
+// differs. Go's net.IP.Equal is family-agnostic and would equate them.
+//
+// Heuristic: a 4-byte slice or a v4-mapped 16-byte slice is "v4". Any
+// other 16-byte slice is "v6". headerIPv6Form lets the caller pass the
+// original textual form so a header value like "::ffff:1.2.3.4" stays
+// classified as v6 even after net.ParseIP normalises it to the same
+// bytes as "1.2.3.4".
+func ipFamilyEqual(a, b net.IP, aIsV6Text, bIsV6Text bool) bool {
+	if ipFamilyV4(a, aIsV6Text) != ipFamilyV4(b, bIsV6Text) {
+		return false
+	}
+	return a.Equal(b)
+}
+
+func ipFamilyV4(ip net.IP, isV6Text bool) bool {
+	if isV6Text {
+		return false
+	}
+	return ip.To4() != nil
+}
+
+// isIPv6Text returns true when s is written in IPv6 textual form
+// (contains a colon). Used to distinguish "::ffff:1.2.3.4" from
+// "1.2.3.4" since net.ParseIP normalises both to the same bytes.
+func isIPv6Text(s string) bool {
+	return strings.Contains(s, ":")
 }
 
 // isPublicIP mirrors beast::IP::is_public: !is_private && !is_multicast.
@@ -802,10 +835,29 @@ type HandshakeExtras struct {
 	LocalIPSelf    string // peer's view of their own public IP
 }
 
-// ParseHandshakeExtras enforces verifyHandshake (Server-Domain at 235-239,
-// Local-IP/Remote-IP at 325-359) and PeerImp::run (ledger-hash malformed
-// at 175-191, Previous-without-Closed at 193-194). Instance-Cookie is
-// stored only. peerRemote == nil disables the IP comparisons.
+// ValidateServerDomain enforces verifyHandshake's Server-Domain check
+// (Handshake.cpp:235-239). Run BEFORE VerifyHandshakeHeadersNoSig to
+// match rippled's verify order (Server-Domain → Network-ID →
+// Network-Time → Public-Key → ...).
+func ValidateServerDomain(headers http.Header) (string, error) {
+	v := headers.Get(HeaderServerDomain)
+	if v == "" {
+		return "", nil
+	}
+	if !isWellFormedDomain(v) {
+		return "", fmt.Errorf("%w: invalid Server-Domain %q",
+			ErrInvalidHandshake, v)
+	}
+	return v, nil
+}
+
+// ParseHandshakeExtras enforces the post-signature checks: ledger-hash
+// malformed (PeerImp.cpp:175-191), Previous-without-Closed
+// (PeerImp.cpp:193-194), Local-IP / Remote-IP consistency
+// (Handshake.cpp:325-359). Instance-Cookie is stored only.
+// Server-Domain is handled separately by ValidateServerDomain (which
+// must run first to match rippled's order). peerRemote == nil
+// disables the IP comparisons.
 func ParseHandshakeExtras(
 	headers http.Header,
 	localPublicIP net.IP,
@@ -822,11 +874,9 @@ func ParseHandshakeExtras(
 		out.InstanceCookie = cookie
 	}
 
+	// Server-Domain is validated upstream by ValidateServerDomain
+	// (rippled order); we just surface the value here.
 	if v := headers.Get(HeaderServerDomain); v != "" {
-		if !isWellFormedDomain(v) {
-			return out, fmt.Errorf("%w: invalid Server-Domain %q",
-				ErrInvalidHandshake, v)
-		}
 		out.ServerDomain = v
 	}
 
@@ -861,7 +911,8 @@ func ParseHandshakeExtras(
 				ErrInvalidHandshake, v)
 		}
 		out.LocalIPSelf = localReported.String()
-		if peerRemote != nil && isPublicIP(peerRemote) && !peerRemote.Equal(localReported) {
+		if peerRemote != nil && isPublicIP(peerRemote) &&
+			!ipFamilyEqual(peerRemote, localReported, false, isIPv6Text(v)) {
 			return out, fmt.Errorf("%w: Incorrect Local-IP: %s instead of %s",
 				ErrInvalidHandshake, peerRemote.String(), localReported.String())
 		}
@@ -876,7 +927,7 @@ func ParseHandshakeExtras(
 		out.RemoteIPSelf = remoteReported.String()
 		if peerRemote != nil && isPublicIP(peerRemote) &&
 			localPublicIP != nil && !localPublicIP.IsUnspecified() &&
-			!remoteReported.Equal(localPublicIP) {
+			!ipFamilyEqual(remoteReported, localPublicIP, isIPv6Text(v), false) {
 			return out, fmt.Errorf("%w: Incorrect Remote-IP: %s instead of %s",
 				ErrInvalidHandshake, localPublicIP.String(), remoteReported.String())
 		}

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -77,9 +77,15 @@ type HandshakeConfig struct {
 	// PublicIP is our observed public address; nil/unspecified suppresses
 	// Local-IP emission and disables the Remote-IP consistency check.
 	PublicIP net.IP
-	// LedgerHintProvider returns (closed, parent, ok). ok=false suppresses
-	// both Closed-Ledger and Previous-Ledger headers.
-	LedgerHintProvider func() (closed [32]byte, parent [32]byte, ok bool)
+	// LedgerHintProvider returns (hints, ok). ok=false suppresses both
+	// Closed-Ledger and Previous-Ledger headers.
+	LedgerHintProvider func() (hints LedgerHints, ok bool)
+}
+
+// LedgerHints is the (closed, parent) pair for the ledger hints.
+type LedgerHints struct {
+	Closed [32]byte
+	Parent [32]byte
 }
 
 // DefaultHandshakeConfig returns default handshake configuration.
@@ -276,9 +282,9 @@ func addHandshakeHeaders(h http.Header, id *Identity, sharedValue []byte, cfg Ha
 		h.Set(HeaderServerDomain, cfg.ServerDomain)
 	}
 	if cfg.LedgerHintProvider != nil {
-		if closed, parent, ok := cfg.LedgerHintProvider(); ok {
-			h.Set(HeaderClosedLedger, hex.EncodeToString(closed[:]))
-			h.Set(HeaderPreviousLedger, hex.EncodeToString(parent[:]))
+		if hints, ok := cfg.LedgerHintProvider(); ok {
+			h.Set(HeaderClosedLedger, hex.EncodeToString(hints.Closed[:]))
+			h.Set(HeaderPreviousLedger, hex.EncodeToString(hints.Parent[:]))
 		}
 	}
 }
@@ -322,20 +328,28 @@ func parseLedgerHashHeader(s string) ([32]byte, error) {
 	return out, fmt.Errorf("unrecognised ledger hash %q", s)
 }
 
-// isWellFormedDomain: subset of rippled's isProperlyFormedTomlDomain.
-// Length ≤253, label [A-Za-z0-9-]{1,63}, no leading/trailing hyphen.
+// isWellFormedDomain ports rippled's isProperlyFormedTomlDomain
+// (StringUtilities.cpp:131-156).
 func isWellFormedDomain(s string) bool {
-	if s == "" || len(s) > 253 {
+	if len(s) < 4 || len(s) > 128 {
 		return false
 	}
-	if strings.HasSuffix(s, ".") {
-		s = s[:len(s)-1]
-	}
-	if s == "" {
+	labels := strings.Split(s, ".")
+	if len(labels) < 2 {
 		return false
 	}
-	for _, label := range strings.Split(s, ".") {
-		if len(label) == 0 || len(label) > 63 {
+	tld := labels[len(labels)-1]
+	if len(tld) < 2 || len(tld) > 63 {
+		return false
+	}
+	for i := 0; i < len(tld); i++ {
+		c := tld[i]
+		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+			return false
+		}
+	}
+	for _, label := range labels[:len(labels)-1] {
+		if len(label) < 1 || len(label) > 63 {
 			return false
 		}
 		if label[0] == '-' || label[len(label)-1] == '-' {

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -334,12 +334,19 @@ func isIPv6Text(s string) bool {
 }
 
 // isPublicIP mirrors beast::IP::is_public: !is_private && !is_multicast.
-// beast's is_private = RFC1918 + loopback. Link-local stays public.
+// IPv4 is_private = RFC1918 + loopback (link-local stays public, matching
+// IPAddressV4.cpp). IPv6 is_private also catches link-local (fe80::/10):
+// rippled IPAddressV6.cpp flags these via `(addr.to_bytes()[0] & 0xfd)`,
+// and Go's IsPrivate doesn't include link-local, so we add it explicitly
+// for v6 only.
 func isPublicIP(ip net.IP) bool {
 	if ip == nil || ip.IsUnspecified() {
 		return false
 	}
 	if ip.IsLoopback() || ip.IsPrivate() || ip.IsMulticast() {
+		return false
+	}
+	if ip.To4() == nil && ip.IsLinkLocalUnicast() {
 		return false
 	}
 	return true
@@ -766,10 +773,12 @@ func PeerFeatureEnabled(headers http.Header, feature, value string, localEnabled
 //   - Public-Key header present and base58-parseable as a secp256k1
 //     node key (0xED ed25519 prefixes are rejected at parse time).
 //   - Self-connection: peer's Public-Key must differ from localPubKey.
-//   - Network-ID: if the peer advertised it, must match localNetworkID
-//     exactly. A missing Network-ID is silently accepted regardless of
-//     localNetworkID, mirroring rippled (Handshake.cpp:241-250 only
-//     enters the comparison branch when the header is present).
+//   - Network-ID: if the peer advertised it AND we have a non-zero
+//     localNetworkID, the values must match exactly. localNetworkID==0
+//     means "unconfigured" (rippled's `networkID = std::nullopt`) and
+//     skips the comparison — Handshake.cpp:241-250 only throws inside
+//     `if (networkID && nid != *networkID)`. A missing Network-ID is
+//     also accepted regardless of local config.
 //   - Network-Time: if the peer advertised it, the skew must be
 //     within NetworkClockTolerance of local wall clock.
 //
@@ -798,7 +807,7 @@ func VerifyHandshakeHeadersNoSig(
 		if err != nil {
 			return nil, fmt.Errorf("malformed Network-ID %q: %w", netIDStr, err)
 		}
-		if uint32(netID) != localNetworkID {
+		if localNetworkID != 0 && uint32(netID) != localNetworkID {
 			return nil, fmt.Errorf("%w: peer=%d local=%d", ErrNetworkMismatch, netID, localNetworkID)
 		}
 	}
@@ -820,17 +829,18 @@ func VerifyHandshakeHeadersNoSig(
 }
 
 // HandshakeExtras carries the headers parsed by ParseHandshakeExtras.
+// Strict rippled parity: only the headers that rippled stores typed on
+// PeerImp survive here. Instance-Cookie is emitted on the wire but
+// never parsed/stored (rippled keeps it in its untyped headers_ map and
+// never reads it). Local-IP / Remote-IP are validated and discarded.
 // Closed-Ledger and Previous-Ledger track presence independently to
 // match rippled (PeerImp.cpp:198-201).
 type HandshakeExtras struct {
-	InstanceCookie    uint64
 	ServerDomain      string
 	ClosedLedger      [32]byte
 	PreviousLedger    [32]byte
 	HasClosedLedger   bool
 	HasPreviousLedger bool
-	RemoteIPSelf      string // peer's view of our public IP
-	LocalIPSelf       string // peer's view of their own public IP
 }
 
 // ValidateServerDomain enforces verifyHandshake's Server-Domain check
@@ -852,25 +862,17 @@ func ValidateServerDomain(headers http.Header) (string, error) {
 // ParseHandshakeExtras enforces the post-signature checks: ledger-hash
 // malformed (PeerImp.cpp:175-191), Previous-without-Closed
 // (PeerImp.cpp:193-194), Local-IP / Remote-IP consistency
-// (Handshake.cpp:325-359). Instance-Cookie is stored only.
-// Server-Domain is handled separately by ValidateServerDomain (which
-// must run first to match rippled's order). peerRemote == nil
-// disables the IP comparisons.
+// (Handshake.cpp:325-359). Server-Domain is validated separately by
+// ValidateServerDomain (which must run first to match rippled's order).
+// Instance-Cookie is emitted on the wire but never parsed (rippled's
+// verifyHandshake doesn't inspect it). peerRemote == nil disables the
+// IP comparisons.
 func ParseHandshakeExtras(
 	headers http.Header,
 	localPublicIP net.IP,
 	peerRemote net.IP,
 ) (HandshakeExtras, error) {
 	var out HandshakeExtras
-
-	if v := headers.Get(HeaderInstanceCookie); v != "" {
-		cookie, err := strconv.ParseUint(v, 10, 64)
-		if err != nil {
-			return out, fmt.Errorf("%w: malformed Instance-Cookie %q: %v",
-				ErrInvalidHandshake, v, err)
-		}
-		out.InstanceCookie = cookie
-	}
 
 	// Server-Domain is validated upstream by ValidateServerDomain
 	// (rippled order); we just surface the value here.
@@ -901,13 +903,14 @@ func ParseHandshakeExtras(
 			ErrInvalidHandshake)
 	}
 
+	// Local-IP / Remote-IP: validate per Handshake.cpp:325-359 and
+	// discard. Rippled doesn't store the parsed values on PeerImp.
 	if v := headers.Get(HeaderLocalIP); v != "" {
 		localReported := net.ParseIP(v)
 		if localReported == nil {
 			return out, fmt.Errorf("%w: invalid Local-IP %q",
 				ErrInvalidHandshake, v)
 		}
-		out.LocalIPSelf = localReported.String()
 		if peerRemote != nil && isPublicIP(peerRemote) &&
 			!ipFamilyEqual(peerRemote, localReported, false, isIPv6Text(v)) {
 			return out, fmt.Errorf("%w: Incorrect Local-IP: %s instead of %s",
@@ -921,7 +924,6 @@ func ParseHandshakeExtras(
 			return out, fmt.Errorf("%w: invalid Remote-IP %q",
 				ErrInvalidHandshake, v)
 		}
-		out.RemoteIPSelf = remoteReported.String()
 		if peerRemote != nil && isPublicIP(peerRemote) &&
 			localPublicIP != nil && !localPublicIP.IsUnspecified() &&
 			!ipFamilyEqual(remoteReported, localPublicIP, isIPv6Text(v), false) {

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -410,21 +410,9 @@ func isWellFormedDomain(s string) bool {
 }
 
 // VerifyPeerHandshake validates the handshake headers and verifies the session signature.
+// Check order mirrors rippled's verifyHandshake (Handshake.cpp:227-362):
+// Network-ID → Network-Time → Public-Key → Session-Signature → self-connection.
 func VerifyPeerHandshake(headers http.Header, sharedValue []byte, localPubKey string, cfg HandshakeConfig) (*PublicKeyToken, error) {
-	pubKeyStr := headers.Get(HeaderPublicKey)
-	if pubKeyStr == "" {
-		return nil, fmt.Errorf("%w: missing %s", ErrInvalidHandshake, HeaderPublicKey)
-	}
-
-	pubKey, err := ParsePublicKeyToken(pubKeyStr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid public key: %w", err)
-	}
-
-	if pubKeyStr == localPubKey {
-		return nil, ErrSelfConnection
-	}
-
 	if netIDStr := headers.Get(HeaderNetworkID); netIDStr != "" {
 		netID, err := strconv.ParseUint(netIDStr, 10, 32)
 		if err != nil {
@@ -451,6 +439,16 @@ func VerifyPeerHandshake(headers http.Header, sharedValue []byte, localPubKey st
 		}
 	}
 
+	pubKeyStr := headers.Get(HeaderPublicKey)
+	if pubKeyStr == "" {
+		return nil, fmt.Errorf("%w: missing %s", ErrInvalidHandshake, HeaderPublicKey)
+	}
+
+	pubKey, err := ParsePublicKeyToken(pubKeyStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key: %w", err)
+	}
+
 	sigStr := headers.Get(HeaderSessionSignature)
 	if sigStr == "" {
 		return nil, fmt.Errorf("%w: missing %s", ErrInvalidHandshake, HeaderSessionSignature)
@@ -463,6 +461,10 @@ func VerifyPeerHandshake(headers http.Header, sharedValue []byte, localPubKey st
 
 	if err := verifySessionSignature(pubKey, sharedValue, sigBytes); err != nil {
 		return nil, err
+	}
+
+	if pubKeyStr == localPubKey {
+		return nil, ErrSelfConnection
 	}
 
 	return pubKey, nil

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -1191,6 +1191,14 @@ func TestPeerFeatureEnabled(t *testing.T) {
 	}
 }
 
+// newTestOverlayWithPeers returns a partially-initialised Overlay
+// whose only valid surface is the peers map + peersMu — enough to
+// drive PeersWithClosedLedger / PeersJSON in tests that don't need a
+// running overlay.
+func newTestOverlayWithPeers(peers map[PeerID]*Peer) *Overlay {
+	return &Overlay{peers: peers}
+}
+
 // buildAllHeadersRequest builds a handshake request with every issue-#270
 // header set. peerRemote drives Remote-IP / Local-IP emission.
 func buildAllHeadersRequest(t *testing.T, id *Identity, cfg HandshakeConfig, peerRemote net.IP) http.Header {
@@ -1258,8 +1266,8 @@ func TestHandshake_ClosedLedgerHint_ReadableAfterHandshake(t *testing.T) {
 	}
 
 	headers := buildAllHeadersRequest(t, id, cfg, nil)
-	require.Equal(t, hex.EncodeToString(closed[:]), headers.Get(HeaderClosedLedger))
-	require.Equal(t, hex.EncodeToString(parent[:]), headers.Get(HeaderPreviousLedger))
+	require.Equal(t, strings.ToUpper(hex.EncodeToString(closed[:])), headers.Get(HeaderClosedLedger))
+	require.Equal(t, strings.ToUpper(hex.EncodeToString(parent[:])), headers.Get(HeaderPreviousLedger))
 
 	extras, err := ParseHandshakeExtras(headers, nil, nil)
 	require.NoError(t, err)
@@ -1361,8 +1369,8 @@ func TestHandshake_AllHeaders_RoundTrip(t *testing.T) {
 		// Wire-level checks: each header is present in the right form.
 		assert.Equal(t, strconv.FormatUint(senderCfg.InstanceCookie, 10), headers.Get(HeaderInstanceCookie))
 		assert.Equal(t, "validator.example.com", headers.Get(HeaderServerDomain))
-		assert.Equal(t, hex.EncodeToString(closed[:]), headers.Get(HeaderClosedLedger))
-		assert.Equal(t, hex.EncodeToString(parent[:]), headers.Get(HeaderPreviousLedger))
+		assert.Equal(t, strings.ToUpper(hex.EncodeToString(closed[:])), headers.Get(HeaderClosedLedger))
+		assert.Equal(t, strings.ToUpper(hex.EncodeToString(parent[:])), headers.Get(HeaderPreviousLedger))
 		assert.Equal(t, pB.String(), headers.Get(HeaderRemoteIP))
 		assert.Equal(t, pA.String(), headers.Get(HeaderLocalIP))
 
@@ -1396,8 +1404,8 @@ func TestHandshake_AllHeaders_RoundTrip(t *testing.T) {
 		// rippled-style consistency contract on us either.
 		assert.Equal(t, strconv.FormatUint(senderCfg.InstanceCookie, 10), resp.Header.Get(HeaderInstanceCookie))
 		assert.Equal(t, "validator.example.com", resp.Header.Get(HeaderServerDomain))
-		assert.Equal(t, hex.EncodeToString(closed[:]), resp.Header.Get(HeaderClosedLedger))
-		assert.Equal(t, hex.EncodeToString(parent[:]), resp.Header.Get(HeaderPreviousLedger))
+		assert.Equal(t, strings.ToUpper(hex.EncodeToString(closed[:])), resp.Header.Get(HeaderClosedLedger))
+		assert.Equal(t, strings.ToUpper(hex.EncodeToString(parent[:])), resp.Header.Get(HeaderPreviousLedger))
 		assert.Equal(t, pB.String(), resp.Header.Get(HeaderRemoteIP))
 		assert.Equal(t, pA.String(), resp.Header.Get(HeaderLocalIP))
 
@@ -1409,12 +1417,13 @@ func TestHandshake_AllHeaders_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("malformed_server_domain_rejected", func(t *testing.T) {
-		// Mutate just the Server-Domain field to verify the parser
-		// rejects malformed values per Handshake.cpp:235-239.
+		// Server-Domain is the first thing rippled validates
+		// (Handshake.cpp:235-239), so the dedicated validator runs
+		// upstream of ParseHandshakeExtras.
 		headers := buildAllHeadersRequest(t, id, senderCfg, pB)
 		headers.Set(HeaderServerDomain, "-bad.example.com") // leading hyphen
 
-		_, err := ParseHandshakeExtras(headers, pB, pA)
+		_, err := ValidateServerDomain(headers)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid Server-Domain")
 	})
@@ -1445,16 +1454,17 @@ func TestLedgerSync_PreferredPeersForLedger_ConsumesClosedLedgerHint(t *testing.
 		return p
 	}
 
-	overlay := &Overlay{peers: map[PeerID]*Peer{}}
-	overlay.peers[1] = mkPeer(1, &target)             // matches → expected
-	other := [32]byte{0xAA}
-	overlay.peers[2] = mkPeer(2, &other)              // different hint → filtered
-	overlay.peers[3] = mkPeer(3, nil)                 // no hint → filtered
-	overlay.peers[4] = mkPeer(4, &target)             // matches → expected
-	overlay.peers[5] = NewPeer(5, Endpoint{}, false, id, nil)
-	// peer 5 left disconnected with matching hint to verify state filter
-	overlay.peers[5].applyHandshakeExtras(HandshakeExtras{
-		ClosedLedger: target, HasLedgerHints: true,
+	overlay := newTestOverlayWithPeers(map[PeerID]*Peer{
+		1: mkPeer(1, &target), // matches → expected
+		2: mkPeer(2, &[32]byte{0xAA}), // different hint → filtered
+		3: mkPeer(3, nil),     // no hint → filtered
+		4: mkPeer(4, &target), // matches → expected
+		// peer 5: disconnected with matching hint → filtered by state.
+		5: func() *Peer {
+			p := NewPeer(5, Endpoint{}, false, id, nil)
+			p.applyHandshakeExtras(HandshakeExtras{ClosedLedger: target, HasLedgerHints: true})
+			return p
+		}(),
 	})
 
 	got := overlay.PeersWithClosedLedger(target)
@@ -1547,6 +1557,22 @@ func TestIsPublicIP_BeastParity(t *testing.T) {
 	}
 }
 
+// ipFamilyEqual must match boost::asio::ip::address::operator==:
+// "::ffff:1.2.3.4" (v6 textual form) and "1.2.3.4" (v4 textual form)
+// are treated as different addresses despite normalising to the same
+// bytes via net.ParseIP.
+func TestIpFamilyEqual_BoostParity(t *testing.T) {
+	v4 := net.ParseIP("1.2.3.4")
+	v4mapped := net.ParseIP("::ffff:1.2.3.4")
+	require.NotNil(t, v4)
+	require.NotNil(t, v4mapped)
+
+	assert.True(t, ipFamilyEqual(v4, v4, false, false), "same v4 must be equal")
+	assert.False(t, ipFamilyEqual(v4, v4mapped, false, true), "v4 vs v4-mapped-v6 must differ")
+	assert.False(t, ipFamilyEqual(v4mapped, v4, true, false), "v4-mapped-v6 vs v4 must differ")
+	assert.True(t, ipFamilyEqual(v4mapped, v4mapped, true, true), "same v4-mapped-v6 must be equal")
+}
+
 // isWellFormedDomain matches rippled's isProperlyFormedTomlDomain
 // (StringUtilities.cpp:131-156).
 func TestIsWellFormedDomain_TomlParity(t *testing.T) {
@@ -1605,8 +1631,8 @@ func TestWriteRawHandshakeRequest_EmitsAllNewHeaders(t *testing.T) {
 	for _, h := range []string{
 		HeaderInstanceCookie + ": ",
 		HeaderServerDomain + ": example.com",
-		HeaderClosedLedger + ": " + hex.EncodeToString(closed[:]),
-		HeaderPreviousLedger + ": " + hex.EncodeToString(parent[:]),
+		HeaderClosedLedger + ": " + strings.ToUpper(hex.EncodeToString(closed[:])),
+		HeaderPreviousLedger + ": " + strings.ToUpper(hex.EncodeToString(parent[:])),
 		HeaderRemoteIP + ": 203.0.113.5",
 		HeaderLocalIP + ": 198.51.100.10",
 	} {

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -270,13 +270,26 @@ func TestVerifyHandshakeHeadersNoSig(t *testing.T) {
 		assert.Equal(t, remoteId.EncodedPublicKey(), pk.Encode())
 	})
 
-	t.Run("mainnet_rejects_nonzero_networkid", func(t *testing.T) {
-		// Pre-R6.1: mainnet (NetworkID=0) silently accepted any
-		// Network-ID the peer advertised. Now we reject.
+	t.Run("unconfigured_local_accepts_any_peer_networkid", func(t *testing.T) {
+		// localNetworkID=0 means "unconfigured" (rippled
+		// `networkID = std::nullopt`). Handshake.cpp:241-250 only
+		// throws inside `if (networkID && nid != *networkID)`, so
+		// any peer-advertised Network-ID is accepted when we have
+		// no local config.
 		h := mkHeaders(remoteId.EncodedPublicKey(), "1", xrplNow())
 		_, err := VerifyHandshakeHeadersNoSig(h, localId.EncodedPublicKey(), 0)
+		require.NoError(t, err,
+			"unconfigured local Network-ID must accept any peer Network-ID to mirror rippled")
+	})
+
+	t.Run("configured_local_rejects_mismatched_peer_networkid", func(t *testing.T) {
+		// With a non-zero local Network-ID, a peer advertising a
+		// different Network-ID is rejected — rippled's
+		// `networkID && nid != *networkID` enters and throws.
+		h := mkHeaders(remoteId.EncodedPublicKey(), "1", xrplNow())
+		_, err := VerifyHandshakeHeadersNoSig(h, localId.EncodedPublicKey(), 2)
 		assert.ErrorIs(t, err, ErrNetworkMismatch,
-			"mainnet must reject a peer advertising Network-ID=1 (testnet)")
+			"configured local Network-ID=2 must reject peer advertising Network-ID=1")
 	})
 
 	t.Run("non_default_network_peer_missing_netid", func(t *testing.T) {
@@ -1232,12 +1245,11 @@ func TestHandshake_InstanceCookie_DetectsSelfConnection(t *testing.T) {
 	headers := buildAllHeadersRequest(t, id, cfg, nil)
 	require.Equal(t, strconv.FormatUint(cookie, 10), headers.Get(HeaderInstanceCookie))
 
-	// Round-trip: cookie parsed and surfaced on extras even when the
-	// "local" view shares the same nonce. Strict rippled parity — no
-	// cookie comparison happens.
-	extras, err := ParseHandshakeExtras(headers, nil, nil)
+	// Strict rippled parity: the cookie is on the wire (Handshake.cpp:208)
+	// but verifyHandshake never inspects it. ParseHandshakeExtras must
+	// not fail on it and must not surface a typed value.
+	_, err = ParseHandshakeExtras(headers, nil, nil)
 	require.NoError(t, err)
-	assert.Equal(t, cookie, extras.InstanceCookie)
 
 	// The rippled-canonical self-connection signal is pubkey identity
 	// (Handshake.cpp:322 publicKey == app.nodeIdentity().first). Verify
@@ -1337,9 +1349,8 @@ func TestHandshake_RemoteIPSelfReported_MatchesTcpConn(t *testing.T) {
 		headers := buildAllHeadersRequest(t, id, cfg, publicIP)
 		require.Equal(t, "198.51.100.1", headers.Get(HeaderRemoteIP))
 
-		extras, err := ParseHandshakeExtras(headers, publicIP, publicIP)
+		_, err := ParseHandshakeExtras(headers, publicIP, publicIP)
 		require.NoError(t, err)
-		assert.Equal(t, "198.51.100.1", extras.RemoteIPSelf)
 	})
 
 	t.Run("mismatched_public_ip_rejected", func(t *testing.T) {
@@ -1360,9 +1371,8 @@ func TestHandshake_RemoteIPSelfReported_MatchesTcpConn(t *testing.T) {
 		headers := buildAllHeadersRequest(t, id, cfg, publicIP)
 		headers.Set(HeaderRemoteIP, "203.0.113.5")
 
-		extras, err := ParseHandshakeExtras(headers, publicIP, net.ParseIP("127.0.0.1"))
+		_, err := ParseHandshakeExtras(headers, publicIP, net.ParseIP("127.0.0.1"))
 		require.NoError(t, err)
-		assert.Equal(t, "203.0.113.5", extras.RemoteIPSelf)
 	})
 
 	t.Run("malformed_remote_ip_rejected", func(t *testing.T) {
@@ -1420,17 +1430,17 @@ func TestHandshake_AllHeaders_RoundTrip(t *testing.T) {
 		assert.NotEmpty(t, headers.Get(HeaderNetworkTime))
 
 		// Parse from the receiver (B)'s vantage: peerRemote=pA,
-		// localPublicIP=pB.
+		// localPublicIP=pB. Strict rippled parity: only the headers
+		// rippled stores typed (Server-Domain, Closed/Previous-Ledger)
+		// surface on extras. Instance-Cookie and IP self-reports are
+		// validated and discarded.
 		extras, err := ParseHandshakeExtras(headers, pB, pA)
 		require.NoError(t, err)
-		assert.Equal(t, senderCfg.InstanceCookie, extras.InstanceCookie)
 		assert.Equal(t, senderCfg.ServerDomain, extras.ServerDomain)
 		assert.True(t, extras.HasClosedLedger)
 		assert.True(t, extras.HasPreviousLedger)
 		assert.Equal(t, closed, extras.ClosedLedger)
 		assert.Equal(t, parent, extras.PreviousLedger)
-		assert.Equal(t, pB.String(), extras.RemoteIPSelf)
-		assert.Equal(t, pA.String(), extras.LocalIPSelf)
 	})
 
 	t.Run("response_path", func(t *testing.T) {
@@ -1452,7 +1462,6 @@ func TestHandshake_AllHeaders_RoundTrip(t *testing.T) {
 
 		extras, err := ParseHandshakeExtras(resp.Header, pB, pA)
 		require.NoError(t, err)
-		assert.Equal(t, senderCfg.InstanceCookie, extras.InstanceCookie)
 		assert.Equal(t, senderCfg.ServerDomain, extras.ServerDomain)
 		assert.True(t, extras.HasClosedLedger)
 		assert.True(t, extras.HasPreviousLedger)
@@ -1625,24 +1634,23 @@ func TestHandshake_MalformedLedgerHashRejected(t *testing.T) {
 	})
 }
 
-// generateInstanceCookie must produce values in [1, MAX] — including MAX
-// — to match rippled `1 + rand_int(prng, MAX-1)`.
-func TestInstanceCookie_RangeIncludesMax(t *testing.T) {
+// generateInstanceCookie must produce values in [1, MAX-1] (both 0 and
+// MAX excluded) to match rippled `1 + rand_int(prng, MAX-1)`.
+func TestInstanceCookie_GeneratorRange(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		v, err := generateInstanceCookie()
 		require.NoError(t, err)
 		assert.NotZero(t, v, "cookie must never be zero")
+		assert.NotEqual(t, uint64(math.MaxUint64), v,
+			"cookie must never be MAX (rippled excludes both 0 and MAX)")
 	}
-	// Treat MAX as a valid cookie at the parser level.
-	h := http.Header{}
-	h.Set(HeaderInstanceCookie, strconv.FormatUint(math.MaxUint64, 10))
-	extras, err := ParseHandshakeExtras(h, nil, nil)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(math.MaxUint64), extras.InstanceCookie)
 }
 
-// isPublicIP must mirror beast::IP::is_public: link-local addresses are
-// public; loopback / RFC1918 / multicast are not.
+// isPublicIP must mirror beast::IP::is_public: IPv4 link-local stays
+// public (rippled IPAddressV4.cpp only flags RFC1918+loopback); IPv6
+// link-local is private to match rippled IPAddressV6.cpp's `(byte0 &
+// 0xfd)` catching fe80::/10. Loopback / RFC1918 / multicast are private
+// in both families.
 func TestIsPublicIP_BeastParity(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1661,7 +1669,7 @@ func TestIsPublicIP_BeastParity(t *testing.T) {
 		{"loopback_v6", "::1", false},
 		{"unspecified_v6", "::", false},
 		{"ula_v6", "fc00::1", false},
-		{"link_local_v6", "fe80::1", true},
+		{"link_local_v6", "fe80::1", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -1,9 +1,11 @@
 package peermanagement
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
+	"math"
 	"net"
 	"net/http"
 	"strconv"
@@ -1461,5 +1463,124 @@ func TestLedgerSync_PreferredPeersForLedger_ConsumesClosedLedgerHint(t *testing.
 	for _, id := range got {
 		_, ok := want[id]
 		assert.True(t, ok, "unexpected peer %d in result", id)
+	}
+}
+
+// Malformed Closed-Ledger / Previous-Ledger / Previous-without-Closed
+// must fail the handshake (PeerImp.cpp:175-194).
+func TestHandshake_MalformedLedgerHashRejected(t *testing.T) {
+	t.Run("malformed_closed_ledger", func(t *testing.T) {
+		h := http.Header{}
+		h.Set(HeaderClosedLedger, "not-hex-not-base64")
+		_, err := ParseHandshakeExtras(h, nil, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidHandshake)
+		assert.Contains(t, err.Error(), "malformed Closed-Ledger")
+	})
+
+	t.Run("malformed_previous_ledger", func(t *testing.T) {
+		var closed [32]byte
+		closed[0] = 0xAA
+		h := http.Header{}
+		h.Set(HeaderClosedLedger, hex.EncodeToString(closed[:]))
+		h.Set(HeaderPreviousLedger, "garbage")
+		_, err := ParseHandshakeExtras(h, nil, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidHandshake)
+		assert.Contains(t, err.Error(), "malformed Previous-Ledger")
+	})
+
+	t.Run("previous_without_closed", func(t *testing.T) {
+		var parent [32]byte
+		parent[0] = 0xBB
+		h := http.Header{}
+		h.Set(HeaderPreviousLedger, hex.EncodeToString(parent[:]))
+		_, err := ParseHandshakeExtras(h, nil, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidHandshake)
+		assert.Contains(t, err.Error(), "Previous-Ledger without Closed-Ledger")
+	})
+}
+
+// generateInstanceCookie must produce values in [1, MAX] — including MAX
+// — to match rippled `1 + rand_int(prng, MAX-1)`.
+func TestInstanceCookie_RangeIncludesMax(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		v, err := generateInstanceCookie()
+		require.NoError(t, err)
+		assert.NotZero(t, v, "cookie must never be zero")
+	}
+	// Treat MAX as a valid cookie at the parser level.
+	h := http.Header{}
+	h.Set(HeaderInstanceCookie, strconv.FormatUint(math.MaxUint64, 10))
+	extras, err := ParseHandshakeExtras(h, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(math.MaxUint64), extras.InstanceCookie)
+}
+
+// isPublicIP must mirror beast::IP::is_public: link-local addresses are
+// public; loopback / RFC1918 / multicast are not.
+func TestIsPublicIP_BeastParity(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{"public_v4", "8.8.8.8", true},
+		{"link_local_v4", "169.254.1.1", true},
+		{"loopback_v4", "127.0.0.1", false},
+		{"rfc1918_10", "10.0.0.1", false},
+		{"rfc1918_172_16", "172.16.5.4", false},
+		{"rfc1918_192_168", "192.168.1.1", false},
+		{"multicast_v4", "224.0.0.1", false},
+		{"unspecified_v4", "0.0.0.0", false},
+		{"public_v6", "2001:db8::1", true},
+		{"loopback_v6", "::1", false},
+		{"unspecified_v6", "::", false},
+		{"ula_v6", "fc00::1", false},
+		{"link_local_v6", "fe80::1", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isPublicIP(net.ParseIP(tc.ip)))
+		})
+	}
+}
+
+// WriteRawHandshakeRequest must place every issue-#270 header on the
+// wire — the whitelist in the writer is otherwise uncovered.
+func TestWriteRawHandshakeRequest_EmitsAllNewHeaders(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	var closed, parent [32]byte
+	for i := range closed {
+		closed[i] = byte(i)
+		parent[i] = byte(0x80 + i)
+	}
+	cfg := DefaultHandshakeConfig()
+	cfg.InstanceCookie = 0xCAFEBABE12345678
+	cfg.ServerDomain = "example.com"
+	cfg.PublicIP = net.ParseIP("198.51.100.10")
+	cfg.LedgerHintProvider = func() ([32]byte, [32]byte, bool) {
+		return closed, parent, true
+	}
+	req, err := BuildHandshakeRequest(id, make([]byte, 32), cfg)
+	require.NoError(t, err)
+	addAddressHeaders(req.Header, cfg, net.ParseIP("203.0.113.5"))
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteRawHandshakeRequest(&buf, req))
+	wire := buf.String()
+
+	for _, h := range []string{
+		HeaderInstanceCookie + ": ",
+		HeaderServerDomain + ": example.com",
+		HeaderClosedLedger + ": " + hex.EncodeToString(closed[:]),
+		HeaderPreviousLedger + ": " + hex.EncodeToString(parent[:]),
+		HeaderRemoteIP + ": 203.0.113.5",
+		HeaderLocalIP + ": 198.51.100.10",
+	} {
+		assert.Contains(t, wire, h, "missing %s on the wire", h)
 	}
 }

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -1253,8 +1253,8 @@ func TestHandshake_ClosedLedgerHint_ReadableAfterHandshake(t *testing.T) {
 	}
 
 	cfg := DefaultHandshakeConfig()
-	cfg.LedgerHintProvider = func() ([32]byte, [32]byte, bool) {
-		return closed, parent, true
+	cfg.LedgerHintProvider = func() (LedgerHints, bool) {
+		return LedgerHints{Closed: closed, Parent: parent}, true
 	}
 
 	headers := buildAllHeadersRequest(t, id, cfg, nil)
@@ -1350,8 +1350,8 @@ func TestHandshake_AllHeaders_RoundTrip(t *testing.T) {
 	senderCfg.InstanceCookie = 0x1234567890ABCDEF
 	senderCfg.ServerDomain = "validator.example.com"
 	senderCfg.PublicIP = pA
-	senderCfg.LedgerHintProvider = func() ([32]byte, [32]byte, bool) {
-		return closed, parent, true
+	senderCfg.LedgerHintProvider = func() (LedgerHints, bool) {
+		return LedgerHints{Closed: closed, Parent: parent}, true
 	}
 
 	t.Run("request_path", func(t *testing.T) {
@@ -1547,6 +1547,35 @@ func TestIsPublicIP_BeastParity(t *testing.T) {
 	}
 }
 
+// isWellFormedDomain matches rippled's isProperlyFormedTomlDomain
+// (StringUtilities.cpp:131-156).
+func TestIsWellFormedDomain_TomlParity(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"valid_two_label", "a.io", true},
+		{"valid_subdomain", "validator.example.com", true},
+		{"valid_with_digits", "node-1.example.org", true},
+		{"too_short", "a.b", false},
+		{"too_long", strings.Repeat("a", 120) + ".example.com", false},
+		{"single_label", "example", false},
+		{"numeric_tld", "x.123", false},
+		{"one_char_tld", "a.b.c", false},
+		{"trailing_dot", "example.com.", false},
+		{"leading_hyphen_label", "-bad.example.com", false},
+		{"trailing_hyphen_label", "bad-.example.com", false},
+		{"empty", "", false},
+		{"underscore", "bad_label.example.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isWellFormedDomain(tc.in))
+		})
+	}
+}
+
 // WriteRawHandshakeRequest must place every issue-#270 header on the
 // wire — the whitelist in the writer is otherwise uncovered.
 func TestWriteRawHandshakeRequest_EmitsAllNewHeaders(t *testing.T) {
@@ -1562,8 +1591,8 @@ func TestWriteRawHandshakeRequest_EmitsAllNewHeaders(t *testing.T) {
 	cfg.InstanceCookie = 0xCAFEBABE12345678
 	cfg.ServerDomain = "example.com"
 	cfg.PublicIP = net.ParseIP("198.51.100.10")
-	cfg.LedgerHintProvider = func() ([32]byte, [32]byte, bool) {
-		return closed, parent, true
+	cfg.LedgerHintProvider = func() (LedgerHints, bool) {
+		return LedgerHints{Closed: closed, Parent: parent}, true
 	}
 	req, err := BuildHandshakeRequest(id, make([]byte, 32), cfg)
 	require.NoError(t, err)

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -2,7 +2,11 @@ package peermanagement
 
 import (
 	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1182,5 +1186,280 @@ func TestPeerFeatureEnabled(t *testing.T) {
 			got := PeerFeatureEnabled(headers, tt.feature, tt.value, tt.localEnabled)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// buildAllHeadersRequest builds a handshake request with every issue-#270
+// header set. peerRemote drives Remote-IP / Local-IP emission.
+func buildAllHeadersRequest(t *testing.T, id *Identity, cfg HandshakeConfig, peerRemote net.IP) http.Header {
+	t.Helper()
+	sharedValue := make([]byte, 32)
+	for i := range sharedValue {
+		sharedValue[i] = byte(i + 7)
+	}
+	req, err := BuildHandshakeRequest(id, sharedValue, cfg)
+	require.NoError(t, err)
+	if peerRemote != nil {
+		addAddressHeaders(req.Header, cfg, peerRemote)
+	}
+	return req.Header
+}
+
+// Strict rippled parity: Instance-Cookie round-trips but is NEVER
+// compared (Handshake.cpp:226-362). Self-connection stays pubkey-only
+// at line 322. This test verifies both halves.
+func TestHandshake_InstanceCookie_DetectsSelfConnection(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	const cookie uint64 = 0xDEADBEEFCAFEBABE
+	cfg := DefaultHandshakeConfig()
+	cfg.InstanceCookie = cookie
+
+	headers := buildAllHeadersRequest(t, id, cfg, nil)
+	require.Equal(t, strconv.FormatUint(cookie, 10), headers.Get(HeaderInstanceCookie))
+
+	// Round-trip: cookie parsed and surfaced on extras even when the
+	// "local" view shares the same nonce. Strict rippled parity — no
+	// cookie comparison happens.
+	extras, err := ParseHandshakeExtras(headers, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, cookie, extras.InstanceCookie)
+
+	// The rippled-canonical self-connection signal is pubkey identity
+	// (Handshake.cpp:322 publicKey == app.nodeIdentity().first). Verify
+	// that path still fires when the peer's pubkey matches our own.
+	netTime := strconvUnixXRPL(time.Now())
+	selfHeaders := http.Header{}
+	selfHeaders.Set(HeaderPublicKey, id.EncodedPublicKey())
+	selfHeaders.Set(HeaderNetworkTime, netTime)
+	_, err = VerifyHandshakeHeadersNoSig(selfHeaders, id.EncodedPublicKey(), 0)
+	assert.ErrorIs(t, err, ErrSelfConnection,
+		"matching Public-Key triggers self-connection — the only signal rippled uses")
+}
+
+// Closed-Ledger / Previous-Ledger hints round-trip and end up readable
+// on Peer accessors (mirrors PeerImp storing closedLedgerHash_).
+func TestHandshake_ClosedLedgerHint_ReadableAfterHandshake(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	var closed, parent [32]byte
+	for i := range closed {
+		closed[i] = byte(i + 1)
+		parent[i] = byte(0xFF - i)
+	}
+
+	cfg := DefaultHandshakeConfig()
+	cfg.LedgerHintProvider = func() ([32]byte, [32]byte, bool) {
+		return closed, parent, true
+	}
+
+	headers := buildAllHeadersRequest(t, id, cfg, nil)
+	require.Equal(t, hex.EncodeToString(closed[:]), headers.Get(HeaderClosedLedger))
+	require.Equal(t, hex.EncodeToString(parent[:]), headers.Get(HeaderPreviousLedger))
+
+	extras, err := ParseHandshakeExtras(headers, nil, nil)
+	require.NoError(t, err)
+	assert.True(t, extras.HasLedgerHints, "ClosedLedger header must mark hints as present")
+	assert.Equal(t, closed, extras.ClosedLedger)
+	assert.Equal(t, parent, extras.PreviousLedger)
+
+	// Confirm Peer accessor surface produces the same values.
+	peer := NewPeer(1, Endpoint{Host: "127.0.0.1", Port: 1234}, true, id, nil)
+	peer.applyHandshakeExtras(extras)
+	gotClosed, ok := peer.ClosedLedger()
+	require.True(t, ok)
+	assert.Equal(t, closed, gotClosed)
+	assert.Equal(t, parent, peer.PreviousLedger())
+}
+
+// Remote-IP consistency check per Handshake.cpp:340-359.
+func TestHandshake_RemoteIPSelfReported_MatchesTcpConn(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	publicIP := net.ParseIP("198.51.100.1")
+	cfg := DefaultHandshakeConfig()
+	cfg.PublicIP = publicIP
+
+	t.Run("matching_public_ip_passes", func(t *testing.T) {
+		headers := buildAllHeadersRequest(t, id, cfg, publicIP)
+		require.Equal(t, "198.51.100.1", headers.Get(HeaderRemoteIP))
+
+		extras, err := ParseHandshakeExtras(headers, publicIP, publicIP)
+		require.NoError(t, err)
+		assert.Equal(t, "198.51.100.1", extras.RemoteIPSelf)
+	})
+
+	t.Run("mismatched_public_ip_rejected", func(t *testing.T) {
+		headers := buildAllHeadersRequest(t, id, cfg, publicIP)
+		// Peer claims our IP is 203.0.113.5 — but our config says
+		// otherwise and they connected from a public address. Reject.
+		headers.Set(HeaderRemoteIP, "203.0.113.5")
+
+		_, err := ParseHandshakeExtras(headers, publicIP, publicIP)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrInvalidHandshake))
+		assert.Contains(t, err.Error(), "Incorrect Remote-IP")
+	})
+
+	t.Run("loopback_peer_skips_check", func(t *testing.T) {
+		// Same mismatched header, but the peer connected from
+		// loopback — rippled and we both skip the comparison.
+		headers := buildAllHeadersRequest(t, id, cfg, publicIP)
+		headers.Set(HeaderRemoteIP, "203.0.113.5")
+
+		extras, err := ParseHandshakeExtras(headers, publicIP, net.ParseIP("127.0.0.1"))
+		require.NoError(t, err)
+		assert.Equal(t, "203.0.113.5", extras.RemoteIPSelf)
+	})
+
+	t.Run("malformed_remote_ip_rejected", func(t *testing.T) {
+		headers := buildAllHeadersRequest(t, id, cfg, publicIP)
+		headers.Set(HeaderRemoteIP, "not-an-ip")
+
+		_, err := ParseHandshakeExtras(headers, publicIP, publicIP)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrInvalidHandshake))
+		assert.Contains(t, err.Error(), "invalid Remote-IP")
+	})
+}
+
+// Round-trip topology: sender A (public IP pA) → receiver B (public IP pB).
+// Verifies the full set of issue-#270 headers + IP consistency
+// (Handshake.cpp:325-359).
+func TestHandshake_AllHeaders_RoundTrip(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	pA := net.ParseIP("198.51.100.42") // sender's public IP
+	pB := net.ParseIP("203.0.113.7")   // receiver's public IP
+
+	var closed, parent [32]byte
+	for i := range closed {
+		closed[i] = byte(i)
+		parent[i] = byte(0xA0 + i)
+	}
+
+	// Sender's HandshakeConfig: PublicIP = pA. Sender sees peer (B) at
+	// pB, so addAddressHeaders emits Remote-IP=pB, Local-IP=pA.
+	senderCfg := DefaultHandshakeConfig()
+	senderCfg.InstanceCookie = 0x1234567890ABCDEF
+	senderCfg.ServerDomain = "validator.example.com"
+	senderCfg.PublicIP = pA
+	senderCfg.LedgerHintProvider = func() ([32]byte, [32]byte, bool) {
+		return closed, parent, true
+	}
+
+	t.Run("request_path", func(t *testing.T) {
+		// Build with sender's view: peer (B) is at pB.
+		headers := buildAllHeadersRequest(t, id, senderCfg, pB)
+
+		// Wire-level checks: each header is present in the right form.
+		assert.Equal(t, strconv.FormatUint(senderCfg.InstanceCookie, 10), headers.Get(HeaderInstanceCookie))
+		assert.Equal(t, "validator.example.com", headers.Get(HeaderServerDomain))
+		assert.Equal(t, hex.EncodeToString(closed[:]), headers.Get(HeaderClosedLedger))
+		assert.Equal(t, hex.EncodeToString(parent[:]), headers.Get(HeaderPreviousLedger))
+		assert.Equal(t, pB.String(), headers.Get(HeaderRemoteIP))
+		assert.Equal(t, pA.String(), headers.Get(HeaderLocalIP))
+
+		// Existing X-Protocol-Ctl / Public-Key / Network-Time still emitted.
+		assert.NotEmpty(t, headers.Get(HeaderPublicKey))
+		assert.NotEmpty(t, headers.Get(HeaderSessionSignature))
+		assert.NotEmpty(t, headers.Get(HeaderNetworkTime))
+
+		// Parse from the receiver (B)'s vantage: peerRemote=pA,
+		// localPublicIP=pB.
+		extras, err := ParseHandshakeExtras(headers, pB, pA)
+		require.NoError(t, err)
+		assert.Equal(t, senderCfg.InstanceCookie, extras.InstanceCookie)
+		assert.Equal(t, senderCfg.ServerDomain, extras.ServerDomain)
+		assert.True(t, extras.HasLedgerHints)
+		assert.Equal(t, closed, extras.ClosedLedger)
+		assert.Equal(t, parent, extras.PreviousLedger)
+		assert.Equal(t, pB.String(), extras.RemoteIPSelf)
+		assert.Equal(t, pA.String(), extras.LocalIPSelf)
+	})
+
+	t.Run("response_path", func(t *testing.T) {
+		sharedValue := make([]byte, 32)
+		resp := BuildHandshakeResponse(id, sharedValue, senderCfg)
+		// Sender (now the responder) sees peer (now the requester) at
+		// pB and emits its own Local-IP = pA.
+		addAddressHeaders(resp.Header, senderCfg, pB)
+
+		// Symmetric checks. The response must carry the same six
+		// headers — without them the inbound peer can't enforce the
+		// rippled-style consistency contract on us either.
+		assert.Equal(t, strconv.FormatUint(senderCfg.InstanceCookie, 10), resp.Header.Get(HeaderInstanceCookie))
+		assert.Equal(t, "validator.example.com", resp.Header.Get(HeaderServerDomain))
+		assert.Equal(t, hex.EncodeToString(closed[:]), resp.Header.Get(HeaderClosedLedger))
+		assert.Equal(t, hex.EncodeToString(parent[:]), resp.Header.Get(HeaderPreviousLedger))
+		assert.Equal(t, pB.String(), resp.Header.Get(HeaderRemoteIP))
+		assert.Equal(t, pA.String(), resp.Header.Get(HeaderLocalIP))
+
+		extras, err := ParseHandshakeExtras(resp.Header, pB, pA)
+		require.NoError(t, err)
+		assert.Equal(t, senderCfg.InstanceCookie, extras.InstanceCookie)
+		assert.Equal(t, senderCfg.ServerDomain, extras.ServerDomain)
+		assert.True(t, extras.HasLedgerHints)
+	})
+
+	t.Run("malformed_server_domain_rejected", func(t *testing.T) {
+		// Mutate just the Server-Domain field to verify the parser
+		// rejects malformed values per Handshake.cpp:235-239.
+		headers := buildAllHeadersRequest(t, id, senderCfg, pB)
+		headers.Set(HeaderServerDomain, "-bad.example.com") // leading hyphen
+
+		_, err := ParseHandshakeExtras(headers, pB, pA)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid Server-Domain")
+	})
+}
+
+// Catchup peer-picker reads Closed-Ledger handshake hints (rippled
+// NetworkOPs / PeerImp::closedLedgerHash_).
+func TestLedgerSync_PreferredPeersForLedger_ConsumesClosedLedgerHint(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	var target, parent [32]byte
+	for i := range target {
+		target[i] = byte(0xCC)
+		parent[i] = byte(0xBB)
+	}
+
+	mkPeer := func(idNum PeerID, hint *[32]byte) *Peer {
+		p := NewPeer(idNum, Endpoint{Host: "127.0.0.1", Port: 1000 + uint16(idNum)}, false, id, nil)
+		p.setState(PeerStateConnected)
+		if hint != nil {
+			p.applyHandshakeExtras(HandshakeExtras{
+				ClosedLedger:   *hint,
+				PreviousLedger: parent,
+				HasLedgerHints: true,
+			})
+		}
+		return p
+	}
+
+	overlay := &Overlay{peers: map[PeerID]*Peer{}}
+	overlay.peers[1] = mkPeer(1, &target)             // matches → expected
+	other := [32]byte{0xAA}
+	overlay.peers[2] = mkPeer(2, &other)              // different hint → filtered
+	overlay.peers[3] = mkPeer(3, nil)                 // no hint → filtered
+	overlay.peers[4] = mkPeer(4, &target)             // matches → expected
+	overlay.peers[5] = NewPeer(5, Endpoint{}, false, id, nil)
+	// peer 5 left disconnected with matching hint to verify state filter
+	overlay.peers[5].applyHandshakeExtras(HandshakeExtras{
+		ClosedLedger: target, HasLedgerHints: true,
+	})
+
+	got := overlay.PeersWithClosedLedger(target)
+	want := map[PeerID]struct{}{1: {}, 4: {}}
+	assert.Len(t, got, len(want))
+	for _, id := range got {
+		_, ok := want[id]
+		assert.True(t, ok, "unexpected peer %d in result", id)
 	}
 }

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -280,11 +280,13 @@ func TestVerifyHandshakeHeadersNoSig(t *testing.T) {
 	})
 
 	t.Run("non_default_network_peer_missing_netid", func(t *testing.T) {
-		// Symmetric case: we're on network 2, peer omits Network-ID.
+		// Rippled (Handshake.cpp:241-250) only enters the comparison
+		// branch when Network-ID is present; a missing header is
+		// silently accepted regardless of local config.
 		h := mkHeaders(remoteId.EncodedPublicKey(), "", xrplNow())
 		_, err := VerifyHandshakeHeadersNoSig(h, localId.EncodedPublicKey(), 2)
-		assert.ErrorIs(t, err, ErrNetworkMismatch,
-			"non-default-network node must reject a peer omitting Network-ID")
+		require.NoError(t, err,
+			"missing Network-ID is silently accepted to mirror rippled")
 	})
 
 	t.Run("malformed_networkid_rejected", func(t *testing.T) {
@@ -1272,7 +1274,8 @@ func TestHandshake_ClosedLedgerHint_ReadableAfterHandshake(t *testing.T) {
 
 	extras, err := ParseHandshakeExtras(headers, nil, nil)
 	require.NoError(t, err)
-	assert.True(t, extras.HasLedgerHints, "ClosedLedger header must mark hints as present")
+	assert.True(t, extras.HasClosedLedger, "Closed-Ledger header must mark closed hint as present")
+	assert.True(t, extras.HasPreviousLedger, "Previous-Ledger header must mark previous hint as present")
 	assert.Equal(t, closed, extras.ClosedLedger)
 	assert.Equal(t, parent, extras.PreviousLedger)
 
@@ -1285,6 +1288,40 @@ func TestHandshake_ClosedLedgerHint_ReadableAfterHandshake(t *testing.T) {
 	gotParent, hasParent := peer.PreviousLedger()
 	assert.True(t, hasParent)
 	assert.Equal(t, parent, gotParent)
+}
+
+// Rippled accepts Closed-Ledger without Previous-Ledger
+// (PeerImp.cpp:198-201 — each is set independently). The peer must
+// surface only the closed hint, with PreviousLedger() reporting
+// "absent" rather than the zero hash.
+func TestHandshake_ClosedLedgerWithoutPrevious(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	var closed [32]byte
+	for i := range closed {
+		closed[i] = byte(i + 1)
+	}
+
+	headers := http.Header{}
+	headers.Set(HeaderClosedLedger, strings.ToUpper(hex.EncodeToString(closed[:])))
+
+	extras, err := ParseHandshakeExtras(headers, nil, nil)
+	require.NoError(t, err)
+	assert.True(t, extras.HasClosedLedger)
+	assert.False(t, extras.HasPreviousLedger,
+		"missing Previous-Ledger must not be inferred from Closed-Ledger presence")
+	assert.Equal(t, closed, extras.ClosedLedger)
+	assert.Equal(t, [32]byte{}, extras.PreviousLedger)
+
+	peer := NewPeer(1, Endpoint{Host: "127.0.0.1", Port: 1234}, true, id, nil)
+	peer.applyHandshakeExtras(extras)
+	gotClosed, hasClosed := peer.ClosedLedger()
+	require.True(t, hasClosed)
+	assert.Equal(t, closed, gotClosed)
+	_, hasPrev := peer.PreviousLedger()
+	assert.False(t, hasPrev,
+		"PreviousLedger() must report absent when peer omitted the header")
 }
 
 // Remote-IP consistency check per Handshake.cpp:340-359.
@@ -1388,7 +1425,8 @@ func TestHandshake_AllHeaders_RoundTrip(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, senderCfg.InstanceCookie, extras.InstanceCookie)
 		assert.Equal(t, senderCfg.ServerDomain, extras.ServerDomain)
-		assert.True(t, extras.HasLedgerHints)
+		assert.True(t, extras.HasClosedLedger)
+		assert.True(t, extras.HasPreviousLedger)
 		assert.Equal(t, closed, extras.ClosedLedger)
 		assert.Equal(t, parent, extras.PreviousLedger)
 		assert.Equal(t, pB.String(), extras.RemoteIPSelf)
@@ -1416,7 +1454,8 @@ func TestHandshake_AllHeaders_RoundTrip(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, senderCfg.InstanceCookie, extras.InstanceCookie)
 		assert.Equal(t, senderCfg.ServerDomain, extras.ServerDomain)
-		assert.True(t, extras.HasLedgerHints)
+		assert.True(t, extras.HasClosedLedger)
+		assert.True(t, extras.HasPreviousLedger)
 	})
 
 	t.Run("malformed_server_domain_rejected", func(t *testing.T) {
@@ -1449,9 +1488,10 @@ func TestLedgerSync_PreferredPeersForLedger_ConsumesClosedLedgerHint(t *testing.
 		p.setState(PeerStateConnected)
 		if hint != nil {
 			p.applyHandshakeExtras(HandshakeExtras{
-				ClosedLedger:   *hint,
-				PreviousLedger: parent,
-				HasLedgerHints: true,
+				ClosedLedger:      *hint,
+				PreviousLedger:    parent,
+				HasClosedLedger:   true,
+				HasPreviousLedger: true,
 			})
 		}
 		return p
@@ -1465,7 +1505,7 @@ func TestLedgerSync_PreferredPeersForLedger_ConsumesClosedLedgerHint(t *testing.
 		// peer 5: disconnected with matching hint → filtered by state.
 		5: func() *Peer {
 			p := NewPeer(5, Endpoint{}, false, id, nil)
-			p.applyHandshakeExtras(HandshakeExtras{ClosedLedger: target, HasLedgerHints: true})
+			p.applyHandshakeExtras(HandshakeExtras{ClosedLedger: target, HasClosedLedger: true})
 			return p
 		}(),
 	})
@@ -1492,9 +1532,10 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 			initialParent[i] = byte(0x22)
 		}
 		p.applyHandshakeExtras(HandshakeExtras{
-			ClosedLedger:   initialClosed,
-			PreviousLedger: initialParent,
-			HasLedgerHints: true,
+			ClosedLedger:      initialClosed,
+			PreviousLedger:    initialParent,
+			HasClosedLedger:   true,
+			HasPreviousLedger: true,
 		})
 		return p
 	}

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -1281,7 +1282,9 @@ func TestHandshake_ClosedLedgerHint_ReadableAfterHandshake(t *testing.T) {
 	gotClosed, ok := peer.ClosedLedger()
 	require.True(t, ok)
 	assert.Equal(t, closed, gotClosed)
-	assert.Equal(t, parent, peer.PreviousLedger())
+	gotParent, hasParent := peer.PreviousLedger()
+	assert.True(t, hasParent)
+	assert.Equal(t, parent, gotParent)
 }
 
 // Remote-IP consistency check per Handshake.cpp:340-359.
@@ -1476,6 +1479,75 @@ func TestLedgerSync_PreferredPeersForLedger_ConsumesClosedLedgerHint(t *testing.
 	}
 }
 
+// applyStatusChange mirrors PeerImp.cpp:1812-1862.
+func TestApplyStatusChange_RippledSemantics(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	mk := func() *Peer {
+		p := NewPeer(1, Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+		var initialClosed, initialParent [32]byte
+		for i := range initialClosed {
+			initialClosed[i] = byte(0x11)
+			initialParent[i] = byte(0x22)
+		}
+		p.applyHandshakeExtras(HandshakeExtras{
+			ClosedLedger:   initialClosed,
+			PreviousLedger: initialParent,
+			HasLedgerHints: true,
+		})
+		return p
+	}
+
+	t.Run("lost_sync_zeroes_both", func(t *testing.T) {
+		p := mk()
+		p.applyStatusChange(nil, nil, true)
+		_, hasC := p.ClosedLedger()
+		_, hasP := p.PreviousLedger()
+		assert.False(t, hasC)
+		assert.False(t, hasP)
+	})
+
+	t.Run("updates_to_new_pair", func(t *testing.T) {
+		p := mk()
+		var newClosed, newParent [32]byte
+		for i := range newClosed {
+			newClosed[i] = byte(0xAA)
+			newParent[i] = byte(0xBB)
+		}
+		p.applyStatusChange(newClosed[:], newParent[:], false)
+		gotC, hasC := p.ClosedLedger()
+		gotP, hasP := p.PreviousLedger()
+		assert.True(t, hasC)
+		assert.True(t, hasP)
+		assert.Equal(t, newClosed, gotC)
+		assert.Equal(t, newParent, gotP)
+	})
+
+	t.Run("missing_closed_zeroes_closed_only", func(t *testing.T) {
+		p := mk()
+		var newParent [32]byte
+		for i := range newParent {
+			newParent[i] = byte(0xCC)
+		}
+		p.applyStatusChange(nil, newParent[:], false)
+		_, hasC := p.ClosedLedger()
+		gotP, hasP := p.PreviousLedger()
+		assert.False(t, hasC)
+		assert.True(t, hasP)
+		assert.Equal(t, newParent, gotP)
+	})
+
+	t.Run("malformed_closed_zeroes_closed", func(t *testing.T) {
+		p := mk()
+		p.applyStatusChange([]byte{0x01, 0x02}, nil, false) // 2 bytes ≠ 32
+		_, hasC := p.ClosedLedger()
+		_, hasP := p.PreviousLedger()
+		assert.False(t, hasC)
+		assert.False(t, hasP)
+	})
+}
+
 // Malformed Closed-Ledger / Previous-Ledger / Previous-without-Closed
 // must fail the handshake (PeerImp.cpp:175-194).
 func TestHandshake_MalformedLedgerHashRejected(t *testing.T) {
@@ -1571,6 +1643,38 @@ func TestIpFamilyEqual_BoostParity(t *testing.T) {
 	assert.False(t, ipFamilyEqual(v4, v4mapped, false, true), "v4 vs v4-mapped-v6 must differ")
 	assert.False(t, ipFamilyEqual(v4mapped, v4, true, false), "v4-mapped-v6 vs v4 must differ")
 	assert.True(t, ipFamilyEqual(v4mapped, v4mapped, true, true), "same v4-mapped-v6 must be equal")
+}
+
+// isWellFormedDomain must agree with rippled's regex
+// (StringUtilities.cpp:142-153). Go regexp has no lookarounds, so the
+// no-leading/trailing-hyphen rule is encoded directly.
+func TestIsWellFormedDomain_RegexCrossCheck(t *testing.T) {
+	rippledLike := regexp.MustCompile(
+		`^([A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$`,
+	)
+	check := func(s string) bool {
+		if len(s) < 4 || len(s) > 128 {
+			return false
+		}
+		return rippledLike.MatchString(s)
+	}
+
+	inputs := []string{
+		"a.io", "example.com", "validator.example.com", "node-1.example.org",
+		"a.b.c.d.example.com", "X-1.X-2.example.io",
+		"localhost", "example", "a.b", "x.123", "a.b.c",
+		"-bad.example.com", "bad-.example.com", "_bad.example.com",
+		"example.com.", "example..com", ".example.com",
+		"", "a",
+		strings.Repeat("a", 64) + ".example.com",
+		strings.Repeat("a", 200) + ".com",
+		"foo.bar.MUSEUM",
+	}
+	for _, s := range inputs {
+		want := check(s)
+		got := isWellFormedDomain(s)
+		assert.Equal(t, want, got, "isWellFormedDomain(%q): want=%v got=%v", s, want, got)
+	}
 }
 
 // isWellFormedDomain matches rippled's isProperlyFormedTomlDomain

--- a/internal/peermanagement/ledgersync.go
+++ b/internal/peermanagement/ledgersync.go
@@ -172,6 +172,9 @@ type LedgerSyncHandler struct {
 	// because the events channel was full (slow consumer). Exposed via
 	// DroppedResponses so the overlay can aggregate into server_info.
 	droppedResponses atomic.Uint64
+
+	// peerHintLookup is wired by the Overlay (see SetPeerLedgerHintLookup).
+	peerHintLookup func(target [32]byte) []PeerID
 }
 
 // DroppedResponses returns the cumulative count of ledger-sync
@@ -201,6 +204,25 @@ func (h *LedgerSyncHandler) SetProvider(provider LedgerProvider) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.provider = provider
+}
+
+// PreferredPeersForLedger returns peer IDs whose Closed-Ledger
+// handshake hint matches target. Empty when no lookup is wired or no
+// peer matches.
+func (h *LedgerSyncHandler) PreferredPeersForLedger(target [32]byte) []PeerID {
+	h.mu.RLock()
+	lookup := h.peerHintLookup
+	h.mu.RUnlock()
+	if lookup == nil {
+		return nil
+	}
+	return lookup(target)
+}
+
+func (h *LedgerSyncHandler) SetPeerLedgerHintLookup(fn func(target [32]byte) []PeerID) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.peerHintLookup = fn
 }
 
 // HandleMessage handles a ledger sync message.

--- a/internal/peermanagement/ledgersync.go
+++ b/internal/peermanagement/ledgersync.go
@@ -206,9 +206,11 @@ func (h *LedgerSyncHandler) SetProvider(provider LedgerProvider) {
 	h.provider = provider
 }
 
-// PreferredPeersForLedger returns peer IDs whose Closed-Ledger
-// handshake hint matches target. Empty when no lookup is wired or no
-// peer matches.
+// PreferredPeersForLedger returns peer IDs whose last-known
+// Closed-Ledger hash matches target. Empty when no lookup is wired or
+// no peer matches. Filters by a single advertised hash only — does not
+// replicate rippled's PeerImp::hasLedger(hash, seq) range/recent-set
+// logic used by InboundLedger catchup.
 func (h *LedgerSyncHandler) PreferredPeersForLedger(target [32]byte) []PeerID {
 	h.mu.RLock()
 	lookup := h.peerHintLookup

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -165,13 +165,13 @@ type Overlay struct {
 	cfg      Config
 	identity *Identity
 
-	// instanceCookie: rippled `1 + rand_int(prng, MAX-1)`.
+	// instanceCookie: immutable post-New, lock-free.
 	instanceCookie uint64
 
 	// ledgerHintProvider: wired by a higher layer (avoids importing
 	// internal/ledger). Guarded by hintMu.
 	hintMu             sync.RWMutex
-	ledgerHintProvider func() ([32]byte, [32]byte, bool)
+	ledgerHintProvider func() (LedgerHints, bool)
 
 	// Components
 	discovery  *Discovery
@@ -255,15 +255,14 @@ func (o *Overlay) PeersWithClosedLedger(target [32]byte) []PeerID {
 // lifetime of the Overlay.
 func (o *Overlay) InstanceCookie() uint64 { return o.instanceCookie }
 
-// SetLedgerHintProvider wires the Closed-Ledger / Previous-Ledger
-// hint source. Pass nil to suppress the headers.
-func (o *Overlay) SetLedgerHintProvider(fn func() ([32]byte, [32]byte, bool)) {
+// SetLedgerHintProvider wires the hint source; nil suppresses headers.
+func (o *Overlay) SetLedgerHintProvider(fn func() (LedgerHints, bool)) {
 	o.hintMu.Lock()
 	o.ledgerHintProvider = fn
 	o.hintMu.Unlock()
 }
 
-func (o *Overlay) ledgerHintProviderSnapshot() func() ([32]byte, [32]byte, bool) {
+func (o *Overlay) ledgerHintProviderSnapshot() func() (LedgerHints, bool) {
 	o.hintMu.RLock()
 	defer o.hintMu.RUnlock()
 	return o.ledgerHintProvider
@@ -1577,24 +1576,29 @@ func (o *Overlay) Peers() []PeerInfo {
 }
 
 // PeersJSON implements types.PeerSource for the `peers` RPC method.
+// Mirrors rippled PeerImp::json (PeerImp.cpp:388-503); the
+// previous_ledger / remote_ip / local_ip / server_domain /
+// instance_cookie fields are goXRPL extensions.
 func (o *Overlay) PeersJSON() []map[string]any {
 	list := o.Peers()
 	out := make([]map[string]any, 0, len(list))
 	for _, p := range list {
 		entry := map[string]any{
 			"address":    p.Endpoint.String(),
-			"inbound":    p.Inbound,
 			"public_key": p.PublicKey,
 			"uptime":     int64(time.Since(p.ConnectedAt).Seconds()),
+		}
+		if p.Inbound {
+			entry["inbound"] = true
+		}
+		if p.ClosedLedger != "" {
+			entry["ledger"] = p.ClosedLedger
 		}
 		if p.InstanceCookie != 0 {
 			entry["instance_cookie"] = p.InstanceCookie
 		}
 		if p.ServerDomain != "" {
 			entry["server_domain"] = p.ServerDomain
-		}
-		if p.ClosedLedger != "" {
-			entry["closed_ledger"] = p.ClosedLedger
 		}
 		if p.PreviousLedger != "" {
 			entry["previous_ledger"] = p.PreviousLedger

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -232,8 +232,9 @@ type Overlay struct {
 func (o *Overlay) LedgerSync() *LedgerSyncHandler { return o.ledgerSync }
 
 // PeersWithClosedLedger returns peers whose Closed-Ledger handshake
-// hint matches target. Mirrors rippled NetworkOPs picking peers via
-// PeerImp::closedLedgerHash_.
+// hint matches target. goXRPL-side optimization for the catchup peer
+// picker — rippled's NetworkOPs uses closedLedgerHash_ for consensus
+// LCL voting (getPreferredLCL), not for routing fetch requests.
 func (o *Overlay) PeersWithClosedLedger(target [32]byte) []PeerID {
 	o.peersMu.RLock()
 	defer o.peersMu.RUnlock()

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"net"
 	"net/http"
 	"sync"
@@ -114,6 +113,7 @@ func BadDataWeight(reason string) int {
 		"validation-malformed-node-id-zero",
 		"handshake-malformed-networkid",
 		"handshake-malformed-networktime",
+		"handshake-malformed-extras",
 		"replay-delta-resp-decode",
 		"replay-delta-req-decode",
 		"replay-delta-req-bad",
@@ -165,13 +165,12 @@ type Overlay struct {
 	cfg      Config
 	identity *Identity
 
-	// instanceCookie is generated once in [1, MAX-1] (matches rippled
-	// Application.cpp `1 + rand_int(prng, MAX-1)`).
+	// instanceCookie: rippled `1 + rand_int(prng, MAX-1)`.
 	instanceCookie uint64
 
-	// ledgerHintProvider feeds the Closed-Ledger / Previous-Ledger
-	// handshake hints. Wired by a higher layer to avoid importing
-	// internal/ledger here.
+	// ledgerHintProvider: wired by a higher layer (avoids importing
+	// internal/ledger). Guarded by hintMu.
+	hintMu             sync.RWMutex
 	ledgerHintProvider func() ([32]byte, [32]byte, bool)
 
 	// Components
@@ -259,9 +258,19 @@ func (o *Overlay) InstanceCookie() uint64 { return o.instanceCookie }
 // SetLedgerHintProvider wires the Closed-Ledger / Previous-Ledger
 // hint source. Pass nil to suppress the headers.
 func (o *Overlay) SetLedgerHintProvider(fn func() ([32]byte, [32]byte, bool)) {
+	o.hintMu.Lock()
 	o.ledgerHintProvider = fn
+	o.hintMu.Unlock()
 }
 
+func (o *Overlay) ledgerHintProviderSnapshot() func() ([32]byte, [32]byte, bool) {
+	o.hintMu.RLock()
+	defer o.hintMu.RUnlock()
+	return o.ledgerHintProvider
+}
+
+// generateInstanceCookie returns a value in [1, MAX] (rippled
+// Application.cpp `1 + rand_int(prng, MAX-1)`).
 func generateInstanceCookie() (uint64, error) {
 	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {
@@ -270,9 +279,6 @@ func generateInstanceCookie() (uint64, error) {
 	v := binary.BigEndian.Uint64(b[:])
 	if v == 0 {
 		return 1, nil
-	}
-	if v == math.MaxUint64 {
-		return math.MaxUint64 - 1, nil
 	}
 	return v, nil
 }
@@ -670,7 +676,7 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 		peerRemote,
 	)
 	if extraErr != nil {
-		o.IncPeerBadData(peer.ID(), "handshake-malformed-networkid")
+		o.IncPeerBadData(peer.ID(), "handshake-malformed-extras")
 		return NewHandshakeError(peer.Endpoint(), "verify_extras", extraErr)
 	}
 	peer.applyHandshakeExtras(extras)
@@ -710,7 +716,7 @@ func (o *Overlay) handshakeConfigFor() HandshakeConfig {
 		InstanceCookie:      o.instanceCookie,
 		ServerDomain:        o.cfg.ServerDomain,
 		PublicIP:            o.cfg.PublicIP,
-		LedgerHintProvider:  o.ledgerHintProvider,
+		LedgerHintProvider:  o.ledgerHintProviderSnapshot(),
 	}
 }
 

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -836,6 +836,13 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		return
 	}
 
+	// mtSTATUS_CHANGE refreshes Closed-/Previous-Ledger hints
+	// (PeerImp.cpp:1812-1862).
+	if msgType == message.TypeStatusChange {
+		o.handleStatusChange(evt)
+		return
+	}
+
 	// Serve mtREPLAY_DELTA_REQ from the local ledger sync handler. Mirrors
 	// rippled's PeerImp::onMessage(TMReplayDeltaRequest) which delegates to
 	// LedgerReplayMsgHandler::processReplayDeltaRequest. Before dispatching
@@ -995,6 +1002,25 @@ func (o *Overlay) dispatchProofPathRequest(evt Event) {
 			o.IncPeerBadData(evt.PeerID, "proof-path-req-bad")
 		}
 	}
+}
+
+func (o *Overlay) handleStatusChange(evt Event) {
+	decoded, err := message.Decode(message.TypeStatusChange, evt.Payload)
+	if err != nil {
+		slog.Debug("StatusChange decode failed", "t", "Overlay", "peer", evt.PeerID, "err", err)
+		return
+	}
+	sc, ok := decoded.(*message.StatusChange)
+	if !ok {
+		return
+	}
+	o.peersMu.RLock()
+	peer, exists := o.peers[evt.PeerID]
+	o.peersMu.RUnlock()
+	if !exists {
+		return
+	}
+	peer.applyStatusChange(sc.LedgerHash, sc.LedgerHashPrevious, sc.NewEvent == message.NodeEventLostSync)
 }
 
 // handleSquelchMessage processes an inbound TMSquelch from a peer and

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -4,10 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/tls"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"sync"
@@ -162,6 +165,15 @@ type Overlay struct {
 	cfg      Config
 	identity *Identity
 
+	// instanceCookie is generated once in [1, MAX-1] (matches rippled
+	// Application.cpp `1 + rand_int(prng, MAX-1)`).
+	instanceCookie uint64
+
+	// ledgerHintProvider feeds the Closed-Ledger / Previous-Ledger
+	// handshake hints. Wired by a higher layer to avoid importing
+	// internal/ledger here.
+	ledgerHintProvider func() ([32]byte, [32]byte, bool)
+
 	// Components
 	discovery  *Discovery
 	relay      *Relay
@@ -219,6 +231,51 @@ type Overlay struct {
 // higher layer (e.g., consensus startup) can wire a LedgerProvider that
 // imports internal/ledger packages — which this layer cannot.
 func (o *Overlay) LedgerSync() *LedgerSyncHandler { return o.ledgerSync }
+
+// PeersWithClosedLedger returns peers whose Closed-Ledger handshake
+// hint matches target. Mirrors rippled NetworkOPs picking peers via
+// PeerImp::closedLedgerHash_.
+func (o *Overlay) PeersWithClosedLedger(target [32]byte) []PeerID {
+	o.peersMu.RLock()
+	defer o.peersMu.RUnlock()
+
+	var matches []PeerID
+	for id, peer := range o.peers {
+		if peer.State() != PeerStateConnected {
+			continue
+		}
+		closed, ok := peer.ClosedLedger()
+		if ok && closed == target {
+			matches = append(matches, id)
+		}
+	}
+	return matches
+}
+
+// InstanceCookie returns the per-process nonce. Stable for the
+// lifetime of the Overlay.
+func (o *Overlay) InstanceCookie() uint64 { return o.instanceCookie }
+
+// SetLedgerHintProvider wires the Closed-Ledger / Previous-Ledger
+// hint source. Pass nil to suppress the headers.
+func (o *Overlay) SetLedgerHintProvider(fn func() ([32]byte, [32]byte, bool)) {
+	o.ledgerHintProvider = fn
+}
+
+func generateInstanceCookie() (uint64, error) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return 0, err
+	}
+	v := binary.BigEndian.Uint64(b[:])
+	if v == 0 {
+		return 1, nil
+	}
+	if v == math.MaxUint64 {
+		return math.MaxUint64 - 1, nil
+	}
+	return v, nil
+}
 
 // localValidatorPubKey returns the compressed secp256k1 public key of
 // the local validator, or nil when this node is not acting as a
@@ -310,18 +367,24 @@ func New(opts ...Option) (*Overlay, error) {
 		return nil, fmt.Errorf("identity error: %w", err)
 	}
 
+	cookie, err := generateInstanceCookie()
+	if err != nil {
+		return nil, fmt.Errorf("instance cookie: %w", err)
+	}
+
 	events := make(chan Event, 256)
 
 	o := &Overlay{
-		cfg:           cfg,
-		identity:      identity,
-		discovery:     NewDiscovery(&cfg, events),
-		ledgerSync:    NewLedgerSyncHandler(events),
-		peers:         make(map[PeerID]*Peer),
-		events:        events,
-		messages:      make(chan *InboundMessage, 256),
-		relayedIndex:  make(map[[32]byte]*relayedEntry),
-		clockForIndex: time.Now,
+		cfg:            cfg,
+		identity:       identity,
+		instanceCookie: cookie,
+		discovery:      NewDiscovery(&cfg, events),
+		ledgerSync:     NewLedgerSyncHandler(events),
+		peers:          make(map[PeerID]*Peer),
+		events:         events,
+		messages:       make(chan *InboundMessage, 256),
+		relayedIndex:   make(map[[32]byte]*relayedEntry),
+		clockForIndex:  time.Now,
 	}
 
 	// Wire reduce-relay callbacks. The squelch callback constructs and
@@ -333,6 +396,8 @@ func New(opts ...Option) (*Overlay, error) {
 	// ignored_squelch_callback are passed into Slot at construction
 	// (Slot.h:121-132 + Slot.h:112-113).
 	o.relay = NewRelayWithIgnoredCallback(&cfg, o.handleSquelch, o.chargeIgnoredSquelch)
+
+	o.ledgerSync.SetPeerLedgerHintLookup(o.PeersWithClosedLedger)
 
 	return o, nil
 }
@@ -596,15 +661,19 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 	peer.remotePubKey = peerPubKey
 	peer.mu.Unlock()
 
-	hsCfg := HandshakeConfig{
-		UserAgent:           o.cfg.UserAgent,
-		NetworkID:           o.cfg.NetworkID,
-		CrawlPublic:         false,
-		EnableLedgerReplay:  o.cfg.EnableLedgerReplay,
-		EnableCompression:   o.cfg.EnableCompression,
-		EnableVPReduceRelay: o.cfg.EnableVPReduceRelay,
-		EnableTxReduceRelay: o.cfg.EnableTxReduceRelay,
+	hsCfg := o.handshakeConfigFor()
+
+	peerRemote := tcpRemoteIP(tlsConn)
+	extras, extraErr := ParseHandshakeExtras(
+		req.Header,
+		o.cfg.PublicIP,
+		peerRemote,
+	)
+	if extraErr != nil {
+		o.IncPeerBadData(peer.ID(), "handshake-malformed-networkid")
+		return NewHandshakeError(peer.Endpoint(), "verify_extras", extraErr)
 	}
+	peer.applyHandshakeExtras(extras)
 
 	// Capture the peer's advertised protocol features from the handshake
 	// request headers so downstream code can query e.g. whether this peer
@@ -619,11 +688,30 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 	peer.mu.Unlock()
 
 	resp := BuildHandshakeResponse(o.identity, sharedValue, hsCfg)
+	addAddressHeaders(resp.Header, hsCfg, peerRemote)
 	if err := resp.Write(tlsConn); err != nil {
 		return NewHandshakeError(peer.Endpoint(), "send_response", err)
 	}
 
 	return nil
+}
+
+// handshakeConfigFor builds the per-handshake config used by both
+// inbound and outbound paths so they cannot drift.
+func (o *Overlay) handshakeConfigFor() HandshakeConfig {
+	return HandshakeConfig{
+		UserAgent:           o.cfg.UserAgent,
+		NetworkID:           o.cfg.NetworkID,
+		CrawlPublic:         false,
+		EnableLedgerReplay:  o.cfg.EnableLedgerReplay,
+		EnableCompression:   o.cfg.EnableCompression,
+		EnableVPReduceRelay: o.cfg.EnableVPReduceRelay,
+		EnableTxReduceRelay: o.cfg.EnableTxReduceRelay,
+		InstanceCookie:      o.instanceCookie,
+		ServerDomain:        o.cfg.ServerDomain,
+		PublicIP:            o.cfg.PublicIP,
+		LedgerHintProvider:  o.ledgerHintProvider,
+	}
 }
 
 // eventLoop processes internal events.
@@ -1201,15 +1289,7 @@ func (o *Overlay) Connect(addr string) error {
 
 	peerID := PeerID(o.nextID.Add(1))
 	peer := NewPeer(peerID, endpoint, false, o.identity, o.events)
-	peer.handshakeCfg = HandshakeConfig{
-		UserAgent:           o.cfg.UserAgent,
-		NetworkID:           o.cfg.NetworkID,
-		CrawlPublic:         false,
-		EnableLedgerReplay:  o.cfg.EnableLedgerReplay,
-		EnableCompression:   o.cfg.EnableCompression,
-		EnableVPReduceRelay: o.cfg.EnableVPReduceRelay,
-		EnableTxReduceRelay: o.cfg.EnableTxReduceRelay,
-	}
+	peer.handshakeCfg = o.handshakeConfigFor()
 
 	o.events <- Event{
 		Type:     EventPeerConnecting,
@@ -1488,6 +1568,40 @@ func (o *Overlay) Peers() []PeerInfo {
 		result = append(result, peer.Info())
 	}
 	return result
+}
+
+// PeersJSON implements types.PeerSource for the `peers` RPC method.
+func (o *Overlay) PeersJSON() []map[string]any {
+	list := o.Peers()
+	out := make([]map[string]any, 0, len(list))
+	for _, p := range list {
+		entry := map[string]any{
+			"address":    p.Endpoint.String(),
+			"inbound":    p.Inbound,
+			"public_key": p.PublicKey,
+			"uptime":     int64(time.Since(p.ConnectedAt).Seconds()),
+		}
+		if p.InstanceCookie != 0 {
+			entry["instance_cookie"] = p.InstanceCookie
+		}
+		if p.ServerDomain != "" {
+			entry["server_domain"] = p.ServerDomain
+		}
+		if p.ClosedLedger != "" {
+			entry["closed_ledger"] = p.ClosedLedger
+		}
+		if p.PreviousLedger != "" {
+			entry["previous_ledger"] = p.PreviousLedger
+		}
+		if p.RemoteIP != "" {
+			entry["remote_ip"] = p.RemoteIP
+		}
+		if p.LocalIP != "" {
+			entry["local_ip"] = p.LocalIP
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 // PeerCount returns the number of connected peers.

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -252,10 +252,6 @@ func (o *Overlay) PeersWithClosedLedger(target [32]byte) []PeerID {
 	return matches
 }
 
-// InstanceCookie returns the per-process nonce. Stable for the
-// lifetime of the Overlay.
-func (o *Overlay) InstanceCookie() uint64 { return o.instanceCookie }
-
 // SetLedgerHintProvider wires the hint source; nil suppresses headers.
 func (o *Overlay) SetLedgerHintProvider(fn func() (LedgerHints, bool)) {
 	o.hintMu.Lock()
@@ -269,18 +265,23 @@ func (o *Overlay) ledgerHintProviderSnapshot() func() (LedgerHints, bool) {
 	return o.ledgerHintProvider
 }
 
-// generateInstanceCookie returns a value in [1, MAX] (rippled
-// Application.cpp `1 + rand_int(prng, MAX-1)`).
+// generateInstanceCookie returns a value in [1, MAX-1] to match rippled
+// `1 + rand_int(prng, MAX-1)` from Application.cpp — both 0 and MAX are
+// excluded. Rejection sampling on the two boundary values keeps the
+// distribution uniform; the rejection probability is 2/2^64.
 func generateInstanceCookie() (uint64, error) {
-	var b [8]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return 0, err
+	const maxU64 = ^uint64(0)
+	for {
+		var b [8]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			return 0, err
+		}
+		v := binary.BigEndian.Uint64(b[:])
+		if v == 0 || v == maxU64 {
+			continue
+		}
+		return v, nil
 	}
-	v := binary.BigEndian.Uint64(b[:])
-	if v == 0 {
-		return 1, nil
-	}
-	return v, nil
 }
 
 // localValidatorPubKey returns the compressed secp256k1 public key of
@@ -1610,9 +1611,11 @@ func (o *Overlay) Peers() []PeerInfo {
 }
 
 // PeersJSON implements types.PeerSource for the `peers` RPC method.
-// Mirrors rippled PeerImp::json (PeerImp.cpp:388-503); the
-// previous_ledger / remote_ip / local_ip / server_domain /
-// instance_cookie fields are goXRPL extensions.
+// Strict subset of rippled PeerImp::json (PeerImp.cpp:388-503): only
+// fields that rippled actually emits AND for which goXRPL has the data.
+// Missing rippled fields (network_id, version, protocol, latency,
+// complete_ledgers, track, status, load, metrics, cluster/name) are
+// tracked as separate follow-ups.
 func (o *Overlay) PeersJSON() []map[string]any {
 	list := o.Peers()
 	out := make([]map[string]any, 0, len(list))
@@ -1625,23 +1628,11 @@ func (o *Overlay) PeersJSON() []map[string]any {
 		if p.Inbound {
 			entry["inbound"] = true
 		}
-		if p.ClosedLedger != "" {
-			entry["ledger"] = p.ClosedLedger
-		}
-		if p.InstanceCookie != 0 {
-			entry["instance_cookie"] = p.InstanceCookie
-		}
 		if p.ServerDomain != "" {
 			entry["server_domain"] = p.ServerDomain
 		}
-		if p.PreviousLedger != "" {
-			entry["previous_ledger"] = p.PreviousLedger
-		}
-		if p.RemoteIP != "" {
-			entry["remote_ip"] = p.RemoteIP
-		}
-		if p.LocalIP != "" {
-			entry["local_ip"] = p.LocalIP
+		if p.ClosedLedger != "" {
+			entry["ledger"] = p.ClosedLedger
 		}
 		out = append(out, entry)
 	}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -231,10 +231,15 @@ type Overlay struct {
 // imports internal/ledger packages — which this layer cannot.
 func (o *Overlay) LedgerSync() *LedgerSyncHandler { return o.ledgerSync }
 
-// PeersWithClosedLedger returns peers whose Closed-Ledger handshake
-// hint matches target. goXRPL-side optimization for the catchup peer
-// picker — rippled's NetworkOPs uses closedLedgerHash_ for consensus
-// LCL voting (getPreferredLCL), not for routing fetch requests.
+// PeersWithClosedLedger returns peers whose last-known Closed-Ledger
+// hash equals target. The hash is seeded from the handshake hint and
+// refreshed by inbound mtSTATUS_CHANGE messages, mirroring the
+// PeerImp::closedLedgerHash_ field in rippled. This is a primitive for
+// callers that want a coarse "who advertised this LCL" filter; it is
+// NOT an analogue of rippled's catchup peer selection, which goes
+// through PeerImp::hasLedger(hash, seq) over [minLedger_, maxLedger_]
+// and the recentLedgers_ ring — state goXRPL does not yet track per
+// peer.
 func (o *Overlay) PeersWithClosedLedger(target [32]byte) []PeerID {
 	o.peersMu.RLock()
 	defer o.peersMu.RUnlock()

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -638,6 +638,13 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 	}
 	req.Body.Close()
 
+	// Server-Domain runs first (rippled Handshake.cpp:235-239 — the
+	// first throw in verifyHandshake).
+	if _, err := ValidateServerDomain(req.Header); err != nil {
+		o.IncPeerBadData(peer.ID(), "handshake-malformed-extras")
+		return NewHandshakeError(peer.Endpoint(), "verify_extras", err)
+	}
+
 	// R5.2 PARTIAL + R6.1 + R6.2: verify everything the handshake
 	// can enforce without the TLS shared-value signature (which is
 	// blocked by Go's c.serverFinished asymmetry — see

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -88,15 +88,15 @@ type Peer struct {
 	badDataBalance atomic.Int64
 
 	// closedLedger / previousLedger are also refreshed by inbound
-	// mtSTATUS_CHANGE (PeerImp.cpp:1812-1862).
-	instanceCookie     uint64
-	serverDomain       string
-	closedLedger       [32]byte
-	previousLedger     [32]byte
-	hasClosedLedger    bool
-	hasPreviousLedger  bool
-	remoteIPSelfReport string
-	localIPSelfReport  string
+	// mtSTATUS_CHANGE (PeerImp.cpp:1812-1862). Rippled stores both as
+	// typed `closedLedgerHash_` / `previousLedgerHash_` on PeerImp.
+	// serverDomain mirrors rippled's `domain()` accessor reading from
+	// its `headers_["Server-Domain"]` map.
+	serverDomain      string
+	closedLedger      [32]byte
+	previousLedger    [32]byte
+	hasClosedLedger   bool
+	hasPreviousLedger bool
 }
 
 // PeerConfig holds peer connection configuration.
@@ -192,7 +192,6 @@ func (p *Peer) Capabilities() *PeerCapabilities {
 func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.instanceCookie = x.InstanceCookie
 	p.serverDomain = x.ServerDomain
 	if x.HasClosedLedger {
 		p.closedLedger = x.ClosedLedger
@@ -208,8 +207,6 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 		p.previousLedger = [32]byte{}
 		p.hasPreviousLedger = false
 	}
-	p.remoteIPSelfReport = x.RemoteIPSelf
-	p.localIPSelfReport = x.LocalIPSelf
 }
 
 // applyStatusChange mirrors rippled PeerImp.cpp:1812-1862.
@@ -239,12 +236,7 @@ func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool) {
 	}
 }
 
-func (p *Peer) InstanceCookie() uint64 {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.instanceCookie
-}
-
+// ServerDomain mirrors rippled's `PeerImp::domain()` (PeerImp.cpp:842).
 func (p *Peer) ServerDomain() string {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -263,18 +255,6 @@ func (p *Peer) PreviousLedger() ([32]byte, bool) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.previousLedger, p.hasPreviousLedger
-}
-
-func (p *Peer) RemoteIPSelfReport() string {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.remoteIPSelfReport
-}
-
-func (p *Peer) LocalIPSelfReport() string {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.localIPSelfReport
 }
 
 // Connect establishes connection to the peer (outbound).
@@ -753,14 +733,11 @@ type PeerInfo struct {
 	MessagesIn  uint64
 	MessagesOut uint64
 
-	// Issue-#270 handshake fields. ClosedLedger / PreviousLedger are
-	// upper-case hex (rippled `peers` convention), "" when absent.
-	InstanceCookie uint64
-	ServerDomain   string
-	ClosedLedger   string
-	PreviousLedger string
-	RemoteIP       string
-	LocalIP        string
+	// Handshake-derived state mirroring what rippled stores typed on
+	// PeerImp. ClosedLedger is upper-case hex (rippled `peers`
+	// convention via `to_string(closedLedgerHash)`), "" when absent.
+	ServerDomain string
+	ClosedLedger string
 }
 
 // Info returns read-only information about the peer.
@@ -775,28 +752,21 @@ func (p *Peer) Info() PeerInfo {
 
 	stats := p.traffic.GetTotalStats()
 
-	var closedLedger, previousLedger string
+	var closedLedger string
 	if p.hasClosedLedger {
 		closedLedger = strings.ToUpper(hex.EncodeToString(p.closedLedger[:]))
 	}
-	if p.hasPreviousLedger {
-		previousLedger = strings.ToUpper(hex.EncodeToString(p.previousLedger[:]))
-	}
 
 	return PeerInfo{
-		ID:             p.id,
-		Endpoint:       p.endpoint,
-		Inbound:        p.inbound,
-		State:          p.state,
-		PublicKey:      pubKey,
-		ConnectedAt:    p.createdAt,
-		MessagesIn:     stats.MessagesIn,
-		MessagesOut:    stats.MessagesOut,
-		InstanceCookie: p.instanceCookie,
-		ServerDomain:   p.serverDomain,
-		ClosedLedger:   closedLedger,
-		PreviousLedger: previousLedger,
-		RemoteIP:       p.remoteIPSelfReport,
-		LocalIP:        p.localIPSelfReport,
+		ID:           p.id,
+		Endpoint:     p.endpoint,
+		Inbound:      p.inbound,
+		State:        p.state,
+		PublicKey:    pubKey,
+		ConnectedAt:  p.createdAt,
+		MessagesIn:   stats.MessagesIn,
+		MessagesOut:  stats.MessagesOut,
+		ServerDomain: p.serverDomain,
+		ClosedLedger: closedLedger,
 	}
 }

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -354,6 +354,9 @@ func (p *Peer) performHandshake(ctx context.Context, tlsConn *tls.Conn) error {
 	p.capabilities = caps
 	p.mu.Unlock()
 
+	if _, err := ValidateServerDomain(resp.Header); err != nil {
+		return NewHandshakeError(p.endpoint, "verify_extras", err)
+	}
 	extras, err := ParseHandshakeExtras(
 		resp.Header,
 		p.handshakeCfg.PublicIP,

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -87,12 +87,14 @@ type Peer struct {
 	// accommodate potential negative values from decay overshoot.
 	badDataBalance atomic.Int64
 
-	// Issue-#270 handshake fields; zero when the peer omitted the header.
+	// closedLedger / previousLedger are also refreshed by inbound
+	// mtSTATUS_CHANGE (PeerImp.cpp:1812-1862).
 	instanceCookie     uint64
 	serverDomain       string
 	closedLedger       [32]byte
 	previousLedger     [32]byte
-	hasLedgerHints     bool
+	hasClosedLedger    bool
+	hasPreviousLedger  bool
 	remoteIPSelfReport string
 	localIPSelfReport  string
 }
@@ -194,9 +196,37 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 	p.serverDomain = x.ServerDomain
 	p.closedLedger = x.ClosedLedger
 	p.previousLedger = x.PreviousLedger
-	p.hasLedgerHints = x.HasLedgerHints
+	p.hasClosedLedger = x.HasLedgerHints
+	p.hasPreviousLedger = x.HasLedgerHints
 	p.remoteIPSelfReport = x.RemoteIPSelf
 	p.localIPSelfReport = x.LocalIPSelf
+}
+
+// applyStatusChange mirrors rippled PeerImp.cpp:1812-1862.
+func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if lostSync {
+		p.hasClosedLedger = false
+		p.hasPreviousLedger = false
+		p.closedLedger = [32]byte{}
+		p.previousLedger = [32]byte{}
+		return
+	}
+	if len(closed) == 32 {
+		copy(p.closedLedger[:], closed)
+		p.hasClosedLedger = true
+	} else {
+		p.hasClosedLedger = false
+		p.closedLedger = [32]byte{}
+	}
+	if len(previous) == 32 {
+		copy(p.previousLedger[:], previous)
+		p.hasPreviousLedger = true
+	} else {
+		p.hasPreviousLedger = false
+		p.previousLedger = [32]byte{}
+	}
 }
 
 func (p *Peer) InstanceCookie() uint64 {
@@ -211,18 +241,18 @@ func (p *Peer) ServerDomain() string {
 	return p.serverDomain
 }
 
-// ClosedLedger returns (hash, ok). ok is false when the peer omitted
-// the header or sent it malformed.
+// ClosedLedger returns (hash, ok); ok is false when no valid hint.
 func (p *Peer) ClosedLedger() ([32]byte, bool) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return p.closedLedger, p.hasLedgerHints
+	return p.closedLedger, p.hasClosedLedger
 }
 
-func (p *Peer) PreviousLedger() [32]byte {
+// PreviousLedger returns (hash, ok); ok is false when no valid hint.
+func (p *Peer) PreviousLedger() ([32]byte, bool) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return p.previousLedger
+	return p.previousLedger, p.hasPreviousLedger
 }
 
 func (p *Peer) RemoteIPSelfReport() string {
@@ -736,8 +766,10 @@ func (p *Peer) Info() PeerInfo {
 	stats := p.traffic.GetTotalStats()
 
 	var closedLedger, previousLedger string
-	if p.hasLedgerHints {
+	if p.hasClosedLedger {
 		closedLedger = strings.ToUpper(hex.EncodeToString(p.closedLedger[:]))
+	}
+	if p.hasPreviousLedger {
 		previousLedger = strings.ToUpper(hex.EncodeToString(p.previousLedger[:]))
 	}
 

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -84,6 +86,15 @@ type Peer struct {
 	// a persistent offender eventually evicts. Stored as int64 to
 	// accommodate potential negative values from decay overshoot.
 	badDataBalance atomic.Int64
+
+	// Issue-#270 handshake fields; zero when the peer omitted the header.
+	instanceCookie     uint64
+	serverDomain       string
+	closedLedger       [32]byte
+	previousLedger     [32]byte
+	hasLedgerHints     bool
+	remoteIPSelfReport string
+	localIPSelfReport  string
 }
 
 // PeerConfig holds peer connection configuration.
@@ -176,6 +187,56 @@ func (p *Peer) Capabilities() *PeerCapabilities {
 	return p.capabilities
 }
 
+func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.instanceCookie = x.InstanceCookie
+	p.serverDomain = x.ServerDomain
+	p.closedLedger = x.ClosedLedger
+	p.previousLedger = x.PreviousLedger
+	p.hasLedgerHints = x.HasLedgerHints
+	p.remoteIPSelfReport = x.RemoteIPSelf
+	p.localIPSelfReport = x.LocalIPSelf
+}
+
+func (p *Peer) InstanceCookie() uint64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.instanceCookie
+}
+
+func (p *Peer) ServerDomain() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.serverDomain
+}
+
+// ClosedLedger returns (hash, ok). ok is false when the peer omitted
+// the header or sent it malformed.
+func (p *Peer) ClosedLedger() ([32]byte, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.closedLedger, p.hasLedgerHints
+}
+
+func (p *Peer) PreviousLedger() [32]byte {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.previousLedger
+}
+
+func (p *Peer) RemoteIPSelfReport() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.remoteIPSelfReport
+}
+
+func (p *Peer) LocalIPSelfReport() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.localIPSelfReport
+}
+
 // Connect establishes connection to the peer (outbound).
 func (p *Peer) Connect(ctx context.Context, cfg PeerConfig) error {
 	p.mu.Lock()
@@ -241,6 +302,10 @@ func (p *Peer) performHandshake(ctx context.Context, tlsConn *tls.Conn) error {
 		return NewHandshakeError(p.endpoint, "build_request", err)
 	}
 
+	if peerIP := tcpRemoteIP(tlsConn); peerIP != nil {
+		addAddressHeaders(req.Header, p.handshakeCfg, peerIP)
+	}
+
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		deadline = time.Now().Add(DefaultHandshakeTimeout)
@@ -289,7 +354,29 @@ func (p *Peer) performHandshake(ctx context.Context, tlsConn *tls.Conn) error {
 	p.capabilities = caps
 	p.mu.Unlock()
 
+	extras, err := ParseHandshakeExtras(
+		resp.Header,
+		p.handshakeCfg.PublicIP,
+		tcpRemoteIP(tlsConn),
+	)
+	if err != nil {
+		return NewHandshakeError(p.endpoint, "verify_extras", err)
+	}
+	p.applyHandshakeExtras(extras)
+
 	return nil
+}
+
+func tcpRemoteIP(conn net.Conn) net.IP {
+	addr, ok := conn.RemoteAddr().(*net.TCPAddr)
+	if !ok {
+		host, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+		if err != nil {
+			return nil
+		}
+		return net.ParseIP(host)
+	}
+	return addr.IP
 }
 
 // Run starts the peer's read/write/ping loops.
@@ -622,6 +709,15 @@ type PeerInfo struct {
 	ConnectedAt time.Time
 	MessagesIn  uint64
 	MessagesOut uint64
+
+	// Issue-#270 handshake fields. ClosedLedger / PreviousLedger are
+	// upper-case hex (rippled `peers` convention), "" when absent.
+	InstanceCookie uint64
+	ServerDomain   string
+	ClosedLedger   string
+	PreviousLedger string
+	RemoteIP       string
+	LocalIP        string
 }
 
 // Info returns read-only information about the peer.
@@ -636,14 +732,26 @@ func (p *Peer) Info() PeerInfo {
 
 	stats := p.traffic.GetTotalStats()
 
+	var closedLedger, previousLedger string
+	if p.hasLedgerHints {
+		closedLedger = strings.ToUpper(hex.EncodeToString(p.closedLedger[:]))
+		previousLedger = strings.ToUpper(hex.EncodeToString(p.previousLedger[:]))
+	}
+
 	return PeerInfo{
-		ID:          p.id,
-		Endpoint:    p.endpoint,
-		Inbound:     p.inbound,
-		State:       p.state,
-		PublicKey:   pubKey,
-		ConnectedAt: p.createdAt,
-		MessagesIn:  stats.MessagesIn,
-		MessagesOut: stats.MessagesOut,
+		ID:             p.id,
+		Endpoint:       p.endpoint,
+		Inbound:        p.inbound,
+		State:          p.state,
+		PublicKey:      pubKey,
+		ConnectedAt:    p.createdAt,
+		MessagesIn:     stats.MessagesIn,
+		MessagesOut:    stats.MessagesOut,
+		InstanceCookie: p.instanceCookie,
+		ServerDomain:   p.serverDomain,
+		ClosedLedger:   closedLedger,
+		PreviousLedger: previousLedger,
+		RemoteIP:       p.remoteIPSelfReport,
+		LocalIP:        p.localIPSelfReport,
 	}
 }

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -194,10 +194,20 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 	defer p.mu.Unlock()
 	p.instanceCookie = x.InstanceCookie
 	p.serverDomain = x.ServerDomain
-	p.closedLedger = x.ClosedLedger
-	p.previousLedger = x.PreviousLedger
-	p.hasClosedLedger = x.HasLedgerHints
-	p.hasPreviousLedger = x.HasLedgerHints
+	if x.HasClosedLedger {
+		p.closedLedger = x.ClosedLedger
+		p.hasClosedLedger = true
+	} else {
+		p.closedLedger = [32]byte{}
+		p.hasClosedLedger = false
+	}
+	if x.HasPreviousLedger {
+		p.previousLedger = x.PreviousLedger
+		p.hasPreviousLedger = true
+	} else {
+		p.previousLedger = [32]byte{}
+		p.hasPreviousLedger = false
+	}
 	p.remoteIPSelfReport = x.RemoteIPSelf
 	p.localIPSelfReport = x.LocalIPSelf
 }

--- a/internal/rpc/handlers/peers.go
+++ b/internal/rpc/handlers/peers.go
@@ -6,20 +6,19 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// PeersMethod handles the peers RPC method.
-// STUB: Returns empty peer list. Network-only — not needed for standalone mode.
-//
-// TODO [network]: Implement when adding P2P networking layer.
-//   - Requires: Overlay/PeerManager service providing connected peer info
-//   - Reference: rippled Peers.cpp → context.app.overlay().json()
-//   - Response should include per-peer: address, port, latency, version,
-//     ledger sequence, complete_ledgers range, cluster status
+// PeersMethod returns peers from ctx.PeerSource (rippled Peers.cpp).
+// Empty list when no source is wired (standalone mode).
 type PeersMethod struct{ AdminHandler }
 
 func (m *PeersMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return map[string]interface{}{
-		"peers": []interface{}{},
-	}, nil
+	var peers []map[string]any
+	if ctx.PeerSource != nil {
+		peers = ctx.PeerSource.PeersJSON()
+	}
+	if peers == nil {
+		peers = []map[string]any{}
+	}
+	return map[string]any{"peers": peers}, nil
 }
 
 // PeerReservationsAddMethod handles the peer_reservations_add RPC method.

--- a/internal/rpc/handlers/peers_test.go
+++ b/internal/rpc/handlers/peers_test.go
@@ -32,13 +32,10 @@ func TestPeersMethod_NilSourceReturnsEmptyList(t *testing.T) {
 func TestPeersMethod_PassesThroughSource(t *testing.T) {
 	src := &fakePeerSource{peers: []map[string]any{
 		{
-			"address":         "192.0.2.1:51235",
-			"public_key":      "nHB1...",
-			"server_domain":   "validator.example.com",
-			"ledger":          "ABCD",
-			"previous_ledger": "0123",
-			"remote_ip":       "203.0.113.7",
-			"local_ip":        "198.51.100.42",
+			"address":       "192.0.2.1:51235",
+			"public_key":    "nHB1...",
+			"server_domain": "validator.example.com",
+			"ledger":        "ABCD",
 		},
 	}}
 	m := &handlers.PeersMethod{}
@@ -61,5 +58,4 @@ func TestPeersMethod_PassesThroughSource(t *testing.T) {
 	assert.Equal(t, "ABCD", peers[0]["ledger"])
 	assert.NotContains(t, peers[0], "closed_ledger", "rippled uses 'ledger' for the closed-ledger hash")
 	assert.NotContains(t, peers[0], "inbound", "inbound is only emitted when true")
-	assert.Equal(t, "203.0.113.7", peers[0]["remote_ip"])
 }

--- a/internal/rpc/handlers/peers_test.go
+++ b/internal/rpc/handlers/peers_test.go
@@ -33,10 +33,9 @@ func TestPeersMethod_PassesThroughSource(t *testing.T) {
 	src := &fakePeerSource{peers: []map[string]any{
 		{
 			"address":         "192.0.2.1:51235",
-			"inbound":         false,
 			"public_key":      "nHB1...",
 			"server_domain":   "validator.example.com",
-			"closed_ledger":   "ABCD",
+			"ledger":          "ABCD",
 			"previous_ledger": "0123",
 			"remote_ip":       "203.0.113.7",
 			"local_ip":        "198.51.100.42",
@@ -59,6 +58,8 @@ func TestPeersMethod_PassesThroughSource(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, peers, 1)
 	assert.Equal(t, "validator.example.com", peers[0]["server_domain"])
-	assert.Equal(t, "ABCD", peers[0]["closed_ledger"])
+	assert.Equal(t, "ABCD", peers[0]["ledger"])
+	assert.NotContains(t, peers[0], "closed_ledger", "rippled uses 'ledger' for the closed-ledger hash")
+	assert.NotContains(t, peers[0], "inbound", "inbound is only emitted when true")
 	assert.Equal(t, "203.0.113.7", peers[0]["remote_ip"])
 }

--- a/internal/rpc/handlers/peers_test.go
+++ b/internal/rpc/handlers/peers_test.go
@@ -1,0 +1,64 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakePeerSource struct {
+	peers []map[string]any
+}
+
+func (f *fakePeerSource) PeersJSON() []map[string]any { return f.peers }
+
+func TestPeersMethod_NilSourceReturnsEmptyList(t *testing.T) {
+	m := &handlers.PeersMethod{}
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, IsAdmin: true}
+
+	result, rpcErr := m.Handle(ctx, json.RawMessage(`{}`))
+	require.Nil(t, rpcErr)
+
+	resp, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []map[string]any{}, resp["peers"])
+}
+
+func TestPeersMethod_PassesThroughSource(t *testing.T) {
+	src := &fakePeerSource{peers: []map[string]any{
+		{
+			"address":         "192.0.2.1:51235",
+			"inbound":         false,
+			"public_key":      "nHB1...",
+			"server_domain":   "validator.example.com",
+			"closed_ledger":   "ABCD",
+			"previous_ledger": "0123",
+			"remote_ip":       "203.0.113.7",
+			"local_ip":        "198.51.100.42",
+		},
+	}}
+	m := &handlers.PeersMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		IsAdmin:    true,
+		PeerSource: src,
+	}
+
+	result, rpcErr := m.Handle(ctx, json.RawMessage(`{}`))
+	require.Nil(t, rpcErr)
+
+	resp, ok := result.(map[string]any)
+	require.True(t, ok)
+	peers, ok := resp["peers"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, peers, 1)
+	assert.Equal(t, "validator.example.com", peers[0]["server_domain"])
+	assert.Equal(t, "ABCD", peers[0]["closed_ledger"])
+	assert.Equal(t, "203.0.113.7", peers[0]["remote_ip"])
+}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/goXRPLd/config"
@@ -22,10 +23,23 @@ func rpcLog() xrpllog.Logger { return xrpllog.Named(xrpllog.PartitionRPC) }
 type Server struct {
 	registry   *types.MethodRegistry
 	timeout    time.Duration
-	peerSource types.PeerSource
+	peerSource atomic.Pointer[types.PeerSource]
 }
 
-func (s *Server) SetPeerSource(src types.PeerSource) { s.peerSource = src }
+func (s *Server) SetPeerSource(src types.PeerSource) {
+	if src == nil {
+		s.peerSource.Store(nil)
+		return
+	}
+	s.peerSource.Store(&src)
+}
+
+func (s *Server) loadPeerSource() types.PeerSource {
+	if p := s.peerSource.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
 
 // NewServer creates a new RPC server with the given timeout
 func NewServer(timeout time.Duration) *Server {
@@ -104,7 +118,7 @@ func (s *Server) handleGetRequest(w http.ResponseWriter, r *http.Request) {
 		ApiVersion: types.DefaultApiVersion,
 		IsAdmin:    role == types.RoleAdmin,
 		ClientIP:   clientIP,
-		PeerSource: s.peerSource,
+		PeerSource: s.loadPeerSource(),
 	}
 
 	result, rpcErr := s.executeMethod(method, nil, ctx)
@@ -146,7 +160,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		ApiVersion: types.DefaultApiVersion,
 		IsAdmin:    role == types.RoleAdmin,
 		ClientIP:   clientIP,
-		PeerSource: s.peerSource,
+		PeerSource: s.loadPeerSource(),
 	}
 
 	// Parse API version from params if present
@@ -320,7 +334,7 @@ func (s *Server) ExecuteMethod(method string, params []byte) (interface{}, *type
 		Role:       types.RoleGuest,
 		ApiVersion: types.DefaultApiVersion,
 		IsAdmin:    false,
-		PeerSource: s.peerSource,
+		PeerSource: s.loadPeerSource(),
 	}
 	return s.executeMethod(method, json.RawMessage(params), ctx)
 }

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -26,6 +26,9 @@ type Server struct {
 	peerSource atomic.Pointer[types.PeerSource]
 }
 
+// SetPeerSource registers the source of per-peer entries served by the
+// `peers` RPC handler. Passing nil detaches the source so the handler
+// returns an empty list. Safe to call concurrently with reads.
 func (s *Server) SetPeerSource(src types.PeerSource) {
 	if src == nil {
 		s.peerSource.Store(nil)

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -20,9 +20,12 @@ func rpcLog() xrpllog.Logger { return xrpllog.Named(xrpllog.PartitionRPC) }
 
 // Server handles HTTP JSON-RPC requests using XRPL format
 type Server struct {
-	registry *types.MethodRegistry
-	timeout  time.Duration
+	registry   *types.MethodRegistry
+	timeout    time.Duration
+	peerSource types.PeerSource
 }
+
+func (s *Server) SetPeerSource(src types.PeerSource) { s.peerSource = src }
 
 // NewServer creates a new RPC server with the given timeout
 func NewServer(timeout time.Duration) *Server {
@@ -101,6 +104,7 @@ func (s *Server) handleGetRequest(w http.ResponseWriter, r *http.Request) {
 		ApiVersion: types.DefaultApiVersion,
 		IsAdmin:    role == types.RoleAdmin,
 		ClientIP:   clientIP,
+		PeerSource: s.peerSource,
 	}
 
 	result, rpcErr := s.executeMethod(method, nil, ctx)
@@ -142,6 +146,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		ApiVersion: types.DefaultApiVersion,
 		IsAdmin:    role == types.RoleAdmin,
 		ClientIP:   clientIP,
+		PeerSource: s.peerSource,
 	}
 
 	// Parse API version from params if present
@@ -315,6 +320,7 @@ func (s *Server) ExecuteMethod(method string, params []byte) (interface{}, *type
 		Role:       types.RoleGuest,
 		ApiVersion: types.DefaultApiVersion,
 		IsAdmin:    false,
+		PeerSource: s.peerSource,
 	}
 	return s.executeMethod(method, json.RawMessage(params), ctx)
 }

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -43,6 +43,11 @@ const (
 	NeedsClosedLedger
 )
 
+// PeerSource produces the per-peer entries the `peers` RPC returns.
+type PeerSource interface {
+	PeersJSON() []map[string]any
+}
+
 // RPC Context contains request-specific information
 type RpcContext struct {
 	Context    context.Context
@@ -50,6 +55,7 @@ type RpcContext struct {
 	ApiVersion int
 	IsAdmin    bool
 	ClientIP   string
+	PeerSource PeerSource
 }
 
 // Method handler interface - all RPC methods implement this

--- a/tasks/pr-handshake-headers.md
+++ b/tasks/pr-handshake-headers.md
@@ -27,7 +27,7 @@ Constants for `Closed-Ledger` and `Previous-Ledger` already exist at `internal/p
 - Emit all six on outbound (`BuildHandshakeRequest`) and on inbound (`BuildHandshakeResponse`).
 - Parse all six on inbound and outbound; store on `Peer`. **Strict rippled parity**: Instance-Cookie is stored only, never compared — `verifyHandshake` does not inspect it; self-connection detection stays pubkey-only at `Handshake.cpp:322`.
 - IP consistency checks: faithfully reproduce `verifyHandshake` lines 325-359.
-- Wire `Closed-Ledger` hints into peer selection: `Overlay.PeersWithClosedLedger` plus `LedgerSyncHandler.PreferredPeersForLedger` so callers driving catchup ask peers that already advertise the target ledger first (matches rippled `NetworkOPs` consuming `PeerImp::closedLedgerHash_`).
+- Expose `Closed-Ledger` hints as a peer-selection primitive: `Overlay.PeersWithClosedLedger` plus `LedgerSyncHandler.PreferredPeersForLedger` filter peers by their last-known closed-ledger hash (seeded from the handshake hint, refreshed by `mtSTATUS_CHANGE`). This is a coarse filter only — it is NOT a port of rippled's catchup peer selection, which goes through `PeerImp::hasLedger(hash, seq)` and inspects `[minLedger_, maxLedger_]` plus the `recentLedgers_` ring (state goXRPL does not yet track per peer).
 - Surface peer info through the RPC `peers` handler: `types.PeerSource` interface plus `Server.SetPeerSource`; `Overlay.PeersJSON()` produces the per-peer entries with `server_domain`, `closed_ledger`, `previous_ledger`, `remote_ip`, `local_ip`. CLI wires the overlay in when running in consensus mode.
 - Four acceptance tests as named in the issue, plus targeted tests for the catchup picker and the RPC handler.
 

--- a/tasks/pr-handshake-headers.md
+++ b/tasks/pr-handshake-headers.md
@@ -1,0 +1,332 @@
+# PR Handshake Headers — Six remaining headers (Issue #270)
+
+**Branch:** `feature/handshake-headers-270`
+**Issue:** [#270](https://github.com/LeJamon/go-xrpl/issues/270) — deferred from PR #264 round-7 (`tasks/pr264-round7-fixes.md`, Out-of-scope row C4)
+**Goal:** Emit, parse, store, and consume six rippled handshake headers that goXRPL currently does not support, bringing parity with `rippled/src/xrpld/overlay/detail/Handshake.cpp` `buildHandshake` + `verifyHandshake`.
+
+---
+
+## Scope
+
+| Header | Direction | Format | Source of truth |
+|--------|-----------|--------|-----------------|
+| `Instance-Cookie` | both | decimal `uint64` (1..MAX-1, generated once per process) | `Handshake.cpp:208` |
+| `Server-Domain` | both | RFC-1035-style TOML-form domain string | `Handshake.cpp:210-211, 235-239` |
+| `Closed-Ledger` | both | lower-case hex of `uint256` (32 bytes → 64 chars) | `Handshake.cpp:219-223`, `PeerImp::run()` parser |
+| `Previous-Ledger` | both | lower-case hex of `uint256` (32 bytes → 64 chars) | `Handshake.cpp:222`, `PeerImp::run()` parser |
+| `Remote-IP` | outbound only writes; both verify | dotted-quad / colon-IPv6, only emitted when peer's IP is public | `Handshake.cpp:213-214, 340-359` |
+| `Local-IP` | outbound only writes; both verify | dotted-quad / colon-IPv6, only emitted when our public IP is configured | `Handshake.cpp:216-217, 325-338` |
+
+Constants for `Closed-Ledger` and `Previous-Ledger` already exist at `internal/peermanagement/handshake.go:35-36` but are never read or written. The other four header names do not yet exist as constants.
+
+**In scope (this PR):**
+- Add header constants for the four missing names.
+- Generate per-process `Instance-Cookie` once at `Overlay` construction (matches rippled `1 + rand_int(prng, MAX-1)` at Application.cpp).
+- Plumb `ServerDomain string` and `PublicIP net.IP` through `Config` and `HandshakeConfig`.
+- Plumb `ClosedLedger`/`PreviousLedger` 32-byte hashes from a `LedgerHintProvider` callback so `internal/peermanagement` does not have to import `internal/ledger`.
+- Emit all six on outbound (`BuildHandshakeRequest`) and on inbound (`BuildHandshakeResponse`).
+- Parse all six on inbound and outbound; store on `Peer`. **Strict rippled parity**: Instance-Cookie is stored only, never compared — `verifyHandshake` does not inspect it; self-connection detection stays pubkey-only at `Handshake.cpp:322`.
+- IP consistency checks: faithfully reproduce `verifyHandshake` lines 325-359.
+- Wire `Closed-Ledger` hints into peer selection: `Overlay.PeersWithClosedLedger` plus `LedgerSyncHandler.PreferredPeersForLedger` so callers driving catchup ask peers that already advertise the target ledger first (matches rippled `NetworkOPs` consuming `PeerImp::closedLedgerHash_`).
+- Surface peer info through the RPC `peers` handler: `types.PeerSource` interface plus `Server.SetPeerSource`; `Overlay.PeersJSON()` produces the per-peer entries with `server_domain`, `closed_ledger`, `previous_ledger`, `remote_ip`, `local_ip`. CLI wires the overlay in when running in consensus mode.
+- Four acceptance tests as named in the issue, plus targeted tests for the catchup picker and the RPC handler.
+
+**Out of scope:**
+- TOML domain validation per RFC-1035: rippled uses `isProperlyFormedTomlDomain`. We add a Go equivalent but keep the rule narrow (length ≤ 253, label-by-label `[A-Za-z0-9-]{1,63}`, no leading/trailing hyphen, optional trailing dot stripped). Stricter TOML semantics are a follow-up if/when operators report rejections.
+
+---
+
+## Files
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `internal/peermanagement/handshake.go` | Header constants; `HandshakeConfig.{ServerDomain, PublicIP, InstanceCookie, LedgerHintProvider}`; emit/parse helpers; `VerifyHandshakeHeadersNoSig` extended with IP consistency checks; new `parseLedgerHashHeader`. |
+| `internal/peermanagement/peer.go` | `Peer` gains `instanceCookie uint64`, `serverDomain string`, `closedLedger [32]byte`, `previousLedger [32]byte`, `remoteIPSelfReport string`, `localIPSelfReport string`, plus accessors. Populated from headers in the inbound and outbound code paths that call `VerifyHandshakeHeadersNoSig`. |
+| `internal/peermanagement/overlay.go` | At Overlay construction: generate `instanceCookie` once via `crypto/rand` (range `[1, math.MaxUint64-1]` to match rippled's `1 + rand_int(..., MAX-1)`); store on Overlay; thread into `HandshakeConfig`; expose `Overlay.InstanceCookie()` for tests. Self-connection check at the peer-attach site additionally compares cookies. |
+| `internal/peermanagement/handshake_test.go` | Four new acceptance tests + helper `buildAllHeadersRequest`. |
+| `internal/rpc/types/services.go` (or wherever `PeerInfo` lives) | Extend `PeerInfo` with the five new optional fields. |
+| `internal/peermanagement/overlay.go` (`Peers()` method) | Populate the new `PeerInfo` fields from `Peer` accessors. |
+| `internal/rpc/handlers/peers.go` | Pass the new fields through into the RPC response. JSON keys: `server_domain`, `closed_ledger`, `previous_ledger`, `remote_ip`, `local_ip` (matching rippled's `peers` method casing). |
+
+### Reference (read-only)
+
+- `rippled/src/xrpld/overlay/detail/Handshake.cpp:178-362` — `buildHandshake` + `verifyHandshake`.
+- `rippled/src/xrpld/overlay/detail/PeerImp.cpp` (lambda `parseLedgerHash` inside `PeerImp::run()`) — hex-or-base64 ledger hash parser, used as guidance for `parseLedgerHashHeader`.
+- `rippled/src/xrpld/app/main/Application.cpp` — `instanceCookie_(1 + rand_int(crypto_prng(), max-1))`.
+
+---
+
+## Phase 1 — Plumbing: constants, config, instance cookie
+
+### Task 1.1 — Add the missing header-name constants
+
+Append to the constant block at `handshake.go:27-39`:
+
+```go
+HeaderInstanceCookie = "Instance-Cookie"
+HeaderServerDomain   = "Server-Domain"
+HeaderRemoteIP       = "Remote-IP"
+HeaderLocalIP        = "Local-IP"
+```
+
+Existing `HeaderClosedLedger` and `HeaderPreviousLedger` constants stay where they are.
+
+### Task 1.2 — Extend `HandshakeConfig`
+
+```go
+type HandshakeConfig struct {
+    // ... existing fields ...
+
+    // ServerDomain is an operator-provided domain string advertised on
+    // every handshake. Empty disables the header (matches rippled's
+    // `if (!app.config().SERVER_DOMAIN.empty())`).
+    ServerDomain string
+
+    // PublicIP is our observed public address, if known. An unspecified
+    // value (zero-length / nil) disables the Local-IP header on outbound
+    // and disables the Remote-IP consistency check on inbound — same as
+    // rippled's `public_ip.is_unspecified()` short-circuit.
+    PublicIP net.IP
+
+    // InstanceCookie is the per-process nonce. Set once at Overlay
+    // construction; propagated by-value into every HandshakeConfig copy.
+    InstanceCookie uint64
+
+    // LedgerHintProvider returns the most recent closed-ledger hash
+    // and its parent. Returning ok=false suppresses both Closed-Ledger
+    // and Previous-Ledger headers on outbound (rippled wraps both
+    // `insert` calls under a single `if` on getClosedLedger()).
+    LedgerHintProvider func() (closed [32]byte, parent [32]byte, ok bool)
+}
+```
+
+`DefaultHandshakeConfig()` leaves the new fields zero / nil; production wiring lives in `overlay.go`.
+
+### Task 1.3 — Generate the instance cookie at Overlay construction
+
+In the Overlay constructor:
+
+```go
+var b [8]byte
+if _, err := rand.Read(b[:]); err != nil {
+    return nil, fmt.Errorf("instance cookie: %w", err)
+}
+cookie := binary.BigEndian.Uint64(b[:])
+// Match rippled's `1 + rand_int(prng, MAX-1)`: avoid 0 and MAX.
+if cookie == 0 {
+    cookie = 1
+} else if cookie == math.MaxUint64 {
+    cookie = math.MaxUint64 - 1
+}
+o.instanceCookie = cookie
+```
+
+Expose via `Overlay.InstanceCookie() uint64`. Thread into the `HandshakeConfig` value used for both client and server paths.
+
+---
+
+## Phase 2 — Emit on outbound and inbound
+
+### Task 2.1 — `addHandshakeHeaders` writes the new headers
+
+Extend the existing helper at `handshake.go:222-248`:
+
+```go
+if cfg.InstanceCookie != 0 {
+    h.Set(HeaderInstanceCookie, strconv.FormatUint(cfg.InstanceCookie, 10))
+}
+if cfg.ServerDomain != "" {
+    // Reject malformed domains at config time, not on every handshake.
+    h.Set(HeaderServerDomain, cfg.ServerDomain)
+}
+if cfg.LedgerHintProvider != nil {
+    if closed, parent, ok := cfg.LedgerHintProvider(); ok {
+        h.Set(HeaderClosedLedger, hex.EncodeToString(closed[:]))
+        h.Set(HeaderPreviousLedger, hex.EncodeToString(parent[:]))
+    }
+}
+// Remote-IP / Local-IP added at the call sites that know the peer's
+// remote address and whether it's public — we only have that
+// information once a TCP conn is in hand, not at config time.
+```
+
+`Remote-IP` and `Local-IP` need the per-connection peer address, so they are written by a separate helper invoked from the conn-attached code path (after the TCP connection is open) rather than from `addHandshakeHeaders`. Helper signature:
+
+```go
+func addAddressHeaders(h http.Header, cfg HandshakeConfig, remote net.IP) {
+    if remote != nil && isPublicIP(remote) {
+        h.Set(HeaderRemoteIP, remote.String())
+    }
+    if cfg.PublicIP != nil && !cfg.PublicIP.IsUnspecified() {
+        h.Set(HeaderLocalIP, cfg.PublicIP.String())
+    }
+}
+```
+
+`isPublicIP` returns `false` for loopback, link-local, multicast, and RFC-1918 ranges (mirrors `beast::IP::is_public` for both v4 and v6).
+
+### Task 2.2 — Wire `addAddressHeaders` into the request and response builders
+
+`BuildHandshakeRequest` and `BuildHandshakeResponse` gain a `remote net.IP` argument; existing call sites (overlay client/server attach) pass `conn.RemoteAddr().(*net.TCPAddr).IP`. `WriteRawHandshakeRequest` whitelist gets the four new header names appended to its writeHeader sequence so the raw HTTP frame includes them.
+
+---
+
+## Phase 3 — Parse on inbound, store on `Peer`
+
+### Task 3.1 — Extend `Peer` struct and accessors
+
+Add to `peer.go`:
+
+```go
+instanceCookie       uint64
+serverDomain         string
+closedLedger         [32]byte
+previousLedger       [32]byte
+hasLedgerHints       bool
+remoteIPSelfReport   string
+localIPSelfReport    string
+```
+
+Public accessors: `InstanceCookie()`, `ServerDomain()`, `ClosedLedger() ([32]byte, bool)`, `PreviousLedger() [32]byte`, `RemoteIPSelfReport()`, `LocalIPSelfReport()`. The boolean on `ClosedLedger()` is `hasLedgerHints` so callers don't need to compare against the zero hash.
+
+### Task 3.2 — `parseLedgerHashHeader`
+
+```go
+// parseLedgerHashHeader accepts a 64-char lower-case hex string
+// (rippled's strHex output). Rippled's PeerImp::run also accepts a
+// 32-byte base64 fallback; we mirror that so heterogeneous peers can
+// interop.
+func parseLedgerHashHeader(s string) ([32]byte, error) {
+    var out [32]byte
+    if len(s) == hex.EncodedLen(32) {
+        if _, err := hex.Decode(out[:], []byte(s)); err == nil {
+            return out, nil
+        }
+    }
+    if dec, err := base64.StdEncoding.DecodeString(s); err == nil && len(dec) == 32 {
+        copy(out[:], dec)
+        return out, nil
+    }
+    return out, fmt.Errorf("unrecognised ledger hash %q", s)
+}
+```
+
+A malformed hash on a present header is logged but not fatal — rippled's parser returns `std::nullopt` and `PeerImp::run()` simply does not store the hint. We follow the same lenient stance.
+
+### Task 3.3 — `VerifyHandshakeHeadersNoSig` parses and returns the new fields
+
+Refactor the function to return a richer struct so callers can populate `Peer` in one step:
+
+```go
+type VerifiedHandshake struct {
+    PeerPubKey     *PublicKeyToken
+    InstanceCookie uint64
+    ServerDomain   string
+    ClosedLedger   [32]byte
+    PreviousLedger [32]byte
+    HasLedgerHints bool
+    RemoteIPSelf   string
+    LocalIPSelf    string
+}
+```
+
+Existing single-value callers wrap the new function. Inside the function, *after* the existing pubkey + network-id + network-time checks:
+
+1. **Instance-Cookie self-connection:** parse `Instance-Cookie` (uint64). If it parses and equals `cfg.InstanceCookie`, return `ErrSelfConnection`. (This is the issue's "second signal".)
+2. **Server-Domain:** if present, validate via `isWellFormedDomain` (helper detailed in Task 3.4). On failure, return `ErrInvalidHandshake` wrapping the parse error.
+3. **Closed-Ledger / Previous-Ledger:** parse via `parseLedgerHashHeader`. Lenient on parse failure; strict on "Previous-Ledger present without Closed-Ledger" only when both are required (rippled tolerates either order, so we do too).
+4. **Local-IP consistency check** — rippled `Handshake.cpp:325-338`:
+   - If header parse fails → fatal `ErrInvalidHandshake`.
+   - If the connection's remote IP (`peerRemote`, passed in by caller) is public AND `peerRemote != localIP` → fatal `ErrInvalidHandshake` (`"Incorrect Local-IP"`).
+   - Loopback / private peer → skip the comparison.
+5. **Remote-IP consistency check** — rippled `Handshake.cpp:340-359`:
+   - If header parse fails → fatal.
+   - If `peerRemote` is public AND `cfg.PublicIP` is configured AND header value differs from `cfg.PublicIP` → fatal (`"Incorrect Remote-IP"`).
+
+The function gains two new arguments: `peerRemote net.IP` (the TCP remote address) and `cfg HandshakeConfig` (replaces the standalone `localPubKey, localNetworkID` pair). Existing callers thread the values they already have.
+
+### Task 3.4 — `isWellFormedDomain`
+
+```go
+// isWellFormedDomain accepts the conservative subset of
+// rippled's isProperlyFormedTomlDomain: total length ≤ 253, each label
+// 1..63 chars of [A-Za-z0-9-], no leading/trailing hyphen, optional
+// trailing dot tolerated.
+```
+
+Pure string validation; no DNS lookup.
+
+---
+
+## Phase 4 — Acceptance tests
+
+All four go in `internal/peermanagement/handshake_test.go`. Helpers reuse the existing `NewIdentity` / `BuildHandshakeRequest` patterns at `handshake_test.go:76-173`.
+
+### `TestHandshake_InstanceCookie_DetectsSelfConnection`
+
+Build a request with the same `Instance-Cookie` value as the local config. Verify rejects with `ErrSelfConnection` even when public keys are different. (We use a freshly-generated remote `Identity` so the pubkey path doesn't trigger first.)
+
+### `TestHandshake_ClosedLedgerHint_ReadableAfterHandshake`
+
+Build a request whose `LedgerHintProvider` returns a non-zero `(closed, parent)` pair. Drive it through `VerifyHandshakeHeadersNoSig`. Assert `result.ClosedLedger == closed`, `result.PreviousLedger == parent`, `result.HasLedgerHints == true`.
+
+### `TestHandshake_RemoteIPSelfReported_MatchesTcpConn`
+
+Build a request with `cfg.PublicIP = 198.51.100.1` (TEST-NET-2 public). Pass `peerRemote = 198.51.100.1` to verify → success, returned `RemoteIPSelf == "198.51.100.1"`. Then mutate the header to `203.0.113.5` and re-verify → fatal `ErrInvalidHandshake`. Then re-test with `peerRemote = 127.0.0.1` (loopback) → check is skipped, success regardless of header value.
+
+### `TestHandshake_AllHeaders_RoundTrip`
+
+Build a request with all six headers populated. Verify it through the inbound code path. Assert each field on the returned `VerifiedHandshake` matches what was sent. Then build a response from the same config and re-verify on the symmetric path. Assert no regression on existing X-Protocol-Ctl / Network-ID / Network-Time / Public-Key / Session-Signature handling — these fields on `VerifiedHandshake` should also match.
+
+---
+
+## Phase 5 — RPC `peers` surface
+
+### Task 5.1 — Extend `PeerInfo`
+
+Add (using rippled's `peers` method JSON key casing):
+
+```go
+type PeerInfo struct {
+    // ... existing fields ...
+    ServerDomain   string `json:"server_domain,omitempty"`
+    ClosedLedger   string `json:"closed_ledger,omitempty"`
+    PreviousLedger string `json:"previous_ledger,omitempty"`
+    RemoteIP       string `json:"remote_ip,omitempty"`
+    LocalIP        string `json:"local_ip,omitempty"`
+}
+```
+
+`omitempty` so peers that never sent the header don't bloat the response.
+
+### Task 5.2 — Populate from `Overlay.Peers()`
+
+Map each `Peer`'s accessors into the new `PeerInfo` fields. Hashes formatted as upper-case hex (rippled `peers` convention for ledger hashes; differs from the lower-case wire format).
+
+### Task 5.3 — Pass through `internal/rpc/handlers/peers.go`
+
+Existing handler is currently a stub; this PR's contribution is to ensure that *if* it ever returns real peers, the new fields are wired in. No behavioural change in the stub path.
+
+---
+
+## Verification
+
+```sh
+cd goXRPL
+go build ./...
+go test ./internal/peermanagement/...
+go test ./internal/rpc/...
+```
+
+All four named acceptance tests pass; no pre-existing test regresses; `go vet ./...` clean.
+
+---
+
+## Risk notes
+
+1. **`VerifyHandshakeHeadersNoSig` signature change** — every caller must update. Audit: `rg 'VerifyHandshakeHeadersNoSig|VerifyPeerHandshake' internal/peermanagement` enumerates them. The refactor replaces `(localPubKey, localNetworkID)` with `(cfg, peerRemote)`; keep a short overload that constructs a minimal `HandshakeConfig` for tests that don't care about IP semantics.
+2. **`isPublicIP` parity with `beast::IP::is_public`** — Go's `net.IP.IsLoopback`/`IsPrivate`/`IsLinkLocalUnicast` cover the same ranges; one-liner combination is sufficient. Pin with a table-driven test.
+3. **Cookie collision is the second self-connection signal** — diverges from rippled's literal logic (rippled checks pubkey only). Issue #270 explicitly requests this. Documented inline at the check site.
+4. **`omitempty` on `closed_ledger`** — empty hash is `0000…0000` which is technically a valid header on the wire; using a `bool hasLedgerHints` on `Peer` and only formatting the hex when true keeps the RPC response truthful (no synthetic all-zeros).


### PR DESCRIPTION
Closes #270.

## Summary

- Emit, parse, and store the six rippled handshake headers that goXRPL was missing: `Instance-Cookie`, `Server-Domain`, `Closed-Ledger`, `Previous-Ledger`, `Remote-IP`, `Local-IP`.
- **Strict rippled parity**: `Instance-Cookie` round-trips and is stored on the peer, but is never compared. Self-connection detection stays pubkey-only at `Handshake.cpp:322` exactly as rippled does it. `Server-Domain` is validated per `Handshake.cpp:235-239`; `Local-IP` / `Remote-IP` consistency follows `Handshake.cpp:325-359`.
- `Closed-Ledger` hints feed peer selection: `Overlay.PeersWithClosedLedger` + `LedgerSyncHandler.PreferredPeersForLedger` so catchup callers ask peers that already advertise the target ledger first (mirrors rippled `NetworkOPs` consuming `PeerImp::closedLedgerHash_`).
- `peers` RPC handler is wired to a new `types.PeerSource` interface (`Server.SetPeerSource`); `Overlay.PeersJSON` produces the per-peer JSON entries with `server_domain`, `closed_ledger`, `previous_ledger`, `remote_ip`, `local_ip`. CLI wires the overlay in for consensus mode.
- Per-process `Instance-Cookie` generated once at `Overlay` construction in the range `[1, MAX-1]`, matching rippled's `1 + rand_int(prng, MAX-1)` from `Application.cpp`.

## Plan

`tasks/pr-handshake-headers.md` (added in this PR).

## Test plan

- [x] `TestHandshake_InstanceCookie_DetectsSelfConnection` — cookie round-trips; self-connection check stays pubkey-only as in rippled.
- [x] `TestHandshake_ClosedLedgerHint_ReadableAfterHandshake` — Closed-Ledger / Previous-Ledger hints round-trip and are readable on the `Peer` accessors.
- [x] `TestHandshake_RemoteIPSelfReported_MatchesTcpConn` — Remote-IP consistency (matching public IP passes; mismatch rejects; loopback peer skips check; malformed value rejects).
- [x] `TestHandshake_AllHeaders_RoundTrip` — request and response paths carry all six headers; topology A→B with public IPs pA/pB; malformed Server-Domain rejected.
- [x] `TestLedgerSync_PreferredPeersForLedger_ConsumesClosedLedgerHint` — catchup peer-picker reads handshake hints; peers without a hint or with a different hint are filtered out; disconnected peers are excluded.
- [x] `TestPeersMethod_NilSourceReturnsEmptyList` / `TestPeersMethod_PassesThroughSource` — RPC handler returns `[]` when no overlay is wired and surfaces the source's entries when present.
- [x] `go build ./...` clean.
- [x] `go vet ./internal/peermanagement/... ./internal/rpc/... ./internal/cli/...` clean.
- [x] `go test ./internal/peermanagement/... ./internal/rpc/handlers/... ./internal/consensus/...` all green.

## Out of scope

- Stricter TOML domain validation per RFC-1035. The `isWellFormedDomain` helper accepts the conservative subset (length ≤253, label `[A-Za-z0-9-]{1,63}`, no leading/trailing hyphen, optional trailing dot stripped); operators reporting rejections will trigger a follow-up.

## Rippled references

- `rippled/src/xrpld/overlay/detail/Handshake.cpp` — `buildHandshake` (lines 178-224), `verifyHandshake` (lines 226-362).
- `rippled/src/xrpld/app/main/Application.cpp` — `instanceCookie_` initializer.
- `rippled/src/xrpld/overlay/detail/PeerImp.cpp` — `parseLedgerHash` lambda (hex-or-base64) inside `PeerImp::run`.