### PR TITLE
Consolidate secp256k1 sign/verify in peer handshake (closes #307)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ main
 
 # Worktrees
 .worktrees/
+worktrees/

--- a/crypto/secp256k1/raw.go
+++ b/crypto/secp256k1/raw.go
@@ -7,12 +7,7 @@ import (
 	ecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
 )
 
-// SignDigestBytes signs a pre-hashed 32-byte digest with raw private key
-// bytes. The result is DER-encoded. No re-hashing — mirrors rippled's
-// signDigest() which feeds the hash directly to secp256k1.
-//
-// Use this from contexts that already hold raw key/digest bytes (e.g.
-// the peer handshake's session-signature path) to avoid hex round-trips.
+// SignDigestBytes signs a pre-hashed 32-byte digest. Result is DER-encoded.
 func SignDigestBytes(digest, privKey []byte) ([]byte, error) {
 	if len(digest) != 32 {
 		return nil, errors.New("secp256k1: digest must be 32 bytes")
@@ -21,18 +16,11 @@ func SignDigestBytes(digest, privKey []byte) ([]byte, error) {
 		return nil, ErrInvalidPrivateKey
 	}
 	sk := secp256k1.PrivKeyFromBytes(privKey)
-	if sk == nil {
-		return nil, ErrInvalidPrivateKey
-	}
 	return ecdsa.Sign(sk, digest).Serialize(), nil
 }
 
-// VerifyDigestBytes verifies a DER-encoded signature against a 32-byte
-// digest with a compressed-form public key. Mirrors rippled's
-// verifyDigest(..., mustBeFullyCanonical=false): rejects only signatures
-// that fail the minimum canonicality screen, accepts non-low-S forms.
-//
-// Returns false on any parse or verification failure.
+// VerifyDigestBytes verifies a DER-encoded signature against a 32-byte digest.
+// Matches rippled's verifyDigest(..., mustBeFullyCanonical=false).
 func VerifyDigestBytes(digest, pubKey, sig []byte) bool {
 	if len(digest) != 32 {
 		return false

--- a/crypto/secp256k1/raw.go
+++ b/crypto/secp256k1/raw.go
@@ -1,0 +1,43 @@
+package secp256k1
+
+import (
+	"errors"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	ecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
+)
+
+// SignDigestBytes signs a pre-hashed 32-byte digest with raw private key
+// bytes. The result is DER-encoded. No re-hashing — mirrors rippled's
+// signDigest() which feeds the hash directly to secp256k1.
+//
+// Use this from contexts that already hold raw key/digest bytes (e.g.
+// the peer handshake's session-signature path) to avoid hex round-trips.
+func SignDigestBytes(digest, privKey []byte) ([]byte, error) {
+	if len(digest) != 32 {
+		return nil, errors.New("secp256k1: digest must be 32 bytes")
+	}
+	if len(privKey) != 32 {
+		return nil, ErrInvalidPrivateKey
+	}
+	sk := secp256k1.PrivKeyFromBytes(privKey)
+	if sk == nil {
+		return nil, ErrInvalidPrivateKey
+	}
+	return ecdsa.Sign(sk, digest).Serialize(), nil
+}
+
+// VerifyDigestBytes verifies a DER-encoded signature against a 32-byte
+// digest with a compressed-form public key. Mirrors rippled's
+// verifyDigest(..., mustBeFullyCanonical=false): rejects only signatures
+// that fail the minimum canonicality screen, accepts non-low-S forms.
+//
+// Returns false on any parse or verification failure.
+func VerifyDigestBytes(digest, pubKey, sig []byte) bool {
+	if len(digest) != 32 {
+		return false
+	}
+	var d [32]byte
+	copy(d[:], digest)
+	return SECP256K1().ValidateDigest(d, pubKey, sig)
+}

--- a/crypto/secp256k1/raw_test.go
+++ b/crypto/secp256k1/raw_test.go
@@ -1,0 +1,170 @@
+package secp256k1
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	btcecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
+)
+
+func newTestKey(t *testing.T) (*btcec.PrivateKey, []byte, []byte) {
+	t.Helper()
+	priv, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("NewPrivateKey: %v", err)
+	}
+	return priv, priv.Serialize(), priv.PubKey().SerializeCompressed()
+}
+
+func sampleDigest(b byte) []byte {
+	d := make([]byte, 32)
+	for i := range d {
+		d[i] = b ^ byte(i)
+	}
+	return d
+}
+
+func TestSignVerifyDigestBytes_RoundTrip(t *testing.T) {
+	_, priv, pub := newTestKey(t)
+	digest := sampleDigest(0x42)
+
+	sig, err := SignDigestBytes(digest, priv)
+	if err != nil {
+		t.Fatalf("SignDigestBytes: %v", err)
+	}
+	if !VerifyDigestBytes(digest, pub, sig) {
+		t.Fatalf("VerifyDigestBytes rejected own signature")
+	}
+}
+
+func TestVerifyDigestBytes_WrongDigest(t *testing.T) {
+	_, priv, pub := newTestKey(t)
+	digest := sampleDigest(0x42)
+
+	sig, err := SignDigestBytes(digest, priv)
+	if err != nil {
+		t.Fatalf("SignDigestBytes: %v", err)
+	}
+	if VerifyDigestBytes(sampleDigest(0x99), pub, sig) {
+		t.Fatalf("VerifyDigestBytes accepted signature over a different digest")
+	}
+}
+
+func TestVerifyDigestBytes_WrongKey(t *testing.T) {
+	_, priv, _ := newTestKey(t)
+	_, _, otherPub := newTestKey(t)
+	digest := sampleDigest(0x42)
+
+	sig, err := SignDigestBytes(digest, priv)
+	if err != nil {
+		t.Fatalf("SignDigestBytes: %v", err)
+	}
+	if VerifyDigestBytes(digest, otherPub, sig) {
+		t.Fatalf("VerifyDigestBytes accepted signature with mismatched key")
+	}
+}
+
+func TestVerifyDigestBytes_GarbageSig(t *testing.T) {
+	_, _, pub := newTestKey(t)
+	if VerifyDigestBytes(sampleDigest(0x01), pub, []byte("not a der signature")) {
+		t.Fatalf("VerifyDigestBytes accepted garbage signature")
+	}
+}
+
+// Cross-impl: a signature produced via btcecdsa.Sign + Serialize (the
+// path peermanagement/identity.go used pre-consolidation) must verify
+// via VerifyDigestBytes. Locks in wire-compatibility with any peer
+// already using that path.
+func TestVerifyDigestBytes_AcceptsBtcecdsaSignature(t *testing.T) {
+	priv, _, pub := newTestKey(t)
+	digest := sampleDigest(0x55)
+
+	sig := btcecdsa.Sign(priv, digest).Serialize()
+	if !VerifyDigestBytes(digest, pub, sig) {
+		t.Fatalf("VerifyDigestBytes did not accept a btcecdsa-produced signature")
+	}
+}
+
+// Inverse: a signature produced via SignDigestBytes must verify with
+// the btcec/btcecdsa parser too. Catches divergence in DER encoding.
+func TestSignDigestBytes_AcceptedByBtcecdsa(t *testing.T) {
+	priv, privBytes, _ := newTestKey(t)
+	digest := sampleDigest(0xAA)
+
+	sig, err := SignDigestBytes(digest, privBytes)
+	if err != nil {
+		t.Fatalf("SignDigestBytes: %v", err)
+	}
+	parsed, err := btcecdsa.ParseDERSignature(sig)
+	if err != nil {
+		t.Fatalf("btcecdsa.ParseDERSignature: %v", err)
+	}
+	if !parsed.Verify(digest, priv.PubKey()) {
+		t.Fatalf("btcecdsa rejected signature produced by SignDigestBytes")
+	}
+}
+
+// Cross-impl: a signature produced by the existing SECP256K1().SignDigest
+// (hex API) must verify via VerifyDigestBytes. Confirms the byte-form
+// API is interchangeable with the legacy hex one.
+func TestVerifyDigestBytes_AcceptsLegacyHexSign(t *testing.T) {
+	_, privBytes, pub := newTestKey(t)
+	digest := sampleDigest(0x77)
+
+	var d [32]byte
+	copy(d[:], digest)
+	sig, err := SECP256K1().SignDigest(d, strings.ToUpper(hex.EncodeToString(privBytes)))
+	if err != nil {
+		t.Fatalf("SECP256K1.SignDigest: %v", err)
+	}
+	if !VerifyDigestBytes(digest, pub, sig) {
+		t.Fatalf("VerifyDigestBytes rejected a signature produced via the hex API")
+	}
+}
+
+func TestSignDigestBytes_BadInputs(t *testing.T) {
+	_, priv, _ := newTestKey(t)
+
+	if _, err := SignDigestBytes(make([]byte, 31), priv); err == nil {
+		t.Fatalf("SignDigestBytes accepted a 31-byte digest")
+	}
+	if _, err := SignDigestBytes(make([]byte, 33), priv); err == nil {
+		t.Fatalf("SignDigestBytes accepted a 33-byte digest")
+	}
+	if _, err := SignDigestBytes(sampleDigest(1), make([]byte, 31)); err == nil {
+		t.Fatalf("SignDigestBytes accepted a 31-byte private key")
+	}
+}
+
+func TestVerifyDigestBytes_BadDigestLen(t *testing.T) {
+	_, priv, pub := newTestKey(t)
+	sig, err := SignDigestBytes(sampleDigest(0x10), priv)
+	if err != nil {
+		t.Fatalf("SignDigestBytes: %v", err)
+	}
+	// Truncated digest → false.
+	if VerifyDigestBytes(make([]byte, 16), pub, sig) {
+		t.Fatalf("VerifyDigestBytes accepted a 16-byte digest")
+	}
+}
+
+// Sanity: the DER bytes from SignDigestBytes survive a parse-serialize
+// round-trip (i.e., they're well-formed DER, not just bytes that happen
+// to pass our verifier).
+func TestSignDigestBytes_OutputIsValidDER(t *testing.T) {
+	_, priv, _ := newTestKey(t)
+	sig, err := SignDigestBytes(sampleDigest(0x33), priv)
+	if err != nil {
+		t.Fatalf("SignDigestBytes: %v", err)
+	}
+	parsed, err := btcecdsa.ParseDERSignature(sig)
+	if err != nil {
+		t.Fatalf("ParseDERSignature: %v", err)
+	}
+	if !bytes.Equal(parsed.Serialize(), sig) {
+		t.Fatalf("DER bytes did not survive parse-serialize round-trip")
+	}
+}

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
 )
 
 const (
@@ -360,12 +360,7 @@ func VerifyPeerHandshake(headers http.Header, sharedValue []byte, localPubKey st
 }
 
 func verifySessionSignature(pubKey *PublicKeyToken, sharedValue, signature []byte) error {
-	sig, err := ecdsa.ParseDERSignature(signature)
-	if err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidSignature, err)
-	}
-	// sharedValue is already a 32-byte digest; verify it directly.
-	if !sig.Verify(sharedValue, pubKey.BtcecKey()) {
+	if !secp256k1.VerifyDigestBytes(sharedValue, pubKey.Bytes(), signature) {
 		return ErrInvalidSignature
 	}
 	return nil

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	rootcrypto "github.com/LeJamon/goXRPLd/crypto"
 	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
 )
 
@@ -360,6 +361,9 @@ func VerifyPeerHandshake(headers http.Header, sharedValue []byte, localPubKey st
 }
 
 func verifySessionSignature(pubKey *PublicKeyToken, sharedValue, signature []byte) error {
+	if rootcrypto.ECDSACanonicality(signature) == rootcrypto.CanonicityNone {
+		return fmt.Errorf("%w: malformed DER signature", ErrInvalidSignature)
+	}
 	if !secp256k1.VerifyDigestBytes(sharedValue, pubKey.Bytes(), signature) {
 		return ErrInvalidSignature
 	}

--- a/internal/peermanagement/identity.go
+++ b/internal/peermanagement/identity.go
@@ -22,6 +22,7 @@ import (
 	btcecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
 )
 
 var (
@@ -140,13 +141,7 @@ func (i *Identity) SignDigest(digest []byte) ([]byte, error) {
 	if i.privateKey == nil {
 		return nil, ErrInvalidPrivateKey
 	}
-
-	sig := btcecdsa.Sign(i.privateKey, digest)
-	if sig == nil {
-		return nil, ErrSignatureFailed
-	}
-
-	return sig.Serialize(), nil
+	return secp256k1.SignDigestBytes(digest, i.privateKey.Serialize())
 }
 
 // PublicKey returns the raw compressed public key bytes.

--- a/internal/peermanagement/identity.go
+++ b/internal/peermanagement/identity.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	btcecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
@@ -27,7 +26,6 @@ import (
 
 var (
 	ErrInvalidPrivateKey = errors.New("invalid private key")
-	ErrSignatureFailed   = errors.New("failed to sign message")
 )
 
 const (
@@ -128,12 +126,7 @@ func (i *Identity) Sign(message []byte) ([]byte, error) {
 	h.Write(message)
 	hash := h.Sum(nil)[:32]
 
-	sig := btcecdsa.Sign(i.privateKey, hash)
-	if sig == nil {
-		return nil, ErrSignatureFailed
-	}
-
-	return sig.Serialize(), nil
+	return secp256k1.SignDigestBytes(hash, i.privateKey.Serialize())
 }
 
 // SignDigest signs a pre-hashed 32-byte digest (used for session sigs).


### PR DESCRIPTION
## Summary

Closes #307. The peer handshake (added in #295) reaches into \`btcec/v2\` directly for sign + verify, duplicating logic already in \`crypto/secp256k1\`. This PR adds raw-bytes entry points to that package and routes \`peermanagement\` through them.

## What changes

**New: \`crypto/secp256k1/raw.go\`**

\`\`\`go
func SignDigestBytes(digest, privKey []byte) ([]byte, error)
func VerifyDigestBytes(digest, pubKey, sig []byte) bool
\`\`\`

Package-level functions taking raw bytes on both sides — no hex round-trips. \`VerifyDigestBytes\` thinly wraps the existing \`SECP256K1().ValidateDigest\` (which was already raw-typed); \`SignDigestBytes\` is new but delegates to the same \`decred/dcrec\` primitives \`SignDigest\` already used.

**Refactor: \`peermanagement\`**

- \`Identity.SignDigest\` → one-line delegation to \`secp256k1.SignDigestBytes\`. Drops the intermediate btcecdsa nil-check (the new function returns a typed error directly).
- \`verifySessionSignature\` → drops the inline \`ParseDERSignature\` + \`Verify\` pair in favour of \`secp256k1.VerifyDigestBytes\`.
- The \`btcec/v2/ecdsa\` import is gone from \`handshake.go\`.

**Out of scope**
- \`Identity.privateKey\` stays \`*btcec.PrivateKey\` (used for keypair generation; consolidating keygen is a bigger refactor).
- The ed25519 reject in \`ParsePublicKeyToken\` stays — it's peer-specific.
- The \`0x1C\` 'n' base58check encoding stays — peer-specific (account keys use \`0x23\`).

## Subtle behaviour change

\`verifySessionSignature\` now also runs the \`CanonicityNone\` screen that \`ValidateDigest\` performs, rejecting byte sequences that don't decode as ECDSA at all. This brings the verify path closer to rippled's \`verifyDigest()\` and doesn't reject any signature the prior btcec-based code accepted in practice — btcec rejects the same inputs, just one layer deeper. Called out in the commit message.

## Test plan

- [x] \`go test ./crypto/secp256k1/...\` — 10 new tests pass:
  - Sign/verify round-trip
  - Cross-impl: signatures from \`btcecdsa.Sign\` verify via \`VerifyDigestBytes\` (and vice versa) — locks in wire-compatibility with the prior path
  - Cross-impl: signatures from the legacy hex-string \`SECP256K1().SignDigest\` verify via \`VerifyDigestBytes\` (proves the byte-form API is interchangeable with the existing one)
  - Bad inputs: 31/33-byte digest, 31-byte private key, garbage sig, mismatched key, mismatched digest
  - DER well-formedness: output survives parse-serialize round-trip
- [x] \`go test ./internal/peermanagement/...\` — all green (handshake unit tests still pass with the delegated verify path)
- [x] \`PEERTLS_DOCKER_INTEROP=1 go test -tags docker -run TestHandshake_Interop_RippledDocker ./internal/peermanagement/peertls/\` — live interop with \`xrpllabsofficial/xrpld:latest\` still produces 101 + verifies rippled's response signature against our SharedValue. Wire-level parity confirmed.

## Drive-by

\`worktrees/\` was added to \`.gitignore\` (alongside the existing \`.worktrees/\` entry). Any contributor not pre-creating \`.worktrees/\` ends up with the un-prefixed form, so both should be ignored.