### PR TITLE
shamap: O(1) Size() with cached-on-immutable count (issue #431 follow-up)

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -892,9 +892,7 @@ func (l *Ledger) ForEachTransaction(fn func(txHash [32]byte, txData []byte) bool
 	})
 }
 
-// TxCount returns the number of transactions in the tx map. Delegates to
-// SHAMap.Size, which is O(1) on the closed/immutable ledger views that
-// TxQ fee math and RPC handlers query.
+// TxCount returns the number of transactions in the tx map.
 func (l *Ledger) TxCount() uint32 {
 	l.mu.RLock()
 	defer l.mu.RUnlock()

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -892,17 +892,13 @@ func (l *Ledger) ForEachTransaction(fn func(txHash [32]byte, txData []byte) bool
 	})
 }
 
-// TxCount returns the number of transactions in the tx map.
+// TxCount returns the number of transactions in the tx map. Delegates to
+// SHAMap.Size, which is O(1) on the closed/immutable ledger views that
+// TxQ fee math and RPC handlers query.
 func (l *Ledger) TxCount() uint32 {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
-
-	var count uint32
-	_ = l.txMap.ForEach(func(_ *shamap.Item) bool {
-		count++
-		return true
-	})
-	return count
+	return uint32(l.txMap.Size())
 }
 
 // StateMapSnapshot returns a mutable snapshot of the state map.

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -990,6 +990,15 @@ func (sm *SHAMap) snapshotBacked(mutable bool) (*SHAMap, error) {
 	newMap.state = newState
 	newMap.ledgerSeq = sm.ledgerSeq
 
+	// Immutable→immutable backed snapshot owns the same leaf set as its
+	// source; carry the cached count across so the snapshot is O(1) on
+	// first Size() too. Mirrors the unbacked branch in Snapshot().
+	if !mutable && sm.state == StateImmutable {
+		if n := sm.cachedSize.Load(); n >= 0 {
+			newMap.cachedSize.Store(n)
+		}
+	}
+
 	return newMap, nil
 }
 
