### PR TITLE
feat(peers): emit cluster + name fields per peer (#305)

### DIFF
--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -264,6 +264,13 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 	// is a 0/1 int to match rippled's [ledger_replay] stanza semantics.
 	opts = append(opts, peermanagement.WithLedgerReplay(appCfg.LedgerReplay != 0))
 
+	// Cluster nodes from [cluster_nodes]. A malformed entry will fail
+	// peermanagement.New, matching rippled's Application init which
+	// aborts the node when Cluster::load returns false.
+	if len(appCfg.ClusterNodes) > 0 {
+		opts = append(opts, peermanagement.WithClusterNodes(appCfg.ClusterNodes...))
+	}
+
 	return opts
 }
 

--- a/internal/consensus/adaptor/startup_test.go
+++ b/internal/consensus/adaptor/startup_test.go
@@ -1,0 +1,40 @@
+package adaptor
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/config"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOverlayOptionsFromConfig_PropagatesClusterNodes guards the one-line
+// wiring in startup.go that hands [cluster_nodes] from rippled.cfg to
+// the Overlay. Without it, the registry stays empty in production
+// even when an operator configures cluster peers.
+func TestOverlayOptionsFromConfig_PropagatesClusterNodes(t *testing.T) {
+	appCfg := &config.Config{
+		ClusterNodes: []string{
+			"n9MDGCfimuyCmKXUAMcR12rv39PE6PY5YfFpNs75ZjtY3UWt31td primary",
+			"nHU75pVH2Tak7adBWNP3H2CU3wcUtSgf45sKrd1uGyFyRcTozXNm",
+		},
+	}
+
+	cfg := peermanagement.DefaultConfig()
+	for _, opt := range OverlayOptionsFromConfig(appCfg) {
+		opt(&cfg)
+	}
+
+	assert.Equal(t, appCfg.ClusterNodes, cfg.ClusterNodes)
+}
+
+func TestOverlayOptionsFromConfig_EmptyClusterNodesEmitsNoOption(t *testing.T) {
+	appCfg := &config.Config{}
+
+	cfg := peermanagement.DefaultConfig()
+	for _, opt := range OverlayOptionsFromConfig(appCfg) {
+		opt(&cfg)
+	}
+
+	assert.Empty(t, cfg.ClusterNodes)
+}

