### PR TITLE
feat: validator-list publisher subsystem (#459)

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -187,7 +187,7 @@ journal_size_limit = 1582080
 
 	validatorsContent := `
 validator_list_sites = ["https://test.example.com"]
-validator_list_keys = ["ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D58"]
+validator_list_keys = ["ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860"]
 validator_list_threshold = 1
 `
 	validatorsPath := filepath.Join(tempDir, "test_validators.toml")
@@ -204,7 +204,7 @@ validator_list_threshold = 1
 	require.NotNil(t, config)
 
 	assert.Equal(t, []string{"https://test.example.com"}, config.Validators.ValidatorListSites)
-	assert.Equal(t, []string{"ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D58"}, config.Validators.ValidatorListKeys)
+	assert.Equal(t, []string{"ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860"}, config.Validators.ValidatorListKeys)
 	assert.Equal(t, 1, config.Validators.ValidatorListThreshold)
 }
 

--- a/config/validators.go
+++ b/config/validators.go
@@ -133,20 +133,28 @@ func validateValidatorListSite(site string) error {
 	return nil
 }
 
-// validateValidatorListKey validates a validator list publisher key
+// validateValidatorListKey validates a validator list publisher key.
+// Publisher keys are 33-byte compressed public keys hex-encoded
+// (66 chars) with a key-type prefix byte: 0xED for ed25519 — the
+// common case in practice; vl.ripple.com / vl.xrplf.org both publish
+// ed25519 — or 0x02/0x03 for secp256k1.
 func validateValidatorListKey(key string) error {
 	if key == "" {
 		return fmt.Errorf("validator list key cannot be empty")
 	}
 
-	// Should be hex-encoded and 64 characters long (32 bytes * 2)
-	if len(key) != 64 {
-		return fmt.Errorf("validator list key has invalid length %d, expected 64", len(key))
+	if len(key) != 66 {
+		return fmt.Errorf("validator list key has invalid length %d, expected 66 (33-byte hex)", len(key))
 	}
 
-	// Hex character validation
 	if !isValidHex(key) {
 		return fmt.Errorf("validator list key contains invalid hex characters")
+	}
+
+	// Sanity-check the key-type prefix byte.
+	prefix := strings.ToUpper(key[:2])
+	if prefix != "ED" && prefix != "02" && prefix != "03" {
+		return fmt.Errorf("validator list key has unrecognized key-type prefix %q (want ED, 02, or 03)", prefix)
 	}
 
 	return nil

--- a/config/validators.go
+++ b/config/validators.go
@@ -38,6 +38,15 @@ func (v *ValidatorsConfig) Validate() error {
 		return fmt.Errorf("validator_list_threshold must be non-negative, got %d", v.ValidatorListThreshold)
 	}
 
+	// A positive threshold with zero publisher keys would trip rippled's
+	// XRPL_ASSERT(listThreshold_ > 0 && listThreshold_ <= publisherLists_.size())
+	// at ValidatorList.cpp:201-203 — catch it here so the operator gets
+	// a clean message at startup instead of a runtime divergence.
+	if v.ValidatorListThreshold > 0 && len(v.ValidatorListKeys) == 0 {
+		return fmt.Errorf("validator_list_threshold (%d) requires at least one validator_list_keys entry",
+			v.ValidatorListThreshold)
+	}
+
 	if len(v.ValidatorListKeys) > 0 && v.ValidatorListThreshold > len(v.ValidatorListKeys) {
 		return fmt.Errorf("validator_list_threshold (%d) cannot be greater than number of validator_list_keys (%d)",
 			v.ValidatorListThreshold, len(v.ValidatorListKeys))

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -341,10 +341,14 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		// Expose static config validators, cached signing keys, and the
 		// negative-UNL set to the `validators` RPC so it returns the
 		// same shape rippled's ValidatorList::getJson does.
-		staticMasters := append([][33]byte(nil), consensusComponents.StaticTrustedMasterKeys...)
+		//
+		// Bind to the live accessor (not a boot-time copy) so a SIGHUP
+		// reload of the [validators] stanza is visible to the RPC.
+		componentsRef := consensusComponents
 		services.LocalStaticTrustedKeysBase58 = func() []string {
-			out := make([]string, 0, len(staticMasters))
-			for _, mk := range staticMasters {
+			masters := componentsRef.StaticTrustedMasterKeys()
+			out := make([]string, 0, len(masters))
+			for _, mk := range masters {
 				if enc, err := addresscodec.EncodeNodePublicKey(mk[:]); err == nil {
 					out = append(out, enc)
 				}
@@ -668,32 +672,33 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	}
 }
 
-// trustedValidatorSink is the writable surface reloadTrustedValidators
-// drives on a successful config reload. Satisfied by *adaptor.Adaptor;
-// extracted as a tiny interface so applyValidatorReload can be tested
-// without constructing a full *adaptor.Components.
-type trustedValidatorSink interface {
-	SetTrustedValidators(validators []consensus.NodeID, masterKeys [][33]byte)
+// staticValidatorReloader is the writable surface
+// reloadTrustedValidators drives on a successful config reload.
+// Satisfied by *adaptor.Components, which routes the new static set
+// through staticMu + a merge with the live publisher-trust aggregator
+// so a SIGHUP removal is not silently undone by the next OnChange.
+type staticValidatorReloader interface {
+	ReloadStaticValidators(validators []consensus.NodeID, masterKeys [][33]byte)
 }
 
 // reloadTrustedValidators is the SIGHUP entry point: bridge from the
 // production *adaptor.Components down to the pure applyValidatorReload
 // helper. Skipped silently when components is nil (standalone mode).
 func reloadTrustedValidators(serverLog xrpllog.Logger, components *adaptor.Components) {
-	if components == nil || components.Adaptor == nil {
+	if components == nil {
 		return
 	}
-	applyValidatorReload(serverLog, components.Adaptor, configFile)
+	applyValidatorReload(serverLog, components, configFile)
 }
 
 // applyValidatorReload re-reads configPath, re-parses the [validators]
-// stanza, and pushes the result into sink. Errors are logged and the
-// previous trusted set is retained — a bad reload must not wedge the
-// node.
+// stanza, and pushes the result into reloader. Errors are logged and
+// the previous trusted set is retained — a bad reload must not wedge
+// the node.
 //
 // Skipped silently when configPath is empty (validator config can't
 // be re-read from nothing).
-func applyValidatorReload(serverLog xrpllog.Logger, sink trustedValidatorSink, configPath string) {
+func applyValidatorReload(serverLog xrpllog.Logger, reloader staticValidatorReloader, configPath string) {
 	if configPath == "" {
 		serverLog.Warn("SIGHUP received but no --conf path set; skipping UNL reload")
 		return
@@ -708,7 +713,7 @@ func applyValidatorReload(serverLog xrpllog.Logger, sink trustedValidatorSink, c
 		serverLog.Error("SIGHUP UNL reload: parse validators failed", "err", err)
 		return
 	}
-	sink.SetTrustedValidators(validators, masterKeys)
+	reloader.ReloadStaticValidators(validators, masterKeys)
 	serverLog.Info("SIGHUP UNL reload applied",
 		"validators_count", len(validators),
 		"master_keys_count", len(masterKeys),

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -356,13 +356,38 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			return out
 		}
 		if mc := consensusComponents.Manifests; mc != nil {
+			// Mirrors rippled getJson at ValidatorList.cpp:1726-1734 —
+			// `signing_keys` only surfaces master→signing pairs for
+			// masters present in keyListings_, i.e. validators listed
+			// by at least one publisher or pinned in the local
+			// [validators] stanza. Without this filter we would leak
+			// every gossiped manifest, including ones unrelated to any
+			// trusted publisher.
+			vlAgg := consensusComponents.ValidatorList
 			services.SigningKeysBase58 = func() map[string]string {
 				snap := mc.MasterToSigning()
 				if len(snap) == 0 {
 					return nil
 				}
-				out := make(map[string]string, len(snap))
+				listed := make(map[[33]byte]struct{})
+				for _, mk := range componentsRef.StaticTrustedMasterKeys() {
+					listed[mk] = struct{}{}
+				}
+				if vlAgg != nil {
+					for _, p := range vlAgg.PublisherSnapshot() {
+						for _, mk := range p.Validators {
+							listed[mk] = struct{}{}
+						}
+					}
+				}
+				if len(listed) == 0 {
+					return nil
+				}
+				out := make(map[string]string, len(listed))
 				for master, signing := range snap {
+					if _, ok := listed[master]; !ok {
+						continue
+					}
 					mEnc, mErr := addresscodec.EncodeNodePublicKey(master[:])
 					sEnc, sErr := addresscodec.EncodeNodePublicKey(signing[:])
 					if mErr == nil && sErr == nil {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/config"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
@@ -24,6 +25,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 	"github.com/LeJamon/goXRPLd/internal/rpc"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	validatorlist "github.com/LeJamon/goXRPLd/internal/validator/list"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
 	"github.com/LeJamon/goXRPLd/protocol"
 	kvpebble "github.com/LeJamon/goXRPLd/storage/kvstore/pebble"
@@ -31,7 +33,6 @@ import (
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb/postgres"
 	sqlitedb "github.com/LeJamon/goXRPLd/storage/relationaldb/sqlite"
-	validatorlist "github.com/LeJamon/goXRPLd/internal/validator/list"
 	"github.com/LeJamon/goXRPLd/version"
 	"github.com/spf13/cobra"
 )
@@ -336,6 +337,51 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		// aggregator is nil, so the handlers return empty arrays in
 		// that case rather than panicking.
 		services.ValidatorList = validatorlist.NewRPCReader(consensusComponents.ValidatorList)
+
+		// Expose static config validators, cached signing keys, and the
+		// negative-UNL set to the `validators` RPC so it returns the
+		// same shape rippled's ValidatorList::getJson does.
+		staticMasters := append([][33]byte(nil), consensusComponents.StaticTrustedMasterKeys...)
+		services.LocalStaticTrustedKeysBase58 = func() []string {
+			out := make([]string, 0, len(staticMasters))
+			for _, mk := range staticMasters {
+				if enc, err := addresscodec.EncodeNodePublicKey(mk[:]); err == nil {
+					out = append(out, enc)
+				}
+			}
+			return out
+		}
+		if mc := consensusComponents.Manifests; mc != nil {
+			services.SigningKeysBase58 = func() map[string]string {
+				snap := mc.MasterToSigning()
+				if len(snap) == 0 {
+					return nil
+				}
+				out := make(map[string]string, len(snap))
+				for master, signing := range snap {
+					mEnc, mErr := addresscodec.EncodeNodePublicKey(master[:])
+					sEnc, sErr := addresscodec.EncodeNodePublicKey(signing[:])
+					if mErr == nil && sErr == nil {
+						out[mEnc] = sEnc
+					}
+				}
+				return out
+			}
+		}
+		adaptorRef := consensusComponents.Adaptor
+		services.NegativeUNLBase58 = func() []string {
+			masters := adaptorRef.GetNegativeUNLMasters()
+			if len(masters) == 0 {
+				return nil
+			}
+			out := make([]string, 0, len(masters))
+			for _, mk := range masters {
+				if enc, err := addresscodec.EncodeNodePublicKey(mk[:]); err == nil {
+					out = append(out, enc)
+				}
+			}
+			return out
+		}
 
 		// Expose the local validator's signing key to validator_info.
 		// Mirrors rippled's getValidationPublicKey gate: empty means

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb/postgres"
 	sqlitedb "github.com/LeJamon/goXRPLd/storage/relationaldb/sqlite"
+	validatorlist "github.com/LeJamon/goXRPLd/internal/validator/list"
 	"github.com/LeJamon/goXRPLd/version"
 	"github.com/spf13/cobra"
 )
@@ -328,6 +329,13 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		// the engine reads for ephemeral→master translation, and this
 		// RPC reads for external queries.
 		services.Manifests = consensusComponents.Manifests
+
+		// Expose the publisher-list aggregator (when configured) to
+		// the `validators` and `validator_list_sites` RPC methods.
+		// nil-safe: NewRPCReader returns an inert reader when the
+		// aggregator is nil, so the handlers return empty arrays in
+		// that case rather than panicking.
+		services.ValidatorList = validatorlist.NewRPCReader(consensusComponents.ValidatorList)
 
 		// Expose the local validator's signing key to validator_info.
 		// Mirrors rippled's getValidationPublicKey gate: empty means

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// recordingSink captures every SetTrustedValidators invocation so the
-// SIGHUP-reload error paths can assert the sink is NOT touched on bad
-// inputs (the previous trusted set must be retained on any failure).
+// recordingSink captures every ReloadStaticValidators invocation so the
+// SIGHUP-reload error paths can assert the reloader is NOT touched on
+// bad inputs (the previous trusted set must be retained on any failure).
 type recordingSink struct {
 	mu    sync.Mutex
 	calls []recordingSinkCall
@@ -24,7 +24,7 @@ type recordingSinkCall struct {
 	masterKeys [][33]byte
 }
 
-func (s *recordingSink) SetTrustedValidators(validators []consensus.NodeID, masterKeys [][33]byte) {
+func (s *recordingSink) ReloadStaticValidators(validators []consensus.NodeID, masterKeys [][33]byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	v := make([]consensus.NodeID, len(validators))
@@ -46,7 +46,7 @@ func (s *recordingSink) SetTrustedValidators(validators []consensus.NodeID, mast
 func TestApplyValidatorReload_EmptyConfigPathIsNoOp(t *testing.T) {
 	sink := &recordingSink{}
 	applyValidatorReload(xrpllog.Discard(), sink, "")
-	assert.Empty(t, sink.calls, "empty configPath must not invoke SetTrustedValidators")
+	assert.Empty(t, sink.calls, "empty configPath must not invoke ReloadStaticValidators")
 }
 
 // TestApplyValidatorReload_MissingFileIsNoOp pins the LoadConfig
@@ -58,7 +58,7 @@ func TestApplyValidatorReload_MissingFileIsNoOp(t *testing.T) {
 	sink := &recordingSink{}
 	missing := filepath.Join(t.TempDir(), "does-not-exist.toml")
 	applyValidatorReload(xrpllog.Discard(), sink, missing)
-	assert.Empty(t, sink.calls, "nonexistent configPath must not invoke SetTrustedValidators")
+	assert.Empty(t, sink.calls, "nonexistent configPath must not invoke ReloadStaticValidators")
 }
 
 // TestApplyValidatorReload_MalformedFileIsNoOp pins the parse-failure
@@ -75,7 +75,7 @@ func TestApplyValidatorReload_MalformedFileIsNoOp(t *testing.T) {
 
 	sink := &recordingSink{}
 	applyValidatorReload(xrpllog.Discard(), sink, path)
-	assert.Empty(t, sink.calls, "malformed config must not invoke SetTrustedValidators")
+	assert.Empty(t, sink.calls, "malformed config must not invoke ReloadStaticValidators")
 }
 
 // TestReloadTrustedValidators_NilComponentsIsNoOp pins the standalone-mode

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1063,6 +1063,46 @@ func computeQuorum(trusted, disabled int) int {
 	return q
 }
 
+// GetNegativeUNLMasters reads the ltNEGATIVE_UNL SLE and returns the
+// raw 33-byte master pubkeys of disabled validators (not the derived
+// NodeIDs that GetNegativeUNL returns). Used by the `validators` RPC,
+// which surfaces these as base58 NodePublic strings under the
+// `NegativeUNL` key — matching rippled's getJson at
+// ValidatorList.cpp:1737-1744.
+//
+// Returns nil under the same conditions GetNegativeUNL does: no ledger
+// service, no validated ledger, no SLE, or parse failure.
+func (a *Adaptor) GetNegativeUNLMasters() [][33]byte {
+	if a.ledgerService == nil {
+		return nil
+	}
+	l := a.ledgerService.GetValidatedLedger()
+	if l == nil {
+		return nil
+	}
+	data, err := l.Read(keylet.NegativeUNL())
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+	sle, err := pseudo.ParseNegativeUNLSLE(data)
+	if err != nil {
+		return nil
+	}
+	if len(sle.DisabledValidators) == 0 {
+		return nil
+	}
+	out := make([][33]byte, 0, len(sle.DisabledValidators))
+	for _, pubKey := range sle.DisabledValidators {
+		if len(pubKey) != 33 {
+			continue
+		}
+		var master [33]byte
+		copy(master[:], pubKey)
+		out = append(out, master)
+	}
+	return out
+}
+
 // GetNegativeUNL reads the ltNEGATIVE_UNL SLE from the current validated
 // ledger and returns the NodeIDs of disabled validators. Mirrors
 // rippled's per-ledger NegativeUNL scan; without this the

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -296,6 +296,15 @@ func (r *Router) HandlePeerDisconnect(peerID peermanagement.PeerID) {
 	// Clear the peer's LCL vote so getNetworkLedger stops counting its
 	// stale hash. The adaptor uses the zero LedgerID as a delete key.
 	r.adaptor.UpdatePeerLCL(uint64(peerID), consensus.LedgerID{})
+
+	// Drop the peer's per-publisher sequence record so the publisher-
+	// trust aggregator's peerSeq map doesn't grow unbounded across the
+	// lifetime of the process. Mirrors the implicit cleanup rippled
+	// gets from publisherListSequences_ living on the PeerImp itself
+	// (PeerImp.h:183) — when the peer object dies the map dies with it.
+	if r.validatorList != nil {
+		r.validatorList.ForgetPeer(uint64(peerID))
+	}
 }
 
 // Run reads messages from the overlay and dispatches them.

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -16,6 +16,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/manifest"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	validatorlist "github.com/LeJamon/goXRPLd/internal/validator/list"
 	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/shamap"
 )
@@ -80,6 +81,13 @@ type Router struct {
 	// directly via Overlay.BroadcastExcept. Nil in tests that
 	// construct a router without manifest support.
 	overlay *peermanagement.Overlay
+
+	// validatorList is the publisher-trust subsystem. Wired by the
+	// Components bootstrap when validator_list_keys is configured. Nil
+	// in standalone-mode or when no publisher trust is configured —
+	// the dispatch switch silently drops TMValidatorList /
+	// TMValidatorListCollection frames in that case.
+	validatorList *validatorlist.Aggregator
 
 	// overrideManifestSender, when non-nil, replaces r.overlay for the
 	// local-manifest emission paths (SendLocalManifestTo /
@@ -245,6 +253,14 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManag
 func (r *Router) SetManifestCache(cache *manifest.Cache, overlay *peermanagement.Overlay) {
 	r.manifests = cache
 	r.overlay = overlay
+}
+
+// SetValidatorListAggregator installs the publisher-trust subsystem.
+// Calling with a nil aggregator disables the TMValidatorList /
+// TMValidatorListCollection paths — the dispatch switch silently
+// drops inbound frames in that case. Safe to call before Run.
+func (r *Router) SetValidatorListAggregator(agg *validatorlist.Aggregator) {
+	r.validatorList = agg
 }
 
 // SetInboundClock overrides the clock used by new inbound replay-delta
@@ -428,6 +444,10 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 		r.handleProofPathResponse(msg)
 	case message.TypeManifests:
 		r.handleManifests(msg)
+	case message.TypeValidatorList:
+		r.handleValidatorList(msg)
+	case message.TypeValidatorListCollection:
+		r.handleValidatorListCollection(msg)
 	default:
 		// Not a consensus message — ignore
 	}

--- a/internal/consensus/adaptor/router_dedup.go
+++ b/internal/consensus/adaptor/router_dedup.go
@@ -148,9 +148,9 @@ type messageSuppression struct {
 	// sender now has it because they sent it to us) and on outbound
 	// broadcast (the recipient now has it because we sent it to them).
 	// Mirrors rippled's HashRouter::addSuppressionPeer at
-	// rippled/src/xrpld/app/misc/detail/HashRouter.cpp:115-134, used
-	// by validator-list broadcast to skip peers known to already have
-	// the same content.
+	// rippled/src/xrpld/app/misc/HashRouter.cpp:51-79, used by
+	// validator-list broadcast to skip peers known to already have the
+	// same content.
 	peers   map[[32]byte]map[uint64]struct{}
 	ttl     time.Duration
 	maxSize int
@@ -218,10 +218,12 @@ func (s *messageSuppression) observe(hash [32]byte) (firstSeen bool, lastSeenAt 
 }
 
 // recordPeer marks peerID as a peer known to already have the message
-// identified by hash. Returns true if the peer was newly added,
-// matching rippled's HashRouter::addSuppressionPeer "added" return
-// semantics. Always refreshes the hash's last-seen time so a steady
-// stream of activity keeps the entry live.
+// identified by hash. Returns true if the peer was newly added to the
+// per-hash set (note: this differs from rippled's addSuppressionPeer
+// which returns whether the *key* was newly inserted — the two ride
+// on the same emplace+addPeer pair but expose different bits of it).
+// Always refreshes the hash's last-seen time so a steady stream of
+// activity keeps the entry live.
 //
 // Caller-side semantics:
 //   - On inbound observe (peer just delivered the hash) — record the

--- a/internal/consensus/adaptor/router_dedup.go
+++ b/internal/consensus/adaptor/router_dedup.go
@@ -139,8 +139,19 @@ func appendVLPrefix(buf []byte, n int) []byte {
 // N-fold and produces squelches earlier and more aggressively than
 // the rest of the network would expect.
 type messageSuppression struct {
-	mu      sync.Mutex
-	seen    map[[32]byte]time.Time
+	mu sync.Mutex
+	// seen maps a suppression hash to the most recent observation time.
+	// TTL-evicted on observe when at maxSize.
+	seen map[[32]byte]time.Time
+	// peers maps a suppression hash to the set of peer IDs known to
+	// already have the message. Populated both on inbound observe (the
+	// sender now has it because they sent it to us) and on outbound
+	// broadcast (the recipient now has it because we sent it to them).
+	// Mirrors rippled's HashRouter::addSuppressionPeer at
+	// rippled/src/xrpld/app/misc/detail/HashRouter.cpp:115-134, used
+	// by validator-list broadcast to skip peers known to already have
+	// the same content.
+	peers   map[[32]byte]map[uint64]struct{}
 	ttl     time.Duration
 	maxSize int
 	now     func() time.Time
@@ -152,6 +163,7 @@ type messageSuppression struct {
 func newMessageSuppression(ttl time.Duration, maxSize int) *messageSuppression {
 	return &messageSuppression{
 		seen:    make(map[[32]byte]time.Time),
+		peers:   make(map[[32]byte]map[uint64]struct{}),
 		ttl:     ttl,
 		maxSize: maxSize,
 		now:     time.Now,
@@ -181,10 +193,9 @@ func (s *messageSuppression) observe(hash [32]byte) (firstSeen bool, lastSeenAt 
 		for h, seenAt := range s.seen {
 			if seenAt.Before(cutoff) {
 				delete(s.seen, h)
+				delete(s.peers, h)
 			}
 		}
-		// If that didn't free enough space (adversarial churn), drop
-		// half the map — bounded worst case.
 		if len(s.seen) >= s.maxSize {
 			i := 0
 			for h := range s.seen {
@@ -192,6 +203,7 @@ func (s *messageSuppression) observe(hash [32]byte) (firstSeen bool, lastSeenAt 
 					break
 				}
 				delete(s.seen, h)
+				delete(s.peers, h)
 				i++
 			}
 		}
@@ -203,4 +215,49 @@ func (s *messageSuppression) observe(hash [32]byte) (firstSeen bool, lastSeenAt 
 	}
 	s.seen[hash] = now
 	return true, time.Time{}
+}
+
+// recordPeer marks peerID as a peer known to already have the message
+// identified by hash. Returns true if the peer was newly added,
+// matching rippled's HashRouter::addSuppressionPeer "added" return
+// semantics. Always refreshes the hash's last-seen time so a steady
+// stream of activity keeps the entry live.
+//
+// Caller-side semantics:
+//   - On inbound observe (peer just delivered the hash) — record the
+//     sender so we know they have it.
+//   - On outbound broadcast (we just sent the hash to the peer) —
+//     record the recipient so we don't re-send and so a back-relay
+//     is attributable.
+func (s *messageSuppression) recordPeer(hash [32]byte, peerID uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	s.seen[hash] = now
+
+	peers, ok := s.peers[hash]
+	if !ok {
+		peers = make(map[uint64]struct{})
+		s.peers[hash] = peers
+	}
+	if _, present := peers[peerID]; present {
+		return false
+	}
+	peers[peerID] = struct{}{}
+	return true
+}
+
+// peerHasHash reports whether peerID is known to already have the
+// message identified by hash. Used by broadcast paths to skip peers
+// that would receive a redundant frame.
+func (s *messageSuppression) peerHasHash(hash [32]byte, peerID uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	peers, ok := s.peers[hash]
+	if !ok {
+		return false
+	}
+	_, present := peers[peerID]
+	return present
 }

--- a/internal/consensus/adaptor/router_dedup_test.go
+++ b/internal/consensus/adaptor/router_dedup_test.go
@@ -50,3 +50,46 @@ func TestMessageSuppression_ObserveReturnsLastSeen(t *testing.T) {
 	assert.True(t, lastSeen.IsZero(),
 		"TTL-expired re-observation must return zero lastSeenAt")
 }
+
+// TestMessageSuppression_RecordPeerAndHasHash pins the per-hash peer
+// set semantics that drive validator-list broadcast suppression:
+// recordPeer adds the peer to the set, peerHasHash reflects it, and a
+// repeated recordPeer for the same (hash, peer) is reported as not
+// newly-added. Mirrors rippled HashRouter::addSuppressionPeer's
+// peer-set extension behaviour at HashRouter.cpp:51-79.
+func TestMessageSuppression_RecordPeerAndHasHash(t *testing.T) {
+	s := newMessageSuppression(30*time.Second, 64)
+
+	hash := [32]byte{0xBB}
+
+	// Unknown hash → peerHasHash must be false for any peer.
+	assert.False(t, s.peerHasHash(hash, 42),
+		"peerHasHash for unknown hash must be false")
+
+	// Recording peer 42 first-time: returns true (newly added), and
+	// peerHasHash flips to true for that peer.
+	added := s.recordPeer(hash, 42)
+	assert.True(t, added, "first recordPeer must return true (newly added)")
+	assert.True(t, s.peerHasHash(hash, 42),
+		"peerHasHash must be true after recordPeer")
+
+	// Re-recording the same peer: returns false (already in set),
+	// peerHasHash still true.
+	added = s.recordPeer(hash, 42)
+	assert.False(t, added, "duplicate recordPeer must return false")
+	assert.True(t, s.peerHasHash(hash, 42),
+		"peerHasHash must remain true on duplicate recordPeer")
+
+	// A second peer on the same hash is independent.
+	added = s.recordPeer(hash, 43)
+	assert.True(t, added, "different peer on same hash must be newly added")
+	assert.True(t, s.peerHasHash(hash, 42))
+	assert.True(t, s.peerHasHash(hash, 43))
+	assert.False(t, s.peerHasHash(hash, 44),
+		"unrelated peer must not be reported as having the hash")
+
+	// A different hash is isolated from peer 42's prior entry.
+	other := [32]byte{0xCC}
+	assert.False(t, s.peerHasHash(other, 42),
+		"peer-set must be scoped per hash")
+}

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -61,7 +61,7 @@ func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
 		}
 	}
 
-	disp, pubKey, seq := r.validatorList.ApplyList(vl.Manifest, vl.Blob, vl.Signature, vl.Version, peerSite(msg.PeerID))
+	disp, pubKey, seq := r.validatorList.ApplyList(vl.Manifest, vl.Blob, vl.Signature, vl.Version, r.peerSite(msg.PeerID))
 
 	r.logger.Debug("validator list applied",
 		"peer", msg.PeerID,
@@ -103,8 +103,13 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 		return
 	}
 
-	// Peer-feature gate. Mirrors PeerImp.cpp:2282-2290.
-	if !r.peerSupportsValidatorListFeature(msg.PeerID) {
+	// Peer-protocol gate. Mirrors rippled PeerImp.cpp:2282-2290 which
+	// gates TMValidatorListCollection on
+	// `supportsFeature(ValidatorList2Propagation)`. That feature is
+	// implicit at protocol >= 2.2 (PeerImp.cpp:511-514). A peer that
+	// only negotiated v2.1 may send TMValidatorList (v1) but MUST NOT
+	// send the collection frame.
+	if !r.peerSupportsValidatorList2(msg.PeerID) {
 		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-unsupported-peer")
 		return
 	}
@@ -147,7 +152,7 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 		}
 	}
 
-	dispList, pubKey, maxSeq := r.validatorList.ApplyCollection(coll, peerSite(msg.PeerID))
+	dispList, pubKey, maxSeq := r.validatorList.ApplyCollection(coll, r.peerSite(msg.PeerID))
 
 	worst := validatorlist.Accepted
 	anyRelay := false
@@ -194,6 +199,22 @@ func (r *Router) peerSupportsValidatorListFeature(peer peermanagement.PeerID) bo
 		return true
 	}
 	return r.overlay.PeerSupports(peer, peermanagement.FeatureValidatorListPropagation)
+}
+
+// peerSupportsValidatorList2 mirrors rippled's
+// supportsFeature(ProtocolFeature::ValidatorList2Propagation) at
+// PeerImp.cpp:511-514: returns true iff the peer's negotiated
+// peer-protocol version is at least 2.2. Used to gate
+// TMValidatorListCollection ingress; v2.1 peers that send a collection
+// are charged feeUselessData "unsupported peer".
+//
+// When the overlay is unavailable (tests) we err on the side of
+// accepting the frame.
+func (r *Router) peerSupportsValidatorList2(peer peermanagement.PeerID) bool {
+	if r.overlay == nil {
+		return true
+	}
+	return r.overlay.PeerProtocolAtLeast(peer, 2, 2)
 }
 
 // validatorListSemanticHash builds the canonical byte stream that
@@ -266,10 +287,16 @@ func chargePeerForDisposition(r *Router, peer peermanagement.PeerID, prefix stri
 }
 
 // peerSite formats a peer-sourced site URI for the aggregator's
-// per-publisher SiteURI field. Distinct from HTTP-polled URIs so the
-// RPC can tell at a glance where a publisher's most recent list came
-// from.
-func peerSite(peerID peermanagement.PeerID) string {
+// per-publisher SiteURI field. Mirrors rippled's
+// `remote_address_.to_string()` used at PeerImp.cpp:2072 — emits a
+// "host:port" string when the overlay is available, falling back to
+// "peer:<id>" for tests or transient peer lookups.
+func (r *Router) peerSite(peerID peermanagement.PeerID) string {
+	if r.overlay != nil {
+		if addr := r.overlay.PeerRemoteAddr(peerID); addr != "" {
+			return addr
+		}
+	}
 	return "peer:" + strconv.FormatUint(uint64(peerID), 10)
 }
 

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -137,9 +137,18 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 
 	// Empty-blobs guard. Rippled charges feeHeavyBurdenPeer "no blobs"
 	// at PeerImp.cpp:2042-2049 — the heaviest tier, reserved for severe
-	// protocol violations. Surface it as a distinct label so operators
-	// can see this is not a generic bad-signature case.
+	// protocol violations.
+	//
+	// goXRPL's IncPeerBadData does not yet expose tiered fee weights:
+	// every label increments the same counter. Two labels are used to
+	// make the rippled tier difference visible in metrics so operators
+	// can wire alerting on heavy-tier abuse separately, even before the
+	// underlying weight machinery exists:
+	//   - "vl-coll-heavy-no-blobs"   → rippled feeHeavyBurdenPeer
+	//   - "vl-coll-no-blobs"          → general counter retained for
+	//                                   backwards-compatible dashboards
 	if len(coll.Blobs) == 0 {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-heavy-no-blobs")
 		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-no-blobs")
 		return
 	}
@@ -217,11 +226,16 @@ func (r *Router) peerSupportsValidatorList2(peer peermanagement.PeerID) bool {
 	return r.overlay.PeerProtocolAtLeast(peer, 2, 2)
 }
 
-// validatorListSemanticHash builds the canonical byte stream that
-// stands in for rippled's `sha512Half(manifest, blobs, version)` at
-// PeerImp.cpp:2051. The shape is fixed across protobuf re-encodings so
-// dedup catches semantically-identical replays even when the wire bytes
-// differ.
+// validatorListSemanticHash builds a canonical byte stream the local
+// message-seen cache uses to dedup TMValidatorList frames whose wire
+// bytes happened to differ across protobuf re-encodings. The shape is
+// deliberately simple (length-prefixed big-endian) and is NOT
+// byte-equivalent to rippled's `sha512Half(manifest, blobs, version)`
+// at PeerImp.cpp:2051 — rippled's hash flows through C++ `hash_append`
+// overloads. Cross-node equivalence is not required because each node
+// runs an independent seen-hash cache; the only invariant is that two
+// semantically-identical inputs hash to the same value within THIS
+// process.
 func validatorListSemanticHash(vl *message.ValidatorList) []byte {
 	out := make([]byte, 0, 4+len(vl.Manifest)+len(vl.Blob)+len(vl.Signature))
 	out = appendUint32BE(out, vl.Version)
@@ -232,10 +246,11 @@ func validatorListSemanticHash(vl *message.ValidatorList) []byte {
 }
 
 // validatorListCollectionSemanticHash is the collection counterpart of
-// validatorListSemanticHash. Per-blob fields are concatenated in the
-// order the collection presents them — that order is also what
+// validatorListSemanticHash — same local-only dedup contract, not
+// byte-equivalent to rippled's hash. Per-blob fields are concatenated
+// in the order the collection presents them — that order is also what
 // ApplyCollection iterates, so semantically-identical collections hash
-// the same.
+// the same within this process.
 func validatorListCollectionSemanticHash(coll *message.ValidatorListCollection) []byte {
 	out := make([]byte, 0, 4+len(coll.Manifest)+64*len(coll.Blobs))
 	out = appendUint32BE(out, coll.Version)

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -64,7 +64,6 @@ func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
 			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-duplicate")
 			return
 		}
-		// First-seen: register the sender as a peer that has this hash.
 		r.messageSeen.recordPeer(hash, uint64(msg.PeerID))
 	}
 

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -1,0 +1,162 @@
+package adaptor
+
+import (
+	"strconv"
+
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	validatorlist "github.com/LeJamon/goXRPLd/internal/validator/list"
+)
+
+// handleValidatorList ingests an inbound TMValidatorList frame, feeds
+// it into the publisher-trust aggregator, and — on Accepted —
+// rebroadcasts the original frame to other peers. Mirrors rippled's
+// PeerImp::onMessage(TMValidatorList) at PeerImp.cpp:2248-2274 +
+// ValidatorList::applyListsAndBroadcast at ValidatorList.cpp:940-995.
+//
+// When no aggregator is wired (standalone / no publisher trust
+// configured) the frame is silently dropped — gossip carries lists for
+// publishers we may not have opted into trusting, and that's not
+// malicious.
+//
+// Decode failures and verification failures attribute "vl-decode" /
+// "vl-invalid" bad-data to the sender, matching the manifest handler's
+// pattern of charging only on structural / cryptographic failures
+// (Untrusted publishers and Stale / SameSequence dispositions are
+// silent).
+func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
+	if r.validatorList == nil {
+		return
+	}
+	decoded, err := message.Decode(message.TypeValidatorList, msg.Payload)
+	if err != nil {
+		r.logger.Warn("failed to decode TMValidatorList", "error", err, "peer", msg.PeerID)
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-decode")
+		return
+	}
+	vl, ok := decoded.(*message.ValidatorList)
+	if !ok || vl == nil {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-decode")
+		return
+	}
+
+	disp, _ := r.validatorList.ApplyList(vl.Manifest, vl.Blob, vl.Signature, vl.Version, peerSite(msg.PeerID))
+
+	r.logger.Debug("validator list applied",
+		"peer", msg.PeerID,
+		"disposition", disp.String(),
+		"version", vl.Version)
+
+	if disp.IsBadData() {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-"+disp.String())
+		return
+	}
+
+	if disp.ShouldRelay() && r.overlay != nil {
+		frame, err := encodeFrame(message.TypeValidatorList, vl)
+		if err != nil {
+			r.logger.Warn("failed to encode TMValidatorList relay frame", "error", err)
+			return
+		}
+		_ = r.overlay.BroadcastExcept(msg.PeerID, frame)
+	}
+}
+
+// handleValidatorListCollection ingests a TMValidatorListCollection
+// (v2) frame, applying each blob individually with the collection's
+// shared publisher manifest. On any Accepted blob the frame is
+// rebroadcast (matching rippled's per-collection broadcast policy).
+//
+// Bad-data attribution is summarized to the worst disposition across
+// blobs — a collection with one Invalid and several Accepted gets the
+// peer charged once for vl-collection-invalid rather than several
+// times.
+func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessage) {
+	if r.validatorList == nil {
+		return
+	}
+	decoded, err := message.Decode(message.TypeValidatorListCollection, msg.Payload)
+	if err != nil {
+		r.logger.Warn("failed to decode TMValidatorListCollection", "error", err, "peer", msg.PeerID)
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-decode")
+		return
+	}
+	coll, ok := decoded.(*message.ValidatorListCollection)
+	if !ok || coll == nil {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-decode")
+		return
+	}
+
+	dispList, _ := r.validatorList.ApplyCollection(coll, peerSite(msg.PeerID))
+
+	worst := validatorlist.Accepted
+	anyAccepted := false
+	for _, d := range dispList {
+		if d == validatorlist.Accepted {
+			anyAccepted = true
+		}
+		if dispositionRank(d) > dispositionRank(worst) {
+			worst = d
+		}
+	}
+
+	r.logger.Debug("validator list collection applied",
+		"peer", msg.PeerID,
+		"blobs", len(dispList),
+		"worst", worst.String())
+
+	if worst.IsBadData() {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-"+worst.String())
+		// Don't relay a frame containing a poison blob.
+		return
+	}
+
+	if anyAccepted && r.overlay != nil {
+		frame, err := encodeFrame(message.TypeValidatorListCollection, coll)
+		if err != nil {
+			r.logger.Warn("failed to encode TMValidatorListCollection relay frame", "error", err)
+			return
+		}
+		_ = r.overlay.BroadcastExcept(msg.PeerID, frame)
+	}
+}
+
+// dispositionRank returns a "worse-is-larger" ordering used to pick the
+// summary disposition for a v2 collection. Keep in sync with the table
+// in validatorlist.bestDisposition — they describe the same ordering
+// but here we go "worst wins" because the router uses it to attribute
+// bad-data to the sender, whereas the poller uses "best wins" for RPC.
+func dispositionRank(d validatorlist.Disposition) int {
+	switch d {
+	case validatorlist.Accepted:
+		return 0
+	case validatorlist.Expired:
+		return 1
+	case validatorlist.Pending:
+		return 2
+	case validatorlist.SameSequence:
+		return 3
+	case validatorlist.KnownSequence:
+		return 4
+	case validatorlist.Stale:
+		return 5
+	case validatorlist.Untrusted:
+		return 6
+	case validatorlist.Invalid:
+		return 7
+	case validatorlist.UnsupportedVersion:
+		return 8
+	case validatorlist.Malformed:
+		return 9
+	default:
+		return -1
+	}
+}
+
+// peerSite formats a peer-sourced site URI for the aggregator's
+// per-publisher SiteURI field. Distinct from HTTP-polled URIs so the
+// RPC can tell at a glance where a publisher's most recent list came
+// from.
+func peerSite(peerID peermanagement.PeerID) string {
+	return "peer:" + strconv.FormatUint(uint64(peerID), 10)
+}

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"encoding/binary"
 	"strconv"
 
 	"github.com/LeJamon/goXRPLd/crypto/common"
@@ -15,8 +16,8 @@ import (
 //
 // Mirrors rippled's PeerImp::onMessage(TMValidatorList) at
 // PeerImp.cpp:2248-2274 plus the shared onValidatorListMessage helper
-// at PeerImp.cpp:2033-2245 (hash-suppression dedup, charge-by-
-// disposition, broadcast-on-fresh).
+// at PeerImp.cpp:2033-2245 (feature gate, hash-suppression dedup,
+// charge-by-disposition, broadcast-on-fresh).
 //
 // When no aggregator is wired (standalone / no publisher trust
 // configured) the frame is silently dropped — gossip carries lists for
@@ -27,16 +28,12 @@ func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
 		return
 	}
 
-	// Hash-suppression dedup (PeerImp.cpp:2051-2066). Rippled keys this
-	// by `sha512Half(manifest, blobs, version)`; the goXRPL message_seen
-	// tracker hashes the full wire payload, which yields the same
-	// equivalence class for any byte-identical frame replay.
-	if r.messageSeen != nil {
-		hash := common.Sha512Half(msg.Payload)
-		if firstSeen, _ := r.messageSeen.observe(hash); !firstSeen {
-			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-duplicate")
-			return
-		}
+	// Peer-feature gate. Mirrors PeerImp.cpp:2252-2260: peers that did
+	// not negotiate ValidatorListPropagation should not be pushing
+	// these frames; rippled charges feeUselessData and returns.
+	if !r.peerSupportsValidatorListFeature(msg.PeerID) {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-unsupported-peer")
+		return
 	}
 
 	decoded, err := message.Decode(message.TypeValidatorList, msg.Payload)
@@ -49,6 +46,18 @@ func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
 	if !ok || vl == nil {
 		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-decode")
 		return
+	}
+
+	// Semantic dedup. Rippled keys this by `sha512Half(manifest, blobs,
+	// version)` (PeerImp.cpp:2051) — semantic content, not wire bytes,
+	// so two peers gossiping the same blob via different protobuf
+	// encodings both suppress on the second arrival.
+	if r.messageSeen != nil {
+		hash := common.Sha512Half(validatorListSemanticHash(vl))
+		if firstSeen, _ := r.messageSeen.observe(hash); !firstSeen {
+			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-duplicate")
+			return
+		}
 	}
 
 	disp, _ := r.validatorList.ApplyList(vl.Manifest, vl.Blob, vl.Signature, vl.Version, peerSite(msg.PeerID))
@@ -84,20 +93,10 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 		return
 	}
 
-	// Reject v1 collections upfront, matching rippled PeerImp.cpp:2291-2299.
-	if peeked, err := message.Decode(message.TypeValidatorListCollection, msg.Payload); err == nil {
-		if coll, ok := peeked.(*message.ValidatorListCollection); ok && coll != nil && coll.Version < 2 {
-			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-wrong-version")
-			return
-		}
-	}
-
-	if r.messageSeen != nil {
-		hash := common.Sha512Half(msg.Payload)
-		if firstSeen, _ := r.messageSeen.observe(hash); !firstSeen {
-			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-duplicate")
-			return
-		}
+	// Peer-feature gate. Mirrors PeerImp.cpp:2282-2290.
+	if !r.peerSupportsValidatorListFeature(msg.PeerID) {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-unsupported-peer")
+		return
 	}
 
 	decoded, err := message.Decode(message.TypeValidatorListCollection, msg.Payload)
@@ -110,6 +109,32 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 	if !ok || coll == nil {
 		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-decode")
 		return
+	}
+
+	// Reject v1 collections upfront, matching rippled PeerImp.cpp:2291-2299
+	// (feeInvalidData "wrong version"). Decoding once and inspecting the
+	// version on the decoded message avoids the original code's
+	// double-decode.
+	if coll.Version < 2 {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-wrong-version")
+		return
+	}
+
+	// Empty-blobs guard. Rippled charges feeHeavyBurdenPeer "no blobs"
+	// at PeerImp.cpp:2042-2049 — the heaviest tier, reserved for severe
+	// protocol violations. Surface it as a distinct label so operators
+	// can see this is not a generic bad-signature case.
+	if len(coll.Blobs) == 0 {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-no-blobs")
+		return
+	}
+
+	if r.messageSeen != nil {
+		hash := common.Sha512Half(validatorListCollectionSemanticHash(coll))
+		if firstSeen, _ := r.messageSeen.observe(hash); !firstSeen {
+			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-duplicate")
+			return
+		}
 	}
 
 	dispList, _ := r.validatorList.ApplyCollection(coll, peerSite(msg.PeerID))
@@ -145,6 +170,60 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 		}
 		_ = r.overlay.BroadcastExcept(msg.PeerID, frame)
 	}
+}
+
+// peerSupportsValidatorListFeature mirrors rippled's
+// supportsFeature(ProtocolFeature::ValidatorListPropagation) check at
+// PeerImp.cpp:2252. When the overlay is unavailable (tests) we err on
+// the side of accepting the frame — matching the pre-fix behaviour.
+func (r *Router) peerSupportsValidatorListFeature(peer peermanagement.PeerID) bool {
+	if r.overlay == nil {
+		return true
+	}
+	return r.overlay.PeerSupports(peer, peermanagement.FeatureValidatorListPropagation)
+}
+
+// validatorListSemanticHash builds the canonical byte stream that
+// stands in for rippled's `sha512Half(manifest, blobs, version)` at
+// PeerImp.cpp:2051. The shape is fixed across protobuf re-encodings so
+// dedup catches semantically-identical replays even when the wire bytes
+// differ.
+func validatorListSemanticHash(vl *message.ValidatorList) []byte {
+	out := make([]byte, 0, 4+len(vl.Manifest)+len(vl.Blob)+len(vl.Signature))
+	out = appendUint32BE(out, vl.Version)
+	out = appendLengthPrefixed(out, vl.Manifest)
+	out = appendLengthPrefixed(out, vl.Blob)
+	out = appendLengthPrefixed(out, vl.Signature)
+	return out
+}
+
+// validatorListCollectionSemanticHash is the collection counterpart of
+// validatorListSemanticHash. Per-blob fields are concatenated in the
+// order the collection presents them — that order is also what
+// ApplyCollection iterates, so semantically-identical collections hash
+// the same.
+func validatorListCollectionSemanticHash(coll *message.ValidatorListCollection) []byte {
+	out := make([]byte, 0, 4+len(coll.Manifest)+64*len(coll.Blobs))
+	out = appendUint32BE(out, coll.Version)
+	out = appendLengthPrefixed(out, coll.Manifest)
+	for _, b := range coll.Blobs {
+		out = appendLengthPrefixed(out, b.Manifest)
+		out = appendLengthPrefixed(out, b.Blob)
+		out = appendLengthPrefixed(out, b.Signature)
+	}
+	return out
+}
+
+func appendUint32BE(out []byte, v uint32) []byte {
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], v)
+	return append(out, buf[:]...)
+}
+
+func appendLengthPrefixed(out, data []byte) []byte {
+	out = appendUint32BE(out, uint32(len(data)))
+	out = append(out, data...)
+	return out
 }
 
 // chargePeerForDisposition maps a Disposition's rippled fee tier

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -2,6 +2,7 @@ package adaptor
 
 import (
 	"encoding/binary"
+	"fmt"
 	"strconv"
 
 	"github.com/LeJamon/goXRPLd/crypto/common"
@@ -60,22 +61,31 @@ func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
 		}
 	}
 
-	disp, _ := r.validatorList.ApplyList(vl.Manifest, vl.Blob, vl.Signature, vl.Version, peerSite(msg.PeerID))
+	disp, pubKey, seq := r.validatorList.ApplyList(vl.Manifest, vl.Blob, vl.Signature, vl.Version, peerSite(msg.PeerID))
 
 	r.logger.Debug("validator list applied",
 		"peer", msg.PeerID,
 		"disposition", disp.String(),
-		"version", vl.Version)
+		"version", vl.Version,
+		"sequence", seq)
 
 	chargePeerForDisposition(r, msg.PeerID, "vl", disp)
 
-	if disp.ShouldRelay() && r.overlay != nil {
-		frame, encErr := encodeFrame(message.TypeValidatorList, vl)
-		if encErr != nil {
-			r.logger.Warn("failed to encode TMValidatorList relay frame", "error", encErr)
-			return
-		}
-		_ = r.overlay.BroadcastExcept(msg.PeerID, frame)
+	// Record what the peer demonstrably has so subsequent broadcasts
+	// from any source skip them. Mirrors rippled PeerImp.cpp:2102-2110
+	// which updates publisherListSequences_[pubKey] for accepted /
+	// expired / pending / same_sequence / known_sequence dispositions.
+	if pubKey != (validatorlist.PublisherKey{}) && seq > 0 && disp.ShouldRelay() {
+		r.validatorList.RecordPeerSequence(uint64(msg.PeerID), pubKey, seq)
+	}
+
+	// Relay the latest STORED accepted blob (not necessarily the
+	// inbound frame) via the aggregator-owned broadcast path. The
+	// aggregator skips peers already at this sequence and the
+	// originating peer. Mirrors rippled applyListsAndBroadcast →
+	// broadcastBlobs at ValidatorList.cpp:872-937.
+	if disp.ShouldRelay() && pubKey != (validatorlist.PublisherKey{}) {
+		r.validatorList.BroadcastLatest(pubKey, uint64(msg.PeerID))
 	}
 }
 
@@ -137,7 +147,7 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 		}
 	}
 
-	dispList, _ := r.validatorList.ApplyCollection(coll, peerSite(msg.PeerID))
+	dispList, pubKey, maxSeq := r.validatorList.ApplyCollection(coll, peerSite(msg.PeerID))
 
 	worst := validatorlist.Accepted
 	anyRelay := false
@@ -153,7 +163,8 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 	r.logger.Debug("validator list collection applied",
 		"peer", msg.PeerID,
 		"blobs", len(dispList),
-		"worst", worst.String())
+		"worst", worst.String(),
+		"max_sequence", maxSeq)
 
 	chargePeerForDisposition(r, msg.PeerID, "vl-coll", worst)
 
@@ -162,13 +173,15 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 		return
 	}
 
-	if anyRelay && r.overlay != nil {
-		frame, encErr := encodeFrame(message.TypeValidatorListCollection, coll)
-		if encErr != nil {
-			r.logger.Warn("failed to encode TMValidatorListCollection relay frame", "error", encErr)
-			return
-		}
-		_ = r.overlay.BroadcastExcept(msg.PeerID, frame)
+	// Record per-peer sequence using the highest blob sequence observed
+	// across the collection (mirrors rippled PeerImp.cpp:2110 which
+	// uses applyResult.sequence == bestDisposition's max sequence).
+	if pubKey != (validatorlist.PublisherKey{}) && maxSeq > 0 && anyRelay {
+		r.validatorList.RecordPeerSequence(uint64(msg.PeerID), pubKey, maxSeq)
+	}
+
+	if anyRelay && pubKey != (validatorlist.PublisherKey{}) {
+		r.validatorList.BroadcastLatest(pubKey, uint64(msg.PeerID))
 	}
 }
 
@@ -258,4 +271,68 @@ func chargePeerForDisposition(r *Router, peer peermanagement.PeerID, prefix stri
 // from.
 func peerSite(peerID peermanagement.PeerID) string {
 	return "peer:" + strconv.FormatUint(uint64(peerID), 10)
+}
+
+// RouterBroadcaster is the concrete validatorlist.PeerBroadcaster
+// adapter that bridges the aggregator to the overlay + frame codec.
+// One instance lives for the lifetime of the router; the aggregator
+// holds a reference (set via SetBroadcaster in Components bootstrap).
+//
+// All three methods are safe for concurrent use: ActivePeers and
+// PeerSupportsVL take the overlay's read-side locks; SendList encodes
+// fresh bytes per call. Returns are non-fatal — the aggregator logs
+// and continues with the next peer.
+type RouterBroadcaster struct {
+	overlay *peermanagement.Overlay
+	sender  NetworkSender
+}
+
+// NewRouterBroadcaster wires the overlay (for peer enumeration +
+// feature lookup) and the sender (for per-peer SendToPeer). Passing
+// nil for either degrades the broadcaster to a silent no-op so tests
+// without an overlay don't crash.
+func NewRouterBroadcaster(overlay *peermanagement.Overlay, sender NetworkSender) *RouterBroadcaster {
+	return &RouterBroadcaster{overlay: overlay, sender: sender}
+}
+
+// ActivePeers implements validatorlist.PeerBroadcaster.
+func (b *RouterBroadcaster) ActivePeers() []uint64 {
+	if b == nil || b.overlay == nil {
+		return nil
+	}
+	infos := b.overlay.Peers()
+	out := make([]uint64, 0, len(infos))
+	for _, p := range infos {
+		out = append(out, uint64(p.ID))
+	}
+	return out
+}
+
+// PeerSupportsVL implements validatorlist.PeerBroadcaster.
+func (b *RouterBroadcaster) PeerSupportsVL(peerID uint64) bool {
+	if b == nil || b.overlay == nil {
+		return false
+	}
+	return b.overlay.PeerSupports(peermanagement.PeerID(peerID), peermanagement.FeatureValidatorListPropagation)
+}
+
+// SendList implements validatorlist.PeerBroadcaster. Encodes a
+// TMValidatorList carrying the supplied wire bytes verbatim and
+// delivers it to peerID via the adaptor sender. blobVersion goes on
+// the frame's `version` field.
+func (b *RouterBroadcaster) SendList(peerID uint64, manifestBytes, blob, signature []byte, blobVersion uint32) error {
+	if b == nil || b.sender == nil {
+		return fmt.Errorf("router broadcaster: nil sender")
+	}
+	vl := &message.ValidatorList{
+		Manifest:  manifestBytes,
+		Blob:      blob,
+		Signature: signature,
+		Version:   blobVersion,
+	}
+	frame, err := encodeFrame(message.TypeValidatorList, vl)
+	if err != nil {
+		return fmt.Errorf("encode TMValidatorList: %w", err)
+	}
+	return b.sender.SendToPeer(peerID, frame)
 }

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -56,9 +56,16 @@ func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
 	if r.messageSeen != nil {
 		hash := common.Sha512Half(validatorListSemanticHash(vl))
 		if firstSeen, _ := r.messageSeen.observe(hash); !firstSeen {
+			// Stamp the sender on the existing hash entry so downstream
+			// rebroadcast paths skip them. Mirrors rippled
+			// HashRouter::addSuppressionPeer's peer-set extension on a
+			// duplicate (HashRouter.cpp:115-134).
+			r.messageSeen.recordPeer(hash, uint64(msg.PeerID))
 			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-duplicate")
 			return
 		}
+		// First-seen: register the sender as a peer that has this hash.
+		r.messageSeen.recordPeer(hash, uint64(msg.PeerID))
 	}
 
 	disp, pubKey, seq := r.validatorList.ApplyList(vl.Manifest, vl.Blob, vl.Signature, vl.Version, r.peerSite(msg.PeerID))
@@ -156,9 +163,11 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 	if r.messageSeen != nil {
 		hash := common.Sha512Half(validatorListCollectionSemanticHash(coll))
 		if firstSeen, _ := r.messageSeen.observe(hash); !firstSeen {
+			r.messageSeen.recordPeer(hash, uint64(msg.PeerID))
 			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-duplicate")
 			return
 		}
+		r.messageSeen.recordPeer(hash, uint64(msg.PeerID))
 	}
 
 	dispList, pubKey, maxSeq := r.validatorList.ApplyCollection(coll, r.peerSite(msg.PeerID))
@@ -327,14 +336,33 @@ func (r *Router) peerSite(peerID peermanagement.PeerID) string {
 type RouterBroadcaster struct {
 	overlay *peermanagement.Overlay
 	sender  NetworkSender
+	// suppression is the optional shared hash registry. When wired,
+	// SendList / SendCollection record each (hash, peer) pair after a
+	// successful send so future inbound from that peer with the same
+	// hash maps to a "known sender" path and the broadcast loop can
+	// skip peers already known to have the content. Mirrors rippled's
+	// `hashRouter.addSuppressionPeer(hash, peer->id())` at
+	// rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:781 + 932.
+	suppression *messageSuppression
 }
 
 // NewRouterBroadcaster wires the overlay (for peer enumeration +
 // feature lookup) and the sender (for per-peer SendToPeer). Passing
 // nil for either degrades the broadcaster to a silent no-op so tests
-// without an overlay don't crash.
+// without an overlay don't crash. Direct callers that pass through
+// this constructor get a broadcaster without hash-suppression
+// tracking; route through Router.NewValidatorListBroadcaster to
+// plumb the shared suppression registry.
 func NewRouterBroadcaster(overlay *peermanagement.Overlay, sender NetworkSender) *RouterBroadcaster {
 	return &RouterBroadcaster{overlay: overlay, sender: sender}
+}
+
+// NewValidatorListBroadcaster constructs a RouterBroadcaster bound to
+// the Router's suppression registry so SendList / SendCollection
+// stamp the hash→peer association expected by rippled's HashRouter
+// model.
+func (r *Router) NewValidatorListBroadcaster(overlay *peermanagement.Overlay, sender NetworkSender) *RouterBroadcaster {
+	return &RouterBroadcaster{overlay: overlay, sender: sender, suppression: r.messageSeen}
 }
 
 // ActivePeers implements validatorlist.PeerBroadcaster.
@@ -358,10 +386,22 @@ func (b *RouterBroadcaster) PeerSupportsVL(peerID uint64) bool {
 	return b.overlay.PeerSupports(peermanagement.PeerID(peerID), peermanagement.FeatureValidatorListPropagation)
 }
 
+// PeerSupportsV2 implements validatorlist.PeerBroadcaster. Mirrors
+// rippled's `supportsFeature(ProtocolFeature::ValidatorList2Propagation)`
+// at PeerImp.cpp:511-514 which gates on negotiated protocol >= 2.2.
+func (b *RouterBroadcaster) PeerSupportsV2(peerID uint64) bool {
+	if b == nil || b.overlay == nil {
+		return false
+	}
+	return b.overlay.PeerProtocolAtLeast(peermanagement.PeerID(peerID), 2, 2)
+}
+
 // SendList implements validatorlist.PeerBroadcaster. Encodes a
 // TMValidatorList carrying the supplied wire bytes verbatim and
 // delivers it to peerID via the adaptor sender. blobVersion goes on
-// the frame's `version` field.
+// the frame's `version` field. When wired with a suppression
+// registry: short-circuits peers already known to have the content,
+// and stamps the (hash, peer) pair after a successful send.
 func (b *RouterBroadcaster) SendList(peerID uint64, manifestBytes, blob, signature []byte, blobVersion uint32) error {
 	if b == nil || b.sender == nil {
 		return fmt.Errorf("router broadcaster: nil sender")
@@ -376,5 +416,56 @@ func (b *RouterBroadcaster) SendList(peerID uint64, manifestBytes, blob, signatu
 	if err != nil {
 		return fmt.Errorf("encode TMValidatorList: %w", err)
 	}
-	return b.sender.SendToPeer(peerID, frame)
+	hash := common.Sha512Half(validatorListSemanticHash(vl))
+	if b.suppression != nil && b.suppression.peerHasHash(hash, peerID) {
+		// Peer already has this content. Skip the redundant send.
+		// Mirrors rippled's "skip peers already in the hash's
+		// suppression peer-set" optimisation at
+		// ValidatorList.cpp:923-925.
+		return nil
+	}
+	if err := b.sender.SendToPeer(peerID, frame); err != nil {
+		return err
+	}
+	if b.suppression != nil {
+		b.suppression.recordPeer(hash, peerID)
+	}
+	return nil
+}
+
+// SendCollection implements validatorlist.PeerBroadcaster. Encodes a
+// TMValidatorListCollection carrying the publisher manifest plus the
+// supplied (per-blob manifest, blob, signature) tuples and delivers
+// it to peerID. Used by BroadcastLatest when the publisher has
+// pending Remaining blobs AND the recipient negotiated v2.
+func (b *RouterBroadcaster) SendCollection(peerID uint64, manifestBytes []byte, blobs []validatorlist.BroadcastBlob, version uint32) error {
+	if b == nil || b.sender == nil {
+		return fmt.Errorf("router broadcaster: nil sender")
+	}
+	coll := &message.ValidatorListCollection{
+		Version:  version,
+		Manifest: manifestBytes,
+	}
+	for _, blob := range blobs {
+		coll.Blobs = append(coll.Blobs, message.ValidatorBlobInfo{
+			Manifest:  blob.Manifest,
+			Blob:      blob.Blob,
+			Signature: blob.Signature,
+		})
+	}
+	frame, err := encodeFrame(message.TypeValidatorListCollection, coll)
+	if err != nil {
+		return fmt.Errorf("encode TMValidatorListCollection: %w", err)
+	}
+	hash := common.Sha512Half(validatorListCollectionSemanticHash(coll))
+	if b.suppression != nil && b.suppression.peerHasHash(hash, peerID) {
+		return nil
+	}
+	if err := b.sender.SendToPeer(peerID, frame); err != nil {
+		return err
+	}
+	if b.suppression != nil {
+		b.suppression.recordPeer(hash, peerID)
+	}
+	return nil
 }

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -59,7 +59,7 @@ func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
 			// Stamp the sender on the existing hash entry so downstream
 			// rebroadcast paths skip them. Mirrors rippled
 			// HashRouter::addSuppressionPeer's peer-set extension on a
-			// duplicate (HashRouter.cpp:115-134).
+			// duplicate (HashRouter.cpp:51-79).
 			r.messageSeen.recordPeer(hash, uint64(msg.PeerID))
 			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-duplicate")
 			return
@@ -421,7 +421,7 @@ func (b *RouterBroadcaster) SendList(peerID uint64, manifestBytes, blob, signatu
 		// Peer already has this content. Skip the redundant send.
 		// Mirrors rippled's "skip peers already in the hash's
 		// suppression peer-set" optimisation at
-		// ValidatorList.cpp:923-925.
+		// ValidatorList.cpp:909 (`if (toSkip->count(peer->id()) == 0)`).
 		return nil
 	}
 	if err := b.sender.SendToPeer(peerID, frame); err != nil {
@@ -436,8 +436,9 @@ func (b *RouterBroadcaster) SendList(peerID uint64, manifestBytes, blob, signatu
 // SendCollection implements validatorlist.PeerBroadcaster. Encodes a
 // TMValidatorListCollection carrying the publisher manifest plus the
 // supplied (per-blob manifest, blob, signature) tuples and delivers
-// it to peerID. Used by BroadcastLatest when the publisher has
-// pending Remaining blobs AND the recipient negotiated v2.
+// it to peerID. Used by BroadcastLatest for every v2-capable peer
+// (single-entry collection when the publisher has no Remaining
+// blobs, multi-entry when it does).
 func (b *RouterBroadcaster) SendCollection(peerID uint64, manifestBytes []byte, blobs []validatorlist.BroadcastBlob, version uint32) error {
 	if b == nil || b.sender == nil {
 		return fmt.Errorf("router broadcaster: nil sender")

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -3,31 +3,42 @@ package adaptor
 import (
 	"strconv"
 
+	"github.com/LeJamon/goXRPLd/crypto/common"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 	validatorlist "github.com/LeJamon/goXRPLd/internal/validator/list"
 )
 
 // handleValidatorList ingests an inbound TMValidatorList frame, feeds
-// it into the publisher-trust aggregator, and — on Accepted —
-// rebroadcasts the original frame to other peers. Mirrors rippled's
-// PeerImp::onMessage(TMValidatorList) at PeerImp.cpp:2248-2274 +
-// ValidatorList::applyListsAndBroadcast at ValidatorList.cpp:940-995.
+// it into the publisher-trust aggregator, and — when the disposition
+// permits — rebroadcasts the original frame to other peers.
+//
+// Mirrors rippled's PeerImp::onMessage(TMValidatorList) at
+// PeerImp.cpp:2248-2274 plus the shared onValidatorListMessage helper
+// at PeerImp.cpp:2033-2245 (hash-suppression dedup, charge-by-
+// disposition, broadcast-on-fresh).
 //
 // When no aggregator is wired (standalone / no publisher trust
 // configured) the frame is silently dropped — gossip carries lists for
 // publishers we may not have opted into trusting, and that's not
 // malicious.
-//
-// Decode failures and verification failures attribute "vl-decode" /
-// "vl-invalid" bad-data to the sender, matching the manifest handler's
-// pattern of charging only on structural / cryptographic failures
-// (Untrusted publishers and Stale / SameSequence dispositions are
-// silent).
 func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
 	if r.validatorList == nil {
 		return
 	}
+
+	// Hash-suppression dedup (PeerImp.cpp:2051-2066). Rippled keys this
+	// by `sha512Half(manifest, blobs, version)`; the goXRPL message_seen
+	// tracker hashes the full wire payload, which yields the same
+	// equivalence class for any byte-identical frame replay.
+	if r.messageSeen != nil {
+		hash := common.Sha512Half(msg.Payload)
+		if firstSeen, _ := r.messageSeen.observe(hash); !firstSeen {
+			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-duplicate")
+			return
+		}
+	}
+
 	decoded, err := message.Decode(message.TypeValidatorList, msg.Payload)
 	if err != nil {
 		r.logger.Warn("failed to decode TMValidatorList", "error", err, "peer", msg.PeerID)
@@ -47,15 +58,12 @@ func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
 		"disposition", disp.String(),
 		"version", vl.Version)
 
-	if disp.IsBadData() {
-		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-"+disp.String())
-		return
-	}
+	chargePeerForDisposition(r, msg.PeerID, "vl", disp)
 
 	if disp.ShouldRelay() && r.overlay != nil {
-		frame, err := encodeFrame(message.TypeValidatorList, vl)
-		if err != nil {
-			r.logger.Warn("failed to encode TMValidatorList relay frame", "error", err)
+		frame, encErr := encodeFrame(message.TypeValidatorList, vl)
+		if encErr != nil {
+			r.logger.Warn("failed to encode TMValidatorList relay frame", "error", encErr)
 			return
 		}
 		_ = r.overlay.BroadcastExcept(msg.PeerID, frame)
@@ -64,17 +72,34 @@ func (r *Router) handleValidatorList(msg *peermanagement.InboundMessage) {
 
 // handleValidatorListCollection ingests a TMValidatorListCollection
 // (v2) frame, applying each blob individually with the collection's
-// shared publisher manifest. On any Accepted blob the frame is
-// rebroadcast (matching rippled's per-collection broadcast policy).
+// shared publisher manifest. When at least one blob relays the frame
+// is rebroadcast to other peers.
 //
-// Bad-data attribution is summarized to the worst disposition across
-// blobs — a collection with one Invalid and several Accepted gets the
-// peer charged once for vl-collection-invalid rather than several
-// times.
+// Bad-data attribution uses the worst per-blob disposition — a
+// collection with one Invalid blob and several Accepted blobs gets the
+// peer charged once for vl-coll-invalid rather than several times.
+// Mirrors rippled's PeerImp.cpp:2141-2183 worstDisposition logic.
 func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessage) {
 	if r.validatorList == nil {
 		return
 	}
+
+	// Reject v1 collections upfront, matching rippled PeerImp.cpp:2291-2299.
+	if peeked, err := message.Decode(message.TypeValidatorListCollection, msg.Payload); err == nil {
+		if coll, ok := peeked.(*message.ValidatorListCollection); ok && coll != nil && coll.Version < 2 {
+			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-wrong-version")
+			return
+		}
+	}
+
+	if r.messageSeen != nil {
+		hash := common.Sha512Half(msg.Payload)
+		if firstSeen, _ := r.messageSeen.observe(hash); !firstSeen {
+			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-duplicate")
+			return
+		}
+	}
+
 	decoded, err := message.Decode(message.TypeValidatorListCollection, msg.Payload)
 	if err != nil {
 		r.logger.Warn("failed to decode TMValidatorListCollection", "error", err, "peer", msg.PeerID)
@@ -90,12 +115,12 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 	dispList, _ := r.validatorList.ApplyCollection(coll, peerSite(msg.PeerID))
 
 	worst := validatorlist.Accepted
-	anyAccepted := false
+	anyRelay := false
 	for _, d := range dispList {
-		if d == validatorlist.Accepted {
-			anyAccepted = true
+		if d.ShouldRelay() {
+			anyRelay = true
 		}
-		if dispositionRank(d) > dispositionRank(worst) {
+		if d.Severity() > worst.Severity() {
 			worst = d
 		}
 	}
@@ -105,52 +130,47 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 		"blobs", len(dispList),
 		"worst", worst.String())
 
+	chargePeerForDisposition(r, msg.PeerID, "vl-coll", worst)
+
 	if worst.IsBadData() {
-		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "vl-coll-"+worst.String())
 		// Don't relay a frame containing a poison blob.
 		return
 	}
 
-	if anyAccepted && r.overlay != nil {
-		frame, err := encodeFrame(message.TypeValidatorListCollection, coll)
-		if err != nil {
-			r.logger.Warn("failed to encode TMValidatorListCollection relay frame", "error", err)
+	if anyRelay && r.overlay != nil {
+		frame, encErr := encodeFrame(message.TypeValidatorListCollection, coll)
+		if encErr != nil {
+			r.logger.Warn("failed to encode TMValidatorListCollection relay frame", "error", encErr)
 			return
 		}
 		_ = r.overlay.BroadcastExcept(msg.PeerID, frame)
 	}
 }
 
-// dispositionRank returns a "worse-is-larger" ordering used to pick the
-// summary disposition for a v2 collection. Keep in sync with the table
-// in validatorlist.bestDisposition — they describe the same ordering
-// but here we go "worst wins" because the router uses it to attribute
-// bad-data to the sender, whereas the poller uses "best wins" for RPC.
-func dispositionRank(d validatorlist.Disposition) int {
-	switch d {
-	case validatorlist.Accepted:
-		return 0
-	case validatorlist.Expired:
-		return 1
-	case validatorlist.Pending:
-		return 2
-	case validatorlist.SameSequence:
-		return 3
-	case validatorlist.KnownSequence:
-		return 4
-	case validatorlist.Stale:
-		return 5
-	case validatorlist.Untrusted:
-		return 6
-	case validatorlist.Invalid:
-		return 7
-	case validatorlist.UnsupportedVersion:
-		return 8
-	case validatorlist.Malformed:
-		return 9
+// chargePeerForDisposition maps a Disposition's rippled fee tier
+// (Disposition.Charge) into a distinct IncPeerBadData label. Mirrors
+// PeerImp.cpp:2141-2183:
+//
+//	feeUselessData     -> "<prefix>-useless-<disposition>"
+//	feeInvalidData     -> "<prefix>-baddata-<disposition>"
+//	feeInvalidSignature -> "<prefix>-badsig-<disposition>"
+//
+// Operators get per-tier metrics matching rippled's accounting.
+func chargePeerForDisposition(r *Router, peer peermanagement.PeerID, prefix string, d validatorlist.Disposition) {
+	var tag string
+	switch d.Charge() {
+	case validatorlist.ChargeNone:
+		return
+	case validatorlist.ChargeUselessData:
+		tag = "useless"
+	case validatorlist.ChargeInvalidData:
+		tag = "baddata"
+	case validatorlist.ChargeInvalidSignature:
+		tag = "badsig"
 	default:
-		return -1
+		return
 	}
+	r.adaptor.IncPeerBadData(uint64(peer), prefix+"-"+tag+"-"+d.String())
 }
 
 // peerSite formats a peer-sourced site URI for the aggregator's

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/LeJamon/goXRPLd/config"
@@ -45,12 +46,15 @@ type Components struct {
 	// Nil iff ValidatorList is nil or no sites are configured.
 	ValidatorListPoller *validatorlist.SitePoller
 
-	// StaticTrustedMasterKeys carries the master pubkeys parsed out of
-	// the operator's `[validators]` config stanza. Captured here so the
-	// `validators` RPC can surface them as `local_static_keys` without
-	// having to re-parse config or query a mutable adaptor field that
-	// also includes publisher-derived entries.
-	StaticTrustedMasterKeys [][33]byte
+	// staticMu guards staticValidators / staticMasterKeys. Both slices
+	// hold the operator's most recent [validators] stanza — initially
+	// from boot, refreshed on every SIGHUP via ReloadStaticValidators.
+	// The publisher-trust OnChange callback reads under staticMu so a
+	// SIGHUP removal can never be silently undone by the next publisher
+	// event re-merging a boot-time snapshot.
+	staticMu         sync.RWMutex
+	staticValidators []consensus.NodeID
+	staticMasterKeys [][33]byte
 
 	// Archive is the on-disk validation archive, when enabled.
 	// Nil if disabled in config or if no relational DB is configured.
@@ -311,17 +315,6 @@ func NewFromConfig(
 		if err != nil {
 			return nil, fmt.Errorf("validator-list aggregator: %w", err)
 		}
-		// On every publisher-trust recompute, merge the publisher's
-		// validators with the operator's static [validators] stanza and
-		// push the union into the adaptor. The static list never
-		// disappears — operators may want to pin a few validators in
-		// addition to whatever a publisher publishes.
-		staticValidators := append([]consensus.NodeID(nil), validators...)
-		staticMasterKeys := append([][33]byte(nil), masterKeys...)
-		vlAgg.OnChange(func(publisherNodes []consensus.NodeID, publisherMasters [][33]byte) {
-			merged, mergedMasters := mergeValidators(staticValidators, staticMasterKeys, publisherNodes, publisherMasters)
-			adaptor.SetTrustedValidators(merged, mergedMasters)
-		})
 		router.SetValidatorListAggregator(vlAgg)
 		if len(appCfg.Validators.ValidatorListSites) > 0 {
 			vlPoller = validatorlist.NewSitePoller(
@@ -360,19 +353,82 @@ func NewFromConfig(
 		return opMode.String()
 	})
 
-	staticMastersCopy := append([][33]byte(nil), masterKeys...)
-	return &Components{
-		Overlay:                 overlay,
-		Engine:                  engine,
-		Adaptor:                 adaptor,
-		Router:                  router,
-		ModeManager:             modeManager,
-		Manifests:               manifestCache,
-		ValidatorList:           vlAgg,
-		ValidatorListPoller:     vlPoller,
-		StaticTrustedMasterKeys: staticMastersCopy,
-		Archive:                 validationArchive,
-	}, nil
+	c := &Components{
+		Overlay:             overlay,
+		Engine:              engine,
+		Adaptor:             adaptor,
+		Router:              router,
+		ModeManager:         modeManager,
+		Manifests:           manifestCache,
+		ValidatorList:       vlAgg,
+		ValidatorListPoller: vlPoller,
+		staticValidators:    append([]consensus.NodeID(nil), validators...),
+		staticMasterKeys:    append([][33]byte(nil), masterKeys...),
+		Archive:             validationArchive,
+	}
+
+	// Wire the publisher OnChange to merge against the live static set
+	// (held under c.staticMu, refreshed by SIGHUP). Capturing the boot
+	// values directly here would let a SIGHUP removal be silently undone
+	// by the next publisher event.
+	if vlAgg != nil {
+		vlAgg.OnChange(func(publisherNodes []consensus.NodeID, publisherMasters [][33]byte) {
+			staticV, staticM := c.snapshotStatic()
+			merged, mergedMasters := mergeValidators(staticV, staticM, publisherNodes, publisherMasters)
+			adaptor.SetTrustedValidators(merged, mergedMasters)
+		})
+	}
+
+	return c, nil
+}
+
+// snapshotStatic returns deep copies of the current static validator
+// set under staticMu. Both slices are safe for the caller to retain.
+func (c *Components) snapshotStatic() ([]consensus.NodeID, [][33]byte) {
+	c.staticMu.RLock()
+	defer c.staticMu.RUnlock()
+	v := append([]consensus.NodeID(nil), c.staticValidators...)
+	m := append([][33]byte(nil), c.staticMasterKeys...)
+	return v, m
+}
+
+// StaticTrustedMasterKeys returns a snapshot of the operator's static
+// [validators] master keys. Reflects the latest ReloadStaticValidators
+// call — i.e. SIGHUP-updated state, not just the boot-time stanza.
+func (c *Components) StaticTrustedMasterKeys() [][33]byte {
+	_, m := c.snapshotStatic()
+	return m
+}
+
+// ReloadStaticValidators replaces the operator's static [validators]
+// stanza atomically and re-pushes the resulting trusted set into the
+// adaptor.
+//
+// When a publisher-trust aggregator is wired, the push is the union of
+// the new static set and the aggregator's current trusted set —
+// mirrors rippled's updateTrusted which always recomputes from both
+// localPublisherList and publisherLists_. When no aggregator is wired
+// the static set is pushed verbatim (single source of truth).
+//
+// SIGHUP-driven config reload calls this; publisher events do NOT —
+// they go through the aggregator's OnChange callback wired in
+// NewFromConfig.
+func (c *Components) ReloadStaticValidators(validators []consensus.NodeID, masterKeys [][33]byte) {
+	c.staticMu.Lock()
+	c.staticValidators = append([]consensus.NodeID(nil), validators...)
+	c.staticMasterKeys = append([][33]byte(nil), masterKeys...)
+	c.staticMu.Unlock()
+
+	if c.Adaptor == nil {
+		return
+	}
+	if c.ValidatorList == nil {
+		c.Adaptor.SetTrustedValidators(validators, masterKeys)
+		return
+	}
+	pubNodes, pubMasters := c.ValidatorList.TrustedValidators()
+	merged, mergedMasters := mergeValidators(validators, masterKeys, pubNodes, pubMasters)
+	c.Adaptor.SetTrustedValidators(merged, mergedMasters)
 }
 
 // mergeValidators returns the deduplicated union of two

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -2,6 +2,7 @@ package adaptor
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
 	"github.com/LeJamon/goXRPLd/internal/manifest"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	validatorlist "github.com/LeJamon/goXRPLd/internal/validator/list"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
@@ -31,6 +33,17 @@ type Components struct {
 	// non-nil — starts empty and fills as peers gossip manifests.
 	Manifests *manifest.Cache
 
+	// ValidatorList is the publisher-trust subsystem. Nil when no
+	// validator_list_keys are configured. When non-nil, peer-gossiped
+	// TMValidatorList frames feed it via the router and the configured
+	// validator_list_sites URLs are polled by ValidatorListPoller.
+	ValidatorList *validatorlist.Aggregator
+
+	// ValidatorListPoller drives periodic HTTP fetches of configured
+	// validator_list_sites and pipes the results into ValidatorList.
+	// Nil iff ValidatorList is nil or no sites are configured.
+	ValidatorListPoller *validatorlist.SitePoller
+
 	// Archive is the on-disk validation archive, when enabled.
 	// Nil if disabled in config or if no relational DB is configured.
 	// The engine owns the lifecycle (drain + Close on Stop), but it's
@@ -42,6 +55,7 @@ type Components struct {
 	overlayCancel          context.CancelFunc
 	routerCancel           context.CancelFunc
 	manifestPeriodicCancel context.CancelFunc
+	sitePollerCancel       context.CancelFunc
 }
 
 // periodicManifestBroadcastInterval is how often Components.Start
@@ -81,6 +95,14 @@ func (c *Components) Start() error {
 	c.manifestPeriodicCancel = periodicCancel
 	go c.runPeriodicManifestBroadcast(periodicCtx, periodicManifestBroadcastInterval)
 
+	// Start the publisher-list HTTP poller. Cancellation propagates to
+	// per-URL goroutines via the poller's own stop channel.
+	if c.ValidatorListPoller != nil {
+		pollerCtx, pollerCancel := context.WithCancel(context.Background())
+		c.sitePollerCancel = pollerCancel
+		c.ValidatorListPoller.Start(pollerCtx)
+	}
+
 	return nil
 }
 
@@ -105,6 +127,12 @@ func (c *Components) runPeriodicManifestBroadcast(ctx context.Context, interval 
 
 // Stop gracefully shuts down all components.
 func (c *Components) Stop() {
+	if c.sitePollerCancel != nil {
+		c.sitePollerCancel()
+	}
+	if c.ValidatorListPoller != nil {
+		c.ValidatorListPoller.Stop()
+	}
 	if c.manifestPeriodicCancel != nil {
 		c.manifestPeriodicCancel()
 	}
@@ -248,6 +276,54 @@ func NewFromConfig(
 	router := NewRouter(engine, adaptor, modeManager, overlay.Messages())
 	router.SetManifestCache(manifestCache, overlay)
 
+	// Build the publisher-list aggregator when validator_list_keys are
+	// configured. Lists are then ingested both via peer gossip
+	// (TMValidatorList through the router) and via HTTP polling of
+	// validator_list_sites. The aggregator pushes its recomputed
+	// trusted UNL into adaptor.SetTrustedValidators on every change —
+	// the same write path SIGHUP reload uses.
+	publisherKeys, err := ParseValidatorListPublisherKeys(appCfg)
+	if err != nil {
+		return nil, fmt.Errorf("parse validator_list_keys: %w", err)
+	}
+	var vlAgg *validatorlist.Aggregator
+	var vlPoller *validatorlist.SitePoller
+	if len(publisherKeys) > 0 {
+		pkSlice := make([]validatorlist.PublisherKey, len(publisherKeys))
+		for i, k := range publisherKeys {
+			pkSlice[i] = validatorlist.PublisherKey(k)
+		}
+		vlAgg, err = validatorlist.New(validatorlist.Config{
+			PublisherKeys: pkSlice,
+			SiteURIs:      append([]string(nil), appCfg.Validators.ValidatorListSites...),
+			Threshold:     appCfg.Validators.GetValidatorListThreshold(),
+			Manifests:     manifestCache,
+			Logger:        slog.Default().With("component", "validator-list-aggregator"),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("validator-list aggregator: %w", err)
+		}
+		// On every publisher-trust recompute, merge the publisher's
+		// validators with the operator's static [validators] stanza and
+		// push the union into the adaptor. The static list never
+		// disappears — operators may want to pin a few validators in
+		// addition to whatever a publisher publishes.
+		staticValidators := append([]consensus.NodeID(nil), validators...)
+		staticMasterKeys := append([][33]byte(nil), masterKeys...)
+		vlAgg.OnChange(func(publisherNodes []consensus.NodeID, publisherMasters [][33]byte) {
+			merged, mergedMasters := mergeValidators(staticValidators, staticMasterKeys, publisherNodes, publisherMasters)
+			adaptor.SetTrustedValidators(merged, mergedMasters)
+		})
+		router.SetValidatorListAggregator(vlAgg)
+		if len(appCfg.Validators.ValidatorListSites) > 0 {
+			vlPoller = validatorlist.NewSitePoller(
+				append([]string(nil), appCfg.Validators.ValidatorListSites...),
+				vlAgg,
+				slog.Default().With("component", "validator-list-site-poller"),
+			)
+		}
+	}
+
 	// Plumb peer disconnect notifications back through the router so
 	// per-peer state (peerStates for catch-up, peerLCLs for the
 	// getNetworkLedger vote) is cleaned the instant a peer goes away.
@@ -277,14 +353,65 @@ func NewFromConfig(
 	})
 
 	return &Components{
-		Overlay:     overlay,
-		Engine:      engine,
-		Adaptor:     adaptor,
-		Router:      router,
-		ModeManager: modeManager,
-		Manifests:   manifestCache,
-		Archive:     validationArchive,
+		Overlay:             overlay,
+		Engine:              engine,
+		Adaptor:             adaptor,
+		Router:              router,
+		ModeManager:         modeManager,
+		Manifests:           manifestCache,
+		ValidatorList:       vlAgg,
+		ValidatorListPoller: vlPoller,
+		Archive:             validationArchive,
 	}, nil
+}
+
+// mergeValidators returns the deduplicated union of two
+// (validators, masterKeys) pairs, sorted by master key for
+// determinism. Used to combine the static [validators] config (held
+// constant across publisher-list churn) with the publisher-derived
+// trusted set on every aggregator OnChange callback.
+//
+// The two inputs are assumed already index-aligned (validators[i]
+// derives from masterKeys[i] via consensus.CalcNodeID); the merged
+// outputs preserve that invariant.
+func mergeValidators(aIDs []consensus.NodeID, aMKs [][33]byte, bIDs []consensus.NodeID, bMKs [][33]byte) ([]consensus.NodeID, [][33]byte) {
+	seen := make(map[[33]byte]consensus.NodeID, len(aIDs)+len(bIDs))
+	for i, mk := range aMKs {
+		if _, ok := seen[mk]; ok {
+			continue
+		}
+		if i < len(aIDs) {
+			seen[mk] = aIDs[i]
+		} else {
+			seen[mk] = consensus.CalcNodeID(mk)
+		}
+	}
+	for i, mk := range bMKs {
+		if _, ok := seen[mk]; ok {
+			continue
+		}
+		if i < len(bIDs) {
+			seen[mk] = bIDs[i]
+		} else {
+			seen[mk] = consensus.CalcNodeID(mk)
+		}
+	}
+	masters := make([][33]byte, 0, len(seen))
+	for mk := range seen {
+		masters = append(masters, mk)
+	}
+	// Sort by master key for stable order (helps tests + deterministic
+	// downstream logging).
+	for i := 1; i < len(masters); i++ {
+		for j := i; j > 0 && string(masters[j][:]) < string(masters[j-1][:]); j-- {
+			masters[j], masters[j-1] = masters[j-1], masters[j]
+		}
+	}
+	ids := make([]consensus.NodeID, len(masters))
+	for i, mk := range masters {
+		ids[i] = seen[mk]
+	}
+	return ids, masters
 }
 
 // OverlayOptionsFromConfig maps app config fields to overlay options.
@@ -342,6 +469,38 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 func ParseValidatorKeys(appCfg *config.Config) ([]consensus.NodeID, error) {
 	validators, _, err := ParseValidatorKeysWithMaster(appCfg)
 	return validators, err
+}
+
+// ParseValidatorListPublisherKeys decodes the `validator_list_keys`
+// config field into 33-byte master public keys suitable for the
+// publisher-trust aggregator. Each key is a hex-encoded 33-byte
+// compressed pubkey (the form rippled and public list publishers like
+// vl.ripple.com use). The leading byte is the key-type prefix —
+// 0xED for ed25519 (the common case), 0x02/0x03 for secp256k1.
+//
+// Returns (nil, nil) when no publisher keys are configured. Returns an
+// error if any key is malformed: this is a hard configuration failure
+// rather than a silently-disabled publisher, since the operator
+// explicitly opted in.
+func ParseValidatorListPublisherKeys(appCfg *config.Config) ([][33]byte, error) {
+	keys := appCfg.Validators.ValidatorListKeys
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	out := make([][33]byte, 0, len(keys))
+	for _, k := range keys {
+		raw, err := hex.DecodeString(k)
+		if err != nil {
+			return nil, fmt.Errorf("validator_list_key %q: hex decode: %w", k, err)
+		}
+		if len(raw) != 33 {
+			return nil, fmt.Errorf("validator_list_key %q: expected 33 bytes (66 hex chars), got %d", k, len(raw))
+		}
+		var pk [33]byte
+		copy(pk[:], raw)
+		out = append(out, pk)
+	}
+	return out, nil
 }
 
 // ParseValidatorKeysWithMaster parses validator public keys into both

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -43,6 +44,13 @@ type Components struct {
 	// validator_list_sites and pipes the results into ValidatorList.
 	// Nil iff ValidatorList is nil or no sites are configured.
 	ValidatorListPoller *validatorlist.SitePoller
+
+	// StaticTrustedMasterKeys carries the master pubkeys parsed out of
+	// the operator's `[validators]` config stanza. Captured here so the
+	// `validators` RPC can surface them as `local_static_keys` without
+	// having to re-parse config or query a mutable adaptor field that
+	// also includes publisher-derived entries.
+	StaticTrustedMasterKeys [][33]byte
 
 	// Archive is the on-disk validation archive, when enabled.
 	// Nil if disabled in config or if no relational DB is configured.
@@ -352,16 +360,18 @@ func NewFromConfig(
 		return opMode.String()
 	})
 
+	staticMastersCopy := append([][33]byte(nil), masterKeys...)
 	return &Components{
-		Overlay:             overlay,
-		Engine:              engine,
-		Adaptor:             adaptor,
-		Router:              router,
-		ModeManager:         modeManager,
-		Manifests:           manifestCache,
-		ValidatorList:       vlAgg,
-		ValidatorListPoller: vlPoller,
-		Archive:             validationArchive,
+		Overlay:                 overlay,
+		Engine:                  engine,
+		Adaptor:                 adaptor,
+		Router:                  router,
+		ModeManager:             modeManager,
+		Manifests:               manifestCache,
+		ValidatorList:           vlAgg,
+		ValidatorListPoller:     vlPoller,
+		StaticTrustedMasterKeys: staticMastersCopy,
+		Archive:                 validationArchive,
 	}, nil
 }
 
@@ -400,13 +410,9 @@ func mergeValidators(aIDs []consensus.NodeID, aMKs [][33]byte, bIDs []consensus.
 	for mk := range seen {
 		masters = append(masters, mk)
 	}
-	// Sort by master key for stable order (helps tests + deterministic
-	// downstream logging).
-	for i := 1; i < len(masters); i++ {
-		for j := i; j > 0 && string(masters[j][:]) < string(masters[j-1][:]); j-- {
-			masters[j], masters[j-1] = masters[j-1], masters[j]
-		}
-	}
+	sort.Slice(masters, func(i, j int) bool {
+		return string(masters[i][:]) < string(masters[j][:])
+	})
 	ids := make([]consensus.NodeID, len(masters))
 	for i, mk := range masters {
 		ids[i] = seen[mk]

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -68,7 +68,17 @@ type Components struct {
 	routerCancel           context.CancelFunc
 	manifestPeriodicCancel context.CancelFunc
 	sitePollerCancel       context.CancelFunc
+	vlTickCancel           context.CancelFunc
 }
+
+// validatorListTickInterval is how often Components.Start fires
+// ValidatorList.Tick to promote future-dated rotations and re-emit
+// OnChange. Rippled drives the equivalent path from updateTrusted on
+// every ledger close (ValidatorList.cpp:1910-1928, roughly every 4s on
+// mainnet); 30s here keeps the wake-up cost low while still bounding
+// the lag between a rotation's effective time and trusted-set update
+// to half a minute in the worst case.
+const validatorListTickInterval = 30 * time.Second
 
 // periodicManifestBroadcastInterval is how often Components.Start
 // re-emits the cached aggregate TMManifests frame. Rippled has no
@@ -115,7 +125,34 @@ func (c *Components) Start() error {
 		c.ValidatorListPoller.Start(pollerCtx)
 	}
 
+	// Periodic ValidatorList.Tick promotes future-dated remaining
+	// rotations and emits OnChange when the trusted union changes.
+	// Without this, a rotation announced during a quiet period (no
+	// peer gossip, no site polls) would only land when the next
+	// ingest happens.
+	if c.ValidatorList != nil {
+		tickCtx, tickCancel := context.WithCancel(context.Background())
+		c.vlTickCancel = tickCancel
+		go c.runValidatorListTick(tickCtx, validatorListTickInterval)
+	}
+
 	return nil
+}
+
+func (c *Components) runValidatorListTick(ctx context.Context, interval time.Duration) {
+	if c.ValidatorList == nil || interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.ValidatorList.Tick()
+		}
+	}
 }
 
 func (c *Components) runPeriodicManifestBroadcast(ctx context.Context, interval time.Duration) {
@@ -139,6 +176,9 @@ func (c *Components) runPeriodicManifestBroadcast(ctx context.Context, interval 
 
 // Stop gracefully shuts down all components.
 func (c *Components) Stop() {
+	if c.vlTickCancel != nil {
+		c.vlTickCancel()
+	}
 	if c.sitePollerCancel != nil {
 		c.sitePollerCancel()
 	}

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -356,13 +357,33 @@ func NewFromConfig(
 			return nil, fmt.Errorf("validator-list aggregator: %w", err)
 		}
 		router.SetValidatorListAggregator(vlAgg)
+		// On-disk publisher-list cache. Mirrors rippled's
+		// ValidatorList::cacheValidatorFile + loadLists pair
+		// (rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:368-396
+		// and 1300-1351): accepted lists are persisted under
+		// <database_path>/validator-list/cache.<pubHex> after every
+		// successful apply, and hydrated on cold start so the trusted
+		// UNL is non-empty before the first poll cycle. Failed cache
+		// I/O is logged but never blocks startup.
+		if appCfg.DatabasePath != "" {
+			cacheDir := filepath.Join(appCfg.DatabasePath, "validator-list")
+			if err := vlAgg.SetCacheDir(cacheDir); err != nil {
+				slog.Default().Warn("validator-list cache disabled",
+					"dir", cacheDir, "error", err)
+			} else if loaded := vlAgg.LoadCache(); loaded > 0 {
+				slog.Default().Info("validator-list cache hydrated",
+					"publishers", loaded)
+			}
+		}
 		// Wire the broadcaster so both ingress paths (peer router +
 		// HTTP poller) can push accepted lists out through the single
-		// aggregator-owned BroadcastLatest entry point. Mirrors
-		// rippled's applyListsAndBroadcast which uniformly fans out
-		// from inside ValidatorList for both peer-gossip and
-		// site-poll origins (ValidatorList.cpp:872-937, 939-994).
-		vlAgg.SetBroadcaster(NewRouterBroadcaster(overlay, sender))
+		// aggregator-owned BroadcastLatest entry point. The
+		// router-bound constructor plumbs the shared message
+		// suppression registry so SendList / SendCollection stamp the
+		// (hash, peer) pair that mirrors rippled's
+		// `hashRouter.addSuppressionPeer(hash, peer->id())` at
+		// ValidatorList.cpp:781 + 932.
+		vlAgg.SetBroadcaster(router.NewValidatorListBroadcaster(overlay, sender))
 		if len(appCfg.Validators.ValidatorListSites) > 0 {
 			vlPoller, err = validatorlist.NewSitePoller(
 				append([]string(nil), appCfg.Validators.ValidatorListSites...),

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -324,11 +324,14 @@ func NewFromConfig(
 		// site-poll origins (ValidatorList.cpp:872-937, 939-994).
 		vlAgg.SetBroadcaster(NewRouterBroadcaster(overlay, sender))
 		if len(appCfg.Validators.ValidatorListSites) > 0 {
-			vlPoller = validatorlist.NewSitePoller(
+			vlPoller, err = validatorlist.NewSitePoller(
 				append([]string(nil), appCfg.Validators.ValidatorListSites...),
 				vlAgg,
 				slog.Default().With("component", "validator-list-site-poller"),
 			)
+			if err != nil {
+				return nil, fmt.Errorf("validator-list site poller: %w", err)
+			}
 		}
 	}
 

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -316,6 +316,13 @@ func NewFromConfig(
 			return nil, fmt.Errorf("validator-list aggregator: %w", err)
 		}
 		router.SetValidatorListAggregator(vlAgg)
+		// Wire the broadcaster so both ingress paths (peer router +
+		// HTTP poller) can push accepted lists out through the single
+		// aggregator-owned BroadcastLatest entry point. Mirrors
+		// rippled's applyListsAndBroadcast which uniformly fans out
+		// from inside ValidatorList for both peer-gossip and
+		// site-poll origins (ValidatorList.cpp:872-937, 939-994).
+		vlAgg.SetBroadcaster(NewRouterBroadcaster(overlay, sender))
 		if len(appCfg.Validators.ValidatorListSites) > 0 {
 			vlPoller = validatorlist.NewSitePoller(
 				append([]string(nil), appCfg.Validators.ValidatorListSites...),

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -269,6 +269,27 @@ func (c *Cache) Revoked(masterKey [33]byte) bool {
 	return m.Revoked()
 }
 
+// MasterToSigning returns a snapshot of the master→signing key map for
+// every cached (non-revoked) manifest. Used by the `validators` RPC to
+// emit the `signing_keys` object, mirroring rippled's
+// ValidatorManifests::for_each_manifest walk in getJson at
+// ValidatorList.cpp:1725-1734.
+func (c *Cache) MasterToSigning() map[[33]byte][33]byte {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.byMaster) == 0 {
+		return nil
+	}
+	out := make(map[[33]byte][33]byte, len(c.byMaster))
+	for master, m := range c.byMaster {
+		if m == nil || m.Revoked() {
+			continue
+		}
+		out[master] = m.SigningKey
+	}
+	return out
+}
+
 // SerializedAll returns the wire bytes of every cached manifest in
 // arbitrary order, with each entry defensively copied. Used by the
 // post-handshake TMManifests emission to gossip the entire aggregated

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -523,6 +523,52 @@ func (o *Overlay) PeerSupports(peerID PeerID, f Feature) bool {
 	return caps.HasFeature(f)
 }
 
+// PeerRemoteAddr returns the peer's remote endpoint as "host:port", or
+// "" if the peer is unknown. Mirrors rippled's `remote_address_.to_string()`
+// at PeerImp.cpp:2072 used to populate the `uri` field on per-publisher
+// state for peer-sourced lists.
+func (o *Overlay) PeerRemoteAddr(peerID PeerID) string {
+	o.peersMu.RLock()
+	peer, ok := o.peers[peerID]
+	o.peersMu.RUnlock()
+	if !ok {
+		return ""
+	}
+	return peer.Endpoint().String()
+}
+
+// PeerProtocolAtLeast reports whether the peer's negotiated peer-protocol
+// version is at least the given (major, minor). Mirrors rippled's
+// `protocol_ >= make_protocol(major, minor)` test at
+// rippled/src/xrpld/overlay/detail/PeerImp.cpp:511-514, used to gate
+// version-implicit features such as ValidatorList2Propagation.
+//
+// Returns false when the peer is unknown or has not completed the
+// handshake.
+func (o *Overlay) PeerProtocolAtLeast(peerID PeerID, major, minor uint16) bool {
+	o.peersMu.RLock()
+	peer, ok := o.peers[peerID]
+	o.peersMu.RUnlock()
+	if !ok {
+		return false
+	}
+	got := peer.ProtocolVersion()
+	if got == "" {
+		return false
+	}
+	pvs := parseProtocolVersions(got)
+	if len(pvs) == 0 {
+		return false
+	}
+	want := protocolVersion{major: major, minor: minor}
+	for _, v := range pvs {
+		if !v.less(want) {
+			return true
+		}
+	}
+	return false
+}
+
 // ListenAddr returns the resolved address the overlay is accepting
 // connections on, or the empty string if no listener is bound. Useful
 // when the overlay was configured with port 0 (ephemeral) and the

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -172,7 +172,7 @@ func BadDataWeight(reason string) int {
 		//   "vl-coll-heavy-no-blobs", "vl-coll-no-blobs" -> feeHeavyBurdenPeer
 		//   "vl-...-badsig-*"                            -> feeInvalidSignature
 		//   "vl-...-baddata-*", "*-wrong-version",
-		//   "*-decode", "*-manifest-decode"              -> feeInvalidData
+		//   "*-decode"                                   -> feeInvalidData
 		//   "vl-...-useless-*", "*-duplicate",
 		//   "*-unsupported-peer"                         -> feeUselessData
 		switch {
@@ -183,8 +183,7 @@ func BadDataWeight(reason string) int {
 			return weightInvalidSignature
 		case strings.Contains(reason, "-baddata-"),
 			strings.HasSuffix(reason, "-wrong-version"),
-			strings.HasSuffix(reason, "-decode"),
-			strings.HasSuffix(reason, "-manifest-decode"):
+			strings.HasSuffix(reason, "-decode"):
 			return weightInvalidData
 		case strings.Contains(reason, "-useless-"),
 			strings.HasSuffix(reason, "-duplicate"),

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -76,10 +76,23 @@ const acceptBackoff = 100 * time.Millisecond
 // events should approach the eviction threshold.
 const (
 	weightInvalidSignature = 2000
-	weightInvalidData      = 400
-	weightMalformedReq     = 200
-	weightRequestNoReply   = 10
-	weightDefaultBadData   = 100 // fallback for unrecognized reasons
+	// weightHeavyBurden mirrors rippled's Charge::feeHeavyBurdenPeer
+	// which is set to the same value as feeInvalidSignature
+	// (Resource::Fees.h). Reserved for protocol violations that would
+	// force the receiver into expensive computation (e.g. a
+	// TMValidatorListCollection with zero blobs forces an N-pass over
+	// an empty set — heavier in intent, identical in numeric impact).
+	weightHeavyBurden  = 2000
+	weightInvalidData  = 400
+	weightMalformedReq = 200
+	// weightUselessData mirrors rippled's Charge::feeUselessData — a
+	// light charge for messages that are semantically wasteful (peer
+	// re-relayed a list at the same sequence we already have, sent a
+	// frame they should know we don't accept, etc.). A small number of
+	// such events MUST NOT approach eviction; only sustained spamming.
+	weightUselessData    = 40
+	weightRequestNoReply = 10
+	weightDefaultBadData = 100 // fallback for unrecognized reasons
 )
 
 // BadDataWeight returns the weight to charge IncBadData for `reason`.
@@ -151,6 +164,33 @@ func BadDataWeight(reason string) int {
 	case "no-reply":
 		return weightRequestNoReply
 	default:
+		// Validator-list ingest labels embed the rippled fee tier in
+		// the label prefix; classify by prefix so a new disposition
+		// added to the router doesn't accidentally fall through to
+		// weightDefaultBadData. Charge tiers from
+		// rippled/src/xrpld/overlay/detail/PeerImp.cpp:2141-2183:
+		//   "vl-coll-heavy-no-blobs", "vl-coll-no-blobs" -> feeHeavyBurdenPeer
+		//   "vl-...-badsig-*"                            -> feeInvalidSignature
+		//   "vl-...-baddata-*", "*-wrong-version",
+		//   "*-decode", "*-manifest-decode"              -> feeInvalidData
+		//   "vl-...-useless-*", "*-duplicate",
+		//   "*-unsupported-peer"                         -> feeUselessData
+		switch {
+		case reason == "vl-coll-no-blobs",
+			strings.HasSuffix(reason, "-heavy-no-blobs"):
+			return weightHeavyBurden
+		case strings.Contains(reason, "-badsig-"):
+			return weightInvalidSignature
+		case strings.Contains(reason, "-baddata-"),
+			strings.HasSuffix(reason, "-wrong-version"),
+			strings.HasSuffix(reason, "-decode"),
+			strings.HasSuffix(reason, "-manifest-decode"):
+			return weightInvalidData
+		case strings.Contains(reason, "-useless-"),
+			strings.HasSuffix(reason, "-duplicate"),
+			strings.HasSuffix(reason, "-unsupported-peer"):
+			return weightUselessData
+		}
 		return weightDefaultBadData
 	}
 }

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -1,39 +1,92 @@
 package handlers
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"strings"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// ValidatorsMethod handles the validators RPC method.
-// STUB: Returns empty list. Network-only — not needed for standalone mode.
+// ValidatorsMethod handles the `validators` admin RPC. Returns the
+// trusted UNL (master pubkeys) plus per-publisher metadata. Mirrors
+// rippled's Validators handler (Validators.cpp) which surfaces
+// app.validators() state to operators.
 //
-// TODO [network]: Implement when adding consensus/validator tracking.
-//   - Requires: ValidatorList service tracking trusted validators
-//   - Reference: rippled Validators.cpp → context.app.validators()
-//   - Returns: list of trusted validators with their public keys, manifests,
-//     and current validation status
-//   - Also returns publisher_lists with their public keys, sequence, expiration
+// When the publisher-trust subsystem isn't wired (standalone mode or
+// no validator_list_keys configured) the response still includes
+// validation_quorum and trusted_validator_keys derived from the static
+// adaptor UNL — only the publisher_lists array is empty.
 type ValidatorsMethod struct{ AdminHandler }
 
-func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
+func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (interface{}, *types.RpcError) {
+	publisherLists := []map[string]interface{}{}
+	trustedKeys := []string{}
+
+	if ctx != nil && ctx.Services != nil && ctx.Services.ValidatorList != nil {
+		vl := ctx.Services.ValidatorList
+		for _, p := range vl.Publishers() {
+			entry := map[string]interface{}{
+				"public_key":      p.PublicKey,
+				"available":       p.Status == "available",
+				"status":          p.Status,
+				"seq":             p.Sequence,
+				"validator_count": p.ValidatorCount,
+				"site":            p.SiteURI,
+			}
+			if p.EffectiveUnix > 0 {
+				entry["effective"] = p.EffectiveUnix
+			}
+			if p.ExpirationUnix > 0 {
+				entry["expiration"] = p.ExpirationUnix
+			}
+			publisherLists = append(publisherLists, entry)
+		}
+		for _, mk := range vl.TrustedMasterKeys() {
+			trustedKeys = append(trustedKeys, strings.ToUpper(hex.EncodeToString(mk[:])))
+		}
+	}
+
+	quorum := 0
+	if ctx != nil && ctx.Services != nil && ctx.Services.ValidationQuorum != nil {
+		quorum = ctx.Services.ValidationQuorum()
+	}
+
 	return map[string]interface{}{
-		"trusted_validator_keys": []interface{}{},
-		"publisher_lists":        []interface{}{},
-		"validation_quorum":      0,
+		"trusted_validator_keys": trustedKeys,
+		"publisher_lists":        publisherLists,
+		"validation_quorum":      quorum,
 	}, nil
 }
 
-// ValidatorListSitesMethod handles the validator_list_sites RPC method.
-// STUB: Returns empty list. Network-only — not needed for standalone mode.
-//
-// TODO [network]: Implement when adding validator list fetching.
-//   - Requires: ValidatorSite service that fetches validator lists from URLs
-//   - Reference: rippled ValidatorListSites.cpp
-//   - Returns: array of configured validator list sites with their fetch status
+// ValidatorListSitesMethod handles the `validator_list_sites` admin
+// RPC. Returns the configured publisher URLs along with the most
+// recent fetch status. Mirrors rippled's ValidatorListSites handler
+// (ValidatorListSites.cpp).
 type ValidatorListSitesMethod struct{ AdminHandler }
 
-func (m *ValidatorListSitesMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return map[string]interface{}{"validator_sites": []interface{}{}}, nil
+func (m *ValidatorListSitesMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (interface{}, *types.RpcError) {
+	sites := []map[string]interface{}{}
+
+	if ctx != nil && ctx.Services != nil && ctx.Services.ValidatorList != nil {
+		for _, s := range ctx.Services.ValidatorList.Sites() {
+			entry := map[string]interface{}{
+				"uri":                  s.URI,
+				"last_disposition":     s.LastDisposition,
+				"refresh_interval_sec": s.RefreshIntervalSec,
+			}
+			if s.LastRefreshUnix > 0 {
+				entry["last_refresh"] = s.LastRefreshUnix
+			}
+			if s.LastSuccessUnix > 0 {
+				entry["last_success"] = s.LastSuccessUnix
+			}
+			if s.LastError != "" {
+				entry["last_error"] = s.LastError
+			}
+			sites = append(sites, entry)
+		}
+	}
+
+	return map[string]interface{}{"validator_sites": sites}, nil
 }

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -38,6 +38,7 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 	var earliestExpirationUnix int64
 	anyExpired := false
 	allAvailable := true
+	anyMissingExpiration := false
 	publisherCount := 0
 	threshold := 0
 
@@ -69,6 +70,8 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 					if earliestExpirationUnix == 0 || p.ExpirationUnix < earliestExpirationUnix {
 						earliestExpirationUnix = p.ExpirationUnix
 					}
+				} else {
+					anyMissingExpiration = true
 				}
 				if !p.Available {
 					allAvailable = false
@@ -102,15 +105,28 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 		quorum = ctx.Services.ValidationQuorum()
 	}
 
+	// Match rippled ValidatorList::count (ValidatorList.cpp:1547-1551):
+	// publisherLists_.size() + (localPublisherList non-empty ? 1 : 0).
+	// The non-empty local static stanza counts as a single source on top
+	// of the publisher set.
+	listCount := publisherCount
+	if len(localStatic) > 0 {
+		listCount++
+	}
+
 	validatorListSummary := map[string]interface{}{
-		"count":                    publisherCount,
+		"count":                    listCount,
 		"validator_list_threshold": threshold,
 	}
-	if publisherCount == 0 || earliestExpirationUnix == 0 {
+	// "unknown" gating mirrors rippled's expires() (ValidatorList.cpp:1560-1591):
+	// if any publisher's current.validUntil is unset the whole summary
+	// reports unknown. Tracked via anyMissingExpiration so a partial fetch
+	// can't paint over an unfetched publisher.
+	if publisherCount == 0 || anyMissingExpiration || earliestExpirationUnix == 0 {
 		validatorListSummary["status"] = "unknown"
 		validatorListSummary["expiration"] = "unknown"
 	} else {
-		validatorListSummary["expiration"] = time.Unix(earliestExpirationUnix, 0).UTC().Format(time.RFC3339)
+		validatorListSummary["expiration"] = formatRippledTime(time.Unix(earliestExpirationUnix, 0))
 		if anyExpired || !allAvailable {
 			validatorListSummary["status"] = "expired"
 		} else {
@@ -172,4 +188,16 @@ func nonNilStrings(s []string) []string {
 		return []string{}
 	}
 	return s
+}
+
+// rippledTimeLayout matches rippled's to_string(NetClock::time_point)
+// at rippled/include/xrpl/basics/chrono.h:75-88 — `date::format("%Y-%b-%d %T %Z", tp)`
+// which produces strings like `"2026-May-18 10:30:00 UTC"`. Use for
+// the `expiration` / `effective` / `last_refresh_time` / `next_refresh_time`
+// fields exposed by the validators and validator_list_sites RPCs.
+const rippledTimeLayout = "2006-Jan-02 15:04:05 UTC"
+
+// formatRippledTime renders t in rippled's boost-style timestamp format.
+func formatRippledTime(t time.Time) string {
+	return t.UTC().Format(rippledTimeLayout)
 }

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -77,11 +77,16 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 				if len(p.Remaining) > 0 {
 					rem := make([]map[string]interface{}, 0, len(p.Remaining))
 					for _, r := range p.Remaining {
+						// Mirrors rippled appendList at
+						// ValidatorList.cpp:1673-1689 which emits
+						// uri/seq/expiration/effective/list for every
+						// entry. `version` lives on the top-level publisher
+						// object (line 1695) and is NOT repeated per
+						// remaining entry — keep parity by omitting it here.
 						re := map[string]interface{}{
-							"uri":     r.SiteURI,
-							"list":    nonNilStrings(r.ValidatorsBase58),
-							"seq":     r.Sequence,
-							"version": r.Version,
+							"uri":  r.SiteURI,
+							"list": nonNilStrings(r.ValidatorsBase58),
+							"seq":  r.Sequence,
 						}
 						if r.EffectiveSet && r.EffectiveISO != "" {
 							re["effective"] = r.EffectiveISO

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -120,14 +120,26 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 		"count":                    listCount,
 		"validator_list_threshold": threshold,
 	}
-	// "unknown" gating mirrors rippled's expires() (ValidatorList.cpp:1560-1591):
-	// if any publisher's current.validUntil is unset the whole summary
-	// reports unknown. Tracked via anyMissingExpiration so a partial fetch
-	// can't paint over an unfetched publisher.
-	if publisherCount == 0 || anyMissingExpiration || earliestExpirationUnix == 0 {
+	// Status / expiration gating mirrors rippled's expires() +
+	// getJson (ValidatorList.cpp:1560-1651). Three cases:
+	//
+	//  1. No publishers configured but the local [validators] stanza
+	//     is populated — rippled's expires() returns the local
+	//     validUntil which is TimeKeeper::time_point::max(); getJson
+	//     emits status="active" expiration="never".
+	//  2. Any publisher's current.validUntil is unset (unfetched) — or
+	//     no source of trust at all — emit status="unknown".
+	//  3. Otherwise emit the earliest publisher validUntil; status is
+	//     "expired" when any publisher is expired/unavailable, else
+	//     "active".
+	switch {
+	case publisherCount == 0 && len(localStatic) > 0:
+		validatorListSummary["status"] = "active"
+		validatorListSummary["expiration"] = "never"
+	case publisherCount == 0 || anyMissingExpiration || earliestExpirationUnix == 0:
 		validatorListSummary["status"] = "unknown"
 		validatorListSummary["expiration"] = "unknown"
-	} else {
+	default:
 		validatorListSummary["expiration"] = formatRippledTime(time.Unix(earliestExpirationUnix, 0))
 		if anyExpired || !allAvailable {
 			validatorListSummary["status"] = "expired"

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -1,49 +1,99 @@
 package handlers
 
 import (
-	"encoding/hex"
 	"encoding/json"
-	"strings"
+	"time"
 
+	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// ValidatorsMethod handles the `validators` admin RPC. Returns the
-// trusted UNL (master pubkeys) plus per-publisher metadata. Mirrors
-// rippled's Validators handler (Validators.cpp) which surfaces
-// app.validators() state to operators.
+// ValidatorsMethod handles the `validators` admin RPC. Mirrors rippled's
+// ValidatorList::getJson at rippled/src/xrpld/app/misc/detail/
+// ValidatorList.cpp:1617-1747:
 //
-// When the publisher-trust subsystem isn't wired (standalone mode or
-// no validator_list_keys configured) the response still includes
-// validation_quorum and trusted_validator_keys derived from the static
-// adaptor UNL — only the publisher_lists array is empty.
+//   - validation_quorum (UInt)
+//   - validator_list (count / status / expiration / threshold)
+//   - local_static_keys (base58 NodePublic, from operator config)
+//   - publisher_lists (per-publisher state including the validators
+//     each publisher signs as base58 NodePublic keys, plus per-publisher
+//     uri / seq / version / effective / expiration)
+//   - trusted_validator_keys (base58 NodePublic)
+//   - signing_keys (master → signing, base58→base58)
+//   - NegativeUNL (base58 NodePublic, omitted when empty)
+//
+// When the publisher-trust subsystem is not wired (standalone, or no
+// validator_list_keys configured), publisher_lists is empty but the
+// other fields still surface real state pulled from the static config /
+// adaptor.
 type ValidatorsMethod struct{ AdminHandler }
 
 func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (interface{}, *types.RpcError) {
 	publisherLists := []map[string]interface{}{}
 	trustedKeys := []string{}
+	signingKeys := map[string]interface{}{}
+	localStatic := []string{}
+	negativeUNL := []string{}
 
-	if ctx != nil && ctx.Services != nil && ctx.Services.ValidatorList != nil {
-		vl := ctx.Services.ValidatorList
-		for _, p := range vl.Publishers() {
-			entry := map[string]interface{}{
-				"public_key":      p.PublicKey,
-				"available":       p.Status == "available",
-				"status":          p.Status,
-				"seq":             p.Sequence,
-				"validator_count": p.ValidatorCount,
-				"site":            p.SiteURI,
+	var earliestExpirationUnix int64
+	anyExpired := false
+	allAvailable := true
+	publisherCount := 0
+	threshold := 0
+
+	if ctx != nil && ctx.Services != nil {
+		if vl := ctx.Services.ValidatorList; vl != nil {
+			publisherCount = vl.PublisherCount()
+			threshold = vl.Threshold()
+			for _, p := range vl.Publishers() {
+				entry := map[string]interface{}{
+					"pubkey_publisher": p.PublicKeyHex,
+					"available":        p.Available,
+					"status":           p.Status,
+					"uri":              p.SiteURI,
+					"list":             nonNilStrings(p.ValidatorsBase58),
+				}
+				if p.Sequence > 0 {
+					entry["seq"] = p.Sequence
+				}
+				if p.Version > 0 {
+					entry["version"] = p.Version
+				}
+				if p.EffectiveISO != "" {
+					entry["effective"] = p.EffectiveISO
+				}
+				if p.ExpirationISO != "" {
+					entry["expiration"] = p.ExpirationISO
+				}
+				if p.ExpirationUnix > 0 {
+					if earliestExpirationUnix == 0 || p.ExpirationUnix < earliestExpirationUnix {
+						earliestExpirationUnix = p.ExpirationUnix
+					}
+				}
+				if !p.Available {
+					allAvailable = false
+				}
+				if p.Status == "expired" {
+					anyExpired = true
+				}
+				publisherLists = append(publisherLists, entry)
 			}
-			if p.EffectiveUnix > 0 {
-				entry["effective"] = p.EffectiveUnix
+			for _, mk := range vl.TrustedMasterKeys() {
+				if enc, err := addresscodec.EncodeNodePublicKey(mk[:]); err == nil {
+					trustedKeys = append(trustedKeys, enc)
+				}
 			}
-			if p.ExpirationUnix > 0 {
-				entry["expiration"] = p.ExpirationUnix
-			}
-			publisherLists = append(publisherLists, entry)
 		}
-		for _, mk := range vl.TrustedMasterKeys() {
-			trustedKeys = append(trustedKeys, strings.ToUpper(hex.EncodeToString(mk[:])))
+		if fn := ctx.Services.LocalStaticTrustedKeysBase58; fn != nil {
+			localStatic = nonNilStrings(fn())
+		}
+		if fn := ctx.Services.SigningKeysBase58; fn != nil {
+			for master, signing := range fn() {
+				signingKeys[master] = signing
+			}
+		}
+		if fn := ctx.Services.NegativeUNLBase58; fn != nil {
+			negativeUNL = nonNilStrings(fn())
 		}
 	}
 
@@ -52,17 +102,39 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 		quorum = ctx.Services.ValidationQuorum()
 	}
 
-	return map[string]interface{}{
+	validatorListSummary := map[string]interface{}{
+		"count":                    publisherCount,
+		"validator_list_threshold": threshold,
+	}
+	if publisherCount == 0 || earliestExpirationUnix == 0 {
+		validatorListSummary["status"] = "unknown"
+		validatorListSummary["expiration"] = "unknown"
+	} else {
+		validatorListSummary["expiration"] = time.Unix(earliestExpirationUnix, 0).UTC().Format(time.RFC3339)
+		if anyExpired || !allAvailable {
+			validatorListSummary["status"] = "expired"
+		} else {
+			validatorListSummary["status"] = "active"
+		}
+	}
+
+	resp := map[string]interface{}{
 		"trusted_validator_keys": trustedKeys,
 		"publisher_lists":        publisherLists,
 		"validation_quorum":      quorum,
-	}, nil
+		"validator_list":         validatorListSummary,
+		"local_static_keys":      localStatic,
+		"signing_keys":           signingKeys,
+	}
+	if len(negativeUNL) > 0 {
+		resp["NegativeUNL"] = negativeUNL
+	}
+	return resp, nil
 }
 
 // ValidatorListSitesMethod handles the `validator_list_sites` admin
-// RPC. Returns the configured publisher URLs along with the most
-// recent fetch status. Mirrors rippled's ValidatorListSites handler
-// (ValidatorListSites.cpp).
+// RPC. Mirrors rippled's ValidatorSite::getJson at
+// rippled/src/xrpld/app/misc/detail/ValidatorSite.cpp:672-705.
 type ValidatorListSitesMethod struct{ AdminHandler }
 
 func (m *ValidatorListSitesMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (interface{}, *types.RpcError) {
@@ -72,21 +144,32 @@ func (m *ValidatorListSitesMethod) Handle(ctx *types.RpcContext, _ json.RawMessa
 		for _, s := range ctx.Services.ValidatorList.Sites() {
 			entry := map[string]interface{}{
 				"uri":                  s.URI,
-				"last_disposition":     s.LastDisposition,
-				"refresh_interval_sec": s.RefreshIntervalSec,
+				"refresh_interval_min": s.RefreshIntervalMin,
 			}
-			if s.LastRefreshUnix > 0 {
-				entry["last_refresh"] = s.LastRefreshUnix
+			if s.LastDisposition != "" {
+				entry["last_refresh_status"] = s.LastDisposition
 			}
-			if s.LastSuccessUnix > 0 {
-				entry["last_success"] = s.LastSuccessUnix
+			if s.LastRefreshISO != "" {
+				entry["last_refresh_time"] = s.LastRefreshISO
+			}
+			if s.NextRefreshISO != "" {
+				entry["next_refresh_time"] = s.NextRefreshISO
 			}
 			if s.LastError != "" {
-				entry["last_error"] = s.LastError
+				entry["last_refresh_message"] = s.LastError
 			}
 			sites = append(sites, entry)
 		}
 	}
 
 	return map[string]interface{}{"validator_sites": sites}, nil
+}
+
+// nonNilStrings returns an empty []string instead of nil so JSON
+// serialization yields `[]` rather than `null`.
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -36,8 +36,6 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 	negativeUNL := []string{}
 
 	var earliestExpirationUnix int64
-	anyExpired := false
-	allAvailable := true
 	anyMissingExpiration := false
 	publisherCount := 0
 	threshold := 0
@@ -53,13 +51,14 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 					"uri":              p.SiteURI,
 					"list":             nonNilStrings(p.ValidatorsBase58),
 				}
-				if p.Sequence > 0 {
+				// Mirrors rippled ValidatorList.cpp:1676-1696: `seq` and
+				// `version` are both gated on the publisher having an
+				// accepted list (i.e. current.validUntil set), not on
+				// whether the value itself is non-zero. The signal is
+				// "has the publisher delivered yet", consistent across
+				// the two fields.
+				if p.ExpirationUnix > 0 {
 					entry["seq"] = p.Sequence
-				}
-				// Mirrors rippled ValidatorList.cpp:1693-1696: `version`
-				// is only emitted when the publisher's current.validUntil
-				// is set (i.e. an accepted/expired list has been ingested).
-				if p.ExpirationUnix > 0 && p.Version > 0 {
 					entry["version"] = p.Version
 				}
 				if p.EffectiveISO != "" {
@@ -74,12 +73,6 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 					}
 				} else {
 					anyMissingExpiration = true
-				}
-				if !p.Available {
-					allAvailable = false
-				}
-				if p.Status == "expired" {
-					anyExpired = true
 				}
 				publisherLists = append(publisherLists, entry)
 			}
@@ -140,8 +133,15 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 		validatorListSummary["status"] = "unknown"
 		validatorListSummary["expiration"] = "unknown"
 	default:
-		validatorListSummary["expiration"] = formatRippledTime(time.Unix(earliestExpirationUnix, 0))
-		if anyExpired || !allAvailable {
+		expiry := time.Unix(earliestExpirationUnix, 0)
+		validatorListSummary["expiration"] = formatRippledTime(expiry)
+		// Mirrors rippled ValidatorList.cpp:1641-1644 — status is a pure
+		// timestamp comparison of the earliest validUntil against
+		// wall-clock now, NOT a join over publisher Status/Available
+		// signals. Those latter signals already feed `available` /
+		// `expiration` per publisher; mixing them in here would break
+		// monitors that key on `validator_list.status`.
+		if time.Now().After(expiry) {
 			validatorListSummary["status"] = "expired"
 		} else {
 			validatorListSummary["status"] = "active"
@@ -177,20 +177,23 @@ func (m *ValidatorListSitesMethod) Handle(ctx *types.RpcContext, _ json.RawMessa
 				"refresh_interval_min": s.RefreshIntervalMin,
 			}
 			// Mirrors rippled's `if (site.lastRefreshStatus)` gate at
-			// ValidatorSite.cpp:690 — the field is absent from the
-			// response until the first fetch attempt completes.
+			// ValidatorSite.cpp:690-697 — last_refresh_time,
+			// last_refresh_status, and last_refresh_message share a
+			// single condition: they appear together once the first
+			// fetch attempt completes, or are all absent.
 			if s.LastDispositionSet {
-				entry["last_refresh_status"] = s.LastDisposition
-			}
-			if s.LastRefreshISO != "" {
 				entry["last_refresh_time"] = s.LastRefreshISO
+				entry["last_refresh_status"] = s.LastDisposition
+				if s.LastError != "" {
+					entry["last_refresh_message"] = s.LastError
+				}
 			}
-			if s.NextRefreshISO != "" {
-				entry["next_refresh_time"] = s.NextRefreshISO
-			}
-			if s.LastError != "" {
-				entry["last_refresh_message"] = s.LastError
-			}
+			// next_refresh_time is emitted unconditionally to match
+			// rippled ValidatorSite.cpp:689 (`to_string(site.nextRefresh)`,
+			// no opt gate). Sites are constructed with nextRefresh set to
+			// the construction clock so the field is never empty after
+			// startup.
+			entry["next_refresh_time"] = s.NextRefreshISO
 			sites = append(sites, entry)
 		}
 	}

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -61,15 +61,62 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 					entry["seq"] = p.Sequence
 					entry["version"] = p.Version
 				}
-				if p.EffectiveISO != "" {
+				// `effective` only emitted when the blob carried the field
+				// (rippled gates on `validFrom != TimeKeeper::time_point{}`
+				// at ValidatorList.cpp:1682; the EffectiveSet sentinel is
+				// the Go-side equivalent — see ValidatorListPublisherInfo).
+				if p.EffectiveSet && p.EffectiveISO != "" {
 					entry["effective"] = p.EffectiveISO
 				}
 				if p.ExpirationISO != "" {
 					entry["expiration"] = p.ExpirationISO
 				}
-				if p.ExpirationUnix > 0 {
-					if earliestExpirationUnix == 0 || p.ExpirationUnix < earliestExpirationUnix {
-						earliestExpirationUnix = p.ExpirationUnix
+				// Mirrors rippled ValidatorList.cpp:1699-1713 — emit a
+				// `remaining` array of future-dated rotations, omitted
+				// when empty.
+				if len(p.Remaining) > 0 {
+					rem := make([]map[string]interface{}, 0, len(p.Remaining))
+					for _, r := range p.Remaining {
+						re := map[string]interface{}{
+							"uri":     r.SiteURI,
+							"list":    nonNilStrings(r.ValidatorsBase58),
+							"seq":     r.Sequence,
+							"version": r.Version,
+						}
+						if r.EffectiveSet && r.EffectiveISO != "" {
+							re["effective"] = r.EffectiveISO
+						}
+						if r.ExpirationISO != "" {
+							re["expiration"] = r.ExpirationISO
+						}
+						rem = append(rem, re)
+					}
+					entry["remaining"] = rem
+				}
+				// Chained-extension walk for `expires()` (rippled
+				// ValidatorList.cpp:1560-1607): if a `remaining` entry's
+				// validFrom <= the chained validUntil, extend the chain
+				// to that entry's validUntil. The `validator_list`
+				// summary at the end uses earliestExpirationUnix.
+				chainedExp := p.ExpirationUnix
+				if chainedExp > 0 && len(p.Remaining) > 0 {
+					// p.Remaining is already sorted by sequence by the
+					// adapter; effective times within a single publisher's
+					// queue are monotonic by construction (validFrom <
+					// next validFrom for a rotation chain).
+					for _, r := range p.Remaining {
+						if r.EffectiveUnix == 0 || r.ExpirationUnix == 0 {
+							break
+						}
+						if r.EffectiveUnix > chainedExp {
+							break
+						}
+						chainedExp = r.ExpirationUnix
+					}
+				}
+				if chainedExp > 0 {
+					if earliestExpirationUnix == 0 || chainedExp < earliestExpirationUnix {
+						earliestExpirationUnix = chainedExp
 					}
 				} else {
 					anyMissingExpiration = true

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -162,7 +162,10 @@ func (m *ValidatorListSitesMethod) Handle(ctx *types.RpcContext, _ json.RawMessa
 				"uri":                  s.URI,
 				"refresh_interval_min": s.RefreshIntervalMin,
 			}
-			if s.LastDisposition != "" {
+			// Mirrors rippled's `if (site.lastRefreshStatus)` gate at
+			// ValidatorSite.cpp:690 — the field is absent from the
+			// response until the first fetch attempt completes.
+			if s.LastDispositionSet {
 				entry["last_refresh_status"] = s.LastDisposition
 			}
 			if s.LastRefreshISO != "" {

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -50,14 +50,16 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (int
 				entry := map[string]interface{}{
 					"pubkey_publisher": p.PublicKeyHex,
 					"available":        p.Available,
-					"status":           p.Status,
 					"uri":              p.SiteURI,
 					"list":             nonNilStrings(p.ValidatorsBase58),
 				}
 				if p.Sequence > 0 {
 					entry["seq"] = p.Sequence
 				}
-				if p.Version > 0 {
+				// Mirrors rippled ValidatorList.cpp:1693-1696: `version`
+				// is only emitted when the publisher's current.validUntil
+				// is set (i.e. an accepted/expired list has been ingested).
+				if p.ExpirationUnix > 0 && p.Version > 0 {
 					entry["version"] = p.Version
 				}
 				if p.EffectiveISO != "" {

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -269,7 +269,6 @@ func nonNilStrings(s []string) []string {
 // fields exposed by the validators and validator_list_sites RPCs.
 const rippledTimeLayout = "2006-Jan-02 15:04:05 UTC"
 
-// formatRippledTime renders t in rippled's boost-style timestamp format.
 func formatRippledTime(t time.Time) string {
 	return t.UTC().Format(rippledTimeLayout)
 }

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -85,12 +85,9 @@ type ValidatorListSiteInfo struct {
 // Expressed as an interface so internal/rpc/types doesn't import
 // internal/validator/list.
 type ValidatorListReader interface {
-	// HasConfiguredPublishers reports whether any validator_list_keys
-	// are configured. False means the publisher-trust subsystem is
-	// inert and the RPC should report an empty publisher list.
-	HasConfiguredPublishers() bool
 	// PublisherCount returns the number of configured publishers in the
-	// trust set.
+	// trust set. Zero means the publisher-trust subsystem is inert and
+	// the RPC will report an empty publisher list.
 	PublisherCount() int
 	// Threshold returns the configured publisher threshold (minimum
 	// number of publishers whose lists must agree on a validator

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -55,6 +55,33 @@ type ValidatorListPublisherInfo struct {
 	// keys (base58, NodePublicKey prefix), sorted lexicographically.
 	// Matches rippled's `list` array at ValidatorList.cpp:1684-1688.
 	ValidatorsBase58 []string
+	// EffectiveSet records whether the accepted blob carried an
+	// `effective` field. Rippled gates the JSON `effective` emit on
+	// `validFrom != TimeKeeper::time_point{}` at
+	// ValidatorList.cpp:1682-1683; without this sentinel a missing
+	// blob field would be flattened to a synthetic 2000-Jan-01 stamp
+	// by the ripple-epoch offset.
+	EffectiveSet bool
+	// Remaining holds the per-publisher future-dated rotation queue.
+	// Mirrors rippled's `remaining` JSON array emitted under each
+	// publisher entry at ValidatorList.cpp:1699-1713.
+	Remaining []ValidatorListRemainingInfo
+}
+
+// ValidatorListRemainingInfo is one entry in a publisher's
+// `remaining` array — a future-dated list that has not yet been
+// promoted into the current slot. Mirrors rippled's PublisherList
+// shape inside `pubCollection.remaining`.
+type ValidatorListRemainingInfo struct {
+	Sequence         uint32
+	Version          uint32
+	SiteURI          string
+	EffectiveUnix    int64
+	ExpirationUnix   int64
+	EffectiveISO     string
+	ExpirationISO    string
+	EffectiveSet     bool
+	ValidatorsBase58 []string
 }
 
 // ValidatorListSiteInfo is the per-URL snapshot the

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -21,38 +21,56 @@ type MethodDispatcher interface {
 // doesn't import internal/validator/list — same anti-cycle pattern as
 // ManifestLookup below.
 type ValidatorListPublisherInfo struct {
-	// PublicKey is the 33-byte master pubkey as hex (uppercase). Empty
-	// when the publisher has not yet produced a list and only the
-	// configured key is known.
-	PublicKey string
+	// PublicKeyHex is the 33-byte master pubkey, hex-encoded uppercase.
+	// Emitted as `pubkey_publisher` in the validators RPC to match
+	// rippled's getJson at ValidatorList.cpp:1669 (`strHex(publicKey)`).
+	PublicKeyHex string
+	// Available is true when the publisher's current list is fresh
+	// (matches rippled's `pubCollection.status == available`).
+	Available bool
 	// Status is one of "unavailable" / "available" / "expired" / "revoked".
 	Status string
 	// Sequence is the version of the currently-effective list. Zero
 	// before the first accepted list.
 	Sequence uint32
+	// Version is the protocol version of the most recently applied
+	// list (rippled `pubCollection.rawVersion`).
+	Version uint32
 	// EffectiveUnix is the Unix-epoch second at which the current list
 	// became effective. Zero when unset.
 	EffectiveUnix int64
 	// ExpirationUnix is the Unix-epoch second after which the current
 	// list is treated as expired. Zero when unset.
 	ExpirationUnix int64
-	// ValidatorCount is the number of validators in the publisher's
-	// currently-effective list.
-	ValidatorCount int
+	// EffectiveISO is the same time formatted RFC3339-UTC. Empty when
+	// EffectiveUnix is zero.
+	EffectiveISO string
+	// ExpirationISO is the same time formatted RFC3339-UTC. Empty when
+	// ExpirationUnix is zero.
+	ExpirationISO string
 	// SiteURI is the source URL (or "peer:<id>") of the most recent
-	// list.
+	// list. Emitted as `uri` to match rippled.
 	SiteURI string
+	// ValidatorsBase58 is the per-publisher list of validator NodePublic
+	// keys (base58, NodePublicKey prefix), sorted lexicographically.
+	// Matches rippled's `list` array at ValidatorList.cpp:1684-1688.
+	ValidatorsBase58 []string
 }
 
 // ValidatorListSiteInfo is the per-URL snapshot the
-// `validator_list_sites` RPC surfaces.
+// `validator_list_sites` RPC surfaces. Field names track rippled's
+// ValidatorSite::getJson at ValidatorSite.cpp:683-702.
 type ValidatorListSiteInfo struct {
 	URI                string
 	LastRefreshUnix    int64
 	LastSuccessUnix    int64
+	NextRefreshUnix    int64
+	LastRefreshISO     string
+	NextRefreshISO     string
 	LastError          string
 	LastDisposition    string
 	RefreshIntervalSec int
+	RefreshIntervalMin int
 }
 
 // ValidatorListReader is the read-only facet of the publisher-trust
@@ -142,6 +160,23 @@ type ServiceContainer struct {
 	// the `validators` and `validator_list_sites` RPC methods. Nil when
 	// no validator_list_keys are configured — handlers must nil-check.
 	ValidatorList ValidatorListReader
+
+	// LocalStaticTrustedKeysBase58 returns the operator's static
+	// `[validators]` config entries, base58-encoded with the NodePublic
+	// prefix. Surfaced by the `validators` RPC as `local_static_keys`
+	// (rippled getJson at ValidatorList.cpp:1657-1661). Nil-safe — a nil
+	// func means "no static keys".
+	LocalStaticTrustedKeysBase58 func() []string
+
+	// SigningKeysBase58 returns the master→signing key map projected as
+	// base58 strings. Surfaced by the `validators` RPC as `signing_keys`
+	// (rippled getJson at ValidatorList.cpp:1725-1734). Nil-safe.
+	SigningKeysBase58 func() map[string]string
+
+	// NegativeUNLBase58 returns the current negative-UNL set, base58-
+	// encoded. Surfaced by the `validators` RPC as `NegativeUNL`
+	// (rippled getJson at ValidatorList.cpp:1737-1744). Nil-safe.
+	NegativeUNLBase58 func() []string
 }
 
 // LedgerNavigator provides ledger index navigation and mode queries.

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -61,14 +61,21 @@ type ValidatorListPublisherInfo struct {
 // `validator_list_sites` RPC surfaces. Field names track rippled's
 // ValidatorSite::getJson at ValidatorSite.cpp:683-702.
 type ValidatorListSiteInfo struct {
-	URI                string
-	LastRefreshUnix    int64
-	LastSuccessUnix    int64
-	NextRefreshUnix    int64
-	LastRefreshISO     string
-	NextRefreshISO     string
-	LastError          string
-	LastDisposition    string
+	URI             string
+	LastRefreshUnix int64
+	LastSuccessUnix int64
+	NextRefreshUnix int64
+	LastRefreshISO  string
+	NextRefreshISO  string
+	LastError       string
+	LastDisposition string
+	// LastDispositionSet mirrors rippled's
+	// std::optional<Site::Status>::has_value() at
+	// ValidatorSite.cpp:690: the handler must omit
+	// `last_refresh_status` from the RPC response until the first
+	// poll attempt completes. Without this flag the zero-value
+	// disposition string would surface as a false "accepted" status.
+	LastDispositionSet bool
 	RefreshIntervalSec int
 	RefreshIntervalMin int
 }

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -15,6 +15,73 @@ type MethodDispatcher interface {
 	ExecuteMethod(method string, params []byte) (interface{}, *RpcError)
 }
 
+// ValidatorListPublisherInfo is the per-publisher snapshot the
+// `validators` RPC surfaces. Expressed as a value type (not the
+// internal/validator/list.PublisherState struct) so internal/rpc/types
+// doesn't import internal/validator/list — same anti-cycle pattern as
+// ManifestLookup below.
+type ValidatorListPublisherInfo struct {
+	// PublicKey is the 33-byte master pubkey as hex (uppercase). Empty
+	// when the publisher has not yet produced a list and only the
+	// configured key is known.
+	PublicKey string
+	// Status is one of "unavailable" / "available" / "expired" / "revoked".
+	Status string
+	// Sequence is the version of the currently-effective list. Zero
+	// before the first accepted list.
+	Sequence uint32
+	// EffectiveUnix is the Unix-epoch second at which the current list
+	// became effective. Zero when unset.
+	EffectiveUnix int64
+	// ExpirationUnix is the Unix-epoch second after which the current
+	// list is treated as expired. Zero when unset.
+	ExpirationUnix int64
+	// ValidatorCount is the number of validators in the publisher's
+	// currently-effective list.
+	ValidatorCount int
+	// SiteURI is the source URL (or "peer:<id>") of the most recent
+	// list.
+	SiteURI string
+}
+
+// ValidatorListSiteInfo is the per-URL snapshot the
+// `validator_list_sites` RPC surfaces.
+type ValidatorListSiteInfo struct {
+	URI                string
+	LastRefreshUnix    int64
+	LastSuccessUnix    int64
+	LastError          string
+	LastDisposition    string
+	RefreshIntervalSec int
+}
+
+// ValidatorListReader is the read-only facet of the publisher-trust
+// aggregator that the validators / validator_list_sites RPCs need.
+// Expressed as an interface so internal/rpc/types doesn't import
+// internal/validator/list.
+type ValidatorListReader interface {
+	// HasConfiguredPublishers reports whether any validator_list_keys
+	// are configured. False means the publisher-trust subsystem is
+	// inert and the RPC should report an empty publisher list.
+	HasConfiguredPublishers() bool
+	// PublisherCount returns the number of configured publishers in the
+	// trust set.
+	PublisherCount() int
+	// Threshold returns the configured publisher threshold (minimum
+	// number of publishers whose lists must agree on a validator
+	// before it enters the effective UNL).
+	Threshold() int
+	// Publishers returns a snapshot of per-publisher state for the
+	// `validators` RPC.
+	Publishers() []ValidatorListPublisherInfo
+	// Sites returns a snapshot of per-URL polling state for the
+	// `validator_list_sites` RPC.
+	Sites() []ValidatorListSiteInfo
+	// TrustedMasterKeys returns the master pubkeys currently in the
+	// effective trusted UNL contributed by publishers.
+	TrustedMasterKeys() [][33]byte
+}
+
 // ManifestLookup is the read-only facet of the validator-manifest cache
 // that the `manifest` RPC needs. Expressed as an interface (not a
 // concrete type) so internal/rpc/types doesn't import
@@ -70,6 +137,11 @@ type ServiceContainer struct {
 	// Computed by the adaptor from the current UNL minus the negative-UNL.
 	// Nil in standalone mode (server_info falls back to 1).
 	ValidationQuorum func() int
+
+	// ValidatorList is the publisher-trust subsystem's read facet for
+	// the `validators` and `validator_list_sites` RPC methods. Nil when
+	// no validator_list_keys are configured — handlers must nil-check.
+	ValidatorList ValidatorListReader
 }
 
 // LedgerNavigator provides ledger index navigation and mode queries.

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -117,7 +117,14 @@ type SiteState struct {
 	LastSuccess     time.Time
 	LastError       string
 	LastDisposition Disposition
-	RefreshSeconds  int
+	// LastDispositionSet is the sentinel rippled mirrors via
+	// `std::optional<Site::Status>::has_value()` at
+	// ValidatorSite.cpp:690 — `last_refresh_status` is omitted from the
+	// RPC until the first fetch attempt completes. Without the sentinel
+	// the zero-value `Disposition` (== Accepted) would emit a false
+	// "accepted" status before any poll runs.
+	LastDispositionSet bool
+	RefreshSeconds     int
 	// NextRefresh is the wall-clock time at which the next poll attempt
 	// is scheduled. Mirrors rippled's ValidatorSite::Site::nextRefresh
 	// surfaced via `next_refresh_time` in the validator_list_sites RPC.
@@ -171,9 +178,16 @@ type Aggregator struct {
 
 	// onChange is invoked whenever the recomputed trusted set differs
 	// from the previously emitted one. Wired by Components.NewFromConfig
-	// to push into Adaptor.SetTrustedValidators. The callback runs
-	// under the aggregator mutex so implementations MUST NOT call back
-	// into the aggregator from the callback (would deadlock).
+	// to push into Adaptor.SetTrustedValidators.
+	//
+	// LOCK INVARIANT: the callback runs *under* a.mu. Implementations
+	// must not, directly or transitively, call back into the aggregator
+	// (any exported method here re-locks a.mu and would deadlock). The
+	// production wiring satisfies this by routing the call to
+	// Adaptor.SetTrustedValidators, which takes its own lock and does
+	// not reach back into the aggregator. Any future caller that
+	// reschedules work or fans out to other subscribers must hop off
+	// this goroutine before re-entering the aggregator.
 	onChange func(validators []consensus.NodeID, masterKeys [][33]byte)
 
 	// lastEmitted is the most recently published trusted set (master
@@ -228,11 +242,19 @@ func New(cfg Config) (*Aggregator, error) {
 	// rippled ValidatorSite.cpp:83 (`nextRefresh = clock_type::now() +
 	// refreshInterval`).
 	initialNextRefresh := clock().Add(DefaultRefreshInterval)
+	// Seed RefreshSeconds with the default refresh interval so the
+	// `refresh_interval_min` RPC field reports the configured cadence
+	// from boot, before any envelope-supplied override is observed.
+	// Mirrors rippled ValidatorSite.cpp:81 where Site::refreshInterval
+	// is initialised to default_refresh_interval (5 minutes) at
+	// construction and emitted unconditionally in getJson.
+	defaultRefreshSec := int(DefaultRefreshInterval / time.Second)
 	sites := make([]*SiteState, 0, len(cfg.SiteURIs))
 	for _, u := range cfg.SiteURIs {
 		sites = append(sites, &SiteState{
-			URI:         u,
-			NextRefresh: initialNextRefresh,
+			URI:            u,
+			NextRefresh:    initialNextRefresh,
+			RefreshSeconds: defaultRefreshSec,
 		})
 	}
 	logger := cfg.Logger
@@ -351,6 +373,7 @@ func (a *Aggregator) UpdateSiteState(uri string, lastFetched, lastSuccess time.T
 		}
 		s.LastError = lastErr
 		s.LastDisposition = lastDisp
+		s.LastDispositionSet = true
 		if refreshSec > 0 {
 			s.RefreshSeconds = refreshSec
 		}
@@ -417,12 +440,22 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	// caches the manifest for later use and gives us the current
 	// ephemeral signing key. A revoked manifest invalidates the
 	// publisher entirely.
+	//
+	// Track the cache disposition so revocation only flips publisher
+	// state when the manifest cache actually accepted the revocation.
+	// Mirrors rippled ValidatorList.cpp:1373-1378 — `removePublisherList`
+	// runs only under `revoked && result == ManifestDisposition::accepted`;
+	// a stale revocation (cache already holds a higher-sequence
+	// non-revoked manifest) returns untrusted without clearing state.
+	manifestAccepted := false
 	if a.manifests != nil {
 		switch d := a.manifests.ApplyManifest(parsed); d {
-		case manifest.Accepted, manifest.Stale:
-			// Accepted: fresh manifest installed. Stale: we already
-			// had this or a newer one — either way the cache now has
-			// a current ephemeral key for the publisher.
+		case manifest.Accepted:
+			manifestAccepted = true
+		case manifest.Stale:
+			// Already had this or a newer one — cache state is
+			// unchanged; don't let an old revocation manifest flip
+			// the publisher's status.
 		case manifest.Invalid:
 			return Invalid, pubKey
 		case manifest.BadMasterKey, manifest.BadEphemeralKey:
@@ -435,15 +468,22 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 		if err := parsed.Verify(); err != nil {
 			return Invalid, pubKey
 		}
+		// No cache means every fresh verify is "accepted" for the
+		// purpose of the revocation gate.
+		manifestAccepted = true
 	}
 
 	if parsed.Revoked() {
 		// Rippled returns ListDisposition::untrusted on revocation
 		// (ValidatorList.cpp:1382-1383). Revocations are legitimate
 		// gossip; punishing the forwarding peer would cascade across
-		// every honest hop in the mesh. The side-effect (clearing
-		// publisher contribution + status flip) still runs.
-		a.handleRevocation(pubKey)
+		// every honest hop in the mesh. The state-clearing side effect
+		// only runs when the manifest cache actually accepted the
+		// revocation — mirrors rippled's `revoked && result == accepted`
+		// gate at ValidatorList.cpp:1373.
+		if manifestAccepted {
+			a.handleRevocation(pubKey)
+		}
 		return Untrusted, pubKey
 	}
 

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -1325,18 +1325,22 @@ func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
 	rawManifest := append([]byte(nil), s.RawManifest...)
 	rawBlob := append([]byte(nil), s.RawBlob...)
 	rawSignature := append([]byte(nil), s.RawSignature...)
-	// Snapshot any Remaining blobs into an ordered BroadcastBlob list
-	// so v2-capable peers can pre-pin the rotation. Mirrors rippled
-	// buildBlobInfos at ValidatorList.cpp:852-857 which serialises
-	// current + remaining into a single map<sequence,…>.
-	var collBlobs []BroadcastBlob
+	// Snapshot the publisher's current blob plus any Remaining blobs
+	// into an ordered BroadcastBlob list so v2-capable peers always
+	// receive a TMValidatorListCollection (single-entry when no
+	// Remaining). Mirrors rippled's sendValidatorList at
+	// ValidatorList.cpp:752-757 which selects messageVersion=2 purely
+	// on the peer's ValidatorList2Propagation feature, regardless of
+	// whether the publisher has Remaining blobs, and buildBlobInfos
+	// at ValidatorList.cpp:852-857 which serialises current + remaining
+	// into a single map<sequence,…>.
+	collBlobs := make([]BroadcastBlob, 0, len(s.Remaining)+1)
+	collBlobs = append(collBlobs, BroadcastBlob{
+		Blob:      append([]byte(nil), s.RawBlob...),
+		Signature: append([]byte(nil), s.RawSignature...),
+	})
 	maxSeq := sequence
 	if len(s.Remaining) > 0 {
-		collBlobs = make([]BroadcastBlob, 0, len(s.Remaining)+1)
-		collBlobs = append(collBlobs, BroadcastBlob{
-			Blob:      append([]byte(nil), s.RawBlob...),
-			Signature: append([]byte(nil), s.RawSignature...),
-		})
 		seqs := make([]uint32, 0, len(s.Remaining))
 		for seq := range s.Remaining {
 			seqs = append(seqs, seq)
@@ -1354,7 +1358,7 @@ func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
 		}
 	}
 	collVersion := blobVersion
-	if len(collBlobs) > 0 && collVersion < 2 {
+	if collVersion < 2 {
 		collVersion = 2
 	}
 	logger := a.logger
@@ -1369,12 +1373,12 @@ func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
 		if !bcaster.PeerSupportsVL(peerID) {
 			continue
 		}
-		// v2-capable peer with Remaining blobs available: send the full
-		// collection so the peer can pre-pin the rotation. Mirrors
-		// rippled broadcastBlobs at ValidatorList.cpp:872-937 which
-		// picks the wire shape per-peer based on the
-		// ValidatorList2Propagation feature.
-		if len(collBlobs) > 0 && bcaster.PeerSupportsV2(peerID) {
+		// v2-capable peer: always send the collection (single-entry
+		// when there are no Remaining blobs, multi-entry otherwise)
+		// so the wire shape matches rippled's broadcastBlobs at
+		// ValidatorList.cpp:872-937 which picks the message type
+		// purely on the peer's ValidatorList2Propagation feature.
+		if bcaster.PeerSupportsV2(peerID) {
 			if a.PeerSequence(peerID, pubKey) >= maxSeq {
 				continue
 			}
@@ -1413,7 +1417,7 @@ func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
 		logger.Debug("validator list broadcast",
 			"publisher", hex.EncodeToString(pubKey[:]),
 			"sequence", sequence,
-			"remaining", len(collBlobs),
+			"remaining", len(collBlobs)-1,
 			"peers_sent", sent)
 	}
 }

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -492,15 +492,20 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 
 	// Decode the publisher manifest. The manifest is base64-encoded on
 	// the wire; the inner STObject is what manifest.Deserialize wants.
+	// Both failure modes mirror rippled ValidatorList.cpp:1363-1366
+	// which folds bad-manifest into Untrusted (no extractable master
+	// key, no usable trust decision) charged at feeUselessData — never
+	// at the heavier feeInvalidSignature reserved for bad cryptography
+	// over a structurally-sound list.
 	manifestRaw, err := decodeBase64Tolerant(manifestBytes)
 	if err != nil {
 		a.logger.Debug("validator list: manifest base64 decode failed", "error", err, "site", siteURI)
-		return Malformed, PublisherKey{}, 0
+		return Untrusted, PublisherKey{}, 0
 	}
 	parsed, err := manifest.Deserialize(manifestRaw)
 	if err != nil {
 		a.logger.Debug("validator list: manifest deserialize failed", "error", err, "site", siteURI)
-		return Malformed, PublisherKey{}, 0
+		return Untrusted, PublisherKey{}, 0
 	}
 	pubKey := PublisherKey(parsed.MasterKey)
 
@@ -700,8 +705,26 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 	// Also seed any embedded validator manifests into the manifest
 	// cache so consensus can resolve ephemeral signing keys
 	// immediately, without waiting for the validator to gossip its
-	// own manifest. Mirrors rippled ValidatorList.cpp:1242-1273.
+	// own manifest. Mirrors rippled ValidatorList.cpp:1117-1133 which
+	// gates the apply on `keyListings_.count(m->masterKey)` — the
+	// embedded manifest's master key must be listed by some publisher
+	// (or by this publisher's new list, which is already incorporated
+	// above via `keys`). Manifests for unlisted validators are dropped:
+	// a malicious publisher must not be able to pollute the cache with
+	// manifests for validators they don't actually attest to.
 	if a.manifests != nil {
+		listed := make(map[[33]byte]struct{}, len(keys)+8)
+		for _, k := range keys {
+			listed[k] = struct{}{}
+		}
+		for pubMaster, ps := range a.state {
+			if pubMaster == s.MasterKey {
+				continue
+			}
+			for _, k := range ps.Validators {
+				listed[k] = struct{}{}
+			}
+		}
 		for _, v := range blob.Validators {
 			if v.Manifest == "" {
 				continue
@@ -712,6 +735,11 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 			}
 			parsed, err := manifest.Deserialize(raw)
 			if err != nil {
+				continue
+			}
+			if _, ok := listed[parsed.MasterKey]; !ok {
+				a.logger.Debug("validator list: dropping embedded manifest for unlisted master",
+					"master", hex.EncodeToString(parsed.MasterKey[:]))
 				continue
 			}
 			_ = a.manifests.ApplyManifest(parsed)

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -280,6 +280,16 @@ type Aggregator struct {
 	// BroadcastLatest can consult it without reaching into peer
 	// internals.
 	peerSeq map[uint64]map[PublisherKey]uint32
+
+	// cacheDir is the on-disk path where accepted publisher lists are
+	// persisted. Set via SetCacheDir; empty disables the cache.
+	// Mirrors rippled's ValidatorList::dataPath_ at
+	// rippled/src/xrpld/app/misc/ValidatorList.h:155 + the
+	// cacheValidatorFile / loadLists pair at
+	// rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:368-396 and
+	// 1300-1351. Read under a.mu so a SetCacheDir call doesn't race
+	// with an in-flight writeCacheLocked.
+	cacheDir string
 }
 
 // Config carries Aggregator construction parameters. All fields are
@@ -843,6 +853,7 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 		}
 	}
 
+	a.writeCacheLocked(s)
 	return prevCount != len(keys)
 }
 
@@ -909,6 +920,7 @@ func (a *Aggregator) applyPendingLocked(s *PublisherState, blob *blobJSON, signi
 		RawBlob:      append([]byte(nil), rawBlob...),
 		RawSignature: append([]byte(nil), rawSignature...),
 	}
+	a.writeCacheLocked(s)
 	if !s.MaxSequenceSet || blob.Sequence > s.MaxSequence {
 		s.MaxSequence = blob.Sequence
 		s.MaxSequenceSet = true
@@ -986,6 +998,7 @@ func (a *Aggregator) promoteRemainingLocked(s *PublisherState, now time.Time) (p
 	if len(s.Remaining) == 0 {
 		s.Remaining = nil
 	}
+	a.writeCacheLocked(s)
 	return true
 }
 
@@ -1019,6 +1032,7 @@ func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
 		return
 	}
 	s.Status = StatusRevoked
+	a.removeCacheLocked(s.MasterKey)
 	s.Validators = nil
 	s.RawManifest = nil
 	s.RawBlob = nil
@@ -1311,6 +1325,38 @@ func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
 	rawManifest := append([]byte(nil), s.RawManifest...)
 	rawBlob := append([]byte(nil), s.RawBlob...)
 	rawSignature := append([]byte(nil), s.RawSignature...)
+	// Snapshot any Remaining blobs into an ordered BroadcastBlob list
+	// so v2-capable peers can pre-pin the rotation. Mirrors rippled
+	// buildBlobInfos at ValidatorList.cpp:852-857 which serialises
+	// current + remaining into a single map<sequence,…>.
+	var collBlobs []BroadcastBlob
+	maxSeq := sequence
+	if len(s.Remaining) > 0 {
+		collBlobs = make([]BroadcastBlob, 0, len(s.Remaining)+1)
+		collBlobs = append(collBlobs, BroadcastBlob{
+			Blob:      append([]byte(nil), s.RawBlob...),
+			Signature: append([]byte(nil), s.RawSignature...),
+		})
+		seqs := make([]uint32, 0, len(s.Remaining))
+		for seq := range s.Remaining {
+			seqs = append(seqs, seq)
+		}
+		sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
+		for _, seq := range seqs {
+			rb := s.Remaining[seq]
+			collBlobs = append(collBlobs, BroadcastBlob{
+				Blob:      append([]byte(nil), rb.RawBlob...),
+				Signature: append([]byte(nil), rb.RawSignature...),
+			})
+			if seq > maxSeq {
+				maxSeq = seq
+			}
+		}
+	}
+	collVersion := blobVersion
+	if len(collBlobs) > 0 && collVersion < 2 {
+		collVersion = 2
+	}
 	logger := a.logger
 	a.mu.Unlock()
 
@@ -1321,6 +1367,27 @@ func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
 			continue
 		}
 		if !bcaster.PeerSupportsVL(peerID) {
+			continue
+		}
+		// v2-capable peer with Remaining blobs available: send the full
+		// collection so the peer can pre-pin the rotation. Mirrors
+		// rippled broadcastBlobs at ValidatorList.cpp:872-937 which
+		// picks the wire shape per-peer based on the
+		// ValidatorList2Propagation feature.
+		if len(collBlobs) > 0 && bcaster.PeerSupportsV2(peerID) {
+			if a.PeerSequence(peerID, pubKey) >= maxSeq {
+				continue
+			}
+			if err := bcaster.SendCollection(peerID, rawManifest, collBlobs, collVersion); err != nil {
+				logger.Debug("validator list collection broadcast: send failed",
+					"peer", peerID,
+					"publisher", hex.EncodeToString(pubKey[:]),
+					"max_sequence", maxSeq,
+					"error", err)
+				continue
+			}
+			a.RecordPeerSequence(peerID, pubKey, maxSeq)
+			sent++
 			continue
 		}
 		if a.PeerSequence(peerID, pubKey) >= sequence {
@@ -1346,6 +1413,7 @@ func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
 		logger.Debug("validator list broadcast",
 			"publisher", hex.EncodeToString(pubKey[:]),
 			"sequence", sequence,
+			"remaining", len(collBlobs),
 			"peers_sent", sent)
 	}
 }

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -107,6 +107,21 @@ type PublisherState struct {
 	// list. Mirrors rippled's PublisherListCollection.rawVersion at
 	// ValidatorList.h:74. Zero before the first accepted list.
 	Version uint32
+
+	// RawManifest / RawBlob / RawSignature are the wire-form bytes of
+	// the most recently accepted list, retained so the aggregator can
+	// rebroadcast the canonical accepted form to peers (mirrors
+	// rippled's PublisherList.rawManifest / rawBlob / rawSignature at
+	// ValidatorList.h:184-191). Cleared on revocation. Nil before the
+	// first accepted list.
+	//
+	// `RawManifest` and `RawBlob` are base64-encoded ASCII as received;
+	// `RawSignature` is hex-encoded ASCII. The aggregator stores them
+	// verbatim — no re-encoding — so what we relay is byte-identical
+	// to what an honest peer would have sent us.
+	RawManifest  []byte
+	RawBlob      []byte
+	RawSignature []byte
 }
 
 // SiteState is the per-URL polling state surfaced via the
@@ -201,6 +216,26 @@ type Aggregator struct {
 	clock func() time.Time
 
 	logger *slog.Logger
+
+	// bcaster is the overlay/encoder surface BroadcastLatest delivers
+	// frames through. Optional — nil disables outgoing relay (suits
+	// tests and standalone deployments with no peers).
+	bcaster PeerBroadcaster
+
+	// peerSeqMu guards peerSeq. Held briefly during ingress
+	// (RecordPeerSequence), disconnect (ForgetPeer), and broadcast
+	// (snapshot + post-send update). Distinct from `mu` so a
+	// long-running broadcast never blocks publisher-list ingest.
+	peerSeqMu sync.Mutex
+
+	// peerSeq[peerID][publisherKey] is the highest list sequence we
+	// know the peer has for that publisher. Updated on every accepted
+	// ingress (peer told us) and after every send (we told peer).
+	// Mirrors rippled's per-PeerImp publisherListSequences_ map
+	// (PeerImp.h:183, PeerImp.cpp:2102-2110); kept centrally here so
+	// BroadcastLatest can consult it without reaching into peer
+	// internals.
+	peerSeq map[uint64]map[PublisherKey]uint32
 }
 
 // Config carries Aggregator construction parameters. All fields are
@@ -282,7 +317,18 @@ func New(cfg Config) (*Aggregator, error) {
 		threshold:  threshold,
 		clock:      clock,
 		logger:     logger,
+		peerSeq:    make(map[uint64]map[PublisherKey]uint32),
 	}, nil
+}
+
+// SetBroadcaster wires the overlay/encoder surface BroadcastLatest
+// uses to deliver frames. Pass nil to disable relay (the default).
+// Safe to call multiple times; not safe to race with BroadcastLatest
+// — wire once at startup.
+func (a *Aggregator) SetBroadcaster(b PeerBroadcaster) {
+	a.mu.Lock()
+	a.bcaster = b
+	a.mu.Unlock()
 }
 
 // OnChange registers (or replaces) the callback fired when the
@@ -331,6 +377,15 @@ func (a *Aggregator) PublisherSnapshot() []PublisherState {
 		if len(s.Validators) > 0 {
 			cp.Validators = make([][33]byte, len(s.Validators))
 			copy(cp.Validators, s.Validators)
+		}
+		if len(s.RawManifest) > 0 {
+			cp.RawManifest = append([]byte(nil), s.RawManifest...)
+		}
+		if len(s.RawBlob) > 0 {
+			cp.RawBlob = append([]byte(nil), s.RawBlob...)
+		}
+		if len(s.RawSignature) > 0 {
+			cp.RawSignature = append([]byte(nil), s.RawSignature...)
 		}
 		out = append(out, cp)
 	}
@@ -408,11 +463,11 @@ func (a *Aggregator) UpdateSiteState(uri string, lastFetched, lastSuccess time.T
 
 // ApplyList ingests a single (manifest, blob, signature) triple and
 // returns the resulting disposition along with the publisher master
-// key (when extractable). Wraps the rippled-faithful applyList
-// algorithm: verify the publisher manifest, look up its current
-// ephemeral signing key, verify the blob signature, JSON-parse the
-// blob, then update per-publisher state and trigger an OnChange if the
-// trusted union changed.
+// key (when extractable) and the blob's sequence (when extractable).
+// Wraps the rippled-faithful applyList algorithm: verify the publisher
+// manifest, look up its current ephemeral signing key, verify the blob
+// signature, JSON-parse the blob, then update per-publisher state and
+// trigger an OnChange if the trusted union changed.
 //
 // `manifestBytes` and `blob` carry the WIRE-FORM ascii strings as
 // received in TMValidatorList / TMValidatorListCollection (base64-
@@ -427,10 +482,12 @@ func (a *Aggregator) UpdateSiteState(uri string, lastFetched, lastSuccess time.T
 // extractable (i.e. the manifest decoded), so the caller can attribute
 // metrics / bad-data charges with publisher-level granularity even on
 // failure paths. Returns the zero PublisherKey when the manifest
-// itself could not be parsed.
-func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version uint32, siteURI string) (Disposition, PublisherKey) {
+// itself could not be parsed. The sequence return is non-zero only
+// when the blob was decoded; the router uses it to record per-peer
+// publisher sequences regardless of accept/expired/pending outcome.
+func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version uint32, siteURI string) (Disposition, PublisherKey, uint32) {
 	if !isSupportedVersion(version) {
-		return UnsupportedVersion, PublisherKey{}
+		return UnsupportedVersion, PublisherKey{}, 0
 	}
 
 	// Decode the publisher manifest. The manifest is base64-encoded on
@@ -438,12 +495,12 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	manifestRaw, err := decodeBase64Tolerant(manifestBytes)
 	if err != nil {
 		a.logger.Debug("validator list: manifest base64 decode failed", "error", err, "site", siteURI)
-		return Malformed, PublisherKey{}
+		return Malformed, PublisherKey{}, 0
 	}
 	parsed, err := manifest.Deserialize(manifestRaw)
 	if err != nil {
 		a.logger.Debug("validator list: manifest deserialize failed", "error", err, "site", siteURI)
-		return Malformed, PublisherKey{}
+		return Malformed, PublisherKey{}, 0
 	}
 	pubKey := PublisherKey(parsed.MasterKey)
 
@@ -455,7 +512,7 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	_, trusted := a.publishers[pubKey]
 	a.mu.Unlock()
 	if !trusted {
-		return Untrusted, pubKey
+		return Untrusted, pubKey, 0
 	}
 
 	// Apply the publisher manifest to the manifest cache. This both
@@ -486,7 +543,7 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 			// (light), Invalid would map to feeInvalidSignature (heavy)
 			// — using Untrusted avoids overcharging honest peers that
 			// forward a list whose manifest the cache cannot accept.
-			return Untrusted, pubKey
+			return Untrusted, pubKey, 0
 		}
 	} else {
 		// Fall back to direct verification when no cache is wired
@@ -494,7 +551,7 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 		// pulled from the cache. Mirrors rippled's invalid-manifest →
 		// untrusted mapping at ValidatorList.cpp:1382-1383.
 		if err := parsed.Verify(); err != nil {
-			return Untrusted, pubKey
+			return Untrusted, pubKey, 0
 		}
 		// No cache means every fresh verify is "accepted" for the
 		// purpose of the revocation gate.
@@ -512,7 +569,7 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 		if manifestAccepted {
 			a.handleRevocation(pubKey)
 		}
-		return Untrusted, pubKey
+		return Untrusted, pubKey, 0
 	}
 
 	// Pull the current ephemeral signing key. With a cache: this is
@@ -531,19 +588,19 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 			// treat as untrusted (no usable signing key from a trusted
 			// publisher means we cannot verify the blob; rippled's
 			// equivalent at ValidatorList.cpp:1382 is also untrusted).
-			return Untrusted, pubKey
+			return Untrusted, pubKey, 0
 		}
 	}
 
 	if err := verifyBlobSignature(signingKey, blob, signature); err != nil {
 		a.logger.Debug("validator list: blob signature invalid", "error", err, "publisher", hex.EncodeToString(pubKey[:]))
-		return Invalid, pubKey
+		return Invalid, pubKey, 0
 	}
 
 	parsedBlob, disp, err := parseBlob(blob)
 	if err != nil {
 		a.logger.Debug("validator list: blob parse failed", "error", err, "publisher", hex.EncodeToString(pubKey[:]))
-		return disp, pubKey
+		return disp, pubKey, 0
 	}
 
 	now := a.clock()
@@ -564,20 +621,20 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	// rippled returns same_sequence for every repeat of the current
 	// sequence regardless of `pubCollection.status`.
 	if parsedBlob.Sequence < current.Sequence {
-		return Stale, pubKey
+		return Stale, pubKey, parsedBlob.Sequence
 	}
 	if parsedBlob.Sequence == current.Sequence {
-		return SameSequence, pubKey
+		return SameSequence, pubKey, parsedBlob.Sequence
 	}
 	if validUntil.Before(now) || validUntil.Equal(now) {
 		// Even an expired list still updates the publisher entry so
 		// the RPC can surface "expired" — but the validators do NOT
 		// flow into the trusted union (status is StatusExpired).
-		applied := a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version)
+		applied := a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, manifestBytes, blob, signature)
 		_ = applied // applyAcceptedLocked sets Status; trusted set recompute below skips expired.
 		current.Status = StatusExpired
 		a.recomputeAndEmitLocked()
-		return Expired, pubKey
+		return Expired, pubKey, parsedBlob.Sequence
 	}
 	if validFrom.After(now) {
 		// Future-dated. Rippled stores this in `remaining` so it can
@@ -586,19 +643,24 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 		// republish at effective time, and the 5-min poller cadence
 		// limits the lag). Tracked for future work but not blocking
 		// for the issue.
-		return Pending, pubKey
+		return Pending, pubKey, parsedBlob.Sequence
 	}
 
-	a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version)
+	a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, manifestBytes, blob, signature)
 	a.recomputeAndEmitLocked()
-	return Accepted, pubKey
+	return Accepted, pubKey, parsedBlob.Sequence
 }
 
 // applyAcceptedLocked materializes the parsed blob into the
 // publisher's state. Caller must hold a.mu. Does NOT emit OnChange —
 // that's done by recomputeAndEmitLocked once the caller has decided
 // the disposition warrants a trusted-set recompute.
-func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, now time.Time, version uint32) bool {
+//
+// rawManifest / rawBlob / rawSignature are the wire-form bytes from
+// the original TMValidatorList / envelope; they are copied (not
+// referenced) so the caller may reuse its slices safely. Used later
+// by BroadcastLatest to re-emit the canonical accepted form to peers.
+func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, now time.Time, version uint32, rawManifest, rawBlob, rawSignature []byte) bool {
 	prevCount := len(s.Validators)
 	s.Sequence = blob.Sequence
 	s.Effective = validFrom
@@ -610,6 +672,9 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 	if version > s.Version {
 		s.Version = version
 	}
+	s.RawManifest = append(s.RawManifest[:0], rawManifest...)
+	s.RawBlob = append(s.RawBlob[:0], rawBlob...)
+	s.RawSignature = append(s.RawSignature[:0], rawSignature...)
 
 	keys := make([][33]byte, 0, len(blob.Validators))
 	for i, v := range blob.Validators {
@@ -658,7 +723,8 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 
 // handleRevocation removes a publisher's contribution when its master
 // key is revoked by a fresh manifest. Mirrors rippled's
-// removePublisherList(StatusRevoked) branch in verify().
+// removePublisherList(StatusRevoked) branch in verify(). Also clears
+// the retained wire bytes so a revoked publisher is never rebroadcast.
 func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -668,6 +734,9 @@ func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
 	}
 	s.Status = StatusRevoked
 	s.Validators = nil
+	s.RawManifest = nil
+	s.RawBlob = nil
+	s.RawSignature = nil
 	a.recomputeAndEmitLocked()
 }
 
@@ -793,23 +862,26 @@ func (a *Aggregator) TrustedValidators() ([]consensus.NodeID, [][33]byte) {
 // applying each blob individually with the collection's shared
 // publisher manifest. Returns the per-blob dispositions in the same
 // order as the collection's blob array, plus the publisher key once
-// the manifest decoded. The router uses the dispositions to decide
-// whether to charge the sender (any Invalid / Malformed) and whether
-// to relay (at least one Accepted).
+// the manifest decoded and the highest sequence observed across the
+// collection. The router uses the dispositions to decide whether to
+// charge the sender (any Invalid / Malformed) and whether to relay
+// (at least one Accepted), and uses the max-sequence value to update
+// the per-peer publisherListSequences entry.
 //
 // Mirrors rippled's applyLists at ValidatorList.cpp:998-1070.
-func (a *Aggregator) ApplyCollection(coll *message.ValidatorListCollection, siteURI string) ([]Disposition, PublisherKey) {
+func (a *Aggregator) ApplyCollection(coll *message.ValidatorListCollection, siteURI string) ([]Disposition, PublisherKey, uint32) {
 	if coll == nil {
-		return []Disposition{Malformed}, PublisherKey{}
+		return []Disposition{Malformed}, PublisherKey{}, 0
 	}
 	if !isSupportedVersion(coll.Version) {
-		return []Disposition{UnsupportedVersion}, PublisherKey{}
+		return []Disposition{UnsupportedVersion}, PublisherKey{}, 0
 	}
 	if len(coll.Blobs) == 0 {
-		return []Disposition{Malformed}, PublisherKey{}
+		return []Disposition{Malformed}, PublisherKey{}, 0
 	}
 	out := make([]Disposition, len(coll.Blobs))
 	var pubKey PublisherKey
+	var maxSeq uint32
 	for i, blob := range coll.Blobs {
 		// Per blob: prefer the embedded local manifest when present,
 		// else fall back to the collection's shared manifest. Matches
@@ -819,13 +891,16 @@ func (a *Aggregator) ApplyCollection(coll *message.ValidatorListCollection, site
 		if len(mf) == 0 {
 			mf = coll.Manifest
 		}
-		disp, pk := a.ApplyList(mf, blob.Blob, blob.Signature, coll.Version, siteURI)
+		disp, pk, seq := a.ApplyList(mf, blob.Blob, blob.Signature, coll.Version, siteURI)
 		out[i] = disp
 		if pk != (PublisherKey{}) {
 			pubKey = pk
 		}
+		if seq > maxSeq {
+			maxSeq = seq
+		}
 	}
-	return out, pubKey
+	return out, pubKey, maxSeq
 }
 
 // isSupportedVersion reports whether version is in SupportedVersions.
@@ -836,6 +911,130 @@ func isSupportedVersion(v uint32) bool {
 		}
 	}
 	return false
+}
+
+// RecordPeerSequence remembers that `peerID` has at least sequence
+// `seq` for `pubKey`. Called by the router after a successful ingress
+// of a TMValidatorList / TMValidatorListCollection — the peer has
+// proved possession of that sequence, so subsequent BroadcastLatest
+// passes for the same or older sequence can skip them.
+//
+// Monotonic: lower sequences are ignored. Zero `seq` is a no-op (we
+// only ever record a confirmed sequence). Mirrors rippled
+// PeerImp.cpp:2102-2110.
+func (a *Aggregator) RecordPeerSequence(peerID uint64, pubKey PublisherKey, seq uint32) {
+	if seq == 0 {
+		return
+	}
+	a.peerSeqMu.Lock()
+	defer a.peerSeqMu.Unlock()
+	m, ok := a.peerSeq[peerID]
+	if !ok {
+		m = make(map[PublisherKey]uint32)
+		a.peerSeq[peerID] = m
+	}
+	if seq > m[pubKey] {
+		m[pubKey] = seq
+	}
+}
+
+// ForgetPeer drops every per-publisher sequence record for `peerID`.
+// Called by the router from the peer-disconnect callback so the
+// per-peer map doesn't grow unbounded across the lifetime of the
+// process. Idempotent for unknown peers.
+func (a *Aggregator) ForgetPeer(peerID uint64) {
+	a.peerSeqMu.Lock()
+	defer a.peerSeqMu.Unlock()
+	delete(a.peerSeq, peerID)
+}
+
+// PeerSequence returns the highest sequence we believe `peerID` has
+// for `pubKey`, or 0 if unknown. Read-only accessor for tests and
+// observability; production code consults peerSeq via BroadcastLatest.
+func (a *Aggregator) PeerSequence(peerID uint64, pubKey PublisherKey) uint32 {
+	a.peerSeqMu.Lock()
+	defer a.peerSeqMu.Unlock()
+	if m, ok := a.peerSeq[peerID]; ok {
+		return m[pubKey]
+	}
+	return 0
+}
+
+// BroadcastLatest pushes the most recently accepted list for `pubKey`
+// to every connected peer that (a) negotiated ValidatorListPropagation
+// and (b) is known to be at a lower sequence than ours. `exceptPeer`
+// is the peer ID we just received the list from (or 0 for site-polled
+// lists) and is always skipped to avoid echoing back to the sender.
+//
+// No-op when no broadcaster is wired, when the publisher has no
+// accepted list to retain, or when the stored raw bytes are empty.
+// Mirrors rippled's ValidatorList::broadcastBlobs at
+// ValidatorList.cpp:872-937 — the per-peer publisherListSequence gate
+// + the "send the latest stored blob, not the inbound frame"
+// invariant. Per-peer state is updated after each successful send so
+// subsequent calls naturally skip the just-served peer.
+//
+// MUST NOT be called with a.mu held — the call snapshots state under
+// a.mu briefly then releases it, and may hold peerSeqMu and call into
+// the broadcaster (which writes to peer sockets) without either lock.
+func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
+	a.mu.Lock()
+	bcaster := a.bcaster
+	if bcaster == nil {
+		a.mu.Unlock()
+		return
+	}
+	s, ok := a.state[pubKey]
+	if !ok || s.Sequence == 0 || s.Status == StatusRevoked ||
+		len(s.RawManifest) == 0 || len(s.RawBlob) == 0 || len(s.RawSignature) == 0 {
+		a.mu.Unlock()
+		return
+	}
+	sequence := s.Sequence
+	blobVersion := s.Version
+	if blobVersion == 0 {
+		blobVersion = 1
+	}
+	rawManifest := append([]byte(nil), s.RawManifest...)
+	rawBlob := append([]byte(nil), s.RawBlob...)
+	rawSignature := append([]byte(nil), s.RawSignature...)
+	logger := a.logger
+	a.mu.Unlock()
+
+	active := bcaster.ActivePeers()
+	sent := 0
+	for _, peerID := range active {
+		if peerID == exceptPeer {
+			continue
+		}
+		if !bcaster.PeerSupportsVL(peerID) {
+			continue
+		}
+		if a.PeerSequence(peerID, pubKey) >= sequence {
+			continue
+		}
+		if err := bcaster.SendList(peerID, rawManifest, rawBlob, rawSignature, blobVersion); err != nil {
+			logger.Debug("validator list broadcast: send failed",
+				"peer", peerID,
+				"publisher", hex.EncodeToString(pubKey[:]),
+				"sequence", sequence,
+				"error", err)
+			continue
+		}
+		// Even if the wire bytes happened to coincide with a frame the
+		// peer just sent us, the in-flight RecordPeerSequence call
+		// will reach the same target sequence — so updating here is
+		// idempotent.
+		a.RecordPeerSequence(peerID, pubKey, sequence)
+		sent++
+	}
+
+	if sent > 0 {
+		logger.Debug("validator list broadcast",
+			"publisher", hex.EncodeToString(pubKey[:]),
+			"sequence", sequence,
+			"peers_sent", sent)
+	}
 }
 
 // mastersEqual reports whether two sorted master-key slices contain

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -49,7 +49,6 @@ const (
 	StatusRevoked
 )
 
-// String returns a short lowercase label for logs and RPC output.
 func (s PublisherStatus) String() string {
 	switch s {
 	case StatusUnavailable:
@@ -402,7 +401,6 @@ func (a *Aggregator) PublisherCount() int {
 	return len(a.publishers)
 }
 
-// Threshold returns the configured publisher threshold.
 func (a *Aggregator) Threshold() int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -478,8 +476,6 @@ func (a *Aggregator) PublisherSnapshot() []PublisherState {
 	return out
 }
 
-// SiteSnapshot returns a deep copy of the per-URL polling state for the
-// validator_list_sites RPC.
 func (a *Aggregator) SiteSnapshot() []SiteState {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -1230,7 +1226,6 @@ func (a *Aggregator) ApplyCollection(coll *message.ValidatorListCollection, site
 	return out, pubKey, maxSeq
 }
 
-// isSupportedVersion reports whether version is in SupportedVersions.
 func isSupportedVersion(v uint32) bool {
 	for _, sv := range SupportedVersions {
 		if sv == v {

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -540,15 +540,24 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 			// Already had this or a newer one — cache state is
 			// unchanged; don't let an old revocation manifest flip
 			// the publisher's status.
-		case manifest.Invalid, manifest.BadMasterKey, manifest.BadEphemeralKey:
+		case manifest.Invalid:
 			// Rippled ValidatorList.cpp:1382-1383 returns
-			// `untrusted` for `result == ManifestDisposition::invalid`
-			// (and implicitly for badMasterKey/badEphemeralKey via the
-			// `!signingKey` fallback). Untrusted maps to feeUselessData
-			// (light), Invalid would map to feeInvalidSignature (heavy)
-			// — using Untrusted avoids overcharging honest peers that
-			// forward a list whose manifest the cache cannot accept.
+			// `untrusted` strictly for `result == ManifestDisposition::invalid`.
+			// Untrusted maps to feeUselessData (light), Invalid would map
+			// to feeInvalidSignature (heavy) — using Untrusted avoids
+			// overcharging honest peers that forward a list whose manifest
+			// the cache cannot accept.
 			return Untrusted, pubKey, 0
+		case manifest.BadMasterKey, manifest.BadEphemeralKey:
+			// Cache state is unchanged for these (Manifest.cpp:436-477
+			// returns before any mutation), so `getSigningKey(masterPubKey)`
+			// below will still return the previously-cached signing key if
+			// any. Rippled's check at ValidatorList.cpp:1380-1383 gates only
+			// on `result == invalid`, NOT on badMasterKey/badEphemeralKey,
+			// so we fall through to the signing-key lookup. If the cache
+			// has no key for this master, the lookup branch a few lines
+			// below returns Untrusted; if it has one, blob verification
+			// proceeds against that cached key — matching rippled.
 		}
 	} else {
 		// Fall back to direct verification when no cache is wired
@@ -905,6 +914,15 @@ func (a *Aggregator) ApplyCollection(coll *message.ValidatorListCollection, site
 		return []Disposition{UnsupportedVersion}, PublisherKey{}, 0
 	}
 	if len(coll.Blobs) == 0 {
+		return []Disposition{Malformed}, PublisherKey{}, 0
+	}
+	// Anti-abuse cap. Matches rippled ValidatorList.h:272
+	// `static constexpr std::size_t maxSupportedBlobs = 5;` enforced
+	// at ValidatorList.cpp:428 (v2 JSON path) and 472-473 (parseBlobs).
+	// A peer that sends a collection larger than this would force the
+	// aggregator to run N signature verifications; reject before any
+	// crypto work.
+	if len(coll.Blobs) > MaxSupportedBlobs {
 		return []Disposition{Malformed}, PublisherKey{}, 0
 	}
 	out := make([]Disposition, len(coll.Blobs))

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -352,6 +352,28 @@ func (a *Aggregator) SiteSnapshot() []SiteState {
 	return out
 }
 
+// SetNextRefresh schedules the next poll time for the given URL without
+// touching other site-state fields. Called by the poller at the start
+// of each fetch attempt so the validator_list_sites RPC reports the
+// upcoming refresh time even while the in-flight fetch is outstanding.
+// Mirrors rippled's onTimer ordering at ValidatorSite.cpp:354-355 where
+// `nextRefresh` is updated before `makeRequest` is invoked.
+//
+// Idempotent for unknown URIs.
+func (a *Aggregator) SetNextRefresh(uri string, nextRefresh time.Time) {
+	if nextRefresh.IsZero() {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, s := range a.sites {
+		if s.URI == uri {
+			s.NextRefresh = nextRefresh
+			return
+		}
+	}
+}
+
 // UpdateSiteState records the outcome of an HTTP poll attempt against a
 // configured publisher URL. The poller goroutine calls this after each
 // fetch attempt; the data flows through to the validator_list_sites
@@ -456,17 +478,23 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 			// Already had this or a newer one — cache state is
 			// unchanged; don't let an old revocation manifest flip
 			// the publisher's status.
-		case manifest.Invalid:
-			return Invalid, pubKey
-		case manifest.BadMasterKey, manifest.BadEphemeralKey:
-			return Invalid, pubKey
+		case manifest.Invalid, manifest.BadMasterKey, manifest.BadEphemeralKey:
+			// Rippled ValidatorList.cpp:1382-1383 returns
+			// `untrusted` for `result == ManifestDisposition::invalid`
+			// (and implicitly for badMasterKey/badEphemeralKey via the
+			// `!signingKey` fallback). Untrusted maps to feeUselessData
+			// (light), Invalid would map to feeInvalidSignature (heavy)
+			// — using Untrusted avoids overcharging honest peers that
+			// forward a list whose manifest the cache cannot accept.
+			return Untrusted, pubKey
 		}
 	} else {
 		// Fall back to direct verification when no cache is wired
 		// (tests). The signing key in the manifest is what we'd have
-		// pulled from the cache.
+		// pulled from the cache. Mirrors rippled's invalid-manifest →
+		// untrusted mapping at ValidatorList.cpp:1382-1383.
 		if err := parsed.Verify(); err != nil {
-			return Invalid, pubKey
+			return Untrusted, pubKey
 		}
 		// No cache means every fresh verify is "accepted" for the
 		// purpose of the revocation gate.
@@ -584,9 +612,15 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 	}
 
 	keys := make([][33]byte, 0, len(blob.Validators))
-	for _, v := range blob.Validators {
+	for i, v := range blob.Validators {
 		raw, err := hex.DecodeString(v.ValidationPublicKey)
-		if err != nil || len(raw) != 33 {
+		if err != nil || !validatorKeyValid(raw) {
+			// Mirrors rippled ValidatorList.cpp:1250-1273 which logs
+			// `Invalid node identity` and silently skips the entry
+			// rather than rejecting the surrounding blob.
+			a.logger.Debug("validator list: skipping invalid validator entry",
+				"index", i,
+				"pubkey", v.ValidationPublicKey)
 			continue
 		}
 		var k [33]byte

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -219,13 +219,21 @@ func New(cfg Config) (*Aggregator, error) {
 			Status:    StatusUnavailable,
 		}
 	}
-	sites := make([]*SiteState, 0, len(cfg.SiteURIs))
-	for _, u := range cfg.SiteURIs {
-		sites = append(sites, &SiteState{URI: u})
-	}
 	clock := cfg.Clock
 	if clock == nil {
 		clock = time.Now
+	}
+	// Seed NextRefresh at construction so the validator_list_sites RPC
+	// surfaces a real value before the first poll fires. Mirrors
+	// rippled ValidatorSite.cpp:83 (`nextRefresh = clock_type::now() +
+	// refreshInterval`).
+	initialNextRefresh := clock().Add(DefaultRefreshInterval)
+	sites := make([]*SiteState, 0, len(cfg.SiteURIs))
+	for _, u := range cfg.SiteURIs {
+		sites = append(sites, &SiteState{
+			URI:         u,
+			NextRefresh: initialNextRefresh,
+		})
 	}
 	logger := cfg.Logger
 	if logger == nil {
@@ -477,20 +485,20 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	current, ok := a.state[pubKey]
-	if !ok {
-		// Defensive — every publisher in `publishers` had an entry
-		// preallocated in New().
-		current = &PublisherState{MasterKey: pubKey, Status: StatusUnavailable}
-		a.state[pubKey] = current
-	}
+	// New() pre-populates state[pubKey] for every trusted publisher and
+	// the entry is never deleted, so a missing key would be an internal
+	// invariant break — surface it loudly rather than silently re-create.
+	current := a.state[pubKey]
 
 	// Determine disposition by sequence + time ordering. Mirrors the
-	// rippled state machine at ValidatorList.cpp:1394-1437.
+	// rippled state machine at ValidatorList.cpp:1394-1437. The
+	// SameSequence branch is intentionally unguarded by status —
+	// rippled returns same_sequence for every repeat of the current
+	// sequence regardless of `pubCollection.status`.
 	if parsedBlob.Sequence < current.Sequence {
 		return Stale, pubKey
 	}
-	if parsedBlob.Sequence == current.Sequence && current.Status != StatusUnavailable {
+	if parsedBlob.Sequence == current.Sequence {
 		return SameSequence, pubKey
 	}
 	if validUntil.Before(now) || validUntil.Equal(now) {

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -83,9 +83,16 @@ type PublisherState struct {
 	Sequence uint32
 
 	// Effective is the Unix timestamp at which the current list became
-	// effective. Zero when the publisher hasn't specified one (rippled
-	// treats absent `effective` as "immediately").
+	// effective. Treated as a sentinel ("not set") when EffectiveSet is
+	// false; rippled gates `validFrom != TimeKeeper::time_point{}` at
+	// ValidatorList.cpp:1682 and a Go-side zero-value time.Time cannot
+	// stand in for the C++ zero sentinel because rippleSecondsToUnix(0)
+	// resolves to 2000-01-01 UTC, not Go's epoch.
 	Effective time.Time
+	// EffectiveSet records whether the accepted blob carried an
+	// `effective` field. False means rippled would omit it from the
+	// `validators` RPC `effective` key.
+	EffectiveSet bool
 
 	// Expiration is the Unix timestamp after which the current list is
 	// considered expired and contributes nothing further.
@@ -119,6 +126,43 @@ type PublisherState struct {
 	// `RawSignature` is hex-encoded ASCII. The aggregator stores them
 	// verbatim — no re-encoding — so what we relay is byte-identical
 	// to what an honest peer would have sent us.
+	RawManifest  []byte
+	RawBlob      []byte
+	RawSignature []byte
+
+	// Remaining is the queue of future-dated lists for this publisher,
+	// keyed by sequence and ordered by validFrom. Mirrors rippled's
+	// PublisherListCollection.remaining at ValidatorList.h:75-83. A
+	// rotation announced ahead of `effective` time lands here and is
+	// promoted into the current slot once its validFrom passes — see
+	// promoteRemainingLocked. Empty when no rotation is pending.
+	Remaining map[uint32]*PendingList
+
+	// MaxSequence is the largest sequence ever stored in `Remaining`.
+	// Mirrors rippled's PublisherListCollection.maxSequence; combined
+	// with `Remaining` it drives the pending-vs-known_sequence decision
+	// at applyList (ValidatorList.cpp:1414-1432).
+	MaxSequence uint32
+	// MaxSequenceSet records whether MaxSequence has ever been
+	// populated (a future-dated blob has been observed). Distinct from
+	// `MaxSequence == 0` because sequence 0 is not a valid published
+	// list — but we keep the sentinel explicit to mirror rippled's
+	// std::optional<size_t>.
+	MaxSequenceSet bool
+}
+
+// PendingList is one entry in PublisherState.Remaining — a fully-verified
+// future-dated list that will become current at validFrom. Wire bytes are
+// retained so the post-promotion broadcast can re-emit the canonical form.
+type PendingList struct {
+	Sequence     uint32
+	Effective    time.Time
+	EffectiveSet bool
+	Expiration   time.Time
+	Validators   [][33]byte
+	SiteURI      string
+	Version      uint32
+	SigningKey   [33]byte
 	RawManifest  []byte
 	RawBlob      []byte
 	RawSignature []byte
@@ -368,9 +412,19 @@ func (a *Aggregator) HasConfiguredPublishers() bool {
 // PublisherSnapshot returns a deep copy of the per-publisher state for
 // RPC and observability. Order is sorted by publisher master key for
 // stable output. Safe to call concurrently with ingest.
+//
+// Lazily runs the Remaining → current promotion so the RPC sees a
+// timely view even when no new lists have been ingested in this
+// process tick. The promotion is purely a state shift inside the
+// publisher entry; it does not emit OnChange (Tick is the explicit
+// emit-on-time entry point).
 func (a *Aggregator) PublisherSnapshot() []PublisherState {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	now := a.clock()
+	for _, s := range a.state {
+		a.promoteRemainingLocked(s, now)
+	}
 	out := make([]PublisherState, 0, len(a.state))
 	for _, s := range a.state {
 		cp := *s
@@ -386,6 +440,25 @@ func (a *Aggregator) PublisherSnapshot() []PublisherState {
 		}
 		if len(s.RawSignature) > 0 {
 			cp.RawSignature = append([]byte(nil), s.RawSignature...)
+		}
+		if len(s.Remaining) > 0 {
+			cp.Remaining = make(map[uint32]*PendingList, len(s.Remaining))
+			for seq, p := range s.Remaining {
+				pcopy := *p
+				if len(p.Validators) > 0 {
+					pcopy.Validators = append([][33]byte(nil), p.Validators...)
+				}
+				if len(p.RawManifest) > 0 {
+					pcopy.RawManifest = append([]byte(nil), p.RawManifest...)
+				}
+				if len(p.RawBlob) > 0 {
+					pcopy.RawBlob = append([]byte(nil), p.RawBlob...)
+				}
+				if len(p.RawSignature) > 0 {
+					pcopy.RawSignature = append([]byte(nil), p.RawSignature...)
+				}
+				cp.Remaining[seq] = &pcopy
+			}
 		}
 		out = append(out, cp)
 	}
@@ -629,6 +702,15 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	// invariant break — surface it loudly rather than silently re-create.
 	current := a.state[pubKey]
 
+	// Promote any pending Remaining entries that have reached their
+	// validFrom before the disposition check — mirrors rippled's lazy
+	// rotation in updateTrusted at ValidatorList.cpp:1929-1991, except
+	// driven by ingest rather than ledger close. Without this a fresh
+	// blob arriving after a queued rotation's effective time would see
+	// a stale `current.sequence` and decide pending/known_sequence on
+	// the wrong baseline.
+	a.promoteRemainingLocked(current, now)
+
 	// Determine disposition by sequence + time ordering. Mirrors the
 	// rippled state machine at ValidatorList.cpp:1394-1437. The
 	// SameSequence branch is intentionally unguarded by status —
@@ -647,17 +729,22 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 		applied := a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, manifestBytes, blob, signature)
 		_ = applied // applyAcceptedLocked sets Status; trusted set recompute below skips expired.
 		current.Status = StatusExpired
+		// Mirrors rippled removePublisherList(StatusExpired) at
+		// ValidatorList.cpp:1529-1542 — on expiry the publisher's
+		// validator list is cleared. Without this the `validators`
+		// RPC would show stale keys under `available=false`.
+		current.Validators = nil
 		a.recomputeAndEmitLocked()
 		return Expired, pubKey, parsedBlob.Sequence
 	}
 	if validFrom.After(now) {
-		// Future-dated. Rippled stores this in `remaining` so it can
-		// be promoted later. goXRPL's first-cut subsystem keeps a
-		// simpler model: drop pending lists (the publisher will
-		// republish at effective time, and the 5-min poller cadence
-		// limits the lag). Tracked for future work but not blocking
-		// for the issue.
-		return Pending, pubKey, parsedBlob.Sequence
+		// Future-dated. Mirrors rippled ValidatorList.cpp:1414-1432
+		// pending-vs-known_sequence: a list is "pending" the first
+		// time it lands or whenever its sequence is the largest seen,
+		// and "known_sequence" only for re-arrivals at an already-
+		// queued sequence. The queued blob is retained so the next
+		// promoteRemainingLocked pass can rotate it into `current`.
+		return a.applyPendingLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, version, manifestBytes, blob, signature), pubKey, parsedBlob.Sequence
 	}
 
 	a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, manifestBytes, blob, signature)
@@ -678,6 +765,7 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 	prevCount := len(s.Validators)
 	s.Sequence = blob.Sequence
 	s.Effective = validFrom
+	s.EffectiveSet = blob.EffectiveSet
 	s.Expiration = validUntil
 	s.SigningKey = signingKey
 	s.SiteURI = siteURI
@@ -758,6 +846,167 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 	return prevCount != len(keys)
 }
 
+// applyPendingLocked stores a future-dated blob in the publisher's
+// Remaining queue and returns Pending vs KnownSequence per rippled
+// ValidatorList.cpp:1414-1432:
+//
+//   - Pending: no MaxSequence yet, or sequence > MaxSequence, or
+//     sequence is unknown AND validFrom precedes the current
+//     MaxSequence entry's validFrom (out-of-order delivery).
+//   - KnownSequence: re-arrival at a sequence already queued.
+//
+// The blob is only stored on the Pending branch; KnownSequence is a
+// no-op since we already have the same sequence queued. Caller must
+// hold a.mu. Does NOT emit OnChange — promotion drives the trusted-set
+// update.
+func (a *Aggregator) applyPendingLocked(s *PublisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, version uint32, rawManifest, rawBlob, rawSignature []byte) Disposition {
+	known := false
+	if s.MaxSequenceSet {
+		if _, hit := s.Remaining[blob.Sequence]; hit {
+			known = true
+		} else if blob.Sequence <= s.MaxSequence {
+			// New sequence below max — pending only if it lands ahead
+			// of the current max-stored validFrom (out-of-order).
+			if maxEntry, ok := s.Remaining[s.MaxSequence]; !ok || !validFrom.Before(maxEntry.Effective) {
+				known = true
+			}
+		}
+	}
+	if known {
+		return KnownSequence
+	}
+
+	keys := make([][33]byte, 0, len(blob.Validators))
+	for i, v := range blob.Validators {
+		raw, err := hex.DecodeString(v.ValidationPublicKey)
+		if err != nil || !validatorKeyValid(raw) {
+			a.logger.Debug("validator list: skipping invalid validator entry in pending blob",
+				"index", i,
+				"pubkey", v.ValidationPublicKey)
+			continue
+		}
+		var k [33]byte
+		copy(k[:], raw)
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return string(keys[i][:]) < string(keys[j][:])
+	})
+
+	if s.Remaining == nil {
+		s.Remaining = make(map[uint32]*PendingList, 2)
+	}
+	s.Remaining[blob.Sequence] = &PendingList{
+		Sequence:     blob.Sequence,
+		Effective:    validFrom,
+		EffectiveSet: blob.EffectiveSet,
+		Expiration:   validUntil,
+		Validators:   keys,
+		SiteURI:      siteURI,
+		Version:      version,
+		SigningKey:   signingKey,
+		RawManifest:  append([]byte(nil), rawManifest...),
+		RawBlob:      append([]byte(nil), rawBlob...),
+		RawSignature: append([]byte(nil), rawSignature...),
+	}
+	if !s.MaxSequenceSet || blob.Sequence > s.MaxSequence {
+		s.MaxSequence = blob.Sequence
+		s.MaxSequenceSet = true
+	}
+	return Pending
+}
+
+// promoteRemainingLocked rotates ready Remaining entries (those whose
+// validFrom <= now) into the publisher's current slot, mirroring
+// rippled's updateTrusted loop at ValidatorList.cpp:1929-1991.
+// Operates on a single publisher; caller drives publisher iteration if
+// promoting for the whole set.
+//
+// Walks Remaining in ascending sequence order so a chain of stacked
+// rotations resolves to the LAST ready entry (rippled's iter/next
+// scan). Earlier entries are skipped and discarded — rippled
+// likewise erases [firstIter, std::next(iter)] after the rotation.
+//
+// Caller must hold a.mu. Does not emit OnChange — caller decides when
+// to recompute (typically immediately after the call when invoked at
+// ingest, or via Tick → recomputeAndEmitLocked on the time-driven
+// path).
+func (a *Aggregator) promoteRemainingLocked(s *PublisherState, now time.Time) (promoted bool) {
+	if len(s.Remaining) == 0 {
+		return false
+	}
+	seqs := make([]uint32, 0, len(s.Remaining))
+	for seq := range s.Remaining {
+		seqs = append(seqs, seq)
+	}
+	sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
+
+	// Find the LAST entry that is ready to promote.
+	pickIdx := -1
+	for i, seq := range seqs {
+		p := s.Remaining[seq]
+		if !p.Effective.After(now) {
+			pickIdx = i
+			continue
+		}
+		break
+	}
+	if pickIdx < 0 {
+		return false
+	}
+
+	chosen := s.Remaining[seqs[pickIdx]]
+	s.Sequence = chosen.Sequence
+	s.Effective = chosen.Effective
+	s.EffectiveSet = chosen.EffectiveSet
+	s.Expiration = chosen.Expiration
+	s.SigningKey = chosen.SigningKey
+	s.SiteURI = chosen.SiteURI
+	if chosen.Version > s.Version {
+		s.Version = chosen.Version
+	}
+	s.RawManifest = append(s.RawManifest[:0], chosen.RawManifest...)
+	s.RawBlob = append(s.RawBlob[:0], chosen.RawBlob...)
+	s.RawSignature = append(s.RawSignature[:0], chosen.RawSignature...)
+	s.Validators = append([][33]byte(nil), chosen.Validators...)
+	s.Status = StatusAvailable
+	// Mirrors rippled ValidatorList.cpp:1970 — if the promoted list is
+	// itself already expired, clear the validators so the next
+	// expiration sweep can downgrade the publisher cleanly.
+	if !s.Expiration.IsZero() && !s.Expiration.After(now) {
+		s.Status = StatusExpired
+		s.Validators = nil
+	}
+
+	// Erase all entries up to and including the chosen one — rippled
+	// remaining.erase(firstIter, std::next(iter)).
+	for i := 0; i <= pickIdx; i++ {
+		delete(s.Remaining, seqs[i])
+	}
+	if len(s.Remaining) == 0 {
+		s.Remaining = nil
+	}
+	return true
+}
+
+// Tick performs a time-driven promotion sweep across every publisher
+// and emits OnChange if the resulting trusted union changed. Callers
+// should invoke this periodically (rippled drives it from updateTrusted
+// at every ledger close, ValidatorList.cpp:1910-1928); without an
+// external tick a pending rotation announced during a quiet period
+// would only promote on the next ApplyList / TrustedValidators call.
+//
+// Safe to call from any goroutine. Briefly takes the aggregator lock.
+func (a *Aggregator) Tick() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	now := a.clock()
+	for _, s := range a.state {
+		a.promoteRemainingLocked(s, now)
+	}
+	a.recomputeAndEmitLocked()
+}
+
 // handleRevocation removes a publisher's contribution when its master
 // key is revoked by a fresh manifest. Mirrors rippled's
 // removePublisherList(StatusRevoked) branch in verify(). Also clears
@@ -774,6 +1023,9 @@ func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
 	s.RawManifest = nil
 	s.RawBlob = nil
 	s.RawSignature = nil
+	s.Remaining = nil
+	s.MaxSequence = 0
+	s.MaxSequenceSet = false
 	a.recomputeAndEmitLocked()
 }
 
@@ -792,6 +1044,14 @@ func (a *Aggregator) recomputeAndEmitLocked() {
 	}
 
 	now := a.clock()
+	// Promote any Remaining entries whose validFrom has passed before
+	// counting — without this a rotation queued at applyPendingLocked
+	// would only feed the trusted set on the next ApplyList /
+	// TrustedValidators call, even if the caller (Tick or ingest path)
+	// invoked us specifically to refresh.
+	for _, s := range a.state {
+		a.promoteRemainingLocked(s, now)
+	}
 	counts := make(map[[33]byte]int, 64)
 	for _, s := range a.state {
 		if s.Status != StatusAvailable {
@@ -858,6 +1118,13 @@ func (a *Aggregator) TrustedValidators() ([]consensus.NodeID, [][33]byte) {
 	}
 
 	now := a.clock()
+	// Lazy-promote ready Remaining entries so the trusted set reflects
+	// rotations that became effective since the last ingest. Tick()
+	// handles the OnChange emission on the time-driven path; here we
+	// just need a fresh snapshot.
+	for _, s := range a.state {
+		a.promoteRemainingLocked(s, now)
+	}
 	counts := make(map[[33]byte]int, 64)
 	for _, s := range a.state {
 		if s.Status != StatusAvailable {

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -1,0 +1,746 @@
+package list
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/manifest"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+)
+
+// PublisherKey is the 33-byte master public key of a list publisher
+// (including the key-type prefix byte: 0xED for ed25519, 0x02/0x03 for
+// secp256k1). Used as the map key for per-publisher state.
+type PublisherKey [33]byte
+
+// PublisherStatus mirrors rippled's PublisherStatus enum
+// (rippled/src/xrpld/app/misc/ValidatorList.h:103-114).
+type PublisherStatus uint8
+
+const (
+	// StatusUnavailable: configured but no valid list has been ingested
+	// yet. The publisher's validators do not contribute to the trusted
+	// set.
+	StatusUnavailable PublisherStatus = iota
+
+	// StatusAvailable: at least one fresh, signature-verified, non-
+	// expired list has been ingested. The publisher's validators
+	// contribute to the trusted set on every recompute.
+	StatusAvailable
+
+	// StatusExpired: the most recent list passed verification but its
+	// expiration is in the past. The publisher no longer contributes
+	// new validators, but RPC surfaces the staleness.
+	StatusExpired
+
+	// StatusRevoked: the publisher's master key has been revoked by a
+	// signed manifest. The entry is retained for RPC visibility but
+	// contributes nothing.
+	StatusRevoked
+)
+
+// String returns a short lowercase label for logs and RPC output.
+func (s PublisherStatus) String() string {
+	switch s {
+	case StatusUnavailable:
+		return "unavailable"
+	case StatusAvailable:
+		return "available"
+	case StatusExpired:
+		return "expired"
+	case StatusRevoked:
+		return "revoked"
+	default:
+		return "unknown"
+	}
+}
+
+// PublisherState is the per-publisher state the aggregator maintains.
+// Tracks the current accepted list plus a queue of future-dated
+// "remaining" lists (rippled's PublisherList.remaining at
+// ValidatorList.h:75-83) so a publisher rotation announced ahead of
+// time can be applied at the right moment.
+//
+// Exposed via Snapshot() for RPC and observability — callers receive a
+// deep copy and may NOT mutate the aggregator's internal state.
+type PublisherState struct {
+	MasterKey  PublisherKey
+	SigningKey [33]byte
+	Status     PublisherStatus
+
+	// Sequence is the strictly-monotonic version of the currently
+	// effective list. Zero before the first accepted list.
+	Sequence uint32
+
+	// Effective is the Unix timestamp at which the current list became
+	// effective. Zero when the publisher hasn't specified one (rippled
+	// treats absent `effective` as "immediately").
+	Effective time.Time
+
+	// Expiration is the Unix timestamp after which the current list is
+	// considered expired and contributes nothing further.
+	Expiration time.Time
+
+	// Validators is the 33-byte master pubkey set published by this
+	// publisher in the current accepted list, sorted lexicographically
+	// for deterministic union computation.
+	Validators [][33]byte
+
+	// SiteURI is where this list came from — a publisher URL, or "peer"
+	// when ingested from TMValidatorList gossip.
+	SiteURI string
+
+	// LastUpdate is when we accepted this publisher's most recent list.
+	LastUpdate time.Time
+}
+
+// SiteState is the per-URL polling state surfaced via the
+// validator_list_sites RPC.
+type SiteState struct {
+	URI            string
+	LastFetched    time.Time
+	LastSuccess    time.Time
+	LastError      string
+	LastDisposition Disposition
+	RefreshSeconds int
+}
+
+// Aggregator is the central publisher-trust subsystem. It owns the
+// configured publisher trust set and threshold, tracks per-publisher
+// state, exposes a writable surface (ApplyList / ApplyCollection) the
+// router and HTTP poller call into, and emits a recomputed trusted
+// validator set via OnChange every time the set changes.
+//
+// Safe for concurrent use; the single mutex covers all maps. Signature
+// verification happens outside the lock so concurrent applies don't
+// serialize on the (potentially expensive) ed25519/secp256k1 verify.
+type Aggregator struct {
+	mu sync.Mutex
+
+	// publishers is the configured trust set: every key here is a
+	// publisher whose lists we will accept. Populated once at startup
+	// from the [validators] config stanza's validator_list_keys field
+	// and never mutated thereafter — adding/removing publishers
+	// requires a SIGHUP reload.
+	publishers map[PublisherKey]struct{}
+
+	// state holds per-publisher state for every publisher whose key is
+	// in `publishers`. Pre-populated with empty StatusUnavailable
+	// entries so the RPC surface is non-empty from the moment of
+	// startup.
+	state map[PublisherKey]*PublisherState
+
+	// sites holds per-URL polling state for every URL in
+	// validator_list_sites. Updated by the HTTP poller; read by RPC.
+	sites []*SiteState
+
+	// manifests is the validator manifest cache. Used to:
+	//   1. Apply incoming publisher manifests (verify + cache the
+	//      ephemeral signing key for blob verification).
+	//   2. Resolve ephemeral validator signing keys back to master keys
+	//      when emitting the trusted set for consensus.
+	//
+	// Shared with the consensus engine and the TMManifests gossip path
+	// so the same manifest seen via a VL applies everywhere.
+	manifests *manifest.Cache
+
+	// threshold is the minimum number of publishers from `publishers`
+	// that must list a validator before that validator is admitted to
+	// the effective trusted UNL. Mirrors rippled's listThreshold_
+	// (ValidatorList.h:140-141 / ValidatorList.cpp:289).
+	threshold int
+
+	// onChange is invoked whenever the recomputed trusted set differs
+	// from the previously emitted one. Wired by Components.NewFromConfig
+	// to push into Adaptor.SetTrustedValidators. The callback runs
+	// under the aggregator mutex so implementations MUST NOT call back
+	// into the aggregator from the callback (would deadlock).
+	onChange func(validators []consensus.NodeID, masterKeys [][33]byte)
+
+	// lastEmitted is the most recently published trusted set (master
+	// keys, sorted). Cached so we suppress no-op OnChange callbacks
+	// when a publisher list update doesn't move any validator into or
+	// out of the union.
+	lastEmitted [][33]byte
+
+	// clock returns the wall-clock time the aggregator uses to gate
+	// effective / expiration comparisons. Overridable for tests.
+	clock func() time.Time
+
+	logger *slog.Logger
+}
+
+// Config carries Aggregator construction parameters. All fields are
+// optional; Defaults handle nil Logger / Clock / Manifests so the type
+// is usable in narrowly-scoped tests.
+type Config struct {
+	PublisherKeys []PublisherKey
+	SiteURIs      []string
+	Threshold     int
+	Manifests     *manifest.Cache
+	Clock         func() time.Time
+	Logger        *slog.Logger
+}
+
+// New constructs an Aggregator from the operator-supplied config.
+// Returns an error if a publisher key has an unrecognized key-type
+// prefix — this is a configuration bug that should fail boot rather
+// than silently disable the publisher.
+func New(cfg Config) (*Aggregator, error) {
+	publishers := make(map[PublisherKey]struct{}, len(cfg.PublisherKeys))
+	state := make(map[PublisherKey]*PublisherState, len(cfg.PublisherKeys))
+	for _, k := range cfg.PublisherKeys {
+		var zero PublisherKey
+		if k == zero {
+			return nil, errors.New("publisher key is all zero")
+		}
+		publishers[k] = struct{}{}
+		state[k] = &PublisherState{
+			MasterKey: k,
+			Status:    StatusUnavailable,
+		}
+	}
+	sites := make([]*SiteState, 0, len(cfg.SiteURIs))
+	for _, u := range cfg.SiteURIs {
+		sites = append(sites, &SiteState{URI: u})
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default().With("component", "validator-list-aggregator")
+	}
+	threshold := cfg.Threshold
+	if threshold <= 0 && len(publishers) > 0 {
+		// Mirror rippled's default: ceil(N/2 + 1) for N >= 3, else 1.
+		// Matches config.ValidatorsConfig.GetValidatorListThreshold().
+		if len(publishers) < 3 {
+			threshold = 1
+		} else {
+			threshold = (len(publishers) / 2) + 1
+		}
+	}
+	if threshold > len(publishers) {
+		return nil, fmt.Errorf("threshold %d exceeds publisher count %d", threshold, len(publishers))
+	}
+	return &Aggregator{
+		publishers: publishers,
+		state:      state,
+		sites:      sites,
+		manifests:  cfg.Manifests,
+		threshold:  threshold,
+		clock:      clock,
+		logger:     logger,
+	}, nil
+}
+
+// OnChange registers (or replaces) the callback fired when the
+// recomputed trusted UNL differs from the previously emitted one.
+// Passing nil clears the callback. Safe to call before or after Start.
+func (a *Aggregator) OnChange(cb func(validators []consensus.NodeID, masterKeys [][33]byte)) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.onChange = cb
+}
+
+// PublisherCount returns the number of configured publishers in the
+// trust set — a constant for the lifetime of the aggregator.
+func (a *Aggregator) PublisherCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.publishers)
+}
+
+// Threshold returns the configured publisher threshold.
+func (a *Aggregator) Threshold() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.threshold
+}
+
+// HasConfiguredPublishers reports whether any publishers were
+// configured at startup. False means the publisher-trust subsystem is
+// inert — the trusted UNL comes entirely from the static [validators]
+// stanza or SIGHUP reload.
+func (a *Aggregator) HasConfiguredPublishers() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.publishers) > 0
+}
+
+// PublisherSnapshot returns a deep copy of the per-publisher state for
+// RPC and observability. Order is sorted by publisher master key for
+// stable output. Safe to call concurrently with ingest.
+func (a *Aggregator) PublisherSnapshot() []PublisherState {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]PublisherState, 0, len(a.state))
+	for _, s := range a.state {
+		cp := *s
+		if len(s.Validators) > 0 {
+			cp.Validators = make([][33]byte, len(s.Validators))
+			copy(cp.Validators, s.Validators)
+		}
+		out = append(out, cp)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return string(out[i].MasterKey[:]) < string(out[j].MasterKey[:])
+	})
+	return out
+}
+
+// SiteSnapshot returns a deep copy of the per-URL polling state for the
+// validator_list_sites RPC.
+func (a *Aggregator) SiteSnapshot() []SiteState {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]SiteState, len(a.sites))
+	for i, s := range a.sites {
+		out[i] = *s
+	}
+	return out
+}
+
+// UpdateSiteState records the outcome of an HTTP poll attempt against a
+// configured publisher URL. The poller goroutine calls this after each
+// fetch attempt; the data flows through to the validator_list_sites
+// RPC.
+//
+// Idempotent for unknown URIs — the call is silently dropped rather
+// than erroring, so a poller cannot panic the server by being out of
+// sync with the configured site set.
+func (a *Aggregator) UpdateSiteState(uri string, lastFetched, lastSuccess time.Time, lastErr string, lastDisp Disposition, refreshSec int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, s := range a.sites {
+		if s.URI != uri {
+			continue
+		}
+		s.LastFetched = lastFetched
+		if !lastSuccess.IsZero() {
+			s.LastSuccess = lastSuccess
+		}
+		s.LastError = lastErr
+		s.LastDisposition = lastDisp
+		if refreshSec > 0 {
+			s.RefreshSeconds = refreshSec
+		}
+		return
+	}
+}
+
+// ApplyList ingests a single (manifest, blob, signature) triple and
+// returns the resulting disposition along with the publisher master
+// key (when extractable). Wraps the rippled-faithful applyList
+// algorithm: verify the publisher manifest, look up its current
+// ephemeral signing key, verify the blob signature, JSON-parse the
+// blob, then update per-publisher state and trigger an OnChange if the
+// trusted union changed.
+//
+// `manifestBytes` and `blob` carry the WIRE-FORM ascii strings as
+// received in TMValidatorList / TMValidatorListCollection (base64-
+// encoded). `signature` carries the WIRE-FORM hex string. `version`
+// is the protocol version negotiated at the message level.
+//
+// `siteURI` is recorded on the per-publisher state for RPC visibility
+// — pass "peer:<id>" for gossip-sourced lists and the URL for
+// HTTP-polled ones.
+//
+// Returns the publisher master key on every disposition where it's
+// extractable (i.e. the manifest decoded), so the caller can attribute
+// metrics / bad-data charges with publisher-level granularity even on
+// failure paths. Returns the zero PublisherKey when the manifest
+// itself could not be parsed.
+func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version uint32, siteURI string) (Disposition, PublisherKey) {
+	if !isSupportedVersion(version) {
+		return UnsupportedVersion, PublisherKey{}
+	}
+
+	// Decode the publisher manifest. The manifest is base64-encoded on
+	// the wire; the inner STObject is what manifest.Deserialize wants.
+	manifestRaw, err := decodeBase64Tolerant(manifestBytes)
+	if err != nil {
+		a.logger.Debug("validator list: manifest base64 decode failed", "error", err, "site", siteURI)
+		return Malformed, PublisherKey{}
+	}
+	parsed, err := manifest.Deserialize(manifestRaw)
+	if err != nil {
+		a.logger.Debug("validator list: manifest deserialize failed", "error", err, "site", siteURI)
+		return Malformed, PublisherKey{}
+	}
+	pubKey := PublisherKey(parsed.MasterKey)
+
+	// Reject lists from publishers we don't trust. Per rippled this is
+	// a silent drop — gossip carries lists from many publishers and we
+	// shouldn't penalize peers for forwarding lists we choose not to
+	// trust ourselves.
+	a.mu.Lock()
+	_, trusted := a.publishers[pubKey]
+	a.mu.Unlock()
+	if !trusted {
+		return Untrusted, pubKey
+	}
+
+	// Apply the publisher manifest to the manifest cache. This both
+	// caches the manifest for later use and gives us the current
+	// ephemeral signing key. A revoked manifest invalidates the
+	// publisher entirely.
+	if a.manifests != nil {
+		switch d := a.manifests.ApplyManifest(parsed); d {
+		case manifest.Accepted, manifest.Stale:
+			// Accepted: fresh manifest installed. Stale: we already
+			// had this or a newer one — either way the cache now has
+			// a current ephemeral key for the publisher.
+		case manifest.Invalid:
+			return Invalid, pubKey
+		case manifest.BadMasterKey, manifest.BadEphemeralKey:
+			return Invalid, pubKey
+		}
+	} else {
+		// Fall back to direct verification when no cache is wired
+		// (tests). The signing key in the manifest is what we'd have
+		// pulled from the cache.
+		if err := parsed.Verify(); err != nil {
+			return Invalid, pubKey
+		}
+	}
+
+	if parsed.Revoked() {
+		a.handleRevocation(pubKey)
+		return Invalid, pubKey
+	}
+
+	// Pull the current ephemeral signing key. With a cache: this is
+	// the freshest signing key we've ever seen for the publisher,
+	// which might be NEWER than the one in this very manifest if a
+	// later manifest arrived first via gossip. That's intentional —
+	// rippled also uses publisherManifests_.getSigningKey here, which
+	// is the latest cached key, not the one in `manifestBytes`.
+	signingKey := parsed.SigningKey
+	if a.manifests != nil {
+		if k, ok := a.manifests.GetSigningKey(parsed.MasterKey); ok {
+			signingKey = k
+		} else {
+			// Cache says the master is unknown or revoked. If revoked
+			// we already handled above; if unknown despite the apply,
+			// treat as invalid.
+			return Invalid, pubKey
+		}
+	}
+
+	if err := verifyBlobSignature(signingKey, blob, signature); err != nil {
+		a.logger.Debug("validator list: blob signature invalid", "error", err, "publisher", hex.EncodeToString(pubKey[:]))
+		return Invalid, pubKey
+	}
+
+	parsedBlob, disp, err := parseBlob(blob)
+	if err != nil {
+		a.logger.Debug("validator list: blob parse failed", "error", err, "publisher", hex.EncodeToString(pubKey[:]))
+		return disp, pubKey
+	}
+
+	now := a.clock()
+	validFrom := time.Unix(rippleSecondsToUnix(parsedBlob.Effective), 0).UTC()
+	validUntil := time.Unix(rippleSecondsToUnix(parsedBlob.Expiration), 0).UTC()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	current, ok := a.state[pubKey]
+	if !ok {
+		// Defensive — every publisher in `publishers` had an entry
+		// preallocated in New().
+		current = &PublisherState{MasterKey: pubKey, Status: StatusUnavailable}
+		a.state[pubKey] = current
+	}
+
+	// Determine disposition by sequence + time ordering. Mirrors the
+	// rippled state machine at ValidatorList.cpp:1394-1437.
+	if parsedBlob.Sequence < current.Sequence {
+		return Stale, pubKey
+	}
+	if parsedBlob.Sequence == current.Sequence && current.Status != StatusUnavailable {
+		return SameSequence, pubKey
+	}
+	if validUntil.Before(now) || validUntil.Equal(now) {
+		// Even an expired list still updates the publisher entry so
+		// the RPC can surface "expired" — but the validators do NOT
+		// flow into the trusted union (status is StatusExpired).
+		applied := a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now)
+		_ = applied // applyAcceptedLocked sets Status; trusted set recompute below skips expired.
+		current.Status = StatusExpired
+		a.recomputeAndEmitLocked()
+		return Expired, pubKey
+	}
+	if validFrom.After(now) {
+		// Future-dated. Rippled stores this in `remaining` so it can
+		// be promoted later. goXRPL's first-cut subsystem keeps a
+		// simpler model: drop pending lists (the publisher will
+		// republish at effective time, and the 5-min poller cadence
+		// limits the lag). Tracked for future work but not blocking
+		// for the issue.
+		return Pending, pubKey
+	}
+
+	a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now)
+	a.recomputeAndEmitLocked()
+	return Accepted, pubKey
+}
+
+// applyAcceptedLocked materializes the parsed blob into the
+// publisher's state. Caller must hold a.mu. Does NOT emit OnChange —
+// that's done by recomputeAndEmitLocked once the caller has decided
+// the disposition warrants a trusted-set recompute.
+func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, now time.Time) bool {
+	prevCount := len(s.Validators)
+	s.Sequence = blob.Sequence
+	s.Effective = validFrom
+	s.Expiration = validUntil
+	s.SigningKey = signingKey
+	s.SiteURI = siteURI
+	s.LastUpdate = now
+	s.Status = StatusAvailable
+
+	keys := make([][33]byte, 0, len(blob.Validators))
+	for _, v := range blob.Validators {
+		raw, err := hex.DecodeString(v.ValidationPublicKey)
+		if err != nil || len(raw) != 33 {
+			continue
+		}
+		var k [33]byte
+		copy(k[:], raw)
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return string(keys[i][:]) < string(keys[j][:])
+	})
+	s.Validators = keys
+
+	// Also seed any embedded validator manifests into the manifest
+	// cache so consensus can resolve ephemeral signing keys
+	// immediately, without waiting for the validator to gossip its
+	// own manifest. Mirrors rippled ValidatorList.cpp:1242-1273.
+	if a.manifests != nil {
+		for _, v := range blob.Validators {
+			if v.Manifest == "" {
+				continue
+			}
+			raw, err := decodeBase64Tolerant([]byte(v.Manifest))
+			if err != nil {
+				continue
+			}
+			parsed, err := manifest.Deserialize(raw)
+			if err != nil {
+				continue
+			}
+			_ = a.manifests.ApplyManifest(parsed)
+		}
+	}
+
+	return prevCount != len(keys)
+}
+
+// handleRevocation removes a publisher's contribution when its master
+// key is revoked by a fresh manifest. Mirrors rippled's
+// removePublisherList(StatusRevoked) branch in verify().
+func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	s, ok := a.state[pubKey]
+	if !ok {
+		return
+	}
+	s.Status = StatusRevoked
+	s.Validators = nil
+	a.recomputeAndEmitLocked()
+}
+
+// recomputeAndEmitLocked walks the per-publisher state, computes the
+// union of validators present in at least `threshold` publishers' lists,
+// and — if the result differs from the last emitted set — invokes the
+// OnChange callback with sorted NodeID and master-key slices ready for
+// Adaptor.SetTrustedValidators.
+//
+// Caller MUST hold a.mu. The OnChange callback runs under the lock; the
+// adaptor.SetTrustedValidators path takes a different mutex so the
+// nesting is safe.
+func (a *Aggregator) recomputeAndEmitLocked() {
+	if a.threshold <= 0 || len(a.publishers) == 0 {
+		return
+	}
+
+	now := a.clock()
+	counts := make(map[[33]byte]int, 64)
+	for _, s := range a.state {
+		if s.Status != StatusAvailable {
+			continue
+		}
+		if !s.Expiration.IsZero() && !s.Expiration.After(now) {
+			continue
+		}
+		if !s.Effective.IsZero() && s.Effective.After(now) {
+			continue
+		}
+		// Use a set per publisher so duplicate entries in one
+		// publisher's list don't double-count toward the threshold.
+		seen := make(map[[33]byte]struct{}, len(s.Validators))
+		for _, k := range s.Validators {
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			counts[k]++
+		}
+	}
+
+	trusted := make([][33]byte, 0, len(counts))
+	for k, c := range counts {
+		if c >= a.threshold {
+			trusted = append(trusted, k)
+		}
+	}
+	sort.Slice(trusted, func(i, j int) bool {
+		return string(trusted[i][:]) < string(trusted[j][:])
+	})
+
+	if mastersEqual(trusted, a.lastEmitted) {
+		return
+	}
+	a.lastEmitted = trusted
+
+	if a.onChange == nil {
+		return
+	}
+
+	nodeIDs := make([]consensus.NodeID, len(trusted))
+	for i, k := range trusted {
+		nodeIDs[i] = consensus.CalcNodeID(k)
+	}
+	a.logger.Info("validator-list publisher trust recomputed",
+		"trusted_count", len(trusted),
+		"publisher_count", len(a.publishers),
+		"threshold", a.threshold)
+	a.onChange(nodeIDs, trusted)
+}
+
+// TrustedValidators returns the current effective trusted set as
+// NodeIDs + master keys, both sorted by master key for determinism.
+// Recomputes on every call from the current per-publisher state.
+// Mirrors rippled's ValidatorList::getQuorumKeys() shape.
+func (a *Aggregator) TrustedValidators() ([]consensus.NodeID, [][33]byte) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.threshold <= 0 || len(a.publishers) == 0 {
+		return nil, nil
+	}
+
+	now := a.clock()
+	counts := make(map[[33]byte]int, 64)
+	for _, s := range a.state {
+		if s.Status != StatusAvailable {
+			continue
+		}
+		if !s.Expiration.IsZero() && !s.Expiration.After(now) {
+			continue
+		}
+		if !s.Effective.IsZero() && s.Effective.After(now) {
+			continue
+		}
+		seen := make(map[[33]byte]struct{}, len(s.Validators))
+		for _, k := range s.Validators {
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			counts[k]++
+		}
+	}
+
+	masters := make([][33]byte, 0, len(counts))
+	for k, c := range counts {
+		if c >= a.threshold {
+			masters = append(masters, k)
+		}
+	}
+	sort.Slice(masters, func(i, j int) bool {
+		return string(masters[i][:]) < string(masters[j][:])
+	})
+	nodeIDs := make([]consensus.NodeID, len(masters))
+	for i, k := range masters {
+		nodeIDs[i] = consensus.CalcNodeID(k)
+	}
+	return nodeIDs, masters
+}
+
+// ApplyCollection processes a v2 collection (TMValidatorListCollection),
+// applying each blob individually with the collection's shared
+// publisher manifest. Returns the per-blob dispositions in the same
+// order as the collection's blob array, plus the publisher key once
+// the manifest decoded. The router uses the dispositions to decide
+// whether to charge the sender (any Invalid / Malformed) and whether
+// to relay (at least one Accepted).
+//
+// Mirrors rippled's applyLists at ValidatorList.cpp:998-1070.
+func (a *Aggregator) ApplyCollection(coll *message.ValidatorListCollection, siteURI string) ([]Disposition, PublisherKey) {
+	if coll == nil {
+		return []Disposition{Malformed}, PublisherKey{}
+	}
+	if !isSupportedVersion(coll.Version) {
+		return []Disposition{UnsupportedVersion}, PublisherKey{}
+	}
+	if len(coll.Blobs) == 0 {
+		return []Disposition{Malformed}, PublisherKey{}
+	}
+	out := make([]Disposition, len(coll.Blobs))
+	var pubKey PublisherKey
+	for i, blob := range coll.Blobs {
+		// Per blob: prefer the embedded local manifest when present,
+		// else fall back to the collection's shared manifest. Matches
+		// rippled applyList(globalManifest, localManifest, ...) at
+		// ValidatorList.cpp:1140-1151.
+		mf := blob.Manifest
+		if len(mf) == 0 {
+			mf = coll.Manifest
+		}
+		disp, pk := a.ApplyList(mf, blob.Blob, blob.Signature, coll.Version, siteURI)
+		out[i] = disp
+		if pk != (PublisherKey{}) {
+			pubKey = pk
+		}
+	}
+	return out, pubKey
+}
+
+// isSupportedVersion reports whether version is in SupportedVersions.
+func isSupportedVersion(v uint32) bool {
+	for _, sv := range SupportedVersions {
+		if sv == v {
+			return true
+		}
+	}
+	return false
+}
+
+// mastersEqual reports whether two sorted master-key slices contain
+// the same elements in the same order. Used to short-circuit no-op
+// OnChange emissions.
+func mastersEqual(a, b [][33]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -19,8 +19,12 @@ import (
 // secp256k1). Used as the map key for per-publisher state.
 type PublisherKey [33]byte
 
-// PublisherStatus mirrors rippled's PublisherStatus enum
-// (rippled/src/xrpld/app/misc/ValidatorList.h:103-114).
+// PublisherStatus tracks per-publisher availability. The label set
+// (unavailable / available / expired / revoked) matches rippled's
+// PublisherStatus enum at rippled/src/xrpld/app/misc/ValidatorList.h:87-100,
+// but the underlying iota values are not aligned with rippled — goXRPL
+// never compares PublisherStatus by ordinal so the numeric mapping is
+// not load-bearing.
 type PublisherStatus uint8
 
 const (
@@ -98,17 +102,26 @@ type PublisherState struct {
 
 	// LastUpdate is when we accepted this publisher's most recent list.
 	LastUpdate time.Time
+
+	// Version is the protocol version of the most recently applied
+	// list. Mirrors rippled's PublisherListCollection.rawVersion at
+	// ValidatorList.h:74. Zero before the first accepted list.
+	Version uint32
 }
 
 // SiteState is the per-URL polling state surfaced via the
 // validator_list_sites RPC.
 type SiteState struct {
-	URI            string
-	LastFetched    time.Time
-	LastSuccess    time.Time
-	LastError      string
+	URI             string
+	LastFetched     time.Time
+	LastSuccess     time.Time
+	LastError       string
 	LastDisposition Disposition
-	RefreshSeconds int
+	RefreshSeconds  int
+	// NextRefresh is the wall-clock time at which the next poll attempt
+	// is scheduled. Mirrors rippled's ValidatorSite::Site::nextRefresh
+	// surfaced via `next_refresh_time` in the validator_list_sites RPC.
+	NextRefresh time.Time
 }
 
 // Aggregator is the central publisher-trust subsystem. It owns the
@@ -317,7 +330,7 @@ func (a *Aggregator) SiteSnapshot() []SiteState {
 // Idempotent for unknown URIs — the call is silently dropped rather
 // than erroring, so a poller cannot panic the server by being out of
 // sync with the configured site set.
-func (a *Aggregator) UpdateSiteState(uri string, lastFetched, lastSuccess time.Time, lastErr string, lastDisp Disposition, refreshSec int) {
+func (a *Aggregator) UpdateSiteState(uri string, lastFetched, lastSuccess time.Time, lastErr string, lastDisp Disposition, refreshSec int, nextRefresh time.Time) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	for _, s := range a.sites {
@@ -332,6 +345,9 @@ func (a *Aggregator) UpdateSiteState(uri string, lastFetched, lastSuccess time.T
 		s.LastDisposition = lastDisp
 		if refreshSec > 0 {
 			s.RefreshSeconds = refreshSec
+		}
+		if !nextRefresh.IsZero() {
+			s.NextRefresh = nextRefresh
 		}
 		return
 	}
@@ -414,16 +430,21 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	}
 
 	if parsed.Revoked() {
+		// Rippled returns ListDisposition::untrusted on revocation
+		// (ValidatorList.cpp:1382-1383). Revocations are legitimate
+		// gossip; punishing the forwarding peer would cascade across
+		// every honest hop in the mesh. The side-effect (clearing
+		// publisher contribution + status flip) still runs.
 		a.handleRevocation(pubKey)
-		return Invalid, pubKey
+		return Untrusted, pubKey
 	}
 
 	// Pull the current ephemeral signing key. With a cache: this is
 	// the freshest signing key we've ever seen for the publisher,
 	// which might be NEWER than the one in this very manifest if a
-	// later manifest arrived first via gossip. That's intentional —
-	// rippled also uses publisherManifests_.getSigningKey here, which
-	// is the latest cached key, not the one in `manifestBytes`.
+	// later manifest arrived first via gossip. Rippled also uses
+	// publisherManifests_.getSigningKey here, which is the latest
+	// cached key, not the one in `manifestBytes`.
 	signingKey := parsed.SigningKey
 	if a.manifests != nil {
 		if k, ok := a.manifests.GetSigningKey(parsed.MasterKey); ok {
@@ -431,8 +452,10 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 		} else {
 			// Cache says the master is unknown or revoked. If revoked
 			// we already handled above; if unknown despite the apply,
-			// treat as invalid.
-			return Invalid, pubKey
+			// treat as untrusted (no usable signing key from a trusted
+			// publisher means we cannot verify the blob; rippled's
+			// equivalent at ValidatorList.cpp:1382 is also untrusted).
+			return Untrusted, pubKey
 		}
 	}
 
@@ -474,7 +497,7 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 		// Even an expired list still updates the publisher entry so
 		// the RPC can surface "expired" — but the validators do NOT
 		// flow into the trusted union (status is StatusExpired).
-		applied := a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now)
+		applied := a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version)
 		_ = applied // applyAcceptedLocked sets Status; trusted set recompute below skips expired.
 		current.Status = StatusExpired
 		a.recomputeAndEmitLocked()
@@ -490,7 +513,7 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 		return Pending, pubKey
 	}
 
-	a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now)
+	a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version)
 	a.recomputeAndEmitLocked()
 	return Accepted, pubKey
 }
@@ -499,7 +522,7 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 // publisher's state. Caller must hold a.mu. Does NOT emit OnChange —
 // that's done by recomputeAndEmitLocked once the caller has decided
 // the disposition warrants a trusted-set recompute.
-func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, now time.Time) bool {
+func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, now time.Time, version uint32) bool {
 	prevCount := len(s.Validators)
 	s.Sequence = blob.Sequence
 	s.Effective = validFrom
@@ -508,6 +531,9 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 	s.SiteURI = siteURI
 	s.LastUpdate = now
 	s.Status = StatusAvailable
+	if version > s.Version {
+		s.Version = version
+	}
 
 	keys := make([][33]byte, 0, len(blob.Validators))
 	for _, v := range blob.Validators {

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -126,7 +126,7 @@ func TestAggregator_ApplyList_Accepted_SinglePublisher_SingleValidator(t *testin
 
 	now := fixedClock()()
 	blob, sig := pub.signList(t, 1, 0, now.Add(24*time.Hour).Unix(), [][33]byte{val1})
-	disp, key := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	disp, key, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
 	if disp != list.Accepted {
 		t.Fatalf("disposition: got %s want Accepted", disp)
 	}
@@ -144,7 +144,7 @@ func TestAggregator_ApplyList_Accepted_SinglePublisher_SingleValidator(t *testin
 	changeMu.Unlock()
 
 	// Reapplying the same list is SameSequence and triggers no OnChange.
-	disp, _ = agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	disp, _, _ = agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
 	if disp != list.SameSequence {
 		t.Fatalf("re-apply disposition: got %s want SameSequence", disp)
 	}
@@ -182,7 +182,7 @@ func TestAggregator_ApplyList_Threshold_TwoOfThree(t *testing.T) {
 
 	// Publisher 1 lists {v1, v2}. Threshold not yet met.
 	blob, sig := pub1.signList(t, 1, 0, exp, [][33]byte{v1, v2})
-	if d, _ := agg.ApplyList(pub1.manifestB64, blob, sig, 1, "p1://"); d != list.Accepted {
+	if d, _, _ := agg.ApplyList(pub1.manifestB64, blob, sig, 1, "p1://"); d != list.Accepted {
 		t.Fatalf("pub1 disposition: %s", d)
 	}
 	if _, m := agg.TrustedValidators(); len(m) != 0 {
@@ -191,7 +191,7 @@ func TestAggregator_ApplyList_Threshold_TwoOfThree(t *testing.T) {
 
 	// Publisher 2 lists {v2, v3}. v2 now has 2 publisher votes ≥ threshold.
 	blob, sig = pub2.signList(t, 1, 0, exp, [][33]byte{v2, v3})
-	if d, _ := agg.ApplyList(pub2.manifestB64, blob, sig, 1, "p2://"); d != list.Accepted {
+	if d, _, _ := agg.ApplyList(pub2.manifestB64, blob, sig, 1, "p2://"); d != list.Accepted {
 		t.Fatalf("pub2 disposition: %s", d)
 	}
 	_, masters := agg.TrustedValidators()
@@ -201,7 +201,7 @@ func TestAggregator_ApplyList_Threshold_TwoOfThree(t *testing.T) {
 
 	// Publisher 3 lists {v1, v3}. Now v1, v2, v3 all have 2+ votes.
 	blob, sig = pub3.signList(t, 1, 0, exp, [][33]byte{v1, v3})
-	if d, _ := agg.ApplyList(pub3.manifestB64, blob, sig, 1, "p3://"); d != list.Accepted {
+	if d, _, _ := agg.ApplyList(pub3.manifestB64, blob, sig, 1, "p3://"); d != list.Accepted {
 		t.Fatalf("pub3 disposition: %s", d)
 	}
 	_, masters = agg.TrustedValidators()
@@ -237,12 +237,12 @@ func TestAggregator_ApplyList_Stale(t *testing.T) {
 
 	// Apply sequence 5.
 	blob, sig := pub.signList(t, 5, 0, exp, [][33]byte{v1})
-	if d, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://"); d != list.Accepted {
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://"); d != list.Accepted {
 		t.Fatalf("seq=5 disposition: %s", d)
 	}
 	// Then sequence 3 should be Stale.
 	blob3, sig3 := pub.signList(t, 3, 0, exp, [][33]byte{v1})
-	if d, _ := agg.ApplyList(pub.manifestB64, blob3, sig3, 1, "test://"); d != list.Stale {
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob3, sig3, 1, "test://"); d != list.Stale {
 		t.Fatalf("seq=3 disposition: got %s want Stale", d)
 	}
 }
@@ -264,7 +264,7 @@ func TestAggregator_ApplyList_UntrustedPublisher(t *testing.T) {
 
 	now := fixedClock()()
 	blob, sig := pubOther.signList(t, 1, 0, now.Add(24*time.Hour).Unix(), [][33]byte{v1})
-	d, _ := agg.ApplyList(pubOther.manifestB64, blob, sig, 1, "test://")
+	d, _, _ := agg.ApplyList(pubOther.manifestB64, blob, sig, 1, "test://")
 	if d != list.Untrusted {
 		t.Fatalf("disposition: got %s want Untrusted", d)
 	}
@@ -291,7 +291,7 @@ func TestAggregator_ApplyList_BadSignature(t *testing.T) {
 	blob, sig := pub.signList(t, 1, 0, now.Add(24*time.Hour).Unix(), [][33]byte{v1})
 	// Corrupt the signature.
 	sig[5] ^= 0xff
-	d, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
 	if d != list.Invalid {
 		t.Fatalf("disposition: got %s want Invalid", d)
 	}
@@ -315,7 +315,7 @@ func TestAggregator_ApplyList_Expired(t *testing.T) {
 	// Expiration in the past relative to fixedClock.
 	exp := now.Add(-1 * time.Hour).Unix()
 	blob, sig := pub.signList(t, 1, 0, exp, [][33]byte{v1})
-	d, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
 	if d != list.Expired {
 		t.Fatalf("disposition: got %s want Expired", d)
 	}
@@ -332,7 +332,7 @@ func TestAggregator_ApplyList_UnsupportedVersion(t *testing.T) {
 		Manifests:     manifest.NewCache(),
 		Clock:         fixedClock(),
 	})
-	d, _ := agg.ApplyList(pub.manifestB64, []byte("garbage"), []byte("00"), 99, "test://")
+	d, _, _ := agg.ApplyList(pub.manifestB64, []byte("garbage"), []byte("00"), 99, "test://")
 	if d != list.UnsupportedVersion {
 		t.Fatalf("disposition: got %s want UnsupportedVersion", d)
 	}
@@ -344,7 +344,7 @@ func TestAggregator_ApplyList_MalformedManifest(t *testing.T) {
 		Threshold:     1,
 		Clock:         fixedClock(),
 	})
-	d, _ := agg.ApplyList([]byte("!@not_base64"), []byte("blob"), []byte("00"), 1, "test://")
+	d, _, _ := agg.ApplyList([]byte("!@not_base64"), []byte("blob"), []byte("00"), 1, "test://")
 	if d != list.Malformed {
 		t.Fatalf("disposition: got %s want Malformed", d)
 	}
@@ -372,7 +372,7 @@ func TestAggregator_ApplyCollection_AcceptedAndStale(t *testing.T) {
 			{Blob: blob1, Signature: sig1},
 		},
 	}
-	dispList, key := agg.ApplyCollection(coll, "test://")
+	dispList, key, _ := agg.ApplyCollection(coll, "test://")
 	if key != list.PublisherKey(pub.masterPub) {
 		t.Fatalf("publisher key mismatch")
 	}

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -497,3 +497,115 @@ func sortMasters(m [][33]byte) {
 		return string(m[i][:]) < string(m[j][:])
 	})
 }
+
+// TestAggregator_ApplyList_PendingThenKnownSequence pins the rippled
+// state-machine at ValidatorList.cpp:1414-1432: a future-dated blob
+// stores into Remaining and returns Pending; a repeat at the same
+// sequence returns KnownSequence (no-op). Without the Remaining queue
+// the second arrival would also return Pending and the publisher
+// would never promote.
+func TestAggregator_ApplyList_PendingThenKnownSequence(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	v1 := derivedValidatorKey(0x10)
+
+	now := fixedClock()()
+	mutableNow := now
+	clk := func() time.Time { return mutableNow }
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         clk,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	futureEff := mutableNow.Add(2 * time.Hour).Unix()
+	exp := mutableNow.Add(48 * time.Hour).Unix()
+
+	blob, sig := pub.signList(t, 7, futureEff, exp, [][33]byte{v1})
+	d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	if d != list.Pending {
+		t.Fatalf("first apply: got %s want Pending", d)
+	}
+	// No promotion yet → trusted set empty.
+	if _, m := agg.TrustedValidators(); len(m) != 0 {
+		t.Fatalf("trusted before promotion: want 0, got %d", len(m))
+	}
+
+	// Same sequence again — KnownSequence (re-arrival at a queued seq).
+	d, _, _ = agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	if d != list.KnownSequence {
+		t.Fatalf("re-apply at queued sequence: got %s want KnownSequence", d)
+	}
+
+	// Advance the clock past validFrom and Tick — rotation promotes
+	// and the validator enters the trusted set.
+	mutableNow = now.Add(3 * time.Hour)
+	agg.Tick()
+	_, masters := agg.TrustedValidators()
+	if len(masters) != 1 || masters[0] != v1 {
+		t.Fatalf("post-Tick trusted: want [v1] got %d entries", len(masters))
+	}
+}
+
+// TestAggregator_ApplyList_EffectiveSet_Sentinel pins the rippled
+// gating at ValidatorList.cpp:1682 — `effective` is only emitted in
+// the RPC when the publisher blob actually carried the field. Without
+// EffectiveSet, a missing `effective` flattens through the
+// ripple-epoch offset into a synthetic 2000-Jan-01 timestamp.
+func TestAggregator_ApplyList_EffectiveSet_Sentinel(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	v1 := derivedValidatorKey(0x10)
+
+	agg, _ := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	now := fixedClock()()
+	// signList passes validFromUnix=0 which means we OMIT `effective`.
+	blob, sig := pub.signList(t, 1, 0, now.Add(24*time.Hour).Unix(), [][33]byte{v1})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://"); d != list.Accepted {
+		t.Fatalf("disposition: %s", d)
+	}
+	snap := agg.PublisherSnapshot()
+	if len(snap) != 1 {
+		t.Fatalf("snapshot len: %d", len(snap))
+	}
+	if snap[0].EffectiveSet {
+		t.Fatalf("EffectiveSet must be false when blob omits the field")
+	}
+}
+
+// TestAggregator_ApplyList_Expired_ClearsValidators pins rippled
+// removePublisherList(StatusExpired) at ValidatorList.cpp:1529-1542 —
+// expiry clears the publisher's `list` so the RPC does not surface
+// stale validator keys under `available=false`.
+func TestAggregator_ApplyList_Expired_ClearsValidators(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	v1 := derivedValidatorKey(0x10)
+
+	agg, _ := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	now := fixedClock()()
+	exp := now.Add(-1 * time.Hour).Unix() // expired
+	blob, sig := pub.signList(t, 1, 0, exp, [][33]byte{v1})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://"); d != list.Expired {
+		t.Fatalf("disposition: %s", d)
+	}
+	snap := agg.PublisherSnapshot()
+	if len(snap) != 1 {
+		t.Fatalf("snapshot len: %d", len(snap))
+	}
+	if len(snap[0].Validators) != 0 {
+		t.Fatalf("expired publisher must surface empty validator list; got %d", len(snap[0].Validators))
+	}
+}

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -1,0 +1,463 @@
+package list_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/manifest"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/internal/validator/list"
+	"github.com/LeJamon/goXRPLd/protocol"
+)
+
+// rippleEpochOffset mirrors the constant in blob.go — duplicated here so
+// the test doesn't depend on package-private fields.
+const rippleEpochOffset int64 = 946684800
+
+// fixedClock yields a deterministic "now" so test expectations don't
+// drift across CI runs.
+func fixedClock() func() time.Time {
+	t := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	return func() time.Time { return t }
+}
+
+// publisherFixture is a synthetic publisher used in test scenarios.
+type publisherFixture struct {
+	masterPub  [33]byte
+	masterPriv ed25519.PrivateKey
+	ephPub     [33]byte
+	ephPriv    ed25519.PrivateKey
+	// manifestB64 is the base64-encoded manifest STObject bytes (the
+	// wire form TMValidatorList carries as `manifest`).
+	manifestB64 []byte
+}
+
+func newPublisher(t *testing.T, masterSeed, ephSeed byte) *publisherFixture {
+	t.Helper()
+	masterPub32, masterPriv := deterministicKey(masterSeed)
+	ephPub32, ephPriv := deterministicKey(ephSeed)
+
+	var mp, ep [33]byte
+	copy(mp[:], append([]byte{0xED}, masterPub32...))
+	copy(ep[:], append([]byte{0xED}, ephPub32...))
+
+	manifestRaw := buildManifest(t, mp, masterPriv, ep, ephPriv, 1)
+	b64 := []byte(base64.StdEncoding.EncodeToString(manifestRaw))
+
+	return &publisherFixture{
+		masterPub:   mp,
+		masterPriv:  masterPriv,
+		ephPub:      ep,
+		ephPriv:     ephPriv,
+		manifestB64: b64,
+	}
+}
+
+// signList produces the (blob, signature) pair the aggregator expects:
+// a base64-encoded JSON envelope and a hex-encoded ed25519 signature
+// over the base64-decoded JSON bytes (matching rippled's verify which
+// signs the decoded form).
+func (p *publisherFixture) signList(t *testing.T, sequence uint32, validFromUnix, validUntilUnix int64, validatorMasters [][33]byte) (blobB64, signatureHex []byte) {
+	t.Helper()
+	type entry struct {
+		ValidationPublicKey string `json:"validation_public_key"`
+		Manifest            string `json:"manifest,omitempty"`
+	}
+	type body struct {
+		Sequence   uint32  `json:"sequence"`
+		Expiration uint32  `json:"expiration"`
+		Effective  uint32  `json:"effective,omitempty"`
+		Validators []entry `json:"validators"`
+	}
+	b := body{
+		Sequence:   sequence,
+		Expiration: uint32(validUntilUnix - rippleEpochOffset),
+	}
+	if validFromUnix > 0 {
+		b.Effective = uint32(validFromUnix - rippleEpochOffset)
+	}
+	for _, mk := range validatorMasters {
+		b.Validators = append(b.Validators, entry{
+			ValidationPublicKey: hex.EncodeToString(mk[:]),
+		})
+	}
+	jsonBytes, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("blob JSON marshal: %v", err)
+	}
+	blobB64 = []byte(base64.StdEncoding.EncodeToString(jsonBytes))
+	sig := ed25519.Sign(p.ephPriv, jsonBytes)
+	signatureHex = []byte(hex.EncodeToString(sig))
+	return blobB64, signatureHex
+}
+
+func TestAggregator_ApplyList_Accepted_SinglePublisher_SingleValidator(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	val1 := derivedValidatorKey(0x10)
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var changeMu sync.Mutex
+	var lastMasters [][33]byte
+	var changes int
+	agg.OnChange(func(_ []consensus.NodeID, m [][33]byte) {
+		changeMu.Lock()
+		defer changeMu.Unlock()
+		lastMasters = append([][33]byte(nil), m...)
+		changes++
+	})
+
+	now := fixedClock()()
+	blob, sig := pub.signList(t, 1, 0, now.Add(24*time.Hour).Unix(), [][33]byte{val1})
+	disp, key := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	if disp != list.Accepted {
+		t.Fatalf("disposition: got %s want Accepted", disp)
+	}
+	if key != list.PublisherKey(pub.masterPub) {
+		t.Fatalf("publisher key mismatch")
+	}
+
+	changeMu.Lock()
+	if changes != 1 {
+		t.Fatalf("OnChange invocations: got %d want 1", changes)
+	}
+	if len(lastMasters) != 1 || lastMasters[0] != val1 {
+		t.Fatalf("trusted set: got %x want [%x]", lastMasters, val1)
+	}
+	changeMu.Unlock()
+
+	// Reapplying the same list is SameSequence and triggers no OnChange.
+	disp, _ = agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	if disp != list.SameSequence {
+		t.Fatalf("re-apply disposition: got %s want SameSequence", disp)
+	}
+	changeMu.Lock()
+	if changes != 1 {
+		t.Fatalf("OnChange invoked on resend; got %d want 1", changes)
+	}
+	changeMu.Unlock()
+}
+
+func TestAggregator_ApplyList_Threshold_TwoOfThree(t *testing.T) {
+	pub1 := newPublisher(t, 0x01, 0x02)
+	pub2 := newPublisher(t, 0x03, 0x04)
+	pub3 := newPublisher(t, 0x05, 0x06)
+	v1 := derivedValidatorKey(0x11)
+	v2 := derivedValidatorKey(0x12)
+	v3 := derivedValidatorKey(0x13)
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{
+			list.PublisherKey(pub1.masterPub),
+			list.PublisherKey(pub2.masterPub),
+			list.PublisherKey(pub3.masterPub),
+		},
+		Threshold: 2,
+		Manifests: manifest.NewCache(),
+		Clock:     fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	now := fixedClock()()
+	exp := now.Add(24 * time.Hour).Unix()
+
+	// Publisher 1 lists {v1, v2}. Threshold not yet met.
+	blob, sig := pub1.signList(t, 1, 0, exp, [][33]byte{v1, v2})
+	if d, _ := agg.ApplyList(pub1.manifestB64, blob, sig, 1, "p1://"); d != list.Accepted {
+		t.Fatalf("pub1 disposition: %s", d)
+	}
+	if _, m := agg.TrustedValidators(); len(m) != 0 {
+		t.Fatalf("trusted after one publisher: want 0, got %d", len(m))
+	}
+
+	// Publisher 2 lists {v2, v3}. v2 now has 2 publisher votes ≥ threshold.
+	blob, sig = pub2.signList(t, 1, 0, exp, [][33]byte{v2, v3})
+	if d, _ := agg.ApplyList(pub2.manifestB64, blob, sig, 1, "p2://"); d != list.Accepted {
+		t.Fatalf("pub2 disposition: %s", d)
+	}
+	_, masters := agg.TrustedValidators()
+	if len(masters) != 1 || masters[0] != v2 {
+		t.Fatalf("expected single trusted validator v2, got %d entries", len(masters))
+	}
+
+	// Publisher 3 lists {v1, v3}. Now v1, v2, v3 all have 2+ votes.
+	blob, sig = pub3.signList(t, 1, 0, exp, [][33]byte{v1, v3})
+	if d, _ := agg.ApplyList(pub3.manifestB64, blob, sig, 1, "p3://"); d != list.Accepted {
+		t.Fatalf("pub3 disposition: %s", d)
+	}
+	_, masters = agg.TrustedValidators()
+	if len(masters) != 3 {
+		t.Fatalf("expected 3 trusted validators, got %d", len(masters))
+	}
+	sortMasters(masters)
+	expected := [][33]byte{v1, v2, v3}
+	sortMasters(expected)
+	for i := range expected {
+		if masters[i] != expected[i] {
+			t.Fatalf("trusted[%d] mismatch", i)
+		}
+	}
+}
+
+func TestAggregator_ApplyList_Stale(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	v1 := derivedValidatorKey(0x10)
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	now := fixedClock()()
+	exp := now.Add(24 * time.Hour).Unix()
+
+	// Apply sequence 5.
+	blob, sig := pub.signList(t, 5, 0, exp, [][33]byte{v1})
+	if d, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://"); d != list.Accepted {
+		t.Fatalf("seq=5 disposition: %s", d)
+	}
+	// Then sequence 3 should be Stale.
+	blob3, sig3 := pub.signList(t, 3, 0, exp, [][33]byte{v1})
+	if d, _ := agg.ApplyList(pub.manifestB64, blob3, sig3, 1, "test://"); d != list.Stale {
+		t.Fatalf("seq=3 disposition: got %s want Stale", d)
+	}
+}
+
+func TestAggregator_ApplyList_UntrustedPublisher(t *testing.T) {
+	pubInTrust := newPublisher(t, 0x01, 0x02)
+	pubOther := newPublisher(t, 0x09, 0x0A)
+	v1 := derivedValidatorKey(0x10)
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pubInTrust.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	now := fixedClock()()
+	blob, sig := pubOther.signList(t, 1, 0, now.Add(24*time.Hour).Unix(), [][33]byte{v1})
+	d, _ := agg.ApplyList(pubOther.manifestB64, blob, sig, 1, "test://")
+	if d != list.Untrusted {
+		t.Fatalf("disposition: got %s want Untrusted", d)
+	}
+	if _, m := agg.TrustedValidators(); len(m) != 0 {
+		t.Fatalf("untrusted publisher should not contribute, got %d trusted", len(m))
+	}
+}
+
+func TestAggregator_ApplyList_BadSignature(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	v1 := derivedValidatorKey(0x10)
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	now := fixedClock()()
+	blob, sig := pub.signList(t, 1, 0, now.Add(24*time.Hour).Unix(), [][33]byte{v1})
+	// Corrupt the signature.
+	sig[5] ^= 0xff
+	d, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	if d != list.Invalid {
+		t.Fatalf("disposition: got %s want Invalid", d)
+	}
+}
+
+func TestAggregator_ApplyList_Expired(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	v1 := derivedValidatorKey(0x10)
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	now := fixedClock()()
+	// Expiration in the past relative to fixedClock.
+	exp := now.Add(-1 * time.Hour).Unix()
+	blob, sig := pub.signList(t, 1, 0, exp, [][33]byte{v1})
+	d, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	if d != list.Expired {
+		t.Fatalf("disposition: got %s want Expired", d)
+	}
+	if _, m := agg.TrustedValidators(); len(m) != 0 {
+		t.Fatalf("expired list should not contribute, got %d trusted", len(m))
+	}
+}
+
+func TestAggregator_ApplyList_UnsupportedVersion(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	agg, _ := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	d, _ := agg.ApplyList(pub.manifestB64, []byte("garbage"), []byte("00"), 99, "test://")
+	if d != list.UnsupportedVersion {
+		t.Fatalf("disposition: got %s want UnsupportedVersion", d)
+	}
+}
+
+func TestAggregator_ApplyList_MalformedManifest(t *testing.T) {
+	agg, _ := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey{0xED, 1, 2, 3}},
+		Threshold:     1,
+		Clock:         fixedClock(),
+	})
+	d, _ := agg.ApplyList([]byte("!@not_base64"), []byte("blob"), []byte("00"), 1, "test://")
+	if d != list.Malformed {
+		t.Fatalf("disposition: got %s want Malformed", d)
+	}
+}
+
+func TestAggregator_ApplyCollection_AcceptedAndStale(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	v1 := derivedValidatorKey(0x10)
+
+	agg, _ := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+
+	now := fixedClock()()
+	blob1, sig1 := pub.signList(t, 1, 0, now.Add(24*time.Hour).Unix(), [][33]byte{v1})
+	blob5, sig5 := pub.signList(t, 5, 0, now.Add(48*time.Hour).Unix(), [][33]byte{v1})
+	coll := &message.ValidatorListCollection{
+		Version:  2,
+		Manifest: pub.manifestB64,
+		Blobs: []message.ValidatorBlobInfo{
+			{Blob: blob5, Signature: sig5},
+			{Blob: blob1, Signature: sig1},
+		},
+	}
+	dispList, key := agg.ApplyCollection(coll, "test://")
+	if key != list.PublisherKey(pub.masterPub) {
+		t.Fatalf("publisher key mismatch")
+	}
+	if len(dispList) != 2 {
+		t.Fatalf("disposition count: %d", len(dispList))
+	}
+	// Blob 5 applied first (Accepted), blob 1 then Stale.
+	if dispList[0] != list.Accepted {
+		t.Fatalf("dispList[0]: %s", dispList[0])
+	}
+	if dispList[1] != list.Stale {
+		t.Fatalf("dispList[1]: %s", dispList[1])
+	}
+}
+
+// --- helpers ---
+
+func deterministicKey(seed byte) (pub32 []byte, priv ed25519.PrivateKey) {
+	s := bytes.Repeat([]byte{seed}, ed25519.SeedSize)
+	priv = ed25519.NewKeyFromSeed(s)
+	pub32 = priv.Public().(ed25519.PublicKey)
+	return
+}
+
+func derivedValidatorKey(seed byte) [33]byte {
+	pub32, _ := deterministicKey(seed)
+	var k [33]byte
+	copy(k[:], append([]byte{0xED}, pub32...))
+	return k
+}
+
+// buildManifest constructs a serialized manifest STObject (NOT base64-
+// encoded — the caller is responsible for that wrapping when feeding
+// it into a wire message). Both the master and ephemeral signatures
+// are computed over the manifest's canonical signing preimage.
+func buildManifest(t *testing.T, masterPub [33]byte, masterPriv ed25519.PrivateKey, ephPub [33]byte, ephPriv ed25519.PrivateKey, seq uint32) []byte {
+	t.Helper()
+	obj := map[string]any{
+		"PublicKey":     hex.EncodeToString(masterPub[:]),
+		"Sequence":      seq,
+		"SigningPubKey": hex.EncodeToString(ephPub[:]),
+	}
+	preimage := manifestSigningPreimage(t, obj)
+	ephSig := ed25519.Sign(ephPriv, preimage)
+	obj["Signature"] = hex.EncodeToString(ephSig)
+	masterSig := ed25519.Sign(masterPriv, preimage)
+	obj["MasterSignature"] = hex.EncodeToString(masterSig)
+
+	encoded, err := binarycodec.Encode(obj)
+	if err != nil {
+		t.Fatalf("binarycodec.Encode manifest: %v", err)
+	}
+	raw, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode manifest hex: %v", err)
+	}
+	return raw
+}
+
+func manifestSigningPreimage(t *testing.T, src map[string]any) []byte {
+	t.Helper()
+	filtered := make(map[string]any, len(src))
+	for k, v := range src {
+		if k == "Signature" || k == "MasterSignature" {
+			continue
+		}
+		filtered[k] = v
+	}
+	encoded, err := binarycodec.Encode(filtered)
+	if err != nil {
+		t.Fatalf("encode signing body: %v", err)
+	}
+	body, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode signing body hex: %v", err)
+	}
+	prefix := protocol.HashPrefixManifest
+	out := make([]byte, 0, len(prefix)+len(body))
+	out = append(out, prefix[:]...)
+	out = append(out, body...)
+	return out
+}
+
+func sortMasters(m [][33]byte) {
+	sort.Slice(m, func(i, j int) bool {
+		return string(m[i][:]) < string(m[j][:])
+	})
+}

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -338,15 +338,51 @@ func TestAggregator_ApplyList_UnsupportedVersion(t *testing.T) {
 	}
 }
 
-func TestAggregator_ApplyList_MalformedManifest(t *testing.T) {
+// TestAggregator_ApplyList_BadManifest pins the rippled-faithful mapping
+// for malformed publisher manifests: rippled ValidatorList.cpp:1363-1366
+// folds both `!m` (manifest deserialize failure) and unknown-publisher
+// into ListDisposition::untrusted (charged at feeUselessData), never at
+// the heavier feeInvalidSignature. Without this test a future change
+// could regress to charging honest peers feeInvalidSignature for
+// forwarding lists from broken publishers.
+func TestAggregator_ApplyList_BadManifest(t *testing.T) {
 	agg, _ := list.New(list.Config{
 		PublisherKeys: []list.PublisherKey{list.PublisherKey{0xED, 1, 2, 3}},
 		Threshold:     1,
 		Clock:         fixedClock(),
 	})
 	d, _, _ := agg.ApplyList([]byte("!@not_base64"), []byte("blob"), []byte("00"), 1, "test://")
-	if d != list.Malformed {
-		t.Fatalf("disposition: got %s want Malformed", d)
+	if d != list.Untrusted {
+		t.Fatalf("disposition: got %s want Untrusted", d)
+	}
+}
+
+// TestAggregator_ApplyList_MissingRequiredField pins the rippled-faithful
+// blob-validation requirement that `sequence`, `expiration`, and
+// `validators` are JSON-present (rippled ValidatorList.cpp:1394-1397
+// returns Invalid otherwise). Without this guard, a publisher feed
+// omitting `validators` would be silently accepted with an empty
+// validator set.
+func TestAggregator_ApplyList_MissingRequiredField(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	agg, _ := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	// Blob with only `sequence` and `expiration`, no `validators` array.
+	now := fixedClock()()
+	body := map[string]any{
+		"sequence":   uint32(1),
+		"expiration": uint32(now.Add(24*time.Hour).Unix() - rippleEpochOffset),
+	}
+	jsonBytes, _ := json.Marshal(body)
+	blob := []byte(base64.StdEncoding.EncodeToString(jsonBytes))
+	sig := ed25519.Sign(pub.ephPriv, jsonBytes)
+	d, _, _ := agg.ApplyList(pub.manifestB64, blob, []byte(hex.EncodeToString(sig)), 1, "test://")
+	if d != list.Invalid {
+		t.Fatalf("disposition: got %s want Invalid (missing validators field)", d)
 	}
 }
 

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -424,8 +424,6 @@ func TestAggregator_ApplyCollection_AcceptedAndStale(t *testing.T) {
 	}
 }
 
-// --- helpers ---
-
 func deterministicKey(seed byte) (pub32 []byte, priv ed25519.PrivateKey) {
 	s := bytes.Repeat([]byte{seed}, ed25519.SeedSize)
 	priv = ed25519.NewKeyFromSeed(s)

--- a/internal/validator/list/blob.go
+++ b/internal/validator/list/blob.go
@@ -90,19 +90,9 @@ func parseBlob(rawBlob []byte) (*blobJSON, Disposition, error) {
 }
 
 // verifyBlobSignature checks that `signature` (hex-encoded) is a valid
-// signature by `signingKey` over the raw blob bytes (the base64-encoded
-// payload AS-RECEIVED, NOT its decoded form). Mirrors rippled
-// ValidatorList.cpp:1385-1388:
-//
-//	auto const sig = strUnHex(signature);
-//	auto const data = base64_decode(blob);
-//	if (!ripple::verify(*signingKey, makeSlice(data), makeSlice(*sig)))
-//
-// Wait — rippled actually signs the BASE64-DECODED data, not the raw
-// blob bytes. The decoded JSON text is the signing input. Reading the
-// rippled snippet carefully: `data = base64_decode(blob)` then
-// `verify(signingKey, data, sig)`. So the signature is over the
-// decoded JSON text. We match that here.
+// signature by `signingKey` over the base64-decoded blob (the inner
+// JSON payload). Mirrors rippled ValidatorList.cpp:1385-1388, which
+// signs `base64_decode(blob)` — not the on-wire base64 bytes.
 func verifyBlobSignature(signingKey [33]byte, blob, signatureHex []byte) error {
 	decoded, err := decodeBase64Tolerant(blob)
 	if err != nil {

--- a/internal/validator/list/blob.go
+++ b/internal/validator/list/blob.go
@@ -71,9 +71,10 @@ func parseBlob(rawBlob []byte) (*blobJSON, Disposition, error) {
 	if b.Expiration <= b.Effective {
 		return nil, Invalid, fmt.Errorf("blob expiration %d <= effective %d", b.Expiration, b.Effective)
 	}
-	if len(b.Validators) == 0 {
-		return nil, Invalid, errors.New("blob carries no validators")
-	}
+	// Empty `validators` arrays are structurally legal: rippled's
+	// verify() (ValidatorList.cpp:1394-1397) only asserts the field is
+	// an array, and applyList iterates zero entries when it's empty.
+	// Rejecting here would charge a peer for a frame rippled accepts.
 	for i, v := range b.Validators {
 		raw, err := hex.DecodeString(v.ValidationPublicKey)
 		if err != nil {

--- a/internal/validator/list/blob.go
+++ b/internal/validator/list/blob.go
@@ -12,6 +12,18 @@ import (
 	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
 )
 
+// validatorKeyValid reports whether raw is a 33-byte master pubkey with
+// a recognized key-type prefix. Used by applyAcceptedLocked to silently
+// skip malformed validator entries — mirrors rippled
+// ValidatorList.cpp:1250-1273 which logs and skips bad entries without
+// rejecting the surrounding list.
+func validatorKeyValid(raw []byte) bool {
+	if len(raw) != 33 {
+		return false
+	}
+	return crypto.PublicKeyType(raw) != crypto.KeyTypeUnknown
+}
+
 // rippleEpochOffset is the gap between Unix epoch (1970) and the XRPL
 // ripple epoch (2000-01-01 UTC). Validator-list expiration / effective
 // fields are encoded as seconds-since-ripple-epoch. Mirrors rippled's
@@ -50,9 +62,14 @@ type blobEntryJS struct {
 // parseBlob decodes the base64-encoded blob, JSON-unmarshals the inner
 // payload, and returns the parsed structure. Returns Malformed when the
 // outer encoding is broken (not base64 / not JSON), Invalid when the
-// structural invariants of the inner JSON fail (missing fields,
-// expiration <= effective, validator pubkey isn't 33 bytes of a known
-// key type).
+// validity-window invariant fails (expiration <= effective — mirrors
+// rippled ValidatorList.cpp:1406-1407).
+//
+// Per-entry validator pubkey validation is intentionally deferred to
+// applyAcceptedLocked: rippled at ValidatorList.cpp:1250-1273 logs and
+// silently skips malformed entries rather than rejecting the surrounding
+// blob, so a publisher mistake on one entry does not poison the whole
+// list.
 func parseBlob(rawBlob []byte) (*blobJSON, Disposition, error) {
 	decoded, err := decodeBase64Tolerant(rawBlob)
 	if err != nil {
@@ -62,30 +79,8 @@ func parseBlob(rawBlob []byte) (*blobJSON, Disposition, error) {
 	if err := json.Unmarshal(decoded, &b); err != nil {
 		return nil, Malformed, fmt.Errorf("blob JSON unmarshal: %w", err)
 	}
-	if b.Sequence == 0 {
-		return nil, Invalid, errors.New("blob missing or zero sequence")
-	}
-	if b.Expiration == 0 {
-		return nil, Invalid, errors.New("blob missing or zero expiration")
-	}
 	if b.Expiration <= b.Effective {
 		return nil, Invalid, fmt.Errorf("blob expiration %d <= effective %d", b.Expiration, b.Effective)
-	}
-	// Empty `validators` arrays are structurally legal: rippled's
-	// verify() (ValidatorList.cpp:1394-1397) only asserts the field is
-	// an array, and applyList iterates zero entries when it's empty.
-	// Rejecting here would charge a peer for a frame rippled accepts.
-	for i, v := range b.Validators {
-		raw, err := hex.DecodeString(v.ValidationPublicKey)
-		if err != nil {
-			return nil, Invalid, fmt.Errorf("validator[%d] pubkey not hex: %w", i, err)
-		}
-		if len(raw) != 33 {
-			return nil, Invalid, fmt.Errorf("validator[%d] pubkey is %d bytes, want 33", i, len(raw))
-		}
-		if crypto.PublicKeyType(raw) == crypto.KeyTypeUnknown {
-			return nil, Invalid, fmt.Errorf("validator[%d] pubkey has unknown key-type prefix", i)
-		}
 	}
 	return &b, Accepted, nil
 }

--- a/internal/validator/list/blob.go
+++ b/internal/validator/list/blob.go
@@ -54,6 +54,12 @@ type blobJSON struct {
 	Expiration uint32        `json:"expiration"`
 	Effective  uint32        `json:"effective,omitempty"`
 	Validators []blobEntryJS `json:"validators"`
+	// EffectiveSet records whether `effective` was JSON-present in the
+	// blob (distinct from the JSON-default zero). Rippled gates the RPC
+	// `effective` emit on `validFrom != TimeKeeper::time_point{}` at
+	// ValidatorList.cpp:1682; without this sentinel the ripple-epoch
+	// offset turns an absent field into a synthetic 2000-Jan-01 stamp.
+	EffectiveSet bool `json:"-"`
 }
 
 // blobEntryJS is a single validator entry inside a publisher blob. The
@@ -110,6 +116,7 @@ func parseBlob(rawBlob []byte) (*blobJSON, Disposition, error) {
 		if err := json.Unmarshal(effRaw, &b.Effective); err != nil {
 			return nil, Invalid, fmt.Errorf("blob effective not uint32: %w", err)
 		}
+		b.EffectiveSet = true
 	}
 	if err := json.Unmarshal(valsRaw, &b.Validators); err != nil {
 		return nil, Invalid, fmt.Errorf("blob validators not array: %w", err)

--- a/internal/validator/list/blob.go
+++ b/internal/validator/list/blob.go
@@ -1,0 +1,162 @@
+package list
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/LeJamon/goXRPLd/crypto"
+	"github.com/LeJamon/goXRPLd/crypto/ed25519"
+	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
+)
+
+// rippleEpochOffset is the gap between Unix epoch (1970) and the XRPL
+// ripple epoch (2000-01-01 UTC). Validator-list expiration / effective
+// fields are encoded as seconds-since-ripple-epoch. Mirrors rippled's
+// TimeKeeper time_point arithmetic at TimeKeeper.h.
+const rippleEpochOffset int64 = 946684800
+
+// SupportedVersions enumerates the protocol versions this aggregator
+// accepts. Version 1 is the original single-blob format; version 2 adds
+// the blobs_v2 collection used for forward-dated lists. Anything else
+// is treated as UnsupportedVersion.
+var SupportedVersions = []uint32{1, 2}
+
+// blobJSON is the schema published in vl.ripple.com-style envelopes and
+// embedded in TMValidatorList / TMValidatorListCollection messages.
+// Decoded from the base64-encoded blob bytes.
+//
+// Fields beyond these are tolerated and ignored — rippled's JSON parser
+// is lenient and forward-compatibility relies on it.
+type blobJSON struct {
+	Sequence   uint32        `json:"sequence"`
+	Expiration uint32        `json:"expiration"`
+	Effective  uint32        `json:"effective,omitempty"`
+	Validators []blobEntryJS `json:"validators"`
+}
+
+// blobEntryJS is a single validator entry inside a publisher blob. The
+// validation_public_key is the validator's 33-byte compressed master
+// pubkey in hex. The optional manifest carries the validator's current
+// manifest STObject (base64-encoded) — peers without it would otherwise
+// be unable to translate the ephemeral signing key back to the master.
+type blobEntryJS struct {
+	ValidationPublicKey string `json:"validation_public_key"`
+	Manifest            string `json:"manifest,omitempty"`
+}
+
+// parseBlob decodes the base64-encoded blob, JSON-unmarshals the inner
+// payload, and returns the parsed structure. Returns Malformed when the
+// outer encoding is broken (not base64 / not JSON), Invalid when the
+// structural invariants of the inner JSON fail (missing fields,
+// expiration <= effective, validator pubkey isn't 33 bytes of a known
+// key type).
+func parseBlob(rawBlob []byte) (*blobJSON, Disposition, error) {
+	decoded, err := decodeBase64Tolerant(rawBlob)
+	if err != nil {
+		return nil, Malformed, fmt.Errorf("blob base64 decode: %w", err)
+	}
+	var b blobJSON
+	if err := json.Unmarshal(decoded, &b); err != nil {
+		return nil, Malformed, fmt.Errorf("blob JSON unmarshal: %w", err)
+	}
+	if b.Sequence == 0 {
+		return nil, Invalid, errors.New("blob missing or zero sequence")
+	}
+	if b.Expiration == 0 {
+		return nil, Invalid, errors.New("blob missing or zero expiration")
+	}
+	if b.Expiration <= b.Effective {
+		return nil, Invalid, fmt.Errorf("blob expiration %d <= effective %d", b.Expiration, b.Effective)
+	}
+	if len(b.Validators) == 0 {
+		return nil, Invalid, errors.New("blob carries no validators")
+	}
+	for i, v := range b.Validators {
+		raw, err := hex.DecodeString(v.ValidationPublicKey)
+		if err != nil {
+			return nil, Invalid, fmt.Errorf("validator[%d] pubkey not hex: %w", i, err)
+		}
+		if len(raw) != 33 {
+			return nil, Invalid, fmt.Errorf("validator[%d] pubkey is %d bytes, want 33", i, len(raw))
+		}
+		if crypto.PublicKeyType(raw) == crypto.KeyTypeUnknown {
+			return nil, Invalid, fmt.Errorf("validator[%d] pubkey has unknown key-type prefix", i)
+		}
+	}
+	return &b, Accepted, nil
+}
+
+// verifyBlobSignature checks that `signature` (hex-encoded) is a valid
+// signature by `signingKey` over the raw blob bytes (the base64-encoded
+// payload AS-RECEIVED, NOT its decoded form). Mirrors rippled
+// ValidatorList.cpp:1385-1388:
+//
+//	auto const sig = strUnHex(signature);
+//	auto const data = base64_decode(blob);
+//	if (!ripple::verify(*signingKey, makeSlice(data), makeSlice(*sig)))
+//
+// Wait — rippled actually signs the BASE64-DECODED data, not the raw
+// blob bytes. The decoded JSON text is the signing input. Reading the
+// rippled snippet carefully: `data = base64_decode(blob)` then
+// `verify(signingKey, data, sig)`. So the signature is over the
+// decoded JSON text. We match that here.
+func verifyBlobSignature(signingKey [33]byte, blob, signatureHex []byte) error {
+	decoded, err := decodeBase64Tolerant(blob)
+	if err != nil {
+		return fmt.Errorf("blob decode for signature verify: %w", err)
+	}
+	sigHexStr := string(signatureHex)
+	if _, err := hex.DecodeString(sigHexStr); err != nil {
+		return fmt.Errorf("signature not hex: %w", err)
+	}
+	pubHex := hex.EncodeToString(signingKey[:])
+	switch crypto.PublicKeyType(signingKey[:]) {
+	case crypto.KeyTypeEd25519:
+		if !ed25519.ED25519().Validate(string(decoded), pubHex, sigHexStr) {
+			return errors.New("ed25519 signature invalid")
+		}
+		return nil
+	case crypto.KeyTypeSecp256k1:
+		// Rippled verify() requires fully-canonical signatures
+		// (PublicKey::verify default). Match by passing canonicality=true.
+		if !secp256k1.SECP256K1().ValidateWithCanonicality(string(decoded), pubHex, sigHexStr, true) {
+			return errors.New("secp256k1 signature invalid")
+		}
+		return nil
+	default:
+		return errors.New("unknown signing key type")
+	}
+}
+
+// decodeBase64Tolerant decodes a base64-encoded payload that may be in
+// either the standard or URL-safe variant, and may or may not include
+// padding. Real publisher JSON envelopes consistently use standard
+// padded base64, but rippled accepts unpadded too via boost::beast's
+// detail::base64::decode (lenient). Match the same tolerance.
+func decodeBase64Tolerant(payload []byte) ([]byte, error) {
+	s := string(payload)
+	if out, err := base64.StdEncoding.DecodeString(s); err == nil {
+		return out, nil
+	}
+	if out, err := base64.RawStdEncoding.DecodeString(s); err == nil {
+		return out, nil
+	}
+	if out, err := base64.URLEncoding.DecodeString(s); err == nil {
+		return out, nil
+	}
+	if out, err := base64.RawURLEncoding.DecodeString(s); err == nil {
+		return out, nil
+	}
+	return nil, errors.New("payload is not valid base64 in any variant")
+}
+
+// rippleSecondsToUnix converts a ripple-epoch second count (the form
+// validator blobs use for expiration / effective) into a Unix epoch
+// second count. Pure arithmetic; no time.Time round-trip so the result
+// is deterministic across machines with different time zones.
+func rippleSecondsToUnix(rippleSec uint32) int64 {
+	return int64(rippleSec) + rippleEpochOffset
+}

--- a/internal/validator/list/blob.go
+++ b/internal/validator/list/blob.go
@@ -60,10 +60,17 @@ type blobEntryJS struct {
 }
 
 // parseBlob decodes the base64-encoded blob, JSON-unmarshals the inner
-// payload, and returns the parsed structure. Returns Malformed when the
-// outer encoding is broken (not base64 / not JSON), Invalid when the
-// validity-window invariant fails (expiration <= effective — mirrors
-// rippled ValidatorList.cpp:1406-1407).
+// payload, and returns the parsed structure. Every parse / structure
+// failure returns Invalid — matching rippled ValidatorList.cpp:1390-1437
+// which folds bad-base64, bad-JSON, missing-required-field, wrong-type,
+// and validity-window violations all into ListDisposition::invalid.
+//
+// Required fields (rippled lines 1394-1397): `sequence` (int),
+// `expiration` (int), `validators` (array). `effective` is optional but
+// must be an integer when present. Absence is a hard reject — the
+// silent-zero-coercion json.Unmarshal default would let a malformed
+// publisher feed produce an empty trusted set without ever surfacing
+// the error.
 //
 // Per-entry validator pubkey validation is intentionally deferred to
 // applyAcceptedLocked: rippled at ValidatorList.cpp:1250-1273 logs and
@@ -73,11 +80,32 @@ type blobEntryJS struct {
 func parseBlob(rawBlob []byte) (*blobJSON, Disposition, error) {
 	decoded, err := decodeBase64Tolerant(rawBlob)
 	if err != nil {
-		return nil, Malformed, fmt.Errorf("blob base64 decode: %w", err)
+		return nil, Invalid, fmt.Errorf("blob base64 decode: %w", err)
 	}
-	var b blobJSON
-	if err := json.Unmarshal(decoded, &b); err != nil {
-		return nil, Malformed, fmt.Errorf("blob JSON unmarshal: %w", err)
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(decoded, &raw); err != nil {
+		return nil, Invalid, fmt.Errorf("blob JSON unmarshal: %w", err)
+	}
+	seqRaw, hasSeq := raw["sequence"]
+	expRaw, hasExp := raw["expiration"]
+	valsRaw, hasVals := raw["validators"]
+	if !hasSeq || !hasExp || !hasVals {
+		return nil, Invalid, fmt.Errorf("blob missing required field(s); have sequence=%t expiration=%t validators=%t", hasSeq, hasExp, hasVals)
+	}
+	b := blobJSON{}
+	if err := json.Unmarshal(seqRaw, &b.Sequence); err != nil {
+		return nil, Invalid, fmt.Errorf("blob sequence not uint32: %w", err)
+	}
+	if err := json.Unmarshal(expRaw, &b.Expiration); err != nil {
+		return nil, Invalid, fmt.Errorf("blob expiration not uint32: %w", err)
+	}
+	if effRaw, ok := raw["effective"]; ok {
+		if err := json.Unmarshal(effRaw, &b.Effective); err != nil {
+			return nil, Invalid, fmt.Errorf("blob effective not uint32: %w", err)
+		}
+	}
+	if err := json.Unmarshal(valsRaw, &b.Validators); err != nil {
+		return nil, Invalid, fmt.Errorf("blob validators not array: %w", err)
 	}
 	if b.Expiration <= b.Effective {
 		return nil, Invalid, fmt.Errorf("blob expiration %d <= effective %d", b.Expiration, b.Effective)

--- a/internal/validator/list/blob.go
+++ b/internal/validator/list/blob.go
@@ -36,6 +36,13 @@ const rippleEpochOffset int64 = 946684800
 // is treated as UnsupportedVersion.
 var SupportedVersions = []uint32{1, 2}
 
+// MaxSupportedBlobs caps how many per-blob entries a v2 collection may
+// carry. Matches rippled ValidatorList.h:272
+// `static constexpr std::size_t maxSupportedBlobs = 5;`. A peer that
+// sends more than this is treated as Malformed before any signature
+// verification work.
+const MaxSupportedBlobs = 5
+
 // blobJSON is the schema published in vl.ripple.com-style envelopes and
 // embedded in TMValidatorList / TMValidatorListCollection messages.
 // Decoded from the base64-encoded blob bytes.
@@ -145,11 +152,13 @@ func verifyBlobSignature(signingKey [33]byte, blob, signatureHex []byte) error {
 	}
 }
 
-// decodeBase64Tolerant decodes a base64-encoded payload that may be in
-// either the standard or URL-safe variant, and may or may not include
-// padding. Real publisher JSON envelopes consistently use standard
-// padded base64, but rippled accepts unpadded too via boost::beast's
-// detail::base64::decode (lenient). Match the same tolerance.
+// decodeBase64Tolerant decodes a standard base64-encoded payload,
+// padded or unpadded. Rippled's `base64_decode` uses the standard
+// alphabet only (`base64.cpp:191-234`); URL-safe characters `-` and `_`
+// are rejected. Accepting them in goXRPL would let a malicious peer
+// craft a payload that this implementation accepts and rippled rejects
+// (or vice versa), diverging hash-routing and relay decisions across
+// implementations.
 func decodeBase64Tolerant(payload []byte) ([]byte, error) {
 	s := string(payload)
 	if out, err := base64.StdEncoding.DecodeString(s); err == nil {
@@ -158,13 +167,7 @@ func decodeBase64Tolerant(payload []byte) ([]byte, error) {
 	if out, err := base64.RawStdEncoding.DecodeString(s); err == nil {
 		return out, nil
 	}
-	if out, err := base64.URLEncoding.DecodeString(s); err == nil {
-		return out, nil
-	}
-	if out, err := base64.RawURLEncoding.DecodeString(s); err == nil {
-		return out, nil
-	}
-	return nil, errors.New("payload is not valid base64 in any variant")
+	return nil, errors.New("payload is not valid standard base64")
 }
 
 // rippleSecondsToUnix converts a ripple-epoch second count (the form

--- a/internal/validator/list/broadcaster.go
+++ b/internal/validator/list/broadcaster.go
@@ -10,13 +10,14 @@ package list
 //   - SendList: TMValidatorList (v1) carrying a single accepted blob.
 //     Used for peers that did not negotiate ValidatorList2Propagation.
 //   - SendCollection: TMValidatorListCollection (v2) carrying current
-//   - remaining blobs. Used for peers that did negotiate v2 and
-//     when the publisher has pending Remaining blobs to pre-announce.
+//     plus any Remaining blobs. Used for any peer that negotiated v2,
+//     even when the publisher has no Remaining blobs (in which case
+//     the collection has a single entry — current).
 //
-// The aggregator picks the entry point per peer via PeerSupportsV2 —
-// v1-only peers always receive SendList carrying the current accepted
-// blob, matching rippled's degraded-mode behaviour in broadcastBlobs
-// at rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:872-937.
+// The aggregator picks the entry point per peer via PeerSupportsV2,
+// matching rippled's sendValidatorList at
+// rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:752-757 which
+// selects messageVersion based on the peer feature alone.
 type PeerBroadcaster interface {
 	// ActivePeers returns the IDs of every connected, handshake-
 	// complete peer. The aggregator iterates this set on each
@@ -42,9 +43,10 @@ type PeerBroadcaster interface {
 
 	// SendCollection delivers a TMValidatorListCollection (v2) frame
 	// carrying the publisher manifest plus an ordered slice of
-	// (per-blob optional manifest, blob, signature) tuples. Used when
-	// the recipient supports v2 and the publisher has Remaining blobs
-	// to pre-announce. Returns any send error.
+	// (per-blob optional manifest, blob, signature) tuples. Used for
+	// every v2-capable recipient (the slice has a single current entry
+	// when the publisher has no Remaining blobs). Returns any send
+	// error.
 	SendCollection(peerID uint64, manifest []byte, blobs []BroadcastBlob, version uint32) error
 }
 

--- a/internal/validator/list/broadcaster.go
+++ b/internal/validator/list/broadcaster.go
@@ -1,0 +1,33 @@
+package list
+
+// PeerBroadcaster is the minimal overlay+encoder surface the aggregator
+// uses to push the most recently accepted list for a publisher out to
+// connected peers. Implemented by the router so that validator/list
+// stays free of any peermanagement / message-codec dependency.
+//
+// Sends are issued at TMValidatorList (v1, single-blob) granularity:
+// goXRPL's aggregator never stores pending blobs, so the canonical
+// accepted form for any publisher is always a single (manifest, blob,
+// signature) triple — and v1 is the wire-version every VL-capable
+// peer can decode, which lets us defer ValidatorList2Propagation
+// feature-negotiation work without losing relay coverage.
+type PeerBroadcaster interface {
+	// ActivePeers returns the IDs of every connected, handshake-
+	// complete peer. The aggregator iterates this set on each
+	// BroadcastLatest call; order is unspecified.
+	ActivePeers() []uint64
+
+	// PeerSupportsVL reports whether `peerID` negotiated
+	// ValidatorListPropagation at handshake. Mirrors rippled's
+	// peer->supportsFeature(ProtocolFeature::ValidatorListPropagation)
+	// gate in PeerImp.cpp:2252-2260. Peers that didn't advertise the
+	// feature are silently skipped.
+	PeerSupportsVL(peerID uint64) bool
+
+	// SendList delivers a TMValidatorList frame to peerID carrying
+	// the supplied wire bytes verbatim. blobVersion is recorded on
+	// the frame so the receiver knows which blob schema to parse.
+	// Returns any send error; the aggregator logs and continues
+	// with the remaining peers rather than aborting the broadcast.
+	SendList(peerID uint64, manifest, blob, signature []byte, blobVersion uint32) error
+}

--- a/internal/validator/list/broadcaster.go
+++ b/internal/validator/list/broadcaster.go
@@ -1,16 +1,22 @@
 package list
 
 // PeerBroadcaster is the minimal overlay+encoder surface the aggregator
-// uses to push the most recently accepted list for a publisher out to
+// uses to push the most recently accepted list (current + any
+// verified-but-future Remaining blobs) for a publisher out to
 // connected peers. Implemented by the router so that validator/list
 // stays free of any peermanagement / message-codec dependency.
 //
-// Sends are issued at TMValidatorList (v1, single-blob) granularity:
-// goXRPL's aggregator never stores pending blobs, so the canonical
-// accepted form for any publisher is always a single (manifest, blob,
-// signature) triple — and v1 is the wire-version every VL-capable
-// peer can decode, which lets us defer ValidatorList2Propagation
-// feature-negotiation work without losing relay coverage.
+// Two send entry points distinguish the rippled wire shapes:
+//   - SendList: TMValidatorList (v1) carrying a single accepted blob.
+//     Used for peers that did not negotiate ValidatorList2Propagation.
+//   - SendCollection: TMValidatorListCollection (v2) carrying current
+//   - remaining blobs. Used for peers that did negotiate v2 and
+//     when the publisher has pending Remaining blobs to pre-announce.
+//
+// The aggregator picks the entry point per peer via PeerSupportsV2 —
+// v1-only peers always receive SendList carrying the current accepted
+// blob, matching rippled's degraded-mode behaviour in broadcastBlobs
+// at rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:872-937.
 type PeerBroadcaster interface {
 	// ActivePeers returns the IDs of every connected, handshake-
 	// complete peer. The aggregator iterates this set on each
@@ -20,14 +26,37 @@ type PeerBroadcaster interface {
 	// PeerSupportsVL reports whether `peerID` negotiated
 	// ValidatorListPropagation at handshake. Mirrors rippled's
 	// peer->supportsFeature(ProtocolFeature::ValidatorListPropagation)
-	// gate in PeerImp.cpp:2252-2260. Peers that didn't advertise the
-	// feature are silently skipped.
+	// gate in PeerImp.cpp:2252-2260.
 	PeerSupportsVL(peerID uint64) bool
 
-	// SendList delivers a TMValidatorList frame to peerID carrying
-	// the supplied wire bytes verbatim. blobVersion is recorded on
-	// the frame so the receiver knows which blob schema to parse.
-	// Returns any send error; the aggregator logs and continues
-	// with the remaining peers rather than aborting the broadcast.
+	// PeerSupportsV2 reports whether `peerID` negotiated
+	// ValidatorList2Propagation (implicitly at peer-protocol >= 2.2).
+	// Mirrors rippled PeerImp.cpp:511-514.
+	PeerSupportsV2(peerID uint64) bool
+
+	// SendList delivers a TMValidatorList (v1) frame to peerID carrying
+	// the supplied wire bytes verbatim. blobVersion is recorded on the
+	// frame's `version` field. Returns any send error; the aggregator
+	// logs and continues with the remaining peers.
 	SendList(peerID uint64, manifest, blob, signature []byte, blobVersion uint32) error
+
+	// SendCollection delivers a TMValidatorListCollection (v2) frame
+	// carrying the publisher manifest plus an ordered slice of
+	// (per-blob optional manifest, blob, signature) tuples. Used when
+	// the recipient supports v2 and the publisher has Remaining blobs
+	// to pre-announce. Returns any send error.
+	SendCollection(peerID uint64, manifest []byte, blobs []BroadcastBlob, version uint32) error
+}
+
+// BroadcastBlob is one entry inside a TMValidatorListCollection frame.
+// The aggregator constructs a slice of these from the publisher's
+// current + Remaining state for v2 broadcasts.
+type BroadcastBlob struct {
+	// Manifest is the per-blob manifest override; empty for blobs that
+	// use the collection's shared publisher manifest.
+	Manifest []byte
+	// Blob is the base64-encoded blob bytes as originally received.
+	Blob []byte
+	// Signature is the hex-encoded blob signature.
+	Signature []byte
 }

--- a/internal/validator/list/broadcaster_test.go
+++ b/internal/validator/list/broadcaster_test.go
@@ -1,0 +1,185 @@
+package list_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/manifest"
+	"github.com/LeJamon/goXRPLd/internal/validator/list"
+)
+
+// fakeBroadcaster records each call so tests can assert which wire
+// shape (SendList vs SendCollection) BroadcastLatest selected for each
+// peer based on its negotiated feature flags.
+type fakeBroadcaster struct {
+	mu       sync.Mutex
+	peers    []uint64
+	supports map[uint64]bool
+	v2       map[uint64]bool
+
+	listCalls       []sendListCall
+	collectionCalls []sendCollectionCall
+}
+
+type sendListCall struct {
+	peerID  uint64
+	blob    []byte
+	sig     []byte
+	version uint32
+}
+
+type sendCollectionCall struct {
+	peerID  uint64
+	blobs   []list.BroadcastBlob
+	version uint32
+}
+
+func newFakeBroadcaster(peers []uint64, vlSupport, v2Support map[uint64]bool) *fakeBroadcaster {
+	return &fakeBroadcaster{peers: peers, supports: vlSupport, v2: v2Support}
+}
+
+func (f *fakeBroadcaster) ActivePeers() []uint64 {
+	out := make([]uint64, len(f.peers))
+	copy(out, f.peers)
+	return out
+}
+
+func (f *fakeBroadcaster) PeerSupportsVL(peerID uint64) bool {
+	return f.supports[peerID]
+}
+
+func (f *fakeBroadcaster) PeerSupportsV2(peerID uint64) bool {
+	return f.v2[peerID]
+}
+
+func (f *fakeBroadcaster) SendList(peerID uint64, manifest, blob, signature []byte, version uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listCalls = append(f.listCalls, sendListCall{
+		peerID:  peerID,
+		blob:    append([]byte(nil), blob...),
+		sig:     append([]byte(nil), signature...),
+		version: version,
+	})
+	return nil
+}
+
+func (f *fakeBroadcaster) SendCollection(peerID uint64, manifest []byte, blobs []list.BroadcastBlob, version uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := make([]list.BroadcastBlob, len(blobs))
+	for i, b := range blobs {
+		cp[i] = list.BroadcastBlob{
+			Manifest:  append([]byte(nil), b.Manifest...),
+			Blob:      append([]byte(nil), b.Blob...),
+			Signature: append([]byte(nil), b.Signature...),
+		}
+	}
+	f.collectionCalls = append(f.collectionCalls, sendCollectionCall{
+		peerID:  peerID,
+		blobs:   cp,
+		version: version,
+	})
+	return nil
+}
+
+// TestBroadcastLatest_V2PeerGetsCollection_NoRemaining pins M1: a
+// v2-capable peer must receive a TMValidatorListCollection (single
+// entry — current only) even when the publisher has no Remaining
+// blobs, mirroring rippled's sendValidatorList branch on
+// peer->supportsFeature(ValidatorList2Propagation) at
+// ValidatorList.cpp:752-757.
+func TestBroadcastLatest_V2PeerGetsCollection_NoRemaining(t *testing.T) {
+	pub := newPublisher(t, 0x51, 0x52)
+	v1 := derivedValidatorKey(0x60)
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Peer 100: v1-only. Peer 200: v2-capable.
+	fake := newFakeBroadcaster(
+		[]uint64{100, 200},
+		map[uint64]bool{100: true, 200: true},
+		map[uint64]bool{100: false, 200: true},
+	)
+	agg.SetBroadcaster(fake)
+
+	now := fixedClock()()
+	exp := now.Add(24 * time.Hour).Unix()
+	blob, sig := pub.signList(t, 5, 0, exp, [][33]byte{v1})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "p1://"); d != list.Accepted {
+		t.Fatalf("apply: %s", d)
+	}
+
+	// No Remaining present (single accepted blob).
+	agg.BroadcastLatest(list.PublisherKey(pub.masterPub), 0)
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.listCalls) != 1 || fake.listCalls[0].peerID != 100 {
+		t.Fatalf("v1-only peer must receive exactly one SendList; got %+v", fake.listCalls)
+	}
+	if len(fake.collectionCalls) != 1 || fake.collectionCalls[0].peerID != 200 {
+		t.Fatalf("v2 peer must receive exactly one SendCollection; got %+v", fake.collectionCalls)
+	}
+	if len(fake.collectionCalls[0].blobs) != 1 {
+		t.Fatalf("v2 collection with no Remaining must carry single entry (current); got %d blobs",
+			len(fake.collectionCalls[0].blobs))
+	}
+	if fake.collectionCalls[0].version < 2 {
+		t.Fatalf("collection version must be ≥ 2; got %d", fake.collectionCalls[0].version)
+	}
+}
+
+// TestBroadcastLatest_V2PeerSkippedWhenAtMaxSeq verifies the
+// peer-sequence gate is honored on the v2 path.
+func TestBroadcastLatest_V2PeerSkippedWhenAtMaxSeq(t *testing.T) {
+	pub := newPublisher(t, 0x53, 0x54)
+	v1 := derivedValidatorKey(0x61)
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	fake := newFakeBroadcaster(
+		[]uint64{200},
+		map[uint64]bool{200: true},
+		map[uint64]bool{200: true},
+	)
+	agg.SetBroadcaster(fake)
+
+	now := fixedClock()()
+	exp := now.Add(24 * time.Hour).Unix()
+	blob, sig := pub.signList(t, 5, 0, exp, [][33]byte{v1})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "p1://"); d != list.Accepted {
+		t.Fatalf("apply: %s", d)
+	}
+
+	// Pre-record that peer 200 has already received sequence 5.
+	agg.RecordPeerSequence(200, list.PublisherKey(pub.masterPub), 5)
+
+	agg.BroadcastLatest(list.PublisherKey(pub.masterPub), 0)
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.collectionCalls) != 0 {
+		t.Fatalf("peer at maxSeq must not receive SendCollection; got %d call(s)", len(fake.collectionCalls))
+	}
+	if len(fake.listCalls) != 0 {
+		t.Fatalf("peer at maxSeq must not receive SendList either; got %d call(s)", len(fake.listCalls))
+	}
+}

--- a/internal/validator/list/cache.go
+++ b/internal/validator/list/cache.go
@@ -6,8 +6,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
+
+// cacheRefreshIntervalMinutes mirrors rippled's
+// `value[jss::refresh_interval] = 24 * 60` at
+// rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:386 — rippled is
+// the only writer of these files in its model, so reads can be safely
+// delayed up to 24 hours. goXRPL does not consume the value on the
+// load path (LoadCache hydrates unconditionally before site polling
+// begins) but emits it so the on-disk format stays byte-compatible.
+const cacheRefreshIntervalMinutes = 24 * 60
 
 // cacheFilePrefix mirrors rippled's ValidatorList::filePrefix_ at
 // rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:118
@@ -17,14 +27,22 @@ const cacheFilePrefix = "cache."
 
 // cachedEnvelope is the on-disk shape produced by writeCacheLocked
 // and consumed by LoadCache. Mirrors rippled's buildFileData layout
-// at ValidatorList.cpp:312-366 — top-level manifest / version for v1,
-// plus a blobs_v2 array for collections.
+// at ValidatorList.cpp:304-366 — top-level manifest / version /
+// public_key for v1, plus a blobs_v2 array for collections, and a
+// refresh_interval added by cacheValidatorFile.
+//
+// PublicKey and RefreshInterval are written for byte-compatibility
+// with rippled's format (line 321 + line 386) but are not consumed
+// by LoadCache: the publisher is identified by the file name, and
+// refresh cadence is driven by the site poller, not the cache.
 type cachedEnvelope struct {
-	Manifest  string            `json:"manifest"`
-	Blob      string            `json:"blob,omitempty"`
-	Signature string            `json:"signature,omitempty"`
-	Version   uint32            `json:"version"`
-	BlobsV2   []cachedBlobEntry `json:"blobs_v2,omitempty"`
+	Manifest        string            `json:"manifest"`
+	PublicKey       string            `json:"public_key,omitempty"`
+	Blob            string            `json:"blob,omitempty"`
+	Signature       string            `json:"signature,omitempty"`
+	Version         uint32            `json:"version"`
+	BlobsV2         []cachedBlobEntry `json:"blobs_v2,omitempty"`
+	RefreshInterval uint32            `json:"refresh_interval,omitempty"`
 }
 
 type cachedBlobEntry struct {
@@ -74,8 +92,10 @@ func (a *Aggregator) writeCacheLocked(s *PublisherState) {
 		return
 	}
 	env := cachedEnvelope{
-		Manifest: string(s.RawManifest),
-		Version:  s.Version,
+		Manifest:        string(s.RawManifest),
+		PublicKey:       hex.EncodeToString(s.MasterKey[:]),
+		Version:         s.Version,
+		RefreshInterval: cacheRefreshIntervalMinutes,
 	}
 	if env.Version == 0 {
 		env.Version = 1
@@ -91,11 +111,7 @@ func (a *Aggregator) writeCacheLocked(s *PublisherState) {
 		for seq := range s.Remaining {
 			seqs = append(seqs, seq)
 		}
-		for i := 1; i < len(seqs); i++ {
-			for j := i; j > 0 && seqs[j-1] > seqs[j]; j-- {
-				seqs[j-1], seqs[j] = seqs[j], seqs[j-1]
-			}
-		}
+		sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
 		for _, seq := range seqs {
 			rb := s.Remaining[seq]
 			env.BlobsV2 = append(env.BlobsV2, cachedBlobEntry{
@@ -164,8 +180,15 @@ func (a *Aggregator) removeCacheLocked(pk PublisherKey) {
 func (a *Aggregator) LoadCache() int {
 	a.mu.Lock()
 	dir := a.cacheDir
+	// Snapshot the publisher set and skip any that have already been
+	// hydrated by another source (e.g. a site-poll racing the cache
+	// load). Mirrors rippled's loadLists() at ValidatorList.cpp:1315-1316
+	// which skips publishers whose PublisherStatus is `available`.
 	pubs := make([]PublisherKey, 0, len(a.publishers))
 	for k := range a.publishers {
+		if st, ok := a.state[k]; ok && st != nil && st.Status == StatusAvailable {
+			continue
+		}
 		pubs = append(pubs, k)
 	}
 	a.mu.Unlock()

--- a/internal/validator/list/cache.go
+++ b/internal/validator/list/cache.go
@@ -1,0 +1,265 @@
+package list
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// cacheFilePrefix mirrors rippled's ValidatorList::filePrefix_ at
+// rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:118
+// (`"cache."`). Combined with the hex-encoded publisher master key
+// it yields the per-publisher cache file name.
+const cacheFilePrefix = "cache."
+
+// cachedEnvelope is the on-disk shape produced by writeCacheLocked
+// and consumed by LoadCache. Mirrors rippled's buildFileData layout
+// at ValidatorList.cpp:312-366 — top-level manifest / version for v1,
+// plus a blobs_v2 array for collections.
+type cachedEnvelope struct {
+	Manifest  string            `json:"manifest"`
+	Blob      string            `json:"blob,omitempty"`
+	Signature string            `json:"signature,omitempty"`
+	Version   uint32            `json:"version"`
+	BlobsV2   []cachedBlobEntry `json:"blobs_v2,omitempty"`
+}
+
+type cachedBlobEntry struct {
+	Manifest  string `json:"manifest,omitempty"`
+	Blob      string `json:"blob"`
+	Signature string `json:"signature"`
+}
+
+// SetCacheDir wires the on-disk cache directory for accepted
+// publisher lists. After each accepted ApplyList the aggregator
+// writes `<dir>/cache.<pubKeyHex>` so a cold restart has up-to-date
+// trust without waiting for the first poll. Mirrors rippled's
+// ValidatorList::cacheValidatorFile at
+// rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:368-396.
+//
+// Passing an empty string disables on-disk caching. Safe to call
+// before or after Start; takes a.mu briefly.
+func (a *Aggregator) SetCacheDir(dir string) error {
+	if dir == "" {
+		a.mu.Lock()
+		a.cacheDir = ""
+		a.mu.Unlock()
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create cache dir %q: %w", dir, err)
+	}
+	a.mu.Lock()
+	a.cacheDir = dir
+	a.mu.Unlock()
+	return nil
+}
+
+// writeCacheLocked persists the publisher's current accepted form to
+// disk. Caller must hold a.mu. No-op when no cache directory is set
+// or the publisher has no accepted list to write.
+//
+// Atomic via tmp + rename so a partial write cannot be observed by a
+// concurrent LoadCache. Errors are logged but not surfaced — a failed
+// cache write is recoverable; rippled does the same (logs and
+// ignores) at ValidatorList.cpp:390-395.
+func (a *Aggregator) writeCacheLocked(s *PublisherState) {
+	if a.cacheDir == "" {
+		return
+	}
+	if s == nil || s.Sequence == 0 || len(s.RawManifest) == 0 {
+		return
+	}
+	env := cachedEnvelope{
+		Manifest: string(s.RawManifest),
+		Version:  s.Version,
+	}
+	if env.Version == 0 {
+		env.Version = 1
+	}
+	if len(s.Remaining) > 0 {
+		// v2 shape — current + remaining, ordered by sequence ascending.
+		env.Version = 2
+		env.BlobsV2 = append(env.BlobsV2, cachedBlobEntry{
+			Blob:      string(s.RawBlob),
+			Signature: string(s.RawSignature),
+		})
+		seqs := make([]uint32, 0, len(s.Remaining))
+		for seq := range s.Remaining {
+			seqs = append(seqs, seq)
+		}
+		for i := 1; i < len(seqs); i++ {
+			for j := i; j > 0 && seqs[j-1] > seqs[j]; j-- {
+				seqs[j-1], seqs[j] = seqs[j], seqs[j-1]
+			}
+		}
+		for _, seq := range seqs {
+			rb := s.Remaining[seq]
+			env.BlobsV2 = append(env.BlobsV2, cachedBlobEntry{
+				Blob:      string(rb.RawBlob),
+				Signature: string(rb.RawSignature),
+			})
+		}
+	} else {
+		env.Blob = string(s.RawBlob)
+		env.Signature = string(s.RawSignature)
+	}
+	body, err := json.Marshal(env)
+	if err != nil {
+		a.logger.Debug("validator list: cache marshal failed",
+			"publisher", hex.EncodeToString(s.MasterKey[:]),
+			"error", err)
+		return
+	}
+	path := cachePathFor(a.cacheDir, s.MasterKey)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, body, 0o644); err != nil {
+		a.logger.Debug("validator list: cache write failed",
+			"publisher", hex.EncodeToString(s.MasterKey[:]),
+			"error", err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		a.logger.Debug("validator list: cache rename failed",
+			"publisher", hex.EncodeToString(s.MasterKey[:]),
+			"error", err)
+		_ = os.Remove(tmp)
+	}
+}
+
+// removeCacheLocked deletes the on-disk cache file for a publisher
+// (called on revocation). Caller must hold a.mu. Missing-file errors
+// are silently ignored.
+func (a *Aggregator) removeCacheLocked(pk PublisherKey) {
+	if a.cacheDir == "" {
+		return
+	}
+	if err := os.Remove(cachePathFor(a.cacheDir, pk)); err != nil && !os.IsNotExist(err) {
+		a.logger.Debug("validator list: cache remove failed",
+			"publisher", hex.EncodeToString(pk[:]),
+			"error", err)
+	}
+}
+
+// LoadCache rehydrates publisher state from the on-disk cache. For
+// every configured publisher, reads `<cacheDir>/cache.<pubKeyHex>` if
+// present and re-applies the blob through the normal ApplyList /
+// applyCachedCollection pipeline so the usual signature verification
+// and trust-set computation runs.
+//
+// Returns the number of publishers whose state was hydrated. Safe to
+// call before Start; intended to be invoked once during component
+// bootstrap. Failed cache reads (missing file, parse error, signature
+// mismatch) are logged and skipped — a stale or tampered cache file
+// MUST NOT prevent normal startup.
+//
+// Mirrors rippled ValidatorList::loadLists at
+// rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:1300-1351 +
+// missingSite() drain at ValidatorSite.cpp:120-124, folded into a
+// single call here because goXRPL plumbs the file source directly to
+// the aggregator rather than routing through the site poller.
+func (a *Aggregator) LoadCache() int {
+	a.mu.Lock()
+	dir := a.cacheDir
+	pubs := make([]PublisherKey, 0, len(a.publishers))
+	for k := range a.publishers {
+		pubs = append(pubs, k)
+	}
+	a.mu.Unlock()
+
+	if dir == "" {
+		return 0
+	}
+
+	loaded := 0
+	for _, pk := range pubs {
+		path := cachePathFor(dir, pk)
+		body, err := os.ReadFile(path)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				a.logger.Debug("validator list: cache read failed",
+					"publisher", hex.EncodeToString(pk[:]),
+					"error", err)
+			}
+			continue
+		}
+		var env cachedEnvelope
+		if err := json.Unmarshal(body, &env); err != nil {
+			a.logger.Debug("validator list: cache decode failed",
+				"publisher", hex.EncodeToString(pk[:]),
+				"error", err)
+			continue
+		}
+		if env.Version == 0 || env.Manifest == "" {
+			continue
+		}
+		uri := "file://" + path
+		applied := false
+		if len(env.BlobsV2) > 0 {
+			if a.applyCachedCollection(env.Version, []byte(env.Manifest), env.BlobsV2, uri) {
+				applied = true
+			}
+		} else if env.Blob != "" && env.Signature != "" {
+			disp, _, _ := a.ApplyList(
+				[]byte(env.Manifest),
+				[]byte(env.Blob),
+				[]byte(env.Signature),
+				env.Version,
+				uri,
+			)
+			if disp.ShouldRelay() {
+				applied = true
+			}
+		}
+		if applied {
+			loaded++
+		}
+	}
+	if loaded > 0 {
+		a.logger.Info("validator list: hydrated publishers from cache",
+			"count", loaded,
+			"dir", dir)
+	}
+	return loaded
+}
+
+// applyCachedCollection feeds a parsed cachedEnvelope.blobs_v2 through
+// the per-blob apply path (signature verify + state machine). Returns
+// true if at least one blob applied to ShouldRelay disposition.
+func (a *Aggregator) applyCachedCollection(version uint32, manifestBytes []byte, blobs []cachedBlobEntry, siteURI string) bool {
+	if !isSupportedVersion(version) || len(blobs) == 0 {
+		return false
+	}
+	if len(blobs) > MaxSupportedBlobs {
+		return false
+	}
+	any := false
+	for _, b := range blobs {
+		mf := []byte(b.Manifest)
+		if len(mf) == 0 {
+			mf = manifestBytes
+		}
+		disp, _, _ := a.ApplyList(mf, []byte(b.Blob), []byte(b.Signature), version, siteURI)
+		if disp.ShouldRelay() {
+			any = true
+		}
+	}
+	return any
+}
+
+// cachePathFor returns the absolute cache file path for a publisher
+// master key. The hex encoding is lowercase via hex.EncodeToString —
+// rippled accepts case-insensitive filenames on the read path so
+// either works; lowercase is the Go convention.
+func cachePathFor(dir string, pk PublisherKey) string {
+	name := cacheFilePrefix + hex.EncodeToString(pk[:])
+	// Defensive: refuse a path with separators in the publisher hex
+	// (impossible — hex is /[0-9a-f]/ — but cheap insurance).
+	if strings.ContainsAny(name, "/\\") {
+		name = cacheFilePrefix + "invalid"
+	}
+	return filepath.Join(dir, name)
+}

--- a/internal/validator/list/cache_test.go
+++ b/internal/validator/list/cache_test.go
@@ -1,0 +1,180 @@
+package list_test
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/manifest"
+	"github.com/LeJamon/goXRPLd/internal/validator/list"
+)
+
+func TestAggregator_Cache_WriteThenRoundTripLoad(t *testing.T) {
+	pub := newPublisher(t, 0x21, 0x22)
+	v1 := derivedValidatorKey(0x30)
+
+	dir := t.TempDir()
+	pubKey := list.PublisherKey(pub.masterPub)
+
+	// First aggregator: write the cache by applying an accepted list.
+	src, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{pubKey},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New src: %v", err)
+	}
+	if err := src.SetCacheDir(dir); err != nil {
+		t.Fatalf("SetCacheDir: %v", err)
+	}
+
+	now := fixedClock()()
+	exp := now.Add(24 * time.Hour).Unix()
+	blob, sig := pub.signList(t, 7, 0, exp, [][33]byte{v1})
+	if d, _, _ := src.ApplyList(pub.manifestB64, blob, sig, 1, "src://"); d != list.Accepted {
+		t.Fatalf("apply disposition: %s", d)
+	}
+
+	// Cache file must be present at the rippled-conformant path.
+	cachePath := filepath.Join(dir, "cache."+hex.EncodeToString(pub.masterPub[:]))
+	body, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatalf("read cache file: %v", err)
+	}
+
+	// Envelope shape must include rippled-compatible fields.
+	var env struct {
+		Manifest        string `json:"manifest"`
+		PublicKey       string `json:"public_key"`
+		Blob            string `json:"blob"`
+		Signature       string `json:"signature"`
+		Version         uint32 `json:"version"`
+		RefreshInterval uint32 `json:"refresh_interval"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode cache JSON: %v", err)
+	}
+	if env.PublicKey != hex.EncodeToString(pub.masterPub[:]) {
+		t.Fatalf("public_key: got %q want %q", env.PublicKey, hex.EncodeToString(pub.masterPub[:]))
+	}
+	if env.RefreshInterval != 24*60 {
+		t.Fatalf("refresh_interval: got %d want %d", env.RefreshInterval, 24*60)
+	}
+	if env.Version == 0 || env.Manifest == "" || env.Blob == "" || env.Signature == "" {
+		t.Fatalf("v1 envelope must populate manifest/blob/signature/version, got %+v", env)
+	}
+
+	// Second aggregator: hydrate from the same directory and check
+	// the publisher reached StatusAvailable at the expected sequence.
+	dst, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{pubKey},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New dst: %v", err)
+	}
+	if err := dst.SetCacheDir(dir); err != nil {
+		t.Fatalf("SetCacheDir dst: %v", err)
+	}
+	loaded := dst.LoadCache()
+	if loaded != 1 {
+		t.Fatalf("LoadCache: got %d want 1", loaded)
+	}
+	snap := dst.PublisherSnapshot()
+	if len(snap) != 1 {
+		t.Fatalf("PublisherSnapshot: len=%d", len(snap))
+	}
+	if snap[0].Status != list.StatusAvailable {
+		t.Fatalf("status after hydrate: got %s want Available", snap[0].Status)
+	}
+	if snap[0].Sequence != 7 {
+		t.Fatalf("sequence after hydrate: got %d want 7", snap[0].Sequence)
+	}
+}
+
+func TestAggregator_Cache_LoadSkipsAlreadyAvailable(t *testing.T) {
+	pub := newPublisher(t, 0x31, 0x32)
+	v1 := derivedValidatorKey(0x40)
+	v2 := derivedValidatorKey(0x41)
+
+	dir := t.TempDir()
+	pubKey := list.PublisherKey(pub.masterPub)
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{pubKey},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := agg.SetCacheDir(dir); err != nil {
+		t.Fatalf("SetCacheDir: %v", err)
+	}
+
+	now := fixedClock()()
+	exp := now.Add(24 * time.Hour).Unix()
+
+	// Seq 3 lands first and writes the cache.
+	blob3, sig3 := pub.signList(t, 3, 0, exp, [][33]byte{v1})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob3, sig3, 1, "p1://"); d != list.Accepted {
+		t.Fatalf("seq=3 disposition: %s", d)
+	}
+
+	// Seq 9 supersedes — the aggregator is now Available at seq 9 and
+	// the cache file on disk is also at seq 9. Calling LoadCache here
+	// must NOT re-apply seq 9 (or seq 3) over the live state.
+	blob9, sig9 := pub.signList(t, 9, 0, exp, [][33]byte{v1, v2})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob9, sig9, 1, "p1://"); d != list.Accepted {
+		t.Fatalf("seq=9 disposition: %s", d)
+	}
+
+	// LoadCache must skip the publisher because it is already
+	// StatusAvailable, mirroring rippled's loadLists() skip.
+	if loaded := agg.LoadCache(); loaded != 0 {
+		t.Fatalf("LoadCache after Available: got %d want 0", loaded)
+	}
+	snap := agg.PublisherSnapshot()
+	if snap[0].Sequence != 9 {
+		t.Fatalf("sequence drift: got %d want 9", snap[0].Sequence)
+	}
+}
+
+func TestAggregator_Cache_DisabledDirNoFile(t *testing.T) {
+	pub := newPublisher(t, 0x41, 0x42)
+	v1 := derivedValidatorKey(0x50)
+
+	dir := t.TempDir()
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     manifest.NewCache(),
+		Clock:         fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Cache disabled (SetCacheDir never called).
+	now := fixedClock()()
+	exp := now.Add(24 * time.Hour).Unix()
+	blob, sig := pub.signList(t, 1, 0, exp, [][33]byte{v1})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "p1://"); d != list.Accepted {
+		t.Fatalf("apply: %s", d)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("cache dir written without SetCacheDir: %d entries", len(entries))
+	}
+}

--- a/internal/validator/list/disposition.go
+++ b/internal/validator/list/disposition.go
@@ -17,6 +17,18 @@ package list
 // (rippled/src/xrpld/app/misc/ValidatorList.h:55-82): smaller values
 // are "more desirable" outcomes.
 //
+// ORDERING INVARIANT (load-bearing — do not reorder without auditing
+// every consumer of Severity() / ShouldRelay() / Charge()):
+//
+//	Accepted < Expired < Pending < SameSequence < KnownSequence
+//	         < Stale < Untrusted < UnsupportedVersion < Invalid
+//	         < Malformed  (goXRPL-only)
+//
+// `ShouldRelay()` is `Severity() <= KnownSequence.Severity()`, mirroring
+// rippled's `disposition <= ListDisposition::known_sequence` gate at
+// ValidatorList.cpp:973. Re-arranging this iota would silently flip the
+// relay set.
+//
 // Malformed is a goXRPL-only summary disposition emitted exclusively
 // by the HTTP site poller for wire-level envelope failures (HTTP
 // transport error, JSON body undecodable, required envelope fields

--- a/internal/validator/list/disposition.go
+++ b/internal/validator/list/disposition.go
@@ -13,14 +13,12 @@
 package list
 
 // Disposition reports the outcome of applying a single validator list
-// blob. Mirrors rippled's ListDisposition enum
-// (rippled/src/xrpld/app/misc/ValidatorList.h:62-90).
-//
-// The ordering matters: dispositions strictly greater than Pending mean
-// "no state change" (the caller should NOT update publisherLists_),
-// while Accepted / Expired / Pending are all "store-and-act" outcomes
-// (see ValidatorList.cpp:1169 — `if (result > ListDisposition::pending)
-// return early`).
+// blob. The numeric ordering mirrors rippled's ListDisposition
+// (rippled/src/xrpld/app/misc/ValidatorList.h:55-82): smaller values
+// are "more desirable" outcomes. Malformed is goXRPL-only — rippled
+// folds parse / decode failures into invalid; goXRPL keeps the split
+// so the router can distinguish wire-level rejects from cryptographic
+// rejects in its bad-data attribution.
 type Disposition uint8
 
 const (
@@ -49,33 +47,35 @@ const (
 	KnownSequence
 
 	// Stale: the blob's sequence is below our current accepted sequence
-	// from this publisher. Drop silently (the peer hasn't seen our
-	// latest yet, which is fine).
+	// from this publisher.
 	Stale
 
 	// Untrusted: the publisher master key extracted from the manifest is
-	// not in our configured trust set. Per rippled this drops without
-	// charging the peer — a peer may gossip lists from publishers we
-	// don't trust, and that's not malicious.
+	// not in our configured trust set, OR the publisher's manifest is
+	// revoked. Rippled returns untrusted in both cases
+	// (ValidatorList.cpp:1366,1382-1383) — revocation is legitimate
+	// gossip and must not punish the forwarding peer.
 	Untrusted
 
-	// Invalid: the manifest's master/ephemeral signature failed
-	// verification, or the blob's signature failed against the
-	// publisher's current ephemeral key, or the inner JSON is
-	// structurally invalid. Charge the sender for bad data.
-	Invalid
-
 	// UnsupportedVersion: the protocol version field is outside the
-	// supported range (1 or 2). Charge the sender — newer rippled may
-	// emit versions we don't grok, but per rippled we still treat this
-	// as malformed because the wire format itself was rejected.
+	// supported range. Charge the sender.
 	UnsupportedVersion
 
-	// Malformed: the wire message itself could not be parsed (proto
-	// decode failed, blob isn't base64, manifest isn't base64, etc.).
-	// Charge the sender.
+	// Invalid: the blob's signature failed verification, or the inner
+	// JSON is structurally invalid. Charge the sender for bad data.
+	Invalid
+
+	// Malformed: goXRPL-only. The wire envelope itself could not be
+	// parsed (manifest not base64, blob not base64, message decode
+	// failure). Charge the sender.
 	Malformed
 )
+
+// MaxValidRelaySeverity is the upper severity bound (inclusive) for
+// dispositions that warrant rebroadcasting the originating frame.
+// Mirrors rippled's `disposition <= ListDisposition::known_sequence`
+// gate at ValidatorList.cpp:973.
+const MaxValidRelaySeverity = KnownSequence
 
 // String returns a short, lowercase label suitable for logs and metrics.
 func (d Disposition) String() string {
@@ -94,10 +94,10 @@ func (d Disposition) String() string {
 		return "stale"
 	case Untrusted:
 		return "untrusted"
-	case Invalid:
-		return "invalid"
 	case UnsupportedVersion:
 		return "unsupported_version"
+	case Invalid:
+		return "invalid"
 	case Malformed:
 		return "malformed"
 	default:
@@ -105,9 +105,18 @@ func (d Disposition) String() string {
 	}
 }
 
+// Severity returns the numeric "worse-is-larger" rank used to pick
+// summary dispositions (worst-wins for peer bad-data attribution,
+// best-wins for site-poller RPC). The underlying iota ordering is the
+// canonical source; this method exists so callers don't open-code
+// rank tables that drift from the enum.
+func (d Disposition) Severity() int { return int(d) }
+
 // IsBadData reports whether the disposition warrants charging the
 // originating peer for malformed / cryptographically-invalid data.
-// Used by the router to decide whether to call IncPeerBadData.
+// Mirrors the worst-case charge tiers in PeerImp::onValidatorListMessage
+// (PeerImp.cpp:2141-2183). Untrusted / SameSequence / KnownSequence /
+// Stale are charged but at lower tiers — see ChargeCategory.
 func (d Disposition) IsBadData() bool {
 	switch d {
 	case Invalid, UnsupportedVersion, Malformed:
@@ -117,10 +126,49 @@ func (d Disposition) IsBadData() bool {
 	}
 }
 
-// ShouldRelay reports whether an accepted disposition warrants
-// rebroadcasting the originating wire frame to other peers. Mirrors
-// rippled's broadcastBlobs branch in applyListsAndBroadcast — only
-// strictly-accepted lists propagate; expired/pending/same do not.
+// ChargeCategory is the rippled fee tier a disposition maps to in
+// PeerImp::onValidatorListMessage. The router translates this into a
+// distinct label passed to IncPeerBadData so operators can distinguish
+// the misbehavior types in metrics.
+type ChargeCategory uint8
+
+const (
+	// ChargeNone means the disposition is "good data" — no peer charge.
+	ChargeNone ChargeCategory = iota
+	// ChargeUselessData mirrors rippled feeUselessData (light): duplicate
+	// list, untrusted publisher, same/known sequence.
+	ChargeUselessData
+	// ChargeInvalidData mirrors rippled feeInvalidData (medium): stale
+	// list, unsupported version.
+	ChargeInvalidData
+	// ChargeInvalidSignature mirrors rippled feeInvalidSignature
+	// (heaviest): malformed wire / invalid cryptography.
+	ChargeInvalidSignature
+)
+
+// Charge returns the rippled fee tier this disposition maps to in
+// PeerImp::onValidatorListMessage (PeerImp.cpp:2141-2183).
+func (d Disposition) Charge() ChargeCategory {
+	switch d {
+	case Accepted, Expired, Pending:
+		return ChargeNone
+	case SameSequence, KnownSequence, Untrusted:
+		return ChargeUselessData
+	case Stale, UnsupportedVersion:
+		return ChargeInvalidData
+	case Invalid, Malformed:
+		return ChargeInvalidSignature
+	default:
+		return ChargeNone
+	}
+}
+
+// ShouldRelay reports whether the disposition warrants rebroadcasting
+// the originating frame. Mirrors rippled's
+// `broadcast = disposition <= ListDisposition::known_sequence` gate
+// at ValidatorList.cpp:973 — Accepted, Expired, Pending, SameSequence
+// and KnownSequence all relay. Per-peer filtering (skip peers already
+// at the same sequence) is done at broadcast time, not here.
 func (d Disposition) ShouldRelay() bool {
-	return d == Accepted
+	return d.Severity() <= MaxValidRelaySeverity.Severity()
 }

--- a/internal/validator/list/disposition.go
+++ b/internal/validator/list/disposition.go
@@ -15,10 +15,17 @@ package list
 // Disposition reports the outcome of applying a single validator list
 // blob. The numeric ordering mirrors rippled's ListDisposition
 // (rippled/src/xrpld/app/misc/ValidatorList.h:55-82): smaller values
-// are "more desirable" outcomes. Malformed is goXRPL-only — rippled
-// folds parse / decode failures into invalid; goXRPL keeps the split
-// so the router can distinguish wire-level rejects from cryptographic
-// rejects in its bad-data attribution.
+// are "more desirable" outcomes.
+//
+// Malformed is a goXRPL-only summary disposition emitted exclusively
+// by the HTTP site poller for wire-level envelope failures (HTTP
+// transport error, JSON body undecodable, required envelope fields
+// absent). The aggregator itself never returns Malformed: a corrupt
+// publisher manifest folds into Untrusted (rippled
+// ValidatorList.cpp:1363-1366) and a corrupt blob envelope folds into
+// Invalid (rippled ValidatorList.cpp:1386-1392). Malformed is folded
+// back to "invalid" by the RPC adapter so external consumers see only
+// rippled-emitted labels.
 type Disposition uint8
 
 const (
@@ -117,6 +124,10 @@ func (d Disposition) Severity() int { return int(d) }
 // Mirrors the worst-case charge tiers in PeerImp::onValidatorListMessage
 // (PeerImp.cpp:2141-2183). Untrusted / SameSequence / KnownSequence /
 // Stale are charged but at lower tiers — see ChargeCategory.
+//
+// Malformed is poller-only and never reaches a peer-attribution path;
+// it is retained here as a defensive "true" so any accidental router
+// use surfaces as bad data rather than silently passing.
 func (d Disposition) IsBadData() bool {
 	switch d {
 	case Invalid, UnsupportedVersion, Malformed:
@@ -147,16 +158,18 @@ const (
 )
 
 // Charge returns the rippled fee tier this disposition maps to in
-// PeerImp::onValidatorListMessage (PeerImp.cpp:2141-2183).
+// PeerImp::onValidatorListMessage (PeerImp.cpp:2141-2183). Malformed
+// is poller-only (the aggregator never emits it) so it maps to
+// ChargeNone — the poller has no peer to charge.
 func (d Disposition) Charge() ChargeCategory {
 	switch d {
-	case Accepted, Expired, Pending:
+	case Accepted, Expired, Pending, Malformed:
 		return ChargeNone
 	case SameSequence, KnownSequence, Untrusted:
 		return ChargeUselessData
 	case Stale, UnsupportedVersion:
 		return ChargeInvalidData
-	case Invalid, Malformed:
+	case Invalid:
 		return ChargeInvalidSignature
 	default:
 		return ChargeNone

--- a/internal/validator/list/disposition.go
+++ b/internal/validator/list/disposition.go
@@ -1,0 +1,126 @@
+// Package list implements the publisher-trust validator-list subsystem —
+// the rippled-faithful counterpart of rippled/src/xrpld/app/misc/
+// ValidatorList.cpp + ValidatorSite.cpp.
+//
+// A "validator list" is a signed bundle of validator master public keys
+// distributed by an out-of-band publisher (e.g. vl.ripple.com). Operators
+// configure a trusted set of publishers and a threshold; the Aggregator
+// ingests lists (via peer gossip or HTTP polling), verifies the
+// publisher manifest + blob signature, and recomputes the effective
+// trusted UNL as the union of validators present in lists from at least
+// `threshold` distinct trusted publishers. The result is pushed into
+// Adaptor.SetTrustedValidators so the consensus engine sees the delta.
+package list
+
+// Disposition reports the outcome of applying a single validator list
+// blob. Mirrors rippled's ListDisposition enum
+// (rippled/src/xrpld/app/misc/ValidatorList.h:62-90).
+//
+// The ordering matters: dispositions strictly greater than Pending mean
+// "no state change" (the caller should NOT update publisherLists_),
+// while Accepted / Expired / Pending are all "store-and-act" outcomes
+// (see ValidatorList.cpp:1169 — `if (result > ListDisposition::pending)
+// return early`).
+type Disposition uint8
+
+const (
+	// Accepted: the blob is the newest valid list from this publisher and
+	// has been stored. The caller should relay the originating wire
+	// message to other peers (matches rippled applyListsAndBroadcast).
+	Accepted Disposition = iota
+
+	// Expired: the blob is structurally and cryptographically valid but
+	// its expiration is in the past. The publisher entry is still
+	// updated (so the RPC can surface "expired"), but no new validators
+	// are admitted to the trusted set from this list.
+	Expired
+
+	// Pending: a future-dated list whose `effective` time has not yet
+	// arrived. The blob is stored in the publisher's `remaining` queue
+	// and applied when its effective time is reached.
+	Pending
+
+	// SameSequence: we already have a stored list at this exact
+	// sequence. Harmless no-op (peer gossip is lossy and chatty).
+	SameSequence
+
+	// KnownSequence: we already have a pending entry at this sequence.
+	// Equivalent of rippled's known_sequence — no state change.
+	KnownSequence
+
+	// Stale: the blob's sequence is below our current accepted sequence
+	// from this publisher. Drop silently (the peer hasn't seen our
+	// latest yet, which is fine).
+	Stale
+
+	// Untrusted: the publisher master key extracted from the manifest is
+	// not in our configured trust set. Per rippled this drops without
+	// charging the peer — a peer may gossip lists from publishers we
+	// don't trust, and that's not malicious.
+	Untrusted
+
+	// Invalid: the manifest's master/ephemeral signature failed
+	// verification, or the blob's signature failed against the
+	// publisher's current ephemeral key, or the inner JSON is
+	// structurally invalid. Charge the sender for bad data.
+	Invalid
+
+	// UnsupportedVersion: the protocol version field is outside the
+	// supported range (1 or 2). Charge the sender — newer rippled may
+	// emit versions we don't grok, but per rippled we still treat this
+	// as malformed because the wire format itself was rejected.
+	UnsupportedVersion
+
+	// Malformed: the wire message itself could not be parsed (proto
+	// decode failed, blob isn't base64, manifest isn't base64, etc.).
+	// Charge the sender.
+	Malformed
+)
+
+// String returns a short, lowercase label suitable for logs and metrics.
+func (d Disposition) String() string {
+	switch d {
+	case Accepted:
+		return "accepted"
+	case Expired:
+		return "expired"
+	case Pending:
+		return "pending"
+	case SameSequence:
+		return "same_sequence"
+	case KnownSequence:
+		return "known_sequence"
+	case Stale:
+		return "stale"
+	case Untrusted:
+		return "untrusted"
+	case Invalid:
+		return "invalid"
+	case UnsupportedVersion:
+		return "unsupported_version"
+	case Malformed:
+		return "malformed"
+	default:
+		return "unknown"
+	}
+}
+
+// IsBadData reports whether the disposition warrants charging the
+// originating peer for malformed / cryptographically-invalid data.
+// Used by the router to decide whether to call IncPeerBadData.
+func (d Disposition) IsBadData() bool {
+	switch d {
+	case Invalid, UnsupportedVersion, Malformed:
+		return true
+	default:
+		return false
+	}
+}
+
+// ShouldRelay reports whether an accepted disposition warrants
+// rebroadcasting the originating wire frame to other peers. Mirrors
+// rippled's broadcastBlobs branch in applyListsAndBroadcast — only
+// strictly-accepted lists propagate; expired/pending/same do not.
+func (d Disposition) ShouldRelay() bool {
+	return d == Accepted
+}

--- a/internal/validator/list/rpc_adapter.go
+++ b/internal/validator/list/rpc_adapter.go
@@ -108,7 +108,7 @@ func (r *RPCReader) Sites() []rpctypes.ValidatorListSiteInfo {
 			RefreshIntervalMin: (s.RefreshSeconds + 59) / 60,
 		}
 		if s.LastDispositionSet {
-			info.LastDisposition = s.LastDisposition.String()
+			info.LastDisposition = dispositionRPCLabel(s.LastDisposition)
 		}
 		if !s.LastFetched.IsZero() {
 			info.LastRefreshUnix = s.LastFetched.Unix()
@@ -134,6 +134,17 @@ func (r *RPCReader) TrustedMasterKeys() [][33]byte {
 	}
 	_, masters := r.agg.TrustedValidators()
 	return masters
+}
+
+// dispositionRPCLabel returns the wire string for a Disposition as it
+// appears in the validator_list_sites RPC. Folds the goXRPL-only
+// Malformed back into rippled's "invalid" so external consumers parsing
+// rippled's ListDisposition enum see only labels rippled would emit.
+func dispositionRPCLabel(d Disposition) string {
+	if d == Malformed {
+		return Invalid.String()
+	}
+	return d.String()
 }
 
 // encodeNodeKeysBase58 returns base58-encoded NodePublic strings for a

--- a/internal/validator/list/rpc_adapter.go
+++ b/internal/validator/list/rpc_adapter.go
@@ -3,11 +3,16 @@ package list
 import (
 	"encoding/hex"
 	"strings"
-	"time"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	rpctypes "github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
+
+// rippledTimeLayout mirrors rippled's to_string(NetClock::time_point)
+// format `%Y-%b-%d %T %Z` (chrono.h:75-88) — e.g.
+// "2026-May-18 10:30:00 UTC". Used for every timestamp field exposed
+// via the validators / validator_list_sites RPCs.
+const rippledTimeLayout = "2006-Jan-02 15:04:05 UTC"
 
 // RPCReader wraps an *Aggregator so it satisfies the
 // rpctypes.ValidatorListReader interface used by the validators and
@@ -75,11 +80,11 @@ func (r *RPCReader) Publishers() []rpctypes.ValidatorListPublisherInfo {
 		}
 		if !s.Effective.IsZero() {
 			info.EffectiveUnix = s.Effective.Unix()
-			info.EffectiveISO = s.Effective.UTC().Format(time.RFC3339)
+			info.EffectiveISO = s.Effective.UTC().Format(rippledTimeLayout)
 		}
 		if !s.Expiration.IsZero() {
 			info.ExpirationUnix = s.Expiration.Unix()
-			info.ExpirationISO = s.Expiration.UTC().Format(time.RFC3339)
+			info.ExpirationISO = s.Expiration.UTC().Format(rippledTimeLayout)
 		}
 		out = append(out, info)
 	}
@@ -104,14 +109,14 @@ func (r *RPCReader) Sites() []rpctypes.ValidatorListSiteInfo {
 		}
 		if !s.LastFetched.IsZero() {
 			info.LastRefreshUnix = s.LastFetched.Unix()
-			info.LastRefreshISO = s.LastFetched.UTC().Format(time.RFC3339)
+			info.LastRefreshISO = s.LastFetched.UTC().Format(rippledTimeLayout)
 		}
 		if !s.LastSuccess.IsZero() {
 			info.LastSuccessUnix = s.LastSuccess.Unix()
 		}
 		if !s.NextRefresh.IsZero() {
 			info.NextRefreshUnix = s.NextRefresh.Unix()
-			info.NextRefreshISO = s.NextRefresh.UTC().Format(time.RFC3339)
+			info.NextRefreshISO = s.NextRefresh.UTC().Format(rippledTimeLayout)
 		}
 		out = append(out, info)
 	}

--- a/internal/validator/list/rpc_adapter.go
+++ b/internal/validator/list/rpc_adapter.go
@@ -105,7 +105,11 @@ func (r *RPCReader) Sites() []rpctypes.ValidatorListSiteInfo {
 			LastError:          s.LastError,
 			LastDispositionSet: s.LastDispositionSet,
 			RefreshIntervalSec: s.RefreshSeconds,
-			RefreshIntervalMin: (s.RefreshSeconds + 59) / 60,
+			// Truncate (not ceiling) to match rippled which stores
+			// `std::chrono::minutes` directly — no sub-minute precision
+			// exists upstream so the rounding mode matters only for the
+			// never-clamped initial value (0 → 0).
+			RefreshIntervalMin: s.RefreshSeconds / 60,
 		}
 		if s.LastDispositionSet {
 			info.LastDisposition = dispositionRPCLabel(s.LastDisposition)

--- a/internal/validator/list/rpc_adapter.go
+++ b/internal/validator/list/rpc_adapter.go
@@ -103,9 +103,12 @@ func (r *RPCReader) Sites() []rpctypes.ValidatorListSiteInfo {
 		info := rpctypes.ValidatorListSiteInfo{
 			URI:                s.URI,
 			LastError:          s.LastError,
-			LastDisposition:    s.LastDisposition.String(),
+			LastDispositionSet: s.LastDispositionSet,
 			RefreshIntervalSec: s.RefreshSeconds,
 			RefreshIntervalMin: (s.RefreshSeconds + 59) / 60,
+		}
+		if s.LastDispositionSet {
+			info.LastDisposition = s.LastDisposition.String()
 		}
 		if !s.LastFetched.IsZero() {
 			info.LastRefreshUnix = s.LastFetched.Unix()

--- a/internal/validator/list/rpc_adapter.go
+++ b/internal/validator/list/rpc_adapter.go
@@ -1,0 +1,117 @@
+package list
+
+import (
+	"encoding/hex"
+	"strings"
+
+	rpctypes "github.com/LeJamon/goXRPLd/internal/rpc/types"
+)
+
+// RPCReader wraps an *Aggregator so it satisfies the
+// rpctypes.ValidatorListReader interface used by the validators and
+// validator_list_sites RPC methods. Lives in this package (not in
+// internal/rpc) so the dependency direction stays
+// rpc → validator/list, never the reverse.
+//
+// Always pass through nil-safely: a nil *RPCReader returns the same
+// empty-shape responses the legacy stub did, which lets server bootstrap
+// install the adapter unconditionally and have it degrade gracefully
+// when no publisher trust is configured.
+type RPCReader struct {
+	agg *Aggregator
+}
+
+// NewRPCReader constructs an RPCReader. Passing nil is allowed and
+// yields an inert reader.
+func NewRPCReader(agg *Aggregator) *RPCReader {
+	return &RPCReader{agg: agg}
+}
+
+// HasConfiguredPublishers reports whether the underlying aggregator was
+// initialized with at least one publisher key.
+func (r *RPCReader) HasConfiguredPublishers() bool {
+	if r == nil || r.agg == nil {
+		return false
+	}
+	return r.agg.HasConfiguredPublishers()
+}
+
+// PublisherCount returns the number of configured publishers in the
+// aggregator's trust set.
+func (r *RPCReader) PublisherCount() int {
+	if r == nil || r.agg == nil {
+		return 0
+	}
+	return r.agg.PublisherCount()
+}
+
+// Threshold returns the configured publisher threshold.
+func (r *RPCReader) Threshold() int {
+	if r == nil || r.agg == nil {
+		return 0
+	}
+	return r.agg.Threshold()
+}
+
+// Publishers translates the aggregator's PublisherSnapshot into the
+// RPC-facing ValidatorListPublisherInfo shape.
+func (r *RPCReader) Publishers() []rpctypes.ValidatorListPublisherInfo {
+	if r == nil || r.agg == nil {
+		return nil
+	}
+	snap := r.agg.PublisherSnapshot()
+	out := make([]rpctypes.ValidatorListPublisherInfo, 0, len(snap))
+	for _, s := range snap {
+		info := rpctypes.ValidatorListPublisherInfo{
+			PublicKey:      strings.ToUpper(hex.EncodeToString(s.MasterKey[:])),
+			Status:         s.Status.String(),
+			Sequence:       s.Sequence,
+			ValidatorCount: len(s.Validators),
+			SiteURI:        s.SiteURI,
+		}
+		if !s.Effective.IsZero() {
+			info.EffectiveUnix = s.Effective.Unix()
+		}
+		if !s.Expiration.IsZero() {
+			info.ExpirationUnix = s.Expiration.Unix()
+		}
+		out = append(out, info)
+	}
+	return out
+}
+
+// Sites translates the aggregator's SiteSnapshot into the RPC-facing
+// ValidatorListSiteInfo shape.
+func (r *RPCReader) Sites() []rpctypes.ValidatorListSiteInfo {
+	if r == nil || r.agg == nil {
+		return nil
+	}
+	snap := r.agg.SiteSnapshot()
+	out := make([]rpctypes.ValidatorListSiteInfo, 0, len(snap))
+	for _, s := range snap {
+		info := rpctypes.ValidatorListSiteInfo{
+			URI:                s.URI,
+			LastError:          s.LastError,
+			LastDisposition:    s.LastDisposition.String(),
+			RefreshIntervalSec: s.RefreshSeconds,
+		}
+		if !s.LastFetched.IsZero() {
+			info.LastRefreshUnix = s.LastFetched.Unix()
+		}
+		if !s.LastSuccess.IsZero() {
+			info.LastSuccessUnix = s.LastSuccess.Unix()
+		}
+		out = append(out, info)
+	}
+	return out
+}
+
+// TrustedMasterKeys returns the publisher-contributed validator master
+// keys currently in the effective trusted UNL.
+func (r *RPCReader) TrustedMasterKeys() [][33]byte {
+	if r == nil || r.agg == nil {
+		return nil
+	}
+	_, masters := r.agg.TrustedValidators()
+	return masters
+}

--- a/internal/validator/list/rpc_adapter.go
+++ b/internal/validator/list/rpc_adapter.go
@@ -3,7 +3,9 @@ package list
 import (
 	"encoding/hex"
 	"strings"
+	"time"
 
+	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	rpctypes "github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
@@ -63,17 +65,21 @@ func (r *RPCReader) Publishers() []rpctypes.ValidatorListPublisherInfo {
 	out := make([]rpctypes.ValidatorListPublisherInfo, 0, len(snap))
 	for _, s := range snap {
 		info := rpctypes.ValidatorListPublisherInfo{
-			PublicKey:      strings.ToUpper(hex.EncodeToString(s.MasterKey[:])),
-			Status:         s.Status.String(),
-			Sequence:       s.Sequence,
-			ValidatorCount: len(s.Validators),
-			SiteURI:        s.SiteURI,
+			PublicKeyHex:     strings.ToUpper(hex.EncodeToString(s.MasterKey[:])),
+			Available:        s.Status == StatusAvailable,
+			Status:           s.Status.String(),
+			Sequence:         s.Sequence,
+			Version:          s.Version,
+			SiteURI:          s.SiteURI,
+			ValidatorsBase58: encodeNodeKeysBase58(s.Validators),
 		}
 		if !s.Effective.IsZero() {
 			info.EffectiveUnix = s.Effective.Unix()
+			info.EffectiveISO = s.Effective.UTC().Format(time.RFC3339)
 		}
 		if !s.Expiration.IsZero() {
 			info.ExpirationUnix = s.Expiration.Unix()
+			info.ExpirationISO = s.Expiration.UTC().Format(time.RFC3339)
 		}
 		out = append(out, info)
 	}
@@ -94,12 +100,18 @@ func (r *RPCReader) Sites() []rpctypes.ValidatorListSiteInfo {
 			LastError:          s.LastError,
 			LastDisposition:    s.LastDisposition.String(),
 			RefreshIntervalSec: s.RefreshSeconds,
+			RefreshIntervalMin: (s.RefreshSeconds + 59) / 60,
 		}
 		if !s.LastFetched.IsZero() {
 			info.LastRefreshUnix = s.LastFetched.Unix()
+			info.LastRefreshISO = s.LastFetched.UTC().Format(time.RFC3339)
 		}
 		if !s.LastSuccess.IsZero() {
 			info.LastSuccessUnix = s.LastSuccess.Unix()
+		}
+		if !s.NextRefresh.IsZero() {
+			info.NextRefreshUnix = s.NextRefresh.Unix()
+			info.NextRefreshISO = s.NextRefresh.UTC().Format(time.RFC3339)
 		}
 		out = append(out, info)
 	}
@@ -114,4 +126,24 @@ func (r *RPCReader) TrustedMasterKeys() [][33]byte {
 	}
 	_, masters := r.agg.TrustedValidators()
 	return masters
+}
+
+// encodeNodeKeysBase58 returns base58-encoded NodePublic strings for a
+// slice of 33-byte master keys. Entries that fail to encode (wrong
+// length, etc.) are skipped silently — the alternative would be to
+// return an error from a read-only RPC adapter, which doesn't match
+// the rest of the interface.
+func encodeNodeKeysBase58(keys [][33]byte) []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		enc, err := addresscodec.EncodeNodePublicKey(k[:])
+		if err != nil {
+			continue
+		}
+		out = append(out, enc)
+	}
+	return out
 }

--- a/internal/validator/list/rpc_adapter.go
+++ b/internal/validator/list/rpc_adapter.go
@@ -35,8 +35,6 @@ func NewRPCReader(agg *Aggregator) *RPCReader {
 	return &RPCReader{agg: agg}
 }
 
-// HasConfiguredPublishers reports whether the underlying aggregator was
-// initialized with at least one publisher key.
 func (r *RPCReader) HasConfiguredPublishers() bool {
 	if r == nil || r.agg == nil {
 		return false
@@ -44,8 +42,6 @@ func (r *RPCReader) HasConfiguredPublishers() bool {
 	return r.agg.HasConfiguredPublishers()
 }
 
-// PublisherCount returns the number of configured publishers in the
-// aggregator's trust set.
 func (r *RPCReader) PublisherCount() int {
 	if r == nil || r.agg == nil {
 		return 0
@@ -53,7 +49,6 @@ func (r *RPCReader) PublisherCount() int {
 	return r.agg.PublisherCount()
 }
 
-// Threshold returns the configured publisher threshold.
 func (r *RPCReader) Threshold() int {
 	if r == nil || r.agg == nil {
 		return 0
@@ -61,8 +56,6 @@ func (r *RPCReader) Threshold() int {
 	return r.agg.Threshold()
 }
 
-// Publishers translates the aggregator's PublisherSnapshot into the
-// RPC-facing ValidatorListPublisherInfo shape.
 func (r *RPCReader) Publishers() []rpctypes.ValidatorListPublisherInfo {
 	if r == nil || r.agg == nil {
 		return nil
@@ -129,8 +122,6 @@ func (r *RPCReader) Publishers() []rpctypes.ValidatorListPublisherInfo {
 	return out
 }
 
-// Sites translates the aggregator's SiteSnapshot into the RPC-facing
-// ValidatorListSiteInfo shape.
 func (r *RPCReader) Sites() []rpctypes.ValidatorListSiteInfo {
 	if r == nil || r.agg == nil {
 		return nil

--- a/internal/validator/list/rpc_adapter.go
+++ b/internal/validator/list/rpc_adapter.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"encoding/hex"
+	"sort"
 	"strings"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
@@ -77,14 +78,51 @@ func (r *RPCReader) Publishers() []rpctypes.ValidatorListPublisherInfo {
 			Version:          s.Version,
 			SiteURI:          s.SiteURI,
 			ValidatorsBase58: encodeNodeKeysBase58(s.Validators),
+			EffectiveSet:     s.EffectiveSet,
 		}
-		if !s.Effective.IsZero() {
+		// Mirrors rippled ValidatorList.cpp:1682-1683 which gates the
+		// JSON emit on `validFrom != TimeKeeper::time_point{}`. The Go
+		// zero-value time.Time is not a usable sentinel here because
+		// rippleSecondsToUnix(0) resolves to year 2000.
+		if s.EffectiveSet && !s.Effective.IsZero() {
 			info.EffectiveUnix = s.Effective.Unix()
 			info.EffectiveISO = s.Effective.UTC().Format(rippledTimeLayout)
 		}
 		if !s.Expiration.IsZero() {
 			info.ExpirationUnix = s.Expiration.Unix()
 			info.ExpirationISO = s.Expiration.UTC().Format(rippledTimeLayout)
+		}
+		// Mirror rippled's `remaining` array per publisher
+		// (ValidatorList.cpp:1699-1713). Each entry is the future-dated
+		// list waiting to be promoted into the current slot. Sorted by
+		// sequence for stable RPC output.
+		if len(s.Remaining) > 0 {
+			seqs := make([]uint32, 0, len(s.Remaining))
+			for seq := range s.Remaining {
+				seqs = append(seqs, seq)
+			}
+			sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
+			rem := make([]rpctypes.ValidatorListRemainingInfo, 0, len(seqs))
+			for _, seq := range seqs {
+				p := s.Remaining[seq]
+				e := rpctypes.ValidatorListRemainingInfo{
+					Sequence:         p.Sequence,
+					Version:          p.Version,
+					SiteURI:          p.SiteURI,
+					EffectiveSet:     p.EffectiveSet,
+					ValidatorsBase58: encodeNodeKeysBase58(p.Validators),
+				}
+				if p.EffectiveSet && !p.Effective.IsZero() {
+					e.EffectiveUnix = p.Effective.Unix()
+					e.EffectiveISO = p.Effective.UTC().Format(rippledTimeLayout)
+				}
+				if !p.Expiration.IsZero() {
+					e.ExpirationUnix = p.Expiration.Unix()
+					e.ExpirationISO = p.Expiration.UTC().Format(rippledTimeLayout)
+				}
+				rem = append(rem, e)
+			}
+			info.Remaining = rem
 		}
 		out = append(out, info)
 	}

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -37,6 +37,10 @@ const DefaultMaxRefresh = 24 * time.Hour
 // 30s in ValidatorSite::activeFetcher; we mirror.
 const DefaultRequestTimeout = 30 * time.Second
 
+// MaxRedirects caps the number of HTTP redirects followed during a
+// single fetch. Matches rippled ValidatorSite.cpp:36 `max_redirects = 3`.
+const MaxRedirects = 3
+
 // ErrorRetryInterval is the cadence used to retry a failed fetch
 // (network error, non-2xx status, JSON decode failure). Mirrors
 // rippled's error_retry_interval at ValidatorSite.cpp:35 and the
@@ -101,6 +105,12 @@ func NewSitePoller(uris []string, agg *Aggregator, logger *slog.Logger) *SitePol
 		aggregator: agg,
 		client: &http.Client{
 			Timeout: DefaultRequestTimeout,
+			CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+				if len(via) >= MaxRedirects {
+					return fmt.Errorf("stopped after %d redirects", MaxRedirects)
+				}
+				return nil
+			},
 		},
 		logger:   logger,
 		interval: DefaultRefreshInterval,
@@ -194,6 +204,13 @@ func (p *SitePoller) runOne(ctx context.Context, uri string) {
 //   - Otherwise: zero, meaning "keep using the caller's interval".
 func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duration {
 	now := time.Now().UTC()
+	// Schedule the next refresh time BEFORE the fetch begins, mirroring
+	// rippled's onTimer ordering (ValidatorSite.cpp:354-355) so the RPC
+	// reports the upcoming wakeup even while this fetch is outstanding.
+	// Errors and per-publisher overrides reset NextRefresh in the
+	// UpdateSiteState call below.
+	p.aggregator.SetNextRefresh(uri, now.Add(p.interval))
+
 	body, err := p.fetch(ctx, uri)
 	if err != nil {
 		p.logger.Warn("validator list site fetch failed",
@@ -210,8 +227,16 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 		return ErrorRetryInterval
 	}
 
+	// Rippled ValidatorSite.cpp:391-393 requires `version` to be a
+	// present integer; a missing field fails validation and is logged
+	// as "missing fields". Treat a zero/absent version as Malformed so
+	// the RPC reports a real disposition rather than silently coercing
+	// the envelope into v1.
 	if env.Version == 0 {
-		env.Version = 1
+		msg := "envelope missing required `version` field"
+		p.logger.Warn(msg, "uri", uri)
+		p.aggregator.UpdateSiteState(uri, now, time.Time{}, msg, Malformed, 0, now.Add(ErrorRetryInterval))
+		return ErrorRetryInterval
 	}
 
 	var disp Disposition

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -37,16 +37,22 @@ const DefaultMaxRefresh = 24 * time.Hour
 // 30s in ValidatorSite::activeFetcher; we mirror.
 const DefaultRequestTimeout = 30 * time.Second
 
+// ErrorRetryInterval is the cadence used to retry a failed fetch
+// (network error, non-2xx status, JSON decode failure). Mirrors
+// rippled's error_retry_interval at ValidatorSite.cpp:35 and the
+// onError(...,retry=true) branch at ValidatorSite.cpp:555-561.
+const ErrorRetryInterval = 30 * time.Second
+
 // envelopeJSON is the JSON shape published at vl.* URLs (and the
 // equivalent file:// payloads). Decoded from the HTTP response body.
 type envelopeJSON struct {
-	Manifest      string             `json:"manifest"`
-	Blob          string             `json:"blob,omitempty"`
-	Signature     string             `json:"signature,omitempty"`
-	Version       uint32             `json:"version"`
-	PublicKey     string             `json:"public_key,omitempty"`
-	BlobsV2       []envelopeBlobJSON `json:"blobs_v2,omitempty"`
-	RefreshSecs   int                `json:"refresh_interval,omitempty"`
+	Manifest    string             `json:"manifest"`
+	Blob        string             `json:"blob,omitempty"`
+	Signature   string             `json:"signature,omitempty"`
+	Version     uint32             `json:"version"`
+	PublicKey   string             `json:"public_key,omitempty"`
+	BlobsV2     []envelopeBlobJSON `json:"blobs_v2,omitempty"`
+	RefreshSecs int                `json:"refresh_interval,omitempty"`
 }
 
 // envelopeBlobJSON is a v2 collection entry inside the JSON envelope.
@@ -170,26 +176,27 @@ func (p *SitePoller) runOne(ctx context.Context, uri string) {
 // aggregator (last-fetched / last-error / disposition) regardless of
 // outcome so the validator_list_sites RPC reflects every attempt.
 //
-// Returns the next refresh interval to use — derived from the
-// envelope's refresh_interval field when present (clamped to
-// [DefaultMinRefresh, DefaultMaxRefresh]), else zero to keep the
-// caller-supplied interval.
+// Returns the next refresh interval to use:
+//   - On fetch / decode failure: ErrorRetryInterval (30s), mirroring
+//     rippled's error_retry_interval.
+//   - On success with an envelope refresh_interval: the clamped value.
+//   - Otherwise: zero, meaning "keep using the caller's interval".
 func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duration {
 	now := time.Now().UTC()
 	body, err := p.fetch(ctx, uri)
 	if err != nil {
 		p.logger.Warn("validator list site fetch failed",
 			"uri", uri, "error", err)
-		p.aggregator.UpdateSiteState(uri, now, time.Time{}, err.Error(), Malformed, 0)
-		return 0
+		p.aggregator.UpdateSiteState(uri, now, time.Time{}, err.Error(), Malformed, 0, now.Add(ErrorRetryInterval))
+		return ErrorRetryInterval
 	}
 
 	var env envelopeJSON
 	if err := json.Unmarshal(body, &env); err != nil {
 		msg := fmt.Sprintf("envelope JSON decode: %v", err)
 		p.logger.Warn(msg, "uri", uri)
-		p.aggregator.UpdateSiteState(uri, now, time.Time{}, msg, Malformed, 0)
-		return 0
+		p.aggregator.UpdateSiteState(uri, now, time.Time{}, msg, Malformed, 0, now.Add(ErrorRetryInterval))
+		return ErrorRetryInterval
 	}
 
 	if env.Version == 0 {
@@ -247,7 +254,15 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 	} else {
 		lastErr = "disposition=" + disp.String()
 	}
-	p.aggregator.UpdateSiteState(uri, now, lastSuccess, lastErr, disp, refreshSec)
+	// nextInterval is 0 here when no per-publisher refresh override was
+	// present in the envelope; in that case the caller will reuse its
+	// configured interval. Compute the wall-clock next refresh for the
+	// validator_list_sites RPC accordingly.
+	scheduled := nextInterval
+	if scheduled == 0 {
+		scheduled = p.interval
+	}
+	p.aggregator.UpdateSiteState(uri, now, lastSuccess, lastErr, disp, refreshSec, now.Add(scheduled))
 
 	return nextInterval
 }
@@ -293,32 +308,17 @@ func (p *SitePoller) fetch(ctx context.Context, uri string) ([]byte, error) {
 }
 
 // bestDisposition reduces a collection of dispositions to the single
-// summary the caller (RPC, logs) sees. Order of preference:
-// Accepted > Expired > Pending > SameSequence > KnownSequence > Stale
-// > Untrusted > Invalid > UnsupportedVersion > Malformed. Mirrors
-// rippled's PublisherListStats best-of-many reduction.
+// summary the caller (RPC, logs) sees, using Disposition.Severity as
+// the canonical "lower-is-better" ordering. Mirrors rippled's
+// PublisherListStats best-of-many reduction.
 func bestDisposition(dispList []Disposition) Disposition {
 	if len(dispList) == 0 {
 		return Malformed
 	}
-	rank := map[Disposition]int{
-		Accepted:           0,
-		Expired:            1,
-		Pending:            2,
-		SameSequence:       3,
-		KnownSequence:      4,
-		Stale:              5,
-		Untrusted:          6,
-		Invalid:            7,
-		UnsupportedVersion: 8,
-		Malformed:          9,
-	}
 	best := dispList[0]
-	bestRank := rank[best]
 	for _, d := range dispList[1:] {
-		if r, ok := rank[d]; ok && r < bestRank {
+		if d.Severity() < best.Severity() {
 			best = d
-			bestRank = r
 		}
 	}
 	return best

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -19,9 +19,7 @@ import (
 
 // DefaultRefreshInterval matches rippled's
 // ValidatorSite::default_refresh_interval — 5 minutes between polls of
-// a configured publisher URL. Operators rarely override; the publisher
-// JSON envelope may carry a per-site refresh override which the poller
-// honors within [DefaultMinRefresh, DefaultMaxRefresh].
+// a configured publisher URL.
 const DefaultRefreshInterval = 5 * time.Minute
 
 // DefaultMinRefresh is the floor applied to a publisher-supplied
@@ -33,30 +31,27 @@ const DefaultMinRefresh = 1 * time.Minute
 // refresh interval. 24 hours matches rippled.
 const DefaultMaxRefresh = 24 * time.Hour
 
-// DefaultRequestTimeout caps a single HTTP fetch attempt. Rippled uses
-// 30s in ValidatorSite::activeFetcher; we mirror.
-const DefaultRequestTimeout = 30 * time.Second
+// DefaultRequestTimeout caps a single HTTP fetch attempt. Mirrors
+// rippled's ValidatorSite constructor default at
+// rippled/src/xrpld/app/misc/ValidatorSite.h:142-145
+// (`std::chrono::seconds timeout = std::chrono::seconds{20}`).
+const DefaultRequestTimeout = 20 * time.Second
 
 // MaxRedirects caps the number of HTTP redirects followed during a
 // single fetch. Matches rippled ValidatorSite.cpp:36 `max_redirects = 3`.
 const MaxRedirects = 3
 
-// ErrorRetryInterval is the cadence used to retry a failed fetch
-// (network error, non-2xx status, JSON decode failure). Mirrors
-// rippled's error_retry_interval at ValidatorSite.cpp:35 and the
-// onError(...,retry=true) branch at ValidatorSite.cpp:555-561.
+// ErrorRetryInterval is the cadence used to retry a failed fetch.
+// Mirrors rippled's error_retry_interval at ValidatorSite.cpp:35.
 const ErrorRetryInterval = 30 * time.Second
 
+// missingFieldsMessage mirrors rippled's exception text from
+// ValidatorSite.cpp::parseJsonResponse ("Missing fields in JSON
+// response") so external monitors keyed on the literal string match.
+const missingFieldsMessage = "Missing fields in JSON response"
+
 // envelopeJSON is the JSON shape published at vl.* URLs (and the
-// equivalent file:// payloads). Decoded from the HTTP response body.
-//
-// RefreshMinutes mirrors rippled's `refresh_interval` field which is
-// parsed as `std::chrono::minutes{body[jss::refresh_interval].asUInt()}`
-// (ValidatorSite.cpp:484-489). Stored as float64 to match rippled's
-// isNumeric() tolerance: integer or fractional JSON values are accepted
-// and truncated to whole minutes via asUInt() in rippled, via
-// int(RefreshMinutes) here. Keep the wire-side unit explicit in the
-// field name so future readers do not redo this conformance check.
+// equivalent file:// payloads).
 type envelopeJSON struct {
 	Manifest       string             `json:"manifest"`
 	Blob           string             `json:"blob,omitempty"`
@@ -74,94 +69,169 @@ type envelopeBlobJSON struct {
 	Signature string `json:"signature"`
 }
 
+// siteState tracks the per-URL scheduling cursor inside the poller.
+// Mirrors the fields rippled's `setTimer` consults to pick the next
+// site to fetch (ValidatorSite.cpp:213-228).
+type siteState struct {
+	uri         string
+	interval    time.Duration
+	nextRefresh time.Time
+}
+
 // SitePoller fetches publisher list URLs on a periodic cadence and
 // feeds the parsed envelopes into an Aggregator. Mirrors rippled's
-// ValidatorSite at rippled/src/xrpld/app/misc/ValidatorSite.cpp.
-//
-// One goroutine per configured URL; per-URL state (next refresh time,
-// last error) lives on the Aggregator so the validator_list_sites RPC
-// can read it without traversing the poller's internals.
+// ValidatorSite. Fetches are serialized through a single timer-driven
+// goroutine: rippled's `fetching_` flag guarantees at most one
+// in-flight request across all sites (ValidatorSite.cpp:236, 625-629),
+// and the BroadcastLatest hand-off on the success path is correct only
+// under that same exclusion.
 type SitePoller struct {
-	uris       []string
 	aggregator *Aggregator
 	client     *http.Client
 	logger     *slog.Logger
 	interval   time.Duration
 
-	wg   sync.WaitGroup
-	stop chan struct{}
+	mu    sync.Mutex
+	sites []*siteState
+	wg    sync.WaitGroup
+	stop  chan struct{}
 }
 
-// NewSitePoller constructs a poller for the given URLs. Passing zero
-// URLs yields an inert poller — Run / Stop are still safe to call.
-// Passing a nil aggregator panics: the poller has nowhere to deliver
-// what it fetches.
-func NewSitePoller(uris []string, agg *Aggregator, logger *slog.Logger) *SitePoller {
+// NewSitePoller constructs a poller for the given URLs. Each URL is
+// validated up front, mirroring rippled's `ValidatorSite::load()` which
+// rejects unparseable / invalid URIs at startup
+// (ValidatorSite.cpp:147-159 + Resource constructor at
+// ValidatorSite.cpp:38-75). Returns an error on the first invalid URI
+// so misconfiguration surfaces immediately rather than only after the
+// first periodic fetch fails. Passing a nil aggregator panics: the
+// poller has nowhere to deliver what it fetches.
+func NewSitePoller(uris []string, agg *Aggregator, logger *slog.Logger) (*SitePoller, error) {
 	if agg == nil {
 		panic("validator/list: SitePoller requires non-nil Aggregator")
 	}
 	if logger == nil {
 		logger = slog.Default().With("component", "validator-list-site-poller")
 	}
-	return &SitePoller{
-		uris:       uris,
-		aggregator: agg,
-		client: &http.Client{
-			Timeout: DefaultRequestTimeout,
-			CheckRedirect: func(_ *http.Request, via []*http.Request) error {
-				if len(via) >= MaxRedirects {
-					return fmt.Errorf("stopped after %d redirects", MaxRedirects)
-				}
-				return nil
-			},
-		},
-		logger:   logger,
-		interval: DefaultRefreshInterval,
-		stop:     make(chan struct{}),
+	sites := make([]*siteState, 0, len(uris))
+	for _, u := range uris {
+		if err := validateSiteURI(u); err != nil {
+			return nil, fmt.Errorf("invalid validator site uri %q: %w", u, err)
+		}
+		sites = append(sites, &siteState{uri: u, interval: DefaultRefreshInterval})
 	}
+	p := &SitePoller{
+		aggregator: agg,
+		logger:     logger,
+		interval:   DefaultRefreshInterval,
+		sites:      sites,
+		stop:       make(chan struct{}),
+	}
+	p.client = &http.Client{
+		Timeout:       DefaultRequestTimeout,
+		CheckRedirect: checkRedirect,
+	}
+	return p, nil
 }
 
-// SetInterval overrides the default poll interval. Useful for tests that
-// don't want to wait 5 minutes between fetches; production callers
-// rarely override.
-//
-// MUST be called before Start — there is no synchronization between
-// runOne goroutines and these setters.
+// validateSiteURI mirrors rippled's
+// `ValidatorSite::Site::Resource::Resource(std::string uri)` at
+// rippled/src/xrpld/app/misc/detail/ValidatorSite.cpp:38-75. Rejects:
+//   - unparseable URIs
+//   - file:// with a non-empty host (`file://ripple.com/...`)
+//   - file:// with an empty path
+//   - http:// / https:// without a hostname
+//   - any scheme other than file, http, https
+func validateSiteURI(uri string) error {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("cannot be parsed: %w", err)
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "file":
+		if parsed.Host != "" {
+			return errors.New("file URI cannot contain a hostname")
+		}
+		if parsed.Path == "" {
+			return errors.New("file URI must contain a path")
+		}
+	case "http", "https":
+		if parsed.Host == "" {
+			return fmt.Errorf("%s URI must contain a hostname", parsed.Scheme)
+		}
+	case "":
+		return errors.New("missing scheme")
+	default:
+		return fmt.Errorf("unsupported scheme: %q", parsed.Scheme)
+	}
+	return nil
+}
+
+// checkRedirect is the redirect policy applied to every HTTP fetch.
+// Caps the chain at MaxRedirects and rejects any redirect target whose
+// scheme is not http/https — mirrors rippled's processRedirect at
+// rippled/src/xrpld/app/misc/detail/ValidatorSite.cpp:511-531. Without
+// the scheme gate an attacker controlling the publisher hostname (or
+// any intermediate redirect target) could send the fetcher at a
+// `file:///etc/passwd` URL and read arbitrary local files.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= MaxRedirects {
+		return fmt.Errorf("max redirects (%d) exceeded", MaxRedirects)
+	}
+	scheme := strings.ToLower(req.URL.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("invalid scheme in redirect %q", scheme)
+	}
+	return nil
+}
+
+// SetInterval overrides the default poll interval. Useful for tests
+// that don't want to wait 5 minutes between fetches; production
+// callers rarely override. MUST be called before Start.
 func (p *SitePoller) SetInterval(d time.Duration) {
 	if d <= 0 {
 		return
 	}
 	p.interval = d
-}
-
-// SetHTTPClient overrides the HTTP client. Useful for tests that wire
-// a custom Transport (e.g. recording requests in-memory).
-//
-// MUST be called before Start — there is no synchronization between
-// runOne goroutines and these setters.
-func (p *SitePoller) SetHTTPClient(c *http.Client) {
-	if c != nil {
-		p.client = c
+	for _, s := range p.sites {
+		s.interval = d
 	}
 }
 
-// Start launches one goroutine per configured URL. Each goroutine
-// performs an immediate fetch (so the initial trust set is populated
-// without waiting one refresh period) then loops on the configured
-// interval. Safe to call once; subsequent calls are no-ops while the
-// poller is running.
-func (p *SitePoller) Start(ctx context.Context) {
-	if len(p.uris) == 0 {
+// SetHTTPClient overrides the HTTP client. The CheckRedirect / Timeout
+// fields are forced to the poller defaults so caller-supplied clients
+// cannot inadvertently widen the redirect/scheme attack surface.
+// MUST be called before Start.
+func (p *SitePoller) SetHTTPClient(c *http.Client) {
+	if c == nil {
 		return
 	}
-	for _, u := range p.uris {
-		p.wg.Add(1)
-		go p.runOne(ctx, u)
+	c.CheckRedirect = checkRedirect
+	if c.Timeout == 0 {
+		c.Timeout = DefaultRequestTimeout
 	}
+	p.client = c
 }
 
-// Stop signals all polling goroutines to exit and blocks until they
-// have. Safe to call multiple times; idempotent.
+// Start launches the polling goroutine. The goroutine drives all
+// configured sites serially through a single timer, mirroring rippled's
+// `setTimer` / `fetching_` exclusion at
+// rippled/src/xrpld/app/misc/detail/ValidatorSite.cpp:208-228. The
+// first iteration fires immediately (nextRefresh defaults to the zero
+// time) so a fresh boot has up-to-date publisher state without waiting
+// one full interval — matches rippled's constructor at
+// ValidatorSite.cpp:82 (`nextRefresh{clock_type::now()}`).
+//
+// Safe to call once; subsequent calls are no-ops.
+func (p *SitePoller) Start(ctx context.Context) {
+	if len(p.sites) == 0 {
+		return
+	}
+	p.wg.Add(1)
+	go p.runLoop(ctx)
+}
+
+// Stop signals the polling goroutine to exit and blocks until it has.
+// Safe to call multiple times; idempotent.
 func (p *SitePoller) Stop() {
 	select {
 	case <-p.stop:
@@ -172,90 +242,106 @@ func (p *SitePoller) Stop() {
 	p.wg.Wait()
 }
 
-func (p *SitePoller) runOne(ctx context.Context, uri string) {
+// runLoop drives the timer pattern: pick the site with the smallest
+// nextRefresh, sleep until then, fetch it, update its nextRefresh,
+// repeat. The single-goroutine design matches rippled's setTimer and
+// avoids parallel BroadcastLatest races when two sites simultaneously
+// deliver the same publisher's list.
+func (p *SitePoller) runLoop(ctx context.Context) {
 	defer p.wg.Done()
 
-	interval := p.interval
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
 	for {
-		// Immediate fetch on entry, then sleep — so a fresh boot has
-		// up-to-date publisher state without waiting one full
-		// interval.
-		nextInterval := p.fetchAndApply(ctx, uri)
-		if nextInterval > 0 {
-			interval = nextInterval
+		next := p.pickNext()
+		now := time.Now().UTC()
+		wait := time.Duration(0)
+		if next != nil && next.nextRefresh.After(now) {
+			wait = next.nextRefresh.Sub(now)
 		}
+
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(wait)
 
 		select {
 		case <-ctx.Done():
 			return
 		case <-p.stop:
 			return
-		case <-time.After(interval):
+		case <-timer.C:
 		}
+
+		if next == nil {
+			continue
+		}
+		p.fetchSite(ctx, next)
 	}
 }
 
-// fetchAndApply runs a single fetch attempt, parses the envelope, and
-// feeds it into the aggregator. Updates the per-site state on the
-// aggregator (last-fetched / last-error / disposition) regardless of
-// outcome so the validator_list_sites RPC reflects every attempt.
-//
-// Returns the next refresh interval to use:
-//   - On fetch / decode failure: ErrorRetryInterval (30s), mirroring
-//     rippled's error_retry_interval.
-//   - On success with an envelope refresh_interval: the clamped value.
-//   - Otherwise: zero, meaning "keep using the caller's interval".
-func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duration {
-	now := time.Now().UTC()
-	// Schedule the next refresh time BEFORE the fetch begins, mirroring
-	// rippled's onTimer ordering (ValidatorSite.cpp:354-355) so the RPC
-	// reports the upcoming wakeup even while this fetch is outstanding.
-	// Errors and per-publisher overrides reset NextRefresh in the
-	// UpdateSiteState call below.
-	p.aggregator.SetNextRefresh(uri, now.Add(p.interval))
+// pickNext returns the site with the smallest nextRefresh time. nil
+// when no sites are configured.
+func (p *SitePoller) pickNext() *siteState {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.sites) == 0 {
+		return nil
+	}
+	best := p.sites[0]
+	for _, s := range p.sites[1:] {
+		if s.nextRefresh.Before(best.nextRefresh) {
+			best = s
+		}
+	}
+	return best
+}
 
+// fetchSite performs one fetch+apply cycle for a single site. Updates
+// the site's internal interval/nextRefresh cursor and pushes the
+// outcome through to the aggregator for RPC visibility.
+func (p *SitePoller) fetchSite(ctx context.Context, s *siteState) {
+	uri := s.uri
 	body, err := p.fetch(ctx, uri)
 	if err != nil {
-		p.logger.Warn("validator list site fetch failed",
-			"uri", uri, "error", err)
-		p.aggregator.UpdateSiteState(uri, now, time.Time{}, err.Error(), Malformed, 0, now.Add(ErrorRetryInterval))
-		return ErrorRetryInterval
+		p.recordFailure(s, err.Error(), "validator list site fetch failed", "error", err)
+		return
 	}
 
 	var env envelopeJSON
-	if err := json.Unmarshal(body, &env); err != nil {
-		msg := fmt.Sprintf("envelope JSON decode: %v", err)
-		p.logger.Warn(msg, "uri", uri)
-		p.aggregator.UpdateSiteState(uri, now, time.Time{}, msg, Malformed, 0, now.Add(ErrorRetryInterval))
-		return ErrorRetryInterval
+	if jsonErr := json.Unmarshal(body, &env); jsonErr != nil {
+		msg := fmt.Sprintf("envelope JSON decode: %v", jsonErr)
+		p.recordFailure(s, msg, msg, "uri", uri)
+		return
 	}
 
-	// Rippled ValidatorSite.cpp:391-393 requires `manifest` (string)
-	// and `version` (int) to be present at the envelope level — for
-	// BOTH v1 and v2 envelopes (parseBlobs may then read per-blob
-	// manifest overrides on top, but the top-level field is still
-	// required). Treat a zero/absent version or empty manifest as
-	// Malformed so the RPC reports a real disposition rather than
-	// silently coercing the envelope into v1 or accepting a v2
-	// envelope that has no global publisher manifest.
-	if env.Version == 0 {
-		msg := "envelope missing required `version` field"
-		p.logger.Warn(msg, "uri", uri)
-		p.aggregator.UpdateSiteState(uri, now, time.Time{}, msg, Malformed, 0, now.Add(ErrorRetryInterval))
-		return ErrorRetryInterval
-	}
-	if env.Manifest == "" {
-		msg := "envelope missing required `manifest` field"
-		p.logger.Warn(msg, "uri", uri)
-		p.aggregator.UpdateSiteState(uri, now, time.Time{}, msg, Malformed, 0, now.Add(ErrorRetryInterval))
-		return ErrorRetryInterval
+	// Rippled requires `manifest` (string) and `version` (int) at the
+	// envelope level for both v1 and v2 — see ValidatorList::parseBlobs
+	// and ValidatorSite.cpp:391-410. The literal "Missing fields in
+	// JSON response" message is the rippled-faithful error text.
+	if env.Version == 0 || env.Manifest == "" {
+		p.recordFailure(s, missingFieldsMessage, missingFieldsMessage, "uri", uri)
+		return
 	}
 
+	// Dispatch strictly on the envelope's declared version — rippled's
+	// parseBlobs switches on `version`, NOT on which fields happen to
+	// be populated. A v2 envelope that only carries top-level
+	// blob/signature is invalid (no blobs_v2), regardless of whether
+	// v1 fields are present.
 	var disp Disposition
 	var dispList []Disposition
 	var pubKey PublisherKey
-	if len(env.BlobsV2) > 0 {
-		// v2 envelope: collection of forward-dated blobs.
+	switch {
+	case env.Version >= 2:
+		if len(env.BlobsV2) == 0 {
+			p.recordFailure(s, missingFieldsMessage, missingFieldsMessage, "uri", uri, "version", env.Version)
+			return
+		}
 		coll := &message.ValidatorListCollection{
 			Version:  env.Version,
 			Manifest: []byte(env.Manifest),
@@ -269,8 +355,11 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 		}
 		dispList, pubKey, _ = p.aggregator.ApplyCollection(coll, uri)
 		disp = bestDisposition(dispList)
-	} else if env.Blob != "" && env.Signature != "" && env.Manifest != "" {
-		// v1 envelope.
+	case env.Version == 1:
+		if env.Blob == "" || env.Signature == "" {
+			p.recordFailure(s, missingFieldsMessage, missingFieldsMessage, "uri", uri)
+			return
+		}
 		disp, pubKey, _ = p.aggregator.ApplyList(
 			[]byte(env.Manifest),
 			[]byte(env.Blob),
@@ -278,28 +367,28 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 			env.Version,
 			uri,
 		)
-	} else {
-		disp = Malformed
-		p.logger.Warn("validator list envelope missing required fields", "uri", uri)
+	default:
+		p.recordFailure(s, missingFieldsMessage, missingFieldsMessage, "uri", uri, "version", env.Version)
+		return
 	}
 
+	// Capture time AFTER apply completes — mirrors rippled
+	// ValidatorSite.cpp:430 which writes `Site::Status{clock_type::now(), ...}`
+	// at the apply boundary, not pre-fetch. The RPC `last_refresh_time`
+	// reflects when the list was applied, not when the fetch began.
+	applyTime := time.Now().UTC()
+
 	// Push the canonical accepted form out to peers. Mirrors rippled
-	// ValidatorSite::parseJsonResponse calling applyListsAndBroadcast
-	// at ValidatorSite.cpp:418-427 — the broadcaster owned by the
-	// aggregator skips peers that already have this sequence (no
-	// originating peer for HTTP-polled lists, so exceptPeer == 0).
+	// applyListsAndBroadcast at ValidatorSite.cpp:418-427.
 	if disp.ShouldRelay() && pubKey != (PublisherKey{}) {
 		p.aggregator.BroadcastLatest(pubKey, 0)
 	}
 
+	// Per-publisher refresh override (clamped). Rippled parses with
+	// `asUInt()` so fractional minutes are truncated
+	// (ValidatorSite.cpp:484-489).
+	chosenInterval := p.interval
 	refreshSec := 0
-	nextInterval := time.Duration(0)
-	// Truncate to whole minutes, mirroring rippled's
-	// `std::chrono::minutes{body[jss::refresh_interval].asUInt()}`
-	// (ValidatorSite.cpp:484-489) which accepts any numeric JSON value
-	// and reads it as an unsigned integer (fractional component
-	// discarded). Negative or zero values fall through to the default
-	// refresh interval.
 	if refreshMin := int(env.RefreshMinutes); refreshMin > 0 {
 		d := time.Duration(refreshMin) * time.Minute
 		if d < DefaultMinRefresh {
@@ -307,35 +396,49 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 		} else if d > DefaultMaxRefresh {
 			d = DefaultMaxRefresh
 		}
-		nextInterval = d
+		chosenInterval = d
 		refreshSec = int(d / time.Second)
 	}
 
+	// rippled emits an empty `last_refresh_message` whenever the parse
+	// succeeded — the disposition itself carries the outcome
+	// (ValidatorSite.cpp:430). Stash the disposition string in the
+	// message only for dispositions that indicate the apply rejected
+	// the list (anything not ShouldRelay-eligible).
 	lastSuccess := time.Time{}
 	lastErr := ""
-	if disp == Accepted || disp == SameSequence || disp == Pending || disp == Expired {
-		lastSuccess = now
+	if disp.ShouldRelay() {
+		lastSuccess = applyTime
 	} else {
 		lastErr = "disposition=" + disp.String()
 	}
-	// nextInterval is 0 here when no per-publisher refresh override was
-	// present in the envelope; in that case the caller will reuse its
-	// configured interval. Compute the wall-clock next refresh for the
-	// validator_list_sites RPC accordingly.
-	scheduled := nextInterval
-	if scheduled == 0 {
-		scheduled = p.interval
-	}
-	p.aggregator.UpdateSiteState(uri, now, lastSuccess, lastErr, disp, refreshSec, now.Add(scheduled))
+	nextAt := applyTime.Add(chosenInterval)
+	p.aggregator.UpdateSiteState(uri, applyTime, lastSuccess, lastErr, disp, refreshSec, nextAt)
 
-	return nextInterval
+	p.mu.Lock()
+	s.interval = chosenInterval
+	s.nextRefresh = nextAt
+	p.mu.Unlock()
 }
 
-// fetch retrieves the raw envelope body from the given URI. Supports
-// http://, https:// (via the package HTTP client) and file:// for
-// operators wanting to point at a locally-mirrored list. Other
-// schemes return an explicit error so misconfiguration surfaces
-// immediately.
+// recordFailure pushes a fetch / parse failure through to the
+// aggregator and the per-site scheduling cursor. The error message
+// becomes both the log line and the `last_refresh_message` surfaced
+// via RPC. NextRefresh is set to now+ErrorRetryInterval to mirror
+// rippled's error_retry_interval at ValidatorSite.cpp:555-561.
+func (p *SitePoller) recordFailure(s *siteState, lastErr, logMsg string, logFields ...any) {
+	now := time.Now().UTC()
+	nextAt := now.Add(ErrorRetryInterval)
+	p.logger.Warn(logMsg, logFields...)
+	p.aggregator.UpdateSiteState(s.uri, now, time.Time{}, lastErr, Malformed, 0, nextAt)
+	p.mu.Lock()
+	s.nextRefresh = nextAt
+	p.mu.Unlock()
+}
+
+// fetch retrieves the raw envelope body from the given URI. Scheme
+// validation has already happened at construction time, so the switch
+// here is structural rather than defensive.
 func (p *SitePoller) fetch(ctx context.Context, uri string) ([]byte, error) {
 	parsed, err := url.Parse(uri)
 	if err != nil {
@@ -347,8 +450,6 @@ func (p *SitePoller) fetch(ctx context.Context, uri string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("build request: %w", err)
 		}
-		req.Header.Set("User-Agent", "goXRPLd/validator-list-fetcher")
-		req.Header.Set("Accept", "application/json")
 		resp, err := p.client.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP GET: %w", err)
@@ -357,15 +458,12 @@ func (p *SitePoller) fetch(ctx context.Context, uri string) ([]byte, error) {
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			return nil, fmt.Errorf("HTTP %d %s", resp.StatusCode, resp.Status)
 		}
-		// Cap body size at 8 MiB — vl.ripple.com responses are ~30 KiB.
 		const maxBody = 8 << 20
 		return io.ReadAll(io.LimitReader(resp.Body, maxBody))
 	case "file":
-		path := parsed.Path
-		if path == "" {
-			return nil, errors.New("file URI missing path")
-		}
-		return os.ReadFile(path)
+		// Host already rejected at construction (see validateSiteURI);
+		// Path already guaranteed non-empty.
+		return os.ReadFile(parsed.Path)
 	default:
 		return nil, fmt.Errorf("unsupported URI scheme %q", parsed.Scheme)
 	}

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -241,6 +241,7 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 
 	var disp Disposition
 	var dispList []Disposition
+	var pubKey PublisherKey
 	if len(env.BlobsV2) > 0 {
 		// v2 envelope: collection of forward-dated blobs.
 		coll := &message.ValidatorListCollection{
@@ -254,11 +255,11 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 				Signature: []byte(b.Signature),
 			})
 		}
-		dispList, _ = p.aggregator.ApplyCollection(coll, uri)
+		dispList, pubKey, _ = p.aggregator.ApplyCollection(coll, uri)
 		disp = bestDisposition(dispList)
 	} else if env.Blob != "" && env.Signature != "" && env.Manifest != "" {
 		// v1 envelope.
-		disp, _ = p.aggregator.ApplyList(
+		disp, pubKey, _ = p.aggregator.ApplyList(
 			[]byte(env.Manifest),
 			[]byte(env.Blob),
 			[]byte(env.Signature),
@@ -268,6 +269,15 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 	} else {
 		disp = Malformed
 		p.logger.Warn("validator list envelope missing required fields", "uri", uri)
+	}
+
+	// Push the canonical accepted form out to peers. Mirrors rippled
+	// ValidatorSite::parseJsonResponse calling applyListsAndBroadcast
+	// at ValidatorSite.cpp:418-427 — the broadcaster owned by the
+	// aggregator skips peers that already have this sequence (no
+	// originating peer for HTTP-polled lists, so exceptPeer == 0).
+	if disp.ShouldRelay() && pubKey != (PublisherKey{}) {
+		p.aggregator.BroadcastLatest(pubKey, 0)
 	}
 
 	refreshSec := 0

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -52,7 +52,10 @@ const ErrorRetryInterval = 30 * time.Second
 //
 // RefreshMinutes mirrors rippled's `refresh_interval` field which is
 // parsed as `std::chrono::minutes{body[jss::refresh_interval].asUInt()}`
-// (ValidatorSite.cpp:484-489). Keep the wire-side unit explicit in the
+// (ValidatorSite.cpp:484-489). Stored as float64 to match rippled's
+// isNumeric() tolerance: integer or fractional JSON values are accepted
+// and truncated to whole minutes via asUInt() in rippled, via
+// int(RefreshMinutes) here. Keep the wire-side unit explicit in the
 // field name so future readers do not redo this conformance check.
 type envelopeJSON struct {
 	Manifest       string             `json:"manifest"`
@@ -61,7 +64,7 @@ type envelopeJSON struct {
 	Version        uint32             `json:"version"`
 	PublicKey      string             `json:"public_key,omitempty"`
 	BlobsV2        []envelopeBlobJSON `json:"blobs_v2,omitempty"`
-	RefreshMinutes int                `json:"refresh_interval,omitempty"`
+	RefreshMinutes float64            `json:"refresh_interval,omitempty"`
 }
 
 // envelopeBlobJSON is a v2 collection entry inside the JSON envelope.
@@ -227,13 +230,22 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 		return ErrorRetryInterval
 	}
 
-	// Rippled ValidatorSite.cpp:391-393 requires `version` to be a
-	// present integer; a missing field fails validation and is logged
-	// as "missing fields". Treat a zero/absent version as Malformed so
-	// the RPC reports a real disposition rather than silently coercing
-	// the envelope into v1.
+	// Rippled ValidatorSite.cpp:391-393 requires `manifest` (string)
+	// and `version` (int) to be present at the envelope level — for
+	// BOTH v1 and v2 envelopes (parseBlobs may then read per-blob
+	// manifest overrides on top, but the top-level field is still
+	// required). Treat a zero/absent version or empty manifest as
+	// Malformed so the RPC reports a real disposition rather than
+	// silently coercing the envelope into v1 or accepting a v2
+	// envelope that has no global publisher manifest.
 	if env.Version == 0 {
 		msg := "envelope missing required `version` field"
+		p.logger.Warn(msg, "uri", uri)
+		p.aggregator.UpdateSiteState(uri, now, time.Time{}, msg, Malformed, 0, now.Add(ErrorRetryInterval))
+		return ErrorRetryInterval
+	}
+	if env.Manifest == "" {
+		msg := "envelope missing required `manifest` field"
 		p.logger.Warn(msg, "uri", uri)
 		p.aggregator.UpdateSiteState(uri, now, time.Time{}, msg, Malformed, 0, now.Add(ErrorRetryInterval))
 		return ErrorRetryInterval
@@ -282,8 +294,14 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 
 	refreshSec := 0
 	nextInterval := time.Duration(0)
-	if env.RefreshMinutes > 0 {
-		d := time.Duration(env.RefreshMinutes) * time.Minute
+	// Truncate to whole minutes, mirroring rippled's
+	// `std::chrono::minutes{body[jss::refresh_interval].asUInt()}`
+	// (ValidatorSite.cpp:484-489) which accepts any numeric JSON value
+	// and reads it as an unsigned integer (fractional component
+	// discarded). Negative or zero values fall through to the default
+	// refresh interval.
+	if refreshMin := int(env.RefreshMinutes); refreshMin > 0 {
+		d := time.Duration(refreshMin) * time.Minute
 		if d < DefaultMinRefresh {
 			d = DefaultMinRefresh
 		} else if d > DefaultMaxRefresh {

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -45,14 +45,19 @@ const ErrorRetryInterval = 30 * time.Second
 
 // envelopeJSON is the JSON shape published at vl.* URLs (and the
 // equivalent file:// payloads). Decoded from the HTTP response body.
+//
+// RefreshMinutes mirrors rippled's `refresh_interval` field which is
+// parsed as `std::chrono::minutes{body[jss::refresh_interval].asUInt()}`
+// (ValidatorSite.cpp:484-489). Keep the wire-side unit explicit in the
+// field name so future readers do not redo this conformance check.
 type envelopeJSON struct {
-	Manifest    string             `json:"manifest"`
-	Blob        string             `json:"blob,omitempty"`
-	Signature   string             `json:"signature,omitempty"`
-	Version     uint32             `json:"version"`
-	PublicKey   string             `json:"public_key,omitempty"`
-	BlobsV2     []envelopeBlobJSON `json:"blobs_v2,omitempty"`
-	RefreshSecs int                `json:"refresh_interval,omitempty"`
+	Manifest       string             `json:"manifest"`
+	Blob           string             `json:"blob,omitempty"`
+	Signature      string             `json:"signature,omitempty"`
+	Version        uint32             `json:"version"`
+	PublicKey      string             `json:"public_key,omitempty"`
+	BlobsV2        []envelopeBlobJSON `json:"blobs_v2,omitempty"`
+	RefreshMinutes int                `json:"refresh_interval,omitempty"`
 }
 
 // envelopeBlobJSON is a v2 collection entry inside the JSON envelope.
@@ -106,6 +111,9 @@ func NewSitePoller(uris []string, agg *Aggregator, logger *slog.Logger) *SitePol
 // SetInterval overrides the default poll interval. Useful for tests that
 // don't want to wait 5 minutes between fetches; production callers
 // rarely override.
+//
+// MUST be called before Start — there is no synchronization between
+// runOne goroutines and these setters.
 func (p *SitePoller) SetInterval(d time.Duration) {
 	if d <= 0 {
 		return
@@ -115,6 +123,9 @@ func (p *SitePoller) SetInterval(d time.Duration) {
 
 // SetHTTPClient overrides the HTTP client. Useful for tests that wire
 // a custom Transport (e.g. recording requests in-memory).
+//
+// MUST be called before Start — there is no synchronization between
+// runOne goroutines and these setters.
 func (p *SitePoller) SetHTTPClient(c *http.Client) {
 	if c != nil {
 		p.client = c
@@ -236,8 +247,8 @@ func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duratio
 
 	refreshSec := 0
 	nextInterval := time.Duration(0)
-	if env.RefreshSecs > 0 {
-		d := time.Duration(env.RefreshSecs) * time.Second
+	if env.RefreshMinutes > 0 {
+		d := time.Duration(env.RefreshMinutes) * time.Minute
 		if d < DefaultMinRefresh {
 			d = DefaultMinRefresh
 		} else if d > DefaultMaxRefresh {

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -1,0 +1,325 @@
+package list
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+)
+
+// DefaultRefreshInterval matches rippled's
+// ValidatorSite::default_refresh_interval — 5 minutes between polls of
+// a configured publisher URL. Operators rarely override; the publisher
+// JSON envelope may carry a per-site refresh override which the poller
+// honors within [DefaultMinRefresh, DefaultMaxRefresh].
+const DefaultRefreshInterval = 5 * time.Minute
+
+// DefaultMinRefresh is the floor applied to a publisher-supplied
+// refresh interval. One minute matches rippled's clamp at
+// ValidatorSite.cpp:486.
+const DefaultMinRefresh = 1 * time.Minute
+
+// DefaultMaxRefresh is the ceiling applied to a publisher-supplied
+// refresh interval. 24 hours matches rippled.
+const DefaultMaxRefresh = 24 * time.Hour
+
+// DefaultRequestTimeout caps a single HTTP fetch attempt. Rippled uses
+// 30s in ValidatorSite::activeFetcher; we mirror.
+const DefaultRequestTimeout = 30 * time.Second
+
+// envelopeJSON is the JSON shape published at vl.* URLs (and the
+// equivalent file:// payloads). Decoded from the HTTP response body.
+type envelopeJSON struct {
+	Manifest      string             `json:"manifest"`
+	Blob          string             `json:"blob,omitempty"`
+	Signature     string             `json:"signature,omitempty"`
+	Version       uint32             `json:"version"`
+	PublicKey     string             `json:"public_key,omitempty"`
+	BlobsV2       []envelopeBlobJSON `json:"blobs_v2,omitempty"`
+	RefreshSecs   int                `json:"refresh_interval,omitempty"`
+}
+
+// envelopeBlobJSON is a v2 collection entry inside the JSON envelope.
+type envelopeBlobJSON struct {
+	Manifest  string `json:"manifest,omitempty"`
+	Blob      string `json:"blob"`
+	Signature string `json:"signature"`
+}
+
+// SitePoller fetches publisher list URLs on a periodic cadence and
+// feeds the parsed envelopes into an Aggregator. Mirrors rippled's
+// ValidatorSite at rippled/src/xrpld/app/misc/ValidatorSite.cpp.
+//
+// One goroutine per configured URL; per-URL state (next refresh time,
+// last error) lives on the Aggregator so the validator_list_sites RPC
+// can read it without traversing the poller's internals.
+type SitePoller struct {
+	uris       []string
+	aggregator *Aggregator
+	client     *http.Client
+	logger     *slog.Logger
+	interval   time.Duration
+
+	wg   sync.WaitGroup
+	stop chan struct{}
+}
+
+// NewSitePoller constructs a poller for the given URLs. Passing zero
+// URLs yields an inert poller — Run / Stop are still safe to call.
+// Passing a nil aggregator panics: the poller has nowhere to deliver
+// what it fetches.
+func NewSitePoller(uris []string, agg *Aggregator, logger *slog.Logger) *SitePoller {
+	if agg == nil {
+		panic("validator/list: SitePoller requires non-nil Aggregator")
+	}
+	if logger == nil {
+		logger = slog.Default().With("component", "validator-list-site-poller")
+	}
+	return &SitePoller{
+		uris:       uris,
+		aggregator: agg,
+		client: &http.Client{
+			Timeout: DefaultRequestTimeout,
+		},
+		logger:   logger,
+		interval: DefaultRefreshInterval,
+		stop:     make(chan struct{}),
+	}
+}
+
+// SetInterval overrides the default poll interval. Useful for tests that
+// don't want to wait 5 minutes between fetches; production callers
+// rarely override.
+func (p *SitePoller) SetInterval(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	p.interval = d
+}
+
+// SetHTTPClient overrides the HTTP client. Useful for tests that wire
+// a custom Transport (e.g. recording requests in-memory).
+func (p *SitePoller) SetHTTPClient(c *http.Client) {
+	if c != nil {
+		p.client = c
+	}
+}
+
+// Start launches one goroutine per configured URL. Each goroutine
+// performs an immediate fetch (so the initial trust set is populated
+// without waiting one refresh period) then loops on the configured
+// interval. Safe to call once; subsequent calls are no-ops while the
+// poller is running.
+func (p *SitePoller) Start(ctx context.Context) {
+	if len(p.uris) == 0 {
+		return
+	}
+	for _, u := range p.uris {
+		p.wg.Add(1)
+		go p.runOne(ctx, u)
+	}
+}
+
+// Stop signals all polling goroutines to exit and blocks until they
+// have. Safe to call multiple times; idempotent.
+func (p *SitePoller) Stop() {
+	select {
+	case <-p.stop:
+		return
+	default:
+		close(p.stop)
+	}
+	p.wg.Wait()
+}
+
+func (p *SitePoller) runOne(ctx context.Context, uri string) {
+	defer p.wg.Done()
+
+	interval := p.interval
+	for {
+		// Immediate fetch on entry, then sleep — so a fresh boot has
+		// up-to-date publisher state without waiting one full
+		// interval.
+		nextInterval := p.fetchAndApply(ctx, uri)
+		if nextInterval > 0 {
+			interval = nextInterval
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.stop:
+			return
+		case <-time.After(interval):
+		}
+	}
+}
+
+// fetchAndApply runs a single fetch attempt, parses the envelope, and
+// feeds it into the aggregator. Updates the per-site state on the
+// aggregator (last-fetched / last-error / disposition) regardless of
+// outcome so the validator_list_sites RPC reflects every attempt.
+//
+// Returns the next refresh interval to use — derived from the
+// envelope's refresh_interval field when present (clamped to
+// [DefaultMinRefresh, DefaultMaxRefresh]), else zero to keep the
+// caller-supplied interval.
+func (p *SitePoller) fetchAndApply(ctx context.Context, uri string) time.Duration {
+	now := time.Now().UTC()
+	body, err := p.fetch(ctx, uri)
+	if err != nil {
+		p.logger.Warn("validator list site fetch failed",
+			"uri", uri, "error", err)
+		p.aggregator.UpdateSiteState(uri, now, time.Time{}, err.Error(), Malformed, 0)
+		return 0
+	}
+
+	var env envelopeJSON
+	if err := json.Unmarshal(body, &env); err != nil {
+		msg := fmt.Sprintf("envelope JSON decode: %v", err)
+		p.logger.Warn(msg, "uri", uri)
+		p.aggregator.UpdateSiteState(uri, now, time.Time{}, msg, Malformed, 0)
+		return 0
+	}
+
+	if env.Version == 0 {
+		env.Version = 1
+	}
+
+	var disp Disposition
+	var dispList []Disposition
+	if len(env.BlobsV2) > 0 {
+		// v2 envelope: collection of forward-dated blobs.
+		coll := &message.ValidatorListCollection{
+			Version:  env.Version,
+			Manifest: []byte(env.Manifest),
+		}
+		for _, b := range env.BlobsV2 {
+			coll.Blobs = append(coll.Blobs, message.ValidatorBlobInfo{
+				Manifest:  []byte(b.Manifest),
+				Blob:      []byte(b.Blob),
+				Signature: []byte(b.Signature),
+			})
+		}
+		dispList, _ = p.aggregator.ApplyCollection(coll, uri)
+		disp = bestDisposition(dispList)
+	} else if env.Blob != "" && env.Signature != "" && env.Manifest != "" {
+		// v1 envelope.
+		disp, _ = p.aggregator.ApplyList(
+			[]byte(env.Manifest),
+			[]byte(env.Blob),
+			[]byte(env.Signature),
+			env.Version,
+			uri,
+		)
+	} else {
+		disp = Malformed
+		p.logger.Warn("validator list envelope missing required fields", "uri", uri)
+	}
+
+	refreshSec := 0
+	nextInterval := time.Duration(0)
+	if env.RefreshSecs > 0 {
+		d := time.Duration(env.RefreshSecs) * time.Second
+		if d < DefaultMinRefresh {
+			d = DefaultMinRefresh
+		} else if d > DefaultMaxRefresh {
+			d = DefaultMaxRefresh
+		}
+		nextInterval = d
+		refreshSec = int(d / time.Second)
+	}
+
+	lastSuccess := time.Time{}
+	lastErr := ""
+	if disp == Accepted || disp == SameSequence || disp == Pending || disp == Expired {
+		lastSuccess = now
+	} else {
+		lastErr = "disposition=" + disp.String()
+	}
+	p.aggregator.UpdateSiteState(uri, now, lastSuccess, lastErr, disp, refreshSec)
+
+	return nextInterval
+}
+
+// fetch retrieves the raw envelope body from the given URI. Supports
+// http://, https:// (via the package HTTP client) and file:// for
+// operators wanting to point at a locally-mirrored list. Other
+// schemes return an explicit error so misconfiguration surfaces
+// immediately.
+func (p *SitePoller) fetch(ctx context.Context, uri string) ([]byte, error) {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("parse URI: %w", err)
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("User-Agent", "goXRPLd/validator-list-fetcher")
+		req.Header.Set("Accept", "application/json")
+		resp, err := p.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("HTTP GET: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("HTTP %d %s", resp.StatusCode, resp.Status)
+		}
+		// Cap body size at 8 MiB — vl.ripple.com responses are ~30 KiB.
+		const maxBody = 8 << 20
+		return io.ReadAll(io.LimitReader(resp.Body, maxBody))
+	case "file":
+		path := parsed.Path
+		if path == "" {
+			return nil, errors.New("file URI missing path")
+		}
+		return os.ReadFile(path)
+	default:
+		return nil, fmt.Errorf("unsupported URI scheme %q", parsed.Scheme)
+	}
+}
+
+// bestDisposition reduces a collection of dispositions to the single
+// summary the caller (RPC, logs) sees. Order of preference:
+// Accepted > Expired > Pending > SameSequence > KnownSequence > Stale
+// > Untrusted > Invalid > UnsupportedVersion > Malformed. Mirrors
+// rippled's PublisherListStats best-of-many reduction.
+func bestDisposition(dispList []Disposition) Disposition {
+	if len(dispList) == 0 {
+		return Malformed
+	}
+	rank := map[Disposition]int{
+		Accepted:           0,
+		Expired:            1,
+		Pending:            2,
+		SameSequence:       3,
+		KnownSequence:      4,
+		Stale:              5,
+		Untrusted:          6,
+		Invalid:            7,
+		UnsupportedVersion: 8,
+		Malformed:          9,
+	}
+	best := dispList[0]
+	bestRank := rank[best]
+	for _, d := range dispList[1:] {
+		if r, ok := rank[d]; ok && r < bestRank {
+			best = d
+			bestRank = r
+		}
+	}
+	return best
+}


### PR DESCRIPTION
## Summary

Implements the rippled-faithful counterpart of `ValidatorList.cpp` + `ValidatorSite.cpp`. Before this PR, goXRPL had wire-level scaffolding for the validator-list publisher path (proto types, handshake feature flag, config fields, RPC method names) but no functional implementation — peers' `TMValidatorList` / `TMValidatorListCollection` messages were deserialized, counted in metrics, then dropped. After this PR, goXRPL ingests publisher lists, verifies them, and pushes a recomputed trusted UNL into `Adaptor.SetTrustedValidators`.

### What's new

- **`internal/validator/list/`** — the publisher-trust subsystem:
  - `Aggregator` owns the configured publisher trust set, per-publisher state (current accepted list + status), and threshold. `ApplyList` verifies the publisher manifest against the trust set, applies it to the shared `manifest.Cache`, verifies the blob signature against the publisher's current ephemeral signing key, JSON-parses the blob, and emits a recomputed trusted set via `OnChange` when the union across publishers changes.
  - `Disposition` mirrors rippled's `ListDisposition` (Accepted / Expired / Pending / Stale / Untrusted / Invalid / UnsupportedVersion / Malformed) — distinguishes "charge the peer" outcomes from silent-drop ones.
  - `SitePoller` polls each configured `validator_list_sites` URL on rippled's 5-minute cadence (clamped to publisher-supplied `refresh_interval` within `[1m, 24h]`). Honors `http://`, `https://`, `file://`. Reports per-URL fetch outcomes through to the `validator_list_sites` RPC.
  - `RPCReader` adapts the aggregator to the `rpctypes.ValidatorListReader` interface used by the two RPC handlers (no rpc → validator/list import cycle).
- **Router dispatch** (`internal/consensus/adaptor/router_validator_list.go`) — `handleValidatorList` and `handleValidatorListCollection` decode incoming frames, feed them to the aggregator, charge `IncPeerBadData` on `Invalid` / `UnsupportedVersion` / `Malformed`, and rebroadcast accepted frames to other peers via `Overlay.BroadcastExcept`. Mirrors `PeerImp::onMessage(TMValidatorList)` + `applyListsAndBroadcast`.
- **Components wiring** (`internal/consensus/adaptor/startup.go`) — builds the aggregator from `validator_list_keys` + `validator_list_sites` + `validator_list_threshold`, wires its `OnChange` callback to the adaptor (merging the static `[validators]` stanza with publisher-derived validators so operators can pin extras), and starts the HTTP poller goroutine. Graceful shutdown threads the poller into `Components.Stop`.
- **RPC handlers** (`internal/rpc/handlers/validators.go`) — `validators` and `validator_list_sites` now return real per-publisher / per-site state instead of empty arrays. Backwards-compatible response shape extended with rippled-style fields (`available`, `seq`, `expiration`, `last_refresh`, `last_error`).
- **Config fix** (`config/validators.go`) — `validator_list_keys` validation now requires the canonical 66-char hex form (33-byte compressed pubkey with `ED` / `02` / `03` prefix). The mainnet/testnet built-in defaults already used 66-char keys; this aligns the validator with real-world publisher keys like `vl.ripple.com`.

### How it integrates

The aggregator's `OnChange` callback merges the static `[validators]` config with publisher-derived validators and pushes the union into the same `Adaptor.SetTrustedValidators` entry point #456 introduced for SIGHUP reload — so a single write path serves config, SIGHUP, peer gossip, and HTTP polling. The consensus engine's `driveNegativeUNLNewValidatorsLocked` already picks up deltas per round and forwards `added` to `OnUNLChange` (NegativeUNL grace period), so no consensus-side changes were needed.

### Out of scope (deferred)

- Persisting accepted lists across restart. Rippled writes the latest accepted blob per publisher to disk so a cold boot has a current UNL before the first network round-trip. goXRPL bootstraps from `validator_list_sites` polling on every start instead — the first 5-minute window has only static config trust. Tracked for follow-up.
- Forward-dated lists ("pending" disposition). The aggregator recognizes future-effective blobs and reports `Pending`, but does not store them in a `remaining` queue for later promotion. Publishers republish near the effective time so the lag is bounded by the polling cadence; the abstraction can be added when needed.

## Test plan

- [x] `go test ./internal/validator/list/...` — unit tests for `ApplyList` (accepted single + threshold-2-of-3 + stale sequence + untrusted publisher + bad signature + expired list + unsupported version + malformed manifest) and `ApplyCollection` (multi-blob ordering, dedupe by sequence).
- [x] `go test ./...` — full test suite passes; no regressions in router, RPC, config, peer-management, manifest, or consensus packages.
- [x] `go build ./...` — clean build across all packages.

Fixes #459