### PR TITLE
consensus + txq: resolve all P0/P1/P2 items from audit #433

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -148,7 +148,14 @@ var _ consensus.Adaptor = (*Adaptor)(nil)
 // Adaptor implements consensus.Adaptor, bridging the consensus engine
 // to the ledger service, transaction queue, and P2P network.
 type Adaptor struct {
-	mu sync.RWMutex
+	// mu protects trustedValidators / trustedSet / trustedMasterKeys /
+	// quorum / operatingMode. Plain Mutex rather than RWMutex: the
+	// fields are mutated rarely (UNL changes, SetOperatingMode) and
+	// read from a handful of getters per round, so contention is low
+	// and the RWMutex overhead is not justified. The two hot RPC
+	// paths (operatingMode, peerLCLs) already escape this lock — one
+	// via the modeAtomic mirror, the other via peerLCLsMu.
+	mu sync.Mutex
 
 	ledgerService *service.Service
 	sender        NetworkSender
@@ -900,15 +907,15 @@ func (a *Adaptor) VerifyValidation(validation *consensus.Validation) error {
 // --- Trust operations ---
 
 func (a *Adaptor) IsTrusted(node consensus.NodeID) bool {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	_, ok := a.trustedSet[node]
 	return ok
 }
 
 func (a *Adaptor) GetTrustedValidators() []consensus.NodeID {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	result := make([]consensus.NodeID, len(a.trustedValidators))
 	copy(result, a.trustedValidators)
 	return result
@@ -921,7 +928,15 @@ func (a *Adaptor) GetTrustedValidators() []consensus.NodeID {
 // goXRPL froze quorum at Adaptor construction, so partial-UNL
 // outages slowed finality relative to rippled.
 func (a *Adaptor) GetQuorum() int {
+	// Take a.mu around the trustedValidators read — the slice header is
+	// only mutated in New() today but the TrustChanged event will be
+	// driven from the validator-manager wiring noted at line 376, after
+	// which an unlocked read becomes a data race against the writer.
+	// GetNegativeUNL has its own lock, so call it after release to
+	// avoid nesting locks.
+	a.mu.Lock()
 	trusted := len(a.trustedValidators)
+	a.mu.Unlock()
 	disabled := len(a.GetNegativeUNL())
 	return computeQuorum(trusted, disabled)
 }
@@ -1252,8 +1267,8 @@ func (a *Adaptor) AdjustCloseTime(rawCloseTimes consensus.CloseTimes) {
 // --- Status operations ---
 
 func (a *Adaptor) GetOperatingMode() consensus.OperatingMode {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	return a.operatingMode
 }
 

--- a/internal/consensus/adaptor/modemanager.go
+++ b/internal/consensus/adaptor/modemanager.go
@@ -53,79 +53,97 @@ func (m *ModeManager) Mode() consensus.OperatingMode {
 	return m.mode
 }
 
+// pendingTransition captures the side effects of a mode transition that
+// must run *outside* m.mu to avoid lock inversion against the Adaptor's
+// own mutex and against any onModeChange subscriber that might call back
+// into ModeManager (issue #418 bootstrap deadlock class).
+type pendingTransition struct {
+	oldMode   consensus.OperatingMode
+	newMode   consensus.OperatingMode
+	peerCount int
+	cb        func(old, new consensus.OperatingMode)
+}
+
 // OnPeerConnected should be called when a new peer connects.
 func (m *ModeManager) OnPeerConnected() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.peerCount++
+	var p *pendingTransition
 	if m.mode == consensus.OpModeDisconnected && m.peerCount > 0 {
-		m.transitionLocked(consensus.OpModeConnected)
+		p = m.stageTransitionLocked(consensus.OpModeConnected)
 	}
+	m.mu.Unlock()
+	m.applyTransition(p)
 }
 
 // OnPeerDisconnected should be called when a peer disconnects.
 func (m *ModeManager) OnPeerDisconnected() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if m.peerCount > 0 {
 		m.peerCount--
 	}
+	var p *pendingTransition
 	if m.peerCount == 0 {
-		m.transitionLocked(consensus.OpModeDisconnected)
+		p = m.stageTransitionLocked(consensus.OpModeDisconnected)
 	}
+	m.mu.Unlock()
+	m.applyTransition(p)
 }
 
 // OnLCLMismatch should be called when a peer reports a different LCL.
 // Transitions Connected → Syncing.
 func (m *ModeManager) OnLCLMismatch() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
+	var p *pendingTransition
 	if m.mode == consensus.OpModeConnected {
-		m.transitionLocked(consensus.OpModeSyncing)
+		p = m.stageTransitionLocked(consensus.OpModeSyncing)
 	}
+	m.mu.Unlock()
+	m.applyTransition(p)
 }
 
 // OnLCLAcquired should be called when we have the correct LCL.
 // Transitions Syncing → Tracking.
 func (m *ModeManager) OnLCLAcquired() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
+	var p *pendingTransition
 	if m.mode == consensus.OpModeSyncing {
-		m.transitionLocked(consensus.OpModeTracking)
+		p = m.stageTransitionLocked(consensus.OpModeTracking)
 	}
+	m.mu.Unlock()
+	m.applyTransition(p)
 }
 
 // OnValidationsReceived should be called when we receive validations
 // confirming our chain. Transitions Tracking → Full.
 func (m *ModeManager) OnValidationsReceived() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
+	var p *pendingTransition
 	if m.mode == consensus.OpModeTracking {
-		m.transitionLocked(consensus.OpModeFull)
+		p = m.stageTransitionLocked(consensus.OpModeFull)
 	}
+	m.mu.Unlock()
+	m.applyTransition(p)
 }
 
 // OnWrongLedger should be called when consensus detects we're on the
 // wrong ledger. Transitions Full → Syncing.
 func (m *ModeManager) OnWrongLedger() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
+	var p *pendingTransition
 	if m.mode == consensus.OpModeFull || m.mode == consensus.OpModeTracking {
-		m.transitionLocked(consensus.OpModeSyncing)
+		p = m.stageTransitionLocked(consensus.OpModeSyncing)
 	}
+	m.mu.Unlock()
+	m.applyTransition(p)
 }
 
 // SetMode forces a mode transition (for testing or manual override).
 func (m *ModeManager) SetMode(mode consensus.OperatingMode) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.transitionLocked(mode)
+	p := m.stageTransitionLocked(mode)
+	m.mu.Unlock()
+	m.applyTransition(p)
 }
 
 // OnEvent translates engine ModeChangedEvents into adaptor OperatingMode
@@ -140,41 +158,58 @@ func (m *ModeManager) OnEvent(event consensus.Event) {
 		return
 	}
 	current := m.adaptor.GetOperatingMode()
+	var p *pendingTransition
 	if mc.NewMode == consensus.ModeWrongLedger {
 		if current == consensus.OpModeFull || current == consensus.OpModeTracking {
 			m.mu.Lock()
-			m.transitionLocked(consensus.OpModeSyncing)
+			p = m.stageTransitionLocked(consensus.OpModeSyncing)
 			m.mu.Unlock()
 		}
-		return
-	}
-	if mc.OldMode == consensus.ModeWrongLedger {
+	} else if mc.OldMode == consensus.ModeWrongLedger {
 		if current == consensus.OpModeSyncing {
 			m.mu.Lock()
-			m.transitionLocked(consensus.OpModeTracking)
+			p = m.stageTransitionLocked(consensus.OpModeTracking)
 			m.mu.Unlock()
 		}
 	}
+	m.applyTransition(p)
 }
 
