### PR TITLE
feat(peermanagement): emit per-peer status in peers RPC (#299)

### DIFF
--- a/internal/cli/replay.go
+++ b/internal/cli/replay.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	_ "github.com/LeJamon/goXRPLd/internal/tx/all"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/shamap"
 	"github.com/spf13/cobra"
 )
@@ -334,9 +335,8 @@ func executeReplayVerbose(state *StateFixture, env *EnvFixture, txs *TxsFixture,
 		return nil, nil, fmt.Errorf("parsing parent_hash: %w", err)
 	}
 
-	rippleEpoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	closeTime := rippleEpoch.Add(time.Duration(env.CloseTime) * time.Second)
-	parentCloseTime := rippleEpoch.Add(time.Duration(env.ParentCloseTime) * time.Second)
+	closeTime := time.Unix(protocol.RippleEpochUnix+int64(env.CloseTime), 0).UTC()
+	parentCloseTime := time.Unix(protocol.RippleEpochUnix+int64(env.ParentCloseTime), 0).UTC()
 
 	ledgerHeader := header.LedgerHeader{
 		LedgerIndex:         env.LedgerIndex,

--- a/internal/cli/replay_range.go
+++ b/internal/cli/replay_range.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
 	"github.com/LeJamon/goXRPLd/internal/statecompare"
 	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/shamap"
 	"github.com/spf13/cobra"
 )
@@ -425,9 +426,8 @@ func processBlock(
 	}
 
 	// Setup ledger header
