### PR TITLE
consensus: port AmendmentTable.doVoting producer algorithm (refs #370)

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/amendmentvote"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
@@ -168,10 +169,14 @@ type Adaptor struct {
 	// at construction. Zero values mean "no vote".
 	feeVote FeeVoteStance
 
-	// amendmentVoteIDs are the amendment IDs this validator wishes to
-	// vote FOR on the next flag ledger. Resolved from Config.AmendmentVote
-	// names at construction (unknown names logged and dropped).
-	amendmentVoteIDs [][32]byte
+	// amendmentStances is this validator's per-amendment voting
+	// stance, seeded from the registry's per-feature Vote behavior
+	// at construction and overridden by Config.AmendmentVote. Mirrors
+	// rippled's amendmentMap_ vote field
+	// (AmendmentTable.cpp:556-580). Amendments not in the map default
+	// to VoteAbstain on lookup; obsolete amendments cannot be
+	// overridden to VoteUp.
+	amendmentStances map[[32]byte]amendmentvote.Stance
 
 	// trustedVotes caches per-validator amendment votes for 24h to
 	// dampen amendment "flapping" when a flaky validator drops
@@ -281,19 +286,40 @@ func New(cfg Config) *Adaptor {
 		cookie = 1
 	}
 
-	// Resolve amendment-vote names to IDs. Unknown names are logged
-	// and dropped — an operator with a stale config shouldn't block
-	// node boot. Same behavior as rippled silently skipping unknown
-	// amendments from [amendments].
+	// Seed per-amendment stances from the registry so an
+	// unconfigured validator votes the way rippled would: every
+	// supported feature defaults to its registered VoteBehavior
+	// (DefaultYes → VoteUp, DefaultNo → VoteAbstain via map lookup,
+	// Obsolete → VoteObsolete). Mirrors the constructor walk at
+	// AmendmentTable.cpp:556-580.
 	logger := slog.Default().With("component", "consensus-adaptor")
-	var amendmentVoteIDs [][32]byte
+	amendmentStances := make(map[[32]byte]amendmentvote.Stance)
+	for _, f := range amendment.AllFeatures() {
+		switch {
+		case f.Vote == amendment.VoteObsolete:
+			amendmentStances[f.ID] = amendmentvote.VoteObsolete
+		case f.Supported == amendment.SupportedYes && f.Vote == amendment.VoteDefaultYes && !f.Retired:
+			amendmentStances[f.ID] = amendmentvote.VoteUp
+		}
+	}
+
+	// Layer Config.AmendmentVote on top as operator overrides to
+	// VoteUp — same role as rippled's [amendments] stanza. Unknown
+	// names are logged and dropped (stale config must not block
+	// boot). Obsolete amendments cannot be promoted to VoteUp:
+	// rippled's persistVote refuses obsolete entries
+	// (AmendmentTable.cpp:728-733).
 	for _, name := range cfg.AmendmentVote {
 		f := amendment.GetFeatureByName(name)
 		if f == nil {
 			logger.Warn("unknown amendment in vote config; ignoring", "name", name)
 			continue
 		}
-		amendmentVoteIDs = append(amendmentVoteIDs, f.ID)
+		if f.Vote == amendment.VoteObsolete {
+			logger.Warn("obsolete amendment cannot be voted up; ignoring", "name", name)
+			continue
+		}
+		amendmentStances[f.ID] = amendmentvote.VoteUp
 	}
 
 	// Seed the amendment-vote cache with the initial UNL so
@@ -333,7 +359,7 @@ func New(cfg Config) *Adaptor {
 		peerLCLs:          make(map[uint64]consensus.LedgerID),
 		cookie:            cookie,
 		feeVote:           feeVote,
-		amendmentVoteIDs:  amendmentVoteIDs,
+		amendmentStances:  amendmentStances,
 		trustedVotes:      trustedVotes,
 		logger:            logger,
 	}
@@ -975,7 +1001,7 @@ func (a *Adaptor) GetFeeVote() (baseFee, reserveBase, reserveIncrement uint64, p
 // sorted by amendment ID so two validators with the same stance
 // produce byte-identical validations.
 func (a *Adaptor) GetAmendmentVote() [][32]byte {
-	if len(a.amendmentVoteIDs) == 0 {
+	if len(a.amendmentStances) == 0 {
 		return nil
 	}
 
@@ -989,8 +1015,11 @@ func (a *Adaptor) GetAmendmentVote() [][32]byte {
 		}
 	}
 
-	out := make([][32]byte, 0, len(a.amendmentVoteIDs))
-	for _, id := range a.amendmentVoteIDs {
+	out := make([][32]byte, 0, len(a.amendmentStances))
+	for id, stance := range a.amendmentStances {
+		if stance != amendmentvote.VoteUp {
+			continue
+		}
 		if rules != nil && rules.Enabled(id) {
 			continue
 		}

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -558,24 +558,49 @@ func (a *Adaptor) GetPendingTxs() [][]byte {
 	return blobs
 }
 
-// GenerateFlagLedgerPseudoTxs is currently a stub. Both producers
-// are now ported as algorithm-only packages:
+// GenerateFlagLedgerPseudoTxs runs the fee-vote and amendment-vote
+// producers and returns their concatenated pseudo-tx blobs to
+// inject into the proposal initial set. Mirrors rippled
+// RCLConsensus.cpp:354-367.
 //
-//   - fee voting → internal/consensus/feevote (#369)
-//   - amendment voting → internal/consensus/amendmentvote (#370)
+// The producers themselves live in internal/consensus/feevote
+// (#369) and internal/consensus/amendmentvote (#370); this method
+// is the boundary that resolves prevLedger state, the local
+// stance, and parentValidations into the producers' input shape.
 //
-// Each is exercised by package-level tests against synthetic
-// inputs. Wiring them into this method needs the same per-seq
-// validation history extension to ValidationTracker called out on
-// GenerateNegativeUNLPseudoTx below; once that lands, the prior
-// voting-ledger's trusted validations can feed both producers and
-// the resulting blobs are concatenated as the return.
+// Returns nil when the ledger service is missing or the parent
+// ledger isn't readable. Per-producer parse / read failures are
+// logged at warn and that producer falls through to nil — a
+// malformed FeeSettings SLE doesn't suppress amendment-vote
+// emission and vice versa.
 //
-// Returning nil keeps the engine's injection step a no-op until
-// the wiring lands — matching the pre-#367 behavior of never
-// injecting.
-func (a *Adaptor) GenerateFlagLedgerPseudoTxs(_ consensus.Ledger) [][]byte {
-	return nil
+// Both producers need to know which feature amendments are
+// enabled on prevLedger (XRPFees gates the fee wire format;
+// fixAmendmentMajorityCalc switches the amendment threshold
+// strict-vs-lax). The base *ledger.Ledger doesn't carry an
+// amendment.Rules struct (Ledger.Rules returns nil), so we read
+// the Amendments SLE once at this boundary and pass the parsed
+// enabled-set down to both runners.
+func (a *Adaptor) GenerateFlagLedgerPseudoTxs(prevLedger consensus.Ledger, parentValidations []*consensus.Validation) [][]byte {
+	if a.ledgerService == nil {
+		return nil
+	}
+	prev, err := a.ledgerService.GetLedgerByHash([32]byte(prevLedger.ID()))
+	if err != nil || prev == nil {
+		return nil
+	}
+	upcomingSeq := prev.Sequence() + 1
+
+	enabled, majorities := a.readAmendmentsSLE(prev)
+
+	var blobs [][]byte
+	if extra := a.runFeeVote(prev, upcomingSeq, parentValidations, enabled); len(extra) > 0 {
+		blobs = append(blobs, extra...)
+	}
+	if extra := a.runAmendmentVote(prev, upcomingSeq, parentValidations, enabled, majorities); len(extra) > 0 {
+		blobs = append(blobs, extra...)
+	}
+	return blobs
 }
 
 // GenerateNegativeUNLPseudoTx is currently a stub. The vote-tally

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -296,11 +296,9 @@ func New(cfg Config) *Adaptor {
 		amendmentVoteIDs = append(amendmentVoteIDs, f.ID)
 	}
 
-	// Initialize the per-validator amendment-vote cache and seed it
-	// with the current trusted set so RecordVotes accepts validations
-	// from any UNL member from round one. UNL changes after boot
-	// must call trustedVotes.TrustChanged again to keep the cache in
-	// sync — currently the trusted set is static post-construction.
+	// Seed the amendment-vote cache with the initial UNL so
+	// RecordVotes accepts validations from round one. Re-call
+	// TrustChanged whenever the trusted set mutates at runtime.
 	trustedVotes := NewTrustedVotes()
 	trustedVotes.TrustChanged(cfg.Validators)
 
@@ -615,10 +613,10 @@ func (a *Adaptor) GetPendingTxs() [][]byte {
 // :358 and the quorum gate at :361 — both producers run only when
 // the negUNL-filtered validation set meets the current quorum.
 //
-// The producers themselves live in internal/consensus/feevote
-// (#369) and internal/consensus/amendmentvote (#370); this method
-// is the boundary that resolves prevLedger state, the local
-// stance, and parentValidations into the producers' input shape.
+// The producers live in internal/consensus/feevote and
+// internal/consensus/amendmentvote; this method resolves
+// prevLedger state, the local stance, and parentValidations into
+// the producers' input shape.
 //
 // Returns nil when the ledger service is missing, the parent
 // ledger isn't readable, or the negUNL-filtered validation set

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -561,15 +561,18 @@ func (a *Adaptor) GetPendingTxs() [][]byte {
 // GenerateFlagLedgerPseudoTxs runs the fee-vote and amendment-vote
 // producers and returns their concatenated pseudo-tx blobs to
 // inject into the proposal initial set. Mirrors rippled
-// RCLConsensus.cpp:354-367.
+// RCLConsensus.cpp:354-367, including the negative-UNL filter at
+// :358 and the quorum gate at :361 — both producers run only when
+// the negUNL-filtered validation set meets the current quorum.
 //
 // The producers themselves live in internal/consensus/feevote
 // (#369) and internal/consensus/amendmentvote (#370); this method
 // is the boundary that resolves prevLedger state, the local
 // stance, and parentValidations into the producers' input shape.
 //
-// Returns nil when the ledger service is missing or the parent
-// ledger isn't readable. Per-producer parse / read failures are
+// Returns nil when the ledger service is missing, the parent
+// ledger isn't readable, or the negUNL-filtered validation set
+// falls below quorum. Per-producer parse / read failures are
 // logged at warn and that producer falls through to nil — a
 // malformed FeeSettings SLE doesn't suppress amendment-vote
 // emission and vice versa.
@@ -591,16 +594,59 @@ func (a *Adaptor) GenerateFlagLedgerPseudoTxs(prevLedger consensus.Ledger, paren
 	}
 	upcomingSeq := prev.Sequence() + 1
 
+	// Strip validations from validators currently on the negative
+	// UNL — they don't count toward quorum and their amendment /
+	// fee votes are not tallied. Mirrors RCLConsensus.cpp:358's
+	// negativeUNLFilter wrapping getTrustedForLedger.
+	filtered := a.filterNegativeUNL(parentValidations)
+
+	// Quorum gate: with fewer than quorum validations of prev's
+	// parent (post-negUNL filter) we don't have enough signal to
+	// produce pseudo-txs. Standalone (zero trusted validators)
+	// reports quorum 0 and falls through. RCLConsensus.cpp:361.
+	if len(filtered) < a.GetQuorum() {
+		return nil
+	}
+
 	enabled, majorities := a.readAmendmentsSLE(prev)
 
 	var blobs [][]byte
-	if extra := a.runFeeVote(prev, upcomingSeq, parentValidations, enabled); len(extra) > 0 {
+	if extra := a.runFeeVote(prev, upcomingSeq, filtered, enabled); len(extra) > 0 {
 		blobs = append(blobs, extra...)
 	}
-	if extra := a.runAmendmentVote(prev, upcomingSeq, parentValidations, enabled, majorities); len(extra) > 0 {
+	if extra := a.runAmendmentVote(prev, upcomingSeq, filtered, enabled, majorities); len(extra) > 0 {
 		blobs = append(blobs, extra...)
 	}
 	return blobs
+}
+
+// filterNegativeUNL returns vals minus any validations signed by
+// validators currently on the negative UNL. Mirrors rippled's
+// ValidatorList::negativeUNLFilter at RCLConsensus.cpp:358.
+func (a *Adaptor) filterNegativeUNL(vals []*consensus.Validation) []*consensus.Validation {
+	return excludeNegativeUNL(vals, a.GetNegativeUNL())
+}
+
+// excludeNegativeUNL is the pure-arithmetic core of the negUNL
+// filter — extracted for testability without standing up a
+// NegativeUNL SLE in the ledger fixture. Empty negUNL returns vals
+// unchanged (no allocation).
+func excludeNegativeUNL(vals []*consensus.Validation, negUNL []consensus.NodeID) []*consensus.Validation {
+	if len(vals) == 0 || len(negUNL) == 0 {
+		return vals
+	}
+	skip := make(map[consensus.NodeID]struct{}, len(negUNL))
+	for _, id := range negUNL {
+		skip[id] = struct{}{}
+	}
+	out := make([]*consensus.Validation, 0, len(vals))
+	for _, v := range vals {
+		if _, banned := skip[v.NodeID]; banned {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
 }
 
 // GenerateNegativeUNLPseudoTx is currently a stub. The vote-tally

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -558,16 +558,18 @@ func (a *Adaptor) GetPendingTxs() [][]byte {
 	return blobs
 }
 
-// GenerateFlagLedgerPseudoTxs is currently a stub. The fee-vote
-// algorithm lives in internal/consensus/feevote (ported in #369)
-// and is exercised by package-level tests against synthetic vote
-// inputs; the amendment-vote producer is still TODO (#370).
+// GenerateFlagLedgerPseudoTxs is currently a stub. Both producers
+// are now ported as algorithm-only packages:
 //
-// Wiring fee-vote into this method needs the same per-seq
+//   - fee voting → internal/consensus/feevote (#369)
+//   - amendment voting → internal/consensus/amendmentvote (#370)
+//
+// Each is exercised by package-level tests against synthetic
+// inputs. Wiring them into this method needs the same per-seq
 // validation history extension to ValidationTracker called out on
-// GenerateNegativeUNLPseudoTx below — once that lands, the fee
-// votes can be extracted from the prior voting ledger's
-// validations and fed into feevote.DoVoting.
+// GenerateNegativeUNLPseudoTx below; once that lands, the prior
+// voting-ledger's trusted validations can feed both producers and
+// the resulting blobs are concatenated as the return.
 //
 // Returning nil keeps the engine's injection step a no-op until
 // the wiring lands — matching the pre-#367 behavior of never

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -173,6 +173,12 @@ type Adaptor struct {
 	// names at construction (unknown names logged and dropped).
 	amendmentVoteIDs [][32]byte
 
+	// trustedVotes caches per-validator amendment votes for 24h to
+	// dampen amendment "flapping" when a flaky validator drops
+	// briefly. See trusted_votes.go and rippled's TrustedVotes at
+	// AmendmentTable.cpp:75-286.
+	trustedVotes *TrustedVotes
+
 	logger *slog.Logger
 }
 
@@ -194,11 +200,28 @@ const goXRPLServerVersionTag uint64 = 0x4000_0000_0000_0000
 // rules — matches rippled's FeeVoteImpl.cpp:120-192 hard if/else
 // gate on featureXRPFees.
 //
-// Zero values mean "no vote" — the serializer skips the fields.
+// Zero values on any individual field mean "operator did not set
+// this field" — adaptor.New() substitutes the rippled FeeSetup
+// default (Config.h:65-78) so an unconfigured validator votes
+// toward those defaults rather than abstaining.
 type FeeVoteStance struct {
 	BaseFee          uint64
 	ReserveBase      uint32
 	ReserveIncrement uint32
+}
+
+// defaultFeeVote returns the rippled FeeSetup defaults — a validator
+// with no [voting] stanza in its config votes toward these values.
+// Mirrors the default-constructed FeeSetup at
+// rippled/src/xrpld/core/Config.h:65-78
+// (reference_fee=10, account_reserve=10*DROPS_PER_XRP=10_000_000,
+// owner_reserve=2*DROPS_PER_XRP=2_000_000).
+func defaultFeeVote() FeeVoteStance {
+	return FeeVoteStance{
+		BaseFee:          10,
+		ReserveBase:      10_000_000,
+		ReserveIncrement: 2_000_000,
+	}
 }
 
 // Config holds configuration for the Adaptor.
@@ -273,6 +296,32 @@ func New(cfg Config) *Adaptor {
 		amendmentVoteIDs = append(amendmentVoteIDs, f.ID)
 	}
 
+	// Initialize the per-validator amendment-vote cache and seed it
+	// with the current trusted set so RecordVotes accepts validations
+	// from any UNL member from round one. UNL changes after boot
+	// must call trustedVotes.TrustChanged again to keep the cache in
+	// sync — currently the trusted set is static post-construction.
+	trustedVotes := NewTrustedVotes()
+	trustedVotes.TrustChanged(cfg.Validators)
+
+	// Substitute rippled FeeSetup defaults on a per-field basis: an
+	// operator may set BaseFee but leave reserves zero, and we want
+	// each unset field to fall back to the rippled default
+	// (Config.h:65-78) rather than to "abstain". An empty config thus
+	// votes toward 10/10_000_000/2_000_000 — matching rippled's
+	// default-constructed FeeSetup.
+	feeVote := cfg.FeeVote
+	defaults := defaultFeeVote()
+	if feeVote.BaseFee == 0 {
+		feeVote.BaseFee = defaults.BaseFee
+	}
+	if feeVote.ReserveBase == 0 {
+		feeVote.ReserveBase = defaults.ReserveBase
+	}
+	if feeVote.ReserveIncrement == 0 {
+		feeVote.ReserveIncrement = defaults.ReserveIncrement
+	}
+
 	return &Adaptor{
 		ledgerService:     cfg.LedgerService,
 		sender:            sender,
@@ -285,8 +334,9 @@ func New(cfg Config) *Adaptor {
 		pendingTxs:        make(map[consensus.TxID][]byte),
 		peerLCLs:          make(map[uint64]consensus.LedgerID),
 		cookie:            cookie,
-		feeVote:           cfg.FeeVote,
+		feeVote:           feeVote,
 		amendmentVoteIDs:  amendmentVoteIDs,
+		trustedVotes:      trustedVotes,
 		logger:            logger,
 	}
 }
@@ -608,7 +658,10 @@ func (a *Adaptor) GenerateFlagLedgerPseudoTxs(prevLedger consensus.Ledger, paren
 		return nil
 	}
 
-	enabled, majorities := a.readAmendmentsSLE(prev)
+	enabled, majorities, ok := a.readAmendmentsSLE(prev)
+	if !ok {
+		return nil
+	}
 
 	var blobs [][]byte
 	if extra := a.runFeeVote(prev, upcomingSeq, filtered, enabled); len(extra) > 0 {

--- a/internal/consensus/adaptor/flag_ledger_vote.go
+++ b/internal/consensus/adaptor/flag_ledger_vote.go
@@ -18,9 +18,6 @@ import (
 // majority on the ledger before it's enabled. Mainnet config:
 // 14 days. Mirrors rippled's default at AmendmentTable.cpp via
 // SET_AMENDMENT_MAJORITY_TIME (Application.cpp:1216-1220).
-//
-// Constant for now — operators don't currently have a knob to
-// override it; if that changes the value moves into Config.
 const amendmentMajorityTimeout = 14 * 24 * time.Hour
 
 // readAmendmentsSLE pulls the parent ledger's Amendments SLE
@@ -59,16 +56,11 @@ func (a *Adaptor) readAmendmentsSLE(prev *ledger.Ledger) (
 	return enabled, majorities, ok
 }
 
-// parseAmendmentsSLEBytes is the pure-data half of readAmendmentsSLE
-// — extracted so the parse-failure branch is unit-testable without
-// having to inject corrupt bytes through a *ledger.Ledger (which is
-// immutable on the closed-ledger path used by the producer).
-//
-// Returns ok=false ONLY on parse failure of non-empty data. An
-// empty input (len(data)==0, the pre-bootstrap genesis state) is a
-// successful read of empty state and returns ok=true with empty
-// maps — matching the rippled ledger walk that finds no SLE at the
-// keylet.Amendments() index.
+// parseAmendmentsSLEBytes returns ok=false ONLY on parse failure
+// of non-empty data. An empty input (len(data)==0, the
+// pre-bootstrap genesis state) is a successful read of empty state
+// and returns ok=true with empty maps — matching the rippled
+// ledger walk that finds no SLE at the keylet.Amendments() index.
 func parseAmendmentsSLEBytes(data []byte) (
 	enabled map[[32]byte]bool,
 	majorities map[[32]byte]time.Time,

--- a/internal/consensus/adaptor/flag_ledger_vote.go
+++ b/internal/consensus/adaptor/flag_ledger_vote.go
@@ -1,0 +1,234 @@
+package adaptor
+
+import (
+	"time"
+
+	"github.com/LeJamon/goXRPLd/amendment"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/amendmentvote"
+	"github.com/LeJamon/goXRPLd/internal/consensus/feevote"
+	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
+)
+
+// amendmentMajorityTimeout is how long an amendment must hold
+// majority on the ledger before it's enabled. Mainnet config:
+// 14 days. Mirrors rippled's default at AmendmentTable.cpp via
+// SET_AMENDMENT_MAJORITY_TIME (Application.cpp:1216-1220).
+//
+// Constant for now — operators don't currently have a knob to
+// override it; if that changes the value moves into Config.
+const amendmentMajorityTimeout = 14 * 24 * time.Hour
+
+// readAmendmentsSLE pulls the parent ledger's Amendments SLE
+// (enabled set + majorities array) once at the producer boundary.
+// Both runners consume the result, and the enabled set doubles as
+// the feature-flag oracle (rules.Enabled(...) replacement) since
+// *ledger.Ledger doesn't carry an amendment.Rules struct.
+//
+// On read or parse failure, returns empty maps and logs at warn —
+// "no amendments enabled" is a safe degradation: it just means
+// the legacy / pre-fix code paths are taken.
+func (a *Adaptor) readAmendmentsSLE(prev *ledger.Ledger) (
+	enabled map[[32]byte]bool,
+	majorities map[[32]byte]time.Time,
+) {
+	enabled = map[[32]byte]bool{}
+	majorities = map[[32]byte]time.Time{}
+
+	data, err := prev.Read(keylet.Amendments())
+	if err != nil {
+		a.logger.Warn("flag-ledger producer: failed to read Amendments SLE",
+			"err", err, "seq", prev.Sequence())
+		return enabled, majorities
+	}
+	if len(data) == 0 {
+		return enabled, majorities
+	}
+	sle, err := pseudo.ParseAmendmentsSLE(data)
+	if err != nil {
+		a.logger.Warn("flag-ledger producer: failed to parse Amendments SLE",
+			"err", err, "seq", prev.Sequence())
+		return enabled, majorities
+	}
+	for _, h := range sle.Amendments {
+		enabled[h] = true
+	}
+	for _, m := range sle.Majorities {
+		// MajorityEntry.CloseTime is XRPL-epoch seconds — convert
+		// to time.Time so the algorithm's
+		// majoritySince + MajorityTimeout <= closeTime arithmetic
+		// runs over a uniform clock.
+		majorities[m.Amendment] = time.Unix(protocol.RippleEpochUnix+int64(m.CloseTime), 0).UTC()
+	}
+	return enabled, majorities
+}
+
+// runFeeVote runs the FeeVote producer against the parent
+// ledger's current FeeSettings SLE and the trusted validations
+// that referenced it. Returns the serialized SetFee blob (one or
+// none) or nil on read/parse failure (logged at warn, treated as
+// "abstain" so a single bad SLE doesn't block amendment voting).
+func (a *Adaptor) runFeeVote(
+	prev *ledger.Ledger,
+	upcomingSeq uint32,
+	parentValidations []*consensus.Validation,
+	enabled map[[32]byte]bool,
+) [][]byte {
+	feeData, err := prev.Read(keylet.Fees())
+	if err != nil {
+		a.logger.Warn("flag-ledger fee vote: failed to read FeeSettings SLE",
+			"err", err, "seq", prev.Sequence())
+		return nil
+	}
+	if len(feeData) == 0 {
+		// No FeeSettings SLE installed yet — pre-genesis-bootstrap
+		// or a corrupted state. Either way, no current to vote
+		// against; bail.
+		return nil
+	}
+	fees, err := state.ParseFeeSettings(feeData)
+	if err != nil {
+		a.logger.Warn("flag-ledger fee vote: failed to parse FeeSettings SLE",
+			"err", err, "seq", prev.Sequence())
+		return nil
+	}
+
+	xrpFeesEnabled := enabled[amendment.FeatureXRPFees]
+
+	var current feevote.Stance
+	if xrpFeesEnabled {
+		current = feevote.Stance{
+			BaseFee:          fees.BaseFeeDrops,
+			ReserveBase:      fees.ReserveBaseDrops,
+			ReserveIncrement: fees.ReserveIncrementDrops,
+		}
+	} else {
+		current = feevote.Stance{
+			BaseFee:          fees.BaseFee,
+			ReserveBase:      uint64(fees.ReserveBase),
+			ReserveIncrement: uint64(fees.ReserveIncrement),
+		}
+	}
+
+	// Local target stance from the operator config. Zero values
+	// mean "no preference" — fall back to current so the algorithm
+	// sees a no-change signal for that field.
+	target := feevote.Stance{
+		BaseFee:          a.feeVote.BaseFee,
+		ReserveBase:      uint64(a.feeVote.ReserveBase),
+		ReserveIncrement: uint64(a.feeVote.ReserveIncrement),
+	}
+	if target.BaseFee == 0 {
+		target.BaseFee = current.BaseFee
+	}
+	if target.ReserveBase == 0 {
+		target.ReserveBase = current.ReserveBase
+	}
+	if target.ReserveIncrement == 0 {
+		target.ReserveIncrement = current.ReserveIncrement
+	}
+
+	votes := make([]feevote.Vote, 0, len(parentValidations))
+	for _, v := range parentValidations {
+		votes = append(votes, extractFeeVote(v, xrpFeesEnabled))
+	}
+
+	blob, err := feevote.DoVoting(upcomingSeq, current, target, votes, xrpFeesEnabled)
+	if err != nil {
+		a.logger.Warn("flag-ledger fee vote: producer error",
+			"err", err, "seq", prev.Sequence())
+		return nil
+	}
+	if blob == nil {
+		return nil
+	}
+	return [][]byte{blob}
+}
+
+// extractFeeVote pulls the relevant fee fields off a validation
+// into a feevote.Vote. The field set depends on whether the
+// XRPFees amendment is enabled on the parent ledger — pre-XRPFees
+// uses sfBaseFee / sfReserveBase / sfReserveIncrement; post-XRPFees
+// uses the *Drops variants. A zero value on the wire means "field
+// not present" (rippled's STValidation never carries an explicit
+// zero for these fields), which extractFeeVote translates into a
+// nil pointer — feevote.applyVote then routes that to noVote.
+func extractFeeVote(v *consensus.Validation, xrpFeesEnabled bool) feevote.Vote {
+	var out feevote.Vote
+	if xrpFeesEnabled {
+		if v.BaseFeeDrops != 0 {
+			x := v.BaseFeeDrops
+			out.BaseFee = &x
+		}
+		if v.ReserveBaseDrops != 0 {
+			x := v.ReserveBaseDrops
+			out.ReserveBase = &x
+		}
+		if v.ReserveIncrementDrops != 0 {
+			x := v.ReserveIncrementDrops
+			out.ReserveIncrement = &x
+		}
+		return out
+	}
+	if v.BaseFee != 0 {
+		x := v.BaseFee
+		out.BaseFee = &x
+	}
+	if v.ReserveBase != 0 {
+		x := uint64(v.ReserveBase)
+		out.ReserveBase = &x
+	}
+	if v.ReserveIncrement != 0 {
+		x := uint64(v.ReserveIncrement)
+		out.ReserveIncrement = &x
+	}
+	return out
+}
+
+// runAmendmentVote runs the AmendmentTable producer against the
+// parent ledger's enabled amendments + majorities (already parsed
+// at the boundary in readAmendmentsSLE) and the trusted
+// validations' sfAmendments. Returns the serialized
+// EnableAmendment blobs or nil.
+func (a *Adaptor) runAmendmentVote(
+	prev *ledger.Ledger,
+	upcomingSeq uint32,
+	parentValidations []*consensus.Validation,
+	enabled map[[32]byte]bool,
+	majority map[[32]byte]time.Time,
+) [][]byte {
+	votes := make(map[amendmentvote.Amendment]int)
+	for _, v := range parentValidations {
+		for _, h := range v.Amendments {
+			votes[h]++
+		}
+	}
+
+	stances := make(map[amendmentvote.Amendment]amendmentvote.Stance, len(a.amendmentVoteIDs))
+	for _, id := range a.amendmentVoteIDs {
+		stances[id] = amendmentvote.VoteUp
+	}
+
+	in := amendmentvote.Inputs{
+		UpcomingSeq:        upcomingSeq,
+		CloseTime:          prev.Header().CloseTime,
+		MajorityTimeout:    amendmentMajorityTimeout,
+		TrustedValidations: len(parentValidations),
+		Votes:              votes,
+		Enabled:            enabled,
+		Majority:           majority,
+		Stances:            stances,
+		StrictMajority:     enabled[amendment.FeatureFixAmendmentMajorityCalc],
+	}
+	blobs, err := amendmentvote.DoVoting(in)
+	if err != nil {
+		a.logger.Warn("flag-ledger amendment vote: producer error",
+			"err", err, "seq", prev.Sequence())
+		return nil
+	}
+	return blobs
+}

--- a/internal/consensus/adaptor/flag_ledger_vote.go
+++ b/internal/consensus/adaptor/flag_ledger_vote.go
@@ -29,30 +29,59 @@ const amendmentMajorityTimeout = 14 * 24 * time.Hour
 // the feature-flag oracle (rules.Enabled(...) replacement) since
 // *ledger.Ledger doesn't carry an amendment.Rules struct.
 //
-// On read or parse failure, returns empty maps and logs at warn —
-// "no amendments enabled" is a safe degradation: it just means
-// the legacy / pre-fix code paths are taken.
+// On read or parse failure returns ok=false; the producer falls
+// through to nil. Fail-closed mirrors rippled's
+// RCLConsensus.cpp::onClose — there is no try/catch around
+// amendmentTable.doVoting, so a malformed Amendments SLE
+// propagates the exception and suppresses the round. Treating a
+// corrupted SLE as "no amendments enabled" would let GotMajority /
+// Enable fire spuriously on every tracked amendment.
+//
+// A genuinely empty SLE (len(data)==0 — pre-bootstrap genesis
+// state) is a successful read of empty state, not corruption, and
+// returns ok=true with empty maps.
 func (a *Adaptor) readAmendmentsSLE(prev *ledger.Ledger) (
 	enabled map[[32]byte]bool,
 	majorities map[[32]byte]time.Time,
+	ok bool,
+) {
+	data, err := prev.Read(keylet.Amendments())
+	if err != nil {
+		a.logger.Warn("flag-ledger producer: failed to read Amendments SLE; suppressing this round",
+			"err", err, "seq", prev.Sequence())
+		return nil, nil, false
+	}
+	enabled, majorities, ok = parseAmendmentsSLEBytes(data)
+	if !ok {
+		a.logger.Warn("flag-ledger producer: failed to parse Amendments SLE; suppressing this round",
+			"seq", prev.Sequence())
+	}
+	return enabled, majorities, ok
+}
+
+// parseAmendmentsSLEBytes is the pure-data half of readAmendmentsSLE
+// — extracted so the parse-failure branch is unit-testable without
+// having to inject corrupt bytes through a *ledger.Ledger (which is
+// immutable on the closed-ledger path used by the producer).
+//
+// Returns ok=false ONLY on parse failure of non-empty data. An
+// empty input (len(data)==0, the pre-bootstrap genesis state) is a
+// successful read of empty state and returns ok=true with empty
+// maps — matching the rippled ledger walk that finds no SLE at the
+// keylet.Amendments() index.
+func parseAmendmentsSLEBytes(data []byte) (
+	enabled map[[32]byte]bool,
+	majorities map[[32]byte]time.Time,
+	ok bool,
 ) {
 	enabled = map[[32]byte]bool{}
 	majorities = map[[32]byte]time.Time{}
-
-	data, err := prev.Read(keylet.Amendments())
-	if err != nil {
-		a.logger.Warn("flag-ledger producer: failed to read Amendments SLE",
-			"err", err, "seq", prev.Sequence())
-		return enabled, majorities
-	}
 	if len(data) == 0 {
-		return enabled, majorities
+		return enabled, majorities, true
 	}
 	sle, err := pseudo.ParseAmendmentsSLE(data)
 	if err != nil {
-		a.logger.Warn("flag-ledger producer: failed to parse Amendments SLE",
-			"err", err, "seq", prev.Sequence())
-		return enabled, majorities
+		return nil, nil, false
 	}
 	for _, h := range sle.Amendments {
 		enabled[h] = true
@@ -64,7 +93,7 @@ func (a *Adaptor) readAmendmentsSLE(prev *ledger.Ledger) (
 		// runs over a uniform clock.
 		majorities[m.Amendment] = time.Unix(protocol.RippleEpochUnix+int64(m.CloseTime), 0).UTC()
 	}
-	return enabled, majorities
+	return enabled, majorities, true
 }
 
 // runFeeVote runs the FeeVote producer against the parent
@@ -114,22 +143,19 @@ func (a *Adaptor) runFeeVote(
 		}
 	}
 
-	// Local target stance from the operator config. Zero values
-	// mean "no preference" — fall back to current so the algorithm
-	// sees a no-change signal for that field.
+	// Local target stance from the operator config. Each field is
+	// guaranteed non-zero here — adaptor.New() substituted the
+	// rippled FeeSetup defaults (Config.h:65-78) for any field the
+	// operator left unset. We deliberately do NOT fall back to
+	// `current` for zero fields: rippled's FeeVoteImpl.cpp:114-117
+	// constructor takes the supplied FeeSetup verbatim and never
+	// re-defaults at doVoting time, so an operator who somehow
+	// supplied a zero (e.g. via a bug elsewhere) should produce a
+	// zero vote, not silently inherit the parent ledger's setting.
 	target := feevote.Stance{
 		BaseFee:          a.feeVote.BaseFee,
 		ReserveBase:      uint64(a.feeVote.ReserveBase),
 		ReserveIncrement: uint64(a.feeVote.ReserveIncrement),
-	}
-	if target.BaseFee == 0 {
-		target.BaseFee = current.BaseFee
-	}
-	if target.ReserveBase == 0 {
-		target.ReserveBase = current.ReserveBase
-	}
-	if target.ReserveIncrement == 0 {
-		target.ReserveIncrement = current.ReserveIncrement
 	}
 
 	votes := make([]feevote.Vote, 0, len(parentValidations))
@@ -194,6 +220,15 @@ func extractFeeVote(v *consensus.Validation, xrpFeesEnabled bool) feevote.Vote {
 // at the boundary in readAmendmentsSLE) and the trusted
 // validations' sfAmendments. Returns the serialized
 // EnableAmendment blobs or nil.
+//
+// Vote tallies are routed through a.trustedVotes — a 24h
+// per-validator cache mirroring rippled's TrustedVotes at
+// AmendmentTable.cpp:75-286 — so a validator that drops briefly
+// near a flag ledger doesn't cause an amendment to flap between
+// GotMajority and LostMajority across consecutive rounds. Both
+// TrustedValidations (the threshold denominator) and Votes flow
+// from the cache; the raw parentValidations slice is fed into
+// the cache via RecordVotes and not used afterwards.
 func (a *Adaptor) runAmendmentVote(
 	prev *ledger.Ledger,
 	upcomingSeq uint32,
@@ -201,11 +236,13 @@ func (a *Adaptor) runAmendmentVote(
 	enabled map[[32]byte]bool,
 	majority map[[32]byte]time.Time,
 ) [][]byte {
-	votes := make(map[amendmentvote.Amendment]int)
-	for _, v := range parentValidations {
-		for _, h := range v.Amendments {
-			votes[h]++
-		}
+	closeTime := prev.Header().CloseTime
+	a.trustedVotes.RecordVotes(closeTime, parentValidations)
+	available, rawVotes := a.trustedVotes.GetVotes()
+
+	votes := make(map[amendmentvote.Amendment]int, len(rawVotes))
+	for k, v := range rawVotes {
+		votes[k] = v
 	}
 
 	stances := make(map[amendmentvote.Amendment]amendmentvote.Stance, len(a.amendmentVoteIDs))
@@ -215,9 +252,9 @@ func (a *Adaptor) runAmendmentVote(
 
 	in := amendmentvote.Inputs{
 		UpcomingSeq:        upcomingSeq,
-		CloseTime:          prev.Header().CloseTime,
+		CloseTime:          closeTime,
 		MajorityTimeout:    amendmentMajorityTimeout,
-		TrustedValidations: len(parentValidations),
+		TrustedValidations: available,
 		Votes:              votes,
 		Enabled:            enabled,
 		Majority:           majority,

--- a/internal/consensus/adaptor/flag_ledger_vote.go
+++ b/internal/consensus/adaptor/flag_ledger_vote.go
@@ -245,9 +245,9 @@ func (a *Adaptor) runAmendmentVote(
 		votes[k] = v
 	}
 
-	stances := make(map[amendmentvote.Amendment]amendmentvote.Stance, len(a.amendmentVoteIDs))
-	for _, id := range a.amendmentVoteIDs {
-		stances[id] = amendmentvote.VoteUp
+	stances := make(map[amendmentvote.Amendment]amendmentvote.Stance, len(a.amendmentStances))
+	for id, stance := range a.amendmentStances {
+		stances[id] = stance
 	}
 
 	in := amendmentvote.Inputs{

--- a/internal/consensus/adaptor/flag_ledger_vote.go
+++ b/internal/consensus/adaptor/flag_ledger_vote.go
@@ -236,7 +236,15 @@ func (a *Adaptor) runAmendmentVote(
 	enabled map[[32]byte]bool,
 	majority map[[32]byte]time.Time,
 ) [][]byte {
-	closeTime := prev.Header().CloseTime
+	// Use prev's parent close time, not prev's own close time:
+	// rippled passes lastClosedLedger->parentCloseTime() into
+	// AmendmentTable::doVoting (AmendmentTable.h:157), which is the
+	// close time of the ledger whose validations we're tallying
+	// (parentValidations come from prev's parent). Pairing the
+	// validations with prev's close time would drift the 24h
+	// trusted-vote cache expiry and the majority-window enable
+	// check by one round.
+	closeTime := prev.Header().ParentCloseTime
 	a.trustedVotes.RecordVotes(closeTime, parentValidations)
 	available, rawVotes := a.trustedVotes.GetVotes()
 

--- a/internal/consensus/adaptor/flag_ledger_vote_test.go
+++ b/internal/consensus/adaptor/flag_ledger_vote_test.go
@@ -1,0 +1,197 @@
+package adaptor
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestAdaptorWithConfig is newTestAdaptor with the operator
+// config knobs (FeeVote, AmendmentVote) exposed for the
+// flag-ledger-vote tests. Reuses the same standalone service +
+// validator seed.
+func newTestAdaptorWithConfig(t *testing.T, fee FeeVoteStance, amendmentVote []string) *Adaptor {
+	t.Helper()
+	svc := newTestLedgerService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	return New(Config{
+		LedgerService: svc,
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+		FeeVote:       fee,
+		AmendmentVote: amendmentVote,
+	})
+}
+
+// TestGenerateFlagLedgerPseudoTxs_NoStanceNoBlobs verifies the
+// quiet path: a freshly-started node with no fee or amendment
+// vote stance produces no pseudo-txs at flag-ledger close.
+func TestGenerateFlagLedgerPseudoTxs_NoStanceNoBlobs(t *testing.T) {
+	a := newTestAdaptor(t)
+	prev := a.ledgerService.GetClosedLedger()
+	require.NotNil(t, prev)
+	wrapped := WrapLedger(prev)
+
+	blobs := a.GenerateFlagLedgerPseudoTxs(wrapped, nil)
+	assert.Nil(t, blobs,
+		"no fee target, no amendment stance, no validations → no pseudo-txs")
+}
+
+// TestGenerateFlagLedgerPseudoTxs_FeeVoteSeedsSetFee pins the
+// fee-vote wiring: with a configured FeeVote target that differs
+// from the parent ledger's FeeSettings, the constructor seed for
+// target wins and a SetFee pseudo-tx is emitted.
+//
+// Genesis FeeSettings carries the standalone defaults; a target
+// 10× the base fee is well outside that, so the algorithm picks
+// target.
+func TestGenerateFlagLedgerPseudoTxs_FeeVoteSeedsSetFee(t *testing.T) {
+	a := newTestAdaptorWithConfig(t, FeeVoteStance{
+		BaseFee:          100, // genesis is 10
+		ReserveBase:      50_000_000,
+		ReserveIncrement: 5_000_000,
+	}, nil)
+	prev := a.ledgerService.GetClosedLedger()
+	require.NotNil(t, prev)
+	wrapped := WrapLedger(prev)
+
+	blobs := a.GenerateFlagLedgerPseudoTxs(wrapped, nil)
+	require.Len(t, blobs, 1, "fee target differs from current → one SetFee blob")
+
+	stx := decodeTx(t, blobs[0])
+	assert.Equal(t, "SetFee", stx["TransactionType"],
+		"emitted blob must be a SetFee pseudo-tx")
+	// LedgerSequence carries upcoming seq = parent + 1.
+	assert.EqualValues(t, prev.Sequence()+1, asUint(stx["LedgerSequence"]))
+}
+
+// TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority
+// pins the amendment-vote wiring: with a configured AmendmentVote
+// stance and one trusted validator (ourselves) voting for it, the
+// algorithm emits an EnableAmendment with tfGotMajority.
+//
+// Genesis enables every SupportedYes/VoteDefaultYes amendment in
+// the registry, so any real amendment name is already in the
+// Enabled set and the producer correctly skips it. To exercise
+// the not-yet-enabled branch we synthesize a pretend amendment
+// hash that the ledger has never seen and inject it into the
+// local stance directly.
+func TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority(t *testing.T) {
+	a := newTestAdaptorWithConfig(t, FeeVoteStance{}, nil)
+	var synthetic [32]byte
+	for i := range synthetic {
+		synthetic[i] = 0xC1
+	}
+	a.amendmentVoteIDs = [][32]byte{synthetic}
+
+	prev := a.ledgerService.GetClosedLedger()
+	require.NotNil(t, prev)
+	wrapped := WrapLedger(prev)
+
+	val := &consensus.Validation{
+		LedgerID:   wrapped.ID(),
+		LedgerSeq:  wrapped.Seq(),
+		NodeID:     a.identity.NodeID,
+		SignTime:   time.Now(),
+		Amendments: [][32]byte{synthetic},
+	}
+
+	blobs := a.GenerateFlagLedgerPseudoTxs(wrapped, []*consensus.Validation{val})
+
+	var found bool
+	for _, blob := range blobs {
+		stx := decodeTx(t, blob)
+		if stx["TransactionType"] != "EnableAmendment" {
+			continue
+		}
+		if stringFold(stx["Amendment"]) != hex.EncodeToString(synthetic[:]) {
+			continue
+		}
+		if asUint(stx["Flags"]) == 0x00010000 {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"expected EnableAmendment(synthetic, GotMajority) when our single trusted validator votes for it")
+}
+
+// TestGenerateFlagLedgerPseudoTxs_NoLedgerService is the defensive
+// path: an adaptor with no ledger service returns nil rather than
+// panicking. Tests that construct adaptors directly (without going
+// through Components) hit this path.
+func TestGenerateFlagLedgerPseudoTxs_NoLedgerService(t *testing.T) {
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	a := New(Config{
+		Identity:   identity,
+		Validators: []consensus.NodeID{identity.NodeID},
+	})
+	prev := newTestLedgerService(t).GetClosedLedger()
+	wrapped := WrapLedger(prev)
+	blobs := a.GenerateFlagLedgerPseudoTxs(wrapped, nil)
+	assert.Nil(t, blobs, "no ledger service → no pseudo-txs (no panic)")
+}
+
+func decodeTx(t *testing.T, blob []byte) map[string]any {
+	t.Helper()
+	out, err := binarycodec.Decode(hex.EncodeToString(blob))
+	require.NoError(t, err, "pseudo-tx blob must round-trip through binarycodec.Decode")
+	return out
+}
+
+func asUint(v any) uint64 {
+	switch n := v.(type) {
+	case uint8:
+		return uint64(n)
+	case uint16:
+		return uint64(n)
+	case uint32:
+		return uint64(n)
+	case uint64:
+		return n
+	case int:
+		return uint64(n)
+	case int64:
+		return uint64(n)
+	case float64:
+		return uint64(n)
+	case string:
+		var x uint64
+		for _, c := range n {
+			x <<= 4
+			switch {
+			case c >= '0' && c <= '9':
+				x |= uint64(c - '0')
+			case c >= 'a' && c <= 'f':
+				x |= uint64(c-'a') + 10
+			case c >= 'A' && c <= 'F':
+				x |= uint64(c-'A') + 10
+			}
+		}
+		return x
+	}
+	return 0
+}
+
+func stringFold(v any) string {
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	out := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'F' {
+			c = c - 'A' + 'a'
+		}
+		out[i] = c
+	}
+	return string(out)
+}

--- a/internal/consensus/adaptor/flag_ledger_vote_test.go
+++ b/internal/consensus/adaptor/flag_ledger_vote_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/drops"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/amendmentvote"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
 	"github.com/LeJamon/goXRPLd/shamap"
@@ -142,7 +144,7 @@ func TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority(t *testing.T)
 	for i := range synthetic {
 		synthetic[i] = 0xC1
 	}
-	a.amendmentVoteIDs = [][32]byte{synthetic}
+	a.amendmentStances = map[[32]byte]amendmentvote.Stance{synthetic: amendmentvote.VoteUp}
 
 	prev := a.ledgerService.GetClosedLedger()
 	require.NotNil(t, prev)
@@ -174,6 +176,102 @@ func TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority(t *testing.T)
 	}
 	assert.True(t, found,
 		"expected EnableAmendment(synthetic, GotMajority) when our single trusted validator votes for it")
+}
+
+// TestAmendmentStances_SeededFromRegistry verifies the constructor
+// walks amendment.AllFeatures() and seeds the stance map from each
+// feature's registered VoteBehavior, mirroring rippled's
+// AmendmentTable.cpp:556-580 — DefaultYes amendments default to
+// VoteUp, Obsolete amendments default to VoteObsolete, DefaultNo
+// amendments are absent from the map (lookup returns VoteAbstain).
+// Without this, an unconfigured Go validator silently abstains on
+// every amendment a rippled validator would auto-upvote.
+func TestAmendmentStances_SeededFromRegistry(t *testing.T) {
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	a := New(Config{
+		LedgerService: newTestLedgerService(t),
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+
+	upvoted, obsolete, defaultNoSeen := 0, 0, 0
+	for _, f := range amendment.AllFeatures() {
+		stance, present := a.amendmentStances[f.ID]
+		switch {
+		case f.Vote == amendment.VoteObsolete:
+			require.True(t, present, "obsolete amendment %q must seed VoteObsolete", f.Name)
+			assert.Equal(t, amendmentvote.VoteObsolete, stance,
+				"obsolete amendment %q must be VoteObsolete", f.Name)
+			obsolete++
+		case f.Supported == amendment.SupportedYes && f.Vote == amendment.VoteDefaultYes && !f.Retired:
+			require.True(t, present, "default-yes amendment %q must seed VoteUp", f.Name)
+			assert.Equal(t, amendmentvote.VoteUp, stance,
+				"default-yes supported non-retired amendment %q must be VoteUp", f.Name)
+			upvoted++
+		case f.Vote == amendment.VoteDefaultNo:
+			assert.False(t, present,
+				"default-no amendment %q must NOT be in stances (lookup returns VoteAbstain)", f.Name)
+			defaultNoSeen++
+		}
+	}
+	assert.Greater(t, upvoted, 0, "registry must contain at least one default-yes amendment")
+	assert.Greater(t, obsolete, 0, "registry must contain at least one obsolete amendment")
+	assert.Greater(t, defaultNoSeen, 0, "registry must contain at least one default-no amendment")
+}
+
+// TestAmendmentStances_ConfigOverridesUpvote verifies an operator
+// can promote a default-no amendment to VoteUp via
+// Config.AmendmentVote — the same role rippled's [amendments]
+// stanza plays at AmendmentTable.cpp:584-598.
+func TestAmendmentStances_ConfigOverridesUpvote(t *testing.T) {
+	// Pick a default-no, supported, non-retired feature from the
+	// registry. fixDirectoryLimit fits this profile in the current
+	// registry; if that ever flips we'll fail loudly here rather
+	// than silently testing the wrong branch.
+	target := amendment.GetFeatureByName("fixDirectoryLimit")
+	require.NotNil(t, target)
+	require.Equal(t, amendment.VoteDefaultNo, target.Vote,
+		"test premise: target must be VoteDefaultNo (registry changed?)")
+
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	a := New(Config{
+		LedgerService: newTestLedgerService(t),
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+		AmendmentVote: []string{target.Name},
+	})
+
+	stance, present := a.amendmentStances[target.ID]
+	require.True(t, present, "operator-listed amendment must enter stances")
+	assert.Equal(t, amendmentvote.VoteUp, stance,
+		"Config.AmendmentVote must override default-no to VoteUp")
+}
+
+// TestAmendmentStances_ConfigCannotOverrideObsolete pins rippled's
+// AmendmentTable.cpp:728-733 contract: persistVote refuses to flip
+// an obsolete amendment's vote. Listing such an amendment in
+// Config.AmendmentVote must NOT promote it to VoteUp.
+func TestAmendmentStances_ConfigCannotOverrideObsolete(t *testing.T) {
+	target := amendment.GetFeatureByName("NonFungibleTokensV1")
+	require.NotNil(t, target)
+	require.Equal(t, amendment.VoteObsolete, target.Vote,
+		"test premise: target must be VoteObsolete (registry changed?)")
+
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	a := New(Config{
+		LedgerService: newTestLedgerService(t),
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+		AmendmentVote: []string{target.Name},
+	})
+
+	stance, present := a.amendmentStances[target.ID]
+	require.True(t, present, "obsolete amendment seeded by registry walk")
+	assert.Equal(t, amendmentvote.VoteObsolete, stance,
+		"Config.AmendmentVote must NOT promote obsolete amendments to VoteUp")
 }
 
 // TestFeeVote_EmptyConfigUsesRippledDefaults pins Item 1: with no

--- a/internal/consensus/adaptor/flag_ledger_vote_test.go
+++ b/internal/consensus/adaptor/flag_ledger_vote_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestAdaptorWithConfig is newTestAdaptor with the operator
-// config knobs (FeeVote, AmendmentVote) exposed for the
-// flag-ledger-vote tests. Reuses the same standalone service +
-// validator seed.
+// newTestAdaptorWithConfig is newTestAdaptor with FeeVote and
+// AmendmentVote config knobs exposed.
 func newTestAdaptorWithConfig(t *testing.T, fee FeeVoteStance, amendmentVote []string) *Adaptor {
 	t.Helper()
 	svc := newTestLedgerService(t)
@@ -90,8 +88,8 @@ func TestGenerateFlagLedgerPseudoTxs_FeeVoteSeedsSetFee(t *testing.T) {
 	stx := decodeTx(t, blobs[0])
 	assert.Equal(t, "SetFee", stx["TransactionType"],
 		"emitted blob must be a SetFee pseudo-tx")
-	// LedgerSequence carries upcoming seq = parent + 1.
-	assert.EqualValues(t, prev.Sequence()+1, asUint(stx["LedgerSequence"]))
+	assert.EqualValues(t, prev.Sequence()+1, asUint(stx["LedgerSequence"]),
+		"LedgerSequence carries upcoming seq = parent + 1")
 }
 
 // TestExcludeNegativeUNL_DropsBannedValidators is a pure-helper
@@ -176,8 +174,7 @@ func TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority(t *testing.T)
 
 // TestGenerateFlagLedgerPseudoTxs_NoLedgerService is the defensive
 // path: an adaptor with no ledger service returns nil rather than
-// panicking. Tests that construct adaptors directly (without going
-// through Components) hit this path.
+// panicking.
 func TestGenerateFlagLedgerPseudoTxs_NoLedgerService(t *testing.T) {
 	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
 	require.NoError(t, err)

--- a/internal/consensus/adaptor/flag_ledger_vote_test.go
+++ b/internal/consensus/adaptor/flag_ledger_vote_test.go
@@ -172,6 +172,74 @@ func TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority(t *testing.T)
 		"expected EnableAmendment(synthetic, GotMajority) when our single trusted validator votes for it")
 }
 
+// TestFeeVote_EmptyConfigUsesRippledDefaults pins Item 1: with no
+// FeeVote stanza in the config, adaptor.New() must seed each field
+// from rippled's FeeSetup defaults (Config.h:65-78) so an
+// unconfigured validator votes toward those defaults rather than
+// no-change.
+func TestFeeVote_EmptyConfigUsesRippledDefaults(t *testing.T) {
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	a := New(Config{
+		LedgerService: newTestLedgerService(t),
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+	assert.EqualValues(t, 10, a.feeVote.BaseFee,
+		"empty BaseFee → rippled FeeSetup default reference_fee=10")
+	assert.EqualValues(t, 10_000_000, a.feeVote.ReserveBase,
+		"empty ReserveBase → rippled FeeSetup default account_reserve=10*DROPS_PER_XRP")
+	assert.EqualValues(t, 2_000_000, a.feeVote.ReserveIncrement,
+		"empty ReserveIncrement → rippled FeeSetup default owner_reserve=2*DROPS_PER_XRP")
+}
+
+// TestFeeVote_PartialConfigKeepsExplicitFields verifies the
+// per-field substitution: an operator who sets BaseFee but leaves
+// reserves zero must keep their explicit BaseFee and inherit the
+// rippled defaults for the unset reserve fields.
+func TestFeeVote_PartialConfigKeepsExplicitFields(t *testing.T) {
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	a := New(Config{
+		LedgerService: newTestLedgerService(t),
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+		FeeVote:       FeeVoteStance{BaseFee: 25}, // reserves left zero
+	})
+	assert.EqualValues(t, 25, a.feeVote.BaseFee, "explicit BaseFee preserved")
+	assert.EqualValues(t, 10_000_000, a.feeVote.ReserveBase,
+		"unset ReserveBase → rippled default")
+	assert.EqualValues(t, 2_000_000, a.feeVote.ReserveIncrement,
+		"unset ReserveIncrement → rippled default")
+}
+
+// TestParseAmendmentsSLEBytes_FailsClosedOnGarbage pins Item 2:
+// the bytes-half of readAmendmentsSLE returns ok=false on parse
+// error so GenerateFlagLedgerPseudoTxs can suppress the round.
+// Mirrors rippled's RCLConsensus::onClose, which has no try/catch
+// around amendmentTable.doVoting — a malformed Amendments SLE
+// propagates the exception and prevents pseudo-tx emission. The
+// alternative ("no amendments enabled") would let GotMajority /
+// Enable fire spuriously on every tracked amendment.
+func TestParseAmendmentsSLEBytes_FailsClosedOnGarbage(t *testing.T) {
+	corrupt := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+	enabled, majorities, ok := parseAmendmentsSLEBytes(corrupt)
+	assert.False(t, ok, "garbage SLE bytes must return ok=false")
+	assert.Nil(t, enabled, "ok=false must zero enabled to prevent partial-state misuse")
+	assert.Nil(t, majorities, "ok=false must zero majorities to prevent partial-state misuse")
+}
+
+// TestParseAmendmentsSLEBytes_EmptyIsBootstrap pins the
+// genesis-bootstrap path: an empty SLE (no entry installed) is a
+// successful read of empty state, NOT corruption — returns
+// ok=true with empty maps so producers can run normally.
+func TestParseAmendmentsSLEBytes_EmptyIsBootstrap(t *testing.T) {
+	enabled, majorities, ok := parseAmendmentsSLEBytes(nil)
+	assert.True(t, ok, "empty SLE is bootstrap state, not corruption")
+	assert.Empty(t, enabled)
+	assert.Empty(t, majorities)
+}
+
 // TestGenerateFlagLedgerPseudoTxs_NoLedgerService is the defensive
 // path: an adaptor with no ledger service returns nil rather than
 // panicking.

--- a/internal/consensus/adaptor/flag_ledger_vote_test.go
+++ b/internal/consensus/adaptor/flag_ledger_vote_test.go
@@ -6,7 +6,11 @@ import (
 	"time"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/drops"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/shamap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -238,6 +242,52 @@ func TestParseAmendmentsSLEBytes_EmptyIsBootstrap(t *testing.T) {
 	assert.True(t, ok, "empty SLE is bootstrap state, not corruption")
 	assert.Empty(t, enabled)
 	assert.Empty(t, majorities)
+}
+
+// TestRunAmendmentVote_UsesParentCloseTime pins the rippled-parity
+// time choice at AmendmentTable.h:157: doVoting is invoked with
+// lastClosedLedger->parentCloseTime() — the close time of the
+// ledger whose validations are being tallied — not the close time
+// of the flag ledger itself. Pairing the parent-validations with
+// prev's own close time would drift the 24h trusted-vote cache
+// expiry and the majority-window enable check by one round.
+//
+// Build a synthetic prev with ParentCloseTime far enough below
+// CloseTime that the cache timeout is unambiguous, run the
+// producer, and verify the recorded timeout is parent-anchored.
+func TestRunAmendmentVote_UsesParentCloseTime(t *testing.T) {
+	a := newTestAdaptorWithConfig(t, FeeVoteStance{}, nil)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+
+	parentClose := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	flagClose := parentClose.Add(time.Hour)
+	prev := ledger.NewFromHeader(header.LedgerHeader{
+		LedgerIndex:     256,
+		ParentCloseTime: parentClose,
+		CloseTime:       flagClose,
+	}, stateMap, txMap, drops.Fees{})
+
+	val := &consensus.Validation{
+		NodeID:     a.identity.NodeID,
+		Amendments: [][32]byte{{0xA1}},
+	}
+	a.runAmendmentVote(prev, prev.Sequence()+1, []*consensus.Validation{val}, nil, nil)
+
+	entry, ok := a.trustedVotes.recordedVotes[a.identity.NodeID]
+	require.True(t, ok, "self-validation must register in trusted-vote cache")
+	require.True(t, entry.hasTimeout(),
+		"recordVotes must seat the timeout for a fresh validation")
+
+	want := parentClose.Add(trustedVotesTimeout)
+	assert.True(t, entry.timeout.Equal(want),
+		"timeout must be ParentCloseTime+24h (got %s, want %s); "+
+			"if this drifts to flagClose+24h the producer regressed to "+
+			"prev.CloseTime, breaking AmendmentTable.h:157 parity",
+		entry.timeout, want)
 }
 
 // TestGenerateFlagLedgerPseudoTxs_NoLedgerService is the defensive

--- a/internal/consensus/adaptor/flag_ledger_vote_test.go
+++ b/internal/consensus/adaptor/flag_ledger_vote_test.go
@@ -29,18 +29,21 @@ func newTestAdaptorWithConfig(t *testing.T, fee FeeVoteStance, amendmentVote []s
 	})
 }
 
-// TestGenerateFlagLedgerPseudoTxs_NoStanceNoBlobs verifies the
-// quiet path: a freshly-started node with no fee or amendment
-// vote stance produces no pseudo-txs at flag-ledger close.
-func TestGenerateFlagLedgerPseudoTxs_NoStanceNoBlobs(t *testing.T) {
+// TestGenerateFlagLedgerPseudoTxs_BelowQuorumNoBlobs pins the
+// quorum gate at RCLConsensus.cpp:361: with the trusted set
+// non-empty (quorum >= 1) and zero validations passed in, the
+// producer falls through to nil before any fee or amendment work.
+func TestGenerateFlagLedgerPseudoTxs_BelowQuorumNoBlobs(t *testing.T) {
 	a := newTestAdaptor(t)
 	prev := a.ledgerService.GetClosedLedger()
 	require.NotNil(t, prev)
 	wrapped := WrapLedger(prev)
 
+	require.Equal(t, 1, a.GetQuorum(), "single-validator UNL must yield quorum=1")
+
 	blobs := a.GenerateFlagLedgerPseudoTxs(wrapped, nil)
 	assert.Nil(t, blobs,
-		"no fee target, no amendment stance, no validations → no pseudo-txs")
+		"len(filtered)=0 < quorum=1 → no pseudo-txs (RCLConsensus.cpp:361)")
 }
 
 // TestGenerateFlagLedgerPseudoTxs_FeeVoteSeedsSetFee pins the
@@ -50,7 +53,10 @@ func TestGenerateFlagLedgerPseudoTxs_NoStanceNoBlobs(t *testing.T) {
 //
 // Genesis FeeSettings carries the standalone defaults; a target
 // 10× the base fee is well outside that, so the algorithm picks
-// target.
+// target. We pass a self-validation of the parent so the post-
+// quorum-gate code runs (RCLConsensus.cpp:361 requires
+// validations.size() >= quorum, which is 1 in this single-validator
+// fixture).
 func TestGenerateFlagLedgerPseudoTxs_FeeVoteSeedsSetFee(t *testing.T) {
 	a := newTestAdaptorWithConfig(t, FeeVoteStance{
 		BaseFee:          100, // genesis is 10
@@ -61,7 +67,24 @@ func TestGenerateFlagLedgerPseudoTxs_FeeVoteSeedsSetFee(t *testing.T) {
 	require.NotNil(t, prev)
 	wrapped := WrapLedger(prev)
 
-	blobs := a.GenerateFlagLedgerPseudoTxs(wrapped, nil)
+	// Self-validation that votes for the target fees. Both legacy
+	// and post-XRPFees field sets are populated so the test is
+	// agnostic to whichever wire format the parent ledger's
+	// amendment state selects.
+	val := &consensus.Validation{
+		LedgerID:              wrapped.ParentID(),
+		LedgerSeq:             wrapped.Seq() - 1,
+		NodeID:                a.identity.NodeID,
+		SignTime:              time.Now(),
+		BaseFee:               100,
+		ReserveBase:           50_000_000,
+		ReserveIncrement:      5_000_000,
+		BaseFeeDrops:          100,
+		ReserveBaseDrops:      50_000_000,
+		ReserveIncrementDrops: 5_000_000,
+	}
+
+	blobs := a.GenerateFlagLedgerPseudoTxs(wrapped, []*consensus.Validation{val})
 	require.Len(t, blobs, 1, "fee target differs from current → one SetFee blob")
 
 	stx := decodeTx(t, blobs[0])
@@ -69,6 +92,35 @@ func TestGenerateFlagLedgerPseudoTxs_FeeVoteSeedsSetFee(t *testing.T) {
 		"emitted blob must be a SetFee pseudo-tx")
 	// LedgerSequence carries upcoming seq = parent + 1.
 	assert.EqualValues(t, prev.Sequence()+1, asUint(stx["LedgerSequence"]))
+}
+
+// TestExcludeNegativeUNL_DropsBannedValidators is a pure-helper
+// test of the negUNL filter at RCLConsensus.cpp:358: validations
+// signed by validators in the negUNL set are dropped before the
+// quorum count and before vote tallying.
+func TestExcludeNegativeUNL_DropsBannedValidators(t *testing.T) {
+	good := consensus.NodeID{0x01}
+	banned := consensus.NodeID{0x02}
+	keep := consensus.NodeID{0x03}
+	vals := []*consensus.Validation{
+		{NodeID: good},
+		{NodeID: banned},
+		{NodeID: keep},
+	}
+
+	out := excludeNegativeUNL(vals, []consensus.NodeID{banned})
+	require.Len(t, out, 2, "one validator on negUNL → two validations remain")
+	assert.Equal(t, good, out[0].NodeID)
+	assert.Equal(t, keep, out[1].NodeID)
+}
+
+// TestExcludeNegativeUNL_EmptyNegUNLPassesThrough verifies the
+// no-allocation fast path: an empty negUNL returns the input slice
+// header unchanged.
+func TestExcludeNegativeUNL_EmptyNegUNLPassesThrough(t *testing.T) {
+	vals := []*consensus.Validation{{NodeID: consensus.NodeID{0x01}}}
+	out := excludeNegativeUNL(vals, nil)
+	assert.Equal(t, vals, out, "empty negUNL → unchanged input")
 }
 
 // TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority

--- a/internal/consensus/adaptor/trusted_votes.go
+++ b/internal/consensus/adaptor/trusted_votes.go
@@ -1,0 +1,134 @@
+package adaptor
+
+import (
+	"sync"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// trustedVotesTimeout is how long a validator's amendment vote is
+// retained after their last validation. Mirrors rippled's
+// expiresAfter = 24h at
+// rippled/src/xrpld/app/misc/detail/AmendmentTable.cpp:172.
+const trustedVotesTimeout = 24 * time.Hour
+
+// upvotesAndTimeout is the per-validator entry — last-seen vote set
+// and the close-time at which it expires. Mirrors UpvotesAndTimeout
+// at rippled/src/xrpld/app/misc/detail/AmendmentTable.cpp:98-107.
+type upvotesAndTimeout struct {
+	upVotes [][32]byte
+	// timeout zero-value means "unseated" — either we have never
+	// seen a validation from this validator, or its previous vote
+	// already expired and was cleared.
+	timeout time.Time
+}
+
+func (u *upvotesAndTimeout) hasTimeout() bool { return !u.timeout.IsZero() }
+
+// TrustedVotes records the most recent amendment vote from each
+// trusted validator and applies a 24h timeout. The cache prevents
+// amendment "flapping" — when a flaky validator drops connectivity
+// briefly, their last vote is retained for up to 24h so a borderline
+// amendment doesn't oscillate between GotMajority and LostMajority
+// across consecutive flag ledgers. Mirrors rippled's TrustedVotes
+// class at rippled/src/xrpld/app/misc/detail/AmendmentTable.cpp:75-286.
+type TrustedVotes struct {
+	mu sync.Mutex
+	// recordedVotes maps trusted-validator NodeID to its retained
+	// vote. Membership is reconciled by TrustChanged; non-trusted
+	// validators are never inserted.
+	recordedVotes map[consensus.NodeID]*upvotesAndTimeout
+}
+
+// NewTrustedVotes constructs an empty TrustedVotes. Call
+// TrustChanged with the initial UNL before recording any votes —
+// otherwise every validation will be ignored as untrusted.
+func NewTrustedVotes() *TrustedVotes {
+	return &TrustedVotes{recordedVotes: map[consensus.NodeID]*upvotesAndTimeout{}}
+}
+
+// TrustChanged reconciles the recordedVotes set against the current
+// trusted-validator list. Existing entries for still-trusted
+// validators are preserved verbatim; entries for removed validators
+// are dropped; newly-trusted validators get an empty entry with
+// unseated timeout. Mirrors trustChanged at
+// AmendmentTable.cpp:119-147.
+func (t *TrustedVotes) TrustChanged(allTrusted []consensus.NodeID) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	newSet := make(map[consensus.NodeID]*upvotesAndTimeout, len(allTrusted))
+	for _, id := range allTrusted {
+		if existing, ok := t.recordedVotes[id]; ok {
+			newSet[id] = existing
+		} else {
+			newSet[id] = &upvotesAndTimeout{}
+		}
+	}
+	t.recordedVotes = newSet
+}
+
+// RecordVotes ingests this round's validations. For each validation
+// signed by a trusted validator: timeout is reset to closeTime + 24h
+// and upVotes are replaced with the validation's amendments. Then
+// any entry whose timeout is past closeTime is cleared (timeout
+// unseated, upVotes emptied) so its votes no longer count. Mirrors
+// recordVotes at AmendmentTable.cpp:152-261.
+func (t *TrustedVotes) RecordVotes(
+	closeTime time.Time,
+	validations []*consensus.Validation,
+) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	newTimeout := closeTime.Add(trustedVotesTimeout)
+	for _, v := range validations {
+		entry, ok := t.recordedVotes[v.NodeID]
+		if !ok {
+			continue // ignore untrusted-validator validations
+		}
+		entry.timeout = newTimeout
+		if len(v.Amendments) == 0 {
+			// Validator emitted no sfAmendments — equivalent to
+			// rippled's "validator has no amendment votes" branch
+			// at AmendmentTable.cpp:206-211 which clears upVotes.
+			entry.upVotes = nil
+			continue
+		}
+		entry.upVotes = append(entry.upVotes[:0], v.Amendments...)
+	}
+	for _, entry := range t.recordedVotes {
+		if !entry.hasTimeout() {
+			continue
+		}
+		if closeTime.After(entry.timeout) {
+			entry.timeout = time.Time{}
+			entry.upVotes = nil
+		}
+	}
+}
+
+// GetVotes returns (availableValidatorCount, votesPerAmendment).
+// availableValidatorCount is the count of entries whose timeout is
+// set (i.e., we've seen a recent enough validation).
+// votesPerAmendment sums upVotes across all entries — only entries
+// with a set timeout contribute, by RecordVotes's invariant
+// (cleared entries have empty upVotes). Mirrors getVotes at
+// AmendmentTable.cpp:266-285.
+func (t *TrustedVotes) GetVotes() (int, map[[32]byte]int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	votes := map[[32]byte]int{}
+	available := 0
+	for _, entry := range t.recordedVotes {
+		if entry.hasTimeout() {
+			available++
+		}
+		for _, h := range entry.upVotes {
+			votes[h]++
+		}
+	}
+	return available, votes
+}

--- a/internal/consensus/adaptor/trusted_votes_test.go
+++ b/internal/consensus/adaptor/trusted_votes_test.go
@@ -1,0 +1,304 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// trustedVotesEpoch is a stable reference past the XRPL epoch so
+// timeout arithmetic stays in well-defined territory.
+var trustedVotesEpoch = time.Unix(1_700_000_000, 0).UTC()
+
+func makeNodeID(b byte) consensus.NodeID {
+	var id consensus.NodeID
+	id[0] = b
+	return id
+}
+
+func makeAmendmentTV(b byte) [32]byte {
+	var a [32]byte
+	for i := range a {
+		a[i] = b
+	}
+	return a
+}
+
+// TestTrustedVotes_RecordsTrustedValidatorVotes verifies the basic
+// happy path: a validation from a trusted validator contributes
+// its sfAmendments to GetVotes and bumps available by one.
+func TestTrustedVotes_RecordsTrustedValidatorVotes(t *testing.T) {
+	v1 := makeNodeID(1)
+	v2 := makeNodeID(2)
+	a := makeAmendmentTV(0xAA)
+	b := makeAmendmentTV(0xBB)
+
+	tv := NewTrustedVotes()
+	tv.TrustChanged([]consensus.NodeID{v1, v2})
+
+	tv.RecordVotes(trustedVotesEpoch, []*consensus.Validation{
+		{NodeID: v1, Amendments: [][32]byte{a, b}},
+		{NodeID: v2, Amendments: [][32]byte{a}},
+	})
+
+	available, votes := tv.GetVotes()
+	assert.Equal(t, 2, available, "both trusted validators voted → available=2")
+	assert.Equal(t, 2, votes[a], "amendment a got two upVotes")
+	assert.Equal(t, 1, votes[b], "amendment b got one upVote")
+}
+
+// TestTrustedVotes_IgnoresUntrustedValidations verifies that a
+// validation from a non-trusted NodeID is silently dropped — its
+// votes do not appear in GetVotes and it does not affect available.
+func TestTrustedVotes_IgnoresUntrustedValidations(t *testing.T) {
+	trusted := makeNodeID(1)
+	untrusted := makeNodeID(99)
+	a := makeAmendmentTV(0xAA)
+
+	tv := NewTrustedVotes()
+	tv.TrustChanged([]consensus.NodeID{trusted})
+
+	tv.RecordVotes(trustedVotesEpoch, []*consensus.Validation{
+		{NodeID: untrusted, Amendments: [][32]byte{a}},
+	})
+
+	available, votes := tv.GetVotes()
+	assert.Equal(t, 0, available, "no trusted validations → available=0")
+	assert.Empty(t, votes, "untrusted votes must not be tallied")
+}
+
+// TestTrustedVotes_24hTimeoutClears advances closeTime past the
+// 24h timeout and verifies that the cached vote is fully evicted —
+// timeout unseated, upVotes cleared, available drops to zero.
+func TestTrustedVotes_24hTimeoutClears(t *testing.T) {
+	v1 := makeNodeID(1)
+	a := makeAmendmentTV(0xAA)
+
+	tv := NewTrustedVotes()
+	tv.TrustChanged([]consensus.NodeID{v1})
+	tv.RecordVotes(trustedVotesEpoch, []*consensus.Validation{
+		{NodeID: v1, Amendments: [][32]byte{a}},
+	})
+
+	// Advance 25h with no fresh validations → entry expires.
+	tv.RecordVotes(trustedVotesEpoch.Add(25*time.Hour), nil)
+
+	available, votes := tv.GetVotes()
+	assert.Equal(t, 0, available, "timeout expired → available=0")
+	assert.Empty(t, votes, "expired entry contributes no votes")
+}
+
+// TestTrustedVotes_BelowTimeoutPreservesVote verifies the
+// flap-dampening core: a validator silent for less than 24h still
+// contributes its last seen vote.
+func TestTrustedVotes_BelowTimeoutPreservesVote(t *testing.T) {
+	v1 := makeNodeID(1)
+	a := makeAmendmentTV(0xAA)
+
+	tv := NewTrustedVotes()
+	tv.TrustChanged([]consensus.NodeID{v1})
+	tv.RecordVotes(trustedVotesEpoch, []*consensus.Validation{
+		{NodeID: v1, Amendments: [][32]byte{a}},
+	})
+
+	// 23h later, no fresh validations: entry still alive.
+	tv.RecordVotes(trustedVotesEpoch.Add(23*time.Hour), nil)
+
+	available, votes := tv.GetVotes()
+	assert.Equal(t, 1, available, "within timeout → available preserved")
+	assert.Equal(t, 1, votes[a], "within timeout → vote preserved")
+}
+
+// TestTrustedVotes_NewVotesReplacePrevious verifies that a fresh
+// validation replaces the cached upVotes wholesale (not append).
+func TestTrustedVotes_NewVotesReplacePrevious(t *testing.T) {
+	v1 := makeNodeID(1)
+	a := makeAmendmentTV(0xAA)
+	b := makeAmendmentTV(0xBB)
+
+	tv := NewTrustedVotes()
+	tv.TrustChanged([]consensus.NodeID{v1})
+
+	tv.RecordVotes(trustedVotesEpoch, []*consensus.Validation{
+		{NodeID: v1, Amendments: [][32]byte{a}},
+	})
+	tv.RecordVotes(trustedVotesEpoch.Add(time.Hour), []*consensus.Validation{
+		{NodeID: v1, Amendments: [][32]byte{b}},
+	})
+
+	_, votes := tv.GetVotes()
+	assert.Zero(t, votes[a], "replaced vote must NOT contribute to a anymore")
+	assert.Equal(t, 1, votes[b], "current vote contributes to b")
+}
+
+// TestTrustedVotes_EmptyAmendmentsClearsUpvotes mirrors rippled's
+// "validator has no amendment votes" branch at
+// AmendmentTable.cpp:206-211: a validation with empty sfAmendments
+// resets the cached upVotes to nothing while still refreshing the
+// timeout.
+func TestTrustedVotes_EmptyAmendmentsClearsUpvotes(t *testing.T) {
+	v1 := makeNodeID(1)
+	a := makeAmendmentTV(0xAA)
+
+	tv := NewTrustedVotes()
+	tv.TrustChanged([]consensus.NodeID{v1})
+
+	tv.RecordVotes(trustedVotesEpoch, []*consensus.Validation{
+		{NodeID: v1, Amendments: [][32]byte{a}},
+	})
+	tv.RecordVotes(trustedVotesEpoch.Add(time.Hour), []*consensus.Validation{
+		{NodeID: v1, Amendments: nil}, // empty sfAmendments
+	})
+
+	available, votes := tv.GetVotes()
+	assert.Equal(t, 1, available, "validator still alive → available=1")
+	assert.Empty(t, votes, "empty sfAmendments → no votes contributed")
+}
+
+// TestTrustedVotes_TrustChangedPreservesExisting mirrors
+// AmendmentTable.cpp:130-143: validators retained across a UNL
+// change keep their cached vote; new validators get a fresh
+// empty entry.
+func TestTrustedVotes_TrustChangedPreservesExisting(t *testing.T) {
+	v1 := makeNodeID(1)
+	v2 := makeNodeID(2)
+	v3 := makeNodeID(3)
+	a := makeAmendmentTV(0xAA)
+
+	tv := NewTrustedVotes()
+	tv.TrustChanged([]consensus.NodeID{v1, v2})
+	tv.RecordVotes(trustedVotesEpoch, []*consensus.Validation{
+		{NodeID: v1, Amendments: [][32]byte{a}},
+	})
+
+	// Replace v2 with v3; v1 retained.
+	tv.TrustChanged([]consensus.NodeID{v1, v3})
+
+	available, votes := tv.GetVotes()
+	assert.Equal(t, 1, available, "v1 still alive (v3 has no validations yet)")
+	assert.Equal(t, 1, votes[a], "v1's preserved vote still contributes")
+}
+
+// TestTrustedVotes_TrustChangedDropsRemoved verifies that votes
+// from validators no longer trusted are evicted entirely. Mirrors
+// the swap at AmendmentTable.cpp:146.
+func TestTrustedVotes_TrustChangedDropsRemoved(t *testing.T) {
+	v1 := makeNodeID(1)
+	v2 := makeNodeID(2)
+	a := makeAmendmentTV(0xAA)
+
+	tv := NewTrustedVotes()
+	tv.TrustChanged([]consensus.NodeID{v1})
+	tv.RecordVotes(trustedVotesEpoch, []*consensus.Validation{
+		{NodeID: v1, Amendments: [][32]byte{a}},
+	})
+
+	// v1 removed from UNL, v2 added.
+	tv.TrustChanged([]consensus.NodeID{v2})
+
+	available, votes := tv.GetVotes()
+	assert.Equal(t, 0, available, "v2 has no votes; v1's entry was dropped")
+	assert.Zero(t, votes[a], "removed validator's votes must not contribute")
+}
+
+// TestTrustedVotes_AvailableCountReflectsTimeoutSet exercises the
+// available counter through the full lifecycle: fresh, recording,
+// and post-expiry.
+func TestTrustedVotes_AvailableCountReflectsTimeoutSet(t *testing.T) {
+	v1 := makeNodeID(1)
+	v2 := makeNodeID(2)
+	v3 := makeNodeID(3)
+	a := makeAmendmentTV(0xAA)
+
+	tv := NewTrustedVotes()
+	tv.TrustChanged([]consensus.NodeID{v1, v2, v3})
+
+	available, _ := tv.GetVotes()
+	assert.Equal(t, 0, available, "fresh entries have unseated timeout → available=0")
+
+	tv.RecordVotes(trustedVotesEpoch, []*consensus.Validation{
+		{NodeID: v1, Amendments: [][32]byte{a}},
+	})
+	available, _ = tv.GetVotes()
+	assert.Equal(t, 1, available, "one validation → available=1")
+
+	// Advance past timeout with no fresh validations.
+	tv.RecordVotes(trustedVotesEpoch.Add(25*time.Hour), nil)
+	available, _ = tv.GetVotes()
+	assert.Equal(t, 0, available, "post-expiry → available=0")
+}
+
+// TestTrustedVotes_Integration_FlapsAtFlagLedger pins the flap-
+// dampening behavior the cache exists for. Two scenarios with 11
+// validators and a single test amendment:
+//
+//   - fast flap (validator drops every 23h): all votes contribute,
+//     11/11 stays above 80%.
+//   - slow flap (validator drops every 25h): the flapping
+//     validator's vote expires before its next validation, so the
+//     tally drops to 10/11 some rounds and below the strict 80%
+//     gate (8.8 → strictly > 8 fails when votes drop to ≤ 8).
+//
+// We exercise GetVotes directly rather than running Decide; the
+// algorithm-level threshold check is exercised in the
+// amendmentvote package tests. What this test pins is the cache's
+// effect on the available denominator and per-amendment votes
+// across multi-round time advancement.
+func TestTrustedVotes_Integration_FlapsAtFlagLedger(t *testing.T) {
+	const total = 11
+	flapper := makeNodeID(0)
+	stable := make([]consensus.NodeID, 0, total-1)
+	for i := 1; i < total; i++ {
+		stable = append(stable, makeNodeID(byte(i)))
+	}
+	all := append([]consensus.NodeID{flapper}, stable...)
+	amend := makeAmendmentTV(0xAA)
+
+	build := func(nodes []consensus.NodeID) []*consensus.Validation {
+		out := make([]*consensus.Validation, 0, len(nodes))
+		for _, id := range nodes {
+			out = append(out, &consensus.Validation{
+				NodeID:     id,
+				Amendments: [][32]byte{amend},
+			})
+		}
+		return out
+	}
+
+	t.Run("fast flap stays above threshold", func(t *testing.T) {
+		tv := NewTrustedVotes()
+		tv.TrustChanged(all)
+
+		// Round 0: everyone votes.
+		tv.RecordVotes(trustedVotesEpoch, build(all))
+
+		// Round 1 (23h later): flapper silent, but still within
+		// timeout → its vote still contributes.
+		tv.RecordVotes(trustedVotesEpoch.Add(23*time.Hour), build(stable))
+		available, votes := tv.GetVotes()
+		assert.Equal(t, total, available,
+			"23h flap: all entries still within timeout")
+		assert.Equal(t, total, votes[amend],
+			"23h flap: flapper's last vote still contributes")
+	})
+
+	t.Run("slow flap loses the flapper's vote", func(t *testing.T) {
+		tv := NewTrustedVotes()
+		tv.TrustChanged(all)
+
+		// Round 0: everyone votes.
+		tv.RecordVotes(trustedVotesEpoch, build(all))
+
+		// Round 1 (25h later): flapper silent and past timeout →
+		// its entry is cleared.
+		tv.RecordVotes(trustedVotesEpoch.Add(25*time.Hour), build(stable))
+		available, votes := tv.GetVotes()
+		require.Equal(t, total-1, available,
+			"25h flap: flapper expired, only stable validators count")
+		assert.Equal(t, total-1, votes[amend],
+			"25h flap: flapper's vote no longer contributes")
+	})
+}

--- a/internal/consensus/amendmentvote/vote.go
+++ b/internal/consensus/amendmentvote/vote.go
@@ -1,0 +1,297 @@
+// Package amendmentvote ports rippled's AmendmentTableImpl::doVoting
+// (src/xrpld/app/misc/detail/AmendmentTable.cpp:847-941) — the
+// producer side that decides whether to inject EnableAmendment
+// pseudo-txs into the consensus tx set on a flag-ledger boundary.
+//
+// The algorithm:
+//
+//  1. Compute the validator threshold from trustedValidations.
+//     Pre-fixAmendmentMajorityCalc: 204/256 ≈ 79.7%; post-fix:
+//     80/100 = 80%. threshold = max(1, trustedValidations × frac).
+//
+//  2. For every amendment the local server knows about that isn't
+//     already enabled, classify against three signals:
+//
+//     - hasValMajority — did votes ≥ threshold (lax) or > threshold
+//       (strict, post-fixAmendmentMajorityCalc)? With exactly one
+//       trusted validator, both modes degrade to ≥.
+//     - hasLedgerMajority — is the amendment recorded in the
+//       parent ledger's majority list (the sfMajorities SLE)?
+//     - vote — is this server voting yes locally (Stance == Up)?
+//
+//  3. Emit one of three actions, mirroring AmendmentTable.cpp:902-924:
+//
+//     - tfGotMajority — validators say yes, ledger doesn't yet
+//       record majority, AND we're voting yes locally.
+//     - tfLostMajority — ledger records majority but validators
+//       fell off (regardless of local stance).
+//     - 0 (enable) — ledger records majority, the timer has
+//       expired (majorityTime + majorityTimeout ≤ closeTime), AND
+//       we're voting yes locally.
+//
+//     All other classifications produce no action.
+//
+//  4. Each entry is serialized as an EnableAmendment pseudo-tx
+//     with sfAmendment, sfLedgerSequence, and sfFlags (omitted
+//     when 0; rippled writes only when non-zero per
+//     AmendmentTable.h:172-174).
+package amendmentvote
+
+import (
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+)
+
+const (
+	// PreFixThresholdNum / PreFixThresholdDen express the
+	// pre-fixAmendmentMajorityCalc threshold fraction (204/256 ≈
+	// 79.69%). Mirrors rippled SystemParameters.h:81.
+	PreFixThresholdNum = 204
+	PreFixThresholdDen = 256
+
+	// PostFixThresholdNum / PostFixThresholdDen express the
+	// post-fixAmendmentMajorityCalc threshold fraction (80/100 =
+	// 80%). Mirrors rippled SystemParameters.h:83.
+	PostFixThresholdNum = 80
+	PostFixThresholdDen = 100
+
+	// TfGotMajority / TfLostMajority are the EnableAmendment
+	// sfFlags values that signal a state-change pseudo-tx (as
+	// opposed to an enable, which carries no flags). Mirrors
+	// rippled TxFlags.h:128-129.
+	TfGotMajority  uint32 = 0x00010000
+	TfLostMajority uint32 = 0x00020000
+)
+
+// Amendment is the 32-byte hash uniquely identifying an amendment.
+type Amendment = [32]byte
+
+// Stance is the local server's voting stance toward an amendment.
+// Mirrors rippled's AmendmentVote enum.
+type Stance int
+
+const (
+	// VoteAbstain is the default — the server has no opinion. Used
+	// for amendments rippled is aware of but the operator hasn't
+	// taken a position on. Mirrors AmendmentVote::down — abstaining
+	// counts as "no" for tally purposes.
+	VoteAbstain Stance = iota
+	// VoteUp — the server actively votes yes. Required for the
+	// gotMajority and enable actions; the lostMajority action does
+	// not require it (it fires regardless of local stance, because
+	// the ledger needs to record the majority loss either way).
+	VoteUp
+	// VoteObsolete — vetoed locally; never propose enable, never
+	// propose gotMajority. Mirrors AmendmentVote::obsolete.
+	VoteObsolete
+)
+
+// Inputs aggregates everything DoVoting needs to decide. The
+// caller resolves rules / per-ledger state into these primitive
+// shapes — the algorithm itself is pure and testable in isolation.
+type Inputs struct {
+	// UpcomingSeq is the sequence the EnableAmendment tx will
+	// carry (parent + 1).
+	UpcomingSeq uint32
+
+	// CloseTime is the parent ledger's close time. Used as the
+	// "now" reference for the majority-held-long-enough check.
+	// Mirrors AmendmentTable.cpp:849.
+	CloseTime time.Time
+
+	// MajorityTimeout is the duration an amendment must hold
+	// majority on the ledger before it can be enabled. Mainnet:
+	// 14 days. Mirrors majorityTime_ at AmendmentTable.cpp:423.
+	MajorityTimeout time.Duration
+
+	// TrustedValidations is the count of trusted validators whose
+	// votes are tallied this round. Used to compute the threshold.
+	TrustedValidations int
+
+	// Votes counts trusted upVotes per amendment. Mirrors the
+	// AmendmentSet::votes_ map at AmendmentTable.cpp:318.
+	Votes map[Amendment]int
+
+	// Enabled is the set of amendments already enabled on the
+	// parent ledger (from the sfAmendments SLE). Already-enabled
+	// amendments are skipped at AmendmentTable.cpp:877-882.
+	Enabled map[Amendment]bool
+
+	// Majority maps amendment → time it gained majority on the
+	// ledger (from the sfMajorities SLE). Empty time.Time means
+	// "no entry"; this matches AmendmentTable.cpp:886-893's
+	// std::optional handling.
+	Majority map[Amendment]time.Time
+
+	// Stances is this server's per-amendment voting stance, keyed
+	// by amendment hash. Amendments not in the map default to
+	// VoteAbstain. Mirrors AmendmentState::vote at
+	// AmendmentTable.cpp:286.
+	Stances map[Amendment]Stance
+
+	// StrictMajority is true once fixAmendmentMajorityCalc is
+	// enabled. Selects the post-fix threshold fraction (80/100 vs
+	// 204/256) AND switches the passes-comparison from ≥ to >.
+	// Mirrors AmendmentTable.cpp:328-340 + 372-376.
+	StrictMajority bool
+}
+
+// Decision is one entry of the doVoting return map at
+// AmendmentTable.cpp:872. Flags is 0 (enable), TfGotMajority, or
+// TfLostMajority.
+type Decision struct {
+	Amendment Amendment
+	Flags     uint32
+}
+
+// Threshold returns the vote count an amendment needs to pass.
+// Pre-fix: (trusted * 204) / 256. Post-fix: (trusted * 80) / 100.
+// Both clamp to a minimum of 1 to keep the gate reachable on tiny
+// validator sets. Mirrors AmendmentTable.cpp:325-341.
+func Threshold(trustedValidations int, strict bool) int {
+	num, den := PreFixThresholdNum, PreFixThresholdDen
+	if strict {
+		num, den = PostFixThresholdNum, PostFixThresholdDen
+	}
+	t := (trustedValidations * num) / den
+	if t < 1 {
+		return 1
+	}
+	return t
+}
+
+// passes is the per-amendment quorum check. With exactly one
+// trusted validator, both pre-fix and post-fix degrade to ≥
+// (otherwise the gate would be unreachable). Otherwise post-fix
+// uses strict >. Mirrors AmendmentTable.cpp:359-377.
+func passes(votes, threshold, trustedValidations int, strict bool) bool {
+	if !strict || trustedValidations == 1 {
+		return votes >= threshold
+	}
+	return votes > threshold
+}
+
+// Decide is the pure-algorithm step. Returns a deterministic,
+// hash-sorted slice of Decisions — at most one per amendment —
+// classifying each tracked amendment as gotMajority / lostMajority
+// / enable, or omitting it entirely. Result order is stable
+// across runs to keep the tx-set hash deterministic; rippled's
+// std::map iterates in hash-key order, so we match by sorting on
+// amendment bytes.
+func Decide(in Inputs) []Decision {
+	threshold := Threshold(in.TrustedValidations, in.StrictMajority)
+
+	// Walk every amendment the server is aware of (Stances ∪
+	// Votes ∪ Majority). An amendment with no Stance entry is
+	// treated as VoteAbstain.
+	seen := make(map[Amendment]struct{}, len(in.Stances)+len(in.Votes)+len(in.Majority))
+	for k := range in.Stances {
+		seen[k] = struct{}{}
+	}
+	for k := range in.Votes {
+		seen[k] = struct{}{}
+	}
+	for k := range in.Majority {
+		seen[k] = struct{}{}
+	}
+
+	var out []Decision
+	for amendment := range seen {
+		if in.Enabled[amendment] {
+			// Already enabled — never produces a pseudo-tx.
+			// Mirrors AmendmentTable.cpp:877-882.
+			continue
+		}
+
+		stance := in.Stances[amendment]
+		votes := in.Votes[amendment]
+		hasValMajority := passes(votes, threshold, in.TrustedValidations, in.StrictMajority)
+		majoritySince, hasLedgerMajority := in.Majority[amendment]
+
+		switch {
+		case hasValMajority && !hasLedgerMajority && stance == VoteUp:
+			// Validators say yes; ledger doesn't record majority
+			// yet; we vote yes locally. Inject GotMajority so the
+			// ledger starts the majority-held timer.
+			// AmendmentTable.cpp:902-909.
+			out = append(out, Decision{Amendment: amendment, Flags: TfGotMajority})
+
+		case !hasValMajority && hasLedgerMajority:
+			// Ledger records majority, validators fell off.
+			// Inject LostMajority regardless of local stance —
+			// the ledger needs to clear the timer either way.
+			// AmendmentTable.cpp:910-915.
+			out = append(out, Decision{Amendment: amendment, Flags: TfLostMajority})
+
+		case hasLedgerMajority &&
+			!majoritySince.Add(in.MajorityTimeout).After(in.CloseTime) &&
+			stance == VoteUp:
+			// Majority has held on the ledger for at least
+			// MajorityTimeout; we still vote yes locally; emit the
+			// enable pseudo-tx. AmendmentTable.cpp:916-924.
+			out = append(out, Decision{Amendment: amendment, Flags: 0})
+
+		default:
+			// Logging-only branches in rippled — no pseudo-tx.
+			// AmendmentTable.cpp:926-935.
+		}
+	}
+
+	// Stable hash-key order so the tx-set hash is deterministic.
+	sort.Slice(out, func(i, j int) bool {
+		return lessAmendment(out[i].Amendment, out[j].Amendment)
+	})
+	return out
+}
+
+func lessAmendment(a, b Amendment) bool {
+	for i := 0; i < 32; i++ {
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return false
+}
+
+// DoVoting runs Decide and serializes each Decision as an
+// EnableAmendment pseudo-tx wire blob. Returns nil when no
+// pseudo-txs apply.
+func DoVoting(in Inputs) ([][]byte, error) {
+	decisions := Decide(in)
+	if len(decisions) == 0 {
+		return nil, nil
+	}
+	out := make([][]byte, 0, len(decisions))
+	for _, d := range decisions {
+		blob, err := buildEnableAmendmentTx(in.UpcomingSeq, d.Amendment, d.Flags)
+		if err != nil {
+			return nil, fmt.Errorf("amendmentvote: serialize %s: %w",
+				hex.EncodeToString(d.Amendment[:8]), err)
+		}
+		out = append(out, blob)
+	}
+	return out, nil
+}
+
+// buildEnableAmendmentTx serializes an EnableAmendment pseudo-tx.
+// Wire format mirrors AmendmentTable.h:165-187: zero account, zero
+// fee, empty signing key, sequence 0; sfAmendment carries the
+// 32-byte hash; sfLedgerSequence carries the upcoming seq; sfFlags
+// is set only when non-zero (got/lost majority).
+func buildEnableAmendmentTx(seq uint32, amendment Amendment, flags uint32) ([]byte, error) {
+	etx := &pseudo.EnableAmendment{
+		BaseTx:         *tx.NewBaseTx(tx.TypeAmendment, pseudo.ZeroAccount),
+		Amendment:      hex.EncodeToString(amendment[:]),
+		LedgerSequence: &seq,
+	}
+	if flags != 0 {
+		f := flags
+		etx.Common.Flags = &f
+	}
+	return pseudo.EncodePseudoTx(etx)
+}

--- a/internal/consensus/amendmentvote/vote.go
+++ b/internal/consensus/amendmentvote/vote.go
@@ -13,21 +13,21 @@
 //     already enabled, classify against three signals:
 //
 //     - hasValMajority — did votes ≥ threshold (lax) or > threshold
-//       (strict, post-fixAmendmentMajorityCalc)? With exactly one
-//       trusted validator, both modes degrade to ≥.
+//     (strict, post-fixAmendmentMajorityCalc)? With exactly one
+//     trusted validator, both modes degrade to ≥.
 //     - hasLedgerMajority — is the amendment recorded in the
-//       parent ledger's majority list (the sfMajorities SLE)?
+//     parent ledger's majority list (the sfMajorities SLE)?
 //     - vote — is this server voting yes locally (Stance == Up)?
 //
 //  3. Emit one of three actions, mirroring AmendmentTable.cpp:902-924:
 //
 //     - tfGotMajority — validators say yes, ledger doesn't yet
-//       record majority, AND we're voting yes locally.
+//     record majority, AND we're voting yes locally.
 //     - tfLostMajority — ledger records majority but validators
-//       fell off (regardless of local stance).
+//     fell off (regardless of local stance).
 //     - 0 (enable) — ledger records majority, the timer has
-//       expired (majorityTime + majorityTimeout ≤ closeTime), AND
-//       we're voting yes locally.
+//     expired (majorityTime + majorityTimeout ≤ closeTime), AND
+//     we're voting yes locally.
 //
 //     All other classifications produce no action.
 //

--- a/internal/consensus/amendmentvote/vote_test.go
+++ b/internal/consensus/amendmentvote/vote_test.go
@@ -267,6 +267,222 @@ func TestDoVoting_EnableTxOmitsFlags(t *testing.T) {
 	assert.False(t, hasFlags, "enable pseudo-tx (Flags=0) must omit sfFlags on the wire")
 }
 
+// runRoundFor is a helper that mirrors rippled's
+// AmendmentTable_test.cpp doRound() at the algorithm level. It
+// runs Decide once, then mutates `enabled` and `majority` based on
+// the emitted Decisions: a GotMajority pseudo-tx records the
+// closeTime as the majoritySince timestamp; an Enable pseudo-tx
+// (Flags==0) marks the amendment enabled and clears its majority
+// entry; a LostMajority pseudo-tx clears the majority entry. This
+// matches rippled's `Change::applyEnableAmendment` side-effects on
+// the parent ledger between rounds (AmendmentTable.cpp:902-924
+// enumerated against ChangeImpl.cpp).
+func runRoundFor(
+	upcomingSeq uint32,
+	closeTime time.Time,
+	majorityTimeout time.Duration,
+	trusted int,
+	votes map[Amendment]int,
+	stances map[Amendment]Stance,
+	strict bool,
+	enabled map[Amendment]bool,
+	majority map[Amendment]time.Time,
+) []Decision {
+	decisions := Decide(Inputs{
+		UpcomingSeq:        upcomingSeq,
+		CloseTime:          closeTime,
+		MajorityTimeout:    majorityTimeout,
+		TrustedValidations: trusted,
+		Votes:              votes,
+		Enabled:            enabled,
+		Majority:           majority,
+		Stances:            stances,
+		StrictMajority:     strict,
+	})
+	for _, d := range decisions {
+		switch d.Flags {
+		case TfGotMajority:
+			majority[d.Amendment] = closeTime
+		case TfLostMajority:
+			delete(majority, d.Amendment)
+		case 0:
+			enabled[d.Amendment] = true
+			delete(majority, d.Amendment)
+		}
+	}
+	return decisions
+}
+
+// TestDecide_DetectMajoritySweep is the algorithm-level analog of
+// rippled's testDetectMajority (AmendmentTable_test.cpp:837-902).
+// 16 validators, post-fix strict, 2-week MajorityTimeout, sweep
+// validator support i = 0..17 across consecutive weekly rounds.
+//
+// Expected state machine, mirroring the C++ assertions:
+//
+//   - i < 13 (< 80%): no GotMajority, no enable, no majority entry
+//   - 13 <= i < 15: GotMajority crossed; majority entry held
+//   - i == 15: timeout window elapsed → enable fires; majority cleared
+//   - i > 15: amendment enabled; no further pseudo-tx
+func TestDecide_DetectMajoritySweep(t *testing.T) {
+	const validators = 16
+	const majorityTimeout = 2 * 7 * 24 * time.Hour
+	a := makeAmendment(0xA1)
+
+	stances := map[Amendment]Stance{a: VoteUp}
+	enabled := map[Amendment]bool{}
+	majority := map[Amendment]time.Time{}
+
+	for i := 0; i <= 17; i++ {
+		votes := map[Amendment]int{}
+		// Match rippled's "if i>0 && i<17" block: at i==0 nobody
+		// votes; at i==17 we stop voting (the amendment is already
+		// enabled by then so the producer should be silent).
+		if i > 0 && i < 17 {
+			votes[a] = i
+		}
+		closeTime := baseTime.Add(time.Duration(i) * 7 * 24 * time.Hour)
+
+		runRoundFor(
+			uint32(1024+i), closeTime, majorityTimeout,
+			validators, votes, stances, true,
+			enabled, majority,
+		)
+
+		switch {
+		case i < 13:
+			assert.False(t, enabled[a], "i=%d: amendment must not be enabled yet", i)
+			assert.NotContains(t, majority, a, "i=%d: no majority recorded", i)
+		case i < 15:
+			assert.False(t, enabled[a], "i=%d: still pre-enable", i)
+			assert.Contains(t, majority, a, "i=%d: majority recorded but timer not elapsed", i)
+		case i == 15:
+			assert.True(t, enabled[a], "i=%d: enable fires after 2-week window", i)
+			assert.NotContains(t, majority, a, "i=%d: enable clears majority entry", i)
+		default:
+			assert.True(t, enabled[a], "i=%d: amendment stays enabled", i)
+			assert.NotContains(t, majority, a, "i=%d: enabled amendment has no majority entry", i)
+		}
+	}
+}
+
+// TestDecide_LostMajoritySweep is the algorithm-level analog of
+// rippled's testLostMajority (AmendmentTable_test.cpp:906-979).
+// 16 validators, post-fix strict, 8-week MajorityTimeout (so the
+// enable doesn't fire and we observe lost-majority cleanly).
+//
+// Round 1: full support → GotMajority; majority recorded.
+// Rounds 2..7: gradually reduce support (16-i votes).
+// At i=4 (12/16 = 75% < 80%) LostMajority fires; majority cleared.
+func TestDecide_LostMajoritySweep(t *testing.T) {
+	const validators = 16
+	const majorityTimeout = 8 * 7 * 24 * time.Hour
+	a := makeAmendment(0xA2)
+
+	stances := map[Amendment]Stance{a: VoteUp}
+	enabled := map[Amendment]bool{}
+	majority := map[Amendment]time.Time{}
+
+	// Round 1: establish majority.
+	runRoundFor(
+		1024,
+		baseTime.Add(7*24*time.Hour),
+		majorityTimeout,
+		validators,
+		map[Amendment]int{a: validators},
+		stances, true,
+		enabled, majority,
+	)
+	require.False(t, enabled[a], "round 1: enable must not fire (8-week timeout)")
+	require.Contains(t, majority, a, "round 1: majority must be recorded")
+
+	for i := 1; i < 8; i++ {
+		closeTime := baseTime.Add(time.Duration(i+1) * 7 * 24 * time.Hour)
+		runRoundFor(
+			uint32(1024+i), closeTime, majorityTimeout,
+			validators,
+			map[Amendment]int{a: validators - i},
+			stances, true,
+			enabled, majority,
+		)
+
+		if i < 4 {
+			assert.False(t, enabled[a], "i=%d: not yet enabled", i)
+			assert.Contains(t, majority, a, "i=%d: majority still held (>80%%)", i)
+		} else {
+			assert.False(t, enabled[a], "i=%d: still not enabled (lost majority)", i)
+			assert.NotContains(t, majority, a,
+				"i=%d: LostMajority must clear the majority entry", i)
+		}
+	}
+}
+
+// TestDecide_VoteEnableMultiWeek mirrors rippled's testVoteEnable
+// (AmendmentTable_test.cpp:757-833) at the algorithm level. With
+// 10 validators, 2-week MajorityTimeout, post-fix strict, and a
+// single test amendment we vote VoteUp for:
+//
+//   - Week 1: nobody else has voted → no decision
+//   - Week 2: full support → GotMajority + majority recorded
+//   - Week 5 (3 weeks past majority, > 2-week timeout): enable
+//     fires; majority cleared; enabled set populated
+//   - Week 6: amendment enabled — producer must stay silent
+//
+// This pins the multi-week ordering: GotMajority precedes Enable
+// by at least MajorityTimeout, and an enabled amendment never
+// re-emits.
+func TestDecide_VoteEnableMultiWeek(t *testing.T) {
+	const validators = 10
+	const majorityTimeout = 2 * 7 * 24 * time.Hour
+	a := makeAmendment(0xA3)
+
+	stances := map[Amendment]Stance{a: VoteUp}
+	enabled := map[Amendment]bool{}
+	majority := map[Amendment]time.Time{}
+
+	// Week 1: validators don't yet have any opinion (votes empty).
+	d1 := runRoundFor(
+		1024, baseTime.Add(1*7*24*time.Hour), majorityTimeout,
+		validators, map[Amendment]int{},
+		stances, true, enabled, majority,
+	)
+	assert.Empty(t, d1, "week 1: no votes yet → no decision")
+	assert.False(t, enabled[a])
+	assert.NotContains(t, majority, a)
+
+	// Week 2: all 10 vote → GotMajority.
+	d2 := runRoundFor(
+		1025, baseTime.Add(2*7*24*time.Hour), majorityTimeout,
+		validators, map[Amendment]int{a: validators},
+		stances, true, enabled, majority,
+	)
+	require.Len(t, d2, 1)
+	assert.Equal(t, TfGotMajority, d2[0].Flags,
+		"week 2: full support crosses threshold → GotMajority")
+	assert.Contains(t, majority, a, "week 2: majority recorded")
+	assert.False(t, enabled[a])
+
+	// Week 5: 3 weeks past majority (> 2-week timeout) → enable.
+	d5 := runRoundFor(
+		1028, baseTime.Add(5*7*24*time.Hour), majorityTimeout,
+		validators, map[Amendment]int{a: validators},
+		stances, true, enabled, majority,
+	)
+	require.Len(t, d5, 1)
+	assert.EqualValues(t, 0, d5[0].Flags,
+		"week 5: timeout elapsed → enable pseudo-tx (Flags==0)")
+	assert.True(t, enabled[a], "week 5: enable mutates the enabled set")
+	assert.NotContains(t, majority, a, "week 5: enable clears majority entry")
+
+	// Week 6: amendment is enabled → producer silent.
+	d6 := runRoundFor(
+		1029, baseTime.Add(6*7*24*time.Hour), majorityTimeout,
+		validators, map[Amendment]int{a: validators},
+		stances, true, enabled, majority,
+	)
+	assert.Empty(t, d6, "week 6: enabled amendment must produce no further pseudo-tx")
+}
+
 func decodeTx(t *testing.T, blob []byte) map[string]any {
 	t.Helper()
 	out, err := binarycodec.Decode(hex.EncodeToString(blob))

--- a/internal/consensus/amendmentvote/vote_test.go
+++ b/internal/consensus/amendmentvote/vote_test.go
@@ -1,0 +1,319 @@
+package amendmentvote
+
+import (
+	"encoding/hex"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeAmendment produces a deterministic 32-byte amendment hash
+// for a given byte tag. The hash itself doesn't need to match any
+// real amendment — the algorithm only treats it as an opaque key.
+func makeAmendment(tag byte) Amendment {
+	var a Amendment
+	for i := range a {
+		a[i] = tag
+	}
+	return a
+}
+
+// baseTime is a stable reference point well past the XRPL epoch so
+// MajorityTimeout arithmetic stays in a well-defined range.
+var baseTime = time.Unix(1_700_000_000, 0).UTC()
+
+func TestThreshold_PreFix(t *testing.T) {
+	// 5 validators × 204/256 = 3.98… → integer division → 3.
+	assert.Equal(t, 3, Threshold(5, false))
+	// 100 validators × 204/256 = 79.6… → 79.
+	assert.Equal(t, 79, Threshold(100, false))
+	// 0 validators clamps to 1.
+	assert.Equal(t, 1, Threshold(0, false))
+}
+
+func TestThreshold_PostFix(t *testing.T) {
+	// 5 × 80/100 = 4 → 4.
+	assert.Equal(t, 4, Threshold(5, true))
+	// 100 × 80/100 = 80.
+	assert.Equal(t, 80, Threshold(100, true))
+	// Clamps to 1 on tiny sets.
+	assert.Equal(t, 1, Threshold(1, true))
+}
+
+func TestPasses_StrictVsLax(t *testing.T) {
+	// trustedValidations=10, strict (post-fix). threshold = 8.
+	// Lax: votes >= 8 passes. Strict: votes > 8 passes.
+	assert.True(t, passes(8, 8, 10, false), "lax: votes==threshold passes")
+	assert.False(t, passes(8, 8, 10, true), "strict: votes==threshold fails")
+	assert.True(t, passes(9, 8, 10, true), "strict: votes>threshold passes")
+}
+
+func TestPasses_SingleValidatorAlwaysLax(t *testing.T) {
+	// trustedValidations==1: even strict mode degrades to >=, else
+	// the gate is unreachable. AmendmentTable.cpp:372-374.
+	assert.True(t, passes(1, 1, 1, true),
+		"with 1 validator and strict mode, votes==threshold MUST pass")
+}
+
+func TestDecide_GotMajority(t *testing.T) {
+	a := makeAmendment(0xAA)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 9}, // > threshold 8 (strict)
+		Stances:            map[Amendment]Stance{a: VoteUp},
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	require.Len(t, got, 1)
+	assert.Equal(t, a, got[0].Amendment)
+	assert.Equal(t, TfGotMajority, got[0].Flags)
+}
+
+func TestDecide_LostMajority(t *testing.T) {
+	// Ledger has majority, validators fell off — emit lostMajority
+	// regardless of local stance.
+	a := makeAmendment(0xBB)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 4}, // below threshold
+		Majority:           map[Amendment]time.Time{a: baseTime.Add(-time.Hour)},
+		Stances:            map[Amendment]Stance{a: VoteAbstain}, // not voting yes locally
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	require.Len(t, got, 1)
+	assert.Equal(t, a, got[0].Amendment)
+	assert.Equal(t, TfLostMajority, got[0].Flags)
+}
+
+func TestDecide_EnableWhenWindowHeld(t *testing.T) {
+	// Ledger has majority for >= MajorityTimeout, validators still
+	// agree (above threshold), local stance is up → enable.
+	a := makeAmendment(0xCC)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 9},
+		Majority:           map[Amendment]time.Time{a: baseTime.Add(-15 * 24 * time.Hour)},
+		Stances:            map[Amendment]Stance{a: VoteUp},
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	require.Len(t, got, 1)
+	assert.Equal(t, a, got[0].Amendment)
+	assert.Equal(t, uint32(0), got[0].Flags, "enable pseudo-tx carries no flags")
+}
+
+func TestDecide_EnableSkippedWhenWindowNotHeldYet(t *testing.T) {
+	a := makeAmendment(0xCC)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 9},
+		Majority:           map[Amendment]time.Time{a: baseTime.Add(-1 * 24 * time.Hour)},
+		Stances:            map[Amendment]Stance{a: VoteUp},
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	assert.Empty(t, got, "must wait until majority has held for MajorityTimeout")
+}
+
+func TestDecide_AlreadyEnabledSkipped(t *testing.T) {
+	a := makeAmendment(0xDD)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 10},
+		Majority:           map[Amendment]time.Time{a: baseTime.Add(-30 * 24 * time.Hour)},
+		Stances:            map[Amendment]Stance{a: VoteUp},
+		Enabled:            map[Amendment]bool{a: true}, // already on
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	assert.Empty(t, got, "already-enabled amendments must be skipped")
+}
+
+func TestDecide_ObsoleteStanceNeverVotes(t *testing.T) {
+	a := makeAmendment(0xEE)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 10}, // strong validator support
+		Stances:            map[Amendment]Stance{a: VoteObsolete},
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	assert.Empty(t, got, "obsolete amendments must never produce gotMajority/enable")
+}
+
+func TestDecide_AbstainStanceNeverVotes(t *testing.T) {
+	// VoteAbstain must produce no gotMajority — only VoteUp does.
+	// (Abstain still allows lostMajority, see other test.)
+	a := makeAmendment(0xEF)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 10},
+		Stances:            map[Amendment]Stance{a: VoteAbstain},
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	assert.Empty(t, got, "abstain stance does not propose gotMajority")
+}
+
+func TestDecide_LostMajorityFiresEvenForAbstain(t *testing.T) {
+	// LostMajority does NOT gate on local stance — the ledger
+	// needs the timer cleared either way. AmendmentTable.cpp:910-915.
+	a := makeAmendment(0xF0)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 0},
+		Majority:           map[Amendment]time.Time{a: baseTime.Add(-time.Hour)},
+		Stances:            map[Amendment]Stance{a: VoteAbstain},
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	require.Len(t, got, 1)
+	assert.Equal(t, TfLostMajority, got[0].Flags)
+}
+
+func TestDecide_DeterministicOrder(t *testing.T) {
+	// Multiple amendments → output sorted by hash so the resulting
+	// tx-set hash is deterministic across map-iteration runs.
+	hi := makeAmendment(0xFF)
+	mid := makeAmendment(0x80)
+	lo := makeAmendment(0x10)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{hi: 9, mid: 9, lo: 9},
+		Stances:            map[Amendment]Stance{hi: VoteUp, mid: VoteUp, lo: VoteUp},
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	require.Len(t, got, 3)
+	assert.Equal(t, lo, got[0].Amendment)
+	assert.Equal(t, mid, got[1].Amendment)
+	assert.Equal(t, hi, got[2].Amendment)
+}
+
+func TestDoVoting_SerializesEnableAmendmentTx(t *testing.T) {
+	a := makeAmendment(0x42)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 9},
+		Stances:            map[Amendment]Stance{a: VoteUp},
+		StrictMajority:     true,
+	}
+	blobs, err := DoVoting(in)
+	require.NoError(t, err)
+	require.Len(t, blobs, 1)
+
+	stx := decodeTx(t, blobs[0])
+	assert.Equal(t, hex.EncodeToString(a[:]), stringFold(stx["Amendment"]))
+	assert.EqualValues(t, 1024, asUint(stx["LedgerSequence"]))
+	assert.EqualValues(t, TfGotMajority, asUint(stx["Flags"]),
+		"GotMajority pseudo-tx must carry sfFlags = tfGotMajority")
+}
+
+func TestDoVoting_EnableTxOmitsFlags(t *testing.T) {
+	// AmendmentTable.h:172-174: rippled writes sfFlags only when
+	// non-zero. Our serialized enable pseudo-tx must have no Flags
+	// field at all on the wire.
+	a := makeAmendment(0x43)
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 9},
+		Majority:           map[Amendment]time.Time{a: baseTime.Add(-15 * 24 * time.Hour)},
+		Stances:            map[Amendment]Stance{a: VoteUp},
+		StrictMajority:     true,
+	}
+	blobs, err := DoVoting(in)
+	require.NoError(t, err)
+	require.Len(t, blobs, 1)
+
+	stx := decodeTx(t, blobs[0])
+	_, hasFlags := stx["Flags"]
+	assert.False(t, hasFlags, "enable pseudo-tx (Flags=0) must omit sfFlags on the wire")
+}
+
+func decodeTx(t *testing.T, blob []byte) map[string]any {
+	t.Helper()
+	out, err := binarycodec.Decode(hex.EncodeToString(blob))
+	require.NoError(t, err, "EnableAmendment must round-trip through binarycodec.Decode")
+	return out
+}
+
+func asUint(v any) uint64 {
+	switch n := v.(type) {
+	case uint8:
+		return uint64(n)
+	case uint16:
+		return uint64(n)
+	case uint32:
+		return uint64(n)
+	case uint64:
+		return n
+	case int:
+		return uint64(n)
+	case int64:
+		return uint64(n)
+	case float64:
+		return uint64(n)
+	case string:
+		x, err := strconv.ParseUint(n, 10, 64)
+		if err == nil {
+			return x
+		}
+		x, _ = strconv.ParseUint(n, 16, 64)
+		return x
+	}
+	return 0
+}
+
+func stringFold(v any) string {
+	switch s := v.(type) {
+	case string:
+		out := make([]byte, len(s))
+		for i := 0; i < len(s); i++ {
+			c := s[i]
+			if c >= 'A' && c <= 'F' {
+				c = c - 'A' + 'a'
+			}
+			out[i] = c
+		}
+		return string(out)
+	}
+	return ""
+}

--- a/internal/consensus/amendmentvote/vote_test.go
+++ b/internal/consensus/amendmentvote/vote_test.go
@@ -77,17 +77,15 @@ func TestDecide_GotMajority(t *testing.T) {
 }
 
 func TestDecide_LostMajority(t *testing.T) {
-	// Ledger has majority, validators fell off — emit lostMajority
-	// regardless of local stance.
 	a := makeAmendment(0xBB)
 	in := Inputs{
 		UpcomingSeq:        1024,
 		CloseTime:          baseTime,
 		MajorityTimeout:    14 * 24 * time.Hour,
 		TrustedValidations: 10,
-		Votes:              map[Amendment]int{a: 4}, // below threshold
+		Votes:              map[Amendment]int{a: 4},
 		Majority:           map[Amendment]time.Time{a: baseTime.Add(-time.Hour)},
-		Stances:            map[Amendment]Stance{a: VoteAbstain}, // not voting yes locally
+		Stances:            map[Amendment]Stance{a: VoteAbstain},
 		StrictMajority:     true,
 	}
 	got := Decide(in)
@@ -142,7 +140,7 @@ func TestDecide_AlreadyEnabledSkipped(t *testing.T) {
 		Votes:              map[Amendment]int{a: 10},
 		Majority:           map[Amendment]time.Time{a: baseTime.Add(-30 * 24 * time.Hour)},
 		Stances:            map[Amendment]Stance{a: VoteUp},
-		Enabled:            map[Amendment]bool{a: true}, // already on
+		Enabled:            map[Amendment]bool{a: true},
 		StrictMajority:     true,
 	}
 	got := Decide(in)
@@ -156,7 +154,7 @@ func TestDecide_ObsoleteStanceNeverVotes(t *testing.T) {
 		CloseTime:          baseTime,
 		MajorityTimeout:    14 * 24 * time.Hour,
 		TrustedValidations: 10,
-		Votes:              map[Amendment]int{a: 10}, // strong validator support
+		Votes:              map[Amendment]int{a: 10},
 		Stances:            map[Amendment]Stance{a: VoteObsolete},
 		StrictMajority:     true,
 	}
@@ -165,8 +163,9 @@ func TestDecide_ObsoleteStanceNeverVotes(t *testing.T) {
 }
 
 func TestDecide_AbstainStanceNeverVotes(t *testing.T) {
-	// VoteAbstain must produce no gotMajority — only VoteUp does.
-	// (Abstain still allows lostMajority, see other test.)
+	// Abstain must NOT propose gotMajority — only VoteUp does. The
+	// LostMajority case for abstain is covered by
+	// TestDecide_LostMajorityFiresEvenForAbstain.
 	a := makeAmendment(0xEF)
 	in := Inputs{
 		UpcomingSeq:        1024,

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -155,18 +155,19 @@ type Adaptor interface {
 	// validations of the ledger before that and emit SetFee /
 	// EnableAmendment pseudo-txs reflecting the consensus.
 	//
+	// parentValidations are the trusted validations that referenced
+	// prevLedger.ID() — i.e. the votes the producer should tally.
+	// The engine pulls them from its validation tracker and passes
+	// them through; the adaptor does not have direct tracker access.
+	//
 	// The producer is also responsible for the quorum gate at
 	// RCLConsensus.cpp:361 (`validations.size() >= quorum`) and the
 	// negativeUNLFilter at RCLConsensus.cpp:358 — the engine does not
 	// pre-check those.
 	//
 	// Returns nil when no votes apply (insufficient validations, no
-	// vote stance to emit, etc.). Adaptors that don't implement vote
-	// tallying yet (most goXRPL builds today) should return nil — the
-	// engine treats nil as "no pseudo-txs", matching the behavior
-	// before #367 landed. The actual vote-tally producers ship in
-	// #368/#369/#370.
-	GenerateFlagLedgerPseudoTxs(prevLedger Ledger) [][]byte
+	// vote stance to emit, etc.).
+	GenerateFlagLedgerPseudoTxs(prevLedger Ledger, parentValidations []*Validation) [][]byte
 
 	// GenerateNegativeUNLPseudoTx returns the NegativeUNL pseudo-tx
 	// to inject when prevLedger is a voting ledger AND the

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -155,17 +155,17 @@ type Adaptor interface {
 	// validations of the ledger before that and emit SetFee /
 	// EnableAmendment pseudo-txs reflecting the consensus.
 	//
-	// parentValidations are the trusted validations that referenced
-	// prevLedger.ID() — i.e. the votes the producer should tally.
-	// The engine pulls them from its validation tracker and passes
-	// them through; the adaptor does not have direct tracker access.
+	// parentValidations are the trusted validations of prevLedger's
+	// parent (the ledger before the flag). The engine sources them
+	// from its validation tracker via prevLedger.ParentID() — matching
+	// rippled's getTrustedForLedger(prevLedger->parentHash, prev.seq()-1)
+	// at RCLConsensus.cpp:359-360.
 	//
-	// The producer is also responsible for the quorum gate at
-	// RCLConsensus.cpp:361 (`validations.size() >= quorum`) and the
-	// negativeUNLFilter at RCLConsensus.cpp:358 — the engine does not
-	// pre-check those.
+	// The adaptor applies the negative-UNL filter (RCLConsensus.cpp:358)
+	// and the quorum gate (RCLConsensus.cpp:361) internally, so the
+	// engine passes the raw trusted set through unchanged.
 	//
-	// Returns nil when no votes apply (insufficient validations, no
+	// Returns nil when no votes apply (below-quorum validations, no
 	// vote stance to emit, etc.).
 	GenerateFlagLedgerPseudoTxs(prevLedger Ledger, parentValidations []*Validation) [][]byte
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -872,6 +872,18 @@ func (e *Engine) OnLedger(id consensus.LedgerID, ledger []byte) error {
 	return nil
 }
 
+// parentValidations returns the trusted validations the engine has
+// recorded for the given ledger ID — passed to
+// Adaptor.GenerateFlagLedgerPseudoTxs so the producer can tally
+// fee/amendment votes from validations of prevLedger. Returns nil
+// when the tracker hasn't been wired (test fixtures, early startup).
+func (e *Engine) parentValidations(id consensus.LedgerID) []*consensus.Validation {
+	if e.validationTracker == nil {
+		return nil
+	}
+	return e.validationTracker.GetTrustedValidations(id)
+}
+
 // State returns the current consensus state.
 func (e *Engine) State() *consensus.RoundState {
 	e.mu.RLock()
@@ -1471,7 +1483,8 @@ func (e *Engine) closeLedger() {
 		prev := e.prevLedger
 		switch {
 		case consensus.IsFlagLedger(prev.Seq()):
-			if extra := e.adaptor.GenerateFlagLedgerPseudoTxs(prev); len(extra) > 0 {
+			parentVals := e.parentValidations(prev.ID())
+			if extra := e.adaptor.GenerateFlagLedgerPseudoTxs(prev, parentVals); len(extra) > 0 {
 				txs = append(txs, extra...)
 			}
 		case consensus.IsVotingLedger(prev.Seq()) && e.adaptor.IsFeatureEnabledOnLedger(prev, "NegativeUNL"):

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -875,8 +875,11 @@ func (e *Engine) OnLedger(id consensus.LedgerID, ledger []byte) error {
 // parentValidations returns the trusted validations the engine has
 // recorded for the given ledger ID — passed to
 // Adaptor.GenerateFlagLedgerPseudoTxs so the producer can tally
-// fee/amendment votes from validations of prevLedger. Returns nil
-// when the tracker hasn't been wired (test fixtures, early startup).
+// fee/amendment votes. Callers pass prevLedger.ParentID() (the flag
+// ledger's parent) so the lookup matches rippled's
+// RCLConsensus.cpp:359-360 getTrustedForLedger(prevLedger->parentHash,
+// prevLedger->seq() - 1). Returns nil when the tracker hasn't been
+// wired (test fixtures, early startup).
 func (e *Engine) parentValidations(id consensus.LedgerID) []*consensus.Validation {
 	if e.validationTracker == nil {
 		return nil
@@ -1483,7 +1486,7 @@ func (e *Engine) closeLedger() {
 		prev := e.prevLedger
 		switch {
 		case consensus.IsFlagLedger(prev.Seq()):
-			parentVals := e.parentValidations(prev.ID())
+			parentVals := e.parentValidations(prev.ParentID())
 			if extra := e.adaptor.GenerateFlagLedgerPseudoTxs(prev, parentVals); len(extra) > 0 {
 				txs = append(txs, extra...)
 			}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -309,7 +309,7 @@ func (a *mockAdaptor) GetPendingTxs() [][]byte {
 	return a.pendingTxs
 }
 
-func (a *mockAdaptor) GenerateFlagLedgerPseudoTxs(_ consensus.Ledger) [][]byte {
+func (a *mockAdaptor) GenerateFlagLedgerPseudoTxs(_ consensus.Ledger, _ []*consensus.Validation) [][]byte {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.flagLedgerPseudoTxs


### PR DESCRIPTION
## Summary

Pure-algorithm port of rippled's [`AmendmentTableImpl::doVoting`](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/misc/detail/AmendmentTable.cpp#L847-L941) to a new `internal/consensus/amendmentvote` package, **plus the production wiring** that threads it (and the `feevote` producer from #380) through `Adaptor.GenerateFlagLedgerPseudoTxs` so the engine actually injects the resulting pseudo-txs on flag ledgers.

Closes #370.

## What's in this PR

### 1. `internal/consensus/amendmentvote` — algorithm port
Decides whether to inject `EnableAmendment` pseudo-txs on a flag ledger, classifying each known amendment as **gotMajority** / **lostMajority** / **enable** / **no-action**. Mirrors `AmendmentTable.cpp:847-941` plus the threshold helpers at L313-L401.

### 2. `Adaptor.GenerateFlagLedgerPseudoTxs` — end-to-end wiring
| Step | What |
|---|---|
| Interface change | New `parentValidations []*Validation` parameter. Engine pulls trusted validations of `prevLedger`'s parent from its `ValidationTracker` (new `Engine.parentValidations` helper, keyed on `prevLedger.ParentID()` to mirror rippled's `getTrustedForLedger(parentHash, seq-1)`) and passes them through. |
| Boundary read | `readAmendmentsSLE(prev)` reads the Amendments SLE once at the producer entry. The parsed enabled set doubles as the feature-flag oracle (`rules.Enabled` replacement) since `*ledger.Ledger.Rules()` returns nil. Fail-closed on parse error. |
| NegUNL filter + quorum gate | `filterNegativeUNL` strips banned validators; the producer falls through to nil if `len(filtered) < quorum`. Mirrors `RCLConsensus.cpp:358-361`. |
| Fee branch | `runFeeVote` reads the FeeSettings SLE → current Stance, derives pre/post-XRPFees branch from `enabled[FeatureXRPFees]`, builds target from `Adaptor.feeVote` (zero fields fall back to rippled's `FeeSetup` defaults), extracts per-validator votes, calls `feevote.DoVoting`. |
| Amendment branch | `runAmendmentVote` records this round's validations into the `TrustedVotes` cache (anchored on `prev.ParentCloseTime` per `AmendmentTable.h:157`), reads `(available, votes)` back, builds Stances from the registry-seeded `Adaptor.amendmentStances` map (DefaultYes → VoteUp, Obsolete → VoteObsolete, DefaultNo → VoteAbstain via lookup; `Config.AmendmentVote` layers as VoteUp overrides), feeds `StrictMajority = enabled[FeatureFixAmendmentMajorityCalc]`, 14-day MajorityTimeout, calls `amendmentvote.DoVoting`. |
| Concat | Both branches' blobs appended in order. |

### 3. `TrustedVotes` flap-dampening cache
24h per-validator vote retention port of `AmendmentTable.cpp:75-286` so a flaky validator dropping briefly near a flag ledger doesn't cause an amendment to oscillate between GotMajority/LostMajority. Includes the slow-flap (>24h) vs fast-flap (<24h) integration test from rippled's `testValidatorFlapping`.

### 4. Registry-seeded operator stances
`Adaptor.amendmentStances` map seeded from `amendment.AllFeatures()` at construction so an unconfigured Go validator votes the way rippled does (DefaultYes auto-up, Obsolete refuses promotion). Without this, a default-config validator silently abstained on every amendment a rippled validator would auto-upvote — including NegativeUNL, fixAmendmentMajorityCalc, and every default-yes amendment in the registry — drifting the network's vote tally.

## Tests

**Algorithm**: threshold pre/post-fix + clamp, strict vs lax with single-validator special case, every classification branch (gotMajority / lostMajority / enable / window-not-held / already-enabled / obsolete / abstain / lostMajority-fires-through-abstain), deterministic output ordering, GotMajority wire format, enable-omits-Flags. Plus algorithm-level analogs of rippled's `testDetectMajority` / `testLostMajority` / `testVoteEnable` multi-week sweeps.

**TrustedVotes**: trusted-only ingestion, 24h timeout sweep, below/at-timeout preservation, replacement vs append, empty-amendments clears upvotes, TrustChanged preserves/drops, available-count lifecycle, plus a 23h-vs-25h flap-rate integration test mirroring rippled's `testValidatorFlapping`.

**Wiring**: below-quorum-no-blobs, FeeVote seeds SetFee, AmendmentVote(synthetic) seeds GotMajority, parent-close-time-anchored cache timeout (regression test for the time-source pairing with parentValidations), FeeVote empty-config rippled-defaults, FeeVote partial-config preserves explicit fields, parseAmendmentsSLEBytes fail-closed on garbage / empty-is-bootstrap, defensive nil-service. Plus three tests covering the registry-seeded stance map (default-yes seeded as VoteUp, operator override of default-no, obsolete-cannot-be-promoted).

`go test ./internal/consensus/...` passes; `go vet` clean; `golangci-lint run` clean. Pre-existing `internal/testing/*` failures (account/amm/batch/check/clawback/conformance) reproduce on `origin/main` and don't touch this PR's interface.

## Scope notes

- **NegativeUNL wiring is still a stub** (separate sub-issue under #362). Its producer needs the 256-ledger-ancestor walk plus per-seq validation history.
