### PR TITLE
tx: reconcile account/check/clawback tests with current validators (#386)

### DIFF
--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -220,7 +220,7 @@ func (a *AccountSet) Validate() error {
 	if a.TickSize != nil {
 		ts := *a.TickSize
 		if ts != 0 && (ts < protocol.TickSizeMin || ts > protocol.TickSizeMax) {
-			return tx.Errorf(tx.TemBAD_TICK_SIZE, "tick size must be 0 or 3-15")
+			return tx.Errorf(tx.TemBAD_TICK_SIZE, "tick size must be 0 or 3-16")
 		}
 	}
 

--- a/internal/tx/account/account_set_test.go
+++ b/internal/tx/account/account_set_test.go
@@ -188,7 +188,9 @@ func TestAccountSetTransferRate(t *testing.T) {
 }
 
 // TestAccountSetTickSize tests TickSize validation.
-// Reference: rippled Quality.h minTickSize=3, maxTickSize=15
+// Reference: rippled Quality.h minTickSize=3, maxTickSize=16 and SetAccount.cpp:149-155
+// rippled treats TickSize == maxTickSize (16) as a request to clear the field, so it
+// passes preflight validation. Only values outside the [3, 16] band (apart from 0) fail.
 func TestAccountSetTickSize(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -213,8 +215,13 @@ func TestAccountSetTickSize(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "tick size 15 (max)",
+			name:        "tick size 15",
 			tickSize:    15,
+			expectError: false,
+		},
+		{
+			name:        "tick size 16 (max - treated as clear)",
+			tickSize:    16,
 			expectError: false,
 		},
 		// Invalid tick sizes
@@ -222,19 +229,19 @@ func TestAccountSetTickSize(t *testing.T) {
 			name:        "tick size 1 - temBAD_TICK_SIZE",
 			tickSize:    1,
 			expectError: true,
-			errorMsg:    "temBAD_TICK_SIZE: tick size must be 0 or 3-15",
+			errorMsg:    "temBAD_TICK_SIZE: tick size must be 0 or 3-16",
 		},
 		{
 			name:        "tick size 2 - temBAD_TICK_SIZE",
 			tickSize:    2,
 			expectError: true,
-			errorMsg:    "temBAD_TICK_SIZE: tick size must be 0 or 3-15",
+			errorMsg:    "temBAD_TICK_SIZE: tick size must be 0 or 3-16",
 		},
 		{
-			name:        "tick size 16 - temBAD_TICK_SIZE",
-			tickSize:    16,
+			name:        "tick size 17 - temBAD_TICK_SIZE",
+			tickSize:    17,
 			expectError: true,
-			errorMsg:    "temBAD_TICK_SIZE: tick size must be 0 or 3-15",
+			errorMsg:    "temBAD_TICK_SIZE: tick size must be 0 or 3-16",
 		},
 	}
 

--- a/internal/tx/check/check_create.go
+++ b/internal/tx/check/check_create.go
@@ -51,6 +51,10 @@ func (c *CheckCreate) Validate() error {
 		return err
 	}
 
+	if c.Destination == "" {
+		return tx.Errorf(tx.TemDST_NEEDED, "Destination is required")
+	}
+
 	// Cannot create check to self
 	// Reference: CreateCheck.cpp L47-52
 	if c.Account == c.Destination {

--- a/internal/tx/check/check_test.go
+++ b/internal/tx/check/check_test.go
@@ -62,7 +62,7 @@ func TestCheckCreateValidation(t *testing.T) {
 				SendMax:     tx.NewXRPAmount(10000000000),
 			},
 			expectError: true,
-			errorMsg:    "Destination is required",
+			errorMsg:    "temDST_NEEDED: Destination is required",
 		},
 		{
 			name: "missing SendMax - temBAD_AMOUNT equivalent",
@@ -72,7 +72,7 @@ func TestCheckCreateValidation(t *testing.T) {
 				SendMax:     tx.Amount{},
 			},
 			expectError: true,
-			errorMsg:    "SendMax is required",
+			errorMsg:    "temBAD_AMOUNT: SendMax must be positive",
 		},
 		{
 			name: "check to self - temREDUNDANT equivalent",
@@ -82,7 +82,7 @@ func TestCheckCreateValidation(t *testing.T) {
 				SendMax:     tx.NewXRPAmount(10000000000),
 			},
 			expectError: true,
-			errorMsg:    "cannot create check to self",
+			errorMsg:    "temREDUNDANT: cannot create check to self",
 		},
 		{
 			name: "missing account",
@@ -166,7 +166,7 @@ func TestCheckCashValidation(t *testing.T) {
 				Amount:  ptrAmount(tx.NewXRPAmount(10000000000)),
 			},
 			expectError: true,
-			errorMsg:    "CheckID is required",
+			errorMsg:    "temMALFORMED: CheckID is required",
 		},
 		{
 			name: "missing both Amount and DeliverMin - temMALFORMED equivalent",
@@ -175,7 +175,7 @@ func TestCheckCashValidation(t *testing.T) {
 				CheckID: "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0",
 			},
 			expectError: true,
-			errorMsg:    "must specify Amount or DeliverMin",
+			errorMsg:    "temMALFORMED: must specify exactly one of Amount or DeliverMin",
 		},
 		{
 			name: "both Amount and DeliverMin specified - temMALFORMED equivalent",
@@ -186,7 +186,7 @@ func TestCheckCashValidation(t *testing.T) {
 				DeliverMin: ptrAmount(tx.NewXRPAmount(5000000000)),
 			},
 			expectError: true,
-			errorMsg:    "cannot specify both Amount and DeliverMin",
+			errorMsg:    "temMALFORMED: must specify exactly one of Amount or DeliverMin",
 		},
 		{
 			name: "missing account",

--- a/internal/tx/clawback/clawback_test.go
+++ b/internal/tx/clawback/clawback_test.go
@@ -3,12 +3,18 @@ package clawback
 import (
 	"testing"
 
-	"github.com/LeJamon/goXRPLd/internal/tx"
-
 	"github.com/LeJamon/goXRPLd/amendment"
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testMPTIssuanceID = "000000000000000000000001000000000000000000000001"
+
+func newTestMPTAmount(value int64, issuer string) state.Amount {
+	return state.NewMPTAmountWithIssuanceID(value, issuer, testMPTIssuanceID)
+}
 
 // Clawback Validation Tests
 // Based on rippled Clawback_test.cpp
@@ -33,7 +39,7 @@ func TestClawbackValidation(t *testing.T) {
 			name: "valid - MPToken clawback with Holder",
 			tx: &Clawback{
 				BaseTx: *tx.NewBaseTx(tx.TypeClawback, "rIssuer"),
-				Amount: tx.NewIssuedAmountFromFloat64(100.0, "MPT", "rIssuer"),
+				Amount: newTestMPTAmount(100, "rIssuer"),
 				Holder: "rHolder",
 			},
 			wantErr: false,
@@ -89,11 +95,11 @@ func TestClawbackValidation(t *testing.T) {
 			name: "invalid - MPToken clawback - Holder same as issuer",
 			tx: &Clawback{
 				BaseTx: *tx.NewBaseTx(tx.TypeClawback, "rIssuer"),
-				Amount: tx.NewIssuedAmountFromFloat64(100.0, "MPT", "rIssuer"),
+				Amount: newTestMPTAmount(100, "rIssuer"),
 				Holder: "rIssuer", // Same as Account
 			},
 			wantErr: true,
-			errMsg:  "issuer",
+			errMsg:  "Holder cannot be the same as issuer",
 		},
 		{
 			name: "invalid - universal flags set",
@@ -200,7 +206,7 @@ func TestClawbackRequiredAmendments(t *testing.T) {
 	})
 
 	t.Run("MPToken clawback requires Clawback and MPTokensV1 amendments", func(t *testing.T) {
-		clawbackTx := NewMPTokenClawback("rIssuer", "rHolder", "000000000000000000000001", tx.NewIssuedAmountFromFloat64(100.0, "MPT", "rIssuer"))
+		clawbackTx := NewMPTokenClawback("rIssuer", "rHolder", testMPTIssuanceID, newTestMPTAmount(100, "rIssuer"))
 		amendments := clawbackTx.RequiredAmendments()
 		assert.Contains(t, amendments, amendment.FeatureClawback)
 		assert.Contains(t, amendments, amendment.FeatureMPTokensV1)


### PR DESCRIPTION
## Summary

Fixes #386 — `Test (tx)` CI job (running `./internal/tx/...`) was red on `main` with stale assertions that predated the migration to rippled-prefixed error messages and recent clawback work.

- **account**: `AccountSet` `TickSize` bound is `[3, maxTickSize]` per rippled's `Quality.h` (`maxTickSize = 16`). The validator already used the correct comparison, but its error string advertised the wrong upper bound. Updated message to "0 or 3-16", added 17 as the genuinely-invalid upper case, and reclassified 16 as valid (rippled accepts it and treats it as a clear in `SetAccount::doApply`).
- **check**: Re-introduced the explicit "Destination is required" preflight check (`temDST_NEEDED`). rippled's `preflight1` rejects a missing `sfDestination` on `CreateCheck`, but the field is a non-pointer string in Go so the empty case was slipping through. Updated `check_test.go` assertions to match the `temXXX:`-prefixed strings already returned by `CheckCreate` and `CheckCash`.
- **clawback**: The MPToken validation/amendment cases were constructing `tx.NewIssuedAmountFromFloat64(_, "MPT", _)`, which is an IOU with a "MPT" currency string — `Amount.IsMPT()` returned false, so the validator took the IOU branch and rejected the `Holder` field, and `RequiredAmendments` did not include `MPTokensV1`. Switched to `state.NewMPTAmountWithIssuanceID` so the MPT branch is exercised, and tightened the "Holder same as issuer" assertion to the real error message instead of a substring search for "issuer".

No protocol-behaviour changes; one error string is now more accurate, and one preflight gap (`Destination` required) is closed to match rippled.

## Test plan

- [x] `just test-pkg ./internal/tx/account/...` — green
- [x] `just test-pkg ./internal/tx/check/...` — green
- [x] `just test-pkg ./internal/tx/clawback/...` — green
- [x] `just test-tx` — full `./internal/tx/...` suite green (this is what `Test (tx)` runs)
- [x] `just vet` and `just build` clean
- [ ] CI `Test (tx)` job goes green on this PR

Integration-test failures observed in `internal/testing/...` (AccountSet flag bit 0x40000000, AMM bid suite, `EnableAmendment` lifecycle) are pre-existing on `main` and unrelated to the changed packages.