### PR TITLE
feat(rpc): make WebSocket timeouts and limits configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -83,8 +83,6 @@ type Config struct {
 	WebsocketPingFrequency int    `toml:"websocket_ping_frequency" mapstructure:"websocket_ping_frequency"`
 	ServerDomain           string `toml:"server_domain" mapstructure:"server_domain"`
 
-	// WebSocket connection limits and timeouts. An omitted [websocket]
-	// section preserves the historical hardcoded values via WithDefaults().
 	WebSocket WebSocketConfig `toml:"websocket" mapstructure:"websocket"`
 
 	// Genesis file path (JSON format)

--- a/config/config.go
+++ b/config/config.go
@@ -75,11 +75,15 @@ type Config struct {
 	BetaRPCAPI     int         `toml:"beta_rpc_api" mapstructure:"beta_rpc_api"`
 
 	// Special startup commands
-	RPCStartup             []RPCStartupCommand `toml:"rpc_startup" mapstructure:"rpc_startup"`
-	WebsocketPingFrequency int                 `toml:"websocket_ping_frequency" mapstructure:"websocket_ping_frequency"`
-	ServerDomain           string              `toml:"server_domain" mapstructure:"server_domain"`
+	RPCStartup []RPCStartupCommand `toml:"rpc_startup" mapstructure:"rpc_startup"`
 
-	// WebSocket connection limits and timeouts. Omitting the [websocket]
+	// Deprecated: top-level websocket_ping_frequency is unused; configure
+	// websocket.ping_interval under the [websocket] section instead.
+	// Retained so existing configs continue to parse.
+	WebsocketPingFrequency int    `toml:"websocket_ping_frequency" mapstructure:"websocket_ping_frequency"`
+	ServerDomain           string `toml:"server_domain" mapstructure:"server_domain"`
+
+	// WebSocket connection limits and timeouts. An omitted [websocket]
 	// section preserves the historical hardcoded values via WithDefaults().
 	WebSocket WebSocketConfig `toml:"websocket" mapstructure:"websocket"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,10 @@ type Config struct {
 	WebsocketPingFrequency int                 `toml:"websocket_ping_frequency" mapstructure:"websocket_ping_frequency"`
 	ServerDomain           string              `toml:"server_domain" mapstructure:"server_domain"`
 
+	// WebSocket connection limits and timeouts. Omitting the [websocket]
+	// section preserves the historical hardcoded values via WithDefaults().
+	WebSocket WebSocketConfig `toml:"websocket" mapstructure:"websocket"`
+
 	// Genesis file path (JSON format)
 	// If empty, uses built-in default genesis configuration
 	GenesisFile               string `toml:"genesis_file" mapstructure:"genesis_file"`

--- a/config/deprecations.go
+++ b/config/deprecations.go
@@ -1,0 +1,33 @@
+package config
+
+// warnLogger is the minimal logger surface used by deprecation notices.
+// It is satisfied by xrpllog.Logger and by test fakes that only need to
+// capture Warn calls.
+type warnLogger interface {
+	Warn(msg string, args ...any)
+}
+
+// LogDeprecations emits a warning for each deprecated knob the operator
+// has explicitly set. When the deprecated knob has a replacement that is
+// also set, the warning makes the precedence explicit (the new value
+// always wins). No-op when c or log is nil so callers can invoke it
+// unconditionally.
+func (c *Config) LogDeprecations(log warnLogger) {
+	if c == nil || log == nil {
+		return
+	}
+	if c.WebsocketPingFrequency != 0 {
+		if c.WebSocket.PingInterval > 0 {
+			log.Warn(
+				"websocket_ping_frequency is deprecated and is overridden by websocket.ping_interval",
+				"deprecated_value", c.WebsocketPingFrequency,
+				"effective_value", c.WebSocket.PingInterval,
+			)
+		} else {
+			log.Warn(
+				"websocket_ping_frequency is deprecated; configure websocket.ping_interval under the [websocket] section instead",
+				"value", c.WebsocketPingFrequency,
+			)
+		}
+	}
+}

--- a/config/deprecations_test.go
+++ b/config/deprecations_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+type captureLogger struct {
+	msgs []string
+	args [][]any
+}
+
+func (c *captureLogger) Warn(msg string, args ...any) {
+	c.msgs = append(c.msgs, msg)
+	c.args = append(c.args, args)
+}
+
+func TestConfig_LogDeprecations_NoOpWhenUnset(t *testing.T) {
+	log := &captureLogger{}
+	(&Config{}).LogDeprecations(log)
+	if len(log.msgs) != 0 {
+		t.Fatalf("expected no warnings, got %v", log.msgs)
+	}
+}
+
+func TestConfig_LogDeprecations_NilSafe(t *testing.T) {
+	var c *Config
+	c.LogDeprecations(&captureLogger{})
+
+	(&Config{WebsocketPingFrequency: 60}).LogDeprecations(nil)
+}
+
+func TestConfig_LogDeprecations_WarnsOnDeprecatedFieldAlone(t *testing.T) {
+	log := &captureLogger{}
+	(&Config{WebsocketPingFrequency: 60}).LogDeprecations(log)
+
+	if len(log.msgs) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(log.msgs), log.msgs)
+	}
+	if !strings.Contains(log.msgs[0], "websocket_ping_frequency is deprecated") {
+		t.Errorf("unexpected message: %q", log.msgs[0])
+	}
+	if strings.Contains(log.msgs[0], "overridden") {
+		t.Errorf("alone-case must not mention precedence, got %q", log.msgs[0])
+	}
+}
+
+func TestConfig_LogDeprecations_PrecedenceWarning(t *testing.T) {
+	log := &captureLogger{}
+	(&Config{
+		WebsocketPingFrequency: 60,
+		WebSocket:              WebSocketConfig{PingInterval: 20 * time.Second},
+	}).LogDeprecations(log)
+
+	if len(log.msgs) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(log.msgs), log.msgs)
+	}
+	if !strings.Contains(log.msgs[0], "overridden by websocket.ping_interval") {
+		t.Errorf("expected precedence wording, got %q", log.msgs[0])
+	}
+}
+
+func TestConfig_LogDeprecations_PingIntervalAloneIsSilent(t *testing.T) {
+	log := &captureLogger{}
+	(&Config{
+		WebSocket: WebSocketConfig{PingInterval: 20 * time.Second},
+	}).LogDeprecations(log)
+
+	if len(log.msgs) != 0 {
+		t.Errorf("expected no warning when only the new field is set, got %v", log.msgs)
+	}
+}

--- a/config/server.go
+++ b/config/server.go
@@ -7,9 +7,8 @@ import (
 	"time"
 )
 
-// Default WebSocket connection limits and timeouts. These mirror the values
-// hardcoded in internal/rpc/websocket.go before WebSocketConfig was introduced
-// and preserve historical behavior when the [websocket] section is omitted.
+// Default WebSocket connection limits and timeouts applied when the
+// [websocket] section is omitted from config.
 const (
 	DefaultWebSocketMaxReadSize  int64         = 512 * 1024
 	DefaultWebSocketReadTimeout  time.Duration = 90 * time.Second
@@ -30,10 +29,10 @@ const minWebSocketDuration = 100 * time.Millisecond
 // frame and render the server unreachable.
 const minWebSocketReadSize int64 = 1024
 
-// WebSocketConfig holds tunable limits and timeouts applied to every
-// WebSocket connection. Zero-valued fields fall back to the matching
-// Default* constants via WithDefaults, so existing deployments that omit
-// the [websocket] section behave identically to before this struct existed.
+// WebSocketConfig holds tunable per-connection WebSocket limits and
+// timeouts. Zero-valued fields fall back to the matching Default*
+// constants via WithDefaults, so an omitted [websocket] section yields
+// the documented defaults.
 type WebSocketConfig struct {
 	MaxReadSize  int64         `toml:"max_read_size" mapstructure:"max_read_size"`
 	ReadTimeout  time.Duration `toml:"read_timeout" mapstructure:"read_timeout"`
@@ -42,9 +41,9 @@ type WebSocketConfig struct {
 	PongTimeout  time.Duration `toml:"pong_timeout" mapstructure:"pong_timeout"`
 }
 
-// WithDefaults returns a copy of cfg with any zero-valued field replaced by
-// the matching Default* constant. Callers should use the returned value
-// instead of the original to ensure every limit is set.
+// WithDefaults returns a copy of cfg with each zero-valued field
+// replaced by its matching Default* constant. Use the returned value;
+// the receiver is unchanged.
 func (cfg WebSocketConfig) WithDefaults() WebSocketConfig {
 	if cfg.MaxReadSize <= 0 {
 		cfg.MaxReadSize = DefaultWebSocketMaxReadSize
@@ -64,11 +63,10 @@ func (cfg WebSocketConfig) WithDefaults() WebSocketConfig {
 	return cfg
 }
 
-// Validate rejects values that cannot reasonably drive the WebSocket
-// server. Sizes and durations must either be zero (use the default) or
-// at least their respective minimum. The zero/positive split keeps
-// "[websocket] omitted" valid while catching unit typos and
-// trivially-broken values that would silently break the server at runtime.
+// Validate accepts zero (use the default) or values >= their minimum.
+// The zero/positive split keeps "[websocket] omitted" valid while
+// catching unit typos and trivially-broken values that would silently
+// break the server at runtime.
 func (cfg WebSocketConfig) Validate() error {
 	if cfg.MaxReadSize < 0 {
 		return fmt.Errorf("websocket.max_read_size must be non-negative, got %d", cfg.MaxReadSize)

--- a/config/server.go
+++ b/config/server.go
@@ -4,7 +4,74 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 )
+
+// Default WebSocket connection limits and timeouts. These mirror the values
+// hardcoded in internal/rpc/websocket.go before WebSocketConfig was introduced
+// and preserve historical behavior when the [websocket] section is omitted.
+const (
+	DefaultWebSocketMaxReadSize  int64         = 512 * 1024
+	DefaultWebSocketReadTimeout  time.Duration = 90 * time.Second
+	DefaultWebSocketWriteTimeout time.Duration = 10 * time.Second
+	DefaultWebSocketPingInterval time.Duration = 30 * time.Second
+	DefaultWebSocketPongTimeout  time.Duration = 30 * time.Second
+)
+
+// WebSocketConfig holds tunable limits and timeouts applied to every
+// WebSocket connection. All zero-valued fields fall back to the matching
+// Default* constants so existing deployments that omit the [websocket]
+// section behave identically to before this struct existed.
+type WebSocketConfig struct {
+	MaxReadSize  int64         `toml:"max_read_size" mapstructure:"max_read_size"`
+	ReadTimeout  time.Duration `toml:"read_timeout" mapstructure:"read_timeout"`
+	WriteTimeout time.Duration `toml:"write_timeout" mapstructure:"write_timeout"`
+	PingInterval time.Duration `toml:"ping_interval" mapstructure:"ping_interval"`
+	PongTimeout  time.Duration `toml:"pong_timeout" mapstructure:"pong_timeout"`
+}
+
+// WithDefaults returns a copy of cfg with any zero-valued field replaced by
+// the matching Default* constant. Callers should use the returned value
+// instead of the original to ensure every limit is set.
+func (cfg WebSocketConfig) WithDefaults() WebSocketConfig {
+	if cfg.MaxReadSize <= 0 {
+		cfg.MaxReadSize = DefaultWebSocketMaxReadSize
+	}
+	if cfg.ReadTimeout <= 0 {
+		cfg.ReadTimeout = DefaultWebSocketReadTimeout
+	}
+	if cfg.WriteTimeout <= 0 {
+		cfg.WriteTimeout = DefaultWebSocketWriteTimeout
+	}
+	if cfg.PingInterval <= 0 {
+		cfg.PingInterval = DefaultWebSocketPingInterval
+	}
+	if cfg.PongTimeout <= 0 {
+		cfg.PongTimeout = DefaultWebSocketPongTimeout
+	}
+	return cfg
+}
+
+// Validate ensures negative durations or sizes are rejected. Zero values
+// are allowed and resolved by WithDefaults at use time.
+func (cfg WebSocketConfig) Validate() error {
+	if cfg.MaxReadSize < 0 {
+		return fmt.Errorf("websocket.max_read_size must be non-negative, got %d", cfg.MaxReadSize)
+	}
+	if cfg.ReadTimeout < 0 {
+		return fmt.Errorf("websocket.read_timeout must be non-negative, got %s", cfg.ReadTimeout)
+	}
+	if cfg.WriteTimeout < 0 {
+		return fmt.Errorf("websocket.write_timeout must be non-negative, got %s", cfg.WriteTimeout)
+	}
+	if cfg.PingInterval < 0 {
+		return fmt.Errorf("websocket.ping_interval must be non-negative, got %s", cfg.PingInterval)
+	}
+	if cfg.PongTimeout < 0 {
+		return fmt.Errorf("websocket.pong_timeout must be non-negative, got %s", cfg.PongTimeout)
+	}
+	return nil
+}
 
 // ServerConfig represents the [server] section
 // This defines the ports that the server will listen on and default values

--- a/config/server.go
+++ b/config/server.go
@@ -24,6 +24,12 @@ const (
 // of a millisecond and burn CPU.
 const minWebSocketDuration = 100 * time.Millisecond
 
+// minWebSocketReadSize is the lower bound enforced by Validate on
+// MaxReadSize. It guards against trivially-broken values (e.g., a
+// single-digit byte cap) that would reject every realistic XRPL command
+// frame and render the server unreachable.
+const minWebSocketReadSize int64 = 1024
+
 // WebSocketConfig holds tunable limits and timeouts applied to every
 // WebSocket connection. Zero-valued fields fall back to the matching
 // Default* constants via WithDefaults, so existing deployments that omit
@@ -59,13 +65,16 @@ func (cfg WebSocketConfig) WithDefaults() WebSocketConfig {
 }
 
 // Validate rejects values that cannot reasonably drive the WebSocket
-// server. Sizes must be non-negative; durations must either be zero (use
-// the default) or at least minWebSocketDuration. The zero/positive split
-// keeps "[websocket] omitted" valid while catching unit typos that would
-// otherwise produce sub-millisecond timers at runtime.
+// server. Sizes and durations must either be zero (use the default) or
+// at least their respective minimum. The zero/positive split keeps
+// "[websocket] omitted" valid while catching unit typos and
+// trivially-broken values that would silently break the server at runtime.
 func (cfg WebSocketConfig) Validate() error {
 	if cfg.MaxReadSize < 0 {
 		return fmt.Errorf("websocket.max_read_size must be non-negative, got %d", cfg.MaxReadSize)
+	}
+	if cfg.MaxReadSize > 0 && cfg.MaxReadSize < minWebSocketReadSize {
+		return fmt.Errorf("websocket.max_read_size must be >= %d bytes (likely unit typo), got %d", minWebSocketReadSize, cfg.MaxReadSize)
 	}
 	if err := validateWebSocketDuration("read_timeout", cfg.ReadTimeout); err != nil {
 		return err

--- a/config/server.go
+++ b/config/server.go
@@ -15,13 +15,19 @@ const (
 	DefaultWebSocketReadTimeout  time.Duration = 90 * time.Second
 	DefaultWebSocketWriteTimeout time.Duration = 10 * time.Second
 	DefaultWebSocketPingInterval time.Duration = 30 * time.Second
-	DefaultWebSocketPongTimeout  time.Duration = 30 * time.Second
+	DefaultWebSocketPongTimeout  time.Duration = 90 * time.Second
 )
 
+// minWebSocketDuration is the lower bound enforced by Validate on every
+// duration field. It guards against unit typos (e.g., "30ns" instead of
+// "30s") that would otherwise pin the read/write/ping loops at fractions
+// of a millisecond and burn CPU.
+const minWebSocketDuration = 100 * time.Millisecond
+
 // WebSocketConfig holds tunable limits and timeouts applied to every
-// WebSocket connection. All zero-valued fields fall back to the matching
-// Default* constants so existing deployments that omit the [websocket]
-// section behave identically to before this struct existed.
+// WebSocket connection. Zero-valued fields fall back to the matching
+// Default* constants via WithDefaults, so existing deployments that omit
+// the [websocket] section behave identically to before this struct existed.
 type WebSocketConfig struct {
 	MaxReadSize  int64         `toml:"max_read_size" mapstructure:"max_read_size"`
 	ReadTimeout  time.Duration `toml:"read_timeout" mapstructure:"read_timeout"`
@@ -52,23 +58,39 @@ func (cfg WebSocketConfig) WithDefaults() WebSocketConfig {
 	return cfg
 }
 
-// Validate ensures negative durations or sizes are rejected. Zero values
-// are allowed and resolved by WithDefaults at use time.
+// Validate rejects values that cannot reasonably drive the WebSocket
+// server. Sizes must be non-negative; durations must either be zero (use
+// the default) or at least minWebSocketDuration. The zero/positive split
+// keeps "[websocket] omitted" valid while catching unit typos that would
+// otherwise produce sub-millisecond timers at runtime.
 func (cfg WebSocketConfig) Validate() error {
 	if cfg.MaxReadSize < 0 {
 		return fmt.Errorf("websocket.max_read_size must be non-negative, got %d", cfg.MaxReadSize)
 	}
-	if cfg.ReadTimeout < 0 {
-		return fmt.Errorf("websocket.read_timeout must be non-negative, got %s", cfg.ReadTimeout)
+	if err := validateWebSocketDuration("read_timeout", cfg.ReadTimeout); err != nil {
+		return err
 	}
-	if cfg.WriteTimeout < 0 {
-		return fmt.Errorf("websocket.write_timeout must be non-negative, got %s", cfg.WriteTimeout)
+	if err := validateWebSocketDuration("write_timeout", cfg.WriteTimeout); err != nil {
+		return err
 	}
-	if cfg.PingInterval < 0 {
-		return fmt.Errorf("websocket.ping_interval must be non-negative, got %s", cfg.PingInterval)
+	if err := validateWebSocketDuration("ping_interval", cfg.PingInterval); err != nil {
+		return err
 	}
-	if cfg.PongTimeout < 0 {
-		return fmt.Errorf("websocket.pong_timeout must be non-negative, got %s", cfg.PongTimeout)
+	if err := validateWebSocketDuration("pong_timeout", cfg.PongTimeout); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateWebSocketDuration(field string, d time.Duration) error {
+	if d == 0 {
+		return nil
+	}
+	if d < 0 {
+		return fmt.Errorf("websocket.%s must be non-negative, got %s", field, d)
+	}
+	if d < minWebSocketDuration {
+		return fmt.Errorf("websocket.%s must be >= %s (likely unit typo), got %s", field, minWebSocketDuration, d)
 	}
 	return nil
 }

--- a/config/server_websocket_test.go
+++ b/config/server_websocket_test.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Pins each Default* constant to the value hardcoded in
+// internal/rpc/websocket.go before WebSocketConfig was introduced. If any
+// of these flip, "[websocket] omitted" no longer reproduces historical
+// behavior — which is the contract WebSocketConfig promises.
+func TestWebSocketConfig_DefaultsMatchPreRefactorConstants(t *testing.T) {
+	cases := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"MaxReadSize", DefaultWebSocketMaxReadSize, int64(512 * 1024)},
+		{"ReadTimeout", DefaultWebSocketReadTimeout, 90 * time.Second},
+		{"WriteTimeout", DefaultWebSocketWriteTimeout, 10 * time.Second},
+		{"PingInterval", DefaultWebSocketPingInterval, 30 * time.Second},
+		{"PongTimeout", DefaultWebSocketPongTimeout, 90 * time.Second},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("Default%s = %v, want %v (pre-refactor hardcoded value)", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestWebSocketConfig_WithDefaults_ZeroFieldsFallBack(t *testing.T) {
+	out := WebSocketConfig{}.WithDefaults()
+	if out.MaxReadSize != DefaultWebSocketMaxReadSize {
+		t.Errorf("MaxReadSize = %d, want %d", out.MaxReadSize, DefaultWebSocketMaxReadSize)
+	}
+	if out.ReadTimeout != DefaultWebSocketReadTimeout {
+		t.Errorf("ReadTimeout = %s, want %s", out.ReadTimeout, DefaultWebSocketReadTimeout)
+	}
+	if out.WriteTimeout != DefaultWebSocketWriteTimeout {
+		t.Errorf("WriteTimeout = %s, want %s", out.WriteTimeout, DefaultWebSocketWriteTimeout)
+	}
+	if out.PingInterval != DefaultWebSocketPingInterval {
+		t.Errorf("PingInterval = %s, want %s", out.PingInterval, DefaultWebSocketPingInterval)
+	}
+	if out.PongTimeout != DefaultWebSocketPongTimeout {
+		t.Errorf("PongTimeout = %s, want %s", out.PongTimeout, DefaultWebSocketPongTimeout)
+	}
+}
+
+func TestWebSocketConfig_WithDefaults_NonZeroFieldsPreserved(t *testing.T) {
+	in := WebSocketConfig{
+		MaxReadSize:  1024 * 1024,
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		PingInterval: 15 * time.Second,
+		PongTimeout:  45 * time.Second,
+	}
+	out := in.WithDefaults()
+	if out != in {
+		t.Errorf("WithDefaults overwrote a non-zero field: in=%+v out=%+v", in, out)
+	}
+}
+
+func TestWebSocketConfig_Validate_AcceptsZeroAndDefaults(t *testing.T) {
+	if err := (WebSocketConfig{}).Validate(); err != nil {
+		t.Errorf("zero-value WebSocketConfig must validate, got %v", err)
+	}
+	defaults := WebSocketConfig{}.WithDefaults()
+	if err := defaults.Validate(); err != nil {
+		t.Errorf("defaulted WebSocketConfig must validate, got %v", err)
+	}
+}
+
+func TestWebSocketConfig_Validate_RejectsNegatives(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  WebSocketConfig
+		want string
+	}{
+		{"MaxReadSize", WebSocketConfig{MaxReadSize: -1}, "max_read_size"},
+		{"ReadTimeout", WebSocketConfig{ReadTimeout: -1}, "read_timeout"},
+		{"WriteTimeout", WebSocketConfig{WriteTimeout: -1}, "write_timeout"},
+		{"PingInterval", WebSocketConfig{PingInterval: -1}, "ping_interval"},
+		{"PongTimeout", WebSocketConfig{PongTimeout: -1}, "pong_timeout"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected error for negative %s, got nil", c.name)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error %q missing field token %q", err, c.want)
+			}
+		})
+	}
+}
+
+// Validate must catch unit typos like "30ns" — values that are positive
+// but absurdly small would otherwise produce sub-millisecond timers.
+func TestWebSocketConfig_Validate_RejectsBelowMinimumDuration(t *testing.T) {
+	cases := []struct {
+		name  string
+		cfg   WebSocketConfig
+		field string
+	}{
+		{"ReadTimeout", WebSocketConfig{ReadTimeout: 30 * time.Nanosecond}, "read_timeout"},
+		{"WriteTimeout", WebSocketConfig{WriteTimeout: time.Microsecond}, "write_timeout"},
+		{"PingInterval", WebSocketConfig{PingInterval: time.Millisecond}, "ping_interval"},
+		{"PongTimeout", WebSocketConfig{PongTimeout: 99 * time.Millisecond}, "pong_timeout"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected error for sub-minimum %s, got nil", c.name)
+			}
+			if !strings.Contains(err.Error(), c.field) {
+				t.Errorf("error %q missing field token %q", err, c.field)
+			}
+		})
+	}
+}
+
+func TestWebSocketConfig_Validate_AcceptsAtAndAboveMinimum(t *testing.T) {
+	cfg := WebSocketConfig{
+		ReadTimeout:  minWebSocketDuration,
+		WriteTimeout: minWebSocketDuration,
+		PingInterval: minWebSocketDuration,
+		PongTimeout:  minWebSocketDuration,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("durations exactly at minWebSocketDuration must validate, got %v", err)
+	}
+}

--- a/config/server_websocket_test.go
+++ b/config/server_websocket_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Pins each Default* constant to the value hardcoded in
-// internal/rpc/websocket.go before WebSocketConfig was introduced. If any
-// of these flip, "[websocket] omitted" no longer reproduces historical
-// behavior — which is the contract WebSocketConfig promises.
+// Pins each Default* constant to its expected value. If any of these
+// flip, "[websocket] omitted" no longer yields the contract documented
+// on WebSocketConfig.
 func TestWebSocketConfig_DefaultsMatchPreRefactorConstants(t *testing.T) {
 	cases := []struct {
 		name string
@@ -186,8 +185,8 @@ pong_timeout  = "60s"
 }
 
 // Omitting the [websocket] section must yield a zero-value
-// WebSocketConfig that, after WithDefaults, reproduces pre-refactor
-// behavior — the contract the deprecation comment in config.go promises.
+// WebSocketConfig that defaults correctly via WithDefaults — the
+// contract documented on WebSocketConfig.
 func TestLoadConfig_WebSocketSectionOmittedYieldsDefaults(t *testing.T) {
 	tempDir := t.TempDir()
 	mainConfigPath := filepath.Join(tempDir, "test_config.toml")

--- a/config/server_websocket_test.go
+++ b/config/server_websocket_test.go
@@ -1,9 +1,14 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Pins each Default* constant to the value hardcoded in
@@ -125,12 +130,95 @@ func TestWebSocketConfig_Validate_RejectsBelowMinimumDuration(t *testing.T) {
 
 func TestWebSocketConfig_Validate_AcceptsAtAndAboveMinimum(t *testing.T) {
 	cfg := WebSocketConfig{
+		MaxReadSize:  minWebSocketReadSize,
 		ReadTimeout:  minWebSocketDuration,
 		WriteTimeout: minWebSocketDuration,
 		PingInterval: minWebSocketDuration,
 		PongTimeout:  minWebSocketDuration,
 	}
 	if err := cfg.Validate(); err != nil {
-		t.Errorf("durations exactly at minWebSocketDuration must validate, got %v", err)
+		t.Errorf("values exactly at the configured minimums must validate, got %v", err)
 	}
+}
+
+// Validate must reject positive-but-trivially-small MaxReadSize values
+// that would reject every realistic XRPL command frame at runtime.
+func TestWebSocketConfig_Validate_RejectsBelowMinimumReadSize(t *testing.T) {
+	for _, size := range []int64{1, 64, minWebSocketReadSize - 1} {
+		err := WebSocketConfig{MaxReadSize: size}.Validate()
+		if err == nil {
+			t.Fatalf("expected error for sub-minimum MaxReadSize=%d, got nil", size)
+		}
+		if !strings.Contains(err.Error(), "max_read_size") {
+			t.Errorf("error %q missing field token %q", err, "max_read_size")
+		}
+	}
+}
+
+// End-to-end check that the [websocket] TOML section round-trips through
+// the loader: every field tag must match the documented key and the
+// duration decode-hook must convert "120s" / "20s" / etc. into
+// time.Duration. A regression here (renamed tag, dropped DecodeHook on a
+// future viper bump) would silently fall back to defaults at runtime.
+func TestLoadConfig_WebSocketSectionRoundTrips(t *testing.T) {
+	tempDir := t.TempDir()
+	mainConfigPath := filepath.Join(tempDir, "test_config.toml")
+
+	body := completeTestConfig() + `
+[websocket]
+max_read_size = 1048576
+read_timeout  = "120s"
+write_timeout = "15s"
+ping_interval = "20s"
+pong_timeout  = "60s"
+`
+	require.NoError(t, os.WriteFile(mainConfigPath, []byte(body), 0644))
+
+	cfg, err := LoadConfig(ConfigPaths{Main: mainConfigPath})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, int64(1048576), cfg.WebSocket.MaxReadSize)
+	assert.Equal(t, 120*time.Second, cfg.WebSocket.ReadTimeout)
+	assert.Equal(t, 15*time.Second, cfg.WebSocket.WriteTimeout)
+	assert.Equal(t, 20*time.Second, cfg.WebSocket.PingInterval)
+	assert.Equal(t, 60*time.Second, cfg.WebSocket.PongTimeout)
+}
+
+// Omitting the [websocket] section must yield a zero-value
+// WebSocketConfig that, after WithDefaults, reproduces pre-refactor
+// behavior — the contract the deprecation comment in config.go promises.
+func TestLoadConfig_WebSocketSectionOmittedYieldsDefaults(t *testing.T) {
+	tempDir := t.TempDir()
+	mainConfigPath := filepath.Join(tempDir, "test_config.toml")
+	require.NoError(t, os.WriteFile(mainConfigPath, []byte(completeTestConfig()), 0644))
+
+	cfg, err := LoadConfig(ConfigPaths{Main: mainConfigPath})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, WebSocketConfig{}, cfg.WebSocket)
+
+	defaulted := cfg.WebSocket.WithDefaults()
+	assert.Equal(t, DefaultWebSocketMaxReadSize, defaulted.MaxReadSize)
+	assert.Equal(t, DefaultWebSocketReadTimeout, defaulted.ReadTimeout)
+	assert.Equal(t, DefaultWebSocketWriteTimeout, defaulted.WriteTimeout)
+	assert.Equal(t, DefaultWebSocketPingInterval, defaulted.PingInterval)
+	assert.Equal(t, DefaultWebSocketPongTimeout, defaulted.PongTimeout)
+}
+
+// A sub-minimum value in the loaded TOML must surface as a Validate error
+// from the loader, not silently fall through to runtime.
+func TestLoadConfig_WebSocketSectionRejectsBadValues(t *testing.T) {
+	tempDir := t.TempDir()
+	mainConfigPath := filepath.Join(tempDir, "test_config.toml")
+
+	body := completeTestConfig() + `
+[websocket]
+read_timeout = "30ns"
+`
+	require.NoError(t, os.WriteFile(mainConfigPath, []byte(body), 0644))
+
+	_, err := LoadConfig(ConfigPaths{Main: mainConfigPath})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read_timeout")
 }

--- a/config/validation.go
+++ b/config/validation.go
@@ -361,6 +361,9 @@ func validateMiscSettings(config *Config) error {
 	if err := ValidateWebsocketPingFrequency(config.WebsocketPingFrequency); err != nil {
 		return err
 	}
+	if err := config.WebSocket.Validate(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -317,7 +317,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	// Create WebSocket server for real-time subscriptions. Connection
 	// limits and timeouts come from the [websocket] config section; an
 	// omitted section yields the historical defaults via WithDefaults().
-	wsServer := rpc.NewWebSocketServer(30*time.Second, services, globalConfig.WebSocket)
+	wsServer := rpc.NewWebSocketServer(services, globalConfig.WebSocket)
 	wsServer.RegisterAllMethods()
 
 	// Create a ledger info provider adapter for WebSocket subscribe responses

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -314,8 +314,10 @@ func runServer(cmd *cobra.Command, args []string) {
 
 	services.SetDispatcher(httpServer)
 
-	// Create WebSocket server for real-time subscriptions
-	wsServer := rpc.NewWebSocketServer(30*time.Second, services)
+	// Create WebSocket server for real-time subscriptions. Connection
+	// limits and timeouts come from the [websocket] config section; an
+	// omitted section yields the historical defaults via WithDefaults().
+	wsServer := rpc.NewWebSocketServer(30*time.Second, services, globalConfig.WebSocket)
 	wsServer.RegisterAllMethods()
 
 	// Create a ledger info provider adapter for WebSocket subscribe responses

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -314,9 +314,6 @@ func runServer(cmd *cobra.Command, args []string) {
 
 	services.SetDispatcher(httpServer)
 
-	// Create WebSocket server for real-time subscriptions. Connection
-	// limits and timeouts come from the [websocket] config section; an
-	// omitted section yields the historical defaults via WithDefaults().
 	wsServer := rpc.NewWebSocketServer(services, globalConfig.WebSocket)
 	wsServer.RegisterAllMethods()
 

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -85,6 +85,8 @@ func runServer(cmd *cobra.Command, args []string) {
 	xrpllog.SetRootConfig(&logCfg)
 	serverLog := rootLogger.Named(xrpllog.PartitionServer)
 
+	globalConfig.LogDeprecations(serverLog)
+
 	serverLog.Info("Starting goXRPLd", "version", version.Version)
 
 	// Initialize storage from config

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -31,7 +31,6 @@ type WebSocketServer struct {
 	methodRegistry      *types.MethodRegistry
 	connections         map[string]*WebSocketConnection
 	connectionsMutex    sync.RWMutex
-	timeout             time.Duration
 	wsConfig            config.WebSocketConfig
 	ledgerInfoProvider  types.LedgerInfoProvider
 	connLimiter         *ConnLimiter
@@ -61,7 +60,7 @@ type WebSocketConnection struct {
 // test contexts. wsCfg supplies tunable read/write/ping limits; any
 // zero-valued field is replaced by its config.Default* counterpart so
 // callers may pass a zero-value struct to keep historical behavior.
-func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer, wsCfg config.WebSocketConfig) *WebSocketServer {
+func NewWebSocketServer(services *types.ServiceContainer, wsCfg config.WebSocketConfig) *WebSocketServer {
 	return &WebSocketServer{
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
@@ -76,7 +75,6 @@ func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer,
 		},
 		methodRegistry: types.NewMethodRegistry(),
 		connections:    make(map[string]*WebSocketConnection),
-		timeout:        timeout,
 		wsConfig:       wsCfg.WithDefaults(),
 		services:       services,
 	}

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -54,12 +54,11 @@ type WebSocketConnection struct {
 	portCtx         *PortContext     // per-port config for role determination
 }
 
-// NewWebSocketServer creates a new WebSocket server. The provided
-// service container is attached to every RpcContext routed through the
-// server so handlers reach the ledger via ctx.Services. May be nil for
-// test contexts. wsCfg supplies tunable read/write/ping limits; any
-// zero-valued field is replaced by its config.Default* counterpart so
-// callers may pass a zero-value struct to keep historical behavior.
+// NewWebSocketServer creates a new WebSocket server. The service
+// container is attached to every RpcContext routed through the server
+// so handlers reach the ledger via ctx.Services; nil is allowed for
+// test contexts. Zero-valued wsCfg fields fall back to their
+// config.Default* counterparts.
 func NewWebSocketServer(services *types.ServiceContainer, wsCfg config.WebSocketConfig) *WebSocketServer {
 	return &WebSocketServer{
 		upgrader: websocket.Upgrader{

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/config"
 	"github.com/LeJamon/goXRPLd/internal/rpc/subscription"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
@@ -31,6 +32,7 @@ type WebSocketServer struct {
 	connections         map[string]*WebSocketConnection
 	connectionsMutex    sync.RWMutex
 	timeout             time.Duration
+	wsConfig            config.WebSocketConfig
 	ledgerInfoProvider  types.LedgerInfoProvider
 	connLimiter         *ConnLimiter
 	services            *types.ServiceContainer
@@ -56,8 +58,10 @@ type WebSocketConnection struct {
 // NewWebSocketServer creates a new WebSocket server. The provided
 // service container is attached to every RpcContext routed through the
 // server so handlers reach the ledger via ctx.Services. May be nil for
-// test contexts.
-func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer) *WebSocketServer {
+// test contexts. wsCfg supplies tunable read/write/ping limits; any
+// zero-valued field is replaced by its config.Default* counterpart so
+// callers may pass a zero-value struct to keep historical behavior.
+func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer, wsCfg config.WebSocketConfig) *WebSocketServer {
 	return &WebSocketServer{
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
@@ -73,6 +77,7 @@ func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer)
 		methodRegistry: types.NewMethodRegistry(),
 		connections:    make(map[string]*WebSocketConnection),
 		timeout:        timeout,
+		wsConfig:       wsCfg.WithDefaults(),
 		services:       services,
 	}
 }
@@ -151,11 +156,11 @@ func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 	defer ws.closeConnection(wsConn)
 
-	wsConn.conn.SetReadLimit(512 * 1024) // 512KB max message size
+	wsConn.conn.SetReadLimit(ws.wsConfig.MaxReadSize)
 
 	// Set up pong handler to reset read deadline on pong received
 	wsConn.conn.SetPongHandler(func(string) error {
-		wsConn.conn.SetReadDeadline(time.Now().Add(90 * time.Second))
+		wsConn.conn.SetReadDeadline(time.Now().Add(ws.wsConfig.PongTimeout))
 		return nil
 	})
 
@@ -168,7 +173,7 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 
 	// Read loop - this is blocking and runs until error or close
 	for {
-		wsConn.conn.SetReadDeadline(time.Now().Add(90 * time.Second))
+		wsConn.conn.SetReadDeadline(time.Now().Add(ws.wsConfig.ReadTimeout))
 
 		// Read message from WebSocket (blocking)
 		_, message, err := wsConn.conn.ReadMessage()
@@ -192,7 +197,7 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 
 // pingLoop sends periodic pings to keep the connection alive
 func (ws *WebSocketServer) pingLoop(wsConn *WebSocketConnection) {
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(ws.wsConfig.PingInterval)
 	defer ticker.Stop()
 
 	for {
@@ -200,7 +205,7 @@ func (ws *WebSocketServer) pingLoop(wsConn *WebSocketConnection) {
 		case <-wsConn.ctx.Done():
 			return
 		case <-ticker.C:
-			wsConn.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			wsConn.conn.SetWriteDeadline(time.Now().Add(ws.wsConfig.WriteTimeout))
 			if err := wsConn.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
 				wsLog().Debug("WebSocket ping failed", "err", err)
 				return
@@ -218,7 +223,7 @@ func (ws *WebSocketServer) handleSend(wsConn *WebSocketConnection) {
 		case <-wsConn.closeChannel:
 			return
 		case message := <-wsConn.sendChannel:
-			wsConn.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			wsConn.conn.SetWriteDeadline(time.Now().Add(ws.wsConfig.WriteTimeout))
 			if err := wsConn.conn.WriteMessage(websocket.TextMessage, message); err != nil {
 				wsLog().Debug("WebSocket send failed", "err", err)
 				return

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/config"
 	"github.com/gorilla/websocket"
 )
 
@@ -17,7 +18,7 @@ import (
 // all per-connection goroutines (read loop, send pump, ping loop) have exited.
 // Regression test for issue #186.
 func TestWebSocketServer_Close_JoinsHandlers(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(nil, config.WebSocketConfig{})
 	ws.RegisterAllMethods()
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
@@ -87,7 +88,7 @@ func TestWebSocketServer_Close_JoinsHandlers(t *testing.T) {
 // TestWebSocketServer_Close_RespectsContext verifies Close returns promptly
 // when the context expires, even if handlers might otherwise linger.
 func TestWebSocketServer_Close_RespectsContext(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(nil, config.WebSocketConfig{})
 
 	// Inflate the WaitGroup so it never reaches zero on its own.
 	ws.wg.Add(1)
@@ -111,7 +112,7 @@ func TestWebSocketServer_Close_RespectsContext(t *testing.T) {
 // TestWebSocketServer_Close_NoConnections verifies Close is safe with no
 // active connections and returns immediately.
 func TestWebSocketServer_Close_NoConnections(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(nil, config.WebSocketConfig{})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := ws.Close(ctx); err != nil {
@@ -126,7 +127,7 @@ func TestWebSocketServer_New_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = NewWebSocketServer(time.Second, nil)
+			_ = NewWebSocketServer(nil, config.WebSocketConfig{})
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION
## Summary
- New `config.WebSocketConfig` struct (in `config/server.go`) with `MaxReadSize`, `ReadTimeout`, `WriteTimeout`, `PingInterval`, `PongTimeout`.
- `WithDefaults()` substitutes the previous hardcoded values when fields are zero.
- `Validate()` rejects negatives; hooked into `validateMiscSettings`.
- `internal/rpc/websocket.go` reads from `wsConfig` instead of literals.
- Wired through `Config` → `internal/cli/server.go` → `rpc.NewWebSocketServer`.

```toml
[websocket]
max_read_size  = 1048576
read_timeout   = "120s"
write_timeout  = "15s"
ping_interval  = "20s"
pong_timeout   = "60s"
```

Omitting the `[websocket]` block reproduces today's behavior exactly.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/rpc/... ./config/...` — `config`, `internal/rpc/handlers`, `internal/rpc/types` green; all WebSocket-named tests pass

Closes #189