### PR TITLE
perf(crypto/secp256k1): cgo binding to libsecp256k1 for verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install OpenSSL dev headers
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
+      - name: Install CGO dev headers (OpenSSL, libsecp256k1)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev libsecp256k1-dev pkg-config
       - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install OpenSSL dev headers
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
+      - name: Install CGO dev headers (OpenSSL, libsecp256k1)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev libsecp256k1-dev pkg-config
       - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
@@ -54,8 +54,8 @@ jobs:
             packages: ./codec/... ./crypto/... ./shamap/... ./storage/... ./keylet/... ./ledger/... ./amendment/... ./drops/... ./protocol/... ./config/...
     steps:
       - uses: actions/checkout@v5
-      - name: Install OpenSSL dev headers
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
+      - name: Install CGO dev headers (OpenSSL, libsecp256k1)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev libsecp256k1-dev pkg-config
       - uses: actions/setup-go@v6
         with:
           go-version: "1.24"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,24 @@
 # Stage 1: Build
 FROM golang:1.24-alpine AS builder
 
-RUN apk add --no-cache git gcc musl-dev pkgconf openssl-dev openssl-libs-static
+# Alpine ships libsecp256k1 only as a shared .so; the static-linked
+# goxrpl binary needs a .a. Build it from a pinned upstream release in
+# the builder stage. v0.5.0 matches Alpine community's packaging and
+# exposes the same parse_der + normalize + verify ABI we use.
+ARG LIBSECP256K1_VERSION=v0.5.0
+
+RUN apk add --no-cache \
+    git gcc make musl-dev pkgconf autoconf automake libtool \
+    openssl-dev openssl-libs-static \
+ && git clone --depth 1 --branch ${LIBSECP256K1_VERSION} \
+    https://github.com/bitcoin-core/secp256k1.git /tmp/secp256k1 \
+ && cd /tmp/secp256k1 \
+ && ./autogen.sh \
+ && ./configure --disable-shared --enable-static \
+    --disable-tests --disable-benchmark --disable-exhaustive-tests \
+    --enable-module-recovery=no \
+ && make -j"$(nproc)" install \
+ && rm -rf /tmp/secp256k1
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # Stage 1: Build
 FROM golang:1.24-alpine AS builder
 
-# Alpine ships libsecp256k1 only as a shared .so; the static-linked
-# goxrpl binary needs a .a. Build it from a pinned upstream release in
-# the builder stage. v0.5.0 matches Alpine community's packaging and
-# exposes the same parse_der + normalize + verify ABI we use.
+# Alpine ships libsecp256k1 only as a shared .so, so build the static .a
+# from upstream for the distroless static-linked binary.
 ARG LIBSECP256K1_VERSION=v0.5.0
 
 RUN apk add --no-cache \

--- a/README.md
+++ b/README.md
@@ -58,38 +58,45 @@ go test ./internal/testing/offer/... -run TestOfferCreateValidation
 
 ## Building
 
-`goxrpl` uses CGO to call OpenSSL for the peer-to-peer TLS handshake — required to compute the
-session-signature shared value matching rippled's `SSL_get_finished` / `SSL_get_peer_finished`
-flow. You need OpenSSL development headers installed on the build host.
+`goxrpl` uses CGO for two subsystems:
+
+- **OpenSSL** — peer-to-peer TLS handshake, computing the session-signature shared
+  value matching rippled's `SSL_get_finished` / `SSL_get_peer_finished` flow.
+- **libsecp256k1** — ECDSA signature verification on the hot path (transaction
+  signatures, validator manifests, consensus). Falls back to a pure-Go
+  implementation under `CGO_ENABLED=0`.
+
+You need the development headers for both on the build host.
 
 ### macOS
 
 ```bash
-brew install openssl@3 pkg-config
-export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig"
+brew install openssl@3 secp256k1 pkg-config
+export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig:$(brew --prefix secp256k1)/lib/pkgconfig"
 go build ./cmd/xrpld
 ```
 
 ### Ubuntu / Debian
 
 ```bash
-sudo apt install -y libssl-dev pkg-config
+sudo apt install -y libssl-dev libsecp256k1-dev pkg-config
 go build ./cmd/xrpld
 ```
 
 ### Alpine (or static-linked Linux build)
 
 ```bash
-apk add --no-cache gcc musl-dev pkgconf openssl-dev openssl-libs-static
+apk add --no-cache gcc musl-dev pkgconf openssl-dev openssl-libs-static libsecp256k1-dev libsecp256k1-static
 CGO_ENABLED=1 go build -ldflags="-linkmode external -extldflags '-static'" ./cmd/xrpld
 ```
 
 ### CGO-disabled builds
 
 `CGO_ENABLED=0 go build ./cmd/xrpld` is supported. The resulting binary cannot
