### PR TITLE
fix(peermanagement): include MAX_UINT64 in instance cookie range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ main
 
 # Worktrees
 .worktrees/
+worktrees/

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
-	"math"
 	"net"
 	"net/http"
 	"regexp"
@@ -1545,15 +1544,14 @@ func TestHandshake_MalformedLedgerHashRejected(t *testing.T) {
 	})
 }
 
-// generateInstanceCookie must produce values in [1, MAX-1] (both 0 and
-// MAX excluded) to match rippled `1 + rand_int(prng, MAX-1)`.
+// generateInstanceCookie must produce values in [1, MAX_UINT64] to
+// match rippled `1 + rand_int(prng, MAX_UINT64 - 1)`, which uses a
+// closed interval and so includes MAX_UINT64. Only 0 is excluded.
 func TestInstanceCookie_GeneratorRange(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		v, err := generateInstanceCookie()
 		require.NoError(t, err)
 		assert.NotZero(t, v, "cookie must never be zero")
-		assert.NotEqual(t, uint64(math.MaxUint64), v,
-			"cookie must never be MAX (rippled excludes both 0 and MAX)")
 	}
 }
 

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/stretchr/testify/assert"
@@ -175,37 +174,6 @@ func TestVerifyPeerHandshake_MissingSignature(t *testing.T) {
 	_, err := VerifyPeerHandshake(headers, make([]byte, 32), "nLocalKey", DefaultHandshakeConfig())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Session-Signature")
-}
-
-// strconvUnixXRPL formats a time as XRPL epoch seconds (like rippled's
-// Network-Time header builder). Test helper.
-func strconvUnixXRPL(t time.Time) string {
-	xrplSec := t.Unix() - XRPLEpochOffset
-	return fmtInt(xrplSec)
-}
-
-func fmtInt(n int64) string {
-	// Simple base-10 stringification without importing another package.
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	buf := make([]byte, 0, 20)
-	for n > 0 {
-		buf = append(buf, byte('0'+n%10))
-		n /= 10
-	}
-	if neg {
-		buf = append(buf, '-')
-	}
-	// reverse
-	for i, j := 0, len(buf)-1; i < j; i, j = i+1, j-1 {
-		buf[i], buf[j] = buf[j], buf[i]
-	}
-	return string(buf)
 }
 
 // TestParsePublicKeyToken_RejectsEd25519Prefix pins R5.13: the 0xED

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -1609,8 +1609,8 @@ func TestIpFamilyEqual_BoostParity(t *testing.T) {
 // as address_v6, otherwise a peer announcing "::ffff:x.x.x.x" while
 // connecting via AF_INET6 is incorrectly rejected as family-mismatched.
 func TestSocketIPIsV6_FamilyFromByteLength(t *testing.T) {
-	v4Socket := net.IP{1, 2, 3, 4}                                         // AF_INET socket
-	v6Socket := net.ParseIP("2001:db8::1")                                 // AF_INET6 socket
+	v4Socket := net.IP{1, 2, 3, 4}                                                 // AF_INET socket
+	v6Socket := net.ParseIP("2001:db8::1")                                         // AF_INET6 socket
 	v4MappedSocket := net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 1, 2, 3, 4} // AF_INET6 receiving v4
 
 	assert.False(t, socketIPIsV6(v4Socket), "4-byte socket IP is AF_INET")

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -270,22 +270,19 @@ func (o *Overlay) ledgerHintProviderSnapshot() func() (LedgerHints, bool) {
 	return o.ledgerHintProvider
 }
 
-// generateInstanceCookie returns a value in [1, MAX-1] to match rippled
-// `1 + rand_int(prng, MAX-1)` from Application.cpp — both 0 and MAX are
-// excluded. Rejection sampling on the two boundary values keeps the
-// distribution uniform; the rejection probability is 2/2^64.
+// generateInstanceCookie matches rippled Application.cpp:
+//   1 + rand_int(crypto_prng(), MAX_UINT64 - 1)
+// where rand_int returns a closed interval, so the result is uniform
+// in [1, MAX_UINT64]. Only 0 is rejected.
 func generateInstanceCookie() (uint64, error) {
-	const maxU64 = ^uint64(0)
 	for {
 		var b [8]byte
 		if _, err := rand.Read(b[:]); err != nil {
 			return 0, err
 		}
-		v := binary.BigEndian.Uint64(b[:])
-		if v == 0 || v == maxU64 {
-			continue
+		if v := binary.BigEndian.Uint64(b[:]); v != 0 {
+			return v, nil
 		}
-		return v, nil
 	}
 }
 

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -271,7 +271,9 @@ func (o *Overlay) ledgerHintProviderSnapshot() func() (LedgerHints, bool) {
 }
 
 // generateInstanceCookie matches rippled Application.cpp:
-//   1 + rand_int(crypto_prng(), MAX_UINT64 - 1)
+//
+//	1 + rand_int(crypto_prng(), MAX_UINT64 - 1)
+//
 // where rand_int returns a closed interval, so the result is uniform
 // in [1, MAX_UINT64]. Only 0 is rejected.
 func generateInstanceCookie() (uint64, error) {

--- a/internal/peermanagement/peertls/shared_value_test.go
+++ b/internal/peermanagement/peertls/shared_value_test.go
@@ -54,7 +54,6 @@ func TestComputeSharedValue_TooShort(t *testing.T) {
 		{"exactly 11 peer", make([]byte, 12), make([]byte, 11)},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := computeSharedValue(tc.local, tc.peer)
 			if err == nil {


### PR DESCRIPTION
## Summary

- `generateInstanceCookie` was rejecting both `0` and `MAX_UINT64`, but rippled's `1 + rand_int(crypto_prng(), MAX_UINT64 - 1)` uses a closed-interval RNG and produces `[1, MAX_UINT64]`. Only `0` should be rejected.
- The doc comment also incorrectly claimed rippled excludes `MAX_UINT64`.
- Drop the `MAX_UINT64` rejection, update the comment to describe rippled's actual behaviour, and adjust the parity test accordingly.

Closes #306

## Reference

`rippled/src/xrpld/app/main/Application.cpp:274-278`:

```cpp
, instanceCookie_(
      1 +
      rand_int(
          crypto_prng(),
          std::numeric_limits<std::uint64_t>::max() - 1))
```

`rand_int` is documented as a closed interval (`rippled/include/xrpl/basics/random.h:104-108`), so the result is uniform in `[1, MAX_UINT64]`.

## Test plan

- [x] `go vet ./internal/peermanagement/...`
- [x] `go test -count=1 ./internal/peermanagement/...` (all green, including `TestInstanceCookie_GeneratorRange`)