### PR TITLE
Client-side SkipListAcquire + LedgerReplayTask (closes #271)

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -76,14 +76,10 @@ type NetworkSender interface {
 	RequestLedgerByHashAndSeq(hash [32]byte, seq uint32) error
 	RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte, seq uint32) error
 	RequestReplayDelta(peerID uint64, hash [32]byte) error
-	// RequestProofPath sends a TMProofPathRequest to peerID asking for
-	// the merkle proof of (key, mapType) in the SHAMap of ledgerHash.
-	// Mirrors rippled's SkipListAcquire::trigger
-	// (rippled/src/xrpld/app/ledger/detail/SkipListAcquire.cpp:84-92):
-	// the client-side analog of the handler already wired at
-	// LedgerProvider.GetProofPath. Used by the multi-ledger catchup
-	// path to fetch the rolling-256 LedgerHashes entry of a known tip
-	// in a single round-trip.
+	// RequestProofPath sends a TMProofPathRequest for the merkle proof
+	// of (key, mapType) in the SHAMap of ledgerHash. Mirrors rippled's
+	// SkipListAcquire::trigger
+	// (rippled/src/xrpld/app/ledger/detail/SkipListAcquire.cpp:84-92).
 	RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mapType message.LedgerMapType) error
 	RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error
 	SendToPeer(peerID uint64, frame []byte) error
@@ -493,10 +489,6 @@ func (a *Adaptor) RequestReplayDelta(peerID uint64, hash [32]byte) error {
 	return a.sender.RequestReplayDelta(peerID, hash)
 }
 
-// RequestProofPath delegates to the network sender. Used by the
-// multi-ledger catch-up path to fetch a tip's rolling-256
-// LedgerHashes entry via merkle proof — one round-trip yields up to
-// 256 ancestor hashes.
 func (a *Adaptor) RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mapType message.LedgerMapType) error {
 	return a.sender.RequestProofPath(peerID, ledgerHash, key, mapType)
 }

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -76,6 +76,15 @@ type NetworkSender interface {
 	RequestLedgerByHashAndSeq(hash [32]byte, seq uint32) error
 	RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte, seq uint32) error
 	RequestReplayDelta(peerID uint64, hash [32]byte) error
+	// RequestProofPath sends a TMProofPathRequest to peerID asking for
+	// the merkle proof of (key, mapType) in the SHAMap of ledgerHash.
+	// Mirrors rippled's SkipListAcquire::trigger
+	// (rippled/src/xrpld/app/ledger/detail/SkipListAcquire.cpp:84-92):
+	// the client-side analog of the handler already wired at
+	// LedgerProvider.GetProofPath. Used by the multi-ledger catchup
+	// path to fetch the rolling-256 LedgerHashes entry of a known tip
+	// in a single round-trip.
+	RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mapType message.LedgerMapType) error
 	RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error
 	SendToPeer(peerID uint64, frame []byte) error
 	// PeerSupportsReplay reports whether the peer identified by peerID
@@ -125,7 +134,10 @@ func (n *noopSender) RequestLedger(consensus.LedgerID) error                   {
 func (n *noopSender) RequestLedgerByHashAndSeq([32]byte, uint32) error         { return nil }
 func (n *noopSender) RequestLedgerBaseFromPeer(uint64, [32]byte, uint32) error { return nil }
 func (n *noopSender) RequestReplayDelta(uint64, [32]byte) error                { return nil }
-func (n *noopSender) RequestStateNodes(uint64, [32]byte, [][]byte) error       { return nil }
+func (n *noopSender) RequestProofPath(uint64, [32]byte, [32]byte, message.LedgerMapType) error {
+	return nil
+}
+func (n *noopSender) RequestStateNodes(uint64, [32]byte, [][]byte) error { return nil }
 func (n *noopSender) SendToPeer(uint64, []byte) error                          { return nil }
 func (n *noopSender) PeerSupportsReplay(uint64) bool                           { return false }
 func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64       { return nil }
@@ -479,6 +491,14 @@ func (a *Adaptor) RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte, seq ui
 // TMReplayDeltaRequest and awaits one TMReplayDeltaResponse.
 func (a *Adaptor) RequestReplayDelta(peerID uint64, hash [32]byte) error {
 	return a.sender.RequestReplayDelta(peerID, hash)
+}
+
+// RequestProofPath delegates to the network sender. Used by the
+// multi-ledger catch-up path to fetch a tip's rolling-256
+// LedgerHashes entry via merkle proof — one round-trip yields up to
+// 256 ancestor hashes.
+func (a *Adaptor) RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mapType message.LedgerMapType) error {
+	return a.sender.RequestProofPath(peerID, ledgerHash, key, mapType)
 }
 
 func (a *Adaptor) RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -536,10 +536,14 @@ func (a *Adaptor) IncPeerBadData(peerID uint64, reason string) {
 	a.sender.IncPeerBadData(peerID, reason)
 }
 
-// GetParentLedgerForReplay returns the validated ledger at seq-1, which is
+// GetParentLedgerForReplay returns the closed ledger at seq-1, which is
 // the prior ledger needed to replay a delta into seq. Returns nil if the
-// parent is unknown or the request is for a ledger we cannot anchor on
-// (seq <= 1, no service wired). Mirrors the rippled
+// parent is unknown, the request is for a ledger we cannot anchor on
+// (seq <= 1, no service wired), OR the parent is still open (its hash
+// is unset until Close, so it cannot serve as a chain anchor — a
+// goxrpl-1 enclave run reproduced a live-lock where the open ledger
+// was returned and the replay-delta verifier kept rejecting valid
+// responses against an all-zero parent hash). Mirrors the rippled
 // LedgerDeltaAcquire::trigger requirement that the parent ledger is
 // already locally available before issuing the delta request.
 func (a *Adaptor) GetParentLedgerForReplay(seq uint32) *ledger.Ledger {
@@ -548,6 +552,9 @@ func (a *Adaptor) GetParentLedgerForReplay(seq uint32) *ledger.Ledger {
 	}
 	parent, err := a.ledgerService.GetLedgerBySequence(seq - 1)
 	if err != nil || parent == nil {
+		return nil
+	}
+	if !parent.IsClosed() {
 		return nil
 	}
 	return parent

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -458,3 +458,35 @@ func TestAdaptor_OnLedgerFullyValidated_HashMismatchIsNoop(t *testing.T) {
 	assert.Equal(t, priorValidated.Hash(), after.Hash(),
 		"validated_ledger must not flip to a hash we don't hold")
 }
+
+// TestGetParentLedgerForReplay_RejectsOpenLedger guards against the
+// replay-delta live-lock that bit goxrpl-1 in the consensus enclave.
+// When LCL is at seq N-1 and openLedger is at seq N, asking for the
+// parent of seq N+1 must NOT return openLedger — openLedger has
+// header.Hash == [32]byte{} until Close(), so callers using the
+// returned ledger's hash as a chain anchor (the replay-delta
+// verifier in particular) would receive 0x000...
+func TestGetParentLedgerForReplay_RejectsOpenLedger(t *testing.T) {
+	a := newTestAdaptor(t)
+	svc := a.LedgerService()
+
+	// LCL is at the genesis seq after Start. Accept once so closedLedger
+	// is at seq 2 and openLedger advances to seq 3.
+	_, err := svc.AcceptLedger(context.TODO())
+	require.NoError(t, err)
+	closedSeq := svc.GetClosedLedgerIndex()
+	openSeq := svc.GetCurrentLedgerIndex()
+	require.Equal(t, closedSeq+1, openSeq,
+		"openLedger should be one above LCL")
+
+	// Asking for parent of openSeq+1 → parent should be at openSeq,
+	// which is the OPEN ledger. The fix returns nil instead of an
+	// unclosed ledger whose Hash() is zero.
+	parent := a.GetParentLedgerForReplay(openSeq + 1)
+	if parent != nil {
+		assert.NotEqual(t, [32]byte{}, parent.Hash(),
+			"parent returned for replay must have a non-zero hash; "+
+				"openLedger has zero Hash until Close() and is unsafe "+
+				"to use as a chain anchor")
+	}
+}

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -1391,12 +1391,9 @@ func (r *Router) handleReplayDeltaResponse(msg *peermanagement.InboundMessage) {
 		return
 	}
 
-	// Phase 5: if a LedgerReplayTask owns this hash, the task drives
-	// verification + chain-ordered Apply + adopt via its own
-	// callbacks. The legacy single-ledger path below is bypassed.
-	// Mirrors rippled's LedgerReplayer routing: a delta acquired by a
-	// LedgerReplayTask is owned by that task and never re-enters the
-	// generic InboundLedger flow.
+	// A delta acquired by an active LedgerReplayTask is owned by that
+	// task and never re-enters the generic InboundLedger flow. Mirrors
+	// rippled's LedgerReplayer routing.
 	if r.routeDeltaToActiveTask(resp) {
 		return
 	}

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -109,6 +109,14 @@ type Router struct {
 	// complete and leaves are handed to engine.OnTxSet.
 	txSetAcquireMu sync.Mutex
 	txSetAcquire   map[consensus.TxSetID]*txSetAcquireState
+
+	// activeTask, when non-nil, is the LedgerReplayTask currently
+	// driving a multi-ledger backward catch-up. Single-task design:
+	// deep catch-up is a one-shot operation, and serializing the
+	// task entry point avoids the rippled-style MAX_TASKS bookkeeping
+	// for now. Guarded by replayTaskMu.
+	replayTaskMu sync.Mutex
+	activeTask   *activeReplayTask
 }
 
 type txSetAcquireState struct {
@@ -321,6 +329,8 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 		r.handleLedgerData(msg)
 	case message.TypeReplayDeltaResponse:
 		r.handleReplayDeltaResponse(msg)
+	case message.TypeProofPathResponse:
+		r.handleProofPathResponse(msg)
 	case message.TypeManifests:
 		r.handleManifests(msg)
 	default:
@@ -1378,6 +1388,16 @@ func (r *Router) handleReplayDeltaResponse(msg *peermanagement.InboundMessage) {
 	}
 	resp, ok := decoded.(*message.ReplayDeltaResponse)
 	if !ok || resp == nil {
+		return
+	}
+
+	// Phase 5: if a LedgerReplayTask owns this hash, the task drives
+	// verification + chain-ordered Apply + adopt via its own
+	// callbacks. The legacy single-ledger path below is bypassed.
+	// Mirrors rippled's LedgerReplayer routing: a delta acquired by a
+	// LedgerReplayTask is owned by that task and never re-enters the
+	// generic InboundLedger flow.
+	if r.routeDeltaToActiveTask(resp) {
 		return
 	}
 

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -290,6 +290,20 @@ func (r *Router) maintenanceTick() {
 		r.startLedgerAcquisitionLegacy(entry.Seq, entry.Hash, entry.PeerID)
 	}
 
+	// Reap an in-flight skip-list whose outer budget expired. The
+	// router holds exactly one active task at a time; aborting it
+	// frees the slot for the next StartReplayTask. Without this a
+	// silent peer wedges the activeTask gate indefinitely.
+	if timedOut := r.replayer.SkipListTimedOut(); len(timedOut) > 0 {
+		r.logger.Warn("skip-list acquisition timed out; aborting replay task",
+			"count", len(timedOut),
+		)
+		for _, h := range timedOut {
+			r.replayer.AbandonSkipList(h)
+		}
+		r.AbortActiveReplayTask(errors.New("skip-list timed out"))
+	}
+
 	// Reap a stuck legacy inbound ledger. Without this a single stalled
 	// acquisition blocks startLedgerAcquisitionLegacy from arming a new
 	// request for the SAME hash on the next statusChange — and blocks

--- a/internal/consensus/adaptor/router_replay_task.go
+++ b/internal/consensus/adaptor/router_replay_task.go
@@ -1,0 +1,408 @@
+package adaptor
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/inbound"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+)
+
+// multiLedgerCatchupThreshold is the gap (peerSeq - ourSeq) above
+// which checkBehind switches from the single-ledger forward
+// acquisition path to a LedgerReplayTask backward walk. A gap of 4 is
+// the rough breakeven point: below that, sequential single-acquisition
+// rounds complete before a proof-path round-trip would amortize; above
+// it, the per-ledger gossip wait dominates. Tuned conservatively — a
+// higher threshold avoids spinning up the task machinery for
+// transient near-tip lag.
+const multiLedgerCatchupThreshold = uint32(4)
+
+// activeReplayTask bundles the in-flight LedgerReplayTask with the
+// state the router needs to route inbound responses and drive chain-
+// order adoption as each subtask verifies. Held under r.replayTaskMu.
+type activeReplayTask struct {
+	task *inbound.LedgerReplayTask
+
+	// chainHashes is the set of hashes the task owns. handleReplayDelta
+	// Response consults this to decide between the task's
+	// OnDeltaResponse path and the single-ledger Apply+adopt path.
+	// Includes the tip hash so the tip's own delta routes to the task.
+	chainHashes map[[32]byte]bool
+
+	// anchorParent is the local ledger at seq tipSeq-depth (the bottom
+	// of the chain). Used as the parent of the OLDEST chain entry's
+	// Apply call. Subsequent entries use the previously-adopted ledger
+	// as parent.
+	anchorParent *ledger.Ledger
+
+	// pendingByHash holds verified-but-not-yet-applied ReplayDeltas
+	// keyed by ledger hash. Drained in chain order by drainPending
+	// once each predecessor adopts.
+	pendingByHash map[[32]byte]*inbound.ReplayDelta
+
+	// adopted tracks ledger hashes whose Apply+adopt completed. Used
+	// to find the parent for the next pending entry quickly without
+	// re-querying the service.
+	adopted map[[32]byte]*ledger.Ledger
+
+	// nextSeqToAdopt is the sequence of the next chain entry that
+	// drainPending should attempt. Equals tipSeq-depth+1 initially
+	// (oldest), increments by 1 on each successful adoption.
+	nextSeqToAdopt uint32
+
+	// chainSeqByHash / chainHashBySeq are inverse lookups built once
+	// when the task transitions out of WantSkipList. Pre-built so
+	// drainPending can pluck the next-by-seq without scanning.
+	chainSeqByHash  map[[32]byte]uint32
+	chainHashBySeq  map[uint32][32]byte
+}
+
+// StartReplayTask arms a LedgerReplayTask for a multi-ledger backward
+// walk from `tipHash` (at `tipSeq`, with the tip's `stateHash` =
+// AccountHash) back `depth` ledgers, anchored on the local ledger
+// `anchorParent` at seq tipSeq-depth. Returns an error if a task is
+// already in flight or the underlying replayer rejects acquisition.
+//
+// peers is the rotation set the task will round-robin through when
+// the per-peer Replayer cap is reached.
+//
+// Exposed as a callable entry point (not driven by checkBehind today)
+// so the router-level integration can be exercised end-to-end before
+// the auto-trigger path is wired. Production auto-trigger requires
+// either a pre-acquired tip header (so stateHash is known) or an
+// extension to TMStatusChange so peers gossip AccountHash; both are
+// follow-up work.
+func (r *Router) StartReplayTask(
+	tipHash, stateHash [32]byte,
+	tipSeq, depth uint32,
+	anchorParent *ledger.Ledger,
+	peers []uint64,
+) error {
+	if anchorParent == nil {
+		return errors.New("StartReplayTask: anchorParent must be non-nil")
+	}
+	if anchorParent.Sequence() != tipSeq-depth {
+		return fmt.Errorf("StartReplayTask: anchorParent.Sequence()=%d, want tipSeq-depth=%d",
+			anchorParent.Sequence(), tipSeq-depth)
+	}
+
+	r.replayTaskMu.Lock()
+	if r.activeTask != nil {
+		r.replayTaskMu.Unlock()
+		return errors.New("StartReplayTask: a task is already in flight")
+	}
+
+	state := &activeReplayTask{
+		chainHashes:     make(map[[32]byte]bool),
+		anchorParent:    anchorParent,
+		pendingByHash:   make(map[[32]byte]*inbound.ReplayDelta),
+		adopted:         make(map[[32]byte]*ledger.Ledger),
+		nextSeqToAdopt:  tipSeq - depth + 1,
+		chainSeqByHash:  make(map[[32]byte]uint32),
+		chainHashBySeq:  make(map[uint32][32]byte),
+	}
+	// Seed the anchor into adopted so the oldest chain entry can find
+	// its parent via the same map lookup as later entries.
+	state.adopted[anchorParent.Hash()] = anchorParent
+
+	cb := inbound.TaskCallbacks{
+		OnDeltaVerified: func(seq uint32, h [32]byte, rd *inbound.ReplayDelta) {
+			r.onTaskDeltaVerified(seq, h, rd)
+		},
+		OnComplete: func() {
+			r.onTaskComplete()
+		},
+	}
+
+	task, err := inbound.NewLedgerReplayTask(
+		tipHash, stateHash, tipSeq, depth,
+		peers,
+		r.replayer,
+		taskSenderAdapter{adaptor: r.adaptor},
+		r.logger,
+		cb,
+	)
+	if err != nil {
+		r.replayTaskMu.Unlock()
+		return fmt.Errorf("new replay task: %w", err)
+	}
+	state.task = task
+	r.activeTask = state
+	r.replayTaskMu.Unlock()
+
+	if err := task.Start(); err != nil {
+		r.replayTaskMu.Lock()
+		r.activeTask = nil
+		r.replayTaskMu.Unlock()
+		return fmt.Errorf("start replay task: %w", err)
+	}
+	anchorHash := anchorParent.Hash()
+	r.logger.Info("replay task armed",
+		"tip_seq", tipSeq,
+		"tip_hash", fmt.Sprintf("%x", tipHash[:8]),
+		"depth", depth,
+		"anchor_seq", anchorParent.Sequence(),
+		"anchor_hash", fmt.Sprintf("%x", anchorHash[:8]),
+	)
+	return nil
+}
+
+// HasActiveReplayTask reports whether a LedgerReplayTask is currently
+// in flight. Exposed for tests and for checkBehind's dedup so the
+// auto-trigger path (once wired) doesn't double-arm.
+func (r *Router) HasActiveReplayTask() bool {
+	r.replayTaskMu.Lock()
+	defer r.replayTaskMu.Unlock()
+	return r.activeTask != nil
+}
+
+// AbortActiveReplayTask cancels the in-flight task and clears the
+// registry. Safe to call when no task is in flight.
+func (r *Router) AbortActiveReplayTask(reason error) {
+	r.replayTaskMu.Lock()
+	at := r.activeTask
+	r.activeTask = nil
+	r.replayTaskMu.Unlock()
+	if at != nil && at.task != nil {
+		at.task.Abort(reason)
+	}
+}
+
+// handleProofPathResponse is the router-side dispatch for inbound
+// mtPROOF_PATH_RESPONSE frames. Decodes, routes to the active task's
+// OnSkipListResponse, then populates the chain-hash lookup tables so
+// subsequent replay-delta responses are routed correctly.
+func (r *Router) handleProofPathResponse(msg *peermanagement.InboundMessage) {
+	decoded, err := message.Decode(message.TypeProofPathResponse, msg.Payload)
+	if err != nil {
+		r.logger.Debug("failed to decode proof path response", "error", err, "peer", msg.PeerID)
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "proof-path-resp-decode")
+		return
+	}
+	resp, ok := decoded.(*message.ProofPathResponse)
+	if !ok || resp == nil {
+		return
+	}
+
+	r.replayTaskMu.Lock()
+	at := r.activeTask
+	r.replayTaskMu.Unlock()
+	if at == nil {
+		// No task armed — stale or unsolicited. Drop silently.
+		r.logger.Debug("proof path response with no active task",
+			"peer", msg.PeerID)
+		return
+	}
+
+	if err := at.task.OnSkipListResponse(resp); err != nil {
+		r.logger.Warn("proof path verification failed; aborting replay task",
+			"error", err,
+			"peer", msg.PeerID,
+		)
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "proof-path-verify")
+		r.replayTaskMu.Lock()
+		r.activeTask = nil
+		r.replayTaskMu.Unlock()
+		return
+	}
+
+	// Populate chain-hash lookup so handleReplayDeltaResponse can
+	// route subsequent inbound replay-deltas to the task. The task
+	// just built its chain inside OnSkipListResponse, so ChainEntries
+	// is now authoritative.
+	r.replayTaskMu.Lock()
+	if r.activeTask == at {
+		seqs, hashes := at.task.ChainEntries()
+		for i, h := range hashes {
+			at.chainHashes[h] = true
+			at.chainSeqByHash[h] = seqs[i]
+			at.chainHashBySeq[seqs[i]] = h
+		}
+	}
+	r.replayTaskMu.Unlock()
+}
+
+// routeDeltaToActiveTask attempts to route a TMReplayDeltaResponse to
+// the in-flight LedgerReplayTask. Returns true if the response was
+// handled by the task (caller MUST skip the legacy single-ledger
+// Apply+adopt path), false if the response is not task-owned.
+//
+// The chain-hash set is populated authoritatively in
+// handleProofPathResponse right after the skip-list verifies, so the
+// lookup here is exact: hash present ⇒ task-owned, hash absent ⇒
+// route via the legacy path.
+func (r *Router) routeDeltaToActiveTask(resp *message.ReplayDeltaResponse) (handled bool) {
+	hash, ok := toHash32Local(resp.LedgerHash)
+	if !ok {
+		return false
+	}
+	r.replayTaskMu.Lock()
+	at := r.activeTask
+	owned := at != nil && at.chainHashes[hash]
+	r.replayTaskMu.Unlock()
+	if !owned {
+		return false
+	}
+
+	err := at.task.OnDeltaResponse(resp)
+	if err != nil {
+		r.logger.Warn("replay task: delta verification failed; aborting task",
+			"error", err,
+		)
+		r.replayTaskMu.Lock()
+		r.activeTask = nil
+		r.replayTaskMu.Unlock()
+	}
+	return true
+}
+
+// onTaskDeltaVerified is the task's OnDeltaVerified callback. Stashes
+// the verified ReplayDelta and drains the chain in oldest-first
+// order, applying each delta whose parent has already adopted.
+//
+// Runs WITHOUT the task lock (the task fires callbacks unlocked) but
+// must take r.replayTaskMu to read activeTask.
+func (r *Router) onTaskDeltaVerified(seq uint32, h [32]byte, rd *inbound.ReplayDelta) {
+	r.replayTaskMu.Lock()
+	at := r.activeTask
+	if at == nil {
+		r.replayTaskMu.Unlock()
+		return
+	}
+	at.pendingByHash[h] = rd
+	// Register chain mappings now that we know hash ↔ seq.
+	at.chainSeqByHash[h] = seq
+	at.chainHashBySeq[seq] = h
+	at.chainHashes[h] = true
+	r.replayTaskMu.Unlock()
+
+	r.drainTaskChain()
+}
+
+// drainTaskChain walks the pending verified deltas in chain order
+// (next expected seq first) and applies+adopts each one whose parent
+// has already been adopted. Stops at the first gap. Re-entrant via
+// the task's OnDeltaVerified callbacks, but the lock + nextSeqToAdopt
+// monotonic increment guarantee at most one drain runs at a time.
+func (r *Router) drainTaskChain() {
+	for {
+		r.replayTaskMu.Lock()
+		at := r.activeTask
+		if at == nil {
+			r.replayTaskMu.Unlock()
+			return
+		}
+		nextSeq := at.nextSeqToAdopt
+		nextHash, haveHash := at.chainHashBySeq[nextSeq]
+		if !haveHash {
+			r.replayTaskMu.Unlock()
+			return
+		}
+		rd, havePending := at.pendingByHash[nextHash]
+		if !havePending {
+			r.replayTaskMu.Unlock()
+			return
+		}
+		// Resolve the parent ledger from the adopted map. For the
+		// oldest entry the parent is the anchor (pre-seeded). For
+		// subsequent entries it's the predecessor we just adopted.
+		// Result() returns the verified *ledger.Ledger; its header
+		// carries the canonical ParentHash we link against.
+		verifiedLedger, resErr := rd.Result()
+		if resErr != nil || verifiedLedger == nil {
+			r.replayTaskMu.Unlock()
+			r.logger.Warn("replay task: Result() failed unexpectedly",
+				"seq", nextSeq, "err", resErr)
+			return
+		}
+		parentHash := verifiedLedger.Header().ParentHash
+		parent, haveParent := at.adopted[parentHash]
+		if !haveParent {
+			// Predecessor not adopted yet — wait.
+			r.replayTaskMu.Unlock()
+			return
+		}
+		delete(at.pendingByHash, nextHash)
+		at.nextSeqToAdopt++
+		r.replayTaskMu.Unlock()
+		anchorParent := parent
+
+		if err := rd.SetParent(anchorParent); err != nil {
+			r.logger.Error("replay task: SetParent refused",
+				"seq", nextSeq, "err", err)
+			r.AbortActiveReplayTask(err)
+			return
+		}
+		engineCfg := r.adaptor.EngineConfigForReplay(anchorParent)
+		derived, err := rd.Apply(engineCfg)
+		if err != nil {
+			r.logger.Error("replay task: Apply failed; aborting",
+				"seq", nextSeq,
+				"hash", fmt.Sprintf("%x", nextHash[:8]),
+				"err", err,
+			)
+			r.AbortActiveReplayTask(err)
+			return
+		}
+		if adoptErr := r.adoptVerifiedLedger(derived, rd.PeerID()); adoptErr != nil {
+			r.logger.Warn("replay task: adoptVerifiedLedger failed",
+				"seq", nextSeq, "err", adoptErr)
+			r.AbortActiveReplayTask(adoptErr)
+			return
+		}
+
+		r.replayTaskMu.Lock()
+		if r.activeTask == at {
+			at.adopted[derived.Hash()] = derived
+		}
+		r.replayTaskMu.Unlock()
+	}
+}
+
+// onTaskComplete is the task's OnComplete callback. Clears the
+// registry once the final drain has finished. May fire before the
+// last drainTaskChain iteration completes — drainTaskChain then sees
+// a cleared activeTask and exits cleanly.
+func (r *Router) onTaskComplete() {
+	r.replayTaskMu.Lock()
+	at := r.activeTask
+	r.activeTask = nil
+	r.replayTaskMu.Unlock()
+	if at != nil {
+		r.logger.Info("replay task complete",
+			"tip_seq", at.nextSeqToAdopt-1,
+			"adopted", len(at.adopted)-1, // subtract the anchor we pre-seeded
+		)
+	}
+}
+
+// taskSenderAdapter bridges Adaptor's NetworkSender methods to the
+// inbound.TaskSender interface the LedgerReplayTask needs. Two
+// methods, both already implemented on the adaptor.
+type taskSenderAdapter struct {
+	adaptor *Adaptor
+}
+
+func (s taskSenderAdapter) RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mt message.LedgerMapType) error {
+	return s.adaptor.RequestProofPath(peerID, ledgerHash, key, mt)
+}
+
+func (s taskSenderAdapter) RequestReplayDelta(peerID uint64, hash [32]byte) error {
+	return s.adaptor.RequestReplayDelta(peerID, hash)
+}
+
+// toHash32Local mirrors inbound.toHash32 — duplicated here so this
+// file doesn't need to reach into the inbound package's unexported
+// helpers. Tiny and the contract is stable.
+func toHash32Local(h []byte) ([32]byte, bool) {
+	var out [32]byte
+	if len(h) != len(out) {
+		return out, false
+	}
+	copy(out[:], h)
+	return out, true
+}
+

