### PR TITLE
consensus/router: notify engine on inbound ledger adoption (fixes #359)

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -1032,6 +1032,15 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
 		"seq", hdr.LedgerIndex,
 		"hash", fmt.Sprintf("%x", hdr.Hash[:8]),
 	)
+	// Notify the consensus engine so it can flip out of
+	// ModeWrongLedger via Engine.OnLedger (rcl/engine.go:801). Without
+	// this, the engine remains stuck in wrongLedger indefinitely after
+	// a successful inbound acquisition. Issue #359.
+	if r.engine != nil {
+		if err := r.engine.OnLedger(consensus.LedgerID(hdr.Hash), nil); err != nil {
+			r.logger.Debug("engine rejected adopted ledger", "error", err, "seq", hdr.LedgerIndex)
+		}
+	}
 	return nil
 }
 
@@ -1319,4 +1328,12 @@ func (r *Router) completeInboundLedger() {
 		"hash", fmt.Sprintf("%x", h.Hash[:8]),
 		"account_hash", fmt.Sprintf("%x", h.AccountHash[:8]),
 	)
+	// Notify the consensus engine so it can flip out of
+	// ModeWrongLedger via Engine.OnLedger. Mirrors the replay-delta
+	// path in adoptVerifiedLedger — see Issue #359.
+	if r.engine != nil {
+		if err := r.engine.OnLedger(consensus.LedgerID(h.Hash), nil); err != nil {
+			r.logger.Debug("engine rejected adopted ledger", "error", err, "seq", h.LedgerIndex)
+		}
+	}
 }

--- a/internal/consensus/adaptor/router_recovery_test.go
+++ b/internal/consensus/adaptor/router_recovery_test.go
@@ -1,0 +1,52 @@
+package adaptor
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeRouterWithEngine wires a router against a real adaptor + recording
+// sender like makeRouter, but installs a mockEngine so tests can assert
+// on engine notifications from the router.
+func makeRouterWithEngine(t *testing.T) (*Router, *mockEngine, *service.Service) {
+	t.Helper()
+	svc := newTestLedgerService(t)
+	a, _ := newRecordingAdaptor(t, svc)
+	inbox := make(chan *peermanagement.InboundMessage, 8)
+	engine := &mockEngine{}
+	r := NewRouter(engine, a, nil, inbox)
+	return r, engine, svc
+}
+
+// TestRouter_AdoptVerifiedLedger_NotifiesEngine pins issue #359. When a
+// replay-delta acquisition succeeds and the router adopts the new
+// ledger via adoptVerifiedLedger, it MUST notify the consensus engine
+// via Engine.OnLedger. Without this notification the engine sits
+// indefinitely in ModeWrongLedger after acquisition (rcl/engine.go:801)
+// because OnLedger is the recovery primitive that flips back into
+// ModeSwitchedLedger and re-enters consensus.
+func TestRouter_AdoptVerifiedLedger_NotifiesEngine(t *testing.T) {
+	r, engine, svc := makeRouterWithEngine(t)
+	resp, expectedHash, seq := buildEmptyClosedSuccessorResponse(t, svc)
+
+	parent := svc.GetClosedLedger()
+	require.NoError(t, r.startReplayDeltaAcquisition(seq, expectedHash, 7, parent))
+
+	payload, err := message.Encode(resp)
+	require.NoError(t, err)
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeReplayDeltaResponse),
+		Payload: payload,
+	})
+
+	ledgers := engine.getLedgers()
+	require.Len(t, ledgers, 1, "router must notify engine of adopted ledger after replay-delta succeeds")
+	assert.Equal(t, consensus.LedgerID(expectedHash), ledgers[0])
+}

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -20,18 +20,31 @@ type mockEngine struct {
 	proposals   []*consensus.Proposal
 	validations []*consensus.Validation
 	txSets      []consensus.TxSetID
+	ledgers     []consensus.LedgerID
 }
 
