### PR TITLE
consensus: port FeeVote producer algorithm (refs #369)

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -558,11 +558,20 @@ func (a *Adaptor) GetPendingTxs() [][]byte {
 	return blobs
 }
 
-// GenerateFlagLedgerPseudoTxs is a stub: vote-tally producers (fee
-// vote, amendment vote) are not yet implemented in goXRPL. See
-// follow-up issues #369 (fee) and #370 (amendments). Returns nil so
-// the engine's injection step at closeLedger is a no-op until those
-// land — matching the pre-#367 behavior of never injecting.
+// GenerateFlagLedgerPseudoTxs is currently a stub. The fee-vote
+// algorithm lives in internal/consensus/feevote (ported in #369)
+// and is exercised by package-level tests against synthetic vote
+// inputs; the amendment-vote producer is still TODO (#370).
+//
+// Wiring fee-vote into this method needs the same per-seq
+// validation history extension to ValidationTracker called out on
+// GenerateNegativeUNLPseudoTx below — once that lands, the fee
+// votes can be extracted from the prior voting ledger's
+// validations and fed into feevote.DoVoting.
+//
+// Returning nil keeps the engine's injection step a no-op until
+// the wiring lands — matching the pre-#367 behavior of never
+// injecting.
 func (a *Adaptor) GenerateFlagLedgerPseudoTxs(_ consensus.Ledger) [][]byte {
 	return nil
 }

--- a/internal/consensus/feevote/vote.go
+++ b/internal/consensus/feevote/vote.go
@@ -29,20 +29,24 @@
 package feevote
 
 import (
-	"encoding/hex"
 	"fmt"
+	"math"
+	"sort"
 	"strconv"
 
-	"github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
 )
 
-// MaxLegalDrops is the upper bound on a single XRPAmount field
-// value. Mirrors rippled's isLegalAmountSigned check at
-// FeeVoteImpl.cpp:225-228 — values exceeding this are silently
-// treated as "no vote" rather than errors. 100 billion XRP * 10⁶
-// drops/XRP. Matches codec/binarycodec/types.MaxDrops.
+// MaxLegalDrops is the upper bound on a legal XRPAmount, equal to
+// INITIAL_XRP (1e17 drops = 100 billion XRP). Mirrors rippled's
+// isLegalAmountSigned check at SystemParameters.h:55-59 — values
+// exceeding this are silently treated as "no vote" rather than
+// errors. rippled also rejects amounts below -INITIAL_XRP, but Vote
+// fields are *uint64 so the negative branch is structurally
+// unreachable here. Any extractor that builds Vote from an
+// STValidation MUST clamp negative XRPAmounts to noVote before
+// reaching this layer.
 const MaxLegalDrops uint64 = 100_000_000_000 * 1_000_000
 
 // ReferenceFeeUnitsDeprecated is the legacy sfReferenceFeeUnits
@@ -53,8 +57,9 @@ const ReferenceFeeUnitsDeprecated uint32 = 10
 // Stance is the three vote-able fee parameters (in drops) — both
 // the parent ledger's "current" and the validator's preferred
 // "target" use this shape. ReserveBase / ReserveIncrement are
-// uint32 in the pre-XRPFees wire format but always representable
-// as uint64 drops in memory.
+// uint32 in the pre-XRPFees wire format; values above UINT32_MAX
+// fall back to current at emission time, mirroring rippled's
+// dropsAs<uint32>(current) at FeeVoteImpl.cpp:312-316.
 type Stance struct {
 	BaseFee          uint64
 	ReserveBase      uint64
@@ -100,24 +105,32 @@ func (v *votableValue) noVote() {
 }
 
 // getVotes returns (chosen, changed). chosen is the most-voted
-// value within [min(current, target), max(current, target)];
-// changed indicates whether chosen differs from current. Mirrors
-// VotableValue::getVotes at FeeVoteImpl.cpp:69-86.
+// value within [min(current, target), max(current, target)] —
+// votes outside that range are clamped out. On ties, the lowest
+// in-window key wins, matching rippled's std::map ascending-key
+// iteration with strict `val > weight` at FeeVoteImpl.cpp:69-86.
+// changed indicates whether chosen differs from current.
 func (v *votableValue) getVotes() (uint64, bool) {
 	lo, hi := v.current, v.target
 	if lo > hi {
 		lo, hi = hi, lo
 	}
 
+	keys := make([]uint64, 0, len(v.votes))
+	for k := range v.votes {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
 	chosen := v.current
 	weight := 0
-	for value, count := range v.votes {
+	for _, value := range keys {
 		if value < lo || value > hi {
 			continue
 		}
-		if count > weight {
+		if v.votes[value] > weight {
 			chosen = value
-			weight = count
+			weight = v.votes[value]
 		}
 	}
 	return chosen, chosen != v.current
@@ -167,14 +180,14 @@ func DoVoting(
 		ReserveBase:      chosenReserveBase,
 		ReserveIncrement: chosenReserveIncrement,
 	}
-	return buildSetFeeTx(upcomingSeq, chosen, xrpFeesEnabled)
+	return buildSetFeeTx(upcomingSeq, current, chosen, xrpFeesEnabled)
 }
 
-// applyVote calls addVote with field's value when set and within
-// [0, MaxLegalDrops], or noVote otherwise. Out-of-range values are
-// clamped out at the per-field level so a single bad field doesn't
-// poison the rest of a validator's votes — matching rippled's
-// isLegalAmountSigned check at FeeVoteImpl.cpp:225-262.
+// applyVote routes a per-validator field vote into the tally.
+// Missing fields and overflow values both count as a vote for
+// current (noVote), so a single bad field does not poison the
+// rest of a validator's votes — matching rippled's
+// isLegalAmountSigned guard at FeeVoteImpl.cpp:222-262.
 func applyVote(v *votableValue, field *uint64) {
 	if field == nil || *field > MaxLegalDrops {
 		v.noVote()
@@ -183,51 +196,42 @@ func applyVote(v *votableValue, field *uint64) {
 	v.addVote(*field)
 }
 
-// zeroAccount is the base58-encoded all-zero AccountID used as the
-// source on every pseudo-transaction (rippled AccountID()). The
-// wire form serializes to a 20-byte zero blob.
-const zeroAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
-
 // buildSetFeeTx serializes a SetFee pseudo-tx. Pre-XRPFees uses
 // sfBaseFee (uint64) / sfReserveBase (uint32) / sfReserveIncrement
 // (uint32) / sfReferenceFeeUnits; post-XRPFees uses sfBaseFeeDrops
 // / sfReserveBaseDrops / sfReserveIncrementDrops (XRPAmount-as-
 // string). Mirrors FeeVoteImpl.cpp:297-319.
-func buildSetFeeTx(seq uint32, chosen Stance, xrpFeesEnabled bool) ([]byte, error) {
-	zeroSeq := uint32(0)
+func buildSetFeeTx(seq uint32, current, chosen Stance, xrpFeesEnabled bool) ([]byte, error) {
 	stx := &pseudo.SetFee{
-		BaseTx:         *tx.NewBaseTx(tx.TypeFee, zeroAccount),
+		BaseTx:         *tx.NewBaseTx(tx.TypeFee, pseudo.ZeroAccount),
 		LedgerSequence: &seq,
 	}
-	stx.Common.Fee = "0"
-	stx.Common.SigningPubKey = ""
-	stx.Common.Sequence = &zeroSeq
 
 	if xrpFeesEnabled {
 		stx.BaseFeeDrops = strconv.FormatUint(chosen.BaseFee, 10)
 		stx.ReserveBaseDrops = strconv.FormatUint(chosen.ReserveBase, 10)
 		stx.ReserveIncrementDrops = strconv.FormatUint(chosen.ReserveIncrement, 10)
 	} else {
-		// Pre-XRPFees: sfBaseFee is uint64 hex, sfReserveBase /
-		// sfReserveIncrement are uint32. ReferenceFeeUnits is
-		// required and always 10 (FEE_UNITS_DEPRECATED).
-		baseFeeHex := fmt.Sprintf("%X", chosen.BaseFee)
-		stx.BaseFee = baseFeeHex
-		rb := uint32(chosen.ReserveBase)
+		stx.BaseFee = fmt.Sprintf("%X", chosen.BaseFee)
+		rb := narrowToUint32(chosen.ReserveBase, current.ReserveBase)
 		stx.ReserveBase = &rb
-		ri := uint32(chosen.ReserveIncrement)
+		ri := narrowToUint32(chosen.ReserveIncrement, current.ReserveIncrement)
 		stx.ReserveIncrement = &ri
 		ref := ReferenceFeeUnitsDeprecated
 		stx.ReferenceFeeUnits = &ref
 	}
 
-	flat, err := stx.Flatten()
-	if err != nil {
-		return nil, fmt.Errorf("flatten SetFee: %w", err)
+	return pseudo.EncodePseudoTx(stx)
+}
+
+// narrowToUint32 returns chosen as uint32, or fallback if chosen
+// exceeds UINT32_MAX. Mirrors rippled's
+// dropsAs<std::uint32_t>(current) at FeeVoteImpl.cpp:312-316: if
+// the chosen XRPAmount cannot fit in uint32, fall back to the
+// current ledger setting rather than silently truncating.
+func narrowToUint32(chosen, fallback uint64) uint32 {
+	if chosen > math.MaxUint32 {
+		return uint32(fallback)
 	}
-	hexStr, err := binarycodec.Encode(flat)
-	if err != nil {
-		return nil, fmt.Errorf("encode SetFee: %w", err)
-	}
-	return hex.DecodeString(hexStr)
+	return uint32(chosen)
 }

--- a/internal/consensus/feevote/vote.go
+++ b/internal/consensus/feevote/vote.go
@@ -1,0 +1,233 @@
+// Package feevote ports rippled's FeeVoteImpl
+// (src/xrpld/app/misc/FeeVoteImpl.cpp) — the producer side that
+// decides whether to inject a SetFee pseudo-tx into the consensus
+// tx set on a flag-ledger boundary, based on trusted validators'
+// fee votes from the prior voting ledger.
+//
+// The algorithm:
+//
+//  1. Initialize three VotableValues (baseFee, reserveBase,
+//     reserveIncrement) seeded with the parent ledger's current
+//     fees and the local validator's preferred target. Each
+//     constructor pre-increments voteMap[target], which represents
+//     the local validator's stance.
+//
+//  2. For each trusted validation, extract the fee fields and
+//     addVote() the value (or noVote() if the field is missing or
+//     out of legal range — counts as a vote for current).
+//
+//  3. getVotes() picks the most-voted value WITHIN
+//     [min(current, target), max(current, target)] — votes outside
+//     that window are clamped out. The chosen value flips
+//     `changed` if it differs from current.
+//
+//  4. If any of the three changed, build a SetFee pseudo-tx with
+//     all three values (chosen-or-current) and the upcoming
+//     ledger sequence. Pre-XRPFees uses sfBaseFee/sfReserveBase/
+//     sfReserveIncrement/sfReferenceFeeUnits; post-XRPFees uses
+//     sfBaseFeeDrops/sfReserveBaseDrops/sfReserveIncrementDrops.
+package feevote
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+)
+
+// MaxLegalDrops is the upper bound on a single XRPAmount field
+// value. Mirrors rippled's isLegalAmountSigned check at
+// FeeVoteImpl.cpp:225-228 — values exceeding this are silently
+// treated as "no vote" rather than errors. 100 billion XRP * 10⁶
+// drops/XRP. Matches codec/binarycodec/types.MaxDrops.
+const MaxLegalDrops uint64 = 100_000_000_000 * 1_000_000
+
+// ReferenceFeeUnitsDeprecated is the legacy sfReferenceFeeUnits
+// value rippled stamps on every pre-XRPFees SetFee pseudo-tx
+// (FeeVoteImpl.cpp:317 → Config::FEE_UNITS_DEPRECATED == 10).
+const ReferenceFeeUnitsDeprecated uint32 = 10
+
+// Stance is the three vote-able fee parameters (in drops) — both
+// the parent ledger's "current" and the validator's preferred
+// "target" use this shape. ReserveBase / ReserveIncrement are
+// uint32 in the pre-XRPFees wire format but always representable
+// as uint64 drops in memory.
+type Stance struct {
+	BaseFee          uint64
+	ReserveBase      uint64
+	ReserveIncrement uint64
+}
+
+// Vote is one trusted validator's per-field fee preference,
+// extracted from sfBaseFee / sfReserveBase / sfReserveIncrement
+// (pre-XRPFees) or the *Drops variants (post-XRPFees) on their
+// STValidation. Each field is independent: a validator may emit
+// any subset, and a missing or out-of-range value is treated as
+// "noVote" — counted as a vote for current at tally time.
+type Vote struct {
+	BaseFee          *uint64
+	ReserveBase      *uint64
+	ReserveIncrement *uint64
+}
+
+// votableValue is the per-field tallying state. Mirrors rippled's
+// detail::VotableValue at FeeVoteImpl.cpp:31-86.
+type votableValue struct {
+	current uint64
+	target  uint64
+	votes   map[uint64]int
+}
+
+func newVotableValue(current, target uint64) *votableValue {
+	v := &votableValue{
+		current: current,
+		target:  target,
+		votes:   map[uint64]int{},
+	}
+	v.votes[target]++
+	return v
+}
+
+func (v *votableValue) addVote(value uint64) {
+	v.votes[value]++
+}
+
+func (v *votableValue) noVote() {
+	v.votes[v.current]++
+}
+
+// getVotes returns (chosen, changed). chosen is the most-voted
+// value within [min(current, target), max(current, target)];
+// changed indicates whether chosen differs from current. Mirrors
+// VotableValue::getVotes at FeeVoteImpl.cpp:69-86.
+func (v *votableValue) getVotes() (uint64, bool) {
+	lo, hi := v.current, v.target
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+
+	chosen := v.current
+	weight := 0
+	for value, count := range v.votes {
+		if value < lo || value > hi {
+			continue
+		}
+		if count > weight {
+			chosen = value
+			weight = count
+		}
+	}
+	return chosen, chosen != v.current
+}
+
+// DoVoting tallies trusted validators' fee votes from the
+// validations of the prior voting ledger and returns a serialized
+// SetFee pseudo-tx blob if any of the three settings would
+// change, or nil otherwise.
+//
+// upcomingSeq is the sequence the SetFee tx will carry (parent +
+// 1). current is the parent ledger's fee setup; target is the
+// local validator's preferred stance. votes are the trusted
+// validations' fee votes (the local validator's stance is already
+// represented by target — getVotes seeds +1 for target in the
+// constructor, so the local stance is implicit).
+//
+// xrpFeesEnabled selects the pre-XRPFees vs post-XRPFees wire
+// format. Both use the same algorithm; only the SetFee field set
+// differs.
+func DoVoting(
+	upcomingSeq uint32,
+	current, target Stance,
+	votes []Vote,
+	xrpFeesEnabled bool,
+) ([]byte, error) {
+	baseFee := newVotableValue(current.BaseFee, target.BaseFee)
+	reserveBase := newVotableValue(current.ReserveBase, target.ReserveBase)
+	reserveIncrement := newVotableValue(current.ReserveIncrement, target.ReserveIncrement)
+
+	for _, v := range votes {
+		applyVote(baseFee, v.BaseFee)
+		applyVote(reserveBase, v.ReserveBase)
+		applyVote(reserveIncrement, v.ReserveIncrement)
+	}
+
+	chosenBase, baseChanged := baseFee.getVotes()
+	chosenReserveBase, reserveBaseChanged := reserveBase.getVotes()
+	chosenReserveIncrement, reserveIncrementChanged := reserveIncrement.getVotes()
+
+	if !baseChanged && !reserveBaseChanged && !reserveIncrementChanged {
+		return nil, nil
+	}
+
+	chosen := Stance{
+		BaseFee:          chosenBase,
+		ReserveBase:      chosenReserveBase,
+		ReserveIncrement: chosenReserveIncrement,
+	}
+	return buildSetFeeTx(upcomingSeq, chosen, xrpFeesEnabled)
+}
+
+// applyVote calls addVote with field's value when set and within
+// [0, MaxLegalDrops], or noVote otherwise. Out-of-range values are
+// clamped out at the per-field level so a single bad field doesn't
+// poison the rest of a validator's votes — matching rippled's
+// isLegalAmountSigned check at FeeVoteImpl.cpp:225-262.
+func applyVote(v *votableValue, field *uint64) {
+	if field == nil || *field > MaxLegalDrops {
+		v.noVote()
+		return
+	}
+	v.addVote(*field)
+}
+
+// zeroAccount is the base58-encoded all-zero AccountID used as the
+// source on every pseudo-transaction (rippled AccountID()). The
+// wire form serializes to a 20-byte zero blob.
+const zeroAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+
+// buildSetFeeTx serializes a SetFee pseudo-tx. Pre-XRPFees uses
+// sfBaseFee (uint64) / sfReserveBase (uint32) / sfReserveIncrement
+// (uint32) / sfReferenceFeeUnits; post-XRPFees uses sfBaseFeeDrops
+// / sfReserveBaseDrops / sfReserveIncrementDrops (XRPAmount-as-
+// string). Mirrors FeeVoteImpl.cpp:297-319.
+func buildSetFeeTx(seq uint32, chosen Stance, xrpFeesEnabled bool) ([]byte, error) {
+	zeroSeq := uint32(0)
+	stx := &pseudo.SetFee{
+		BaseTx:         *tx.NewBaseTx(tx.TypeFee, zeroAccount),
+		LedgerSequence: &seq,
+	}
+	stx.Common.Fee = "0"
+	stx.Common.SigningPubKey = ""
+	stx.Common.Sequence = &zeroSeq
+
+	if xrpFeesEnabled {
+		stx.BaseFeeDrops = strconv.FormatUint(chosen.BaseFee, 10)
+		stx.ReserveBaseDrops = strconv.FormatUint(chosen.ReserveBase, 10)
+		stx.ReserveIncrementDrops = strconv.FormatUint(chosen.ReserveIncrement, 10)
+	} else {
+		// Pre-XRPFees: sfBaseFee is uint64 hex, sfReserveBase /
+		// sfReserveIncrement are uint32. ReferenceFeeUnits is
+		// required and always 10 (FEE_UNITS_DEPRECATED).
+		baseFeeHex := fmt.Sprintf("%X", chosen.BaseFee)
+		stx.BaseFee = baseFeeHex
+		rb := uint32(chosen.ReserveBase)
+		stx.ReserveBase = &rb
+		ri := uint32(chosen.ReserveIncrement)
+		stx.ReserveIncrement = &ri
+		ref := ReferenceFeeUnitsDeprecated
+		stx.ReferenceFeeUnits = &ref
+	}
+
+	flat, err := stx.Flatten()
+	if err != nil {
+		return nil, fmt.Errorf("flatten SetFee: %w", err)
+	}
+	hexStr, err := binarycodec.Encode(flat)
+	if err != nil {
+		return nil, fmt.Errorf("encode SetFee: %w", err)
+	}
+	return hex.DecodeString(hexStr)
+}

--- a/internal/consensus/feevote/vote.go
+++ b/internal/consensus/feevote/vote.go
@@ -72,6 +72,22 @@ type Stance struct {
 // STValidation. Each field is independent: a validator may emit
 // any subset, and a missing or out-of-range value is treated as
 // "noVote" — counted as a vote for current at tally time.
+//
+// Preconditions on extractor (the future STValidation→Vote
+// adapter, deferred per #369): the extractor MUST set the field
+// to nil ("noVote") when:
+//
+//   - post-XRPFees: the STAmount is non-native (IOU). Mirrors
+//     FeeVoteImpl.cpp:222 (`field->native()` guard).
+//   - pre-XRPFees: the STUInt64 exceeds INT64_MAX. Mirrors
+//     FeeVoteImpl.cpp:254 (`vote <= numeric_limits<int64>::max()`
+//     guard, which precedes isLegalAmountSigned).
+//   - either mode: the XRPAmount is negative. Mirrors
+//     isLegalAmountSigned's lower bound at SystemParameters.h:58.
+//
+// applyVote here only enforces the upper bound (MaxLegalDrops);
+// the other three conditions are structurally unrepresentable in
+// *uint64 and so MUST be filtered upstream.
 type Vote struct {
 	BaseFee          *uint64
 	ReserveBase      *uint64
@@ -229,6 +245,14 @@ func buildSetFeeTx(seq uint32, current, chosen Stance, xrpFeesEnabled bool) ([]b
 // dropsAs<std::uint32_t>(current) at FeeVoteImpl.cpp:312-316: if
 // the chosen XRPAmount cannot fit in uint32, fall back to the
 // current ledger setting rather than silently truncating.
+//
+// If fallback itself exceeds UINT32_MAX the low 32 bits are
+// returned. This is unreachable on any real ledger — pre-XRPFees
+// reserves are sourced from on-chain FeeSettings whose uint32
+// fields cannot exceed UINT32_MAX by construction. Documented
+// here so the divergence from rippled's `T(drops_)` cast (which
+// is implementation-defined for an out-of-range XRPAmount) is
+// explicit.
 func narrowToUint32(chosen, fallback uint64) uint32 {
 	if chosen > math.MaxUint32 {
 		return uint32(fallback)

--- a/internal/consensus/feevote/vote_test.go
+++ b/internal/consensus/feevote/vote_test.go
@@ -212,22 +212,27 @@ func TestVotableValue_PicksHighestCountWithinWindow(t *testing.T) {
 // Without this guarantee, two goXRPL nodes given identical inputs
 // could pick different values from Go's randomized map iteration —
 // the resulting SetFee blobs would diverge across the network.
+//
+// The case is constructed so two distinct in-window keys (11 and
+// 13) reach the same vote count (2), and that count strictly
+// exceeds every other in-window key's count. Under ascending-key
+// iteration with `val > weight`, the first key to reach the max
+// wins (11); a `val >= weight` bug, descending iteration, or
+// random map-order would let 13 win on at least some runs.
 func TestVotableValue_TieBreakLowestKeyWins(t *testing.T) {
-	// Run repeatedly: a non-deterministic implementation would
-	// occasionally pick 12 or 13 across iterations; the
-	// deterministic implementation always picks 11.
 	for i := 0; i < 64; i++ {
 		v := newVotableValue(10, 14) // window = [10, 14], seeds voteMap[14]=1
 		v.addVote(11)
-		v.addVote(12)
+		v.addVote(11)
 		v.addVote(13)
-		// All four values now have count 1 — first ascending-key
-		// in-window value wins → 11 (10 == current loses on
-		// strict `count > weight`).
+		v.addVote(13)
+		// voteMap = {11:2, 13:2, 14:1}. Both 11 and 13 are in
+		// window and tied at the max count. Ascending iteration
+		// with strict-greater picks the first to reach the max → 11.
 		chosen, changed := v.getVotes()
 		assert.True(t, changed)
 		assert.EqualValues(t, 11, chosen,
-			"iter %d: tie at count=1 → lowest in-window key (11) wins, not %d", i, chosen)
+			"iter %d: tie at count=2 between 11 and 13 → lowest in-window key (11) wins, not %d", i, chosen)
 	}
 }
 
@@ -248,17 +253,51 @@ func TestBuildSetFeeTx_EmitsEmptySigningPubKey(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, blob)
 
-		// Empty sfSigningPubKey serializes as the two bytes 0x73 0x00.
-		// We assert the byte sequence appears anywhere in the blob —
-		// canonical-sort field order is verified by the codec
-		// round-trip below.
-		assert.Contains(t, hex.EncodeToString(blob), "7300",
-			"xrpFeesEnabled=%v: blob must include sfSigningPubKey VL(0)", xrpFees)
+		// Empty sfSigningPubKey serializes as 0x73 0x00 followed by
+		// the next-larger field tag in canonical sort order. After
+		// sfSigningPubKey (code 0x73) the next present common field
+		// in a pseudo-tx is sfAccount (code 0x81). Asserting the
+		// 3-byte sequence "730081" pins both the empty VL byte and
+		// its position in the sort order.
+		assert.Contains(t, hex.EncodeToString(blob), "730081",
+			"xrpFeesEnabled=%v: blob must include sfSigningPubKey VL(0) followed by sfAccount", xrpFees)
 
 		stx := decodeTx(t, blob)
 		got, ok := stx["SigningPubKey"]
 		assert.True(t, ok, "xrpFeesEnabled=%v: decoded tx must include SigningPubKey", xrpFees)
 		assert.Equal(t, "", got, "xrpFeesEnabled=%v: SigningPubKey must decode as empty", xrpFees)
+	}
+}
+
+// TestBuildSetFeeTx_OmitsFlags pins the inverse of the
+// SigningPubKey requirement: rippled declares sfFlags as
+// soeOPTIONAL in the common-fields template (TxFormats.cpp:34) and
+// FeeVoteImpl::doVoting (FeeVoteImpl.cpp:297-319) never sets it on
+// the assembled STTx, so STObject::set(SOTemplate) at
+// STObject.cpp:156-169 leaves it as STI_NOTPRESENT and
+// STObject::add at STObject.cpp:907-921 filters it out of the
+// serialized blob. The Go encoder must match — emitting Flags=0
+// would prepend `2200000000` to the blob, shift every later field,
+// and produce a different transaction ID. Validators that disagree
+// on the txID cannot converge their SHAMaps on the flag-ledger
+// pseudo-tx position, so consensus on the fee change fails.
+func TestBuildSetFeeTx_OmitsFlags(t *testing.T) {
+	current := Stance{BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+	target := Stance{BaseFee: 12, ReserveBase: 11_000_000, ReserveIncrement: 2_500_000}
+
+	for _, xrpFees := range []bool{false, true} {
+		blob, err := DoVoting(1024, current, target, nil, xrpFees)
+		require.NoError(t, err)
+		require.NotNil(t, blob)
+
+		hexBlob := hex.EncodeToString(blob)
+		assert.NotContains(t, hexBlob, "2200000000",
+			"xrpFeesEnabled=%v: blob must not carry sfFlags=0 (rippled omits soeOPTIONAL nonPresent fields)", xrpFees)
+
+		stx := decodeTx(t, blob)
+		_, hasFlags := stx["Flags"]
+		assert.False(t, hasFlags,
+			"xrpFeesEnabled=%v: decoded tx must not include Flags", xrpFees)
 	}
 }
 

--- a/internal/consensus/feevote/vote_test.go
+++ b/internal/consensus/feevote/vote_test.go
@@ -193,10 +193,7 @@ func TestDoVoting_LedgerSequenceIsUpcoming(t *testing.T) {
 
 // TestVotableValue_PicksHighestCountWithinWindow exercises the
 // inner getVotes loop directly: the most-voted in-window value
-// wins, ties broken by iteration order (rippled accepts whichever
-// entry the first reaches `> weight`, so it's effectively a
-// "last-tied wins" pattern that depends on map iteration; we
-// match this without testing tie ordering).
+// wins.
 func TestVotableValue_PicksHighestCountWithinWindow(t *testing.T) {
 	v := newVotableValue(10, 14) // window = [10, 14]
 	v.addVote(11)
@@ -205,6 +202,94 @@ func TestVotableValue_PicksHighestCountWithinWindow(t *testing.T) {
 	chosen, changed := v.getVotes()
 	assert.True(t, changed)
 	assert.EqualValues(t, 11, chosen, "11 has 2 votes, beats 13 (1) and seed-target 14 (1)")
+}
+
+// TestVotableValue_TieBreakLowestKeyWins pins the deterministic
+// tie-break order: with two in-window values at equal vote counts,
+// the lowest key wins. Mirrors rippled's std::map ascending-key
+// iteration with strict `val > weight` at FeeVoteImpl.cpp:74-83.
+//
+// Without this guarantee, two goXRPL nodes given identical inputs
+// could pick different values from Go's randomized map iteration —
+// the resulting SetFee blobs would diverge across the network.
+func TestVotableValue_TieBreakLowestKeyWins(t *testing.T) {
+	// Run repeatedly: a non-deterministic implementation would
+	// occasionally pick 12 or 13 across iterations; the
+	// deterministic implementation always picks 11.
+	for i := 0; i < 64; i++ {
+		v := newVotableValue(10, 14) // window = [10, 14], seeds voteMap[14]=1
+		v.addVote(11)
+		v.addVote(12)
+		v.addVote(13)
+		// All four values now have count 1 — first ascending-key
+		// in-window value wins → 11 (10 == current loses on
+		// strict `count > weight`).
+		chosen, changed := v.getVotes()
+		assert.True(t, changed)
+		assert.EqualValues(t, 11, chosen,
+			"iter %d: tie at count=1 → lowest in-window key (11) wins, not %d", i, chosen)
+	}
+}
+
+// TestBuildSetFeeTx_EmitsEmptySigningPubKey pins the wire-format
+// requirement that pseudo-tx blobs carry sfSigningPubKey as an
+// empty VL (field code 0x73, length 0x00). rippled's STTx ctor at
+// STTx.cpp:113-128 calls set(format->getSOTemplate()), inserting a
+// default-constructed empty Blob for every REQUIRED common field
+// (TxFormats.cpp:32-50); STObject::add at STObject.cpp:881-921
+// then serializes the empty Blob. Omitting it changes the blob
+// length and hence the txID — diverging consensus.
+func TestBuildSetFeeTx_EmitsEmptySigningPubKey(t *testing.T) {
+	current := Stance{BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+	target := Stance{BaseFee: 12, ReserveBase: 11_000_000, ReserveIncrement: 2_500_000}
+
+	for _, xrpFees := range []bool{false, true} {
+		blob, err := DoVoting(1024, current, target, nil, xrpFees)
+		require.NoError(t, err)
+		require.NotNil(t, blob)
+
+		// Empty sfSigningPubKey serializes as the two bytes 0x73 0x00.
+		// We assert the byte sequence appears anywhere in the blob —
+		// canonical-sort field order is verified by the codec
+		// round-trip below.
+		assert.Contains(t, hex.EncodeToString(blob), "7300",
+			"xrpFeesEnabled=%v: blob must include sfSigningPubKey VL(0)", xrpFees)
+
+		stx := decodeTx(t, blob)
+		got, ok := stx["SigningPubKey"]
+		assert.True(t, ok, "xrpFeesEnabled=%v: decoded tx must include SigningPubKey", xrpFees)
+		assert.Equal(t, "", got, "xrpFeesEnabled=%v: SigningPubKey must decode as empty", xrpFees)
+	}
+}
+
+// TestBuildSetFeeTx_PreXRPFeesReserveOverflowFallsBackToCurrent
+// pins the dropsAs<uint32>(current) fallback at
+// FeeVoteImpl.cpp:312-316: when the chosen pre-XRPFees ReserveBase
+// or ReserveIncrement does not fit in uint32, rippled emits the
+// CURRENT value, not a silent truncation of chosen.
+//
+// Triggered here by setting target above UINT32_MAX so getVotes
+// picks an out-of-range value. The window
+// [current, target] then spans up to 2^33, and the seeded
+// voteMap[target]=1 wins because no other vote is in the window.
+func TestBuildSetFeeTx_PreXRPFeesReserveOverflowFallsBackToCurrent(t *testing.T) {
+	overflow := uint64(1) << 33 // > UINT32_MAX
+	current := Stance{BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+	target := Stance{
+		BaseFee:          11,
+		ReserveBase:      overflow,
+		ReserveIncrement: overflow,
+	}
+
+	blob, err := DoVoting(1024, current, target, nil, false /* pre-XRPFees */)
+	require.NoError(t, err)
+	require.NotNil(t, blob, "BaseFee changed → tx emitted")
+
+	stx := decodeTx(t, blob)
+	assert.EqualValues(t, current.ReserveBase, asUint(stx["ReserveBase"]),
+		"chosen ReserveBase > UINT32_MAX → fall back to current, not truncate")
+	assert.EqualValues(t, current.ReserveIncrement, asUint(stx["ReserveIncrement"]),
+		"chosen ReserveIncrement > UINT32_MAX → fall back to current")
 }
 
 func decodeTx(t *testing.T, blob []byte) map[string]any {

--- a/internal/consensus/feevote/vote_test.go
+++ b/internal/consensus/feevote/vote_test.go
@@ -1,0 +1,257 @@
+package feevote
+
+import (
+	"encoding/hex"
+	"strconv"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ptr wraps a uint64 for the pointer-set Vote fields.
+func ptr(x uint64) *uint64 { return &x }
+
+// TestDoVoting_NoChangeNoTx pins the early-return path when the
+// chosen value matches current for all three fields. Mirrors
+// FeeVoteImpl.cpp:291 (the `||` gate) — if nothing changed, no
+// SetFee tx is emitted.
+func TestDoVoting_NoChangeNoTx(t *testing.T) {
+	current := Stance{BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+	target := current // unchanged → no votes for anything outside current
+
+	blob, err := DoVoting(1024, current, target, nil, true)
+	require.NoError(t, err)
+	assert.Nil(t, blob, "no change → no SetFee tx")
+}
+
+// TestDoVoting_TargetSeededAsInitialVote verifies the constructor
+// quirk at FeeVoteImpl.cpp:44 — voteMap[target] is pre-incremented
+// in the constructor, so a single trusted validator at target with
+// no other votes is enough to pick target as consensus.
+func TestDoVoting_TargetSeededAsInitialVote(t *testing.T) {
+	current := Stance{BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+	target := Stance{BaseFee: 12, ReserveBase: 15_000_000, ReserveIncrement: 3_000_000}
+
+	// No additional votes — only the constructor's seed.
+	blob, err := DoVoting(1024, current, target, nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, blob, "constructor seeds target → consensus picks target")
+
+	stx := decodeTx(t, blob)
+	assert.Equal(t, "12", stx["BaseFeeDrops"])
+	assert.Equal(t, "15000000", stx["ReserveBaseDrops"])
+	assert.Equal(t, "3000000", stx["ReserveIncrementDrops"])
+}
+
+// TestDoVoting_VoteOutsideWindowIgnored pins the
+// [min(current, target), max(current, target)] clamp at
+// VotableValue::getVotes (FeeVoteImpl.cpp:74-83). A vote far
+// outside that range cannot be picked, so a single in-window seed
+// (target) wins.
+func TestDoVoting_VoteOutsideWindowIgnored(t *testing.T) {
+	current := Stance{BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+	target := Stance{BaseFee: 12, ReserveBase: 11_000_000, ReserveIncrement: 2_500_000}
+
+	// Three votes way outside [10,12] for BaseFee. They should be
+	// dropped at getVotes time even though they outnumber the seed.
+	votes := []Vote{
+		{BaseFee: ptr(99)},
+		{BaseFee: ptr(99)},
+		{BaseFee: ptr(99)},
+	}
+
+	blob, err := DoVoting(1024, current, target, votes, true)
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+	stx := decodeTx(t, blob)
+	assert.Equal(t, "12", stx["BaseFeeDrops"],
+		"votes outside [current, target] window must not be picked")
+}
+
+// TestDoVoting_NoVoteCountsAsCurrent pins the noVote semantics at
+// VotableValue::noVote (FeeVoteImpl.cpp:53-57). A field absent on
+// a validator's vote increments voteMap[current], so abstainers on
+// that specific field pull the consensus toward current — even
+// while the validator still votes for target on the other fields.
+func TestDoVoting_NoVoteCountsAsCurrent(t *testing.T) {
+	current := Stance{BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+	target := Stance{BaseFee: 12, ReserveBase: 11_000_000, ReserveIncrement: 2_500_000}
+
+	// Three validators agree on target for the two reserves but
+	// diverge on BaseFee: two explicitly hold at current=10 and one
+	// abstains (BaseFee nil → noVote → counted as current). Net for
+	// BaseFee: voteMap[10]=3, voteMap[12]=1 → current wins, no
+	// change. The reserves still flip to target because every vote
+	// either explicitly chooses target or is the constructor seed.
+	votes := []Vote{
+		{BaseFee: ptr(10), ReserveBase: ptr(target.ReserveBase), ReserveIncrement: ptr(target.ReserveIncrement)},
+		{BaseFee: ptr(10), ReserveBase: ptr(target.ReserveBase), ReserveIncrement: ptr(target.ReserveIncrement)},
+		{ /* BaseFee abstain */ ReserveBase: ptr(target.ReserveBase), ReserveIncrement: ptr(target.ReserveIncrement)},
+	}
+
+	blob, err := DoVoting(1024, current, target, votes, true)
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+	stx := decodeTx(t, blob)
+	assert.Equal(t, "10", stx["BaseFeeDrops"], "BaseFee held at current by noVote majority")
+	assert.Equal(t, "11000000", stx["ReserveBaseDrops"])
+	assert.Equal(t, "2500000", stx["ReserveIncrementDrops"])
+}
+
+// TestDoVoting_OutOfRangeIsNoVote pins the isLegalAmountSigned
+// guard at applyVote — values exceeding MaxLegalDrops must be
+// dropped silently (counted as a vote for current), not raise
+// an error. Matches FeeVoteImpl.cpp:225-262.
+func TestDoVoting_OutOfRangeIsNoVote(t *testing.T) {
+	current := Stance{BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+	target := Stance{BaseFee: 12, ReserveBase: 11_000_000, ReserveIncrement: 2_500_000}
+
+	overflow := MaxLegalDrops + 1
+	// Three votes overflowing on BaseFee → counted as 3× current
+	// for that field. Beats the single seed for target → BaseFee
+	// held at current. Reserves are voted explicitly so they still
+	// flip; without that this DoVoting call would have nothing
+	// changed and emit no tx.
+	votes := []Vote{
+		{BaseFee: &overflow, ReserveBase: ptr(target.ReserveBase), ReserveIncrement: ptr(target.ReserveIncrement)},
+		{BaseFee: &overflow, ReserveBase: ptr(target.ReserveBase), ReserveIncrement: ptr(target.ReserveIncrement)},
+		{BaseFee: &overflow, ReserveBase: ptr(target.ReserveBase), ReserveIncrement: ptr(target.ReserveIncrement)},
+	}
+	blob, err := DoVoting(1024, current, target, votes, true)
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+	stx := decodeTx(t, blob)
+	assert.Equal(t, "10", stx["BaseFeeDrops"],
+		"overflow values must be treated as noVote, not picked")
+}
+
+// TestDoVoting_PreXRPFeesWireFormat exercises the legacy field
+// shape: sfBaseFee (uint64 hex), sfReserveBase (uint32),
+// sfReserveIncrement (uint32), sfReferenceFeeUnits required.
+// Mirrors FeeVoteImpl.cpp:307-318.
+func TestDoVoting_PreXRPFeesWireFormat(t *testing.T) {
+	current := Stance{BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+	target := Stance{BaseFee: 16, ReserveBase: 12_000_000, ReserveIncrement: 3_000_000}
+
+	blob, err := DoVoting(1024, current, target, nil, false /* pre-XRPFees */)
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+
+	stx := decodeTx(t, blob)
+	// sfBaseFee is uint64 — the codec returns it as a 16-character
+	// big-endian hex string. 16 decimal = 0x10 = "0000000000000010".
+	assert.Equal(t, "0000000000000010", baseFeeHex(t, stx["BaseFee"]),
+		"sfBaseFee must encode the uint64 value 16 (=0x10) in legacy hex form")
+	assert.EqualValues(t, 12_000_000, asUint(stx["ReserveBase"]))
+	assert.EqualValues(t, 3_000_000, asUint(stx["ReserveIncrement"]))
+	assert.EqualValues(t, ReferenceFeeUnitsDeprecated, asUint(stx["ReferenceFeeUnits"]),
+		"pre-XRPFees SetFee MUST stamp sfReferenceFeeUnits = FEE_UNITS_DEPRECATED")
+	// Modern fields must be absent.
+	_, hasModern := stx["BaseFeeDrops"]
+	assert.False(t, hasModern, "pre-XRPFees must not carry sfBaseFeeDrops")
+}
+
+// TestDoVoting_TxCarriesAllThreeOnPartialChange pins the
+// FeeVoteImpl.cpp:297-319 contract: when ANY field changes, the tx
+// carries all three at their chosen values (which equal current
+// for unchanged fields). Useful so the on-chain SetFee snapshot is
+// always self-contained.
+func TestDoVoting_TxCarriesAllThreeOnPartialChange(t *testing.T) {
+	current := Stance{BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+	target := Stance{
+		BaseFee:          12, // changed
+		ReserveBase:      current.ReserveBase,
+		ReserveIncrement: current.ReserveIncrement,
+	}
+
+	blob, err := DoVoting(1024, current, target, nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+	stx := decodeTx(t, blob)
+
+	// All three fields present even though only BaseFee changed.
+	assert.Equal(t, "12", stx["BaseFeeDrops"])
+	assert.Equal(t, strconv.FormatUint(current.ReserveBase, 10), stx["ReserveBaseDrops"])
+	assert.Equal(t, strconv.FormatUint(current.ReserveIncrement, 10), stx["ReserveIncrementDrops"])
+}
+
+// TestDoVoting_LedgerSequenceIsUpcoming pins the seq plumbing —
+// the SetFee tx carries the parent+1 seq (the upcoming flag
+// ledger). Mirrors FeeVoteImpl.cpp:299.
+func TestDoVoting_LedgerSequenceIsUpcoming(t *testing.T) {
+	current := Stance{BaseFee: 10}
+	target := Stance{BaseFee: 12}
+
+	blob, err := DoVoting(99999, current, target, nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+	stx := decodeTx(t, blob)
+	assert.EqualValues(t, 99999, asUint(stx["LedgerSequence"]))
+}
+
+// TestVotableValue_PicksHighestCountWithinWindow exercises the
+// inner getVotes loop directly: the most-voted in-window value
+// wins, ties broken by iteration order (rippled accepts whichever
+// entry the first reaches `> weight`, so it's effectively a
+// "last-tied wins" pattern that depends on map iteration; we
+// match this without testing tie ordering).
+func TestVotableValue_PicksHighestCountWithinWindow(t *testing.T) {
+	v := newVotableValue(10, 14) // window = [10, 14]
+	v.addVote(11)
+	v.addVote(11)
+	v.addVote(13)
+	chosen, changed := v.getVotes()
+	assert.True(t, changed)
+	assert.EqualValues(t, 11, chosen, "11 has 2 votes, beats 13 (1) and seed-target 14 (1)")
+}
+
+func decodeTx(t *testing.T, blob []byte) map[string]any {
+	t.Helper()
+	out, err := binarycodec.Decode(hex.EncodeToString(blob))
+	require.NoError(t, err, "serialized SetFee must round-trip through binarycodec.Decode")
+	return out
+}
+
+// baseFeeHex normalizes the codec-decoded sfBaseFee value to a
+// stable hex representation for comparison. The codec may return
+// uint64 fields as hex strings under some paths.
+func baseFeeHex(t *testing.T, v any) string {
+	t.Helper()
+	switch s := v.(type) {
+	case string:
+		return s
+	default:
+		t.Fatalf("sfBaseFee unexpected type %T: %v", v, v)
+		return ""
+	}
+}
+
+func asUint(v any) uint64 {
+	switch n := v.(type) {
+	case uint8:
+		return uint64(n)
+	case uint16:
+		return uint64(n)
+	case uint32:
+		return uint64(n)
+	case uint64:
+		return n
+	case int:
+		return uint64(n)
+	case int64:
+		return uint64(n)
+	case float64:
+		return uint64(n)
+	case string:
+		x, err := strconv.ParseUint(n, 10, 64)
+		if err == nil {
+			return x
+		}
+		// Fallback: treat as hex.
+		x, _ = strconv.ParseUint(n, 16, 64)
+		return x
+	}
+	return 0
+}

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
-	"github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
@@ -440,35 +439,17 @@ func compareNodeID20(a, b [20]byte) int {
 	return 0
 }
 
-// zeroAccount is the base58-encoded all-zero AccountID used as the
-// source account on every XRPL pseudo-transaction (rippled
-// AccountID()). The wire form serializes to a 20-byte zero blob.
-const zeroAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
-
 // buildUNLModifyTx serializes a UNLModify pseudo-tx for inclusion in
 // the proposal initial set. Wire format mirrors rippled's
 // NegativeUNLVote::addTx at NegativeUNLVote.cpp:110-140 — zero
 // account, zero fee, empty signing pubkey, sequence 0.
 func buildUNLModifyTx(seq uint32, validator [33]byte, modify Modify) ([]byte, error) {
 	disabling := uint8(modify)
-	zeroSeq := uint32(0)
 	utx := &pseudo.UNLModify{
-		BaseTx:             *tx.NewBaseTx(tx.TypeUNLModify, zeroAccount),
+		BaseTx:             *tx.NewBaseTx(tx.TypeUNLModify, pseudo.ZeroAccount),
 		UNLModifyDisabling: &disabling,
 		LedgerSequence:     &seq,
 		UNLModifyValidator: hex.EncodeToString(validator[:]),
 	}
-	utx.Common.Fee = "0"
-	utx.Common.SigningPubKey = ""
-	utx.Common.Sequence = &zeroSeq
-
-	flat, err := utx.Flatten()
-	if err != nil {
-		return nil, fmt.Errorf("flatten UNLModify: %w", err)
-	}
-	hexStr, err := binarycodec.Encode(flat)
-	if err != nil {
-		return nil, fmt.Errorf("encode UNLModify: %w", err)
-	}
-	return hex.DecodeString(hexStr)
+	return pseudo.EncodePseudoTx(utx)
 }

--- a/internal/consensus/negativeunlvote/vote_test.go
+++ b/internal/consensus/negativeunlvote/vote_test.go
@@ -736,3 +736,58 @@ func TestFindAllCandidates_RippledCombination2(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildUNLModifyTx_PseudoTxWireFormat pins the UNLModify
+// pseudo-tx wire shape against rippled's REQUIRED/OPTIONAL common
+// field rules. This guards the byte-level output of
+// buildUNLModifyTx, which now routes through pseudo.EncodePseudoTx
+// — a behaviour change from the previous in-place serialization
+// that omitted sfSigningPubKey and emitted sfFlags=0.
+//
+// rippled references:
+//   - TxFormats.cpp:34, 44 — sfFlags is soeOPTIONAL,
+//     sfSigningPubKey is soeREQUIRED
+//   - STObject.cpp:162-168 — set(SOTemplate) writes
+//     defaultObject for REQUIRED (empty VL for SigningPubKey) and
+//     nonPresentObject for OPTIONAL (Flags)
+//   - STObject.cpp:907-921 — STI_NOTPRESENT fields are filtered
+//     out of the serialized blob
+//   - NegativeUNLVote.cpp:110-140 — addTx assembles the pseudo-tx
+//     without setting sfFlags
+//
+// Asserting the bytes here means a regression in the encoder
+// (e.g., a future "always emit Flags" change) fails this test
+// with a precise message rather than silently diverging the
+// transaction ID and breaking flag-ledger SHAMap consensus on
+// the negative-UNL pseudo-tx position.
+func TestBuildUNLModifyTx_PseudoTxWireFormat(t *testing.T) {
+	validator := makeKey(0x42)
+	blob, err := buildUNLModifyTx(99999, validator, ToDisable)
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+
+	hexBlob := hex.EncodeToString(blob)
+	// sfSigningPubKey (field id 0x73 = type 7 / fieldCode 3) must
+	// appear as VL(0) — bytes "7300". For UNLModify the next
+	// field in canonical sort order is sfUNLModifyValidator
+	// (0x70 0x13), so SigningPubKey ends with "73007013" rather
+	// than the "730081" pattern used by SetFee.
+	assert.Contains(t, hexBlob, "73007013",
+		"UNLModify blob must carry sfSigningPubKey VL(0) immediately before sfUNLModifyValidator")
+	// sfFlags (UInt32 type marker 0x22 + 4 zero bytes) must not
+	// appear; rippled marks sfFlags as soeOPTIONAL and
+	// NegativeUNLVote::addTx never sets it. STObject::add filters
+	// STI_NOTPRESENT optionals out of the serialized blob.
+	assert.NotContains(t, hexBlob, "2200000000",
+		"UNLModify blob must not carry sfFlags=0 (rippled omits soeOPTIONAL nonPresent fields)")
+
+	stx, err := binarycodec.Decode(hexBlob)
+	require.NoError(t, err, "UNLModify blob must round-trip through binarycodec.Decode")
+
+	got, ok := stx["SigningPubKey"]
+	assert.True(t, ok, "decoded UNLModify must include SigningPubKey")
+	assert.Equal(t, "", got, "SigningPubKey must decode as empty")
+
+	_, hasFlags := stx["Flags"]
+	assert.False(t, hasFlags, "decoded UNLModify must not include Flags")
+}

--- a/internal/tx/pseudo/wire.go
+++ b/internal/tx/pseudo/wire.go
@@ -32,28 +32,21 @@ func applyPseudoTxDefaults(c *tx.Common) {
 // present in the encoded blob (matching rippled's STObject::add
 // behaviour at STObject.cpp:881-921 — every field with a default
 // value emitted by set(SOTemplate) is serialized, including the
-// empty Blob for sfSigningPubKey), drops sfFlags so the blob does
-// not carry an STI_NOTPRESENT optional that rippled would omit, and
-// returns the binary blob.
+// empty Blob for sfSigningPubKey), and returns the binary blob.
 //
 // Common.ToMap omits SigningPubKey when empty, but rippled's wire
 // format always carries it as VL(0) for pseudo-tx because it is a
-// REQUIRED common field. We re-inject it after Flatten so the codec
-// emits the trailing 0x73 0x00 bytes.
+// REQUIRED common field (TxFormats.cpp:44 → soeREQUIRED →
+// STObject.cpp:165 writes a defaultObject). We re-inject it after
+// Flatten so the codec emits the trailing 0x73 0x00 bytes.
 //
-// Common.ToMap conversely emits Flags=0 unconditionally, but rippled
-// declares sfFlags as soeOPTIONAL in the common-fields template
-// (TxFormats.cpp:34) and STObject::set(SOTemplate) at
-// STObject.cpp:156-169 stores it as nonPresentObject when not set by
-// the assembler. STObject::add at STObject.cpp:907-921 filters
-// STI_NOTPRESENT fields out of the serialized blob. The pseudo-tx
+// sfFlags is soeOPTIONAL (TxFormats.cpp:34) and the pseudo-tx
 // assemblers in rippled (FeeVoteImpl::doVoting at
 // FeeVoteImpl.cpp:297-319; NegativeUNLVote::addTx at
-// NegativeUNLVote.cpp:110-140) never set sfFlags, so rippled's blob
-// has no Flags bytes. We delete it after Flatten to match — leaving
-// it in would shift the serialized field sequence and produce a
-// different transaction ID, breaking SHAMap consensus on the flag
-// ledger position.
+// NegativeUNLVote.cpp:110-140) never set it. Common.ToMap honors
+// this by omitting Flags when c.Flags is nil, so no special
+// handling is needed here — applyPseudoTxDefaults does not touch
+// Flags.
 func EncodePseudoTx(stx tx.Transaction) ([]byte, error) {
 	applyPseudoTxDefaults(stx.GetCommon())
 
@@ -64,7 +57,6 @@ func EncodePseudoTx(stx tx.Transaction) ([]byte, error) {
 	if _, ok := flat["SigningPubKey"]; !ok {
 		flat["SigningPubKey"] = ""
 	}
-	delete(flat, "Flags")
 
 	hexStr, err := binarycodec.Encode(flat)
 	if err != nil {

--- a/internal/tx/pseudo/wire.go
+++ b/internal/tx/pseudo/wire.go
@@ -1,0 +1,57 @@
+package pseudo
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+)
+
+// ZeroAccount is the base58-encoded all-zero AccountID used as the
+// source on every XRPL pseudo-transaction (rippled AccountID()). The
+// wire form serializes to a 20-byte zero blob.
+const ZeroAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+
+// applyPseudoTxDefaults stamps the rippled-default values for the
+// REQUIRED common fields on a pseudo-tx. Mirrors rippled's
+// STTx(TxType, …) constructor at STTx.cpp:113-128, which calls
+// set(format->getSOTemplate()) and inserts default values for every
+// REQUIRED common field (TxFormats.cpp:32-50): zero Fee, zero
+// Sequence, empty SigningPubKey.
+func applyPseudoTxDefaults(c *tx.Common) {
+	zeroSeq := uint32(0)
+	c.Fee = "0"
+	c.Sequence = &zeroSeq
+	c.SigningPubKey = ""
+}
+
+// EncodePseudoTx serializes a pseudo-tx to the canonical XRPL wire
+// bytes used in the consensus tx set. It stamps the rippled-default
+// common fields, flattens the tx, ensures the empty SigningPubKey is
+// present in the encoded blob (matching rippled's
+// STObject::add behaviour at STObject.cpp:881-921 — every field with
+// a default value emitted by set(SOTemplate) is serialized, including
+// the empty Blob for sfSigningPubKey), and returns the binary blob.
+//
+// Common.ToMap omits SigningPubKey when empty, but rippled's wire
+// format always carries it as VL(0) for pseudo-tx because it is a
+// REQUIRED common field. We re-inject it after Flatten so the codec
+// emits the trailing 0x73 0x00 bytes.
+func EncodePseudoTx(stx tx.Transaction) ([]byte, error) {
+	applyPseudoTxDefaults(stx.GetCommon())
+
+	flat, err := stx.Flatten()
+	if err != nil {
+		return nil, fmt.Errorf("flatten pseudo-tx: %w", err)
+	}
+	if _, ok := flat["SigningPubKey"]; !ok {
+		flat["SigningPubKey"] = ""
+	}
+
+	hexStr, err := binarycodec.Encode(flat)
+	if err != nil {
+		return nil, fmt.Errorf("encode pseudo-tx: %w", err)
+	}
+	return hex.DecodeString(hexStr)
+}

--- a/internal/tx/pseudo/wire.go
+++ b/internal/tx/pseudo/wire.go
@@ -29,15 +29,31 @@ func applyPseudoTxDefaults(c *tx.Common) {
 // EncodePseudoTx serializes a pseudo-tx to the canonical XRPL wire
 // bytes used in the consensus tx set. It stamps the rippled-default
 // common fields, flattens the tx, ensures the empty SigningPubKey is
-// present in the encoded blob (matching rippled's
-// STObject::add behaviour at STObject.cpp:881-921 — every field with
-// a default value emitted by set(SOTemplate) is serialized, including
-// the empty Blob for sfSigningPubKey), and returns the binary blob.
+// present in the encoded blob (matching rippled's STObject::add
+// behaviour at STObject.cpp:881-921 — every field with a default
+// value emitted by set(SOTemplate) is serialized, including the
+// empty Blob for sfSigningPubKey), drops sfFlags so the blob does
+// not carry an STI_NOTPRESENT optional that rippled would omit, and
+// returns the binary blob.
 //
 // Common.ToMap omits SigningPubKey when empty, but rippled's wire
 // format always carries it as VL(0) for pseudo-tx because it is a
 // REQUIRED common field. We re-inject it after Flatten so the codec
 // emits the trailing 0x73 0x00 bytes.
+//
+// Common.ToMap conversely emits Flags=0 unconditionally, but rippled
+// declares sfFlags as soeOPTIONAL in the common-fields template
+// (TxFormats.cpp:34) and STObject::set(SOTemplate) at
+// STObject.cpp:156-169 stores it as nonPresentObject when not set by
+// the assembler. STObject::add at STObject.cpp:907-921 filters
+// STI_NOTPRESENT fields out of the serialized blob. The pseudo-tx
+// assemblers in rippled (FeeVoteImpl::doVoting at
+// FeeVoteImpl.cpp:297-319; NegativeUNLVote::addTx at
+// NegativeUNLVote.cpp:110-140) never set sfFlags, so rippled's blob
+// has no Flags bytes. We delete it after Flatten to match — leaving
+// it in would shift the serialized field sequence and produce a
+// different transaction ID, breaking SHAMap consensus on the flag
+// ledger position.
 func EncodePseudoTx(stx tx.Transaction) ([]byte, error) {
 	applyPseudoTxDefaults(stx.GetCommon())
 
@@ -48,6 +64,7 @@ func EncodePseudoTx(stx tx.Transaction) ([]byte, error) {
 	if _, ok := flat["SigningPubKey"]; !ok {
 		flat["SigningPubKey"] = ""
 	}
+	delete(flat, "Flags")
 
 	hexStr, err := binarycodec.Encode(flat)
 	if err != nil {

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -279,13 +279,17 @@ func (c *Common) ToMap() map[string]any {
 	if c.AccountTxnID != "" {
 		m["AccountTxnID"] = c.AccountTxnID
 	}
-	// Flags is always serialized, even when 0. rippled's STObject always
-	// includes Flags as a required field. Omitting it produces a different
-	// binary serialization and different tx hash.
+	// sfFlags is soeOPTIONAL in rippled's common-fields template
+	// (TxFormats.cpp:34). STObject::set(SOTemplate) at
+	// STObject.cpp:165 stores it as nonPresentObject when the
+	// assembler did not set it, and STObject::add at
+	// STObject.cpp:907-921 filters STI_NOTPRESENT fields out of the
+	// serialized blob. So when c.Flags is nil, the wire format must
+	// carry no Flags bytes — emitting Flags=0 anyway would shift the
+	// serialized field sequence and produce a different transaction
+	// ID than rippled computes for the same JSON.
 	if c.Flags != nil {
 		m["Flags"] = *c.Flags
-	} else {
-		m["Flags"] = uint32(0)
 	}
 	if c.LastLedgerSequence != nil {
 		m["LastLedgerSequence"] = *c.LastLedgerSequence


### PR DESCRIPTION
## Summary

Pure-algorithm port of rippled's [`FeeVoteImpl`](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/misc/FeeVoteImpl.cpp) (345 LOC) to a new `internal/consensus/feevote` package. Decides whether to inject a `SetFee` pseudo-tx into the consensus tx set on a flag-ledger boundary, based on trusted validators' fee votes from the prior voting ledger.

Same algorithm-only scope as #375: ships the producer + comprehensive tests; `Adaptor.GenerateFlagLedgerPseudoTxs` still returns nil, gated on the same per-seq validation history extension to `ValidationTracker` called out on `GenerateNegativeUNLPseudoTx`.

## Behavior matched against rippled

| Behavior | Source | Mechanism |
|---|---|---|
| `VotableValue` constructor seeds `target` with +1 | `FeeVoteImpl.cpp:44` | local validator's stance is implicit in `target` |
| `addVote(value)` | `FeeVoteImpl.cpp:48-51` | increments `voteMap[value]` |
| `noVote()` (counted as current) | `FeeVoteImpl.cpp:53-57` | missing or out-of-range fields → +1 to `current` |
| `getVotes()` window clamp | `FeeVoteImpl.cpp:74-83` | pick most-voted value within `[min(current, target), max(current, target)]` |
| `isLegalAmountSigned` guard | `FeeVoteImpl.cpp:225-262` | overflow values silently treated as noVote, no error |
| Pre-XRPFees wire fields | `FeeVoteImpl.cpp:307-318` | `sfBaseFee` (uint64) / `sfReserveBase`, `sfReserveIncrement` (uint32) / `sfReferenceFeeUnits` |
| Post-XRPFees wire fields | `FeeVoteImpl.cpp:300-305` | `sfBaseFeeDrops` / `sfReserveBaseDrops` / `sfReserveIncrementDrops` |
| All-three on partial change | `FeeVoteImpl.cpp:291-319` | tx carries every field at chosen-or-current when ANY changed |
| `sfReferenceFeeUnits = FEE_UNITS_DEPRECATED` | `FeeVoteImpl.cpp:317` | constant `10` stamped on every pre-XRPFees `SetFee` |

## Tests

All in `internal/consensus/feevote/vote_test.go`:

- [x] `TestDoVoting_NoChangeNoTx` — early return when nothing changed
- [x] `TestDoVoting_TargetSeededAsInitialVote` — constructor's +1 for target wins with no other votes
- [x] `TestDoVoting_VoteOutsideWindowIgnored` — votes outside `[current, target]` clamped out
- [x] `TestDoVoting_NoVoteCountsAsCurrent` — abstainers + explicit-current beat seed
- [x] `TestDoVoting_OutOfRangeIsNoVote` — overflow values silent → noVote
- [x] `TestDoVoting_PreXRPFeesWireFormat` — `sfBaseFee` (16-char hex), `ReserveBase/Increment` as uint32, `sfReferenceFeeUnits = 10`, no `*Drops`
- [x] `TestDoVoting_TxCarriesAllThreeOnPartialChange`
- [x] `TestDoVoting_LedgerSequenceIsUpcoming` — tx carries `parent.seq + 1`
- [x] `TestVotableValue_PicksHighestCountWithinWindow`

`go test ./internal/consensus/...` passes; `go vet` clean.

## Follow-up

`Adaptor.GenerateFlagLedgerPseudoTxs` returns nil. Wiring it requires the same plumbing as `GenerateNegativeUNLPseudoTx` from #368/#375:

1. Per-seq validation history in `ValidationTracker` (currently only `LedgerID`-indexed)
2. State-map read access on `consensus.Ledger` so the producer can read the parent ledger's current fee setup

The `feevote.DoVoting` API takes `current Stance` as input, so once the wiring exposes `prevLedger`'s fee setup, plugging in is mechanical.

## Note on local validator double-counting

Rippled's `FeeVoteImpl::doVoting` seeds `voteMap[target]` in the constructor AND iterates over all trusted validations (including the local one), so the local validator's vote is effectively counted twice when its `STValidation` carries the same fee fields as `target`. This port matches that behavior — `target` is the local stance, and the caller passes whatever set of trusted votes they have (including local's). Documented in the `DoVoting` comment.