### PR TITLE
feat(peermanagement): emit per-peer network_id in peers RPC (#296)

### DIFF
--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -598,6 +598,7 @@ func PeerFeatureEnabled(headers http.Header, feature, value string, localEnabled
 // wire but are validated-and-discarded (matching rippled PeerImp).
 type HandshakeExtras struct {
 	ServerDomain      string
+	NetworkID         string
 	ClosedLedger      [32]byte
 	PreviousLedger    [32]byte
 	HasClosedLedger   bool
@@ -637,6 +638,15 @@ func ParseHandshakeExtras(
 	// Server-Domain is validated by ValidateServerDomain upstream.
 	if v := headers.Get(HeaderServerDomain); v != "" {
 		out.ServerDomain = v
+	}
+
+	// Network-ID: rippled (Handshake.cpp:241-249) parses-and-validates
+	// the value but stores the raw header on PeerImp::headers_, surfacing
+	// it as a string in PeerImp::json (PeerImp.cpp:411-412). Numeric
+	// validation + mismatch rejection happens upstream in
+	// VerifyPeerHandshake; here we just round-trip the original string.
+	if v := headers.Get(HeaderNetworkID); v != "" {
+		out.NetworkID = v
 	}
 
 	if v := headers.Get(HeaderClosedLedger); v != "" {

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1682,6 +1682,10 @@ func (o *Overlay) PeersJSON() []map[string]any {
 		if p.ServerDomain != "" {
 			entry["server_domain"] = p.ServerDomain
 		}
+		// PeerImp.cpp:411-412: emit only when the peer set a Network-ID.
+		if p.NetworkID != "" {
+			entry["network_id"] = p.NetworkID
+		}
 		if p.ClosedLedger != "" {
 			entry["ledger"] = p.ClosedLedger
 		}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -99,6 +99,7 @@ type Peer struct {
 	tracking atomic.Int32
 
 	serverDomain      string
+	networkID         string
 	closedLedger      [32]byte
 	previousLedger    [32]byte
 	hasClosedLedger   bool
@@ -198,6 +199,7 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.serverDomain = x.ServerDomain
+	p.networkID = x.NetworkID
 	if x.HasClosedLedger {
 		p.closedLedger = x.ClosedLedger
 		p.hasClosedLedger = true
@@ -296,6 +298,15 @@ func (p *Peer) ServerDomain() string {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.serverDomain
+}
+
+// NetworkID reports the peer's reported Network-ID handshake header,
+// or "" if the peer omitted it. Mirrors rippled PeerImp's
+// headers_["Network-ID"] passthrough (PeerImp.cpp:411-412).
+func (p *Peer) NetworkID() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.networkID
 }
 
 // ClosedLedger reports the peer's last closed-ledger hint, or ok=false.
@@ -856,6 +867,7 @@ type PeerInfo struct {
 	MessagesOut    uint64
 
 	ServerDomain    string
+	NetworkID       string
 	ClosedLedger    string
 	CompleteLedgers string
 	Tracking        PeerTracking
@@ -903,6 +915,7 @@ func (p *Peer) Info() PeerInfo {
 		MessagesIn:      stats.MessagesIn,
 		MessagesOut:     stats.MessagesOut,
 		ServerDomain:    p.serverDomain,
+		NetworkID:       p.networkID,
 		ClosedLedger:    closedLedger,
 		CompleteLedgers: completeLedgers,
 		Tracking:        PeerTracking(p.tracking.Load()),

--- a/internal/peermanagement/peers_json_test.go
+++ b/internal/peermanagement/peers_json_test.go
@@ -1,6 +1,7 @@
 package peermanagement
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,81 @@ func TestOverlay_PeersJSON_EmitsLoad(t *testing.T) {
 		_, hasLoad := entry["load"]
 		assert.True(t, hasLoad, "peer %q missing load field", addr)
 	}
+}
+
+// PeersJSON must round-trip the peer's reported Network-ID header
+// matching rippled PeerImp::json (PeerImp.cpp:411-412): emit
+// `network_id` only when the peer set the header.
+func TestOverlay_PeersJSON_NetworkID(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	mk := func(pid PeerID, host string, networkID string) *Peer {
+		p := NewPeer(pid, Endpoint{Host: host, Port: 51235}, false, id, nil)
+		p.setState(PeerStateConnected)
+		p.applyHandshakeExtras(HandshakeExtras{NetworkID: networkID})
+		return p
+	}
+
+	overlay := newTestOverlayWithPeers(map[PeerID]*Peer{
+		1: mk(1, "10.0.0.1", "21337"), // testnet-style id
+		2: mk(2, "10.0.0.2", ""),      // peer omitted the header
+	})
+
+	got := overlay.PeersJSON()
+	require.Len(t, got, 2)
+
+	by := map[string]map[string]any{}
+	for _, e := range got {
+		by[e["address"].(string)] = e
+	}
+
+	assert.Equal(t, "21337", by["10.0.0.1:51235"]["network_id"],
+		"peer that sent Network-ID must round-trip via PeersJSON")
+	_, hasNID := by["10.0.0.2:51235"]["network_id"]
+	assert.False(t, hasNID,
+		"peer without Network-ID must omit network_id (rippled's !nid.empty() gate)")
+}
+
+// Peer.NetworkID accessor surfaces the handshake-stored value, and
+// HandshakeExtras carries it through ParseHandshakeExtras.
+func TestPeer_NetworkID_AccessorAndHandshakeExtras(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	p := NewPeer(1, Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, nil)
+	assert.Equal(t, "", p.NetworkID(),
+		"NetworkID defaults to empty before handshake")
+
+	p.applyHandshakeExtras(HandshakeExtras{NetworkID: "1024"})
+	assert.Equal(t, "1024", p.NetworkID())
+	assert.Equal(t, "1024", p.Info().NetworkID,
+		"PeerInfo.NetworkID must mirror the accessor")
+
+	p.applyHandshakeExtras(HandshakeExtras{}) // re-handshake without header
+	assert.Equal(t, "", p.NetworkID(),
+		"applyHandshakeExtras must clear NetworkID when the new header is absent")
+}
+
+// ParseHandshakeExtras must round-trip the raw Network-ID header.
+// rippled stores the header as-is on PeerImp::headers_ — the numeric
+// validation in verifyHandshake (Handshake.cpp:241-249) lives upstream
+// of extras parsing.
+func TestParseHandshakeExtras_NetworkID(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		h := http.Header{}
+		h.Set(HeaderNetworkID, "21338")
+
+		extras, err := ParseHandshakeExtras(h, nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "21338", extras.NetworkID)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		extras, err := ParseHandshakeExtras(http.Header{}, nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "", extras.NetworkID)
+	})
 }
 
 func TestPeer_Load_TracksBadDataBalance(t *testing.T) {


### PR DESCRIPTION
## Summary
- Round-trips each peer's `Network-ID` handshake header into the `peers` RPC response, matching rippled `PeerImp::json` (`PeerImp.cpp:411-412`) which emits `network_id` only when `headers_["Network-ID"]` is non-empty.
- Adds `NetworkID` to `HandshakeExtras` and stores the raw header string on `Peer` (rippled keeps it as-is on `PeerImp::headers_`); numeric validation continues to live upstream in `VerifyPeerHandshake` (`Handshake.cpp:241-249`).
- Surfaces a new `Peer.NetworkID() string` accessor and threads it into `PeerInfo.NetworkID`.

Closes #296.

## Implementation
1. `internal/peermanagement/handshake.go` — extend `HandshakeExtras` with `NetworkID string`; populate it in `ParseHandshakeExtras` from `headers.Get(HeaderNetworkID)`.
2. `internal/peermanagement/peer.go` — add `networkID` field, copy it through `applyHandshakeExtras`, expose `Peer.NetworkID()`, and add `PeerInfo.NetworkID` (set in `Info()`).
3. `internal/peermanagement/overlay.go` — `PeersJSON` emits `entry["network_id"] = p.NetworkID` only when non-empty (rippled's `!nid.empty()` gate).

Both inbound (`overlay.go:705`) and outbound (`peer.go:456`) handshake paths already feed through `ParseHandshakeExtras` → `applyHandshakeExtras`, so no per-direction wiring was needed.

## Test plan
- [x] `go vet ./internal/peermanagement/...`
- [x] `go test ./internal/peermanagement/...` (full suite green)
- [x] `go test -run TestPeers ./internal/rpc/handlers/...`
- [x] New tests in `peers_json_test.go`:
  - `TestOverlay_PeersJSON_NetworkID` — emits when set, omits when blank.
  - `TestPeer_NetworkID_AccessorAndHandshakeExtras` — accessor + `PeerInfo` mirror, and clears on a re-handshake without the header.
  - `TestParseHandshakeExtras_NetworkID` — present/absent round-trip.