### PR TITLE
feat(peermanagement): emit per-peer track state in peers RPC (#303)

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -233,9 +233,6 @@ func runServer(cmd *cobra.Command, args []string) {
 			return peermanagement.LedgerHints{Closed: cl.Hash(), Parent: cl.ParentHash()}, true
 		})
 
-		// Validated-ledger source for per-peer tracking convergence
-		// (PeerImp.cpp:1885-1890). overlay.handleStatusChange compares
-		// peer-reported ledger seqs against this baseline.
 		overlay.SetValidLedgerProvider(func() (uint32, time.Duration, bool) {
 			vl := ledgerService.GetValidatedLedger()
 			if vl == nil {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -232,6 +232,18 @@ func runServer(cmd *cobra.Command, args []string) {
 			}
 			return peermanagement.LedgerHints{Closed: cl.Hash(), Parent: cl.ParentHash()}, true
 		})
+
+		// Validated-ledger source for per-peer tracking convergence
+		// (PeerImp.cpp:1885-1890). overlay.handleStatusChange compares
+		// peer-reported ledger seqs against this baseline.
+		overlay.SetValidLedgerProvider(func() (uint32, time.Duration, bool) {
+			vl := ledgerService.GetValidatedLedger()
+			if vl == nil {
+				return 0, 0, false
+			}
+			age := time.Since(vl.CloseTime())
+			return vl.Sequence(), age, true
+		})
 		ledgerAdapter.SetTxBroadcaster(func(txBlob []byte) {
 			txMsg := &message.Transaction{
 				RawTransaction: txBlob,

--- a/internal/peermanagement/export_test.go
+++ b/internal/peermanagement/export_test.go
@@ -1,0 +1,3 @@
+package peermanagement
+
+func (p *Peer) SetTracking(t PeerTracking) { p.setTracking(t) }

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -177,16 +177,9 @@ type Overlay struct {
 	// instanceCookie: immutable post-New, lock-free.
 	instanceCookie uint64
 
-	// ledgerHintProvider: wired by a higher layer (avoids importing
-	// internal/ledger). Guarded by hintMu.
-	hintMu             sync.RWMutex
-	ledgerHintProvider func() (LedgerHints, bool)
-
-	// validLedgerProvider: returns the local node's most recent
-	// validated ledger sequence and its age, used to drive per-peer
-	// tracking convergence comparisons. Wired by a higher layer to
-	// avoid importing internal/ledger. Guarded by hintMu (same lock —
-	// both fields are wired/read on similar lifecycles).
+	// Higher-layer callbacks (avoid importing internal/ledger here).
+	providersMu         sync.RWMutex
+	ledgerHintProvider  func() (LedgerHints, bool)
 	validLedgerProvider func() (seq uint32, age time.Duration, ok bool)
 
 	// Components
@@ -275,30 +268,29 @@ func (o *Overlay) PeersWithClosedLedger(target [32]byte) []PeerID {
 
 // SetLedgerHintProvider wires the hint source; nil suppresses headers.
 func (o *Overlay) SetLedgerHintProvider(fn func() (LedgerHints, bool)) {
-	o.hintMu.Lock()
+	o.providersMu.Lock()
 	o.ledgerHintProvider = fn
-	o.hintMu.Unlock()
+	o.providersMu.Unlock()
 }
 
 func (o *Overlay) ledgerHintProviderSnapshot() func() (LedgerHints, bool) {
-	o.hintMu.RLock()
-	defer o.hintMu.RUnlock()
+	o.providersMu.RLock()
+	defer o.providersMu.RUnlock()
 	return o.ledgerHintProvider
 }
 
-// SetValidLedgerProvider wires the local validated-ledger source used
-// by handleStatusChange to drive per-peer tracking convergence checks.
-// fn returns (seq, age, ok); ok=false suppresses tracking updates,
-// matching rippled's "validated ledger age < 2min" gate (PeerImp.cpp:1885-1890).
+// SetValidLedgerProvider wires the validated-ledger source used by
+// handleStatusChange (PeerImp.cpp:1885-1890). ok=false suppresses
+// tracking updates.
 func (o *Overlay) SetValidLedgerProvider(fn func() (seq uint32, age time.Duration, ok bool)) {
-	o.hintMu.Lock()
+	o.providersMu.Lock()
 	o.validLedgerProvider = fn
-	o.hintMu.Unlock()
+	o.providersMu.Unlock()
 }
 
 func (o *Overlay) validLedgerProviderSnapshot() func() (seq uint32, age time.Duration, ok bool) {
-	o.hintMu.RLock()
-	defer o.hintMu.RUnlock()
+	o.providersMu.RLock()
+	defer o.providersMu.RUnlock()
 	return o.validLedgerProvider
 }
 

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -182,6 +182,13 @@ type Overlay struct {
 	hintMu             sync.RWMutex
 	ledgerHintProvider func() (LedgerHints, bool)
 
+	// validLedgerProvider: returns the local node's most recent
+	// validated ledger sequence and its age, used to drive per-peer
+	// tracking convergence comparisons. Wired by a higher layer to
+	// avoid importing internal/ledger. Guarded by hintMu (same lock —
+	// both fields are wired/read on similar lifecycles).
+	validLedgerProvider func() (seq uint32, age time.Duration, ok bool)
+
 	// Components
 	discovery  *Discovery
 	relay      *Relay
@@ -277,6 +284,22 @@ func (o *Overlay) ledgerHintProviderSnapshot() func() (LedgerHints, bool) {
 	o.hintMu.RLock()
 	defer o.hintMu.RUnlock()
 	return o.ledgerHintProvider
+}
+
+// SetValidLedgerProvider wires the local validated-ledger source used
+// by handleStatusChange to drive per-peer tracking convergence checks.
+// fn returns (seq, age, ok); ok=false suppresses tracking updates,
+// matching rippled's "validated ledger age < 2min" gate (PeerImp.cpp:1885-1890).
+func (o *Overlay) SetValidLedgerProvider(fn func() (seq uint32, age time.Duration, ok bool)) {
+	o.hintMu.Lock()
+	o.validLedgerProvider = fn
+	o.hintMu.Unlock()
+}
+
+func (o *Overlay) validLedgerProviderSnapshot() func() (seq uint32, age time.Duration, ok bool) {
+	o.hintMu.RLock()
+	defer o.hintMu.RUnlock()
+	return o.validLedgerProvider
 }
 
 // generateInstanceCookie matches rippled Application.cpp:
@@ -1034,6 +1057,20 @@ func (o *Overlay) handleStatusChange(evt Event) {
 		sc.FirstSeq,
 		sc.LastSeq,
 	)
+
+	// PeerImp.cpp:1885-1890: gate on a fresh (<2 min) validated ledger.
+	if sc.LedgerSeq == 0 {
+		return
+	}
+	provider := o.validLedgerProviderSnapshot()
+	if provider == nil {
+		return
+	}
+	validSeq, age, ok := provider()
+	if !ok || validSeq == 0 || age >= 2*time.Minute {
+		return
+	}
+	peer.CheckTracking(sc.LedgerSeq, validSeq)
 }
 
 // handleSquelchMessage processes an inbound TMSquelch from a peer and
@@ -1658,6 +1695,13 @@ func (o *Overlay) PeersJSON() []map[string]any {
 					entry["name"] = member.Name
 				}
 			}
+		}
+		// PeerImp.cpp:437-450: omit when converged.
+		switch p.Tracking {
+		case PeerTrackingDiverged:
+			entry["track"] = "diverged"
+		case PeerTrackingUnknown:
+			entry["track"] = "unknown"
 		}
 		out = append(out, entry)
 	}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -44,6 +44,25 @@ func (s PeerState) String() string {
 	}
 }
 
+// PeerTracking is the per-peer consensus-convergence state. Mirrors
+// rippled PeerImp::Tracking (PeerImp.h:58). Defaults to Unknown until
+// enough StatusChange messages and a fresh local validated ledger
+// produce a comparison.
+type PeerTracking int32
+
+const (
+	PeerTrackingUnknown PeerTracking = iota
+	PeerTrackingConverged
+	PeerTrackingDiverged
+)
+
+// Tuning constants for convergence comparison. Mirrors rippled
+// Tuning.h convergedLedgerLimit / divergedLedgerLimit.
+const (
+	convergedLedgerLimit uint32 = 24
+	divergedLedgerLimit  uint32 = 128
+)
+
 // Peer represents a connection to an XRPL peer node.
 type Peer struct {
 	mu sync.RWMutex
@@ -80,6 +99,8 @@ type Peer struct {
 	// cadence by the overlay so transient errors decay. int64 because
 	// decay can overshoot zero.
 	badDataBalance atomic.Int64
+
+	tracking atomic.Int32
 
 	serverDomain      string
 	closedLedger      [32]byte
@@ -228,6 +249,41 @@ func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSe
 	} else {
 		p.firstLedgerSeq = *firstSeq
 		p.lastLedgerSeq = *lastSeq
+	}
+}
+
+// Tracking returns the current consensus-convergence state.
+func (p *Peer) Tracking() PeerTracking {
+	return PeerTracking(p.tracking.Load())
+}
+
+// SetTracking overrides the convergence state. Exposed for tests.
+func (p *Peer) SetTracking(t PeerTracking) {
+	p.tracking.Store(int32(t))
+}
+
+// CheckTracking compares a peer-reported ledger sequence against the
+// local validated ledger sequence and updates Tracking accordingly.
+// Mirrors rippled PeerImp::checkTracking (PeerImp.cpp:1986-2005):
+//
+//   - diff < convergedLedgerLimit  → Converged
+//   - diff > divergedLedgerLimit   → Diverged (sticky once set)
+//   - in between                   → no change
+func (p *Peer) CheckTracking(peerSeq, validSeq uint32) {
+	if peerSeq == 0 || validSeq == 0 {
+		return
+	}
+	var diff uint32
+	if peerSeq > validSeq {
+		diff = peerSeq - validSeq
+	} else {
+		diff = validSeq - peerSeq
+	}
+	if diff < convergedLedgerLimit {
+		p.tracking.Store(int32(PeerTrackingConverged))
+	}
+	if diff > divergedLedgerLimit && PeerTracking(p.tracking.Load()) != PeerTrackingDiverged {
+		p.tracking.Store(int32(PeerTrackingDiverged))
 	}
 }
 
@@ -712,6 +768,7 @@ type PeerInfo struct {
 	ServerDomain    string
 	ClosedLedger    string
 	CompleteLedgers string
+	Tracking        PeerTracking
 }
 
 func (p *Peer) Info() PeerInfo {
@@ -752,5 +809,6 @@ func (p *Peer) Info() PeerInfo {
 		ServerDomain:    p.serverDomain,
 		ClosedLedger:    closedLedger,
 		CompleteLedgers: completeLedgers,
+		Tracking:        PeerTracking(p.tracking.Load()),
 	}
 }

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -44,10 +44,7 @@ func (s PeerState) String() string {
 	}
 }
 
-// PeerTracking is the per-peer consensus-convergence state. Mirrors
-// rippled PeerImp::Tracking (PeerImp.h:58). Defaults to Unknown until
-// enough StatusChange messages and a fresh local validated ledger
-// produce a comparison.
+// PeerTracking mirrors rippled PeerImp::Tracking (PeerImp.h:58).
 type PeerTracking int32
 
 const (
@@ -56,8 +53,7 @@ const (
 	PeerTrackingDiverged
 )
 
-// Tuning constants for convergence comparison. Mirrors rippled
-// Tuning.h convergedLedgerLimit / divergedLedgerLimit.
+// rippled Tuning.h.
 const (
 	convergedLedgerLimit uint32 = 24
 	divergedLedgerLimit  uint32 = 128
@@ -252,23 +248,17 @@ func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSe
 	}
 }
 
-// Tracking returns the current consensus-convergence state.
 func (p *Peer) Tracking() PeerTracking {
 	return PeerTracking(p.tracking.Load())
 }
 
-// SetTracking overrides the convergence state. Exposed for tests.
-func (p *Peer) SetTracking(t PeerTracking) {
+func (p *Peer) setTracking(t PeerTracking) {
 	p.tracking.Store(int32(t))
 }
 
-// CheckTracking compares a peer-reported ledger sequence against the
-// local validated ledger sequence and updates Tracking accordingly.
-// Mirrors rippled PeerImp::checkTracking (PeerImp.cpp:1986-2005):
-//
-//   - diff < convergedLedgerLimit  → Converged
-//   - diff > divergedLedgerLimit   → Diverged (sticky once set)
-//   - in between                   → no change
+// CheckTracking mirrors rippled PeerImp::checkTracking (PeerImp.cpp:1986-2005).
+// CAS on the diverged branch keeps a concurrent Converged write from
+// being clobbered (rippled holds recentLock_; CAS is the lock-free equivalent).
 func (p *Peer) CheckTracking(peerSeq, validSeq uint32) {
 	if peerSeq == 0 || validSeq == 0 {
 		return
@@ -281,9 +271,18 @@ func (p *Peer) CheckTracking(peerSeq, validSeq uint32) {
 	}
 	if diff < convergedLedgerLimit {
 		p.tracking.Store(int32(PeerTrackingConverged))
+		return
 	}
-	if diff > divergedLedgerLimit && PeerTracking(p.tracking.Load()) != PeerTrackingDiverged {
-		p.tracking.Store(int32(PeerTrackingDiverged))
+	if diff > divergedLedgerLimit {
+		for {
+			cur := p.tracking.Load()
+			if PeerTracking(cur) == PeerTrackingDiverged {
+				return
+			}
+			if p.tracking.CompareAndSwap(cur, int32(PeerTrackingDiverged)) {
+				return
+			}
+		}
 	}
 }
 

--- a/internal/peermanagement/peer_tracking_test.go
+++ b/internal/peermanagement/peer_tracking_test.go
@@ -1,0 +1,181 @@
+package peermanagement
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTrackingPeer(t *testing.T) *Peer {
+	t.Helper()
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	return NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+}
+
+func TestPeerTracking_DefaultUnknown(t *testing.T) {
+	p := newTrackingPeer(t)
+	assert.Equal(t, PeerTrackingUnknown, p.Tracking())
+	assert.Equal(t, PeerTrackingUnknown, p.Info().Tracking)
+}
+
+// CheckTracking mirrors PeerImp::checkTracking (PeerImp.cpp:1986-2005).
+func TestPeerTracking_CheckTracking(t *testing.T) {
+	cases := []struct {
+		name     string
+		peerSeq  uint32
+		validSeq uint32
+		initial  PeerTracking
+		want     PeerTracking
+	}{
+		{"converged_within_limit", 1000, 1000, PeerTrackingUnknown, PeerTrackingConverged},
+		{"converged_at_boundary_minus_one", 1000, 1023, PeerTrackingUnknown, PeerTrackingConverged},
+		{"diverged_above_limit", 1000, 1200, PeerTrackingUnknown, PeerTrackingDiverged},
+		{"between_limits_no_change", 1000, 1050, PeerTrackingUnknown, PeerTrackingUnknown},
+		{"converged_overrides_previous_unknown", 5000, 5005, PeerTrackingUnknown, PeerTrackingConverged},
+		{"diverged_sticky_no_reflip_within_window", 1000, 1100, PeerTrackingDiverged, PeerTrackingDiverged},
+		{"converged_can_overwrite_diverged", 1000, 1010, PeerTrackingDiverged, PeerTrackingConverged},
+		{"zero_peer_seq_no_op", 0, 1000, PeerTrackingUnknown, PeerTrackingUnknown},
+		{"zero_valid_seq_no_op", 1000, 0, PeerTrackingUnknown, PeerTrackingUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTrackingPeer(t)
+			p.SetTracking(tc.initial)
+			p.CheckTracking(tc.peerSeq, tc.validSeq)
+			assert.Equal(t, tc.want, p.Tracking())
+		})
+	}
+}
+
+func TestOverlay_handleStatusChange_UpdatesTracking(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+	o.SetValidLedgerProvider(func() (uint32, time.Duration, bool) {
+		return 5000, 30 * time.Second, true
+	})
+
+	sc := &message.StatusChange{
+		LedgerSeq:  4995,
+		LedgerHash: make([]byte, 32),
+	}
+	encoded, err := message.Encode(sc)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 7, Payload: encoded})
+	assert.Equal(t, PeerTrackingConverged, peer.Tracking())
+
+	sc2 := &message.StatusChange{
+		LedgerSeq:  4500,
+		LedgerHash: make([]byte, 32),
+	}
+	encoded2, err := message.Encode(sc2)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 7, Payload: encoded2})
+	assert.Equal(t, PeerTrackingDiverged, peer.Tracking())
+}
+
+func TestOverlay_handleStatusChange_StaleValidLedgerSkipsTracking(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{1: peer})
+	// Validated ledger is older than rippled's 2-min freshness gate.
+	o.SetValidLedgerProvider(func() (uint32, time.Duration, bool) {
+		return 5000, 5 * time.Minute, true
+	})
+
+	sc := &message.StatusChange{
+		LedgerSeq:  5000,
+		LedgerHash: make([]byte, 32),
+	}
+	encoded, err := message.Encode(sc)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 1, Payload: encoded})
+	assert.Equal(t, PeerTrackingUnknown, peer.Tracking())
+}
+
+func TestOverlay_handleStatusChange_NoProviderLeavesUnknown(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{1: peer})
+
+	sc := &message.StatusChange{
+		LedgerSeq:  5000,
+		LedgerHash: make([]byte, 32),
+	}
+	encoded, err := message.Encode(sc)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 1, Payload: encoded})
+	assert.Equal(t, PeerTrackingUnknown, peer.Tracking())
+}
+
+func TestOverlay_handleStatusChange_ZeroLedgerSeqSkipsTracking(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{1: peer})
+	o.SetValidLedgerProvider(func() (uint32, time.Duration, bool) {
+		return 5000, 30 * time.Second, true
+	})
+
+	// LedgerSeq=0 — peer reported no ledger info; tracking must not flip.
+	sc := &message.StatusChange{
+		LedgerSeq:  0,
+		LedgerHash: make([]byte, 32),
+	}
+	encoded, err := message.Encode(sc)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 1, Payload: encoded})
+	assert.Equal(t, PeerTrackingUnknown, peer.Tracking())
+}
+
+// PeersJSON's track field mirrors PeerImp::json (PeerImp.cpp:437-450):
+// "diverged" / "unknown" emit; "converged" omits.
+func TestOverlay_PeersJSON_TrackField(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	mk := func(state PeerTracking) *Peer {
+		p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+		p.SetTracking(state)
+		return p
+	}
+
+	cases := []struct {
+		name      string
+		state     PeerTracking
+		wantKey   bool
+		wantValue string
+	}{
+		{"unknown_emits_unknown", PeerTrackingUnknown, true, "unknown"},
+		{"diverged_emits_diverged", PeerTrackingDiverged, true, "diverged"},
+		{"converged_omits_field", PeerTrackingConverged, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := newTestOverlayWithPeers(map[PeerID]*Peer{1: mk(tc.state)})
+			out := o.PeersJSON()
+			require.Len(t, out, 1)
+			v, hasKey := out[0]["track"]
+			assert.Equal(t, tc.wantKey, hasKey)
+			if tc.wantKey {
+				assert.Equal(t, tc.wantValue, v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Resolves #303. Adds per-peer consensus-convergence tracking and emits the `track` field in the `peers` RPC response, matching rippled's `PeerImp::json` (PeerImp.cpp:437-450).

- `PeerTracking { Unknown, Converged, Diverged }` with `atomic.Int32` field on `Peer`; defaults to Unknown.
- `Peer.CheckTracking(peerSeq, validSeq)` mirrors `PeerImp::checkTracking` (PeerImp.cpp:1986-2005): diff < 24 → Converged, diff > 128 → Diverged (sticky).
- `Overlay.handleStatusChange` calls `CheckTracking` using `StatusChange.LedgerSeq` against the local validated-ledger seq, gated on validated-ledger age < 2 min (PeerImp.cpp:1885-1890).
- New `SetValidLedgerProvider` callback (analogous to `LedgerHintProvider`) keeps `internal/peermanagement` free of `internal/ledger` imports; wired from `cli/server.go` via `ledgerService.GetValidatedLedger()`.
- `PeersJSON` emits `"track":"diverged"`/`"unknown"`; omits when Converged.

## Test plan

- [x] `go test ./internal/peermanagement/...` — all green (incl. 16 new tests in `peer_tracking_test.go`)
- [x] Default state is Unknown
- [x] `CheckTracking` transitions: converged at boundary, diverged sticky, in-between no-op, zero-seq no-op, converged-overrides-diverged
- [x] End-to-end `handleStatusChange`: fresh validated ledger triggers tracking, stale (>2min) skips, missing provider skips, `LedgerSeq=0` skips
- [x] `PeersJSON` emits `track` correctly for each state
- [x] `go vet` clean on touched packages, `gofmt` clean
- [x] No regressions in `internal/rpc/handlers/peers_test.go`

## Out of scope

The remaining rippled `PeerImp::json` fields not yet emitted by goXRPL (`network_id`, `version`, `protocol`, `latency`, `complete_ledgers`, `status`, `load`, `metrics`, `cluster`/`name`) remain follow-up issues — comment in `PeersJSON` updated accordingly.