### PR TITLE
fix: peer-management + manifest audit sweep

### DIFF
--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -56,9 +56,21 @@ func (d Disposition) String() string {
 // the inverse ephemeral→master lookup so consensus can translate a
 // validation's signing key back to a UNL master key.
 //
-// Safe for concurrent use.
+// Safe for concurrent use. Two locks split the hot read path from
+// the slow Apply signature-verification path: `mu` guards the maps
+// (RLock for lookups, Lock only for the brief mutation window),
+// `applyMu` serializes ApplyManifest writers so two concurrent
+// Apply calls cannot both pass the Stale gate and race a write —
+// without blocking any RLock-only lookup while the writer runs its
+// ed25519/secp256k1 verify.
 type Cache struct {
 	mu sync.RWMutex
+
+	// applyMu serializes ApplyManifest so signature verification
+	// (the expensive step) does not block GetMasterKey / GetSigningKey
+	// lookups via `mu` — those readers are on the hot path for every
+	// inbound validation.
+	applyMu sync.Mutex
 
 	// byMaster maps master public key → the latest accepted manifest.
 	// Entries persist across revocations: a revoked manifest is kept so
@@ -107,21 +119,37 @@ func (c *Cache) ApplyManifest(m *Manifest) Disposition {
 		return Invalid
 	}
 
+	// applyMu serializes the verify-then-mutate sequence so two
+	// concurrent ApplyManifest calls for the same master cannot both
+	// pass the Stale gate. Readers only ever take c.mu (RLock or
+	// briefly Lock during mutation), so they are not blocked by the
+	// signature verification step.
+	c.applyMu.Lock()
+	defer c.applyMu.Unlock()
+
+	c.mu.RLock()
+	if existing, ok := c.byMaster[m.MasterKey]; ok && m.Sequence <= existing.Sequence {
+		c.mu.RUnlock()
+		return Stale
+	}
+	c.mu.RUnlock()
+
+	// Verify outside any map lock — GetMasterKey / GetSigningKey
+	// lookups proceed unblocked through the (potentially) expensive
+	// secp256k1 verify.
+	if err := m.Verify(); err != nil {
+		return Invalid
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if existing, ok := c.byMaster[m.MasterKey]; ok {
-		if m.Sequence <= existing.Sequence {
-			return Stale
-		}
-	}
-
-	// Signature verification happens under the lock so concurrent
-	// callers can't race in two manifests for the same master at the
-	// same sequence. Cost is bounded: O(manifests-per-second) × O(one
-	// ed25519/secp256k1 verify).
-	if err := m.Verify(); err != nil {
-		return Invalid
+	// Re-check Stale under the write lock in case another writer
+	// raced past while we were verifying. applyMu rules that out for
+	// well-behaved callers, but a future caller that bypasses Apply
+	// (none today) could still insert directly.
+	if existing, ok := c.byMaster[m.MasterKey]; ok && m.Sequence <= existing.Sequence {
+		return Stale
 	}
 
 	// The manifest's master key must not already be recorded as
@@ -157,10 +185,6 @@ func (c *Cache) ApplyManifest(m *Manifest) Disposition {
 		c.signingToMaster[m.SigningKey] = m.MasterKey
 	}
 	if isUpdate {
-		// Match rippled Manifest.cpp:538: bump only when an existing
-		// entry is replaced. The first insert is rare ("should only
-		// ever happen once per validator run" per the rippled comment)
-		// and is handled by the consumer's never-built sentinel.
 		c.seq++
 	}
 	return Accepted

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -56,20 +56,16 @@ func (d Disposition) String() string {
 // the inverse ephemeral→master lookup so consensus can translate a
 // validation's signing key back to a UNL master key.
 //
-// Safe for concurrent use. Two locks split the hot read path from
-// the slow Apply signature-verification path: `mu` guards the maps
-// (RLock for lookups, Lock only for the brief mutation window),
-// `applyMu` serializes ApplyManifest writers so two concurrent
-// Apply calls cannot both pass the Stale gate and race a write —
-// without blocking any RLock-only lookup while the writer runs its
-// ed25519/secp256k1 verify.
+// Safe for concurrent use. Two locks separate the hot read path from
+// the slow Apply signature-verification path: `mu` guards the maps,
+// `applyMu` serializes ApplyManifest writers around the verify step
+// so concurrent Applies cannot both pass the Stale gate and race a
+// write while leaving RLock-only lookups unblocked.
 type Cache struct {
 	mu sync.RWMutex
 
-	// applyMu serializes ApplyManifest so signature verification
-	// (the expensive step) does not block GetMasterKey / GetSigningKey
-	// lookups via `mu` — those readers are on the hot path for every
-	// inbound validation.
+	// applyMu serializes ApplyManifest's verify-then-mutate sequence
+	// without holding c.mu across the secp256k1/ed25519 verify.
 	applyMu sync.Mutex
 
 	// byMaster maps master public key → the latest accepted manifest.
@@ -110,20 +106,13 @@ func NewCache() *Cache {
 // (Invalid / BadMasterKey / BadEphemeralKey). Stale is a no-op.
 //
 // Mirrors ManifestCache::applyManifest at rippled Manifest.cpp:382-580,
-// collapsed to a single write-lock path — the two-phase read/write
-// optimization there exists because signature verification is
-// expensive; in our deployments the expected rate of inbound manifests
-// is too low to matter.
+// including the two-phase shared→unique pattern that keeps lookups
+// unblocked across the expensive signature verify.
 func (c *Cache) ApplyManifest(m *Manifest) Disposition {
 	if m == nil {
 		return Invalid
 	}
 
-	// applyMu serializes the verify-then-mutate sequence so two
-	// concurrent ApplyManifest calls for the same master cannot both
-	// pass the Stale gate. Readers only ever take c.mu (RLock or
-	// briefly Lock during mutation), so they are not blocked by the
-	// signature verification step.
 	c.applyMu.Lock()
 	defer c.applyMu.Unlock()
 
@@ -144,10 +133,8 @@ func (c *Cache) ApplyManifest(m *Manifest) Disposition {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Re-check Stale under the write lock in case another writer
-	// raced past while we were verifying. applyMu rules that out for
-	// well-behaved callers, but a future caller that bypasses Apply
-	// (none today) could still insert directly.
+	// Re-check Stale under the write lock against any direct map
+	// writer that bypassed applyMu.
 	if existing, ok := c.byMaster[m.MasterKey]; ok && m.Sequence <= existing.Sequence {
 		return Stale
 	}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -174,12 +174,6 @@ func Deserialize(data []byte) (*Manifest, error) {
 // manifests) the ephemeral-key signature against the canonical signing
 // preimage: HashPrefix("MAN\0") || STObject(manifest without Signature
 // and MasterSignature). Mirrors Manifest::verify at Manifest.cpp:195-214.
-//
-// The serialized payload is decoded exactly once, then the signature
-// fields are read off the decoded map and the same map is reused to
-// build the signing preimage. Previously this path decoded twice per
-// Verify — once for the preimage and once for the signatures — under
-// the manifest cache write lock at #434.
 func (m *Manifest) Verify() error {
 	decoded, err := binarycodec.Decode(hex.EncodeToString(m.Serialized))
 	if err != nil {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -174,29 +174,36 @@ func Deserialize(data []byte) (*Manifest, error) {
 // manifests) the ephemeral-key signature against the canonical signing
 // preimage: HashPrefix("MAN\0") || STObject(manifest without Signature
 // and MasterSignature). Mirrors Manifest::verify at Manifest.cpp:195-214.
+//
+// The serialized payload is decoded exactly once, then the signature
+// fields are read off the decoded map and the same map is reused to
+// build the signing preimage. Previously this path decoded twice per
+// Verify — once for the preimage and once for the signatures — under
+// the manifest cache write lock at #434.
 func (m *Manifest) Verify() error {
-	preimage, err := signingPreimage(m.Serialized)
-	if err != nil {
-		return fmt.Errorf("manifest: build signing preimage: %w", err)
-	}
-	// Re-decode to extract signature fields — small cost, keeps the
-	// Manifest struct free of intermediate parser state.
 	decoded, err := binarycodec.Decode(hex.EncodeToString(m.Serialized))
 	if err != nil {
-		return fmt.Errorf("manifest: re-decode for verify: %w", err)
+		return fmt.Errorf("manifest: decode for verify: %w", err)
 	}
 	masterSigHex, _ := decoded["MasterSignature"].(string)
 	if masterSigHex == "" {
 		return errors.New("manifest: MasterSignature missing on verify")
 	}
+	var sigHex string
+	if !m.Revoked() {
+		sigHex, _ = decoded["Signature"].(string)
+		if sigHex == "" {
+			return errors.New("manifest: Signature missing on verify")
+		}
+	}
+	preimage, err := signingPreimageFromDecoded(decoded)
+	if err != nil {
+		return fmt.Errorf("manifest: build signing preimage: %w", err)
+	}
 	if !verifySignature(m.MasterKey, preimage, masterSigHex) {
 		return errors.New("manifest: master signature invalid")
 	}
 	if !m.Revoked() {
-		sigHex, _ := decoded["Signature"].(string)
-		if sigHex == "" {
-			return errors.New("manifest: Signature missing on verify")
-		}
 		if !verifySignature(m.SigningKey, preimage, sigHex) {
 			return errors.New("manifest: ephemeral signature invalid")
 		}
@@ -204,15 +211,13 @@ func (m *Manifest) Verify() error {
 	return nil
 }
 
-// signingPreimage returns HashPrefix("MAN\0") || STObject(manifest
-// without signing fields). Mirrors rippled's ripple::verify pattern
-// (Sign.cpp:47-62) where ss.add32(prefix) precedes
-// st.addWithoutSigningFields(ss).
-func signingPreimage(serialized []byte) ([]byte, error) {
-	decoded, err := binarycodec.Decode(hex.EncodeToString(serialized))
-	if err != nil {
-		return nil, err
-	}
+// signingPreimageFromDecoded returns HashPrefix("MAN\0") || STObject
+// (manifest without signing fields). The caller owns `decoded`; this
+// function mutates it (deletes non-signing fields), so callers that
+// still need the original map must pass a clone. Mirrors rippled's
+// ripple::verify pattern (Sign.cpp:47-62) where ss.add32(prefix)
+// precedes st.addWithoutSigningFields(ss).
+func signingPreimageFromDecoded(decoded map[string]any) ([]byte, error) {
 	for k := range decoded {
 		fi, _ := definitions.Get().GetFieldInstanceByFieldName(k)
 		if fi != nil && !fi.IsSigningField {

--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -18,6 +18,8 @@ var (
 	ErrSendBufferFull     = errors.New("peer send buffer full")
 	ErrPingTimeout        = errors.New("peer ping timeout")
 	ErrLargeSendQueue     = errors.New("peer send queue saturated; closing")
+	ErrReadIdle           = errors.New("peer read idle deadline exceeded")
+	ErrWriteIdle          = errors.New("peer write idle deadline exceeded")
 
 	// Handshake errors
 	ErrHandshakeFailed  = errors.New("handshake failed")

--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -21,9 +21,9 @@ import (
 // at compile time (an unknown MessageType maps to defaultPerTypeMax,
 // not to "missing key").
 const (
-	smallMsgMax      = 64 * 1024         // 64 KiB
-	mediumMsgMax     = 1 * 1024 * 1024   // 1 MiB
-	largeMsgMax      = 16 * 1024 * 1024  // 16 MiB
+	smallMsgMax       = 64 * 1024        // 64 KiB
+	mediumMsgMax      = 1 * 1024 * 1024  // 1 MiB
+	largeMsgMax       = 16 * 1024 * 1024 // 16 MiB
 	defaultPerTypeMax = mediumMsgMax
 )
 

--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -9,17 +9,10 @@ import (
 )
 
 // Per-MessageType payload-size caps applied by ReadMessage BEFORE
-// allocating the payload slice. Without these, a peer can claim a
-// full MaxPayloadSize (64MB-1) header for any message type and force
-// a 64MB allocation per claim — a small fleet of malicious peers can
-// OOM the process before any decode runs. The values below are
-// generous (10x the typical observed size per type) so honest peers
-// never see ErrMessageTooLarge while obvious abuse is rejected at the
-// header. Anything not listed falls back to defaultPerTypeMax.
-//
-// Use a function rather than a `var` map so the table is fail-loud
-// at compile time (an unknown MessageType maps to defaultPerTypeMax,
-// not to "missing key").
+// allocating. Without these, a peer can claim MaxPayloadSize for any
+// type and force a 64MB allocation per claim — trivial OOM vector.
+// Values are ~10× typical observed traffic per type; unknown types
+// fall back to defaultPerTypeMax.
 const (
 	smallMsgMax       = 64 * 1024        // 64 KiB
 	mediumMsgMax      = 1 * 1024 * 1024  // 1 MiB
@@ -27,11 +20,9 @@ const (
 	defaultPerTypeMax = mediumMsgMax
 )
 
-// MaxPayloadSizeForType returns the largest payload (post-decompress
-// size for compressed messages) a peer may claim for the given
-// message type. Returns defaultPerTypeMax for unknown types so the
-// loop closes on the peer rather than silently accepting a 64MB
-// allocation claim.
+// MaxPayloadSizeForType returns the largest payload a peer may claim
+// for the given message type (post-decompress for compressed frames).
+// Unknown types fall back to defaultPerTypeMax.
 func MaxPayloadSizeForType(t MessageType) uint32 {
 	switch t {
 	case TypePing, TypeSquelch:
@@ -257,10 +248,8 @@ func ReadMessage(r io.Reader) (*Header, []byte, error) {
 		return nil, nil, err
 	}
 
-	// Per-type sanity cap on the on-wire payload claim BEFORE
-	// allocating. For compressed frames we also cap the
-	// uncompressed-size claim so a tiny LZ4 frame cannot decompress
-	// into a gigabyte-scale allocation.
+	// Cap both the on-wire and uncompressed claims BEFORE allocating
+	// so a tiny LZ4 frame cannot decompress into a giant slice.
 	maxSize := MaxPayloadSizeForType(header.MessageType)
 	if header.PayloadSize > maxSize {
 		return nil, nil, fmt.Errorf("%w: %d > %d for %s",

--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -8,6 +8,61 @@ import (
 	"io"
 )
 
+// Per-MessageType payload-size caps applied by ReadMessage BEFORE
+// allocating the payload slice. Without these, a peer can claim a
+// full MaxPayloadSize (64MB-1) header for any message type and force
+// a 64MB allocation per claim — a small fleet of malicious peers can
+// OOM the process before any decode runs. The values below are
+// generous (10x the typical observed size per type) so honest peers
+// never see ErrMessageTooLarge while obvious abuse is rejected at the
+// header. Anything not listed falls back to defaultPerTypeMax.
+//
+// Use a function rather than a `var` map so the table is fail-loud
+// at compile time (an unknown MessageType maps to defaultPerTypeMax,
+// not to "missing key").
+const (
+	smallMsgMax      = 64 * 1024         // 64 KiB
+	mediumMsgMax     = 1 * 1024 * 1024   // 1 MiB
+	largeMsgMax      = 16 * 1024 * 1024  // 16 MiB
+	defaultPerTypeMax = mediumMsgMax
+)
+
+// MaxPayloadSizeForType returns the largest payload (post-decompress
+// size for compressed messages) a peer may claim for the given
+// message type. Returns defaultPerTypeMax for unknown types so the
+// loop closes on the peer rather than silently accepting a 64MB
+// allocation claim.
+func MaxPayloadSizeForType(t MessageType) uint32 {
+	switch t {
+	case TypePing, TypeSquelch:
+		return 2048
+	case TypeEndpoints,
+		TypeStatusChange,
+		TypeProposeLedger,
+		TypeValidation,
+		TypeHaveSet,
+		TypeHaveTransactions,
+		TypeCluster:
+		return smallMsgMax
+	case TypeManifests,
+		TypeValidatorList,
+		TypeValidatorListCollection,
+		TypeGetLedger,
+		TypeGetObjects,
+		TypeProofPathReq,
+		TypeReplayDeltaReq,
+		TypeTransaction:
+		return mediumMsgMax
+	case TypeLedgerData,
+		TypeTransactions,
+		TypeProofPathResponse,
+		TypeReplayDeltaResponse:
+		return largeMsgMax
+	default:
+		return defaultPerTypeMax
+	}
+}
+
 const (
 	// HeaderSizeUncompressed is the size of an uncompressed message header.
 	// Format: 4 bytes (6 bits flags + 26 bits size) + 2 bytes (type)
@@ -200,6 +255,20 @@ func ReadMessage(r io.Reader) (*Header, []byte, error) {
 	header, err := DecodeHeader(headerBuf)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// Per-type sanity cap on the on-wire payload claim BEFORE
+	// allocating. For compressed frames we also cap the
+	// uncompressed-size claim so a tiny LZ4 frame cannot decompress
+	// into a gigabyte-scale allocation.
+	maxSize := MaxPayloadSizeForType(header.MessageType)
+	if header.PayloadSize > maxSize {
+		return nil, nil, fmt.Errorf("%w: %d > %d for %s",
+			ErrMessageTooLarge, header.PayloadSize, maxSize, header.MessageType)
+	}
+	if header.Compressed && header.UncompressedSize > maxSize {
+		return nil, nil, fmt.Errorf("%w: uncompressed %d > %d for %s",
+			ErrMessageTooLarge, header.UncompressedSize, maxSize, header.MessageType)
 	}
 
 	// Read payload

--- a/internal/peermanagement/message/serialize_proto.go
+++ b/internal/peermanagement/message/serialize_proto.go
@@ -7,14 +7,9 @@ import (
 	pb "google.golang.org/protobuf/proto"
 )
 
-// msgCodec bundles the three operations every message type needs into
-// a single record. Previously these lived in three parallel
-// type-switches (newProtoMessage / toProto / fromProto); adding a new
-// type meant touching all three sites and forgetting one was an easy
-// way to ship a half-wired message. With the registry, one missing
-// table entry surfaces as a single "unknown message type" at both
-// encode and decode, and the three pieces of logic for one type sit
-// next to each other.
+// msgCodec bundles the three operations every message type needs:
+// proto constructor, encoder, decoder. A missing table entry surfaces
+// as a single "unknown message type" at both encode and decode.
 type msgCodec struct {
 	newProto func() pb.Message
 	encode   func(Message) (pb.Message, error)

--- a/internal/peermanagement/message/serialize_proto.go
+++ b/internal/peermanagement/message/serialize_proto.go
@@ -7,538 +7,579 @@ import (
 	pb "google.golang.org/protobuf/proto"
 )
 
+// msgCodec bundles the three operations every message type needs into
+// a single record. Previously these lived in three parallel
+// type-switches (newProtoMessage / toProto / fromProto); adding a new
+// type meant touching all three sites and forgetting one was an easy
+// way to ship a half-wired message. With the registry, one missing
+// table entry surfaces as a single "unknown message type" at both
+// encode and decode, and the three pieces of logic for one type sit
+// next to each other.
+type msgCodec struct {
+	newProto func() pb.Message
+	encode   func(Message) (pb.Message, error)
+	decode   func(pb.Message) (Message, error)
+}
+
+// codecs is the per-MessageType registry. Order in this map carries
+// no semantics — keep it sorted by MessageType constant order for
+// reviewer sanity.
+var codecs = map[MessageType]msgCodec{
+	TypeManifests: {
+		newProto: func() pb.Message { return &proto.TMManifests{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*Manifests)
+			list := make([]*proto.TMManifest, len(m.List))
+			for i, manifest := range m.List {
+				list[i] = &proto.TMManifest{Stobject: manifest.STObject}
+			}
+			return &proto.TMManifests{List: list, History: m.History}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMManifests)
+			list := make([]Manifest, len(p.List))
+			for i, m := range p.List {
+				list[i] = Manifest{STObject: m.Stobject}
+			}
+			return &Manifests{List: list, History: p.History}, nil
+		},
+	},
+	TypePing: {
+		newProto: func() pb.Message { return &proto.TMPing{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*Ping)
+			pingType := proto.TMPing_PingType(m.PType)
+			return &proto.TMPing{
+				Type:     &pingType,
+				Seq:      &m.Seq,
+				PingTime: &m.PingTime,
+				NetTime:  &m.NetTime,
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMPing)
+			return &Ping{
+				PType:    PingType(p.GetType()),
+				Seq:      p.GetSeq(),
+				PingTime: p.GetPingTime(),
+				NetTime:  p.GetNetTime(),
+			}, nil
+		},
+	},
+	TypeCluster: {
+		newProto: func() pb.Message { return &proto.TMCluster{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*Cluster)
+			nodes := make([]*proto.TMClusterNode, len(m.ClusterNodes))
+			for i, n := range m.ClusterNodes {
+				nodes[i] = &proto.TMClusterNode{
+					PublicKey:  pb.String(n.PublicKey),
+					ReportTime: pb.Uint32(n.ReportTime),
+					NodeLoad:   pb.Uint32(n.NodeLoad),
+					NodeName:   n.NodeName,
+					Address:    n.Address,
+				}
+			}
+			sources := make([]*proto.TMLoadSource, len(m.LoadSources))
+			for i, s := range m.LoadSources {
+				sources[i] = &proto.TMLoadSource{
+					Name:  pb.String(s.Name),
+					Cost:  pb.Uint32(s.Cost),
+					Count: s.Count,
+				}
+			}
+			return &proto.TMCluster{ClusterNodes: nodes, LoadSources: sources}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMCluster)
+			nodes := make([]ClusterNode, len(p.ClusterNodes))
+			for i, n := range p.ClusterNodes {
+				nodes[i] = ClusterNode{
+					PublicKey:  n.GetPublicKey(),
+					ReportTime: n.GetReportTime(),
+					NodeLoad:   n.GetNodeLoad(),
+					NodeName:   n.GetNodeName(),
+					Address:    n.GetAddress(),
+				}
+			}
+			sources := make([]LoadSource, len(p.LoadSources))
+			for i, s := range p.LoadSources {
+				sources[i] = LoadSource{
+					Name:  s.GetName(),
+					Cost:  s.GetCost(),
+					Count: s.GetCount(),
+				}
+			}
+			return &Cluster{ClusterNodes: nodes, LoadSources: sources}, nil
+		},
+	},
+	TypeEndpoints: {
+		newProto: func() pb.Message { return &proto.TMEndpoints{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*Endpoints)
+			eps := make([]*proto.TMEndpoints_TMEndpointv2, len(m.EndpointsV2))
+			for i, ep := range m.EndpointsV2 {
+				eps[i] = &proto.TMEndpoints_TMEndpointv2{
+					Endpoint: pb.String(ep.Endpoint),
+					Hops:     pb.Uint32(ep.Hops),
+				}
+			}
+			return &proto.TMEndpoints{Version: pb.Uint32(m.Version), EndpointsV2: eps}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMEndpoints)
+			eps := make([]Endpointv2, len(p.EndpointsV2))
+			for i, ep := range p.EndpointsV2 {
+				eps[i] = Endpointv2{
+					Endpoint: ep.GetEndpoint(),
+					Hops:     ep.GetHops(),
+				}
+			}
+			return &Endpoints{Version: p.GetVersion(), EndpointsV2: eps}, nil
+		},
+	},
+	TypeTransaction: {
+		newProto: func() pb.Message { return &proto.TMTransaction{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*Transaction)
+			txStatus := proto.TransactionStatus(m.Status)
+			return &proto.TMTransaction{
+				RawTransaction:   m.RawTransaction,
+				Status:           &txStatus,
+				ReceiveTimestamp: m.ReceiveTimestamp,
+				Deferred:         m.Deferred,
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMTransaction)
+			return &Transaction{
+				RawTransaction:   p.GetRawTransaction(),
+				Status:           TransactionStatus(p.GetStatus()),
+				ReceiveTimestamp: p.GetReceiveTimestamp(),
+				Deferred:         p.GetDeferred(),
+			}, nil
+		},
+	},
+	TypeGetLedger: {
+		newProto: func() pb.Message { return &proto.TMGetLedger{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*GetLedger)
+			itype := proto.TMLedgerInfoType(m.InfoType)
+			ltype := proto.TMLedgerType(m.LType)
+			return &proto.TMGetLedger{
+				Itype:         &itype,
+				Ltype:         &ltype,
+				LedgerHash:    m.LedgerHash,
+				LedgerSeq:     m.LedgerSeq,
+				NodeIds:       m.NodeIDs,
+				RequestCookie: m.RequestCookie,
+				QueryDepth:    m.QueryDepth,
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMGetLedger)
+			return &GetLedger{
+				InfoType:      LedgerInfoType(p.GetItype()),
+				LType:         LedgerType(p.GetLtype()),
+				LedgerHash:    p.GetLedgerHash(),
+				LedgerSeq:     p.GetLedgerSeq(),
+				NodeIDs:       p.GetNodeIds(),
+				RequestCookie: p.GetRequestCookie(),
+				QueryDepth:    p.GetQueryDepth(),
+			}, nil
+		},
+	},
+	TypeLedgerData: {
+		newProto: func() pb.Message { return &proto.TMLedgerData{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*LedgerData)
+			nodes := make([]*proto.TMLedgerNode, len(m.Nodes))
+			for i, n := range m.Nodes {
+				nodes[i] = &proto.TMLedgerNode{
+					Nodedata: n.NodeData,
+					Nodeid:   n.NodeID,
+				}
+			}
+			ledgerInfoType := proto.TMLedgerInfoType(m.InfoType)
+			return &proto.TMLedgerData{
+				LedgerHash:    m.LedgerHash,
+				LedgerSeq:     pb.Uint32(m.LedgerSeq),
+				Type:          &ledgerInfoType,
+				Nodes:         nodes,
+				RequestCookie: m.RequestCookie,
+				Error:         proto.TMReplyError(m.Error),
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMLedgerData)
+			nodes := make([]LedgerNode, len(p.Nodes))
+			for i, n := range p.Nodes {
+				nodes[i] = LedgerNode{
+					NodeData: n.GetNodedata(),
+					NodeID:   n.GetNodeid(),
+				}
+			}
+			return &LedgerData{
+				LedgerHash:    p.GetLedgerHash(),
+				LedgerSeq:     p.GetLedgerSeq(),
+				InfoType:      LedgerInfoType(p.GetType()),
+				Nodes:         nodes,
+				RequestCookie: p.GetRequestCookie(),
+				Error:         ReplyError(p.GetError()),
+			}, nil
+		},
+	},
+	TypeProposeLedger: {
+		newProto: func() pb.Message { return &proto.TMProposeSet{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*ProposeSet)
+			return &proto.TMProposeSet{
+				ProposeSeq:          pb.Uint32(m.ProposeSeq),
+				CurrentTxHash:       m.CurrentTxHash,
+				NodePubKey:          m.NodePubKey,
+				CloseTime:           pb.Uint32(m.CloseTime),
+				Signature:           m.Signature,
+				PreviousLedger:      m.PreviousLedger,
+				AddedTransactions:   m.AddedTransactions,
+				RemovedTransactions: m.RemovedTransactions,
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMProposeSet)
+			return &ProposeSet{
+				ProposeSeq:          p.GetProposeSeq(),
+				CurrentTxHash:       p.GetCurrentTxHash(),
+				NodePubKey:          p.GetNodePubKey(),
+				CloseTime:           p.GetCloseTime(),
+				Signature:           p.GetSignature(),
+				PreviousLedger:      p.GetPreviousLedger(),
+				AddedTransactions:   p.GetAddedTransactions(),
+				RemovedTransactions: p.GetRemovedTransactions(),
+			}, nil
+		},
+	},
+	TypeStatusChange: {
+		newProto: func() pb.Message { return &proto.TMStatusChange{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*StatusChange)
+			return &proto.TMStatusChange{
+				NewStatus:          proto.NodeStatus(m.NewStatus),
+				NewEvent:           proto.NodeEvent(m.NewEvent),
+				LedgerSeq:          m.LedgerSeq,
+				LedgerHash:         m.LedgerHash,
+				LedgerHashPrevious: m.LedgerHashPrevious,
+				NetworkTime:        m.NetworkTime,
+				FirstSeq:           m.FirstSeq,
+				LastSeq:            m.LastSeq,
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMStatusChange)
+			return &StatusChange{
+				NewStatus:          NodeStatus(p.GetNewStatus()),
+				NewEvent:           NodeEvent(p.GetNewEvent()),
+				LedgerSeq:          p.GetLedgerSeq(),
+				LedgerHash:         p.GetLedgerHash(),
+				LedgerHashPrevious: p.GetLedgerHashPrevious(),
+				NetworkTime:        p.GetNetworkTime(),
+				FirstSeq:           p.FirstSeq,
+				LastSeq:            p.LastSeq,
+			}, nil
+		},
+	},
+	TypeHaveSet: {
+		newProto: func() pb.Message { return &proto.TMHaveTransactionSet{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*HaveTransactionSet)
+			txSetStatus := proto.TxSetStatus(m.Status)
+			return &proto.TMHaveTransactionSet{
+				Status: &txSetStatus,
+				Hash:   m.Hash,
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMHaveTransactionSet)
+			return &HaveTransactionSet{
+				Status: TxSetStatus(p.GetStatus()),
+				Hash:   p.GetHash(),
+			}, nil
+		},
+	},
+	TypeValidation: {
+		newProto: func() pb.Message { return &proto.TMValidation{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*Validation)
+			return &proto.TMValidation{Validation: m.Validation}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMValidation)
+			return &Validation{Validation: p.GetValidation()}, nil
+		},
+	},
+	TypeGetObjects: {
+		newProto: func() pb.Message { return &proto.TMGetObjectByHash{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*GetObjectByHash)
+			objects := make([]*proto.TMIndexedObject, len(m.Objects))
+			for i, o := range m.Objects {
+				objects[i] = &proto.TMIndexedObject{
+					Hash:      o.Hash,
+					NodeId:    o.NodeID,
+					Index:     o.Index,
+					Data:      o.Data,
+					LedgerSeq: o.LedgerSeq,
+				}
+			}
+			objType := proto.ObjectType(m.ObjType)
+			return &proto.TMGetObjectByHash{
+				Type:       &objType,
+				Query:      pb.Bool(m.Query),
+				Seq:        m.Seq,
+				LedgerHash: m.LedgerHash,
+				Fat:        m.Fat,
+				Objects:    objects,
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMGetObjectByHash)
+			objects := make([]IndexedObject, len(p.Objects))
+			for i, o := range p.Objects {
+				objects[i] = IndexedObject{
+					Hash:      o.GetHash(),
+					NodeID:    o.GetNodeId(),
+					Index:     o.GetIndex(),
+					Data:      o.GetData(),
+					LedgerSeq: o.GetLedgerSeq(),
+				}
+			}
+			return &GetObjectByHash{
+				ObjType:    ObjectType(p.GetType()),
+				Query:      p.GetQuery(),
+				Seq:        p.GetSeq(),
+				LedgerHash: p.GetLedgerHash(),
+				Fat:        p.GetFat(),
+				Objects:    objects,
+			}, nil
+		},
+	},
+	TypeValidatorList: {
+		newProto: func() pb.Message { return &proto.TMValidatorList{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*ValidatorList)
+			return &proto.TMValidatorList{
+				Manifest:  m.Manifest,
+				Blob:      m.Blob,
+				Signature: m.Signature,
+				Version:   pb.Uint32(m.Version),
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMValidatorList)
+			return &ValidatorList{
+				Manifest:  p.GetManifest(),
+				Blob:      p.GetBlob(),
+				Signature: p.GetSignature(),
+				Version:   p.GetVersion(),
+			}, nil
+		},
+	},
+	TypeSquelch: {
+		newProto: func() pb.Message { return &proto.TMSquelch{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*Squelch)
+			return &proto.TMSquelch{
+				Squelch:         pb.Bool(m.Squelch),
+				ValidatorPubKey: m.ValidatorPubKey,
+				SquelchDuration: m.SquelchDuration,
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMSquelch)
+			return &Squelch{
+				Squelch:         p.GetSquelch(),
+				ValidatorPubKey: p.GetValidatorPubKey(),
+				SquelchDuration: p.GetSquelchDuration(),
+			}, nil
+		},
+	},
+	TypeValidatorListCollection: {
+		newProto: func() pb.Message { return &proto.TMValidatorListCollection{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*ValidatorListCollection)
+			blobs := make([]*proto.ValidatorBlobInfo, len(m.Blobs))
+			for i, b := range m.Blobs {
+				blobs[i] = &proto.ValidatorBlobInfo{
+					Manifest:  b.Manifest,
+					Blob:      b.Blob,
+					Signature: b.Signature,
+				}
+			}
+			return &proto.TMValidatorListCollection{
+				Version:  pb.Uint32(m.Version),
+				Manifest: m.Manifest,
+				Blobs:    blobs,
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMValidatorListCollection)
+			blobs := make([]ValidatorBlobInfo, len(p.Blobs))
+			for i, b := range p.Blobs {
+				blobs[i] = ValidatorBlobInfo{
+					Manifest:  b.GetManifest(),
+					Blob:      b.GetBlob(),
+					Signature: b.GetSignature(),
+				}
+			}
+			return &ValidatorListCollection{
+				Version:  p.GetVersion(),
+				Manifest: p.GetManifest(),
+				Blobs:    blobs,
+			}, nil
+		},
+	},
+	TypeProofPathReq: {
+		newProto: func() pb.Message { return &proto.TMProofPathRequest{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*ProofPathRequest)
+			mapType := proto.TMLedgerMapType(m.MapType)
+			return &proto.TMProofPathRequest{
+				Key:        m.Key,
+				LedgerHash: m.LedgerHash,
+				Type:       &mapType,
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMProofPathRequest)
+			return &ProofPathRequest{
+				Key:        p.GetKey(),
+				LedgerHash: p.GetLedgerHash(),
+				MapType:    LedgerMapType(p.GetType()),
+			}, nil
+		},
+	},
+	TypeProofPathResponse: {
+		newProto: func() pb.Message { return &proto.TMProofPathResponse{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*ProofPathResponse)
+			mapType := proto.TMLedgerMapType(m.MapType)
+			return &proto.TMProofPathResponse{
+				Key:          m.Key,
+				LedgerHash:   m.LedgerHash,
+				Type:         &mapType,
+				LedgerHeader: m.LedgerHeader,
+				Path:         m.Path,
+				Error:        proto.TMReplyError(m.Error),
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMProofPathResponse)
+			return &ProofPathResponse{
+				Key:          p.GetKey(),
+				LedgerHash:   p.GetLedgerHash(),
+				MapType:      LedgerMapType(p.GetType()),
+				LedgerHeader: p.GetLedgerHeader(),
+				Path:         p.GetPath(),
+				Error:        ReplyError(p.GetError()),
+			}, nil
+		},
+	},
+	TypeReplayDeltaReq: {
+		newProto: func() pb.Message { return &proto.TMReplayDeltaRequest{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*ReplayDeltaRequest)
+			return &proto.TMReplayDeltaRequest{LedgerHash: m.LedgerHash}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMReplayDeltaRequest)
+			return &ReplayDeltaRequest{LedgerHash: p.GetLedgerHash()}, nil
+		},
+	},
+	TypeReplayDeltaResponse: {
+		newProto: func() pb.Message { return &proto.TMReplayDeltaResponse{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*ReplayDeltaResponse)
+			return &proto.TMReplayDeltaResponse{
+				LedgerHash:   m.LedgerHash,
+				LedgerHeader: m.LedgerHeader,
+				Transaction:  m.Transactions,
+				Error:        proto.TMReplyError(m.Error),
+			}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMReplayDeltaResponse)
+			return &ReplayDeltaResponse{
+				LedgerHash:   p.GetLedgerHash(),
+				LedgerHeader: p.GetLedgerHeader(),
+				Transactions: p.GetTransaction(),
+				Error:        ReplyError(p.GetError()),
+			}, nil
+		},
+	},
+	TypeHaveTransactions: {
+		newProto: func() pb.Message { return &proto.TMHaveTransactions{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*HaveTransactions)
+			return &proto.TMHaveTransactions{Hashes: m.Hashes}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMHaveTransactions)
+			return &HaveTransactions{Hashes: p.GetHashes()}, nil
+		},
+	},
+	TypeTransactions: {
+		newProto: func() pb.Message { return &proto.TMTransactions{} },
+		encode: func(msg Message) (pb.Message, error) {
+			m := msg.(*Transactions)
+			txs := make([]*proto.TMTransaction, len(m.Transactions))
+			for i, tx := range m.Transactions {
+				txStatus := proto.TransactionStatus(tx.Status)
+				txs[i] = &proto.TMTransaction{
+					RawTransaction:   tx.RawTransaction,
+					Status:           &txStatus,
+					ReceiveTimestamp: tx.ReceiveTimestamp,
+					Deferred:         tx.Deferred,
+				}
+			}
+			return &proto.TMTransactions{Transactions: txs}, nil
+		},
+		decode: func(pmsg pb.Message) (Message, error) {
+			p := pmsg.(*proto.TMTransactions)
+			txs := make([]Transaction, len(p.Transactions))
+			for i, tx := range p.Transactions {
+				txs[i] = Transaction{
+					RawTransaction:   tx.GetRawTransaction(),
+					Status:           TransactionStatus(tx.GetStatus()),
+					ReceiveTimestamp: tx.GetReceiveTimestamp(),
+					Deferred:         tx.GetDeferred(),
+				}
+			}
+			return &Transactions{Transactions: txs}, nil
+		},
+	},
+}
+
 // Encode encodes a message to bytes using protobuf.
 func Encode(msg Message) ([]byte, error) {
-	protoMsg, err := toProto(msg)
+	c, ok := codecs[msg.Type()]
+	if !ok {
+		return nil, fmt.Errorf("unknown message type: %d", msg.Type())
+	}
+	pmsg, err := c.encode(msg)
 	if err != nil {
 		return nil, err
 	}
-	return pb.Marshal(protoMsg)
+	return pb.Marshal(pmsg)
 }
 
 // Decode decodes a message from bytes using protobuf.
 func Decode(msgType MessageType, data []byte) (Message, error) {
-	protoMsg, err := newProtoMessage(msgType)
-	if err != nil {
-		return nil, err
+	c, ok := codecs[msgType]
+	if !ok {
+		return nil, fmt.Errorf("unknown message type: %d", msgType)
 	}
-
-	if err := pb.Unmarshal(data, protoMsg); err != nil {
+	pmsg := c.newProto()
+	if err := pb.Unmarshal(data, pmsg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal: %w", err)
 	}
-
-	return fromProto(msgType, protoMsg)
-}
-
-// newProtoMessage creates a new proto message for the given type.
-func newProtoMessage(msgType MessageType) (pb.Message, error) {
-	switch msgType {
-	case TypePing:
-		return &proto.TMPing{}, nil
-	case TypeManifests:
-		return &proto.TMManifests{}, nil
-	case TypeCluster:
-		return &proto.TMCluster{}, nil
-	case TypeEndpoints:
-		return &proto.TMEndpoints{}, nil
-	case TypeTransaction:
-		return &proto.TMTransaction{}, nil
-	case TypeTransactions:
-		return &proto.TMTransactions{}, nil
-	case TypeGetLedger:
-		return &proto.TMGetLedger{}, nil
-	case TypeLedgerData:
-		return &proto.TMLedgerData{}, nil
-	case TypeProposeLedger:
-		return &proto.TMProposeSet{}, nil
-	case TypeStatusChange:
-		return &proto.TMStatusChange{}, nil
-	case TypeHaveSet:
-		return &proto.TMHaveTransactionSet{}, nil
-	case TypeValidation:
-		return &proto.TMValidation{}, nil
-	case TypeGetObjects:
-		return &proto.TMGetObjectByHash{}, nil
-	case TypeValidatorList:
-		return &proto.TMValidatorList{}, nil
-	case TypeSquelch:
-		return &proto.TMSquelch{}, nil
-	case TypeValidatorListCollection:
-		return &proto.TMValidatorListCollection{}, nil
-	case TypeProofPathReq:
-		return &proto.TMProofPathRequest{}, nil
-	case TypeProofPathResponse:
-		return &proto.TMProofPathResponse{}, nil
-	case TypeReplayDeltaReq:
-		return &proto.TMReplayDeltaRequest{}, nil
-	case TypeReplayDeltaResponse:
-		return &proto.TMReplayDeltaResponse{}, nil
-	case TypeHaveTransactions:
-		return &proto.TMHaveTransactions{}, nil
-	default:
-		return nil, fmt.Errorf("unknown message type: %d", msgType)
-	}
-}
-
-// toProto converts a message to its protobuf representation.
-func toProto(msg Message) (pb.Message, error) {
-	switch m := msg.(type) {
-	case *Ping:
-		pingType := proto.TMPing_PingType(m.PType)
-		return &proto.TMPing{
-			Type:     &pingType,
-			Seq:      &m.Seq,
-			PingTime: &m.PingTime,
-			NetTime:  &m.NetTime,
-		}, nil
-
-	case *Manifests:
-		list := make([]*proto.TMManifest, len(m.List))
-		for i, manifest := range m.List {
-			list[i] = &proto.TMManifest{Stobject: manifest.STObject}
-		}
-		return &proto.TMManifests{List: list, History: m.History}, nil
-
-	case *Cluster:
-		nodes := make([]*proto.TMClusterNode, len(m.ClusterNodes))
-		for i, n := range m.ClusterNodes {
-			nodes[i] = &proto.TMClusterNode{
-				PublicKey:  pb.String(n.PublicKey),
-				ReportTime: pb.Uint32(n.ReportTime),
-				NodeLoad:   pb.Uint32(n.NodeLoad),
-				NodeName:   n.NodeName,
-				Address:    n.Address,
-			}
-		}
-		sources := make([]*proto.TMLoadSource, len(m.LoadSources))
-		for i, s := range m.LoadSources {
-			sources[i] = &proto.TMLoadSource{
-				Name:  pb.String(s.Name),
-				Cost:  pb.Uint32(s.Cost),
-				Count: s.Count,
-			}
-		}
-		return &proto.TMCluster{ClusterNodes: nodes, LoadSources: sources}, nil
-
-	case *Endpoints:
-		eps := make([]*proto.TMEndpoints_TMEndpointv2, len(m.EndpointsV2))
-		for i, ep := range m.EndpointsV2 {
-			eps[i] = &proto.TMEndpoints_TMEndpointv2{
-				Endpoint: pb.String(ep.Endpoint),
-				Hops:     pb.Uint32(ep.Hops),
-			}
-		}
-		return &proto.TMEndpoints{Version: pb.Uint32(m.Version), EndpointsV2: eps}, nil
-
-	case *Transaction:
-		txStatus := proto.TransactionStatus(m.Status)
-		return &proto.TMTransaction{
-			RawTransaction:   m.RawTransaction,
-			Status:           &txStatus,
-			ReceiveTimestamp: m.ReceiveTimestamp,
-			Deferred:         m.Deferred,
-		}, nil
-
-	case *Transactions:
-		txs := make([]*proto.TMTransaction, len(m.Transactions))
-		for i, tx := range m.Transactions {
-			txStatus := proto.TransactionStatus(tx.Status)
-			txs[i] = &proto.TMTransaction{
-				RawTransaction:   tx.RawTransaction,
-				Status:           &txStatus,
-				ReceiveTimestamp: tx.ReceiveTimestamp,
-				Deferred:         tx.Deferred,
-			}
-		}
-		return &proto.TMTransactions{Transactions: txs}, nil
-
-	case *StatusChange:
-		return &proto.TMStatusChange{
-			NewStatus:          proto.NodeStatus(m.NewStatus),
-			NewEvent:           proto.NodeEvent(m.NewEvent),
-			LedgerSeq:          m.LedgerSeq,
-			LedgerHash:         m.LedgerHash,
-			LedgerHashPrevious: m.LedgerHashPrevious,
-			NetworkTime:        m.NetworkTime,
-			FirstSeq:           m.FirstSeq,
-			LastSeq:            m.LastSeq,
-		}, nil
-
-	case *ProposeSet:
-		return &proto.TMProposeSet{
-			ProposeSeq:          pb.Uint32(m.ProposeSeq),
-			CurrentTxHash:       m.CurrentTxHash,
-			NodePubKey:          m.NodePubKey,
-			CloseTime:           pb.Uint32(m.CloseTime),
-			Signature:           m.Signature,
-			PreviousLedger:      m.PreviousLedger,
-			AddedTransactions:   m.AddedTransactions,
-			RemovedTransactions: m.RemovedTransactions,
-		}, nil
-
-	case *HaveTransactionSet:
-		txSetStatus := proto.TxSetStatus(m.Status)
-		return &proto.TMHaveTransactionSet{
-			Status: &txSetStatus,
-			Hash:   m.Hash,
-		}, nil
-
-	case *Validation:
-		return &proto.TMValidation{Validation: m.Validation}, nil
-
-	case *ValidatorList:
-		return &proto.TMValidatorList{
-			Manifest:  m.Manifest,
-			Blob:      m.Blob,
-			Signature: m.Signature,
-			Version:   pb.Uint32(m.Version),
-		}, nil
-
-	case *ValidatorListCollection:
-		blobs := make([]*proto.ValidatorBlobInfo, len(m.Blobs))
-		for i, b := range m.Blobs {
-			blobs[i] = &proto.ValidatorBlobInfo{
-				Manifest:  b.Manifest,
-				Blob:      b.Blob,
-				Signature: b.Signature,
-			}
-		}
-		return &proto.TMValidatorListCollection{
-			Version:  pb.Uint32(m.Version),
-			Manifest: m.Manifest,
-			Blobs:    blobs,
-		}, nil
-
-	case *GetLedger:
-		itype := proto.TMLedgerInfoType(m.InfoType)
-		ltype := proto.TMLedgerType(m.LType)
-		return &proto.TMGetLedger{
-			Itype:         &itype,
-			Ltype:         &ltype,
-			LedgerHash:    m.LedgerHash,
-			LedgerSeq:     m.LedgerSeq,
-			NodeIds:       m.NodeIDs,
-			RequestCookie: m.RequestCookie,
-			QueryDepth:    m.QueryDepth,
-		}, nil
-
-	case *LedgerData:
-		nodes := make([]*proto.TMLedgerNode, len(m.Nodes))
-		for i, n := range m.Nodes {
-			nodes[i] = &proto.TMLedgerNode{
-				Nodedata: n.NodeData,
-				Nodeid:   n.NodeID,
-			}
-		}
-		ledgerInfoType := proto.TMLedgerInfoType(m.InfoType)
-		return &proto.TMLedgerData{
-			LedgerHash:    m.LedgerHash,
-			LedgerSeq:     pb.Uint32(m.LedgerSeq),
-			Type:          &ledgerInfoType,
-			Nodes:         nodes,
-			RequestCookie: m.RequestCookie,
-			Error:         proto.TMReplyError(m.Error),
-		}, nil
-
-	case *GetObjectByHash:
-		objects := make([]*proto.TMIndexedObject, len(m.Objects))
-		for i, o := range m.Objects {
-			objects[i] = &proto.TMIndexedObject{
-				Hash:      o.Hash,
-				NodeId:    o.NodeID,
-				Index:     o.Index,
-				Data:      o.Data,
-				LedgerSeq: o.LedgerSeq,
-			}
-		}
-		objType := proto.ObjectType(m.ObjType)
-		return &proto.TMGetObjectByHash{
-			Type:       &objType,
-			Query:      pb.Bool(m.Query),
-			Seq:        m.Seq,
-			LedgerHash: m.LedgerHash,
-			Fat:        m.Fat,
-			Objects:    objects,
-		}, nil
-
-	case *Squelch:
-		return &proto.TMSquelch{
-			Squelch:         pb.Bool(m.Squelch),
-			ValidatorPubKey: m.ValidatorPubKey,
-			SquelchDuration: m.SquelchDuration,
-		}, nil
-
-	case *ProofPathRequest:
-		mapType := proto.TMLedgerMapType(m.MapType)
-		return &proto.TMProofPathRequest{
-			Key:        m.Key,
-			LedgerHash: m.LedgerHash,
-			Type:       &mapType,
-		}, nil
-
-	case *ProofPathResponse:
-		mapType := proto.TMLedgerMapType(m.MapType)
-		return &proto.TMProofPathResponse{
-			Key:          m.Key,
-			LedgerHash:   m.LedgerHash,
-			Type:         &mapType,
-			LedgerHeader: m.LedgerHeader,
-			Path:         m.Path,
-			Error:        proto.TMReplyError(m.Error),
-		}, nil
-
-	case *ReplayDeltaRequest:
-		return &proto.TMReplayDeltaRequest{LedgerHash: m.LedgerHash}, nil
-
-	case *ReplayDeltaResponse:
-		return &proto.TMReplayDeltaResponse{
-			LedgerHash:   m.LedgerHash,
-			LedgerHeader: m.LedgerHeader,
-			Transaction:  m.Transactions,
-			Error:        proto.TMReplyError(m.Error),
-		}, nil
-
-	case *HaveTransactions:
-		return &proto.TMHaveTransactions{Hashes: m.Hashes}, nil
-
-	default:
-		return nil, fmt.Errorf("unknown message type: %T", msg)
-	}
-}
-
-// fromProto converts a protobuf message to our message type.
-func fromProto(msgType MessageType, protoMsg pb.Message) (Message, error) {
-	switch msgType {
-	case TypePing:
-		p := protoMsg.(*proto.TMPing)
-		return &Ping{
-			PType:    PingType(p.GetType()),
-			Seq:      p.GetSeq(),
-			PingTime: p.GetPingTime(),
-			NetTime:  p.GetNetTime(),
-		}, nil
-
-	case TypeManifests:
-		p := protoMsg.(*proto.TMManifests)
-		list := make([]Manifest, len(p.List))
-		for i, m := range p.List {
-			list[i] = Manifest{STObject: m.Stobject}
-		}
-		return &Manifests{List: list, History: p.History}, nil
-
-	case TypeCluster:
-		p := protoMsg.(*proto.TMCluster)
-		nodes := make([]ClusterNode, len(p.ClusterNodes))
-		for i, n := range p.ClusterNodes {
-			nodes[i] = ClusterNode{
-				PublicKey:  n.GetPublicKey(),
-				ReportTime: n.GetReportTime(),
-				NodeLoad:   n.GetNodeLoad(),
-				NodeName:   n.GetNodeName(),
-				Address:    n.GetAddress(),
-			}
-		}
-		sources := make([]LoadSource, len(p.LoadSources))
-		for i, s := range p.LoadSources {
-			sources[i] = LoadSource{
-				Name:  s.GetName(),
-				Cost:  s.GetCost(),
-				Count: s.GetCount(),
-			}
-		}
-		return &Cluster{ClusterNodes: nodes, LoadSources: sources}, nil
-
-	case TypeEndpoints:
-		p := protoMsg.(*proto.TMEndpoints)
-		eps := make([]Endpointv2, len(p.EndpointsV2))
-		for i, ep := range p.EndpointsV2 {
-			eps[i] = Endpointv2{
-				Endpoint: ep.GetEndpoint(),
-				Hops:     ep.GetHops(),
-			}
-		}
-		return &Endpoints{Version: p.GetVersion(), EndpointsV2: eps}, nil
-
-	case TypeTransaction:
-		p := protoMsg.(*proto.TMTransaction)
-		return &Transaction{
-			RawTransaction:   p.GetRawTransaction(),
-			Status:           TransactionStatus(p.GetStatus()),
-			ReceiveTimestamp: p.GetReceiveTimestamp(),
-			Deferred:         p.GetDeferred(),
-		}, nil
-
-	case TypeTransactions:
-		p := protoMsg.(*proto.TMTransactions)
-		txs := make([]Transaction, len(p.Transactions))
-		for i, tx := range p.Transactions {
-			txs[i] = Transaction{
-				RawTransaction:   tx.GetRawTransaction(),
-				Status:           TransactionStatus(tx.GetStatus()),
-				ReceiveTimestamp: tx.GetReceiveTimestamp(),
-				Deferred:         tx.GetDeferred(),
-			}
-		}
-		return &Transactions{Transactions: txs}, nil
-
-	case TypeGetLedger:
-		p := protoMsg.(*proto.TMGetLedger)
-		return &GetLedger{
-			InfoType:      LedgerInfoType(p.GetItype()),
-			LType:         LedgerType(p.GetLtype()),
-			LedgerHash:    p.GetLedgerHash(),
-			LedgerSeq:     p.GetLedgerSeq(),
-			NodeIDs:       p.GetNodeIds(),
-			RequestCookie: p.GetRequestCookie(),
-			QueryDepth:    p.GetQueryDepth(),
-		}, nil
-
-	case TypeLedgerData:
-		p := protoMsg.(*proto.TMLedgerData)
-		nodes := make([]LedgerNode, len(p.Nodes))
-		for i, n := range p.Nodes {
-			nodes[i] = LedgerNode{
-				NodeData: n.GetNodedata(),
-				NodeID:   n.GetNodeid(),
-			}
-		}
-		return &LedgerData{
-			LedgerHash:    p.GetLedgerHash(),
-			LedgerSeq:     p.GetLedgerSeq(),
-			InfoType:      LedgerInfoType(p.GetType()),
-			Nodes:         nodes,
-			RequestCookie: p.GetRequestCookie(),
-			Error:         ReplyError(p.GetError()),
-		}, nil
-
-	case TypeProposeLedger:
-		p := protoMsg.(*proto.TMProposeSet)
-		return &ProposeSet{
-			ProposeSeq:          p.GetProposeSeq(),
-			CurrentTxHash:       p.GetCurrentTxHash(),
-			NodePubKey:          p.GetNodePubKey(),
-			CloseTime:           p.GetCloseTime(),
-			Signature:           p.GetSignature(),
-			PreviousLedger:      p.GetPreviousLedger(),
-			AddedTransactions:   p.GetAddedTransactions(),
-			RemovedTransactions: p.GetRemovedTransactions(),
-		}, nil
-
-	case TypeStatusChange:
-		p := protoMsg.(*proto.TMStatusChange)
-		return &StatusChange{
-			NewStatus:          NodeStatus(p.GetNewStatus()),
-			NewEvent:           NodeEvent(p.GetNewEvent()),
-			LedgerSeq:          p.GetLedgerSeq(),
-			LedgerHash:         p.GetLedgerHash(),
-			LedgerHashPrevious: p.GetLedgerHashPrevious(),
-			NetworkTime:        p.GetNetworkTime(),
-			FirstSeq:           p.FirstSeq,
-			LastSeq:            p.LastSeq,
-		}, nil
-
-	case TypeHaveSet:
-		p := protoMsg.(*proto.TMHaveTransactionSet)
-		return &HaveTransactionSet{
-			Status: TxSetStatus(p.GetStatus()),
-			Hash:   p.GetHash(),
-		}, nil
-
-	case TypeValidation:
-		p := protoMsg.(*proto.TMValidation)
-		return &Validation{Validation: p.GetValidation()}, nil
-
-	case TypeGetObjects:
-		p := protoMsg.(*proto.TMGetObjectByHash)
-		objects := make([]IndexedObject, len(p.Objects))
-		for i, o := range p.Objects {
-			objects[i] = IndexedObject{
-				Hash:      o.GetHash(),
-				NodeID:    o.GetNodeId(),
-				Index:     o.GetIndex(),
-				Data:      o.GetData(),
-				LedgerSeq: o.GetLedgerSeq(),
-			}
-		}
-		return &GetObjectByHash{
-			ObjType:    ObjectType(p.GetType()),
-			Query:      p.GetQuery(),
-			Seq:        p.GetSeq(),
-			LedgerHash: p.GetLedgerHash(),
-			Fat:        p.GetFat(),
-			Objects:    objects,
-		}, nil
-
-	case TypeValidatorList:
-		p := protoMsg.(*proto.TMValidatorList)
-		return &ValidatorList{
-			Manifest:  p.GetManifest(),
-			Blob:      p.GetBlob(),
-			Signature: p.GetSignature(),
-			Version:   p.GetVersion(),
-		}, nil
-
-	case TypeSquelch:
-		p := protoMsg.(*proto.TMSquelch)
-		return &Squelch{
-			Squelch:         p.GetSquelch(),
-			ValidatorPubKey: p.GetValidatorPubKey(),
-			SquelchDuration: p.GetSquelchDuration(),
-		}, nil
-
-	case TypeValidatorListCollection:
-		p := protoMsg.(*proto.TMValidatorListCollection)
-		blobs := make([]ValidatorBlobInfo, len(p.Blobs))
-		for i, b := range p.Blobs {
-			blobs[i] = ValidatorBlobInfo{
-				Manifest:  b.GetManifest(),
-				Blob:      b.GetBlob(),
-				Signature: b.GetSignature(),
-			}
-		}
-		return &ValidatorListCollection{
-			Version:  p.GetVersion(),
-			Manifest: p.GetManifest(),
-			Blobs:    blobs,
-		}, nil
-
-	case TypeProofPathReq:
-		p := protoMsg.(*proto.TMProofPathRequest)
-		return &ProofPathRequest{
-			Key:        p.GetKey(),
-			LedgerHash: p.GetLedgerHash(),
-			MapType:    LedgerMapType(p.GetType()),
-		}, nil
-
-	case TypeProofPathResponse:
-		p := protoMsg.(*proto.TMProofPathResponse)
-		return &ProofPathResponse{
-			Key:          p.GetKey(),
-			LedgerHash:   p.GetLedgerHash(),
-			MapType:      LedgerMapType(p.GetType()),
-			LedgerHeader: p.GetLedgerHeader(),
-			Path:         p.GetPath(),
-			Error:        ReplyError(p.GetError()),
-		}, nil
-
-	case TypeReplayDeltaReq:
-		p := protoMsg.(*proto.TMReplayDeltaRequest)
-		return &ReplayDeltaRequest{LedgerHash: p.GetLedgerHash()}, nil
-
-	case TypeReplayDeltaResponse:
-		p := protoMsg.(*proto.TMReplayDeltaResponse)
-		return &ReplayDeltaResponse{
-			LedgerHash:   p.GetLedgerHash(),
-			LedgerHeader: p.GetLedgerHeader(),
-			Transactions: p.GetTransaction(),
-			Error:        ReplyError(p.GetError()),
-		}, nil
-
-	case TypeHaveTransactions:
-		p := protoMsg.(*proto.TMHaveTransactions)
-		return &HaveTransactions{Hashes: p.GetHashes()}, nil
-
-	default:
-		return nil, fmt.Errorf("unknown message type: %d", msgType)
-	}
+	return c.decode(pmsg)
 }

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -52,6 +52,17 @@ const EvictBadDataThreshold = 25000
 // asymptotes at 800 and never crosses the threshold.
 const badDataDecayInterval = 10 * time.Second
 
+// inboundBacklogSlack lets the accept loop hold a small queue of
+// not-yet-handled inbound TCP accepts past MaxInbound — the handler
+// itself enforces canAcceptInbound, but bounding the goroutine count
+// above MaxInbound at all is the point.
+const inboundBacklogSlack = 8
+
+// acceptBackoff bounds the retry rate when listener.Accept returns a
+// non-fatal error (typically EMFILE-class). Without it the loop spins
+// at CPU speed for as long as the FD pressure persists.
+const acceptBackoff = 100 * time.Millisecond
+
 // Bad-data weights mirror rippled's Resource::Fees.cpp:26-30. They
 // scale the per-reason severity of an IncBadData call:
 //   - feeInvalidSignature (2000) — bad signature / wrong pubkey format
@@ -98,7 +109,9 @@ func BadDataWeight(reason string) int {
 		"ledger-data-state",
 		"squelch-duration",
 		"squelch-map-full",
-		"squelch-malformed-pubkey":
+		"squelch-malformed-pubkey",
+		"decompress-lz4-failed",
+		"message-too-large":
 		return weightInvalidData
 	// Malformed requests: decode failures, bad hashes, wrong-field
 	// requests. Rippled: feeMalformedRequest at PeerImp.cpp:1693 for
@@ -201,6 +214,23 @@ type Overlay struct {
 	peersMu sync.RWMutex
 	nextID  atomic.Uint64
 
+	// peerWG joins every peer.Run goroutine launched by handleInbound
+	// or Connect. Stop() blocks on it so shutdown is deterministic
+	// instead of leaking goroutines past Overlay teardown.
+	peerWG sync.WaitGroup
+
+	// inboundSem caps concurrent handleInbound goroutines so a burst
+	// of TCP accepts past MaxInbound cannot blow up goroutine fan-out
+	// while each waits its turn for peersMu in canAcceptInbound.
+	// Length = MaxInbound + inboundBacklogSlack.
+	inboundSem chan struct{}
+
+	// outboundSem caps concurrent autoconnect Connect goroutines. The
+	// MaxOutbound check inside Connect re-validates under peersMu, but
+	// without an upstream bound a slow discovery tick stacks one
+	// goroutine per candidate.
+	outboundSem chan struct{}
+
 	// relayedIndex maps suppression-hash → set of peers known to have
 	// that message. Populated as we forward a validator message (each
 	// recipient joins the set) and queried by the consensus router on
@@ -244,6 +274,14 @@ type Overlay struct {
 	// response send path (EventLedgerResponse). Separate from
 	// droppedMessages so the two traffic classes can be distinguished.
 	droppedLedgerResponses atomic.Uint64
+
+	// droppedEvents counts non-blocking sends to the internal events
+	// channel that fell through because the event loop was wedged.
+	// Surfaces back-pressure on the events fan-in (peer lifecycle +
+	// EventMessageReceived) so operators can spot a stalled handler
+	// rather than deadlocking the peer read hot path against
+	// peersMu-taking event handlers.
+	droppedEvents atomic.Uint64
 
 	// pingTimeoutDisconnects counts peers torn down because the oldest
 	// in-flight ping aged past pingTimeout. Mirrors rippled's
@@ -533,6 +571,15 @@ func New(opts ...Option) (*Overlay, error) {
 
 	events := make(chan Event, 256)
 
+	inboundCap := cfg.MaxInbound + inboundBacklogSlack
+	if inboundCap <= 0 {
+		inboundCap = inboundBacklogSlack
+	}
+	outboundCap := cfg.MaxOutbound
+	if outboundCap <= 0 {
+		outboundCap = 1
+	}
+
 	o := &Overlay{
 		cfg:            cfg,
 		identity:       identity,
@@ -545,6 +592,8 @@ func New(opts ...Option) (*Overlay, error) {
 		messages:       make(chan *InboundMessage, 256),
 		relayedIndex:   make(map[[32]byte]*relayedEntry),
 		clockForIndex:  time.Now,
+		inboundSem:     make(chan struct{}, inboundCap),
+		outboundSem:    make(chan struct{}, outboundCap),
 	}
 
 	// Wire reduce-relay callbacks. The squelch callback constructs and
@@ -636,7 +685,10 @@ func (o *Overlay) Run(ctx context.Context) error {
 	return g.Wait()
 }
 
-// Stop gracefully shuts down the overlay.
+// Stop gracefully shuts down the overlay. Blocks on peerWG so callers
+// (and the test harness) observe a fully-quiesced overlay rather than
+// racing against peer.Run goroutines still draining their read/write
+// loops after Close.
 func (o *Overlay) Stop() error {
 	if o.cancel != nil {
 		o.cancel()
@@ -656,6 +708,8 @@ func (o *Overlay) Stop() error {
 		p.Close()
 	}
 	o.peersMu.Unlock()
+
+	o.peerWG.Wait()
 
 	return nil
 }
@@ -680,7 +734,10 @@ func (o *Overlay) startListener() error {
 	return nil
 }
 
-// acceptLoop accepts incoming connections.
+// acceptLoop accepts incoming connections. A 100ms backoff on errors
+// avoids a tight retry loop under EMFILE-class storms, and inboundSem
+// caps concurrent handlers so a burst of accepts past MaxInbound
+// cannot fan goroutines out unbounded.
 func (o *Overlay) acceptLoop(ctx context.Context) error {
 	for {
 		select {
@@ -694,10 +751,35 @@ func (o *Overlay) acceptLoop(ctx context.Context) error {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			// A closed listener is terminal — exit instead of
+			// spinning the backoff. This is also the stub path under
+			// !cgo, where peertls.NewListener closes the inner
+			// listener immediately so the overlay shuts down cleanly
+			// rather than churning ErrSessionSigUnsupported.
+			if errors.Is(err, net.ErrClosed) {
+				return err
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(acceptBackoff):
+			}
 			continue
 		}
 
-		go o.handleInbound(ctx, conn)
+		select {
+		case o.inboundSem <- struct{}{}:
+		case <-ctx.Done():
+			conn.Close()
+			return ctx.Err()
+		}
+
+		o.peerWG.Add(1)
+		go func(c net.Conn) {
+			defer o.peerWG.Done()
+			defer func() { <-o.inboundSem }()
+			o.handleInbound(ctx, c)
+		}(conn)
 	}
 }
 
@@ -720,6 +802,7 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 
 	peerID := PeerID(o.nextID.Add(1))
 	peer := NewPeer(peerID, endpoint, true, o.identity, o.events)
+	peer.SetDroppedEventsCounter(&o.droppedEvents)
 	if err := peer.AcceptConnection(conn); err != nil {
 		slog.Warn("Inbound rejected: peer not in disconnected state",
 			"t", "Overlay", "remote", remoteAddr, "err", err)
@@ -737,13 +820,13 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 	if err := o.performInboundHandshake(ctx, peer, tlsConn); err != nil {
 		slog.Info("Inbound handshake failed", "t", "Overlay", "remote", remoteAddr, "err", err)
 		conn.Close()
-		o.events <- Event{
+		o.dispatchEvent(Event{
 			Type:     EventPeerFailed,
 			PeerID:   peerID,
 			Endpoint: endpoint,
 			Inbound:  true,
 			Error:    err,
-		}
+		})
 		return
 	}
 
@@ -757,7 +840,9 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 
 	o.addPeer(peer)
 
+	o.peerWG.Add(1)
 	go func() {
+		defer o.peerWG.Done()
 		err := peer.Run(ctx)
 		if err != nil {
 			slog.Info("Inbound peer run ended", "t", "Overlay", "remote", remoteAddr, "err", err)
@@ -1135,6 +1220,30 @@ func (o *Overlay) PingTimeoutDisconnects() uint64 {
 	return o.pingTimeoutDisconnects.Load()
 }
 
+// DroppedEvents returns the cumulative count of internal events
+// (peer lifecycle + EventMessageReceived) dropped because the event
+// loop fell behind. Non-zero growth means handlers attached to the
+// event loop are slow enough that the read hot path would have
+// deadlocked if events sends were blocking — investigate handler
+// latency before raising the events buffer.
+func (o *Overlay) DroppedEvents() uint64 {
+	return o.droppedEvents.Load()
+}
+
+// dispatchEvent attempts a non-blocking send to the internal events
+// channel. Both peer-originated and overlay-originated event sends
+// route through here so back-pressure shows up as a single counter
+// rather than as a deadlock between the read hot path and the event
+// loop (handlers take peersMu, which peer-side goroutines also
+// contend for).
+func (o *Overlay) dispatchEvent(evt Event) {
+	select {
+	case o.events <- evt:
+	default:
+		o.droppedEvents.Add(1)
+	}
+}
+
 func (o *Overlay) notePeerRunEnded(err error) {
 	if errors.Is(err, ErrPingTimeout) {
 		o.pingTimeoutDisconnects.Add(1)
@@ -1448,15 +1557,16 @@ func (o *Overlay) autoconnect(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		default:
-			go func(a string) {
-				if err := o.Connect(a); err != nil {
-					slog.Info("Peer connection failed", "t", "Overlay", "addr", a, "err", err)
-				} else {
-					slog.Info("Peer connected", "t", "Overlay", "addr", a)
-				}
-			}(addr)
+		case o.outboundSem <- struct{}{}:
 		}
+		go func(a string) {
+			defer func() { <-o.outboundSem }()
+			if err := o.Connect(a); err != nil {
+				slog.Info("Peer connection failed", "t", "Overlay", "addr", a, "err", err)
+			} else {
+				slog.Info("Peer connected", "t", "Overlay", "addr", a)
+			}
+		}(addr)
 	}
 }
 
@@ -1618,14 +1728,15 @@ func (o *Overlay) Connect(addr string) error {
 
 	peerID := PeerID(o.nextID.Add(1))
 	peer := NewPeer(peerID, endpoint, false, o.identity, o.events)
+	peer.SetDroppedEventsCounter(&o.droppedEvents)
 	peer.handshakeCfg = o.handshakeConfigFor()
 
-	o.events <- Event{
+	o.dispatchEvent(Event{
 		Type:     EventPeerConnecting,
 		PeerID:   peerID,
 		Endpoint: endpoint,
 		Inbound:  false,
-	}
+	})
 
 	ctx, cancel := context.WithTimeout(o.ctx, o.cfg.ConnectTimeout)
 	defer cancel()
@@ -1643,13 +1754,13 @@ func (o *Overlay) Connect(addr string) error {
 	}
 
 	if err := peer.Connect(ctx, cfg); err != nil {
-		o.events <- Event{
+		o.dispatchEvent(Event{
 			Type:     EventPeerFailed,
 			PeerID:   peerID,
 			Endpoint: endpoint,
 			Inbound:  false,
 			Error:    err,
-		}
+		})
 		return err
 	}
 
@@ -1662,7 +1773,9 @@ func (o *Overlay) Connect(addr string) error {
 
 	o.addPeer(peer)
 
+	o.peerWG.Add(1)
 	go func() {
+		defer o.peerWG.Done()
 		err := peer.Run(o.ctx)
 		if err != nil {
 			slog.Info("Peer run ended", "t", "Overlay", "addr", addr, "err", err)
@@ -2183,12 +2296,12 @@ func (o *Overlay) addPeer(peer *Peer) {
 	o.peers[peer.ID()] = peer
 	o.peersMu.Unlock()
 
-	o.events <- Event{
+	o.dispatchEvent(Event{
 		Type:     EventPeerConnected,
 		PeerID:   peer.ID(),
 		Endpoint: peer.Endpoint(),
 		Inbound:  peer.Inbound(),
-	}
+	})
 }
 
 // removePeer removes a peer from the overlay.
@@ -2199,12 +2312,12 @@ func (o *Overlay) removePeer(peerID PeerID) {
 	o.peersMu.Unlock()
 
 	if exists {
-		o.events <- Event{
+		o.dispatchEvent(Event{
 			Type:     EventPeerDisconnected,
 			PeerID:   peerID,
 			Endpoint: peer.Endpoint(),
 			Inbound:  peer.Inbound(),
-		}
+		})
 	}
 }
 

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -52,15 +52,14 @@ const EvictBadDataThreshold = 25000
 // asymptotes at 800 and never crosses the threshold.
 const badDataDecayInterval = 10 * time.Second
 
-// inboundBacklogSlack lets the accept loop hold a small queue of
-// not-yet-handled inbound TCP accepts past MaxInbound — the handler
-// itself enforces canAcceptInbound, but bounding the goroutine count
-// above MaxInbound at all is the point.
+// inboundBacklogSlack caps the accept-side goroutine count to
+// MaxInbound + slack so a burst of accepts cannot fan out unbounded;
+// canAcceptInbound is the authoritative slot gate.
 const inboundBacklogSlack = 8
 
-// acceptBackoff bounds the retry rate when listener.Accept returns a
-// non-fatal error (typically EMFILE-class). Without it the loop spins
-// at CPU speed for as long as the FD pressure persists.
+// acceptBackoff throttles the retry rate when listener.Accept returns
+// a non-fatal error (typically EMFILE-class) so the loop does not
+// spin at CPU speed under FD pressure.
 const acceptBackoff = 100 * time.Millisecond
 
 // Bad-data weights mirror rippled's Resource::Fees.cpp:26-30. They
@@ -215,20 +214,15 @@ type Overlay struct {
 	nextID  atomic.Uint64
 
 	// peerWG joins every peer.Run goroutine launched by handleInbound
-	// or Connect. Stop() blocks on it so shutdown is deterministic
-	// instead of leaking goroutines past Overlay teardown.
+	// or Connect. Stop blocks on it for deterministic shutdown.
 	peerWG sync.WaitGroup
 
-	// inboundSem caps concurrent handleInbound goroutines so a burst
-	// of TCP accepts past MaxInbound cannot blow up goroutine fan-out
-	// while each waits its turn for peersMu in canAcceptInbound.
+	// inboundSem caps concurrent handleInbound goroutines.
 	// Length = MaxInbound + inboundBacklogSlack.
 	inboundSem chan struct{}
 
-	// outboundSem caps concurrent autoconnect Connect goroutines. The
-	// MaxOutbound check inside Connect re-validates under peersMu, but
-	// without an upstream bound a slow discovery tick stacks one
-	// goroutine per candidate.
+	// outboundSem caps concurrent autoconnect Connect goroutines so
+	// a slow discovery tick cannot stack one goroutine per candidate.
 	outboundSem chan struct{}
 
 	// relayedIndex maps suppression-hash → set of peers known to have
@@ -275,12 +269,11 @@ type Overlay struct {
 	// droppedMessages so the two traffic classes can be distinguished.
 	droppedLedgerResponses atomic.Uint64
 
-	// droppedEvents counts non-blocking sends to the internal events
-	// channel that fell through because the event loop was wedged.
-	// Surfaces back-pressure on the events fan-in (peer lifecycle +
-	// EventMessageReceived) so operators can spot a stalled handler
-	// rather than deadlocking the peer read hot path against
-	// peersMu-taking event handlers.
+	// droppedEvents counts non-blocking sends to the events channel
+	// that fell through. Surfaces back-pressure on the events fan-in
+	// (peer lifecycle + EventMessageReceived) so a stalled handler
+	// shows up as a counter rather than a deadlock against peer-side
+	// goroutines that contend for peersMu.
 	droppedEvents atomic.Uint64
 
 	// pingTimeoutDisconnects counts peers torn down because the oldest
@@ -686,9 +679,8 @@ func (o *Overlay) Run(ctx context.Context) error {
 }
 
 // Stop gracefully shuts down the overlay. Blocks on peerWG so callers
-// (and the test harness) observe a fully-quiesced overlay rather than
-// racing against peer.Run goroutines still draining their read/write
-// loops after Close.
+// observe a fully-quiesced overlay rather than racing against
+// peer.Run goroutines still draining after Close.
 func (o *Overlay) Stop() error {
 	if o.cancel != nil {
 		o.cancel()
@@ -734,10 +726,9 @@ func (o *Overlay) startListener() error {
 	return nil
 }
 
-// acceptLoop accepts incoming connections. A 100ms backoff on errors
-// avoids a tight retry loop under EMFILE-class storms, and inboundSem
-// caps concurrent handlers so a burst of accepts past MaxInbound
-// cannot fan goroutines out unbounded.
+// acceptLoop accepts incoming connections. acceptBackoff throttles
+// retries under EMFILE-class errors; inboundSem caps the handler
+// goroutine fan-out.
 func (o *Overlay) acceptLoop(ctx context.Context) error {
 	for {
 		select {
@@ -752,10 +743,8 @@ func (o *Overlay) acceptLoop(ctx context.Context) error {
 				return ctx.Err()
 			}
 			// A closed listener is terminal — exit instead of
-			// spinning the backoff. This is also the stub path under
-			// !cgo, where peertls.NewListener closes the inner
-			// listener immediately so the overlay shuts down cleanly
-			// rather than churning ErrSessionSigUnsupported.
+			// spinning the backoff. Also the !cgo peertls stub path,
+			// which closes the inner listener at NewListener.
 			if errors.Is(err, net.ErrClosed) {
 				return err
 			}
@@ -1220,22 +1209,18 @@ func (o *Overlay) PingTimeoutDisconnects() uint64 {
 	return o.pingTimeoutDisconnects.Load()
 }
 
-// DroppedEvents returns the cumulative count of internal events
-// (peer lifecycle + EventMessageReceived) dropped because the event
-// loop fell behind. Non-zero growth means handlers attached to the
-// event loop are slow enough that the read hot path would have
-// deadlocked if events sends were blocking — investigate handler
-// latency before raising the events buffer.
+// DroppedEvents returns the cumulative count of events dropped
+// because the event loop fell behind. Non-zero growth means handlers
+// are slow enough that blocking sends would have deadlocked the read
+// hot path — investigate handler latency before raising the buffer.
 func (o *Overlay) DroppedEvents() uint64 {
 	return o.droppedEvents.Load()
 }
 
-// dispatchEvent attempts a non-blocking send to the internal events
-// channel. Both peer-originated and overlay-originated event sends
-// route through here so back-pressure shows up as a single counter
-// rather than as a deadlock between the read hot path and the event
-// loop (handlers take peersMu, which peer-side goroutines also
-// contend for).
+// dispatchEvent attempts a non-blocking send to the events channel.
+// Peer- and overlay-originated sends route through here so
+// back-pressure surfaces as a counter rather than a deadlock against
+// peersMu-taking handlers.
 func (o *Overlay) dispatchEvent(evt Event) {
 	select {
 	case o.events <- evt:

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -79,6 +79,20 @@ type Peer struct {
 	send   chan []byte
 	events chan<- Event
 
+	// droppedEvents counts non-blocking event sends that hit the
+	// default branch because the overlay event loop fell behind. Set
+	// by Overlay.addPeer; nil in tests that don't wire it. Mirrors the
+	// shape of Overlay.droppedMessages so back-pressure on the events
+	// channel is observable instead of silently deadlocking the read
+	// hot path.
+	droppedEvents *atomic.Uint64
+
+	// runWG joins read/write/ping goroutines so callers of Run (and
+	// through them, Overlay.removePeer bookkeeping) observe a
+	// fully-quiesced peer rather than racing against goroutines parked
+	// on a slow OS-level close.
+	runWG sync.WaitGroup
+
 	score   *PeerScore
 	traffic *TrafficCounter
 	metrics *peerMetrics
@@ -102,6 +116,12 @@ type Peer struct {
 	// Consecutive ErrSendBufferFull count; close at sendqIntervals.
 	// PeerImp.cpp:705-708 "Large send queue".
 	largeSendQ atomic.Uint32
+
+	// consecutiveDecompressFailures tracks back-to-back LZ4 decompress
+	// errors so a peer that's spraying garbage compressed frames gets
+	// closed at maxConsecutiveDecompressFailures rather than wasting
+	// the read loop on a frame-by-frame bad-data charge.
+	consecutiveDecompressFailures atomic.Uint32
 
 	serverDomain      string
 	networkID         string
@@ -163,6 +183,31 @@ func NewPeer(id PeerID, endpoint Endpoint, inbound bool, identity *Identity, eve
 		pingsInFlight: make(map[uint32]time.Time),
 		createdAt:     time.Now(),
 		closeCh:       make(chan struct{}),
+	}
+}
+
+// SetDroppedEventsCounter wires a counter that dispatchEvent bumps on
+// each non-blocking events send that falls through. Called by
+// Overlay.addPeer; safe to call once before the peer's Run goroutines
+// start.
+func (p *Peer) SetDroppedEventsCounter(c *atomic.Uint64) {
+	p.droppedEvents = c
+}
+
+// dispatchEvent attempts a non-blocking send to the events channel. A
+// full channel (overlay event loop wedged) bumps droppedEvents instead
+// of pinning the caller — the read hot path and Close path must never
+// block on the event loop, which itself takes overlay-level locks.
+func (p *Peer) dispatchEvent(evt Event) {
+	if p.events == nil {
+		return
+	}
+	select {
+	case p.events <- evt:
+	default:
+		if p.droppedEvents != nil {
+			p.droppedEvents.Add(1)
+		}
 	}
 }
 
@@ -580,7 +625,13 @@ func tcpRemoteIP(conn net.Conn) net.IP {
 	return addr.IP
 }
 
-// Run starts read/write/ping loops; returns when any of them errors.
+// Run starts read/write/ping loops and blocks until all three have
+// returned. The first loop to error (or context cancellation) triggers
+// Close, which fans the shutdown signal out to the other two via the
+// closed conn and closeCh. runWG.Wait then ensures callers observe a
+// fully-quiesced peer before they proceed to removePeer bookkeeping —
+// otherwise a slow OS-level close can leave the read or write
+// goroutine alive past the overlay-level cleanup.
 func (p *Peer) Run(ctx context.Context) error {
 	p.mu.RLock()
 	if p.state != PeerStateConnected {
@@ -591,26 +642,32 @@ func (p *Peer) Run(ctx context.Context) error {
 
 	errCh := make(chan error, 3)
 
+	p.runWG.Add(3)
 	go func() {
+		defer p.runWG.Done()
 		errCh <- p.readLoop(ctx)
 	}()
 
 	go func() {
+		defer p.runWG.Done()
 		errCh <- p.writeLoop(ctx)
 	}()
 
 	go func() {
+		defer p.runWG.Done()
 		errCh <- p.pingLoop(ctx)
 	}()
 
+	var runErr error
 	select {
 	case <-ctx.Done():
-		p.Close()
-		return ctx.Err()
+		runErr = ctx.Err()
 	case err := <-errCh:
-		p.Close()
-		return err
+		runErr = err
 	}
+	p.Close()
+	p.runWG.Wait()
+	return runErr
 }
 
 func (p *Peer) readLoop(ctx context.Context) error {
@@ -625,16 +682,35 @@ func (p *Peer) readLoop(ctx context.Context) error {
 
 		p.mu.RLock()
 		reader := p.bufReader
+		conn := p.conn
 		p.mu.RUnlock()
 
 		if reader == nil {
 			return ErrConnectionClosed
 		}
 
+		// Refresh the read deadline each iteration so a peer that goes
+		// silent post-handshake cannot park us in io.ReadFull forever.
+		if conn != nil {
+			_ = conn.SetReadDeadline(time.Now().Add(readIdleDeadline))
+		}
+
 		header, payload, err := ReadMessage(reader)
 		if err != nil {
 			if p.closed.Load() {
 				return nil
+			}
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				return ErrReadIdle
+			}
+			// An over-budget per-type size claim is a protocol-level
+			// abuse signal — charge bad-data so a peer spraying
+			// 16MB-claimed Ping headers actually evicts via the
+			// reputation system. Other ReadMessage errors (truncated
+			// frames, unknown compression) tear the peer down
+			// immediately because the framing is unrecoverable.
+			if errors.Is(err, message.ErrMessageTooLarge) {
+				p.IncBadData("message-too-large")
 			}
 			return err
 		}
@@ -653,20 +729,24 @@ func (p *Peer) readLoop(ctx context.Context) error {
 		if header.Compressed {
 			payload, err = DecompressLZ4(payload, int(header.UncompressedSize))
 			if err != nil {
+				p.IncBadData("decompress-lz4-failed")
+				if p.consecutiveDecompressFailures.Add(1) >= maxConsecutiveDecompressFailures {
+					return fmt.Errorf("decompress-lz4 failed %d times in a row: %w",
+						maxConsecutiveDecompressFailures, err)
+				}
 				continue
 			}
+			p.consecutiveDecompressFailures.Store(0)
 		}
 
 		p.traffic.AddCount(CategorizeMessage(uint16(header.MessageType)), true, len(payload))
 
-		if p.events != nil {
-			p.events <- Event{
-				Type:        EventMessageReceived,
-				PeerID:      p.id,
-				MessageType: uint16(header.MessageType),
-				Payload:     payload,
-			}
-		}
+		p.dispatchEvent(Event{
+			Type:        EventMessageReceived,
+			PeerID:      p.id,
+			MessageType: uint16(header.MessageType),
+			Payload:     payload,
+		})
 	}
 }
 
@@ -686,8 +766,16 @@ func (p *Peer) writeLoop(ctx context.Context) error {
 				return ErrConnectionClosed
 			}
 
+			// Cap each Write so a peer with a never-draining kernel
+			// send buffer (half-open TCP) cannot block the writer
+			// indefinitely. The write goroutine is single-threaded, so
+			// a short deadline is safe.
+			_ = conn.SetWriteDeadline(time.Now().Add(writeIdleDeadline))
 			n, err := conn.Write(data)
 			if err != nil {
+				if ne, ok := err.(net.Error); ok && ne.Timeout() {
+					return ErrWriteIdle
+				}
 				return err
 			}
 			// Mirrors rippled metrics_.sent.add_message at
@@ -792,6 +880,26 @@ const (
 	pingsInFlightCap = 16
 	// Tuning::sendqIntervals (PeerImp.cpp:705 + Tuning.h).
 	sendqIntervals = 4
+	// maxConsecutiveDecompressFailures bounds how many bad LZ4 frames
+	// the read loop will tolerate from one peer before tearing the
+	// connection down. Each failure also charges bad-data via the
+	// reputation system, so a peer that mixes a single garbage frame
+	// into otherwise-honest traffic decays the counter via the next
+	// successful decompress rather than being evicted.
+	maxConsecutiveDecompressFailures = 4
+	// readIdleDeadline bounds an idle TLS read so a peer that completes
+	// the handshake and then goes silent cannot pin a slot indefinitely
+	// (e.g. on a host where the OS-level conn.Close hasn't unblocked
+	// io.ReadFull yet). Set slightly above pingTimeout so the existing
+	// ErrPingTimeout disconnect path stays the primary signal; the
+	// deadline is the belt-and-braces fallback.
+	readIdleDeadline = pingTimeout + 5*time.Second
+	// writeIdleDeadline bounds a single conn.Write. A peer whose kernel
+	// send buffer never drains (half-open TCP) would otherwise block
+	// writeLoop forever — ErrLargeSendQueue only fires when Send()
+	// returns ErrSendBufferFull, which requires the write goroutine to
+	// have already returned to the select.
+	writeIdleDeadline = 10 * time.Second
 )
 
 func (p *Peer) staleInFlightPing(now time.Time, threshold time.Duration) (seq uint32, age time.Duration, ok bool) {
@@ -1047,13 +1155,11 @@ func (p *Peer) Close() error {
 
 	p.setState(PeerStateDisconnected)
 
-	if p.events != nil {
-		p.events <- Event{
-			Type:     EventPeerDisconnected,
-			PeerID:   p.id,
-			Endpoint: p.endpoint,
-		}
-	}
+	p.dispatchEvent(Event{
+		Type:     EventPeerDisconnected,
+		PeerID:   p.id,
+		Endpoint: p.endpoint,
+	})
 
 	return err
 }

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -79,18 +79,15 @@ type Peer struct {
 	send   chan []byte
 	events chan<- Event
 
-	// droppedEvents counts non-blocking event sends that hit the
-	// default branch because the overlay event loop fell behind. Set
-	// by Overlay.addPeer; nil in tests that don't wire it. Mirrors the
-	// shape of Overlay.droppedMessages so back-pressure on the events
-	// channel is observable instead of silently deadlocking the read
-	// hot path.
+	// droppedEvents counts non-blocking event sends that fell through
+	// because the overlay event loop was wedged. nil until wired by
+	// Overlay; back-pressure must surface as a counter rather than
+	// deadlocking the read hot path.
 	droppedEvents *atomic.Uint64
 
-	// runWG joins read/write/ping goroutines so callers of Run (and
-	// through them, Overlay.removePeer bookkeeping) observe a
-	// fully-quiesced peer rather than racing against goroutines parked
-	// on a slow OS-level close.
+	// runWG joins read/write/ping goroutines so callers of Run observe
+	// a fully-quiesced peer rather than racing against goroutines
+	// parked on a slow OS-level close.
 	runWG sync.WaitGroup
 
 	score   *PeerScore
@@ -117,10 +114,8 @@ type Peer struct {
 	// PeerImp.cpp:705-708 "Large send queue".
 	largeSendQ atomic.Uint32
 
-	// consecutiveDecompressFailures tracks back-to-back LZ4 decompress
-	// errors so a peer that's spraying garbage compressed frames gets
-	// closed at maxConsecutiveDecompressFailures rather than wasting
-	// the read loop on a frame-by-frame bad-data charge.
+	// consecutiveDecompressFailures: back-to-back LZ4 errors; closed
+	// at maxConsecutiveDecompressFailures.
 	consecutiveDecompressFailures atomic.Uint32
 
 	serverDomain      string
@@ -186,18 +181,15 @@ func NewPeer(id PeerID, endpoint Endpoint, inbound bool, identity *Identity, eve
 	}
 }
 
-// SetDroppedEventsCounter wires a counter that dispatchEvent bumps on
-// each non-blocking events send that falls through. Called by
-// Overlay.addPeer; safe to call once before the peer's Run goroutines
-// start.
+// SetDroppedEventsCounter wires the counter dispatchEvent bumps on
+// non-blocking sends that fall through. Safe to call once before Run.
 func (p *Peer) SetDroppedEventsCounter(c *atomic.Uint64) {
 	p.droppedEvents = c
 }
 
-// dispatchEvent attempts a non-blocking send to the events channel. A
-// full channel (overlay event loop wedged) bumps droppedEvents instead
-// of pinning the caller — the read hot path and Close path must never
-// block on the event loop, which itself takes overlay-level locks.
+// dispatchEvent attempts a non-blocking send to the events channel.
+// The read hot path and Close path must never block on the event
+// loop, which itself takes overlay-level locks.
 func (p *Peer) dispatchEvent(evt Event) {
 	if p.events == nil {
 		return
@@ -626,12 +618,11 @@ func tcpRemoteIP(conn net.Conn) net.IP {
 }
 
 // Run starts read/write/ping loops and blocks until all three have
-// returned. The first loop to error (or context cancellation) triggers
-// Close, which fans the shutdown signal out to the other two via the
-// closed conn and closeCh. runWG.Wait then ensures callers observe a
-// fully-quiesced peer before they proceed to removePeer bookkeeping —
-// otherwise a slow OS-level close can leave the read or write
-// goroutine alive past the overlay-level cleanup.
+// returned. The first loop to error (or ctx cancellation) triggers
+// Close, which fans the shutdown out to the others via the closed
+// conn and closeCh; runWG.Wait ensures a fully-quiesced peer before
+// return so a slow OS-level close cannot leak goroutines past the
+// caller's cleanup.
 func (p *Peer) Run(ctx context.Context) error {
 	p.mu.RLock()
 	if p.state != PeerStateConnected {
@@ -703,12 +694,9 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			if ne, ok := err.(net.Error); ok && ne.Timeout() {
 				return ErrReadIdle
 			}
-			// An over-budget per-type size claim is a protocol-level
-			// abuse signal — charge bad-data so a peer spraying
-			// 16MB-claimed Ping headers actually evicts via the
-			// reputation system. Other ReadMessage errors (truncated
-			// frames, unknown compression) tear the peer down
-			// immediately because the framing is unrecoverable.
+			// Over-budget size claim is protocol abuse — charge so the
+			// reputation system evicts. Other framing errors are
+			// unrecoverable and tear the peer down directly.
 			if errors.Is(err, message.ErrMessageTooLarge) {
 				p.IncBadData("message-too-large")
 			}
@@ -766,10 +754,8 @@ func (p *Peer) writeLoop(ctx context.Context) error {
 				return ErrConnectionClosed
 			}
 
-			// Cap each Write so a peer with a never-draining kernel
-			// send buffer (half-open TCP) cannot block the writer
-			// indefinitely. The write goroutine is single-threaded, so
-			// a short deadline is safe.
+			// Cap each Write so a half-open TCP peer with a
+			// never-draining kernel send buffer cannot pin the writer.
 			_ = conn.SetWriteDeadline(time.Now().Add(writeIdleDeadline))
 			n, err := conn.Write(data)
 			if err != nil {
@@ -880,25 +866,17 @@ const (
 	pingsInFlightCap = 16
 	// Tuning::sendqIntervals (PeerImp.cpp:705 + Tuning.h).
 	sendqIntervals = 4
-	// maxConsecutiveDecompressFailures bounds how many bad LZ4 frames
-	// the read loop will tolerate from one peer before tearing the
-	// connection down. Each failure also charges bad-data via the
-	// reputation system, so a peer that mixes a single garbage frame
-	// into otherwise-honest traffic decays the counter via the next
-	// successful decompress rather than being evicted.
+	// maxConsecutiveDecompressFailures: close after this many
+	// back-to-back LZ4 errors. A single bad frame still charges
+	// bad-data but resets on the next successful decompress.
 	maxConsecutiveDecompressFailures = 4
-	// readIdleDeadline bounds an idle TLS read so a peer that completes
-	// the handshake and then goes silent cannot pin a slot indefinitely
-	// (e.g. on a host where the OS-level conn.Close hasn't unblocked
-	// io.ReadFull yet). Set slightly above pingTimeout so the existing
-	// ErrPingTimeout disconnect path stays the primary signal; the
-	// deadline is the belt-and-braces fallback.
+	// readIdleDeadline: belt-and-braces backstop to ErrPingTimeout for
+	// a peer that completes the handshake then goes silent. Set above
+	// pingTimeout so the existing disconnect path stays primary.
 	readIdleDeadline = pingTimeout + 5*time.Second
-	// writeIdleDeadline bounds a single conn.Write. A peer whose kernel
-	// send buffer never drains (half-open TCP) would otherwise block
-	// writeLoop forever — ErrLargeSendQueue only fires when Send()
-	// returns ErrSendBufferFull, which requires the write goroutine to
-	// have already returned to the select.
+	// writeIdleDeadline bounds a single conn.Write so a half-open TCP
+	// peer with a never-draining kernel send buffer cannot pin
+	// writeLoop forever.
 	writeIdleDeadline = 10 * time.Second
 )
 

--- a/internal/peermanagement/peer_dispatch_test.go
+++ b/internal/peermanagement/peer_dispatch_test.go
@@ -1,0 +1,101 @@
+package peermanagement
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPeer_DispatchEvent_NonBlocking confirms the helper used by both
+// readLoop and Close never blocks when the events channel is full and
+// instead bumps the dropped counter. This is the contract that
+// prevents the read hot path from deadlocking against an event loop
+// that is waiting on peersMu.
+func TestPeer_DispatchEvent_NonBlocking(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	events := make(chan Event, 1)
+	peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, events)
+	var dropped atomic.Uint64
+	peer.SetDroppedEventsCounter(&dropped)
+
+	peer.dispatchEvent(Event{Type: EventMessageReceived, PeerID: 1})
+	assert.Equal(t, uint64(0), dropped.Load())
+
+	for i := 0; i < 5; i++ {
+		done := make(chan struct{})
+		go func() {
+			peer.dispatchEvent(Event{Type: EventMessageReceived, PeerID: 1})
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatalf("dispatchEvent blocked on full channel (iter %d)", i)
+		}
+	}
+	assert.Equal(t, uint64(5), dropped.Load())
+}
+
+// TestPeer_DispatchEvent_NilCounter ensures a peer with no wired
+// counter (e.g., constructed in tests outside Overlay) still does not
+// block on a full channel — only the counter side-effect is suppressed.
+func TestPeer_DispatchEvent_NilCounter(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	events := make(chan Event, 1)
+	peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, events)
+	peer.dispatchEvent(Event{Type: EventMessageReceived, PeerID: 1})
+
+	done := make(chan struct{})
+	go func() {
+		peer.dispatchEvent(Event{Type: EventMessageReceived, PeerID: 1})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("dispatchEvent blocked with nil counter on full channel")
+	}
+}
+
+// TestPeer_DispatchEvent_NilChannel ensures a peer constructed with no
+// events channel at all silently discards events instead of panicking.
+func TestPeer_DispatchEvent_NilChannel(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	peer.dispatchEvent(Event{Type: EventMessageReceived, PeerID: 1})
+}
+
+// TestOverlay_DispatchEvent_NonBlocking confirms the overlay-side
+// helper used by addPeer/removePeer/Connect/handleInbound is
+// non-blocking and surfaces drops via DroppedEvents.
+func TestOverlay_DispatchEvent_NonBlocking(t *testing.T) {
+	o := &Overlay{
+		events: make(chan Event, 1),
+	}
+
+	o.dispatchEvent(Event{Type: EventPeerConnected, PeerID: 1})
+	assert.Equal(t, uint64(0), o.DroppedEvents())
+
+	for i := 0; i < 3; i++ {
+		done := make(chan struct{})
+		go func() {
+			o.dispatchEvent(Event{Type: EventPeerConnected, PeerID: 2})
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatalf("Overlay.dispatchEvent blocked on full channel (iter %d)", i)
+		}
+	}
+	assert.Equal(t, uint64(3), o.DroppedEvents())
+}

--- a/internal/peermanagement/peer_dispatch_test.go
+++ b/internal/peermanagement/peer_dispatch_test.go
@@ -9,11 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPeer_DispatchEvent_NonBlocking confirms the helper used by both
-// readLoop and Close never blocks when the events channel is full and
-// instead bumps the dropped counter. This is the contract that
-// prevents the read hot path from deadlocking against an event loop
-// that is waiting on peersMu.
+// dispatchEvent must never block — read hot path and Close path
+// would otherwise deadlock against an event loop holding peersMu.
 func TestPeer_DispatchEvent_NonBlocking(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
@@ -41,9 +38,7 @@ func TestPeer_DispatchEvent_NonBlocking(t *testing.T) {
 	assert.Equal(t, uint64(5), dropped.Load())
 }
 
-// TestPeer_DispatchEvent_NilCounter ensures a peer with no wired
-// counter (e.g., constructed in tests outside Overlay) still does not
-// block on a full channel — only the counter side-effect is suppressed.
+// Nil counter must still not block on a full channel.
 func TestPeer_DispatchEvent_NilCounter(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
@@ -64,8 +59,7 @@ func TestPeer_DispatchEvent_NilCounter(t *testing.T) {
 	}
 }
 
-// TestPeer_DispatchEvent_NilChannel ensures a peer constructed with no
-// events channel at all silently discards events instead of panicking.
+// Nil events channel must silently discard rather than panic.
 func TestPeer_DispatchEvent_NilChannel(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
@@ -74,9 +68,8 @@ func TestPeer_DispatchEvent_NilChannel(t *testing.T) {
 	peer.dispatchEvent(Event{Type: EventMessageReceived, PeerID: 1})
 }
 
-// TestOverlay_DispatchEvent_NonBlocking confirms the overlay-side
-// helper used by addPeer/removePeer/Connect/handleInbound is
-// non-blocking and surfaces drops via DroppedEvents.
+// Overlay-side dispatchEvent is non-blocking and surfaces drops via
+// DroppedEvents.
 func TestOverlay_DispatchEvent_NonBlocking(t *testing.T) {
 	o := &Overlay{
 		events: make(chan Event, 1),

--- a/internal/peermanagement/peertls/shim/shim.go
+++ b/internal/peermanagement/peertls/shim/shim.go
@@ -87,8 +87,13 @@ func NewCtx(isServer bool) (*Ctx, error) {
 	if isServer {
 		flag = 1
 	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	p := C.peertls_ctx_new(flag)
 	if p == nil {
+		if detail := lastErrorLocked(); detail != "" {
+			return nil, fmt.Errorf("peertls/shim: peertls_ctx_new failed: %s", detail)
+		}
 		return nil, errors.New("peertls/shim: peertls_ctx_new failed")
 	}
 	return &Ctx{p: p}, nil
@@ -98,6 +103,8 @@ func (c *Ctx) Free() {
 	if c == nil || c.p == nil {
 		return
 	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	C.peertls_ctx_free(c.p)
 	c.p = nil
 }
@@ -122,8 +129,13 @@ func (c *Ctx) UseCertPEM(cert, key []byte) error {
 // NewSSL creates an SSL bound to a fresh BIO_pair under the context.
 // Free with SSL.Free; that releases the BIO too.
 func (c *Ctx) NewSSL() (*SSL, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	p := C.peertls_new(c.p)
 	if p == nil {
+		if detail := lastErrorLocked(); detail != "" {
+			return nil, fmt.Errorf("peertls/shim: peertls_new failed: %s", detail)
+		}
 		return nil, errors.New("peertls/shim: peertls_new failed")
 	}
 	return &SSL{p: p}, nil
@@ -133,6 +145,8 @@ func (s *SSL) Free() {
 	if s == nil || s.p == nil {
 		return
 	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	C.peertls_free(s.p)
 	s.p = nil
 }

--- a/internal/peermanagement/peertls/tls_openssl.go
+++ b/internal/peermanagement/peertls/tls_openssl.go
@@ -20,6 +20,32 @@ const (
 	pumpBufSize     = 16 * 1024 // max TLS record size
 )
 
+// pumpBufPool recycles 16 KiB pump buffers used by pumpInboundLocked
+// and drainBIOLocked. Both sites previously made([]byte, pumpBufSize)
+// on every call; under sustained traffic that's 16 KiB of GC pressure
+// per record pumped in either direction.
+var pumpBufPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, pumpBufSize)
+		return &buf
+	},
+}
+
+func getPumpBuf() []byte {
+	return *(pumpBufPool.Get().(*[]byte))
+}
+
+func putPumpBuf(buf []byte) {
+	// Defensive: only return the originally-sized buffer to the pool.
+	// A caller that grew the slice would otherwise grow the pool's
+	// memory footprint silently.
+	if cap(buf) != pumpBufSize {
+		return
+	}
+	buf = buf[:pumpBufSize]
+	pumpBufPool.Put(&buf)
+}
+
 func Client(inner net.Conn, cfg *Config) (PeerConn, error) {
 	return newConn(inner, cfg, false)
 }
@@ -180,7 +206,8 @@ func (c *conn) pumpInboundLocked() error {
 		return c.bioWriteAllLocked()
 	}
 
-	buf := make([]byte, pumpBufSize)
+	buf := getPumpBuf()
+	defer putPumpBuf(buf)
 	n, err := c.inner.Read(buf)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
@@ -203,6 +230,9 @@ func (c *conn) pumpInboundLocked() error {
 		return werr
 	}
 	if w < n {
+		// pendingIn must NOT alias the pooled buffer — the buffer
+		// returns to the pool the moment this function exits, and a
+		// later pump call would race against the prior pendingIn read.
 		c.pendingIn = append(c.pendingIn[:0], buf[w:n]...)
 	}
 	return nil
@@ -222,10 +252,14 @@ func (c *conn) bioWriteAllLocked() error {
 	return nil
 }
 
-// drainBIOLocked drains pending BIO output. Caller holds sslMu.
+// drainBIOLocked drains pending BIO output. Caller holds sslMu. The
+// returned slice is freshly allocated (callers persist or write it
+// to the wire) but the per-read scratch buffer comes from pumpBufPool
+// to avoid a 16 KiB allocation per BIO read.
 func (c *conn) drainBIOLocked() []byte {
 	out := make([]byte, 0, pumpBufSize)
-	buf := make([]byte, pumpBufSize)
+	buf := getPumpBuf()
+	defer putPumpBuf(buf)
 	for {
 		n, err := c.ssl.BIORead(buf)
 		if err != nil || n == 0 {

--- a/internal/peermanagement/peertls/tls_openssl.go
+++ b/internal/peermanagement/peertls/tls_openssl.go
@@ -20,10 +20,9 @@ const (
 	pumpBufSize     = 16 * 1024 // max TLS record size
 )
 
-// pumpBufPool recycles 16 KiB pump buffers used by pumpInboundLocked
-// and drainBIOLocked. Both sites previously made([]byte, pumpBufSize)
-// on every call; under sustained traffic that's 16 KiB of GC pressure
-// per record pumped in either direction.
+// pumpBufPool recycles 16 KiB scratch buffers for pumpInboundLocked
+// and drainBIOLocked — avoids a 16 KiB allocation per record pumped
+// under sustained traffic.
 var pumpBufPool = sync.Pool{
 	New: func() any {
 		buf := make([]byte, pumpBufSize)
@@ -252,10 +251,9 @@ func (c *conn) bioWriteAllLocked() error {
 	return nil
 }
 
-// drainBIOLocked drains pending BIO output. Caller holds sslMu. The
-// returned slice is freshly allocated (callers persist or write it
-// to the wire) but the per-read scratch buffer comes from pumpBufPool
-// to avoid a 16 KiB allocation per BIO read.
+// drainBIOLocked drains pending BIO output. Caller holds sslMu.
+// The returned slice is freshly allocated; the per-read scratch
+// buffer comes from pumpBufPool.
 func (c *conn) drainBIOLocked() []byte {
 	out := make([]byte, 0, pumpBufSize)
 	buf := getPumpBuf()

--- a/internal/peermanagement/peertls/tls_stub.go
+++ b/internal/peermanagement/peertls/tls_stub.go
@@ -1,16 +1,12 @@
 //go:build !cgo
 
 // Package peertls provides the XRPL session-signature TLS wrapper used
-// by the peer overlay. The XRPL handshake binds the session's TLS
-// Finished bytes into a peer-protocol signature; the only available
+// by the peer overlay. The handshake binds the session's TLS Finished
+// bytes into a peer-protocol signature; the only available
 // implementation is the OpenSSL shim under the cgo build tag.
 //
-// The !cgo file you are reading is a fail-loud stub. NewListener and
-// Client both return ErrSessionSigUnsupported, and the stub listener
-// closes its inner net.Listener immediately so callers that loop on
-// Accept get net.ErrClosed on the first iteration instead of spinning
-// on ErrSessionSigUnsupported forever. A production build MUST enable
-// cgo and link OpenSSL (see goXRPL/justfile: `just build`).
+// This !cgo file is a fail-loud stub: a production build MUST enable
+// cgo and link OpenSSL.
 package peertls
 
 import (
@@ -26,10 +22,7 @@ func Client(_ net.Conn, _ *Config) (PeerConn, error) {
 
 // NewListener under !cgo logs a hard error and closes the inner
 // listener so the overlay's acceptLoop sees net.ErrClosed on the very
-// first Accept. Without the immediate close, the stub previously
-// returned ErrSessionSigUnsupported on every Accept and the loop
-// retried forever (the audit at #434 flagged this as the "stub
-// spinning Accept" issue).
+// first Accept rather than spinning on ErrSessionSigUnsupported.
 func NewListener(inner net.Listener, _ *Config) net.Listener {
 	slog.Error("peertls: NewListener called in !cgo build; XRPL peer protocol requires the cgo OpenSSL shim — closing listener",
 		"t", "peertls/stub", "addr", inner.Addr())
@@ -41,10 +34,6 @@ type stubListener struct{ inner net.Listener }
 
 var _ net.Listener = (*stubListener)(nil)
 
-// Accept returns whatever the (already-closed) inner listener
-// returns, which on every supported platform is a wrapped
-// net.ErrClosed. Callers that handle net.ErrClosed (overlay.acceptLoop
-// does) break out of the accept loop on the first try.
 func (s *stubListener) Accept() (net.Conn, error) {
 	c, err := s.inner.Accept()
 	if err != nil {

--- a/internal/peermanagement/peertls/tls_stub.go
+++ b/internal/peermanagement/peertls/tls_stub.go
@@ -1,9 +1,21 @@
 //go:build !cgo
 
+// Package peertls provides the XRPL session-signature TLS wrapper used
+// by the peer overlay. The XRPL handshake binds the session's TLS
+// Finished bytes into a peer-protocol signature; the only available
+// implementation is the OpenSSL shim under the cgo build tag.
+//
+// The !cgo file you are reading is a fail-loud stub. NewListener and
+// Client both return ErrSessionSigUnsupported, and the stub listener
+// closes its inner net.Listener immediately so callers that loop on
+// Accept get net.ErrClosed on the first iteration instead of spinning
+// on ErrSessionSigUnsupported forever. A production build MUST enable
+// cgo and link OpenSSL (see goXRPL/justfile: `just build`).
 package peertls
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"time"
 )
@@ -12,7 +24,16 @@ func Client(_ net.Conn, _ *Config) (PeerConn, error) {
 	return nil, ErrSessionSigUnsupported
 }
 
+// NewListener under !cgo logs a hard error and closes the inner
+// listener so the overlay's acceptLoop sees net.ErrClosed on the very
+// first Accept. Without the immediate close, the stub previously
+// returned ErrSessionSigUnsupported on every Accept and the loop
+// retried forever (the audit at #434 flagged this as the "stub
+// spinning Accept" issue).
 func NewListener(inner net.Listener, _ *Config) net.Listener {
+	slog.Error("peertls: NewListener called in !cgo build; XRPL peer protocol requires the cgo OpenSSL shim — closing listener",
+		"t", "peertls/stub", "addr", inner.Addr())
+	_ = inner.Close()
 	return &stubListener{inner: inner}
 }
 
@@ -20,9 +41,21 @@ type stubListener struct{ inner net.Listener }
 
 var _ net.Listener = (*stubListener)(nil)
 
-func (s *stubListener) Accept() (net.Conn, error) { return nil, ErrSessionSigUnsupported }
-func (s *stubListener) Close() error              { return s.inner.Close() }
-func (s *stubListener) Addr() net.Addr            { return s.inner.Addr() }
+// Accept returns whatever the (already-closed) inner listener
+// returns, which on every supported platform is a wrapped
+// net.ErrClosed. Callers that handle net.ErrClosed (overlay.acceptLoop
+// does) break out of the accept loop on the first try.
+func (s *stubListener) Accept() (net.Conn, error) {
+	c, err := s.inner.Accept()
+	if err != nil {
+		return nil, err
+	}
+	_ = c.Close()
+	return nil, ErrSessionSigUnsupported
+}
+
+func (s *stubListener) Close() error   { return s.inner.Close() }
+func (s *stubListener) Addr() net.Addr { return s.inner.Addr() }
 
 type stubConn struct{}
 


### PR DESCRIPTION
## Summary

Addresses every item from the #434 peer-management / manifest audit in a single PR.

### Peer I/O loops (`internal/peermanagement/peer.go`)
- **WaitGroup-joined Run** — read/write/ping goroutines all unwind before `Run` returns, killing the leak window past `removePeer`.
- **`readLoop` SetReadDeadline** ≈ `pingTimeout + 5s`, surfacing as `ErrReadIdle`.
- **`writeLoop` SetWriteDeadline** = 10s, surfacing as `ErrWriteIdle`.
- **Non-blocking event sends** — `Peer.dispatchEvent` / `Overlay.dispatchEvent` use `select`/`default` and bump `droppedEvents` counters; `Overlay.DroppedEvents()` exposes the counter. Eliminates the deadlock shape against the event loop.
- **DecompressLZ4 / per-type ReadMessage rejections charge bad-data** (new reasons: `decompress-lz4-failed`, `message-too-large`); 4 consecutive decompress failures close the peer.

### Overlay lifecycle + back-pressure (`internal/peermanagement/overlay.go`)
- **`peerWG`** joins every `peer.Run` spawned by `handleInbound` / `Connect`; `Stop` blocks on it.
- **`acceptLoop`** bounded by `inboundSem` (`MaxInbound + 8`) with a 100ms backoff on Accept errors; bails on `net.ErrClosed` so the `!cgo` stub path terminates cleanly.
- **`autoconnect`** bounded by `outboundSem` (`MaxOutbound`).

### Message codec (`internal/peermanagement/message/codec.go`, `serialize_proto.go`)
- **Per-MessageType payload-size cap** (`smallMsgMax` / `mediumMsgMax` / `largeMsgMax`) applied in `ReadMessage` BEFORE the `make([]byte, payloadSize)`. Compressed `UncompressedSize` is capped too.
- **Registry refactor** — `serialize_proto.go` collapses three parallel type-switches into a single `msgCodec` registry keyed by `MessageType`. Adding a type now requires exactly one map entry.

### Manifest (`internal/manifest/manifest.go`, `cache.go`)
- **`Verify` decodes once** — signing preimage and signature lookup share the decoded map (previously decoded twice per call under the cache write lock).
- **Cache split lock** — `c.mu` (RWMutex over the maps) + `c.applyMu` (serializer for verify-then-mutate). `GetMasterKey` / `GetSigningKey` lookups now proceed unblocked through signature verification.

### peertls (`shim/shim.go`, `tls_openssl.go`, `tls_stub.go`)
- **`shim` `LockOSThread`** wraps `NewCtx`, `NewSSL`, `Ctx.Free`, `SSL.Free`; error paths surface OpenSSL's thread-local error queue.
- **`pumpBufPool`** recycles the 16 KiB scratch buffers used by `pumpInboundLocked` and `drainBIOLocked`.
- **`!cgo` stub fails loud** — `NewListener` closes its inner listener and logs an `slog.Error`; `acceptLoop` sees `net.ErrClosed` on the first iteration instead of spinning on `ErrSessionSigUnsupported`. Package docstring spells out the cgo requirement.

## Test plan

- [x] `go test ./...` (full module, `CGO_ENABLED=1` with OpenSSL) — green.
- [x] `go test -race ./internal/manifest/...` — green (validates the split-lock).
- [x] New `peer_dispatch_test.go` covers `Peer.dispatchEvent` and `Overlay.dispatchEvent` non-blocking behavior + nil-counter / nil-channel safety.

Fixes #434
