### PR TITLE
testing: encode SeqProxy type bit in canonical sort (#392)

### DIFF
--- a/internal/ledger/service/canonical_txset.go
+++ b/internal/ledger/service/canonical_txset.go
@@ -16,7 +16,7 @@ type pendingTx struct {
 	txBlob   []byte   // raw binary blob
 	hash     [32]byte // transaction hash (SHA-512Half of TXN prefix + blob)
 	account  [20]byte // sender account ID (raw 20 bytes)
-	sequence uint32   // effective sequence (SeqProxy: Sequence or TicketSequence)
+	seqProxy uint64   // SeqProxy encoded as uint64: high bit set for ticket-based txns
 }
 
 // canonicalSort sorts pending transactions using the CanonicalTXSet ordering from rippled.
@@ -55,9 +55,9 @@ func canonicalSort(txs []pendingTx) {
 		if cmp != 0 {
 			return cmp < 0
 		}
-		// Compare sequence
-		if entries[i].tx.sequence != entries[j].tx.sequence {
-			return entries[i].tx.sequence < entries[j].tx.sequence
+		// Compare seqProxy (sequence-typed sorts before ticket-typed regardless of value)
+		if entries[i].tx.seqProxy != entries[j].tx.seqProxy {
+			return entries[i].tx.seqProxy < entries[j].tx.seqProxy
 		}
 		// Compare txID (hash)
 		return bytes.Compare(entries[i].tx.hash[:], entries[j].tx.hash[:]) < 0
@@ -116,8 +116,23 @@ func parsePendingTx(blob []byte) (pendingTx, error) {
 		txBlob:   blob,
 		hash:     txHash,
 		account:  accountID,
-		sequence: common.SeqProxy(),
+		seqProxy: encodeSeqProxy(common),
 	}, nil
+}
+
+// encodeSeqProxy encodes a transaction's SeqProxy (type + value) into a single
+// uint64 suitable for canonical ordering. All sequence-based txns sort before
+// all ticket-based txns regardless of value, matching rippled's
+// SeqProxy::operator< (Seq=0 < Ticket=1, type bit dominates value).
+// Reference: rippled SeqProxy.h operator<.
+func encodeSeqProxy(c *tx.Common) uint64 {
+	if c.Sequence != nil && *c.Sequence != 0 {
+		return uint64(*c.Sequence)
+	}
+	if c.TicketSequence != nil {
+		return uint64(*c.TicketSequence) | (1 << 32)
+	}
+	return 0
 }
 
 // computeAccountKey computes the sort key for an account.

--- a/internal/ledger/service/canonical_txset.go
+++ b/internal/ledger/service/canonical_txset.go
@@ -16,7 +16,7 @@ type pendingTx struct {
 	txBlob   []byte   // raw binary blob
 	hash     [32]byte // transaction hash (SHA-512Half of TXN prefix + blob)
 	account  [20]byte // sender account ID (raw 20 bytes)
-	seqProxy uint64   // SeqProxy encoded as uint64: high bit set for ticket-based txns
+	seqProxy uint64   // SeqProxy key: bit 32 set for ticket-based txns, lower 32 bits hold the value
 }
 
 // canonicalSort sorts pending transactions using the CanonicalTXSet ordering from rippled.
@@ -116,23 +116,8 @@ func parsePendingTx(blob []byte) (pendingTx, error) {
 		txBlob:   blob,
 		hash:     txHash,
 		account:  accountID,
-		seqProxy: encodeSeqProxy(common),
+		seqProxy: common.SeqProxyKey(),
 	}, nil
-}
-
-// encodeSeqProxy encodes a transaction's SeqProxy (type + value) into a single
-// uint64 suitable for canonical ordering. All sequence-based txns sort before
-// all ticket-based txns regardless of value, matching rippled's
-// SeqProxy::operator< (Seq=0 < Ticket=1, type bit dominates value).
-// Reference: rippled SeqProxy.h operator<.
-func encodeSeqProxy(c *tx.Common) uint64 {
-	if c.Sequence != nil && *c.Sequence != 0 {
-		return uint64(*c.Sequence)
-	}
-	if c.TicketSequence != nil {
-		return uint64(*c.TicketSequence) | (1 << 32)
-	}
-	return 0
 }
 
 // computeAccountKey computes the sort key for an account.

--- a/internal/ledger/service/canonical_txset_test.go
+++ b/internal/ledger/service/canonical_txset_test.go
@@ -17,7 +17,7 @@ func TestCanonicalSortEmpty(t *testing.T) {
 
 func TestCanonicalSortSingle(t *testing.T) {
 	txs := []pendingTx{
-		{hash: [32]byte{0x01}, account: [20]byte{0xAA}, sequence: 1},
+		{hash: [32]byte{0x01}, account: [20]byte{0xAA}, seqProxy: 1},
 	}
 	canonicalSort(txs)
 	if txs[0].hash[0] != 0x01 {
@@ -32,8 +32,8 @@ func TestCanonicalSortByAccountKey(t *testing.T) {
 	account2 := [20]byte{0xFF}
 
 	txs := []pendingTx{
-		{txBlob: []byte{1}, hash: makeHash(1), account: account2, sequence: 1},
-		{txBlob: []byte{2}, hash: makeHash(2), account: account1, sequence: 1},
+		{txBlob: []byte{1}, hash: makeHash(1), account: account2, seqProxy: 1},
+		{txBlob: []byte{2}, hash: makeHash(2), account: account1, seqProxy: 1},
 	}
 
 	canonicalSort(txs)
@@ -63,22 +63,45 @@ func TestCanonicalSortBySequence(t *testing.T) {
 	// Same account, different sequences
 	account := [20]byte{0x42}
 	txs := []pendingTx{
-		{txBlob: []byte{1}, hash: makeHash(3), account: account, sequence: 10},
-		{txBlob: []byte{2}, hash: makeHash(1), account: account, sequence: 5},
-		{txBlob: []byte{3}, hash: makeHash(2), account: account, sequence: 8},
+		{txBlob: []byte{1}, hash: makeHash(3), account: account, seqProxy: 10},
+		{txBlob: []byte{2}, hash: makeHash(1), account: account, seqProxy: 5},
+		{txBlob: []byte{3}, hash: makeHash(2), account: account, seqProxy: 8},
 	}
 
 	canonicalSort(txs)
 
 	// Same account => sorted by sequence
-	if txs[0].sequence != 5 {
-		t.Errorf("expected sequence 5 first, got %d", txs[0].sequence)
+	if txs[0].seqProxy != 5 {
+		t.Errorf("expected sequence 5 first, got %d", txs[0].seqProxy)
 	}
-	if txs[1].sequence != 8 {
-		t.Errorf("expected sequence 8 second, got %d", txs[1].sequence)
+	if txs[1].seqProxy != 8 {
+		t.Errorf("expected sequence 8 second, got %d", txs[1].seqProxy)
 	}
-	if txs[2].sequence != 10 {
-		t.Errorf("expected sequence 10 third, got %d", txs[2].sequence)
+	if txs[2].seqProxy != 10 {
+		t.Errorf("expected sequence 10 third, got %d", txs[2].seqProxy)
+	}
+}
+
+func TestCanonicalSortSeqBeforeTicket(t *testing.T) {
+	// Same account: a sequence-based txn must sort before a ticket-based txn
+	// regardless of numeric value, matching rippled's SeqProxy::operator<.
+	// This guarantees that ticket-creating txns (sequence-based) sort before
+	// ticket-consuming txns (ticket-based) and that an account-creating txn
+	// is applied before a batch that uses an earlier-issued ticket.
+	account := [20]byte{0x42}
+	const ticketBit = uint64(1) << 32
+	txs := []pendingTx{
+		{txBlob: []byte{1}, hash: makeHash(1), account: account, seqProxy: ticketBit | 6}, // ticket value 6
+		{txBlob: []byte{2}, hash: makeHash(2), account: account, seqProxy: 16},             // sequence value 16
+	}
+
+	canonicalSort(txs)
+
+	if txs[0].seqProxy != 16 {
+		t.Errorf("expected sequence-based (16) first, got seqProxy=%#x", txs[0].seqProxy)
+	}
+	if txs[1].seqProxy != ticketBit|6 {
+		t.Errorf("expected ticket-based (6) second, got seqProxy=%#x", txs[1].seqProxy)
 	}
 }
 
@@ -90,9 +113,9 @@ func TestCanonicalSortByTxID(t *testing.T) {
 	hash3 := [32]byte{0x03}
 
 	txs := []pendingTx{
-		{txBlob: []byte{1}, hash: hash3, account: account, sequence: 1},
-		{txBlob: []byte{2}, hash: hash1, account: account, sequence: 1},
-		{txBlob: []byte{3}, hash: hash2, account: account, sequence: 1},
+		{txBlob: []byte{1}, hash: hash3, account: account, seqProxy: 1},
+		{txBlob: []byte{2}, hash: hash1, account: account, seqProxy: 1},
+		{txBlob: []byte{3}, hash: hash2, account: account, seqProxy: 1},
 	}
 
 	canonicalSort(txs)
@@ -113,10 +136,10 @@ func TestCanonicalSortDeterministic(t *testing.T) {
 	// Sorting the same set twice should produce the same result
 	makeTxs := func() []pendingTx {
 		return []pendingTx{
-			{txBlob: []byte{1}, hash: makeHash(5), account: [20]byte{0xAA}, sequence: 3},
-			{txBlob: []byte{2}, hash: makeHash(2), account: [20]byte{0xBB}, sequence: 1},
-			{txBlob: []byte{3}, hash: makeHash(8), account: [20]byte{0xCC}, sequence: 2},
-			{txBlob: []byte{4}, hash: makeHash(1), account: [20]byte{0xAA}, sequence: 1},
+			{txBlob: []byte{1}, hash: makeHash(5), account: [20]byte{0xAA}, seqProxy: 3},
+			{txBlob: []byte{2}, hash: makeHash(2), account: [20]byte{0xBB}, seqProxy: 1},
+			{txBlob: []byte{3}, hash: makeHash(8), account: [20]byte{0xCC}, seqProxy: 2},
+			{txBlob: []byte{4}, hash: makeHash(1), account: [20]byte{0xAA}, seqProxy: 1},
 		}
 	}
 

--- a/internal/ledger/service/canonical_txset_test.go
+++ b/internal/ledger/service/canonical_txset_test.go
@@ -90,7 +90,7 @@ func TestCanonicalSortSeqBeforeTicket(t *testing.T) {
 	const ticketBit = uint64(1) << 32
 	txs := []pendingTx{
 		{txBlob: []byte{1}, hash: makeHash(1), account: account, seqProxy: ticketBit | 6}, // ticket value 6
-		{txBlob: []byte{2}, hash: makeHash(2), account: account, seqProxy: 16},             // sequence value 16
+		{txBlob: []byte{2}, hash: makeHash(2), account: account, seqProxy: 16},            // sequence value 16
 	}
 
 	canonicalSort(txs, [32]byte{})

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -105,7 +105,7 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte) 
 				txBlob:   rawBlob,
 				hash:     txHash,
 				account:  accountID,
-				sequence: common.SeqProxy(),
+				seqProxy: encodeSeqProxy(common),
 			})
 		}
 	}

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -105,7 +105,7 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte) 
 				txBlob:   rawBlob,
 				hash:     txHash,
 				account:  accountID,
-				seqProxy: encodeSeqProxy(common),
+				seqProxy: common.SeqProxyKey(),
 			})
 		}
 	}

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -793,7 +793,7 @@ type canonicalEntry struct {
 	txn      tx.Transaction
 	hash     [32]byte
 	account  [20]byte
-	sequence uint32
+	seqProxy uint64
 }
 
 // buildCanonicalEntries pre-computes hashes, account IDs, and sequences for
@@ -812,7 +812,7 @@ func buildCanonicalEntries(txns []tx.Transaction) []canonicalEntry {
 			txn:      txn,
 			hash:     h,
 			account:  accountID,
-			sequence: common.SeqProxy(),
+			seqProxy: canonicalSeq(common),
 		}
 	}
 	return entries
