### PR TITLE
fix(payment): propagate Update error in PaymentSandbox.ApplyToView

### DIFF
--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -775,7 +775,7 @@ func (s *PaymentSandbox) ApplyToView(view tx.LedgerView) error {
 	for key := range s.deletions {
 		if finalState := s.getDeletedFinalState(key); finalState != nil {
 			if err := view.Update(keylet.Keylet{Key: key}, finalState); err != nil {
-				_ = err
+				return err
 			}
 		}
 		if err := view.Erase(keylet.Keylet{Key: key}); err != nil {


### PR DESCRIPTION
Closes #184.

## Summary
- `internal/tx/payment/sandbox.go:778` — replaced \`_ = err\` with \`return err\`, matching the surrounding Update/Erase convention on lines 781-797.
- The two \`internal/tx/engine.go\` sites listed in the issue (lines 1744, 1910) were already addressed by the recent engine refactor — engine.go is now 302 lines and the affected code lives in \`internal/tx/apply.go\` / \`internal/tx/do_apply.go\`, where it returns \`TefINTERNAL\` instead of silencing the error.
- Other \`_ = ...\` discards reviewed and intentionally left:
  - \`internal/tx/do_apply.go:524\` — \`_ = violation // logged in future via journal\`
  - Cleanup paths in \`engine.go\` and \`do_apply.go\` (function-call discards, not silent-error-dismissal)
  - \`internal/tx/payment/pathfinder/ripple_line_cache.go:141\` — best-effort cache, callback returns nil for unreadable entries by design

## Test plan
- [x] \`just lint\` — 0 issues
- [x] \`just build\`
- [x] \`just test-pkg ./internal/tx/payment/...\`
- [x] \`just test-pkg ./internal/tx/...\` — only pre-existing failures unrelated to this work