### PR TITLE
fix: engine state & registration hygiene

### DIFF
--- a/internal/tx/apply.go
+++ b/internal/tx/apply.go
@@ -272,8 +272,7 @@ func (e *Engine) Apply(tx Transaction) ApplyResult {
 	// Record fee as destroyed and assign TransactionIndex
 	if applied {
 		e.view.AdjustDropsDestroyed(drops.XRPAmount(fee))
-		metadata.TransactionIndex = e.txCount
-		e.txCount++
+		metadata.TransactionIndex = e.txCount.Add(1) - 1
 	}
 
 	e.logger.Debug("apply result",
@@ -364,8 +363,7 @@ func (e *Engine) applyPseudoTransaction(tx Transaction) ApplyResult {
 
 	// Assign TransactionIndex for applied pseudo-transactions
 	if result.IsApplied() {
-		metadata.TransactionIndex = e.txCount
-		e.txCount++
+		metadata.TransactionIndex = e.txCount.Add(1) - 1
 	}
 
 	return ApplyResult{

--- a/internal/tx/do_apply.go
+++ b/internal/tx/do_apply.go
@@ -31,9 +31,6 @@ type applyState struct {
 // For tec results, only fee/sequence changes are applied; transaction effects are discarded.
 // Reference: rippled Transactor.cpp - tec results claim fee but don't apply effects
 func (e *Engine) doApply(tx Transaction, metadata *Metadata, txHash [32]byte) Result {
-	// Store txHash for use by apply functions
-	e.currentTxHash = txHash
-
 	common := tx.GetCommon()
 	accountID, _ := state.DecodeAccountID(common.Account)
 	accountKey := keylet.Account(accountID)

--- a/internal/tx/engine.go
+++ b/internal/tx/engine.go
@@ -2,6 +2,7 @@ package tx
 
 import (
 	"encoding/hex"
+	"sync/atomic"
 
 	"github.com/LeJamon/goXRPLd/amendment"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
@@ -36,7 +37,14 @@ const (
 	QualityOne = protocol.QualityOne
 )
 
-// Engine processes transactions against a ledger
+// Engine processes transactions against a ledger.
+//
+// Engine instances are NOT safe for concurrent Apply/ApplyPseudo calls. A
+// single Engine is meant to drive a single open ledger's transaction stream
+// in order (matching rippled's OpenView, which is also single-writer). The
+// only field that may be touched off-thread is txCount (read via TxCount,
+// reset via SetBaseTxCount), which is atomic to make those accessors safe
+// for observers — it is not a license to call Apply concurrently.
 type Engine struct {
 	// View provides access to ledger state
 	view LedgerView
@@ -48,15 +56,11 @@ type Engine struct {
 	// Always non-nil; falls back to xrpllog.Discard() when not configured.
 	logger xrpllog.Logger
 
-	// currentTxHash is the hash of the transaction currently being applied
-	// Used to set PreviousTxnID on modified ledger entries
-	currentTxHash [32]byte
-
 	// txCount tracks the number of applied transactions for TransactionIndex.
 	// Each applied transaction (tesSUCCESS or tec) gets the current count as
 	// its TransactionIndex, then the counter increments.
 	// Reference: rippled OpenView::txCount() = baseTxCount_ + txs_.size()
-	txCount uint32
+	txCount atomic.Uint32
 }
 
 // ApplyFlags controls transaction application behavior during consensus.
@@ -224,7 +228,7 @@ func (e *Engine) rules() *amendment.Rules {
 // TxCount returns the current transaction count (for batch baseTxCount).
 // Reference: rippled OpenView::txCount()
 func (e *Engine) TxCount() uint32 {
-	return e.txCount
+	return e.txCount.Load()
 }
 
 // Preclaim runs the full preclaim pipeline against the engine's view
@@ -239,7 +243,7 @@ func (e *Engine) Preclaim(tx Transaction, txHash [32]byte) Result {
 // Inner transactions start numbering from this value.
 // Reference: rippled OpenView::baseTxCount_ initialized from parent view
 func (e *Engine) SetBaseTxCount(count uint32) {
-	e.txCount = count
+	e.txCount.Store(count)
 }
 
 // ComputeTransactionHash computes the hash of a transaction.

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -268,7 +268,6 @@ func parseValidationError(err error) Result {
 	msg := err.Error()
 	for code, result := range validationErrorPrefixes {
 		if len(msg) >= len(code) && msg[:len(code)] == code {
-			// Code must be followed by ':', ' ', or end-of-string
 			if len(msg) == len(code) || msg[len(code)] == ':' || msg[len(code)] == ' ' {
 				return result
 			}

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -196,6 +196,64 @@ func (e *Engine) verifySignatures(tx Transaction) Result {
 	return TesSUCCESS
 }
 
+// validationErrorPrefixes maps the legacy "code: message" prefix used by
+// unmigrated callers back to the typed Result. Built once at package init —
+// parseValidationError runs on every preflight error, so rebuilding a
+// 50-entry map per call was pure waste. New code should use tx.Errorf to
+// carry the Result through a *ResultError instead of via string prefixes.
+var validationErrorPrefixes = map[string]Result{
+	// tem (malformed) codes
+	"temMALFORMED":                TemMALFORMED,
+	"temBAD_AMOUNT":               TemBAD_AMOUNT,
+	"temBAD_CURRENCY":             TemBAD_CURRENCY,
+	"temBAD_EXPIRATION":           TemBAD_EXPIRATION,
+	"temBAD_FEE":                  TemBAD_FEE,
+	"temBAD_ISSUER":               TemBAD_ISSUER,
+	"temBAD_LIMIT":                TemBAD_LIMIT,
+	"temBAD_OFFER":                TemBAD_OFFER,
+	"temBAD_PATH":                 TemBAD_PATH,
+	"temBAD_PATH_LOOP":            TemBAD_PATH_LOOP,
+	"temBAD_REGKEY":               TemBAD_REGKEY,
+	"temBAD_SEQUENCE":             TemBAD_SEQUENCE,
+	"temBAD_SIGNATURE":            TemBAD_SIGNATURE,
+	"temBAD_SRC_ACCOUNT":          TemBAD_SRC_ACCOUNT,
+	"temBAD_TRANSFER_RATE":        TemBAD_TRANSFER_RATE,
+	"temDST_IS_SRC":               TemDST_IS_SRC,
+	"temDST_NEEDED":               TemDST_NEEDED,
+	"temINVALID":                  TemINVALID,
+	"temINVALID_FLAG":             TemINVALID_FLAG,
+	"temREDUNDANT":                TemREDUNDANT,
+	"temRIPPLE_EMPTY":             TemRIPPLE_EMPTY,
+	"temDISABLED":                 TemDISABLED,
+	"temBAD_SIGNER":               TemBAD_SIGNER,
+	"temBAD_QUORUM":               TemBAD_QUORUM,
+	"temBAD_WEIGHT":               TemBAD_WEIGHT,
+	"temBAD_TICK_SIZE":            TemBAD_TICK_SIZE,
+	"temINVALID_ACCOUNT_ID":       TemINVALID_ACCOUNT_ID,
+	"temUNCERTAIN":                TemUNCERTAIN,
+	"temUNKNOWN":                  TemUNKNOWN,
+	"temSEQ_AND_TICKET":           TemSEQ_AND_TICKET,
+	"temBAD_SEND_XRP_MAX":         TemBAD_SEND_XRP_MAX,
+	"temBAD_SEND_XRP_PARTIAL":     TemBAD_SEND_XRP_PARTIAL,
+	"temBAD_SEND_XRP_PATHS":       TemBAD_SEND_XRP_PATHS,
+	"temBAD_SEND_XRP_LIMIT":       TemBAD_SEND_XRP_LIMIT,
+	"temBAD_SEND_XRP_NO_DIRECT":   TemBAD_SEND_XRP_NO_DIRECT,
+	"temCANNOT_PREAUTH_SELF":      TemCAN_NOT_PREAUTH_SELF,
+	"temCAN_NOT_PREAUTH_SELF":     TemCAN_NOT_PREAUTH_SELF,
+	"temEMPTY_DID":                TemEMPTY_DID,
+	"temARRAY_EMPTY":              TemARRAY_EMPTY,
+	"temARRAY_TOO_LARGE":          TemARRAY_TOO_LARGE,
+	"temBAD_AMM_TOKENS":           TemBAD_AMM_TOKENS,
+	"temBAD_TRANSFER_FEE":         TemBAD_TRANSFER_FEE,
+	"temBAD_NFTOKEN_TRANSFER_FEE": TemBAD_NFTOKEN_TRANSFER_FEE,
+	"temINVALID_COUNT":            TemINVALID_COUNT,
+	// tef (failure) codes
+	"tefINVALID_LEDGER_FIX_TYPE": TefINVALID_LEDGER_FIX_TYPE,
+	// tel (local) codes
+	"telBAD_DOMAIN":     TelBAD_DOMAIN,
+	"telBAD_PUBLIC_KEY": TelBAD_PUBLIC_KEY,
+}
+
 // parseValidationError extracts a TER result code from a validation error message.
 // If the error message starts with a valid TER code prefix (e.g., "temREDUNDANT:"),
 // it returns the corresponding Result. Otherwise, it returns TemINVALID.
@@ -208,72 +266,15 @@ func parseValidationError(err error) Result {
 
 	// Legacy fallback: string-prefix matching for unmigrated callers
 	msg := err.Error()
-
-	// Check for known TER code prefixes
-	// Common tem (malformed) codes
-	terCodes := map[string]Result{
-		"temMALFORMED":                TemMALFORMED,
-		"temBAD_AMOUNT":               TemBAD_AMOUNT,
-		"temBAD_CURRENCY":             TemBAD_CURRENCY,
-		"temBAD_EXPIRATION":           TemBAD_EXPIRATION,
-		"temBAD_FEE":                  TemBAD_FEE,
-		"temBAD_ISSUER":               TemBAD_ISSUER,
-		"temBAD_LIMIT":                TemBAD_LIMIT,
-		"temBAD_OFFER":                TemBAD_OFFER,
-		"temBAD_PATH":                 TemBAD_PATH,
-		"temBAD_PATH_LOOP":            TemBAD_PATH_LOOP,
-		"temBAD_REGKEY":               TemBAD_REGKEY,
-		"temBAD_SEQUENCE":             TemBAD_SEQUENCE,
-		"temBAD_SIGNATURE":            TemBAD_SIGNATURE,
-		"temBAD_SRC_ACCOUNT":          TemBAD_SRC_ACCOUNT,
-		"temBAD_TRANSFER_RATE":        TemBAD_TRANSFER_RATE,
-		"temDST_IS_SRC":               TemDST_IS_SRC,
-		"temDST_NEEDED":               TemDST_NEEDED,
-		"temINVALID":                  TemINVALID,
-		"temINVALID_FLAG":             TemINVALID_FLAG,
-		"temREDUNDANT":                TemREDUNDANT,
-		"temRIPPLE_EMPTY":             TemRIPPLE_EMPTY,
-		"temDISABLED":                 TemDISABLED,
-		"temBAD_SIGNER":               TemBAD_SIGNER,
-		"temBAD_QUORUM":               TemBAD_QUORUM,
-		"temBAD_WEIGHT":               TemBAD_WEIGHT,
-		"temBAD_TICK_SIZE":            TemBAD_TICK_SIZE,
-		"temINVALID_ACCOUNT_ID":       TemINVALID_ACCOUNT_ID,
-		"temUNCERTAIN":                TemUNCERTAIN,
-		"temUNKNOWN":                  TemUNKNOWN,
-		"temSEQ_AND_TICKET":           TemSEQ_AND_TICKET,
-		"temBAD_SEND_XRP_MAX":         TemBAD_SEND_XRP_MAX,
-		"temBAD_SEND_XRP_PARTIAL":     TemBAD_SEND_XRP_PARTIAL,
-		"temBAD_SEND_XRP_PATHS":       TemBAD_SEND_XRP_PATHS,
-		"temBAD_SEND_XRP_LIMIT":       TemBAD_SEND_XRP_LIMIT,
-		"temBAD_SEND_XRP_NO_DIRECT":   TemBAD_SEND_XRP_NO_DIRECT,
-		"temCANNOT_PREAUTH_SELF":      TemCAN_NOT_PREAUTH_SELF,
-		"temCAN_NOT_PREAUTH_SELF":     TemCAN_NOT_PREAUTH_SELF,
-		"temEMPTY_DID":                TemEMPTY_DID,
-		"temARRAY_EMPTY":              TemARRAY_EMPTY,
-		"temARRAY_TOO_LARGE":          TemARRAY_TOO_LARGE,
-		"temBAD_AMM_TOKENS":           TemBAD_AMM_TOKENS,
-		"temBAD_TRANSFER_FEE":         TemBAD_TRANSFER_FEE,
-		"temBAD_NFTOKEN_TRANSFER_FEE": TemBAD_NFTOKEN_TRANSFER_FEE,
-		"temINVALID_COUNT":            TemINVALID_COUNT,
-		// tef (failure) codes
-		"tefINVALID_LEDGER_FIX_TYPE": TefINVALID_LEDGER_FIX_TYPE,
-		// tel (local) codes
-		"telBAD_DOMAIN":     TelBAD_DOMAIN,
-		"telBAD_PUBLIC_KEY": TelBAD_PUBLIC_KEY,
-	}
-
-	// Check if the message starts with any known TER code
-	for code, result := range terCodes {
+	for code, result := range validationErrorPrefixes {
 		if len(msg) >= len(code) && msg[:len(code)] == code {
-			// Check that it's followed by a colon, space, or is the entire message
+			// Code must be followed by ':', ' ', or end-of-string
 			if len(msg) == len(code) || msg[len(code)] == ':' || msg[len(code)] == ' ' {
 				return result
 			}
 		}
 	}
 
-	// Default to temINVALID
 	return TemINVALID
 }
 

--- a/internal/tx/registry.go
+++ b/internal/tx/registry.go
@@ -16,16 +16,17 @@ var (
 	registry   = make(map[Type]func() Transaction)
 )
 
-// Register registers a transaction type factory. Called from init() in each transaction type file.
-// Returns an error if the type is already registered.
-func Register(t Type, factory func() Transaction) error {
+// Register registers a transaction type factory. Called from init() in each
+// transaction type file. Panics on duplicate registration so a copy-paste bug
+// that swaps one tx type's behavior for another's fails loudly at init time
+// instead of silently overwriting.
+func Register(t Type, factory func() Transaction) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 	if _, exists := registry[t]; exists {
-		return fmt.Errorf("tx: transaction type %d (%s) already registered", t, t.String())
+		panic(fmt.Sprintf("tx: transaction type %d (%s) already registered", t, t.String()))
 	}
 	registry[t] = factory
-	return nil
 }
 
 // NewFromType creates a new transaction of the given type using the registered factory.


### PR DESCRIPTION
## Summary

Addresses three P0 findings from the `internal/tx/` audit (#432):

- **Remove dead `Engine.currentTxHash`** — the field is only written in `do_apply.go`, never read anywhere in the tree (`grep` confirms). It was the subject of the "unsynchronized per-tx mutable state" P0 in the audit. Gone.
- **Make `Engine.txCount` atomic** (`atomic.Uint32`) and document `Engine` as single-writer for `Apply`/`ApplyPseudo`. Apply paths now use `txCount.Add(1) - 1` for the index assignment. Public `TxCount() uint32` and `SetBaseTxCount(uint32)` signatures unchanged.
- **`tx.Register` panics on duplicate** — all 24 callers ignored its `error` return, so a copy-paste duplicate would silently overwrite the prior factory. The `error` return was dead too; removed it. Future copy-paste at init fails loudly.
- **Hoist `parseValidationError`'s 50-entry TER prefix map** from per-call to a package-level `var`. Runs on every preflight error.

Scope intentionally narrow: this PR is the "engine state + registration hygiene" slice. The remaining sweep items (`Flatten` codegen, tec-recovery dedup, Pathfinder fixes, `ResultError` migration completion, `stringer`-generate `Result.String`, `context.Context` threading, invariants inline-interfaces) deserve their own focused PRs and are not closed by this change — hence `Refs` rather than `Fixes`.

## Test plan

- [x] `go vet ./internal/tx/...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./internal/tx/...` — all passing
- [x] `go test ./internal/testing/... ./internal/ledger/... ./internal/txq/...` — all passing (no FAILs)

Refs #432