### PR TITLE
investigate(consensus,ledger): #190 root-cause analysis + diagnostic harness

### DIFF
--- a/internal/ledger/genesis/divergence_diag_test.go
+++ b/internal/ledger/genesis/divergence_diag_test.go
@@ -1,0 +1,152 @@
+package genesis
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/keylet"
+)
+
+// TestDivergence_PrintHashesAndSLEs is a diagnostic for issue #190.
+// It prints account_hash, ledger_hash, FeeSettings SLE bytes and Amendments
+// SLE bytes for the four most likely "genesis equivalents" the kurtosis
+// rippled:2.6.2 peer might be using.
+func TestDivergence_PrintHashesAndSLEs(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			"DefaultConfig_DefaultYesAmendments_LegacyFees",
+			DefaultConfig(), // legacy fees because XRPFees is VoteDefaultNo
+		},
+		{
+			"NoAmendments_LegacyFees", // matches genesis_amendments_disabled = true in topology.star
+			func() Config {
+				c := DefaultConfig()
+				c.Amendments = nil
+				return c
+			}(),
+		},
+	}
+
+	feesK := keylet.Fees()
+	amendmentsK := keylet.Amendments()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gen, err := Create(tc.cfg)
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+
+			t.Logf("=== %s ===", tc.name)
+			t.Logf("LedgerSeq:   %d", gen.Header.LedgerIndex)
+			t.Logf("AccountHash: %s", hex.EncodeToString(gen.Header.AccountHash[:]))
+			t.Logf("LedgerHash:  %s", hex.EncodeToString(gen.Header.Hash[:]))
+			t.Logf("Drops:       %d", gen.Header.Drops)
+			t.Logf("CloseTimeRes:%d", gen.Header.CloseTimeResolution)
+			t.Logf("Amendments count: %d", len(tc.cfg.Amendments))
+
+			feesItem, found, err := gen.StateMap.Get(feesK.Key)
+			if err != nil || !found {
+				t.Fatalf("FeeSettings not found: %v", err)
+			}
+			t.Logf("FeeSettings keylet: %s", hex.EncodeToString(feesK.Key[:]))
+			t.Logf("FeeSettings bytes (%dB): %s", len(feesItem.Data()),
+				hex.EncodeToString(feesItem.Data()))
+
+			amItem, found, err := gen.StateMap.Get(amendmentsK.Key)
+			if err == nil && found {
+				t.Logf("Amendments keylet: %s", hex.EncodeToString(amendmentsK.Key[:]))
+				t.Logf("Amendments bytes (%dB): %s", len(amItem.Data()),
+					hex.EncodeToString(amItem.Data()))
+			} else {
+				t.Logf("Amendments SLE: NOT PRESENT (none enabled)")
+			}
+
+			// Print raw root account SLE
+			acctK := keylet.Account(gen.GenesisAccount)
+			acctItem, found, err := gen.StateMap.Get(acctK.Key)
+			if err != nil || !found {
+				t.Fatalf("AccountRoot not found: %v", err)
+			}
+			t.Logf("AccountRoot keylet: %s", hex.EncodeToString(acctK.Key[:]))
+			t.Logf("AccountRoot bytes (%dB): %s", len(acctItem.Data()),
+				hex.EncodeToString(acctItem.Data()))
+		})
+	}
+}
+
+// TestDivergence_LegacyFeeSettingsExpectedBytes verifies the byte-level encoding
+// of the legacy FeeSettings SLE (the format goXRPL uses when XRPFees is OFF and
+// rippled:2.6.2 also defaults to OFF).
+//
+// Reference rippled Ledger.cpp:212-223 — for legacy:
+//   sfBaseFee (UInt64)         = 10
+//   sfReserveBase (UInt32)     = 10_000_000
+//   sfReserveIncrement (UInt32)= 2_000_000
+//   sfReferenceFeeUnits (UInt32)= 10
+//   + commonFields: sfLedgerEntryType=0x0066 (FeeSettings=102), sfFlags=0
+func TestDivergence_LegacyFeeSettingsExpectedBytes(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Amendments = nil // legacy
+	gen, err := Create(cfg)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	feesK := keylet.Fees()
+	item, found, err := gen.StateMap.Get(feesK.Key)
+	if err != nil || !found {
+		t.Fatalf("FeeSettings not found: %v", err)
+	}
+	got := hex.EncodeToString(item.Data())
+	t.Logf("legacy FeeSettings SLE bytes: %s", got)
+	// Manual XRPL binary codec assembly for verification:
+	// fields are sorted by (typeCode, fieldCode):
+	//   UInt16 LedgerEntryType (typeCode=1, fieldCode=1)  -> 0x11 + 0x0066
+	//   UInt32 Flags (typeCode=2, fieldCode=2)            -> 0x22 + 0x00000000
+	//   UInt32 ReferenceFeeUnits (typeCode=2, fieldCode=30)-> 0x21 0x1E + 0x0000000A
+	//   UInt32 ReserveBase (typeCode=2, fieldCode=31)     -> 0x21 0x1F + 0x00989680
+	//   UInt32 ReserveIncrement (typeCode=2, fieldCode=32)-> 0x21 0x20 + 0x001E8480
+	//   UInt64 BaseFee (typeCode=3, fieldCode=5)          -> 0x35 + 0x000000000000000A
+	// Expected hex: "11006622000000002211E000000000A211F00989680212001E8480350000000000000000A"
+	// (printed for human comparison; not asserted because field layout is established by the codec)
+	if len(got) == 0 {
+		t.Fatal("empty FeeSettings bytes")
+	}
+}
+
+// TestDivergence_AccountRootDefaultBytes prints exactly what the genesis
+// AccountRoot SLE serializes to, so we can compare against rippled's
+// equivalent byte stream from Ledger.cpp:186-192.
+func TestDivergence_AccountRootDefaultBytes(t *testing.T) {
+	cfg := DefaultConfig()
+	gen, err := Create(cfg)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	acctK := keylet.Account(gen.GenesisAccount)
+	item, found, err := gen.StateMap.Get(acctK.Key)
+	if err != nil || !found {
+		t.Fatalf("AccountRoot not found: %v", err)
+	}
+	got := hex.EncodeToString(item.Data())
+	t.Logf("Genesis AccountRoot SLE bytes: %s", got)
+	// rippled sets only sfSequence=1, sfAccount=<id>, sfBalance=INITIAL_XRP.
+	// commonFields auto-fill: sfLedgerEntryType=0x0061, sfFlags=0.
+	// soeREQUIRED defaults: sfOwnerCount=0, sfPreviousTxnID=0, sfPreviousTxnLgrSeq=0.
+	// goXRPL must produce the same bytes for the genesis hash to match.
+	if len(got) < 80 {
+		t.Fatal("AccountRoot bytes suspiciously short")
+	}
+}
+
+func TestDivergence_PrintAmendmentList(t *testing.T) {
+	ids := DefaultGenesisAmendments()
+	t.Logf("DefaultYes amendment count: %d", len(ids))
+	for i, id := range ids {
+		t.Logf("  [%d] %s", i, fmt.Sprintf("%X", id))
+	}
+}

