### PR TITLE
TxSetImpl: SHAMap as canonical storage (closes #406)

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -772,7 +772,10 @@ func (a *Adaptor) GetTxSet(id consensus.TxSetID) (consensus.TxSet, error) {
 }
 
 func (a *Adaptor) BuildTxSet(txs [][]byte) (consensus.TxSet, error) {
-	ts := NewTxSet(txs)
+	ts, err := NewTxSet(txs)
+	if err != nil {
+		return nil, err
+	}
 	a.txSetCache.Put(ts)
 	return ts, nil
 }

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -247,7 +247,8 @@ func TestTxSetContains(t *testing.T) {
 	blob2 := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C}
 	blob3 := []byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C}
 
-	ts := NewTxSet([][]byte{blob1, blob2})
+	ts, err := NewTxSet([][]byte{blob1, blob2})
+	require.NoError(t, err)
 
 	id1 := computeTxID(blob1)
 	id2 := computeTxID(blob2)
@@ -262,13 +263,14 @@ func TestTxSetAddRemove(t *testing.T) {
 	blob1 := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C}
 	blob2 := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C}
 
-	ts := NewTxSet([][]byte{blob1})
+	ts, err := NewTxSet([][]byte{blob1})
+	require.NoError(t, err)
 	assert.Equal(t, 1, ts.Size())
 
 	originalID := ts.ID()
 
 	// Add
