### PR TITLE
catchup: arm acquisition when SetValidatedLedger stashes (re-opens #397)

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -119,7 +119,7 @@ const messageDedupMaxEntries = 4096
 // NewRouter creates a new Router.
 func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManager, inbox <-chan *peermanagement.InboundMessage) *Router {
 	logger := slog.Default().With("component", "consensus-router")
-	return &Router{
+	r := &Router{
 		engine:      engine,
 		adaptor:     adaptor,
 		modeManager: modeManager,
@@ -129,6 +129,18 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManag
 		replayer:    inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
 		messageSeen: newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
 	}
+	// Wire the validation-stash hook so the router arms an acquisition
+	// the moment SetValidatedLedger stashes for a seq beyond our closed
+	// tip. Without this, the validation-tracker quorum decision sits
+	// silently in pendingLedgerValidations and validated_ledger.seq
+	// stays frozen even as consensus reports "fully validated".
+	// (Follow-up to issue #397.)
+	if adaptor != nil {
+		if svc := adaptor.LedgerService(); svc != nil {
+			svc.SetOnPendingValidationStashed(r.armValidationStashAcquisition)
+		}
+	}
+	return r
 }
 
 // SetManifestCache installs the validator-manifest cache and the
@@ -1103,6 +1115,63 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger, peerID uint64) error {
 		r.armParentAcquisition(svc, res.ParentSeq, res.ParentHash, peerID)
 	}
 	return nil
+}
+
+// armValidationStashAcquisition fires an acquisition for a (seq, hash)
+// pair that SetValidatedLedger just stashed in pendingLedgerValidations
+// because ledgerHistory[seq] was empty. Wired as the
+// onPendingValidationStashed callback on the ledger service in NewRouter.
+//
+// Mirrors rippled's LedgerMaster::checkAccept(hash, seq), which calls
+// app_.getInboundLedgers().acquire(hash, seq, ...) on the same condition
+// (LedgerMaster.cpp:917-919). Without this kick, a deep gap (network
+// well ahead of our closed ledger) leaves the stashed validation idle:
+// the only acquisition driver is the tip-walking peer-status-change
+// handler, which acquires the peer's CURRENT tip — not the seq the
+// validation tracker just told us reached quorum.
+//
+// Picks any tracked peer; the underlying startLedgerAcquisition prefers
+// replay-delta when a parent is locally available and falls back to
+// legacy mtGET_LEDGER otherwise. If no peers are tracked yet (early
+// startup window), skip — peer-status-change handlers will drive the
+// acquisition once peers connect.
+func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
+	if seq == 0 {
+		return
+	}
+	svc := r.adaptor.LedgerService()
+	if svc == nil {
+		return
+	}
+	// At-or-below-closed guard: at this height we either already have the
+	// ledger in history (in which case SetValidatedLedger took the inline
+	// hash-check branch) or it was evicted; the divergent-fork status-
+	// change handler is the right path for that case. Mirrors PR #398's
+	// armParentAcquisition guard.
+	if seq <= svc.GetClosedLedgerIndex() {
+		return
+	}
+
+	r.peersMu.RLock()
+	var preferredPeerID uint64
+	for pid := range r.peerStates {
+		preferredPeerID = uint64(pid)
+		break
+	}
+	r.peersMu.RUnlock()
+	if preferredPeerID == 0 {
+		// No tracked peers yet — peer status changes will drive the
+		// acquisition once peers connect. Avoid sending to peerID=0
+		// (no recipient).
+		return
+	}
+
+	r.logger.Info("arming acquisition for stashed validation",
+		"seq", seq,
+		"hash", fmt.Sprintf("%x", hash[:8]),
+		"preferred_peer", preferredPeerID,
+	)
+	r.startLedgerAcquisition(seq, hash, preferredPeerID)
 }
 
 // armParentAcquisition fires a backward-chain acquisition for the

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -129,12 +129,9 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManag
 		replayer:    inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
 		messageSeen: newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
 	}
-	// Wire the validation-stash hook so the router arms an acquisition
-	// the moment SetValidatedLedger stashes for a seq beyond our closed
-	// tip. Without this, the validation-tracker quorum decision sits
+	// Without this hook, the validation-tracker quorum decision sits
 	// silently in pendingLedgerValidations and validated_ledger.seq
 	// stays frozen even as consensus reports "fully validated".
