### PR TITLE
catchup: request actual missing SHAMap NodeIDs (closes #395)

### DIFF
--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -211,31 +211,14 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 	return nil
 }
 
-// missingNodeBatch caps how many missing-node IDs we ship per
-// TMGetLedger request. Each request fans out to one peer response
-// containing the requested subtree(s) plus QueryDepth=2 worth of
-// descendants, so 16 keeps the response well under rippled's
-// 256-node-per-reply ceiling while still amortizing several missing
-// nodes per round trip.
+// missingNodeBatch caps NodeIDs per TMGetLedger request. Sits between
+// rippled's blind-request cap (reqNodes=12) and reply cap
+// (reqNodesReply=128, InboundLedger.cpp).
 const missingNodeBatch = 16
 
-// NeedsMissingNodeIDs returns the wire-encoded NodeIDs of missing
-// SHAMap inner nodes that the peer should ship back, ordered by depth
-// so root-adjacent subtrees fill before deeper ones.
-//
-// Earlier this function unconditionally requested the SHAMap root with
-// QueryDepth=2 and ignored the actual missing-node enumeration. That
-// worked for tiny test ledgers (everything fits in root + 2 levels)
-// but on a real network it deadlocked catch-up: once depth 0..2 was
-// populated, any node at depth ≥3 stayed permanently missing because
-// we kept asking for the same root subtree the peer had already
-// served. The "1 missing node" log loop in issue #395 surfaced
-// exactly this — `IsComplete()` never flips to true and the inbound
-// acquisition wedges until the outer timeout.
-//
-// Returns nil if no nodes are missing or the map isn't ready to be
-// fed; otherwise returns up to missingNodeBatch path-based NodeIDs
-// from GetMissingNodes.
+// NeedsMissingNodeIDs returns up to missingNodeBatch wire-encoded
+// path-based NodeIDs of missing SHAMap inner nodes, ordered by depth.
+// Returns nil if the state map is complete or not yet ready (issue #395).
 func (l *Ledger) NeedsMissingNodeIDs() [][]byte {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -211,8 +211,31 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 	return nil
 }
 
-// NeedsMissingNodeIDs returns the wire-encoded nodeIDs of missing SHAMap nodes.
-// Returns nil if the state map is complete or not yet created.
+// missingNodeBatch caps how many missing-node IDs we ship per
+// TMGetLedger request. Each request fans out to one peer response
+// containing the requested subtree(s) plus QueryDepth=2 worth of
+// descendants, so 16 keeps the response well under rippled's
+// 256-node-per-reply ceiling while still amortizing several missing
+// nodes per round trip.
+const missingNodeBatch = 16
+
+// NeedsMissingNodeIDs returns the wire-encoded NodeIDs of missing
+// SHAMap inner nodes that the peer should ship back, ordered by depth
+// so root-adjacent subtrees fill before deeper ones.
+//
+// Earlier this function unconditionally requested the SHAMap root with
+// QueryDepth=2 and ignored the actual missing-node enumeration. That
+// worked for tiny test ledgers (everything fits in root + 2 levels)
+// but on a real network it deadlocked catch-up: once depth 0..2 was
+// populated, any node at depth ≥3 stayed permanently missing because
+// we kept asking for the same root subtree the peer had already
+// served. The "1 missing node" log loop in issue #395 surfaced
+// exactly this — `IsComplete()` never flips to true and the inbound
+// acquisition wedges until the outer timeout.
+//
+// Returns nil if no nodes are missing or the map isn't ready to be
+// fed; otherwise returns up to missingNodeBatch path-based NodeIDs
+// from GetMissingNodes.
 func (l *Ledger) NeedsMissingNodeIDs() [][]byte {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -221,17 +244,15 @@ func (l *Ledger) NeedsMissingNodeIDs() [][]byte {
 		return nil
 	}
 
-	missing := l.stateMap.GetMissingNodes(256, nil)
+	missing := l.stateMap.GetMissingNodes(missingNodeBatch, nil)
 	if len(missing) == 0 {
 		return nil
 	}
 
-	// Request the root with queryDepth=2 which returns fat nodes
-	// (root + children + grandchildren). For small state trees this
-	// returns everything in one shot.
-	rootID := shamap.NewRootNodeID()
-	nodeIDs := [][]byte{rootID.Bytes()}
-
+	nodeIDs := make([][]byte, 0, len(missing))
+	for i := range missing {
+		nodeIDs = append(nodeIDs, missing[i].NodeID.Bytes())
+	}
 	return nodeIDs
 }
 