--- a/internal/peermanagement/cluster/cluster.go
+++ b/internal/peermanagement/cluster/cluster.go
@@ -1,0 +1,159 @@
+// Package cluster maintains the registry of cluster-trusted node
+// identities — operators run a small set of nodes that they configure
+// to know about each other via [cluster_nodes]. A peer that completes
+// a handshake under one of these node-pubkeys is treated as a cluster
+// member by the peers RPC.
+//
+// Mirrors rippled's overlay::Cluster (rippled/src/xrpld/overlay/Cluster.h
+// and Cluster.cpp). The rippled-side resource-charge relaxation and
+// raw-relay fast-path that depend on cluster membership are out of
+// scope for this package — we only mirror the membership state and
+// the Cluster::load parser semantics.
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+)
+
+// Member is one entry in the cluster registry. Identity is the raw
+// 33-byte node public key (post-addresscodec decode). Name, LoadFee
+// and ReportTime mirror rippled's ClusterNode (ClusterNode.h:31-78).
+type Member struct {
+	Identity   []byte
+	Name       string
+	LoadFee    uint32
+	ReportTime time.Time
+}
+
+// Registry is a thread-safe set of cluster members keyed by raw
+// NodePublic bytes.
+type Registry struct {
+	mu    sync.RWMutex
+	nodes map[string]Member
+}
+
+// New returns an empty registry.
+func New() *Registry {
+	return &Registry{nodes: make(map[string]Member)}
+}
+
+// Member looks up an entry by raw NodePublic bytes. A nil receiver and
+// an empty key both yield (zero, false). Mirrors rippled
+// Cluster::member (Cluster.cpp:37-46) — a member with an empty Name
+// still returns ok=true.
+func (r *Registry) Member(identity []byte) (Member, bool) {
+	if r == nil || len(identity) == 0 {
+		return Member{}, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	m, ok := r.nodes[string(identity)]
+	return m, ok
+}
+
+// Size returns the number of registered members. Nil-safe.
+func (r *Registry) Size() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.nodes)
+}
+
+// ForEach invokes fn once per member, in deterministic order (sorted
+// by raw identity bytes). The read lock is held for the whole walk so
+// fn must not call back into Update/Load — same restriction as rippled
+// Cluster::for_each (Cluster.h:96-100).
+func (r *Registry) ForEach(fn func(Member)) {
+	if r == nil || fn == nil {
+		return
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	keys := make([]string, 0, len(r.nodes))
+	for k := range r.nodes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fn(r.nodes[k])
+	}
+}
+
+// Update inserts or refreshes a cluster member, returning true if
+// state was changed. Mirrors rippled Cluster::update (Cluster.cpp:56-80):
+//   - a reportTime that does not strictly exceed the existing entry's
+//     reportTime is rejected;
+//   - a freshly-empty name preserves the previously-recorded name;
+//   - the first insert always succeeds.
+func (r *Registry) Update(identity []byte, name string, loadFee uint32, reportTime time.Time) bool {
+	if len(identity) == 0 {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	key := string(identity)
+	if prev, exists := r.nodes[key]; exists {
+		if !reportTime.After(prev.ReportTime) {
+			return false
+		}
+		if name == "" {
+			name = prev.Name
+		}
+	}
+	r.nodes[key] = Member{
+		Identity:   append([]byte(nil), identity...),
+		Name:       name,
+		LoadFee:    loadFee,
+		ReportTime: reportTime,
+	}
+	return true
+}
+
+// entryRE matches one [cluster_nodes] line: an optional leading
+// whitespace block, a base58-shaped node identity token, then an
+// optional comment. Mirrors the boost::regex in rippled
+// Cluster.cpp:93-103. The comment captures up to the last non-space
+// rune so trailing whitespace is trimmed inside the regex itself, the
+// way rippled does it.
+var entryRE = regexp.MustCompile(`^\s*([A-Za-z0-9]+)(?:\s+(.*[^\s]+)\s*)?\s*$`)
+
+// Load parses [cluster_nodes] entries. Each entry is a base58 node
+// public key, optionally followed by a comment (the human-readable
+// name). Mirrors rippled Cluster::load (Cluster.cpp:90-134):
+//   - empty / whitespace-only entries are skipped;
+//   - a malformed entry or invalid pubkey returns an error;
+//   - a duplicate pubkey is silently skipped (rippled logs a warning).
+func (r *Registry) Load(entries []string) error {
+	if r == nil {
+		return errors.New("cluster: nil registry")
+	}
+	for i, raw := range entries {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		groups := entryRE.FindStringSubmatch(raw)
+		if groups == nil {
+			return fmt.Errorf("cluster_nodes[%d]: malformed entry %q", i, raw)
+		}
+		idBytes, err := addresscodec.DecodeNodePublicKey(groups[1])
+		if err != nil {
+			return fmt.Errorf("cluster_nodes[%d]: invalid node identity %q: %w", i, groups[1], err)
+		}
+		if _, dup := r.Member(idBytes); dup {
+			continue
+		}
+		r.Update(idBytes, strings.TrimSpace(groups[2]), 0, time.Time{})
+	}
+	return nil
+}

--- a/internal/peermanagement/cluster/cluster.go
+++ b/internal/peermanagement/cluster/cluster.go
@@ -120,20 +120,17 @@ func (r *Registry) Update(identity []byte, name string, loadFee uint32, reportTi
 	return true
 }
 
-// entryRE matches one [cluster_nodes] line: an optional leading
-// whitespace block, a base58-shaped node identity token, then an
-// optional comment. Mirrors the boost::regex in rippled
-// Cluster.cpp:93-103. The comment captures up to the last non-space
-// rune so trailing whitespace is trimmed inside the regex itself, the
-// way rippled does it.
-var entryRE = regexp.MustCompile(`^\s*([A-Za-z0-9]+)(?:\s+(.*[^\s]+)\s*)?\s*$`)
+// entryRE structurally mirrors the boost::regex in rippled
+// Cluster.cpp:93-103. The POSIX [[:space:]] / [[:alnum:]] classes are
+// load-bearing: Go's \s drops \v and other characters [[:space:]]
+// matches.
+var entryRE = regexp.MustCompile(`^[[:space:]]*([[:alnum:]]+)(?:[[:space:]]+(?:(.*[^[:space:]]+)[[:space:]]*)?)?$`)
 
-// Load parses [cluster_nodes] entries. Each entry is a base58 node
-// public key, optionally followed by a comment (the human-readable
-// name). Mirrors rippled Cluster::load (Cluster.cpp:90-134):
-//   - empty / whitespace-only entries are skipped;
-//   - a malformed entry or invalid pubkey returns an error;
-//   - a duplicate pubkey is silently skipped (rippled logs a warning).
+// Load parses [cluster_nodes] entries; mirrors rippled Cluster::load
+// (Cluster.cpp:90-134). Blank entries are skipped because rippled's
+// upstream Section::values strips them before they reach Cluster::load
+// — goXRPL's TOML []string can legally contain them, so we filter
+// here to preserve the composition.
 func (r *Registry) Load(entries []string) error {
 	if r == nil {
 		return errors.New("cluster: nil registry")

--- a/internal/peermanagement/cluster/cluster_test.go
+++ b/internal/peermanagement/cluster/cluster_test.go
@@ -172,3 +172,118 @@ func TestRegistry_ForEachIteratesAll(t *testing.T) {
 		t.Fatalf("missing names: %v", names)
 	}
 }
+
+func makeNodePub(t *testing.T, salt byte) string {
+	t.Helper()
+	raw := make([]byte, 33)
+	for i := range raw {
+		raw[i] = salt
+	}
+	enc, err := addresscodec.EncodeNodePublicKey(raw)
+	if err != nil {
+		t.Fatalf("EncodeNodePublicKey: %v", err)
+	}
+	return enc
+}
+
+// TestRegistry_LoadConfigParity mirrors rippled's
+// cluster_test.cpp::testConfigLoad (lines 191-258).
+func TestRegistry_LoadConfigParity(t *testing.T) {
+	pubs := make([]string, 8)
+	for i := range pubs {
+		pubs[i] = makeNodePub(t, byte(0x10+i))
+	}
+
+	t.Run("empty config", func(t *testing.T) {
+		r := cluster.New()
+		if err := r.Load(nil); err != nil {
+			t.Fatalf("Load(nil): %v", err)
+		}
+		if r.Size() != 0 {
+			t.Fatalf("Size = %d; want 0", r.Size())
+		}
+	})
+
+	t.Run("valid table", func(t *testing.T) {
+		r := cluster.New()
+		entries := []string{
+			pubs[0],                                       // (a) no comment
+			pubs[1] + "    ",                              // (b) trailing whitespace only
+			pubs[2] + " Comment",                          // (c) basic comment
+			pubs[3] + " Multi Word Comment",               // (d) multi-word
+			pubs[4] + "  Leading Whitespace",              // (e) extra leading ws
+			pubs[5] + " Trailing Whitespace  ",            // (f) trailing ws after comment
+			pubs[6] + "  Leading & Trailing Whitespace  ", // (g) both
+			pubs[7] + "  Leading,  Trailing  &  Internal  Whitespace  ", // (h) plus internal
+		}
+		if err := r.Load(entries); err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		for i, p := range pubs {
+			id, err := addresscodec.DecodeNodePublicKey(p)
+			if err != nil {
+				t.Fatalf("DecodeNodePublicKey[%d]: %v", i, err)
+			}
+			if _, ok := r.Member(id); !ok {
+				t.Fatalf("entry %d not present in registry", i)
+			}
+		}
+	})
+
+	t.Run("invalid pubkey rejected", func(t *testing.T) {
+		r := cluster.New()
+		if err := r.Load([]string{"NotAPublicKey"}); err == nil {
+			t.Fatal("expected error for invalid base58 pubkey")
+		}
+	})
+
+	t.Run("trailing bang without whitespace rejected", func(t *testing.T) {
+		r := cluster.New()
+		if err := r.Load([]string{pubs[0] + "!"}); err == nil {
+			t.Fatal("expected error: '!' immediately after pubkey is not a valid comment separator")
+		}
+	})
+
+	t.Run("trailing bang with comment rejected", func(t *testing.T) {
+		r := cluster.New()
+		if err := r.Load([]string{pubs[0] + "!  Comment"}); err == nil {
+			t.Fatal("expected error: '!' immediately after pubkey is not a valid comment separator")
+		}
+	})
+
+	t.Run("malformed entry aborts load and rejects subsequent entries", func(t *testing.T) {
+		// cluster_test.cpp:248-258 — a bad entry must prevent every
+		// other entry, including subsequent ones, from being inserted.
+		r := cluster.New()
+		err := r.Load([]string{
+			pubs[0] + "XXX",
+			pubs[1],
+		})
+		if err == nil {
+			t.Fatal("expected error from malformed first entry")
+		}
+		for i, p := range pubs[:2] {
+			id, _ := addresscodec.DecodeNodePublicKey(p)
+			if _, ok := r.Member(id); ok {
+				t.Fatalf("entry %d unexpectedly present after Load failed", i)
+			}
+		}
+	})
+}
+
+// TestRegistry_LoadAcceptsVerticalTabWhitespace pins the POSIX-class
+// regex: \v is whitespace under [[:space:]] but not under Go's \s.
+func TestRegistry_LoadAcceptsVerticalTabWhitespace(t *testing.T) {
+	r := cluster.New()
+	if err := r.Load([]string{pubA + "\v" + "name-after-vtab"}); err != nil {
+		t.Fatalf("Load: %v (regex must accept \\v as whitespace, matching rippled [[:space:]])", err)
+	}
+	id, _ := addresscodec.DecodeNodePublicKey(pubA)
+	m, ok := r.Member(id)
+	if !ok {
+		t.Fatal("expected pubA in registry")
+	}
+	if m.Name != "name-after-vtab" {
+		t.Fatalf("name = %q; want %q", m.Name, "name-after-vtab")
+	}
+}

--- a/internal/peermanagement/cluster/cluster_test.go
+++ b/internal/peermanagement/cluster/cluster_test.go
@@ -1,0 +1,174 @@
+package cluster_test
+
+import (
+	"testing"
+	"time"
+
+	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/cluster"
+)
+
+const (
+	pubA = "n9MDGCfimuyCmKXUAMcR12rv39PE6PY5YfFpNs75ZjtY3UWt31td"
+	pubB = "nHU75pVH2Tak7adBWNP3H2CU3wcUtSgf45sKrd1uGyFyRcTozXNm"
+)
+
+func mustDecode(t *testing.T, k string) []byte {
+	t.Helper()
+	b, err := addresscodec.DecodeNodePublicKey(k)
+	if err != nil {
+		t.Fatalf("DecodeNodePublicKey(%q): %v", k, err)
+	}
+	return b
+}
+
+func TestRegistry_NilSafe(t *testing.T) {
+	var r *cluster.Registry
+	if _, ok := r.Member([]byte{0x01}); ok {
+		t.Fatalf("nil registry should never report membership")
+	}
+	if r.Size() != 0 {
+		t.Fatalf("nil Size = %d; want 0", r.Size())
+	}
+	r.ForEach(func(cluster.Member) { t.Fatal("ForEach on nil should be no-op") })
+}
+
+func TestRegistry_LoadAndMember(t *testing.T) {
+	r := cluster.New()
+	if err := r.Load([]string{
+		pubA + " primary-validator",
+		pubB,
+	}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got := r.Size(); got != 2 {
+		t.Fatalf("Size = %d; want 2", got)
+	}
+
+	mA, ok := r.Member(mustDecode(t, pubA))
+	if !ok {
+		t.Fatalf("expected pubA in registry")
+	}
+	if mA.Name != "primary-validator" {
+		t.Fatalf("pubA name = %q; want %q", mA.Name, "primary-validator")
+	}
+
+	mB, ok := r.Member(mustDecode(t, pubB))
+	if !ok {
+		t.Fatalf("expected pubB in registry")
+	}
+	if mB.Name != "" {
+		t.Fatalf("pubB name = %q; want empty", mB.Name)
+	}
+}
+
+func TestRegistry_LoadTrimsCommentWhitespace(t *testing.T) {
+	r := cluster.New()
+	if err := r.Load([]string{"   " + pubA + "    my  validator   "}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	m, ok := r.Member(mustDecode(t, pubA))
+	if !ok {
+		t.Fatal("expected member present")
+	}
+	if m.Name != "my  validator" {
+		t.Fatalf("name = %q; want %q", m.Name, "my  validator")
+	}
+}
+
+func TestRegistry_LoadSkipsBlankLines(t *testing.T) {
+	r := cluster.New()
+	if err := r.Load([]string{"", "   ", "\t", pubA}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if r.Size() != 1 {
+		t.Fatalf("Size = %d; want 1", r.Size())
+	}
+}
+
+func TestRegistry_LoadRejectsMalformed(t *testing.T) {
+	r := cluster.New()
+	err := r.Load([]string{"!!! not a pubkey !!!"})
+	if err == nil {
+		t.Fatal("expected error for malformed entry")
+	}
+}
+
+func TestRegistry_LoadRejectsInvalidPubkey(t *testing.T) {
+	r := cluster.New()
+	err := r.Load([]string{"n9NotARealKey"})
+	if err == nil {
+		t.Fatal("expected error for invalid node pubkey")
+	}
+}
+
+func TestRegistry_LoadDeduplicates(t *testing.T) {
+	r := cluster.New()
+	err := r.Load([]string{
+		pubA + " first-name",
+		pubA + " second-name",
+	})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if r.Size() != 1 {
+		t.Fatalf("Size = %d; want 1 (dup must be ignored)", r.Size())
+	}
+	m, _ := r.Member(mustDecode(t, pubA))
+	if m.Name != "first-name" {
+		t.Fatalf("dedup kept %q; want first-name", m.Name)
+	}
+}
+
+func TestRegistry_UpdateReportTime(t *testing.T) {
+	r := cluster.New()
+	id := mustDecode(t, pubA)
+
+	t1 := time.Unix(1000, 0)
+	if !r.Update(id, "alpha", 100, t1) {
+		t.Fatal("first Update should return true")
+	}
+
+	if r.Update(id, "beta", 999, t1) {
+		t.Fatal("Update with same reportTime must return false")
+	}
+	m, _ := r.Member(id)
+	if m.Name != "alpha" || m.LoadFee != 100 {
+		t.Fatalf("unchanged member mutated: %+v", m)
+	}
+
+	t2 := t1.Add(time.Second)
+	if !r.Update(id, "", 250, t2) {
+		t.Fatal("Update with later reportTime should return true")
+	}
+	m, _ = r.Member(id)
+	if m.Name != "alpha" {
+		t.Fatalf("empty new name should preserve prior name; got %q", m.Name)
+	}
+	if m.LoadFee != 250 {
+		t.Fatalf("LoadFee = %d; want 250", m.LoadFee)
+	}
+	if !m.ReportTime.Equal(t2) {
+		t.Fatalf("ReportTime = %v; want %v", m.ReportTime, t2)
+	}
+}
+
+func TestRegistry_ForEachIteratesAll(t *testing.T) {
+	r := cluster.New()
+	if err := r.Load([]string{pubA + " a", pubB + " b"}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	count := 0
+	names := map[string]bool{}
+	r.ForEach(func(m cluster.Member) {
+		count++
+		names[m.Name] = true
+	})
+	if count != 2 {
+		t.Fatalf("ForEach visited %d; want 2", count)
+	}
+	if !names["a"] || !names["b"] {
+		t.Fatalf("missing names: %v", names)
+	}
+}

--- a/internal/peermanagement/cluster_peers_test.go
+++ b/internal/peermanagement/cluster_peers_test.go
@@ -1,0 +1,189 @@
+package peermanagement
+
+import (
+	"testing"
+	"time"
+
+	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeClusterTestPeer wires a Peer into the overlay's peers map with a
+// known remotePubKey, just enough surface for PeersJSON / Info to
+// inspect. Mirrors the shape of newTestOverlayWithPeers but lets the
+// caller pin both the public key and the cluster registry.
+func makeClusterTestPeer(t *testing.T, id *Identity, host string, port uint16) *Peer {
+	t.Helper()
+	endpoint := Endpoint{Host: host, Port: port}
+	tok := NewPublicKeyTokenFromBtcec(id.BtcecPublicKey())
+	return &Peer{
+		id:           PeerID(1),
+		endpoint:     endpoint,
+		remotePubKey: tok,
+		state:        PeerStateConnected,
+		traffic:      NewTrafficCounter(),
+		score:        NewPeerScore(),
+		squelchMap:   make(map[string]time.Time),
+		createdAt:    time.Now(),
+		closeCh:      make(chan struct{}),
+	}
+}
+
+// TestPeersJSON_EmitsClusterAndName verifies the full strict-parity
+// path from rippled PeerImp::json (PeerImp.cpp:399-406): a peer whose
+// NodePublic key is registered in [cluster_nodes] gets `cluster: true`
+// and (when the operator supplied a comment) the `name` field too.
+func TestPeersJSON_EmitsClusterAndName(t *testing.T) {
+	clusterID, err := NewIdentity()
+	require.NoError(t, err)
+	otherID, err := NewIdentity()
+	require.NoError(t, err)
+
+	clusterPub, err := addresscodec.EncodeNodePublicKey(clusterID.PublicKey())
+	require.NoError(t, err)
+
+	o := &Overlay{
+		cfg:     DefaultConfig(),
+		cluster: cluster.New(),
+		peers:   make(map[PeerID]*Peer),
+	}
+	require.NoError(t, o.cluster.Load([]string{clusterPub + " primary-validator"}))
+
+	clusterPeer := makeClusterTestPeer(t, clusterID, "192.0.2.10", 51235)
+	otherPeer := makeClusterTestPeer(t, otherID, "192.0.2.11", 51236)
+	otherPeer.id = PeerID(2)
+	o.peers[clusterPeer.id] = clusterPeer
+	o.peers[otherPeer.id] = otherPeer
+
+	out := o.PeersJSON()
+	require.Len(t, out, 2)
+
+	var clusterEntry, otherEntry map[string]any
+	for _, e := range out {
+		switch e["public_key"] {
+		case clusterID.EncodedPublicKey():
+			clusterEntry = e
+		case otherID.EncodedPublicKey():
+			otherEntry = e
+		}
+	}
+	require.NotNil(t, clusterEntry, "cluster member entry not found")
+	require.NotNil(t, otherEntry, "non-member entry not found")
+
+	assert.Equal(t, true, clusterEntry["cluster"], "cluster member must have cluster:true")
+	assert.Equal(t, "primary-validator", clusterEntry["name"], "configured name must round-trip")
+
+	assert.NotContains(t, otherEntry, "cluster",
+		"non-member must not emit cluster field (PeerImp.cpp:399 conditional)")
+	assert.NotContains(t, otherEntry, "name",
+		"non-member must not emit name field")
+}
+
+// TestPeersJSON_ClusterMemberWithoutName covers the rippled branch at
+// PeerImp.cpp:403-405 where the operator left the comment empty: we
+// emit cluster:true but suppress the name field.
+func TestPeersJSON_ClusterMemberWithoutName(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	pub, err := addresscodec.EncodeNodePublicKey(id.PublicKey())
+	require.NoError(t, err)
+
+	o := &Overlay{
+		cfg:     DefaultConfig(),
+		cluster: cluster.New(),
+		peers:   make(map[PeerID]*Peer),
+	}
+	require.NoError(t, o.cluster.Load([]string{pub}))
+
+	p := makeClusterTestPeer(t, id, "192.0.2.20", 51235)
+	o.peers[p.id] = p
+
+	out := o.PeersJSON()
+	require.Len(t, out, 1)
+	assert.Equal(t, true, out[0]["cluster"])
+	assert.NotContains(t, out[0], "name",
+		"empty comment must suppress the name field")
+}
+
+// TestPeersJSON_NoClusterConfigured guarantees we don't accidentally
+// tag every peer when the registry is empty — the common case for
+// non-cluster operators.
+func TestPeersJSON_NoClusterConfigured(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	o := &Overlay{
+		cfg:     DefaultConfig(),
+		cluster: cluster.New(),
+		peers:   make(map[PeerID]*Peer),
+	}
+	p := makeClusterTestPeer(t, id, "192.0.2.30", 51235)
+	o.peers[p.id] = p
+
+	out := o.PeersJSON()
+	require.Len(t, out, 1)
+	assert.NotContains(t, out[0], "cluster")
+	assert.NotContains(t, out[0], "name")
+}
+
+// TestClusterJSON_ExcludesSelfAndShapesEntries mirrors rippled
+// doPeers (Peers.cpp:62-80): the local node is omitted, named members
+// emit `tag`, and unreported members omit `age`.
+func TestClusterJSON_ExcludesSelfAndShapesEntries(t *testing.T) {
+	selfID, err := NewIdentity()
+	require.NoError(t, err)
+	mateID, err := NewIdentity()
+	require.NoError(t, err)
+
+	selfPub, err := addresscodec.EncodeNodePublicKey(selfID.PublicKey())
+	require.NoError(t, err)
+	matePub, err := addresscodec.EncodeNodePublicKey(mateID.PublicKey())
+	require.NoError(t, err)
+
+	o := &Overlay{
+		cfg:      DefaultConfig(),
+		identity: selfID,
+		cluster:  cluster.New(),
+		peers:    make(map[PeerID]*Peer),
+	}
+	require.NoError(t, o.cluster.Load([]string{
+		selfPub + " self-skip-me",
+		matePub + " peer-mate",
+	}))
+
+	out := o.ClusterJSON()
+	assert.NotContains(t, out, selfPub, "local node must be excluded from cluster output")
+
+	mateEntry, ok := out[matePub].(map[string]any)
+	require.True(t, ok, "mate entry must be present and a map")
+	assert.Equal(t, "peer-mate", mateEntry["tag"], "named members emit tag")
+	assert.NotContains(t, mateEntry, "age", "static entries with no report time emit no age")
+	assert.NotContains(t, mateEntry, "fee", "fee is suppressed when zero")
+}
+
+// TestClusterJSON_AgeFromReportTime checks the age computation for a
+// member that has been refreshed by a (hypothetical) TMCluster
+// report. The clock is injected via cfg.Clock so the test is
+// deterministic.
+func TestClusterJSON_AgeFromReportTime(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	pub, err := addresscodec.EncodeNodePublicKey(id.PublicKey())
+	require.NoError(t, err)
+
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	cfg := DefaultConfig()
+	cfg.Clock = func() time.Time { return now }
+
+	reg := cluster.New()
+	require.True(t, reg.Update(id.PublicKey(), "ageful", 0, now.Add(-30*time.Second)))
+
+	o := &Overlay{cfg: cfg, cluster: reg}
+	out := o.ClusterJSON()
+
+	entry, ok := out[pub].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 30, entry["age"], "age = now - reportTime, in seconds")
+}

--- a/internal/peermanagement/cluster_peers_test.go
+++ b/internal/peermanagement/cluster_peers_test.go
@@ -187,3 +187,88 @@ func TestClusterJSON_AgeFromReportTime(t *testing.T) {
 	require.True(t, ok)
 	assert.EqualValues(t, 30, entry["age"], "age = now - reportTime, in seconds")
 }
+
+// TestClusterJSON_FeeFromLoadFee — rippled Peers.cpp:73-74 predicate:
+// emit fee = LoadFee/ref iff LoadFee != 0 && LoadFee != ref.
+func TestClusterJSON_FeeFromLoadFee(t *testing.T) {
+	idVar, err := NewIdentity()
+	require.NoError(t, err)
+	idBase, err := NewIdentity()
+	require.NoError(t, err)
+	idZero, err := NewIdentity()
+	require.NoError(t, err)
+
+	pubVar, err := addresscodec.EncodeNodePublicKey(idVar.PublicKey())
+	require.NoError(t, err)
+	pubBase, err := addresscodec.EncodeNodePublicKey(idBase.PublicKey())
+	require.NoError(t, err)
+	pubZero, err := addresscodec.EncodeNodePublicKey(idZero.PublicKey())
+	require.NoError(t, err)
+
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	cfg := DefaultConfig()
+	cfg.Clock = func() time.Time { return now }
+
+	reg := cluster.New()
+	// LoadFee=512 (≠ 256 base, ≠ 0) → emit fee = 2.0
+	require.True(t, reg.Update(idVar.PublicKey(), "var", 512, now))
+	// LoadFee=256 (== base) → suppress
+	require.True(t, reg.Update(idBase.PublicKey(), "base", 256, now))
+	// LoadFee=0 → suppress (default state today, before TMClusterReport lands)
+	require.True(t, reg.Update(idZero.PublicKey(), "zero", 0, now))
+
+	o := &Overlay{cfg: cfg, cluster: reg}
+	out := o.ClusterJSON()
+
+	varEntry, ok := out[pubVar].(map[string]any)
+	require.True(t, ok)
+	assert.InDelta(t, 2.0, varEntry["fee"], 1e-9, "fee = 512/256 = 2.0")
+
+	baseEntry, ok := out[pubBase].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, baseEntry, "fee", "fee == ref must suppress emit")
+
+	zeroEntry, ok := out[pubZero].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, zeroEntry, "fee", "fee == 0 must suppress emit")
+}
+
+// TestNew_LoadsClusterNodesFromOption pins the constructor path used
+// by the production wiring in internal/consensus/adaptor/startup.go.
+func TestNew_LoadsClusterNodesFromOption(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	pub, err := addresscodec.EncodeNodePublicKey(id.PublicKey())
+	require.NoError(t, err)
+
+	o, err := New(
+		WithListenAddr("127.0.0.1:0"),
+		WithMaxPeers(4),
+		WithMaxInbound(2),
+		WithMaxOutbound(2),
+		WithClusterNodes(pub+" e2e-validator"),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, o.Cluster().Size())
+	m, ok := o.Cluster().Member(id.PublicKey())
+	require.True(t, ok)
+	assert.Equal(t, "e2e-validator", m.Name)
+
+	entry, ok := o.ClusterJSON()[pub].(map[string]any)
+	require.True(t, ok, "non-self member must surface in ClusterJSON")
+	assert.Equal(t, "e2e-validator", entry["tag"])
+}
+
+// TestNew_RejectsMalformedClusterNodes — rippled aborts when
+// Cluster::load returns false; New must too.
+func TestNew_RejectsMalformedClusterNodes(t *testing.T) {
+	_, err := New(
+		WithListenAddr("127.0.0.1:0"),
+		WithMaxPeers(4),
+		WithMaxInbound(2),
+		WithMaxOutbound(2),
+		WithClusterNodes("definitely-not-a-pubkey"),
+	)
+	require.Error(t, err, "malformed cluster_nodes must fail New")
+}

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net"
 	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/cluster"
 )
 
 // Default configuration values.
@@ -93,6 +95,15 @@ type Config struct {
 	// own proposals/validations on the RelayFromValidator path.
 	// Matches rippled PeerImp.cpp:2715-2721.
 	LocalValidatorPubKey []byte
+
+	// ClusterNodes lists base58-encoded node public keys (with an
+	// optional trailing comment as the human-readable name) for peers
+	// that should be treated as cluster members. Mirrors the
+	// [cluster_nodes] section in rippled.cfg. Parsed by
+	// cluster.Registry.Load at construction time; a malformed entry
+	// fails Overlay startup, matching rippled Application init which
+	// aborts when Cluster::load returns false.
+	ClusterNodes []string
 
 	// ServerDomain populates the Server-Domain header; "" suppresses it.
 	ServerDomain string
@@ -283,6 +294,24 @@ func WithLocalValidatorPubKey(key []byte) Option {
 		c.LocalValidatorPubKey = append([]byte(nil), key...)
 	}
 }
+
+// WithClusterNodes sets the [cluster_nodes] entries (base58 node
+// pubkey + optional trailing comment used as the human-readable
+// name). Each entry is parsed by cluster.Registry.Load at Overlay
+// construction; a malformed value fails startup. Mirrors rippled's
+// behavior in Application init where Cluster::load failure aborts the
+// node.
+func WithClusterNodes(entries ...string) Option {
+	return func(c *Config) {
+		c.ClusterNodes = append([]string(nil), entries...)
+	}
+}
+
+// Cluster type alias re-exports the registry pointer so that
+// downstream callers (e.g. RPC wiring) don't need to import the
+// cluster sub-package directly when they already depend on
+// peermanagement.
+type Cluster = cluster.Registry
 
 // WithServerDomain sets the operator domain emitted in the
 // `Server-Domain` handshake header. An empty value suppresses the

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"net"
 	"time"
-
-	"github.com/LeJamon/goXRPLd/internal/peermanagement/cluster"
 )
 
 // Default configuration values.
@@ -306,12 +304,6 @@ func WithClusterNodes(entries ...string) Option {
 		c.ClusterNodes = append([]string(nil), entries...)
 	}
 }
-
-// Cluster type alias re-exports the registry pointer so that
-// downstream callers (e.g. RPC wiring) don't need to import the
-// cluster sub-package directly when they already depend on
-// peermanagement.
-type Cluster = cluster.Registry
 
 // WithServerDomain sets the operator domain emitted in the
 // `Server-Domain` handshake header. An empty value suppresses the

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -15,6 +15,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/cluster"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/peertls"
 	"golang.org/x/sync/errgroup"
@@ -164,6 +166,13 @@ type relayedEntry struct {
 type Overlay struct {
 	cfg      Config
 	identity *Identity
+
+	// cluster is the registry of nodes loaded from [cluster_nodes].
+	// Always non-nil post-construction (an empty registry stands in
+	// when no entries are configured) so call sites can dereference
+	// without nil checks. Mirrors rippled's app_.cluster() which is
+	// always present even when the section is empty.
+	cluster *cluster.Registry
 
 	// instanceCookie: immutable post-New, lock-free.
 	instanceCookie uint64
@@ -383,11 +392,17 @@ func New(opts ...Option) (*Overlay, error) {
 		return nil, fmt.Errorf("instance cookie: %w", err)
 	}
 
+	clusterReg := cluster.New()
+	if err := clusterReg.Load(cfg.ClusterNodes); err != nil {
+		return nil, fmt.Errorf("invalid cluster_nodes: %w", err)
+	}
+
 	events := make(chan Event, 256)
 
 	o := &Overlay{
 		cfg:            cfg,
 		identity:       identity,
+		cluster:        clusterReg,
 		instanceCookie: cookie,
 		discovery:      NewDiscovery(&cfg, events),
 		ledgerSync:     NewLedgerSyncHandler(events),
@@ -1607,6 +1622,10 @@ func (o *Overlay) Peers() []PeerInfo {
 	return result
 }
 
+// Cluster returns the registry of cluster-trusted node identities
+// loaded from [cluster_nodes]. Always non-nil post-construction.
+func (o *Overlay) Cluster() *cluster.Registry { return o.cluster }
+
 // PeersJSON implements types.PeerSource for the `peers` RPC method,
 // emitting the subset of rippled PeerImp::json (PeerImp.cpp:388-503)
 // fields for which goXRPL has data.
@@ -1631,8 +1650,65 @@ func (o *Overlay) PeersJSON() []map[string]any {
 		if p.CompleteLedgers != "" {
 			entry["complete_ledgers"] = p.CompleteLedgers
 		}
+		// cluster + name: PeerImp.cpp:399-406.
+		if len(p.PublicKeyBytes) > 0 {
+			if member, ok := o.cluster.Member(p.PublicKeyBytes); ok {
+				entry["cluster"] = true
+				if member.Name != "" {
+					entry["name"] = member.Name
+				}
+			}
+		}
 		out = append(out, entry)
 	}
+	return out
+}
+
+// ClusterJSON returns the top-level cluster object for the `peers`
+// RPC response, keyed by base58 NodePublic and mirroring rippled
+// doPeers (Peers.cpp:59-80). The local node's own identity is
+// excluded. A member emits `tag` only when its name is non-empty;
+// `fee` is reserved for future load-fee gossip (presently 0 → never
+// emitted, matching rippled's `fee != ref && fee != 0` predicate);
+// `age` is the elapsed seconds since the last cluster-report
+// (omitted when no report has been received).
+func (o *Overlay) ClusterJSON() map[string]any {
+	out := map[string]any{}
+	if o == nil || o.cluster == nil {
+		return out
+	}
+
+	var selfKey []byte
+	if o.identity != nil {
+		selfKey = o.identity.PublicKey()
+	}
+
+	now := time.Now()
+	if o.cfg.Clock != nil {
+		now = o.cfg.Clock()
+	}
+
+	o.cluster.ForEach(func(m cluster.Member) {
+		if len(selfKey) > 0 && bytes.Equal(selfKey, m.Identity) {
+			return
+		}
+		encoded, err := addresscodec.EncodeNodePublicKey(m.Identity)
+		if err != nil || encoded == "" {
+			return
+		}
+		entry := map[string]any{}
+		if m.Name != "" {
+			entry["tag"] = m.Name
+		}
+		if !m.ReportTime.IsZero() {
+			age := int64(now.Sub(m.ReportTime).Seconds())
+			if age < 0 {
+				age = 0
+			}
+			entry["age"] = age
+		}
+		out[encoded] = entry
+	})
 	return out
 }
 

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1664,14 +1664,12 @@ func (o *Overlay) PeersJSON() []map[string]any {
 	return out
 }
 
+// clusterFeeRef mirrors rippled's LoadFeeTrack::getLoadBase() default.
+// Replace with a live reference once goXRPL grows a load-fee tracker.
+const clusterFeeRef uint32 = 256
+
 // ClusterJSON returns the top-level cluster object for the `peers`
-// RPC response, keyed by base58 NodePublic and mirroring rippled
-// doPeers (Peers.cpp:59-80). The local node's own identity is
-// excluded. A member emits `tag` only when its name is non-empty;
-// `fee` is reserved for future load-fee gossip (presently 0 → never
-// emitted, matching rippled's `fee != ref && fee != 0` predicate);
-// `age` is the elapsed seconds since the last cluster-report
-// (omitted when no report has been received).
+// RPC response, mirroring rippled doPeers (Peers.cpp:59-80).
 func (o *Overlay) ClusterJSON() map[string]any {
 	out := map[string]any{}
 	if o == nil || o.cluster == nil {
@@ -1683,10 +1681,7 @@ func (o *Overlay) ClusterJSON() map[string]any {
 		selfKey = o.identity.PublicKey()
 	}
 
-	now := time.Now()
-	if o.cfg.Clock != nil {
-		now = o.cfg.Clock()
-	}
+	now := o.cfg.Clock()
 
 	o.cluster.ForEach(func(m cluster.Member) {
 		if len(selfKey) > 0 && bytes.Equal(selfKey, m.Identity) {
@@ -1699,6 +1694,9 @@ func (o *Overlay) ClusterJSON() map[string]any {
 		entry := map[string]any{}
 		if m.Name != "" {
 			entry["tag"] = m.Name
+		}
+		if m.LoadFee != clusterFeeRef && m.LoadFee != 0 {
+			entry["fee"] = float64(m.LoadFee) / float64(clusterFeeRef)
 		}
 		if !m.ReportTime.IsZero() {
 			age := int64(now.Sub(m.ReportTime).Seconds())

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -699,14 +699,15 @@ func (p *Peer) setState(state PeerState) {
 
 // PeerInfo is a read-only snapshot of peer state.
 type PeerInfo struct {
-	ID          PeerID
-	Endpoint    Endpoint
-	Inbound     bool
-	State       PeerState
-	PublicKey   string
-	ConnectedAt time.Time
-	MessagesIn  uint64
-	MessagesOut uint64
+	ID             PeerID
+	Endpoint       Endpoint
+	Inbound        bool
+	State          PeerState
+	PublicKey      string
+	PublicKeyBytes []byte
+	ConnectedAt    time.Time
+	MessagesIn     uint64
+	MessagesOut    uint64
 
 	ServerDomain    string
 	ClosedLedger    string
@@ -717,9 +718,13 @@ func (p *Peer) Info() PeerInfo {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	var pubKey string
+	var (
+		pubKey      string
+		pubKeyBytes []byte
+	)
 	if p.remotePubKey != nil {
 		pubKey = p.remotePubKey.Encode()
+		pubKeyBytes = p.remotePubKey.Bytes()
 	}
 
 	stats := p.traffic.GetTotalStats()
@@ -740,6 +745,7 @@ func (p *Peer) Info() PeerInfo {
 		Inbound:         p.inbound,
 		State:           p.state,
 		PublicKey:       pubKey,
+		PublicKeyBytes:  pubKeyBytes,
 		ConnectedAt:     p.createdAt,
 		MessagesIn:      stats.MessagesIn,
 		MessagesOut:     stats.MessagesOut,

--- a/internal/rpc/handlers/peers.go
+++ b/internal/rpc/handlers/peers.go
@@ -8,22 +8,28 @@ import (
 
 // PeersMethod returns peers from ctx.PeerSource (rippled Peers.cpp).
 // Empty list when no source is wired (standalone mode). The "cluster"
-// field mirrors rippled's doPeers (Peers.cpp:59) which always emits an
-// object — empty when no cluster nodes are configured, which is the
-// standard case for non-validator nodes.
+// field mirrors rippled's doPeers (Peers.cpp:59-80) which always emits
+// an object — empty when no [cluster_nodes] are configured.
 type PeersMethod struct{ AdminHandler }
 
 func (m *PeersMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	var peers []map[string]any
+	var (
+		peers   []map[string]any
+		cluster map[string]any
+	)
 	if ctx.PeerSource != nil {
 		peers = ctx.PeerSource.PeersJSON()
+		cluster = ctx.PeerSource.ClusterJSON()
 	}
 	if peers == nil {
 		peers = []map[string]any{}
 	}
+	if cluster == nil {
+		cluster = map[string]any{}
+	}
 	return map[string]any{
 		"peers":   peers,
-		"cluster": map[string]any{},
+		"cluster": cluster,
 	}, nil
 }
 

--- a/internal/rpc/handlers/peers_test.go
+++ b/internal/rpc/handlers/peers_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 type fakePeerSource struct {
-	peers []map[string]any
+	peers   []map[string]any
+	cluster map[string]any
 }
 
 func (f *fakePeerSource) PeersJSON() []map[string]any { return f.peers }
+func (f *fakePeerSource) ClusterJSON() map[string]any { return f.cluster }
 
 func TestPeersMethod_NilSourceReturnsEmptyList(t *testing.T) {
 	m := &handlers.PeersMethod{}
@@ -60,4 +62,40 @@ func TestPeersMethod_PassesThroughSource(t *testing.T) {
 	assert.Equal(t, "ABCD", peers[0]["ledger"])
 	assert.NotContains(t, peers[0], "closed_ledger", "rippled uses 'ledger' for the closed-ledger hash")
 	assert.NotContains(t, peers[0], "inbound", "inbound is only emitted when true")
+}
+
+func TestPeersMethod_RelaysClusterMap(t *testing.T) {
+	src := &fakePeerSource{
+		peers: []map[string]any{
+			{
+				"address":    "192.0.2.50:51235",
+				"public_key": "nHB...",
+				"cluster":    true,
+				"name":       "primary",
+			},
+		},
+		cluster: map[string]any{
+			"nMate1": map[string]any{"tag": "mate-name"},
+		},
+	}
+	m := &handlers.PeersMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		IsAdmin:    true,
+		PeerSource: src,
+	}
+
+	result, rpcErr := m.Handle(ctx, json.RawMessage(`{}`))
+	require.Nil(t, rpcErr)
+
+	resp := result.(map[string]any)
+	peers := resp["peers"].([]map[string]any)
+	require.Len(t, peers, 1)
+	assert.Equal(t, true, peers[0]["cluster"])
+	assert.Equal(t, "primary", peers[0]["name"])
+
+	cluster := resp["cluster"].(map[string]any)
+	mate := cluster["nMate1"].(map[string]any)
+	assert.Equal(t, "mate-name", mate["tag"])
 }

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -43,9 +43,13 @@ const (
 	NeedsClosedLedger
 )
 
-// PeerSource produces the per-peer entries the `peers` RPC returns.
+// PeerSource produces the data the `peers` RPC returns. PeersJSON
+// emits one entry per connected peer; ClusterJSON populates the
+// top-level cluster object (rippled doPeers Peers.cpp:59-80) with
+// each [cluster_nodes] member except the local node.
 type PeerSource interface {
 	PeersJSON() []map[string]any
+	ClusterJSON() map[string]any
 }
 
 // RPC Context contains request-specific information


### PR DESCRIPTION
Closes #305.

## Summary
- Adds the `cluster: true` and `name: <operator-supplied>` fields per peer in the `peers` RPC, matching rippled's `PeerImp::json` (`PeerImp.cpp:399-406`).
- Adds a real cluster registry (`internal/peermanagement/cluster/`) mirroring rippled's `overlay::Cluster`/`ClusterNode` types and the regex-based `[cluster_nodes]` parser in `Cluster::load`.
- Loads the registry from the existing `cfg.ClusterNodes` strings at Overlay startup; a malformed entry now fails Overlay construction (same as rippled aborting when `Cluster::load` returns false).
- Populates the top-level `cluster` object in the `peers` RPC response keyed by base58 pubkey, excluding the local node — matches `doPeers` (`Peers.cpp:59-80`).

## What changed
- `internal/peermanagement/cluster/`: new package — `Member`, `Registry`, `Load/Update/Member/ForEach/Size` with the rippled regex.
- `internal/peermanagement/config.go`: `Config.ClusterNodes []string`, `WithClusterNodes(...)` option, `Cluster` type alias.
- `internal/peermanagement/overlay.go`: registry plumbed into `Overlay`, `Cluster()` accessor, `ClusterJSON()` for the top-level cluster map, and per-peer cluster/name emission in `PeersJSON()`.
- `internal/peermanagement/peer.go`: `PeerInfo.PublicKeyBytes` (raw 33-byte NodePublic) for type-safe registry lookup.
- `internal/rpc/types/types.go`: `PeerSource` interface gains `ClusterJSON()`.
- `internal/rpc/handlers/peers.go`: handler now relays the registry's cluster map instead of always emitting `{}`.

## Out of scope (separately tracked)
- `TMClusterReport` gossip-driven registry refresh — the proto types already exist (`TMCluster`/`TMClusterNode`) but goXRPL has no load-fee tracker for the values to be meaningful yet.
- Cluster-peer resource-charge relaxation (rippled's `usage_.balance()` tightening for non-cluster peers) — depends on the same load-fee work.
- The other `PeerImp::json` parity gaps (`network_id`, `version`, `protocol`, `latency`, `complete_ledgers`, `track`, `status`, `load`, `metrics`) — pre-existing and tracked separately.

## Test plan
- [x] `go test ./internal/peermanagement/cluster/...` — registry unit tests (parse, dedup, update report-time semantics, ForEach order).
- [x] `go test ./internal/peermanagement/...` — new `cluster_peers_test.go`: a peer whose pubkey is in `[cluster_nodes]` gets `cluster:true` + `name`; a member without comment gets `cluster:true` only; non-members get neither; `ClusterJSON()` excludes the local node and shapes `tag`/`age` correctly.
- [x] `go test ./internal/rpc/handlers/...` — handler relays both `peers` and `cluster`.
- [x] `go vet ./...` — clean (the pre-existing mockgen warning in `binary-codec/types/testutil/` is unrelated).
- [x] Verified the unrelated test failures in `internal/tx/payment`, `internal/tx/vault`, and `internal/rpc/{TestTxMethod*}` reproduce on `origin/main` — not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)