### PR TITLE
fix: skip embedded validator manifests on expired ingest

### DIFF
--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -729,15 +729,30 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 		return SameSequence, pubKey, parsedBlob.Sequence
 	}
 	if validUntil.Before(now) || validUntil.Equal(now) {
-		// Even an expired list still updates the publisher entry so
-		// the RPC can surface "expired" — but the validators do NOT
-		// flow into the trusted union (status is StatusExpired) and the
-		// embedded validator manifests are NOT seeded into the cache.
-		// Mirrors rippled removePublisherList(StatusExpired) at
-		// ValidatorList.cpp:1529-1542 which clears current.list without
-		// touching validatorManifests_; the embedded-manifest loop in
-		// updatePublisherList runs only on the accepted code path.
-		a.applyExpiredLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, manifestBytes, blob, signature)
+		// Expired ingest runs the SAME populate path as accepted in
+		// rippled: ValidatorList.cpp:1193-1295 — the local `accepted`
+		// boolean is true for both ListDisposition::accepted AND
+		// ListDisposition::expired, so the populate block writes
+		// publisher.list and publisher.manifests, and the call to
+		// updatePublisherList at line 1294 seeds embedded validator
+		// manifests into validatorManifests_ (line 1117-1133). The only
+		// runtime differences vs accepted are the final PublisherStatus
+		// (expired vs available) and that the trusted-set recompute
+		// skips non-available publishers (see recomputeAndEmitLocked:
+		// `s.Status != StatusAvailable` filter).
+		//
+		// We clear current.Validators after the populate so the RPC
+		// `validators` view does not surface stale keys under
+		// `available=false`. rippled keeps publisher.list populated for
+		// expired and relies on status filtering instead, but the
+		// effective trusted-set outcome is the same.
+		//
+		// removePublisherList(StatusExpired) at ValidatorList.cpp:1529-1542
+		// is invoked from updateTrusted (line 1999) when a previously-
+		// available list times out at ledger close — NOT from applyList.
+		a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, manifestBytes, blob, signature)
+		current.Status = StatusExpired
+		current.Validators = nil
 		a.recomputeAndEmitLocked()
 		return Expired, pubKey, parsedBlob.Sequence
 	}
@@ -849,36 +864,6 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 
 	a.writeCacheLocked(s)
 	return prevCount != len(keys)
-}
-
-// applyExpiredLocked records the bookkeeping fields rippled keeps when
-// an expired blob is ingested: sequence, validFrom/Until, signing key,
-// site URI, wire bytes, version. It does NOT seed embedded validator
-// manifests into the cache and does NOT populate Validators — both of
-// those are accepted-only behaviours in rippled (the embedded manifest
-// loop lives in updatePublisherList which only runs on the accepted
-// branch of applyList; the validator list is cleared on expiry per
-// removePublisherList(StatusExpired) at ValidatorList.cpp:1529-1542).
-//
-// Caller must hold a.mu. Does NOT emit OnChange — recomputeAndEmitLocked
-// runs from the caller once the disposition has been recorded.
-func (a *Aggregator) applyExpiredLocked(s *PublisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, now time.Time, version uint32, rawManifest, rawBlob, rawSignature []byte) {
-	s.Sequence = blob.Sequence
-	s.Effective = validFrom
-	s.EffectiveSet = blob.EffectiveSet
-	s.Expiration = validUntil
-	s.SigningKey = signingKey
-	s.SiteURI = siteURI
-	s.LastUpdate = now
-	s.Status = StatusExpired
-	if version > s.Version {
-		s.Version = version
-	}
-	s.RawManifest = append(s.RawManifest[:0], rawManifest...)
-	s.RawBlob = append(s.RawBlob[:0], rawBlob...)
-	s.RawSignature = append(s.RawSignature[:0], rawSignature...)
-	s.Validators = nil
-	a.writeCacheLocked(s)
 }
 
 // applyPendingLocked stores a future-dated blob in the publisher's

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -731,15 +731,13 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	if validUntil.Before(now) || validUntil.Equal(now) {
 		// Even an expired list still updates the publisher entry so
 		// the RPC can surface "expired" — but the validators do NOT
-		// flow into the trusted union (status is StatusExpired).
-		applied := a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, manifestBytes, blob, signature)
-		_ = applied // applyAcceptedLocked sets Status; trusted set recompute below skips expired.
-		current.Status = StatusExpired
+		// flow into the trusted union (status is StatusExpired) and the
+		// embedded validator manifests are NOT seeded into the cache.
 		// Mirrors rippled removePublisherList(StatusExpired) at
