### PR TITLE
feat(peermanagement): emit per-peer version in peers RPC (#297)

### DIFF
--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -603,6 +603,10 @@ type HandshakeExtras struct {
 	PreviousLedger    [32]byte
 	HasClosedLedger   bool
 	HasPreviousLedger bool
+	// Raw version headers; applyHandshakeExtras picks one by direction,
+	// mirroring PeerImp::getVersion (PeerImp.cpp:381-386).
+	UserAgentHeader string
+	ServerHeader    string
 }
 
 // ValidateServerDomain enforces verifyHandshake's Server-Domain check
@@ -648,6 +652,9 @@ func ParseHandshakeExtras(
 	if v := headers.Get(HeaderNetworkID); v != "" {
 		out.NetworkID = v
 	}
+
+	out.UserAgentHeader = headers.Get(HeaderUserAgent)
+	out.ServerHeader = headers.Get(HeaderServer)
 
 	if v := headers.Get(HeaderClosedLedger); v != "" {
 		h, err := parseLedgerHashHeader(v)

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1711,6 +1711,11 @@ func (o *Overlay) PeersJSON() []map[string]any {
 		if p.HasLatency {
 			entry["latency"] = uint32(p.Latency / time.Millisecond)
 		}
+		// PeerImp.cpp:416-417: version sourced from User-Agent (inbound)
+		// or Server (outbound) header.
+		if p.Version != "" {
+			entry["version"] = p.Version
+		}
 		out = append(out, entry)
 	}
 	return out

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -100,6 +100,7 @@ type Peer struct {
 
 	serverDomain      string
 	networkID         string
+	userAgent         string
 	closedLedger      [32]byte
 	previousLedger    [32]byte
 	hasClosedLedger   bool
@@ -200,6 +201,12 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 	defer p.mu.Unlock()
 	p.serverDomain = x.ServerDomain
 	p.networkID = x.NetworkID
+	// PeerImp::getVersion (PeerImp.cpp:381-386) picks by direction.
+	if p.inbound {
+		p.userAgent = x.UserAgentHeader
+	} else {
+		p.userAgent = x.ServerHeader
+	}
 	if x.HasClosedLedger {
 		p.closedLedger = x.ClosedLedger
 		p.hasClosedLedger = true
@@ -868,6 +875,7 @@ type PeerInfo struct {
 
 	ServerDomain    string
 	NetworkID       string
+	Version         string
 	ClosedLedger    string
 	CompleteLedgers string
 	Tracking        PeerTracking
@@ -916,6 +924,7 @@ func (p *Peer) Info() PeerInfo {
 		MessagesOut:     stats.MessagesOut,
 		ServerDomain:    p.serverDomain,
 		NetworkID:       p.networkID,
+		Version:         p.userAgent,
 		ClosedLedger:    closedLedger,
 		CompleteLedgers: completeLedgers,
 		Tracking:        PeerTracking(p.tracking.Load()),

--- a/internal/peermanagement/peers_json_test.go
+++ b/internal/peermanagement/peers_json_test.go
@@ -127,6 +127,90 @@ func TestParseHandshakeExtras_NetworkID(t *testing.T) {
 	})
 }
 
+// PeerImp.cpp:416-417 — version is sourced from the peer's User-Agent
+// header (inbound) or Server header (outbound). Emit only when non-empty.
+func TestPeersJSON_Version(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	t.Run("emits_user_agent_for_inbound", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set(HeaderUserAgent, "rippled-2.5.0")
+		extras, err := ParseHandshakeExtras(headers, nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "rippled-2.5.0", extras.UserAgentHeader)
+
+		p := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, true, id, nil)
+		p.applyHandshakeExtras(extras)
+
+		o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
+		entries := o.PeersJSON()
+		require.Len(t, entries, 1)
+		assert.Equal(t, "rippled-2.5.0", entries[0]["version"])
+	})
+
+	t.Run("emits_server_for_outbound", func(t *testing.T) {
+		// Outbound responses carry the version on the Server header
+		// (BuildHandshakeResponse mirrors rippled).
+		headers := http.Header{}
+		headers.Set(HeaderServer, "rippled-2.6.0")
+		extras, err := ParseHandshakeExtras(headers, nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "rippled-2.6.0", extras.ServerHeader)
+
+		p := NewPeer(2, Endpoint{Host: "192.0.2.2", Port: 51235}, false, id, nil)
+		p.applyHandshakeExtras(extras)
+
+		o := newTestOverlayWithPeers(map[PeerID]*Peer{2: p})
+		entries := o.PeersJSON()
+		require.Len(t, entries, 1)
+		assert.Equal(t, "rippled-2.6.0", entries[0]["version"])
+	})
+
+	t.Run("inbound_ignores_spurious_server_header", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set(HeaderUserAgent, "rippled-ua")
+		headers.Set(HeaderServer, "rippled-server")
+		extras, err := ParseHandshakeExtras(headers, nil, nil)
+		require.NoError(t, err)
+
+		p := NewPeer(4, Endpoint{Host: "192.0.2.4", Port: 51235}, true, id, nil)
+		p.applyHandshakeExtras(extras)
+
+		o := newTestOverlayWithPeers(map[PeerID]*Peer{4: p})
+		entries := o.PeersJSON()
+		require.Len(t, entries, 1)
+		assert.Equal(t, "rippled-ua", entries[0]["version"],
+			"inbound peer reads User-Agent regardless of Server")
+	})
+
+	t.Run("outbound_ignores_spurious_user_agent_header", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set(HeaderUserAgent, "rippled-ua")
+		headers.Set(HeaderServer, "rippled-server")
+		extras, err := ParseHandshakeExtras(headers, nil, nil)
+		require.NoError(t, err)
+
+		p := NewPeer(5, Endpoint{Host: "192.0.2.5", Port: 51235}, false, id, nil)
+		p.applyHandshakeExtras(extras)
+
+		o := newTestOverlayWithPeers(map[PeerID]*Peer{5: p})
+		entries := o.PeersJSON()
+		require.Len(t, entries, 1)
+		assert.Equal(t, "rippled-server", entries[0]["version"],
+			"outbound peer reads Server regardless of User-Agent")
+	})
+
+	t.Run("absent_when_no_version", func(t *testing.T) {
+		p := NewPeer(3, Endpoint{Host: "192.0.2.3", Port: 51235}, false, id, nil)
+		o := newTestOverlayWithPeers(map[PeerID]*Peer{3: p})
+		entries := o.PeersJSON()
+		require.Len(t, entries, 1)
+		_, present := entries[0]["version"]
+		assert.False(t, present, "rippled omits `version` when getVersion() is empty")
+	})
+}
+
 func TestPeer_Load_TracksBadDataBalance(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Closes #297. Emits the `version` field per peer in the `peers` RPC response, mirroring rippled `PeerImp::json` (PeerImp.cpp:416-417).
- Source follows rippled `PeerImp::getVersion` direction split: inbound peers' `User-Agent` (request) or outbound peers' `Server` (response). The two headers are disjoint by construction, so `ParseHandshakeExtras` checks `User-Agent` first then falls back to `Server`.
- Threads through `HandshakeExtras.UserAgent` → `Peer.userAgent` → `PeerInfo.Version` → `PeersJSON` (emits only when non-empty).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/peermanagement/...`
- [x] `go test ./internal/peermanagement/...`
- [x] `go test ./internal/rpc/handlers/...`
- [x] New `TestPeersJSON_Version` covers inbound (User-Agent), outbound (Server), User-Agent precedence over Server, and absence (no header → field omitted).