### PR TITLE
refactor(codec): reuse type assertion result in st_object

### DIFF
--- a/codec/binarycodec/types/st_object.go
+++ b/codec/binarycodec/types/st_object.go
@@ -27,10 +27,11 @@ func NewSTObject(bs interfaces.BinarySerializer) *STObject {
 // and value), and then serializing each field instance.
 // This method returns an error if the JSON input is not a valid object.
 func (t *STObject) FromJSON(json any) ([]byte, error) {
-	if _, ok := json.(map[string]any); !ok {
+	jsonMap, ok := json.(map[string]any)
+	if !ok {
 		return nil, errNotValidJSON
 	}
-	fimap, err := createFieldInstanceMapFromJson(json.(map[string]any))
+	fimap, err := createFieldInstanceMapFromJson(jsonMap)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Replace the discarded-result type assertion + duplicate `json.(map[string]any)` re-assertion with a single reused `jsonMap`.

## Test plan
- [x] `go test ./codec/binarycodec/types/ -run STObject` PASS

Closes #196