### PR TITLE
adaptor: emit local manifest on peer connect + at startup (refs #372)

### DIFF
--- a/internal/consensus/adaptor/manifest_emit.go
+++ b/internal/consensus/adaptor/manifest_emit.go
@@ -18,9 +18,8 @@ type manifestSender interface {
 
 // encodeManifestsFrame wraps one or more wire-format manifest STObjects
 // in a TMManifests frame ready for Overlay.Broadcast / Overlay.Send.
-// Mirrors rippled OverlayImpl::sendEndpoints which emits manifests
-// alongside endpoints in the post-handshake window — every peer
-// receives the same TMManifests payload.
+// Mirrors rippled OverlayImpl::getManifestsMessage which builds a
+// TMManifests carrying every ValidatorManifests entry (Manifest.cpp:1184-1212).
 //
 // Shared by relayManifest (single-manifest gossip from a peer) and the
 // local-manifest emission paths in #372 so both produce byte-identical
@@ -37,26 +36,21 @@ func encodeManifestsFrame(serialized ...[]byte) ([]byte, error) {
 	return encodeFrame(message.TypeManifests, &message.Manifests{List: list})
 }
 
-// SendLocalManifestTo sends our local validator manifest to a single
-// peer. Returns nil and emits nothing when:
-//   - the router has no overlay handle (test-only construction);
-//   - we have no local validator (observer mode);
-//   - the local validator is seed-only (no manifest to broadcast — the
-//     legacy path where master == signing has nothing to gossip).
-//
-// Any encode error is logged and swallowed: emission is best-effort.
-// The caller does not get a chance to retry per-peer because the next
-// reconnect will just trigger another HandlePeerConnect anyway.
+// SendLocalManifestTo sends the aggregated TMManifests frame (every
+// cached validator manifest) to a single peer. Returns nil and emits
+// nothing when the cache is empty or no sender is wired (test-only
+// construction). Any encode error is logged and swallowed: emission is
+// best-effort, the next reconnect will retry on its own.
 func (r *Router) SendLocalManifestTo(peerID peermanagement.PeerID) {
-	wire := r.localManifestBytes()
-	if wire == nil {
+	wires := r.manifestsForEmission()
+	if len(wires) == 0 {
 		return
 	}
 	sender := r.manifestEmitter()
 	if sender == nil {
 		return
 	}
-	frame, err := encodeManifestsFrame(wire)
+	frame, err := encodeManifestsFrame(wires...)
 	if err != nil {
 		r.logger.Warn("failed to encode local manifest frame for peer", "error", err, "peer", peerID)
 		return
@@ -70,30 +64,26 @@ func (r *Router) SendLocalManifestTo(peerID peermanagement.PeerID) {
 	}
 }
 
-// BroadcastLocalManifest gossips our local validator manifest to every
-// currently-connected peer. Used by the startup one-shot broadcast and
-// (in #373) by the periodic re-emission timer. Same skip cases as
-// SendLocalManifestTo.
-//
-// Returns the number of peers the frame was queued for (0 when there's
-// nothing to broadcast or no peers connected) so callers can decide
-// whether to log the emission.
+// BroadcastLocalManifest gossips the aggregated TMManifests frame to
+// every currently-connected peer. Returns the number of peers the frame
+// was queued for (0 when there's nothing to broadcast or no peers are
+// connected) so callers can decide whether to log the emission.
 func (r *Router) BroadcastLocalManifest() int {
-	wire := r.localManifestBytes()
-	if wire == nil {
+	wires := r.manifestsForEmission()
+	if len(wires) == 0 {
 		return 0
 	}
 	sender := r.manifestEmitter()
 	if sender == nil {
 		return 0
 	}
-	frame, err := encodeManifestsFrame(wire)
-	if err != nil {
-		r.logger.Warn("failed to encode local manifest frame", "error", err)
-		return 0
-	}
 	peers := sender.Peers()
 	if len(peers) == 0 {
+		return 0
+	}
+	frame, err := encodeManifestsFrame(wires...)
+	if err != nil {
+		r.logger.Warn("failed to encode local manifest frame", "error", err)
 		return 0
 	}
 	if err := sender.Broadcast(frame); err != nil {
@@ -104,12 +94,12 @@ func (r *Router) BroadcastLocalManifest() int {
 }
 
 // manifestEmitter returns the sender used by SendLocalManifestTo /
-// BroadcastLocalManifest. Falls back to nil when the router has
-// neither a real overlay nor a test override — in that case the
-// emission paths short-circuit instead of segfaulting.
+// BroadcastLocalManifest. Falls back to nil when the router has neither
+// a real overlay nor a test override — in that case the emission paths
+// short-circuit instead of segfaulting.
 func (r *Router) manifestEmitter() manifestSender {
-	if r.testManifestSender != nil {
-		return r.testManifestSender
+	if r.overrideManifestSender != nil {
+		return r.overrideManifestSender
 	}
 	if r.overlay == nil {
 		return nil
@@ -119,27 +109,26 @@ func (r *Router) manifestEmitter() manifestSender {
 
 // HandlePeerConnect is the callback wired into Overlay.SetPeerConnectCallback.
 // Fires once a peer has finished its handshake and joined the overlay;
-// emits our local manifest so the peer can resolve our ephemeral signing
-// key back to the trusted master before our first validation arrives.
+// emits the cached validator manifests so the peer can resolve every
+// known ephemeral signing key back to its trusted master before any
+// validation arrives.
 //
-// Mirrors rippled OverlayImpl::sendEndpoints which always emits the
-// local manifest (when one exists) immediately after a peer is added.
-// Skip cases (seed-only, no overlay) are handled inside
+// Mirrors rippled PeerImp::doProtocolStart (PeerImp.cpp:851-886) which
+// sends overlay_.getManifestsMessage() in the post-handshake window.
+// Skip cases (cache empty, no overlay) are handled inside
 // SendLocalManifestTo so this stays a thin event-loop trampoline.
 func (r *Router) HandlePeerConnect(peerID peermanagement.PeerID) {
 	r.SendLocalManifestTo(peerID)
 }
 
-// localManifestBytes returns the wire bytes of our local validator
-// manifest, or nil if we have nothing to emit. Centralizes the
-// "do we have a manifest to broadcast?" decision so the per-peer and
-// broadcast paths can't drift on the skip-case logic.
-func (r *Router) localManifestBytes() []byte {
-	if r.adaptor == nil || r.adaptor.identity == nil {
+// manifestsForEmission returns the wire bytes of every cached validator
+// manifest, in arbitrary order. Centralizes the "what do we have to
+// gossip?" decision so the per-peer and broadcast paths can't drift on
+// the skip-case logic. Returns nil when the cache is empty (observer /
+// seed-only mode, or fresh boot before any peer has gossiped anything).
+func (r *Router) manifestsForEmission() [][]byte {
+	if r.manifests == nil {
 		return nil
 	}
-	if len(r.adaptor.identity.SerializedMfst) == 0 {
-		return nil
-	}
-	return r.adaptor.identity.SerializedMfst
+	return r.manifests.SerializedAll()
 }

--- a/internal/consensus/adaptor/manifest_emit.go
+++ b/internal/consensus/adaptor/manifest_emit.go
@@ -19,7 +19,8 @@ type manifestSender interface {
 // encodeManifestsFrame wraps one or more wire-format manifest STObjects
 // in a TMManifests frame ready for Overlay.Broadcast / Overlay.Send.
 // Mirrors rippled OverlayImpl::getManifestsMessage which builds a
-// TMManifests carrying every ValidatorManifests entry (Manifest.cpp:1184-1212).
+// TMManifests carrying every ValidatorManifests entry
+// (OverlayImpl.cpp:1184-1212).
 //
 // Shared by relayManifest (single-manifest gossip from a peer) and the
 // local-manifest emission paths in #372 so both produce byte-identical
@@ -42,24 +43,19 @@ func encodeManifestsFrame(serialized ...[]byte) ([]byte, error) {
 // construction). Any encode error is logged and swallowed: emission is
 // best-effort, the next reconnect will retry on its own.
 func (r *Router) SendLocalManifestTo(peerID peermanagement.PeerID) {
-	wires := r.manifestsForEmission()
-	if len(wires) == 0 {
+	frame := r.cachedManifestFrame()
+	if len(frame) == 0 {
 		return
 	}
 	sender := r.manifestEmitter()
 	if sender == nil {
 		return
 	}
-	frame, err := encodeManifestsFrame(wires...)
-	if err != nil {
-		r.logger.Warn("failed to encode local manifest frame for peer", "error", err, "peer", peerID)
-		return
-	}
 	if err := sender.Send(peerID, frame); err != nil {
 		// Peer may have raced a disconnect between addPeer and the
-		// callback. ErrPeerNotFound is benign; surface other errors at
-		// debug to aid diagnosis without spamming logs on a flapping
-		// peer.
+		// callback. ErrPeerNotFound / ErrConnectionClosed are benign;
+		// surface at debug to aid diagnosis without spamming logs on a
+		// flapping peer.
 		r.logger.Debug("send local manifest to peer failed", "error", err, "peer", peerID)
 	}
 }
@@ -69,8 +65,8 @@ func (r *Router) SendLocalManifestTo(peerID peermanagement.PeerID) {
 // was queued for (0 when there's nothing to broadcast or no peers are
 // connected) so callers can decide whether to log the emission.
 func (r *Router) BroadcastLocalManifest() int {
-	wires := r.manifestsForEmission()
-	if len(wires) == 0 {
+	frame := r.cachedManifestFrame()
+	if len(frame) == 0 {
 		return 0
 	}
 	sender := r.manifestEmitter()
@@ -79,11 +75,6 @@ func (r *Router) BroadcastLocalManifest() int {
 	}
 	peers := sender.Peers()
 	if len(peers) == 0 {
-		return 0
-	}
-	frame, err := encodeManifestsFrame(wires...)
-	if err != nil {
-		r.logger.Warn("failed to encode local manifest frame", "error", err)
 		return 0
 	}
 	if err := sender.Broadcast(frame); err != nil {
@@ -121,14 +112,54 @@ func (r *Router) HandlePeerConnect(peerID peermanagement.PeerID) {
 	r.SendLocalManifestTo(peerID)
 }
 
-// manifestsForEmission returns the wire bytes of every cached validator
-// manifest, in arbitrary order. Centralizes the "what do we have to
-// gossip?" decision so the per-peer and broadcast paths can't drift on
-// the skip-case logic. Returns nil when the cache is empty (observer /
-// seed-only mode, or fresh boot before any peer has gossiped anything).
-func (r *Router) manifestsForEmission() [][]byte {
+// cachedManifestFrame returns the encoded TMManifests frame for the
+// current state of the manifest cache, building it on demand and
+// reusing it across calls until the cache's Sequence advances. Mirrors
+// rippled OverlayImpl::getManifestsMessage at OverlayImpl.cpp:1184-1212,
+// which compares manifestListSeq_ against ManifestCache::sequence() and
+// only rebuilds the cached protocol::Message on a mismatch — so a burst
+// of post-handshake emissions reuses the same encoded bytes instead of
+// re-walking the cache per peer.
+//
+// Returns nil when the cache is unwired, empty, or fails to encode.
+// Encode failures are NOT cached so a transient error doesn't pin a
+// stale frame; the next caller re-attempts.
+func (r *Router) cachedManifestFrame() []byte {
 	if r.manifests == nil {
 		return nil
 	}
-	return r.manifests.SerializedAll()
+
+	// Read sequence outside the frame lock so we never nest the cache's
+	// RLock under our own mutex. A racing increment between this read
+	// and the lock acquisition just causes the next caller to rebuild —
+	// not a correctness issue.
+	seq := r.manifests.Sequence()
+
+	r.manifestFrameMu.Lock()
+	defer r.manifestFrameMu.Unlock()
+
+	if r.manifestFrameBuilt && r.manifestFrameSeq == seq {
+		return r.manifestFrame
+	}
+
+	wires := r.manifests.SerializedAll()
+	if len(wires) == 0 {
+		// Empty cache — cache that fact too so the next call doesn't
+		// re-walk byMaster only to find it still empty.
+		r.manifestFrame = nil
+		r.manifestFrameSeq = seq
+		r.manifestFrameBuilt = true
+		return nil
+	}
+
+	frame, err := encodeManifestsFrame(wires...)
+	if err != nil {
+		r.logger.Warn("failed to encode local manifest frame", "error", err)
+		return nil
+	}
+
+	r.manifestFrame = frame
+	r.manifestFrameSeq = seq
+	r.manifestFrameBuilt = true
+	return frame
 }

--- a/internal/consensus/adaptor/manifest_emit.go
+++ b/internal/consensus/adaptor/manifest_emit.go
@@ -1,0 +1,145 @@
+package adaptor
+
+import (
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+)
+
+// manifestSender is the slice of *peermanagement.Overlay the manifest
+// emitter calls into. Defining it here keeps the production path on the
+// concrete overlay (no indirection cost) while letting tests substitute
+// a fake without standing up real listeners. *peermanagement.Overlay
+// satisfies this interface by virtue of its existing public methods.
+type manifestSender interface {
+	Send(peerID peermanagement.PeerID, frame []byte) error
+	Broadcast(frame []byte) error
+	Peers() []peermanagement.PeerInfo
+}
+
+// encodeManifestsFrame wraps one or more wire-format manifest STObjects
+// in a TMManifests frame ready for Overlay.Broadcast / Overlay.Send.
+// Mirrors rippled OverlayImpl::sendEndpoints which emits manifests
+// alongside endpoints in the post-handshake window — every peer
+// receives the same TMManifests payload.
+//
+// Shared by relayManifest (single-manifest gossip from a peer) and the
+// local-manifest emission paths in #372 so both produce byte-identical
+// frames; rippled's PeerImp doesn't distinguish between the two on the
+// wire.
+func encodeManifestsFrame(serialized ...[]byte) ([]byte, error) {
+	list := make([]message.Manifest, 0, len(serialized))
+	for _, b := range serialized {
+		if len(b) == 0 {
+			continue
+		}
+		list = append(list, message.Manifest{STObject: b})
+	}
+	return encodeFrame(message.TypeManifests, &message.Manifests{List: list})
+}
+
+// SendLocalManifestTo sends our local validator manifest to a single
+// peer. Returns nil and emits nothing when:
+//   - the router has no overlay handle (test-only construction);
+//   - we have no local validator (observer mode);
+//   - the local validator is seed-only (no manifest to broadcast — the
+//     legacy path where master == signing has nothing to gossip).
+//
+// Any encode error is logged and swallowed: emission is best-effort.
+// The caller does not get a chance to retry per-peer because the next
+// reconnect will just trigger another HandlePeerConnect anyway.
+func (r *Router) SendLocalManifestTo(peerID peermanagement.PeerID) {
+	wire := r.localManifestBytes()
+	if wire == nil {
+		return
+	}
+	sender := r.manifestEmitter()
+	if sender == nil {
+		return
+	}
+	frame, err := encodeManifestsFrame(wire)
+	if err != nil {
+		r.logger.Warn("failed to encode local manifest frame for peer", "error", err, "peer", peerID)
+		return
+	}
+	if err := sender.Send(peerID, frame); err != nil {
+		// Peer may have raced a disconnect between addPeer and the
+		// callback. ErrPeerNotFound is benign; surface other errors at
+		// debug to aid diagnosis without spamming logs on a flapping
+		// peer.
+		r.logger.Debug("send local manifest to peer failed", "error", err, "peer", peerID)
+	}
+}
+
+// BroadcastLocalManifest gossips our local validator manifest to every
+// currently-connected peer. Used by the startup one-shot broadcast and
+// (in #373) by the periodic re-emission timer. Same skip cases as
+// SendLocalManifestTo.
+//
+// Returns the number of peers the frame was queued for (0 when there's
+// nothing to broadcast or no peers connected) so callers can decide
+// whether to log the emission.
+func (r *Router) BroadcastLocalManifest() int {
+	wire := r.localManifestBytes()
+	if wire == nil {
+		return 0
+	}
+	sender := r.manifestEmitter()
+	if sender == nil {
+		return 0
+	}
+	frame, err := encodeManifestsFrame(wire)
+	if err != nil {
+		r.logger.Warn("failed to encode local manifest frame", "error", err)
+		return 0
+	}
+	peers := sender.Peers()
+	if len(peers) == 0 {
+		return 0
+	}
+	if err := sender.Broadcast(frame); err != nil {
+		r.logger.Warn("broadcast local manifest failed", "error", err)
+		return 0
+	}
+	return len(peers)
+}
+
+// manifestEmitter returns the sender used by SendLocalManifestTo /
+// BroadcastLocalManifest. Falls back to nil when the router has
+// neither a real overlay nor a test override — in that case the
+// emission paths short-circuit instead of segfaulting.
+func (r *Router) manifestEmitter() manifestSender {
+	if r.testManifestSender != nil {
+		return r.testManifestSender
+	}
+	if r.overlay == nil {
+		return nil
+	}
+	return r.overlay
+}
+
+// HandlePeerConnect is the callback wired into Overlay.SetPeerConnectCallback.
+// Fires once a peer has finished its handshake and joined the overlay;
+// emits our local manifest so the peer can resolve our ephemeral signing
+// key back to the trusted master before our first validation arrives.
+//
+// Mirrors rippled OverlayImpl::sendEndpoints which always emits the
+// local manifest (when one exists) immediately after a peer is added.
+// Skip cases (seed-only, no overlay) are handled inside
+// SendLocalManifestTo so this stays a thin event-loop trampoline.
+func (r *Router) HandlePeerConnect(peerID peermanagement.PeerID) {
+	r.SendLocalManifestTo(peerID)
+}
+
+// localManifestBytes returns the wire bytes of our local validator
+// manifest, or nil if we have nothing to emit. Centralizes the
+// "do we have a manifest to broadcast?" decision so the per-peer and
+// broadcast paths can't drift on the skip-case logic.
+func (r *Router) localManifestBytes() []byte {
+	if r.adaptor == nil || r.adaptor.identity == nil {
+		return nil
+	}
+	if len(r.adaptor.identity.SerializedMfst) == 0 {
+		return nil
+	}
+	return r.adaptor.identity.SerializedMfst
+}

--- a/internal/consensus/adaptor/manifest_emit_test.go
+++ b/internal/consensus/adaptor/manifest_emit_test.go
@@ -58,7 +58,6 @@ func (f *fakeManifestSender) Peers() []peermanagement.PeerInfo {
 // gives tests a single payload to compare against the expected one.
 func frameToManifestBytes(t *testing.T, frame []byte) [][]byte {
 	t.Helper()
-	// Read the wire header off the front of the frame.
 	r := bytes.NewReader(frame)
 	hdr, payload, err := message.ReadMessage(r)
 	if err != nil {
@@ -82,34 +81,41 @@ func frameToManifestBytes(t *testing.T, frame []byte) [][]byte {
 	return out
 }
 
-// withTokenIdentity attaches a synthetic token-mode identity to the
-// adaptor so the manifest emitter has something to broadcast. The
-// fixture comes from identity_token_test.go's newTokenFixture; see
-// that file for the token construction details.
-func withTokenIdentity(t *testing.T, ad *Adaptor, seed byte, seq uint32) *ValidatorIdentity {
+// routerWithCache builds a router with a fresh manifest cache attached
+// and a fake sender installed. The optional `seed` and `seq` mint a
+// token-mode identity whose manifest is applied to the cache so the
+// emission paths have something to gossip — mirroring the production
+// startup path that seeds the local manifest into the shared cache.
+//
+// Pass empty seed/seq=0 to skip seeding (observer mode: empty cache).
+func routerWithCache(t *testing.T, sender manifestSender, seedKey byte, seq uint32) (*Router, *manifest.Cache, *ValidatorIdentity) {
 	t.Helper()
-	fix := newTokenFixture(t, seed, seq)
-	id, err := NewValidatorIdentityFromToken(fix.tokenBlock)
-	if err != nil {
-		t.Fatalf("NewValidatorIdentityFromToken: %v", err)
-	}
-	ad.identity = id
-	return id
-}
+	ad := newTestAdaptor(t)
+	cache := manifest.NewCache()
 
-func newRouterWithSender(t *testing.T, ad *Adaptor, sender manifestSender) *Router {
-	t.Helper()
+	var id *ValidatorIdentity
+	if seq != 0 {
+		fix := newTokenFixture(t, seedKey, seq)
+		var err error
+		id, err = NewValidatorIdentityFromToken(fix.tokenBlock)
+		if err != nil {
+			t.Fatalf("NewValidatorIdentityFromToken: %v", err)
+		}
+		ad.identity = id
+		if d := cache.ApplyManifest(id.Manifest); d != manifest.Accepted {
+			t.Fatalf("seed local manifest into cache: %s", d)
+		}
+	}
+
 	router := NewRouter(&mockEngine{}, ad, nil, nil)
-	router.testManifestSender = sender
-	return router
+	router.manifests = cache
+	router.overrideManifestSender = sender
+	return router, cache, id
 }
 
 func TestRouter_SendLocalManifestTo_EmitsExpectedFrame(t *testing.T) {
-	ad := newTestAdaptor(t)
-	id := withTokenIdentity(t, ad, 0x42, 5)
-
 	sender := &fakeManifestSender{}
-	router := newRouterWithSender(t, ad, sender)
+	router, _, id := routerWithCache(t, sender, 0x42, 5)
 
 	router.SendLocalManifestTo(peermanagement.PeerID(17))
 
@@ -128,9 +134,6 @@ func TestRouter_SendLocalManifestTo_EmitsExpectedFrame(t *testing.T) {
 		t.Errorf("emitted manifest bytes do not match local manifest")
 	}
 
-	// Round-trip the emitted bytes through Deserialize: confirms the
-	// payload is recognized as a valid manifest by the same decoder
-	// rippled and our cache use, not just byte-equal to the source.
 	parsed, err := manifest.Deserialize(wire[0])
 	if err != nil {
 		t.Fatalf("emitted manifest fails Deserialize: %v", err)
@@ -144,15 +147,12 @@ func TestRouter_SendLocalManifestTo_EmitsExpectedFrame(t *testing.T) {
 }
 
 func TestRouter_BroadcastLocalManifest_EmitsToAllPeers(t *testing.T) {
-	ad := newTestAdaptor(t)
-	id := withTokenIdentity(t, ad, 0x55, 3)
-
 	sender := &fakeManifestSender{
 		// Stub three peers — the count shapes the return value and is
 		// what BroadcastLocalManifest checks before calling Broadcast.
 		peers: []peermanagement.PeerInfo{{}, {}, {}},
 	}
-	router := newRouterWithSender(t, ad, sender)
+	router, _, id := routerWithCache(t, sender, 0x55, 3)
 
 	n := router.BroadcastLocalManifest()
 	if n != 3 {
@@ -169,11 +169,8 @@ func TestRouter_BroadcastLocalManifest_EmitsToAllPeers(t *testing.T) {
 }
 
 func TestRouter_BroadcastLocalManifest_NoPeersIsNoOp(t *testing.T) {
-	ad := newTestAdaptor(t)
-	withTokenIdentity(t, ad, 0x66, 2)
-
 	sender := &fakeManifestSender{} // empty Peers()
-	router := newRouterWithSender(t, ad, sender)
+	router, _, _ := routerWithCache(t, sender, 0x66, 2)
 
 	if n := router.BroadcastLocalManifest(); n != 0 {
 		t.Errorf("expected 0 with no peers, got %d", n)
@@ -183,56 +180,91 @@ func TestRouter_BroadcastLocalManifest_NoPeersIsNoOp(t *testing.T) {
 	}
 }
 
-func TestRouter_LocalManifestEmission_SeedOnlySkips(t *testing.T) {
-	ad := newTestAdaptor(t)
-	// Seed-only identity has no Manifest / no SerializedMfst.
-	seedID, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
-	if err != nil {
-		t.Fatalf("NewValidatorIdentity: %v", err)
-	}
-	if seedID.Manifest != nil || len(seedID.SerializedMfst) != 0 {
-		t.Fatal("precondition: seed identity must carry no manifest")
-	}
-	ad.identity = seedID
-
+// Empty-cache mode covers both observer (no validator at all) and
+// seed-only (validator without a token-mode manifest). In both cases
+// nothing has been applied to the cache and emission must skip.
+func TestRouter_LocalManifestEmission_EmptyCacheSkips(t *testing.T) {
 	sender := &fakeManifestSender{
 		peers: []peermanagement.PeerInfo{{}},
 	}
-	router := newRouterWithSender(t, ad, sender)
+	// seq=0 → routerWithCache skips seeding.
+	router, _, _ := routerWithCache(t, sender, 0, 0)
 
 	router.SendLocalManifestTo(peermanagement.PeerID(1))
 	if n := router.BroadcastLocalManifest(); n != 0 {
-		t.Errorf("seed-only broadcast should return 0, got %d", n)
+		t.Errorf("empty-cache broadcast should return 0, got %d", n)
 	}
 	if len(sender.sends) != 0 || len(sender.bcasts) != 0 {
-		t.Errorf("seed-only must not emit: sends=%d bcasts=%d", len(sender.sends), len(sender.bcasts))
+		t.Errorf("empty cache must not emit: sends=%d bcasts=%d", len(sender.sends), len(sender.bcasts))
 	}
 }
 
-func TestRouter_LocalManifestEmission_NoIdentitySkips(t *testing.T) {
-	ad := newTestAdaptor(t)
-	ad.identity = nil
-
+func TestRouter_LocalManifestEmission_NilCacheSkips(t *testing.T) {
 	sender := &fakeManifestSender{
 		peers: []peermanagement.PeerInfo{{}},
 	}
-	router := newRouterWithSender(t, ad, sender)
+	router, _, _ := routerWithCache(t, sender, 0, 0)
+	// Drop the cache entirely — exercises the r.manifests == nil
+	// guard in manifestsForEmission.
+	router.manifests = nil
 
 	router.SendLocalManifestTo(peermanagement.PeerID(1))
 	if n := router.BroadcastLocalManifest(); n != 0 {
-		t.Errorf("no-identity broadcast should return 0, got %d", n)
+		t.Errorf("nil-cache broadcast should return 0, got %d", n)
 	}
 	if len(sender.sends) != 0 || len(sender.bcasts) != 0 {
-		t.Errorf("no-identity must not emit: sends=%d bcasts=%d", len(sender.sends), len(sender.bcasts))
+		t.Errorf("nil cache must not emit: sends=%d bcasts=%d", len(sender.sends), len(sender.bcasts))
+	}
+}
+
+// Two cached manifests (local + a peer-gossiped one) must both end up
+// in the emitted frame — this is the rippled getManifestsMessage
+// parity property.
+func TestRouter_LocalManifestEmission_AggregatesCache(t *testing.T) {
+	sender := &fakeManifestSender{}
+	router, cache, id := routerWithCache(t, sender, 0x91, 4)
+
+	// Mint a second token-mode identity and apply its manifest to the
+	// cache as if it had been gossiped by a trusted peer.
+	otherFix := newTokenFixture(t, 0xA3, 11)
+	other, err := NewValidatorIdentityFromToken(otherFix.tokenBlock)
+	if err != nil {
+		t.Fatalf("NewValidatorIdentityFromToken (other): %v", err)
+	}
+	if d := cache.ApplyManifest(other.Manifest); d != manifest.Accepted {
+		t.Fatalf("apply remote manifest: %s", d)
+	}
+
+	router.SendLocalManifestTo(peermanagement.PeerID(7))
+	if len(sender.sends) != 1 {
+		t.Fatalf("expected 1 Send, got %d", len(sender.sends))
+	}
+
+	got := frameToManifestBytes(t, sender.sends[0].frame)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 manifests in aggregated frame, got %d", len(got))
+	}
+	// Cache iteration order is map-random; check both expected payloads
+	// appear regardless of order.
+	want := map[string]bool{
+		string(id.SerializedMfst):    false,
+		string(other.SerializedMfst): false,
+	}
+	for _, w := range got {
+		if _, ok := want[string(w)]; ok {
+			want[string(w)] = true
+		}
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("aggregated frame missing manifest %x...", []byte(k)[:8])
+		}
 	}
 }
 
 func TestRouter_HandlePeerConnect_DelegatesToSendLocalManifest(t *testing.T) {
-	ad := newTestAdaptor(t)
-	withTokenIdentity(t, ad, 0x77, 9)
-
 	sender := &fakeManifestSender{}
-	router := newRouterWithSender(t, ad, sender)
+	router, _, _ := routerWithCache(t, sender, 0x77, 9)
 
 	router.HandlePeerConnect(peermanagement.PeerID(42))
 
@@ -245,11 +277,8 @@ func TestRouter_HandlePeerConnect_DelegatesToSendLocalManifest(t *testing.T) {
 }
 
 func TestRouter_SendLocalManifestTo_SwallowsSenderError(t *testing.T) {
-	ad := newTestAdaptor(t)
-	withTokenIdentity(t, ad, 0x88, 1)
-
 	sender := &fakeManifestSender{sendErr: errors.New("peer gone")}
-	router := newRouterWithSender(t, ad, sender)
+	router, _, _ := routerWithCache(t, sender, 0x88, 1)
 
 	// Must not panic / propagate. The peer can race a disconnect
 	// between addPeer and the connect callback firing — the emitter

--- a/internal/consensus/adaptor/manifest_emit_test.go
+++ b/internal/consensus/adaptor/manifest_emit_test.go
@@ -1,0 +1,258 @@
+package adaptor
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/manifest"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+)
+
+// fakeManifestSender records every Send / Broadcast invocation so a
+// test can assert that the router emitted the expected TMManifests
+// frame. Peers() lets BroadcastLocalManifest see a non-zero peer count
+// without standing up real connections.
+type fakeManifestSender struct {
+	mu     sync.Mutex
+	sends  []sendCall
+	bcasts [][]byte
+	peers  []peermanagement.PeerInfo
+	// sendErr / broadcastErr let individual tests force the error
+	// branches in the emitter.
+	sendErr      error
+	broadcastErr error
+}
+
+type sendCall struct {
+	peerID peermanagement.PeerID
+	frame  []byte
+}
+
+func (f *fakeManifestSender) Send(peerID peermanagement.PeerID, frame []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sends = append(f.sends, sendCall{peerID: peerID, frame: append([]byte(nil), frame...)})
+	return f.sendErr
+}
+
+func (f *fakeManifestSender) Broadcast(frame []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bcasts = append(f.bcasts, append([]byte(nil), frame...))
+	return f.broadcastErr
+}
+
+func (f *fakeManifestSender) Peers() []peermanagement.PeerInfo {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]peermanagement.PeerInfo, len(f.peers))
+	copy(out, f.peers)
+	return out
+}
+
+// frameToManifestBytes pulls the wire-format manifest STObject back out
+// of an emitted TMManifests frame. Confirms the frame round-trips and
+// gives tests a single payload to compare against the expected one.
+func frameToManifestBytes(t *testing.T, frame []byte) [][]byte {
+	t.Helper()
+	// Read the wire header off the front of the frame.
+	r := bytes.NewReader(frame)
+	hdr, payload, err := message.ReadMessage(r)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if hdr.MessageType != message.TypeManifests {
+		t.Fatalf("frame type: got %v want TypeManifests", hdr.MessageType)
+	}
+	decoded, err := message.Decode(hdr.MessageType, payload)
+	if err != nil {
+		t.Fatalf("decode TMManifests payload: %v", err)
+	}
+	mfs, ok := decoded.(*message.Manifests)
+	if !ok {
+		t.Fatalf("decoded payload not Manifests: %T", decoded)
+	}
+	out := make([][]byte, 0, len(mfs.List))
+	for _, m := range mfs.List {
+		out = append(out, m.STObject)
+	}
+	return out
+}
+
+// withTokenIdentity attaches a synthetic token-mode identity to the
+// adaptor so the manifest emitter has something to broadcast. The
+// fixture comes from identity_token_test.go's newTokenFixture; see
+// that file for the token construction details.
+func withTokenIdentity(t *testing.T, ad *Adaptor, seed byte, seq uint32) *ValidatorIdentity {
+	t.Helper()
+	fix := newTokenFixture(t, seed, seq)
+	id, err := NewValidatorIdentityFromToken(fix.tokenBlock)
+	if err != nil {
+		t.Fatalf("NewValidatorIdentityFromToken: %v", err)
+	}
+	ad.identity = id
+	return id
+}
+
+func newRouterWithSender(t *testing.T, ad *Adaptor, sender manifestSender) *Router {
+	t.Helper()
+	router := NewRouter(&mockEngine{}, ad, nil, nil)
+	router.testManifestSender = sender
+	return router
+}
+
+func TestRouter_SendLocalManifestTo_EmitsExpectedFrame(t *testing.T) {
+	ad := newTestAdaptor(t)
+	id := withTokenIdentity(t, ad, 0x42, 5)
+
+	sender := &fakeManifestSender{}
+	router := newRouterWithSender(t, ad, sender)
+
+	router.SendLocalManifestTo(peermanagement.PeerID(17))
+
+	if len(sender.sends) != 1 {
+		t.Fatalf("expected 1 Send, got %d", len(sender.sends))
+	}
+	if sender.sends[0].peerID != 17 {
+		t.Errorf("Send peerID: got %v want 17", sender.sends[0].peerID)
+	}
+
+	wire := frameToManifestBytes(t, sender.sends[0].frame)
+	if len(wire) != 1 {
+		t.Fatalf("expected 1 manifest in frame, got %d", len(wire))
+	}
+	if !bytes.Equal(wire[0], id.SerializedMfst) {
+		t.Errorf("emitted manifest bytes do not match local manifest")
+	}
+
+	// Round-trip the emitted bytes through Deserialize: confirms the
+	// payload is recognized as a valid manifest by the same decoder
+	// rippled and our cache use, not just byte-equal to the source.
+	parsed, err := manifest.Deserialize(wire[0])
+	if err != nil {
+		t.Fatalf("emitted manifest fails Deserialize: %v", err)
+	}
+	if parsed.MasterKey != id.MasterKey {
+		t.Errorf("emitted manifest master key mismatch")
+	}
+	if parsed.Sequence != id.Manifest.Sequence {
+		t.Errorf("emitted manifest sequence: got %d want %d", parsed.Sequence, id.Manifest.Sequence)
+	}
+}
+
+func TestRouter_BroadcastLocalManifest_EmitsToAllPeers(t *testing.T) {
+	ad := newTestAdaptor(t)
+	id := withTokenIdentity(t, ad, 0x55, 3)
+
+	sender := &fakeManifestSender{
+		// Stub three peers — the count shapes the return value and is
+		// what BroadcastLocalManifest checks before calling Broadcast.
+		peers: []peermanagement.PeerInfo{{}, {}, {}},
+	}
+	router := newRouterWithSender(t, ad, sender)
+
+	n := router.BroadcastLocalManifest()
+	if n != 3 {
+		t.Errorf("BroadcastLocalManifest: got %d, want 3", n)
+	}
+	if len(sender.bcasts) != 1 {
+		t.Fatalf("expected 1 Broadcast, got %d", len(sender.bcasts))
+	}
+
+	wire := frameToManifestBytes(t, sender.bcasts[0])
+	if len(wire) != 1 || !bytes.Equal(wire[0], id.SerializedMfst) {
+		t.Errorf("broadcast frame did not carry the local manifest")
+	}
+}
+
+func TestRouter_BroadcastLocalManifest_NoPeersIsNoOp(t *testing.T) {
+	ad := newTestAdaptor(t)
+	withTokenIdentity(t, ad, 0x66, 2)
+
+	sender := &fakeManifestSender{} // empty Peers()
+	router := newRouterWithSender(t, ad, sender)
+
+	if n := router.BroadcastLocalManifest(); n != 0 {
+		t.Errorf("expected 0 with no peers, got %d", n)
+	}
+	if len(sender.bcasts) != 0 {
+		t.Errorf("expected no Broadcast call when peer list is empty, got %d", len(sender.bcasts))
+	}
+}
+
+func TestRouter_LocalManifestEmission_SeedOnlySkips(t *testing.T) {
+	ad := newTestAdaptor(t)
+	// Seed-only identity has no Manifest / no SerializedMfst.
+	seedID, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	if err != nil {
+		t.Fatalf("NewValidatorIdentity: %v", err)
+	}
+	if seedID.Manifest != nil || len(seedID.SerializedMfst) != 0 {
+		t.Fatal("precondition: seed identity must carry no manifest")
+	}
+	ad.identity = seedID
+
+	sender := &fakeManifestSender{
+		peers: []peermanagement.PeerInfo{{}},
+	}
+	router := newRouterWithSender(t, ad, sender)
+
+	router.SendLocalManifestTo(peermanagement.PeerID(1))
+	if n := router.BroadcastLocalManifest(); n != 0 {
+		t.Errorf("seed-only broadcast should return 0, got %d", n)
+	}
+	if len(sender.sends) != 0 || len(sender.bcasts) != 0 {
+		t.Errorf("seed-only must not emit: sends=%d bcasts=%d", len(sender.sends), len(sender.bcasts))
+	}
+}
+
+func TestRouter_LocalManifestEmission_NoIdentitySkips(t *testing.T) {
+	ad := newTestAdaptor(t)
+	ad.identity = nil
+
+	sender := &fakeManifestSender{
+		peers: []peermanagement.PeerInfo{{}},
+	}
+	router := newRouterWithSender(t, ad, sender)
+
+	router.SendLocalManifestTo(peermanagement.PeerID(1))
+	if n := router.BroadcastLocalManifest(); n != 0 {
+		t.Errorf("no-identity broadcast should return 0, got %d", n)
+	}
+	if len(sender.sends) != 0 || len(sender.bcasts) != 0 {
+		t.Errorf("no-identity must not emit: sends=%d bcasts=%d", len(sender.sends), len(sender.bcasts))
+	}
+}
+
+func TestRouter_HandlePeerConnect_DelegatesToSendLocalManifest(t *testing.T) {
+	ad := newTestAdaptor(t)
+	withTokenIdentity(t, ad, 0x77, 9)
+
+	sender := &fakeManifestSender{}
+	router := newRouterWithSender(t, ad, sender)
+
+	router.HandlePeerConnect(peermanagement.PeerID(42))
+
+	if len(sender.sends) != 1 {
+		t.Fatalf("expected 1 Send from HandlePeerConnect, got %d", len(sender.sends))
+	}
+	if sender.sends[0].peerID != 42 {
+		t.Errorf("HandlePeerConnect routed to wrong peer: got %v want 42", sender.sends[0].peerID)
+	}
+}
+
+func TestRouter_SendLocalManifestTo_SwallowsSenderError(t *testing.T) {
+	ad := newTestAdaptor(t)
+	withTokenIdentity(t, ad, 0x88, 1)
+
+	sender := &fakeManifestSender{sendErr: errors.New("peer gone")}
+	router := newRouterWithSender(t, ad, sender)
+
+	// Must not panic / propagate. The peer can race a disconnect
+	// between addPeer and the connect callback firing — the emitter
+	// is expected to log and move on.
+	router.SendLocalManifestTo(peermanagement.PeerID(1))
+}

--- a/internal/consensus/adaptor/manifest_emit_test.go
+++ b/internal/consensus/adaptor/manifest_emit_test.go
@@ -205,7 +205,7 @@ func TestRouter_LocalManifestEmission_NilCacheSkips(t *testing.T) {
 	}
 	router, _, _ := routerWithCache(t, sender, 0, 0)
 	// Drop the cache entirely — exercises the r.manifests == nil
-	// guard in manifestsForEmission.
+	// guard in cachedManifestFrame.
 	router.manifests = nil
 
 	router.SendLocalManifestTo(peermanagement.PeerID(1))
@@ -284,4 +284,90 @@ func TestRouter_SendLocalManifestTo_SwallowsSenderError(t *testing.T) {
 	// between addPeer and the connect callback firing — the emitter
 	// is expected to log and move on.
 	router.SendLocalManifestTo(peermanagement.PeerID(1))
+}
+
+// Two back-to-back emissions with no cache mutation between them must
+// produce the SAME frame bytes — this is the rippled
+// (manifestMessage_, manifestListSeq_) reuse property at
+// OverlayImpl.cpp:1184-1212. Identity here means "same backing array",
+// which proves the second emission did not re-encode.
+func TestRouter_CachedManifestFrame_ReusedAcrossEmissions(t *testing.T) {
+	sender := &fakeManifestSender{}
+	router, _, _ := routerWithCache(t, sender, 0xB1, 6)
+
+	router.SendLocalManifestTo(peermanagement.PeerID(1))
+	router.SendLocalManifestTo(peermanagement.PeerID(2))
+	if len(sender.sends) != 2 {
+		t.Fatalf("expected 2 Sends, got %d", len(sender.sends))
+	}
+
+	first := router.manifestFrame
+	if first == nil {
+		t.Fatalf("frame cache empty after first Send")
+	}
+	if seq := router.manifestFrameSeq; seq != 0 {
+		// First-insert path doesn't bump cache.Sequence (rippled
+		// Manifest.cpp:507-518 parity), so the cursor stays at 0.
+		t.Fatalf("cached cursor: got %d want 0 (first-insert quirk)", seq)
+	}
+
+	router.SendLocalManifestTo(peermanagement.PeerID(3))
+	if got := router.manifestFrame; &got[0] != &first[0] {
+		t.Errorf("frame re-encoded despite unchanged cache (backing arrays differ)")
+	}
+}
+
+// A subsequent ApplyManifest that REPLACES an existing master must bump
+// cache.Sequence and force the next emission to re-encode.
+func TestRouter_CachedManifestFrame_RebuiltOnSequenceAdvance(t *testing.T) {
+	sender := &fakeManifestSender{}
+	router, cache, _ := routerWithCache(t, sender, 0xC2, 1)
+
+	router.SendLocalManifestTo(peermanagement.PeerID(1))
+	first := router.manifestFrame
+
+	// Mint a higher-sequence manifest under the SAME master+ephemeral
+	// keypair (newTokenFixture is seed-deterministic — same seed byte
+	// = same keys; only the sequence differs). This hits the update
+	// branch in cache.ApplyManifest, which is the only path that bumps
+	// Sequence — matching rippled Manifest.cpp:538.
+	rotated := newTokenFixture(t, 0xC2, 7)
+	rotatedID, err := NewValidatorIdentityFromToken(rotated.tokenBlock)
+	if err != nil {
+		t.Fatalf("rotated identity: %v", err)
+	}
+	if d := cache.ApplyManifest(rotatedID.Manifest); d != manifest.Accepted {
+		t.Fatalf("apply rotated manifest: %s", d)
+	}
+	if seq := cache.Sequence(); seq != 1 {
+		t.Fatalf("cache.Sequence after update: got %d want 1", seq)
+	}
+
+	router.SendLocalManifestTo(peermanagement.PeerID(2))
+	if router.manifestFrame == nil {
+		t.Fatalf("frame cache empty after rotation")
+	}
+	if &router.manifestFrame[0] == &first[0] {
+		t.Errorf("frame NOT re-encoded after Sequence advance — cache cursor stuck")
+	}
+	if router.manifestFrameSeq != 1 {
+		t.Errorf("cached cursor: got %d want 1", router.manifestFrameSeq)
+	}
+}
+
+// Empty cache hits the "cache the empty fact" branch — second call
+// must NOT re-walk SerializedAll.
+func TestRouter_CachedManifestFrame_EmptyCacheCachesNegative(t *testing.T) {
+	sender := &fakeManifestSender{
+		peers: []peermanagement.PeerInfo{{}},
+	}
+	router, _, _ := routerWithCache(t, sender, 0, 0)
+
+	router.SendLocalManifestTo(peermanagement.PeerID(1))
+	if !router.manifestFrameBuilt {
+		t.Errorf("empty-cache path did not record the negative result")
+	}
+	if router.manifestFrame != nil {
+		t.Errorf("empty cache should cache nil frame, got %d bytes", len(router.manifestFrame))
+	}
 }

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -77,12 +77,14 @@ type Router struct {
 	// construct a router without manifest support.
 	overlay *peermanagement.Overlay
 
-	// testManifestSender, when non-nil, replaces r.overlay for the
+	// overrideManifestSender, when non-nil, replaces r.overlay for the
 	// local-manifest emission paths (SendLocalManifestTo /
 	// BroadcastLocalManifest). Tests install a fake here to observe
 	// the emitted frame without standing up real listeners; production
-	// leaves it nil so the real overlay is used.
-	testManifestSender manifestSender
+	// leaves it nil so the real overlay is used. The relayManifest
+	// path still needs r.overlay directly because BroadcastExcept has
+	// no equivalent on the sender interface.
+	overrideManifestSender manifestSender
 }
 
 // messageDedupTTL is how long a proposal/validation hash is

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -76,6 +76,13 @@ type Router struct {
 	// directly via Overlay.BroadcastExcept. Nil in tests that
 	// construct a router without manifest support.
 	overlay *peermanagement.Overlay
+
+	// testManifestSender, when non-nil, replaces r.overlay for the
+	// local-manifest emission paths (SendLocalManifestTo /
+	// BroadcastLocalManifest). Tests install a fake here to observe
+	// the emitted frame without standing up real listeners; production
+	// leaves it nil so the real overlay is used.
+	testManifestSender manifestSender
 }
 
 // messageDedupTTL is how long a proposal/validation hash is
@@ -333,15 +340,13 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) {
 // except the origin. Wraps the serialized STObject in a TMManifests
 // frame (a list of one) — matching rippled's per-manifest relay
 // (OverlayImpl.cpp:633-686 loops through and relays each one via
-// overlay_.foreach).
+// overlay_.foreach). Shares its framing with the local-manifest
+// emission paths in manifest_emit.go.
 func (r *Router) relayManifest(exceptPeer peermanagement.PeerID, serialized []byte) {
 	if r.overlay == nil {
 		return
 	}
-	relayMsg := &message.Manifests{
-		List: []message.Manifest{{STObject: serialized}},
-	}
-	frame, err := encodeFrame(message.TypeManifests, relayMsg)
+	frame, err := encodeManifestsFrame(serialized)
 	if err != nil {
 		r.logger.Warn("failed to encode manifest relay frame", "error", err)
 		return

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -85,6 +85,21 @@ type Router struct {
 	// path still needs r.overlay directly because BroadcastExcept has
 	// no equivalent on the sender interface.
 	overrideManifestSender manifestSender
+
+	// manifestFrameMu guards the cached TMManifests emission frame and
+	// its companion sequence cursor. Mirrors the (manifestMessage_,
+	// manifestListSeq_) pair on rippled's OverlayImpl
+	// (OverlayImpl.cpp:1184-1212): re-encode only when manifests.Sequence
+	// has advanced past the value seen at last build, so back-to-back
+	// peer connects reuse the same encoded bytes without re-walking the
+	// cache. manifestFrameBuilt is the never-built sentinel — a zero
+	// manifestFrameSeq is a valid cursor (a fresh cache starts at 0),
+	// so we need an explicit "have we ever built?" flag rather than
+	// using the zero value as the sentinel.
+	manifestFrameMu    sync.Mutex
+	manifestFrame      []byte
+	manifestFrameSeq   uint64
+	manifestFrameBuilt bool
 }
 
 // messageDedupTTL is how long a proposal/validation hash is

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -39,9 +39,22 @@ type Components struct {
 	Archive *archive.Archive
 
 	// cancel functions for background goroutines
-	overlayCancel context.CancelFunc
-	routerCancel  context.CancelFunc
+	overlayCancel       context.CancelFunc
+	routerCancel        context.CancelFunc
+	manifestStartCancel context.CancelFunc
 }
+
+// startupManifestBroadcastDelay is how long Components.Start waits
+// after wiring everything up before its one-shot local-manifest
+// broadcast. The per-peer connect callback already handles the
+// common case (a peer connects after we're up); the startup
+// broadcast is the safety net for peers that connected during the
+// brief window between Overlay.Run starting and the connect callback
+// being able to do useful work, plus revoked-manifest propagation
+// per #372 spec. Short enough to be effectively immediate from an
+// operator's view, long enough to let the initial connection burst
+// settle so the broadcast actually has someone to broadcast to.
+const startupManifestBroadcastDelay = 2 * time.Second
 
 // Start launches all background goroutines (overlay, engine, router).
 func (c *Components) Start() error {
@@ -61,11 +74,58 @@ func (c *Components) Start() error {
 	c.routerCancel = routerCancel
 	go c.Router.Run(routerCtx)
 
+	// One-shot startup local-manifest broadcast. Validators configured
+	// via [validator_token] need every peer to know the master ↔
+	// signing-key binding before our first validation lands; the
+	// per-peer connect callback handles new peers, but a brief startup
+	// delay + Broadcast covers peers that joined in the gap between
+	// Overlay.Run starting and the callback being meaningful, and
+	// propagates revoked manifests at boot per rippled's pattern.
+	// Skipped at log-once granularity for seed-only / observer nodes.
+	manifestCtx, manifestCancel := context.WithCancel(context.Background())
+	c.manifestStartCancel = manifestCancel
+	go c.runStartupManifestBroadcast(manifestCtx)
+
 	return nil
+}
+
+// runStartupManifestBroadcast sleeps for startupManifestBroadcastDelay
+// then emits one TMManifests broadcast for our local manifest. Returns
+// early if the context is cancelled (Stop) or if there's no manifest to
+// emit (observer / seed-only mode); the latter is logged once at INFO
+// so operators can see at boot why the validator isn't gossiping.
+func (c *Components) runStartupManifestBroadcast(ctx context.Context) {
+	if c.Router == nil {
+		return
+	}
+	if c.Router.localManifestBytes() == nil {
+		// Observer or legacy seed-only validator — nothing to
+		// broadcast. One INFO line at boot makes the silence
+		// debuggable.
+		slog.Info("local validator manifest not configured; TMManifests emission skipped",
+			"t", "Components.Start")
+		return
+	}
+
+	timer := time.NewTimer(startupManifestBroadcastDelay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return
+	case <-timer.C:
+	}
+
+	if n := c.Router.BroadcastLocalManifest(); n > 0 {
+		slog.Info("startup local manifest broadcast",
+			"t", "Components.Start", "peers", n)
+	}
 }
 
 // Stop gracefully shuts down all components.
 func (c *Components) Stop() {
+	if c.manifestStartCancel != nil {
+		c.manifestStartCancel()
+	}
 	if c.routerCancel != nil {
 		c.routerCancel()
 	}
@@ -196,6 +256,15 @@ func NewFromConfig(
 	// Without this a disconnected peer's stale LCL keeps influencing
 	// consensus convergence.
 	overlay.SetPeerDisconnectCallback(router.HandlePeerDisconnect)
+
+	// Send our local validator manifest to each peer the moment its
+	// handshake completes. Mirrors rippled OverlayImpl::sendEndpoints
+	// which emits the local manifest in the post-handshake window so
+	// the peer's ManifestCache can resolve our ephemeral signing key
+	// back to the trusted master before our first validation arrives.
+	// Skip cases (no validator, seed-only, no overlay) are absorbed
+	// inside SendLocalManifestTo.
+	overlay.SetPeerConnectCallback(router.HandlePeerConnect)
 
 	// Wire operating mode into ledger service for server_info.
 	// Matches rippled: report "proposing" when both in full operating mode

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -39,22 +39,9 @@ type Components struct {
 	Archive *archive.Archive
 
 	// cancel functions for background goroutines
-	overlayCancel       context.CancelFunc
-	routerCancel        context.CancelFunc
-	manifestStartCancel context.CancelFunc
+	overlayCancel context.CancelFunc
+	routerCancel  context.CancelFunc
 }
-
-// startupManifestBroadcastDelay is how long Components.Start waits
-// after wiring everything up before its one-shot local-manifest
-// broadcast. The per-peer connect callback already handles the
-// common case (a peer connects after we're up); the startup
-// broadcast is the safety net for peers that connected during the
-// brief window between Overlay.Run starting and the connect callback
-// being able to do useful work, plus revoked-manifest propagation
-// per #372 spec. Short enough to be effectively immediate from an
-// operator's view, long enough to let the initial connection burst
-// settle so the broadcast actually has someone to broadcast to.
-const startupManifestBroadcastDelay = 2 * time.Second
 
 // Start launches all background goroutines (overlay, engine, router).
 func (c *Components) Start() error {
@@ -74,58 +61,11 @@ func (c *Components) Start() error {
 	c.routerCancel = routerCancel
 	go c.Router.Run(routerCtx)
 
-	// One-shot startup local-manifest broadcast. Validators configured
-	// via [validator_token] need every peer to know the master ↔
-	// signing-key binding before our first validation lands; the
-	// per-peer connect callback handles new peers, but a brief startup
-	// delay + Broadcast covers peers that joined in the gap between
-	// Overlay.Run starting and the callback being meaningful, and
-	// propagates revoked manifests at boot per rippled's pattern.
-	// Skipped at log-once granularity for seed-only / observer nodes.
-	manifestCtx, manifestCancel := context.WithCancel(context.Background())
-	c.manifestStartCancel = manifestCancel
-	go c.runStartupManifestBroadcast(manifestCtx)
-
 	return nil
-}
-
-// runStartupManifestBroadcast sleeps for startupManifestBroadcastDelay
-// then emits one TMManifests broadcast for our local manifest. Returns
-// early if the context is cancelled (Stop) or if there's no manifest to
-// emit (observer / seed-only mode); the latter is logged once at INFO
-// so operators can see at boot why the validator isn't gossiping.
-func (c *Components) runStartupManifestBroadcast(ctx context.Context) {
-	if c.Router == nil {
-		return
-	}
-	if c.Router.localManifestBytes() == nil {
-		// Observer or legacy seed-only validator — nothing to
-		// broadcast. One INFO line at boot makes the silence
-		// debuggable.
-		slog.Info("local validator manifest not configured; TMManifests emission skipped",
-			"t", "Components.Start")
-		return
-	}
-
-	timer := time.NewTimer(startupManifestBroadcastDelay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return
-	case <-timer.C:
-	}
-
-	if n := c.Router.BroadcastLocalManifest(); n > 0 {
-		slog.Info("startup local manifest broadcast",
-			"t", "Components.Start", "peers", n)
-	}
 }
 
 // Stop gracefully shuts down all components.
 func (c *Components) Stop() {
-	if c.manifestStartCancel != nil {
-		c.manifestStartCancel()
-	}
 	if c.routerCancel != nil {
 		c.routerCancel()
 	}
@@ -217,6 +157,22 @@ func NewFromConfig(
 	// as itself.
 	manifestCache := manifest.NewCache()
 
+	// Seed the local validator's manifest into the cache when running
+	// in token mode so the post-handshake TMManifests emission walks
+	// every cached entry — local + aggregated remote — matching
+	// rippled's OverlayImpl::getManifestsMessage which iterates
+	// ValidatorManifests::for_each_manifest (Manifest.cpp:1184-1212).
+	// In observer / seed-only mode there is nothing to seed and the
+	// cache stays cold until peers gossip something.
+	if identity != nil && identity.Manifest != nil {
+		if d := manifestCache.ApplyManifest(identity.Manifest); d != manifest.Accepted {
+			return nil, fmt.Errorf("seed local manifest into cache: disposition=%s", d)
+		}
+	} else {
+		slog.Info("local validator manifest not configured; TMManifests emission limited to peer-gossiped entries",
+			"t", "adaptor.NewFromConfig")
+	}
+
 	engine := rcl.NewEngine(adaptor, rcl.DefaultConfig())
 
 	// Translate ephemeral signing keys → master keys before quorum
@@ -257,13 +213,14 @@ func NewFromConfig(
 	// consensus convergence.
 	overlay.SetPeerDisconnectCallback(router.HandlePeerDisconnect)
 
-	// Send our local validator manifest to each peer the moment its
-	// handshake completes. Mirrors rippled OverlayImpl::sendEndpoints
-	// which emits the local manifest in the post-handshake window so
-	// the peer's ManifestCache can resolve our ephemeral signing key
-	// back to the trusted master before our first validation arrives.
-	// Skip cases (no validator, seed-only, no overlay) are absorbed
-	// inside SendLocalManifestTo.
+	// Emit cached validator manifests (local + aggregated remote) the
+	// moment a peer's handshake completes. Mirrors rippled
+	// PeerImp::doProtocolStart (PeerImp.cpp:851-886) which sends
+	// OverlayImpl::getManifestsMessage — i.e. every entry in
+	// ValidatorManifests — so the new peer can resolve our ephemeral
+	// signing key (and any other validator's) back to its trusted
+	// master before any validation it receives. Skip cases (cache
+	// empty, no overlay) are absorbed inside SendLocalManifestTo.
 	overlay.SetPeerConnectCallback(router.HandlePeerConnect)
 
 	// Wire operating mode into ledger service for server_info.

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -226,3 +226,25 @@ func (c *Cache) Revoked(masterKey [33]byte) bool {
 	}
 	return m.Revoked()
 }
+
+// SerializedAll returns the wire bytes of every cached manifest in
+// arbitrary order, with each entry defensively copied. Used by the
+// post-handshake TMManifests emission to gossip the entire aggregated
+// cache to a freshly-connected peer, mirroring rippled's
+// OverlayImpl::getManifestsMessage which calls
+// ValidatorManifests::for_each_manifest (Manifest.cpp:1184-1212).
+func (c *Cache) SerializedAll() [][]byte {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.byMaster) == 0 {
+		return nil
+	}
+	out := make([][]byte, 0, len(c.byMaster))
+	for _, m := range c.byMaster {
+		if len(m.Serialized) == 0 {
+			continue
+		}
+		out = append(out, append([]byte(nil), m.Serialized...))
+	}
+	return out
+}

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -70,6 +70,18 @@ type Cache struct {
 	// when the master rotates (old ephemeral removed) or revokes
 	// (entry removed so lookups no longer resolve).
 	signingToMaster map[[33]byte][33]byte
+
+	// seq advances every time an existing master's entry is replaced
+	// with a higher-sequence manifest. Mirrors rippled's
+	// ManifestCache::seq_ at Manifest.cpp:538: the counter is the
+	// "something has changed" signal a downstream emitter (here, the
+	// Router's TMManifests frame cache) consults to decide whether the
+	// previously-encoded frame is still current. Like rippled, first-
+	// inserts do NOT advance seq — first-insert paths are reachable
+	// without an existing entry to "update" so the counter stays put;
+	// the manifest is still in byMaster and will be picked up the next
+	// time the cache is fully walked.
+	seq uint64
 }
 
 // NewCache returns an empty Cache.
@@ -135,17 +147,36 @@ func (c *Cache) ApplyManifest(m *Manifest) Disposition {
 	// Drop the previous ephemeral mapping (if any) before installing
 	// the new one; otherwise a validation signed with the OLD
 	// ephemeral would still resolve to the master after rotation.
-	if prev, ok := c.byMaster[m.MasterKey]; ok {
-		if !prev.Revoked() {
-			delete(c.signingToMaster, prev.SigningKey)
-		}
+	prev, isUpdate := c.byMaster[m.MasterKey]
+	if isUpdate && !prev.Revoked() {
+		delete(c.signingToMaster, prev.SigningKey)
 	}
 
 	c.byMaster[m.MasterKey] = m
 	if !m.Revoked() {
 		c.signingToMaster[m.SigningKey] = m.MasterKey
 	}
+	if isUpdate {
+		// Match rippled Manifest.cpp:538: bump only when an existing
+		// entry is replaced. The first insert is rare ("should only
+		// ever happen once per validator run" per the rippled comment)
+		// and is handled by the consumer's never-built sentinel.
+		c.seq++
+	}
 	return Accepted
+}
+
+// Sequence returns the cache's "something has changed" counter.
+// Increments every time an existing master's manifest is replaced with
+// a higher-sequence one (key rotation or revocation). First-inserts
+// don't advance it — see ApplyManifest. Mirrors rippled
+// ManifestCache::sequence() at Manifest.h:278-281, used by emitters to
+// short-circuit re-encoding the TMManifests frame when nothing has
+// changed since the last build.
+func (c *Cache) Sequence() uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.seq
 }
 
 // GetMasterKey returns the master key associated with a signing key.

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -313,3 +313,61 @@ func TestManifest_Revoked_WithEphemeral_Rejected(t *testing.T) {
 		t.Fatal("Deserialize: got nil, want rejection of revoked + ephemeral")
 	}
 }
+
+// Sequence() tracks rippled's seq_++ semantics: only the UPDATE branch
+// in ApplyManifest advances the counter (Manifest.cpp:538). First-
+// inserts and Stale re-applies leave it alone.
+func TestManifest_Sequence_AdvancesOnlyOnUpdate(t *testing.T) {
+	c := manifest.NewCache()
+	if got := c.Sequence(); got != 0 {
+		t.Fatalf("fresh cache Sequence: got %d want 0", got)
+	}
+
+	// First insert under master A.
+	aSeq1Bytes, _, _ := buildManifest(t, 1, false, 0x21, 0x22)
+	aSeq1, err := manifest.Deserialize(aSeq1Bytes)
+	if err != nil {
+		t.Fatalf("Deserialize aSeq1: %v", err)
+	}
+	if d := c.ApplyManifest(aSeq1); d != manifest.Accepted {
+		t.Fatalf("first insert: %s", d)
+	}
+	if got := c.Sequence(); got != 0 {
+		t.Errorf("Sequence after first insert: got %d want 0 (rippled first-insert quirk)", got)
+	}
+
+	// First insert under a SECOND master B — still a first-insert, so
+	// no bump.
+	bSeq1Bytes, _, _ := buildManifest(t, 1, false, 0x23, 0x24)
+	bSeq1, err := manifest.Deserialize(bSeq1Bytes)
+	if err != nil {
+		t.Fatalf("Deserialize bSeq1: %v", err)
+	}
+	if d := c.ApplyManifest(bSeq1); d != manifest.Accepted {
+		t.Fatalf("second master first insert: %s", d)
+	}
+	if got := c.Sequence(); got != 0 {
+		t.Errorf("Sequence after second first-insert: got %d want 0", got)
+	}
+
+	// Update master A → seq must bump.
+	aSeq2Bytes, _, _ := buildManifest(t, 2, false, 0x21, 0x25)
+	aSeq2, err := manifest.Deserialize(aSeq2Bytes)
+	if err != nil {
+		t.Fatalf("Deserialize aSeq2: %v", err)
+	}
+	if d := c.ApplyManifest(aSeq2); d != manifest.Accepted {
+		t.Fatalf("update aSeq2: %s", d)
+	}
+	if got := c.Sequence(); got != 1 {
+		t.Errorf("Sequence after update: got %d want 1", got)
+	}
+
+	// Stale re-apply must NOT bump.
+	if d := c.ApplyManifest(aSeq1); d != manifest.Stale {
+		t.Fatalf("stale re-apply: %s", d)
+	}
+	if got := c.Sequence(); got != 1 {
+		t.Errorf("Sequence after stale: got %d want 1", got)
+	}
+}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -224,6 +224,15 @@ type Overlay struct {
 	// no subscriber is registered.
 	onPeerDisconnect func(PeerID)
 
+	// onPeerConnect fires once a peer has finished its handshake and
+	// been added to the overlay's peer map. Higher layers use this to
+	// trigger post-connect emissions like the local manifest broadcast
+	// (#372 / rippled OverlayImpl::sendEndpoints which emits manifests
+	// alongside endpoints in the post-handshake window). Same blocking
+	// contract as onPeerDisconnect: runs on the event loop, must not
+	// block.
+	onPeerConnect func(PeerID)
+
 	// droppedMessages counts how many times the non-blocking send to
 	// the messages channel hit its default branch (downstream consumer
 	// slow). Exposed via DroppedMessages() so server_info / telemetry
@@ -919,6 +928,12 @@ func (o *Overlay) onPeerConnected(evt Event) {
 	if !evt.Inbound {
 		o.discovery.MarkConnected(evt.Endpoint.String(), evt.PeerID)
 	}
+	// Notify higher layers AFTER discovery state is updated so any work
+	// they do (e.g. sending us-originated frames to the peer) sees a
+	// fully-bookkept overlay. Mirrors the disconnect callback ordering.
+	if cb := o.onPeerConnect; cb != nil {
+		cb(evt.PeerID)
+	}
 }
 
 func (o *Overlay) onPeerHandshakeComplete(evt Event) {
@@ -948,6 +963,19 @@ func (o *Overlay) onPeerDisconnected(evt Event) {
 // per-peer state. Prefer this over polling Peers().
 func (o *Overlay) SetPeerDisconnectCallback(cb func(PeerID)) {
 	o.onPeerDisconnect = cb
+}
+
+// SetPeerConnectCallback registers a callback fired after a peer's
+// handshake has completed and the peer is in the overlay's peer map.
+// Same blocking contract as SetPeerDisconnectCallback: runs on the
+// event loop and MUST NOT block. Passing nil clears the callback.
+//
+// Used by the consensus router to send our local validator manifest
+// to a freshly-connected peer (#372), so peers configured under
+// validator-list publishing can resolve our signing key back to the
+// trusted master.
+func (o *Overlay) SetPeerConnectCallback(cb func(PeerID)) {
+	o.onPeerConnect = cb
 }
 
 func (o *Overlay) onPeerFailed(evt Event) {


### PR DESCRIPTION
Sub-issue of #360. Stacked on #376 (#371). Builds the foundation for #373.

## Summary

Wires the TMManifests emission paths so peers configured via standard validator-list publishing can resolve our ephemeral signing key back to the trusted master before our first validation arrives. Seed-only and observer modes skip cleanly with a single startup INFO line.

- `internal/peermanagement/overlay.go`: `SetPeerConnectCallback`, fired from `onPeerConnected` after discovery state is updated. Symmetric with the existing `SetPeerDisconnectCallback`. Same blocking contract — runs on the event-loop goroutine, must not block.
- `internal/consensus/adaptor/manifest_emit.go` (new): `encodeManifestsFrame` shared with `relayManifest`; `SendLocalManifestTo` for the per-peer connect path; `BroadcastLocalManifest` for the startup one-shot. `manifestSender` interface keeps the production path on the concrete `*peermanagement.Overlay` while letting tests observe emitted frames without standing up listeners.
- `internal/consensus/adaptor/router.go`: `relayManifest` reuses the shared frame encoder; `testManifestSender` field for unit-test injection.
- `internal/consensus/adaptor/startup.go`: `SetPeerConnectCallback` wired to `Router.HandlePeerConnect`; `runStartupManifestBroadcast` goroutine fires one Broadcast after a 2s delay so peers that joined in the bootstrap window pick up the manifest, plus revoked-manifest propagation. Cancelled cleanly on `Components.Stop`.

## Test plan

- [x] Emitted frame round-trips through `ReadMessage` → `Decode` → `manifest.Deserialize` back to the local manifest bytes
- [x] Seed-only and observer adaptors emit nothing (no `Send` / `Broadcast` calls)
- [x] `HandlePeerConnect` routes to `SendLocalManifestTo` for the right peer ID
- [x] Sender error from a flapping peer is swallowed (no panic, no error propagation)
- [x] `BroadcastLocalManifest` returns 0 when no peers are connected and skips the actual `Broadcast` call
- [x] `go test ./internal/peermanagement/... ./internal/consensus/adaptor/...` — pass
- [x] `go build` for `cmd/xrpld` (CGO + OpenSSL) — clean