### PR TITLE
catchup: backward-chain held-adoption parents (closes #397)

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -1056,9 +1056,7 @@ func (r *Router) handleReplayDeltaResponse(msg *peermanagement.InboundMessage) {
 // for the awaited parent (issue #397). Without this, a tip-only
 // acquisition policy (checkBehind) leaves stashed candidates waiting
 // for parents that are never requested, and they age out at
-// heldAdoptionTTL. peerID is the source of the replay delta — used as
-// the preferred peer for the parent acquisition; existing dedup in
-// startLedgerAcquisition makes redundant calls cheap.
+// heldAdoptionTTL.
 func (r *Router) adoptVerifiedLedger(l *ledger.Ledger, peerID uint64) error {
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
@@ -1115,10 +1113,7 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger, peerID uint64) error {
 // regime we already have something at this height locally, and either
 // (a) the SubmitHeldAdoption fast-path would have adopted, or (b) the
 // divergent-fork drop fired. Either way another acquisition won't
-// help. Above our closed seq, we don't have the parent, so request it.
-//
-// Dedup happens inside startLedgerAcquisition.isAcquiring; this
-// function does not need to track in-flight state.
+// help.
 func (r *Router) armParentAcquisition(svc *service.Service, parentSeq uint32, parentHash [32]byte, preferredPeerID uint64) {
 	if parentSeq == 0 {
 		return

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/inbound"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service"
 	"github.com/LeJamon/goXRPLd/internal/manifest"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
@@ -1029,8 +1030,9 @@ func (r *Router) handleReplayDeltaResponse(msg *peermanagement.InboundMessage) {
 		r.startLedgerAcquisitionLegacy(seq, hash, peerID)
 		return
 	}
+	peerID := rd.PeerID()
 	r.replayer.Complete(rd.Hash())
-	if err := r.adoptVerifiedLedger(derived); err != nil {
+	if err := r.adoptVerifiedLedger(derived, peerID); err != nil {
 		r.logger.Warn("failed to adopt replay-delta ledger", "error", err)
 	}
 }
@@ -1048,10 +1050,16 @@ func (r *Router) handleReplayDeltaResponse(msg *peermanagement.InboundMessage) {
 // ledger's ParentHash, SubmitHeldAdoption fast-paths into the immediate
 // adopt (same call-shape as before). If the parent hasn't landed yet
 // — i.e. the replay-delta arrived out of order — the ledger is stashed
-// in the held-adoptions map keyed by its awaited parent seq, and
-// cascade-promoted automatically from inside the parent's eventual
-// adopt. The router no longer needs to observe ordering.
-func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
+// in the held-adoptions map keyed by its awaited parent seq.
+//
+// When SubmitHeldAdoption stashes, we arm a backward-chain acquisition
+// for the awaited parent (issue #397). Without this, a tip-only
+// acquisition policy (checkBehind) leaves stashed candidates waiting
+// for parents that are never requested, and they age out at
+// heldAdoptionTTL. peerID is the source of the replay delta — used as
+// the preferred peer for the parent acquisition; existing dedup in
+// startLedgerAcquisition makes redundant calls cheap.
+func (r *Router) adoptVerifiedLedger(l *ledger.Ledger, peerID uint64) error {
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
 		return errors.New("no ledger service")
@@ -1073,7 +1081,8 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
 	// handler stack that does not currently carry a context. Threading
 	// one through the message-dispatch chain is tracked separately from
 	// this issue (#185).
-	if err := svc.SubmitHeldAdoption(context.TODO(), &hdr, stateMap, txMap); err != nil {
+	res, err := svc.SubmitHeldAdoption(context.TODO(), &hdr, stateMap, txMap)
+	if err != nil {
 		return fmt.Errorf("adopt with state: %w", err)
 	}
 	if r.adaptor.GetOperatingMode() < consensus.OpModeTracking {
@@ -1092,7 +1101,37 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
 			r.logger.Debug("engine rejected adopted ledger", "error", err, "seq", hdr.LedgerIndex)
 		}
 	}
+	if res.Stashed {
+		r.armParentAcquisition(svc, res.ParentSeq, res.ParentHash, peerID)
+	}
 	return nil
+}
+
+// armParentAcquisition fires a backward-chain acquisition for the
+// parent of a stashed held-adoption candidate (issue #397). Caller
+// invokes after SubmitHeldAdoption returns Stashed=true.
+//
+// Skips if the parent seq is at or below our closed ledger — in that
+// regime we already have something at this height locally, and either
+// (a) the SubmitHeldAdoption fast-path would have adopted, or (b) the
+// divergent-fork drop fired. Either way another acquisition won't
+// help. Above our closed seq, we don't have the parent, so request it.
+//
+// Dedup happens inside startLedgerAcquisition.isAcquiring; this
+// function does not need to track in-flight state.
+func (r *Router) armParentAcquisition(svc *service.Service, parentSeq uint32, parentHash [32]byte, preferredPeerID uint64) {
+	if parentSeq == 0 {
+		return
+	}
+	if parentSeq <= svc.GetClosedLedgerIndex() {
+		return
+	}
+	r.logger.Info("arming backward-chain acquisition for stashed held-adoption parent",
+		"parent_seq", parentSeq,
+		"parent_hash", fmt.Sprintf("%x", parentHash[:8]),
+		"preferred_peer", preferredPeerID,
+	)
+	r.startLedgerAcquisition(parentSeq, parentHash, preferredPeerID)
 }
 
 // checkBehind decides what to do based on how far behind a peer
@@ -1344,6 +1383,7 @@ func (r *Router) completeInboundLedger() {
 		r.logger.Warn("inbound ledger: failed to get result", "error", err)
 		return
 	}
+	peerID := il.PeerID()
 
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
@@ -1364,7 +1404,8 @@ func (r *Router) completeInboundLedger() {
 	// interleaving — the held-queue is the correct seam regardless.
 	// context.TODO: same as adoptVerifiedLedger — reached from a peer-
 	// message handler stack with no plumbed context. See note there.
-	if err := svc.SubmitHeldAdoption(context.TODO(), h, stateMap, nil); err != nil {
+	res, err := svc.SubmitHeldAdoption(context.TODO(), h, stateMap, nil)
+	if err != nil {
 		r.logger.Warn("inbound ledger: failed to adopt with state", "error", err)
 		return
 	}
@@ -1386,5 +1427,8 @@ func (r *Router) completeInboundLedger() {
 		if err := r.engine.OnLedger(consensus.LedgerID(h.Hash), nil); err != nil {
 			r.logger.Debug("engine rejected adopted ledger", "error", err, "seq", h.LedgerIndex)
 		}
+	}
+	if res.Stashed {
+		r.armParentAcquisition(svc, res.ParentSeq, res.ParentHash, peerID)
 	}
 }

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -697,13 +697,9 @@ func TestRouter_ReplayDelta_CascadesOutOfOrderArrival(t *testing.T) {
 	assert.Equal(t, parentSeq, svc.GetClosedLedger().Sequence(),
 		"closedLedger must not advance when the replay-delta is stashed")
 
-	// --- In-order arrival: N+1 lands and cascades N+2 ---
-	//
-	// The router auto-armed the N+1 acquisition above. Deliver N+1's
-	// response into the existing slot. SubmitHeldAdoption fast-paths
-	// into the adopt (parentN IS in svc history), then runs
-	// cascadeHeldAdoptionsLocked and finds the N+2 entry keyed by
-	// seqN1. N+2's ParentHash == hashN1, so the cascade promotes it.
+	// In-order arrival: N+1 lands into the auto-armed slot, fast-paths
+	// the adopt (parentN IS in svc history), and cascadeHeldAdoptions
+	// promotes the stashed N+2 entry keyed by seqN1.
 	payloadN1, err := message.Encode(respN1)
 	require.NoError(t, err)
 	r.handleMessage(&peermanagement.InboundMessage{
@@ -745,27 +741,12 @@ func TestRouter_ReplayDelta_CascadesOutOfOrderArrival(t *testing.T) {
 		"operating mode must be at least Tracking after cascade (was %s)", a.GetOperatingMode())
 }
 
-// TestRouter_ReplayDelta_Issue397_AutoArmsParentOnStash is the issue
-// #397 regression. Reproduces the steady-state symptom: the node is
-// multiple ledgers behind the network, checkBehind acquires only the
-// peer's tip, and the tip's replay-delta arrives with a parent that is
-// not in svc history. Without backward-chaining, the candidate sits in
-// heldAdoptions until heldAdoptionTTL evicts it; the validation-tracker
-// notification for the tip stashes in pendingLedgerValidations but
-// never promotes because ledgerHistory[seq] is never populated; RPC
-// validated_ledger.seq stays at genesis indefinitely.
-//
-// The fix wires SubmitHeldAdoption to return Stashed=true on the
-// missing-parent path, and adoptVerifiedLedger / completeInboundLedger
-// auto-arm an acquisition for the awaited parent seq+hash. The chain
-// converges as each backward acquisition arrives and stashes one step
-// further back, until a parent that DOES match svc history lands and
-// the existing cascade promotes the chain forward (covered by
-// TestRouter_ReplayDelta_CascadesOutOfOrderArrival).
-//
-// This test pins the auto-arm signal: the observable evidence that the
-// router fires a backward-chain request when SubmitHeldAdoption stashes
-// instead of leaving the candidate to age out at heldAdoptionTTL.
+// Issue #397 regression: under tip-only acquisition (checkBehind), a
+// replay-delta whose parent is missing from svc history must trigger a
+// backward-chain acquisition for that parent — otherwise the candidate
+// ages out at heldAdoptionTTL and the chain stays stuck. This test pins
+// the auto-arm signal; cascade-forward is covered by
+// TestRouter_ReplayDelta_CascadesOutOfOrderArrival.
 func TestRouter_ReplayDelta_Issue397_AutoArmsParentOnStash(t *testing.T) {
 	r, _, rs, svc := makeRouter(t)
 
@@ -787,10 +768,9 @@ func TestRouter_ReplayDelta_Issue397_AutoArmsParentOnStash(t *testing.T) {
 	require.Equal(t, parentSeq+2, seqN2)
 	require.NotEqual(t, hashN1, hashN2)
 
-	// --- Tip-only acquisition: arm N+2 (the peer's tip). ledgerN1 is
-	// supplied as the in-memory parent so the replay-delta verifier
-	// passes; we want the test to exercise the post-Apply adopt path,
-	// not the verification path. ---
+	// Tip-only acquisition: arm N+2. ledgerN1 is supplied as the in-
+	// memory parent so verification passes — we want to exercise the
+	// post-Apply adopt path, not the verifier.
 	require.NoError(t, r.startReplayDeltaAcquisition(seqN2, hashN2, 7, ledgerN1))
 
 	// Reset the recording sender so the assertion below sees only the
@@ -800,9 +780,6 @@ func TestRouter_ReplayDelta_Issue397_AutoArmsParentOnStash(t *testing.T) {
 	rs.legacyBaseCalls = nil
 	rs.mu.Unlock()
 
-	// Deliver N+2's response. SubmitHeldAdoption must stash (N+1 is
-	// not in svc history) and the router must auto-arm a backward-
-	// chain acquisition for (seqN+1, hashN+1).
 	payloadN2, err := message.Encode(respN2)
 	require.NoError(t, err)
 	r.handleMessage(&peermanagement.InboundMessage{
@@ -819,19 +796,9 @@ func TestRouter_ReplayDelta_Issue397_AutoArmsParentOnStash(t *testing.T) {
 	assert.Equal(t, parentSeq, svc.GetClosedLedger().Sequence(),
 		"closedLedger must not advance while N+2 is stashed")
 
-	// Auto-arm assertion (the fix for issue #397).
-	//
-	// Before the fix: nothing fires after the stash; len(replay) +
-	// len(legacy) == 0, the held entry sits until heldAdoptionTTL=60s
-	// evicts it, and the chain stays stuck.
-	//
-	// After the fix: armParentAcquisition fires startLedgerAcquisition
-	// for (seqN+1, hashN+1). startLedgerAcquisition picks replay-delta
-	// when GetParentLedgerForReplay can supply a parent at seqN+0; in
-	// this scenario svc.GetLedgerBySequence(parentSeq) will return
-	// parentN, so the replay-delta path is exercised. Either path is
-	// acceptable for this contract — both terminate at the network
-	// layer with a request for the awaited parent's hash.
+	// Auto-arm assertion. Either path (replay-delta or legacy) is
+	// acceptable — both terminate at the network layer with a request
+	// for the awaited parent's hash.
 	totalAutoArmCalls := len(rs.replayCalls()) + len(rs.legacyCalls())
 	require.Equal(t, 1, totalAutoArmCalls,
 		"router must auto-arm exactly one backward-chain acquisition (issue #397)")
@@ -849,9 +816,8 @@ func TestRouter_ReplayDelta_Issue397_AutoArmsParentOnStash(t *testing.T) {
 }
 
 // autoArmTarget returns the hash and seq of the single auto-armed
-// acquisition recorded against rs. seq is 0 when the call took the
-// replay-delta path (which is hash-keyed on the wire). Caller asserts
-// totalAutoArmCalls == 1 before invoking.
+// acquisition. seq is 0 when the replay-delta path was taken (hash-
+// keyed on the wire). Caller asserts totalAutoArmCalls == 1 first.
 func autoArmTarget(rs *recordingSender) ([32]byte, uint32) {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -812,7 +812,6 @@ func TestRouter_ReplayDelta_Issue397_AutoArmsParentOnStash(t *testing.T) {
 		assert.Equal(t, seqN1, armedSeq,
 			"auto-arm must target the awaited parent seq")
 	}
-
 }
 
 // autoArmTarget returns the hash and seq of the single auto-armed

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -682,10 +682,15 @@ func TestRouter_ReplayDelta_CascadesOutOfOrderArrival(t *testing.T) {
 		Payload: payloadN2,
 	})
 
-	// N+2's acquisition has completed (verified + applied), but the
-	// adopt was stashed — not persisted to history.
-	require.Equal(t, 0, r.replayer.Count(),
-		"N+2 acquisition must be cleared once the response is verified and adopt routed")
+	// N+2's verified acquisition slot has been cleared, and the adopt
+	// was stashed (not persisted to history). Issue #397: when
+	// SubmitHeldAdoption stashes, the router auto-arms a backward-
+	// chain acquisition for the awaited parent (N+1). So the in-flight
+	// count is now 1 — the auto-armed N+1 slot — not 0.
+	require.Equal(t, 1, r.replayer.Count(),
+		"after stash the router must auto-arm a backward-chain acquisition for the missing parent")
+	require.True(t, r.replayer.Has(hashN1),
+		"the auto-armed acquisition must target the awaited parent hash N+1")
 	_, err = svc.GetLedgerByHash(hashN2)
 	require.Error(t, err,
 		"N+2 must NOT be in svc history yet — parent seq N+1 has not arrived, so SubmitHeldAdoption must stash")
@@ -694,12 +699,11 @@ func TestRouter_ReplayDelta_CascadesOutOfOrderArrival(t *testing.T) {
 
 	// --- In-order arrival: N+1 lands and cascades N+2 ---
 	//
-	// Arm and deliver N+1. Its ParentHash matches parentN.Hash()
-	// (parentN IS in svc history), so SubmitHeldAdoption fast-paths
-	// into the adopt, which then runs cascadeHeldAdoptionsLocked and
-	// finds the N+2 entry keyed by seqN1. N+2's ParentHash ==
-	// hashN1, so the cascade promotes it.
-	require.NoError(t, r.startReplayDeltaAcquisition(seqN1, hashN1, 9, parentN))
+	// The router auto-armed the N+1 acquisition above. Deliver N+1's
+	// response into the existing slot. SubmitHeldAdoption fast-paths
+	// into the adopt (parentN IS in svc history), then runs
+	// cascadeHeldAdoptionsLocked and finds the N+2 entry keyed by
+	// seqN1. N+2's ParentHash == hashN1, so the cascade promotes it.
 	payloadN1, err := message.Encode(respN1)
 	require.NoError(t, err)
 	r.handleMessage(&peermanagement.InboundMessage{
@@ -739,4 +743,123 @@ func TestRouter_ReplayDelta_CascadesOutOfOrderArrival(t *testing.T) {
 	// the final state must be >= Tracking regardless.
 	assert.True(t, a.GetOperatingMode() >= consensus.OpModeTracking,
 		"operating mode must be at least Tracking after cascade (was %s)", a.GetOperatingMode())
+}
+
+// TestRouter_ReplayDelta_Issue397_AutoArmsParentOnStash is the issue
+// #397 regression. Reproduces the steady-state symptom: the node is
+// multiple ledgers behind the network, checkBehind acquires only the
+// peer's tip, and the tip's replay-delta arrives with a parent that is
+// not in svc history. Without backward-chaining, the candidate sits in
+// heldAdoptions until heldAdoptionTTL evicts it; the validation-tracker
+// notification for the tip stashes in pendingLedgerValidations but
+// never promotes because ledgerHistory[seq] is never populated; RPC
+// validated_ledger.seq stays at genesis indefinitely.
+//
+// The fix wires SubmitHeldAdoption to return Stashed=true on the
+// missing-parent path, and adoptVerifiedLedger / completeInboundLedger
+// auto-arm an acquisition for the awaited parent seq+hash. The chain
+// converges as each backward acquisition arrives and stashes one step
+// further back, until a parent that DOES match svc history lands and
+// the existing cascade promotes the chain forward (covered by
+// TestRouter_ReplayDelta_CascadesOutOfOrderArrival).
+//
+// This test pins the auto-arm signal: the observable evidence that the
+// router fires a backward-chain request when SubmitHeldAdoption stashes
+// instead of leaving the candidate to age out at heldAdoptionTTL.
+func TestRouter_ReplayDelta_Issue397_AutoArmsParentOnStash(t *testing.T) {
+	r, _, rs, svc := makeRouter(t)
+
+	// Step svc past genesis so we have a real parent at seq 2 whose
+	// hash chains correctly into a Close()-derived successor at seq 3
+	// (genesis's skip-list is a special case).
+	_, err := svc.AcceptLedger(context.TODO())
+	require.NoError(t, err)
+
+	parentN := svc.GetClosedLedger()
+	require.NotNil(t, parentN)
+	parentSeq := parentN.Sequence()
+
+	// Build a 2-link chain in-memory: N+1 (the gap) and N+2 (the tip).
+	// Only parentN is in svc history; N+1 is NOT — that is the gap.
+	_, ledgerN1, hashN1, seqN1 := buildSuccessorAgainstParent(t, parentN)
+	respN2, _, hashN2, seqN2 := buildSuccessorAgainstParent(t, ledgerN1)
+	require.Equal(t, parentSeq+1, seqN1)
+	require.Equal(t, parentSeq+2, seqN2)
+	require.NotEqual(t, hashN1, hashN2)
+
+	// --- Tip-only acquisition: arm N+2 (the peer's tip). ledgerN1 is
+	// supplied as the in-memory parent so the replay-delta verifier
+	// passes; we want the test to exercise the post-Apply adopt path,
+	// not the verification path. ---
+	require.NoError(t, r.startReplayDeltaAcquisition(seqN2, hashN2, 7, ledgerN1))
+
+	// Reset the recording sender so the assertion below sees only the
+	// auto-arm, not the manual N+2 arm above.
+	rs.mu.Lock()
+	rs.replayDeltaCalls = nil
+	rs.legacyBaseCalls = nil
+	rs.mu.Unlock()
+
+	// Deliver N+2's response. SubmitHeldAdoption must stash (N+1 is
+	// not in svc history) and the router must auto-arm a backward-
+	// chain acquisition for (seqN+1, hashN+1).
+	payloadN2, err := message.Encode(respN2)
+	require.NoError(t, err)
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeReplayDeltaResponse),
+		Payload: payloadN2,
+	})
+
+	// Stash assertion: N+2 must not be in svc history (parent missing
+	// → SubmitHeldAdoption stashed) and closedLedger must not advance.
+	// These hold both before and after the fix.
+	_, err = svc.GetLedgerByHash(hashN2)
+	require.Error(t, err, "N+2 must be stashed, not adopted")
+	assert.Equal(t, parentSeq, svc.GetClosedLedger().Sequence(),
+		"closedLedger must not advance while N+2 is stashed")
+
+	// Auto-arm assertion (the fix for issue #397).
+	//
+	// Before the fix: nothing fires after the stash; len(replay) +
+	// len(legacy) == 0, the held entry sits until heldAdoptionTTL=60s
+	// evicts it, and the chain stays stuck.
+	//
+	// After the fix: armParentAcquisition fires startLedgerAcquisition
+	// for (seqN+1, hashN+1). startLedgerAcquisition picks replay-delta
+	// when GetParentLedgerForReplay can supply a parent at seqN+0; in
+	// this scenario svc.GetLedgerBySequence(parentSeq) will return
+	// parentN, so the replay-delta path is exercised. Either path is
+	// acceptable for this contract — both terminate at the network
+	// layer with a request for the awaited parent's hash.
+	totalAutoArmCalls := len(rs.replayCalls()) + len(rs.legacyCalls())
+	require.Equal(t, 1, totalAutoArmCalls,
+		"router must auto-arm exactly one backward-chain acquisition (issue #397)")
+
+	armedHash, armedSeq := autoArmTarget(rs)
+	assert.Equal(t, hashN1, armedHash,
+		"auto-arm must target the awaited parent hash (issue #397)")
+	if armedSeq != 0 {
+		// Only the legacy path carries seq on the wire — replay-delta
+		// is hash-keyed. When legacy was chosen, also pin the seq.
+		assert.Equal(t, seqN1, armedSeq,
+			"auto-arm must target the awaited parent seq")
+	}
+
+}
+
+// autoArmTarget returns the hash and seq of the single auto-armed
+// acquisition recorded against rs. seq is 0 when the call took the
+// replay-delta path (which is hash-keyed on the wire). Caller asserts
+// totalAutoArmCalls == 1 before invoking.
+func autoArmTarget(rs *recordingSender) ([32]byte, uint32) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if len(rs.replayDeltaCalls) == 1 {
+		return rs.replayDeltaCalls[0].hash, 0
+	}
+	if len(rs.legacyBaseCalls) == 1 {
+		return rs.legacyBaseCalls[0].hash, rs.legacyBaseCalls[0].seq
+	}
+	return [32]byte{}, 0
 }

--- a/internal/ledger/service/held_adoption_test.go
+++ b/internal/ledger/service/held_adoption_test.go
@@ -78,7 +78,8 @@ func TestAdoptLedgerWithState_CascadesHeldOrphan(t *testing.T) {
 
 	// Submit 102 as a held adoption. 101 is not yet in history so it
 	// must stash, not adopt immediately.
-	require.NoError(t, svc.SubmitHeldAdoption(context.TODO(), fx102.hdr, fx102.stateMap, fx102.txMap))
+	_, err = svc.SubmitHeldAdoption(context.TODO(), fx102.hdr, fx102.stateMap, fx102.txMap)
+	require.NoError(t, err)
 
 	svc.mu.RLock()
 	_, held := svc.heldAdoptions[baseSeq] // keyed by awaited-parent seq
@@ -140,7 +141,8 @@ func TestAdoptLedgerWithState_OrphanMismatchDropped(t *testing.T) {
 	// 102 says its parent is X (a different fork), not Y.
 	fx102 := buildHeldAdoptionInputs(t, baseSeq+1, hash102, hashX)
 
-	require.NoError(t, svc.SubmitHeldAdoption(context.TODO(), fx102.hdr, fx102.stateMap, fx102.txMap))
+	_, err = svc.SubmitHeldAdoption(context.TODO(), fx102.hdr, fx102.stateMap, fx102.txMap)
+	require.NoError(t, err)
 
 	// Adopt 101 with hash Y. 102's ParentHash is X ≠ Y → drop 102.
 	require.NoError(t, svc.AdoptLedgerWithState(context.TODO(), fx101.hdr, fx101.stateMap, fx101.txMap))
@@ -183,7 +185,10 @@ func TestSubmitHeldAdoption_ParentAlreadyPresent(t *testing.T) {
 	require.NoError(t, svc.AdoptLedgerWithState(context.TODO(), fx101.hdr, fx101.stateMap, fx101.txMap))
 
 	fx102 := buildHeldAdoptionInputs(t, baseSeq+1, hash102, hash101)
-	require.NoError(t, svc.SubmitHeldAdoption(context.TODO(), fx102.hdr, fx102.stateMap, fx102.txMap))
+	res, err := svc.SubmitHeldAdoption(context.TODO(), fx102.hdr, fx102.stateMap, fx102.txMap)
+	require.NoError(t, err)
+	require.True(t, res.Adopted, "fast path must report Adopted=true when parent is present")
+	require.False(t, res.Stashed, "fast path must not report Stashed=true")
 
 	// 102 must be installed immediately (parent already present).
 	got102, err := svc.GetLedgerByHash(hash102)
@@ -229,7 +234,8 @@ func TestSubmitHeldAdoption_ParentPresentButHashMismatch(t *testing.T) {
 	// mismatched chain; it must be refused as a no-op from the ledger-
 	// history perspective.
 	fx102 := buildHeldAdoptionInputs(t, baseSeq+1, hash102, hash101Wanted)
-	require.NoError(t, svc.SubmitHeldAdoption(context.TODO(), fx102.hdr, fx102.stateMap, fx102.txMap))
+	_, err = svc.SubmitHeldAdoption(context.TODO(), fx102.hdr, fx102.stateMap, fx102.txMap)
+	require.NoError(t, err)
 
 	// 102 must NOT be in history — neither adopted nor cascaded.
 	_, err = svc.GetLedgerByHash(hash102)
@@ -308,8 +314,10 @@ func TestAdoptLedgerWithState_MultiLevelCascade(t *testing.T) {
 	fx103 := buildHeldAdoptionInputs(t, baseSeq+2, hash103, hash102)
 
 	// Submit 103 before 102 — both stash.
-	require.NoError(t, svc.SubmitHeldAdoption(context.TODO(), fx103.hdr, fx103.stateMap, fx103.txMap))
-	require.NoError(t, svc.SubmitHeldAdoption(context.TODO(), fx102.hdr, fx102.stateMap, fx102.txMap))
+	_, err = svc.SubmitHeldAdoption(context.TODO(), fx103.hdr, fx103.stateMap, fx103.txMap)
+	require.NoError(t, err)
+	_, err = svc.SubmitHeldAdoption(context.TODO(), fx102.hdr, fx102.stateMap, fx102.txMap)
+	require.NoError(t, err)
 
 	svc.mu.RLock()
 	_, has102Parent := svc.heldAdoptions[baseSeq]   // 102 waits on 101
@@ -346,10 +354,10 @@ func TestSubmitHeldAdoption_RejectsNil(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, svc.Start())
 
-	assert.Error(t, svc.SubmitHeldAdoption(context.TODO(), nil, nil, nil),
-		"nil header must be rejected")
+	_, err = svc.SubmitHeldAdoption(context.TODO(), nil, nil, nil)
+	assert.Error(t, err, "nil header must be rejected")
 
 	hdr := &header.LedgerHeader{LedgerIndex: 42}
-	assert.Error(t, svc.SubmitHeldAdoption(context.TODO(), hdr, nil, nil),
-		"nil state map must be rejected")
+	_, err = svc.SubmitHeldAdoption(context.TODO(), hdr, nil, nil)
+	assert.Error(t, err, "nil state map must be rejected")
 }

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1673,6 +1673,34 @@ const heldAdoptionTTL = 60 * time.Second
 // magnitude above any legitimate cascade length.
 const heldAdoptionCascadeMax = 256
 
+// SubmitHeldAdoptionResult describes what SubmitHeldAdoption did with
+// the supplied candidate ledger. Callers that drive ledger acquisition
+// use Stashed to chain backward: when Stashed is true, the candidate is
+// waiting on a parent that is not yet in history, and the caller should
+// arm an acquisition for (ParentSeq, ParentHash) so the chain converges
+// rather than aging out at heldAdoptionTTL. See issue #397.
+type SubmitHeldAdoptionResult struct {
+	// Adopted is true when the candidate was fast-pathed into the active
+	// adoption (its awaited parent was already in history at the expected
+	// hash). When true, callers do not need to drive backward acquisition.
+	Adopted bool
+
+	// Stashed is true when the candidate was placed in the held-adoption
+	// stash awaiting cascade-promotion at the parent seq. When true,
+	// callers SHOULD arm a backward acquisition for (ParentSeq,
+	// ParentHash) — without that, the stash entry will age out at
+	// heldAdoptionTTL and the chain stays stuck.
+	Stashed bool
+
+	// ParentSeq is the awaited parent's sequence (= h.LedgerIndex - 1).
+	// Set whenever h.LedgerIndex > 1, regardless of outcome.
+	ParentSeq uint32
+
+	// ParentHash is the awaited parent's hash (= h.ParentHash). Set
+	// whenever h.LedgerIndex > 1, regardless of outcome.
+	ParentHash [32]byte
+}
+
 // SubmitHeldAdoption routes a fetched replay-delta either to immediate
 // adoption (when the awaited parent seq is already in history and its
 // hash matches the supplied ParentHash) or to the held-orphan stash
@@ -1684,14 +1712,27 @@ const heldAdoptionCascadeMax = 256
 // nil txMap is allowed (legacy catchup path — AdoptLedgerWithState
 // falls back to the genesis-shaped empty tx map).
 //
+// Returns a SubmitHeldAdoptionResult describing whether the candidate
+// was adopted immediately, stashed, or dropped (Adopted == Stashed ==
+// false), and — when applicable — the awaited parent's seq+hash so the
+// caller can drive backward acquisition. See issue #397: without
+// backward-chaining, a tip-only acquisition policy lets every candidate
+// age out at heldAdoptionTTL.
+//
 // Mirrors rippled's tryAdvance cascade shape, flattened to single-hop
 // (see comment on heldAdoptions for the scope trade-off).
-func (s *Service) SubmitHeldAdoption(ctx context.Context, h *header.LedgerHeader, stateMap *shamap.SHAMap, txMap *shamap.SHAMap) error {
+func (s *Service) SubmitHeldAdoption(ctx context.Context, h *header.LedgerHeader, stateMap *shamap.SHAMap, txMap *shamap.SHAMap) (SubmitHeldAdoptionResult, error) {
 	if h == nil {
-		return errors.New("SubmitHeldAdoption: nil header")
+		return SubmitHeldAdoptionResult{}, errors.New("SubmitHeldAdoption: nil header")
 	}
 	if stateMap == nil {
-		return errors.New("SubmitHeldAdoption: nil state map")
+		return SubmitHeldAdoptionResult{}, errors.New("SubmitHeldAdoption: nil state map")
+	}
+
+	res := SubmitHeldAdoptionResult{}
+	if h.LedgerIndex > 1 {
+		res.ParentSeq = h.LedgerIndex - 1
+		res.ParentHash = h.ParentHash
 	}
 
 	s.mu.Lock()
@@ -1711,7 +1752,11 @@ func (s *Service) SubmitHeldAdoption(ctx context.Context, h *header.LedgerHeader
 		if parent, ok := s.ledgerHistory[parentSeq]; ok {
 			parentHash := parent.Hash()
 			if parentHash == h.ParentHash {
-				return s.adoptLedgerWithStateLocked(ctx, h, stateMap, txMap, 0)
+				if err := s.adoptLedgerWithStateLocked(ctx, h, stateMap, txMap, 0); err != nil {
+					return res, err
+				}
+				res.Adopted = true
+				return res, nil
 			}
 			// Parent seq present but on a different fork. Stashing would
 			// create a never-draining entry (the real fork's parent-seq
@@ -1722,7 +1767,7 @@ func (s *Service) SubmitHeldAdoption(ctx context.Context, h *header.LedgerHeader
 				"parent_have", fmt.Sprintf("%x", parentHash[:8]),
 				"parent_want", fmt.Sprintf("%x", h.ParentHash[:8]),
 			)
-			return nil
+			return res, nil
 		}
 	}
 
@@ -1733,7 +1778,8 @@ func (s *Service) SubmitHeldAdoption(ctx context.Context, h *header.LedgerHeader
 		txMap:    txMap,
 		at:       time.Now(),
 	}
-	return nil
+	res.Stashed = true
+	return res, nil
 }
 
 // cascadeHeldAdoptionsLocked promotes a held child whose awaited parent

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1673,31 +1673,22 @@ const heldAdoptionTTL = 60 * time.Second
 // magnitude above any legitimate cascade length.
 const heldAdoptionCascadeMax = 256
 
-// SubmitHeldAdoptionResult describes what SubmitHeldAdoption did with
-// the supplied candidate ledger. Callers that drive ledger acquisition
-// use Stashed to chain backward: when Stashed is true, the candidate is
-// waiting on a parent that is not yet in history, and the caller should
-// arm an acquisition for (ParentSeq, ParentHash) so the chain converges
-// rather than aging out at heldAdoptionTTL. See issue #397.
+// SubmitHeldAdoptionResult describes the disposition of a candidate
+// ledger passed to SubmitHeldAdoption. When Stashed is true the caller
+// should arm a backward acquisition for (ParentSeq, ParentHash) — without
+// that, the stash entry will age out at heldAdoptionTTL (issue #397).
 type SubmitHeldAdoptionResult struct {
-	// Adopted is true when the candidate was fast-pathed into the active
-	// adoption (its awaited parent was already in history at the expected
-	// hash). When true, callers do not need to drive backward acquisition.
+	// Adopted means the awaited parent was already in history at the
+	// expected hash and the candidate was fast-pathed into the adopt.
 	Adopted bool
 
-	// Stashed is true when the candidate was placed in the held-adoption
-	// stash awaiting cascade-promotion at the parent seq. When true,
-	// callers SHOULD arm a backward acquisition for (ParentSeq,
-	// ParentHash) — without that, the stash entry will age out at
-	// heldAdoptionTTL and the chain stays stuck.
+	// Stashed means the candidate is parked in the held-adoption stash
+	// pending cascade-promotion at the parent seq.
 	Stashed bool
 
-	// ParentSeq is the awaited parent's sequence (= h.LedgerIndex - 1).
-	// Set whenever h.LedgerIndex > 1, regardless of outcome.
-	ParentSeq uint32
-
-	// ParentHash is the awaited parent's hash (= h.ParentHash). Set
-	// whenever h.LedgerIndex > 1, regardless of outcome.
+	// ParentSeq, ParentHash describe the awaited parent. Set whenever
+	// h.LedgerIndex > 1, regardless of outcome.
+	ParentSeq  uint32
 	ParentHash [32]byte
 }
 
@@ -1711,13 +1702,6 @@ type SubmitHeldAdoptionResult struct {
 // Safe to call concurrently. Nil header or nil stateMap is rejected;
 // nil txMap is allowed (legacy catchup path — AdoptLedgerWithState
 // falls back to the genesis-shaped empty tx map).
-//
-// Returns a SubmitHeldAdoptionResult describing whether the candidate
-// was adopted immediately, stashed, or dropped (Adopted == Stashed ==
-// false), and — when applicable — the awaited parent's seq+hash so the
-// caller can drive backward acquisition. See issue #397: without
-// backward-chaining, a tip-only acquisition policy lets every candidate
-// age out at heldAdoptionTTL.
 //
 // Mirrors rippled's tryAdvance cascade shape, flattened to single-hop
 // (see comment on heldAdoptions for the scope trade-off).


### PR DESCRIPTION
## Summary

- Fixes the adoption gap from issue #397: when goxrpl is multiple ledgers behind, every replay-delta the router acquires gets stashed in `heldAdoptions` waiting for a parent that's never requested, and ages out at the 60s TTL. RPC `validated_ledger.seq` stays at genesis indefinitely while the consensus-adaptor keeps logging "Ledger fully validated" for the network's tip.
- `Service.SubmitHeldAdoption` now returns a `SubmitHeldAdoptionResult` distinguishing adopted / stashed / dropped outcomes, with the awaited parent's seq+hash on every result.
- `Router.adoptVerifiedLedger` and `Router.completeInboundLedger` call `armParentAcquisition` whenever the result reports `Stashed=true`, requesting the awaited parent. Each stash arms exactly one backward step; the chain converges naturally and the existing cascade-adopt mechanism promotes the chain forward when a matching parent lands.

## Why backward-chaining

Without it, `checkBehind`'s tip-only acquisition policy puts every candidate into `heldAdoptions` keyed by a parent_seq that's never acquired. The smoking-gun pattern from #397 — every "Ledger fully validated" followed within 1–2s by a `heldAdoption TTL eviction` at age=60s — is the natural consequence: validations keep arriving on schedule but `SetValidatedLedger` drops them into `pendingLedgerValidations` because `ledgerHistory[seq]` stays empty.

Backward-chaining reuses the verified ParentHash already in each acquired header, so we never have to guess intermediate hashes.

## Safety notes

- `armParentAcquisition` skips when `parentSeq <= GetClosedLedgerIndex` — at or below our closed tip the candidate is either already in history (fast path adopts) or on a divergent fork (already dropped).
- Existing dedup in `startLedgerAcquisition.isAcquiring` covers double-fires from concurrent paths.
- `SubmitHeldAdoption`'s signature change ripples through 10 call sites (2 in router, 8 in service tests) — all updated; no behavior change for tests that already verified Adopted vs Stashed outcomes implicitly.

## Test plan

- [x] New regression `TestRouter_ReplayDelta_Issue397_AutoArmsParentOnStash` verified to FAIL on un-fixed code (no auto-arm) and PASS with the fix.
- [x] Existing `TestRouter_ReplayDelta_CascadesOutOfOrderArrival` updated to reflect that the router now auto-arms the awaited parent on stash; cascade still verified end-to-end.
- [x] All 8 existing `held_adoption_test.go` callers updated for the new return signature.
- [x] `go test ./internal/consensus/... ./internal/ledger/...` — all green.
- [ ] Confluence soak (per #397 reproduction harness): observe `validated_ledger.seq` advancing past genesis when the node falls many ledgers behind a healthy network.