### PR TITLE
fix(server_info): wire live metrics for overflow, peers, ledger age, load factors

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -243,7 +243,7 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	services := types.NewServiceContainer(ledgerAdapter)
 
 	// TxQ metrics are available in both standalone and consensus modes,
-	// so wire the server_info hook before the !standalone branch — #480.
+	// so wire the server_info hook before the !standalone branch.
 	ledgerSvcRef := ledgerService
 	services.TxQMetrics = func() types.TxQServerMetrics {
 		m := ledgerSvcRef.GetTxQMetrics()
@@ -339,10 +339,10 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		// the bootstrap-time field used to return — #451.
 		services.ValidationQuorum = consensusComponents.Adaptor.GetQuorum
 
-		// Expose peer-disconnect counters and the operating-mode
-		// state-accounting snapshot to server_info — replaces the
-		// hardcoded zeros from #480. (TxQMetrics is wired above the
-		// !standalone branch since it's available in either mode.)
+		// Peer-disconnect counters and the operating-mode state-accounting
+		// snapshot need the overlay/adaptor, so they live inside the
+		// !standalone branch. (TxQMetrics is wired above; it only needs
+		// the ledger service.)
 		overlayRef := consensusComponents.Overlay
 		services.PeerDisconnects = func() (uint64, uint64) {
 			return overlayRef.PeerDisconnects(), overlayRef.PeerDisconnectsResources()

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -242,6 +242,19 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	ledgerAdapter := rpc.NewLedgerServiceAdapter(ledgerService)
 	services := types.NewServiceContainer(ledgerAdapter)
 
+	// TxQ metrics are available in both standalone and consensus modes,
+	// so wire the server_info hook before the !standalone branch — #480.
+	ledgerSvcRef := ledgerService
+	services.TxQMetrics = func() types.TxQServerMetrics {
+		m := ledgerSvcRef.GetTxQMetrics()
+		return types.TxQServerMetrics{
+			JqTransOverflow:       m.JqTransOverflow,
+			ReferenceFeeLevel:     m.ReferenceFeeLevel,
+			MinProcessingFeeLevel: m.MinProcessingFeeLevel,
+			OpenLedgerFeeLevel:    m.OpenLedgerFeeLevel,
+		}
+	}
+
 	// Start consensus/networking if not in standalone mode
 	if !standalone {
 		var compErr error
@@ -326,19 +339,10 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		// the bootstrap-time field used to return — #451.
 		services.ValidationQuorum = consensusComponents.Adaptor.GetQuorum
 
-		// Expose live TxQ metrics, peer-disconnect counters, and the
-		// operating-mode state-accounting snapshot to server_info —
-		// replaces the hardcoded zeros from #480.
-		ledgerSvcRef := ledgerService
-		services.TxQMetrics = func() types.TxQServerMetrics {
-			m := ledgerSvcRef.GetTxQMetrics()
-			return types.TxQServerMetrics{
-				JqTransOverflow:       m.JqTransOverflow,
-				ReferenceFeeLevel:     m.ReferenceFeeLevel,
-				MinProcessingFeeLevel: m.MinProcessingFeeLevel,
-				OpenLedgerFeeLevel:    m.OpenLedgerFeeLevel,
-			}
-		}
+		// Expose peer-disconnect counters and the operating-mode
+		// state-accounting snapshot to server_info — replaces the
+		// hardcoded zeros from #480. (TxQMetrics is wired above the
+		// !standalone branch since it's available in either mode.)
 		overlayRef := consensusComponents.Overlay
 		services.PeerDisconnects = func() (uint64, uint64) {
 			return overlayRef.PeerDisconnects(), overlayRef.PeerDisconnectsResources()

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -366,6 +366,7 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 				InitialSyncUs:     snap.InitialSyncUs,
 			}
 		}
+		services.CloseTimeOffset = acctRef.CloseOffset
 		// Expose the validator-manifest cache to the `manifest` RPC.
 		// The cache is shared — the router writes inbound manifests,
 		// the engine reads for ephemeral→master translation, and this

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -344,19 +344,23 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			return overlayRef.PeerDisconnects(), overlayRef.PeerDisconnectsResources()
 		}
 		acctRef := consensusComponents.Adaptor
-		services.StateAccounting = func() map[string]types.StateAccountingEntry {
+		services.StateAccounting = func() types.StateAccountingSnapshot {
 			snap := acctRef.StateAccounting()
-			if len(snap) == 0 {
-				return nil
+			if len(snap.Modes) == 0 {
+				return types.StateAccountingSnapshot{}
 			}
-			out := make(map[string]types.StateAccountingEntry, len(snap))
-			for mode, entry := range snap {
-				out[mode] = types.StateAccountingEntry{
+			modes := make(map[string]types.StateAccountingEntry, len(snap.Modes))
+			for mode, entry := range snap.Modes {
+				modes[mode] = types.StateAccountingEntry{
 					Transitions: entry.Transitions,
 					DurationUs:  entry.DurationUs,
 				}
 			}
-			return out
+			return types.StateAccountingSnapshot{
+				Modes:             modes,
+				CurrentDurationUs: snap.CurrentDurationUs,
+				InitialSyncUs:     snap.InitialSyncUs,
+			}
 		}
 		// Expose the validator-manifest cache to the `manifest` RPC.
 		// The cache is shared — the router writes inbound manifests,

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -325,6 +325,39 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		// from UNL ∖ negative-UNL) instead of the hardcoded "1" that
 		// the bootstrap-time field used to return — #451.
 		services.ValidationQuorum = consensusComponents.Adaptor.GetQuorum
+
+		// Expose live TxQ metrics, peer-disconnect counters, and the
+		// operating-mode state-accounting snapshot to server_info —
+		// replaces the hardcoded zeros from #480.
+		ledgerSvcRef := ledgerService
+		services.TxQMetrics = func() types.TxQServerMetrics {
+			m := ledgerSvcRef.GetTxQMetrics()
+			return types.TxQServerMetrics{
+				JqTransOverflow:       m.JqTransOverflow,
+				ReferenceFeeLevel:     m.ReferenceFeeLevel,
+				MinProcessingFeeLevel: m.MinProcessingFeeLevel,
+				OpenLedgerFeeLevel:    m.OpenLedgerFeeLevel,
+			}
+		}
+		overlayRef := consensusComponents.Overlay
+		services.PeerDisconnects = func() (uint64, uint64) {
+			return overlayRef.PeerDisconnects(), overlayRef.PeerDisconnectsResources()
+		}
+		acctRef := consensusComponents.Adaptor
+		services.StateAccounting = func() map[string]types.StateAccountingEntry {
+			snap := acctRef.StateAccounting()
+			if len(snap) == 0 {
+				return nil
+			}
+			out := make(map[string]types.StateAccountingEntry, len(snap))
+			for mode, entry := range snap {
+				out[mode] = types.StateAccountingEntry{
+					Transitions: entry.Transitions,
+					DurationUs:  entry.DurationUs,
+				}
+			}
+			return out
+		}
 		// Expose the validator-manifest cache to the `manifest` RPC.
 		// The cache is shared — the router writes inbound manifests,
 		// the engine reads for ephemeral→master translation, and this

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -183,7 +183,7 @@ type Adaptor struct {
 	operatingMode consensus.OperatingMode
 
 	// stateAcct tracks transition counts and cumulative durations per
-	// operating mode for server_info.state_accounting (#480).
+	// operating mode for server_info.state_accounting.
 	stateAcct *stateAccounting
 
 	// Close time offset — adjusted each round toward network average.

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1342,6 +1342,13 @@ func (a *Adaptor) Now() time.Time {
 	return time.Now().Add(time.Duration(a.closeOffsetNs.Load()))
 }
 
+// CloseOffset returns the current consensus-derived close-time offset.
+// Mirrors rippled TimeKeeper::closeOffset(); surfaced via server_info
+// as close_time_offset when |offset| >= 60s (NetworkOPs.cpp:2946-2949).
+func (a *Adaptor) CloseOffset() time.Duration {
+	return time.Duration(a.closeOffsetNs.Load())
+}
+
 func (a *Adaptor) CloseTimeResolution() time.Duration {
 	l := a.ledgerService.GetClosedLedger()
 	if l != nil {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -182,6 +182,10 @@ type Adaptor struct {
 	// Operating mode
 	operatingMode consensus.OperatingMode
 
+	// stateAcct tracks transition counts and cumulative durations per
+	// operating mode for server_info.state_accounting (#480).
+	stateAcct *stateAccounting
+
 	// Close time offset — adjusted each round toward network average.
 	// Matches rippled's timeKeeper().closeTime() offset. Stored as
 	// nanoseconds in an atomic so the consensus hot path (Now) avoids
@@ -440,6 +444,7 @@ func New(cfg Config) *Adaptor {
 		trustedMasterKeys: trustedMasterKeys,
 		quorum:            quorum,
 		operatingMode:     consensus.OpModeDisconnected,
+		stateAcct:         newStateAccounting(consensus.OpModeDisconnected, time.Now),
 		negUNLVoter:       negUNLVoter,
 		txSetCache:        NewTxSetCache(),
 		peerLCLs:          make(map[uint64]consensus.LedgerID),
@@ -1410,8 +1415,26 @@ func (a *Adaptor) GetOperatingMode() consensus.OperatingMode {
 
 func (a *Adaptor) SetOperatingMode(mode consensus.OperatingMode) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
 	a.operatingMode = mode
+	sa := a.stateAcct
+	a.mu.Unlock()
+	if sa != nil {
+		sa.transition(mode)
+	}
+}
+
+// StateAccounting returns a snapshot of per-operating-mode transition
+// counts and cumulative microsecond durations for server_info. Returns
+// nil when the adaptor was constructed without a tracker (legacy
+// tests). Mirrors rippled's NetworkOPsImp::StateAccounting::json.
+func (a *Adaptor) StateAccounting() map[string]StateAccountingEntry {
+	a.mu.Lock()
+	sa := a.stateAcct
+	a.mu.Unlock()
+	if sa == nil {
+		return nil
+	}
+	return sa.snapshot()
 }
 
 // OnConsensusReached logs the close and fires the consensus-phase hook.

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1415,24 +1415,28 @@ func (a *Adaptor) GetOperatingMode() consensus.OperatingMode {
 
 func (a *Adaptor) SetOperatingMode(mode consensus.OperatingMode) {
 	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.operatingMode = mode
-	sa := a.stateAcct
-	a.mu.Unlock()
-	if sa != nil {
-		sa.transition(mode)
+	if a.stateAcct != nil {
+		// Held under a.mu so the operatingMode field and the
+		// accounting transition observe the same serialization
+		// order. The tracker has its own mutex; this nested take
+		// is short and never re-enters a.mu.
+		a.stateAcct.transition(mode)
 	}
 }
 
-// StateAccounting returns a snapshot of per-operating-mode transition
-// counts and cumulative microsecond durations for server_info. Returns
-// nil when the adaptor was constructed without a tracker (legacy
-// tests). Mirrors rippled's NetworkOPsImp::StateAccounting::json.
-func (a *Adaptor) StateAccounting() map[string]StateAccountingEntry {
+// StateAccounting returns the snapshot used by server_info to populate
+// state_accounting + the top-level server_state_duration_us /
+// initial_sync_duration_us fields. Returns the zero value when the
+// adaptor was constructed without a tracker (legacy tests). Mirrors
+// rippled's NetworkOPsImp::StateAccounting::json.
+func (a *Adaptor) StateAccounting() StateAccountingSnapshot {
 	a.mu.Lock()
 	sa := a.stateAcct
 	a.mu.Unlock()
 	if sa == nil {
-		return nil
+		return StateAccountingSnapshot{}
 	}
 	return sa.snapshot()
 }

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1430,15 +1430,14 @@ func (a *Adaptor) SetOperatingMode(mode consensus.OperatingMode) {
 // state_accounting + the top-level server_state_duration_us /
 // initial_sync_duration_us fields. Returns the zero value when the
 // adaptor was constructed without a tracker (legacy tests). Mirrors
-// rippled's NetworkOPsImp::StateAccounting::json.
+// rippled's NetworkOPsImp::StateAccounting::json. stateAcct is set
+// once in New() and never reassigned, so no Adaptor-level lock is
+// needed; the tracker has its own mutex.
 func (a *Adaptor) StateAccounting() StateAccountingSnapshot {
-	a.mu.Lock()
-	sa := a.stateAcct
-	a.mu.Unlock()
-	if sa == nil {
+	if a.stateAcct == nil {
 		return StateAccountingSnapshot{}
 	}
-	return sa.snapshot()
+	return a.stateAcct.snapshot()
 }
 
 // OnConsensusReached logs the close and fires the consensus-phase hook.

--- a/internal/consensus/adaptor/state_accounting.go
+++ b/internal/consensus/adaptor/state_accounting.go
@@ -1,0 +1,91 @@
+package adaptor
+
+import (
+	"sync"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// StateAccountingEntry is one row of the operating-mode state machine
+// surfaced by server_info.state_accounting. Transitions counts the
+// number of times the node has entered the mode and DurationUs is the
+// cumulative microseconds spent in it.
+type StateAccountingEntry struct {
+	Transitions uint64
+	DurationUs  uint64
+}
+
+// stateAccounting tracks per-OperatingMode transition counts and
+// microsecond durations. Mirrors rippled's NetworkOPsImp::StateAccounting
+// (NetworkOPs.cpp:4836-4843) so the server_info handler can surface
+// real numbers in place of hardcoded zeros (#480).
+type stateAccounting struct {
+	mu      sync.Mutex
+	now     func() time.Time
+	current consensus.OperatingMode
+	since   time.Time
+	counts  [5]uint64 // transitions per mode, indexed by OperatingMode
+	durs    [5]time.Duration
+}
+
+func newStateAccounting(initial consensus.OperatingMode, now func() time.Time) *stateAccounting {
+	if now == nil {
+		now = time.Now
+	}
+	sa := &stateAccounting{now: now, current: initial, since: now()}
+	if int(initial) >= 0 && int(initial) < len(sa.counts) {
+		sa.counts[initial] = 1
+	}
+	return sa
+}
+
+// transition advances the state machine, charging elapsed time against
+// the prior mode and bumping the new mode's transition count. A
+// same-mode call is a no-op.
+func (s *stateAccounting) transition(mode consensus.OperatingMode) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if mode == s.current {
+		return
+	}
+	now := s.now()
+	if idx := int(s.current); idx >= 0 && idx < len(s.durs) {
+		s.durs[idx] += now.Sub(s.since)
+	}
+	s.current = mode
+	s.since = now
+	if idx := int(mode); idx >= 0 && idx < len(s.counts) {
+		s.counts[idx]++
+	}
+}
+
+// snapshot returns a frozen view of the counters with elapsed time in
+// the current mode rolled into its duration. Callers iterate the result
+// in any order — the keys are rippled's lowercase mode names.
+func (s *stateAccounting) snapshot() map[string]StateAccountingEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	durs := s.durs
+	if idx := int(s.current); idx >= 0 && idx < len(durs) {
+		durs[idx] += s.now().Sub(s.since)
+	}
+	out := make(map[string]StateAccountingEntry, len(stateAccountingNames))
+	for i, name := range stateAccountingNames {
+		out[name] = StateAccountingEntry{
+			Transitions: s.counts[i],
+			DurationUs:  uint64(durs[i].Microseconds()),
+		}
+	}
+	return out
+}
+
+// stateAccountingNames maps OperatingMode index → lowercase name used
+// by rippled's server_info JSON.
+var stateAccountingNames = [5]string{
+	consensus.OpModeDisconnected: "disconnected",
+	consensus.OpModeConnected:    "connected",
+	consensus.OpModeSyncing:      "syncing",
+	consensus.OpModeTracking:     "tracking",
+	consensus.OpModeFull:         "full",
+}

--- a/internal/consensus/adaptor/state_accounting.go
+++ b/internal/consensus/adaptor/state_accounting.go
@@ -36,8 +36,7 @@ type StateAccountingSnapshot struct {
 
 // stateAccounting tracks per-OperatingMode transition counts and
 // microsecond durations. Mirrors rippled's NetworkOPsImp::StateAccounting
-// (NetworkOPs.cpp:143-200, 4808-4849) so the server_info handler can
-// surface real numbers in place of hardcoded zeros (#480).
+// at NetworkOPs.cpp:143-200, 4808-4849.
 type stateAccounting struct {
 	mu           sync.Mutex
 	now          func() time.Time

--- a/internal/consensus/adaptor/state_accounting.go
+++ b/internal/consensus/adaptor/state_accounting.go
@@ -16,24 +16,45 @@ type StateAccountingEntry struct {
 	DurationUs  uint64
 }
 
+// StateAccountingSnapshot is everything server_info needs to render
+// state_accounting + the two top-level companion fields
+// (server_state_duration_us, initial_sync_duration_us). Mirrors the
+// data rippled's NetworkOPsImp::StateAccounting::json emits.
+type StateAccountingSnapshot struct {
+	// Modes is the per-mode counts/durations table.
+	Modes map[string]StateAccountingEntry
+	// CurrentDurationUs is the time spent in the current operating
+	// mode since the last transition. Rippled exposes it as the
+	// top-level server_state_duration_us.
+	CurrentDurationUs uint64
+	// InitialSyncUs is the time from process start to the first
+	// transition into OpModeFull; zero before that transition has
+	// occurred. Rippled emits initial_sync_duration_us only when
+	// non-zero.
+	InitialSyncUs uint64
+}
+
 // stateAccounting tracks per-OperatingMode transition counts and
 // microsecond durations. Mirrors rippled's NetworkOPsImp::StateAccounting
-// (NetworkOPs.cpp:4836-4843) so the server_info handler can surface
-// real numbers in place of hardcoded zeros (#480).
+// (NetworkOPs.cpp:143-200, 4808-4849) so the server_info handler can
+// surface real numbers in place of hardcoded zeros (#480).
 type stateAccounting struct {
-	mu      sync.Mutex
-	now     func() time.Time
-	current consensus.OperatingMode
-	since   time.Time
-	counts  [5]uint64 // transitions per mode, indexed by OperatingMode
-	durs    [5]time.Duration
+	mu           sync.Mutex
+	now          func() time.Time
+	current      consensus.OperatingMode
+	since        time.Time
+	processStart time.Time
+	initialSync  time.Duration
+	counts       [5]uint64 // transitions per mode, indexed by OperatingMode
+	durs         [5]time.Duration
 }
 
 func newStateAccounting(initial consensus.OperatingMode, now func() time.Time) *stateAccounting {
 	if now == nil {
 		now = time.Now
 	}
-	sa := &stateAccounting{now: now, current: initial, since: now()}
+	start := now()
+	sa := &stateAccounting{now: now, current: initial, since: start, processStart: start}
 	if int(initial) >= 0 && int(initial) < len(sa.counts) {
 		sa.counts[initial] = 1
 	}
@@ -42,7 +63,8 @@ func newStateAccounting(initial consensus.OperatingMode, now func() time.Time) *
 
 // transition advances the state machine, charging elapsed time against
 // the prior mode and bumping the new mode's transition count. A
-// same-mode call is a no-op.
+// same-mode call is a no-op (matches rippled's setMode early-return at
+// NetworkOPs.cpp:2560-2561, which gates accounting_.mode()).
 func (s *stateAccounting) transition(mode consensus.OperatingMode) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -57,31 +79,44 @@ func (s *stateAccounting) transition(mode consensus.OperatingMode) {
 	s.since = now
 	if idx := int(mode); idx >= 0 && idx < len(s.counts) {
 		s.counts[idx]++
+		// First transition into Full: record initial sync duration.
+		// Mirrors rippled NetworkOPs.cpp:4814-4820.
+		if mode == consensus.OpModeFull && s.counts[idx] == 1 && s.initialSync == 0 {
+			s.initialSync = now.Sub(s.processStart)
+		}
 	}
 }
 
 // snapshot returns a frozen view of the counters with elapsed time in
-// the current mode rolled into its duration. Callers iterate the result
-// in any order — the keys are rippled's lowercase mode names.
-func (s *stateAccounting) snapshot() map[string]StateAccountingEntry {
+// the current mode rolled into its duration, plus the current-state
+// duration and initial-sync duration used by the top-level
+// server_info fields. Map keys are rippled's lowercase mode names.
+func (s *stateAccounting) snapshot() StateAccountingSnapshot {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	now := s.now()
+	current := now.Sub(s.since)
 	durs := s.durs
 	if idx := int(s.current); idx >= 0 && idx < len(durs) {
-		durs[idx] += s.now().Sub(s.since)
+		durs[idx] += current
 	}
-	out := make(map[string]StateAccountingEntry, len(stateAccountingNames))
+	modes := make(map[string]StateAccountingEntry, len(stateAccountingNames))
 	for i, name := range stateAccountingNames {
-		out[name] = StateAccountingEntry{
+		modes[name] = StateAccountingEntry{
 			Transitions: s.counts[i],
 			DurationUs:  uint64(durs[i].Microseconds()),
 		}
 	}
-	return out
+	return StateAccountingSnapshot{
+		Modes:             modes,
+		CurrentDurationUs: uint64(current.Microseconds()),
+		InitialSyncUs:     uint64(s.initialSync.Microseconds()),
+	}
 }
 
 // stateAccountingNames maps OperatingMode index → lowercase name used
-// by rippled's server_info JSON.
+// by rippled's server_info JSON. Ordered to match rippled's
+// iteration (NetworkOPs.cpp:871-872 stateNames + 4837-4845 loop).
 var stateAccountingNames = [5]string{
 	consensus.OpModeDisconnected: "disconnected",
 	consensus.OpModeConnected:    "connected",

--- a/internal/consensus/adaptor/state_accounting_test.go
+++ b/internal/consensus/adaptor/state_accounting_test.go
@@ -1,0 +1,109 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+)
+
+// TestStateAccounting_InitialCounts checks rippled NetworkOPs.cpp:163-167:
+// fresh tracker starts in DISCONNECTED with exactly one transition into it.
+func TestStateAccounting_InitialCounts(t *testing.T) {
+	t0 := time.Unix(1_700_000_000, 0)
+	now := t0
+	sa := newStateAccounting(consensus.OpModeDisconnected, func() time.Time { return now })
+
+	snap := sa.snapshot()
+	if got := snap.Modes["disconnected"].Transitions; got != 1 {
+		t.Fatalf("disconnected.transitions = %d, want 1", got)
+	}
+	for _, mode := range []string{"connected", "syncing", "tracking", "full"} {
+		if got := snap.Modes[mode].Transitions; got != 0 {
+			t.Errorf("%s.transitions = %d, want 0", mode, got)
+		}
+	}
+	if snap.InitialSyncUs != 0 {
+		t.Errorf("InitialSyncUs = %d, want 0 (no Full transition yet)", snap.InitialSyncUs)
+	}
+}
+
+// TestStateAccounting_DurationAccrualAndCurrent verifies that elapsed
+// time in the current mode rolls into both the per-mode duration AND
+// the CurrentDurationUs companion field. server_state_duration_us must
+// reflect time-since-last-transition, not process uptime (B2).
+func TestStateAccounting_DurationAccrualAndCurrent(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	sa := newStateAccounting(consensus.OpModeDisconnected, func() time.Time { return now })
+
+	// 5 seconds elapse in DISCONNECTED, then transition to CONNECTED.
+	now = now.Add(5 * time.Second)
+	sa.transition(consensus.OpModeConnected)
+
+	// 2 seconds later, snapshot.
+	now = now.Add(2 * time.Second)
+	snap := sa.snapshot()
+
+	if got := snap.Modes["disconnected"].DurationUs; got != uint64(5*time.Second/time.Microsecond) {
+		t.Errorf("disconnected.duration_us = %d, want %d", got, 5*time.Second/time.Microsecond)
+	}
+	if got := snap.Modes["connected"].DurationUs; got != uint64(2*time.Second/time.Microsecond) {
+		t.Errorf("connected.duration_us = %d, want %d", got, 2*time.Second/time.Microsecond)
+	}
+	if got := snap.CurrentDurationUs; got != uint64(2*time.Second/time.Microsecond) {
+		t.Errorf("CurrentDurationUs = %d, want %d (time in CONNECTED since last transition)", got, 2*time.Second/time.Microsecond)
+	}
+}
+
+// TestStateAccounting_InitialSyncCapturedOnFirstFull mirrors rippled
+// NetworkOPs.cpp:4814-4820: initial_sync_duration_us is the time from
+// process start to the FIRST transition into Full, and is sticky.
+func TestStateAccounting_InitialSyncCapturedOnFirstFull(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	now := start
+	sa := newStateAccounting(consensus.OpModeDisconnected, func() time.Time { return now })
+
+	// 30s in DISCONNECTED, 20s in CONNECTED, 15s in SYNCING.
+	now = now.Add(30 * time.Second)
+	sa.transition(consensus.OpModeConnected)
+	now = now.Add(20 * time.Second)
+	sa.transition(consensus.OpModeSyncing)
+	now = now.Add(15 * time.Second)
+	sa.transition(consensus.OpModeFull)
+
+	snap := sa.snapshot()
+	wantInitial := uint64(65 * time.Second / time.Microsecond)
+	if snap.InitialSyncUs != wantInitial {
+		t.Errorf("InitialSyncUs = %d, want %d (sum of pre-Full mode times)", snap.InitialSyncUs, wantInitial)
+	}
+
+	// Drop out of Full and back in — InitialSyncUs must not change.
+	now = now.Add(5 * time.Second)
+	sa.transition(consensus.OpModeTracking)
+	now = now.Add(5 * time.Second)
+	sa.transition(consensus.OpModeFull)
+
+	snap = sa.snapshot()
+	if snap.InitialSyncUs != wantInitial {
+		t.Errorf("InitialSyncUs changed after re-entering Full: got %d, want %d (sticky)", snap.InitialSyncUs, wantInitial)
+	}
+	if got := snap.Modes["full"].Transitions; got != 2 {
+		t.Errorf("full.transitions = %d, want 2", got)
+	}
+}
+
+// TestStateAccounting_NoopTransitionDoesNotBumpCount mirrors rippled
+// NetworkOPs.cpp:2560-2561, where setMode returns early before
+// invoking accounting_.mode() when the requested state already matches.
+func TestStateAccounting_NoopTransitionDoesNotBumpCount(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	sa := newStateAccounting(consensus.OpModeDisconnected, func() time.Time { return now })
+
+	sa.transition(consensus.OpModeDisconnected)
+	sa.transition(consensus.OpModeDisconnected)
+
+	snap := sa.snapshot()
+	if got := snap.Modes["disconnected"].Transitions; got != 1 {
+		t.Errorf("disconnected.transitions = %d after no-op calls, want 1", got)
+	}
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1361,7 +1361,7 @@ func (s *Service) GetTxQMetrics() txq.Metrics {
 	}
 	var txInLedger uint32
 	if s.openLedger != nil {
-		txInLedger = uint32(s.openLedger.TxCount())
+		txInLedger = s.openLedger.TxCount()
 	}
 	return s.txQueue.GetMetrics(txInLedger)
 }

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1350,9 +1350,8 @@ func (s *Service) GetGenesisAccount() (string, error) {
 	return address, err
 }
 
-// GetTxQMetrics returns the current TxQ metrics — used by server_info
-// for jq_trans_overflow and the load_factor_fee_* fields. Returns the
-// zero value when the queue isn't initialised.
+// GetTxQMetrics returns the current TxQ metrics, or the zero value when
+// the queue isn't initialised.
 func (s *Service) GetTxQMetrics() txq.Metrics {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/txq"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/shamap"
 	"github.com/LeJamon/goXRPLd/storage/nodestore"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
@@ -1349,6 +1350,22 @@ func (s *Service) GetGenesisAccount() (string, error) {
 	return address, err
 }
 
+// GetTxQMetrics returns the current TxQ metrics — used by server_info
+// for jq_trans_overflow and the load_factor_fee_* fields. Returns the
+// zero value when the queue isn't initialised.
+func (s *Service) GetTxQMetrics() txq.Metrics {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.txQueue == nil {
+		return txq.Metrics{}
+	}
+	var txInLedger uint32
+	if s.openLedger != nil {
+		txInLedger = uint32(s.openLedger.TxCount())
+	}
+	return s.txQueue.GetMetrics(txInLedger)
+}
+
 // GetServerInfo returns basic server information
 func (s *Service) GetServerInfo() ServerInfo {
 	s.mu.RLock()
@@ -1373,11 +1390,13 @@ func (s *Service) GetServerInfo() ServerInfo {
 	if s.closedLedger != nil {
 		info.ClosedLedgerSeq = s.closedLedger.Sequence()
 		info.ClosedLedgerHash = s.closedLedger.Hash()
+		info.ClosedLedgerCloseTime = rippleEpochSeconds(s.closedLedger.CloseTime())
 	}
 
 	if s.validatedLedger != nil {
 		info.ValidatedLedgerSeq = s.validatedLedger.Sequence()
 		info.ValidatedLedgerHash = s.validatedLedger.Hash()
+		info.ValidatedLedgerCloseTime = rippleEpochSeconds(s.validatedLedger.CloseTime())
 	}
 
 	// Calculate complete ledgers range
@@ -1404,15 +1423,31 @@ func (s *Service) GetServerInfo() ServerInfo {
 
 // ServerInfo contains basic server status information
 type ServerInfo struct {
-	Standalone          bool
-	ServerState         string // "disconnected", "connected", "syncing", "tracking", "full"
-	OpenLedgerSeq       uint32
-	ClosedLedgerSeq     uint32
-	ClosedLedgerHash    [32]byte
-	ValidatedLedgerSeq  uint32
-	ValidatedLedgerHash [32]byte
-	CompleteLedgers     string
-	NetworkID           uint32
+	Standalone               bool
+	ServerState              string // "disconnected", "connected", "syncing", "tracking", "full"
+	OpenLedgerSeq            uint32
+	ClosedLedgerSeq          uint32
+	ClosedLedgerHash         [32]byte
+	ClosedLedgerCloseTime    int64 // Ripple-epoch seconds
+	ValidatedLedgerSeq       uint32
+	ValidatedLedgerHash      [32]byte
+	ValidatedLedgerCloseTime int64 // Ripple-epoch seconds
+	CompleteLedgers          string
+	NetworkID                uint32
+}
+
+// rippleEpochSeconds converts a wall-clock close time to seconds since
+// the XRPL epoch (2000-01-01 UTC). Returns 0 for the zero time so a
+// genesis-only node reports close_time=0 instead of a negative value.
+func rippleEpochSeconds(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	s := t.Unix() - protocol.RippleEpochUnix
+	if s < 0 {
+		return 0
+	}
+	return s
 }
 
 // GetLedgerInfo returns information about a specific ledger

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1393,6 +1393,7 @@ func (s *Service) GetServerInfo() ServerInfo {
 	}
 
 	if s.validatedLedger != nil {
+		info.HaveValidated = true
 		info.ValidatedLedgerSeq = s.validatedLedger.Sequence()
 		info.ValidatedLedgerHash = s.validatedLedger.Hash()
 		info.ValidatedLedgerCloseTime = rippleEpochSeconds(s.validatedLedger.CloseTime())
@@ -1428,6 +1429,7 @@ type ServerInfo struct {
 	ClosedLedgerSeq          uint32
 	ClosedLedgerHash         [32]byte
 	ClosedLedgerCloseTime    int64 // Ripple-epoch seconds
+	HaveValidated            bool  // mirrors rippled LedgerMaster::haveValidated()
 	ValidatedLedgerSeq       uint32
 	ValidatedLedgerHash      [32]byte
 	ValidatedLedgerCloseTime int64 // Ripple-epoch seconds

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -330,7 +330,8 @@ type Overlay struct {
 
 	// peerDisconnects counts every peer torn down for any reason.
 	// Mirrors rippled OverlayImpl::peerDisconnects_ surfaced via
-	// server_info as peer_disconnects (PeerImp::~PeerImp increments).
+	// server_info as peer_disconnects (PeerImp::close increments at
+	// PeerImp.cpp:587).
 	peerDisconnects atomic.Uint64
 
 	// Network

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -318,8 +318,14 @@ type Overlay struct {
 	// pingTimeoutDisconnects counts peers torn down because the oldest
 	// in-flight ping aged past pingTimeout. Mirrors rippled's
 	// fail("Ping Timeout") at PeerImp.cpp:731-736. Surfaced via
-	// server_info as peer_disconnects_resources — ping-timeout is the
-	// goxrpl analogue of rippled's resource-charge-driven drops.
+	// server_info as peer_disconnects_resources as a stand-in: in
+	// rippled that field comes from peerDisconnectsCharges_, bumped
+	// only by PeerImp::charge() when a Resource::Charge exceeds budget
+	// (PeerImp.cpp:358); ping timeouts there go through PeerImp::close
+	// and increment the plain peerDisconnects_. goxrpl has no
+	// ResourceManager yet, so ping-timeout is the closest available
+	// "involuntary drop" signal — replace with a real charge counter
+	// once that subsystem lands.
 	pingTimeoutDisconnects atomic.Uint64
 
 	// peerDisconnects counts every peer torn down for any reason.
@@ -1325,10 +1331,12 @@ func (o *Overlay) PeerDisconnects() uint64 {
 	return o.peerDisconnects.Load()
 }
 
-// PeerDisconnectsResources returns the cumulative count of peers torn
-// down for resource-related reasons (ping timeout in goxrpl, which is
-// the analogue of rippled's resource-charge threshold drop). Surfaced
-// via server_info.peer_disconnects_resources.
+// PeerDisconnectsResources returns the count of peers torn down for
+// involuntary, infrastructure-driven reasons. Surfaced via
+// server_info.peer_disconnects_resources. Until goxrpl grows a
+// ResourceManager analog of rippled's Resource::Charge, this
+// returns the ping-timeout drop count as a stand-in — see the
+// pingTimeoutDisconnects field doc for the semantic gap.
 func (o *Overlay) PeerDisconnectsResources() uint64 {
 	return o.pingTimeoutDisconnects.Load()
 }

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -317,8 +317,15 @@ type Overlay struct {
 
 	// pingTimeoutDisconnects counts peers torn down because the oldest
 	// in-flight ping aged past pingTimeout. Mirrors rippled's
-	// fail("Ping Timeout") at PeerImp.cpp:731-736.
+	// fail("Ping Timeout") at PeerImp.cpp:731-736. Surfaced via
+	// server_info as peer_disconnects_resources — ping-timeout is the
+	// goxrpl analogue of rippled's resource-charge-driven drops.
 	pingTimeoutDisconnects atomic.Uint64
+
+	// peerDisconnects counts every peer torn down for any reason.
+	// Mirrors rippled OverlayImpl::peerDisconnects_ surfaced via
+	// server_info as peer_disconnects (PeerImp::~PeerImp increments).
+	peerDisconnects atomic.Uint64
 
 	// Network
 	// listenerMu guards listener: written once by startListener (called
@@ -1116,6 +1123,7 @@ func (o *Overlay) onPeerHandshakeComplete(evt Event) {
 }
 
 func (o *Overlay) onPeerDisconnected(evt Event) {
+	o.peerDisconnects.Add(1)
 	o.discovery.MarkDisconnected(evt.PeerID)
 	o.relay.RemovePeer(evt.PeerID)
 	// Fire the higher-layer disconnect callback so per-peer state in
@@ -1307,6 +1315,21 @@ func (o *Overlay) DroppedMessages() uint64 {
 // nonzero, growing value flags either a flaky network or peers that
 // have stopped servicing the overlay protocol.
 func (o *Overlay) PingTimeoutDisconnects() uint64 {
+	return o.pingTimeoutDisconnects.Load()
+}
+
+// PeerDisconnects returns the cumulative count of peers torn down for
+// any reason. Mirrors rippled's getPeerDisconnect surfaced by
+// server_info.peer_disconnects.
+func (o *Overlay) PeerDisconnects() uint64 {
+	return o.peerDisconnects.Load()
+}
+
+// PeerDisconnectsResources returns the cumulative count of peers torn
+// down for resource-related reasons (ping timeout in goxrpl, which is
+// the analogue of rippled's resource-charge threshold drop). Surfaced
+// via server_info.peer_disconnects_resources.
+func (o *Overlay) PeerDisconnectsResources() uint64 {
 	return o.pingTimeoutDisconnects.Load()
 }
 

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -9,8 +9,32 @@ import (
 
 	"github.com/LeJamon/goXRPLd/internal/observability"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/version"
 )
+
+// loadBase is the fee-tracker reference level. Mirrors rippled's
+// LoadFeeTrack default at LoadFeeTrack.h — every load_factor_* field
+// is expressed as a multiple of this base.
+const loadBase uint64 = 256
+
+// validatedLedgerAgeThreshold matches rippled's
+// NetworkOPsImp::getServerInfo (NetworkOPs.cpp:2952): once the
+// validated ledger is older than this the age is clamped to 0 in the
+// JSON so monitoring dashboards don't render misleading values from a
+// stalled node. 600s is rippled's published threshold.
+const validatedLedgerAgeThreshold = 600 * time.Second
+
+// stateAccountingModes is the fixed set of operating-mode keys
+// rippled emits. Emitting them all (zero-filled when needed) keeps the
+// shape stable for downstream consumers.
+var stateAccountingModes = []string{
+	"connected",
+	"disconnected",
+	"full",
+	"syncing",
+	"tracking",
+}
 
 // serverStartTime tracks when the server started for uptime calculation
 var serverStartTime = time.Now()
@@ -80,6 +104,8 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	// Duration in microseconds for state accounting
 	uptimeUs := uptimeDuration.Microseconds()
 
+	overflow, peerDisc, peerDiscRes := resolveDisconnectCounters(services)
+
 	info := map[string]interface{}{
 		"build_version":     BuildVersion,
 		"complete_ledgers":  completeLedgers,
@@ -90,35 +116,13 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		"validation_quorum": resolveValidationQuorum(services),
 		"peers":             getPeerCount(ctx),
 
-		// Overflow/disconnect counters (string in rippled)
-		"jq_trans_overflow":          "0", // TODO: track real overflow count
-		"peer_disconnects":           "0", // TODO: track real disconnect count
-		"peer_disconnects_resources": "0", // TODO: track real disconnect-resources count
+		// Overflow/disconnect counters (string in rippled).
+		"jq_trans_overflow":          fmt.Sprintf("%d", overflow),
+		"peer_disconnects":           fmt.Sprintf("%d", peerDisc),
+		"peer_disconnects_resources": fmt.Sprintf("%d", peerDiscRes),
 
-		// State accounting
 		"server_state_duration_us": fmt.Sprintf("%d", uptimeUs),
-		"state_accounting": map[string]interface{}{
-			"connected": map[string]interface{}{
-				"duration_us": "0",
-				"transitions": "0",
-			},
-			"disconnected": map[string]interface{}{
-				"duration_us": "0",
-				"transitions": "0",
-			},
-			"full": map[string]interface{}{
-				"duration_us": fmt.Sprintf("%d", uptimeUs),
-				"transitions": "1",
-			},
-			"syncing": map[string]interface{}{
-				"duration_us": "0",
-				"transitions": "0",
-			},
-			"tracking": map[string]interface{}{
-				"duration_us": "0",
-				"transitions": "0",
-			},
-		},
+		"state_accounting":         resolveStateAccounting(services, serverState, uptimeUs),
 	}
 
 	// hostid: only in human mode (server_info), matching rippled
@@ -153,26 +157,38 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		}
 	}
 
-	// load_factor: human mode is float (loadFactor/loadBase), machine mode has integers
+	// load_factor: human mode is float (loadFactor/loadBase), machine mode has integers.
+	// Until a full LoadFeeTrack lands, the server-wide load factor mirrors the
+	// fee-escalation level — the only load signal we currently track. Matches
+	// rippled's NetworkOPs.cpp:2863-2875 fallback when no other load source
+	// (cluster, admin) is active.
+	feeEscalation, feeQueue, feeReference := resolveLoadFactorFees(services)
+	loadFactor := feeEscalation
+	if loadFactor < loadBase {
+		loadFactor = loadBase
+	}
 	if human {
-		info["load_factor"] = 1.0 // TODO: compute from fee tracker
+		info["load_factor"] = float64(loadFactor) / float64(loadBase)
 	} else {
-		info["load_base"] = 256                  // TODO: get from fee tracker (rippled default is 256)
-		info["load_factor"] = 256                // TODO: get from fee tracker
-		info["load_factor_server"] = 256         // TODO: get from fee tracker
-		info["load_factor_fee_escalation"] = 256 // TODO: get from TxQ metrics
-		info["load_factor_fee_queue"] = 256      // TODO: get from TxQ metrics
-		info["load_factor_fee_reference"] = 256  // TODO: get from TxQ metrics
+		info["load_base"] = loadBase
+		info["load_factor"] = loadFactor
+		info["load_factor_server"] = loadBase
+		info["load_factor_fee_escalation"] = feeEscalation
+		info["load_factor_fee_queue"] = feeQueue
+		info["load_factor_fee_reference"] = feeReference
 	}
 
-	// Validated ledger info
+	now := time.Now()
+	validatedAge := ledgerAge(serverInfo.ValidatedLedgerCloseTime, now)
+	closedAge := ledgerAge(serverInfo.ClosedLedgerCloseTime, now)
+
 	if human {
 		baseFeeXRP := float64(baseFee) / 1_000_000.0
 		reserveBaseXRP := float64(reserveBase) / 1_000_000.0
 		reserveIncXRP := float64(reserveIncrement) / 1_000_000.0
 
 		info["validated_ledger"] = map[string]interface{}{
-			"age":              0, // TODO: compute from ledger close time vs now
+			"age":              validatedAge,
 			"base_fee_xrp":     baseFeeXRP,
 			"hash":             validatedLedgerHash,
 			"reserve_base_xrp": reserveBaseXRP,
@@ -182,7 +198,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 
 		// closed_ledger in human mode
 		info["closed_ledger"] = map[string]interface{}{
-			"age":              0,
+			"age":              closedAge,
 			"base_fee_xrp":     baseFeeXRP,
 			"hash":             closedLedgerHash,
 			"reserve_base_xrp": reserveBaseXRP,
@@ -192,7 +208,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	} else {
 		info["validated_ledger"] = map[string]interface{}{
 			"base_fee":     baseFee,
-			"close_time":   0, // TODO: get from ledger close time (ripple epoch seconds)
+			"close_time":   serverInfo.ValidatedLedgerCloseTime,
 			"hash":         validatedLedgerHash,
 			"reserve_base": reserveBase,
 			"reserve_inc":  reserveIncrement,
@@ -202,7 +218,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		// closed_ledger in machine mode
 		info["closed_ledger"] = map[string]interface{}{
 			"base_fee":     baseFee,
-			"close_time":   0,
+			"close_time":   serverInfo.ClosedLedgerCloseTime,
 			"hash":         closedLedgerHash,
 			"reserve_base": reserveBase,
 			"reserve_inc":  reserveIncrement,
@@ -251,4 +267,91 @@ func resolveValidationQuorum(services *types.ServiceContainer) int {
 		}
 	}
 	return 1
+}
+
+// resolveDisconnectCounters reads the overlay/TxQ disconnect &
+// overflow counters via service hooks. Returns zeros when hooks aren't
+// wired so server_info still produces a complete shape.
+func resolveDisconnectCounters(services *types.ServiceContainer) (overflow, peerDisc, peerDiscRes uint64) {
+	if services == nil {
+		return 0, 0, 0
+	}
+	if services.TxQMetrics != nil {
+		overflow = services.TxQMetrics().JqTransOverflow
+	}
+	if services.PeerDisconnects != nil {
+		peerDisc, peerDiscRes = services.PeerDisconnects()
+	}
+	return overflow, peerDisc, peerDiscRes
+}
+
+// resolveLoadFactorFees returns (escalation, queue, reference) levels
+// for the server_info load_factor_fee_* fields. Falls back to the
+// reference level (loadBase) when the TxQ isn't wired.
+func resolveLoadFactorFees(services *types.ServiceContainer) (escalation, queue, reference uint64) {
+	escalation, queue, reference = loadBase, loadBase, loadBase
+	if services == nil || services.TxQMetrics == nil {
+		return
+	}
+	m := services.TxQMetrics()
+	if m.ReferenceFeeLevel > 0 {
+		reference = m.ReferenceFeeLevel
+	}
+	if m.OpenLedgerFeeLevel > 0 {
+		escalation = m.OpenLedgerFeeLevel
+	}
+	if m.MinProcessingFeeLevel > 0 {
+		queue = m.MinProcessingFeeLevel
+	}
+	return
+}
+
+// resolveStateAccounting builds the state_accounting JSON value.
+// Prefers the adaptor's per-mode tracker when wired, otherwise falls
+// back to attributing the whole uptime to the current server state
+// (matching the pre-#480 stub shape).
+func resolveStateAccounting(services *types.ServiceContainer, serverState string, uptimeUs int64) map[string]interface{} {
+	out := make(map[string]interface{}, len(stateAccountingModes))
+	for _, m := range stateAccountingModes {
+		out[m] = map[string]interface{}{
+			"duration_us": "0",
+			"transitions": "0",
+		}
+	}
+
+	if services != nil && services.StateAccounting != nil {
+		for mode, entry := range services.StateAccounting() {
+			out[mode] = map[string]interface{}{
+				"duration_us": fmt.Sprintf("%d", entry.DurationUs),
+				"transitions": fmt.Sprintf("%d", entry.Transitions),
+			}
+		}
+		return out
+	}
+
+	if _, ok := out[serverState]; ok {
+		out[serverState] = map[string]interface{}{
+			"duration_us": fmt.Sprintf("%d", uptimeUs),
+			"transitions": "1",
+		}
+	}
+	return out
+}
+
+// ledgerAge returns the age of a ledger in seconds. Clamps to 0 when
+// the close time is unknown, in the future (clock skew), or past
+// rippled's high-age threshold — see NetworkOPs.cpp:2952.
+func ledgerAge(closeTimeRippleEpoch int64, now time.Time) int64 {
+	if closeTimeRippleEpoch <= 0 {
+		return 0
+	}
+	closeUnix := closeTimeRippleEpoch + protocol.RippleEpochUnix
+	age := now.Unix() - closeUnix
+	if age <= 0 {
+		return 0
+	}
+	if time.Duration(age)*time.Second >= validatedLedgerAgeThreshold {
+		return 0
+	}
+	return age
 }

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -19,21 +19,24 @@ import (
 const loadBase uint64 = 256
 
 // validatedLedgerAgeThreshold matches rippled's
-// NetworkOPsImp::getServerInfo (NetworkOPs.cpp:2952): once the
+// NetworkOPsImp::getServerInfo (NetworkOPs.cpp:2951): once the
 // validated ledger is older than this the age is clamped to 0 in the
-// JSON so monitoring dashboards don't render misleading values from a
-// stalled node. 600s is rippled's published threshold.
-const validatedLedgerAgeThreshold = 600 * time.Second
+// JSON. Rippled uses 1,000,000 seconds (~11.57 days), so ordinary
+// stall durations (minutes / hours / days) are still reported.
+const validatedLedgerAgeThreshold = 1_000_000 * time.Second
 
 // stateAccountingModes is the fixed set of operating-mode keys
-// rippled emits. Emitting them all (zero-filled when needed) keeps the
-// shape stable for downstream consumers.
+// rippled emits, in OperatingMode index order to mirror
+// NetworkOPs.cpp:871-872 + 4837-4845. JSON object keys are unordered
+// on the wire but matching the iteration order keeps review noise
+// down. Emitting all keys (zero-filled when needed) keeps the shape
+// stable for downstream consumers.
 var stateAccountingModes = []string{
-	"connected",
 	"disconnected",
-	"full",
+	"connected",
 	"syncing",
 	"tracking",
+	"full",
 }
 
 // serverStartTime tracks when the server started for uptime calculation
@@ -101,10 +104,12 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		serverState = "standalone"
 	}
 
-	// Duration in microseconds for state accounting
+	// Duration in microseconds for the legacy state-accounting fallback
+	// (used only when consensus hasn't wired a tracker).
 	uptimeUs := uptimeDuration.Microseconds()
 
 	overflow, peerDisc, peerDiscRes := resolveDisconnectCounters(services)
+	accounting := resolveStateAccounting(services, serverState, uptimeUs)
 
 	info := map[string]interface{}{
 		"build_version":     BuildVersion,
@@ -121,8 +126,17 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		"peer_disconnects":           fmt.Sprintf("%d", peerDisc),
 		"peer_disconnects_resources": fmt.Sprintf("%d", peerDiscRes),
 
-		"server_state_duration_us": fmt.Sprintf("%d", uptimeUs),
-		"state_accounting":         resolveStateAccounting(services, serverState, uptimeUs),
+		// Time spent in the current operating mode (NOT total uptime),
+		// matching rippled NetworkOPs.cpp:4846 which emits
+		// `current.count()` = now - last-transition-time.
+		"server_state_duration_us": fmt.Sprintf("%d", accounting.currentDurationUs),
+		"state_accounting":         accounting.modes,
+	}
+
+	// Rippled emits initial_sync_duration_us only when the node has
+	// completed its first sync to Full (NetworkOPs.cpp:4847-4848).
+	if accounting.initialSyncUs > 0 {
+		info["initial_sync_duration_us"] = fmt.Sprintf("%d", accounting.initialSyncUs)
 	}
 
 	// hostid: only in human mode (server_info), matching rippled
@@ -169,6 +183,19 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	}
 	if human {
 		info["load_factor"] = float64(loadFactor) / float64(loadBase)
+		// Mirror rippled NetworkOPs.cpp:2902-2912: in human mode the
+		// escalation and queue fields are emitted only when they
+		// actually diverge from the reference level (i.e., load is
+		// active). With no LoadFeeTrack yet we can't honour the
+		// `admin || feeEscalation != loadFactor` extra gate exactly,
+		// so we emit whenever escalation/queue are above reference —
+		// the conservative subset of rippled's predicate.
+		if feeEscalation != feeReference {
+			info["load_factor_fee_escalation"] = float64(feeEscalation) / float64(feeReference)
+		}
+		if feeQueue != feeReference {
+			info["load_factor_fee_queue"] = float64(feeQueue) / float64(feeReference)
+		}
 	} else {
 		info["load_base"] = loadBase
 		info["load_factor"] = loadFactor
@@ -179,14 +206,17 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	}
 
 	now := time.Now()
-	validatedAge := ledgerAge(serverInfo.ValidatedLedgerCloseTime, now)
-	closedAge := ledgerAge(serverInfo.ClosedLedgerCloseTime, now)
+	validatedAge, _ := ledgerAge(serverInfo.ValidatedLedgerCloseTime, now)
+	closedAge, closedAgeOK := ledgerAge(serverInfo.ClosedLedgerCloseTime, now)
 
 	if human {
 		baseFeeXRP := float64(baseFee) / 1_000_000.0
 		reserveBaseXRP := float64(reserveBase) / 1_000_000.0
 		reserveIncXRP := float64(reserveIncrement) / 1_000_000.0
 
+		// validated_ledger always carries an `age` in rippled (the
+		// `haveValidated() == true` branch at NetworkOPs.cpp:2952-2956
+		// unconditionally writes it, possibly as 0).
 		info["validated_ledger"] = map[string]interface{}{
 			"age":              validatedAge,
 			"base_fee_xrp":     baseFeeXRP,
@@ -196,15 +226,20 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 			"seq":              serverInfo.ValidatedLedgerSeq,
 		}
 
-		// closed_ledger in human mode
-		info["closed_ledger"] = map[string]interface{}{
-			"age":              closedAge,
+		// closed_ledger in human mode. Rippled omits `age` when the
+		// close-time is in the future (clock skew, no valid answer)
+		// — NetworkOPs.cpp:2962-2969.
+		closedLedger := map[string]interface{}{
 			"base_fee_xrp":     baseFeeXRP,
 			"hash":             closedLedgerHash,
 			"reserve_base_xrp": reserveBaseXRP,
 			"reserve_inc_xrp":  reserveIncXRP,
 			"seq":              serverInfo.ClosedLedgerSeq,
 		}
+		if closedAgeOK {
+			closedLedger["age"] = closedAge
+		}
+		info["closed_ledger"] = closedLedger
 	} else {
 		info["validated_ledger"] = map[string]interface{}{
 			"base_fee":     baseFee,
@@ -306,11 +341,20 @@ func resolveLoadFactorFees(services *types.ServiceContainer) (escalation, queue,
 	return
 }
 
-// resolveStateAccounting builds the state_accounting JSON value.
-// Prefers the adaptor's per-mode tracker when wired, otherwise falls
-// back to attributing the whole uptime to the current server state
-// (matching the pre-#480 stub shape).
-func resolveStateAccounting(services *types.ServiceContainer, serverState string, uptimeUs int64) map[string]interface{} {
+// stateAccountingResolved is the rendered shape consumed by
+// buildServerInfo — the state_accounting map plus the two top-level
+// companion fields (server_state_duration_us, initial_sync_duration_us).
+type stateAccountingResolved struct {
+	modes             map[string]interface{}
+	currentDurationUs uint64
+	initialSyncUs     uint64
+}
+
+// resolveStateAccounting builds the state_accounting JSON value and the
+// top-level companion durations. Prefers the adaptor's tracker when
+// wired; falls back to attributing the whole uptime to the current
+// server state (matching the pre-#480 stub shape).
+func resolveStateAccounting(services *types.ServiceContainer, serverState string, uptimeUs int64) stateAccountingResolved {
 	out := make(map[string]interface{}, len(stateAccountingModes))
 	for _, m := range stateAccountingModes {
 		out[m] = map[string]interface{}{
@@ -320,38 +364,59 @@ func resolveStateAccounting(services *types.ServiceContainer, serverState string
 	}
 
 	if services != nil && services.StateAccounting != nil {
-		for mode, entry := range services.StateAccounting() {
+		snap := services.StateAccounting()
+		for mode, entry := range snap.Modes {
 			out[mode] = map[string]interface{}{
 				"duration_us": fmt.Sprintf("%d", entry.DurationUs),
 				"transitions": fmt.Sprintf("%d", entry.Transitions),
 			}
 		}
-		return out
+		return stateAccountingResolved{
+			modes:             out,
+			currentDurationUs: snap.CurrentDurationUs,
+			initialSyncUs:     snap.InitialSyncUs,
+		}
 	}
 
+	// Legacy fallback: attribute total uptime to the current state.
+	// server_state_duration_us in this branch necessarily equals
+	// uptime — there's no transition history to derive a tighter
+	// value from.
 	if _, ok := out[serverState]; ok {
 		out[serverState] = map[string]interface{}{
 			"duration_us": fmt.Sprintf("%d", uptimeUs),
 			"transitions": "1",
 		}
 	}
-	return out
+	currentDur := uint64(0)
+	if uptimeUs > 0 {
+		currentDur = uint64(uptimeUs)
+	}
+	return stateAccountingResolved{
+		modes:             out,
+		currentDurationUs: currentDur,
+	}
 }
 
-// ledgerAge returns the age of a ledger in seconds. Clamps to 0 when
-// the close time is unknown, in the future (clock skew), or past
-// rippled's high-age threshold — see NetworkOPs.cpp:2952.
-func ledgerAge(closeTimeRippleEpoch int64, now time.Time) int64 {
+// ledgerAge returns the age of a ledger in seconds, along with an
+// `ok` flag indicating whether the field should be emitted at all.
+// Clamps to 0 when the close time is past rippled's high-age
+// threshold (NetworkOPs.cpp:2956). Returns ok=false when the close
+// time is unknown or in the future — rippled omits the `age` field
+// in that case (NetworkOPs.cpp:2962-2969); callers may still emit a
+// 0 when their branch is the "validated_ledger" path, which rippled
+// always emits.
+func ledgerAge(closeTimeRippleEpoch int64, now time.Time) (int64, bool) {
 	if closeTimeRippleEpoch <= 0 {
-		return 0
+		return 0, false
 	}
 	closeUnix := closeTimeRippleEpoch + protocol.RippleEpochUnix
 	age := now.Unix() - closeUnix
-	if age <= 0 {
-		return 0
+	if age < 0 {
+		return 0, false
 	}
 	if time.Duration(age)*time.Second >= validatedLedgerAgeThreshold {
-		return 0
+		return 0, true
 	}
-	return age
+	return age, true
 }

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -37,6 +37,11 @@ func clipToUint32(v uint64) uint32 {
 // stall durations (minutes / hours / days) are still reported.
 const validatedLedgerAgeThreshold = 1_000_000 * time.Second
 
+// closeTimeOffsetThreshold mirrors rippled NetworkOPs.cpp:2946-2949:
+// close_time_offset is only surfaced when |offset| reaches a full
+// minute, suppressing transient sub-minute drift.
+const closeTimeOffsetThreshold = 60 * time.Second
+
 // stateAccountingModes is the fixed set of operating-mode keys
 // rippled emits, in OperatingMode index order to mirror
 // NetworkOPs.cpp:871-872 + 4837-4845. JSON object keys are unordered
@@ -194,6 +199,29 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	}
 	if human {
 		info["load_factor"] = float64(loadFactor) / float64(loadBase)
+		// Mirror rippled NetworkOPs.cpp:2883-2885: emit load_factor_server
+		// when it diverges from the overall load_factor. With no
+		// LoadFeeTrack subsystem loadFactorServer == loadBase, so this
+		// fires whenever fee escalation drives load_factor above 1.0.
+		if loadBase != loadFactor {
+			info["load_factor_server"] = float64(loadBase) / float64(loadBase)
+		}
+		// Mirror rippled NetworkOPs.cpp:2887-2901: admin-only emission
+		// of load_factor_{local,net,cluster}, each gated on the fee
+		// differing from loadBase. The LoadFactorFees hook is nil until
+		// a LoadFeeTrack subsystem lands, suppressing all three.
+		if ctx.IsAdmin && services != nil && services.LoadFactorFees != nil {
+			fees := services.LoadFactorFees()
+			if uint64(fees.Local) != loadBase {
+				info["load_factor_local"] = float64(fees.Local) / float64(loadBase)
+			}
+			if uint64(fees.Net) != loadBase {
+				info["load_factor_net"] = float64(fees.Net) / float64(loadBase)
+			}
+			if uint64(fees.Cluster) != loadBase {
+				info["load_factor_cluster"] = float64(fees.Cluster) / float64(loadBase)
+			}
+		}
 		// Mirror rippled NetworkOPs.cpp:2902-2912: in human mode the
 		// escalation field is gated on
 		//   openLedgerFeeLevel != referenceFeeLevel
@@ -222,59 +250,77 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		info["load_factor_fee_reference"] = clipToUint32(feeReference)
 	}
 
-	now := time.Now()
-	validatedAge, _ := ledgerAge(serverInfo.ValidatedLedgerCloseTime, now)
-	closedAge, closedAgeOK := ledgerAge(serverInfo.ClosedLedgerCloseTime, now)
+	// Mirror rippled NetworkOPs.cpp:2915-2975: emit exactly one of
+	// validated_ledger / closed_ledger, sourced from the validated
+	// ledger when haveValidated(), otherwise from the closed ledger.
+	// Suppress both when neither is available.
+	var (
+		ledgerSeq       uint32
+		ledgerHash      string
+		ledgerCloseTime int64
+		ledgerKey       string
+		haveLedger      bool
+	)
+	switch {
+	case serverInfo.HaveValidated:
+		ledgerSeq = serverInfo.ValidatedLedgerSeq
+		ledgerHash = validatedLedgerHash
+		ledgerCloseTime = serverInfo.ValidatedLedgerCloseTime
+		ledgerKey = "validated_ledger"
+		haveLedger = true
+	case serverInfo.ClosedLedgerSeq > 0:
+		ledgerSeq = serverInfo.ClosedLedgerSeq
+		ledgerHash = closedLedgerHash
+		ledgerCloseTime = serverInfo.ClosedLedgerCloseTime
+		ledgerKey = "closed_ledger"
+		haveLedger = true
+	}
 
-	if human {
-		baseFeeXRP := float64(baseFee) / 1_000_000.0
-		reserveBaseXRP := float64(reserveBase) / 1_000_000.0
-		reserveIncXRP := float64(reserveIncrement) / 1_000_000.0
+	if haveLedger {
+		now := time.Now()
+		age, ageOK := ledgerAge(ledgerCloseTime, now)
+		if human {
+			baseFeeXRP := float64(baseFee) / 1_000_000.0
+			reserveBaseXRP := float64(reserveBase) / 1_000_000.0
+			reserveIncXRP := float64(reserveIncrement) / 1_000_000.0
 
-		// validated_ledger always carries an `age` in rippled (the
-		// `haveValidated() == true` branch at NetworkOPs.cpp:2952-2956
-		// unconditionally writes it, possibly as 0).
-		info["validated_ledger"] = map[string]interface{}{
-			"age":              validatedAge,
-			"base_fee_xrp":     baseFeeXRP,
-			"hash":             validatedLedgerHash,
-			"reserve_base_xrp": reserveBaseXRP,
-			"reserve_inc_xrp":  reserveIncXRP,
-			"seq":              serverInfo.ValidatedLedgerSeq,
-		}
-
-		// closed_ledger in human mode. Rippled omits `age` when the
-		// close-time is in the future (clock skew, no valid answer)
-		// — NetworkOPs.cpp:2962-2969.
-		closedLedger := map[string]interface{}{
-			"base_fee_xrp":     baseFeeXRP,
-			"hash":             closedLedgerHash,
-			"reserve_base_xrp": reserveBaseXRP,
-			"reserve_inc_xrp":  reserveIncXRP,
-			"seq":              serverInfo.ClosedLedgerSeq,
-		}
-		if closedAgeOK {
-			closedLedger["age"] = closedAge
-		}
-		info["closed_ledger"] = closedLedger
-	} else {
-		info["validated_ledger"] = map[string]interface{}{
-			"base_fee":     baseFee,
-			"close_time":   serverInfo.ValidatedLedgerCloseTime,
-			"hash":         validatedLedgerHash,
-			"reserve_base": reserveBase,
-			"reserve_inc":  reserveIncrement,
-			"seq":          serverInfo.ValidatedLedgerSeq,
-		}
-
-		// closed_ledger in machine mode
-		info["closed_ledger"] = map[string]interface{}{
-			"base_fee":     baseFee,
-			"close_time":   serverInfo.ClosedLedgerCloseTime,
-			"hash":         closedLedgerHash,
-			"reserve_base": reserveBase,
-			"reserve_inc":  reserveIncrement,
-			"seq":          serverInfo.ClosedLedgerSeq,
+			ledger := map[string]interface{}{
+				"base_fee_xrp":     baseFeeXRP,
+				"hash":             ledgerHash,
+				"reserve_base_xrp": reserveBaseXRP,
+				"reserve_inc_xrp":  reserveIncXRP,
+				"seq":              ledgerSeq,
+			}
+			// rippled NetworkOPs.cpp:2946-2949: close_time_offset is
+			// emitted on the ledger object when |offset| >= 60s.
+			if services != nil && services.CloseTimeOffset != nil {
+				offset := services.CloseTimeOffset()
+				if offset < 0 {
+					if -offset >= closeTimeOffsetThreshold {
+						ledger["close_time_offset"] = int32(offset / time.Second)
+					}
+				} else if offset >= closeTimeOffsetThreshold {
+					ledger["close_time_offset"] = int32(offset / time.Second)
+				}
+			}
+			// Age handling differs by branch (NetworkOPs.cpp:2952-2969):
+			// validated → always emit (0 when unknown / too old);
+			// closed-only → omit when close-time is in the future.
+			if serverInfo.HaveValidated {
+				ledger["age"] = age
+			} else if ageOK {
+				ledger["age"] = age
+			}
+			info[ledgerKey] = ledger
+		} else {
+			info[ledgerKey] = map[string]interface{}{
+				"base_fee":     baseFee,
+				"close_time":   ledgerCloseTime,
+				"hash":         ledgerHash,
+				"reserve_base": reserveBase,
+				"reserve_inc":  reserveIncrement,
+				"seq":          ledgerSeq,
+			}
 		}
 	}
 

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -14,8 +14,8 @@ import (
 )
 
 // loadBase is the fee-tracker reference level. Mirrors rippled's
-// LoadFeeTrack default at LoadFeeTrack.h — every load_factor_* field
-// is expressed as a multiple of this base.
+// LoadFeeTrack::lftNormalFee at LoadFeeTrack.h:141-142 — every
+// load_factor_* field is expressed as a multiple of this base.
 const loadBase uint64 = 256
 
 // clipToUint32 mirrors rippled's trunc32 / FeeLevel::jsonClipped at

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -192,8 +192,17 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	// fee-escalation level — the only load signal we currently track. Matches
 	// rippled's NetworkOPs.cpp:2863-2875 fallback when no other load source
 	// (cluster, admin) is active.
+	//
+	// loadFactorFeeEscalation = openLedgerFeeLevel * loadBase / referenceFeeLevel
+	// (NetworkOPs.cpp:2850-2855). When referenceFeeLevel == loadBase this reduces
+	// to feeEscalation, but compute the ratio explicitly so the algebra survives
+	// any future TxQ configuration drift.
 	feeEscalation, feeQueue, feeReference := resolveLoadFactorFees(services)
-	loadFactor := feeEscalation
+	loadFactorFeeEscalation := feeEscalation
+	if feeReference != 0 {
+		loadFactorFeeEscalation = feeEscalation * loadBase / feeReference
+	}
+	loadFactor := loadFactorFeeEscalation
 	if loadFactor < loadBase {
 		loadFactor = loadBase
 	}
@@ -228,11 +237,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		//     && (admin || loadFactorFeeEscalation != loadFactor)
 		// and the queue field on
 		//   minProcessingFeeLevel != referenceFeeLevel.
-		// We have no separate LoadFeeTrack yet, so
-		// loadFactorFeeEscalation == feeEscalation (referenceFeeLevel
-		// is the rippled-invariant 256), making the inner comparison
-		// equivalent to `feeEscalation != loadFactor`.
-		if feeEscalation != feeReference && (ctx.IsAdmin || feeEscalation != loadFactor) {
+		if feeEscalation != feeReference && (ctx.IsAdmin || loadFactorFeeEscalation != loadFactor) {
 			info["load_factor_fee_escalation"] = float64(feeEscalation) / float64(feeReference)
 		}
 		if feeQueue != feeReference {
@@ -292,15 +297,19 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 				"seq":              ledgerSeq,
 			}
 			// rippled NetworkOPs.cpp:2946-2949: close_time_offset is
-			// emitted on the ledger object when |offset| >= 60s.
+			// emitted on the ledger object when |offset| >= 60s. Rippled
+			// casts the signed seconds count through static_cast<uint32_t>,
+			// preserving the two's-complement bit pattern — so a negative
+			// offset surfaces as a large positive number. Match that wire
+			// shape rather than emit a signed value.
 			if services != nil && services.CloseTimeOffset != nil {
 				offset := services.CloseTimeOffset()
-				if offset < 0 {
-					if -offset >= closeTimeOffsetThreshold {
-						ledger["close_time_offset"] = int32(offset / time.Second)
-					}
-				} else if offset >= closeTimeOffsetThreshold {
-					ledger["close_time_offset"] = int32(offset / time.Second)
+				abs := offset
+				if abs < 0 {
+					abs = -abs
+				}
+				if abs >= closeTimeOffsetThreshold {
+					ledger["close_time_offset"] = uint32(int32(offset / time.Second))
 				}
 			}
 			// Age handling differs by branch (NetworkOPs.cpp:2952-2969):
@@ -384,24 +393,17 @@ func resolveDisconnectCounters(services *types.ServiceContainer) (overflow, peer
 }
 
 // resolveLoadFactorFees returns (escalation, queue, reference) levels
-// for the server_info load_factor_fee_* fields. Falls back to the
-// reference level (loadBase) when the TxQ isn't wired.
+// for the server_info load_factor_fee_* fields. Falls back to (loadBase,
+// loadBase, loadBase) when the TxQ isn't wired so the load_factor_fee_*
+// gates collapse to "absent". Once the hook fires, values pass through
+// unfiltered — a zero from TxQ would be a TxQ bug, not something to
+// paper over here.
 func resolveLoadFactorFees(services *types.ServiceContainer) (escalation, queue, reference uint64) {
-	escalation, queue, reference = loadBase, loadBase, loadBase
 	if services == nil || services.TxQMetrics == nil {
-		return
+		return loadBase, loadBase, loadBase
 	}
 	m := services.TxQMetrics()
-	if m.ReferenceFeeLevel > 0 {
-		reference = m.ReferenceFeeLevel
-	}
-	if m.OpenLedgerFeeLevel > 0 {
-		escalation = m.OpenLedgerFeeLevel
-	}
-	if m.MinProcessingFeeLevel > 0 {
-		queue = m.MinProcessingFeeLevel
-	}
-	return
+	return m.OpenLedgerFeeLevel, m.MinProcessingFeeLevel, m.ReferenceFeeLevel
 }
 
 // stateAccountingResolved is the rendered shape consumed by
@@ -415,7 +417,14 @@ type stateAccountingResolved struct {
 
 // resolveStateAccounting builds the state_accounting JSON value and the
 // top-level companion durations. Prefers the adaptor's tracker when
-// wired; otherwise attributes total uptime to the current server state.
+// wired; otherwise attributes total uptime to the current server state
+// as a synthetic single-transition row.
+//
+// The synthetic fallback is intentionally non-rippled-conformant: rippled
+// always has a StateAccounting instance, so this branch only fires in
+// goxrpl-only deployments (standalone / RPC-only tests) where wiring the
+// real tracker isn't applicable. Production network nodes always take
+// the wired path above.
 func resolveStateAccounting(services *types.ServiceContainer, serverState string, uptimeUs int64) stateAccountingResolved {
 	out := make(map[string]interface{}, len(stateAccountingModes))
 	for _, m := range stateAccountingModes {

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -18,6 +18,18 @@ import (
 // is expressed as a multiple of this base.
 const loadBase uint64 = 256
 
+// clipToUint32 mirrors rippled's trunc32 / FeeLevel::jsonClipped at
+// NetworkOPs.cpp:2862-2876: load_factor* and load_base are emitted as
+// JSON UInts, with values above uint32 max saturated rather than
+// overflowed. Pathological for realistic load, but keeps the wire type
+// matching rippled.
+func clipToUint32(v uint64) uint32 {
+	if v > uint64(^uint32(0)) {
+		return ^uint32(0)
+	}
+	return uint32(v)
+}
+
 // validatedLedgerAgeThreshold matches rippled's
 // NetworkOPsImp::getServerInfo (NetworkOPs.cpp:2951): once the
 // validated ledger is older than this the age is clamped to 0 in the
@@ -184,25 +196,31 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	if human {
 		info["load_factor"] = float64(loadFactor) / float64(loadBase)
 		// Mirror rippled NetworkOPs.cpp:2902-2912: in human mode the
-		// escalation and queue fields are emitted only when they
-		// actually diverge from the reference level (i.e., load is
-		// active). With no LoadFeeTrack yet we can't honour the
-		// `admin || feeEscalation != loadFactor` extra gate exactly,
-		// so we emit whenever escalation/queue are above reference —
-		// the conservative subset of rippled's predicate.
-		if feeEscalation != feeReference {
+		// escalation field is gated on
+		//   openLedgerFeeLevel != referenceFeeLevel
+		//     && (admin || loadFactorFeeEscalation != loadFactor)
+		// and the queue field on
+		//   minProcessingFeeLevel != referenceFeeLevel.
+		// We have no separate LoadFeeTrack yet, so
+		// loadFactorFeeEscalation == feeEscalation (referenceFeeLevel
+		// is the rippled-invariant 256), making the inner comparison
+		// equivalent to `feeEscalation != loadFactor`.
+		if feeEscalation != feeReference && (ctx.IsAdmin || feeEscalation != loadFactor) {
 			info["load_factor_fee_escalation"] = float64(feeEscalation) / float64(feeReference)
 		}
 		if feeQueue != feeReference {
 			info["load_factor_fee_queue"] = float64(feeQueue) / float64(feeReference)
 		}
 	} else {
-		info["load_base"] = loadBase
-		info["load_factor"] = loadFactor
-		info["load_factor_server"] = loadBase
-		info["load_factor_fee_escalation"] = feeEscalation
-		info["load_factor_fee_queue"] = feeQueue
-		info["load_factor_fee_reference"] = feeReference
+		// Machine mode mirrors rippled NetworkOPs.cpp:2862-2876: load_base
+		// and load_factor* are emitted as JSON UInts; rippled clamps via
+		// trunc32() / jsonClipped() so the field type stays uint32.
+		info["load_base"] = uint32(loadBase)
+		info["load_factor"] = clipToUint32(loadFactor)
+		info["load_factor_server"] = uint32(loadBase)
+		info["load_factor_fee_escalation"] = clipToUint32(feeEscalation)
+		info["load_factor_fee_queue"] = clipToUint32(feeQueue)
+		info["load_factor_fee_reference"] = clipToUint32(feeReference)
 	}
 
 	now := time.Now()

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -116,8 +116,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		serverState = "standalone"
 	}
 
-	// Duration in microseconds for the legacy state-accounting fallback
-	// (used only when consensus hasn't wired a tracker).
+	// Fallback used only when consensus hasn't wired a state-accounting tracker.
 	uptimeUs := uptimeDuration.Microseconds()
 
 	overflow, peerDisc, peerDiscRes := resolveDisconnectCounters(services)
@@ -370,8 +369,7 @@ type stateAccountingResolved struct {
 
 // resolveStateAccounting builds the state_accounting JSON value and the
 // top-level companion durations. Prefers the adaptor's tracker when
-// wired; falls back to attributing the whole uptime to the current
-// server state (matching the pre-#480 stub shape).
+// wired; otherwise attributes total uptime to the current server state.
 func resolveStateAccounting(services *types.ServiceContainer, serverState string, uptimeUs int64) stateAccountingResolved {
 	out := make(map[string]interface{}, len(stateAccountingModes))
 	for _, m := range stateAccountingModes {
@@ -396,10 +394,7 @@ func resolveStateAccounting(services *types.ServiceContainer, serverState string
 		}
 	}
 
-	// Legacy fallback: attribute total uptime to the current state.
-	// server_state_duration_us in this branch necessarily equals
-	// uptime — there's no transition history to derive a tighter
-	// value from.
+	// No tracker wired — attribute total uptime to the current state.
 	if _, ok := out[serverState]; ok {
 		out[serverState] = map[string]interface{}{
 			"duration_us": fmt.Sprintf("%d", uptimeUs),

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -77,6 +77,7 @@ func (a *LedgerServiceAdapter) GetServerInfo() types.LedgerServerInfo {
 		ClosedLedgerSeq:          info.ClosedLedgerSeq,
 		ClosedLedgerHash:         info.ClosedLedgerHash,
 		ClosedLedgerCloseTime:    info.ClosedLedgerCloseTime,
+		HaveValidated:            info.HaveValidated,
 		ValidatedLedgerSeq:       info.ValidatedLedgerSeq,
 		ValidatedLedgerHash:      info.ValidatedLedgerHash,
 		ValidatedLedgerCloseTime: info.ValidatedLedgerCloseTime,

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -71,15 +71,17 @@ func (a *LedgerServiceAdapter) IsStandalone() bool {
 func (a *LedgerServiceAdapter) GetServerInfo() types.LedgerServerInfo {
 	info := a.svc.GetServerInfo()
 	return types.LedgerServerInfo{
-		Standalone:          info.Standalone,
-		ServerState:         info.ServerState,
-		OpenLedgerSeq:       info.OpenLedgerSeq,
-		ClosedLedgerSeq:     info.ClosedLedgerSeq,
-		ClosedLedgerHash:    info.ClosedLedgerHash,
-		ValidatedLedgerSeq:  info.ValidatedLedgerSeq,
-		ValidatedLedgerHash: info.ValidatedLedgerHash,
-		CompleteLedgers:     info.CompleteLedgers,
-		NetworkID:           info.NetworkID,
+		Standalone:               info.Standalone,
+		ServerState:              info.ServerState,
+		OpenLedgerSeq:            info.OpenLedgerSeq,
+		ClosedLedgerSeq:          info.ClosedLedgerSeq,
+		ClosedLedgerHash:         info.ClosedLedgerHash,
+		ClosedLedgerCloseTime:    info.ClosedLedgerCloseTime,
+		ValidatedLedgerSeq:       info.ValidatedLedgerSeq,
+		ValidatedLedgerHash:      info.ValidatedLedgerHash,
+		ValidatedLedgerCloseTime: info.ValidatedLedgerCloseTime,
+		CompleteLedgers:          info.CompleteLedgers,
+		NetworkID:                info.NetworkID,
 	}
 }
 

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -1434,19 +1434,25 @@ func TestServerInfo_HumanMode_LoadFactorLocalNetCluster_AdminGate(t *testing.T) 
 
 // TestServerInfo_CloseTimeOffset_Threshold pins rippled
 // NetworkOPs.cpp:2946-2949: close_time_offset is surfaced on the
-// ledger object only when |offset| reaches a full minute.
+// ledger object only when |offset| reaches a full minute, and is cast
+// through static_cast<uint32_t> — preserving the two's-complement bit
+// pattern, so negative offsets surface as large positives on the wire.
 func TestServerInfo_CloseTimeOffset_Threshold(t *testing.T) {
 	method := &handlers.ServerInfoMethod{}
+	// Helper so the two's-complement reinterpretation can sit in the
+	// table literal without tripping Go's compile-time overflow check on
+	// `uint32(int32(<negative-const>))`.
+	asU32 := func(v int32) uint32 { return uint32(v) }
 	cases := []struct {
 		name      string
 		offset    time.Duration
 		wantEmit  bool
-		wantValue int32
+		wantValue uint32
 	}{
 		{"below threshold", 59 * time.Second, false, 0},
 		{"at threshold positive", 60 * time.Second, true, 60},
-		{"at threshold negative", -60 * time.Second, true, -60},
-		{"large negative", -125 * time.Second, true, -125},
+		{"at threshold negative", -60 * time.Second, true, asU32(-60)},
+		{"large negative", -125 * time.Second, true, asU32(-125)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,12 +64,14 @@ func (m *mockLedgerServiceServerInfo) GetCurrentFees() (baseFee, reserveBase, re
 
 func (m *mockLedgerServiceServerInfo) GetServerInfo() types.LedgerServerInfo {
 	return types.LedgerServerInfo{
-		Standalone:          m.standalone,
-		OpenLedgerSeq:       m.currentLedgerIndex,
-		ClosedLedgerSeq:     m.closedLedgerIndex,
-		ValidatedLedgerSeq:  m.validatedLedgerIndex,
-		CompleteLedgers:     m.serverInfo.CompleteLedgers,
-		ValidatedLedgerHash: m.serverInfo.ValidatedLedgerHash,
+		Standalone:               m.standalone,
+		OpenLedgerSeq:            m.currentLedgerIndex,
+		ClosedLedgerSeq:          m.closedLedgerIndex,
+		ClosedLedgerCloseTime:    m.serverInfo.ClosedLedgerCloseTime,
+		ValidatedLedgerSeq:       m.validatedLedgerIndex,
+		ValidatedLedgerHash:      m.serverInfo.ValidatedLedgerHash,
+		ValidatedLedgerCloseTime: m.serverInfo.ValidatedLedgerCloseTime,
+		CompleteLedgers:          m.serverInfo.CompleteLedgers,
 	}
 }
 
@@ -1039,11 +1043,14 @@ func TestServerInfoWithParams(t *testing.T) {
 // instead of the previous hardcoded zeros / placeholders.
 func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	now := uint32(900_000_000) // ripple-epoch seconds; well past the 600s age threshold floor when paired with a fresh "now"
+	// Use a recent ripple-epoch close time so the age computation is
+	// non-zero but well under the high-age threshold.
+	nowUnix := time.Now().Unix()
+	closeRippleEpoch := nowUnix - protocol.RippleEpochUnix - 5
 	mock.serverInfo.ValidatedLedgerSeq = 100
 	mock.serverInfo.ClosedLedgerSeq = 101
-	mock.serverInfo.ValidatedLedgerCloseTime = int64(now)
-	mock.serverInfo.ClosedLedgerCloseTime = int64(now) + 4
+	mock.serverInfo.ValidatedLedgerCloseTime = closeRippleEpoch
+	mock.serverInfo.ClosedLedgerCloseTime = closeRippleEpoch + 1
 
 	services := servicesForServerInfo(mock)
 	services.TxQMetrics = func() types.TxQServerMetrics {
@@ -1055,13 +1062,17 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 		}
 	}
 	services.PeerDisconnects = func() (uint64, uint64) { return 42, 9 }
-	services.StateAccounting = func() map[string]types.StateAccountingEntry {
-		return map[string]types.StateAccountingEntry{
-			"disconnected": {Transitions: 1, DurationUs: 1500},
-			"connected":    {Transitions: 2, DurationUs: 2500},
-			"syncing":      {Transitions: 1, DurationUs: 750},
-			"tracking":     {Transitions: 1, DurationUs: 500},
-			"full":         {Transitions: 1, DurationUs: 9000},
+	services.StateAccounting = func() types.StateAccountingSnapshot {
+		return types.StateAccountingSnapshot{
+			Modes: map[string]types.StateAccountingEntry{
+				"disconnected": {Transitions: 1, DurationUs: 1500},
+				"connected":    {Transitions: 2, DurationUs: 2500},
+				"syncing":      {Transitions: 1, DurationUs: 750},
+				"tracking":     {Transitions: 1, DurationUs: 500},
+				"full":         {Transitions: 1, DurationUs: 9000},
+			},
+			CurrentDurationUs: 4321,
+			InitialSyncUs:     1234,
 		}
 	}
 
@@ -1087,8 +1098,17 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	assert.Equal(t, "42", info["peer_disconnects"])
 	assert.Equal(t, "9", info["peer_disconnects_resources"])
 
+	// Top-level companions of state_accounting reflect the tracker's
+	// current-state and initial-sync values, not process uptime.
+	assert.Equal(t, "4321", info["server_state_duration_us"])
+	assert.Equal(t, "1234", info["initial_sync_duration_us"])
+
 	// human-mode load_factor is the float ratio openLedgerFeeLevel/loadBase.
 	assert.InDelta(t, 4.0, info["load_factor"].(float64), 0.0001)
+	// load_factor_fee_escalation / _queue are emitted in human mode
+	// only when they diverge from the reference level (M4).
+	assert.InDelta(t, 4.0, info["load_factor_fee_escalation"].(float64), 0.0001)
+	assert.InDelta(t, 2.0, info["load_factor_fee_queue"].(float64), 0.0001)
 
 	sa := info["state_accounting"].(map[string]interface{})
 	full := sa["full"].(map[string]interface{})
@@ -1135,4 +1155,66 @@ func TestServerInfo_MachineMode_LoadFactorFees(t *testing.T) {
 	assert.EqualValues(t, 256, state["load_factor_fee_reference"])
 	assert.EqualValues(t, 2048, state["load_factor"])
 	assert.EqualValues(t, 256, state["load_base"])
+}
+
+// TestServerInfo_ValidatedLedgerAge_HighAgeThreshold guards against
+// regressing the threshold below rippled's 1,000,000-second limit
+// (NetworkOPs.cpp:2951). A 1-hour-old ledger must report an actual
+// age, not the threshold-clamped 0.
+func TestServerInfo_ValidatedLedgerAge_HighAgeThreshold(t *testing.T) {
+	mock := newMockLedgerServiceServerInfo()
+	nowUnix := time.Now().Unix()
+	mock.serverInfo.ValidatedLedgerSeq = 5
+	mock.serverInfo.ValidatedLedgerCloseTime = nowUnix - protocol.RippleEpochUnix - 3600
+
+	services := servicesForServerInfo(mock)
+	method := &handlers.ServerInfoMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	result, rpcErr := method.Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+	raw, _ := json.Marshal(result)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	info := resp["info"].(map[string]interface{})
+	validated := info["validated_ledger"].(map[string]interface{})
+
+	age, ok := validated["age"].(float64)
+	require.True(t, ok)
+	assert.InDelta(t, 3600, age, 5, "1-hour-old ledger must surface its real age; rippled clamps only above 1,000,000s")
+}
+
+// TestServerInfo_ClosedLedgerAge_OmittedOnFutureCloseTime mirrors
+// rippled NetworkOPs.cpp:2962-2969: when the closed ledger's close
+// time is in the future (clock skew), `age` is omitted from the
+// closed_ledger object rather than emitted as 0.
+func TestServerInfo_ClosedLedgerAge_OmittedOnFutureCloseTime(t *testing.T) {
+	mock := newMockLedgerServiceServerInfo()
+	mock.serverInfo.ClosedLedgerSeq = 7
+	// 1 hour in the future
+	mock.serverInfo.ClosedLedgerCloseTime = time.Now().Unix() - protocol.RippleEpochUnix + 3600
+
+	services := servicesForServerInfo(mock)
+	method := &handlers.ServerInfoMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	result, rpcErr := method.Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+	raw, _ := json.Marshal(result)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	info := resp["info"].(map[string]interface{})
+	closed := info["closed_ledger"].(map[string]interface{})
+	_, hasAge := closed["age"]
+	assert.False(t, hasAge, "closed_ledger.age must be omitted when close_time is in the future")
 }

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -1077,9 +1077,13 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	}
 
 	method := &handlers.ServerInfoMethod{}
+	// IsAdmin=true so load_factor_fee_escalation is emitted even when
+	// loadFactorFeeEscalation == loadFactor; mirrors rippled's
+	// NetworkOPs.cpp:2902-2907 (admin || loadFactorFeeEscalation != loadFactor).
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
-		Role:       types.RoleGuest,
+		Role:       types.RoleAdmin,
+		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -1106,7 +1110,8 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	// human-mode load_factor is the float ratio openLedgerFeeLevel/loadBase.
 	assert.InDelta(t, 4.0, info["load_factor"].(float64), 0.0001)
 	// load_factor_fee_escalation / _queue are emitted in human mode
-	// only when they diverge from the reference level (M4).
+	// only when they diverge from the reference level, with an extra
+	// admin gate on _escalation matching rippled's predicate.
 	assert.InDelta(t, 4.0, info["load_factor_fee_escalation"].(float64), 0.0001)
 	assert.InDelta(t, 2.0, info["load_factor_fee_queue"].(float64), 0.0001)
 
@@ -1187,6 +1192,45 @@ func TestServerInfo_ValidatedLedgerAge_HighAgeThreshold(t *testing.T) {
 	age, ok := validated["age"].(float64)
 	require.True(t, ok)
 	assert.InDelta(t, 3600, age, 5, "1-hour-old ledger must surface its real age; rippled clamps only above 1,000,000s")
+}
+
+// TestServerInfo_HumanMode_LoadFactorFeeEscalation_NonAdminGate pins
+// rippled NetworkOPs.cpp:2902-2907: in human mode, non-admin callers
+// only see load_factor_fee_escalation when it actually changes the
+// overall load_factor (i.e. loadFactorFeeEscalation != loadFactor).
+// With feeEscalation > loadBase and no separate LoadFeeTrack,
+// loadFactorFeeEscalation == loadFactor, so the field is hidden.
+func TestServerInfo_HumanMode_LoadFactorFeeEscalation_NonAdminGate(t *testing.T) {
+	mock := newMockLedgerServiceServerInfo()
+	services := servicesForServerInfo(mock)
+	services.TxQMetrics = func() types.TxQServerMetrics {
+		return types.TxQServerMetrics{
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 768, // diverges -> _queue still emitted
+			OpenLedgerFeeLevel:    1024,
+		}
+	}
+
+	method := &handlers.ServerInfoMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	result, rpcErr := method.Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+	raw, _ := json.Marshal(result)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	info := resp["info"].(map[string]interface{})
+
+	_, hasEscalation := info["load_factor_fee_escalation"]
+	assert.False(t, hasEscalation,
+		"non-admin: field must be omitted when loadFactorFeeEscalation == loadFactor (rippled gate)")
+	// _queue has no admin gate in rippled — only the != reference check.
+	assert.InDelta(t, 3.0, info["load_factor_fee_queue"].(float64), 0.0001)
 }
 
 // TestServerInfo_ClosedLedgerAge_OmittedOnFutureCloseTime mirrors

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -1038,9 +1038,8 @@ func TestServerInfoWithParams(t *testing.T) {
 	}
 }
 
-// TestServerInfo_DynamicMetrics_FromHooks confirms #480: server_info
-// surfaces live values from the TxQ, peer, and state-accounting hooks
-// instead of the previous hardcoded zeros / placeholders.
+// TestServerInfo_DynamicMetrics_FromHooks pins that server_info surfaces
+// live values from the TxQ, peer, and state-accounting hooks.
 func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
 	// Use a recent ripple-epoch close time so the age computation is
@@ -1125,7 +1124,7 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 
 // TestServerInfo_MachineMode_LoadFactorFees verifies the server_state
 // (machine) variant surfaces the load_factor_fee_* triple from TxQ
-// metrics, not the pre-#480 hardcoded 256s.
+// metrics.
 func TestServerInfo_MachineMode_LoadFactorFees(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
 	services := servicesForServerInfo(mock)

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -68,6 +68,7 @@ func (m *mockLedgerServiceServerInfo) GetServerInfo() types.LedgerServerInfo {
 		OpenLedgerSeq:            m.currentLedgerIndex,
 		ClosedLedgerSeq:          m.closedLedgerIndex,
 		ClosedLedgerCloseTime:    m.serverInfo.ClosedLedgerCloseTime,
+		HaveValidated:            m.validatedLedgerIndex > 0,
 		ValidatedLedgerSeq:       m.validatedLedgerIndex,
 		ValidatedLedgerHash:      m.serverInfo.ValidatedLedgerHash,
 		ValidatedLedgerCloseTime: m.serverInfo.ValidatedLedgerCloseTime,
@@ -1238,7 +1239,11 @@ func TestServerInfo_HumanMode_LoadFactorFeeEscalation_NonAdminGate(t *testing.T)
 // closed_ledger object rather than emitted as 0.
 func TestServerInfo_ClosedLedgerAge_OmittedOnFutureCloseTime(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	mock.serverInfo.ClosedLedgerSeq = 7
+	// Force the closed-ledger branch by zeroing the validated index
+	// (drives HaveValidated=false in the mock); rippled emits exactly
+	// one of validated_ledger / closed_ledger.
+	mock.validatedLedgerIndex = 0
+	mock.closedLedgerIndex = 7
 	// 1 hour in the future
 	mock.serverInfo.ClosedLedgerCloseTime = time.Now().Unix() - protocol.RippleEpochUnix + 3600
 
@@ -1260,4 +1265,216 @@ func TestServerInfo_ClosedLedgerAge_OmittedOnFutureCloseTime(t *testing.T) {
 	closed := info["closed_ledger"].(map[string]interface{})
 	_, hasAge := closed["age"]
 	assert.False(t, hasAge, "closed_ledger.age must be omitted when close_time is in the future")
+}
+
+// TestServerInfo_SingleLedgerEmit pins rippled NetworkOPs.cpp:2915-2975:
+// exactly one of validated_ledger / closed_ledger is emitted, sourced
+// from the validated ledger when haveValidated() and otherwise from the
+// closed ledger. Suppressed entirely when neither is available.
+func TestServerInfo_SingleLedgerEmit(t *testing.T) {
+	method := &handlers.ServerInfoMethod{}
+	newCtx := func(svc *types.ServiceContainer) *types.RpcContext {
+		return &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   svc,
+		}
+	}
+	dispatch := func(ctx *types.RpcContext) map[string]interface{} {
+		result, rpcErr := method.Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+		raw, _ := json.Marshal(result)
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &resp))
+		return resp["info"].(map[string]interface{})
+	}
+
+	t.Run("validated present → only validated_ledger", func(t *testing.T) {
+		mock := newMockLedgerServiceServerInfo()
+		mock.validatedLedgerIndex = 42
+		mock.closedLedgerIndex = 43
+		info := dispatch(newCtx(servicesForServerInfo(mock)))
+		assert.Contains(t, info, "validated_ledger")
+		assert.NotContains(t, info, "closed_ledger")
+	})
+
+	t.Run("validated absent → only closed_ledger", func(t *testing.T) {
+		mock := newMockLedgerServiceServerInfo()
+		mock.validatedLedgerIndex = 0
+		mock.closedLedgerIndex = 7
+		info := dispatch(newCtx(servicesForServerInfo(mock)))
+		assert.NotContains(t, info, "validated_ledger")
+		assert.Contains(t, info, "closed_ledger")
+	})
+
+	t.Run("neither present → neither emitted", func(t *testing.T) {
+		mock := newMockLedgerServiceServerInfo()
+		mock.validatedLedgerIndex = 0
+		mock.closedLedgerIndex = 0
+		info := dispatch(newCtx(servicesForServerInfo(mock)))
+		assert.NotContains(t, info, "validated_ledger")
+		assert.NotContains(t, info, "closed_ledger")
+	})
+}
+
+// TestServerInfo_HumanMode_LoadFactorServer pins rippled
+// NetworkOPs.cpp:2883-2885: in human mode, load_factor_server is
+// emitted only when it differs from the overall load_factor. With no
+// LoadFeeTrack the server-side factor is loadBase, so the field fires
+// whenever fee escalation drives load_factor above 1.0.
+func TestServerInfo_HumanMode_LoadFactorServer(t *testing.T) {
+	method := &handlers.ServerInfoMethod{}
+
+	t.Run("escalation > loadBase → field present", func(t *testing.T) {
+		mock := newMockLedgerServiceServerInfo()
+		services := servicesForServerInfo(mock)
+		services.TxQMetrics = func() types.TxQServerMetrics {
+			return types.TxQServerMetrics{
+				ReferenceFeeLevel:  256,
+				OpenLedgerFeeLevel: 1024,
+			}
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+		}
+		result, rpcErr := method.Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+		raw, _ := json.Marshal(result)
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &resp))
+		info := resp["info"].(map[string]interface{})
+		v, ok := info["load_factor_server"]
+		require.True(t, ok, "load_factor_server must be emitted when escalation > loadBase")
+		assert.InDelta(t, 1.0, v.(float64), 0.0001)
+	})
+
+	t.Run("escalation == loadBase → field absent", func(t *testing.T) {
+		mock := newMockLedgerServiceServerInfo()
+		services := servicesForServerInfo(mock)
+		// No TxQMetrics → escalation falls back to loadBase.
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+		}
+		result, rpcErr := method.Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+		raw, _ := json.Marshal(result)
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &resp))
+		info := resp["info"].(map[string]interface{})
+		_, present := info["load_factor_server"]
+		assert.False(t, present, "load_factor_server must be omitted when loadFactorServer == loadFactor")
+	})
+}
+
+// TestServerInfo_HumanMode_LoadFactorLocalNetCluster_AdminGate pins
+// rippled NetworkOPs.cpp:2887-2901: admin-only emission, each field
+// gated on its fee != loadBase. Non-admin callers must never see them
+// regardless of fee divergence.
+func TestServerInfo_HumanMode_LoadFactorLocalNetCluster_AdminGate(t *testing.T) {
+	method := &handlers.ServerInfoMethod{}
+	feesHook := func() types.LoadFactorFees {
+		return types.LoadFactorFees{Local: 512, Net: 256, Cluster: 768}
+	}
+	build := func(admin bool, withHook bool) map[string]interface{} {
+		mock := newMockLedgerServiceServerInfo()
+		services := servicesForServerInfo(mock)
+		if withHook {
+			services.LoadFactorFees = feesHook
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+			IsAdmin:    admin,
+		}
+		result, rpcErr := method.Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+		raw, _ := json.Marshal(result)
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &resp))
+		return resp["info"].(map[string]interface{})
+	}
+
+	t.Run("admin + hook → diverging fields emitted, matching ones suppressed", func(t *testing.T) {
+		info := build(true, true)
+		v, ok := info["load_factor_local"].(float64)
+		require.True(t, ok)
+		assert.InDelta(t, 2.0, v, 0.0001)
+		_, hasNet := info["load_factor_net"] // Net == loadBase, must be absent.
+		assert.False(t, hasNet)
+		v, ok = info["load_factor_cluster"].(float64)
+		require.True(t, ok)
+		assert.InDelta(t, 3.0, v, 0.0001)
+	})
+
+	t.Run("non-admin + hook → all three suppressed", func(t *testing.T) {
+		info := build(false, true)
+		for _, k := range []string{"load_factor_local", "load_factor_net", "load_factor_cluster"} {
+			_, present := info[k]
+			assert.Falsef(t, present, "%s must be admin-only", k)
+		}
+	})
+
+	t.Run("admin without hook → all three suppressed", func(t *testing.T) {
+		info := build(true, false)
+		for _, k := range []string{"load_factor_local", "load_factor_net", "load_factor_cluster"} {
+			_, present := info[k]
+			assert.Falsef(t, present, "%s must be absent when hook is nil", k)
+		}
+	})
+}
+
+// TestServerInfo_CloseTimeOffset_Threshold pins rippled
+// NetworkOPs.cpp:2946-2949: close_time_offset is surfaced on the
+// ledger object only when |offset| reaches a full minute.
+func TestServerInfo_CloseTimeOffset_Threshold(t *testing.T) {
+	method := &handlers.ServerInfoMethod{}
+	cases := []struct {
+		name      string
+		offset    time.Duration
+		wantEmit  bool
+		wantValue int32
+	}{
+		{"below threshold", 59 * time.Second, false, 0},
+		{"at threshold positive", 60 * time.Second, true, 60},
+		{"at threshold negative", -60 * time.Second, true, -60},
+		{"large negative", -125 * time.Second, true, -125},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newMockLedgerServiceServerInfo()
+			services := servicesForServerInfo(mock)
+			offset := tc.offset
+			services.CloseTimeOffset = func() time.Duration { return offset }
+			ctx := &types.RpcContext{
+				Context:    context.Background(),
+				Role:       types.RoleGuest,
+				ApiVersion: types.ApiVersion1,
+				Services:   services,
+			}
+			result, rpcErr := method.Handle(ctx, nil)
+			require.Nil(t, rpcErr)
+			raw, _ := json.Marshal(result)
+			var resp map[string]interface{}
+			require.NoError(t, json.Unmarshal(raw, &resp))
+			info := resp["info"].(map[string]interface{})
+			validated, ok := info["validated_ledger"].(map[string]interface{})
+			require.True(t, ok, "validated_ledger must be present for the offset assertion")
+			v, present := validated["close_time_offset"]
+			if !tc.wantEmit {
+				assert.False(t, present, "close_time_offset must be omitted below threshold")
+				return
+			}
+			require.True(t, present, "close_time_offset must be emitted at/above threshold")
+			assert.EqualValues(t, tc.wantValue, v)
+		})
+	}
 }

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -1033,3 +1033,106 @@ func TestServerInfoWithParams(t *testing.T) {
 		})
 	}
 }
+
+// TestServerInfo_DynamicMetrics_FromHooks confirms #480: server_info
+// surfaces live values from the TxQ, peer, and state-accounting hooks
+// instead of the previous hardcoded zeros / placeholders.
+func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
+	mock := newMockLedgerServiceServerInfo()
+	now := uint32(900_000_000) // ripple-epoch seconds; well past the 600s age threshold floor when paired with a fresh "now"
+	mock.serverInfo.ValidatedLedgerSeq = 100
+	mock.serverInfo.ClosedLedgerSeq = 101
+	mock.serverInfo.ValidatedLedgerCloseTime = int64(now)
+	mock.serverInfo.ClosedLedgerCloseTime = int64(now) + 4
+
+	services := servicesForServerInfo(mock)
+	services.TxQMetrics = func() types.TxQServerMetrics {
+		return types.TxQServerMetrics{
+			JqTransOverflow:       7,
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 512,
+			OpenLedgerFeeLevel:    1024,
+		}
+	}
+	services.PeerDisconnects = func() (uint64, uint64) { return 42, 9 }
+	services.StateAccounting = func() map[string]types.StateAccountingEntry {
+		return map[string]types.StateAccountingEntry{
+			"disconnected": {Transitions: 1, DurationUs: 1500},
+			"connected":    {Transitions: 2, DurationUs: 2500},
+			"syncing":      {Transitions: 1, DurationUs: 750},
+			"tracking":     {Transitions: 1, DurationUs: 500},
+			"full":         {Transitions: 1, DurationUs: 9000},
+		}
+	}
+
+	method := &handlers.ServerInfoMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	result, rpcErr := method.Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+
+	raw, err := json.Marshal(result)
+	require.NoError(t, err)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	info := resp["info"].(map[string]interface{})
+
+	assert.Equal(t, "7", info["jq_trans_overflow"])
+	assert.Equal(t, "42", info["peer_disconnects"])
+	assert.Equal(t, "9", info["peer_disconnects_resources"])
+
+	// human-mode load_factor is the float ratio openLedgerFeeLevel/loadBase.
+	assert.InDelta(t, 4.0, info["load_factor"].(float64), 0.0001)
+
+	sa := info["state_accounting"].(map[string]interface{})
+	full := sa["full"].(map[string]interface{})
+	assert.Equal(t, "9000", full["duration_us"])
+	assert.Equal(t, "1", full["transitions"])
+	disconnected := sa["disconnected"].(map[string]interface{})
+	assert.Equal(t, "1500", disconnected["duration_us"])
+}
+
+// TestServerInfo_MachineMode_LoadFactorFees verifies the server_state
+// (machine) variant surfaces the load_factor_fee_* triple from TxQ
+// metrics, not the pre-#480 hardcoded 256s.
+func TestServerInfo_MachineMode_LoadFactorFees(t *testing.T) {
+	mock := newMockLedgerServiceServerInfo()
+	services := servicesForServerInfo(mock)
+	services.TxQMetrics = func() types.TxQServerMetrics {
+		return types.TxQServerMetrics{
+			JqTransOverflow:       0,
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 768,
+			OpenLedgerFeeLevel:    2048,
+		}
+	}
+
+	method := &handlers.ServerStateMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	result, rpcErr := method.Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+
+	raw, _ := json.Marshal(result)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	state := resp["state"].(map[string]interface{})
+
+	// Machine mode emits these as JSON numbers — unmarshal as float64.
+	assert.EqualValues(t, 2048, state["load_factor_fee_escalation"])
+	assert.EqualValues(t, 768, state["load_factor_fee_queue"])
+	assert.EqualValues(t, 256, state["load_factor_fee_reference"])
+	assert.EqualValues(t, 2048, state["load_factor"])
+	assert.EqualValues(t, 256, state["load_base"])
+}

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -221,9 +221,10 @@ type ServiceContainer struct {
 	PeerDisconnects func() (total, resources uint64)
 
 	// StateAccounting returns the operating-mode state-machine
-	// snapshot surfaced by server_info.state_accounting. Keys are the
-	// rippled lowercase mode names. Nil until consensus is wired.
-	StateAccounting func() map[string]StateAccountingEntry
+	// snapshot surfaced by server_info: per-mode counts/durations
+	// plus the current-state and initial-sync durations. The Modes
+	// map is empty until consensus is wired.
+	StateAccounting func() StateAccountingSnapshot
 }
 
 // LedgerNavigator provides ledger index navigation and mode queries.
@@ -387,6 +388,23 @@ type TxQServerMetrics struct {
 type StateAccountingEntry struct {
 	Transitions uint64
 	DurationUs  uint64
+}
+
+// StateAccountingSnapshot bundles everything server_info needs from
+// the state-accounting tracker. Mirrors the data emitted by rippled's
+// NetworkOPsImp::StateAccounting::json (NetworkOPs.cpp:4828-4849):
+// per-mode rows plus the two top-level companion fields.
+type StateAccountingSnapshot struct {
+	// Modes is the per-mode counts/durations table.
+	Modes map[string]StateAccountingEntry
+	// CurrentDurationUs is the time spent in the current operating
+	// mode since the last transition. Surfaced as the top-level
+	// server_state_duration_us field.
+	CurrentDurationUs uint64
+	// InitialSyncUs is the duration from process start to the first
+	// transition into Full. Zero before that transition. Surfaced as
+	// initial_sync_duration_us; rippled emits it only when non-zero.
+	InitialSyncUs uint64
 }
 
 // SubmitResult contains the result of submitting a transaction.

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -208,6 +208,22 @@ type ServiceContainer struct {
 	// encoded. Surfaced by the `validators` RPC as `NegativeUNL`
 	// (rippled getJson at ValidatorList.cpp:1737-1744). Nil-safe.
 	NegativeUNLBase58 func() []string
+
+	// TxQMetrics returns the current transaction-queue metrics used by
+	// server_info for jq_trans_overflow and the load_factor_fee_*
+	// triple. Nil until the ledger service is wired (standalone tests,
+	// pre-startup) — server_info falls back to baseline values.
+	TxQMetrics func() TxQServerMetrics
+
+	// PeerDisconnects returns cumulative peer-disconnect counters
+	// surfaced by server_info: (total, resources-driven). Nil when
+	// the overlay isn't wired (standalone, RPC-only tests).
+	PeerDisconnects func() (total, resources uint64)
+
+	// StateAccounting returns the operating-mode state-machine
+	// snapshot surfaced by server_info.state_accounting. Keys are the
+	// rippled lowercase mode names. Nil until consensus is wired.
+	StateAccounting func() map[string]StateAccountingEntry
 }
 
 // LedgerNavigator provides ledger index navigation and mode queries.
@@ -342,15 +358,35 @@ type LedgerReader interface {
 
 // LedgerServerInfo contains server status information from the ledger service
 type LedgerServerInfo struct {
-	Standalone          bool
-	ServerState         string
-	OpenLedgerSeq       uint32
-	ClosedLedgerSeq     uint32
-	ClosedLedgerHash    [32]byte
-	ValidatedLedgerSeq  uint32
-	ValidatedLedgerHash [32]byte
-	CompleteLedgers     string
-	NetworkID           uint32
+	Standalone               bool
+	ServerState              string
+	OpenLedgerSeq            uint32
+	ClosedLedgerSeq          uint32
+	ClosedLedgerHash         [32]byte
+	ClosedLedgerCloseTime    int64 // Ripple-epoch seconds; 0 when unknown.
+	ValidatedLedgerSeq       uint32
+	ValidatedLedgerHash      [32]byte
+	ValidatedLedgerCloseTime int64 // Ripple-epoch seconds; 0 when unknown.
+	CompleteLedgers          string
+	NetworkID                uint32
+}
+
+// TxQServerMetrics is the subset of TxQ metrics surfaced by
+// server_info. Kept in rpc/types so handlers don't reach across into
+// internal/txq.
+type TxQServerMetrics struct {
+	JqTransOverflow       uint64
+	ReferenceFeeLevel     uint64
+	MinProcessingFeeLevel uint64
+	OpenLedgerFeeLevel    uint64
+}
+
+// StateAccountingEntry is one row of server_info.state_accounting:
+// the cumulative time spent in an operating mode and the number of
+// times the node entered it.
+type StateAccountingEntry struct {
+	Transitions uint64
+	DurationUs  uint64
 }
 
 // SubmitResult contains the result of submitting a transaction.

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -372,9 +372,7 @@ type LedgerServerInfo struct {
 	NetworkID                uint32
 }
 
-// TxQServerMetrics is the subset of TxQ metrics surfaced by
-// server_info. Kept in rpc/types so handlers don't reach across into
-// internal/txq.
+// TxQServerMetrics is the subset of TxQ metrics surfaced by server_info.
 type TxQServerMetrics struct {
 	JqTransOverflow       uint64
 	ReferenceFeeLevel     uint64

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -225,6 +225,18 @@ type ServiceContainer struct {
 	// plus the current-state and initial-sync durations. The Modes
 	// map is empty until consensus is wired.
 	StateAccounting func() StateAccountingSnapshot
+
+	// CloseTimeOffset returns the consensus-derived close-time offset
+	// from the adaptor. Surfaced as close_time_offset on the ledger
+	// object in human mode when |offset| >= 60s
+	// (NetworkOPs.cpp:2946-2949). Nil before consensus is wired.
+	CloseTimeOffset func() time.Duration
+
+	// LoadFactorFees returns the LoadFeeTrack local/net/cluster fees
+	// driving the admin-only human-mode load_factor_local/net/cluster
+	// emits (NetworkOPs.cpp:2887-2901). Nil until a LoadFeeTrack
+	// subsystem lands — handler suppresses the fields when nil.
+	LoadFactorFees func() LoadFactorFees
 }
 
 // LedgerNavigator provides ledger index navigation and mode queries.
@@ -359,17 +371,31 @@ type LedgerReader interface {
 
 // LedgerServerInfo contains server status information from the ledger service
 type LedgerServerInfo struct {
-	Standalone               bool
-	ServerState              string
-	OpenLedgerSeq            uint32
-	ClosedLedgerSeq          uint32
-	ClosedLedgerHash         [32]byte
-	ClosedLedgerCloseTime    int64 // Ripple-epoch seconds; 0 when unknown.
+	Standalone            bool
+	ServerState           string
+	OpenLedgerSeq         uint32
+	ClosedLedgerSeq       uint32
+	ClosedLedgerHash      [32]byte
+	ClosedLedgerCloseTime int64 // Ripple-epoch seconds; 0 when unknown.
+	// HaveValidated is true when the service has a validated ledger.
+	// Mirrors rippled LedgerMaster::haveValidated() — drives the
+	// validated_ledger vs closed_ledger emit gate at NetworkOPs.cpp:2918.
+	HaveValidated            bool
 	ValidatedLedgerSeq       uint32
 	ValidatedLedgerHash      [32]byte
 	ValidatedLedgerCloseTime int64 // Ripple-epoch seconds; 0 when unknown.
 	CompleteLedgers          string
 	NetworkID                uint32
+}
+
+// LoadFactorFees carries rippled's per-source LoadFeeTrack fees used
+// for the admin-only human-mode load_factor_local/net/cluster emits
+// at NetworkOPs.cpp:2887-2901. Each field is a fee level on the same
+// scale as loadBase; values equal to loadBase suppress emission.
+type LoadFactorFees struct {
+	Local   uint32
+	Net     uint32
+	Cluster uint32
 }
 
 // TxQServerMetrics is the subset of TxQ metrics surfaced by server_info.

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -414,6 +414,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		}
 
 		if lowestOther == nil {
+			q.incJqTransOverflow()
 			return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
 
@@ -456,6 +457,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 				q.erase(dropCandidate)
 			}
 		} else {
+			q.incJqTransOverflow()
 			return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
 	}
@@ -608,11 +610,13 @@ func (q *TxQ) canBeHeld(aq *AccountQueue, replacingCandidate *Candidate, seqProx
 			}
 		}
 		if !hasLaterSeq {
+			q.incJqTransOverflow()
 			return true, ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
 		// Real gap fill — allow it
 		return false, ApplyResult{}
 	}
+	q.incJqTransOverflow()
 	return true, ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
 }
 

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -35,10 +35,14 @@ type TxQ struct {
 	// This ensures different validators build similar queues.
 	parentHash [32]byte
 
-	// jqTransOverflow counts transactions rejected because the queue
-	// was full at submission time (telCAN_NOT_QUEUE_FULL). Mirrors
-	// rippled's NetworkOPsImp::getJqTransOverflow surfaced by
-	// server_info as jq_trans_overflow.
+	// jqTransOverflow counts transactions rejected because the TxQ
+	// was full at submission time (telCAN_NOT_QUEUE_FULL). Surfaced
+	// via server_info as jq_trans_overflow. Note rippled's same-named
+	// counter (OverlayImpl::getJqTransOverflow, bumped at
+	// PeerImp.cpp:1353) tracks JobQueue jtTRANSACTION overflow on
+	// inbound TMTransaction processing, not TxQ saturation — goxrpl
+	// has no JobQueue subsystem, so the TxQ-full count is the closest
+	// available analog until that lands.
 	jqTransOverflow atomic.Uint64
 }
 
@@ -68,8 +72,9 @@ type Metrics struct {
 }
 
 // JqTransOverflow returns the cumulative count of transactions rejected
-// because the queue was full (telCAN_NOT_QUEUE_FULL). Mirrors rippled's
-// OverlayImpl::getJqTransOverflow surfaced by server_info.
+// because the TxQ was full (telCAN_NOT_QUEUE_FULL). Surfaced via
+// server_info as jq_trans_overflow; see the jqTransOverflow field doc
+// for the rippled-vs-goxrpl semantic difference.
 func (q *TxQ) JqTransOverflow() uint64 {
 	return q.jqTransOverflow.Load()
 }

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -71,16 +71,12 @@ type Metrics struct {
 	JqTransOverflow       uint64
 }
 
-// JqTransOverflow returns the cumulative count of transactions rejected
-// because the TxQ was full (telCAN_NOT_QUEUE_FULL). Surfaced via
-// server_info as jq_trans_overflow; see the jqTransOverflow field doc
-// for the rippled-vs-goxrpl semantic difference.
+// JqTransOverflow returns the counter surfaced as server_info.jq_trans_overflow.
+// See the jqTransOverflow field doc for the rippled-vs-goxrpl semantic difference.
 func (q *TxQ) JqTransOverflow() uint64 {
 	return q.jqTransOverflow.Load()
 }
 
-// incJqTransOverflow bumps the overflow counter. Called on every
-// telCAN_NOT_QUEUE_FULL rejection in apply.go.
 func (q *TxQ) incJqTransOverflow() {
 	q.jqTransOverflow.Add(1)
 }

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/LeJamon/goXRPLd/internal/tx"
 )
@@ -33,6 +34,12 @@ type TxQ struct {
 	// parentHash is used to pseudo-randomly order transactions with the same fee.
 	// This ensures different validators build similar queues.
 	parentHash [32]byte
+
+	// jqTransOverflow counts transactions rejected because the queue
+	// was full at submission time (telCAN_NOT_QUEUE_FULL). Mirrors
+	// rippled's NetworkOPsImp::getJqTransOverflow surfaced by
+	// server_info as jq_trans_overflow.
+	jqTransOverflow atomic.Uint64
 }
 
 // New creates a new transaction queue with the given configuration.
@@ -57,6 +64,20 @@ type Metrics struct {
 	MinProcessingFeeLevel uint64
 	MedFeeLevel           uint64
 	OpenLedgerFeeLevel    uint64
+	JqTransOverflow       uint64
+}
+
+// JqTransOverflow returns the cumulative count of transactions rejected
+// because the queue was full (telCAN_NOT_QUEUE_FULL). Mirrors rippled's
+// OverlayImpl::getJqTransOverflow surfaced by server_info.
+func (q *TxQ) JqTransOverflow() uint64 {
+	return q.jqTransOverflow.Load()
+}
+
+// incJqTransOverflow bumps the overflow counter. Called on every
+// telCAN_NOT_QUEUE_FULL rejection in apply.go.
+func (q *TxQ) incJqTransOverflow() {
+	q.jqTransOverflow.Add(1)
 }
 
 // GetMetrics returns the current queue metrics.
@@ -81,6 +102,7 @@ func (q *TxQ) GetMetrics(txInLedger uint32) Metrics {
 		MinProcessingFeeLevel: minProcessingFeeLevel,
 		MedFeeLevel:           snapshot.EscalationMultiplier,
 		OpenLedgerFeeLevel:    uint64(openLedgerFeeLevel),
+		JqTransOverflow:       q.jqTransOverflow.Load(),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace hardcoded zeros / 256s in `server_info` and `server_state` with live values pulled from the TxQ, overlay, ledger service, and a new operating-mode state-accounting tracker on the consensus adaptor.
- Add a `jq_trans_overflow` counter to TxQ (incremented on every `telCAN_NOT_QUEUE_FULL` rejection) and surface it through a new `ServiceContainer.TxQMetrics` hook alongside the fee-escalation levels used for `load_factor_fee_escalation/queue/reference`.
- Track peer disconnects on the overlay (with ping-timeout drops reported as the resource-driven counter) and surface `peer_disconnects` / `peer_disconnects_resources` via `ServiceContainer.PeerDisconnects`.
- Extend `LedgerServerInfo` with validated- and closed-ledger close times (ripple-epoch seconds), populated from `service.GetServerInfo`, so the handler can compute `validated_ledger.age` / `closed_ledger.age` and emit non-zero `close_time` fields. Age is clamped to 0 past the 600s threshold rippled uses in `NetworkOPs.cpp:2952`.
- Add an `Adaptor.StateAccounting()` snapshot fed from a new `stateAccounting` tracker that charges elapsed time on every `SetOperatingMode` transition; `state_accounting` JSON now reflects real durations and transition counts per operating mode.

## Test plan
- [ ] `go test ./internal/rpc/... ./internal/txq/... ./internal/peermanagement/... ./internal/ledger/service/... ./internal/consensus/... ./internal/cli/...`
- [ ] New tests in `internal/rpc/server_info_test.go`: `TestServerInfo_DynamicMetrics_FromHooks`, `TestServerInfo_MachineMode_LoadFactorFees`
- [ ] Manual smoke: `curl -X POST :8080/ -d '{"jsonrpc":"2.0","method":"server_info","id":1}'` and confirm `jq_trans_overflow`, `peer_disconnects*`, `validated_ledger.{age,close_time}`, and `state_accounting.*` are populated.

Fixes #480