-func (m *mockEngine) Start(context.Context) error               { return nil }
-func (m *mockEngine) Stop() error                               { return nil }
-func (m *mockEngine) StartRound(consensus.RoundID, bool) error  { return nil }
-func (m *mockEngine) State() *consensus.RoundState              { return nil }
-func (m *mockEngine) Mode() consensus.Mode                      { return consensus.ModeObserving }
-func (m *mockEngine) Phase() consensus.Phase                    { return consensus.PhaseOpen }
-func (m *mockEngine) IsProposing() bool                         { return false }
-func (m *mockEngine) Timing() consensus.Timing                  { return consensus.DefaultTiming() }
-func (m *mockEngine) GetLastCloseInfo() (int, time.Duration)    { return 0, 0 }
-func (m *mockEngine) OnLedger(consensus.LedgerID, []byte) error { return nil }
+func (m *mockEngine) Start(context.Context) error              { return nil }
+func (m *mockEngine) Stop() error                              { return nil }
+func (m *mockEngine) StartRound(consensus.RoundID, bool) error { return nil }
+func (m *mockEngine) State() *consensus.RoundState             { return nil }
+func (m *mockEngine) Mode() consensus.Mode                     { return consensus.ModeObserving }
+func (m *mockEngine) Phase() consensus.Phase                   { return consensus.PhaseOpen }
+func (m *mockEngine) IsProposing() bool                        { return false }
+func (m *mockEngine) Timing() consensus.Timing                 { return consensus.DefaultTiming() }
+func (m *mockEngine) GetLastCloseInfo() (int, time.Duration)   { return 0, 0 }
+
+func (m *mockEngine) OnLedger(id consensus.LedgerID, _ []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ledgers = append(m.ledgers, id)
+	return nil
+}
+
+func (m *mockEngine) getLedgers() []consensus.LedgerID {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]consensus.LedgerID(nil), m.ledgers...)
+}
 
 func (m *mockEngine) OnProposal(p *consensus.Proposal, _ uint64) error {
 	m.mu.Lock()


### PR DESCRIPTION
## Summary

- After `SubmitHeldAdoption` succeeds in `Router.completeInboundLedger` and `Router.adoptVerifiedLedger`, call `Engine.OnLedger(adoptedHash, nil)` so the consensus engine can flip out of `ModeWrongLedger`. Without this, the engine sat indefinitely in wrongLedger after a successful inbound acquisition — the proposing→observing→wrongLedger oscillation reported in #358.
- Adds a regression test (`TestRouter_AdoptVerifiedLedger_NotifiesEngine`) that drives a replay-delta acquisition end-to-end and asserts the engine is notified with the adopted ledger's hash.
- Extends `mockEngine` with `OnLedger` recording.

## Why

`Engine.OnLedger` (`internal/consensus/rcl/engine.go:801`) is the recovery primitive that flips out of `ModeWrongLedger`, sets `HaveCorrectLCL=true`, and calls `startRoundLocked(..., recovering=true)`. The only previous caller (`router.go:1196`) is in the legacy `ledger_data` fall-through and is gated off when `r.inboundLedger != nil`, so a successful inbound acquisition skipped the engine entirely.

This matches rippled's `Consensus<>::handleWrongLedger` (`Consensus.h:1062-1113`) which calls `adaptor_.acquireLedger` synchronously and on success calls `startRoundInternal(..., switchedLedger)`.

The `r.engine != nil` guard preserves existing test code paths (`makeRouter` still passes nil engine).

## Test plan

- [x] `go test ./internal/consensus/...` — all pass
- [x] `go vet ./internal/consensus/...` — clean
- [x] New test `TestRouter_AdoptVerifiedLedger_NotifiesEngine` — fails on main, passes on this branch
- [ ] Reproduce #358 testnet (2 rippled v2.6.2 + 1 goXRPL with all keys trusted) and observe `validated_ledger.seq` advancing past 5 — needs follow-up validation in the testnet harness