### PR TITLE
feat(vault): add ctx.Log instrumentation to vault transactors

### DIFF
--- a/internal/tx/vault/vault_clawback.go
+++ b/internal/tx/vault/vault_clawback.go
@@ -117,6 +117,13 @@ func (v *VaultClawback) RequiredAmendments() [][32]byte {
 }
 
 func (v *VaultClawback) Apply(ctx *tx.ApplyContext) tx.Result {
+	ctx.Log.Trace("vault clawback apply",
+		"account", v.Account,
+		"vaultID", v.VaultID,
+		"holder", v.Holder,
+		"amount", v.Amount,
+	)
+
 	if v.VaultID == "" || v.Holder == "" {
 		return tx.TemINVALID
 	}

--- a/internal/tx/vault/vault_create.go
+++ b/internal/tx/vault/vault_create.go
@@ -133,6 +133,12 @@ func (v *VaultCreate) RequiredAmendments() [][32]byte {
 }
 
 func (v *VaultCreate) Apply(ctx *tx.ApplyContext) tx.Result {
+	ctx.Log.Trace("vault create apply",
+		"account", v.Account,
+		"asset", v.Asset,
+		"flags", v.GetFlags(),
+	)
+
 	if v.Asset.Currency == "" {
 		return tx.TemINVALID
 	}

--- a/internal/tx/vault/vault_delete.go
+++ b/internal/tx/vault/vault_delete.go
@@ -78,6 +78,11 @@ func (v *VaultDelete) RequiredAmendments() [][32]byte {
 }
 
 func (v *VaultDelete) Apply(ctx *tx.ApplyContext) tx.Result {
+	ctx.Log.Trace("vault delete apply",
+		"account", v.Account,
+		"vaultID", v.VaultID,
+	)
+
 	if v.VaultID == "" {
 		return tx.TemINVALID
 	}

--- a/internal/tx/vault/vault_deposit.go
+++ b/internal/tx/vault/vault_deposit.go
@@ -89,6 +89,12 @@ func (v *VaultDeposit) RequiredAmendments() [][32]byte {
 }
 
 func (v *VaultDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
+	ctx.Log.Trace("vault deposit apply",
+		"account", v.Account,
+		"vaultID", v.VaultID,
+		"amount", v.Amount,
+	)
+
 	if v.VaultID == "" || v.Amount.IsZero() {
 		return tx.TemINVALID
 	}
@@ -110,5 +116,12 @@ func (v *VaultDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 		ctx.Account.Balance -= amount
 	}
+
+	ctx.Log.Debug("vault deposit: shares issued",
+		"account", v.Account,
+		"vaultID", v.VaultID,
+		"amount", v.Amount,
+		"shares", v.Amount,
+	)
 	return tx.TesSUCCESS
 }

--- a/internal/tx/vault/vault_set.go
+++ b/internal/tx/vault/vault_set.go
@@ -107,6 +107,14 @@ func (v *VaultSet) RequiredAmendments() [][32]byte {
 }
 
 func (v *VaultSet) Apply(ctx *tx.ApplyContext) tx.Result {
+	ctx.Log.Trace("vault set apply",
+		"account", v.Account,
+		"vaultID", v.VaultID,
+		"hasData", v.Data != "",
+		"hasDomainID", v.DomainID != "",
+		"hasAssetsMaximum", v.AssetsMaximum != nil,
+	)
+
 	if v.VaultID == "" {
 		return tx.TemINVALID
 	}

--- a/internal/tx/vault/vault_withdraw.go
+++ b/internal/tx/vault/vault_withdraw.go
@@ -109,6 +109,12 @@ func (v *VaultWithdraw) RequiredAmendments() [][32]byte {
 }
 
 func (v *VaultWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
+	ctx.Log.Trace("vault withdraw apply",
+		"account", v.Account,
+		"vaultID", v.VaultID,
+		"amount", v.Amount,
+	)
+
 	if v.VaultID == "" || v.Amount.IsZero() {
 		return tx.TemINVALID
 	}
@@ -127,5 +133,12 @@ func (v *VaultWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		amount := uint64(v.Amount.Drops())
 		ctx.Account.Balance += amount
 	}
+
+	ctx.Log.Debug("vault withdraw: shares redeemed",
+		"account", v.Account,
+		"vaultID", v.VaultID,
+		"amount", v.Amount,
+		"shares", v.Amount,
+	)
 	return tx.TesSUCCESS
 }


### PR DESCRIPTION
## Summary
- Trace at entry of every Vault `Apply()` (matches `payment`/`offer` idiom).
- Debug post-action lines on `VaultDeposit` (shares issued) and `VaultWithdraw` (shares redeemed).
- No nil-guard needed — `ctx.Log` is documented as always non-nil (falls back to `xrpllog.Discard()`).

## Test plan
- [x] `go test ./internal/tx/vault/...` PASS
- Vault `Apply()` is currently stubbed; the Debug `shares` field equals `amount` until real share math lands. Logging will not need updating then — only the value being logged.

Closes #151