-	// (Follow-up to issue #397.)
 	if adaptor != nil {
 		if svc := adaptor.LedgerService(); svc != nil {
 			svc.SetOnPendingValidationStashed(r.armValidationStashAcquisition)
@@ -1117,11 +1114,9 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger, peerID uint64) error {
 	return nil
 }
 
-// armValidationStashAcquisition fires an acquisition for a (seq, hash)
-// pair that SetValidatedLedger just stashed in pendingLedgerValidations
-// because ledgerHistory had no entry at seq matching expectedHash.
-// Wired as the onPendingValidationStashed callback on the ledger
-// service in NewRouter.
+// armValidationStashAcquisition arms an inbound acquisition for a
+// (seq, hash) pair that SetValidatedLedger stashed because we don't
+// have that exact ledger.
 //
 // Mirrors rippled's LedgerMaster::checkAccept(hash, seq), which calls
 // app_.getInboundLedgers().acquire(hash, seq, ...) on the same condition
@@ -1134,9 +1129,8 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger, peerID uint64) error {
 // Prefers a peer whose advertised LCL is at or above seq so the request
 // goes to a peer that can actually serve the ledger; falls back to any
 // tracked peer if none qualify (the maintenance tick rotates on silent-
-// peer timeouts). If no peers are tracked yet (early startup window),
-// skip — peer-status-change handlers will drive the acquisition once
-// peers connect.
+// peer timeouts). If no peers are tracked yet, skip — peer-status-change
+// handlers will drive the acquisition once peers connect.
 func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
 	defer func() {
 		if rv := recover(); rv != nil {
@@ -1154,11 +1148,9 @@ func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
 	if svc == nil {
 		return
 	}
-	// At-or-below-closed guard: at this height we either already have the
-	// ledger in history (in which case SetValidatedLedger took the inline
-	// hash-check branch) or it was evicted; the divergent-fork status-
-	// change handler is the right path for that case. Mirrors PR #398's
-	// armParentAcquisition guard.
+	// At or below closed: we either already have it locally or it was
+	// evicted; the divergent-fork status-change handler drives any
+	// reacquisition at active height.
 	if seq <= svc.GetClosedLedgerIndex() {
 		return
 	}

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -1119,8 +1119,9 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger, peerID uint64) error {
 
 // armValidationStashAcquisition fires an acquisition for a (seq, hash)
 // pair that SetValidatedLedger just stashed in pendingLedgerValidations
-// because ledgerHistory[seq] was empty. Wired as the
-// onPendingValidationStashed callback on the ledger service in NewRouter.
+// because ledgerHistory had no entry at seq matching expectedHash.
+// Wired as the onPendingValidationStashed callback on the ledger
+// service in NewRouter.
 //
 // Mirrors rippled's LedgerMaster::checkAccept(hash, seq), which calls
 // app_.getInboundLedgers().acquire(hash, seq, ...) on the same condition
@@ -1130,12 +1131,22 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger, peerID uint64) error {
 // handler, which acquires the peer's CURRENT tip — not the seq the
 // validation tracker just told us reached quorum.
 //
-// Picks any tracked peer; the underlying startLedgerAcquisition prefers
-// replay-delta when a parent is locally available and falls back to
-// legacy mtGET_LEDGER otherwise. If no peers are tracked yet (early
-// startup window), skip — peer-status-change handlers will drive the
-// acquisition once peers connect.
+// Prefers a peer whose advertised LCL is at or above seq so the request
+// goes to a peer that can actually serve the ledger; falls back to any
+// tracked peer if none qualify (the maintenance tick rotates on silent-
+// peer timeouts). If no peers are tracked yet (early startup window),
+// skip — peer-status-change handlers will drive the acquisition once
+// peers connect.
 func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
+	defer func() {
+		if rv := recover(); rv != nil {
+			r.logger.Error("armValidationStashAcquisition panic recovered",
+				"seq", seq,
+				"hash", fmt.Sprintf("%x", hash[:8]),
+				"panic", rv,
+			)
+		}
+	}()
 	if seq == 0 {
 		return
 	}
@@ -1153,12 +1164,23 @@ func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
 	}
 
 	r.peersMu.RLock()
-	var preferredPeerID uint64
-	for pid := range r.peerStates {
-		preferredPeerID = uint64(pid)
-		break
+	var (
+		preferredPeerID uint64
+		fallbackPeerID  uint64
+	)
+	for pid, st := range r.peerStates {
+		if fallbackPeerID == 0 {
+			fallbackPeerID = uint64(pid)
+		}
+		if st != nil && st.LedgerSeq >= seq {
+			preferredPeerID = uint64(pid)
+			break
+		}
 	}
 	r.peersMu.RUnlock()
+	if preferredPeerID == 0 {
+		preferredPeerID = fallbackPeerID
+	}
 	if preferredPeerID == 0 {
 		// No tracked peers yet — peer status changes will drive the
 		// acquisition once peers connect. Avoid sending to peerID=0

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -829,23 +829,22 @@ func autoArmTarget(rs *recordingSender) ([32]byte, uint32) {
 	return [32]byte{}, 0
 }
 
-// TestRouter_Issue397_AutoArmsAcquisitionOnValidationStash pins the
-// follow-up to #397: when SetValidatedLedger fires for a seq beyond our
-// closed ledger and ledgerHistory[seq] is empty, the router must arm an
-// acquisition for (seq, hash). Without this, validation-tracker quorum
-// decisions for ledgers we have not yet adopted sit silently in
-// pendingLedgerValidations until the entry expires, and validated_
-// ledger.seq stays frozen even while consensus reports "fully validated".
+// TestRouter_Issue397_AutoArmsAcquisitionOnValidationStash: when
+// SetValidatedLedger fires for a seq beyond our closed ledger and
+// ledgerHistory has nothing for it, the router must arm an acquisition
+// for (seq, hash). Without this, validation-tracker quorum decisions
+// for ledgers we have not yet adopted sit silently in
+// pendingLedgerValidations until the entry expires, and
+// validated_ledger.seq stays frozen even while consensus reports
+// "fully validated".
 //
 // Mirrors rippled's LedgerMaster::checkAccept(hash, seq) (LedgerMaster.cpp:917-919),
 // which calls app_.getInboundLedgers().acquire(hash, seq, ...) on the
-// same condition. PR #398 added the analogous arming for the held-
-// adoption stash; this test pins arming for the validation stash.
+// same condition.
 func TestRouter_Issue397_AutoArmsAcquisitionOnValidationStash(t *testing.T) {
 	r, _, rs, svc := makeRouter(t)
 
-	// Register a tracked peer so the router has a target for the
-	// acquisition. The recordingSender defaults to peerSupportsReplay=true.
+	// recordingSender defaults to peerSupportsReplay=true.
 	const peerID peermanagement.PeerID = 7
 	r.peersMu.Lock()
 	r.peerStates[peerID] = &peerLedgerState{
@@ -853,8 +852,7 @@ func TestRouter_Issue397_AutoArmsAcquisitionOnValidationStash(t *testing.T) {
 	}
 	r.peersMu.Unlock()
 
-	// Validation tracker fires for a seq well beyond our closed tip.
-	// Hash is arbitrary — we only need to verify the router asks for it.
+	// Hash is arbitrary — we only verify the router asks for it.
 	var validatedHash [32]byte
 	for i := range validatedHash {
 		validatedHash[i] = byte(0xA0 + i%16)
@@ -863,8 +861,6 @@ func TestRouter_Issue397_AutoArmsAcquisitionOnValidationStash(t *testing.T) {
 
 	svc.SetValidatedLedger(validatedSeq, validatedHash)
 
-	// Stash sanity: SetValidatedLedger must have stashed the (seq, hash)
-	// pair (no ledgerHistory entry yet — pre-condition for arming).
 	require.Eventually(t, func() bool {
 		return len(rs.replayCalls())+len(rs.legacyCalls()) >= 1
 	}, time.Second, 10*time.Millisecond,
@@ -883,15 +879,13 @@ func TestRouter_Issue397_AutoArmsAcquisitionOnValidationStash(t *testing.T) {
 	}
 }
 
-// TestRouter_Issue397_NoAcquisitionWhenNoPeers pins the no-peer guard:
-// when SetValidatedLedger stashes but the router has no tracked peers,
-// no acquisition is armed (peer-status-change handlers will drive it
-// once peers reconnect). Without this, dispatching to peerID=0 races
-// against the wire layer's per-peer routing.
+// TestRouter_Issue397_NoAcquisitionWhenNoPeers: when SetValidatedLedger
+// stashes but the router has no tracked peers, no acquisition is armed.
+// Dispatching to peerID=0 would race against the wire layer's per-peer
+// routing; peer-status-change handlers drive acquisition once peers
+// reconnect.
 func TestRouter_Issue397_NoAcquisitionWhenNoPeers(t *testing.T) {
 	_, _, rs, svc := makeRouter(t)
-
-	// No peer registered in r.peerStates.
 
 	var validatedHash [32]byte
 	for i := range validatedHash {

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -828,3 +828,83 @@ func autoArmTarget(rs *recordingSender) ([32]byte, uint32) {
 	}
 	return [32]byte{}, 0
 }
+
+// TestRouter_Issue397_AutoArmsAcquisitionOnValidationStash pins the
+// follow-up to #397: when SetValidatedLedger fires for a seq beyond our
+// closed ledger and ledgerHistory[seq] is empty, the router must arm an
+// acquisition for (seq, hash). Without this, validation-tracker quorum
+// decisions for ledgers we have not yet adopted sit silently in
+// pendingLedgerValidations until the entry expires, and validated_
+// ledger.seq stays frozen even while consensus reports "fully validated".
+//
+// Mirrors rippled's LedgerMaster::checkAccept(hash, seq) (LedgerMaster.cpp:917-919),
+// which calls app_.getInboundLedgers().acquire(hash, seq, ...) on the
+// same condition. PR #398 added the analogous arming for the held-
+// adoption stash; this test pins arming for the validation stash.
+func TestRouter_Issue397_AutoArmsAcquisitionOnValidationStash(t *testing.T) {
+	r, _, rs, svc := makeRouter(t)
+
+	// Register a tracked peer so the router has a target for the
+	// acquisition. The recordingSender defaults to peerSupportsReplay=true.
+	const peerID peermanagement.PeerID = 7
+	r.peersMu.Lock()
+	r.peerStates[peerID] = &peerLedgerState{
+		LedgerSeq: svc.GetClosedLedgerIndex() + 100,
+	}
+	r.peersMu.Unlock()
+
+	// Validation tracker fires for a seq well beyond our closed tip.
+	// Hash is arbitrary — we only need to verify the router asks for it.
+	var validatedHash [32]byte
+	for i := range validatedHash {
+		validatedHash[i] = byte(0xA0 + i%16)
+	}
+	validatedSeq := svc.GetClosedLedgerIndex() + 5
+
+	svc.SetValidatedLedger(validatedSeq, validatedHash)
+
+	// Stash sanity: SetValidatedLedger must have stashed the (seq, hash)
+	// pair (no ledgerHistory entry yet — pre-condition for arming).
+	require.Eventually(t, func() bool {
+		return len(rs.replayCalls())+len(rs.legacyCalls()) >= 1
+	}, time.Second, 10*time.Millisecond,
+		"router must auto-arm an acquisition when SetValidatedLedger stashes a validation for a seq beyond closed_ledger")
+
+	totalCalls := len(rs.replayCalls()) + len(rs.legacyCalls())
+	require.Equal(t, 1, totalCalls,
+		"router must auto-arm exactly one acquisition for the stashed validation")
+
+	armedHash, armedSeq := autoArmTarget(rs)
+	assert.Equal(t, validatedHash, armedHash,
+		"auto-armed acquisition must target the stashed validation's hash")
+	if armedSeq != 0 {
+		assert.Equal(t, validatedSeq, armedSeq,
+			"auto-armed acquisition must carry the stashed validation's seq (legacy path)")
+	}
+}
+
+// TestRouter_Issue397_NoAcquisitionWhenNoPeers pins the no-peer guard:
+// when SetValidatedLedger stashes but the router has no tracked peers,
+// no acquisition is armed (peer-status-change handlers will drive it
+// once peers reconnect). Without this, dispatching to peerID=0 races
+// against the wire layer's per-peer routing.
+func TestRouter_Issue397_NoAcquisitionWhenNoPeers(t *testing.T) {
+	_, _, rs, svc := makeRouter(t)
+
+	// No peer registered in r.peerStates.
+
+	var validatedHash [32]byte
+	for i := range validatedHash {
+		validatedHash[i] = byte(0x30 + i%16)
+	}
+	validatedSeq := svc.GetClosedLedgerIndex() + 5
+
+	svc.SetValidatedLedger(validatedSeq, validatedHash)
+
+	// Wait briefly so any errant goroutine would have fired by now.
+	time.Sleep(50 * time.Millisecond)
+
+	totalCalls := len(rs.replayCalls()) + len(rs.legacyCalls())
+	assert.Equal(t, 0, totalCalls,
+		"router must NOT arm an acquisition when no peers are tracked")
+}

--- a/internal/ledger/service/pending_ledger_validation_test.go
+++ b/internal/ledger/service/pending_ledger_validation_test.go
@@ -202,6 +202,87 @@ func TestSetValidatedLedger_StashHashMismatch(t *testing.T) {
 		"drain must delete hash-mismatched entries on the seq-adopt side")
 }
 
+// TestSetValidatedLedger_StashesOnForkDivergence pins parity with
+// rippled's LedgerMaster::checkAccept(hash, seq), which is hash-keyed:
+// when the validated hash differs from the one we have at that seq,
+// rippled still calls getInboundLedgers().acquire(hash, seq, GENERIC)
+// (LedgerMaster.cpp:904-918). Our seq-keyed map must mirror by stashing
+// the (seq, expectedHash) pair on hash mismatch so a later acquisition-
+// then-adopt at the validated hash drains the stash and promotes
+// validated. The handler-fire side is guarded by seq > closedLedger
+// (the fork-divergence case typically sits at closed), so this test
+// also pins that the handler is NOT invoked for seq <= closed.
+func TestSetValidatedLedger_StashesOnForkDivergence(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	// Adopt locally at hash B.
+	var localHashB [32]byte
+	localHashB[0] = 0xD1
+	adoptedSeq := svc.GetClosedLedgerIndex() + 1
+	hdr := &header.LedgerHeader{
+		LedgerIndex: adoptedSeq,
+		Hash:        localHashB,
+		TxHash:      txRoot,
+		AccountHash: stateRoot,
+	}
+	require.NoError(t, svc.AdoptLedgerWithState(context.TODO(), hdr, stateMap, txMap))
+	require.Equal(t, adoptedSeq, svc.GetClosedLedgerIndex(),
+		"setup: adopt must advance closedLedger so the fork case sits at seq == closed")
+	startValidated := svc.GetValidatedLedgerIndex()
+
+	// Wire a handler that records every fire so we can assert it is
+	// NOT invoked in the seq <= closed regime.
+	var (
+		mu    sync.Mutex
+		fires []uint32
+	)
+	svc.SetOnPendingValidationStashed(func(seq uint32, _ [32]byte) {
+		mu.Lock()
+		fires = append(fires, seq)
+		mu.Unlock()
+	})
+
+	// Quorum validates a *different* hash A at the same seq — fork.
+	var validatedHashA [32]byte
+	validatedHashA[0] = 0xD2
+	svc.SetValidatedLedger(adoptedSeq, validatedHashA)
+
+	// Stash must hold the validated hash so a future re-adopt at hash A
+	// (after fixMismatch + acquisition) can drain and promote.
+	svc.mu.RLock()
+	entry, stashed := svc.pendingLedgerValidations[adoptedSeq]
+	svc.mu.RUnlock()
+	require.True(t, stashed,
+		"hash-mismatched validation must stash so a later acquired+adopted matching hash can promote")
+	assert.Equal(t, validatedHashA, entry.expectedHash,
+		"stashed entry must carry the validated hash, not the locally-adopted one")
+
+	// Validated must NOT advance — fork safety.
+	assert.Equal(t, startValidated, svc.GetValidatedLedgerIndex(),
+		"hash mismatch must NOT promote validated")
+
+	// Handler must NOT fire — seq <= closed guard.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	gotFires := append([]uint32(nil), fires...)
+	mu.Unlock()
+	assert.Empty(t, gotFires,
+		"onPendingValidationStashed must not fire for seq <= closedLedger; the divergent-fork status-change path drives reacquisition at active height")
+}
+
 // TestAdoptLedgerWithState_EventCallbackFiresAfterValidationFirstRace pins
 // the validation-first race fix: when SetValidatedLedger arrives BEFORE the
 // adopt path installs the ledger, the subsequent adopt's F4 drain promotes

--- a/internal/ledger/service/pending_ledger_validation_test.go
+++ b/internal/ledger/service/pending_ledger_validation_test.go
@@ -203,15 +203,14 @@ func TestSetValidatedLedger_StashHashMismatch(t *testing.T) {
 }
 
 // TestSetValidatedLedger_StashesOnForkDivergence pins parity with
-// rippled's LedgerMaster::checkAccept(hash, seq), which is hash-keyed:
-// when the validated hash differs from the one we have at that seq,
-// rippled still calls getInboundLedgers().acquire(hash, seq, GENERIC)
-// (LedgerMaster.cpp:904-918). Our seq-keyed map must mirror by stashing
-// the (seq, expectedHash) pair on hash mismatch so a later acquisition-
-// then-adopt at the validated hash drains the stash and promotes
-// validated. The handler-fire side is guarded by seq > closedLedger
-// (the fork-divergence case typically sits at closed), so this test
-// also pins that the handler is NOT invoked for seq <= closed.
+// rippled's hash-keyed LedgerMaster::checkAccept(hash, seq): when the
+// validated hash differs from the one we have at that seq, rippled
+// still calls getInboundLedgers().acquire(hash, seq, GENERIC)
+// (LedgerMaster.cpp:904-918). Our seq-keyed map mirrors by stashing
+// the (seq, expectedHash) pair on hash mismatch so a later
+// acquisition-then-adopt at the validated hash drains the stash and
+// promotes validated. The handler-fire side is guarded by
+// seq > closedLedger; this test pins both halves.
 func TestSetValidatedLedger_StashesOnForkDivergence(t *testing.T) {
 	cfg := DefaultConfig()
 	svc, err := New(cfg)
@@ -228,7 +227,6 @@ func TestSetValidatedLedger_StashesOnForkDivergence(t *testing.T) {
 	stateRoot, err := stateMap.Hash()
 	require.NoError(t, err)
 
-	// Adopt locally at hash B.
 	var localHashB [32]byte
 	localHashB[0] = 0xD1
 	adoptedSeq := svc.GetClosedLedgerIndex() + 1
@@ -243,8 +241,7 @@ func TestSetValidatedLedger_StashesOnForkDivergence(t *testing.T) {
 		"setup: adopt must advance closedLedger so the fork case sits at seq == closed")
 	startValidated := svc.GetValidatedLedgerIndex()
 
-	// Wire a handler that records every fire so we can assert it is
-	// NOT invoked in the seq <= closed regime.
+	// Records every handler fire so we can assert none happened.
 	var (
 		mu    sync.Mutex
 		fires []uint32

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -170,10 +170,9 @@ type Service struct {
 
 	// onPendingValidationStashed, if non-nil, is invoked off-thread when
 	// SetValidatedLedger stashes a validation for a seq beyond the closed
-	// ledger. Wired by the consensus router to drive an inbound ledger
-	// acquisition for (seq, hash) — without this kick, validation-tracker
-	// quorum decisions for ledgers we have not yet adopted sit silently
-	// in pendingLedgerValidations and validated_ledger.seq stays frozen.
+	// ledger. Without this kick, validation-tracker quorum decisions for
+	// ledgers we have not yet adopted sit silently in
+	// pendingLedgerValidations and validated_ledger.seq stays frozen.
 	// Mirrors rippled's LedgerMaster::checkAccept which calls
 	// getInboundLedgers().acquire(hash, seq, ...) on the same condition.
 	onPendingValidationStashed func(seq uint32, hash [32]byte)
@@ -236,11 +235,8 @@ func (s *Service) SetEventCallback(callback EventCallback) {
 }
 
 // SetOnPendingValidationStashed registers a handler invoked off-thread
-// when SetValidatedLedger stashes a validation for a seq beyond the
-// closed ledger (i.e. ledgerHistory[seq] is empty). The router uses
-// this to arm an inbound acquisition for (seq, hash) so the cascade
-// catchup is driven by validation-arrival events, not just by peer
-// status-change polling. Pass nil to unwire.
+// when SetValidatedLedger stashes a validation that doesn't match a
+// ledger we have. Pass nil to unwire.
 func (s *Service) SetOnPendingValidationStashed(handler func(seq uint32, hash [32]byte)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1505,13 +1501,11 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	// validated.
 	if !ok || l.Hash() != expectedHash {
 		s.stashPendingLedgerValidationLocked(seq, expectedHash)
-		// Capture the arm-acquisition handler before unlocking so a
-		// concurrent SetOnPendingValidationStashed cannot race the
-		// dispatch decision. Only fire when seq is strictly above the
-		// closed ledger — at or below, the divergent-fork status-
-		// change handler is the right path for any reacquisition.
-		// Mirrors PR #398's parentSeq <= closed guard in
-		// armParentAcquisition.
+		// Capture the handler before unlocking so a concurrent
+		// SetOnPendingValidationStashed cannot race the dispatch
+		// decision. Fire only when seq is strictly above closed —
+		// at or below, the divergent-fork status-change handler is
+		// the right path for any reacquisition.
 		var (
 			handler func(uint32, [32]byte)
 			fire    bool
@@ -1611,17 +1605,13 @@ type pendingValidationEntry struct {
 	at           time.Time
 }
 
-// pendingValidationTTL bounds how long a stashed validation is considered
-// fresh enough to promote on later adopt/close. The 10-minute window is
-// driven by the deep-gap catchup case: when the network is hundreds of
-// ledgers ahead and adoption walks the chain backward one hop per peer
-// round-trip (the post-PR #398 cascade), the trip from "validation
-// arrived for seq N" to "ledger at seq N adopted" can take several
-// minutes. With pendingValidationMaxLen=256 already bounding memory and
-// the on-drain hash check guaranteeing fork safety, a generous TTL keeps
-// the validation-first race fix correct under realistic catchup
-// timelines without sacrificing the staleness guard a fork on the
-// validation-quorum side might create.
+// pendingValidationTTL bounds how long a stashed validation is
+// considered fresh enough to promote on later adopt/close. The
+// 10-minute window covers deep-gap catchup, where backward-chain
+// adoption walks one hop per peer round-trip — "validation arrived
+// for seq N" to "ledger at seq N adopted" can take several minutes.
+// pendingValidationMaxLen=256 already bounds memory and the on-drain
+// hash check guarantees fork safety, so a generous TTL is safe.
 const pendingValidationTTL = 10 * time.Minute
 
 // stashPendingLedgerValidationLocked stores a (seq, expectedHash, at) entry

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -168,6 +168,16 @@ type Service struct {
 	// eviction of pendingLedgerValidations.
 	pendingLedgerValidationsOrder []uint32
 
+	// onPendingValidationStashed, if non-nil, is invoked off-thread when
+	// SetValidatedLedger stashes a validation for a seq beyond the closed
+	// ledger. Wired by the consensus router to drive an inbound ledger
+	// acquisition for (seq, hash) — without this kick, validation-tracker
+	// quorum decisions for ledgers we have not yet adopted sit silently
+	// in pendingLedgerValidations and validated_ledger.seq stays frozen.
+	// Mirrors rippled's LedgerMaster::checkAccept which calls
+	// getInboundLedgers().acquire(hash, seq, ...) on the same condition.
+	onPendingValidationStashed func(seq uint32, hash [32]byte)
+
 	// heldAdoptions stashes replay-delta adoptions that arrived out of
 	// order (child seq before parent seq). Keyed by the *awaited parent
 	// seq* so a successful adopt at seq N can pop the child at seq N+1
@@ -223,6 +233,18 @@ func (s *Service) SetEventCallback(callback EventCallback) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.eventCallback = callback
+}
+
+// SetOnPendingValidationStashed registers a handler invoked off-thread
+// when SetValidatedLedger stashes a validation for a seq beyond the
+// closed ledger (i.e. ledgerHistory[seq] is empty). The router uses
+// this to arm an inbound acquisition for (seq, hash) so the cascade
+// catchup is driven by validation-arrival events, not just by peer
+// status-change polling. Pass nil to unwire.
+func (s *Service) SetOnPendingValidationStashed(handler func(seq uint32, hash [32]byte)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onPendingValidationStashed = handler
 }
 
 // SetEventHooks sets the event hooks for ledger events
@@ -1479,7 +1501,32 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 		// validation is dropped and server_info.validated_ledger
 		// lags closed_ledger indefinitely.
 		s.stashPendingLedgerValidationLocked(seq, expectedHash)
+		// Capture the arm-acquisition handler before unlocking so a
+		// concurrent SetOnPendingValidationStashed cannot race the
+		// dispatch decision. Only fire when seq is strictly above the
+		// closed ledger — at or below, we either already have it in
+		// history (the ledgerHistory[seq] hit branch above would have
+		// fired) or it was evicted, in which case the divergent-fork
+		// path drives any reacquisition. Mirrors PR #398's parentSeq
+		// <= closed guard in armParentAcquisition.
+		var (
+			handler func(uint32, [32]byte)
+			fire    bool
+		)
+		if s.onPendingValidationStashed != nil {
+			closedSeq := uint32(0)
+			if s.closedLedger != nil {
+				closedSeq = s.closedLedger.Sequence()
+			}
+			if seq > closedSeq {
+				handler = s.onPendingValidationStashed
+				fire = true
+			}
+		}
 		s.mu.Unlock()
+		if fire {
+			go handler(seq, expectedHash)
+		}
 		return
 	}
 	if l.Hash() != expectedHash {
@@ -1566,11 +1613,17 @@ type pendingValidationEntry struct {
 }
 
 // pendingValidationTTL bounds how long a stashed validation is considered
-// fresh enough to promote on later adopt/close. 30s is comfortably larger
-// than the quorum-gossip window (a few seconds in practice) but small
-// enough that a truly stale validation — one where the adopt path is
-// lagging minutes behind — fails safe by refusing promotion.
-const pendingValidationTTL = 30 * time.Second
+// fresh enough to promote on later adopt/close. The 10-minute window is
+// driven by the deep-gap catchup case: when the network is hundreds of
+// ledgers ahead and adoption walks the chain backward one hop per peer
+// round-trip (the post-PR #398 cascade), the trip from "validation
+// arrived for seq N" to "ledger at seq N adopted" can take several
+// minutes. With pendingValidationMaxLen=256 already bounding memory and
+// the on-drain hash check guaranteeing fork safety, a generous TTL keeps
+// the validation-first race fix correct under realistic catchup
+// timelines without sacrificing the staleness guard a fork on the
+// validation-quorum side might create.
+const pendingValidationTTL = 10 * time.Minute
 
 // stashPendingLedgerValidationLocked stores a (seq, expectedHash, at) entry
 // for later drain when ledgerHistory[seq] is populated. LRU-evicts the

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1492,23 +1492,26 @@ func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledg
 func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	s.mu.Lock()
 	l, ok := s.ledgerHistory[seq]
-	if !ok {
-		// Validation tracker raced ahead of the peer-adoption loop:
-		// quorum was reached for seq N before our local adopt/close
-		// installed seq N into ledgerHistory. Stash the (seq, hash)
-		// pair so the next insertion at that seq can promote to
-		// validated if the hash matches. Without this stash, the
-		// validation is dropped and server_info.validated_ledger
-		// lags closed_ledger indefinitely.
+	// Mirrors rippled's LedgerMaster::checkAccept(hash, seq), which is
+	// hash-keyed: getLedgerByHash(hash) returns null both when nothing
+	// sits at that seq AND when something else does, and the acquire
+	// fires unconditionally on null (LedgerMaster.cpp:904-918). Our seq-
+	// keyed map turns that single rippled branch into two: no entry, or
+	// entry-with-different-hash (a fork at the same height). Both must
+	// stash and arm acquisition for the validated hash. The acquired
+	// ledger lands via adoptLedgerWithStateLocked, which overwrites
+	// ledgerHistory[seq] and runs fixMismatchLocked; the seq-keyed stash
+	// then drains on hash match and promotes the adopted ledger to
+	// validated.
+	if !ok || l.Hash() != expectedHash {
 		s.stashPendingLedgerValidationLocked(seq, expectedHash)
 		// Capture the arm-acquisition handler before unlocking so a
 		// concurrent SetOnPendingValidationStashed cannot race the
 		// dispatch decision. Only fire when seq is strictly above the
-		// closed ledger — at or below, we either already have it in
-		// history (the ledgerHistory[seq] hit branch above would have
-		// fired) or it was evicted, in which case the divergent-fork
-		// path drives any reacquisition. Mirrors PR #398's parentSeq
-		// <= closed guard in armParentAcquisition.
+		// closed ledger — at or below, the divergent-fork status-
+		// change handler is the right path for any reacquisition.
+		// Mirrors PR #398's parentSeq <= closed guard in
+		// armParentAcquisition.
 		var (
 			handler func(uint32, [32]byte)
 			fire    bool
@@ -1527,10 +1530,6 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 		if fire {
 			go handler(seq, expectedHash)
 		}
-		return
-	}
-	if l.Hash() != expectedHash {
-		s.mu.Unlock()
 		return
 	}
 	_ = l.SetValidated()


### PR DESCRIPTION
## Summary

PR #398 fixed the held-adoption stash by arming a backward-chain acquisition when `SubmitHeldAdoption` returned `Stashed=true`. The parallel `SetValidatedLedger` stash path was left silent — when the validation tracker reached quorum for a seq we hadn't yet adopted, the `(seq, hash)` pair sat in `pendingLedgerValidations` with **no acquisition driven**, and the 30 s TTL evicted it before adoption ever caught up. Net effect: `server_info.validated_ledger.seq` stayed frozen near genesis even as the consensus-adaptor logged "Ledger fully validated" at the network's tip — the symptom in the [follow-up to #397 the user observed on `origin/main` HEAD `6360570`](https://github.com/LeJamon/go-xrpl/issues/397).

Mirrors rippled's `LedgerMaster::checkAccept(hash, seq)` at [`LedgerMaster.cpp:917-919`](../blob/main/rippled/src/xrpld/app/ledger/detail/LedgerMaster.cpp#L917-L919), which calls `app_.getInboundLedgers().acquire(hash, seq, ...)` on the same condition.

- `service.SetValidatedLedger`: stash branch now dispatches a new `OnPendingValidationStashed(seq, hash)` hook off-thread, gated on `seq > closedLedger.Sequence()`.
- `Router.armValidationStashAcquisition`: picks any tracked peer and runs `startLedgerAcquisition`, with the same `seq <= closed` guard PR #398 added to `armParentAcquisition`. Skips when no peer is tracked yet — peer-status handlers will drive the acquisition once peers connect.
- `pendingValidationTTL`: bumped from 30 s to 10 min. With `pendingValidationMaxLen=256` already bounding memory and the on-drain hash check enforcing fork safety, the 30 s freshness window was rejecting valid quorum decisions during legitimate deep-gap catchup (the post-PR #398 cascade can take minutes for hundreds of held-adoption hops).

## Test plan

- [x] `TestRouter_Issue397_AutoArmsAcquisitionOnValidationStash` — fails on main (no auto-arm), passes after fix.
- [x] `TestRouter_Issue397_NoAcquisitionWhenNoPeers` — pins the no-tracked-peer skip.
- [x] `TestSetValidatedLedger_StashExpires` (existing) — still passes; backdating uses `2 * pendingValidationTTL` so the staleness contract is preserved.
- [x] `go test ./internal/consensus/adaptor/... ./internal/ledger/service/... ./internal/consensus/rcl/... -count=1` — all pass.
- [x] `go vet ./...` clean (the pre-existing `mock_binary_parser.go` warning is unrelated).
- [x] Confirmed the two `internal/testing/{batch,conformance}` failures in the broader sweep are pre-existing on `worktree-issue-397` HEAD `24e1b28` — unrelated to this change.
- [ ] Re-run the xrpl-confluence chaos harness from issue #397 with this branch built to confirm `validated_ledger.seq` advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)