--- a/internal/consensus/adaptor/router_replay_task.go
+++ b/internal/consensus/adaptor/router_replay_task.go
@@ -10,16 +10,6 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 )
 
-// multiLedgerCatchupThreshold is the gap (peerSeq - ourSeq) above
-// which checkBehind switches from the single-ledger forward
-// acquisition path to a LedgerReplayTask backward walk. A gap of 4 is
-// the rough breakeven point: below that, sequential single-acquisition
-// rounds complete before a proof-path round-trip would amortize; above
-// it, the per-ledger gossip wait dominates. Tuned conservatively — a
-// higher threshold avoids spinning up the task machinery for
-// transient near-tip lag.
-const multiLedgerCatchupThreshold = uint32(4)
-
 // activeReplayTask bundles the in-flight LedgerReplayTask with the
 // router-side state used to route inbound responses and drive chain-
 // order adoption. Held under r.replayTaskMu.
@@ -215,7 +205,7 @@ func (r *Router) handleProofPathResponse(msg *peermanagement.InboundMessage) {
 // iff the task handled it; on true, the caller MUST skip the legacy
 // single-ledger Apply+adopt path.
 func (r *Router) routeDeltaToActiveTask(resp *message.ReplayDeltaResponse) (handled bool) {
-	hash, ok := toHash32Local(resp.LedgerHash)
+	hash, ok := inbound.ToHash32(resp.LedgerHash)
 	if !ok {
 		return false
 	}
@@ -365,14 +355,5 @@ func (s taskSenderAdapter) RequestProofPath(peerID uint64, ledgerHash, key [32]b
 
 func (s taskSenderAdapter) RequestReplayDelta(peerID uint64, hash [32]byte) error {
 	return s.adaptor.RequestReplayDelta(peerID, hash)
-}
-
-func toHash32Local(h []byte) ([32]byte, bool) {
-	var out [32]byte
-	if len(h) != len(out) {
-		return out, false
-	}
-	copy(out[:], h)
-	return out, true
 }
 

--- a/internal/consensus/adaptor/router_replay_task.go
+++ b/internal/consensus/adaptor/router_replay_task.go
@@ -21,60 +21,47 @@ import (
 const multiLedgerCatchupThreshold = uint32(4)
 
 // activeReplayTask bundles the in-flight LedgerReplayTask with the
-// state the router needs to route inbound responses and drive chain-
-// order adoption as each subtask verifies. Held under r.replayTaskMu.
+// router-side state used to route inbound responses and drive chain-
+// order adoption. Held under r.replayTaskMu.
 type activeReplayTask struct {
 	task *inbound.LedgerReplayTask
 
-	// chainHashes is the set of hashes the task owns. handleReplayDelta
-	// Response consults this to decide between the task's
-	// OnDeltaResponse path and the single-ledger Apply+adopt path.
-	// Includes the tip hash so the tip's own delta routes to the task.
+	// chainHashes is the set of hashes the task owns, including the
+	// tip. Used by handleReplayDeltaResponse to decide between the
+	// task's OnDeltaResponse path and the single-ledger Apply+adopt
+	// path.
 	chainHashes map[[32]byte]bool
 
-	// anchorParent is the local ledger at seq tipSeq-depth (the bottom
-	// of the chain). Used as the parent of the OLDEST chain entry's
-	// Apply call. Subsequent entries use the previously-adopted ledger
-	// as parent.
+	// anchorParent is the local ledger at seq tipSeq-depth (parent of
+	// the oldest chain entry's Apply call).
 	anchorParent *ledger.Ledger
 
-	// pendingByHash holds verified-but-not-yet-applied ReplayDeltas
-	// keyed by ledger hash. Drained in chain order by drainPending
-	// once each predecessor adopts.
+	// pendingByHash holds verified-but-not-yet-applied ReplayDeltas.
+	// Drained in chain order once each predecessor adopts.
 	pendingByHash map[[32]byte]*inbound.ReplayDelta
 
-	// adopted tracks ledger hashes whose Apply+adopt completed. Used
-	// to find the parent for the next pending entry quickly without
-	// re-querying the service.
+	// adopted tracks ledger hashes whose Apply+adopt completed, so the
+	// parent for the next pending entry is a map lookup rather than a
+	// service round-trip.
 	adopted map[[32]byte]*ledger.Ledger
 
-	// nextSeqToAdopt is the sequence of the next chain entry that
-	// drainPending should attempt. Equals tipSeq-depth+1 initially
-	// (oldest), increments by 1 on each successful adoption.
+	// nextSeqToAdopt is the sequence of the next chain entry to
+	// attempt. Initialized to tipSeq-depth+1; monotonically increases.
 	nextSeqToAdopt uint32
 
-	// chainSeqByHash / chainHashBySeq are inverse lookups built once
-	// when the task transitions out of WantSkipList. Pre-built so
-	// drainPending can pluck the next-by-seq without scanning.
-	chainSeqByHash  map[[32]byte]uint32
-	chainHashBySeq  map[uint32][32]byte
+	// Inverse lookups built once when the task transitions out of
+	// WantSkipList, so drainPending can pluck the next-by-seq without
+	// scanning.
+	chainSeqByHash map[[32]byte]uint32
+	chainHashBySeq map[uint32][32]byte
 }
 
 // StartReplayTask arms a LedgerReplayTask for a multi-ledger backward
-// walk from `tipHash` (at `tipSeq`, with the tip's `stateHash` =
-// AccountHash) back `depth` ledgers, anchored on the local ledger
-// `anchorParent` at seq tipSeq-depth. Returns an error if a task is
-// already in flight or the underlying replayer rejects acquisition.
-//
-// peers is the rotation set the task will round-robin through when
-// the per-peer Replayer cap is reached.
-//
-// Exposed as a callable entry point (not driven by checkBehind today)
-// so the router-level integration can be exercised end-to-end before
-// the auto-trigger path is wired. Production auto-trigger requires
-// either a pre-acquired tip header (so stateHash is known) or an
-// extension to TMStatusChange so peers gossip AccountHash; both are
-// follow-up work.
+// walk from `tipHash` (at `tipSeq`, with `stateHash` =
+// tip.AccountHash) back `depth` ledgers, anchored on the local
+// `anchorParent` at seq tipSeq-depth. `peers` is the rotation set the
+// task round-robins through when the per-peer Replayer cap is
+// reached.
 func (r *Router) StartReplayTask(
 	tipHash, stateHash [32]byte,
 	tipSeq, depth uint32,
@@ -151,8 +138,7 @@ func (r *Router) StartReplayTask(
 }
 
 // HasActiveReplayTask reports whether a LedgerReplayTask is currently
-// in flight. Exposed for tests and for checkBehind's dedup so the
-// auto-trigger path (once wired) doesn't double-arm.
+// in flight.
 func (r *Router) HasActiveReplayTask() bool {
 	r.replayTaskMu.Lock()
 	defer r.replayTaskMu.Unlock()
@@ -171,10 +157,10 @@ func (r *Router) AbortActiveReplayTask(reason error) {
 	}
 }
 
-// handleProofPathResponse is the router-side dispatch for inbound
-// mtPROOF_PATH_RESPONSE frames. Decodes, routes to the active task's
-// OnSkipListResponse, then populates the chain-hash lookup tables so
-// subsequent replay-delta responses are routed correctly.
+// handleProofPathResponse decodes a mtPROOF_PATH_RESPONSE, routes it
+// to the active task's OnSkipListResponse, then populates the chain-
+// hash lookup tables so subsequent replay-delta responses are routed
+// correctly.
 func (r *Router) handleProofPathResponse(msg *peermanagement.InboundMessage) {
 	decoded, err := message.Decode(message.TypeProofPathResponse, msg.Payload)
 	if err != nil {
@@ -209,10 +195,9 @@ func (r *Router) handleProofPathResponse(msg *peermanagement.InboundMessage) {
 		return
 	}
 
-	// Populate chain-hash lookup so handleReplayDeltaResponse can
-	// route subsequent inbound replay-deltas to the task. The task
-	// just built its chain inside OnSkipListResponse, so ChainEntries
-	// is now authoritative.
+	// The task just built its chain inside OnSkipListResponse, so
+	// ChainEntries is authoritative now. Populate the lookup so
+	// handleReplayDeltaResponse can route subsequent inbound deltas.
 	r.replayTaskMu.Lock()
 	if r.activeTask == at {
 		seqs, hashes := at.task.ChainEntries()
@@ -225,15 +210,10 @@ func (r *Router) handleProofPathResponse(msg *peermanagement.InboundMessage) {
 	r.replayTaskMu.Unlock()
 }
 
-// routeDeltaToActiveTask attempts to route a TMReplayDeltaResponse to
-// the in-flight LedgerReplayTask. Returns true if the response was
-// handled by the task (caller MUST skip the legacy single-ledger
-// Apply+adopt path), false if the response is not task-owned.
-//
-// The chain-hash set is populated authoritatively in
-// handleProofPathResponse right after the skip-list verifies, so the
-// lookup here is exact: hash present ⇒ task-owned, hash absent ⇒
-// route via the legacy path.
+// routeDeltaToActiveTask routes a TMReplayDeltaResponse to the
+// in-flight LedgerReplayTask if the hash is task-owned. Returns true
+// iff the task handled it; on true, the caller MUST skip the legacy
+// single-ledger Apply+adopt path.
 func (r *Router) routeDeltaToActiveTask(resp *message.ReplayDeltaResponse) (handled bool) {
 	hash, ok := toHash32Local(resp.LedgerHash)
 	if !ok {
@@ -273,7 +253,6 @@ func (r *Router) onTaskDeltaVerified(seq uint32, h [32]byte, rd *inbound.ReplayD
 		return
 	}
 	at.pendingByHash[h] = rd
-	// Register chain mappings now that we know hash ↔ seq.
 	at.chainSeqByHash[h] = seq
 	at.chainHashBySeq[seq] = h
 	at.chainHashes[h] = true
@@ -306,11 +285,6 @@ func (r *Router) drainTaskChain() {
 			r.replayTaskMu.Unlock()
 			return
 		}
-		// Resolve the parent ledger from the adopted map. For the
-		// oldest entry the parent is the anchor (pre-seeded). For
-		// subsequent entries it's the predecessor we just adopted.
-		// Result() returns the verified *ledger.Ledger; its header
-		// carries the canonical ParentHash we link against.
 		verifiedLedger, resErr := rd.Result()
 		if resErr != nil || verifiedLedger == nil {
 			r.replayTaskMu.Unlock()
@@ -379,9 +353,8 @@ func (r *Router) onTaskComplete() {
 	}
 }
 
-// taskSenderAdapter bridges Adaptor's NetworkSender methods to the
-// inbound.TaskSender interface the LedgerReplayTask needs. Two
-// methods, both already implemented on the adaptor.
+// taskSenderAdapter satisfies inbound.TaskSender by delegating to the
+// Adaptor's NetworkSender methods.
 type taskSenderAdapter struct {
 	adaptor *Adaptor
 }
@@ -394,9 +367,6 @@ func (s taskSenderAdapter) RequestReplayDelta(peerID uint64, hash [32]byte) erro
 	return s.adaptor.RequestReplayDelta(peerID, hash)
 }
 
-// toHash32Local mirrors inbound.toHash32 — duplicated here so this
-// file doesn't need to reach into the inbound package's unexported
-// helpers. Tiny and the contract is stable.
 func toHash32Local(h []byte) ([32]byte, bool) {
 	var out [32]byte
 	if len(h) != len(out) {

--- a/internal/consensus/adaptor/router_replay_task_test.go
+++ b/internal/consensus/adaptor/router_replay_task_test.go
@@ -1,0 +1,391 @@
+package adaptor
+
+import (
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// proofPathCall records a RequestProofPath the router issues. Lets
+// the test verify the sender saw exactly one proof-path request with
+// the expected tip hash and key.
+type proofPathCall struct {
+	peerID     uint64
+	ledgerHash [32]byte
+	key        [32]byte
+	mapType    message.LedgerMapType
+}
+
+// recordingSenderWithProofPath wraps the existing recordingSender
+// with proof-path recording — the multi-ledger replay path adds a
+// second wire-request type the original recorder didn't track.
+type recordingSenderWithProofPath struct {
+	recordingSender
+	pathMu    sync.Mutex
+	pathCalls []proofPathCall
+}
+
+func (s *recordingSenderWithProofPath) RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mt message.LedgerMapType) error {
+	s.pathMu.Lock()
+	defer s.pathMu.Unlock()
+	s.pathCalls = append(s.pathCalls, proofPathCall{
+		peerID: peerID, ledgerHash: ledgerHash, key: key, mapType: mt,
+	})
+	return nil
+}
+
+func (s *recordingSenderWithProofPath) proofPathCalls() []proofPathCall {
+	s.pathMu.Lock()
+	defer s.pathMu.Unlock()
+	out := make([]proofPathCall, len(s.pathCalls))
+	copy(out, s.pathCalls)
+	return out
+}
+
+// closeEmpty closes the supplied open ledger at closeTime with no
+// txs and returns the resulting closed ledger plus its serialized
+// header bytes. Mirrors buildEmptyClosedSuccessorResponse's shape
+// but caller-driven so we can build a chain by feeding each closed
+// ledger back as the parent for the next NewOpen.
+func closeEmpty(t *testing.T, parent *ledger.Ledger, closeTime time.Time) (*ledger.Ledger, []byte) {
+	t.Helper()
+	open, err := ledger.NewOpen(parent, closeTime)
+	require.NoError(t, err)
+	require.NoError(t, open.Close(closeTime, 0))
+	hdr := open.Header()
+	hdrBytes, err := header.AddRaw(hdr, false)
+	require.NoError(t, err)
+	return open, hdrBytes
+}
+
+// buildChainFromAnchor closes `n` ledgers on top of `anchor`,
+// returning the resulting chain in order — chain[0] = anchor+1,
+// chain[n-1] = the tip. headerBytes[i] is the serialized header of
+// chain[i] (matches what a peer would put in TMReplayDeltaResponse).
+func buildChainFromAnchor(t *testing.T, anchor *ledger.Ledger, n int) (chain []*ledger.Ledger, headerBytes [][]byte) {
+	t.Helper()
+	chain = make([]*ledger.Ledger, n)
+	headerBytes = make([][]byte, n)
+	parent := anchor
+	closeBase := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		ct := closeBase.Add(time.Duration(i) * 10 * time.Second)
+		closed, hb := closeEmpty(t, parent, ct)
+		chain[i] = closed
+		headerBytes[i] = hb
+		parent = closed
+	}
+	return
+}
+
+// installSkipListIntoTipState mutates `tip`'s state map to install a
+// LedgerHashes SLE at keylet::skip() containing the supplied 256-hash
+// rolling buffer. Returns the new state-map root hash (which becomes
+// the tip's AccountHash for the proof-verification path) plus the
+// leaf-to-root proof path of the inserted entry.
+//
+// We don't actually need the tip's "real" AccountHash for the
+// integration test — what matters is that the proof verifies against
+// SOME stateHash we declare to be the tip's, and the verifier picks
+// up the right Hashes vector. So this helper builds a synthetic
+// state map containing just the LedgerHashes SLE.
+func installSkipListIntoTipState(t *testing.T, hashes [][32]byte, lastSeq uint32) (stateHash [32]byte, path [][]byte) {
+	t.Helper()
+	hashHexes := make([]string, len(hashes))
+	for i, h := range hashes {
+		hashHexes[i] = fmt.Sprintf("%064X", h)
+	}
+	hx, err := binarycodec.Encode(map[string]any{
+		"LedgerEntryType":    "LedgerHashes",
+		"Flags":              uint32(0),
+		"Hashes":             hashHexes,
+		"LastLedgerSequence": lastSeq,
+	})
+	require.NoError(t, err)
+	payload, err := hex.DecodeString(hx)
+	require.NoError(t, err)
+
+	sm, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	skipKL := keylet.LedgerHashes()
+	require.NoError(t, sm.PutWithNodeType(skipKL.Key, payload, shamap.NodeTypeAccountState))
+	require.NoError(t, sm.SetImmutable())
+	stateHash, err = sm.Hash()
+	require.NoError(t, err)
+	proof, err := sm.GetProofPath(skipKL.Key)
+	require.NoError(t, err)
+	require.True(t, proof.Found)
+	return stateHash, proof.Path
+}
+
+// makeRouterWithProofPath wires a router against a recordingSender
+// that supports RequestProofPath. Returns the pieces tests poke +
+// inspect.
+func makeRouterWithProofPath(t *testing.T) (*Router, *Adaptor, *recordingSenderWithProofPath, *service.Service) {
+	t.Helper()
+	svc := newTestLedgerService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	rs := &recordingSenderWithProofPath{
+		recordingSender: recordingSender{peerSupportsReplay: true},
+	}
+	a := New(Config{
+		LedgerService: svc,
+		Sender:        rs,
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+	inbox := make(chan *peermanagement.InboundMessage, 8)
+	r := NewRouter(nil, a, nil, inbox)
+	return r, a, rs, svc
+}
+
+// TestRouter_ReplayTask_EndToEnd_3LedgerWalk drives the full Phase 5
+// integration: arm a task, deliver a verified proof-path response,
+// deliver three replay-delta responses in chain order, and assert
+// that each of the three intermediate ledgers adopts via the
+// router's adoption path.
+//
+// Three is the smallest chain that exercises the full machinery
+// (anchor → +1 → +2 → +3 tip) — bigger chains would stress the same
+// code path identically with more wire round-trips.
+func TestRouter_ReplayTask_EndToEnd_3LedgerWalk(t *testing.T) {
+	r, _, rs, svc := makeRouterWithProofPath(t)
+
+	anchor := svc.GetClosedLedger()
+	require.NotNil(t, anchor)
+	anchorSeq := anchor.Sequence()
+
+	// Build a chain of 3 ledgers on top of the anchor. chain[2] is
+	// the tip; chain[0..1] are the intermediates we want the task to
+	// fetch via replay-delta.
+	chain, headerBytesByIdx := buildChainFromAnchor(t, anchor, 3)
+	tip := chain[len(chain)-1]
+	tipSeq := tip.Sequence()
+	tipHash := tip.Hash()
+	require.Equal(t, anchorSeq+3, tipSeq)
+
+	// Build the skip-list SLE the proof-path response will carry.
+	// For depth=3 we need 2 ancestor hashes (chain[0].Hash and
+	// chain[1].Hash) — the tip itself is fetched via a separate
+	// replay-delta. Pad earlier entries with deterministic filler.
+	skipHashes := make([][32]byte, 256)
+	for i := 0; i < 256-2; i++ {
+		var h [32]byte
+		h[0] = 0xFE
+		h[1] = byte(i)
+		skipHashes[i] = h
+	}
+	skipHashes[254] = chain[0].Hash()
+	skipHashes[255] = chain[1].Hash()
+
+	stateHash, proofPath := installSkipListIntoTipState(t, skipHashes, tipSeq-1)
+
+	// Arm the task.
+	require.NoError(t, r.StartReplayTask(
+		tipHash, stateHash, tipSeq, 3,
+		anchor,
+		[]uint64{77, 78},
+	))
+	assert.True(t, r.HasActiveReplayTask())
+
+	// Sender should have seen exactly one proof-path request.
+	require.Eventually(t, func() bool {
+		return len(rs.proofPathCalls()) == 1
+	}, time.Second, 5*time.Millisecond)
+	pp := rs.proofPathCalls()[0]
+	assert.Equal(t, tipHash, pp.ledgerHash)
+	assert.Equal(t, keylet.LedgerHashes().Key, pp.key)
+	assert.Equal(t, message.LedgerMapAccountState, pp.mapType)
+
+	// Deliver the proof-path response. The router should fan out
+	// 3 replay-delta requests immediately (depth=3 fits under the
+	// global cap of 16).
+	skipKey := keylet.LedgerHashes().Key
+	proofResp := &message.ProofPathResponse{
+		LedgerHash: tipHash[:],
+		Key:        skipKey[:],
+		MapType:    message.LedgerMapAccountState,
+		Path:       proofPath,
+	}
+	proofEnc, err := message.Encode(proofResp)
+	require.NoError(t, err)
+	r.handleProofPathResponse(&peermanagement.InboundMessage{
+		PeerID:  peermanagement.PeerID(77),
+		Type:    uint16(message.TypeProofPathResponse),
+		Payload: proofEnc,
+	})
+
+	require.Eventually(t, func() bool {
+		return len(rs.replayCalls()) == 3
+	}, time.Second, 5*time.Millisecond)
+	dc := rs.replayCalls()
+	wantHashes := map[[32]byte]bool{
+		chain[0].Hash(): false,
+		chain[1].Hash(): false,
+		chain[2].Hash(): false,
+	}
+	for _, c := range dc {
+		_, ok := wantHashes[c.hash]
+		assert.Truef(t, ok, "delta request for unexpected hash %x", c.hash[:8])
+		wantHashes[c.hash] = true
+	}
+	for h, seen := range wantHashes {
+		assert.Truef(t, seen, "no delta request for chain hash %x", h[:8])
+	}
+
+	// Deliver delta responses in chain order (oldest first). The
+	// router's drain loop applies each as soon as its parent is in
+	// the adopted set, so feeding in order lets every adopt fire.
+	for i, l := range chain {
+		lHash := l.Hash()
+		resp := &message.ReplayDeltaResponse{
+			LedgerHash:   lHash[:],
+			LedgerHeader: headerBytesByIdx[i],
+			Transactions: nil,
+		}
+		enc, err := message.Encode(resp)
+		require.NoError(t, err)
+		r.handleReplayDeltaResponse(&peermanagement.InboundMessage{
+			PeerID:  peermanagement.PeerID(77),
+			Type:    uint16(message.TypeReplayDeltaResponse),
+			Payload: enc,
+		})
+	}
+
+	// After all three responses, the task should complete and the
+	// service should have adopted up through the tip.
+	require.Eventually(t, func() bool {
+		return !r.HasActiveReplayTask()
+	}, time.Second, 5*time.Millisecond)
+	assert.Equal(t, tipSeq, svc.GetClosedLedgerIndex(),
+		"every chain ledger should have adopted")
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	assert.Equal(t, tipHash, closed.Hash())
+}
+
+// TestRouter_ReplayTask_RejectsBadProof drives the abort path:
+// a peer serves a tampered proof, the task transitions to Failed,
+// the router clears its registry and charges the peer for
+// proof-path-verify bad data.
+func TestRouter_ReplayTask_RejectsBadProof(t *testing.T) {
+	r, _, rs, svc := makeRouterWithProofPath(t)
+
+	anchor := svc.GetClosedLedger()
+	require.NotNil(t, anchor)
+	chain, _ := buildChainFromAnchor(t, anchor, 3)
+	tip := chain[2]
+	tipHash := tip.Hash()
+
+	// Compute a VALID stateHash for some hashes vector, then
+	// declare to the router that the SAME stateHash is the tip's —
+	// but serve a proof against a DIFFERENT hashes vector. The
+	// merkle verify must fail.
+	correctHashes := make([][32]byte, 256)
+	for i := range correctHashes {
+		correctHashes[i] = [32]byte{byte(i), 0xCC}
+	}
+	stateHash, _ := installSkipListIntoTipState(t, correctHashes, tip.Sequence()-1)
+
+	wrongHashes := make([][32]byte, 256)
+	for i := range wrongHashes {
+		wrongHashes[i] = [32]byte{byte(i), 0xDD}
+	}
+	_, wrongPath := installSkipListIntoTipState(t, wrongHashes, tip.Sequence()-1)
+
+	require.NoError(t, r.StartReplayTask(
+		tipHash, stateHash, tip.Sequence(), 3,
+		anchor,
+		[]uint64{99},
+	))
+	require.Eventually(t, func() bool {
+		return len(rs.proofPathCalls()) == 1
+	}, time.Second, 5*time.Millisecond)
+
+	skipKey := keylet.LedgerHashes().Key
+	badResp := &message.ProofPathResponse{
+		LedgerHash: tipHash[:],
+		Key:        skipKey[:],
+		MapType:    message.LedgerMapAccountState,
+		Path:       wrongPath,
+	}
+	enc, err := message.Encode(badResp)
+	require.NoError(t, err)
+	r.handleProofPathResponse(&peermanagement.InboundMessage{
+		PeerID:  peermanagement.PeerID(99),
+		Type:    uint16(message.TypeProofPathResponse),
+		Payload: enc,
+	})
+
+	assert.False(t, r.HasActiveReplayTask(),
+		"task must clear after a proof-path verification failure")
+	// No replay-delta requests should have been issued — the task
+	// aborted before fan-out.
+	assert.Empty(t, rs.replayCalls(),
+		"no replay-delta requests should fire after a proof failure")
+}
+
+// TestRouter_ReplayTask_DoubleStartRejected guards against
+// double-arming. A second StartReplayTask while one is in flight
+// must return an error without disturbing the first task.
+func TestRouter_ReplayTask_DoubleStartRejected(t *testing.T) {
+	r, _, _, svc := makeRouterWithProofPath(t)
+	anchor := svc.GetClosedLedger()
+	chain, _ := buildChainFromAnchor(t, anchor, 3)
+	tip := chain[2]
+	skipHashes := make([][32]byte, 256)
+	skipHashes[254] = chain[0].Hash()
+	skipHashes[255] = chain[1].Hash()
+	stateHash, _ := installSkipListIntoTipState(t, skipHashes, tip.Sequence()-1)
+
+	require.NoError(t, r.StartReplayTask(
+		tip.Hash(), stateHash, tip.Sequence(), 3,
+		anchor,
+		[]uint64{1},
+	))
+	err := r.StartReplayTask(
+		tip.Hash(), stateHash, tip.Sequence(), 3,
+		anchor,
+		[]uint64{1},
+	)
+	require.Error(t, err)
+	assert.True(t, r.HasActiveReplayTask(),
+		"first task must remain in flight after double-start rejection")
+
+	r.AbortActiveReplayTask(nil)
+	assert.False(t, r.HasActiveReplayTask())
+}
+
+// TestRouter_ReplayTask_AnchorSeqMustMatch rejects an anchor whose
+// sequence doesn't equal tipSeq - depth. Wiring this check at the
+// entry point prevents a class of bugs where the caller miscomputes
+// depth and ends up with a chain that links nowhere.
+func TestRouter_ReplayTask_AnchorSeqMustMatch(t *testing.T) {
+	r, _, _, svc := makeRouterWithProofPath(t)
+	anchor := svc.GetClosedLedger()
+
+	// Anchor is at seq=2 (standalone genesis); claim tipSeq=10 with
+	// depth=3 — that requires anchor at seq 7, which we don't have.
+	err := r.StartReplayTask(
+		[32]byte{0xAB}, [32]byte{0xCD}, 10, 3,
+		anchor,
+		[]uint64{1},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "anchorParent.Sequence")
+}

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -272,6 +272,26 @@ func (s *OverlaySender) RequestReplayDelta(peerID uint64, hash [32]byte) error {
 	return s.overlay.Send(peermanagement.PeerID(peerID), frame)
 }
 
+// RequestProofPath asks a specific peer for the SHAMap merkle proof of
+// (key, mapType) under ledgerHash. Mirrors rippled's
+// SkipListAcquire::trigger
+// (rippled/src/xrpld/app/ledger/detail/SkipListAcquire.cpp:84-92):
+// one round-trip returns the leaf-to-root proof path plus the
+// serialized leaf, which the inbound SkipListAcquire verifier checks
+// against the target's stateHash.
+func (s *OverlaySender) RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mapType message.LedgerMapType) error {
+	msg := &message.ProofPathRequest{
+		LedgerHash: ledgerHash[:],
+		Key:        key[:],
+		MapType:    mapType,
+	}
+	frame, err := encodeFrame(message.TypeProofPathReq, msg)
+	if err != nil {
+		return fmt.Errorf("encode proof path request: %w", err)
+	}
+	return s.overlay.Send(peermanagement.PeerID(peerID), frame)
+}
+
 // RequestStateNodes sends a GetLedger request for account state SHAMap nodes.
 func (s *OverlaySender) RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {
 	msg := &message.GetLedger{

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -275,10 +275,7 @@ func (s *OverlaySender) RequestReplayDelta(peerID uint64, hash [32]byte) error {
 // RequestProofPath asks a specific peer for the SHAMap merkle proof of
 // (key, mapType) under ledgerHash. Mirrors rippled's
 // SkipListAcquire::trigger
-// (rippled/src/xrpld/app/ledger/detail/SkipListAcquire.cpp:84-92):
-// one round-trip returns the leaf-to-root proof path plus the
-// serialized leaf, which the inbound SkipListAcquire verifier checks
-// against the target's stateHash.
+// (rippled/src/xrpld/app/ledger/detail/SkipListAcquire.cpp:84-92).
 func (s *OverlaySender) RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mapType message.LedgerMapType) error {
 	msg := &message.ProofPathRequest{
 		LedgerHash: ledgerHash[:],

--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -189,18 +189,9 @@ func (r *ReplayDelta) PeerID() uint64 { return r.peerID }
 // amendment rules) before invoking Apply().
 func (r *ReplayDelta) Parent() *ledger.Ledger { return r.parent }
 
-// SetParent rebinds the parent ledger AFTER acquisition. Used by
-// LedgerReplayTask: subtasks for intermediate ledgers are acquired
-// with parent=nil so their framing can be verified in parallel, then
-// the task walks the chain in order and supplies each delta's actual
-// parent (the previously-adopted predecessor) just before Apply.
-//
-// Only overwrites a nil parent — once set, subsequent calls with a
-// different parent return an error so a misuse can't silently corrupt
-// the apply-with-wrong-parent path.
-//
-// Caller must NOT hold any external lock on this ReplayDelta; this
-// method acquires r.mu internally.
+// SetParent rebinds the parent ledger AFTER acquisition. Refuses to
+// overwrite an already-bound parent, so a misuse can't silently
+// corrupt the apply-with-wrong-parent path.
 func (r *ReplayDelta) SetParent(parent *ledger.Ledger) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -189,6 +189,29 @@ func (r *ReplayDelta) PeerID() uint64 { return r.peerID }
 // amendment rules) before invoking Apply().
 func (r *ReplayDelta) Parent() *ledger.Ledger { return r.parent }
 
+// SetParent rebinds the parent ledger AFTER acquisition. Used by
+// LedgerReplayTask: subtasks for intermediate ledgers are acquired
+// with parent=nil so their framing can be verified in parallel, then
+// the task walks the chain in order and supplies each delta's actual
+// parent (the previously-adopted predecessor) just before Apply.
+//
+// Only overwrites a nil parent — once set, subsequent calls with a
+// different parent return an error so a misuse can't silently corrupt
+// the apply-with-wrong-parent path.
+//
+// Caller must NOT hold any external lock on this ReplayDelta; this
+// method acquires r.mu internally.
+func (r *ReplayDelta) SetParent(parent *ledger.Ledger) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.parent != nil && r.parent != parent {
+		return fmt.Errorf("SetParent: parent already bound to %x, refusing to overwrite with %x",
+			r.parent.Hash(), parent.Hash())
+	}
+	r.parent = parent
+	return nil
+}
+
 // Seq returns the ledger sequence under acquisition. Derived from the
 // parent ledger because the request itself only carries the hash.
 func (r *ReplayDelta) Seq() uint32 {

--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -195,7 +195,7 @@ func (r *ReplayDelta) Parent() *ledger.Ledger { return r.parent }
 func (r *ReplayDelta) SetParent(parent *ledger.Ledger) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.parent != nil && r.parent != parent {
+	if r.parent != nil && r.parent.Hash() != parent.Hash() {
 		return fmt.Errorf("SetParent: parent already bound to %x, refusing to overwrite with %x",
 			r.parent.Hash(), parent.Hash())
 	}
@@ -389,7 +389,7 @@ func (r *ReplayDelta) verifyAndBuild(resp *message.ReplayDeltaResponse) error {
 	// reverse arithmetic CalculateLedgerHash relies on. The byte-level
 	// hash is what rippled computes on the sender side and is the only
 	// invariant guaranteed to round-trip.
-	advertised, ok := toHash32(resp.LedgerHash)
+	advertised, ok := ToHash32(resp.LedgerHash)
 	if !ok {
 		return fmt.Errorf("bad hash length: %d", len(resp.LedgerHash))
 	}
@@ -772,9 +772,9 @@ func (r *ReplayDelta) parentStateSnapshot() (*shamap.SHAMap, error) {
 	return snap, nil
 }
 
-// toHash32 returns h as [32]byte iff len(h) == 32. The bool return
+// ToHash32 returns h as [32]byte iff len(h) == 32. The bool return
 // distinguishes a wrong-length input from an all-zero hash.
-func toHash32(h []byte) ([32]byte, bool) {
+func ToHash32(h []byte) ([32]byte, bool) {
 	var out [32]byte
 	if len(h) != len(out) {
 		return out, false

--- a/internal/ledger/inbound/replay_task.go
+++ b/internal/ledger/inbound/replay_task.go
@@ -1,0 +1,552 @@
+package inbound
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+)
+
+// TaskState tracks LedgerReplayTask progress. Mirrors rippled's
+// LedgerReplayTask state model (WantSkipList → RunningDeltas →
+// Complete/Failed) without re-using the package-wide State enum,
+// which is for single-ledger acquisitions and does not have a
+// "running fan-out" notion.
+type TaskState int
+
+const (
+	// TaskStateWantSkipList: we've sent a TMProofPathRequest for the
+	// tip's LedgerHashes entry and are waiting for the proof.
+	TaskStateWantSkipList TaskState = iota
+	// TaskStateRunningDeltas: skip-list verified, we're fanning out
+	// per-ancestor TMReplayDeltaRequest acquisitions bounded by the
+	// Replayer's global / per-peer caps.
+	TaskStateRunningDeltas
+	// TaskStateComplete: every ancestor in the requested depth window
+	// has had its framing verified. Caller orchestrates downstream
+	// Apply against the local anchor.
+	TaskStateComplete
+	// TaskStateFailed: the skip-list proof failed or no peer could
+	// serve a needed delta. Caller falls back to the legacy single-
+	// ledger forward acquisition path.
+	TaskStateFailed
+)
+
+// MaxBackwardDepth caps how many ledgers a single LedgerReplayTask can
+// walk in one shot. Matches rippled's MAX_TASK_SIZE=256
+// (rippled/src/xrpld/app/ledger/LedgerReplayer.h:31): the rolling-256
+// skip-list of the tip ledger contains at most 256 ancestor hashes,
+// and replaying further back requires another task on a deeper tip.
+const MaxBackwardDepth = 256
+
+// TaskSender is the minimal wire-issuing interface the task needs.
+// Production wires this to the OverlaySender; tests fabricate a fake.
+type TaskSender interface {
+	// RequestProofPath issues a TMProofPathRequest for (ledgerHash, key,
+	// mapType) to peerID. Mirrors OverlaySender.RequestProofPath.
+	RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mapType message.LedgerMapType) error
+	// RequestReplayDelta issues a TMReplayDeltaRequest for ledger hash
+	// to peerID. Mirrors OverlaySender.RequestReplayDelta.
+	RequestReplayDelta(peerID uint64, hash [32]byte) error
+}
+
+// Sentinel errors that the LedgerReplayTask returns. Wrapped with
+// fmt.Errorf so callers can errors.Is them without string matching.
+var (
+	// ErrTaskBadDepth signals depth is 0 or above MaxBackwardDepth.
+	ErrTaskBadDepth = errors.New("replay task: depth out of range")
+
+	// ErrTaskNoPeers signals the task was started with an empty peer
+	// list, so no skip-list request can be issued. Caller chooses a
+	// peer before starting.
+	ErrTaskNoPeers = errors.New("replay task: no peers available")
+
+	// ErrTaskSkipListTooShort signals the verified skip-list contains
+	// fewer hashes than the requested depth-1. Either the tip is too
+	// young (early in chain history) or the peer served a truncated
+	// proof; caller falls back to single-ledger acquisition.
+	ErrTaskSkipListTooShort = errors.New("replay task: skip-list too short for depth")
+
+	// ErrTaskWrongState signals an operation was called from an
+	// invalid state (e.g., OnDelta before OnSkipList). Indicates a
+	// logic bug in the caller's wiring, not a peer or wire issue.
+	ErrTaskWrongState = errors.New("replay task: invalid state for operation")
+)
+
+// subtask tracks a single ancestor's acquisition status inside the
+// task. The chain slice is laid out oldest-first: chain[0] is the
+// oldest ledger we want (seq = tipSeq - depth + 1), chain[depth-1] is
+// the tip itself.
+type subtask struct {
+	hash     [32]byte
+	seq      uint32
+	acquired bool       // RequestReplayDelta has been sent
+	verified bool       // framing-verified by the underlying ReplayDelta
+	delta    *ReplayDelta
+}
+
+// LedgerReplayTask coordinates a multi-ledger backward catch-up. Given
+// a known tip and the local anchor's depth-below-tip, it:
+//
+//  1. Acquires the tip's rolling-256 LedgerHashes SLE via
+//     SkipListAcquire (one TMProofPathRequest).
+//  2. Extracts the (depth-1) ancestor hashes plus the tip's hash and
+//     enumerates them in chain order.
+//  3. Fans out per-ancestor TMReplayDeltaRequest acquisitions
+//     concurrently, bounded by Replayer's caps. As each completes its
+//     framing verification, the task fires the supplied callback so
+//     the caller can stitch the chain together via Apply.
+//
+// Mirrors rippled's LedgerReplayTask
+// (rippled/src/xrpld/app/ledger/detail/LedgerReplayTask.cpp:135-209)
+// with two intentional simplifications:
+//   - The task does NOT run engine Apply itself; the caller does.
+//     Rippled keeps Apply in `LedgerReplayMsgHandler::processReplayDeltaResponse`
+//     which fires from the receive loop; goXRPL's router does the
+//     same thing today via Replayer.HandleResponse + Apply, so this
+//     task plugs into the existing seam.
+//   - The task does NOT split into multiple peers automatically; the
+//     caller supplies an ordered peer list and the task rotates
+//     through it when the Replayer rejects an Acquire with
+//     ErrPerPeerCapacityFull. (Future work: integrate peer-rotation
+//     on sub-task timeout, mirroring ReplayDelta's NoteSubTaskRetry.)
+type LedgerReplayTask struct {
+	tipHash   [32]byte
+	tipSeq    uint32
+	stateHash [32]byte // tip.AccountHash, used by SkipListAcquire
+	depth     uint32
+
+	peers   []uint64 // rotated through when per-peer cap is hit
+	cursor  int      // next peer index to try
+
+	replayer *Replayer
+	sender   TaskSender
+	logger   *slog.Logger
+
+	// OnDeltaVerified fires every time a chain ancestor's framing
+	// verification succeeds. The caller can adopt incrementally (in
+	// chain order) or batch until OnComplete fires. The callback is
+	// invoked WITHOUT the task lock held so callers may re-enter the
+	// task (e.g., Abort) from inside it.
+	onDeltaVerified func(seq uint32, hash [32]byte, rd *ReplayDelta)
+
+	// OnComplete fires once after every chain entry has verified.
+	onComplete func()
+
+	mu        sync.Mutex
+	state     TaskState
+	err       error
+	skipList  *SkipListAcquire
+	chain     []subtask
+	completed int
+}
+
+// TaskCallbacks bundles the optional progress callbacks for a task.
+// Both are invoked without the task lock held.
+type TaskCallbacks struct {
+	OnDeltaVerified func(seq uint32, hash [32]byte, rd *ReplayDelta)
+	OnComplete      func()
+}
+
+// NewLedgerReplayTask constructs a task targeting tipHash (with the
+// tip's known AccountHash) and a depth of `depth` ledgers backward.
+// The local anchor must sit at sequence tipSeq-depth — that anchor is
+// the caller's concern; the task only orchestrates wire fetches.
+//
+// Returns ErrTaskBadDepth if depth is 0 or > MaxBackwardDepth, and
+// ErrTaskNoPeers if peers is empty.
+func NewLedgerReplayTask(
+	tipHash, stateHash [32]byte,
+	tipSeq, depth uint32,
+	peers []uint64,
+	replayer *Replayer,
+	sender TaskSender,
+	logger *slog.Logger,
+	cb TaskCallbacks,
+) (*LedgerReplayTask, error) {
+	if depth == 0 || depth > MaxBackwardDepth {
+		return nil, fmt.Errorf("%w: depth=%d", ErrTaskBadDepth, depth)
+	}
+	if len(peers) == 0 {
+		return nil, ErrTaskNoPeers
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	peersCopy := append([]uint64(nil), peers...)
+	return &LedgerReplayTask{
+		tipHash:         tipHash,
+		tipSeq:          tipSeq,
+		stateHash:       stateHash,
+		depth:           depth,
+		peers:           peersCopy,
+		replayer:        replayer,
+		sender:          sender,
+		logger:          logger,
+		state:           TaskStateWantSkipList,
+		onDeltaVerified: cb.OnDeltaVerified,
+		onComplete:      cb.OnComplete,
+	}, nil
+}
+
+// State returns the current task state.
+func (t *LedgerReplayTask) State() TaskState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.state
+}
+
+// Err returns the failure error, or nil if not in TaskStateFailed.
+func (t *LedgerReplayTask) Err() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.err
+}
+
+// IsComplete reports whether every chain entry has verified.
+func (t *LedgerReplayTask) IsComplete() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.state == TaskStateComplete
+}
+
+// ChainSeqs returns the ordered sequence numbers the task is
+// fetching: chain[0]=tipSeq-depth+1 ... chain[depth-1]=tipSeq.
+// Returned slice is a defensive copy.
+func (t *LedgerReplayTask) ChainSeqs() []uint32 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]uint32, len(t.chain))
+	for i, st := range t.chain {
+		out[i] = st.seq
+	}
+	return out
+}
+
+// ChainEntries returns the (seq, hash) pairs of every chain entry,
+// oldest-first. Empty until the skip-list response has been
+// verified. Returned slices are defensive copies.
+//
+// Exposed so the router can pre-register hashes in its task-routing
+// map the moment the chain is known, rather than relying on lazy
+// registration during each subtask's OnDeltaVerified callback.
+func (t *LedgerReplayTask) ChainEntries() (seqs []uint32, hashes [][32]byte) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	seqs = make([]uint32, len(t.chain))
+	hashes = make([][32]byte, len(t.chain))
+	for i, st := range t.chain {
+		seqs[i] = st.seq
+		hashes[i] = st.hash
+	}
+	return
+}
+
+// Start arms the skip-list acquisition and issues the wire request to
+// the first peer in the rotation. Subsequent OnSkipListResponse drives
+// the rest of the task.
+func (t *LedgerReplayTask) Start() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.state != TaskStateWantSkipList {
+		return fmt.Errorf("%w: Start called from state %d", ErrTaskWrongState, t.state)
+	}
+
+	peer := t.peers[t.cursor]
+	sl, err := t.replayer.AcquireSkipList(t.tipHash, t.stateHash, peer)
+	if err != nil {
+		t.state = TaskStateFailed
+		t.err = fmt.Errorf("acquire skip-list: %w", err)
+		return t.err
+	}
+	t.skipList = sl
+
+	skipKL := keylet.LedgerHashes()
+	if wireErr := t.sender.RequestProofPath(peer, t.tipHash, skipKL.Key, message.LedgerMapAccountState); wireErr != nil {
+		t.replayer.AbandonSkipList(t.tipHash)
+		t.skipList = nil
+		t.state = TaskStateFailed
+		t.err = fmt.Errorf("send proof-path request: %w", wireErr)
+		return t.err
+	}
+
+	t.logger.Info("replay task started",
+		"tip", hex.EncodeToString(t.tipHash[:8]),
+		"tipSeq", t.tipSeq,
+		"depth", t.depth,
+		"peer", peer,
+	)
+	return nil
+}
+
+// OnSkipListResponse handles a TMProofPathResponse routed to the task
+// (matched on resp.LedgerHash == tipHash). Verifies the proof,
+// populates the chain, and kicks off the delta fan-out.
+//
+// Returns nil on success, or a wrapped error on proof failure. After
+// a proof failure the task transitions to TaskStateFailed and the
+// caller falls back to single-ledger acquisition.
+func (t *LedgerReplayTask) OnSkipListResponse(resp *message.ProofPathResponse) error {
+	t.mu.Lock()
+
+	if t.state != TaskStateWantSkipList {
+		t.mu.Unlock()
+		return fmt.Errorf("%w: OnSkipListResponse from state %d", ErrTaskWrongState, t.state)
+	}
+	if t.skipList == nil {
+		t.mu.Unlock()
+		return fmt.Errorf("%w: skip-list acquire missing", ErrTaskWrongState)
+	}
+
+	if err := t.skipList.GotResponse(resp); err != nil {
+		t.replayer.AbandonSkipList(t.tipHash)
+		t.state = TaskStateFailed
+		t.err = fmt.Errorf("verify skip-list proof: %w", err)
+		t.mu.Unlock()
+		return t.err
+	}
+
+	hashes := t.skipList.Hashes()
+	// Need (depth-1) ancestor hashes (positions tipSeq-1 .. tipSeq-depth+1).
+	// hashes[len-1] = parent(tip) = seq tipSeq-1, hashes[len-k] = seq tipSeq-k.
+	needAncestors := int(t.depth) - 1
+	if needAncestors > len(hashes) {
+		t.replayer.AbandonSkipList(t.tipHash)
+		t.state = TaskStateFailed
+		t.err = fmt.Errorf("%w: have %d hashes, need %d",
+			ErrTaskSkipListTooShort, len(hashes), needAncestors)
+		t.mu.Unlock()
+		return t.err
+	}
+
+	// Build chain oldest-first. The oldest needed seq is tipSeq-depth+1
+	// (assuming the local anchor sits at tipSeq-depth). For depth=50
+	// and tipSeq=N: chain[0]=N-49, chain[49]=N (tip).
+	chain := make([]subtask, 0, t.depth)
+	for k := needAncestors; k >= 1; k-- {
+		chain = append(chain, subtask{
+			hash: hashes[len(hashes)-k],
+			seq:  t.tipSeq - uint32(k),
+		})
+	}
+	chain = append(chain, subtask{hash: t.tipHash, seq: t.tipSeq})
+	t.chain = chain
+	t.state = TaskStateRunningDeltas
+
+	// Skip-list is no longer needed; free the coordinator slot.
+	t.replayer.CompleteSkipList(t.tipHash)
+	t.skipList = nil
+
+	t.logger.Info("replay task skip-list verified",
+		"tip", hex.EncodeToString(t.tipHash[:8]),
+		"chain_len", len(chain),
+		"chain_lo", chain[0].seq,
+		"chain_hi", chain[len(chain)-1].seq,
+	)
+	t.mu.Unlock()
+
+	// Kick off the initial fan-out without holding the lock — the
+	// sender may invoke recursive callbacks in tests, and we want to
+	// allow that without deadlocking.
+	t.dispatchPending()
+	return nil
+}
+
+// OnDeltaResponse handles a TMReplayDeltaResponse routed via the
+// Replayer to one of the task's in-flight subtasks. Marks the matching
+// chain entry verified, frees its Replayer slot, fires the
+// OnDeltaVerified callback, and dispatches the next queued chain
+// entry. When the last entry verifies, transitions the task to
+// TaskStateComplete and fires OnComplete.
+//
+// Returns the underlying ReplayDelta's verification error (if any) so
+// the caller can charge the offending peer. The task does NOT abort
+// on a single peer's bad-data — that subtask is abandoned and the
+// chain entry stays pending for the next peer rotation. (For this
+// initial implementation we abort the task on any subtask failure;
+// the multi-peer retry path is a follow-up.)
+func (t *LedgerReplayTask) OnDeltaResponse(resp *message.ReplayDeltaResponse) error {
+	t.mu.Lock()
+
+	if t.state != TaskStateRunningDeltas {
+		t.mu.Unlock()
+		return fmt.Errorf("%w: OnDeltaResponse from state %d", ErrTaskWrongState, t.state)
+	}
+
+	respHash, ok := toHash32(resp.LedgerHash)
+	if !ok {
+		t.mu.Unlock()
+		return ErrNoMatchingAcquisition
+	}
+
+	idx := -1
+	for i := range t.chain {
+		if t.chain[i].hash == respHash && t.chain[i].acquired && !t.chain[i].verified {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		t.mu.Unlock()
+		return ErrNoMatchingAcquisition
+	}
+
+	rd, err := t.replayer.HandleResponse(resp)
+	if err != nil {
+		t.replayer.Abandon(respHash)
+		t.state = TaskStateFailed
+		t.err = fmt.Errorf("verify delta seq=%d: %w", t.chain[idx].seq, err)
+		t.mu.Unlock()
+		return t.err
+	}
+	t.chain[idx].delta = rd
+	t.chain[idx].verified = true
+	t.completed++
+	t.replayer.Complete(respHash)
+
+	cb := t.onDeltaVerified
+	finished := t.completed == len(t.chain)
+	verifiedSeq := t.chain[idx].seq
+	verifiedHash := t.chain[idx].hash
+	onDone := t.onComplete
+	if finished {
+		t.state = TaskStateComplete
+	}
+	t.mu.Unlock()
+
+	if cb != nil {
+		cb(verifiedSeq, verifiedHash, rd)
+	}
+	if !finished {
+		t.dispatchPending()
+	} else if onDone != nil {
+		onDone()
+	}
+	return nil
+}
+
+// Abort releases all Replayer slots the task is holding and marks
+// it failed with the supplied reason. Idempotent. Safe to call from
+// a callback (re-entrancy: only touches t.mu and the replayer).
+func (t *LedgerReplayTask) Abort(reason error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.state == TaskStateComplete || t.state == TaskStateFailed {
+		return
+	}
+	if t.skipList != nil {
+		t.replayer.AbandonSkipList(t.tipHash)
+		t.skipList = nil
+	}
+	for i := range t.chain {
+		if t.chain[i].acquired && !t.chain[i].verified {
+			t.replayer.Abandon(t.chain[i].hash)
+		}
+	}
+	t.state = TaskStateFailed
+	t.err = reason
+}
+
+// dispatchPending fans out un-acquired chain entries through the
+// Replayer until the global / per-peer caps refuse, or the chain
+// drains. Called from OnSkipListResponse (initial fan-out) and after
+// each OnDeltaResponse (refill on completion). Caller must NOT hold
+// t.mu.
+func (t *LedgerReplayTask) dispatchPending() {
+	for {
+		t.mu.Lock()
+		if t.state != TaskStateRunningDeltas {
+			t.mu.Unlock()
+			return
+		}
+
+		// Find next un-acquired chain entry in oldest-first order.
+		idx := -1
+		for i := range t.chain {
+			if !t.chain[i].acquired {
+				idx = i
+				break
+			}
+		}
+		if idx == -1 {
+			t.mu.Unlock()
+			return
+		}
+
+		// Pick the next peer in rotation. Iterate until we either
+		// successfully acquire or every peer has refused.
+		entry := t.chain[idx]
+		acquired := false
+		attempts := 0
+		for attempts < len(t.peers) {
+			peer := t.peers[t.cursor]
+			t.cursor = (t.cursor + 1) % len(t.peers)
+			attempts++
+
+			_, err := t.replayer.Acquire(entry.hash, peer, nil)
+			if err == nil {
+				if wireErr := t.sender.RequestReplayDelta(peer, entry.hash); wireErr != nil {
+					// Wire send failed — release the slot and try the
+					// next peer. This is rare (transport-level error).
+					t.replayer.Abandon(entry.hash)
+					continue
+				}
+				t.chain[idx].acquired = true
+				acquired = true
+				break
+			}
+			// Acquire refused. The interesting cases are:
+			//   - ErrPerPeerCapacityFull: try the next peer.
+			//   - ErrCapacityFull: global cap reached — stop fanning out,
+			//     wait for a completion to free a slot.
+			//   - ErrAcquisitionExists: another task is acquiring the
+			//     same hash (rare). Treat as success — when its response
+			//     arrives, our HandleResponse-style lookup against
+			//     resp.LedgerHash still routes it correctly because the
+			//     Replayer.inFlight map is global. But the framing-
+			//     verified callback won't fire on us. For now, surface
+			//     this as a non-fatal "skip" — we'd need cross-task
+			//     subscription to handle properly. We mark the entry
+			//     acquired and rely on the eventual response routing to
+			//     us via OnDeltaResponse. If the other task abandons
+			//     before completing, we time out via the outer budget.
+			if errors.Is(err, ErrCapacityFull) {
+				// Wait for a completion. Don't keep trying more peers.
+				t.mu.Unlock()
+				return
+			}
+			if errors.Is(err, ErrAcquisitionExists) {
+				t.chain[idx].acquired = true
+				acquired = true
+				break
+			}
+			// ErrPerPeerCapacityFull or other — try next peer.
+		}
+
+		if !acquired {
+			// Every peer refused. Wait for a completion to retry.
+			t.mu.Unlock()
+			return
+		}
+		t.mu.Unlock()
+	}
+}
+
+// InFlightCount returns the number of chain entries currently
+// acquired-but-not-yet-verified. Exposed for tests and metrics.
+func (t *LedgerReplayTask) InFlightCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	n := 0
+	for _, st := range t.chain {
+		if st.acquired && !st.verified {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/ledger/inbound/replay_task.go
+++ b/internal/ledger/inbound/replay_task.go
@@ -11,28 +11,22 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 )
 
-// TaskState tracks LedgerReplayTask progress. Mirrors rippled's
-// LedgerReplayTask state model (WantSkipList → RunningDeltas →
-// Complete/Failed) without re-using the package-wide State enum,
-// which is for single-ledger acquisitions and does not have a
-// "running fan-out" notion.
+// TaskState tracks LedgerReplayTask progress. Distinct from the
+// package-wide State enum, which has no "running fan-out" notion.
+// Mirrors rippled's LedgerReplayTask state model (WantSkipList →
+// RunningDeltas → Complete/Failed).
 type TaskState int
 
 const (
-	// TaskStateWantSkipList: we've sent a TMProofPathRequest for the
-	// tip's LedgerHashes entry and are waiting for the proof.
+	// TaskStateWantSkipList: TMProofPathRequest sent, awaiting proof.
 	TaskStateWantSkipList TaskState = iota
-	// TaskStateRunningDeltas: skip-list verified, we're fanning out
-	// per-ancestor TMReplayDeltaRequest acquisitions bounded by the
-	// Replayer's global / per-peer caps.
+	// TaskStateRunningDeltas: skip-list verified, fanning out
+	// TMReplayDeltaRequest acquisitions under the Replayer's caps.
 	TaskStateRunningDeltas
-	// TaskStateComplete: every ancestor in the requested depth window
-	// has had its framing verified. Caller orchestrates downstream
-	// Apply against the local anchor.
+	// TaskStateComplete: every chain entry's framing has verified.
 	TaskStateComplete
-	// TaskStateFailed: the skip-list proof failed or no peer could
-	// serve a needed delta. Caller falls back to the legacy single-
-	// ledger forward acquisition path.
+	// TaskStateFailed: skip-list proof rejected, or a delta failed
+	// verification, or no peer could serve a needed delta.
 	TaskStateFailed
 )
 
@@ -43,14 +37,10 @@ const (
 // and replaying further back requires another task on a deeper tip.
 const MaxBackwardDepth = 256
 
-// TaskSender is the minimal wire-issuing interface the task needs.
-// Production wires this to the OverlaySender; tests fabricate a fake.
+// TaskSender is the wire-issuing interface the task needs. Mirrors
+// the relevant OverlaySender methods so tests can fabricate a fake.
 type TaskSender interface {
-	// RequestProofPath issues a TMProofPathRequest for (ledgerHash, key,
-	// mapType) to peerID. Mirrors OverlaySender.RequestProofPath.
 	RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mapType message.LedgerMapType) error
-	// RequestReplayDelta issues a TMReplayDeltaRequest for ledger hash
-	// to peerID. Mirrors OverlaySender.RequestReplayDelta.
 	RequestReplayDelta(peerID uint64, hash [32]byte) error
 }
 
@@ -89,31 +79,20 @@ type subtask struct {
 	delta    *ReplayDelta
 }
 
-// LedgerReplayTask coordinates a multi-ledger backward catch-up. Given
-// a known tip and the local anchor's depth-below-tip, it:
+// LedgerReplayTask coordinates a multi-ledger backward catch-up:
 //
-//  1. Acquires the tip's rolling-256 LedgerHashes SLE via
+//  1. Acquire the tip's rolling-256 LedgerHashes SLE via
 //     SkipListAcquire (one TMProofPathRequest).
-//  2. Extracts the (depth-1) ancestor hashes plus the tip's hash and
-//     enumerates them in chain order.
-//  3. Fans out per-ancestor TMReplayDeltaRequest acquisitions
-//     concurrently, bounded by Replayer's caps. As each completes its
-//     framing verification, the task fires the supplied callback so
-//     the caller can stitch the chain together via Apply.
+//  2. Enumerate (depth-1) ancestor hashes + the tip in chain order.
+//  3. Fan out per-ancestor TMReplayDeltaRequest acquisitions under
+//     Replayer's caps, firing the supplied callback as each entry's
+//     framing verifies so the caller can stitch the chain via Apply.
 //
 // Mirrors rippled's LedgerReplayTask
 // (rippled/src/xrpld/app/ledger/detail/LedgerReplayTask.cpp:135-209)
-// with two intentional simplifications:
-//   - The task does NOT run engine Apply itself; the caller does.
-//     Rippled keeps Apply in `LedgerReplayMsgHandler::processReplayDeltaResponse`
-//     which fires from the receive loop; goXRPL's router does the
-//     same thing today via Replayer.HandleResponse + Apply, so this
-//     task plugs into the existing seam.
-//   - The task does NOT split into multiple peers automatically; the
-//     caller supplies an ordered peer list and the task rotates
-//     through it when the Replayer rejects an Acquire with
-//     ErrPerPeerCapacityFull. (Future work: integrate peer-rotation
-//     on sub-task timeout, mirroring ReplayDelta's NoteSubTaskRetry.)
+// with two simplifications: the task does NOT run engine Apply (the
+// caller does), and peer rotation happens only on Acquire refusal,
+// not on response-level failure.
 type LedgerReplayTask struct {
 	tipHash   [32]byte
 	tipSeq    uint32
@@ -127,15 +106,10 @@ type LedgerReplayTask struct {
 	sender   TaskSender
 	logger   *slog.Logger
 
-	// OnDeltaVerified fires every time a chain ancestor's framing
-	// verification succeeds. The caller can adopt incrementally (in
-	// chain order) or batch until OnComplete fires. The callback is
-	// invoked WITHOUT the task lock held so callers may re-enter the
-	// task (e.g., Abort) from inside it.
+	// Callbacks fire WITHOUT the task lock held so callers may
+	// re-enter the task (e.g., Abort) from inside one.
 	onDeltaVerified func(seq uint32, hash [32]byte, rd *ReplayDelta)
-
-	// OnComplete fires once after every chain entry has verified.
-	onComplete func()
+	onComplete      func()
 
 	mu        sync.Mutex
 	state     TaskState
@@ -152,13 +126,9 @@ type TaskCallbacks struct {
 	OnComplete      func()
 }
 
-// NewLedgerReplayTask constructs a task targeting tipHash (with the
-// tip's known AccountHash) and a depth of `depth` ledgers backward.
-// The local anchor must sit at sequence tipSeq-depth — that anchor is
-// the caller's concern; the task only orchestrates wire fetches.
-//
-// Returns ErrTaskBadDepth if depth is 0 or > MaxBackwardDepth, and
-// ErrTaskNoPeers if peers is empty.
+// NewLedgerReplayTask constructs a task targeting tipHash (with
+// AccountHash=stateHash) walking back `depth` ledgers. The caller's
+// local anchor must sit at sequence tipSeq-depth.
 func NewLedgerReplayTask(
 	tipHash, stateHash [32]byte,
 	tipSeq, depth uint32,
@@ -193,30 +163,26 @@ func NewLedgerReplayTask(
 	}, nil
 }
 
-// State returns the current task state.
 func (t *LedgerReplayTask) State() TaskState {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.state
 }
 
-// Err returns the failure error, or nil if not in TaskStateFailed.
 func (t *LedgerReplayTask) Err() error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.err
 }
 
-// IsComplete reports whether every chain entry has verified.
 func (t *LedgerReplayTask) IsComplete() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.state == TaskStateComplete
 }
 
-// ChainSeqs returns the ordered sequence numbers the task is
-// fetching: chain[0]=tipSeq-depth+1 ... chain[depth-1]=tipSeq.
-// Returned slice is a defensive copy.
+// ChainSeqs returns a defensive copy of the ordered sequence numbers
+// the task is fetching: chain[0]=tipSeq-depth+1 ... chain[depth-1]=tipSeq.
 func (t *LedgerReplayTask) ChainSeqs() []uint32 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -227,13 +193,8 @@ func (t *LedgerReplayTask) ChainSeqs() []uint32 {
 	return out
 }
 
-// ChainEntries returns the (seq, hash) pairs of every chain entry,
-// oldest-first. Empty until the skip-list response has been
-// verified. Returned slices are defensive copies.
-//
-// Exposed so the router can pre-register hashes in its task-routing
-// map the moment the chain is known, rather than relying on lazy
-// registration during each subtask's OnDeltaVerified callback.
+// ChainEntries returns defensive copies of every chain entry's
+// (seq, hash), oldest-first. Empty until the skip-list verifies.
 func (t *LedgerReplayTask) ChainEntries() (seqs []uint32, hashes [][32]byte) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -246,9 +207,8 @@ func (t *LedgerReplayTask) ChainEntries() (seqs []uint32, hashes [][32]byte) {
 	return
 }
 
-// Start arms the skip-list acquisition and issues the wire request to
-// the first peer in the rotation. Subsequent OnSkipListResponse drives
-// the rest of the task.
+// Start arms the skip-list acquisition and issues the proof-path
+// request to the first peer in the rotation.
 func (t *LedgerReplayTask) Start() error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -284,13 +244,9 @@ func (t *LedgerReplayTask) Start() error {
 	return nil
 }
 
-// OnSkipListResponse handles a TMProofPathResponse routed to the task
-// (matched on resp.LedgerHash == tipHash). Verifies the proof,
-// populates the chain, and kicks off the delta fan-out.
-//
-// Returns nil on success, or a wrapped error on proof failure. After
-// a proof failure the task transitions to TaskStateFailed and the
-// caller falls back to single-ledger acquisition.
+// OnSkipListResponse verifies a TMProofPathResponse against the
+// stored stateHash, populates the chain, and kicks off the delta
+// fan-out. On proof failure the task transitions to TaskStateFailed.
 func (t *LedgerReplayTask) OnSkipListResponse(resp *message.ProofPathResponse) error {
 	t.mu.Lock()
 
@@ -324,9 +280,6 @@ func (t *LedgerReplayTask) OnSkipListResponse(resp *message.ProofPathResponse) e
 		return t.err
 	}
 
-	// Build chain oldest-first. The oldest needed seq is tipSeq-depth+1
-	// (assuming the local anchor sits at tipSeq-depth). For depth=50
-	// and tipSeq=N: chain[0]=N-49, chain[49]=N (tip).
 	chain := make([]subtask, 0, t.depth)
 	for k := needAncestors; k >= 1; k-- {
 		chain = append(chain, subtask{
@@ -338,7 +291,6 @@ func (t *LedgerReplayTask) OnSkipListResponse(resp *message.ProofPathResponse) e
 	t.chain = chain
 	t.state = TaskStateRunningDeltas
 
-	// Skip-list is no longer needed; free the coordinator slot.
 	t.replayer.CompleteSkipList(t.tipHash)
 	t.skipList = nil
 
@@ -357,19 +309,10 @@ func (t *LedgerReplayTask) OnSkipListResponse(resp *message.ProofPathResponse) e
 	return nil
 }
 
-// OnDeltaResponse handles a TMReplayDeltaResponse routed via the
-// Replayer to one of the task's in-flight subtasks. Marks the matching
-// chain entry verified, frees its Replayer slot, fires the
-// OnDeltaVerified callback, and dispatches the next queued chain
-// entry. When the last entry verifies, transitions the task to
-// TaskStateComplete and fires OnComplete.
-//
-// Returns the underlying ReplayDelta's verification error (if any) so
-// the caller can charge the offending peer. The task does NOT abort
-// on a single peer's bad-data — that subtask is abandoned and the
-// chain entry stays pending for the next peer rotation. (For this
-// initial implementation we abort the task on any subtask failure;
-// the multi-peer retry path is a follow-up.)
+// OnDeltaResponse handles a TMReplayDeltaResponse for one of the
+// task's in-flight subtasks: marks the chain entry verified, fires
+// OnDeltaVerified, and refills the fan-out. On verification failure
+// the entire task aborts; per-peer retry is a follow-up.
 func (t *LedgerReplayTask) OnDeltaResponse(resp *message.ReplayDeltaResponse) error {
 	t.mu.Lock()
 
@@ -430,9 +373,9 @@ func (t *LedgerReplayTask) OnDeltaResponse(resp *message.ReplayDeltaResponse) er
 	return nil
 }
 
-// Abort releases all Replayer slots the task is holding and marks
-// it failed with the supplied reason. Idempotent. Safe to call from
-// a callback (re-entrancy: only touches t.mu and the replayer).
+// Abort releases all Replayer slots the task holds and marks it
+// failed with the supplied reason. Idempotent and re-entrant from a
+// callback.
 func (t *LedgerReplayTask) Abort(reason error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -453,10 +396,8 @@ func (t *LedgerReplayTask) Abort(reason error) {
 }
 
 // dispatchPending fans out un-acquired chain entries through the
-// Replayer until the global / per-peer caps refuse, or the chain
-// drains. Called from OnSkipListResponse (initial fan-out) and after
-// each OnDeltaResponse (refill on completion). Caller must NOT hold
-// t.mu.
+// Replayer until the caps refuse or the chain drains. Caller must
+// NOT hold t.mu.
 func (t *LedgerReplayTask) dispatchPending() {
 	for {
 		t.mu.Lock()
@@ -465,7 +406,6 @@ func (t *LedgerReplayTask) dispatchPending() {
 			return
 		}
 
-		// Find next un-acquired chain entry in oldest-first order.
 		idx := -1
 		for i := range t.chain {
 			if !t.chain[i].acquired {
@@ -478,8 +418,6 @@ func (t *LedgerReplayTask) dispatchPending() {
 			return
 		}
 
-		// Pick the next peer in rotation. Iterate until we either
-		// successfully acquire or every peer has refused.
 		entry := t.chain[idx]
 		acquired := false
 		attempts := 0
@@ -491,8 +429,6 @@ func (t *LedgerReplayTask) dispatchPending() {
 			_, err := t.replayer.Acquire(entry.hash, peer, nil)
 			if err == nil {
 				if wireErr := t.sender.RequestReplayDelta(peer, entry.hash); wireErr != nil {
-					// Wire send failed — release the slot and try the
-					// next peer. This is rare (transport-level error).
 					t.replayer.Abandon(entry.hash)
 					continue
 				}
@@ -500,36 +436,24 @@ func (t *LedgerReplayTask) dispatchPending() {
 				acquired = true
 				break
 			}
-			// Acquire refused. The interesting cases are:
-			//   - ErrPerPeerCapacityFull: try the next peer.
-			//   - ErrCapacityFull: global cap reached — stop fanning out,
-			//     wait for a completion to free a slot.
-			//   - ErrAcquisitionExists: another task is acquiring the
-			//     same hash (rare). Treat as success — when its response
-			//     arrives, our HandleResponse-style lookup against
-			//     resp.LedgerHash still routes it correctly because the
-			//     Replayer.inFlight map is global. But the framing-
-			//     verified callback won't fire on us. For now, surface
-			//     this as a non-fatal "skip" — we'd need cross-task
-			//     subscription to handle properly. We mark the entry
-			//     acquired and rely on the eventual response routing to
-			//     us via OnDeltaResponse. If the other task abandons
-			//     before completing, we time out via the outer budget.
 			if errors.Is(err, ErrCapacityFull) {
-				// Wait for a completion. Don't keep trying more peers.
+				// Global cap reached — wait for a completion before
+				// trying more peers.
 				t.mu.Unlock()
 				return
 			}
 			if errors.Is(err, ErrAcquisitionExists) {
+				// Another task is fetching the same hash; trust the
+				// global inFlight map to route the response and mark
+				// acquired so we don't redundantly re-issue.
 				t.chain[idx].acquired = true
 				acquired = true
 				break
 			}
-			// ErrPerPeerCapacityFull or other — try next peer.
+			// ErrPerPeerCapacityFull or other — try the next peer.
 		}
 
 		if !acquired {
-			// Every peer refused. Wait for a completion to retry.
 			t.mu.Unlock()
 			return
 		}
@@ -537,8 +461,8 @@ func (t *LedgerReplayTask) dispatchPending() {
 	}
 }
 
-// InFlightCount returns the number of chain entries currently
-// acquired-but-not-yet-verified. Exposed for tests and metrics.
+// InFlightCount returns the number of chain entries acquired but not
+// yet verified.
 func (t *LedgerReplayTask) InFlightCount() int {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/internal/ledger/inbound/replay_task.go
+++ b/internal/ledger/inbound/replay_task.go
@@ -74,9 +74,14 @@ var (
 type subtask struct {
 	hash     [32]byte
 	seq      uint32
-	acquired bool       // RequestReplayDelta has been sent
-	verified bool       // framing-verified by the underlying ReplayDelta
+	acquired bool // RequestReplayDelta has been sent
+	verified bool // framing-verified by the underlying ReplayDelta
 	delta    *ReplayDelta
+	// tried records peers we've already asked for this hash. On
+	// verification failure we re-dispatch to a peer not in this set
+	// rather than aborting the whole task. Mirrors rippled's per-
+	// subtask peer rotation (LedgerReplayer.h:49-57).
+	tried map[uint64]bool
 }
 
 // LedgerReplayTask coordinates a multi-ledger backward catch-up:
@@ -283,11 +288,16 @@ func (t *LedgerReplayTask) OnSkipListResponse(resp *message.ProofPathResponse) e
 	chain := make([]subtask, 0, t.depth)
 	for k := needAncestors; k >= 1; k-- {
 		chain = append(chain, subtask{
-			hash: hashes[len(hashes)-k],
-			seq:  t.tipSeq - uint32(k),
+			hash:  hashes[len(hashes)-k],
+			seq:   t.tipSeq - uint32(k),
+			tried: make(map[uint64]bool),
 		})
 	}
-	chain = append(chain, subtask{hash: t.tipHash, seq: t.tipSeq})
+	chain = append(chain, subtask{
+		hash:  t.tipHash,
+		seq:   t.tipSeq,
+		tried: make(map[uint64]bool),
+	})
 	t.chain = chain
 	t.state = TaskStateRunningDeltas
 
@@ -321,7 +331,7 @@ func (t *LedgerReplayTask) OnDeltaResponse(resp *message.ReplayDeltaResponse) er
 		return fmt.Errorf("%w: OnDeltaResponse from state %d", ErrTaskWrongState, t.state)
 	}
 
-	respHash, ok := toHash32(resp.LedgerHash)
+	respHash, ok := ToHash32(resp.LedgerHash)
 	if !ok {
 		t.mu.Unlock()
 		return ErrNoMatchingAcquisition
@@ -341,11 +351,30 @@ func (t *LedgerReplayTask) OnDeltaResponse(resp *message.ReplayDeltaResponse) er
 
 	rd, err := t.replayer.HandleResponse(resp)
 	if err != nil {
+		// Verification failed against this peer. Drop the
+		// acquisition and mark the subtask as not-acquired so
+		// dispatchPending re-issues to a fresh peer. The whole task
+		// only fails if every peer has been tried for this hash.
 		t.replayer.Abandon(respHash)
-		t.state = TaskStateFailed
-		t.err = fmt.Errorf("verify delta seq=%d: %w", t.chain[idx].seq, err)
+		t.chain[idx].acquired = false
+		t.chain[idx].delta = nil
+		untried := 0
+		for _, p := range t.peers {
+			if !t.chain[idx].tried[p] {
+				untried++
+			}
+		}
+		if untried == 0 {
+			t.state = TaskStateFailed
+			t.err = fmt.Errorf("verify delta seq=%d (all peers exhausted): %w",
+				t.chain[idx].seq, err)
+			t.mu.Unlock()
+			return t.err
+		}
+		retryErr := fmt.Errorf("verify delta seq=%d: %w", t.chain[idx].seq, err)
 		t.mu.Unlock()
-		return t.err
+		t.dispatchPending()
+		return retryErr
 	}
 	t.chain[idx].delta = rd
 	t.chain[idx].verified = true
@@ -426,6 +455,11 @@ func (t *LedgerReplayTask) dispatchPending() {
 			t.cursor = (t.cursor + 1) % len(t.peers)
 			attempts++
 
+			// Skip peers that already returned bad data for this hash.
+			if entry.tried[peer] {
+				continue
+			}
+
 			_, err := t.replayer.Acquire(entry.hash, peer, nil)
 			if err == nil {
 				if wireErr := t.sender.RequestReplayDelta(peer, entry.hash); wireErr != nil {
@@ -433,6 +467,7 @@ func (t *LedgerReplayTask) dispatchPending() {
 					continue
 				}
 				t.chain[idx].acquired = true
+				t.chain[idx].tried[peer] = true
 				acquired = true
 				break
 			}
@@ -447,6 +482,7 @@ func (t *LedgerReplayTask) dispatchPending() {
 				// global inFlight map to route the response and mark
 				// acquired so we don't redundantly re-issue.
 				t.chain[idx].acquired = true
+				t.chain[idx].tried[peer] = true
 				acquired = true
 				break
 			}

--- a/internal/ledger/inbound/replay_task_test.go
+++ b/internal/ledger/inbound/replay_task_test.go
@@ -276,6 +276,7 @@ func TestLedgerReplayTask_50LedgerBackwardWalk(t *testing.T) {
 	for i, h := range chainHashes {
 		chainSeqByHash[h] = i
 	}
+	alreadyDelivered := map[[32]byte]bool{}
 
 	for !task.IsComplete() {
 		// Take a snapshot of the next-not-yet-responded request.
@@ -338,12 +339,6 @@ func TestLedgerReplayTask_50LedgerBackwardWalk(t *testing.T) {
 	assert.Equal(t, 0, replayer.Count(), "all replay-delta slots freed")
 	assert.Equal(t, 0, replayer.SkipListCount(), "skip-list slot freed")
 }
-
-// alreadyDelivered is shared between sub-tests in this file so the
-// 50-ledger driver and the parallelism driver can both track which
-// (peer,hash) pairs have been responded to without re-instantiating a
-// recorder.
-var alreadyDelivered = map[[32]byte]bool{}
 
 // TestLedgerReplayTask_ParallelismBoundedByExistingCaps drives the
 // same 50-ledger backward walk but asserts at every wire event that

--- a/internal/ledger/inbound/replay_task_test.go
+++ b/internal/ledger/inbound/replay_task_test.go
@@ -1,0 +1,515 @@
+package inbound
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emptyTxMapRoot returns the canonical empty SHAMap.TypeTransaction
+// root. Cached at first use because constructing it is the same work
+// the verifier does for an empty tx list — keeping the helper
+// transparent makes the test header builder one-liner.
+var emptyTxMapRootOnce = struct {
+	sync.Once
+	root [32]byte
+}{}
+
+func emptyTxMapRoot(t *testing.T) [32]byte {
+	t.Helper()
+	emptyTxMapRootOnce.Do(func() {
+		sm, err := shamap.New(shamap.TypeTransaction)
+		require.NoError(t, err)
+		require.NoError(t, sm.SetImmutable())
+		root, err := sm.Hash()
+		require.NoError(t, err)
+		emptyTxMapRootOnce.root = root
+	})
+	return emptyTxMapRootOnce.root
+}
+
+// makeSyntheticLedgerHeader fabricates a serializable ledger header
+// for the given seq, parent hash, and a synthetic account hash. Each
+// header in the chain links cryptographically: the returned hash
+// equals what genesis.CalculateLedgerHash produces for the header
+// bytes, so a ReplayDeltaResponse carrying these bytes verifies under
+// the existing framing path.
+func makeSyntheticLedgerHeader(t *testing.T, seq uint32, parentHash, accountHash [32]byte) (headerBytes []byte, ledgerHash [32]byte) {
+	t.Helper()
+
+	closeBase := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Stagger close times by seq so each header is distinct even when
+	// every other field matches.
+	closeTime := closeBase.Add(time.Duration(seq) * 10 * time.Second)
+
+	hdr := header.LedgerHeader{
+		LedgerIndex:         seq,
+		ParentHash:          parentHash,
+		ParentCloseTime:     closeTime,
+		CloseTime:           closeTime.Add(10 * time.Second),
+		CloseTimeResolution: 10,
+		Drops:               100_000_000_000_000_000,
+		CloseFlags:          0,
+		TxHash:              emptyTxMapRoot(t),
+		AccountHash:         accountHash,
+	}
+	bytes, err := header.AddRaw(hdr, false)
+	require.NoError(t, err)
+
+	parsed, err := header.DeserializeHeader(bytes, false)
+	require.NoError(t, err)
+	expected := genesis.CalculateLedgerHash(*parsed)
+	return bytes, expected
+}
+
+// buildChain fabricates a chain of n+1 ledger headers starting from
+// anchor seq+1 up through tipSeq=anchorSeq+n. Returns:
+//
+//	headers[i] = serialized header for seq anchorSeq+1+i
+//	hashes[i]  = canonical hash of headers[i]
+//
+// hashes[0] is the oldest, hashes[n-1] is the tip. Each header's
+// ParentHash chains to hashes[i-1] (or anchorHash for i=0).
+func buildChain(t *testing.T, anchorHash [32]byte, anchorSeq uint32, n int) (headers [][]byte, hashes [][32]byte) {
+	t.Helper()
+	headers = make([][]byte, n)
+	hashes = make([][32]byte, n)
+	parent := anchorHash
+	for i := 0; i < n; i++ {
+		seq := anchorSeq + uint32(i) + 1
+		// Per-seq synthetic account hash so headers differ even with
+		// identical close times and tx hashes.
+		var ah [32]byte
+		ah[0] = byte(seq >> 8)
+		ah[1] = byte(seq)
+		hb, h := makeSyntheticLedgerHeader(t, seq, parent, ah)
+		headers[i] = hb
+		hashes[i] = h
+		parent = h
+	}
+	return
+}
+
+// recordingTaskSender captures every RequestProofPath /
+// RequestReplayDelta the task issues and exposes them for replay
+// against the task via callbacks. It tracks in-flight delta counts so
+// the parallelism-cap test can assert at every wire event.
+type recordingTaskSender struct {
+	mu        sync.Mutex
+	proofReqs []proofReq
+	deltaReqs []deltaReq
+
+	// inFlightPerPeer / inFlightGlobal are book-kept on each delta
+	// request and decremented when the test "delivers" a response.
+	inFlightPerPeer map[uint64]int
+	inFlightGlobal  int
+
+	// peakInFlight* track the maximum observed so test assertions can
+	// confirm the caps were respected.
+	peakGlobal   int
+	peakPerPeer  map[uint64]int
+
+	// failProof / failDelta optionally cause the next wire call to
+	// fail synchronously, simulating transport errors.
+	failProofOnce atomic.Bool
+	failDeltaOnce atomic.Bool
+}
+
+type proofReq struct {
+	PeerID     uint64
+	LedgerHash [32]byte
+	Key        [32]byte
+	MapType    message.LedgerMapType
+}
+
+type deltaReq struct {
+	PeerID uint64
+	Hash   [32]byte
+}
+
+func newRecordingTaskSender() *recordingTaskSender {
+	return &recordingTaskSender{
+		inFlightPerPeer: make(map[uint64]int),
+		peakPerPeer:     make(map[uint64]int),
+	}
+}
+
+func (s *recordingTaskSender) RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mt message.LedgerMapType) error {
+	if s.failProofOnce.CompareAndSwap(true, false) {
+		return errors.New("synthetic proof-path send failure")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.proofReqs = append(s.proofReqs, proofReq{peerID, ledgerHash, key, mt})
+	return nil
+}
+
+func (s *recordingTaskSender) RequestReplayDelta(peerID uint64, hash [32]byte) error {
+	if s.failDeltaOnce.CompareAndSwap(true, false) {
+		return errors.New("synthetic delta send failure")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deltaReqs = append(s.deltaReqs, deltaReq{peerID, hash})
+	s.inFlightGlobal++
+	s.inFlightPerPeer[peerID]++
+	if s.inFlightGlobal > s.peakGlobal {
+		s.peakGlobal = s.inFlightGlobal
+	}
+	if s.inFlightPerPeer[peerID] > s.peakPerPeer[peerID] {
+		s.peakPerPeer[peerID] = s.inFlightPerPeer[peerID]
+	}
+	return nil
+}
+
+func (s *recordingTaskSender) noteDeltaDelivered(peerID uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inFlightGlobal--
+	s.inFlightPerPeer[peerID]--
+}
+
+func (s *recordingTaskSender) deltaReqsCopy() []deltaReq {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]deltaReq, len(s.deltaReqs))
+	copy(out, s.deltaReqs)
+	return out
+}
+
+// TestLedgerReplayTask_50LedgerBackwardWalk drives the full backward
+// catchup: node has local anchor at seq N-50, task fetches tip's
+// skip-list, then framing-verifies all 50 ancestor + tip ledgers in
+// chain order. Verifies the OnDeltaVerified callback fires for every
+// chain entry and the task transitions to TaskStateComplete.
+func TestLedgerReplayTask_50LedgerBackwardWalk(t *testing.T) {
+	const (
+		depth     uint32 = 50
+		anchorSeq uint32 = 1000
+		tipSeq    uint32 = anchorSeq + depth
+	)
+	anchorHash := [32]byte{0xAA}
+
+	// Build the 50 ledgers from anchor+1 to tip.
+	chainHeaders, chainHashes := buildChain(t, anchorHash, anchorSeq, int(depth))
+	tipHash := chainHashes[len(chainHashes)-1]
+
+	// Build the skip-list SLE for the tip's state: the rolling-256
+	// list as it would exist after the tip's close. Pad earlier
+	// entries with dummy hashes so the LAST 49 entries are the
+	// hashes of seqs tip-49..tip-1 (which is chainHashes[0..48]).
+	skipHashes := make([][32]byte, 256)
+	// Earlier 207 slots filled with deterministic but distinct
+	// fillers so they wouldn't accidentally collide with chainHashes.
+	for i := 0; i < 256-49; i++ {
+		var h [32]byte
+		h[0] = 0xCC
+		h[1] = byte(i)
+		skipHashes[i] = h
+	}
+	// Last 49 = chainHashes[0..48] (seqs tipSeq-49..tipSeq-1).
+	copy(skipHashes[256-49:], chainHashes[:49])
+
+	leafPayload := buildSkipListLeafSLE(t, skipHashes, tipSeq-1)
+	stateHash, proofPath := buildSkipListProof(t, leafPayload)
+
+	// Wire up task + sender + replayer.
+	replayer := NewReplayer(nil, nil, 0)
+	sender := newRecordingTaskSender()
+
+	verifiedOrder := []uint32{}
+	var verifiedMu sync.Mutex
+	cb := TaskCallbacks{
+		OnDeltaVerified: func(seq uint32, hash [32]byte, rd *ReplayDelta) {
+			verifiedMu.Lock()
+			defer verifiedMu.Unlock()
+			verifiedOrder = append(verifiedOrder, seq)
+			assert.True(t, rd.IsComplete(), "callback must fire after rd.IsComplete")
+		},
+	}
+
+	task, err := NewLedgerReplayTask(
+		tipHash, stateHash, tipSeq, depth,
+		[]uint64{42, 43, 44}, // three peers — global cap can be reached
+		replayer, sender, nil, cb,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, task.Start())
+	assert.Equal(t, TaskStateWantSkipList, task.State())
+	require.Len(t, sender.proofReqs, 1)
+	assert.Equal(t, tipHash, sender.proofReqs[0].LedgerHash)
+	assert.Equal(t, message.LedgerMapAccountState, sender.proofReqs[0].MapType)
+
+	// Deliver the skip-list proof — task should fan out deltas.
+	skipKey := keylet.LedgerHashes().Key
+	proofResp := &message.ProofPathResponse{
+		LedgerHash: tipHash[:],
+		Key:        skipKey[:],
+		MapType:    message.LedgerMapAccountState,
+		Path:       proofPath,
+	}
+	require.NoError(t, task.OnSkipListResponse(proofResp))
+	assert.Equal(t, TaskStateRunningDeltas, task.State())
+
+	// After initial fan-out, sender should have queued exactly
+	// min(depth, DefaultMaxInFlightReplays) delta requests — depth=50
+	// here, cap=16, so 16 requests are in flight, the rest pending.
+	require.GreaterOrEqual(t, len(sender.deltaReqsCopy()), 1,
+		"task must fan out at least one delta on skip-list arrival")
+	assert.LessOrEqual(t, len(sender.deltaReqsCopy()), DefaultMaxInFlightReplays,
+		"initial fan-out must respect the global cap")
+
+	// Deliver delta responses in chain order, refilling the fan-out
+	// each time. Continue until the task completes.
+	chainSeqByHash := make(map[[32]byte]int)
+	for i, h := range chainHashes {
+		chainSeqByHash[h] = i
+	}
+
+	for !task.IsComplete() {
+		// Take a snapshot of the next-not-yet-responded request.
+		reqs := sender.deltaReqsCopy()
+		var next *deltaReq
+		for i := range reqs {
+			r := reqs[i]
+			// We don't track per-request delivery state on the recorder
+			// directly; instead we look up the chain entry by hash and
+			// check if the task already verified it.
+			idx, ok := chainSeqByHash[r.Hash]
+			if !ok {
+				t.Fatalf("sender issued delta for unknown hash %x", r.Hash[:8])
+			}
+			seq := chainHashes[idx]
+			_ = seq
+			// Use the task's snapshot to find an unverified hash.
+			// (Avoid coupling to internal chain state by querying
+			// what's outstanding via the per-test pendingMap.)
+			next = &r
+			// Skip if we've already delivered (i.e., the in-flight
+			// counter would underflow). The simplest invariant is:
+			// for each unique deltaReq, deliver exactly once. We
+			// track that here.
+			if alreadyDelivered[r.Hash] {
+				next = nil
+				continue
+			}
+			break
+		}
+		require.NotNil(t, next, "no pending delta to deliver but task incomplete")
+		alreadyDelivered[next.Hash] = true
+
+		idx := chainSeqByHash[next.Hash]
+		deltaResp := &message.ReplayDeltaResponse{
+			LedgerHash:   next.Hash[:],
+			LedgerHeader: chainHeaders[idx],
+			Transactions: nil,
+		}
+		sender.noteDeltaDelivered(next.PeerID)
+		require.NoError(t, task.OnDeltaResponse(deltaResp))
+	}
+
+	// Every chain entry must have verified, in oldest-first order.
+	require.Len(t, verifiedOrder, int(depth))
+	// The task fires the callback in the order responses arrive (not
+	// strictly chain-ordered: deliveries can interleave across peers).
+	// What we MUST hold: every seq from anchorSeq+1..tipSeq appears
+	// exactly once.
+	seen := make(map[uint32]bool, len(verifiedOrder))
+	for _, s := range verifiedOrder {
+		assert.GreaterOrEqual(t, s, anchorSeq+1)
+		assert.LessOrEqual(t, s, tipSeq)
+		assert.False(t, seen[s], "seq %d verified twice", s)
+		seen[s] = true
+	}
+	assert.Len(t, seen, int(depth))
+	assert.Equal(t, TaskStateComplete, task.State())
+	// Replayer slots should be drained.
+	assert.Equal(t, 0, replayer.Count(), "all replay-delta slots freed")
+	assert.Equal(t, 0, replayer.SkipListCount(), "skip-list slot freed")
+}
+
+// alreadyDelivered is shared between sub-tests in this file so the
+// 50-ledger driver and the parallelism driver can both track which
+// (peer,hash) pairs have been responded to without re-instantiating a
+// recorder.
+var alreadyDelivered = map[[32]byte]bool{}
+
+// TestLedgerReplayTask_ParallelismBoundedByExistingCaps drives the
+// same 50-ledger backward walk but asserts at every wire event that
+// in-flight counts never exceed the Replayer's caps:
+//
+//	DefaultMaxInFlightReplays = 16 globally
+//	MaxPerPeerReplays         =  2 per peer
+//
+// With three peers and 50 chain entries, the global cap of 16 caps
+// concurrent in-flight at 16 (3 peers × 2 each = 6 is the per-peer
+// ceiling, so the per-peer cap is the binding constraint here).
+func TestLedgerReplayTask_ParallelismBoundedByExistingCaps(t *testing.T) {
+	const (
+		depth     uint32 = 50
+		anchorSeq uint32 = 5000
+		tipSeq    uint32 = anchorSeq + depth
+	)
+	anchorHash := [32]byte{0xBB}
+
+	chainHeaders, chainHashes := buildChain(t, anchorHash, anchorSeq, int(depth))
+	tipHash := chainHashes[len(chainHashes)-1]
+
+	skipHashes := make([][32]byte, 256)
+	for i := 0; i < 256-49; i++ {
+		var h [32]byte
+		h[0] = 0xDD
+		h[1] = byte(i)
+		skipHashes[i] = h
+	}
+	copy(skipHashes[256-49:], chainHashes[:49])
+
+	leafPayload := buildSkipListLeafSLE(t, skipHashes, tipSeq-1)
+	stateHash, proofPath := buildSkipListProof(t, leafPayload)
+
+	replayer := NewReplayer(nil, nil, 0)
+	sender := newRecordingTaskSender()
+
+	peers := []uint64{100, 101, 102}
+	task, err := NewLedgerReplayTask(
+		tipHash, stateHash, tipSeq, depth,
+		peers,
+		replayer, sender, nil, TaskCallbacks{},
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, task.Start())
+	skipKey := keylet.LedgerHashes().Key
+	require.NoError(t, task.OnSkipListResponse(&message.ProofPathResponse{
+		LedgerHash: tipHash[:],
+		Key:        skipKey[:],
+		MapType:    message.LedgerMapAccountState,
+		Path:       proofPath,
+	}))
+
+	// Drive deliveries one at a time, asserting cap invariants after
+	// every batch of new wire requests.
+	chainSeqByHash := make(map[[32]byte]int)
+	for i, h := range chainHashes {
+		chainSeqByHash[h] = i
+	}
+	delivered := make(map[[32]byte]bool)
+
+	for !task.IsComplete() {
+		// After every fan-out, the in-flight bookkeeping must respect
+		// both caps.
+		assertCaps(t, sender, peers)
+
+		// Find the next undelivered delta in order of issuance.
+		reqs := sender.deltaReqsCopy()
+		var next *deltaReq
+		for i := range reqs {
+			r := reqs[i]
+			if !delivered[r.Hash] {
+				next = &r
+				break
+			}
+		}
+		require.NotNil(t, next, "no pending delta but task incomplete")
+		delivered[next.Hash] = true
+
+		idx := chainSeqByHash[next.Hash]
+		sender.noteDeltaDelivered(next.PeerID)
+		require.NoError(t, task.OnDeltaResponse(&message.ReplayDeltaResponse{
+			LedgerHash:   next.Hash[:],
+			LedgerHeader: chainHeaders[idx],
+			Transactions: nil,
+		}))
+	}
+
+	// Final assertions.
+	assertCaps(t, sender, peers)
+	assert.Equal(t, TaskStateComplete, task.State())
+	assert.LessOrEqual(t, sender.peakGlobal, DefaultMaxInFlightReplays,
+		"global cap must never be exceeded")
+	for _, p := range peers {
+		assert.LessOrEqual(t, sender.peakPerPeer[p], MaxPerPeerReplays,
+			"per-peer cap must never be exceeded for peer %d", p)
+	}
+	// Sanity: the work was actually distributed — not all 50 deltas
+	// went through one peer.
+	usedPeers := 0
+	for _, p := range peers {
+		if sender.peakPerPeer[p] > 0 {
+			usedPeers++
+		}
+	}
+	assert.Greater(t, usedPeers, 1, "task must rotate across peers under per-peer cap pressure")
+}
+
+func assertCaps(t *testing.T, s *recordingTaskSender, peers []uint64) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	assert.LessOrEqualf(t, s.inFlightGlobal, DefaultMaxInFlightReplays,
+		"global in-flight %d exceeds cap %d", s.inFlightGlobal, DefaultMaxInFlightReplays)
+	for _, p := range peers {
+		assert.LessOrEqualf(t, s.inFlightPerPeer[p], MaxPerPeerReplays,
+			"per-peer in-flight for %d = %d exceeds cap %d",
+			p, s.inFlightPerPeer[p], MaxPerPeerReplays)
+	}
+}
+
+// TestLedgerReplayTask_DepthValidation rejects out-of-range depth.
+func TestLedgerReplayTask_DepthValidation(t *testing.T) {
+	r := NewReplayer(nil, nil, 0)
+	s := newRecordingTaskSender()
+
+	_, err := NewLedgerReplayTask([32]byte{}, [32]byte{}, 100, 0, []uint64{1}, r, s, nil, TaskCallbacks{})
+	assert.ErrorIs(t, err, ErrTaskBadDepth, "depth=0 must be rejected")
+
+	_, err = NewLedgerReplayTask([32]byte{}, [32]byte{}, 100, MaxBackwardDepth+1, []uint64{1}, r, s, nil, TaskCallbacks{})
+	assert.ErrorIs(t, err, ErrTaskBadDepth, "depth>MaxBackwardDepth must be rejected")
+
+	_, err = NewLedgerReplayTask([32]byte{}, [32]byte{}, 100, 10, nil, r, s, nil, TaskCallbacks{})
+	assert.ErrorIs(t, err, ErrTaskNoPeers, "empty peer list must be rejected")
+}
+
+// TestLedgerReplayTask_SkipListTooShort aborts when the verified
+// skip-list has fewer hashes than the requested depth needs.
+func TestLedgerReplayTask_SkipListTooShort(t *testing.T) {
+	const depth uint32 = 50
+	tipHash := [32]byte{0xEE}
+	// Only 10 hashes — depth=50 needs 49 ancestors.
+	short := make([][32]byte, 10)
+	for i := range short {
+		short[i] = [32]byte{byte(i + 1)}
+	}
+	leafPayload := buildSkipListLeafSLE(t, short, 999)
+	stateHash, proofPath := buildSkipListProof(t, leafPayload)
+
+	r := NewReplayer(nil, nil, 0)
+	s := newRecordingTaskSender()
+	task, err := NewLedgerReplayTask(tipHash, stateHash, 1000, depth, []uint64{1}, r, s, nil, TaskCallbacks{})
+	require.NoError(t, err)
+	require.NoError(t, task.Start())
+
+	skipKey := keylet.LedgerHashes().Key
+	resp := &message.ProofPathResponse{
+		LedgerHash: tipHash[:],
+		Key:        skipKey[:],
+		MapType:    message.LedgerMapAccountState,
+		Path:       proofPath,
+	}
+	err = task.OnSkipListResponse(resp)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTaskSkipListTooShort)
+	assert.Equal(t, TaskStateFailed, task.State())
+	assert.Equal(t, 0, r.SkipListCount(), "skip-list slot freed on abort")
+}

--- a/internal/ledger/inbound/replayer.go
+++ b/internal/ledger/inbound/replayer.go
@@ -74,12 +74,21 @@ type TimedOutEntry struct {
 // caller (the consensus router) issues the wire request via its own
 // NetworkSender. This keeps the Replayer easy to unit-test and mirrors
 // how inbound.Ledger is already layered against its transport.
+//
+// The Replayer also tracks in-flight *SkipListAcquire acquisitions,
+// keyed by the TARGET ledger hash (the tip whose 256-entry ancestor
+// vector we're fetching). Skip-list and replay-delta acquisitions
+// each have their own map so the per-hash dedup is precise — a node
+// might legitimately want both a skip-list for hash X and a
+// replay-delta for the same hash X if X is both a multi-ledger
+// catch-up tip and a single-ledger forward acquisition target.
 type Replayer struct {
-	mu          sync.Mutex
-	inFlight    map[[32]byte]*ReplayDelta
-	logger      *slog.Logger
-	clock       Clock
-	maxInFlight int
+	mu            sync.Mutex
+	inFlight      map[[32]byte]*ReplayDelta
+	inFlightSkip  map[[32]byte]*SkipListAcquire
+	logger        *slog.Logger
+	clock         Clock
+	maxInFlight   int
 }
 
 // NewReplayer returns a Replayer configured with the given concurrency
@@ -97,10 +106,11 @@ func NewReplayer(logger *slog.Logger, clock Clock, maxInFlight int) *Replayer {
 		maxInFlight = DefaultMaxInFlightReplays
 	}
 	return &Replayer{
-		inFlight:    make(map[[32]byte]*ReplayDelta),
-		logger:      logger,
-		clock:       clock,
-		maxInFlight: maxInFlight,
+		inFlight:     make(map[[32]byte]*ReplayDelta),
+		inFlightSkip: make(map[[32]byte]*SkipListAcquire),
+		logger:       logger,
+		clock:        clock,
+		maxInFlight:  maxInFlight,
 	}
 }
 
@@ -232,8 +242,9 @@ func (r *Replayer) Abandon(hash [32]byte) {
 func (r *Replayer) Stop() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	n := len(r.inFlight)
+	n := len(r.inFlight) + len(r.inFlightSkip)
 	r.inFlight = make(map[[32]byte]*ReplayDelta)
+	r.inFlightSkip = make(map[[32]byte]*SkipListAcquire)
 	return n
 }
 
@@ -322,4 +333,105 @@ func (r *Replayer) Has(hash [32]byte) bool {
 	defer r.mu.Unlock()
 	_, ok := r.inFlight[hash]
 	return ok
+}
+
+// AcquireSkipList arms a new *SkipListAcquire for the rolling-256
+// LedgerHashes entry of targetHash, anchored on stateHash (the
+// target's AccountHash). Slot accounting is SEPARATE from
+// replay-delta acquisitions: skip-list fetches are short-lived (one
+// proof request, one response, no per-tx engine apply) and would
+// otherwise be starved by a 16-deep delta backlog. The dedup,
+// per-peer, and global cap semantics mirror Acquire.
+//
+// Returns:
+//   - ErrAcquisitionExists: targetHash already has a skip-list in flight.
+//   - ErrCapacityFull: at the maxInFlight cap.
+//   - ErrPerPeerCapacityFull: peerID already has MaxPerPeerReplays
+//     skip-list acquisitions in flight (kept separate from replay-delta
+//     per-peer accounting; the wire requests are distinct).
+func (r *Replayer) AcquireSkipList(targetHash, stateHash [32]byte, peerID uint64) (*SkipListAcquire, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.inFlightSkip[targetHash]; exists {
+		return nil, ErrAcquisitionExists
+	}
+	if len(r.inFlightSkip) >= r.maxInFlight {
+		return nil, ErrCapacityFull
+	}
+
+	perPeer := 0
+	for _, sa := range r.inFlightSkip {
+		if sa.PeerID() == peerID {
+			perPeer++
+		}
+	}
+	if perPeer >= MaxPerPeerReplays {
+		return nil, ErrPerPeerCapacityFull
+	}
+
+	sa := NewSkipListAcquireWithClock(targetHash, stateHash, peerID, r.logger, r.clock)
+	r.inFlightSkip[targetHash] = sa
+	return sa, nil
+}
+
+// HandleSkipListResponse routes resp to the matching in-flight
+// SkipListAcquire (keyed by resp.LedgerHash), runs its GotResponse
+// verifier, and returns the acquisition so the caller can consume
+// Hashes(). Returns ErrNoMatchingAcquisition for stale/unsolicited
+// responses. Mirrors HandleResponse's contract for replay-delta.
+func (r *Replayer) HandleSkipListResponse(resp *message.ProofPathResponse) (*SkipListAcquire, error) {
+	if resp == nil {
+		return nil, ErrNoMatchingAcquisition
+	}
+	hash, ok := toHash32(resp.LedgerHash)
+	if !ok {
+		return nil, ErrNoMatchingAcquisition
+	}
+
+	r.mu.Lock()
+	sa, exists := r.inFlightSkip[hash]
+	r.mu.Unlock()
+
+	if !exists {
+		return nil, ErrNoMatchingAcquisition
+	}
+
+	if err := sa.GotResponse(resp); err != nil {
+		return sa, err
+	}
+	return sa, nil
+}
+
+// CompleteSkipList removes the skip-list acquisition for targetHash
+// from in-flight. Counterpart to Complete for replay-delta.
+func (r *Replayer) CompleteSkipList(targetHash [32]byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.inFlightSkip, targetHash)
+}
+
+// AbandonSkipList is a synonym for CompleteSkipList at the caller
+// site — "we're giving up" vs "we finished" reads more clearly than
+// reusing a single name for both intents.
+func (r *Replayer) AbandonSkipList(targetHash [32]byte) {
+	r.CompleteSkipList(targetHash)
+}
+
+// HasSkipList reports whether the given target hash currently has a
+// skip-list acquisition in flight.
+func (r *Replayer) HasSkipList(targetHash [32]byte) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.inFlightSkip[targetHash]
+	return ok
+}
+
+// SkipListCount returns the number of in-flight skip-list
+// acquisitions. Separate from Count (replay-delta) so tests and
+// metrics can distinguish the two work streams.
+func (r *Replayer) SkipListCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.inFlightSkip)
 }

--- a/internal/ledger/inbound/replayer.go
+++ b/internal/ledger/inbound/replayer.go
@@ -183,7 +183,7 @@ func (r *Replayer) HandleResponse(resp *message.ReplayDeltaResponse) (*ReplayDel
 	if resp == nil {
 		return nil, ErrNoMatchingAcquisition
 	}
-	hash, ok := toHash32(resp.LedgerHash)
+	hash, ok := ToHash32(resp.LedgerHash)
 	if !ok {
 		return nil, ErrNoMatchingAcquisition
 	}
@@ -369,7 +369,7 @@ func (r *Replayer) HandleSkipListResponse(resp *message.ProofPathResponse) (*Ski
 	if resp == nil {
 		return nil, ErrNoMatchingAcquisition
 	}
-	hash, ok := toHash32(resp.LedgerHash)
+	hash, ok := ToHash32(resp.LedgerHash)
 	if !ok {
 		return nil, ErrNoMatchingAcquisition
 	}
@@ -415,4 +415,19 @@ func (r *Replayer) SkipListCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.inFlightSkip)
+}
+
+// SkipListTimedOut returns target hashes of every in-flight skip-list
+// acquisition whose outer budget has expired. Counterpart to TimedOut.
+func (r *Replayer) SkipListTimedOut() [][32]byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var out [][32]byte
+	for h, sa := range r.inFlightSkip {
+		if sa.IsTimedOut() {
+			out = append(out, h)
+		}
+	}
+	return out
 }

--- a/internal/ledger/inbound/replayer.go
+++ b/internal/ledger/inbound/replayer.go
@@ -67,21 +67,15 @@ type TimedOutEntry struct {
 	PeerID uint64
 }
 
-// Replayer coordinates multiple concurrent *ReplayDelta acquisitions,
-// keyed by target ledger hash, under a shared concurrency cap. Mirrors
-// rippled's LedgerReplayer: it holds a map<uint256, LedgerDeltaAcquire>
-// and hands out slots up to maxInFlight. Transport-agnostic — the
-// caller (the consensus router) issues the wire request via its own
-// NetworkSender. This keeps the Replayer easy to unit-test and mirrors
-// how inbound.Ledger is already layered against its transport.
+// Replayer coordinates concurrent *ReplayDelta and *SkipListAcquire
+// acquisitions under a shared cap. Transport-agnostic; the caller
+// issues the wire request via its own NetworkSender. Mirrors
+// rippled's LedgerReplayer.
 //
-// The Replayer also tracks in-flight *SkipListAcquire acquisitions,
-// keyed by the TARGET ledger hash (the tip whose 256-entry ancestor
-// vector we're fetching). Skip-list and replay-delta acquisitions
-// each have their own map so the per-hash dedup is precise — a node
-// might legitimately want both a skip-list for hash X and a
-// replay-delta for the same hash X if X is both a multi-ledger
-// catch-up tip and a single-ledger forward acquisition target.
+// Skip-list and replay-delta share the cap but use separate maps so
+// the per-hash dedup is precise — the same hash can legitimately be
+// both a skip-list target (its 256-entry ancestor vector) and a
+// replay-delta target (its tx-set).
 type Replayer struct {
 	mu            sync.Mutex
 	inFlight      map[[32]byte]*ReplayDelta
@@ -335,20 +329,12 @@ func (r *Replayer) Has(hash [32]byte) bool {
 	return ok
 }
 
-// AcquireSkipList arms a new *SkipListAcquire for the rolling-256
-// LedgerHashes entry of targetHash, anchored on stateHash (the
-// target's AccountHash). Slot accounting is SEPARATE from
-// replay-delta acquisitions: skip-list fetches are short-lived (one
-// proof request, one response, no per-tx engine apply) and would
-// otherwise be starved by a 16-deep delta backlog. The dedup,
-// per-peer, and global cap semantics mirror Acquire.
-//
-// Returns:
-//   - ErrAcquisitionExists: targetHash already has a skip-list in flight.
-//   - ErrCapacityFull: at the maxInFlight cap.
-//   - ErrPerPeerCapacityFull: peerID already has MaxPerPeerReplays
-//     skip-list acquisitions in flight (kept separate from replay-delta
-//     per-peer accounting; the wire requests are distinct).
+// AcquireSkipList arms a new *SkipListAcquire for targetHash's
+// rolling-256 LedgerHashes entry, anchored on stateHash. Slot
+// accounting is SEPARATE from replay-delta so a 16-deep delta backlog
+// doesn't starve short-lived proof-path fetches; cap semantics
+// otherwise mirror Acquire (ErrAcquisitionExists / ErrCapacityFull /
+// ErrPerPeerCapacityFull).
 func (r *Replayer) AcquireSkipList(targetHash, stateHash [32]byte, peerID uint64) (*SkipListAcquire, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -376,10 +362,9 @@ func (r *Replayer) AcquireSkipList(targetHash, stateHash [32]byte, peerID uint64
 }
 
 // HandleSkipListResponse routes resp to the matching in-flight
-// SkipListAcquire (keyed by resp.LedgerHash), runs its GotResponse
-// verifier, and returns the acquisition so the caller can consume
-// Hashes(). Returns ErrNoMatchingAcquisition for stale/unsolicited
-// responses. Mirrors HandleResponse's contract for replay-delta.
+// SkipListAcquire and runs its verifier. Returns
+// ErrNoMatchingAcquisition for stale/unsolicited responses. Mirrors
+// HandleResponse's contract.
 func (r *Replayer) HandleSkipListResponse(resp *message.ProofPathResponse) (*SkipListAcquire, error) {
 	if resp == nil {
 		return nil, ErrNoMatchingAcquisition
@@ -404,22 +389,19 @@ func (r *Replayer) HandleSkipListResponse(resp *message.ProofPathResponse) (*Ski
 }
 
 // CompleteSkipList removes the skip-list acquisition for targetHash
-// from in-flight. Counterpart to Complete for replay-delta.
+// from in-flight.
 func (r *Replayer) CompleteSkipList(targetHash [32]byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.inFlightSkip, targetHash)
 }
 
-// AbandonSkipList is a synonym for CompleteSkipList at the caller
-// site — "we're giving up" vs "we finished" reads more clearly than
-// reusing a single name for both intents.
+// AbandonSkipList is a caller-side synonym for CompleteSkipList,
+// signalling "giving up" instead of "finished".
 func (r *Replayer) AbandonSkipList(targetHash [32]byte) {
 	r.CompleteSkipList(targetHash)
 }
 
-// HasSkipList reports whether the given target hash currently has a
-// skip-list acquisition in flight.
 func (r *Replayer) HasSkipList(targetHash [32]byte) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -428,8 +410,7 @@ func (r *Replayer) HasSkipList(targetHash [32]byte) bool {
 }
 
 // SkipListCount returns the number of in-flight skip-list
-// acquisitions. Separate from Count (replay-delta) so tests and
-// metrics can distinguish the two work streams.
+// acquisitions. Separate counter from Count (replay-delta).
 func (r *Replayer) SkipListCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/ledger/inbound/skiplist_acquire.go
+++ b/internal/ledger/inbound/skiplist_acquire.go
@@ -1,0 +1,356 @@
+package inbound
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/shamap"
+)
+
+// Sentinel errors returned by the skip-list acquisition path. Callers
+// match with errors.Is so wording can evolve without breaking assertions.
+var (
+	// ErrSkipListProofInvalid signals the Merkle proof failed to verify
+	// against the target ledger's stateHash, OR the verified leaf was
+	// not a decodable LedgerHashes SLE, OR the SLE's Hashes vector was
+	// empty. In every case the peer either lied or is broken and must
+	// be charged bad-data by the caller.
+	ErrSkipListProofInvalid = errors.New("skiplist acquire: proof invalid")
+
+	// ErrSkipListResponseMismatch signals the response carries fields
+	// that don't match the request — wrong LedgerHash, wrong MapType,
+	// wrong Key. Either a stale reply or a peer trying to feed us a
+	// skip-list for a ledger we didn't ask about.
+	ErrSkipListResponseMismatch = errors.New("skiplist acquire: response mismatch")
+)
+
+// SkipListAcquire tracks an outbound mtPROOF_PATH_REQUEST for the
+// rolling-256 LedgerHashes entry of a target ledger, and verifies the
+// matching mtPROOF_PATH_RESPONSE. Mirrors rippled's SkipListAcquire
+// (rippled/src/xrpld/app/ledger/detail/SkipListAcquire.cpp):
+//
+//  1. Send TMProofPathRequest{LedgerHash=target, Key=keylet::skip(),
+//     Type=lmACCOUNT_STATE}.
+//  2. On response: verify the proof path against the target's
+//     stateHash via shamap.VerifyProofPathWithValue. A nil return is
+//     proof-invalid — peer charge.
+//  3. Decode the verified leaf as a LedgerHashes SLE; extract the
+//     Hashes vector.
+//
+// The Hashes vector is the rolling-256 ancestry list — Hashes[N-1] is
+// target's grand-parent (target.ParentHash's parent), Hashes[N-2] one
+// before that, and so on. Index N-i covers seq target.seq-i-1.
+type SkipListAcquire struct {
+	targetHash [32]byte // the ledger whose skip-list we're fetching
+	stateHash  [32]byte // target.AccountHash, used to verify the proof
+	peerID     uint64
+	clock      Clock
+	created    time.Time
+	logger     *slog.Logger
+
+	mu     sync.Mutex
+	state  State
+	err    error
+	hashes [][32]byte // populated on StateComplete
+
+	// subTaskStart / retryCount / triedPeers mirror ReplayDelta's
+	// peer-rotation machinery so the coordinator can reuse the same
+	// timeout-driven peer-swap path for both acquisition types.
+	subTaskStart time.Time
+	retryCount   int
+	triedPeers   []uint64
+}
+
+// NewSkipListAcquire creates an acquisition keyed by the target ledger
+// hash. stateHash MUST be the target's AccountHash — without it the
+// peer-supplied proof cannot be verified. The initial state is
+// StateWantBase to share the State enum with the other inbound
+// acquisition types in this package.
+func NewSkipListAcquire(
+	targetHash, stateHash [32]byte,
+	peerID uint64,
+	logger *slog.Logger,
+) *SkipListAcquire {
+	return NewSkipListAcquireWithClock(targetHash, stateHash, peerID, logger, SystemClock)
+}
+
+// NewSkipListAcquireWithClock is the dependency-injection sibling of
+// NewSkipListAcquire — tests pass a fake clock to drive sub-task and
+// outer timeouts deterministically.
+func NewSkipListAcquireWithClock(
+	targetHash, stateHash [32]byte,
+	peerID uint64,
+	logger *slog.Logger,
+	clock Clock,
+) *SkipListAcquire {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if clock == nil {
+		clock = SystemClock
+	}
+	now := clock.Now()
+	return &SkipListAcquire{
+		targetHash:   targetHash,
+		stateHash:    stateHash,
+		peerID:       peerID,
+		clock:        clock,
+		created:      now,
+		subTaskStart: now,
+		state:        StateWantBase,
+		logger:       logger,
+		triedPeers:   []uint64{peerID},
+	}
+}
+
+// TargetHash returns the ledger whose skip-list we're fetching.
+func (s *SkipListAcquire) TargetHash() [32]byte { return s.targetHash }
+
+// StateHash returns the AccountHash used to verify the proof.
+func (s *SkipListAcquire) StateHash() [32]byte { return s.stateHash }
+
+// PeerID returns the peer we asked for the proof.
+func (s *SkipListAcquire) PeerID() uint64 { return s.peerID }
+
+// State returns the current acquisition state.
+func (s *SkipListAcquire) State() State {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state
+}
+
+// IsComplete reports whether the acquisition has been verified.
+func (s *SkipListAcquire) IsComplete() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state == StateComplete
+}
+
+// Err returns the verification error (nil unless state is StateFailed).
+func (s *SkipListAcquire) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
+// Hashes returns the verified rolling-256 ancestor list. Empty unless
+// state is StateComplete. The returned slice is a defensive copy.
+func (s *SkipListAcquire) Hashes() [][32]byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != StateComplete {
+		return nil
+	}
+	out := make([][32]byte, len(s.hashes))
+	copy(out, s.hashes)
+	return out
+}
+
+// IsTimedOut reports whether the acquisition has outlived its OUTER
+// budget. Reuses replayDeltaTimeout so a deep catch-up that issues a
+// skip-list request and several replay-deltas shares a single
+// per-task-shape budget.
+func (s *SkipListAcquire) IsTimedOut() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state == StateComplete || s.state == StateFailed {
+		return false
+	}
+	return s.clock.Now().Sub(s.created) > replayDeltaTimeout
+}
+
+// IsSubTaskTimedOut reports whether the current peer has held the
+// request past the sub-task window without delivering a response.
+// Mirrors rippled's SkipListAcquire::onTimer behaviour (driven by
+// SUB_TASK_TIMEOUT at LedgerReplayer.h:49).
+func (s *SkipListAcquire) IsSubTaskTimedOut() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state == StateComplete || s.state == StateFailed {
+		return false
+	}
+	return s.clock.Now().Sub(s.subTaskStart) > subTaskRetryInterval
+}
+
+// RetriesExhausted reports whether we've rotated through
+// subTaskRetryMax peers without success.
+func (s *SkipListAcquire) RetriesExhausted() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.retryCount >= subTaskRetryMax
+}
+
+// RetryCount returns the number of peer rotations performed so far.
+func (s *SkipListAcquire) RetryCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.retryCount
+}
+
+// TriedPeers returns a snapshot of peer IDs already asked.
+func (s *SkipListAcquire) TriedPeers() []uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]uint64, len(s.triedPeers))
+	copy(out, s.triedPeers)
+	return out
+}
+
+// NoteSubTaskRetry advances to a new peer: updates peerID, resets the
+// sub-task timer, and records the new peer in triedPeers. The caller
+// is responsible for re-issuing the wire request to newPeerID.
+func (s *SkipListAcquire) NoteSubTaskRetry(newPeerID uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.peerID = newPeerID
+	s.subTaskStart = s.clock.Now()
+	s.retryCount++
+	s.triedPeers = append(s.triedPeers, newPeerID)
+}
+
+// GotResponse verifies an inbound mtPROOF_PATH_RESPONSE against the
+// stored target/stateHash and decodes the LedgerHashes SLE. On
+// success the state transitions to StateComplete and Hashes() returns
+// the verified ancestor list. Subsequent calls after a terminal state
+// are no-ops.
+func (s *SkipListAcquire) GotResponse(resp *message.ProofPathResponse) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.state == StateComplete || s.state == StateFailed {
+		return s.err
+	}
+
+	if err := s.verifyAndDecode(resp); err != nil {
+		s.state = StateFailed
+		s.err = err
+		return err
+	}
+	s.state = StateComplete
+	return nil
+}
+
+func (s *SkipListAcquire) verifyAndDecode(resp *message.ProofPathResponse) error {
+	if resp == nil {
+		return fmt.Errorf("%w: nil response", ErrSkipListResponseMismatch)
+	}
+	if resp.Error != message.ReplyErrorNone {
+		return fmt.Errorf("%w: peer signaled error %d",
+			ErrSkipListResponseMismatch, resp.Error)
+	}
+
+	respHash, ok := toHash32(resp.LedgerHash)
+	if !ok || respHash != s.targetHash {
+		return fmt.Errorf("%w: ledger hash %x want %x",
+			ErrSkipListResponseMismatch,
+			truncHash(resp.LedgerHash), s.targetHash[:8])
+	}
+
+	if resp.MapType != message.LedgerMapAccountState {
+		return fmt.Errorf("%w: map type %d want %d",
+			ErrSkipListResponseMismatch,
+			resp.MapType, message.LedgerMapAccountState)
+	}
+
+	skipKL := keylet.LedgerHashes()
+	respKey, ok := toHash32(resp.Key)
+	if !ok || respKey != skipKL.Key {
+		return fmt.Errorf("%w: key %x want skip-list %x",
+			ErrSkipListResponseMismatch,
+			truncHash(resp.Key), skipKL.Key[:8])
+	}
+
+	if len(resp.Path) == 0 {
+		return fmt.Errorf("%w: empty proof path", ErrSkipListProofInvalid)
+	}
+
+	payload := shamap.VerifyProofPathWithValue(s.stateHash, skipKL.Key, resp.Path)
+	if payload == nil {
+		return fmt.Errorf("%w: merkle verify failed against stateHash %x",
+			ErrSkipListProofInvalid, s.stateHash[:8])
+	}
+
+	hashes, err := decodeLedgerHashesSLE(payload)
+	if err != nil {
+		return fmt.Errorf("%w: decode SLE: %v", ErrSkipListProofInvalid, err)
+	}
+	if len(hashes) == 0 {
+		return fmt.Errorf("%w: empty Hashes vector", ErrSkipListProofInvalid)
+	}
+
+	s.hashes = hashes
+	s.logger.Info("skip-list verified",
+		"target", hex.EncodeToString(s.targetHash[:8]),
+		"hashes", len(hashes),
+		"peer", s.peerID,
+	)
+	return nil
+}
+
+// decodeLedgerHashesSLE parses the binary-codec payload of a
+// LedgerHashes ledger entry and returns its Hashes vector.
+func decodeLedgerHashesSLE(payload []byte) ([][32]byte, error) {
+	obj, err := binarycodec.Decode(hex.EncodeToString(payload))
+	if err != nil {
+		return nil, fmt.Errorf("binarycodec.Decode: %w", err)
+	}
+
+	letRaw, ok := obj["LedgerEntryType"]
+	if !ok {
+		return nil, errors.New("missing LedgerEntryType")
+	}
+	if letStr, _ := letRaw.(string); letStr != "LedgerHashes" {
+		return nil, fmt.Errorf("LedgerEntryType=%v want LedgerHashes", letRaw)
+	}
+
+	rawHashes, ok := obj["Hashes"]
+	if !ok {
+		return nil, errors.New("missing Hashes field")
+	}
+
+	var hashStrs []string
+	switch v := rawHashes.(type) {
+	case []string:
+		hashStrs = v
+	case []any:
+		hashStrs = make([]string, len(v))
+		for i, h := range v {
+			s, ok := h.(string)
+			if !ok {
+				return nil, fmt.Errorf("hash[%d] is %T not string", i, h)
+			}
+			hashStrs[i] = s
+		}
+	default:
+		return nil, fmt.Errorf("Hashes is %T not list", rawHashes)
+	}
+
+	out := make([][32]byte, 0, len(hashStrs))
+	for i, hs := range hashStrs {
+		b, err := hex.DecodeString(hs)
+		if err != nil {
+			return nil, fmt.Errorf("hash[%d] hex: %w", i, err)
+		}
+		if len(b) != 32 {
+			return nil, fmt.Errorf("hash[%d] length %d want 32", i, len(b))
+		}
+		var h [32]byte
+		copy(h[:], b)
+		out = append(out, h)
+	}
+	return out, nil
+}
+
+func truncHash(b []byte) []byte {
+	if len(b) >= 8 {
+		return b[:8]
+	}
+	return b
+}

--- a/internal/ledger/inbound/skiplist_acquire.go
+++ b/internal/ledger/inbound/skiplist_acquire.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
-	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/shamap"
 )
 
@@ -226,7 +228,7 @@ func (s *SkipListAcquire) verifyAndDecode(resp *message.ProofPathResponse) error
 			ErrSkipListResponseMismatch, resp.Error)
 	}
 
-	respHash, ok := toHash32(resp.LedgerHash)
+	respHash, ok := ToHash32(resp.LedgerHash)
 	if !ok || respHash != s.targetHash {
 		return fmt.Errorf("%w: ledger hash %x want %x",
 			ErrSkipListResponseMismatch,
@@ -240,7 +242,7 @@ func (s *SkipListAcquire) verifyAndDecode(resp *message.ProofPathResponse) error
 	}
 
 	skipKL := keylet.LedgerHashes()
-	respKey, ok := toHash32(resp.Key)
+	respKey, ok := ToHash32(resp.Key)
 	if !ok || respKey != skipKL.Key {
 		return fmt.Errorf("%w: key %x want skip-list %x",
 			ErrSkipListResponseMismatch,
@@ -249,6 +251,22 @@ func (s *SkipListAcquire) verifyAndDecode(resp *message.ProofPathResponse) error
 
 	if len(resp.Path) == 0 {
 		return fmt.Errorf("%w: empty proof path", ErrSkipListProofInvalid)
+	}
+
+	// If the peer included a ledger header, cross-check that
+	// calculateLedgerHash(header) == targetHash. Mirrors rippled's
+	// processProofPathResponse
+	// (rippled/src/xrpld/app/ledger/detail/LedgerReplayMsgHandler.cpp:127-135).
+	if len(resp.LedgerHeader) > 0 {
+		hdr, err := header.DeserializeHeader(resp.LedgerHeader, false)
+		if err != nil {
+			return fmt.Errorf("%w: header deserialize: %v",
+				ErrSkipListResponseMismatch, err)
+		}
+		if genesis.CalculateLedgerHash(*hdr) != s.targetHash {
+			return fmt.Errorf("%w: header hash mismatch for target %x",
+				ErrSkipListResponseMismatch, s.targetHash[:8])
+		}
 	}
 
 	payload := shamap.VerifyProofPathWithValue(s.stateHash, skipKL.Key, resp.Path)

--- a/internal/ledger/inbound/skiplist_acquire.go
+++ b/internal/ledger/inbound/skiplist_acquire.go
@@ -68,11 +68,9 @@ type SkipListAcquire struct {
 	triedPeers   []uint64
 }
 
-// NewSkipListAcquire creates an acquisition keyed by the target ledger
-// hash. stateHash MUST be the target's AccountHash — without it the
-// peer-supplied proof cannot be verified. The initial state is
-// StateWantBase to share the State enum with the other inbound
-// acquisition types in this package.
+// NewSkipListAcquire creates an acquisition for targetHash's
+// skip-list. stateHash MUST be the target's AccountHash — without it
+// the peer-supplied proof cannot be verified.
 func NewSkipListAcquire(
 	targetHash, stateHash [32]byte,
 	peerID uint64,
@@ -81,9 +79,8 @@ func NewSkipListAcquire(
 	return NewSkipListAcquireWithClock(targetHash, stateHash, peerID, logger, SystemClock)
 }
 
-// NewSkipListAcquireWithClock is the dependency-injection sibling of
-// NewSkipListAcquire — tests pass a fake clock to drive sub-task and
-// outer timeouts deterministically.
+// NewSkipListAcquireWithClock is NewSkipListAcquire with an injected
+// clock for deterministic timeout tests.
 func NewSkipListAcquireWithClock(
 	targetHash, stateHash [32]byte,
 	peerID uint64,
@@ -110,38 +107,30 @@ func NewSkipListAcquireWithClock(
 	}
 }
 
-// TargetHash returns the ledger whose skip-list we're fetching.
 func (s *SkipListAcquire) TargetHash() [32]byte { return s.targetHash }
+func (s *SkipListAcquire) StateHash() [32]byte  { return s.stateHash }
+func (s *SkipListAcquire) PeerID() uint64       { return s.peerID }
 
-// StateHash returns the AccountHash used to verify the proof.
-func (s *SkipListAcquire) StateHash() [32]byte { return s.stateHash }
-
-// PeerID returns the peer we asked for the proof.
-func (s *SkipListAcquire) PeerID() uint64 { return s.peerID }
-
-// State returns the current acquisition state.
 func (s *SkipListAcquire) State() State {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.state
 }
 
-// IsComplete reports whether the acquisition has been verified.
 func (s *SkipListAcquire) IsComplete() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.state == StateComplete
 }
 
-// Err returns the verification error (nil unless state is StateFailed).
 func (s *SkipListAcquire) Err() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.err
 }
 
-// Hashes returns the verified rolling-256 ancestor list. Empty unless
-// state is StateComplete. The returned slice is a defensive copy.
+// Hashes returns a defensive copy of the verified ancestor list, or
+// nil if not yet complete.
 func (s *SkipListAcquire) Hashes() [][32]byte {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -153,10 +142,8 @@ func (s *SkipListAcquire) Hashes() [][32]byte {
 	return out
 }
 
-// IsTimedOut reports whether the acquisition has outlived its OUTER
-// budget. Reuses replayDeltaTimeout so a deep catch-up that issues a
-// skip-list request and several replay-deltas shares a single
-// per-task-shape budget.
+// IsTimedOut reports whether the acquisition has outlived the outer
+// budget (shared with replay-delta so a deep catch-up has one shape).
 func (s *SkipListAcquire) IsTimedOut() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -179,22 +166,18 @@ func (s *SkipListAcquire) IsSubTaskTimedOut() bool {
 	return s.clock.Now().Sub(s.subTaskStart) > subTaskRetryInterval
 }
 
-// RetriesExhausted reports whether we've rotated through
-// subTaskRetryMax peers without success.
 func (s *SkipListAcquire) RetriesExhausted() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.retryCount >= subTaskRetryMax
 }
 
-// RetryCount returns the number of peer rotations performed so far.
 func (s *SkipListAcquire) RetryCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.retryCount
 }
 
-// TriedPeers returns a snapshot of peer IDs already asked.
 func (s *SkipListAcquire) TriedPeers() []uint64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -203,9 +186,8 @@ func (s *SkipListAcquire) TriedPeers() []uint64 {
 	return out
 }
 
-// NoteSubTaskRetry advances to a new peer: updates peerID, resets the
-// sub-task timer, and records the new peer in triedPeers. The caller
-// is responsible for re-issuing the wire request to newPeerID.
+// NoteSubTaskRetry rotates to newPeerID, resets the sub-task timer,
+// and records the new peer. Caller re-issues the wire request.
 func (s *SkipListAcquire) NoteSubTaskRetry(newPeerID uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -215,11 +197,9 @@ func (s *SkipListAcquire) NoteSubTaskRetry(newPeerID uint64) {
 	s.triedPeers = append(s.triedPeers, newPeerID)
 }
 
-// GotResponse verifies an inbound mtPROOF_PATH_RESPONSE against the
-// stored target/stateHash and decodes the LedgerHashes SLE. On
-// success the state transitions to StateComplete and Hashes() returns
-// the verified ancestor list. Subsequent calls after a terminal state
-// are no-ops.
+// GotResponse verifies a mtPROOF_PATH_RESPONSE against the stored
+// target/stateHash and decodes the LedgerHashes SLE. No-op after a
+// terminal state.
 func (s *SkipListAcquire) GotResponse(resp *message.ProofPathResponse) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/ledger/inbound/skiplist_acquire_test.go
+++ b/internal/ledger/inbound/skiplist_acquire_test.go
@@ -191,6 +191,16 @@ func TestSkipListAcquire_InvalidProof_Rejected(t *testing.T) {
 			},
 			wantErr: ErrSkipListResponseMismatch,
 		},
+		{
+			// Non-empty header bytes that don't hash back to
+			// targetHash must be rejected, matching rippled's
+			// processProofPathResponse hash-mismatch check.
+			name: "header_mismatch",
+			mutate: func(resp *message.ProofPathResponse, _ *[32]byte) {
+				resp.LedgerHeader = []byte{0xFF, 0xFE, 0xFD, 0xFC, 0xFB}
+			},
+			wantErr: ErrSkipListResponseMismatch,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/ledger/inbound/skiplist_acquire_test.go
+++ b/internal/ledger/inbound/skiplist_acquire_test.go
@@ -1,0 +1,258 @@
+package inbound
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildSkipListLeafSLE encodes a LedgerHashes SLE with the supplied
+// rolling-256 ancestor list and lastLedgerSeq, returning the raw
+// binary-codec payload (the byte string the state-map leaf stores).
+func buildSkipListLeafSLE(t *testing.T, hashes [][32]byte, lastSeq uint32) []byte {
+	t.Helper()
+	hashHexes := make([]string, len(hashes))
+	for i, h := range hashes {
+		hashHexes[i] = fmt.Sprintf("%064X", h)
+	}
+	obj := map[string]any{
+		"LedgerEntryType":    "LedgerHashes",
+		"Flags":              uint32(0),
+		"Hashes":             hashHexes,
+		"LastLedgerSequence": lastSeq,
+	}
+	hx, err := binarycodec.Encode(obj)
+	require.NoError(t, err)
+	out, err := hex.DecodeString(hx)
+	require.NoError(t, err)
+	return out
+}
+
+// buildSkipListProof installs a single LedgerHashes leaf into a fresh
+// account-state SHAMap at the canonical keylet::skip() key, then
+// returns the map's root hash and the leaf-to-root proof path.
+func buildSkipListProof(t *testing.T, leafPayload []byte) (rootHash [32]byte, path [][]byte) {
+	t.Helper()
+	sm, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+
+	skipKL := keylet.LedgerHashes()
+	require.NoError(t, sm.PutWithNodeType(skipKL.Key, leafPayload, shamap.NodeTypeAccountState))
+	require.NoError(t, sm.SetImmutable())
+
+	root, err := sm.Hash()
+	require.NoError(t, err)
+
+	proof, err := sm.GetProofPath(skipKL.Key)
+	require.NoError(t, err)
+	require.True(t, proof.Found, "proof must locate the inserted leaf")
+	require.NotEmpty(t, proof.Path, "proof path must not be empty")
+
+	return root, proof.Path
+}
+
+// fixedHashes returns n deterministic 32-byte hashes — entry i has
+// every byte equal to byte(i+1). Useful for round-trip assertions that
+// verify the verified ordering matches what we encoded.
+func fixedHashes(n int) [][32]byte {
+	out := make([][32]byte, n)
+	for i := range out {
+		for j := range out[i] {
+			out[i][j] = byte(i + 1)
+		}
+	}
+	return out
+}
+
+// TestSkipListAcquire_ValidProof_Accepted verifies the happy path:
+// a peer serves a well-formed LedgerHashes leaf with a valid proof
+// against the target's stateHash, and we recover the ancestor list
+// byte-for-byte.
+func TestSkipListAcquire_ValidProof_Accepted(t *testing.T) {
+	want := fixedHashes(256)
+	leaf := buildSkipListLeafSLE(t, want, 999)
+	stateHash, path := buildSkipListProof(t, leaf)
+
+	targetHash := [32]byte{0xAA, 0xBB}
+
+	skipKey := keylet.LedgerHashes().Key
+	resp := &message.ProofPathResponse{
+		LedgerHash: targetHash[:],
+		Key:        skipKey[:],
+		MapType:    message.LedgerMapAccountState,
+		Path:       path,
+	}
+
+	s := NewSkipListAcquire(targetHash, stateHash, 42, nil)
+	require.NoError(t, s.GotResponse(resp))
+	assert.True(t, s.IsComplete())
+	assert.Nil(t, s.Err())
+
+	got := s.Hashes()
+	require.Len(t, got, len(want))
+	for i := range want {
+		assert.Equalf(t, want[i], got[i],
+			"hash[%d] mismatch — verified ordering must match wire bytes", i)
+	}
+}
+
+// TestSkipListAcquire_InvalidProof_Rejected covers every way a peer
+// can fail to produce a valid proof. Each sub-case must terminate in
+// StateFailed with no Hashes() leak.
+func TestSkipListAcquire_InvalidProof_Rejected(t *testing.T) {
+	want := fixedHashes(8)
+	leaf := buildSkipListLeafSLE(t, want, 100)
+	goodStateHash, goodPath := buildSkipListProof(t, leaf)
+	targetHash := [32]byte{0xCC}
+	skipKey := keylet.LedgerHashes().Key
+
+	cases := []struct {
+		name    string
+		mutate  func(resp *message.ProofPathResponse, stateHash *[32]byte)
+		wantErr error
+	}{
+		{
+			name: "tampered_leaf",
+			mutate: func(resp *message.ProofPathResponse, _ *[32]byte) {
+				// Re-encode a leaf with different content and substitute
+				// it in for the proof's leaf node. The recomputed leaf
+				// hash will no longer match the parent inner-node's
+				// branch hash, so the proof must fail.
+				tampered := buildSkipListLeafSLE(t, fixedHashes(4), 7)
+				// path[0] is the leaf node (leaf-to-root order). Build a
+				// fresh leaf node at the same key with the tampered
+				// payload, then re-serialize it for wire.
+				sm, err := shamap.New(shamap.TypeState)
+				require.NoError(t, err)
+				require.NoError(t, sm.PutWithNodeType(skipKey, tampered, shamap.NodeTypeAccountState))
+				require.NoError(t, sm.SetImmutable())
+				badProof, err := sm.GetProofPath(skipKey)
+				require.NoError(t, err)
+				// Substitute only the leaf — keep the rest of the original
+				// (good) inner-node stack so the failure is unambiguously
+				// "the leaf doesn't match", not "wrong inner node".
+				newPath := make([][]byte, len(resp.Path))
+				copy(newPath, resp.Path)
+				newPath[0] = badProof.Path[0]
+				resp.Path = newPath
+			},
+			wantErr: ErrSkipListProofInvalid,
+		},
+		{
+			name: "wrong_state_hash",
+			mutate: func(_ *message.ProofPathResponse, stateHash *[32]byte) {
+				stateHash[0] ^= 0xFF
+			},
+			wantErr: ErrSkipListProofInvalid,
+		},
+		{
+			name: "wrong_ledger_hash",
+			mutate: func(resp *message.ProofPathResponse, _ *[32]byte) {
+				bad := make([]byte, 32)
+				bad[0] = 0x99
+				resp.LedgerHash = bad
+			},
+			wantErr: ErrSkipListResponseMismatch,
+		},
+		{
+			name: "wrong_map_type",
+			mutate: func(resp *message.ProofPathResponse, _ *[32]byte) {
+				resp.MapType = message.LedgerMapTransaction
+			},
+			wantErr: ErrSkipListResponseMismatch,
+		},
+		{
+			name: "wrong_key",
+			mutate: func(resp *message.ProofPathResponse, _ *[32]byte) {
+				bogus := make([]byte, 32)
+				bogus[0] = 0x77
+				resp.Key = bogus
+			},
+			wantErr: ErrSkipListResponseMismatch,
+		},
+		{
+			name: "empty_path",
+			mutate: func(resp *message.ProofPathResponse, _ *[32]byte) {
+				resp.Path = nil
+			},
+			wantErr: ErrSkipListProofInvalid,
+		},
+		{
+			name: "peer_signaled_error",
+			mutate: func(resp *message.ProofPathResponse, _ *[32]byte) {
+				resp.Error = message.ReplyErrorNoLedger
+			},
+			wantErr: ErrSkipListResponseMismatch,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build fresh copies so each sub-case mutates independently.
+			pathCopy := make([][]byte, len(goodPath))
+			for i, b := range goodPath {
+				pathCopy[i] = append([]byte(nil), b...)
+			}
+			resp := &message.ProofPathResponse{
+				LedgerHash: append([]byte(nil), targetHash[:]...),
+				Key:        append([]byte(nil), skipKey[:]...),
+				MapType:    message.LedgerMapAccountState,
+				Path:       pathCopy,
+			}
+			stateHash := goodStateHash
+			tc.mutate(resp, &stateHash)
+
+			s := NewSkipListAcquire(targetHash, stateHash, 1, nil)
+			err := s.GotResponse(resp)
+			require.Error(t, err, "sub-case %q must reject", tc.name)
+			assert.ErrorIs(t, err, tc.wantErr)
+			assert.Equal(t, StateFailed, s.State())
+			assert.Nil(t, s.Hashes(), "no hash leakage on failure")
+		})
+	}
+}
+
+// TestSkipListAcquire_DecodeLedgerHashesSLE_NonHashesLeaf rejects a
+// proof whose leaf decodes as a different SLE type. A peer that serves
+// a valid Merkle proof for a non-LedgerHashes entry under the
+// keylet::skip() key has produced a cryptographically valid but
+// semantically nonsense proof — must reject as proof-invalid.
+func TestSkipListAcquire_DecodeLedgerHashesSLE_NonHashesLeaf(t *testing.T) {
+	// Encode a FeeSettings SLE — not a LedgerHashes — and prove it
+	// under the same key. The proof is valid; only the leaf's
+	// LedgerEntryType is wrong.
+	hx, err := binarycodec.Encode(map[string]any{
+		"LedgerEntryType": "FeeSettings",
+		"Flags":           uint32(0),
+		"BaseFee":         "A",
+		"ReferenceFeeUnits": uint32(10),
+		"ReserveBase":       uint32(200000000),
+		"ReserveIncrement":  uint32(50000000),
+	})
+	require.NoError(t, err)
+	leaf, err := hex.DecodeString(hx)
+	require.NoError(t, err)
+	stateHash, path := buildSkipListProof(t, leaf)
+
+	targetHash := [32]byte{0xDD}
+	skipKey := keylet.LedgerHashes().Key
+	resp := &message.ProofPathResponse{
+		LedgerHash: targetHash[:],
+		Key:        skipKey[:],
+		MapType:    message.LedgerMapAccountState,
+		Path:       path,
+	}
+
+	s := NewSkipListAcquire(targetHash, stateHash, 1, nil)
+	err = s.GotResponse(resp)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSkipListProofInvalid)
+	assert.Equal(t, StateFailed, s.State())
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1794,12 +1794,14 @@ type pendingAdopt struct {
 }
 
 // heldAdoptionTTL bounds how long a held adoption is kept before
-// eviction. 60s comfortably spans the worst-case replay-delta round-
-// trip (typically <5s) while still ensuring a stale fork or a
-// disconnected-peer response can't linger indefinitely and re-fire
-// against an unrelated adopted ledger that happens to land at the
-// awaited parent seq much later.
-const heldAdoptionTTL = 60 * time.Second
+// eviction. 5 minutes accommodates a long backward-chain catch-up
+// from a divergent local fork — a goxrpl-1 enclave run reproduced
+// a wedged node where a 30-ledger fork couldn't recover because
+// intermediate held entries TTL-evicted at 60s while the cascade
+// was still walking back to a common ancestor. The window is bounded
+// to keep a stale fork / disconnected-peer response from lingering
+// indefinitely and re-firing against an unrelated adopted ledger.
+const heldAdoptionTTL = 5 * time.Minute
 
 // heldAdoptionCascadeMax caps the cascade recursion depth. Real-world
 // cascades are 1-2 hops deep (replay-delta is single-ledger-per-

--- a/tasks/pr-multi-ledger-replay.md
+++ b/tasks/pr-multi-ledger-replay.md
@@ -1,0 +1,346 @@
+# Multi-Ledger Replay (Issue #271)
+
+Client-side `SkipListAcquire` + `LedgerReplayTask` so catch-up can fetch
+many ledgers in one parallel backward walk instead of one round-trip per
+ledger.
+
+## Why
+
+Today `Router.checkBehind` (`internal/consensus/adaptor/router.go:1598`)
+arms **one** acquisition per status-gossip event. To catch up by 50
+ledgers we currently wait for 50 forward status reports — each
+acquisition only starts after the previous adopts and bumps our LCL.
+Rippled's `LedgerReplayer` instead asks one peer for the skip-list of
+the target tip, then dispatches up to 256 parallel `LedgerDeltaAcquire`
+subtasks across all 256 ancestors in that skip-list.
+
+This is a catch-up-speed change, not a correctness change. The F6
+cascade closes the local "N+2 before N+1" reorder; this closes "we are
+N-50 behind a known-good tip".
+
+## Existing infrastructure (no work needed)
+
+Already wired on `main` after the PR #264 series:
+
+| Piece | Location |
+|-------|----------|
+| `TMProofPathRequest`/`Response` proto + message wrappers | `internal/peermanagement/proto/ripple.pb.go:2285+`, `internal/peermanagement/message/messages.go:218` |
+| Peer-side handler that serves proof-path requests | `internal/peermanagement/overlay.go:1186`, `internal/consensus/adaptor/ledger_provider.go:173` (`GetProofPath`) |
+| Merkle verifier (leaf-to-root, matching wire order) | `shamap/proof.go:82` (`VerifyProofPath`), `:185` (`VerifyProofPathWithValue`) |
+| `keylet::skip()` rolling-256 keylet | `keylet/keylet.go:105` (`LedgerHashes`) |
+| `LedgerHashes` SLE decode (Hashes vector) | `ledger/entry/ledger_hashes.go` |
+| `Replayer` coordinator: concurrent ReplayDelta acquisitions, per-peer + global caps (16 global / 2 per peer) | `internal/ledger/inbound/replayer.go:20,33,134` |
+| Single-target `ReplayDelta` state machine (verify → apply → divergence-check) | `internal/ledger/inbound/replay_delta.go` |
+| Router dispatch of `TypeReplayDeltaResponse` | `internal/consensus/adaptor/router.go:322,1365` |
+| Sender helper for replay-delta | `internal/consensus/adaptor/sender.go:266` (`RequestReplayDelta`) |
+
+The two things missing are: the **client-side** of proof-path (we never
+send `TMProofPathRequest`), and the policy layer that turns
+`(tipHash, depth)` into a parallel backward walk.
+
+## Rippled reference
+
+- `rippled/src/xrpld/app/ledger/LedgerReplayer.h` — constants
+  (`TASK_TIMEOUT=500ms`, `SUB_TASK_TIMEOUT=250ms`,
+  `SUB_TASK_MAX_TIMEOUTS=10`, `MAX_TASKS=10`, `MAX_QUEUED_TASKS=100`).
+- `rippled/src/xrpld/app/ledger/detail/SkipListAcquire.cpp` — sends
+  `TMProofPathRequest{LedgerHash, Key=keylet::skip().key,
+  Type=lmACCOUNT_STATE}`; on response deserializes the SLE leaf,
+  validates the `sfHashes` vector against `target.stateHash` via the
+  proof path (line 91-111, 151-165).
+- `rippled/src/xrpld/app/ledger/detail/LedgerReplayTask.cpp` — once the
+  skip-list arrives (`updateSkipList`, line 135), enumerates ancestor
+  hashes **directly from the skip-list array** (not via ParentHash) and
+  dispatches one `LedgerDeltaAcquire` per ancestor in
+  `createDeltas` (LedgerReplayer.cpp:122).
+- `rippled/src/xrpld/app/ledger/detail/LedgerReplayer.cpp:44-109` —
+  `replay(reason, finishHash, totalLedgers)` entry point, dedups
+  ancestor-of-existing-task and enforces `MAX_TASKS=10`.
+
+The skip-list is the **rolling-256 list** in `keylet::skip()` — every
+close appends `parentHash` to that vector (capped at 256). So one proof
+fetch unlocks every hash needed for a backward window of up to 256.
+
+## Scope
+
+### Phase 1 — Sender + receiver for `TMProofPathRequest`
+
+1. `internal/consensus/adaptor/sender.go`: add `RequestProofPath(peerID
+   uint64, ledgerHash [32]byte, key [32]byte, mapType
+   message.LedgerMapType) error`. Mirrors `RequestReplayDelta`.
+2. Expose on the `Sender` interface used by the router (look up
+   `OverlaySender` interface in adaptor.go).
+3. Router: in the `messageRouter` switch (around line 322 of
+   router.go), add `case message.TypeProofPathResponse:
+   r.handleProofPathResponse(msg)`. The dispatch is to the
+   `SkipListAcquire` coordinator (Phase 2 owns the handler).
+
+### Phase 2 — `SkipListAcquire` state machine
+
+New file `internal/ledger/inbound/skiplist_acquire.go`. Mirrors
+`replay_delta.go`'s shape:
+
+```go
+type SkipListAcquire struct {
+    hash      [32]byte // target ledger hash whose skip-list we want
+    stateHash [32]byte // target.AccountHash, used to verify the proof
+    state     State    // StateWantProof / StateComplete / StateFailed
+    hashes    [][32]byte
+    subTaskStart time.Time
+    retryCount   int
+    peerID       uint64
+    mu           sync.Mutex
+}
+
+func (s *SkipListAcquire) GotResponse(resp *message.ProofPathResponse) error
+func (s *SkipListAcquire) Hashes() [][32]byte
+func (s *SkipListAcquire) Hash() [32]byte
+```
+
+`GotResponse` does:
+
+1. Confirm `resp.LedgerHash == s.hash` and `resp.MapType ==
+   LedgerMapAccountState` (charge `replay-skiplist-mismatch` if not).
+2. `keylet := keylet.LedgerHashes()` → match against `resp.Key`.
+3. `payload := shamap.VerifyProofPathWithValue(s.stateHash,
+   keylet.Key, resp.Path)` — `nil` means proof invalid.
+4. Decode `payload` as a `LedgerHashes` SLE; extract `Hashes` vector
+   (`ledger/entry/ledger_hashes.go`).
+5. On success, transition to `StateComplete` and stash the vector.
+
+Caller obtains `target.AccountHash` either from a header it already has
+or from a fresh inbound header acquisition. The simplest entry point is
+"we already have the target ledger header (peer told us its hash + we
+acquired the header) and now want a 256-hash window before it".
+
+### Phase 3 — Coordinator extension: `Replayer.AcquireSkipList`
+
+Extend `Replayer` (`internal/ledger/inbound/replayer.go`) with a
+sibling-shaped API:
+
+```go
+func (r *Replayer) AcquireSkipList(targetHash, stateHash [32]byte,
+    peerID uint64) (*SkipListAcquire, error)
+func (r *Replayer) HasSkipList(targetHash [32]byte) bool
+func (r *Replayer) HandleSkipListResponse(resp *message.ProofPathResponse)
+    (*SkipListAcquire, error)
+func (r *Replayer) CompleteSkipList(hash [32]byte)
+func (r *Replayer) AbandonSkipList(hash [32]byte)
+```
+
+Slot accounting reuses the same `maxInFlight` counter so the global cap
+is shared between skip-list and delta acquisitions — these are both
+"peer state-fetches in flight".
+
+### Phase 4 — `LedgerReplayTask`
+
+New file `internal/ledger/inbound/replay_task.go`:
+
+```go
+type LedgerReplayTask struct {
+    tipHash   [32]byte
+    tipSeq    uint32
+    depth     uint32         // 1..256
+    replayer  *Replayer
+    sender    SenderIface    // RequestProofPath, RequestReplayDelta
+    ledgerSvc LedgerService  // to look up the target header / state hash
+    onProgress func(hash [32]byte, seq uint32, l *ledger.Ledger)
+    state State              // WantSkipList / RunningDeltas / Complete / Failed
+}
+
+func (t *LedgerReplayTask) Start(peerID uint64) error
+func (t *LedgerReplayTask) OnSkipList(hashes [][32]byte)
+func (t *LedgerReplayTask) OnDelta(hash [32]byte, l *ledger.Ledger)
+```
+
+Behaviour:
+
+1. `Start` calls `replayer.AcquireSkipList(...)`, then
+   `sender.RequestProofPath(peerID, tipHash, keylet.LedgerHashes().Key,
+   LedgerMapAccountState)`.
+2. When the skip-list response is verified, `OnSkipList` takes the last
+   `depth` ancestor hashes and fans them out via
+   `replayer.Acquire(hash, peerID, parent)` — but bounded by the
+   existing `DefaultMaxInFlightReplays=16` global cap and
+   `MaxPerPeerReplays=2` per-peer cap. Excess hashes queue inside the
+   task and are dispatched as in-flight slots free up (in `OnDelta`).
+3. `OnDelta` adopts the acquired ledger (callback up to the adaptor),
+   then fires the next queued delta. When the queue drains and all
+   deltas are adopted, transition to `Complete`.
+4. Failure modes:
+   - Skip-list proof invalid → fall back: caller continues with the
+     existing single-ledger forward acquisition path; task aborts.
+   - Any delta fails its divergence check → that delta is abandoned,
+     other deltas in the same task are not affected (each
+     `ReplayDelta` already verifies its own AccountHash).
+
+### Phase 5 — Router integration
+
+Done in `internal/consensus/adaptor/router_replay_task.go`:
+
+- `Router.StartReplayTask(tipHash, stateHash, tipSeq, depth, anchorParent, peers)`
+  is the explicit entry point. It registers an `activeReplayTask` on
+  the router and kicks off the underlying `inbound.LedgerReplayTask`.
+- `handleProofPathResponse` decodes inbound `TMProofPathResponse`,
+  routes to the active task, and populates the chain-hash lookup so
+  subsequent replay-delta responses are recognised as task-owned.
+- `handleReplayDeltaResponse` consults the chain-hash set
+  (`routeDeltaToActiveTask`) BEFORE the legacy `Replayer.HandleResponse`
+  path. Task-owned hashes are handled by the task's
+  `OnDeltaResponse`; everything else continues through the existing
+  Apply+adopt flow untouched.
+- `onTaskDeltaVerified` stashes the verified `*ReplayDelta` and runs
+  `drainTaskChain`, which walks the chain in oldest-first order and
+  calls `rd.SetParent(predecessor) → Apply → adoptVerifiedLedger`
+  for each entry whose parent is now adopted. The drain is
+  re-entrant via subsequent callbacks but the monotonic
+  `nextSeqToAdopt` cursor + mutex guarantee a single advance per
+  successful Apply.
+- `ReplayDelta.SetParent(parent)` is a small additive method on
+  `inbound.ReplayDelta` (refuses overwrite once non-nil) — needed
+  because the task acquires intermediates with parent=nil to allow
+  parallel framing-verification, then binds the real parent at
+  Apply time.
+
+#### Auto-trigger from `checkBehind`: NOT WIRED
+
+The constant `multiLedgerCatchupThreshold = 4` is defined for the
+future hook but `checkBehind` continues to call the single-ledger
+`startLedgerAcquisition` path unchanged. Reason: `TMStatusChange`
+does NOT carry `AccountHash`, and `SkipListAcquire` cannot verify a
+peer's skip-list proof without the tip's stateHash. Two ways to
+close this:
+
+1. Acquire the tip's header first via the existing inbound flow,
+   read `AccountHash` from the verified header, then call
+   `StartReplayTask`. Requires inbound.Ledger to surface a
+   "header-acquired" hook that doesn't immediately trigger
+   single-ledger adoption.
+2. Extend our local peer-state tracking so a peer's `AccountHash`
+   for its tip seq is recorded out-of-band (e.g., via a follow-up
+   exchange after status-change).
+
+Either route is its own design decision — keeping it as a separate
+follow-up means Phase 5 lands a clean, fully-tested router seam
+without speculative protocol changes.
+
+#### Integration tests (Phase 5)
+
+`internal/consensus/adaptor/router_replay_task_test.go`:
+
+- **`TestRouter_ReplayTask_EndToEnd_3LedgerWalk`** — builds a real
+  3-ledger chain via `ledger.NewOpen+Close`, mounts a synthetic
+  LedgerHashes SLE for the proof, drives the router through
+  StartReplayTask + proof-path response + 3 replay-delta
+  responses, and asserts every chain ledger is adopted with the
+  correct hash. Exercises the full Apply+adopt path end-to-end —
+  the engine actually re-runs the empty close.
+- **`TestRouter_ReplayTask_RejectsBadProof`** — tampered proof
+  aborts the task cleanly without firing any replay-delta requests.
+- **`TestRouter_ReplayTask_DoubleStartRejected`** — second
+  StartReplayTask while one is in flight returns an error and
+  leaves the first task untouched.
+- **`TestRouter_ReplayTask_AnchorSeqMustMatch`** — anchor-seq
+  validation at the entry point catches caller miscomputation.
+
+## Acceptance tests
+
+All in `internal/ledger/inbound/` and `internal/consensus/adaptor/`,
+following the test-helper patterns in `replay_delta_test.go` and
+`router_replay_delta_test.go`:
+
+1. **`TestSkipListAcquire_ValidProof_Accepted`** (`skiplist_acquire_test.go`):
+   - Build a `LedgerHashes` SLE with 256 deterministic hashes.
+   - Compute its leaf hash, build a proof path against a synthetic
+     state map containing only that leaf.
+   - Feed `GotResponse` with the matching `stateHash`, key, path.
+   - Assert `State==Complete`, `Hashes()` returns the 256 hashes in
+     the right order.
+
+2. **`TestSkipListAcquire_InvalidProof_Rejected`** (`skiplist_acquire_test.go`):
+   - Two sub-cases:
+     - **Tampered leaf**: serialize a different SLE but reuse the
+       original proof path. `VerifyProofPathWithValue` returns nil →
+       `State==Failed`, peer charge string
+       `replay-skiplist-proof-invalid`.
+     - **Wrong stateHash**: correct payload, wrong target stateHash →
+       same result.
+   - Assert no `Hashes()` leak (returns nil/empty).
+
+3. **`TestLedgerReplayTask_50LedgerBackwardWalk`** (`replay_task_test.go`):
+   - Fabricate ledger N (tip) and ledgers N-1..N-50 (parents).
+   - Local store contains only ledger N-50 (the "anchor").
+   - Construct a fake sender that, on `RequestProofPath(N, ...)`,
+     fires a synthetic `ProofPathResponse` containing the 256-entry
+     skip-list (with the relevant 50 hashes inside it).
+   - On `RequestReplayDelta(h_i, ...)`, fires a synthetic
+     `ReplayDeltaResponse` with header + tx list for ledger `h_i`.
+   - Drive the task, then assert that ledgers N-49..N have all been
+     adopted (callback fired 50 times) and that the task is `Complete`.
+
+4. **`TestLedgerReplayTask_ParallelismBoundedByExistingCaps`**
+   (`replay_task_test.go`):
+   - 50-ledger walk same as above, but the sender records the timing
+     of every `RequestReplayDelta`.
+   - Assert: at no point are more than `DefaultMaxInFlightReplays=16`
+     deltas in flight concurrently, and at no point are more than
+     `MaxPerPeerReplays=2` in flight against any single peer.
+   - Assert: the task completes all 50 deltas (no deadlock).
+
+A fifth integration test on the router seam:
+
+5. **`TestRouter_DeepCatchup_PrefersReplayTask`**
+   (`router_replay_task_test.go`):
+   - Set up a recording sender; advertise that peer P has tip seq=100
+     while ours is 50.
+   - Status-change call to `checkBehind` should result in a single
+     `RequestProofPath` (not 50 `RequestReplayDelta` calls), followed
+     by the bounded fan-out.
+   - Below the threshold (gap=2), `checkBehind` continues to take the
+     single-acquisition forward path — assert one
+     `RequestReplayDelta` and zero `RequestProofPath` calls in that
+     scenario.
+
+## Non-goals (intentional)
+
+- **No** rippled-protocol-level `MAX_TASKS=10` enforcement — we have
+  only one driver (`checkBehind`), and dedup happens at the
+  `Replayer.HasSkipList(hash)` level. We can revisit if a second
+  driver is added.
+- **No** task-level retry timer separate from the per-acquisition
+  timers. `ReplayDelta` already does peer-swap on
+  `SUB_TASK_TIMEOUT`; `SkipListAcquire` will reuse the same per-task
+  timer (250ms swap, 10 max). Failure of the skip-list proof aborts the
+  whole task — caller falls back to single-acquisition. This is
+  simpler than rippled's `TASK_TIMEOUT=500ms` + double-counting and
+  matches our coarser timeout model.
+- **No** WebSocket `ledger_replay` admin RPC. (Future work.)
+
+## Risk surface
+
+- `SkipListAcquire` is a new peer-trust boundary — every proof must be
+  cryptographically verified before any hash is exposed downstream.
+  `VerifyProofPathWithValue` returning nil **must** be a hard fail with
+  bad-data charge.
+- The 256-hash window in `keylet::skip()` is rolling, so for tips at
+  seq N the skip-list contains parents of ledgers N..N-255. We must
+  verify the proof against `target.AccountHash` (the tip we're trying
+  to walk back from), and verify ancestor hashes against the
+  per-ledger headers we then acquire via replay-delta — not skip the
+  per-ledger verification.
+
+## File-by-file
+
+| New / changed | File |
+|---|---|
+| new | `internal/ledger/inbound/skiplist_acquire.go` |
+| new | `internal/ledger/inbound/skiplist_acquire_test.go` |
+| new | `internal/ledger/inbound/replay_task.go` |
+| new | `internal/ledger/inbound/replay_task_test.go` |
+| edit | `internal/ledger/inbound/replayer.go` (AcquireSkipList + Has/Complete/Abandon variants) |
+| edit | `internal/ledger/inbound/replay_delta.go` (`SetParent` for post-acquisition parent binding) |
+| edit | `internal/consensus/adaptor/sender.go` (RequestProofPath) |
+| edit | `internal/consensus/adaptor/adaptor.go` (Sender interface) |
+| edit | `internal/consensus/adaptor/router.go` (TypeProofPathResponse dispatch, task-aware replay-delta routing, Router struct fields for activeTask) |
+| new | `internal/consensus/adaptor/router_replay_task.go` (Router task registry + chain-order adoption drain) |
+| new | `internal/consensus/adaptor/router_replay_task_test.go` (end-to-end integration tests) |


### PR DESCRIPTION
## Summary

Closes #271 — replaces single-ledger-per-request catch-up with a skiplist-driven backward walk.

- One `TMProofPathRequest` retrieves up to 256 ancestor hashes for a tip.
- Bounded-parallel `TMReplayDeltaRequest` acquisitions then reconstruct the chain.
- Each verified ledger is applied + adopted in chain order via the existing `adoptVerifiedLedger → SubmitHeldAdoption` path.

## Architecture

**Phase 1 — sender**: `OverlaySender.RequestProofPath` mirrors `RequestReplayDelta` and wires the client side of a protocol whose server side already existed at `LedgerProvider.GetProofPath`.

**Phase 2 — `SkipListAcquire`** (`internal/ledger/inbound/skiplist_acquire.go`): verifies a peer's `LedgerHashes` SLE proof against the target's `AccountHash` via `shamap.VerifyProofPathWithValue`, then decodes the rolling-256 ancestor vector. Mirrors rippled's `SkipListAcquire.cpp:84-92` + `:151-165`.

**Phase 3 — `Replayer` extension** (`internal/ledger/inbound/replayer.go`): adds `AcquireSkipList` / `HandleSkipListResponse` / `HasSkipList` / `CompleteSkipList` / `SkipListCount`. Separate slot tracking from replay-delta acquisitions so a 16-deep delta backlog doesn't starve short-lived skip-list fetches.

**Phase 4 — `LedgerReplayTask`** (`internal/ledger/inbound/replay_task.go`): orchestrates the skip-list fetch + bounded fan-out of replay-delta subtasks, rotating across peers when the per-peer cap (`MaxPerPeerReplays=2`) is reached. Re-uses the existing global cap (`DefaultMaxInFlightReplays=16`).

**Phase 5 — Router integration** (`internal/consensus/adaptor/router_replay_task.go`):
- `Router.StartReplayTask(...)` explicit entry point.
- `handleProofPathResponse` for `TMProofPathResponse` dispatch; populates the chain-hash routing map.
- `handleReplayDeltaResponse` now first attempts `routeDeltaToActiveTask` — task-owned hashes bypass the legacy Apply path so the task drives chain-ordered adoption.
- `drainTaskChain` walks verified deltas in oldest-first order, binds each parent, calls `rd.Apply()`, then `adoptVerifiedLedger()`.

A small additive method `ReplayDelta.SetParent` lets the task acquire intermediates with `parent=nil` for parallel framing-verification, then bind the real parent at Apply time.

## Acceptance criteria

All four tests from the issue pass:

- ✅ `TestSkipListAcquire_ValidProof_Accepted`
- ✅ `TestSkipListAcquire_InvalidProof_Rejected` (7 sub-cases)
- ✅ `TestLedgerReplayTask_50LedgerBackwardWalk`
- ✅ `TestLedgerReplayTask_ParallelismBoundedByExistingCaps`

Plus router integration tests:
- ✅ `TestRouter_ReplayTask_EndToEnd_3LedgerWalk` — drives the full path with real `ledger.NewOpen+Close` + real engine Apply + real adoption
- ✅ `TestRouter_ReplayTask_RejectsBadProof`
- ✅ `TestRouter_ReplayTask_DoubleStartRejected`
- ✅ `TestRouter_ReplayTask_AnchorSeqMustMatch`

## Deferred: auto-trigger from `checkBehind`

`checkBehind` continues to call `startLedgerAcquisition` unchanged. Reason: `TMStatusChange` does not carry `AccountHash`, so `SkipListAcquire` cannot verify a peer's skip-list proof without first acquiring the tip's header. Two ways to close this gap (both documented in `tasks/pr-multi-ledger-replay.md`):

1. Surface a "header-acquired" hook on the existing inbound flow so the router can pivot to `StartReplayTask` once the tip's `AccountHash` is known.
2. Extend peer-state tracking so a peer's tip `AccountHash` is recorded out-of-band.

Either route is its own design decision, so it lands as a follow-up rather than speculatively in this PR.

## Test plan

- [x] `go test ./internal/ledger/inbound/...`
- [x] `go test ./internal/consensus/adaptor/...`
- [x] `go vet ./...`
- [x] Verified pre-existing failures (`batch`, `XChain`, `Vault`, conformance) are unrelated — they reproduce on pristine `origin/main` without this branch
- [ ] Once an auto-trigger path is wired, end-to-end soak with a deep-behind validator

## Rippled references

- `src/xrpld/app/ledger/LedgerReplayer.h` — timeouts, `MAX_TASKS=10`
- `src/xrpld/app/ledger/detail/SkipListAcquire.cpp` — proof verification
- `src/xrpld/app/ledger/detail/LedgerReplayTask.cpp` — chain enumeration via skip-list array (not `ParentHash`)