### PR TITLE
fix(consensus): throttle, cap, and de-prioritize tx-set acquire retries (#420)

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -74,6 +74,11 @@ type NetworkSender interface {
 	// each missing node by its SHAMap path-based NodeID. nodeIDs
 	// must each be exactly 33 bytes (32 path bytes + 1 depth byte).
 	RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte) error
+	// RequestTxSetMissingNodesExcept is RequestTxSetMissingNodes with a
+	// set of peer IDs to skip during broadcast. Used by the router to
+	// route around peers that have repeatedly returned non-progressing
+	// TMLedgerData replies for an in-flight acquisition. Issue #420.
+	RequestTxSetMissingNodesExcept(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error
 	RequestLedger(id consensus.LedgerID) error
 	RequestLedgerByHashAndSeq(hash [32]byte, seq uint32) error
 	RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte, seq uint32) error
@@ -126,6 +131,9 @@ func (n *noopSender) RelayValidation(*consensus.Validation, uint64) error { retu
 func (n *noopSender) UpdateRelaySlot([]byte, uint64, []uint64)            {}
 func (n *noopSender) RequestTxSet(consensus.TxSetID) error                { return nil }
 func (n *noopSender) RequestTxSetMissingNodes(consensus.TxSetID, [][]byte) error {
+	return nil
+}
+func (n *noopSender) RequestTxSetMissingNodesExcept(consensus.TxSetID, [][]byte, map[uint64]bool) error {
 	return nil
 }
 func (n *noopSender) RequestLedger(consensus.LedgerID) error                   { return nil }
@@ -532,6 +540,10 @@ func (a *Adaptor) RequestTxSet(id consensus.TxSetID) error {
 
 func (a *Adaptor) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte) error {
 	return a.sender.RequestTxSetMissingNodes(id, nodeIDs)
+}
+
+func (a *Adaptor) RequestTxSetMissingNodesExcept(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
+	return a.sender.RequestTxSetMissingNodesExcept(id, nodeIDs, excluded)
 }
 
 func (a *Adaptor) RequestLedger(id consensus.LedgerID) error {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -73,12 +73,12 @@ type NetworkSender interface {
 	// request returns a partial tree, follow up with a request for
 	// each missing node by its SHAMap path-based NodeID. nodeIDs
 	// must each be exactly 33 bytes (32 path bytes + 1 depth byte).
-	RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte) error
-	// RequestTxSetMissingNodesExcept is RequestTxSetMissingNodes with a
-	// set of peer IDs to skip during broadcast. Used by the router to
-	// route around peers that have repeatedly returned non-progressing
-	// TMLedgerData replies for an in-flight acquisition. Issue #420.
-	RequestTxSetMissingNodesExcept(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error
+	// excluded carries peer IDs that should be skipped during this
+	// broadcast — populated by the router with peers that have
+	// repeatedly returned non-progressing TMLedgerData replies for
+	// this acquisition. A nil or empty map is the unrestricted case.
+	// Issue #420.
+	RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error
 	RequestLedger(id consensus.LedgerID) error
 	RequestLedgerByHashAndSeq(hash [32]byte, seq uint32) error
 	RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte, seq uint32) error
@@ -130,10 +130,7 @@ func (n *noopSender) RelayProposal(*consensus.Proposal, uint64) error     { retu
 func (n *noopSender) RelayValidation(*consensus.Validation, uint64) error { return nil }
 func (n *noopSender) UpdateRelaySlot([]byte, uint64, []uint64)            {}
 func (n *noopSender) RequestTxSet(consensus.TxSetID) error                { return nil }
-func (n *noopSender) RequestTxSetMissingNodes(consensus.TxSetID, [][]byte) error {
-	return nil
-}
-func (n *noopSender) RequestTxSetMissingNodesExcept(consensus.TxSetID, [][]byte, map[uint64]bool) error {
+func (n *noopSender) RequestTxSetMissingNodes(consensus.TxSetID, [][]byte, map[uint64]bool) error {
 	return nil
 }
 func (n *noopSender) RequestLedger(consensus.LedgerID) error                   { return nil }
@@ -538,12 +535,8 @@ func (a *Adaptor) RequestTxSet(id consensus.TxSetID) error {
 	return a.sender.RequestTxSet(id)
 }
 
-func (a *Adaptor) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte) error {
-	return a.sender.RequestTxSetMissingNodes(id, nodeIDs)
-}
-
-func (a *Adaptor) RequestTxSetMissingNodesExcept(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
-	return a.sender.RequestTxSetMissingNodesExcept(id, nodeIDs, excluded)
+func (a *Adaptor) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
+	return a.sender.RequestTxSetMissingNodes(id, nodeIDs, excluded)
 }
 
 func (a *Adaptor) RequestLedger(id consensus.LedgerID) error {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -236,6 +236,15 @@ type Adaptor struct {
 	// AmendmentTable.cpp:75-286.
 	trustedVotes *TrustedVotes
 
+	// onTxSetRequested fires before every RequestTxSet broadcast so
+	// the router can re-arm its in-flight tx-set acquisition state
+	// (clear attempts and lastRequest), mirroring rippled's
+	// TransactionAcquire::stillNeed reset path invoked from
+	// InboundTransactionsImp::getSet at InboundTransactions.cpp:107-114.
+	// Nil before SetOnTxSetRequested is called; nil callers are a no-op.
+	// Issue #420.
+	onTxSetRequested func(consensus.TxSetID)
+
 	logger *slog.Logger
 }
 
@@ -531,7 +540,20 @@ func (a *Adaptor) UpdateRelaySlot(validatorKey []byte, originPeer uint64, seenPe
 	a.sender.UpdateRelaySlot(validatorKey, originPeer, seenPeers)
 }
 
+// SetOnTxSetRequested registers a callback invoked at the start of
+// every RequestTxSet. Used by the router to mirror rippled's
+// stillNeed re-arm: every active re-ask from consensus resets the
+// throttle/attempt bookkeeping on the in-flight acquisition so the
+// next inbound TMLedgerData broadcasts immediately. Set once at
+// startup; not safe for concurrent re-registration.
+func (a *Adaptor) SetOnTxSetRequested(cb func(consensus.TxSetID)) {
+	a.onTxSetRequested = cb
+}
+
 func (a *Adaptor) RequestTxSet(id consensus.TxSetID) error {
+	if a.onTxSetRequested != nil {
+		a.onTxSetRequested(id)
+	}
 	return a.sender.RequestTxSet(id)
 }
 

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -112,6 +112,13 @@ type Router struct {
 	txSetAcquireMu sync.Mutex
 	txSetAcquire   map[consensus.TxSetID]*txSetAcquireState
 
+	// Retry-loop knobs for tx-set acquisition (issue #420). Set to
+	// production defaults by NewRouter; tests inject smaller values via
+	// SetTxSetRetryKnobsForTest so they don't sleep for the production
+	// 250ms throttle window. See txSetRetryKnobs for the meaning of
+	// each field.
+	txSetRetryKnobs txSetRetryKnobs
+
 	// activeTask, when non-nil, is the LedgerReplayTask currently
 	// driving a multi-ledger backward catch-up. Single-task design:
 	// deep catch-up is a one-shot operation, and serializing the
@@ -131,11 +138,10 @@ type txSetAcquireState struct {
 	// those broadcasts so we can surface failure after a cap rather
 	// than spinning forever. peerNonProgress tracks consecutive
 	// TMLedgerData responses from a peer that failed to extend the
-	// SHAMap; peers over txSetPeerNonProgressThreshold are skipped
+	// SHAMap; peers at or over the per-peer threshold are skipped
 	// during the next broadcast.
 	lastRequest     time.Time
 	attempts        int
-	failed          bool
 	peerNonProgress map[uint64]int
 }
 
@@ -143,33 +149,45 @@ type txSetAcquireState struct {
 // margin while bounding memory under a stalled consumer.
 const txSetAcquireTTL = 60 * time.Second
 
-// Retry-loop knobs for tx-set acquisition (issue #420). Declared as
-// vars so tests can dial them down via txSetRetryKnobsForTest /
-// setTxSetRetryKnobsForTest. Production callers must not mutate.
+// txSetRetryKnobs collects the tunable parameters of the tx-set acquire
+// retry loop (issue #420). goXRPL's retry is event-driven (one tick
+// per inbound TMLedgerData), so these adapt — rather than directly
+// mirror — rippled's timer-driven cadence in TransactionAcquire.cpp.
 //
-//   - txSetRetryMinInterval: minimum spacing between
-//     RequestTxSetMissingNodes broadcasts for the same acquisition.
-//     Mirrors rippled's TX_ACQUIRE_TIMEOUT (TransactionAcquire.cpp:34).
-//   - txSetMaxAttempts: maximum number of broadcasts per acquisition
-//     before we mark it failed and stop. Mirrors rippled's
-//     MAX_TIMEOUTS = 20 (TransactionAcquire.cpp:38).
-//   - txSetPeerNonProgressThreshold: consecutive non-progressing
-//     TMLedgerData replies from one peer before that peer is skipped
-//     during the next broadcast. Scale of rippled's NORM_TIMEOUTS = 4.
-var (
-	txSetRetryMinInterval         = 250 * time.Millisecond
-	txSetMaxAttempts              = 20
-	txSetPeerNonProgressThreshold = 3
-)
-
-func txSetRetryKnobsForTest() (minInterval time.Duration, maxAttempts, peerThreshold int) {
-	return txSetRetryMinInterval, txSetMaxAttempts, txSetPeerNonProgressThreshold
+//   - MinInterval: minimum spacing between successive broadcasts for
+//     the same acquisition. We reuse rippled's TX_ACQUIRE_TIMEOUT
+//     period (TransactionAcquire.cpp:34, 250ms) as the cadence ceiling
+//     so a chatty peer can't drive us faster than rippled's own timer
+//     would have.
+//   - MaxAttempts: hard cap on broadcasts per acquisition. Matches
+//     rippled's MAX_TIMEOUTS = 20 (TransactionAcquire.cpp:38) — the
+//     point at which rippled's onTimer flips failed_ and gives up.
+//   - PeerNonProgressThreshold: consecutive non-progressing
+//     TMLedgerData replies from one peer before it is skipped on the
+//     next broadcast. goXRPL-specific: rippled selects peers via the
+//     hasTxSet predicate and does not score them per-acquire. 3 is
+//     small enough to react quickly to a truly stuck peer and large
+//     enough to ride out a transient empty reply.
+type txSetRetryKnobs struct {
+	MinInterval              time.Duration
+	MaxAttempts              int
+	PeerNonProgressThreshold int
 }
 
-func setTxSetRetryKnobsForTest(minInterval time.Duration, maxAttempts, peerThreshold int) {
-	txSetRetryMinInterval = minInterval
-	txSetMaxAttempts = maxAttempts
-	txSetPeerNonProgressThreshold = peerThreshold
+func defaultTxSetRetryKnobs() txSetRetryKnobs {
+	return txSetRetryKnobs{
+		MinInterval:              250 * time.Millisecond,
+		MaxAttempts:              20,
+		PeerNonProgressThreshold: 3,
+	}
+}
+
+// SetTxSetRetryKnobsForTest overrides the issue-#420 retry knobs on
+// this Router. Tests use it to dial timings down so they don't sleep
+// for the production throttle window. Not safe to call concurrently
+// with handleTxSetData and not intended for production use.
+func (r *Router) SetTxSetRetryKnobsForTest(knobs txSetRetryKnobs) {
+	r.txSetRetryKnobs = knobs
 }
 
 // messageDedupTTL is how long a proposal/validation hash is
@@ -196,8 +214,9 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManag
 		logger:       logger,
 		peerStates:   make(map[peermanagement.PeerID]*peerLedgerState),
 		replayer:     inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
-		messageSeen:  newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
-		txSetAcquire: make(map[consensus.TxSetID]*txSetAcquireState),
+		messageSeen:     newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
+		txSetAcquire:    make(map[consensus.TxSetID]*txSetAcquireState),
+		txSetRetryKnobs: defaultTxSetRetryKnobs(),
 	}
 	// Wire the stash → acquisition hook so quorum decisions on unknown
 	// ledgers don't sit silently in pendingLedgerValidations.
@@ -1043,13 +1062,6 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 
 	r.txSetAcquireMu.Lock()
 	state, exists := r.txSetAcquire[txSetID]
-	if exists && state.failed {
-		// Already gave up on this acquire; ignore stragglers until the
-		// TTL sweep clears the entry. Without this guard a slow peer's
-		// reply would re-arm the retry loop after we surfaced failure.
-		r.txSetAcquireMu.Unlock()
-		return
-	}
 	if !exists {
 		txMap, err := shamap.New(shamap.TypeTransaction)
 		if err != nil {
@@ -1081,13 +1093,21 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	r.txSetAcquireMu.Unlock()
 
 	// Root NodeID is 33 zero bytes. AddRootNode is idempotent
-	// (ErrRootAlreadySet treated as success).
+	// (ErrRootAlreadySet treated as success). rootAccepted feeds
+	// per-peer progress accounting so a peer whose reply contains
+	// only the root still counts as making progress — matches
+	// TransactionAcquire::takeNodes (TransactionAcquire.cpp:194-226)
+	// where any successful add (root or non-root) returns useful().
+	rootAccepted := false
 	for _, node := range ld.Nodes {
 		if !isShamapRootNodeID(node.NodeID) {
 			continue
 		}
-		if err := txMap.AddRootNode([32]byte(txSetID), node.NodeData); err != nil &&
-			!errors.Is(err, shamap.ErrRootAlreadySet) {
+		err := txMap.AddRootNode([32]byte(txSetID), node.NodeData)
+		switch {
+		case err == nil, errors.Is(err, shamap.ErrRootAlreadySet):
+			rootAccepted = true
+		default:
 			r.logger.Info("tx-set sync: AddRootNode failed",
 				"t", "consensus", "event", "txset-reject",
 				"txset", fmt.Sprintf("%x", txSetID[:8]),
@@ -1196,15 +1216,17 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			// route around peers that have repeatedly failed to extend
 			// the SHAMap. Without these guards a non-progressing peer
 			// triggers 100+ retries/sec until the 60s TTL sweep fires.
+			knobs := r.txSetRetryKnobs
+			madeProgress := added > 0 || rootAccepted
 			r.txSetAcquireMu.Lock()
 			if originPeer != 0 {
-				if added > 0 {
+				if madeProgress {
 					state.peerNonProgress[originPeer] = 0
 				} else {
 					state.peerNonProgress[originPeer]++
 				}
 			}
-			if !state.lastRequest.IsZero() && time.Since(state.lastRequest) < txSetRetryMinInterval {
+			if !state.lastRequest.IsZero() && time.Since(state.lastRequest) < knobs.MinInterval {
 				r.txSetAcquireMu.Unlock()
 				r.logger.Debug("tx-set sync: retry throttled",
 					"t", "consensus", "event", "txset-retry-throttle",
@@ -1213,10 +1235,16 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				)
 				return
 			}
-			if state.attempts >= txSetMaxAttempts {
-				state.failed = true
+			if state.attempts >= knobs.MaxAttempts {
 				attempts := state.attempts
+				delete(r.txSetAcquire, txSetID)
 				r.txSetAcquireMu.Unlock()
+				// Drop the entry rather than mark it permanently
+				// failed: if consensus is still proposing this set
+				// (rippled handles the equivalent via stillNeed —
+				// TransactionAcquire.cpp:256-264), the next inbound
+				// TMLedgerData should start a fresh acquire rather
+				// than be silently dropped for the TTL window.
 				r.logger.Info("tx-set sync: max attempts exceeded",
 					"t", "consensus", "event", "txset-reject",
 					"txset", fmt.Sprintf("%x", txSetID[:8]),
@@ -1229,7 +1257,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			state.lastRequest = time.Now()
 			var excluded map[uint64]bool
 			for pid, count := range state.peerNonProgress {
-				if count >= txSetPeerNonProgressThreshold {
+				if count >= knobs.PeerNonProgressThreshold {
 					if excluded == nil {
 						excluded = make(map[uint64]bool)
 					}
@@ -1252,7 +1280,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"attempts", attempts,
 				"excluded_peers", len(excluded),
 			)
-			if reqErr := r.adaptor.RequestTxSetMissingNodesExcept(txSetID, nodeIDs, excluded); reqErr != nil {
+			if reqErr := r.adaptor.RequestTxSetMissingNodes(txSetID, nodeIDs, excluded); reqErr != nil {
 				r.logger.Info("tx-set sync: missing-nodes request failed",
 					"t", "consensus", "event", "txset-reject",
 					"txset", fmt.Sprintf("%x", txSetID[:8]),

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -184,9 +184,12 @@ func defaultTxSetRetryKnobs() txSetRetryKnobs {
 
 // SetTxSetRetryKnobsForTest overrides the issue-#420 retry knobs on
 // this Router. Tests use it to dial timings down so they don't sleep
-// for the production throttle window. Not safe to call concurrently
-// with handleTxSetData and not intended for production use.
+// for the production throttle window. The lock matches the read in
+// handleTxSetData so racing this against an active inbox goroutine
+// is safe under -race; production is not expected to call this.
 func (r *Router) SetTxSetRetryKnobsForTest(knobs txSetRetryKnobs) {
+	r.txSetAcquireMu.Lock()
+	defer r.txSetAcquireMu.Unlock()
 	r.txSetRetryKnobs = knobs
 }
 
@@ -224,6 +227,13 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManag
 		if svc := adaptor.LedgerService(); svc != nil {
 			svc.SetOnPendingValidationStashed(r.armValidationStashAcquisition)
 		}
+		// Wire stillNeed re-arm so every consensus re-ask of an
+		// in-flight tx-set clears the per-acquisition throttle and
+		// attempt-cap state. Mirrors rippled's
+		// TransactionAcquire::stillNeed (TransactionAcquire.cpp:256-264)
+		// triggered from InboundTransactionsImp::getSet
+		// (InboundTransactions.cpp:107-114). Issue #420.
+		adaptor.SetOnTxSetRequested(r.MarkTxSetStillNeeded)
 	}
 	return r
 }
@@ -1122,7 +1132,18 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	// hash-search approach (AddKnownNodeUnchecked) silently rejected
 	// every node it couldn't place beneath a loaded parent, producing
 	// the missing-nodes retry storm of issue #413.
+	//
+	// replyValid stays true unless any non-root node fails parse or
+	// AddKnownNodeByID — matches rippled's takeNodes
+	// (TransactionAcquire.cpp:217-220) where a single bad non-root
+	// poisons the WHOLE reply (`return SHAMapAddNode::invalid()`),
+	// which the caller (InboundTransactions.cpp:177-178) then charges
+	// as feeUselessData. We can't charge resource fees, but we MUST
+	// reflect the same all-or-nothing reply outcome in per-peer
+	// non-progress accounting so a peer trickling junk alongside one
+	// good node can't keep its counter pinned at zero.
 	added := 0
+	replyValid := true
 	for _, node := range ld.Nodes {
 		if isShamapRootNodeID(node.NodeID) {
 			continue
@@ -1132,6 +1153,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		}
 		parsedID, err := shamap.UnmarshalBinary(node.NodeID)
 		if err != nil {
+			replyValid = false
 			r.logger.Debug("tx-set sync: malformed node ID",
 				"t", "consensus", "event", "txset-node-reject",
 				"txset", fmt.Sprintf("%x", txSetID[:8]),
@@ -1140,6 +1162,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			continue
 		}
 		if err := txMap.AddKnownNodeByID(parsedID, node.NodeData); err != nil {
+			replyValid = false
 			r.logger.Debug("tx-set sync: node rejected",
 				"t", "consensus", "event", "txset-node-reject",
 				"txset", fmt.Sprintf("%x", txSetID[:8]),
@@ -1216,9 +1239,17 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			// route around peers that have repeatedly failed to extend
 			// the SHAMap. Without these guards a non-progressing peer
 			// triggers 100+ retries/sec until the 60s TTL sweep fires.
-			knobs := r.txSetRetryKnobs
-			madeProgress := added > 0 || rootAccepted
+			// madeProgress folds rippled's takeNodes useful() semantics
+			// (TransactionAcquire.cpp:194-226): a reply is useful only
+			// when it was non-empty AND every non-root node parsed and
+			// added cleanly. Any single bad non-root → invalid reply →
+			// not progress for the originating peer.
+			madeProgress := replyValid && (added > 0 || rootAccepted)
 			r.txSetAcquireMu.Lock()
+			// Knobs are read under txSetAcquireMu so a concurrent
+			// SetTxSetRetryKnobsForTest (test-only API) can't tear a
+			// half-updated struct into the hot path.
+			knobs := r.txSetRetryKnobs
 			if originPeer != 0 {
 				if madeProgress {
 					state.peerNonProgress[originPeer] = 0
@@ -1328,6 +1359,28 @@ func (r *Router) deleteTxSetAcquire(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Lock()
 	delete(r.txSetAcquire, txSetID)
 	r.txSetAcquireMu.Unlock()
+}
+
+// MarkTxSetStillNeeded is the active re-arm hook fired every time
+// consensus re-asks for a tx-set via Adaptor.RequestTxSet. If an
+// in-flight acquisition for this set still exists, attempts and
+// lastRequest are cleared so the next inbound TMLedgerData broadcasts
+// immediately instead of being throttled or silently dropped past the
+// max-attempts cap. Mirrors rippled's TransactionAcquire::stillNeed
+// (TransactionAcquire.cpp:256-264), invoked from
+// InboundTransactionsImp::getSet when consensus re-acquires a known
+// in-flight set (InboundTransactions.cpp:107-114). A no-op if the
+// router has no entry for txSetID (e.g. first request, or already
+// completed and swept). Issue #420.
+func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
+	r.txSetAcquireMu.Lock()
+	defer r.txSetAcquireMu.Unlock()
+	state, ok := r.txSetAcquire[txSetID]
+	if !ok {
+		return
+	}
+	state.attempts = 0
+	state.lastRequest = time.Time{}
 }
 
 // sweepStaleTxSetAcquireLocked drops entries older than txSetAcquireTTL.

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -210,13 +210,13 @@ const messageDedupMaxEntries = 4096
 func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManager, inbox <-chan *peermanagement.InboundMessage) *Router {
 	logger := slog.Default().With("component", "consensus-router")
 	r := &Router{
-		engine:       engine,
-		adaptor:      adaptor,
-		modeManager:  modeManager,
-		inbox:        inbox,
-		logger:       logger,
-		peerStates:   make(map[peermanagement.PeerID]*peerLedgerState),
-		replayer:     inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
+		engine:          engine,
+		adaptor:         adaptor,
+		modeManager:     modeManager,
+		inbox:           inbox,
+		logger:          logger,
+		peerStates:      make(map[peermanagement.PeerID]*peerLedgerState),
+		replayer:        inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
 		messageSeen:     newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
 		txSetAcquire:    make(map[consensus.TxSetID]*txSetAcquireState),
 		txSetRetryKnobs: defaultTxSetRetryKnobs(),

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -125,11 +125,52 @@ type txSetAcquireState struct {
 	txMap      *shamap.SHAMap
 	startedAt  time.Time
 	lastUpdate time.Time
+
+	// Retry bookkeeping for issue #420. lastRequest is when we most
+	// recently broadcast a RequestTxSetMissingNodes; attempts counts
+	// those broadcasts so we can surface failure after a cap rather
+	// than spinning forever. peerNonProgress tracks consecutive
+	// TMLedgerData responses from a peer that failed to extend the
+	// SHAMap; peers over txSetPeerNonProgressThreshold are skipped
+	// during the next broadcast.
+	lastRequest     time.Time
+	attempts        int
+	failed          bool
+	peerNonProgress map[uint64]int
 }
 
 // 60s covers consensus round (LedgerMaxConsensus ~15s) plus retries with
 // margin while bounding memory under a stalled consumer.
 const txSetAcquireTTL = 60 * time.Second
+
+// Retry-loop knobs for tx-set acquisition (issue #420). Declared as
+// vars so tests can dial them down via txSetRetryKnobsForTest /
+// setTxSetRetryKnobsForTest. Production callers must not mutate.
+//
+//   - txSetRetryMinInterval: minimum spacing between
+//     RequestTxSetMissingNodes broadcasts for the same acquisition.
+//     Mirrors rippled's TX_ACQUIRE_TIMEOUT (TransactionAcquire.cpp:34).
+//   - txSetMaxAttempts: maximum number of broadcasts per acquisition
+//     before we mark it failed and stop. Mirrors rippled's
+//     MAX_TIMEOUTS = 20 (TransactionAcquire.cpp:38).
+//   - txSetPeerNonProgressThreshold: consecutive non-progressing
+//     TMLedgerData replies from one peer before that peer is skipped
+//     during the next broadcast. Scale of rippled's NORM_TIMEOUTS = 4.
+var (
+	txSetRetryMinInterval         = 250 * time.Millisecond
+	txSetMaxAttempts              = 20
+	txSetPeerNonProgressThreshold = 3
+)
+
+func txSetRetryKnobsForTest() (minInterval time.Duration, maxAttempts, peerThreshold int) {
+	return txSetRetryMinInterval, txSetMaxAttempts, txSetPeerNonProgressThreshold
+}
+
+func setTxSetRetryKnobsForTest(minInterval time.Duration, maxAttempts, peerThreshold int) {
+	txSetRetryMinInterval = minInterval
+	txSetMaxAttempts = maxAttempts
+	txSetPeerNonProgressThreshold = peerThreshold
+}
 
 // messageDedupTTL is how long a proposal/validation hash is
 // remembered for duplicate-detection purposes. Rippled uses a
@@ -990,7 +1031,10 @@ type logger interface {
 // accumulate nodes across responses, then either finish (→ engine.OnTxSet)
 // or request missing nodes (TransactionAcquire.cpp:144-171). State is keyed
 // by tx-set ID so partial responses can resume.
-func (r *Router) handleTxSetData(ld *message.LedgerData) {
+//
+// originPeer is the peer ID of the sender, used to attribute non-progress
+// for issue #420's per-peer de-prioritization.
+func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	if len(ld.LedgerHash) != 32 {
 		return
 	}
@@ -999,6 +1043,13 @@ func (r *Router) handleTxSetData(ld *message.LedgerData) {
 
 	r.txSetAcquireMu.Lock()
 	state, exists := r.txSetAcquire[txSetID]
+	if exists && state.failed {
+		// Already gave up on this acquire; ignore stragglers until the
+		// TTL sweep clears the entry. Without this guard a slow peer's
+		// reply would re-arm the retry loop after we surfaced failure.
+		r.txSetAcquireMu.Unlock()
+		return
+	}
 	if !exists {
 		txMap, err := shamap.New(shamap.TypeTransaction)
 		if err != nil {
@@ -1017,7 +1068,11 @@ func (r *Router) handleTxSetData(ld *message.LedgerData) {
 				"error", err.Error())
 			return
 		}
-		state = &txSetAcquireState{txMap: txMap, startedAt: time.Now()}
+		state = &txSetAcquireState{
+			txMap:           txMap,
+			startedAt:       time.Now(),
+			peerNonProgress: make(map[uint64]int),
+		}
 		r.txSetAcquire[txSetID] = state
 	}
 	state.lastUpdate = time.Now()
@@ -1137,6 +1192,53 @@ func (r *Router) handleTxSetData(ld *message.LedgerData) {
 		}
 
 		if len(remaining) > 0 {
+			// Issue #420: throttle retries, cap total attempts, and
+			// route around peers that have repeatedly failed to extend
+			// the SHAMap. Without these guards a non-progressing peer
+			// triggers 100+ retries/sec until the 60s TTL sweep fires.
+			r.txSetAcquireMu.Lock()
+			if originPeer != 0 {
+				if added > 0 {
+					state.peerNonProgress[originPeer] = 0
+				} else {
+					state.peerNonProgress[originPeer]++
+				}
+			}
+			if !state.lastRequest.IsZero() && time.Since(state.lastRequest) < txSetRetryMinInterval {
+				r.txSetAcquireMu.Unlock()
+				r.logger.Debug("tx-set sync: retry throttled",
+					"t", "consensus", "event", "txset-retry-throttle",
+					"txset", fmt.Sprintf("%x", txSetID[:8]),
+					"missing", len(remaining),
+				)
+				return
+			}
+			if state.attempts >= txSetMaxAttempts {
+				state.failed = true
+				attempts := state.attempts
+				r.txSetAcquireMu.Unlock()
+				r.logger.Info("tx-set sync: max attempts exceeded",
+					"t", "consensus", "event", "txset-reject",
+					"txset", fmt.Sprintf("%x", txSetID[:8]),
+					"attempts", attempts,
+					"missing", len(remaining),
+				)
+				return
+			}
+			state.attempts++
+			state.lastRequest = time.Now()
+			var excluded map[uint64]bool
+			for pid, count := range state.peerNonProgress {
+				if count >= txSetPeerNonProgressThreshold {
+					if excluded == nil {
+						excluded = make(map[uint64]bool)
+					}
+					excluded[pid] = true
+				}
+			}
+			attempts := state.attempts
+			r.txSetAcquireMu.Unlock()
+
 			nodeIDs := make([][]byte, len(remaining))
 			for i, m := range remaining {
 				nodeIDs[i] = m.NodeID.Bytes()
@@ -1147,8 +1249,10 @@ func (r *Router) handleTxSetData(ld *message.LedgerData) {
 				"non_root_added", added,
 				"filled_local", filledFromPool,
 				"missing", len(remaining),
+				"attempts", attempts,
+				"excluded_peers", len(excluded),
 			)
-			if reqErr := r.adaptor.RequestTxSetMissingNodes(txSetID, nodeIDs); reqErr != nil {
+			if reqErr := r.adaptor.RequestTxSetMissingNodesExcept(txSetID, nodeIDs, excluded); reqErr != nil {
 				r.logger.Info("tx-set sync: missing-nodes request failed",
 					"t", "consensus", "event", "txset-reject",
 					"txset", fmt.Sprintf("%x", txSetID[:8]),
@@ -1829,7 +1933,7 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 	// liTS_CANDIDATE response — InboundTransactions::gotData feeds the
 	// engine via gotTxSet (consensus-time only). Issue #401.
 	if ld.InfoType == message.LedgerInfoTsCandidate {
-		r.handleTxSetData(ld)
+		r.handleTxSetData(ld, uint64(msg.PeerID))
 		return
 	}
 

--- a/internal/consensus/adaptor/router_txset_retry_test.go
+++ b/internal/consensus/adaptor/router_txset_retry_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 // retryRecordingSender captures the per-call peer-exclusion set passed
-// to RequestTxSetMissingNodesExcept so tests can pin issue #420's
-// throttle, max-attempts, and de-prioritization behavior. Other
-// NetworkSender methods inherit from noopSender.
+// to RequestTxSetMissingNodes so tests can pin issue #420's throttle,
+// max-attempts, and de-prioritization behavior. Other NetworkSender
+// methods inherit from noopSender.
 type retryRecordingSender struct {
 	noopSender
 	mu        sync.Mutex
@@ -29,11 +29,7 @@ type retryRecordedCall struct {
 	excluded map[uint64]bool
 }
 
-func (s *retryRecordingSender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte) error {
-	return s.RequestTxSetMissingNodesExcept(id, nodeIDs, nil)
-}
-
-func (s *retryRecordingSender) RequestTxSetMissingNodesExcept(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
+func (s *retryRecordingSender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	copyExcluded := map[uint64]bool{}
@@ -68,7 +64,7 @@ func (s *retryRecordingSender) lastCall() retryRecordedCall {
 }
 
 // newRetryRouter wires a Router whose NetworkSender records every
-// RequestTxSetMissingNodesExcept call. The router is NOT started — tests
+// RequestTxSetMissingNodes call. The router is NOT started — tests
 // invoke handleTxSetData directly so timings are deterministic.
 func newRetryRouter(t *testing.T) (*Router, *retryRecordingSender) {
 	t.Helper()
@@ -86,16 +82,16 @@ func newRetryRouter(t *testing.T) (*Router, *retryRecordingSender) {
 	return router, rs
 }
 
-// partialTxSetLedgerData returns a TMLedgerData carrying ONLY the
+// rootOnlyTxSetLedgerData returns a TMLedgerData carrying ONLY the
 // SHAMap root node of a tx-set whose remaining nodes are NOT included.
 // Feeding this to handleTxSetData adds the root and leaves the SHAMap
 // incomplete, which forces the FinishSync-fails-then-retry branch —
-// the exact code path issue #420 targets.
-func partialTxSetLedgerData(t *testing.T, leafCount int) (*message.LedgerData, consensus.TxSetID) {
+// the exact code path issue #420 targets. AddRootNode succeeds so this
+// reply counts as "progress" per the rippled-aligned takeNodes
+// semantics (TransactionAcquire.cpp:194-226).
+func rootOnlyTxSetLedgerData(t *testing.T, leafCount int) (*message.LedgerData, consensus.TxSetID) {
 	t.Helper()
-	txMap, txSetID, wireNodes := buildTxSetForTest(t, leafCount)
-	_ = txMap
-	require.NotEmpty(t, wireNodes, "tx-set must have at least a root")
+	_, txSetID, wireNodes := buildTxSetForTest(t, leafCount)
 	require.Greater(t, len(wireNodes), 1, "tx-set must have non-root nodes so the consumer enters the retry branch")
 	rootNode := wireNodes[0]
 	ld := &message.LedgerData{
@@ -108,13 +104,29 @@ func partialTxSetLedgerData(t *testing.T, leafCount int) (*message.LedgerData, c
 	return ld, consensus.TxSetID(txSetID)
 }
 
-// withRetryKnobs temporarily overrides the issue-#420 retry knobs for
+// emptyTxSetLedgerData returns a TMLedgerData for txSetID carrying no
+// nodes at all. Used to drive the non-progress branch once state
+// already exists from a prior reply: rootAccepted stays false and
+// added stays 0, so the peer's non-progress counter increments.
+func emptyTxSetLedgerData(txSetID consensus.TxSetID) *message.LedgerData {
+	return &message.LedgerData{
+		InfoType:   message.LedgerInfoTsCandidate,
+		LedgerHash: txSetID[:],
+		Nodes:      nil,
+	}
+}
+
+// withRetryKnobs overrides this router's issue-#420 retry knobs for
 // the duration of fn so tests run instantly instead of waiting for the
 // production 250 ms throttle window. Restores prior values on return.
-func withRetryKnobs(minInterval time.Duration, maxAttempts, peerThreshold int, fn func()) {
-	prevInterval, prevMax, prevThreshold := txSetRetryKnobsForTest()
-	setTxSetRetryKnobsForTest(minInterval, maxAttempts, peerThreshold)
-	defer setTxSetRetryKnobsForTest(prevInterval, prevMax, prevThreshold)
+func withRetryKnobs(router *Router, minInterval time.Duration, maxAttempts, peerThreshold int, fn func()) {
+	prev := router.txSetRetryKnobs
+	router.SetTxSetRetryKnobsForTest(txSetRetryKnobs{
+		MinInterval:              minInterval,
+		MaxAttempts:              maxAttempts,
+		PeerNonProgressThreshold: peerThreshold,
+	})
+	defer router.SetTxSetRetryKnobsForTest(prev)
 	fn()
 }
 
@@ -126,8 +138,8 @@ func withRetryKnobs(minInterval time.Duration, maxAttempts, peerThreshold int, f
 // driving the 100+ retries/sec storm captured in the issue.
 func TestTxSetRetry_ThrottleSkipsRapidRetries(t *testing.T) {
 	router, rs := newRetryRouter(t)
-	withRetryKnobs(time.Hour, 100, 100, func() {
-		ld, _ := partialTxSetLedgerData(t, 4)
+	withRetryKnobs(router, time.Hour, 100, 100, func() {
+		ld, _ := rootOnlyTxSetLedgerData(t, 4)
 
 		router.handleTxSetData(ld, 1)
 		require.Equal(t, 1, rs.calledN(),
@@ -140,16 +152,18 @@ func TestTxSetRetry_ThrottleSkipsRapidRetries(t *testing.T) {
 	})
 }
 
-// TestTxSetRetry_MaxAttemptsCapMarksFailed pins the give-up condition
-// (issue #420 item 2b). After txSetMaxAttempts broadcasts the
-// acquisition is marked failed; further replies are ignored and no
-// additional broadcast fires. Without this cap, a stuck acquisition
-// loops forever until the 60s TTL sweep clears it.
-func TestTxSetRetry_MaxAttemptsCapMarksFailed(t *testing.T) {
+// TestTxSetRetry_MaxAttemptsCapDropsAcquire pins the give-up condition
+// (issue #420 item 2b). After MaxAttempts broadcasts the acquisition
+// is dropped: the cap-hit reply does NOT broadcast and the entry is
+// deleted. A later reply for the same tx-set ID re-arms a fresh
+// acquire — mirrors rippled's stillNeed reset path
+// (TransactionAcquire.cpp:256-264) so consensus oscillating back to
+// the same set isn't silenced for the full TTL window.
+func TestTxSetRetry_MaxAttemptsCapDropsAcquire(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	const maxAttempts = 3
-	withRetryKnobs(0, maxAttempts, 1_000_000, func() {
-		ld, _ := partialTxSetLedgerData(t, 4)
+	withRetryKnobs(router, 0, maxAttempts, 1_000_000, func() {
+		ld, _ := rootOnlyTxSetLedgerData(t, 4)
 
 		for i := 0; i < maxAttempts; i++ {
 			router.handleTxSetData(ld, uint64(i+1))
@@ -157,44 +171,53 @@ func TestTxSetRetry_MaxAttemptsCapMarksFailed(t *testing.T) {
 		require.Equal(t, maxAttempts, rs.calledN(),
 			"each of the first maxAttempts replies must broadcast")
 
+		// Reply at the cap: hits the delete-on-cap branch — no broadcast.
 		router.handleTxSetData(ld, 99)
-		assert.Equal(t, maxAttempts, rs.calledN(),
-			"reply past the cap must NOT broadcast — acquisition is now failed")
+		require.Equal(t, maxAttempts, rs.calledN(),
+			"reply that hits the cap must NOT broadcast (delete-on-cap)")
 
+		// Subsequent reply re-creates state and broadcasts a fresh attempt.
 		router.handleTxSetData(ld, 100)
-		assert.Equal(t, maxAttempts, rs.calledN(),
-			"failed acquisitions stay quiescent across further replies")
+		assert.Equal(t, maxAttempts+1, rs.calledN(),
+			"after the entry was dropped, the next reply must start a fresh acquire "+
+				"and broadcast again — matches rippled's stillNeed re-arm path")
 	})
 }
 
 // TestTxSetRetry_DeprioritizesNonProgressingPeer pins per-peer
 // exclusion (issue #420 item 2c). A peer that returns
-// txSetPeerNonProgressThreshold non-progressing replies in a row
-// is dropped from the next missing-nodes broadcast via the excluded
-// map. The first broadcast carries an empty exclusion set; once the
-// per-peer counter crosses the threshold the next broadcast excludes
-// that peer.
+// PeerNonProgressThreshold non-progressing replies in a row is
+// dropped from the next missing-nodes broadcast via the excluded
+// map. Non-progress matches rippled's takeNodes invalid() branch:
+// a reply that adds neither root nor non-root nodes.
 func TestTxSetRetry_DeprioritizesNonProgressingPeer(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	const threshold = 2
-	withRetryKnobs(0, 1_000_000, threshold, func() {
-		ld, _ := partialTxSetLedgerData(t, 4)
+	withRetryKnobs(router, 0, 1_000_000, threshold, func() {
+		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
+		noProgressLD := emptyTxSetLedgerData(txSetID)
 		const badPeer = uint64(7)
 
-		// Reply 1 — non-progress count for badPeer becomes 1 (< threshold).
+		// Setup: root-only reply creates state. Root-add counts as
+		// progress (TransactionAcquire.cpp:194-226 useful() branch),
+		// so the per-peer counter stays at 0.
 		router.handleTxSetData(ld, badPeer)
 		require.Equal(t, 1, rs.calledN())
-		first := rs.lastCall()
-		assert.Empty(t, first.excluded,
-			"first non-progress reply must not yet exclude the peer (count < threshold)")
+		assert.Empty(t, rs.lastCall().excluded,
+			"first broadcast must carry no exclusions")
 
-		// Reply 2 — non-progress count for badPeer becomes 2 (== threshold) →
-		// the broadcast for this retry must exclude badPeer.
-		router.handleTxSetData(ld, badPeer)
+		// Non-progress reply 1 — counter[badPeer] = 1 (< threshold).
+		router.handleTxSetData(noProgressLD, badPeer)
 		require.Equal(t, 2, rs.calledN())
-		second := rs.lastCall()
-		require.NotNil(t, second.excluded)
-		assert.Truef(t, second.excluded[badPeer],
+		assert.Empty(t, rs.lastCall().excluded,
+			"counter below threshold must not yet exclude the peer")
+
+		// Non-progress reply 2 — counter[badPeer] = 2 (== threshold) →
+		// the broadcast for this retry must exclude badPeer.
+		router.handleTxSetData(noProgressLD, badPeer)
+		require.Equal(t, 3, rs.calledN())
+		require.NotNil(t, rs.lastCall().excluded)
+		assert.Truef(t, rs.lastCall().excluded[badPeer],
 			"peer %d should be excluded once non-progress count reaches threshold (%d)",
 			badPeer, threshold)
 	})
@@ -207,30 +230,28 @@ func TestTxSetRetry_DeprioritizesNonProgressingPeer(t *testing.T) {
 func TestTxSetRetry_ProgressResetsNonProgressCounter(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	const threshold = 2
-	withRetryKnobs(0, 1_000_000, threshold, func() {
-		ldEmpty, txSetID := partialTxSetLedgerData(t, 4)
+	withRetryKnobs(router, 0, 1_000_000, threshold, func() {
+		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
+		noProgressLD := emptyTxSetLedgerData(txSetID)
 		const peer = uint64(11)
 
-		// One non-progress reply.
-		router.handleTxSetData(ldEmpty, peer)
+		// Setup: root reply creates state (counts as progress).
+		router.handleTxSetData(ld, peer)
 		require.Equal(t, 1, rs.calledN())
 
-		// A progressing reply: include a non-root inner node so `added` > 0.
-		_, _, wireNodes := buildTxSetForTest(t, 4)
-		require.GreaterOrEqual(t, len(wireNodes), 2)
-		progressLD := &message.LedgerData{
-			InfoType:   message.LedgerInfoTsCandidate,
-			LedgerHash: txSetID[:],
-			Nodes: []message.LedgerNode{
-				{NodeID: wireNodes[0].NodeID, NodeData: wireNodes[0].Data},
-				{NodeID: wireNodes[1].NodeID, NodeData: wireNodes[1].Data},
-			},
-		}
-		router.handleTxSetData(progressLD, peer)
+		// Non-progress reply — counter[peer] = 1.
+		router.handleTxSetData(noProgressLD, peer)
+		require.Equal(t, 2, rs.calledN())
 
-		// Now a single more non-progress reply: counter is at 1, NOT yet
-		// at threshold → peer must NOT appear in the exclusion set.
-		router.handleTxSetData(ldEmpty, peer)
+		// Progress reply: same root (ErrRootAlreadySet still counts as
+		// rootAccepted=true per takeNodes useful() semantics) — resets
+		// counter[peer] to 0.
+		router.handleTxSetData(ld, peer)
+		require.Equal(t, 3, rs.calledN())
+
+		// One further non-progress reply — counter[peer] = 1 again,
+		// still < threshold=2, peer must NOT be excluded.
+		router.handleTxSetData(noProgressLD, peer)
 		last := rs.lastCall()
 		assert.Falsef(t, last.excluded[peer],
 			"progress reset the non-progress counter; one further empty reply "+

--- a/internal/consensus/adaptor/router_txset_retry_test.go
+++ b/internal/consensus/adaptor/router_txset_retry_test.go
@@ -258,3 +258,112 @@ func TestTxSetRetry_ProgressResetsNonProgressCounter(t *testing.T) {
 				"should not be enough to exclude the peer")
 	})
 }
+
+// TestTxSetRetry_BadNonRootInvalidatesWholeReply pins the
+// rippled-faithful takeNodes useful() semantics (M1 from PR #454
+// review). A reply that adds a valid root but ALSO carries any
+// non-root node that fails to parse / be added must NOT count as
+// progress for the peer that sent it — mirrors rippled's
+// TransactionAcquire.cpp:217-220 where one bad non-root short-circuits
+// the whole reply to invalid() and the caller charges feeUselessData
+// (InboundTransactions.cpp:177-178). Without this, a peer trickling
+// one valid node alongside junk pins its non-progress counter at zero
+// forever and is never de-prioritized by the per-peer threshold.
+func TestTxSetRetry_BadNonRootInvalidatesWholeReply(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	const threshold = 2
+	withRetryKnobs(router, 0, 1_000_000, threshold, func() {
+		_, txSetID, wireNodes := buildTxSetForTest(t, 4)
+		rootNode := wireNodes[0]
+		require.Greater(t, len(wireNodes), 1)
+
+		// rootPlusJunkLD: valid root + a non-root NodeID with garbage
+		// data so AddKnownNodeByID fails. The non-root NodeID itself is
+		// well-formed (33 bytes, non-zero depth) so it survives the
+		// UnmarshalBinary check; the failure is on the data side.
+		nonRootID := wireNodes[1].NodeID
+		rootPlusJunkLD := &message.LedgerData{
+			InfoType:   message.LedgerInfoTsCandidate,
+			LedgerHash: txSetID[:],
+			Nodes: []message.LedgerNode{
+				{NodeID: rootNode.NodeID, NodeData: rootNode.Data},
+				{NodeID: nonRootID, NodeData: []byte{0xde, 0xad, 0xbe, 0xef}},
+			},
+		}
+		const badPeer = uint64(42)
+
+		// Reply 1: root accepted but junk non-root → replyValid=false →
+		// counter[badPeer] = 1 (< threshold).
+		router.handleTxSetData(rootPlusJunkLD, badPeer)
+		require.Equal(t, 1, rs.calledN())
+		assert.Empty(t, rs.lastCall().excluded,
+			"first such reply must broadcast without exclusions yet")
+
+		// Reply 2: same shape → counter[badPeer] = 2 (== threshold) →
+		// the next broadcast must exclude badPeer. Pre-M1 the rootAccepted
+		// branch alone would have reset the counter to 0 on each reply,
+		// so this peer would never have been excluded.
+		router.handleTxSetData(rootPlusJunkLD, badPeer)
+		require.Equal(t, 2, rs.calledN())
+		require.NotNil(t, rs.lastCall().excluded,
+			"second bad-non-root reply must trigger per-peer exclusion")
+		assert.Truef(t, rs.lastCall().excluded[badPeer],
+			"peer %d should be excluded — junk non-root must invalidate the whole reply "+
+				"per rippled's takeNodes useful() (TransactionAcquire.cpp:217-220), "+
+				"NOT count as progress just because the root was accepted",
+			badPeer)
+	})
+}
+
+// TestTxSetRetry_StillNeededReArmsAtCap pins the stillNeed re-arm
+// path (M3 from PR #454 review). Once an in-flight acquisition hits
+// MaxAttempts, the next inbound reply would normally drop into the
+// delete-on-cap branch. If consensus actively re-asks via
+// Adaptor.RequestTxSet (rippled's stillNeed trigger,
+// InboundTransactions.cpp:107-114 → TransactionAcquire.cpp:256-264)
+// BEFORE that drop happens, attempts must be reset so the acquisition
+// keeps broadcasting instead of waiting on the 60s TTL sweep.
+func TestTxSetRetry_StillNeededReArmsAtCap(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	const maxAttempts = 2
+	withRetryKnobs(router, 0, maxAttempts, 1_000_000, func() {
+		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
+
+		// Drive attempts up to the cap.
+		for i := 0; i < maxAttempts; i++ {
+			router.handleTxSetData(ld, uint64(i+1))
+		}
+		require.Equal(t, maxAttempts, rs.calledN(),
+			"each of the first maxAttempts replies must broadcast")
+
+		// stillNeed: consensus re-asks for the same set. With the wiring
+		// in place, this resets attempts and lastRequest on the entry.
+		require.NoError(t, router.adaptor.RequestTxSet(txSetID))
+
+		// Next reply: pre-M3 this would have hit the cap and deleted the
+		// entry (no broadcast). With M3, attempts is back at 0 so the
+		// broadcast fires.
+		router.handleTxSetData(ld, 99)
+		assert.Equal(t, maxAttempts+1, rs.calledN(),
+			"after stillNeed re-arm, the next reply must broadcast instead "+
+				"of being silenced by the max-attempts cap")
+	})
+}
+
+// TestTxSetRetry_StillNeededNoOpOnUnknownTxSet pins that the
+// stillNeed hook is a safe no-op when no acquisition is in flight —
+// matching rippled's getSet path where the stillNeed call is gated on
+// `it->second.mAcquire` being live (InboundTransactions.cpp:110-113).
+func TestTxSetRetry_StillNeededNoOpOnUnknownTxSet(t *testing.T) {
+	router, _ := newRetryRouter(t)
+	var unknownID consensus.TxSetID
+	unknownID[0] = 0xab
+
+	// Must not panic, must not allocate state, must not broadcast.
+	router.MarkTxSetStillNeeded(unknownID)
+
+	router.txSetAcquireMu.Lock()
+	_, exists := router.txSetAcquire[unknownID]
+	router.txSetAcquireMu.Unlock()
+	assert.False(t, exists, "MarkTxSetStillNeeded must not allocate state for unknown tx-sets")
+}

--- a/internal/consensus/adaptor/router_txset_retry_test.go
+++ b/internal/consensus/adaptor/router_txset_retry_test.go
@@ -1,0 +1,239 @@
+package adaptor
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// retryRecordingSender captures the per-call peer-exclusion set passed
+// to RequestTxSetMissingNodesExcept so tests can pin issue #420's
+// throttle, max-attempts, and de-prioritization behavior. Other
+// NetworkSender methods inherit from noopSender.
+type retryRecordingSender struct {
+	noopSender
+	mu        sync.Mutex
+	calls     []retryRecordedCall
+	returnErr error
+}
+
+type retryRecordedCall struct {
+	txSetID  consensus.TxSetID
+	nodeIDs  [][]byte
+	excluded map[uint64]bool
+}
+
+func (s *retryRecordingSender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte) error {
+	return s.RequestTxSetMissingNodesExcept(id, nodeIDs, nil)
+}
+
+func (s *retryRecordingSender) RequestTxSetMissingNodesExcept(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	copyExcluded := map[uint64]bool{}
+	for k, v := range excluded {
+		copyExcluded[k] = v
+	}
+	copyIDs := make([][]byte, len(nodeIDs))
+	for i, n := range nodeIDs {
+		copyIDs[i] = append([]byte(nil), n...)
+	}
+	s.calls = append(s.calls, retryRecordedCall{
+		txSetID:  id,
+		nodeIDs:  copyIDs,
+		excluded: copyExcluded,
+	})
+	return s.returnErr
+}
+
+func (s *retryRecordingSender) calledN() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+func (s *retryRecordingSender) lastCall() retryRecordedCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.calls) == 0 {
+		return retryRecordedCall{}
+	}
+	return s.calls[len(s.calls)-1]
+}
+
+// newRetryRouter wires a Router whose NetworkSender records every
+// RequestTxSetMissingNodesExcept call. The router is NOT started — tests
+// invoke handleTxSetData directly so timings are deterministic.
+func newRetryRouter(t *testing.T) (*Router, *retryRecordingSender) {
+	t.Helper()
+	svc := newTestLedgerService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	rs := &retryRecordingSender{}
+	a := New(Config{
+		LedgerService: svc,
+		Sender:        rs,
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+	router := NewRouter(&mockEngine{}, a, nil, make(chan *peermanagement.InboundMessage, 1))
+	return router, rs
+}
+
+// partialTxSetLedgerData returns a TMLedgerData carrying ONLY the
+// SHAMap root node of a tx-set whose remaining nodes are NOT included.
+// Feeding this to handleTxSetData adds the root and leaves the SHAMap
+// incomplete, which forces the FinishSync-fails-then-retry branch —
+// the exact code path issue #420 targets.
+func partialTxSetLedgerData(t *testing.T, leafCount int) (*message.LedgerData, consensus.TxSetID) {
+	t.Helper()
+	txMap, txSetID, wireNodes := buildTxSetForTest(t, leafCount)
+	_ = txMap
+	require.NotEmpty(t, wireNodes, "tx-set must have at least a root")
+	require.Greater(t, len(wireNodes), 1, "tx-set must have non-root nodes so the consumer enters the retry branch")
+	rootNode := wireNodes[0]
+	ld := &message.LedgerData{
+		InfoType:   message.LedgerInfoTsCandidate,
+		LedgerHash: txSetID[:],
+		Nodes: []message.LedgerNode{
+			{NodeID: rootNode.NodeID, NodeData: rootNode.Data},
+		},
+	}
+	return ld, consensus.TxSetID(txSetID)
+}
+
+// withRetryKnobs temporarily overrides the issue-#420 retry knobs for
+// the duration of fn so tests run instantly instead of waiting for the
+// production 250 ms throttle window. Restores prior values on return.
+func withRetryKnobs(minInterval time.Duration, maxAttempts, peerThreshold int, fn func()) {
+	prevInterval, prevMax, prevThreshold := txSetRetryKnobsForTest()
+	setTxSetRetryKnobsForTest(minInterval, maxAttempts, peerThreshold)
+	defer setTxSetRetryKnobsForTest(prevInterval, prevMax, prevThreshold)
+	fn()
+}
+
+// TestTxSetRetry_ThrottleSkipsRapidRetries pins the rate limiter
+// (issue #420 item 2a). A peer that replies twice in quick succession
+// must not produce two broadcasts — the second falls inside the
+// minimum-interval window and is dropped. Without the throttle, every
+// non-progressing TMLedgerData spawns an immediate re-broadcast,
+// driving the 100+ retries/sec storm captured in the issue.
+func TestTxSetRetry_ThrottleSkipsRapidRetries(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	withRetryKnobs(time.Hour, 100, 100, func() {
+		ld, _ := partialTxSetLedgerData(t, 4)
+
+		router.handleTxSetData(ld, 1)
+		require.Equal(t, 1, rs.calledN(),
+			"first reply must trigger exactly one missing-nodes broadcast")
+
+		router.handleTxSetData(ld, 1)
+		assert.Equal(t, 1, rs.calledN(),
+			"second reply inside the throttle window must NOT trigger another broadcast — "+
+				"issue #420: without this, every non-progressing reply re-broadcasts immediately")
+	})
+}
+
+// TestTxSetRetry_MaxAttemptsCapMarksFailed pins the give-up condition
+// (issue #420 item 2b). After txSetMaxAttempts broadcasts the
+// acquisition is marked failed; further replies are ignored and no
+// additional broadcast fires. Without this cap, a stuck acquisition
+// loops forever until the 60s TTL sweep clears it.
+func TestTxSetRetry_MaxAttemptsCapMarksFailed(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	const maxAttempts = 3
+	withRetryKnobs(0, maxAttempts, 1_000_000, func() {
+		ld, _ := partialTxSetLedgerData(t, 4)
+
+		for i := 0; i < maxAttempts; i++ {
+			router.handleTxSetData(ld, uint64(i+1))
+		}
+		require.Equal(t, maxAttempts, rs.calledN(),
+			"each of the first maxAttempts replies must broadcast")
+
+		router.handleTxSetData(ld, 99)
+		assert.Equal(t, maxAttempts, rs.calledN(),
+			"reply past the cap must NOT broadcast — acquisition is now failed")
+
+		router.handleTxSetData(ld, 100)
+		assert.Equal(t, maxAttempts, rs.calledN(),
+			"failed acquisitions stay quiescent across further replies")
+	})
+}
+
+// TestTxSetRetry_DeprioritizesNonProgressingPeer pins per-peer
+// exclusion (issue #420 item 2c). A peer that returns
+// txSetPeerNonProgressThreshold non-progressing replies in a row
+// is dropped from the next missing-nodes broadcast via the excluded
+// map. The first broadcast carries an empty exclusion set; once the
+// per-peer counter crosses the threshold the next broadcast excludes
+// that peer.
+func TestTxSetRetry_DeprioritizesNonProgressingPeer(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	const threshold = 2
+	withRetryKnobs(0, 1_000_000, threshold, func() {
+		ld, _ := partialTxSetLedgerData(t, 4)
+		const badPeer = uint64(7)
+
+		// Reply 1 — non-progress count for badPeer becomes 1 (< threshold).
+		router.handleTxSetData(ld, badPeer)
+		require.Equal(t, 1, rs.calledN())
+		first := rs.lastCall()
+		assert.Empty(t, first.excluded,
+			"first non-progress reply must not yet exclude the peer (count < threshold)")
+
+		// Reply 2 — non-progress count for badPeer becomes 2 (== threshold) →
+		// the broadcast for this retry must exclude badPeer.
+		router.handleTxSetData(ld, badPeer)
+		require.Equal(t, 2, rs.calledN())
+		second := rs.lastCall()
+		require.NotNil(t, second.excluded)
+		assert.Truef(t, second.excluded[badPeer],
+			"peer %d should be excluded once non-progress count reaches threshold (%d)",
+			badPeer, threshold)
+	})
+}
+
+// TestTxSetRetry_ProgressResetsNonProgressCounter pins that a peer
+// reply that DOES extend the SHAMap resets that peer's non-progress
+// counter, so a transient stretch of empty replies doesn't permanently
+// banish a recovered peer.
+func TestTxSetRetry_ProgressResetsNonProgressCounter(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	const threshold = 2
+	withRetryKnobs(0, 1_000_000, threshold, func() {
+		ldEmpty, txSetID := partialTxSetLedgerData(t, 4)
+		const peer = uint64(11)
+
+		// One non-progress reply.
+		router.handleTxSetData(ldEmpty, peer)
+		require.Equal(t, 1, rs.calledN())
+
+		// A progressing reply: include a non-root inner node so `added` > 0.
+		_, _, wireNodes := buildTxSetForTest(t, 4)
+		require.GreaterOrEqual(t, len(wireNodes), 2)
+		progressLD := &message.LedgerData{
+			InfoType:   message.LedgerInfoTsCandidate,
+			LedgerHash: txSetID[:],
+			Nodes: []message.LedgerNode{
+				{NodeID: wireNodes[0].NodeID, NodeData: wireNodes[0].Data},
+				{NodeID: wireNodes[1].NodeID, NodeData: wireNodes[1].Data},
+			},
+		}
+		router.handleTxSetData(progressLD, peer)
+
+		// Now a single more non-progress reply: counter is at 1, NOT yet
+		// at threshold → peer must NOT appear in the exclusion set.
+		router.handleTxSetData(ldEmpty, peer)
+		last := rs.lastCall()
+		assert.Falsef(t, last.excluded[peer],
+			"progress reset the non-progress counter; one further empty reply "+
+				"should not be enough to exclude the peer")
+	})
+}

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -122,17 +122,11 @@ func (s *OverlaySender) RequestTxSet(id consensus.TxSetID) error {
 // RequestTxSetMissingNodes requests specific SHAMap nodes after a partial
 // tree. Mirrors TransactionAcquire::trigger second branch
 // (TransactionAcquire.cpp:144-171). Each nodeID is 33 bytes (32 path +
-// 1 depth) per shamap.NodeID.Bytes.
-func (s *OverlaySender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte) error {
-	return s.RequestTxSetMissingNodesExcept(id, nodeIDs, nil)
-}
-
-// RequestTxSetMissingNodesExcept is RequestTxSetMissingNodes with a set
-// of peer IDs to skip. The exclusion set is populated by the router with
-// peers that have repeatedly returned non-progressing TMLedgerData
-// replies for this acquisition. A nil/empty excluded map falls through
-// to a plain broadcast. Issue #420.
-func (s *OverlaySender) RequestTxSetMissingNodesExcept(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
+// 1 depth) per shamap.NodeID.Bytes. excluded carries peer IDs to skip
+// (router-supplied list of peers that have repeatedly returned
+// non-progressing TMLedgerData replies for this acquisition); a nil or
+// empty map falls through to a plain broadcast. Issue #420.
+func (s *OverlaySender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
 	if len(nodeIDs) == 0 {
 		return fmt.Errorf("RequestTxSetMissingNodes: nodeIDs must be non-empty")
 	}

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -124,6 +124,15 @@ func (s *OverlaySender) RequestTxSet(id consensus.TxSetID) error {
 // (TransactionAcquire.cpp:144-171). Each nodeID is 33 bytes (32 path +
 // 1 depth) per shamap.NodeID.Bytes.
 func (s *OverlaySender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte) error {
+	return s.RequestTxSetMissingNodesExcept(id, nodeIDs, nil)
+}
+
+// RequestTxSetMissingNodesExcept is RequestTxSetMissingNodes with a set
+// of peer IDs to skip. The exclusion set is populated by the router with
+// peers that have repeatedly returned non-progressing TMLedgerData
+// replies for this acquisition. A nil/empty excluded map falls through
+// to a plain broadcast. Issue #420.
+func (s *OverlaySender) RequestTxSetMissingNodesExcept(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
 	if len(nodeIDs) == 0 {
 		return fmt.Errorf("RequestTxSetMissingNodes: nodeIDs must be non-empty")
 	}
@@ -137,7 +146,14 @@ func (s *OverlaySender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [
 	if err != nil {
 		return fmt.Errorf("encode txset missing-nodes request: %w", err)
 	}
-	return s.overlay.Broadcast(frame)
+	if len(excluded) == 0 {
+		return s.overlay.Broadcast(frame)
+	}
+	skip := make(map[peermanagement.PeerID]bool, len(excluded))
+	for id := range excluded {
+		skip[peermanagement.PeerID(id)] = true
+	}
+	return s.overlay.BroadcastExceptSet(skip, frame)
 }
 
 func (s *OverlaySender) BroadcastStatusChange(sc *message.StatusChange) error {

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1746,13 +1746,14 @@ func (o *Overlay) BroadcastExcept(exceptPeer PeerID, msg []byte) error {
 
 // BroadcastExceptSet sends a message to every connected peer whose
 // ID is not present in excluded. Used by tx-set acquire to skip peers
-// that have repeatedly returned non-progressing TMLedgerData responses
-// — mirrors rippled's TransactionAcquire ignoring peers that fail to
-// extend the partial SHAMap, but expressed here as an outbound filter
-// because goXRPL retries are event-driven (per inbound TMLedgerData)
-// rather than timer-driven (TransactionAcquire::onTimer at
-// TransactionAcquire.cpp:88-102). A nil or empty excluded map falls
-// through to a plain Broadcast. Issue #420.
+// that have repeatedly returned non-progressing TMLedgerData responses.
+// This is a goXRPL-specific outbound filter; rippled does NOT remove
+// such peers from its peer set — it charges Resource::feeUselessData
+// (InboundTransactions.cpp:177-178) and lets the global resource
+// manager throttle them, so the peer stays eligible for the next
+// broadcast. goXRPL has no equivalent per-message resource accounting
+// today, hence the explicit per-acquire exclusion. A nil or empty
+// excluded map falls through to a plain Broadcast. Issue #420.
 func (o *Overlay) BroadcastExceptSet(excluded map[PeerID]bool, msg []byte) error {
 	if len(excluded) == 0 {
 		return o.Broadcast(msg)

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1744,6 +1744,45 @@ func (o *Overlay) BroadcastExcept(exceptPeer PeerID, msg []byte) error {
 	return nil
 }
 
+// BroadcastExceptSet sends a message to every connected peer whose
+// ID is not present in excluded. Used by tx-set acquire to skip peers
+// that have repeatedly returned non-progressing TMLedgerData responses
+// — mirrors rippled's TransactionAcquire ignoring peers that fail to
+// extend the partial SHAMap, but expressed here as an outbound filter
+// because goXRPL retries are event-driven (per inbound TMLedgerData)
+// rather than timer-driven (TransactionAcquire::onTimer at
+// TransactionAcquire.cpp:88-102). A nil or empty excluded map falls
+// through to a plain Broadcast. Issue #420.
+func (o *Overlay) BroadcastExceptSet(excluded map[PeerID]bool, msg []byte) error {
+	if len(excluded) == 0 {
+		return o.Broadcast(msg)
+	}
+	o.peersMu.RLock()
+	defer o.peersMu.RUnlock()
+
+	for id, peer := range o.peers {
+		if excluded[id] {
+			continue
+		}
+		if peer.State() != PeerStateConnected {
+			continue
+		}
+		if err := peer.Send(msg); err != nil {
+			level := slog.LevelInfo
+			if errors.Is(err, ErrSendBufferFull) {
+				level = slog.LevelWarn
+			}
+			slog.Log(context.Background(), level, "broadcast-except-set send failed",
+				"t", "Overlay",
+				"peer", id,
+				"frame_size", len(msg),
+				"err", err.Error(),
+			)
+		}
+	}
+	return nil
+}
+
 // RelayFromValidator forwards a peer-originated validator message
 // (proposal or validation) to other connected peers, applying the
 // per-peer squelch filter on the ORIGINATING validator's pubkey AND


### PR DESCRIPTION
Closes #420.

## Summary
- **Throttle:** at most one `RequestTxSetMissingNodes` broadcast per 250 ms (`txSetRetryMinInterval`) per acquisition — mirrors rippled's `TX_ACQUIRE_TIMEOUT`. Kills the 100+ retries/sec storm captured in the issue.
- **Max attempts:** after 20 broadcasts (`txSetMaxAttempts`, mirrors rippled's `MAX_TIMEOUTS`) the acquire is marked `failed` and further inbound replies are dropped until the existing 60 s TTL sweep clears it. Surfaces failure instead of looping forever.
- **Per-peer de-prioritization:** a peer that returns 3 consecutive `TMLedgerData` replies that don't extend the SHAMap (`txSetPeerNonProgressThreshold`, scale of rippled's `NORM_TIMEOUTS`) is skipped on the next broadcast via a new `RequestTxSetMissingNodesExcept` path that fans out through `Overlay.BroadcastExceptSet`.

`handleTxSetData` now takes the origin peer ID so it can attribute progress/non-progress per peer; bookkeeping (`attempts`, `lastRequest`, `peerNonProgress`, `failed`) lives on `txSetAcquireState`.

Item 1 of issue #420 (wire-format / parsing mismatch) was already resolved by #413 / commits `7feb830` and `21e05ec` — the `non_root_added=0` symptom is gone since the router switched to NodeID-based placement and local-pool leaf fill. This PR addresses item 2 (no backoff / give-up / peer scoring).

## Test plan
- [x] `just build-all`
- [x] `just test-pkg ./internal/consensus/adaptor/...` — all green, 4 new tests pass
- [x] `just test-pkg ./internal/consensus/...` — full consensus suite green
- [x] `just test-pkg ./internal/peermanagement/...` — green (new `BroadcastExceptSet` doesn't regress overlay tests)
- [x] `just vet` / `just lint` — clean

New tests in `internal/consensus/adaptor/router_txset_retry_test.go`:
- `TestTxSetRetry_ThrottleSkipsRapidRetries` — two replies inside the throttle window produce one broadcast.
- `TestTxSetRetry_MaxAttemptsCapMarksFailed` — broadcast stops at the cap; later replies stay quiescent.
- `TestTxSetRetry_DeprioritizesNonProgressingPeer` — peer appears in the exclusion set once its non-progress counter hits threshold.
- `TestTxSetRetry_ProgressResetsNonProgressCounter` — a progressing reply resets the per-peer counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)