### PR TITLE
fix(drops,codec): match rippled overflow + empty-path semantics

### DIFF
--- a/codec/binarycodec/types/pathset.go
+++ b/codec/binarycodec/types/pathset.go
@@ -167,6 +167,9 @@ func newPathStep(v map[string]any) ([]byte, error) {
 // newPath constructs a path from a slice of path steps.
 // It generates a byte array representation of the path, encoding each path step in turn.
 func newPath(v []any) ([]byte, error) {
+	if len(v) == 0 {
+		return nil, ErrInvalidPathSet
+	}
 	b := make([]byte, 0, len(v)*pathStepMaxLen)
 	for _, step := range v {
 		stepMap, ok := step.(map[string]any)

--- a/codec/binarycodec/types/pathset_test.go
+++ b/codec/binarycodec/types/pathset_test.go
@@ -226,6 +226,12 @@ func TestNewPath(t *testing.T) {
 	}
 }
 
+func TestNewPath_Empty(t *testing.T) {
+	// rippled's STPathSet parser rejects empty inner paths; match that.
+	_, err := newPath([]any{})
+	require.ErrorIs(t, err, ErrInvalidPathSet)
+}
+
 func TestNewPathSet(t *testing.T) {
 	tt := []struct {
 		description string

--- a/drops/xrp_amount.go
+++ b/drops/xrp_amount.go
@@ -18,8 +18,9 @@ const DropsPerXRP XRPAmount = 1_000_000
 const MaxDrops XRPAmount = 100_000_000_000_000_000
 
 // ErrXRPAmountOverflow is returned when a checked operation would push the
-// result outside [-MaxDrops, MaxDrops]. Unchecked arithmetic (Add/Sub/Mul)
-// panics with this error wrapped in a string.
+// result outside int64 range. The unchecked operators (Add/Sub/Mul) mirror
+// rippled's plain int64 arithmetic and silently wrap on overflow; callers that
+// need overflow signalled should use AddChecked/SubChecked/MulChecked.
 var ErrXRPAmountOverflow = errors.New("XRPAmount overflow")
 
 // ErrInvalidDecimalXRP is returned by FromDecimalXRP for NaN/Inf inputs.
@@ -50,13 +51,10 @@ func (x XRPAmount) DecimalXRP() float64 {
 	return float64(x) / float64(DropsPerXRP)
 }
 
-// Add returns x+other. It panics on int64 overflow.
+// Add returns x+other with plain int64 arithmetic, mirroring rippled's
+// XRPAmount::operator+. Overflow wraps silently; use AddChecked to detect it.
 func (x XRPAmount) Add(other XRPAmount) XRPAmount {
-	out, err := x.AddChecked(other)
-	if err != nil {
-		panic("drops: " + err.Error())
-	}
-	return out
+	return XRPAmount(int64(x) + int64(other))
 }
 
 // AddChecked returns x+other and an error on int64 overflow.
@@ -68,13 +66,10 @@ func (x XRPAmount) AddChecked(other XRPAmount) (XRPAmount, error) {
 	return XRPAmount(r), nil
 }
 
-// Sub returns x-other. It panics on int64 overflow.
+// Sub returns x-other with plain int64 arithmetic, mirroring rippled's
+// XRPAmount::operator-. Overflow wraps silently; use SubChecked to detect it.
 func (x XRPAmount) Sub(other XRPAmount) XRPAmount {
-	out, err := x.SubChecked(other)
-	if err != nil {
-		panic("drops: " + err.Error())
-	}
-	return out
+	return XRPAmount(int64(x) - int64(other))
 }
 
 // SubChecked returns x-other and an error on int64 overflow.
@@ -86,15 +81,10 @@ func (x XRPAmount) SubChecked(other XRPAmount) (XRPAmount, error) {
 	return XRPAmount(r), nil
 }
 
-// Mul returns x*factor. It panics on int64 overflow rather than silently
-// wrapping. Callers that can tolerate the overflow as an error should use
-// MulChecked.
+// Mul returns x*factor with plain int64 arithmetic, mirroring rippled's
+// XRPAmount::operator*. Overflow wraps silently; use MulChecked to detect it.
 func (x XRPAmount) Mul(factor int64) XRPAmount {
-	out, err := x.MulChecked(factor)
-	if err != nil {
-		panic("drops: " + err.Error())
-	}
-	return out
+	return XRPAmount(int64(x) * factor)
 }
 
 // MulChecked returns x*factor and an error on int64 overflow.

--- a/drops/xrp_amount.go
+++ b/drops/xrp_amount.go
@@ -17,10 +17,11 @@ const DropsPerXRP XRPAmount = 1_000_000
 // Mirrors rippled's `SYSTEM_CURRENCY_PARTS * 100_000_000_000`.
 const MaxDrops XRPAmount = 100_000_000_000_000_000
 
-// ErrXRPAmountOverflow is returned when a checked operation would push the
-// result outside int64 range. The unchecked operators (Add/Sub/Mul) mirror
-// rippled's plain int64 arithmetic and silently wrap on overflow; callers that
-// need overflow signalled should use AddChecked/SubChecked/MulChecked.
+// ErrXRPAmountOverflow is returned when an XRPAmount conversion or checked
+// operation would produce a value outside int64 range — by AddChecked,
+// SubChecked, MulChecked, and by FromDecimalXRP for inputs whose scaled value
+// falls outside [MinInt64, MaxInt64]. The unchecked operators (Add/Sub/Mul)
+// mirror rippled's plain int64 arithmetic and silently wrap on overflow.
 var ErrXRPAmountOverflow = errors.New("XRPAmount overflow")
 
 // ErrInvalidDecimalXRP is returned by FromDecimalXRP for NaN/Inf inputs.

--- a/drops/xrp_amount_test.go
+++ b/drops/xrp_amount_test.go
@@ -17,7 +17,6 @@ func TestXRPAmount_AddOverflow(t *testing.T) {
 	max := XRPAmount(math.MaxInt64)
 	_, err := max.AddChecked(1)
 	require.ErrorIs(t, err, ErrXRPAmountOverflow)
-	// Unchecked Add mirrors rippled's plain int64 +: silent two's-complement wrap.
 	require.Equal(t, XRPAmount(math.MinInt64), max.Add(1))
 
 	min := XRPAmount(math.MinInt64)
@@ -30,7 +29,6 @@ func TestXRPAmount_SubOverflow(t *testing.T) {
 	min := XRPAmount(math.MinInt64)
 	_, err := min.SubChecked(1)
 	require.ErrorIs(t, err, ErrXRPAmountOverflow)
-	// Unchecked Sub mirrors rippled's plain int64 -: silent two's-complement wrap.
 	require.Equal(t, XRPAmount(math.MaxInt64), min.Sub(1))
 
 	max := XRPAmount(math.MaxInt64)
@@ -43,7 +41,6 @@ func TestXRPAmount_MulOverflow(t *testing.T) {
 	// 1e10 * 1e10 = 1e20 overflows int64 (~9.2e18).
 	_, err := XRPAmount(1e10).MulChecked(1e10)
 	require.ErrorIs(t, err, ErrXRPAmountOverflow)
-	// Unchecked Mul mirrors rippled's plain int64 *: silent two's-complement wrap.
 	a, b := int64(1e10), int64(1e10)
 	require.Equal(t, XRPAmount(a*b), XRPAmount(a).Mul(b))
 

--- a/drops/xrp_amount_test.go
+++ b/drops/xrp_amount_test.go
@@ -17,28 +17,35 @@ func TestXRPAmount_AddOverflow(t *testing.T) {
 	max := XRPAmount(math.MaxInt64)
 	_, err := max.AddChecked(1)
 	require.ErrorIs(t, err, ErrXRPAmountOverflow)
-	require.Panics(t, func() { max.Add(1) })
+	// Unchecked Add mirrors rippled's plain int64 +: silent two's-complement wrap.
+	require.Equal(t, XRPAmount(math.MinInt64), max.Add(1))
 
 	min := XRPAmount(math.MinInt64)
 	_, err = min.AddChecked(-1)
 	require.ErrorIs(t, err, ErrXRPAmountOverflow)
+	require.Equal(t, XRPAmount(math.MaxInt64), min.Add(-1))
 }
 
 func TestXRPAmount_SubOverflow(t *testing.T) {
 	min := XRPAmount(math.MinInt64)
 	_, err := min.SubChecked(1)
 	require.ErrorIs(t, err, ErrXRPAmountOverflow)
+	// Unchecked Sub mirrors rippled's plain int64 -: silent two's-complement wrap.
+	require.Equal(t, XRPAmount(math.MaxInt64), min.Sub(1))
 
 	max := XRPAmount(math.MaxInt64)
 	_, err = max.SubChecked(-1)
 	require.ErrorIs(t, err, ErrXRPAmountOverflow)
+	require.Equal(t, XRPAmount(math.MinInt64), max.Sub(-1))
 }
 
 func TestXRPAmount_MulOverflow(t *testing.T) {
 	// 1e10 * 1e10 = 1e20 overflows int64 (~9.2e18).
 	_, err := XRPAmount(1e10).MulChecked(1e10)
 	require.ErrorIs(t, err, ErrXRPAmountOverflow)
-	require.Panics(t, func() { _ = XRPAmount(1e10).Mul(1e10) })
+	// Unchecked Mul mirrors rippled's plain int64 *: silent two's-complement wrap.
+	a, b := int64(1e10), int64(1e10)
+	require.Equal(t, XRPAmount(a*b), XRPAmount(a).Mul(b))
 
 	// Sign handling: MinInt64 * 1 must work.
 	got, err := XRPAmount(math.MinInt64).MulChecked(1)


### PR DESCRIPTION
## Summary
- Revert `XRPAmount.{Add,Sub,Mul}` to plain int64 arithmetic so they silently wrap like rippled's `operator+/-/*`. The panic-on-overflow behaviour from #438 introduced a DoS surface in consensus-adjacent paths (`drops/fees.go`, `internal/tx/apply_state_table.go`). `*Checked` siblings + `ErrXRPAmountOverflow` stay for callers that need overflow signalled.
- Reject empty inner paths in `codec/binarycodec/types/pathset.newPath`, matching rippled's `STPathSet.cpp` parser which throws on empty paths and bad type bits.

## Test plan
- [x] `just test-pkg ./drops/...`
- [x] `just test-pkg ./codec/binarycodec/...`
- [x] `just test-pkg ./internal/tx/...`
- [x] `go build ./...`

Fixes #448