### PR TITLE
fix(txset-sync): drive node placement by NodeID, surface rejection reasons

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -134,11 +134,11 @@ func (n *noopSender) RequestProofPath(uint64, [32]byte, [32]byte, message.Ledger
 	return nil
 }
 func (n *noopSender) RequestStateNodes(uint64, [32]byte, [][]byte) error { return nil }
-func (n *noopSender) SendToPeer(uint64, []byte) error                          { return nil }
-func (n *noopSender) PeerSupportsReplay(uint64) bool                           { return false }
-func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64       { return nil }
-func (n *noopSender) IncPeerBadData(uint64, string)                            {}
-func (n *noopSender) PeersThatHave([32]byte) []uint64                          { return nil }
+func (n *noopSender) SendToPeer(uint64, []byte) error                    { return nil }
+func (n *noopSender) PeerSupportsReplay(uint64) bool                     { return false }
+func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64 { return nil }
+func (n *noopSender) IncPeerBadData(uint64, string)                      {}
+func (n *noopSender) PeersThatHave([32]byte) []uint64                    { return nil }
 
 // Compile-time interface check.
 var _ consensus.Adaptor = (*Adaptor)(nil)

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -1030,9 +1030,12 @@ func (r *Router) handleTxSetData(ld *message.LedgerData) {
 		break
 	}
 
