### PR TITLE
consensus: thread closeTimeCorrect through ledger close (fixes #361)

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -497,7 +497,7 @@ func (a *Adaptor) GetValidatedLedgerHash() consensus.LedgerID {
 	return consensus.LedgerID(vl.Hash())
 }
 
-func (a *Adaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time) (consensus.Ledger, error) {
+func (a *Adaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, closeTimeCorrect bool) (consensus.Ledger, error) {
 	// Unwrap the parent to get the concrete ledger for the service.
 	// This is critical for chain switching: the parent may differ from
 	// the service's internal closedLedger after wrong ledger detection.
@@ -509,7 +509,7 @@ func (a *Adaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, cl
 	// propagate a context. Until that interface gains one, persistence
 	// here cannot be cancelled by the consensus engine. Tracked separately
 	// from this issue (#185).
-	seq, err := a.ledgerService.AcceptConsensusResult(context.TODO(), parentLedger, txSet.Txs(), closeTime)
+	seq, err := a.ledgerService.AcceptConsensusResult(context.TODO(), parentLedger, txSet.Txs(), closeTime, closeTimeCorrect)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -131,7 +131,10 @@ type Adaptor interface {
 	GetValidatedLedgerHash() LedgerID
 
 	// BuildLedger constructs a new ledger from a transaction set.
-	BuildLedger(parent Ledger, txSet TxSet, closeTime time.Time) (Ledger, error)
+	// closeTimeCorrect is true when consensus agreed on the close time;
+	// when false, the resulting header carries sLCF_NoConsensusTime so
+	// the hash matches what rippled produces in the same case.
+	BuildLedger(parent Ledger, txSet TxSet, closeTime time.Time, closeTimeCorrect bool) (Ledger, error)
 
 	// ValidateLedger checks if a ledger is valid.
 	ValidateLedger(ledger Ledger) error

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1873,7 +1873,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	}
 
 	// Build the new ledger
-	newLedger, err := e.adaptor.BuildLedger(e.prevLedger, txSet, closeTime)
+	newLedger, err := e.adaptor.BuildLedger(e.prevLedger, txSet, closeTime, e.haveCloseTimeConsensus)
 	if err != nil {
 		return
 	}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -228,7 +228,7 @@ func (a *mockAdaptor) GetLastClosedLedger() (consensus.Ledger, error) {
 	return a.lastLCL, nil
 }
 
-func (a *mockAdaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time) (consensus.Ledger, error) {
+func (a *mockAdaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, _ bool) (consensus.Ledger, error) {
 	newLedger := &mockLedger{
 		id:        consensus.LedgerID{byte(parent.Seq() + 1)},
 		seq:       parent.Seq() + 1,

--- a/internal/ledger/service/close_flags_test.go
+++ b/internal/ledger/service/close_flags_test.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAcceptConsensusResult_CloseTimeCorrectFlag pins issue #361. When
+// consensus did not agree on close time, AcceptConsensusResult must
+// stamp the closed ledger header with sLCF_NoConsensusTime (0x01) so
+// the resulting hash matches what rippled produces in the same case
+// (RCLConsensus.cpp:775-801 → Ledger.cpp:367).
+func TestAcceptConsensusResult_CloseTimeCorrectFlag(t *testing.T) {
+	correct := closeAndGetFlags(t, true)
+	noConsensus := closeAndGetFlags(t, false)
+
+	assert.Zero(t, correct&header.LCFNoConsensusTime,
+		"closeTimeCorrect=true must clear LCFNoConsensusTime")
+	assert.NotZero(t, noConsensus&header.LCFNoConsensusTime,
+		"closeTimeCorrect=false must set LCFNoConsensusTime")
+}
+
+// TestAcceptConsensusResult_CloseFlagsAffectHash verifies the flag
+// participates in the ledger hash. Two ledgers with identical inputs but
+// different closeTimeCorrect values must have different hashes; otherwise
+// the flag could not be the cause of the silent rippled rejection in #358.
+func TestAcceptConsensusResult_CloseFlagsAffectHash(t *testing.T) {
+	hashCorrect := closeAndGetHash(t, true)
+	hashNoConsensus := closeAndGetHash(t, false)
+
+	assert.NotEqual(t, hashCorrect, hashNoConsensus,
+		"closeFlags byte is part of the hashed header — flipping it must change the hash")
+}
+
+func closeAndGetFlags(t *testing.T, closeTimeCorrect bool) uint8 {
+	t.Helper()
+	hdr := closeAndGetHeader(t, closeTimeCorrect)
+	return hdr.CloseFlags
+}
+
+func closeAndGetHash(t *testing.T, closeTimeCorrect bool) [32]byte {
+	t.Helper()
+	hdr := closeAndGetHeader(t, closeTimeCorrect)
+	return hdr.Hash
+}
+
+func closeAndGetHeader(t *testing.T, closeTimeCorrect bool) header.LedgerHeader {
+	t.Helper()
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	parent := svc.GetClosedLedger()
+	require.NotNil(t, parent)
+	closeTime := time.Unix(1700000000, 0)
+
+	_, err = svc.AcceptConsensusResult(context.TODO(), parent, nil, closeTime, closeTimeCorrect)
+	require.NoError(t, err)
+
+	svc.mu.RLock()
+	defer svc.mu.RUnlock()
+	return svc.closedLedger.Header()
+}

--- a/internal/ledger/service/pending_ledger_validation_test.go
+++ b/internal/ledger/service/pending_ledger_validation_test.go
@@ -378,7 +378,7 @@ func TestAcceptConsensusResult_EventCallbackFiresAfterValidationFirstRace(t *tes
 	require.NotNil(t, parent)
 	expectedSeq := parent.Sequence() + 1
 	closeTime := time.Unix(1700000000, 0)
-	_, err = probeSvc.AcceptConsensusResult(context.TODO(), parent, nil, closeTime)
+	_, err = probeSvc.AcceptConsensusResult(context.TODO(), parent, nil, closeTime, true)
 	require.NoError(t, err)
 
 	// Capture the hash that the deterministic close produced.
@@ -404,7 +404,7 @@ func TestAcceptConsensusResult_EventCallbackFiresAfterValidationFirstRace(t *tes
 	// Close the consensus ledger. F4 drain sees the matching-hash,
 	// non-expired stash and promotes validatedLedger. eventCallback MUST
 	// fire inline because no later SetValidatedLedger will arrive.
-	closedSeq, err := svc.AcceptConsensusResult(context.TODO(), parentReal, nil, closeTime)
+	closedSeq, err := svc.AcceptConsensusResult(context.TODO(), parentReal, nil, closeTime, true)
 	require.NoError(t, err)
 	require.Equal(t, expectedSeq, closedSeq)
 

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1138,7 +1138,7 @@ type LedgerInfo struct {
 //
 // The multi-pass retry logic is the same as AcceptLedger to match rippled's
 // BuildLedger behavior.
-func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledger, txBlobs [][]byte, closeTime time.Time) (uint32, error) {
+func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledger, txBlobs [][]byte, closeTime time.Time, closeTimeCorrect bool) (uint32, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1327,8 +1327,15 @@ func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledg
 	// Reset pending transactions
 	s.pendingTxs = nil
 
-	// Close the ledger with the consensus-agreed close time
-	if err := s.openLedger.Close(closeTime, 0); err != nil {
+	// Close the ledger with the consensus-agreed close time. Match
+	// rippled's Ledger.cpp:367 — when consensus did not agree on
+	// closeTime, set sLCF_NoConsensusTime so the hash matches what
+	// rippled produces in the same case (Issue #361).
+	var closeFlags uint8
+	if !closeTimeCorrect {
+		closeFlags = header.LCFNoConsensusTime
+	}
+	if err := s.openLedger.Close(closeTime, closeFlags); err != nil {
 		return 0, fmt.Errorf("failed to close ledger: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Add `closeTimeCorrect bool` to `consensus.Engine.BuildLedger`, plumb it through `Adaptor.BuildLedger` → `Service.AcceptConsensusResult` → `Ledger.Close`.
- Source it from `rcl.Engine.haveCloseTimeConsensus` at the call site.
- When false, `Service.AcceptConsensusResult` now sets `header.LCFNoConsensusTime` (`0x01`) on the closed ledger header — matching rippled's `Ledger.cpp:367` behavior.
- Standalone close paths (genesis bootstrap, `AcceptLedger`) keep their existing `closeFlags=0` since there's no consensus disagreement in standalone mode.

## Why

`internal/ledger/service/service.go:1331` was hardcoding `closeFlags=0` on every consensus close, regardless of whether consensus agreed on the close time. The `closeFlags` byte is part of the hashed header (`internal/ledger/ledger.go:892-921`), so whenever the network falls into the no-consensus-time branch, goXRPL produced a different ledger hash than rippled and rippled silently rejected the resulting validation. Contributing factor to #358.

Reference: rippled `RCLConsensus.cpp:775-801` passes `closeTimeCorrect` to `buildLedger`; `Ledger.cpp:367` writes `info_.closeFlags = correctCloseTime ? 0 : sLCF_NoConsensusTime`.

## Test plan

- [x] New `TestAcceptConsensusResult_CloseTimeCorrectFlag` — closing with `closeTimeCorrect=false` sets `LCFNoConsensusTime`; with `true` it stays clear
- [x] New `TestAcceptConsensusResult_CloseFlagsAffectHash` — flipping the flag changes the ledger hash (proves the byte is hashed)
- [x] `go test ./internal/consensus/... ./internal/ledger/...` — all pass
- [x] `go vet ./...` — clean (pre-existing warning in mock_binary_parser.go is unrelated)
- [ ] Reproduce #358 testnet and confirm the rippled-side acceptance counter for the goXRPL signing pubkey ticks up — needs follow-up validation in the testnet harness once #359 is also merged