### PR TITLE
fix: uppercase hex hashes in RPC responses to match rippled

### DIFF
--- a/internal/rpc/handlers/account_objects.go
+++ b/internal/rpc/handlers/account_objects.go
@@ -199,13 +199,13 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		if err != nil {
 			// Fallback to raw data if decode fails
 			objects = append(objects, map[string]interface{}{
-				"index":           obj.Index,
+				"index":           strings.ToUpper(obj.Index),
 				"LedgerEntryType": obj.LedgerEntryType,
-				"data":            hexData,
+				"data":            strings.ToUpper(hexData),
 			})
 			continue
 		}
-		decoded["index"] = obj.Index
+		decoded["index"] = strings.ToUpper(obj.Index)
 		objects = append(objects, decoded)
 	}
 

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -193,7 +193,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	}
 
 	if ammEntry.LedgerHash != [32]byte{} {
-		response["ledger_hash"] = hex.EncodeToString(ammEntry.LedgerHash[:])
+		response["ledger_hash"] = FormatLedgerHash(ammEntry.LedgerHash)
 	}
 
 	return response, nil

--- a/internal/rpc/handlers/ledger_closed.go
+++ b/internal/rpc/handlers/ledger_closed.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/hex"
 	"encoding/json"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -27,7 +26,7 @@ func (m *LedgerClosedMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 
 	hash := ledger.Hash()
 	response := map[string]interface{}{
-		"ledger_hash":  hex.EncodeToString(hash[:]),
+		"ledger_hash":  FormatLedgerHash(hash),
 		"ledger_index": seq,
 	}
 

--- a/internal/rpc/handlers/ledger_range.go
+++ b/internal/rpc/handlers/ledger_range.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -50,7 +49,7 @@ func (m *LedgerRangeMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	for seq, hash := range result.Hashes {
 		ledgers = append(ledgers, map[string]interface{}{
 			"ledger_index": seq,
-			"ledger_hash":  hex.EncodeToString(hash[:]),
+			"ledger_hash":  FormatLedgerHash(hash),
 		})
 	}
 

--- a/internal/rpc/handlers/nft_buy_offers.go
+++ b/internal/rpc/handlers/nft_buy_offers.go
@@ -117,7 +117,7 @@ func buildNFTOffersResponse(nftIDHex string, result *types.NFTOffersResult, limi
 	response := map[string]interface{}{
 		"nft_id":       nftIDHex,
 		"offers":       offers,
-		"ledger_hash":  strings.ToUpper(FormatLedgerHash(result.LedgerHash)),
+		"ledger_hash":  FormatLedgerHash(result.LedgerHash),
 		"ledger_index": result.LedgerIndex,
 		"validated":    result.Validated,
 	}

--- a/internal/rpc/handlers/tx.go
+++ b/internal/rpc/handlers/tx.go
@@ -247,7 +247,7 @@ func (m *TxMethod) lookupByCTID(ctx *types.RpcContext, ledgerSeq uint32, txIndex
 	validated := ledger.IsValidated()
 	closeTimeSec := ledger.CloseTime()
 	ledgerHash := ledger.Hash()
-	ledgerHashStr := strings.ToUpper(fmt.Sprintf("%x", ledgerHash))
+	ledgerHashStr := fmt.Sprintf("%X", ledgerHash)
 
 	// Decode the VL-encoded blob into tx + meta
 	storedTx, decodeErr := decodeTxBlob(foundData)

--- a/internal/rpc/handlers/vault_info.go
+++ b/internal/rpc/handlers/vault_info.go
@@ -109,7 +109,7 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	}
 
 	if vaultEntry.LedgerHash != [32]byte{} {
-		response["ledger_hash"] = hex.EncodeToString(vaultEntry.LedgerHash[:])
+		response["ledger_hash"] = FormatLedgerHash(vaultEntry.LedgerHash)
 	}
 
 	return response, nil

--- a/internal/rpc/hex_case_test.go
+++ b/internal/rpc/hex_case_test.go
@@ -96,4 +96,24 @@ func TestRPCHexCaseRegression(t *testing.T) {
 		require.NotEmpty(t, idx)
 		assert.Equal(t, strings.ToUpper(idx), idx, "account_objects[*].index must be uppercase")
 	})
+
+	// FormatLedgerHash / FormatHash are the single chokepoint that
+	// LedgerServiceAdapter.GetAccountInfo, GetTransaction, and GetLedgerEntry
+	// all funnel through for hash-like response fields (LedgerHash, Index,
+	// PreviousTxnID, NodeBinary). Pinning the chokepoint covers every adapter
+	// field that previously regressed in issue #475.
+	t.Run("FormatLedgerHash uppercase invariant", func(t *testing.T) {
+		var h [32]byte
+		h[0] = 0xab
+		h[15] = 0xcd
+		h[31] = 0xef
+		got := handlers.FormatLedgerHash(h)
+		require.Len(t, got, 64)
+		assert.Equal(t, strings.ToUpper(got), got, "FormatLedgerHash must return uppercase hex")
+	})
+
+	t.Run("FormatHash uppercase invariant", func(t *testing.T) {
+		got := handlers.FormatHash([]byte{0xab, 0xcd, 0xef})
+		assert.Equal(t, "ABCDEF", got, "FormatHash must return uppercase hex")
+	})
 }

--- a/internal/rpc/hex_case_test.go
+++ b/internal/rpc/hex_case_test.go
@@ -1,0 +1,99 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRPCHexCaseRegression locks in the rippled-compatible uppercase-hex
+// convention for hash-like response fields. Rippled returns every hash and
+// ledger entry index as uppercase hex (see strHex() in
+// rippled/src/libxrpl/basics/StringUtilities.cpp); clients diff responses
+// byte-for-byte, so any lowercase regression silently breaks them.
+//
+// See issue #475.
+func TestRPCHexCaseRegression(t *testing.T) {
+	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+	t.Run("ledger_closed", func(t *testing.T) {
+		mock := &ledgerClosedMock{mockLedgerService: newMockLedgerService()}
+		var closedHash [32]byte
+		closedHash[0] = 0xAB
+		closedHash[1] = 0xCD
+		closedHash[31] = 0xEF
+		mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
+			return &mockLedgerReader{seq: 2, hash: closedHash, closed: true, validated: true}, nil
+		}
+
+		method := &handlers.LedgerClosedMethod{}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
+
+		result, rpcErr := method.Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+		resp := resultToMapClosed(t, result)
+		hash, _ := resp["ledger_hash"].(string)
+		assert.Equal(t, strings.ToUpper(hash), hash, "ledger_closed ledger_hash must be uppercase")
+	})
+
+	t.Run("account_objects per-object index", func(t *testing.T) {
+		mock := newAccountObjectsMock()
+		mock.getAccountObjectsFn = func(account string, _ string, _ string, _ uint32) (*types.AccountObjectsResult, error) {
+			return &types.AccountObjectsResult{
+				Account: account,
+				AccountObjects: []types.AccountObjectItem{
+					{
+						Index:           "abc123def456",
+						LedgerEntryType: "Offer",
+						// Force the decode-fallback path by passing empty Data.
+						Data: []byte{},
+					},
+				},
+				LedgerIndex: 2,
+				LedgerHash:  [32]byte{0xAA, 0xBB, 0xCC},
+				Validated:   true,
+			}, nil
+		}
+
+		method := &handlers.AccountObjectsMethod{}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
+
+		params, err := json.Marshal(map[string]interface{}{"account": validAccount})
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, params)
+		require.Nil(t, rpcErr)
+
+		resultJSON, err := json.Marshal(result)
+		require.NoError(t, err)
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(resultJSON, &resp))
+
+		ledgerHash, _ := resp["ledger_hash"].(string)
+		assert.Equal(t, strings.ToUpper(ledgerHash), ledgerHash, "ledger_hash must be uppercase")
+
+		objs, ok := resp["account_objects"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, objs, 1)
+		obj := objs[0].(map[string]interface{})
+		idx, _ := obj["index"].(string)
+		require.NotEmpty(t, idx)
+		assert.Equal(t, strings.ToUpper(idx), idx, "account_objects[*].index must be uppercase")
+	})
+}

