### PR TITLE
fix(rpc): unify peer count source so peers RPC and server_info agree (#419)

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -294,10 +294,7 @@ func runServer(cmd *cobra.Command, args []string) {
 			overlay.Broadcast(frame)
 		})
 
-		// Expose node identity and consensus stats to RPC handlers. The
-		// peer count is read through ctx.PeerSource (wired below for
-		// both the HTTP and WebSocket dispatchers) so server_info.peers
-		// and `peers` RPC share a single underlying overlay reference.
+		// Expose node identity and consensus stats to RPC handlers.
 		services.NodePublicKey = consensusComponents.Overlay.Identity().EncodedPublicKey()
 		engine := consensusComponents.Engine
 		services.LastCloseInfo = func() (int, int) {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -294,9 +294,11 @@ func runServer(cmd *cobra.Command, args []string) {
 			overlay.Broadcast(frame)
 		})
 
-		// Expose node identity, peer count, and consensus stats to RPC handlers
+		// Expose node identity and consensus stats to RPC handlers. The
+		// peer count is read through ctx.PeerSource (wired below for
+		// both the HTTP and WebSocket dispatchers) so server_info.peers
+		// and `peers` RPC share a single underlying overlay reference.
 		services.NodePublicKey = consensusComponents.Overlay.Identity().EncodedPublicKey()
