### PR TITLE
fix(ledger/service): bound ledgerHistory + tx-index caches

### DIFF
--- a/internal/ledger/service/history_eviction_test.go
+++ b/internal/ledger/service/history_eviction_test.go
@@ -1,0 +1,128 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+)
+
+// TestEvictOldHistoryLocked verifies that ledgerHistory and the tx
+// indexes are pruned at the historyWindow boundary, with entries
+// above the cutoff preserved intact.
+func TestEvictOldHistoryLocked(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	makeLedger := func(seq uint32, salt byte) *ledger.Ledger {
+		stateMap, err := svc.genesisLedger.StateMapSnapshot()
+		if err != nil {
+			t.Fatalf("StateMapSnapshot: %v", err)
+		}
+		txMap, err := svc.genesisLedger.TxMapSnapshot()
+		if err != nil {
+			t.Fatalf("TxMapSnapshot: %v", err)
+		}
+		var h header.LedgerHeader
+		h.LedgerIndex = seq
+		h.Hash[0] = salt
+		h.Hash[1] = byte(seq)
+		h.Hash[2] = byte(seq >> 8)
+		l := ledger.NewOpenWithHeader(h, stateMap, txMap, drops.Fees{})
+		var txHash [32]byte
+		txHash[0] = 0xAA
+		txHash[1] = byte(seq)
+		txHash[2] = byte(seq >> 8)
+		txData := make([]byte, 16)
+		txData[0] = salt
+		txData[1] = byte(seq)
+		txData[2] = byte(seq >> 8)
+		if err := l.AddTransaction(txHash, txData); err != nil {
+			t.Fatalf("AddTransaction(seq=%d): %v", seq, err)
+		}
+		svc.txIndex[txHash] = seq
+		svc.txPositionIndex[txHash] = 0
+		return l
+	}
+
+	// Populate 3 * historyWindow entries so eviction has plenty to chew on.
+	const totalLedgers = historyWindow * 3
+	var latestSeq uint32 = 1
+	for i := 0; i < totalLedgers; i++ {
+		svc.ledgerHistory[latestSeq] = makeLedger(latestSeq, 0x42)
+		latestSeq++
+	}
+	latestValidated := latestSeq - 1
+
+	svc.mu.Lock()
+	svc.evictOldHistoryLocked(latestValidated)
+	svc.mu.Unlock()
+
+	if got := len(svc.ledgerHistory); got != historyWindow {
+		t.Errorf("ledgerHistory size after eviction: got %d, want %d", got, historyWindow)
+	}
+
+	cutoff := latestValidated - historyWindow
+	for seq, l := range svc.ledgerHistory {
+		if seq <= cutoff {
+			t.Errorf("ledgerHistory[%d] survived eviction; cutoff=%d", seq, cutoff)
+		}
+		_ = l
+	}
+
+	// Tx-index entries for evicted ledgers must be gone; entries for
+	// surviving ledgers must remain.
+	for txHash, txSeq := range svc.txIndex {
+		if txSeq <= cutoff {
+			t.Errorf("txIndex[%x]=%d survived eviction; cutoff=%d", txHash[:4], txSeq, cutoff)
+		}
+	}
+	if got, want := len(svc.txIndex), historyWindow; got != want {
+		t.Errorf("txIndex size: got %d, want %d", got, want)
+	}
+	if got, want := len(svc.txPositionIndex), historyWindow; got != want {
+		t.Errorf("txPositionIndex size: got %d, want %d", got, want)
+	}
+}
+
+// TestEvictOldHistoryLocked_BelowWindow verifies that no eviction
+// occurs while the validated sequence is still within the first
+// historyWindow ledgers (a node fresh out of genesis).
+func TestEvictOldHistoryLocked_BelowWindow(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	for seq := uint32(1); seq <= historyWindow/2; seq++ {
+		stateMap, err := svc.genesisLedger.StateMapSnapshot()
+		if err != nil {
+			t.Fatalf("StateMapSnapshot: %v", err)
+		}
+		txMap, err := svc.genesisLedger.TxMapSnapshot()
+		if err != nil {
+			t.Fatalf("TxMapSnapshot: %v", err)
+		}
+		var h header.LedgerHeader
+		h.LedgerIndex = seq
+		svc.ledgerHistory[seq] = ledger.NewOpenWithHeader(h, stateMap, txMap, drops.Fees{})
+	}
+
+	before := len(svc.ledgerHistory)
+	svc.mu.Lock()
+	svc.evictOldHistoryLocked(historyWindow / 2)
+	svc.mu.Unlock()
+
+	if got := len(svc.ledgerHistory); got != before {
+		t.Errorf("ledgerHistory size changed despite being below window: before=%d after=%d", before, got)
+	}
+}