--- a/internal/rpc/hex_case_test.go
+++ b/internal/rpc/hex_case_test.go
@@ -97,11 +97,8 @@ func TestRPCHexCaseRegression(t *testing.T) {
 		assert.Equal(t, strings.ToUpper(idx), idx, "account_objects[*].index must be uppercase")
 	})
 
-	// FormatLedgerHash / FormatHash are the single chokepoint that
-	// LedgerServiceAdapter.GetAccountInfo, GetTransaction, and GetLedgerEntry
-	// all funnel through for hash-like response fields (LedgerHash, Index,
-	// PreviousTxnID, NodeBinary). Pinning the chokepoint covers every adapter
-	// field that previously regressed in issue #475.
+	// LedgerServiceAdapter routes every hash-like field through these helpers,
+	// so pinning them locks the adapter-fed sites that regressed in issue #475.
 	t.Run("FormatLedgerHash uppercase invariant", func(t *testing.T) {
 		var h [32]byte
 		h[0] = 0xab

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -284,7 +284,7 @@ func (a *LedgerServiceAdapter) GetAccountInfo(ctx context.Context, account strin
 		PreviousTxnID:     prevTxnID,
 		PreviousTxnLgrSeq: result.PreviousTxnLgrSeq,
 		LedgerIndex:       result.LedgerIndex,
-		LedgerHash:        hex.EncodeToString(result.LedgerHash[:]),
+		LedgerHash:        strings.ToUpper(hex.EncodeToString(result.LedgerHash[:])),
 		Validated:         result.Validated,
 		RawData:           result.RawData,
 		Index:             strings.ToUpper(hex.EncodeToString(result.Index[:])),
@@ -301,7 +301,7 @@ func (a *LedgerServiceAdapter) GetTransaction(txHash [32]byte) (*types.Transacti
 	return &types.TransactionInfo{
 		TxData:      result.TxData,
 		LedgerIndex: result.LedgerIndex,
-		LedgerHash:  hex.EncodeToString(result.LedgerHash[:]),
+		LedgerHash:  strings.ToUpper(hex.EncodeToString(result.LedgerHash[:])),
 		Validated:   result.Validated,
 		TxIndex:     result.TxIndex,
 	}, nil
@@ -525,7 +525,7 @@ func (a *LedgerServiceAdapter) GetLedgerEntry(ctx context.Context, entryKey [32]
 		LedgerIndex: result.LedgerIndex,
 		LedgerHash:  result.LedgerHash,
 		Node:        result.Node,
-		NodeBinary:  hex.EncodeToString(result.Node),
+		NodeBinary:  strings.ToUpper(hex.EncodeToString(result.Node)),
 		Validated:   result.Validated,
 	}, nil
 }

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -6,12 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/protocol"
@@ -267,7 +267,7 @@ func (a *LedgerServiceAdapter) GetAccountInfo(ctx context.Context, account strin
 	var prevTxnID string
 	zeroHash := [32]byte{}
 	if result.PreviousTxnID != zeroHash {
-		prevTxnID = strings.ToUpper(hex.EncodeToString(result.PreviousTxnID[:]))
+		prevTxnID = handlers.FormatLedgerHash(result.PreviousTxnID)
 	}
 
 	return &types.AccountInfo{
@@ -284,10 +284,10 @@ func (a *LedgerServiceAdapter) GetAccountInfo(ctx context.Context, account strin
 		PreviousTxnID:     prevTxnID,
 		PreviousTxnLgrSeq: result.PreviousTxnLgrSeq,
 		LedgerIndex:       result.LedgerIndex,
-		LedgerHash:        strings.ToUpper(hex.EncodeToString(result.LedgerHash[:])),
+		LedgerHash:        handlers.FormatLedgerHash(result.LedgerHash),
 		Validated:         result.Validated,
 		RawData:           result.RawData,
-		Index:             strings.ToUpper(hex.EncodeToString(result.Index[:])),
+		Index:             handlers.FormatLedgerHash(result.Index),
 	}, nil
 }
 
@@ -301,7 +301,7 @@ func (a *LedgerServiceAdapter) GetTransaction(txHash [32]byte) (*types.Transacti
 	return &types.TransactionInfo{
 		TxData:      result.TxData,
 		LedgerIndex: result.LedgerIndex,
-		LedgerHash:  strings.ToUpper(hex.EncodeToString(result.LedgerHash[:])),
+		LedgerHash:  handlers.FormatLedgerHash(result.LedgerHash),
 		Validated:   result.Validated,
 		TxIndex:     result.TxIndex,
 	}, nil
@@ -525,7 +525,7 @@ func (a *LedgerServiceAdapter) GetLedgerEntry(ctx context.Context, entryKey [32]
 		LedgerIndex: result.LedgerIndex,
 		LedgerHash:  result.LedgerHash,
 		Node:        result.Node,
-		NodeBinary:  strings.ToUpper(hex.EncodeToString(result.Node)),
+		NodeBinary:  handlers.FormatHash(result.Node),
 		Validated:   result.Validated,
 	}, nil
 }

--- a/internal/rpc/ledger_closed_test.go
+++ b/internal/rpc/ledger_closed_test.go
@@ -82,7 +82,6 @@ func TestLedgerClosedBasicSuccess(t *testing.T) {
 		t.Errorf("unexpected ledger_index type: %T", v)
 	}
 
-	// ledger_hash should match the expected hash (uppercase, matching rippled)
 	expectedHashStr := strings.ToUpper(hex.EncodeToString(closedHash[:]))
 	assert.Equal(t, expectedHashStr, resp["ledger_hash"])
 }
@@ -144,7 +143,6 @@ func TestLedgerClosedHashFormat(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 32, len(decoded), "Decoded hash should be 32 bytes")
 
-	// Verify the hash is uppercase hex, matching rippled.
 	assert.Equal(t, strings.ToUpper(hashStr), hashStr,
 		"ledger_hash should be uppercase hex, matching rippled")
 }

--- a/internal/rpc/ledger_closed_test.go
+++ b/internal/rpc/ledger_closed_test.go
@@ -82,8 +82,8 @@ func TestLedgerClosedBasicSuccess(t *testing.T) {
 		t.Errorf("unexpected ledger_index type: %T", v)
 	}
 
-	// ledger_hash should match the expected hash
-	expectedHashStr := hex.EncodeToString(closedHash[:])
+	// ledger_hash should match the expected hash (uppercase, matching rippled)
+	expectedHashStr := strings.ToUpper(hex.EncodeToString(closedHash[:]))
 	assert.Equal(t, expectedHashStr, resp["ledger_hash"])
 }
 
@@ -144,9 +144,9 @@ func TestLedgerClosedHashFormat(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 32, len(decoded), "Decoded hash should be 32 bytes")
 
-	// Verify the hash is lowercase hex (the handler uses hex.EncodeToString which produces lowercase)
-	assert.Equal(t, strings.ToLower(hashStr), hashStr,
-		"ledger_hash should be lowercase hex from hex.EncodeToString")
+	// Verify the hash is uppercase hex, matching rippled.
+	assert.Equal(t, strings.ToUpper(hashStr), hashStr,
+		"ledger_hash should be uppercase hex, matching rippled")
 }
 
 // TestLedgerClosedServiceUnavailable tests behavior when ledger service is not available


