### PR TITLE
refactor: wrap errors with %w for errors.Is / errors.As support

### DIFF
--- a/internal/ledger/genesis/genesis.go
+++ b/internal/ledger/genesis/genesis.go
@@ -207,19 +207,19 @@ func Create(cfg Config) (*GenesisLedger, error) {
 	// Generate genesis account from passphrase
 	accountID, address, err := GenerateAccountIDFromPassphrase(passphrase)
 	if err != nil {
-		return nil, errors.New("failed to generate genesis account: " + err.Error())
+		return nil, fmt.Errorf("failed to generate genesis account: %w", err)
 	}
 
 	// Create state map (account state tree)
 	stateMap, err := shamap.New(shamap.TypeState)
 	if err != nil {
-		return nil, errors.New("failed to create state map: " + err.Error())
+		return nil, fmt.Errorf("failed to create state map: %w", err)
 	}
 
 	// Create transaction map (empty for genesis)
 	txMap, err := shamap.New(shamap.TypeTransaction)
 	if err != nil {
-		return nil, errors.New("failed to create transaction map: " + err.Error())
+		return nil, fmt.Errorf("failed to create transaction map: %w", err)
 	}
 
 	// Calculate genesis account balance (total XRP minus initial accounts)
@@ -233,51 +233,51 @@ func Create(cfg Config) (*GenesisLedger, error) {
 
 	// 1. Create genesis account with remaining XRP
 	if err := createGenesisAccountWithBalance(stateMap, accountID, genesisBalance); err != nil {
-		return nil, errors.New("failed to create genesis account: " + err.Error())
+		return nil, fmt.Errorf("failed to create genesis account: %w", err)
 	}
 
 	// 2. Create initial accounts if specified
 	for _, acc := range cfg.InitialAccounts {
 		accID, err := DecodeAddress(acc.Address)
 		if err != nil {
-			return nil, errors.New("failed to decode address " + acc.Address + ": " + err.Error())
+			return nil, fmt.Errorf("failed to decode address %s: %w", acc.Address, err)
 		}
 		if err := createInitialAccount(stateMap, accID, acc.Balance, acc.Sequence, acc.Flags); err != nil {
-			return nil, errors.New("failed to create account " + acc.Address + ": " + err.Error())
+			return nil, fmt.Errorf("failed to create account %s: %w", acc.Address, err)
 		}
 	}
 
 	// 3. Create fee settings
 	if err := createFeeSettings(stateMap, cfg); err != nil {
-		return nil, errors.New("failed to create fee settings: " + err.Error())
+		return nil, fmt.Errorf("failed to create fee settings: %w", err)
 	}
 
 	// 4. Create amendments if specified
 	if len(cfg.Amendments) > 0 {
 		if err := createAmendments(stateMap, cfg.Amendments); err != nil {
-			return nil, errors.New("failed to create amendments: " + err.Error())
+			return nil, fmt.Errorf("failed to create amendments: %w", err)
 		}
 	}
 
 	// Make state map immutable
 	if err := stateMap.SetImmutable(); err != nil {
-		return nil, errors.New("failed to make state map immutable: " + err.Error())
+		return nil, fmt.Errorf("failed to make state map immutable: %w", err)
 	}
 
 	// Make tx map immutable
 	if err := txMap.SetImmutable(); err != nil {
-		return nil, errors.New("failed to make tx map immutable: " + err.Error())
+		return nil, fmt.Errorf("failed to make tx map immutable: %w", err)
 	}
 
 	// Get hashes
 	accountHash, err := stateMap.Hash()
 	if err != nil {
-		return nil, errors.New("failed to get state map hash: " + err.Error())
+		return nil, fmt.Errorf("failed to get state map hash: %w", err)
 	}
 
 	txHash, err := txMap.Hash()
 	if err != nil {
-		return nil, errors.New("failed to get tx map hash: " + err.Error())
+		return nil, fmt.Errorf("failed to get tx map hash: %w", err)
 	}
 
 	// Create ledger header

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -130,13 +130,13 @@ func NewOpen(parent *Ledger, closeTime time.Time) (*Ledger, error) {
 	// Snapshot the parent state map as mutable
 	stateMap, err := parent.stateMap.Snapshot(true)
 	if err != nil {
-		return nil, errors.New("failed to snapshot state map: " + err.Error())
+		return nil, fmt.Errorf("failed to snapshot state map: %w", err)
 	}
 
 	// Create empty transaction map
 	txMap, err := shamap.New(shamap.TypeTransaction)
 	if err != nil {
-		return nil, errors.New("failed to create tx map: " + err.Error())
+		return nil, fmt.Errorf("failed to create tx map: %w", err)
 	}
 
 	// Compute the child's close-time resolution dynamically. Rippled
@@ -498,10 +498,10 @@ func (l *Ledger) Close(closeTime time.Time, closeFlags uint8) error {
 
 	// Make maps immutable
 	if err := l.stateMap.SetImmutable(); err != nil {
-		return errors.New("failed to make state map immutable: " + err.Error())
+		return fmt.Errorf("failed to make state map immutable: %w", err)
 	}
 	if err := l.txMap.SetImmutable(); err != nil {
-		return errors.New("failed to make tx map immutable: " + err.Error())
+		return fmt.Errorf("failed to make tx map immutable: %w", err)
 	}
 
 	// Update drops (subtract destroyed)
@@ -510,12 +510,12 @@ func (l *Ledger) Close(closeTime time.Time, closeFlags uint8) error {
 	// Get hashes
 	accountHash, err := l.stateMap.Hash()
 	if err != nil {
-		return errors.New("failed to get state map hash: " + err.Error())
+		return fmt.Errorf("failed to get state map hash: %w", err)
 	}
 
 	txHash, err := l.txMap.Hash()
 	if err != nil {
-		return errors.New("failed to get tx map hash: " + err.Error())
+		return fmt.Errorf("failed to get tx map hash: %w", err)
 	}
 
 	// Update header

--- a/internal/ledger/service/account_query.go
+++ b/internal/ledger/service/account_query.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -77,7 +78,7 @@ func (s *Service) GetAccountInfo(account string, ledgerIndex string) (*AccountIn
 	// Decode the account address to get the account ID
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil {
-		return nil, errors.New("invalid account address: " + err.Error())
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 
 	var accountID [20]byte
@@ -89,7 +90,7 @@ func (s *Service) GetAccountInfo(account string, ledgerIndex string) (*AccountIn
 	// Check if account exists
 	exists, err := targetLedger.Exists(accountKey)
 	if err != nil {
-		return nil, errors.New("failed to check account existence: " + err.Error())
+		return nil, fmt.Errorf("failed to check account existence: %w", err)
 	}
 	if !exists {
 		return nil, errors.New("account not found")
@@ -98,13 +99,13 @@ func (s *Service) GetAccountInfo(account string, ledgerIndex string) (*AccountIn
 	// Read the account data
 	data, err := targetLedger.Read(accountKey)
 	if err != nil {
-		return nil, errors.New("failed to read account: " + err.Error())
+		return nil, fmt.Errorf("failed to read account: %w", err)
 	}
 
 	// Parse the account root
 	accountRoot, err := state.ParseAccountRootFromBytes(data)
 	if err != nil {
-		return nil, errors.New("failed to parse account data: " + err.Error())
+		return nil, fmt.Errorf("failed to parse account data: %w", err)
 	}
 
 	return &AccountInfoResult{
@@ -169,7 +170,7 @@ func (s *Service) GetAccountLines(account string, ledgerIndex string, peer strin
 	// Decode the account address
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil {
-		return nil, errors.New("invalid account address: " + err.Error())
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 	var accountID [20]byte
 	copy(accountID[:], accountIDBytes)
@@ -180,7 +181,7 @@ func (s *Service) GetAccountLines(account string, ledgerIndex string, peer strin
 	if peer != "" {
 		_, peerIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(peer)
 		if err != nil {
-			return nil, errors.New("invalid peer address: " + err.Error())
+			return nil, fmt.Errorf("invalid peer address: %w", err)
 		}
 		copy(peerID[:], peerIDBytes)
 		hasPeer = true
@@ -329,7 +330,7 @@ func (s *Service) GetAccountOffers(account string, ledgerIndex string, limit uin
 	// Decode the account address
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil {
-		return nil, errors.New("invalid account address: " + err.Error())
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 	var accountID [20]byte
 	copy(accountID[:], accountIDBytes)
@@ -451,7 +452,7 @@ func (s *Service) GetAccountObjects(account string, ledgerIndex string, objType 
 
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil {
-		return nil, errors.New("invalid account address: " + err.Error())
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 	var accountID [20]byte
 	copy(accountID[:], accountIDBytes)
@@ -549,7 +550,7 @@ func (s *Service) GetAccountChannels(account string, destinationAccount string, 
 	// Decode the account address
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil {
-		return nil, errors.New("invalid account address: " + err.Error())
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 	var accountID [20]byte
 	copy(accountID[:], accountIDBytes)
@@ -558,7 +559,7 @@ func (s *Service) GetAccountChannels(account string, destinationAccount string, 
 	accountKey := keylet.Account(accountID)
 	exists, err := targetLedger.Exists(accountKey)
 	if err != nil {
-		return nil, errors.New("failed to check account existence: " + err.Error())
+		return nil, fmt.Errorf("failed to check account existence: %w", err)
 	}
 	if !exists {
 		return nil, errors.New("account not found")
@@ -570,7 +571,7 @@ func (s *Service) GetAccountChannels(account string, destinationAccount string, 
 	if destinationAccount != "" {
 		_, destIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(destinationAccount)
 		if err != nil {
-			return nil, errors.New("invalid destination_account address: " + err.Error())
+			return nil, fmt.Errorf("invalid destination_account address: %w", err)
 		}
 		copy(destID[:], destIDBytes)
 		hasDestFilter = true
@@ -697,7 +698,7 @@ func (s *Service) GetAccountCurrencies(account string, ledgerIndex string) (*Acc
 	// Decode the account address
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil {
-		return nil, errors.New("invalid account address: " + err.Error())
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 	var accountID [20]byte
 	copy(accountID[:], accountIDBytes)
@@ -706,7 +707,7 @@ func (s *Service) GetAccountCurrencies(account string, ledgerIndex string) (*Acc
 	accountKey := keylet.Account(accountID)
 	exists, err := targetLedger.Exists(accountKey)
 	if err != nil {
-		return nil, errors.New("failed to check account existence: " + err.Error())
+		return nil, fmt.Errorf("failed to check account existence: %w", err)
 	}
 	if !exists {
 		return nil, errors.New("account not found")
@@ -880,7 +881,7 @@ func (s *Service) GetAccountNFTs(account string, ledgerIndex string, limit uint3
 	// Decode the account address
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil {
-		return nil, errors.New("invalid account address: " + err.Error())
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 	var accountID [20]byte
 	copy(accountID[:], accountIDBytes)
@@ -889,7 +890,7 @@ func (s *Service) GetAccountNFTs(account string, ledgerIndex string, limit uint3
 	accountKey := keylet.Account(accountID)
 	exists, err := targetLedger.Exists(accountKey)
 	if err != nil {
-		return nil, errors.New("failed to check account existence: " + err.Error())
+		return nil, fmt.Errorf("failed to check account existence: %w", err)
 	}
 	if !exists {
 		return nil, errors.New("account not found")
@@ -992,7 +993,7 @@ func (s *Service) GetGatewayBalances(account string, hotWallets []string, ledger
 	// Decode the account address
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil {
-		return nil, errors.New("invalid account address: " + err.Error())
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 	var accountID [20]byte
 	copy(accountID[:], accountIDBytes)
@@ -1001,7 +1002,7 @@ func (s *Service) GetGatewayBalances(account string, hotWallets []string, ledger
 	accountKey := keylet.Account(accountID)
 	exists, err := targetLedger.Exists(accountKey)
 	if err != nil {
-		return nil, errors.New("failed to check account existence: " + err.Error())
+		return nil, fmt.Errorf("failed to check account existence: %w", err)
 	}
 	if !exists {
 		return nil, errors.New("account not found")
@@ -1209,7 +1210,7 @@ func (s *Service) GetNoRippleCheck(account string, role string, ledgerIndex stri
 	// Decode the account address
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil {
-		return nil, errors.New("invalid account address: " + err.Error())
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 	var accountID [20]byte
 	copy(accountID[:], accountIDBytes)
@@ -1218,7 +1219,7 @@ func (s *Service) GetNoRippleCheck(account string, role string, ledgerIndex stri
 	accountKey := keylet.Account(accountID)
 	exists, err := targetLedger.Exists(accountKey)
 	if err != nil {
-		return nil, errors.New("failed to check account existence: " + err.Error())
+		return nil, fmt.Errorf("failed to check account existence: %w", err)
 	}
 	if !exists {
 		return nil, errors.New("account not found")
@@ -1227,12 +1228,12 @@ func (s *Service) GetNoRippleCheck(account string, role string, ledgerIndex stri
 	// Read the account data to get flags and sequence
 	data, err := targetLedger.Read(accountKey)
 	if err != nil {
-		return nil, errors.New("failed to read account: " + err.Error())
+		return nil, fmt.Errorf("failed to read account: %w", err)
 	}
 
 	accountRoot, err := state.ParseAccountRootFromBytes(data)
 	if err != nil {
-		return nil, errors.New("failed to parse account data: " + err.Error())
+		return nil, fmt.Errorf("failed to parse account data: %w", err)
 	}
 
 	// Validate role
@@ -1449,7 +1450,7 @@ func (s *Service) GetDepositAuthorized(sourceAccount string, destinationAccount 
 	// Decode the source account address
 	_, srcIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(sourceAccount)
 	if err != nil {
-		return nil, errors.New("invalid source_account address: " + err.Error())
+		return nil, fmt.Errorf("invalid source_account address: %w", err)
 	}
 	var srcID [20]byte
 	copy(srcID[:], srcIDBytes)
@@ -1457,7 +1458,7 @@ func (s *Service) GetDepositAuthorized(sourceAccount string, destinationAccount 
 	// Decode the destination account address
 	_, dstIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(destinationAccount)
 	if err != nil {
-		return nil, errors.New("invalid destination_account address: " + err.Error())
+		return nil, fmt.Errorf("invalid destination_account address: %w", err)
 	}
 	var dstID [20]byte
 	copy(dstID[:], dstIDBytes)
@@ -1466,7 +1467,7 @@ func (s *Service) GetDepositAuthorized(sourceAccount string, destinationAccount 
 	srcKey := keylet.Account(srcID)
 	exists, err := targetLedger.Exists(srcKey)
 	if err != nil {
-		return nil, errors.New("failed to check source account existence: " + err.Error())
+		return nil, fmt.Errorf("failed to check source account existence: %w", err)
 	}
 	if !exists {
 		return nil, errors.New("source account not found")
@@ -1476,7 +1477,7 @@ func (s *Service) GetDepositAuthorized(sourceAccount string, destinationAccount 
 	dstKey := keylet.Account(dstID)
 	exists, err = targetLedger.Exists(dstKey)
 	if err != nil {
-		return nil, errors.New("failed to check destination account existence: " + err.Error())
+		return nil, fmt.Errorf("failed to check destination account existence: %w", err)
 	}
 	if !exists {
 		return nil, errors.New("destination account not found")
@@ -1485,12 +1486,12 @@ func (s *Service) GetDepositAuthorized(sourceAccount string, destinationAccount 
 	// Read the destination account data to get flags
 	dstData, err := targetLedger.Read(dstKey)
 	if err != nil {
-		return nil, errors.New("failed to read destination account: " + err.Error())
+		return nil, fmt.Errorf("failed to read destination account: %w", err)
 	}
 
 	dstAccountRoot, err := state.ParseAccountRootFromBytes(dstData)
 	if err != nil {
-		return nil, errors.New("failed to parse destination account data: " + err.Error())
+		return nil, fmt.Errorf("failed to parse destination account data: %w", err)
 	}
 
 	// Check if DepositAuth flag is set on destination
@@ -1517,7 +1518,7 @@ func (s *Service) GetDepositAuthorized(sourceAccount string, destinationAccount 
 		depositPreauthKey := keylet.DepositPreauth(dstID, srcID)
 		exists, err := targetLedger.Exists(depositPreauthKey)
 		if err != nil {
-			return nil, errors.New("failed to check deposit preauthorization: " + err.Error())
+			return nil, fmt.Errorf("failed to check deposit preauthorization: %w", err)
 		}
 		depositAuthorized = exists
 
@@ -1527,7 +1528,7 @@ func (s *Service) GetDepositAuthorized(sourceAccount string, destinationAccount 
 			credPreauthKey := keylet.DepositPreauthCredentials(dstID, sortedCredPairs)
 			exists, err := targetLedger.Exists(credPreauthKey)
 			if err != nil {
-				return nil, errors.New("failed to check credential deposit preauthorization: " + err.Error())
+				return nil, fmt.Errorf("failed to check credential deposit preauthorization: %w", err)
 			}
 			depositAuthorized = exists
 		}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -247,7 +247,7 @@ func (s *Service) Start() error {
 	// Create genesis ledger
 	genesisResult, err := genesis.Create(s.config.GenesisConfig)
 	if err != nil {
-		return errors.New("failed to create genesis ledger: " + err.Error())
+		return fmt.Errorf("failed to create genesis ledger: %w", err)
 	}
 
 	// Convert genesis to Ledger.
@@ -274,13 +274,13 @@ func (s *Service) Start() error {
 		// Reference: rippled Application.cpp startGenesisLedger()
 		nextLedger, err := ledger.NewOpen(genesisLedger, time.Now())
 		if err != nil {
-			return errors.New("failed to create next ledger: " + err.Error())
+			return fmt.Errorf("failed to create next ledger: %w", err)
 		}
 		if err := nextLedger.Close(time.Now(), 0); err != nil {
-			return errors.New("failed to close initial ledger: " + err.Error())
+			return fmt.Errorf("failed to close initial ledger: %w", err)
 		}
 		if err := nextLedger.SetValidated(); err != nil {
-			return errors.New("failed to validate initial ledger: " + err.Error())
+			return fmt.Errorf("failed to validate initial ledger: %w", err)
 		}
 		s.closedLedger = nextLedger
 		s.validatedLedger = nextLedger
@@ -289,7 +289,7 @@ func (s *Service) Start() error {
 		// Create the open ledger (ledger 3)
 		openLedger, err := ledger.NewOpen(nextLedger, time.Now())
 		if err != nil {
-			return errors.New("failed to create open ledger: " + err.Error())
+			return fmt.Errorf("failed to create open ledger: %w", err)
 		}
 		s.openLedger = openLedger
 	} else {
@@ -302,7 +302,7 @@ func (s *Service) Start() error {
 		// Create open ledger (seq 2) on top of genesis — will be replaced on adoption
 		openLedger, err := ledger.NewOpen(genesisLedger, time.Now())
 		if err != nil {
-			return errors.New("failed to create open ledger: " + err.Error())
+			return fmt.Errorf("failed to create open ledger: %w", err)
 		}
 		s.openLedger = openLedger
 	}
@@ -433,7 +433,7 @@ func (s *Service) AcceptLedger() (uint32, error) {
 		// Create a fresh open ledger from the LCL
 		freshLedger, err := ledger.NewOpen(s.closedLedger, closeTime)
 		if err != nil {
-			return 0, errors.New("failed to create fresh ledger for canonical reapply: " + err.Error())
+			return 0, fmt.Errorf("failed to create fresh ledger for canonical reapply: %w", err)
 		}
 
 		// Read fees from the LCL for the engine config
@@ -479,7 +479,7 @@ func (s *Service) AcceptLedger() (uint32, error) {
 			// Rebuild fresh from LCL each pass
 			freshLedger, err = ledger.NewOpen(s.closedLedger, closeTime)
 			if err != nil {
-				return 0, errors.New("failed to create fresh ledger: " + err.Error())
+				return 0, fmt.Errorf("failed to create fresh ledger: %w", err)
 			}
 			engineConfig.LedgerSequence = freshLedger.Sequence()
 			engine := tx.NewEngine(freshLedger, engineConfig)
@@ -611,18 +611,18 @@ func (s *Service) AcceptLedger() (uint32, error) {
 
 	// Close the current open ledger
 	if err := s.openLedger.Close(closeTime, 0); err != nil {
-		return 0, errors.New("failed to close ledger: " + err.Error())
+		return 0, fmt.Errorf("failed to close ledger: %w", err)
 	}
 
 	// In standalone mode, immediately validate
 	if err := s.openLedger.SetValidated(); err != nil {
-		return 0, errors.New("failed to validate ledger: " + err.Error())
+		return 0, fmt.Errorf("failed to validate ledger: %w", err)
 	}
 
 	// Persist the closed ledger to storage backends (nodestore and/or relational DB).
 	// persistLedger has internal nil guards for each backend.
 	if err := s.persistLedger(s.openLedger); err != nil {
-		return 0, errors.New("failed to persist ledger: " + err.Error())
+		return 0, fmt.Errorf("failed to persist ledger: %w", err)
 	}
 
 	// Store the closed ledger in memory cache
@@ -647,7 +647,7 @@ func (s *Service) AcceptLedger() (uint32, error) {
 	// Create new open ledger
 	newOpen, err := ledger.NewOpen(s.closedLedger, time.Now())
 	if err != nil {
-		return 0, errors.New("failed to create new open ledger: " + err.Error())
+		return 0, fmt.Errorf("failed to create new open ledger: %w", err)
 	}
 	s.openLedger = newOpen
 
@@ -1168,7 +1168,7 @@ func (s *Service) AcceptConsensusResult(parent *ledger.Ledger, txBlobs [][]byte,
 		// Multi-pass application (same as AcceptLedger)
 		freshLedger, err := ledger.NewOpen(s.closedLedger, closeTime)
 		if err != nil {
-			return 0, errors.New("failed to create fresh ledger for consensus: " + err.Error())
+			return 0, fmt.Errorf("failed to create fresh ledger for consensus: %w", err)
 		}
 
 		baseFee, reserveBase, reserveIncrement := readFeesFromLedger(s.closedLedger)
@@ -1200,7 +1200,7 @@ func (s *Service) AcceptConsensusResult(parent *ledger.Ledger, txBlobs [][]byte,
 		for pass := 0; pass < totalPasses; pass++ {
 			freshLedger, err = ledger.NewOpen(s.closedLedger, closeTime)
 			if err != nil {
-				return 0, errors.New("failed to create fresh ledger: " + err.Error())
+				return 0, fmt.Errorf("failed to create fresh ledger: %w", err)
 			}
 			engineConfig.LedgerSequence = freshLedger.Sequence()
 			engine := tx.NewEngine(freshLedger, engineConfig)
@@ -1318,14 +1318,14 @@ func (s *Service) AcceptConsensusResult(parent *ledger.Ledger, txBlobs [][]byte,
 
 	// Close the ledger with the consensus-agreed close time
 	if err := s.openLedger.Close(closeTime, 0); err != nil {
-		return 0, errors.New("failed to close ledger: " + err.Error())
+		return 0, fmt.Errorf("failed to close ledger: %w", err)
 	}
 
 	// Do NOT auto-validate — validation comes from the consensus validation tracker.
 
 	// Persist
 	if err := s.persistLedger(s.openLedger); err != nil {
-		return 0, errors.New("failed to persist ledger: " + err.Error())
+		return 0, fmt.Errorf("failed to persist ledger: %w", err)
 	}
 
 	closedSeq := s.openLedger.Sequence()
@@ -1351,7 +1351,7 @@ func (s *Service) AcceptConsensusResult(parent *ledger.Ledger, txBlobs [][]byte,
 	// Create new open ledger
 	newOpen, err := ledger.NewOpen(s.closedLedger, time.Now())
 	if err != nil {
-		return 0, errors.New("failed to create new open ledger: " + err.Error())
+		return 0, fmt.Errorf("failed to create new open ledger: %w", err)
 	}
 	s.openLedger = newOpen
 

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
@@ -206,7 +207,7 @@ func (s *Service) GetTransaction(txHash [32]byte) (*TransactionResult, error) {
 	// Get the transaction data
 	txData, found, err := l.GetTransaction(txHash)
 	if err != nil {
-		return nil, errors.New("failed to get transaction: " + err.Error())
+		return nil, fmt.Errorf("failed to get transaction: %w", err)
 	}
 	if !found {
 		return nil, errors.New("transaction not found in ledger")
@@ -254,7 +255,7 @@ func (s *Service) SimulateTransaction(transaction tx.Transaction) (*SubmitResult
 	// Create a snapshot of the open ledger's state map for isolation
 	snapshot, err := s.openLedger.StateMapSnapshot()
 	if err != nil {
-		return nil, errors.New("failed to create ledger snapshot: " + err.Error())
+		return nil, fmt.Errorf("failed to create ledger snapshot: %w", err)
 	}
 
 	// Create a temporary ledger view backed by the snapshot
@@ -331,7 +332,7 @@ func (s *Service) GetAccountTransactions(account string, ledgerMin, ledgerMax in
 	// Decode account address
 	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil {
-		return nil, errors.New("invalid account address: " + err.Error())
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 	var accountID relationaldb.AccountID
 	copy(accountID[:], accountIDBytes)

--- a/internal/rpc/handlers/account_channels.go
+++ b/internal/rpc/handlers/account_channels.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -58,7 +59,7 @@ func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMes
 		if len(err.Error()) > 32 && err.Error()[:32] == "invalid destination_account addr" {
 			return nil, types.RpcErrorInvalidParams("Destination account malformed.")
 		}
-		return nil, types.RpcErrorInternal("Failed to get account channels: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account channels: %v", err))
 	}
 
 	// Build channels array with proper field handling

--- a/internal/rpc/handlers/account_currencies.go
+++ b/internal/rpc/handlers/account_currencies.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -52,7 +53,7 @@ func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawM
 				Message: "Account malformed.",
 			}
 		}
-		return nil, types.RpcErrorInternal("Failed to get account currencies: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account currencies: %v", err))
 	}
 
 	// Build response

--- a/internal/rpc/handlers/account_info.go
+++ b/internal/rpc/handlers/account_info.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -37,7 +38,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	var rawFields map[string]json.RawMessage
 	if params != nil {
 		if err := json.Unmarshal(params, &rawFields); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 
@@ -103,7 +104,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		if err.Error() == "account not found" {
 			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
-		return nil, types.RpcErrorInternal("Failed to get account info: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account info: %v", err))
 	}
 
 	// Build account_data by decoding the full SLE binary via binarycodec,

--- a/internal/rpc/handlers/account_lines.go
+++ b/internal/rpc/handlers/account_lines.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -52,7 +53,7 @@ func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 				Message: "Account not found.",
 			}
 		}
-		return nil, types.RpcErrorInternal("Failed to get account lines: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account lines: %v", err))
 	}
 
 	// Filter out default-state trust lines when ignore_default is true

--- a/internal/rpc/handlers/account_nfts.go
+++ b/internal/rpc/handlers/account_nfts.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -53,7 +54,7 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 				Message: "Account malformed.",
 			}
 		}
-		return nil, types.RpcErrorInternal("Failed to get account NFTs: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account NFTs: %v", err))
 	}
 
 	// Build NFTs array with proper field handling

--- a/internal/rpc/handlers/account_objects.go
+++ b/internal/rpc/handlers/account_objects.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -171,7 +172,7 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 				Message: "Account not found.",
 			}
 		}
-		return nil, types.RpcErrorInternal("Failed to get account objects: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account objects: %v", err))
 	}
 
 	// Build account_objects array with deserialized fields

--- a/internal/rpc/handlers/account_offers.go
+++ b/internal/rpc/handlers/account_offers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -44,7 +45,7 @@ func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 				Message: "Account not found.",
 			}
 		}
-		return nil, types.RpcErrorInternal("Failed to get account offers: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account offers: %v", err))
 	}
 
 	// Build response

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -116,7 +116,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 				Message: "Account not found.",
 			}
 		}
-		return nil, types.RpcErrorInternal("Failed to get account transactions: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account transactions: %v", err))
 	}
 
 	// Cache for ledger lookups by sequence, to avoid repeated lookups

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -93,12 +93,12 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		// Look up AMM by asset pair
 		issue1Issuer, issue1Currency, err := parseIssue(request.Asset)
 		if err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid asset: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid asset: %v", err))
 		}
 
 		issue2Issuer, issue2Currency, err := parseIssue(request.Asset2)
 		if err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid asset2: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid asset2: %v", err))
 		}
 
 		ammKeylet := keylet.AMM(issue1Issuer, issue1Currency, issue2Issuer, issue2Currency)

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -34,13 +35,13 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	// Parse taker_gets amount
 	takerGets, err := ParseAmountFromJSON(request.TakerGets)
 	if err != nil {
-		return nil, types.RpcErrorInvalidParams("Invalid taker_gets: " + err.Error())
+		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid taker_gets: %v", err))
 	}
 
 	// Parse taker_pays amount
 	takerPays, err := ParseAmountFromJSON(request.TakerPays)
 	if err != nil {
-		return nil, types.RpcErrorInvalidParams("Invalid taker_pays: " + err.Error())
+		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid taker_pays: %v", err))
 	}
 
 	// Validate currencies (rippled rejects non-standard currency codes)
@@ -62,7 +63,7 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	limit := ClampLimit(request.Limit, LimitBookOffers, ctx.IsAdmin)
 	result, err := ctx.Services.Ledger.GetBookOffers(takerGets, takerPays, ledgerIndex, limit)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to get book offers: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get book offers: %v", err))
 	}
 
 	// Build response matching rippled's book_offers structure.

--- a/internal/rpc/handlers/channel_authorize.go
+++ b/internal/rpc/handlers/channel_authorize.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -35,7 +36,7 @@ func (m *ChannelAuthorizeMethod) Handle(ctx *types.RpcContext, params json.RawMe
 
 	if params != nil {
 		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 
@@ -113,20 +114,20 @@ func (m *ChannelAuthorizeMethod) Handle(ctx *types.RpcContext, params json.RawMe
 	}
 	messageHex, err := binarycodec.EncodeForSigningClaim(claimJSON)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to encode claim: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode claim: %v", err))
 	}
 
 	// Convert hex message to raw bytes for signing
 	messageBytes, err := hex.DecodeString(messageHex)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to decode message: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to decode message: %v", err))
 	}
 
 	// Sign the message
 	// The Sign functions expect the raw message bytes (as a string)
 	signature, err := signMessage(messageBytes, privateKeyHex, request.KeyType)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Exception occurred during signing: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Exception occurred during signing: %v", err))
 	}
 
 	response := map[string]interface{}{

--- a/internal/rpc/handlers/channel_verify.go
+++ b/internal/rpc/handlers/channel_verify.go
@@ -31,7 +31,7 @@ func (m *ChannelVerifyMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 
 	if params != nil {
 		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 
@@ -138,13 +138,13 @@ func (m *ChannelVerifyMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	}
 	messageHex, err := binarycodec.EncodeForSigningClaim(claimJSON)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to encode claim: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode claim: %v", err))
 	}
 
 	// Convert hex message to raw bytes for verification
 	messageBytes, err := hex.DecodeString(messageHex)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to decode message: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to decode message: %v", err))
 	}
 
 	// Verify the signature

--- a/internal/rpc/handlers/gateway_balances.go
+++ b/internal/rpc/handlers/gateway_balances.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -90,7 +91,7 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 			}
 			return nil, types.RpcErrorInvalidParams("Invalid field 'hotwallet'.")
 		}
-		return nil, types.RpcErrorInternal("Failed to get gateway balances: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get gateway balances: %v", err))
 	}
 
 	// Build response matching rippled's GatewayBalances.cpp format.

--- a/internal/rpc/handlers/get_aggregate_price.go
+++ b/internal/rpc/handlers/get_aggregate_price.go
@@ -29,7 +29,7 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 	var raw map[string]json.RawMessage
 	if params != nil {
 		if err := json.Unmarshal(params, &raw); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 	if raw == nil {

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -26,7 +27,7 @@ func ParseParams(params json.RawMessage, dest interface{}) *types.RpcError {
 		return nil
 	}
 	if err := json.Unmarshal(params, dest); err != nil {
-		return types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+		return types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 	}
 	return nil
 }

--- a/internal/rpc/handlers/json.go
+++ b/internal/rpc/handlers/json.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -19,7 +20,7 @@ func (m *JsonMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inte
 
 	if params != nil {
 		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 

--- a/internal/rpc/handlers/ledger_accept.go
+++ b/internal/rpc/handlers/ledger_accept.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -23,7 +24,7 @@ func (m *LedgerAcceptMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 
 	closedSeq, err := ctx.Services.Ledger.AcceptLedger()
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to accept ledger: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to accept ledger: %v", err))
 	}
 
 	response := map[string]interface{}{

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -56,7 +56,7 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 
 	result, err := ctx.Services.Ledger.GetLedgerData(ledgerIndex, limit, markerStr)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to get ledger data: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get ledger data: %v", err))
 	}
 
 	// Build state array based on binary flag

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
@@ -71,7 +72,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 			}
 			accountID, err := decodeAccountID(addr)
 			if err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid account_root address: " + err.Error())
+				return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid account_root address: %v", err))
 			}
 			entryKey = keylet.Account(accountID).Key
 			keySet = true
@@ -153,7 +154,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 			}
 			accountID, err := decodeAccountID(addr)
 			if err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid did address: " + err.Error())
+				return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid did address: %v", err))
 			}
 			entryKey = keylet.DID(accountID).Key
 			keySet = true
@@ -308,7 +309,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 			}
 			accountID, err := decodeAccountID(addr)
 			if err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid signer_list address: " + err.Error())
+				return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid signer_list address: %v", err))
 			}
 			entryKey = keylet.SignerList(accountID).Key
 			keySet = true
@@ -368,7 +369,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		if err.Error() == "entry not found" {
 			return nil, types.RpcErrorEntryNotFound("Requested ledger entry not found.")
 		}
-		return nil, types.RpcErrorInternal("Failed to get ledger entry: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get ledger entry: %v", err))
 	}
 
 	response := map[string]interface{}{
@@ -462,11 +463,11 @@ func parseAMMKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 
 	issue1Currency, issue1Issuer, err := parseCurrencyIssuer(req.Asset)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid amm asset: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid amm asset: %v", err))
 	}
 	issue2Currency, issue2Issuer, err := parseCurrencyIssuer(req.Asset2)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid amm asset2: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid amm asset2: %v", err))
 	}
 
 	return keylet.AMM(issue1Issuer, issue1Currency, issue2Issuer, issue2Currency).Key, nil
@@ -491,11 +492,11 @@ func parseCredentialKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	}
 	subjectID, err := decodeAccountID(req.Subject)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid credential subject: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid credential subject: %v", err))
 	}
 	issuerID, err := decodeAccountID(req.Issuer)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid credential issuer: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid credential issuer: %v", err))
 	}
 	credType, err := hex.DecodeString(req.CredentialType)
 	if err != nil {
@@ -525,11 +526,11 @@ func parseDelegateKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	}
 	accountID, err := decodeAccountID(req.Account)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid delegate account: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid delegate account: %v", err))
 	}
 	authorizeID, err := decodeAccountID(req.Authorize)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid delegate authorize: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid delegate authorize: %v", err))
 	}
 	return keylet.DelegateKeylet(accountID, authorizeID).Key, nil
 }
@@ -553,11 +554,11 @@ func parseDepositPreauthKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) 
 	}
 	ownerID, err := decodeAccountID(req.Owner)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid deposit_preauth owner: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid deposit_preauth owner: %v", err))
 	}
 	authID, err := decodeAccountID(req.Authorized)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid deposit_preauth authorized: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid deposit_preauth authorized: %v", err))
 	}
 	return keylet.DepositPreauth(ownerID, authID).Key, nil
 }
@@ -601,7 +602,7 @@ func parseDirectoryKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	if req.Owner != "" {
 		accountID, err := decodeAccountID(req.Owner)
 		if err != nil {
-			return [32]byte{}, types.RpcErrorInvalidParams("Invalid directory owner: " + err.Error())
+			return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid directory owner: %v", err))
 		}
 		ownerDir := keylet.OwnerDir(accountID)
 		return keylet.DirPage(ownerDir.Key, req.SubIndex).Key, nil
@@ -628,7 +629,7 @@ func parseEscrowKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	}
 	accountID, err := decodeAccountID(req.Owner)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid escrow owner: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid escrow owner: %v", err))
 	}
 	return keylet.Escrow(accountID, req.Seq).Key, nil
 }
@@ -657,7 +658,7 @@ func parseMPTokenKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	copy(mptID[:], idBytes)
 	accountID, err := decodeAccountID(req.Account)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid mptoken account: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid mptoken account: %v", err))
 	}
 	return keylet.MPTokenByID(mptID, accountID).Key, nil
 }
@@ -680,7 +681,7 @@ func parseOfferKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	}
 	accountID, err := decodeAccountID(req.Account)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid offer account: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid offer account: %v", err))
 	}
 	return keylet.Offer(accountID, req.Seq).Key, nil
 }
@@ -703,7 +704,7 @@ func parseOracleKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	}
 	accountID, err := decodeAccountID(req.Account)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid oracle account: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid oracle account: %v", err))
 	}
 	return keylet.Oracle(accountID, req.OracleDocumentID).Key, nil
 }
@@ -726,7 +727,7 @@ func parsePermissionedDomainKeylet(raw json.RawMessage) ([32]byte, *types.RpcErr
 	}
 	accountID, err := decodeAccountID(req.Account)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid permissioned_domain account: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid permissioned_domain account: %v", err))
 	}
 	return keylet.PermissionedDomain(accountID, req.Seq).Key, nil
 }
@@ -745,11 +746,11 @@ func parseRippleStateKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	}
 	account1, err := decodeAccountID(req.Accounts[0])
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid ripple_state account[0]: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid ripple_state account[0]: %v", err))
 	}
 	account2, err := decodeAccountID(req.Accounts[1])
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid ripple_state account[1]: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid ripple_state account[1]: %v", err))
 	}
 	return keylet.Line(account1, account2, req.Currency).Key, nil
 }
@@ -772,7 +773,7 @@ func parseTicketKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	}
 	accountID, err := decodeAccountID(req.Account)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid ticket account: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid ticket account: %v", err))
 	}
 	return keylet.Ticket(accountID, req.TicketSeq).Key, nil
 }
