### PR TITLE
perf(shamap): replace random eviction with LRU in FullBelowCache

### DIFF
--- a/shamap/cache.go
+++ b/shamap/cache.go
@@ -160,16 +160,21 @@ func (c *TreeNodeCache) Contains(hash [32]byte) bool {
 // When a subtree is marked as "full", we know all its nodes are present locally,
 // which allows skipping sync checks for that entire subtree.
 // This significantly improves sync performance for large trees.
+//
+// The cache uses an LRU eviction policy: when at capacity, the least
+// recently touched entry is evicted. Both reads (IsFull) and writes
+// (MarkFull, Touch) update recency.
 type FullBelowCache struct {
-	mu      sync.RWMutex
-	fullSet map[[32]byte]struct{}
+	mu      sync.Mutex
 	maxSize int
+	fullSet map[[32]byte]*list.Element
+	lruList *list.List
 }
 
 // NewFullBelowCache creates a new FullBelowCache.
 //
 // Parameters:
-//   - maxSize: maximum number of hashes to track (0 = unlimited, use with caution)
+//   - maxSize: maximum number of hashes to track (0 = use default size)
 //
 // Returns a new FullBelowCache instance.
 func NewFullBelowCache(maxSize int) *FullBelowCache {
@@ -178,53 +183,62 @@ func NewFullBelowCache(maxSize int) *FullBelowCache {
 	}
 
 	return &FullBelowCache{
-		fullSet: make(map[[32]byte]struct{}, maxSize),
+		fullSet: make(map[[32]byte]*list.Element, maxSize),
+		lruList: list.New(),
 		maxSize: maxSize,
 	}
 }
 
 // IsFull returns true if the subtree rooted at the given hash is fully synced.
+// On a hit, the entry is moved to the front of the LRU list (touched).
 func (c *FullBelowCache) IsFull(hash [32]byte) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	_, found := c.fullSet[hash]
-	return found
+	elem, found := c.fullSet[hash]
+	if !found {
+		return false
+	}
+	c.lruList.MoveToFront(elem)
+	return true
 }
 
 // MarkFull marks the subtree rooted at the given hash as fully synced.