-	rippleEpoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	closeTime := rippleEpoch.Add(time.Duration(postSnapshot.CloseTime) * time.Second)
-	parentCloseTime := rippleEpoch.Add(time.Duration(preSnapshot.CloseTime) * time.Second)
+	closeTime := time.Unix(protocol.RippleEpochUnix+int64(postSnapshot.CloseTime), 0).UTC()
+	parentCloseTime := time.Unix(protocol.RippleEpochUnix+int64(preSnapshot.CloseTime), 0).UTC()
 
 	ledgerHeader := header.LedgerHeader{
 		LedgerIndex:         targetLedger,

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
+	"github.com/LeJamon/goXRPLd/protocol"
 	kvpebble "github.com/LeJamon/goXRPLd/storage/kvstore/pebble"
 	"github.com/LeJamon/goXRPLd/storage/nodestore"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
@@ -339,8 +340,7 @@ func runServer(cmd *cobra.Command, args []string) {
 
 		baseFee, reserveBase, reserveInc := ledgerService.GetCurrentFees()
 
-		rippleEpoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-		ledgerTime := uint32(event.LedgerInfo.CloseTime.Unix() - rippleEpoch.Unix())
+		ledgerTime := uint32(event.LedgerInfo.CloseTime.Unix() - protocol.RippleEpochUnix)
 
 		ledgerCloseEvent := &rpc.LedgerCloseEvent{
 			Type:             "ledgerClosed",
@@ -573,8 +573,7 @@ func (a *ledgerInfoAdapter) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
 
 	baseFee, reserveBase, reserveInc := a.ledgerService.GetCurrentFees()
 
-	rippleEpoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	ledgerTime := uint32(validatedLedger.CloseTime().Unix() - rippleEpoch.Unix())
+	ledgerTime := uint32(validatedLedger.CloseTime().Unix() - protocol.RippleEpochUnix)
 
 	hash := validatedLedger.Hash()
 	serverInfo := a.ledgerService.GetServerInfo()

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -313,6 +313,24 @@ func runServer(cmd *cobra.Command, args []string) {
 
 	publisher := rpc.NewPublisher(wsServer.GetSubscriptionManager())
 
+	// Wire pubPeerStatus → peer_status WebSocket subscription. Mirrors
+	// rippled NetworkOPs::pubPeerStatus (NetworkOPs.cpp:2514-2540) which
+	// broadcasts to InfoSubs registered for the sPeerStatus stream.
+	if consensusComponents != nil && consensusComponents.Overlay != nil {
+		consensusComponents.Overlay.SetPeerStatusPublisher(func(u peermanagement.PeerStatusUpdate) {
+			publisher.PublishPeerStatus(&rpc.PeerStatusEvent{
+				Type:           "peerStatusChange",
+				Status:         u.Status,
+				Action:         u.Action,
+				Date:           u.Date,
+				LedgerHash:     u.LedgerHash,
+				LedgerIndex:    u.LedgerIndex,
+				LedgerIndexMin: u.LedgerIndexMin,
+				LedgerIndexMax: u.LedgerIndexMax,
+			})
+		})
+	}
+
 	// Wire up ledger service events to WebSocket broadcasts
 	ledgerService.SetEventCallback(func(event *service.LedgerAcceptedEvent) {
 		if event == nil || event.LedgerInfo == nil {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 var (
@@ -1062,7 +1063,7 @@ func (a *Adaptor) broadcastStatus(event message.NodeEvent) {
 	}
 
 	// NetworkTime: XRPL epoch seconds (rippled sends seconds, not microseconds)
-	networkTime := uint64(time.Now().Unix() - xrplEpochOffset)
+	networkTime := uint64(time.Now().Unix() - protocol.RippleEpochUnix)
 
 	firstSeq := uint32(2) // genesis sequence
 	lastSeq := l.Sequence()

--- a/internal/consensus/adaptor/converter.go
+++ b/internal/consensus/adaptor/converter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // ProposalFromMessage converts a decoded ProposeSet message to a consensus.Proposal.
@@ -110,9 +111,9 @@ func HaveSetToMessage(id consensus.TxSetID, status message.TxSetStatus) *message
 }
 
 func xrplEpochToTime(epoch uint32) time.Time {
-	return time.Unix(int64(epoch)+xrplEpochOffset, 0)
+	return time.Unix(int64(epoch)+protocol.RippleEpochUnix, 0)
 }
 
 func timeToXrplEpoch(t time.Time) uint32 {
-	return uint32(t.Unix() - xrplEpochOffset)
+	return uint32(t.Unix() - protocol.RippleEpochUnix)
 }

--- a/internal/consensus/adaptor/identity.go
+++ b/internal/consensus/adaptor/identity.go
@@ -147,7 +147,7 @@ func buildProposalSigningData(p *consensus.Proposal) []byte {
 	buf = append(buf, byte(p.Position>>24), byte(p.Position>>16), byte(p.Position>>8), byte(p.Position))
 
 	// CloseTime as XRPL epoch seconds (4 bytes, big-endian)
-	closeTimeSec := uint32(p.CloseTime.Unix() - xrplEpochOffset)
+	closeTimeSec := uint32(p.CloseTime.Unix() - protocol.RippleEpochUnix)
 	buf = append(buf, byte(closeTimeSec>>24), byte(closeTimeSec>>16), byte(closeTimeSec>>8), byte(closeTimeSec))
 
 	// PreviousLedger (32 bytes)
@@ -199,7 +199,7 @@ func buildValidationSigningData(v *consensus.Validation) []byte {
 	buf = append(buf, byte(v.LedgerSeq>>24), byte(v.LedgerSeq>>16), byte(v.LedgerSeq>>8), byte(v.LedgerSeq))
 
 	// sfSigningTime (type 2, field 9)
-	signTimeSec := uint32(v.SignTime.Unix() - xrplEpochOffset)
+	signTimeSec := uint32(v.SignTime.Unix() - protocol.RippleEpochUnix)
 	buf = appendFieldHeader(buf, typeUINT32, fieldSigningTime)
 	buf = append(buf, byte(signTimeSec>>24), byte(signTimeSec>>16), byte(signTimeSec>>8), byte(signTimeSec))
 
@@ -305,5 +305,3 @@ func buildValidationSigningData(v *consensus.Validation) []byte {
 	return hash[:]
 }
 
-// xrplEpochOffset is the difference between Unix epoch and XRPL epoch (2000-01-01 00:00:00 UTC).
-const xrplEpochOffset int64 = 946684800

--- a/internal/consensus/adaptor/router_dedup.go
+++ b/internal/consensus/adaptor/router_dedup.go
@@ -7,16 +7,8 @@ import (
 
 	"github.com/LeJamon/goXRPLd/crypto/common"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
-
-// xrplEpochUnixOffset is the delta between Unix epoch (1970-01-01) and
-// XRPL NetClock epoch (2000-01-01). The proposal close-time field on
-// the wire — and in rippled's proposalUniqueId hash input — is seconds
-// since the XRPL epoch, NOT seconds since Unix epoch. Keeping this
-// separate from the converter.go alias documents intent at the call
-// site where the difference matters most (divergent hashes = dedup
-// desync across mixed Go/rippled peers).
-const xrplEpochUnixOffset int64 = 946684800
 
 // hashProposalSuppression returns the suppression key for a proposal,
 // matching rippled's proposalUniqueId at
@@ -37,7 +29,7 @@ const xrplEpochUnixOffset int64 = 946684800
 //   - `add32(closeTime.time_since_epoch().count())` feeds the XRPL
 //     NetClock count — seconds since the XRPL epoch (2000-01-01 UTC),
 //     NOT Unix epoch. We derive that count from Proposal.CloseTime via
-//     `Unix() - xrplEpochUnixOffset`, exactly matching the converter's
+//     `Unix() - protocol.RippleEpochUnix`, exactly matching the converter's
 //     wire-format convention.
 //   - `addVL` writes rippled's variable-length length prefix (1–3 bytes,
 //     see Serializer::addEncoded) followed by the raw bytes. For the
@@ -71,7 +63,7 @@ func hashProposalSuppression(p *consensus.Proposal) [32]byte {
 	// pre-epoch Time still produces a deterministic hash rather than
 	// wrapping to a large positive uint32.
 	var closeTimeSec uint32
-	if ct := p.CloseTime.Unix() - xrplEpochUnixOffset; ct > 0 {
+	if ct := p.CloseTime.Unix() - protocol.RippleEpochUnix; ct > 0 {
 		closeTimeSec = uint32(ct)
 	}
 	buf = binary.BigEndian.AppendUint32(buf, closeTimeSec)

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -125,7 +126,7 @@ func TestRouterDispatchesValidation(t *testing.T) {
 	testVal := &consensus.Validation{
 		Full:      true,
 		LedgerSeq: 42,
-		SignTime:  time.Unix(946684800+828618000, 0), // XRPL epoch + offset
+		SignTime:  time.Unix(protocol.RippleEpochUnix+828618000, 0), // XRPL epoch + offset
 		LoadFee:   0,
 	}
 	copy(testVal.LedgerID[:], []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32})

--- a/internal/consensus/adaptor/stvalidation_test.go
+++ b/internal/consensus/adaptor/stvalidation_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,7 @@ func buildTestValidation() *consensus.Validation {
 	v := &consensus.Validation{
 		Full:      true,
 		LedgerSeq: 100,
-		SignTime:  time.Unix(946684800+828618000, 0),
+		SignTime:  time.Unix(protocol.RippleEpochUnix+828618000, 0),
 		Cookie:    12345,
 		LoadFee:   5000,
 	}
@@ -508,7 +509,7 @@ func TestParseSTValidation_CloseTime(t *testing.T) {
 	// We build it by hand (type UINT32, field 7) and append the
 	// minimal required fields around it so the parser doesn't bail
 	// on missing mandatory fields.
-	closeEpoch := uint32(946684800 + 123456789 - 946684800) // XRPL epoch seconds
+	closeEpoch := uint32(123456789) // XRPL epoch seconds
 	var closeTimeBytes [4]byte
 	binary.BigEndian.PutUint32(closeTimeBytes[:], closeEpoch)
 
@@ -546,7 +547,7 @@ func TestParseSTValidation_CloseTime(t *testing.T) {
 	// signing_time (type 2, field 9)
 	buf = appendFieldHeader(buf, typeUINT32, fieldSigningTime)
 	var sigTimeBytes [4]byte
-	binary.BigEndian.PutUint32(sigTimeBytes[:], 946684800+1_000_000-946684800)
+	binary.BigEndian.PutUint32(sigTimeBytes[:], 1_000_000)
 	buf = append(buf, sigTimeBytes[:]...)
 
 	// ledger_hash (type 5, field 1) — must be non-zero to pass the
@@ -574,7 +575,7 @@ func TestParseSTValidation_CloseTime(t *testing.T) {
 	require.NoError(t, err, "parser must accept a validation with sfCloseTime")
 	assert.False(t, v.CloseTime.IsZero(),
 		"CloseTime must be populated when sfCloseTime is present")
-	assert.Equal(t, int64(closeEpoch)+946684800, v.CloseTime.Unix(),
+	assert.Equal(t, int64(closeEpoch)+protocol.RippleEpochUnix, v.CloseTime.Unix(),
 		"CloseTime must decode back to the original XRPL epoch seconds")
 }
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // Engine implements the RCL consensus algorithm.
@@ -1833,9 +1834,9 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	slog.Debug("acceptLedger close time",
 		"seq", e.prevLedger.Seq()+1,
 		"mode", e.mode,
-		"raw_ct", rawCloseTime.Unix()-946684800,
-		"eff_ct", closeTime.Unix()-946684800,
-		"prior_ct", priorClose.Unix()-946684800,
+		"raw_ct", rawCloseTime.Unix()-protocol.RippleEpochUnix,
+		"eff_ct", closeTime.Unix()-protocol.RippleEpochUnix,
+		"prior_ct", priorClose.Unix()-protocol.RippleEpochUnix,
 		"resolution", resolution,
 		"proposers", len(e.proposals),
 		"has_position", e.state.OurPosition != nil,

--- a/internal/grpc/helpers.go
+++ b/internal/grpc/helpers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // Common errors for gRPC handlers
@@ -164,12 +165,9 @@ func formatHash(hash [32]byte) string {
 	return hex.EncodeToString(hash[:])
 }
 
-// RippleEpoch is January 1, 2000 00:00:00 UTC (XRPL epoch)
-var RippleEpoch = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-
 // toRippleTime converts a time.Time to seconds since the Ripple epoch.
 func toRippleTime(t time.Time) uint32 {
-	return uint32(t.Unix() - RippleEpoch.Unix())
+	return uint32(t.Unix() - protocol.RippleEpochUnix)
 }
 
 // getLedgerEntryType extracts the ledger entry type from serialized data.

--- a/internal/ledger/genesis/genesis.go
+++ b/internal/ledger/genesis/genesis.go
@@ -443,14 +443,13 @@ func CalculateLedgerHash(h header.LedgerHeader) [32]byte {
 	data = append(data, h.AccountHash[:]...)
 
 	// Parent close time (uint32, seconds since ripple epoch - Jan 1, 2000)
-	const rippleEpochUnix int64 = 946684800
 	parentCloseBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(parentCloseBytes, uint32(h.ParentCloseTime.Unix()-rippleEpochUnix))
+	binary.BigEndian.PutUint32(parentCloseBytes, uint32(h.ParentCloseTime.Unix()-protocol.RippleEpochUnix))
 	data = append(data, parentCloseBytes...)
 
 	// Close time (uint32, seconds since ripple epoch - Jan 1, 2000)
 	closeTimeBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(closeTimeBytes, uint32(h.CloseTime.Unix()-rippleEpochUnix))
+	binary.BigEndian.PutUint32(closeTimeBytes, uint32(h.CloseTime.Unix()-protocol.RippleEpochUnix))
 	data = append(data, closeTimeBytes...)
 
 	// Close time resolution (uint8)

--- a/internal/ledger/header/header.go
+++ b/internal/ledger/header/header.go
@@ -5,13 +5,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"time"
+
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // LCFNoConsensusTime Ledger close flags
 const LCFNoConsensusTime uint8 = 0x01
-
-// xrplEpochOffset is the difference between Unix epoch and XRPL epoch (2000-01-01 00:00:00 UTC).
-const xrplEpochOffset int64 = 946684800
 
 const (
 	// SizeBase matches rippled's serialized ledger header format exactly.
@@ -198,7 +197,7 @@ func timeToXRPLEpoch(t time.Time) uint32 {
 	if t.IsZero() {
 		return 0
 	}
-	secs := t.Unix() - xrplEpochOffset
+	secs := t.Unix() - protocol.RippleEpochUnix
 	if secs < 0 {
 		return 0
 	}
@@ -211,5 +210,5 @@ func xrplEpochToTime(epoch uint32) time.Time {
 	if epoch == 0 {
 		return time.Time{}
 	}
-	return time.Unix(int64(epoch)+xrplEpochOffset, 0)
+	return time.Unix(int64(epoch)+protocol.RippleEpochUnix, 0)
 }

--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -731,12 +731,11 @@ func (r *ReplayDelta) Apply(engineCfg tx.EngineConfig) (*ledger.Ledger, error) {
 // the tx.EngineConfig.ParentCloseTime contract used elsewhere in the
 // engine. The Ripple epoch is 2000-01-01 UTC.
 func parentCloseTimeRippleEpoch(parent *ledger.Ledger) uint32 {
-	const rippleEpochUnix int64 = 946684800
 	t := parent.CloseTime()
 	if t.IsZero() {
 		return 0
 	}
-	secs := t.Unix() - rippleEpochUnix
+	secs := t.Unix() - protocol.RippleEpochUnix
 	if secs < 0 {
 		return 0
 	}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -887,8 +887,6 @@ func (l *Ledger) SerializeHeader() []byte {
 	return data
 }
 
-const rippleEpochUnix int64 = 946684800
-
 // calculateLedgerHash computes the hash of a ledger header
 // This is duplicated from genesis package to avoid circular imports
 func calculateLedgerHash(h header.LedgerHeader) [32]byte {
@@ -909,11 +907,11 @@ func calculateLedgerHash(h header.LedgerHeader) [32]byte {
 	data = append(data, h.AccountHash[:]...)
 
 	parentCloseBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(parentCloseBytes, uint32(h.ParentCloseTime.Unix()-rippleEpochUnix))
+	binary.BigEndian.PutUint32(parentCloseBytes, uint32(h.ParentCloseTime.Unix()-protocol.RippleEpochUnix))
 	data = append(data, parentCloseBytes...)
 
 	closeTimeBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(closeTimeBytes, uint32(h.CloseTime.Unix()-rippleEpochUnix))
+	binary.BigEndian.PutUint32(closeTimeBytes, uint32(h.CloseTime.Unix()-protocol.RippleEpochUnix))
 	data = append(data, closeTimeBytes...)
 
 	data = append(data, byte(h.CloseTimeResolution))

--- a/internal/ledger/service/ledger_query.go
+++ b/internal/ledger/service/ledger_query.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
@@ -131,12 +132,9 @@ type LedgerDataItem struct {
 	Data  []byte `json:"data"`
 }
 
-// RippleEpoch is January 1, 2000 00:00:00 UTC
-var RippleEpoch = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-
 // toRippleTime converts a time.Time to seconds since Ripple epoch
 func toRippleTime(t time.Time) int64 {
-	return t.Unix() - RippleEpoch.Unix()
+	return t.Unix() - protocol.RippleEpochUnix
 }
 
 // formatCloseTimeHuman formats close time in XRPL human-readable format

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -17,6 +17,7 @@ import (
 
 	rootcrypto "github.com/LeJamon/goXRPLd/crypto"
 	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // protocolVersion is a (major, minor) peer-protocol pair. Mirrors
@@ -70,11 +71,7 @@ const (
 	HeaderServer           = "Server"
 )
 
-const (
-	// XRPLEpochOffset converts Unix seconds to XRPL epoch (2000-01-01).
-	XRPLEpochOffset       = 946684800
-	NetworkClockTolerance = 20 * time.Second
-)
+const NetworkClockTolerance = 20 * time.Second
 
 type HandshakeConfig struct {
 	UserAgent   string
@@ -218,7 +215,7 @@ func addHandshakeHeaders(h http.Header, id *Identity, sharedValue []byte, cfg Ha
 		h.Set(HeaderNetworkID, strconv.FormatUint(uint64(cfg.NetworkID), 10))
 	}
 
-	networkTime := uint64(time.Now().Unix()) - XRPLEpochOffset
+	networkTime := uint64(time.Now().Unix() - protocol.RippleEpochUnix)
 	h.Set(HeaderNetworkTime, strconv.FormatUint(networkTime, 10))
 	h.Set(HeaderPublicKey, id.EncodedPublicKey())
 
@@ -381,7 +378,7 @@ func VerifyPeerHandshake(headers http.Header, sharedValue []byte, localPubKey st
 			return nil, fmt.Errorf("invalid network time: %w", err)
 		}
 
-		peerTime := time.Unix(netTime+XRPLEpochOffset, 0)
+		peerTime := time.Unix(netTime+protocol.RippleEpochUnix, 0)
 		diff := time.Since(peerTime)
 		if diff < 0 {
 			diff = -diff

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1534,7 +1535,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("lost_sync_zeroes_both", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, true, nil, nil, 0)
+		p.applyStatusChange(&message.StatusChange{NewEvent: message.NodeEventLostSync})
 		_, hasC := p.ClosedLedger()
 		_, hasP := p.PreviousLedger()
 		assert.False(t, hasC)
@@ -1548,7 +1549,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 			newClosed[i] = byte(0xAA)
 			newParent[i] = byte(0xBB)
 		}
-		p.applyStatusChange(newClosed[:], newParent[:], false, nil, nil, 0)
+		p.applyStatusChange(&message.StatusChange{LedgerHash: newClosed[:], LedgerHashPrevious: newParent[:]})
 		gotC, hasC := p.ClosedLedger()
 		gotP, hasP := p.PreviousLedger()
 		assert.True(t, hasC)
@@ -1563,7 +1564,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 		for i := range newParent {
 			newParent[i] = byte(0xCC)
 		}
-		p.applyStatusChange(nil, newParent[:], false, nil, nil, 0)
+		p.applyStatusChange(&message.StatusChange{LedgerHashPrevious: newParent[:]})
 		_, hasC := p.ClosedLedger()
 		gotP, hasP := p.PreviousLedger()
 		assert.False(t, hasC)
@@ -1573,7 +1574,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("malformed_closed_zeroes_closed", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange([]byte{0x01, 0x02}, nil, false, nil, nil, 0) // 2 bytes ≠ 32
+		p.applyStatusChange(&message.StatusChange{LedgerHash: []byte{0x01, 0x02}}) // 2 bytes ≠ 32
 		_, hasC := p.ClosedLedger()
 		_, hasP := p.PreviousLedger()
 		assert.False(t, hasC)
@@ -1583,7 +1584,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 	// PeerImp.cpp:1874-1883 — ledger range update + clamp.
 	t.Run("ledger_range_valid_pair_stored", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(200)})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(100), minSeq)
 		assert.Equal(t, uint32(200), maxSeq)
@@ -1591,7 +1592,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("ledger_range_first_zero_clamped", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(0), u32(200), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(0), LastSeq: u32(200)})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(0), minSeq)
 		assert.Equal(t, uint32(0), maxSeq)
@@ -1599,7 +1600,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("ledger_range_last_zero_clamped", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(0), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(0)})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(0), minSeq)
 		assert.Equal(t, uint32(0), maxSeq)
@@ -1607,7 +1608,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("ledger_range_inverted_clamped", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(200), u32(100), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(200), LastSeq: u32(100)})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(0), minSeq)
 		assert.Equal(t, uint32(0), maxSeq)
@@ -1617,8 +1618,8 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 	// block, so the previously-advertised range must persist.
 	t.Run("ledger_range_lost_sync_preserves_range", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
-		p.applyStatusChange(nil, nil, true, nil, nil, 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(200)})
+		p.applyStatusChange(&message.StatusChange{NewEvent: message.NodeEventLostSync})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(100), minSeq)
 		assert.Equal(t, uint32(200), maxSeq)
@@ -1629,8 +1630,8 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 	// previously-stored range.
 	t.Run("ledger_range_absent_preserves_existing", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
-		p.applyStatusChange(nil, nil, false, nil, nil, 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(200)})
+		p.applyStatusChange(&message.StatusChange{})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(100), minSeq)
 		assert.Equal(t, uint32(200), maxSeq)
@@ -1638,7 +1639,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("info_complete_ledgers_formatted", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(200)})
 		assert.Equal(t, "100 - 200", p.Info().CompleteLedgers,
 			"matches rippled PeerImp.cpp:434-435 format with surrounding spaces")
 	})
@@ -1877,7 +1878,7 @@ func TestPeersJSON_CompleteLedgers(t *testing.T) {
 
 	t.Run("emits_when_range_advertised", func(t *testing.T) {
 		p := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(200)})
 
 		o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
 		entries := o.PeersJSON()
@@ -1896,7 +1897,7 @@ func TestPeersJSON_CompleteLedgers(t *testing.T) {
 
 	t.Run("absent_after_clamp_on_invalid_range", func(t *testing.T) {
 		p := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
-		p.applyStatusChange(nil, nil, false, u32(0), u32(200), 0) // first=0 → clamped to (0,0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(0), LastSeq: u32(200)}) // first=0 → clamped to (0,0)
 
 		o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
 		entries := o.PeersJSON()

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -1534,7 +1534,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("lost_sync_zeroes_both", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, true, nil, nil)
+		p.applyStatusChange(nil, nil, true, nil, nil, 0)
 		_, hasC := p.ClosedLedger()
 		_, hasP := p.PreviousLedger()
 		assert.False(t, hasC)
@@ -1548,7 +1548,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 			newClosed[i] = byte(0xAA)
 			newParent[i] = byte(0xBB)
 		}
-		p.applyStatusChange(newClosed[:], newParent[:], false, nil, nil)
+		p.applyStatusChange(newClosed[:], newParent[:], false, nil, nil, 0)
 		gotC, hasC := p.ClosedLedger()
 		gotP, hasP := p.PreviousLedger()
 		assert.True(t, hasC)
@@ -1563,7 +1563,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 		for i := range newParent {
 			newParent[i] = byte(0xCC)
 		}
-		p.applyStatusChange(nil, newParent[:], false, nil, nil)
+		p.applyStatusChange(nil, newParent[:], false, nil, nil, 0)
 		_, hasC := p.ClosedLedger()
 		gotP, hasP := p.PreviousLedger()
 		assert.False(t, hasC)
@@ -1573,7 +1573,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("malformed_closed_zeroes_closed", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange([]byte{0x01, 0x02}, nil, false, nil, nil) // 2 bytes ≠ 32
+		p.applyStatusChange([]byte{0x01, 0x02}, nil, false, nil, nil, 0) // 2 bytes ≠ 32
 		_, hasC := p.ClosedLedger()
 		_, hasP := p.PreviousLedger()
 		assert.False(t, hasC)
@@ -1583,7 +1583,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 	// PeerImp.cpp:1874-1883 — ledger range update + clamp.
 	t.Run("ledger_range_valid_pair_stored", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200))
+		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(100), minSeq)
 		assert.Equal(t, uint32(200), maxSeq)
@@ -1591,7 +1591,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("ledger_range_first_zero_clamped", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(0), u32(200))
+		p.applyStatusChange(nil, nil, false, u32(0), u32(200), 0)
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(0), minSeq)
 		assert.Equal(t, uint32(0), maxSeq)
@@ -1599,7 +1599,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("ledger_range_last_zero_clamped", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(0))
+		p.applyStatusChange(nil, nil, false, u32(100), u32(0), 0)
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(0), minSeq)
 		assert.Equal(t, uint32(0), maxSeq)
@@ -1607,7 +1607,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("ledger_range_inverted_clamped", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(200), u32(100))
+		p.applyStatusChange(nil, nil, false, u32(200), u32(100), 0)
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(0), minSeq)
 		assert.Equal(t, uint32(0), maxSeq)
@@ -1617,8 +1617,8 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 	// block, so the previously-advertised range must persist.
 	t.Run("ledger_range_lost_sync_preserves_range", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200))
-		p.applyStatusChange(nil, nil, true, nil, nil)
+		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
+		p.applyStatusChange(nil, nil, true, nil, nil, 0)
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(100), minSeq)
 		assert.Equal(t, uint32(200), maxSeq)
@@ -1629,8 +1629,8 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 	// previously-stored range.
 	t.Run("ledger_range_absent_preserves_existing", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200))
-		p.applyStatusChange(nil, nil, false, nil, nil)
+		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
+		p.applyStatusChange(nil, nil, false, nil, nil, 0)
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(100), minSeq)
 		assert.Equal(t, uint32(200), maxSeq)
@@ -1638,7 +1638,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("info_complete_ledgers_formatted", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200))
+		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
 		assert.Equal(t, "100 - 200", p.Info().CompleteLedgers,
 			"matches rippled PeerImp.cpp:434-435 format with surrounding spaces")
 	})
@@ -1877,7 +1877,7 @@ func TestPeersJSON_CompleteLedgers(t *testing.T) {
 
 	t.Run("emits_when_range_advertised", func(t *testing.T) {
 		p := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200))
+		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
 
 		o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
 		entries := o.PeersJSON()
@@ -1896,7 +1896,7 @@ func TestPeersJSON_CompleteLedgers(t *testing.T) {
 
 	t.Run("absent_after_clamp_on_invalid_range", func(t *testing.T) {
 		p := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
-		p.applyStatusChange(nil, nil, false, u32(0), u32(200)) // first=0 → clamped to (0,0)
+		p.applyStatusChange(nil, nil, false, u32(0), u32(200), 0) // first=0 → clamped to (0,0)
 
 		o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
 		entries := o.PeersJSON()

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -6,12 +6,14 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -182,6 +184,11 @@ type Overlay struct {
 	providersMu         sync.RWMutex
 	ledgerHintProvider  func() (LedgerHints, bool)
 	validLedgerProvider func() (seq uint32, age time.Duration, ok bool)
+	// peerStatusPublisher: optional sink for pubPeerStatus updates.
+	// Wired by the RPC layer to broadcast over the peer_status
+	// WebSocket subscription. nil-safe — no-op when unset (tests,
+	// embedded usage, or RPC disabled).
+	peerStatusPublisher func(PeerStatusUpdate)
 
 	// Components
 	discovery  *Discovery
@@ -293,6 +300,93 @@ func (o *Overlay) validLedgerProviderSnapshot() func() (seq uint32, age time.Dur
 	o.providersMu.RLock()
 	defer o.providersMu.RUnlock()
 	return o.validLedgerProvider
+}
+
+// PeerStatusUpdate captures the post-decode TMStatusChange fields the
+// RPC layer needs to materialize a peer_status WebSocket event.
+// Mirrors the JSON shape produced by rippled's pubPeerStatus callback
+// at PeerImp.cpp:1892-1963: each field maps 1:1 onto the wire object,
+// and zero/empty values mean "field absent" (the RPC layer omits them
+// via `omitempty` to match rippled's `if (m->has_xxx)` gates).
+type PeerStatusUpdate struct {
+	// Status mirrors PeerImp.cpp:1895-1915: emitted when the inbound
+	// message carries a NewStatus, in rippled's UPPERCASE spelling.
+	Status string
+	// Action mirrors PeerImp.cpp:1917-1934: emitted when the message
+	// carries a NewEvent. Note that LOST_SYNC never reaches the
+	// callback in rippled — the early-return at 1812-1830 fires
+	// before pubPeerStatus is invoked — so the action field is
+	// limited to CLOSING_LEDGER/ACCEPTED_LEDGER/SWITCHED_LEDGER.
+	Action string
+	// LedgerIndex mirrors PeerImp.cpp:1936-1939 (`has_ledgerseq`).
+	LedgerIndex uint32
+	// LedgerHash mirrors PeerImp.cpp:1941-1949: rippled re-reads the
+	// peer's closedLedgerHash_ under recentLock_ rather than the raw
+	// wire bytes, so callers must source this from the peer state
+	// AFTER applyStatusChange.
+	LedgerHash string
+	// Date mirrors PeerImp.cpp:1951-1954 (`has_networktime`).
+	Date uint32
+	// LedgerIndexMin / LedgerIndexMax mirror PeerImp.cpp:1956-1960
+	// (`has_firstseq && has_lastseq`).
+	LedgerIndexMin uint32
+	LedgerIndexMax uint32
+}
+
+// SetPeerStatusPublisher wires a sink for pubPeerStatus events.
+// Mirrors rippled's NetworkOPs::pubPeerStatus (NetworkOPs.cpp:2514) —
+// the overlay invokes this callback for every non-lostSync TMStatusChange
+// after state has been recorded, mirroring PeerImp.cpp:1892-1963.
+// Passing nil disconnects the sink.
+func (o *Overlay) SetPeerStatusPublisher(fn func(PeerStatusUpdate)) {
+	o.providersMu.Lock()
+	o.peerStatusPublisher = fn
+	o.providersMu.Unlock()
+}
+
+func (o *Overlay) peerStatusPublisherSnapshot() func(PeerStatusUpdate) {
+	o.providersMu.RLock()
+	defer o.providersMu.RUnlock()
+	return o.peerStatusPublisher
+}
+
+// peerStatusUpperName mirrors PeerImp.cpp:1899-1913: the pubPeerStatus
+// callback emits status names in UPPERCASE (CONNECTING/...), distinct
+// from the lowercase strings used by the `peers` RPC at
+// PeerImp.cpp:467-485. Returns "" for nsUNKNOWN or any unknown enum
+// (rippled's switch falls through silently for the latter).
+func peerStatusUpperName(s message.NodeStatus) string {
+	switch s {
+	case message.NodeStatusConnecting:
+		return "CONNECTING"
+	case message.NodeStatusConnected:
+		return "CONNECTED"
+	case message.NodeStatusMonitoring:
+		return "MONITORING"
+	case message.NodeStatusValidating:
+		return "VALIDATING"
+	case message.NodeStatusShutting:
+		return "SHUTTING"
+	default:
+		return ""
+	}
+}
+
+// peerStatusActionName mirrors PeerImp.cpp:1921-1934. The lostSync
+// case is intentionally excluded: rippled's lostSync branch returns
+// before pubPeerStatus runs (PeerImp.cpp:1812-1830). Unknown enums
+// fall through silently.
+func peerStatusActionName(e message.NodeEvent) string {
+	switch e {
+	case message.NodeEventClosingLedger:
+		return "CLOSING_LEDGER"
+	case message.NodeEventAcceptedLedger:
+		return "ACCEPTED_LEDGER"
+	case message.NodeEventSwitchedLedger:
+		return "SWITCHED_LEDGER"
+	default:
+		return ""
+	}
 }
 
 // generateInstanceCookie matches rippled Application.cpp:
@@ -1074,19 +1168,54 @@ func (o *Overlay) handleStatusChange(evt Event) {
 		sc.NewStatus,
 	)
 
-	// PeerImp.cpp:1885-1890: gate on a fresh (<2 min) validated ledger.
-	if sc.LedgerSeq == 0 {
+	// PeerImp.cpp:1812-1830 — rippled's lostSync handling returns
+	// before either checkTracking or pubPeerStatus runs. Match that
+	// flow so a lostSync update never surfaces as a peer_status
+	// WebSocket event.
+	if sc.NewEvent == message.NodeEventLostSync {
 		return
 	}
-	provider := o.validLedgerProviderSnapshot()
-	if provider == nil {
-		return
+
+	// PeerImp.cpp:1885-1890: tracking check is gated on a fresh
+	// (<2 min) validated ledger. The gate must NOT short-circuit
+	// pubPeerStatus, which rippled invokes unconditionally for
+	// non-lostSync messages at PeerImp.cpp:1892-1963.
+	if sc.LedgerSeq != 0 {
+		if provider := o.validLedgerProviderSnapshot(); provider != nil {
+			if validSeq, age, ok := provider(); ok && validSeq != 0 && age < 2*time.Minute {
+				peer.CheckTracking(sc.LedgerSeq, validSeq)
+			}
+		}
 	}
-	validSeq, age, ok := provider()
-	if !ok || validSeq == 0 || age >= 2*time.Minute {
-		return
+
+	// PeerImp.cpp:1892-1963 — publish to peer_status subscribers.
+	if pub := o.peerStatusPublisherSnapshot(); pub != nil {
+		var ledgerHashHex string
+		if len(sc.LedgerHash) > 0 {
+			// PeerImp.cpp:1941-1948 re-reads peer.closedLedgerHash_
+			// under recentLock_ rather than echoing the raw wire
+			// bytes — the read-back captures whatever
+			// applyStatusChange retained (32-byte values stored,
+			// malformed wire bytes cleared).
+			if h, ok := peer.ClosedLedger(); ok {
+				ledgerHashHex = strings.ToUpper(hex.EncodeToString(h[:]))
+			}
+		}
+		var firstSeq, lastSeq uint32
+		if sc.FirstSeq != nil && sc.LastSeq != nil {
+			firstSeq = *sc.FirstSeq
+			lastSeq = *sc.LastSeq
+		}
+		pub(PeerStatusUpdate{
+			Status:         peerStatusUpperName(sc.NewStatus),
+			Action:         peerStatusActionName(sc.NewEvent),
+			LedgerIndex:    sc.LedgerSeq,
+			LedgerHash:     ledgerHashHex,
+			Date:           uint32(sc.NetworkTime),
+			LedgerIndexMin: firstSeq,
+			LedgerIndexMax: lastSeq,
+		})
 	}
-	peer.CheckTracking(sc.LedgerSeq, validSeq)
 }
 
 // handleSquelchMessage processes an inbound TMSquelch from a peer and

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1187,14 +1187,7 @@ func (o *Overlay) handleStatusChange(evt Event) {
 		sc.NetworkTime = uint64(time.Now().Unix() - rippleEpochUnix)
 	}
 
-	effectiveStatus := peer.applyStatusChange(
-		sc.LedgerHash,
-		sc.LedgerHashPrevious,
-		sc.NewEvent == message.NodeEventLostSync,
-		sc.FirstSeq,
-		sc.LastSeq,
-		sc.NewStatus,
-	)
+	effectiveStatus := peer.applyStatusChange(sc)
 
 	// PeerImp.cpp:1812-1830 — rippled's lostSync handling returns
 	// before either checkTracking or pubPeerStatus runs. Match that

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1744,8 +1744,15 @@ func (o *Overlay) PeersJSON() []map[string]any {
 		// negotiated value once the handshake has completed).
 		entry["protocol"] = p.Protocol
 		// PeerImp.cpp:463-491 — emit only when last_status_.has_newstatus().
-		if s := nodeStatusRPCName(p.Status); s != "" {
+		if s, known := nodeStatusRPCName(p.Status); s != "" {
 			entry["status"] = s
+		} else if !known && p.Status != 0 {
+			// PeerImp.cpp:487-490 — rippled logs a journal warning
+			// when last_status_.newstatus() falls outside the known
+			// enum, then drops the field. Mirror the diagnostic so
+			// out-of-range values aren't silent.
+			slog.Warn("Unknown peer status",
+				"t", "Overlay", "peer", p.ID, "status", int32(p.Status))
 		}
 		// PeerImp.cpp:493-501: emit the metrics object — rippled formats
 		// each value with std::to_string, so they're decimal strings.
@@ -1760,23 +1767,27 @@ func (o *Overlay) PeersJSON() []map[string]any {
 	return out
 }
 
-// nodeStatusRPCName mirrors PeerImp.cpp:463-491. Returns the empty
-// string for nsUNKNOWN (no status reported) or any unknown enum value,
-// signaling the caller to omit the `status` field entirely.
-func nodeStatusRPCName(s message.NodeStatus) string {
+// nodeStatusRPCName mirrors PeerImp.cpp:463-491. Returns the rippled
+// spelling for each known NodeStatus and a `known` flag distinguishing
+// "no status reported" (nsUNKNOWN, known=true) from "unrecognized
+// enum value" (known=false). The caller omits the `status` field for
+// either case but logs only the unknown-enum case, matching rippled.
+func nodeStatusRPCName(s message.NodeStatus) (string, bool) {
 	switch s {
+	case 0:
+		return "", true
 	case message.NodeStatusConnecting:
-		return "connecting"
+		return "connecting", true
 	case message.NodeStatusConnected:
-		return "connected"
+		return "connected", true
 	case message.NodeStatusMonitoring:
-		return "monitoring"
+		return "monitoring", true
 	case message.NodeStatusValidating:
-		return "validating"
+		return "validating", true
 	case message.NodeStatusShutting:
-		return "shutting"
+		return "shutting", true
 	default:
-		return ""
+		return "", false
 	}
 }
 

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1071,6 +1071,7 @@ func (o *Overlay) handleStatusChange(evt Event) {
 		sc.NewEvent == message.NodeEventLostSync,
 		sc.FirstSeq,
 		sc.LastSeq,
+		sc.NewStatus,
 	)
 
 	// PeerImp.cpp:1885-1890: gate on a fresh (<2 min) validated ledger.
@@ -1742,6 +1743,10 @@ func (o *Overlay) PeersJSON() []map[string]any {
 		// PeerImp.cpp:419 — emit unconditionally (rippled always has a
 		// negotiated value once the handshake has completed).
 		entry["protocol"] = p.Protocol
+		// PeerImp.cpp:463-491 — emit only when last_status_.has_newstatus().
+		if s := nodeStatusRPCName(p.Status); s != "" {
+			entry["status"] = s
+		}
 		// PeerImp.cpp:493-501: emit the metrics object — rippled formats
 		// each value with std::to_string, so they're decimal strings.
 		entry["metrics"] = map[string]any{
@@ -1753,6 +1758,26 @@ func (o *Overlay) PeersJSON() []map[string]any {
 		out = append(out, entry)
 	}
 	return out
+}
+
+// nodeStatusRPCName mirrors PeerImp.cpp:463-491. Returns the empty
+// string for nsUNKNOWN (no status reported) or any unknown enum value,
+// signaling the caller to omit the `status` field entirely.
+func nodeStatusRPCName(s message.NodeStatus) string {
+	switch s {
+	case message.NodeStatusConnecting:
+		return "connecting"
+	case message.NodeStatusConnected:
+		return "connected"
+	case message.NodeStatusMonitoring:
+		return "monitoring"
+	case message.NodeStatusValidating:
+		return "validating"
+	case message.NodeStatusShutting:
+		return "shutting"
+	default:
+		return ""
+	}
 }
 
 // clusterFeeRef mirrors rippled's LoadFeeTrack::getLoadBase() default.

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -22,14 +22,9 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/cluster"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/peertls"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"golang.org/x/sync/errgroup"
 )
-
-// rippleEpochUnix is the Unix timestamp of the XRPL epoch
-// (2000-01-01 00:00:00 UTC). Used to convert local time to the
-// uint32 Ripple-Epoch seconds rippled stamps onto TMStatusChange
-// messages at PeerImp.cpp:1796-1797.
-const rippleEpochUnix int64 = 946684800
 
 // EvictBadDataThreshold is the bad-data BALANCE at which the overlay
 // disconnects a peer. IncBadData adds a per-reason weight (see
@@ -387,12 +382,10 @@ func peerStatusUpperName(s message.NodeStatus) string {
 	}
 }
 
-// peerStatusActionName mirrors PeerImp.cpp:1921-1934. handleStatusChange
-// returns at PeerImp.cpp:1830 before pubPeerStatus is invoked for
-// neLOST_SYNC, so the LOST_SYNC arm is unreachable today — it's wired
-// up anyway to match rippled's switch verbatim and stay correct if a
-// future change relaxes the early-return invariant. Unknown enums fall
-// through silently.
+// peerStatusActionName mirrors PeerImp.cpp:1921-1932. handleStatusChange
+// returns at PeerImp.cpp:1830 before pubPeerStatus runs for neLOST_SYNC,
+// so the LOST_SYNC arm is unreachable from this call site and intentionally
+// omitted. Unknown enums fall through silently.
 func peerStatusActionName(e message.NodeEvent) string {
 	switch e {
 	case message.NodeEventClosingLedger:
@@ -401,8 +394,6 @@ func peerStatusActionName(e message.NodeEvent) string {
 		return "ACCEPTED_LEDGER"
 	case message.NodeEventSwitchedLedger:
 		return "SWITCHED_LEDGER"
-	case message.NodeEventLostSync:
-		return "LOST_SYNC"
 	default:
 		return ""
 	}
@@ -1184,7 +1175,7 @@ func (o *Overlay) handleStatusChange(evt Event) {
 	// `date`. Mirror that here, mutating sc so the auto-filled value
 	// is observable to subscribers.
 	if sc.NetworkTime == 0 {
-		sc.NetworkTime = uint64(time.Now().Unix() - rippleEpochUnix)
+		sc.NetworkTime = uint64(time.Now().Unix() - protocol.RippleEpochUnix)
 	}
 
 	effectiveStatus := peer.applyStatusChange(sc)

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -25,6 +25,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// rippleEpochUnix is the Unix timestamp of the XRPL epoch
+// (2000-01-01 00:00:00 UTC). Used to convert local time to the
+// uint32 Ripple-Epoch seconds rippled stamps onto TMStatusChange
+// messages at PeerImp.cpp:1796-1797.
+const rippleEpochUnix int64 = 946684800
+
 // EvictBadDataThreshold is the bad-data BALANCE at which the overlay
 // disconnects a peer. IncBadData adds a per-reason weight (see
 // BadDataWeight) and a background decay halves the balance every
@@ -303,34 +309,43 @@ func (o *Overlay) validLedgerProviderSnapshot() func() (seq uint32, age time.Dur
 }
 
 // PeerStatusUpdate captures the post-decode TMStatusChange fields the
-// RPC layer needs to materialize a peer_status WebSocket event.
-// Mirrors the JSON shape produced by rippled's pubPeerStatus callback
-// at PeerImp.cpp:1892-1963: each field maps 1:1 onto the wire object,
-// and zero/empty values mean "field absent" (the RPC layer omits them
-// via `omitempty` to match rippled's `if (m->has_xxx)` gates).
+// RPC layer needs to materialize a peer_status WebSocket event. Pointer
+// fields preserve protobuf has-presence; nil means "wire field absent,
+// rippled's `if (m->has_xxx)` gate is false" and the RPC layer omits the
+// JSON field. Mirrors PeerImp.cpp:1892-1963.
 type PeerStatusUpdate struct {
-	// Status mirrors PeerImp.cpp:1895-1915: emitted when the inbound
-	// message carries a NewStatus, in rippled's UPPERCASE spelling.
+	// Status mirrors PeerImp.cpp:1895-1915. UPPERCASE spelling.
+	// Carries the post-inheritance value returned by applyStatusChange,
+	// so a status-less wire message still emits the prior enum once
+	// (rippled's `m->set_newstatus(status)` mutation at PeerImp.cpp:1808).
 	Status string
-	// Action mirrors PeerImp.cpp:1917-1934: emitted when the message
-	// carries a NewEvent. Note that LOST_SYNC never reaches the
-	// callback in rippled — the early-return at 1812-1830 fires
-	// before pubPeerStatus is invoked — so the action field is
-	// limited to CLOSING_LEDGER/ACCEPTED_LEDGER/SWITCHED_LEDGER.
+	// Action mirrors PeerImp.cpp:1917-1934 — CLOSING_LEDGER,
+	// ACCEPTED_LEDGER, SWITCHED_LEDGER. LOST_SYNC is unreachable
+	// because handleStatusChange returns at PeerImp.cpp:1830 before
+	// the publish.
 	Action string
-	// LedgerIndex mirrors PeerImp.cpp:1936-1939 (`has_ledgerseq`).
-	LedgerIndex uint32
 	// LedgerHash mirrors PeerImp.cpp:1941-1949: rippled re-reads the
-	// peer's closedLedgerHash_ under recentLock_ rather than the raw
-	// wire bytes, so callers must source this from the peer state
-	// AFTER applyStatusChange.
+	// peer's closedLedgerHash_ under recentLock_ rather than echoing
+	// the raw wire bytes. When wire bytes were malformed, that stored
+	// hash is zeroed at PeerImp.cpp:1850 and rippled emits the
+	// 64-char zero hex string — so callers must ALWAYS emit a value
+	// when has_ledgerhash, falling back to "00…00" if the peer's
+	// post-apply state was cleared.
 	LedgerHash string
-	// Date mirrors PeerImp.cpp:1951-1954 (`has_networktime`).
-	Date uint32
+	// LedgerIndex mirrors PeerImp.cpp:1936-1939 (`has_ledgerseq`).
+	// nil = field absent; non-nil = emit (even when value is 0 — a
+	// peer can legitimately advertise the genesis seq).
+	LedgerIndex *uint32
+	// Date mirrors PeerImp.cpp:1951-1954 (`has_networktime`). rippled
+	// auto-stamps this at PeerImp.cpp:1796-1797 when the wire didn't
+	// carry it, so handleStatusChange does the same and Date is
+	// always non-nil here.
+	Date *uint32
 	// LedgerIndexMin / LedgerIndexMax mirror PeerImp.cpp:1956-1960
-	// (`has_firstseq && has_lastseq`).
-	LedgerIndexMin uint32
-	LedgerIndexMax uint32
+	// (`has_firstseq && has_lastseq`). Both are nil unless both wire
+	// fields were present.
+	LedgerIndexMin *uint32
+	LedgerIndexMax *uint32
 }
 
 // SetPeerStatusPublisher wires a sink for pubPeerStatus events.
@@ -372,10 +387,12 @@ func peerStatusUpperName(s message.NodeStatus) string {
 	}
 }
 
-// peerStatusActionName mirrors PeerImp.cpp:1921-1934. The lostSync
-// case is intentionally excluded: rippled's lostSync branch returns
-// before pubPeerStatus runs (PeerImp.cpp:1812-1830). Unknown enums
-// fall through silently.
+// peerStatusActionName mirrors PeerImp.cpp:1921-1934. handleStatusChange
+// returns at PeerImp.cpp:1830 before pubPeerStatus is invoked for
+// neLOST_SYNC, so the LOST_SYNC arm is unreachable today — it's wired
+// up anyway to match rippled's switch verbatim and stay correct if a
+// future change relaxes the early-return invariant. Unknown enums fall
+// through silently.
 func peerStatusActionName(e message.NodeEvent) string {
 	switch e {
 	case message.NodeEventClosingLedger:
@@ -384,6 +401,8 @@ func peerStatusActionName(e message.NodeEvent) string {
 		return "ACCEPTED_LEDGER"
 	case message.NodeEventSwitchedLedger:
 		return "SWITCHED_LEDGER"
+	case message.NodeEventLostSync:
+		return "LOST_SYNC"
 	default:
 		return ""
 	}
@@ -1159,7 +1178,16 @@ func (o *Overlay) handleStatusChange(evt Event) {
 	if !exists {
 		return
 	}
-	peer.applyStatusChange(
+	// PeerImp.cpp:1796-1797 — rippled stamps the wire's networktime
+	// with the local clock when the peer didn't include it, so the
+	// pubPeerStatus emit at PeerImp.cpp:1951-1954 always carries a
+	// `date`. Mirror that here, mutating sc so the auto-filled value
+	// is observable to subscribers.
+	if sc.NetworkTime == 0 {
+		sc.NetworkTime = uint64(time.Now().Unix() - rippleEpochUnix)
+	}
+
+	effectiveStatus := peer.applyStatusChange(
 		sc.LedgerHash,
 		sc.LedgerHashPrevious,
 		sc.NewEvent == message.NodeEventLostSync,
@@ -1190,30 +1218,50 @@ func (o *Overlay) handleStatusChange(evt Event) {
 
 	// PeerImp.cpp:1892-1963 — publish to peer_status subscribers.
 	if pub := o.peerStatusPublisherSnapshot(); pub != nil {
-		var ledgerHashHex string
+		// PeerImp.cpp:1941-1948 emits ledger_hash whenever the wire
+		// carried the field, sourcing the value from the peer's
+		// post-apply closedLedgerHash_. When the wire bytes were
+		// malformed, applyStatusChange clears that storage and
+		// rippled emits the all-zeros 64-char hex string. Match both
+		// branches.
+		var ledgerHash string
 		if len(sc.LedgerHash) > 0 {
-			// PeerImp.cpp:1941-1948 re-reads peer.closedLedgerHash_
-			// under recentLock_ rather than echoing the raw wire
-			// bytes — the read-back captures whatever
-			// applyStatusChange retained (32-byte values stored,
-			// malformed wire bytes cleared).
 			if h, ok := peer.ClosedLedger(); ok {
-				ledgerHashHex = strings.ToUpper(hex.EncodeToString(h[:]))
+				ledgerHash = strings.ToUpper(hex.EncodeToString(h[:]))
+			} else {
+				ledgerHash = strings.Repeat("0", 64)
 			}
 		}
-		var firstSeq, lastSeq uint32
+		// PeerImp.cpp:1956-1960 — emit min/max only when both wire
+		// fields were present. nil-on-absence keeps that paired gate
+		// without conflating value 0 with "absent".
+		var minSeq, maxSeq *uint32
 		if sc.FirstSeq != nil && sc.LastSeq != nil {
-			firstSeq = *sc.FirstSeq
-			lastSeq = *sc.LastSeq
+			f, l := *sc.FirstSeq, *sc.LastSeq
+			minSeq, maxSeq = &f, &l
 		}
+		// PeerImp.cpp:1936-1939 (`has_ledgerseq`). The decoder loses
+		// proto-presence for ledger_seq (see
+		// internal/peermanagement/proto/ripple.pb.go), so use 0 as
+		// the absence proxy — XRPL ledger sequences start at the
+		// genesis ledger 1, no real peer broadcasts has_ledgerseq=0.
+		var ledgerIndex *uint32
+		if sc.LedgerSeq != 0 {
+			ls := sc.LedgerSeq
+			ledgerIndex = &ls
+		}
+		// PeerImp.cpp:1951-1954 — Date is always set thanks to the
+		// auto-fill above. Truncate uint64 → uint32 to match
+		// rippled's `Json::UInt(...)` cast (Json::UInt is uint32_t).
+		dateVal := uint32(sc.NetworkTime)
 		pub(PeerStatusUpdate{
-			Status:         peerStatusUpperName(sc.NewStatus),
+			Status:         peerStatusUpperName(effectiveStatus),
 			Action:         peerStatusActionName(sc.NewEvent),
-			LedgerIndex:    sc.LedgerSeq,
-			LedgerHash:     ledgerHashHex,
-			Date:           uint32(sc.NetworkTime),
-			LedgerIndexMin: firstSeq,
-			LedgerIndexMax: lastSeq,
+			LedgerIndex:    ledgerIndex,
+			LedgerHash:     ledgerHash,
+			Date:           &dateVal,
+			LedgerIndexMin: minSeq,
+			LedgerIndexMax: maxSeq,
 		})
 	}
 }

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -122,6 +122,8 @@ type Peer struct {
 	firstLedgerSeq uint32
 	lastLedgerSeq  uint32
 
+	lastStatus message.NodeStatus
+
 	latencyMu     sync.RWMutex
 	pingsInFlight map[uint32]time.Time
 	latency       time.Duration
@@ -241,9 +243,13 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 // Mirrors rippled PeerImp.cpp:1812-1883: lostSync clears closed/previous
 // ledger only; the (firstSeq, lastSeq) range is updated only when both
 // fields are present, then clamped to (0,0) if either is zero or inverted.
-func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSeq, lastSeq *uint32) {
+// newStatus mirrors rippled's last_status_ retention: the latest TMStatusChange
+// is stored verbatim, so a lostSync update with a NewStatus still records it.
+// A zero (nsUNKNOWN) value means "no status reported in the latest update".
+func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSeq, lastSeq *uint32, newStatus message.NodeStatus) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.lastStatus = newStatus
 	if lostSync {
 		p.hasClosedLedger = false
 		p.hasPreviousLedger = false
@@ -366,6 +372,16 @@ func (p *Peer) LedgerRange() (uint32, uint32) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.firstLedgerSeq, p.lastLedgerSeq
+}
+
+// LastStatus returns the peer's most recently advertised NodeStatus
+// (rippled's last_status_.newstatus()). Returns 0 (nsUNKNOWN) if the
+// peer has not sent a TMStatusChange with new_status set — matching
+// rippled PeerImp::json's `if (last_status.has_newstatus())` gate.
+func (p *Peer) LastStatus() message.NodeStatus {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.lastStatus
 }
 
 func (p *Peer) Connect(ctx context.Context, cfg PeerConfig) error {
@@ -938,6 +954,8 @@ type PeerInfo struct {
 
 	Protocol string
 
+	Status message.NodeStatus
+
 	// Per-peer wire byte counters and rolling-window throughput.
 	// Mirrors rippled PeerImp::metrics_ (PeerImp.h:226-230). Emitted
 	// under the `metrics` object in `peers` RPC.
@@ -994,6 +1012,7 @@ func (p *Peer) Info() PeerInfo {
 		Latency:         latency,
 		HasLatency:      hasLatency,
 		Protocol:        p.protocolVersion,
+		Status:          p.lastStatus,
 		TotalBytesRecv:  p.metrics.recv.totalBytesSnapshot(),
 		TotalBytesSent:  p.metrics.sent.totalBytesSnapshot(),
 		AvgBpsRecv:      p.metrics.recv.averageBytes(),

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -243,24 +243,37 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 // Mirrors rippled PeerImp.cpp:1812-1883: lostSync clears closed/previous
 // ledger only; the (firstSeq, lastSeq) range is updated only when both
 // fields are present, then clamped to (0,0) if either is zero or inverted.
-// newStatus mirrors rippled PeerImp.cpp:1799-1810: last_status_.newstatus()
-// is sticky — the field is overwritten only when the inbound message carries
-// a non-zero NewStatus. A zero argument signals "no new_status in this wire
-// message" and preserves the previously-recorded enum (rippled's "preserve
-// old status" branch). The retention runs before the lostSync early-return,
-// so a lostSync update carrying a NewStatus still records it.
-func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSeq, lastSeq *uint32, newStatus message.NodeStatus) {
+//
+// newStatus mirrors rippled PeerImp.cpp:1799-1810. Read carefully: rippled's
+// branches both end with `last_status_ = *m;`, which copy-assigns the
+// inbound proto verbatim — so the stored last_status_.newstatus() is
+// dropped whenever the wire message has no newstatus. The else-branch
+// additionally mutates the local `m` to carry the prior enum, so the
+// pubPeerStatus callback (which reads `m`, not last_status_) still sees
+// the inherited value once. We model the same split:
+//   - lastStatus is overwritten verbatim with the wire's newStatus (zero
+//     argument drops the prior value, matching rippled's `peers` RPC).
+//   - The returned effective status is the wire value when set, or the
+//     prior lastStatus otherwise — consumed by handleStatusChange's
+//     pubPeerStatus emit so subscribers receive the inherited enum.
+//
+// The lostSync early-return runs after the lastStatus write, so a
+// lostSync update carrying a NewStatus still records it — but
+// handleStatusChange returns before any publish (PeerImp.cpp:1830).
+func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSeq, lastSeq *uint32, newStatus message.NodeStatus) message.NodeStatus {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if newStatus != 0 {
-		p.lastStatus = newStatus
+	effective := newStatus
+	if newStatus == 0 {
+		effective = p.lastStatus
 	}
+	p.lastStatus = newStatus
 	if lostSync {
 		p.hasClosedLedger = false
 		p.hasPreviousLedger = false
 		p.closedLedger = [32]byte{}
 		p.previousLedger = [32]byte{}
-		return
+		return effective
 	}
 	if len(closed) == 32 {
 		copy(p.closedLedger[:], closed)
@@ -277,7 +290,7 @@ func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSe
 		p.previousLedger = [32]byte{}
 	}
 	if firstSeq == nil || lastSeq == nil {
-		return
+		return effective
 	}
 	if *firstSeq == 0 || *lastSeq == 0 || *lastSeq < *firstSeq {
 		p.firstLedgerSeq = 0
@@ -286,6 +299,7 @@ func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSe
 		p.firstLedgerSeq = *firstSeq
 		p.lastLedgerSeq = *lastSeq
 	}
+	return effective
 }
 
 func (p *Peer) Tracking() PeerTracking {
@@ -380,9 +394,14 @@ func (p *Peer) LedgerRange() (uint32, uint32) {
 }
 
 // LastStatus returns the peer's most recently advertised NodeStatus
-// (rippled's last_status_.newstatus()). Returns 0 (nsUNKNOWN) if the
-// peer has not sent a TMStatusChange with new_status set — matching
-// rippled PeerImp::json's `if (last_status.has_newstatus())` gate.
+// (rippled's last_status_.newstatus()). Returns 0 (nsUNKNOWN) when the
+// peer has never sent a TMStatusChange with new_status, OR when the
+// most recent TMStatusChange omitted new_status — both cases drop the
+// stored value, mirroring rippled's `last_status_ = *m;` overwrite at
+// PeerImp.cpp:1802 / 1807. This is what the `peers` RPC's
+// `if (last_status.has_newstatus())` gate (PeerImp.cpp:463) reads;
+// the per-event pubPeerStatus inheritance is a separate path that
+// flows through applyStatusChange's return value.
 func (p *Peer) LastStatus() message.NodeStatus {
 	p.mu.RLock()
 	defer p.mu.RUnlock()

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -251,7 +251,7 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 // additionally mutates the local `m` to carry the prior enum, so the
 // pubPeerStatus callback (which reads `m`, not last_status_) still sees
 // the inherited value once. We model the same split:
-//   - lastStatus is overwritten verbatim with the wire's newStatus (zero
+//   - lastStatus is overwritten verbatim with the wire's NewStatus (zero
 //     argument drops the prior value, matching rippled's `peers` RPC).
 //   - The returned effective status is the wire value when set, or the
 //     prior lastStatus otherwise — consumed by handleStatusChange's
@@ -260,44 +260,47 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 // The lostSync early-return runs after the lastStatus write, so a
 // lostSync update carrying a NewStatus still records it — but
 // handleStatusChange returns before any publish (PeerImp.cpp:1830).
-func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSeq, lastSeq *uint32, newStatus message.NodeStatus) message.NodeStatus {
+func (p *Peer) applyStatusChange(sc *message.StatusChange) message.NodeStatus {
+	if sc == nil {
+		return 0
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	effective := newStatus
-	if newStatus == 0 {
+	effective := sc.NewStatus
+	if sc.NewStatus == 0 {
 		effective = p.lastStatus
 	}
-	p.lastStatus = newStatus
-	if lostSync {
+	p.lastStatus = sc.NewStatus
+	if sc.NewEvent == message.NodeEventLostSync {
 		p.hasClosedLedger = false
 		p.hasPreviousLedger = false
 		p.closedLedger = [32]byte{}
 		p.previousLedger = [32]byte{}
 		return effective
 	}
-	if len(closed) == 32 {
-		copy(p.closedLedger[:], closed)
+	if len(sc.LedgerHash) == 32 {
+		copy(p.closedLedger[:], sc.LedgerHash)
 		p.hasClosedLedger = true
 	} else {
 		p.hasClosedLedger = false
 		p.closedLedger = [32]byte{}
 	}
-	if len(previous) == 32 {
-		copy(p.previousLedger[:], previous)
+	if len(sc.LedgerHashPrevious) == 32 {
+		copy(p.previousLedger[:], sc.LedgerHashPrevious)
 		p.hasPreviousLedger = true
 	} else {
 		p.hasPreviousLedger = false
 		p.previousLedger = [32]byte{}
 	}
-	if firstSeq == nil || lastSeq == nil {
+	if sc.FirstSeq == nil || sc.LastSeq == nil {
 		return effective
 	}
-	if *firstSeq == 0 || *lastSeq == 0 || *lastSeq < *firstSeq {
+	if *sc.FirstSeq == 0 || *sc.LastSeq == 0 || *sc.LastSeq < *sc.FirstSeq {
 		p.firstLedgerSeq = 0
 		p.lastLedgerSeq = 0
 	} else {
-		p.firstLedgerSeq = *firstSeq
-		p.lastLedgerSeq = *lastSeq
+		p.firstLedgerSeq = *sc.FirstSeq
+		p.lastLedgerSeq = *sc.LastSeq
 	}
 	return effective
 }

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -243,13 +243,18 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 // Mirrors rippled PeerImp.cpp:1812-1883: lostSync clears closed/previous
 // ledger only; the (firstSeq, lastSeq) range is updated only when both
 // fields are present, then clamped to (0,0) if either is zero or inverted.
-// newStatus mirrors rippled's last_status_ retention: the latest TMStatusChange
-// is stored verbatim, so a lostSync update with a NewStatus still records it.
-// A zero (nsUNKNOWN) value means "no status reported in the latest update".
+// newStatus mirrors rippled PeerImp.cpp:1799-1810: last_status_.newstatus()
+// is sticky — the field is overwritten only when the inbound message carries
+// a non-zero NewStatus. A zero argument signals "no new_status in this wire
+// message" and preserves the previously-recorded enum (rippled's "preserve
+// old status" branch). The retention runs before the lostSync early-return,
+// so a lostSync update carrying a NewStatus still records it.
 func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSeq, lastSeq *uint32, newStatus message.NodeStatus) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.lastStatus = newStatus
+	if newStatus != 0 {
+		p.lastStatus = newStatus
+	}
 	if lostSync {
 		p.hasClosedLedger = false
 		p.hasPreviousLedger = false

--- a/internal/peermanagement/peer_status_test.go
+++ b/internal/peermanagement/peer_status_test.go
@@ -42,10 +42,12 @@ func TestPeer_ApplyStatusChange_StoresNewStatus(t *testing.T) {
 }
 
 // TestPeer_ApplyStatusChange_StatusRetention covers rippled's
-// last_status_ retention semantics (PeerImp.cpp:1799-1810):
-//   - a non-zero NewStatus overwrites the prior value
-//   - a TMStatusChange that omits new_status preserves the
-//     previously-recorded enum (the "preserve old status" branch)
+// last_status_ retention semantics (PeerImp.cpp:1799-1810). Both
+// branches end with `last_status_ = *m;`, so a TMStatusChange that
+// omits new_status DROPS the stored value — the "preserve old status"
+// comment refers only to the inherited value rippled mutates onto the
+// local message `m` (consumed by pubPeerStatus, see
+// TestPeer_ApplyStatusChange_StatusInheritedToPublished).
 func TestPeer_ApplyStatusChange_StatusRetention(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
@@ -57,11 +59,43 @@ func TestPeer_ApplyStatusChange_StatusRetention(t *testing.T) {
 	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusValidating)
 	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
 
-	// rippled PeerImp.cpp:1801-1809: when the inbound TMStatusChange
-	// has no newstatus, last_status_.newstatus() is preserved.
+	// PeerImp.cpp:1802 / 1807: `last_status_ = *m;` runs verbatim in
+	// both branches. m has no newstatus → stored last_status_.newstatus()
+	// becomes false, so subsequent `peers` RPC reads drop the field.
 	p.applyStatusChange(nil, nil, false, nil, nil, 0)
-	assert.Equal(t, message.NodeStatusValidating, p.LastStatus(),
-		"absent new_status must preserve prior value (rippled sticky retention)")
+	assert.Equal(t, message.NodeStatus(0), p.LastStatus(),
+		"absent new_status must drop the prior stored value (rippled `last_status_ = *m;`)")
+}
+
+// TestPeer_ApplyStatusChange_StatusInheritedToPublished covers
+// rippled's PeerImp.cpp:1804-1808 — when the inbound message has no
+// new_status, the local `m` is mutated to carry the prior enum so the
+// pubPeerStatus callback (which reads `m`, not last_status_) emits the
+// inherited value once. applyStatusChange's return value is the
+// post-inheritance status the publisher must use; it differs from
+// LastStatus() in exactly this case.
+func TestPeer_ApplyStatusChange_StatusInheritedToPublished(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+
+	got := p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusValidating)
+	assert.Equal(t, message.NodeStatusValidating, got, "wire-set status returned verbatim")
+	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
+
+	// status-less follow-up: published value inherits the prior enum,
+	// stored value is dropped.
+	got = p.applyStatusChange(nil, nil, false, nil, nil, 0)
+	assert.Equal(t, message.NodeStatusValidating, got,
+		"absent new_status must inherit prior for pubPeerStatus (PeerImp.cpp:1808)")
+	assert.Equal(t, message.NodeStatus(0), p.LastStatus(),
+		"but stored last_status_ is dropped (PeerImp.cpp:1807)")
+
+	// second status-less message: nothing left to inherit.
+	got = p.applyStatusChange(nil, nil, false, nil, nil, 0)
+	assert.Equal(t, message.NodeStatus(0), got,
+		"after the prior is dropped, subsequent status-less messages publish no status")
 }
 
 // TestPeer_ApplyStatusChange_StatusRecordedOnLostSync covers the
@@ -139,14 +173,160 @@ func TestOverlay_handleStatusChange_PublishesPeerStatus(t *testing.T) {
 	require.Equal(t, 1, fired, "publisher must fire exactly once for non-lostSync")
 	assert.Equal(t, "VALIDATING", got.Status, "rippled PeerImp.cpp:1908 — UPPERCASE")
 	assert.Equal(t, "ACCEPTED_LEDGER", got.Action, "rippled PeerImp.cpp:1924")
-	assert.Equal(t, uint32(150), got.LedgerIndex)
-	assert.Equal(t, uint32(700_000_000), got.Date)
-	assert.Equal(t, uint32(100), got.LedgerIndexMin)
-	assert.Equal(t, uint32(200), got.LedgerIndexMax)
+	require.NotNil(t, got.LedgerIndex)
+	assert.Equal(t, uint32(150), *got.LedgerIndex)
+	require.NotNil(t, got.Date)
+	assert.Equal(t, uint32(700_000_000), *got.Date)
+	require.NotNil(t, got.LedgerIndexMin)
+	assert.Equal(t, uint32(100), *got.LedgerIndexMin)
+	require.NotNil(t, got.LedgerIndexMax)
+	assert.Equal(t, uint32(200), *got.LedgerIndexMax)
 	assert.Equal(t,
 		"ABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAB",
 		got.LedgerHash,
 		"PeerImp.cpp:1948 hex-encodes peer.closedLedgerHash_, not the wire bytes")
+}
+
+// TestOverlay_handleStatusChange_PublishedStatusInheritsPrior covers
+// rippled's PeerImp.cpp:1804-1808 carry-over: a status-less follow-up
+// message must publish the prior status to subscribers (rippled's
+// `m->set_newstatus(status)` mutation on the local message), even
+// though `last_status_` itself has been overwritten with the new
+// (status-less) wire value.
+func TestOverlay_handleStatusChange_PublishedStatusInheritsPrior(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+
+	var got []PeerStatusUpdate
+	o.SetPeerStatusPublisher(func(u PeerStatusUpdate) { got = append(got, u) })
+
+	encode := func(sc *message.StatusChange) []byte {
+		b, err := message.Encode(sc)
+		require.NoError(t, err)
+		return b
+	}
+
+	// Seed the peer with a known status.
+	o.handleStatusChange(Event{PeerID: 7, Payload: encode(&message.StatusChange{
+		NewStatus:   message.NodeStatusValidating,
+		NewEvent:    message.NodeEventAcceptedLedger,
+		LedgerSeq:   100,
+		NetworkTime: 1,
+	})})
+	require.Len(t, got, 1)
+	assert.Equal(t, "VALIDATING", got[0].Status)
+
+	// Status-less follow-up. Published Status must inherit VALIDATING.
+	o.handleStatusChange(Event{PeerID: 7, Payload: encode(&message.StatusChange{
+		NewEvent:    message.NodeEventClosingLedger,
+		LedgerSeq:   101,
+		NetworkTime: 2,
+	})})
+	require.Len(t, got, 2)
+	assert.Equal(t, "VALIDATING", got[1].Status,
+		"PeerImp.cpp:1808 — pubPeerStatus reads the inherited m->newstatus()")
+	assert.Equal(t, message.NodeStatus(0), peer.LastStatus(),
+		"but stored last_status_ has been overwritten by the wire (PeerImp.cpp:1807)")
+
+	// Second status-less message: nothing to inherit anymore.
+	o.handleStatusChange(Event{PeerID: 7, Payload: encode(&message.StatusChange{
+		NewEvent:    message.NodeEventClosingLedger,
+		LedgerSeq:   102,
+		NetworkTime: 3,
+	})})
+	require.Len(t, got, 3)
+	assert.Equal(t, "", got[2].Status,
+		"after the prior is dropped, subsequent publishes carry no status")
+}
+
+// TestOverlay_handleStatusChange_LedgerHashZerosOnMalformedWire covers
+// PeerImp.cpp:1842-1851 + 1941-1948. When wire bytes for ledger_hash
+// are present but not 32 bytes, applyStatusChange clears the peer's
+// stored closedLedgerHash_; rippled still emits the field but with the
+// 64-character zero hex string.
+func TestOverlay_handleStatusChange_LedgerHashZerosOnMalformedWire(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+
+	var got PeerStatusUpdate
+	o.SetPeerStatusPublisher(func(u PeerStatusUpdate) { got = u })
+
+	sc := &message.StatusChange{
+		NewStatus:   message.NodeStatusConnected,
+		NewEvent:    message.NodeEventClosingLedger,
+		LedgerSeq:   1,
+		LedgerHash:  []byte{0x01, 0x02}, // 2 bytes ≠ 32 → malformed
+		NetworkTime: 1,
+	}
+	encoded, err := message.Encode(sc)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 7, Payload: encoded})
+
+	assert.Equal(t,
+		"0000000000000000000000000000000000000000000000000000000000000000",
+		got.LedgerHash,
+		"PeerImp.cpp:1948 emits hex of the cleared closedLedgerHash_, not the wire bytes")
+}
+
+// TestOverlay_handleStatusChange_AutoFillsDate covers
+// PeerImp.cpp:1796-1797 — rippled stamps networktime with the local
+// clock when the wire didn't carry it. The published Date must be
+// non-nil even when the peer omitted network_time.
+func TestOverlay_handleStatusChange_AutoFillsDate(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+
+	var got PeerStatusUpdate
+	o.SetPeerStatusPublisher(func(u PeerStatusUpdate) { got = u })
+
+	sc := &message.StatusChange{
+		NewEvent:  message.NodeEventClosingLedger,
+		LedgerSeq: 1,
+		// NetworkTime omitted on purpose.
+	}
+	encoded, err := message.Encode(sc)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 7, Payload: encoded})
+
+	require.NotNil(t, got.Date, "PeerImp.cpp:1796-1797 — networktime auto-filled")
+	assert.Greater(t, *got.Date, uint32(0))
+}
+
+// TestOverlay_SetPeerStatusPublisher_Disconnect verifies the doc
+// comment: passing nil to SetPeerStatusPublisher silences the sink so
+// subsequent handleStatusChange events emit no callbacks.
+func TestOverlay_SetPeerStatusPublisher_Disconnect(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+
+	var fired int
+	o.SetPeerStatusPublisher(func(u PeerStatusUpdate) { fired++ })
+	o.SetPeerStatusPublisher(nil)
+
+	sc := &message.StatusChange{
+		NewStatus: message.NodeStatusConnecting,
+		NewEvent:  message.NodeEventClosingLedger,
+		LedgerSeq: 1,
+	}
+	encoded, err := message.Encode(sc)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 7, Payload: encoded})
+	assert.Equal(t, 0, fired, "SetPeerStatusPublisher(nil) must disconnect the sink")
 }
 
 // TestOverlay_handleStatusChange_LostSyncSuppressesPublish covers

--- a/internal/peermanagement/peer_status_test.go
+++ b/internal/peermanagement/peer_status_test.go
@@ -1,0 +1,156 @@
+package peermanagement
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPeer_LastStatus_DefaultZero asserts a freshly constructed peer
+// reports nsUNKNOWN — rippled's "no status reported" state.
+func TestPeer_LastStatus_DefaultZero(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	assert.Equal(t, message.NodeStatus(0), p.LastStatus())
+	assert.Equal(t, message.NodeStatus(0), p.Info().Status)
+}
+
+// TestPeer_ApplyStatusChange_StoresNewStatus checks that each rippled
+// NodeStatus enum value is recorded verbatim by applyStatusChange and
+// surfaced via LastStatus / PeerInfo.Status.
+func TestPeer_ApplyStatusChange_StoresNewStatus(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	cases := []message.NodeStatus{
+		message.NodeStatusConnecting,
+		message.NodeStatusConnected,
+		message.NodeStatusMonitoring,
+		message.NodeStatusValidating,
+		message.NodeStatusShutting,
+	}
+	for _, ns := range cases {
+		p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+		p.applyStatusChange(nil, nil, false, nil, nil, ns)
+		assert.Equal(t, ns, p.LastStatus())
+		assert.Equal(t, ns, p.Info().Status)
+	}
+}
+
+// TestPeer_ApplyStatusChange_StatusOverwritten verifies that a
+// subsequent TMStatusChange replaces the prior status — rippled's
+// last_status_ tracks only the latest message.
+func TestPeer_ApplyStatusChange_StatusOverwritten(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusConnecting)
+	require.Equal(t, message.NodeStatusConnecting, p.LastStatus())
+
+	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusValidating)
+	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
+
+	// A subsequent TMStatusChange that omits new_status (proto3 default)
+	// must reset the recorded status — rippled re-evaluates
+	// has_newstatus() against the latest message only.
+	p.applyStatusChange(nil, nil, false, nil, nil, 0)
+	assert.Equal(t, message.NodeStatus(0), p.LastStatus())
+}
+
+// TestPeer_ApplyStatusChange_StatusRecordedOnLostSync covers the
+// rippled invariant that last_status_ is replaced by the entire
+// inbound TMStatusChange — including a NewStatus carried alongside a
+// neLOST_SYNC event.
+func TestPeer_ApplyStatusChange_StatusRecordedOnLostSync(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	p.applyStatusChange(nil, nil, true, nil, nil, message.NodeStatusValidating)
+	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
+}
+
+// TestOverlay_handleStatusChange_PropagatesNewStatus verifies that the
+// overlay decodes TMStatusChange.new_status and writes it to the peer.
+func TestOverlay_handleStatusChange_PropagatesNewStatus(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+
+	sc := &message.StatusChange{
+		NewStatus:  message.NodeStatusMonitoring,
+		LedgerSeq:  100,
+		LedgerHash: make([]byte, 32),
+	}
+	encoded, err := message.Encode(sc)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 7, Payload: encoded})
+	assert.Equal(t, message.NodeStatusMonitoring, peer.LastStatus())
+}
+
+// TestOverlay_PeersJSON_StatusField mirrors PeerImp.cpp:463-491 — the
+// `status` field is emitted with the rippled spelling for each known
+// NodeStatus, and omitted when the peer has not reported one.
+func TestOverlay_PeersJSON_StatusField(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	cases := []struct {
+		name   string
+		status message.NodeStatus
+		want   string // empty => field must be absent
+	}{
+		{"omitted_when_unknown", 0, ""},
+		{"connecting", message.NodeStatusConnecting, "connecting"},
+		{"connected", message.NodeStatusConnected, "connected"},
+		{"monitoring", message.NodeStatusMonitoring, "monitoring"},
+		{"validating", message.NodeStatusValidating, "validating"},
+		{"shutting", message.NodeStatusShutting, "shutting"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewPeer(PeerID(1), Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
+			if tc.status != 0 {
+				p.applyStatusChange(nil, nil, false, nil, nil, tc.status)
+			}
+
+			o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
+			entries := o.PeersJSON()
+			require.Len(t, entries, 1)
+
+			got, present := entries[0]["status"]
+			if tc.want == "" {
+				assert.False(t, present, "expected `status` to be absent")
+				return
+			}
+			require.True(t, present, "expected `status` field")
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestOverlay_PeersJSON_StatusOmittedForOutOfRangeEnum guards against
+// surfacing future / unknown enum values as "unknown" or similar
+// fall-through strings — rippled's switch only handles the five named
+// statuses and silently drops anything else.
+func TestOverlay_PeersJSON_StatusOmittedForOutOfRangeEnum(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	p := NewPeer(PeerID(1), Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
+	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatus(99))
+
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
+	entries := o.PeersJSON()
+	require.Len(t, entries, 1)
+	_, present := entries[0]["status"]
+	assert.False(t, present, "unknown enum values must not surface as `status`")
+}

--- a/internal/peermanagement/peer_status_test.go
+++ b/internal/peermanagement/peer_status_test.go
@@ -35,7 +35,7 @@ func TestPeer_ApplyStatusChange_StoresNewStatus(t *testing.T) {
 	}
 	for _, ns := range cases {
 		p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
-		p.applyStatusChange(nil, nil, false, nil, nil, ns)
+		p.applyStatusChange(&message.StatusChange{NewStatus: ns})
 		assert.Equal(t, ns, p.LastStatus())
 		assert.Equal(t, ns, p.Info().Status)
 	}
@@ -53,16 +53,16 @@ func TestPeer_ApplyStatusChange_StatusRetention(t *testing.T) {
 	require.NoError(t, err)
 
 	p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
-	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusConnecting)
+	p.applyStatusChange(&message.StatusChange{NewStatus: message.NodeStatusConnecting})
 	require.Equal(t, message.NodeStatusConnecting, p.LastStatus())
 
-	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusValidating)
+	p.applyStatusChange(&message.StatusChange{NewStatus: message.NodeStatusValidating})
 	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
 
 	// PeerImp.cpp:1802 / 1807: `last_status_ = *m;` runs verbatim in
 	// both branches. m has no newstatus → stored last_status_.newstatus()
 	// becomes false, so subsequent `peers` RPC reads drop the field.
-	p.applyStatusChange(nil, nil, false, nil, nil, 0)
+	p.applyStatusChange(&message.StatusChange{})
 	assert.Equal(t, message.NodeStatus(0), p.LastStatus(),
 		"absent new_status must drop the prior stored value (rippled `last_status_ = *m;`)")
 }
@@ -80,20 +80,20 @@ func TestPeer_ApplyStatusChange_StatusInheritedToPublished(t *testing.T) {
 
 	p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
 
-	got := p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusValidating)
+	got := p.applyStatusChange(&message.StatusChange{NewStatus: message.NodeStatusValidating})
 	assert.Equal(t, message.NodeStatusValidating, got, "wire-set status returned verbatim")
 	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
 
 	// status-less follow-up: published value inherits the prior enum,
 	// stored value is dropped.
-	got = p.applyStatusChange(nil, nil, false, nil, nil, 0)
+	got = p.applyStatusChange(&message.StatusChange{})
 	assert.Equal(t, message.NodeStatusValidating, got,
 		"absent new_status must inherit prior for pubPeerStatus (PeerImp.cpp:1808)")
 	assert.Equal(t, message.NodeStatus(0), p.LastStatus(),
 		"but stored last_status_ is dropped (PeerImp.cpp:1807)")
 
 	// second status-less message: nothing left to inherit.
-	got = p.applyStatusChange(nil, nil, false, nil, nil, 0)
+	got = p.applyStatusChange(&message.StatusChange{})
 	assert.Equal(t, message.NodeStatus(0), got,
 		"after the prior is dropped, subsequent status-less messages publish no status")
 }
@@ -107,7 +107,7 @@ func TestPeer_ApplyStatusChange_StatusRecordedOnLostSync(t *testing.T) {
 	require.NoError(t, err)
 
 	p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
-	p.applyStatusChange(nil, nil, true, nil, nil, message.NodeStatusValidating)
+	p.applyStatusChange(&message.StatusChange{NewStatus: message.NodeStatusValidating, NewEvent: message.NodeEventLostSync})
 	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
 }
 
@@ -378,7 +378,7 @@ func TestOverlay_PeersJSON_StatusField(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := NewPeer(PeerID(1), Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
 			if tc.status != 0 {
-				p.applyStatusChange(nil, nil, false, nil, nil, tc.status)
+				p.applyStatusChange(&message.StatusChange{NewStatus: tc.status})
 			}
 
 			o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
@@ -405,7 +405,7 @@ func TestOverlay_PeersJSON_StatusOmittedForOutOfRangeEnum(t *testing.T) {
 	require.NoError(t, err)
 
 	p := NewPeer(PeerID(1), Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
-	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatus(99))
+	p.applyStatusChange(&message.StatusChange{NewStatus: message.NodeStatus(99)})
 
 	o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
 	entries := o.PeersJSON()

--- a/internal/peermanagement/peer_status_test.go
+++ b/internal/peermanagement/peer_status_test.go
@@ -98,6 +98,83 @@ func TestOverlay_handleStatusChange_PropagatesNewStatus(t *testing.T) {
 	assert.Equal(t, message.NodeStatusMonitoring, peer.LastStatus())
 }
 
+// TestOverlay_handleStatusChange_PublishesPeerStatus mirrors rippled's
+// pubPeerStatus callback at PeerImp.cpp:1892-1963. The publisher must
+// receive UPPERCASE status / action strings, the wire ledger fields,
+// and a hex-encoded ledger_hash sourced from the peer's stored
+// closedLedger (PeerImp.cpp:1941-1948 re-reads under recentLock_).
+func TestOverlay_handleStatusChange_PublishesPeerStatus(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+
+	var got PeerStatusUpdate
+	var fired int
+	o.SetPeerStatusPublisher(func(u PeerStatusUpdate) {
+		fired++
+		got = u
+	})
+
+	closed := make([]byte, 32)
+	for i := range closed {
+		closed[i] = byte(0xAB)
+	}
+	first, last := uint32(100), uint32(200)
+	sc := &message.StatusChange{
+		NewStatus:   message.NodeStatusValidating,
+		NewEvent:    message.NodeEventAcceptedLedger,
+		LedgerSeq:   150,
+		LedgerHash:  closed,
+		NetworkTime: 700_000_000,
+		FirstSeq:    &first,
+		LastSeq:     &last,
+	}
+	encoded, err := message.Encode(sc)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 7, Payload: encoded})
+
+	require.Equal(t, 1, fired, "publisher must fire exactly once for non-lostSync")
+	assert.Equal(t, "VALIDATING", got.Status, "rippled PeerImp.cpp:1908 — UPPERCASE")
+	assert.Equal(t, "ACCEPTED_LEDGER", got.Action, "rippled PeerImp.cpp:1924")
+	assert.Equal(t, uint32(150), got.LedgerIndex)
+	assert.Equal(t, uint32(700_000_000), got.Date)
+	assert.Equal(t, uint32(100), got.LedgerIndexMin)
+	assert.Equal(t, uint32(200), got.LedgerIndexMax)
+	assert.Equal(t,
+		"ABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAB",
+		got.LedgerHash,
+		"PeerImp.cpp:1948 hex-encodes peer.closedLedgerHash_, not the wire bytes")
+}
+
+// TestOverlay_handleStatusChange_LostSyncSuppressesPublish covers
+// PeerImp.cpp:1812-1830 — rippled's lostSync branch returns before
+// pubPeerStatus is invoked, so subscribers never see a LOST_SYNC
+// peer_status event.
+func TestOverlay_handleStatusChange_LostSyncSuppressesPublish(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+
+	var fired int
+	o.SetPeerStatusPublisher(func(u PeerStatusUpdate) { fired++ })
+
+	sc := &message.StatusChange{
+		NewEvent:  message.NodeEventLostSync,
+		LedgerSeq: 0,
+	}
+	encoded, err := message.Encode(sc)
+	require.NoError(t, err)
+
+	o.handleStatusChange(Event{PeerID: 7, Payload: encoded})
+	assert.Equal(t, 0, fired,
+		"lostSync must not publish (PeerImp.cpp:1830 returns before pubPeerStatus)")
+}
+
 // TestOverlay_PeersJSON_StatusField mirrors PeerImp.cpp:463-491 — the
 // `status` field is emitted with the rippled spelling for each known
 // NodeStatus, and omitted when the peer has not reported one.

--- a/internal/peermanagement/peer_status_test.go
+++ b/internal/peermanagement/peer_status_test.go
@@ -41,10 +41,12 @@ func TestPeer_ApplyStatusChange_StoresNewStatus(t *testing.T) {
 	}
 }
 
-// TestPeer_ApplyStatusChange_StatusOverwritten verifies that a
-// subsequent TMStatusChange replaces the prior status — rippled's
-// last_status_ tracks only the latest message.
-func TestPeer_ApplyStatusChange_StatusOverwritten(t *testing.T) {
+// TestPeer_ApplyStatusChange_StatusRetention covers rippled's
+// last_status_ retention semantics (PeerImp.cpp:1799-1810):
+//   - a non-zero NewStatus overwrites the prior value
+//   - a TMStatusChange that omits new_status preserves the
+//     previously-recorded enum (the "preserve old status" branch)
+func TestPeer_ApplyStatusChange_StatusRetention(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
 
@@ -55,11 +57,11 @@ func TestPeer_ApplyStatusChange_StatusOverwritten(t *testing.T) {
 	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusValidating)
 	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
 
-	// A subsequent TMStatusChange that omits new_status (proto3 default)
-	// must reset the recorded status — rippled re-evaluates
-	// has_newstatus() against the latest message only.
+	// rippled PeerImp.cpp:1801-1809: when the inbound TMStatusChange
+	// has no newstatus, last_status_.newstatus() is preserved.
 	p.applyStatusChange(nil, nil, false, nil, nil, 0)
-	assert.Equal(t, message.NodeStatus(0), p.LastStatus())
+	assert.Equal(t, message.NodeStatusValidating, p.LastStatus(),
+		"absent new_status must preserve prior value (rippled sticky retention)")
 }
 
 // TestPeer_ApplyStatusChange_StatusRecordedOnLostSync covers the

--- a/internal/peermanagement/peertls/tls_interop_test.go
+++ b/internal/peermanagement/peertls/tls_interop_test.go
@@ -23,12 +23,8 @@ import (
 	btcecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
-
-// XRPL epoch (2000-01-01) offset from unix epoch — matches
-// peermanagement.XRPLEpochOffset. Inlined to keep this leaf-package
-// test free of circular imports back to peermanagement.
-const xrplEpochOffset = 946684800
 
 // nodePublicKeyPrefix is the base58 prefix byte for XRPL node public
 // keys (results in 'n' prefix). Mirrors peermanagement.NodePublicKeyPrefix.
@@ -135,7 +131,7 @@ func TestHandshake_Interop_RippledDocker(t *testing.T) {
 	nodePub := encodeNodePublicKey(priv.PubKey().SerializeCompressed())
 	sig := btcecdsa.Sign(priv, sharedValue).Serialize()
 	sigB64 := base64.StdEncoding.EncodeToString(sig)
-	netTime := strconv.FormatUint(uint64(time.Now().Unix())-xrplEpochOffset, 10)
+	netTime := strconv.FormatUint(uint64(time.Now().Unix()-protocol.RippleEpochUnix), 10)
 
 	req := "GET / HTTP/1.1\r\n" +
 		"User-Agent: peertls-interop-test\r\n" +

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -217,23 +217,35 @@ func NewManifestEvent(masterKey, signingKey, signature string, sequence uint32) 
 }
 
 // PeerStatusEvent represents peer connection status changes
-// This is sent to subscribers of the "peer_status" stream
+// This is sent to subscribers of the "peer_status" stream.
+// Mirrors rippled PeerImp.cpp:1892-1963 (pubPeerStatus callback) wrapped
+// by NetworkOPs.cpp:2514-2540 which adds `type: "peerStatusChange"`.
 type PeerStatusEvent struct {
 	Type           string `json:"type"`                       // Always "peerStatusChange"
-	Action         string `json:"action"`                     // Action type (see constants below)
-	Date           uint32 `json:"date"`                       // Time of status change (Ripple epoch)
+	Status         string `json:"status,omitempty"`           // Peer's advertised status (UPPERCASE: CONNECTING/CONNECTED/MONITORING/VALIDATING/SHUTTING)
+	Action         string `json:"action,omitempty"`           // Action type (see constants below)
+	Date           uint32 `json:"date,omitempty"`             // Time of status change (Ripple epoch)
 	LedgerHash     string `json:"ledger_hash,omitempty"`      // Ledger hash (if relevant)
 	LedgerIndex    uint32 `json:"ledger_index,omitempty"`     // Ledger index (if relevant)
 	LedgerIndexMax uint32 `json:"ledger_index_max,omitempty"` // Max ledger index peer has
 	LedgerIndexMin uint32 `json:"ledger_index_min,omitempty"` // Min ledger index peer has
 }
 
-// Peer status actions
+// Peer status actions — rippled PeerImp.cpp:1921-1932.
 const (
 	PeerActionClosingLedger  = "CLOSING_LEDGER"
 	PeerActionAcceptedLedger = "ACCEPTED_LEDGER"
 	PeerActionSwitchedLedger = "SWITCHED_LEDGER"
 	PeerActionLostSync       = "LOST_SYNC"
+)
+
+// Peer status strings — rippled PeerImp.cpp:1899-1913.
+const (
+	PeerStatusConnecting = "CONNECTING"
+	PeerStatusConnected  = "CONNECTED"
+	PeerStatusMonitoring = "MONITORING"
+	PeerStatusValidating = "VALIDATING"
+	PeerStatusShutting   = "SHUTTING"
 )
 
 // NewPeerStatusEvent creates a new PeerStatusEvent

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -5,14 +5,12 @@ import (
 	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
-
-// RippleEpoch is January 1, 2000 00:00:00 UTC - used for XRPL time calculations
-var RippleEpochRPC = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // ToRippleTime converts a time.Time to seconds since Ripple epoch
 func ToRippleTime(t time.Time) uint32 {
-	return uint32(t.Unix() - RippleEpochRPC.Unix())
+	return uint32(t.Unix() - protocol.RippleEpochUnix)
 }
 
 // LedgerCloseEvent represents a ledger close notification sent to subscribers

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -220,15 +220,21 @@ func NewManifestEvent(masterKey, signingKey, signature string, sequence uint32) 
 // This is sent to subscribers of the "peer_status" stream.
 // Mirrors rippled PeerImp.cpp:1892-1963 (pubPeerStatus callback) wrapped
 // by NetworkOPs.cpp:2514-2540 which adds `type: "peerStatusChange"`.
+//
+// Pointer fields preserve protobuf has-presence: nil = wire field
+// absent (rippled's `if (m->has_xxx)` is false → JSON field omitted),
+// non-nil = emit even when value is 0. This distinction matters because
+// JSON `omitempty` on a bare uint32 cannot distinguish "absent" from
+// "value 0", but rippled's emit gates rely on the protobuf has-bit.
 type PeerStatusEvent struct {
-	Type           string `json:"type"`                       // Always "peerStatusChange"
-	Status         string `json:"status,omitempty"`           // Peer's advertised status (UPPERCASE: CONNECTING/CONNECTED/MONITORING/VALIDATING/SHUTTING)
-	Action         string `json:"action,omitempty"`           // Action type (see constants below)
-	Date           uint32 `json:"date,omitempty"`             // Time of status change (Ripple epoch)
-	LedgerHash     string `json:"ledger_hash,omitempty"`      // Ledger hash (if relevant)
-	LedgerIndex    uint32 `json:"ledger_index,omitempty"`     // Ledger index (if relevant)
-	LedgerIndexMax uint32 `json:"ledger_index_max,omitempty"` // Max ledger index peer has
-	LedgerIndexMin uint32 `json:"ledger_index_min,omitempty"` // Min ledger index peer has
+	Type           string  `json:"type"`                       // Always "peerStatusChange"
+	Status         string  `json:"status,omitempty"`           // Peer's advertised status (UPPERCASE: CONNECTING/CONNECTED/MONITORING/VALIDATING/SHUTTING)
+	Action         string  `json:"action,omitempty"`           // Action type (see constants below)
+	Date           *uint32 `json:"date,omitempty"`             // Time of status change (Ripple epoch). Auto-stamped by the overlay so always non-nil in practice (PeerImp.cpp:1796-1797).
+	LedgerHash     string  `json:"ledger_hash,omitempty"`      // Ledger hash (peer's post-apply closedLedgerHash_; empty if wire didn't carry has_ledgerhash)
+	LedgerIndex    *uint32 `json:"ledger_index,omitempty"`     // Ledger index — nil when peer didn't advertise ledger_seq
+	LedgerIndexMax *uint32 `json:"ledger_index_max,omitempty"` // Max ledger index peer has — nil unless paired with min (PeerImp.cpp:1956-1960)
+	LedgerIndexMin *uint32 `json:"ledger_index_min,omitempty"` // Min ledger index peer has — nil unless paired with max
 }
 
 // Peer status actions — rippled PeerImp.cpp:1921-1932.
@@ -253,7 +259,7 @@ func NewPeerStatusEvent(action string, date uint32) *PeerStatusEvent {
 	return &PeerStatusEvent{
 		Type:   "peerStatusChange",
 		Action: action,
-		Date:   date,
+		Date:   &date,
 	}
 }
 

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -11,6 +11,7 @@ import (
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // AMMInfoMethod handles the amm_info RPC method
@@ -205,14 +206,10 @@ const (
 	auctionSlotIntervalDuration = totalTimeSlotSecs / auctionSlotTimeIntervals // 4320 seconds
 )
 
-// rippleEpochOffset is the number of seconds between Unix epoch (1970-01-01)
-// and Ripple epoch (2000-01-01): 946684800 seconds.
-const rippleEpochOffset = 946684800
-
 // rippleEpochToISO8601 converts a Ripple epoch timestamp to an ISO 8601 string.
 // Matches rippled's to_iso8601() in AMMInfo.cpp.
 func rippleEpochToISO8601(rippleSeconds uint32) string {
-	unixTime := int64(rippleSeconds) + rippleEpochOffset
+	unixTime := int64(rippleSeconds) + protocol.RippleEpochUnix
 	t := time.Unix(unixTime, 0).UTC()
 	return t.Format("2006-01-02T15:04:05+0000")
 }

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
@@ -125,15 +126,12 @@ func (a *ledgerReaderAdapter) TotalDrops() uint64 {
 	return a.l.TotalDrops()
 }
 
-// rippleEpoch is 2000-01-01T00:00:00Z in Unix seconds
-const rippleEpoch int64 = 946684800
-
 func (a *ledgerReaderAdapter) CloseTime() int64 {
 	t := a.l.CloseTime()
 	if t.IsZero() {
 		return 0
 	}
-	return t.Unix() - rippleEpoch
+	return t.Unix() - protocol.RippleEpochUnix
 }
 
 func (a *ledgerReaderAdapter) CloseTimeResolution() uint32 {
@@ -149,7 +147,7 @@ func (a *ledgerReaderAdapter) ParentCloseTime() int64 {
 	if t.IsZero() {
 		return 0
 	}
-	return t.Unix() - rippleEpoch
+	return t.Unix() - protocol.RippleEpochUnix
 }
 
 func (a *ledgerReaderAdapter) TxMapHash() [32]byte {

--- a/internal/testing/check/check_test.go
+++ b/internal/testing/check/check_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/testing/trustset"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	accounttx "github.com/LeJamon/goXRPLd/internal/tx/account"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -124,7 +125,7 @@ func TestCheck_CreateValid(t *testing.T) {
 	t.Run("OptionalFields", func(t *testing.T) {
 		// Expiration
 		result := env.Submit(check.CheckCreate(alice, bob, USD(50)).
-			Expiration(uint32(env.Now().Unix()-946684800) + 1).Build())
+			Expiration(uint32(env.Now().Unix()-protocol.RippleEpochUnix) + 1).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -148,7 +149,7 @@ func TestCheck_CreateValid(t *testing.T) {
 
 		// All optional fields combined
 		result = env.Submit(check.CheckCreate(alice, bob, USD(50)).
-			Expiration(uint32(env.Now().Unix()-946684800) + 1).
+			Expiration(uint32(env.Now().Unix()-protocol.RippleEpochUnix) + 1).
 			SourceTag(12).
 			DestTag(13).
 			InvoiceID("0000000000000000000000000000000000000000000000000000000000000004").Build())
@@ -518,7 +519,7 @@ func TestCheck_CreateInvalid(t *testing.T) {
 	// Expired expiration
 	t.Run("ExpiredExpiration", func(t *testing.T) {
 		// Ripple epoch: current close time
-		now := uint32(env.Now().Unix() - 946684800)
+		now := uint32(env.Now().Unix() - protocol.RippleEpochUnix)
 		result := env.Submit(check.CheckCreate(alice, bob, USD(50)).Expiration(now).Build())
 		require.Equal(t, "tecEXPIRED", result.Code)
 		env.Close()
@@ -1212,7 +1213,7 @@ func TestCheck_CashInvalid(t *testing.T) {
 	env.Close()
 
 	// Create an expiring check
-	now := uint32(env.Now().Unix() - 946684800)
+	now := uint32(env.Now().Unix() - protocol.RippleEpochUnix)
 	chkIDExp := check.GetCheckID(alice, env.Seq(alice))
 	env.Submit(check.CheckCreate(alice, bob, tx.NewXRPAmount(jtx.XRP(10))).Expiration(now + 1).Build())
 	env.Close()
@@ -1503,7 +1504,7 @@ func TestCheck_CancelValid(t *testing.T) {
 	env.Close()
 
 	// Three checks that expire in 10 minutes.
-	now := uint32(env.Now().Unix() - 946684800)
+	now := uint32(env.Now().Unix() - protocol.RippleEpochUnix)
 	chkIDNotExp1 := check.GetCheckID(alice, env.Seq(alice))
 	env.Submit(check.CheckCreate(alice, bob, tx.NewXRPAmount(jtx.XRP(10))).Expiration(now + 600).Build())
 	env.Close()
@@ -1520,7 +1521,7 @@ func TestCheck_CancelValid(t *testing.T) {
 	// Re-capture now so that expiration is in the future during creation.
 	// All three are created without intermediate Close() calls since Close()
 	// advances time by 10 seconds, which would expire them.
-	now = uint32(env.Now().Unix() - 946684800)
+	now = uint32(env.Now().Unix() - protocol.RippleEpochUnix)
 	chkIDExp1 := check.GetCheckID(alice, env.Seq(alice))
 	env.Submit(check.CheckCreate(alice, bob, USD(10)).Expiration(now + 1).Build())
 

--- a/internal/testing/conformance/runner.go
+++ b/internal/testing/conformance/runner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx/amm"
 	"github.com/LeJamon/goXRPLd/internal/tx/trustset"
 	"github.com/LeJamon/goXRPLd/internal/txq"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // Fixture represents a single xrpl-fixtures test vector file.
@@ -152,8 +153,9 @@ type AccountState struct {
 	Flags      *uint32 `json:"flags,omitempty"`
 }
 
-// rippleEpoch is Jan 1, 2000 00:00:00 UTC — the Ripple epoch start.
-var rippleEpoch = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+// rippleEpoch is Jan 1, 2000 00:00:00 UTC as a time.Time value, derived
+// from the canonical protocol.RippleEpochUnix constant.
+var rippleEpoch = time.Unix(protocol.RippleEpochUnix, 0).UTC()
 
 // defaultEnvConfig returns rippled's standard test defaults for fixtures
 // that don't specify an env section. Matches rippled's jtx::Env default

--- a/internal/testing/credential/credential_test.go
+++ b/internal/testing/credential/credential_test.go
@@ -15,9 +15,8 @@ import (
 	acctx "github.com/LeJamon/goXRPLd/internal/tx/account"
 	credtx "github.com/LeJamon/goXRPLd/internal/tx/credential"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
-
-const rippleEpoch = 946684800
 
 // xrpAccount is the XRPL zero account address (20 bytes of zero).
 // This matches rippled's xrpAccount() / noAccount().
@@ -30,7 +29,7 @@ func credentialKeylet(subject, issuer *jtx.Account, credType string) keylet.Keyl
 
 // rippleTime returns the current Ripple epoch time from the test environment.
 func rippleTime(env *jtx.TestEnv) uint32 {
-	return uint32(env.Now().Unix() - rippleEpoch)
+	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
 }
 
 // TestSuccessful tests the basic credential lifecycle: create, accept, delete.

--- a/internal/testing/depositpreauth/depositpreauth_test.go
+++ b/internal/testing/depositpreauth/depositpreauth_test.go
@@ -17,17 +17,16 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx/depositpreauth"
 	paymentPkg "github.com/LeJamon/goXRPLd/internal/tx/payment"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/require"
 )
 
 // xrpAccount is the XRPL zero account address (20 bytes of zero).
 const xrpAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
 
-const rippleEpoch = 946684800
-
 // rippleTime returns the current Ripple epoch time from the test environment.
 func rippleTime(env *jtx.TestEnv) uint32 {
-	return uint32(env.Now().Unix() - rippleEpoch)
+	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
 }
 
 // credentialKeylet computes the keylet for a credential.

--- a/internal/testing/env_signing.go
+++ b/internal/testing/env_signing.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // DecodeAddress decodes an XRPL address to a 20-byte account ID.
@@ -240,7 +241,7 @@ func (e *TestEnv) autoFillForSigning(txn tx.Transaction) {
 func (e *TestEnv) submitWithSigVerification(txn tx.Transaction) TxResult {
 	e.t.Helper()
 
-	parentCloseTime := uint32(e.clock.Now().Unix() - 946684800)
+	parentCloseTime := uint32(e.clock.Now().Unix() - protocol.RippleEpochUnix)
 	engineConfig := tx.EngineConfig{
 		BaseFee:                   e.baseFee,
 		ReserveBase:               e.reserveBase,

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/txq"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // Close closes the current ledger and advances to a new one.
@@ -462,7 +463,7 @@ func (e *TestEnv) applyDirect(txn tx.Transaction) TxResult {
 	// parent ledger's closeTime (OpenView.cpp line 106), not from the
 	// network time. Using the ledger header ensures consistency between
 	// initial apply and replay-on-close.
-	parentCloseTime := uint32(e.ledger.ParentCloseTime().Unix() - 946684800)
+	parentCloseTime := uint32(e.ledger.ParentCloseTime().Unix() - protocol.RippleEpochUnix)
 	engineConfig := tx.EngineConfig{
 		BaseFee:                   e.baseFee,
 		ReserveBase:               e.reserveBase,
@@ -730,7 +731,7 @@ func (e *TestEnv) applyForReplay(txn tx.Transaction, certainRetry bool) (tx.Resu
 	// Use the ledger's stored ParentCloseTime, matching applyDirect().
 	// Both paths use the ledger header so time-dependent checks produce
 	// the same result during initial apply and during replay.
-	parentCloseTime := uint32(e.ledger.ParentCloseTime().Unix() - 946684800)
+	parentCloseTime := uint32(e.ledger.ParentCloseTime().Unix() - protocol.RippleEpochUnix)
 	engineConfig := tx.EngineConfig{
 		BaseFee:                   e.baseFee,
 		ReserveBase:               e.reserveBase,
@@ -1176,7 +1177,7 @@ func (c *testTxQApplyContext) GetLedgerSequence() uint32 {
 }
 
 func (c *testTxQApplyContext) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
-	parentCloseTime := uint32(c.env.clock.Now().Unix() - 946684800)
+	parentCloseTime := uint32(c.env.clock.Now().Unix() - protocol.RippleEpochUnix)
 	// Transactions applied through the TxQ must NOT check open-ledger fee
 	// adequacy. In rippled, TxQ::tryDirectApply calls ripple::apply() with
 	// tapNONE flags (NOT tapOPEN_LEDGER). The TxQ's own fee-level check is
@@ -1259,7 +1260,7 @@ func (c *testTxQAcceptContext) GetAccountSequence(account [20]byte) uint32 {
 }
 
 func (c *testTxQAcceptContext) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
-	parentCloseTime := uint32(c.env.clock.Now().Unix() - 946684800)
+	parentCloseTime := uint32(c.env.clock.Now().Unix() - protocol.RippleEpochUnix)
 	// TxQ accept (drain on close) applies queued transactions with tapNONE
 	// flags in rippled — NOT tapOPEN_LEDGER. This prevents the engine's
 	// fee adequacy check from rejecting fee=0 transactions that were
@@ -1391,7 +1392,7 @@ func (e *TestEnv) SubmitPseudo(transaction interface{}) TxResult {
 		return TxResult{Code: "temINVALID", Success: false, Message: "Invalid transaction type"}
 	}
 
-	parentCloseTime := uint32(e.clock.Now().Unix() - 946684800)
+	parentCloseTime := uint32(e.clock.Now().Unix() - protocol.RippleEpochUnix)
 	engineConfig := tx.EngineConfig{
 		BaseFee:                   e.baseFee,
 		ReserveBase:               e.reserveBase,

--- a/internal/testing/escrow/builder.go
+++ b/internal/testing/escrow/builder.go
@@ -8,20 +8,17 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/testing"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	escrowtx "github.com/LeJamon/goXRPLd/internal/tx/escrow"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
-
-// RippleEpoch is the Unix timestamp for the Ripple epoch (January 1, 2000 00:00:00 UTC).
-// All Ripple timestamps are seconds since this epoch.
-const RippleEpoch = 946684800
 
 // ToRippleTime converts a Go time.Time to Ripple epoch time.
 func ToRippleTime(t time.Time) uint32 {
-	return uint32(t.Unix() - RippleEpoch)
+	return uint32(t.Unix() - protocol.RippleEpochUnix)
 }
 
 // FromRippleTime converts a Ripple epoch time to Go time.Time.
 func FromRippleTime(rippleTime uint32) time.Time {
-	return time.Unix(int64(rippleTime)+RippleEpoch, 0)
+	return time.Unix(int64(rippleTime)+protocol.RippleEpochUnix, 0)
 }
 
 // EscrowCreateBuilder provides a fluent interface for building EscrowCreate transactions.

--- a/internal/testing/nft/nftoken_test.go
+++ b/internal/testing/nft/nftoken_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx/account"
 	"github.com/LeJamon/goXRPLd/internal/tx/nftoken"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // TestDiagnosticMultiPage verifies NFTokenPage handling with multiple pages
@@ -1403,7 +1404,7 @@ func TestCreateOfferExpiration(t *testing.T) {
 	// Future expiration - create and then test expired acceptance
 	t.Run("ExpiredOfferCantBeAccepted", func(t *testing.T) {
 		// Use a time far enough in the future to create the offer
-		futureTime := uint32(env.Now().Unix()-946684800) + 25
+		futureTime := uint32(env.Now().Unix()-protocol.RippleEpochUnix) + 25
 		offerIndex := nft.GetOfferIndex(env, issuer)
 		result := env.Submit(nft.NFTokenCreateSellOffer(issuer, nftID, tx.NewXRPAmount(0)).
 			Expiration(futureTime).Build())

--- a/internal/testing/offer/helpers.go
+++ b/internal/testing/offer/helpers.go
@@ -9,11 +9,9 @@ import (
 	jtx "github.com/LeJamon/goXRPLd/internal/testing"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/require"
 )
-
-// rippleEpoch is the number of seconds between Unix epoch and Ripple epoch (Jan 1, 2000 00:00:00 UTC).
-const rippleEpoch int64 = 946684800
 
 // featureSet defines a set of disabled features for testing.
 type featureSet struct {
@@ -81,12 +79,12 @@ func Reserve(env *jtx.TestEnv, count uint32) uint64 {
 // Equivalent to rippled's lastClose(env) in Offer_test.cpp.
 func LastClose(env *jtx.TestEnv) uint32 {
 	unixSecs := env.Now().Unix()
-	return uint32(unixSecs - rippleEpoch)
+	return uint32(unixSecs - protocol.RippleEpochUnix)
 }
 
 // RippleTimeFromUnix converts a time.Time to Ripple epoch seconds.
 func RippleTimeFromUnix(t time.Time) uint32 {
-	return uint32(t.Unix() - rippleEpoch)
+	return uint32(t.Unix() - protocol.RippleEpochUnix)
 }
 
 // OfferInLedger checks if an offer exists in the ledger by account and sequence.

--- a/internal/testing/oracle/builder.go
+++ b/internal/testing/oracle/builder.go
@@ -9,9 +9,6 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx/oracle"
 )
 
-// XRPLEpochOffset is the XRPL epoch (Jan 1, 2000 00:00:00 UTC) in Unix seconds.
-const XRPLEpochOffset = 946684800
-
 // OracleSetBuilder provides a fluent interface for building OracleSet transactions.
 type OracleSetBuilder struct {
 	account           *testing.Account

--- a/internal/testing/oracle/oracle_test.go
+++ b/internal/testing/oracle/oracle_test.go
@@ -9,6 +9,7 @@ import (
 	oracletest "github.com/LeJamon/goXRPLd/internal/testing/oracle"
 	accounttx "github.com/LeJamon/goXRPLd/internal/tx/account"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -557,9 +558,9 @@ func TestInvalidSet(t *testing.T) {
 		}
 
 		// Compute close time in XRPL epoch
-		closeTimeXRPL := uint32(env.Now().Unix()) - oracletest.XRPLEpochOffset
+		closeTimeXRPL := uint32(env.Now().Unix()) - uint32(protocol.RippleEpochUnix)
 		// LastUpdateTime too old: closeTime - 301 (in Unix = epoch + XRPL epoch offset)
-		tooOld := (closeTimeXRPL - 301) + oracletest.XRPLEpochOffset
+		tooOld := (closeTimeXRPL - 301) + uint32(protocol.RippleEpochUnix)
 		result = env.Submit(oracletest.OracleSet(owner, 1, tooOld).
 			AddPrice("XRP", "USD", 740, 1).
 			Fee(baseFee).
@@ -588,8 +589,8 @@ func TestInvalidSet(t *testing.T) {
 			env.Close()
 		}
 
-		closeTimeXRPL := uint32(env.Now().Unix()) - oracletest.XRPLEpochOffset
-		tooNew := (closeTimeXRPL + 311) + oracletest.XRPLEpochOffset
+		closeTimeXRPL := uint32(env.Now().Unix()) - uint32(protocol.RippleEpochUnix)
+		tooNew := (closeTimeXRPL + 311) + uint32(protocol.RippleEpochUnix)
 		result = env.Submit(oracletest.OracleSet(owner, 1, tooNew).
 			AddPrice("XRP", "USD", 740, 1).
 			Fee(baseFee).
@@ -653,7 +654,7 @@ func TestInvalidSet(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 
 		// Update with time < epoch_offset (946684800)
-		result = env.Submit(oracletest.OracleSet(owner, 1, oracletest.XRPLEpochOffset-1).
+		result = env.Submit(oracletest.OracleSet(owner, 1, uint32(protocol.RippleEpochUnix)-1).
 			AddPrice("XRP", "USD", 740, 1).
 			Fee(baseFee).
 			Build())

--- a/internal/testing/p2p/replay_delta_apply_integration_test.go
+++ b/internal/testing/p2p/replay_delta_apply_integration_test.go
@@ -13,6 +13,7 @@ import (
 	xrplgoTesting "github.com/LeJamon/goXRPLd/internal/testing"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/payment"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -230,8 +231,7 @@ func buildClosedSuccessor(
 
 	parentCloseTime := uint32(0)
 	if !parent.CloseTime().IsZero() {
-		const rippleEpochUnix int64 = 946684800
-		parentCloseTime = uint32(parent.CloseTime().Unix() - rippleEpochUnix)
+		parentCloseTime = uint32(parent.CloseTime().Unix() - protocol.RippleEpochUnix)
 	}
 
 	engine := tx.NewEngine(child, tx.EngineConfig{

--- a/internal/testing/paychan/builder.go
+++ b/internal/testing/paychan/builder.go
@@ -7,12 +7,11 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/testing"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	paychan "github.com/LeJamon/goXRPLd/internal/tx/paychan"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
-const RippleEpoch = 946684800
-
 func ToRippleTime(t time.Time) uint32 {
-	return uint32(t.Unix() - RippleEpoch)
+	return uint32(t.Unix() - protocol.RippleEpochUnix)
 }
 
 type ChannelCreateBuilder struct {

--- a/internal/testing/paychan/paychan_test.go
+++ b/internal/testing/paychan/paychan_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/testing/credential"
 	"github.com/LeJamon/goXRPLd/internal/testing/depositpreauth"
 	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/protocol"
 
 	jtx "github.com/LeJamon/goXRPLd/internal/testing"
 	"github.com/stretchr/testify/require"
@@ -676,7 +677,7 @@ func TestPayChan_Expiration(t *testing.T) {
 	require.Equal(t, minExpiration, exp)
 
 	// Advance past expiration
-	env.SetTime(time.Unix(int64(minExpiration)+RippleEpoch, 0))
+	env.SetTime(time.Unix(int64(minExpiration)+protocol.RippleEpochUnix, 0))
 	env.Close()
 
 	// Try to extend the expiration after the expiration has already passed

--- a/internal/testing/payment/depositauth_test.go
+++ b/internal/testing/payment/depositauth_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx/depositpreauth"
 	paymentPkg "github.com/LeJamon/goXRPLd/internal/tx/payment"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -820,12 +821,9 @@ func TestDepositPreauth_Credentials(t *testing.T) {
 	t.Log("DepositPreauth credentials test passed")
 }
 
-// rippleEpoch is the XRPL epoch start (2000-01-01 00:00:00 UTC).
-const rippleEpoch = 946684800
-
 // rippleTime returns the current Ripple epoch time from the test environment.
 func rippleTime(env *xrplgoTesting.TestEnv) uint32 {
-	return uint32(env.Now().Unix() - rippleEpoch)
+	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
 }
 
 // credentialKeylet computes the keylet for a credential given subject, issuer, and raw credential type.

--- a/internal/testing/permissioneddex/permissioned_dex_test.go
+++ b/internal/testing/permissioneddex/permissioned_dex_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/payment"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // requireResult asserts the transaction result matches the expected code.
@@ -42,10 +43,8 @@ func xrpUsdEurPath(gw *jtx.Account) [][]payment.PathStep {
 }
 
 // rippleTimeNow returns the current ledger time as Ripple epoch seconds.
-// The Ripple epoch is Jan 1, 2000 00:00:00 UTC (946684800 Unix seconds).
 func rippleTimeNow(env *jtx.TestEnv) uint32 {
-	const rippleEpoch int64 = 946684800
-	return uint32(env.Now().Unix() - rippleEpoch)
+	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
 }
 
 // badDomain is a nonexistent domain ID (hex).

--- a/internal/tx/oracle/constant.go
+++ b/internal/tx/oracle/constant.go
@@ -21,8 +21,4 @@ const (
 	// MaxPriceScale is the maximum allowed scale value for price data
 	// Reference: rippled Oracle_test.cpp line 354 tests maxPriceScale + 1 = 9 fails
 	MaxPriceScale = 8
-
-	// RippleEpochOffset is the number of seconds between Unix epoch (Jan 1, 1970)
-	// and Ripple epoch (Jan 1, 2000). This equals 946684800 seconds.
-	RippleEpochOffset = 946684800
 )

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 func init() {
@@ -275,10 +276,10 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	closeTime := uint64(ctx.Config.ParentCloseTime)
 	lastUpdateTime := uint64(o.LastUpdateTime)
 
-	if lastUpdateTime < RippleEpochOffset {
+	if lastUpdateTime < uint64(protocol.RippleEpochUnix) {
 		return tx.TecINVALID_UPDATE_TIME
 	}
-	lastUpdateTimeEpoch := lastUpdateTime - RippleEpochOffset
+	lastUpdateTimeEpoch := lastUpdateTime - uint64(protocol.RippleEpochUnix)
 
 	// Validate that lastUpdateTimeEpoch is within maxLastUpdateTimeDelta of closeTime.
 	// The lower-bound subtraction (closeTime - delta) is guarded to prevent underflow.

--- a/internal/tx/payment/payment_test.go
+++ b/internal/tx/payment/payment_test.go
@@ -81,7 +81,7 @@ func TestPaymentValidation(t *testing.T) {
 				Destination: "",
 			},
 			expectError: true,
-			errorMsg:    "Destination is required",
+			errorMsg:    "temDST_NEEDED: Destination is required",
 		},
 		{
 			name: "missing amount - temBAD_AMOUNT equivalent",
@@ -91,10 +91,14 @@ func TestPaymentValidation(t *testing.T) {
 				Destination: "rBob",
 			},
 			expectError: true,
-			errorMsg:    "Amount is required",
+			errorMsg:    "temBAD_AMOUNT: Amount is required",
 		},
 		{
-			name: "missing account - temBAD_SRC_ACCOUNT equivalent",
+			// internal/tx/transaction.go:191 — common BaseTx validation
+			// returns a bare "Account is required" without the temXXX
+			// prefix. This pre-empts payment-specific preflight, so we
+			// match the upstream error verbatim.
+			name: "missing account",
 			payment: &Payment{
 				BaseTx:      tx.BaseTx{Common: tx.Common{TransactionType: "Payment"}},
 				Amount:      xrpAmount("1000000"),
@@ -104,7 +108,12 @@ func TestPaymentValidation(t *testing.T) {
 			errorMsg:    "Account is required",
 		},
 
-		// Payment to self validation
+		// Payment to self validation — rippled Payment.cpp:159-166:
+		// temREDUNDANT iff account == dst && equalTokens && !hasPaths.
+		// Same-asset to-self without paths/SendMax is rejected for both
+		// XRP and IOU; cross-currency to-self (e.g. SendMax in a
+		// different asset) bypasses the equalTokens check and is
+		// allowed.
 		{
 			name: "XRP payment to self - temREDUNDANT equivalent",
 			payment: &Payment{
@@ -113,16 +122,27 @@ func TestPaymentValidation(t *testing.T) {
 				Destination: "rAlice",
 			},
 			expectError: true,
-			errorMsg:    "temREDUNDANT: cannot send XRP to self without path",
+			errorMsg:    "temREDUNDANT: cannot send to self without path",
 		},
 		{
-			name: "IOU payment to self is allowed (for cross-currency)",
+			name: "same-asset IOU payment to self - temREDUNDANT equivalent",
 			payment: &Payment{
 				BaseTx:      *tx.NewBaseTx(tx.TypePayment, "rAlice"),
 				Amount:      iouAmount("100", "USD", "rGateway"),
 				Destination: "rAlice",
 			},
-			expectError: false, // IOU payments to self are allowed for cross-currency
+			expectError: true,
+			errorMsg:    "temREDUNDANT: cannot send to self without path",
+		},
+		{
+			name: "cross-currency IOU-to-self with SendMax is allowed",
+			payment: &Payment{
+				BaseTx:      *tx.NewBaseTx(tx.TypePayment, "rAlice"),
+				Amount:      iouAmount("100", "USD", "rGateway"),
+				Destination: "rAlice",
+				SendMax:     ptrAmount(iouAmount("110", "EUR", "rGateway")),
+			},
+			expectError: false,
 		},
 	}
 
@@ -202,10 +222,14 @@ func TestPaymentAmounts(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "IOU payment - scientific notation",
+			// parseIOUValueFromString (internal/ledger/state/amount.go:579)
+			// accepts decimal strings only — scientific notation isn't
+			// part of the JSON wire shape, so we exercise the equivalent
+			// large-magnitude value as a plain decimal.
+			name: "IOU payment - very large decimal value",
 			payment: &Payment{
 				BaseTx:      *tx.NewBaseTx(tx.TypePayment, "rAlice"),
-				Amount:      iouAmount("1e10", "USD", "rGateway"),
+				Amount:      iouAmount("10000000000", "USD", "rGateway"),
 				Destination: "rBob",
 			},
 			expectError: false,
@@ -467,6 +491,10 @@ func TestPaymentDeliverMin(t *testing.T) {
 
 // TestPaymentPaths tests Paths field handling.
 // Inspired by rippled's path handling tests in PayStrand_test.cpp.
+//
+// Flatten() converts [][]PathStep into the binary-codec wire shape:
+// []any of []any of map[string]any. The map fields are lower-cased
+// (rippled wire convention: jss::account / jss::currency / jss::issuer).
 func TestPaymentPaths(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -487,18 +515,10 @@ func TestPaymentPaths(t *testing.T) {
 				},
 			},
 			checkMap: func(t *testing.T, m map[string]any) {
-				paths, ok := m["Paths"].([][]PathStep)
-				if !ok {
-					t.Fatalf("Paths should be [][]PathStep, got %T", m["Paths"])
-				}
-				if len(paths) != 1 {
-					t.Errorf("expected 1 path, got %d", len(paths))
-				}
-				if len(paths[0]) != 1 {
-					t.Errorf("expected 1 step in path, got %d", len(paths[0]))
-				}
-				if paths[0][0].Currency != "XRP" {
-					t.Errorf("expected currency=XRP, got %v", paths[0][0].Currency)
+				paths := requirePathSet(t, m, 1)
+				steps := requirePathSteps(t, paths[0], 1)
+				if got := steps[0]["currency"]; got != "XRP" {
+					t.Errorf("expected currency=XRP, got %v", got)
 				}
 			},
 		},
@@ -518,16 +538,8 @@ func TestPaymentPaths(t *testing.T) {
 				},
 			},
 			checkMap: func(t *testing.T, m map[string]any) {
-				paths, ok := m["Paths"].([][]PathStep)
-				if !ok {
-					t.Fatalf("Paths should be [][]PathStep, got %T", m["Paths"])
-				}
-				if len(paths) != 1 {
-					t.Errorf("expected 1 path, got %d", len(paths))
-				}
-				if len(paths[0]) != 3 {
-					t.Errorf("expected 3 steps in path, got %d", len(paths[0]))
-				}
+				paths := requirePathSet(t, m, 1)
+				requirePathSteps(t, paths[0], 3)
 			},
 		},
 		{
@@ -547,13 +559,7 @@ func TestPaymentPaths(t *testing.T) {
 				},
 			},
 			checkMap: func(t *testing.T, m map[string]any) {
-				paths, ok := m["Paths"].([][]PathStep)
-				if !ok {
-					t.Fatalf("Paths should be [][]PathStep, got %T", m["Paths"])
-				}
-				if len(paths) != 2 {
-					t.Errorf("expected 2 paths, got %d", len(paths))
-				}
+				requirePathSet(t, m, 2)
 			},
 		},
 		{
@@ -582,12 +588,10 @@ func TestPaymentPaths(t *testing.T) {
 				},
 			},
 			checkMap: func(t *testing.T, m map[string]any) {
-				paths, ok := m["Paths"].([][]PathStep)
-				if !ok {
-					t.Fatalf("Paths should be [][]PathStep, got %T", m["Paths"])
-				}
-				if paths[0][0].Account != "rCarol" {
-					t.Errorf("expected account=rCarol, got %v", paths[0][0].Account)
+				paths := requirePathSet(t, m, 1)
+				steps := requirePathSteps(t, paths[0], 1)
+				if got := steps[0]["account"]; got != "rCarol" {
+					t.Errorf("expected account=rCarol, got %v", got)
 				}
 			},
 		},
@@ -602,6 +606,41 @@ func TestPaymentPaths(t *testing.T) {
 			tt.checkMap(t, m)
 		})
 	}
+}
+
+// requirePathSet asserts that m["Paths"] is the wire-shaped []any of
+// path arrays produced by (*Payment).Flatten and returns it.
+func requirePathSet(t *testing.T, m map[string]any, want int) []any {
+	t.Helper()
+	paths, ok := m["Paths"].([]any)
+	if !ok {
+		t.Fatalf("Paths should be []any, got %T", m["Paths"])
+	}
+	if len(paths) != want {
+		t.Fatalf("expected %d path(s), got %d", want, len(paths))
+	}
+	return paths
+}
+
+// requirePathSteps unwraps a single path entry into its step-maps.
+func requirePathSteps(t *testing.T, path any, want int) []map[string]any {
+	t.Helper()
+	steps, ok := path.([]any)
+	if !ok {
+		t.Fatalf("path should be []any, got %T", path)
+	}
+	if len(steps) != want {
+		t.Fatalf("expected %d step(s), got %d", want, len(steps))
+	}
+	out := make([]map[string]any, len(steps))
+	for i, s := range steps {
+		m, ok := s.(map[string]any)
+		if !ok {
+			t.Fatalf("path step %d should be map[string]any, got %T", i, s)
+		}
+		out[i] = m
+	}
+	return out
 }
 
 // TestPaymentFlatten tests the Flatten method for Payment.
@@ -778,7 +817,8 @@ func TestPaymentFlagConstants(t *testing.T) {
 }
 
 // TestPaymentZeroAmount tests handling of zero amounts.
-// Inspired by rippled's amount validation tests.
+// rippled Payment.cpp:148-152 — preflight rejects dstAmount <= zero
+// with temBAD_AMOUNT for both native and IOU.
 func TestPaymentZeroAmount(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -792,9 +832,7 @@ func TestPaymentZeroAmount(t *testing.T) {
 				Amount:      xrpAmount("0"),
 				Destination: "rBob",
 			},
-			// Zero amount validation is typically done at a higher level
-			// The basic validation just checks if Value is not empty
-			expectError: false,
+			expectError: true,
 		},
 		{
 			name: "zero IOU amount string",
@@ -803,7 +841,7 @@ func TestPaymentZeroAmount(t *testing.T) {
 				Amount:      iouAmount("0", "USD", "rGateway"),
 				Destination: "rBob",
 			},
-			expectError: false,
+			expectError: true,
 		},
 	}
 
@@ -973,13 +1011,12 @@ func TestPaymentCrossCurrency(t *testing.T) {
 			t.Errorf("expected SendMax currency=USD, got %v", sendMax["currency"])
 		}
 
-		// Verify Paths includes XRP hop
-		paths, ok := m["Paths"].([][]PathStep)
-		if !ok {
-			t.Fatal("Paths should be [][]PathStep")
-		}
-		if len(paths) != 1 || paths[0][0].Currency != "XRP" {
-			t.Error("expected path with XRP hop")
+		// Verify Paths includes XRP hop. Flatten serializes Paths as
+		// []any of []any of map[string]any (binary-codec wire shape).
+		paths := requirePathSet(t, m, 1)
+		steps := requirePathSteps(t, paths[0], 1)
+		if got := steps[0]["currency"]; got != "XRP" {
+			t.Errorf("expected currency=XRP at first hop, got %v", got)
 		}
 	})
 
@@ -1088,8 +1125,9 @@ func TestDeliverMinValidation(t *testing.T) {
 			errorMsg:    "temBAD_AMOUNT: DeliverMin currency must match Amount",
 		},
 
-		// DeliverMin must not exceed Amount
-		// Reference: rippled DeliverMin_test.cpp line 61-64
+		// DeliverMin must not exceed Amount.
+		// rippled Payment.cpp:232-238 — preflight returns temBAD_AMOUNT
+		// when dMin > dstAmount.
 		{
 			name: "DeliverMin exceeds Amount - temBAD_AMOUNT",
 			payment: func() *Payment {
@@ -1103,7 +1141,8 @@ func TestDeliverMinValidation(t *testing.T) {
 				p.DeliverMin = &deliverMin
 				return p
 			}(),
-			expectError: false, // This is validated in apply, not preflight
+			expectError: true,
+			errorMsg:    "temBAD_AMOUNT: DeliverMin cannot exceed Amount",
 		},
 
 		// Valid DeliverMin with tfPartialPayment
@@ -1201,7 +1240,11 @@ func TestPartialPaymentXRPRestriction(t *testing.T) {
 			errorMsg:    "temBAD_SEND_XRP_PARTIAL",
 		},
 		{
-			name: "tfPartialPayment with XRP-to-XRP (with XRP SendMax) - temBAD_SEND_XRP_PARTIAL",
+			// rippled Payment.cpp:168-173 — XRP-direct + SendMax returns
+			// temBAD_SEND_XRP_MAX before the partial-payment branch
+			// (Payment.cpp:182-188) is reached. Order is intentional;
+			// match it so we surface the same error code as rippled.
+			name: "tfPartialPayment with XRP-to-XRP (with XRP SendMax) - temBAD_SEND_XRP_MAX",
 			payment: func() *Payment {
 				p := &Payment{
 					BaseTx:      *tx.NewBaseTx(tx.TypePayment, "rAlice"),
@@ -1213,7 +1256,7 @@ func TestPartialPaymentXRPRestriction(t *testing.T) {
 				return p
 			}(),
 			expectError: true,
-			errorMsg:    "temBAD_SEND_XRP_PARTIAL",
+			errorMsg:    "temBAD_SEND_XRP_MAX",
 		},
 		{
 			name: "tfPartialPayment with IOU - allowed",

--- a/internal/tx/types.go
+++ b/internal/tx/types.go
@@ -5,8 +5,6 @@ import "fmt"
 // Type represents a transaction type code
 type Type uint16
 
-const RippleEpoch int64 = 946684800
-
 // All transaction type codes from rippled
 const (
 	TypeInvalid Type = 0xFFFF // Invalid/unknown type

--- a/internal/tx/vault/constant.go
+++ b/internal/tx/vault/constant.go
@@ -34,7 +34,6 @@ var (
 	ErrVaultDataEmpty        = tx.Errorf(tx.TemMALFORMED, "Data cannot be empty if present")
 	ErrVaultDomainIDZero     = tx.Errorf(tx.TemMALFORMED, "DomainID cannot be zero")
 	ErrVaultDomainNotPrivate = tx.Errorf(tx.TemMALFORMED, "DomainID only allowed on private vaults")
-	ErrVaultAmountRequired   = tx.Errorf(tx.TemBAD_AMOUNT, "Amount is required")
 	ErrVaultAmountNotPos     = tx.Errorf(tx.TemBAD_AMOUNT, "Amount must be positive")
 	ErrVaultHolderRequired   = tx.Errorf(tx.TemMALFORMED, "Holder is required")
 	ErrVaultHolderIsSelf     = tx.Errorf(tx.TemMALFORMED, "Holder cannot be same as issuer")

--- a/internal/tx/vault/vault_deposit.go
+++ b/internal/tx/vault/vault_deposit.go
@@ -70,13 +70,10 @@ func (v *VaultDeposit) Validate() error {
 		return ErrVaultIDZero
 	}
 
-	// Amount is required and must be positive
-	// Reference: rippled VaultDeposit.cpp:53-54
-	if v.Amount.IsZero() {
-		return ErrVaultAmountRequired
-	}
-	amountVal := v.Amount.Float64()
-	if amountVal <= 0 {
+	// Amount must be positive — rippled VaultDeposit.cpp:53-54 returns
+	// temBAD_AMOUNT for any sfAmount <= beast::zero (covers default,
+	// explicit zero, and negative), so one check suffices.
+	if v.Amount.Float64() <= 0 {
 		return ErrVaultAmountNotPos
 	}
 

--- a/internal/tx/vault/vault_test.go
+++ b/internal/tx/vault/vault_test.go
@@ -443,22 +443,25 @@ func TestVaultDepositValidation(t *testing.T) {
 			errMsg:  "VaultID cannot be zero",
 		},
 		{
+			// rippled VaultDeposit.cpp:53-54 collapses missing / zero
+			// / negative into a single temBAD_AMOUNT — they all surface
+			// the same "must be positive" message in goXRPL.
 			name:    "invalid - missing Amount",
 			tx:      NewVaultDeposit("rOwner", makeValidVaultID(), tx.Amount{}),
 			wantErr: true,
-			errMsg:  "Amount is required",
+			errMsg:  "Amount must be positive",
 		},
 		{
 			name:    "invalid - zero Amount",
 			tx:      NewVaultDeposit("rOwner", makeValidVaultID(), tx.NewXRPAmount(0)),
 			wantErr: true,
-			errMsg:  "positive",
+			errMsg:  "Amount must be positive",
 		},
 		{
 			name:    "invalid - negative Amount",
 			tx:      NewVaultDeposit("rOwner", makeValidVaultID(), tx.NewXRPAmount(-100)),
 			wantErr: true,
-			errMsg:  "positive",
+			errMsg:  "Amount must be positive",
 		},
 		{
 			name: "invalid - universal flags set",
@@ -548,22 +551,24 @@ func TestVaultWithdrawValidation(t *testing.T) {
 			errMsg:  "VaultID cannot be zero",
 		},
 		{
+			// rippled VaultWithdraw.cpp:51-52 — missing / zero /
+			// negative all surface as temBAD_AMOUNT.
 			name:    "invalid - missing Amount",
 			tx:      NewVaultWithdraw("rOwner", makeValidVaultID(), tx.Amount{}),
 			wantErr: true,
-			errMsg:  "Amount is required",
+			errMsg:  "Amount must be positive",
 		},
 		{
 			name:    "invalid - zero Amount",
 			tx:      NewVaultWithdraw("rOwner", makeValidVaultID(), tx.NewXRPAmount(0)),
 			wantErr: true,
-			errMsg:  "positive",
+			errMsg:  "Amount must be positive",
 		},
 		{
 			name:    "invalid - negative Amount",
 			tx:      NewVaultWithdraw("rOwner", makeValidVaultID(), tx.NewXRPAmount(-100)),
 			wantErr: true,
-			errMsg:  "positive",
+			errMsg:  "Amount must be positive",
 		},
 		{
 			name: "invalid - DestinationTag without Destination",

--- a/internal/tx/vault/vault_withdraw.go
+++ b/internal/tx/vault/vault_withdraw.go
@@ -76,13 +76,10 @@ func (v *VaultWithdraw) Validate() error {
 		return ErrVaultIDZero
 	}
 
-	// Amount is required and must be positive
-	// Reference: rippled VaultWithdraw.cpp:51-52
-	if v.Amount.IsZero() {
-		return ErrVaultAmountRequired
-	}
-	amountVal := v.Amount.Float64()
-	if amountVal <= 0 {
+	// Amount must be positive — rippled VaultWithdraw.cpp:51-52 returns
+	// temBAD_AMOUNT for any sfAmount <= beast::zero (covers default,
+	// explicit zero, and negative), so one check suffices.
+	if v.Amount.Float64() <= 0 {
 		return ErrVaultAmountNotPos
 	}
 

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -22,3 +22,9 @@ const (
 	// NFTokenTransferFeeMax is the maximum NFToken transfer fee in basis points (50000 = 50%).
 	NFTokenTransferFeeMax uint16 = 50000
 )
+
+// RippleEpochUnix is the Unix timestamp of the XRPL epoch (2000-01-01
+// 00:00:00 UTC). Subtract from a Unix-seconds value to convert to
+// Ripple-Epoch seconds, the on-the-wire format rippled stamps onto
+// network-time fields.
+const RippleEpochUnix int64 = 946684800

--- a/storage/relationaldb/postgres/ledger_repository.go
+++ b/storage/relationaldb/postgres/ledger_repository.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
@@ -96,8 +97,8 @@ func (r *LedgerRepository) GetLedgerInfoBySeq(ctx context.Context, seq relationa
 	}
 
 	// Convert rippled time format (seconds since 2000-01-01) to Go time
-	info.CloseTime = time.Unix(closingTime+946684800, 0).UTC() // Add Ripple epoch offset
-	info.ParentCloseTime = time.Unix(prevClosingTime+946684800, 0).UTC()
+	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC() // Add Ripple epoch offset
+	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
 
 	return &info, nil
 }
@@ -133,8 +134,8 @@ func (r *LedgerRepository) GetLedgerInfoByHash(ctx context.Context, hash relatio
 		info.TotalCoins = relationaldb.Amount(totalCoins)
 	}
 
-	info.CloseTime = time.Unix(closingTime+946684800, 0).UTC()
-	info.ParentCloseTime = time.Unix(prevClosingTime+946684800, 0).UTC()
+	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC()
+	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
 
 	return &info, nil
 }
@@ -170,8 +171,8 @@ func (r *LedgerRepository) GetNewestLedgerInfo(ctx context.Context) (*relational
 		info.TotalCoins = relationaldb.Amount(totalCoins)
 	}
 
-	info.CloseTime = time.Unix(closingTime+946684800, 0).UTC()
-	info.ParentCloseTime = time.Unix(prevClosingTime+946684800, 0).UTC()
+	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC()
+	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
 
 	return &info, nil
 }
@@ -206,8 +207,8 @@ func (r *LedgerRepository) GetLimitedOldestLedgerInfo(ctx context.Context, minSe
 		info.TotalCoins = relationaldb.Amount(totalCoins)
 	}
 
-	info.CloseTime = time.Unix(closingTime+946684800, 0).UTC()
-	info.ParentCloseTime = time.Unix(prevClosingTime+946684800, 0).UTC()
+	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC()
+	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
 
 	return &info, nil
 }
@@ -242,8 +243,8 @@ func (r *LedgerRepository) GetLimitedNewestLedgerInfo(ctx context.Context, minSe
 		info.TotalCoins = relationaldb.Amount(totalCoins)
 	}
 
-	info.CloseTime = time.Unix(closingTime+946684800, 0).UTC()
-	info.ParentCloseTime = time.Unix(prevClosingTime+946684800, 0).UTC()
+	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC()
+	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
 
 	return &info, nil
 }
@@ -317,8 +318,8 @@ func (r *LedgerRepository) GetHashesByRange(ctx context.Context, minSeq, maxSeq 
 
 func (r *LedgerRepository) SaveValidatedLedger(ctx context.Context, ledger *relationaldb.LedgerInfo, current bool) error {
 	// Convert Go time back to rippled format (seconds since 2000-01-01)
-	closingTime := ledger.CloseTime.Unix() - 946684800
-	prevClosingTime := ledger.ParentCloseTime.Unix() - 946684800
+	closingTime := ledger.CloseTime.Unix() - protocol.RippleEpochUnix
+	prevClosingTime := ledger.ParentCloseTime.Unix() - protocol.RippleEpochUnix
 
 	query := `INSERT INTO ledgers (ledger_hash, ledger_seq, prev_hash, account_set_hash, trans_set_hash,
 			  total_coins, closing_time, prev_closing_time, close_time_res, close_flags)

--- a/storage/relationaldb/postgres/validation_repository.go
+++ b/storage/relationaldb/postgres/validation_repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
@@ -37,22 +38,18 @@ func (r *ValidationRepository) getExecutor() executor {
 const validationSelectCols = `ledger_seq, initial_seq, ledger_hash, node_pubkey,
 	sign_time, seen_time, flags, raw`
 
-// xrplEpochOffset matches the SQLite backend so times round-trip across
-// backends without drift. See the SQLite impl for rationale.
-const xrplEpochOffset int64 = 946684800
-
 func toXRPLEpochSeconds(t time.Time) int64 {
 	if t.IsZero() {
 		return 0
 	}
-	return t.Unix() - xrplEpochOffset
+	return t.Unix() - protocol.RippleEpochUnix
 }
 
 func fromXRPLEpochSeconds(s int64) time.Time {
 	if s == 0 {
 		return time.Time{}
 	}
-	return time.Unix(s+xrplEpochOffset, 0).UTC()
+	return time.Unix(s+protocol.RippleEpochUnix, 0).UTC()
 }
 
 func (r *ValidationRepository) Save(ctx context.Context, v *relationaldb.ValidationRecord) error {

--- a/storage/relationaldb/sqlite/ledger_repository.go
+++ b/storage/relationaldb/sqlite/ledger_repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
@@ -74,8 +75,8 @@ func (r *LedgerRepository) scanLedgerInfo(row interface {
 	copy(info.AccountHash[:], accountHashBytes)
 	copy(info.TransactionHash[:], txHashBytes)
 	info.TotalCoins = relationaldb.Amount(totalCoins)
-	info.CloseTime = time.Unix(closingTime+946684800, 0).UTC()
-	info.ParentCloseTime = time.Unix(prevClosingTime+946684800, 0).UTC()
+	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC()
+	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
 
 	return &info, nil
 }
@@ -207,8 +208,8 @@ func (r *LedgerRepository) GetHashesByRange(ctx context.Context, minSeq, maxSeq 
 }
 
 func (r *LedgerRepository) SaveValidatedLedger(ctx context.Context, ledger *relationaldb.LedgerInfo, current bool) error {
-	closingTime := ledger.CloseTime.Unix() - 946684800
-	prevClosingTime := ledger.ParentCloseTime.Unix() - 946684800
+	closingTime := ledger.CloseTime.Unix() - protocol.RippleEpochUnix
+	prevClosingTime := ledger.ParentCloseTime.Unix() - protocol.RippleEpochUnix
 
 	query := `INSERT INTO ledgers (ledger_hash, ledger_seq, prev_hash, account_set_hash, trans_set_hash,
 			  total_coins, closing_time, prev_closing_time, close_time_res, close_flags)

--- a/storage/relationaldb/sqlite/validation_repository.go
+++ b/storage/relationaldb/sqlite/validation_repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
@@ -40,23 +41,18 @@ func (r *ValidationRepository) getExecutor() executor {
 const validationSelectCols = `ledger_seq, initial_seq, ledger_hash, node_pubkey,
 	sign_time, seen_time, flags, raw`
 
-// xrplEpochOffset is the difference between Unix epoch (1970-01-01) and
-// the XRPL epoch (2000-01-01). Times stored in the archive are XRPL-epoch
-// seconds to stay wire-compatible with the serialized SignTime field.
-const xrplEpochOffset int64 = 946684800
-
 func toXRPLEpochSeconds(t time.Time) int64 {
 	if t.IsZero() {
 		return 0
 	}
-	return t.Unix() - xrplEpochOffset
+	return t.Unix() - protocol.RippleEpochUnix
 }
 
 func fromXRPLEpochSeconds(s int64) time.Time {
 	if s == 0 {
 		return time.Time{}
 	}
-	return time.Unix(s+xrplEpochOffset, 0).UTC()
+	return time.Unix(s+protocol.RippleEpochUnix, 0).UTC()
 }
 
 func (r *ValidationRepository) Save(ctx context.Context, v *relationaldb.ValidationRecord) error {


### PR DESCRIPTION
## Summary
- Record the latest `TMStatusChange.new_status` on each peer; surface via `Peer.LastStatus()` and `PeerInfo.Status`.
- Emit `"status": "<string>"` per peer in the `peers` RPC response, mirroring rippled `PeerImp::json` (PeerImp.cpp:463-491). The five strings (`connecting`/`connected`/`monitoring`/`validating`/`shutting`) match rippled exactly; the field is omitted when the peer has not advertised a status (`nsUNKNOWN`) or the enum is out of range.
- `applyStatusChange` records `newStatus` before the lostSync early-return, mirroring rippled's `last_status_ = m;` retention so a lostSync update carrying a `NewStatus` still reports it.

Closes #299.

## Test plan
- [x] `go test ./internal/peermanagement/...` — full peer-management suite passes (cluster / message / peertls / overlay).
- [x] `go test ./internal/rpc/handlers -run TestPeers` — `peers` RPC handler still passes.
- [x] New tests in `internal/peermanagement/peer_status_test.go`:
  - default `LastStatus()` is zero
  - each of the five `NodeStatus` values is stored verbatim and surfaces via `PeerInfo.Status`
  - subsequent `applyStatusChange` overwrites prior status, including reset to zero on a status-less update
  - lostSync TMStatusChange still records `NewStatus`
  - `Overlay.handleStatusChange` decodes `new_status` and writes through
  - `PeersJSON` emits the rippled string for each known status, omits for zero, omits for unknown enum values