-		services.PeerCount = consensusComponents.Overlay.PeerCount
 		engine := consensusComponents.Engine
 		services.LastCloseInfo = func() (int, int) {
 			proposers, convergeTime := engine.GetLastCloseInfo()
@@ -343,6 +345,9 @@ func runServer(cmd *cobra.Command, args []string) {
 	// Create WebSocket server for real-time subscriptions
 	wsServer := rpc.NewWebSocketServer(30*time.Second, services)
 	wsServer.RegisterAllMethods()
+	if consensusComponents != nil && consensusComponents.Overlay != nil {
+		wsServer.SetPeerSource(consensusComponents.Overlay)
+	}
 
 	// Create a ledger info provider adapter for WebSocket subscribe responses
 	wsServer.SetLedgerInfoProvider(&ledgerInfoAdapter{ledgerService: ledgerService})

--- a/internal/rpc/handlers/peers_test.go
+++ b/internal/rpc/handlers/peers_test.go
@@ -18,6 +18,7 @@ type fakePeerSource struct {
 
 func (f *fakePeerSource) PeersJSON() []map[string]any { return f.peers }
 func (f *fakePeerSource) ClusterJSON() map[string]any { return f.cluster }
+func (f *fakePeerSource) PeerCount() int              { return len(f.peers) }
 
 func TestPeersMethod_NilSourceReturnsEmptyList(t *testing.T) {
 	m := &handlers.PeersMethod{}

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -232,9 +232,6 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	return info
 }
 
-// getPeerCount reads the live peer count from the same PeerSource that
-// the peers RPC iterates, so server_info.peers and len(peers RPC result)
-// cannot disagree. Returns 0 in standalone mode where no source is wired.
 func getPeerCount(ctx *types.RpcContext) int {
 	if ctx == nil || ctx.PeerSource == nil {
 		return 0

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -37,7 +37,7 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, err
 	}
 
-	info := buildServerInfo(ctx.Services, true)
+	info := buildServerInfo(ctx, true)
 
 	response := map[string]interface{}{
 		"info": info,
@@ -49,7 +49,8 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 // buildServerInfo constructs the info/state object.
 // When human is true it produces the server_info format (XRP decimals, converge_time_s, hostid).
 // When human is false it produces the server_state format (drops integers, converge_time, load_base, etc.).
-func buildServerInfo(services *types.ServiceContainer, human bool) map[string]interface{} {
+func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
+	services := ctx.Services
 	serverInfo := services.Ledger.GetServerInfo()
 	baseFee, reserveBase, reserveIncrement := services.Ledger.GetCurrentFees()
 
@@ -87,7 +88,7 @@ func buildServerInfo(services *types.ServiceContainer, human bool) map[string]in
 		"server_state":      serverState,
 		"uptime":            uptime,
 		"validation_quorum": 1, // TODO: get from consensus/validators
-		"peers":             getPeerCount(services),
+		"peers":             getPeerCount(ctx),
 
 		// Overflow/disconnect counters (string in rippled)
 		"jq_trans_overflow":          "0", // TODO: track real overflow count
@@ -231,9 +232,12 @@ func buildServerInfo(services *types.ServiceContainer, human bool) map[string]in
 	return info
 }
 
-func getPeerCount(services *types.ServiceContainer) int {
-	if services.PeerCount != nil {
-		return services.PeerCount()
+// getPeerCount reads the live peer count from the same PeerSource that
+// the peers RPC iterates, so server_info.peers and len(peers RPC result)
+// cannot disagree. Returns 0 in standalone mode where no source is wired.
+func getPeerCount(ctx *types.RpcContext) int {
+	if ctx == nil || ctx.PeerSource == nil {
+		return 0
 	}
-	return 0
+	return ctx.PeerSource.PeerCount()
 }

--- a/internal/rpc/handlers/server_state.go
+++ b/internal/rpc/handlers/server_state.go
@@ -15,7 +15,7 @@ func (m *ServerStateMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, err
 	}
 
-	state := buildServerInfo(ctx.Services, false)
+	state := buildServerInfo(ctx, false)
 
 	response := map[string]interface{}{
 		"state": state,

--- a/internal/rpc/peers_server_info_parity_test.go
+++ b/internal/rpc/peers_server_info_parity_test.go
@@ -1,0 +1,98 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubPeerSource is a minimal PeerSource that tests can pin to a known
+// number of peers. PeerCount() must always equal len(PeersJSON()) so
+// the parity invariant the production overlay enforces also holds here.
+type stubPeerSource struct {
+	peers   []map[string]any
+	cluster map[string]any
+}
+
+func (s *stubPeerSource) PeersJSON() []map[string]any { return s.peers }
+func (s *stubPeerSource) ClusterJSON() map[string]any { return s.cluster }
+func (s *stubPeerSource) PeerCount() int              { return len(s.peers) }
+
+// TestPeersAndServerInfoShareSource pins the invariant from issue #419:
+// `peers` RPC and `server_info.peers` MUST be wired to the same source,
+// so len(peers result) always equals server_info.peers. Pre-fix, the
+// two read independent fields (services.PeerCount and ctx.PeerSource);
+// a wiring mistake on either side could — and did — desync them.
+func TestPeersAndServerInfoShareSource(t *testing.T) {
+	src := &stubPeerSource{
+		peers: []map[string]any{
+			{"address": "192.0.2.1:51235", "public_key": "nHB1"},
+			{"address": "192.0.2.2:51235", "public_key": "nHB2"},
+			{"address": "192.0.2.3:51235", "public_key": "nHB3"},
+		},
+	}
+
+	ledger := &mockLedgerService{}
+	services := &types.ServiceContainer{Ledger: ledger}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		ApiVersion: types.DefaultApiVersion,
+		IsAdmin:    true,
+		PeerSource: src,
+		Services:   services,
+	}
+
+	peersRes, err := (&handlers.PeersMethod{}).Handle(ctx, nil)
+	require.Nil(t, err)
+	infoRes, err := (&handlers.ServerInfoMethod{}).Handle(ctx, nil)
+	require.Nil(t, err)
+
+	peersList := peersRes.(map[string]any)["peers"].([]map[string]any)
+	infoPeers := serverInfoPeerCount(t, infoRes)
+
+	assert.Equal(t, len(src.peers), infoPeers,
+		"server_info.peers must reflect the live overlay count")
+	assert.Equal(t, len(peersList), infoPeers,
+		"len(peers RPC result) must equal server_info.peers — single source of truth (issue #419)")
+}
+
+// TestPeersAndServerInfoBothEmptyWithoutSource confirms the degenerate
+// case still agrees: with no PeerSource wired, both methods report 0.
+func TestPeersAndServerInfoBothEmptyWithoutSource(t *testing.T) {
+	ledger := &mockLedgerService{}
+	services := &types.ServiceContainer{Ledger: ledger}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		ApiVersion: types.DefaultApiVersion,
+		IsAdmin:    true,
+		Services:   services,
+	}
+
+	peersRes, err := (&handlers.PeersMethod{}).Handle(ctx, nil)
+	require.Nil(t, err)
+	infoRes, err := (&handlers.ServerInfoMethod{}).Handle(ctx, nil)
+	require.Nil(t, err)
+
+	peersList := peersRes.(map[string]any)["peers"].([]map[string]any)
+	infoPeers := serverInfoPeerCount(t, infoRes)
+
+	assert.Equal(t, 0, infoPeers)
+	assert.Equal(t, 0, len(peersList))
+}
+
+func serverInfoPeerCount(t *testing.T, infoRes interface{}) int {
+	t.Helper()
+	raw, err := json.Marshal(infoRes)
+	require.NoError(t, err)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+	info := parsed["info"].(map[string]any)
+	return int(info["peers"].(float64))
+}

--- a/internal/rpc/peers_server_info_parity_test.go
+++ b/internal/rpc/peers_server_info_parity_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// stubPeerSource is a minimal PeerSource that tests can pin to a known
-// number of peers. PeerCount() must always equal len(PeersJSON()) so
-// the parity invariant the production overlay enforces also holds here.
 type stubPeerSource struct {
 	peers   []map[string]any
 	cluster map[string]any
@@ -23,11 +20,6 @@ func (s *stubPeerSource) PeersJSON() []map[string]any { return s.peers }
 func (s *stubPeerSource) ClusterJSON() map[string]any { return s.cluster }
 func (s *stubPeerSource) PeerCount() int              { return len(s.peers) }
 
-// TestPeersAndServerInfoShareSource pins the invariant from issue #419:
-// `peers` RPC and `server_info.peers` MUST be wired to the same source,
-// so len(peers result) always equals server_info.peers. Pre-fix, the
-// two read independent fields (services.PeerCount and ctx.PeerSource);
-// a wiring mistake on either side could — and did — desync them.
 func TestPeersAndServerInfoShareSource(t *testing.T) {
 	src := &stubPeerSource{
 		peers: []map[string]any{
@@ -62,8 +54,6 @@ func TestPeersAndServerInfoShareSource(t *testing.T) {
 		"len(peers RPC result) must equal server_info.peers — single source of truth (issue #419)")
 }
 
-// TestPeersAndServerInfoBothEmptyWithoutSource confirms the degenerate
-// case still agrees: with no PeerSource wired, both methods report 0.
 func TestPeersAndServerInfoBothEmptyWithoutSource(t *testing.T) {
 	ledger := &mockLedgerService{}
 	services := &types.ServiceContainer{Ledger: ledger}

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -50,9 +50,6 @@ type ServiceContainer struct {
 	// NodePublicKey is the base58-encoded node identity public key (e.g. "n9...")
 	NodePublicKey string
 
-	// PeerCount returns the number of connected peers (nil when not in consensus mode)
-	PeerCount func() int
-
 	// LastCloseInfo returns proposer count and convergence time (ms) from the last consensus round
 	LastCloseInfo func() (proposers int, convergeTimeMs int)
 

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -47,8 +47,7 @@ const (
 // emits one entry per connected peer; ClusterJSON populates the
 // top-level cluster object (rippled doPeers Peers.cpp:59-80) with
 // each [cluster_nodes] member except the local node. PeerCount feeds
-// server_info.peers, sharing a single underlying source with peers
-// RPC so the two cannot disagree.
+// server_info.peers from the same underlying source.
 type PeerSource interface {
 	PeersJSON() []map[string]any
 	ClusterJSON() map[string]any

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -46,10 +46,13 @@ const (
 // PeerSource produces the data the `peers` RPC returns. PeersJSON
 // emits one entry per connected peer; ClusterJSON populates the
 // top-level cluster object (rippled doPeers Peers.cpp:59-80) with
-// each [cluster_nodes] member except the local node.
+// each [cluster_nodes] member except the local node. PeerCount feeds
+// server_info.peers, sharing a single underlying source with peers
+// RPC so the two cannot disagree.
 type PeerSource interface {
 	PeersJSON() []map[string]any
 	ClusterJSON() map[string]any
+	PeerCount() int
 }
 
 // RPC Context contains request-specific information

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/subscription"
@@ -34,9 +35,30 @@ type WebSocketServer struct {
 	ledgerInfoProvider  types.LedgerInfoProvider
 	connLimiter         *ConnLimiter
 	services            *types.ServiceContainer
+	peerSource          atomic.Pointer[types.PeerSource]
 	// wg tracks per-connection goroutines (read loop, send pump, ping loop)
 	// so Close can join them on shutdown.
 	wg sync.WaitGroup
+}
+
+// SetPeerSource registers the source of per-peer entries served by the
+// `peers` RPC and the peer count returned by `server_info` over this
+// WebSocket server. Passing nil detaches the source. Mirrors
+// (*Server).SetPeerSource so HTTP and WebSocket dispatchers share a
+// single overlay reference and cannot disagree.
+func (ws *WebSocketServer) SetPeerSource(src types.PeerSource) {
+	if src == nil {
+		ws.peerSource.Store(nil)
+		return
+	}
+	ws.peerSource.Store(&src)
+}
+
+func (ws *WebSocketServer) loadPeerSource() types.PeerSource {
+	if p := ws.peerSource.Load(); p != nil {
+		return *p
+	}
+	return nil
 }
 
 // WebSocketConnection represents a single WebSocket connection
@@ -283,6 +305,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 		ApiVersion: apiVersion,
 		IsAdmin:    role == types.RoleAdmin,
 		ClientIP:   clientIP,
+		PeerSource: ws.loadPeerSource(),
 		Services:   ws.services,
 	}
 

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -42,10 +42,8 @@ type WebSocketServer struct {
 }
 
 // SetPeerSource registers the source of per-peer entries served by the
-// `peers` RPC and the peer count returned by `server_info` over this
-// WebSocket server. Passing nil detaches the source. Mirrors
-// (*Server).SetPeerSource so HTTP and WebSocket dispatchers share a
-// single overlay reference and cannot disagree.
+// `peers` RPC handler. Passing nil detaches the source so the handler
+// returns an empty list. Safe to call concurrently with reads.
 func (ws *WebSocketServer) SetPeerSource(src types.PeerSource) {
 	if src == nil {
 		ws.peerSource.Store(nil)

--- a/internal/rpc/websocket_peers_test.go
+++ b/internal/rpc/websocket_peers_test.go
@@ -1,0 +1,81 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWebSocket_PeersRPC_UsesPeerSource exercises the WebSocket path
+// end-to-end: a client sends `peers` and `server_info` over WS, and
+// both must reflect the overlay state. Pre-fix, the WebSocket dispatcher
+// built RpcContext without PeerSource — `peers` returned [] while
+// `server_info.peers` still worked via the (now removed) services.PeerCount.
+// This test pins both at the same source so they can't drift.
+func TestWebSocket_PeersRPC_UsesPeerSource(t *testing.T) {
+	src := &stubPeerSource{
+		peers: []map[string]any{
+			{"address": "192.0.2.1:51235", "public_key": "nHB1"},
+			{"address": "192.0.2.2:51235", "public_key": "nHB2"},
+		},
+	}
+
+	ledger := &mockLedgerService{}
+	services := &types.ServiceContainer{Ledger: ledger}
+
+	ws := NewWebSocketServer(30*time.Second, services)
+	ws.RegisterAllMethods()
+	ws.SetPeerSource(src)
+
+	// Admin port context so peers (admin-only) is reachable.
+	pc := &PortContext{PortName: "test_admin", AdminNets: nil}
+	httpSrv := httptest.NewServer(PortMiddleware(pc, nil, ws))
+	defer httpSrv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	peers := wsCall(t, conn, map[string]any{"command": "peers", "id": 1})
+	peersList, ok := peers["result"].(map[string]any)["peers"].([]any)
+	require.True(t, ok, "peers result must contain a `peers` array")
+	assert.Len(t, peersList, len(src.peers),
+		"`peers` RPC over WS must return one entry per overlay peer (issue #419)")
+
+	info := wsCall(t, conn, map[string]any{"command": "server_info", "id": 2})
+	infoMap := info["result"].(map[string]any)["info"].(map[string]any)
+	assert.Equal(t, float64(len(src.peers)), infoMap["peers"],
+		"server_info.peers over WS must equal len(peers RPC result)")
+}
+
+func wsCall(t *testing.T, conn *websocket.Conn, req map[string]any) map[string]any {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	require.NoError(t, conn.WriteJSON(req))
+	_, raw, err := conn.ReadMessage()
+	require.NoError(t, err)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	return resp
+}
+
+// TestWebSocket_SetPeerSource_AdminRole verifies the AdminHandler check
+// on PeersMethod is reached over WS: a guest port gets `commandUntrusted`
+// rather than seeing an empty list because PeerSource is nil.
+func TestWebSocket_SetPeerSource_NilDetaches(t *testing.T) {
+	src := &stubPeerSource{peers: []map[string]any{{"address": "192.0.2.1:51235"}}}
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ws.SetPeerSource(src)
+	require.NotNil(t, ws.loadPeerSource())
+	ws.SetPeerSource(nil)
+	require.Nil(t, ws.loadPeerSource())
+}
+

--- a/internal/rpc/websocket_peers_test.go
+++ b/internal/rpc/websocket_peers_test.go
@@ -13,12 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestWebSocket_PeersRPC_UsesPeerSource exercises the WebSocket path
-// end-to-end: a client sends `peers` and `server_info` over WS, and
-// both must reflect the overlay state. Pre-fix, the WebSocket dispatcher
-// built RpcContext without PeerSource — `peers` returned [] while
-// `server_info.peers` still worked via the (now removed) services.PeerCount.
-// This test pins both at the same source so they can't drift.
 func TestWebSocket_PeersRPC_UsesPeerSource(t *testing.T) {
 	src := &stubPeerSource{
 		peers: []map[string]any{
@@ -67,9 +61,6 @@ func wsCall(t *testing.T, conn *websocket.Conn, req map[string]any) map[string]a
 	return resp
 }
 
-// TestWebSocket_SetPeerSource_AdminRole verifies the AdminHandler check
-// on PeersMethod is reached over WS: a guest port gets `commandUntrusted`
-// rather than seeing an empty list because PeerSource is nil.
 func TestWebSocket_SetPeerSource_NilDetaches(t *testing.T) {
 	src := &stubPeerSource{peers: []map[string]any{{"address": "192.0.2.1:51235"}}}
 	ws := NewWebSocketServer(30*time.Second, nil)

--- a/internal/rpc/websocket_peers_test.go
+++ b/internal/rpc/websocket_peers_test.go
@@ -69,4 +69,3 @@ func TestWebSocket_SetPeerSource_NilDetaches(t *testing.T) {
 	ws.SetPeerSource(nil)
 	require.Nil(t, ws.loadPeerSource())
 }
-


### PR DESCRIPTION
## Summary

Closes #419.

`peers` RPC and `server_info.peers` previously read from two independent fields:

- `ctx.PeerSource` — wired only on the HTTP server (`(*rpc.Server).SetPeerSource`)
- `services.PeerCount` — a captured method value on the same overlay, set on `ServiceContainer`

This split made the two views structurally able to disagree. On the WebSocket dispatcher it actively did: `handleMessage` never populated `PeerSource`, so `peers` over WS always returned `[]` even when `server_info.peers > 0`. The fuzz soak surfaced the same disagreement on the HTTP dispatcher (issue #419).

This change collapses both views onto a single `types.PeerSource` per dispatcher, so the divergence becomes mechanically impossible:

- `types.PeerSource` gains `PeerCount() int`
- `server_info`/`server_state` read peer count via `ctx.PeerSource.PeerCount()` instead of `services.PeerCount`
- `ServiceContainer.PeerCount` is removed
- `WebSocketServer` grows `SetPeerSource`/`loadPeerSource`; `handleMessage` populates `RpcContext.PeerSource`
- `cli/server.go` wires `SetPeerSource(overlay)` on **both** HTTP and WebSocket dispatchers

`Overlay.PeerCount()` already exists and reads the same `o.peers` map under the same `peersMu` lock as `Peers()` → `PeersJSON()`, so the invariant `len(peersJSON) == peerCount` is enforced at the source.

## Test plan

- [x] `go test ./internal/rpc/... ./internal/peermanagement/... ./internal/consensus/... ./internal/cli/...` — passes
- [x] `go build ./...` clean
- [x] New parity tests:
  - `TestPeersAndServerInfoShareSource` — single fake source, both APIs return matching count
  - `TestPeersAndServerInfoBothEmptyWithoutSource` — both report 0 when no source is wired
  - `TestWebSocket_PeersRPC_UsesPeerSource` — end-to-end over a real `httptest` WebSocket
  - `TestWebSocket_SetPeerSource_NilDetaches` — nil tears down the registration
- [x] Pre-existing failures (`TxQPosNegFlows/blockers_sequence`, NFTokenBurn{Base,All}{Features,Util}) untouched and unrelated to peer wiring