### PR TITLE
TEST: deliberate consensus break to validate smoke CI (DO NOT MERGE)

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -2976,6 +2976,12 @@ func effCloseTime(closeTime time.Time, resolution time.Duration, priorCloseTime 
 		return closeTime
 	}
 	rounded := roundCloseTime(closeTime, resolution)
+	// CI-BREAK-TEST: deliberate cross-impl divergence — adds a 1-second
+	// offset to every effective close time so this goxrpl build closes
+	// every ledger with a different close_time than rippled, producing
+	// distinct ledger_hash values. This commit exists only to confirm
+	// scripts/consensus-smoke/ CI catches consensus regressions. REVERT.
+	rounded = rounded.Add(time.Second)
 	minTime := priorCloseTime.Add(time.Second)
 	if rounded.Before(minTime) {
 		return minTime


### PR DESCRIPTION
**Do not merge.** This PR exists only to validate that the
`consensus-smoke` job added in #437 actually fails when goxrpl ↔ rippled
consensus diverges.

## What's broken

`effCloseTime` adds a 1-second offset to every effective close time
(`internal/consensus/rcl/engine.go`). Every ledger this goxrpl build
closes will have a `close_time` 1s after what rippled computes from the
same input, so:

* ledger header bytes differ between goxrpl and rippled
* `ledger_hash` differs
* quorum (3 of 3) is never reached
* network wedges at validated_seq=null

## Local validation

```
$ bash scripts/consensus-smoke/smoke.sh
exit=1
[smoke] waiting for seq >= 15 — rippled-0=null rippled-1=null goxrpl-0=1
...
[smoke] timeout waiting for validated seq >= 15 after 180s
[smoke] phase 1 failed — dumping container logs
```

## Expected CI

* lint / build / test jobs: PASS (the modification has no direct unit-test
  coverage)
* consensus-smoke: FAIL at phase 1 timeout, ~3 minutes in

That asymmetry is the whole point: an interop bug that no unit test
catches still trips the smoke.

## After observing the failure

Close without merging. The base branch (`ci-consensus-smoke`, PR #437)
still has the clean smoke commit and is what should land on main.