@@ -1007,14 +1016,18 @@ func (sm *SHAMap) Size() int {
 
 	sm.mu.RLock()
 	count := 0
-	_ = sm.forEachUnsafe(context.Background(), sm.root, func(*Item) bool {
+	err := sm.forEachUnsafe(context.Background(), sm.root, func(*Item) bool {
 		count++
 		return true
 	})
 	isImmutable := sm.state == StateImmutable
 	sm.mu.RUnlock()
 
-	if isImmutable {
+	// Only cache when the walk completed without error. A backed map's
+	// descend() can fail mid-traversal (NodeStore fetch / deserialize);
+	// caching a partial count would lock the wrong value in for the
+	// lifetime of the map, so let the next call retry instead.
+	if isImmutable && err == nil {
 		// Race between concurrent first-readers is benign: every walker
 		// sees the same frozen tree and so computes the same count.
 		sm.cachedSize.Store(int64(count))

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 )
 
 // Common errors
@@ -77,20 +78,28 @@ type SHAMap struct {
 	full      bool
 	backed    bool
 	family    Family // nil for unbacked maps
+	// cachedSize memoises Size() once the map is immutable. -1 means
+	// uncached; any non-negative value is the authoritative leaf count.
+	// Only written for immutable maps, where the tree is frozen and a
+	// race between concurrent first-readers is benign (they all compute
+	// the same count).
+	cachedSize atomic.Int64
 }
 
 // New creates a new empty SHAMap with the specified type
 func New(mapType Type) (*SHAMap, error) {
 	root := NewInnerNode()
 
-	return &SHAMap{
+	sm := &SHAMap{
 		root:      root,
 		mapType:   mapType,
 		state:     StateModifying,
 		ledgerSeq: 0,
 		full:      true,
 		backed:    false,
-	}, nil
+	}
+	sm.cachedSize.Store(-1)
+	return sm, nil
 }
 
 // NewBacked creates a new empty backed SHAMap with the specified type and Family.
@@ -100,14 +109,16 @@ func NewBacked(mapType Type, family Family) (*SHAMap, error) {
 		return nil, errors.New("family is required for backed SHAMap")
 	}
 	root := NewInnerNode()
-	return &SHAMap{
+	sm := &SHAMap{
 		root:    root,
 		mapType: mapType,
 		state:   StateModifying,
 		full:    true,
 		backed:  true,
 		family:  family,
-	}, nil
+	}
+	sm.cachedSize.Store(-1)
+	return sm, nil
 }
 
 // SetFamily sets the Family on an existing SHAMap, enabling backed mode.
@@ -147,14 +158,16 @@ func NewFromRootHash(mapType Type, rootHash [32]byte, family Family) (*SHAMap, e
 		return nil, fmt.Errorf("root node is not an InnerNode, got %T", node)
 	}
 
-	return &SHAMap{
+	sm := &SHAMap{
 		root:    root,
 		mapType: mapType,
 		state:   StateModifying,
 		full:    true,
 		backed:  true,
 		family:  family,
-	}, nil
+	}
+	sm.cachedSize.Store(-1)
+	return sm, nil
 }
 
 // descend returns the child node at the given branch of an inner node.
@@ -923,13 +936,23 @@ func (sm *SHAMap) Snapshot(mutable bool) (*SHAMap, error) {
 		return nil, fmt.Errorf("failed to clone tree: %w", err)
 	}
 
-	return &SHAMap{
+	out := &SHAMap{
 		root:      newRoot,
 		mapType:   sm.mapType,
 		state:     newState,
 		ledgerSeq: sm.ledgerSeq,
 		full:      sm.full,
-	}, nil
+	}
+	out.cachedSize.Store(-1)
+	// Immutable→immutable snapshot owns the same leaf set as its source; if
+	// the source already cached its size, carry it over so the snapshot is
+	// also O(1) on first Size().
+	if !mutable && sm.state == StateImmutable {
+		if n := sm.cachedSize.Load(); n >= 0 {
+			out.cachedSize.Store(n)
+		}
+	}
+	return out, nil
 }
 
 // snapshotBacked creates a snapshot of a backed map by flushing dirty nodes
@@ -968,6 +991,35 @@ func (sm *SHAMap) snapshotBacked(mutable bool) (*SHAMap, error) {
 	newMap.ledgerSeq = sm.ledgerSeq
 
 	return newMap, nil
+}
+
+// Size returns the number of leaf items in the SHAMap.
+//
+// For immutable maps (the typical consumer — closed/historical ledgers
+// queried by TxQ fee math, RPC handlers, etc.) the result is computed on
+// the first call and cached, so subsequent calls are O(1). For mutable
+// maps the tree is walked each call, matching what callers had to do
+// inline before this method existed.
+func (sm *SHAMap) Size() int {
+	if n := sm.cachedSize.Load(); n >= 0 {
+		return int(n)
+	}
+
+	sm.mu.RLock()
+	count := 0
+	_ = sm.forEachUnsafe(context.Background(), sm.root, func(*Item) bool {
+		count++
+		return true
+	})
+	isImmutable := sm.state == StateImmutable
+	sm.mu.RUnlock()
+
+	if isImmutable {
+		// Race between concurrent first-readers is benign: every walker
+		// sees the same frozen tree and so computes the same count.
+		sm.cachedSize.Store(int64(count))
+	}
+	return count
 }
 
 // ForEach calls fn for every item in the tree.

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -78,11 +78,9 @@ type SHAMap struct {
 	full      bool
 	backed    bool
 	family    Family // nil for unbacked maps
-	// cachedSize memoises Size() once the map is immutable. -1 means
-	// uncached; any non-negative value is the authoritative leaf count.
-	// Only written for immutable maps, where the tree is frozen and a
-	// race between concurrent first-readers is benign (they all compute
-	// the same count).
+	// cachedSize memoises Size(); -1 = uncached. Only written once the
+	// map is immutable, so concurrent first-readers race benignly on a
+	// frozen tree.
 	cachedSize atomic.Int64
 }
 
@@ -944,9 +942,8 @@ func (sm *SHAMap) Snapshot(mutable bool) (*SHAMap, error) {
 		full:      sm.full,
 	}
 	out.cachedSize.Store(-1)
-	// Immutable→immutable snapshot owns the same leaf set as its source; if
-	// the source already cached its size, carry it over so the snapshot is
-	// also O(1) on first Size().
+	// Immutable→immutable snapshot owns the same leaf set; carry the
+	// cached count across so the snapshot is O(1) on first Size() too.
 	if !mutable && sm.state == StateImmutable {
 		if n := sm.cachedSize.Load(); n >= 0 {
 			out.cachedSize.Store(n)
@@ -990,9 +987,8 @@ func (sm *SHAMap) snapshotBacked(mutable bool) (*SHAMap, error) {
 	newMap.state = newState
 	newMap.ledgerSeq = sm.ledgerSeq
 
-	// Immutable→immutable backed snapshot owns the same leaf set as its
-	// source; carry the cached count across so the snapshot is O(1) on
-	// first Size() too. Mirrors the unbacked branch in Snapshot().
+	// Immutable→immutable snapshot owns the same leaf set; carry the
+	// cached count across so the snapshot is O(1) on first Size() too.
 	if !mutable && sm.state == StateImmutable {
 		if n := sm.cachedSize.Load(); n >= 0 {
 			newMap.cachedSize.Store(n)
@@ -1003,12 +999,7 @@ func (sm *SHAMap) snapshotBacked(mutable bool) (*SHAMap, error) {
 }
 
 // Size returns the number of leaf items in the SHAMap.
-//
-// For immutable maps (the typical consumer — closed/historical ledgers
-// queried by TxQ fee math, RPC handlers, etc.) the result is computed on
-// the first call and cached, so subsequent calls are O(1). For mutable
-// maps the tree is walked each call, matching what callers had to do
-// inline before this method existed.
+// O(1) on immutable maps (memoised after the first call), O(n) on mutable.
 func (sm *SHAMap) Size() int {
 	if n := sm.cachedSize.Load(); n >= 0 {
 		return int(n)
@@ -1023,13 +1014,9 @@ func (sm *SHAMap) Size() int {
 	isImmutable := sm.state == StateImmutable
 	sm.mu.RUnlock()
 
-	// Only cache when the walk completed without error. A backed map's
-	// descend() can fail mid-traversal (NodeStore fetch / deserialize);
-	// caching a partial count would lock the wrong value in for the
-	// lifetime of the map, so let the next call retry instead.
+	// Never cache a partial count: descend() can fail mid-walk on a backed
+	// map, and a poisoned cache would persist for the map's lifetime.
 	if isImmutable && err == nil {
-		// Race between concurrent first-readers is benign: every walker
-		// sees the same frozen tree and so computes the same count.
 		sm.cachedSize.Store(int64(count))
 	}
 	return count

--- a/shamap/size_test.go
+++ b/shamap/size_test.go
@@ -1,6 +1,8 @@
 package shamap
 
 import (
+	"errors"
+	"sync/atomic"
 	"testing"
 )
 
@@ -85,12 +87,12 @@ func TestSize_CachedWhenImmutable(t *testing.T) {
 		t.Errorf("after immutable Size cachedSize = %d, want 5", v)
 	}
 
-	// Subsequent calls read the cache (we can't directly observe that the
-	// walk is skipped from the test surface, but corrupting the root and
-	// confirming Size still reports 5 proves the cache is consulted).
-	sm.root = nil
-	if got := sm.Size(); got != 5 {
-		t.Errorf("cached Size = %d, want 5 (cache not consulted)", got)
+	// Subsequent calls must consult the cache rather than re-walking.
+	// Overwrite the cached value to a sentinel and assert Size returns
+	// the sentinel — only possible if the walk is skipped.
+	sm.cachedSize.Store(999)
+	if got := sm.Size(); got != 999 {
+		t.Errorf("cached Size = %d, want 999 (cache not consulted)", got)
 	}
 }
 
@@ -130,5 +132,119 @@ func TestSize_SnapshotInheritsImmutableCache(t *testing.T) {
 	}
 	if v := mut.cachedSize.Load(); v != -1 {
 		t.Errorf("mutable snapshot cachedSize = %d, want -1", v)
+	}
+}
+
+// failingFamily wraps a Family and forces Fetch to fail after the first N
+// successful calls, simulating a NodeStore I/O blip mid-traversal.
+type failingFamily struct {
+	inner    Family
+	failAfter int32
+	calls     atomic.Int32
+}
+
+func (f *failingFamily) Fetch(hash [32]byte) ([]byte, error) {
+	if f.calls.Add(1) > f.failAfter {
+		return nil, errors.New("simulated fetch failure")
+	}
+	return f.inner.Fetch(hash)
+}
+
+func (f *failingFamily) StoreBatch(entries []FlushEntry) error {
+	return f.inner.StoreBatch(entries)
+}
+
+func TestSize_DoesNotCacheOnWalkError(t *testing.T) {
+	t.Parallel()
+	mem := NewMemoryFamily()
+	sm, err := NewBacked(TypeState, mem)
+	if err != nil {
+		t.Fatalf("new backed: %v", err)
+	}
+	// Use diverse keys so the tree has internal branching and Size's walk
+	// must descend through multiple inner nodes (each a potential fetch).
+	keys := [][32]byte{
+		{0x00, 0x11}, {0x10, 0x22}, {0x20, 0x33}, {0x30, 0x44},
+		{0x40, 0x55}, {0x50, 0x66}, {0x60, 0x77}, {0x70, 0x88},
+	}
+	for i, k := range keys {
+		if err := sm.PutItem(makeItem(k, intToBytes(i+1))); err != nil {
+			t.Fatalf("put %d: %v", i, err)
+		}
+	}
+
+	// Flush dirty nodes to the family and drop in-memory children, so any
+	// subsequent descend() goes through Family.Fetch.
+	batch, err := sm.FlushDirty(true)
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if err := mem.StoreBatch(batch.Entries); err != nil {
+		t.Fatalf("storebatch: %v", err)
+	}
+
+	if err := sm.SetImmutable(); err != nil {
+		t.Fatalf("SetImmutable: %v", err)
+	}
+
+	// Swap in a family that fails after the first fetch.
+	sm.SetFamily(&failingFamily{inner: mem, failAfter: 1})
+
+	// Walk will abort partway; the partial count must NOT be cached.
+	_ = sm.Size()
+	if v := sm.cachedSize.Load(); v != -1 {
+		t.Errorf("after errored walk cachedSize = %d, want -1 (partial counts must not be cached)", v)
+	}
+
+	// Restore a working family — the next Size() must re-walk and now cache
+	// the true count, proving the prior error didn't poison the map.
+	sm.SetFamily(mem)
+	if got := sm.Size(); got != len(keys) {
+		t.Errorf("post-recovery Size = %d, want %d", got, len(keys))
+	}
+	if v := sm.cachedSize.Load(); v != int64(len(keys)) {
+		t.Errorf("post-recovery cachedSize = %d, want %d", v, len(keys))
+	}
+}
+
+func TestSize_BackedSnapshotInheritsImmutableCache(t *testing.T) {
+	t.Parallel()
+	mem := NewMemoryFamily()
+	sm, err := NewBacked(TypeState, mem)
+	if err != nil {
+		t.Fatalf("new backed: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		k := [32]byte{byte(i * 0x11)}
+		if err := sm.PutItem(makeItem(k, intToBytes(i+1))); err != nil {
+			t.Fatalf("put: %v", err)
+		}
+	}
+	if err := sm.SetImmutable(); err != nil {
+		t.Fatalf("SetImmutable: %v", err)
+	}
+	if got := sm.Size(); got != 4 {
+		t.Fatalf("source Size = %d, want 4", got)
+	}
+	if v := sm.cachedSize.Load(); v != 4 {
+		t.Fatalf("source cachedSize = %d, want 4", v)
+	}
+
+	// Immutable→immutable backed snapshot must inherit the cache.
+	snap, err := sm.Snapshot(false)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if v := snap.cachedSize.Load(); v != 4 {
+		t.Errorf("backed immutable snapshot cachedSize = %d, want 4 (inheritance)", v)
+	}
+
+	// Mutable backed snapshot must NOT inherit (callers may mutate).
+	mut, err := sm.Snapshot(true)
+	if err != nil {
+		t.Fatalf("snapshot mutable: %v", err)
+	}
+	if v := mut.cachedSize.Load(); v != -1 {
+		t.Errorf("backed mutable snapshot cachedSize = %d, want -1", v)
 	}
 }

--- a/shamap/size_test.go
+++ b/shamap/size_test.go
@@ -133,7 +133,7 @@ func TestSize_SnapshotInheritsImmutableCache(t *testing.T) {
 // failingFamily forces Fetch to fail after the first N successful calls,
 // simulating a NodeStore blip mid-traversal.
 type failingFamily struct {
-	inner    Family
+	inner     Family
 	failAfter int32
 	calls     atomic.Int32
 }

--- a/shamap/size_test.go
+++ b/shamap/size_test.go
@@ -1,0 +1,134 @@
+package shamap
+
+import (
+	"testing"
+)
+
+func TestSize_EmptyMap(t *testing.T) {
+	t.Parallel()
+	sm, err := New(TypeTransaction)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if got := sm.Size(); got != 0 {
+		t.Errorf("Size on empty map = %d, want 0", got)
+	}
+}
+
+func TestSize_AfterPutAndDelete(t *testing.T) {
+	t.Parallel()
+	sm, err := New(TypeTransaction)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	keys := []string{
+		"092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7",
+		"436ccbac3347baa1f1e53baeef1f43334da88f1f6d70d963b833afd6dfa289fe",
+		"b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8",
+		"b92891fe4ef6cee585fdc6fda2e09eb4d386363158ec3321b8123e5a772c6ca8",
+	}
+	hashes := make([][32]byte, len(keys))
+	for i, k := range keys {
+		hashes[i] = hexToHash(k)
+		if err := sm.PutItem(makeItem(hashes[i], intToBytes(i+1))); err != nil {
+			t.Fatalf("put %d: %v", i, err)
+		}
+	}
+
+	if got := sm.Size(); got != len(keys) {
+		t.Errorf("Size after %d puts = %d, want %d", len(keys), got, len(keys))
+	}
+
+	// Re-put an existing key: count stays.
+	if err := sm.Delete(hashes[0]); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if got := sm.Size(); got != len(keys)-1 {
+		t.Errorf("Size after delete = %d, want %d", got, len(keys)-1)
+	}
+}
+
+func TestSize_CachedWhenImmutable(t *testing.T) {
+	t.Parallel()
+	sm, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		k := [32]byte{byte(i)}
+		if err := sm.PutItem(makeItem(k, intToBytes(i))); err != nil {
+			t.Fatalf("put: %v", err)
+		}
+	}
+
+	// Before SetImmutable the cache stays uncached.
+	if v := sm.cachedSize.Load(); v != -1 {
+		t.Fatalf("mutable map cachedSize = %d, want -1", v)
+	}
+	if got := sm.Size(); got != 5 {
+		t.Errorf("Size = %d, want 5", got)
+	}
+	if v := sm.cachedSize.Load(); v != -1 {
+		t.Errorf("after mutable Size cachedSize = %d, want -1 (no caching for mutable maps)", v)
+	}
+
+	if err := sm.SetImmutable(); err != nil {
+		t.Fatalf("SetImmutable: %v", err)
+	}
+
+	// First post-immutable Size primes the cache.
+	if got := sm.Size(); got != 5 {
+		t.Errorf("immutable Size = %d, want 5", got)
+	}
+	if v := sm.cachedSize.Load(); v != 5 {
+		t.Errorf("after immutable Size cachedSize = %d, want 5", v)
+	}
+
+	// Subsequent calls read the cache (we can't directly observe that the
+	// walk is skipped from the test surface, but corrupting the root and
+	// confirming Size still reports 5 proves the cache is consulted).
+	sm.root = nil
+	if got := sm.Size(); got != 5 {
+		t.Errorf("cached Size = %d, want 5 (cache not consulted)", got)
+	}
+}
+
+func TestSize_SnapshotInheritsImmutableCache(t *testing.T) {
+	t.Parallel()
+	sm, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		k := [32]byte{byte(i)}
+		if err := sm.PutItem(makeItem(k, intToBytes(i))); err != nil {
+			t.Fatalf("put: %v", err)
+		}
+	}
+	if err := sm.SetImmutable(); err != nil {
+		t.Fatalf("SetImmutable: %v", err)
+	}
+	_ = sm.Size() // prime parent cache
+	if v := sm.cachedSize.Load(); v != 3 {
+		t.Fatalf("parent cachedSize = %d, want 3", v)
+	}
+
+	// Immutable→immutable snapshot inherits the cached count.
+	snap, err := sm.Snapshot(false)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if v := snap.cachedSize.Load(); v != 3 {
+		t.Errorf("immutable snapshot cachedSize = %d, want 3 (inheritance)", v)
+	}
+
+	// Mutable snapshot does NOT inherit the cache (callers may mutate it).
+	mut, err := sm.Snapshot(true)
+	if err != nil {
+		t.Fatalf("snapshot mutable: %v", err)
+	}
+	if v := mut.cachedSize.Load(); v != -1 {
+		t.Errorf("mutable snapshot cachedSize = %d, want -1", v)
+	}
+}

--- a/shamap/size_test.go
+++ b/shamap/size_test.go
@@ -42,7 +42,6 @@ func TestSize_AfterPutAndDelete(t *testing.T) {
 		t.Errorf("Size after %d puts = %d, want %d", len(keys), got, len(keys))
 	}
 
-	// Re-put an existing key: count stays.
 	if err := sm.Delete(hashes[0]); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
@@ -64,7 +63,6 @@ func TestSize_CachedWhenImmutable(t *testing.T) {
 		}
 	}
 
-	// Before SetImmutable the cache stays uncached.
 	if v := sm.cachedSize.Load(); v != -1 {
 		t.Fatalf("mutable map cachedSize = %d, want -1", v)
 	}
@@ -79,7 +77,6 @@ func TestSize_CachedWhenImmutable(t *testing.T) {
 		t.Fatalf("SetImmutable: %v", err)
 	}
 
-	// First post-immutable Size primes the cache.
 	if got := sm.Size(); got != 5 {
 		t.Errorf("immutable Size = %d, want 5", got)
 	}
@@ -87,9 +84,8 @@ func TestSize_CachedWhenImmutable(t *testing.T) {
 		t.Errorf("after immutable Size cachedSize = %d, want 5", v)
 	}
 
-	// Subsequent calls must consult the cache rather than re-walking.
-	// Overwrite the cached value to a sentinel and assert Size returns
-	// the sentinel — only possible if the walk is skipped.
+	// Overwrite the cache with a sentinel: Size returning it proves the
+	// walk is skipped on subsequent calls.
 	sm.cachedSize.Store(999)
 	if got := sm.Size(); got != 999 {
 		t.Errorf("cached Size = %d, want 999 (cache not consulted)", got)
@@ -116,7 +112,6 @@ func TestSize_SnapshotInheritsImmutableCache(t *testing.T) {
 		t.Fatalf("parent cachedSize = %d, want 3", v)
 	}
 
-	// Immutable→immutable snapshot inherits the cached count.
 	snap, err := sm.Snapshot(false)
 	if err != nil {
 		t.Fatalf("snapshot: %v", err)
@@ -125,7 +120,7 @@ func TestSize_SnapshotInheritsImmutableCache(t *testing.T) {
 		t.Errorf("immutable snapshot cachedSize = %d, want 3 (inheritance)", v)
 	}
 
-	// Mutable snapshot does NOT inherit the cache (callers may mutate it).
+	// Mutable snapshot must not inherit: callers may mutate it.
 	mut, err := sm.Snapshot(true)
 	if err != nil {
 		t.Fatalf("snapshot mutable: %v", err)
@@ -135,8 +130,8 @@ func TestSize_SnapshotInheritsImmutableCache(t *testing.T) {
 	}
 }
 
-// failingFamily wraps a Family and forces Fetch to fail after the first N
-// successful calls, simulating a NodeStore I/O blip mid-traversal.
+// failingFamily forces Fetch to fail after the first N successful calls,
+// simulating a NodeStore blip mid-traversal.
 type failingFamily struct {
 	inner    Family
 	failAfter int32
@@ -161,8 +156,8 @@ func TestSize_DoesNotCacheOnWalkError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new backed: %v", err)
 	}
-	// Use diverse keys so the tree has internal branching and Size's walk
-	// must descend through multiple inner nodes (each a potential fetch).
+	// Diverse keys → internal branching, so Size's walk descends through
+	// multiple inner nodes (each a potential fetch).
 	keys := [][32]byte{
 		{0x00, 0x11}, {0x10, 0x22}, {0x20, 0x33}, {0x30, 0x44},
 		{0x40, 0x55}, {0x50, 0x66}, {0x60, 0x77}, {0x70, 0x88},
@@ -173,8 +168,8 @@ func TestSize_DoesNotCacheOnWalkError(t *testing.T) {
 		}
 	}
 
-	// Flush dirty nodes to the family and drop in-memory children, so any
-	// subsequent descend() goes through Family.Fetch.
+	// FlushDirty(true) drops in-memory children, so any subsequent
+	// descend() goes through Family.Fetch.
 	batch, err := sm.FlushDirty(true)
 	if err != nil {
 		t.Fatalf("flush: %v", err)
@@ -187,17 +182,15 @@ func TestSize_DoesNotCacheOnWalkError(t *testing.T) {
 		t.Fatalf("SetImmutable: %v", err)
 	}
 
-	// Swap in a family that fails after the first fetch.
 	sm.SetFamily(&failingFamily{inner: mem, failAfter: 1})
 
-	// Walk will abort partway; the partial count must NOT be cached.
 	_ = sm.Size()
 	if v := sm.cachedSize.Load(); v != -1 {
 		t.Errorf("after errored walk cachedSize = %d, want -1 (partial counts must not be cached)", v)
 	}
 
-	// Restore a working family — the next Size() must re-walk and now cache
-	// the true count, proving the prior error didn't poison the map.
+	// With a working family restored, the next Size() must re-walk and
+	// cache the true count — proving the prior error didn't poison the map.
 	sm.SetFamily(mem)
 	if got := sm.Size(); got != len(keys) {
 		t.Errorf("post-recovery Size = %d, want %d", got, len(keys))
@@ -230,7 +223,6 @@ func TestSize_BackedSnapshotInheritsImmutableCache(t *testing.T) {
 		t.Fatalf("source cachedSize = %d, want 4", v)
 	}
 
-	// Immutable→immutable backed snapshot must inherit the cache.
 	snap, err := sm.Snapshot(false)
 	if err != nil {
 		t.Fatalf("snapshot: %v", err)
@@ -239,7 +231,7 @@ func TestSize_BackedSnapshotInheritsImmutableCache(t *testing.T) {
 		t.Errorf("backed immutable snapshot cachedSize = %d, want 4 (inheritance)", v)
 	}
 
-	// Mutable backed snapshot must NOT inherit (callers may mutate).
+	// Mutable snapshot must not inherit: callers may mutate it.
 	mut, err := sm.Snapshot(true)
 	if err != nil {
 		t.Fatalf("snapshot mutable: %v", err)


### PR DESCRIPTION
## Summary

Follow-up to issue #431 (P0/P1/P2 audit) shipped in #441. The audit flagged:

> **`[P2]`** `TxqAdapter.GetTxInLedger` walks every transaction to return a count … The SHAMap should expose `Size()`/`Count()` directly; this is called for every TxQ fee-level computation, which is per-Submit-call.

PR #441 collapsed the walk into `Ledger.TxCount()` but the walk itself was still O(n) per call. This change pushes the optimisation down into `SHAMap` itself.

- New `SHAMap.Size()` method.
- For **immutable** maps (closed/historical ledger views — the only consumers that hit this in hot paths: TxQ fee math, RPC handlers, replay) the count is computed on first call and memoised via `atomic.Int64`. Subsequent calls are O(1).
- For **mutable** maps the tree is walked each call, matching prior behaviour. Mutable maps never cache, so cache-vs-mutation cannot diverge.
- Immutable→immutable `Snapshot(false)` inherits the cached count (the leaf set is identical). Mutable snapshots start uncached because callers may mutate them.
- `Ledger.TxCount()` now delegates to `txMap.Size()`.

## On the other P2 follow-up (panic→error in `xrpl_number.go` / `amount.go` / `amount_sqrt.go`)

The audit also asked to convert the arithmetic panic sites to `(result, error)` returns. The conformance review on #441 found that goXRPL's panic + engine-boundary `recover` model is exactly what rippled does:

- `applySteps.cpp:447-466` — `doApply` wraps `invoke_apply(ctx)` in `try { ... } catch (std::exception const&) { return {tefEXCEPTION, false}; }`.
- `ApplyContext.cpp:97-148` — `checkInvariantsHelper` wraps invariant evaluation in `try { ... } catch (std::exception const&) { return failInvariantCheck(result); }`.

Converting to `(result, error)` would diverge from rippled rather than converge. Not pursued in this PR.

## Test plan

- [x] `just vet`
- [x] `just build`
- [x] `just test-pkg ./shamap/...` (incl. 4 new tests: empty / put+delete / cached-when-immutable / snapshot-inherits-cache)
- [x] `just test-pkg ./internal/ledger/... ./internal/txq/...`

Closes the last open follow-up from issue #431.