### PR TITLE
feat(consensus): log when peer proposers fall below quorum at close (#422)

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1556,13 +1556,10 @@ func (e *Engine) phaseOpen() {
 // closeLedger transitions from open to establish phase.
 // Reference: rippled Consensus.h closeLedger() (~line 1434)
 func (e *Engine) closeLedger() {
-	// Stall observability (issue #422): if the trusted-peer proposer
-	// count from the prior round + self can't meet the validation
-	// quorum, this round almost certainly won't reach consensus either.
-	// Emit one INFO line per close attempt so operators see the stall
-	// signal in goxrpl's own logs instead of having to query rippled.
+	// #422: if peer proposers from the prior round + self can't
+	// meet quorum, this round almost certainly won't reach consensus.
 	// Skipped before the first completed round, where prevProposers
-	// carries no real signal.
+	// carries no signal.
 	if e.consensusCount > 0 {
 		quorum := e.adaptor.GetQuorum()
 		if e.prevProposers+1 < quorum {

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1556,6 +1556,31 @@ func (e *Engine) phaseOpen() {
 // closeLedger transitions from open to establish phase.
 // Reference: rippled Consensus.h closeLedger() (~line 1434)
 func (e *Engine) closeLedger() {
+	// Stall observability (issue #422): if the trusted-peer proposer
+	// count from the prior round + self can't meet the validation
+	// quorum, this round almost certainly won't reach consensus either.
+	// Emit one INFO line per close attempt so operators see the stall
+	// signal in goxrpl's own logs instead of having to query rippled.
+	// Skipped before the first completed round, where prevProposers
+	// carries no real signal.
+	if e.consensusCount > 0 {
+		quorum := e.adaptor.GetQuorum()
+		if e.prevProposers+1 < quorum {
+			seq := uint32(0)
+			if e.prevLedger != nil {
+				seq = e.prevLedger.Seq() + 1
+			}
+			slog.Info("consensus close — peer proposers below quorum (likely stall)",
+				"t", "consensus",
+				"event", "close-below-quorum",
+				"peer_proposers", e.prevProposers,
+				"quorum", quorum,
+				"unl_size", len(e.adaptor.GetTrustedValidators()),
+				"seq", seq,
+			)
+		}
+	}
+
 	// Filter pending txs through the open-ledger gate when proposing,
 	// matching app_.openLedger().current()->txs at RCLConsensus.cpp:333-349.
 	// In non-proposing modes the position isn't broadcast, so skip the

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -1,7 +1,10 @@
 package rcl
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -2805,6 +2808,102 @@ func TestCloseLedger_ProposingUsesFilteredTxSet(t *testing.T) {
 				"standalone). Got %d calls — would burn the per-round "+
 				"multi-pass apply cost on a position we won't "+
 				"broadcast.", got)
+		}
+	})
+}
+
+// TestCloseLedger_BelowQuorumStallLog pins the issue #422 observability
+// signal: when peer_proposers + self can't meet the validation quorum at
+// close-attempt time, closeLedger MUST emit one INFO log line per close
+// so operators see the stall in goxrpl's own logs (today they have to
+// query rippled). Skipped before the first completed round, where
+// prevProposers carries no real signal yet.
+func TestCloseLedger_BelowQuorumStallLog(t *testing.T) {
+	const stallTag = "close-below-quorum"
+
+	withCapturedLogs := func(t *testing.T, fn func()) string {
+		t.Helper()
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+		t.Cleanup(func() { slog.SetDefault(prev) })
+		fn()
+		return buf.String()
+	}
+
+	newEngineWithUNL := func(t *testing.T, quorum, prevProposers, consensusCount int) (*Engine, *mockAdaptor) {
+		t.Helper()
+		adaptor := newMockAdaptor()
+		adaptor.validator = true
+		adaptor.opMode = consensus.OpModeFull
+		adaptor.quorum = quorum
+		// Populate a trusted set so the log's unl_size field is
+		// representative and so adaptor.GetTrustedValidators() returns
+		// the expected count even though IsTrusted isn't consulted in
+		// this path.
+		for i := 1; i <= 5; i++ {
+			adaptor.trusted[consensus.NodeID{byte(i)}] = true
+		}
+		engine := NewEngine(adaptor, DefaultConfig())
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		if err := engine.Start(ctx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		t.Cleanup(func() { _ = engine.Stop() })
+		round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+		engine.StartRound(round, true)
+		engine.mu.Lock()
+		engine.setMode(consensus.ModeProposing)
+		engine.setPhase(consensus.PhaseOpen)
+		engine.prevProposers = prevProposers
+		engine.consensusCount = uint64(consensusCount)
+		engine.mu.Unlock()
+		return engine, adaptor
+	}
+
+	t.Run("below-quorum-fires-once", func(t *testing.T) {
+		engine, _ := newEngineWithUNL(t, 4, 2, 1)
+		out := withCapturedLogs(t, func() {
+			engine.mu.Lock()
+			engine.closeLedger()
+			engine.mu.Unlock()
+		})
+		if !strings.Contains(out, stallTag) {
+			t.Fatalf("expected close-below-quorum log when peer_proposers(2)+1 < quorum(4); got:\n%s", out)
+		}
+		if !strings.Contains(out, "peer_proposers=2") || !strings.Contains(out, "quorum=4") {
+			t.Fatalf("log missing structured fields; got:\n%s", out)
+		}
+		if got := strings.Count(out, stallTag); got != 1 {
+			t.Fatalf("close-below-quorum must fire exactly once per close, got %d:\n%s", got, out)
+		}
+	})
+
+	t.Run("at-quorum-silent", func(t *testing.T) {
+		// peer_proposers(3) + self(1) == quorum(4): stall log MUST NOT fire.
+		engine, _ := newEngineWithUNL(t, 4, 3, 1)
+		out := withCapturedLogs(t, func() {
+			engine.mu.Lock()
+			engine.closeLedger()
+			engine.mu.Unlock()
+		})
+		if strings.Contains(out, stallTag) {
+			t.Fatalf("close-below-quorum must NOT fire when peer_proposers+1 >= quorum; got:\n%s", out)
+		}
+	})
+
+	t.Run("genesis-round-silent", func(t *testing.T) {
+		// consensusCount==0: no completed prior round, so prevProposers
+		// is meaningless. Suppressing avoids spurious noise at startup.
+		engine, _ := newEngineWithUNL(t, 4, 0, 0)
+		out := withCapturedLogs(t, func() {
+			engine.mu.Lock()
+			engine.closeLedger()
+			engine.mu.Unlock()
+		})
+		if strings.Contains(out, stallTag) {
+			t.Fatalf("close-below-quorum must NOT fire before the first completed round; got:\n%s", out)
 		}
 	})
 }

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -2812,12 +2812,10 @@ func TestCloseLedger_ProposingUsesFilteredTxSet(t *testing.T) {
 	})
 }
 
-// TestCloseLedger_BelowQuorumStallLog pins the issue #422 observability
-// signal: when peer_proposers + self can't meet the validation quorum at
-// close-attempt time, closeLedger MUST emit one INFO log line per close
-// so operators see the stall in goxrpl's own logs (today they have to
-// query rippled). Skipped before the first completed round, where
-// prevProposers carries no real signal yet.
+// TestCloseLedger_BelowQuorumStallLog pins the #422 stall signal:
+// closeLedger emits one INFO log when peer_proposers+self can't meet
+// quorum, and stays silent at-quorum and before the first completed
+// round (where prevProposers carries no signal).
 func TestCloseLedger_BelowQuorumStallLog(t *testing.T) {
 	const stallTag = "close-below-quorum"
 
@@ -2837,10 +2835,8 @@ func TestCloseLedger_BelowQuorumStallLog(t *testing.T) {
 		adaptor.validator = true
 		adaptor.opMode = consensus.OpModeFull
 		adaptor.quorum = quorum
-		// Populate a trusted set so the log's unl_size field is
-		// representative and so adaptor.GetTrustedValidators() returns
-		// the expected count even though IsTrusted isn't consulted in
-		// this path.
+		// Trusted set sized to make unl_size representative; IsTrusted
+		// isn't consulted on this path.
 		for i := 1; i <= 5; i++ {
 			adaptor.trusted[consensus.NodeID{byte(i)}] = true
 		}
@@ -2894,8 +2890,8 @@ func TestCloseLedger_BelowQuorumStallLog(t *testing.T) {
 	})
 
 	t.Run("genesis-round-silent", func(t *testing.T) {
-		// consensusCount==0: no completed prior round, so prevProposers
-		// is meaningless. Suppressing avoids spurious noise at startup.
+		// consensusCount==0: prevProposers is meaningless before any
+		// round has completed.
 		engine, _ := newEngineWithUNL(t, 4, 0, 0)
 		out := withCapturedLogs(t, func() {
 			engine.mu.Lock()


### PR DESCRIPTION
## Summary

- Adds an INFO-level log in `closeLedger()` (`internal/consensus/rcl/engine.go`) when the trusted-peer proposer count from the previous round + self can't meet `validation_quorum`. Fires once per close attempt, skipped before the first completed round (no prior-round signal yet).
- Structured fields: `t=consensus`, `event=close-below-quorum`, `peer_proposers`, `quorum`, `unl_size`, `seq`. Example: `consensus close — peer proposers below quorum (likely stall) peer_proposers=2 quorum=4 unl_size=5 seq=6`.
- Pins behaviour with `TestCloseLedger_BelowQuorumStallLog` (3 sub-tests: below-quorum fires once, at-quorum silent, genesis silent).

## Why

Closes #422. Operators currently have to query rippled (`last_close.proposers` vs `validation_quorum`) to diagnose a goxrpl stall driven by insufficient peer proposals — the txset-retry loop (#420) doesn't say *why* the ledger isn't closing. With this log, the fuzz oracle and on-call see the stall signal directly in goxrpl's own output.

The optional Prometheus gauge mentioned in the issue is intentionally not wired up: the repo has no prometheus infrastructure yet, and the log alone resolves the immediate observability gap. Can be revisited if/when metrics scaffolding lands.

## Test plan

- [x] `go test ./internal/consensus/rcl/ -run TestCloseLedger_BelowQuorumStallLog -v` — new test passes (3/3)
- [x] `go test ./internal/consensus/...` — full consensus suite green
- [x] `go test ./internal/testing/consensus/...` — integration tests green
- [x] `go vet ./internal/consensus/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)