### PR TITLE
fix: emit UInt64 JSON fields without leading zeros, lowercase

### DIFF
--- a/codec/binarycodec/codec_test.go
+++ b/codec/binarycodec/codec_test.go
@@ -230,6 +230,32 @@ func TestEncode(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			// sMD_BaseTen field: input arrives as decimal string (rippled wire
+			// shape) — see rippled MPToken_test.cpp:189.
+			description: "serialize MaximumAmount example - UInt64 sMD_BaseTen (max int64)",
+			input:       map[string]any{"MaximumAmount": "9223372036854775807"},
+			output:      "30187FFFFFFFFFFFFFFF",
+			expectedErr: nil,
+		},
+		{
+			description: "serialize OutstandingAmount example - UInt64 sMD_BaseTen",
+			input:       map[string]any{"OutstandingAmount": "100"},
+			output:      "30190000000000000064",
+			expectedErr: nil,
+		},
+		{
+			description: "serialize MPTAmount example - UInt64 sMD_BaseTen",
+			input:       map[string]any{"MPTAmount": "9990"},
+			output:      "301A0000000000002706",
+			expectedErr: nil,
+		},
+		{
+			description: "serialize LockedAmount example - UInt64 sMD_BaseTen (zero)",
+			input:       map[string]any{"LockedAmount": "0"},
+			output:      "301D0000000000000000",
+			expectedErr: nil,
+		},
+		{
 			description: "serialize LedgerEntryType example - UInt8",
 			input:       map[string]any{"LedgerEntryType": "RippleState"},
 			output:      "110072",
@@ -387,6 +413,34 @@ func TestDecode(t *testing.T) {
 			description: "deserialize Uint64 correctly",
 			input:       "34000000044B82FA09",
 			output:      map[string]any{"OwnerNode": "44b82fa09"},
+			expectedErr: nil,
+		},
+		{
+			// sMD_BaseTen field: rippled emits decimal, not hex. Mirrors
+			// rippled MPToken_test.cpp:189 (sfMaximumAmount == "9223372036854775807").
+			description: "deserialize Uint64 MaximumAmount (sMD_BaseTen, max int64)",
+			input:       "30187FFFFFFFFFFFFFFF",
+			output:      map[string]any{"MaximumAmount": "9223372036854775807"},
+			expectedErr: nil,
+		},
+		{
+			// Mirrors rippled Vault_test.cpp:1288 (sfOutstandingAmount == "100").
+			description: "deserialize Uint64 OutstandingAmount (sMD_BaseTen, small)",
+			input:       "30190000000000000064",
+			output:      map[string]any{"OutstandingAmount": "100"},
+			expectedErr: nil,
+		},
+		{
+			// Mirrors rippled MPToken_test.cpp:1654 (sfMPTAmount == "9990").
+			description: "deserialize Uint64 MPTAmount (sMD_BaseTen)",
+			input:       "301A0000000000002706",
+			output:      map[string]any{"MPTAmount": "9990"},
+			expectedErr: nil,
+		},
+		{
+			description: "deserialize Uint64 LockedAmount (sMD_BaseTen, zero)",
+			input:       "301D0000000000000000",
+			output:      map[string]any{"LockedAmount": "0"},
 			expectedErr: nil,
 		},
 		{

--- a/codec/binarycodec/codec_test.go
+++ b/codec/binarycodec/codec_test.go
@@ -386,7 +386,7 @@ func TestDecode(t *testing.T) {
 		{
 			description: "deserialize Uint64 correctly",
 			input:       "34000000044B82FA09",
-			output:      map[string]any{"OwnerNode": "000000044B82FA09"},
+			output:      map[string]any{"OwnerNode": "44b82fa09"},
 			expectedErr: nil,
 		},
 		{

--- a/codec/binarycodec/definitions/uint64_base_ten.go
+++ b/codec/binarycodec/definitions/uint64_base_ten.go
@@ -1,0 +1,14 @@
+package definitions
+
+// IsBaseTenUInt64FieldName reports whether the given SField is a UInt64 that
+// rippled emits as a decimal string (base 10) rather than the default
+// lowercase hex. Mirrors rippled SField::sMD_BaseTen, see
+// rippled/include/xrpl/protocol/detail/sfields.macro and
+// rippled/src/libxrpl/protocol/STInteger.cpp:246.
+func IsBaseTenUInt64FieldName(name string) bool {
+	switch name {
+	case "MaximumAmount", "OutstandingAmount", "MPTAmount", "LockedAmount":
+		return true
+	}
+	return false
+}

--- a/codec/binarycodec/types/st_array_test.go
+++ b/codec/binarycodec/types/st_array_test.go
@@ -122,7 +122,7 @@ func TestSTArrayToJson(t *testing.T) {
 				map[string]any{
 					"DeletedNode": map[string]any{
 						"FinalFields": map[string]any{
-							"ExchangeRate":      "4A0745621D069432",
+							"ExchangeRate":      "4a0745621d069432",
 							"Flags":             uint32(0),
 							"RootIndex":         "036D7E923EF22B65E19D95A6365C3373E1E96586E27015074A0745621D069432",
 							"TakerGetsCurrency": "0000000000000000000000000000000000000000",

--- a/codec/binarycodec/types/st_object.go
+++ b/codec/binarycodec/types/st_object.go
@@ -4,6 +4,7 @@ package types
 import (
 	"fmt"
 	"sort"
+	"strconv"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
@@ -99,9 +100,34 @@ func (t *STObject) ToJSON(p interfaces.BinaryParser, _ ...int) (any, error) {
 			return nil, err
 		}
 
+		res = coerceUInt64BaseTen(fi.Type, fi.FieldName, res)
+
 		m[fi.FieldName] = res
 	}
 	return m, nil
+}
+
+// coerceUInt64BaseTen converts the lowercase-hex string produced by
+// UInt64.ToJSON into the decimal string rippled emits for SFields flagged
+// sMD_BaseTen — see rippled src/libxrpl/protocol/STInteger.cpp:246 and the
+// rippled SField definitions in include/xrpl/protocol/detail/sfields.macro.
+// A no-op for any other field/type combination.
+func coerceUInt64BaseTen(fieldType, fieldName string, value any) any {
+	if fieldType != "UInt64" {
+		return value
+	}
+	if !definitions.IsBaseTenUInt64FieldName(fieldName) {
+		return value
+	}
+	s, ok := value.(string)
+	if !ok {
+		return value
+	}
+	n, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		return value
+	}
+	return strconv.FormatUint(n, 10)
 }
 
 // nolint
@@ -217,6 +243,20 @@ func parseSpecialFields(k string, v any) (any, error) {
 				return nil, err
 			}
 			return int(code), nil
+		}
+	}
+
+	// For UInt64 SFields rippled emits as decimal (sMD_BaseTen — sfMPTAmount,
+	// sfMaximumAmount, sfOutstandingAmount, sfLockedAmount), accept the decimal
+	// string and hand UInt64.FromJSON a numeric value so it skips its default
+	// base-16 string parse. See rippled STParsedJSON.cpp:441-449.
+	if definitions.IsBaseTenUInt64FieldName(k) {
+		if strValue, ok := v.(string); ok {
+			n, err := strconv.ParseUint(strValue, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", k, err)
+			}
+			return n, nil
 		}
 	}
 

--- a/codec/binarycodec/types/uint64.go
+++ b/codec/binarycodec/types/uint64.go
@@ -3,10 +3,8 @@ package types
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"strconv"
-	"strings"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/types/interfaces"
 )
@@ -53,11 +51,13 @@ func (u *UInt64) FromJSON(value any) ([]byte, error) {
 // ToJSON takes a BinaryParser and optional parameters, and converts the serialized byte data
 // back into a JSON string value. This method assumes the parser contains data representing
 // a 64-bit unsigned integer. If the parsing fails, an error is returned.
-// The output is an uppercase hex string zero-padded to 16 characters (matching rippled behavior).
+// The output is a lowercase hex string without leading zeros, matching rippled's
+// STUInt64::getJson (std::to_chars with base 16) — see rippled
+// src/libxrpl/protocol/STInteger.cpp.
 func (u *UInt64) ToJSON(p interfaces.BinaryParser, _ ...int) (any, error) {
 	b, err := p.ReadBytes(8)
 	if err != nil {
 		return nil, err
 	}
-	return strings.ToUpper(hex.EncodeToString(b)), nil
+	return strconv.FormatUint(binary.BigEndian.Uint64(b), 16), nil
 }

--- a/codec/binarycodec/types/uint64_test.go
+++ b/codec/binarycodec/types/uint64_test.go
@@ -124,7 +124,7 @@ func TestUint64_ToJson(t *testing.T) {
 		{
 			name:     "pass - valid uint64",
 			input:    []byte{0, 0, 0, 0, 0, 0, 0, 1},
-			expected: "0000000000000001",
+			expected: "1",
 			malleate: func(t *testing.T) interfaces.BinaryParser {
 				return serdes.NewBinaryParser([]byte{0, 0, 0, 0, 0, 0, 0, 1}, defs)
 			},
@@ -133,7 +133,7 @@ func TestUint64_ToJson(t *testing.T) {
 		{
 			name:        "pass - valid uint64 (2)",
 			input:       []byte{0, 0, 0, 0, 0, 0, 0, 100},
-			expected:    "0000000000000064",
+			expected:    "64",
 			expectedErr: nil,
 			malleate: func(t *testing.T) interfaces.BinaryParser {
 				return serdes.NewBinaryParser([]byte{0, 0, 0, 0, 0, 0, 0, 100}, defs)
@@ -142,16 +142,25 @@ func TestUint64_ToJson(t *testing.T) {
 		{
 			name:        "pass - valid uint64 (3)",
 			input:       []byte{0, 0, 0, 0, 0, 0, 0, 255},
-			expected:    "00000000000000FF",
+			expected:    "ff",
 			expectedErr: nil,
 			malleate: func(t *testing.T) interfaces.BinaryParser {
 				return serdes.NewBinaryParser([]byte{0, 0, 0, 0, 0, 0, 0, 255}, defs)
 			},
 		},
 		{
+			name:        "pass - zero value emits \"0\" (rippled to_chars)",
+			input:       []byte{0, 0, 0, 0, 0, 0, 0, 0},
+			expected:    "0",
+			expectedErr: nil,
+			malleate: func(t *testing.T) interfaces.BinaryParser {
+				return serdes.NewBinaryParser([]byte{0, 0, 0, 0, 0, 0, 0, 0}, defs)
+			},
+		},
+		{
 			name:        "pass - valid uint64 (large number)",
 			input:       []byte{255, 255, 255, 255, 255, 255, 255, 255},
-			expected:    "FFFFFFFFFFFFFFFF", // Max uint64 value
+			expected:    "ffffffffffffffff", // Max uint64 value
 			expectedErr: nil,
 			malleate: func(t *testing.T) interfaces.BinaryParser {
 				return serdes.NewBinaryParser([]byte{255, 255, 255, 255, 255, 255, 255, 255}, defs)

--- a/internal/consensus/feevote/vote_test.go
+++ b/internal/consensus/feevote/vote_test.go
@@ -140,9 +140,10 @@ func TestDoVoting_PreXRPFeesWireFormat(t *testing.T) {
 	require.NotNil(t, blob)
 
 	stx := decodeTx(t, blob)
-	// sfBaseFee is uint64 — the codec returns it as a 16-character
-	// big-endian hex string. 16 decimal = 0x10 = "0000000000000010".
-	assert.Equal(t, "0000000000000010", baseFeeHex(t, stx["BaseFee"]),
+	// sfBaseFee is uint64 — the codec returns it as a lowercase hex
+	// string without leading zeros (matching rippled's
+	// STUInt64::getJson, std::to_chars base 16). 16 decimal = 0x10.
+	assert.Equal(t, "10", baseFeeHex(t, stx["BaseFee"]),
 		"sfBaseFee must encode the uint64 value 16 (=0x10) in legacy hex form")
 	assert.EqualValues(t, 12_000_000, asUint(stx["ReserveBase"]))
 	assert.EqualValues(t, 3_000_000, asUint(stx["ReserveIncrement"]))

--- a/internal/tx/ledgerfields/amm_gen.go
+++ b/internal/tx/ledgerfields/amm_gen.go
@@ -21,7 +21,7 @@ type AMM struct {
 	LPTokenBalance    any // Amount (XRP string | IOU map)
 	Asset             any
 	Asset2            any
-	OwnerNode         string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	PreviousTxnID     string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq uint32
 }

--- a/internal/tx/ledgerfields/amm_gen.go
+++ b/internal/tx/ledgerfields/amm_gen.go
@@ -78,12 +78,12 @@ func (a *AMM) Decode(data []byte) error {
 				return newErrUnknownField("AMM", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				a.OwnerNode = val
 				a.present |= ammBitOwnerNode
 			default:

--- a/internal/tx/ledgerfields/bridge_gen.go
+++ b/internal/tx/ledgerfields/bridge_gen.go
@@ -75,21 +75,33 @@ func (b *Bridge) Decode(data []byte) error {
 				return newErrUnknownField("Bridge", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				b.OwnerNode = val
 				b.present |= bridgeBitOwnerNode
 			case 20:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				b.XChainClaimID = val
 				b.present |= bridgeBitXChainClaimID
 			case 21:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				b.XChainAccountCreateCount = val
 				b.present |= bridgeBitXChainAccountCreateCount
 			case 22:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				b.XChainAccountClaimCount = val
 				b.present |= bridgeBitXChainAccountClaimCount
 			default:

--- a/internal/tx/ledgerfields/bridge_gen.go
+++ b/internal/tx/ledgerfields/bridge_gen.go
@@ -18,10 +18,10 @@ type Bridge struct {
 	SignatureReward          any    // Amount (XRP string | IOU map)
 	MinAccountCreateAmount   any    // Amount (XRP string | IOU map)
 	XChainBridge             any
-	XChainClaimID            string // UInt64 (uppercase hex)
-	XChainAccountCreateCount string // UInt64 (uppercase hex)
-	XChainAccountClaimCount  string // UInt64 (uppercase hex)
-	OwnerNode                string // UInt64 (uppercase hex)
+	XChainClaimID            string // UInt64 (lowercase hex, no leading zeros)
+	XChainAccountCreateCount string // UInt64 (lowercase hex, no leading zeros)
+	XChainAccountClaimCount  string // UInt64 (lowercase hex, no leading zeros)
+	OwnerNode                string // UInt64 (lowercase hex, no leading zeros)
 	PreviousTxnID            string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq        uint32
 }

--- a/internal/tx/ledgerfields/check_gen.go
+++ b/internal/tx/ledgerfields/check_gen.go
@@ -18,8 +18,8 @@ type Check struct {
 	Destination       string // AccountID (base58)
 	SendMax           any    // Amount (XRP string | IOU map)
 	Sequence          uint32
-	OwnerNode         string // UInt64 (uppercase hex)
-	DestinationNode   string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
+	DestinationNode   string // UInt64 (lowercase hex, no leading zeros)
 	Expiration        uint32
 	InvoiceID         string // Hash256 (uppercase hex)
 	SourceTag         uint32

--- a/internal/tx/ledgerfields/check_gen.go
+++ b/internal/tx/ledgerfields/check_gen.go
@@ -96,15 +96,19 @@ func (c *Check) Decode(data []byte) error {
 				return newErrUnknownField("Check", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				c.OwnerNode = val
 				c.present |= checkBitOwnerNode
 			case 9:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				c.DestinationNode = val
 				c.present |= checkBitDestinationNode
 			default:

--- a/internal/tx/ledgerfields/cmd/ledgerfieldsgen/main.go
+++ b/internal/tx/ledgerfields/cmd/ledgerfieldsgen/main.go
@@ -324,7 +324,7 @@ func init() {
 // the decoded blob so the emit methods only write entries that actually exist.
 type {{ .StructName }} struct {
 	present uint64
-{{ range .Fields }}{{ if ne .Meta 3 }}	{{ .GoField }} {{ .GoType }}{{ if eq .XRPLType "AccountID" }} // AccountID (base58){{ else if eq .XRPLType "Amount" }} // Amount (XRP string | IOU map){{ else if eq .XRPLType "Hash256" }} // Hash256 (uppercase hex){{ else if eq .XRPLType "Hash160" }} // Hash160 (uppercase hex){{ else if eq .XRPLType "Hash128" }} // Hash128 (uppercase hex){{ else if eq .XRPLType "Blob" }} // Blob (uppercase hex){{ else if eq .XRPLType "UInt64" }} // UInt64 (uppercase hex){{ end }}
+{{ range .Fields }}{{ if ne .Meta 3 }}	{{ .GoField }} {{ .GoType }}{{ if eq .XRPLType "AccountID" }} // AccountID (base58){{ else if eq .XRPLType "Amount" }} // Amount (XRP string | IOU map){{ else if eq .XRPLType "Hash256" }} // Hash256 (uppercase hex){{ else if eq .XRPLType "Hash160" }} // Hash160 (uppercase hex){{ else if eq .XRPLType "Hash128" }} // Hash128 (uppercase hex){{ else if eq .XRPLType "Blob" }} // Blob (uppercase hex){{ else if eq .XRPLType "UInt64" }} // UInt64 (lowercase hex, no leading zeros){{ end }}
 {{ end }}{{ end }}}
 
 const (

--- a/internal/tx/ledgerfields/cmd/ledgerfieldsgen/main.go
+++ b/internal/tx/ledgerfields/cmd/ledgerfieldsgen/main.go
@@ -52,20 +52,21 @@ func main() {
 
 // fieldRender carries the resolved per-field data the template needs.
 type fieldRender struct {
-	Name       string // canonical XRPL field name
-	GoField    string // Go struct field name (mirrors XRPL name)
-	BitConst   string // const name of the presence bit
-	GoType     string // Go type of the slot
-	XRPLType   string // XRPL type name (UInt32, Hash256, ...)
-	TypeCode   int    // XRPL type code
-	FieldCode  int    // XRPL field code
-	Meta       spec.Meta
-	Comparer   string // "String" | "Uint32" | "Int" | "Amount" — selects emitIfChanged*
-	IsAmount   bool
-	IsHash     bool   // hex-string default-value check
-	XRPOnly    bool   // Balance on AccountRoot uses readAmount (XRP-only)
-	ReadCall   string // expression that reads from streamReader
-	DecodeKind string // "uint32" | "int" | "string" | "amount" — drives the switch arm
+	Name            string // canonical XRPL field name
+	GoField         string // Go struct field name (mirrors XRPL name)
+	BitConst        string // const name of the presence bit
+	GoType          string // Go type of the slot
+	XRPLType        string // XRPL type name (UInt32, Hash256, ...)
+	TypeCode        int    // XRPL type code
+	FieldCode       int    // XRPL field code
+	Meta            spec.Meta
+	Comparer        string // "String" | "Uint32" | "Int" | "Amount" — selects emitIfChanged*
+	IsAmount        bool
+	IsHash          bool // hex-string default-value check
+	XRPOnly         bool // Balance on AccountRoot uses readAmount (XRP-only)
+	IsBaseTenUInt64 bool // UInt64 field rippled emits as decimal (sMD_BaseTen)
+	ReadCall        string
+	DecodeKind      string
 }
 
 type entryRender struct {
@@ -79,14 +80,15 @@ type entryRender struct {
 }
 
 type decodeArm struct {
-	TypeCode  int
-	FieldCode int
-	XRPLType  string
-	GoField   string
-	BitConst  string
-	GoType    string
-	XRPOnly   bool      // for Amount fields
-	Meta      spec.Meta // controls assign-vs-discard in the inner switch
+	TypeCode        int
+	FieldCode       int
+	XRPLType        string
+	GoField         string
+	BitConst        string
+	GoType          string
+	XRPOnly         bool // for Amount fields
+	IsBaseTenUInt64 bool // UInt64 sMD_BaseTen field — decode as decimal not hex
+	Meta            spec.Meta
 }
 
 func generate(defs *definitions.Definitions, entry spec.Entry, outDir string) (string, []byte, error) {
@@ -129,14 +131,15 @@ func generate(defs *definitions.Definitions, entry spec.Entry, outDir string) (s
 		// for them so the fail-fast outer default doesn't trip on a field
 		// the spec already declared.
 		arm := decodeArm{
-			TypeCode:  int(fi.FieldHeader.TypeCode),
-			FieldCode: int(fi.Nth),
-			XRPLType:  fi.Type,
-			GoField:   fr.GoField,
-			BitConst:  fr.BitConst,
-			GoType:    fr.GoType,
-			XRPOnly:   fr.XRPOnly,
-			Meta:      f.Meta,
+			TypeCode:        int(fi.FieldHeader.TypeCode),
+			FieldCode:       int(fi.Nth),
+			XRPLType:        fi.Type,
+			GoField:         fr.GoField,
+			BitConst:        fr.BitConst,
+			GoType:          fr.GoType,
+			XRPOnly:         fr.XRPOnly,
+			IsBaseTenUInt64: fr.IsBaseTenUInt64,
+			Meta:            f.Meta,
 		}
 		if arm.XRPLType == "Amount" && !arm.XRPOnly {
 			er.HasUnsupported = true
@@ -190,6 +193,7 @@ func makeFieldRender(f spec.Field, fi *definitions.FieldInstance, entryName, bit
 		fr.Comparer = "String"
 		fr.DecodeKind = "uint64hex"
 		fr.IsHash = true
+		fr.IsBaseTenUInt64 = definitions.IsBaseTenUInt64FieldName(f.Name)
 	case "Hash128":
 		fr.GoType = "string"
 		fr.Comparer = "String"
@@ -324,7 +328,7 @@ func init() {
 // the decoded blob so the emit methods only write entries that actually exist.
 type {{ .StructName }} struct {
 	present uint64
-{{ range .Fields }}{{ if ne .Meta 3 }}	{{ .GoField }} {{ .GoType }}{{ if eq .XRPLType "AccountID" }} // AccountID (base58){{ else if eq .XRPLType "Amount" }} // Amount (XRP string | IOU map){{ else if eq .XRPLType "Hash256" }} // Hash256 (uppercase hex){{ else if eq .XRPLType "Hash160" }} // Hash160 (uppercase hex){{ else if eq .XRPLType "Hash128" }} // Hash128 (uppercase hex){{ else if eq .XRPLType "Blob" }} // Blob (uppercase hex){{ else if eq .XRPLType "UInt64" }} // UInt64 (lowercase hex, no leading zeros){{ end }}
+{{ range .Fields }}{{ if ne .Meta 3 }}	{{ .GoField }} {{ .GoType }}{{ if eq .XRPLType "AccountID" }} // AccountID (base58){{ else if eq .XRPLType "Amount" }} // Amount (XRP string | IOU map){{ else if eq .XRPLType "Hash256" }} // Hash256 (uppercase hex){{ else if eq .XRPLType "Hash160" }} // Hash160 (uppercase hex){{ else if eq .XRPLType "Hash128" }} // Hash128 (uppercase hex){{ else if eq .XRPLType "Blob" }} // Blob (uppercase hex){{ else if eq .XRPLType "UInt64" }}{{ if .IsBaseTenUInt64 }} // UInt64 (decimal string, sMD_BaseTen){{ else }} // UInt64 (lowercase hex, no leading zeros){{ end }}{{ end }}
 {{ end }}{{ end }}}
 
 const (
@@ -346,6 +350,35 @@ func ({{ .Receiver }} *{{ .StructName }}) Decode(data []byte) error {
 {{- range $tc, $arms := .DecodeArms }}
 		case {{ $tc }}: // {{ (index $arms 0).XRPLType }}
 {{- $first := index $arms 0 }}
+{{- if eq $first.XRPLType "UInt64" }}
+			switch fieldCode {
+{{- range $arm := $arms }}
+			case {{ $arm.FieldCode }}:
+{{- if eq $arm.Meta 3 }}
+				if _, err := sr.readUint64Raw(); err != nil {
+					return err
+				}
+				// {{ $arm.GoField }} is sMD_Never; discard
+{{- else if $arm.IsBaseTenUInt64 }}
+				val, err := sr.readUint64Decimal()
+				if err != nil {
+					return err
+				}
+				{{ $.Receiver }}.{{ $arm.GoField }} = val
+				{{ $.Receiver }}.present |= {{ $arm.BitConst }}
+{{- else }}
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
+				{{ $.Receiver }}.{{ $arm.GoField }} = val
+				{{ $.Receiver }}.present |= {{ $arm.BitConst }}
+{{- end }}
+{{- end }}
+			default:
+				return newErrUnknownField({{ printf "%q" $.Name }}, typeCode, fieldCode)
+			}
+{{- else }}
 {{- if eq $first.XRPLType "Amount" }}
 {{- if $first.XRPOnly }}
 			val, err := sr.readAmount()
@@ -369,11 +402,6 @@ func ({{ .Receiver }} *{{ .StructName }}) Decode(data []byte) error {
 			val := int(u16Val)
 {{- else if eq $first.XRPLType "UInt32" }}
 			val, err := sr.readUint32()
-			if err != nil {
-				return err
-			}
-{{- else if eq $first.XRPLType "UInt64" }}
-			val, err := sr.readUint64Hex()
 			if err != nil {
 				return err
 			}
@@ -461,6 +489,7 @@ func ({{ .Receiver }} *{{ .StructName }}) Decode(data []byte) error {
 			default:
 				return newErrUnknownField({{ printf "%q" $.Name }}, typeCode, fieldCode)
 			}
+{{- end }}
 {{- end }}
 		default:
 			return newErrUnknownField({{ printf "%q" $.Name }}, typeCode, fieldCode)

--- a/internal/tx/ledgerfields/credential_gen.go
+++ b/internal/tx/ledgerfields/credential_gen.go
@@ -81,15 +81,19 @@ func (c *Credential) Decode(data []byte) error {
 				return newErrUnknownField("Credential", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 27:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				c.IssuerNode = val
 				c.present |= credentialBitIssuerNode
 			case 28:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				c.SubjectNode = val
 				c.present |= credentialBitSubjectNode
 			default:

--- a/internal/tx/ledgerfields/credential_gen.go
+++ b/internal/tx/ledgerfields/credential_gen.go
@@ -19,8 +19,8 @@ type Credential struct {
 	CredentialType    string // Blob (uppercase hex)
 	Expiration        uint32
 	URI               string // Blob (uppercase hex)
-	IssuerNode        string // UInt64 (uppercase hex)
-	SubjectNode       string // UInt64 (uppercase hex)
+	IssuerNode        string // UInt64 (lowercase hex, no leading zeros)
+	SubjectNode       string // UInt64 (lowercase hex, no leading zeros)
 	Flags             uint32
 	PreviousTxnID     string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq uint32

--- a/internal/tx/ledgerfields/decode_stream.go
+++ b/internal/tx/ledgerfields/decode_stream.go
@@ -83,15 +83,17 @@ func (r *streamReader) readUint8() (byte, error) {
 	return v, nil
 }
 
-// readUint64Hex reads 8 bytes and returns the uppercase hex string — the
-// canonical decoded form used by binarycodec.Decode for UInt64 fields.
+// readUint64Hex reads 8 bytes and returns the lowercase hex string with no
+// leading zeros — the canonical decoded form used by binarycodec.Decode for
+// UInt64 fields, matching rippled's STUInt64::getJson (std::to_chars base 16,
+// see rippled src/libxrpl/protocol/STInteger.cpp).
 func (r *streamReader) readUint64Hex() (string, error) {
 	if r.pos+8 > len(r.data) {
 		return "", errors.New("ledgerfields: out of bounds reading UInt64")
 	}
-	s := upperHex(r.data[r.pos : r.pos+8])
+	v := binary.BigEndian.Uint64(r.data[r.pos : r.pos+8])
 	r.pos += 8
-	return s, nil
+	return strconv.FormatUint(v, 16), nil
 }
 
 func (r *streamReader) readHash(n int) (string, error) {

--- a/internal/tx/ledgerfields/decode_stream.go
+++ b/internal/tx/ledgerfields/decode_stream.go
@@ -84,16 +84,36 @@ func (r *streamReader) readUint8() (byte, error) {
 }
 
 // readUint64Hex reads 8 bytes and returns the lowercase hex string with no
-// leading zeros — the canonical decoded form used by binarycodec.Decode for
-// UInt64 fields, matching rippled's STUInt64::getJson (std::to_chars base 16,
-// see rippled src/libxrpl/protocol/STInteger.cpp).
+// leading zeros — see rippled STUInt64::getJson hex branch
+// (src/libxrpl/protocol/STInteger.cpp:251).
 func (r *streamReader) readUint64Hex() (string, error) {
+	v, err := r.readUint64Raw()
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatUint(v, 16), nil
+}
+
+// readUint64Decimal reads 8 bytes and returns the decimal string — see
+// rippled STUInt64::getJson base-10 branch
+// (src/libxrpl/protocol/STInteger.cpp:248), used for SFields flagged
+// sMD_BaseTen (sfMaximumAmount, sfOutstandingAmount, sfMPTAmount,
+// sfLockedAmount).
+func (r *streamReader) readUint64Decimal() (string, error) {
+	v, err := r.readUint64Raw()
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatUint(v, 10), nil
+}
+
+func (r *streamReader) readUint64Raw() (uint64, error) {
 	if r.pos+8 > len(r.data) {
-		return "", errors.New("ledgerfields: out of bounds reading UInt64")
+		return 0, errors.New("ledgerfields: out of bounds reading UInt64")
 	}
 	v := binary.BigEndian.Uint64(r.data[r.pos : r.pos+8])
 	r.pos += 8
-	return strconv.FormatUint(v, 16), nil
+	return v, nil
 }
 
 func (r *streamReader) readHash(n int) (string, error) {

--- a/internal/tx/ledgerfields/decode_stream_test.go
+++ b/internal/tx/ledgerfields/decode_stream_test.go
@@ -104,3 +104,40 @@ func TestReadAmountAny_MatchesCodec(t *testing.T) {
 		})
 	}
 }
+
+// TestReadUint64_HexVsDecimal pins the two streamReader UInt64 emit modes
+// against rippled's STUInt64::getJson branches:
+//   - hex (default)            — rippled STInteger.cpp:251
+//   - decimal (sMD_BaseTen)    — rippled STInteger.cpp:248
+func TestReadUint64_HexVsDecimal(t *testing.T) {
+	cases := []struct {
+		name    string
+		blob    []byte
+		hex     string
+		decimal string
+	}{
+		{name: "zero", blob: []byte{0, 0, 0, 0, 0, 0, 0, 0}, hex: "0", decimal: "0"},
+		{name: "small", blob: []byte{0, 0, 0, 0, 0, 0, 0, 100}, hex: "64", decimal: "100"},
+		{name: "mpt_amount_9990", blob: []byte{0, 0, 0, 0, 0, 0, 0x27, 0x06}, hex: "2706", decimal: "9990"},
+		{name: "max_int64", blob: []byte{0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, hex: "7fffffffffffffff", decimal: "9223372036854775807"},
+		{name: "max_uint64", blob: []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, hex: "ffffffffffffffff", decimal: "18446744073709551615"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHex, err := newStreamReader(tc.blob).readUint64Hex()
+			if err != nil {
+				t.Fatalf("readUint64Hex: %v", err)
+			}
+			if gotHex != tc.hex {
+				t.Errorf("hex mismatch: want %q got %q", tc.hex, gotHex)
+			}
+			gotDec, err := newStreamReader(tc.blob).readUint64Decimal()
+			if err != nil {
+				t.Fatalf("readUint64Decimal: %v", err)
+			}
+			if gotDec != tc.decimal {
+				t.Errorf("decimal mismatch: want %q got %q", tc.decimal, gotDec)
+			}
+		})
+	}
+}

--- a/internal/tx/ledgerfields/delegate_gen.go
+++ b/internal/tx/ledgerfields/delegate_gen.go
@@ -17,7 +17,7 @@ type Delegate struct {
 	Account           string // AccountID (base58)
 	Authorize         string // AccountID (base58)
 	Permissions       []any
-	OwnerNode         string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	Flags             uint32
 	PreviousTxnID     string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq uint32

--- a/internal/tx/ledgerfields/delegate_gen.go
+++ b/internal/tx/ledgerfields/delegate_gen.go
@@ -72,12 +72,12 @@ func (d *Delegate) Decode(data []byte) error {
 				return newErrUnknownField("Delegate", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				d.OwnerNode = val
 				d.present |= delegateBitOwnerNode
 			default:

--- a/internal/tx/ledgerfields/deposit_preauth_gen.go
+++ b/internal/tx/ledgerfields/deposit_preauth_gen.go
@@ -16,7 +16,7 @@ type DepositPreauth struct {
 	present              uint64
 	Account              string // AccountID (base58)
 	Authorize            string // AccountID (base58)
-	OwnerNode            string // UInt64 (uppercase hex)
+	OwnerNode            string // UInt64 (lowercase hex, no leading zeros)
 	AuthorizeCredentials []any
 	Flags                uint32
 	PreviousTxnID        string // Hash256 (uppercase hex)

--- a/internal/tx/ledgerfields/deposit_preauth_gen.go
+++ b/internal/tx/ledgerfields/deposit_preauth_gen.go
@@ -72,12 +72,12 @@ func (d *DepositPreauth) Decode(data []byte) error {
 				return newErrUnknownField("DepositPreauth", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				d.OwnerNode = val
 				d.present |= depositpreauthBitOwnerNode
 			default:

--- a/internal/tx/ledgerfields/did_gen.go
+++ b/internal/tx/ledgerfields/did_gen.go
@@ -18,7 +18,7 @@ type DID struct {
 	DIDDocument       string // Blob (uppercase hex)
 	URI               string // Blob (uppercase hex)
 	Data              string // Blob (uppercase hex)
-	OwnerNode         string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	Flags             uint32
 	PreviousTxnID     string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq uint32

--- a/internal/tx/ledgerfields/did_gen.go
+++ b/internal/tx/ledgerfields/did_gen.go
@@ -74,12 +74,12 @@ func (d *DID) Decode(data []byte) error {
 				return newErrUnknownField("DID", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				d.OwnerNode = val
 				d.present |= didBitOwnerNode
 			default:

--- a/internal/tx/ledgerfields/directory_node_gen.go
+++ b/internal/tx/ledgerfields/directory_node_gen.go
@@ -16,14 +16,14 @@ type DirectoryNode struct {
 	present           uint64
 	Flags             uint32
 	RootIndex         string // Hash256 (uppercase hex)
-	IndexNext         string // UInt64 (uppercase hex)
-	IndexPrevious     string // UInt64 (uppercase hex)
+	IndexNext         string // UInt64 (lowercase hex, no leading zeros)
+	IndexPrevious     string // UInt64 (lowercase hex, no leading zeros)
 	Owner             string // AccountID (base58)
 	TakerPaysCurrency string // Hash160 (uppercase hex)
 	TakerPaysIssuer   string // Hash160 (uppercase hex)
 	TakerGetsCurrency string // Hash160 (uppercase hex)
 	TakerGetsIssuer   string // Hash160 (uppercase hex)
-	ExchangeRate      string // UInt64 (uppercase hex)
+	ExchangeRate      string // UInt64 (lowercase hex, no leading zeros)
 	NFTokenID         string // Hash256 (uppercase hex)
 	DomainID          string // Hash256 (uppercase hex)
 	PreviousTxnID     string // Hash256 (uppercase hex)

--- a/internal/tx/ledgerfields/directory_node_gen.go
+++ b/internal/tx/ledgerfields/directory_node_gen.go
@@ -87,18 +87,26 @@ func (d *DirectoryNode) Decode(data []byte) error {
 				return newErrUnknownField("DirectoryNode", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 1:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				d.IndexNext = val
 				d.present |= directorynodeBitIndexNext
 			case 2:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				d.IndexPrevious = val
 				d.present |= directorynodeBitIndexPrevious
 			case 6:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				d.ExchangeRate = val
 				d.present |= directorynodeBitExchangeRate
 			default:

--- a/internal/tx/ledgerfields/escrow_gen.go
+++ b/internal/tx/ledgerfields/escrow_gen.go
@@ -103,18 +103,26 @@ func (e *Escrow) Decode(data []byte) error {
 				return newErrUnknownField("Escrow", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				e.OwnerNode = val
 				e.present |= escrowBitOwnerNode
 			case 9:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				e.DestinationNode = val
 				e.present |= escrowBitDestinationNode
 			case 27:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				e.IssuerNode = val
 				e.present |= escrowBitIssuerNode
 			default:

--- a/internal/tx/ledgerfields/escrow_gen.go
+++ b/internal/tx/ledgerfields/escrow_gen.go
@@ -22,10 +22,10 @@ type Escrow struct {
 	FinishAfter       uint32
 	SourceTag         uint32
 	DestinationTag    uint32
-	OwnerNode         string // UInt64 (uppercase hex)
-	DestinationNode   string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
+	DestinationNode   string // UInt64 (lowercase hex, no leading zeros)
 	TransferRate      uint32
-	IssuerNode        string // UInt64 (uppercase hex)
+	IssuerNode        string // UInt64 (lowercase hex, no leading zeros)
 	Flags             uint32
 	PreviousTxnID     string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq uint32

--- a/internal/tx/ledgerfields/fee_settings_gen.go
+++ b/internal/tx/ledgerfields/fee_settings_gen.go
@@ -14,7 +14,7 @@ func init() {
 // the decoded blob so the emit methods only write entries that actually exist.
 type FeeSettings struct {
 	present               uint64
-	BaseFee               string // UInt64 (uppercase hex)
+	BaseFee               string // UInt64 (lowercase hex, no leading zeros)
 	ReferenceFeeUnits     uint32
 	ReserveBase           uint32
 	ReserveIncrement      uint32

--- a/internal/tx/ledgerfields/fee_settings_gen.go
+++ b/internal/tx/ledgerfields/fee_settings_gen.go
@@ -82,12 +82,12 @@ func (f *FeeSettings) Decode(data []byte) error {
 				return newErrUnknownField("FeeSettings", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 5:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				f.BaseFee = val
 				f.present |= feesettingsBitBaseFee
 			default:

--- a/internal/tx/ledgerfields/mp_token_gen.go
+++ b/internal/tx/ledgerfields/mp_token_gen.go
@@ -18,8 +18,8 @@ type MPToken struct {
 	Issuer            string // AccountID (base58)
 	Sequence          uint32
 	MPTokenIssuanceID string
-	MPTAmount         string // UInt64 (lowercase hex, no leading zeros)
-	LockedAmount      string // UInt64 (lowercase hex, no leading zeros)
+	MPTAmount         string // UInt64 (decimal string, sMD_BaseTen)
+	LockedAmount      string // UInt64 (decimal string, sMD_BaseTen)
 	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	Flags             uint32
 	PreviousTxnID     string // Hash256 (uppercase hex)
@@ -81,18 +81,26 @@ func (m *MPToken) Decode(data []byte) error {
 				return newErrUnknownField("MPToken", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				m.OwnerNode = val
 				m.present |= mptokenBitOwnerNode
 			case 26:
+				val, err := sr.readUint64Decimal()
+				if err != nil {
+					return err
+				}
 				m.MPTAmount = val
 				m.present |= mptokenBitMPTAmount
 			case 29:
+				val, err := sr.readUint64Decimal()
+				if err != nil {
+					return err
+				}
 				m.LockedAmount = val
 				m.present |= mptokenBitLockedAmount
 			default:

--- a/internal/tx/ledgerfields/mp_token_gen.go
+++ b/internal/tx/ledgerfields/mp_token_gen.go
@@ -18,9 +18,9 @@ type MPToken struct {
 	Issuer            string // AccountID (base58)
 	Sequence          uint32
 	MPTokenIssuanceID string
-	MPTAmount         string // UInt64 (uppercase hex)
-	LockedAmount      string // UInt64 (uppercase hex)
-	OwnerNode         string // UInt64 (uppercase hex)
+	MPTAmount         string // UInt64 (lowercase hex, no leading zeros)
+	LockedAmount      string // UInt64 (lowercase hex, no leading zeros)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	Flags             uint32
 	PreviousTxnID     string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq uint32

--- a/internal/tx/ledgerfields/mp_token_issuance_gen.go
+++ b/internal/tx/ledgerfields/mp_token_issuance_gen.go
@@ -19,9 +19,9 @@ type MPTokenIssuance struct {
 	TransferFee       int
 	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	AssetScale        int
-	MaximumAmount     string // UInt64 (lowercase hex, no leading zeros)
-	OutstandingAmount string // UInt64 (lowercase hex, no leading zeros)
-	LockedAmount      string // UInt64 (lowercase hex, no leading zeros)
+	MaximumAmount     string // UInt64 (decimal string, sMD_BaseTen)
+	OutstandingAmount string // UInt64 (decimal string, sMD_BaseTen)
+	LockedAmount      string // UInt64 (decimal string, sMD_BaseTen)
 	MPTokenMetadata   string // Blob (uppercase hex)
 	DomainID          string // Hash256 (uppercase hex)
 	Flags             uint32
@@ -90,21 +90,33 @@ func (m *MPTokenIssuance) Decode(data []byte) error {
 				return newErrUnknownField("MPTokenIssuance", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				m.OwnerNode = val
 				m.present |= mptokenissuanceBitOwnerNode
 			case 24:
+				val, err := sr.readUint64Decimal()
+				if err != nil {
+					return err
+				}
 				m.MaximumAmount = val
 				m.present |= mptokenissuanceBitMaximumAmount
 			case 25:
+				val, err := sr.readUint64Decimal()
+				if err != nil {
+					return err
+				}
 				m.OutstandingAmount = val
 				m.present |= mptokenissuanceBitOutstandingAmount
 			case 29:
+				val, err := sr.readUint64Decimal()
+				if err != nil {
+					return err
+				}
 				m.LockedAmount = val
 				m.present |= mptokenissuanceBitLockedAmount
 			default:

--- a/internal/tx/ledgerfields/mp_token_issuance_gen.go
+++ b/internal/tx/ledgerfields/mp_token_issuance_gen.go
@@ -17,11 +17,11 @@ type MPTokenIssuance struct {
 	Issuer            string // AccountID (base58)
 	Sequence          uint32
 	TransferFee       int
-	OwnerNode         string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	AssetScale        int
-	MaximumAmount     string // UInt64 (uppercase hex)
-	OutstandingAmount string // UInt64 (uppercase hex)
-	LockedAmount      string // UInt64 (uppercase hex)
+	MaximumAmount     string // UInt64 (lowercase hex, no leading zeros)
+	OutstandingAmount string // UInt64 (lowercase hex, no leading zeros)
+	LockedAmount      string // UInt64 (lowercase hex, no leading zeros)
 	MPTokenMetadata   string // Blob (uppercase hex)
 	DomainID          string // Hash256 (uppercase hex)
 	Flags             uint32

--- a/internal/tx/ledgerfields/nf_token_offer_gen.go
+++ b/internal/tx/ledgerfields/nf_token_offer_gen.go
@@ -18,8 +18,8 @@ type NFTokenOffer struct {
 	Owner             string // AccountID (base58)
 	NFTokenID         string // Hash256 (uppercase hex)
 	Amount            any    // Amount (XRP string | IOU map)
-	OwnerNode         string // UInt64 (uppercase hex)
-	NFTokenOfferNode  string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
+	NFTokenOfferNode  string // UInt64 (lowercase hex, no leading zeros)
 	Destination       string // AccountID (base58)
 	Expiration        uint32
 	Flags             uint32

--- a/internal/tx/ledgerfields/nf_token_offer_gen.go
+++ b/internal/tx/ledgerfields/nf_token_offer_gen.go
@@ -83,15 +83,19 @@ func (n *NFTokenOffer) Decode(data []byte) error {
 				return newErrUnknownField("NFTokenOffer", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				n.OwnerNode = val
 				n.present |= nftokenofferBitOwnerNode
 			case 12:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				n.NFTokenOfferNode = val
 				n.present |= nftokenofferBitNFTokenOfferNode
 			default:

--- a/internal/tx/ledgerfields/offer_gen.go
+++ b/internal/tx/ledgerfields/offer_gen.go
@@ -19,8 +19,8 @@ type Offer struct {
 	TakerPays         any    // Amount (XRP string | IOU map)
 	TakerGets         any    // Amount (XRP string | IOU map)
 	BookDirectory     string // Hash256 (uppercase hex)
-	BookNode          string // UInt64 (uppercase hex)
-	OwnerNode         string // UInt64 (uppercase hex)
+	BookNode          string // UInt64 (lowercase hex, no leading zeros)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	Expiration        uint32
 	Flags             uint32
 	DomainID          string // Hash256 (uppercase hex)

--- a/internal/tx/ledgerfields/offer_gen.go
+++ b/internal/tx/ledgerfields/offer_gen.go
@@ -90,15 +90,19 @@ func (o *Offer) Decode(data []byte) error {
 				return newErrUnknownField("Offer", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 3:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				o.BookNode = val
 				o.present |= offerBitBookNode
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				o.OwnerNode = val
 				o.present |= offerBitOwnerNode
 			default:

--- a/internal/tx/ledgerfields/oracle_gen.go
+++ b/internal/tx/ledgerfields/oracle_gen.go
@@ -20,7 +20,7 @@ type Oracle struct {
 	AssetClass        string // Blob (uppercase hex)
 	LastUpdateTime    uint32
 	URI               string // Blob (uppercase hex)
-	OwnerNode         string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	Flags             uint32
 	PreviousTxnID     string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq uint32

--- a/internal/tx/ledgerfields/oracle_gen.go
+++ b/internal/tx/ledgerfields/oracle_gen.go
@@ -81,12 +81,12 @@ func (o *Oracle) Decode(data []byte) error {
 				return newErrUnknownField("Oracle", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				o.OwnerNode = val
 				o.present |= oracleBitOwnerNode
 			default:

--- a/internal/tx/ledgerfields/pay_channel_gen.go
+++ b/internal/tx/ledgerfields/pay_channel_gen.go
@@ -103,15 +103,19 @@ func (p *PayChannel) Decode(data []byte) error {
 				return newErrUnknownField("PayChannel", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				p.OwnerNode = val
 				p.present |= paychannelBitOwnerNode
 			case 9:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				p.DestinationNode = val
 				p.present |= paychannelBitDestinationNode
 			default:

--- a/internal/tx/ledgerfields/pay_channel_gen.go
+++ b/internal/tx/ledgerfields/pay_channel_gen.go
@@ -24,8 +24,8 @@ type PayChannel struct {
 	CancelAfter       uint32
 	SourceTag         uint32
 	DestinationTag    uint32
-	OwnerNode         string // UInt64 (uppercase hex)
-	DestinationNode   string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
+	DestinationNode   string // UInt64 (lowercase hex, no leading zeros)
 	Flags             uint32
 	PreviousTxnID     string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq uint32

--- a/internal/tx/ledgerfields/permissioned_domain_gen.go
+++ b/internal/tx/ledgerfields/permissioned_domain_gen.go
@@ -75,12 +75,12 @@ func (p *PermissionedDomain) Decode(data []byte) error {
 				return newErrUnknownField("PermissionedDomain", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				p.OwnerNode = val
 				p.present |= permissioneddomainBitOwnerNode
 			default:

--- a/internal/tx/ledgerfields/permissioned_domain_gen.go
+++ b/internal/tx/ledgerfields/permissioned_domain_gen.go
@@ -17,7 +17,7 @@ type PermissionedDomain struct {
 	Owner               string // AccountID (base58)
 	Sequence            uint32
 	AcceptedCredentials []any
-	OwnerNode           string // UInt64 (uppercase hex)
+	OwnerNode           string // UInt64 (lowercase hex, no leading zeros)
 	Flags               uint32
 	PreviousTxnID       string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq   uint32

--- a/internal/tx/ledgerfields/ripple_state_gen.go
+++ b/internal/tx/ledgerfields/ripple_state_gen.go
@@ -18,8 +18,8 @@ type RippleState struct {
 	Balance           any    // Amount (XRP string | IOU map)
 	LowLimit          any    // Amount (XRP string | IOU map)
 	HighLimit         any    // Amount (XRP string | IOU map)
-	LowNode           string // UInt64 (uppercase hex)
-	HighNode          string // UInt64 (uppercase hex)
+	LowNode           string // UInt64 (lowercase hex, no leading zeros)
+	HighNode          string // UInt64 (lowercase hex, no leading zeros)
 	LowQualityIn      uint32
 	LowQualityOut     uint32
 	HighQualityIn     uint32

--- a/internal/tx/ledgerfields/ripple_state_gen.go
+++ b/internal/tx/ledgerfields/ripple_state_gen.go
@@ -94,15 +94,19 @@ func (r *RippleState) Decode(data []byte) error {
 				return newErrUnknownField("RippleState", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 7:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				r.LowNode = val
 				r.present |= ripplestateBitLowNode
 			case 8:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				r.HighNode = val
 				r.present |= ripplestateBitHighNode
 			default:

--- a/internal/tx/ledgerfields/signer_list_gen.go
+++ b/internal/tx/ledgerfields/signer_list_gen.go
@@ -15,7 +15,7 @@ func init() {
 type SignerList struct {
 	present           uint64
 	Account           string // AccountID (base58)
-	OwnerNode         string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	SignerQuorum      uint32
 	SignerEntries     []any
 	SignerListID      uint32

--- a/internal/tx/ledgerfields/signer_list_gen.go
+++ b/internal/tx/ledgerfields/signer_list_gen.go
@@ -80,12 +80,12 @@ func (s *SignerList) Decode(data []byte) error {
 				return newErrUnknownField("SignerList", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				s.OwnerNode = val
 				s.present |= signerlistBitOwnerNode
 			default:

--- a/internal/tx/ledgerfields/ticket_gen.go
+++ b/internal/tx/ledgerfields/ticket_gen.go
@@ -15,7 +15,7 @@ func init() {
 type Ticket struct {
 	present           uint64
 	Account           string // AccountID (base58)
-	OwnerNode         string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	TicketSequence    uint32
 	Flags             uint32
 	PreviousTxnID     string // Hash256 (uppercase hex)

--- a/internal/tx/ledgerfields/ticket_gen.go
+++ b/internal/tx/ledgerfields/ticket_gen.go
@@ -73,12 +73,12 @@ func (t *Ticket) Decode(data []byte) error {
 				return newErrUnknownField("Ticket", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				t.OwnerNode = val
 				t.present |= ticketBitOwnerNode
 			default:

--- a/internal/tx/ledgerfields/vault_gen.go
+++ b/internal/tx/ledgerfields/vault_gen.go
@@ -15,7 +15,7 @@ func init() {
 type Vault struct {
 	present           uint64
 	Sequence          uint32
-	OwnerNode         string // UInt64 (uppercase hex)
+	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	Owner             string // AccountID (base58)
 	Account           string // AccountID (base58)
 	Data              string // Blob (uppercase hex)

--- a/internal/tx/ledgerfields/vault_gen.go
+++ b/internal/tx/ledgerfields/vault_gen.go
@@ -86,12 +86,12 @@ func (v *Vault) Decode(data []byte) error {
 				return newErrUnknownField("Vault", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				v.OwnerNode = val
 				v.present |= vaultBitOwnerNode
 			default:

--- a/internal/tx/ledgerfields/x_chain_owned_claim_id_gen.go
+++ b/internal/tx/ledgerfields/x_chain_owned_claim_id_gen.go
@@ -16,11 +16,11 @@ type XChainOwnedClaimID struct {
 	present                 uint64
 	Account                 string // AccountID (base58)
 	XChainBridge            any
-	XChainClaimID           string // UInt64 (uppercase hex)
+	XChainClaimID           string // UInt64 (lowercase hex, no leading zeros)
 	OtherChainSource        string // AccountID (base58)
 	XChainClaimAttestations []any
 	SignatureReward         any    // Amount (XRP string | IOU map)
-	OwnerNode               string // UInt64 (uppercase hex)
+	OwnerNode               string // UInt64 (lowercase hex, no leading zeros)
 	PreviousTxnID           string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq       uint32
 }

--- a/internal/tx/ledgerfields/x_chain_owned_claim_id_gen.go
+++ b/internal/tx/ledgerfields/x_chain_owned_claim_id_gen.go
@@ -73,15 +73,19 @@ func (x *XChainOwnedClaimID) Decode(data []byte) error {
 				return newErrUnknownField("XChainOwnedClaimID", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				x.OwnerNode = val
 				x.present |= xchainownedclaimidBitOwnerNode
 			case 20:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				x.XChainClaimID = val
 				x.present |= xchainownedclaimidBitXChainClaimID
 			default:

--- a/internal/tx/ledgerfields/x_chain_owned_create_account_claim_id_gen.go
+++ b/internal/tx/ledgerfields/x_chain_owned_create_account_claim_id_gen.go
@@ -69,15 +69,19 @@ func (x *XChainOwnedCreateAccountClaimID) Decode(data []byte) error {
 				return newErrUnknownField("XChainOwnedCreateAccountClaimID", typeCode, fieldCode)
 			}
 		case 3: // UInt64
-			val, err := sr.readUint64Hex()
-			if err != nil {
-				return err
-			}
 			switch fieldCode {
 			case 4:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				x.OwnerNode = val
 				x.present |= xchainownedcreateaccountclaimidBitOwnerNode
 			case 21:
+				val, err := sr.readUint64Hex()
+				if err != nil {
+					return err
+				}
 				x.XChainAccountCreateCount = val
 				x.present |= xchainownedcreateaccountclaimidBitXChainAccountCreateCount
 			default:

--- a/internal/tx/ledgerfields/x_chain_owned_create_account_claim_id_gen.go
+++ b/internal/tx/ledgerfields/x_chain_owned_create_account_claim_id_gen.go
@@ -16,9 +16,9 @@ type XChainOwnedCreateAccountClaimID struct {
 	present                         uint64
 	Account                         string // AccountID (base58)
 	XChainBridge                    any
-	XChainAccountCreateCount        string // UInt64 (uppercase hex)
+	XChainAccountCreateCount        string // UInt64 (lowercase hex, no leading zeros)
 	XChainCreateAccountAttestations []any
-	OwnerNode                       string // UInt64 (uppercase hex)
+	OwnerNode                       string // UInt64 (lowercase hex, no leading zeros)
 	PreviousTxnID                   string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq               uint32
 }


### PR DESCRIPTION
## Summary

- Match rippled's `STUInt64::getJson` (`std::to_chars(value, 16)`): emit UInt64 RPC fields (`BaseFee`, `OwnerNode`, `HighNode`, `BookNode`, etc.) as lowercase hex with no leading zeros, instead of a 16-char zero-padded uppercase string.
- Update both the generic `binarycodec` decoder and the typed `ledgerfields` fast-path used in metadata building, plus the codegen template that emits the typed structs.
- Binary serialization is unchanged; only the JSON shape changes, eliminating spurious differences when diffing `ledger_data` and similar RPC output against rippled.

## Test plan
- [x] `just test-pkg ./codec/binarycodec/...`
- [x] `just test-pkg ./internal/tx/...` (includes the typed↔generic metadata parity tests)
- [x] `just test-pkg ./internal/consensus/feevote/...`
- [x] `just build`
- [ ] CI

Fixes #471