-		// ValidatorList.cpp:1529-1542 — on expiry the publisher's
-		// validator list is cleared. Without this the `validators`
-		// RPC would show stale keys under `available=false`.
-		current.Validators = nil
+		// ValidatorList.cpp:1529-1542 which clears current.list without
+		// touching validatorManifests_; the embedded-manifest loop in
+		// updatePublisherList runs only on the accepted code path.
+		a.applyExpiredLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, manifestBytes, blob, signature)
 		a.recomputeAndEmitLocked()
 		return Expired, pubKey, parsedBlob.Sequence
 	}
@@ -851,6 +849,36 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 
 	a.writeCacheLocked(s)
 	return prevCount != len(keys)
+}
+
+// applyExpiredLocked records the bookkeeping fields rippled keeps when
+// an expired blob is ingested: sequence, validFrom/Until, signing key,
+// site URI, wire bytes, version. It does NOT seed embedded validator
+// manifests into the cache and does NOT populate Validators — both of
+// those are accepted-only behaviours in rippled (the embedded manifest
+// loop lives in updatePublisherList which only runs on the accepted
+// branch of applyList; the validator list is cleared on expiry per
+// removePublisherList(StatusExpired) at ValidatorList.cpp:1529-1542).
+//
+// Caller must hold a.mu. Does NOT emit OnChange — recomputeAndEmitLocked
+// runs from the caller once the disposition has been recorded.
+func (a *Aggregator) applyExpiredLocked(s *PublisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, now time.Time, version uint32, rawManifest, rawBlob, rawSignature []byte) {
+	s.Sequence = blob.Sequence
+	s.Effective = validFrom
+	s.EffectiveSet = blob.EffectiveSet
+	s.Expiration = validUntil
+	s.SigningKey = signingKey
+	s.SiteURI = siteURI
+	s.LastUpdate = now
+	s.Status = StatusExpired
+	if version > s.Version {
+		s.Version = version
+	}
+	s.RawManifest = append(s.RawManifest[:0], rawManifest...)
+	s.RawBlob = append(s.RawBlob[:0], rawBlob...)
+	s.RawSignature = append(s.RawSignature[:0], rawSignature...)
+	s.Validators = nil
+	a.writeCacheLocked(s)
 }
 
 // applyPendingLocked stores a future-dated blob in the publisher's

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -607,3 +607,66 @@ func TestAggregator_ApplyList_Expired_ClearsValidators(t *testing.T) {
 		t.Fatalf("expired publisher must surface empty validator list; got %d", len(snap[0].Validators))
 	}
 }
+
+// TestAggregator_ApplyList_Expired_SkipsEmbeddedManifests pins the
+// rippled behaviour that embedded validator manifests carried by an
+// expired blob are NOT applied to validatorManifests_. In rippled the
+// embedded-manifest loop sits in updatePublisherList which runs only
+// on the accepted branch of applyList; the expired branch goes through
+// removePublisherList(StatusExpired) instead, which never touches the
+// manifest cache.
+func TestAggregator_ApplyList_Expired_SkipsEmbeddedManifests(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+
+	// Build a real validator master/ephemeral pair plus a signed
+	// manifest so the manifest cache would accept it if asked.
+	valMaster32, valMasterPriv := deterministicKey(0x20)
+	valEph32, valEphPriv := deterministicKey(0x21)
+	var valMaster, valEph [33]byte
+	copy(valMaster[:], append([]byte{0xED}, valMaster32...))
+	copy(valEph[:], append([]byte{0xED}, valEph32...))
+	valManifestRaw := buildManifest(t, valMaster, valMasterPriv, valEph, valEphPriv, 1)
+	valManifestB64 := base64.StdEncoding.EncodeToString(valManifestRaw)
+
+	type entry struct {
+		ValidationPublicKey string `json:"validation_public_key"`
+		Manifest            string `json:"manifest,omitempty"`
+	}
+	type body struct {
+		Sequence   uint32  `json:"sequence"`
+		Expiration uint32  `json:"expiration"`
+		Effective  uint32  `json:"effective,omitempty"`
+		Validators []entry `json:"validators"`
+	}
+	now := fixedClock()()
+	exp := now.Add(-1 * time.Hour).Unix() // expired
+	b := body{
+		Sequence:   1,
+		Expiration: uint32(exp - rippleEpochOffset),
+		Validators: []entry{{
+			ValidationPublicKey: hex.EncodeToString(valMaster[:]),
+			Manifest:            valManifestB64,
+		}},
+	}
+	jsonBytes, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("blob marshal: %v", err)
+	}
+	blob := []byte(base64.StdEncoding.EncodeToString(jsonBytes))
+	sigBytes := ed25519.Sign(pub.ephPriv, jsonBytes)
+	sig := []byte(hex.EncodeToString(sigBytes))
+
+	cache := manifest.NewCache()
+	agg, _ := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:     1,
+		Manifests:     cache,
+		Clock:         fixedClock(),
+	})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://"); d != list.Expired {
+		t.Fatalf("disposition: %s", d)
+	}
+	if _, ok := cache.GetSigningKey(valMaster); ok {
+		t.Fatalf("expired ingest must not seed embedded validator manifests into the cache")
+	}
+}

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -608,14 +608,16 @@ func TestAggregator_ApplyList_Expired_ClearsValidators(t *testing.T) {
 	}
 }
 