@@ -795,7 +796,7 @@ func parseVaultKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 	}
 	accountID, err := decodeAccountID(req.Owner)
 	if err != nil {
-		return [32]byte{}, types.RpcErrorInvalidParams("Invalid vault owner: " + err.Error())
+		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid vault owner: %v", err))
 	}
 	return keylet.Vault(accountID, req.Seq).Key, nil
 }

--- a/internal/rpc/handlers/ledger_header.go
+++ b/internal/rpc/handlers/ledger_header.go
@@ -28,7 +28,7 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 
 	if params != nil {
 		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 

--- a/internal/rpc/handlers/ledger_range.go
+++ b/internal/rpc/handlers/ledger_range.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -41,7 +42,7 @@ func (m *LedgerRangeMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 
 	result, err := ctx.Services.Ledger.GetLedgerRange(request.StartLedger, request.StopLedger)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to get ledger range: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get ledger range: %v", err))
 	}
 
 	// Build ledgers array

--- a/internal/rpc/handlers/manifest.go
+++ b/internal/rpc/handlers/manifest.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -33,7 +34,7 @@ func (m *ManifestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 
 	if params != nil {
 		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 
@@ -45,7 +46,7 @@ func (m *ManifestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	// rejects non-base58 or wrong-type inputs with rpcPUBLIC_MALFORMED.
 	rawKey, err := addresscodec.DecodeNodePublicKey(request.PublicKey)
 	if err != nil {
-		return nil, types.RpcErrorInvalidParams("invalid node public key: " + err.Error())
+		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("invalid node public key: %v", err))
 	}
 	if len(rawKey) != 33 {
 		return nil, types.RpcErrorInvalidParams("node public key must be 33 bytes")
@@ -82,7 +83,7 @@ func (m *ManifestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 
 	masterB58, err := addresscodec.EncodeNodePublicKey(master[:])
 	if err != nil {
-		return nil, types.RpcErrorInternal("encode master key: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("encode master key: %v", err))
 	}
 
 	details := map[string]interface{}{
@@ -92,7 +93,7 @@ func (m *ManifestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	if ephOK {
 		ephB58, err := addresscodec.EncodeNodePublicKey(ephemeral[:])
 		if err != nil {
-			return nil, types.RpcErrorInternal("encode ephemeral key: " + err.Error())
+			return nil, types.RpcErrorInternal(fmt.Sprintf("encode ephemeral key: %v", err))
 		}
 		details["ephemeral_key"] = ephB58
 	}

--- a/internal/rpc/handlers/nft_buy_offers.go
+++ b/internal/rpc/handlers/nft_buy_offers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -83,7 +84,7 @@ func (m *NftBuyOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		if err.Error() == "invalid marker" {
 			return nil, types.RpcErrorInvalidParams("Invalid marker")
 		}
-		return nil, types.RpcErrorInternal("Failed to get NFT buy offers: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get NFT buy offers: %v", err))
 	}
 
 	return buildNFTOffersResponse(nftIDHex, result, limit), nil

--- a/internal/rpc/handlers/nft_sell_offers.go
+++ b/internal/rpc/handlers/nft_sell_offers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -83,7 +84,7 @@ func (m *NftSellOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		if err.Error() == "invalid marker" {
 			return nil, types.RpcErrorInvalidParams("Invalid marker")
 		}
-		return nil, types.RpcErrorInternal("Failed to get NFT sell offers: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get NFT sell offers: %v", err))
 	}
 
 	return buildNFTOffersResponse(nftIDHex, result, limit), nil

--- a/internal/rpc/handlers/random.go
+++ b/internal/rpc/handlers/random.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -17,7 +18,7 @@ func (m *RandomMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 	randomBytes := make([]byte, 32)
 	_, err := rand.Read(randomBytes)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to generate random data: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to generate random data: %v", err))
 	}
 
 	response := map[string]interface{}{

--- a/internal/rpc/handlers/sign.go
+++ b/internal/rpc/handlers/sign.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -31,7 +32,7 @@ func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inte
 
 	if params != nil {
 		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -30,7 +31,7 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 
 	if params != nil {
 		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 
@@ -75,7 +76,7 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	// Parse the transaction JSON
 	var txMap map[string]interface{}
 	if err := json.Unmarshal(request.TxJson, &txMap); err != nil {
-		return nil, types.RpcErrorInvalidParams("Invalid tx_json: " + err.Error())
+		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_json: %v", err))
 	}
 
 	// Verify that Account field exists in transaction
@@ -114,13 +115,13 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	// Encode for multisigning (adds the signer's account as suffix)
 	signingPayload, err := binarycodec.EncodeForMultisigning(txMapForSigning, request.Account)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to encode for multisigning: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode for multisigning: %v", err))
 	}
 
 	// Sign the payload
 	signature, err := signPayload(signingPayload, privateKey, keyType)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to sign transaction: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to sign transaction: %v", err))
 	}
 
 	newSigner := map[string]interface{}{
@@ -150,7 +151,7 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 
 	txBlob, err := binarycodec.Encode(txMap)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to encode transaction: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode transaction: %v", err))
 	}
 
 	txHash := CalculateTxHash(txBlob)

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -171,13 +171,13 @@ func signTransactionJSON(services *types.ServiceContainer, txJSON json.RawMessag
 	// Derive address from public key
 	address, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(publicKey)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to derive address: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to derive address: %v", err))
 	}
 
 	// Parse the transaction JSON
 	var txMap map[string]interface{}
 	if err := json.Unmarshal(txJSON, &txMap); err != nil {
-		return nil, types.RpcErrorInvalidParams("Invalid tx_json: " + err.Error())
+		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_json: %v", err))
 	}
 
 	// Verify the account matches the signing key
@@ -218,7 +218,7 @@ func signTransactionJSON(services *types.ServiceContainer, txJSON json.RawMessag
 			// For now, attempt to get account info.
 			info, err := services.Ledger.GetAccountInfo(address, "current")
 			if err != nil {
-				return nil, types.RpcErrorInternal("Failed to get account sequence: " + err.Error())
+				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account sequence: %v", err))
 			}
 			txMap["Sequence"] = info.Sequence
 		}
@@ -245,12 +245,12 @@ func signTransactionJSON(services *types.ServiceContainer, txJSON json.RawMessag
 
 	txBytes, err := json.Marshal(txMap)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to marshal transaction: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to marshal transaction: %v", err))
 	}
 
 	transaction, err := tx.ParseJSON(txBytes)
 	if err != nil {
-		return nil, types.RpcErrorInvalidParams("Failed to parse transaction: " + err.Error())
+		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Failed to parse transaction: %v", err))
 	}
 
 	txCommon := transaction.GetCommon()
@@ -258,14 +258,14 @@ func signTransactionJSON(services *types.ServiceContainer, txJSON json.RawMessag
 
 	signature, err := tx.SignTransaction(transaction, privateKey)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to sign transaction: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to sign transaction: %v", err))
 	}
 
 	txMap["TxnSignature"] = signature
 
 	txBlob, err := binarycodec.Encode(txMap)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to encode transaction: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode transaction: %v", err))
 	}
 
 	txHash := CalculateTxHash(txBlob)

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -19,7 +20,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	var rawParams map[string]json.RawMessage
 	if params != nil {
 		if err := json.Unmarshal(params, &rawParams); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	} else {
 		rawParams = make(map[string]json.RawMessage)
@@ -185,7 +186,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	// Run the transaction in simulation mode (snapshot, no commit)
 	result, err := ctx.Services.Ledger.SimulateTransaction(txJSON)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Simulation failed: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Simulation failed: %v", err))
 	}
 
 	response := map[string]interface{}{

--- a/internal/rpc/handlers/stubs_ledger.go
+++ b/internal/rpc/handlers/stubs_ledger.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -24,7 +25,7 @@ func (m *OwnerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 
 	if params != nil {
 		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 

--- a/internal/rpc/handlers/stubs_network.go
+++ b/internal/rpc/handlers/stubs_network.go
@@ -111,7 +111,7 @@ func (m *ConnectMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 
 	if params != nil {
 		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -59,7 +59,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		// Decode tx_blob to get tx_json
 		decoded, err := binarycodec.Decode(request.TxBlob)
 		if err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid tx_blob: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_blob: %v", err))
 		}
 		txJsonMap = decoded
 		txBlobHex = request.TxBlob
@@ -112,7 +112,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 	// The blob is needed for canonical re-ordering during AcceptLedger.
 	result, err := ctx.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to submit transaction: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to submit transaction: %v", err))
 	}
 	txHashStr := CalculateTxHash(txBlobHex)
 

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -33,7 +34,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	// Parse the transaction JSON
 	var txMap map[string]interface{}
 	if err := json.Unmarshal(request.TxJson, &txMap); err != nil {
-		return nil, types.RpcErrorInvalidParams("Invalid tx_json: " + err.Error())
+		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_json: %v", err))
 	}
 
 	// --- checkMultiSignFields (rippled TransactionSign.cpp:1032-1057) ---

--- a/internal/rpc/handlers/tx.go
+++ b/internal/rpc/handlers/tx.go
@@ -32,7 +32,7 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interf
 	if request.CTID != "" && request.Transaction == "" {
 		ctidLedgerSeq, ctidTxIndex, err := parseCTID(request.CTID)
 		if err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid ctid: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid ctid: %v", err))
 		}
 		return m.lookupByCTID(ctx, ctidLedgerSeq, ctidTxIndex, request.Binary)
 	}
@@ -66,7 +66,7 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interf
 	// Split the VL-encoded blob into tx bytes and meta bytes
 	txBytes, metaBytes, err := tx.SplitTxWithMetaBlob(txInfo.TxData)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to split transaction blob: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to split transaction blob: %v", err))
 	}
 
 	// Decode transaction binary to JSON

--- a/internal/rpc/handlers/tx_history.go
+++ b/internal/rpc/handlers/tx_history.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -33,7 +34,7 @@ func (m *TxHistoryMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 				Message: "Transaction history not available. Database not configured.",
 			}
 		}
-		return nil, types.RpcErrorInternal("Failed to get transaction history: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get transaction history: %v", err))
 	}
 
 	// Build transactions array with deserialized JSON

--- a/internal/rpc/handlers/validator_info.go
+++ b/internal/rpc/handlers/validator_info.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -48,7 +49,7 @@ func (m *ValidatorInfoMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (
 
 	masterB58, err := addresscodec.EncodeNodePublicKey(masterKey[:])
 	if err != nil {
-		return nil, types.RpcErrorInternal("encode master key: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("encode master key: %v", err))
 	}
 	resp := validatorInfoResponse{MasterKey: masterB58}
 
@@ -60,7 +61,7 @@ func (m *ValidatorInfoMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (
 	if masterKey != keyArr {
 		ephB58, err := addresscodec.EncodeNodePublicKey(keyArr[:])
 		if err != nil {
-			return nil, types.RpcErrorInternal("encode ephemeral key: " + err.Error())
+			return nil, types.RpcErrorInternal(fmt.Sprintf("encode ephemeral key: %v", err))
 		}
 		resp.EphemeralKey = ephB58
 

--- a/internal/rpc/handlers/vault_info.go
+++ b/internal/rpc/handlers/vault_info.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -60,7 +61,7 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		// Lookup by owner + seq
 		_, ownerBytes, err := addresscodec.DecodeClassicAddressToAccountID(request.Owner)
 		if err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid owner address: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid owner address: %v", err))
 		}
 		var ownerID [20]byte
 		copy(ownerID[:], ownerBytes)

--- a/internal/rpc/handlers/wallet_propose.go
+++ b/internal/rpc/handlers/wallet_propose.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math"
 	"strings"
 
@@ -32,7 +33,7 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 
 	if params != nil {
 		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
 
@@ -104,7 +105,7 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		// Generate random seed
 		entropy = make([]byte, 16)
 		if _, err := rand.Read(entropy); err != nil {
-			return nil, types.RpcErrorInternal("Failed to generate random seed: " + err.Error())
+			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to generate random seed: %v", err))
 		}
 	}
 
@@ -117,21 +118,21 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		algo := ed25519.ED25519()
 		privateKey, publicKey, err = algo.DeriveKeypair(entropy, false)
 		if err != nil {
-			return nil, types.RpcErrorInternal("Failed to derive keypair: " + err.Error())
+			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to derive keypair: %v", err))
 		}
 		encodedSeed, err = addresscodec.EncodeSeed(entropy, algo)
 		if err != nil {
-			return nil, types.RpcErrorInternal("Failed to encode seed: " + err.Error())
+			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode seed: %v", err))
 		}
 	} else {
 		algo := secp256k1.SECP256K1()
 		privateKey, publicKey, err = algo.DeriveKeypair(entropy, false)
 		if err != nil {
-			return nil, types.RpcErrorInternal("Failed to derive keypair: " + err.Error())
+			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to derive keypair: %v", err))
 		}
 		encodedSeed, err = addresscodec.EncodeSeed(entropy, algo)
 		if err != nil {
-			return nil, types.RpcErrorInternal("Failed to encode seed: " + err.Error())
+			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode seed: %v", err))
 		}
 	}
 	_ = privateKey // Private key is derived but not returned (security)
@@ -139,17 +140,17 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	// Derive account address from public key
 	accountID, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(publicKey)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to derive account address: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to derive account address: %v", err))
 	}
 
 	// Encode public key in base58
 	pubKeyBytes, err := hex.DecodeString(publicKey)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to decode public key: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to decode public key: %v", err))
 	}
 	encodedPublicKey, err := addresscodec.EncodeAccountPublicKey(pubKeyBytes)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to encode public key: " + err.Error())
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode public key: %v", err))
 	}
 
 	// Encode seed as RFC-1751 human-readable words (master_key)

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -175,7 +175,7 @@ func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte, txBlobHex ...str
 		return &types.SubmitResult{
 			EngineResult:        "temMALFORMED",
 			EngineResultCode:    -299,
-			EngineResultMessage: "Transaction is malformed: " + err.Error(),
+			EngineResultMessage: fmt.Sprintf("Transaction is malformed: %v", err),
 			Applied:             false,
 		}, nil
 	}
@@ -207,7 +207,7 @@ func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte, txBlobHex ...str
 		return &types.SubmitResult{
 			EngineResult:        "tefINTERNAL",
 			EngineResultCode:    -199,
-			EngineResultMessage: "Internal error: " + err.Error(),
+			EngineResultMessage: fmt.Sprintf("Internal error: %v", err),
 			Applied:             false,
 		}, nil
 	}
@@ -823,7 +823,7 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 		return &types.SubmitResult{
 			EngineResult:        "temMALFORMED",
 			EngineResultCode:    -299,
-			EngineResultMessage: "Transaction is malformed: " + err.Error(),
+			EngineResultMessage: fmt.Sprintf("Transaction is malformed: %v", err),
 			Applied:             false,
 		}, nil
 	}
@@ -833,7 +833,7 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 		return &types.SubmitResult{
 			EngineResult:        "tefINTERNAL",
 			EngineResultCode:    -199,
-			EngineResultMessage: "Internal error: " + err.Error(),
+			EngineResultMessage: fmt.Sprintf("Internal error: %v", err),
 			Applied:             false,
 		}, nil
 	}

--- a/internal/rpc/path_find_session.go
+++ b/internal/rpc/path_find_session.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"sync"
 
@@ -56,7 +57,7 @@ type pathFindCreateRequest struct {
 func ParseAndCreateSession(params json.RawMessage, id interface{}) (*PathFindSession, *rpctypes.RpcError) {
 	var request pathFindCreateRequest
 	if err := json.Unmarshal(params, &request); err != nil {
-		return nil, rpctypes.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+		return nil, rpctypes.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 	}
 
 	// Validate required fields

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
@@ -138,13 +139,13 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 			if err := json.Unmarshal(book.TakerGets, &takerGets); err != nil {
 				return &types.RpcError{
 					Code:    types.RpcINVALID_PARAMS,
-					Message: "Invalid taker_gets: " + err.Error(),
+					Message: fmt.Sprintf("Invalid taker_gets: %v", err),
 				}
 			}
 			if err := json.Unmarshal(book.TakerPays, &takerPays); err != nil {
 				return &types.RpcError{
 					Code:    types.RpcINVALID_PARAMS,
-					Message: "Invalid taker_pays: " + err.Error(),
+					Message: fmt.Sprintf("Invalid taker_pays: %v", err),
 				}
 			}
 

--- a/internal/tx/apply.go
+++ b/internal/tx/apply.go
@@ -2,6 +2,7 @@ package tx
 
 import (
 	"encoding/hex"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/drops"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
@@ -52,7 +53,7 @@ func (e *Engine) Apply(tx Transaction) ApplyResult {
 		return ApplyResult{
 			Result:  TefINTERNAL,
 			Applied: false,
-			Message: "failed to compute transaction hash: " + err.Error(),
+			Message: fmt.Sprintf("failed to compute transaction hash: %v", err),
 		}
 	}
 
@@ -313,7 +314,7 @@ func (e *Engine) applyPseudoTransaction(tx Transaction) ApplyResult {
 		return ApplyResult{
 			Result:  TefINTERNAL,
 			Applied: false,
-			Message: "failed to compute transaction hash: " + err.Error(),
+			Message: fmt.Sprintf("failed to compute transaction hash: %v", err),
 		}
 	}
 
@@ -355,7 +356,7 @@ func (e *Engine) applyPseudoTransaction(tx Transaction) ApplyResult {
 				Result:   TefINTERNAL,
 				Applied:  false,
 				Metadata: metadata,
-				Message:  "failed to apply state changes: " + err.Error(),
+				Message:  fmt.Sprintf("failed to apply state changes: %v", err),
 			}
 		}
 		metadata.AffectedNodes = generatedMeta.AffectedNodes

--- a/internal/tx/block_processor.go
+++ b/internal/tx/block_processor.go
@@ -1,5 +1,7 @@
 package tx
 
+import "fmt"
+
 // BlockProcessor handles batch application of transactions to a ledger.
 // It wraps the Engine to provide higher-level functionality:
 // - Applying multiple transactions in sequence
@@ -114,7 +116,7 @@ func (bp *BlockProcessor) ApplyTransactions(transactions []ParsedTx) (*BlockResu
 		if err != nil {
 			// Log the error but continue with other transactions
 			// The error is captured in the result
-			txResult.ApplyResult.Message = "block processor error: " + err.Error()
+			txResult.ApplyResult.Message = fmt.Sprintf("block processor error: %v", err)
 		}
 
 		result.Transactions = append(result.Transactions, txResult)

--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -3,7 +3,7 @@ package tx
 import (
 	"encoding/hex"
 	"encoding/json"
-	"errors"
+	"fmt"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 )
@@ -19,12 +19,12 @@ func ParseJSON(data []byte) (Transaction, error) {
 			TransactionType string `json:"TransactionType"`
 		}
 		if err := json.Unmarshal(data, &header); err != nil {
-			return nil, errors.New("failed to parse transaction: " + err.Error())
+			return nil, fmt.Errorf("failed to parse transaction: %w", err)
 		}
 		txType, _ := TypeFromName(header.TransactionType)
 		var baseTx BaseTx
 		if err := json.Unmarshal(data, &baseTx); err != nil {
-			return nil, errors.New("failed to parse transaction: " + err.Error())
+			return nil, fmt.Errorf("failed to parse transaction: %w", err)
 		}
 		baseTx.txType = txType
 		return &baseTx, nil
@@ -49,7 +49,7 @@ func ParseFromBinary(blob []byte) (Transaction, error) {
 	// Decode binary to JSON map
 	jsonMap, err := binarycodec.Decode(hexStr)
 	if err != nil {
-		return nil, errors.New("failed to decode binary transaction: " + err.Error())
+		return nil, fmt.Errorf("failed to decode binary transaction: %w", err)
 	}
 
 	// Extract present fields from the decoded map
@@ -62,7 +62,7 @@ func ParseFromBinary(blob []byte) (Transaction, error) {
 	// Convert map to JSON bytes
 	jsonBytes, err := json.Marshal(jsonMap)
 	if err != nil {
-		return nil, errors.New("failed to marshal decoded transaction: " + err.Error())
+		return nil, fmt.Errorf("failed to marshal decoded transaction: %w", err)
 	}
 
 	tx, err := ParseJSON(jsonBytes)

--- a/internal/tx/signature.go
+++ b/internal/tx/signature.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -101,7 +102,7 @@ func VerifySignature(tx Transaction) error {
 	// Get the message that was signed
 	signingPayload, err := getSigningPayload(tx)
 	if err != nil {
-		return errors.New("failed to get signing payload: " + err.Error())
+		return fmt.Errorf("failed to get signing payload: %w", err)
 	}
 
 	// Verify the signature based on the key type
@@ -147,7 +148,7 @@ func VerifyMultiSignature(tx Transaction, lookup SignerListLookup) error {
 	}
 	signerList, err := lookup.GetSignerList(idAccount)
 	if err != nil {
-		return errors.New("failed to get signer list: " + err.Error())
+		return fmt.Errorf("failed to get signer list: %w", err)
 	}
 	if signerList == nil {
 		return ErrNotMultiSigning
@@ -173,7 +174,7 @@ func VerifyMultiSignature(tx Transaction, lookup SignerListLookup) error {
 	// Each signer signs a different message (transaction + their account ID suffix)
 	txMap, err := tx.Flatten()
 	if err != nil {
-		return errors.New("failed to flatten transaction: " + err.Error())
+		return fmt.Errorf("failed to flatten transaction: %w", err)
 	}
 
 	// Verify signers are sorted by binary AccountID (required by XRPL).
@@ -278,7 +279,7 @@ func VerifyMultiSignature(tx Transaction, lookup SignerListLookup) error {
 		// Get the multi-signing payload for this specific signer
 		signingPayload, err := binarycodec.EncodeForMultisigning(copyMap(txMap), txSignerAccount)
 		if err != nil {
-			return errors.New("failed to encode for multi-signing: " + err.Error())
+			return fmt.Errorf("failed to encode for multi-signing: %w", err)
 		}
 
 		// Verify the signature
@@ -365,7 +366,7 @@ func SignTransaction(tx Transaction, privateKeyHex string) (string, error) {
 	// Get the signing payload
 	signingPayload, err := getSigningPayload(tx)
 	if err != nil {
-		return "", errors.New("failed to get signing payload: " + err.Error())
+		return "", fmt.Errorf("failed to get signing payload: %w", err)
 	}
 
 	// Decode the private key to determine the algorithm
@@ -394,7 +395,7 @@ func SignTransaction(tx Transaction, privateKeyHex string) (string, error) {
 		algo := ed25519.ED25519()
 		signature, err = algo.Sign(msgStr, privateKeyHex)
 		if err != nil {
-			return "", errors.New("ED25519 signing failed: " + err.Error())
+			return "", fmt.Errorf("ED25519 signing failed: %w", err)
 		}
 
 	case 0x00:
@@ -402,7 +403,7 @@ func SignTransaction(tx Transaction, privateKeyHex string) (string, error) {
 		algo := secp256k1.SECP256K1()
 		signature, err = algo.Sign(msgStr, privateKeyHex)
 		if err != nil {
-			return "", errors.New("SECP256K1 signing failed: " + err.Error())
+			return "", fmt.Errorf("SECP256K1 signing failed: %w", err)
 		}
 
 	default:
@@ -430,7 +431,7 @@ func CalculateMultiSigFee(baseFee uint64, numSigners int) uint64 {
 func CalculateMultiSigFeeDrops(baseFeeDrops string, numSigners int) (string, error) {
 	baseFee, err := strconv.ParseUint(baseFeeDrops, 10, 64)
 	if err != nil {
-		return "", errors.New("invalid base fee: " + err.Error())
+		return "", fmt.Errorf("invalid base fee: %w", err)
 	}
 
 	totalFee := CalculateMultiSigFee(baseFee, numSigners)
@@ -451,13 +452,13 @@ func SignTransactionForMultiSign(tx Transaction, signerAccount string, privateKe
 	// Flatten the transaction to a map
 	txMap, err := tx.Flatten()
 	if err != nil {
-		return "", errors.New("failed to flatten transaction: " + err.Error())
+		return "", fmt.Errorf("failed to flatten transaction: %w", err)
 	}
 
 	// Get the multi-signing payload for this specific signer
 	signingPayload, err := binarycodec.EncodeForMultisigning(txMap, signerAccount)
 	if err != nil {
-		return "", errors.New("failed to encode for multi-signing: " + err.Error())
+		return "", fmt.Errorf("failed to encode for multi-signing: %w", err)
 	}
 
 	// Decode the private key to determine the algorithm
@@ -486,7 +487,7 @@ func SignTransactionForMultiSign(tx Transaction, signerAccount string, privateKe
 		algo := ed25519.ED25519()
 		signature, err = algo.Sign(msgStr, privateKeyHex)
 		if err != nil {
-			return "", errors.New("ED25519 signing failed: " + err.Error())
+			return "", fmt.Errorf("ED25519 signing failed: %w", err)
 		}
 
 	case 0x00:
@@ -494,7 +495,7 @@ func SignTransactionForMultiSign(tx Transaction, signerAccount string, privateKe
 		algo := secp256k1.SECP256K1()
 		signature, err = algo.Sign(msgStr, privateKeyHex)
 		if err != nil {
-			return "", errors.New("SECP256K1 signing failed: " + err.Error())
+			return "", fmt.Errorf("SECP256K1 signing failed: %w", err)
 		}
 
 	default:
@@ -519,7 +520,7 @@ func AddMultiSigner(tx Transaction, account, publicKey, signature string) error 
 	// Decode the new signer's AccountID for binary comparison
 	newID, err := state.DecodeAccountID(account)
 	if err != nil {
-		return errors.New("invalid signer account: " + err.Error())
+		return fmt.Errorf("invalid signer account: %w", err)
 	}
 
 	// Create the new signer entry

--- a/storage/nodestore/kvstore_database.go
+++ b/storage/nodestore/kvstore_database.go
@@ -3,6 +3,7 @@ package nodestore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -75,7 +76,7 @@ func (d *KVDatabaseImpl) Store(ctx context.Context, node *Node) error {
 
 	encoded := encodeNodeData(node)
 	if err := d.store.Put(node.Hash[:], encoded); err != nil {
-		return errors.New("store failed: " + err.Error())
+		return fmt.Errorf("store failed: %w", err)
 	}
 
 	atomic.AddUint64(&d.stats.writes, 1)
@@ -127,7 +128,7 @@ func (d *KVDatabaseImpl) Fetch(ctx context.Context, hash Hash256) (*Node, error)
 			}
 			return nil, nil
 		}
-		return nil, errors.New("fetch failed: " + err.Error())
+		return nil, fmt.Errorf("fetch failed: %w", err)
 	}
 
 	node, err := decodeNodeData(hash, data)
@@ -188,11 +189,11 @@ func (d *KVDatabaseImpl) StoreBatch(ctx context.Context, nodes []*Node) error {
 		}
 		encoded := encodeNodeData(node)
 		if err := batch.Put(node.Hash[:], encoded); err != nil {
-			return errors.New("store batch failed: " + err.Error())
+			return fmt.Errorf("store batch failed: %w", err)
 		}
 	}
 	if err := batch.Write(); err != nil {
-		return errors.New("store batch commit failed: " + err.Error())
+		return fmt.Errorf("store batch commit failed: %w", err)
 	}
 
 	for _, node := range nodes {


### PR DESCRIPTION
Closes #182.

## Summary
- 187 sites across 51 files converted from `errors.New(\"msg: \" + err.Error())` to `fmt.Errorf(\"msg: %w\", err)`.
- RPC error wrappers (`types.RpcErrorXxx`, struct fields like `Message`, `EngineResultMessage`) take strings, so they use `fmt.Sprintf(\"%v\", err)` — `%w` adds nothing to a string-typed sink.
- `panic(\"msg: \" + err.Error())` calls left alone — panics propagate as `interface{}`, no error chain to preserve.

## Test plan
- [x] `just lint` — 0 issues
- [x] `just build`
- [x] `just test` — only pre-existing failures unrelated to this work, verified by stashing the diff and re-running on `main`