### PR TITLE
codec: align XRP amount tests with negative-drops contract (fixes #385)

### DIFF
--- a/codec/binarycodec/types/amount_rippled_test.go
+++ b/codec/binarycodec/types/amount_rippled_test.go
@@ -79,13 +79,16 @@ func TestXRPAmountSerialization(t *testing.T) {
 			expectedHex: "416345785d8a0000",
 			expectError: false,
 		},
-		// Invalid values
+		// Negative XRP drops are valid in the codec: ledger objects such as
+		// NFToken sell offers may carry signed amounts. The absolute value is
+		// encoded without the positive sign bit (matches rippled STAmount).
 		{
-			name:        "negative XRP - should fail",
+			name:        "negative one drop",
 			drops:       "-1",
-			expectedHex: "",
-			expectError: true,
+			expectedHex: "0000000000000001",
+			expectError: false,
 		},
+		// Invalid values
 		{
 			name:        "decimal XRP - should fail",
 			drops:       "1.5",

--- a/codec/binarycodec/types/amount_test.go
+++ b/codec/binarycodec/types/amount_test.go
@@ -40,7 +40,7 @@ func TestVerifyXrpValue(t *testing.T) {
 		{
 			name:   "pass - valid xrp value - no decimal - negative value",
 			input:  "-125000708",
-			expErr: &InvalidAmountError{Amount: "-125000708"},
+			expErr: nil,
 		},
 	}
 	for _, tt := range tests {
@@ -183,10 +183,13 @@ func TestSerializeXrpAmount(t *testing.T) {
 			expErr:         nil,
 		},
 		{
-			name:           "fail - invalid xrp value - negative",
+			// Negative XRP drops are accepted at the codec layer so ledger objects
+			// such as NFToken sell offers can carry signed amounts; the absolute
+			// value is encoded without the positive sign bit.
+			name:           "pass - valid xrp value - negative",
 			input:          "-125000708",
-			expectedOutput: nil,
-			expErr:         &InvalidAmountError{Amount: "-125000708"},
+			expectedOutput: []byte{0x00, 0x00, 0x00, 0x00, 0x07, 0x73, 0x5C, 0x04},
+			expErr:         nil,
 		},
 		{
 			name:           "fail - invalid xrp value - decimal",
@@ -223,7 +226,8 @@ func TestSerializeXrpAmount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := serializeXrpAmount(tt.input)
 			if tt.expErr != nil {
-				require.EqualError(t, tt.expErr, err.Error())
+				require.Error(t, err)
+				require.Equal(t, tt.expErr.Error(), err.Error())
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedOutput, got)

--- a/codec/binarycodec/types/rippled_protocol_test.go
+++ b/codec/binarycodec/types/rippled_protocol_test.go
@@ -182,11 +182,14 @@ func TestXRPAmountEncoding_RippledVectors(t *testing.T) {
 			description: "exceeds max XRP drops",
 		},
 		{
-			name:        "negative XRP not allowed",
+			// Negative XRP drops are accepted at the codec layer so ledger
+			// objects (e.g., NFToken sell offers) can carry signed amounts.
+			// The absolute value is encoded without the positive sign bit.
+			name:        "negative one drop",
 			drops:       "-1",
-			expectedHex: "",
-			expectError: true,
-			description: "negative XRP not allowed in serialization",
+			expectedHex: "0000000000000001",
+			expectError: false,
+			description: "negative XRP encodes |val| without positive sign bit",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Update three stale subtests in `codec/binarycodec/types` (`amount_test.go`, `amount_rippled_test.go`, `rippled_protocol_test.go`) that asserted the pre-5dc61c5 contract — `verifyXrpValue` / `serializeXrpAmount` rejecting negative drops. The codec layer now intentionally accepts them so ledger objects (e.g., NFToken sell offers when `fixNFTokenNegOffer` is disabled) can carry signed amounts (matches rippled `STAmount` sign-bit behavior).
- Negative drops encode the absolute value without the positive sign bit: `-125000708 → 00 00 00 00 07 73 5C 04`, `-1 → 00 00 00 00 00 00 00 01`.
- Harden `TestSerializeXrpAmount`'s error branch to call `err.Error()` only after `require.Error(t, err)`, so a future missing-error regression surfaces as a test failure instead of a SIGSEGV that nukes the package binary (the original symptom in #385).

Test-only change; no production code is touched.

Fixes #385.

## Test plan
- [x] `just test-pkg ./codec/binarycodec/types/...` — was failing on `main` (3 subtests + nil-deref panic), now green.
- [x] `just test-libs` — all packages pass.
- [x] `just vet` — clean.