### PR TITLE
feat(peermanagement): emit per-peer metrics object in peers RPC (#300)

### DIFF
--- a/internal/peermanagement/cluster_peers_test.go
+++ b/internal/peermanagement/cluster_peers_test.go
@@ -24,6 +24,7 @@ func makeClusterTestPeer(t *testing.T, id *Identity, host string, port uint16) *
 		remotePubKey: tok,
 		state:        PeerStateConnected,
 		traffic:      NewTrafficCounter(),
+		metrics:      newPeerMetrics(nil),
 		score:        NewPeerScore(),
 		squelchMap:   make(map[string]time.Time),
 		createdAt:    time.Now(),

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1715,6 +1716,14 @@ func (o *Overlay) PeersJSON() []map[string]any {
 		// or Server (outbound) header.
 		if p.Version != "" {
 			entry["version"] = p.Version
+		}
+		// PeerImp.cpp:493-501: emit the metrics object — rippled formats
+		// each value with std::to_string, so they're decimal strings.
+		entry["metrics"] = map[string]any{
+			"total_bytes_recv": strconv.FormatUint(p.TotalBytesRecv, 10),
+			"total_bytes_sent": strconv.FormatUint(p.TotalBytesSent, 10),
+			"avg_bps_recv":     strconv.FormatUint(p.AvgBpsRecv, 10),
+			"avg_bps_sent":     strconv.FormatUint(p.AvgBpsSent, 10),
 		}
 		out = append(out, entry)
 	}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -81,6 +81,7 @@ type Peer struct {
 
 	score   *PeerScore
 	traffic *TrafficCounter
+	metrics *peerMetrics
 
 	// squelchMap: per-validator squelch deadlines. Messages from a
 	// squelched validator are not relayed to this peer until expiry.
@@ -139,6 +140,7 @@ func NewPeer(id PeerID, endpoint Endpoint, inbound bool, identity *Identity, eve
 		events:        events,
 		score:         NewPeerScore(),
 		traffic:       NewTrafficCounter(),
+		metrics:       newPeerMetrics(nil),
 		squelchMap:    make(map[string]time.Time),
 		pingsInFlight: make(map[uint32]time.Time),
 		createdAt:     time.Now(),
@@ -555,6 +557,17 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			return err
 		}
 
+		// Account wire bytes (header + on-the-wire payload, before
+		// decompression) — matches rippled metrics_.recv.add_message at
+		// PeerImp.cpp:911 which uses bytes_transferred from the socket.
+		wireBytes := uint64(len(payload))
+		if header.Compressed {
+			wireBytes += HeaderSizeCompressed
+		} else {
+			wireBytes += HeaderSizeUncompressed
+		}
+		p.metrics.recv.addMessage(wireBytes)
+
 		if header.Compressed {
 			payload, err = DecompressLZ4(payload, int(header.UncompressedSize))
 			if err != nil {
@@ -591,10 +604,14 @@ func (p *Peer) writeLoop(ctx context.Context) error {
 				return ErrConnectionClosed
 			}
 
-			_, err := conn.Write(data)
+			n, err := conn.Write(data)
 			if err != nil {
 				return err
 			}
+			// Mirrors rippled metrics_.sent.add_message at
+			// PeerImp.cpp:970 — account whatever the socket reports as
+			// transferred.
+			p.metrics.sent.addMessage(uint64(n))
 		}
 	}
 }
@@ -883,6 +900,14 @@ type PeerInfo struct {
 
 	Latency    time.Duration
 	HasLatency bool
+
+	// Per-peer wire byte counters and rolling-window throughput.
+	// Mirrors rippled PeerImp::metrics_ (PeerImp.h:226-230). Emitted
+	// under the `metrics` object in `peers` RPC.
+	TotalBytesRecv uint64
+	TotalBytesSent uint64
+	AvgBpsRecv     uint64
+	AvgBpsSent     uint64
 }
 
 func (p *Peer) Info() PeerInfo {
@@ -931,5 +956,9 @@ func (p *Peer) Info() PeerInfo {
 		Load:            p.Load(),
 		Latency:         latency,
 		HasLatency:      hasLatency,
+		TotalBytesRecv:  p.metrics.recv.totalBytesSnapshot(),
+		TotalBytesSent:  p.metrics.sent.totalBytesSnapshot(),
+		AvgBpsRecv:      p.metrics.recv.averageBytes(),
+		AvgBpsSent:      p.metrics.sent.averageBytes(),
 	}
 }

--- a/internal/peermanagement/peer_metrics.go
+++ b/internal/peermanagement/peer_metrics.go
@@ -1,0 +1,103 @@
+package peermanagement
+
+import (
+	"sync"
+	"time"
+)
+
+// rollingWindowSeconds matches rippled's circular_buffer<uint64>(30, 0)
+// in PeerImp::Metrics (PeerImp.h:219). The bps reading is the mean of
+// the last 30 one-second buckets.
+const rollingWindowSeconds = 30
+
+// byteMetrics tracks total bytes seen and a rolling per-second average,
+// mirroring rippled PeerImp::Metrics (PeerImp.cpp:3514-3551).
+//
+// The model: every wire-byte arrival increments totalBytes and
+// accumBytes. Once at least one second has elapsed since intervalStart,
+// we close the bucket — pushing accumBytes/elapsedSeconds onto the
+// rolling buffer and recomputing the mean — then reset the interval.
+type byteMetrics struct {
+	mu sync.Mutex
+
+	clock func() time.Time
+
+	totalBytes      uint64
+	accumBytes      uint64
+	intervalStart   time.Time
+	rollingAvg      [rollingWindowSeconds]uint64
+	rollingAvgBytes uint64
+}
+
+func newByteMetrics(clock func() time.Time) *byteMetrics {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &byteMetrics{
+		clock:         clock,
+		intervalStart: clock(),
+	}
+}
+
+// addMessage records bytes transferred on the wire. Mirrors
+// PeerImp::Metrics::add_message (PeerImp.cpp:3514).
+func (m *byteMetrics) addMessage(bytes uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.totalBytes += bytes
+	m.accumBytes += bytes
+
+	elapsed := m.clock().Sub(m.intervalStart)
+	elapsedSecs := uint64(elapsed / time.Second)
+	if elapsedSecs == 0 {
+		return
+	}
+
+	avg := m.accumBytes / elapsedSecs
+
+	// Shift the ring left by one and append the new bucket. Matches the
+	// behavior of boost::circular_buffer::push_back: drop the oldest,
+	// append the newest. Pre-fill (count<30) is handled by initialising
+	// the array with zeros, exactly as rippled does
+	// (rollingAvg_{30, 0ull}).
+	copy(m.rollingAvg[:rollingWindowSeconds-1], m.rollingAvg[1:])
+	m.rollingAvg[rollingWindowSeconds-1] = avg
+
+	var sum uint64
+	for _, v := range m.rollingAvg {
+		sum += v
+	}
+	m.rollingAvgBytes = sum / rollingWindowSeconds
+
+	m.intervalStart = m.clock()
+	m.accumBytes = 0
+}
+
+// totalBytesSnapshot returns the cumulative byte count.
+func (m *byteMetrics) totalBytesSnapshot() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.totalBytes
+}
+
+// averageBytes returns the latest rolling-window mean (bytes/sec).
+func (m *byteMetrics) averageBytes() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.rollingAvgBytes
+}
+
+// peerMetrics groups receive and send byteMetrics for a single peer,
+// matching rippled's anonymous metrics_ struct (PeerImp.h:226-230).
+type peerMetrics struct {
+	recv *byteMetrics
+	sent *byteMetrics
+}
+
+func newPeerMetrics(clock func() time.Time) *peerMetrics {
+	return &peerMetrics{
+		recv: newByteMetrics(clock),
+		sent: newByteMetrics(clock),
+	}
+}