--- a/internal/ledger/inbound/inbound_test.go
+++ b/internal/ledger/inbound/inbound_test.go
@@ -1,0 +1,90 @@
+package inbound
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/shamap"
+)
+
+// TestNeedsMissingNodeIDs_RequestsActualMissingNodes is a regression
+// test for issue #395. After GotBase has installed the state-map root,
+// NeedsMissingNodeIDs must return path-based NodeIDs of the actual
+// missing inner nodes — not just the root NodeID. The previous
+// implementation always returned [rootID], which left any subtree
+// rooted at depth ≥3 permanently unrequestable (peer responses to a
+// root request top out at QueryDepth=2), wedging legacy catch-up with
+// the "1 missing node" symptom in the bug report.
+func TestNeedsMissingNodeIDs_RequestsActualMissingNodes(t *testing.T) {
+	source, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatalf("new source map: %v", err)
+	}
+	for branch := byte(0); branch < 8; branch++ {
+		for i := byte(0); i < 4; i++ {
+			var key [32]byte
+			key[0] = (branch << 4) | i
+			if err := source.Put(key, make([]byte, 12)); err != nil {
+				t.Fatalf("put: %v", err)
+			}
+		}
+	}
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("serialize root: %v", err)
+	}
+
+	// Build a header that points at the source map's root so GotBase
+	// will install it as the AccountHash anchor.
+	hdr := header.LedgerHeader{
+		LedgerIndex: 100,
+		AccountHash: rootHash,
+	}
+	hdrBytes, err := header.AddRaw(hdr, false)
+	if err != nil {
+		t.Fatalf("addraw header: %v", err)
+	}
+
+	var ledgerHash [32]byte
+	ledgerHash[0] = 0xAA
+
+	il := New(ledgerHash, 100, 7, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err := il.GotBase([]message.LedgerNode{
+		{NodeData: hdrBytes},
+		{NodeData: rootData},
+	}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+
+	ids := il.NeedsMissingNodeIDs()
+	if len(ids) == 0 {
+		t.Fatal("expected missing node IDs after GotBase, got none")
+	}
+
+	// Pre-fix this returned a single rootID; the fix must surface real
+	// non-root subtree NodeIDs so we can pull deep nodes from peers.
+	root := shamap.NewRootNodeID().Bytes()
+	if len(ids) == 1 && bytes.Equal(ids[0], root) {
+		t.Fatalf("regression: NeedsMissingNodeIDs returned only rootID; deep nodes can never be requested")
+	}
+	for i, raw := range ids {
+		nid, err := shamap.UnmarshalBinary(raw)
+		if err != nil {
+			t.Fatalf("nodeID %d: malformed: %v", i, err)
+		}
+		if nid.IsRoot() {
+			t.Errorf("nodeID %d: expected non-root NodeID, got root", i)
+		}
+		if err := nid.Validate(); err != nil {
+			t.Errorf("nodeID %d: validate: %v", i, err)
+		}
+	}
+}

--- a/internal/ledger/inbound/inbound_test.go
+++ b/internal/ledger/inbound/inbound_test.go
@@ -11,14 +11,9 @@ import (
 	"github.com/LeJamon/goXRPLd/shamap"
 )
 
-// TestNeedsMissingNodeIDs_RequestsActualMissingNodes is a regression
-// test for issue #395. After GotBase has installed the state-map root,
-// NeedsMissingNodeIDs must return path-based NodeIDs of the actual
-// missing inner nodes — not just the root NodeID. The previous
-// implementation always returned [rootID], which left any subtree
-// rooted at depth ≥3 permanently unrequestable (peer responses to a
-// root request top out at QueryDepth=2), wedging legacy catch-up with
-// the "1 missing node" symptom in the bug report.
+// Regression for issue #395: after GotBase, NeedsMissingNodeIDs must
+// surface path-based NodeIDs of the actual missing inner nodes, not
+// just the root NodeID.
 func TestNeedsMissingNodeIDs_RequestsActualMissingNodes(t *testing.T) {
 	source, err := shamap.New(shamap.TypeState)
 	if err != nil {
@@ -42,8 +37,6 @@ func TestNeedsMissingNodeIDs_RequestsActualMissingNodes(t *testing.T) {
 		t.Fatalf("serialize root: %v", err)
 	}
 
-	// Build a header that points at the source map's root so GotBase
-	// will install it as the AccountHash anchor.
 	hdr := header.LedgerHeader{
 		LedgerIndex: 100,
 		AccountHash: rootHash,
@@ -69,8 +62,6 @@ func TestNeedsMissingNodeIDs_RequestsActualMissingNodes(t *testing.T) {
 		t.Fatal("expected missing node IDs after GotBase, got none")
 	}
 
-	// Pre-fix this returned a single rootID; the fix must surface real
-	// non-root subtree NodeIDs so we can pull deep nodes from peers.
 	root := shamap.NewRootNodeID().Bytes()
 	if len(ids) == 1 && bytes.Equal(ids[0], root) {
 		t.Fatalf("regression: NeedsMissingNodeIDs returned only rootID; deep nodes can never be requested")

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1503,19 +1503,9 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 
 // pendingValidationMaxLen caps the pending-validation stash so a node
 // that never reaches quorum (misconfigured UNL, network partition) can't
-// leak memory.
-//
-// Sized for a node performing extended catch-up: at 3s ledger close
-// times 256 entries ≈ 13 minutes of buffered (ledger, validation)
-// gossip — comfortably larger than any realistic acquisition or chain-
-// switch window. The previous 16-entry cap (~48s) was too small under
-// steady network production: while a node closed and tried to acquire
-// peer ledgers, validations for hashes the node hadn't yet adopted
-// arrived faster than the stash could drain, evicting the very
-// notifications needed to certify the catch-up target. Issue #395
-// surfaced this as `pendingValidation LRU drop — event lost for this
-// ledger hash cap=16` repeating until the node never crosses
-// validated quorum on any acquired ledger.
+// leak memory. At 3s ledger close, 256 entries ≈ 13 minutes — large
+// enough to cover extended catch-up without evicting in-flight quorum
+// notifications (issue #395).
 const pendingValidationMaxLen = 256
 
 // stashPendingValidationLocked stores an accepted event keyed by hash

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1503,9 +1503,20 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 
 // pendingValidationMaxLen caps the pending-validation stash so a node
 // that never reaches quorum (misconfigured UNL, network partition) can't
-// leak memory. 16 ledgers ≈ 48s at 3s rounds — larger than any realistic
-// quorum-wait window but small enough to be bounded.
-const pendingValidationMaxLen = 16
+// leak memory.
+//
+// Sized for a node performing extended catch-up: at 3s ledger close
+// times 256 entries ≈ 13 minutes of buffered (ledger, validation)
+// gossip — comfortably larger than any realistic acquisition or chain-
+// switch window. The previous 16-entry cap (~48s) was too small under
+// steady network production: while a node closed and tried to acquire
+// peer ledgers, validations for hashes the node hadn't yet adopted
+// arrived faster than the stash could drain, evicting the very
+// notifications needed to certify the catch-up target. Issue #395
+// surfaced this as `pendingValidation LRU drop — event lost for this
+// ledger hash cap=16` repeating until the node never crosses
+// validated quorum on any acquired ledger.
+const pendingValidationMaxLen = 256
 
 // stashPendingValidationLocked stores an accepted event keyed by hash
 // for later eventCallback dispatch once the ledger is fully validated.

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -84,6 +84,12 @@ type MissingNode struct {
 	ParentHash [32]byte
 	// Branch is the branch index in the parent node (0-15 for inner nodes)
 	Branch int
+	// NodeID is the path-based identifier of the missing node, used to
+	// request the node from a peer via TMGetLedger. The peer locates a
+	// node by its tree path (depth + key prefix), not by its hash, so
+	// requesting by Hash alone is insufficient — without NodeID, the
+	// caller can only ever ask for the root.
+	NodeID NodeID
 }
 
 // String returns a string representation of the MissingNode.
@@ -131,6 +137,7 @@ func (sm *SHAMap) GetMissingNodes(maxNodes int, filter SyncFilter) []MissingNode
 	type workItem struct {
 		node       Node
 		nodeHash   [32]byte
+		nodeID     NodeID
 		parentHash [32]byte
 		depth      int
 		branch     int
@@ -144,6 +151,7 @@ func (sm *SHAMap) GetMissingNodes(maxNodes int, filter SyncFilter) []MissingNode
 		queue = append(queue, workItem{
 			node:     sm.root,
 			nodeHash: rootHash,
+			nodeID:   NewRootNodeID(),
 			depth:    0,
 			branch:   -1,
 		})
@@ -184,6 +192,14 @@ func (sm *SHAMap) GetMissingNodes(maxNodes int, filter SyncFilter) []MissingNode
 				continue
 			}
 
+			// Compute the child's path-based NodeID so a downstream
+			// caller can request this exact subtree from a peer (the
+			// peer locates a node by its NodeID, not by its hash).
+			childNodeID, err := item.nodeID.ChildNodeID(uint8(branch))
+			if err != nil {
+				continue
+			}
+
 			// Check if child is missing (hash present but no child node)
 			child, err := inner.Child(branch)
 			if err != nil {
@@ -198,6 +214,7 @@ func (sm *SHAMap) GetMissingNodes(maxNodes int, filter SyncFilter) []MissingNode
 						Depth:      item.depth + 1,
 						ParentHash: item.nodeHash,
 						Branch:     branch,
+						NodeID:     childNodeID,
 					})
 
 					if maxNodes > 0 && len(missing) >= maxNodes {
@@ -209,6 +226,7 @@ func (sm *SHAMap) GetMissingNodes(maxNodes int, filter SyncFilter) []MissingNode
 				queue = append(queue, workItem{
 					node:       child,
 					nodeHash:   childHash,
+					nodeID:     childNodeID,
 					parentHash: item.nodeHash,
 					depth:      item.depth + 1,
 					branch:     branch,
@@ -421,6 +439,7 @@ func (sm *SHAMap) getMissingNodesUnsafe(maxNodes int, filter SyncFilter) []Missi
 	type workItem struct {
 		node       Node
 		nodeHash   [32]byte
+		nodeID     NodeID
 		parentHash [32]byte
 		depth      int
 		branch     int
@@ -433,6 +452,7 @@ func (sm *SHAMap) getMissingNodesUnsafe(maxNodes int, filter SyncFilter) []Missi
 		queue = append(queue, workItem{
 			node:     sm.root,
 			nodeHash: rootHash,
+			nodeID:   NewRootNodeID(),
 			depth:    0,
 			branch:   -1,
 		})
@@ -469,6 +489,11 @@ func (sm *SHAMap) getMissingNodesUnsafe(maxNodes int, filter SyncFilter) []Missi
 				continue
 			}
 
+			childNodeID, err := item.nodeID.ChildNodeID(uint8(branch))
+			if err != nil {
+				continue
+			}
+
 			child, err := inner.Child(branch)
 			if err != nil {
 				continue
@@ -481,6 +506,7 @@ func (sm *SHAMap) getMissingNodesUnsafe(maxNodes int, filter SyncFilter) []Missi
 						Depth:      item.depth + 1,
 						ParentHash: item.nodeHash,
 						Branch:     branch,
+						NodeID:     childNodeID,
 					})
 
 					if maxNodes > 0 && len(missing) >= maxNodes {
@@ -491,6 +517,7 @@ func (sm *SHAMap) getMissingNodesUnsafe(maxNodes int, filter SyncFilter) []Missi
 				queue = append(queue, workItem{
 					node:       child,
 					nodeHash:   childHash,
+					nodeID:     childNodeID,
 					parentHash: item.nodeHash,
 					depth:      item.depth + 1,
 					branch:     branch,

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -84,11 +84,9 @@ type MissingNode struct {
 	ParentHash [32]byte
 	// Branch is the branch index in the parent node (0-15 for inner nodes)
 	Branch int
-	// NodeID is the path-based identifier of the missing node, used to
-	// request the node from a peer via TMGetLedger. The peer locates a
-	// node by its tree path (depth + key prefix), not by its hash, so
-	// requesting by Hash alone is insufficient — without NodeID, the
-	// caller can only ever ask for the root.
+	// NodeID is the path-based identifier of the missing node. Required
+	// for TMGetLedger requests because peers locate nodes by tree path,
+	// not by hash.
 	NodeID NodeID
 }
 
@@ -192,9 +190,6 @@ func (sm *SHAMap) GetMissingNodes(maxNodes int, filter SyncFilter) []MissingNode
 				continue
 			}
 
-			// Compute the child's path-based NodeID so a downstream
-			// caller can request this exact subtree from a peer (the
-			// peer locates a node by its NodeID, not by its hash).
 			childNodeID, err := item.nodeID.ChildNodeID(uint8(branch))
 			if err != nil {
 				continue

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -229,18 +229,10 @@ func TestAddRootNodeErrors(t *testing.T) {
 	}
 }
 
-// TestGetMissingNodes_PathNodeIDs is a regression test for issue #395.
-// GetMissingNodes must populate MissingNode.NodeID with the path-based
-// identifier of each missing inner node so the caller can request that
-// exact subtree from a peer. Earlier the inbound-ledger acquisition
-// only ever requested the root NodeID with QueryDepth=2, which caps
-// observable depth at 2; any missing node deeper than that could never
-// be filled and catch-up wedged with "1 missing node" forever.
+// Regression for issue #395: GetMissingNodes must populate
+// MissingNode.NodeID with each missing node's path-based identifier so
+// the caller can request that exact subtree from a peer.
 func TestGetMissingNodes_PathNodeIDs(t *testing.T) {
-	// Populate a source map with keys whose top nibble fans out across
-	// several branches at the root, guaranteeing the root has multiple
-	// inner-node children that get reported as missing once we sync
-	// only the root into a destination map.
 	source, err := New(TypeState)
 	if err != nil {
 		t.Fatalf("New source: %v", err)
@@ -264,9 +256,6 @@ func TestGetMissingNodes_PathNodeIDs(t *testing.T) {
 		t.Fatalf("SerializeRoot: %v", err)
 	}
 
-	// Sync only the root into the destination — every non-empty branch
-	// at depth 1 should now be reported as missing with a non-root
-	// NodeID we can ship to a peer.
 	dest, err := New(TypeState)
 	if err != nil {
 		t.Fatalf("New dest: %v", err)

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -229,6 +229,77 @@ func TestAddRootNodeErrors(t *testing.T) {
 	}
 }
 
+// TestGetMissingNodes_PathNodeIDs is a regression test for issue #395.
+// GetMissingNodes must populate MissingNode.NodeID with the path-based
+// identifier of each missing inner node so the caller can request that
+// exact subtree from a peer. Earlier the inbound-ledger acquisition
+// only ever requested the root NodeID with QueryDepth=2, which caps
+// observable depth at 2; any missing node deeper than that could never
+// be filled and catch-up wedged with "1 missing node" forever.
+func TestGetMissingNodes_PathNodeIDs(t *testing.T) {
+	// Populate a source map with keys whose top nibble fans out across
+	// several branches at the root, guaranteeing the root has multiple
+	// inner-node children that get reported as missing once we sync
+	// only the root into a destination map.
+	source, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("New source: %v", err)
+	}
+	for branch := byte(0); branch < 8; branch++ {
+		for i := byte(0); i < 4; i++ {
+			var key [32]byte
+			key[0] = (branch << 4) | i
+			if err := source.Put(key, make([]byte, 12)); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+		}
+	}
+
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("SerializeRoot: %v", err)
+	}
+
+	// Sync only the root into the destination — every non-empty branch
+	// at depth 1 should now be reported as missing with a non-root
+	// NodeID we can ship to a peer.
+	dest, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("New dest: %v", err)
+	}
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		t.Fatalf("AddRootNode: %v", err)
+	}
+
+	missing := dest.GetMissingNodes(64, nil)
+	if len(missing) == 0 {
+		t.Fatal("expected missing nodes after syncing only root, got none")
+	}
+
+	seen := make(map[[33]byte]struct{}, len(missing))
+	for _, m := range missing {
+		if m.NodeID.IsRoot() {
+			t.Errorf("missing node at depth %d should not have root NodeID", m.Depth)
+		}
+		if int(m.NodeID.Depth()) != m.Depth {
+			t.Errorf("NodeID depth %d != MissingNode.Depth %d", m.NodeID.Depth(), m.Depth)
+		}
+		var k [33]byte
+		copy(k[:], m.NodeID.Bytes())
+		if _, dup := seen[k]; dup {
+			t.Errorf("duplicate NodeID for missing node at depth %d", m.Depth)
+		}
+		seen[k] = struct{}{}
+		if err := m.NodeID.Validate(); err != nil {
+			t.Errorf("missing NodeID is malformed: %v", err)
+		}
+	}
+}
+
 func TestAddKnownNodeErrors(t *testing.T) {
 	sMap, err := New(TypeState)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes the catch-up loop in #395 where `validated_seq` stays frozen while `own_seq` creeps and the node logs the recurring trio:
- `replay delta verification failed; falling back to legacy ... parent hash mismatch`
- `inbound ledger: GotStateNodes failed ... still have 1 missing nodes`
- `pendingValidation LRU drop — event lost for this ledger hash cap=16`

**Root cause.** `inbound.NeedsMissingNodeIDs` always asked the peer for the SHAMap root with `QueryDepth=2` and ignored `GetMissingNodes`. Once the top two levels were filled, any node at depth ≥3 was unrequestable forever (the peer happily re-served the same fat-root response), and `IsComplete()` never flipped. With legacy wedged, replay-delta couldn't recover either (it anchors on our local-but-forked parent), and pending validations evicted off the 16-slot LRU before any acquired ledger could cross quorum.

**Fix.**
- `shamap.MissingNode` now carries a path-based `NodeID`. Both BFS variants in `shamap/sync.go` track each node's path so a caller can request the exact subtree from a peer.
- `inbound.NeedsMissingNodeIDs` ships up to 16 real missing `NodeID`s per `TMGetLedger` instead of just the rootID.
- `pendingValidationMaxLen` bumped from 16 to 256 so a node performing legitimate extended catch-up no longer evicts in-flight quorum notifications.

The replay-delta parent-hash mismatch (hypothesis 1 in the issue) self-resolves once legacy works: the very next acquired peer ledger becomes the local parent, and replay-delta succeeds on subsequent rounds.

## Test plan

- [x] `go build ./...`
- [x] `go test ./shamap/... ./internal/ledger/... ./internal/consensus/...` — all green
- [x] New regression tests:
  - `shamap.TestGetMissingNodes_PathNodeIDs` — asserts `MissingNode.NodeID` is non-root, well-formed, unique
  - `inbound.TestNeedsMissingNodeIDs_RequestsActualMissingNodes` — drives `GotBase` with a real header + state root and asserts the request is no longer `[rootID]`
- [x] Full `go test ./...` — only failures are `internal/testing/batch/TestObjectsOpenLedger` and `internal/testing/conformance/.../Vault/...`, both fail identically on clean `origin/main` (pre-existing)
- [ ] Reproduce against the `xrpl-confluence` chaos enclave (3× rippled + 2× goxrpl) and confirm `validated_seq` advances in lockstep with rippled