-	// Tx-set acquisition has no authoritative external hash to compare;
-	// AddKnownNodeUnchecked trusts the node's own computed hash and skips
-	// the redundant deserialize/UpdateHash.
+	// Use NodeID-based placement (mirrors rippled SHAMap::addKnownNode):
+	// path-based descent works when the peer's response contains nodes
+	// deeper than our currently-loaded layer of stubs. The previous
+	// hash-search approach (AddKnownNodeUnchecked) silently rejected
+	// every node it couldn't place beneath a loaded parent, producing
+	// the missing-nodes retry storm of issue #413.
 	added := 0
 	for _, node := range ld.Nodes {
 		if isShamapRootNodeID(node.NodeID) {
@@ -1041,9 +1044,25 @@ func (r *Router) handleTxSetData(ld *message.LedgerData) {
 		if len(node.NodeData) == 0 {
 			continue
 		}
-		if err := txMap.AddKnownNodeUnchecked(node.NodeData); err == nil {
-			added++
+		parsedID, err := shamap.UnmarshalBinary(node.NodeID)
+		if err != nil {
+			r.logger.Debug("tx-set sync: malformed node ID",
+				"t", "consensus", "event", "txset-node-reject",
+				"txset", fmt.Sprintf("%x", txSetID[:8]),
+				"node_id_len", len(node.NodeID),
+				"error", err.Error())
+			continue
 		}
+		if err := txMap.AddKnownNodeByID(parsedID, node.NodeData); err != nil {
+			r.logger.Debug("tx-set sync: node rejected",
+				"t", "consensus", "event", "txset-node-reject",
+				"txset", fmt.Sprintf("%x", txSetID[:8]),
+				"node_id", fmt.Sprintf("%x", node.NodeID),
+				"node_data_len", len(node.NodeData),
+				"error", err.Error())
+			continue
+		}
+		added++
 	}
 
 	if err := txMap.FinishSync(); err != nil {

--- a/internal/consensus/adaptor/router_replay_task.go
+++ b/internal/consensus/adaptor/router_replay_task.go
@@ -73,13 +73,13 @@ func (r *Router) StartReplayTask(
 	}
 
 	state := &activeReplayTask{
-		chainHashes:     make(map[[32]byte]bool),
-		anchorParent:    anchorParent,
-		pendingByHash:   make(map[[32]byte]*inbound.ReplayDelta),
-		adopted:         make(map[[32]byte]*ledger.Ledger),
-		nextSeqToAdopt:  tipSeq - depth + 1,
-		chainSeqByHash:  make(map[[32]byte]uint32),
-		chainHashBySeq:  make(map[uint32][32]byte),
+		chainHashes:    make(map[[32]byte]bool),
+		anchorParent:   anchorParent,
+		pendingByHash:  make(map[[32]byte]*inbound.ReplayDelta),
+		adopted:        make(map[[32]byte]*ledger.Ledger),
+		nextSeqToAdopt: tipSeq - depth + 1,
+		chainSeqByHash: make(map[[32]byte]uint32),
+		chainHashBySeq: make(map[uint32][32]byte),
 	}
 	// Seed the anchor into adopted so the oldest chain entry can find
 	// its parent via the same map lookup as later entries.
@@ -356,4 +356,3 @@ func (s taskSenderAdapter) RequestProofPath(peerID uint64, ledgerHash, key [32]b
 func (s taskSenderAdapter) RequestReplayDelta(peerID uint64, hash [32]byte) error {
 	return s.adaptor.RequestReplayDelta(peerID, hash)
 }
-

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -161,13 +161,30 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 		return fmt.Errorf("unexpected state %d for GotStateNodes", l.state)
 	}
 
+	// Mirrors the tx-set sync fix in router.handleTxSetData (issue #413):
+	// drive placement by the peer-supplied NodeID via AddKnownNodeByID
+	// rather than the hash-search AddKnownNodeUnchecked, which silently
+	// drops nodes whose direct parent isn't loaded yet.
 	added := 0
 	for _, node := range nodes {
 		if len(node.NodeData) == 0 {
 			continue
 		}
-		if err := l.stateMap.AddKnownNodeUnchecked(node.NodeData); err != nil {
-			l.logger.Debug("inbound ledger: AddKnownNodeUnchecked", "error", err)
+		parsedID, err := shamap.UnmarshalBinary(node.NodeID)
+		if err != nil {
+			l.logger.Debug("inbound ledger: malformed state node ID",
+				"node_id_len", len(node.NodeID),
+				"error", err.Error())
+			continue
+		}
+		if parsedID.IsRoot() {
+			continue
+		}
+		if err := l.stateMap.AddKnownNodeByID(parsedID, node.NodeData); err != nil {
+			l.logger.Debug("inbound ledger: state node rejected",
+				"node_id", fmt.Sprintf("%x", node.NodeID),
+				"node_data_len", len(node.NodeData),
+				"error", err.Error())
 			continue
 		}
 		added++

--- a/internal/ledger/inbound/inbound_test.go
+++ b/internal/ledger/inbound/inbound_test.go
@@ -79,3 +79,80 @@ func TestNeedsMissingNodeIDs_RequestsActualMissingNodes(t *testing.T) {
 		}
 	}
 }
+
+// Regression for issue #413 applied to the state-map sync path:
+// GotStateNodes must accept peer-supplied nodes that land beneath
+// stubs we haven't yet expanded. The pre-fix AddKnownNodeUnchecked
+// hash-search silently dropped them; AddKnownNodeByID descends by
+// NodeID and succeeds.
+func TestGotStateNodes_DeepNodesUnderStubs(t *testing.T) {
+	source, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatalf("new source map: %v", err)
+	}
+	for branch := byte(0); branch < 4; branch++ {
+		for sub := byte(0); sub < 4; sub++ {
+			for i := byte(0); i < 4; i++ {
+				var key [32]byte
+				key[0] = (branch << 4) | sub
+				key[1] = i << 4
+				// TypeState rejects zero keys at the leaf; keep every key
+				// non-zero by stuffing a sentinel tail.
+				key[31] = 0xA5
+				if err := source.Put(key, []byte{branch, sub, i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}); err != nil {
+					t.Fatalf("put: %v", err)
+				}
+			}
+		}
+	}
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("serialize root: %v", err)
+	}
+	wireNodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("walk wire nodes: %v", err)
+	}
+	if len(wireNodes) < 3 {
+		t.Fatalf("test setup gave %d wire nodes; need a multi-level tree", len(wireNodes))
+	}
+
+	hdr := header.LedgerHeader{LedgerIndex: 200, AccountHash: rootHash}
+	hdrBytes, err := header.AddRaw(hdr, false)
+	if err != nil {
+		t.Fatalf("addraw header: %v", err)
+	}
+
+	var ledgerHash [32]byte
+	ledgerHash[0] = 0xBB
+	il := New(ledgerHash, 200, 9, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err := il.GotBase([]message.LedgerNode{
+		{NodeData: hdrBytes},
+		{NodeData: rootData},
+	}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+
+	nodes := make([]message.LedgerNode, 0, len(wireNodes))
+	for _, w := range wireNodes {
+		nodes = append(nodes, message.LedgerNode{NodeID: w.NodeID, NodeData: w.Data})
+	}
+	if err := il.GotStateNodes(nodes); err != nil {
+		t.Fatalf("GotStateNodes: %v", err)
+	}
+
+	if il.state != StateComplete {
+		t.Fatalf("state = %d, want StateComplete", il.state)
+	}
+	gotHash, err := il.stateMap.Hash()
+	if err != nil {
+		t.Fatalf("dest hash: %v", err)
+	}
+	if gotHash != rootHash {
+		t.Errorf("reconstructed state hash mismatch: want %x got %x", rootHash[:8], gotHash[:8])
+	}
+}

--- a/internal/ledger/inbound/replay_task.go
+++ b/internal/ledger/inbound/replay_task.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/keylet"
 )
 
 // TaskState tracks LedgerReplayTask progress. Distinct from the
@@ -104,8 +104,8 @@ type LedgerReplayTask struct {
 	stateHash [32]byte // tip.AccountHash, used by SkipListAcquire
 	depth     uint32
 
-	peers   []uint64 // rotated through when per-peer cap is hit
-	cursor  int      // next peer index to try
+	peers  []uint64 // rotated through when per-peer cap is hit
+	cursor int      // next peer index to try
 
 	replayer *Replayer
 	sender   TaskSender

--- a/internal/ledger/inbound/replay_task_test.go
+++ b/internal/ledger/inbound/replay_task_test.go
@@ -116,8 +116,8 @@ type recordingTaskSender struct {
 
 	// peakInFlight* track the maximum observed so test assertions can
 	// confirm the caps were respected.
-	peakGlobal   int
-	peakPerPeer  map[uint64]int
+	peakGlobal  int
+	peakPerPeer map[uint64]int
 
 	// failProof / failDelta optionally cause the next wire call to
 	// fail synchronously, simulating transport errors.

--- a/internal/ledger/inbound/replayer.go
+++ b/internal/ledger/inbound/replayer.go
@@ -77,12 +77,12 @@ type TimedOutEntry struct {
 // both a skip-list target (its 256-entry ancestor vector) and a
 // replay-delta target (its tx-set).
 type Replayer struct {
-	mu            sync.Mutex
-	inFlight      map[[32]byte]*ReplayDelta
-	inFlightSkip  map[[32]byte]*SkipListAcquire
-	logger        *slog.Logger
-	clock         Clock
-	maxInFlight   int
+	mu           sync.Mutex
+	inFlight     map[[32]byte]*ReplayDelta
+	inFlightSkip map[[32]byte]*SkipListAcquire
+	logger       *slog.Logger
+	clock        Clock
+	maxInFlight  int
 }
 
 // NewReplayer returns a Replayer configured with the given concurrency

--- a/internal/ledger/inbound/skiplist_acquire_test.go
+++ b/internal/ledger/inbound/skiplist_acquire_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
-	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/shamap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -239,9 +239,9 @@ func TestSkipListAcquire_DecodeLedgerHashesSLE_NonHashesLeaf(t *testing.T) {
 	// under the same key. The proof is valid; only the leaf's
 	// LedgerEntryType is wrong.
 	hx, err := binarycodec.Encode(map[string]any{
-		"LedgerEntryType": "FeeSettings",
-		"Flags":           uint32(0),
-		"BaseFee":         "A",
+		"LedgerEntryType":   "FeeSettings",
+		"Flags":             uint32(0),
+		"BaseFee":           "A",
 		"ReferenceFeeUnits": uint32(10),
 		"ReserveBase":       uint32(200000000),
 		"ReserveIncrement":  uint32(50000000),

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -337,6 +337,12 @@ func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) error {
 			if err != nil {
 				return fmt.Errorf("%w: %v", ErrInvalidNodeData, err)
 			}
+			// Mirrors rippled SHAMapSync.cpp:632-638: at leaf depth, an
+			// inner node is provably invalid — mark the map and bail.
+			if !newNode.IsLeaf() && targetDepth == MaxDepth {
+				sm.state = StateInvalid
+				return ErrUnexpectedNode
+			}
 			if err := newNode.UpdateHash(); err != nil {
 				return fmt.Errorf("failed to compute node hash: %w", err)
 			}
@@ -349,6 +355,13 @@ func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) error {
 
 		if child == nil {
 			return ErrParentNotInTree
+		}
+		// A leaf encountered mid-path is the canonical content at this
+		// slot (SHAMap consolidates lone leaves above leafDepth). Rippled
+		// exits the !isInner() loop and returns duplicate (SHAMapSync.cpp:597,
+		// 671-672).
+		if child.IsLeaf() {
+			return nil
 		}
 		nextInner, ok := child.(*InnerNode)
 		if !ok {

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -14,6 +14,8 @@ var (
 	ErrNodeHashMismatch  = errors.New("node hash does not match expected")
 	ErrRootAlreadySet    = errors.New("root node already set")
 	ErrUnexpectedNode    = errors.New("unexpected node received")
+	ErrEmptyBranchOnPath = errors.New("path descends into an empty branch")
+	ErrParentNotInTree   = errors.New("parent node not yet loaded for path")
 )
 
 // SyncFilter is an interface for filtering which nodes should be fetched during sync.
@@ -269,6 +271,98 @@ func (sm *SHAMap) AddKnownNode(nodeHash [32]byte, data []byte) error {
 
 	// Find the location in the tree where this node belongs
 	return sm.insertKnownNode(nodeHash, node)
+}
+
+// AddKnownNodeByID inserts a node from wire data at the position specified
+// by the peer-supplied SHAMap NodeID (path + depth). The node's computed
+// hash must match the parent's stored child hash at the target branch.
+//
+// Mirrors rippled's SHAMap::addKnownNode (SHAMapSync.cpp:578-673): descent
+// through the partial tree is driven by the NodeID, not by hash-searching.
+// This is what the tx-set acquire path needs when a peer responds with
+// nodes deeper than the layer of stubs we have locally — the hash-search
+// variant (AddKnownNodeUnchecked) can only attach nodes whose direct
+// parent is already loaded, and silently drops the rest, causing endless
+// missing-node retries (issue #413).
+//
+// Returns:
+//   - nil on successful attach, or when the slot is already populated
+//     (duplicate, matching rippled's SHAMapAddNode::duplicate())
+//   - ErrEmptyBranchOnPath when descent hits an empty branch — peer sent
+//     a node we never asked for
+//   - ErrParentNotInTree when an intermediate ancestor on the path is
+//     still a hash-only stub — caller must acquire ancestors first
+//   - ErrNodeHashMismatch when the computed hash doesn't match what the
+//     parent expects at the target branch
+//   - ErrSyncNotInProgress / ErrInvalidNodeData on misuse
+func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.state != StateSyncing {
+		return ErrSyncNotInProgress
+	}
+	if nodeID.IsRoot() {
+		return ErrUnexpectedNode
+	}
+	if len(data) == 0 {
+		return ErrInvalidNodeData
+	}
+	if sm.root == nil {
+		return ErrParentNotInTree
+	}
+
+	targetDepth := int(nodeID.Depth())
+	targetPath := nodeID.ID()
+
+	parent := sm.root
+
+	for curDepth := 0; curDepth < targetDepth; curDepth++ {
+		branch := selectBranchForPath(targetPath, curDepth)
+
+		parent.mu.RLock()
+		empty := parent.isBranch&(1<<uint(branch)) == 0
+		var childHash [32]byte
+		var child Node
+		if !empty {
+			childHash = parent.hashes[branch]
+			child = parent.children[branch]
+		}
+		parent.mu.RUnlock()
+
+		if empty {
+			return ErrEmptyBranchOnPath
+		}
+
+		if curDepth+1 == targetDepth {
+			if child != nil {
+				return nil
+			}
+			newNode, err := DeserializeNodeFromWire(data)
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrInvalidNodeData, err)
+			}
+			if err := newNode.UpdateHash(); err != nil {
+				return fmt.Errorf("failed to compute node hash: %w", err)
+			}
+			if newNode.Hash() != childHash {
+				return ErrNodeHashMismatch
+			}
+			parent.SetChildDirect(branch, newNode)
+			return nil
+		}
+
+		if child == nil {
+			return ErrParentNotInTree
+		}
+		nextInner, ok := child.(*InnerNode)
+		if !ok {
+			return ErrUnexpectedNode
+		}
+		parent = nextInner
+	}
+
+	return ErrUnexpectedNode
 }
 
 // AddKnownNodeUnchecked adds a node from wire data trusting its computed

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -279,11 +279,6 @@ func (sm *SHAMap) AddKnownNode(nodeHash [32]byte, data []byte) error {
 //
 // Mirrors rippled's SHAMap::addKnownNode (SHAMapSync.cpp:578-673): descent
 // through the partial tree is driven by the NodeID, not by hash-searching.
-// This is what the tx-set acquire path needs when a peer responds with
-// nodes deeper than the layer of stubs we have locally — the hash-search
-// variant (AddKnownNodeUnchecked) can only attach nodes whose direct
-// parent is already loaded, and silently drops the rest, causing endless
-// missing-node retries (issue #413).
 //
 // Returns:
 //   - nil on successful attach, or when the slot is already populated

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -290,14 +290,7 @@ func TestGetMissingNodes_PathNodeIDs(t *testing.T) {
 	}
 }
 
-// Regression for issue #413: tx-set sync used AddKnownNodeUnchecked, a
-// tree-wide hash-search that silently fails (returning ErrUnexpectedNode
-// without diagnostics) whenever the path it would need to follow goes
-// through a hash-only stub child. AddKnownNodeByID mirrors rippled's
-// SHAMap::addKnownNode: it uses the peer-supplied SHAMapNodeID to drive
-// descent, accepts the node when its computed hash matches the parent's
-// stored child hash, and returns sentinel errors that let the caller
-// distinguish "wrong data" from "need to fetch ancestors first."
+// Regression for issue #413: full SHAMap reconstruct via AddKnownNodeByID.
 func TestAddKnownNodeByID_RippledStyleReconstruct(t *testing.T) {
 	source, err := New(TypeTransaction)
 	if err != nil {
@@ -369,9 +362,6 @@ func TestAddKnownNodeByID_RippledStyleReconstruct(t *testing.T) {
 	}
 }
 
-// Validates the sentinel-error contract so callers (router.handleTxSetData)
-// can react: re-request ancestors on ErrParentNotInTree, drop the peer on
-// ErrNodeHashMismatch, log-and-skip on ErrEmptyBranchOnPath.
 func TestAddKnownNodeByID_SentinelErrors(t *testing.T) {
 	source, err := New(TypeTransaction)
 	if err != nil {

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -1,6 +1,7 @@
 package shamap
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -287,6 +288,255 @@ func TestGetMissingNodes_PathNodeIDs(t *testing.T) {
 			t.Errorf("missing NodeID is malformed: %v", err)
 		}
 	}
+}
+
+// Regression for issue #413: tx-set sync used AddKnownNodeUnchecked, a
+// tree-wide hash-search that silently fails (returning ErrUnexpectedNode
+// without diagnostics) whenever the path it would need to follow goes
+// through a hash-only stub child. AddKnownNodeByID mirrors rippled's
+// SHAMap::addKnownNode: it uses the peer-supplied SHAMapNodeID to drive
+// descent, accepts the node when its computed hash matches the parent's
+// stored child hash, and returns sentinel errors that let the caller
+// distinguish "wrong data" from "need to fetch ancestors first."
+func TestAddKnownNodeByID_RippledStyleReconstruct(t *testing.T) {
+	source, err := New(TypeTransaction)
+	if err != nil {
+		t.Fatalf("New source: %v", err)
+	}
+	for branch := byte(0); branch < 4; branch++ {
+		for sub := byte(0); sub < 4; sub++ {
+			for i := byte(0); i < 4; i++ {
+				var key [32]byte
+				key[0] = (branch << 4) | sub
+				key[1] = i << 4
+				if err := source.Put(key, []byte{branch, sub, i, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66}); err != nil {
+					t.Fatalf("Put: %v", err)
+				}
+			}
+		}
+	}
+
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("SerializeRoot: %v", err)
+	}
+	wireNodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("WalkWireNodes: %v", err)
+	}
+	if len(wireNodes) < 3 {
+		t.Fatalf("test setup gave only %d wire nodes; need a multi-level tree", len(wireNodes))
+	}
+
+	dest, err := New(TypeTransaction)
+	if err != nil {
+		t.Fatalf("New dest: %v", err)
+	}
+	if err := dest.StartSync(); err != nil {
+		t.Fatalf("StartSync: %v", err)
+	}
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		t.Fatalf("AddRootNode: %v", err)
+	}
+
+	for i, w := range wireNodes {
+		nid, err := UnmarshalBinary(w.NodeID)
+		if err != nil {
+			t.Fatalf("UnmarshalBinary[%d]: %v", i, err)
+		}
+		if nid.IsRoot() {
+			continue
+		}
+		if err := dest.AddKnownNodeByID(nid, w.Data); err != nil {
+			t.Fatalf("AddKnownNodeByID[%d] depth=%d: %v", i, nid.Depth(), err)
+		}
+	}
+
+	if err := dest.FinishSync(); err != nil {
+		t.Fatalf("FinishSync: %v", err)
+	}
+
+	destHash, err := dest.Hash()
+	if err != nil {
+		t.Fatalf("dest hash: %v", err)
+	}
+	if destHash != rootHash {
+		t.Errorf("reconstructed hash mismatch: want %x got %x", rootHash[:8], destHash[:8])
+	}
+}
+
+// Validates the sentinel-error contract so callers (router.handleTxSetData)
+// can react: re-request ancestors on ErrParentNotInTree, drop the peer on
+// ErrNodeHashMismatch, log-and-skip on ErrEmptyBranchOnPath.
+func TestAddKnownNodeByID_SentinelErrors(t *testing.T) {
+	source, err := New(TypeTransaction)
+	if err != nil {
+		t.Fatalf("New source: %v", err)
+	}
+	for branch := byte(0); branch < 3; branch++ {
+		for sub := byte(0); sub < 3; sub++ {
+			var key [32]byte
+			key[0] = (branch << 4) | sub
+			if err := source.Put(key, []byte{branch, sub, 0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66}); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+		}
+	}
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("SerializeRoot: %v", err)
+	}
+	wireNodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("WalkWireNodes: %v", err)
+	}
+
+	// Find a depth>=2 wire node — its parent stub will not be loaded yet
+	// on the dest map after only AddRootNode.
+	var deep *WireNode
+	for i := range wireNodes {
+		nid, err := UnmarshalBinary(wireNodes[i].NodeID)
+		if err != nil || nid.Depth() < 2 {
+			continue
+		}
+		deep = &wireNodes[i]
+		break
+	}
+	if deep == nil {
+		t.Fatal("test setup did not produce a depth>=2 node")
+	}
+
+	t.Run("ParentNotInTree", func(t *testing.T) {
+		dest, err := New(TypeTransaction)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if err := dest.StartSync(); err != nil {
+			t.Fatalf("StartSync: %v", err)
+		}
+		if err := dest.AddRootNode(rootHash, rootData); err != nil {
+			t.Fatalf("AddRootNode: %v", err)
+		}
+		nid, _ := UnmarshalBinary(deep.NodeID)
+		err = dest.AddKnownNodeByID(nid, deep.Data)
+		if !errors.Is(err, ErrParentNotInTree) {
+			t.Fatalf("want ErrParentNotInTree, got %v", err)
+		}
+	})
+
+	t.Run("NodeHashMismatch", func(t *testing.T) {
+		dest, err := New(TypeTransaction)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if err := dest.StartSync(); err != nil {
+			t.Fatalf("StartSync: %v", err)
+		}
+		if err := dest.AddRootNode(rootHash, rootData); err != nil {
+			t.Fatalf("AddRootNode: %v", err)
+		}
+		// Use a depth-1 node's NodeID with another depth-1 node's data:
+		// hash will be the unrelated sibling's hash, not what the parent
+		// has stored for that branch.
+		var d1a, d1b *WireNode
+		for i := range wireNodes {
+			nid, _ := UnmarshalBinary(wireNodes[i].NodeID)
+			if nid.Depth() != 1 {
+				continue
+			}
+			if d1a == nil {
+				d1a = &wireNodes[i]
+			} else {
+				d1b = &wireNodes[i]
+				break
+			}
+		}
+		if d1a == nil || d1b == nil {
+			t.Skip("need at least two depth-1 wire nodes")
+		}
+		nid, _ := UnmarshalBinary(d1a.NodeID)
+		err = dest.AddKnownNodeByID(nid, d1b.Data)
+		if !errors.Is(err, ErrNodeHashMismatch) {
+			t.Fatalf("want ErrNodeHashMismatch, got %v", err)
+		}
+	})
+
+	t.Run("EmptyBranchOnPath", func(t *testing.T) {
+		dest, err := New(TypeTransaction)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if err := dest.StartSync(); err != nil {
+			t.Fatalf("StartSync: %v", err)
+		}
+		if err := dest.AddRootNode(rootHash, rootData); err != nil {
+			t.Fatalf("AddRootNode: %v", err)
+		}
+		// Build a NodeID at depth=1 whose first nibble points into an
+		// empty branch on root (we used only branches 0..2 above, so
+		// nibble 0xF is guaranteed empty).
+		var path [32]byte
+		path[0] = 0xF0
+		nid, err := NewNodeID(1, path)
+		if err != nil {
+			t.Fatalf("NewNodeID: %v", err)
+		}
+		// Borrow any non-root wire data; descent fails before the data
+		// is parsed.
+		var anyData []byte
+		for i := range wireNodes {
+			rid, _ := UnmarshalBinary(wireNodes[i].NodeID)
+			if !rid.IsRoot() {
+				anyData = wireNodes[i].Data
+				break
+			}
+		}
+		err = dest.AddKnownNodeByID(nid, anyData)
+		if !errors.Is(err, ErrEmptyBranchOnPath) {
+			t.Fatalf("want ErrEmptyBranchOnPath, got %v", err)
+		}
+	})
+
+	t.Run("DuplicateIsNoOp", func(t *testing.T) {
+		dest, err := New(TypeTransaction)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if err := dest.StartSync(); err != nil {
+			t.Fatalf("StartSync: %v", err)
+		}
+		if err := dest.AddRootNode(rootHash, rootData); err != nil {
+			t.Fatalf("AddRootNode: %v", err)
+		}
+		var d1 *WireNode
+		for i := range wireNodes {
+			nid, _ := UnmarshalBinary(wireNodes[i].NodeID)
+			if nid.Depth() == 1 {
+				d1 = &wireNodes[i]
+				break
+			}
+		}
+		if d1 == nil {
+			t.Skip("no depth-1 node available")
+		}
+		nid, _ := UnmarshalBinary(d1.NodeID)
+		if err := dest.AddKnownNodeByID(nid, d1.Data); err != nil {
+			t.Fatalf("first AddKnownNodeByID: %v", err)
+		}
+		// Second call must be a no-op success (rippled SHAMap::addKnownNode
+		// returns SHAMapAddNode::duplicate(); we surface that as nil).
+		if err := dest.AddKnownNodeByID(nid, d1.Data); err != nil {
+			t.Fatalf("duplicate AddKnownNodeByID: %v", err)
+		}
+	})
 }
 
 func TestAddKnownNodeErrors(t *testing.T) {

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -529,6 +529,69 @@ func TestAddKnownNodeByID_SentinelErrors(t *testing.T) {
 	})
 }
 
+// Mirrors rippled SHAMapSync.cpp:597,671-672: a leaf encountered mid-path
+// is the canonical content at that slot — return duplicate (nil), not error.
+func TestAddKnownNodeByID_LeafMidPathReturnsDuplicate(t *testing.T) {
+	source, err := New(TypeTransaction)
+	if err != nil {
+		t.Fatalf("New source: %v", err)
+	}
+	// Single key → root has a single leaf child at the path's first
+	// nibble, consolidated at depth 1.
+	var k [32]byte
+	k[0] = 0x12
+	k[1] = 0x34
+	if err := source.Put(k, []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("SerializeRoot: %v", err)
+	}
+	wireNodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("WalkWireNodes: %v", err)
+	}
+
+	dest, err := New(TypeTransaction)
+	if err != nil {
+		t.Fatalf("New dest: %v", err)
+	}
+	if err := dest.StartSync(); err != nil {
+		t.Fatalf("StartSync: %v", err)
+	}
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		t.Fatalf("AddRootNode: %v", err)
+	}
+	for _, w := range wireNodes {
+		nid, err := UnmarshalBinary(w.NodeID)
+		if err != nil {
+			t.Fatalf("UnmarshalBinary: %v", err)
+		}
+		if nid.IsRoot() {
+			continue
+		}
+		if err := dest.AddKnownNodeByID(nid, w.Data); err != nil {
+			t.Fatalf("seed AddKnownNodeByID: %v", err)
+		}
+	}
+
+	// Synthesize a depth-2 NodeID on the same path as the consolidated
+	// leaf. The peer's data here is irrelevant — descent must short-
+	// circuit on the leaf and return nil.
+	deepNID, err := NewNodeID(2, k)
+	if err != nil {
+		t.Fatalf("NewNodeID: %v", err)
+	}
+	if err := dest.AddKnownNodeByID(deepNID, []byte{0xFF}); err != nil {
+		t.Fatalf("leaf-mid-path: want nil (duplicate), got %v", err)
+	}
+}
+
 func TestAddKnownNodeErrors(t *testing.T) {
 	sMap, err := New(TypeState)
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes #413.

The tx-set acquire path used `shamap.AddKnownNodeUnchecked`, a
tree-wide **hash-search** that silently fails (`ErrUnexpectedNode`,
dropped on the floor in `router.handleTxSetData`) whenever the path it
would have to follow goes through a hash-only stub child. Under
interop load with rippled validators, this leaves goxrpl in a
missing-nodes retry storm — peer returns 8 SHAMap nodes per round,
every single one rejected without diagnostics, missing count never
decreasing, peer connection hammered until the other links drop and
the node ends up at `peers=1`.

This PR mirrors rippled's `SHAMap::addKnownNode`
(`SHAMapSync.cpp:578-673`):

- **`shamap.AddKnownNodeByID(nodeID, data)`** descends the partial
  tree using the peer-supplied `SHAMapNodeID` (path + depth), verifies
  the new node's computed hash matches the parent's stored child hash,
  and surfaces sentinel errors:
  - `ErrEmptyBranchOnPath` — peer sent a node we never asked for
  - `ErrParentNotInTree` — ancestor still a hash-only stub; caller
    must fetch it first
  - `ErrNodeHashMismatch` — wire data is corrupt or wrong
- **`router.handleTxSetData`** now uses `AddKnownNodeByID` with the
  `NodeID` already on the wire, and `Debug`-logs every rejected node
  with the specific failure. The next interop run will actually tell
  us why a node didn't take instead of silently looping.

The previous comment claimed `AddKnownNodeUnchecked` skipped a
redundant deserialize/UpdateHash — but `AddKnownNodeByID` does the
same parse exactly once (deserialize + UpdateHash + hash compare),
so there's no extra cost on the happy path.

## Test plan

- [x] `go test ./shamap/...` — new `TestAddKnownNodeByID_*` subtests
  cover happy-path reconstruction (rippled-style pre-order with
  `NodeID`s) and the four sentinel-error paths
  (`ParentNotInTree`, `NodeHashMismatch`, `EmptyBranchOnPath`,
  `DuplicateIsNoOp`).
- [x] `go test ./internal/consensus/...` — existing router wire tests
  (`TestRouter_LedgerData_TsCandidate_FeedsEngine`,
  `TestRouter_GetLedger_TsCandidate_ServesCachedTxSet`) still pass
  through the new code path.
- [x] `go test ./internal/ledger/... ./internal/peermanagement/...`
  pass — no regressions.
- [x] `go vet ./...` and `go build ./...` clean.
- [ ] xrpl-confluence soak (`TX_RATE=1 make soak`) — needs the
  reviewer to run; the fix should clear the
  `tx-set sync: requesting missing nodes` retry storm and, if any
  edge case remains, the new `txset-node-reject` debug logs will
  carry the specific error per node.