### PR TITLE
chore(adaptor): surface NegativeUNL pseudo-tx stub to operators

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -164,6 +164,12 @@ type Adaptor struct {
 	// Matches rippled's timeKeeper().closeTime() offset.
 	closeOffset time.Duration
 
+	// negativeUNLStubOnce gates the one-shot operator warning emitted
+	// the first time GenerateNegativeUNLPseudoTx is actually invoked
+	// (i.e. we're proposing AND the amendment is enabled). Tracked
+	// in #415.
+	negativeUNLStubOnce sync.Once
+
 	// Transaction set cache
 	txSetCache *TxSetCache
 
@@ -742,11 +748,26 @@ func excludeNegativeUNL(vals []*consensus.Validation, negUNL []consensus.NodeID)
 	return out
 }
 
-// GenerateNegativeUNLPseudoTx is a stub. The vote-tally algorithm in
-// internal/consensus/negativeunlvote still needs per-seq validation history
-// in ValidationTracker and state-map read access on consensus.Ledger before
-// production wiring. Returning nil keeps the injection step a no-op.
+// GenerateNegativeUNLPseudoTx is intentionally a no-op pending #415.
+// The algorithm itself (internal/consensus/negativeunlvote.Voter) is
+// production-ready, but wiring it requires (a) plumbing the
+// ValidationTracker history into the adaptor, (b) an exported
+// skip-list accessor on *ledger.Ledger so we can enumerate the last
+// 256 ledger hashes, and (c) a NegativeUNL SLE deserializer. The
+// call site (rcl/engine.go) handles a nil return as "no vote this
+// round" — graceful degradation for a validator on a NegativeUNL-
+// enabled network.
+//
+// A one-shot warn fires the first time this path actually executes
+// (i.e. we are proposing AND the amendment is enabled), so an
+// operator running a Go validator sees the gap exactly once rather
+// than discovering it via missing votes on the network side.
 func (a *Adaptor) GenerateNegativeUNLPseudoTx(_ consensus.Ledger) []byte {
+	a.negativeUNLStubOnce.Do(func() {
+		a.logger.Warn("NegativeUNL pseudo-tx generation is not yet implemented; this validator will not contribute UNLModify votes",
+			"tracking_issue", "#415",
+		)
+	})
 	return nil
 }
 

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/consensus/amendmentvote"
+	"github.com/LeJamon/goXRPLd/internal/consensus/negativeunlvote"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
@@ -155,6 +156,14 @@ type Adaptor struct {
 	// UNL: trusted validator public keys
 	trustedValidators []consensus.NodeID
 	trustedSet        map[consensus.NodeID]struct{}
+	// trustedMasterKeys are the 33-byte master pubkeys for each entry
+	// in trustedValidators, index-aligned. Populated when the operator
+	// configures validators via base58 keys (the master pubkey is
+	// available pre-hash); empty when the UNL was supplied as raw
+	// NodeIDs (e.g. some tests). Required for NegativeUNL voting —
+	// mirrors rippled's `app_.validators().getTrustedMasterKeys()` at
+	// RCLConsensus.cpp:377.
+	trustedMasterKeys [][33]byte
 	quorum            int
 
 	// Operating mode
@@ -164,11 +173,18 @@ type Adaptor struct {
 	// Matches rippled's timeKeeper().closeTime() offset.
 	closeOffset time.Duration
 
-	// negativeUNLStubOnce gates the one-shot operator warning emitted
-	// the first time GenerateNegativeUNLPseudoTx is actually invoked
-	// (i.e. we're proposing AND the amendment is enabled). Tracked
-	// in #415.
-	negativeUNLStubOnce sync.Once
+	// negUNLVoter produces the UNLModify pseudo-tx every voting ledger
+	// (one ToDisable + one ToReEnable at most). Holds the local
+	// NodeID and the new-validator skip table. Constructed in New()
+	// from identity.NodeID; nil for non-validating adaptors.
+	negUNLVoter *negativeunlvote.Voter
+
+	// validationHistorian provides per-ledger trusted validation
+	// lookups for buildScoreTable. Wired by the engine after the
+	// ValidationTracker is constructed (see rcl.Engine.Run). Nil
+	// before wiring — GenerateNegativeUNLPseudoTx degrades gracefully
+	// (no vote) until then.
+	validationHistorian consensus.ValidationHistorian
 
 	// Transaction set cache
 	txSetCache *TxSetCache
@@ -256,6 +272,15 @@ type Config struct {
 	Sender        NetworkSender
 	Identity      *ValidatorIdentity
 	Validators    []consensus.NodeID // UNL
+	// ValidatorMasterKeys are the 33-byte compressed master public
+	// keys for each entry in Validators, index-aligned. Optional —
+	// when supplied, the adaptor can participate in NegativeUNL
+	// voting (which requires emitting raw master pubkeys in the
+	// UNLModify tx). NewFromConfig populates this from the operator's
+	// base58-encoded [validators] stanza; bare-NodeID test fixtures
+	// can leave it nil and the adaptor will gracefully skip
+	// NegativeUNL votes.
+	ValidatorMasterKeys [][33]byte
 	// FeeVote is the validator's fee-vote stance. Zero values mean no
 	// vote. Production callers wire this from the [voting] stanza of
 	// the toml config (same semantics as rippled's FeeVoteSetup).
@@ -367,14 +392,31 @@ func New(cfg Config) *Adaptor {
 		feeVote.ReserveIncrement = defaults.ReserveIncrement
 	}
 
+	// NegativeUNL voter: owned per-adaptor, matches rippled's
+	// nUnlVote_ member on RCLConsensus. Constructed only when we have
+	// a local validator identity AND master keys for the UNL — the
+	// algorithm needs both to vote (myID for the local-participation
+	// check, master keys for the emitted UNLModify tx). For
+	// non-validator nodes or bare-NodeID test fixtures, leave it nil
+	// and GenerateNegativeUNLPseudoTx returns no votes.
+	var negUNLVoter *negativeunlvote.Voter
+	var trustedMasterKeys [][33]byte
+	if cfg.Identity != nil && len(cfg.ValidatorMasterKeys) == len(cfg.Validators) && len(cfg.ValidatorMasterKeys) > 0 {
+		trustedMasterKeys = make([][33]byte, len(cfg.ValidatorMasterKeys))
+		copy(trustedMasterKeys, cfg.ValidatorMasterKeys)
+		negUNLVoter = negativeunlvote.NewVoter(cfg.Identity.NodeID)
+	}
+
 	return &Adaptor{
 		ledgerService:     cfg.LedgerService,
 		sender:            sender,
 		identity:          cfg.Identity,
 		trustedValidators: cfg.Validators,
 		trustedSet:        trustedSet,
+		trustedMasterKeys: trustedMasterKeys,
 		quorum:            quorum,
 		operatingMode:     consensus.OpModeDisconnected,
+		negUNLVoter:       negUNLVoter,
 		txSetCache:        NewTxSetCache(),
 		peerLCLs:          make(map[uint64]consensus.LedgerID),
 		cookie:            cookie,
@@ -383,6 +425,17 @@ func New(cfg Config) *Adaptor {
 		trustedVotes:      trustedVotes,
 		logger:            logger,
 	}
+}
+
+// SetValidationHistorian wires per-ledger trusted-validation lookups
+// into the adaptor. The engine calls this once after constructing its
+// ValidationTracker (see rcl.Engine.Run). Required for NegativeUNL
+// voting; until set, GenerateNegativeUNLPseudoTx emits no votes
+// (graceful degradation). Satisfies consensus.WireableAdaptor.
+func (a *Adaptor) SetValidationHistorian(h consensus.ValidationHistorian) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.validationHistorian = h
 }
 
 // UpdatePeerLCL records the last-closed-ledger hash a peer reported
@@ -746,29 +799,6 @@ func excludeNegativeUNL(vals []*consensus.Validation, negUNL []consensus.NodeID)
 		out = append(out, v)
 	}
 	return out
-}
-
-// GenerateNegativeUNLPseudoTx is intentionally a no-op pending #415.
-// The algorithm itself (internal/consensus/negativeunlvote.Voter) is
-// production-ready, but wiring it requires (a) plumbing the
-// ValidationTracker history into the adaptor, (b) an exported
-// skip-list accessor on *ledger.Ledger so we can enumerate the last
-// 256 ledger hashes, and (c) a NegativeUNL SLE deserializer. The
-// call site (rcl/engine.go) handles a nil return as "no vote this
-// round" — graceful degradation for a validator on a NegativeUNL-
-// enabled network.
-//
-// A one-shot warn fires the first time this path actually executes
-// (i.e. we are proposing AND the amendment is enabled), so an
-// operator running a Go validator sees the gap exactly once rather
-// than discovering it via missing votes on the network side.
-func (a *Adaptor) GenerateNegativeUNLPseudoTx(_ consensus.Ledger) []byte {
-	a.negativeUNLStubOnce.Do(func() {
-		a.logger.Warn("NegativeUNL pseudo-tx generation is not yet implemented; this validator will not contribute UNLModify votes",
-			"tracking_issue", "#415",
-		)
-	})
-	return nil
 }
 
 func (a *Adaptor) GetTxSet(id consensus.TxSetID) (consensus.TxSet, error) {

--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -1,0 +1,176 @@
+package adaptor
+
+import (
+	"errors"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/negativeunlvote"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/keylet"
+)
+
+// GenerateNegativeUNLPseudoTx produces the UNLModify pseudo-tx blobs
+// to inject on a NegativeUNL-enabled voting ledger. Mirrors rippled's
+// NegativeUNLVote::doVoting (NegativeUNLVote.cpp:36-108) wired through
+// the adaptor: read the parent NegativeUNL SLE, build the score table
+// from the last FlagLedgerInterval validation snapshots, delegate to
+// negativeunlvote.Voter for candidate selection, and return the
+// serialized [][]byte (zero, one, or two blobs).
+//
+// Returns nil (no votes) under any of:
+//   - this adaptor was constructed without a Voter (no identity or
+//     master keys plumbed in — fixtures, observer nodes)
+//   - the ValidationHistorian has not yet been wired by the engine
+//   - prevLedger is not a *LedgerWrapper (test ledger types)
+//   - the skip-list contains fewer than FlagLedgerInterval ancestors
+//     (early ledgers near genesis)
+//   - local participation is below MinLocalValsToVote (230/256) —
+//     local view too narrow to trust
+//   - no candidates qualify
+//
+// All zero-vote paths are silent; an operator running a validator on
+// a NegativeUNL-enabled network sees neither errors nor warnings when
+// the round simply has nothing to do.
+func (a *Adaptor) GenerateNegativeUNLPseudoTx(prev consensus.Ledger) [][]byte {
+	a.mu.RLock()
+	voter := a.negUNLVoter
+	historian := a.validationHistorian
+	masterKeys := a.trustedMasterKeys
+	a.mu.RUnlock()
+
+	if voter == nil || historian == nil || len(masterKeys) == 0 {
+		return nil
+	}
+
+	wrapper, ok := prev.(*LedgerWrapper)
+	if !ok {
+		return nil
+	}
+	concrete := wrapper.Unwrap()
+	if concrete == nil {
+		return nil
+	}
+
+	state, err := a.negativeUNLState(concrete)
+	if err != nil {
+		a.logger.Warn("NegativeUNL: parse SLE failed; skipping vote this round",
+			"prev_seq", concrete.Sequence(),
+			"err", err,
+		)
+		return nil
+	}
+
+	scoreTable, ok := a.buildNegativeUNLScoreTable(concrete, historian, voter.MyID())
+	if !ok {
+		return nil
+	}
+
+	unlKeys := make([][33]byte, len(masterKeys))
+	copy(unlKeys, masterKeys)
+
+	prevSeq := concrete.Sequence()
+	prevHash := concrete.Hash()
+
+	voter.PurgeNewValidators(prevSeq + 1)
+
+	blobs, err := voter.DoVoting(prevSeq, prevHash, unlKeys, state, scoreTable)
+	if err != nil {
+		if errors.Is(err, negativeunlvote.ErrLocalCountExceedsWindow) {
+			a.logger.Error("NegativeUNL: local validation count exceeds window — likely duplicate-validation bug",
+				"prev_seq", prevSeq,
+				"err", err,
+			)
+			return nil
+		}
+		a.logger.Warn("NegativeUNL: DoVoting failed",
+			"prev_seq", prevSeq,
+			"err", err,
+		)
+		return nil
+	}
+	return blobs
+}
+
+// negativeUNLState reads and parses the NegativeUNL SLE from the
+// given ledger into the negativeunlvote.State shape. An empty/absent
+// SLE returns the zero-value State (no disabled, no pending changes).
+func (a *Adaptor) negativeUNLState(l interface {
+	Read(keylet.Keylet) ([]byte, error)
+}) (negativeunlvote.State, error) {
+	raw, err := l.Read(keylet.NegativeUNL())
+	if err != nil {
+		return negativeunlvote.State{}, err
+	}
+	parsed, err := pseudo.ParseNegativeUNLSLE(raw)
+	if err != nil {
+		return negativeunlvote.State{}, err
+	}
+	state := negativeunlvote.State{}
+	if n := len(parsed.DisabledValidators); n > 0 {
+		state.DisabledKeys = make([][33]byte, 0, n)
+		for _, v := range parsed.DisabledValidators {
+			if len(v) != 33 {
+				continue
+			}
+			var k [33]byte
+			copy(k[:], v)
+			state.DisabledKeys = append(state.DisabledKeys, k)
+		}
+	}
+	if len(parsed.ValidatorToDisable) == 33 {
+		var k [33]byte
+		copy(k[:], parsed.ValidatorToDisable)
+		state.ToDisablePending = &k
+	}
+	if len(parsed.ValidatorToReEnable) == 33 {
+		var k [33]byte
+		copy(k[:], parsed.ValidatorToReEnable)
+		state.ToReEnablePending = &k
+	}
+	return state, nil
+}
+
+// buildNegativeUNLScoreTable mirrors rippled's
+// NegativeUNLVote::buildScoreTable (NegativeUNLVote.cpp:173-244):
+//
+//  1. Read the parent ledger's rolling skip-list of the previous
+//     FlagLedgerInterval ledger hashes.
+//  2. For each ancestor, look up the trusted validations that named
+//     it and increment a per-NodeID counter.
+//  3. Enforce the local-node participation gate
+//     ([MinLocalValsToVote, FlagLedgerInterval]) — outside that range
+//     return ok=false so the producer abstains.
+//
+// Returns (nil, false) when the parent's skip-list is shorter than
+// FlagLedgerInterval (early ledgers) or when local participation is
+// out of range. A successful return guarantees every trusted
+// validator the Voter consults will fall back to score 0 (rippled's
+// invariant at NegativeUNLVote.cpp:197-200, enforced inside DoVoting).
+func (a *Adaptor) buildNegativeUNLScoreTable(
+	prev interface {
+		SkipListHashes() ([][32]byte, error)
+	},
+	historian consensus.ValidationHistorian,
+	myID consensus.NodeID,
+) (map[consensus.NodeID]uint32, bool) {
+	ancestors, err := prev.SkipListHashes()
+	if err != nil || uint32(len(ancestors)) < consensus.FlagLedgerInterval {
+		return nil, false
+	}
+
+	n := uint32(len(ancestors))
+	window := consensus.FlagLedgerInterval
+	scoreTable := make(map[consensus.NodeID]uint32)
+	for i := uint32(0); i < window; i++ {
+		ledgerHash := ancestors[n-1-i]
+		for _, v := range historian.GetTrustedValidations(consensus.LedgerID(ledgerHash)) {
+			scoreTable[v.NodeID]++
+		}
+	}
+
+	myCount := scoreTable[myID]
+	if myCount < negativeunlvote.MinLocalValsToVote || myCount > window {
+		return nil, false
+	}
+	return scoreTable, true
+}

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -1,0 +1,236 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/consensus/negativeunlvote"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubLedgerReader satisfies the narrow interface negativeUNLState
+// consumes (Read by keylet). Used to feed encoded NegativeUNL SLE
+// bytes without standing up a full *ledger.Ledger fixture.
+type stubLedgerReader struct {
+	negativeUNLBytes []byte
+}
+
+func (s *stubLedgerReader) Read(k keylet.Keylet) ([]byte, error) {
+	if k.Key == keylet.NegativeUNL().Key {
+		return s.negativeUNLBytes, nil
+	}
+	return nil, nil
+}
+
+// stubSkipListProvider satisfies the narrow interface
+// buildNegativeUNLScoreTable consumes.
+type stubSkipListProvider struct {
+	hashes [][32]byte
+	err    error
+}
+
+func (s *stubSkipListProvider) SkipListHashes() ([][32]byte, error) {
+	return s.hashes, s.err
+}
+
+// stubHistorian implements consensus.ValidationHistorian by returning
+// per-ledger trusted validations from a pre-seeded map.
+type stubHistorian struct {
+	byLedger map[consensus.LedgerID][]*consensus.Validation
+}
+
+func (s *stubHistorian) GetTrustedValidations(id consensus.LedgerID) []*consensus.Validation {
+	return s.byLedger[id]
+}
+
+func TestAdaptor_NegativeUNL_NilVoterReturnsNil(t *testing.T) {
+	// Adaptor constructed without master keys → voter is nil.
+	a := newTestAdaptor(t)
+	require.Nil(t, a.negUNLVoter, "no master keys plumbed: voter must be nil")
+
+	prev := WrapLedger(a.ledgerService.GetClosedLedger())
+	require.NotNil(t, prev)
+
+	blobs := a.GenerateNegativeUNLPseudoTx(prev)
+	assert.Nil(t, blobs, "without a voter, emit no NegativeUNL vote")
+}
+
+func TestAdaptor_NegativeUNL_NilHistorianReturnsNil(t *testing.T) {
+	// Voter present, but historian not yet wired → must not emit.
+	a := newTestAdaptorWithMasters(t)
+	require.NotNil(t, a.negUNLVoter, "fixture must construct a voter")
+	require.Nil(t, a.validationHistorian, "historian not wired yet")
+
+	prev := WrapLedger(a.ledgerService.GetClosedLedger())
+	require.NotNil(t, prev)
+
+	blobs := a.GenerateNegativeUNLPseudoTx(prev)
+	assert.Nil(t, blobs, "without a historian, emit no NegativeUNL vote")
+}
+
+func TestAdaptor_NegativeUNL_NonWrappedLedgerReturnsNil(t *testing.T) {
+	// A consensus.Ledger that isn't a *LedgerWrapper must be silently
+	// skipped — protects against test ledger types or future adapters.
+	a := newTestAdaptorWithMasters(t)
+	a.SetValidationHistorian(&stubHistorian{})
+
+	blobs := a.GenerateNegativeUNLPseudoTx(notWrappedLedger{})
+	assert.Nil(t, blobs)
+}
+
+func TestNegativeUNLState_ParsesEmptySLE(t *testing.T) {
+	a := newTestAdaptor(t)
+	state, err := a.negativeUNLState(&stubLedgerReader{negativeUNLBytes: nil})
+	require.NoError(t, err)
+	assert.Empty(t, state.DisabledKeys)
+	assert.Nil(t, state.ToDisablePending)
+	assert.Nil(t, state.ToReEnablePending)
+}
+
+func TestNegativeUNLState_ParsesPopulatedSLE(t *testing.T) {
+	a := newTestAdaptor(t)
+
+	master1 := make33Byte(0x01)
+	master2 := make33Byte(0x02)
+	masterPending := make33Byte(0x03)
+
+	sle := &pseudo.NegativeUNLSLE{
+		DisabledValidators:  [][]byte{master1[:], master2[:]},
+		ValidatorToReEnable: masterPending[:],
+	}
+	encoded, err := pseudo.SerializeNegativeUNLSLE(sle)
+	require.NoError(t, err)
+
+	state, err := a.negativeUNLState(&stubLedgerReader{negativeUNLBytes: encoded})
+	require.NoError(t, err)
+
+	require.Len(t, state.DisabledKeys, 2)
+	assert.Equal(t, master1, state.DisabledKeys[0])
+	assert.Equal(t, master2, state.DisabledKeys[1])
+	assert.Nil(t, state.ToDisablePending)
+	require.NotNil(t, state.ToReEnablePending)
+	assert.Equal(t, masterPending, *state.ToReEnablePending)
+}
+
+func TestBuildScoreTable_RejectsShortSkipList(t *testing.T) {
+	a := newTestAdaptor(t)
+	hist := &stubHistorian{}
+
+	scoreTable, ok := a.buildNegativeUNLScoreTable(
+		&stubSkipListProvider{hashes: make([][32]byte, 100)},
+		hist,
+		consensus.NodeID{},
+	)
+	assert.False(t, ok, "skip-list shorter than FlagLedgerInterval must abort")
+	assert.Nil(t, scoreTable)
+}
+
+func TestBuildScoreTable_RejectsInsufficientLocalParticipation(t *testing.T) {
+	a := newTestAdaptor(t)
+
+	ancestors := make([][32]byte, consensus.FlagLedgerInterval)
+	for i := range ancestors {
+		ancestors[i] = [32]byte{byte(i), 0xAB}
+	}
+
+	myID := consensus.NodeID{0x99}
+	otherID := consensus.NodeID{0xAA}
+
+	// Seed the local node with fewer than MinLocalValsToVote (230)
+	// validations, with another validator covering every slot — the
+	// gate must fire on the local count alone, regardless of others.
+	byLedger := make(map[consensus.LedgerID][]*consensus.Validation, len(ancestors))
+	for i, h := range ancestors {
+		vals := []*consensus.Validation{{NodeID: otherID, LedgerID: consensus.LedgerID(h)}}
+		if uint32(i) < negativeunlvote.MinLocalValsToVote-1 {
+			vals = append(vals, &consensus.Validation{NodeID: myID, LedgerID: consensus.LedgerID(h)})
+		}
+		byLedger[consensus.LedgerID(h)] = vals
+	}
+
+	scoreTable, ok := a.buildNegativeUNLScoreTable(
+		&stubSkipListProvider{hashes: ancestors},
+		&stubHistorian{byLedger: byLedger},
+		myID,
+	)
+	assert.False(t, ok, "local count below MinLocalValsToVote must abort")
+	assert.Nil(t, scoreTable)
+}
+
+func TestBuildScoreTable_TalliesAcrossAncestors(t *testing.T) {
+	a := newTestAdaptor(t)
+
+	ancestors := make([][32]byte, consensus.FlagLedgerInterval)
+	for i := range ancestors {
+		ancestors[i] = [32]byte{byte(i >> 8), byte(i), 0xCD}
+	}
+
+	myID := consensus.NodeID{0x11}
+	offline := consensus.NodeID{0x22}
+
+	byLedger := make(map[consensus.LedgerID][]*consensus.Validation, len(ancestors))
+	for i, h := range ancestors {
+		vals := []*consensus.Validation{{NodeID: myID, LedgerID: consensus.LedgerID(h)}}
+		// `offline` validates only the first 50 ledgers — below the
+		// low water mark (128) so the producer would consider it a
+		// ToDisable candidate.
+		if i < 50 {
+			vals = append(vals, &consensus.Validation{NodeID: offline, LedgerID: consensus.LedgerID(h)})
+		}
+		byLedger[consensus.LedgerID(h)] = vals
+	}
+
+	scoreTable, ok := a.buildNegativeUNLScoreTable(
+		&stubSkipListProvider{hashes: ancestors},
+		&stubHistorian{byLedger: byLedger},
+		myID,
+	)
+	require.True(t, ok, "local participation = 256 must pass the gate")
+	require.NotNil(t, scoreTable)
+
+	assert.Equal(t, consensus.FlagLedgerInterval, scoreTable[myID], "local validator scored on every ancestor")
+	assert.Equal(t, uint32(50), scoreTable[offline], "offline validator scored only on first 50 ancestors")
+}
+
+// newTestAdaptorWithMasters builds an Adaptor with a master pubkey
+// plumbed in (so negUNLVoter is non-nil), letting the negative-UNL
+// path execute without the no-voter / no-master short-circuit.
+func newTestAdaptorWithMasters(t *testing.T) *Adaptor {
+	t.Helper()
+	svc := newTestLedgerService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	return New(Config{
+		LedgerService:       svc,
+		Identity:            identity,
+		Validators:          []consensus.NodeID{identity.NodeID},
+		ValidatorMasterKeys: [][33]byte{identity.MasterKey},
+	})
+}
+
+// make33Byte returns a deterministic 33-byte master pubkey filled
+// with the supplied byte, suitable for SLE round-trip tests where
+// only structural shape matters.
+func make33Byte(b byte) [33]byte {
+	var out [33]byte
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+// notWrappedLedger is a minimal consensus.Ledger that is NOT a
+// *LedgerWrapper — used to exercise the type-assertion guard in
+// GenerateNegativeUNLPseudoTx.
+type notWrappedLedger struct{}
+
+func (notWrappedLedger) ID() consensus.LedgerID       { return consensus.LedgerID{} }
+func (notWrappedLedger) Seq() uint32                  { return 0 }
+func (notWrappedLedger) ParentID() consensus.LedgerID { return consensus.LedgerID{} }
+func (notWrappedLedger) CloseTime() time.Time         { return time.Time{} }
+func (notWrappedLedger) TxSetID() consensus.TxSetID   { return consensus.TxSetID{} }
+func (notWrappedLedger) Bytes() []byte                { return nil }

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -174,8 +174,10 @@ func NewFromConfig(
 	// reach the ledger without breaking that layering boundary.
 	overlay.LedgerSync().SetProvider(NewLedgerProvider(ledgerSvc))
 
-	// Load UNL from config
-	validators, err := ParseValidatorKeys(appCfg)
+	// Load UNL from config — retain both NodeID (for trust/quorum
+	// maps) and master pubkey (for NegativeUNL voting; sfUNLModifyValidator
+	// is the master pubkey, see NegativeUNLVote.cpp:118-120).
+	validators, masterKeys, err := ParseValidatorKeysWithMaster(appCfg)
 	if err != nil {
 		return nil, fmt.Errorf("parse validators: %w", err)
 	}
@@ -183,10 +185,11 @@ func NewFromConfig(
 	sender := NewOverlaySender(overlay)
 
 	adaptor := New(Config{
-		LedgerService: ledgerSvc,
-		Sender:        sender,
-		Identity:      identity,
-		Validators:    validators,
+		LedgerService:       ledgerSvc,
+		Sender:              sender,
+		Identity:            identity,
+		Validators:          validators,
+		ValidatorMasterKeys: masterKeys,
 	})
 
 	modeManager := NewModeManager(adaptor)
@@ -337,19 +340,30 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 
 // ParseValidatorKeys parses validator public keys from the config into NodeIDs.
 func ParseValidatorKeys(appCfg *config.Config) ([]consensus.NodeID, error) {
+	validators, _, err := ParseValidatorKeysWithMaster(appCfg)
+	return validators, err
+}
+
+// ParseValidatorKeysWithMaster parses validator public keys into both
+// the NodeID set (for trust/quorum maps) and the 33-byte master pubkey
+// list (index-aligned, for NegativeUNL voting). Returns (nil, nil, nil)
+// when the [validators] stanza is empty.
+func ParseValidatorKeysWithMaster(appCfg *config.Config) ([]consensus.NodeID, [][33]byte, error) {
 	if len(appCfg.Validators.Validators) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
-	var validators []consensus.NodeID
+	validators := make([]consensus.NodeID, 0, len(appCfg.Validators.Validators))
+	masters := make([][33]byte, 0, len(appCfg.Validators.Validators))
 	for _, key := range appCfg.Validators.Validators {
-		nodeID, err := DecodeValidatorKey(key)
+		nodeID, master, err := DecodeValidatorKeyWithMaster(key)
 		if err != nil {
-			return nil, fmt.Errorf("invalid validator key %q: %w", key, err)
+			return nil, nil, fmt.Errorf("invalid validator key %q: %w", key, err)
 		}
 		validators = append(validators, nodeID)
+		masters = append(masters, master)
 	}
-	return validators, nil
+	return validators, masters, nil
 }
 
 // normalizeAddresses converts rippled-style "host port" addresses to "host:port".

--- a/internal/consensus/adaptor/unl.go
+++ b/internal/consensus/adaptor/unl.go
@@ -76,7 +76,17 @@ func (u *UNL) Size() int {
 // applies calcNodeID (RIPEMD-160(SHA-256(masterPubKey))) so the trust
 // set is keyed identically to the inbound NodeID values populated by
 // the consensus router.
-func DecodeValidatorKey(key string) (nodeID consensus.NodeID, err error) {
+func DecodeValidatorKey(key string) (consensus.NodeID, error) {
+	nodeID, _, err := DecodeValidatorKeyWithMaster(key)
+	return nodeID, err
+}
+
+// DecodeValidatorKeyWithMaster decodes a base58-encoded validator
+// public key into both its 20-byte NodeID and the underlying 33-byte
+// master pubkey. NegativeUNL voting needs the raw master because the
+// UNLModify pseudo-tx carries the master pubkey on the wire — see
+// NegativeUNLVote.cpp:118-120 (sfUNLModifyValidator is the master).
+func DecodeValidatorKeyWithMaster(key string) (nodeID consensus.NodeID, master [33]byte, err error) {
 	// Guard against panics in the base58 decoder for malformed input
 	defer func() {
 		if r := recover(); r != nil {
@@ -84,16 +94,15 @@ func DecodeValidatorKey(key string) (nodeID consensus.NodeID, err error) {
 		}
 	}()
 
-	decoded, err := addresscodec.DecodeNodePublicKey(key)
-	if err != nil {
-		return consensus.NodeID{}, fmt.Errorf("decode node public key: %w", err)
+	decoded, decErr := addresscodec.DecodeNodePublicKey(key)
+	if decErr != nil {
+		return consensus.NodeID{}, [33]byte{}, fmt.Errorf("decode node public key: %w", decErr)
 	}
 	if len(decoded) != 33 {
-		return consensus.NodeID{}, fmt.Errorf("unexpected key length: got %d, want 33", len(decoded))
+		return consensus.NodeID{}, [33]byte{}, fmt.Errorf("unexpected key length: got %d, want 33", len(decoded))
 	}
-	var master [33]byte
 	copy(master[:], decoded)
-	return consensus.CalcNodeID(master), nil
+	return consensus.CalcNodeID(master), master, nil
 }
 
 // CalcQuorum computes the quorum for n validators matching rippled.

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -58,6 +58,25 @@ type Engine interface {
 	GetLastCloseInfo() (proposers int, convergeTime time.Duration)
 }
 
+// ValidationHistorian provides historical, per-ledger trusted
+// validation lookups for NegativeUNL score-table building. Implemented
+// by rcl.ValidationTracker; an adaptor that wants to participate in
+// NegativeUNL voting receives one via the WireableAdaptor extension.
+// Mirrors rippled's `validations.getTrustedForLedger(hash, seq)` at
+// NegativeUNLVote.cpp:208 — goXRPL's tracker keys validations by
+// LedgerID, so the (hash, seq) tuple collapses to a single lookup.
+type ValidationHistorian interface {
+	GetTrustedValidations(ledgerID LedgerID) []*Validation
+}
+
+// WireableAdaptor is an optional extension that engine wires up after
+// constructing its ValidationTracker. Adaptors that implement it can
+// emit NegativeUNL pseudo-txs; those that don't (e.g. test mocks)
+// continue to work and simply skip NegativeUNL voting.
+type WireableAdaptor interface {
+	SetValidationHistorian(h ValidationHistorian)
+}
+
 // Adaptor provides the interface between the consensus engine and
 // the rest of the node (network, ledger, transaction queue).
 // This follows rippled's adaptor pattern for clean separation.
@@ -183,13 +202,15 @@ type Adaptor interface {
 	GenerateFlagLedgerPseudoTxs(prevLedger Ledger, parentValidations []*Validation) [][]byte
 
 	// GenerateNegativeUNLPseudoTx returns the NegativeUNL pseudo-tx
-	// to inject when prevLedger is a voting ledger AND the
+	// blobs to inject when prevLedger is a voting ledger AND the
 	// featureNegativeUNL amendment is enabled. Mirrors rippled
-	// RCLConsensus.cpp:368-380.
+	// RCLConsensus.cpp:368-380 + NegativeUNLVote.cpp:84-107 which
+	// emits at most one ToDisable AND at most one ToReEnable per
+	// flag-ledger vote — hence the [][]byte return.
 	//
 	// Returns nil when no NegUNL changes are required. Adaptors
 	// without NegativeUNLVote support return nil.
-	GenerateNegativeUNLPseudoTx(prevLedger Ledger) []byte
+	GenerateNegativeUNLPseudoTx(prevLedger Ledger) [][]byte
 
 	// GetTxSet returns a transaction set by ID.
 	GetTxSet(id TxSetID) (TxSet, error)

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -156,6 +156,16 @@ func NewVoter(myID consensus.NodeID) *Voter {
 	}
 }
 
+// MyID returns the local node's NodeID used by DoVoting for the
+// local-participation gate. Exposed for callers that need to look
+// up the local validator's score in their own score table before
+// invoking DoVoting (e.g. the adaptor's buildScoreTable wrapper,
+// which short-circuits on insufficient local participation to
+// avoid building an unused candidate list).
+func (v *Voter) MyID() consensus.NodeID {
+	return v.myID
+}
+
 // NewValidators registers a set of newly-trusted validators at the
 // given ledger sequence so they are exempt from ToDisable voting for
 // the next NewValidatorDisableSkip ledgers. Mirrors

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -316,6 +316,9 @@ func (e *Engine) Start(ctx context.Context) error {
 	// flips the ledger service's validated_ledger pointer.
 	e.validationTracker = NewValidationTracker(e.adaptor.GetQuorum(), 5*time.Minute)
 	e.validationTracker.SetTrusted(e.adaptor.GetTrustedValidators())
+	if wired, ok := e.adaptor.(consensus.WireableAdaptor); ok {
+		wired.SetValidationHistorian(e.validationTracker)
+	}
 	if e.ledgerAncestry != nil {
 		e.validationTracker.SetLedgerAncestryProvider(e.ledgerAncestry)
 	}
@@ -1582,7 +1585,7 @@ func (e *Engine) closeLedger() {
 			}
 		case consensus.IsVotingLedger(prev.Seq()) && e.adaptor.IsFeatureEnabledOnLedger(prev, "NegativeUNL"):
 			if extra := e.adaptor.GenerateNegativeUNLPseudoTx(prev); len(extra) > 0 {
-				txs = append(txs, extra)
+				txs = append(txs, extra...)
 			}
 		}
 	}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -139,7 +139,7 @@ type mockAdaptor struct {
 	// stub returns nil (no injection), matching the production
 	// adaptor's pre-vote-tally behavior.
 	flagLedgerPseudoTxs [][]byte
-	negativeUNLPseudoTx []byte
+	negativeUNLPseudoTx [][]byte
 
 	// standalone toggles the IsStandalone() return for tests that
 	// exercise rippled's `standalone() || (proposing && !wrongLCL)`
@@ -342,7 +342,7 @@ func (a *mockAdaptor) GenerateFlagLedgerPseudoTxs(_ consensus.Ledger, _ []*conse
 	return a.flagLedgerPseudoTxs
 }
 
-func (a *mockAdaptor) GenerateNegativeUNLPseudoTx(_ consensus.Ledger) []byte {
+func (a *mockAdaptor) GenerateNegativeUNLPseudoTx(_ consensus.Ledger) [][]byte {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.negativeUNLPseudoTx

--- a/internal/consensus/rcl/pseudo_tx_injection_test.go
+++ b/internal/consensus/rcl/pseudo_tx_injection_test.go
@@ -106,7 +106,7 @@ func TestCloseLedger_NegUNLGatedOnFeature(t *testing.T) {
 	a.disabledFeatures = map[string]bool{"NegativeUNL": true}
 
 	negUNLBlob := []byte{0xDE, 0xAD, 0xBE, 0xEF}
-	a.negativeUNLPseudoTx = negUNLBlob
+	a.negativeUNLPseudoTx = [][]byte{negUNLBlob}
 
 	engine := NewEngine(a, DefaultConfig())
 	round := consensus.RoundID{Seq: prev.Seq() + 1, ParentHash: prev.ID()}
@@ -137,7 +137,9 @@ func closeAtModeWith(t *testing.T, mode consensus.Mode, prevSeq uint32, flagBlob
 	a.lastLCL = prev
 	a.ledgers[prev.ID()] = prev
 	a.flagLedgerPseudoTxs = flagBlobs
-	a.negativeUNLPseudoTx = negUNLBlob
+	if negUNLBlob != nil {
+		a.negativeUNLPseudoTx = [][]byte{negUNLBlob}
+	}
 
 	engine := NewEngine(a, DefaultConfig())
 	round := consensus.RoundID{Seq: prev.Seq() + 1, ParentHash: prev.ID()}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -346,6 +346,16 @@ func (l *Ledger) Read(k keylet.Keylet) ([]byte, error) {
 	return item.Data(), nil
 }
 
+// SkipListHashes returns the decoded rolling 256-entry LedgerHashes skip-list
+// from this ledger's state map. Mirrors rippled's `ledger->read(keylet::skip())`
+// at NegativeUNLVote.cpp:179. Returns (nil, nil) when the entry is absent
+// (e.g. early ledgers before the skip-list has been populated).
+func (l *Ledger) SkipListHashes() ([][32]byte, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return readSkipListHashes(l.stateMap, keylet.LedgerHashes().Key)
+}
+
 // Exists checks if a ledger entry exists
 func (l *Ledger) Exists(k keylet.Keylet) (bool, error) {
 	l.mu.RLock()


### PR DESCRIPTION
## Summary

Follow-up from #411. The audit asked us to either implement \`GenerateNegativeUNLPseudoTx\` or formally mark it optional. The full implementation is non-trivial — it needs \`ValidationTracker\` history plumbing, an exported skip-list accessor on \`*ledger.Ledger\`, a \`NegativeUNL\` SLE deserializer, and conformance fixtures against rippled. That work is now tracked as a focused feature issue: **#415**.

In the meantime, this PR makes the no-op honest:

- One-shot \`Warn\` log the first time the stub actually executes (gated by call-site conditions \`ModeProposing || standalone\` AND \`featureNegativeUNL\` enabled), referencing #415.
- Docstring rewritten to spell out exactly which three pieces are missing and that the call site already handles nil as "no vote this round" — graceful degradation.

A non-validator never hits this path, so the warning will be silent on the vast majority of deployments. A Go validator on a NegativeUNL-enabled network will see the gap exactly once, instead of discovering it via missing votes on the network side.

## Test plan

- [x] \`go vet ./internal/consensus/...\` — clean
- [x] \`go build ./...\` — clean
- [x] \`go test ./internal/consensus/adaptor/...\` — passes

Refs #411 #415