### PR TITLE
refactor(peermanagement): collapse applyStatusChange positional params into *message.StatusChange (#321)

### DIFF
--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1534,7 +1535,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("lost_sync_zeroes_both", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, true, nil, nil, 0)
+		p.applyStatusChange(&message.StatusChange{NewEvent: message.NodeEventLostSync})
 		_, hasC := p.ClosedLedger()
 		_, hasP := p.PreviousLedger()
 		assert.False(t, hasC)
@@ -1548,7 +1549,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 			newClosed[i] = byte(0xAA)
 			newParent[i] = byte(0xBB)
 		}
-		p.applyStatusChange(newClosed[:], newParent[:], false, nil, nil, 0)
+		p.applyStatusChange(&message.StatusChange{LedgerHash: newClosed[:], LedgerHashPrevious: newParent[:]})
 		gotC, hasC := p.ClosedLedger()
 		gotP, hasP := p.PreviousLedger()
 		assert.True(t, hasC)
@@ -1563,7 +1564,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 		for i := range newParent {
 			newParent[i] = byte(0xCC)
 		}
-		p.applyStatusChange(nil, newParent[:], false, nil, nil, 0)
+		p.applyStatusChange(&message.StatusChange{LedgerHashPrevious: newParent[:]})
 		_, hasC := p.ClosedLedger()
 		gotP, hasP := p.PreviousLedger()
 		assert.False(t, hasC)
@@ -1573,7 +1574,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("malformed_closed_zeroes_closed", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange([]byte{0x01, 0x02}, nil, false, nil, nil, 0) // 2 bytes ≠ 32
+		p.applyStatusChange(&message.StatusChange{LedgerHash: []byte{0x01, 0x02}}) // 2 bytes ≠ 32
 		_, hasC := p.ClosedLedger()
 		_, hasP := p.PreviousLedger()
 		assert.False(t, hasC)
@@ -1583,7 +1584,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 	// PeerImp.cpp:1874-1883 — ledger range update + clamp.
 	t.Run("ledger_range_valid_pair_stored", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(200)})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(100), minSeq)
 		assert.Equal(t, uint32(200), maxSeq)
@@ -1591,7 +1592,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("ledger_range_first_zero_clamped", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(0), u32(200), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(0), LastSeq: u32(200)})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(0), minSeq)
 		assert.Equal(t, uint32(0), maxSeq)
@@ -1599,7 +1600,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("ledger_range_last_zero_clamped", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(0), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(0)})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(0), minSeq)
 		assert.Equal(t, uint32(0), maxSeq)
@@ -1607,7 +1608,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("ledger_range_inverted_clamped", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(200), u32(100), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(200), LastSeq: u32(100)})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(0), minSeq)
 		assert.Equal(t, uint32(0), maxSeq)
@@ -1617,8 +1618,8 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 	// block, so the previously-advertised range must persist.
 	t.Run("ledger_range_lost_sync_preserves_range", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
-		p.applyStatusChange(nil, nil, true, nil, nil, 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(200)})
+		p.applyStatusChange(&message.StatusChange{NewEvent: message.NodeEventLostSync})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(100), minSeq)
 		assert.Equal(t, uint32(200), maxSeq)
@@ -1629,8 +1630,8 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 	// previously-stored range.
 	t.Run("ledger_range_absent_preserves_existing", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
-		p.applyStatusChange(nil, nil, false, nil, nil, 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(200)})
+		p.applyStatusChange(&message.StatusChange{})
 		minSeq, maxSeq := p.LedgerRange()
 		assert.Equal(t, uint32(100), minSeq)
 		assert.Equal(t, uint32(200), maxSeq)
@@ -1638,7 +1639,7 @@ func TestApplyStatusChange_RippledSemantics(t *testing.T) {
 
 	t.Run("info_complete_ledgers_formatted", func(t *testing.T) {
 		p := mk()
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(200)})
 		assert.Equal(t, "100 - 200", p.Info().CompleteLedgers,
 			"matches rippled PeerImp.cpp:434-435 format with surrounding spaces")
 	})
