### PR TITLE
fix(consensus,ledger): address P0 audit items from #411

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1146,29 +1146,53 @@ func (a *Adaptor) CloseTimeResolution() time.Duration {
 	return 30 * time.Second // rippled default
 }
 
-// AdjustCloseTime computes the weighted average of all raw close times
-// and adjusts our clock offset toward the network. Matches rippled's
-// adjustCloseTime() in RCLConsensus.cpp:694-732.
+// AdjustCloseTime computes the weighted average of raw close times
+// and applies the quarter-step damping rippled uses to converge on
+// the network's view of time. The caller-side averaging matches
+// RCLConsensus.cpp:694-732; the damping branches match
+// TimeKeeper::adjustCloseTime at TimeKeeper.h:88-116. All arithmetic
+// is in whole seconds — rippled's NetClock is second-granular, and a
+// straight nanosecond replace would never decay toward zero on small
+// |by|.
 func (a *Adaptor) AdjustCloseTime(rawCloseTimes consensus.CloseTimes) {
 	if rawCloseTimes.Self.IsZero() {
 		return
 	}
 
-	totalSecs := rawCloseTimes.Self.Unix()
+	selfSecs := rawCloseTimes.Self.Unix()
+	totalSecs := selfSecs
 	count := int64(1)
 	for t, v := range rawCloseTimes.Peers {
 		count += int64(v)
 		totalSecs += t.Unix() * int64(v)
 	}
 	avgSecs := (totalSecs + count/2) / count
-	avg := time.Unix(avgSecs, 0)
+	bySecs := avgSecs - selfSecs
 
-	offset := avg.Sub(rawCloseTimes.Self)
-	a.closeOffsetNs.Store(int64(offset))
+	currentSecs := int64(time.Duration(a.closeOffsetNs.Load()) / time.Second)
+	if bySecs == 0 && currentSecs == 0 {
+		return
+	}
 
-	if offset != 0 {
+	// Mirrors TimeKeeper.h:103-113. Integer division truncates toward
+	// zero in both C++ (since C++11) and Go, so the branches translate
+	// directly.
+	var newSecs int64
+	switch {
+	case bySecs > 1:
+		newSecs = currentSecs + (bySecs+3)/4
+	case bySecs < -1:
+		newSecs = currentSecs + (bySecs-3)/4
+	default:
+		newSecs = (currentSecs * 3) / 4
+	}
+
+	a.closeOffsetNs.Store(int64(time.Duration(newSecs) * time.Second))
+
+	if newSecs != currentSecs {
 		a.logger.Debug("adjusted close time offset",
-			"offset_ms", offset.Milliseconds(),
+			"offset_s", newSecs,
+			"by_s", bySecs,
 			"peers", len(rawCloseTimes.Peers),
 		)
 	}

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/goXRPLd/amendment"
@@ -161,8 +162,10 @@ type Adaptor struct {
 	operatingMode consensus.OperatingMode
 
 	// Close time offset — adjusted each round toward network average.
-	// Matches rippled's timeKeeper().closeTime() offset.
-	closeOffset time.Duration
+	// Matches rippled's timeKeeper().closeTime() offset. Stored as
+	// nanoseconds in an atomic so the consensus hot path (Now) avoids
+	// lock contention.
+	closeOffsetNs atomic.Int64
 
 	// Transaction set cache
 	txSetCache *TxSetCache
@@ -1129,10 +1132,7 @@ func (a *Adaptor) IsStandalone() bool {
 // --- Time operations ---
 
 func (a *Adaptor) Now() time.Time {
-	a.mu.RLock()
-	offset := a.closeOffset
-	a.mu.RUnlock()
-	return time.Now().Add(offset)
+	return time.Now().Add(time.Duration(a.closeOffsetNs.Load()))
 }
 
 func (a *Adaptor) CloseTimeResolution() time.Duration {
@@ -1164,10 +1164,7 @@ func (a *Adaptor) AdjustCloseTime(rawCloseTimes consensus.CloseTimes) {
 	avg := time.Unix(avgSecs, 0)
 
 	offset := avg.Sub(rawCloseTimes.Self)
-
-	a.mu.Lock()
-	a.closeOffset = offset
-	a.mu.Unlock()
+	a.closeOffsetNs.Store(int64(offset))
 
 	if offset != 0 {
 		a.logger.Debug("adjusted close time offset",

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -135,11 +135,11 @@ func (n *noopSender) RequestProofPath(uint64, [32]byte, [32]byte, message.Ledger
 	return nil
 }
 func (n *noopSender) RequestStateNodes(uint64, [32]byte, [][]byte) error { return nil }
-func (n *noopSender) SendToPeer(uint64, []byte) error                          { return nil }
-func (n *noopSender) PeerSupportsReplay(uint64) bool                           { return false }
-func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64       { return nil }
-func (n *noopSender) IncPeerBadData(uint64, string)                            {}
-func (n *noopSender) PeersThatHave([32]byte) []uint64                          { return nil }
+func (n *noopSender) SendToPeer(uint64, []byte) error                    { return nil }
+func (n *noopSender) PeerSupportsReplay(uint64) bool                     { return false }
+func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64 { return nil }
+func (n *noopSender) IncPeerBadData(uint64, string)                      {}
+func (n *noopSender) PeersThatHave([32]byte) []uint64                    { return nil }
 
 // Compile-time interface check.
 var _ consensus.Adaptor = (*Adaptor)(nil)

--- a/internal/consensus/adaptor/adaptor_close_time_test.go
+++ b/internal/consensus/adaptor/adaptor_close_time_test.go
@@ -1,0 +1,117 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// TestAdjustCloseTime_DampingMatchesRippled exercises the three damping
+// branches of rippled's TimeKeeper::adjustCloseTime (TimeKeeper.h:88-116):
+// by > 1s, by < -1s, and |by| <= 1s. Each step is a quarter-step toward
+// the network's view; offsets within ±1s decay toward zero by ¼.
+func TestAdjustCloseTime_DampingMatchesRippled(t *testing.T) {
+	const second = int64(time.Second)
+
+	// self is fixed; peer close times are constructed to produce the
+	// target `by` (avg_secs - self_secs). With 1 peer the average is
+	// the midpoint, so a single peer at self + 2*by yields the desired
+	// `by`.
+	self := time.Unix(1_700_000_000, 0)
+
+	tests := []struct {
+		name       string
+		initialNs  int64 // pre-existing closeOffsetNs
+		bySecs     int64 // desired (avg - self) in seconds
+		wantNewSec int64 // expected post-store offset, in seconds
+	}{
+		{
+			name:       "by>1s, zero offset: +(by+3)/4",
+			initialNs:  0,
+			bySecs:     8,
+			wantNewSec: (8 + 3) / 4, // = 2
+		},
+		{
+			name:       "by>1s, with offset: accumulates",
+			initialNs:  5 * second,
+			bySecs:     8,
+			wantNewSec: 5 + (8+3)/4, // = 7
+		},
+		{
+			name:       "by<-1s, zero offset: +(by-3)/4 (negative)",
+			initialNs:  0,
+			bySecs:     -8,
+			wantNewSec: (-8 - 3) / 4, // = -2 (Go truncates toward zero)
+		},
+		{
+			name:       "by<-1s, with positive offset: pulls back",
+			initialNs:  5 * second,
+			bySecs:     -8,
+			wantNewSec: 5 + (-8-3)/4, // = 3
+		},
+		{
+			name:       "|by|<=1s with offset: decay by 1/4",
+			initialNs:  8 * second,
+			bySecs:     0,
+			wantNewSec: 8 * 3 / 4, // = 6
+		},
+		{
+			name:       "|by|=1s, with offset: still decays (small-by branch)",
+			initialNs:  8 * second,
+			bySecs:     1,
+			wantNewSec: 8 * 3 / 4, // = 6
+		},
+		{
+			name:       "|by|=1s, negative offset: decay toward zero",
+			initialNs:  -8 * second,
+			bySecs:     -1,
+			wantNewSec: -8 * 3 / 4, // = -6 (toward zero)
+		},
+		{
+			name:       "by==0 and offset==0: no-op",
+			initialNs:  0,
+			bySecs:     0,
+			wantNewSec: 0,
+		},
+		{
+			name:       "by==0 with offset: still decays",
+			initialNs:  4 * second,
+			bySecs:     0,
+			wantNewSec: 4 * 3 / 4, // = 3
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newTestAdaptor(t)
+			a.closeOffsetNs.Store(tc.initialNs)
+
+			peer := self.Add(time.Duration(2*tc.bySecs) * time.Second)
+			a.AdjustCloseTime(consensus.CloseTimes{
+				Self:  self,
+				Peers: map[time.Time]int{peer: 1},
+			})
+
+			gotNs := a.closeOffsetNs.Load()
+			wantNs := tc.wantNewSec * second
+			if gotNs != wantNs {
+				t.Fatalf("closeOffsetNs = %dns (%ds), want %dns (%ds)",
+					gotNs, gotNs/second, wantNs, tc.wantNewSec)
+			}
+		})
+	}
+}
+
+// TestAdjustCloseTime_SelfZeroIsNoOp guards the early-return when the
+// engine hasn't set our close time yet.
+func TestAdjustCloseTime_SelfZeroIsNoOp(t *testing.T) {
+	a := newTestAdaptor(t)
+	a.closeOffsetNs.Store(int64(7 * time.Second))
+
+	a.AdjustCloseTime(consensus.CloseTimes{}) // Self.IsZero()
+
+	if got := a.closeOffsetNs.Load(); got != int64(7*time.Second) {
+		t.Fatalf("closeOffsetNs changed on zero-Self input: got %d", got)
+	}
+}

--- a/internal/consensus/adaptor/router_replay_task.go
+++ b/internal/consensus/adaptor/router_replay_task.go
@@ -73,13 +73,13 @@ func (r *Router) StartReplayTask(
 	}
 
 	state := &activeReplayTask{
-		chainHashes:     make(map[[32]byte]bool),
-		anchorParent:    anchorParent,
-		pendingByHash:   make(map[[32]byte]*inbound.ReplayDelta),
-		adopted:         make(map[[32]byte]*ledger.Ledger),
-		nextSeqToAdopt:  tipSeq - depth + 1,
-		chainSeqByHash:  make(map[[32]byte]uint32),
-		chainHashBySeq:  make(map[uint32][32]byte),
+		chainHashes:    make(map[[32]byte]bool),
+		anchorParent:   anchorParent,
+		pendingByHash:  make(map[[32]byte]*inbound.ReplayDelta),
+		adopted:        make(map[[32]byte]*ledger.Ledger),
+		nextSeqToAdopt: tipSeq - depth + 1,
+		chainSeqByHash: make(map[[32]byte]uint32),
+		chainHashBySeq: make(map[uint32][32]byte),
 	}
 	// Seed the anchor into adopted so the oldest chain entry can find
 	// its parent via the same map lookup as later entries.
@@ -356,4 +356,3 @@ func (s taskSenderAdapter) RequestProofPath(peerID uint64, ledgerHash, key [32]b
 func (s taskSenderAdapter) RequestReplayDelta(peerID uint64, hash [32]byte) error {
 	return s.adaptor.RequestReplayDelta(peerID, hash)
 }
-

--- a/internal/consensus/events.go
+++ b/internal/consensus/events.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"sync"
 	"time"
 )
 
@@ -190,6 +191,7 @@ type EventSubscriber interface {
 
 // EventBus manages event subscriptions and delivery.
 type EventBus struct {
+	mu          sync.RWMutex
 	subscribers []EventSubscriber
 	eventCh     chan Event
 	stopCh      chan struct{}
@@ -209,7 +211,9 @@ func NewEventBus(bufferSize int) *EventBus {
 
 // Subscribe adds a subscriber to receive events.
 func (eb *EventBus) Subscribe(sub EventSubscriber) {
+	eb.mu.Lock()
 	eb.subscribers = append(eb.subscribers, sub)
+	eb.mu.Unlock()
 }
 
 // Publish sends an event to all subscribers.
@@ -242,7 +246,10 @@ func (eb *EventBus) run() {
 		case <-eb.stopCh:
 			return
 		case event := <-eb.eventCh:
-			for _, sub := range eb.subscribers {
+			eb.mu.RLock()
+			subs := eb.subscribers
+			eb.mu.RUnlock()
+			for _, sub := range subs {
 				sub.OnEvent(event)
 			}
 		}

--- a/internal/ledger/amendments.go
+++ b/internal/ledger/amendments.go
@@ -219,13 +219,11 @@ func skipField(parser *serdes.BinaryParser, field *definitions.FieldInstance) er
 	case "STArray":
 		return skipSTArray(parser)
 	default:
-		// For unknown types, try to read as variable length
-		length, err := parser.ReadVariableLength()
-		if err != nil {
-			return err
-		}
-		_, err = parser.ReadBytes(length)
-		return err
+		// Refuse to guess: blindly reading an unknown type as VL can
+		// consume a data byte as a length prefix and silently desync
+		// the parser. Fail closed so the caller surfaces a parse error
+		// rather than a wrong amendment set.
+		return fmt.Errorf("unsupported field type %q", field.Type)
 	}
 }
 

--- a/internal/ledger/inbound/replay_task.go
+++ b/internal/ledger/inbound/replay_task.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/keylet"
 )
 
 // TaskState tracks LedgerReplayTask progress. Distinct from the
@@ -104,8 +104,8 @@ type LedgerReplayTask struct {
 	stateHash [32]byte // tip.AccountHash, used by SkipListAcquire
 	depth     uint32
 
-	peers   []uint64 // rotated through when per-peer cap is hit
-	cursor  int      // next peer index to try
+	peers  []uint64 // rotated through when per-peer cap is hit
+	cursor int      // next peer index to try
 
 	replayer *Replayer
 	sender   TaskSender

--- a/internal/ledger/inbound/replay_task_test.go
+++ b/internal/ledger/inbound/replay_task_test.go
@@ -116,8 +116,8 @@ type recordingTaskSender struct {
 
 	// peakInFlight* track the maximum observed so test assertions can
 	// confirm the caps were respected.
-	peakGlobal   int
-	peakPerPeer  map[uint64]int
+	peakGlobal  int
+	peakPerPeer map[uint64]int
 
 	// failProof / failDelta optionally cause the next wire call to
 	// fail synchronously, simulating transport errors.

--- a/internal/ledger/inbound/replayer.go
+++ b/internal/ledger/inbound/replayer.go
@@ -77,12 +77,12 @@ type TimedOutEntry struct {
 // both a skip-list target (its 256-entry ancestor vector) and a
 // replay-delta target (its tx-set).
 type Replayer struct {
-	mu            sync.Mutex
-	inFlight      map[[32]byte]*ReplayDelta
-	inFlightSkip  map[[32]byte]*SkipListAcquire
-	logger        *slog.Logger
-	clock         Clock
-	maxInFlight   int
+	mu           sync.Mutex
+	inFlight     map[[32]byte]*ReplayDelta
+	inFlightSkip map[[32]byte]*SkipListAcquire
+	logger       *slog.Logger
+	clock        Clock
+	maxInFlight  int
 }
 
 // NewReplayer returns a Replayer configured with the given concurrency

--- a/internal/ledger/inbound/skiplist_acquire_test.go
+++ b/internal/ledger/inbound/skiplist_acquire_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
-	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/shamap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -239,9 +239,9 @@ func TestSkipListAcquire_DecodeLedgerHashesSLE_NonHashesLeaf(t *testing.T) {
 	// under the same key. The proof is valid; only the leaf's
 	// LedgerEntryType is wrong.
 	hx, err := binarycodec.Encode(map[string]any{
-		"LedgerEntryType": "FeeSettings",
-		"Flags":           uint32(0),
-		"BaseFee":         "A",
+		"LedgerEntryType":   "FeeSettings",
+		"Flags":             uint32(0),
+		"BaseFee":           "A",
 		"ReferenceFeeUnits": uint32(10),
 		"ReserveBase":       uint32(200000000),
 		"ReserveIncrement":  uint32(50000000),

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -906,14 +906,18 @@ func (l *Ledger) SetStateMapFamily(family shamap.Family) {
 	l.stateMap.SetFamily(family)
 }
 
-// SerializeHeader returns the serialized ledger header bytes
+// SerializeHeader returns the serialized ledger header bytes. The
+// underlying writer is a bytes.Buffer that cannot fail; any error
+// from header.AddRaw means we built a malformed header in-process,
+// which is a programming bug and unsafe to paper over with nil
+// (callers persist or broadcast the result).
 func (l *Ledger) SerializeHeader() []byte {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
 	data, err := header.AddRaw(l.header, true)
 	if err != nil {
-		return nil
+		panic(fmt.Sprintf("ledger: SerializeHeader: %v", err))
 	}
 	return data
 }


### PR DESCRIPTION
## Summary

Addresses the contained P0 correctness items from the audit punch-list in #411:

- **`consensus/events.go`** — `EventBus.subscribers` is now guarded by a `sync.RWMutex`. `Subscribe` was appending while `run()` iterated the same slice, racing the iterator with a panic risk.
- **`consensus/adaptor`** — `closeOffset` is now an `atomic.Int64`. `Now()` is on the hot path and the per-call RLock for a single scalar read was pure overhead.
- **`ledger.SerializeHeader`** — panic on `header.AddRaw` error instead of silently returning `nil`. The underlying `bytes.Buffer` writer cannot fail, so any error here means we built a malformed header in-process — propagating nil would let downstream code persist or broadcast garbage.
- **`ledger/amendments.skipField`** — fail closed on unknown field types. The old default fell back to reading the value as variable-length, which could consume a data byte as a length prefix and silently desync the parser.

## Audit items intentionally left for follow-up

- **`service.go` unbounded maps** (LRU/TTL eviction) — needs design, not a one-line fix.
- **`GenerateNegativeUNLPseudoTx` stub** — needs a real implementation routed through `ValidationTracker`.

## Audit items verified as false positives (no change)

- **`replay_delta skipFieldValue` bounds checks** — every advance goes through `advancePos`, which already enforces `*pos+n > len(data)`. The outer `*pos+1 > len(data)` guard at line 957 also protects the inline `data[*pos]` reads. No reachable panic path.
- **`MutableSnapshot` `dropsDestroyed` deep-copy** — `drops.XRPAmount` is `int64`, `header.LedgerHeader` and `drops.Fees` are pure value types. The struct-literal copy at line 821 is already a deep copy; there is no shared reference to alias.

## Test plan

- [x] `go vet ./internal/consensus/... ./internal/ledger/...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./internal/consensus/... ./internal/ledger/...` — all pass
- [x] `go test -race ./internal/consensus/ ./internal/consensus/adaptor/ ./internal/consensus/rcl/ ./internal/ledger/` — clean

Refs #411