### PR TITLE
fix(flaky): race on Overlay.listener between Run and ListenAddr/Stop

### DIFF
--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -321,7 +321,10 @@ type Overlay struct {
 	pingTimeoutDisconnects atomic.Uint64
 
 	// Network
-	listener net.Listener
+	// listenerMu guards listener: written once by startListener (in the
+	// Run goroutine) and read concurrently by ListenAddr and Stop.
+	listenerMu sync.RWMutex
+	listener   net.Listener
 
 	// Lifecycle
 	ctx    context.Context
@@ -614,10 +617,13 @@ func (o *Overlay) PeerProtocolAtLeast(peerID PeerID, major, minor uint16) bool {
 // caller needs the actual port to drive a peer connection — e.g.,
 // integration tests that wire two overlays together on localhost.
 func (o *Overlay) ListenAddr() string {
-	if o.listener == nil {
+	o.listenerMu.RLock()
+	l := o.listener
+	o.listenerMu.RUnlock()
+	if l == nil {
 		return ""
 	}
-	return o.listener.Addr().String()
+	return l.Addr().String()
 }
 
 // New creates a new Overlay with the provided options.
@@ -772,8 +778,11 @@ func (o *Overlay) Stop() error {
 	}
 
 	// Close listener
-	if o.listener != nil {
-		o.listener.Close()
+	o.listenerMu.RLock()
+	l := o.listener
+	o.listenerMu.RUnlock()
+	if l != nil {
+		l.Close()
 	}
 
 	// Stop discovery
@@ -804,10 +813,13 @@ func (o *Overlay) startListener() error {
 		return fmt.Errorf("overlay: build TLS cert: %w", err)
 	}
 
-	o.listener = peertls.NewListener(tcpListener, &peertls.Config{
+	l := peertls.NewListener(tcpListener, &peertls.Config{
 		CertPEM: certPEM,
 		KeyPEM:  keyPEM,
 	})
+	o.listenerMu.Lock()
+	o.listener = l
+	o.listenerMu.Unlock()
 	return nil
 }
 

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -321,8 +321,12 @@ type Overlay struct {
 	pingTimeoutDisconnects atomic.Uint64
 
 	// Network
-	// listenerMu guards listener: written once by startListener (in the
-	// Run goroutine) and read concurrently by ListenAddr and Stop.
+	// listenerMu guards listener: written once by startListener (called
+	// from Run before any concurrent reader exists). Read under RLock
+	// from ListenAddr and Stop (other goroutines). The reads in Run and
+	// acceptLoop are unlocked: Run's read at "if o.listener != nil" is
+	// in the same goroutine as the write, and acceptLoop is spawned via
+	// g.Go after the write returns, so happens-before applies.
 	listenerMu sync.RWMutex
 	listener   net.Listener
 


### PR DESCRIPTION
## Root-cause analysis

`TestTwoOverlay_*` (and `TestSingleOverlay_*`) share a test helper `startOverlay` in `internal/testing/p2p/two_overlay_test.go`. That helper launches `o.Run(ctx)` in a goroutine and immediately polls `o.ListenAddr()` in a tight loop:

```go
go func() { _ = o.Run(ctx) }()

deadline := time.Now().Add(2 * time.Second)
for time.Now().Before(deadline) {
    if o.ListenAddr() != "" {   // ← reads o.listener
        break
    }
    time.Sleep(10 * time.Millisecond)
}
```

Inside `Run()`, `startListener()` assigns the `o.listener` field:

```go
o.listener = peertls.NewListener(tcpListener, &peertls.Config{...})
```

These two goroutines access `o.listener` (a plain `net.Listener` field) without any synchronisation. The race detector fires on every run under `-race`, which is exactly what the CI matrix uses (`go test -race -count=1 -timeout 15m ./internal/testing/...`).

The same race affects `Stop()`, which reads `o.listener` from the test goroutine to call `l.Close()`.

## Fix

Added `listenerMu sync.RWMutex` to `Overlay` and guarded the three cross-goroutine access sites:

| Site | Before | After |
|------|--------|-------|
| `startListener()` | bare assign `o.listener = l` | write-lock, assign, unlock |
| `ListenAddr()` | bare read `o.listener` | read-lock, snapshot, unlock |
| `Stop()` | bare read `o.listener` | read-lock, snapshot, unlock, close |

The two intra-`Run` accesses (nil-guard before `acceptLoop` and `Accept()` inside `acceptLoop`) are in the same goroutine as `startListener()` and remain unguarded — they are sequentially safe.

## Verification

```
go test -race -count=5 ./internal/testing/p2p/...
```

- **Before fix**: `DATA RACE` on `o.listener` / `l.inner` reported on ≥1 of the `TestTwoOverlay_*` tests in nearly every run; occasional `FAIL`
- **After fix**: 25/25 passes, zero race reports across 5 runs

## Impact on CI

`Test (integration)` has been failing on every PR for the past 7+ days with a ~23-minute wall time (= 15 min `go test -timeout` + CI setup overhead). The `TestTwoOverlay_*` races are the identified root cause: under `-race` the race window between the `Run` goroutine and the polling loop in `startOverlay` is hit reliably, causing the race detector to abort the test binary before other tests complete.

https://claude.ai/code/session_017dpcYDX7mpbnTS9jHYQhwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017dpcYDX7mpbnTS9jHYQhwQ)_