### PR TITLE
consensus: add flag-ledger pseudo-tx injection seam (fixes #367)

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -558,6 +558,21 @@ func (a *Adaptor) GetPendingTxs() [][]byte {
 	return blobs
 }
 
+// GenerateFlagLedgerPseudoTxs is a stub: vote-tally producers (fee
+// vote, amendment vote) are not yet implemented in goXRPL. See
+// follow-up issues #369 (fee) and #370 (amendments). Returns nil so
+// the engine's injection step at closeLedger is a no-op until those
+// land — matching the pre-#367 behavior of never injecting.
+func (a *Adaptor) GenerateFlagLedgerPseudoTxs(_ consensus.Ledger) [][]byte {
+	return nil
+}
+
+// GenerateNegativeUNLPseudoTx is a stub: NegativeUNLVote tally is
+// not yet implemented. See follow-up issue #368.
+func (a *Adaptor) GenerateNegativeUNLPseudoTx(_ consensus.Ledger) []byte {
+	return nil
+}
+
 func (a *Adaptor) GetTxSet(id consensus.TxSetID) (consensus.TxSet, error) {
 	ts, ok := a.txSetCache.Get(id)
 	if !ok {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -897,6 +897,50 @@ func (a *Adaptor) IsFeatureEnabled(name string) bool {
 	return rules.Enabled(f.ID)
 }
 
+// IsFeatureEnabledOnLedger reports whether the named amendment is
+// enabled in the rules of the supplied ledger. Mirrors rippled's
+// `prevLedger->rules().enabled(featureX)` at RCLConsensus.cpp:370:
+// rules are read from THAT specific ledger, not from the validated
+// view, and a miss in the amendment table is "not enabled" (not
+// "assume enabled" — the lax default of IsFeatureEnabled is for
+// the validation-broadcast path, not for engine-level gates).
+//
+// Returns false when the ledger is nil, when it does not unwrap to
+// a *ledger.Ledger this adaptor recognises, when rules are nil, or
+// when the feature name is unknown. That matches rippled's
+// Rules::enabled semantics for a strict gate.
+func (a *Adaptor) IsFeatureEnabledOnLedger(l consensus.Ledger, name string) bool {
+	if l == nil {
+		return false
+	}
+	w, ok := l.(*LedgerWrapper)
+	if !ok {
+		return false
+	}
+	rules := w.Unwrap().Rules()
+	if rules == nil {
+		return false
+	}
+	f := amendment.GetFeatureByName(name)
+	if f == nil {
+		return false
+	}
+	return rules.Enabled(f.ID)
+}
+
+// IsStandalone reports whether the node is configured for standalone
+// (single-node) operation. Mirrors rippled's
+// `app_.config().standalone()` at RCLConsensus.cpp:352. Used by the
+// engine to bypass the proposing-mode gate on flag-ledger pseudo-tx
+// injection (matching rippled's `standalone() || (proposing &&
+// !wrongLCL)` OR-form).
+func (a *Adaptor) IsStandalone() bool {
+	if a.ledgerService == nil {
+		return false
+	}
+	return a.ledgerService.IsStandalone()
+}
+
 // --- Time operations ---
 
 func (a *Adaptor) Now() time.Time {

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -147,6 +147,31 @@ type Adaptor interface {
 	// GetPendingTxs returns transactions waiting to be included.
 	GetPendingTxs() [][]byte
 
+	// GenerateFlagLedgerPseudoTxs returns the fee-vote and
+	// amendment-vote pseudo-transaction blobs to inject into the
+	// proposal initial set when prevLedger is a flag ledger. Mirrors
+	// rippled's RCLConsensus.cpp:354-367 — when the previous ledger is
+	// a flag ledger, validators tally fee and amendment votes from the
+	// validations of the ledger before that and emit SetFee /
+	// EnableAmendment pseudo-txs reflecting the consensus.
+	//
+	// Returns nil when no votes apply or when the local node is not
+	// eligible to inject (non-validating, wrongLCL). Adaptors that
+	// don't implement vote tallying yet (most goXRPL builds today)
+	// should return nil — the engine treats nil as "no pseudo-txs",
+	// matching the behavior before #367 landed. The actual vote-tally
+	// producers ship in #368/#369/#370.
+	GenerateFlagLedgerPseudoTxs(prevLedger Ledger) [][]byte
+
+	// GenerateNegativeUNLPseudoTx returns the NegativeUNL pseudo-tx
+	// to inject when prevLedger is a voting ledger AND the
+	// featureNegativeUNL amendment is enabled. Mirrors rippled
+	// RCLConsensus.cpp:368-380.
+	//
+	// Returns nil when no NegUNL changes are required. Adaptors
+	// without NegativeUNLVote support return nil.
+	GenerateNegativeUNLPseudoTx(prevLedger Ledger) []byte
+
 	// GetTxSet returns a transaction set by ID.
 	GetTxSet(id TxSetID) (TxSet, error)
 

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -155,12 +155,17 @@ type Adaptor interface {
 	// validations of the ledger before that and emit SetFee /
 	// EnableAmendment pseudo-txs reflecting the consensus.
 	//
-	// Returns nil when no votes apply or when the local node is not
-	// eligible to inject (non-validating, wrongLCL). Adaptors that
-	// don't implement vote tallying yet (most goXRPL builds today)
-	// should return nil — the engine treats nil as "no pseudo-txs",
-	// matching the behavior before #367 landed. The actual vote-tally
-	// producers ship in #368/#369/#370.
+	// The producer is also responsible for the quorum gate at
+	// RCLConsensus.cpp:361 (`validations.size() >= quorum`) and the
+	// negativeUNLFilter at RCLConsensus.cpp:358 — the engine does not
+	// pre-check those.
+	//
+	// Returns nil when no votes apply (insufficient validations, no
+	// vote stance to emit, etc.). Adaptors that don't implement vote
+	// tallying yet (most goXRPL builds today) should return nil — the
+	// engine treats nil as "no pseudo-txs", matching the behavior
+	// before #367 landed. The actual vote-tally producers ship in
+	// #368/#369/#370.
 	GenerateFlagLedgerPseudoTxs(prevLedger Ledger) [][]byte
 
 	// GenerateNegativeUNLPseudoTx returns the NegativeUNL pseudo-tx
@@ -241,6 +246,30 @@ type Adaptor interface {
 	// yet, adaptor-only test harness) SHOULD return true to preserve
 	// the mainnet-default behavior of emitting the optional fields.
 	IsFeatureEnabled(name string) bool
+
+	// IsFeatureEnabledOnLedger reports whether the named amendment is
+	// enabled in the rules of the given ledger. Mirrors rippled's
+	// `prevLedger->rules().enabled(featureX)` pattern (e.g.
+	// RCLConsensus.cpp:370 for featureNegativeUNL): the gate is read
+	// from the rules of the ledger consensus is building on, NOT from
+	// the most-recently validated ledger. Disagreement between the two
+	// is possible during sync or right after a fork heal — see
+	// IsFeatureEnabled for the laxer "validated view" variant used by
+	// the validation-broadcast path.
+	//
+	// Returns false on unknown feature, on a nil ledger, or when rules
+	// can't be resolved — matching rippled's `Rules::enabled` (a miss
+	// in the amendment table is "not enabled"). This is the strict
+	// semantic for a gate; the lax "treat unknown as enabled" default
+	// of IsFeatureEnabled is intentionally NOT shared here.
+	IsFeatureEnabledOnLedger(ledger Ledger, name string) bool
+
+	// IsStandalone reports whether the node is configured for
+	// standalone (single-node) operation. Mirrors rippled's
+	// `app_.config().standalone()` check at RCLConsensus.cpp:352,
+	// which forces pseudo-tx injection in standalone mode even when
+	// consensus is not in the proposing state.
+	IsStandalone() bool
 
 	// GetCookie returns the validator's per-boot sfCookie value —
 	// generated once at adaptor construction from a CSPRNG. Emitted on

--- a/internal/consensus/ledger_timing.go
+++ b/internal/consensus/ledger_timing.go
@@ -64,6 +64,35 @@ const increaseLedgerTimeResolutionEvery uint32 = 8
 // seconds). Matches rippled LedgerTiming.h:53.
 const decreaseLedgerTimeResolutionEvery uint32 = 1
 
+// FlagLedgerInterval is the period (in ledgers) on which validators
+// vote on amendments and fee/reserve changes. Matches rippled's
+// FLAG_LEDGER_INTERVAL constant (Ledger.cpp).
+const FlagLedgerInterval uint32 = 256
+
+// IsFlagLedger reports whether the ledger at the given sequence is a
+// flag ledger — the ledger on which fee and amendment vote results
+// take effect. Matches rippled Ledger.cpp `isFlagLedger`: true when
+// seq is non-zero and divisible by FlagLedgerInterval.
+//
+// Pseudo-txs from a flag ledger's voting cycle are injected into the
+// ledger AFTER the flag ledger; rippled gates this on
+// `prevLedger.isFlagLedger()` in RCLConsensus.cpp:354.
+func IsFlagLedger(seq uint32) bool {
+	return seq != 0 && seq%FlagLedgerInterval == 0
+}
+
+// IsVotingLedger reports whether the validation for the ledger at the
+// given sequence carries fee-vote and amendment-vote fields — i.e.
+// the ledger BEFORE a flag ledger. Matches rippled Ledger.cpp:
+// (seq + 1) % FlagLedgerInterval == 0.
+//
+// In rippled this also gates NegativeUNL pseudo-tx injection at
+// RCLConsensus.cpp:368-380 (when prevLedger is a voting ledger the
+// upcoming ledger is a flag ledger and NegUNL changes apply).
+func IsVotingLedger(seq uint32) bool {
+	return (seq+1)%FlagLedgerInterval == 0
+}
+
 // GetNextLedgerTimeResolution returns the close-time resolution, in
 // seconds, for the ledger at sequence newLedgerSeq, given the parent
 // ledger's resolution and whether the prior consensus round agreed

--- a/internal/consensus/ledger_timing.go
+++ b/internal/consensus/ledger_timing.go
@@ -66,25 +66,28 @@ const decreaseLedgerTimeResolutionEvery uint32 = 1
 
 // FlagLedgerInterval is the period (in ledgers) on which validators
 // vote on amendments and fee/reserve changes. Matches rippled's
-// FLAG_LEDGER_INTERVAL constant (Ledger.cpp).
+// FLAG_LEDGER_INTERVAL constant at Ledger.h:426.
 const FlagLedgerInterval uint32 = 256
 
 // IsFlagLedger reports whether the ledger at the given sequence is a
 // flag ledger — the ledger on which fee and amendment vote results
-// take effect. Matches rippled Ledger.cpp `isFlagLedger`: true when
-// seq is non-zero and divisible by FlagLedgerInterval.
+// take effect. Matches rippled's free `isFlagLedger(LedgerIndex seq)`
+// at Ledger.cpp:957-959 and the member `Ledger::isFlagLedger()` at
+// Ledger.cpp:946-948 exactly: `seq % FLAG_LEDGER_INTERVAL == 0`,
+// with no special-casing of seq=0.
 //
 // Pseudo-txs from a flag ledger's voting cycle are injected into the
 // ledger AFTER the flag ledger; rippled gates this on
-// `prevLedger.isFlagLedger()` in RCLConsensus.cpp:354.
+// `prevLedger.isFlagLedger()` at RCLConsensus.cpp:354.
 func IsFlagLedger(seq uint32) bool {
-	return seq != 0 && seq%FlagLedgerInterval == 0
+	return seq%FlagLedgerInterval == 0
 }
 
 // IsVotingLedger reports whether the validation for the ledger at the
 // given sequence carries fee-vote and amendment-vote fields — i.e.
-// the ledger BEFORE a flag ledger. Matches rippled Ledger.cpp:
-// (seq + 1) % FlagLedgerInterval == 0.
+// the ledger BEFORE a flag ledger. Matches rippled's
+// `Ledger::isVotingLedger()` at Ledger.cpp:950-953:
+// `(seq + 1) % FLAG_LEDGER_INTERVAL == 0`.
 //
 // In rippled this also gates NegativeUNL pseudo-tx injection at
 // RCLConsensus.cpp:368-380 (when prevLedger is a voting ledger the

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1390,6 +1390,26 @@ func (e *Engine) phaseOpen() {
 func (e *Engine) closeLedger() {
 	// Build our transaction set from pending transactions
 	txs := e.adaptor.GetPendingTxs()
+
+	// Inject flag-ledger / voting-ledger pseudo-txs BEFORE building
+	// the tx set, so the resulting tx-set hash matches what rippled
+	// computes for the same round (RCLConsensus.cpp:351-381). Gated
+	// on ModeProposing, which excludes wrongLedger by definition,
+	// matching rippled's `proposing && !wrongLCL`.
+	if e.mode == consensus.ModeProposing && e.prevLedger != nil {
+		prev := e.prevLedger
+		switch {
+		case consensus.IsFlagLedger(prev.Seq()):
+			if extra := e.adaptor.GenerateFlagLedgerPseudoTxs(prev); len(extra) > 0 {
+				txs = append(txs, extra...)
+			}
+		case consensus.IsVotingLedger(prev.Seq()) && e.adaptor.IsFeatureEnabled("NegativeUNL"):
+			if extra := e.adaptor.GenerateNegativeUNLPseudoTx(prev); len(extra) > 0 {
+				txs = append(txs, extra)
+			}
+		}
+	}
+
 	txSet, err := e.adaptor.BuildTxSet(txs)
 	if err != nil {
 		slog.Error("Failed to build tx set, falling back to empty set",
@@ -2162,15 +2182,6 @@ func (e *Engine) determineCloseTime() time.Time {
 	return roundCloseTime(e.state.CloseTimes.Self, resolution)
 }
 
-// isVotingLedger reports whether a validation for this ledger should
-// carry fee-vote and amendment-vote fields. Matches rippled
-// Ledger.cpp:951-953: a flag ledger is one whose sequence is 1 less
-// than a multiple of 256 (i.e., (seq+1) % 256 == 0). The validation
-// for that ledger carries the vote for the next flag cycle.
-func isVotingLedger(ledgerSeq uint32) bool {
-	return (ledgerSeq+1)%256 == 0
-}
-
 // sendValidation creates and broadcasts a validation.
 //
 // The Full flag on the emitted validation reflects whether we were
@@ -2231,7 +2242,7 @@ func (e *Engine) sendValidation(ledger consensus.Ledger) {
 		}
 		validation.Cookie = cookie
 
-		if isVotingLedger(ledger.Seq()) {
+		if consensus.IsVotingLedger(ledger.Seq()) {
 			serverVersion := e.adaptor.GetServerVersion()
 			if serverVersion == 0 {
 				slog.Warn("sendValidation: serverVersion is zero on voting ledger under HardenedValidations — adaptor must advertise a build tag; emitting without serverVersion")
@@ -2248,7 +2259,7 @@ func (e *Engine) sendValidation(ledger consensus.Ledger) {
 	// ~256× and confuses peer aggregators that accept these fields
 	// only on the expected boundary. Matches
 	// Ledger.cpp:951-953 isVotingLedger + RCLConsensus.cpp:879.
-	if isVotingLedger(ledger.Seq()) {
+	if consensus.IsVotingLedger(ledger.Seq()) {
 		// Fee vote: emit the AMOUNT triple under post-XRPFees rules, the
 		// legacy UINT triple otherwise. Rippled's FeeVoteImpl.cpp:120-192
 		// is a hard if/else on featureXRPFees; the adaptor's postXRPFees

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1393,17 +1393,20 @@ func (e *Engine) closeLedger() {
 
 	// Inject flag-ledger / voting-ledger pseudo-txs BEFORE building
 	// the tx set, so the resulting tx-set hash matches what rippled
-	// computes for the same round (RCLConsensus.cpp:351-381). Gated
-	// on ModeProposing, which excludes wrongLedger by definition,
-	// matching rippled's `proposing && !wrongLCL`.
-	if e.mode == consensus.ModeProposing && e.prevLedger != nil {
+	// computes for the same round (RCLConsensus.cpp:351-381). The
+	// gate mirrors rippled's `standalone() || (proposing && !wrongLCL)`
+	// at RCLConsensus.cpp:352 — ModeProposing already excludes
+	// wrongLedger by construction, and the standalone branch keeps
+	// single-node test setups injecting pseudo-txs even when they
+	// haven't transitioned to proposing.
+	if e.prevLedger != nil && (e.mode == consensus.ModeProposing || e.adaptor.IsStandalone()) {
 		prev := e.prevLedger
 		switch {
 		case consensus.IsFlagLedger(prev.Seq()):
 			if extra := e.adaptor.GenerateFlagLedgerPseudoTxs(prev); len(extra) > 0 {
 				txs = append(txs, extra...)
 			}
-		case consensus.IsVotingLedger(prev.Seq()) && e.adaptor.IsFeatureEnabled("NegativeUNL"):
+		case consensus.IsVotingLedger(prev.Seq()) && e.adaptor.IsFeatureEnabledOnLedger(prev, "NegativeUNL"):
 			if extra := e.adaptor.GenerateNegativeUNLPseudoTx(prev); len(extra) > 0 {
 				txs = append(txs, extra)
 			}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -134,6 +134,12 @@ type mockAdaptor struct {
 
 	// Load fee for R6b.5b — emitted as sfLoadFee. Zero by default.
 	loadFee uint32
+
+	// Pseudo-tx producer overrides for #367 tests. nil means the
+	// stub returns nil (no injection), matching the production
+	// adaptor's pre-vote-tally behavior.
+	flagLedgerPseudoTxs [][]byte
+	negativeUNLPseudoTx []byte
 }
 
 func newMockAdaptor() *mockAdaptor {
@@ -296,6 +302,18 @@ func (a *mockAdaptor) GetPendingTxs() [][]byte {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.pendingTxs
+}
+
+func (a *mockAdaptor) GenerateFlagLedgerPseudoTxs(_ consensus.Ledger) [][]byte {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.flagLedgerPseudoTxs
+}
+
+func (a *mockAdaptor) GenerateNegativeUNLPseudoTx(_ consensus.Ledger) []byte {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.negativeUNLPseudoTx
 }
 
 func (a *mockAdaptor) HasTx(id consensus.TxID) bool {

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -140,6 +140,11 @@ type mockAdaptor struct {
 	// adaptor's pre-vote-tally behavior.
 	flagLedgerPseudoTxs [][]byte
 	negativeUNLPseudoTx []byte
+
+	// standalone toggles the IsStandalone() return for tests that
+	// exercise rippled's `standalone() || (proposing && !wrongLCL)`
+	// OR-branch at RCLConsensus.cpp:352.
+	standalone bool
 }
 
 func newMockAdaptor() *mockAdaptor {
@@ -376,6 +381,24 @@ func (a *mockAdaptor) IsFeatureEnabled(name string) bool {
 		return false
 	}
 	return true
+}
+
+func (a *mockAdaptor) IsFeatureEnabledOnLedger(_ consensus.Ledger, name string) bool {
+	// Mock collapses the "rules of THIS ledger" into the same
+	// disabledFeatures map used by IsFeatureEnabled — tests that need
+	// per-ledger divergence are not in scope yet.
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.disabledFeatures != nil && a.disabledFeatures[name] {
+		return false
+	}
+	return true
+}
+
+func (a *mockAdaptor) IsStandalone() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.standalone
 }
 
 func (a *mockAdaptor) GetCookie() uint64 {

--- a/internal/consensus/rcl/pseudo_tx_injection_test.go
+++ b/internal/consensus/rcl/pseudo_tx_injection_test.go
@@ -62,6 +62,39 @@ func TestCloseLedger_NoInjectionWhenNotProposing(t *testing.T) {
 		"non-proposing mode must NOT inject pseudo-txs")
 }
 
+// TestCloseLedger_StandaloneInjectsEvenWhenNotProposing pins the
+// `app_.config().standalone() ||` half of rippled's gate at
+// RCLConsensus.cpp:352. A standalone-config node must inject
+// pseudo-txs even when consensus mode is not ModeProposing — the
+// non-proposing path is reachable in single-node test setups, and
+// dropping the injection there silently changes the tx-set hash
+// versus rippled.
+func TestCloseLedger_StandaloneInjectsEvenWhenNotProposing(t *testing.T) {
+	flagBlob := []byte{0xCA, 0xFE, 0xBA, 0xBE}
+
+	prev := &mockLedger{id: consensus.LedgerID{0xCA, 0xFE}, seq: 256}
+	a := newMockAdaptor()
+	a.lastLCL = prev
+	a.ledgers[prev.ID()] = prev
+	a.flagLedgerPseudoTxs = [][]byte{flagBlob}
+	a.standalone = true
+
+	engine := NewEngine(a, DefaultConfig())
+	round := consensus.RoundID{Seq: prev.Seq() + 1, ParentHash: prev.ID()}
+	require.NoError(t, engine.StartRound(round, false))
+
+	engine.mu.Lock()
+	engine.prevLedger = prev
+	engine.setMode(consensus.ModeObserving)
+	engine.setPhase(consensus.PhaseOpen)
+	engine.mu.Unlock()
+
+	engine.closeLedger()
+	require.NotNil(t, engine.ourTxSet)
+	assert.True(t, containsBlob(engine.ourTxSet.Txs(), flagBlob),
+		"standalone mode must inject pseudo-txs even when not in ModeProposing")
+}
+
 // TestCloseLedger_NegUNLGatedOnFeature pins the rippled gate at
 // RCLConsensus.cpp:368-370: NegativeUNL pseudo-tx is only injected
 // when the featureNegativeUNL amendment is enabled.

--- a/internal/consensus/rcl/pseudo_tx_injection_test.go
+++ b/internal/consensus/rcl/pseudo_tx_injection_test.go
@@ -1,0 +1,132 @@
+package rcl
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloseLedger_InjectsFlagLedgerPseudoTxs pins the producer-side
+// half of the rippled flag-ledger pseudo-tx contract
+// (RCLConsensus.cpp:351-381). When prevLedger is a flag ledger and we
+// are in ModeProposing, closeLedger MUST call
+// Adaptor.GenerateFlagLedgerPseudoTxs and inject the returned blobs
+// into the proposal tx set BEFORE BuildTxSet runs, so the tx-set hash
+// rippled and goXRPL compute for the same round agrees on the
+// presence of the fee/amendment vote pseudo-txs.
+//
+// Issue #367 delivers this seam. The actual vote-tally producers
+// ship in #368/#369/#370.
+func TestCloseLedger_InjectsFlagLedgerPseudoTxs(t *testing.T) {
+	flagBlob := []byte{0xFE, 0xE0, 0x01, 0x02, 0x03}
+	gotTxs := closeWithPseudoTxs(t, 256, [][]byte{flagBlob}, nil)
+	require.True(t, containsBlob(gotTxs, flagBlob),
+		"flag-ledger pseudo-tx blob missing from tx set; got %d txs", len(gotTxs))
+}
+
+// TestCloseLedger_InjectsNegativeUNLPseudoTx pins the voting-ledger
+// branch (RCLConsensus.cpp:368-380). When prevLedger is a voting
+// ledger AND the NegativeUNL feature is enabled, closeLedger MUST
+// inject the NegUNL pseudo-tx returned by GenerateNegativeUNLPseudoTx.
+func TestCloseLedger_InjectsNegativeUNLPseudoTx(t *testing.T) {
+	negUNLBlob := []byte{0x4E, 0x55, 0x4C, 0x01}
+	gotTxs := closeWithPseudoTxs(t, 255, nil, negUNLBlob)
+	require.True(t, containsBlob(gotTxs, negUNLBlob),
+		"negUNL pseudo-tx missing from tx set; got %d txs", len(gotTxs))
+}
+
+// TestCloseLedger_NoInjectionOnRegularLedger verifies the negative
+// case: on a non-flag, non-voting prevLedger, neither producer is
+// invoked.
+func TestCloseLedger_NoInjectionOnRegularLedger(t *testing.T) {
+	flagBlob := []byte{0xFF, 0xFF}
+	negUNLBlob := []byte{0xEE, 0xEE}
+	gotTxs := closeWithPseudoTxs(t, 100, [][]byte{flagBlob}, negUNLBlob)
+
+	assert.False(t, containsBlob(gotTxs, flagBlob),
+		"flag pseudo-tx must NOT be injected on a regular ledger")
+	assert.False(t, containsBlob(gotTxs, negUNLBlob),
+		"negUNL pseudo-tx must NOT be injected on a regular ledger")
+}
+
+// TestCloseLedger_NoInjectionWhenNotProposing pins the gate matching
+// rippled's "proposing && !wrongLCL" check at RCLConsensus.cpp:352.
+// In ModeObserving, neither producer is called.
+func TestCloseLedger_NoInjectionWhenNotProposing(t *testing.T) {
+	flagBlob := []byte{0xAB, 0xCD}
+	gotTxs := closeAtModeWith(t, consensus.ModeObserving, 256, [][]byte{flagBlob}, nil)
+	assert.False(t, containsBlob(gotTxs, flagBlob),
+		"non-proposing mode must NOT inject pseudo-txs")
+}
+
+// TestCloseLedger_NegUNLGatedOnFeature pins the rippled gate at
+// RCLConsensus.cpp:368-370: NegativeUNL pseudo-tx is only injected
+// when the featureNegativeUNL amendment is enabled.
+func TestCloseLedger_NegUNLGatedOnFeature(t *testing.T) {
+	prev := &mockLedger{id: consensus.LedgerID{0x55, 0xAA}, seq: 255}
+	a := newMockAdaptor()
+	a.lastLCL = prev
+	a.ledgers[prev.ID()] = prev
+	a.disabledFeatures = map[string]bool{"NegativeUNL": true}
+
+	negUNLBlob := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	a.negativeUNLPseudoTx = negUNLBlob
+
+	engine := NewEngine(a, DefaultConfig())
+	round := consensus.RoundID{Seq: prev.Seq() + 1, ParentHash: prev.ID()}
+	require.NoError(t, engine.StartRound(round, true))
+
+	engine.mu.Lock()
+	engine.prevLedger = prev
+	engine.setMode(consensus.ModeProposing)
+	engine.setPhase(consensus.PhaseOpen)
+	engine.mu.Unlock()
+
+	engine.closeLedger()
+	require.NotNil(t, engine.ourTxSet)
+	assert.False(t, containsBlob(engine.ourTxSet.Txs(), negUNLBlob),
+		"NegUNL pseudo-tx must NOT be injected when featureNegativeUNL is disabled")
+}
+
+func closeWithPseudoTxs(t *testing.T, prevSeq uint32, flagBlobs [][]byte, negUNLBlob []byte) [][]byte {
+	t.Helper()
+	return closeAtModeWith(t, consensus.ModeProposing, prevSeq, flagBlobs, negUNLBlob)
+}
+
+func closeAtModeWith(t *testing.T, mode consensus.Mode, prevSeq uint32, flagBlobs [][]byte, negUNLBlob []byte) [][]byte {
+	t.Helper()
+
+	prev := &mockLedger{id: consensus.LedgerID{byte(prevSeq), 0xAA}, seq: prevSeq}
+	a := newMockAdaptor()
+	a.lastLCL = prev
+	a.ledgers[prev.ID()] = prev
+	a.flagLedgerPseudoTxs = flagBlobs
+	a.negativeUNLPseudoTx = negUNLBlob
+
+	engine := NewEngine(a, DefaultConfig())
+	round := consensus.RoundID{Seq: prev.Seq() + 1, ParentHash: prev.ID()}
+	require.NoError(t, engine.StartRound(round, mode == consensus.ModeProposing))
+
+	engine.mu.Lock()
+	engine.prevLedger = prev
+	engine.setMode(mode)
+	engine.setPhase(consensus.PhaseOpen)
+	engine.mu.Unlock()
+
+	engine.closeLedger()
+
+	require.NotNil(t, engine.ourTxSet, "closeLedger must build our tx set")
+	return engine.ourTxSet.Txs()
+}
+
+func containsBlob(blobs [][]byte, want []byte) bool {
+	for _, b := range blobs {
+		if bytes.Equal(b, want) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Foundation work for #362 (flag-ledger pseudo-tx injection). Establishes the producer interface and the injection point in `Engine.closeLedger` so the actual vote-tally producers in #368 / #369 / #370 can plug in without re-doing the plumbing.

This PR by itself produces **zero behavior change** — the default producer impls return nil — but pins the seam and the trigger conditions with regression tests.

## Changes

- `consensus.IsFlagLedger(seq)`, `consensus.IsVotingLedger(seq)`, `consensus.FlagLedgerInterval` in `internal/consensus/ledger_timing.go`
- `Adaptor.GenerateFlagLedgerPseudoTxs(prevLedger) [][]byte`
- `Adaptor.GenerateNegativeUNLPseudoTx(prevLedger) []byte`
- Default-nil implementations on the production `*Adaptor` (with TODO comments referencing #368/#369/#370)
- `mockAdaptor` in the rcl tests gains the same methods plus override fields for the new tests
- Injection step in `Engine.closeLedger`, gated on `ModeProposing` and on `IsFlagLedger(prev.Seq())` / `(IsVotingLedger(prev.Seq()) && IsFeatureEnabled("NegativeUNL"))`. Mirrors rippled `RCLConsensus.cpp:351-381`.
- Migrates the unexported `rcl.isVotingLedger` to the shared `consensus.IsVotingLedger`

## Why this matters

When the actual producers ship, three sub-PRs would each need to re-touch `Engine.closeLedger` plus the `Adaptor` interface plus every mock. Landing the seam first lets each producer PR be a focused change in its own package.

## Test plan

- [x] `TestCloseLedger_InjectsFlagLedgerPseudoTxs` — flag-ledger blob reaches the tx set
- [x] `TestCloseLedger_InjectsNegativeUNLPseudoTx` — voting-ledger blob reaches the tx set when feature is on
- [x] `TestCloseLedger_NoInjectionOnRegularLedger` — neither blob is injected at non-flag, non-voting seq
- [x] `TestCloseLedger_NoInjectionWhenNotProposing` — `ModeObserving` skips the injection step
- [x] `TestCloseLedger_NegUNLGatedOnFeature` — NegUNL injection requires `featureNegativeUNL`
- [x] `go test ./internal/consensus/...` — all pass
- [x] `go vet ./internal/consensus/... ./internal/ledger/...` — clean