### PR TITLE
fix(rpc): track WebSocket goroutines and join them on shutdown

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -545,7 +545,9 @@ func doShutdown(
 		_ = srv.Shutdown(ctx)
 	}
 
-	wsServer.Close()
+	if err := wsServer.Close(ctx); err != nil {
+		logger.Warn("WebSocket server shutdown timed out", "err", err)
+	}
 
 	// Stop consensus components (if running)
 	if consensusComponents != nil {

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -34,6 +34,9 @@ type WebSocketServer struct {
 	ledgerInfoProvider  types.LedgerInfoProvider
 	connLimiter         *ConnLimiter
 	services            *types.ServiceContainer
+	// wg tracks per-connection goroutines (read loop, send pump, ping loop)
+	// so Close can join them on shutdown.
+	wg sync.WaitGroup
 }
 
 // WebSocketConnection represents a single WebSocket connection
@@ -133,8 +136,15 @@ func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ws.subscriptionManager.AddConnection(legacyConn)
 
 	// Start connection handlers
-	go ws.handleConnection(wsConn)
-	go ws.handleSend(wsConn)
+	ws.wg.Add(2)
+	go func() {
+		defer ws.wg.Done()
+		ws.handleConnection(wsConn)
+	}()
+	go func() {
+		defer ws.wg.Done()
+		ws.handleSend(wsConn)
+	}()
 }
 
 // handleConnection processes messages from a WebSocket connection
@@ -150,7 +160,11 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 	})
 
 	// Start ping goroutine to keep connection alive
-	go ws.pingLoop(wsConn)
+	ws.wg.Add(1)
+	go func() {
+		defer ws.wg.Done()
+		ws.pingLoop(wsConn)
+	}()
 
 	// Read loop - this is blocking and runs until error or close
 	for {
@@ -729,15 +743,31 @@ func (ws *WebSocketServer) GetSubscriptionManager() *subscription.Manager {
 	return ws.subscriptionManager
 }
 
-// Close gracefully closes all active WebSocket connections.
-func (ws *WebSocketServer) Close() {
+// Close gracefully closes all active WebSocket connections and waits for
+// all per-connection goroutines (read loop, send pump, ping loop) to exit.
+// The wait is bounded by ctx so a misbehaving handler cannot stall shutdown
+// indefinitely; if ctx expires first, Close returns ctx.Err().
+func (ws *WebSocketServer) Close(ctx context.Context) error {
 	ws.connectionsMutex.Lock()
-	defer ws.connectionsMutex.Unlock()
 	for _, conn := range ws.connections {
 		conn.conn.WriteMessage(
 			websocket.CloseMessage,
 			websocket.FormatCloseMessage(websocket.CloseGoingAway, "server shutdown"),
 		)
+		conn.cancel()
 		conn.conn.Close()
+	}
+	ws.connectionsMutex.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		ws.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -1,0 +1,133 @@
+package rpc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// TestWebSocketServer_Close_JoinsHandlers verifies that Close blocks until
+// all per-connection goroutines (read loop, send pump, ping loop) have exited.
+// Regression test for issue #186.
+func TestWebSocketServer_Close_JoinsHandlers(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ws.RegisterAllMethods()
+
+	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
+	defer httpSrv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+
+	const numConns = 5
+	clients := make([]*websocket.Conn, 0, numConns)
+	for i := 0; i < numConns; i++ {
+		c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		clients = append(clients, c)
+	}
+
+	// Wait until all connections are registered and goroutines are running.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ws.connectionsMutex.RLock()
+		n := len(ws.connections)
+		ws.connectionsMutex.RUnlock()
+		if n == numConns {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	goroutinesBefore := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- ws.Close(ctx) }()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return within 5s")
+	}
+
+	// After Close returns, goroutine count should drop. Allow runtime slack
+	// for unrelated goroutines but assert per-connection goroutines exited.
+	// Each connection contributes 3 goroutines (read, send, ping). Allow a
+	// small margin for net/http server housekeeping.
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= goroutinesBefore-numConns {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := runtime.NumGoroutine(); got > goroutinesBefore-numConns+2 {
+		t.Errorf("expected goroutine count to drop after Close; before=%d after=%d", goroutinesBefore, got)
+	}
+
+	for _, c := range clients {
+		_ = c.Close()
+	}
+}
+
+// TestWebSocketServer_Close_RespectsContext verifies Close returns promptly
+// when the context expires, even if handlers might otherwise linger.
+func TestWebSocketServer_Close_RespectsContext(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+
+	// Inflate the WaitGroup so it never reaches zero on its own.
+	ws.wg.Add(1)
+	defer ws.wg.Done()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := ws.Close(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected Close to return ctx.Err() when wg never drains")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("Close took too long despite ctx deadline: %v", elapsed)
+	}
+}
+
+// TestWebSocketServer_Close_NoConnections verifies Close is safe with no
+// active connections and returns immediately.
+func TestWebSocketServer_Close_NoConnections(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := ws.Close(ctx); err != nil {
+		t.Fatalf("Close on empty server: %v", err)
+	}
+}
+
+// Sanity: ensure we can call NewWebSocketServer concurrently without races.
+func TestWebSocketServer_New_Concurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = NewWebSocketServer(time.Second, nil)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Closes #186.

## Summary
- Added \`sync.WaitGroup\` to \`WebSocketServer\`. All three per-connection goroutines (\`handleConnection\`, \`handleSend\`, \`pingLoop\`) increment/decrement it.
- \`Close()\` is now \`Close(ctx context.Context) error\`. It signals each connection's context, then drains the WaitGroup bounded by the caller's context so a misbehaving handler can't hang shutdown forever.
- Updated the single caller in \`internal/cli/server.go\` (\`doShutdown\`) to pass the existing shutdown ctx and log a warning on timeout.
- 4 new focused tests (\`websocket_test.go\`):
  - \`TestWebSocketServer_Close_JoinsHandlers\` — opens 5 real WebSocket clients, asserts goroutine count drops after \`Close\` returns.
  - \`TestWebSocketServer_Close_RespectsContext\` — pads the WaitGroup so it never drains, asserts \`Close\` returns \`ctx.Err()\` within the deadline.
  - \`TestWebSocketServer_Close_NoConnections\` — empty-server safety.
  - \`TestWebSocketServer_New_Concurrent\` — basic constructor race sanity.

## Test plan
- [x] \`just lint\` — 0 issues
- [x] \`just build\`
- [x] \`go test -race ./internal/rpc/ -run TestWebSocketServer -count=3\` — all 4 new tests pass on three consecutive runs with \`-race\`
- [x] Other \`./internal/rpc/\` failures verified pre-existing on baseline