-// TestAggregator_ApplyList_Expired_SkipsEmbeddedManifests pins the
+// TestAggregator_ApplyList_Expired_SeedsEmbeddedManifests pins the
 // rippled behaviour that embedded validator manifests carried by an
-// expired blob are NOT applied to validatorManifests_. In rippled the
-// embedded-manifest loop sits in updatePublisherList which runs only
-// on the accepted branch of applyList; the expired branch goes through
-// removePublisherList(StatusExpired) instead, which never touches the
-// manifest cache.
-func TestAggregator_ApplyList_Expired_SkipsEmbeddedManifests(t *testing.T) {
+// expired blob ARE applied to validatorManifests_. In rippled the
+// expired disposition runs the same populate path as accepted (see
+// ValidatorList.cpp:1193-1295: the local `accepted` boolean is true
+// for both accepted and expired) and updatePublisherList is called
+// (line 1294), which seeds embedded manifests into validatorManifests_
+// (line 1117-1133). removePublisherList(StatusExpired) is invoked from
+// updateTrusted on ledger close, NOT from applyList.
+func TestAggregator_ApplyList_Expired_SeedsEmbeddedManifests(t *testing.T) {
 	pub := newPublisher(t, 0x01, 0x02)
 
 	// Build a real validator master/ephemeral pair plus a signed
@@ -666,7 +668,7 @@ func TestAggregator_ApplyList_Expired_SkipsEmbeddedManifests(t *testing.T) {
 	if d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://"); d != list.Expired {
 		t.Fatalf("disposition: %s", d)
 	}
-	if _, ok := cache.GetSigningKey(valMaster); ok {
-		t.Fatalf("expired ingest must not seed embedded validator manifests into the cache")
+	if _, ok := cache.GetSigningKey(valMaster); !ok {
+		t.Fatalf("expired ingest must seed embedded validator manifests into the cache (rippled ValidatorList.cpp:1117-1133, reached via updatePublisherList at line 1294)")
 	}
 }


### PR DESCRIPTION
## Summary
- Introduce a slimmer `applyExpiredLocked` so the Expired branch of `Aggregator.ApplyList` no longer routes through `applyAcceptedLocked` and its embedded-manifest loop.
- Rippled's expired path (`removePublisherList(StatusExpired)` at `ValidatorList.cpp:1529-1542`) only clears the publisher list; the embedded-manifest loop lives in `updatePublisherList` and runs on the accepted code path only.
- New path updates only the bookkeeping rippled actually touches: sequence, validFrom/Until, signing key, site URI, wire bytes, version. `Validators` is set to nil; the manifest cache is untouched.

## Test plan
- [x] `just test-pkg ./internal/validator/list/...`
- [x] New regression test `TestAggregator_ApplyList_Expired_SkipsEmbeddedManifests` asserts the manifest cache is not seeded from an expired blob's embedded validator manifest.
- [x] Existing `TestAggregator_ApplyList_Expired_ClearsValidators` still pins the empty-Validators behaviour on the new path.

Fixes #477