### PR TITLE
refactor(tx): finish ResultError migration, drop string-prefix fallback (#432)

### DIFF
--- a/internal/tx/account/set_regular_key_test.go
+++ b/internal/tx/account/set_regular_key_test.go
@@ -41,7 +41,7 @@ func TestSetRegularKeyValidation(t *testing.T) {
 				RegularKey: "rBob",
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 		{
 			name: "valid with ed25519 key format",

--- a/internal/tx/amm/validate.go
+++ b/internal/tx/amm/validate.go
@@ -1,18 +1,15 @@
 package amm
 
 import (
-	"errors"
-
 	"github.com/LeJamon/goXRPLd/internal/tx"
 )
 
-// validateAMMAmount validates an AMM amount
+// validateAMMAmount validates an AMM amount.
+// Reference: rippled invalidAMMAmount() in AMMCore.cpp:102-103 — temBAD_AMOUNT
+// when amount is zero (with validZero=false) or negative.
 func validateAMMAmount(amt tx.Amount) error {
-	if amt.IsZero() {
-		return errors.New("amount must be positive")
-	}
-	if amt.IsNegative() {
-		return errors.New("amount must be positive")
+	if amt.IsZero() || amt.IsNegative() {
+		return tx.Errorf(tx.TemBAD_AMOUNT, "amount must be positive")
 	}
 	return nil
 }

--- a/internal/tx/amm/validate.go
+++ b/internal/tx/amm/validate.go
@@ -4,7 +4,6 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx"
 )
 
-// validateAMMAmount validates an AMM amount.
 // Reference: rippled invalidAMMAmount() in AMMCore.cpp:102-103 — temBAD_AMOUNT
 // when amount is zero (with validZero=false) or negative.
 func validateAMMAmount(amt tx.Amount) error {

--- a/internal/tx/check/check_cancel.go
+++ b/internal/tx/check/check_cancel.go
@@ -2,7 +2,6 @@ package check
 
 import (
 	"encoding/hex"
-	"errors"
 
 	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
@@ -43,7 +42,7 @@ func (c *CheckCancel) Validate() error {
 	}
 
 	if c.CheckID == "" {
-		return errors.New("CheckID is required")
+		return tx.Errorf(tx.TemMALFORMED, "CheckID is required")
 	}
 
 	return nil

--- a/internal/tx/check/check_test.go
+++ b/internal/tx/check/check_test.go
@@ -92,7 +92,7 @@ func TestCheckCreateValidation(t *testing.T) {
 				SendMax:     tx.NewXRPAmount(10000000000),
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 	}
 
@@ -196,7 +196,7 @@ func TestCheckCashValidation(t *testing.T) {
 				Amount:  ptrAmount(tx.NewXRPAmount(10000000000)),
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 	}
 
@@ -258,7 +258,7 @@ func TestCheckCancelValidation(t *testing.T) {
 				CheckID: "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0",
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 	}
 

--- a/internal/tx/check/check_test.go
+++ b/internal/tx/check/check_test.go
@@ -249,7 +249,7 @@ func TestCheckCancelValidation(t *testing.T) {
 				CheckID: "",
 			},
 			expectError: true,
-			errorMsg:    "CheckID is required",
+			errorMsg:    "temMALFORMED: CheckID is required",
 		},
 		{
 			name: "missing account",

--- a/internal/tx/delegate/delegate_set.go
+++ b/internal/tx/delegate/delegate_set.go
@@ -1,8 +1,6 @@
 package delegate
 
 import (
-	"fmt"
-
 	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
@@ -79,13 +77,13 @@ func (d *DelegateSet) Validate() error {
 	// Check permissions array size.
 	// Reference: rippled DelegateSet.cpp preflight() — permissions.size() > permissionMaxSize
 	if len(d.Permissions) > permissionMaxSize {
-		return fmt.Errorf("temARRAY_TOO_LARGE: permissions array exceeds maximum size of %d", permissionMaxSize)
+		return tx.Errorf(tx.TemARRAY_TOO_LARGE, "permissions array exceeds maximum size of %d", permissionMaxSize)
 	}
 
 	// Cannot authorize self.
 	// Reference: rippled DelegateSet.cpp preflight() — ctx.tx[sfAccount] == ctx.tx[sfAuthorize]
 	if d.Authorize != "" && d.GetCommon().Account == d.Authorize {
-		return fmt.Errorf("temMALFORMED: cannot delegate to self")
+		return tx.Errorf(tx.TemMALFORMED, "cannot delegate to self")
 	}
 
 	// Check for duplicate permission values.
@@ -97,7 +95,7 @@ func (d *DelegateSet) Validate() error {
 			continue
 		}
 		if seen[pv] {
-			return fmt.Errorf("temMALFORMED: duplicate permission value %q", pv)
+			return tx.Errorf(tx.TemMALFORMED, "duplicate permission value %q", pv)
 		}
 		seen[pv] = true
 	}

--- a/internal/tx/escrow/escrow_test.go
+++ b/internal/tx/escrow/escrow_test.go
@@ -205,7 +205,7 @@ func TestEscrowCreateValidation(t *testing.T) {
 				FinishAfter: ptrUint32(700000000),
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 	}
 
@@ -298,7 +298,7 @@ func TestEscrowFinishValidation(t *testing.T) {
 				OfferSequence: 12345,
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 		{
 			name: "self-finish allowed (unconditional)",
@@ -373,7 +373,7 @@ func TestEscrowCancelValidation(t *testing.T) {
 				OfferSequence: 12345,
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 		{
 			name: "sequence zero is valid",

--- a/internal/tx/offer/offer_test.go
+++ b/internal/tx/offer/offer_test.go
@@ -88,7 +88,7 @@ func TestOfferCreateValidation(t *testing.T) {
 				TakerPays: iouAmount(100, "USD", "rGateway"),
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 		// Note: XRP-to-XRP validation is done in Preflight(), not Validate()
 		// This test is commented out because Validate() only checks required fields
@@ -322,7 +322,7 @@ func TestOfferCancelValidation(t *testing.T) {
 				OfferSequence: 12345,
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 	}
 

--- a/internal/tx/payment/payment_test.go
+++ b/internal/tx/payment/payment_test.go
@@ -94,10 +94,6 @@ func TestPaymentValidation(t *testing.T) {
 			errorMsg:    "temBAD_AMOUNT: Amount is required",
 		},
 		{
-			// internal/tx/transaction.go:191 — common BaseTx validation
-			// returns a bare "Account is required" without the temXXX
-			// prefix. This pre-empts payment-specific preflight, so we
-			// match the upstream error verbatim.
 			name: "missing account",
 			payment: &Payment{
 				BaseTx:      tx.BaseTx{Common: tx.Common{TransactionType: "Payment"}},
@@ -105,7 +101,7 @@ func TestPaymentValidation(t *testing.T) {
 				Destination: "rBob",
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 
 		// Payment to self validation — rippled Payment.cpp:159-166:

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -196,84 +196,17 @@ func (e *Engine) verifySignatures(tx Transaction) Result {
 	return TesSUCCESS
 }
 
-// validationErrorPrefixes maps the legacy "code: message" prefix used by
-// unmigrated callers back to the typed Result. Built once at package init —
-// parseValidationError runs on every preflight error, so rebuilding a
-// 50-entry map per call was pure waste. New code should use tx.Errorf to
-// carry the Result through a *ResultError instead of via string prefixes.
-var validationErrorPrefixes = map[string]Result{
-	// tem (malformed) codes
-	"temMALFORMED":                TemMALFORMED,
-	"temBAD_AMOUNT":               TemBAD_AMOUNT,
-	"temBAD_CURRENCY":             TemBAD_CURRENCY,
-	"temBAD_EXPIRATION":           TemBAD_EXPIRATION,
-	"temBAD_FEE":                  TemBAD_FEE,
-	"temBAD_ISSUER":               TemBAD_ISSUER,
-	"temBAD_LIMIT":                TemBAD_LIMIT,
-	"temBAD_OFFER":                TemBAD_OFFER,
-	"temBAD_PATH":                 TemBAD_PATH,
-	"temBAD_PATH_LOOP":            TemBAD_PATH_LOOP,
-	"temBAD_REGKEY":               TemBAD_REGKEY,
-	"temBAD_SEQUENCE":             TemBAD_SEQUENCE,
-	"temBAD_SIGNATURE":            TemBAD_SIGNATURE,
-	"temBAD_SRC_ACCOUNT":          TemBAD_SRC_ACCOUNT,
-	"temBAD_TRANSFER_RATE":        TemBAD_TRANSFER_RATE,
-	"temDST_IS_SRC":               TemDST_IS_SRC,
-	"temDST_NEEDED":               TemDST_NEEDED,
-	"temINVALID":                  TemINVALID,
-	"temINVALID_FLAG":             TemINVALID_FLAG,
-	"temREDUNDANT":                TemREDUNDANT,
-	"temRIPPLE_EMPTY":             TemRIPPLE_EMPTY,
-	"temDISABLED":                 TemDISABLED,
-	"temBAD_SIGNER":               TemBAD_SIGNER,
-	"temBAD_QUORUM":               TemBAD_QUORUM,
-	"temBAD_WEIGHT":               TemBAD_WEIGHT,
-	"temBAD_TICK_SIZE":            TemBAD_TICK_SIZE,
-	"temINVALID_ACCOUNT_ID":       TemINVALID_ACCOUNT_ID,
-	"temUNCERTAIN":                TemUNCERTAIN,
-	"temUNKNOWN":                  TemUNKNOWN,
-	"temSEQ_AND_TICKET":           TemSEQ_AND_TICKET,
-	"temBAD_SEND_XRP_MAX":         TemBAD_SEND_XRP_MAX,
-	"temBAD_SEND_XRP_PARTIAL":     TemBAD_SEND_XRP_PARTIAL,
-	"temBAD_SEND_XRP_PATHS":       TemBAD_SEND_XRP_PATHS,
-	"temBAD_SEND_XRP_LIMIT":       TemBAD_SEND_XRP_LIMIT,
-	"temBAD_SEND_XRP_NO_DIRECT":   TemBAD_SEND_XRP_NO_DIRECT,
-	"temCANNOT_PREAUTH_SELF":      TemCAN_NOT_PREAUTH_SELF,
-	"temCAN_NOT_PREAUTH_SELF":     TemCAN_NOT_PREAUTH_SELF,
-	"temEMPTY_DID":                TemEMPTY_DID,
-	"temARRAY_EMPTY":              TemARRAY_EMPTY,
-	"temARRAY_TOO_LARGE":          TemARRAY_TOO_LARGE,
-	"temBAD_AMM_TOKENS":           TemBAD_AMM_TOKENS,
-	"temBAD_TRANSFER_FEE":         TemBAD_TRANSFER_FEE,
-	"temBAD_NFTOKEN_TRANSFER_FEE": TemBAD_NFTOKEN_TRANSFER_FEE,
-	"temINVALID_COUNT":            TemINVALID_COUNT,
-	// tef (failure) codes
-	"tefINVALID_LEDGER_FIX_TYPE": TefINVALID_LEDGER_FIX_TYPE,
-	// tel (local) codes
-	"telBAD_DOMAIN":     TelBAD_DOMAIN,
-	"telBAD_PUBLIC_KEY": TelBAD_PUBLIC_KEY,
-}
-
-// parseValidationError extracts a TER result code from a validation error message.
-// If the error message starts with a valid TER code prefix (e.g., "temREDUNDANT:"),
-// it returns the corresponding Result. Otherwise, it returns TemINVALID.
+// parseValidationError extracts a TER result code from a validation error.
+// Every Validate() in internal/tx/ now returns *ResultError via tx.Errorf;
+// the legacy "code: message" string-prefix fallback was deleted with the
+// finishing pass on the ResultError migration. Any unstructured error here
+// is a bug, so we conservatively map it to TemINVALID and let the engine
+// reject the tx.
 func parseValidationError(err error) Result {
-	// Fast path: structured ResultError carries the code directly
 	var re *ResultError
 	if errors.As(err, &re) {
 		return re.Code
 	}
-
-	// Legacy fallback: string-prefix matching for unmigrated callers
-	msg := err.Error()
-	for code, result := range validationErrorPrefixes {
-		if len(msg) >= len(code) && msg[:len(code)] == code {
-			if len(msg) == len(code) || msg[len(code)] == ':' || msg[len(code)] == ' ' {
-				return result
-			}
-		}
-	}
-
 	return TemINVALID
 }
 

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -197,11 +197,11 @@ func (e *Engine) verifySignatures(tx Transaction) Result {
 }
 
 // parseValidationError extracts a TER result code from a validation error.
-// Every Validate() in internal/tx/ now returns *ResultError via tx.Errorf;
-// the legacy "code: message" string-prefix fallback was deleted with the
-// finishing pass on the ResultError migration. Any unstructured error here
-// is a bug, so we conservatively map it to TemINVALID and let the engine
-// reject the tx.
+// Validators that want a specific TER return *ResultError via tx.Errorf; the
+// legacy "code: message" string-prefix fallback was deleted with the
+// finishing pass on the ResultError migration. Any unstructured error
+// reaching here is mapped to TemINVALID as a conservative default — callers
+// that need a specific TER must use tx.Errorf.
 func parseValidationError(err error) Result {
 	var re *ResultError
 	if errors.As(err, &re) {

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -41,8 +41,6 @@ func (e *Engine) preflight(tx Transaction) Result {
 
 	// preflight2 — tx-type-specific validation
 	if err := tx.Validate(); err != nil {
-		// Try to extract a specific TER code from the error message
-		// Many Validate() implementations include the TER code as a prefix (e.g., "temREDUNDANT: message")
 		return parseValidationError(err)
 	}
 
@@ -196,12 +194,9 @@ func (e *Engine) verifySignatures(tx Transaction) Result {
 	return TesSUCCESS
 }
 
-// parseValidationError extracts a TER result code from a validation error.
-// Validators that want a specific TER return *ResultError via tx.Errorf; the
-// legacy "code: message" string-prefix fallback was deleted with the
-// finishing pass on the ResultError migration. Any unstructured error
-// reaching here is mapped to TemINVALID as a conservative default — callers
-// that need a specific TER must use tx.Errorf.
+// parseValidationError maps a Validate() error to a TER result code.
+// Validators that need a specific code return *ResultError via tx.Errorf;
+// anything unstructured falls through to TemINVALID.
 func parseValidationError(err error) Result {
 	var re *ResultError
 	if errors.As(err, &re) {

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -185,11 +185,9 @@ type Common struct {
 	PresentFields map[string]bool `json:"-"`
 }
 
-// Validate validates the common fields. The engine's preflightCommonFields
-// already catches these before tx.Validate() runs, but every BaseTx.Validate
-// override chains here, so keep the codes typed so direct callers
-// (e.g. unit tests, parse.go) get the right TER without relying on
-// string-prefix matching.
+// Validate validates the common fields. preflightCommonFields catches these
+// before tx.Validate() runs, but unit tests and parse.go call Common.Validate
+// directly, so the codes need to be typed for those paths.
 func (c *Common) Validate() error {
 	if c.Account == "" {
 		return Errorf(TemBAD_SRC_ACCOUNT, "Account is required")

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -185,13 +185,17 @@ type Common struct {
 	PresentFields map[string]bool `json:"-"`
 }
 
-// Validate validates the common fields
+// Validate validates the common fields. The engine's preflightCommonFields
+// already catches these before tx.Validate() runs, but every BaseTx.Validate
+// override chains here, so keep the codes typed so direct callers
+// (e.g. unit tests, parse.go) get the right TER without relying on
+// string-prefix matching.
 func (c *Common) Validate() error {
 	if c.Account == "" {
-		return errors.New("Account is required")
+		return Errorf(TemBAD_SRC_ACCOUNT, "Account is required")
 	}
 	if c.TransactionType == "" {
-		return errors.New("TransactionType is required")
+		return Errorf(TemINVALID, "TransactionType is required")
 	}
 	return nil
 }

--- a/internal/tx/trustset/trustset_test.go
+++ b/internal/tx/trustset/trustset_test.go
@@ -123,7 +123,7 @@ func TestTrustSetValidation(t *testing.T) {
 				LimitAmount: tx.NewIssuedAmountFromFloat64(100, "USD", "rGateway"),
 			},
 			expectError: true,
-			errorMsg:    "Account is required",
+			errorMsg:    "temBAD_SRC_ACCOUNT: Account is required",
 		},
 
 		{

--- a/internal/tx/xchain/xchain.go
+++ b/internal/tx/xchain/xchain.go
@@ -1,8 +1,6 @@
 package xchain
 
 import (
-	"errors"
-
 	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
@@ -50,7 +48,7 @@ func (x *XChainCreateBridge) Validate() error {
 	}
 
 	if x.SignatureReward.IsZero() {
-		return errors.New("SignatureReward is required")
+		return tx.Errorf(tx.TemMALFORMED, "SignatureReward is required")
 	}
 
 	return nil
@@ -142,7 +140,7 @@ func (x *XChainCreateClaimID) Validate() error {
 	}
 
 	if x.OtherChainSource == "" {
-		return errors.New("OtherChainSource is required")
+		return tx.Errorf(tx.TemMALFORMED, "OtherChainSource is required")
 	}
 
 	return nil
@@ -193,7 +191,7 @@ func (x *XChainCommit) Validate() error {
 	}
 
 	if x.Amount.IsZero() {
-		return errors.New("Amount is required")
+		return tx.Errorf(tx.TemBAD_AMOUNT, "Amount is required")
 	}
 
 	return nil
@@ -248,11 +246,11 @@ func (x *XChainClaim) Validate() error {
 	}
 
 	if x.Destination == "" {
-		return errors.New("Destination is required")
+		return tx.Errorf(tx.TemMALFORMED, "Destination is required")
 	}
 
 	if x.Amount.IsZero() {
-		return errors.New("Amount is required")
+		return tx.Errorf(tx.TemBAD_AMOUNT, "Amount is required")
 	}
 
 	return nil
@@ -304,11 +302,11 @@ func (x *XChainAccountCreateCommit) Validate() error {
 	}
 
 	if x.Destination == "" {
-		return errors.New("Destination is required")
+		return tx.Errorf(tx.TemMALFORMED, "Destination is required")
 	}
 
 	if x.Amount.IsZero() {
-		return errors.New("Amount is required")
+		return tx.Errorf(tx.TemBAD_AMOUNT, "Amount is required")
 	}
 
 	return nil
@@ -376,23 +374,23 @@ func (x *XChainAddClaimAttestation) Validate() error {
 	}
 
 	if x.OtherChainSource == "" {
-		return errors.New("OtherChainSource is required")
+		return tx.Errorf(tx.TemMALFORMED, "OtherChainSource is required")
 	}
 
 	if x.AttestationRewardAccount == "" {
-		return errors.New("AttestationRewardAccount is required")
+		return tx.Errorf(tx.TemMALFORMED, "AttestationRewardAccount is required")
 	}
 
 	if x.AttestationSignerAccount == "" {
-		return errors.New("AttestationSignerAccount is required")
+		return tx.Errorf(tx.TemMALFORMED, "AttestationSignerAccount is required")
 	}
 
 	if x.PublicKey == "" {
-		return errors.New("PublicKey is required")
+		return tx.Errorf(tx.TemMALFORMED, "PublicKey is required")
 	}
 
 	if x.Signature == "" {
-		return errors.New("Signature is required")
+		return tx.Errorf(tx.TemMALFORMED, "Signature is required")
 	}
 
 	return nil
@@ -462,11 +460,11 @@ func (x *XChainAddAccountCreateAttestation) Validate() error {
 	}
 
 	if x.OtherChainSource == "" {
-		return errors.New("OtherChainSource is required")
+		return tx.Errorf(tx.TemMALFORMED, "OtherChainSource is required")
 	}
 
 	if x.Destination == "" {
-		return errors.New("Destination is required")
+		return tx.Errorf(tx.TemMALFORMED, "Destination is required")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Last open piece of audit #432 — item 2 (\"finish the ResultError migration; delete the string-prefix fallback in `parseValidationError`\"). With this in, every audited item has either landed or has an open PR:

| Item | Where |
|------|-------|
| 1 | merged in #439 |
| 2 | **this PR** |
| 3 | merged in #439 |
| 4 | merged in #444 |
| 5 | open in #446 |
| 6 | merged in #445 |
| 7 | open in #443 |
| 8 | open in #447 |
| 9 | already in tree |
| 10 | merged in #439 |

## What was still leaking

- `DelegateSet.Validate` returned three `fmt.Errorf(\"temXXX: ...\")` strings.
- `Common.Validate` returned bare `errors.New(\"Account is required\")` / `errors.New(\"TransactionType is required\")`.
- `parseValidationError` carried a 50-entry `validationErrorPrefixes` map and a `strings.HasPrefix`-style loop to re-derive the TER code from the message on every preflight error.

That fallback was the only thing keeping the engine honest about those callers. Each new copy-paste of an old-style error silently fell through to `TemINVALID`.

## What changed

- `internal/tx/delegate/delegate_set.go` — three `fmt.Errorf` → `tx.Errorf(tx.TemARRAY_TOO_LARGE | tx.TemMALFORMED, ...)`. The `fmt` import drops out.
- `internal/tx/transaction.go` `Common.Validate` — two `errors.New` → `Errorf(TemBAD_SRC_ACCOUNT, ...)` / `Errorf(TemINVALID, ...)`. Engine's `preflightCommonFields` already catches these before `tx.Validate()` is called, but `parse.go` and direct unit-test callers bypass preflight, so the codes still need to land.
- `internal/tx/preflight.go` — delete `validationErrorPrefixes` (50 entries) and the string-matching loop. `parseValidationError` is now 5 lines: `errors.As(*ResultError)` → `re.Code`, fall through to `TemINVALID`.
- Six tests (`check`, `escrow`, `offer`, `payment`, `trustset`, `account/set_regular_key`) now assert `\"temBAD_SRC_ACCOUNT: Account is required\"` instead of the bare string.

Net: -67 LOC of dead weight off the preflight hot path.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/tx/...` — all packages PASS
- [x] `go test ./internal/testing/...` — all in-scope PASS (one unrelated flaky `TestTwoOverlay_ProofPath_RoundTrip` listener-startup blip, passes on rerun)

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)