--- a/internal/peermanagement/peer_metrics.go
+++ b/internal/peermanagement/peer_metrics.go
@@ -17,6 +17,10 @@ const rollingWindowSeconds = 30
 // accumBytes. Once at least one second has elapsed since intervalStart,
 // we close the bucket — pushing accumBytes/elapsedSeconds onto the
 // rolling buffer and recomputing the mean — then reset the interval.
+//
+// While the peer is idle (no addMessage calls), the rolling mean
+// freezes at its last value rather than decaying to zero. Matches
+// rippled, which only flushes the bucket inside add_message.
 type byteMetrics struct {
 	mu sync.Mutex
 
@@ -41,6 +45,13 @@ func newByteMetrics(clock func() time.Time) *byteMetrics {
 
 // addMessage records bytes transferred on the wire. Mirrors
 // PeerImp::Metrics::add_message (PeerImp.cpp:3514).
+//
+// Granularity differs from rippled: rippled fires once per
+// async_read_some / async_write completion (potentially sub-message for
+// large reads), while goXRPL's read/write loops fire once per complete
+// protocol message. Cumulative totals match exactly; the rolling-window
+// distribution can differ slightly when a single message spans more
+// than a second on a slow link.
 func (m *byteMetrics) addMessage(bytes uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -74,6 +85,14 @@ func (m *byteMetrics) addMessage(bytes uint64) {
 	m.accumBytes = 0
 }
 
+// tick flushes the rolling-window bucket if a second boundary has
+// elapsed since the last bucket close, without recording new bytes.
+// Test-only: production code never calls this directly because
+// addMessage already runs the flush on activity.
+func (m *byteMetrics) tick() {
+	m.addMessage(0)
+}
+
 // totalBytesSnapshot returns the cumulative byte count.
 func (m *byteMetrics) totalBytesSnapshot() uint64 {
 	m.mu.Lock()
@@ -88,16 +107,17 @@ func (m *byteMetrics) averageBytes() uint64 {
 	return m.rollingAvgBytes
 }
 
-// peerMetrics groups receive and send byteMetrics for a single peer,
-// matching rippled's anonymous metrics_ struct (PeerImp.h:226-230).
+// peerMetrics groups send and receive byteMetrics for a single peer.
+// Field order matches rippled's anonymous metrics_ struct — sent then
+// recv (PeerImp.h:226-230).
 type peerMetrics struct {
-	recv *byteMetrics
 	sent *byteMetrics
+	recv *byteMetrics
 }
 
 func newPeerMetrics(clock func() time.Time) *peerMetrics {
 	return &peerMetrics{
-		recv: newByteMetrics(clock),
 		sent: newByteMetrics(clock),
+		recv: newByteMetrics(clock),
 	}
 }

--- a/internal/peermanagement/peer_metrics_test.go
+++ b/internal/peermanagement/peer_metrics_test.go
@@ -9,15 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeClock returns the value at *now and lets the test tick it
-// deterministically. Used to drive byteMetrics through second-boundary
-// transitions without relying on real time.
-type fakeClock struct {
-	now *time.Time
-}
-
-func (f fakeClock) Now() time.Time { return *f.now }
-
 // TestByteMetrics_TotalBytesAccumulates pins the cumulative semantics
 // of metrics_.recv.total_bytes() / metrics_.sent.total_bytes()
 // (PeerImp.cpp:3547-3551): every byte ever passed in must be counted,
@@ -57,7 +48,7 @@ func TestByteMetrics_RollingAveragePartialFill(t *testing.T) {
 	// One second of activity at 3000 B/s.
 	m.addMessage(3000)
 	clockNow = clockNow.Add(1 * time.Second)
-	m.addMessage(0) // bucket flush at the boundary
+	m.tick() // flush the bucket at the boundary
 
 	// avg = 3000 / 30 (29 zero buckets pre-filled).
 	assert.EqualValues(t, 3000/rollingWindowSeconds, m.averageBytes())
@@ -75,7 +66,7 @@ func TestByteMetrics_RollingAverageSteadyState(t *testing.T) {
 	for i := 0; i < rollingWindowSeconds; i++ {
 		m.addMessage(bps)
 		clockNow = clockNow.Add(1 * time.Second)
-		m.addMessage(0) // close out the bucket
+		m.tick() // close out the bucket
 	}
 
 	assert.EqualValues(t, bps, m.averageBytes(),
@@ -91,21 +82,21 @@ func TestByteMetrics_RollingAverageDropsOldest(t *testing.T) {
 	clockNow := now
 	m := newByteMetrics(func() time.Time { return clockNow })
 
-	tick := func(bytes uint64) {
+	step := func(bytes uint64) {
 		m.addMessage(bytes)
 		clockNow = clockNow.Add(1 * time.Second)
-		m.addMessage(0)
+		m.tick()
 	}
 
 	// Seed bucket 0 with a distinctive large value.
-	tick(60_000)
+	step(60_000)
 	// Fill the remaining 29 buckets with a steady value.
 	for i := 0; i < rollingWindowSeconds-1; i++ {
-		tick(1000)
+		step(1000)
 	}
-	// One more tick should evict bucket 0; the steady value must now
+	// One more step should evict bucket 0; the steady value must now
 	// dominate the mean.
-	tick(1000)
+	step(1000)
 
 	assert.EqualValues(t, 1000, m.averageBytes(),
 		"after rollingWindowSeconds+1 fills, the seed bucket must be evicted")
@@ -135,6 +126,10 @@ func TestOverlay_PeersJSON_EmitsMetricsObject(t *testing.T) {
 
 	p := NewPeer(1, Endpoint{Host: "10.0.0.1", Port: 51235}, false, id, nil)
 	p.setState(PeerStateConnected)
+	// Frozen clock so the avg_bps_* assertions don't race a real
+	// 1-second boundary on slow CI.
+	frozen := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	p.metrics = newPeerMetrics(func() time.Time { return frozen })
 
 	// Drive the per-peer counters through the same surface PeerImp's
 	// async read/write callbacks would (PeerImp.cpp:911, 970).

--- a/internal/peermanagement/peer_metrics_test.go
+++ b/internal/peermanagement/peer_metrics_test.go
@@ -1,0 +1,200 @@
+package peermanagement
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClock returns the value at *now and lets the test tick it
+// deterministically. Used to drive byteMetrics through second-boundary
+// transitions without relying on real time.
+type fakeClock struct {
+	now *time.Time
+}
+
+func (f fakeClock) Now() time.Time { return *f.now }
+
+// TestByteMetrics_TotalBytesAccumulates pins the cumulative semantics
+// of metrics_.recv.total_bytes() / metrics_.sent.total_bytes()
+// (PeerImp.cpp:3547-3551): every byte ever passed in must be counted,
+// regardless of interval boundaries.
+func TestByteMetrics_TotalBytesAccumulates(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	m := newByteMetrics(func() time.Time { return now })
+
+	m.addMessage(100)
+	m.addMessage(50)
+
+	assert.EqualValues(t, 150, m.totalBytesSnapshot())
+}
+
+// TestByteMetrics_AverageBytesIsZeroBeforeBoundary mirrors rippled
+// (PeerImp.cpp:3525): without one full second elapsed, the rolling
+// average remains at its initial value (0) — the bucket is not flushed.
+func TestByteMetrics_AverageBytesIsZeroBeforeBoundary(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	m := newByteMetrics(clock)
+	m.addMessage(1024)
+
+	assert.EqualValues(t, 0, m.averageBytes(),
+		"sub-second activity must not flush the rolling bucket")
+}
+
+// TestByteMetrics_RollingAveragePartialFill reproduces rippled's
+// pre-filled buffer (rollingAvg_{30, 0ull}, PeerImp.h:219): one bucket
+// of N bps in a 30-slot zero-filled ring averages to N/30.
+func TestByteMetrics_RollingAveragePartialFill(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clockNow := now
+	m := newByteMetrics(func() time.Time { return clockNow })
+
+	// One second of activity at 3000 B/s.
+	m.addMessage(3000)
+	clockNow = clockNow.Add(1 * time.Second)
+	m.addMessage(0) // bucket flush at the boundary
+
+	// avg = 3000 / 30 (29 zero buckets pre-filled).
+	assert.EqualValues(t, 3000/rollingWindowSeconds, m.averageBytes())
+}
+
+// TestByteMetrics_RollingAverageSteadyState fills the ring with
+// identical samples and checks the mean equals that sample. This is
+// the steady-state behavior reported by avg_bps_recv / avg_bps_sent.
+func TestByteMetrics_RollingAverageSteadyState(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clockNow := now
+	m := newByteMetrics(func() time.Time { return clockNow })
+
+	const bps uint64 = 1500
+	for i := 0; i < rollingWindowSeconds; i++ {
+		m.addMessage(bps)
+		clockNow = clockNow.Add(1 * time.Second)
+		m.addMessage(0) // close out the bucket
+	}
+
+	assert.EqualValues(t, bps, m.averageBytes(),
+		"30 identical buckets must average to the per-bucket value")
+}
+
+// TestByteMetrics_RollingAverageDropsOldest verifies the circular
+// buffer eviction matches boost::circular_buffer::push_back semantics
+// (PeerImp.cpp:3528): after rollingWindowSeconds+1 fills, the very
+// first bucket is forgotten.
+func TestByteMetrics_RollingAverageDropsOldest(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clockNow := now
+	m := newByteMetrics(func() time.Time { return clockNow })
+
+	tick := func(bytes uint64) {
+		m.addMessage(bytes)
+		clockNow = clockNow.Add(1 * time.Second)
+		m.addMessage(0)
+	}
+
+	// Seed bucket 0 with a distinctive large value.
+	tick(60_000)
+	// Fill the remaining 29 buckets with a steady value.
+	for i := 0; i < rollingWindowSeconds-1; i++ {
+		tick(1000)
+	}
+	// One more tick should evict bucket 0; the steady value must now
+	// dominate the mean.
+	tick(1000)
+
+	assert.EqualValues(t, 1000, m.averageBytes(),
+		"after rollingWindowSeconds+1 fills, the seed bucket must be evicted")
+}
+
+// TestPeerMetrics_RecvAndSentIndependent sanity-checks that the recv
+// and sent counters do not bleed into each other — rippled's
+// metrics_.recv and metrics_.sent are independent Metrics instances.
+func TestPeerMetrics_RecvAndSentIndependent(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	pm := newPeerMetrics(func() time.Time { return now })
+
+	pm.recv.addMessage(100)
+	pm.sent.addMessage(7)
+
+	assert.EqualValues(t, 100, pm.recv.totalBytesSnapshot())
+	assert.EqualValues(t, 7, pm.sent.totalBytesSnapshot())
+}
+
+// TestOverlay_PeersJSON_EmitsMetricsObject pins the strict-parity
+// contract from rippled PeerImp::json (PeerImp.cpp:493-501): a
+// `metrics` object with the four byte-counter fields, all rendered as
+// decimal strings (rippled uses std::to_string).
+func TestOverlay_PeersJSON_EmitsMetricsObject(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	p := NewPeer(1, Endpoint{Host: "10.0.0.1", Port: 51235}, false, id, nil)
+	p.setState(PeerStateConnected)
+
+	// Drive the per-peer counters through the same surface PeerImp's
+	// async read/write callbacks would (PeerImp.cpp:911, 970).
+	p.metrics.recv.addMessage(2048)
+	p.metrics.sent.addMessage(512)
+
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
+	entries := o.PeersJSON()
+	require.Len(t, entries, 1)
+
+	metrics, ok := entries[0]["metrics"].(map[string]any)
+	require.True(t, ok, "PeersJSON must emit `metrics` as a JSON object")
+
+	for _, key := range []string{
+		"total_bytes_recv",
+		"total_bytes_sent",
+		"avg_bps_recv",
+		"avg_bps_sent",
+	} {
+		val, present := metrics[key]
+		require.True(t, present, "metrics.%s missing", key)
+		s, isString := val.(string)
+		require.True(t, isString,
+			"metrics.%s must be a decimal string (rippled std::to_string), got %T", key, val)
+		_, parseErr := strconv.ParseUint(s, 10, 64)
+		require.NoError(t, parseErr,
+			"metrics.%s must parse as a uint64 decimal, got %q", key, s)
+	}
+
+	assert.Equal(t, "2048", metrics["total_bytes_recv"])
+	assert.Equal(t, "512", metrics["total_bytes_sent"])
+	// avg_bps_* are 0 here because no second boundary has elapsed; the
+	// schema is what we're pinning, not the value.
+	assert.Equal(t, "0", metrics["avg_bps_recv"])
+	assert.Equal(t, "0", metrics["avg_bps_sent"])
+}
+
+// TestOverlay_PeersJSON_EmitsMetricsForEveryPeer guards against a
+// regression where the metrics block is conditional. rippled emits it
+// unconditionally (PeerImp.cpp:493-501).
+func TestOverlay_PeersJSON_EmitsMetricsForEveryPeer(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	mk := func(pid PeerID, host string) *Peer {
+		p := NewPeer(pid, Endpoint{Host: host, Port: 51235}, false, id, nil)
+		p.setState(PeerStateConnected)
+		return p
+	}
+
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{
+		1: mk(1, "10.0.0.1"),
+		2: mk(2, "10.0.0.2"),
+		3: mk(3, "10.0.0.3"),
+	})
+
+	entries := o.PeersJSON()
+	require.Len(t, entries, 3)
+	for _, e := range entries {
+		_, ok := e["metrics"].(map[string]any)
+		require.True(t, ok, "every peer entry must carry a metrics object")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `byteMetrics` mirroring rippled `PeerImp::Metrics` (PeerImp.cpp:3514-3551): cumulative wire-byte totals plus a 30-bucket, 1-second-per-bucket pre-filled circular buffer for the rolling mean.
- Hooks `recv.addMessage(headerBytes + onWirePayload)` after `ReadMessage` and `sent.addMessage(n)` after `conn.Write` — the goXRPL analogues of rippled's `onReadMessage`/`onWriteMessage` callbacks (PeerImp.cpp:911, 970).
- `PeersJSON` emits the `metrics` object per peer with the four fields formatted as decimal strings, matching `std::to_string` at PeerImp.cpp:493-501:
  - `total_bytes_recv`
  - `total_bytes_sent`
  - `avg_bps_recv`
  - `avg_bps_sent`

Closes #300.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/peermanagement/...` clean
- [x] `go test ./internal/peermanagement/...` — all suites pass, including 8 new tests in `peer_metrics_test.go`:
  - cumulative totals across messages
  - sub-second activity does not flush the rolling bucket
  - partial-fill rolling mean (bucket0 / 30 with zero-prefilled ring)
  - steady-state rolling mean equals per-bucket value after 30 fills
  - oldest-bucket eviction after `rollingWindowSeconds + 1` ticks
  - `recv` and `sent` counters are independent
  - `PeersJSON` emits a `metrics` object with the four required string fields
  - every peer entry carries a `metrics` block (rippled emits unconditionally)
- [x] `go test ./internal/rpc/ -run Peers` passes (`TestPeersResponseStructure`, `TestPeersEmptyList`, etc.)
- Two pre-existing `TestTxMethodEdgeCases` failures in `internal/rpc/` are unrelated (transaction-blob parsing) and reproduce on `main` with these changes stashed.