### PR TITLE
chore(tx): remove unused underscore variable assignments

### DIFF
--- a/internal/tx/offer/offer_create_apply.go
+++ b/internal/tx/offer/offer_create_apply.go
@@ -498,9 +498,6 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 	// Reference: line 851
 	ctx.Account.OwnerCount++
 
-	// Check if book exists (for OrderBookDB tracking)
-	bookExisted, _ := sb.Exists(bookDirKey)
-
 	// Reference: lines 884-893
 	bookDirResult, err := state.DirInsert(sb, bookDirKey, offerKey.Key, func(dir *state.DirectoryNode) {
 		dir.TakerPaysCurrency = takerPaysCurrency
@@ -563,9 +560,6 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 	if err := sb.Insert(offerKey, offerData); err != nil {
 		return tx.TefINTERNAL, false
 	}
-
-	// Track new book in OrderBookDB (not implemented yet)
-	_ = bookExisted
 
 	return tx.TesSUCCESS, true // Apply main sandbox
 }

--- a/internal/tx/signature.go
+++ b/internal/tx/signature.go
@@ -257,12 +257,11 @@ func VerifyMultiSignature(tx Transaction, lookup SignerListLookup) error {
 		} else {
 			// May be a Regular Key case
 			// The public key must hash to the signer's regular key
-			flags, regularKey, lookupErr := lookup.GetAccountInfo(txSignerAccount)
+			_, regularKey, lookupErr := lookup.GetAccountInfo(txSignerAccount)
 			if lookupErr != nil {
 				// Non-phantom signer lacks account root
 				return ErrBadSignature
 			}
-			_ = flags // flags checked above if needed
 
 			if regularKey == "" {
 				// Account lacks RegularKey


### PR DESCRIPTION
## Summary
- Drop `_ = flags` in `internal/tx/signature.go` (the regular-key branch never used the value); tighten the destructure to `_, regularKey, lookupErr`.
- Drop `bookExisted, _ := sb.Exists(bookDirKey)` and its `_ = bookExisted` suppression in `internal/tx/offer/offer_create_apply.go`. The `OrderBookDB` it was reserved for was never built — pathfinder uses an on-demand `BookIndex` instead — so the `Exists` call was dead I/O.

## Test plan
- [x] `go vet ./internal/tx/...` clean
- [x] `go test ./internal/tx/ ./internal/tx/offer/...` PASS
- Pre-existing failures in `internal/tx/{account,check,clawback}` reproduce identically on `origin/main` (unrelated)

Closes #199