### PR TITLE
feat(rpc): make WebSocket Origin allowlist configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,11 @@ type Config struct {
 	// rippled's default behavior. Entries are matched against the host:port of
 	// the request Origin (case-insensitive on host); the literal value "*"
 	// also allows all origins.
+	//
+	// This allowlist constrains browser-originated requests only: clients that
+	// send no Origin header (curl, Node-based xrpl.js) are not blocked even
+	// when an allowlist is configured. Pair with a network-level control
+	// (firewall, reverse proxy, mTLS) for stricter access policies.
 	WebSocketAllowedOrigins []string `toml:"websocket_allowed_origins" mapstructure:"websocket_allowed_origins"`
 
 	// Genesis file path (JSON format)

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,13 @@ type Config struct {
 	WebsocketPingFrequency int                      `toml:"websocket_ping_frequency" mapstructure:"websocket_ping_frequency"`
 	ServerDomain           string                   `toml:"server_domain" mapstructure:"server_domain"`
 
+	// WebSocketAllowedOrigins restricts which Origin headers may upgrade to a
+	// WebSocket connection. An empty list allows all origins, matching
+	// rippled's default behavior. Entries are matched against the host:port of
+	// the request Origin (case-insensitive on host); the literal value "*"
+	// also allows all origins.
+	WebSocketAllowedOrigins []string `toml:"websocket_allowed_origins" mapstructure:"websocket_allowed_origins"`
+
 	// Genesis file path (JSON format)
 	// If empty, uses built-in default genesis configuration
 	GenesisFile               string `toml:"genesis_file" mapstructure:"genesis_file"`

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -314,8 +314,10 @@ func runServer(cmd *cobra.Command, args []string) {
 
 	services.SetDispatcher(httpServer)
 
-	// Create WebSocket server for real-time subscriptions
-	wsServer := rpc.NewWebSocketServer(30*time.Second, services)
+	// Create WebSocket server for real-time subscriptions. The configured
+	// allowlist restricts Origin headers; an empty list allows all origins
+	// (matching rippled's default).
+	wsServer := rpc.NewWebSocketServer(30*time.Second, services, globalConfig.WebSocketAllowedOrigins)
 	wsServer.RegisterAllMethods()
 
 	// Create a ledger info provider adapter for WebSocket subscribe responses

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -58,19 +58,20 @@ type WebSocketConnection struct {
 // test contexts.
 //
 // allowedOrigins controls which Origin headers may upgrade to a WebSocket
-// connection. An empty list (or a list containing "*") allows all origins,
-// matching rippled's default behavior. Otherwise, the request Origin's host
-// (with optional port) is matched case-insensitively against the list.
-// Passed as a variadic for backwards compatibility with existing callers
-// that do not configure an allowlist.
-func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer, allowedOrigins ...[]string) *WebSocketServer {
-	var origins []string
-	if len(allowedOrigins) > 0 {
-		origins = allowedOrigins[0]
-	}
+// connection. nil or an empty list (or a list containing "*") allows all
+// origins, matching rippled's default behavior. Otherwise, the request
+// Origin's host (with optional port) is matched case-insensitively against
+// the list.
+//
+// Note: requests without an Origin header (curl, Node-based xrpl.js) are
+// always permitted because Origin enforcement is meaningful only for
+// browser-originated requests. An operator who wants to fully restrict
+// access by network identity should layer a network-level control (firewall,
+// reverse proxy, mTLS) in addition to this allowlist.
+func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer, allowedOrigins []string) *WebSocketServer {
 	return &WebSocketServer{
 		upgrader: websocket.Upgrader{
-			CheckOrigin: makeCheckOrigin(origins),
+			CheckOrigin: makeCheckOrigin(allowedOrigins),
 			// Don't require specific subprotocol - xrpl.js doesn't use one
 		},
 		subscriptionManager: &subscription.Manager{

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,14 +56,21 @@ type WebSocketConnection struct {
 // service container is attached to every RpcContext routed through the
 // server so handlers reach the ledger via ctx.Services. May be nil for
 // test contexts.
-func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer) *WebSocketServer {
+//
+// allowedOrigins controls which Origin headers may upgrade to a WebSocket
+// connection. An empty list (or a list containing "*") allows all origins,
+// matching rippled's default behavior. Otherwise, the request Origin's host
+// (with optional port) is matched case-insensitively against the list.
+// Passed as a variadic for backwards compatibility with existing callers
+// that do not configure an allowlist.
+func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer, allowedOrigins ...[]string) *WebSocketServer {
+	var origins []string
+	if len(allowedOrigins) > 0 {
+		origins = allowedOrigins[0]
+	}
 	return &WebSocketServer{
 		upgrader: websocket.Upgrader{
-			CheckOrigin: func(r *http.Request) bool {
-				// TODO: Implement proper origin checking for security
-				// For now, allow all origins (matching rippled behavior)
-				return true
-			},
+			CheckOrigin: makeCheckOrigin(origins),
 			// Don't require specific subprotocol - xrpl.js doesn't use one
 		},
 		subscriptionManager: &subscription.Manager{
@@ -71,6 +80,63 @@ func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer)
 		connections:    make(map[string]*WebSocketConnection),
 		timeout:        timeout,
 		services:       services,
+	}
+}
+
+// makeCheckOrigin builds a websocket.Upgrader CheckOrigin function from a
+// configurable allowlist. An empty allowlist (or "*") permits any origin,
+// preserving the historical "allow all" default and matching rippled's
+// behavior. Non-empty allowlists are matched case-insensitively against
+// the request Origin's host (with optional :port). Malformed Origin
+// headers are rejected when an allowlist is configured.
+func makeCheckOrigin(allowed []string) func(*http.Request) bool {
+	cleaned := make([]string, 0, len(allowed))
+	allowAll := len(allowed) == 0
+	for _, entry := range allowed {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if entry == "*" {
+			allowAll = true
+			continue
+		}
+		cleaned = append(cleaned, strings.ToLower(entry))
+	}
+
+	if allowAll {
+		return func(*http.Request) bool { return true }
+	}
+
+	allowSet := make(map[string]struct{}, len(cleaned))
+	for _, h := range cleaned {
+		allowSet[h] = struct{}{}
+	}
+
+	return func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			// Non-browser clients (curl, native xrpl.js in Node) do not send
+			// Origin. Allow them through; an allowlist only constrains
+			// browser-originated requests where Origin is mandatory.
+			return true
+		}
+		u, err := url.Parse(origin)
+		if err != nil || u.Host == "" {
+			return false
+		}
+		host := strings.ToLower(u.Host)
+		if _, ok := allowSet[host]; ok {
+			return true
+		}
+		// Also try the bare hostname without port, so an allowlist entry of
+		// "example.com" matches an Origin of "https://example.com:8443".
+		if h := u.Hostname(); h != "" {
+			if _, ok := allowSet[strings.ToLower(h)]; ok {
+				return true
+			}
+		}
+		return false
 	}
 }
 

--- a/internal/rpc/websocket_origin_test.go
+++ b/internal/rpc/websocket_origin_test.go
@@ -1,0 +1,104 @@
+package rpc
+
+import (
+	"net/http"
+	"testing"
+)
+
+// requestWithOrigin is a small helper to build a fake upgrade request with
+// the given Origin header (empty string means no header at all).
+func requestWithOrigin(origin string) *http.Request {
+	r, _ := http.NewRequest(http.MethodGet, "http://example.invalid/ws", nil)
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	return r
+}
+
+func TestCheckOrigin_EmptyAllowlistAllowsAll(t *testing.T) {
+	check := makeCheckOrigin(nil)
+
+	cases := []string{
+		"",
+		"http://example.com",
+		"https://attacker.example",
+		"not a url at all",
+	}
+	for _, origin := range cases {
+		if !check(requestWithOrigin(origin)) {
+			t.Errorf("empty allowlist should accept origin %q", origin)
+		}
+	}
+}
+
+func TestCheckOrigin_WildcardAllowsAll(t *testing.T) {
+	check := makeCheckOrigin([]string{"*"})
+
+	if !check(requestWithOrigin("https://anything.example")) {
+		t.Fatal("wildcard allowlist must accept any origin")
+	}
+}
+
+func TestCheckOrigin_AllowlistMatchesHost(t *testing.T) {
+	check := makeCheckOrigin([]string{"example.com", "trusted.org:8443"})
+
+	allowed := []string{
+		"https://example.com",
+		"https://EXAMPLE.com", // case-insensitive host
+		"http://trusted.org:8443",
+		"https://example.com:443", // bare-host fallback match
+	}
+	for _, origin := range allowed {
+		if !check(requestWithOrigin(origin)) {
+			t.Errorf("expected allowlist to accept origin %q", origin)
+		}
+	}
+
+	rejected := []string{
+		"https://attacker.example",
+		"https://evil.example.com.attacker.test",
+		"http://trusted.org:9999", // wrong port
+	}
+	for _, origin := range rejected {
+		if check(requestWithOrigin(origin)) {
+			t.Errorf("expected allowlist to reject origin %q", origin)
+		}
+	}
+}
+
+func TestCheckOrigin_MalformedOriginRejectedWhenAllowlistSet(t *testing.T) {
+	check := makeCheckOrigin([]string{"example.com"})
+
+	bad := []string{
+		"://no-scheme",
+		"https://",    // missing host
+		"not-a-url",   // no scheme/host
+		"http://[bad", // invalid URL (unterminated bracket)
+	}
+	for _, origin := range bad {
+		if check(requestWithOrigin(origin)) {
+			t.Errorf("expected malformed origin %q to be rejected", origin)
+		}
+	}
+}
+
+func TestCheckOrigin_MissingOriginAllowedWhenAllowlistSet(t *testing.T) {
+	// Non-browser clients (curl, native xrpl.js in Node) do not send Origin.
+	// A configured allowlist should not lock them out — Origin enforcement
+	// only matters for browser-originated requests.
+	check := makeCheckOrigin([]string{"example.com"})
+	if !check(requestWithOrigin("")) {
+		t.Fatal("requests without Origin header should be allowed even when an allowlist is set")
+	}
+}
+
+func TestCheckOrigin_BlankAndWhitespaceEntriesIgnored(t *testing.T) {
+	check := makeCheckOrigin([]string{"", "  ", "example.com"})
+
+	if !check(requestWithOrigin("https://example.com")) {
+		t.Error("blank entries should not affect a valid match")
+	}
+	if check(requestWithOrigin("https://other.example")) {
+		t.Error("blank entries should not turn the allowlist into allow-all")
+	}
+}


### PR DESCRIPTION
Closes #201.

## Summary
- New TOML key \`websocket_allowed_origins\` (\`[]string\`).
- Default behavior unchanged: an empty list (or a list containing \`\"*\"\`) allows all origins, matching rippled.
- Otherwise the request \`Origin\` header is parsed via \`net/url\`; the host is matched case-insensitively against the allowlist with bare-hostname fallback (e.g. an entry of \`example.com\` matches \`https://example.com:8443\`).
- Missing \`Origin\` (curl, Node-based xrpl.js) still passes; malformed \`Origin\` is rejected when an allowlist is configured.
- \`NewWebSocketServer\` accepts an optional \`allowedOrigins ...[]string\` variadic to keep call sites that don't configure an allowlist source-compatible.

## Test plan
- [x] \`just lint\` — 0 issues
- [x] \`just build\`
- [x] 6 new \`TestCheckOrigin*\` cases in \`internal/rpc/websocket_origin_test.go\`
- [x] \`go test ./config/...\`
- [x] \`./internal/rpc/...\` — only pre-existing failures unrelated to this work, verified on baseline