### PR TITLE
perf(tx/ledgerfields): inline IOU/MPT Amount decode for RippleState hot path

### DIFF
--- a/internal/ledger/state/amount.go
+++ b/internal/ledger/state/amount.go
@@ -632,22 +632,4 @@ func parseIOUValueFromString(value string) IOUAmountValue {
 	return NewIOUAmountValue(mantissa, exponent)
 }
 
-// flattenAmount converts an Amount to its JSON-compatible representation
-func flattenAmount(a Amount) any {
-	if a.IsNative() {
-		return a.xrp.String()
-	}
-	if a.IsMPT() {
-		return map[string]string{
-			"value":           a.iou.String(),
-			"mpt_issuance_id": a.mptIssuanceID,
-		}
-	}
-	return map[string]string{
-		"value":    a.iou.String(),
-		"currency": a.Currency,
-		"issuer":   a.Issuer,
-	}
-}
-
 // Add adds two amounts (must be same type)

--- a/internal/ledger/state/directory.go
+++ b/internal/ledger/state/directory.go
@@ -630,12 +630,6 @@ func formatUint64Hex(v uint64) string {
 	return strings.ToLower(h)
 }
 
-// formatUint64HexPadded formats a uint64 as 16-char uppercase hex with leading zeros
-// Used for fields like OwnerNode and BookNode that require zero-padding in metadata
-func formatUint64HexPadded(v uint64) string {
-	return strings.ToUpper(hex.EncodeToString(uint64ToBytes(v)))
-}
-
 // DirRemoveResult contains the result of a directory remove operation
 type DirRemoveResult struct {
 	Success       bool                    // True if the item was found and removed

--- a/internal/tx/ledgerfields/cmd/ledgerfieldsgen/main.go
+++ b/internal/tx/ledgerfields/cmd/ledgerfieldsgen/main.go
@@ -52,30 +52,30 @@ func main() {
 
 // fieldRender carries the resolved per-field data the template needs.
 type fieldRender struct {
-	Name        string // canonical XRPL field name
-	GoField     string // Go struct field name (mirrors XRPL name)
-	BitConst    string // const name of the presence bit
-	GoType      string // Go type of the slot
-	XRPLType    string // XRPL type name (UInt32, Hash256, ...)
-	TypeCode    int    // XRPL type code
-	FieldCode   int    // XRPL field code
-	Meta        spec.Meta
-	Comparer    string // "String" | "Uint32" | "Int" | "Amount" — selects emitIfChanged*
-	IsAmount    bool
-	IsHash      bool   // hex-string default-value check
-	XRPOnly     bool   // Balance on AccountRoot uses readAmount (XRP-only)
-	ReadCall    string // expression that reads from streamReader
-	DecodeKind  string // "uint32" | "int" | "string" | "amount" — drives the switch arm
+	Name       string // canonical XRPL field name
+	GoField    string // Go struct field name (mirrors XRPL name)
+	BitConst   string // const name of the presence bit
+	GoType     string // Go type of the slot
+	XRPLType   string // XRPL type name (UInt32, Hash256, ...)
+	TypeCode   int    // XRPL type code
+	FieldCode  int    // XRPL field code
+	Meta       spec.Meta
+	Comparer   string // "String" | "Uint32" | "Int" | "Amount" — selects emitIfChanged*
+	IsAmount   bool
+	IsHash     bool   // hex-string default-value check
+	XRPOnly    bool   // Balance on AccountRoot uses readAmount (XRP-only)
+	ReadCall   string // expression that reads from streamReader
+	DecodeKind string // "uint32" | "int" | "string" | "amount" — drives the switch arm
 }
 
 type entryRender struct {
-	Name           string                  // ledger-entry-type name
-	StructName     string                  // Go struct name (= entry name)
-	Receiver       string                  // single-letter receiver
-	BitPrefix      string                  // prefix for presence-bit constants
-	Fields         []fieldRender           // emit-ordered (creator order)
-	DecodeArms     map[int][]decodeArm     // typeCode -> list of dispatch arms
-	HasUnsupported bool                    // any Amount field that may be IOU
+	Name           string              // ledger-entry-type name
+	StructName     string              // Go struct name (= entry name)
+	Receiver       string              // single-letter receiver
+	BitPrefix      string              // prefix for presence-bit constants
+	Fields         []fieldRender       // emit-ordered (creator order)
+	DecodeArms     map[int][]decodeArm // typeCode -> list of dispatch arms
+	HasUnsupported bool                // any Amount field that may be IOU
 }
 
 type decodeArm struct {

--- a/internal/tx/ledgerfields/decode_stream.go
+++ b/internal/tx/ledgerfields/decode_stream.go
@@ -1,7 +1,9 @@
 package ledgerfields
 
 import (
+	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"strconv"
 
@@ -193,11 +195,10 @@ func (r *streamReader) readAmount() (any, error) {
 	return nil, errUnsupportedAmount
 }
 
-// readAmountAny decodes any Amount variant (XRP, IOU, MPT). XRP stays inline;
-// IOU/MPT delegate to the binarycodec types.Amount decoder. Order matches
-// types/amount.go ToJSON: IOU first (bit 0x80), then MPT (bit 0x20), else XRP.
-// Used by entry types whose Amount fields can legitimately be non-XRP (e.g.
-// Offer.TakerPays).
+// readAmountAny decodes any Amount variant (XRP, IOU, MPT) inline. Order
+// matches types/amount.go ToJSON: IOU first (bit 0x80), then MPT (bit 0x20),
+// else XRP. Used by entry types whose Amount fields can legitimately be
+// non-XRP (e.g. Offer.TakerPays, RippleState.Balance/LowLimit/HighLimit).
 func (r *streamReader) readAmountAny() (any, error) {
 	if r.pos >= len(r.data) {
 		return nil, errors.New("ledgerfields: out of bounds reading Amount")
@@ -205,26 +206,271 @@ func (r *streamReader) readAmountAny() (any, error) {
 	first := r.data[r.pos]
 	switch {
 	case first&0x80 != 0:
-		return r.readAmountViaCodec(48) // IOU
+		return r.readIOUAmount()
 	case first&0x20 != 0:
-		return r.readAmountViaCodec(33) // MPT
+		return r.readMPTAmount()
 	default:
-		return r.readAmount() // XRP
+		return r.readAmount()
 	}
-}
-
-func (r *streamReader) readAmountViaCodec(n int) (any, error) {
-	if r.pos+n > len(r.data) {
-		return nil, errors.New("ledgerfields: out of bounds reading IOU/MPT Amount")
-	}
-	p := serdes.NewBinaryParser(r.data[r.pos:r.pos+n], definitions.Get())
-	amt := &types.Amount{}
-	v, err := amt.ToJSON(p)
-	r.pos += n
-	return v, err
 }
 
 var errUnsupportedAmount = errors.New("ledgerfields: non-XRP amount in streaming decode")
+
+// iouZeroBytes is the canonical 8-byte representation of an IOU value of 0
+// (matches types/amount.go ZeroCurrencyAmountHex = 0x8000000000000000).
+var iouZeroBytes = []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+// readIOUAmount decodes a 48-byte issued-currency Amount inline. It avoids
+// the allocations that types.Amount.ToJSON incurs through bigdecimal,
+// strings.ToUpper and hex.EncodeToString. The returned map matches the shape
+// the codec produces: {value, currency, issuer}.
+func (r *streamReader) readIOUAmount() (map[string]any, error) {
+	if r.pos+48 > len(r.data) {
+		return nil, errors.New("ledgerfields: out of bounds reading IOU Amount")
+	}
+	data := r.data[r.pos : r.pos+48]
+	r.pos += 48
+
+	var value string
+	if bytes.Equal(data[0:8], iouZeroBytes) {
+		value = "0"
+	} else {
+		v, err := decodeIOUValue(data[0:8])
+		if err != nil {
+			return nil, err
+		}
+		value = v
+	}
+
+	currency, err := decodeCurrencyCode(data[8:28])
+	if err != nil {
+		return nil, err
+	}
+
+	issuer, err := addresscodec.Encode(
+		data[28:48],
+		[]byte{addresscodec.AccountAddressPrefix},
+		addresscodec.AccountAddressLength,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"value":    value,
+		"currency": currency,
+		"issuer":   issuer,
+	}, nil
+}
+
+// IOU bounds — copied from codec/binarycodec/types/amount.go so the inline
+// decoder can validate without importing the codec types package.
+const (
+	maxIOUPrecisionInline = 16
+	minIOUExponentInline  = -96
+	maxIOUExponentInline  = 80
+)
+
+var (
+	errIOUInvalidZero = errors.New("ledgerfields: invalid zero IOU value")
+	errIOUPrecision   = errors.New("ledgerfields: IOU precision out of range")
+	errIOUExponent    = errors.New("ledgerfields: IOU exponent out of range")
+)
+
+// decodeIOUValue produces the decimal string that
+// codec/binarycodec/types/amount.go's deserializeValue → bigdecimal
+// GetScaledValue path would return, but without constructing a big.Float or
+// invoking the bigdecimal package. It also performs the equivalent of
+// verifyIOUValue inline by validating precision and adjusted exponent against
+// the encoded mantissa/exponent.
+func decodeIOUValue(data []byte) (string, error) {
+	b1 := data[0]
+	b2 := data[1]
+	positive := b1&0x40 != 0
+	rawExp := int(b1&0x3F)<<2 | int(b2>>6)
+	rawExp -= 97
+
+	mantissa := uint64(b2&0x3F)<<48 |
+		uint64(data[2])<<40 |
+		uint64(data[3])<<32 |
+		uint64(data[4])<<24 |
+		uint64(data[5])<<16 |
+		uint64(data[6])<<8 |
+		uint64(data[7])
+	if mantissa == 0 {
+		return "", errIOUInvalidZero
+	}
+
+	mantStr := strconv.FormatUint(mantissa, 10)
+	origLen := len(mantStr)
+	trimLen := origLen
+	for trimLen > 0 && mantStr[trimLen-1] == '0' {
+		trimLen--
+	}
+	mTrimmed := mantStr[:trimLen]
+
+	// verifyIOUValue: bigdecimal sees Scale = rawExp + (origLen - trimLen),
+	// Precision = trimLen. adjustedExp = Scale + Precision - 16 collapses to
+	// rawExp + origLen - 16, independent of how many trailing zeros the
+	// mantissa carried.
+	precision := trimLen
+	if precision > maxIOUPrecisionInline {
+		return "", errIOUPrecision
+	}
+	adjustedExp := rawExp + origLen - 16
+	if adjustedExp < minIOUExponentInline || adjustedExp > maxIOUExponentInline {
+		return "", errIOUExponent
+	}
+
+	scale := rawExp + (origLen - trimLen)
+
+	if scale >= 0 {
+		buf := make([]byte, 0, boolToInt(!positive)+trimLen+scale)
+		if !positive {
+			buf = append(buf, '-')
+		}
+		buf = append(buf, mTrimmed...)
+		for i := 0; i < scale; i++ {
+			buf = append(buf, '0')
+		}
+		return string(buf), nil
+	}
+
+	s := -scale
+	if s >= trimLen {
+		// "0." + (s-trimLen) zeros + mTrimmed
+		buf := make([]byte, 0, boolToInt(!positive)+2+(s-trimLen)+trimLen)
+		if !positive {
+			buf = append(buf, '-')
+		}
+		buf = append(buf, '0', '.')
+		for i := 0; i < s-trimLen; i++ {
+			buf = append(buf, '0')
+		}
+		buf = append(buf, mTrimmed...)
+		return string(buf), nil
+	}
+	// mTrimmed[:trimLen-s] + "." + mTrimmed[trimLen-s:]
+	buf := make([]byte, 0, boolToInt(!positive)+trimLen+1)
+	if !positive {
+		buf = append(buf, '-')
+	}
+	buf = append(buf, mTrimmed[:trimLen-s]...)
+	buf = append(buf, '.')
+	buf = append(buf, mTrimmed[trimLen-s:]...)
+	return string(buf), nil
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// decodeCurrencyCode mirrors codec/binarycodec/types/amount.go's
+// deserializeCurrencyCode without the strings.ToUpper(hex.EncodeToString(...))
+// double allocation. Returns "XRP" for the all-zero sentinel, the uppercased
+// 3-char ISO code when the 12/3/5-byte standard layout matches the IOU
+// charset, and the upper-hex 40-char form for any non-standard 20-byte code.
+func decodeCurrencyCode(data []byte) (string, error) {
+	if len(data) != 20 {
+		return "", errors.New("ledgerfields: currency code must be 20 bytes")
+	}
+
+	allZero := true
+	for _, b := range data {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		return "XRP", nil
+	}
+
+	standardLayout := true
+	for i := 0; i < 12; i++ {
+		if data[i] != 0 {
+			standardLayout = false
+			break
+		}
+	}
+	if standardLayout {
+		for i := 15; i < 20; i++ {
+			if data[i] != 0 {
+				standardLayout = false
+				break
+			}
+		}
+	}
+
+	if standardLayout {
+		// 12 zero bytes + "XRP" + 5 zero bytes is reserved.
+		if data[12] == 'X' && data[13] == 'R' && data[14] == 'P' {
+			return "", errors.New("ledgerfields: invalid currency code")
+		}
+		var iso [3]byte
+		ok := true
+		for i := 0; i < 3; i++ {
+			b := data[12+i]
+			if b >= 'a' && b <= 'z' {
+				b -= 'a' - 'A'
+			}
+			iso[i] = b
+			if !isValidIOUCodeByte(b) {
+				ok = false
+			}
+		}
+		if ok {
+			return string(iso[:]), nil
+		}
+	}
+
+	return upperHex(data), nil
+}
+
+func isValidIOUCodeByte(b byte) bool {
+	switch {
+	case b >= '0' && b <= '9':
+		return true
+	case b >= 'A' && b <= 'Z':
+		return true
+	}
+	switch b {
+	case '?', '!', '@', '#', '$', '%', '^', '&', '*',
+		'<', '>', '(', ')', '{', '}', '[', ']', '|':
+		return true
+	}
+	return false
+}
+
+// readMPTAmount decodes a 33-byte MPToken Amount inline. verifyMPTValue
+// constrains |value| ≤ 2^63-1, so the 8-byte mantissa fits in a uint64 and
+// no big.Int math is required. The returned map shape matches the codec's
+// deserializeMPTAmount: {value, mpt_issuance_id}.
+func (r *streamReader) readMPTAmount() (map[string]any, error) {
+	if r.pos+33 > len(r.data) {
+		return nil, errors.New("ledgerfields: out of bounds reading MPT Amount")
+	}
+	data := r.data[r.pos : r.pos+33]
+	r.pos += 33
+
+	positive := data[0]&0x40 != 0
+	mant := binary.BigEndian.Uint64(data[1:9])
+
+	var value string
+	if positive {
+		value = strconv.FormatUint(mant, 10)
+	} else {
+		value = "-" + strconv.FormatUint(mant, 10)
+	}
+
+	return map[string]any{
+		"value":           value,
+		"mpt_issuance_id": hex.EncodeToString(data[9:33]),
+	}, nil
+}
 
 // readVector256 reads a VL-prefixed array of 32-byte hashes and returns
 // the canonical decoded form ([]string of uppercase hex hashes) that
@@ -383,4 +629,3 @@ func (r *streamReader) skipField(typeCode int) error {
 	}
 	return nil
 }
-

--- a/internal/tx/ledgerfields/decode_stream.go
+++ b/internal/tx/ledgerfields/decode_stream.go
@@ -543,12 +543,6 @@ func (r *streamReader) readNumber() (any, error) {
 	return r.decodeViaCodec(&types.Number{}, -1)
 }
 
-// readPathSet reads a PathSet. Currently no ledger entry type carries one;
-// this exists so the generator's type dispatch is complete.
-func (r *streamReader) readPathSet() (any, error) {
-	return r.decodeViaCodec(&types.PathSet{}, -1)
-}
-
 // decodeViaCodec builds a sub-parser positioned at r.pos, hands it to the
 // supplied SerializedType to decode, then advances r.pos by the number of
 // bytes the sub-parser consumed. vlen < 0 means "no explicit length"; the
@@ -582,50 +576,4 @@ func upperHex(b []byte) string {
 		buf[i*2+1] = hextable[v&0x0F]
 	}
 	return string(buf)
-}
-
-// skipField advances past the value of a field of the given type/code without
-// decoding it — used for unknown or sMD_Never fields. Falls back via err if
-// the type is one we don't know how to size.
-func (r *streamReader) skipField(typeCode int) error {
-	switch typeCode {
-	case 1: // UInt16
-		r.pos += 2
-	case 2: // UInt32
-		r.pos += 4
-	case 3: // UInt64
-		r.pos += 8
-	case 4: // Hash128
-		r.pos += 16
-	case 5: // Hash256
-		r.pos += 32
-	case 6: // Amount — same order as types/amount.go ToJSON.
-		if r.pos >= len(r.data) {
-			return errors.New("ledgerfields: out of bounds skipping Amount")
-		}
-		switch {
-		case r.data[r.pos]&0x80 != 0:
-			r.pos += 48 // IOU
-		case r.data[r.pos]&0x20 != 0:
-			r.pos += 33 // MPT
-		default:
-			r.pos += 8 // XRP
-		}
-	case 7, 8, 19: // Blob, AccountID, Vector256 (VL-prefixed)
-		n, err := r.readVariableLength()
-		if err != nil {
-			return err
-		}
-		r.pos += n
-	case 16: // UInt8
-		r.pos++
-	case 17: // Hash160
-		r.pos += 20
-	default:
-		return errors.New("ledgerfields: cannot skip unknown type code")
-	}
-	if r.pos > len(r.data) {
-		return errors.New("ledgerfields: skip overran buffer")
-	}
-	return nil
 }

--- a/internal/tx/ledgerfields/decode_stream_test.go
+++ b/internal/tx/ledgerfields/decode_stream_test.go
@@ -1,0 +1,86 @@
+package ledgerfields
+
+import (
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
+	"github.com/LeJamon/goXRPLd/codec/binarycodec/serdes"
+	"github.com/LeJamon/goXRPLd/codec/binarycodec/types"
+)
+
+// TestReadAmountAny_MatchesCodec exercises the inline IOU/MPT decoders
+// against the codec's reference path for cases the metadata-parity test
+// doesn't exercise: zero, negative, non-standard currency, MPT.
+func TestReadAmountAny_MatchesCodec(t *testing.T) {
+	cases := []struct {
+		name string
+		// Serialize input via codec, then decode through both paths.
+		jsonValue any
+	}{
+		{
+			name:      "IOU_positive_standard",
+			jsonValue: map[string]any{"value": "100", "currency": "USD", "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"},
+		},
+		{
+			name:      "IOU_fractional",
+			jsonValue: map[string]any{"value": "0.0012345", "currency": "USD", "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"},
+		},
+		{
+			name:      "IOU_negative",
+			jsonValue: map[string]any{"value": "-42.5", "currency": "USD", "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"},
+		},
+		{
+			name:      "IOU_large_integer",
+			jsonValue: map[string]any{"value": "9999999999999999", "currency": "USD", "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"},
+		},
+		{
+			name:      "IOU_zero",
+			jsonValue: map[string]any{"value": "0", "currency": "USD", "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"},
+		},
+		{
+			name:      "IOU_non_standard_currency",
+			jsonValue: map[string]any{"value": "1", "currency": "0158415500000000C1F76FF6ECB0BAC600000000", "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"},
+		},
+		{
+			name:      "MPT_positive",
+			jsonValue: map[string]any{"value": "1234567890", "mpt_issuance_id": "00000000ABCDEF0123456789FEDCBA9876543210FEDCBA98"},
+		},
+		{
+			name:      "XRP_drops",
+			jsonValue: "1000000",
+		},
+	}
+
+	amt := &types.Amount{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := amt.FromJSON(tc.jsonValue)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+
+			// Reference: codec round-trip.
+			refParser := serdes.NewBinaryParser(encoded, definitions.Get())
+			refDecoded, err := amt.ToJSON(refParser)
+			if err != nil {
+				t.Fatalf("codec ToJSON: %v", err)
+			}
+
+			// Inline: streamReader path.
+			sr := newStreamReader(encoded)
+			got, err := sr.readAmountAny()
+			if err != nil {
+				t.Fatalf("readAmountAny: %v", err)
+			}
+			if sr.pos != len(encoded) {
+				t.Errorf("reader did not consume entire blob: pos=%d len=%d", sr.pos, len(encoded))
+			}
+
+			if !reflect.DeepEqual(refDecoded, got) {
+				t.Errorf("decoder mismatch\n  codec=%#v\n  inline=%#v\n  blob=%s", refDecoded, got, hex.EncodeToString(encoded))
+			}
+		})
+	}
+}

--- a/internal/tx/ledgerfields/decode_stream_test.go
+++ b/internal/tx/ledgerfields/decode_stream_test.go
@@ -48,6 +48,10 @@ func TestReadAmountAny_MatchesCodec(t *testing.T) {
 			jsonValue: map[string]any{"value": "1234567890", "mpt_issuance_id": "00000000ABCDEF0123456789FEDCBA9876543210FEDCBA98"},
 		},
 		{
+			name:      "MPT_negative",
+			jsonValue: map[string]any{"value": "-1234567890", "mpt_issuance_id": "00000000ABCDEF0123456789FEDCBA9876543210FEDCBA98"},
+		},
+		{
 			name:      "XRP_drops",
 			jsonValue: "1000000",
 		},


### PR DESCRIPTION
## Summary
- Replaces `readAmountAny`'s codec fallback with native streaming decoders for IOU (48B) and MPT (33B) amounts so RippleState metadata no longer pays `bigdecimal.NewBigDecimal` + `serdes.BinaryParser` allocations on every Amount field.
- `decodeIOUValue` formats the decimal value directly from the 8-byte mantissa/exponent (no `big.Float` math); `decodeCurrencyCode` emits the ISO/hex form into a pre-sized buffer; `readMPTAmount` uses `uint64` arithmetic since `verifyMPTValue` already constrains `|value| ≤ 2^63-1`.
- Adds `decode_stream_test.go` covering IOU/MPT/XRP edge cases (negative, fractional, large integer, zero, non-standard currency, MPT) by comparing the inline path against the codec round-trip.

## Bench (BenchmarkBuildModifiedNode_RippleState, M3 Pro)

| | allocs/op | B/op | ns/op |
|---|---:|---:|---:|
| generic | 599 | 49,468 | 28,560 |
| typed (was) | 531 | n/a | n/a |
| typed (now) | **87** | 4,896 | 3,361 |

84% allocs/op reduction vs the post-#457 baseline, well past the ≥50% acceptance bar. RippleState typed path now sits between AccountRoot (28) and Offer (41), matching the issue's expected 25–50 alloc target.

## Test plan
- [x] `go test ./internal/tx/...` (parity tests for AccountRoot / Offer / DirectoryNode / RippleState all green)
- [x] `go test -v -run TestReadAmountAny_MatchesCodec ./internal/tx/ledgerfields/` (8 new cases)
- [x] `go test ./...` (only pre-existing `TestConformance` failure remains, present on base branch)
- [x] `go test -bench BenchmarkBuildModifiedNode -benchmem ./internal/tx/`

## Stacking
Targets `worktree-issue-455-typed-sle` (PR #457) since the typed `ledgerfields/` package only exists on that branch; rebase to `main` after #457 lands.

Fixes #464