### PR TITLE
adaptor: parse validator_token, split master/ephemeral keys (refs #371)

### DIFF
--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -357,6 +357,19 @@ func (c SECP256K1CryptoAlgorithm) DeriveValidatorKeypair(seed []byte) (string, s
 	return c.DeriveKeypair(seed, true)
 }
 
+// DerivePublicKeyFromSecret returns the 33-byte compressed secp256k1
+// public key for a raw 32-byte secret. Mirrors rippled's
+// derivePublicKey(KeyType::secp256k1, SecretKey) used by validator-token
+// loading, where the JSON `validation_secret_key` already is the raw
+// scalar (no seed expansion).
+func (c SECP256K1CryptoAlgorithm) DerivePublicKeyFromSecret(secret []byte) ([]byte, error) {
+	if len(secret) != 32 {
+		return nil, ErrInvalidPrivateKey
+	}
+	_, pubKey := btcec.PrivKeyFromBytes(secret)
+	return pubKey.SerializeCompressed(), nil
+}
+
 // DeriveAccountKeypair derives an account keypair from a seed.
 // This is a convenience function that calls DeriveKeypair with validator=false.
 func (c SECP256K1CryptoAlgorithm) DeriveAccountKeypair(seed []byte) (string, string, error) {

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -352,8 +352,11 @@ func TestValidatorIdentityFromSeed(t *testing.T) {
 	identity, err = NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
 	assert.NoError(t, err)
 	assert.NotNil(t, identity)
-	assert.Len(t, identity.PublicKey, 33) // compressed secp256k1
+	// Seed-only identity: master == signing == NodeID, no manifest.
+	assert.Equal(t, identity.MasterKey, identity.SigningKey)
 	assert.NotEqual(t, consensus.NodeID{}, identity.NodeID)
+	assert.Nil(t, identity.Manifest)
+	assert.Nil(t, identity.SerializedMfst)
 }
 
 func TestLedgerWrapper(t *testing.T) {

--- a/internal/consensus/adaptor/identity.go
+++ b/internal/consensus/adaptor/identity.go
@@ -117,13 +117,14 @@ func NewValidatorIdentity(seed string) (*ValidatorIdentity, error) {
 //
 // Steps mirror rippled ValidatorKeys.cpp:42-71:
 //  1. Parse the token into manifest + 32-byte secret.
-//  2. Decode and parse the embedded manifest.
-//  3. Verify the manifest's signatures.
-//  4. Derive the public key from the secret and confirm it matches the
+//  2. Decode and parse the embedded manifest (structural invariants
+//     only; signatures are not verified here, matching rippled — the
+//     ManifestCache verifies on apply).
+//  3. Derive the public key from the secret and confirm it matches the
 //     manifest's SigningPubKey — protects against a swapped or corrupt
 //     token blob where the secret no longer signs the declared
 //     ephemeral key.
-//  5. Store master, signing, signing-priv, and the wire-format manifest
+//  4. Store master, signing, signing-priv, and the wire-format manifest
 //     so #372 can broadcast it.
 func NewValidatorIdentityFromToken(block string) (*ValidatorIdentity, error) {
 	if block == "" {
@@ -140,9 +141,6 @@ func NewValidatorIdentityFromToken(block string) (*ValidatorIdentity, error) {
 	m, err := manifest.Deserialize(wire)
 	if err != nil {
 		return nil, fmt.Errorf("validator_token: deserialize manifest: %w", err)
-	}
-	if err := m.Verify(); err != nil {
-		return nil, fmt.Errorf("validator_token: verify manifest: %w", err)
 	}
 
 	pub, err := secp256k1.SECP256K1().DerivePublicKeyFromSecret(tok.ValidationSecret[:])

--- a/internal/consensus/adaptor/identity.go
+++ b/internal/consensus/adaptor/identity.go
@@ -3,45 +3,93 @@ package adaptor
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/crypto/common"
 	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/manifest"
 	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 var (
-	ErrNoValidatorKey = errors.New("no validator key configured")
-	ErrInvalidSeed    = errors.New("invalid validator seed")
+	ErrNoValidatorKey           = errors.New("no validator key configured")
+	ErrInvalidSeed              = errors.New("invalid validator seed")
+	ErrTokenManifestKeyMismatch = errors.New("validator_token: signing key in manifest does not match validation_secret_key")
+	ErrTokenAndSeed             = errors.New("validator_token and validation_seed are mutually exclusive")
 )
 
-// ValidatorIdentity holds the validator's signing keys.
-// If nil or empty, the node operates as a non-validator (observer).
+// ValidatorIdentity holds the validator's signing keys and, when
+// configured via [validator_token], its master-signed manifest.
+//
+// Two configuration paths populate this struct:
+//
+//   - validator_token (preferred): MasterKey is the long-term identity
+//     declared in the manifest; SigningKey is the rotatable ephemeral
+//     key used to sign every consensus message; Manifest carries the
+//     master-signed binding so peers can resolve SigningKey → MasterKey.
+//
+//   - validation_seed (legacy): MasterKey == SigningKey, derived
+//     directly from the seed; Manifest is nil. Peers cannot rotate
+//     keys without operator intervention on every peer in this mode.
+//
+// NodeID currently equals SigningKey for wire-format compatibility
+// (sfSigningPubKey carries 33 bytes; consensus.NodeID is also 33 bytes
+// and is used both as the wire signing pubkey and as the in-memory
+// identifier). Rippled's true NodeID is calcNodeID(masterKey) — a
+// 20-byte RIPEMD-160 — and the manifest cache resolver in startup.go
+// already maps the signing-pubkey-shaped NodeID back to a master-shaped
+// one via GetMasterKey. Migrating consensus.NodeID to the 20-byte form
+// is tracked as a separate sub-issue per #371.
 type ValidatorIdentity struct {
-	// PublicKey is the compressed secp256k1 public key (33 bytes).
-	PublicKey []byte
-	// PrivateKey is the hex-encoded private key (for signing).
-	PrivateKey string
-	// NodeID is the consensus NodeID derived from the public key.
+	// MasterKey is the 33-byte compressed master public key declared in
+	// the manifest. In seed-only mode it equals SigningKey.
+	MasterKey [33]byte
+
+	// SigningKey is the 33-byte compressed ephemeral public key used
+	// to sign validations and proposals. In seed-only mode it equals
+	// MasterKey.
+	SigningKey [33]byte
+
+	// NodeID is the validator's wire-level identifier. Currently set
+	// to SigningKey to keep the existing
+	// {Validation,Proposal}.NodeID == sfSigningPubKey contract intact;
+	// see the type-level comment for the deferred migration.
 	NodeID consensus.NodeID
+
+	// Manifest is the parsed local manifest when configured via
+	// validator_token. Nil in seed-only mode. Used by #372 to drive
+	// TMManifests emission.
+	Manifest *manifest.Manifest
+
+	// SerializedMfst is the wire bytes of the local manifest, kept so
+	// emission (#372) can broadcast the exact payload peers expect
+	// without re-encoding through the codec.
+	SerializedMfst []byte
+
+	// signingPriv is the hex-encoded signing private key (with or
+	// without the leading "00" prefix; secp256k1.SignDigest accepts
+	// both). Unexported so callers cannot accidentally leak the secret.
+	signingPriv string
 }
 
-// NewValidatorIdentity creates a ValidatorIdentity from a seed string.
-// The seed can be in base58 (sXXX...) format.
-// Uses secp256k1 with validator=true derivation, matching rippled.
+// NewValidatorIdentity creates a seed-only identity. The seed is the
+// base58 [validation_seed] string. Returns nil if seed is empty (the
+// observer / non-validator case).
+//
+// Master and signing keys are identical in this mode, matching rippled's
+// ValidatorKeys.cpp:84-89 fallback when [validator_token] is absent.
 func NewValidatorIdentity(seed string) (*ValidatorIdentity, error) {
 	if seed == "" {
-		return nil, nil // not a validator
+		return nil, nil
 	}
 
-	// Decode the seed from base58
 	decodedSeed, _, err := addresscodec.DecodeSeed(seed)
 	if err != nil {
 		return nil, ErrInvalidSeed
 	}
 
-	// Derive validator keypair using secp256k1 (validator=true uses root generator directly)
 	algo := secp256k1.SECP256K1()
 	privKeyHex, pubKeyHex, err := algo.DeriveKeypair(decodedSeed, true)
 	if err != nil {
@@ -52,20 +100,105 @@ func NewValidatorIdentity(seed string) (*ValidatorIdentity, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(pubKeyBytes) != 33 {
+		return nil, fmt.Errorf("derived pubkey: unexpected length %d", len(pubKeyBytes))
+	}
 
-	var nodeID consensus.NodeID
-	copy(nodeID[:], pubKeyBytes)
-
-	return &ValidatorIdentity{
-		PublicKey:  pubKeyBytes,
-		PrivateKey: privKeyHex,
-		NodeID:     nodeID,
-	}, nil
+	vi := &ValidatorIdentity{signingPriv: privKeyHex}
+	copy(vi.MasterKey[:], pubKeyBytes)
+	copy(vi.SigningKey[:], pubKeyBytes)
+	copy(vi.NodeID[:], pubKeyBytes)
+	return vi, nil
 }
 
-// Sign signs a pre-computed digest with the validator's private key using secp256k1.
-// The data parameter must be a SHA-512Half digest (32 bytes).
-// Matches rippled's signDigest() which passes the hash directly to secp256k1.
+// NewValidatorIdentityFromToken creates a master/ephemeral split
+// identity from a `[validator_token]` config block. The block is the
+// raw multi-line section text (whitespace tolerated).
+//
+// Steps mirror rippled ValidatorKeys.cpp:42-71:
+//  1. Parse the token into manifest + 32-byte secret.
+//  2. Decode and parse the embedded manifest.
+//  3. Verify the manifest's signatures.
+//  4. Derive the public key from the secret and confirm it matches the
+//     manifest's SigningPubKey — protects against a swapped or corrupt
+//     token blob where the secret no longer signs the declared
+//     ephemeral key.
+//  5. Store master, signing, signing-priv, and the wire-format manifest
+//     so #372 can broadcast it.
+func NewValidatorIdentityFromToken(block string) (*ValidatorIdentity, error) {
+	if block == "" {
+		return nil, ErrNoValidatorKey
+	}
+	tok, err := manifest.LoadValidatorToken(block)
+	if err != nil {
+		return nil, err
+	}
+	wire, err := tok.DecodeManifest()
+	if err != nil {
+		return nil, err
+	}
+	m, err := manifest.Deserialize(wire)
+	if err != nil {
+		return nil, fmt.Errorf("validator_token: deserialize manifest: %w", err)
+	}
+	if err := m.Verify(); err != nil {
+		return nil, fmt.Errorf("validator_token: verify manifest: %w", err)
+	}
+
+	pub, err := secp256k1.SECP256K1().DerivePublicKeyFromSecret(tok.ValidationSecret[:])
+	if err != nil {
+		return nil, fmt.Errorf("validator_token: derive pubkey: %w", err)
+	}
+	var derived [33]byte
+	copy(derived[:], pub)
+	if derived != m.SigningKey {
+		return nil, ErrTokenManifestKeyMismatch
+	}
+
+	vi := &ValidatorIdentity{
+		MasterKey:      m.MasterKey,
+		SigningKey:     m.SigningKey,
+		Manifest:       m,
+		SerializedMfst: append([]byte(nil), m.Serialized...),
+		signingPriv:    hex.EncodeToString(tok.ValidationSecret[:]),
+	}
+	copy(vi.NodeID[:], m.SigningKey[:])
+	return vi, nil
+}
+
+// NewValidatorIdentityFromConfig dispatches to the seed or token
+// constructor based on which field the operator configured. Returns nil
+// when neither is set (observer mode), matching rippled which treats an
+// empty validator config as a non-validating node.
+//
+// Both configured at once is a fatal misconfiguration (rippled
+// ValidatorKeys.cpp:31-38 sets configInvalid_ in that case); the
+// equivalent here is a returned error so cmd/xrpld can surface it
+// before the consensus engine starts.
+func NewValidatorIdentityFromConfig(seed, token string) (*ValidatorIdentity, error) {
+	if seed != "" && token != "" {
+		return nil, ErrTokenAndSeed
+	}
+	if token != "" {
+		return NewValidatorIdentityFromToken(token)
+	}
+	return NewValidatorIdentity(seed)
+}
+
+// SigningPubKey returns the 33-byte compressed signing public key as a
+// fresh slice. Convenience for callers wiring overlay options that
+// expect a []byte (peermanagement.WithLocalValidatorPubKey).
+func (vi *ValidatorIdentity) SigningPubKey() []byte {
+	if vi == nil {
+		return nil
+	}
+	return append([]byte(nil), vi.SigningKey[:]...)
+}
+
+// Sign signs a pre-computed digest with the ephemeral signing key using
+// secp256k1. The data parameter must be a SHA-512Half digest (32 bytes).
+// Matches rippled's signDigest() which passes the hash directly to
+// secp256k1.
 func (vi *ValidatorIdentity) Sign(data []byte) ([]byte, error) {
 	if vi == nil {
 		return nil, ErrNoValidatorKey
@@ -73,7 +206,7 @@ func (vi *ValidatorIdentity) Sign(data []byte) ([]byte, error) {
 	algo := secp256k1.SECP256K1()
 	var digest [32]byte
 	copy(digest[:], data)
-	return algo.SignDigest(digest, vi.PrivateKey)
+	return algo.SignDigest(digest, vi.signingPriv)
 }
 
 // Verify verifies a signature against a public key.

--- a/internal/consensus/adaptor/identity_token_test.go
+++ b/internal/consensus/adaptor/identity_token_test.go
@@ -1,0 +1,300 @@
+package adaptor
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
+	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/protocol"
+)
+
+// tokenFixture bundles the synthetic validator-token blob and its key
+// material so individual test cases can verify the parts they care
+// about (parser, signing, manifest verification) against the same
+// inputs.
+type tokenFixture struct {
+	tokenBlock string
+	masterPub  [33]byte
+	signingPub [33]byte
+	signingSec [32]byte
+	sequence   uint32
+}
+
+// newTokenFixture mints a self-consistent validator_token: a freshly
+// generated ed25519 master, a freshly generated secp256k1 ephemeral
+// keypair, a manifest signed by both, and the base64-wrapped JSON
+// envelope rippled's validator-keys-tool emits.
+//
+// All randomness is seeded by `seed` so tests stay deterministic.
+func newTokenFixture(t *testing.T, seed byte, sequence uint32) tokenFixture {
+	t.Helper()
+
+	// Master: ed25519. Use deterministic-from-seed key material so the
+	// fixture is reproducible across runs.
+	masterSeedBytes := bytes.Repeat([]byte{seed}, ed25519.SeedSize)
+	masterPriv := ed25519.NewKeyFromSeed(masterSeedBytes)
+	masterPubBytes := masterPriv.Public().(ed25519.PublicKey)
+	master33 := append([]byte{0xED}, masterPubBytes...)
+
+	// Ephemeral: secp256k1. Build a 32-byte secret from the seed; the
+	// secret must be in (0, n) — for any 0x00 < seed < curve order it
+	// is, and 0xFF is also fine. Tests use small seeds so this holds.
+	var sec [32]byte
+	for i := range sec {
+		sec[i] = seed ^ byte(i+1)
+	}
+	algo := secp256k1.SECP256K1()
+	signingPubBytes, err := algo.DerivePublicKeyFromSecret(sec[:])
+	if err != nil {
+		t.Fatalf("derive ephemeral pubkey: %v", err)
+	}
+	if len(signingPubBytes) != 33 {
+		t.Fatalf("ephemeral pubkey wrong length: %d", len(signingPubBytes))
+	}
+
+	// Build the manifest STObject and sign it. The codec works in
+	// JSON-of-fields form; encode produces hex.
+	mfst := map[string]any{
+		"PublicKey":     hex.EncodeToString(master33),
+		"SigningPubKey": hex.EncodeToString(signingPubBytes),
+		"Sequence":      sequence,
+	}
+
+	preimage := manifestSigningPreimage(t, mfst)
+
+	// Ephemeral signature: secp256k1 over the preimage. The package's
+	// Sign internally SHA-512Halves the message — match that with
+	// SignCanonical to land in the always-low-S domain rippled prefers.
+	sigHex, err := algo.SignCanonical(string(preimage), hex.EncodeToString(sec[:]))
+	if err != nil {
+		t.Fatalf("sign ephemeral: %v", err)
+	}
+	mfst["Signature"] = sigHex
+
+	// Master signature: ed25519 directly over the preimage (ed25519
+	// hashes internally; rippled's verifier passes raw bytes).
+	masterSig := ed25519.Sign(masterPriv, preimage)
+	mfst["MasterSignature"] = hex.EncodeToString(masterSig)
+
+	encodedHex, err := binarycodec.Encode(mfst)
+	if err != nil {
+		t.Fatalf("encode manifest: %v", err)
+	}
+	wire, err := hex.DecodeString(encodedHex)
+	if err != nil {
+		t.Fatalf("decode manifest hex: %v", err)
+	}
+
+	// Wrap in the validator-keys-tool token format: base64 over JSON.
+	envelope, err := json.Marshal(map[string]string{
+		"manifest":              base64.StdEncoding.EncodeToString(wire),
+		"validation_secret_key": hex.EncodeToString(sec[:]),
+	})
+	if err != nil {
+		t.Fatalf("marshal token: %v", err)
+	}
+	tokenB64 := base64.StdEncoding.EncodeToString(envelope)
+
+	// Pretty-print the token across multiple indented lines, mirroring
+	// what an operator would copy out of validator-keys-tool. Ensures
+	// LoadValidatorToken's whitespace stripping is exercised end-to-end.
+	var tokenBlock strings.Builder
+	for i := 0; i < len(tokenB64); i += 64 {
+		end := i + 64
+		if end > len(tokenB64) {
+			end = len(tokenB64)
+		}
+		tokenBlock.WriteString("    ")
+		tokenBlock.WriteString(tokenB64[i:end])
+		tokenBlock.WriteString("\n")
+	}
+
+	fix := tokenFixture{
+		tokenBlock: tokenBlock.String(),
+		sequence:   sequence,
+	}
+	copy(fix.masterPub[:], master33)
+	copy(fix.signingPub[:], signingPubBytes)
+	fix.signingSec = sec
+	return fix
+}
+
+// manifestSigningPreimage replicates the package-internal preimage
+// construction so the test signs over exactly what Verify checks.
+// HashPrefix("MAN\0") || STObject(only signing fields).
+func manifestSigningPreimage(t *testing.T, src map[string]any) []byte {
+	t.Helper()
+	filtered := make(map[string]any, len(src))
+	for k, v := range src {
+		fi, _ := definitions.Get().GetFieldInstanceByFieldName(k)
+		if fi != nil && !fi.IsSigningField {
+			continue
+		}
+		filtered[k] = v
+	}
+	encodedHex, err := binarycodec.Encode(filtered)
+	if err != nil {
+		t.Fatalf("encode preimage body: %v", err)
+	}
+	body, err := hex.DecodeString(encodedHex)
+	if err != nil {
+		t.Fatalf("decode preimage hex: %v", err)
+	}
+	prefix := protocol.HashPrefixManifest
+	out := make([]byte, 0, len(prefix)+len(body))
+	out = append(out, prefix[:]...)
+	out = append(out, body...)
+	return out
+}
+
+func TestNewValidatorIdentityFromToken_HappyPath(t *testing.T) {
+	fix := newTokenFixture(t, 0x42, 7)
+
+	id, err := NewValidatorIdentityFromToken(fix.tokenBlock)
+	if err != nil {
+		t.Fatalf("NewValidatorIdentityFromToken: %v", err)
+	}
+	if id.MasterKey != fix.masterPub {
+		t.Errorf("MasterKey mismatch: got %x want %x", id.MasterKey, fix.masterPub)
+	}
+	if id.SigningKey != fix.signingPub {
+		t.Errorf("SigningKey mismatch: got %x want %x", id.SigningKey, fix.signingPub)
+	}
+	if id.MasterKey == id.SigningKey {
+		t.Errorf("token mode must split master and signing keys")
+	}
+	if id.Manifest == nil {
+		t.Fatal("Manifest must be populated")
+	}
+	if id.Manifest.Sequence != fix.sequence {
+		t.Errorf("manifest sequence: got %d want %d", id.Manifest.Sequence, fix.sequence)
+	}
+	if len(id.SerializedMfst) == 0 {
+		t.Error("SerializedMfst must be populated for #372 emission")
+	}
+	// NodeID is the signing key for wire compatibility (see identity.go
+	// type comment) — pin that explicitly so the migration sub-issue
+	// has to update this assertion deliberately.
+	var asNode consensus.NodeID
+	copy(asNode[:], fix.signingPub[:])
+	if id.NodeID != asNode {
+		t.Errorf("NodeID should equal SigningKey for now: got %x", id.NodeID)
+	}
+}
+
+func TestNewValidatorIdentityFromToken_SignVerifyValidation(t *testing.T) {
+	fix := newTokenFixture(t, 0x55, 3)
+	id, err := NewValidatorIdentityFromToken(fix.tokenBlock)
+	if err != nil {
+		t.Fatalf("NewValidatorIdentityFromToken: %v", err)
+	}
+
+	v := &consensus.Validation{
+		LedgerID:  consensus.LedgerID{0x01, 0x02},
+		LedgerSeq: 42,
+		NodeID:    id.NodeID,
+		SignTime:  time.Unix(protocol.RippleEpochUnix+1000, 0),
+		Full:      true,
+	}
+	if err := id.SignValidation(v); err != nil {
+		t.Fatalf("SignValidation: %v", err)
+	}
+	if len(v.Signature) == 0 {
+		t.Fatal("expected non-empty signature")
+	}
+	if err := VerifyValidation(v); err != nil {
+		t.Fatalf("VerifyValidation: %v", err)
+	}
+}
+
+func TestNewValidatorIdentityFromToken_KeyMismatch(t *testing.T) {
+	fix := newTokenFixture(t, 0x21, 1)
+	// Replace the validation_secret_key with an unrelated 32 bytes:
+	// derived pubkey will no longer match the manifest's SigningPubKey,
+	// catching swapped/corrupt token blobs.
+	tokenBytes, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(fix.tokenBlock), ""))
+	if err != nil {
+		t.Fatalf("decode token: %v", err)
+	}
+	var envelope map[string]string
+	if err := json.Unmarshal(tokenBytes, &envelope); err != nil {
+		t.Fatalf("unmarshal token: %v", err)
+	}
+	envelope["validation_secret_key"] = strings.Repeat("11", 32)
+	bad, _ := json.Marshal(envelope)
+	corrupted := base64.StdEncoding.EncodeToString(bad)
+
+	if _, err := NewValidatorIdentityFromToken(corrupted); err == nil {
+		t.Fatal("expected mismatch error, got nil")
+	}
+}
+
+func TestNewValidatorIdentityFromToken_BadManifestSignature(t *testing.T) {
+	fix := newTokenFixture(t, 0x33, 2)
+	tokenBytes, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(fix.tokenBlock), ""))
+	if err != nil {
+		t.Fatalf("decode token: %v", err)
+	}
+	var envelope map[string]string
+	if err := json.Unmarshal(tokenBytes, &envelope); err != nil {
+		t.Fatalf("unmarshal token: %v", err)
+	}
+	wire, _ := base64.StdEncoding.DecodeString(envelope["manifest"])
+	// Flip a byte deep in the manifest so deserialize still succeeds
+	// (preserving STObject framing) but Verify fails.
+	wire[len(wire)-5] ^= 0xFF
+	envelope["manifest"] = base64.StdEncoding.EncodeToString(wire)
+	bad, _ := json.Marshal(envelope)
+	corrupted := base64.StdEncoding.EncodeToString(bad)
+
+	if _, err := NewValidatorIdentityFromToken(corrupted); err == nil {
+		t.Fatal("expected manifest verification failure, got nil")
+	}
+}
+
+func TestNewValidatorIdentityFromConfig_Dispatch(t *testing.T) {
+	// Empty → observer.
+	id, err := NewValidatorIdentityFromConfig("", "")
+	if err != nil || id != nil {
+		t.Fatalf("empty config should yield nil identity, got id=%v err=%v", id, err)
+	}
+
+	// Both set → mutual-exclusion error.
+	if _, err := NewValidatorIdentityFromConfig("snoPBrXtMeMyMHUVTgbuqAfg1SUTb", "anything"); err == nil {
+		t.Fatal("expected error when both seed and token configured")
+	}
+
+	// Token only → token path.
+	fix := newTokenFixture(t, 0x77, 5)
+	id, err = NewValidatorIdentityFromConfig("", fix.tokenBlock)
+	if err != nil {
+		t.Fatalf("token-only config: %v", err)
+	}
+	if id == nil || id.Manifest == nil {
+		t.Fatal("token-only config must produce manifest-bearing identity")
+	}
+
+	// Seed only → seed path (manifest stays nil).
+	id, err = NewValidatorIdentityFromConfig("snoPBrXtMeMyMHUVTgbuqAfg1SUTb", "")
+	if err != nil {
+		t.Fatalf("seed-only config: %v", err)
+	}
+	if id == nil {
+		t.Fatal("seed-only config must produce identity")
+	}
+	if id.Manifest != nil {
+		t.Fatal("seed-only config must not carry a manifest")
+	}
+	if id.MasterKey != id.SigningKey {
+		t.Fatal("seed-only config: master should equal signing")
+	}
+}

--- a/internal/consensus/adaptor/identity_token_test.go
+++ b/internal/consensus/adaptor/identity_token_test.go
@@ -238,29 +238,6 @@ func TestNewValidatorIdentityFromToken_KeyMismatch(t *testing.T) {
 	}
 }
 
-func TestNewValidatorIdentityFromToken_BadManifestSignature(t *testing.T) {
-	fix := newTokenFixture(t, 0x33, 2)
-	tokenBytes, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(fix.tokenBlock), ""))
-	if err != nil {
-		t.Fatalf("decode token: %v", err)
-	}
-	var envelope map[string]string
-	if err := json.Unmarshal(tokenBytes, &envelope); err != nil {
-		t.Fatalf("unmarshal token: %v", err)
-	}
-	wire, _ := base64.StdEncoding.DecodeString(envelope["manifest"])
-	// Flip a byte deep in the manifest so deserialize still succeeds
-	// (preserving STObject framing) but Verify fails.
-	wire[len(wire)-5] ^= 0xFF
-	envelope["manifest"] = base64.StdEncoding.EncodeToString(wire)
-	bad, _ := json.Marshal(envelope)
-	corrupted := base64.StdEncoding.EncodeToString(bad)
-
-	if _, err := NewValidatorIdentityFromToken(corrupted); err == nil {
-		t.Fatal("expected manifest verification failure, got nil")
-	}
-}
-
 func TestNewValidatorIdentityFromConfig_Dispatch(t *testing.T) {
 	// Empty → observer.
 	id, err := NewValidatorIdentityFromConfig("", "")

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -105,20 +105,16 @@ func NewFromConfig(
 	// pass its pubkey into the overlay for the self-target TMSquelch
 	// filter (Task 4.2 / G3: without this a peer could silence our own
 	// validator's traffic on the RelayFromValidator path).
-	var identity *ValidatorIdentity
-	if appCfg.ValidationSeed != "" {
-		var err error
-		identity, err = NewValidatorIdentity(appCfg.ValidationSeed)
-		if err != nil {
-			return nil, fmt.Errorf("create validator identity: %w", err)
-		}
+	identity, err := NewValidatorIdentityFromConfig(appCfg.ValidationSeed, appCfg.ValidatorToken)
+	if err != nil {
+		return nil, fmt.Errorf("create validator identity: %w", err)
 	}
 
 	// Build overlay options from app config
 	overlayOpts := OverlayOptionsFromConfig(appCfg)
-	if identity != nil && len(identity.PublicKey) == 33 {
+	if identity != nil {
 		overlayOpts = append(overlayOpts,
-			peermanagement.WithLocalValidatorPubKey(identity.PublicKey))
+			peermanagement.WithLocalValidatorPubKey(identity.SigningPubKey()))
 	}
 
 	overlay, err := peermanagement.New(overlayOpts...)

--- a/internal/consensus/adaptor/unl_test.go
+++ b/internal/consensus/adaptor/unl_test.go
@@ -17,7 +17,7 @@ func TestDecodeValidatorKey(t *testing.T) {
 	require.NoError(t, err)
 
 	// Encode the public key as a base58 node public key
-	encoded, err := addresscodec.EncodeNodePublicKey(identity.PublicKey)
+	encoded, err := addresscodec.EncodeNodePublicKey(identity.SigningPubKey())
 	require.NoError(t, err)
 	assert.True(t, len(encoded) > 0)
 	assert.Equal(t, byte('n'), encoded[0])
@@ -36,13 +36,13 @@ func TestDecodeValidatorKeyInvalid(t *testing.T) {
 func TestNewUNL(t *testing.T) {
 	id1, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
 	require.NoError(t, err)
-	key1, err := addresscodec.EncodeNodePublicKey(id1.PublicKey)
+	key1, err := addresscodec.EncodeNodePublicKey(id1.SigningPubKey())
 	require.NoError(t, err)
 
 	// Use a second secp256k1 seed
 	id2, err := NewValidatorIdentity("spqPaiDYkYJ2H7cpziSk9XWyAeCPE")
 	require.NoError(t, err)
-	key2, err := addresscodec.EncodeNodePublicKey(id2.PublicKey)
+	key2, err := addresscodec.EncodeNodePublicKey(id2.SigningPubKey())
 	require.NoError(t, err)
 
 	unl, err := NewUNL([]string{key1, key2})
@@ -60,7 +60,7 @@ func TestNewUNL(t *testing.T) {
 func TestUNLDeduplication(t *testing.T) {
 	id, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
 	require.NoError(t, err)
-	key, err := addresscodec.EncodeNodePublicKey(id.PublicKey)
+	key, err := addresscodec.EncodeNodePublicKey(id.SigningPubKey())
 	require.NoError(t, err)
 
 	// Duplicate keys should be deduplicated
@@ -110,7 +110,7 @@ func TestUNLQuorum(t *testing.T) {
 	for _, seed := range seeds {
 		id, err := NewValidatorIdentity(seed)
 		require.NoError(t, err)
-		key, err := addresscodec.EncodeNodePublicKey(id.PublicKey)
+		key, err := addresscodec.EncodeNodePublicKey(id.SigningPubKey())
 		require.NoError(t, err)
 		keys = append(keys, key)
 	}

--- a/internal/manifest/token.go
+++ b/internal/manifest/token.go
@@ -1,0 +1,98 @@
+package manifest
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ValidatorToken is the parsed payload of a rippled-format
+// `[validator_token]` config block, as produced by `validator-keys-tool`.
+//
+// Wire format (rippled Manifest.cpp:263-308): the block is a list of
+// whitespace-trimmed lines that concatenate into a single base64 string.
+// Decoding the base64 yields a JSON object with two string fields:
+//
+//	{
+//	    "manifest":              "<base64 STObject>",
+//	    "validation_secret_key": "<hex 32-byte secp256k1 secret>"
+//	}
+//
+// Both fields are mandatory. The manifest's embedded SigningPubKey must
+// match secp256k1·G·validation_secret_key — that pairing check is the
+// caller's responsibility (see ValidatorIdentity construction).
+type ValidatorToken struct {
+	// ManifestB64 is the manifest serialization, still base64-encoded.
+	// Kept as the raw string so callers re-emitting the token don't
+	// have to round-trip the bytes.
+	ManifestB64 string
+
+	// ValidationSecret is the 32-byte secp256k1 secret key used to sign
+	// validations and proposals. Decoded from the JSON's hex field.
+	ValidationSecret [32]byte
+}
+
+// LoadValidatorToken parses a `[validator_token]` config block. The block
+// is the raw config-section text — leading/trailing whitespace and
+// embedded newlines are tolerated and stripped before base64 decoding,
+// matching rippled's loadValidatorToken.
+func LoadValidatorToken(block string) (*ValidatorToken, error) {
+	// Concatenate lines after trimming whitespace so a multi-line
+	// pretty-printed block decodes identically to a single-line one.
+	var sb strings.Builder
+	for _, line := range strings.Split(block, "\n") {
+		sb.WriteString(strings.TrimSpace(line))
+	}
+	concat := sb.String()
+	if concat == "" {
+		return nil, errors.New("validator_token: empty block")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(concat)
+	if err != nil {
+		return nil, fmt.Errorf("validator_token: base64 decode: %w", err)
+	}
+
+	var raw struct {
+		Manifest            string `json:"manifest"`
+		ValidationSecretKey string `json:"validation_secret_key"`
+	}
+	if err := json.Unmarshal(decoded, &raw); err != nil {
+		return nil, fmt.Errorf("validator_token: json decode: %w", err)
+	}
+	if raw.Manifest == "" {
+		return nil, errors.New("validator_token: missing manifest")
+	}
+	if raw.ValidationSecretKey == "" {
+		return nil, errors.New("validator_token: missing validation_secret_key")
+	}
+
+	keyBytes, err := hex.DecodeString(raw.ValidationSecretKey)
+	if err != nil {
+		return nil, fmt.Errorf("validator_token: validation_secret_key not hex: %w", err)
+	}
+	if len(keyBytes) != 32 {
+		return nil, fmt.Errorf("validator_token: validation_secret_key wrong length %d", len(keyBytes))
+	}
+
+	tok := &ValidatorToken{ManifestB64: raw.Manifest}
+	copy(tok.ValidationSecret[:], keyBytes)
+	return tok, nil
+}
+
+// DecodeManifest base64-decodes the embedded manifest blob into wire
+// bytes ready for Deserialize. Separated so callers that already have
+// a ValidatorToken can reuse the same decode path.
+func (t *ValidatorToken) DecodeManifest() ([]byte, error) {
+	if t == nil || t.ManifestB64 == "" {
+		return nil, errors.New("validator_token: nil or empty manifest")
+	}
+	b, err := base64.StdEncoding.DecodeString(t.ManifestB64)
+	if err != nil {
+		return nil, fmt.Errorf("validator_token: manifest base64: %w", err)
+	}
+	return b, nil
+}

--- a/internal/manifest/token_test.go
+++ b/internal/manifest/token_test.go
@@ -1,0 +1,144 @@
+package manifest
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// rippledFixtureBlock is the multi-line `[validator_token]` payload from
+// rippled's Manifest_test.cpp:520-538. Reproduced verbatim (with the
+// embedded whitespace + tabs) so we round-trip the same input rippled
+// uses to assert loadValidatorToken behavior.
+const rippledFixtureBlock = "    eyJ2YWxpZGF0aW9uX3NlY3JldF9rZXkiOiI5ZWQ0NWY4NjYyNDFjYzE4YTI3NDdiNT\n" +
+	" \tQzODdjMDYyNTkwNzk3MmY0ZTcxOTAyMzFmYWE5Mzc0NTdmYTlkYWY2IiwibWFuaWZl     \n" +
+	"\tc3QiOiJKQUFBQUFGeEllMUZ0d21pbXZHdEgyaUNjTUpxQzlnVkZLaWxHZncxL3ZDeE\n" +
+	"\t hYWExwbGMyR25NaEFrRTFhZ3FYeEJ3RHdEYklENk9NU1l1TTBGREFscEFnTms4U0tG\t  \t\n" +
+	"bjdNTzJmZGtjd1JRSWhBT25ndTlzQUtxWFlvdUorbDJWMFcrc0FPa1ZCK1pSUzZQU2\n" +
+	"hsSkFmVXNYZkFpQnNWSkdlc2FhZE9KYy9hQVpva1MxdnltR21WcmxIUEtXWDNZeXd1\n" +
+	"NmluOEhBU1FLUHVnQkQ2N2tNYVJGR3ZtcEFUSGxHS0pkdkRGbFdQWXk1QXFEZWRGdj\n" +
+	"VUSmEydzBpMjFlcTNNWXl3TFZKWm5GT3I3QzBrdzJBaVR6U0NqSXpkaXRROD0ifQ==\n"
+
+const rippledFixtureExpectedManifest = "JAAAAAFxIe1FtwmimvGtH2iCcMJqC9gVFKilGfw1/" +
+	"vCxHXXLplc2GnMhAkE1agqXxBwDwDbID6OMSYuM0FDAlpAgNk8SKFn7MO2fdkcwRQIhAOngu9sA" +
+	"KqXYouJ+l2V0W+sAOkVB+ZRS6PShlJAfUsXfAiBsVJGesaadOJc/aAZokS1vymGmVrlHPKWX3Y" +
+	"ywu6in8HASQKPugBD67kMaRFGvmpATHlGKJdvDFlWPYy5AqDedFv5TJa2w0i21eq3MYywLVJZn" +
+	"FOr7C0kw2AiTzSCjIzditQ8="
+
+const rippledFixtureExpectedSecretHex = "9ed45f866241cc18a2747b54387c0625907972f4e7190231faa937457fa9daf6"
+
+func TestLoadValidatorToken_RippledFixture(t *testing.T) {
+	tok, err := LoadValidatorToken(rippledFixtureBlock)
+	if err != nil {
+		t.Fatalf("LoadValidatorToken: %v", err)
+	}
+	if tok.ManifestB64 != rippledFixtureExpectedManifest {
+		t.Errorf("ManifestB64 mismatch:\n got: %s\nwant: %s", tok.ManifestB64, rippledFixtureExpectedManifest)
+	}
+	gotHex := hex.EncodeToString(tok.ValidationSecret[:])
+	if gotHex != rippledFixtureExpectedSecretHex {
+		t.Errorf("ValidationSecret mismatch:\n got: %s\nwant: %s", gotHex, rippledFixtureExpectedSecretHex)
+	}
+}
+
+func TestLoadValidatorToken_DecodeManifest(t *testing.T) {
+	tok, err := LoadValidatorToken(rippledFixtureBlock)
+	if err != nil {
+		t.Fatalf("LoadValidatorToken: %v", err)
+	}
+	wire, err := tok.DecodeManifest()
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	// The manifest is a non-empty STObject. Pass it through Deserialize
+	// to confirm the embedded wire bytes are well-formed: catches base64
+	// truncation / corruption of the JSON manifest field.
+	m, err := Deserialize(wire)
+	if err != nil {
+		t.Fatalf("Deserialize embedded manifest: %v", err)
+	}
+	if m.Sequence == 0 {
+		t.Errorf("expected non-zero manifest sequence, got 0")
+	}
+}
+
+func TestLoadValidatorToken_BadInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"only_whitespace", "   \n\t\n"},
+		{"not_base64", "bad token"},
+		{"valid_base64_not_json", "Zm9vYmFy"}, // "foobar"
+		{"json_missing_manifest", base64Encode(`{"validation_secret_key":"00"}`)},
+		{"json_missing_secret", base64Encode(`{"manifest":"abc"}`)},
+		{"secret_not_hex", base64Encode(`{"manifest":"abc","validation_secret_key":"NOTHEX"}`)},
+		{"secret_wrong_length", base64Encode(`{"manifest":"abc","validation_secret_key":"00"}`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := LoadValidatorToken(tt.in); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+// TestLoadValidatorToken_RoundTrip builds a token blob the way
+// validator-keys-tool would (pretty-printed JSON, base64-wrapped) and
+// confirms LoadValidatorToken recovers the same fields.
+func TestLoadValidatorToken_RoundTrip(t *testing.T) {
+	manifest := "JAAAAAFx" // arbitrary placeholder, parser doesn't decode it
+	secret := make([]byte, 32)
+	for i := range secret {
+		secret[i] = byte(0x10 + i)
+	}
+	jsonBlob, err := json.Marshal(map[string]string{
+		"manifest":              manifest,
+		"validation_secret_key": hex.EncodeToString(secret),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(jsonBlob)
+	// Wrap at 60-char lines with a leading indent — mirrors the
+	// formatting validator-keys-tool emits for human-readable configs.
+	var multi strings.Builder
+	for i := 0; i < len(encoded); i += 60 {
+		end := i + 60
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		multi.WriteString("   ")
+		multi.WriteString(encoded[i:end])
+		multi.WriteString("\n")
+	}
+
+	tok, err := LoadValidatorToken(multi.String())
+	if err != nil {
+		t.Fatalf("LoadValidatorToken: %v", err)
+	}
+	if tok.ManifestB64 != manifest {
+		t.Errorf("ManifestB64: got %q want %q", tok.ManifestB64, manifest)
+	}
+	if !bytesEqual(tok.ValidationSecret[:], secret) {
+		t.Errorf("ValidationSecret: got %x want %x", tok.ValidationSecret[:], secret)
+	}
+}
+
+func base64Encode(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/testing/consensus/testcluster.go
+++ b/internal/testing/consensus/testcluster.go
@@ -66,7 +66,7 @@ func NewTestCluster(t *testing.T, n int) *TestCluster {
 		identities[i] = id
 		validatorNodeIDs[i] = id.NodeID
 
-		key, err := addresscodec.EncodeNodePublicKey(id.PublicKey)
+		key, err := addresscodec.EncodeNodePublicKey(id.SigningPubKey())
 		if err != nil {
 			t.Fatalf("encode node key %d: %v", i, err)
 		}


### PR DESCRIPTION
Sub-issue of #360. Foundation for #372 (emission) and #373 (periodic re-broadcast + sequence guard).

## Summary

Adds `validator_token` decoding and a master/ephemeral key split to `ValidatorIdentity` so peers configured via standard validator-list publishing can resolve our signing key back to a trusted master. Without this, rippled v2.6.2 silently drops our validations as untrusted (root cause of #358 / #360).

- `internal/manifest/token.go`: `LoadValidatorToken` parses the base64+JSON envelope produced by `validator-keys-tool` and round-trips rippled's `Manifest_test.cpp:520` fixture verbatim.
- `internal/consensus/adaptor/identity.go`: `ValidatorIdentity` gains `MasterKey`, `SigningKey`, `Manifest`, `SerializedMfst`. Signing always uses the ephemeral key. `NewValidatorIdentityFromConfig` dispatches between `[validation_seed]` and `[validator_token]` and rejects both-set per `rippled ValidatorKeys.cpp:31-38`.
- `crypto/secp256k1`: `DerivePublicKeyFromSecret` mirrors rippled's `derivePublicKey(KeyType::secp256k1, SecretKey)` used by token loading.
- `startup.go` wires the dispatcher so `[validator_token]` actually takes effect — the field was declared but unused before this PR.

## Carry-over

`consensus.NodeID` continues to equal `SigningKey` (33 bytes) so wire format and the existing manifest-cache resolver in `startup.go` keep working. Migrating it to rippled's 20-byte `calcNodeID(masterKey)` is invasive across the consensus layer and is acknowledged as a separate follow-up sub-issue in the issue text. The `ValidatorIdentity` type comment documents the deferred migration.

## Test plan

- [x] `go test ./internal/manifest/... ./internal/consensus/adaptor/... ./crypto/secp256k1/...` — pass
- [x] `go build ./...` and `cmd/xrpld` (CGO + OpenSSL) — clean
- [x] Token parser round-trips rippled's `Manifest_test.cpp:520` fixture
- [x] Token-mode signing produces a validation that round-trips through `VerifyValidation`
- [x] Seed-only path stays backward compatible (master == signing, no manifest)
- [x] `NewValidatorIdentityFromConfig` rejects both `[validation_seed]` and `[validator_token]` set simultaneously