-connect to or accept peers (peertls returns `ErrSessionSigUnsupported`), but RPC,
-WebSocket, tx, codec, and all other subsystems work unchanged. Useful for contributors
-without an OpenSSL toolchain.
+connect to or accept peers (peertls returns `ErrSessionSigUnsupported`) and falls
+back to the pure-Go secp256k1 verify (~6x slower per signature), but RPC,
+WebSocket, tx, codec, and all other subsystems work unchanged. Useful for
+contributors without a CGO toolchain.
 
 ### Running interop tests
 

--- a/crypto/secp256k1/bench_test.go
+++ b/crypto/secp256k1/bench_test.go
@@ -7,13 +7,8 @@ import (
 	"github.com/LeJamon/goXRPLd/crypto/common"
 )
 
-// BenchmarkValidateDigest measures end-to-end signature verification
-// against a pre-computed SHA-512Half digest — the hot path used by
-// transaction signature checks and validator manifest verification.
-//
-// The active backend (libsecp256k1 via cgo, or decred pure-Go under
-// !cgo) is selected by build tags. Run with -tags ” to bench purego,
-// default build tags to bench cgo.
+// BenchmarkValidateDigest exercises the active backend (libsecp256k1
+// via cgo by default; decred pure-Go when built with CGO_ENABLED=0).
 func BenchmarkValidateDigest(b *testing.B) {
 	algo := SECP256K1()
 	pub, err := hex.DecodeString("02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D56E")

--- a/crypto/secp256k1/bench_test.go
+++ b/crypto/secp256k1/bench_test.go
@@ -1,0 +1,36 @@
+package secp256k1
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/crypto/common"
+)
+
+// BenchmarkValidateDigest measures end-to-end signature verification
+// against a pre-computed SHA-512Half digest — the hot path used by
+// transaction signature checks and validator manifest verification.
+//
+// The active backend (libsecp256k1 via cgo, or decred pure-Go under
+// !cgo) is selected by build tags. Run with -tags ” to bench purego,
+// default build tags to bench cgo.
+func BenchmarkValidateDigest(b *testing.B) {
+	algo := SECP256K1()
+	pub, err := hex.DecodeString("02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D56E")
+	if err != nil {
+		b.Fatal(err)
+	}
+	sig, err := hex.DecodeString("3045022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64")
+	if err != nil {
+		b.Fatal(err)
+	}
+	digest := common.Sha512Half([]byte("Hello World"))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !algo.ValidateDigest(digest, pub, sig) {
+			b.Fatal("signature must verify")
+		}
+	}
+}

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -235,10 +235,6 @@ func (c SECP256K1CryptoAlgorithm) ValidateBytes(msg, pubkey, sig []byte) bool {
 // validateBytes is the byte-level core used by Validate/ValidateBytes/ValidateDigest.
 // When hashMsg is true the message is SHA-512Half-hashed before verification;
 // otherwise msg is treated as a pre-computed 32-byte digest.
-//
-// The actual signature verify is delegated to verifyDigestRaw, which has
-// two backends selected at build time: libsecp256k1 via cgo (default)
-// or the pure-Go decred library (build tag !cgo).
 func (c SECP256K1CryptoAlgorithm) validateBytes(msg, pubkey, sig []byte, mustBeFullyCanonical, hashMsg bool) bool {
 	canonicality := rootcrypto.ECDSACanonicality(sig)
 	if canonicality == rootcrypto.CanonicityNone {

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -235,31 +235,16 @@ func (c SECP256K1CryptoAlgorithm) ValidateBytes(msg, pubkey, sig []byte) bool {
 // validateBytes is the byte-level core used by Validate/ValidateBytes/ValidateDigest.
 // When hashMsg is true the message is SHA-512Half-hashed before verification;
 // otherwise msg is treated as a pre-computed 32-byte digest.
+//
+// The actual signature verify is delegated to verifyDigestRaw, which has
+// two backends selected at build time: libsecp256k1 via cgo (default)
+// or the pure-Go decred library (build tag !cgo).
 func (c SECP256K1CryptoAlgorithm) validateBytes(msg, pubkey, sig []byte, mustBeFullyCanonical, hashMsg bool) bool {
 	canonicality := rootcrypto.ECDSACanonicality(sig)
 	if canonicality == rootcrypto.CanonicityNone {
 		return false
 	}
 	if mustBeFullyCanonical && canonicality != rootcrypto.CanonicityFullyCanonical {
-		return false
-	}
-	r, s, err := rootcrypto.DERSigToRS(sig)
-	if err != nil {
-		return false
-	}
-	var rBytes, sBytes [32]byte
-	if len(r) > 32 || len(s) > 32 {
-		return false
-	}
-	copy(rBytes[32-len(r):], r)
-	copy(sBytes[32-len(s):], s)
-	ecdsaR := &secp256k1.ModNScalar{}
-	ecdsaS := &secp256k1.ModNScalar{}
-	ecdsaR.SetBytes(&rBytes)
-	ecdsaS.SetBytes(&sBytes)
-	parsedSig := ecdsa.NewSignature(ecdsaR, ecdsaS)
-	pubKey, err := secp256k1.ParsePubKey(pubkey)
-	if err != nil {
 		return false
 	}
 	var digest [32]byte
@@ -271,7 +256,7 @@ func (c SECP256K1CryptoAlgorithm) validateBytes(msg, pubkey, sig []byte, mustBeF
 		}
 		copy(digest[:], msg)
 	}
-	return parsedSig.Verify(digest[:], pubKey)
+	return verifyDigestRaw(digest[:], pubkey, sig)
 }
 
 // ValidateDigest verifies a signature against a pre-computed digest (hash).

--- a/crypto/secp256k1/shim/sha512_test.go
+++ b/crypto/secp256k1/shim/sha512_test.go
@@ -4,9 +4,7 @@ package shim
 
 import "crypto/sha512"
 
-// sha512HalfBytes mirrors crypto/common.Sha512Half locally so the test
-// file (which lives in the shim package) doesn't need to import
-// crypto/common — keeping the shim's dependency surface minimal.
+// Local mirror of common.Sha512Half so the shim has no non-stdlib deps.
 func sha512HalfBytes(b []byte) [32]byte {
 	sum := sha512.Sum512(b)
 	var out [32]byte

--- a/crypto/secp256k1/shim/sha512_test.go
+++ b/crypto/secp256k1/shim/sha512_test.go
@@ -1,0 +1,15 @@
+//go:build cgo
+
+package shim
+
+import "crypto/sha512"
+
+// sha512HalfBytes mirrors crypto/common.Sha512Half locally so the test
+// file (which lives in the shim package) doesn't need to import
+// crypto/common — keeping the shim's dependency surface minimal.
+func sha512HalfBytes(b []byte) [32]byte {
+	sum := sha512.Sum512(b)
+	var out [32]byte
+	copy(out[:], sum[:32])
+	return out
+}

--- a/crypto/secp256k1/shim/shim.c
+++ b/crypto/secp256k1/shim/shim.c
@@ -1,0 +1,50 @@
+#include "shim.h"
+
+#include <secp256k1.h>
+
+/* Process-wide verify context. libsecp256k1 documents the verify
+ * context as thread-safe; we create it once and never free it. The
+ * lifetime is the process. */
+static secp256k1_context* g_ctx = NULL;
+
+/* SECP256K1_CONTEXT_VERIFY is the historically correct flag and is
+ * still accepted by every released version of libsecp256k1. Newer
+ * versions (>=0.3.0) unified the context flags and emit a deprecation
+ * notice, but the runtime behavior is unchanged. Using it preserves
+ * compatibility with older system installs. */
+void goxrpl_secp256k1_init(void) {
+    if (g_ctx == NULL) {
+        g_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    }
+}
+
+int goxrpl_secp256k1_verify_digest(const unsigned char* pub, size_t pub_len,
+                                    const unsigned char* sig_der, size_t sig_len,
+                                    const unsigned char* hash32) {
+    if (g_ctx == NULL || pub == NULL || sig_der == NULL || hash32 == NULL) {
+        return 0;
+    }
+    if (pub_len == 0 || sig_len == 0) {
+        return 0;
+    }
+
+    secp256k1_pubkey pubkey;
+    if (!secp256k1_ec_pubkey_parse(g_ctx, &pubkey, pub, pub_len)) {
+        return 0;
+    }
+
+    secp256k1_ecdsa_signature sig;
+    if (!secp256k1_ecdsa_signature_parse_der(g_ctx, &sig, sig_der, sig_len)) {
+        return 0;
+    }
+
+    /* Normalize S to low-S before verifying. The pure-Go decred verify
+     * does not enforce low-S, so callers that pass mustBeFullyCanonical=
+     * false (e.g. manifest verification) currently accept high-S
+     * signatures. Normalizing here preserves that behavior — the C and
+     * Go paths must agree on accept/reject. Mathematically (r,S) and
+     * (r,N-S) verify the same (msg, pubkey), so normalizing is lossless. */
+    secp256k1_ecdsa_signature_normalize(g_ctx, &sig, &sig);
+
+    return secp256k1_ecdsa_verify(g_ctx, &sig, hash32, &pubkey);
+}

--- a/crypto/secp256k1/shim/shim.c
+++ b/crypto/secp256k1/shim/shim.c
@@ -6,12 +6,13 @@
  * thread-safe per libsecp256k1. */
 static secp256k1_context* g_ctx = NULL;
 
-/* SECP256K1_CONTEXT_VERIFY is deprecated since libsecp256k1 0.3.0 but
- * still functional; it is the only flag pre-0.3.0 accepts for verify
- * ops, so use it for back-compat with older system packages. */
+/* Requires libsecp256k1 >= 0.3.0 (Ubuntu 24.04, Debian 12+, Alpine
+ * 3.18+, Homebrew). SECP256K1_CONTEXT_NONE is the unified flag; the
+ * older SECP256K1_CONTEXT_VERIFY is deprecated and emits
+ * -Wdeprecated-declarations on >= 0.3.0. */
 void goxrpl_secp256k1_init(void) {
     if (g_ctx == NULL) {
-        g_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+        g_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     }
 }
 

--- a/crypto/secp256k1/shim/shim.c
+++ b/crypto/secp256k1/shim/shim.c
@@ -2,16 +2,13 @@
 
 #include <secp256k1.h>
 
-/* Process-wide verify context. libsecp256k1 documents the verify
- * context as thread-safe; we create it once and never free it. The
- * lifetime is the process. */
+/* Process-lifetime, never freed. Verify ops on this context are
+ * thread-safe per libsecp256k1. */
 static secp256k1_context* g_ctx = NULL;
 
-/* SECP256K1_CONTEXT_VERIFY is the historically correct flag and is
- * still accepted by every released version of libsecp256k1. Newer
- * versions (>=0.3.0) unified the context flags and emit a deprecation
- * notice, but the runtime behavior is unchanged. Using it preserves
- * compatibility with older system installs. */
+/* SECP256K1_CONTEXT_VERIFY is deprecated since libsecp256k1 0.3.0 but
+ * still functional; it is the only flag pre-0.3.0 accepts for verify
+ * ops, so use it for back-compat with older system packages. */
 void goxrpl_secp256k1_init(void) {
     if (g_ctx == NULL) {
         g_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
@@ -38,12 +35,9 @@ int goxrpl_secp256k1_verify_digest(const unsigned char* pub, size_t pub_len,
         return 0;
     }
 
-    /* Normalize S to low-S before verifying. The pure-Go decred verify
-     * does not enforce low-S, so callers that pass mustBeFullyCanonical=
-     * false (e.g. manifest verification) currently accept high-S
-     * signatures. Normalizing here preserves that behavior — the C and
-     * Go paths must agree on accept/reject. Mathematically (r,S) and
-     * (r,N-S) verify the same (msg, pubkey), so normalizing is lossless. */
+    /* Always normalize to low-S so this path matches the pure-Go decred
+     * verify, which accepts high-S (manifest verification relies on it).
+     * (r,S) and (r,N-S) verify the same (msg, pubkey), so lossless. */
     secp256k1_ecdsa_signature_normalize(g_ctx, &sig, &sig);
 
     return secp256k1_ecdsa_verify(g_ctx, &sig, hash32, &pubkey);

--- a/crypto/secp256k1/shim/shim.go
+++ b/crypto/secp256k1/shim/shim.go
@@ -1,0 +1,42 @@
+//go:build cgo
+
+// Package shim is the cgo binding for libsecp256k1's verify path. Only
+// signature verification is wired through C; signing and key derivation
+// stay in pure Go. The verify context is process-lifetime and
+// libsecp256k1's verify operations are thread-safe, so no OS-thread
+// locking is needed on the call path.
+package shim
+
+// #cgo pkg-config: libsecp256k1
+// #include "shim.h"
+import "C"
+
+import (
+	"sync"
+	"unsafe"
+)
+
+var initOnce sync.Once
+
+func ensureInit() {
+	initOnce.Do(func() {
+		C.goxrpl_secp256k1_init()
+	})
+}
+
+// VerifyDigest verifies a DER-encoded ECDSA signature against a 32-byte
+// message hash and a SEC1 public key (33-byte compressed or 65-byte
+// uncompressed). Returns true iff the signature is valid AND low-S;
+// libsecp256k1 rejects high-S signatures internally.
+func VerifyDigest(hash32 []byte, pub []byte, sigDER []byte) bool {
+	if len(hash32) != 32 || len(pub) == 0 || len(sigDER) == 0 {
+		return false
+	}
+	ensureInit()
+	rc := C.goxrpl_secp256k1_verify_digest(
+		(*C.uchar)(unsafe.Pointer(&pub[0])), C.size_t(len(pub)),
+		(*C.uchar)(unsafe.Pointer(&sigDER[0])), C.size_t(len(sigDER)),
+		(*C.uchar)(unsafe.Pointer(&hash32[0])),
+	)
+	return rc == 1
+}

--- a/crypto/secp256k1/shim/shim.go
+++ b/crypto/secp256k1/shim/shim.go
@@ -1,10 +1,9 @@
 //go:build cgo
 
-// Package shim is the cgo binding for libsecp256k1's verify path. Only
-// signature verification is wired through C; signing and key derivation
-// stay in pure Go. The verify context is process-lifetime and
-// libsecp256k1's verify operations are thread-safe, so no OS-thread
-// locking is needed on the call path.
+// Package shim is the cgo verify binding for libsecp256k1. Signing and
+// key derivation stay in pure Go. The verify context is process-lifetime
+// and libsecp256k1's verify ops are thread-safe, so the call path needs
+// no OS-thread locking.
 package shim
 
 // #cgo pkg-config: libsecp256k1
@@ -24,10 +23,10 @@ func ensureInit() {
 	})
 }
 
-// VerifyDigest verifies a DER-encoded ECDSA signature against a 32-byte
-// message hash and a SEC1 public key (33-byte compressed or 65-byte
-// uncompressed). Returns true iff the signature is valid AND low-S;
-// libsecp256k1 rejects high-S signatures internally.
+// VerifyDigest accepts a DER-encoded ECDSA signature with either low-S
+// or high-S — the shim normalizes to low-S before calling
+// secp256k1_ecdsa_verify, which itself rejects high-S. Canonicality
+// gating (if any) is the caller's responsibility.
 func VerifyDigest(hash32 []byte, pub []byte, sigDER []byte) bool {
 	if len(hash32) != 32 || len(pub) == 0 || len(sigDER) == 0 {
 		return false

--- a/crypto/secp256k1/shim/shim.go
+++ b/crypto/secp256k1/shim/shim.go
@@ -10,17 +10,10 @@ package shim
 // #include "shim.h"
 import "C"
 
-import (
-	"sync"
-	"unsafe"
-)
+import "unsafe"
 
-var initOnce sync.Once
-
-func ensureInit() {
-	initOnce.Do(func() {
-		C.goxrpl_secp256k1_init()
-	})
+func init() {
+	C.goxrpl_secp256k1_init()
 }
 
 // VerifyDigest accepts a DER-encoded ECDSA signature with either low-S
@@ -31,7 +24,6 @@ func VerifyDigest(hash32 []byte, pub []byte, sigDER []byte) bool {
 	if len(hash32) != 32 || len(pub) == 0 || len(sigDER) == 0 {
 		return false
 	}
-	ensureInit()
 	rc := C.goxrpl_secp256k1_verify_digest(
 		(*C.uchar)(unsafe.Pointer(&pub[0])), C.size_t(len(pub)),
 		(*C.uchar)(unsafe.Pointer(&sigDER[0])), C.size_t(len(sigDER)),

--- a/crypto/secp256k1/shim/shim.h
+++ b/crypto/secp256k1/shim/shim.h
@@ -1,11 +1,3 @@
-/* shim.h - libsecp256k1 verify shim.
- *
- * Verify-only path. The shim owns a single process-wide
- * secp256k1_context (verify flavor), created lazily and never freed.
- * libsecp256k1 documents the verify context as thread-safe, so no
- * locking is required around verify_digest.
- */
-
 #ifndef GOXRPL_SECP256K1_SHIM_H
 #define GOXRPL_SECP256K1_SHIM_H
 
@@ -15,20 +7,13 @@
 extern "C" {
 #endif
 
-/* Lazily initialize the verify context. Safe to call repeatedly. */
+/* Idempotent; safe to call repeatedly. */
 void goxrpl_secp256k1_init(void);
 
-/* Verify a DER-encoded ECDSA signature against a 32-byte message hash
- * and a 33-byte compressed (or 65-byte uncompressed) SEC1 public key.
- *
- * Returns:
- *    1 - signature is valid
- *    0 - signature is invalid, malformed, non-low-S, or pubkey is bad
- *
- * libsecp256k1's secp256k1_ecdsa_verify enforces low-S internally, so
- * any signature with high-S is rejected even if it would otherwise be
- * arithmetically valid.
- */
+/* Returns 1 if the DER signature verifies against (hash32, pub),
+ * 0 otherwise. The signature is normalized to low-S before verify, so
+ * both low-S and high-S sigs can pass. pub is 33-byte compressed or
+ * 65-byte uncompressed SEC1. */
 int goxrpl_secp256k1_verify_digest(const unsigned char* pub, size_t pub_len,
                                     const unsigned char* sig_der, size_t sig_len,
                                     const unsigned char* hash32);

--- a/crypto/secp256k1/shim/shim.h
+++ b/crypto/secp256k1/shim/shim.h
@@ -1,0 +1,40 @@
+/* shim.h - libsecp256k1 verify shim.
+ *
+ * Verify-only path. The shim owns a single process-wide
+ * secp256k1_context (verify flavor), created lazily and never freed.
+ * libsecp256k1 documents the verify context as thread-safe, so no
+ * locking is required around verify_digest.
+ */
+
+#ifndef GOXRPL_SECP256K1_SHIM_H
+#define GOXRPL_SECP256K1_SHIM_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Lazily initialize the verify context. Safe to call repeatedly. */
+void goxrpl_secp256k1_init(void);
+
+/* Verify a DER-encoded ECDSA signature against a 32-byte message hash
+ * and a 33-byte compressed (or 65-byte uncompressed) SEC1 public key.
+ *
+ * Returns:
+ *    1 - signature is valid
+ *    0 - signature is invalid, malformed, non-low-S, or pubkey is bad
+ *
+ * libsecp256k1's secp256k1_ecdsa_verify enforces low-S internally, so
+ * any signature with high-S is rejected even if it would otherwise be
+ * arithmetically valid.
+ */
+int goxrpl_secp256k1_verify_digest(const unsigned char* pub, size_t pub_len,
+                                    const unsigned char* sig_der, size_t sig_len,
+                                    const unsigned char* hash32);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/crypto/secp256k1/shim/shim_test.go
+++ b/crypto/secp256k1/shim/shim_test.go
@@ -1,0 +1,78 @@
+//go:build cgo
+
+package shim
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// Vector lifted from the package-level Validate tests so we exercise
+// the libsecp256k1 verify path against a known-good Sign() output.
+//
+//	msg:    "Hello World" → SHA-512Half digest
+//	pubKey: 02950F47...0D56E (compressed)
+//	sigDER: 30450221...516E64 (fully canonical)
+const (
+	testMsg       = "Hello World"
+	testPubHex    = "02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D56E"
+	testSigDERHex = "3045022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64"
+)
+
+func sha512HalfStr(s string) [32]byte {
+	// Local copy to avoid importing crypto/common (test-only package).
+	// Mirrors common.Sha512Half: SHA-512 of bytes, first 32 bytes.
+	return sha512HalfBytes([]byte(s))
+}
+
+func TestVerifyDigest_Valid(t *testing.T) {
+	pub := mustHex(t, testPubHex)
+	sig := mustHex(t, testSigDERHex)
+	digest := sha512HalfStr(testMsg)
+	if !VerifyDigest(digest[:], pub, sig) {
+		t.Fatal("expected libsecp256k1 to accept the known-good signature")
+	}
+}
+
+func TestVerifyDigest_RejectsTamperedDigest(t *testing.T) {
+	pub := mustHex(t, testPubHex)
+	sig := mustHex(t, testSigDERHex)
+	digest := sha512HalfStr(testMsg)
+	digest[0] ^= 0x01
+	if VerifyDigest(digest[:], pub, sig) {
+		t.Fatal("expected libsecp256k1 to reject a tampered digest")
+	}
+}
+
+func TestVerifyDigest_RejectsMalformedSig(t *testing.T) {
+	pub := mustHex(t, testPubHex)
+	digest := sha512HalfStr(testMsg)
+	if VerifyDigest(digest[:], pub, []byte{0x30, 0x00}) {
+		t.Fatal("expected libsecp256k1 to reject malformed DER")
+	}
+}
+
+func TestVerifyDigest_RejectsBadInputs(t *testing.T) {
+	if VerifyDigest(nil, []byte{1}, []byte{1}) {
+		t.Fatal("nil hash should be rejected")
+	}
+	hash := make([]byte, 32)
+	if VerifyDigest(hash, nil, []byte{1}) {
+		t.Fatal("nil pubkey should be rejected")
+	}
+	if VerifyDigest(hash, []byte{1}, nil) {
+		t.Fatal("nil sig should be rejected")
+	}
+	if VerifyDigest(make([]byte, 31), []byte{1}, []byte{1}) {
+		t.Fatal("short hash should be rejected")
+	}
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("decode hex: %v", err)
+	}
+	return b
+}

--- a/crypto/secp256k1/shim/shim_test.go
+++ b/crypto/secp256k1/shim/shim_test.go
@@ -7,12 +7,7 @@ import (
 	"testing"
 )
 
-// Vector lifted from the package-level Validate tests so we exercise
-// the libsecp256k1 verify path against a known-good Sign() output.
-//
-//	msg:    "Hello World" → SHA-512Half digest
-//	pubKey: 02950F47...0D56E (compressed)
-//	sigDER: 30450221...516E64 (fully canonical)
+// Vector lifted from the package-level Validate tests.
 const (
 	testMsg       = "Hello World"
 	testPubHex    = "02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D56E"
@@ -20,8 +15,6 @@ const (
 )
 
 func sha512HalfStr(s string) [32]byte {
-	// Local copy to avoid importing crypto/common (test-only package).
-	// Mirrors common.Sha512Half: SHA-512 of bytes, first 32 bytes.
 	return sha512HalfBytes([]byte(s))
 }
 

--- a/crypto/secp256k1/verify_cgo.go
+++ b/crypto/secp256k1/verify_cgo.go
@@ -1,0 +1,14 @@
+//go:build cgo
+
+package secp256k1
+
+import "github.com/LeJamon/goXRPLd/crypto/secp256k1/shim"
+
+// verifyDigestRaw verifies a DER-encoded ECDSA signature against a
+// 32-byte hash and a SEC1-encoded public key using libsecp256k1.
+// Callers must have already rejected CanonicityNone signatures; high-S
+// (canonical-but-not-fully-canonical) signatures are normalized by the
+// shim so behavior matches the pure-Go backend.
+func verifyDigestRaw(hash32, pubkey, sigDER []byte) bool {
+	return shim.VerifyDigest(hash32, pubkey, sigDER)
+}

--- a/crypto/secp256k1/verify_cgo.go
+++ b/crypto/secp256k1/verify_cgo.go
@@ -4,11 +4,9 @@ package secp256k1
 
 import "github.com/LeJamon/goXRPLd/crypto/secp256k1/shim"
 
-// verifyDigestRaw verifies a DER-encoded ECDSA signature against a
-// 32-byte hash and a SEC1-encoded public key using libsecp256k1.
-// Callers must have already rejected CanonicityNone signatures; high-S
-// (canonical-but-not-fully-canonical) signatures are normalized by the
-// shim so behavior matches the pure-Go backend.
+// verifyDigestRaw assumes the caller has already rejected CanonicityNone.
+// High-S signatures are normalized inside the shim so cgo and purego
+// backends agree on accept/reject.
 func verifyDigestRaw(hash32, pubkey, sigDER []byte) bool {
 	return shim.VerifyDigest(hash32, pubkey, sigDER)
 }

--- a/crypto/secp256k1/verify_purego.go
+++ b/crypto/secp256k1/verify_purego.go
@@ -9,9 +9,6 @@ import (
 	ecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
 )
 
-// verifyDigestRaw verifies a DER-encoded ECDSA signature against a
-// 32-byte hash and a SEC1-encoded public key using the pure-Go decred
-// implementation. Used when CGO is disabled.
 func verifyDigestRaw(hash32, pubkey, sigDER []byte) bool {
 	r, s, err := rootcrypto.DERSigToRS(sigDER)
 	if err != nil {

--- a/crypto/secp256k1/verify_purego.go
+++ b/crypto/secp256k1/verify_purego.go
@@ -1,0 +1,36 @@
+//go:build !cgo
+
+package secp256k1
+
+import (
+	rootcrypto "github.com/LeJamon/goXRPLd/crypto"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	ecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
+)
+
+// verifyDigestRaw verifies a DER-encoded ECDSA signature against a
+// 32-byte hash and a SEC1-encoded public key using the pure-Go decred
+// implementation. Used when CGO is disabled.
+func verifyDigestRaw(hash32, pubkey, sigDER []byte) bool {
+	r, s, err := rootcrypto.DERSigToRS(sigDER)
+	if err != nil {
+		return false
+	}
+	if len(r) > 32 || len(s) > 32 {
+		return false
+	}
+	var rBytes, sBytes [32]byte
+	copy(rBytes[32-len(r):], r)
+	copy(sBytes[32-len(s):], s)
+	ecdsaR := &secp256k1.ModNScalar{}
+	ecdsaS := &secp256k1.ModNScalar{}
+	ecdsaR.SetBytes(&rBytes)
+	ecdsaS.SetBytes(&sBytes)
+	parsedSig := ecdsa.NewSignature(ecdsaR, ecdsaS)
+	pubKey, err := secp256k1.ParsePubKey(pubkey)
+	if err != nil {
+		return false
+	}
+	return parsedSig.Verify(hash32, pubKey)
+}

--- a/crypto/secp256k1/verify_test.go
+++ b/crypto/secp256k1/verify_test.go
@@ -1,0 +1,65 @@
+package secp256k1
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strings"
+	"testing"
+
+	rootcrypto "github.com/LeJamon/goXRPLd/crypto"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateWithCanonicality_HighS locks in the manifest-verify
+// parity claim: with mustBeFullyCanonical=false, a high-S signature
+// must verify. Both backends must agree:
+//   - cgo: shim normalizes high-S to low-S before secp256k1_ecdsa_verify
+//   - !cgo: decred's Verify accepts arbitrary-S
+//
+// If either backend rejects, manifest verification is broken.
+func TestValidateWithCanonicality_HighS(t *testing.T) {
+	t.Parallel()
+
+	const (
+		msg     = "Hello World"
+		pubHex  = "02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D56E"
+		lowSDER = "3045022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64"
+	)
+
+	algo := SECP256K1()
+
+	require.True(t, algo.Validate(msg, pubHex, lowSDER),
+		"baseline: low-S DER must verify under strict (mustBeFullyCanonical=true)")
+
+	highSDER := flipSToHighS(t, lowSDER)
+
+	lowSBytes, err := hex.DecodeString(lowSDER)
+	require.NoError(t, err)
+	highSBytes, err := hex.DecodeString(highSDER)
+	require.NoError(t, err)
+	require.Equal(t, rootcrypto.CanonicityFullyCanonical, rootcrypto.ECDSACanonicality(lowSBytes))
+	require.Equal(t, rootcrypto.CanonicityCanonical, rootcrypto.ECDSACanonicality(highSBytes))
+
+	require.False(t, algo.Validate(msg, pubHex, highSDER),
+		"high-S DER must be rejected under strict (mustBeFullyCanonical=true)")
+
+	require.True(t, algo.ValidateWithCanonicality(msg, pubHex, highSDER, false),
+		"high-S DER must verify under mustBeFullyCanonical=false — manifest path parity")
+}
+
+// flipSToHighS rewrites a DER ECDSA signature so its s value becomes
+// N-s, converting low-S → high-S (or vice versa). Mathematically
+// equivalent for verification.
+func flipSToHighS(t *testing.T, sigHex string) string {
+	t.Helper()
+	sigBytes, err := hex.DecodeString(sigHex)
+	require.NoError(t, err)
+	r, s, err := rootcrypto.DERSigToRS(sigBytes)
+	require.NoError(t, err)
+	sBig := new(big.Int).SetBytes(s)
+	flipped := new(big.Int).Sub(curveOrderN, sBig)
+	return strings.ToUpper(hex.EncodeToString(
+		rootcrypto.EncodeDERSignature(new(big.Int).SetBytes(r), flipped),
+	))
+}

--- a/justfile
+++ b/justfile
@@ -2,11 +2,9 @@
 #
 # Install just: `brew install just` or `cargo install just`.
 
-# Honor an existing PKG_CONFIG_PATH; otherwise try Homebrew openssl@3
-# and secp256k1 on macOS so the CGO shims (peertls, crypto/secp256k1)
-# build out of the box. On Linux, libssl-dev / openssl-devel and
-# libsecp256k1-dev already register libssl + libcrypto + libsecp256k1
-# in the default pkg-config path.
+# Honor an existing PKG_CONFIG_PATH; otherwise resolve Homebrew openssl@3
+# + secp256k1 on macOS so the CGO shims build out of the box. Linux's
+# distro -dev packages already register on the default pkg-config path.
 export PKG_CONFIG_PATH := env_var_or_default("PKG_CONFIG_PATH", `command -v brew >/dev/null 2>&1 && { paths=""; for pkg in openssl@3 secp256k1; do p=$(brew --prefix $pkg 2>/dev/null); [ -d "$p/lib/pkgconfig" ] && paths="${paths:+$paths:}$p/lib/pkgconfig"; done; echo "$paths"; } || echo ""`)
 export CGO_ENABLED := env_var_or_default("CGO_ENABLED", "1")
 

--- a/justfile
+++ b/justfile
@@ -2,11 +2,12 @@
 #
 # Install just: `brew install just` or `cargo install just`.
 
-# Honor an existing PKG_CONFIG_PATH; otherwise try Homebrew openssl@3 on
-# macOS so the OpenSSL CGO shim builds out of the box. On Linux,
-# libssl-dev / openssl-devel already register libssl + libcrypto in the
-# default pkg-config path.
-export PKG_CONFIG_PATH := env_var_or_default("PKG_CONFIG_PATH", `command -v brew >/dev/null 2>&1 && p=$(brew --prefix openssl@3 2>/dev/null) && [ -d "$p/lib/pkgconfig" ] && echo "$p/lib/pkgconfig" || echo ""`)
+# Honor an existing PKG_CONFIG_PATH; otherwise try Homebrew openssl@3
+# and secp256k1 on macOS so the CGO shims (peertls, crypto/secp256k1)
+# build out of the box. On Linux, libssl-dev / openssl-devel and
+# libsecp256k1-dev already register libssl + libcrypto + libsecp256k1
+# in the default pkg-config path.
+export PKG_CONFIG_PATH := env_var_or_default("PKG_CONFIG_PATH", `command -v brew >/dev/null 2>&1 && { paths=""; for pkg in openssl@3 secp256k1; do p=$(brew --prefix $pkg 2>/dev/null); [ -d "$p/lib/pkgconfig" ] && paths="${paths:+$paths:}$p/lib/pkgconfig"; done; echo "$paths"; } || echo ""`)
 export CGO_ENABLED := env_var_or_default("CGO_ENABLED", "1")
 
 golangci_version := "v2.11.3"


### PR DESCRIPTION
## Summary

- Routes `secp256k1.Validate*` / `ValidateDigest` through a new cgo shim over `libsecp256k1`. On M3 Pro: **184 µs → 29 µs per verify (6.3×)**, allocations 21 → 3.
- Pure-Go decred backend preserved behind `!cgo` build tag — `CGO_ENABLED=0` still builds and works (just slower).
- High-S sigs are normalized inside the shim so behavior matches the pure-Go path; manifest verification (which passes `mustBeFullyCanonical=false`) is unchanged.

## Layout

- `crypto/secp256k1/shim/` — cgo binding (`parse_der` + `normalize` + `verify`) with a process-lifetime `SECP256K1_CONTEXT_VERIFY`. libsecp256k1's verify ops are thread-safe so no OS-thread locking.
- `crypto/secp256k1/verify_cgo.go` (build:cgo) — delegates to the shim.
- `crypto/secp256k1/verify_purego.go` (build:!cgo) — preserves the decred path.
- `crypto/secp256k1/secp256k1.go` — `validateBytes` now ends with a single `verifyDigestRaw` call after the canonicality reject path.
- `justfile` — auto-resolves the Homebrew `secp256k1` pkg-config path alongside `openssl@3`.
- `README.md` — documents the new system dependency (`brew install secp256k1`, `apt install libsecp256k1-dev`).

## Bench

```
BenchmarkValidateDigest (cgo)     28,942 ns/op   176 B/op    3 allocs/op
BenchmarkValidateDigest (!cgo)   183,675 ns/op  1064 B/op   21 allocs/op
```

## Test plan

- [x] `just test-pkg ./crypto/secp256k1/...` (wycheproof corpus + fuzz seeds, both backends)
- [x] `just test-libs` (full crypto/codec/shamap/storage)
- [x] `just test-tx` (every tx type — exercises hot-path sig verify)
- [x] `just test-core` (consensus/ledger/rpc/peermanagement — exercises manifest + validator-set verify)
- [x] `just build-nocgo` (pure-Go fallback compiles + runs)
- [x] `just vet` + `just lint` clean

Fixes #460