### PR TITLE
refactor(rpc): route Services through RpcContext (#293)

### DIFF
--- a/internal/cli/replay.go
+++ b/internal/cli/replay.go
@@ -335,8 +335,8 @@ func executeReplayVerbose(state *StateFixture, env *EnvFixture, txs *TxsFixture,
 		return nil, nil, fmt.Errorf("parsing parent_hash: %w", err)
 	}
 
-	closeTime := time.Unix(protocol.RippleEpochUnix+int64(env.CloseTime), 0).UTC()
-	parentCloseTime := time.Unix(protocol.RippleEpochUnix+int64(env.ParentCloseTime), 0).UTC()
+	closeTime := time.Unix(protocol.RippleEpochUnix+env.CloseTime, 0).UTC()
+	parentCloseTime := time.Unix(protocol.RippleEpochUnix+env.ParentCloseTime, 0).UTC()
 
 	ledgerHeader := header.LedgerHeader{
 		LedgerIndex:         env.LedgerIndex,

--- a/internal/cli/replay_range.go
+++ b/internal/cli/replay_range.go
@@ -426,8 +426,8 @@ func processBlock(
 	}
 
 	// Setup ledger header
-	closeTime := time.Unix(protocol.RippleEpochUnix+int64(postSnapshot.CloseTime), 0).UTC()
-	parentCloseTime := time.Unix(protocol.RippleEpochUnix+int64(preSnapshot.CloseTime), 0).UTC()
+	closeTime := time.Unix(protocol.RippleEpochUnix+postSnapshot.CloseTime, 0).UTC()
+	parentCloseTime := time.Unix(protocol.RippleEpochUnix+preSnapshot.CloseTime, 0).UTC()
 
 	ledgerHeader := header.LedgerHeader{
 		LedgerIndex:         targetLedger,

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -214,7 +214,7 @@ func runServer(cmd *cobra.Command, args []string) {
 
 	// Wire up RPC services
 	ledgerAdapter := rpc.NewLedgerServiceAdapter(ledgerService)
-	types.InitServices(ledgerAdapter)
+	services := types.NewServiceContainer(ledgerAdapter)
 
 	// Start consensus/networking if not in standalone mode
 	var consensusComponents *adaptor.Components
@@ -269,10 +269,10 @@ func runServer(cmd *cobra.Command, args []string) {
 		})
 
 		// Expose node identity, peer count, and consensus stats to RPC handlers
-		types.Services.NodePublicKey = consensusComponents.Overlay.Identity().EncodedPublicKey()
-		types.Services.PeerCount = consensusComponents.Overlay.PeerCount
+		services.NodePublicKey = consensusComponents.Overlay.Identity().EncodedPublicKey()
+		services.PeerCount = consensusComponents.Overlay.PeerCount
 		engine := consensusComponents.Engine
-		types.Services.LastCloseInfo = func() (int, int) {
+		services.LastCloseInfo = func() (int, int) {
 			proposers, convergeTime := engine.GetLastCloseInfo()
 			return proposers, int(convergeTime.Milliseconds())
 		}
@@ -280,7 +280,7 @@ func runServer(cmd *cobra.Command, args []string) {
 		// The cache is shared — the router writes inbound manifests,
 		// the engine reads for ephemeral→master translation, and this
 		// RPC reads for external queries.
-		types.Services.Manifests = consensusComponents.Manifests
+		services.Manifests = consensusComponents.Manifests
 
 		// Expose the local validator's signing key to validator_info.
 		// Mirrors rippled's getValidationPublicKey gate: empty means
@@ -289,7 +289,7 @@ func runServer(cmd *cobra.Command, args []string) {
 		if vid, err := consensusComponents.Adaptor.GetValidatorKey(); err == nil {
 			pk := make([]byte, 33)
 			copy(pk, vid[:])
-			types.Services.ValidatorPublicKey = pk
+			services.ValidatorPublicKey = pk
 		}
 
 		isValidator := globalConfig.IsValidator()
@@ -307,15 +307,15 @@ func runServer(cmd *cobra.Command, args []string) {
 	}
 
 	// Create HTTP JSON-RPC server with 30 second timeout
-	httpServer := rpc.NewServer(30 * time.Second)
+	httpServer := rpc.NewServer(30*time.Second, services)
 	if consensusComponents != nil && consensusComponents.Overlay != nil {
 		httpServer.SetPeerSource(consensusComponents.Overlay)
 	}
 
-	types.Services.SetDispatcher(httpServer)
+	services.SetDispatcher(httpServer)
 
 	// Create WebSocket server for real-time subscriptions
-	wsServer := rpc.NewWebSocketServer(30 * time.Second)
+	wsServer := rpc.NewWebSocketServer(30*time.Second, services)
 	wsServer.RegisterAllMethods()
 
 	// Create a ledger info provider adapter for WebSocket subscribe responses
@@ -387,7 +387,7 @@ func runServer(cmd *cobra.Command, args []string) {
 
 		// Update persistent path_find sessions on ledger close
 		wsServer.UpdatePathFindSessions(func() (types.LedgerStateView, error) {
-			return types.Services.Ledger.GetClosedLedgerView()
+			return services.Ledger.GetClosedLedgerView()
 		})
 
 		serverLog.Debug("Broadcasted ledger",
@@ -508,7 +508,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	// shutdownCh lets the RPC stop command trigger the same path
 	shutdownCh := make(chan struct{}, 1)
 
-	types.Services.SetShutdownFunc(func() {
+	services.SetShutdownFunc(func() {
 		serverLog.Info("Shutdown requested via RPC stop command")
 		shutdownCh <- struct{}{}
 	})

--- a/internal/consensus/adaptor/identity.go
+++ b/internal/consensus/adaptor/identity.go
@@ -304,4 +304,3 @@ func buildValidationSigningData(v *consensus.Validation) []byte {
 	hash := common.Sha512Half(buf)
 	return hash[:]
 }
-

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -166,29 +166,23 @@ func (m *mockAccountChannelsLedgerService) GetClosedLedgerView() (types.LedgerSt
 	return nil, errors.New("not implemented in mock")
 }
 
-// setupAccountChannelsTestServices initializes the Services singleton with a mock for testing
-func setupAccountChannelsTestServices(mock *mockAccountChannelsLedgerService) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
-		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
-	}
+// newAccountChannelsTestServices builds a *types.ServiceContainer wrapping the mock.
+func newAccountChannelsTestServices(mock *mockAccountChannelsLedgerService) *types.ServiceContainer {
+	return &types.ServiceContainer{Ledger: mock}
 }
 
 // TestAccountChannelsErrorValidation tests error handling for invalid inputs
 // Based on rippled PayChan_test.cpp testAccountChannels()
 func TestAccountChannelsErrorValidation(t *testing.T) {
 	mock := newMockAccountChannelsLedgerService()
-	cleanup := setupAccountChannelsTestServices(mock)
-	defer cleanup()
+	services := newAccountChannelsTestServices(mock)
 
 	method := &handlers.AccountChannelsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -284,14 +278,14 @@ func TestAccountChannelsErrorValidation(t *testing.T) {
 // Based on rippled PayChan_test.cpp testSimple()
 func TestAccountChannelsSimple(t *testing.T) {
 	mock := newMockAccountChannelsLedgerService()
-	cleanup := setupAccountChannelsTestServices(mock)
-	defer cleanup()
+	services := newAccountChannelsTestServices(mock)
 
 	method := &handlers.AccountChannelsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	aliceAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -477,14 +471,14 @@ func TestAccountChannelsSimple(t *testing.T) {
 // Based on rippled AccountChannels.cpp destination_account parameter handling
 func TestAccountChannelsDestinationFilter(t *testing.T) {
 	mock := newMockAccountChannelsLedgerService()
-	cleanup := setupAccountChannelsTestServices(mock)
-	defer cleanup()
+	services := newAccountChannelsTestServices(mock)
 
 	method := &handlers.AccountChannelsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	aliceAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -570,14 +564,14 @@ func TestAccountChannelsDestinationFilter(t *testing.T) {
 // Based on rippled PayChan_test.cpp channel creation with various options
 func TestAccountChannelsOptionalFields(t *testing.T) {
 	mock := newMockAccountChannelsLedgerService()
-	cleanup := setupAccountChannelsTestServices(mock)
-	defer cleanup()
+	services := newAccountChannelsTestServices(mock)
 
 	method := &handlers.AccountChannelsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	aliceAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -770,14 +764,14 @@ func TestAccountChannelsOptionalFields(t *testing.T) {
 // TestAccountChannelsLedgerSpecification tests different ledger index specifications
 func TestAccountChannelsLedgerSpecification(t *testing.T) {
 	mock := newMockAccountChannelsLedgerService()
-	cleanup := setupAccountChannelsTestServices(mock)
-	defer cleanup()
+	services := newAccountChannelsTestServices(mock)
 
 	method := &handlers.AccountChannelsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -900,15 +894,12 @@ func TestAccountChannelsLedgerSpecification(t *testing.T) {
 
 // TestAccountChannelsServiceUnavailable tests behavior when ledger service is not available
 func TestAccountChannelsServiceUnavailable(t *testing.T) {
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.AccountChannelsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{
@@ -945,14 +936,14 @@ func TestAccountChannelsMethodMetadata(t *testing.T) {
 // TestAccountChannelsMultipleChannels tests retrieval of multiple channels
 func TestAccountChannelsMultipleChannels(t *testing.T) {
 	mock := newMockAccountChannelsLedgerService()
-	cleanup := setupAccountChannelsTestServices(mock)
-	defer cleanup()
+	services := newAccountChannelsTestServices(mock)
 
 	method := &handlers.AccountChannelsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	aliceAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -168,29 +168,23 @@ func (m *mockAccountCurrenciesLedgerService) GetClosedLedgerView() (types.Ledger
 	return nil, errors.New("not implemented in mock")
 }
 
-// setupAccountCurrenciesTestServices initializes the Services singleton with a mock for testing
-func setupAccountCurrenciesTestServices(mock *mockAccountCurrenciesLedgerService) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
-		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
-	}
+// newAccountCurrenciesTestServices builds a *types.ServiceContainer wrapping the mock.
+func newAccountCurrenciesTestServices(mock *mockAccountCurrenciesLedgerService) *types.ServiceContainer {
+	return &types.ServiceContainer{Ledger: mock}
 }
 
 // TestAccountCurrenciesBadInput tests error handling for invalid inputs
 // Based on rippled AccountCurrencies_test.cpp testBadInput()
 func TestAccountCurrenciesBadInput(t *testing.T) {
 	mock := newMockAccountCurrenciesLedgerService()
-	cleanup := setupAccountCurrenciesTestServices(mock)
-	defer cleanup()
+	services := newAccountCurrenciesTestServices(mock)
 
 	method := &handlers.AccountCurrenciesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -303,14 +297,14 @@ func TestAccountCurrenciesBadInput(t *testing.T) {
 // Based on rippled AccountCurrencies_test.cpp testBasic()
 func TestAccountCurrenciesBasic(t *testing.T) {
 	mock := newMockAccountCurrenciesLedgerService()
-	cleanup := setupAccountCurrenciesTestServices(mock)
-	defer cleanup()
+	services := newAccountCurrenciesTestServices(mock)
 
 	method := &handlers.AccountCurrenciesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	aliceAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -516,14 +510,14 @@ func TestAccountCurrenciesBasic(t *testing.T) {
 // TestAccountCurrenciesResponseFields tests that all required fields are present
 func TestAccountCurrenciesResponseFields(t *testing.T) {
 	mock := newMockAccountCurrenciesLedgerService()
-	cleanup := setupAccountCurrenciesTestServices(mock)
-	defer cleanup()
+	services := newAccountCurrenciesTestServices(mock)
 
 	method := &handlers.AccountCurrenciesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.accountCurrenciesResult = &types.AccountCurrenciesResult{
@@ -560,15 +554,12 @@ func TestAccountCurrenciesResponseFields(t *testing.T) {
 
 // TestAccountCurrenciesServiceUnavailable tests behavior when ledger service is not available
 func TestAccountCurrenciesServiceUnavailable(t *testing.T) {
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.AccountCurrenciesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -145,30 +145,24 @@ func (m *mockLedgerService) GetClosedLedgerView() (types.LedgerStateView, error)
 	return nil, errors.New("not implemented in mock")
 }
 
-// setupTestServices initializes the Services singleton with a mock for testing.
+// newTestServices builds a *types.ServiceContainer wrapping the given LedgerService.
 // Accepts any type that implements types.LedgerService.
-func setupTestServices(mock types.LedgerService) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
-		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
-	}
+func newTestServices(mock types.LedgerService) *types.ServiceContainer {
+	return &types.ServiceContainer{Ledger: mock}
 }
 
 // TestAccountInfoErrorValidation tests error handling for invalid inputs
 // Based on rippled AccountInfo_test.cpp testErrors()
 func TestAccountInfoErrorValidation(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.AccountInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -303,14 +297,14 @@ func TestAccountInfoErrorValidation(t *testing.T) {
 // Based on rippled's ledger specification behavior
 func TestAccountInfoLedgerSpecification(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.AccountInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -505,14 +499,14 @@ func TestAccountInfoLedgerSpecification(t *testing.T) {
 // Based on rippled account_info response structure
 func TestAccountInfoResponseFields(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.AccountInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -692,14 +686,14 @@ func TestAccountInfoResponseFields(t *testing.T) {
 // Based on rippled AccountInfo_test.cpp testInvalidAccountParam
 func TestAccountInfoInvalidAccountTypes(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.AccountInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// These test cases mirror rippled's testInvalidAccountParam lambda
@@ -744,14 +738,14 @@ func TestAccountInfoInvalidAccountTypes(t *testing.T) {
 // Based on rippled AccountInfo_test.cpp malformed account tests
 func TestAccountInfoMalformedAddresses(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.AccountInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	malformedAddresses := []struct {
@@ -792,16 +786,12 @@ func TestAccountInfoMalformedAddresses(t *testing.T) {
 
 // TestAccountInfoServiceUnavailable tests behavior when ledger service is not available
 func TestAccountInfoServiceUnavailable(t *testing.T) {
-	// Temporarily set Services to nil
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.AccountInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{
@@ -820,16 +810,12 @@ func TestAccountInfoServiceUnavailable(t *testing.T) {
 
 // TestAccountInfoServiceNilLedger tests behavior when ledger service is nil
 func TestAccountInfoServiceNilLedger(t *testing.T) {
-	// Set Services with nil Ledger
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{Ledger: nil}
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.AccountInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: nil},
 	}
 
 	params := map[string]interface{}{
@@ -866,14 +852,14 @@ func TestAccountInfoMethodMetadata(t *testing.T) {
 // TestAccountInfoStrictMode tests the strict parameter behavior
 func TestAccountInfoStrictMode(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.AccountInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -919,14 +905,14 @@ func TestAccountInfoStrictMode(t *testing.T) {
 // TestAccountInfoLedgerIndexFormats tests different ledger_index format handling
 func TestAccountInfoLedgerIndexFormats(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.AccountInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -162,29 +162,23 @@ func (m *mockAccountLinesLedgerService) GetClosedLedgerView() (types.LedgerState
 	return nil, errors.New("not implemented in mock")
 }
 
-// setupAccountLinesTestServices initializes the Services singleton with a mock for testing
-func setupAccountLinesTestServices(mock *mockAccountLinesLedgerService) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
-		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
-	}
+// newAccountLinesTestServices builds a *types.ServiceContainer wrapping the mock.
+func newAccountLinesTestServices(mock *mockAccountLinesLedgerService) *types.ServiceContainer {
+	return &types.ServiceContainer{Ledger: mock}
 }
 
 // TestAccountLinesErrorValidation tests error handling for invalid inputs
 // Based on rippled AccountLines_test.cpp testAccountLines()
 func TestAccountLinesErrorValidation(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -315,14 +309,14 @@ func TestAccountLinesErrorValidation(t *testing.T) {
 // Based on rippled AccountLines_test.cpp testInvalidAccountParam lambda (lines 60-76)
 func TestAccountLinesInvalidAccountTypes(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// These test cases mirror rippled's testInvalidAccountParam lambda
@@ -367,14 +361,14 @@ func TestAccountLinesInvalidAccountTypes(t *testing.T) {
 // Based on rippled AccountLines_test.cpp lines 102-124
 func TestAccountLinesLedgerSpecification(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -589,14 +583,14 @@ func TestAccountLinesLedgerSpecification(t *testing.T) {
 // Based on rippled AccountLines_test.cpp lines 242-270
 func TestAccountLinesPeerFilter(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -722,14 +716,14 @@ func TestAccountLinesPeerFilter(t *testing.T) {
 // Based on rippled AccountLines_test.cpp lines 271-342
 func TestAccountLinesPagination(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -963,14 +957,14 @@ func TestAccountLinesPagination(t *testing.T) {
 // Based on rippled AccountLines_test.cpp lines 343-392
 func TestAccountLinesResponseFields(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -1195,16 +1189,12 @@ func TestAccountLinesResponseFields(t *testing.T) {
 
 // TestAccountLinesServiceUnavailable tests behavior when ledger service is not available
 func TestAccountLinesServiceUnavailable(t *testing.T) {
-	// Temporarily set types.Services to nil
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{
@@ -1223,16 +1213,12 @@ func TestAccountLinesServiceUnavailable(t *testing.T) {
 
 // TestAccountLinesServiceNilLedger tests behavior when ledger service is nil
 func TestAccountLinesServiceNilLedger(t *testing.T) {
-	// Set types.Services with nil Ledger
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{Ledger: nil}
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: nil},
 	}
 
 	params := map[string]interface{}{
@@ -1270,14 +1256,14 @@ func TestAccountLinesMethodMetadata(t *testing.T) {
 // Based on rippled AccountLines_test.cpp malformed account tests
 func TestAccountLinesMalformedAddresses(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Malformed addresses are now caught by ValidateAccount at handler level
@@ -1320,14 +1306,14 @@ func TestAccountLinesMalformedAddresses(t *testing.T) {
 // Based on rippled AccountLines_test.cpp testAccountLinesHistory lambda (lines 181-206)
 func TestAccountLinesHistoricLedgers(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -1410,14 +1396,14 @@ func TestAccountLinesHistoricLedgers(t *testing.T) {
 // Based on rippled AccountLines_test.cpp testAccountLinesMarker (lines 395-478)
 func TestAccountLinesMarkerOwnership(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Marker from alice's account cannot be used for becky's account", func(t *testing.T) {
@@ -1447,14 +1433,14 @@ func TestAccountLinesMarkerOwnership(t *testing.T) {
 // Based on rippled AccountLines_test.cpp testAccountLineDelete (lines 480-554)
 func TestAccountLinesDeletedEntry(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Marker becomes invalid when pointed entry is deleted", func(t *testing.T) {
@@ -1482,14 +1468,14 @@ func TestAccountLinesDeletedEntry(t *testing.T) {
 // Based on rippled AccountLines_test.cpp testAccountLinesWalkMarkers (lines 556-773)
 func TestAccountLinesWalkMarkers(t *testing.T) {
 	mock := newMockAccountLinesLedgerService()
-	cleanup := setupAccountLinesTestServices(mock)
-	defer cleanup()
+	services := newAccountLinesTestServices(mock)
 
 	method := &handlers.AccountLinesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -164,29 +164,23 @@ func (m *mockAccountNFTsLedgerService) GetClosedLedgerView() (types.LedgerStateV
 	return nil, errors.New("not implemented in mock")
 }
 
-// setupAccountNFTsTestServices initializes the Services singleton with a mock for testing
-func setupAccountNFTsTestServices(mock *mockAccountNFTsLedgerService) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
-		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
-	}
+// newAccountNFTsTestServices builds a *types.ServiceContainer wrapping the mock.
+func newAccountNFTsTestServices(mock *mockAccountNFTsLedgerService) *types.ServiceContainer {
+	return &types.ServiceContainer{Ledger: mock}
 }
 
 // TestAccountNFTsErrorValidation tests error handling for invalid inputs
 // Based on rippled AccountObjects_test.cpp testAccountNFTs()
 func TestAccountNFTsErrorValidation(t *testing.T) {
 	mock := newMockAccountNFTsLedgerService()
-	cleanup := setupAccountNFTsTestServices(mock)
-	defer cleanup()
+	services := newAccountNFTsTestServices(mock)
 
 	method := &handlers.AccountNftsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -283,14 +277,14 @@ func TestAccountNFTsErrorValidation(t *testing.T) {
 // Based on rippled AccountObjects_test.cpp testAccountNFTs() - testInvalidAccountParam
 func TestAccountNFTsInvalidAccountTypes(t *testing.T) {
 	mock := newMockAccountNFTsLedgerService()
-	cleanup := setupAccountNFTsTestServices(mock)
-	defer cleanup()
+	services := newAccountNFTsTestServices(mock)
 
 	method := &handlers.AccountNftsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// These test cases mirror rippled's testInvalidAccountParam lambda
@@ -332,14 +326,14 @@ func TestAccountNFTsInvalidAccountTypes(t *testing.T) {
 // Based on rippled NFToken_test.cpp
 func TestAccountNFTsBasic(t *testing.T) {
 	mock := newMockAccountNFTsLedgerService()
-	cleanup := setupAccountNFTsTestServices(mock)
-	defer cleanup()
+	services := newAccountNFTsTestServices(mock)
 
 	method := &handlers.AccountNftsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	bobAccount := "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
@@ -483,14 +477,14 @@ func TestAccountNFTsBasic(t *testing.T) {
 // Based on rippled NFToken_test.cpp
 func TestAccountNFTsOptionalFields(t *testing.T) {
 	mock := newMockAccountNFTsLedgerService()
-	cleanup := setupAccountNFTsTestServices(mock)
-	defer cleanup()
+	services := newAccountNFTsTestServices(mock)
 
 	method := &handlers.AccountNftsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	bobAccount := "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
@@ -627,14 +621,14 @@ func TestAccountNFTsOptionalFields(t *testing.T) {
 // TestAccountNFTsLedgerSpecification tests different ledger index specifications
 func TestAccountNFTsLedgerSpecification(t *testing.T) {
 	mock := newMockAccountNFTsLedgerService()
-	cleanup := setupAccountNFTsTestServices(mock)
-	defer cleanup()
+	services := newAccountNFTsTestServices(mock)
 
 	method := &handlers.AccountNftsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -759,14 +753,14 @@ func TestAccountNFTsLedgerSpecification(t *testing.T) {
 // Based on rippled AccountObjects_test.cpp testNFTsMarker()
 func TestAccountNFTsPagination(t *testing.T) {
 	mock := newMockAccountNFTsLedgerService()
-	cleanup := setupAccountNFTsTestServices(mock)
-	defer cleanup()
+	services := newAccountNFTsTestServices(mock)
 
 	method := &handlers.AccountNftsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	bobAccount := "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
@@ -867,15 +861,12 @@ func TestAccountNFTsPagination(t *testing.T) {
 
 // TestAccountNFTsServiceUnavailable tests behavior when ledger service is not available
 func TestAccountNFTsServiceUnavailable(t *testing.T) {
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.AccountNftsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{
@@ -912,14 +903,14 @@ func TestAccountNFTsMethodMetadata(t *testing.T) {
 // TestAccountNFTsResponseFields tests that all required fields are present
 func TestAccountNFTsResponseFields(t *testing.T) {
 	mock := newMockAccountNFTsLedgerService()
-	cleanup := setupAccountNFTsTestServices(mock)
-	defer cleanup()
+	services := newAccountNFTsTestServices(mock)
 
 	method := &handlers.AccountNftsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	bobAccount := "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"

--- a/internal/rpc/account_objects_test.go
+++ b/internal/rpc/account_objects_test.go
@@ -35,16 +35,9 @@ func newAccountObjectsMock() *accountObjectsMock {
 	}
 }
 
-// setupAccountObjectsTestServices wires the accountObjectsMock into the global
-// types.Services singleton and returns a cleanup function.
-func setupAccountObjectsTestServices(mock *accountObjectsMock) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
-		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
-	}
+// newAccountObjectsTestServices builds a *types.ServiceContainer wrapping the mock.
+func newAccountObjectsTestServices(mock *accountObjectsMock) *types.ServiceContainer {
+	return &types.ServiceContainer{Ledger: mock}
 }
 
 // Test: Error cases – missing / invalid / malformed account
@@ -52,14 +45,14 @@ func setupAccountObjectsTestServices(mock *accountObjectsMock) func() {
 
 func TestAccountObjectsErrorValidation(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -196,14 +189,14 @@ func TestAccountObjectsErrorValidation(t *testing.T) {
 
 func TestAccountObjectsResponseStructure(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -320,14 +313,14 @@ func TestAccountObjectsResponseStructure(t *testing.T) {
 
 func TestAccountObjectsEmptyAccount(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -379,14 +372,14 @@ func TestAccountObjectsEmptyAccount(t *testing.T) {
 
 func TestAccountObjectsTypeFiltering(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -455,14 +448,14 @@ func TestAccountObjectsTypeFiltering(t *testing.T) {
 
 func TestAccountObjectsDeletionBlockersOnly(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -525,14 +518,14 @@ func TestAccountObjectsDeletionBlockersOnly(t *testing.T) {
 
 func TestAccountObjectsPagination(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -669,14 +662,14 @@ func TestAccountObjectsPagination(t *testing.T) {
 
 func TestAccountObjectsLedgerSpecification(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -766,11 +759,6 @@ func TestAccountObjectsLedgerSpecification(t *testing.T) {
 
 func TestAccountObjectsServiceUnavailable(t *testing.T) {
 	method := &handlers.AccountObjectsMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	params := map[string]interface{}{
 		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -779,9 +767,12 @@ func TestAccountObjectsServiceUnavailable(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Services is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 
@@ -792,9 +783,12 @@ func TestAccountObjectsServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Ledger is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 
@@ -828,14 +822,14 @@ func TestAccountObjectsMethodMetadata(t *testing.T) {
 
 func TestAccountObjectsInvalidAccountTypes(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	invalidParams := []struct {
@@ -879,14 +873,14 @@ func TestAccountObjectsInvalidAccountTypes(t *testing.T) {
 
 func TestAccountObjectsMalformedAddresses(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	malformedAddresses := []struct {
@@ -941,14 +935,14 @@ func TestAccountObjectsMalformedAddresses(t *testing.T) {
 
 func TestAccountObjectsServiceErrors(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -997,14 +991,14 @@ func TestAccountObjectsServiceErrors(t *testing.T) {
 
 func TestAccountObjectsAccountEcho(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -1042,8 +1036,7 @@ func TestAccountObjectsAccountEcho(t *testing.T) {
 
 func TestAccountObjectsApiVersions(t *testing.T) {
 	mock := newAccountObjectsMock()
-	cleanup := setupAccountObjectsTestServices(mock)
-	defer cleanup()
+	services := newAccountObjectsTestServices(mock)
 
 	method := &handlers.AccountObjectsMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -1065,6 +1058,7 @@ func TestAccountObjectsApiVersions(t *testing.T) {
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
 				ApiVersion: version,
+				Services:   services,
 			}
 
 			params := map[string]interface{}{

--- a/internal/rpc/account_offers_test.go
+++ b/internal/rpc/account_offers_test.go
@@ -38,29 +38,23 @@ func (m *accountOffersMock) GetAccountOffers(account string, ledgerIndex string,
 	}, nil
 }
 
-// setupAccountOffersTestServices sets up the test services with the accountOffersMock
-func setupAccountOffersTestServices(mock *accountOffersMock) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
-		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
-	}
+// newAccountOffersTestServices builds a *types.ServiceContainer wrapping the mock.
+func newAccountOffersTestServices(mock *accountOffersMock) *types.ServiceContainer {
+	return &types.ServiceContainer{Ledger: mock}
 }
 
 // TestAccountOffersErrorValidation tests error handling for invalid inputs
 // Based on rippled AccountOffers_test.cpp testBadInput()
 func TestAccountOffersErrorValidation(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -195,14 +189,14 @@ func TestAccountOffersErrorValidation(t *testing.T) {
 // Based on rippled AccountOffers_test.cpp testNonAdminMinLimit()
 func TestAccountOffersNonAdminMinLimit(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -286,14 +280,14 @@ func TestAccountOffersNonAdminMinLimit(t *testing.T) {
 // Based on rippled AccountOffers_test.cpp testSequential()
 func TestAccountOffersSequentialRetrieval(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -438,14 +432,14 @@ func TestAccountOffersSequentialRetrieval(t *testing.T) {
 // Based on rippled account_offers response structure
 func TestAccountOffersResponseFields(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -533,14 +527,14 @@ func TestAccountOffersResponseFields(t *testing.T) {
 // TestAccountOffersEmptyOffers tests response for account with no offers
 func TestAccountOffersEmptyOffers(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -584,8 +578,7 @@ func TestAccountOffersEmptyOffers(t *testing.T) {
 // Based on rippled AccountOffers_test.cpp testSequential() with admin limit=1
 func TestAccountOffersMarkerPagination(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
@@ -593,6 +586,7 @@ func TestAccountOffersMarkerPagination(t *testing.T) {
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
 		IsAdmin:    true,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -755,14 +749,14 @@ func TestAccountOffersMarkerPagination(t *testing.T) {
 // Based on rippled AccountOffers_test.cpp response validation
 func TestAccountOffersOfferFields(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -939,16 +933,14 @@ func TestAccountOffersOfferFields(t *testing.T) {
 // TestAccountOffersServiceUnavailable tests behavior when ledger service is not available
 func TestAccountOffersServiceUnavailable(t *testing.T) {
 	method := &handlers.AccountOffersMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	t.Run("Services nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		params := map[string]interface{}{
 			"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -965,9 +957,12 @@ func TestAccountOffersServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Ledger nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		params := map[string]interface{}{
 			"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -1004,14 +999,14 @@ func TestAccountOffersMethodMetadata(t *testing.T) {
 // TestAccountOffersLedgerSpecification tests different ledger index specifications
 func TestAccountOffersLedgerSpecification(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -1064,14 +1059,14 @@ func TestAccountOffersLedgerSpecification(t *testing.T) {
 // Based on rippled AccountOffers_test.cpp testBadInput() - testInvalidAccountParam lambda
 func TestAccountOffersInvalidAccountTypes(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	invalidParams := []struct {
@@ -1114,14 +1109,14 @@ func TestAccountOffersInvalidAccountTypes(t *testing.T) {
 // Based on rippled AccountOffers_test.cpp testBadInput() - empty account and bogus account
 func TestAccountOffersMalformedAddresses(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Set up mock to return "account not found" for all address lookups
@@ -1179,14 +1174,14 @@ func TestAccountOffersMalformedAddresses(t *testing.T) {
 // TestAccountOffersServiceError tests behavior when the ledger service returns an error
 func TestAccountOffersServiceError(t *testing.T) {
 	mock := newAccountOffersMock()
-	cleanup := setupAccountOffersTestServices(mock)
-	defer cleanup()
+	services := newAccountOffersTestServices(mock)
 
 	method := &handlers.AccountOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"

--- a/internal/rpc/account_tx_test.go
+++ b/internal/rpc/account_tx_test.go
@@ -33,14 +33,9 @@ func (m *accountTxMock) GetAccountTransactions(account string, ledgerMin, ledger
 	return nil, errors.New("not implemented")
 }
 
-func setupTestServicesAccountTx(mock *accountTxMock) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
-		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
-	}
+// newTestServicesAccountTx builds a *types.ServiceContainer wrapping the mock.
+func newTestServicesAccountTx(mock *accountTxMock) *types.ServiceContainer {
+	return &types.ServiceContainer{Ledger: mock}
 }
 
 // Error Validation Tests
@@ -49,14 +44,14 @@ func setupTestServicesAccountTx(mock *accountTxMock) func() {
 // TestAccountTxErrorValidation tests error handling for invalid inputs
 func TestAccountTxErrorValidation(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -190,8 +185,7 @@ func TestAccountTxErrorValidation(t *testing.T) {
 
 func TestAccountTxLedgerIndexMinMax(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -201,6 +195,7 @@ func TestAccountTxLedgerIndexMinMax(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		mock.getAccountTransactionsFn = func(account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {
@@ -234,6 +229,7 @@ func TestAccountTxLedgerIndexMinMax(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		mock.getAccountTransactionsFn = func(account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {
@@ -264,6 +260,7 @@ func TestAccountTxLedgerIndexMinMax(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		mock.getAccountTransactionsFn = func(account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {
@@ -307,8 +304,7 @@ func TestAccountTxLedgerIndexMinMax(t *testing.T) {
 
 func TestAccountTxBinaryMode(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -329,6 +325,7 @@ func TestAccountTxBinaryMode(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion2,
+			Services:   services,
 		}
 
 		mock.getAccountTransactionsFn = func(account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {
@@ -392,6 +389,7 @@ func TestAccountTxBinaryMode(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		mock.getAccountTransactionsFn = func(account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {
@@ -445,8 +443,7 @@ func TestAccountTxBinaryMode(t *testing.T) {
 
 func TestAccountTxForwardReverse(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -454,6 +451,7 @@ func TestAccountTxForwardReverse(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Forward=true passes forward flag", func(t *testing.T) {
@@ -536,8 +534,7 @@ func TestAccountTxForwardReverse(t *testing.T) {
 
 func TestAccountTxMarkerPagination(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -545,6 +542,7 @@ func TestAccountTxMarkerPagination(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("No marker returns first page", func(t *testing.T) {
@@ -633,8 +631,7 @@ func TestAccountTxMarkerPagination(t *testing.T) {
 
 func TestAccountTxResponseStructure(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -642,6 +639,7 @@ func TestAccountTxResponseStructure(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Response contains all required fields", func(t *testing.T) {
@@ -767,8 +765,7 @@ func TestAccountTxResponseStructure(t *testing.T) {
 
 func TestAccountTxEmptyAccount(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -776,6 +773,7 @@ func TestAccountTxEmptyAccount(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.getAccountTransactionsFn = func(account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {
@@ -815,8 +813,7 @@ func TestAccountTxEmptyAccount(t *testing.T) {
 
 func TestAccountTxMultipleTransactions(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -854,6 +851,7 @@ func TestAccountTxMultipleTransactions(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion2,
+			Services:   services,
 		}
 
 		params := map[string]interface{}{
@@ -900,6 +898,7 @@ func TestAccountTxMultipleTransactions(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion2,
+			Services:   services,
 		}
 
 		params := map[string]interface{}{
@@ -951,11 +950,6 @@ func TestAccountTxMultipleTransactions(t *testing.T) {
 
 func TestAccountTxServiceUnavailable(t *testing.T) {
 	method := &handlers.AccountTxMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	params := map[string]interface{}{
 		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -964,9 +958,12 @@ func TestAccountTxServiceUnavailable(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Services is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 
@@ -977,9 +974,12 @@ func TestAccountTxServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Services.Ledger is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 
@@ -994,14 +994,14 @@ func TestAccountTxServiceUnavailable(t *testing.T) {
 
 func TestAccountTxTransactionHistoryNotAvailable(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.getAccountTransactionsFn = func(account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {
@@ -1044,8 +1044,7 @@ func TestAccountTxMethodMetadata(t *testing.T) {
 
 func TestAccountTxLimitParameter(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -1053,6 +1052,7 @@ func TestAccountTxLimitParameter(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Custom limit is passed to service", func(t *testing.T) {
@@ -1121,8 +1121,7 @@ func TestAccountTxInjectDeliveredAmount(t *testing.T) {
 	// indirectly through the handler's JSON mode behavior.
 
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -1130,6 +1129,7 @@ func TestAccountTxInjectDeliveredAmount(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// We test indirectly: when a Payment transaction is decoded in JSON mode,
@@ -1194,8 +1194,7 @@ func TestAccountTxInjectDeliveredAmount(t *testing.T) {
 
 func TestAccountTxServiceErrors(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -1203,6 +1202,7 @@ func TestAccountTxServiceErrors(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Generic service error", func(t *testing.T) {
@@ -1265,8 +1265,7 @@ func TestAccountTxServiceErrors(t *testing.T) {
 
 func TestAccountTxValidatedField(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -1274,6 +1273,7 @@ func TestAccountTxValidatedField(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	txHash := [32]byte{0x01}
@@ -1326,8 +1326,7 @@ func TestAccountTxValidatedField(t *testing.T) {
 
 func TestAccountTxAccountPassedToService(t *testing.T) {
 	mock := newAccountTxMock()
-	cleanup := setupTestServicesAccountTx(mock)
-	defer cleanup()
+	services := newTestServicesAccountTx(mock)
 
 	method := &handlers.AccountTxMethod{}
 	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -1335,6 +1334,7 @@ func TestAccountTxAccountPassedToService(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.getAccountTransactionsFn = func(account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {

--- a/internal/rpc/amendment_blocked_test.go
+++ b/internal/rpc/amendment_blocked_test.go
@@ -88,14 +88,14 @@ func newTestServer() *Server {
 func TestAmendmentBlockedMethodsReturnError(t *testing.T) {
 	mock := newMockLedgerService()
 	mock.amendmentBlocked = true
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	server := newTestServer()
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	for _, method := range blockedMethods {
@@ -120,14 +120,14 @@ func TestAmendmentBlockedMethodsReturnError(t *testing.T) {
 func TestAmendmentBlockedUnblockedMethodsStillWork(t *testing.T) {
 	mock := newMockLedgerService()
 	mock.amendmentBlocked = true
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	server := newTestServer()
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	for _, method := range unblockedMethods {
@@ -152,14 +152,14 @@ func TestAmendmentBlockedUnblockedMethodsStillWork(t *testing.T) {
 func TestAmendmentNotBlockedAllMethodsWork(t *testing.T) {
 	mock := newMockLedgerService()
 	mock.amendmentBlocked = false
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	server := newTestServer()
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	allMethods := append(blockedMethods, unblockedMethods...)
@@ -182,14 +182,14 @@ func TestAmendmentNotBlockedAllMethodsWork(t *testing.T) {
 func TestAmendmentBlockedErrorFormat(t *testing.T) {
 	mock := newMockLedgerService()
 	mock.amendmentBlocked = true
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	server := newTestServer()
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Use submit as a representative blocked method

--- a/internal/rpc/api_version_test.go
+++ b/internal/rpc/api_version_test.go
@@ -220,8 +220,7 @@ func TestApiVersionAllMethodsSupportV1(t *testing.T) {
 
 func TestApiVersionMethodsWorkWithEachVersion(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	// Handlers that can be invoked with minimal params and still produce a
 	// non-version-related response (success or a domain error, but NOT a
@@ -267,6 +266,7 @@ func TestApiVersionMethodsWorkWithEachVersion(t *testing.T) {
 					Context:    context.Background(),
 					Role:       types.RoleGuest,
 					ApiVersion: ver,
+					Services:   services,
 				}
 
 				var paramsJSON json.RawMessage

--- a/internal/rpc/book_changes_test.go
+++ b/internal/rpc/book_changes_test.go
@@ -106,14 +106,9 @@ func (m *mockLedgerServiceBC) addLedger(lr *mockLedgerReaderBC) {
 	m.ledgersByHash[lr.hash] = lr
 }
 
-func setupTestServicesBC(mock *mockLedgerServiceBC) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
-		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
-	}
+// newTestServicesBC builds a *types.ServiceContainer wrapping the mock.
+func newTestServicesBC(mock *mockLedgerServiceBC) *types.ServiceContainer {
+	return &types.ServiceContainer{Ledger: mock}
 }
 
 // Tests
@@ -122,8 +117,7 @@ func setupTestServicesBC(mock *mockLedgerServiceBC) func() {
 // Based on rippled BookChanges_test.cpp testConventionalLedgerInputStrings.
 func TestBookChangesValidLedgerIndexVariants(t *testing.T) {
 	mock := newMockLedgerServiceBC()
-	cleanup := setupTestServicesBC(mock)
-	defer cleanup()
+	services := newTestServicesBC(mock)
 
 	// Add ledgers for validated (2), current (3), closed (2)
 	ledger2 := newMockLedgerReaderBC(2)
@@ -139,6 +133,7 @@ func TestBookChangesValidLedgerIndexVariants(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -198,8 +193,7 @@ func TestBookChangesValidLedgerIndexVariants(t *testing.T) {
 // (non_conventional_ledger_input case).
 func TestBookChangesInvalidLedger(t *testing.T) {
 	mock := newMockLedgerServiceBC()
-	cleanup := setupTestServicesBC(mock)
-	defer cleanup()
+	services := newTestServicesBC(mock)
 
 	// Add only ledger 2 - ledger 999 does not exist
 	ledger2 := newMockLedgerReaderBC(2)
@@ -210,6 +204,7 @@ func TestBookChangesInvalidLedger(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("non-existent ledger index", func(t *testing.T) {
@@ -231,8 +226,7 @@ func TestBookChangesInvalidLedger(t *testing.T) {
 // Based on rippled BookChanges_test.cpp testLedgerInputDefaultBehavior (ledger with no offers).
 func TestBookChangesEmptyChanges(t *testing.T) {
 	mock := newMockLedgerServiceBC()
-	cleanup := setupTestServicesBC(mock)
-	defer cleanup()
+	services := newTestServicesBC(mock)
 
 	// Add a ledger with no transactions (hence no offer changes)
 	ledger2 := newMockLedgerReaderBC(2)
@@ -243,6 +237,7 @@ func TestBookChangesEmptyChanges(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := map[string]interface{}{
@@ -269,8 +264,7 @@ func TestBookChangesEmptyChanges(t *testing.T) {
 // Based on rippled BookChanges_test.cpp expected response format.
 func TestBookChangesResponseStructure(t *testing.T) {
 	mock := newMockLedgerServiceBC()
-	cleanup := setupTestServicesBC(mock)
-	defer cleanup()
+	services := newTestServicesBC(mock)
 
 	ledger2 := newMockLedgerReaderBC(2)
 	ledger2.closeTime = 42
@@ -281,6 +275,7 @@ func TestBookChangesResponseStructure(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := map[string]interface{}{
@@ -338,8 +333,7 @@ func TestBookChangesResponseStructure(t *testing.T) {
 // Based on rippled BookChanges_test.cpp testLedgerInputDefaultBehavior.
 func TestBookChangesDefaultLedger(t *testing.T) {
 	mock := newMockLedgerServiceBC()
-	cleanup := setupTestServicesBC(mock)
-	defer cleanup()
+	services := newTestServicesBC(mock)
 
 	ledger2 := newMockLedgerReaderBC(2)
 	ledger2.validated = true
@@ -350,6 +344,7 @@ func TestBookChangesDefaultLedger(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Empty params: should default to validated ledger (index 2)
@@ -372,16 +367,14 @@ func TestBookChangesDefaultLedger(t *testing.T) {
 // TestBookChangesServiceUnavailable tests behavior when the ledger service is not available.
 func TestBookChangesServiceUnavailable(t *testing.T) {
 	method := &handlers.BookChangesMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	t.Run("Services is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		params := map[string]interface{}{
 			"ledger_index": "validated",
@@ -397,9 +390,12 @@ func TestBookChangesServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Services.Ledger is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		params := map[string]interface{}{
 			"ledger_index": "validated",
@@ -435,8 +431,7 @@ func TestBookChangesMethodMetadata(t *testing.T) {
 // TestBookChangesNilParams tests that nil params are handled gracefully.
 func TestBookChangesNilParams(t *testing.T) {
 	mock := newMockLedgerServiceBC()
-	cleanup := setupTestServicesBC(mock)
-	defer cleanup()
+	services := newTestServicesBC(mock)
 
 	ledger2 := newMockLedgerReaderBC(2)
 	mock.addLedger(ledger2)
@@ -446,6 +441,7 @@ func TestBookChangesNilParams(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -31,28 +31,23 @@ func newBookOffersMock() *bookOffersMock {
 	}
 }
 
-func setupBookOffersTestServices(mock *bookOffersMock) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
-		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
-	}
+// newBookOffersTestServices builds a *types.ServiceContainer wrapping the mock.
+func newBookOffersTestServices(mock *bookOffersMock) *types.ServiceContainer {
+	return &types.ServiceContainer{Ledger: mock}
 }
 
 // TestBookOffersErrorValidation tests error handling for invalid inputs
 // Based on rippled Book_test.cpp testBookOfferErrors()
 func TestBookOffersErrorValidation(t *testing.T) {
 	mock := newBookOffersMock()
-	cleanup := setupBookOffersTestServices(mock)
-	defer cleanup()
+	services := newBookOffersTestServices(mock)
 
 	method := &handlers.BookOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -179,14 +174,14 @@ func TestBookOffersErrorValidation(t *testing.T) {
 // In rippled, XRP amounts in book_offers use {currency: "XRP"} object format
 func TestBookOffersXRPAmountHandling(t *testing.T) {
 	mock := newBookOffersMock()
-	cleanup := setupBookOffersTestServices(mock)
-	defer cleanup()
+	services := newBookOffersTestServices(mock)
 
 	method := &handlers.BookOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Track what arguments are passed to GetBookOffers
@@ -273,14 +268,14 @@ func TestBookOffersXRPAmountHandling(t *testing.T) {
 // Based on rippled Book_test.cpp testTrackOffers() book_offers call
 func TestBookOffersValidRequestWithOffers(t *testing.T) {
 	mock := newBookOffersMock()
-	cleanup := setupBookOffersTestServices(mock)
-	defer cleanup()
+	services := newBookOffersTestServices(mock)
 
 	method := &handlers.BookOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	expectedOffers := []types.BookOffer{
@@ -391,14 +386,14 @@ func TestBookOffersValidRequestWithOffers(t *testing.T) {
 // Based on rippled Book_test.cpp testOneSideEmptyBook() - empty offers array
 func TestBookOffersEmptyOrderBook(t *testing.T) {
 	mock := newBookOffersMock()
-	cleanup := setupBookOffersTestServices(mock)
-	defer cleanup()
+	services := newBookOffersTestServices(mock)
 
 	method := &handlers.BookOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
@@ -444,14 +439,14 @@ func TestBookOffersEmptyOrderBook(t *testing.T) {
 // Based on rippled Book_test.cpp testBookOfferLimits()
 func TestBookOffersLimitParameter(t *testing.T) {
 	mock := newBookOffersMock()
-	cleanup := setupBookOffersTestServices(mock)
-	defer cleanup()
+	services := newBookOffersTestServices(mock)
 
 	method := &handlers.BookOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Track the limit passed to GetBookOffers
@@ -552,14 +547,14 @@ func TestBookOffersLimitParameter(t *testing.T) {
 // Based on rippled book_offers response format (offers array, ledger_index, validated)
 func TestBookOffersResponseStructure(t *testing.T) {
 	mock := newBookOffersMock()
-	cleanup := setupBookOffersTestServices(mock)
-	defer cleanup()
+	services := newBookOffersTestServices(mock)
 
 	method := &handlers.BookOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
@@ -641,14 +636,14 @@ func TestBookOffersResponseStructure(t *testing.T) {
 // Based on rippled Book_test.cpp testTrackOffers() field assertions
 func TestBookOffersOfferFields(t *testing.T) {
 	mock := newBookOffersMock()
-	cleanup := setupBookOffersTestServices(mock)
-	defer cleanup()
+	services := newBookOffersTestServices(mock)
 
 	method := &handlers.BookOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
@@ -762,11 +757,6 @@ func TestBookOffersOfferFields(t *testing.T) {
 // TestBookOffersServiceUnavailable tests behavior when ledger service is not available
 func TestBookOffersServiceUnavailable(t *testing.T) {
 	method := &handlers.BookOffersMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	params := map[string]interface{}{
 		"taker_pays": map[string]interface{}{
@@ -781,9 +771,12 @@ func TestBookOffersServiceUnavailable(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Services is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 
@@ -794,9 +787,12 @@ func TestBookOffersServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Ledger is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 
@@ -810,14 +806,14 @@ func TestBookOffersServiceUnavailable(t *testing.T) {
 // TestBookOffersServiceError tests behavior when GetBookOffers returns an error
 func TestBookOffersServiceError(t *testing.T) {
 	mock := newBookOffersMock()
-	cleanup := setupBookOffersTestServices(mock)
-	defer cleanup()
+	services := newBookOffersTestServices(mock)
 
 	method := &handlers.BookOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
@@ -864,14 +860,14 @@ func TestBookOffersMethodMetadata(t *testing.T) {
 // TestBookOffersLedgerIndexPassthrough tests that the ledger_index is forwarded to the service
 func TestBookOffersLedgerIndexPassthrough(t *testing.T) {
 	mock := newBookOffersMock()
-	cleanup := setupBookOffersTestServices(mock)
-	defer cleanup()
+	services := newBookOffersTestServices(mock)
 
 	method := &handlers.BookOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	var capturedLedgerIndex string
@@ -942,14 +938,14 @@ func TestBookOffersLedgerIndexPassthrough(t *testing.T) {
 // TestBookOffersNilOffersArray tests that nil offers are serialized as an empty array
 func TestBookOffersNilOffersArray(t *testing.T) {
 	mock := newBookOffersMock()
-	cleanup := setupBookOffersTestServices(mock)
-	defer cleanup()
+	services := newBookOffersTestServices(mock)
 
 	method := &handlers.BookOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -169,14 +169,10 @@ func (m *mockDepositAuthorizedLedgerService) GetClosedLedgerView() (types.Ledger
 	return nil, errors.New("not implemented in mock")
 }
 
-// setupDepositAuthorizedTestServices initializes the Services singleton with a mock for testing
-func setupDepositAuthorizedTestServices(mock *mockDepositAuthorizedLedgerService) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+// newDepositAuthorizedTestServices builds a per-test ServiceContainer wrapping mock.
+func newDepositAuthorizedTestServices(mock *mockDepositAuthorizedLedgerService) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -186,14 +182,14 @@ func setupDepositAuthorizedTestServices(mock *mockDepositAuthorizedLedgerService
 // Based on rippled DepositAuthorized_test.cpp testErrors()
 func TestDepositAuthorizedErrorValidation(t *testing.T) {
 	mock := newMockDepositAuthorizedLedgerService()
-	cleanup := setupDepositAuthorizedTestServices(mock)
-	defer cleanup()
+	services := newDepositAuthorizedTestServices(mock)
 
 	method := &handlers.DepositAuthorizedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -302,14 +298,14 @@ func TestDepositAuthorizedErrorValidation(t *testing.T) {
 // Based on rippled DepositAuthorized_test.cpp testValid()
 func TestDepositAuthorizedBasicAuthorized(t *testing.T) {
 	mock := newMockDepositAuthorizedLedgerService()
-	cleanup := setupDepositAuthorizedTestServices(mock)
-	defer cleanup()
+	services := newDepositAuthorizedTestServices(mock)
 
 	method := &handlers.DepositAuthorizedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Alice can deposit to Becky (no DepositAuth set)
@@ -349,14 +345,14 @@ func TestDepositAuthorizedBasicAuthorized(t *testing.T) {
 // Based on rippled DepositAuthorized_test.cpp testValid() - becky can deposit to herself
 func TestDepositAuthorizedSelfDeposit(t *testing.T) {
 	mock := newMockDepositAuthorizedLedgerService()
-	cleanup := setupDepositAuthorizedTestServices(mock)
-	defer cleanup()
+	services := newDepositAuthorizedTestServices(mock)
 
 	method := &handlers.DepositAuthorizedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Becky can always deposit to herself, even with DepositAuth set
@@ -390,14 +386,14 @@ func TestDepositAuthorizedSelfDeposit(t *testing.T) {
 // Based on rippled DepositAuthorized_test.cpp testValid()
 func TestDepositAuthorizedNotAuthorized(t *testing.T) {
 	mock := newMockDepositAuthorizedLedgerService()
-	cleanup := setupDepositAuthorizedTestServices(mock)
-	defer cleanup()
+	services := newDepositAuthorizedTestServices(mock)
 
 	method := &handlers.DepositAuthorizedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Alice is NOT authorized to deposit to Becky (DepositAuth set, no preauth)
@@ -431,14 +427,14 @@ func TestDepositAuthorizedNotAuthorized(t *testing.T) {
 // Based on rippled DepositAuthorized_test.cpp testValid()
 func TestDepositAuthorizedWithPreauth(t *testing.T) {
 	mock := newMockDepositAuthorizedLedgerService()
-	cleanup := setupDepositAuthorizedTestServices(mock)
-	defer cleanup()
+	services := newDepositAuthorizedTestServices(mock)
 
 	method := &handlers.DepositAuthorizedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Alice is authorized to deposit to Becky (DepositAuth set, with preauth)
@@ -472,14 +468,14 @@ func TestDepositAuthorizedWithPreauth(t *testing.T) {
 // Based on rippled DepositAuthorized_test.cpp testValid()
 func TestDepositAuthorizedReciprocal(t *testing.T) {
 	mock := newMockDepositAuthorizedLedgerService()
-	cleanup := setupDepositAuthorizedTestServices(mock)
-	defer cleanup()
+	services := newDepositAuthorizedTestServices(mock)
 
 	method := &handlers.DepositAuthorizedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Becky can deposit to Alice even though Alice can't deposit to Becky
@@ -514,18 +510,12 @@ func TestDepositAuthorizedReciprocal(t *testing.T) {
 
 // TestDepositAuthorizedServiceUnavailable tests response when ledger service is unavailable
 func TestDepositAuthorizedServiceUnavailable(t *testing.T) {
-	// Set Services to nil
-	oldServices := types.Services
-	types.Services = nil
-	defer func() {
-		types.Services = oldServices
-	}()
-
 	method := &handlers.DepositAuthorizedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{
@@ -566,14 +556,14 @@ func TestDepositAuthorizedMethodMetadata(t *testing.T) {
 // Reference: rippled DepositAuthorized.cpp — parseBase58 → rpcACT_MALFORMED
 func TestDepositAuthorizedAddressValidation(t *testing.T) {
 	mock := newMockDepositAuthorizedLedgerService()
-	cleanup := setupDepositAuthorizedTestServices(mock)
-	defer cleanup()
+	services := newDepositAuthorizedTestServices(mock)
 
 	method := &handlers.DepositAuthorizedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -662,14 +652,14 @@ func TestDepositAuthorizedAddressValidation(t *testing.T) {
 // Reference: rippled DepositAuthorized.cpp — credential parsing loop + sorted.emplace()
 func TestDepositAuthorizedCredentialValidation(t *testing.T) {
 	mock := newMockDepositAuthorizedLedgerService()
-	cleanup := setupDepositAuthorizedTestServices(mock)
-	defer cleanup()
+	services := newDepositAuthorizedTestServices(mock)
 
 	method := &handlers.DepositAuthorizedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validCred1 := "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2"

--- a/internal/rpc/feature_test.go
+++ b/internal/rpc/feature_test.go
@@ -18,14 +18,14 @@ import (
 // Based on rippled Feature_test.cpp testNoParams()
 func TestFeatureNoParams(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.FeatureMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Call with nil params (no parameters)
@@ -76,14 +76,14 @@ func TestFeatureNoParams(t *testing.T) {
 // TestFeatureNoParamsEmptyObject tests that calling feature with empty params returns all features.
 func TestFeatureNoParamsEmptyObject(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.FeatureMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	paramsJSON, err := json.Marshal(map[string]interface{}{})
@@ -109,14 +109,14 @@ func TestFeatureNoParamsEmptyObject(t *testing.T) {
 // Based on rippled Feature_test.cpp testSingleFeature()
 func TestFeatureSingleLookupByName(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.FeatureMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Pick the first feature from the registry to test with
@@ -158,14 +158,14 @@ func TestFeatureSingleLookupByName(t *testing.T) {
 // Based on rippled Feature_test.cpp testNonAdmin - single feature by hex
 func TestFeatureSingleLookupByHexID(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.FeatureMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Pick a feature and use its hex ID
@@ -207,14 +207,14 @@ func TestFeatureSingleLookupByHexID(t *testing.T) {
 // Based on rippled Feature_test.cpp testInvalidFeature()
 func TestFeatureInvalidName(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.FeatureMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -249,14 +249,14 @@ func TestFeatureInvalidName(t *testing.T) {
 // Based on rippled Feature_test.cpp testNoParams() - validates enabled/supported/vetoed fields
 func TestFeatureResponseStructure(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := newTestServices(mock)
 
 	method := &handlers.FeatureMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -165,14 +165,10 @@ func (m *mockGatewayBalancesLedgerService) GetClosedLedgerView() (types.LedgerSt
 	return nil, errors.New("not implemented in mock")
 }
 
-// setupGatewayBalancesTestServices initializes the Services singleton with a mock for testing
-func setupGatewayBalancesTestServices(mock *mockGatewayBalancesLedgerService) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+// newGatewayBalancesTestServices builds a per-test ServiceContainer wrapping mock.
+func newGatewayBalancesTestServices(mock *mockGatewayBalancesLedgerService) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -180,14 +176,14 @@ func setupGatewayBalancesTestServices(mock *mockGatewayBalancesLedgerService) fu
 // Based on rippled GatewayBalances_test.cpp
 func TestGatewayBalancesErrorValidation(t *testing.T) {
 	mock := newMockGatewayBalancesLedgerService()
-	cleanup := setupGatewayBalancesTestServices(mock)
-	defer cleanup()
+	services := newGatewayBalancesTestServices(mock)
 
 	method := &handlers.GatewayBalancesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -267,8 +263,7 @@ func TestGatewayBalancesErrorValidation(t *testing.T) {
 // Based on rippled GatewayBalances_test.cpp testGWBApiVersions
 func TestGatewayBalancesInvalidHotwallet(t *testing.T) {
 	mock := newMockGatewayBalancesLedgerService()
-	cleanup := setupGatewayBalancesTestServices(mock)
-	defer cleanup()
+	services := newGatewayBalancesTestServices(mock)
 
 	method := &handlers.GatewayBalancesMethod{}
 
@@ -281,6 +276,7 @@ func TestGatewayBalancesInvalidHotwallet(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := map[string]interface{}{
@@ -304,6 +300,7 @@ func TestGatewayBalancesInvalidHotwallet(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion2,
+			Services:   services,
 		}
 
 		params := map[string]interface{}{
@@ -325,14 +322,14 @@ func TestGatewayBalancesInvalidHotwallet(t *testing.T) {
 // Based on rippled GatewayBalances_test.cpp testGWB
 func TestGatewayBalancesBasic(t *testing.T) {
 	mock := newMockGatewayBalancesLedgerService()
-	cleanup := setupGatewayBalancesTestServices(mock)
-	defer cleanup()
+	services := newGatewayBalancesTestServices(mock)
 
 	method := &handlers.GatewayBalancesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	aliceAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -559,14 +556,14 @@ func TestGatewayBalancesBasic(t *testing.T) {
 // TestGatewayBalancesHotwalletFormats tests different hotwallet parameter formats
 func TestGatewayBalancesHotwalletFormats(t *testing.T) {
 	mock := newMockGatewayBalancesLedgerService()
-	cleanup := setupGatewayBalancesTestServices(mock)
-	defer cleanup()
+	services := newGatewayBalancesTestServices(mock)
 
 	method := &handlers.GatewayBalancesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	aliceAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -641,15 +638,12 @@ func TestGatewayBalancesHotwalletFormats(t *testing.T) {
 
 // TestGatewayBalancesServiceUnavailable tests behavior when ledger service is not available
 func TestGatewayBalancesServiceUnavailable(t *testing.T) {
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.GatewayBalancesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{
@@ -686,14 +680,14 @@ func TestGatewayBalancesMethodMetadata(t *testing.T) {
 // TestGatewayBalancesResponseFields tests that all required fields are present
 func TestGatewayBalancesResponseFields(t *testing.T) {
 	mock := newMockGatewayBalancesLedgerService()
-	cleanup := setupGatewayBalancesTestServices(mock)
-	defer cleanup()
+	services := newGatewayBalancesTestServices(mock)
 
 	method := &handlers.GatewayBalancesMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.gatewayBalancesResult = &types.GatewayBalancesResult{

--- a/internal/rpc/handlers/account_channels.go
+++ b/internal/rpc/handlers/account_channels.go
@@ -32,7 +32,7 @@ func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMes
 		}
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -44,7 +44,7 @@ func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMes
 
 	// Get account channels from the ledger service
 	limit := ClampLimit(request.Limit, LimitAccountChannels, ctx.IsAdmin)
-	result, err := types.Services.Ledger.GetAccountChannels(
+	result, err := ctx.Services.Ledger.GetAccountChannels(
 		request.Account,
 		request.DestinationAccount,
 		ledgerIndex,

--- a/internal/rpc/handlers/account_currencies.go
+++ b/internal/rpc/handlers/account_currencies.go
@@ -24,7 +24,7 @@ func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -35,7 +35,7 @@ func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawM
 	}
 
 	// Get account currencies from the ledger service
-	result, err := types.Services.Ledger.GetAccountCurrencies(
+	result, err := ctx.Services.Ledger.GetAccountCurrencies(
 		request.Account,
 		ledgerIndex,
 	)

--- a/internal/rpc/handlers/account_info.go
+++ b/internal/rpc/handlers/account_info.go
@@ -68,7 +68,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -98,7 +98,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	info, err := types.Services.Ledger.GetAccountInfo(request.Account, ledgerIndex)
+	info, err := ctx.Services.Ledger.GetAccountInfo(request.Account, ledgerIndex)
 	if err != nil {
 		if err.Error() == "account not found" {
 			return nil, types.RpcErrorActNotFound("Account not found.")
@@ -156,7 +156,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 
 	// Load signer lists if requested
 	if request.SignerLists {
-		signerLists := m.loadSignerLists(request.Account, ledgerIndex)
+		signerLists := m.loadSignerLists(ctx.Services, request.Account, ledgerIndex)
 		if ctx.ApiVersion > 1 {
 			// API v2: signer_lists at top level
 			response["signer_lists"] = signerLists
@@ -221,8 +221,8 @@ func (m *AccountInfoMethod) buildAccountData(info *types.AccountInfo) map[string
 }
 
 // loadSignerLists retrieves signer list objects for an account
-func (m *AccountInfoMethod) loadSignerLists(account string, ledgerIndex string) []interface{} {
-	result, err := types.Services.Ledger.GetAccountObjects(account, ledgerIndex, "SignerList", 10)
+func (m *AccountInfoMethod) loadSignerLists(services *types.ServiceContainer, account string, ledgerIndex string) []interface{} {
+	result, err := services.Ledger.GetAccountObjects(account, ledgerIndex, "SignerList", 10)
 	if err != nil || len(result.AccountObjects) == 0 {
 		return []interface{}{}
 	}

--- a/internal/rpc/handlers/account_lines.go
+++ b/internal/rpc/handlers/account_lines.go
@@ -33,7 +33,7 @@ func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		}
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -44,7 +44,7 @@ func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 	}
 
 	limit := ClampLimit(request.Limit, LimitAccountLines, ctx.IsAdmin)
-	result, err := types.Services.Ledger.GetAccountLines(request.Account, ledgerIndex, request.Peer, limit)
+	result, err := ctx.Services.Ledger.GetAccountLines(request.Account, ledgerIndex, request.Peer, limit)
 	if err != nil {
 		if err.Error() == "account not found" {
 			return nil, &types.RpcError{

--- a/internal/rpc/handlers/account_nfts.go
+++ b/internal/rpc/handlers/account_nfts.go
@@ -24,7 +24,7 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -35,7 +35,7 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	}
 
 	limit := ClampLimit(request.Limit, LimitAccountNFTokens, ctx.IsAdmin)
-	result, err := types.Services.Ledger.GetAccountNFTs(
+	result, err := ctx.Services.Ledger.GetAccountNFTs(
 		request.Account,
 		ledgerIndex,
 		limit,

--- a/internal/rpc/handlers/account_objects.go
+++ b/internal/rpc/handlers/account_objects.go
@@ -111,7 +111,7 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -163,7 +163,7 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		}
 	}
 
-	result, err := types.Services.Ledger.GetAccountObjects(request.Account, ledgerIndex, effectiveType, limit)
+	result, err := ctx.Services.Ledger.GetAccountObjects(request.Account, ledgerIndex, effectiveType, limit)
 	if err != nil {
 		if err.Error() == "account not found" {
 			return nil, &types.RpcError{

--- a/internal/rpc/handlers/account_offers.go
+++ b/internal/rpc/handlers/account_offers.go
@@ -25,7 +25,7 @@ func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -36,7 +36,7 @@ func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	}
 
 	limit := ClampLimit(request.Limit, LimitAccountOffers, ctx.IsAdmin)
-	result, err := types.Services.Ledger.GetAccountOffers(request.Account, ledgerIndex, limit)
+	result, err := ctx.Services.Ledger.GetAccountOffers(request.Account, ledgerIndex, limit)
 	if err != nil {
 		if err.Error() == "account not found" {
 			return nil, &types.RpcError{

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -34,7 +34,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -95,7 +95,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		}
 	}
 
-	result, err := types.Services.Ledger.GetAccountTransactions(
+	result, err := ctx.Services.Ledger.GetAccountTransactions(
 		request.Account,
 		int64(ledgerIndexMin),
 		int64(ledgerIndexMax),
@@ -133,7 +133,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 			return entry
 		}
 		entry := &ledgerCacheEntry{}
-		ledger, lookupErr := types.Services.Ledger.GetLedgerBySequence(seq)
+		ledger, lookupErr := ctx.Services.Ledger.GetLedgerBySequence(seq)
 		if lookupErr == nil && ledger != nil {
 			entry.hash = ledger.Hash()
 			entry.closeTimeSec = ledger.CloseTime()
@@ -143,7 +143,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		return entry
 	}
 
-	serverInfo := types.Services.Ledger.GetServerInfo()
+	serverInfo := ctx.Services.Ledger.GetServerInfo()
 	networkID := serverInfo.NetworkID
 
 	isV2 := ctx.ApiVersion > 1

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -38,7 +38,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		return nil, types.RpcErrorInvalidParams("Must specify either (asset + asset2) or amm_account, but not both or neither")
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -62,7 +62,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		copy(accountIDArray[:], accountID)
 		accountKey := keylet.Account(accountIDArray)
 
-		accountEntry, lookupErr := types.Services.Ledger.GetLedgerEntry(accountKey.Key, ledgerIndex)
+		accountEntry, lookupErr := ctx.Services.Ledger.GetLedgerEntry(accountKey.Key, ledgerIndex)
 		if lookupErr != nil {
 			return nil, &types.RpcError{
 				Code:    19,
@@ -105,7 +105,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		ammKey = ammKeylet.Key
 	}
 
-	ammEntry, err := types.Services.Ledger.GetLedgerEntry(ammKey, ledgerIndex)
+	ammEntry, err := ctx.Services.Ledger.GetLedgerEntry(ammKey, ledgerIndex)
 	if err != nil {
 		return nil, types.RpcErrorActNotFound("AMM not found")
 	}
@@ -169,7 +169,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	// rippled: ammAuctionTimeSlot(ledger->info().parentCloseTime, auctionSlot)
 	var parentCloseTime uint64
 	if ammEntry.LedgerIndex > 0 {
-		if lr, lrErr := types.Services.Ledger.GetLedgerBySequence(ammEntry.LedgerIndex); lrErr == nil && lr != nil {
+		if lr, lrErr := ctx.Services.Ledger.GetLedgerBySequence(ammEntry.LedgerIndex); lrErr == nil && lr != nil {
 			pct := lr.ParentCloseTime()
 			if pct > 0 {
 				parentCloseTime = uint64(pct)

--- a/internal/rpc/handlers/book_changes.go
+++ b/internal/rpc/handlers/book_changes.go
@@ -38,21 +38,21 @@ func (m *BookChangesMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
 	// Resolve ledger - default to validated
-	ledgerSeq := types.Services.Ledger.GetValidatedLedgerIndex()
+	ledgerSeq := ctx.Services.Ledger.GetValidatedLedgerIndex()
 	if request.LedgerIndex != "" {
 		li := request.LedgerIndex.String()
 		switch li {
 		case "current":
-			ledgerSeq = types.Services.Ledger.GetCurrentLedgerIndex()
+			ledgerSeq = ctx.Services.Ledger.GetCurrentLedgerIndex()
 		case "closed":
-			ledgerSeq = types.Services.Ledger.GetClosedLedgerIndex()
+			ledgerSeq = ctx.Services.Ledger.GetClosedLedgerIndex()
 		case "validated":
-			ledgerSeq = types.Services.Ledger.GetValidatedLedgerIndex()
+			ledgerSeq = ctx.Services.Ledger.GetValidatedLedgerIndex()
 		default:
 			if n, err := strconv.ParseUint(li, 10, 32); err == nil {
 				ledgerSeq = uint32(n)
@@ -60,7 +60,7 @@ func (m *BookChangesMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	targetLedger, err := types.Services.Ledger.GetLedgerBySequence(ledgerSeq)
+	targetLedger, err := ctx.Services.Ledger.GetLedgerBySequence(ledgerSeq)
 	if err != nil {
 		// For the current (open) ledger, return empty changes since no
 		// transactions have been finalized yet.

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -27,7 +27,7 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, types.RpcErrorInvalidParams("Both taker_gets and taker_pays are required")
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -60,7 +60,7 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	// Clamp the limit using rippled's bookOffers range {0, 60, 100}.
 	// When the user omits "limit" (zero value), ClampLimit returns the default (60).
 	limit := ClampLimit(request.Limit, LimitBookOffers, ctx.IsAdmin)
-	result, err := types.Services.Ledger.GetBookOffers(takerGets, takerPays, ledgerIndex, limit)
+	result, err := ctx.Services.Ledger.GetBookOffers(takerGets, takerPays, ledgerIndex, limit)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to get book offers: " + err.Error())
 	}

--- a/internal/rpc/handlers/deposit_authorized.go
+++ b/internal/rpc/handlers/deposit_authorized.go
@@ -53,7 +53,7 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		}
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -71,7 +71,7 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	//   3. Credential expiry — checkExpired(sleCred, parentCloseTime) → rpcBAD_CREDENTIALS "credentials are expired"
 	//   4. Credential ownership — sleCred[sfSubject] == srcAcct → rpcBAD_CREDENTIALS "credentials doesn't belong to the root account"
 	//   5. Credential duplicates by (issuer, credentialType) — rpcBAD_CREDENTIALS "duplicates in credentials"
-	result, err := types.Services.Ledger.GetDepositAuthorized(
+	result, err := ctx.Services.Ledger.GetDepositAuthorized(
 		request.SourceAccount,
 		request.DestinationAccount,
 		ledgerIndex,

--- a/internal/rpc/handlers/feature.go
+++ b/internal/rpc/handlers/feature.go
@@ -26,7 +26,7 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	}
 
 	// Read the enabled amendments from the ledger.
-	enabledSet := m.getEnabledAmendments()
+	enabledSet := m.getEnabledAmendments(ctx.Services)
 
 	// If a specific feature is requested, return just that one
 	if request.Feature != "" {
@@ -78,12 +78,12 @@ func (m *FeatureMethod) handleSingleFeature(feature string, enabledSet map[[32]b
 // the set of amendment hashes that are actually enabled on-ledger.
 // Returns nil if the ledger is unavailable, meaning the caller should fall back
 // to deriving enabled status from the registry defaults.
-func (m *FeatureMethod) getEnabledAmendments() map[[32]byte]bool {
-	if types.Services == nil || types.Services.Ledger == nil {
+func (m *FeatureMethod) getEnabledAmendments(services *types.ServiceContainer) map[[32]byte]bool {
+	if services == nil || services.Ledger == nil {
 		return nil
 	}
 
-	view, err := types.Services.Ledger.GetClosedLedgerView()
+	view, err := services.Ledger.GetClosedLedgerView()
 	if err != nil || view == nil {
 		return nil
 	}

--- a/internal/rpc/handlers/fee.go
+++ b/internal/rpc/handlers/fee.go
@@ -21,12 +21,12 @@ import (
 type FeeMethod struct{}
 
 func (m *FeeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
-	baseFee, _, _ := types.Services.Ledger.GetCurrentFees()
-	currentLedgerIndex := types.Services.Ledger.GetCurrentLedgerIndex()
+	baseFee, _, _ := ctx.Services.Ledger.GetCurrentFees()
+	currentLedgerIndex := ctx.Services.Ledger.GetCurrentLedgerIndex()
 
 	baseFeeStr := fmt.Sprintf("%d", baseFee)
 
@@ -39,7 +39,7 @@ func (m *FeeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inter
 	// max_queue_size = ledgersInQueue * txPerLedger.
 	expectedLedgerSize := "32"
 	maxQueueSize := "640"
-	if types.Services.Ledger.IsStandalone() {
+	if ctx.Services.Ledger.IsStandalone() {
 		expectedLedgerSize = "1000"
 		maxQueueSize = "20000"
 	}

--- a/internal/rpc/handlers/gateway_balances.go
+++ b/internal/rpc/handlers/gateway_balances.go
@@ -25,7 +25,7 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -63,7 +63,7 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 	}
 
 	// Get gateway balances from the ledger service
-	result, err := types.Services.Ledger.GetGatewayBalances(
+	result, err := ctx.Services.Ledger.GetGatewayBalances(
 		request.Account,
 		hotWallets,
 		ledgerIndex,

--- a/internal/rpc/handlers/get_aggregate_price.go
+++ b/internal/rpc/handlers/get_aggregate_price.go
@@ -99,7 +99,7 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -165,7 +165,7 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		}
 
 		oracleKeylet := keylet.Oracle(accountID, documentID)
-		oracleEntry, lookupErr := types.Services.Ledger.GetLedgerEntry(oracleKeylet.Key, ledgerIndex)
+		oracleEntry, lookupErr := ctx.Services.Ledger.GetLedgerEntry(oracleKeylet.Key, ledgerIndex)
 		if lookupErr != nil {
 			continue
 		}

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -10,10 +10,10 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx"
 )
 
-// RequireLedgerService checks that the ledger service is available.
-// Returns an RpcError if the service is nil.
-func RequireLedgerService() *types.RpcError {
-	if types.Services == nil || types.Services.Ledger == nil {
+// RequireLedgerService checks that the ledger service is available
+// on the request's service container. Returns an RpcError if not.
+func RequireLedgerService(services *types.ServiceContainer) *types.RpcError {
+	if services == nil || services.Ledger == nil {
 		return types.RpcErrorInternal("Ledger service not available")
 	}
 	return nil

--- a/internal/rpc/handlers/json.go
+++ b/internal/rpc/handlers/json.go
@@ -27,7 +27,7 @@ func (m *JsonMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inte
 		return nil, types.RpcErrorInvalidParams("Missing required parameter: method")
 	}
 
-	if types.Services == nil || types.Services.Dispatcher == nil {
+	if ctx.Services == nil || ctx.Services.Dispatcher == nil {
 		return nil, types.RpcErrorInternal("Method dispatcher not available")
 	}
 
@@ -44,5 +44,5 @@ func (m *JsonMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inte
 		}
 	}
 
-	return types.Services.Dispatcher.ExecuteMethod(request.Method, forwardParams)
+	return ctx.Services.Dispatcher.ExecuteMethod(request.Method, forwardParams)
 }

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -34,7 +34,7 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -50,7 +50,7 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		}
 		var hash [32]byte
 		copy(hash[:], hashBytes)
-		targetLedger, err = types.Services.Ledger.GetLedgerByHash(hash)
+		targetLedger, err = ctx.Services.Ledger.GetLedgerByHash(hash)
 		if err != nil {
 			return nil, &types.RpcError{Code: -1, ErrorString: "lgrNotFound", Message: "Ledger not found"}
 		}
@@ -63,26 +63,26 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 
 		switch ledgerIndex {
 		case "validated":
-			seq := types.Services.Ledger.GetValidatedLedgerIndex()
+			seq := ctx.Services.Ledger.GetValidatedLedgerIndex()
 			if seq == 0 {
 				return nil, &types.RpcError{Code: -1, ErrorString: "lgrNotFound", Message: "No validated ledger"}
 			}
-			targetLedger, err = types.Services.Ledger.GetLedgerBySequence(seq)
+			targetLedger, err = ctx.Services.Ledger.GetLedgerBySequence(seq)
 			validated = true
 		case "current":
-			seq := types.Services.Ledger.GetCurrentLedgerIndex()
-			targetLedger, err = types.Services.Ledger.GetLedgerBySequence(seq)
+			seq := ctx.Services.Ledger.GetCurrentLedgerIndex()
+			targetLedger, err = ctx.Services.Ledger.GetLedgerBySequence(seq)
 			validated = false
 		case "closed":
-			seq := types.Services.Ledger.GetClosedLedgerIndex()
-			targetLedger, err = types.Services.Ledger.GetLedgerBySequence(seq)
+			seq := ctx.Services.Ledger.GetClosedLedgerIndex()
+			targetLedger, err = ctx.Services.Ledger.GetLedgerBySequence(seq)
 			validated = targetLedger != nil && targetLedger.IsValidated()
 		default:
 			seq, parseErr := strconv.ParseUint(ledgerIndex, 10, 32)
 			if parseErr != nil {
 				return nil, types.RpcErrorInvalidParams("Invalid ledger_index")
 			}
-			targetLedger, err = types.Services.Ledger.GetLedgerBySequence(uint32(seq))
+			targetLedger, err = ctx.Services.Ledger.GetLedgerBySequence(uint32(seq))
 			if err != nil {
 				return nil, &types.RpcError{Code: -1, ErrorString: "lgrNotFound", Message: "Ledger not found"}
 			}
@@ -110,7 +110,7 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 	closeTimeHuman := closeTime.UTC().Format("2006-Jan-02 15:04:05.000000000 UTC")
 	closeTimeISO := closeTime.UTC().Format(time.RFC3339)
 
-	_, reserveBase, reserveInc := types.Services.Ledger.GetCurrentFees()
+	_, reserveBase, reserveInc := ctx.Services.Ledger.GetCurrentFees()
 
 	ledgerInfo := map[string]interface{}{
 		"accepted":              true,

--- a/internal/rpc/handlers/ledger_accept.go
+++ b/internal/rpc/handlers/ledger_accept.go
@@ -12,16 +12,16 @@ import (
 type LedgerAcceptMethod struct{}
 
 func (m *LedgerAcceptMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
-	if !types.Services.Ledger.IsStandalone() {
+	if !ctx.Services.Ledger.IsStandalone() {
 		return nil, types.NewRpcError(types.RpcNOT_STANDALONE, "notStandalone", "notStandalone",
 			"ledger_accept is only available in standalone mode")
 	}
 
-	closedSeq, err := types.Services.Ledger.AcceptLedger()
+	closedSeq, err := ctx.Services.Ledger.AcceptLedger()
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to accept ledger: " + err.Error())
 	}

--- a/internal/rpc/handlers/ledger_closed.go
+++ b/internal/rpc/handlers/ledger_closed.go
@@ -11,16 +11,16 @@ import (
 type LedgerClosedMethod struct{}
 
 func (m *LedgerClosedMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
-	seq := types.Services.Ledger.GetClosedLedgerIndex()
+	seq := ctx.Services.Ledger.GetClosedLedgerIndex()
 	if seq == 0 {
 		return nil, &types.RpcError{Code: -1, ErrorString: "lgrNotFound", Message: "No closed ledger"}
 	}
 
-	ledger, err := types.Services.Ledger.GetLedgerBySequence(seq)
+	ledger, err := ctx.Services.Ledger.GetLedgerBySequence(seq)
 	if err != nil {
 		return nil, &types.RpcError{Code: -1, ErrorString: "lgrNotFound", Message: "Closed ledger not found"}
 	}

--- a/internal/rpc/handlers/ledger_current.go
+++ b/internal/rpc/handlers/ledger_current.go
@@ -10,11 +10,11 @@ import (
 type LedgerCurrentMethod struct{}
 
 func (m *LedgerCurrentMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
-	seq := types.Services.Ledger.GetCurrentLedgerIndex()
+	seq := ctx.Services.Ledger.GetCurrentLedgerIndex()
 	if seq == 0 {
 		return nil, &types.RpcError{Code: -1, ErrorString: "lgrNotFound", Message: "No current ledger"}
 	}

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -27,7 +27,7 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -54,7 +54,7 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		}
 	}
 
-	result, err := types.Services.Ledger.GetLedgerData(ledgerIndex, limit, markerStr)
+	result, err := ctx.Services.Ledger.GetLedgerData(ledgerIndex, limit, markerStr)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to get ledger data: " + err.Error())
 	}

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -22,7 +22,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -363,7 +363,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, types.RpcErrorUnknownOption("Must specify object to look up")
 	}
 
-	result, err := types.Services.Ledger.GetLedgerEntry(entryKey, ledgerIndex)
+	result, err := ctx.Services.Ledger.GetLedgerEntry(entryKey, ledgerIndex)
 	if err != nil {
 		if err.Error() == "entry not found" {
 			return nil, types.RpcErrorEntryNotFound("Requested ledger entry not found.")

--- a/internal/rpc/handlers/ledger_header.go
+++ b/internal/rpc/handlers/ledger_header.go
@@ -32,7 +32,7 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		}
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -47,28 +47,28 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		}
 		var hash [32]byte
 		copy(hash[:], hashBytes)
-		targetLedger, lookupErr = types.Services.Ledger.GetLedgerByHash(hash)
+		targetLedger, lookupErr = ctx.Services.Ledger.GetLedgerByHash(hash)
 	} else if request.LedgerIndex != "" {
 		ledgerIndexStr := request.LedgerIndex.String()
 		switch ledgerIndexStr {
 		case "validated":
-			seq := types.Services.Ledger.GetValidatedLedgerIndex()
-			targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+			seq := ctx.Services.Ledger.GetValidatedLedgerIndex()
+			targetLedger, lookupErr = ctx.Services.Ledger.GetLedgerBySequence(seq)
 		case "closed":
-			seq := types.Services.Ledger.GetClosedLedgerIndex()
-			targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+			seq := ctx.Services.Ledger.GetClosedLedgerIndex()
+			targetLedger, lookupErr = ctx.Services.Ledger.GetLedgerBySequence(seq)
 		case "current":
-			seq := types.Services.Ledger.GetCurrentLedgerIndex()
-			targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+			seq := ctx.Services.Ledger.GetCurrentLedgerIndex()
+			targetLedger, lookupErr = ctx.Services.Ledger.GetLedgerBySequence(seq)
 			if lookupErr != nil {
 				// Open ledger may not be in history yet; fall back to closed ledger.
-				seq = types.Services.Ledger.GetClosedLedgerIndex()
-				targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+				seq = ctx.Services.Ledger.GetClosedLedgerIndex()
+				targetLedger, lookupErr = ctx.Services.Ledger.GetLedgerBySequence(seq)
 			}
 		default:
 			var seq uint32
 			if _, scanErr := fmt.Sscanf(ledgerIndexStr, "%d", &seq); scanErr == nil {
-				targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+				targetLedger, lookupErr = ctx.Services.Ledger.GetLedgerBySequence(seq)
 			} else {
 				return nil, types.RpcErrorInvalidParams("Invalid ledger_index: " + ledgerIndexStr)
 			}
@@ -76,8 +76,8 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 	} else {
 		// Default to validated (rippled defaults to current via lookupLedger,
 		// but for ledger_header the common usage is validated)
-		seq := types.Services.Ledger.GetValidatedLedgerIndex()
-		targetLedger, lookupErr = types.Services.Ledger.GetLedgerBySequence(seq)
+		seq := ctx.Services.Ledger.GetValidatedLedgerIndex()
+		targetLedger, lookupErr = ctx.Services.Ledger.GetLedgerBySequence(seq)
 	}
 
 	if lookupErr != nil || targetLedger == nil {

--- a/internal/rpc/handlers/ledger_range.go
+++ b/internal/rpc/handlers/ledger_range.go
@@ -35,11 +35,11 @@ func (m *LedgerRangeMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, types.RpcErrorInvalidParams("Ledger range too large (max 1000 ledgers)")
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
-	result, err := types.Services.Ledger.GetLedgerRange(request.StartLedger, request.StopLedger)
+	result, err := ctx.Services.Ledger.GetLedgerRange(request.StartLedger, request.StopLedger)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to get ledger range: " + err.Error())
 	}

--- a/internal/rpc/handlers/manifest.go
+++ b/internal/rpc/handlers/manifest.go
@@ -58,10 +58,10 @@ func (m *ManifestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	// Manifest cache isn't wired in standalone / pre-consensus setups
 	// — return the sparse response so clients can still probe the
 	// method without a 500.
-	if types.Services == nil || types.Services.Manifests == nil {
+	if ctx.Services == nil || ctx.Services.Manifests == nil {
 		return resp, nil
 	}
-	cache := types.Services.Manifests
+	cache := ctx.Services.Manifests
 
 	// Callers may pass EITHER the master key or its ephemeral signing
 	// key. GetMasterKey collapses both into the master; if the input

--- a/internal/rpc/handlers/manifest_test.go
+++ b/internal/rpc/handlers/manifest_test.go
@@ -91,16 +91,13 @@ func deterministicEd25519KeypairRPC(seed byte) ([]byte, []byte) {
 	return append([]byte{0xED}, pub...), priv
 }
 
-// withServices replaces the global types.Services for the duration of a
-// test and restores it on cleanup.
-func withServices(t *testing.T, cache types.ManifestLookup) {
-	t.Helper()
-	prev := types.Services
-	types.Services = &types.ServiceContainer{Manifests: cache}
-	t.Cleanup(func() { types.Services = prev })
+// servicesForCache builds a per-test ServiceContainer wired to the given
+// manifest cache.
+func servicesForCache(cache types.ManifestLookup) *types.ServiceContainer {
+	return &types.ServiceContainer{Manifests: cache}
 }
 
-func callManifestRPC(t *testing.T, publicKey string) (map[string]any, *types.RpcError) {
+func callManifestRPC(t *testing.T, services *types.ServiceContainer, publicKey string) (map[string]any, *types.RpcError) {
 	t.Helper()
 	var params json.RawMessage
 	if publicKey != "" {
@@ -110,7 +107,7 @@ func callManifestRPC(t *testing.T, publicKey string) (map[string]any, *types.Rpc
 		params = json.RawMessage(`{}`)
 	}
 	method := &handlers.ManifestMethod{}
-	result, rpcErr := method.Handle(&types.RpcContext{}, params)
+	result, rpcErr := method.Handle(&types.RpcContext{Services: services}, params)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
@@ -124,7 +121,7 @@ func callManifestRPC(t *testing.T, publicKey string) (map[string]any, *types.Rpc
 
 func TestRPC_Manifest_ReturnsStoredState_ByMasterKey(t *testing.T) {
 	cache, master, ephemeral, serialized := buildAndApplyManifest(t)
-	withServices(t, cache)
+	services := servicesForCache(cache)
 
 	masterB58, err := addresscodec.EncodeNodePublicKey(master[:])
 	if err != nil {
@@ -135,7 +132,7 @@ func TestRPC_Manifest_ReturnsStoredState_ByMasterKey(t *testing.T) {
 		t.Fatalf("encode ephemeral: %v", err)
 	}
 
-	out, rpcErr := callManifestRPC(t, masterB58)
+	out, rpcErr := callManifestRPC(t, services, masterB58)
 	if rpcErr != nil {
 		t.Fatalf("rpc error: %v", rpcErr)
 	}
@@ -168,14 +165,14 @@ func TestRPC_Manifest_ReturnsStoredState_ByMasterKey(t *testing.T) {
 
 func TestRPC_Manifest_ByEphemeralKey_ResolvesToMaster(t *testing.T) {
 	cache, master, ephemeral, _ := buildAndApplyManifest(t)
-	withServices(t, cache)
+	services := servicesForCache(cache)
 
 	masterB58, _ := addresscodec.EncodeNodePublicKey(master[:])
 	ephemeralB58, _ := addresscodec.EncodeNodePublicKey(ephemeral[:])
 
 	// Query with the EPHEMERAL key — the handler must resolve up to
 	// the master via GetMasterKey and return the master in details.
-	out, rpcErr := callManifestRPC(t, ephemeralB58)
+	out, rpcErr := callManifestRPC(t, services, ephemeralB58)
 	if rpcErr != nil {
 		t.Fatalf("rpc error: %v", rpcErr)
 	}
@@ -190,12 +187,12 @@ func TestRPC_Manifest_ByEphemeralKey_ResolvesToMaster(t *testing.T) {
 
 func TestRPC_Manifest_UnknownKey_ReturnsSparseResponse(t *testing.T) {
 	cache := manifest.NewCache()
-	withServices(t, cache)
+	services := servicesForCache(cache)
 
 	unknownBytes, _ := deterministicEd25519KeypairRPC(0x99)
 	unknownB58, _ := addresscodec.EncodeNodePublicKey(unknownBytes)
 
-	out, rpcErr := callManifestRPC(t, unknownB58)
+	out, rpcErr := callManifestRPC(t, services, unknownB58)
 	if rpcErr != nil {
 		t.Fatalf("rpc error: %v", rpcErr)
 	}
@@ -212,9 +209,9 @@ func TestRPC_Manifest_UnknownKey_ReturnsSparseResponse(t *testing.T) {
 
 func TestRPC_Manifest_MissingPublicKey_InvalidParams(t *testing.T) {
 	cache := manifest.NewCache()
-	withServices(t, cache)
+	services := servicesForCache(cache)
 
-	_, rpcErr := callManifestRPC(t, "")
+	_, rpcErr := callManifestRPC(t, services, "")
 	if rpcErr == nil {
 		t.Fatal("expected error on missing public_key")
 	}

--- a/internal/rpc/handlers/nft_buy_offers.go
+++ b/internal/rpc/handlers/nft_buy_offers.go
@@ -43,7 +43,7 @@ func (m *NftBuyOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 	var nftID [32]byte
 	copy(nftID[:], nftIDBytes)
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +72,7 @@ func (m *NftBuyOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		}
 	}
 
-	result, err := types.Services.Ledger.GetNFTBuyOffers(nftID, ledgerIndex, limit, marker)
+	result, err := ctx.Services.Ledger.GetNFTBuyOffers(nftID, ledgerIndex, limit, marker)
 	if err != nil {
 		if err.Error() == "ledger not found" {
 			return nil, types.RpcErrorLgrNotFound("Ledger not found.")

--- a/internal/rpc/handlers/nft_sell_offers.go
+++ b/internal/rpc/handlers/nft_sell_offers.go
@@ -43,7 +43,7 @@ func (m *NftSellOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	var nftID [32]byte
 	copy(nftID[:], nftIDBytes)
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +72,7 @@ func (m *NftSellOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		}
 	}
 
-	result, err := types.Services.Ledger.GetNFTSellOffers(nftID, ledgerIndex, limit, marker)
+	result, err := ctx.Services.Ledger.GetNFTSellOffers(nftID, ledgerIndex, limit, marker)
 	if err != nil {
 		if err.Error() == "ledger not found" {
 			return nil, types.RpcErrorLgrNotFound("Ledger not found.")

--- a/internal/rpc/handlers/noripple_check.go
+++ b/internal/rpc/handlers/noripple_check.go
@@ -51,7 +51,7 @@ func (m *NoRippleCheckMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		}
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -64,7 +64,7 @@ func (m *NoRippleCheckMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	// Apply limit clamping matching rippled's readLimitField with noRippleCheck tuning
 	limit := ClampLimit(request.Limit, LimitNoRippleCheck, ctx.IsAdmin)
 
-	result, err := types.Services.Ledger.GetNoRippleCheck(
+	result, err := ctx.Services.Ledger.GetNoRippleCheck(
 		request.Account,
 		request.Role,
 		ledgerIndex,

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -103,7 +103,7 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		srcCurrencies = append(srcCurrencies, issue)
 	}
 
-	view, err := types.Services.Ledger.GetClosedLedgerView()
+	view, err := ctx.Services.Ledger.GetClosedLedgerView()
 	if err != nil {
 		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
 			"No closed ledger available")

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -33,11 +33,11 @@ func resolveHostID() string {
 type ServerInfoMethod struct{ BaseHandler }
 
 func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
-	info := buildServerInfo(true)
+	info := buildServerInfo(ctx.Services, true)
 
 	response := map[string]interface{}{
 		"info": info,
@@ -49,9 +49,9 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 // buildServerInfo constructs the info/state object.
 // When human is true it produces the server_info format (XRP decimals, converge_time_s, hostid).
 // When human is false it produces the server_state format (drops integers, converge_time, load_base, etc.).
-func buildServerInfo(human bool) map[string]interface{} {
-	serverInfo := types.Services.Ledger.GetServerInfo()
-	baseFee, reserveBase, reserveIncrement := types.Services.Ledger.GetCurrentFees()
+func buildServerInfo(services *types.ServiceContainer, human bool) map[string]interface{} {
+	serverInfo := services.Ledger.GetServerInfo()
+	baseFee, reserveBase, reserveIncrement := services.Ledger.GetCurrentFees()
 
 	// Uptime in seconds
 	uptimeDuration := time.Since(serverStartTime)
@@ -83,11 +83,11 @@ func buildServerInfo(human bool) map[string]interface{} {
 		"build_version":     BuildVersion,
 		"complete_ledgers":  completeLedgers,
 		"io_latency_ms":     observability.SchedLatencyMs(),
-		"pubkey_node":       types.Services.NodePublicKey,
+		"pubkey_node":       services.NodePublicKey,
 		"server_state":      serverState,
 		"uptime":            uptime,
 		"validation_quorum": 1, // TODO: get from consensus/validators
-		"peers":             getPeerCount(),
+		"peers":             getPeerCount(services),
 
 		// Overflow/disconnect counters (string in rippled)
 		"jq_trans_overflow":          "0", // TODO: track real overflow count
@@ -137,8 +137,8 @@ func buildServerInfo(human bool) map[string]interface{} {
 	// last_close: converge_time_s (float seconds) for human, converge_time (int ms) for machine
 	proposers := 0
 	convergeTimeMs := 0
-	if types.Services.LastCloseInfo != nil {
-		proposers, convergeTimeMs = types.Services.LastCloseInfo()
+	if services.LastCloseInfo != nil {
+		proposers, convergeTimeMs = services.LastCloseInfo()
 	}
 	if human {
 		info["last_close"] = map[string]interface{}{
@@ -224,16 +224,16 @@ func buildServerInfo(human bool) map[string]interface{} {
 	}
 
 	// amendment_blocked: rippled only includes this when true
-	if types.Services.Ledger.IsAmendmentBlocked() {
+	if services.Ledger.IsAmendmentBlocked() {
 		info["amendment_blocked"] = true
 	}
 
 	return info
 }
 
-func getPeerCount() int {
-	if types.Services.PeerCount != nil {
-		return types.Services.PeerCount()
+func getPeerCount(services *types.ServiceContainer) int {
+	if services.PeerCount != nil {
+		return services.PeerCount()
 	}
 	return 0
 }

--- a/internal/rpc/handlers/server_state.go
+++ b/internal/rpc/handlers/server_state.go
@@ -11,11 +11,11 @@ import (
 type ServerStateMethod struct{ BaseHandler }
 
 func (m *ServerStateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
-	state := buildServerInfo(false)
+	state := buildServerInfo(ctx.Services, false)
 
 	response := map[string]interface{}{
 		"state": state,

--- a/internal/rpc/handlers/sign.go
+++ b/internal/rpc/handlers/sign.go
@@ -40,7 +40,7 @@ func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inte
 	}
 
 	// Sign the transaction using the shared helper
-	signed, rpcErr := signTransactionJSON(request.TxJson, signCredentials{
+	signed, rpcErr := signTransactionJSON(ctx.Services, request.TxJson, signCredentials{
 		Secret:     request.Secret,
 		Seed:       request.Seed,
 		SeedHex:    request.SeedHex,

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -149,9 +149,9 @@ type signResult struct {
 // The feeOpts parameter controls auto-fee behavior: if Fee is not present in
 // tx_json and auto-fill is active, the network fee is computed and checked
 // against the limit baseFee * feeOpts.Mult / feeOpts.Div.
-func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline bool, apiVersion int, feeOpts feeOptions) (*signResult, *types.RpcError) {
+func signTransactionJSON(services *types.ServiceContainer, txJSON json.RawMessage, creds signCredentials, offline bool, apiVersion int, feeOpts feeOptions) (*signResult, *types.RpcError) {
 	// Check if ledger service is available (needed for auto-filling fields)
-	if !offline && (types.Services == nil || types.Services.Ledger == nil) {
+	if !offline && (services == nil || services.Ledger == nil) {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
@@ -194,7 +194,7 @@ func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline 
 		// Auto-fill Fee if not present, with fee_mult_max/fee_div_max limit check.
 		// This matches rippled's checkFee() in TransactionSign.cpp.
 		if _, ok := txMap["Fee"]; !ok {
-			baseFee, _, _ := types.Services.Ledger.GetCurrentFees()
+			baseFee, _, _ := services.Ledger.GetCurrentFees()
 
 			// In a full implementation, networkFee would incorporate load-based
 			// fee escalation. For now, networkFee == baseFee.
@@ -216,7 +216,7 @@ func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline 
 		if _, ok := txMap["Sequence"]; !ok {
 			// TODO: When ledger lookup is available, auto-fill from account state.
 			// For now, attempt to get account info.
-			info, err := types.Services.Ledger.GetAccountInfo(address, "current")
+			info, err := services.Ledger.GetAccountInfo(address, "current")
 			if err != nil {
 				return nil, types.RpcErrorInternal("Failed to get account sequence: " + err.Error())
 			}
@@ -225,7 +225,7 @@ func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline 
 
 		// Set LastLedgerSequence if not present (current + 4)
 		if _, ok := txMap["LastLedgerSequence"]; !ok {
-			currentLedger := types.Services.Ledger.GetCurrentLedgerIndex()
+			currentLedger := services.Ledger.GetCurrentLedgerIndex()
 			txMap["LastLedgerSequence"] = currentLedger + 4
 		}
 
@@ -234,7 +234,7 @@ func signTransactionJSON(txJSON json.RawMessage, creds signCredentials, offline 
 		// legacy networks (ID <= 1024) must NOT include NetworkID;
 		// new networks (ID > 1024) require it and it is auto-filled here.
 		if _, ok := txMap["NetworkID"]; !ok {
-			serverInfo := types.Services.Ledger.GetServerInfo()
+			serverInfo := services.Ledger.GetServerInfo()
 			if serverInfo.NetworkID > 1024 {
 				txMap["NetworkID"] = serverInfo.NetworkID
 			}

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -54,7 +54,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorInvalidParams("Neither `tx_blob` nor `tx_json` included.")
 	}
 
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
@@ -164,7 +164,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	// Autofill NetworkID if not present and network ID > 1024.
 	// Matches rippled's autofillTx() in Simulate.cpp.
 	if _, ok := txJsonMap["NetworkID"]; !ok {
-		serverInfo := types.Services.Ledger.GetServerInfo()
+		serverInfo := ctx.Services.Ledger.GetServerInfo()
 		if serverInfo.NetworkID > 1024 {
 			txJsonMap["NetworkID"] = serverInfo.NetworkID
 		}
@@ -183,7 +183,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	}
 
 	// Run the transaction in simulation mode (snapshot, no commit)
-	result, err := types.Services.Ledger.SimulateTransaction(txJSON)
+	result, err := ctx.Services.Ledger.SimulateTransaction(txJSON)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Simulation failed: " + err.Error())
 	}

--- a/internal/rpc/handlers/stop.go
+++ b/internal/rpc/handlers/stop.go
@@ -12,12 +12,12 @@ import (
 type StopMethod struct{ AdminHandler }
 
 func (m *StopMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if types.Services == nil || types.Services.ShutdownFunc == nil {
+	if ctx.Services == nil || ctx.Services.ShutdownFunc == nil {
 		return nil, types.RpcErrorInternal("Shutdown function not available")
 	}
 
 	// Trigger shutdown asynchronously so the response can be sent first
-	types.Services.ShutdownFunc()
+	ctx.Services.ShutdownFunc()
 
 	response := map[string]interface{}{
 		"message": "ripple server stopping",

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -18,7 +18,7 @@ import (
 type LedgerCleanerMethod struct{ AdminHandler }
 
 func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
@@ -36,7 +36,7 @@ func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 type PrintMethod struct{ AdminHandler }
 
 func (m *PrintMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
@@ -69,11 +69,11 @@ func (m *CanDeleteMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 type GetCountsMethod struct{ AdminHandler }
 
 func (m *GetCountsMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
-	serverInfo := types.Services.Ledger.GetServerInfo()
+	serverInfo := ctx.Services.Ledger.GetServerInfo()
 	return map[string]interface{}{
 		"standalone": serverInfo.Standalone,
 	}, nil
@@ -137,7 +137,7 @@ func (m *LogLevelMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 type LogRotateMethod struct{ AdminHandler }
 
 func (m *LogRotateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 

--- a/internal/rpc/handlers/stubs_network.go
+++ b/internal/rpc/handlers/stubs_network.go
@@ -24,7 +24,7 @@ func (m *FetchInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		_ = json.Unmarshal(params, &request)
 	}
 
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
@@ -47,11 +47,11 @@ func (m *FetchInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 type LedgerRequestMethod struct{ AdminHandler }
 
 func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
-	if types.Services.Ledger.IsStandalone() {
+	if ctx.Services.Ledger.IsStandalone() {
 		return nil, types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
 			"Not synced to the network")
 	}
@@ -70,7 +70,7 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 type TxReduceRelayMethod struct{}
 
 func (m *TxReduceRelayMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
@@ -119,11 +119,11 @@ func (m *ConnectMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		return nil, types.RpcErrorInvalidParams("Missing required parameter: ip")
 	}
 
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
-	if types.Services.Ledger.IsStandalone() {
+	if ctx.Services.Ledger.IsStandalone() {
 		return nil, types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
 			"Cannot connect to peers in standalone mode")
 	}
@@ -148,7 +148,7 @@ func (m *ConnectMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 type UnlListMethod struct{ AdminHandler }
 
 func (m *UnlListMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 
@@ -167,7 +167,7 @@ func (m *UnlListMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 type BlackListMethod struct{ AdminHandler }
 
 func (m *BlackListMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if types.Services == nil || types.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
 

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -44,7 +44,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		return nil, types.RpcErrorInvalidParams("Either tx_blob or tx_json must be provided")
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +72,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 	} else if hasSigningCreds {
 		// Sign-and-submit path: sign the transaction first, then submit the blob.
 		// This matches rippled's behavior in doSubmit() when tx_blob is absent.
-		signed, rpcErr := signTransactionJSON(request.TxJson, signCredentials{
+		signed, rpcErr := signTransactionJSON(ctx.Services, request.TxJson, signCredentials{
 			Secret:     request.Secret,
 			Seed:       request.Seed,
 			SeedHex:    request.SeedHex,
@@ -110,7 +110,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 
 	// Submit the transaction with the original signed blob.
 	// The blob is needed for canonical re-ordering during AcceptLedger.
-	result, err := types.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
+	result, err := ctx.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to submit transaction: " + err.Error())
 	}
@@ -129,7 +129,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 				},
 			}
 			storedData, _ := json.Marshal(storedTx)
-			_ = types.Services.Ledger.StoreTransaction(txHash, storedData)
+			_ = ctx.Services.Ledger.StoreTransaction(txHash, storedData)
 		}
 	}
 
@@ -144,7 +144,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		txJsonMap["hash"] = txHashStr
 	}
 
-	baseFee, _, _ := types.Services.Ledger.GetCurrentFees()
+	baseFee, _, _ := ctx.Services.Ledger.GetCurrentFees()
 
 	// Build response with independent boolean fields matching rippled's
 	// Transaction::SubmitResult struct. "accepted" = any() in rippled.
@@ -174,7 +174,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 
 	// Add account_sequence_next and account_sequence_available
 	if account, ok := txJsonMap["Account"].(string); ok {
-		if acctInfo, err := types.Services.Ledger.GetAccountInfo(account, "current"); err == nil {
+		if acctInfo, err := ctx.Services.Ledger.GetAccountInfo(account, "current"); err == nil {
 			response["account_sequence_next"] = acctInfo.Sequence
 			response["account_sequence_available"] = acctInfo.Sequence
 		}

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -26,7 +26,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorMissingField("tx_json")
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -182,7 +182,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorInternal("Failed to marshal transaction: " + encErr.Error())
 	}
 
-	result, submitErr := types.Services.Ledger.SubmitTransaction(txJSON)
+	result, submitErr := ctx.Services.Ledger.SubmitTransaction(txJSON)
 	if submitErr != nil {
 		return nil, types.RpcErrorInternal("Transaction submission failed: " + submitErr.Error())
 	}

--- a/internal/rpc/handlers/transaction_entry.go
+++ b/internal/rpc/handlers/transaction_entry.go
@@ -34,7 +34,7 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 		return nil, types.NewRpcError(-1, "fieldNotFoundTransaction", "fieldNotFoundTransaction", "Missing field 'tx_hash'.")
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -48,7 +48,7 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 	copy(txHash[:], txHashBytes)
 
 	// Look up the transaction
-	txInfo, err := types.Services.Ledger.GetTransaction(txHash)
+	txInfo, err := ctx.Services.Ledger.GetTransaction(txHash)
 	if err != nil || txInfo == nil {
 		return nil, &types.RpcError{
 			Code:        -1,
@@ -58,7 +58,7 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 	}
 
 	// Resolve the target ledger and verify the transaction is in it
-	targetSeq, rpcErr := m.resolveTargetLedger(request.LedgerHash, request.LedgerIndex)
+	targetSeq, rpcErr := m.resolveTargetLedger(ctx.Services, request.LedgerHash, request.LedgerIndex)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
@@ -80,7 +80,7 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 
 	ledgerHash := txInfo.LedgerHash
 	if ledgerHash == "" {
-		ledger, err := types.Services.Ledger.GetLedgerBySequence(targetSeq)
+		ledger, err := ctx.Services.Ledger.GetLedgerBySequence(targetSeq)
 		if err == nil && ledger != nil {
 			h := ledger.Hash()
 			ledgerHash = fmt.Sprintf("%X", h)
@@ -113,7 +113,7 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 		}
 		if txInfo.Validated {
 			response["ledger_index"] = txInfo.LedgerIndex
-			if targetLedger, err := types.Services.Ledger.GetLedgerBySequence(targetSeq); err == nil {
+			if targetLedger, err := ctx.Services.Ledger.GetLedgerBySequence(targetSeq); err == nil {
 				closeTimeSec := targetLedger.CloseTime()
 				if closeTimeSec > 0 {
 					closeTime := rippleEpochTime.Add(secondsToDuration(closeTimeSec))
@@ -132,7 +132,7 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 }
 
 // resolveTargetLedger resolves the ledger sequence from the request params.
-func (m *TransactionEntryMethod) resolveTargetLedger(ledgerHash string, ledgerIndex any) (uint32, *types.RpcError) {
+func (m *TransactionEntryMethod) resolveTargetLedger(services *types.ServiceContainer, ledgerHash string, ledgerIndex any) (uint32, *types.RpcError) {
 	// If ledger_hash is provided, resolve by hash
 	if ledgerHash != "" {
 		hashBytes, err := hex.DecodeString(ledgerHash)
@@ -141,7 +141,7 @@ func (m *TransactionEntryMethod) resolveTargetLedger(ledgerHash string, ledgerIn
 		}
 		var hash [32]byte
 		copy(hash[:], hashBytes)
-		ledger, err := types.Services.Ledger.GetLedgerByHash(hash)
+		ledger, err := services.Ledger.GetLedgerByHash(hash)
 		if err != nil || ledger == nil {
 			return 0, types.RpcErrorLgrNotFound("Ledger not found")
 		}
@@ -156,11 +156,11 @@ func (m *TransactionEntryMethod) resolveTargetLedger(ledgerHash string, ledgerIn
 		case string:
 			switch v {
 			case "validated":
-				return types.Services.Ledger.GetValidatedLedgerIndex(), nil
+				return services.Ledger.GetValidatedLedgerIndex(), nil
 			case "closed":
-				return types.Services.Ledger.GetClosedLedgerIndex(), nil
+				return services.Ledger.GetClosedLedgerIndex(), nil
 			case "current":
-				return types.Services.Ledger.GetCurrentLedgerIndex(), nil
+				return services.Ledger.GetCurrentLedgerIndex(), nil
 			default:
 				seq, err := strconv.ParseUint(v, 10, 32)
 				if err != nil {
@@ -172,5 +172,5 @@ func (m *TransactionEntryMethod) resolveTargetLedger(ledgerHash string, ledgerIn
 	}
 
 	// Default to validated ledger
-	return types.Services.Ledger.GetValidatedLedgerIndex(), nil
+	return services.Ledger.GetValidatedLedgerIndex(), nil
 }

--- a/internal/rpc/handlers/tx.go
+++ b/internal/rpc/handlers/tx.go
@@ -41,7 +41,7 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interf
 		return nil, types.RpcErrorInvalidParams("Missing required parameter: transaction")
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -55,7 +55,7 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interf
 	copy(txHash[:], txHashBytes)
 
 	// Look up the transaction
-	txInfo, err := types.Services.Ledger.GetTransaction(txHash)
+	txInfo, err := ctx.Services.Ledger.GetTransaction(txHash)
 	if err != nil {
 		return nil, &types.RpcError{
 			Code:        -1,
@@ -92,7 +92,7 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interf
 	// Resolve close time from the containing ledger
 	var closeTimeSec int64
 	if txInfo.LedgerIndex > 0 {
-		if ledger, err := types.Services.Ledger.GetLedgerBySequence(txInfo.LedgerIndex); err == nil {
+		if ledger, err := ctx.Services.Ledger.GetLedgerBySequence(txInfo.LedgerIndex); err == nil {
 			closeTimeSec = ledger.CloseTime()
 		}
 	}
@@ -226,11 +226,11 @@ func (m *TxMethod) buildResponseV2(
 
 // lookupByCTID looks up a transaction using a CTID (Compact Transaction ID)
 func (m *TxMethod) lookupByCTID(ctx *types.RpcContext, ledgerSeq uint32, txIndex uint16, binary bool) (interface{}, *types.RpcError) {
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
-	ledger, err := types.Services.Ledger.GetLedgerBySequence(ledgerSeq)
+	ledger, err := ctx.Services.Ledger.GetLedgerBySequence(ledgerSeq)
 	if err != nil {
 		return nil, &types.RpcError{
 			Code:        -1,

--- a/internal/rpc/handlers/tx_history.go
+++ b/internal/rpc/handlers/tx_history.go
@@ -21,11 +21,11 @@ func (m *TxHistoryMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		return nil, err
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
-	result, err := types.Services.Ledger.GetTransactionHistory(request.Start)
+	result, err := ctx.Services.Ledger.GetTransactionHistory(request.Start)
 	if err != nil {
 		if err.Error() == "transaction history not available (no database configured)" {
 			return nil, &types.RpcError{

--- a/internal/rpc/handlers/validator_info.go
+++ b/internal/rpc/handlers/validator_info.go
@@ -28,12 +28,12 @@ type validatorInfoResponse struct {
 	Domain string  `json:"domain,omitempty"`
 }
 
-func (m *ValidatorInfoMethod) Handle(_ *types.RpcContext, _ json.RawMessage) (interface{}, *types.RpcError) {
-	if types.Services == nil || len(types.Services.ValidatorPublicKey) == 0 {
+func (m *ValidatorInfoMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (interface{}, *types.RpcError) {
+	if ctx.Services == nil || len(ctx.Services.ValidatorPublicKey) == 0 {
 		return nil, types.RpcErrorInvalidParams("not a validator")
 	}
 
-	validationPK := types.Services.ValidatorPublicKey
+	validationPK := ctx.Services.ValidatorPublicKey
 	if len(validationPK) != 33 {
 		return nil, types.RpcErrorInternal("validator public key has invalid length")
 	}
@@ -42,8 +42,8 @@ func (m *ValidatorInfoMethod) Handle(_ *types.RpcContext, _ json.RawMessage) (in
 	copy(keyArr[:], validationPK)
 
 	masterKey := keyArr
-	if types.Services.Manifests != nil {
-		masterKey = types.Services.Manifests.GetMasterKey(keyArr)
+	if ctx.Services.Manifests != nil {
+		masterKey = ctx.Services.Manifests.GetMasterKey(keyArr)
 	}
 
 	masterB58, err := addresscodec.EncodeNodePublicKey(masterKey[:])
@@ -64,14 +64,14 @@ func (m *ValidatorInfoMethod) Handle(_ *types.RpcContext, _ json.RawMessage) (in
 		}
 		resp.EphemeralKey = ephB58
 
-		if manifestBytes, ok := types.Services.Manifests.GetManifest(masterKey); ok {
+		if manifestBytes, ok := ctx.Services.Manifests.GetManifest(masterKey); ok {
 			resp.Manifest = base64.StdEncoding.EncodeToString(manifestBytes)
 		}
-		if seq, ok := types.Services.Manifests.GetSequence(masterKey); ok {
+		if seq, ok := ctx.Services.Manifests.GetSequence(masterKey); ok {
 			s := seq
 			resp.Seq = &s
 		}
-		if domain, ok := types.Services.Manifests.GetDomain(masterKey); ok {
+		if domain, ok := ctx.Services.Manifests.GetDomain(masterKey); ok {
 			resp.Domain = domain
 		}
 	}

--- a/internal/rpc/handlers/validator_info_test.go
+++ b/internal/rpc/handlers/validator_info_test.go
@@ -60,20 +60,19 @@ func makeValidatorPubKey(prefix byte) []byte {
 	return pk
 }
 
-func installServices(pk []byte, manifests types.ManifestLookup) func() {
-	prev := types.Services
-	types.Services = &types.ServiceContainer{
+func installServices(pk []byte, manifests types.ManifestLookup) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		ValidatorPublicKey: pk,
 		Manifests:          manifests,
 	}
-	return func() { types.Services = prev }
 }
 
-func adminCtx() *types.RpcContext {
+func adminCtx(services *types.ServiceContainer) *types.RpcContext {
 	return &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 }
 
@@ -89,11 +88,10 @@ func decodeResponse(t *testing.T, result interface{}) map[string]interface{} {
 // TestValidatorInfo_NotConfigured pins rippled's testErrors:
 // `error_message == "not a validator"` with rpcINVALID_PARAMS code.
 func TestValidatorInfo_NotConfigured(t *testing.T) {
-	cleanup := installServices(nil, nil)
-	defer cleanup()
+	services := installServices(nil, nil)
 
 	method := &handlers.ValidatorInfoMethod{}
-	result, rpcErr := method.Handle(adminCtx(), nil)
+	result, rpcErr := method.Handle(adminCtx(services), nil)
 
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
@@ -111,11 +109,10 @@ func TestValidatorInfo_MasterOnly(t *testing.T) {
 	expectedMaster, err := addresscodec.EncodeNodePublicKey(pk)
 	require.NoError(t, err)
 
-	cleanup := installServices(pk, nil)
-	defer cleanup()
+	services := installServices(pk, nil)
 
 	method := &handlers.ValidatorInfoMethod{}
-	result, rpcErr := method.Handle(adminCtx(), nil)
+	result, rpcErr := method.Handle(adminCtx(services), nil)
 	require.Nil(t, rpcErr)
 	require.NotNil(t, result)
 
@@ -151,11 +148,10 @@ func TestValidatorInfo_WithManifest(t *testing.T) {
 		seqFor:      map[[33]byte]uint32{masterArr: seq},
 		domainFor:   map[[33]byte]string{masterArr: domain},
 	}
-	cleanup := installServices(signingKey, manifests)
-	defer cleanup()
+	services := installServices(signingKey, manifests)
 
 	method := &handlers.ValidatorInfoMethod{}
-	result, rpcErr := method.Handle(adminCtx(), nil)
+	result, rpcErr := method.Handle(adminCtx(services), nil)
 	require.Nil(t, rpcErr)
 
 	resp := decodeResponse(t, result)
@@ -188,11 +184,10 @@ func TestValidatorInfo_SeqZeroSerialises(t *testing.T) {
 		masterFor: map[[33]byte][33]byte{signingArr: masterArr},
 		seqFor:    map[[33]byte]uint32{masterArr: 0},
 	}
-	cleanup := installServices(signingKey, manifests)
-	defer cleanup()
+	services := installServices(signingKey, manifests)
 
 	method := &handlers.ValidatorInfoMethod{}
-	result, rpcErr := method.Handle(adminCtx(), nil)
+	result, rpcErr := method.Handle(adminCtx(services), nil)
 	require.Nil(t, rpcErr)
 
 	resp := decodeResponse(t, result)
@@ -223,11 +218,10 @@ func TestValidatorInfo_ManifestCachePresentNoMapping(t *testing.T) {
 
 	// Empty fake — every Get* returns the not-found path, and
 	// GetMasterKey returns the input unchanged (matches rippled).
-	cleanup := installServices(pk, &fakeManifestLookup{})
-	defer cleanup()
+	services := installServices(pk, &fakeManifestLookup{})
 
 	method := &handlers.ValidatorInfoMethod{}
-	result, rpcErr := method.Handle(adminCtx(), nil)
+	result, rpcErr := method.Handle(adminCtx(services), nil)
 	require.Nil(t, rpcErr)
 	require.NotNil(t, result)
 
@@ -244,11 +238,10 @@ func TestValidatorInfo_ManifestCachePresentNoMapping(t *testing.T) {
 // a 33-byte NodeID, but the field is a []byte so we still verify the
 // internal-error path rather than silently truncating or panicking.
 func TestValidatorInfo_InvalidPublicKeyLength(t *testing.T) {
-	cleanup := installServices(make([]byte, 32), nil) // wrong length
-	defer cleanup()
+	services := installServices(make([]byte, 32), nil) // wrong length
 
 	method := &handlers.ValidatorInfoMethod{}
-	result, rpcErr := method.Handle(adminCtx(), nil)
+	result, rpcErr := method.Handle(adminCtx(services), nil)
 
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)

--- a/internal/rpc/handlers/vault_info.go
+++ b/internal/rpc/handlers/vault_info.go
@@ -37,7 +37,7 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		return nil, types.RpcErrorInvalidParams("Must specify either vault_id or (owner + seq)")
 	}
 
-	if err := RequireLedgerService(); err != nil {
+	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
 
@@ -69,7 +69,7 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		vaultKey = vaultKeylet.Key
 	}
 
-	vaultEntry, err := types.Services.Ledger.GetLedgerEntry(vaultKey, ledgerIndex)
+	vaultEntry, err := ctx.Services.Ledger.GetLedgerEntry(vaultKey, ledgerIndex)
 	if err != nil {
 		return nil, &types.RpcError{
 			Code:    21,
@@ -90,7 +90,7 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 			var mptIssuanceKey [32]byte
 			copy(mptIssuanceKey[:], shareMPTIDBytes)
 
-			mptIssuanceEntry, mptErr := types.Services.Ledger.GetLedgerEntry(mptIssuanceKey, ledgerIndex)
+			mptIssuanceEntry, mptErr := ctx.Services.Ledger.GetLedgerEntry(mptIssuanceKey, ledgerIndex)
 			if mptErr == nil {
 				mptIssuanceDecoded, mptDecodeErr := binarycodec.Decode(hex.EncodeToString(mptIssuanceEntry.Node))
 				if mptDecodeErr == nil {

--- a/internal/rpc/ledger_closed_test.go
+++ b/internal/rpc/ledger_closed_test.go
@@ -54,14 +54,14 @@ func TestLedgerClosedBasicSuccess(t *testing.T) {
 		return nil, errors.New("not found")
 	}
 
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerClosedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -114,14 +114,14 @@ func TestLedgerClosedHashFormat(t *testing.T) {
 		return nil, errors.New("not found")
 	}
 
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerClosedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -152,16 +152,14 @@ func TestLedgerClosedHashFormat(t *testing.T) {
 // TestLedgerClosedServiceUnavailable tests behavior when ledger service is not available
 func TestLedgerClosedServiceUnavailable(t *testing.T) {
 	method := &handlers.LedgerClosedMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	t.Run("Nil services", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		result, rpcErr := method.Handle(ctx, nil)
 		assert.Nil(t, result)
@@ -171,9 +169,12 @@ func TestLedgerClosedServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Nil ledger in services", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		result, rpcErr := method.Handle(ctx, nil)
 		assert.Nil(t, result)
@@ -188,9 +189,12 @@ func TestLedgerClosedServiceUnavailable(t *testing.T) {
 				closedLedgerIndex: 0,
 			},
 		}
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: mock}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
 
 		result, rpcErr := method.Handle(ctx, nil)
 		assert.Nil(t, result)
@@ -205,9 +209,12 @@ func TestLedgerClosedServiceUnavailable(t *testing.T) {
 		mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
 			return nil, errors.New("storage error")
 		}
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: mock}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
 
 		result, rpcErr := method.Handle(ctx, nil)
 		assert.Nil(t, result)

--- a/internal/rpc/ledger_data_test.go
+++ b/internal/rpc/ledger_data_test.go
@@ -70,14 +70,14 @@ func TestLedgerDataLimitClamping(t *testing.T) {
 		return newDefaultLedgerDataResult(int(limit), false), nil
 	}
 
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("JSON mode default limit is 256", func(t *testing.T) {
@@ -223,14 +223,14 @@ func TestLedgerDataBinaryMode(t *testing.T) {
 		return newDefaultLedgerDataResult(3, false), nil
 	}
 
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Binary false returns JSON objects", func(t *testing.T) {
@@ -300,14 +300,14 @@ func TestLedgerDataTypeFilter(t *testing.T) {
 		return newDefaultLedgerDataResult(5, false), nil
 	}
 
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// The type parameter is passed through to the service layer.
@@ -343,14 +343,14 @@ func TestLedgerDataMarkerPagination(t *testing.T) {
 		return newDefaultLedgerDataResult(3, false), nil
 	}
 
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("First page has marker and limit", func(t *testing.T) {
@@ -429,14 +429,14 @@ func TestLedgerDataResponseStructure(t *testing.T) {
 		}, nil
 	}
 
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := map[string]interface{}{
@@ -492,16 +492,14 @@ func TestLedgerDataResponseStructure(t *testing.T) {
 // TestLedgerDataServiceUnavailable tests behavior when ledger service is not available
 func TestLedgerDataServiceUnavailable(t *testing.T) {
 	method := &handlers.LedgerDataMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	t.Run("Nil services", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		result, rpcErr := method.Handle(ctx, nil)
 		assert.Nil(t, result)
@@ -511,9 +509,12 @@ func TestLedgerDataServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Nil ledger in services", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		result, rpcErr := method.Handle(ctx, nil)
 		assert.Nil(t, result)
@@ -529,9 +530,12 @@ func TestLedgerDataServiceUnavailable(t *testing.T) {
 		mock.getLedgerDataFn = func(ledgerIndex string, limit uint32, marker string) (*types.LedgerDataResult, error) {
 			return nil, errors.New("storage unavailable")
 		}
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: mock}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
 
 		params := map[string]interface{}{
 			"ledger_index": "current",
@@ -600,14 +604,14 @@ func TestLedgerDataLedgerHeader(t *testing.T) {
 		return result, nil
 	}
 
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("First query includes ledger header JSON with uppercase hashes", func(t *testing.T) {
@@ -682,14 +686,14 @@ func TestLedgerDataEmptyState(t *testing.T) {
 		return newDefaultLedgerDataResult(0, false), nil
 	}
 
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := map[string]interface{}{

--- a/internal/rpc/ledger_entry_test.go
+++ b/internal/rpc/ledger_entry_test.go
@@ -56,14 +56,10 @@ func (m *mockLedgerEntryService) GetLedgerEntry(entryKey [32]byte, ledgerIndex s
 	}, nil
 }
 
-// setupLedgerEntryTestServices initializes the Services singleton with a mock for ledger_entry testing
-func setupLedgerEntryTestServices(mock *mockLedgerEntryService) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+// newLedgerEntryTestServices builds a per-test ServiceContainer wrapping mock.
+func newLedgerEntryTestServices(mock *mockLedgerEntryService) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -73,14 +69,14 @@ func setupLedgerEntryTestServices(mock *mockLedgerEntryService) func() {
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryInvalid() and testLedgerEntryAccountRoot()
 func TestLedgerEntryDirectIndexLookup(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validIndex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -216,14 +212,14 @@ func TestLedgerEntryDirectIndexLookup(t *testing.T) {
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryCheck()
 func TestLedgerEntryCheck(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	checkIndex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -322,14 +318,14 @@ func TestLedgerEntryCheck(t *testing.T) {
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryPayChan()
 func TestLedgerEntryPaymentChannel(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	payChanIndex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -429,14 +425,14 @@ func TestLedgerEntryPaymentChannel(t *testing.T) {
 // Note: Current implementation only supports lookup by direct index string, not by owner/dir_root objects
 func TestLedgerEntryDirectory(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	dirRootIndex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -534,14 +530,14 @@ func TestLedgerEntryDirectory(t *testing.T) {
 // TestLedgerEntryNFTPage tests NFT page lookup by page index
 func TestLedgerEntryNFTPage(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	nftPageIndex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -639,14 +635,14 @@ func TestLedgerEntryNFTPage(t *testing.T) {
 // TestLedgerEntryMissingEntryType tests error when no entry type is specified
 func TestLedgerEntryMissingEntryType(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -689,14 +685,14 @@ func TestLedgerEntryMissingEntryType(t *testing.T) {
 // Based on rippled ledger specification behavior
 func TestLedgerEntryLedgerSpecification(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validIndex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -878,14 +874,14 @@ func TestLedgerEntryLedgerSpecification(t *testing.T) {
 // TestLedgerEntryResponseFields tests that the response contains expected fields
 func TestLedgerEntryResponseFields(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validIndex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -966,16 +962,14 @@ func TestLedgerEntryResponseFields(t *testing.T) {
 // TestLedgerEntryServiceUnavailable tests behavior when ledger service is not available
 func TestLedgerEntryServiceUnavailable(t *testing.T) {
 	method := &handlers.LedgerEntryMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	t.Run("Services is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		params := map[string]interface{}{
 			"index": "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
@@ -992,9 +986,12 @@ func TestLedgerEntryServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Services.Ledger is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		params := map[string]interface{}{
 			"index": "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D",
@@ -1035,14 +1032,14 @@ func TestLedgerEntryMethodMetadata(t *testing.T) {
 // TestLedgerEntryTypePriority tests that index takes priority over other entry types
 func TestLedgerEntryTypePriority(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	indexValue := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -1088,14 +1085,14 @@ func TestLedgerEntryTypePriority(t *testing.T) {
 // The mock returns a default result for any keylet, so these should succeed.
 func TestLedgerEntryImplementedTypes(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("account_root by address", func(t *testing.T) {
@@ -1181,14 +1178,14 @@ func TestLedgerEntryImplementedTypes(t *testing.T) {
 // TestLedgerEntryInvalidParameters tests various invalid parameter scenarios
 func TestLedgerEntryInvalidParameters(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -1259,14 +1256,14 @@ func TestLedgerEntryInvalidParameters(t *testing.T) {
 // TestLedgerEntryNotFoundErrorCode tests that entry not found returns correct error code
 func TestLedgerEntryNotFoundErrorCode(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.ledgerEntryErr = errors.New("entry not found")
@@ -1292,14 +1289,14 @@ func TestLedgerEntryNotFoundErrorCode(t *testing.T) {
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryAccountRoot()
 func TestLedgerEntryAccountRoot(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	accountRootIndex := "9CE54C3B934E473A995B477E92EC229F99CED5B62BF4D2ACE4DC42719103AE2F"
@@ -1414,14 +1411,14 @@ func TestLedgerEntryAccountRoot(t *testing.T) {
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryEscrow()
 func TestLedgerEntryEscrow(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	escrowIndex := "DC5F3851D8A1AB622F957761E5963BC5BD439D5C24AC6AD7AC4523F0640A0BF5"
@@ -1512,14 +1509,14 @@ func TestLedgerEntryEscrow(t *testing.T) {
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryOffer()
 func TestLedgerEntryOffer(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	offerIndex := "E7D0EC33B0C2A0F2C9E16CCCA8E12F88F4F9CEFEC3D82C1E68F5B4CC4B3DEEEF"
@@ -1610,14 +1607,14 @@ func TestLedgerEntryOffer(t *testing.T) {
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryRippleState()
 func TestLedgerEntryRippleState(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	rippleStateIndex := "B7F9C5E1A8D4F2C3E6B9A8D7C5E4F3A2B1C9D8E7F6A5B4C3D2E1F0A9B8C7D6E5"
@@ -1708,14 +1705,14 @@ func TestLedgerEntryRippleState(t *testing.T) {
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryTicket()
 func TestLedgerEntryTicket(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	ticketIndex := "C8D2A5E4B7F1C3D6E9A8B7C5D4E3F2A1B9C8D7E6F5A4B3C2D1E0F9A8B7C6D5E4"
@@ -1806,14 +1803,14 @@ func TestLedgerEntryTicket(t *testing.T) {
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryDepositPreauth()
 func TestLedgerEntryDepositPreauth(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	depositPreauthIndex := "F1E2D3C4B5A6978869504132B4C5D6E7F8A9B0C1D2E3F4A5B6C7D8E9F0A1B2C3"
@@ -1904,14 +1901,14 @@ func TestLedgerEntryDepositPreauth(t *testing.T) {
 // Based on rippled AMM ledger entry tests
 func TestLedgerEntryAMM(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	ammIndex := "A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9B0C1D2E3F4A5B6C7D8E9F0A1B2"
@@ -2002,14 +1999,14 @@ func TestLedgerEntryAMM(t *testing.T) {
 // Based on rippled LedgerEntry_test.cpp testLedgerEntryInvalid()
 func TestLedgerEntryInvalidLedgerSpecification(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validIndex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -2079,14 +2076,14 @@ func TestLedgerEntryInvalidLedgerSpecification(t *testing.T) {
 // Based on rippled behavior where requesting an AccountRoot index via check field fails
 func TestLedgerEntryUnexpectedType(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Test requesting an entry using the wrong type
@@ -2126,14 +2123,14 @@ func TestLedgerEntryUnexpectedType(t *testing.T) {
 // TestLedgerEntryMultipleTypes tests behavior when multiple entry types are specified
 func TestLedgerEntryMultipleTypes(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	index1 := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -2179,14 +2176,14 @@ func TestLedgerEntryMultipleTypes(t *testing.T) {
 // Based on rippled LedgerEntry_test.cpp malformed request handling
 func TestLedgerEntryMalformedRequests(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -2257,8 +2254,7 @@ func TestLedgerEntryMalformedRequests(t *testing.T) {
 // TestLedgerEntryAPIVersions tests that the method works correctly with different API versions
 func TestLedgerEntryAPIVersions(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 
@@ -2281,6 +2277,7 @@ func TestLedgerEntryAPIVersions(t *testing.T) {
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
 				ApiVersion: version,
+				Services:   services,
 			}
 
 			params := map[string]interface{}{
@@ -2303,14 +2300,14 @@ func TestLedgerEntryAPIVersions(t *testing.T) {
 // TestLedgerEntryHexValidation tests hex string validation for various entry types
 func TestLedgerEntryHexValidation(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -2473,14 +2470,14 @@ func TestLedgerEntryHexValidation(t *testing.T) {
 // first and falls back to parseHex if the value is a string.
 func TestLedgerEntryHexFallback(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validHex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -2544,14 +2541,14 @@ func TestLedgerEntryHexFallback(t *testing.T) {
 // TestLedgerEntryVault tests vault entry lookup by hex and by object form
 func TestLedgerEntryVault(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	vaultHex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -2605,14 +2602,14 @@ func TestLedgerEntryVault(t *testing.T) {
 // TestLedgerEntryDelegate tests delegate entry lookup by hex and by object form
 func TestLedgerEntryDelegate(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	delegateHex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
@@ -2665,14 +2662,14 @@ func TestLedgerEntryDelegate(t *testing.T) {
 // TestLedgerEntryBridge tests bridge entry lookup by hex string
 func TestLedgerEntryBridge(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("bridge by hex string", func(t *testing.T) {
@@ -2705,14 +2702,14 @@ func TestLedgerEntryBridge(t *testing.T) {
 // TestLedgerEntryXChainClaimID tests xchain_owned_claim_id entry lookup by hex
 func TestLedgerEntryXChainClaimID(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("xchain_owned_claim_id by hex string", func(t *testing.T) {
@@ -2748,14 +2745,14 @@ func TestLedgerEntryXChainClaimID(t *testing.T) {
 // matching rippled's parseTicket() which expects jss::ticket_seq
 func TestLedgerEntryTicketConformance(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("ticket by account and ticket_seq", func(t *testing.T) {
@@ -2794,14 +2791,14 @@ func TestLedgerEntryTicketConformance(t *testing.T) {
 // uses uppercase hex encoding, matching rippled's output.
 func TestLedgerEntryUppercaseHex(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.ledgerEntryResult = &types.LedgerEntryResult{
@@ -2842,14 +2839,14 @@ func TestLedgerEntryUppercaseHex(t *testing.T) {
 // TestLedgerEntryEscrowHexFallback tests escrow specifically with hex vs object form
 func TestLedgerEntryEscrowHexFallback(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("escrow by hex string", func(t *testing.T) {
@@ -2887,14 +2884,14 @@ func TestLedgerEntryEscrowHexFallback(t *testing.T) {
 // TestLedgerEntryOfferHexFallback tests offer specifically with hex vs object form
 func TestLedgerEntryOfferHexFallback(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("offer by hex string", func(t *testing.T) {
@@ -2932,14 +2929,14 @@ func TestLedgerEntryOfferHexFallback(t *testing.T) {
 // TestLedgerEntryOracleHexFallback tests oracle with hex vs object form
 func TestLedgerEntryOracleHexFallback(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("oracle by hex string", func(t *testing.T) {
@@ -2977,14 +2974,14 @@ func TestLedgerEntryOracleHexFallback(t *testing.T) {
 // TestLedgerEntryAMMHexFallback tests AMM with hex vs object form
 func TestLedgerEntryAMMHexFallback(t *testing.T) {
 	mock := newMockLedgerEntryService()
-	cleanup := setupLedgerEntryTestServices(mock)
-	defer cleanup()
+	services := newLedgerEntryTestServices(mock)
 
 	method := &handlers.LedgerEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("amm by hex string", func(t *testing.T) {

--- a/internal/rpc/ledger_header_test.go
+++ b/internal/rpc/ledger_header_test.go
@@ -39,14 +39,14 @@ func TestLedgerHeaderBasicRequest(t *testing.T) {
 		}
 		return nil, errors.New("ledger not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Default params returns validated ledger with all fields", func(t *testing.T) {
@@ -202,14 +202,14 @@ func TestLedgerHeaderBinaryFormat(t *testing.T) {
 	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
 		return reader, nil
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -284,14 +284,14 @@ func TestLedgerHeaderHashFormat(t *testing.T) {
 	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
 		return reader, nil
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -327,14 +327,14 @@ func TestLedgerHeaderBadInput(t *testing.T) {
 		}
 		return nil, errors.New("ledger not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Invalid string ledger_index", func(t *testing.T) {
@@ -393,14 +393,14 @@ func TestLedgerHeaderOpenLedger(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{"ledger_index": "current"}`)
@@ -441,14 +441,14 @@ func TestLedgerHeaderCloseTimeEstimated(t *testing.T) {
 	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
 		return reader, nil
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -484,16 +484,14 @@ func TestLedgerHeaderMethodMetadata(t *testing.T) {
 // TestLedgerHeaderServiceUnavailable tests behavior when services are not available.
 func TestLedgerHeaderServiceUnavailable(t *testing.T) {
 	method := &handlers.LedgerHeaderMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	t.Run("Nil services", func(t *testing.T) {
-		old := types.Services
-		types.Services = nil
-		defer func() { types.Services = old }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		result, rpcErr := method.Handle(ctx, nil)
 		assert.Nil(t, result)
@@ -501,9 +499,12 @@ func TestLedgerHeaderServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Nil ledger in services", func(t *testing.T) {
-		old := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = old }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		result, rpcErr := method.Handle(ctx, nil)
 		assert.Nil(t, result)

--- a/internal/rpc/ledger_test.go
+++ b/internal/rpc/ledger_test.go
@@ -114,14 +114,14 @@ func TestLedgerBasicRequest(t *testing.T) {
 		}
 		return nil, errors.New("ledger not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Default params returns validated ledger", func(t *testing.T) {
@@ -185,14 +185,14 @@ func TestLedgerBadInput(t *testing.T) {
 		}
 		return nil, errors.New("ledger not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -241,14 +241,14 @@ func TestLedgerCurrentRequest(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := map[string]interface{}{
@@ -294,14 +294,14 @@ func TestLedgerFullOption(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Transactions true returns tx hashes", func(t *testing.T) {
@@ -364,14 +364,14 @@ func TestLedgerAccountsOption(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// The accounts option requests account state. Even without account state
@@ -409,14 +409,14 @@ func TestLedgerLookupByHash(t *testing.T) {
 		}
 		return nil, errors.New("ledger not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	hashStr := hex.EncodeToString(expectedHash[:])
@@ -489,14 +489,14 @@ func TestLedgerResponseStructure(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := map[string]interface{}{
@@ -557,16 +557,14 @@ func TestLedgerResponseStructure(t *testing.T) {
 // TestLedgerServiceUnavailable tests behavior when ledger service is not available
 func TestLedgerServiceUnavailable(t *testing.T) {
 	method := &handlers.LedgerMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	t.Run("Nil services", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		result, rpcErr := method.Handle(ctx, nil)
 		assert.Nil(t, result)
@@ -576,9 +574,12 @@ func TestLedgerServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Nil ledger in services", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		result, rpcErr := method.Handle(ctx, nil)
 		assert.Nil(t, result)
@@ -596,14 +597,14 @@ func TestLedgerNilLedgerReturned(t *testing.T) {
 	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
 		return nil, errors.New("not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -648,14 +649,14 @@ func TestLedgerLookupByIndex(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("closed keyword", func(t *testing.T) {

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -24,14 +24,11 @@ func newMockLedgerServiceMissingMethods() *mockLedgerServiceMissingMethods {
 	}
 }
 
-// setupTestServicesMissingMethods initializes Services for testing
-func setupTestServicesMissingMethods(mock *mockLedgerServiceMissingMethods) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+// servicesForMissingMethods builds a per-test ServiceContainer for tests
+// that exercise the "missing methods" handlers.
+func servicesForMissingMethods(mock *mockLedgerServiceMissingMethods) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -40,8 +37,7 @@ func setupTestServicesMissingMethods(mock *mockLedgerServiceMissingMethods) func
 
 func TestFetchInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.FetchInfoMethod{}
 
@@ -50,6 +46,7 @@ func TestFetchInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"clear": true}`)
@@ -67,6 +64,7 @@ func TestFetchInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -92,8 +90,7 @@ func TestFetchInfoMethod(t *testing.T) {
 
 func TestOwnerInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.OwnerInfoMethod{}
 
@@ -102,6 +99,7 @@ func TestOwnerInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -116,6 +114,7 @@ func TestOwnerInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"account": ""}`)
@@ -132,6 +131,7 @@ func TestOwnerInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}`)
@@ -152,8 +152,7 @@ func TestOwnerInfoMethod(t *testing.T) {
 
 func TestLedgerHeaderMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.LedgerHeaderMethod{}
 
@@ -163,6 +162,7 @@ func TestLedgerHeaderMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"ledger_index": "current"}`)
@@ -179,6 +179,7 @@ func TestLedgerHeaderMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"ledger_index": "validated"}`)
@@ -206,8 +207,7 @@ func TestLedgerHeaderMethod(t *testing.T) {
 
 func TestLedgerRequestMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.LedgerRequestMethod{}
 
@@ -217,6 +217,7 @@ func TestLedgerRequestMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"ledger_index": 100}`)
@@ -237,8 +238,7 @@ func TestLedgerRequestMethod(t *testing.T) {
 
 func TestLedgerCleanerMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.LedgerCleanerMethod{}
 
@@ -248,6 +248,7 @@ func TestLedgerCleanerMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -266,8 +267,7 @@ func TestLedgerCleanerMethod(t *testing.T) {
 
 func TestLedgerDiffMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.LedgerDiffMethod{}
 
@@ -276,6 +276,7 @@ func TestLedgerDiffMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -296,8 +297,7 @@ func TestLedgerDiffMethod(t *testing.T) {
 
 func TestSimulateMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.SimulateMethod{}
 
@@ -307,6 +307,7 @@ func TestSimulateMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{}`)
@@ -323,6 +324,7 @@ func TestSimulateMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"tx_json": {}, "tx_blob": "1200"}`)
@@ -350,8 +352,7 @@ func TestSimulateMethod(t *testing.T) {
 
 func TestTxReduceRelayMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.TxReduceRelayMethod{}
 
@@ -360,6 +361,7 @@ func TestTxReduceRelayMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -387,8 +389,7 @@ func TestTxReduceRelayMethod(t *testing.T) {
 func TestConnectMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
 	mock.standalone = true // Standalone mode
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.ConnectMethod{}
 
@@ -398,6 +399,7 @@ func TestConnectMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"ip": "127.0.0.1", "port": 51235}`)
@@ -414,6 +416,7 @@ func TestConnectMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{}`)
@@ -433,8 +436,7 @@ func TestConnectMethod(t *testing.T) {
 
 func TestPrintMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.PrintMethod{}
 
@@ -443,6 +445,7 @@ func TestPrintMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -467,8 +470,7 @@ func TestPrintMethod(t *testing.T) {
 
 func TestValidatorInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.ValidatorInfoMethod{}
 
@@ -478,6 +480,7 @@ func TestValidatorInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -498,8 +501,7 @@ func TestValidatorInfoMethod(t *testing.T) {
 
 func TestCanDeleteMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.CanDeleteMethod{}
 
@@ -509,6 +511,7 @@ func TestCanDeleteMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -528,8 +531,7 @@ func TestCanDeleteMethod(t *testing.T) {
 
 func TestGetAggregatePriceMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.GetAggregatePriceMethod{}
 
@@ -543,6 +545,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD"}`)
@@ -560,6 +563,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": []}`)
@@ -576,6 +580,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": "bad"}`)
@@ -592,6 +597,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"quote_asset": "USD", "oracles": [` + validOracle + `]}`)
@@ -608,6 +614,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"base_asset": "XRP", "oracles": [` + validOracle + `]}`)
@@ -624,6 +631,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": [` + validOracle + `], "trim": 0}`)
@@ -639,6 +647,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": [` + validOracle + `], "trim": 26}`)
@@ -654,6 +663,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		// empty string
@@ -678,6 +688,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": [{"oracle_document_id": 1}]}`)
@@ -694,6 +705,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"base_asset": "XRP", "quote_asset": "USD", "oracles": [{"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}]}`)
@@ -710,6 +722,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		// float trim
@@ -726,6 +739,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		// non-numeric time_threshold
@@ -747,8 +761,7 @@ func TestGetAggregatePriceMethod(t *testing.T) {
 
 func TestGetCountsMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.GetCountsMethod{}
 
@@ -758,6 +771,7 @@ func TestGetCountsMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -777,8 +791,7 @@ func TestGetCountsMethod(t *testing.T) {
 
 func TestLogLevelMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.LogLevelMethod{}
 
@@ -787,6 +800,7 @@ func TestLogLevelMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -800,6 +814,7 @@ func TestLogLevelMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"severity": "invalid_level"}`)
@@ -819,6 +834,7 @@ func TestLogLevelMethod(t *testing.T) {
 					Context:    context.Background(),
 					Role:       types.RoleAdmin,
 					ApiVersion: types.ApiVersion1,
+					Services:   services,
 				}
 
 				params, _ := json.Marshal(map[string]string{"severity": level})
@@ -839,8 +855,7 @@ func TestLogLevelMethod(t *testing.T) {
 
 func TestLogRotateMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.LogRotateMethod{}
 
@@ -849,6 +864,7 @@ func TestLogRotateMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -870,8 +886,7 @@ func TestLogRotateMethod(t *testing.T) {
 
 func TestAMMInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.AMMInfoMethod{}
 
@@ -881,6 +896,7 @@ func TestAMMInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"amm_account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}`)
@@ -897,6 +913,7 @@ func TestAMMInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{
@@ -917,6 +934,7 @@ func TestAMMInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{}`)
@@ -932,6 +950,7 @@ func TestAMMInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{
@@ -955,8 +974,7 @@ func TestAMMInfoMethod(t *testing.T) {
 
 func TestVaultInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.VaultInfoMethod{}
 
@@ -966,6 +984,7 @@ func TestVaultInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"vault_id": "0000000000000000000000000000000000000000000000000000000000000000"}`)
@@ -982,6 +1001,7 @@ func TestVaultInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"owner": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", "seq": 1}`)
@@ -998,6 +1018,7 @@ func TestVaultInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"vault_id": "invalid_hex"}`)
@@ -1013,6 +1034,7 @@ func TestVaultInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{}`)
@@ -1028,6 +1050,7 @@ func TestVaultInfoMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{
@@ -1050,8 +1073,7 @@ func TestVaultInfoMethod(t *testing.T) {
 
 func TestUnlListMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.UnlListMethod{}
 
@@ -1060,6 +1082,7 @@ func TestUnlListMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -1080,8 +1103,7 @@ func TestUnlListMethod(t *testing.T) {
 
 func TestBlackListMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	cleanup := setupTestServicesMissingMethods(mock)
-	defer cleanup()
+	services := servicesForMissingMethods(mock)
 
 	method := &handlers.BlackListMethod{}
 
@@ -1090,6 +1112,7 @@ func TestBlackListMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -1106,6 +1129,7 @@ func TestBlackListMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := json.RawMessage(`{"threshold": 100}`)
@@ -1124,14 +1148,11 @@ func TestBlackListMethod(t *testing.T) {
 
 func TestMissingMethodsServiceUnavailable(t *testing.T) {
 	// Test all methods handle nil Services gracefully
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	methods := []struct {
@@ -1180,14 +1201,11 @@ func TestMissingMethodsServiceUnavailable(t *testing.T) {
 
 func TestMissingMethodsNilLedgerService(t *testing.T) {
 	// Test all methods handle nil Ledger gracefully
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{Ledger: nil}
-	defer func() { types.Services = oldServices }()
-
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: nil},
 	}
 
 	// Methods that depend on ledger service should return RpcINTERNAL when Ledger is nil

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -149,14 +149,10 @@ func (m *mockNFTOffersLedgerService) GetClosedLedgerView() (types.LedgerStateVie
 	return nil, errors.New("not implemented in mock")
 }
 
-// setupNFTOffersTestServices initializes the Services singleton with a mock for testing
-func setupNFTOffersTestServices(mock *mockNFTOffersLedgerService) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+// newNFTOffersTestServices builds a per-test ServiceContainer wrapping mock.
+func newNFTOffersTestServices(mock *mockNFTOffersLedgerService) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -166,14 +162,14 @@ func setupNFTOffersTestServices(mock *mockNFTOffersLedgerService) func() {
 // Reference: rippled NFTOffers_test.cpp testErrors()
 func TestNftBuyOffersErrorValidation(t *testing.T) {
 	mock := newMockNFTOffersLedgerService()
-	cleanup := setupNFTOffersTestServices(mock)
-	defer cleanup()
+	services := newNFTOffersTestServices(mock)
 
 	method := &handlers.NftBuyOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -267,14 +263,14 @@ func TestNftBuyOffersErrorValidation(t *testing.T) {
 // TestNftBuyOffersSuccess tests successful retrieval of NFT buy offers
 func TestNftBuyOffersSuccess(t *testing.T) {
 	mock := newMockNFTOffersLedgerService()
-	cleanup := setupNFTOffersTestServices(mock)
-	defer cleanup()
+	services := newNFTOffersTestServices(mock)
 
 	method := &handlers.NftBuyOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Setup mock to return some buy offers
@@ -338,14 +334,14 @@ func TestNftBuyOffersSuccess(t *testing.T) {
 // TestNftBuyOffersWithIOUAmount tests NFT buy offers with IOU amounts
 func TestNftBuyOffersWithIOUAmount(t *testing.T) {
 	mock := newMockNFTOffersLedgerService()
-	cleanup := setupNFTOffersTestServices(mock)
-	defer cleanup()
+	services := newNFTOffersTestServices(mock)
 
 	method := &handlers.NftBuyOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Setup mock to return a buy offer with IOU amount
@@ -396,14 +392,14 @@ func TestNftBuyOffersWithIOUAmount(t *testing.T) {
 // TestNftBuyOffersWithPagination tests NFT buy offers with pagination
 func TestNftBuyOffersWithPagination(t *testing.T) {
 	mock := newMockNFTOffersLedgerService()
-	cleanup := setupNFTOffersTestServices(mock)
-	defer cleanup()
+	services := newNFTOffersTestServices(mock)
 
 	method := &handlers.NftBuyOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Setup mock to return paginated results
@@ -449,14 +445,14 @@ func TestNftBuyOffersWithPagination(t *testing.T) {
 // TestNftSellOffersErrorValidation tests error handling for invalid inputs
 func TestNftSellOffersErrorValidation(t *testing.T) {
 	mock := newMockNFTOffersLedgerService()
-	cleanup := setupNFTOffersTestServices(mock)
-	defer cleanup()
+	services := newNFTOffersTestServices(mock)
 
 	method := &handlers.NftSellOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -533,14 +529,14 @@ func TestNftSellOffersErrorValidation(t *testing.T) {
 // TestNftSellOffersSuccess tests successful retrieval of NFT sell offers
 func TestNftSellOffersSuccess(t *testing.T) {
 	mock := newMockNFTOffersLedgerService()
-	cleanup := setupNFTOffersTestServices(mock)
-	defer cleanup()
+	services := newNFTOffersTestServices(mock)
 
 	method := &handlers.NftSellOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// lsfSellNFToken flag
@@ -589,14 +585,14 @@ func TestNftSellOffersSuccess(t *testing.T) {
 // TestNftSellOffersEmptyResult tests when no sell offers exist
 func TestNftSellOffersEmptyResult(t *testing.T) {
 	mock := newMockNFTOffersLedgerService()
-	cleanup := setupNFTOffersTestServices(mock)
-	defer cleanup()
+	services := newNFTOffersTestServices(mock)
 
 	method := &handlers.NftSellOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Setup mock to return empty result
@@ -630,17 +626,12 @@ func TestNftSellOffersEmptyResult(t *testing.T) {
 
 // TestNftBuyOffersServiceUnavailable tests response when ledger service is unavailable
 func TestNftBuyOffersServiceUnavailable(t *testing.T) {
-	oldServices := types.Services
-	types.Services = nil
-	defer func() {
-		types.Services = oldServices
-	}()
-
 	method := &handlers.NftBuyOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{
@@ -657,17 +648,12 @@ func TestNftBuyOffersServiceUnavailable(t *testing.T) {
 
 // TestNftSellOffersServiceUnavailable tests response when ledger service is unavailable
 func TestNftSellOffersServiceUnavailable(t *testing.T) {
-	oldServices := types.Services
-	types.Services = nil
-	defer func() {
-		types.Services = oldServices
-	}()
-
 	method := &handlers.NftSellOffersMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -163,14 +163,10 @@ func (m *mockNoRippleCheckLedgerService) GetClosedLedgerView() (types.LedgerStat
 	return nil, errors.New("not implemented in mock")
 }
 
-// setupNoRippleCheckTestServices initializes the Services singleton with a mock for testing
-func setupNoRippleCheckTestServices(mock *mockNoRippleCheckLedgerService) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+// newNoRippleCheckTestServices builds a per-test ServiceContainer wrapping mock.
+func newNoRippleCheckTestServices(mock *mockNoRippleCheckLedgerService) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -180,14 +176,14 @@ func setupNoRippleCheckTestServices(mock *mockNoRippleCheckLedgerService) func()
 // Based on rippled NoRippleCheck_test.cpp testBadInput()
 func TestNoRippleCheckErrorValidation(t *testing.T) {
 	mock := newMockNoRippleCheckLedgerService()
-	cleanup := setupNoRippleCheckTestServices(mock)
-	defer cleanup()
+	services := newNoRippleCheckTestServices(mock)
 
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -275,14 +271,14 @@ func TestNoRippleCheckErrorValidation(t *testing.T) {
 // Based on rippled NoRippleCheck_test.cpp testBasic(user=true, problems=false)
 func TestNoRippleCheckUserRoleNoProblems(t *testing.T) {
 	mock := newMockNoRippleCheckLedgerService()
-	cleanup := setupNoRippleCheckTestServices(mock)
-	defer cleanup()
+	services := newNoRippleCheckTestServices(mock)
 
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// User with no problems: DefaultRipple not set, NoRipple set on trust lines
@@ -325,14 +321,14 @@ func TestNoRippleCheckUserRoleNoProblems(t *testing.T) {
 // Based on rippled NoRippleCheck_test.cpp testBasic(user=true, problems=true)
 func TestNoRippleCheckUserRoleWithProblems(t *testing.T) {
 	mock := newMockNoRippleCheckLedgerService()
-	cleanup := setupNoRippleCheckTestServices(mock)
-	defer cleanup()
+	services := newNoRippleCheckTestServices(mock)
 
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// User with problems: DefaultRipple set (bad), NoRipple not set on trust lines (bad)
@@ -377,14 +373,14 @@ func TestNoRippleCheckUserRoleWithProblems(t *testing.T) {
 // Based on rippled NoRippleCheck_test.cpp testBasic(user=false, problems=false)
 func TestNoRippleCheckGatewayRoleNoProblems(t *testing.T) {
 	mock := newMockNoRippleCheckLedgerService()
-	cleanup := setupNoRippleCheckTestServices(mock)
-	defer cleanup()
+	services := newNoRippleCheckTestServices(mock)
 
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Gateway with no problems: DefaultRipple set, NoRipple not set on trust lines
@@ -422,14 +418,14 @@ func TestNoRippleCheckGatewayRoleNoProblems(t *testing.T) {
 // Based on rippled NoRippleCheck_test.cpp testBasic(user=false, problems=true)
 func TestNoRippleCheckGatewayRoleWithProblems(t *testing.T) {
 	mock := newMockNoRippleCheckLedgerService()
-	cleanup := setupNoRippleCheckTestServices(mock)
-	defer cleanup()
+	services := newNoRippleCheckTestServices(mock)
 
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Gateway with problems: DefaultRipple not set (bad), NoRipple set on trust lines (bad)
@@ -474,14 +470,14 @@ func TestNoRippleCheckGatewayRoleWithProblems(t *testing.T) {
 // Based on rippled NoRippleCheck_test.cpp testBasic with transactions=true
 func TestNoRippleCheckWithTransactionsUser(t *testing.T) {
 	mock := newMockNoRippleCheckLedgerService()
-	cleanup := setupNoRippleCheckTestServices(mock)
-	defer cleanup()
+	services := newNoRippleCheckTestServices(mock)
 
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// User with problems requesting transactions (only TrustSet, no AccountSet since DefaultRipple should not be set)
@@ -538,14 +534,14 @@ func TestNoRippleCheckWithTransactionsUser(t *testing.T) {
 // Based on rippled NoRippleCheck_test.cpp testBasic with transactions=true
 func TestNoRippleCheckWithTransactionsGateway(t *testing.T) {
 	mock := newMockNoRippleCheckLedgerService()
-	cleanup := setupNoRippleCheckTestServices(mock)
-	defer cleanup()
+	services := newNoRippleCheckTestServices(mock)
 
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Gateway with problems requesting transactions (AccountSet + TrustSet)
@@ -616,14 +612,14 @@ func TestNoRippleCheckWithTransactionsGateway(t *testing.T) {
 // Based on rippled NoRippleCheck.cpp API version check
 func TestNoRippleCheckTransactionsFieldValidationAPIv2(t *testing.T) {
 	mock := newMockNoRippleCheckLedgerService()
-	cleanup := setupNoRippleCheckTestServices(mock)
-	defer cleanup()
+	services := newNoRippleCheckTestServices(mock)
 
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion2,
+		Services:   services,
 	}
 
 	// In API v2, transactions must be a boolean, not a string
@@ -641,14 +637,14 @@ func TestNoRippleCheckTransactionsFieldValidationAPIv2(t *testing.T) {
 // TestNoRippleCheckTransactionsFieldAPIv1 tests that API v1 accepts transactions as any truthy value
 func TestNoRippleCheckTransactionsFieldAPIv1(t *testing.T) {
 	mock := newMockNoRippleCheckLedgerService()
-	cleanup := setupNoRippleCheckTestServices(mock)
-	defer cleanup()
+	services := newNoRippleCheckTestServices(mock)
 
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.noRippleCheckResult = &types.NoRippleCheckResult{
@@ -671,18 +667,12 @@ func TestNoRippleCheckTransactionsFieldAPIv1(t *testing.T) {
 
 // TestNoRippleCheckServiceUnavailable tests response when ledger service is unavailable
 func TestNoRippleCheckServiceUnavailable(t *testing.T) {
-	// Set Services to nil
-	oldServices := types.Services
-	types.Services = nil
-	defer func() {
-		types.Services = oldServices
-	}()
-
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{
@@ -703,14 +693,14 @@ func TestNoRippleCheckServiceUnavailable(t *testing.T) {
 // TestNoRippleCheckWithLimit tests the limit parameter
 func TestNoRippleCheckWithLimit(t *testing.T) {
 	mock := newMockNoRippleCheckLedgerService()
-	cleanup := setupNoRippleCheckTestServices(mock)
-	defer cleanup()
+	services := newNoRippleCheckTestServices(mock)
 
 	method := &handlers.NoRippleCheckMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.noRippleCheckResult = &types.NoRippleCheckResult{

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -24,6 +24,7 @@ type Server struct {
 	registry   *types.MethodRegistry
 	timeout    time.Duration
 	peerSource atomic.Pointer[types.PeerSource]
+	services   *types.ServiceContainer
 }
 
 // SetPeerSource registers the source of per-peer entries served by the
@@ -44,11 +45,14 @@ func (s *Server) loadPeerSource() types.PeerSource {
 	return nil
 }
 
-// NewServer creates a new RPC server with the given timeout
-func NewServer(timeout time.Duration) *Server {
+// NewServer creates a new RPC server with the given timeout and the
+// service container handlers will read through ctx.Services. The
+// container may be nil for test contexts that exercise routing only.
+func NewServer(timeout time.Duration, services *types.ServiceContainer) *Server {
 	server := &Server{
 		registry: types.NewMethodRegistry(),
 		timeout:  timeout,
+		services: services,
 	}
 
 	// Register all RPC methods
@@ -56,6 +60,11 @@ func NewServer(timeout time.Duration) *Server {
 
 	return server
 }
+
+// Services returns the service container wired to this server. Used by
+// callers that need to attach the dispatcher (this server itself) or
+// the shutdown hook after construction.
+func (s *Server) Services() *types.ServiceContainer { return s.services }
 
 // XrplRequest represents an XRPL JSON-RPC request
 // Format: {"method": "method_name", "params": [{...}]}
@@ -122,6 +131,7 @@ func (s *Server) handleGetRequest(w http.ResponseWriter, r *http.Request) {
 		IsAdmin:    role == types.RoleAdmin,
 		ClientIP:   clientIP,
 		PeerSource: s.loadPeerSource(),
+		Services:   s.services,
 	}
 
 	result, rpcErr := s.executeMethod(method, nil, ctx)
@@ -164,6 +174,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		IsAdmin:    role == types.RoleAdmin,
 		ClientIP:   clientIP,
 		PeerSource: s.loadPeerSource(),
+		Services:   s.services,
 	}
 
 	// Parse API version from params if present
@@ -218,8 +229,8 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 	// When the server is amendment-blocked, methods with any condition
 	// other than NoCondition are blocked with rpcAMENDMENT_BLOCKED.
 	if handler.RequiredCondition() != types.NoCondition {
-		if types.Services != nil && types.Services.Ledger != nil {
-			if types.Services.Ledger.IsAmendmentBlocked() {
+		if ctx.Services != nil && ctx.Services.Ledger != nil {
+			if ctx.Services.Ledger.IsAmendmentBlocked() {
 				return nil, types.NewRpcError(types.RpcAMENDMENT_BLOCKED,
 					"amendmentBlocked", "amendmentBlocked",
 					"Amendment blocked, need upgrade.")

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -55,14 +55,10 @@ func (m *mockLedgerServiceServerInfo) GetServerInfo() types.LedgerServerInfo {
 	}
 }
 
-// setupTestServicesServerInfo initializes the Services singleton with a server_info mock for testing
-func setupTestServicesServerInfo(mock *mockLedgerServiceServerInfo) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+// servicesForServerInfo builds a per-test ServiceContainer with a server_info mock.
+func servicesForServerInfo(mock *mockLedgerServiceServerInfo) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -73,14 +69,14 @@ func setupTestServicesServerInfo(mock *mockLedgerServiceServerInfo) func() {
 // Based on rippled ServerInfo_test.cpp: BEAST_EXPECT(info.isMember(jss::build_version));
 func TestServerInfoResponseFields(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("info.build_version field present", func(t *testing.T) {
@@ -274,14 +270,14 @@ func TestServerInfoResponseFields(t *testing.T) {
 // TestServerInfoValidatedLedgerFields tests the validated_ledger nested object fields
 func TestServerInfoValidatedLedgerFields(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("validated_ledger.age field present", func(t *testing.T) {
@@ -401,14 +397,14 @@ func TestServerInfoValidatedLedgerFields(t *testing.T) {
 // Based on rippled's NetworkOPs operating modes
 func TestServerInfoServerStates(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Valid server states per XRPL documentation
@@ -444,14 +440,14 @@ func TestServerInfoServerStates(t *testing.T) {
 func TestServerInfoStandaloneMode(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
 	mock.standalone = true
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Standalone mode returns correct server_state", func(t *testing.T) {
@@ -499,8 +495,7 @@ func TestServerInfoStandaloneMode(t *testing.T) {
 // TestServerInfoApiVersions tests server_info across different API versions
 func TestServerInfoApiVersions(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 
@@ -512,6 +507,7 @@ func TestServerInfoApiVersions(t *testing.T) {
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
 				ApiVersion: apiVersion,
+				Services:   services,
 			}
 
 			result, rpcErr := method.Handle(ctx, nil)
@@ -546,16 +542,12 @@ func TestServerInfoMethodSupportedApiVersions(t *testing.T) {
 
 // TestServerInfoServiceUnavailable tests behavior when ledger service is not available
 func TestServerInfoServiceUnavailable(t *testing.T) {
-	// Temporarily set Services to nil
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -568,16 +560,12 @@ func TestServerInfoServiceUnavailable(t *testing.T) {
 
 // TestServerInfoServiceNilLedger tests behavior when ledger service is nil
 func TestServerInfoServiceNilLedger(t *testing.T) {
-	// Set Services with nil Ledger
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{Ledger: nil}
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: nil},
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -612,14 +600,14 @@ func TestServerInfoMethodMetadata(t *testing.T) {
 // TestServerInfoCompleteLedgersFormat tests various complete_ledgers string formats
 func TestServerInfoCompleteLedgersFormat(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -672,14 +660,14 @@ func TestServerInfoCompleteLedgersFormat(t *testing.T) {
 // TestServerInfoStateAccounting tests the state_accounting field
 func TestServerInfoStateAccounting(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("state_accounting contains all states", func(t *testing.T) {
@@ -711,14 +699,14 @@ func TestServerInfoStateAccounting(t *testing.T) {
 // TestServerInfoTimeField tests the time field format
 func TestServerInfoTimeField(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("time field present and formatted", func(t *testing.T) {
@@ -744,14 +732,14 @@ func TestServerInfoTimeField(t *testing.T) {
 // TestServerInfoFeeCalculations tests fee conversions from drops to XRP
 func TestServerInfoFeeCalculations(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -823,14 +811,14 @@ func TestServerInfoFeeCalculations(t *testing.T) {
 // TestServerStateMethod tests the server_state RPC method
 func TestServerStateMethod(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerStateMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("server_state returns state wrapper", func(t *testing.T) {
@@ -894,15 +882,12 @@ func TestServerStateMethodMetadata(t *testing.T) {
 
 // TestServerStateServiceUnavailable tests behavior when ledger service is not available
 func TestServerStateServiceUnavailable(t *testing.T) {
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.ServerStateMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -918,14 +903,14 @@ func TestServerStateServiceUnavailable(t *testing.T) {
 // TestServerInfoWithDifferentLedgerStates tests server_info with various ledger states
 func TestServerInfoWithDifferentLedgerStates(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -989,14 +974,14 @@ func TestServerInfoWithDifferentLedgerStates(t *testing.T) {
 // TestServerInfoWithParams tests that server_info ignores any parameters passed
 func TestServerInfoWithParams(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	cleanup := setupTestServicesServerInfo(mock)
-	defer cleanup()
+	services := servicesForServerInfo(mock)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// server_info takes no parameters, but should not error if params are passed

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -253,13 +253,13 @@ func TestWalletPropose_Metadata(t *testing.T) {
 
 func TestSign_MissingTxJson(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{"secret": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"}`)
@@ -271,13 +271,13 @@ func TestSign_MissingTxJson(t *testing.T) {
 
 func TestSign_MissingCredentials(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -296,13 +296,13 @@ func TestSign_MissingCredentials(t *testing.T) {
 
 func TestSign_InvalidKeyType(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -323,13 +323,13 @@ func TestSign_InvalidKeyType(t *testing.T) {
 
 func TestSign_InvalidSeed(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -353,13 +353,13 @@ func TestSign_InvalidSeed(t *testing.T) {
 
 func TestSign_AccountMismatch(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Account in tx_json doesn't match the key derived from seed_hex
@@ -379,15 +379,11 @@ func TestSign_AccountMismatch(t *testing.T) {
 }
 
 func TestSign_LedgerServiceUnavailable(t *testing.T) {
-	// Services set to nil
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := json.RawMessage(`{
@@ -407,14 +403,11 @@ func TestSign_LedgerServiceUnavailable(t *testing.T) {
 
 func TestSign_OfflineMode(t *testing.T) {
 	// No services needed for offline mode
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	// Use passphrase and provide all required fields
@@ -467,13 +460,13 @@ func TestSign_FeeMultMax_DefaultAccepted(t *testing.T) {
 	// With default fee_mult_max=10 and fee_div_max=1, a baseFee of 10
 	// should be accepted (10 <= 10*10/1 = 100).
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// No Fee in tx_json, auto-fill will kick in
@@ -501,13 +494,13 @@ func TestSign_FeeMultMax_ZeroRejects(t *testing.T) {
 	// fee_mult_max=0 means limit = baseFee * 0 / 1 = 0.
 	// Since networkFee (10) > 0, should return rpcHIGH_FEE.
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -530,13 +523,13 @@ func TestSign_FeeDivMax_LargeRejects(t *testing.T) {
 	// fee_div_max=100 means limit = baseFee * 10 / 100 = 1.
 	// Since networkFee (10) > 1, should return rpcHIGH_FEE.
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -1004,13 +997,13 @@ func TestSignFor_Metadata(t *testing.T) {
 
 func TestSubmitMultisigned_MissingTxJson(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{}`)
@@ -1021,13 +1014,13 @@ func TestSubmitMultisigned_MissingTxJson(t *testing.T) {
 
 func TestSubmitMultisigned_MissingAccount(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -1048,13 +1041,13 @@ func TestSubmitMultisigned_MissingAccount(t *testing.T) {
 
 func TestSubmitMultisigned_NonEmptySigningPubKey(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -1076,13 +1069,13 @@ func TestSubmitMultisigned_NonEmptySigningPubKey(t *testing.T) {
 
 func TestSubmitMultisigned_EmptySignersArray(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -1104,13 +1097,13 @@ func TestSubmitMultisigned_EmptySignersArray(t *testing.T) {
 
 func TestSubmitMultisigned_InvalidSignerFormat(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -1136,13 +1129,13 @@ func TestSubmitMultisigned_InvalidSignerFormat(t *testing.T) {
 
 func TestSubmitMultisigned_MissingSignerAccount(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -1171,13 +1164,13 @@ func TestSubmitMultisigned_MissingSignerAccount(t *testing.T) {
 
 func TestSubmitMultisigned_MissingSigningPubKey(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -1206,13 +1199,13 @@ func TestSubmitMultisigned_MissingSigningPubKey(t *testing.T) {
 
 func TestSubmitMultisigned_MissingTxnSignature(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -1241,13 +1234,13 @@ func TestSubmitMultisigned_MissingTxnSignature(t *testing.T) {
 
 func TestSubmitMultisigned_SignersNotSorted(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Signers not sorted by account (rP... < rH... is false alphabetically)
@@ -1284,14 +1277,11 @@ func TestSubmitMultisigned_SignersNotSorted(t *testing.T) {
 }
 
 func TestSubmitMultisigned_LedgerServiceUnavailable(t *testing.T) {
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := json.RawMessage(`{

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -38,13 +38,9 @@ func (m *mockLedgerServiceSimulate) SimulateTransaction(txJSON []byte) (*types.S
 	return m.simulateResult, nil
 }
 
-func setupTestServicesSimulate(mock *mockLedgerServiceSimulate) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+func newSimulateTestServices(mock *mockLedgerServiceSimulate) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -53,14 +49,14 @@ const validAccountAddress = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
 
 func TestSimulateMethod_ParamErrors(t *testing.T) {
 	mock := newMockLedgerServiceSimulate()
-	cleanup := setupTestServicesSimulate(mock)
-	defer cleanup()
+	services := newSimulateTestServices(mock)
 
 	method := &handlers.SimulateMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion2,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -204,14 +200,14 @@ func TestSimulateMethod_ParamErrors(t *testing.T) {
 
 func TestSimulateMethod_TxnSignature(t *testing.T) {
 	mock := newMockLedgerServiceSimulate()
-	cleanup := setupTestServicesSimulate(mock)
-	defer cleanup()
+	services := newSimulateTestServices(mock)
 
 	method := &handlers.SimulateMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion2,
+		Services:   services,
 	}
 
 	t.Run("Signed transaction — non-empty TxnSignature", func(t *testing.T) {
@@ -273,14 +269,14 @@ func TestSimulateMethod_TxnSignature(t *testing.T) {
 
 func TestSimulateMethod_SignedMultisig(t *testing.T) {
 	mock := newMockLedgerServiceSimulate()
-	cleanup := setupTestServicesSimulate(mock)
-	defer cleanup()
+	services := newSimulateTestServices(mock)
 
 	method := &handlers.SimulateMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion2,
+		Services:   services,
 	}
 
 	t.Run("Signed multisig transaction — non-empty signer TxnSignature", func(t *testing.T) {
@@ -383,14 +379,14 @@ func TestSimulateMethod_SignedMultisig(t *testing.T) {
 
 func TestSimulateMethod_BatchRejection(t *testing.T) {
 	mock := newMockLedgerServiceSimulate()
-	cleanup := setupTestServicesSimulate(mock)
-	defer cleanup()
+	services := newSimulateTestServices(mock)
 
 	method := &handlers.SimulateMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion2,
+		Services:   services,
 	}
 
 	params := map[string]interface{}{
@@ -411,14 +407,14 @@ func TestSimulateMethod_BatchRejection(t *testing.T) {
 
 func TestSimulateMethod_SuccessfulSimulation(t *testing.T) {
 	mock := newMockLedgerServiceSimulate()
-	cleanup := setupTestServicesSimulate(mock)
-	defer cleanup()
+	services := newSimulateTestServices(mock)
 
 	method := &handlers.SimulateMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion2,
+		Services:   services,
 	}
 
 	params := map[string]interface{}{
@@ -454,14 +450,14 @@ func TestSimulateMethod_SuccessfulSimulation(t *testing.T) {
 
 func TestSimulateMethod_SrcActMalformed(t *testing.T) {
 	mock := newMockLedgerServiceSimulate()
-	cleanup := setupTestServicesSimulate(mock)
-	defer cleanup()
+	services := newSimulateTestServices(mock)
 
 	method := &handlers.SimulateMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion2,
+		Services:   services,
 	}
 
 	params := map[string]interface{}{

--- a/internal/rpc/submit_multisigned_test.go
+++ b/internal/rpc/submit_multisigned_test.go
@@ -48,11 +48,10 @@ func makeSubmitMultisignedParams(t *testing.T, txJSON map[string]interface{}) js
 // Matches rippled: checkMultiSignFields -> missing_field_error("tx_json.Sequence")
 func TestSubmitMultisigned_MissingSequence(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
 	delete(txJSON, "Sequence")
@@ -66,11 +65,10 @@ func TestSubmitMultisigned_MissingSequence(t *testing.T) {
 // TestSubmitMultisigned_InvalidSequenceType verifies that a non-numeric Sequence is rejected.
 func TestSubmitMultisigned_InvalidSequenceType(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
 	txJSON["Sequence"] = "not_a_number"
@@ -85,11 +83,10 @@ func TestSubmitMultisigned_InvalidSequenceType(t *testing.T) {
 // Matches rippled: "Invalid Fee field.  Fees must be specified in XRP."
 func TestSubmitMultisigned_FeeNotPresent(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
 	delete(txJSON, "Fee")
@@ -104,11 +101,10 @@ func TestSubmitMultisigned_FeeNotPresent(t *testing.T) {
 // Fee must be a string of drops.
 func TestSubmitMultisigned_FeeNotString(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
 	txJSON["Fee"] = 12 // numeric, not string
@@ -123,11 +119,10 @@ func TestSubmitMultisigned_FeeNotString(t *testing.T) {
 // Matches rippled: "Invalid Fee field.  Fees must be greater than zero."
 func TestSubmitMultisigned_FeeZero(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
 	txJSON["Fee"] = "0"
@@ -141,11 +136,10 @@ func TestSubmitMultisigned_FeeZero(t *testing.T) {
 // TestSubmitMultisigned_FeeNegative verifies that a negative Fee is rejected.
 func TestSubmitMultisigned_FeeNegative(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
 	txJSON["Fee"] = "-10"
@@ -159,11 +153,10 @@ func TestSubmitMultisigned_FeeNegative(t *testing.T) {
 // TestSubmitMultisigned_FeeNotNumericString verifies that a non-numeric Fee string is rejected.
 func TestSubmitMultisigned_FeeNotNumericString(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
 	txJSON["Fee"] = "abc"
@@ -179,11 +172,10 @@ func TestSubmitMultisigned_FeeNotNumericString(t *testing.T) {
 // Matches rippled: rpcError(rpcSIGNING_MALFORMED) -> code 63, "signingMalformed"
 func TestSubmitMultisigned_TxnSignaturePresent(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
 	txJSON["TxnSignature"] = "DEADBEEF"
@@ -201,11 +193,10 @@ func TestSubmitMultisigned_TxnSignaturePresent(t *testing.T) {
 // "A Signer may not be the transaction's Account (<addr>)."
 func TestSubmitMultisigned_SelfSigning(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
 	txAccount := txJSON["Account"].(string)
@@ -228,11 +219,10 @@ func TestSubmitMultisigned_SelfSigning(t *testing.T) {
 // "Duplicate Signers:Signer:Account entries (<addr>) are not allowed."
 func TestSubmitMultisigned_DuplicateSigners(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	dupAccount := "rPMh7Pi9ct699iZUTWzJaUOVnFNaREiPik"
 	txJSON := validMultisignedTxJSON()
@@ -264,11 +254,10 @@ func TestSubmitMultisigned_DuplicateSigners(t *testing.T) {
 // This test proceeds past Fee validation and hits the binary encoding step.
 func TestSubmitMultisigned_FeeValidPositive(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
 	txJSON["Fee"] = "10"
@@ -284,11 +273,10 @@ func TestSubmitMultisigned_FeeValidPositive(t *testing.T) {
 // Sequence is checked before TxnSignature.
 func TestSubmitMultisigned_ValidationOrder_SequenceBeforeTxnSignature(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	// Both Sequence missing AND TxnSignature present -- Sequence error should come first.
 	txJSON := validMultisignedTxJSON()
@@ -304,11 +292,10 @@ func TestSubmitMultisigned_ValidationOrder_SequenceBeforeTxnSignature(t *testing
 // TxnSignature is checked before Fee.
 func TestSubmitMultisigned_ValidationOrder_TxnSignatureBeforeFee(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	handler := &handlers.SubmitMultisignedMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	// Both TxnSignature present AND Fee invalid -- TxnSignature error should come first.
 	txJSON := validMultisignedTxJSON()

--- a/internal/rpc/submit_test.go
+++ b/internal/rpc/submit_test.go
@@ -50,28 +50,24 @@ func (m *mockLedgerServiceSubmit) StoreTransaction(txHash [32]byte, txData []byt
 	return nil
 }
 
-// setupTestServicesSubmit initializes the Services singleton with a submit mock for testing
-func setupTestServicesSubmit(mock *mockLedgerServiceSubmit) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+// newSubmitTestServices builds a per-test ServiceContainer wrapping mock.
+func newSubmitTestServices(mock *mockLedgerServiceSubmit) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
 // TestSubmitMethodErrorValidation tests error handling for invalid inputs
 func TestSubmitMethodErrorValidation(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -176,14 +172,14 @@ func TestSubmitMethodErrorValidation(t *testing.T) {
 // TestSubmitMethodValidTxJson tests valid tx_json submission
 func TestSubmitMethodValidTxJson(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -296,14 +292,14 @@ func TestSubmitMethodValidTxJson(t *testing.T) {
 // TestSubmitMethodResponseFields tests that response contains expected fields
 func TestSubmitMethodResponseFields(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.submitResult = &types.SubmitResult{
@@ -399,14 +395,14 @@ func TestSubmitMethodResponseFields(t *testing.T) {
 // TestSubmitMethodEngineResults tests various engine result codes
 func TestSubmitMethodEngineResults(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	baseTxJson := map[string]interface{}{
@@ -576,14 +572,14 @@ func TestSubmitMethodEngineResults(t *testing.T) {
 // during the unmarshal to map[string]interface{} in the method itself.
 func TestSubmitMethodMalformedTransaction(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Note: The current implementation uses json.RawMessage for tx_json,
@@ -665,15 +661,12 @@ func TestSubmitMethodMalformedTransaction(t *testing.T) {
 
 // TestSubmitMethodServiceUnavailable tests behavior when ledger service is not available
 func TestSubmitMethodServiceUnavailable(t *testing.T) {
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{
@@ -697,15 +690,12 @@ func TestSubmitMethodServiceUnavailable(t *testing.T) {
 
 // TestSubmitMethodServiceNilLedger tests behavior when ledger service is nil
 func TestSubmitMethodServiceNilLedger(t *testing.T) {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{Ledger: nil}
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: nil},
 	}
 
 	params := map[string]interface{}{
@@ -730,14 +720,14 @@ func TestSubmitMethodServiceNilLedger(t *testing.T) {
 // TestSubmitMethodSubmitError tests handling of ledger service errors
 func TestSubmitMethodSubmitError(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -806,14 +796,14 @@ func TestSubmitMethodMetadata(t *testing.T) {
 // TestSubmitMethodOptionalParams tests optional parameters
 func TestSubmitMethodOptionalParams(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	baseTxJson := map[string]interface{}{
@@ -923,14 +913,14 @@ func TestSubmitMethodOptionalParams(t *testing.T) {
 // the key, signs the transaction, and submits the signed blob.
 func TestSubmitMethodSigningCredentials(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -1024,8 +1014,7 @@ func TestSubmitMethodSigningCredentials(t *testing.T) {
 // API v2 should include "hash" at the root level of the response.
 func TestSubmitMethodApiV2Response(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 
@@ -1043,6 +1032,7 @@ func TestSubmitMethodApiV2Response(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleUser,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := map[string]interface{}{
@@ -1076,6 +1066,7 @@ func TestSubmitMethodApiV2Response(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleUser,
 			ApiVersion: types.ApiVersion2,
+			Services:   services,
 		}
 
 		params := map[string]interface{}{
@@ -1110,6 +1101,7 @@ func TestSubmitMethodApiV2Response(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleUser,
 			ApiVersion: types.ApiVersion3,
+			Services:   services,
 		}
 
 		params := map[string]interface{}{
@@ -1140,8 +1132,7 @@ func TestSubmitMethodApiV2Response(t *testing.T) {
 // For API v2+: Amount is removed, DeliverMax replaces it.
 func TestSubmitMethodDeliverMax(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 
@@ -1150,6 +1141,7 @@ func TestSubmitMethodDeliverMax(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleUser,
 			ApiVersion: types.ApiVersion1,
+			Services:   services,
 		}
 
 		params := map[string]interface{}{
@@ -1191,6 +1183,7 @@ func TestSubmitMethodDeliverMax(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleUser,
 			ApiVersion: types.ApiVersion2,
+			Services:   services,
 		}
 
 		params := map[string]interface{}{
@@ -1233,6 +1226,7 @@ func TestSubmitMethodDeliverMax(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleUser,
 			ApiVersion: types.ApiVersion2,
+			Services:   services,
 		}
 
 		params := map[string]interface{}{
@@ -1272,14 +1266,14 @@ func TestSubmitMethodDeliverMax(t *testing.T) {
 // matching rippled's Transaction::SubmitResult struct.
 func TestSubmitMethodIndependentBooleans(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	cleanup := setupTestServicesSubmit(mock)
-	defer cleanup()
+	services := newSubmitTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	baseTxJson := map[string]interface{}{

--- a/internal/rpc/transaction_entry_test.go
+++ b/internal/rpc/transaction_entry_test.go
@@ -117,13 +117,9 @@ func (m *mockLedgerServiceTE) addLedger(lr *mockLedgerReaderTE) {
 	m.ledgersByHash[lr.hash] = lr
 }
 
-func setupTestServicesTE(mock *mockLedgerServiceTE) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+func newTransactionEntryTestServices(mock *mockLedgerServiceTE) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -133,14 +129,14 @@ func setupTestServicesTE(mock *mockLedgerServiceTE) func() {
 // Based on rippled TransactionEntry_test.cpp testBadInput (no params case).
 func TestTransactionEntryMissingTxHash(t *testing.T) {
 	mock := newMockLedgerServiceTE()
-	cleanup := setupTestServicesTE(mock)
-	defer cleanup()
+	services := newTransactionEntryTestServices(mock)
 
 	method := &handlers.TransactionEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -187,14 +183,14 @@ func TestTransactionEntryMissingTxHash(t *testing.T) {
 // Based on rippled TransactionEntry_test.cpp (DEADBEEF case and too-short/too-long cases).
 func TestTransactionEntryInvalidTxHash(t *testing.T) {
 	mock := newMockLedgerServiceTE()
-	cleanup := setupTestServicesTE(mock)
-	defer cleanup()
+	services := newTransactionEntryTestServices(mock)
 
 	method := &handlers.TransactionEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -245,8 +241,7 @@ func TestTransactionEntryInvalidTxHash(t *testing.T) {
 // Based on rippled TransactionEntry_test.cpp testRequest (ledger_index and ledger_hash lookups).
 func TestTransactionEntryLedgerResolution(t *testing.T) {
 	mock := newMockLedgerServiceTE()
-	cleanup := setupTestServicesTE(mock)
-	defer cleanup()
+	services := newTransactionEntryTestServices(mock)
 
 	// Add a ledger at sequence 2
 	ledger2 := newMockLedgerReaderTE(2)
@@ -283,6 +278,7 @@ func TestTransactionEntryLedgerResolution(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("by ledger_index integer", func(t *testing.T) {
@@ -377,8 +373,7 @@ func TestTransactionEntryLedgerResolution(t *testing.T) {
 // Based on rippled TransactionEntry_test.cpp (valid structure but tx not found case).
 func TestTransactionEntryTxNotFound(t *testing.T) {
 	mock := newMockLedgerServiceTE()
-	cleanup := setupTestServicesTE(mock)
-	defer cleanup()
+	services := newTransactionEntryTestServices(mock)
 
 	// Add a ledger but no transactions
 	ledger2 := newMockLedgerReaderTE(2)
@@ -389,6 +384,7 @@ func TestTransactionEntryTxNotFound(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	txHashStr := "E2FE8D4AF3FCC3944DDF6CD8CDDC5E3F0AD50863EF8919AFEF10CB6408CD4D05"
@@ -409,8 +405,7 @@ func TestTransactionEntryTxNotFound(t *testing.T) {
 // ledger than requested returns an error.
 func TestTransactionEntryTxNotInRequestedLedger(t *testing.T) {
 	mock := newMockLedgerServiceTE()
-	cleanup := setupTestServicesTE(mock)
-	defer cleanup()
+	services := newTransactionEntryTestServices(mock)
 
 	// Add two ledgers
 	ledger2 := newMockLedgerReaderTE(2)
@@ -447,6 +442,7 @@ func TestTransactionEntryTxNotInRequestedLedger(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Request with ledger 3, but tx is in ledger 2
@@ -468,8 +464,7 @@ func TestTransactionEntryTxNotInRequestedLedger(t *testing.T) {
 // Based on rippled TransactionEntry_test.cpp testRequest (checking response members).
 func TestTransactionEntryResponseStructure(t *testing.T) {
 	mock := newMockLedgerServiceTE()
-	cleanup := setupTestServicesTE(mock)
-	defer cleanup()
+	services := newTransactionEntryTestServices(mock)
 
 	ledger2 := newMockLedgerReaderTE(2)
 	ledger2.closeTime = 10
@@ -502,6 +497,7 @@ func TestTransactionEntryResponseStructure(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := map[string]interface{}{
@@ -545,16 +541,14 @@ func TestTransactionEntryResponseStructure(t *testing.T) {
 // TestTransactionEntryServiceUnavailable tests behavior when ledger service is not available.
 func TestTransactionEntryServiceUnavailable(t *testing.T) {
 	method := &handlers.TransactionEntryMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	t.Run("Services is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		params := map[string]interface{}{
 			"tx_hash":      "E2FE8D4AF3FCC3944DDF6CD8CDDC5E3F0AD50863EF8919AFEF10CB6408CD4D05",
@@ -571,9 +565,12 @@ func TestTransactionEntryServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Services.Ledger is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		params := map[string]interface{}{
 			"tx_hash":      "E2FE8D4AF3FCC3944DDF6CD8CDDC5E3F0AD50863EF8919AFEF10CB6408CD4D05",
@@ -610,14 +607,14 @@ func TestTransactionEntryMethodMetadata(t *testing.T) {
 // TestTransactionEntryInvalidLedgerHash tests that an invalid ledger_hash returns an error.
 func TestTransactionEntryInvalidLedgerHash(t *testing.T) {
 	mock := newMockLedgerServiceTE()
-	cleanup := setupTestServicesTE(mock)
-	defer cleanup()
+	services := newTransactionEntryTestServices(mock)
 
 	method := &handlers.TransactionEntryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	txHashStr := "E2FE8D4AF3FCC3944DDF6CD8CDDC5E3F0AD50863EF8919AFEF10CB6408CD4D05"

--- a/internal/rpc/tx_history_test.go
+++ b/internal/rpc/tx_history_test.go
@@ -40,13 +40,9 @@ func (m *mockLedgerServiceTxHistory) GetTransactionHistory(startIndex uint32) (*
 	}, nil
 }
 
-func setupTestServicesTxHistory(mock *mockLedgerServiceTxHistory) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+func newTxHistoryTestServices(mock *mockLedgerServiceTxHistory) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -56,14 +52,14 @@ func setupTestServicesTxHistory(mock *mockLedgerServiceTxHistory) func() {
 // Based on rippled TransactionHistory_test.cpp testRequest.
 func TestTxHistoryBasicRequest(t *testing.T) {
 	mock := newMockLedgerServiceTxHistory()
-	cleanup := setupTestServicesTxHistory(mock)
-	defer cleanup()
+	services := newTxHistoryTestServices(mock)
 
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("start=0", func(t *testing.T) {
@@ -136,14 +132,14 @@ func TestTxHistoryBasicRequest(t *testing.T) {
 // Based on rippled TransactionHistory_test.cpp empty history scenario.
 func TestTxHistoryEmptyResult(t *testing.T) {
 	mock := newMockLedgerServiceTxHistory()
-	cleanup := setupTestServicesTxHistory(mock)
-	defer cleanup()
+	services := newTxHistoryTestServices(mock)
 
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.txHistoryResult = &types.TxHistoryResult{
@@ -174,14 +170,14 @@ func TestTxHistoryEmptyResult(t *testing.T) {
 // Based on rippled TransactionHistory_test.cpp response validation.
 func TestTxHistoryResponseStructure(t *testing.T) {
 	mock := newMockLedgerServiceTxHistory()
-	cleanup := setupTestServicesTxHistory(mock)
-	defer cleanup()
+	services := newTxHistoryTestServices(mock)
 
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.txHistoryResult = &types.TxHistoryResult{
@@ -220,14 +216,14 @@ func TestTxHistoryResponseStructure(t *testing.T) {
 // Based on rippled TransactionHistory_test.cpp - tx_history requires a database.
 func TestTxHistoryDatabaseNotConfigured(t *testing.T) {
 	mock := newMockLedgerServiceTxHistory()
-	cleanup := setupTestServicesTxHistory(mock)
-	defer cleanup()
+	services := newTxHistoryTestServices(mock)
 
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.txHistoryErr = errors.New("transaction history not available (no database configured)")
@@ -247,16 +243,14 @@ func TestTxHistoryDatabaseNotConfigured(t *testing.T) {
 // TestTxHistoryServiceUnavailable tests behavior when the ledger service is not available.
 func TestTxHistoryServiceUnavailable(t *testing.T) {
 	method := &handlers.TxHistoryMethod{}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleUser,
-		ApiVersion: types.ApiVersion1,
-	}
 
 	t.Run("Services is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = nil
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion1,
+			Services:   nil,
+		}
 
 		params := map[string]interface{}{
 			"start": 0,
@@ -272,9 +266,12 @@ func TestTxHistoryServiceUnavailable(t *testing.T) {
 	})
 
 	t.Run("Services.Ledger is nil", func(t *testing.T) {
-		oldServices := types.Services
-		types.Services = &types.ServiceContainer{Ledger: nil}
-		defer func() { types.Services = oldServices }()
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: nil},
+		}
 
 		params := map[string]interface{}{
 			"start": 0,
@@ -293,14 +290,14 @@ func TestTxHistoryServiceUnavailable(t *testing.T) {
 // TestTxHistoryInternalError tests behavior when the service returns a generic error.
 func TestTxHistoryInternalError(t *testing.T) {
 	mock := newMockLedgerServiceTxHistory()
-	cleanup := setupTestServicesTxHistory(mock)
-	defer cleanup()
+	services := newTxHistoryTestServices(mock)
 
 	method := &handlers.TxHistoryMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	mock.txHistoryErr = errors.New("internal database failure")

--- a/internal/rpc/tx_test.go
+++ b/internal/rpc/tx_test.go
@@ -64,14 +64,10 @@ func (m *mockLedgerServiceTx) GetLedgerRange(minSeq, maxSeq uint32) (*types.Ledg
 	}, nil
 }
 
-// setupTestServicesTx initializes the Services singleton with a tx mock for testing
-func setupTestServicesTx(mock *mockLedgerServiceTx) func() {
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{
+// servicesForTx builds a per-test ServiceContainer with a tx mock.
+func servicesForTx(mock *mockLedgerServiceTx) *types.ServiceContainer {
+	return &types.ServiceContainer{
 		Ledger: mock,
-	}
-	return func() {
-		types.Services = oldServices
 	}
 }
 
@@ -81,14 +77,14 @@ func setupTestServicesTx(mock *mockLedgerServiceTx) func() {
 // Based on rippled Transaction_test.cpp
 func TestTxMethodErrorValidation(t *testing.T) {
 	mock := newMockLedgerServiceTx()
-	cleanup := setupTestServicesTx(mock)
-	defer cleanup()
+	services := servicesForTx(mock)
 
 	method := &handlers.TxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	tests := []struct {
@@ -278,14 +274,14 @@ func TestTxMethodErrorValidation(t *testing.T) {
 // Based on rippled Transaction_test.cpp testRequest
 func TestTxMethodLookupByHash(t *testing.T) {
 	mock := newMockLedgerServiceTx()
-	cleanup := setupTestServicesTx(mock)
-	defer cleanup()
+	services := servicesForTx(mock)
 
 	method := &handlers.TxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Valid 64-character transaction hash
@@ -394,14 +390,14 @@ func TestTxMethodLookupByHash(t *testing.T) {
 // Based on rippled Transaction_test.cpp testBinaryRequest
 func TestTxMethodBinaryOption(t *testing.T) {
 	mock := newMockLedgerServiceTx()
-	cleanup := setupTestServicesTx(mock)
-	defer cleanup()
+	services := servicesForTx(mock)
 
 	method := &handlers.TxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validHash := "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7"
@@ -1027,14 +1023,14 @@ func TestCTIDFormatValidation(t *testing.T) {
 // Based on rippled Transaction_test.cpp testRangeRequest
 func TestTxMethodLedgerRange(t *testing.T) {
 	mock := newMockLedgerServiceTx()
-	cleanup := setupTestServicesTx(mock)
-	defer cleanup()
+	services := servicesForTx(mock)
 
 	method := &handlers.TxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validHash := "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7"
@@ -1272,14 +1268,14 @@ func boolPtr(b bool) *bool {
 // Based on rippled Transaction_test.cpp testRequest and testBinaryRequest
 func TestTxMethodResponseFields(t *testing.T) {
 	mock := newMockLedgerServiceTx()
-	cleanup := setupTestServicesTx(mock)
-	defer cleanup()
+	services := servicesForTx(mock)
 
 	method := &handlers.TxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	validHash := "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7"
@@ -1421,16 +1417,12 @@ func TestTxMethodResponseFields(t *testing.T) {
 
 // TestTxMethodServiceUnavailable tests behavior when ledger service is not available
 func TestTxMethodServiceUnavailable(t *testing.T) {
-	// Temporarily set Services to nil
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.TxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	params := map[string]interface{}{
@@ -1449,16 +1441,12 @@ func TestTxMethodServiceUnavailable(t *testing.T) {
 
 // TestTxMethodServiceNilLedger tests behavior when ledger service is nil
 func TestTxMethodServiceNilLedger(t *testing.T) {
-	// Set Services with nil Ledger
-	oldServices := types.Services
-	types.Services = &types.ServiceContainer{Ledger: nil}
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.TxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: nil},
 	}
 
 	params := map[string]interface{}{
@@ -1500,8 +1488,7 @@ func TestTxMethodMetadata(t *testing.T) {
 // Based on rippled Transaction_test.cpp testRequest with api_version parameter
 func TestTxMethodApiVersions(t *testing.T) {
 	mock := newMockLedgerServiceTx()
-	cleanup := setupTestServicesTx(mock)
-	defer cleanup()
+	services := servicesForTx(mock)
 
 	method := &handlers.TxMethod{}
 
@@ -1536,6 +1523,7 @@ func TestTxMethodApiVersions(t *testing.T) {
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
 				ApiVersion: version,
+				Services:   services,
 			}
 
 			params := map[string]interface{}{
@@ -1653,14 +1641,14 @@ func TestCTIDNetworkIDInResponse(t *testing.T) {
 // TestTxMethodEdgeCases tests various edge cases
 func TestTxMethodEdgeCases(t *testing.T) {
 	mock := newMockLedgerServiceTx()
-	cleanup := setupTestServicesTx(mock)
-	defer cleanup()
+	services := servicesForTx(mock)
 
 	method := &handlers.TxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Transaction with corrupted stored data", func(t *testing.T) {
@@ -1735,14 +1723,14 @@ func TestTxMethodEdgeCases(t *testing.T) {
 // TestTxMethodInternalErrors tests internal error handling
 func TestTxMethodInternalErrors(t *testing.T) {
 	mock := newMockLedgerServiceTx()
-	cleanup := setupTestServicesTx(mock)
-	defer cleanup()
+	services := servicesForTx(mock)
 
 	method := &handlers.TxMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	t.Run("Database error during lookup", func(t *testing.T) {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -6,11 +6,6 @@ import (
 	"github.com/LeJamon/goXRPLd/keylet"
 )
 
-// Services provides access to core services from RPC handlers
-// This is a singleton that holds references to the services
-// needed by RPC method handlers.
-var Services *ServiceContainer
-
 // MethodDispatcher allows forwarding RPC calls to the method registry.
 // Used by the 'json' RPC method to proxy calls.
 type MethodDispatcher interface {
@@ -583,9 +578,11 @@ type NFTOffersResult struct {
 	Marker      string         `json:"marker,omitempty"` // Only present when more results available
 }
 
-// InitServices initializes the service container
-func InitServices(ledger LedgerService) {
-	Services = &ServiceContainer{
+// NewServiceContainer constructs a ServiceContainer wired to the given
+// ledger service. Callers attach the dispatcher, peer hooks, manifest
+// cache, etc. afterwards as components come online.
+func NewServiceContainer(ledger LedgerService) *ServiceContainer {
+	return &ServiceContainer{
 		Ledger: ledger,
 	}
 }

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -60,6 +60,13 @@ type RpcContext struct {
 	IsAdmin    bool
 	ClientIP   string
 	PeerSource PeerSource
+	// Services is the per-request service container handlers read to
+	// reach the ledger service, dispatcher, manifest cache, etc. The
+	// HTTP/WebSocket dispatchers populate this from the server's wired
+	// container; tests construct RpcContext directly with whatever
+	// fixtures they need. Replaces the former package-level
+	// types.Services global.
+	Services *ServiceContainer
 }
 
 // Method handler interface - all RPC methods implement this

--- a/internal/rpc/validators_test.go
+++ b/internal/rpc/validators_test.go
@@ -20,14 +20,14 @@ import (
 // trusted_validator_keys, publisher_lists, validation_quorum are present.
 func TestValidatorsResponseStructure(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.ValidatorsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -57,14 +57,14 @@ func TestValidatorsResponseStructure(t *testing.T) {
 // trusted_validator_keys.size() == 0 and publisher_lists.size() == 0.
 func TestValidatorsEmptyList(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.ValidatorsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -121,14 +121,14 @@ func TestValidatorsMethodMetadata(t *testing.T) {
 // The validators method accepts no parameters but should not fail if extras are sent.
 func TestValidatorsWithParams(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.ValidatorsMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params, err := json.Marshal(map[string]interface{}{
@@ -150,14 +150,14 @@ func TestValidatorsWithParams(t *testing.T) {
 // status == "success" and the result to contain validation key fields.
 func TestValidationCreateReturnsKeyPair(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.ValidationCreateMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	// Call without params (generate random key pair)
@@ -177,14 +177,14 @@ func TestValidationCreateReturnsKeyPair(t *testing.T) {
 // "BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE" and expects success.
 func TestValidationCreateWithSecret(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.ValidationCreateMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params, err := json.Marshal(map[string]interface{}{
@@ -237,14 +237,14 @@ func TestValidationCreateMethodMetadata(t *testing.T) {
 // is the correct response.
 func TestConsensusInfoResponseStructure(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.ConsensusInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -296,14 +296,14 @@ func TestConsensusInfoMethodMetadata(t *testing.T) {
 // The consensus_info method accepts no parameters but should not fail if extras are sent.
 func TestConsensusInfoWithParams(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	method := &handlers.ConsensusInfoMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params, err := json.Marshal(map[string]interface{}{
@@ -323,12 +323,11 @@ func TestConsensusInfoWithParams(t *testing.T) {
 // Reference: rippled Stop.cpp — returns message "ripple server stopping".
 func TestStopReturnsStoppingMessage(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	// Set up a shutdown function that records it was called
 	shutdownCalled := false
-	types.Services.ShutdownFunc = func() {
+	services.ShutdownFunc = func() {
 		shutdownCalled = true
 	}
 
@@ -337,6 +336,7 @@ func TestStopReturnsStoppingMessage(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -385,16 +385,12 @@ func TestStopMethodMetadata(t *testing.T) {
 // TestStopServiceUnavailable tests behavior when Services is nil.
 // When the service container is not initialized, stop should return an internal error.
 func TestStopServiceUnavailable(t *testing.T) {
-	// Temporarily set Services to nil
-	oldServices := types.Services
-	types.Services = nil
-	defer func() { types.Services = oldServices }()
-
 	method := &handlers.StopMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   nil,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -411,17 +407,17 @@ func TestStopServiceUnavailable(t *testing.T) {
 // When the shutdown function is not set, stop should return an internal error.
 func TestStopShutdownFuncNil(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
-	// ShutdownFunc is nil by default in setupTestServices
-	types.Services.ShutdownFunc = nil
+	// ShutdownFunc is nil by default
+	services.ShutdownFunc = nil
 
 	method := &handlers.StopMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -437,11 +433,10 @@ func TestStopShutdownFuncNil(t *testing.T) {
 // TestStopWithParams tests that providing params does not affect stop behavior.
 func TestStopWithParams(t *testing.T) {
 	mock := newMockLedgerService()
-	cleanup := setupTestServices(mock)
-	defer cleanup()
+	services := &types.ServiceContainer{Ledger: mock}
 
 	shutdownCalled := false
-	types.Services.ShutdownFunc = func() {
+	services.ShutdownFunc = func() {
 		shutdownCalled = true
 	}
 
@@ -450,6 +445,7 @@ func TestStopWithParams(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params, err := json.Marshal(map[string]interface{}{

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -33,6 +33,7 @@ type WebSocketServer struct {
 	timeout             time.Duration
 	ledgerInfoProvider  types.LedgerInfoProvider
 	connLimiter         *ConnLimiter
+	services            *types.ServiceContainer
 }
 
 // WebSocketConnection represents a single WebSocket connection
@@ -49,8 +50,11 @@ type WebSocketConnection struct {
 	portCtx         *PortContext     // per-port config for role determination
 }
 
-// NewWebSocketServer creates a new WebSocket server
-func NewWebSocketServer(timeout time.Duration) *WebSocketServer {
+// NewWebSocketServer creates a new WebSocket server. The provided
+// service container is attached to every RpcContext routed through the
+// server so handlers reach the ledger via ctx.Services. May be nil for
+// test contexts.
+func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer) *WebSocketServer {
 	return &WebSocketServer{
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
@@ -66,6 +70,7 @@ func NewWebSocketServer(timeout time.Duration) *WebSocketServer {
 		methodRegistry: types.NewMethodRegistry(),
 		connections:    make(map[string]*WebSocketConnection),
 		timeout:        timeout,
+		services:       services,
 	}
 }
 
@@ -264,6 +269,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 		ApiVersion: apiVersion,
 		IsAdmin:    role == types.RoleAdmin,
 		ClientIP:   clientIP,
+		Services:   ws.services,
 	}
 
 	// Handle subscription commands specially
@@ -408,7 +414,12 @@ func (ws *WebSocketServer) handlePathFindCreate(wsConn *WebSocketConnection, ctx
 		return
 	}
 
-	view, err := types.Services.Ledger.GetClosedLedgerView()
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
+		ws.sendError(wsConn, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
+			"No closed ledger available"), cmd.ID)
+		return
+	}
+	view, err := ctx.Services.Ledger.GetClosedLedgerView()
 	if err != nil {
 		ws.sendError(wsConn, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
 			"No closed ledger available"), cmd.ID)

--- a/internal/tx/check/check_create.go
+++ b/internal/tx/check/check_create.go
@@ -257,7 +257,7 @@ func isTrustLineFrozenByCounterparty(view tx.LedgerView, accountID, issuerID [20
 	if !ok {
 		return false
 	}
-	freezeFlag := uint32(state.LsfHighFreeze)
+	freezeFlag := state.LsfHighFreeze
 	if !keylet.IsLowAccount(accountID, issuerID) {
 		freezeFlag = state.LsfLowFreeze
 	}
@@ -275,7 +275,7 @@ func isTrustLineFrozenBySelf(view tx.LedgerView, accountID, issuerID [20]byte, c
 	if !ok {
 		return false
 	}
-	freezeFlag := uint32(state.LsfLowFreeze)
+	freezeFlag := state.LsfLowFreeze
 	if !keylet.IsLowAccount(accountID, issuerID) {
 		freezeFlag = state.LsfHighFreeze
 	}


### PR DESCRIPTION
## Summary

- Replace the package-level `var types.Services *ServiceContainer` global with a per-request `*ServiceContainer` carried on `RpcContext`.
- The HTTP and WebSocket dispatchers populate `ctx.Services` from the server's wired container; tests construct an `RpcContext` with the desired fixtures instead of mutating a global.
- Drop `types.InitServices`; replace with `types.NewServiceContainer(ledger)` as the explicit constructor wired in `internal/cli/server.go`.

Closes #293.

## Why

Tests that need fixture services were swapping `types.Services` and restoring via deferred cleanup. That pattern is correct only because the affected tests don't call `t.Parallel()`; any new parallel test (or a future caller touching the global from a goroutine) would observe a partially-installed container. Routing through `RpcContext` removes the singleton and the latent race.

## What changed

- `types.RpcContext` gains a `Services *ServiceContainer` field.
- `rpc.NewServer` and `rpc.NewWebSocketServer` take `*ServiceContainer`. Single wiring point in `internal/cli/server.go`.
- All handlers read services from `ctx.Services`. Helpers that previously read the global (`RequireLedgerService`, `signTransactionJSON`, plus a few package-level helpers in `server_info.go`, `feature.go`, `account_info.go`, `transaction_entry.go`) now take `services` as a parameter.
- Test fixtures replace `setupTestServices`-style global mutation with per-test containers attached to the request context (`ctx.Services = &types.ServiceContainer{Ledger: mock}`).

## Out of scope

- Refactoring the `LedgerService` / `ManifestLookup` interfaces themselves.
- Splitting `ServiceContainer` into smaller per-domain bundles.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/rpc/...` clean
- [x] `go test ./internal/rpc/handlers/...` passes
- [x] `go test ./internal/rpc/types/...` passes
- [x] `go test ./internal/rpc/` shows the same 13 pre-existing failures as `main` (verified by stashing and comparing) — zero new failures introduced by this refactor