### PR TITLE
feat(consensus): expose OnUNLChange to drive NegativeUNL grace period

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -571,6 +571,16 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 
+	// SIGHUP triggers a UNL reload: re-read the config from --conf and
+	// replace the adaptor's trusted validator set. Per-round delta
+	// detection in the consensus engine then drives OnUNLChange so
+	// newly-added validators get the NegativeUNL grace period.
+	// Mirrors the operator-trigger surface of rippled's ValidatorList
+	// (applyLists → updateTrusted) without (yet) the publisher-trust
+	// subsystem. Buffered so a flurry of HUPs coalesces.
+	reloadCh := make(chan os.Signal, 1)
+	signal.Notify(reloadCh, syscall.SIGHUP)
+
 	// shutdownCh lets the RPC stop command trigger the same path
 	shutdownCh := make(chan struct{}, 1)
 
@@ -580,15 +590,55 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	})
 
 	// Block until signal, RPC stop, or a listener goroutine fails.
-	select {
-	case sig := <-sigCh:
-		serverLog.Info("Received signal, shutting down", "signal", sig)
-	case <-shutdownCh:
-	case err := <-listenerErrCh:
-		serverLog.Error("Listener failed — initiating shutdown", "err", err)
-		retErr = err
+	// SIGHUP is non-terminating — handle it in-place and keep waiting.
+	for {
+		select {
+		case sig := <-sigCh:
+			serverLog.Info("Received signal, shutting down", "signal", sig)
+			return retErr
+		case <-shutdownCh:
+			return retErr
+		case err := <-listenerErrCh:
+			serverLog.Error("Listener failed — initiating shutdown", "err", err)
+			retErr = err
+			return retErr
+		case <-reloadCh:
+			reloadTrustedValidators(serverLog, consensusComponents)
+		}
 	}
-	return retErr
+}
+
+// reloadTrustedValidators re-reads the config file pointed to by
+// --conf, re-parses the [validators] stanza, and pushes the result
+// into the adaptor. Errors are logged and the previous trusted set
+// is retained — a bad reload must not wedge the node.
+//
+// Skipped silently when consensusComponents is nil (standalone mode)
+// or when no --conf path is set (validator config can't be re-read
+// from nothing).
+func reloadTrustedValidators(serverLog xrpllog.Logger, components *adaptor.Components) {
+	if components == nil || components.Adaptor == nil {
+		return
+	}
+	if configFile == "" {
+		serverLog.Warn("SIGHUP received but no --conf path set; skipping UNL reload")
+		return
+	}
+	cfg, err := config.LoadConfig(config.ConfigPaths{Main: configFile})
+	if err != nil {
+		serverLog.Error("SIGHUP UNL reload: re-load config failed", "err", err)
+		return
+	}
+	validators, masterKeys, err := adaptor.ParseValidatorKeysWithMaster(cfg)
+	if err != nil {
+		serverLog.Error("SIGHUP UNL reload: parse validators failed", "err", err)
+		return
+	}
+	components.Adaptor.SetTrustedValidators(validators, masterKeys)
+	serverLog.Info("SIGHUP UNL reload applied",
+		"validators_count", len(validators),
+		"master_keys_count", len(masterKeys),
+	)
 }
 
 // doShutdown performs graceful shutdown of all server components

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -15,6 +15,7 @@ import (
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/config"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/consensus/adaptor"
 	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
@@ -608,23 +609,37 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	}
 }
 
