### PR TITLE
style(codec): standardize error message formatting

### DIFF
--- a/codec/binarycodec/codec.go
+++ b/codec/binarycodec/codec.go
@@ -13,19 +13,19 @@ import (
 )
 
 var (
-	// ErrSigningClaimFieldNotFound is returned when the 'Channel' & 'Amount' fields are both required, but were not found.
-	ErrSigningClaimFieldNotFound = errors.New("'Channel' & 'Amount' fields are both required, but were not found")
-	// ErrBatchFlagsFieldNotFound is returned when the 'flags' field is missing.
-	ErrBatchFlagsFieldNotFound = errors.New("no field `flags`")
-	// ErrBatchTxIDsFieldNotFound is returned when the 'txIDs' field is missing.
-	ErrBatchTxIDsFieldNotFound = errors.New("no field `txIDs`")
-	// ErrBatchTxIDsNotArray is returned when the 'txIDs' field is not an array.
+	// ErrSigningClaimFieldNotFound is returned when the channel and amount fields are not both present.
+	ErrSigningClaimFieldNotFound = errors.New("channel and amount fields are required")
+	// ErrBatchFlagsFieldNotFound is returned when the flags field is missing.
+	ErrBatchFlagsFieldNotFound = errors.New("missing flags field")
+	// ErrBatchTxIDsFieldNotFound is returned when the txIDs field is missing.
+	ErrBatchTxIDsFieldNotFound = errors.New("missing txIDs field")
+	// ErrBatchTxIDsNotArray is returned when the txIDs field is not an array.
 	ErrBatchTxIDsNotArray = errors.New("txIDs field must be an array")
 	// ErrBatchTxIDNotString is returned when a txID is not a string.
 	ErrBatchTxIDNotString = errors.New("each txID must be a string")
-	// ErrBatchFlagsNotUInt32 is returned when the 'flags' field is not a uint32.
+	// ErrBatchFlagsNotUInt32 is returned when the flags field is not a uint32.
 	ErrBatchFlagsNotUInt32 = errors.New("flags field must be a uint32")
-	// ErrBatchTxIDsLengthTooLong is returned when the 'txIDs' field is too long.
+	// ErrBatchTxIDsLengthTooLong is returned when the txIDs field is too long.
 	ErrBatchTxIDsLengthTooLong = errors.New("txIDs length exceeds maximum uint32 value")
 )
 

--- a/codec/binarycodec/types/pathset.go
+++ b/codec/binarycodec/types/pathset.go
@@ -29,7 +29,7 @@ func serializePathCurrency(currency string) ([]byte, error) {
 type PathSet struct{}
 
 // ErrInvalidPathSet is an error that's thrown when an invalid path set is provided.
-var ErrInvalidPathSet = errors.New("invalid type to construct PathSet from. Expected []any of []any")
+var ErrInvalidPathSet = errors.New("invalid path set: expected [][]any")
 
 // FromJSON attempts to serialize a path set from a JSON representation of a slice of paths to a byte array.
 // It returns the byte array representation of the path set, or an error if the provided json does not represent a valid path set.
@@ -73,7 +73,7 @@ func (p PathSet) ToJSON(parser interfaces.BinaryParser, _ ...int) (any, error) {
 			for i, step := range path {
 				stepMap, ok := step.(map[string]any)
 				if !ok {
-					return nil, fmt.Errorf("step is not of type map[string]any")
+					return nil, errors.New("step is not of type map[string]any")
 				}
 				// Calculate type by combining flags
 				stepType := 0

--- a/codec/binarycodec/types/st_array.go
+++ b/codec/binarycodec/types/st_array.go
@@ -20,7 +20,7 @@ const (
 type STArray struct{}
 
 // ErrNotSTObjectInSTArray is returned when a non-STObject value is found in an STArray.
-var ErrNotSTObjectInSTArray = errors.New("not STObject in STArray. Array fields must be STObjects")
+var ErrNotSTObjectInSTArray = errors.New("STArray fields must be STObjects")
 
 // FromJSON is a method that takes a JSON value (which should be a slice of JSON objects),
 // and converts it to a byte slice, representing the serialized form of the STArray.

--- a/codec/binarycodec/types/uint64.go
+++ b/codec/binarycodec/types/uint64.go
@@ -15,7 +15,7 @@ import (
 type UInt64 struct{}
 
 // ErrInvalidUInt64String is returned when a value is not a valid string representation of a UInt64.
-var ErrInvalidUInt64String = errors.New("invalid UInt64 string, value should be a string representation of a UInt64")
+var ErrInvalidUInt64String = errors.New("invalid UInt64 value")
 
 // FromJSON converts a JSON value into a serialized byte slice representing a 64-bit unsigned integer.
 // Accepts either a hex string (e.g. "2E4" for 740) or a numeric value (float64, int, int64, uint64).


### PR DESCRIPTION
## Summary
- 4 files, ~10 error strings normalized to lowercase / no trailing period / concise wording.
- All test sites assert against the sentinel variable, so no test updates were needed.
- Type/identifier names (STObject, STArray, Currency, Issue, etc.) were intentionally preserved.

## Test plan
- [x] `go test ./codec/binarycodec/...` PASS (only pre-existing XRP-amount validation failures reproduce on `origin/main`)

Closes #200