### PR TITLE
perf(codec): use strings.Builder for hex concat in loop

### DIFF
--- a/codec/binarycodec/codec.go
+++ b/codec/binarycodec/codec.go
@@ -170,7 +170,11 @@ func EncodeForSigningBatch(json map[string]any) (string, error) {
 		return "", err
 	}
 
-	result := batchPrefix + hex.EncodeToString(flagsBytes) + hex.EncodeToString(txIDsLengthBytes)
+	var sb strings.Builder
+	sb.Grow(len(batchPrefix) + 2*len(flagsBytes) + 2*len(txIDsLengthBytes) + txIDsLength*2*types.HashLengthBytes)
+	sb.WriteString(batchPrefix)
+	sb.WriteString(hex.EncodeToString(flagsBytes))
+	sb.WriteString(hex.EncodeToString(txIDsLengthBytes))
 
 	for _, txID := range txIDsInterface {
 		hash256 := types.NewHash256()
@@ -178,10 +182,10 @@ func EncodeForSigningBatch(json map[string]any) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		result += hex.EncodeToString(txIDBytes)
+		sb.WriteString(hex.EncodeToString(txIDBytes))
 	}
 
-	return strings.ToUpper(result), nil
+	return strings.ToUpper(sb.String()), nil
 }
 
 // removeNonSigningFields removes the fields from a JSON transaction object that should not be signed.


### PR DESCRIPTION
## Summary
- Replace `result += hex.EncodeToString(...)` inside the per-tx-id loop in `SerializeBatchPayload` with a pre-sized `strings.Builder`.
- Folded the prior 3-string concat seed into the builder so there is one allocation path.

## Test plan
- [x] `go test ./codec/binarycodec/` PASS
- Other `+=` string sites in the codec tree were reviewed and skipped (single non-loop concats, byte arithmetic, or hard-bounded 3-char accumulations).

Closes #187