### PR TITLE
refactor(tx): flatten validation nesting with early-return helpers

### DIFF
--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -308,28 +308,15 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled SetAccount.cpp preclaim() lines 281-307
 	if ctx.Rules().Enabled(amendment.FeatureClawback) {
 		if uSetFlag == AccountSetFlagAllowTrustLineClawback {
-			// Cannot set clawback if NoFreeze is already set
-			if (uFlagsIn & state.LsfNoFreeze) != 0 {
+			if uFlagsIn&state.LsfNoFreeze != 0 {
 				return tx.TecNO_PERMISSION
 			}
-			// Owner directory must be empty
-			ownerDirKey := keylet.OwnerDir(ctx.AccountID)
-			dirExists, dirErr := ctx.View.Exists(ownerDirKey)
-			if dirErr == nil && dirExists {
-				dirData, readErr := ctx.View.Read(ownerDirKey)
-				if readErr == nil {
-					dirNode, parseErr := state.ParseDirectoryNode(dirData)
-					if parseErr == nil && len(dirNode.Indexes) > 0 {
-						return tx.TecOWNERS
-					}
-				}
+			if !ownerDirIsEmpty(ctx.View, ctx.AccountID) {
+				return tx.TecOWNERS
 			}
 		}
-		if uSetFlag == AccountSetFlagNoFreeze {
-			// Cannot set NoFreeze if clawback is already set
-			if (uFlagsIn & state.LsfAllowTrustLineClawback) != 0 {
-				return tx.TecNO_PERMISSION
-			}
+		if uSetFlag == AccountSetFlagNoFreeze && uFlagsIn&state.LsfAllowTrustLineClawback != 0 {
+			return tx.TecNO_PERMISSION
 		}
 	}
 
@@ -344,17 +331,8 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	bSetRequireAuth := (a.GetFlags()&AccountSetTxFlagRequireAuth != 0) ||
 		uSetFlag == AccountSetFlagRequireAuth
 	if bSetRequireAuth && (uFlagsIn&state.LsfRequireAuth) == 0 {
-		// Owner directory must be empty to set RequireAuth
-		ownerDirKey := keylet.OwnerDir(ctx.AccountID)
-		dirExists, dirErr := ctx.View.Exists(ownerDirKey)
-		if dirErr == nil && dirExists {
-			dirData, readErr := ctx.View.Read(ownerDirKey)
-			if readErr == nil {
-				dirNode, parseErr := state.ParseDirectoryNode(dirData)
-				if parseErr == nil && len(dirNode.Indexes) > 0 {
-					return tx.TecOWNERS
-				}
-			}
+		if !ownerDirIsEmpty(ctx.View, ctx.AccountID) {
+			return tx.TecOWNERS
 		}
 		uFlagsOut |= state.LsfRequireAuth
 	}
@@ -578,4 +556,24 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	return tx.TesSUCCESS
+}
+
+// ownerDirIsEmpty reports whether the account's owner directory has no
+// entries. Missing, unreadable, or unparseable directories are treated as
+// empty — matching rippled's dirIsEmpty semantics.
+func ownerDirIsEmpty(view tx.LedgerView, accountID [20]byte) bool {
+	key := keylet.OwnerDir(accountID)
+	exists, err := view.Exists(key)
+	if err != nil || !exists {
+		return true
+	}
+	data, err := view.Read(key)
+	if err != nil {
+		return true
+	}
+	dirNode, err := state.ParseDirectoryNode(data)
+	if err != nil {
+		return true
+	}
+	return len(dirNode.Indexes) == 0
 }

--- a/internal/tx/check/check_create.go
+++ b/internal/tx/check/check_create.go
@@ -151,56 +151,18 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 
 		accountID := ctx.AccountID
 
-		// Check source trust line freeze (if source is not issuer)
+		// Check source trust line freeze (if source is not issuer): the issuer's
+		// freeze of the source side blocks the source from sending.
 		// Reference: CreateCheck.cpp L131-145
-		if accountID != issuerID {
-			srcTLKey := keylet.Line(accountID, issuerID, c.SendMax.Currency)
-			srcTLExists, _ := ctx.View.Exists(srcTLKey)
-			if srcTLExists {
-				srcTLData, err := ctx.View.Read(srcTLKey)
-				if err == nil {
-					srcTL, err := state.ParseRippleState(srcTLData)
-					if err == nil {
-						srcIsLow := keylet.IsLowAccount(accountID, issuerID)
-						if srcIsLow {
-							if srcTL.Flags&state.LsfHighFreeze != 0 {
-								return tx.TecFROZEN
-							}
-						} else {
-							if srcTL.Flags&state.LsfLowFreeze != 0 {
-								return tx.TecFROZEN
-							}
-						}
-					}
-				}
-			}
+		if isTrustLineFrozenByCounterparty(ctx.View, accountID, issuerID, c.SendMax.Currency) {
+			return tx.TecFROZEN
 		}
 
-		// Check destination trust line freeze (if dest is not issuer)
-		// For destination, check if DESTINATION froze their own line (not issuer freeze)
+		// Check destination trust line freeze (if dest is not issuer): check if
+		// the destination froze their own side (not issuer freeze).
 		// Reference: CreateCheck.cpp L146-159
-		if destID != issuerID {
-			dstTLKey := keylet.Line(destID, issuerID, c.SendMax.Currency)
-			dstTLExists, _ := ctx.View.Exists(dstTLKey)
-			if dstTLExists {
-				dstTLData, err := ctx.View.Read(dstTLKey)
-				if err == nil {
-					dstTL, err := state.ParseRippleState(dstTLData)
-					if err == nil {
-						dstIsLow := keylet.IsLowAccount(destID, issuerID)
-						// Check if the destination froze their own side
-						if dstIsLow {
-							if dstTL.Flags&state.LsfLowFreeze != 0 {
-								return tx.TecFROZEN
-							}
-						} else {
-							if dstTL.Flags&state.LsfHighFreeze != 0 {
-								return tx.TecFROZEN
-							}
-						}
-					}
-				}
-			}
+		if isTrustLineFrozenBySelf(ctx.View, destID, issuerID, c.SendMax.Currency) {
+			return tx.TecFROZEN
 		}
 	}
 
@@ -281,4 +243,58 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	ctx.Account.OwnerCount++
 
 	return tx.TesSUCCESS
+}
+
+// isTrustLineFrozenByCounterparty reports whether the trust line between
+// account and issuer is frozen on the counterparty's (issuer's) side. Returns
+// false when account == issuer, the line does not exist, or the line cannot be
+// read or parsed (matching the silent-skip behavior of rippled's CreateCheck).
+func isTrustLineFrozenByCounterparty(view tx.LedgerView, accountID, issuerID [20]byte, currency string) bool {
+	if accountID == issuerID {
+		return false
+	}
+	tl, ok := readRippleState(view, accountID, issuerID, currency)
+	if !ok {
+		return false
+	}
+	freezeFlag := uint32(state.LsfHighFreeze)
+	if !keylet.IsLowAccount(accountID, issuerID) {
+		freezeFlag = state.LsfLowFreeze
+	}
+	return tl.Flags&freezeFlag != 0
+}
+
+// isTrustLineFrozenBySelf reports whether the trust line between account and
+// issuer is frozen on the account's own side. Returns false when account ==
+// issuer, the line does not exist, or the line cannot be read or parsed.
+func isTrustLineFrozenBySelf(view tx.LedgerView, accountID, issuerID [20]byte, currency string) bool {
+	if accountID == issuerID {
+		return false
+	}
+	tl, ok := readRippleState(view, accountID, issuerID, currency)
+	if !ok {
+		return false
+	}
+	freezeFlag := uint32(state.LsfLowFreeze)
+	if !keylet.IsLowAccount(accountID, issuerID) {
+		freezeFlag = state.LsfHighFreeze
+	}
+	return tl.Flags&freezeFlag != 0
+}
+
+func readRippleState(view tx.LedgerView, accountID, issuerID [20]byte, currency string) (*state.RippleState, bool) {
+	key := keylet.Line(accountID, issuerID, currency)
+	exists, _ := view.Exists(key)
+	if !exists {
+		return nil, false
+	}
+	data, err := view.Read(key)
+	if err != nil {
+		return nil, false
+	}
+	tl, err := state.ParseRippleState(data)
+	if err != nil {
+		return nil, false
+	}
+	return tl, true
 }


### PR DESCRIPTION
## Summary
- CheckCreate IOU freeze checks (5+ levels deep) collapse to one-line guards backed by `isTrustLineFrozenByCounterparty` / `isTrustLineFrozenBySelf`, sharing a `readRippleState` helper.
- AccountSet clawback preclaim and the duplicate RequireAuth block (4-deep around the same owner-directory probe) reduce to single-line guards via a new `ownerDirIsEmpty` helper that preserves rippled's silent-skip semantics for missing/unreadable directories.
- Behavior unchanged; only nesting depth and duplication.

Closes #198.

## Test plan
- [x] `go build ./internal/tx/check/... ./internal/tx/account/...`
- [x] `go vet` & `gofmt` clean on changed files
- [x] `TestCheck_CreateInvalid/{GloballyFrozenAsset,FrozenTrustLine}` pass
- [x] `TestAccountSet_RequireAuth`, `TestAccountSet_SetNoFreeze` pass
- [x] `TestClawback_AllowTrustLineClawbackFlag/*` pass (set, NoFreeze conflict, non-empty owner dir, amendment-disabled)
- [x] Full `internal/tx/...` failure set diffed against base `cdc8d58` — identical, all pre-existing & unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)