### PR TITLE
fix(tx): replace panic() with returned errors in sandbox and registry

### DIFF
--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -15,9 +15,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeAccountDelete, func() tx.Transaction {
+	if err := tx.Register(tx.TypeAccountDelete, func() tx.Transaction {
 		return &AccountDelete{BaseTx: *tx.NewBaseTx(tx.TypeAccountDelete, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 type AccountDelete struct {

--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -32,9 +32,11 @@ func isValidPublicKey(key []byte) bool {
 }
 
 func init() {
-	tx.Register(tx.TypeAccountSet, func() tx.Transaction {
+	if err := tx.Register(tx.TypeAccountSet, func() tx.Transaction {
 		return &AccountSet{BaseTx: *tx.NewBaseTx(tx.TypeAccountSet, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // AccountSet modifies the properties of an account in the XRP Ledger.

--- a/internal/tx/amm/amm_bid.go
+++ b/internal/tx/amm/amm_bid.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeAMMBid, func() tx.Transaction {
+	if err := tx.Register(tx.TypeAMMBid, func() tx.Transaction {
 		return &AMMBid{BaseTx: *tx.NewBaseTx(tx.TypeAMMBid, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // AMMBid places a bid on an AMM auction slot.

--- a/internal/tx/amm/amm_clawback.go
+++ b/internal/tx/amm/amm_clawback.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeAMMClawback, func() tx.Transaction {
+	if err := tx.Register(tx.TypeAMMClawback, func() tx.Transaction {
 		return &AMMClawback{BaseTx: *tx.NewBaseTx(tx.TypeAMMClawback, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // AMMClawback claws back tokens from an AMM.

--- a/internal/tx/amm/amm_create.go
+++ b/internal/tx/amm/amm_create.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeAMMCreate, func() tx.Transaction {
+	if err := tx.Register(tx.TypeAMMCreate, func() tx.Transaction {
 		return &AMMCreate{BaseTx: *tx.NewBaseTx(tx.TypeAMMCreate, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // AMMCreate creates an Automated Market Maker (AMM) instance.

--- a/internal/tx/amm/amm_delete.go
+++ b/internal/tx/amm/amm_delete.go
@@ -6,9 +6,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeAMMDelete, func() tx.Transaction {
+	if err := tx.Register(tx.TypeAMMDelete, func() tx.Transaction {
 		return &AMMDelete{BaseTx: *tx.NewBaseTx(tx.TypeAMMDelete, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // AMMDelete deletes an empty AMM.

--- a/internal/tx/amm/amm_deposit.go
+++ b/internal/tx/amm/amm_deposit.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeAMMDeposit, func() tx.Transaction {
+	if err := tx.Register(tx.TypeAMMDeposit, func() tx.Transaction {
 		return &AMMDeposit{BaseTx: *tx.NewBaseTx(tx.TypeAMMDeposit, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // AMMDeposit deposits assets into an AMM.

--- a/internal/tx/amm/amm_vote.go
+++ b/internal/tx/amm/amm_vote.go
@@ -7,9 +7,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeAMMVote, func() tx.Transaction {
+	if err := tx.Register(tx.TypeAMMVote, func() tx.Transaction {
 		return &AMMVote{BaseTx: *tx.NewBaseTx(tx.TypeAMMVote, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // AMMVote votes on the trading fee for an AMM.

--- a/internal/tx/amm/amm_withdraw.go
+++ b/internal/tx/amm/amm_withdraw.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeAMMWithdraw, func() tx.Transaction {
+	if err := tx.Register(tx.TypeAMMWithdraw, func() tx.Transaction {
 		return &AMMWithdraw{BaseTx: *tx.NewBaseTx(tx.TypeAMMWithdraw, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // AMMWithdraw withdraws assets from an AMM.

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeBatch, func() tx.Transaction {
+	if err := tx.Register(tx.TypeBatch, func() tx.Transaction {
 		return &Batch{BaseTx: *tx.NewBaseTx(tx.TypeBatch, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // Batch is a transaction that contains multiple inner transactions.

--- a/internal/tx/check/check_cancel.go
+++ b/internal/tx/check/check_cancel.go
@@ -11,9 +11,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeCheckCancel, func() tx.Transaction {
+	if err := tx.Register(tx.TypeCheckCancel, func() tx.Transaction {
 		return &CheckCancel{BaseTx: *tx.NewBaseTx(tx.TypeCheckCancel, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // CheckCancel cancels a Check.

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -11,9 +11,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeCheckCash, func() tx.Transaction {
+	if err := tx.Register(tx.TypeCheckCash, func() tx.Transaction {
 		return &CheckCash{BaseTx: *tx.NewBaseTx(tx.TypeCheckCash, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // CheckCash cashes a Check, drawing from the sender's balance.

--- a/internal/tx/check/check_create.go
+++ b/internal/tx/check/check_create.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeCheckCreate, func() tx.Transaction {
+	if err := tx.Register(tx.TypeCheckCreate, func() tx.Transaction {
 		return &CheckCreate{BaseTx: *tx.NewBaseTx(tx.TypeCheckCreate, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 type CheckCreate struct {

--- a/internal/tx/clawback/clawback.go
+++ b/internal/tx/clawback/clawback.go
@@ -11,9 +11,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeClawback, func() tx.Transaction {
+	if err := tx.Register(tx.TypeClawback, func() tx.Transaction {
 		return &Clawback{BaseTx: *tx.NewBaseTx(tx.TypeClawback, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // Clawback errors

--- a/internal/tx/credential/credential.go
+++ b/internal/tx/credential/credential.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeCredentialAccept, func() tx.Transaction {
+	if err := tx.Register(tx.TypeCredentialAccept, func() tx.Transaction {
 		return &CredentialAccept{BaseTx: *tx.NewBaseTx(tx.TypeCredentialAccept, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // CredentialAccept accepts a credential.

--- a/internal/tx/credential/credential_create.go
+++ b/internal/tx/credential/credential_create.go
@@ -11,9 +11,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeCredentialCreate, func() tx.Transaction {
+	if err := tx.Register(tx.TypeCredentialCreate, func() tx.Transaction {
 		return &CredentialCreate{BaseTx: *tx.NewBaseTx(tx.TypeCredentialCreate, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // CredentialCreate creates a credential.

--- a/internal/tx/credential/credential_delete.go
+++ b/internal/tx/credential/credential_delete.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeCredentialDelete, func() tx.Transaction {
+	if err := tx.Register(tx.TypeCredentialDelete, func() tx.Transaction {
 		return &CredentialDelete{BaseTx: *tx.NewBaseTx(tx.TypeCredentialDelete, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // CredentialDelete deletes a credential.

--- a/internal/tx/delegate/delegate_set.go
+++ b/internal/tx/delegate/delegate_set.go
@@ -34,9 +34,11 @@ var notDelegatableTxTypes = map[uint16]bool{
 const granularPermissionMin = 65536
 
 func init() {
-	tx.Register(tx.TypeDelegateSet, func() tx.Transaction {
+	if err := tx.Register(tx.TypeDelegateSet, func() tx.Transaction {
 		return &DelegateSet{BaseTx: *tx.NewBaseTx(tx.TypeDelegateSet, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // DelegateSet sets up delegation for an account.

--- a/internal/tx/depositpreauth/depositpreauth.go
+++ b/internal/tx/depositpreauth/depositpreauth.go
@@ -28,9 +28,11 @@ const (
 )
 
 func init() {
-	tx.Register(tx.TypeDepositPreauth, func() tx.Transaction {
+	if err := tx.Register(tx.TypeDepositPreauth, func() tx.Transaction {
 		return &DepositPreauth{BaseTx: *tx.NewBaseTx(tx.TypeDepositPreauth, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // CredentialSpec identifies a credential by issuer and type.

--- a/internal/tx/did/did_delete.go
+++ b/internal/tx/did/did_delete.go
@@ -9,9 +9,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeDIDDelete, func() tx.Transaction {
+	if err := tx.Register(tx.TypeDIDDelete, func() tx.Transaction {
 		return &DIDDelete{BaseTx: *tx.NewBaseTx(tx.TypeDIDDelete, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // DIDDelete deletes a DID document.

--- a/internal/tx/did/did_set.go
+++ b/internal/tx/did/did_set.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeDIDSet, func() tx.Transaction {
+	if err := tx.Register(tx.TypeDIDSet, func() tx.Transaction {
 		return &DIDSet{BaseTx: *tx.NewBaseTx(tx.TypeDIDSet, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // DIDSet creates or updates a DID document.

--- a/internal/tx/escrow/escrow_cancel.go
+++ b/internal/tx/escrow/escrow_cancel.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeEscrowCancel, func() tx.Transaction {
+	if err := tx.Register(tx.TypeEscrowCancel, func() tx.Transaction {
 		return &EscrowCancel{BaseTx: *tx.NewBaseTx(tx.TypeEscrowCancel, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // EscrowCancel cancels an escrow, returning the escrowed XRP to the creator.

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -18,9 +18,11 @@ import (
 const maxMPTokenAmount int64 = 0x7FFFFFFFFFFFFFFF
 
 func init() {
-	tx.Register(tx.TypeEscrowCreate, func() tx.Transaction {
+	if err := tx.Register(tx.TypeEscrowCreate, func() tx.Transaction {
 		return &EscrowCreate{BaseTx: *tx.NewBaseTx(tx.TypeEscrowCreate, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // EscrowCreate creates an escrow that holds XRP until certain conditions are met.

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -13,9 +13,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeEscrowFinish, func() tx.Transaction {
+	if err := tx.Register(tx.TypeEscrowFinish, func() tx.Transaction {
 		return &EscrowFinish{BaseTx: *tx.NewBaseTx(tx.TypeEscrowFinish, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // EscrowFinish completes an escrow, releasing the escrowed XRP.

--- a/internal/tx/ledgerstatefix/ledger_state_fix.go
+++ b/internal/tx/ledgerstatefix/ledger_state_fix.go
@@ -11,9 +11,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeLedgerStateFix, func() tx.Transaction {
+	if err := tx.Register(tx.TypeLedgerStateFix, func() tx.Transaction {
 		return &LedgerStateFix{BaseTx: *tx.NewBaseTx(tx.TypeLedgerStateFix, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // LedgerStateFix fix types

--- a/internal/tx/mpt/mptoken_authorize.go
+++ b/internal/tx/mpt/mptoken_authorize.go
@@ -11,9 +11,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeMPTokenAuthorize, func() tx.Transaction {
+	if err := tx.Register(tx.TypeMPTokenAuthorize, func() tx.Transaction {
 		return &MPTokenAuthorize{BaseTx: *tx.NewBaseTx(tx.TypeMPTokenAuthorize, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // MPTokenAuthorize authorizes or unauthorizes MPToken operations.

--- a/internal/tx/mpt/mptoken_issuance_create.go
+++ b/internal/tx/mpt/mptoken_issuance_create.go
@@ -14,9 +14,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeMPTokenIssuanceCreate, func() tx.Transaction {
+	if err := tx.Register(tx.TypeMPTokenIssuanceCreate, func() tx.Transaction {
 		return &MPTokenIssuanceCreate{BaseTx: *tx.NewBaseTx(tx.TypeMPTokenIssuanceCreate, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // MPTokenIssuanceCreate creates a new multi-purpose token issuance.

--- a/internal/tx/mpt/mptoken_issuance_destroy.go
+++ b/internal/tx/mpt/mptoken_issuance_destroy.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeMPTokenIssuanceDestroy, func() tx.Transaction {
+	if err := tx.Register(tx.TypeMPTokenIssuanceDestroy, func() tx.Transaction {
 		return &MPTokenIssuanceDestroy{BaseTx: *tx.NewBaseTx(tx.TypeMPTokenIssuanceDestroy, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // MPTokenIssuanceDestroy destroys a multi-purpose token issuance.

--- a/internal/tx/mpt/mptoken_issuance_set.go
+++ b/internal/tx/mpt/mptoken_issuance_set.go
@@ -12,9 +12,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeMPTokenIssuanceSet, func() tx.Transaction {
+	if err := tx.Register(tx.TypeMPTokenIssuanceSet, func() tx.Transaction {
 		return &MPTokenIssuanceSet{BaseTx: *tx.NewBaseTx(tx.TypeMPTokenIssuanceSet, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // MPTokenIssuanceSet modifies a multi-purpose token issuance.

--- a/internal/tx/nftoken/nftoken_accept_offer.go
+++ b/internal/tx/nftoken/nftoken_accept_offer.go
@@ -11,9 +11,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeNFTokenAcceptOffer, func() tx.Transaction {
+	if err := tx.Register(tx.TypeNFTokenAcceptOffer, func() tx.Transaction {
 		return &NFTokenAcceptOffer{BaseTx: *tx.NewBaseTx(tx.TypeNFTokenAcceptOffer, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // NFTokenAcceptOffer accepts an NFToken offer.

--- a/internal/tx/nftoken/nftoken_burn.go
+++ b/internal/tx/nftoken/nftoken_burn.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeNFTokenBurn, func() tx.Transaction {
+	if err := tx.Register(tx.TypeNFTokenBurn, func() tx.Transaction {
 		return &NFTokenBurn{BaseTx: *tx.NewBaseTx(tx.TypeNFTokenBurn, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // NFTokenBurn burns an NFToken.

--- a/internal/tx/nftoken/nftoken_cancel_offer.go
+++ b/internal/tx/nftoken/nftoken_cancel_offer.go
@@ -11,9 +11,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeNFTokenCancelOffer, func() tx.Transaction {
+	if err := tx.Register(tx.TypeNFTokenCancelOffer, func() tx.Transaction {
 		return &NFTokenCancelOffer{BaseTx: *tx.NewBaseTx(tx.TypeNFTokenCancelOffer, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // NFTokenCancelOffer cancels NFToken offers.

--- a/internal/tx/nftoken/nftoken_create_offer.go
+++ b/internal/tx/nftoken/nftoken_create_offer.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeNFTokenCreateOffer, func() tx.Transaction {
+	if err := tx.Register(tx.TypeNFTokenCreateOffer, func() tx.Transaction {
 		return &NFTokenCreateOffer{BaseTx: *tx.NewBaseTx(tx.TypeNFTokenCreateOffer, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // NFTokenCreateOffer creates an offer to buy or sell an NFToken.

--- a/internal/tx/nftoken/nftoken_mint.go
+++ b/internal/tx/nftoken/nftoken_mint.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeNFTokenMint, func() tx.Transaction {
+	if err := tx.Register(tx.TypeNFTokenMint, func() tx.Transaction {
 		return &NFTokenMint{BaseTx: *tx.NewBaseTx(tx.TypeNFTokenMint, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // NFTokenMint mints a new NFToken.

--- a/internal/tx/nftoken/nftoken_modify.go
+++ b/internal/tx/nftoken/nftoken_modify.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeNFTokenModify, func() tx.Transaction {
+	if err := tx.Register(tx.TypeNFTokenModify, func() tx.Transaction {
 		return &NFTokenModify{BaseTx: *tx.NewBaseTx(tx.TypeNFTokenModify, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // NFTokenModify modifies an existing NFToken.

--- a/internal/tx/offer/offer_cancel.go
+++ b/internal/tx/offer/offer_cancel.go
@@ -16,9 +16,11 @@ type OfferCancel struct {
 }
 
 func init() {
-	tx.Register(tx.TypeOfferCancel, func() tx.Transaction {
+	if err := tx.Register(tx.TypeOfferCancel, func() tx.Transaction {
 		return &OfferCancel{BaseTx: *tx.NewBaseTx(tx.TypeOfferCancel, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // NewOfferCancel creates a new OfferCancel transaction

--- a/internal/tx/offer/offer_create.go
+++ b/internal/tx/offer/offer_create.go
@@ -45,9 +45,11 @@ type OfferCreate struct {
 }
 
 func init() {
-	tx.Register(tx.TypeOfferCreate, func() tx.Transaction {
+	if err := tx.Register(tx.TypeOfferCreate, func() tx.Transaction {
 		return &OfferCreate{BaseTx: *tx.NewBaseTx(tx.TypeOfferCreate, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // UnmarshalJSON handles DomainID as a hex string from the binary codec.

--- a/internal/tx/oracle/oracle_delete.go
+++ b/internal/tx/oracle/oracle_delete.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeOracleDelete, func() tx.Transaction {
+	if err := tx.Register(tx.TypeOracleDelete, func() tx.Transaction {
 		return &OracleDelete{BaseTx: *tx.NewBaseTx(tx.TypeOracleDelete, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // OracleDelete deletes a price oracle.

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -11,9 +11,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeOracleSet, func() tx.Transaction {
+	if err := tx.Register(tx.TypeOracleSet, func() tx.Transaction {
 		return &OracleSet{BaseTx: *tx.NewBaseTx(tx.TypeOracleSet, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // OracleSet creates or updates a price oracle.

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -14,9 +14,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypePaymentChannelClaim, func() tx.Transaction {
+	if err := tx.Register(tx.TypePaymentChannelClaim, func() tx.Transaction {
 		return &PaymentChannelClaim{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelClaim, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // PaymentChannelClaim claims XRP from a payment channel.

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypePaymentChannelCreate, func() tx.Transaction {
+	if err := tx.Register(tx.TypePaymentChannelCreate, func() tx.Transaction {
 		return &PaymentChannelCreate{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelCreate, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // PaymentChannelCreate creates a payment channel.

--- a/internal/tx/paychan/payment_channel_fund.go
+++ b/internal/tx/paychan/payment_channel_fund.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypePaymentChannelFund, func() tx.Transaction {
+	if err := tx.Register(tx.TypePaymentChannelFund, func() tx.Transaction {
 		return &PaymentChannelFund{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelFund, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // PaymentChannelFund adds more XRP to a payment channel.

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -307,7 +307,15 @@ func Flow(
 
 			// Apply the best strand's sandbox changes
 			if best.sandbox != nil {
-				best.sandbox.Apply(accumSandbox)
+				if err := best.sandbox.Apply(accumSandbox); err != nil {
+					return FlowResult{
+						In:              totalIn,
+						Out:             totalOut,
+						Sandbox:         accumSandbox,
+						RemovableOffers: allOfrsToRm,
+						Result:          tx.TefINTERNAL,
+					}
+				}
 			}
 			// Update AMM iteration counter
 			// Reference: rippled StrandFlow.h line 798: ammContext.update()
@@ -606,7 +614,9 @@ func RippleCalculate(
 	// Apply flow sandbox changes back to the main sandbox
 	if result.Result == tx.TesSUCCESS || result.Result == tx.TecPATH_PARTIAL {
 		if result.Sandbox != nil {
-			result.Sandbox.Apply(sandbox)
+			if err := result.Sandbox.Apply(sandbox); err != nil {
+				return ZeroXRPEitherAmount(), ZeroXRPEitherAmount(), nil, nil, tx.TefINTERNAL
+			}
 		}
 	}
 

--- a/internal/tx/payment/flow_cross.go
+++ b/internal/tx/payment/flow_cross.go
@@ -221,7 +221,16 @@ func FlowCross(
 	// Apply the flow sandbox changes to our root sandbox
 	// Reference: rippled CreateOffer.cpp line 711: psbFlow.apply(sb)
 	if result.Sandbox != nil {
-		result.Sandbox.Apply(sandbox)
+		if err := result.Sandbox.Apply(sandbox); err != nil {
+			return FlowCrossResult{
+				TakerGot:        ZeroXRPEitherAmount(),
+				TakerPaid:       ZeroXRPEitherAmount(),
+				TakerPaidNet:    ZeroXRPEitherAmount(),
+				Sandbox:         sandbox,
+				RemovableOffers: nil,
+				Result:          tx.TefINTERNAL,
+			}
+		}
 	}
 
 	// Calculate GROSS and NET amounts for the taker's payment

--- a/internal/tx/payment/payment.go
+++ b/internal/tx/payment/payment.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypePayment, func() tx.Transaction {
+	if err := tx.Register(tx.TypePayment, func() tx.Transaction {
 		return &Payment{BaseTx: *tx.NewBaseTx(tx.TypePayment, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // Payment transaction moves value from one account to another.

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -2,6 +2,7 @@ package payment
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/drops"
@@ -685,10 +686,11 @@ func (s *PaymentSandbox) AdjustOwnerCount(account [20]byte, cur, next uint32) {
 	s.tab.ownerCount(account, cur, next)
 }
 
-// Apply merges this sandbox's changes into a parent PaymentSandbox
-func (s *PaymentSandbox) Apply(to *PaymentSandbox) {
+// Apply merges this sandbox's changes into a parent PaymentSandbox.
+// Returns an error if to is not this sandbox's parent.
+func (s *PaymentSandbox) Apply(to *PaymentSandbox) error {
 	if s.parent != to {
-		panic("PaymentSandbox.Apply: parent mismatch")
+		return errors.New("PaymentSandbox.Apply: parent mismatch")
 	}
 
 	// Apply ledger item changes
@@ -762,13 +764,14 @@ func (s *PaymentSandbox) Apply(to *PaymentSandbox) {
 
 	// Apply drops destroyed
 	to.dropsDestroyed = to.dropsDestroyed.Add(s.dropsDestroyed)
+	return nil
 }
 
 // ApplyToView merges this sandbox's changes into an underlying LedgerView.
 // This should only be called on a root sandbox (parent == nil).
 func (s *PaymentSandbox) ApplyToView(view tx.LedgerView) error {
 	if s.parent != nil {
-		panic("PaymentSandbox.ApplyToView: not a root sandbox")
+		return errors.New("PaymentSandbox.ApplyToView: not a root sandbox")
 	}
 
 	// Apply deletions - but first apply any final state modifications

--- a/internal/tx/permissioneddomain/permission_domain_set.go
+++ b/internal/tx/permissioneddomain/permission_domain_set.go
@@ -13,9 +13,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypePermissionedDomainSet, func() tx.Transaction {
+	if err := tx.Register(tx.TypePermissionedDomainSet, func() tx.Transaction {
 		return &PermissionedDomainSet{BaseTx: *tx.NewBaseTx(tx.TypePermissionedDomainSet, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // PermissionedDomainSet creates or modifies a permissioned domain.

--- a/internal/tx/permissioneddomain/permissioned_domain_delete.go
+++ b/internal/tx/permissioneddomain/permissioned_domain_delete.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypePermissionedDomainDelete, func() tx.Transaction {
+	if err := tx.Register(tx.TypePermissionedDomainDelete, func() tx.Transaction {
 		return &PermissionedDomainDelete{BaseTx: *tx.NewBaseTx(tx.TypePermissionedDomainDelete, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // PermissionedDomainDelete deletes a permissioned domain.

--- a/internal/tx/pseudo/enable_amendment.go
+++ b/internal/tx/pseudo/enable_amendment.go
@@ -14,9 +14,11 @@ var (
 )
 
 func init() {
-	tx.Register(tx.TypeAmendment, func() tx.Transaction {
+	if err := tx.Register(tx.TypeAmendment, func() tx.Transaction {
 		return &EnableAmendment{BaseTx: *tx.NewBaseTx(tx.TypeAmendment, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // EnableAmendment is a pseudo-transaction that enables or tracks amendment voting.

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeFee, func() tx.Transaction {
+	if err := tx.Register(tx.TypeFee, func() tx.Transaction {
 		return &SetFee{BaseTx: *tx.NewBaseTx(tx.TypeFee, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // SetFee errors matching rippled

--- a/internal/tx/pseudo/unl_modify.go
+++ b/internal/tx/pseudo/unl_modify.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeUNLModify, func() tx.Transaction {
+	if err := tx.Register(tx.TypeUNLModify, func() tx.Transaction {
 		return &UNLModify{BaseTx: *tx.NewBaseTx(tx.TypeUNLModify, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // UNLModify is a pseudo-transaction that modifies the Negative UNL.

--- a/internal/tx/registry.go
+++ b/internal/tx/registry.go
@@ -17,14 +17,15 @@ var (
 )
 
 // Register registers a transaction type factory. Called from init() in each transaction type file.
-// Panics if the type is already registered (indicates a bug).
-func Register(t Type, factory func() Transaction) {
+// Returns an error if the type is already registered.
+func Register(t Type, factory func() Transaction) error {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 	if _, exists := registry[t]; exists {
-		panic(fmt.Sprintf("tx: transaction type %d (%s) already registered", t, t.String()))
+		return fmt.Errorf("tx: transaction type %d (%s) already registered", t, t.String())
 	}
 	registry[t] = factory
+	return nil
 }
 
 // NewFromType creates a new transaction of the given type using the registered factory.

--- a/internal/tx/signerlist/signer_list_set.go
+++ b/internal/tx/signerlist/signer_list_set.go
@@ -10,12 +10,16 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeSignerListSet, func() tx.Transaction {
+	if err := tx.Register(tx.TypeSignerListSet, func() tx.Transaction {
 		return &SignerListSet{BaseTx: *tx.NewBaseTx(tx.TypeSignerListSet, "")}
-	})
-	tx.Register(tx.TypeRegularKeySet, func() tx.Transaction {
+	}); err != nil {
+		panic(err)
+	}
+	if err := tx.Register(tx.TypeRegularKeySet, func() tx.Transaction {
 		return &SetRegularKey{BaseTx: *tx.NewBaseTx(tx.TypeRegularKeySet, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // SignerListSet sets or clears a list of signers for multi-signing.

--- a/internal/tx/ticket/ticket_create.go
+++ b/internal/tx/ticket/ticket_create.go
@@ -8,9 +8,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeTicketCreate, func() tx.Transaction {
+	if err := tx.Register(tx.TypeTicketCreate, func() tx.Transaction {
 		return &TicketCreate{BaseTx: *tx.NewBaseTx(tx.TypeTicketCreate, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // TicketCreate creates tickets for future transactions.

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -9,9 +9,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeTrustSet, func() tx.Transaction {
+	if err := tx.Register(tx.TypeTrustSet, func() tx.Transaction {
 		return &TrustSet{BaseTx: *tx.NewBaseTx(tx.TypeTrustSet, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // TrustSet creates or modifies a trust line between two accounts.

--- a/internal/tx/vault/vault_clawback.go
+++ b/internal/tx/vault/vault_clawback.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeVaultClawback, func() tx.Transaction {
+	if err := tx.Register(tx.TypeVaultClawback, func() tx.Transaction {
 		return &VaultClawback{BaseTx: *tx.NewBaseTx(tx.TypeVaultClawback, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 type VaultClawback struct {

--- a/internal/tx/vault/vault_create.go
+++ b/internal/tx/vault/vault_create.go
@@ -10,9 +10,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeVaultCreate, func() tx.Transaction {
+	if err := tx.Register(tx.TypeVaultCreate, func() tx.Transaction {
 		return &VaultCreate{BaseTx: *tx.NewBaseTx(tx.TypeVaultCreate, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // VaultCreate creates a new vault.

--- a/internal/tx/vault/vault_delete.go
+++ b/internal/tx/vault/vault_delete.go
@@ -9,9 +9,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeVaultDelete, func() tx.Transaction {
+	if err := tx.Register(tx.TypeVaultDelete, func() tx.Transaction {
 		return &VaultDelete{BaseTx: *tx.NewBaseTx(tx.TypeVaultDelete, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // VaultDelete deletes a vault.

--- a/internal/tx/vault/vault_deposit.go
+++ b/internal/tx/vault/vault_deposit.go
@@ -9,9 +9,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeVaultDeposit, func() tx.Transaction {
+	if err := tx.Register(tx.TypeVaultDeposit, func() tx.Transaction {
 		return &VaultDeposit{BaseTx: *tx.NewBaseTx(tx.TypeVaultDeposit, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // VaultDeposit deposits assets into a vault.

--- a/internal/tx/vault/vault_set.go
+++ b/internal/tx/vault/vault_set.go
@@ -9,9 +9,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeVaultSet, func() tx.Transaction {
+	if err := tx.Register(tx.TypeVaultSet, func() tx.Transaction {
 		return &VaultSet{BaseTx: *tx.NewBaseTx(tx.TypeVaultSet, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // VaultSet modifies a vault.

--- a/internal/tx/vault/vault_withdraw.go
+++ b/internal/tx/vault/vault_withdraw.go
@@ -9,9 +9,11 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeVaultWithdraw, func() tx.Transaction {
+	if err := tx.Register(tx.TypeVaultWithdraw, func() tx.Transaction {
 		return &VaultWithdraw{BaseTx: *tx.NewBaseTx(tx.TypeVaultWithdraw, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // VaultWithdraw withdraws assets from a vault.

--- a/internal/tx/xchain/xchain.go
+++ b/internal/tx/xchain/xchain.go
@@ -10,30 +10,46 @@ import (
 )
 
 func init() {
-	tx.Register(tx.TypeXChainCreateBridge, func() tx.Transaction {
+	if err := tx.Register(tx.TypeXChainCreateBridge, func() tx.Transaction {
 		return &XChainCreateBridge{BaseTx: *tx.NewBaseTx(tx.TypeXChainCreateBridge, "")}
-	})
-	tx.Register(tx.TypeXChainModifyBridge, func() tx.Transaction {
+	}); err != nil {
+		panic(err)
+	}
+	if err := tx.Register(tx.TypeXChainModifyBridge, func() tx.Transaction {
 		return &XChainModifyBridge{BaseTx: *tx.NewBaseTx(tx.TypeXChainModifyBridge, "")}
-	})
-	tx.Register(tx.TypeXChainCreateClaimID, func() tx.Transaction {
+	}); err != nil {
+		panic(err)
+	}
+	if err := tx.Register(tx.TypeXChainCreateClaimID, func() tx.Transaction {
 		return &XChainCreateClaimID{BaseTx: *tx.NewBaseTx(tx.TypeXChainCreateClaimID, "")}
-	})
-	tx.Register(tx.TypeXChainCommit, func() tx.Transaction {
+	}); err != nil {
+		panic(err)
+	}
+	if err := tx.Register(tx.TypeXChainCommit, func() tx.Transaction {
 		return &XChainCommit{BaseTx: *tx.NewBaseTx(tx.TypeXChainCommit, "")}
-	})
-	tx.Register(tx.TypeXChainClaim, func() tx.Transaction {
+	}); err != nil {
+		panic(err)
+	}
+	if err := tx.Register(tx.TypeXChainClaim, func() tx.Transaction {
 		return &XChainClaim{BaseTx: *tx.NewBaseTx(tx.TypeXChainClaim, "")}
-	})
-	tx.Register(tx.TypeXChainAccountCreateCommit, func() tx.Transaction {
+	}); err != nil {
+		panic(err)
+	}
+	if err := tx.Register(tx.TypeXChainAccountCreateCommit, func() tx.Transaction {
 		return &XChainAccountCreateCommit{BaseTx: *tx.NewBaseTx(tx.TypeXChainAccountCreateCommit, "")}
-	})
-	tx.Register(tx.TypeXChainAddClaimAttestation, func() tx.Transaction {
+	}); err != nil {
+		panic(err)
+	}
+	if err := tx.Register(tx.TypeXChainAddClaimAttestation, func() tx.Transaction {
 		return &XChainAddClaimAttestation{BaseTx: *tx.NewBaseTx(tx.TypeXChainAddClaimAttestation, "")}
-	})
-	tx.Register(tx.TypeXChainAddAccountCreateAttest, func() tx.Transaction {
+	}); err != nil {
+		panic(err)
+	}
+	if err := tx.Register(tx.TypeXChainAddAccountCreateAttest, func() tx.Transaction {
 		return &XChainAddAccountCreateAttestation{BaseTx: *tx.NewBaseTx(tx.TypeXChainAddAccountCreateAttest, "")}
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // XChainBridge identifies a cross-chain bridge


### PR DESCRIPTION
Closes #183.

## Summary
- `tx.Register()` returns `error` instead of panicking on duplicate registration.
- `PaymentSandbox.Apply()` and `PaymentSandbox.ApplyToView()` return `error` instead of panicking on parent / root invariants. The three internal callers (`Flow`, `RippleCalculate`, `FlowCross`) propagate the failure as `tx.TefINTERNAL`, preserving XRPL result-code discipline.
- All 58 `init()` callsites that registered transaction factories were updated. Per the issue spec, init-time programmer bugs remain panics (panics on `Register()`'s returned error); only `Register()` itself stops panicking.

## Test plan
- [x] `just lint` — 0 issues
- [x] `just build`
- [x] `just test-pkg ./internal/tx/payment/...`
- [x] `just test-pkg ./internal/tx/...` (only pre-existing failures unrelated to this work, verified by stashing the diff)