-	err := ts.Add(blob2)
+	err = ts.Add(blob2)
 	require.NoError(t, err)
 	assert.Equal(t, 2, ts.Size())
 	assert.NotEqual(t, originalID, ts.ID()) // ID should change

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -825,7 +825,7 @@ func (r *Router) serveTxSet(peerID peermanagement.PeerID, req *message.GetLedger
 
 	// SHAMap is non-nil for any TxSet that reached the cache —
 	// NewTxSet returns an error before stashing on shamap.New failure.
-	txMap := ts.SHAMap()
+	txMap := ts.shamap()
 
 	queryDepth := int(req.QueryDepth)
 	if queryDepth == 0 {

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -823,12 +823,8 @@ func (r *Router) serveTxSet(peerID peermanagement.PeerID, req *message.GetLedger
 		return
 	}
 
+	// SHAMap is non-nil post-NewTxSet (NewTxSet panics otherwise).
 	txMap := ts.SHAMap()
-	if txMap == nil {
-		r.logger.Warn("tx-set has no SHAMap to serve",
-			"peer", peerID, "txset", fmt.Sprintf("%x", txSetID[:8]))
-		return
-	}
 
 	queryDepth := int(req.QueryDepth)
 	if queryDepth == 0 {

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -861,7 +861,7 @@ func (r *Router) serveTxSet(peerID peermanagement.PeerID, req *message.GetLedger
 		"peer", peerID,
 		"txset", fmt.Sprintf("%x", txSetID[:8]),
 		"shamap_nodes", len(nodes),
-		"txs", len(ts.Txs()),
+		"txs", ts.Size(),
 		"query_depth", queryDepth,
 		"requested_nodes", len(req.NodeIDs))
 }

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -823,7 +823,8 @@ func (r *Router) serveTxSet(peerID peermanagement.PeerID, req *message.GetLedger
 		return
 	}
 
-	// SHAMap is non-nil post-NewTxSet (NewTxSet panics otherwise).
+	// SHAMap is non-nil for any TxSet that reached the cache —
+	// NewTxSet returns an error before stashing on shamap.New failure.
 	txMap := ts.SHAMap()
 
 	queryDepth := int(req.QueryDepth)

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -823,10 +823,10 @@ func (r *Router) serveTxSet(peerID peermanagement.PeerID, req *message.GetLedger
 		return
 	}
 
-	txMap, err := ts.BuildSHAMap()
-	if err != nil {
-		r.logger.Warn("failed to build tx-set SHAMap for serve",
-			"error", err, "peer", peerID, "txset", fmt.Sprintf("%x", txSetID[:8]))
+	txMap := ts.SHAMap()
+	if txMap == nil {
+		r.logger.Warn("tx-set has no SHAMap to serve",
+			"peer", peerID, "txset", fmt.Sprintf("%x", txSetID[:8]))
 		return
 	}
 

--- a/internal/consensus/adaptor/router_txset_partial_test.go
+++ b/internal/consensus/adaptor/router_txset_partial_test.go
@@ -33,8 +33,7 @@ func buildTxSetForTest(t *testing.T, n int) (*shamap.SHAMap, [32]byte, []shamap.
 		blobs[i] = bytes.Repeat([]byte{byte(0x10 + i)}, 16)
 	}
 	ts := NewTxSet(blobs)
-	txMap, err := ts.BuildSHAMap()
-	require.NoError(t, err)
+	txMap := ts.SHAMap()
 	require.NotNil(t, txMap)
 	wireNodes, err := txMap.WalkWireNodes()
 	require.NoError(t, err)

--- a/internal/consensus/adaptor/router_txset_partial_test.go
+++ b/internal/consensus/adaptor/router_txset_partial_test.go
@@ -32,7 +32,8 @@ func buildTxSetForTest(t *testing.T, n int) (*shamap.SHAMap, [32]byte, []shamap.
 	for i := range blobs {
 		blobs[i] = bytes.Repeat([]byte{byte(0x10 + i)}, 16)
 	}
-	ts := NewTxSet(blobs)
+	ts, err := NewTxSet(blobs)
+	require.NoError(t, err)
 	txMap := ts.SHAMap()
 	require.NotNil(t, txMap)
 	wireNodes, err := txMap.WalkWireNodes()

--- a/internal/consensus/adaptor/router_txset_partial_test.go
+++ b/internal/consensus/adaptor/router_txset_partial_test.go
@@ -34,7 +34,7 @@ func buildTxSetForTest(t *testing.T, n int) (*shamap.SHAMap, [32]byte, []shamap.
 	}
 	ts, err := NewTxSet(blobs)
 	require.NoError(t, err)
-	txMap := ts.SHAMap()
+	txMap := ts.shamap()
 	require.NotNil(t, txMap)
 	wireNodes, err := txMap.WalkWireNodes()
 	require.NoError(t, err)

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -33,22 +33,23 @@ import (
 // canonical hash of the empty SHAMap. Reaching that path is a
 // programmer-error condition that rippled covers with XRPL_ASSERT.
 //
-// Aliasing. SHAMap() exposes the live backing map. Add and Remove
-// mutate it in place — there is no copy-on-write. Callers that hold a
-// pointer returned by SHAMap() across an Add/Remove see the mutation;
-// the only production caller (router.go serveTxSet) takes the pointer
-// and walks it synchronously, so the aliasing is dormant. Rippled
-// avoids this by snapshotting on every MutableTxSet round-trip
-// (RCLCxTx.h:78,119); replicating that would require SHAMap COW which
-// we do not yet support.
+// Aliasing. shamap() (package-internal) exposes the live backing map.
+// Add and Remove mutate it in place — there is no copy-on-write. The
+// only production caller (router.go serveTxSet) takes the pointer and
+// walks it synchronously, so the aliasing is dormant. Rippled avoids
+// this by snapshotting on every MutableTxSet round-trip
+// (RCLCxTx.h:78,119); replicating that would require O(1) SHAMap COW,
+// which the unbacked path here does not yet have (Snapshot does a
+// deep clone). The accessor stays unexported so the aliasing concern
+// cannot leak out of this package.
 //
 // Concurrency. The backing *shamap.SHAMap is internally lock-protected,
 // but TxSetImpl maintains a shadow `count` field for O(1) Size(); the
-// mutex below brackets count mutations against Size() reads. Rippled
-// has no parallel counter (RCLTxSet exposes no size method at all —
-// RCLCxTx.h:62-189); the divergence exists because our consensus
-// engine logs and gates on tx counts from hot paths, so we pay the
-// extra field rather than walk the tree.
+// mutex below brackets every count read (Size, Txs, TxIDs) against
+// Add/Remove writers. Rippled has no parallel counter (RCLTxSet
+// exposes no size method at all — RCLCxTx.h:62-189); the divergence
+// exists because our consensus engine logs and gates on tx counts
+// from hot paths, so we pay the extra field rather than walk the tree.
 type TxSetImpl struct {
 	txMap *shamap.SHAMap
 	mu    sync.Mutex
@@ -97,7 +98,7 @@ func (ts *TxSetImpl) ID() consensus.TxSetID {
 // or mutate the returned slices safely; see Bytes() for the zero-copy
 // counterpart used internally.
 func (ts *TxSetImpl) Txs() [][]byte {
-	result := make([][]byte, 0, ts.count)
+	result := make([][]byte, 0, ts.Size())
 	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
 		result = append(result, it.Data())
 		return true
@@ -107,7 +108,7 @@ func (ts *TxSetImpl) Txs() [][]byte {
 
 // TxIDs returns every txID in canonical key order, parallel to Txs().
 func (ts *TxSetImpl) TxIDs() []consensus.TxID {
-	result := make([]consensus.TxID, 0, ts.count)
+	result := make([]consensus.TxID, 0, ts.Size())
 	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
 		key := it.Key()
 		result = append(result, consensus.TxID(key))
@@ -130,7 +131,7 @@ func (ts *TxSetImpl) Contains(id consensus.TxID) bool {
 // surprised Has on a corrupted root is more useful as a diagnostic
 // than as a silent fall-through into PutWithNodeType.
 //
-// Invalidates any pointer previously returned by SHAMap(): the
+// Invalidates any pointer previously returned by shamap(): the
 // underlying tree is mutated in place. See the TxSetImpl doc comment
 // for the aliasing contract.
 func (ts *TxSetImpl) Add(tx []byte) error {
@@ -154,7 +155,7 @@ func (ts *TxSetImpl) Add(tx []byte) error {
 
 // Remove deletes a transaction by ID. Propagates Has errors for the
 // same reason Add does. Invalidates any pointer previously returned
-// by SHAMap(); see the TxSetImpl doc comment.
+// by shamap(); see the TxSetImpl doc comment.
 func (ts *TxSetImpl) Remove(id consensus.TxID) error {
 	key := [32]byte(id)
 	ok, err := ts.txMap.Has(key)
@@ -205,12 +206,13 @@ func (ts *TxSetImpl) Bytes() []byte {
 	return buf.Bytes()
 }
 
-// SHAMap returns the canonical tx-set SHAMap. The pointer aliases the
-// live backing store: subsequent Add/Remove calls on this TxSetImpl
-// mutate the returned map in place. Callers must treat it as
-// read-only and finish any walk before mutating the parent TxSetImpl.
-// See the TxSetImpl doc comment for the broader aliasing contract.
-func (ts *TxSetImpl) SHAMap() *shamap.SHAMap {
+// shamap returns the canonical tx-set SHAMap. Package-internal: the
+// pointer aliases the live backing store, so subsequent Add/Remove
+// calls on this TxSetImpl mutate the returned map in place. Callers
+// must treat it as read-only and finish any walk before mutating the
+// parent TxSetImpl. See the TxSetImpl doc comment for the broader
+// aliasing contract.
+func (ts *TxSetImpl) shamap() *shamap.SHAMap {
 	return ts.txMap
 }
 

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -10,145 +10,152 @@ import (
 	"github.com/LeJamon/goXRPLd/shamap"
 )
 
-// TxSetImpl implements consensus.TxSet backed by raw transaction blobs.
+// TxSetImpl implements consensus.TxSet backed by a SHAMap of transaction
+// blobs keyed by txID. This mirrors rippled's InboundTransactions: the
+// SHAMap is the canonical storage, and Txs/TxIDs/Bytes derive from it.
+//
+// Complexity profile (N = set size):
+//   - Add/Remove/Contains: O(log N) via SHAMap descent + incremental
+//     hash propagation up the dirty path.
+//   - ID():                O(1) — the SHAMap caches the root hash and
+//     refreshes it on every mutation.
+//   - Txs/TxIDs:           O(N) walk of the leaves in canonical key order.
+//     The two methods walk identically, so callers can zip them.
+//   - Bytes:               O(N) walk.
 type TxSetImpl struct {
-	id  consensus.TxSetID
-	txs [][]byte
-	// Index of txID -> position in txs slice for fast lookup
-	index map[consensus.TxID]int
+	txMap *shamap.SHAMap
+	count int
 }
 
-// NewTxSet creates a TxSet from raw transaction blobs.
-// The ID is computed as the SHAMap root hash of the transaction set,
-// matching rippled's canonical tx set hashing.
+// NewTxSet creates a TxSet from raw transaction blobs. The ID is the
+// SHAMap root hash, matching rippled's canonical tx-set hashing.
 func NewTxSet(txBlobs [][]byte) *TxSetImpl {
-	ts := &TxSetImpl{
-		txs:   make([][]byte, len(txBlobs)),
-		index: make(map[consensus.TxID]int, len(txBlobs)),
+	ts := &TxSetImpl{}
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	if err != nil {
+		return ts
 	}
-	copy(ts.txs, txBlobs)
-
-	// Build index and compute ID
-	for i, blob := range ts.txs {
-		txID := computeTxID(blob)
-		ts.index[txID] = i
+	ts.txMap = txMap
+	for _, blob := range txBlobs {
+		_ = ts.Add(blob)
 	}
-	ts.id = computeTxSetID(ts.txs)
 	return ts
 }
 
 func (ts *TxSetImpl) ID() consensus.TxSetID {
-	return ts.id
+	if ts.txMap == nil {
+		return consensus.TxSetID{}
+	}
+	h, err := ts.txMap.Hash()
+	if err != nil {
+		return consensus.TxSetID{}
+	}
+	return consensus.TxSetID(h)
 }
 
+// Txs returns every transaction blob in canonical key order. The
+// ordering matches TxIDs() so callers can zip the two slices.
 func (ts *TxSetImpl) Txs() [][]byte {
-	result := make([][]byte, len(ts.txs))
-	copy(result, ts.txs)
+	if ts.txMap == nil {
+		return nil
+	}
+	result := make([][]byte, 0, ts.count)
+	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
+		result = append(result, it.Data())
+		return true
+	})
 	return result
 }
 
+// TxIDs returns every txID in canonical key order, parallel to Txs().
 func (ts *TxSetImpl) TxIDs() []consensus.TxID {
-	// Return in the same order as Txs() so callers can zip the two
-	// slices. ts.index maps id→position into ts.txs, so the reverse
-	// walk writes each id at its canonical slot.
-	result := make([]consensus.TxID, len(ts.txs))
-	for id, idx := range ts.index {
-		result[idx] = id
+	if ts.txMap == nil {
+		return nil
 	}
+	result := make([]consensus.TxID, 0, ts.count)
+	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
+		key := it.Key()
+		result = append(result, consensus.TxID(key))
+		return true
+	})
 	return result
 }
 
 func (ts *TxSetImpl) Contains(id consensus.TxID) bool {
-	_, ok := ts.index[id]
-	return ok
+	if ts.txMap == nil {
+		return false
+	}
+	ok, err := ts.txMap.Has([32]byte(id))
+	return err == nil && ok
 }
 
 func (ts *TxSetImpl) Add(tx []byte) error {
-	txID := computeTxID(tx)
-	if _, exists := ts.index[txID]; exists {
-		return nil // already present
+	if ts.txMap == nil {
+		return nil
 	}
-	ts.index[txID] = len(ts.txs)
-	ts.txs = append(ts.txs, tx)
-	ts.id = computeTxSetID(ts.txs) // recompute
+	txID := computeTxID(tx)
+	key := [32]byte(txID)
+	if ok, _ := ts.txMap.Has(key); ok {
+		return nil
+	}
+	// Prefer the typed leaf path; fall back to the untyped Put for
+	// callers that work around CreateLeafNode failures on short
+	// fixture blobs.
+	if err := ts.txMap.PutWithNodeType(key, tx, shamap.NodeTypeTransactionNoMeta); err != nil {
+		if err2 := ts.txMap.Put(key, tx); err2 != nil {
+			return err2
+		}
+	}
+	ts.count++
 	return nil
 }
 
 func (ts *TxSetImpl) Remove(id consensus.TxID) error {
-	idx, ok := ts.index[id]
+	if ts.txMap == nil {
+		return nil
+	}
+	key := [32]byte(id)
+	ok, _ := ts.txMap.Has(key)
 	if !ok {
-		return nil // not present
+		return nil
 	}
-	// Swap with last element and shrink
-	last := len(ts.txs) - 1
-	if idx != last {
-		ts.txs[idx] = ts.txs[last]
-		lastID := computeTxID(ts.txs[idx])
-		ts.index[lastID] = idx
+	if err := ts.txMap.Delete(key); err != nil {
+		return err
 	}
-	ts.txs = ts.txs[:last]
-	delete(ts.index, id)
-	ts.id = computeTxSetID(ts.txs) // recompute
+	ts.count--
 	return nil
 }
 
 func (ts *TxSetImpl) Size() int {
-	return len(ts.txs)
+	return ts.count
 }
 
+// Bytes returns the tx blobs concatenated with a 4-byte length prefix
+// each, walked in canonical SHAMap key order.
 func (ts *TxSetImpl) Bytes() []byte {
-	// Concatenate all tx blobs with 4-byte length prefix each
-	var buf bytes.Buffer
-	for _, tx := range ts.txs {
-		l := uint32(len(tx))
-		buf.Write([]byte{byte(l >> 24), byte(l >> 16), byte(l >> 8), byte(l)})
-		buf.Write(tx)
+	if ts.txMap == nil {
+		return nil
 	}
+	var buf bytes.Buffer
+	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
+		blob := it.DataUnsafe()
+		l := uint32(len(blob))
+		buf.Write([]byte{byte(l >> 24), byte(l >> 16), byte(l >> 8), byte(l)})
+		buf.Write(blob)
+		return true
+	})
 	return buf.Bytes()
 }
 
-// computeTxSetID computes the ID of a transaction set using a SHAMap,
-// matching rippled's approach. The root hash of a SHAMap containing
-// all transactions keyed by their hash is the tx set ID.
-func computeTxSetID(txBlobs [][]byte) consensus.TxSetID {
-	txMap, err := buildTxSetSHAMap(txBlobs)
-	if err != nil || txMap == nil {
-		return consensus.TxSetID{}
-	}
-	hash, err := txMap.Hash()
-	if err != nil {
-		return consensus.TxSetID{}
-	}
-	return consensus.TxSetID(hash)
+// SHAMap returns the canonical tx-set SHAMap. Callers must treat it
+// as read-only — mutating it directly bypasses count tracking.
+func (ts *TxSetImpl) SHAMap() *shamap.SHAMap {
+	return ts.txMap
 }
 
-// buildTxSetSHAMap constructs the canonical tx-set SHAMap whose root hash
-// is the tx-set ID. Falls back to shamap.Put for short test fixture blobs.
-func buildTxSetSHAMap(txBlobs [][]byte) (*shamap.SHAMap, error) {
-	txMap, err := shamap.New(shamap.TypeTransaction)
-	if err != nil {
-		return nil, err
-	}
-	for _, blob := range txBlobs {
-		txID := computeTxID(blob)
-		if putErr := txMap.PutWithNodeType([32]byte(txID), blob, shamap.NodeTypeTransactionNoMeta); putErr != nil {
-			if err := txMap.Put([32]byte(txID), blob); err != nil {
-				return nil, err
-			}
-		}
-	}
-	return txMap, nil
-}
-
-// BuildSHAMap reconstructs the tx-set's canonical SHAMap. Built fresh per
-// call — serveTxSet is not currently hot enough to warrant caching.
-func (ts *TxSetImpl) BuildSHAMap() (*shamap.SHAMap, error) {
-	return buildTxSetSHAMap(ts.txs)
-}
-
-// computeTxID computes the SHA-512Half of a transaction blob
-// with the HashPrefix for transactions (TXN\x00).
-// Matches rippled: sha512Half(HashPrefix::transactionID, txBlob)
+// computeTxID computes the SHA-512Half of a transaction blob with the
+// HashPrefix for transactions (TXN\x00). Matches rippled's
+// sha512Half(HashPrefix::transactionID, txBlob).
 func computeTxID(blob []byte) consensus.TxID {
 	return consensus.TxID(common.Sha512Half(protocol.HashPrefixTransactionID[:], blob))
 }

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -23,6 +23,23 @@ import (
 //   - Txs/TxIDs:           O(N) walk of the leaves in canonical key order.
 //     The two methods walk identically, so callers can zip them.
 //   - Bytes:               O(N) walk.
+//
+// SHAMap errors. The shamap package only returns errors when the map is
+// in StateInvalid (a corrupted/poisoned state we never put it into
+// here) — Has/Hash/Delete are otherwise infallible. We treat any error
+// as "set is broken, fail open": Contains returns false, ID returns the
+// zero hash. The zero hash collides with the canonical hash of the
+// empty SHAMap, which is acceptable because reaching StateInvalid is a
+// programmer-error path that rippled covers with XRPL_ASSERT.
+//
+// Aliasing. SHAMap() exposes the live backing map. Add and Remove
+// mutate it in place — there is no copy-on-write. Callers that hold a
+// pointer returned by SHAMap() across an Add/Remove see the mutation;
+// the only production caller (router.go serveTxSet) takes the pointer
+// and walks it synchronously, so the aliasing is dormant. Rippled
+// avoids this by snapshotting on every MutableTxSet round-trip
+// (RCLCxTx.h:78,119); replicating that would require SHAMap COW which
+// we do not yet support.
 type TxSetImpl struct {
 	txMap *shamap.SHAMap
 	count int
@@ -31,20 +48,27 @@ type TxSetImpl struct {
 // NewTxSet creates a TxSet from raw transaction blobs. The ID is the
 // SHAMap root hash, matching rippled's canonical tx-set hashing.
 //
-// Panics if the backing SHAMap cannot be constructed — mirrors
+// Returns an error if any blob is rejected by the backing SHAMap
+// (e.g. < 12 bytes — see shamap/leaf_node.go). Rippled never silently
+// shrinks a tx-set during construction (RCLCxTx.h:87-91), and a
+// truncated set would compute the wrong root hash and break consensus.
+//
+// Panics if the backing SHAMap cannot even be constructed — mirrors
 // rippled's XRPL_ASSERT(map_) in RCLTxSet (RCLCxTx.h:111). A nil
-// tx-set is unrecoverable: consensus would silently no-op on every
+// tx-set is unrecoverable; consensus would silently no-op on every
 // subsequent Add/Contains/ID call.
-func NewTxSet(txBlobs [][]byte) *TxSetImpl {
+func NewTxSet(txBlobs [][]byte) (*TxSetImpl, error) {
 	txMap, err := shamap.New(shamap.TypeTransaction)
 	if err != nil {
 		panic(fmt.Errorf("NewTxSet: shamap.New(TypeTransaction): %w", err))
 	}
 	ts := &TxSetImpl{txMap: txMap}
-	for _, blob := range txBlobs {
-		_ = ts.Add(blob)
+	for i, blob := range txBlobs {
+		if err := ts.Add(blob); err != nil {
+			return nil, fmt.Errorf("NewTxSet: blob %d (%d bytes): %w", i, len(blob), err)
+		}
 	}
-	return ts
+	return ts, nil
 }
 
 func (ts *TxSetImpl) ID() consensus.TxSetID {
@@ -56,7 +80,10 @@ func (ts *TxSetImpl) ID() consensus.TxSetID {
 }
 
 // Txs returns every transaction blob in canonical key order. The
-// ordering matches TxIDs() so callers can zip the two slices.
+// ordering matches TxIDs() so callers can zip the two slices. Each
+// blob is a defensive copy (shamap.Item.Data()) — callers may retain
+// or mutate the returned slices safely; see Bytes() for the zero-copy
+// counterpart used internally.
 func (ts *TxSetImpl) Txs() [][]byte {
 	result := make([][]byte, 0, ts.count)
 	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
@@ -85,6 +112,10 @@ func (ts *TxSetImpl) Contains(id consensus.TxID) bool {
 // Add inserts a transaction blob into the set. Mirrors rippled's
 // RCLTxSet::MutableTxSet::insert which uses tnTRANSACTION_NM only
 // (RCLCxTx.h:90) — there is no untyped fallback.
+//
+// Invalidates any pointer previously returned by SHAMap(): the
+// underlying tree is mutated in place. See the TxSetImpl doc comment
+// for the aliasing contract.
 func (ts *TxSetImpl) Add(tx []byte) error {
 	txID := computeTxID(tx)
 	key := [32]byte(txID)
@@ -98,6 +129,8 @@ func (ts *TxSetImpl) Add(tx []byte) error {
 	return nil
 }
 
+// Remove deletes a transaction by ID. Invalidates any pointer
+// previously returned by SHAMap(); see the TxSetImpl doc comment.
 func (ts *TxSetImpl) Remove(id consensus.TxID) error {
 	key := [32]byte(id)
 	ok, _ := ts.txMap.Has(key)
@@ -117,6 +150,18 @@ func (ts *TxSetImpl) Size() int {
 
 // Bytes returns the tx blobs concatenated with a 4-byte length prefix
 // each, walked in canonical SHAMap key order.
+//
+// Uses Item.DataUnsafe() (zero-copy) because each blob is written into
+// our own owned buffer before the next ForEach iteration — the unsafe
+// alias never escapes. Txs(), by contrast, uses Item.Data() because
+// the slices are handed back to callers who may mutate or retain them.
+// Do not "normalize" this asymmetry without thinking through both
+// invariants.
+//
+// goXRPL-specific helper with no rippled counterpart; not currently
+// wired to the wire or to disk. If it ever is, consumers must accept
+// the canonical-order framing (insertion order is no longer
+// observable).
 func (ts *TxSetImpl) Bytes() []byte {
 	var buf bytes.Buffer
 	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
@@ -129,8 +174,11 @@ func (ts *TxSetImpl) Bytes() []byte {
 	return buf.Bytes()
 }
 
-// SHAMap returns the canonical tx-set SHAMap. Callers must treat it
-// as read-only — mutating it directly bypasses count tracking.
+// SHAMap returns the canonical tx-set SHAMap. The pointer aliases the
+// live backing store: subsequent Add/Remove calls on this TxSetImpl
+// mutate the returned map in place. Callers must treat it as
+// read-only and finish any walk before mutating the parent TxSetImpl.
+// See the TxSetImpl doc comment for the broader aliasing contract.
 func (ts *TxSetImpl) SHAMap() *shamap.SHAMap {
 	return ts.txMap
 }

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -2,6 +2,7 @@ package adaptor
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 
 	"github.com/LeJamon/goXRPLd/crypto/common"
@@ -29,13 +30,17 @@ type TxSetImpl struct {
 
 // NewTxSet creates a TxSet from raw transaction blobs. The ID is the
 // SHAMap root hash, matching rippled's canonical tx-set hashing.
+//
+// Panics if the backing SHAMap cannot be constructed — mirrors
+// rippled's XRPL_ASSERT(map_) in RCLTxSet (RCLCxTx.h:111). A nil
+// tx-set is unrecoverable: consensus would silently no-op on every
+// subsequent Add/Contains/ID call.
 func NewTxSet(txBlobs [][]byte) *TxSetImpl {
-	ts := &TxSetImpl{}
 	txMap, err := shamap.New(shamap.TypeTransaction)
 	if err != nil {
-		return ts
+		panic(fmt.Errorf("NewTxSet: shamap.New(TypeTransaction): %w", err))
 	}
-	ts.txMap = txMap
+	ts := &TxSetImpl{txMap: txMap}
 	for _, blob := range txBlobs {
 		_ = ts.Add(blob)
 	}
@@ -43,9 +48,6 @@ func NewTxSet(txBlobs [][]byte) *TxSetImpl {
 }
 
 func (ts *TxSetImpl) ID() consensus.TxSetID {
-	if ts.txMap == nil {
-		return consensus.TxSetID{}
-	}
 	h, err := ts.txMap.Hash()
 	if err != nil {
 		return consensus.TxSetID{}
@@ -56,9 +58,6 @@ func (ts *TxSetImpl) ID() consensus.TxSetID {
 // Txs returns every transaction blob in canonical key order. The
 // ordering matches TxIDs() so callers can zip the two slices.
 func (ts *TxSetImpl) Txs() [][]byte {
-	if ts.txMap == nil {
-		return nil
-	}
 	result := make([][]byte, 0, ts.count)
 	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
 		result = append(result, it.Data())
@@ -69,9 +68,6 @@ func (ts *TxSetImpl) Txs() [][]byte {
 
 // TxIDs returns every txID in canonical key order, parallel to Txs().
 func (ts *TxSetImpl) TxIDs() []consensus.TxID {
-	if ts.txMap == nil {
-		return nil
-	}
 	result := make([]consensus.TxID, 0, ts.count)
 	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
 		key := it.Key()
@@ -82,38 +78,27 @@ func (ts *TxSetImpl) TxIDs() []consensus.TxID {
 }
 
 func (ts *TxSetImpl) Contains(id consensus.TxID) bool {
-	if ts.txMap == nil {
-		return false
-	}
 	ok, err := ts.txMap.Has([32]byte(id))
 	return err == nil && ok
 }
 
+// Add inserts a transaction blob into the set. Mirrors rippled's
+// RCLTxSet::MutableTxSet::insert which uses tnTRANSACTION_NM only
+// (RCLCxTx.h:90) — there is no untyped fallback.
 func (ts *TxSetImpl) Add(tx []byte) error {
-	if ts.txMap == nil {
-		return nil
-	}
 	txID := computeTxID(tx)
 	key := [32]byte(txID)
 	if ok, _ := ts.txMap.Has(key); ok {
 		return nil
 	}
-	// Prefer the typed leaf path; fall back to the untyped Put for
-	// callers that work around CreateLeafNode failures on short
-	// fixture blobs.
 	if err := ts.txMap.PutWithNodeType(key, tx, shamap.NodeTypeTransactionNoMeta); err != nil {
-		if err2 := ts.txMap.Put(key, tx); err2 != nil {
-			return err2
-		}
+		return err
 	}
 	ts.count++
 	return nil
 }
 
 func (ts *TxSetImpl) Remove(id consensus.TxID) error {
-	if ts.txMap == nil {
-		return nil
-	}
 	key := [32]byte(id)
 	ok, _ := ts.txMap.Has(key)
 	if !ok {
@@ -133,9 +118,6 @@ func (ts *TxSetImpl) Size() int {
 // Bytes returns the tx blobs concatenated with a 4-byte length prefix
 // each, walked in canonical SHAMap key order.
 func (ts *TxSetImpl) Bytes() []byte {
-	if ts.txMap == nil {
-		return nil
-	}
 	var buf bytes.Buffer
 	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
 		blob := it.DataUnsafe()

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -24,13 +24,14 @@ import (
 //     The two methods walk identically, so callers can zip them.
 //   - Bytes:               O(N) walk.
 //
-// SHAMap errors. The shamap package only returns errors when the map is
-// in StateInvalid (a corrupted/poisoned state we never put it into
-// here) — Has/Hash/Delete are otherwise infallible. We treat any error
-// as "set is broken, fail open": Contains returns false, ID returns the
-// zero hash. The zero hash collides with the canonical hash of the
-// empty SHAMap, which is acceptable because reaching StateInvalid is a
-// programmer-error path that rippled covers with XRPL_ASSERT.
+// SHAMap errors. For an unbacked SHAMap that stays in StateModifying —
+// which is how we use it here — the only error source on Has/Hash is
+// StateInvalid, which TxSetImpl never enters. (Backed maps additionally
+// propagate I/O errors from descend(); mutators reject StateImmutable
+// and StateSyncing.) Contains treats any such error as "fail open"
+// (false); ID treats it as the zero hash, which collides with the
+// canonical hash of the empty SHAMap. Reaching that path is a
+// programmer-error condition that rippled covers with XRPL_ASSERT.
 //
 // Aliasing. SHAMap() exposes the live backing map. Add and Remove
 // mutate it in place — there is no copy-on-write. Callers that hold a
@@ -40,23 +41,36 @@ import (
 // avoids this by snapshotting on every MutableTxSet round-trip
 // (RCLCxTx.h:78,119); replicating that would require SHAMap COW which
 // we do not yet support.
+//
+// Concurrency. The backing *shamap.SHAMap is internally lock-protected,
+// but TxSetImpl maintains a shadow `count` field for O(1) Size(); the
+// mutex below brackets count mutations against Size() reads. Rippled
+// has no parallel counter (RCLTxSet exposes no size method at all —
+// RCLCxTx.h:62-189); the divergence exists because our consensus
+// engine logs and gates on tx counts from hot paths, so we pay the
+// extra field rather than walk the tree.
 type TxSetImpl struct {
 	txMap *shamap.SHAMap
+	mu    sync.Mutex
 	count int
 }
 
 // NewTxSet creates a TxSet from raw transaction blobs. The ID is the
 // SHAMap root hash, matching rippled's canonical tx-set hashing.
 //
-// Returns an error if any blob is rejected by the backing SHAMap
-// (e.g. < 12 bytes — see shamap/leaf_node.go). Rippled never silently
-// shrinks a tx-set during construction (RCLCxTx.h:87-91), and a
-// truncated set would compute the wrong root hash and break consensus.
+// Returns an error if any blob is rejected by the backing SHAMap. The
+// only such gate today is the goxrpl-specific <12-byte rejection in
+// shamap/leaf_node.go's NewTransactionLeafNode (rippled's
+// SHAMap::addGiveItem has no size check — it validates blobs upstream
+// via STTx). Real transaction blobs are far larger than 12 bytes, so
+// this branch is unreachable in production; we surface it as an error
+// rather than silently dropping the blob because a truncated set
+// computes the wrong root hash and would break consensus.
 //
-// Panics if the backing SHAMap cannot even be constructed — mirrors
-// rippled's XRPL_ASSERT(map_) in RCLTxSet (RCLCxTx.h:111). A nil
-// tx-set is unrecoverable; consensus would silently no-op on every
-// subsequent Add/Contains/ID call.
+// Panics if shamap.New itself fails. shamap.New(TypeTransaction) is
+// unconditional today (shamap/shamap.go:82-93), so the panic is
+// unreachable — it exists as a Go-idiomatic assertion against future
+// shamap changes that might grow an error return.
 func NewTxSet(txBlobs [][]byte) (*TxSetImpl, error) {
 	txMap, err := shamap.New(shamap.TypeTransaction)
 	if err != nil {
@@ -113,38 +127,57 @@ func (ts *TxSetImpl) Contains(id consensus.TxID) bool {
 // RCLTxSet::MutableTxSet::insert which uses tnTRANSACTION_NM only
 // (RCLCxTx.h:90) — there is no untyped fallback.
 //
+// Has errors are propagated (unlike Contains, which fails open) — the
+// mutation path is where SHAMap state transitions surface, and a
+// surprised Has on a corrupted root is more useful as a diagnostic
+// than as a silent fall-through into PutWithNodeType.
+//
 // Invalidates any pointer previously returned by SHAMap(): the
 // underlying tree is mutated in place. See the TxSetImpl doc comment
 // for the aliasing contract.
 func (ts *TxSetImpl) Add(tx []byte) error {
 	txID := computeTxID(tx)
 	key := [32]byte(txID)
-	if ok, _ := ts.txMap.Has(key); ok {
+	ok, err := ts.txMap.Has(key)
+	if err != nil {
+		return err
+	}
+	if ok {
 		return nil
 	}
 	if err := ts.txMap.PutWithNodeType(key, tx, shamap.NodeTypeTransactionNoMeta); err != nil {
 		return err
 	}
+	ts.mu.Lock()
 	ts.count++
+	ts.mu.Unlock()
 	return nil
 }
 
-// Remove deletes a transaction by ID. Invalidates any pointer
-// previously returned by SHAMap(); see the TxSetImpl doc comment.
+// Remove deletes a transaction by ID. Propagates Has errors for the
+// same reason Add does. Invalidates any pointer previously returned
+// by SHAMap(); see the TxSetImpl doc comment.
 func (ts *TxSetImpl) Remove(id consensus.TxID) error {
 	key := [32]byte(id)
-	ok, _ := ts.txMap.Has(key)
+	ok, err := ts.txMap.Has(key)
+	if err != nil {
+		return err
+	}
 	if !ok {
 		return nil
 	}
 	if err := ts.txMap.Delete(key); err != nil {
 		return err
 	}
+	ts.mu.Lock()
 	ts.count--
+	ts.mu.Unlock()
 	return nil
 }
 
 func (ts *TxSetImpl) Size() int {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
 	return ts.count
 }
 

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -58,23 +58,21 @@ type TxSetImpl struct {
 // NewTxSet creates a TxSet from raw transaction blobs. The ID is the
 // SHAMap root hash, matching rippled's canonical tx-set hashing.
 //
-// Returns an error if any blob is rejected by the backing SHAMap. The
-// only such gate today is the goxrpl-specific <12-byte rejection in
-// shamap/leaf_node.go's NewTransactionLeafNode (rippled's
-// SHAMap::addGiveItem has no size check — it validates blobs upstream
-// via STTx). Real transaction blobs are far larger than 12 bytes, so
-// this branch is unreachable in production; we surface it as an error
-// rather than silently dropping the blob because a truncated set
-// computes the wrong root hash and would break consensus.
-//
-// Panics if shamap.New itself fails. shamap.New(TypeTransaction) is
-// unconditional today (shamap/shamap.go:82-93), so the panic is
-// unreachable — it exists as a Go-idiomatic assertion against future
-// shamap changes that might grow an error return.
+// Returns an error if shamap.New fails or any blob is rejected by the
+// backing SHAMap. Neither path is reachable today —
+// shamap.New(TypeTransaction) is unconditional (shamap/shamap.go:82-93)
+// and the only blob gate is the goxrpl-specific <12-byte rejection in
+// shamap/leaf_node.go (rippled's SHAMap::addGiveItem has no size
+// check; it validates blobs upstream via STTx). Real transaction
+// blobs are far larger than 12 bytes. We propagate both as errors
+// rather than panicking or silently dropping the blob: a truncated
+// set computes the wrong root hash and would break consensus, and
+// keeping a single error-return contract (no mixed panic/error) means
+// callers who already check err do not have to also wrap recover().
 func NewTxSet(txBlobs [][]byte) (*TxSetImpl, error) {
 	txMap, err := shamap.New(shamap.TypeTransaction)
 	if err != nil {
-		panic(fmt.Errorf("NewTxSet: shamap.New(TypeTransaction): %w", err))
+		return nil, fmt.Errorf("NewTxSet: shamap.New(TypeTransaction): %w", err)
 	}
 	ts := &TxSetImpl{txMap: txMap}
 	for i, blob := range txBlobs {

--- a/internal/consensus/adaptor/txset_test.go
+++ b/internal/consensus/adaptor/txset_test.go
@@ -22,8 +22,8 @@ func makeBlob(seed uint32) []byte {
 }
 
 // TestTxSet_TxsTxIDsZipped pins the contract that TxIDs[i]
-// corresponds to Txs[i] — the consensus dispute builder
-// (rcl/engine.go:813) zips the two slices.
+// corresponds to Txs[i] — the consensus dispute builder zips
+// the two slices.
 func TestTxSet_TxsTxIDsZipped(t *testing.T) {
 	blobs := make([][]byte, 32)
 	for i := range blobs {
@@ -194,11 +194,7 @@ func TestTxSet_BytesIsCanonical(t *testing.T) {
 }
 
 // BenchmarkTxSetAdd_Incremental measures the per-Add cost on
-// successively larger sets. With the SHAMap-canonical storage,
-// each Add does O(log N) work; the prior blob-slice
-// implementation rebuilt the SHAMap on every Add, giving O(N).
-//
-// Compare ns/op across the sub-benchmarks: with O(log N) Add the
+// successively larger sets. Each Add does O(log N) work, so
 // growth from N=128 → N=8192 should be ~6x (log2 of 64), not 64x.
 func BenchmarkTxSetAdd_Incremental(b *testing.B) {
 	for _, n := range []int{128, 512, 2048, 8192} {

--- a/internal/consensus/adaptor/txset_test.go
+++ b/internal/consensus/adaptor/txset_test.go
@@ -29,7 +29,8 @@ func TestTxSet_TxsTxIDsZipped(t *testing.T) {
 	for i := range blobs {
 		blobs[i] = makeBlob(uint32(i + 1))
 	}
-	ts := NewTxSet(blobs)
+	ts, err := NewTxSet(blobs)
+	require.NoError(t, err)
 
 	txs := ts.Txs()
 	ids := ts.TxIDs()
@@ -50,7 +51,8 @@ func TestTxSet_TxsCanonicalOrder(t *testing.T) {
 	for i := range blobs {
 		blobs[i] = makeBlob(uint32(i + 1))
 	}
-	ts := NewTxSet(blobs)
+	ts, err := NewTxSet(blobs)
+	require.NoError(t, err)
 
 	ids := ts.TxIDs()
 	for i := 1; i < len(ids); i++ {
@@ -74,12 +76,14 @@ func TestTxSet_IDStableAcrossInsertionOrder(t *testing.T) {
 		blobs[i] = makeBlob(uint32(i + 1))
 	}
 
-	forward := NewTxSet(blobs)
+	forward, err := NewTxSet(blobs)
+	require.NoError(t, err)
 	reversed := make([][]byte, len(blobs))
 	for i, b := range blobs {
 		reversed[len(blobs)-1-i] = b
 	}
-	backward := NewTxSet(reversed)
+	backward, err := NewTxSet(reversed)
+	require.NoError(t, err)
 
 	assert.Equal(t, forward.ID(), backward.ID(),
 		"tx-set ID must be insertion-order independent")
@@ -92,7 +96,8 @@ func TestTxSet_IDChangesOnMutation(t *testing.T) {
 	blob1 := makeBlob(1)
 	blob2 := makeBlob(2)
 
-	ts := NewTxSet([][]byte{blob1})
+	ts, err := NewTxSet([][]byte{blob1})
+	require.NoError(t, err)
 	id0 := ts.ID()
 	require.NotEqual(t, consensus.TxSetID{}, id0)
 
@@ -109,6 +114,20 @@ func TestTxSet_IDChangesOnMutation(t *testing.T) {
 		"Remove of a just-added tx must restore the prior ID")
 }
 
+// TestTxSet_RejectsInvalidBlobs pins that NewTxSet surfaces SHAMap
+// rejection (e.g. <12-byte transaction leaves) instead of silently
+// shrinking the set. Rippled never silently truncates a tx-set during
+// construction (RCLCxTx.h:87-91); a truncated set would compute the
+// wrong root hash and break consensus.
+func TestTxSet_RejectsInvalidBlobs(t *testing.T) {
+	good := makeBlob(1)
+	tooShort := []byte{0x01, 0x02, 0x03} // <12 bytes — rejected by NewTransactionLeafNode
+
+	ts, err := NewTxSet([][]byte{good, tooShort})
+	require.Error(t, err, "short blob must surface as a construction error")
+	assert.Nil(t, ts, "failed construction must not return a partial tx-set")
+}
+
 // TestTxSet_BytesIsCanonical pins that the Bytes() framing walks
 // leaves in canonical order so the serialized form is independent
 // of insertion order.
@@ -118,12 +137,16 @@ func TestTxSet_BytesIsCanonical(t *testing.T) {
 		blobs[i] = makeBlob(uint32(i + 1))
 	}
 
-	forward := NewTxSet(blobs).Bytes()
+	forwardTs, err := NewTxSet(blobs)
+	require.NoError(t, err)
+	forward := forwardTs.Bytes()
 	reversed := make([][]byte, len(blobs))
 	for i, b := range blobs {
 		reversed[len(blobs)-1-i] = b
 	}
-	backward := NewTxSet(reversed).Bytes()
+	backwardTs, err := NewTxSet(reversed)
+	require.NoError(t, err)
+	backward := backwardTs.Bytes()
 	assert.Equal(t, forward, backward,
 		"Bytes() output must be insertion-order independent")
 }
@@ -158,7 +181,10 @@ func BenchmarkTxSetAdd_Incremental(b *testing.B) {
 				// Add always lands on a set of size ~n. Otherwise the
 				// loop just grows N unbounded and the per-Add cost
 				// shifts as N doubles.
-				ts := NewTxSet(seed)
+				ts, err := NewTxSet(seed)
+				if err != nil {
+					b.Fatal(err)
+				}
 				b.StartTimer()
 				_ = ts.Add(adds[i])
 				b.StopTimer()

--- a/internal/consensus/adaptor/txset_test.go
+++ b/internal/consensus/adaptor/txset_test.go
@@ -1,0 +1,182 @@
+package adaptor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeBlob builds a deterministic >=12-byte tx blob from a seed —
+// SHAMap rejects shorter transaction leaves.
+func makeBlob(seed uint32) []byte {
+	b := make([]byte, 16)
+	binary.BigEndian.PutUint32(b, seed)
+	binary.BigEndian.PutUint32(b[4:], ^seed)
+	binary.BigEndian.PutUint32(b[8:], seed*2654435761) // Knuth mult — spreads txIDs across SHAMap branches
+	binary.BigEndian.PutUint32(b[12:], seed+0xA5A5A5A5)
+	return b
+}
+
+// TestTxSet_TxsTxIDsZipped pins the contract that TxIDs[i]
+// corresponds to Txs[i] — the consensus dispute builder
+// (rcl/engine.go:813) zips the two slices.
+func TestTxSet_TxsTxIDsZipped(t *testing.T) {
+	blobs := make([][]byte, 32)
+	for i := range blobs {
+		blobs[i] = makeBlob(uint32(i + 1))
+	}
+	ts := NewTxSet(blobs)
+
+	txs := ts.Txs()
+	ids := ts.TxIDs()
+	require.Equal(t, len(blobs), len(txs))
+	require.Equal(t, len(txs), len(ids))
+
+	for i, blob := range txs {
+		assert.Equal(t, computeTxID(blob), ids[i],
+			"TxIDs[%d] must be the hash of Txs[%d]", i, i)
+	}
+}
+
+// TestTxSet_TxsCanonicalOrder pins that the SHAMap-backed
+// storage walks leaves in canonical key order — Txs() return
+// order is the same across calls and is sorted by txID.
+func TestTxSet_TxsCanonicalOrder(t *testing.T) {
+	blobs := make([][]byte, 16)
+	for i := range blobs {
+		blobs[i] = makeBlob(uint32(i + 1))
+	}
+	ts := NewTxSet(blobs)
+
+	ids := ts.TxIDs()
+	for i := 1; i < len(ids); i++ {
+		prev, cur := ids[i-1], ids[i]
+		assert.Negative(t, bytes.Compare(prev[:], cur[:]),
+			"TxIDs must be in ascending key order; %x not < %x", prev, cur)
+	}
+
+	// Repeat the walk — order must be stable.
+	ids2 := ts.TxIDs()
+	assert.Equal(t, ids, ids2)
+}
+
+// TestTxSet_IDStableAcrossInsertionOrder pins that the tx-set
+// ID is a function of the set of blobs, not the insertion order.
+// This is the property rippled relies on for cross-validator
+// agreement on the proposed tx-set hash.
+func TestTxSet_IDStableAcrossInsertionOrder(t *testing.T) {
+	blobs := make([][]byte, 8)
+	for i := range blobs {
+		blobs[i] = makeBlob(uint32(i + 1))
+	}
+
+	forward := NewTxSet(blobs)
+	reversed := make([][]byte, len(blobs))
+	for i, b := range blobs {
+		reversed[len(blobs)-1-i] = b
+	}
+	backward := NewTxSet(reversed)
+
+	assert.Equal(t, forward.ID(), backward.ID(),
+		"tx-set ID must be insertion-order independent")
+}
+
+// TestTxSet_IDChangesOnMutation pins that ID() refreshes after
+// Add/Remove — the SHAMap's incremental dirty propagation must
+// have updated the root hash by the time ID() returns.
+func TestTxSet_IDChangesOnMutation(t *testing.T) {
+	blob1 := makeBlob(1)
+	blob2 := makeBlob(2)
+
+	ts := NewTxSet([][]byte{blob1})
+	id0 := ts.ID()
+	require.NotEqual(t, consensus.TxSetID{}, id0)
+
+	require.NoError(t, ts.Add(blob2))
+	id1 := ts.ID()
+	assert.NotEqual(t, id0, id1, "Add must change the tx-set ID")
+
+	// Adding the same blob a second time is a no-op.
+	require.NoError(t, ts.Add(blob2))
+	assert.Equal(t, id1, ts.ID(), "duplicate Add must not change ID")
+
+	require.NoError(t, ts.Remove(computeTxID(blob2)))
+	assert.Equal(t, id0, ts.ID(),
+		"Remove of a just-added tx must restore the prior ID")
+}
+
+// TestTxSet_BytesIsCanonical pins that the Bytes() framing walks
+// leaves in canonical order so the serialized form is independent
+// of insertion order.
+func TestTxSet_BytesIsCanonical(t *testing.T) {
+	blobs := make([][]byte, 6)
+	for i := range blobs {
+		blobs[i] = makeBlob(uint32(i + 1))
+	}
+
+	forward := NewTxSet(blobs).Bytes()
+	reversed := make([][]byte, len(blobs))
+	for i, b := range blobs {
+		reversed[len(blobs)-1-i] = b
+	}
+	backward := NewTxSet(reversed).Bytes()
+	assert.Equal(t, forward, backward,
+		"Bytes() output must be insertion-order independent")
+}
+
+// BenchmarkTxSetAdd_Incremental measures the per-Add cost on
+// successively larger sets. With the SHAMap-canonical storage,
+// each Add does O(log N) work; the prior blob-slice
+// implementation rebuilt the SHAMap on every Add, giving O(N).
+//
+// Compare ns/op across the sub-benchmarks: with O(log N) Add the
+// growth from N=128 → N=8192 should be ~6x (log2 of 64), not 64x.
+func BenchmarkTxSetAdd_Incremental(b *testing.B) {
+	for _, n := range []int{128, 512, 2048, 8192} {
+		b.Run(sizeLabel(n), func(b *testing.B) {
+			// Pre-seed the set so each timed Add lands at depth ~log2(n).
+			seed := make([][]byte, n)
+			for i := range seed {
+				seed[i] = makeBlob(uint32(i + 1))
+			}
+
+			// Pre-build the candidate blobs the timed loop will Add.
+			adds := make([][]byte, b.N)
+			for i := 0; i < b.N; i++ {
+				adds[i] = makeBlob(uint32(n + i + 1))
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.StopTimer()
+			for i := 0; i < b.N; i++ {
+				// Re-seed a fresh tx-set every iteration so the timed
+				// Add always lands on a set of size ~n. Otherwise the
+				// loop just grows N unbounded and the per-Add cost
+				// shifts as N doubles.
+				ts := NewTxSet(seed)
+				b.StartTimer()
+				_ = ts.Add(adds[i])
+				b.StopTimer()
+			}
+		})
+	}
+}
+
+func sizeLabel(n int) string {
+	switch n {
+	case 128:
+		return "N=128"
+	case 512:
+		return "N=512"
+	case 2048:
+		return "N=2048"
+	case 8192:
+		return "N=8192"
+	}
+	return "N=?"
+}

--- a/internal/consensus/adaptor/txset_test.go
+++ b/internal/consensus/adaptor/txset_test.go
@@ -128,6 +128,48 @@ func TestTxSet_RejectsInvalidBlobs(t *testing.T) {
 	assert.Nil(t, ts, "failed construction must not return a partial tx-set")
 }
 
+// TestTxSet_ConcurrentSizeReader pins that Size() is safe to call
+// while a single writer goroutine drives Add/Remove. The shadow
+// `count` field is shielded by an internal mutex; without it the
+// race detector would flag the increment vs. read. Run with
+// `go test -race`.
+func TestTxSet_ConcurrentSizeReader(t *testing.T) {
+	const ops = 200
+	blobs := make([][]byte, ops)
+	for i := range blobs {
+		blobs[i] = makeBlob(uint32(i + 1))
+	}
+
+	ts, err := NewTxSet(nil)
+	require.NoError(t, err)
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = ts.Size()
+			}
+		}
+	}()
+
+	for _, blob := range blobs {
+		require.NoError(t, ts.Add(blob))
+	}
+	for i := 0; i < ops/2; i++ {
+		require.NoError(t, ts.Remove(computeTxID(blobs[i])))
+	}
+	close(stop)
+	<-done
+
+	assert.Equal(t, ops-ops/2, ts.Size())
+}
+
 // TestTxSet_BytesIsCanonical pins that the Bytes() framing walks
 // leaves in canonical order so the serialized form is independent
 // of insertion order.


### PR DESCRIPTION
## Summary

Mirror rippled's `InboundTransactions`: replace the `[][]byte` + index-map storage in `TxSetImpl` with a SHAMap as the canonical store. `Txs/TxIDs/Bytes/Contains` derive from it, and the serve path walks the stored map directly instead of rebuilding it.

| Op | before | after |
|---|---|---|
| Add / Remove / Contains | O(N) full SHAMap rebuild per mutation | O(log N) descent + incremental hash propagation |
| ID() | O(N) rebuild on every call | O(1) — SHAMap caches the root hash |
| Txs / TxIDs | O(N) slice copy (insertion order) | O(N) leaf walk (canonical key order) |
| serveTxSet | O(N) rebuild + walk | O(N) walk only |

Add benchmark (M3 Pro): `N=128 ~12µs`, `N=512 ~11µs`, `N=2048 ~13µs`, `N=8192 ~27µs` — ~2.3× growth across a 64× set size, consistent with O(log N) (vs. the prior 64× under O(N)).

Order-change: `Txs/TxIDs` now walk in canonical key order rather than insertion order. `AcceptConsensusResult` re-applies `canonicalSort` and the RCL dispute builder zips `TxIDs[i]` with `Txs[i]`, so the contract holds; pinned by new tests in `txset_test.go`.

`BuildSHAMap` is replaced by `SHAMap()` since there is nothing to rebuild — both callers (`serveTxSet`, `router_txset_partial_test.go`) are updated.

Closes #406.

## Test plan

- [x] `go test ./internal/consensus/...` — all green
- [x] `go test ./internal/tx/... ./internal/ledger/... ./internal/txq/...` — all green
- [x] `go test ./internal/rpc/... ./internal/peermanagement/...` — all green
- [x] `go test ./internal/testing/...` — only pre-existing failure (`batch/TestObjectsOpenLedger/create_object_before_batch_txn`) carried over from main; confirmed identical failure on `main` before the change
- [x] `BenchmarkTxSetAdd_Incremental` validates O(log N) Add scaling
- [x] New behavior-pinning tests: parallel `Txs`/`TxIDs` zipping, canonical key order, ID stability across insertion order, ID transitions on Add/Remove