-// If the cache is full, older entries may be evicted (FIFO-like behavior).
+// If the cache is at capacity, the least recently used entry is evicted.
+// If the hash is already present, it is moved to the front of the LRU list.
 func (c *FullBelowCache) MarkFull(hash [32]byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if _, found := c.fullSet[hash]; found {
+	c.markFullLocked(hash)
+}
+
+// markFullLocked inserts hash into the cache or refreshes its recency.
+// Caller must hold c.mu.
+func (c *FullBelowCache) markFullLocked(hash [32]byte) {
+	if elem, found := c.fullSet[hash]; found {
+		c.lruList.MoveToFront(elem)
 		return
 	}
 
-	// Simple eviction strategy: if at max size, clear half the cache
-	// This is a simplistic approach; a more sophisticated implementation
-	// would use generational tracking or LRU
-	if len(c.fullSet) >= c.maxSize {
-		c.evictHalf()
+	for c.lruList.Len() >= c.maxSize {
+		c.evictOldestLocked()
 	}
 
-	c.fullSet[hash] = struct{}{}
+	elem := c.lruList.PushFront(hash)
+	c.fullSet[hash] = elem
 }
 
-// evictHalf removes approximately half of the entries.
-// Caller must hold the write lock.
-func (c *FullBelowCache) evictHalf() {
-	target := len(c.fullSet) / 2
-	count := 0
-
-	for hash := range c.fullSet {
-		if count >= target {
-			break
-		}
-		delete(c.fullSet, hash)
-		count++
+// evictOldestLocked removes the least recently used entry.
+// Caller must hold c.mu.
+func (c *FullBelowCache) evictOldestLocked() {
+	elem := c.lruList.Back()
+	if elem == nil {
+		return
 	}
+	hash := elem.Value.([32]byte)
+	c.lruList.Remove(elem)
+	delete(c.fullSet, hash)
 }
 
 // Unmark removes the full marking for a hash.
@@ -232,21 +246,26 @@ func (c *FullBelowCache) evictHalf() {
 func (c *FullBelowCache) Unmark(hash [32]byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.fullSet, hash)
+
+	if elem, found := c.fullSet[hash]; found {
+		c.lruList.Remove(elem)
+		delete(c.fullSet, hash)
+	}
 }
 
 // Clear removes all entries from the cache.
 func (c *FullBelowCache) Clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.fullSet = make(map[[32]byte]struct{}, c.maxSize)
+	c.fullSet = make(map[[32]byte]*list.Element, c.maxSize)
+	c.lruList = list.New()
 }
 
 // Size returns the current number of entries in the cache.
 func (c *FullBelowCache) Size() int {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return len(c.fullSet)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lruList.Len()
 }
 
 // MaxSize returns the maximum capacity of the cache.
@@ -263,25 +282,28 @@ func (c *FullBelowCache) Reset(maxSize int) {
 		maxSize = 65536
 	}
 
-	c.fullSet = make(map[[32]byte]struct{}, maxSize)
+	c.fullSet = make(map[[32]byte]*list.Element, maxSize)
+	c.lruList = list.New()
 	c.maxSize = maxSize
 }
 
 // GetAllFull returns a copy of all hashes currently marked as full.
 // This is useful for debugging or persisting cache state.
+// Order is not guaranteed and this method does not affect LRU recency.
 func (c *FullBelowCache) GetAllFull() [][32]byte {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	result := make([][32]byte, 0, len(c.fullSet))
-	for hash := range c.fullSet {
-		result = append(result, hash)
+	result := make([][32]byte, 0, c.lruList.Len())
+	for elem := c.lruList.Front(); elem != nil; elem = elem.Next() {
+		result = append(result, elem.Value.([32]byte))
 	}
 	return result
 }
 
 // Touch marks a hash as full if and only if all its children are also full.
 // This is used to propagate "fullness" up the tree during sync.
+// Looking up children also refreshes their LRU recency.
 //
 // Parameters:
 //   - hash: the hash to potentially mark
@@ -292,20 +314,19 @@ func (c *FullBelowCache) Touch(hash [32]byte, childHashes [][32]byte) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if _, found := c.fullSet[hash]; found {
+	if elem, found := c.fullSet[hash]; found {
+		c.lruList.MoveToFront(elem)
 		return true
 	}
 
 	for _, childHash := range childHashes {
-		if _, found := c.fullSet[childHash]; !found {
+		elem, found := c.fullSet[childHash]
+		if !found {
 			return false
 		}
+		c.lruList.MoveToFront(elem)
 	}
 
-	// All children are full, mark this node as full
-	if len(c.fullSet) >= c.maxSize {
-		c.evictHalf()
-	}
-	c.fullSet[hash] = struct{}{}
+	c.markFullLocked(hash)
 	return true
 }

--- a/shamap/cache_test.go
+++ b/shamap/cache_test.go
@@ -375,7 +375,7 @@ func TestFullBelowCache(t *testing.T) {
 	t.Run("EvictionOnOverflow", func(t *testing.T) {
 		cache := NewFullBelowCache(10)
 
-		// Fill the cache
+		// Fill the cache.
 		for i := byte(0); i < 10; i++ {
 			cache.MarkFull([32]byte{i})
 		}
@@ -384,12 +384,83 @@ func TestFullBelowCache(t *testing.T) {
 			t.Errorf("Cache size should be 10, got %d", cache.Size())
 		}
 
-		// Add one more - should trigger eviction
+		// Add one more - should trigger LRU eviction of the oldest entry.
 		cache.MarkFull([32]byte{100})
 
-		// Size should be around 5-6 after evicting half
-		if cache.Size() > 6 {
-			t.Errorf("Cache size should be reduced after eviction, got %d", cache.Size())
+		if cache.Size() != 10 {
+			t.Errorf("Cache size should remain at 10 after LRU eviction, got %d", cache.Size())
+		}
+
+		// The first inserted hash should have been evicted.
+		if cache.IsFull([32]byte{0}) {
+			t.Error("Oldest entry should have been evicted by LRU policy")
+		}
+
+		// The newly inserted hash and the most recently inserted ones should remain.
+		if !cache.IsFull([32]byte{100}) {
+			t.Error("Newly inserted entry should be present")
+		}
+		if !cache.IsFull([32]byte{9}) {
+			t.Error("Most recent pre-overflow entry should still be present")
+		}
+	})
+
+	t.Run("LRUTouchOnRead", func(t *testing.T) {
+		cache := NewFullBelowCache(10)
+
+		// Fill the cache.
+		for i := byte(0); i < 10; i++ {
+			cache.MarkFull([32]byte{i})
+		}
+
+		// Touch the oldest entry via IsFull so it becomes the most recently used.
+		if !cache.IsFull([32]byte{0}) {
+			t.Fatal("hash 0 should be present before touch")
+		}
+
+		// Insert a new entry forcing eviction; the touched entry must survive
+		// and the next-oldest (hash 1) must be evicted.
+		cache.MarkFull([32]byte{200})
+
+		if !cache.IsFull([32]byte{0}) {
+			t.Error("Touched entry (hash 0) should survive eviction")
+		}
+		if cache.IsFull([32]byte{1}) {
+			t.Error("Hash 1 should have been evicted after hash 0 was touched")
+		}
+	})
+
+	t.Run("LRUEvictsLeastRecentlyUsed", func(t *testing.T) {
+		cache := NewFullBelowCache(100)
+
+		// Insert 100 distinct hashes.
+		for i := 0; i < 100; i++ {
+			var h [32]byte
+			h[0] = byte(i)
+			h[1] = byte(i >> 8)
+			cache.MarkFull(h)
+		}
+
+		// Touch a known one so it becomes the most recently used.
+		var keep [32]byte
+		keep[0] = 42
+		if !cache.IsFull(keep) {
+			t.Fatal("expected keep entry to be present before touch")
+		}
+
+		// Trigger 50 evictions by inserting fresh entries.
+		for i := 0; i < 50; i++ {
+			var h [32]byte
+			h[0] = byte(200 + i)
+			cache.MarkFull(h)
+		}
+
+		if cache.Size() != 100 {
+			t.Errorf("size should remain at maxSize=100, got %d", cache.Size())
+		}
+
+		if !cache.IsFull(keep) {
+			t.Error("touched entry should survive 50 evictions under LRU policy")
 		}
 	})
 


### PR DESCRIPTION
## Summary
- `container/list` + map-of-elements LRU, mirroring the existing `TreeNodeCache` pattern in the same file.
- Reads (`IsFull`/`Touch`) now refresh recency.
- Eviction removes the single oldest entry, not half the map.
- Switched `sync.RWMutex` → `sync.Mutex` since reads now mutate.

## Test plan
- [x] `go test ./shamap/...` PASS (14/14 `TestFullBelowCache` subtests, plus 2 new `LRUTouchOnRead` and `LRUEvictsLeastRecentlyUsed` cases)

Closes #195