### PR TITLE
consensus: clarify roundCloseTime parity, pin cookie contract (refs #363)

### DIFF
--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -105,6 +105,19 @@ func TestComputeQuorum(t *testing.T) {
 	}
 }
 
+// TestAdaptor_CookieIsAlwaysNonZero pins the boot-cookie contract
+// rippled relies on for sfCookie under HardenedValidations
+// (RCLConsensus.cpp:813-818): the cookie generated at construction is
+// never zero, so soeDEFAULT serialization always includes the field.
+// Issue #363 E2.
+func TestAdaptor_CookieIsAlwaysNonZero(t *testing.T) {
+	for i := 0; i < 16; i++ {
+		a := newTestAdaptor(t)
+		assert.NotZero(t, a.GetCookie(),
+			"Adaptor.cookie must be non-zero at boot; serializer omits zero (soeDEFAULT)")
+	}
+}
+
 func TestAdaptorNonValidator(t *testing.T) {
 	svc := newTestLedgerService(t)
 	a := New(Config{

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -2318,20 +2318,30 @@ func (e *Engine) sendValidation(ledger consensus.Ledger) {
 
 // roundCloseTime rounds a close time to the nearest multiple of resolution.
 // Rounds up if the close time is at the midpoint.
-// Reference: rippled LedgerTiming.h roundCloseTime()
+//
+// Mirrors rippled's chrono integer math at LedgerTiming.h:131-143 over
+// NetClock::time_point (XRPL-epoch seconds). Rippled's input has
+// integer-second precision; we match that semantics by truncating
+// time.Time's sub-second component before rounding, so two validators
+// with skewed nanosecond clocks reduce to the same integer-second
+// input and round to the same boundary.
+//
+// Doing the modulo in XRPL-epoch space (rather than Unix epoch) is
+// equivalent at any resolution that divides RippleEpochUnix — which
+// covers every resolution rippled currently uses — but matches
+// rippled byte-for-byte without depending on that coincidence.
 func roundCloseTime(closeTime time.Time, resolution time.Duration) time.Time {
 	if closeTime.IsZero() {
 		return closeTime
 	}
-	// Add half the resolution for rounding
-	adjusted := closeTime.Add(resolution / 2)
-	// Truncate to the nearest resolution boundary using Unix seconds
-	epoch := adjusted.Unix()
 	resSec := int64(resolution.Seconds())
 	if resSec <= 0 {
 		return closeTime
 	}
-	return time.Unix(epoch-(epoch%resSec), 0).UTC()
+	xrplSec := closeTime.Unix() - protocol.RippleEpochUnix
+	xrplSec += resSec / 2
+	xrplSec -= xrplSec % resSec
+	return time.Unix(xrplSec+protocol.RippleEpochUnix, 0).UTC()
 }
 
 // effCloseTime calculates the effective ledger close time.

--- a/internal/consensus/rcl/round_close_time_test.go
+++ b/internal/consensus/rcl/round_close_time_test.go
@@ -1,0 +1,118 @@
+package rcl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/protocol"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRoundCloseTime_RippledParity pins the XRPL-epoch integer math
+// rippled uses (LedgerTiming.h:131-143). Issue #363 E1.
+//
+// rippled's roundCloseTime over NetClock::time_point operates on
+// integer seconds since the XRPL epoch (2000-01-01). The algorithm:
+//
+//	closeTime += closeResolution / 2
+//	return closeTime - (closeTime.time_since_epoch() % closeResolution)
+//
+// goXRPL must produce identical results when given the same wall-clock
+// inputs at standard close resolutions.
+func TestRoundCloseTime_RippledParity(t *testing.T) {
+	xrplBase := time.Unix(protocol.RippleEpochUnix, 0).UTC()
+
+	cases := []struct {
+		name       string
+		input      time.Time
+		resolution time.Duration
+		want       time.Time
+	}{
+		{
+			name:       "zero stays zero",
+			input:      time.Time{},
+			resolution: 10 * time.Second,
+			want:       time.Time{},
+		},
+		{
+			name:       "exact multiple of resolution",
+			input:      xrplBase.Add(30 * time.Second),
+			resolution: 10 * time.Second,
+			want:       xrplBase.Add(30 * time.Second),
+		},
+		{
+			name:       "below midpoint rounds down",
+			input:      xrplBase.Add(34 * time.Second),
+			resolution: 10 * time.Second,
+			want:       xrplBase.Add(30 * time.Second),
+		},
+		{
+			name:       "at midpoint rounds up",
+			input:      xrplBase.Add(35 * time.Second),
+			resolution: 10 * time.Second,
+			want:       xrplBase.Add(40 * time.Second),
+		},
+		{
+			name:       "above midpoint rounds up",
+			input:      xrplBase.Add(36 * time.Second),
+			resolution: 10 * time.Second,
+			want:       xrplBase.Add(40 * time.Second),
+		},
+		{
+			name:       "sub-second component truncated then rounded",
+			input:      xrplBase.Add(34*time.Second + 999*time.Millisecond),
+			resolution: 10 * time.Second,
+			want:       xrplBase.Add(30 * time.Second),
+		},
+		{
+			name:       "30s resolution at exact half",
+			input:      xrplBase.Add(15 * time.Second),
+			resolution: 30 * time.Second,
+			want:       xrplBase.Add(30 * time.Second),
+		},
+		{
+			name:       "60s resolution",
+			input:      xrplBase.Add(89 * time.Second),
+			resolution: 60 * time.Second,
+			want:       xrplBase.Add(60 * time.Second),
+		},
+		{
+			name:       "well past XRPL epoch (2025-era)",
+			input:      time.Unix(protocol.RippleEpochUnix+780_000_000, 0).UTC(),
+			resolution: 10 * time.Second,
+			want:       time.Unix(protocol.RippleEpochUnix+780_000_000, 0).UTC(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := roundCloseTime(tc.input, tc.resolution)
+			assert.True(t, got.Equal(tc.want),
+				"roundCloseTime(%v, %v) = %v, want %v",
+				tc.input, tc.resolution, got, tc.want)
+		})
+	}
+}
+
+// TestRoundCloseTime_StableAcrossSubSecondInputs verifies that two
+// inputs differing only in their sub-second component produce the same
+// rounded output, because rippled's NetClock has integer-second
+// precision and goXRPL must match that semantics.
+func TestRoundCloseTime_StableAcrossSubSecondInputs(t *testing.T) {
+	xrplBase := time.Unix(protocol.RippleEpochUnix+1_000_000, 0).UTC()
+	resolution := 10 * time.Second
+
+	// Same integer second, different sub-second components.
+	a := xrplBase.Add(34 * time.Second)
+	b := xrplBase.Add(34*time.Second + 500*time.Millisecond)
+	c := xrplBase.Add(34*time.Second + 999_999_999*time.Nanosecond)
+
+	roundedA := roundCloseTime(a, resolution)
+	roundedB := roundCloseTime(b, resolution)
+	roundedC := roundCloseTime(c, resolution)
+
+	assert.True(t, roundedA.Equal(roundedB),
+		"sub-second variance must not change rounded output: %v vs %v", roundedA, roundedB)
+	assert.True(t, roundedA.Equal(roundedC),
+		"nanosecond variance must not change rounded output: %v vs %v", roundedA, roundedC)
+}


### PR DESCRIPTION
## Summary

Two small consensus parity items from #363, with one resolved by refactor and one resolved by investigation.

### E1 — `roundCloseTime` parity refactor
Rippled's `LedgerTiming.h:131-143` does its modulo math in XRPL-epoch space over integer-second `NetClock::time_point`. goXRPL was doing the same modulo in Unix-epoch space, which is mathematically equivalent only because `RippleEpochUnix (946684800)` happens to be divisible by every resolution rippled currently uses (10/20/30/60/90/120s).

Refactored `roundCloseTime` to do XRPL-epoch math directly so the parity is obvious from the code instead of a dependency on a coincidence. Truncate the sub-second component of `time.Time` before adding the half-resolution offset, so two validators with nanosecond clock skew on the same integer second reduce to the same input.

Behavior is unchanged at every standard resolution; the refactor is cosmetic + future-proofing.

Added `TestRoundCloseTime_RippledParity` and `TestRoundCloseTime_StableAcrossSubSecondInputs` as regression guards.

### E2 — `sfCookie` emission (investigation only)
The original concern in #363 was that goXRPL might drop the `sfCookie` field under `HardenedValidations`. Investigation showed there is no actual divergence:

- `Adaptor.cookie` (`adaptor.go:243-259`) is already generated at boot from `crypto/rand` with a fall-back to `time.Now().UnixNano()`, plus an explicit `if cookie == 0 { cookie = 1 }` guard. The boot-cookie is **always** non-zero, matching rippled's `RCLConsensus.cpp:813-818` contract.
- The serializer's `Cookie != 0` gate (`stvalidation.go:321`) is **the correct implementation of `soeDEFAULT`**, which omits zero values per XRPL binary codec rules. Rippled does the same.

So under `HardenedValidations`, both implementations always emit a non-zero `sfCookie` on the wire. No code change required. Added `TestAdaptor_CookieIsAlwaysNonZero` to pin the boot-cookie contract as a regression guard.

## Test plan

- [x] New `TestRoundCloseTime_RippledParity` — 9 sub-cases covering identity, exact multiples, below/at/above midpoint, sub-second truncation, multiple resolutions
- [x] New `TestRoundCloseTime_StableAcrossSubSecondInputs` — sub-second variance must not change rounded output
- [x] New `TestAdaptor_CookieIsAlwaysNonZero` — boot cookie contract over 16 fresh adaptors
- [x] `go test ./internal/consensus/...` — all pass
- [x] `go vet ./internal/consensus/...` — clean