--- a/internal/ledger/service/history_eviction_test.go
+++ b/internal/ledger/service/history_eviction_test.go
@@ -10,9 +10,6 @@ import (
 	"github.com/LeJamon/goXRPLd/shamap"
 )
 
-// TestEvictOldHistoryLocked verifies that ledgerHistory and the tx
-// indexes are pruned at the historyWindow boundary, with entries
-// above the cutoff preserved intact.
 func TestEvictOldHistoryLocked(t *testing.T) {
 	svc, err := New(DefaultConfig())
 	if err != nil {
@@ -53,7 +50,6 @@ func TestEvictOldHistoryLocked(t *testing.T) {
 		return l
 	}
 
-	// Populate 3 * historyWindow entries so eviction has plenty to chew on.
 	const totalLedgers = historyWindow * 3
 	var latestSeq uint32 = 1
 	for i := 0; i < totalLedgers; i++ {
@@ -78,8 +74,6 @@ func TestEvictOldHistoryLocked(t *testing.T) {
 		_ = l
 	}
 
-	// Tx-index entries for evicted ledgers must be gone; entries for
-	// surviving ledgers must remain.
 	for txHash, txSeq := range svc.txIndex {
 		if txSeq <= cutoff {
 			t.Errorf("txIndex[%x]=%d survived eviction; cutoff=%d", txHash[:4], txSeq, cutoff)
@@ -93,9 +87,6 @@ func TestEvictOldHistoryLocked(t *testing.T) {
 	}
 }
 
-// TestEvictOldHistoryLocked_BelowWindow verifies that no eviction
-// occurs while the validated sequence is still within the first
-// historyWindow ledgers (a node fresh out of genesis).
 func TestEvictOldHistoryLocked_BelowWindow(t *testing.T) {
 	svc, err := New(DefaultConfig())
 	if err != nil {
@@ -129,9 +120,6 @@ func TestEvictOldHistoryLocked_BelowWindow(t *testing.T) {
 	}
 }
 
-// TestAcceptLedgerLoop_BoundsHistory drives the operational path:
-// AcceptLedgerAt is called repeatedly past the historyWindow boundary,
-// and ledgerHistory must remain bounded.
 func TestAcceptLedgerLoop_BoundsHistory(t *testing.T) {
 	svc, err := New(DefaultConfig())
 	if err != nil {
@@ -157,12 +145,9 @@ func TestAcceptLedgerLoop_BoundsHistory(t *testing.T) {
 	}
 }
 
-// TestDrainPendingValidation_EvictsHistory verifies that the inline
-// validation-drain promotion path triggers cache eviction. This is the
-// race where SetValidatedLedger arrives before the close, gets
-// stashed, and the close drains + promotes inline — without this
-// eviction call, the AcceptConsensusResult and adoptLedgerWithState
-// callers would leak entries past the window.
+// Covers the race where SetValidatedLedger arrives before the close
+// and is drained + promoted inline — eviction must run on that path
+// because no second SetValidatedLedger arrives for the same seq.
 func TestDrainPendingValidation_EvictsHistory(t *testing.T) {
 	svc, err := New(DefaultConfig())
 	if err != nil {
@@ -184,8 +169,6 @@ func TestDrainPendingValidation_EvictsHistory(t *testing.T) {
 		return stateMap, txMap
 	}
 
-	// Build a synthetic adopted ledger at a seq well past the window
-	// so eviction has work to do.
 	const adoptedSeq uint32 = historyWindow + 50
 	adoptedState, adoptedTx := freshMaps()
 	var adoptedHeader header.LedgerHeader
@@ -193,8 +176,8 @@ func TestDrainPendingValidation_EvictsHistory(t *testing.T) {
 	adoptedHeader.Hash[0] = 0x77
 	adopted := ledger.NewOpenWithHeader(adoptedHeader, adoptedState, adoptedTx, drops.Fees{})
 
-	// Stash old entries below the post-eviction cutoff that the drain
-	// must clean up.
+	// Seed entries below the post-eviction cutoff so the drain path has
+	// observable work to do.
 	cutoff := adoptedSeq - historyWindow
 	for seq := uint32(1); seq <= cutoff; seq++ {
 		st, tx := freshMaps()
@@ -203,8 +186,6 @@ func TestDrainPendingValidation_EvictsHistory(t *testing.T) {
 		svc.ledgerHistory[seq] = ledger.NewOpenWithHeader(h, st, tx, drops.Fees{})
 	}
 
-	// Stash a pending validation so drainPendingLedgerValidationLocked
-	// will promote the adopted ledger inline.
 	svc.mu.Lock()
 	svc.stashPendingLedgerValidationLocked(adoptedSeq, adopted.Hash())
 	promoted := svc.drainPendingLedgerValidationLocked(adoptedSeq, adopted)

--- a/internal/ledger/service/history_eviction_test.go
+++ b/internal/ledger/service/history_eviction_test.go
@@ -1,11 +1,13 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/drops"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/shamap"
 )
 
 // TestEvictOldHistoryLocked verifies that ledgerHistory and the tx
@@ -124,5 +126,95 @@ func TestEvictOldHistoryLocked_BelowWindow(t *testing.T) {
 
 	if got := len(svc.ledgerHistory); got != before {
 		t.Errorf("ledgerHistory size changed despite being below window: before=%d after=%d", before, got)
+	}
+}
+
+// TestAcceptLedgerLoop_BoundsHistory drives the operational path:
+// AcceptLedgerAt is called repeatedly past the historyWindow boundary,
+// and ledgerHistory must remain bounded.
+func TestAcceptLedgerLoop_BoundsHistory(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx := context.Background()
+	for i := 0; i < historyWindow*2; i++ {
+		if _, err := svc.AcceptLedger(ctx); err != nil {
+			t.Fatalf("AcceptLedger #%d: %v", i, err)
+		}
+	}
+
+	svc.mu.Lock()
+	size := len(svc.ledgerHistory)
+	svc.mu.Unlock()
+
+	if size > historyWindow+1 {
+		t.Errorf("ledgerHistory unbounded under AcceptLedger loop: got %d, want <= %d", size, historyWindow+1)
+	}
+}
+
+// TestDrainPendingValidation_EvictsHistory verifies that the inline
+// validation-drain promotion path triggers cache eviction. This is the
+// race where SetValidatedLedger arrives before the close, gets
+// stashed, and the close drains + promotes inline — without this
+// eviction call, the AcceptConsensusResult and adoptLedgerWithState
+// callers would leak entries past the window.
+func TestDrainPendingValidation_EvictsHistory(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	freshMaps := func() (*shamap.SHAMap, *shamap.SHAMap) {
+		stateMap, err := svc.genesisLedger.StateMapSnapshot()
+		if err != nil {
+			t.Fatalf("StateMapSnapshot: %v", err)
+		}
+		txMap, err := svc.genesisLedger.TxMapSnapshot()
+		if err != nil {
+			t.Fatalf("TxMapSnapshot: %v", err)
+		}
+		return stateMap, txMap
+	}
+
+	// Build a synthetic adopted ledger at a seq well past the window
+	// so eviction has work to do.
+	const adoptedSeq uint32 = historyWindow + 50
+	adoptedState, adoptedTx := freshMaps()
+	var adoptedHeader header.LedgerHeader
+	adoptedHeader.LedgerIndex = adoptedSeq
+	adoptedHeader.Hash[0] = 0x77
+	adopted := ledger.NewOpenWithHeader(adoptedHeader, adoptedState, adoptedTx, drops.Fees{})
+
+	// Stash old entries below the post-eviction cutoff that the drain
+	// must clean up.
+	cutoff := adoptedSeq - historyWindow
+	for seq := uint32(1); seq <= cutoff; seq++ {
+		st, tx := freshMaps()
+		var h header.LedgerHeader
+		h.LedgerIndex = seq
+		svc.ledgerHistory[seq] = ledger.NewOpenWithHeader(h, st, tx, drops.Fees{})
+	}
+
+	// Stash a pending validation so drainPendingLedgerValidationLocked
+	// will promote the adopted ledger inline.
+	svc.mu.Lock()
+	svc.stashPendingLedgerValidationLocked(adoptedSeq, adopted.Hash())
+	promoted := svc.drainPendingLedgerValidationLocked(adoptedSeq, adopted)
+	size := len(svc.ledgerHistory)
+	svc.mu.Unlock()
+
+	if !promoted {
+		t.Fatalf("drainPendingLedgerValidationLocked did not promote — stash setup is wrong")
+	}
+	if size > historyWindow+1 {
+		t.Errorf("inline drain-promote left ledgerHistory unbounded: got %d, want <= %d", size, historyWindow+1)
 	}
 }

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1232,25 +1232,17 @@ func (s *Service) fixMismatchLocked(adopted *ledger.Ledger) {
 }
 
 // historyWindow caps the in-memory ledgerHistory + tx-index caches to
-// a sliding window of recent validated ledgers. Matches the existing
-// pendingValidationMaxLen sizing and rippled's default ledger-cache
-// capacity (SizedItem::ledgerSize "large" tier = 256 entries — see
-// rippled/src/xrpld/core/detail/Config.cpp). At 3s closes that's
-// roughly 13 minutes of history. Range-style RPC lookups for older
-// sequences fall through to the relational DB when configured (see
-// ledger_query.go). Hash-based GetTransaction lookups beyond the
-// window currently return "not found" — a DB fallback is tracked
-// separately.
+// a sliding window of recent validated ledgers. Mirrors rippled's
+// default ledger-cache capacity (SizedItem::ledgerSize "large" tier =
+// 256, see rippled/src/xrpld/core/detail/Config.cpp). Range-style RPC
+// lookups for older sequences fall through to the relational DB; hash-
+// based GetTransaction lookups beyond the window currently return
+// "not found" until a DB fallback lands.
 const historyWindow = 256
 
 // evictOldHistoryLocked drops ledgerHistory entries (and their
 // associated tx-index entries) with seq <= latestValidatedSeq -
-// historyWindow. Bounds the in-memory caches so a long-running node
-// does not accumulate every ledger and tx hash ever seen.
-//
-// Caller must hold s.mu.Lock(). Safe to call with any
-// latestValidatedSeq; the helper is a no-op when the window has not
-// been exceeded.
+// historyWindow. Caller must hold s.mu.
 func (s *Service) evictOldHistoryLocked(latestValidatedSeq uint32) {
 	if latestValidatedSeq <= historyWindow {
 		return

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1233,12 +1233,14 @@ func (s *Service) fixMismatchLocked(adopted *ledger.Ledger) {
 
 // historyWindow caps the in-memory ledgerHistory + tx-index caches to
 // a sliding window of recent validated ledgers. Matches the existing
-// pendingValidationMaxLen sizing and rippled's LedgerHistory window
-// (~256 ledgers ≈ 13 minutes at 3s closes). Range-style RPC lookups
-// for older sequences fall through to the relational DB when
-// configured (see ledger_query.go). Hash-based GetTransaction
-// lookups beyond the window currently return "not found" — a DB
-// fallback is tracked separately.
+// pendingValidationMaxLen sizing and rippled's default ledger-cache
+// capacity (SizedItem::ledgerSize "large" tier = 256 entries — see
+// rippled/src/xrpld/core/detail/Config.cpp). At 3s closes that's
+// roughly 13 minutes of history. Range-style RPC lookups for older
+// sequences fall through to the relational DB when configured (see
+// ledger_query.go). Hash-based GetTransaction lookups beyond the
+// window currently return "not found" — a DB fallback is tracked
+// separately.
 const historyWindow = 256
 
 // evictOldHistoryLocked drops ledgerHistory entries (and their
@@ -1916,6 +1918,7 @@ func (s *Service) drainPendingLedgerValidationLocked(seq uint32, adopted *ledger
 
 	_ = adopted.SetValidated()
 	s.validatedLedger = adopted
+	s.evictOldHistoryLocked(seq)
 	return true
 }
 

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -849,6 +849,7 @@ func (s *Service) AcceptLedgerAt(ctx context.Context, explicitCloseTime time.Tim
 	s.closedLedger = s.openLedger
 	s.validatedLedger = s.openLedger
 	s.ledgerHistory[closedSeq] = s.openLedger
+	s.evictOldHistoryLocked(closedSeq)
 
 	// Standalone already promotes to validated above, so any stashed
 	// validation at this seq is redundant — but drain it so the entry
@@ -1228,6 +1229,42 @@ func (s *Service) fixMismatchLocked(adopted *ledger.Ledger) {
 		"purged_count", len(purgedDetails),
 		"purged", purgedDetails,
 	)
+}
+
+// historyWindow caps the in-memory ledgerHistory + tx-index caches to
+// a sliding window of recent validated ledgers. Matches the existing
+// pendingValidationMaxLen sizing and rippled's LedgerHistory window
+// (~256 ledgers ≈ 13 minutes at 3s closes). Range-style RPC lookups
+// for older sequences fall through to the relational DB when
+// configured (see ledger_query.go). Hash-based GetTransaction
+// lookups beyond the window currently return "not found" — a DB
+// fallback is tracked separately.
+const historyWindow = 256
+
+// evictOldHistoryLocked drops ledgerHistory entries (and their
+// associated tx-index entries) with seq <= latestValidatedSeq -
+// historyWindow. Bounds the in-memory caches so a long-running node
+// does not accumulate every ledger and tx hash ever seen.
+//
+// Caller must hold s.mu.Lock(). Safe to call with any
+// latestValidatedSeq; the helper is a no-op when the window has not
+// been exceeded.
+func (s *Service) evictOldHistoryLocked(latestValidatedSeq uint32) {
+	if latestValidatedSeq <= historyWindow {
+		return
+	}
+	cutoff := latestValidatedSeq - historyWindow
+	for seq, l := range s.ledgerHistory {
+		if seq > cutoff {
+			continue
+		}
+		_ = l.ForEachTransaction(func(txHash [32]byte, _ []byte) bool {
+			delete(s.txIndex, txHash)
+			delete(s.txPositionIndex, txHash)
+			return true
+		})
+		delete(s.ledgerHistory, seq)
+	}
 }
 
 // extractAffectedAccounts extracts account addresses affected by a transaction.
@@ -1715,6 +1752,7 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	}
 	_ = l.SetValidated()
 	s.validatedLedger = l
+	s.evictOldHistoryLocked(seq)
 
 	// Sweep the held local pool against the just-validated ledger.
 	// Mirrors LedgerMaster::setValidLedger → app_.getOPs().updateLocalTx(*l)


### PR DESCRIPTION
## Summary

Addresses the unbounded-maps follow-up from #411.

`Service` carried three maps that grew without bound:

| Map | Key | Value | Growth |
| --- | --- | --- | --- |
| ledgerHistory | seq | *ledger.Ledger | every accepted ledger |
| txIndex | txHash | seq | every tx ever seen |
| txPositionIndex | txHash | position | every tx ever seen |

At 3s closes with ~100 tx/ledger, a day of uptime is roughly 28k ledger entries and ~3M tx-hash entries pinned in memory.

This change adds a sequence-window eviction helper sized at 256 ledgers (matching the existing `pendingValidationMaxLen` and rippled's `LedgerHistory` sweep window). It runs whenever the validated head advances — both on the standalone-close path and from `SetValidatedLedger` — and drops every `ledgerHistory` entry with `seq <= validatedSeq - historyWindow`, along with each evicted ledger's tx-index entries via `ForEachTransaction`.

## Behavior change

- **Range-style lookups** (`ledger_query.go`) already fall through to the relational DB for sequences not in the in-memory cache; that path is unchanged.
- **Hash-based `GetTransaction`** currently has no DB fallback, so queries against very old txs that previously hit the in-memory index will now return `"transaction not found"`. Adding a `relationaldb` fallback to `GetTransaction` is tracked as a follow-up — the in-memory window is still aligned with rippled's own caching semantics.

## Scope clarification

Of the six maps the audit listed:

- `pendingValidation` — already bounded by `pendingValidationMaxLen` (no change)
- `pendingLedgerValidations` — already bounded + TTL (no change)
- `heldAdoptions` — already bounded by `heldAdoptionTTL` (no change)
- `ledgerHistory` — **bounded by this PR**
- `txIndex` — **bounded transitively via ledgerHistory eviction**
- `txPositionIndex` — **bounded transitively via ledgerHistory eviction**

## Test plan

- [x] `go vet ./internal/ledger/service/...` — clean
- [x] `go build ./...` — clean
- [x] New unit tests: `TestEvictOldHistoryLocked`, `TestEvictOldHistoryLocked_BelowWindow`
- [x] `go test -race ./internal/ledger/service/...` — clean
- [x] `go test ./internal/ledger/... ./internal/consensus/...` — all pass

Refs #411