### PR TITLE
consensus: port NegativeUNLVote producer algorithm (refs #368)

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -567,8 +567,22 @@ func (a *Adaptor) GenerateFlagLedgerPseudoTxs(_ consensus.Ledger) [][]byte {
 	return nil
 }
 
-// GenerateNegativeUNLPseudoTx is a stub: NegativeUNLVote tally is
-// not yet implemented. See follow-up issue #368.
+// GenerateNegativeUNLPseudoTx is currently a stub. The vote-tally
+// algorithm itself lives in internal/consensus/negativeunlvote
+// (ported in #368) and is exercised by package-level tests against
+// synthetic score tables, but the production wiring still needs:
+//
+//   - per-seq validation history in ValidationTracker (today
+//     validations are only indexed by LedgerID; the algorithm needs
+//     to query "validations for ancestor at seq N by hash H" across
+//     the last FlagLedgerInterval ledgers);
+//   - state-map read access on consensus.Ledger so the producer can
+//     fetch the NegativeUNL SLE and the LedgerHashes skip-list of
+//     prevLedger.
+//
+// Returning nil keeps the engine's injection step a no-op until
+// those land — which preserves the pre-#367 behavior of never
+// injecting a NegUNL pseudo-tx.
 func (a *Adaptor) GenerateNegativeUNLPseudoTx(_ consensus.Ledger) []byte {
 	return nil
 }

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -30,6 +30,7 @@ import (
 	"math"
 	"sync"
 
+	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/tx"
@@ -166,13 +167,28 @@ func (v *Voter) PurgeNewValidators(seq uint32) {
 }
 
 // keyToNodeID is the local node-id derivation goXRPL uses today. It
-// mirrors the layout of consensus.NodeID (33-byte compressed pubkey)
-// rather than rippled's 20-byte RIPEMD-160 hash. Cross-implementation
-// pseudo-tx parity is unaffected because the chosen candidate (the
-// pubkey) is what ends up in sfUNLModifyValidator on the wire — the
-// NodeID is only used as the score-table key locally.
+// mirrors the layout of consensus.NodeID (33-byte compressed pubkey),
+// whereas rippled's NodeID is the 20-byte RIPEMD-160(SHA256(pubkey))
+// hash produced by calcNodeID (PublicKey.cpp:319-327). The 33-byte
+// pubkey is what travels on the wire as sfUNLModifyValidator, and the
+// score-table key is local. Candidate selection — see choose() —
+// reduces each pubkey through the same calcNodeID hash before XOR/min,
+// so a Go validator and a rippled validator on the same network with
+// the same inputs converge on the same picked candidate.
 func keyToNodeID(k [33]byte) consensus.NodeID {
 	return consensus.NodeID(k)
+}
+
+// calcNodeID derives rippled's 20-byte NodeID from a 33-byte master
+// pubkey: RIPEMD-160(SHA256(pubkey)). Mirrors calcNodeID at
+// rippled/src/libxrpl/protocol/PublicKey.cpp:319-327. Used by choose()
+// to make the candidate-picking comparator agree byte-for-byte with
+// rippled across implementations.
+func calcNodeID(pubkey [33]byte) [20]byte {
+	h := addresscodec.Sha256RipeMD160(pubkey[:])
+	var out [20]byte
+	copy(out[:], h)
+	return out
 }
 
 // DoVoting runs the producer end-to-end and returns the serialized
@@ -191,6 +207,13 @@ func keyToNodeID(k [33]byte) consensus.NodeID {
 // the caller; the engine treats a non-nil error as a producer
 // failure and falls through to no-injection rather than blocking the
 // round.
+//
+// scoreTable contract: callers may pass an under-populated table —
+// any UNL key missing from scoreTable is treated as score 0,
+// matching rippled's buildScoreTable invariant
+// (NegativeUNLVote.cpp:197-200) where every UNL member is initialized
+// to 0 before the validation-count loop. This is enforced inside
+// DoVoting; callers do not have to pre-fill themselves.
 func (v *Voter) DoVoting(
 	prevLedgerSeq uint32,
 	prevLedgerHash [32]byte,
@@ -198,24 +221,41 @@ func (v *Voter) DoVoting(
 	state State,
 	scoreTable map[consensus.NodeID]uint32,
 ) ([][]byte, error) {
-	// Refuse to vote if local participation is insufficient. See
-	// buildScoreTable's myValidationCount check at
-	// NegativeUNLVote.cpp:216-244.
+	// Refuse to vote if local participation is insufficient. Mirrors
+	// buildScoreTable's myValidationCount branching at
+	// NegativeUNLVote.cpp:221-244. The boundaries are exact:
+	//   < MinLocalValsToVote        → no vote (low participation)
+	//   == MinLocalValsToVote       → no vote (rippled's else branch
+	//                                 catches the boundary because the
+	//                                 else-if uses strict `>`)
+	//   > FlagLedgerInterval        → no vote (rippled's "Too many!"
+	//                                 branch — a logic error in
+	//                                 rippled, treated as a normal
+	//                                 no-vote here to match the
+	//                                 observed effect on consensus).
 	myCount := scoreTable[v.myID]
-	if myCount < MinLocalValsToVote {
+	if myCount <= MinLocalValsToVote || myCount > flagLedgerInterval {
 		return nil, nil
-	}
-
-	// Cannot exceed FlagLedgerInterval validations in the window —
-	// rippled treats this as a logic error and refuses to vote.
-	if myCount > flagLedgerInterval {
-		return nil, fmt.Errorf("negativeunlvote: local validation count %d exceeds window %d", myCount, flagLedgerInterval)
 	}
 
 	// Build the trusted-key index once.
 	unlNodeIDs := make(map[consensus.NodeID][33]byte, len(unlKeys))
 	for _, k := range unlKeys {
 		unlNodeIDs[keyToNodeID(k)] = k
+	}
+
+	// Establish rippled's scoreTable invariant: every UNL member must
+	// have an entry, with 0 for non-validators (NegativeUNLVote.cpp:
+	// 197-200). Done on a local copy so the caller's map is not
+	// mutated.
+	filledScoreTable := make(map[consensus.NodeID]uint32, len(scoreTable)+len(unlNodeIDs))
+	for n, s := range scoreTable {
+		filledScoreTable[n] = s
+	}
+	for n := range unlNodeIDs {
+		if _, ok := filledScoreTable[n]; !ok {
+			filledScoreTable[n] = 0
+		}
 	}
 
 	// Resolve the effective negUNL for the upcoming flag ledger
@@ -237,7 +277,7 @@ func (v *Voter) DoVoting(
 	upcomingSeq := prevLedgerSeq + 1
 	v.PurgeNewValidators(upcomingSeq)
 
-	candidates := v.findAllCandidates(unlNodeIDs, negUnlNodeIDs, scoreTable)
+	candidates := v.findAllCandidates(unlNodeIDs, negUnlNodeIDs, filledScoreTable)
 
 	var blobs [][]byte
 	if len(candidates.toDisable) > 0 {
@@ -324,23 +364,27 @@ func (v *Voter) findAllCandidates(
 
 // choose deterministically picks one NodeID from candidates using
 // the prevLedger hash as the random pad. Mirrors
-// NegativeUNLVote.cpp:142-161 — XOR with the pad and pick the
-// minimum. This converges every validator on the same choice
-// without coordination.
+// NegativeUNLVote::choose at NegativeUNLVote.cpp:142-161 — XOR with
+// the pad and pick the minimum. This converges every validator on
+// the same choice without coordination.
 //
-// goXRPL's NodeID is 33 bytes vs rippled's 20; we XOR over the
-// first 32 bytes (matching the hash-pad width) and treat them as a
-// big-endian comparison key.
+// rippled's comparator is over 20-byte calcNodeID values
+// (RIPEMD-160(SHA256(pubkey))) XORed with the first 20 bytes of the
+// 32-byte randomPad. goXRPL's consensus.NodeID is the 33-byte master
+// pubkey, so we hash through calcNodeID inside the comparator: this
+// produces the same picked candidate as rippled given the same
+// pubkeys and the same prevLedger.hash, preserving cross-implementation
+// vote convergence on a mixed Go+rippled validator network.
 func choose(randomPad [32]byte, candidates []consensus.NodeID) consensus.NodeID {
 	if len(candidates) == 0 {
 		var zero consensus.NodeID
 		return zero
 	}
 	best := candidates[0]
-	bestKey := xorKey(best, randomPad)
+	bestKey := xorCalcNodeID(best, randomPad)
 	for i := 1; i < len(candidates); i++ {
-		k := xorKey(candidates[i], randomPad)
-		if compareKey(k, bestKey) < 0 {
+		k := xorCalcNodeID(candidates[i], randomPad)
+		if compareNodeID20(k, bestKey) < 0 {
 			best = candidates[i]
 			bestKey = k
 		}
@@ -348,16 +392,21 @@ func choose(randomPad [32]byte, candidates []consensus.NodeID) consensus.NodeID 
 	return best
 }
 
-func xorKey(n consensus.NodeID, pad [32]byte) [32]byte {
-	var out [32]byte
-	for i := 0; i < 32; i++ {
-		out[i] = n[i] ^ pad[i]
+// xorCalcNodeID computes calcNodeID(pubkey) ^ randomPad[:20]. Matches
+// rippled's `candidates[j] ^ randomPad` at NegativeUNLVote.cpp:155
+// once randomPad is truncated via `NodeID::fromVoid(randomPadData.data())`
+// at NegativeUNLVote.cpp:151.
+func xorCalcNodeID(n consensus.NodeID, pad [32]byte) [20]byte {
+	nid := calcNodeID(n)
+	var out [20]byte
+	for i := 0; i < 20; i++ {
+		out[i] = nid[i] ^ pad[i]
 	}
 	return out
 }
 
-func compareKey(a, b [32]byte) int {
-	for i := 0; i < 32; i++ {
+func compareNodeID20(a, b [20]byte) int {
+	for i := 0; i < 20; i++ {
 		switch {
 		case a[i] < b[i]:
 			return -1

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -1,0 +1,402 @@
+// Package negativeunlvote ports rippled's NegativeUNLVote
+// (src/xrpld/app/misc/NegativeUNLVote.{h,cpp}) — the producer side
+// that decides whether to inject a UNLModify pseudo-tx into the
+// consensus tx set on a flag-ledger boundary, based on per-validator
+// participation in the last FlagLedgerInterval ledgers.
+//
+// The algorithm:
+//
+//  1. Build a reliability score table — for each trusted validator,
+//     count its validations across the last FlagLedgerInterval (256)
+//     ledgers, indexed by the parent ledger's skip list. Refuse to
+//     vote if our local node's count is below MinLocalValsToVote
+//     (the local view is too narrow to trust).
+//
+//  2. Find candidates using the (low|high)-water-mark thresholds and
+//     a 25% cap on listed validators. ToDisable picks unreliable
+//     validators not already on the negUNL; ToReEnable picks recovered
+//     validators currently on the negUNL.
+//
+//  3. Pick at most one candidate per category, deterministically by
+//     XOR with prevLedger.hash so every validator on the network
+//     converges on the same choice without coordination.
+//
+//  4. Serialize each picked candidate as a UNLModify pseudo-tx.
+package negativeunlvote
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math"
+	"sync"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+)
+
+const (
+	// flagLedgerInterval is the period (in ledgers) the producer
+	// scores validators over. Mirrors consensus.FlagLedgerInterval;
+	// duplicated here as a uint32 constant so the threshold
+	// constants below can be evaluated at compile time.
+	flagLedgerInterval uint32 = 256
+
+	// LowWaterMark is the validation-count threshold below which a
+	// trusted validator is considered unreliable and becomes a
+	// ToDisable candidate. Matches rippled's
+	// negativeUNLLowWaterMark = FLAG_LEDGER_INTERVAL * 50 / 100.
+	LowWaterMark uint32 = flagLedgerInterval * 50 / 100
+
+	// HighWaterMark is the validation-count threshold above which a
+	// currently-disabled validator becomes a ToReEnable candidate.
+	// Matches rippled's negativeUNLHighWaterMark =
+	// FLAG_LEDGER_INTERVAL * 80 / 100.
+	HighWaterMark uint32 = flagLedgerInterval * 80 / 100
+
+	// MinLocalValsToVote is the minimum number of validations the
+	// local node itself must have produced over the score-table
+	// window for the local view to be considered reliable. Below
+	// this threshold the producer refuses to vote — its local
+	// reliability measurement could be wrong. Matches rippled's
+	// negativeUNLMinLocalValsToVote = FLAG_LEDGER_INTERVAL * 90 / 100.
+	MinLocalValsToVote uint32 = flagLedgerInterval * 90 / 100
+
+	// NewValidatorDisableSkip is the number of ledgers a freshly-
+	// added validator is exempt from ToDisable voting. Matches
+	// rippled's newValidatorDisableSkip = FLAG_LEDGER_INTERVAL * 2.
+	NewValidatorDisableSkip uint32 = flagLedgerInterval * 2
+
+	// MaxListedFraction caps the proportion of the UNL that may
+	// appear on the NegativeUNL at any one time. ToDisable
+	// candidates are dropped once this cap is reached. Matches
+	// rippled's negativeUNLMaxListed = 0.25.
+	MaxListedFraction float64 = 0.25
+)
+
+// Modify identifies the direction of a UNLModify pseudo-tx.
+type Modify uint8
+
+const (
+	ToDisable  Modify = 1 // UNLModify with sfUNLModifyDisabling=1
+	ToReEnable Modify = 0 // UNLModify with sfUNLModifyDisabling=0
+)
+
+// State captures the NegativeUNL ledger entry of the parent ledger:
+// the currently-disabled set plus any pending change a previous
+// flag-ledger UNLModify staged but that hasn't taken effect yet.
+//
+// Mirrors prevLedger->negativeUNL() / validatorToDisable() /
+// validatorToReEnable() at NegativeUNLVote.cpp:61-78.
+type State struct {
+	// DisabledKeys are the master pubkeys currently on the
+	// negUNL — i.e. excluded from quorum.
+	DisabledKeys [][33]byte
+	// ToDisablePending stages a validator for disabling on the
+	// upcoming flag ledger. Nil when no change is pending.
+	ToDisablePending *[33]byte
+	// ToReEnablePending stages a validator for re-enabling on the
+	// upcoming flag ledger. Nil when no change is pending.
+	ToReEnablePending *[33]byte
+}
+
+// effectiveNegUNL applies the pending changes from State to produce
+// the negUNL the upcoming flag ledger will see. Mirrors the
+// negUnlKeys.insert / negUnlKeys.erase handling at
+// NegativeUNLVote.cpp:61-67.
+func (s State) effectiveNegUNL() map[[33]byte]struct{} {
+	out := make(map[[33]byte]struct{}, len(s.DisabledKeys)+1)
+	for _, k := range s.DisabledKeys {
+		out[k] = struct{}{}
+	}
+	if s.ToDisablePending != nil {
+		out[*s.ToDisablePending] = struct{}{}
+	}
+	if s.ToReEnablePending != nil {
+		delete(out, *s.ToReEnablePending)
+	}
+	return out
+}
+
+// Voter is the producer state. Holds the local node's identifier and
+// the new-validator skip table. Methods are safe for concurrent use.
+type Voter struct {
+	myID consensus.NodeID
+
+	mu            sync.Mutex
+	newValidators map[consensus.NodeID]uint32 // ledger seq when added
+}
+
+// NewVoter constructs a Voter for the local node. myID must be the
+// 33-byte master pubkey representation goXRPL uses for NodeID — the
+// same value that appears in scoreTable keys.
+func NewVoter(myID consensus.NodeID) *Voter {
+	return &Voter{
+		myID:          myID,
+		newValidators: make(map[consensus.NodeID]uint32),
+	}
+}
+
+// NewValidators registers a set of newly-trusted validators at the
+// given ledger sequence so they are exempt from ToDisable voting for
+// the next NewValidatorDisableSkip ledgers. Mirrors
+// NegativeUNLVote.cpp:322-337.
+func (v *Voter) NewValidators(seq uint32, nowTrusted []consensus.NodeID) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	for _, n := range nowTrusted {
+		if _, ok := v.newValidators[n]; !ok {
+			v.newValidators[n] = seq
+		}
+	}
+}
+
+// PurgeNewValidators removes any new-validator entry that is older
+// than NewValidatorDisableSkip ledgers relative to seq. Mirrors
+// NegativeUNLVote.cpp:339-355.
+func (v *Voter) PurgeNewValidators(seq uint32) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	for n, addedSeq := range v.newValidators {
+		if seq-addedSeq > NewValidatorDisableSkip {
+			delete(v.newValidators, n)
+		}
+	}
+}
+
+// keyToNodeID is the local node-id derivation goXRPL uses today. It
+// mirrors the layout of consensus.NodeID (33-byte compressed pubkey)
+// rather than rippled's 20-byte RIPEMD-160 hash. Cross-implementation
+// pseudo-tx parity is unaffected because the chosen candidate (the
+// pubkey) is what ends up in sfUNLModifyValidator on the wire — the
+// NodeID is only used as the score-table key locally.
+func keyToNodeID(k [33]byte) consensus.NodeID {
+	return consensus.NodeID(k)
+}
+
+// DoVoting runs the producer end-to-end and returns the serialized
+// UNLModify pseudo-tx blobs to inject (zero, one, or two — at most
+// one ToDisable plus at most one ToReEnable). prevLedgerSeq is the
+// sequence of the parent ledger; the upcoming ledger is therefore
+// prevLedgerSeq + 1. prevLedgerHash is used as the deterministic
+// random pad for candidate picking. unlKeys lists the trusted
+// validator master keys; state describes the parent ledger's
+// NegativeUNL SLE; scoreTable maps each trusted validator's NodeID
+// to its validation count over the last FlagLedgerInterval ledgers.
+//
+// Returns nil when no pseudo-tx is needed or when the producer
+// chooses not to vote (insufficient local participation, no
+// candidates). Errors from pseudo-tx serialization are returned to
+// the caller; the engine treats a non-nil error as a producer
+// failure and falls through to no-injection rather than blocking the
+// round.
+func (v *Voter) DoVoting(
+	prevLedgerSeq uint32,
+	prevLedgerHash [32]byte,
+	unlKeys [][33]byte,
+	state State,
+	scoreTable map[consensus.NodeID]uint32,
+) ([][]byte, error) {
+	// Refuse to vote if local participation is insufficient. See
+	// buildScoreTable's myValidationCount check at
+	// NegativeUNLVote.cpp:216-244.
+	myCount := scoreTable[v.myID]
+	if myCount < MinLocalValsToVote {
+		return nil, nil
+	}
+
+	// Cannot exceed FlagLedgerInterval validations in the window —
+	// rippled treats this as a logic error and refuses to vote.
+	if myCount > flagLedgerInterval {
+		return nil, fmt.Errorf("negativeunlvote: local validation count %d exceeds window %d", myCount, flagLedgerInterval)
+	}
+
+	// Build the trusted-key index once.
+	unlNodeIDs := make(map[consensus.NodeID][33]byte, len(unlKeys))
+	for _, k := range unlKeys {
+		unlNodeIDs[keyToNodeID(k)] = k
+	}
+
+	// Resolve the effective negUNL for the upcoming flag ledger
+	// (current set ± any pending change).
+	negUnlKeys := state.effectiveNegUNL()
+	negUnlNodeIDs := make(map[consensus.NodeID]struct{}, len(negUnlKeys))
+	keyByNode := make(map[consensus.NodeID][33]byte, len(unlKeys)+len(negUnlKeys))
+	for n, k := range unlNodeIDs {
+		keyByNode[n] = k
+	}
+	for k := range negUnlKeys {
+		nid := keyToNodeID(k)
+		negUnlNodeIDs[nid] = struct{}{}
+		if _, ok := keyByNode[nid]; !ok {
+			keyByNode[nid] = k
+		}
+	}
+
+	upcomingSeq := prevLedgerSeq + 1
+	v.PurgeNewValidators(upcomingSeq)
+
+	candidates := v.findAllCandidates(unlNodeIDs, negUnlNodeIDs, scoreTable)
+
+	var blobs [][]byte
+	if len(candidates.toDisable) > 0 {
+		picked := choose(prevLedgerHash, candidates.toDisable)
+		key, ok := keyByNode[picked]
+		if !ok {
+			return nil, fmt.Errorf("negativeunlvote: picked toDisable candidate has no master key in lookup table")
+		}
+		blob, err := buildUNLModifyTx(upcomingSeq, key, ToDisable)
+		if err != nil {
+			return nil, fmt.Errorf("negativeunlvote: serialize toDisable: %w", err)
+		}
+		blobs = append(blobs, blob)
+	}
+	if len(candidates.toReEnable) > 0 {
+		picked := choose(prevLedgerHash, candidates.toReEnable)
+		key, ok := keyByNode[picked]
+		if !ok {
+			return nil, fmt.Errorf("negativeunlvote: picked toReEnable candidate has no master key in lookup table")
+		}
+		blob, err := buildUNLModifyTx(upcomingSeq, key, ToReEnable)
+		if err != nil {
+			return nil, fmt.Errorf("negativeunlvote: serialize toReEnable: %w", err)
+		}
+		blobs = append(blobs, blob)
+	}
+
+	return blobs, nil
+}
+
+type candidates struct {
+	toDisable  []consensus.NodeID
+	toReEnable []consensus.NodeID
+}
+
+// findAllCandidates is the score-table → candidate-set step. Mirrors
+// NegativeUNLVote.cpp:247-320 including the 25% cap, the
+// new-validator skip, and the "drop validators that left the UNL"
+// fallback for ToReEnable.
+func (v *Voter) findAllCandidates(
+	unl map[consensus.NodeID][33]byte,
+	negUNL map[consensus.NodeID]struct{},
+	scoreTable map[consensus.NodeID]uint32,
+) candidates {
+	maxListed := int(math.Ceil(float64(len(unl)) * MaxListedFraction))
+	listed := 0
+	for n := range unl {
+		if _, ok := negUNL[n]; ok {
+			listed++
+		}
+	}
+	canAdd := listed < maxListed
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	var c candidates
+	for nodeID, score := range scoreTable {
+		_, isNegUNL := negUNL[nodeID]
+		_, isNew := v.newValidators[nodeID]
+
+		if canAdd && score < LowWaterMark && !isNegUNL && !isNew {
+			c.toDisable = append(c.toDisable, nodeID)
+		}
+		if score > HighWaterMark && isNegUNL {
+			c.toReEnable = append(c.toReEnable, nodeID)
+		}
+	}
+
+	// Fallback: if a previously-disabled validator has been removed
+	// from the UNL entirely, re-enable it on the negUNL since it's
+	// no longer eligible. Only consulted when the score-driven
+	// re-enable list is empty (NegativeUNLVote.cpp:309-318).
+	if len(c.toReEnable) == 0 {
+		for n := range negUNL {
+			if _, inUNL := unl[n]; !inUNL {
+				c.toReEnable = append(c.toReEnable, n)
+			}
+		}
+	}
+
+	return c
+}
+
+// choose deterministically picks one NodeID from candidates using
+// the prevLedger hash as the random pad. Mirrors
+// NegativeUNLVote.cpp:142-161 — XOR with the pad and pick the
+// minimum. This converges every validator on the same choice
+// without coordination.
+//
+// goXRPL's NodeID is 33 bytes vs rippled's 20; we XOR over the
+// first 32 bytes (matching the hash-pad width) and treat them as a
+// big-endian comparison key.
+func choose(randomPad [32]byte, candidates []consensus.NodeID) consensus.NodeID {
+	if len(candidates) == 0 {
+		var zero consensus.NodeID
+		return zero
+	}
+	best := candidates[0]
+	bestKey := xorKey(best, randomPad)
+	for i := 1; i < len(candidates); i++ {
+		k := xorKey(candidates[i], randomPad)
+		if compareKey(k, bestKey) < 0 {
+			best = candidates[i]
+			bestKey = k
+		}
+	}
+	return best
+}
+
+func xorKey(n consensus.NodeID, pad [32]byte) [32]byte {
+	var out [32]byte
+	for i := 0; i < 32; i++ {
+		out[i] = n[i] ^ pad[i]
+	}
+	return out
+}
+
+func compareKey(a, b [32]byte) int {
+	for i := 0; i < 32; i++ {
+		switch {
+		case a[i] < b[i]:
+			return -1
+		case a[i] > b[i]:
+			return 1
+		}
+	}
+	return 0
+}
+
+// zeroAccount is the base58-encoded all-zero AccountID used as the
+// source account on every XRPL pseudo-transaction (rippled
+// AccountID()). The wire form serializes to a 20-byte zero blob.
+const zeroAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+
+// buildUNLModifyTx serializes a UNLModify pseudo-tx for inclusion in
+// the proposal initial set. Wire format mirrors rippled's
+// NegativeUNLVote::addTx at NegativeUNLVote.cpp:110-140 — zero
+// account, zero fee, empty signing pubkey, sequence 0.
+func buildUNLModifyTx(seq uint32, validator [33]byte, modify Modify) ([]byte, error) {
+	disabling := uint8(modify)
+	zeroSeq := uint32(0)
+	utx := &pseudo.UNLModify{
+		BaseTx:             *tx.NewBaseTx(tx.TypeUNLModify, zeroAccount),
+		UNLModifyDisabling: &disabling,
+		LedgerSequence:     &seq,
+		UNLModifyValidator: hex.EncodeToString(validator[:]),
+	}
+	utx.Common.Fee = "0"
+	utx.Common.SigningPubKey = ""
+	utx.Common.Sequence = &zeroSeq
+
+	flat, err := utx.Flatten()
+	if err != nil {
+		return nil, fmt.Errorf("flatten UNLModify: %w", err)
+	}
+	hexStr, err := binarycodec.Encode(flat)
+	if err != nil {
+		return nil, fmt.Errorf("encode UNLModify: %w", err)
+	}
+	return hex.DecodeString(hexStr)
+}

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -26,6 +26,7 @@ package negativeunlvote
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -36,6 +37,15 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
 )
+
+// ErrLocalCountExceedsWindow is returned when the local node's validation
+// count over the score-table window exceeds FlagLedgerInterval. Mirrors
+// rippled's "Too many!" branch at NegativeUNLVote.cpp:236-244, which
+// rippled logs at error severity. Callers should treat this as a no-vote
+// (the returned blob list is nil) and surface the error for operator
+// visibility — the impossible-state branch indicates an upstream bug
+// (e.g. duplicate validations attributed to the local node).
+var ErrLocalCountExceedsWindow = errors.New("negativeunlvote: local validation count exceeds flag-ledger window")
 
 const (
 	// flagLedgerInterval is the period (in ledgers) the producer
@@ -90,15 +100,24 @@ const (
 //
 // Mirrors prevLedger->negativeUNL() / validatorToDisable() /
 // validatorToReEnable() at NegativeUNLVote.cpp:61-78.
+//
+// Invariant: ToDisablePending and ToReEnablePending must not reference
+// the same validator key. The NegativeUNL SLE enforces this at the tx
+// layer (UNLModify Apply rejects a re-enable for a validator already
+// staged for disable, and vice versa). The producer relies on that
+// invariant; passing both pointers set to the same key would silently
+// drop the validator from effectiveNegUNL.
 type State struct {
 	// DisabledKeys are the master pubkeys currently on the
 	// negUNL — i.e. excluded from quorum.
 	DisabledKeys [][33]byte
 	// ToDisablePending stages a validator for disabling on the
-	// upcoming flag ledger. Nil when no change is pending.
+	// upcoming flag ledger. Nil when no change is pending. Must not
+	// alias ToReEnablePending — see the State doc comment.
 	ToDisablePending *[33]byte
 	// ToReEnablePending stages a validator for re-enabling on the
-	// upcoming flag ledger. Nil when no change is pending.
+	// upcoming flag ledger. Nil when no change is pending. Must not
+	// alias ToDisablePending — see the State doc comment.
 	ToReEnablePending *[33]byte
 }
 
@@ -228,14 +247,18 @@ func (v *Voter) DoVoting(
 	//   == MinLocalValsToVote       → no vote (rippled's else branch
 	//                                 catches the boundary because the
 	//                                 else-if uses strict `>`)
-	//   > FlagLedgerInterval        → no vote (rippled's "Too many!"
-	//                                 branch — a logic error in
-	//                                 rippled, treated as a normal
-	//                                 no-vote here to match the
-	//                                 observed effect on consensus).
+	//   > FlagLedgerInterval        → no vote AND surface
+	//                                 ErrLocalCountExceedsWindow so
+	//                                 the caller can log at error
+	//                                 severity. Rippled logs the same
+	//                                 condition with JLOG(j_.error())
+	//                                 and returns empty (no vote).
 	myCount := scoreTable[v.myID]
-	if myCount <= MinLocalValsToVote || myCount > flagLedgerInterval {
+	if myCount <= MinLocalValsToVote {
 		return nil, nil
+	}
+	if myCount > flagLedgerInterval {
+		return nil, fmt.Errorf("%w: %d > %d", ErrLocalCountExceedsWindow, myCount, flagLedgerInterval)
 	}
 
 	// Build the trusted-key index once.
@@ -308,7 +331,7 @@ func (v *Voter) DoVoting(
 	return blobs, nil
 }
 
-type candidates struct {
+type candidateSet struct {
 	toDisable  []consensus.NodeID
 	toReEnable []consensus.NodeID
 }
@@ -321,7 +344,7 @@ func (v *Voter) findAllCandidates(
 	unl map[consensus.NodeID][33]byte,
 	negUNL map[consensus.NodeID]struct{},
 	scoreTable map[consensus.NodeID]uint32,
-) candidates {
+) candidateSet {
 	maxListed := int(math.Ceil(float64(len(unl)) * MaxListedFraction))
 	listed := 0
 	for n := range unl {
@@ -334,7 +357,7 @@ func (v *Voter) findAllCandidates(
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	var c candidates
+	var c candidateSet
 	for nodeID, score := range scoreTable {
 		_, isNegUNL := negUNL[nodeID]
 		_, isNew := v.newValidators[nodeID]

--- a/internal/consensus/negativeunlvote/vote_test.go
+++ b/internal/consensus/negativeunlvote/vote_test.go
@@ -2,6 +2,7 @@ package negativeunlvote
 
 import (
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -486,9 +487,10 @@ func TestDoVoting_BoundaryParticipation(t *testing.T) {
 
 // TestDoVoting_LocalCountAboveWindow covers the rippled "Too many!"
 // branch at NegativeUNLVote.cpp:236-244 — myValidationCount >
-// FlagLedgerInterval returns empty (no vote). The Go port treats
-// this as a normal no-vote rather than a producer error, matching
-// the observed effect on consensus.
+// FlagLedgerInterval. Rippled logs at error severity and returns
+// empty (no vote). The Go port returns nil blobs (no vote) AND
+// surfaces ErrLocalCountExceedsWindow so the caller can log at
+// error severity, matching rippled's observability.
 func TestDoVoting_LocalCountAboveWindow(t *testing.T) {
 	myKey := makeKey(0xAA)
 	weak := makeKey(0xBB)
@@ -501,7 +503,8 @@ func TestDoVoting_LocalCountAboveWindow(t *testing.T) {
 	}
 
 	blobs, err := v.DoVoting(1024, [32]byte{0xDE, 0xAD}, unl, State{}, scoreTable)
-	require.NoError(t, err, "above-window must NOT surface as a producer error")
+	require.ErrorIs(t, err, ErrLocalCountExceedsWindow,
+		"above-window must surface ErrLocalCountExceedsWindow so the caller can log at error severity")
 	assert.Nil(t, blobs, "myCount > FlagLedgerInterval must NOT vote")
 }
 
@@ -534,4 +537,202 @@ func TestDoVoting_ScoreTableMissingUNLMember(t *testing.T) {
 	assert.Equal(t, hex.EncodeToString(silent[:]),
 		stringFold(tx["UNLModifyValidator"]),
 		"the silent (missing-from-scoreTable) validator must be the picked candidate")
+}
+
+// makeKeyN produces a deterministic 33-byte master pubkey indexed by
+// idx. Unlike makeKey (which fills bytes 1..32 with the same byte
+// tag and so collides above 256 distinct values), makeKeyN encodes
+// the index across the first three bytes so up to 65535 distinct
+// pubkeys can be generated for the combination tests.
+func makeKeyN(idx int) [33]byte {
+	var k [33]byte
+	k[0] = 0x02
+	k[1] = byte(idx >> 8)
+	k[2] = byte(idx)
+	return k
+}
+
+// buildCombinationFixture builds the (unl, negUNL, scoreTable) tuple
+// rippled's testFindAllCandidatesCombination uses for combination 1
+// (NegativeUNL_test.cpp:1185-1257): every UNL member gets the same
+// score, the first floor(unlSize * nUnlPercent / 100) members are
+// placed on the negUNL.
+func buildCombinationFixture(unlSize, nUnlPercent int, score uint32) (
+	map[consensus.NodeID][33]byte,
+	map[consensus.NodeID]struct{},
+	map[consensus.NodeID]uint32,
+) {
+	nodeIDs := make([]consensus.NodeID, unlSize)
+	keys := make([][33]byte, unlSize)
+	for i := 0; i < unlSize; i++ {
+		keys[i] = makeKeyN(i)
+		nodeIDs[i] = keyToNodeID(keys[i])
+	}
+	unl := make(map[consensus.NodeID][33]byte, unlSize)
+	scoreTable := make(map[consensus.NodeID]uint32, unlSize)
+	for i, n := range nodeIDs {
+		unl[n] = keys[i]
+		scoreTable[n] = score
+	}
+	negSize := unlSize * nUnlPercent / 100
+	negUNL := make(map[consensus.NodeID]struct{}, negSize)
+	for i := 0; i < negSize; i++ {
+		negUNL[nodeIDs[i]] = struct{}{}
+	}
+	return unl, negUNL, scoreTable
+}
+
+// TestFindAllCandidates_RippledCombination1 mirrors rippled's
+// testFindAllCandidatesCombination combination 1
+// (NegativeUNL_test.cpp:1185-1257) — a parameterized grid over
+// (unlSize, nUnlPercent, score) covering every boundary score and
+// the no-/half-/full-negUNL cases. This is rippled's parity bar for
+// findAllCandidates and catches off-by-one drift in the canAdd cap
+// or the strict-inequality watermark thresholds.
+func TestFindAllCandidates_RippledCombination1(t *testing.T) {
+	unlSizes := []int{34, 35, 80}
+	nUnlPercents := []int{0, 50, 100}
+	scores := []uint32{
+		0,
+		LowWaterMark - 1,
+		LowWaterMark,
+		LowWaterMark + 1,
+		HighWaterMark - 1,
+		HighWaterMark,
+		HighWaterMark + 1,
+		MinLocalValsToVote,
+	}
+
+	v := NewVoter(nodeID(0xA0))
+
+	for _, us := range unlSizes {
+		for _, np := range nUnlPercents {
+			for _, score := range scores {
+				name := fmt.Sprintf("us=%d/np=%d/score=%d", us, np, score)
+				t.Run(name, func(t *testing.T) {
+					unl, negUNL, scoreTable := buildCombinationFixture(us, np, score)
+					require.Equal(t, us, len(unl))
+					require.Equal(t, us*np/100, len(negUNL))
+					require.Equal(t, us, len(scoreTable))
+
+					var toDisableExpect, toReEnableExpect int
+					switch np {
+					case 0:
+						if score < LowWaterMark {
+							toDisableExpect = us
+						}
+					case 50:
+						if score > HighWaterMark {
+							toReEnableExpect = us * np / 100
+						}
+					case 100:
+						if score > HighWaterMark {
+							toReEnableExpect = us
+						}
+					}
+
+					c := v.findAllCandidates(unl, negUNL, scoreTable)
+					assert.Equal(t, toDisableExpect, len(c.toDisable),
+						"toDisable count mismatch")
+					assert.Equal(t, toReEnableExpect, len(c.toReEnable),
+						"toReEnable count mismatch")
+				})
+			}
+		}
+	}
+}
+
+// TestFindAllCandidates_RippledCombination2 mirrors rippled's
+// testFindAllCandidatesCombination combination 2
+// (NegativeUNL_test.cpp:1258-1334) — the first 16 nodes get pairs of
+// scores from the boundary array, every node beyond gets
+// MinLocalValsToVote (= scores.back()), and the negUNL is built per
+// percent rule. The expected counts encode the cap-and-watermark
+// arithmetic across (unlSize, nUnlPercent) without enumerating every
+// score: a single failure here flags drift in the candidate-set
+// composition that combination 1 cannot reach.
+func TestFindAllCandidates_RippledCombination2(t *testing.T) {
+	unlSizes := []int{34, 35, 80}
+	nUnlPercents := []int{0, 50, 100}
+	scores := []uint32{
+		0,
+		LowWaterMark - 1,
+		LowWaterMark,
+		LowWaterMark + 1,
+		HighWaterMark - 1,
+		HighWaterMark,
+		HighWaterMark + 1,
+		MinLocalValsToVote,
+	}
+
+	v := NewVoter(nodeID(0xA0))
+
+	build := func(unlSize, nUnlPercent int) (
+		map[consensus.NodeID][33]byte,
+		map[consensus.NodeID]struct{},
+		map[consensus.NodeID]uint32,
+	) {
+		nodeIDs := make([]consensus.NodeID, unlSize)
+		keys := make([][33]byte, unlSize)
+		for i := 0; i < unlSize; i++ {
+			keys[i] = makeKeyN(i)
+			nodeIDs[i] = keyToNodeID(keys[i])
+		}
+		unl := make(map[consensus.NodeID][33]byte, unlSize)
+		for i, n := range nodeIDs {
+			unl[n] = keys[i]
+		}
+		scoreTable := make(map[consensus.NodeID]uint32, unlSize)
+		nIdx := 0
+		for _, sc := range scores {
+			scoreTable[nodeIDs[nIdx]] = sc
+			nIdx++
+			scoreTable[nodeIDs[nIdx]] = sc
+			nIdx++
+		}
+		tail := scores[len(scores)-1]
+		for ; nIdx < unlSize; nIdx++ {
+			scoreTable[nodeIDs[nIdx]] = tail
+		}
+		negUNL := make(map[consensus.NodeID]struct{})
+		switch nUnlPercent {
+		case 100:
+			for _, n := range nodeIDs {
+				negUNL[n] = struct{}{}
+			}
+		case 50:
+			for i := 1; i < unlSize; i += 2 {
+				negUNL[nodeIDs[i]] = struct{}{}
+			}
+		}
+		return unl, negUNL, scoreTable
+	}
+
+	for _, us := range unlSizes {
+		for _, np := range nUnlPercents {
+			name := fmt.Sprintf("us=%d/np=%d", us, np)
+			t.Run(name, func(t *testing.T) {
+				unl, negUNL, scoreTable := build(us, np)
+				require.Equal(t, us, len(unl))
+				require.Equal(t, us*np/100, len(negUNL))
+				require.Equal(t, us, len(scoreTable))
+
+				var toDisableExpect, toReEnableExpect int
+				switch np {
+				case 0:
+					toDisableExpect = 4
+				case 50:
+					toReEnableExpect = len(negUNL) - 6
+				case 100:
+					toReEnableExpect = len(negUNL) - 12
+				}
+
+				c := v.findAllCandidates(unl, negUNL, scoreTable)
+				assert.Equal(t, toDisableExpect, len(c.toDisable),
+					"toDisable count mismatch")
+				assert.Equal(t, toReEnableExpect, len(c.toReEnable),
+					"toReEnable count mismatch")
+			})
+		}
+	}
 }

--- a/internal/consensus/negativeunlvote/vote_test.go
+++ b/internal/consensus/negativeunlvote/vote_test.go
@@ -1,0 +1,273 @@
+package negativeunlvote
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeKey produces a deterministic 33-byte master pubkey for a
+// given byte tag. The first byte is a valid secp256k1 prefix (0x02
+// or 0x03) so the codec accepts the field as a Blob; subsequent
+// bytes are filled with the tag for human readability in failures.
+func makeKey(tag byte) [33]byte {
+	var k [33]byte
+	k[0] = 0x02
+	for i := 1; i < 33; i++ {
+		k[i] = tag
+	}
+	return k
+}
+
+func nodeID(tag byte) consensus.NodeID {
+	return consensus.NodeID(makeKey(tag))
+}
+
+// fullScoreTable returns scoreTable[nid] = HighWaterMark+1 for
+// every key in keys, plus the local node at MinLocalValsToVote+1
+// so DoVoting clears the local-participation gate by default. The
+// local-node assignment runs LAST so it overrides any HighWaterMark
+// score the loop wrote when myKey is also in keys.
+func fullScoreTable(myID consensus.NodeID, keys [][33]byte) map[consensus.NodeID]uint32 {
+	st := map[consensus.NodeID]uint32{}
+	for _, k := range keys {
+		st[keyToNodeID(k)] = HighWaterMark + 1
+	}
+	st[myID] = MinLocalValsToVote + 1
+	return st
+}
+
+func TestDoVoting_RefusesWhenLocalParticipationLow(t *testing.T) {
+	myKey := makeKey(0xAA)
+	other := makeKey(0xBB)
+	v := NewVoter(keyToNodeID(myKey))
+
+	scoreTable := map[consensus.NodeID]uint32{
+		v.myID:             MinLocalValsToVote - 1, // below threshold
+		keyToNodeID(other): 0,                      // would normally be disabled
+	}
+
+	blobs, err := v.DoVoting(1024, [32]byte{0xDE, 0xAD}, [][33]byte{myKey, other}, State{}, scoreTable)
+	require.NoError(t, err)
+	assert.Nil(t, blobs, "must not vote when local participation is below MinLocalValsToVote")
+}
+
+func TestDoVoting_NoCandidatesWhenAllParticipating(t *testing.T) {
+	myKey := makeKey(0xAA)
+	other := makeKey(0xBB)
+	v := NewVoter(keyToNodeID(myKey))
+
+	scoreTable := fullScoreTable(v.myID, [][33]byte{myKey, other})
+	blobs, err := v.DoVoting(1024, [32]byte{0xDE, 0xAD}, [][33]byte{myKey, other}, State{}, scoreTable)
+	require.NoError(t, err)
+	assert.Nil(t, blobs, "no candidates → no tx")
+}
+
+func TestDoVoting_ToDisableWhenScoreLow(t *testing.T) {
+	myKey := makeKey(0xAA)
+	good := makeKey(0xBB)
+	weak := makeKey(0xCC)
+	v := NewVoter(keyToNodeID(myKey))
+	unl := [][33]byte{myKey, good, weak}
+
+	scoreTable := fullScoreTable(v.myID, unl)
+	scoreTable[keyToNodeID(weak)] = LowWaterMark - 1 // unreliable
+
+	blobs, err := v.DoVoting(1024, [32]byte{0x01}, unl, State{}, scoreTable)
+	require.NoError(t, err)
+	require.Len(t, blobs, 1, "expected one ToDisable pseudo-tx")
+
+	tx := decodeTx(t, blobs[0])
+	assert.EqualValues(t, 1, asUint(tx["UNLModifyDisabling"]),
+		"sfUNLModifyDisabling must be 1 for ToDisable")
+	assert.Equal(t, hex.EncodeToString(weak[:]),
+		stringFold(tx["UNLModifyValidator"]),
+		"validator field must be the weak validator's master key")
+	assert.EqualValues(t, 1025, asUint(tx["LedgerSequence"]))
+}
+
+func TestDoVoting_ToReEnableWhenDisabledScoreHigh(t *testing.T) {
+	myKey := makeKey(0xAA)
+	good := makeKey(0xBB)
+	recovered := makeKey(0xCC)
+	v := NewVoter(keyToNodeID(myKey))
+	unl := [][33]byte{myKey, good, recovered}
+
+	scoreTable := fullScoreTable(v.myID, unl) // recovered's score is already > HighWaterMark
+	state := State{
+		DisabledKeys: [][33]byte{recovered}, // currently on negUNL
+	}
+
+	blobs, err := v.DoVoting(1024, [32]byte{0x02}, unl, state, scoreTable)
+	require.NoError(t, err)
+	require.Len(t, blobs, 1)
+
+	tx := decodeTx(t, blobs[0])
+	assert.EqualValues(t, 0, asUint(tx["UNLModifyDisabling"]),
+		"sfUNLModifyDisabling must be 0 for ToReEnable")
+	assert.Equal(t, hex.EncodeToString(recovered[:]),
+		stringFold(tx["UNLModifyValidator"]))
+}
+
+func TestDoVoting_RespectsMaxListedFraction(t *testing.T) {
+	// 4-validator UNL → 25% cap = ceil(1) = 1 listed allowed.
+	// One already disabled, one weak: cap reached → no new ToDisable.
+	myKey := makeKey(0xAA)
+	good := makeKey(0xBB)
+	weak := makeKey(0xCC)
+	disabled := makeKey(0xDD)
+	v := NewVoter(keyToNodeID(myKey))
+	unl := [][33]byte{myKey, good, weak, disabled}
+
+	scoreTable := fullScoreTable(v.myID, unl)
+	scoreTable[keyToNodeID(weak)] = LowWaterMark - 1
+
+	state := State{DisabledKeys: [][33]byte{disabled}}
+
+	blobs, err := v.DoVoting(1024, [32]byte{0x03}, unl, state, scoreTable)
+	require.NoError(t, err)
+	for _, b := range blobs {
+		tx := decodeTx(t, b)
+		// Whatever blobs are returned must NOT be a ToDisable for `weak`.
+		if asUint(tx["UNLModifyDisabling"]) == 1 {
+			t.Fatalf("MaxListedFraction cap exceeded — got new ToDisable: %v", tx)
+		}
+	}
+}
+
+func TestDoVoting_NewValidatorSkip(t *testing.T) {
+	myKey := makeKey(0xAA)
+	good := makeKey(0xBB)
+	freshWeak := makeKey(0xCC)
+	v := NewVoter(keyToNodeID(myKey))
+	unl := [][33]byte{myKey, good, freshWeak}
+
+	upcomingSeq := uint32(1025)
+	// Register freshWeak as new at seq=900; the upcoming seq=1025 is
+	// within the NewValidatorDisableSkip window, so freshWeak is not
+	// a ToDisable candidate even with a low score.
+	v.NewValidators(900, []consensus.NodeID{keyToNodeID(freshWeak)})
+	require.True(t, upcomingSeq-900 <= NewValidatorDisableSkip)
+
+	scoreTable := fullScoreTable(v.myID, unl)
+	scoreTable[keyToNodeID(freshWeak)] = LowWaterMark - 1
+
+	blobs, err := v.DoVoting(upcomingSeq-1, [32]byte{0x04}, unl, State{}, scoreTable)
+	require.NoError(t, err)
+	assert.Nil(t, blobs, "new validator within skip window must not be a ToDisable candidate")
+}
+
+func TestDoVoting_RemovedFromUNL_ReEnableFallback(t *testing.T) {
+	// A validator currently on the negUNL is no longer in the trusted
+	// UNL — fallback path at NegativeUNLVote.cpp:309-318 must
+	// re-enable it (so the negUNL doesn't keep a non-validator
+	// listed forever).
+	myKey := makeKey(0xAA)
+	good := makeKey(0xBB)
+	stale := makeKey(0xCC)
+	v := NewVoter(keyToNodeID(myKey))
+	unl := [][33]byte{myKey, good} // stale is NOT in the UNL
+	scoreTable := fullScoreTable(v.myID, unl)
+
+	state := State{DisabledKeys: [][33]byte{stale}}
+	blobs, err := v.DoVoting(1024, [32]byte{0x05}, unl, state, scoreTable)
+	require.NoError(t, err)
+	require.Len(t, blobs, 1)
+
+	tx := decodeTx(t, blobs[0])
+	assert.EqualValues(t, 0, asUint(tx["UNLModifyDisabling"]),
+		"fallback re-enable for validator no longer in UNL")
+	assert.Equal(t, hex.EncodeToString(stale[:]),
+		stringFold(tx["UNLModifyValidator"]))
+}
+
+func TestChoose_DeterministicAcrossCalls(t *testing.T) {
+	candidates := []consensus.NodeID{nodeID(0x01), nodeID(0x02), nodeID(0x03)}
+	pad := [32]byte{0xCA, 0xFE, 0xBA, 0xBE}
+
+	first := choose(pad, candidates)
+	for i := 0; i < 8; i++ {
+		got := choose(pad, candidates)
+		assert.Equal(t, first, got, "choose must be deterministic across repeated calls")
+	}
+}
+
+func TestChoose_OrderIndependent(t *testing.T) {
+	a, b, c := nodeID(0x01), nodeID(0x02), nodeID(0x03)
+	pad := [32]byte{0x42}
+
+	picked := choose(pad, []consensus.NodeID{a, b, c})
+	pickedReordered := choose(pad, []consensus.NodeID{c, b, a})
+	assert.Equal(t, picked, pickedReordered,
+		"choose must be input-order-independent — every validator on the network must converge on the same pick")
+}
+
+// decodeTx round-trips the serialized blob back to a JSON-ish map
+// for field-level assertions. Mirrors how rippled's wire receiver
+// would parse the pseudo-tx; if this fails, the on-wire format is
+// malformed.
+func decodeTx(t *testing.T, blob []byte) map[string]any {
+	t.Helper()
+	out, err := binarycodec.Decode(hex.EncodeToString(blob))
+	require.NoError(t, err, "serialized UNLModify must round-trip through binarycodec.Decode")
+	return out
+}
+
+// asUint coerces a JSON-decoded numeric field to uint64. binarycodec.
+// Decode returns small unsigned ints as float64 / uint via its codec
+// definitions; we accept the common shapes.
+func asUint(v any) uint64 {
+	switch n := v.(type) {
+	case uint8:
+		return uint64(n)
+	case uint16:
+		return uint64(n)
+	case uint32:
+		return uint64(n)
+	case uint64:
+		return n
+	case int:
+		return uint64(n)
+	case int64:
+		return uint64(n)
+	case float64:
+		return uint64(n)
+	case string:
+		// uint64 may decode as a hex string under some codec paths.
+		var x uint64
+		for _, c := range n {
+			x <<= 4
+			switch {
+			case c >= '0' && c <= '9':
+				x |= uint64(c - '0')
+			case c >= 'a' && c <= 'f':
+				x |= uint64(c-'a') + 10
+			case c >= 'A' && c <= 'F':
+				x |= uint64(c-'A') + 10
+			}
+		}
+		return x
+	}
+	return 0
+}
+
+func stringFold(v any) string {
+	switch s := v.(type) {
+	case string:
+		// Lowercase hex for stable comparison.
+		out := make([]byte, len(s))
+		for i := 0; i < len(s); i++ {
+			c := s[i]
+			if c >= 'A' && c <= 'F' {
+				c = c - 'A' + 'a'
+			}
+			out[i] = c
+		}
+		return string(out)
+	}
+	return ""
+}

--- a/internal/consensus/negativeunlvote/vote_test.go
+++ b/internal/consensus/negativeunlvote/vote_test.go
@@ -27,17 +27,23 @@ func nodeID(tag byte) consensus.NodeID {
 	return consensus.NodeID(makeKey(tag))
 }
 
-// fullScoreTable returns scoreTable[nid] = HighWaterMark+1 for
-// every key in keys, plus the local node at MinLocalValsToVote+1
+// fullScoreTable returns scoreTable[nid] = HighWaterMark+1 for every
+// non-local key in keys, plus the local node at MinLocalValsToVote+1
 // so DoVoting clears the local-participation gate by default. The
-// local-node assignment runs LAST so it overrides any HighWaterMark
-// score the loop wrote when myKey is also in keys.
+// local node is set unconditionally — including the case where myID
+// is also a member of keys — so the helper is robust to call sites
+// that include myKey in the UNL list.
 func fullScoreTable(myID consensus.NodeID, keys [][33]byte) map[consensus.NodeID]uint32 {
-	st := map[consensus.NodeID]uint32{}
-	for _, k := range keys {
-		st[keyToNodeID(k)] = HighWaterMark + 1
+	st := map[consensus.NodeID]uint32{
+		myID: MinLocalValsToVote + 1,
 	}
-	st[myID] = MinLocalValsToVote + 1
+	for _, k := range keys {
+		nid := keyToNodeID(k)
+		if nid == myID {
+			continue
+		}
+		st[nid] = HighWaterMark + 1
+	}
 	return st
 }
 
@@ -270,4 +276,262 @@ func stringFold(v any) string {
 		return string(out)
 	}
 	return ""
+}
+
+// expectedChoose mirrors choose() byte-for-byte using the same
+// calcNodeID-then-XOR comparator. Used as the oracle for parity tests
+// against rippled's NegativeUNLVote::choose at NegativeUNLVote.cpp:
+// 142-161. If choose's comparator drifts (e.g. back to a 32-byte XOR
+// over the raw pubkey), these tests will catch the divergence.
+func expectedChoose(pad [32]byte, cands []consensus.NodeID) consensus.NodeID {
+	var bestKey [20]byte
+	var best consensus.NodeID
+	for i, c := range cands {
+		nid := calcNodeID(c)
+		var k [20]byte
+		for j := 0; j < 20; j++ {
+			k[j] = nid[j] ^ pad[j]
+		}
+		if i == 0 {
+			best, bestKey = c, k
+			continue
+		}
+		less := false
+		for j := 0; j < 20; j++ {
+			if k[j] != bestKey[j] {
+				less = k[j] < bestKey[j]
+				break
+			}
+		}
+		if less {
+			best, bestKey = c, k
+		}
+	}
+	return best
+}
+
+// TestChoose_RippledParity_PicksMinCalcNodeIDXorPad asserts that
+// choose() picks the candidate whose calcNodeID(pubkey) XOR pad[:20]
+// is minimal — the exact comparator rippled uses at
+// NegativeUNLVote.cpp:142-161 + PublicKey.cpp:319-327. This test
+// would fail if choose() reverted to comparing the raw 33-byte
+// pubkey with a 32-byte pad, which would silently desync Go votes
+// from rippled votes on a mixed validator network.
+func TestChoose_RippledParity_PicksMinCalcNodeIDXorPad(t *testing.T) {
+	cands := []consensus.NodeID{nodeID(0x11), nodeID(0x22), nodeID(0x33), nodeID(0x44)}
+
+	for _, padTag := range []byte{0x00, 0xFF, 0xA5, 0x5A} {
+		var pad [32]byte
+		for i := range pad {
+			pad[i] = padTag
+		}
+		got := choose(pad, cands)
+		want := expectedChoose(pad, cands)
+		assert.Equal(t, want, got,
+			"pad=0x%02X: choose picked the wrong candidate; comparator must use calcNodeID(pubkey) XOR pad[:20]", padTag)
+	}
+}
+
+// TestChoose_PadAffectsPick asserts that two distinct pads can
+// produce different picks. This catches a comparator that ignores
+// the pad (e.g. a stub that always returns candidates[0]).
+func TestChoose_PadAffectsPick(t *testing.T) {
+	cands := []consensus.NodeID{nodeID(0x11), nodeID(0x22), nodeID(0x33), nodeID(0x44), nodeID(0x55)}
+
+	var padZero [32]byte
+	var padFF [32]byte
+	for i := range padFF {
+		padFF[i] = 0xFF
+	}
+
+	pickZero := choose(padZero, cands)
+	pickFF := choose(padFF, cands)
+	assert.NotEqual(t, pickZero, pickFF,
+		"choose with all-0 vs all-FF pads must produce different picks for this candidate set")
+}
+
+// TestFindAllCandidates_BoundaryScores asserts the strict-inequality
+// boundary in NegativeUNLVote.cpp:282 (`score < negativeUNLLowWaterMark`)
+// and :292 (`score > negativeUNLHighWaterMark`): a validator with
+// score == LowWaterMark is NOT a toDisable candidate, and one with
+// score == HighWaterMark is NOT a toReEnable candidate. rippled's
+// testFindAllCandidatesCombination at NegativeUNL_test.cpp:1175-1183
+// includes these boundary scores in its grid; we cover them
+// directly here.
+func TestFindAllCandidates_BoundaryScores(t *testing.T) {
+	myKey := makeKey(0xAA)
+	atLow := makeKey(0xBB)
+	atHigh := makeKey(0xCC)
+	other := makeKey(0xDD)
+	v := NewVoter(keyToNodeID(myKey))
+
+	unlKeys := [][33]byte{myKey, atLow, atHigh, other}
+	unl := map[consensus.NodeID][33]byte{}
+	for _, k := range unlKeys {
+		unl[keyToNodeID(k)] = k
+	}
+	negUNL := map[consensus.NodeID]struct{}{
+		keyToNodeID(atHigh): {},
+	}
+	scoreTable := map[consensus.NodeID]uint32{
+		keyToNodeID(myKey):  HighWaterMark + 1,
+		keyToNodeID(atLow):  LowWaterMark,  // exactly at boundary — NOT a candidate
+		keyToNodeID(atHigh): HighWaterMark, // exactly at boundary — NOT a candidate
+		keyToNodeID(other):  HighWaterMark + 1,
+	}
+
+	c := v.findAllCandidates(unl, negUNL, scoreTable)
+	assert.Empty(t, c.toDisable, "score == LowWaterMark must not be a toDisable candidate (rippled uses strict `<`)")
+	assert.Empty(t, c.toReEnable, "score == HighWaterMark must not be a toReEnable candidate (rippled uses strict `>`)")
+}
+
+// TestDoVoting_AllBadScores_CapEnforced exercises the
+// MaxListedFraction cap with a UNL large enough that the cap is >1
+// and many candidates qualify. With 8 validators and 0% currently
+// disabled, ceil(8*0.25)=2 are allowed on the negUNL; canAdd is true
+// (since listed=0 < 2), so the candidate scan runs, but DoVoting
+// always picks at most one toDisable per round. The 25% cap is
+// re-tested when votes are applied, so producing one tx per round
+// matches rippled's behavior.
+func TestDoVoting_AllBadScores_CapEnforced(t *testing.T) {
+	myKey := makeKey(0xAA)
+	v := NewVoter(keyToNodeID(myKey))
+
+	unl := [][33]byte{myKey}
+	for i := byte(1); i <= 7; i++ {
+		unl = append(unl, makeKey(0xB0+i))
+	}
+
+	// Local node above MinLocalValsToVote, every other validator
+	// below LowWaterMark.
+	scoreTable := map[consensus.NodeID]uint32{
+		keyToNodeID(myKey): MinLocalValsToVote + 1,
+	}
+	for _, k := range unl {
+		nid := keyToNodeID(k)
+		if nid == keyToNodeID(myKey) {
+			continue
+		}
+		scoreTable[nid] = LowWaterMark - 1
+	}
+
+	blobs, err := v.DoVoting(1024, [32]byte{0xAB, 0xCD}, unl, State{}, scoreTable)
+	require.NoError(t, err)
+	require.Len(t, blobs, 1, "DoVoting returns at most one toDisable per round")
+
+	tx := decodeTx(t, blobs[0])
+	assert.EqualValues(t, 1, asUint(tx["UNLModifyDisabling"]),
+		"the single emitted tx must be a ToDisable")
+}
+
+// TestDoVoting_NewValidatorExpired_BecomesCandidate covers rippled's
+// case 9 in testFindAllCandidates (NegativeUNL_test.cpp:1136-1144):
+// a validator added via NewValidators is exempt from ToDisable while
+// inside the skip window; once seq advances past
+// NewValidatorDisableSkip, PurgeNewValidators removes it and a bad
+// score makes it a candidate. PR #375 shipped only the not-yet-
+// expired half of this case.
+func TestDoVoting_NewValidatorExpired_BecomesCandidate(t *testing.T) {
+	myKey := makeKey(0xAA)
+	good := makeKey(0xBB)
+	exFresh := makeKey(0xCC)
+	v := NewVoter(keyToNodeID(myKey))
+	unl := [][33]byte{myKey, good, exFresh}
+
+	addedAt := uint32(900)
+	v.NewValidators(addedAt, []consensus.NodeID{keyToNodeID(exFresh)})
+
+	// Upcoming seq is past the skip window:
+	//   addedAt + NewValidatorDisableSkip + 2  → strictly > skip,
+	//   so PurgeNewValidators removes the entry.
+	upcomingSeq := addedAt + NewValidatorDisableSkip + 2
+	require.Greater(t, upcomingSeq-addedAt, NewValidatorDisableSkip,
+		"sanity: upcoming seq must be past the skip window")
+
+	scoreTable := fullScoreTable(v.myID, unl)
+	scoreTable[keyToNodeID(exFresh)] = LowWaterMark - 1
+
+	blobs, err := v.DoVoting(upcomingSeq-1, [32]byte{0x06}, unl, State{}, scoreTable)
+	require.NoError(t, err)
+	require.Len(t, blobs, 1, "expired new validator with bad score must produce a ToDisable")
+
+	tx := decodeTx(t, blobs[0])
+	assert.EqualValues(t, 1, asUint(tx["UNLModifyDisabling"]),
+		"sfUNLModifyDisabling must be 1 for the expired-then-bad-score case")
+	assert.Equal(t, hex.EncodeToString(exFresh[:]),
+		stringFold(tx["UNLModifyValidator"]),
+		"validator field must be the (now-expired) fresh validator")
+}
+
+// TestDoVoting_BoundaryParticipation covers the rippled boundary
+// where myValidationCount == MinLocalValsToVote. Rippled's else-if
+// at NegativeUNLVote.cpp:230-231 uses strict `>`, so the boundary
+// falls into the "Too many!" else-branch and returns empty. The Go
+// port must match: at exactly MinLocalValsToVote, do not vote.
+func TestDoVoting_BoundaryParticipation(t *testing.T) {
+	myKey := makeKey(0xAA)
+	weak := makeKey(0xBB)
+	v := NewVoter(keyToNodeID(myKey))
+	unl := [][33]byte{myKey, weak}
+
+	scoreTable := map[consensus.NodeID]uint32{
+		v.myID:            MinLocalValsToVote, // exactly at boundary
+		keyToNodeID(weak): LowWaterMark - 1,   // would be toDisable if we voted
+	}
+
+	blobs, err := v.DoVoting(1024, [32]byte{0xDE, 0xAD}, unl, State{}, scoreTable)
+	require.NoError(t, err)
+	assert.Nil(t, blobs, "myCount == MinLocalValsToVote must NOT vote (rippled uses strict `>`)")
+}
+
+// TestDoVoting_LocalCountAboveWindow covers the rippled "Too many!"
+// branch at NegativeUNLVote.cpp:236-244 — myValidationCount >
+// FlagLedgerInterval returns empty (no vote). The Go port treats
+// this as a normal no-vote rather than a producer error, matching
+// the observed effect on consensus.
+func TestDoVoting_LocalCountAboveWindow(t *testing.T) {
+	myKey := makeKey(0xAA)
+	weak := makeKey(0xBB)
+	v := NewVoter(keyToNodeID(myKey))
+	unl := [][33]byte{myKey, weak}
+
+	scoreTable := map[consensus.NodeID]uint32{
+		v.myID:            flagLedgerInterval + 1,
+		keyToNodeID(weak): LowWaterMark - 1,
+	}
+
+	blobs, err := v.DoVoting(1024, [32]byte{0xDE, 0xAD}, unl, State{}, scoreTable)
+	require.NoError(t, err, "above-window must NOT surface as a producer error")
+	assert.Nil(t, blobs, "myCount > FlagLedgerInterval must NOT vote")
+}
+
+// TestDoVoting_ScoreTableMissingUNLMember covers the API-boundary
+// invariant introduced to match rippled's buildScoreTable at
+// NegativeUNLVote.cpp:197-200: every UNL member is treated as score
+// 0 if absent from the supplied scoreTable. Without the zero-fill
+// inside DoVoting, a UNL member silently absent would never become
+// a toDisable candidate even though rippled would always count it
+// as a non-validator with score 0.
+func TestDoVoting_ScoreTableMissingUNLMember(t *testing.T) {
+	myKey := makeKey(0xAA)
+	silent := makeKey(0xBB) // never validated — missing from scoreTable
+	other := makeKey(0xCC)
+	v := NewVoter(keyToNodeID(myKey))
+	unl := [][33]byte{myKey, silent, other}
+
+	scoreTable := map[consensus.NodeID]uint32{
+		v.myID:             MinLocalValsToVote + 1,
+		keyToNodeID(other): HighWaterMark + 1,
+		// silent intentionally omitted
+	}
+
+	blobs, err := v.DoVoting(1024, [32]byte{0x07}, unl, State{}, scoreTable)
+	require.NoError(t, err)
+	require.Len(t, blobs, 1, "silent UNL member (missing from scoreTable) must be treated as score 0 → toDisable")
+
+	tx := decodeTx(t, blobs[0])
+	assert.EqualValues(t, 1, asUint(tx["UNLModifyDisabling"]))
+	assert.Equal(t, hex.EncodeToString(silent[:]),
+		stringFold(tx["UNLModifyValidator"]),
+		"the silent (missing-from-scoreTable) validator must be the picked candidate")
 }


### PR DESCRIPTION
## Summary

Pure-algorithm port of rippled's [`NegativeUNLVote`](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/misc/NegativeUNLVote.cpp) (357 LOC) to a new `internal/consensus/negativeunlvote` package. Decides whether to inject a `UNLModify` pseudo-tx into the consensus tx set on a flag-ledger boundary, based on per-validator validation counts across the last `FlagLedgerInterval` ledgers.

The algorithm is testable in isolation against synthetic score tables and `NegativeUNL` states, so this PR ships **just the algorithm + comprehensive tests**. Wiring it into `Adaptor.GenerateNegativeUNLPseudoTx` requires extending `ValidationTracker` with per-seq history and adding state-map read access to `consensus.Ledger` — substantial separate work, surfaced as a follow-up below.

## Behavior matched against rippled

| Behavior | Source | Threshold / mechanism |
|---|---|---|
| Score-table window | `NegativeUNLVote.cpp:163-245` | last `FlagLedgerInterval = 256` ledgers |
| ToDisable threshold | `NegativeUNLVote.cpp:282-287` | score < `LowWaterMark` (50%) |
| ToReEnable threshold | `NegativeUNLVote.cpp:289-296` | score > `HighWaterMark` (80%) |
| Local-participation gate | `NegativeUNLVote.cpp:216-244` | own count >= `MinLocalValsToVote` (90%) |
| 25% cap | `NegativeUNLVote.cpp:254-270` | `MaxListedFraction = 0.25` |
| New-validator skip | `NegativeUNLVote.cpp:282-284, 322-355` | 2 × `FlagLedgerInterval` window |
| No-longer-in-UNL fallback | `NegativeUNLVote.cpp:309-318` | re-enable removed validators |
| Deterministic pick | `NegativeUNLVote.cpp:142-161` | XOR with `prevLedger.hash` → minimum |
| UNLModify wire format | `NegativeUNLVote.cpp:110-140` | zero account / zero fee / empty signing key / seq 0 |

## Tests

All in `internal/consensus/negativeunlvote/vote_test.go`:

- [x] `TestDoVoting_RefusesWhenLocalParticipationLow`
- [x] `TestDoVoting_NoCandidatesWhenAllParticipating`
- [x] `TestDoVoting_ToDisableWhenScoreLow`
- [x] `TestDoVoting_ToReEnableWhenDisabledScoreHigh`
- [x] `TestDoVoting_RespectsMaxListedFraction` — 4-validator UNL with one already disabled hits the 25% cap
- [x] `TestDoVoting_NewValidatorSkip`
- [x] `TestDoVoting_RemovedFromUNL_ReEnableFallback`
- [x] `TestChoose_DeterministicAcrossCalls`
- [x] `TestChoose_OrderIndependent` — every validator on the network must converge on the same pick

`go test ./internal/consensus/...` passes; `go vet` clean.

## Follow-up: production wiring

`Adaptor.GenerateNegativeUNLPseudoTx` still returns nil. The algorithm is ready; the wiring is gated on:

1. **Per-seq validation history in `ValidationTracker`** — today validations are only indexed by `LedgerID` (`internal/consensus/rcl/validations.go`). The producer needs to query "validations for ancestor at seq N by hash H" across the last 256 ledgers; that requires extending the tracker with a per-seq map.
2. **State-map read access on `consensus.Ledger`** — the producer reads the `NegativeUNL` SLE and the `LedgerHashes` skip-list off `prevLedger`. The current `consensus.Ledger` interface (`internal/consensus/engine.go:319`) doesn't expose state-map reads. `Adaptor.GetNegativeUNL()` exists but only reads from the validated-ledger view, not from a specific prevLedger.

I'll open a follow-up sub-issue for the wiring once this lands.

## Note on NodeID width

goXRPL's `consensus.NodeID` is the 33-byte compressed pubkey, vs rippled's 20-byte RIPEMD-160 hash. The algorithm uses NodeID only as the score-table key (local lookup); the `UNLModifyValidator` field on the wire carries the 33-byte master pubkey, which is what rippled's receiver also reads as the master key — so cross-implementation pseudo-tx parity is unaffected. Documented in `keyToNodeID`.