### PR DESCRIPTION
## Summary
- Adapter (`internal/rpc/ledger_adapter.go`) now uppercases `LedgerHash` and `NodeBinary` in `GetAccountInfo`, `GetTransaction`, and `GetLedgerEntry` so every handler that consumes them inherits rippled-compatible casing.
- `ledger_closed`, `ledger_range`, `amm_info`, and `vault_info` route through `FormatLedgerHash`; `nft_buy_offers` drops a redundant `strings.ToUpper(FormatLedgerHash(...))`; `tx` CTID lookup uses `%X` directly; `account_objects` uppercases per-object `index` (including the decode-fallback path).
- New `internal/rpc/hex_case_test.go` regression test locks in the uppercase invariant for `ledger_closed` and `account_objects`.

Rippled returns every hash / ledger entry index field as uppercase hex (see `strHex()` in `rippled/src/libxrpl/basics/StringUtilities.cpp`); clients diff responses byte-for-byte, so any lowercase regression silently breaks them.

The issue also lists `account_tx` top-level `ledger_hash` as "missing", but rippled's `AccountTx.cpp` (lines 297-301) does not include a top-level `ledger_hash` — per-tx entries already carry it (uppercased at `account_tx.go:236`). The `manifest` handler does not return raw hex fields (it uses base58 for keys and base64 for the serialized manifest), so no change there.

## Test plan
- [x] `go test ./internal/rpc/...` — all green, including new `TestRPCHexCaseRegression`
- [x] `go test ./internal/ledger/...` — green
- [x] `go build ./...` — clean
- [ ] Reviewer to spot-check live JSON output against rippled if convenient

Fixes #475