@@ -845,8 +845,8 @@ func applyCanonicalSort(txns []tx.Transaction, entries []canonicalEntry, salt [3
 		if cmp != 0 {
 			return cmp < 0
 		}
-		if entries[ei.idx].sequence != entries[ej.idx].sequence {
-			return entries[ei.idx].sequence < entries[ej.idx].sequence
+		if entries[ei.idx].seqProxy != entries[ej.idx].seqProxy {
+			return entries[ei.idx].seqProxy < entries[ej.idx].seqProxy
 		}
 		return bytes.Compare(entries[ei.idx].hash[:], entries[ej.idx].hash[:]) < 0
 	})
@@ -1003,11 +1003,12 @@ func getNibble(h [32]byte, pos int) int {
 	return int(h[byteIdx] & 0x0F)
 }
 
-// canonicalSeq returns the effective sequence number for canonical ordering.
-// Sequence-based transactions sort before ticket-based ones (sequence values
-// are typically lower than ticket sequence values in practice).
-// Reference: rippled SeqProxy ordering: Seq < Ticket when values equal,
-// but in practice sequence numbers are always present.
+// canonicalSeq returns the effective sequence number for canonical ordering,
+// encoding both the SeqProxy type and value into a single uint64. All
+// sequence-based txns sort before all ticket-based txns regardless of value,
+// matching rippled's SeqProxy::operator< (the type bit dominates the value).
+// This guarantees ticket-creating txns sort before ticket-consuming txns.
+// Reference: rippled SeqProxy.h operator< (Seq=0 < Ticket=1).
 func canonicalSeq(c *tx.Common) uint64 {
 	if c.Sequence != nil && *c.Sequence != 0 {
 		return uint64(*c.Sequence)

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -776,9 +776,9 @@ func sortCanonical(txns []tx.Transaction) {
 			return ci.Account < cj.Account
 		}
 
-		// Secondary: sequence proxy (sequence takes priority over tickets)
-		seqI := canonicalSeq(ci)
-		seqJ := canonicalSeq(cj)
+		// Secondary: sequence proxy (sequence-typed sorts before ticket-typed)
+		seqI := ci.SeqProxyKey()
+		seqJ := cj.SeqProxyKey()
 		if seqI != seqJ {
 			return seqI < seqJ
 		}
@@ -812,7 +812,7 @@ func buildCanonicalEntries(txns []tx.Transaction) []canonicalEntry {
 			txn:      txn,
 			hash:     h,
 			account:  accountID,
-			seqProxy: canonicalSeq(common),
+			seqProxy: common.SeqProxyKey(),
 		}
 	}
 	return entries
@@ -1003,46 +1003,13 @@ func getNibble(h [32]byte, pos int) int {
 	return int(h[byteIdx] & 0x0F)
 }
 
-// canonicalSeq returns the effective sequence number for canonical ordering,
-// encoding both the SeqProxy type and value into a single uint64. All
-// sequence-based txns sort before all ticket-based txns regardless of value,
-// matching rippled's SeqProxy::operator< (the type bit dominates the value).
-// This guarantees ticket-creating txns sort before ticket-consuming txns.
-// Reference: rippled SeqProxy.h operator< (Seq=0 < Ticket=1).
-func canonicalSeq(c *tx.Common) uint64 {
-	if c.Sequence != nil && *c.Sequence != 0 {
-		return uint64(*c.Sequence)
-	}
-	if c.TicketSequence != nil {
-		// Tickets sort after sequences. Use a high base to ensure this.
-		return uint64(*c.TicketSequence) + (1 << 32)
-	}
-	return 0
-}
-
-// sortHeldBySequence sorts transactions by sequence number (lowest first).
+// sortHeldBySequence sorts transactions by SeqProxy key (sequence-typed first,
+// then ticket-typed, each ordered by value), matching the canonical ordering
+// used at consensus close.
 func sortHeldBySequence(txns []tx.Transaction) {
-	for i := 0; i < len(txns)-1; i++ {
-		for j := i + 1; j < len(txns); j++ {
-			seqI := getSeqFromTx(txns[i])
-			seqJ := getSeqFromTx(txns[j])
-			if seqJ < seqI {
-				txns[i], txns[j] = txns[j], txns[i]
-			}
-		}
-	}
-}
-
-// getSeqFromTx extracts the sequence number from a transaction.
-func getSeqFromTx(txn tx.Transaction) uint32 {
-	common := txn.GetCommon()
-	if common.Sequence != nil {
-		return *common.Sequence
-	}
-	if common.TicketSequence != nil {
-		return *common.TicketSequence
-	}
-	return 0
+	sort.SliceStable(txns, func(i, j int) bool {
+		return txns[i].GetCommon().SeqProxyKey() < txns[j].GetCommon().SeqProxyKey()
+	})
 }
 
 // computeTxID generates a deterministic transaction ID for a transaction.

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -346,6 +346,22 @@ func (c *Common) SeqProxy() uint32 {
 	return 0
 }
 
+// SeqProxyKey encodes the SeqProxy type and value into a single uint64 suitable
+// for canonical ordering. Bits 0..31 hold the value; bit 32 is set for
+// ticket-based transactions. This guarantees all sequence-typed entries sort
+// strictly before all ticket-typed entries regardless of value, matching
+// rippled's SeqProxy::operator< (the type bit dominates the value).
+// Reference: rippled SeqProxy.h operator<, STTx::getSeqProxy().
+func (c *Common) SeqProxyKey() uint64 {
+	if c.Sequence != nil && *c.Sequence != 0 {
+		return uint64(*c.Sequence)
+	}
+	if c.TicketSequence != nil {
+		return uint64(*c.TicketSequence) | (1 << 32)
+	}
+	return 0
+}
+
 // BaseTx provides a base implementation for transactions
 type BaseTx struct {
 	Common


### PR DESCRIPTION
## Summary

Fixes #392.

The canonical-sort code in `internal/testing/env_submission.go` and `internal/ledger/service/canonical_txset.go` stripped the SeqProxy *type* (Seq vs Ticket) and compared only the raw uint32 value. This diverges from rippled's `SeqProxy::operator<` (`SeqProxy.h:113-140`), which sorts **all sequence-based txns before all ticket-based txns regardless of value** — by design "to guarantee that transactions creating Tickets are sorted in front of transactions that consume Tickets."

In `TestObjectsOpenLedger/create_object_before_batch_txn`, alice's standalone `CheckCreate` uses `Sequence=16` and the `Batch` outer uses `TicketSequence=6`. Rippled puts the `CheckCreate` first; our code put the `Batch` first (6 < 16), so the inner `CheckCash` ran before the check existed. AllOrNothing silently rolled back, bob's sequence didn't advance, and the assertion `bob seq should advance by 1 (inner CheckCash)` failed (expected 4, got 3).

## What changed

- Encode `SeqProxy` as `uint64` with bit 32 set for ticket-typed txns. Natural uint64 ordering then matches rippled.
- Apply the fix in two places that have the same bug:
  - `internal/testing/env_submission.go` — replay-on-close canonical sort (reuses the existing `canonicalSeq` helper, which already had the correct encoding)
  - `internal/ledger/service/canonical_txset.go` — production CanonicalTXSet (new `encodeSeqProxy` helper); also updated `tx_query.go` and existing unit tests for the field rename
- New regression test `TestCanonicalSortSeqBeforeTicket` locking in the seq-before-ticket invariant.

## Test plan

- [x] `just test-pkg "./internal/testing/batch/... -run TestObjectsOpenLedger"` — all three subtests pass (was failing on `create_object_before_batch_txn`).
- [x] `just test-pkg "./internal/testing/batch/..."` — full batch suite green.
- [x] `just test-pkg "./internal/ledger/service/..."` — all canonical-sort tests green, new regression test passes.
- [x] `just vet` — clean.
- [x] `just test-integration` — remaining failures are all pre-existing on `main` (verified by re-running on `origin/main`): out-of-scope conformance suites (`Vault`, `Delegate`, `EscrowToken`, `XChain`, `Batch`, `NFTokenAuth`, etc.) plus the same set of TxQ/AMM flakes.

## Refs

- rippled `include/xrpl/protocol/SeqProxy.h:113-140` — `SeqProxy::operator<` (Seq=0 < Ticket=1, type bit dominates value)
- rippled `src/test/app/Batch_test.cpp:3297-3337` — "Create Object Before Batch Txn"