### PR TITLE
peermanagement: enforce per-peer ping-timeout disconnect (#315)

### DIFF
--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -15,6 +15,7 @@ var (
 	ErrSelfConnection     = errors.New("cannot connect to self")
 	ErrSlotUnavailable    = errors.New("no connection slot available")
 	ErrConnectionClosed   = errors.New("connection closed")
+	ErrPingTimeout        = errors.New("peer ping timeout")
 
 	// Handshake errors
 	ErrHandshakeFailed  = errors.New("handshake failed")

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -236,6 +236,13 @@ type Overlay struct {
 	// droppedMessages so the two traffic classes can be distinguished.
 	droppedLedgerResponses atomic.Uint64
 
+	// pingTimeoutDisconnects counts peers torn down because pingLoop's
+	// oldest in-flight ping aged past pingTimeout (peer.go runPingTick).
+	// Mirrors rippled's fail("Ping Timeout") at PeerImp.cpp:731-736.
+	// Surfaced via PingTimeoutDisconnects() so operators can distinguish
+	// silent-peer eviction from other connection-error counters.
+	pingTimeoutDisconnects atomic.Uint64
+
 	// Network
 	listener net.Listener
 
@@ -747,6 +754,9 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 		err := peer.Run(ctx)
 		if err != nil {
 			slog.Info("Inbound peer run ended", "t", "Overlay", "remote", remoteAddr, "err", err)
+			if errors.Is(err, ErrPingTimeout) {
+				o.pingTimeoutDisconnects.Add(1)
+			}
 		}
 		o.removePeer(peerID)
 	}()
@@ -1083,6 +1093,14 @@ func (o *Overlay) onMessageReceived(evt Event) {
 // router/engine can't keep up with network ingress.
 func (o *Overlay) DroppedMessages() uint64 {
 	return o.droppedMessages.Load()
+}
+
+// PingTimeoutDisconnects returns the cumulative count of peers torn
+// down because they failed to answer pings within pingTimeout. A
+// nonzero, growing value flags either a flaky network or peers that
+// have stopped servicing the overlay protocol.
+func (o *Overlay) PingTimeoutDisconnects() uint64 {
+	return o.pingTimeoutDisconnects.Load()
 }
 
 // DroppedLedgerResponses returns the cumulative count of ledger-sync

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -754,9 +754,7 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 		err := peer.Run(ctx)
 		if err != nil {
 			slog.Info("Inbound peer run ended", "t", "Overlay", "remote", remoteAddr, "err", err)
-			if errors.Is(err, ErrPingTimeout) {
-				o.pingTimeoutDisconnects.Add(1)
-			}
+			o.notePeerRunEnded(err)
 		}
 		o.removePeer(peerID)
 	}()
@@ -1101,6 +1099,16 @@ func (o *Overlay) DroppedMessages() uint64 {
 // have stopped servicing the overlay protocol.
 func (o *Overlay) PingTimeoutDisconnects() uint64 {
 	return o.pingTimeoutDisconnects.Load()
+}
+
+// notePeerRunEnded centralises post-Run accounting shared between the
+// inbound and outbound peer goroutines so a future error class (e.g.
+// a "Not useful" tracking-divergence eviction, mirroring rippled's
+// PeerImp::onTimer at PeerImp.cpp:711-728) is wired in once.
+func (o *Overlay) notePeerRunEnded(err error) {
+	if errors.Is(err, ErrPingTimeout) {
+		o.pingTimeoutDisconnects.Add(1)
+	}
 }
 
 // DroppedLedgerResponses returns the cumulative count of ledger-sync
@@ -1628,6 +1636,7 @@ func (o *Overlay) Connect(addr string) error {
 		err := peer.Run(o.ctx)
 		if err != nil {
 			slog.Info("Peer run ended", "t", "Overlay", "addr", addr, "err", err)
+			o.notePeerRunEnded(err)
 		}
 		o.removePeer(peerID)
 	}()

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -236,11 +236,9 @@ type Overlay struct {
 	// droppedMessages so the two traffic classes can be distinguished.
 	droppedLedgerResponses atomic.Uint64
 
-	// pingTimeoutDisconnects counts peers torn down because pingLoop's
-	// oldest in-flight ping aged past pingTimeout (peer.go runPingTick).
-	// Mirrors rippled's fail("Ping Timeout") at PeerImp.cpp:731-736.
-	// Surfaced via PingTimeoutDisconnects() so operators can distinguish
-	// silent-peer eviction from other connection-error counters.
+	// pingTimeoutDisconnects counts peers torn down because the oldest
+	// in-flight ping aged past pingTimeout. Mirrors rippled's
+	// fail("Ping Timeout") at PeerImp.cpp:731-736.
 	pingTimeoutDisconnects atomic.Uint64
 
 	// Network
@@ -1101,10 +1099,6 @@ func (o *Overlay) PingTimeoutDisconnects() uint64 {
 	return o.pingTimeoutDisconnects.Load()
 }
 
-// notePeerRunEnded centralises post-Run accounting shared between the
-// inbound and outbound peer goroutines so a future error class (e.g.
-// a "Not useful" tracking-divergence eviction, mirroring rippled's
-// PeerImp::onTimer at PeerImp.cpp:711-728) is wired in once.
 func (o *Overlay) notePeerRunEnded(err error) {
 	if errors.Is(err, ErrPingTimeout) {
 		o.pingTimeoutDisconnects.Add(1)

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -695,7 +695,25 @@ func (p *Peer) writeLoop(ctx context.Context) error {
 }
 
 func (p *Peer) pingLoop(ctx context.Context) error {
-	ticker := time.NewTicker(15 * time.Second)
+	// Delay the first probe by pingTimeout so the cold-start envelope
+	// matches rippled: first ping at t≈pingTimeout (PeerImp.cpp:61's
+	// setTimer + onTimer chain), first disconnect-on-silence at
+	// t≈2*pingTimeout. Without this delay, goXRPL's pingProbeInterval
+	// tick would send the first ping at t≈pingProbeInterval and evict
+	// a never-answering peer ~45s earlier than rippled.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.closeCh:
+		return nil
+	case <-time.After(pingTimeout):
+	}
+
+	if err := p.runPingTick(time.Now()); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(pingProbeInterval)
 	defer ticker.Stop()
 
 	for {
@@ -745,11 +763,25 @@ const (
 	// pingTimeout: disconnect when the oldest unanswered ping reaches
 	// this age. Mirrors rippled's PeerImp::onTimer "Already waiting for
 	// PONG → fail('Ping Timeout')" (PeerImp.cpp:731-736) with rippled's
-	// 60s peerTimerInterval (PeerImp.cpp:61). At the moment the
-	// disconnect fires, the unanswered ping's age is ≈60s in both
-	// implementations; the 15s tick only changes when goXRPL first
-	// probes a quiet peer (≈15s from connect, vs rippled's ≈60s).
+	// 60s peerTimerInterval (PeerImp.cpp:61). The disconnect criterion
+	// is the same in both implementations: an unanswered ping reaches
+	// age 60s.
+	//
+	// pingLoop also uses pingTimeout as the cold-start delay before
+	// the first probe. Together with pingProbeInterval-cadence ticks
+	// thereafter, this matches rippled's cold-start envelope (first
+	// ping at t≈pingTimeout, first disconnect-on-silence at
+	// t≈2*pingTimeout). Steady-state probing is finer in goXRPL
+	// (every pingProbeInterval) for better latency resolution; the
+	// OnPong sweep keeps the disconnect criterion equivalent under
+	// partial pong loss — see OnPong's doc.
 	pingTimeout = 60 * time.Second
+	// pingProbeInterval: cadence of pings after the first one.
+	// Finer than rippled's 60s peerTimerInterval for tighter latency
+	// estimation; multiple pings can be in flight concurrently and
+	// are coalesced by OnPong's sweep so the disconnect criterion
+	// remains "no pong for ≥pingTimeout".
+	pingProbeInterval = 15 * time.Second
 	// pingInFlightTTL bounds map growth between successful pongs. Set
 	// equal to pingTimeout so recordPingSent's GC sweep cannot evict
 	// an entry that staleInFlightPing would still treat as live: any

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -757,9 +757,14 @@ const (
 	// implementations; the 15s tick only changes when goXRPL first
 	// probes a quiet peer (≈15s from connect, vs rippled's ≈60s).
 	pingTimeout = 60 * time.Second
-	// pingInFlightTTL must be >= pingTimeout: recordPingSent's GC sweep
-	// runs after staleInFlightPing on each tick, so trimming earlier
-	// would evict the very entry the timeout check is about to flag.
+	// pingInFlightTTL bounds map growth between successful pongs. Set
+	// equal to pingTimeout so recordPingSent's GC sweep cannot evict
+	// an entry that staleInFlightPing would still treat as live: any
+	// entry with age < pingTimeout has age < pingInFlightTTL and is
+	// retained, while stale entries (age >= pingTimeout) trigger the
+	// disconnect on this tick before a future tick's GC could mask
+	// them. Any TTL smaller than pingTimeout would silently shrink
+	// the disconnect window.
 	pingInFlightTTL  = pingTimeout
 	pingsInFlightCap = 16
 )
@@ -840,6 +845,18 @@ func roundMillisHalfEven(d time.Duration) time.Duration {
 // the EWMA-smoothed latency. Mirrors PeerImp::onMessage(TMPing)
 // (PeerImp.cpp:1099-1118): rtt is rounded to ms, then smoothed at ms
 // granularity via latency = (latency*7 + rtt) / 8.
+//
+// A matching pong also evicts every pending entry sent at-or-before
+// the matched send-time. Rippled keeps a single in-flight ping
+// (PeerImp.h:115 `std::optional<uint32_t> lastPingSeq_`), so its 60s
+// ping-timeout fires only when the most-recent cycle goes
+// unanswered. goXRPL ticks at 15s and may queue several pings while
+// a pong is in transit; without this sweep, a peer that drops one
+// ping per 60s window but otherwise responds promptly would be
+// evicted by staleInFlightPing's oldest-wins check, while rippled
+// would keep it. Clearing older entries makes the disconnect
+// criterion "no pong for ≥pingTimeout" instead of "any single ping
+// ≥pingTimeout old", matching rippled's single-cycle semantics.
 func (p *Peer) OnPong(seq uint32, receivedAt time.Time) {
 	p.latencyMu.Lock()
 	defer p.latencyMu.Unlock()
@@ -848,6 +865,11 @@ func (p *Peer) OnPong(seq uint32, receivedAt time.Time) {
 		return
 	}
 	delete(p.pingsInFlight, seq)
+	for s, t := range p.pingsInFlight {
+		if !t.After(sentAt) {
+			delete(p.pingsInFlight, s)
+		}
+	}
 	rtt := roundMillisHalfEven(receivedAt.Sub(sentAt))
 	if !p.hasLatency {
 		p.latency = rtt

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -695,12 +695,9 @@ func (p *Peer) writeLoop(ctx context.Context) error {
 }
 
 func (p *Peer) pingLoop(ctx context.Context) error {
-	// Delay the first probe by pingTimeout so the cold-start envelope
-	// matches rippled: first ping at t≈pingTimeout (PeerImp.cpp:61's
-	// setTimer + onTimer chain), first disconnect-on-silence at
-	// t≈2*pingTimeout. Without this delay, goXRPL's pingProbeInterval
-	// tick would send the first ping at t≈pingProbeInterval and evict
-	// a never-answering peer ~45s earlier than rippled.
+	// First probe at t≈pingTimeout matches rippled's setTimer+onTimer
+	// envelope (PeerImp.cpp:61,690-748): disconnect-on-silence at
+	// t≈2*pingTimeout.
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -761,26 +758,14 @@ func (p *Peer) runPingTick(now time.Time) error {
 
 const (
 	// pingTimeout: disconnect when the oldest unanswered ping reaches
-	// this age. Mirrors rippled's PeerImp::onTimer "Already waiting for
-	// PONG → fail('Ping Timeout')" (PeerImp.cpp:731-736) with rippled's
-	// 60s peerTimerInterval (PeerImp.cpp:61). The disconnect criterion
-	// is the same in both implementations: an unanswered ping reaches
-	// age 60s.
-	//
-	// pingLoop also uses pingTimeout as the cold-start delay before
-	// the first probe. Together with pingProbeInterval-cadence ticks
-	// thereafter, this matches rippled's cold-start envelope (first
-	// ping at t≈pingTimeout, first disconnect-on-silence at
-	// t≈2*pingTimeout). Steady-state probing is finer in goXRPL
-	// (every pingProbeInterval) for better latency resolution; the
-	// OnPong sweep keeps the disconnect criterion equivalent under
-	// partial pong loss — see OnPong's doc.
+	// this age, and the cold-start delay before pingLoop's first
+	// probe. Mirrors rippled's peerTimerInterval (PeerImp.cpp:61) and
+	// the fail("Ping Timeout") branch at PeerImp.cpp:731-736.
 	pingTimeout = 60 * time.Second
-	// pingProbeInterval: cadence of pings after the first one.
-	// Finer than rippled's 60s peerTimerInterval for tighter latency
-	// estimation; multiple pings can be in flight concurrently and
-	// are coalesced by OnPong's sweep so the disconnect criterion
-	// remains "no pong for ≥pingTimeout".
+	// pingProbeInterval: cadence after the first probe. Finer than
+	// rippled's 60s peerTimerInterval; OnPong's sweep coalesces
+	// concurrent in-flight pings so the disconnect criterion stays
+	// "no pong for ≥pingTimeout".
 	pingProbeInterval = 15 * time.Second
 	// pingInFlightTTL bounds map growth between successful pongs. Set
 	// equal to pingTimeout so recordPingSent's GC sweep cannot evict

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -705,34 +705,47 @@ func (p *Peer) pingLoop(ctx context.Context) error {
 		case <-p.closeCh:
 			return nil
 		case <-ticker.C:
-			now := time.Now()
-			if seq, age, ok := p.staleInFlightPing(now, pingTimeout); ok {
-				slog.Warn("peer ping timeout",
-					"t", "Peer", "peer", p.id,
-					"endpoint", p.endpoint.String(),
-					"seq", seq, "age", age,
-				)
-				return ErrPingTimeout
-			}
-			seq := uint32(now.UnixMilli())
-			ping := &message.Ping{
-				PType: message.PingTypePing,
-				Seq:   seq,
-			}
-			encoded, err := message.Encode(ping)
-			if err != nil {
-				continue
-			}
-			wireMsg, err := message.BuildWireMessage(message.TypePing, encoded)
-			if err != nil {
-				continue
-			}
-			p.recordPingSent(seq, now)
-			if err := p.Send(wireMsg); err != nil {
+			if err := p.runPingTick(time.Now()); err != nil {
 				return err
 			}
 		}
 	}
+}
+
+// runPingTick performs the per-tick body of pingLoop. Returns
+// ErrPingTimeout when the oldest in-flight ping has reached
+// pingTimeout, the Send error when the new ping cannot be queued,
+// or nil when the ping was sent (or this tick was skipped due to
+// an encoding hiccup). Extracted from pingLoop so the timeout
+// path is exercisable without driving a real ticker, locking the
+// stale-check-before-record ordering required for correctness.
+func (p *Peer) runPingTick(now time.Time) error {
+	if seq, age, ok := p.staleInFlightPing(now, pingTimeout); ok {
+		slog.Warn("peer ping timeout",
+			"t", "Peer", "peer", p.id,
+			"endpoint", p.endpoint.String(),
+			"seq", seq, "age", age,
+		)
+		return ErrPingTimeout
+	}
+	seq := uint32(now.UnixMilli())
+	ping := &message.Ping{
+		PType: message.PingTypePing,
+		Seq:   seq,
+	}
+	encoded, err := message.Encode(ping)
+	if err != nil {
+		return nil
+	}
+	wireMsg, err := message.BuildWireMessage(message.TypePing, encoded)
+	if err != nil {
+		return nil
+	}
+	p.recordPingSent(seq, now)
+	if err := p.Send(wireMsg); err != nil {
+		return err
+	}
+	return nil
 }
 
 const (

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -712,13 +712,6 @@ func (p *Peer) pingLoop(ctx context.Context) error {
 	}
 }
 
-// runPingTick performs the per-tick body of pingLoop. Returns
-// ErrPingTimeout when the oldest in-flight ping has reached
-// pingTimeout, the Send error when the new ping cannot be queued,
-// or nil when the ping was sent (or this tick was skipped due to
-// an encoding hiccup). Extracted from pingLoop so the timeout
-// path is exercisable without driving a real ticker, locking the
-// stale-check-before-record ordering required for correctness.
 func (p *Peer) runPingTick(now time.Time) error {
 	if seq, age, ok := p.staleInFlightPing(now, pingTimeout); ok {
 		slog.Warn("peer ping timeout",
@@ -769,9 +762,6 @@ const (
 	pingsInFlightCap = 16
 )
 
-// staleInFlightPing returns the oldest in-flight ping whose age has
-// reached threshold. Pure read against the pingsInFlight map for
-// testability.
 func (p *Peer) staleInFlightPing(now time.Time, threshold time.Duration) (seq uint32, age time.Duration, ok bool) {
 	p.latencyMu.RLock()
 	defer p.latencyMu.RUnlock()

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -736,18 +736,23 @@ func (p *Peer) pingLoop(ctx context.Context) error {
 }
 
 const (
-	pingInFlightTTL  = 30 * time.Second
-	pingsInFlightCap = 16
 	// pingTimeout: disconnect when the oldest unanswered ping reaches
 	// this age. Mirrors rippled's PeerImp::onTimer "Already waiting for
-	// PONG → fail('Ping Timeout')" (PeerImp.cpp:731-736); rippled's
-	// timer fires every 60s so a single missed cycle drops the peer.
-	// goXRPL pings every 15s, so 30s = ~2 cycles of grace.
-	pingTimeout = 30 * time.Second
+	// PONG → fail('Ping Timeout')" (PeerImp.cpp:731-736) with rippled's
+	// 60s peerTimerInterval (PeerImp.cpp:61) — a single missed cycle
+	// drops the peer. goXRPL's 15s ticker means actual disconnect lands
+	// in [60s, 75s] from the unanswered ping, vs rippled's [60s, 120s].
+	pingTimeout = 60 * time.Second
+	// pingInFlightTTL must be >= pingTimeout: recordPingSent's GC sweep
+	// runs after staleInFlightPing on each tick, so trimming earlier
+	// would evict the very entry the timeout check is about to flag.
+	pingInFlightTTL  = pingTimeout
+	pingsInFlightCap = 16
 )
 
 // staleInFlightPing returns the oldest in-flight ping whose age has
-// reached threshold. Pure read against the latency map for testability.
+// reached threshold. Pure read against the pingsInFlight map for
+// testability.
 func (p *Peer) staleInFlightPing(now time.Time, threshold time.Duration) (seq uint32, age time.Duration, ok bool) {
 	p.latencyMu.RLock()
 	defer p.latencyMu.RUnlock()

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -706,6 +706,14 @@ func (p *Peer) pingLoop(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			now := time.Now()
+			if seq, age, ok := p.staleInFlightPing(now, pingTimeout); ok {
+				slog.Warn("peer ping timeout",
+					"t", "Peer", "peer", p.id,
+					"endpoint", p.endpoint.String(),
+					"seq", seq, "age", age,
+				)
+				return ErrPingTimeout
+			}
 			seq := uint32(now.UnixMilli())
 			ping := &message.Ping{
 				PType: message.PingTypePing,
@@ -730,7 +738,40 @@ func (p *Peer) pingLoop(ctx context.Context) error {
 const (
 	pingInFlightTTL  = 30 * time.Second
 	pingsInFlightCap = 16
+	// pingTimeout: disconnect when the oldest unanswered ping reaches
+	// this age. Mirrors rippled's PeerImp::onTimer "Already waiting for
+	// PONG → fail('Ping Timeout')" (PeerImp.cpp:731-736); rippled's
+	// timer fires every 60s so a single missed cycle drops the peer.
+	// goXRPL pings every 15s, so 30s = ~2 cycles of grace.
+	pingTimeout = 30 * time.Second
 )
+
+// staleInFlightPing returns the oldest in-flight ping whose age has
+// reached threshold. Pure read against the latency map for testability.
+func (p *Peer) staleInFlightPing(now time.Time, threshold time.Duration) (seq uint32, age time.Duration, ok bool) {
+	p.latencyMu.RLock()
+	defer p.latencyMu.RUnlock()
+	var (
+		oldestSeq  uint32
+		oldestSent time.Time
+		have       bool
+	)
+	for s, t := range p.pingsInFlight {
+		if !have || t.Before(oldestSent) {
+			oldestSeq = s
+			oldestSent = t
+			have = true
+		}
+	}
+	if !have {
+		return 0, 0, false
+	}
+	age = now.Sub(oldestSent)
+	if age < threshold {
+		return 0, 0, false
+	}
+	return oldestSeq, age, true
+}
 
 func (p *Peer) recordPingSent(seq uint32, sentAt time.Time) {
 	p.latencyMu.Lock()

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -752,9 +752,10 @@ const (
 	// pingTimeout: disconnect when the oldest unanswered ping reaches
 	// this age. Mirrors rippled's PeerImp::onTimer "Already waiting for
 	// PONG → fail('Ping Timeout')" (PeerImp.cpp:731-736) with rippled's
-	// 60s peerTimerInterval (PeerImp.cpp:61) — a single missed cycle
-	// drops the peer. goXRPL's 15s ticker means actual disconnect lands
-	// in [60s, 75s] from the unanswered ping, vs rippled's [60s, 120s].
+	// 60s peerTimerInterval (PeerImp.cpp:61). At the moment the
+	// disconnect fires, the unanswered ping's age is ≈60s in both
+	// implementations; the 15s tick only changes when goXRPL first
+	// probes a quiet peer (≈15s from connect, vs rippled's ≈60s).
 	pingTimeout = 60 * time.Second
 	// pingInFlightTTL must be >= pingTimeout: recordPingSent's GC sweep
 	// runs after staleInFlightPing on each tick, so trimming earlier

--- a/internal/peermanagement/peer_ping_timeout_test.go
+++ b/internal/peermanagement/peer_ping_timeout_test.go
@@ -1,6 +1,8 @@
 package peermanagement
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -107,6 +109,71 @@ func TestPeer_OnPong_ClearsOlderInFlight(t *testing.T) {
 	// the surviving seq=4 is only pingTimeout-3s old — still fresh.
 	_, _, stale := p.staleInFlightPing(base.Add(pingTimeout), pingTimeout)
 	assert.False(t, stale, "no stale candidate after responsive pong sweeps older entries")
+}
+
+// TestPeer_OnPong_DelayedPongForSweptSeqIsNoOp pins the silent-drop
+// behavior for pongs whose seq was already evicted by a more-recent
+// matching pong. Mirrors rippled's PeerImp::onMessage(TMPing) where a
+// pong with seq != lastPingSeq_ is ignored (PeerImp.cpp:1099-1118).
+// Without this guarantee, a refactor that panicked or double-counted
+// latency on the unmatched pong would silently slip past the existing
+// sweep test.
+func TestPeer_OnPong_DelayedPongForSweptSeqIsNoOp(t *testing.T) {
+	p := newLatencyTestPeer(t)
+	base := time.Now()
+	p.recordPingSent(1, base)
+	p.recordPingSent(2, base.Add(time.Second))
+
+	// Pong for seq=2 sweeps seq=1 (older).
+	p.OnPong(2, base.Add(time.Second+5*time.Millisecond))
+
+	latencyAfterFirst, hadFirst := p.Latency()
+	require.True(t, hadFirst, "first pong must seed latency")
+
+	// Delayed pong for seq=1 arrives after seq=1 was swept.
+	p.OnPong(1, base.Add(2*time.Second))
+
+	latencyAfter, ok := p.Latency()
+	require.True(t, ok)
+	assert.Equal(t, latencyAfterFirst, latencyAfter,
+		"delayed pong for swept seq must not update latency")
+
+	p.latencyMu.RLock()
+	inFlight := len(p.pingsInFlight)
+	p.latencyMu.RUnlock()
+	assert.Equal(t, 0, inFlight, "delayed pong must not resurrect entries")
+}
+
+// TestOverlay_NotePeerRunEnded_IncrementsPingTimeoutCounter pins the
+// wire from peer.Run returning ErrPingTimeout to the operator-visible
+// counter. Without this, a future refactor that swallowed the sentinel
+// error in Run() (e.g. by wrapping it in a generic disconnect type)
+// would silently zero out PingTimeoutDisconnects().
+func TestOverlay_NotePeerRunEnded_IncrementsPingTimeoutCounter(t *testing.T) {
+	o := &Overlay{}
+
+	require.Equal(t, uint64(0), o.PingTimeoutDisconnects())
+
+	o.notePeerRunEnded(ErrPingTimeout)
+	assert.Equal(t, uint64(1), o.PingTimeoutDisconnects())
+
+	// errors.Is recognises wrapped sentinels — guards against a future
+	// caller that wraps the error with %w on its way back up Run().
+	o.notePeerRunEnded(fmt.Errorf("peer dropped: %w", ErrPingTimeout))
+	assert.Equal(t, uint64(2), o.PingTimeoutDisconnects())
+
+	// Unrelated errors must not advance the ping-timeout counter.
+	o.notePeerRunEnded(errors.New("connection reset"))
+	o.notePeerRunEnded(ErrConnectionClosed)
+	assert.Equal(t, uint64(2), o.PingTimeoutDisconnects(),
+		"only ErrPingTimeout (and wrappers) bump the counter")
+
+	// Nil — the no-error path Run() takes when ctx is cancelled — must
+	// also not bump the counter; notePeerRunEnded is only ever called
+	// after Run returns a non-nil error in production, but the helper
+	// must be defensive against future call sites.
+	o.notePeerRunEnded(nil)
+	assert.Equal(t, uint64(2), o.PingTimeoutDisconnects())
 }
 
 // TestPeer_RunPingTick_HappyPathRecordsAndSends pins the non-timeout

--- a/internal/peermanagement/peer_ping_timeout_test.go
+++ b/internal/peermanagement/peer_ping_timeout_test.go
@@ -1,0 +1,58 @@
+package peermanagement
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeer_StaleInFlightPing_NoneInFlight(t *testing.T) {
+	p := newLatencyTestPeer(t)
+	_, _, ok := p.staleInFlightPing(time.Now(), pingTimeout)
+	assert.False(t, ok)
+}
+
+func TestPeer_StaleInFlightPing_FreshPingNotStale(t *testing.T) {
+	p := newLatencyTestPeer(t)
+	now := time.Now()
+	p.recordPingSent(1, now)
+
+	_, _, ok := p.staleInFlightPing(now.Add(pingTimeout-time.Second), pingTimeout)
+	assert.False(t, ok, "ping younger than threshold is not stale")
+}
+
+func TestPeer_StaleInFlightPing_AtThresholdReportsStale(t *testing.T) {
+	p := newLatencyTestPeer(t)
+	now := time.Now()
+	p.recordPingSent(7, now)
+
+	seq, age, ok := p.staleInFlightPing(now.Add(pingTimeout), pingTimeout)
+	require.True(t, ok, "age == threshold disconnects (one cycle of grace consumed)")
+	assert.Equal(t, uint32(7), seq)
+	assert.Equal(t, pingTimeout, age)
+}
+
+func TestPeer_StaleInFlightPing_PicksOldest(t *testing.T) {
+	p := newLatencyTestPeer(t)
+	base := time.Now()
+	p.recordPingSent(1, base)                   // oldest
+	p.recordPingSent(2, base.Add(time.Second))  // newer
+	p.recordPingSent(3, base.Add(2*time.Second)) // newest
+
+	seq, _, ok := p.staleInFlightPing(base.Add(pingTimeout), pingTimeout)
+	require.True(t, ok)
+	assert.Equal(t, uint32(1), seq, "oldest in-flight ping drives the timeout decision")
+}
+
+func TestPeer_StaleInFlightPing_PongClearsStale(t *testing.T) {
+	p := newLatencyTestPeer(t)
+	now := time.Now()
+	p.recordPingSent(42, now)
+
+	p.OnPong(42, now.Add(50*time.Millisecond))
+
+	_, _, ok := p.staleInFlightPing(now.Add(pingTimeout+time.Hour), pingTimeout)
+	assert.False(t, ok, "answered ping is removed from in-flight map and cannot trigger timeout")
+}

--- a/internal/peermanagement/peer_ping_timeout_test.go
+++ b/internal/peermanagement/peer_ping_timeout_test.go
@@ -56,3 +56,20 @@ func TestPeer_StaleInFlightPing_PongClearsStale(t *testing.T) {
 	_, _, ok := p.staleInFlightPing(now.Add(pingTimeout+time.Hour), pingTimeout)
 	assert.False(t, ok, "answered ping is removed from in-flight map and cannot trigger timeout")
 }
+
+// TestPeer_RunPingTick_StalePingReturnsErrPingTimeout pins the
+// integration the predicate tests above only cover in pieces:
+// runPingTick (the per-tick body of pingLoop, reached via Run())
+// must surface ErrPingTimeout when an in-flight ping has aged past
+// the threshold. Pre-populating with age = 2*pingTimeout means a
+// future regression that swapped the stale-check and the
+// recordPingSent GC sweep would evict the entry before it could be
+// flagged — and this test would fail.
+func TestPeer_RunPingTick_StalePingReturnsErrPingTimeout(t *testing.T) {
+	p := newLatencyTestPeer(t)
+	now := time.Now()
+	p.recordPingSent(7, now.Add(-2*pingTimeout))
+
+	err := p.runPingTick(now)
+	require.ErrorIs(t, err, ErrPingTimeout)
+}

--- a/internal/peermanagement/peer_ping_timeout_test.go
+++ b/internal/peermanagement/peer_ping_timeout_test.go
@@ -39,8 +39,8 @@ func TestPeer_StaleInFlightPing_AtThresholdReportsStale(t *testing.T) {
 func TestPeer_StaleInFlightPing_PicksOldest(t *testing.T) {
 	p := newLatencyTestPeer(t)
 	base := time.Now()
-	p.recordPingSent(1, base)                   // oldest
-	p.recordPingSent(2, base.Add(time.Second))  // newer
+	p.recordPingSent(1, base)                    // oldest
+	p.recordPingSent(2, base.Add(time.Second))   // newer
 	p.recordPingSent(3, base.Add(2*time.Second)) // newest
 
 	seq, _, ok := p.staleInFlightPing(base.Add(pingTimeout), pingTimeout)

--- a/internal/peermanagement/peer_ping_timeout_test.go
+++ b/internal/peermanagement/peer_ping_timeout_test.go
@@ -74,6 +74,41 @@ func TestPeer_RunPingTick_StalePingReturnsErrPingTimeout(t *testing.T) {
 	require.ErrorIs(t, err, ErrPingTimeout)
 }
 
+// TestPeer_OnPong_ClearsOlderInFlight pins the single-cycle semantics
+// adopted to match rippled (PeerImp.h:115's lone std::optional<uint32>
+// lastPingSeq_): a matching pong evicts every in-flight entry sent
+// at-or-before the matched send-time, so a peer that responds to the
+// most recent ping is never disconnected by a still-pending older
+// one. Without this, goXRPL's 15s tick + 60s timeout would evict
+// peers under partial pong loss that rippled keeps.
+func TestPeer_OnPong_ClearsOlderInFlight(t *testing.T) {
+	p := newLatencyTestPeer(t)
+	base := time.Now()
+	p.recordPingSent(1, base)                    // older, will be lost
+	p.recordPingSent(2, base.Add(time.Second))   // older, will be lost
+	p.recordPingSent(3, base.Add(2*time.Second)) // matched
+	p.recordPingSent(4, base.Add(3*time.Second)) // newer than the matched, must survive
+
+	p.OnPong(3, base.Add(2*time.Second+10*time.Millisecond))
+
+	p.latencyMu.RLock()
+	_, has1 := p.pingsInFlight[1]
+	_, has2 := p.pingsInFlight[2]
+	_, has3 := p.pingsInFlight[3]
+	_, has4 := p.pingsInFlight[4]
+	p.latencyMu.RUnlock()
+
+	assert.False(t, has1, "older ping must be cleared by matching pong")
+	assert.False(t, has2, "older ping must be cleared by matching pong")
+	assert.False(t, has3, "matched ping must be cleared")
+	assert.True(t, has4, "ping sent after the matched one must survive")
+
+	// At the moment seq=1 would have aged out (had it not been cleared),
+	// the surviving seq=4 is only pingTimeout-3s old — still fresh.
+	_, _, stale := p.staleInFlightPing(base.Add(pingTimeout), pingTimeout)
+	assert.False(t, stale, "no stale candidate after responsive pong sweeps older entries")
+}
+
 // TestPeer_RunPingTick_HappyPathRecordsAndSends pins the non-timeout
 // branch: with no stale ping, runPingTick records the freshly-issued
 // seq in pingsInFlight and queues exactly one wire message on

--- a/internal/peermanagement/peer_ping_timeout_test.go
+++ b/internal/peermanagement/peer_ping_timeout_test.go
@@ -111,26 +111,20 @@ func TestPeer_OnPong_ClearsOlderInFlight(t *testing.T) {
 	assert.False(t, stale, "no stale candidate after responsive pong sweeps older entries")
 }
 
-// TestPeer_OnPong_DelayedPongForSweptSeqIsNoOp pins the silent-drop
-// behavior for pongs whose seq was already evicted by a more-recent
-// matching pong. Mirrors rippled's PeerImp::onMessage(TMPing) where a
-// pong with seq != lastPingSeq_ is ignored (PeerImp.cpp:1099-1118).
-// Without this guarantee, a refactor that panicked or double-counted
-// latency on the unmatched pong would silently slip past the existing
-// sweep test.
+// Pongs whose seq was already swept by a more-recent matching pong
+// are silently dropped. Mirrors rippled PeerImp.cpp:1099-1118 (pong
+// with seq != lastPingSeq_ ignored).
 func TestPeer_OnPong_DelayedPongForSweptSeqIsNoOp(t *testing.T) {
 	p := newLatencyTestPeer(t)
 	base := time.Now()
 	p.recordPingSent(1, base)
 	p.recordPingSent(2, base.Add(time.Second))
 
-	// Pong for seq=2 sweeps seq=1 (older).
 	p.OnPong(2, base.Add(time.Second+5*time.Millisecond))
 
 	latencyAfterFirst, hadFirst := p.Latency()
 	require.True(t, hadFirst, "first pong must seed latency")
 
-	// Delayed pong for seq=1 arrives after seq=1 was swept.
 	p.OnPong(1, base.Add(2*time.Second))
 
 	latencyAfter, ok := p.Latency()
@@ -144,11 +138,6 @@ func TestPeer_OnPong_DelayedPongForSweptSeqIsNoOp(t *testing.T) {
 	assert.Equal(t, 0, inFlight, "delayed pong must not resurrect entries")
 }
 
-// TestOverlay_NotePeerRunEnded_IncrementsPingTimeoutCounter pins the
-// wire from peer.Run returning ErrPingTimeout to the operator-visible
-// counter. Without this, a future refactor that swallowed the sentinel
-// error in Run() (e.g. by wrapping it in a generic disconnect type)
-// would silently zero out PingTimeoutDisconnects().
 func TestOverlay_NotePeerRunEnded_IncrementsPingTimeoutCounter(t *testing.T) {
 	o := &Overlay{}
 
@@ -157,21 +146,16 @@ func TestOverlay_NotePeerRunEnded_IncrementsPingTimeoutCounter(t *testing.T) {
 	o.notePeerRunEnded(ErrPingTimeout)
 	assert.Equal(t, uint64(1), o.PingTimeoutDisconnects())
 
-	// errors.Is recognises wrapped sentinels — guards against a future
-	// caller that wraps the error with %w on its way back up Run().
+	// errors.Is must follow %w wrappers so a future Run() that wraps
+	// the sentinel still bumps the counter.
 	o.notePeerRunEnded(fmt.Errorf("peer dropped: %w", ErrPingTimeout))
 	assert.Equal(t, uint64(2), o.PingTimeoutDisconnects())
 
-	// Unrelated errors must not advance the ping-timeout counter.
 	o.notePeerRunEnded(errors.New("connection reset"))
 	o.notePeerRunEnded(ErrConnectionClosed)
 	assert.Equal(t, uint64(2), o.PingTimeoutDisconnects(),
 		"only ErrPingTimeout (and wrappers) bump the counter")
 
-	// Nil — the no-error path Run() takes when ctx is cancelled — must
-	// also not bump the counter; notePeerRunEnded is only ever called
-	// after Run returns a non-nil error in production, but the helper
-	// must be defensive against future call sites.
 	o.notePeerRunEnded(nil)
 	assert.Equal(t, uint64(2), o.PingTimeoutDisconnects())
 }

--- a/internal/peermanagement/peer_ping_timeout_test.go
+++ b/internal/peermanagement/peer_ping_timeout_test.go
@@ -73,3 +73,27 @@ func TestPeer_RunPingTick_StalePingReturnsErrPingTimeout(t *testing.T) {
 	err := p.runPingTick(now)
 	require.ErrorIs(t, err, ErrPingTimeout)
 }
+
+// TestPeer_RunPingTick_HappyPathRecordsAndSends pins the non-timeout
+// branch: with no stale ping, runPingTick records the freshly-issued
+// seq in pingsInFlight and queues exactly one wire message on
+// p.send. Guards against silent regressions that would drop the
+// recordPingSent call or short-circuit the Send.
+func TestPeer_RunPingTick_HappyPathRecordsAndSends(t *testing.T) {
+	p := newLatencyTestPeer(t)
+	now := time.Now()
+
+	require.NoError(t, p.runPingTick(now))
+
+	p.latencyMu.RLock()
+	inFlight := len(p.pingsInFlight)
+	p.latencyMu.RUnlock()
+	assert.Equal(t, 1, inFlight, "happy path records exactly one in-flight ping")
+
+	select {
+	case msg := <-p.send:
+		assert.NotEmpty(t, msg, "ping must be queued on the send channel")
+	default:
+		t.Fatal("expected a wire message on p.send after a successful tick")
+	}
+}


### PR DESCRIPTION
## Summary
- `pingLoop` now disconnects a peer when the oldest in-flight ping reaches `pingTimeout` (30s, ~2 cycles of grace at the 15s tick) — mirrors rippled's `PeerImp::onTimer` "Already waiting for PONG → fail" at `PeerImp.cpp:731-736`.
- New `ErrPingTimeout` sentinel; disconnect goes through the existing `Run()` error path so cleanup and `EventPeerDisconnected` stay consistent with `Send`-error shutdowns.
- New `staleInFlightPing` pure helper (read-only against the `pingsInFlight` map added in #312) for testability.
- `slog.Warn` at timeout for operator visibility (peer ID, endpoint, seq, age).

Closes #315.

## Test plan
- [x] `go test ./internal/peermanagement/...` — full suite green
- [x] 6 new unit tests in `peer_ping_timeout_test.go`: empty map, fresh ping, threshold edge, oldest-wins selection, pong-clears-stale
- [x] `go vet ./internal/peermanagement/...`