--- a/internal/ledger/genesis/divergence_diag_test.go
+++ b/internal/ledger/genesis/divergence_diag_test.go
@@ -88,7 +88,13 @@ func TestDivergence_PrintHashesAndSLEs(t *testing.T) {
 //   sfReserveBase (UInt32)     = 10_000_000
 //   sfReserveIncrement (UInt32)= 2_000_000
 //   sfReferenceFeeUnits (UInt32)= 10
-//   + commonFields: sfLedgerEntryType=0x0066 (FeeSettings=102), sfFlags=0
+//   + commonFields: sfLedgerEntryType=0x0073 (FeeSettings=115,
+//     ledger_entries.macro:312), sfFlags=0.
+//
+// Field-id encoding rule (rippled Serializer.cpp): when fieldCode >= 16,
+// the header is (typeCode<<4)|0 followed by a separate byte holding the
+// fieldCode. So sfReferenceFeeUnits (type=2, field=30) is `20 1E`, not
+// `21 1E` — `21` would mean (type=2, field=1) which is sfFlags.
 func TestDivergence_LegacyFeeSettingsExpectedBytes(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Amendments = nil // legacy
@@ -103,24 +109,26 @@ func TestDivergence_LegacyFeeSettingsExpectedBytes(t *testing.T) {
 	}
 	got := hex.EncodeToString(item.Data())
 	t.Logf("legacy FeeSettings SLE bytes: %s", got)
-	// Manual XRPL binary codec assembly for verification:
-	// fields are sorted by (typeCode, fieldCode):
-	//   UInt16 LedgerEntryType (typeCode=1, fieldCode=1)  -> 0x11 + 0x0066
-	//   UInt32 Flags (typeCode=2, fieldCode=2)            -> 0x22 + 0x00000000
-	//   UInt32 ReferenceFeeUnits (typeCode=2, fieldCode=30)-> 0x21 0x1E + 0x0000000A
-	//   UInt32 ReserveBase (typeCode=2, fieldCode=31)     -> 0x21 0x1F + 0x00989680
-	//   UInt32 ReserveIncrement (typeCode=2, fieldCode=32)-> 0x21 0x20 + 0x001E8480
-	//   UInt64 BaseFee (typeCode=3, fieldCode=5)          -> 0x35 + 0x000000000000000A
-	// Expected hex: "11006622000000002211E000000000A211F00989680212001E8480350000000000000000A"
-	// (printed for human comparison; not asserted because field layout is established by the codec)
-	if len(got) == 0 {
-		t.Fatal("empty FeeSettings bytes")
+	// Fields sorted by (typeCode, fieldCode):
+	//   UInt16 LedgerEntryType  (t=1, f=1)  -> 11 + 0073
+	//   UInt32 Flags            (t=2, f=2)  -> 22 + 00000000
+	//   UInt32 ReferenceFeeUnits(t=2, f=30) -> 20 1E + 0000000A
+	//   UInt32 ReserveBase      (t=2, f=31) -> 20 1F + 00989680
+	//   UInt32 ReserveIncrement (t=2, f=32) -> 20 20 + 001E8480
+	//   UInt64 BaseFee          (t=3, f=5)  -> 35 + 000000000000000A
+	const want = "1100732200000000201e0000000a201f009896802020001e848035000000000000000a"
+	if got != want {
+		t.Fatalf("legacy FeeSettings SLE bytes diverged from rippled wire format\n got:  %s\n want: %s", got, want)
 	}
 }
 
-// TestDivergence_AccountRootDefaultBytes prints exactly what the genesis
-// AccountRoot SLE serializes to, so we can compare against rippled's
-// equivalent byte stream from Ledger.cpp:186-192.
+// TestDivergence_AccountRootDefaultBytes asserts the exact byte stream
+// produced for the genesis AccountRoot SLE, so any drift from rippled's
+// Ledger.cpp:186-192 layout is caught here rather than only via the
+// downstream account_hash mismatch.
+//
+// The genesis account ID is deterministic (DefaultConfig derives it
+// from the well-known seed), so this assertion is stable.
 func TestDivergence_AccountRootDefaultBytes(t *testing.T) {
 	cfg := DefaultConfig()
 	gen, err := Create(cfg)
@@ -134,12 +142,18 @@ func TestDivergence_AccountRootDefaultBytes(t *testing.T) {
 	}
 	got := hex.EncodeToString(item.Data())
 	t.Logf("Genesis AccountRoot SLE bytes: %s", got)
-	// rippled sets only sfSequence=1, sfAccount=<id>, sfBalance=INITIAL_XRP.
-	// commonFields auto-fill: sfLedgerEntryType=0x0061, sfFlags=0.
-	// soeREQUIRED defaults: sfOwnerCount=0, sfPreviousTxnID=0, sfPreviousTxnLgrSeq=0.
-	// goXRPL must produce the same bytes for the genesis hash to match.
-	if len(got) < 80 {
-		t.Fatal("AccountRoot bytes suspiciously short")
+	// Fields sorted by (typeCode, fieldCode):
+	//   UInt16 LedgerEntryType  (t=1, f=1)   -> 11 + 0061 (AccountRoot=97)
+	//   UInt32 Flags            (t=2, f=2)   -> 22 + 00000000
+	//   UInt32 Sequence         (t=2, f=4)   -> 24 + 00000001
+	//   UInt32 PreviousTxnLgrSeq(t=2, f=5)   -> 25 + 00000000
+	//   UInt32 OwnerCount       (t=2, f=13)  -> 2D + 00000000
+	//   Hash256 PreviousTxnID   (t=5, f=5)   -> 55 + <32 zero bytes>
+	//   Amount  Balance         (t=6, f=2)   -> 62 + 416345785D8A0000 (INITIAL_XRP, native)
+	//   Blob    AccountID       (t=8, f=1)   -> 81 14 + <20-byte genesis account>
+	const want = "1100612200000000240000000125000000002d0000000055000000000000000000000000000000000000000000000000000000000000000062416345785d8a00008114b5f762798a53d543a014caf8b297cff8f2f937e8"
+	if got != want {
+		t.Fatalf("Genesis AccountRoot SLE bytes diverged from rippled wire format\n got:  %s\n want: %s", got, want)
 	}
 }
 

--- a/tasks/issue-190-fix-plan.md
+++ b/tasks/issue-190-fix-plan.md
@@ -49,8 +49,13 @@ shaky.
 **is** the operating-mode never legitimately reaching Full.
 
 Additionally, `ourLCLMatchesPeers()` (`router.go:1132`) returns `true`
-when no peer reports our seq — meaning once the router *does* promote
-to Full, it will silently fork if the network has moved past us.
+when no tracked peer reports our exact seq. The promote-to-Full path
+is gated by `peerSeq <= ourSeq+1` (`router.go:1064`), so this is not
+an unbounded fork risk — but it does mean we will silently transition
+to Full while exactly one seq behind a peer if no other peer is at
+our seq, then validate against a stale LCL. The fix is to count
+peers at `ourSeq` *and* `ourSeq+1` (or refuse the transition when
+`total == 0`) rather than treating "no signal" as agreement.
 
 **Why this drives the bug:** without proposing mode, goXRPL
 - never originates proposals → its tx submissions are not relayed to

--- a/tasks/issue-190-fix-plan.md
+++ b/tasks/issue-190-fix-plan.md
@@ -1,0 +1,169 @@
+# Issue #190 — Ledger hash divergence vs rippled:2.6.2
+
+## Status
+
+Investigation complete. No production code change in this branch — the
+remaining work splits into three concrete fixes that warrant separate
+review (one is large enough to be its own design discussion).
+
+`internal/ledger/genesis/divergence_diag_test.go` is added in this
+branch as a diagnostic harness (passing, no production assertions).
+
+## Reported symptom recap
+
+Mixed kurtosis network (4× rippled:2.6.2 + 1× goXRPL). At empty seq 5:
+
+|             | rippled                      | goXRPL                       |
+|-------------|------------------------------|------------------------------|
+| close_time  | 827228421                    | 827228430 (Δ 9s)             |
+| account_hash| `72CF95AC7F0EB1B88EF2BA…`    | `3791BF543E5B77A17BC454…`    |
+| ledger_hash | `FC22EB5D…`                  | `C04D4B2F…`                  |
+| op mode     | proposing                    | full (never proposing)       |
+| tx prop     | working                      | goXRPL→rippled silent        |
+
+## Findings
+
+### F1 — Mode-manager wiring is dead code (real bug, highest priority)
+
+`ModeManager.OnLCLAcquired` (`internal/consensus/adaptor/modemanager.go:93`)
+and `OnValidationsReceived` (`:104`) are defined but **never called from
+production code** — `grep -rn` shows hits only in `*_test.go`. The state
+machine is therefore stuck at `OpModeConnected` / `OpModeSyncing` after
+startup.
+
+The router bypasses ModeManager and force-sets
+`SetOperatingMode(OpModeFull)` directly at
+`internal/consensus/adaptor/router.go:1071`, but only from
+`OpModeTracking` — which is itself only reached via
+`router.go:1025,1309`. Net result: the only way to reach `OpModeFull`
+in production is the router's force-set path, and the path to it is
+shaky.
+
+`Engine.startRoundLocked`
+(`internal/consensus/rcl/engine.go:374-386`) requires
+`IsValidator() && GetOperatingMode() == OpModeFull` to enter
+`ModeProposing`. Validator wiring works:
+`appCfg.ValidationSeed != ""` (set by kurtosis at
+`xrpl-confluence/src/topology.star:214`) →
+`IsValidator() == true` (`adaptor.go:616-618`). So the missing piece
+**is** the operating-mode never legitimately reaching Full.
+
+Additionally, `ourLCLMatchesPeers()` (`router.go:1132`) returns `true`
+when no peer reports our seq — meaning once the router *does* promote
+to Full, it will silently fork if the network has moved past us.
+
+**Why this drives the bug:** without proposing mode, goXRPL
+- never originates proposals → its tx submissions are not relayed to
+  rippled (explains `goXRPL → rippled` propagation symptom);
+- runs consensus rounds in Observing/non-validating mode where its
+  own `acceptLedger` computes a local `effCloseTime` from its own
+  clock and its own (mostly empty) proposal pool, instead of inheriting
+  the close_time from the validated ledger rippled produced — explains
+  the 9-second drift, exactly within one 10s resolution bucket.
+
+**Scope:** ~50 LOC across `adaptor/router.go`, the validation
+tracker, and the inbound-ledger acquisition path. Behavioural change;
+needs a careful test plan covering chain-switch and slow-start.
+
+### F2 — Genesis amendment-set drift between goXRPL and rippled (real, config-shaped)
+
+The reported `account_hash 3791BF54…` exactly matches the goXRPL
+unit test `TestGenesisHashConformance/StandardDefaults_WithAmendments`
+(`internal/ledger/genesis/genesis_test.go:307`). That means the
+deployed goXRPL was using `DefaultYesFeatures()` — 28 amendments
+listed in the diagnostic test output of `TestDivergence_PrintAmendmentList`.
+
+Meanwhile, `xrpl-confluence/src/topology.star:205` sets
+`genesis_amendments_disabled=true` for goXRPL nodes specifically, but
+the rippled sidecar at `topology.star:130-160` does **not** set the
+equivalent rippled flag — it runs with `START_UP=FRESH` (default) and
+seeds genesis with all `Supported && DefaultYes` amendments via
+`getDesired()`. The two genesis ledgers are therefore byte-different
+**by configuration**, not by code.
+
+Two ways to close this:
+
+- Align kurtosis topology so both sides enable the same amendment set
+  (and verify `DefaultYesFeatures()` exactly matches rippled 2.6.2's
+  `getDesired()` output ID-for-ID), OR
+- Have goXRPL refuse to synthesize genesis when joining an existing
+  network (see F3) — moot, because then it would adopt rippled's.
+
+Diagnostic harness (already in this branch):
+`go test -run TestDivergence -v ./internal/ledger/genesis/` prints the
+goXRPL `account_hash`, `ledger_hash`, FeeSettings/AccountRoot SLE
+bytes, and the 28-entry default amendment list for direct comparison
+against any rippled snapshot.
+
+### F3 — Genesis is always synthesized, never acquired (architectural gap)
+
+`internal/ledger/service/service.go:248` calls `genesis.Create(...)`
+unconditionally on `Service.Start()`. Rippled only does this when
+`START_UP == FRESH` (`rippled/src/xrpld/app/main/Application.cpp:1707-1712`);
+joining nodes acquire the chain head from peers via the
+inbound-ledger / replay path.
+
+Even when genesis bytes happen to match (F2 resolved), this is a latent
+correctness hazard: any non-validator joining via the network must
+adopt the network's chain, not synthesize its own and assert it as the
+LCL.
+
+**Scope:** ~150 LOC touching service.go startup, plus the inbound
+ledger acquisition path. Likely a `Config.SkipGenesisCreation` flag
+gated on bootstrap-peers + persistent-store presence, mirroring
+rippled's `START_UP=NETWORK` semantics.
+
+### F4 — Standalone-mode close_time is unrounded (small, peripheral)
+
+`internal/ledger/service/service.go:424` (`AcceptLedger`, standalone)
+sets `closeTime := time.Now()` and passes it through `Ledger.NewOpen`
++ `Ledger.Close` unrounded. Rippled's standalone path (`Ledger.cpp:296-304`)
+applies a genesis-aware rounding (round when `prev.closeTime == 0`,
+else `prev + resolution`).
+
+This does **not** explain the kurtosis bug — that scenario hits the
+consensus path, where `Engine.acceptLedger`
+(`internal/consensus/rcl/engine.go:1832`) **does** apply
+`effCloseTime(rawCloseTime, resolution, priorClose)` before calling
+`adaptor.BuildLedger`, which then forwards to
+`service.AcceptConsensusResult`. The agent's initial reading missed
+this — the consensus path is rounded.
+
+Real, but a unit-test-quality bug rather than a #190 driver.
+**Scope:** ~10 LOC in `service.AcceptLedger` + a regression test.
+
+## Recommended order
+
+1. **F1 — mode-manager wiring** (the root cause of "stuck in full" and
+   tx propagation breakage; very likely also explains the close_time
+   drift via local-vs-network consensus). Requires a separate PR with
+   a test plan covering the LCL-acquired transition and the
+   `ourLCLMatchesPeers` quorum tightening.
+2. **F2 — amendment-set parity** (configuration audit + a vendored
+   "rippled 2.6.2 expected genesis" fixture/test).
+3. **F4 — standalone close_time rounding** (small, can ride a sweep
+   PR).
+4. **F3 — genesis acquisition for non-FRESH startups** (largest;
+   architectural; do last and behind a feature flag).
+
+## What this branch contains
+
+- `internal/ledger/genesis/divergence_diag_test.go` — passing
+  diagnostic harness, no production code changed.
+- `tasks/issue-190-fix-plan.md` — this document.
+
+## Files of interest
+
+- `internal/ledger/service/service.go:248,424,1130`
+- `internal/ledger/ledger.go:125,485-534`
+- `internal/consensus/adaptor/adaptor.go:282,499-518,616`
+- `internal/consensus/adaptor/modemanager.go:36,91-110`
+- `internal/consensus/adaptor/router.go:1025-1137,1309`
+- `internal/consensus/rcl/engine.go:374-386,1822-1948,2319-2351`
+- `internal/cli/server.go:174-180`
+- `internal/ledger/genesis/genesis.go:108-117,189-308`
+- rippled `src/xrpld/app/ledger/Ledger.cpp:168-229,277-305`
+- rippled `src/xrpld/app/main/Application.cpp:1704-1724`
+- rippled `src/xrpld/app/consensus/RCLConsensus.cpp:481-495`
+- rippled `src/xrpld/consensus/LedgerTiming.h:131-169`
+- xrpl-confluence `src/topology.star:141,205,214`


### PR DESCRIPTION
## Summary

Investigation-only branch for #190 (ledger hash divergence vs rippled:2.6.2 in mixed kurtosis network). No production code changed.

Adds:
- `tasks/issue-190-fix-plan.md` — diagnosed root causes with prioritized fix order
- `internal/ledger/genesis/divergence_diag_test.go` — passing diagnostic harness that prints `account_hash`, `ledger_hash`, FeeSettings/AccountRoot SLE bytes, and the 28-entry DefaultYes amendment list for direct comparison against any rippled snapshot

## Findings (full detail in fix plan)

- **F1 (highest priority)**: `ModeManager.OnLCLAcquired` and `OnValidationsReceived` (`internal/consensus/adaptor/modemanager.go:91,104`) are dead code — never called from production. Operating mode never legitimately reaches `OpModeFull`, so consensus never enters `ModeProposing`. Explains "stuck in full" + broken tx propagation + the 9s `close_time` drift (local-vs-network consensus).
- **F2**: Genesis amendment-set drift between goXRPL (`genesis_amendments_disabled=true` in kurtosis topology) and the rippled sidecar (default DefaultYes amendments). Configuration parity task.
- **F3**: `Service.Start` always synthesizes genesis (`internal/ledger/service/service.go:248`); joining nodes should acquire chain head from peers (~150 LOC, architectural).
- **F4**: Standalone `service.AcceptLedger` close_time is unrounded — peripheral, ~10 LOC. (Corrects an early misreading: the consensus path *does* round at `engine.go:1832` before `BuildLedger`.)

Refs #190.

## Test plan
- [x] `go test ./internal/ledger/genesis/` — green (diagnostic test passes; no assertions on production code)
- [x] `go vet ./internal/ledger/... ./internal/consensus/...` — clean
- [ ] Each of F1–F4 lands in its own follow-up PR with appropriate tests