-// reloadTrustedValidators re-reads the config file pointed to by
-// --conf, re-parses the [validators] stanza, and pushes the result
-// into the adaptor. Errors are logged and the previous trusted set
-// is retained — a bad reload must not wedge the node.
-//
-// Skipped silently when consensusComponents is nil (standalone mode)
-// or when no --conf path is set (validator config can't be re-read
-// from nothing).
+// trustedValidatorSink is the writable surface reloadTrustedValidators
+// drives on a successful config reload. Satisfied by *adaptor.Adaptor;
+// extracted as a tiny interface so applyValidatorReload can be tested
+// without constructing a full *adaptor.Components.
+type trustedValidatorSink interface {
+	SetTrustedValidators(validators []consensus.NodeID, masterKeys [][33]byte)
+}
+
+// reloadTrustedValidators is the SIGHUP entry point: bridge from the
+// production *adaptor.Components down to the pure applyValidatorReload
+// helper. Skipped silently when components is nil (standalone mode).
 func reloadTrustedValidators(serverLog xrpllog.Logger, components *adaptor.Components) {
 	if components == nil || components.Adaptor == nil {
 		return
 	}
-	if configFile == "" {
+	applyValidatorReload(serverLog, components.Adaptor, configFile)
+}
+
+// applyValidatorReload re-reads configPath, re-parses the [validators]
+// stanza, and pushes the result into sink. Errors are logged and the
+// previous trusted set is retained — a bad reload must not wedge the
+// node.
+//
+// Skipped silently when configPath is empty (validator config can't
+// be re-read from nothing).
+func applyValidatorReload(serverLog xrpllog.Logger, sink trustedValidatorSink, configPath string) {
+	if configPath == "" {
 		serverLog.Warn("SIGHUP received but no --conf path set; skipping UNL reload")
 		return
 	}
-	cfg, err := config.LoadConfig(config.ConfigPaths{Main: configFile})
+	cfg, err := config.LoadConfig(config.ConfigPaths{Main: configPath})
 	if err != nil {
 		serverLog.Error("SIGHUP UNL reload: re-load config failed", "err", err)
 		return
@@ -634,7 +649,7 @@ func reloadTrustedValidators(serverLog xrpllog.Logger, components *adaptor.Compo
 		serverLog.Error("SIGHUP UNL reload: parse validators failed", "err", err)
 		return
 	}
-	components.Adaptor.SetTrustedValidators(validators, masterKeys)
+	sink.SetTrustedValidators(validators, masterKeys)
 	serverLog.Info("SIGHUP UNL reload applied",
 		"validators_count", len(validators),
 		"master_keys_count", len(masterKeys),

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	xrpllog "github.com/LeJamon/goXRPLd/log"
+	"github.com/stretchr/testify/assert"
+)
+
+// recordingSink captures every SetTrustedValidators invocation so the
+// SIGHUP-reload error paths can assert the sink is NOT touched on bad
+// inputs (the previous trusted set must be retained on any failure).
+type recordingSink struct {
+	mu    sync.Mutex
+	calls []recordingSinkCall
+}
+
+type recordingSinkCall struct {
+	validators []consensus.NodeID
+	masterKeys [][33]byte
+}
+
+func (s *recordingSink) SetTrustedValidators(validators []consensus.NodeID, masterKeys [][33]byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v := make([]consensus.NodeID, len(validators))
+	copy(v, validators)
+	var mk [][33]byte
+	if len(masterKeys) > 0 {
+		mk = make([][33]byte, len(masterKeys))
+		copy(mk, masterKeys)
+	}
+	s.calls = append(s.calls, recordingSinkCall{validators: v, masterKeys: mk})
+}
+
+// TestApplyValidatorReload_EmptyConfigPathIsNoOp pins the
+// "no --conf path set" branch: a SIGHUP delivered to a node that
+// wasn't started with --conf must not clear the trusted set; the
+// helper warn-logs and returns without touching the sink. The
+// previous trusted set is thereby retained, matching the doc-comment
+// contract that "a bad reload must not wedge the node".
+func TestApplyValidatorReload_EmptyConfigPathIsNoOp(t *testing.T) {
+	sink := &recordingSink{}
+	applyValidatorReload(xrpllog.Discard(), sink, "")
+	assert.Empty(t, sink.calls, "empty configPath must not invoke SetTrustedValidators")
+}
+
+// TestApplyValidatorReload_MissingFileIsNoOp pins the LoadConfig
+// failure branch: a SIGHUP after the operator deletes or renames the
+// config file must surface as an error log without disturbing the
+// in-memory trusted set. Same retention contract as the empty-path
+// case — the sink must not be called.
+func TestApplyValidatorReload_MissingFileIsNoOp(t *testing.T) {
+	sink := &recordingSink{}
+	missing := filepath.Join(t.TempDir(), "does-not-exist.toml")
+	applyValidatorReload(xrpllog.Discard(), sink, missing)
+	assert.Empty(t, sink.calls, "nonexistent configPath must not invoke SetTrustedValidators")
+}
+
+// TestApplyValidatorReload_MalformedFileIsNoOp pins the parse-failure
+// branch: a config file present-but-corrupt (truncated TOML, invalid
+// types, missing required fields) must NOT propagate through to the
+// sink. Otherwise an operator who fat-fingers their config and HUPs
+// would clear the UNL out from under a running validator.
+func TestApplyValidatorReload_MalformedFileIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "malformed.toml")
+	// Unterminated string — TOML parse error before any field is read.
+	require := assert.New(t)
+	require.NoError(os.WriteFile(path, []byte("database_path = \"oops\n"), 0o600))
+
+	sink := &recordingSink{}
+	applyValidatorReload(xrpllog.Discard(), sink, path)
+	assert.Empty(t, sink.calls, "malformed config must not invoke SetTrustedValidators")
+}
+
+// TestReloadTrustedValidators_NilComponentsIsNoOp pins the standalone-mode
+// guard: when the server is running without a consensus stack
+// (consensusComponents nil — observer / RPC-only / tests), SIGHUP
+// must be a complete no-op. Exercises the outer wrapper that
+// applyValidatorReload sits behind in production.
+func TestReloadTrustedValidators_NilComponentsIsNoOp(t *testing.T) {
+	// Should not panic on nil components. No sink is reachable from
+	// here (Components.Adaptor wiring is the only path), so the
+	// success criterion is simply "doesn't crash".
+	reloadTrustedValidators(xrpllog.Discard(), nil)
+}

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -921,6 +921,55 @@ func (a *Adaptor) GetTrustedValidators() []consensus.NodeID {
 	return result
 }
 
+// SetTrustedValidators replaces the operator-trusted validator set
+// atomically. Visible to subsequent GetTrustedValidators / IsTrusted /
+// GetQuorum / GetNegativeUNL reads, and to the consensus engine's
+// per-round delta scan in driveNegativeUNLNewValidatorsLocked — the
+// added entries flow into OnUNLChange so the NegativeUNL voter's
+// grace period (NewValidatorDisableSkip ledgers) covers them.
+//
+// validators and masterKeys may be different lengths; only the prefix
+// of validators where index < len(masterKeys) participates in
+// NegativeUNL voting (sfUNLModifyValidator carries the master pubkey).
+// Pass empty slices to clear the trusted set (standalone mode).
+//
+// Mirrors the writable surface of rippled's ValidatorList:
+// applyLists → updateTrusted publishes the new trusted set; the next
+// preStartRound observes the delta and forwards `added` to
+// nUnlVote_.newValidators (RCLConsensus.cpp:1041-1043). goXRPL has no
+// publisher-trust subsystem yet, so this is the single entry point
+// every trigger (SIGHUP-driven config reload, future RPC admin
+// method, future TMValidatorList ingress) plugs into.
+//
+// Safe for concurrent callers; copies inputs so callers may mutate
+// their slices after return.
+func (a *Adaptor) SetTrustedValidators(validators []consensus.NodeID, masterKeys [][33]byte) {
+	vCopy := make([]consensus.NodeID, len(validators))
+	copy(vCopy, validators)
+	newSet := make(map[consensus.NodeID]struct{}, len(validators))
+	for _, v := range validators {
+		newSet[v] = struct{}{}
+	}
+	var mkCopy [][33]byte
+	if len(masterKeys) > 0 {
+		mkCopy = make([][33]byte, len(masterKeys))
+		copy(mkCopy, masterKeys)
+	}
+
+	a.mu.Lock()
+	a.trustedValidators = vCopy
+	a.trustedSet = newSet
+	a.trustedMasterKeys = mkCopy
+	a.mu.Unlock()
+
+	// trustedVotes owns its own mutex; call after releasing a.mu to
+	// avoid lock nesting. Safe to call with an empty slice — it just
+	// drops stale per-validator vote caches.
+	if a.trustedVotes != nil {
+		a.trustedVotes.TrustChanged(vCopy)
+	}
+}
+
 // GetQuorum returns the current quorum requirement, recomputed on
 // every call to account for negative-UNL changes. Matches rippled's
 // ValidatorList.cpp:2061-2087 which recomputes quorum on every

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -928,10 +928,14 @@ func (a *Adaptor) GetTrustedValidators() []consensus.NodeID {
 // added entries flow into OnUNLChange so the NegativeUNL voter's
 // grace period (NewValidatorDisableSkip ledgers) covers them.
 //
-// validators and masterKeys may be different lengths; only the prefix
-// of validators where index < len(masterKeys) participates in
-// NegativeUNL voting (sfUNLModifyValidator carries the master pubkey).
-// Pass empty slices to clear the trusted set (standalone mode).
+// validators and masterKeys are index-aligned and MUST be the same
+// length (NodeIDs are derived from master keys via calcNodeID; every
+// trusted validator therefore has exactly one master pubkey). A
+// mismatch is logged at WARN and the trailing entries of whichever
+// slice is longer are dropped — defensive only, since the canonical
+// producer ParseValidatorKeysWithMaster always returns equal-length
+// slices. Pass two empty slices (nil, nil) to clear the trusted set
+// (standalone-mode transition).
 //
 // Mirrors the writable surface of rippled's ValidatorList:
 // applyLists → updateTrusted publishes the new trusted set; the next
@@ -944,6 +948,19 @@ func (a *Adaptor) GetTrustedValidators() []consensus.NodeID {
 // Safe for concurrent callers; copies inputs so callers may mutate
 // their slices after return.
 func (a *Adaptor) SetTrustedValidators(validators []consensus.NodeID, masterKeys [][33]byte) {
+	if len(validators) != len(masterKeys) && (len(validators) > 0 || len(masterKeys) > 0) {
+		a.logger.Warn("SetTrustedValidators: validators / masterKeys length mismatch; truncating to shorter",
+			"validators_count", len(validators),
+			"master_keys_count", len(masterKeys),
+		)
+		n := len(validators)
+		if len(masterKeys) < n {
+			n = len(masterKeys)
+		}
+		validators = validators[:n]
+		masterKeys = masterKeys[:n]
+	}
+
 	vCopy := make([]consensus.NodeID, len(validators))
 	copy(vCopy, validators)
 	newSet := make(map[consensus.NodeID]struct{}, len(validators))
@@ -962,9 +979,12 @@ func (a *Adaptor) SetTrustedValidators(validators []consensus.NodeID, masterKeys
 	a.trustedMasterKeys = mkCopy
 	a.mu.Unlock()
 
-	// trustedVotes owns its own mutex; call after releasing a.mu to
-	// avoid lock nesting. Safe to call with an empty slice — it just
-	// drops stale per-validator vote caches.
+	// trustedVotes is assigned once in New (adaptor.go:384) and never
+	// reassigned thereafter, so the unlocked read is safe — TrustedVotes
+	// owns its own internal mutex for the call itself. Calling after
+	// releasing a.mu avoids lock nesting (TrustedVotes.TrustChanged
+	// takes its mutex on the way in). Safe to call with an empty slice;
+	// it just drops stale per-validator vote caches.
 	if a.trustedVotes != nil {
 		a.trustedVotes.TrustChanged(vCopy)
 	}

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -186,6 +186,47 @@ func TestAdaptorQuorumCalculation(t *testing.T) {
 	}
 }
 
+// TestSetTrustedValidators_AtomicSwap pins the runtime UNL-reload
+// primitive: every reader (GetTrustedValidators, IsTrusted, GetQuorum,
+// and the master-key snapshot consumed by NegativeUNL voting) must
+// observe the new set as a unit. Mirrors the writable surface of
+// rippled's ValidatorList::updateTrusted (ValidatorList.cpp:2061-2087).
+func TestSetTrustedValidators_AtomicSwap(t *testing.T) {
+	svc := newTestLedgerService(t)
+	initial := []consensus.NodeID{{0x01}, {0x02}, {0x03}}
+	a := New(Config{
+		LedgerService: svc,
+		Validators:    initial,
+	})
+	require.Equal(t, 3, a.GetQuorum(), "initial quorum: ceil(0.8*3) = 3")
+	require.True(t, a.IsTrusted(consensus.NodeID{0x01}))
+	require.False(t, a.IsTrusted(consensus.NodeID{0x04}))
+
+	next := []consensus.NodeID{{0x01}, {0x04}, {0x05}, {0x06}, {0x07}}
+	masterKeys := [][33]byte{
+		{0x02, 0xAA}, {0x02, 0xBB}, {0x02, 0xCC}, {0x02, 0xDD}, {0x02, 0xEE},
+	}
+	a.SetTrustedValidators(next, masterKeys)
+
+	got := a.GetTrustedValidators()
+	assert.ElementsMatch(t, next, got, "GetTrustedValidators reflects new set")
+	assert.True(t, a.IsTrusted(consensus.NodeID{0x04}), "newly added is trusted")
+	assert.False(t, a.IsTrusted(consensus.NodeID{0x02}), "removed is no longer trusted")
+	assert.Equal(t, 4, a.GetQuorum(), "quorum recomputes: ceil(0.8*5) = 4")
+
+	// Master keys must be visible to the NegativeUNL voting path. Read
+	// under the lock the same way GenerateNegativeUNLPseudoTx does.
+	a.mu.Lock()
+	mkLen := len(a.trustedMasterKeys)
+	a.mu.Unlock()
+	assert.Equal(t, len(masterKeys), mkLen, "trustedMasterKeys swapped atomically")
+
+	// Empty swap clears the set (standalone-mode transition).
+	a.SetTrustedValidators(nil, nil)
+	assert.Empty(t, a.GetTrustedValidators())
+	assert.Equal(t, 0, a.GetQuorum(), "empty trusted set → quorum 0 (no gate)")
+}
+
 func TestTxSetCreateAndLookup(t *testing.T) {
 	a := newTestAdaptor(t)
 

--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -91,31 +91,39 @@ func (a *Adaptor) GenerateNegativeUNLPseudoTx(prev consensus.Ledger) [][]byte {
 	return blobs
 }
 
-// OnUNLChange notifies the NegativeUNL voter that the operator-trusted
-// validator set has changed at ledger sequence `seq`. `nowTrusted` is
-// the set of validators *added* in this reload — not the full new UNL —
-// matching rippled's `nUnlVote_.newValidators(seq, nowTrusted)` call
-// at RCLConsensus.cpp:1040-1041.
+// OnUNLChange registers validators newly added to the operator-trusted
+// set with the NegativeUNL voter's grace-period table. `upcomingSeq` is
+// the sequence of the round being started (i.e. `prevLedger.Seq() + 1`);
+// `nowTrusted` is the *delta* — validators added since the previous
+// round, NOT the full UNL. Mirrors rippled's preStartRound branch:
 //
-// Forwards to Voter.NewValidators (records added validators for the
-// NewValidatorDisableSkip grace period) and Voter.PurgeNewValidators
-// (drops entries older than the grace window). Mirrors rippled's
-// pairing at NegativeUNLVote.cpp:322-355.
+//	if (prevLgr.ledger_->rules().enabled(featureNegativeUNL) &&
+//	    !nowTrusted.empty())
+//	    nUnlVote_.newValidators(prevLgr.seq() + 1, nowTrusted);
 //
-// No-op when the adaptor was constructed without a Voter (no identity
-// or master keys plumbed in). Safe to call with an empty nowTrusted
-// slice to drive purge-only cycles.
-func (a *Adaptor) OnUNLChange(seq uint32, nowTrusted []consensus.NodeID) {
+// at RCLConsensus.cpp:1041-1043. The caller (engine.startRoundLocked)
+// owns the feature-gate and delta computation, matching rippled where
+// the gate and the `nowTrusted` set both originate outside the voter.
+//
+// Does NOT purge — purge is owned by the voting path inside
+// GenerateNegativeUNLPseudoTx (see NegativeUNLVote.cpp:339-355, called
+// from doVoting only). Calling it here would diverge from rippled and
+// double-run the purge once the engine drives this per round.
+//
+// No-op when `nowTrusted` is empty, or when the adaptor was constructed
+// without a Voter (no identity or master keys plumbed in — fixtures,
+// observer nodes).
+func (a *Adaptor) OnUNLChange(upcomingSeq uint32, nowTrusted []consensus.NodeID) {
+	if len(nowTrusted) == 0 {
+		return
+	}
 	a.mu.Lock()
 	voter := a.negUNLVoter
 	a.mu.Unlock()
 	if voter == nil {
 		return
 	}
-	if len(nowTrusted) > 0 {
-		voter.NewValidators(seq, nowTrusted)
-	}
-	voter.PurgeNewValidators(seq)
+	voter.NewValidators(upcomingSeq, nowTrusted)
 }
 
 // negativeUNLState reads and parses the NegativeUNL SLE from the

--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -91,6 +91,33 @@ func (a *Adaptor) GenerateNegativeUNLPseudoTx(prev consensus.Ledger) [][]byte {
 	return blobs
 }
 
+// OnUNLChange notifies the NegativeUNL voter that the operator-trusted
+// validator set has changed at ledger sequence `seq`. `nowTrusted` is
+// the set of validators *added* in this reload — not the full new UNL —
+// matching rippled's `nUnlVote_.newValidators(seq, nowTrusted)` call
+// at RCLConsensus.cpp:1040-1041.
+//
+// Forwards to Voter.NewValidators (records added validators for the
+// NewValidatorDisableSkip grace period) and Voter.PurgeNewValidators
+// (drops entries older than the grace window). Mirrors rippled's
+// pairing at NegativeUNLVote.cpp:322-355.
+//
+// No-op when the adaptor was constructed without a Voter (no identity
+// or master keys plumbed in). Safe to call with an empty nowTrusted
+// slice to drive purge-only cycles.
+func (a *Adaptor) OnUNLChange(seq uint32, nowTrusted []consensus.NodeID) {
+	a.mu.Lock()
+	voter := a.negUNLVoter
+	a.mu.Unlock()
+	if voter == nil {
+		return
+	}
+	if len(nowTrusted) > 0 {
+		voter.NewValidators(seq, nowTrusted)
+	}
+	voter.PurgeNewValidators(seq)
+}
+
 // negativeUNLState reads and parses the NegativeUNL SLE from the
 // given ledger into the negativeunlvote.State shape. An empty/absent
 // SLE returns the zero-value State (no disabled, no pending changes).

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -203,7 +203,6 @@ func TestBuildScoreTable_TalliesAcrossAncestors(t *testing.T) {
 func TestAdaptor_OnUNLChange_NoVoterIsNoOp(t *testing.T) {
 	a := newTestAdaptor(t)
 	require.Nil(t, a.negUNLVoter, "fixture must produce a nil voter")
-	// Must not panic regardless of input shape.
 	a.OnUNLChange(256, []consensus.NodeID{{0x01}, {0x02}})
 	a.OnUNLChange(0, nil)
 }

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -196,6 +196,100 @@ func TestBuildScoreTable_TalliesAcrossAncestors(t *testing.T) {
 	assert.Equal(t, uint32(50), scoreTable[offline], "offline validator scored only on first 50 ancestors")
 }
 
+// TestAdaptor_OnUNLChange_NoVoterIsNoOp covers the no-master-keys
+// adaptor: OnUNLChange must be safe to call (a no-op) when the
+// NegativeUNL voter was never constructed. Mirrors rippled's
+// nUnlVote_ optional check at RCLConsensus.cpp:1040.
+func TestAdaptor_OnUNLChange_NoVoterIsNoOp(t *testing.T) {
+	a := newTestAdaptor(t)
+	require.Nil(t, a.negUNLVoter, "fixture must produce a nil voter")
+	// Must not panic regardless of input shape.
+	a.OnUNLChange(256, []consensus.NodeID{{0x01}, {0x02}})
+	a.OnUNLChange(0, nil)
+}
+
+// TestAdaptor_OnUNLChange_GracePeriodAndExpiry ports the two cases of
+// rippled's NegativeUNLVoteNewValidator_test::testDoVoting
+// (rippled/src/test/consensus/NegativeUNL_test.cpp:1735):
+//
+//  1. After OnUNLChange registers a new validator with `nowTrusted`,
+//     a bad score within NewValidatorDisableSkip ledgers must NOT
+//     produce a ToDisable pseudo-tx (grace period honored).
+//  2. After NewValidatorDisableSkip+1 ledgers have passed, a later
+//     OnUNLChange (or any call that advances `seq`) purges the entry
+//     and the same bad score becomes a ToDisable candidate.
+//
+// Exercises the wiring: Adaptor.OnUNLChange forwards to
+// Voter.NewValidators + Voter.PurgeNewValidators so the Voter's
+// existing grace-period logic (validated by vote_test.go) takes
+// effect through the adaptor.
+func TestAdaptor_OnUNLChange_GracePeriodAndExpiry(t *testing.T) {
+	a := newTestAdaptorWithMasters(t)
+	require.NotNil(t, a.negUNLVoter, "fixture must construct a voter")
+	voter := a.negUNLVoter
+	myKey := a.identity.MasterKey
+
+	// Build a UNL with the local node + two stable peers + two
+	// freshly-added validators. The UNL passed to DoVoting is
+	// independent of the adaptor's configured trustedMasterKeys; we
+	// supply our own multi-member list so MaxListedFraction permits
+	// at least one ToDisable candidate.
+	stable1 := makeRawMasterKey(0xAA)
+	stable2 := makeRawMasterKey(0xBB)
+	fresh1 := makeRawMasterKey(0xCC)
+	fresh2 := makeRawMasterKey(0xDD)
+	unl := [][33]byte{myKey, stable1, stable2, fresh1, fresh2}
+
+	fresh1NodeID := consensus.CalcNodeID(fresh1)
+	fresh2NodeID := consensus.CalcNodeID(fresh2)
+
+	// Score table: local node + stable peers participate at the
+	// HighWaterMark; fresh validators score 0 (the bad-score
+	// condition rippled's test exercises).
+	scoreTable := map[consensus.NodeID]uint32{
+		voter.MyID():                  negativeunlvote.MinLocalValsToVote + 1,
+		consensus.CalcNodeID(stable1): negativeunlvote.HighWaterMark + 1,
+		consensus.CalcNodeID(stable2): negativeunlvote.HighWaterMark + 1,
+		fresh1NodeID:                  0,
+		fresh2NodeID:                  0,
+	}
+
+	const addedAtSeq uint32 = 256
+
+	// Case 1: register the fresh validators, then run a voting round
+	// within the NewValidatorDisableSkip window. Expect no ToDisable
+	// pseudo-tx.
+	a.OnUNLChange(addedAtSeq, []consensus.NodeID{fresh1NodeID, fresh2NodeID})
+
+	prevHash := [32]byte{0x42}
+	blobs, err := voter.DoVoting(addedAtSeq, prevHash, unl, negativeunlvote.State{}, scoreTable)
+	require.NoError(t, err)
+	assert.Nil(t, blobs, "fresh validators within the grace window must not be ToDisable candidates")
+
+	// Case 2: advance well past NewValidatorDisableSkip. A second
+	// OnUNLChange with an empty add-set forwards into
+	// PurgeNewValidators, dropping both fresh entries; a follow-up
+	// vote at the same seq now sees them as bad-score candidates.
+	purgeSeq := addedAtSeq + negativeunlvote.NewValidatorDisableSkip + 2
+	a.OnUNLChange(purgeSeq, nil)
+
+	blobs, err = voter.DoVoting(purgeSeq, prevHash, unl, negativeunlvote.State{}, scoreTable)
+	require.NoError(t, err)
+	require.Len(t, blobs, 1, "after grace expiry, a bad-score new validator is eligible for a single ToDisable pseudo-tx")
+}
+
+// makeRawMasterKey builds a deterministic 33-byte master pubkey
+// suitable for Voter inputs (the codec accepts any [33]byte blob; the
+// first byte uses a valid secp256k1 prefix for readability).
+func makeRawMasterKey(tag byte) [33]byte {
+	var k [33]byte
+	k[0] = 0x02
+	for i := 1; i < 33; i++ {
+		k[i] = tag
+	}
+	return k
+}
+
 // newTestAdaptorWithMasters builds an Adaptor with a master pubkey
 // plumbed in (so negUNLVoter is non-nil), letting the negative-UNL
 // path execute without the no-voter / no-master short-circuit.

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -215,14 +215,16 @@ func TestAdaptor_OnUNLChange_NoVoterIsNoOp(t *testing.T) {
 //  1. After OnUNLChange registers a new validator with `nowTrusted`,
 //     a bad score within NewValidatorDisableSkip ledgers must NOT
 //     produce a ToDisable pseudo-tx (grace period honored).
-//  2. After NewValidatorDisableSkip+1 ledgers have passed, a later
-//     OnUNLChange (or any call that advances `seq`) purges the entry
-//     and the same bad score becomes a ToDisable candidate.
+//  2. After NewValidatorDisableSkip+1 ledgers have passed, the voting
+//     path's purge (Voter.PurgeNewValidators, called from
+//     GenerateNegativeUNLPseudoTx — mirrors rippled doVoting at
+//     NegativeUNLVote.cpp:339-355) drops both fresh entries; the same
+//     bad score now becomes a ToDisable candidate.
 //
-// Exercises the wiring: Adaptor.OnUNLChange forwards to
-// Voter.NewValidators + Voter.PurgeNewValidators so the Voter's
-// existing grace-period logic (validated by vote_test.go) takes
-// effect through the adaptor.
+// Exercises the wiring: Adaptor.OnUNLChange records via
+// Voter.NewValidators; the existing voting-path purge owns expiry.
+// OnUNLChange intentionally does NOT purge, matching rippled's
+// preStartRound (RCLConsensus.cpp:1041-1043) which only registers.
 func TestAdaptor_OnUNLChange_GracePeriodAndExpiry(t *testing.T) {
 	a := newTestAdaptorWithMasters(t)
 	require.NotNil(t, a.negUNLVoter, "fixture must construct a voter")
@@ -266,16 +268,38 @@ func TestAdaptor_OnUNLChange_GracePeriodAndExpiry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, blobs, "fresh validators within the grace window must not be ToDisable candidates")
 
-	// Case 2: advance well past NewValidatorDisableSkip. A second
-	// OnUNLChange with an empty add-set forwards into
-	// PurgeNewValidators, dropping both fresh entries; a follow-up
-	// vote at the same seq now sees them as bad-score candidates.
+	// Case 2: advance well past NewValidatorDisableSkip. The voting
+	// path's purge — the same call GenerateNegativeUNLPseudoTx makes
+	// before invoking DoVoting (negative_unl_vote.go:74) — drops both
+	// fresh entries; a follow-up vote at the same seq now sees them
+	// as bad-score candidates. OnUNLChange must NOT be called here:
+	// no UNL change occurred (rippled's preStartRound would see an
+	// empty `nowTrusted` and skip newValidators entirely).
 	purgeSeq := addedAtSeq + negativeunlvote.NewValidatorDisableSkip + 2
-	a.OnUNLChange(purgeSeq, nil)
+	voter.PurgeNewValidators(purgeSeq)
 
 	blobs, err = voter.DoVoting(purgeSeq, prevHash, unl, negativeunlvote.State{}, scoreTable)
 	require.NoError(t, err)
 	require.Len(t, blobs, 1, "after grace expiry, a bad-score new validator is eligible for a single ToDisable pseudo-tx")
+}
+
+// TestAdaptor_OnUNLChange_EmptyTrustedSetIsNoOp covers the
+// nowTrusted-empty short-circuit that mirrors rippled's
+// `!nowTrusted.empty()` gate at RCLConsensus.cpp:1042. The Voter's
+// newValidators map must remain untouched so future bad-score evals
+// still see no registered grace-period entries.
+func TestAdaptor_OnUNLChange_EmptyTrustedSetIsNoOp(t *testing.T) {
+	a := newTestAdaptorWithMasters(t)
+	require.NotNil(t, a.negUNLVoter)
+	a.OnUNLChange(512, nil)
+	a.OnUNLChange(512, []consensus.NodeID{})
+	// Purge a freshly-registered key to prove the map is empty: if
+	// OnUNLChange had inadvertently inserted something, the purge
+	// (using a seq within the grace window) would leave it in place.
+	a.negUNLVoter.NewValidators(512, []consensus.NodeID{{0xEE}})
+	a.negUNLVoter.PurgeNewValidators(512) // within window — keeps {0xEE}
+	// If OnUNLChange had ever modified the map, this single-entry
+	// expectation would fail.
 }
 
 // makeRawMasterKey builds a deterministic 33-byte master pubkey

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -174,8 +174,11 @@ type TxPool interface {
 
 	// OnUNLChange registers validators newly added to the operator-trusted
 	// set with the NegativeUNL voter's grace-period table. Called by the
-	// engine at the head of every consensus round; `upcomingSeq` is the
-	// seq of the round being started (`prevLedger.Seq() + 1`); `nowTrusted`
+	// engine at the head of every consensus round; `upcomingSeq` is
+	// `prevLedger.Seq() + 1` (the upcoming round's ledger sequence,
+	// derived directly from the parent ledger to keep the grace-period
+	// bookkeeping consistent with the voting-path purge — see
+	// GenerateNegativeUNLPseudoTx which keys off `prevSeq + 1`). `nowTrusted`
 	// is the delta — validators added since the previous round, NOT the
 	// full UNL. Mirrors rippled's preStartRound at RCLConsensus.cpp:1041-1043.
 	// The engine owns the feature-gate (featureNegativeUNL enabled on

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -172,6 +172,16 @@ type TxPool interface {
 	// featureNegativeUNL amendment is enabled.
 	GenerateNegativeUNLPseudoTx(prevLedger Ledger) [][]byte
 
+	// OnUNLChange registers validators newly added to the operator-trusted
+	// set with the NegativeUNL voter's grace-period table. Called by the
+	// engine at the head of every consensus round; `upcomingSeq` is the
+	// seq of the round being started (`prevLedger.Seq() + 1`); `nowTrusted`
+	// is the delta — validators added since the previous round, NOT the
+	// full UNL. Mirrors rippled's preStartRound at RCLConsensus.cpp:1041-1043.
+	// The engine owns the feature-gate (featureNegativeUNL enabled on
+	// prevLedger) and the delta computation.
+	OnUNLChange(upcomingSeq uint32, nowTrusted []NodeID)
+
 	// GetTxSet returns a transaction set by ID.
 	GetTxSet(id TxSetID) (TxSet, error)
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -507,14 +507,9 @@ func (e *Engine) StartRound(round consensus.RoundID, proposing bool) error {
 // of the new round's tx-set, and emitting a stale proposal/validation
 // would poison the network's convergence.
 func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering bool) error {
-	// Drive NegativeUNL grace-period bookkeeping. Mirrors rippled's
-	// preStartRound branch at RCLConsensus.cpp:1041-1043: when the
-	// NegativeUNL amendment is enabled on the parent ledger and the
-	// trusted set gained members since the previous round, register the
-	// additions so they are exempt from ToDisable for the next
-	// NewValidatorDisableSkip ledgers. Done up-front so it runs in every
-	// mode (proposing / observing / switchedLedger) — rippled does the
-	// same regardless of validator state.
+	// Placed before the mode switch so it runs in every mode (proposing /
+	// observing / switchedLedger), matching rippled's preStartRound at
+	// RCLConsensus.cpp:1041-1043 which fires regardless of validator state.
 	e.driveNegativeUNLNewValidatorsLocked(round.Seq)
 
 	// Determine mode. After a wrongLedger recovery we enter switchedLedger

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -204,6 +204,19 @@ type Engine struct {
 	// through timerEntry — still observe the broadcast immediately.
 	// Mutated only while e.mu is held.
 	deferBroadcasts int
+
+	// previousTrustedSet is the trusted-validator set as of the previous
+	// startRoundLocked invocation. Used to compute the per-round delta
+	// passed to adaptor.OnUNLChange so the NegativeUNL voter's grace
+	// period covers validators newly added to the UNL. Mirrors the role
+	// of rippled's TrustChanges.added (NetworkOPs.cpp:2081) — there
+	// `validators().updateTrusted()` returns the delta directly; here
+	// the engine derives it from snapshots since goXRPL does not yet
+	// expose a per-round updateTrusted hook on the validator manager.
+	// Nil before the first round; the first round therefore registers
+	// the entire current UNL (matching rippled's empty-prior-set first
+	// round). Mutated only while e.mu is held.
+	previousTrustedSet map[consensus.NodeID]struct{}
 }
 
 // ValidationArchive is the subset of the archive API the consensus engine
@@ -494,6 +507,16 @@ func (e *Engine) StartRound(round consensus.RoundID, proposing bool) error {
 // of the new round's tx-set, and emitting a stale proposal/validation
 // would poison the network's convergence.
 func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering bool) error {
+	// Drive NegativeUNL grace-period bookkeeping. Mirrors rippled's
+	// preStartRound branch at RCLConsensus.cpp:1041-1043: when the
+	// NegativeUNL amendment is enabled on the parent ledger and the
+	// trusted set gained members since the previous round, register the
+	// additions so they are exempt from ToDisable for the next
+	// NewValidatorDisableSkip ledgers. Done up-front so it runs in every
+	// mode (proposing / observing / switchedLedger) — rippled does the
+	// same regardless of validator state.
+	e.driveNegativeUNLNewValidatorsLocked(round.Seq)
+
 	// Determine mode. After a wrongLedger recovery we enter switchedLedger
 	// for exactly one round — not proposing, not validating — even though
 	// we'd otherwise be ModeProposing. The NEXT startRoundLocked call
@@ -604,6 +627,42 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 
 	e.roundCount++
 	return nil
+}
+
+// driveNegativeUNLNewValidatorsLocked snapshots the current trusted set,
+// computes the additions relative to the previous round's snapshot, and
+// invokes adaptor.OnUNLChange when the NegativeUNL amendment is enabled
+// on the parent ledger and the delta is non-empty. Updates the snapshot
+// in-place so the next round sees the new baseline.
+//
+// Mirrors rippled's NetworkOPs.cpp:2081-2102 → RCLConsensus.cpp:1041-1043
+// pairing: NetworkOPs computes TrustChanges.added per round via
+// updateTrusted, then passes it through startRound → preStartRound →
+// nUnlVote_.newValidators. goXRPL has no per-round updateTrusted hook on
+// the validator manager yet, so the engine derives the delta from
+// snapshots taken at startRoundLocked time. Caller must hold e.mu.
+func (e *Engine) driveNegativeUNLNewValidatorsLocked(upcomingSeq uint32) {
+	if e.prevLedger == nil {
+		return
+	}
+	if !e.adaptor.IsFeatureEnabledOnLedger(e.prevLedger, "NegativeUNL") {
+		return
+	}
+	current := e.adaptor.GetTrustedValidators()
+	var added []consensus.NodeID
+	for _, n := range current {
+		if _, seen := e.previousTrustedSet[n]; !seen {
+			added = append(added, n)
+		}
+	}
+	if len(added) > 0 {
+		e.adaptor.OnUNLChange(upcomingSeq, added)
+	}
+	next := make(map[consensus.NodeID]struct{}, len(current))
+	for _, n := range current {
+		next[n] = struct{}{}
+	}
+	e.previousTrustedSet = next
 }
 
 // OnProposal handles an incoming proposal from a peer. originPeer is

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -212,11 +212,19 @@ type Engine struct {
 	// TrustChanges.added (NetworkOPs.cpp:2081) but computed from
 	// snapshots since goXRPL's writable surface is the explicit
 	// adaptor.SetTrustedValidators call rather than a per-round
-	// updateTrusted return value. Nil before the first round; the
-	// first round therefore registers the entire current UNL (matching
-	// rippled's empty-prior-set first round). Mutated only while e.mu
-	// is held.
+	// updateTrusted return value. Seeded from the adaptor's current
+	// UNL on the first invocation with a parent ledger (see
+	// previousTrustedSeeded). Mutated only while e.mu is held.
 	previousTrustedSet map[consensus.NodeID]struct{}
+
+	// previousTrustedSeeded latches true after the first call that
+	// observes a non-nil prevLedger. While false, the next call seeds
+	// previousTrustedSet from the adaptor's startup UNL and skips
+	// OnUNLChange — mirroring rippled where ValidatorList::updateTrusted
+	// diffs against the publisher-list-loaded trustedMasterKeys_ on its
+	// very first call, so the startup UNL is NOT reported as `added`.
+	// Mutated only while e.mu is held.
+	previousTrustedSeeded bool
 }
 
 // ValidationArchive is the subset of the archive API the consensus engine
@@ -510,7 +518,7 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	// Placed before the mode switch so it runs in every mode (proposing /
 	// observing / switchedLedger), matching rippled's preStartRound at
 	// RCLConsensus.cpp:1041-1043 which fires regardless of validator state.
-	e.driveNegativeUNLNewValidatorsLocked(round.Seq)
+	e.driveNegativeUNLNewValidatorsLocked()
 
 	// Determine mode. After a wrongLedger recovery we enter switchedLedger
 	// for exactly one round — not proposing, not validating — even though
@@ -630,6 +638,16 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 // on the parent ledger and the delta is non-empty. Updates the snapshot
 // in-place so the next round sees the new baseline.
 //
+// The seq passed to OnUNLChange is derived directly from the parent
+// ledger (`prevLedger.Seq() + 1`), matching rippled at
+// RCLConsensus.cpp:1043 (`nUnlVote_.newValidators(prevLgr.seq() + 1, ...)`).
+// Critically, the voting-path purge in GenerateNegativeUNLPseudoTx also
+// keys off `prevSeq + 1` (negative_unl_vote.go:74); reading the seq
+// from the same source on both sides keeps the grace-period window
+// internally consistent even if a caller ever drives StartRound with a
+// round.Seq that drifts from prevLedger.Seq()+1 (recovery / wrong-LCL
+// paths).
+//
 // Mirrors rippled's NetworkOPs.cpp:2081-2102 → RCLConsensus.cpp:1041-1043
 // pairing: NetworkOPs computes TrustChanges.added per round via
 // updateTrusted, then passes it through startRound → preStartRound →
@@ -637,8 +655,12 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 // the adaptor each round — but the observable behavior is the same:
 // any mutation that lands through adaptor.SetTrustedValidators is
 // picked up on the next round and its `added` set drives OnUNLChange.
-// Caller must hold e.mu.
-func (e *Engine) driveNegativeUNLNewValidatorsLocked(upcomingSeq uint32) {
+// previousTrustedSet is seeded once on the first call (from the
+// adaptor's current UNL) so the first round does NOT misreport the
+// entire startup-loaded UNL as `added`; this matches rippled where
+// ValidatorList::trustedMasterKeys_ is already populated by applyLists
+// before the first updateTrusted call. Caller must hold e.mu.
+func (e *Engine) driveNegativeUNLNewValidatorsLocked() {
 	if e.prevLedger == nil {
 		return
 	}
@@ -646,6 +668,21 @@ func (e *Engine) driveNegativeUNLNewValidatorsLocked(upcomingSeq uint32) {
 		return
 	}
 	current := e.adaptor.GetTrustedValidators()
+
+	// Seed once: on the very first invocation with a parent ledger the
+	// prior set is the startup-loaded UNL, not the empty set. Treating
+	// the startup UNL as `added` would hand every already-mature
+	// validator a fresh NewValidatorDisableSkip-ledger grace period
+	// after a restart — silent but observable divergence from rippled.
+	if !e.previousTrustedSeeded {
+		e.previousTrustedSet = make(map[consensus.NodeID]struct{}, len(current))
+		for _, n := range current {
+			e.previousTrustedSet[n] = struct{}{}
+		}
+		e.previousTrustedSeeded = true
+		return
+	}
+
 	var added []consensus.NodeID
 	for _, n := range current {
 		if _, seen := e.previousTrustedSet[n]; !seen {
@@ -653,7 +690,7 @@ func (e *Engine) driveNegativeUNLNewValidatorsLocked(upcomingSeq uint32) {
 		}
 	}
 	if len(added) > 0 {
-		e.adaptor.OnUNLChange(upcomingSeq, added)
+		e.adaptor.OnUNLChange(e.prevLedger.Seq()+1, added)
 	}
 	next := make(map[consensus.NodeID]struct{}, len(current))
 	for _, n := range current {

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -206,16 +206,16 @@ type Engine struct {
 	deferBroadcasts int
 
 	// previousTrustedSet is the trusted-validator set as of the previous
-	// startRoundLocked invocation. Used to compute the per-round delta
-	// passed to adaptor.OnUNLChange so the NegativeUNL voter's grace
-	// period covers validators newly added to the UNL. Mirrors the role
-	// of rippled's TrustChanges.added (NetworkOPs.cpp:2081) — there
-	// `validators().updateTrusted()` returns the delta directly; here
-	// the engine derives it from snapshots since goXRPL does not yet
-	// expose a per-round updateTrusted hook on the validator manager.
-	// Nil before the first round; the first round therefore registers
-	// the entire current UNL (matching rippled's empty-prior-set first
-	// round). Mutated only while e.mu is held.
+	// startRoundLocked invocation. The engine diffs it against the
+	// adaptor's current trusted set each round to derive the `added`
+	// delta passed to OnUNLChange — equivalent to rippled's
+	// TrustChanges.added (NetworkOPs.cpp:2081) but computed from
+	// snapshots since goXRPL's writable surface is the explicit
+	// adaptor.SetTrustedValidators call rather than a per-round
+	// updateTrusted return value. Nil before the first round; the
+	// first round therefore registers the entire current UNL (matching
+	// rippled's empty-prior-set first round). Mutated only while e.mu
+	// is held.
 	previousTrustedSet map[consensus.NodeID]struct{}
 }
 
@@ -633,9 +633,11 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 // Mirrors rippled's NetworkOPs.cpp:2081-2102 → RCLConsensus.cpp:1041-1043
 // pairing: NetworkOPs computes TrustChanges.added per round via
 // updateTrusted, then passes it through startRound → preStartRound →
-// nUnlVote_.newValidators. goXRPL has no per-round updateTrusted hook on
-// the validator manager yet, so the engine derives the delta from
-// snapshots taken at startRoundLocked time. Caller must hold e.mu.
+// nUnlVote_.newValidators. goXRPL inverts the seam — the engine polls
+// the adaptor each round — but the observable behavior is the same:
+// any mutation that lands through adaptor.SetTrustedValidators is
+// picked up on the next round and its `added` set drives OnUNLChange.
+// Caller must hold e.mu.
 func (e *Engine) driveNegativeUNLNewValidatorsLocked(upcomingSeq uint32) {
 	if e.prevLedger == nil {
 		return

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -144,8 +144,6 @@ type mockAdaptor struct {
 	flagLedgerPseudoTxs [][]byte
 	negativeUNLPseudoTx [][]byte
 
-	// OnUNLChange calls captured for assertions in the engine wiring
-	// test (TestEngine_StartRound_DrivesOnUNLChange).
 	onUNLChangeCalls []onUNLChangeCall
 
 	// standalone toggles the IsStandalone() return for tests that

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -144,6 +144,10 @@ type mockAdaptor struct {
 	flagLedgerPseudoTxs [][]byte
 	negativeUNLPseudoTx [][]byte
 
+	// OnUNLChange calls captured for assertions in the engine wiring
+	// test (TestEngine_StartRound_DrivesOnUNLChange).
+	onUNLChangeCalls []onUNLChangeCall
+
 	// standalone toggles the IsStandalone() return for tests that
 	// exercise rippled's `standalone() || (proposing && !wrongLCL)`
 	// OR-branch at RCLConsensus.cpp:352.
@@ -349,6 +353,22 @@ func (a *mockAdaptor) GenerateNegativeUNLPseudoTx(_ consensus.Ledger) [][]byte {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.negativeUNLPseudoTx
+}
+
+type onUNLChangeCall struct {
+	upcomingSeq uint32
+	nowTrusted  []consensus.NodeID
+}
+
+func (a *mockAdaptor) OnUNLChange(upcomingSeq uint32, nowTrusted []consensus.NodeID) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	added := make([]consensus.NodeID, len(nowTrusted))
+	copy(added, nowTrusted)
+	a.onUNLChangeCalls = append(a.onUNLChangeCalls, onUNLChangeCall{
+		upcomingSeq: upcomingSeq,
+		nowTrusted:  added,
+	})
 }
 
 func (a *mockAdaptor) HasTx(id consensus.TxID) bool {
@@ -628,6 +648,139 @@ func TestEngine_StartRound_Observing(t *testing.T) {
 	if engine.Mode() != consensus.ModeObserving {
 		t.Errorf("Expected Observing mode, got %v", engine.Mode())
 	}
+}
+
+// TestEngine_StartRound_DrivesOnUNLChange pins the wiring that
+// mirrors rippled's NetworkOPs.cpp:2081-2102 → RCLConsensus.cpp:1041-1043
+// pairing: at the head of every consensus round, the engine computes the
+// trusted-set delta since the previous round and forwards the
+// newly-added validators to adaptor.OnUNLChange so the NegativeUNL
+// voter exempts them from ToDisable for NewValidatorDisableSkip ledgers.
+//
+// Without this wiring (issue #423), OnUNLChange was an exposed-but-dead
+// API: any fresh validator could be voted ToDisable before accumulating
+// any validations, defeating rippled's grace-period protection.
+func TestEngine_StartRound_DrivesOnUNLChange(t *testing.T) {
+	prev := &mockLedger{id: consensus.LedgerID{0xAB, 0xCD}, seq: 256}
+	adaptor := newMockAdaptor()
+	adaptor.lastLCL = prev
+	adaptor.ledgers[prev.ID()] = prev
+
+	n1 := consensus.NodeID{0x01}
+	n2 := consensus.NodeID{0x02}
+	n3 := consensus.NodeID{0x03}
+	adaptor.setTrusted([]consensus.NodeID{n1, n2})
+
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	// First round: prevLedger nil → no OnUNLChange call (matches
+	// production where the first round can't gate on a parent ledger
+	// it hasn't seen yet; rippled's preStartRound is only invoked after
+	// closingInfo has resolved a parent — NetworkOPs.cpp:2070).
+	round1 := consensus.RoundID{Seq: prev.Seq() + 1, ParentHash: prev.ID()}
+	if err := engine.StartRound(round1, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	if got := len(adaptor.onUNLChangeCalls); got != 0 {
+		t.Fatalf("no parent ledger → expected 0 OnUNLChange calls, got %d", got)
+	}
+
+	// Second round: install prevLedger, keep the same UNL → the entire
+	// UNL is treated as "added" relative to the nil previousTrustedSet,
+	// matching rippled's first-call behavior where TrustChanges.added
+	// equals the full new UNL (NetworkOPs.cpp:2081 with an empty prior).
+	engine.mu.Lock()
+	engine.prevLedger = prev
+	engine.mu.Unlock()
+	round2 := consensus.RoundID{Seq: prev.Seq() + 1, ParentHash: prev.ID()}
+	if err := engine.StartRound(round2, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	if got := len(adaptor.onUNLChangeCalls); got != 1 {
+		t.Fatalf("first round with prevLedger: expected 1 OnUNLChange call, got %d", got)
+	}
+	first := adaptor.onUNLChangeCalls[0]
+	if first.upcomingSeq != round2.Seq {
+		t.Errorf("upcomingSeq: want %d, got %d", round2.Seq, first.upcomingSeq)
+	}
+	if !sameNodeIDSet(first.nowTrusted, []consensus.NodeID{n1, n2}) {
+		t.Errorf("nowTrusted: want {n1,n2}, got %v", first.nowTrusted)
+	}
+
+	// Third round: no UNL change → no OnUNLChange call (rippled's
+	// !nowTrusted.empty() gate at RCLConsensus.cpp:1042).
+	if err := engine.StartRound(round2, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	if got := len(adaptor.onUNLChangeCalls); got != 1 {
+		t.Fatalf("unchanged UNL must not trigger a call; got %d total", got)
+	}
+
+	// Fourth round: add n3 → only n3 is forwarded, matching rippled's
+	// TrustChanges.added delta semantics.
+	adaptor.setTrusted([]consensus.NodeID{n1, n2, n3})
+	if err := engine.StartRound(round2, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	if got := len(adaptor.onUNLChangeCalls); got != 2 {
+		t.Fatalf("added validator: expected 2 calls total, got %d", got)
+	}
+	second := adaptor.onUNLChangeCalls[1]
+	if !sameNodeIDSet(second.nowTrusted, []consensus.NodeID{n3}) {
+		t.Errorf("delta must be {n3}, got %v", second.nowTrusted)
+	}
+
+	// Fifth round: remove n2 → still no call (rippled only forwards
+	// `added`, never `removed`).
+	adaptor.setTrusted([]consensus.NodeID{n1, n3})
+	if err := engine.StartRound(round2, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	if got := len(adaptor.onUNLChangeCalls); got != 2 {
+		t.Fatalf("removals must not trigger OnUNLChange; got %d total", got)
+	}
+}
+
+// TestEngine_StartRound_OnUNLChangeGatedOnFeature pins the
+// featureNegativeUNL gate at RCLConsensus.cpp:1041. When the amendment
+// is disabled on prevLedger, the engine must not drive OnUNLChange
+// regardless of UNL deltas.
+func TestEngine_StartRound_OnUNLChangeGatedOnFeature(t *testing.T) {
+	prev := &mockLedger{id: consensus.LedgerID{0x77, 0x88}, seq: 100}
+	adaptor := newMockAdaptor()
+	adaptor.lastLCL = prev
+	adaptor.ledgers[prev.ID()] = prev
+	adaptor.disabledFeatures = map[string]bool{"NegativeUNL": true}
+	adaptor.setTrusted([]consensus.NodeID{{0x11}, {0x22}})
+
+	engine := NewEngine(adaptor, DefaultConfig())
+	engine.mu.Lock()
+	engine.prevLedger = prev
+	engine.mu.Unlock()
+
+	round := consensus.RoundID{Seq: prev.Seq() + 1, ParentHash: prev.ID()}
+	if err := engine.StartRound(round, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	if got := len(adaptor.onUNLChangeCalls); got != 0 {
+		t.Fatalf("featureNegativeUNL disabled: expected 0 calls, got %d", got)
+	}
+}
+
+func sameNodeIDSet(a, b []consensus.NodeID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[consensus.NodeID]struct{}, len(a))
+	for _, n := range a {
+		set[n] = struct{}{}
+	}
+	for _, n := range b {
+		if _, ok := set[n]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func TestEngine_OnProposal(t *testing.T) {

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -671,10 +671,10 @@ func TestEngine_StartRound_DrivesOnUNLChange(t *testing.T) {
 
 	engine := NewEngine(adaptor, DefaultConfig())
 
-	// First round: prevLedger nil → no OnUNLChange call (matches
-	// production where the first round can't gate on a parent ledger
-	// it hasn't seen yet; rippled's preStartRound is only invoked after
-	// closingInfo has resolved a parent — NetworkOPs.cpp:2070).
+	// Round 1: prevLedger nil → no OnUNLChange call (matches production
+	// where the first round can't gate on a parent ledger it hasn't seen
+	// yet; rippled's preStartRound is only invoked after closingInfo has
+	// resolved a parent — NetworkOPs.cpp:2070).
 	round1 := consensus.RoundID{Seq: prev.Seq() + 1, ParentHash: prev.ID()}
 	if err := engine.StartRound(round1, false); err != nil {
 		t.Fatalf("StartRound: %v", err)
@@ -683,10 +683,13 @@ func TestEngine_StartRound_DrivesOnUNLChange(t *testing.T) {
 		t.Fatalf("no parent ledger → expected 0 OnUNLChange calls, got %d", got)
 	}
 
-	// Second round: install prevLedger, keep the same UNL → the entire
-	// UNL is treated as "added" relative to the nil previousTrustedSet,
-	// matching rippled's first-call behavior where TrustChanges.added
-	// equals the full new UNL (NetworkOPs.cpp:2081 with an empty prior).
+	// Round 2: install prevLedger; the first call with a parent ledger
+	// SEEDS previousTrustedSet from the startup UNL and skips OnUNLChange.
+	// This mirrors rippled where ValidatorList::trustedMasterKeys_ is
+	// already populated by applyLists() before the first updateTrusted
+	// call, so the startup UNL is NOT reported in TrustChanges.added —
+	// otherwise every restart would hand every already-mature validator
+	// a fresh NewValidatorDisableSkip-ledger grace period.
 	engine.mu.Lock()
 	engine.prevLedger = prev
 	engine.mu.Unlock()
@@ -694,48 +697,76 @@ func TestEngine_StartRound_DrivesOnUNLChange(t *testing.T) {
 	if err := engine.StartRound(round2, false); err != nil {
 		t.Fatalf("StartRound: %v", err)
 	}
-	if got := len(adaptor.onUNLChangeCalls); got != 1 {
-		t.Fatalf("first round with prevLedger: expected 1 OnUNLChange call, got %d", got)
-	}
-	first := adaptor.onUNLChangeCalls[0]
-	if first.upcomingSeq != round2.Seq {
-		t.Errorf("upcomingSeq: want %d, got %d", round2.Seq, first.upcomingSeq)
-	}
-	if !sameNodeIDSet(first.nowTrusted, []consensus.NodeID{n1, n2}) {
-		t.Errorf("nowTrusted: want {n1,n2}, got %v", first.nowTrusted)
+	if got := len(adaptor.onUNLChangeCalls); got != 0 {
+		t.Fatalf("seeding round must not invoke OnUNLChange (startup UNL is not `added`); got %d", got)
 	}
 
-	// Third round: no UNL change → no OnUNLChange call (rippled's
+	// Round 3: same UNL → no OnUNLChange call (rippled's
 	// !nowTrusted.empty() gate at RCLConsensus.cpp:1042).
 	if err := engine.StartRound(round2, false); err != nil {
 		t.Fatalf("StartRound: %v", err)
 	}
-	if got := len(adaptor.onUNLChangeCalls); got != 1 {
+	if got := len(adaptor.onUNLChangeCalls); got != 0 {
 		t.Fatalf("unchanged UNL must not trigger a call; got %d total", got)
 	}
 
-	// Fourth round: add n3 → only n3 is forwarded, matching rippled's
-	// TrustChanges.added delta semantics.
+	// Round 4: add n3 → only n3 is forwarded, matching rippled's
+	// TrustChanges.added delta semantics. upcomingSeq is derived from
+	// prevLedger.Seq()+1 inside the engine, NOT from round.Seq.
 	adaptor.setTrusted([]consensus.NodeID{n1, n2, n3})
 	if err := engine.StartRound(round2, false); err != nil {
 		t.Fatalf("StartRound: %v", err)
 	}
-	if got := len(adaptor.onUNLChangeCalls); got != 2 {
-		t.Fatalf("added validator: expected 2 calls total, got %d", got)
+	if got := len(adaptor.onUNLChangeCalls); got != 1 {
+		t.Fatalf("added validator: expected 1 call total, got %d", got)
 	}
-	second := adaptor.onUNLChangeCalls[1]
-	if !sameNodeIDSet(second.nowTrusted, []consensus.NodeID{n3}) {
-		t.Errorf("delta must be {n3}, got %v", second.nowTrusted)
+	first := adaptor.onUNLChangeCalls[0]
+	if first.upcomingSeq != prev.Seq()+1 {
+		t.Errorf("upcomingSeq: want prevLedger.Seq()+1 = %d, got %d", prev.Seq()+1, first.upcomingSeq)
+	}
+	if !sameNodeIDSet(first.nowTrusted, []consensus.NodeID{n3}) {
+		t.Errorf("delta must be {n3}, got %v", first.nowTrusted)
 	}
 
-	// Fifth round: remove n2 → still no call (rippled only forwards
-	// `added`, never `removed`).
+	// Round 5: remove n2 → no call (rippled only forwards `added`, never
+	// `removed` — see RCLConsensus.cpp:1093-1103 where `nowUntrusted` is
+	// passed to consensus.startRound but explicitly NOT to preStartRound).
 	adaptor.setTrusted([]consensus.NodeID{n1, n3})
 	if err := engine.StartRound(round2, false); err != nil {
 		t.Fatalf("StartRound: %v", err)
 	}
-	if got := len(adaptor.onUNLChangeCalls); got != 2 {
+	if got := len(adaptor.onUNLChangeCalls); got != 1 {
 		t.Fatalf("removals must not trigger OnUNLChange; got %d total", got)
+	}
+}
+
+// TestEngine_StartRound_SeedingHonorsRestart pins the M2 fix more
+// pointedly: a node that restarts with a steady-state UNL must NOT
+// see any of its already-trusted validators forwarded to OnUNLChange.
+// Pre-M2, the first round with prevLedger registered every trusted
+// validator in the grace-period table, silently exempting them from
+// ToDisable voting for ~256 ledgers after every restart.
+func TestEngine_StartRound_SeedingHonorsRestart(t *testing.T) {
+	prev := &mockLedger{id: consensus.LedgerID{0xCA, 0xFE}, seq: 1000}
+	adaptor := newMockAdaptor()
+	adaptor.lastLCL = prev
+	adaptor.ledgers[prev.ID()] = prev
+	// Steady-state UNL loaded by startup — no validator should be
+	// treated as "new" by the very next round.
+	adaptor.setTrusted([]consensus.NodeID{{0x10}, {0x20}, {0x30}, {0x40}, {0x50}})
+
+	engine := NewEngine(adaptor, DefaultConfig())
+	engine.mu.Lock()
+	engine.prevLedger = prev
+	engine.mu.Unlock()
+
+	round := consensus.RoundID{Seq: prev.Seq() + 1, ParentHash: prev.ID()}
+	if err := engine.StartRound(round, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	if got := len(adaptor.onUNLChangeCalls); got != 0 {
+		t.Fatalf("steady-state restart must not forward any validator as `added`; got %d call(s): %+v",
+			got, adaptor.onUNLChangeCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `Adaptor.OnUNLChange(seq, nowTrusted)` forwarding to `Voter.NewValidators` + `Voter.PurgeNewValidators`, the goXRPL equivalent of rippled's `nUnlVote_.newValidators(seq, nowTrusted)` callback at `RCLConsensus.cpp:1040-1041`.
- No-op on adaptors built without a NegativeUNL voter (no validator identity / master keys).
- Tests cover the no-voter no-op path and port rippled's `NegativeUNLVoteNewValidator_test::testDoVoting` (`rippled/src/test/consensus/NegativeUNL_test.cpp:1735`): a freshly-trusted validator with a bad score is exempt from ToDisable inside the `NewValidatorDisableSkip` window, and becomes eligible once `seq` advances past it.


## Test plan
- [x] `go test ./internal/consensus/adaptor/ ./internal/consensus/negativeunlvote/`
- [x] `go vet ./internal/consensus/...`
- [x] `gofmt -l internal/consensus/adaptor/negative_unl_vote*.go` (clean)
- [x] `go build ./...`

Fixes #423