@@ -1877,7 +1878,7 @@ func TestPeersJSON_CompleteLedgers(t *testing.T) {
 
 	t.Run("emits_when_range_advertised", func(t *testing.T) {
 		p := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
-		p.applyStatusChange(nil, nil, false, u32(100), u32(200), 0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(100), LastSeq: u32(200)})
 
 		o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
 		entries := o.PeersJSON()
@@ -1896,7 +1897,7 @@ func TestPeersJSON_CompleteLedgers(t *testing.T) {
 
 	t.Run("absent_after_clamp_on_invalid_range", func(t *testing.T) {
 		p := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
-		p.applyStatusChange(nil, nil, false, u32(0), u32(200), 0) // first=0 → clamped to (0,0)
+		p.applyStatusChange(&message.StatusChange{FirstSeq: u32(0), LastSeq: u32(200)}) // first=0 → clamped to (0,0)
 
 		o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
 		entries := o.PeersJSON()

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1187,14 +1187,7 @@ func (o *Overlay) handleStatusChange(evt Event) {
 		sc.NetworkTime = uint64(time.Now().Unix() - rippleEpochUnix)
 	}
 
-	effectiveStatus := peer.applyStatusChange(
-		sc.LedgerHash,
-		sc.LedgerHashPrevious,
-		sc.NewEvent == message.NodeEventLostSync,
-		sc.FirstSeq,
-		sc.LastSeq,
-		sc.NewStatus,
-	)
+	effectiveStatus := peer.applyStatusChange(sc)
 
 	// PeerImp.cpp:1812-1830 — rippled's lostSync handling returns
 	// before either checkTracking or pubPeerStatus runs. Match that

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -251,7 +251,7 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 // additionally mutates the local `m` to carry the prior enum, so the
 // pubPeerStatus callback (which reads `m`, not last_status_) still sees
 // the inherited value once. We model the same split:
-//   - lastStatus is overwritten verbatim with the wire's newStatus (zero
+//   - lastStatus is overwritten verbatim with the wire's NewStatus (zero
 //     argument drops the prior value, matching rippled's `peers` RPC).
 //   - The returned effective status is the wire value when set, or the
 //     prior lastStatus otherwise — consumed by handleStatusChange's
@@ -260,44 +260,47 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 // The lostSync early-return runs after the lastStatus write, so a
 // lostSync update carrying a NewStatus still records it — but
 // handleStatusChange returns before any publish (PeerImp.cpp:1830).
-func (p *Peer) applyStatusChange(closed, previous []byte, lostSync bool, firstSeq, lastSeq *uint32, newStatus message.NodeStatus) message.NodeStatus {
+func (p *Peer) applyStatusChange(sc *message.StatusChange) message.NodeStatus {
+	if sc == nil {
+		return 0
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	effective := newStatus
-	if newStatus == 0 {
+	effective := sc.NewStatus
+	if sc.NewStatus == 0 {
 		effective = p.lastStatus
 	}
-	p.lastStatus = newStatus
-	if lostSync {
+	p.lastStatus = sc.NewStatus
+	if sc.NewEvent == message.NodeEventLostSync {
 		p.hasClosedLedger = false
 		p.hasPreviousLedger = false
 		p.closedLedger = [32]byte{}
 		p.previousLedger = [32]byte{}
 		return effective
 	}
-	if len(closed) == 32 {
-		copy(p.closedLedger[:], closed)
+	if len(sc.LedgerHash) == 32 {
+		copy(p.closedLedger[:], sc.LedgerHash)
 		p.hasClosedLedger = true
 	} else {
 		p.hasClosedLedger = false
 		p.closedLedger = [32]byte{}
 	}
-	if len(previous) == 32 {
-		copy(p.previousLedger[:], previous)
+	if len(sc.LedgerHashPrevious) == 32 {
+		copy(p.previousLedger[:], sc.LedgerHashPrevious)
 		p.hasPreviousLedger = true
 	} else {
 		p.hasPreviousLedger = false
 		p.previousLedger = [32]byte{}
 	}
-	if firstSeq == nil || lastSeq == nil {
+	if sc.FirstSeq == nil || sc.LastSeq == nil {
 		return effective
 	}
-	if *firstSeq == 0 || *lastSeq == 0 || *lastSeq < *firstSeq {
+	if *sc.FirstSeq == 0 || *sc.LastSeq == 0 || *sc.LastSeq < *sc.FirstSeq {
 		p.firstLedgerSeq = 0
 		p.lastLedgerSeq = 0
 	} else {
-		p.firstLedgerSeq = *firstSeq
-		p.lastLedgerSeq = *lastSeq
+		p.firstLedgerSeq = *sc.FirstSeq
+		p.lastLedgerSeq = *sc.LastSeq
 	}
 	return effective
 }

--- a/internal/peermanagement/peer_status_test.go
+++ b/internal/peermanagement/peer_status_test.go
@@ -35,7 +35,7 @@ func TestPeer_ApplyStatusChange_StoresNewStatus(t *testing.T) {
 	}
 	for _, ns := range cases {
 		p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
-		p.applyStatusChange(nil, nil, false, nil, nil, ns)
+		p.applyStatusChange(&message.StatusChange{NewStatus: ns})
 		assert.Equal(t, ns, p.LastStatus())
 		assert.Equal(t, ns, p.Info().Status)
 	}
@@ -53,16 +53,16 @@ func TestPeer_ApplyStatusChange_StatusRetention(t *testing.T) {
 	require.NoError(t, err)
 
 	p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
-	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusConnecting)
+	p.applyStatusChange(&message.StatusChange{NewStatus: message.NodeStatusConnecting})
 	require.Equal(t, message.NodeStatusConnecting, p.LastStatus())
 
-	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusValidating)
+	p.applyStatusChange(&message.StatusChange{NewStatus: message.NodeStatusValidating})
 	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
 
 	// PeerImp.cpp:1802 / 1807: `last_status_ = *m;` runs verbatim in
 	// both branches. m has no newstatus → stored last_status_.newstatus()
 	// becomes false, so subsequent `peers` RPC reads drop the field.
-	p.applyStatusChange(nil, nil, false, nil, nil, 0)
+	p.applyStatusChange(&message.StatusChange{})
 	assert.Equal(t, message.NodeStatus(0), p.LastStatus(),
 		"absent new_status must drop the prior stored value (rippled `last_status_ = *m;`)")
 }
@@ -80,20 +80,20 @@ func TestPeer_ApplyStatusChange_StatusInheritedToPublished(t *testing.T) {
 
 	p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
 
-	got := p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatusValidating)
+	got := p.applyStatusChange(&message.StatusChange{NewStatus: message.NodeStatusValidating})
 	assert.Equal(t, message.NodeStatusValidating, got, "wire-set status returned verbatim")
 	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
 
 	// status-less follow-up: published value inherits the prior enum,
 	// stored value is dropped.
-	got = p.applyStatusChange(nil, nil, false, nil, nil, 0)
+	got = p.applyStatusChange(&message.StatusChange{})
 	assert.Equal(t, message.NodeStatusValidating, got,
 		"absent new_status must inherit prior for pubPeerStatus (PeerImp.cpp:1808)")
 	assert.Equal(t, message.NodeStatus(0), p.LastStatus(),
 		"but stored last_status_ is dropped (PeerImp.cpp:1807)")
 
 	// second status-less message: nothing left to inherit.
-	got = p.applyStatusChange(nil, nil, false, nil, nil, 0)
+	got = p.applyStatusChange(&message.StatusChange{})
 	assert.Equal(t, message.NodeStatus(0), got,
 		"after the prior is dropped, subsequent status-less messages publish no status")
 }
@@ -107,7 +107,7 @@ func TestPeer_ApplyStatusChange_StatusRecordedOnLostSync(t *testing.T) {
 	require.NoError(t, err)
 
 	p := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
-	p.applyStatusChange(nil, nil, true, nil, nil, message.NodeStatusValidating)
+	p.applyStatusChange(&message.StatusChange{NewStatus: message.NodeStatusValidating, NewEvent: message.NodeEventLostSync})
 	assert.Equal(t, message.NodeStatusValidating, p.LastStatus())
 }
 
@@ -378,7 +378,7 @@ func TestOverlay_PeersJSON_StatusField(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := NewPeer(PeerID(1), Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
 			if tc.status != 0 {
-				p.applyStatusChange(nil, nil, false, nil, nil, tc.status)
+				p.applyStatusChange(&message.StatusChange{NewStatus: tc.status})
 			}
 
 			o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
@@ -405,7 +405,7 @@ func TestOverlay_PeersJSON_StatusOmittedForOutOfRangeEnum(t *testing.T) {
 	require.NoError(t, err)
 
 	p := NewPeer(PeerID(1), Endpoint{Host: "192.0.2.1", Port: 51235}, false, id, nil)
-	p.applyStatusChange(nil, nil, false, nil, nil, message.NodeStatus(99))
+	p.applyStatusChange(&message.StatusChange{NewStatus: message.NodeStatus(99)})
 
 	o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
 	entries := o.PeersJSON()


### PR DESCRIPTION
## Summary

- `Peer.applyStatusChange` now takes `*message.StatusChange` directly; `lostSync` is derived from `sc.NewEvent == NodeEventLostSync` inside the function.
- `Overlay.handleStatusChange` simplifies to `peer.applyStatusChange(sc)` — the caller-side destructure that immediately got reconstructed inside the callee is gone.
- ~22 test call sites converted from positional zero-values to `&message.StatusChange{...}` literals.

Pure call-shape refactor. Behavior unchanged — no rippled-conformance bits move. Future TMStatusChange fields (network_time use, complete_ledgers/track/load follow-ups in #302/#303/#304) can land without touching this signature again. Mirrors rippled's `PeerImp::onMessage(std::shared_ptr<protocol::TMStatusChange>)` style (`PeerImp.cpp:1791-1890`).

Closes #321.

## Base

Stacked on top of #319 (`peers-status-299`). Once #319 lands, this can be retargeted to `main`.

## Test plan

- [x] `go test ./internal/peermanagement/...` — all packages pass
- [x] `go vet ./internal/peermanagement/...` — clean
- [x] `go build ./...` — clean
- [x] Verbose run of `TestApplyStatusChange_RippledSemantics`, `TestPeer_ApplyStatusChange_*`, `TestOverlay_handleStatusChange_*`, `TestOverlay_PeersJSON_Status*`, `TestPeersJSON_CompleteLedgers` — all pass, confirming no change to peers RPC output