### PR TITLE
fix(codec,crypto,drops): address P0/P1/P2 audit findings

### DIFF
--- a/codec/addresscodec/base58check.go
+++ b/codec/addresscodec/base58check.go
@@ -2,6 +2,7 @@ package addresscodec
 
 import (
 	"crypto/sha256"
+	"crypto/subtle"
 )
 
 // checksum: first four bytes of sha256^2
@@ -31,9 +32,8 @@ func Base58CheckDecode(input string) (result []byte, err error) {
 		return nil, ErrInvalidFormat
 	}
 
-	var cksum [4]byte
-	copy(cksum[:], decoded[len(decoded)-4:])
-	if checksum(decoded[:len(decoded)-4]) != cksum {
+	expected := checksum(decoded[:len(decoded)-4])
+	if subtle.ConstantTimeCompare(expected[:], decoded[len(decoded)-4:]) != 1 {
 		return nil, ErrChecksum
 	}
 

--- a/codec/addresscodec/codec.go
+++ b/codec/addresscodec/codec.go
@@ -133,12 +133,11 @@ func EncodeSeed(entropy []byte, encodingType interfaces.CryptoImplementation) (s
 		return "", &EncodeLengthError{Instance: "Entropy", Input: len(entropy), Expected: FamilySeedLength}
 	}
 
-	if encodingType == ed25519.ED25519() {
-		prefix := []byte{0x01, 0xe1, 0x4b}
-		return Encode(entropy, prefix, FamilySeedLength)
-	} else if secp256k1 := secp256k1.SECP256K1(); encodingType == secp256k1 {
-		prefix := []byte{secp256k1.FamilySeedPrefix()}
-		return Encode(entropy, prefix, FamilySeedLength)
+	switch encodingType.(type) {
+	case ed25519.ED25519CryptoAlgorithm:
+		return Encode(entropy, ed25519.ED25519().FamilySeedPrefix(), FamilySeedLength)
+	case secp256k1.SECP256K1CryptoAlgorithm:
+		return Encode(entropy, secp256k1.SECP256K1().FamilySeedPrefix(), FamilySeedLength)
 	}
 	return "", errors.New("encoding type must be `ed25519` or `secp256k1`")
 }

--- a/codec/addresscodec/sha256.go
+++ b/codec/addresscodec/sha256.go
@@ -9,11 +9,8 @@ import (
 // Sha256RipeMD160 returns the RIPEMD160 hash of the SHA256 hash of the given byte slice.
 // It first applies SHA256 to the input, then RIPEMD160 to the SHA256 result.
 func Sha256RipeMD160(b []byte) []byte {
-	sha256 := sha256.New()
-	sha256.Write(b)
-
-	ripemd160 := ripemd160.New()
-	ripemd160.Write(sha256.Sum(nil))
-
-	return ripemd160.Sum(nil)
+	sha := sha256.Sum256(b)
+	r := ripemd160.New()
+	r.Write(sha[:])
+	return r.Sum(nil)
 }

--- a/codec/binarycodec/codec.go
+++ b/codec/binarycodec/codec.go
@@ -3,6 +3,7 @@ package binarycodec
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -27,6 +28,10 @@ var (
 	ErrBatchFlagsNotUInt32 = errors.New("flags field must be a uint32")
 	// ErrBatchTxIDsLengthTooLong is returned when the txIDs field is too long.
 	ErrBatchTxIDsLengthTooLong = errors.New("txIDs length exceeds maximum uint32 value")
+	// ErrUnknownField is returned when Encode receives a JSON key with no
+	// matching field definition. Silently dropping unknown keys masks typos
+	// (e.g. "Acount" vs "Account") that produce different binary transactions.
+	ErrUnknownField = errors.New("unknown field")
 )
 
 const (
@@ -37,18 +42,18 @@ const (
 )
 
 // Encode converts a JSON transaction object to a hex string in the canonical binary format.
-// The binary format is defined in XRPL's core codebase.
+// The binary format is defined in XRPL's core codebase. Encode does not mutate
+// the caller-supplied map. An unknown field name is treated as an error rather
+// than silently dropped — see [ErrUnknownField].
 func Encode(json map[string]any) (string, error) {
-	st := types.NewSTObject(serdes.NewBinarySerializer(serdes.NewFieldIDCodec(definitions.Get())))
-
+	defs := definitions.Get()
 	for k := range json {
-		fh := definitions.Get().Fields[k]
-		if fh == nil {
-			delete(json, k)
-			continue
+		if _, ok := defs.Fields[k]; !ok {
+			return "", fmt.Errorf("%w: %q", ErrUnknownField, k)
 		}
 	}
 
+	st := types.NewSTObject(serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec()))
 	b, err := st.FromJSON(json)
 	if err != nil {
 		return "", err
@@ -58,22 +63,21 @@ func Encode(json map[string]any) (string, error) {
 }
 
 // EncodeForMultisigning encodes a transaction into binary format in preparation for providing one
-// signature towards a multi-signed transaction.
-// Only encodes fields that are intended to be signed.
+// signature towards a multi-signed transaction. Only signing fields are
+// encoded. The caller's map is never mutated.
 func EncodeForMultisigning(json map[string]any, xrpAccountID string) (string, error) {
 	st := &types.AccountID{}
-
-	// SigningPubKey is required for multi-signing but should be set to empty string.
-
-	json["SigningPubKey"] = ""
 
 	suffix, err := st.FromJSON(xrpAccountID)
 	if err != nil {
 		return "", err
 	}
 
-	encoded, err := Encode(removeNonSigningFields(json))
+	// Build the signing-field projection with SigningPubKey overridden to "".
+	signing := removeNonSigningFields(json)
+	signing["SigningPubKey"] = ""
 
+	encoded, err := Encode(signing)
 	if err != nil {
 		return "", err
 	}
@@ -188,17 +192,19 @@ func EncodeForSigningBatch(json map[string]any) (string, error) {
 	return strings.ToUpper(sb.String()), nil
 }
 
-// removeNonSigningFields removes the fields from a JSON transaction object that should not be signed.
+// removeNonSigningFields returns a copy of the JSON transaction object with
+// all non-signing fields stripped. The caller's map is never mutated.
 func removeNonSigningFields(json map[string]any) map[string]any {
-	for k := range json {
-		fi, _ := definitions.Get().GetFieldInstanceByFieldName(k)
-
+	defs := definitions.Get()
+	out := make(map[string]any, len(json))
+	for k, v := range json {
+		fi, _ := defs.GetFieldInstanceByFieldName(k)
 		if fi != nil && !fi.IsSigningField {
-			delete(json, k)
+			continue
 		}
+		out[k] = v
 	}
-
-	return json
+	return out
 }
 
 // Decode decodes a hex string in the canonical binary format into a JSON transaction object.
@@ -208,7 +214,7 @@ func Decode(hexEncoded string) (map[string]any, error) {
 		return nil, err
 	}
 	p := serdes.NewBinaryParser(b, definitions.Get())
-	st := types.NewSTObject(serdes.NewBinarySerializer(serdes.NewFieldIDCodec(definitions.Get())))
+	st := types.NewSTObject(serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec()))
 	m, err := st.ToJSON(p)
 	if err != nil {
 		return nil, err

--- a/codec/binarycodec/codec_test.go
+++ b/codec/binarycodec/codec_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestEncode(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		description string
 		input       map[string]any
@@ -326,6 +327,7 @@ func TestEncode(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			got, err := Encode(tc.input)
 
 			if tc.expectedErr != nil {
@@ -340,6 +342,7 @@ func TestEncode(t *testing.T) {
 }
 
 func TestDecode(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		description string
 		input       string
@@ -432,6 +435,7 @@ func TestDecode(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			act, err := Decode(tc.input)
 			if tc.expectedErr != nil {
 				require.Error(t, err, tc.expectedErr.Error())
@@ -445,6 +449,7 @@ func TestDecode(t *testing.T) {
 }
 
 func TestEncodeForMultisigning(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		description string
 		json        map[string]any
@@ -527,6 +532,7 @@ func TestEncodeForMultisigning(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			got, err := EncodeForMultisigning(tc.json, tc.accountID)
 
 			if tc.expectedErr != nil {
@@ -541,6 +547,7 @@ func TestEncodeForMultisigning(t *testing.T) {
 }
 
 func TestEncodeForSigningClaim(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		description string
 		input       map[string]any
@@ -576,6 +583,7 @@ func TestEncodeForSigningClaim(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			got, err := EncodeForSigningClaim(tc.input)
 
 			if tc.expectedErr != nil {
@@ -590,6 +598,7 @@ func TestEncodeForSigningClaim(t *testing.T) {
 }
 
 func TestEncodeForSigning(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		description string
 		input       map[string]any
@@ -633,6 +642,7 @@ func TestEncodeForSigning(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			got, err := EncodeForSigning(tc.input)
 
 			if tc.expectedErr != nil {
@@ -647,6 +657,7 @@ func TestEncodeForSigning(t *testing.T) {
 }
 
 func TestEncodeForSigningBatch(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		description string
 		input       map[string]any
@@ -740,6 +751,7 @@ func TestEncodeForSigningBatch(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			got, err := EncodeForSigningBatch(tc.input)
 
 			if tc.expectedErr != nil {

--- a/codec/binarycodec/codec_test.go
+++ b/codec/binarycodec/codec_test.go
@@ -656,6 +656,80 @@ func TestEncodeForSigning(t *testing.T) {
 	}
 }
 
+// TestEncode_DoesNotMutateInput guards the non-mutation contract of the public
+// Encode entry points. The fast path in createFieldInstanceMapFromJson aliases
+// inner objects/arrays into the field-instance map by reference; this test
+// ensures neither the outer map nor any nested map/slice is mutated during
+// encoding.
+func TestEncode_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	innerMemo := map[string]any{
+		"MemoData": "04C4D46544659A2D58525043686174",
+	}
+	memoWrapper := map[string]any{"Memo": innerMemo}
+	memos := []any{memoWrapper}
+	pathStep := map[string]any{
+		"account":  "rPDXxSZcuVL3ZWoyU82bcde3zwvmShkRyF",
+		"type":     1,
+		"type_hex": "0000000000000001",
+	}
+	paths := []any{[]any{pathStep}}
+
+	input := map[string]any{
+		"TransactionType": "Payment",
+		"Account":         "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+		"Destination":     "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+		"Amount":          "1000000",
+		"Fee":             "10",
+		"Sequence":        uint32(1),
+		"SigningPubKey":   "0379F17CFA0FFD7518181594BE69FE9A10471D6DE1F4055C6D2746AFD6CF89889E",
+		"Memos":           memos,
+		"Paths":           paths,
+	}
+
+	outerKeysBefore := make([]string, 0, len(input))
+	for k := range input {
+		outerKeysBefore = append(outerKeysBefore, k)
+	}
+	memoBefore := map[string]any{"MemoData": innerMemo["MemoData"]}
+	pathStepBefore := map[string]any{
+		"account":  pathStep["account"],
+		"type":     pathStep["type"],
+		"type_hex": pathStep["type_hex"],
+	}
+	memosLenBefore := len(memos)
+	pathsLenBefore := len(paths)
+
+	_, err := Encode(input)
+	require.NoError(t, err)
+
+	require.Len(t, input, len(outerKeysBefore), "Encode must not add/remove caller-map keys")
+	for _, k := range outerKeysBefore {
+		_, ok := input[k]
+		require.True(t, ok, "Encode removed caller key %q", k)
+	}
+	require.Equal(t, memoBefore, innerMemo, "Encode mutated nested Memo map")
+	require.Equal(t, pathStepBefore, pathStep, "Encode mutated nested PathStep map")
+	require.Len(t, memos, memosLenBefore, "Encode mutated Memos slice length")
+	require.Len(t, paths, pathsLenBefore, "Encode mutated Paths slice length")
+
+	signingPubKey := "0379F17CFA0FFD7518181594BE69FE9A10471D6DE1F4055C6D2746AFD6CF89889E"
+	multisigInput := map[string]any{
+		"TransactionType": "Payment",
+		"Account":         "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+		"Destination":     "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+		"Amount":          "1000000",
+		"Fee":             "10",
+		"Sequence":        uint32(1),
+		"SigningPubKey":   signingPubKey,
+	}
+	_, err = EncodeForMultisigning(multisigInput, "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp")
+	require.NoError(t, err)
+	require.Equal(t, signingPubKey, multisigInput["SigningPubKey"],
+		"EncodeForMultisigning must not clear caller's SigningPubKey")
+}
+
 func TestEncodeForSigningBatch(t *testing.T) {
 	t.Parallel()
 	tt := []struct {

--- a/codec/binarycodec/definitions/definitions.go
+++ b/codec/binarycodec/definitions/definitions.go
@@ -3,8 +3,8 @@ package definitions
 
 import (
 	_ "embed"
-
-	"github.com/ugorji/go/codec"
+	"encoding/json"
+	"fmt"
 )
 
 var (
@@ -15,7 +15,11 @@ var (
 	definitions *Definitions
 )
 
-// Definitions holds the binary serialization definitions for the XRP Ledger, loaded from the RFC JSON document.
+// Definitions holds the binary serialization definitions for the XRP Ledger,
+// loaded once at package init from the embedded RFC JSON document.
+//
+// All forward maps (name -> code) and reverse maps (code -> name) are built
+// eagerly so every lookup is O(1).
 type Definitions struct {
 	Types                  map[string]int32
 	LedgerEntryTypes       map[string]int32
@@ -25,6 +29,12 @@ type Definitions struct {
 	FieldIDNameMap         map[FieldHeader]string
 	GranularPermissions    map[string]int32
 	DelegatablePermissions map[string]int32
+
+	// Reverse lookup maps used by enumToStr-style decoders.
+	transactionTypeNames       map[int32]string
+	transactionResultNames     map[int32]string
+	ledgerEntryTypeNames       map[int32]string
+	delegatablePermissionNames map[int32]string
 }
 
 // Get returns the singleton instance of Definitions.
@@ -40,19 +50,14 @@ type definitionsDoc struct {
 	TransactionTypes   map[string]int32 `json:"TRANSACTION_TYPES"`
 }
 
-// Loads JSON from the definitions file and converts it to a preferred format.
-// The definitions file contains information required for the XRP Ledger's
-// canonical binary serialization format:
-// `Serialization <https://xrpl.org/serialization.html>`_
+// loadDefinitions decodes the embedded JSON definitions document and
+// populates the singleton. It panics if the embedded document is malformed
+// — that condition is a build-time bug, not a runtime input failure.
 func loadDefinitions() {
-	var jh codec.JsonHandle
-
-	jh.MapKeyAsString = true
-	jh.SignedInteger = true
-
-	dec := codec.NewDecoderBytes(docBytes, &jh)
 	var data definitionsDoc
-	dec.MustDecode(&data)
+	if err := json.Unmarshal(docBytes, &data); err != nil {
+		panic(fmt.Errorf("definitions: decode embedded JSON: %w", err))
+	}
 
 	definitions = &Definitions{
 		Types:              data.Types,
@@ -65,36 +70,7 @@ func loadDefinitions() {
 	addFieldHeadersAndOrdinals()
 	createFieldIDNameMap()
 	initializePermissions()
-}
-
-func convertToFieldInstanceMap(m [][]interface{}) map[string]*FieldInstance {
-	nm := make(map[string]*FieldInstance, len(m))
-
-	for _, j := range m {
-		k := j[0].(string)
-		fi, _ := castFieldInfo(j[1])
-		nm[k] = &FieldInstance{
-			FieldName: k,
-			FieldInfo: &fi,
-			Ordinal:   fi.Nth,
-		}
-	}
-	return nm
-}
-
-func castFieldInfo(v interface{}) (FieldInfo, error) {
-	if fi, ok := v.(map[string]interface{}); ok {
-		return FieldInfo{
-			// TODO: Check if this is still needed
-			//nolint:gosec // G115: Potential hardcoded credentials (gosec)
-			Nth:            int32(fi["nth"].(int64)),
-			IsVLEncoded:    fi["isVLEncoded"].(bool),
-			IsSerialized:   fi["isSerialized"].(bool),
-			IsSigningField: fi["isSigningField"].(bool),
-			Type:           fi["type"].(string),
-		}, nil
-	}
-	return FieldInfo{}, ErrUnableToCastFieldInfo
+	buildReverseMaps()
 }
 
 func addFieldHeadersAndOrdinals() {
@@ -137,7 +113,7 @@ func initializePermissions() {
 		"MPTokenIssuanceUnlock":  65548,
 	}
 
-	definitions.DelegatablePermissions = make(map[string]int32)
+	definitions.DelegatablePermissions = make(map[string]int32, len(definitions.GranularPermissions)+len(definitions.TransactionTypes))
 
 	for name, value := range definitions.GranularPermissions {
 		definitions.DelegatablePermissions[name] = value
@@ -145,5 +121,26 @@ func initializePermissions() {
 
 	for txType, value := range definitions.TransactionTypes {
 		definitions.DelegatablePermissions[txType] = value + 1
+	}
+}
+
+// buildReverseMaps populates code->name lookup tables once so that the
+// public Get*Name helpers are O(1) instead of scanning the forward maps.
+func buildReverseMaps() {
+	definitions.transactionTypeNames = make(map[int32]string, len(definitions.TransactionTypes))
+	for name, code := range definitions.TransactionTypes {
+		definitions.transactionTypeNames[code] = name
+	}
+	definitions.transactionResultNames = make(map[int32]string, len(definitions.TransactionResults))
+	for name, code := range definitions.TransactionResults {
+		definitions.transactionResultNames[code] = name
+	}
+	definitions.ledgerEntryTypeNames = make(map[int32]string, len(definitions.LedgerEntryTypes))
+	for name, code := range definitions.LedgerEntryTypes {
+		definitions.ledgerEntryTypeNames[code] = name
+	}
+	definitions.delegatablePermissionNames = make(map[int32]string, len(definitions.DelegatablePermissions))
+	for name, value := range definitions.DelegatablePermissions {
+		definitions.delegatablePermissionNames[value] = name
 	}
 }

--- a/codec/binarycodec/definitions/field_instance.go
+++ b/codec/binarycodec/definitions/field_instance.go
@@ -15,10 +15,10 @@ type FieldInstance struct {
 
 // FieldInfo is a struct that represents the field info.
 type FieldInfo struct {
-	Nth            int32 `json:"nth"`
-	IsVLEncoded    bool  `json:"isVLEncoded"`
-	IsSerialized   bool  `json:"isSerialized"`
-	IsSigningField bool  `json:"isSigningField"`
+	Nth            int32  `json:"nth"`
+	IsVLEncoded    bool   `json:"isVLEncoded"`
+	IsSerialized   bool   `json:"isSerialized"`
+	IsSigningField bool   `json:"isSigningField"`
 	Type           string `json:"type"`
 }
 

--- a/codec/binarycodec/definitions/field_instance.go
+++ b/codec/binarycodec/definitions/field_instance.go
@@ -1,6 +1,9 @@
 package definitions
 
-import "github.com/ugorji/go/codec"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // FieldInstance is a struct that represents a field instance.
 type FieldInstance struct {
@@ -12,11 +15,11 @@ type FieldInstance struct {
 
 // FieldInfo is a struct that represents the field info.
 type FieldInfo struct {
-	Nth            int32
-	IsVLEncoded    bool
-	IsSerialized   bool
-	IsSigningField bool
-	Type           string
+	Nth            int32 `json:"nth"`
+	IsVLEncoded    bool  `json:"isVLEncoded"`
+	IsSerialized   bool  `json:"isSerialized"`
+	IsSigningField bool  `json:"isSigningField"`
+	Type           string `json:"type"`
 }
 
 // FieldHeader is a struct that represents the field header.
@@ -35,13 +38,33 @@ func (d *Definitions) CreateFieldHeader(tc, fc int32) FieldHeader {
 
 type fieldInstanceMap map[string]*FieldInstance
 
-// CodecEncodeSelf implements the codec.SelfEncoder interface.
-func (fi *fieldInstanceMap) CodecEncodeSelf(_ *codec.Encoder) {}
-
-// CodecDecodeSelf implements the codec.SelfDecoder interface.
-func (fi *fieldInstanceMap) CodecDecodeSelf(d *codec.Decoder) {
-	var x [][]interface{}
-	d.MustDecode(&x)
-	y := convertToFieldInstanceMap(x)
-	*fi = y
+// UnmarshalJSON decodes the FIELDS array of `[name, fieldInfo]` pairs from
+// definitions.json into a flat name -> FieldInstance map.
+func (fi *fieldInstanceMap) UnmarshalJSON(data []byte) error {
+	var pairs []json.RawMessage
+	if err := json.Unmarshal(data, &pairs); err != nil {
+		return fmt.Errorf("FIELDS: %w", err)
+	}
+	m := make(fieldInstanceMap, len(pairs))
+	for i, raw := range pairs {
+		var pair [2]json.RawMessage
+		if err := json.Unmarshal(raw, &pair); err != nil {
+			return fmt.Errorf("FIELDS[%d]: %w", i, err)
+		}
+		var name string
+		if err := json.Unmarshal(pair[0], &name); err != nil {
+			return fmt.Errorf("FIELDS[%d].name: %w", i, err)
+		}
+		info := &FieldInfo{}
+		if err := json.Unmarshal(pair[1], info); err != nil {
+			return fmt.Errorf("FIELDS[%d].info (%q): %w", i, name, err)
+		}
+		m[name] = &FieldInstance{
+			FieldName: name,
+			FieldInfo: info,
+			Ordinal:   info.Nth,
+		}
+	}
+	*fi = m
+	return nil
 }

--- a/codec/binarycodec/definitions/helpers.go
+++ b/codec/binarycodec/definitions/helpers.go
@@ -121,10 +121,8 @@ func (d *Definitions) GetTransactionTypeCodeByTransactionTypeName(n string) (int
 
 // GetTransactionTypeNameByTransactionTypeCode returns the transaction type name associated with the transaction type code.
 func (d *Definitions) GetTransactionTypeNameByTransactionTypeCode(c int32) (string, error) {
-	for txTypeName, code := range d.TransactionTypes {
-		if code == c {
-			return txTypeName, nil
-		}
+	if name, ok := d.transactionTypeNames[c]; ok {
+		return name, nil
 	}
 	return "", &NotFoundErrorInt{
 		Instance: "TransactionTypeCode",
@@ -134,12 +132,9 @@ func (d *Definitions) GetTransactionTypeNameByTransactionTypeCode(c int32) (stri
 
 // GetTransactionResultNameByTransactionResultTypeCode returns the transaction result name associated with the transaction result type code.
 func (d *Definitions) GetTransactionResultNameByTransactionResultTypeCode(c int32) (string, error) {
-	for txResultName, code := range d.TransactionResults {
-		if code == c {
-			return txResultName, nil
-		}
+	if name, ok := d.transactionResultNames[c]; ok {
+		return name, nil
 	}
-
 	return "", &NotFoundErrorInt{
 		Instance: "TransactionResultTypeCode",
 		Input:    c,
@@ -174,12 +169,9 @@ func (d *Definitions) GetLedgerEntryTypeCodeByLedgerEntryTypeName(n string) (int
 
 // GetLedgerEntryTypeNameByLedgerEntryTypeCode returns the ledger entry type name associated with the ledger entry type code.
 func (d *Definitions) GetLedgerEntryTypeNameByLedgerEntryTypeCode(c int32) (string, error) {
-	for ledgerEntryTypeName, code := range d.LedgerEntryTypes {
-		if code == c {
-			return ledgerEntryTypeName, nil
-		}
+	if name, ok := d.ledgerEntryTypeNames[c]; ok {
+		return name, nil
 	}
-
 	return "", &NotFoundErrorInt{
 		Instance: "LedgerEntryTypeCode",
 		Input:    c,
@@ -201,12 +193,9 @@ func (d *Definitions) GetDelegatablePermissionValueByName(n string) (int32, erro
 
 // GetDelegatablePermissionNameByValue returns the delegatable permission name associated with the permission value.
 func (d *Definitions) GetDelegatablePermissionNameByValue(v int32) (string, error) {
-	for permissionName, value := range d.DelegatablePermissions {
-		if value == v {
-			return permissionName, nil
-		}
+	if name, ok := d.delegatablePermissionNames[v]; ok {
+		return name, nil
 	}
-
 	return "", &NotFoundErrorInt{
 		Instance: "DelegatablePermissionValue",
 		Input:    v,

--- a/codec/binarycodec/serdes/binary_parser.go
+++ b/codec/binarycodec/serdes/binary_parser.go
@@ -112,16 +112,18 @@ func (p *BinaryParser) Peek() (byte, error) {
 
 // ReadBytes reads the next n bytes in the data.
 // It returns an error if fewer than n bytes are available.
+// The returned slice is a copy; the parser's backing buffer is never aliased.
 func (p *BinaryParser) ReadBytes(n int) ([]byte, error) {
-	var bytes []byte
-	for i := 0; i < n; i++ {
-		b, err := p.ReadByte()
-		if err != nil {
-			return nil, err
-		}
-		bytes = append(bytes, b)
+	if n < 0 {
+		return nil, ErrParserOutOfBound
 	}
-	return bytes, nil
+	if len(p.data) < n {
+		return nil, ErrParserOutOfBound
+	}
+	out := make([]byte, n)
+	copy(out, p.data[:n])
+	p.data = p.data[n:]
+	return out, nil
 }
 
 // HasMore returns true if there is more data to read, and false otherwise.

--- a/codec/binarycodec/serdes/binary_parser_test.go
+++ b/codec/binarycodec/serdes/binary_parser_test.go
@@ -150,6 +150,41 @@ func TestBinaryParser_ReadBytes(t *testing.T) {
 	}
 }
 
+func TestBinaryParser_ReadBytes_Negative(t *testing.T) {
+	p := NewBinaryParser([]byte{1, 2, 3}, definitions.Get())
+	_, err := p.ReadBytes(-1)
+	require.ErrorIs(t, err, ErrParserOutOfBound)
+}
+
+func TestBinaryParser_ReadBytes_Zero(t *testing.T) {
+	p := NewBinaryParser([]byte{1, 2, 3}, definitions.Get())
+	out, err := p.ReadBytes(0)
+	require.NoError(t, err)
+	require.Empty(t, out)
+	// Cursor must not have advanced.
+	require.True(t, p.HasMore())
+	next, err := p.ReadByte()
+	require.NoError(t, err)
+	require.Equal(t, byte(1), next)
+}
+
+func TestBinaryParser_ReadBytes_NoAliasing(t *testing.T) {
+	input := []byte{1, 2, 3, 4, 5}
+	p := NewBinaryParser(input, definitions.Get())
+	out, err := p.ReadBytes(3)
+	require.NoError(t, err)
+	require.Equal(t, []byte{1, 2, 3}, out)
+	// Mutating the returned slice must not affect the parser's remaining data
+	// or the caller-supplied input slice.
+	for i := range out {
+		out[i] = 0xFF
+	}
+	require.Equal(t, []byte{1, 2, 3, 4, 5}, input)
+	rest, err := p.ReadBytes(2)
+	require.NoError(t, err)
+	require.Equal(t, []byte{4, 5}, rest)
+}
+
 func TestBinaryParser_HasMore(t *testing.T) {
 	testcases := []struct {
 		name     string

--- a/codec/binarycodec/serdes/field_id_codec.go
+++ b/codec/binarycodec/serdes/field_id_codec.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 
+	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/serdes/interfaces"
 )
 
@@ -18,8 +19,20 @@ type FieldIDCodec struct {
 }
 
 // NewFieldIDCodec creates a new FieldIDCodec.
-func NewFieldIDCodec(definitions interfaces.Definitions) *FieldIDCodec {
-	return &FieldIDCodec{definitions: definitions}
+func NewFieldIDCodec(defs interfaces.Definitions) *FieldIDCodec {
+	return &FieldIDCodec{definitions: defs}
+}
+
+// defaultFieldIDCodec is the canonical, stateless codec bound to the global
+// definitions singleton. The codec only reads from its definitions field, so
+// sharing one instance across goroutines is safe and avoids per-call allocs
+// on the hot serialization path.
+var defaultFieldIDCodec = &FieldIDCodec{definitions: definitions.Get()}
+
+// DefaultFieldIDCodec returns a shared FieldIDCodec bound to definitions.Get().
+// Call this instead of NewFieldIDCodec(definitions.Get()) on hot paths.
+func DefaultFieldIDCodec() *FieldIDCodec {
+	return defaultFieldIDCodec
 }
 
 // Encode returns the unique field ID for a given field name.

--- a/codec/binarycodec/types/amount.go
+++ b/codec/binarycodec/types/amount.go
@@ -636,7 +636,6 @@ func serializeIssuedCurrencyAmount(value, currency, issuer string) ([]byte, erro
 	// AccountIDs that appear as children of special fields (Amount issuer and PathSet account) are not length-prefixed.
 	// So in Amount and PathSet fields, don't use the length indicator 0x14. This is in contrast to the AccountID fields where the length indicator prefix 0x14 is added.
 
-	// Pre-sized output: 8-byte value + 20-byte currency + 20-byte issuer.
 	out := make([]byte, 0, len(valBytes)+len(currencyBytes)+len(issuerBytes))
 	out = append(out, valBytes...)
 	out = append(out, currencyBytes...)

--- a/codec/binarycodec/types/amount.go
+++ b/codec/binarycodec/types/amount.go
@@ -88,6 +88,12 @@ var (
 	errFailedConvertStringToBigFloat = errors.New("failed to convert string to big.Float")
 )
 
+// Compiled once at package init: avoiding MustCompile on hot paths.
+var (
+	xrpDigitsRegex = regexp.MustCompile(`\d+`)
+	iouCodeRegex   = regexp.MustCompile(IOUCodeRegex)
+)
+
 // InvalidAmountError is a custom error type for invalid amounts.
 type InvalidAmountError struct {
 	Amount string
@@ -276,8 +282,7 @@ func deserializeCurrencyCode(data []byte) (string, error) {
 	// must be returned as the full hex string, not as a 3-char code.
 	if bytes.Equal(data[0:12], make([]byte, 12)) && bytes.Equal(data[15:20], make([]byte, 5)) {
 		iso := strings.ToUpper(string(data[12:15]))
-		ok, _ := regexp.MatchString(IOUCodeRegex, iso)
-		if ok {
+		if iouCodeRegex.MatchString(iso) {
 			return iso, nil
 		}
 	}
@@ -357,8 +362,7 @@ func verifyXrpValue(value string) error {
 		checkValue = checkValue[1:]
 	}
 
-	r := regexp.MustCompile(`\d+`) // regex to match only digits
-	m := r.FindAllString(checkValue, -1)
+	m := xrpDigitsRegex.FindAllString(checkValue, -1)
 
 	if len(m) != 1 {
 		return errInvalidXRPValue
@@ -593,10 +597,7 @@ func serializeIssuedCurrencyCodeHex(currency string) ([]byte, error) {
 }
 
 func serializeIssuedCurrencyCodeChars(currency string) ([]byte, error) {
-	r := regexp.MustCompile(IOUCodeRegex) // regex to check if the currency code is valid
-	m := r.FindAllString(currency, -1)
-
-	if len(m) != 1 {
+	if len(iouCodeRegex.FindAllString(currency, -1)) != 1 {
 		return nil, errInvalidCurrencyCode
 	}
 
@@ -635,7 +636,12 @@ func serializeIssuedCurrencyAmount(value, currency, issuer string) ([]byte, erro
 	// AccountIDs that appear as children of special fields (Amount issuer and PathSet account) are not length-prefixed.
 	// So in Amount and PathSet fields, don't use the length indicator 0x14. This is in contrast to the AccountID fields where the length indicator prefix 0x14 is added.
 
-	return append(append(valBytes, currencyBytes...), issuerBytes...), nil
+	// Pre-sized output: 8-byte value + 20-byte currency + 20-byte issuer.
+	out := make([]byte, 0, len(valBytes)+len(currencyBytes)+len(issuerBytes))
+	out = append(out, valBytes...)
+	out = append(out, currencyBytes...)
+	out = append(out, issuerBytes...)
+	return out, nil
 }
 
 // serializeMPTCurrencyValue serializes an MPT currency value to its binary representation.
@@ -716,10 +722,7 @@ func isPositive(value byte) bool {
 }
 
 func containsInvalidIOUCodeCharactersHex(currency []byte) bool {
-	r := regexp.MustCompile(IOUCodeRegex) // regex to check if the currency code is valid
-	m := r.FindAll(currency, -1)
-
-	return len(m) != 1
+	return len(iouCodeRegex.FindAll(currency, -1)) != 1
 }
 
 // valueToString converts various JSON‐style value types into their string form.

--- a/codec/binarycodec/types/currency.go
+++ b/codec/binarycodec/types/currency.go
@@ -44,26 +44,23 @@ func (c *Currency) ToJSON(p interfaces.BinaryParser, opts ...int) (any, error) {
 		return "XRP", nil
 	}
 
-	// Check if bytes has exactly 3 non-zero bytes at positions 12-14
-	nonZeroCount := 0
-	var currencyStr string
-	for i := 0; i < len(currencyBytes); i++ {
-		if currencyBytes[i] != 0 {
-			if i >= 12 && i <= 14 {
-				nonZeroCount++
-				currencyStr += string(currencyBytes[i])
-			} else {
-				nonZeroCount = 0
-				break
-			}
+	// Standard 3-char ISO code: bytes 0-11 and 15-19 must be zero,
+	// bytes 12-14 must each be non-zero printable.
+	if len(currencyBytes) == 20 &&
+		isAllZero(currencyBytes[:12]) && isAllZero(currencyBytes[15:]) &&
+		currencyBytes[12] != 0 && currencyBytes[13] != 0 && currencyBytes[14] != 0 {
+		return string(currencyBytes[12:15]), nil
+	}
+	return hex.EncodeToString(currencyBytes), nil
+}
+
+func isAllZero(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
 		}
 	}
-
-	if nonZeroCount == 3 {
-		return currencyStr, nil
-	}
-
-	return hex.EncodeToString(currencyBytes), nil
+	return true
 }
 
 func (c *Currency) fromString(str string) ([]byte, error) {

--- a/codec/binarycodec/types/number.go
+++ b/codec/binarycodec/types/number.go
@@ -163,12 +163,10 @@ func normalize(mantissa *big.Int, exponent int32) (*big.Int, int32, error) {
 }
 
 // formatScientific formats mantissa and exponent as scientific notation string.
+// Both signs of the exponent collapse to the same shape because itoa already
+// prepends a leading "-" for negatives.
 func formatScientific(mantissa int64, exponent int32) string {
-	m := big.NewInt(mantissa)
-	if exponent >= 0 {
-		return m.String() + "e" + itoa(int(exponent))
-	}
-	return m.String() + "e" + itoa(int(exponent))
+	return big.NewInt(mantissa).String() + "e" + itoa(int(exponent))
 }
 
 // formatDecimal formats mantissa and exponent as a decimal string.

--- a/codec/binarycodec/types/pathset.go
+++ b/codec/binarycodec/types/pathset.go
@@ -34,15 +34,19 @@ var ErrInvalidPathSet = errors.New("invalid path set: expected [][]any")
 // FromJSON attempts to serialize a path set from a JSON representation of a slice of paths to a byte array.
 // It returns the byte array representation of the path set, or an error if the provided json does not represent a valid path set.
 func (p PathSet) FromJSON(json any) ([]byte, error) {
-	if _, ok := json.([]any)[0].([]any); !ok {
+	outer, ok := json.([]any)
+	if !ok || len(outer) == 0 {
+		return nil, ErrInvalidPathSet
+	}
+	if _, ok := outer[0].([]any); !ok {
 		return nil, ErrInvalidPathSet
 	}
 
-	if !isPathSet(json.([]any)) {
+	if !isPathSet(outer) {
 		return nil, ErrInvalidPathSet
 	}
 
-	return newPathSet(json.([]any)), nil
+	return newPathSet(outer)
 }
 
 // ToJSON decodes a path set from a binary representation using a provided binary parser, then translates it to a JSON representation.
@@ -109,55 +113,96 @@ func isPathStep(v map[string]any) bool {
 	return v["account"] != nil || v["currency"] != nil || v["issuer"] != nil
 }
 
+// pathStepMaxLen is the upper bound for a single serialized path step:
+// 1 type byte + 20 bytes account + 20 bytes currency + 20 bytes issuer.
+const pathStepMaxLen = 1 + 20 + 20 + 20
+
 // newPathStep creates a path step from a map representation.
 // It generates a byte array representation of the path step, encoding account, currency, and issuer information as appropriate.
-func newPathStep(v map[string]any) []byte {
+func newPathStep(v map[string]any) ([]byte, error) {
+	out := make([]byte, 1, pathStepMaxLen)
 	dataType := 0x00
-	b := make([]byte, 0)
 
 	if v["account"] != nil {
-		_, account, _ := addresscodec.DecodeClassicAddressToAccountID(v["account"].(string))
-		b = append(b, account...)
+		addr, ok := v["account"].(string)
+		if !ok {
+			return nil, errors.New("path step: account is not a string")
+		}
+		_, account, err := addresscodec.DecodeClassicAddressToAccountID(addr)
+		if err != nil {
+			return nil, fmt.Errorf("path step: account %q: %w", addr, err)
+		}
+		out = append(out, account...)
 		dataType |= typeAccount
 	}
 	if v["currency"] != nil {
-		currency, _ := serializePathCurrency(v["currency"].(string))
-		b = append(b, currency...)
+		curr, ok := v["currency"].(string)
+		if !ok {
+			return nil, errors.New("path step: currency is not a string")
+		}
+		currency, err := serializePathCurrency(curr)
+		if err != nil {
+			return nil, fmt.Errorf("path step: currency %q: %w", curr, err)
+		}
+		out = append(out, currency...)
 		dataType |= typeCurrency
 	}
 	if v["issuer"] != nil {
-		_, issuer, _ := addresscodec.DecodeClassicAddressToAccountID(v["issuer"].(string))
-		b = append(b, issuer...)
+		addr, ok := v["issuer"].(string)
+		if !ok {
+			return nil, errors.New("path step: issuer is not a string")
+		}
+		_, issuer, err := addresscodec.DecodeClassicAddressToAccountID(addr)
+		if err != nil {
+			return nil, fmt.Errorf("path step: issuer %q: %w", addr, err)
+		}
+		out = append(out, issuer...)
 		dataType |= typeIssuer
 	}
 
-	return append([]byte{byte(dataType)}, b...)
+	out[0] = byte(dataType)
+	return out, nil
 }
 
 // newPath constructs a path from a slice of path steps.
 // It generates a byte array representation of the path, encoding each path step in turn.
-func newPath(v []any) []byte {
-	b := make([]byte, 0)
-
-	for _, step := range v { // for each step in the path (slice of path steps)
-		b = append(b, newPathStep(step.(map[string]any))...) // append the path step to the byte array
+func newPath(v []any) ([]byte, error) {
+	b := make([]byte, 0, len(v)*pathStepMaxLen)
+	for _, step := range v {
+		stepMap, ok := step.(map[string]any)
+		if !ok {
+			return nil, errors.New("path: step is not a map[string]any")
+		}
+		encoded, err := newPathStep(stepMap)
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, encoded...)
 	}
-	return b
+	return b, nil
 }
 
 // newPathSet constructs a path set from a slice of paths.
 // It generates a byte array representation of the path set, encoding each path and adding path separators as appropriate.
-func newPathSet(v []any) []byte {
-	b := make([]byte, 0)
-
-	for _, path := range v { // for each path in the path set (slice of paths)
-		b = append(b, newPath(path.([]any))...) // append the path to the byte array
-		b = append(b, pathSeparatorByte)        // between each path, append a path separator byte
+func newPathSet(v []any) ([]byte, error) {
+	if len(v) == 0 {
+		return []byte{pathsetEndByte}, nil
 	}
-
-	b[len(b)-1] = pathsetEndByte // replace last path separator with path set end byte
-
-	return b
+	b := make([]byte, 0, len(v)*pathStepMaxLen)
+	for _, path := range v {
+		inner, ok := path.([]any)
+		if !ok {
+			return nil, errors.New("path set: path is not a []any")
+		}
+		encoded, err := newPath(inner)
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, encoded...)
+		b = append(b, pathSeparatorByte)
+	}
+	b[len(b)-1] = pathsetEndByte
+	return b, nil
 }
 
 // parsePathStep decodes a path step from a binary representation using a provided binary parser.

--- a/codec/binarycodec/types/pathset_test.go
+++ b/codec/binarycodec/types/pathset_test.go
@@ -186,7 +186,9 @@ func TestNewPathStep(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
-			require.Equal(t, tc.expected, newPathStep(tc.input))
+			actual, err := newPathStep(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
 		})
 	}
 }
@@ -217,7 +219,9 @@ func TestNewPath(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
-			require.Equal(t, tc.expected, newPath(tc.input))
+			actual, err := newPath(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
 		})
 	}
 }
@@ -275,7 +279,9 @@ func TestNewPathSet(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
-			require.Equal(t, tc.expected, newPathSet(tc.input))
+			actual, err := newPathSet(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
 		})
 	}
 }

--- a/codec/binarycodec/types/serialized_type.go
+++ b/codec/binarycodec/types/serialized_type.go
@@ -2,7 +2,6 @@
 package types
 
 import (
-	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/serdes"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/types/interfaces"
 )
@@ -49,7 +48,7 @@ func GetSerializedType(t string) SerializedType {
 	case "Blob":
 		return &Blob{}
 	case "STObject":
-		return NewSTObject(serdes.NewBinarySerializer(serdes.NewFieldIDCodec(definitions.Get())))
+		return NewSTObject(serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec()))
 	case "STArray":
 		return &STArray{}
 	case "PathSet":

--- a/codec/binarycodec/types/st_array.go
+++ b/codec/binarycodec/types/st_array.go
@@ -4,7 +4,6 @@ package types
 import (
 	"errors"
 
-	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/serdes"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/types/interfaces"
 )
@@ -42,7 +41,7 @@ func (t *STArray) FromJSON(json any) ([]byte, error) {
 
 	var sink []byte
 	for _, v := range json.([]any) {
-		st := NewSTObject(serdes.NewBinarySerializer(serdes.NewFieldIDCodec(definitions.Get())))
+		st := NewSTObject(serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec()))
 		b, err := st.FromJSON(v)
 		if err != nil {
 			return nil, err

--- a/codec/binarycodec/types/st_object.go
+++ b/codec/binarycodec/types/st_object.go
@@ -113,33 +113,49 @@ func (t *STObject) ToJSON(p interfaces.BinaryParser, _ ...int) (any, error) {
 //
 //lint:ignore U1000 // ignore this for now
 func createFieldInstanceMapFromJson(json map[string]any) (map[definitions.FieldInstance]any, error) {
-	// First pass: handle X-addresses and extract tags
+	// Fast path: no key holds an X-address — populate the field-instance map
+	// directly from the caller's map without a defensive copy.
+	hasX := false
+	for _, v := range json {
+		if s, ok := v.(string); ok && addresscodec.IsValidXAddress(s) {
+			hasX = true
+			break
+		}
+	}
+
+	defs := definitions.Get()
+	if !hasX {
+		m := make(map[definitions.FieldInstance]any, len(json))
+		for k, v := range json {
+			fi, err := defs.GetFieldInstanceByFieldName(k)
+			if err != nil {
+				return nil, err
+			}
+			v, err = parseSpecialFields(k, v)
+			if err != nil {
+				return nil, err
+			}
+			m[*fi] = v
+		}
+		return m, nil
+}
+
+	// Slow path: at least one X-address present. Copy, then resolve X-addresses
+	// into classic addresses + tag siblings before building the field map.
 	processedJSON := make(map[string]any, len(json))
 	for k, v := range json {
 		processedJSON[k] = v
 	}
-
-	// Process X-addresses
 	for k, v := range json {
 		strVal, ok := v.(string)
-		if !ok {
+		if !ok || !addresscodec.IsValidXAddress(strVal) {
 			continue
 		}
-
-		if !addresscodec.IsValidXAddress(strVal) {
-			continue
-		}
-
-		// Decode X-address
 		classicAddr, tag, _, err := addresscodec.XAddressToClassicAddress(strVal)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode X-address for field %s: %w", k, err)
 		}
-
-		// Replace X-address with classic address
 		processedJSON[k] = classicAddr
-
-		// If there's an embedded tag, add it as SourceTag or DestinationTag
 		if tag != 0 {
 			var tagFieldName string
 			switch k {
@@ -150,8 +166,6 @@ func createFieldInstanceMapFromJson(json map[string]any) (map[definitions.FieldI
 			default:
 				return nil, fmt.Errorf("%s cannot have an associated tag", k)
 			}
-
-			// Check for duplicate tags
 			if existingTag, exists := processedJSON[tagFieldName]; exists {
 				if existingTag != tag {
 					return nil, fmt.Errorf("duplicate %s: X-address tag (%d) does not match existing tag (%v)", tagFieldName, tag, existingTag)
@@ -161,21 +175,16 @@ func createFieldInstanceMapFromJson(json map[string]any) (map[definitions.FieldI
 		}
 	}
 
-	// Second pass: create field instance map
 	m := make(map[definitions.FieldInstance]any, len(processedJSON))
-
 	for k, v := range processedJSON {
-		fi, err := definitions.Get().GetFieldInstanceByFieldName(k)
-
+		fi, err := defs.GetFieldInstanceByFieldName(k)
 		if err != nil {
 			return nil, err
 		}
-
 		v, err = parseSpecialFields(k, v)
 		if err != nil {
 			return nil, err
 		}
-
 		m[*fi] = v
 	}
 	return m, nil

--- a/codec/binarycodec/types/st_object.go
+++ b/codec/binarycodec/types/st_object.go
@@ -114,7 +114,10 @@ func (t *STObject) ToJSON(p interfaces.BinaryParser, _ ...int) (any, error) {
 //lint:ignore U1000 // ignore this for now
 func createFieldInstanceMapFromJson(json map[string]any) (map[definitions.FieldInstance]any, error) {
 	// Fast path: no key holds an X-address — populate the field-instance map
-	// directly from the caller's map without a defensive copy.
+	// directly from the caller's map without a defensive copy. Writes go only
+	// to the fresh m; the caller's json is not mutated. Inner objects/arrays
+	// are aliased into m by reference, but downstream callers (STObject /
+	// STArray nested serialisation) do not mutate them either.
 	hasX := false
 	for _, v := range json {
 		if s, ok := v.(string); ok && addresscodec.IsValidXAddress(s) {
@@ -138,7 +141,7 @@ func createFieldInstanceMapFromJson(json map[string]any) (map[definitions.FieldI
 			m[*fi] = v
 		}
 		return m, nil
-}
+	}
 
 	// Slow path: at least one X-address present. Copy, then resolve X-addresses
 	// into classic addresses + tag siblings before building the field map.

--- a/codec/binarycodec/types/uint16.go
+++ b/codec/binarycodec/types/uint16.go
@@ -2,7 +2,6 @@
 package types
 
 import (
-	"bytes"
 	"encoding/binary"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
@@ -16,10 +15,10 @@ type UInt16 struct{}
 // If the input value is a string, it's assumed to be a transaction type or ledger entry type name, and the
 // method will attempt to convert it into a corresponding type code. If the conversion fails, an error is returned.
 func (u *UInt16) FromJSON(value any) ([]byte, error) {
-	if _, ok := value.(string); ok {
-		tc, err := definitions.Get().GetTransactionTypeCodeByTransactionTypeName(value.(string))
+	if s, ok := value.(string); ok {
+		tc, err := definitions.Get().GetTransactionTypeCodeByTransactionTypeName(s)
 		if err != nil {
-			tc, err = definitions.Get().GetLedgerEntryTypeCodeByLedgerEntryTypeName(value.(string))
+			tc, err = definitions.Get().GetLedgerEntryTypeCodeByLedgerEntryTypeName(s)
 			if err != nil {
 				return nil, err
 			}
@@ -43,14 +42,9 @@ func (u *UInt16) FromJSON(value any) ([]byte, error) {
 		val = uint16(value.(int)) // will panic with meaningful error
 	}
 
-	buf := new(bytes.Buffer)
-	//nolint:gosec // G115: Potential hardcoded credentials (gosec)
-	err := binary.Write(buf, binary.BigEndian, val)
-
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	var out [2]byte
+	binary.BigEndian.PutUint16(out[:], val)
+	return out[:], nil
 }
 
 // ToJSON takes a BinaryParser and optional parameters, and converts the serialized byte data

--- a/codec/binarycodec/types/uint32.go
+++ b/codec/binarycodec/types/uint32.go
@@ -2,7 +2,6 @@
 package types
 
 import (
-	"bytes"
 	"encoding/binary"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/types/interfaces"
@@ -30,13 +29,9 @@ func (u *UInt32) FromJSON(value any) ([]byte, error) {
 		val = value.(uint32) // will panic with meaningful error
 	}
 
-	buf := new(bytes.Buffer)
-	err := binary.Write(buf, binary.BigEndian, val)
-
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	var out [4]byte
+	binary.BigEndian.PutUint32(out[:], val)
+	return out[:], nil
 }
 
 // ToJSON takes a BinaryParser and optional parameters, and converts the serialized byte data

--- a/codec/binarycodec/types/uint64.go
+++ b/codec/binarycodec/types/uint64.go
@@ -2,10 +2,10 @@
 package types
 
 import (
-	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/types/interfaces"
@@ -23,35 +23,31 @@ var ErrInvalidUInt64String = errors.New("invalid UInt64 value")
 // (e.g. AssetPrice in OracleSet transactions).
 // If the serialization fails, an error is returned.
 func (u *UInt64) FromJSON(value any) ([]byte, error) {
-	var buf = new(bytes.Buffer)
-
-	var strVal string
+	var n uint64
 	switch v := value.(type) {
 	case string:
-		strVal = v
+		parsed, err := strconv.ParseUint(v, 16, 64)
+		if err != nil {
+			return nil, err
+		}
+		n = parsed
 	case float64:
-		strVal = fmt.Sprintf("%X", uint64(v))
+		n = uint64(v)
 	case int:
-		strVal = fmt.Sprintf("%X", uint64(v))
+		n = uint64(v)
 	case int64:
-		strVal = fmt.Sprintf("%X", uint64(v))
+		n = uint64(v)
 	case uint64:
-		strVal = fmt.Sprintf("%X", v)
+		n = v
 	case uint32:
-		strVal = fmt.Sprintf("%X", uint64(v))
+		n = uint64(v)
 	default:
 		return nil, ErrInvalidUInt64String
 	}
 
-	// Pad the hex string to 16 characters (8 bytes)
-	strVal = strings.Repeat("0", 16-len(strVal)) + strVal
-	decoded, err := hex.DecodeString(strVal)
-	if err != nil {
-		return nil, err
-	}
-	buf.Write(decoded)
-
-	return buf.Bytes(), nil
+	var out [8]byte
+	binary.BigEndian.PutUint64(out[:], n)
+	return out[:], nil
 }
 
 // ToJSON takes a BinaryParser and optional parameters, and converts the serialized byte data
@@ -63,7 +59,5 @@ func (u *UInt64) ToJSON(p interfaces.BinaryParser, _ ...int) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Convert to uppercase hex with zero padding to 16 characters
-	hexStr := strings.ToUpper(hex.EncodeToString(b))
-	return hexStr, nil
+	return strings.ToUpper(hex.EncodeToString(b)), nil
 }

--- a/codec/binarycodec/types/uint64_test.go
+++ b/codec/binarycodec/types/uint64_test.go
@@ -29,7 +29,7 @@ func TestUint64_FromJson(t *testing.T) {
 			name:        "fail - invalid hex string",
 			input:       "invalid",
 			expected:    nil,
-			expectedErr: errors.New("encoding/hex: invalid byte: U+0069 'i'"),
+			expectedErr: errors.New("strconv.ParseUint: parsing \"invalid\": invalid syntax"),
 		},
 		{
 			name:        "pass - valid uint64 numeric string",

--- a/codec/binarycodec/types/uint8.go
+++ b/codec/binarycodec/types/uint8.go
@@ -2,9 +2,6 @@
 package types
 
 import (
-	"bytes"
-	"encoding/binary"
-
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/types/interfaces"
 )
@@ -25,7 +22,6 @@ func (u *UInt8) FromJSON(value any) ([]byte, error) {
 	}
 
 	var intValue int
-
 	switch v := value.(type) {
 	case int:
 		intValue = v
@@ -39,13 +35,7 @@ func (u *UInt8) FromJSON(value any) ([]byte, error) {
 		intValue = int(v)
 	}
 
-	buf := new(bytes.Buffer)
-	// TODO: Check if this is still needed
-	err := binary.Write(buf, binary.BigEndian, byte(intValue))
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return []byte{byte(intValue)}, nil
 }
 
 // ToJSON takes a BinaryParser and optional parameters, and converts the serialized byte data

--- a/codec/binarycodec/types/vector256.go
+++ b/codec/binarycodec/types/vector256.go
@@ -59,14 +59,12 @@ func (v *Vector256) FromJSON(json any) ([]byte, error) {
 // vector256FromValue takes a slice of strings representing Hash256 values,
 // serializes them, and returns the combined byte slice. If an error occurs during serialization, it is returned.
 func vector256FromValue(value []string) ([]byte, error) {
-	b := make([]byte, 0)
+	b := make([]byte, 0, len(value)*HashLengthBytes)
 	for _, s := range value {
 		hash256, err := NewHash256().FromJSON(s)
-
 		if err != nil {
 			return nil, err
 		}
-
 		b = append(b, hash256...)
 	}
 	return b, nil
@@ -80,8 +78,7 @@ func (v *Vector256) ToJSON(p interfaces.BinaryParser, opts ...int) (any, error) 
 	if err != nil {
 		return nil, err
 	}
-	var value []string
-
+	value := make([]string, 0, len(b)/HashLengthBytes)
 	for i := 0; i < len(b); i += HashLengthBytes {
 		value = append(value, strings.ToUpper(hex.EncodeToString(b[i:i+HashLengthBytes])))
 	}

--- a/crypto/der.go
+++ b/crypto/der.go
@@ -3,9 +3,7 @@ package crypto
 import (
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"math/big"
-	"strings"
 )
 
 var (
@@ -22,86 +20,18 @@ var (
 	ErrLeftoverBytes = errors.New("invalid signature: left bytes after parsing")
 )
 
-// DERHexFromSig converts r and s hex strings to a DER-encoded signature hex string.
-// It returns the DER-encoded signature as a hex string and an error if any occurred during the process.
-func DERHexFromSig(rHex, sHex string) (string, error) {
-	// Helper function to add leading zero if first byte has negative bit enabled
-	slice := func(s string) string {
-		if len(s) > 0 && (s[0] >= '8' && s[0] <= 'f') {
-			return "00" + s
-		}
-		return s
-	}
-
-	// Helper function to ensure even-length hex string
-	ensureEven := func(s string) string {
-		if len(s)%2 != 0 {
-			return "0" + s
-		}
-		return s
-	}
-
-	// Convert hex strings to big.Int
-	r, ok := new(big.Int).SetString(rHex, 16)
-	if !ok {
-		return "", ErrInvalidHexString
-	}
-	s, ok := new(big.Int).SetString(sHex, 16)
-	if !ok {
-		return "", ErrInvalidHexString
-	}
-
-	// Convert r and s to sliced hex strings
-	rStr := slice(ensureEven(r.Text(16)))
-	sStr := slice(ensureEven(s.Text(16)))
-
-	rLen := len(rStr) / 2
-	sLen := len(sStr) / 2
-
-	// Convert lengths to hex
-	rLenHex := ensureEven(fmt.Sprintf("%x", rLen))
-	sLenHex := ensureEven(fmt.Sprintf("%x", sLen))
-
-	// Calculate total length
-	totalLen := rLen + sLen + 4
-	totalLenHex := ensureEven(fmt.Sprintf("%x", totalLen))
-
-	// Construct the final hex string
-	result := strings.Join([]string{
-		"30", totalLenHex,
-		"02", rLenHex, rStr,
-		"02", sLenHex, sStr,
-	}, "")
-
-	return result, nil
+// EncodeDERSignature builds the canonical DER encoding of an ECDSA signature
+// directly into a byte slice. The big.Int input form matches the existing
+// signing code paths; callers holding raw r/s byte slices can pass
+// new(big.Int).SetBytes(rBytes).
+func EncodeDERSignature(r, s *big.Int) []byte {
+	return encodeDERSignature(r, s)
 }
 
-// parseInt parses an integer from DER-encoded data.
-// It returns a *big.Int representing the parsed integer, a byte slice containing the remaining data after parsing,
-// and an error if any occurred during parsing.
-func parseInt(data []byte) (*big.Int, []byte, error) {
-	if len(data) < 2 {
-		return nil, nil, ErrInvalidDERNotEnoughData
-	}
-	if data[0] != 0x02 {
-		return nil, nil, ErrInvalidDERIntegerTag
-	}
-	length := int(data[1])
-	if len(data) < 2+length {
-		return nil, nil, ErrInvalidDERNotEnoughData
-	}
-	number := new(big.Int).SetBytes(data[2 : 2+length])
-	return number, data[2+length:], nil
-}
-
-// DERHexToSig converts a DER-encoded signature hex string to r and s byte slices.
-// It returns the r and s byte slices and an error if any occurred during the process.
-func DERHexToSig(hexSignature string) ([]byte, []byte, error) {
-	data, err := hex.DecodeString(hexSignature)
-	if err != nil {
-		return nil, nil, ErrInvalidHexString
-	}
-
+// DERSigToRS decodes a DER-encoded ECDSA signature into the underlying
+// r and s big-endian byte slices. Unlike [DERHexToSig], this avoids the
+// hex round-trip required for callers that already hold raw bytes.
+func DERSigToRS(data []byte) ([]byte, []byte, error) {
 	if len(data) < 2 || data[0] != 0x30 {
 		return nil, nil, ErrInvalidDERSignature
 	}
@@ -124,4 +54,50 @@ func DERHexToSig(hexSignature string) ([]byte, []byte, error) {
 	}
 
 	return r.Bytes(), s.Bytes(), nil
+}
+
+// DERHexFromSig converts r and s hex strings to a DER-encoded signature hex string.
+//
+// Deprecated: callers that already hold r/s as *big.Int or []byte should use
+// [EncodeDERSignature] directly to skip the hex round-trip.
+func DERHexFromSig(rHex, sHex string) (string, error) {
+	r, ok := new(big.Int).SetString(rHex, 16)
+	if !ok {
+		return "", ErrInvalidHexString
+	}
+	s, ok := new(big.Int).SetString(sHex, 16)
+	if !ok {
+		return "", ErrInvalidHexString
+	}
+	return hex.EncodeToString(encodeDERSignature(r, s)), nil
+}
+
+// parseInt parses an integer from DER-encoded data.
+// It returns a *big.Int representing the parsed integer, a byte slice containing the remaining data after parsing,
+// and an error if any occurred during parsing.
+func parseInt(data []byte) (*big.Int, []byte, error) {
+	if len(data) < 2 {
+		return nil, nil, ErrInvalidDERNotEnoughData
+	}
+	if data[0] != 0x02 {
+		return nil, nil, ErrInvalidDERIntegerTag
+	}
+	length := int(data[1])
+	if len(data) < 2+length {
+		return nil, nil, ErrInvalidDERNotEnoughData
+	}
+	number := new(big.Int).SetBytes(data[2 : 2+length])
+	return number, data[2+length:], nil
+}
+
+// DERHexToSig converts a DER-encoded signature hex string to r and s byte slices.
+//
+// Deprecated: prefer [DERSigToRS] when the signature is already in byte form
+// to avoid the hex round-trip.
+func DERHexToSig(hexSignature string) ([]byte, []byte, error) {
+	data, err := hex.DecodeString(hexSignature)
+	if err != nil {
+		return nil, nil, ErrInvalidHexString
+	}
+	return DERSigToRS(data)
 }

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -76,26 +76,28 @@ func (c ED25519CryptoAlgorithm) DeriveKeypair(decodedSeed []byte, validator bool
 	return private, public, nil
 }
 
-// SignBytes signs msg with the 32-byte seed extracted from privKey. privKey
-// may include the leading 0xED prefix byte (33 bytes) — the prefix is
-// stripped before generating the ed25519 key.
+// SignBytes signs msg with a 32-byte ed25519 seed. privKey must be exactly
+// 32 bytes; the leading 0xED prefix accepted by the hex Sign wrapper is
+// stripped there, not here. This mirrors secp256k1.SignBytes's 32-only
+// contract so callers reasoning about raw key buffers see a symmetric API.
 func (c ED25519CryptoAlgorithm) SignBytes(msg, privKey []byte) ([]byte, error) {
-	seed := privKey
-	if len(seed) == ed25519.SeedSize+1 && seed[0] == c.prefix {
-		seed = seed[1:]
-	}
-	if len(seed) != ed25519.SeedSize {
+	if len(privKey) != ed25519.SeedSize {
 		return nil, ErrInvalidPrivateKey
 	}
-	return ed25519.Sign(ed25519.NewKeyFromSeed(seed), msg), nil
+	return ed25519.Sign(ed25519.NewKeyFromSeed(privKey), msg), nil
 }
 
-// Sign signs msg with the hex-encoded ed25519 private seed (prefixed with
-// 0xED — i.e. 33 bytes = 66 hex chars). Output is uppercase hex.
+// Sign signs msg with the hex-encoded ed25519 private seed. Accepts either
+// the raw 32-byte seed (64 hex chars) or the 33-byte 0xED-prefixed form
+// (66 hex chars); the prefix is stripped before delegating to SignBytes.
+// Output is uppercase hex.
 func (c ED25519CryptoAlgorithm) Sign(msg, privKey string) (string, error) {
 	b, err := hex.DecodeString(privKey)
 	if err != nil {
 		return "", ErrInvalidPrivateKey
+	}
+	if len(b) == ed25519.SeedSize+1 && b[0] == c.prefix {
+		b = b[1:]
 	}
 	sig, err := c.SignBytes([]byte(msg), b)
 	if err != nil {

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -16,6 +16,11 @@ const (
 	ed25519Prefix byte = 0xED
 )
 
+// ed25519FamilySeedPrefixBytes is the three-byte family seed prefix for
+// ed25519 keys per XRPL's address codec. Callers must not mutate the slice
+// returned by FamilySeedPrefix.
+var ed25519FamilySeedPrefixBytes = []byte{0x01, 0xE1, 0x4B}
+
 var (
 	_ rootcrypto.Algorithm = &ED25519CryptoAlgorithm{}
 
@@ -23,18 +28,23 @@ var (
 	ErrValidatorNotSupported = errors.New("validator keypairs can not use Ed25519")
 	// ErrInvalidPrivateKey is returned when a private key is invalid
 	ErrInvalidPrivateKey = errors.New("invalid private key")
+	// ErrInvalidPublicKey is returned when a public key is the wrong length.
+	ErrInvalidPublicKey = errors.New("invalid public key")
+	// ErrInvalidSignature is returned when an ed25519 signature is not 64 bytes.
+	ErrInvalidSignature = errors.New("invalid signature")
 )
 
 // ED25519CryptoAlgorithm is the implementation of the ED25519 cryptographic algorithm.
 type ED25519CryptoAlgorithm struct {
 	prefix           byte
-	familySeedPrefix byte
+	familySeedPrefix []byte
 }
 
 // ED25519 returns the ED25519 cryptographic algorithm.
 func ED25519() ED25519CryptoAlgorithm {
 	return ED25519CryptoAlgorithm{
-		prefix: ed25519Prefix,
+		prefix:           ed25519Prefix,
+		familySeedPrefix: ed25519FamilySeedPrefixBytes,
 	}
 }
 
@@ -44,7 +54,8 @@ func (c ED25519CryptoAlgorithm) Prefix() byte {
 }
 
 // FamilySeedPrefix returns the family seed prefix for the ED25519 cryptographic algorithm.
-func (c ED25519CryptoAlgorithm) FamilySeedPrefix() byte {
+// The returned slice aliases shared package state; callers must not mutate it.
+func (c ED25519CryptoAlgorithm) FamilySeedPrefix() []byte {
 	return c.familySeedPrefix
 }
 
@@ -65,37 +76,55 @@ func (c ED25519CryptoAlgorithm) DeriveKeypair(decodedSeed []byte, validator bool
 	return private, public, nil
 }
 
+// SignBytes signs msg with the 32-byte seed extracted from privKey. privKey
+// may include the leading 0xED prefix byte (33 bytes) — the prefix is
+// stripped before generating the ed25519 key.
+func (c ED25519CryptoAlgorithm) SignBytes(msg, privKey []byte) ([]byte, error) {
+	seed := privKey
+	if len(seed) == ed25519.SeedSize+1 && seed[0] == c.prefix {
+		seed = seed[1:]
+	}
+	if len(seed) != ed25519.SeedSize {
+		return nil, ErrInvalidPrivateKey
+	}
+	return ed25519.Sign(ed25519.NewKeyFromSeed(seed), msg), nil
+}
+
+// Sign signs msg with the hex-encoded ed25519 private seed (prefixed with
+// 0xED — i.e. 33 bytes = 66 hex chars). Output is uppercase hex.
 func (c ED25519CryptoAlgorithm) Sign(msg, privKey string) (string, error) {
 	b, err := hex.DecodeString(privKey)
 	if err != nil {
+		return "", ErrInvalidPrivateKey
+	}
+	sig, err := c.SignBytes([]byte(msg), b)
+	if err != nil {
 		return "", err
 	}
-	rawPriv := ed25519.NewKeyFromSeed(b[1:])
-	signedMsg := ed25519.Sign(rawPriv, []byte(msg))
-	return strings.ToUpper(hex.EncodeToString(signedMsg)), nil
+	return strings.ToUpper(hex.EncodeToString(sig)), nil
 }
 
-// Validate validates a signature for a message with a public key.
+// ValidateBytes verifies sig over msg with pubKey (33 bytes: 0xED prefix +
+// 32 raw bytes).
+func (c ED25519CryptoAlgorithm) ValidateBytes(msg, pubKey, sig []byte) bool {
+	if len(pubKey) != 33 {
+		return false
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return false
+	}
+	return ed25519.Verify(ed25519.PublicKey(pubKey[1:]), msg, sig)
+}
+
+// Validate verifies a hex-encoded signature for a message with a public key.
 func (c ED25519CryptoAlgorithm) Validate(msg, pubkey, sig string) bool {
 	bp, err := hex.DecodeString(pubkey)
 	if err != nil {
 		return false
 	}
-
-	// Public key must be 33 bytes: 1-byte prefix + 32-byte ed25519 key
-	if len(bp) != 33 {
-		return false
-	}
-
 	bs, err := hex.DecodeString(sig)
 	if err != nil {
 		return false
 	}
-
-	// Ed25519 signatures must be exactly 64 bytes
-	if len(bs) != ed25519.SignatureSize {
-		return false
-	}
-
-	return ed25519.Verify(ed25519.PublicKey(bp[1:]), []byte(msg), bs)
+	return c.ValidateBytes([]byte(msg), bp, bs)
 }

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -7,14 +7,17 @@ import (
 )
 
 func TestED25519_Prefix(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, ed25519Prefix, ED25519().Prefix())
 }
 
 func TestED25519_FamilySeedPrefix(t *testing.T) {
-	require.Zero(t, ED25519().FamilySeedPrefix())
+	t.Parallel()
+	require.Equal(t, []byte{0x01, 0xE1, 0x4B}, ED25519().FamilySeedPrefix())
 }
 
 func TestED25519DeriveKeypair(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		name       string
 		seedBytes  []byte
@@ -43,6 +46,7 @@ func TestED25519DeriveKeypair(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			priv, pub, err := ED25519().DeriveKeypair(tc.seedBytes, tc.validator)
 			if tc.expErr != nil {
 				require.Zero(t, pub)
@@ -57,6 +61,7 @@ func TestED25519DeriveKeypair(t *testing.T) {
 }
 
 func TestED25519Sign(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		name         string
 		inputMsg     string
@@ -96,6 +101,7 @@ func TestED25519Sign(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			actual, err := ED25519().Sign(tc.inputMsg, tc.inputPrivKey)
 
 			if tc.expectedErr != nil {
@@ -110,6 +116,7 @@ func TestED25519Sign(t *testing.T) {
 }
 
 func TestED25519Validate(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		name        string
 		inputMsg    string
@@ -149,6 +156,7 @@ func TestED25519Validate(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			actual := ED25519().Validate(tc.inputMsg, tc.inputPubKey, tc.inputSig)
 			require.Equal(t, tc.expected, actual)
 		})

--- a/crypto/multisign.go
+++ b/crypto/multisign.go
@@ -52,12 +52,43 @@ const (
 	HashPrefixBatch HashPrefix = 0x42434800
 )
 
-// MultiSignPrefix is the raw bytes for the multi-sign hash prefix ("SMT\0").
-// This is the same value as HashPrefixTxMultiSign but as bytes.
-var MultiSignPrefix = []byte{0x53, 0x4D, 0x54, 0x00}
+// hashPrefixBytes caches the immutable 4-byte form of every known
+// HashPrefix so that Bytes() is allocation-free on the hot signing/hashing
+// path. The slices alias shared package state and must not be mutated.
+//
+// Note: the protocol package exposes the same XRPL hash-prefix constants
+// in [4]byte form (see protocol.HashPrefix*). They live in two packages
+// because protocol is the public, structural source of truth for the
+// protocol layer while crypto.HashPrefix is the internal uint32-encoded
+// form used by signing helpers in this package.
+var hashPrefixBytes = func() map[HashPrefix][]byte {
+	all := []HashPrefix{
+		HashPrefixTransactionID, HashPrefixTxNode, HashPrefixLeafNode,
+		HashPrefixInnerNode, HashPrefixLedgerMaster, HashPrefixTxSign,
+		HashPrefixTxMultiSign, HashPrefixValidation, HashPrefixProposal,
+		HashPrefixManifest, HashPrefixPaymentChannelClaim,
+		HashPrefixCredential, HashPrefixBatch,
+	}
+	m := make(map[HashPrefix][]byte, len(all))
+	for _, hp := range all {
+		b := make([]byte, 4)
+		binary.BigEndian.PutUint32(b, uint32(hp))
+		m[hp] = b
+	}
+	return m
+}()
 
-// Bytes returns the hash prefix as a 4-byte big-endian slice.
+// MultiSignPrefix is the raw bytes for the multi-sign hash prefix ("SMT\0").
+// This is the same value as HashPrefixTxMultiSign but as bytes. It aliases
+// shared package state and must not be mutated.
+var MultiSignPrefix = hashPrefixBytes[HashPrefixTxMultiSign]
+
+// Bytes returns the hash prefix as a 4-byte big-endian slice. The returned
+// slice aliases shared package state and must not be mutated.
 func (hp HashPrefix) Bytes() []byte {
+	if b, ok := hashPrefixBytes[hp]; ok {
+		return b
+	}
 	b := make([]byte, 4)
 	binary.BigEndian.PutUint32(b, uint32(hp))
 	return b

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -22,6 +22,10 @@ const (
 	secp256K1FamilySeedPrefix byte = 0x21
 )
 
+// secp256K1FamilySeedPrefixBytes is the byte-slice form returned by
+// FamilySeedPrefix. Callers must not mutate the returned slice.
+var secp256K1FamilySeedPrefixBytes = []byte{secp256K1FamilySeedPrefix}
+
 var (
 	_ rootcrypto.Algorithm = SECP256K1CryptoAlgorithm{}
 
@@ -38,14 +42,14 @@ var (
 // SECP256K1CryptoAlgorithm is the implementation of the SECP256K1 algorithm.
 type SECP256K1CryptoAlgorithm struct {
 	prefix           byte
-	familySeedPrefix byte
+	familySeedPrefix []byte
 }
 
 // SECP256K1 returns a new SECP256K1CryptoAlgorithm instance.
 func SECP256K1() SECP256K1CryptoAlgorithm {
 	return SECP256K1CryptoAlgorithm{
 		prefix:           secp256K1Prefix,
-		familySeedPrefix: secp256K1FamilySeedPrefix,
+		familySeedPrefix: secp256K1FamilySeedPrefixBytes,
 	}
 }
 
@@ -55,45 +59,64 @@ func (c SECP256K1CryptoAlgorithm) Prefix() byte {
 }
 
 // FamilySeedPrefix returns the family seed prefix for the SECP256K1 algorithm.
-func (c SECP256K1CryptoAlgorithm) FamilySeedPrefix() byte {
+// The returned slice aliases shared package state; callers must not mutate it.
+func (c SECP256K1CryptoAlgorithm) FamilySeedPrefix() []byte {
 	return c.familySeedPrefix
 }
 
-// deriveScalar derives a scalar from a seed.
-func (c SECP256K1CryptoAlgorithm) deriveScalar(bytes []byte, discrim *big.Int) *big.Int {
+// deriveScalar derives a scalar from a seed using the rippled "XRP Family
+// Generator" construction: SHA512(seed | optional discrim | i++) truncated to
+// 32 bytes, retrying until the result is in (0, n). The loop almost always
+// exits on the first iteration.
+func (c SECP256K1CryptoAlgorithm) deriveScalar(seed []byte, discrim *big.Int) *big.Int {
 	order := btcec.S256().N
-	for i := 0; i <= 0xffffffff; i++ {
-		hash := sha512.New()
+	hasher := sha512.New()
+	sum := make([]byte, 0, sha512.Size)
 
-		hash.Write(bytes)
+	var discrimWord uint32
+	var hasDiscrim bool
+	if discrim != nil {
+		discrimWord = uint32(discrim.Uint64())
+		hasDiscrim = true
+	}
 
-		if discrim != nil {
-			discrimBytes := make([]byte, 4)
-			discrimBytes[0] = byte(discrim.Uint64() >> 24)
-			discrimBytes[1] = byte(discrim.Uint64() >> 16)
-			discrimBytes[2] = byte(discrim.Uint64() >> 8)
-			discrimBytes[3] = byte(discrim.Uint64())
+	var tailBuf [8]byte
+	tail := tailBuf[:0]
+	if hasDiscrim {
+		tail = append(tail,
+			byte(discrimWord>>24),
+			byte(discrimWord>>16),
+			byte(discrimWord>>8),
+			byte(discrimWord),
+		)
+	}
+	tailLen := len(tail)
+	// Reserve four bytes for the loop counter.
+	tail = tail[:tailLen+4]
 
-			hash.Write(discrimBytes)
-		}
+	zero := big.NewInt(0)
+	key := new(big.Int)
 
-		shiftBytes := make([]byte, 4)
-		shiftBytes[0] = byte(i >> 24)
-		shiftBytes[1] = byte(i >> 16)
-		shiftBytes[2] = byte(i >> 8)
-		shiftBytes[3] = byte(i)
+	for i := uint32(0); i <= 0xffffffff; i++ {
+		tail[tailLen] = byte(i >> 24)
+		tail[tailLen+1] = byte(i >> 16)
+		tail[tailLen+2] = byte(i >> 8)
+		tail[tailLen+3] = byte(i)
 
-		hash.Write(shiftBytes)
+		hasher.Reset()
+		hasher.Write(seed)
+		hasher.Write(tail)
+		sum = hasher.Sum(sum[:0])
 
-		key := new(big.Int).SetBytes(hash.Sum(nil)[:32])
-
-		if key.Cmp(big.NewInt(0)) > 0 && key.Cmp(order) < 0 {
-			return key
+		key.SetBytes(sum[:32])
+		if key.Cmp(zero) > 0 && key.Cmp(order) < 0 {
+			// Return a fresh allocation so callers can mutate the result freely.
+			return new(big.Int).Set(key)
 		}
 	}
 	// This error is practically impossible to reach.
 	// The order of the curve describes the (finite) amount of points on the curve.
-	panic("impossible unicorn ;)")
+	panic("secp256k1.deriveScalar: exhausted all 2^32 candidates")
 }
 
 // DeriveKeypair derives a keypair from a seed.
@@ -131,15 +154,28 @@ func (c SECP256K1CryptoAlgorithm) DeriveKeypair(seed []byte, validator bool) (st
 	return "00" + private, strings.ToUpper(hex.EncodeToString(pubKeyBytes)), nil
 }
 
-// Sign signs a message with a private key.
+// SignBytes signs msg with a 32-byte raw secp256k1 private key and returns
+// the DER-encoded signature in bytes.
+func (c SECP256K1CryptoAlgorithm) SignBytes(msg, privKey []byte) ([]byte, error) {
+	if len(privKey) != 32 {
+		return nil, ErrInvalidPrivateKey
+	}
+	if len(msg) == 0 {
+		return nil, ErrInvalidMessage
+	}
+	secpPrivKey := secp256k1.PrivKeyFromBytes(privKey)
+	hash := common.Sha512Half(msg)
+	sig := ecdsa.Sign(secpPrivKey, hash[:])
+	return derFromRS(sig.R(), sig.S()), nil
+}
+
+// Sign signs a message with a private key (hex-encoded, optionally
+// 0x00-prefixed). The returned signature is the uppercase hex form of the
+// DER-encoded signature.
 func (c SECP256K1CryptoAlgorithm) Sign(msg, privKey string) (string, error) {
 	if len(privKey) != 64 && len(privKey) != 66 {
 		return "", ErrInvalidPrivateKey
 	}
-	if len(msg) == 0 {
-		return "", ErrInvalidMessage
-	}
-
 	if len(privKey) == 66 {
 		privKey = privKey[2:]
 	}
@@ -147,16 +183,11 @@ func (c SECP256K1CryptoAlgorithm) Sign(msg, privKey string) (string, error) {
 	if err != nil {
 		return "", ErrInvalidPrivateKey
 	}
-
-	secpPrivKey := secp256k1.PrivKeyFromBytes(key)
-	hash := common.Sha512Half([]byte(msg))
-	sig := ecdsa.Sign(secpPrivKey, hash[:])
-
-	parsedSig, err := rootcrypto.DERHexFromSig(sig.R().String(), sig.S().String())
+	sig, err := c.SignBytes([]byte(msg), key)
 	if err != nil {
 		return "", err
 	}
-	return strings.ToUpper(parsedSig), nil
+	return strings.ToUpper(hex.EncodeToString(sig)), nil
 }
 
 // SignDigest signs a pre-computed digest (hash) directly without re-hashing.
@@ -170,19 +201,9 @@ func (c SECP256K1CryptoAlgorithm) SignDigest(digest [32]byte, privKeyHex string)
 	if err != nil {
 		return nil, ErrInvalidPrivateKey
 	}
-
 	secpPrivKey := secp256k1.PrivKeyFromBytes(key)
 	sig := ecdsa.Sign(secpPrivKey, digest[:])
-
-	parsedSig, err := rootcrypto.DERHexFromSig(sig.R().String(), sig.S().String())
-	if err != nil {
-		return nil, err
-	}
-	sigBytes, err := hex.DecodeString(parsedSig)
-	if err != nil {
-		return nil, err
-	}
-	return sigBytes, nil
+	return derFromRS(sig.R(), sig.S()), nil
 }
 
 // Validate validates a signature for a message with a public key.
@@ -195,55 +216,62 @@ func (c SECP256K1CryptoAlgorithm) Validate(msg, pubkey, sig string) bool {
 // ValidateWithCanonicality validates a signature with optional canonicality checking.
 // If mustBeFullyCanonical is true, the signature must have S <= curve_order/2.
 func (c SECP256K1CryptoAlgorithm) ValidateWithCanonicality(msg, pubkey, sig string, mustBeFullyCanonical bool) bool {
-	// Decode the signature from hex
 	sigBytes, err := hex.DecodeString(sig)
 	if err != nil {
 		return false
 	}
+	pubkeyBytes, err := hex.DecodeString(pubkey)
+	if err != nil {
+		return false
+	}
+	return c.validateBytes([]byte(msg), pubkeyBytes, sigBytes, mustBeFullyCanonical, true)
+}
 
-	// Check signature canonicality
-	canonicality := rootcrypto.ECDSACanonicality(sigBytes)
+// ValidateBytes verifies a fully-canonical DER signature with a SHA-512Half-of-msg digest.
+func (c SECP256K1CryptoAlgorithm) ValidateBytes(msg, pubkey, sig []byte) bool {
+	return c.validateBytes(msg, pubkey, sig, true, true)
+}
+
+// validateBytes is the byte-level core used by Validate/ValidateBytes/ValidateDigest.
+// When hashMsg is true the message is SHA-512Half-hashed before verification;
+// otherwise msg is treated as a pre-computed 32-byte digest.
+func (c SECP256K1CryptoAlgorithm) validateBytes(msg, pubkey, sig []byte, mustBeFullyCanonical, hashMsg bool) bool {
+	canonicality := rootcrypto.ECDSACanonicality(sig)
 	if canonicality == rootcrypto.CanonicityNone {
 		return false
 	}
 	if mustBeFullyCanonical && canonicality != rootcrypto.CanonicityFullyCanonical {
 		return false
 	}
-
-	// Decode the signature from DERHex to r and s
-	r, s, err := rootcrypto.DERHexToSig(sig)
+	r, s, err := rootcrypto.DERSigToRS(sig)
 	if err != nil {
 		return false
 	}
-
-	// Convert r and s slices to [32]byte arrays
 	var rBytes, sBytes [32]byte
-
+	if len(r) > 32 || len(s) > 32 {
+		return false
+	}
 	copy(rBytes[32-len(r):], r)
 	copy(sBytes[32-len(s):], s)
-
 	ecdsaR := &secp256k1.ModNScalar{}
 	ecdsaS := &secp256k1.ModNScalar{}
-
 	ecdsaR.SetBytes(&rBytes)
 	ecdsaS.SetBytes(&sBytes)
-
 	parsedSig := ecdsa.NewSignature(ecdsaR, ecdsaS)
-	// Hash the message
-	hash := common.Sha512Half([]byte(msg))
-
-	// Decode the pubkey from hex to a byte slice
-	pubkeyBytes, err := hex.DecodeString(pubkey)
+	pubKey, err := secp256k1.ParsePubKey(pubkey)
 	if err != nil {
 		return false
 	}
-
-	// Verify the signature
-	pubKey, err := secp256k1.ParsePubKey(pubkeyBytes)
-	if err != nil {
-		return false
+	var digest [32]byte
+	if hashMsg {
+		digest = common.Sha512Half(msg)
+	} else {
+		if len(msg) != 32 {
+			return false
+		}
+		copy(digest[:], msg)
 	}
-	return parsedSig.Verify(hash[:], pubKey)
+	return parsedSig.Verify(digest[:], pubKey)
 }
 
 // ValidateDigest verifies a signature against a pre-computed digest (hash).
@@ -251,35 +279,7 @@ func (c SECP256K1CryptoAlgorithm) ValidateWithCanonicality(msg, pubkey, sig stri
 // Matches rippled's verifyDigest() which passes the SHA-512Half hash directly
 // to secp256k1_ecdsa_verify.
 func (c SECP256K1CryptoAlgorithm) ValidateDigest(digest [32]byte, pubkeyBytes []byte, sigBytes []byte) bool {
-	// Check signature canonicality
-	canonicality := rootcrypto.ECDSACanonicality(sigBytes)
-	if canonicality == rootcrypto.CanonicityNone {
-		return false
-	}
-
-	// Decode the signature from DER to r and s
-	sigHex := hex.EncodeToString(sigBytes)
-	r, s, err := rootcrypto.DERHexToSig(sigHex)
-	if err != nil {
-		return false
-	}
-
-	var rBytes, sBytes [32]byte
-	copy(rBytes[32-len(r):], r)
-	copy(sBytes[32-len(s):], s)
-
-	ecdsaR := &secp256k1.ModNScalar{}
-	ecdsaS := &secp256k1.ModNScalar{}
-	ecdsaR.SetBytes(&rBytes)
-	ecdsaS.SetBytes(&sBytes)
-
-	parsedSig := ecdsa.NewSignature(ecdsaR, ecdsaS)
-
-	pubKey, err := secp256k1.ParsePubKey(pubkeyBytes)
-	if err != nil {
-		return false
-	}
-	return parsedSig.Verify(digest[:], pubKey)
+	return c.validateBytes(digest[:], pubkeyBytes, sigBytes, false, false)
 }
 
 // DerivePublicKeyFromPublicGenerator derives a public key from a public generator.
@@ -323,32 +323,31 @@ func (c SECP256K1CryptoAlgorithm) DerivePublicKeyFromPublicGenerator(pubKey []by
 // SignCanonical signs a message and ensures the signature is fully canonical.
 // It automatically normalizes the S value if needed to produce a low-S signature.
 func (c SECP256K1CryptoAlgorithm) SignCanonical(msg, privKey string) (string, error) {
-	sig, err := c.Sign(msg, privKey)
+	if len(privKey) != 64 && len(privKey) != 66 {
+		return "", ErrInvalidPrivateKey
+	}
+	if len(privKey) == 66 {
+		privKey = privKey[2:]
+	}
+	key, err := hex.DecodeString(privKey)
+	if err != nil {
+		return "", ErrInvalidPrivateKey
+	}
+	sigBytes, err := c.SignBytes([]byte(msg), key)
 	if err != nil {
 		return "", err
 	}
-
-	// Check if signature is already fully canonical
-	sigBytes, err := hex.DecodeString(sig)
-	if err != nil {
-		return "", ErrInvalidSignature
-	}
-
 	canonicality := rootcrypto.ECDSACanonicality(sigBytes)
 	if canonicality == rootcrypto.CanonicityNone {
 		return "", ErrInvalidSignature
 	}
-	if canonicality == rootcrypto.CanonicityFullyCanonical {
-		return sig, nil
+	if canonicality != rootcrypto.CanonicityFullyCanonical {
+		sigBytes = rootcrypto.MakeSignatureCanonical(sigBytes)
+		if sigBytes == nil {
+			return "", ErrInvalidSignature
+		}
 	}
-
-	// Make the signature canonical
-	canonicalSig := rootcrypto.MakeSignatureCanonical(sigBytes)
-	if canonicalSig == nil {
-		return "", ErrInvalidSignature
-	}
-
-	return strings.ToUpper(hex.EncodeToString(canonicalSig)), nil
+	return strings.ToUpper(hex.EncodeToString(sigBytes)), nil
 }
 
 // DeriveValidatorKeypair derives a validator keypair from a seed.
@@ -374,4 +373,15 @@ func (c SECP256K1CryptoAlgorithm) DerivePublicKeyFromSecret(secret []byte) ([]by
 // This is a convenience function that calls DeriveKeypair with validator=false.
 func (c SECP256K1CryptoAlgorithm) DeriveAccountKeypair(seed []byte) (string, string, error) {
 	return c.DeriveKeypair(seed, false)
+}
+
+// derFromRS builds a DER-encoded signature directly from a decred ModNScalar
+// r/s pair. It avoids the string→hex→bytes round-trip done by DERHexFromSig.
+func derFromRS(r, s secp256k1.ModNScalar) []byte {
+	rBytes := r.Bytes()
+	sBytes := s.Bytes()
+	return rootcrypto.EncodeDERSignature(
+		new(big.Int).SetBytes(rBytes[:]),
+		new(big.Int).SetBytes(sBytes[:]),
+	)
 }

--- a/crypto/secp256k1/secp256k1_test.go
+++ b/crypto/secp256k1/secp256k1_test.go
@@ -8,14 +8,17 @@ import (
 )
 
 func TestSecp256k1_Prefix(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, secp256K1Prefix, SECP256K1().Prefix())
 }
 
 func TestSecp256k1_FamilySeedPrefix(t *testing.T) {
-	require.Equal(t, secp256K1FamilySeedPrefix, SECP256K1().FamilySeedPrefix())
+	t.Parallel()
+	require.Equal(t, []byte{secp256K1FamilySeedPrefix}, SECP256K1().FamilySeedPrefix())
 }
 
 func TestSecp256k1_deriveKeypair(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name            string
 		seedBytes       []byte
@@ -44,6 +47,7 @@ func TestSecp256k1_deriveKeypair(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			privKey, pubKey, err := SECP256K1().DeriveKeypair(tc.seedBytes, tc.validator)
 			if tc.expectedErr != nil {
 				require.Error(t, err, tc.expectedErr.Error())
@@ -57,6 +61,7 @@ func TestSecp256k1_deriveKeypair(t *testing.T) {
 }
 
 func TestSecp256k1_Sign(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name              string
 		message           string
@@ -152,6 +157,7 @@ func TestSecp256k1_Sign(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			signature, err := SECP256K1().Sign(tc.message, tc.privKey)
 			if tc.wantErr {
 				require.Error(t, err)
@@ -164,6 +170,7 @@ func TestSecp256k1_Sign(t *testing.T) {
 }
 
 func TestSecp256k1_Validate(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name      string
 		message   string
@@ -217,6 +224,7 @@ func TestSecp256k1_Validate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			isValid := SECP256K1().Validate(tc.message, tc.pubKey, tc.signature)
 			require.Equal(t, tc.wantValid, isValid)
 		})
@@ -224,6 +232,7 @@ func TestSecp256k1_Validate(t *testing.T) {
 }
 
 func TestSecp256k1_DerivePublicKeyFromPublicGenerator(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name        string
 		inputPubKey []byte
@@ -246,6 +255,7 @@ func TestSecp256k1_DerivePublicKeyFromPublicGenerator(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			actual, err := SECP256K1().DerivePublicKeyFromPublicGenerator(tc.inputPubKey)
 			if tc.expectedErr != nil {
 				require.Error(t, err, tc.expectedErr.Error())

--- a/crypto/secure_erase.go
+++ b/crypto/secure_erase.go
@@ -6,17 +6,19 @@ import (
 
 // SecureErase overwrites the contents of a byte slice with zeros.
 //
-// Note: Despite this, remnants of the data may remain in memory, caches,
-// registers, or swap space. For highly sensitive data, consider using
-// hardware security modules or other specialized solutions.
+// The implementation is a plain Go loop followed by runtime.KeepAlive(b). The
+// KeepAlive prevents the compiler from dropping the backing array before the
+// stores complete, but it does not stop the optimiser from eliding stores it
+// can prove are dead. Treat this as best-effort scrubbing: it is comparable
+// in strength to the standard library's clear(b) (Go 1.21+) and weaker than
+// platform primitives like memset_s / RtlSecureZeroMemory. Remnants may
+// remain in caches, registers, or swap space.
 //
 // See: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
 func SecureErase(b []byte) {
 	for i := range b {
 		b[i] = 0
 	}
-	// Keep the backing array alive across the zero-loop to prevent the
-	// compiler from coalescing the stores with later out-of-scope drops.
 	runtime.KeepAlive(b)
 }
 

--- a/crypto/secure_erase.go
+++ b/crypto/secure_erase.go
@@ -2,46 +2,22 @@ package crypto
 
 import (
 	"runtime"
-	"sync/atomic"
-	"unsafe"
 )
 
-// secureEraseNoop is a variable that prevents the compiler from optimizing away
-// the memory clearing operation. By using it in a way that appears to have
-// side effects, the compiler must keep the clearing code.
-var secureEraseNoop atomic.Uint64
-
 // SecureErase overwrites the contents of a byte slice with zeros.
-// It takes pains to prevent the compiler from optimizing away the clearing.
 //
-// Note: Despite these measures, remnants of the data may remain in memory,
-// caches, registers, or swap space. For highly sensitive data, consider
-// using hardware security modules or other specialized solutions.
+// Note: Despite this, remnants of the data may remain in memory, caches,
+// registers, or swap space. For highly sensitive data, consider using
+// hardware security modules or other specialized solutions.
 //
 // See: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
 func SecureErase(b []byte) {
-	if len(b) == 0 {
-		return
+	for i := range b {
+		b[i] = 0
 	}
-
-	// Use a volatile-like approach: write zeros through a pointer
-	// that the compiler cannot prove is not aliased elsewhere.
-	p := (*byte)(unsafe.Pointer(&b[0]))
-	for i := 0; i < len(b); i++ {
-		*(*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + uintptr(i))) = 0
-	}
-
-	// Memory barrier to ensure writes are visible
+	// Keep the backing array alive across the zero-loop to prevent the
+	// compiler from coalescing the stores with later out-of-scope drops.
 	runtime.KeepAlive(b)
-
-	// Touch the data in a way that prevents optimization
-	// This adds a value from the cleared buffer to the atomic counter,
-	// forcing the compiler to believe the buffer contents matter.
-	var sum uint64
-	for i := 0; i < len(b); i++ {
-		sum += uint64(b[i])
-	}
-	secureEraseNoop.Add(sum)
 }
 
 // SecretKey wraps a secret key byte slice and provides secure erasure on close.

--- a/crypto/types.go
+++ b/crypto/types.go
@@ -1,9 +1,21 @@
 package crypto
 
+// Algorithm describes a public-key signature scheme supported by the XRPL.
 type Algorithm interface {
 	Prefix() byte
 	// FamilySeedPrefix returns the byte sequence prepended to a 16-byte family
-	// seed entropy before base58check encoding. For secp256k1 this is a single
-	// byte (0x21); for ed25519 it is a three-byte sequence (0x01, 0xE1, 0x4B).
+	// seed entropy before base58check encoding.
+	//
+	// secp256k1 returns rippled's TokenType::FamilySeed (0x21), matching
+	// rippled/include/xrpl/protocol/tokens.h and producing seeds that start
+	// with 's'. ed25519 returns the three-byte sequence {0x01, 0xE1, 0x4B},
+	// which is an XRPL ecosystem convention defined by ripple-keypairs and
+	// adopted by xrpl.js / xrpl-py — it produces seeds that start with 'sEd'
+	// and lets DecodeSeed recover the algorithm from the encoded string.
+	// Rippled itself stores seeds algorithm-agnostically and always uses
+	// TokenType::FamilySeed=0x21 (rippled/src/libxrpl/protocol/Seed.cpp);
+	// the multi-byte ed25519 prefix is layered on top by client libraries.
+	//
+	// Callers MUST NOT mutate the returned slice.
 	FamilySeedPrefix() []byte
 }

--- a/crypto/types.go
+++ b/crypto/types.go
@@ -2,5 +2,8 @@ package crypto
 
 type Algorithm interface {
 	Prefix() byte
-	FamilySeedPrefix() byte
+	// FamilySeedPrefix returns the byte sequence prepended to a 16-byte family
+	// seed entropy before base58check encoding. For secp256k1 this is a single
+	// byte (0x21); for ed25519 it is a three-byte sequence (0x01, 0xE1, 0x4B).
+	FamilySeedPrefix() []byte
 }

--- a/drops/xrp_amount.go
+++ b/drops/xrp_amount.go
@@ -11,7 +11,6 @@ import (
 // protocol caps a single XRPAmount at 10^17 drops, well within int64 range.
 type XRPAmount int64
 
-// DropsPerXRP is the number of drops in one XRP (10^6).
 const DropsPerXRP XRPAmount = 1_000_000
 
 // MaxDrops is the protocol-level maximum positive value of an XRPAmount.
@@ -26,7 +25,6 @@ var ErrXRPAmountOverflow = errors.New("XRPAmount overflow")
 // ErrInvalidDecimalXRP is returned by FromDecimalXRP for NaN/Inf inputs.
 var ErrInvalidDecimalXRP = errors.New("invalid decimal XRP value (NaN or Inf)")
 
-// NewXRPAmount returns an XRPAmount from raw drops.
 func NewXRPAmount(drops int64) XRPAmount {
 	return XRPAmount(drops)
 }
@@ -141,7 +139,6 @@ func (x XRPAmount) IsZero() bool {
 	return x == 0
 }
 
-// String returns the decimal-drops representation of x.
 func (x XRPAmount) String() string {
 	return strconv.FormatInt(int64(x), 10)
 }

--- a/drops/xrp_amount.go
+++ b/drops/xrp_amount.go
@@ -1,17 +1,47 @@
 package drops
 
-import "fmt"
+import (
+	"errors"
+	"math"
+	"math/bits"
+	"strconv"
+)
 
+// XRPAmount is a signed amount of drops (1 XRP = 1e6 drops). The XRPL
+// protocol caps a single XRPAmount at 10^17 drops, well within int64 range.
 type XRPAmount int64
 
+// DropsPerXRP is the number of drops in one XRP (10^6).
 const DropsPerXRP XRPAmount = 1_000_000
 
+// MaxDrops is the protocol-level maximum positive value of an XRPAmount.
+// Mirrors rippled's `SYSTEM_CURRENCY_PARTS * 100_000_000_000`.
+const MaxDrops XRPAmount = 100_000_000_000_000_000
+
+// ErrXRPAmountOverflow is returned when a checked operation would push the
+// result outside [-MaxDrops, MaxDrops]. Unchecked arithmetic (Add/Sub/Mul)
+// panics with this error wrapped in a string.
+var ErrXRPAmountOverflow = errors.New("XRPAmount overflow")
+
+// ErrInvalidDecimalXRP is returned by FromDecimalXRP for NaN/Inf inputs.
+var ErrInvalidDecimalXRP = errors.New("invalid decimal XRP value (NaN or Inf)")
+
+// NewXRPAmount returns an XRPAmount from raw drops.
 func NewXRPAmount(drops int64) XRPAmount {
 	return XRPAmount(drops)
 }
 
-func FromDecimalXRP(xrp float64) XRPAmount {
-	return XRPAmount(xrp * float64(DropsPerXRP))
+// FromDecimalXRP converts a decimal XRP value to drops. It returns an error
+// rather than producing a silently truncated amount for NaN/Inf input.
+func FromDecimalXRP(xrp float64) (XRPAmount, error) {
+	if math.IsNaN(xrp) || math.IsInf(xrp, 0) {
+		return 0, ErrInvalidDecimalXRP
+	}
+	scaled := xrp * float64(DropsPerXRP)
+	if scaled > float64(math.MaxInt64) || scaled < float64(math.MinInt64) {
+		return 0, ErrXRPAmountOverflow
+	}
+	return XRPAmount(scaled), nil
 }
 
 func (x XRPAmount) Drops() int64 {
@@ -22,16 +52,85 @@ func (x XRPAmount) DecimalXRP() float64 {
 	return float64(x) / float64(DropsPerXRP)
 }
 
+// Add returns x+other. It panics on int64 overflow.
 func (x XRPAmount) Add(other XRPAmount) XRPAmount {
-	return x + other
+	out, err := x.AddChecked(other)
+	if err != nil {
+		panic("drops: " + err.Error())
+	}
+	return out
 }
 
+// AddChecked returns x+other and an error on int64 overflow.
+func (x XRPAmount) AddChecked(other XRPAmount) (XRPAmount, error) {
+	r := int64(x) + int64(other)
+	if (int64(other) > 0 && r < int64(x)) || (int64(other) < 0 && r > int64(x)) {
+		return 0, ErrXRPAmountOverflow
+	}
+	return XRPAmount(r), nil
+}
+
+// Sub returns x-other. It panics on int64 overflow.
 func (x XRPAmount) Sub(other XRPAmount) XRPAmount {
-	return x - other
+	out, err := x.SubChecked(other)
+	if err != nil {
+		panic("drops: " + err.Error())
+	}
+	return out
 }
 
+// SubChecked returns x-other and an error on int64 overflow.
+func (x XRPAmount) SubChecked(other XRPAmount) (XRPAmount, error) {
+	r := int64(x) - int64(other)
+	if (int64(other) > 0 && r > int64(x)) || (int64(other) < 0 && r < int64(x)) {
+		return 0, ErrXRPAmountOverflow
+	}
+	return XRPAmount(r), nil
+}
+
+// Mul returns x*factor. It panics on int64 overflow rather than silently
+// wrapping. Callers that can tolerate the overflow as an error should use
+// MulChecked.
 func (x XRPAmount) Mul(factor int64) XRPAmount {
-	return x * XRPAmount(factor)
+	out, err := x.MulChecked(factor)
+	if err != nil {
+		panic("drops: " + err.Error())
+	}
+	return out
+}
+
+// MulChecked returns x*factor and an error on int64 overflow.
+func (x XRPAmount) MulChecked(factor int64) (XRPAmount, error) {
+	if factor == 0 || int64(x) == 0 {
+		return 0, nil
+	}
+	// Convert to absolute uint64 multiplication, then range-check.
+	var sign int = 1
+	a := int64(x)
+	b := factor
+	if a < 0 {
+		sign = -sign
+		a = -a
+	}
+	if b < 0 {
+		sign = -sign
+		b = -b
+	}
+	hi, lo := bits.Mul64(uint64(a), uint64(b))
+	if hi != 0 {
+		return 0, ErrXRPAmountOverflow
+	}
+	if sign > 0 {
+		if lo > math.MaxInt64 {
+			return 0, ErrXRPAmountOverflow
+		}
+		return XRPAmount(lo), nil
+	}
+	// Negative result: -MinInt64 == MaxInt64+1 is allowed.
+	if lo > uint64(math.MaxInt64)+1 {
+		return 0, ErrXRPAmountOverflow
+	}
+	return XRPAmount(-int64(lo)), nil
 }
 
 func (x XRPAmount) IsPositive() bool {
@@ -42,6 +141,7 @@ func (x XRPAmount) IsZero() bool {
 	return x == 0
 }
 
+// String returns the decimal-drops representation of x.
 func (x XRPAmount) String() string {
-	return fmt.Sprintf("%d", int64(x))
+	return strconv.FormatInt(int64(x), 10)
 }

--- a/drops/xrp_amount_test.go
+++ b/drops/xrp_amount_test.go
@@ -1,0 +1,70 @@
+package drops
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestXRPAmount_String(t *testing.T) {
+	require.Equal(t, "123456", NewXRPAmount(123456).String())
+	require.Equal(t, "-1", NewXRPAmount(-1).String())
+	require.Equal(t, "0", NewXRPAmount(0).String())
+}
+
+func TestXRPAmount_AddOverflow(t *testing.T) {
+	max := XRPAmount(math.MaxInt64)
+	_, err := max.AddChecked(1)
+	require.ErrorIs(t, err, ErrXRPAmountOverflow)
+	require.Panics(t, func() { max.Add(1) })
+
+	min := XRPAmount(math.MinInt64)
+	_, err = min.AddChecked(-1)
+	require.ErrorIs(t, err, ErrXRPAmountOverflow)
+}
+
+func TestXRPAmount_SubOverflow(t *testing.T) {
+	min := XRPAmount(math.MinInt64)
+	_, err := min.SubChecked(1)
+	require.ErrorIs(t, err, ErrXRPAmountOverflow)
+
+	max := XRPAmount(math.MaxInt64)
+	_, err = max.SubChecked(-1)
+	require.ErrorIs(t, err, ErrXRPAmountOverflow)
+}
+
+func TestXRPAmount_MulOverflow(t *testing.T) {
+	// 1e10 * 1e10 = 1e20 overflows int64 (~9.2e18).
+	_, err := XRPAmount(1e10).MulChecked(1e10)
+	require.ErrorIs(t, err, ErrXRPAmountOverflow)
+	require.Panics(t, func() { _ = XRPAmount(1e10).Mul(1e10) })
+
+	// Sign handling: MinInt64 * 1 must work.
+	got, err := XRPAmount(math.MinInt64).MulChecked(1)
+	require.NoError(t, err)
+	require.Equal(t, XRPAmount(math.MinInt64), got)
+
+	// MinInt64 * -1 would equal MaxInt64+1 → must overflow.
+	_, err = XRPAmount(math.MinInt64).MulChecked(-1)
+	require.ErrorIs(t, err, ErrXRPAmountOverflow)
+}
+
+func TestXRPAmount_MulZero(t *testing.T) {
+	got, err := XRPAmount(123).MulChecked(0)
+	require.NoError(t, err)
+	require.Zero(t, got)
+}
+
+func TestFromDecimalXRP_Bounds(t *testing.T) {
+	_, err := FromDecimalXRP(math.NaN())
+	require.ErrorIs(t, err, ErrInvalidDecimalXRP)
+	_, err = FromDecimalXRP(math.Inf(1))
+	require.ErrorIs(t, err, ErrInvalidDecimalXRP)
+	_, err = FromDecimalXRP(math.MaxFloat64)
+	require.ErrorIs(t, err, ErrXRPAmountOverflow)
+
+	got, err := FromDecimalXRP(1.5)
+	require.NoError(t, err)
+	require.Equal(t, XRPAmount(1_500_000), got)
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.2
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/lib/pq v1.10.9
@@ -18,7 +19,6 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	github.com/syndtr/goleveldb v1.0.0
-	github.com/ugorji/go/codec v1.2.12
 	golang.org/x/sync v0.18.0
 	google.golang.org/grpc v1.78.0
 	modernc.org/sqlite v1.46.1
@@ -27,7 +27,6 @@ require (
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,6 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
-github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
-github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
## Summary

Addresses every finding in #429: three correctness bugs, the twelve P1 perf / API-hygiene items, and the twelve P2 cleanups.

### Correctness (P0)
- `codec/binarycodec/serdes.BinaryParser.ReadBytes` is a single `make+copy` slice-and-advance instead of a per-byte append loop on every decode.
- `crypto/ed25519.FamilySeedPrefix()` returns the correct three-byte XRPL prefix `0x01, 0xE1, 0x4B`. The `Algorithm` interface widens to `[]byte` so both algorithms can be honest; `addresscodec.EncodeSeed` dispatches through the interface.
- `codec/addresscodec.Base58CheckDecode` uses `crypto/subtle.ConstantTimeCompare` for the checksum equality.

### Performance / API hygiene (P1)
- `codec/binarycodec/types/amount.go`: regex compilation moved to package level for all four hot-path sites; the final `append(append(...))` is replaced with a pre-sized buffer.
- `codec/binarycodec/serdes`: new `DefaultFieldIDCodec()` singleton — STArray / STObject / production Encode/Decode no longer allocate a fresh codec per element.
- `codec/binarycodec/definitions`: ugorji codec dropped in favor of `encoding/json` with a typed `UnmarshalJSON` on `fieldInstanceMap`; `O(1)` reverse maps replace the four linear-scan helpers.
- `codec/binarycodec.Encode` / `EncodeForMultisigning` no longer mutate the caller's JSON map; unknown field names return `ErrUnknownField` instead of being silently dropped.
- `codec/binarycodec/types/st_object.createFieldInstanceMapFromJson`: fast path for the common no-X-address case skips the unconditional pre-copy of the JSON map.
- `codec/binarycodec/types`: `UInt8/16/32/64.FromJSON` encode into stack arrays instead of `bytes.Buffer + binary.Write`; UInt64 drops the `strings.Repeat` hex padding.
- `crypto/secp256k1.deriveScalar`: hoist `discrim.Uint64()` out of the loop, reuse one `sha512.Hash` via `Reset`, pre-size the tail buffer.
- `crypto/{ed25519,secp256k1}`: new `SignBytes` / `ValidateBytes` `[]byte` APIs; the existing hex `Sign` / `Validate` wrap them.
- `crypto`: new `EncodeDERSignature` / `DERSigToRS` drop the hex round-trip from secp256k1 signing/validation paths. `DERHexFromSig` / `DERHexToSig` kept as deprecated thin wrappers.
- `codec/binarycodec/types/pathset`: `newPathStep` / `newPath` / `newPathSet` now propagate decode errors (no silent `_, _, _ :=` drops) and preallocate based on the path-step upper bound.

### Cleanups (P2)
- `drops.XRPAmount`: `Add/Sub/Mul` panic on int64 overflow; `Add/Sub/MulChecked` siblings return `ErrXRPAmountOverflow`. `FromDecimalXRP` rejects NaN/Inf; `String()` uses `strconv`.
- `crypto.HashPrefix.Bytes()` returns slices from an immutable cache table; `MultiSignPrefix` shares the same backing slice; documents the relationship with `protocol.HashPrefix`.
- `codec/binarycodec/types/currency.ToJSON`: ISO-code detection rewritten to be readable.
- `codec/binarycodec/types/vector256`: preallocate `FromJSON` / `ToJSON` slices.
- `codec/binarycodec/types/number.formatScientific`: collapse the identical branches.
- `codec/addresscodec.Sha256RipeMD160`: stop shadowing the imported package names.
- `crypto.SecureErase`: simple zero loop + `runtime.KeepAlive`; the `unsafe.Pointer` + atomic-noop scaffolding is gone.
- `codec/binarycodec/codec_test`, `crypto/{ed25519,secp256k1}`: leaf tests now `t.Parallel()`.

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 ./codec/... ./crypto/... ./drops/... ./protocol/... ./shamap/... ./keylet/... ./ledger/entry/...`
- [x] `go test -count=1 ./internal/tx/...`
- [x] `go test -count=1 ./internal/rpc/... ./internal/ledger/... ./internal/txq/... ./internal/consensus/...`
- [x] `go test -count=1 -short ./internal/testing/...` (the full integration suite, including the 143s offer suite)
- [x] New regression tests added: `BinaryParser.ReadBytes` non-aliasing & zero-length behavior; full `XRPAmount` overflow coverage; updated `FamilySeedPrefix` assertions for both algorithms.

Fixes #429