### PR TITLE
fix(tx/account): consult IndexNext in ownerDirIsEmpty

### DIFF
--- a/internal/testing/accountset/accountset_test.go
+++ b/internal/testing/accountset/accountset_test.go
@@ -647,3 +647,50 @@ func TestAccountSet_Ticket(t *testing.T) {
 	env.Close()
 	jtx.RequireTxFail(t, result, "tefNO_TICKET")
 }
+
+// TestAccountSet_DirIsEmpty_AnchorEmptyWithContinuation guards rippled's
+// dirIsEmpty() semantics: the anchor (root) page may have an empty Indexes
+// slice while continuation pages still hold entries. In that case the
+// directory is NOT empty and asfRequireAuth / asfAllowTrustLineClawback must
+// be rejected with tecOWNERS.
+//
+// Reference: rippled View.cpp dirIsEmpty (lines 905-911) and
+// SetAccount.cpp preclaim() lines 269-307.
+func TestAccountSet_DirIsEmpty_AnchorEmptyWithContinuation(t *testing.T) {
+	t.Run("RequireAuth", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice)
+		env.Fund(bob)
+		env.Close()
+
+		// Seed the anchor page so it exists, then force it to look empty
+		// while IndexNext points at a (fictitious) continuation page.
+		// ownerDirIsEmpty must consult IndexNext and report the directory
+		// as non-empty.
+		env.SetSignerList(alice, 1, []jtx.TestSigner{{Account: bob, Weight: 1}})
+		env.Close()
+		require.NoError(t, env.ForceOwnerDirEmptyAnchorWithNext(alice, 1))
+
+		result := env.Submit(AccountSet(alice).
+			SetFlag(accounttx.AccountSetFlagRequireAuth).Build())
+		jtx.RequireTxFail(t, result, "tecOWNERS")
+	})
+
+	t.Run("AllowTrustLineClawback", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice)
+		env.Fund(bob)
+		env.Close()
+
+		env.SetSignerList(alice, 1, []jtx.TestSigner{{Account: bob, Weight: 1}})
+		env.Close()
+		require.NoError(t, env.ForceOwnerDirEmptyAnchorWithNext(alice, 1))
+
+		result := env.Submit(AccountSet(alice).AllowClawback().Build())
+		jtx.RequireTxFail(t, result, "tecOWNERS")
+	})
+}

--- a/internal/testing/env_directory.go
+++ b/internal/testing/env_directory.go
@@ -166,3 +166,39 @@ func updateUint64Field(data []byte, fieldName string, value uint64) ([]byte, err
 	}
 	return result, nil
 }
+
+// ForceOwnerDirEmptyAnchorWithNext rewrites the anchor (root) page of an
+// account's owner directory to have an empty Indexes slice while leaving
+// IndexNext pointing at a non-zero continuation page. This reproduces the
+// state rippled's dirIsEmpty must guard against: an emptied anchor whose
+// directory is still non-empty because subsequent pages remain.
+//
+// Reference: rippled View.cpp dirIsEmpty().
+func (e *TestEnv) ForceOwnerDirEmptyAnchorWithNext(acc *Account, nextPage uint64) error {
+	e.t.Helper()
+	if nextPage == 0 {
+		return fmt.Errorf("nextPage must be non-zero")
+	}
+
+	dirRootKey := keylet.OwnerDir(acc.ID)
+	rootData, err := e.ledger.Read(dirRootKey)
+	if err != nil || rootData == nil {
+		return fmt.Errorf("directory root not found")
+	}
+	root, err := state.ParseDirectoryNode(rootData)
+	if err != nil {
+		return fmt.Errorf("failed to parse root: %v", err)
+	}
+
+	root.Indexes = nil
+	root.IndexNext = nextPage
+
+	updated, err := state.SerializeDirectoryNode(root, false)
+	if err != nil {
+		return fmt.Errorf("failed to serialize root: %v", err)
+	}
+	if err := e.ledger.Update(dirRootKey, updated); err != nil {
+		return fmt.Errorf("failed to update root: %v", err)
+	}
+	return nil
+}

--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -561,6 +561,12 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 // ownerDirIsEmpty reports whether the account's owner directory has no
 // entries. Missing, unreadable, or unparseable directories are treated as
 // empty — matching rippled's dirIsEmpty semantics.
+//
+// An anchor (root) page may be empty of indexes while subsequent pages
+// still hold entries; in that case IndexNext is non-zero and the directory
+// is not empty.
+//
+// Reference: rippled View.cpp dirIsEmpty (lines 905-911).
 func ownerDirIsEmpty(view tx.LedgerView, accountID [20]byte) bool {
 	key := keylet.OwnerDir(accountID)
 	exists, err := view.Exists(key)
@@ -575,5 +581,8 @@ func ownerDirIsEmpty(view tx.LedgerView, accountID [20]byte) bool {
 	if err != nil {
 		return true
 	}
-	return len(dirNode.Indexes) == 0
+	if len(dirNode.Indexes) > 0 {
+		return false
+	}
+	return dirNode.IndexNext == 0
 }


### PR DESCRIPTION
## Summary
- `ownerDirIsEmpty` previously returned true whenever the anchor page's `Indexes` slice was empty, ignoring `IndexNext`. A directory whose anchor page had been emptied but still had continuation pages was reported empty, letting `asfRequireAuth` and `asfAllowTrustLineClawback` be set on accounts that still owned objects.
- Now mirrors rippled's `View.cpp:dirIsEmpty()` — non-empty `Indexes` → `false`; otherwise `IndexNext == 0`.
- Adds `TestAccountSet_DirIsEmpty_AnchorEmptyWithContinuation` and a `ForceOwnerDirEmptyAnchorWithNext` test helper that forces the buggy state and asserts both flags are rejected with `tecOWNERS`.

Closes #323.

## Test plan
- [x] New regression test fails before the fix (txns succeed) and passes after (`tecOWNERS`)
- [x] `go test ./internal/testing/accountset/` — passes (existing `TestAccountSet_RequireAuth` still green)
- [x] `go test ./internal/testing/clawback/...` — passes
- [x] `go vet ./internal/tx/account/... ./internal/testing/...` — clean
- [x] `go build ./...` — clean
- [x] Pre-existing failures on `main` (`TestAccountSet_MostFlags` flag 17, `TestAccountSetTickSize/tick_size_16`, `TestCheck_CancelInvalid/BadFee`) confirmed unrelated to this change