-// transitionLocked performs a mode transition while holding the lock.
-func (m *ModeManager) transitionLocked(newMode consensus.OperatingMode) {
+// stageTransitionLocked records a pending mode transition under m.mu and
+// returns the captured side-effect arguments. It does NOT call into the
+// Adaptor or invoke onModeChange — both happen in applyTransition after
+// the lock is released, which breaks the ModeManager↔Adaptor lock cycle
+// that previously deadlocked at bootstrap (issue #418).
+//
+// Returns nil when newMode == m.mode so callers can pass the result
+// through applyTransition unconditionally.
+func (m *ModeManager) stageTransitionLocked(newMode consensus.OperatingMode) *pendingTransition {
 	if m.mode == newMode {
+		return nil
+	}
+	p := &pendingTransition{
+		oldMode:   m.mode,
+		newMode:   newMode,
+		peerCount: m.peerCount,
+		cb:        m.onModeChange,
+	}
+	m.mode = newMode
+	return p
+}
+
+// applyTransition runs the side effects staged by stageTransitionLocked.
+// MUST be called with m.mu released.
+func (m *ModeManager) applyTransition(p *pendingTransition) {
+	if p == nil {
 		return
 	}
-	oldMode := m.mode
-	m.mode = newMode
-
-	// Update the adaptor's operating mode
-	m.adaptor.SetOperatingMode(newMode)
-
+	m.adaptor.SetOperatingMode(p.newMode)
 	m.logger.Info("Operating mode changed",
-		"from", oldMode.String(),
-		"to", newMode.String(),
-		"peers", m.peerCount,
+		"from", p.oldMode.String(),
+		"to", p.newMode.String(),
+		"peers", p.peerCount,
 	)
-
-	if m.onModeChange != nil {
-		m.onModeChange(oldMode, newMode)
+	if p.cb != nil {
+		p.cb(p.oldMode, p.newMode)
 	}
 }

--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -32,11 +32,11 @@ import (
 // a NegativeUNL-enabled network sees neither errors nor warnings when
 // the round simply has nothing to do.
 func (a *Adaptor) GenerateNegativeUNLPseudoTx(prev consensus.Ledger) [][]byte {
-	a.mu.RLock()
+	a.mu.Lock()
 	voter := a.negUNLVoter
 	historian := a.validationHistorian
 	masterKeys := a.trustedMasterKeys
-	a.mu.RUnlock()
+	a.mu.Unlock()
 
 	if voter == nil || historian == nil || len(masterKeys) == 0 {
 		return nil

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
@@ -266,16 +267,25 @@ func (r *Router) maintenanceTick() {
 		}
 		newPeer := candidates[0]
 		rd.NoteSubTaskRetry(newPeer)
-		if err := r.adaptor.RequestReplayDelta(newPeer, rd.Hash()); err != nil {
-			r.logger.Debug("replay-delta retry request failed",
-				"seq", rd.Seq(),
-				"hash", fmt.Sprintf("%x", rd.Hash()),
-				"peer", newPeer,
-				"err", err,
-			)
-			// Next tick will try yet another peer. Continue rather
-			// than return so we process other in-flight retries.
-		}
+		// Dispatch the actual network send in a goroutine so a slow or
+		// back-pressured overlay write doesn't block r.inbox ingest.
+		// Replayer-state mutation (NoteSubTaskRetry above) already
+		// happened on the loop goroutine, preserving the single-writer
+		// invariant against handleMessage; on send failure the next
+		// tick will rotate to another peer (the per-hash timeout
+		// continues to run).
+		seq := rd.Seq()
+		hash := rd.Hash()
+		go func() {
+			if err := r.adaptor.RequestReplayDelta(newPeer, hash); err != nil {
+				r.logger.Debug("replay-delta retry request failed",
+					"seq", seq,
+					"hash", fmt.Sprintf("%x", hash),
+					"peer", newPeer,
+					"err", err,
+				)
+			}
+		}()
 	}
 
 	// Reap acquisitions that exceeded the OUTER budget. At this point
@@ -1635,12 +1645,23 @@ func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
 		return
 	}
 
+	// Walk peers in ID order rather than Go map iteration order. The
+	// chosen peer doesn't affect ledger state (any peer that has the
+	// hash can serve it), but a deterministic pick makes the log
+	// emitted below reproducible across runs — useful when bisecting
+	// soak-test divergence.
 	r.peersMu.RLock()
+	peerIDs := make([]peermanagement.PeerID, 0, len(r.peerStates))
+	for pid := range r.peerStates {
+		peerIDs = append(peerIDs, pid)
+	}
+	sort.Slice(peerIDs, func(i, j int) bool { return peerIDs[i] < peerIDs[j] })
 	var (
 		preferredPeerID uint64
 		fallbackPeerID  uint64
 	)
-	for pid, st := range r.peerStates {
+	for _, pid := range peerIDs {
+		st := r.peerStates[pid]
 		if fallbackPeerID == 0 {
 			fallbackPeerID = uint64(pid)
 		}

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -1645,11 +1645,8 @@ func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
 		return
 	}
 
-	// Walk peers in ID order rather than Go map iteration order. The
-	// chosen peer doesn't affect ledger state (any peer that has the
-	// hash can serve it), but a deterministic pick makes the log
-	// emitted below reproducible across runs — useful when bisecting
-	// soak-test divergence.
+	// Walk peers in ID order so the chosen peer (and the emitted log)
+	// is reproducible across runs. Any peer with the hash can serve it.
 	r.peersMu.RLock()
 	peerIDs := make([]peermanagement.PeerID, 0, len(r.peerStates))
 	for pid := range r.peerStates {

--- a/internal/consensus/csf/network.go
+++ b/internal/consensus/csf/network.go
@@ -1,6 +1,7 @@
 package csf
 
 import (
+	"sort"
 	"sync"
 )
 
@@ -112,6 +113,13 @@ func (n *BasicNetwork) GetDelay(from, to PeerID) (SimDuration, bool) {
 }
 
 // Peers returns all peers that the given peer is connected to.
+//
+// The result is sorted by PeerID so Broadcast schedules per-peer Send
+// calls in a stable order. The scheduler relies on the order in which
+// events are pushed to break ties between events scheduled at the same
+// simulated time — without a sort, two runs with the same seed could
+// assign different sequence numbers to the same logical broadcasts and
+// silently reorder same-time deliveries.
 func (n *BasicNetwork) Peers(id PeerID) []PeerID {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
@@ -125,6 +133,7 @@ func (n *BasicNetwork) Peers(id PeerID) []PeerID {
 	for peer := range peerLinks {
 		result = append(result, peer)
 	}
+	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
 	return result
 }
 

--- a/internal/consensus/csf/peer.go
+++ b/internal/consensus/csf/peer.go
@@ -375,9 +375,17 @@ type Peer struct {
 
 	// Transaction injections for byzantine failure testing
 	txInjections map[uint32]Tx
+
+	// registry is the per-Sim peer index used by findPeer for inbound
+	// message delivery. Nil if the peer was constructed outside of
+	// Sim.CreateGroup (a few unit tests do this); callers tolerate a
+	// nil-registry lookup by treating the target as unknown.
+	registry *PeerRegistry
 }
 
-// NewPeer creates a new simulated peer.
+// NewPeer creates a new simulated peer. registry may be nil for tests
+// that construct peers outside Sim.CreateGroup — inter-peer message
+// delivery (findPeer) is then a no-op.
 func NewPeer(
 	id PeerID,
 	scheduler *Scheduler,
@@ -385,6 +393,7 @@ func NewPeer(
 	net *BasicNetwork,
 	trustGraph *TrustGraph,
 	collectors *Collectors,
+	registry *PeerRegistry,
 ) *Peer {
 	genesis := MakeGenesis()
 
@@ -414,6 +423,7 @@ func NewPeer(
 		mode:                 consensus.ModeObserving,
 		receivedProposals:    make(map[PeerID]*Proposal),
 		txInjections:         make(map[uint32]Tx),
+		registry:             registry,
 	}
 
 	// All peers start from genesis
@@ -888,35 +898,55 @@ func (p *Peer) broadcastProposal(prop *Proposal) {
 	}
 }
 
-// findPeer finds a peer by ID (simplified - in real impl would use registry)
-var peerRegistry = make(map[PeerID]*Peer)
-var peerRegistryMu sync.Mutex
+// PeerRegistry is a per-Sim id→peer index used for message delivery. It
+// replaces the prior package-global registry which forced every test run
+// to share state and made `go test -parallel` race on the map.
+type PeerRegistry struct {
+	mu sync.Mutex
+	m  map[PeerID]*Peer
+}
 
+// NewPeerRegistry returns an empty registry.
+func NewPeerRegistry() *PeerRegistry {
+	return &PeerRegistry{m: make(map[PeerID]*Peer)}
+}
+
+// Register adds peer to the registry.
+func (r *PeerRegistry) Register(peer *Peer) {
+	r.mu.Lock()
+	r.m[peer.ID] = peer
+	r.mu.Unlock()
+}
+
+// Unregister removes a peer by ID.
+func (r *PeerRegistry) Unregister(id PeerID) {
+	r.mu.Lock()
+	delete(r.m, id)
+	r.mu.Unlock()
+}
+
+// Get returns the peer with the given ID, or nil.
+func (r *PeerRegistry) Get(id PeerID) *Peer {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.m[id]
+}
+
+// Len returns the number of registered peers.
+func (r *PeerRegistry) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.m)
+}
+
+// findPeer looks up a peer by ID via the per-Sim registry attached to
+// this peer. Returns nil if the peer is unknown or the registry is
+// unset (e.g. a Peer constructed outside Sim.CreateGroup in a test).
 func (p *Peer) findPeer(id PeerID) *Peer {
-	peerRegistryMu.Lock()
-	defer peerRegistryMu.Unlock()
-	return peerRegistry[id]
-}
-
-// RegisterPeer registers a peer in the global registry for message delivery.
-func RegisterPeer(peer *Peer) {
-	peerRegistryMu.Lock()
-	defer peerRegistryMu.Unlock()
-	peerRegistry[peer.ID] = peer
-}
-
-// UnregisterPeer removes a peer from the global registry.
-func UnregisterPeer(peer *Peer) {
-	peerRegistryMu.Lock()
-	defer peerRegistryMu.Unlock()
-	delete(peerRegistry, peer.ID)
-}
-
-// ClearPeerRegistry clears all peers from the registry.
-func ClearPeerRegistry() {
-	peerRegistryMu.Lock()
-	defer peerRegistryMu.Unlock()
-	peerRegistry = make(map[PeerID]*Peer)
+	if p.registry == nil {
+		return nil
+	}
+	return p.registry.Get(id)
 }
 
 // handleProposalFromPeer handles a proposal received from network.

--- a/internal/consensus/csf/peer.go
+++ b/internal/consensus/csf/peer.go
@@ -377,15 +377,12 @@ type Peer struct {
 	txInjections map[uint32]Tx
 
 	// registry is the per-Sim peer index used by findPeer for inbound
-	// message delivery. Nil if the peer was constructed outside of
-	// Sim.CreateGroup (a few unit tests do this); callers tolerate a
-	// nil-registry lookup by treating the target as unknown.
+	// message delivery. Nil-tolerant: a peer constructed outside
+	// Sim.CreateGroup gets a no-op findPeer.
 	registry *PeerRegistry
 }
 
-// NewPeer creates a new simulated peer. registry may be nil for tests
-// that construct peers outside Sim.CreateGroup — inter-peer message
-// delivery (findPeer) is then a no-op.
+// NewPeer creates a new simulated peer. registry may be nil.
 func NewPeer(
 	id PeerID,
 	scheduler *Scheduler,
@@ -898,9 +895,7 @@ func (p *Peer) broadcastProposal(prop *Proposal) {
 	}
 }
 
-// PeerRegistry is a per-Sim id→peer index used for message delivery. It
-// replaces the prior package-global registry which forced every test run
-// to share state and made `go test -parallel` race on the map.
+// PeerRegistry is a per-Sim id→peer index used for message delivery.
 type PeerRegistry struct {
 	mu sync.Mutex
 	m  map[PeerID]*Peer

--- a/internal/consensus/csf/scheduler.go
+++ b/internal/consensus/csf/scheduler.go
@@ -41,14 +41,14 @@ func (h eventHeap) Swap(i, j int) {
 	h[j].index = j
 }
 
-func (h *eventHeap) Push(x interface{}) {
+func (h *eventHeap) Push(x any) {
 	n := len(*h)
 	e := x.(*event)
 	e.index = n
 	*h = append(*h, e)
 }
 
-func (h *eventHeap) Pop() interface{} {
+func (h *eventHeap) Pop() any {
 	old := *h
 	n := len(old)
 	e := old[n-1]

--- a/internal/consensus/csf/sim.go
+++ b/internal/consensus/csf/sim.go
@@ -2,8 +2,8 @@ package csf
 
 import (
 	"fmt"
-	"testing"
 	"math/rand"
+	"testing"
 )
 
 // Sim orchestrates a consensus simulation.

--- a/internal/consensus/csf/sim.go
+++ b/internal/consensus/csf/sim.go
@@ -2,6 +2,7 @@ package csf
 
 import (
 	"fmt"
+	"testing"
 	"math/rand"
 )
 
@@ -22,14 +23,16 @@ type Sim struct {
 	peers    []*Peer
 	allPeers *PeerGroup
 	nextID   PeerID
+
+	// registry is the per-simulation id→peer index. Hosting it on the
+	// Sim rather than as a package-global lets two simulations run in
+	// parallel (`go test -parallel`) without racing on shared state.
+	registry *PeerRegistry
 }
 
 // NewSim creates a new simulation.
 // The simulation has no peers, no trust links, and no network connections initially.
 func NewSim() *Sim {
-	// Clear peer registry for fresh simulation
-	ClearPeerRegistry()
-
 	scheduler := NewScheduler()
 	return &Sim{
 		Scheduler:  scheduler,
@@ -41,6 +44,7 @@ func NewSim() *Sim {
 		peers:      make([]*Peer, 0),
 		allPeers:   NewPeerGroup(),
 		nextID:     0,
+		registry:   NewPeerRegistry(),
 	}
 }
 
@@ -63,11 +67,11 @@ func (s *Sim) CreateGroup(numPeers int) *PeerGroup {
 			s.Net,
 			s.TrustGraph,
 			s.Collectors,
+			s.registry,
 		)
 		s.peers = append(s.peers, peer)
 		newPeers[i] = peer
-		// Register peer for message delivery
-		RegisterPeer(peer)
+		s.registry.Register(peer)
 		s.nextID++
 	}
 
@@ -91,14 +95,13 @@ func (s *Sim) AllPeers() *PeerGroup {
 	return s.allPeers
 }
 
-// GetPeer returns the peer with the given ID.
+// GetPeer returns the peer with the given ID, or nil. O(1) via the
+// per-Sim registry.
 func (s *Sim) GetPeer(id PeerID) *Peer {
-	for _, peer := range s.peers {
-		if peer.ID == id {
-			return peer
-		}
+	if s.registry == nil {
+		return nil
 	}
-	return nil
+	return s.registry.Get(id)
 }
 
 // Run runs consensus protocol to generate the specified number of ledgers.
@@ -301,17 +304,21 @@ func (s *Sim) WaitForConsensus(targetSeq uint32) bool {
 	return false
 }
 
-// AssertSynchronized panics if peers are not synchronized.
-func (s *Sim) AssertSynchronized() {
+// AssertSynchronized fails the test if peers are not synchronized.
+// Accepts testing.TB rather than panicking so the failure carries the
+// test's frame instead of crashing the harness.
+func (s *Sim) AssertSynchronized(tb testing.TB) {
+	tb.Helper()
 	if !s.SynchronizedAll() {
-		panic("Simulation: peers are not synchronized")
+		tb.Fatalf("Simulation: peers are not synchronized")
 	}
 }
 
-// AssertNoBranches panics if there are multiple branches.
-func (s *Sim) AssertNoBranches() {
-	if s.BranchesAll() > 1 {
-		panic(fmt.Sprintf("Simulation: found %d branches", s.BranchesAll()))
+// AssertNoBranches fails the test if there are multiple branches.
+func (s *Sim) AssertNoBranches(tb testing.TB) {
+	tb.Helper()
+	if n := s.BranchesAll(); n > 1 {
+		tb.Fatalf("Simulation: found %d branches", n)
 	}
 }
 

--- a/internal/consensus/csf/sim.go
+++ b/internal/consensus/csf/sim.go
@@ -24,9 +24,7 @@ type Sim struct {
 	allPeers *PeerGroup
 	nextID   PeerID
 
-	// registry is the per-simulation id→peer index. Hosting it on the
-	// Sim rather than as a package-global lets two simulations run in
-	// parallel (`go test -parallel`) without racing on shared state.
+	// registry is the per-simulation id→peer index.
 	registry *PeerRegistry
 }
 
@@ -95,8 +93,7 @@ func (s *Sim) AllPeers() *PeerGroup {
 	return s.allPeers
 }
 
-// GetPeer returns the peer with the given ID, or nil. O(1) via the
-// per-Sim registry.
+// GetPeer returns the peer with the given ID, or nil.
 func (s *Sim) GetPeer(id PeerID) *Peer {
 	if s.registry == nil {
 		return nil
@@ -305,8 +302,6 @@ func (s *Sim) WaitForConsensus(targetSeq uint32) bool {
 }
 
 // AssertSynchronized fails the test if peers are not synchronized.
-// Accepts testing.TB rather than panicking so the failure carries the
-// test's frame instead of crashing the harness.
 func (s *Sim) AssertSynchronized(tb testing.TB) {
 	tb.Helper()
 	if !s.SynchronizedAll() {

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -77,12 +77,21 @@ type WireableAdaptor interface {
 	SetValidationHistorian(h ValidationHistorian)
 }
 
-// Adaptor provides the interface between the consensus engine and
-// the rest of the node (network, ledger, transaction queue).
-// This follows rippled's adaptor pattern for clean separation.
-type Adaptor interface {
-	// Network operations
+// The Adaptor interface previously held ~60 methods on a single type.
+// To keep test mocks tractable and make the seams between consensus and
+// the rest of the node explicit, it is now composed of smaller
+// interfaces — each named after the subsystem it represents. The
+// composite `Adaptor` keeps the same surface so existing concrete
+// implementations and consumers do not change.
+//
+// New code SHOULD depend on the narrowest interface that satisfies its
+// needs (e.g. `TimeSource` instead of `Adaptor` for code that only
+// reads the clock). Test doubles that historically had to satisfy all
+// 60 methods can now embed only the seams they exercise.
 
+// NetworkBroadcaster handles self-originated outbound traffic and the
+// per-peer squelch / reverse-index bookkeeping that goes with it.
+type NetworkBroadcaster interface {
 	// BroadcastProposal sends OUR OWN proposal to all peers. Not
 	// subject to per-peer squelch filtering — we always deliver our
 	// self-originated traffic. Mirrors rippled's OverlayImpl which
@@ -112,18 +121,10 @@ type Adaptor interface {
 	// UpdateRelaySlot feeds the reduce-relay state machine with an
 	// inbound validator message from originPeer AND every peer in
 	// seenPeers (known-havers from the overlay's reverse index).
-	// Mirrors rippled's PeerImp::onMessage(TMProposeSet/TMValidation)
-	// calling updateSlotAndSquelch with the full haveMessage set
-	// (PeerImp.cpp:3013-3017, 3049-3054) — feeding multi-path
-	// delivery evidence per duplicate is what lets selection converge
-	// at the same rate rippled does. Router calls this on every
-	// trusted inbound proposal/validation duplicate.
 	UpdateRelaySlot(validatorKey []byte, originPeer uint64, seenPeers []uint64)
 
 	// PeersThatHave returns peer IDs known to have the message with
-	// suppressionHash. Populated at outbound relay and queried on
-	// inbound duplicates so UpdateRelaySlot can be fed the whole
-	// known-haver set (B3). Returns nil when unknown or aged out.
+	// suppressionHash. Returns nil when unknown or aged out.
 	PeersThatHave(suppressionHash [32]byte) []uint64
 
 	// RequestTxSet requests a transaction set from peers.
@@ -131,9 +132,12 @@ type Adaptor interface {
 
 	// RequestLedger requests a ledger from peers.
 	RequestLedger(id LedgerID) error
+}
 
-	// Ledger operations
-
+// LedgerProvider exposes the node's persistent ledger view to the
+// engine: lookup, validated-state, and the build/store/validate
+// pipeline.
+type LedgerProvider interface {
 	// GetLedger returns the ledger with the given ID.
 	GetLedger(id LedgerID) (Ledger, error)
 
@@ -142,17 +146,10 @@ type Adaptor interface {
 
 	// GetValidatedLedgerHash returns the hash of the most recent ledger
 	// this node considers FULLY VALIDATED (trusted-validation quorum
-	// reached). Zero LedgerID when no ledger has crossed quorum yet —
-	// callers must treat the zero value as "not available" and skip
-	// emission (e.g., sfValidatedHash in STValidation). Separate from
-	// GetLastClosedLedger which returns the consensus-closed view, not
-	// the network-agreement view.
+	// reached). Zero LedgerID when no ledger has crossed quorum yet.
 	GetValidatedLedgerHash() LedgerID
 
 	// BuildLedger constructs a new ledger from a transaction set.
-	// closeTimeCorrect is true when consensus agreed on the close time;
-	// when false, the resulting header carries sLCF_NoConsensusTime so
-	// the hash matches what rippled produces in the same case.
 	BuildLedger(parent Ledger, txSet TxSet, closeTime time.Time, closeTimeCorrect bool) (Ledger, error)
 
 	// ValidateLedger checks if a ledger is valid.
@@ -160,56 +157,26 @@ type Adaptor interface {
 
 	// StoreLedger persists a ledger.
 	StoreLedger(ledger Ledger) error
+}
 
-	// Transaction operations
-
+// TxPool exposes the open-ledger transaction view to the engine.
+type TxPool interface {
 	// GetPendingTxs returns the tx blobs currently in the open pool.
-	// Used for the open-phase "anyTransactions" gate. Consensus
-	// position formation uses GetProposableTxs instead.
 	GetPendingTxs() [][]byte
 
 	// GetProposableTxs returns the tx set the node will propose this
 	// round. Mirrors rippled's `OpenLedger.current()->txs` read at
-	// proposal time (RCLConsensus.cpp:333-349) — the persistent open-
-	// ledger view already contains only txs that applied successfully,
-	// so this is a pointer-deref, not a per-call filter.
-	//
-	// The `parent` parameter is reserved for interface compatibility;
-	// the persistent view tracks its own parent internally. Returns
-	// nil when no view is available (test mocks).
+	// proposal time.
 	GetProposableTxs(parent Ledger) [][]byte
 
 	// GenerateFlagLedgerPseudoTxs returns the fee-vote and
 	// amendment-vote pseudo-transaction blobs to inject into the
-	// proposal initial set when prevLedger is a flag ledger. Mirrors
-	// rippled's RCLConsensus.cpp:354-367 — when the previous ledger is
-	// a flag ledger, validators tally fee and amendment votes from the
-	// validations of the ledger before that and emit SetFee /
-	// EnableAmendment pseudo-txs reflecting the consensus.
-	//
-	// parentValidations are the trusted validations of prevLedger's
-	// parent (the ledger before the flag). The engine sources them
-	// from its validation tracker via prevLedger.ParentID() — matching
-	// rippled's getTrustedForLedger(prevLedger->parentHash, prev.seq()-1)
-	// at RCLConsensus.cpp:359-360.
-	//
-	// The adaptor applies the negative-UNL filter (RCLConsensus.cpp:358)
-	// and the quorum gate (RCLConsensus.cpp:361) internally, so the
-	// engine passes the raw trusted set through unchanged.
-	//
-	// Returns nil when no votes apply (below-quorum validations, no
-	// vote stance to emit, etc.).
+	// proposal initial set when prevLedger is a flag ledger.
 	GenerateFlagLedgerPseudoTxs(prevLedger Ledger, parentValidations []*Validation) [][]byte
 
 	// GenerateNegativeUNLPseudoTx returns the NegativeUNL pseudo-tx
 	// blobs to inject when prevLedger is a voting ledger AND the
-	// featureNegativeUNL amendment is enabled. Mirrors rippled
-	// RCLConsensus.cpp:368-380 + NegativeUNLVote.cpp:84-107 which
-	// emits at most one ToDisable AND at most one ToReEnable per
-	// flag-ledger vote — hence the [][]byte return.
-	//
-	// Returns nil when no NegUNL changes are required. Adaptors
-	// without NegativeUNLVote support return nil.
+	// featureNegativeUNL amendment is enabled.
 	GenerateNegativeUNLPseudoTx(prevLedger Ledger) [][]byte
 
 	// GetTxSet returns a transaction set by ID.
@@ -223,9 +190,11 @@ type Adaptor interface {
 
 	// GetTx returns a transaction by ID.
 	GetTx(id TxID) ([]byte, error)
+}
 
-	// Validator operations
-
+// ValidatorIdentity carries the local node's validator credentials and
+// the sign/verify pair for proposals and validations.
+type ValidatorIdentity interface {
 	// IsValidator returns true if this node is configured as a validator.
 	IsValidator() bool
 
@@ -243,9 +212,11 @@ type Adaptor interface {
 
 	// VerifyValidation verifies a validation's signature.
 	VerifyValidation(validation *Validation) error
+}
 
-	// Trust operations
-
+// TrustOracle exposes the UNL / negative-UNL / quorum state and the
+// amendment / standalone gates used during proposal and validation.
+type TrustOracle interface {
 	// IsTrusted returns true if the node is in our UNL.
 	IsTrusted(node NodeID) bool
 
@@ -256,113 +227,52 @@ type Adaptor interface {
 	GetQuorum() int
 
 	// GetNegativeUNL returns the set of validator NodeIDs currently on
-	// the negative-UNL — the XRPL mechanism for temporarily disabling
-	// unreliable validators without removing them from the UNL. Rippled
-	// keeps this state in the ltNEGATIVE_UNL SLE on every ledger; the
-	// adaptor reads it from the currently-validated ledger.
-	//
-	// Validators on the negative-UNL are still TRUSTED for message
-	// acceptance but are EXCLUDED from quorum counts in
-	// ValidationTracker.checkFullValidation. Returning the set here
-	// lets the engine refresh the tracker on every acceptLedger so a
-	// validator added to (or removed from) the negUNL across a ledger
-	// boundary is correctly excluded (or re-included).
-	//
-	// Returns nil or empty when no negUNL is in effect — the tracker
-	// treats nil as "all trusted validators contribute to quorum".
+	// the negative-UNL. Validators on negUNL are still trusted for
+	// message acceptance but excluded from quorum counts.
 	GetNegativeUNL() []NodeID
 
 	// IsFeatureEnabled reports whether the named amendment is enabled
-	// on the rules of the currently-validated (or otherwise most
-	// authoritative) ledger. Used by the engine to gate optional
-	// STValidation fields that rippled only emits under specific
-	// amendments — e.g., sfValidatedHash requires featureHardenedValidations
-	// (RCLConsensus.cpp:853). Adaptors that can't read rules (no ledger
-	// yet, adaptor-only test harness) SHOULD return true to preserve
-	// the mainnet-default behavior of emitting the optional fields.
+	// on the rules of the currently-validated ledger. Used to gate
+	// optional STValidation fields. Adaptors that can't read rules
+	// SHOULD return true to preserve mainnet-default behavior.
 	IsFeatureEnabled(name string) bool
 
 	// IsFeatureEnabledOnLedger reports whether the named amendment is
-	// enabled in the rules of the given ledger. Mirrors rippled's
-	// `prevLedger->rules().enabled(featureX)` pattern (e.g.
-	// RCLConsensus.cpp:370 for featureNegativeUNL): the gate is read
-	// from the rules of the ledger consensus is building on, NOT from
-	// the most-recently validated ledger. Disagreement between the two
-	// is possible during sync or right after a fork heal — see
-	// IsFeatureEnabled for the laxer "validated view" variant used by
-	// the validation-broadcast path.
-	//
-	// Returns false on unknown feature, on a nil ledger, or when rules
-	// can't be resolved — matching rippled's `Rules::enabled` (a miss
-	// in the amendment table is "not enabled"). This is the strict
-	// semantic for a gate; the lax "treat unknown as enabled" default
-	// of IsFeatureEnabled is intentionally NOT shared here.
+	// enabled in the rules of the given ledger. The strict gate variant
+	// used during ledger building.
 	IsFeatureEnabledOnLedger(ledger Ledger, name string) bool
 
 	// IsStandalone reports whether the node is configured for
-	// standalone (single-node) operation. Mirrors rippled's
-	// `app_.config().standalone()` check at RCLConsensus.cpp:352,
-	// which forces pseudo-tx injection in standalone mode even when
-	// consensus is not in the proposing state.
+	// standalone (single-node) operation.
 	IsStandalone() bool
 
-	// GetCookie returns the validator's per-boot sfCookie value —
-	// generated once at adaptor construction from a CSPRNG. Emitted on
-	// every outgoing validation so peers can detect a validator
-	// restart. Mirrors rippled RCLConsensus.cpp:813-818.
+	// GetCookie returns the validator's per-boot sfCookie value.
 	GetCookie() uint64
 
 	// GetServerVersion returns the sfServerVersion value the validator
-	// advertises — an implementation + version identifier. Different
-	// implementations (rippled vs goXRPL) use different high-byte tags
-	// so network-wide version accounting can distinguish them. Zero
-	// means "not included" and the serializer will skip the field.
+	// advertises. Zero means "not included" and the serializer skips
+	// the field.
 	GetServerVersion() uint64
 
 	// GetLoadFee returns the local load_fee the validator advertises
-	// on every outbound validation (sfLoadFee). Rippled emits this
-	// under HardenedValidations from the local LoadFeeTrack —
-	// RCLConsensus.cpp:851. Adaptors without a load-feedback loop
-	// should return 0; the serializer treats 0 as omit.
+	// on every outbound validation (sfLoadFee). Zero is treated as omit.
 	GetLoadFee() uint32
 
 	// GetFeeVote returns this validator's fee-vote stance for emission
-	// on every validation. postXRPFees reflects the parent ledger's
-	// rules: when true the engine populates the AMOUNT triple
-	// (sfBaseFeeDrops/sfReserveBaseDrops/sfReserveIncrementDrops);
-	// when false it populates the legacy UINT triple
-	// (sfBaseFee/sfReserveBase/sfReserveIncrement). Matches rippled's
-	// FeeVoteImpl.cpp:120-192 mutual-exclusive gate. Zero values from
-	// the adaptor mean "no vote" and the serializer omits the fields.
+	// on every validation.
 	GetFeeVote() (baseFee, reserveBase, reserveIncrement uint64, postXRPFees bool)
 
 	// GetAmendmentVote returns the list of amendment IDs this
-	// validator wishes to vote FOR on the next flag ledger. The
-	// engine calls this on flag-ledger validations only (see
-	// isVotingLedger). Returns nil on non-validators or when no
-	// amendments require a vote. Matches rippled's
-	// AmendmentTable::doValidation (RCLConsensus.cpp:888-893).
-	//
-	// Implementations should filter amendments already enabled on
-	// the current ledger so we don't re-vote for active ones.
+	// validator wishes to vote FOR on the next flag ledger.
 	GetAmendmentVote() [][32]byte
 
 	// PeerReportedLedgers returns the last-closed ledger hashes that
-	// overlay peers have advertised via statusChange messages. Used
-	// by getNetworkLedger as a fallback signal when peer proposals
-	// haven't yet reached us for the current round — a peer that
-	// just advanced its LCL but hasn't gossipped its proposal to us
-	// still shows up as a vote for where the network is.
-	//
-	// Returns an empty slice when no peer statuses have been seen.
-	// Peer-status votes are subject to the same quorum-validated
-	// gate as proposal votes in checkLedger: they influence the
-	// vote count, but switching to a peer's preferred LCL still
-	// requires that LCL to have trusted-validation quorum.
+	// overlay peers have advertised via statusChange messages.
 	PeerReportedLedgers() []LedgerID
+}
 
-	// Time operations
-
+// TimeSource exposes the network-adjusted clock and close-time machinery.
+type TimeSource interface {
 	// Now returns the current network-adjusted time.
 	Now() time.Time
 
@@ -371,30 +281,25 @@ type Adaptor interface {
 
 	// AdjustCloseTime adjusts the clock offset toward the network average.
 	AdjustCloseTime(rawCloseTimes CloseTimes)
+}
 
-	// Status operations
-
+// StatusEvents carries the engine's coarse-grained state callbacks —
+// operating-mode, consensus-reached, full-validation, and the per-round
+// mode/phase transitions used for instrumentation.
+type StatusEvents interface {
 	// GetOperatingMode returns the node's overall operating mode.
 	GetOperatingMode() OperatingMode
 
-	// SetOperatingMode updates the node's operating mode.
+	// SetOperatingMode updates the node's overall operating mode.
 	SetOperatingMode(mode OperatingMode)
 
 	// OnConsensusReached is called when a round completes successfully.
-	// Fires at local-accept time (consensus round resolution). This is
-	// when the closed ledger is stored and pending-tx bookkeeping runs.
-	// It does NOT mean the network has agreed — see OnLedgerFullyValidated.
+	// Fires at local-accept time. It does NOT mean the network has
+	// agreed — see OnLedgerFullyValidated.
 	OnConsensusReached(ledger Ledger, validations []*Validation)
 
 	// OnLedgerFullyValidated is called once per ledger the first time
 	// trusted validations for that ledger cross the quorum threshold.
-	// This is the network-agreement gate: server_info.validated_ledger
-	// advances here, not at OnConsensusReached. Mirrors rippled's
-	// LedgerMaster::checkAccept() which only calls setValidLedger()
-	// after verifying trusted-validation count >= quorum.
-	//
-	// Safe to call even when the ledger is not yet in local history —
-	// implementations should no-op or defer rather than fail.
 	OnLedgerFullyValidated(ledgerID LedgerID, seq uint32)
 
 	// OnModeChange is called when consensus mode changes.
@@ -402,6 +307,22 @@ type Adaptor interface {
 
 	// OnPhaseChange is called when consensus phase changes.
 	OnPhaseChange(oldPhase, newPhase Phase)
+}
+
+// Adaptor provides the interface between the consensus engine and the
+// rest of the node. It is the composition of the per-subsystem seams
+// declared above. Existing implementations and tests reference this
+// type unchanged; new code should prefer one of the narrower seams.
+//
+// This follows rippled's adaptor pattern for clean separation.
+type Adaptor interface {
+	NetworkBroadcaster
+	LedgerProvider
+	TxPool
+	ValidatorIdentity
+	TrustOracle
+	TimeSource
+	StatusEvents
 }
 
 // Ledger represents a ledger in the consensus process.

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -77,17 +77,10 @@ type WireableAdaptor interface {
 	SetValidationHistorian(h ValidationHistorian)
 }
 
-// The Adaptor interface previously held ~60 methods on a single type.
-// To keep test mocks tractable and make the seams between consensus and
-// the rest of the node explicit, it is now composed of smaller
-// interfaces — each named after the subsystem it represents. The
-// composite `Adaptor` keeps the same surface so existing concrete
-// implementations and consumers do not change.
-//
-// New code SHOULD depend on the narrowest interface that satisfies its
-// needs (e.g. `TimeSource` instead of `Adaptor` for code that only
-// reads the clock). Test doubles that historically had to satisfy all
-// 60 methods can now embed only the seams they exercise.
+// The Adaptor interface is composed of smaller per-subsystem interfaces.
+// New code should depend on the narrowest interface that satisfies its
+// needs (e.g. TimeSource instead of Adaptor for code that only reads
+// the clock).
 
 // NetworkBroadcaster handles self-originated outbound traffic and the
 // per-peer squelch / reverse-index bookkeeping that goes with it.
@@ -310,11 +303,8 @@ type StatusEvents interface {
 }
 
 // Adaptor provides the interface between the consensus engine and the
-// rest of the node. It is the composition of the per-subsystem seams
-// declared above. Existing implementations and tests reference this
-// type unchanged; new code should prefer one of the narrower seams.
-//
-// This follows rippled's adaptor pattern for clean separation.
+// rest of the node. Follows rippled's adaptor pattern for clean
+// separation. New code should prefer one of the narrower seams above.
 type Adaptor interface {
 	NetworkBroadcaster
 	LedgerProvider

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -189,6 +189,13 @@ type Engine struct {
 	// held; drained by takePendingBroadcastsLocked after Unlock.
 	pendingBroadcasts []func()
 
+	// missedHeartbeats counts the number of heartbeat ticks the run
+	// loop observed as dropped (gap between consecutive ticks > 2× the
+	// configured interval). time.Ticker silently coalesces ticks when
+	// the consumer can't keep up; this counter surfaces that pressure
+	// so stalls don't hide. Read via MissedHeartbeats().
+	missedHeartbeats atomic.Uint64
+
 	// deferBroadcasts is incremented on entry to timerEntry / StartRound
 	// (the entry points that drive proposal/validation emission under
 	// e.mu) and decremented on exit. When zero, the enqueue helpers fall
@@ -1107,6 +1114,14 @@ func (e *Engine) Events() <-chan consensus.Event {
 
 // run is the main consensus loop driven by a single global heartbeat,
 // matching rippled's processHeartbeatTimer → timerEntry pattern.
+//
+// time.Ticker silently coalesces ticks when the consumer can't keep up
+// — under a stalled timerEntry (e.g. the bootstrap-deadlock class) the
+// channel buffer drops ticks without surfacing the back-pressure. We
+// observe missed ticks by comparing elapsed wall time between
+// invocations against the configured interval and logging when the gap
+// exceeds 2× expected. This is a strictly observational signal — the
+// next tick still runs unconditionally so a transient stall recovers.
 func (e *Engine) run() {
 	defer e.wg.Done()
 
@@ -1117,14 +1132,38 @@ func (e *Engine) run() {
 	e.heartbeat = time.NewTicker(interval)
 	defer e.heartbeat.Stop()
 
+	last := time.Now()
 	for {
 		select {
 		case <-e.ctx.Done():
 			return
 		case <-e.heartbeat.C:
+			now := time.Now()
+			if gap := now.Sub(last); gap > 2*interval {
+				missed := int64(gap/interval) - 1
+				if missed > 0 {
+					e.missedHeartbeats.Add(uint64(missed))
+					slog.Warn("heartbeat ticks missed",
+						"t", "consensus",
+						"event", "tick-missed",
+						"missed", missed,
+						"gap_ms", gap.Milliseconds(),
+						"interval_ms", interval.Milliseconds(),
+						"total_missed", e.missedHeartbeats.Load(),
+					)
+				}
+			}
+			last = now
 			e.timerEntry()
 		}
 	}
+}
+
+// MissedHeartbeats returns the total number of heartbeat ticks the
+// consensus loop has detected as dropped since process start. Exposed
+// for tests and operator tooling that need to assert progress.
+func (e *Engine) MissedHeartbeats() uint64 {
+	return e.missedHeartbeats.Load()
 }
 
 // timerEntry is the single heartbeat dispatch, matching rippled's

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -178,6 +178,25 @@ type Engine struct {
 	// ledgerAncestry is staged by startup wiring and applied to the
 	// tracker in Start. Nil keeps flat-count semantics.
 	ledgerAncestry LedgerAncestryProvider
+
+	// pendingBroadcasts queues proposal/validation broadcasts produced
+	// while e.mu is held so they can be flushed after the lock is
+	// released. The overlay write path takes its own per-peer locks
+	// and bounded send queues; holding e.mu across BroadcastProposal /
+	// BroadcastValidation blocks OnProposal/OnValidation ingress on
+	// e.mu.RLock and can stall consensus across the trusted set when
+	// a single peer's send queue is slow. Mutated only while e.mu is
+	// held; drained by takePendingBroadcastsLocked after Unlock.
+	pendingBroadcasts []func()
+
+	// deferBroadcasts is incremented on entry to timerEntry / StartRound
+	// (the entry points that drive proposal/validation emission under
+	// e.mu) and decremented on exit. When zero, the enqueue helpers fall
+	// back to a synchronous send so direct callers — primarily unit
+	// tests that drive sendValidation / closeLedger without going
+	// through timerEntry — still observe the broadcast immediately.
+	// Mutated only while e.mu is held.
+	deferBroadcasts int
 }
 
 // ValidationArchive is the subset of the archive API the consensus engine
@@ -200,6 +219,60 @@ func (e *Engine) loadArchive() ValidationArchive {
 		return box.a
 	}
 	return nil
+}
+
+// enqueueProposalBroadcastLocked stages a proposal to be broadcast after
+// e.mu is released. See pendingBroadcasts on Engine for rationale.
+// Caller must hold e.mu. When no deferred-broadcast scope is active
+// (deferBroadcasts == 0, e.g. tests driving sendValidation directly),
+// the send is performed synchronously so observers don't have to flush
+// manually.
+func (e *Engine) enqueueProposalBroadcastLocked(p *consensus.Proposal) {
+	if p == nil {
+		return
+	}
+	if e.deferBroadcasts == 0 {
+		_ = e.adaptor.BroadcastProposal(p)
+		return
+	}
+	e.pendingBroadcasts = append(e.pendingBroadcasts, func() {
+		_ = e.adaptor.BroadcastProposal(p)
+	})
+}
+
+// enqueueValidationBroadcastLocked stages a validation to be broadcast
+// after e.mu is released. Caller must hold e.mu.
+func (e *Engine) enqueueValidationBroadcastLocked(v *consensus.Validation) {
+	if v == nil {
+		return
+	}
+	if e.deferBroadcasts == 0 {
+		_ = e.adaptor.BroadcastValidation(v)
+		return
+	}
+	e.pendingBroadcasts = append(e.pendingBroadcasts, func() {
+		_ = e.adaptor.BroadcastValidation(v)
+	})
+}
+
+// takePendingBroadcastsLocked drains the queued broadcast closures.
+// Caller must hold e.mu. The returned slice should be passed to
+// flushBroadcasts after the lock is released.
+func (e *Engine) takePendingBroadcastsLocked() []func() {
+	if len(e.pendingBroadcasts) == 0 {
+		return nil
+	}
+	out := e.pendingBroadcasts
+	e.pendingBroadcasts = nil
+	return out
+}
+
+// flushBroadcasts runs each queued broadcast. MUST be called with e.mu
+// released.
+func flushBroadcasts(pending []func()) {
+	for _, fn := range pending {
+		fn()
+	}
 }
 
 // avalancheState tracks the close time voting threshold escalation.
@@ -390,8 +463,13 @@ func (e *Engine) Stop() error {
 // StartRound begins a new consensus round.
 func (e *Engine) StartRound(round consensus.RoundID, proposing bool) error {
 	e.mu.Lock()
-	defer e.mu.Unlock()
-	return e.startRoundLocked(round, proposing, false)
+	e.deferBroadcasts++
+	err := e.startRoundLocked(round, proposing, false)
+	e.deferBroadcasts--
+	pending := e.takePendingBroadcastsLocked()
+	e.mu.Unlock()
+	flushBroadcasts(pending)
+	return err
 }
 
 // startRoundLocked is the lock-free inner implementation of StartRound.
@@ -1055,8 +1133,13 @@ func (e *Engine) run() {
 func (e *Engine) timerEntry() {
 	tickStart := time.Now()
 	e.mu.Lock()
+	e.deferBroadcasts++
+	var pending []func()
 	defer func() {
+		e.deferBroadcasts--
+		pending = e.takePendingBroadcastsLocked()
 		e.mu.Unlock()
+		flushBroadcasts(pending)
 		// 50ms threshold — the 250ms heartbeat needs headroom.
 		dur := time.Since(tickStart)
 		if dur > 50*time.Millisecond {
@@ -1703,7 +1786,7 @@ func (e *Engine) closeLedger() {
 
 			if err := e.adaptor.SignProposal(proposal); err == nil {
 				e.state.OurPosition = proposal
-				e.adaptor.BroadcastProposal(proposal)
+				e.enqueueProposalBroadcastLocked(proposal)
 				txSetID := txSet.ID()
 				prevID := e.prevLedger.ID()
 				slog.Info("our initial position",
@@ -2156,7 +2239,7 @@ func (e *Engine) updatePosition() {
 		}
 		if err := e.adaptor.SignProposal(proposal); err == nil {
 			e.state.OurPosition = proposal
-			e.adaptor.BroadcastProposal(proposal)
+			e.enqueueProposalBroadcastLocked(proposal)
 		}
 	}
 
@@ -2575,7 +2658,7 @@ func (e *Engine) updateCloseTimePosition() {
 			e.state.OurPosition.Position++
 			e.state.OurPosition.Timestamp = e.adaptor.Now()
 			if err := e.adaptor.SignProposal(e.state.OurPosition); err == nil {
-				e.adaptor.BroadcastProposal(e.state.OurPosition)
+				e.enqueueProposalBroadcastLocked(e.state.OurPosition)
 			}
 			slog.Info("our close-time bumped",
 				"t", "consensus",
@@ -2908,7 +2991,7 @@ func (e *Engine) sendValidation(ledger consensus.Ledger) {
 		"sign_time_xrpl", signTime.Unix()-protocol.RippleEpochUnix,
 	)
 
-	e.adaptor.BroadcastValidation(validation)
+	e.enqueueValidationBroadcastLocked(validation)
 
 	// Feed our own validation into the tracker. Only Full validations
 	// are accepted by the tracker's Full-gate, so a partial

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -1,12 +1,36 @@
 package rcl
 
 import (
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/consensus/ledgertrie"
 )
+
+// safeTrieCall runs fn under a deferred recover so a ledgertrie
+// invariant panic (LedgerTrie.h:553-style XRPL_ASSERT or our equivalent
+// at trie.go:143/173/306) does not fail-stop the consensus goroutine.
+// rippled responds to these with a process abort; in Go we'd rather
+// log + continue and let the next operation rebuild the trie on its
+// own. Returns true if the call panicked. Caller must already hold the
+// lock that protects the trie state.
+func safeTrieCall(fn string, op func()) (panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+			slog.Error("ledgertrie panic recovered",
+				"t", "consensus",
+				"event", "trie-panic",
+				"fn", fn,
+				"err", r,
+			)
+		}
+	}()
+	op()
+	return false
+}
 
 // ValidationTracker tracks validations and determines ledger finality.
 type ValidationTracker struct {
@@ -531,7 +555,15 @@ func (vt *ValidationTracker) GetPreferred(largestIssued uint32) (consensus.Ledge
 	if vt.trie == nil {
 		return consensus.LedgerID{}, 0, false
 	}
-	tip, ok := vt.trie.GetPreferred(largestIssued)
+	var (
+		tip ledgertrie.SpanTip
+		ok  bool
+	)
+	if safeTrieCall("GetPreferred", func() {
+		tip, ok = vt.trie.GetPreferred(largestIssued)
+	}) {
+		return consensus.LedgerID{}, 0, false
+	}
 	if !ok {
 		return consensus.LedgerID{}, 0, false
 	}
@@ -742,7 +774,9 @@ func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 				delete(vt.byNode, nodeID)
 				if vt.trie != nil {
 					if prev, ok := vt.trieTips[nodeID]; ok {
-						vt.trie.Remove(prev, 1)
+						safeTrieCall("Remove", func() {
+							vt.trie.Remove(prev, 1)
+						})
 						delete(vt.trieTips, nodeID)
 					}
 				}

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -50,7 +50,7 @@ func (vt *ValidationTracker) rebuildTrieLocked() {
 		if !ok {
 			continue
 		}
-		vt.trie.Insert(lgr, 1)
+		safeTrieCall("Insert", func() { vt.trie.Insert(lgr, 1) })
 		vt.trieTips[nodeID] = lgr
 	}
 }
@@ -78,9 +78,9 @@ func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, newLedger
 	}
 
 	if prev, existed := vt.trieTips[nodeID]; existed {
-		vt.trie.Remove(prev, 1)
+		safeTrieCall("Remove", func() { vt.trie.Remove(prev, 1) })
 	}
-	vt.trie.Insert(lgr, 1)
+	safeTrieCall("Insert", func() { vt.trie.Insert(lgr, 1) })
 	vt.trieTips[nodeID] = lgr
 }
 

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -288,11 +288,8 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		if requiresMultiTxn {
 			var totalFee uint64
 			var potentialSpend uint64
-			// Iterate in SeqProxy order rather than over the map directly.
-			// The fee/spend sums are commutative so determinism holds either
-			// way, but a sorted walk makes the invariant local and avoids
-			// drift if a future refactor adds an order-sensitive side
-			// effect inside this loop.
+			// Iterate in SeqProxy order to match rippled's
+			// std::map<SeqProxy, MaybeTx> walk at TxQ.cpp:1048.
 			sortedTxns := aq.GetSortedCandidates()
 			for _, c := range sortedTxns {
 				sp := c.SeqProxy
@@ -450,11 +447,6 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		if feeLevel > endEffectiveFeeLevel {
 			// Drop the last (highest-sequence) transaction from the target account.
 			// Reference: rippled TxQ.cpp:1297-1306
-			//
-			// Iterating sorted candidates avoids relying on Go map order
-			// to pick the tiebreak when two SeqProxy values compare equal
-			// (cannot happen today since SeqProxy is the map key, but the
-			// sorted walk pins the contract).
 			sorted := endAccount.GetSortedCandidates()
 			var dropCandidate *Candidate
 			if n := len(sorted); n > 0 {
@@ -509,10 +501,8 @@ func (q *TxQ) tryClearAccountQueue(
 	txInLedger uint32,
 	account [20]byte,
 ) *ApplyResult {
-	// Collect queued sequence-based transactions that come BEFORE the new tx.
-	// These need to be applied first in order. GetSortedCandidates already
-	// returns SeqProxy-ascending order, so a forward walk gives the
-	// deterministic apply order without a second sort.
+	// Collect queued sequence-based transactions that come BEFORE the new tx,
+	// in SeqProxy-ascending order.
 	var preceding []*Candidate
 	for _, c := range aq.GetSortedCandidates() {
 		if !c.SeqProxy.Less(seqProxy) {

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -1,7 +1,6 @@
 package txq
 
 import (
-	"sort"
 	"strconv"
 
 	"github.com/LeJamon/goXRPLd/internal/tx"
@@ -289,7 +288,14 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		if requiresMultiTxn {
 			var totalFee uint64
 			var potentialSpend uint64
-			for sp, c := range aq.Transactions {
+			// Iterate in SeqProxy order rather than over the map directly.
+			// The fee/spend sums are commutative so determinism holds either
+			// way, but a sorted walk makes the invariant local and avoids
+			// drift if a future refactor adds an order-sensitive side
+			// effect inside this loop.
+			sortedTxns := aq.GetSortedCandidates()
+			for _, c := range sortedTxns {
+				sp := c.SeqProxy
 				if sp.Less(acctSeqProx) {
 					continue // Skip stale transactions
 				}
@@ -302,7 +308,8 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 					// Reference: TxQ.cpp:1059-1066
 					// Check if there's a transaction after this one in the queue.
 					hasNext := false
-					for sp2 := range aq.Transactions {
+					for _, c2 := range sortedTxns {
+						sp2 := c2.SeqProxy
 						if sp2.Less(acctSeqProx) {
 							continue
 						}
@@ -443,11 +450,15 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		if feeLevel > endEffectiveFeeLevel {
 			// Drop the last (highest-sequence) transaction from the target account.
 			// Reference: rippled TxQ.cpp:1297-1306
+			//
+			// Iterating sorted candidates avoids relying on Go map order
+			// to pick the tiebreak when two SeqProxy values compare equal
+			// (cannot happen today since SeqProxy is the map key, but the
+			// sorted walk pins the contract).
+			sorted := endAccount.GetSortedCandidates()
 			var dropCandidate *Candidate
-			for _, c := range endAccount.Transactions {
-				if dropCandidate == nil || !c.SeqProxy.Less(dropCandidate.SeqProxy) {
-					dropCandidate = c
-				}
+			if n := len(sorted); n > 0 {
+				dropCandidate = sorted[n-1]
 			}
 			if dropCandidate != nil {
 				q.erase(dropCandidate)
@@ -499,22 +510,20 @@ func (q *TxQ) tryClearAccountQueue(
 	account [20]byte,
 ) *ApplyResult {
 	// Collect queued sequence-based transactions that come BEFORE the new tx.
-	// These need to be applied first in order.
+	// These need to be applied first in order. GetSortedCandidates already
+	// returns SeqProxy-ascending order, so a forward walk gives the
+	// deterministic apply order without a second sort.
 	var preceding []*Candidate
-	for sp, c := range aq.Transactions {
-		if sp.Less(seqProxy) {
-			preceding = append(preceding, c)
+	for _, c := range aq.GetSortedCandidates() {
+		if !c.SeqProxy.Less(seqProxy) {
+			break
 		}
+		preceding = append(preceding, c)
 	}
 
 	if len(preceding) == 0 {
 		return nil
 	}
-
-	// Sort preceding by SeqProxy (ascending order for application)
-	sort.Slice(preceding, func(i, j int) bool {
-		return preceding[i].SeqProxy.Less(preceding[j].SeqProxy)
-	})
 
 	dist := uint32(len(preceding))
 

--- a/internal/txq/fee.go
+++ b/internal/txq/fee.go
@@ -1,6 +1,7 @@
 package txq
 
 import (
+	"math/bits"
 	"sort"
 )
 
@@ -42,58 +43,16 @@ func mulDiv(a, b, c uint64) uint64 {
 		return ^uint64(0)
 	}
 
-	// Use 128-bit arithmetic via two 64-bit values
-	// high, low = a * b
-	hi, lo := mul64(a, b)
+	// 128-bit a*b. math/bits.Mul64 compiles to a single MUL on amd64/arm64.
+	hi, lo := bits.Mul64(a, b)
 
-	// If high bits are significant relative to c, we'll overflow
+	// Avoid bits.Div64's panic on overflow / divide-by-zero.
 	if hi >= c {
 		return ^uint64(0)
 	}
 
-	// Divide 128-bit value by c
-	return div128(hi, lo, c)
-}
-
-// mul64 multiplies two uint64 values and returns a 128-bit result as (high, low).
-func mul64(a, b uint64) (hi, lo uint64) {
-	const mask32 = (1 << 32) - 1
-	a0 := a & mask32
-	a1 := a >> 32
-	b0 := b & mask32
-	b1 := b >> 32
-
-	p0 := a0 * b0
-	p1 := a0 * b1
-	p2 := a1 * b0
-	p3 := a1 * b1
-
-	mid := p1 + (p0 >> 32) + (p2 & mask32)
-	hi = p3 + (p1 >> 32) + (p2 >> 32) + (mid >> 32)
-	lo = (p0 & mask32) | (mid << 32)
-	return
-}
-
-// div128 divides a 128-bit value (hi, lo) by a 64-bit divisor.
-func div128(hi, lo, divisor uint64) uint64 {
-	if hi == 0 {
-		return lo / divisor
-	}
-
-	// Simple long division for the case where hi < divisor
-	// This works because we already checked hi < divisor in mulDiv
-	quotient := uint64(0)
-	remainder := hi
-
-	for i := 63; i >= 0; i-- {
-		remainder = (remainder << 1) | ((lo >> i) & 1)
-		if remainder >= divisor {
-			remainder -= divisor
-			quotient |= 1 << i
-		}
-	}
-
-	return quotient
+	quo, _ := bits.Div64(hi, lo, c)
+	return quo
 }
 
 // FeeMetrics tracks and computes fee escalation metrics for the transaction queue.

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -207,11 +207,8 @@ func (q *TxQ) erase(c *Candidate) {
 // Called after changing parentHash to reorder same-fee transactions.
 // Caller must hold the lock.
 //
-// Iterates accounts in sorted order and candidates via GetSortedCandidates
-// so the rebuilt byFee slice is bit-identical across validators given the
-// same input set. insertByFee's tiebreak (candidateLess on txID XOR
-// parentHash) already produces a deterministic order from a fixed insert
-// sequence, but pinning the walk order keeps the invariant local.
+// Walks accounts in sorted order and candidates via GetSortedCandidates
+// so the rebuilt byFee slice is bit-identical across validators.
 func (q *TxQ) rebuildByFee() {
 	q.byFee = make([]*Candidate, 0, len(q.byFee))
 

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -1,6 +1,8 @@
 package txq
 
 import (
+	"bytes"
+	"sort"
 	"sync"
 
 	"github.com/LeJamon/goXRPLd/internal/tx"
@@ -204,11 +206,25 @@ func (q *TxQ) erase(c *Candidate) {
 // rebuildByFee rebuilds the byFee index from byAccount.
 // Called after changing parentHash to reorder same-fee transactions.
 // Caller must hold the lock.
+//
+// Iterates accounts in sorted order and candidates via GetSortedCandidates
+// so the rebuilt byFee slice is bit-identical across validators given the
+// same input set. insertByFee's tiebreak (candidateLess on txID XOR
+// parentHash) already produces a deterministic order from a fixed insert
+// sequence, but pinning the walk order keeps the invariant local.
 func (q *TxQ) rebuildByFee() {
 	q.byFee = make([]*Candidate, 0, len(q.byFee))
 
-	for _, aq := range q.byAccount {
-		for _, c := range aq.Transactions {
+	accounts := make([][20]byte, 0, len(q.byAccount))
+	for a := range q.byAccount {
+		accounts = append(accounts, a)
+	}
+	sort.Slice(accounts, func(i, j int) bool {
+		return bytes.Compare(accounts[i][:], accounts[j][:]) < 0
+	})
+
+	for _, a := range accounts {
+		for _, c := range q.byAccount[a].GetSortedCandidates() {
 			q.insertByFee(c)
 		}
 	}


### PR DESCRIPTION
## Summary

- **P0 — ModeManager lock inversion.** `adaptor.transitionLocked` no longer calls `adaptor.SetOperatingMode` or the `onModeChange` subscriber under `m.mu`. The transition is staged under the lock and the side effects run after `Unlock`, breaking the ABBA against `a.mu` that matched the bootstrap deadlock symptom in #418.
- **P0 — `rcl/engine.go` releases `e.mu` before `Broadcast*`.** Proposal/validation broadcasts produced in `timerEntry`/`StartRound` paths are queued and flushed after the lock is released, so `OnProposal`/`OnValidation` ingress (`e.mu.RLock`) is no longer stalled by a slow overlay peer. Direct test callers of `sendValidation`/`closeLedger` keep their synchronous-send behavior via a `deferBroadcasts` depth counter.
- **P1 — txq deterministic iteration.** `rebuildByFee`, the `multiTxn` balance walk, the drop-candidate selection, and the `tryClearAccountQueue` preceding-tx collection now iterate via `GetSortedCandidates` / sorted account keys instead of Go map range.
- **P1 — `csf.BasicNetwork.Peers`** returns peers sorted by `PeerID` so `Broadcast` schedules `Send`s in a stable order and the scheduler's same-time tiebreak is reproducible across runs.

## Test plan
- [x] `go vet ./internal/consensus/... ./internal/txq/...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/consensus/...` (rcl, adaptor, csf, etc.) all pass
- [x] `go test ./internal/txq/...` all pass
- [x] `go test ./internal/ledger/... ./internal/tx/...` (regression sweep) all pass

Fixes #433