### PR TITLE
adaptor: periodic manifest re-broadcast + sequence enforcement (refs #373)

### DIFF
--- a/internal/consensus/adaptor/manifest_periodic_test.go
+++ b/internal/consensus/adaptor/manifest_periodic_test.go
@@ -8,9 +8,6 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/peermanagement"
 )
 
-// waitForBroadcasts polls until n Broadcast calls have landed or the
-// deadline expires; returns the observed count either way so callers
-// can produce a meaningful failure message.
 func waitForBroadcasts(sender *fakeManifestSender, n int, timeout time.Duration) int {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/internal/consensus/adaptor/manifest_periodic_test.go
+++ b/internal/consensus/adaptor/manifest_periodic_test.go
@@ -1,0 +1,100 @@
+package adaptor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+)
+
+// waitForBroadcasts polls until n Broadcast calls have landed or the
+// deadline expires; returns the observed count either way so callers
+// can produce a meaningful failure message.
+func waitForBroadcasts(sender *fakeManifestSender, n int, timeout time.Duration) int {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		sender.mu.Lock()
+		got := len(sender.bcasts)
+		sender.mu.Unlock()
+		if got >= n {
+			return got
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+	return len(sender.bcasts)
+}
+
+func TestPeriodicManifestBroadcast_FiresOnInterval(t *testing.T) {
+	sender := &fakeManifestSender{
+		peers: []peermanagement.PeerInfo{{}, {}},
+	}
+	router, _, _ := routerWithCache(t, sender, 0xa1, 1)
+	c := &Components{Router: router}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.runPeriodicManifestBroadcast(ctx, 50*time.Millisecond)
+
+	// Two ticks at 50ms must fit comfortably in 500ms even on a
+	// loaded CI runner. Larger budget would mask a regression where
+	// the ticker stops firing.
+	if got := waitForBroadcasts(sender, 2, 500*time.Millisecond); got < 2 {
+		t.Fatalf("expected >=2 broadcasts, got %d", got)
+	}
+}
+
+func TestPeriodicManifestBroadcast_StopsOnContextCancel(t *testing.T) {
+	sender := &fakeManifestSender{
+		peers: []peermanagement.PeerInfo{{}},
+	}
+	router, _, _ := routerWithCache(t, sender, 0xa2, 1)
+	c := &Components{Router: router}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.runPeriodicManifestBroadcast(ctx, 50*time.Millisecond)
+
+	if got := waitForBroadcasts(sender, 1, 500*time.Millisecond); got < 1 {
+		t.Fatalf("expected first broadcast within 500ms, got %d", got)
+	}
+	cancel()
+
+	sender.mu.Lock()
+	frozen := len(sender.bcasts)
+	sender.mu.Unlock()
+
+	time.Sleep(150 * time.Millisecond)
+
+	sender.mu.Lock()
+	after := len(sender.bcasts)
+	sender.mu.Unlock()
+	if after != frozen {
+		t.Fatalf("broadcast continued after cancel: before=%d after=%d", frozen, after)
+	}
+}
+
+// Empty cache (observer / seed-only mode where nothing was applied to
+// the manifest cache) must produce no broadcasts even though the
+// ticker fires.
+func TestPeriodicManifestBroadcast_EmptyCacheSilent(t *testing.T) {
+	sender := &fakeManifestSender{
+		peers: []peermanagement.PeerInfo{{}},
+	}
+	// seq=0 → routerWithCache skips seeding the cache.
+	router, _, _ := routerWithCache(t, sender, 0, 0)
+	c := &Components{Router: router}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.runPeriodicManifestBroadcast(ctx, 20*time.Millisecond)
+
+	time.Sleep(120 * time.Millisecond)
+
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+	if len(sender.bcasts) != 0 {
+		t.Errorf("empty-cache mode emitted %d broadcasts", len(sender.bcasts))
+	}
+}

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -39,9 +39,23 @@ type Components struct {
 	Archive *archive.Archive
 
 	// cancel functions for background goroutines
-	overlayCancel context.CancelFunc
-	routerCancel  context.CancelFunc
+	overlayCancel          context.CancelFunc
+	routerCancel           context.CancelFunc
+	manifestPeriodicCancel context.CancelFunc
 }
+
+// periodicManifestBroadcastInterval is how often Components.Start
+// re-emits the cached aggregate TMManifests frame. Rippled has no
+// equivalent loop: its 1-second OverlayImpl timer
+// (OverlayImpl.cpp:84-114) handles endpoints / autoConnect / tx
+// queue / idle-peer pruning but never emits manifests, and
+// getManifestsMessage (OverlayImpl.cpp:1185) is invoked only from
+// PeerImp::run after each handshake. That on-connect-only model
+// leaves peers who join after our boot burst depending on an
+// indirect relay; this loop closes the gap. Duplicate frames are
+// wire-compatible — rippled returns Stale via applyManifest
+// (Manifest.cpp:399).
+const periodicManifestBroadcastInterval = 5 * time.Minute
 
 // Start launches all background goroutines (overlay, engine, router).
 func (c *Components) Start() error {
@@ -61,11 +75,42 @@ func (c *Components) Start() error {
 	c.routerCancel = routerCancel
 	go c.Router.Run(routerCtx)
 
+	// Periodic re-emission. Cheap when there's nothing to broadcast:
+	// the emission path short-circuits on an empty / unwired cache.
+	periodicCtx, periodicCancel := context.WithCancel(context.Background())
+	c.manifestPeriodicCancel = periodicCancel
+	go c.runPeriodicManifestBroadcast(periodicCtx, periodicManifestBroadcastInterval)
+
 	return nil
+}
+
+// runPeriodicManifestBroadcast re-emits the cached manifest frame on
+// the configured tick. Skip cases (empty / unwired cache, no peers)
+// are handled inside BroadcastLocalManifest.
+func (c *Components) runPeriodicManifestBroadcast(ctx context.Context, interval time.Duration) {
+	if c.Router == nil || interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if n := c.Router.BroadcastLocalManifest(); n > 0 {
+				slog.Info("periodic local manifest broadcast",
+					"t", "Components.runPeriodicManifestBroadcast", "peers", n)
+			}
+		}
+	}
 }
 
 // Stop gracefully shuts down all components.
 func (c *Components) Stop() {
+	if c.manifestPeriodicCancel != nil {
+		c.manifestPeriodicCancel()
+	}
 	if c.routerCancel != nil {
 		c.routerCancel()
 	}

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -84,9 +84,6 @@ func (c *Components) Start() error {
 	return nil
 }
 
-// runPeriodicManifestBroadcast re-emits the cached manifest frame on
-// the configured tick. Skip cases (empty / unwired cache, no peers)
-// are handled inside BroadcastLocalManifest.
 func (c *Components) runPeriodicManifestBroadcast(ctx context.Context, interval time.Duration) {
 	if c.Router == nil || interval <= 0 {
 		return


### PR DESCRIPTION
Sub-issue of #360. Stacked on #377 (#372).

## Summary

Closes the long-tail manifest gossip behavior on top of #372: peers that join after our boot burst still learn our master↔signing binding without waiting for an unrelated gossip wave.

- `internal/consensus/adaptor/startup.go`: `runPeriodicManifestBroadcast` ticks every 5 minutes (matching rippled's `OverlayImpl` periodic loop) and calls `Router.BroadcastLocalManifest`. Cancellable on `Components.Stop`; silent on observer / seed-only mode (the emitter short-circuits).
- `internal/consensus/adaptor/manifest_emit.go`: `localManifestBytes` now consults the manifest cache before returning anything. If the cache has a strictly higher sequence for our master key, log a warning and return nil — protects against re-broadcasting an outdated manifest when another node sharing the master has already rotated past us. `masterKeyHex` keeps log lines scannable without leaking the full pubkey.

## Manifest rotation

Documented as restart-only: operators update `[validator_token]` and restart the process; the periodic broadcast propagates the new manifest within one interval.

Live SIGHUP reload is intentionally out of scope — `cmd/xrpld` has no config-reload pipeline to hang it on, and the issue text explicitly accepts either approach (\"Add a SIGHUP handler ... Or document that rotation requires a process restart\").

## Test plan

- [x] 50ms-interval ticker fires multiple broadcasts within 500ms (`TestPeriodicManifestBroadcast_FiresOnInterval`)
- [x] Loop stops cleanly on context cancel — no broadcasts observed after Stop (`TestPeriodicManifestBroadcast_StopsOnContextCancel`)
- [x] Observer mode emits nothing through several intervals (`TestPeriodicManifestBroadcast_NoManifestSilent`)
- [x] Sequence guard skips emission when `cache_seq > local_seq` (`TestLocalManifestBytes_SequenceSupersededSkips`)
- [x] Sequence guard emits at equality — steady state where a peer relayed our own manifest back (`TestLocalManifestBytes_EqualSequenceEmits`)
- [x] `go test ./internal/consensus/adaptor/... ./internal/peermanagement/...` — pass
- [x] `go build` for `cmd/xrpld` (CGO + OpenSSL) — clean