### PR TITLE
fix(rpc): autofill Sequence/Fee and return metadata in simulate

### DIFF
--- a/internal/ledger/service/svcerr/svcerr.go
+++ b/internal/ledger/service/svcerr/svcerr.go
@@ -54,4 +54,9 @@ var (
 	// ErrInvalidMarker is returned when a paginated query supplies a
 	// marker that does not parse or does not match an existing entry.
 	ErrInvalidMarker = errors.New("invalid marker")
+
+	// ErrHighFee is returned by fee-autofill when the escalated fee exceeds
+	// the autofill ceiling (feeDefault * mult / div). Handlers map this to
+	// rpcHIGH_FEE. Mirrors rippled TransactionSign.cpp getCurrentNetworkFee.
+	ErrHighFee = errors.New("high fee")
 )

--- a/internal/ledger/service/svcerr/svcerr.go
+++ b/internal/ledger/service/svcerr/svcerr.go
@@ -4,7 +4,10 @@
 // dependency on internal/ledger/service.
 package svcerr
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	// ErrAccountNotFound is returned when a queried account does not
@@ -55,8 +58,27 @@ var (
 	// marker that does not parse or does not match an existing entry.
 	ErrInvalidMarker = errors.New("invalid marker")
 
-	// ErrHighFee is returned by fee-autofill when the escalated fee exceeds
-	// the autofill ceiling (feeDefault * mult / div). Handlers map this to
-	// rpcHIGH_FEE. Mirrors rippled TransactionSign.cpp getCurrentNetworkFee.
+	// ErrHighFee is the sentinel matched by errors.Is for any high-fee
+	// failure. The fee-autofill path returns the structured HighFeeError
+	// (which Is-matches this sentinel) so handlers can extract Fee/Limit
+	// directly. Mirrors rippled TransactionSign.cpp getCurrentNetworkFee.
 	ErrHighFee = errors.New("high fee")
 )
+
+// HighFeeError carries the structured payload of a fee-autofill rejection:
+// the computed fee and the autofill ceiling that capped it. The Error()
+// body matches rippled's wire message ("Fee of X exceeds the requested tx
+// limit of Y", TransactionSign.cpp:870-873). errors.Is(err, ErrHighFee)
+// matches via the Is method below.
+type HighFeeError struct {
+	Fee   uint64
+	Limit uint64
+}
+
+func (e *HighFeeError) Error() string {
+	return fmt.Sprintf("Fee of %d exceeds the requested tx limit of %d", e.Fee, e.Limit)
+}
+
+func (e *HighFeeError) Is(target error) bool {
+	return target == ErrHighFee
+}

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -20,8 +20,8 @@ import (
 // Autofill fee ceiling: feeDefault * mult / div. Mirrors rippled
 // Tuning.h:60-61.
 const (
-	defaultAutoFillFeeMultiplier = 10
-	defaultAutoFillFeeDivisor    = 1
+	defaultAutoFillFeeMultiplier uint64 = 10
+	defaultAutoFillFeeDivisor    uint64 = 1
 )
 
 // SubmitResult contains the result of submitting a transaction
@@ -209,16 +209,15 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 //
 // The returned fee is capped at feeDefault * defaultAutoFillFeeMultiplier
 // / defaultAutoFillFeeDivisor; exceeding it yields svcerr.ErrHighFee.
-// rippled applies this ceiling regardless of role. isUnlimited mirrors
-// rippled's isUnlimited() and is reserved for the eventual scaleFeeLoad
-// port; today it has no effect.
+// rippled applies this ceiling regardless of role.
 //
 // scaleFeeLoad (rippled load-fee tracker) has no Go equivalent today and
-// is intentionally omitted — see issue tracker.
+// is intentionally omitted — see issue tracker. When it lands, an
+// isUnlimited parameter should be plumbed back through this signature.
 //
 // Reference: rippled Simulate.cpp getAutofillSequence +
 // TransactionSign.cpp getCurrentNetworkFee / getTxFee.
-func (s *Service) GetAutofill(account string, hasTicketSequence bool, parsedTx tx.Transaction, isUnlimited bool) (sequence uint32, fee uint64, err error) {
+func (s *Service) GetAutofill(account string, hasTicketSequence bool, parsedTx tx.Transaction) (sequence uint32, fee uint64, err error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -272,10 +271,7 @@ func (s *Service) GetAutofill(account string, hasTicketSequence bool, parsedTx t
 	}
 
 	// Ceiling check matches rippled TransactionSign.cpp:864-874 — applied
-	// regardless of role. isUnlimited only governs scaleFeeLoad (not yet
-	// ported), so it is currently unused here; keep the parameter so the
-	// interface stays stable for the eventual load-fee implementation.
-	_ = isUnlimited
+	// regardless of role.
 	ceiling, ok := mulDivU64(feeDefault, defaultAutoFillFeeMultiplier, defaultAutoFillFeeDivisor)
 	if !ok {
 		return 0, 0, fmt.Errorf("%w: fee ceiling overflow", svcerr.ErrHighFee)
@@ -289,7 +285,9 @@ func (s *Service) GetAutofill(account string, hasTicketSequence bool, parsedTx t
 
 // computeBaseFeeForTx mirrors rippled getTxFee → calculateBaseFee dispatch:
 // CustomBaseFeeCalculator wins (AccountDelete, AMMCreate, LedgerStateFix);
-// otherwise multisign multiplier; otherwise the ledger base fee.
+// otherwise the default Transactor::calculateBaseFee applies, which charges
+// one extra baseFee per entry in sfSigners regardless of SigningPubKey
+// (rippled Transactor.cpp:229-245).
 func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.EngineConfig) uint64 {
 	if parsedTx == nil {
 		return cfg.BaseFee
@@ -297,23 +295,23 @@ func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.Eng
 	if feeCalc, ok := parsedTx.(tx.CustomBaseFeeCalculator); ok {
 		return feeCalc.CalculateBaseFee(view, cfg)
 	}
-	if tx.IsMultiSigned(parsedTx) {
-		return tx.CalculateMultiSigFee(cfg.BaseFee, len(parsedTx.GetCommon().Signers))
+	if signerCount := len(parsedTx.GetCommon().Signers); signerCount > 0 {
+		return tx.CalculateMultiSigFee(cfg.BaseFee, signerCount)
 	}
 	return cfg.BaseFee
 }
 
 // mulDivU64 returns (a * b) / c with overflow detection. Returns ok=false
-// when the multiplication overflows uint64 or c is non-positive.
-func mulDivU64(a uint64, b, c int) (uint64, bool) {
-	if b < 0 || c <= 0 {
+// when the multiplication overflows uint64 or c is zero.
+func mulDivU64(a, b, c uint64) (uint64, bool) {
+	if c == 0 {
 		return 0, false
 	}
-	hi, lo := bits.Mul64(a, uint64(b))
+	hi, lo := bits.Mul64(a, b)
 	if hi != 0 {
 		return 0, false
 	}
-	return lo / uint64(c), true
+	return lo / c, true
 }
 
 // EngineConfigForReplay returns the shared (non-per-ledger) engine

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -319,11 +319,21 @@ func (s *Service) GetAutofillSequence(account string, hasTicketSequence bool) (u
 // TransactionSign.cpp:795-796. The cap is 32 by default and 8 only when
 // cfg.Rules is supplied AND ExpandedSignerList is disabled — see
 // maxMultiSigners and rippled STTx.h:55-63.
-func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.EngineConfig) uint64 {
+//
+// CustomBaseFeeCalculator dispatch is wrapped in a recover so a panic
+// reading inconsistent view state cannot escape the autofill path. This
+// mirrors the reference_fee fallback rippled's getTxFee performs on any
+// exception (TransactionSign.cpp:832-835).
+func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.EngineConfig) (fee uint64) {
 	if parsedTx == nil {
 		return cfg.BaseFee
 	}
 	if feeCalc, ok := parsedTx.(tx.CustomBaseFeeCalculator); ok {
+		defer func() {
+			if r := recover(); r != nil {
+				fee = cfg.BaseFee
+			}
+		}()
 		return feeCalc.CalculateBaseFee(view, cfg)
 	}
 	signerCount := len(parsedTx.GetCommon().Signers)

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -301,8 +301,7 @@ func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.Eng
 	return cfg.BaseFee
 }
 
-// mulDivU64 returns (a * b) / c with overflow detection. Returns ok=false
-// when the multiplication overflows uint64 or c is zero.
+// mulDivU64 returns (a * b) / c; ok=false on uint64 overflow or c == 0.
 func mulDivU64(a, b, c uint64) (uint64, bool) {
 	if c == 0 {
 		return 0, false

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/txq"
 	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
@@ -184,6 +185,77 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 	defer s.mu.RUnlock()
 
 	return readFeesFromLedger(s.openLedger)
+}
+
+// GetAutofillSequence returns the next sequence to use for an account when
+// constructing a transaction. When hasTicketSequence is true the account's
+// sequence is irrelevant (the ticket carries it) and 0 is returned; the
+// account is still allowed to be missing in that case.
+//
+// Reference: rippled Simulate.cpp getAutofillSequence — reads the account SLE
+// from the current open ledger and asks the TxQ for the next-queueable seq.
+func (s *Service) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.openLedger == nil {
+		return 0, ErrNoOpenLedger
+	}
+
+	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, err)
+	}
+	var accountID [20]byte
+	copy(accountID[:], accountIDBytes)
+
+	data, readErr := s.openLedger.Read(keylet.Account(accountID))
+	if readErr != nil || data == nil {
+		if hasTicketSequence {
+			return 0, nil
+		}
+		return 0, svcerr.ErrAccountNotFound
+	}
+
+	if hasTicketSequence {
+		return 0, nil
+	}
+
+	acct, parseErr := state.ParseAccountRoot(data)
+	if parseErr != nil {
+		return 0, fmt.Errorf("parse account root: %w", parseErr)
+	}
+
+	if s.txQueue != nil {
+		return s.txQueue.NextQueuableSeq(accountID, acct.Sequence), nil
+	}
+	return acct.Sequence, nil
+}
+
+// GetCurrentNetworkFee returns the fee (in drops) a transaction should pay
+// to bypass the TxQ and enter the current open ledger. Falls back to the
+// base fee when the network is uncongested or no TxQ is configured.
+//
+// Reference: rippled getCurrentNetworkFee() in TransactionSign.cpp:
+//
+//	escalatedFee = toDrops(openLedgerFeeLevel - 1, baseFee) + 1
+//
+// Per-transaction-type adjustments (multisign, AccountDelete) are not applied;
+// callers that need exact rippled parity should set Fee explicitly.
+func (s *Service) GetCurrentNetworkFee() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	baseFee, _, _ := readFeesFromLedger(s.openLedger)
+	if s.txQueue == nil || s.openLedger == nil {
+		return baseFee
+	}
+	txInLedger := s.openLedger.TxCount()
+	feeLevel := s.txQueue.GetRequiredFeeLevel(txInLedger)
+	if uint64(feeLevel) <= txq.BaseLevel {
+		return baseFee
+	}
+	return txq.FeeLevel(uint64(feeLevel)-1).ToDrops(baseFee) + 1
 }
 
 // EngineConfigForReplay returns the shared (non-per-ledger) engine

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -17,8 +17,8 @@ import (
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
 )
 
-// Rippled autofill ceiling defaults — Tuning.h: a tx's fee is capped at
-// feeDefault * 10 / 1 unless the role is unlimited.
+// Autofill fee ceiling: feeDefault * mult / div. Mirrors rippled
+// Tuning.h:60-61.
 const (
 	defaultAutoFillFeeMultiplier = 10
 	defaultAutoFillFeeDivisor    = 1

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -195,19 +195,9 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 	return readFeesFromLedger(s.openLedger)
 }
 
-// GetAutofill returns the Sequence (0 when hasTicketSequence is true or
-// needSequence is false) and Fee (drops) a transaction should carry to
-// bypass the TxQ and enter the current open ledger. Both values are read
-// under a single RLock so they observe a consistent ledger snapshot.
-//
-// When needSequence is false the source-account lookup is skipped — Fee
-// computation in rippled (TransactionSign.cpp:849, getTxFee) never reads
-// the account either, so a caller that already supplies Sequence must
-// not get rpcSRC_ACT_NOT_FOUND from this path. Callers are responsible
-// for ensuring the supplied Account is well-formed; the simulate handler
-// validates it up front.
-//
-// Fee dispatch follows rippled TransactionSign.cpp getCurrentNetworkFee:
+// GetAutofillFee returns the Fee (drops) a transaction should carry to
+// bypass the TxQ and enter the current open ledger. Mirrors rippled
+// TransactionSign.cpp getCurrentNetworkFee:
 //
 //   - feeDefault = per-tx-type base fee (multisign multiplier, AccountDelete's
 //     reserve increment, AMMCreate's increment, LedgerStateFix's increment)
@@ -215,45 +205,24 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 //   - returned fee = max(feeDefault, escalatedFee)
 //
 // The returned fee is capped at feeDefault * defaultAutoFillFeeMultiplier
-// / defaultAutoFillFeeDivisor; exceeding it yields svcerr.ErrHighFee.
-// rippled applies this ceiling regardless of role.
+// / defaultAutoFillFeeDivisor; exceeding it yields *svcerr.HighFeeError
+// (which errors.Is(svcerr.ErrHighFee) also matches). rippled applies the
+// ceiling regardless of role.
+//
+// The source account is never read — matches rippled's getTxFee
+// (TransactionSign.cpp:765-836), so callers that have already supplied
+// Sequence must not receive an account-related error from this path.
 //
 // scaleFeeLoad (rippled's load-fee tracker) and the isUnlimited(role)
 // exemption have no Go equivalent and are intentionally omitted: goXRPL
 // never inflates fees for cluster load, and admin/identified callers
 // are not exempt from the ceiling check.
-func (s *Service) GetAutofill(account string, needSequence, hasTicketSequence bool, parsedTx tx.Transaction) (sequence uint32, fee uint64, err error) {
+func (s *Service) GetAutofillFee(parsedTx tx.Transaction) (uint64, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	if s.openLedger == nil {
-		return 0, 0, ErrNoOpenLedger
-	}
-
-	if needSequence {
-		_, accountIDBytes, decodeErr := addresscodec.DecodeClassicAddressToAccountID(account)
-		if decodeErr != nil {
-			return 0, 0, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, decodeErr)
-		}
-		var accountID [20]byte
-		copy(accountID[:], accountIDBytes)
-
-		data, readErr := s.openLedger.Read(keylet.Account(accountID))
-		if readErr != nil || data == nil {
-			if !hasTicketSequence {
-				return 0, 0, svcerr.ErrAccountNotFound
-			}
-		} else if !hasTicketSequence {
-			acct, parseErr := state.ParseAccountRoot(data)
-			if parseErr != nil {
-				return 0, 0, fmt.Errorf("parse account root: %w", parseErr)
-			}
-			if s.txQueue != nil {
-				sequence = s.txQueue.NextQueuableSeq(accountID, acct.Sequence)
-			} else {
-				sequence = acct.Sequence
-			}
-		}
+		return 0, ErrNoOpenLedger
 	}
 
 	baseFee, reserveBase, reserveIncrement := readFeesFromLedger(s.openLedger)
@@ -266,7 +235,7 @@ func (s *Service) GetAutofill(account string, needSequence, hasTicketSequence bo
 	}
 
 	feeDefault := computeBaseFeeForTx(s.openLedger, parsedTx, feeCfg)
-	fee = feeDefault
+	fee := feeDefault
 	if s.txQueue != nil {
 		feeLevel := s.txQueue.GetRequiredFeeLevel(s.openLedger.TxCount())
 		if uint64(feeLevel) > txq.BaseLevel {
@@ -277,17 +246,65 @@ func (s *Service) GetAutofill(account string, needSequence, hasTicketSequence bo
 		}
 	}
 
-	// Ceiling check matches rippled TransactionSign.cpp:864-874 — applied
-	// regardless of role.
 	ceiling, ok := mulDivU64(feeDefault, defaultAutoFillFeeMultiplier, defaultAutoFillFeeDivisor)
 	if !ok {
-		return 0, 0, fmt.Errorf("%w: fee ceiling overflow", svcerr.ErrHighFee)
+		return 0, fmt.Errorf("autofill fee: ceiling overflow (feeDefault=%d)", feeDefault)
 	}
 	if fee > ceiling {
-		return 0, 0, fmt.Errorf("%w: Fee of %d exceeds the requested tx limit of %d", svcerr.ErrHighFee, fee, ceiling)
+		return 0, &svcerr.HighFeeError{Fee: fee, Limit: ceiling}
 	}
 
-	return sequence, fee, nil
+	return fee, nil
+}
+
+// GetAutofillSequence returns the Sequence a transaction should carry,
+// reading the source account under the service RLock so it observes a
+// consistent open-ledger snapshot. Mirrors rippled getAutofillSequence
+// (Simulate.cpp:37-69):
+//
+//   - hasTicketSequence true → returns 0 unconditionally; missing account
+//     does not error (the ticket itself supplies the sequence)
+//   - otherwise reads the account SLE and consults TxQ.NextQueuableSeq so
+//     the returned sequence accounts for already-queued transactions
+//
+// Returns svcerr.ErrAccountMalformed if the address fails to decode and
+// svcerr.ErrAccountNotFound when the account is absent and no ticket
+// supersedes the requirement.
+func (s *Service) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.openLedger == nil {
+		return 0, ErrNoOpenLedger
+	}
+
+	_, accountIDBytes, decodeErr := addresscodec.DecodeClassicAddressToAccountID(account)
+	if decodeErr != nil {
+		return 0, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, decodeErr)
+	}
+	var accountID [20]byte
+	copy(accountID[:], accountIDBytes)
+
+	data, readErr := s.openLedger.Read(keylet.Account(accountID))
+	if readErr != nil || data == nil {
+		if hasTicketSequence {
+			return 0, nil
+		}
+		return 0, svcerr.ErrAccountNotFound
+	}
+
+	if hasTicketSequence {
+		return 0, nil
+	}
+
+	acct, parseErr := state.ParseAccountRoot(data)
+	if parseErr != nil {
+		return 0, fmt.Errorf("parse account root: %w", parseErr)
+	}
+	if s.txQueue != nil {
+		return s.txQueue.NextQueuableSeq(accountID, acct.Sequence), nil
+	}
+	return acct.Sequence, nil
 }
 
 // computeBaseFeeForTx mirrors rippled getTxFee → calculateBaseFee dispatch:

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/bits"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
@@ -14,6 +15,13 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/txq"
 	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+// Rippled autofill ceiling defaults — Tuning.h: a tx's fee is capped at
+// feeDefault * 10 / 1 unless the role is unlimited.
+const (
+	defaultAutoFillFeeMultiplier = 10
+	defaultAutoFillFeeDivisor    = 1
 )
 
 // SubmitResult contains the result of submitting a transaction
@@ -187,75 +195,121 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 	return readFeesFromLedger(s.openLedger)
 }
 
-// GetAutofillSequence returns the next sequence to use for an account when
-// constructing a transaction. When hasTicketSequence is true the account's
-// sequence is irrelevant (the ticket carries it) and 0 is returned; the
-// account is still allowed to be missing in that case.
+// GetAutofill returns the Sequence (0 when hasTicketSequence is true) and
+// Fee (drops) a transaction should carry to bypass the TxQ and enter the
+// current open ledger. Both values are read under a single RLock so they
+// observe a consistent ledger snapshot.
 //
-// Reference: rippled Simulate.cpp getAutofillSequence — reads the account SLE
-// from the current open ledger and asks the TxQ for the next-queueable seq.
-func (s *Service) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+// Fee dispatch follows rippled TransactionSign.cpp getCurrentNetworkFee:
+//
+//   - feeDefault = per-tx-type base fee (multisign multiplier, AccountDelete's
+//     reserve increment, AMMCreate's increment, LedgerStateFix's increment)
+//   - escalatedFee = toDrops(openLedgerFeeLevel-1, baseFee) + 1 (TxQ load)
+//   - returned fee = max(feeDefault, escalatedFee)
+//
+// When isUnlimited is false, the returned fee is capped at feeDefault *
+// defaultAutoFillFeeMultiplier / defaultAutoFillFeeDivisor; exceeding it
+// yields svcerr.ErrHighFee. isUnlimited mirrors rippled's isUnlimited()
+// (admin / identified roles).
+//
+// scaleFeeLoad (rippled load-fee tracker) has no Go equivalent today and
+// is intentionally omitted.
+//
+// Reference: rippled Simulate.cpp getAutofillSequence +
+// TransactionSign.cpp getCurrentNetworkFee / getTxFee.
+func (s *Service) GetAutofill(account string, hasTicketSequence bool, parsedTx tx.Transaction, isUnlimited bool) (sequence uint32, fee uint64, err error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	if s.openLedger == nil {
-		return 0, ErrNoOpenLedger
+		return 0, 0, ErrNoOpenLedger
 	}
 
-	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
-	if err != nil {
-		return 0, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, err)
+	_, accountIDBytes, decodeErr := addresscodec.DecodeClassicAddressToAccountID(account)
+	if decodeErr != nil {
+		return 0, 0, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, decodeErr)
 	}
 	var accountID [20]byte
 	copy(accountID[:], accountIDBytes)
 
 	data, readErr := s.openLedger.Read(keylet.Account(accountID))
 	if readErr != nil || data == nil {
-		if hasTicketSequence {
-			return 0, nil
+		if !hasTicketSequence {
+			return 0, 0, svcerr.ErrAccountNotFound
 		}
-		return 0, svcerr.ErrAccountNotFound
+	} else if !hasTicketSequence {
+		acct, parseErr := state.ParseAccountRoot(data)
+		if parseErr != nil {
+			return 0, 0, fmt.Errorf("parse account root: %w", parseErr)
+		}
+		if s.txQueue != nil {
+			sequence = s.txQueue.NextQueuableSeq(accountID, acct.Sequence)
+		} else {
+			sequence = acct.Sequence
+		}
 	}
 
-	if hasTicketSequence {
-		return 0, nil
+	baseFee, reserveBase, reserveIncrement := readFeesFromLedger(s.openLedger)
+	feeCfg := tx.EngineConfig{
+		BaseFee:          baseFee,
+		ReserveBase:      reserveBase,
+		ReserveIncrement: reserveIncrement,
+		NetworkID:        s.config.NetworkID,
+		Rules:            rulesFromLedger(s.closedLedger, s.logger),
 	}
 
-	acct, parseErr := state.ParseAccountRoot(data)
-	if parseErr != nil {
-		return 0, fmt.Errorf("parse account root: %w", parseErr)
-	}
-
+	feeDefault := computeBaseFeeForTx(s.openLedger, parsedTx, feeCfg)
+	fee = feeDefault
 	if s.txQueue != nil {
-		return s.txQueue.NextQueuableSeq(accountID, acct.Sequence), nil
+		feeLevel := s.txQueue.GetRequiredFeeLevel(s.openLedger.TxCount())
+		if uint64(feeLevel) > txq.BaseLevel {
+			escalated := txq.FeeLevel(uint64(feeLevel)-1).ToDrops(baseFee) + 1
+			if escalated > fee {
+				fee = escalated
+			}
+		}
 	}
-	return acct.Sequence, nil
+
+	if !isUnlimited {
+		ceiling, ok := mulDivU64(feeDefault, defaultAutoFillFeeMultiplier, defaultAutoFillFeeDivisor)
+		if !ok {
+			return 0, 0, fmt.Errorf("%w: fee ceiling overflow", svcerr.ErrHighFee)
+		}
+		if fee > ceiling {
+			return 0, 0, fmt.Errorf("%w: Fee of %d exceeds the requested tx limit of %d", svcerr.ErrHighFee, fee, ceiling)
+		}
+	}
+
+	return sequence, fee, nil
 }
 
-// GetCurrentNetworkFee returns the fee (in drops) a transaction should pay
-// to bypass the TxQ and enter the current open ledger. Falls back to the
-// base fee when the network is uncongested or no TxQ is configured.
-//
-// Reference: rippled getCurrentNetworkFee() in TransactionSign.cpp:
-//
-//	escalatedFee = toDrops(openLedgerFeeLevel - 1, baseFee) + 1
-//
-// Per-transaction-type adjustments (multisign, AccountDelete) are not applied;
-// callers that need exact rippled parity should set Fee explicitly.
-func (s *Service) GetCurrentNetworkFee() uint64 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+// computeBaseFeeForTx mirrors rippled getTxFee → calculateBaseFee dispatch:
+// CustomBaseFeeCalculator wins (AccountDelete, AMMCreate, LedgerStateFix);
+// otherwise multisign multiplier; otherwise the ledger base fee.
+func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.EngineConfig) uint64 {
+	if parsedTx == nil {
+		return cfg.BaseFee
+	}
+	if feeCalc, ok := parsedTx.(tx.CustomBaseFeeCalculator); ok {
+		return feeCalc.CalculateBaseFee(view, cfg)
+	}
+	if tx.IsMultiSigned(parsedTx) {
+		return tx.CalculateMultiSigFee(cfg.BaseFee, len(parsedTx.GetCommon().Signers))
+	}
+	return cfg.BaseFee
+}
 
-	baseFee, _, _ := readFeesFromLedger(s.openLedger)
-	if s.txQueue == nil || s.openLedger == nil {
-		return baseFee
+// mulDivU64 returns (a * b) / c with overflow detection. Returns ok=false
+// when the multiplication overflows uint64 or c is non-positive.
+func mulDivU64(a uint64, b, c int) (uint64, bool) {
+	if b < 0 || c <= 0 {
+		return 0, false
 	}
-	txInLedger := s.openLedger.TxCount()
-	feeLevel := s.txQueue.GetRequiredFeeLevel(txInLedger)
-	if uint64(feeLevel) <= txq.BaseLevel {
-		return baseFee
+	hi, lo := bits.Mul64(a, uint64(b))
+	if hi != 0 {
+		return 0, false
 	}
-	return txq.FeeLevel(uint64(feeLevel)-1).ToDrops(baseFee) + 1
+	return lo / uint64(c), true
 }
 
 // EngineConfigForReplay returns the shared (non-per-ledger) engine

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -207,13 +207,14 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 //   - escalatedFee = toDrops(openLedgerFeeLevel-1, baseFee) + 1 (TxQ load)
 //   - returned fee = max(feeDefault, escalatedFee)
 //
-// When isUnlimited is false, the returned fee is capped at feeDefault *
-// defaultAutoFillFeeMultiplier / defaultAutoFillFeeDivisor; exceeding it
-// yields svcerr.ErrHighFee. isUnlimited mirrors rippled's isUnlimited()
-// (admin / identified roles).
+// The returned fee is capped at feeDefault * defaultAutoFillFeeMultiplier
+// / defaultAutoFillFeeDivisor; exceeding it yields svcerr.ErrHighFee.
+// rippled applies this ceiling regardless of role. isUnlimited mirrors
+// rippled's isUnlimited() and is reserved for the eventual scaleFeeLoad
+// port; today it has no effect.
 //
 // scaleFeeLoad (rippled load-fee tracker) has no Go equivalent today and
-// is intentionally omitted.
+// is intentionally omitted — see issue tracker.
 //
 // Reference: rippled Simulate.cpp getAutofillSequence +
 // TransactionSign.cpp getCurrentNetworkFee / getTxFee.
@@ -270,14 +271,17 @@ func (s *Service) GetAutofill(account string, hasTicketSequence bool, parsedTx t
 		}
 	}
 
-	if !isUnlimited {
-		ceiling, ok := mulDivU64(feeDefault, defaultAutoFillFeeMultiplier, defaultAutoFillFeeDivisor)
-		if !ok {
-			return 0, 0, fmt.Errorf("%w: fee ceiling overflow", svcerr.ErrHighFee)
-		}
-		if fee > ceiling {
-			return 0, 0, fmt.Errorf("%w: Fee of %d exceeds the requested tx limit of %d", svcerr.ErrHighFee, fee, ceiling)
-		}
+	// Ceiling check matches rippled TransactionSign.cpp:864-874 — applied
+	// regardless of role. isUnlimited only governs scaleFeeLoad (not yet
+	// ported), so it is currently unused here; keep the parameter so the
+	// interface stays stable for the eventual load-fee implementation.
+	_ = isUnlimited
+	ceiling, ok := mulDivU64(feeDefault, defaultAutoFillFeeMultiplier, defaultAutoFillFeeDivisor)
+	if !ok {
+		return 0, 0, fmt.Errorf("%w: fee ceiling overflow", svcerr.ErrHighFee)
+	}
+	if fee > ceiling {
+		return 0, 0, fmt.Errorf("%w: Fee of %d exceeds the requested tx limit of %d", svcerr.ErrHighFee, fee, ceiling)
 	}
 
 	return sequence, fee, nil

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -195,10 +195,17 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 	return readFeesFromLedger(s.openLedger)
 }
 
-// GetAutofill returns the Sequence (0 when hasTicketSequence is true) and
-// Fee (drops) a transaction should carry to bypass the TxQ and enter the
-// current open ledger. Both values are read under a single RLock so they
-// observe a consistent ledger snapshot.
+// GetAutofill returns the Sequence (0 when hasTicketSequence is true or
+// needSequence is false) and Fee (drops) a transaction should carry to
+// bypass the TxQ and enter the current open ledger. Both values are read
+// under a single RLock so they observe a consistent ledger snapshot.
+//
+// When needSequence is false the source-account lookup is skipped — Fee
+// computation in rippled (TransactionSign.cpp:849, getTxFee) never reads
+// the account either, so a caller that already supplies Sequence must
+// not get rpcSRC_ACT_NOT_FOUND from this path. Callers are responsible
+// for ensuring the supplied Account is well-formed; the simulate handler
+// validates it up front.
 //
 // Fee dispatch follows rippled TransactionSign.cpp getCurrentNetworkFee:
 //
@@ -211,13 +218,11 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 // / defaultAutoFillFeeDivisor; exceeding it yields svcerr.ErrHighFee.
 // rippled applies this ceiling regardless of role.
 //
-// scaleFeeLoad (rippled load-fee tracker) has no Go equivalent today and
-// is intentionally omitted — see issue tracker. When it lands, an
-// isUnlimited parameter should be plumbed back through this signature.
-//
-// Reference: rippled Simulate.cpp getAutofillSequence +
-// TransactionSign.cpp getCurrentNetworkFee / getTxFee.
-func (s *Service) GetAutofill(account string, hasTicketSequence bool, parsedTx tx.Transaction) (sequence uint32, fee uint64, err error) {
+// scaleFeeLoad (rippled's load-fee tracker) and the isUnlimited(role)
+// exemption have no Go equivalent and are intentionally omitted: goXRPL
+// never inflates fees for cluster load, and admin/identified callers
+// are not exempt from the ceiling check.
+func (s *Service) GetAutofill(account string, needSequence, hasTicketSequence bool, parsedTx tx.Transaction) (sequence uint32, fee uint64, err error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -225,27 +230,29 @@ func (s *Service) GetAutofill(account string, hasTicketSequence bool, parsedTx t
 		return 0, 0, ErrNoOpenLedger
 	}
 
-	_, accountIDBytes, decodeErr := addresscodec.DecodeClassicAddressToAccountID(account)
-	if decodeErr != nil {
-		return 0, 0, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, decodeErr)
-	}
-	var accountID [20]byte
-	copy(accountID[:], accountIDBytes)
+	if needSequence {
+		_, accountIDBytes, decodeErr := addresscodec.DecodeClassicAddressToAccountID(account)
+		if decodeErr != nil {
+			return 0, 0, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, decodeErr)
+		}
+		var accountID [20]byte
+		copy(accountID[:], accountIDBytes)
 
-	data, readErr := s.openLedger.Read(keylet.Account(accountID))
-	if readErr != nil || data == nil {
-		if !hasTicketSequence {
-			return 0, 0, svcerr.ErrAccountNotFound
-		}
-	} else if !hasTicketSequence {
-		acct, parseErr := state.ParseAccountRoot(data)
-		if parseErr != nil {
-			return 0, 0, fmt.Errorf("parse account root: %w", parseErr)
-		}
-		if s.txQueue != nil {
-			sequence = s.txQueue.NextQueuableSeq(accountID, acct.Sequence)
-		} else {
-			sequence = acct.Sequence
+		data, readErr := s.openLedger.Read(keylet.Account(accountID))
+		if readErr != nil || data == nil {
+			if !hasTicketSequence {
+				return 0, 0, svcerr.ErrAccountNotFound
+			}
+		} else if !hasTicketSequence {
+			acct, parseErr := state.ParseAccountRoot(data)
+			if parseErr != nil {
+				return 0, 0, fmt.Errorf("parse account root: %w", parseErr)
+			}
+			if s.txQueue != nil {
+				sequence = s.txQueue.NextQueuableSeq(accountID, acct.Sequence)
+			} else {
+				sequence = acct.Sequence
+			}
 		}
 	}
 
@@ -288,6 +295,11 @@ func (s *Service) GetAutofill(account string, hasTicketSequence bool, parsedTx t
 // otherwise the default Transactor::calculateBaseFee applies, which charges
 // one extra baseFee per entry in sfSigners regardless of SigningPubKey
 // (rippled Transactor.cpp:229-245).
+//
+// Unlike rippled's getTxFee, which falls back to reference_fee on a
+// malformed Signers array (TransactionSign.cpp:792-815), this path
+// assumes the caller has already structurally validated Signers — the
+// simulate handler runs normalizeSigners before invoking GetAutofill.
 func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.EngineConfig) uint64 {
 	if parsedTx == nil {
 		return cfg.BaseFee

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -314,9 +314,11 @@ func (s *Service) GetAutofillSequence(account string, hasTicketSequence bool) (u
 // one extra baseFee per entry in sfSigners regardless of SigningPubKey
 // (rippled Transactor.cpp:229-245).
 //
-// Signer counts above STTx::maxMultiSigners (8 pre-ExpandedSignerList, 32
-// after) fall back to baseFee, mirroring rippled's reference_fee fallback
-// at TransactionSign.cpp:795-796.
+// Signer counts above STTx::maxMultiSigners fall back to baseFee,
+// mirroring rippled's reference_fee fallback at
+// TransactionSign.cpp:795-796. The cap is 32 by default and 8 only when
+// cfg.Rules is supplied AND ExpandedSignerList is disabled — see
+// maxMultiSigners and rippled STTx.h:55-63.
 func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.EngineConfig) uint64 {
 	if parsedTx == nil {
 		return cfg.BaseFee
@@ -334,11 +336,14 @@ func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.Eng
 	return tx.CalculateMultiSigFee(cfg.BaseFee, signerCount)
 }
 
-// maxMultiSigners mirrors rippled STTx::maxMultiSigners (STTx.h:57-63):
-// 8 when ExpandedSignerList is disabled or rules are unavailable, 32
-// when enabled.
+// maxMultiSigners mirrors rippled STTx::maxMultiSigners (STTx.h:55-63).
+// rippled's contract is: "if rules are not supplied then the largest
+// possible value is returned" — i.e. be permissive on nil so callers
+// can't accidentally reject otherwise-valid signer arrays. Only when
+// rules are supplied AND ExpandedSignerList is disabled does the cap
+// fall to 8.
 func maxMultiSigners(rules *amendment.Rules) int {
-	if rules == nil || !rules.ExpandedSignerListEnabled() {
+	if rules != nil && !rules.ExpandedSignerListEnabled() {
 		return 8
 	}
 	return 32

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/bits"
 
+	"github.com/LeJamon/goXRPLd/amendment"
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/openledger"
@@ -313,10 +314,9 @@ func (s *Service) GetAutofillSequence(account string, hasTicketSequence bool) (u
 // one extra baseFee per entry in sfSigners regardless of SigningPubKey
 // (rippled Transactor.cpp:229-245).
 //
-// Unlike rippled's getTxFee, which falls back to reference_fee on a
-// malformed Signers array (TransactionSign.cpp:792-815), this path
-// assumes the caller has already structurally validated Signers — the
-// simulate handler runs normalizeSigners before invoking GetAutofill.
+// Signer counts above STTx::maxMultiSigners (8 pre-ExpandedSignerList, 32
+// after) fall back to baseFee, mirroring rippled's reference_fee fallback
+// at TransactionSign.cpp:795-796.
 func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.EngineConfig) uint64 {
 	if parsedTx == nil {
 		return cfg.BaseFee
@@ -324,10 +324,24 @@ func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.Eng
 	if feeCalc, ok := parsedTx.(tx.CustomBaseFeeCalculator); ok {
 		return feeCalc.CalculateBaseFee(view, cfg)
 	}
-	if signerCount := len(parsedTx.GetCommon().Signers); signerCount > 0 {
-		return tx.CalculateMultiSigFee(cfg.BaseFee, signerCount)
+	signerCount := len(parsedTx.GetCommon().Signers)
+	if signerCount == 0 {
+		return cfg.BaseFee
 	}
-	return cfg.BaseFee
+	if signerCount > maxMultiSigners(cfg.Rules) {
+		return cfg.BaseFee
+	}
+	return tx.CalculateMultiSigFee(cfg.BaseFee, signerCount)
+}
+
+// maxMultiSigners mirrors rippled STTx::maxMultiSigners (STTx.h:57-63):
+// 8 when ExpandedSignerList is disabled or rules are unavailable, 32
+// when enabled.
+func maxMultiSigners(rules *amendment.Rules) int {
+	if rules == nil || !rules.ExpandedSignerListEnabled() {
+		return 8
+	}
+	return 32
 }
 
 // mulDivU64 returns (a * b) / c; ok=false on uint64 overflow or c == 0.

--- a/internal/ledger/service/tx_query_test.go
+++ b/internal/ledger/service/tx_query_test.go
@@ -1,8 +1,10 @@
 package service
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,6 +75,82 @@ func TestComputeBaseFeeForTx_Multisign(t *testing.T) {
 	t.Run("nil parsedTx falls back to baseFee", func(t *testing.T) {
 		assert.Equal(t, uint64(10), computeBaseFeeForTx(nil, nil, cfg))
 	})
+}
+
+// TestComputeBaseFeeForTx_MaxMultiSigners verifies the rippled-faithful
+// fallback to baseFee when the supplied Signers count exceeds
+// STTx::maxMultiSigners (rippled TransactionSign.cpp:795-796 +
+// STTx.h:57-63): 8 pre-ExpandedSignerList, 32 after.
+func TestComputeBaseFeeForTx_MaxMultiSigners(t *testing.T) {
+	rulesDisabled := amendment.NewRules(nil)
+	rulesEnabled := amendment.NewRules([][32]byte{amendment.FeatureExpandedSignerList})
+
+	t.Run("maxMultiSigners returns 8 when ExpandedSignerList is disabled", func(t *testing.T) {
+		assert.Equal(t, 8, maxMultiSigners(rulesDisabled))
+	})
+
+	t.Run("maxMultiSigners returns 8 when Rules is nil", func(t *testing.T) {
+		assert.Equal(t, 8, maxMultiSigners(nil))
+	})
+
+	t.Run("maxMultiSigners returns 32 when ExpandedSignerList is enabled", func(t *testing.T) {
+		assert.Equal(t, 32, maxMultiSigners(rulesEnabled))
+	})
+
+	t.Run("9 signers with ExpandedSignerList disabled falls back to baseFee", func(t *testing.T) {
+		cfg := tx.EngineConfig{BaseFee: 10, Rules: rulesDisabled}
+
+		parsed, err := tx.ParseJSON([]byte(buildSignersTxJSON(9)))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(10), computeBaseFeeForTx(nil, parsed, cfg),
+			"9 signers > maxMultiSigners(8) → reference_fee fallback per rippled TransactionSign.cpp:795")
+	})
+
+	t.Run("8 signers with ExpandedSignerList disabled charges multisign fee", func(t *testing.T) {
+		cfg := tx.EngineConfig{BaseFee: 10, Rules: rulesDisabled}
+
+		parsed, err := tx.ParseJSON([]byte(buildSignersTxJSON(8)))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(90), computeBaseFeeForTx(nil, parsed, cfg),
+			"baseFee * (1 + 8) = 90")
+	})
+
+	t.Run("9 signers with ExpandedSignerList enabled charges multisign fee", func(t *testing.T) {
+		cfg := tx.EngineConfig{BaseFee: 10, Rules: rulesEnabled}
+
+		parsed, err := tx.ParseJSON([]byte(buildSignersTxJSON(9)))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(100), computeBaseFeeForTx(nil, parsed, cfg),
+			"9 ≤ maxMultiSigners(32) → baseFee * (1 + 9) = 100")
+	})
+}
+
+// buildSignersTxJSON returns a tx_json AccountSet with `count` synthetic
+// signer entries. The signer accounts are not unique but ParseJSON does
+// not enforce uniqueness — only structural shape matters for the
+// computeBaseFeeForTx path under test.
+func buildSignersTxJSON(count int) string {
+	signerAccounts := []string{
+		"rPmsLuwgD3yp6mvCXyz44itC9V2qZpDvm6",
+		"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"rB5Ux4Lv2nRx6eeoAAsZmtctnBQ2LiACnk",
+		"rNK7QSVHWvUuQzM7yJjJQbqGD1FpwjsiwL",
+		"rUbPiEXkPHaPa3ECVAJBmYW6cTNkBzjJsB",
+		"rGTQRcXdiBSCDuovpsFh5AssaiVbGM3JCG",
+		"rwhMTPF8d6sLahMcjknKjHxBgrkRgaeoNS",
+		"rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+	}
+	entries := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		acct := signerAccounts[i%len(signerAccounts)]
+		entries = append(entries, `{"Signer":{"Account":"`+acct+`","SigningPubKey":"","TxnSignature":""}}`)
+	}
+	return `{
+		"TransactionType":"AccountSet",
+		"Account":"rEFNJWaJN6JYW9zXxFq1KqtaqgsMcLs9wK",
+		"Signers":[` + strings.Join(entries, ",") + `]
+	}`
 }
 
 func TestMulDivU64(t *testing.T) {

--- a/internal/ledger/service/tx_query_test.go
+++ b/internal/ledger/service/tx_query_test.go
@@ -168,6 +168,32 @@ func buildSignersTxJSON(count int) string {
 	}`
 }
 
+// panickingCustomFeeTx is a minimal tx.Transaction that implements
+// CustomBaseFeeCalculator and panics inside CalculateBaseFee, used to
+// verify computeBaseFeeForTx falls back to cfg.BaseFee on panic — the
+// Go-side equivalent of rippled getTxFee's reference_fee fallback on
+// any exception (TransactionSign.cpp:832-835).
+type panickingCustomFeeTx struct{}
+
+func (panickingCustomFeeTx) TxType() tx.Type                  { return tx.Type(0) }
+func (panickingCustomFeeTx) GetCommon() *tx.Common            { return &tx.Common{} }
+func (panickingCustomFeeTx) Validate() error                  { return nil }
+func (panickingCustomFeeTx) Flatten() (map[string]any, error) { return nil, nil }
+func (panickingCustomFeeTx) GetRawBytes() []byte              { return nil }
+func (panickingCustomFeeTx) SetRawBytes([]byte)               {}
+func (panickingCustomFeeTx) RequiredAmendments() [][32]byte   { return nil }
+func (panickingCustomFeeTx) CalculateBaseFee(_ tx.LedgerView, _ tx.EngineConfig) uint64 {
+	panic("simulated inconsistent view state")
+}
+
+func TestComputeBaseFeeForTx_CustomCalculatorPanicFallsBack(t *testing.T) {
+	cfg := tx.EngineConfig{BaseFee: 42}
+	got := computeBaseFeeForTx(nil, panickingCustomFeeTx{}, cfg)
+	assert.Equal(t, uint64(42), got,
+		"CustomBaseFeeCalculator panic must fall back to cfg.BaseFee — "+
+			"mirrors rippled getTxFee reference_fee fallback (TransactionSign.cpp:832-835)")
+}
+
 func TestMulDivU64(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		got, ok := mulDivU64(10, 3, 2)

--- a/internal/ledger/service/tx_query_test.go
+++ b/internal/ledger/service/tx_query_test.go
@@ -38,10 +38,15 @@ func TestComputeBaseFeeForTx_Multisign(t *testing.T) {
 	})
 
 	t.Run("one signer with non-empty SigningPubKey still gets multisign fee", func(t *testing.T) {
+		// 33-byte compressed secp256k1 pubkey shape (66 hex chars). The value
+		// itself is synthetic; the dispatch under test only counts sfSigners
+		// (rippled Transactor.cpp:229-245), but a well-shaped pubkey keeps
+		// this case robust against future parser tightening.
+		const signingPubKey = "03ABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAB"
 		parsed, err := tx.ParseJSON([]byte(`{
 			"TransactionType":"AccountSet",
 			"Account":"rEFNJWaJN6JYW9zXxFq1KqtaqgsMcLs9wK",
-			"SigningPubKey":"03ABCDEF",
+			"SigningPubKey":"` + signingPubKey + `",
 			"Signers":[
 				{"Signer":{"Account":"rPmsLuwgD3yp6mvCXyz44itC9V2qZpDvm6","SigningPubKey":"","TxnSignature":""}}
 			]

--- a/internal/ledger/service/tx_query_test.go
+++ b/internal/ledger/service/tx_query_test.go
@@ -80,7 +80,9 @@ func TestComputeBaseFeeForTx_Multisign(t *testing.T) {
 // TestComputeBaseFeeForTx_MaxMultiSigners verifies the rippled-faithful
 // fallback to baseFee when the supplied Signers count exceeds
 // STTx::maxMultiSigners (rippled TransactionSign.cpp:795-796 +
-// STTx.h:57-63): 8 pre-ExpandedSignerList, 32 after.
+// STTx.h:55-63): 8 when ExpandedSignerList is supplied AND disabled,
+// 32 otherwise (including when Rules is nil — rippled's permissive
+// default).
 func TestComputeBaseFeeForTx_MaxMultiSigners(t *testing.T) {
 	rulesDisabled := amendment.NewRules(nil)
 	rulesEnabled := amendment.NewRules([][32]byte{amendment.FeatureExpandedSignerList})
@@ -89,8 +91,10 @@ func TestComputeBaseFeeForTx_MaxMultiSigners(t *testing.T) {
 		assert.Equal(t, 8, maxMultiSigners(rulesDisabled))
 	})
 
-	t.Run("maxMultiSigners returns 8 when Rules is nil", func(t *testing.T) {
-		assert.Equal(t, 8, maxMultiSigners(nil))
+	t.Run("maxMultiSigners returns 32 when Rules is nil", func(t *testing.T) {
+		// rippled STTx.h:55-56: "if rules are not supplied then the
+		// largest possible value is returned".
+		assert.Equal(t, 32, maxMultiSigners(nil))
 	})
 
 	t.Run("maxMultiSigners returns 32 when ExpandedSignerList is enabled", func(t *testing.T) {
@@ -104,6 +108,17 @@ func TestComputeBaseFeeForTx_MaxMultiSigners(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, uint64(10), computeBaseFeeForTx(nil, parsed, cfg),
 			"9 signers > maxMultiSigners(8) → reference_fee fallback per rippled TransactionSign.cpp:795")
+	})
+
+	t.Run("9 signers with nil Rules charges multisign fee", func(t *testing.T) {
+		// Permissive default: nil Rules ⇒ cap=32, so 9 signers still
+		// charge the full multisign fee (mirrors rippled STTx.h:55-56).
+		cfg := tx.EngineConfig{BaseFee: 10, Rules: nil}
+
+		parsed, err := tx.ParseJSON([]byte(buildSignersTxJSON(9)))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(100), computeBaseFeeForTx(nil, parsed, cfg),
+			"nil Rules ⇒ cap=32 ⇒ baseFee * (1 + 9) = 100")
 	})
 
 	t.Run("8 signers with ExpandedSignerList disabled charges multisign fee", func(t *testing.T) {

--- a/internal/ledger/service/tx_query_test.go
+++ b/internal/ledger/service/tx_query_test.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComputeBaseFeeForTx_Multisign verifies that the fee dispatch matches
+// rippled Transactor::calculateBaseFee (Transactor.cpp:229-245):
+// baseFee + signerCount * baseFee. The dispatch must not be gated on
+// SigningPubKey being empty — rippled counts sfSigners entries directly.
+func TestComputeBaseFeeForTx_Multisign(t *testing.T) {
+	cfg := tx.EngineConfig{BaseFee: 10}
+
+	t.Run("no signers → baseFee", func(t *testing.T) {
+		parsed, err := tx.ParseJSON([]byte(`{
+			"TransactionType":"AccountSet",
+			"Account":"rEFNJWaJN6JYW9zXxFq1KqtaqgsMcLs9wK"
+		}`))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(10), computeBaseFeeForTx(nil, parsed, cfg))
+	})
+
+	t.Run("one signer with empty SigningPubKey → 2 * baseFee", func(t *testing.T) {
+		parsed, err := tx.ParseJSON([]byte(`{
+			"TransactionType":"AccountSet",
+			"Account":"rEFNJWaJN6JYW9zXxFq1KqtaqgsMcLs9wK",
+			"SigningPubKey":"",
+			"Signers":[
+				{"Signer":{"Account":"rPmsLuwgD3yp6mvCXyz44itC9V2qZpDvm6","SigningPubKey":"","TxnSignature":""}}
+			]
+		}`))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(20), computeBaseFeeForTx(nil, parsed, cfg))
+	})
+
+	t.Run("one signer with non-empty SigningPubKey still gets multisign fee", func(t *testing.T) {
+		parsed, err := tx.ParseJSON([]byte(`{
+			"TransactionType":"AccountSet",
+			"Account":"rEFNJWaJN6JYW9zXxFq1KqtaqgsMcLs9wK",
+			"SigningPubKey":"03ABCDEF",
+			"Signers":[
+				{"Signer":{"Account":"rPmsLuwgD3yp6mvCXyz44itC9V2qZpDvm6","SigningPubKey":"","TxnSignature":""}}
+			]
+		}`))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(20), computeBaseFeeForTx(nil, parsed, cfg),
+			"rippled Transactor.cpp:229-245 counts sfSigners regardless of SigningPubKey")
+	})
+
+	t.Run("three signers → 4 * baseFee", func(t *testing.T) {
+		parsed, err := tx.ParseJSON([]byte(`{
+			"TransactionType":"AccountSet",
+			"Account":"rEFNJWaJN6JYW9zXxFq1KqtaqgsMcLs9wK",
+			"Signers":[
+				{"Signer":{"Account":"rPmsLuwgD3yp6mvCXyz44itC9V2qZpDvm6","SigningPubKey":"","TxnSignature":""}},
+				{"Signer":{"Account":"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH","SigningPubKey":"","TxnSignature":""}},
+				{"Signer":{"Account":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh","SigningPubKey":"","TxnSignature":""}}
+			]
+		}`))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(40), computeBaseFeeForTx(nil, parsed, cfg))
+	})
+
+	t.Run("nil parsedTx falls back to baseFee", func(t *testing.T) {
+		assert.Equal(t, uint64(10), computeBaseFeeForTx(nil, nil, cfg))
+	})
+}
+
+func TestMulDivU64(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		got, ok := mulDivU64(10, 3, 2)
+		assert.True(t, ok)
+		assert.Equal(t, uint64(15), got)
+	})
+	t.Run("zero divisor", func(t *testing.T) {
+		_, ok := mulDivU64(10, 3, 0)
+		assert.False(t, ok)
+	})
+	t.Run("overflow", func(t *testing.T) {
+		_, ok := mulDivU64(^uint64(0), 2, 1)
+		assert.False(t, ok, "uint64 max * 2 overflows")
+	})
+}

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -167,7 +167,7 @@ func (m *mockAccountChannelsLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockAccountChannelsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountChannelsLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (m *mockAccountChannelsLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockAccountChannelsLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -167,7 +167,7 @@ func (m *mockAccountChannelsLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockAccountChannelsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountChannelsLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (m *mockAccountChannelsLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockAccountChannelsLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -167,11 +167,10 @@ func (m *mockAccountChannelsLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockAccountChannelsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountChannelsLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (m *mockAccountChannelsLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	return 0, 0, errors.New("not implemented")
 }
-func (m *mockAccountChannelsLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
-func (m *mockAccountChannelsLedgerService) IsAmendmentBlocked() bool     { return false }
+func (m *mockAccountChannelsLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockAccountChannelsLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -167,8 +167,11 @@ func (m *mockAccountChannelsLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockAccountChannelsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountChannelsLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
-	return 0, 0, errors.New("not implemented")
+func (m *mockAccountChannelsLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockAccountChannelsLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
 }
 func (m *mockAccountChannelsLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockAccountChannelsLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -167,7 +167,11 @@ func (m *mockAccountChannelsLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockAccountChannelsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountChannelsLedgerService) IsAmendmentBlocked() bool { return false }
+func (m *mockAccountChannelsLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockAccountChannelsLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
+func (m *mockAccountChannelsLedgerService) IsAmendmentBlocked() bool     { return false }
 func (m *mockAccountChannelsLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -169,8 +169,11 @@ func (m *mockAccountCurrenciesLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockAccountCurrenciesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountCurrenciesLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
-	return 0, 0, errors.New("not implemented")
+func (m *mockAccountCurrenciesLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockAccountCurrenciesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
 }
 func (m *mockAccountCurrenciesLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockAccountCurrenciesLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -169,11 +169,10 @@ func (m *mockAccountCurrenciesLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockAccountCurrenciesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountCurrenciesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (m *mockAccountCurrenciesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	return 0, 0, errors.New("not implemented")
 }
-func (m *mockAccountCurrenciesLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
-func (m *mockAccountCurrenciesLedgerService) IsAmendmentBlocked() bool     { return false }
+func (m *mockAccountCurrenciesLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockAccountCurrenciesLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -169,7 +169,7 @@ func (m *mockAccountCurrenciesLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockAccountCurrenciesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountCurrenciesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (m *mockAccountCurrenciesLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockAccountCurrenciesLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -169,7 +169,7 @@ func (m *mockAccountCurrenciesLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockAccountCurrenciesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountCurrenciesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (m *mockAccountCurrenciesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockAccountCurrenciesLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -169,7 +169,11 @@ func (m *mockAccountCurrenciesLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockAccountCurrenciesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountCurrenciesLedgerService) IsAmendmentBlocked() bool { return false }
+func (m *mockAccountCurrenciesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockAccountCurrenciesLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
+func (m *mockAccountCurrenciesLedgerService) IsAmendmentBlocked() bool     { return false }
 func (m *mockAccountCurrenciesLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -147,7 +147,7 @@ func (m *mockLedgerService) GetNFTSellOffers(_ context.Context, nftID [32]byte, 
 func (m *mockLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (m *mockLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockLedgerService) IsAmendmentBlocked() bool { return m.amendmentBlocked }

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -147,7 +147,11 @@ func (m *mockLedgerService) GetNFTSellOffers(_ context.Context, nftID [32]byte, 
 func (m *mockLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockLedgerService) IsAmendmentBlocked() bool { return m.amendmentBlocked }
+func (m *mockLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
+func (m *mockLedgerService) IsAmendmentBlocked() bool     { return m.amendmentBlocked }
 func (m *mockLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -147,7 +147,7 @@ func (m *mockLedgerService) GetNFTSellOffers(_ context.Context, nftID [32]byte, 
 func (m *mockLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (m *mockLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockLedgerService) IsAmendmentBlocked() bool { return m.amendmentBlocked }

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -147,11 +147,10 @@ func (m *mockLedgerService) GetNFTSellOffers(_ context.Context, nftID [32]byte, 
 func (m *mockLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (m *mockLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	return 0, 0, errors.New("not implemented")
 }
-func (m *mockLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
-func (m *mockLedgerService) IsAmendmentBlocked() bool     { return m.amendmentBlocked }
+func (m *mockLedgerService) IsAmendmentBlocked() bool { return m.amendmentBlocked }
 func (m *mockLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -147,8 +147,11 @@ func (m *mockLedgerService) GetNFTSellOffers(_ context.Context, nftID [32]byte, 
 func (m *mockLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
-	return 0, 0, errors.New("not implemented")
+func (m *mockLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
 }
 func (m *mockLedgerService) IsAmendmentBlocked() bool { return m.amendmentBlocked }
 func (m *mockLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -163,11 +163,10 @@ func (m *mockAccountLinesLedgerService) GetNFTSellOffers(_ context.Context, nftI
 func (m *mockAccountLinesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountLinesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (m *mockAccountLinesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	return 0, 0, errors.New("not implemented")
 }
-func (m *mockAccountLinesLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
-func (m *mockAccountLinesLedgerService) IsAmendmentBlocked() bool     { return false }
+func (m *mockAccountLinesLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockAccountLinesLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -163,7 +163,11 @@ func (m *mockAccountLinesLedgerService) GetNFTSellOffers(_ context.Context, nftI
 func (m *mockAccountLinesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountLinesLedgerService) IsAmendmentBlocked() bool { return false }
+func (m *mockAccountLinesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockAccountLinesLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
+func (m *mockAccountLinesLedgerService) IsAmendmentBlocked() bool     { return false }
 func (m *mockAccountLinesLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -163,7 +163,7 @@ func (m *mockAccountLinesLedgerService) GetNFTSellOffers(_ context.Context, nftI
 func (m *mockAccountLinesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountLinesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (m *mockAccountLinesLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockAccountLinesLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -163,7 +163,7 @@ func (m *mockAccountLinesLedgerService) GetNFTSellOffers(_ context.Context, nftI
 func (m *mockAccountLinesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountLinesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (m *mockAccountLinesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockAccountLinesLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -163,8 +163,11 @@ func (m *mockAccountLinesLedgerService) GetNFTSellOffers(_ context.Context, nftI
 func (m *mockAccountLinesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountLinesLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
-	return 0, 0, errors.New("not implemented")
+func (m *mockAccountLinesLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockAccountLinesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
 }
 func (m *mockAccountLinesLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockAccountLinesLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -165,8 +165,11 @@ func (m *mockAccountNFTsLedgerService) GetNFTSellOffers(_ context.Context, nftID
 func (m *mockAccountNFTsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountNFTsLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
-	return 0, 0, errors.New("not implemented")
+func (m *mockAccountNFTsLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockAccountNFTsLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
 }
 func (m *mockAccountNFTsLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockAccountNFTsLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -165,7 +165,7 @@ func (m *mockAccountNFTsLedgerService) GetNFTSellOffers(_ context.Context, nftID
 func (m *mockAccountNFTsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountNFTsLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (m *mockAccountNFTsLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockAccountNFTsLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -165,7 +165,7 @@ func (m *mockAccountNFTsLedgerService) GetNFTSellOffers(_ context.Context, nftID
 func (m *mockAccountNFTsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountNFTsLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (m *mockAccountNFTsLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockAccountNFTsLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -165,11 +165,10 @@ func (m *mockAccountNFTsLedgerService) GetNFTSellOffers(_ context.Context, nftID
 func (m *mockAccountNFTsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountNFTsLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (m *mockAccountNFTsLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	return 0, 0, errors.New("not implemented")
 }
-func (m *mockAccountNFTsLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
-func (m *mockAccountNFTsLedgerService) IsAmendmentBlocked() bool     { return false }
+func (m *mockAccountNFTsLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockAccountNFTsLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -165,7 +165,11 @@ func (m *mockAccountNFTsLedgerService) GetNFTSellOffers(_ context.Context, nftID
 func (m *mockAccountNFTsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountNFTsLedgerService) IsAmendmentBlocked() bool { return false }
+func (m *mockAccountNFTsLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockAccountNFTsLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
+func (m *mockAccountNFTsLedgerService) IsAmendmentBlocked() bool     { return false }
 func (m *mockAccountNFTsLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -170,7 +170,7 @@ func (m *mockDepositAuthorizedLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockDepositAuthorizedLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockDepositAuthorizedLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (m *mockDepositAuthorizedLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockDepositAuthorizedLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -170,7 +170,7 @@ func (m *mockDepositAuthorizedLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockDepositAuthorizedLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockDepositAuthorizedLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (m *mockDepositAuthorizedLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockDepositAuthorizedLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -170,7 +170,11 @@ func (m *mockDepositAuthorizedLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockDepositAuthorizedLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockDepositAuthorizedLedgerService) IsAmendmentBlocked() bool { return false }
+func (m *mockDepositAuthorizedLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockDepositAuthorizedLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
+func (m *mockDepositAuthorizedLedgerService) IsAmendmentBlocked() bool     { return false }
 func (m *mockDepositAuthorizedLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -170,11 +170,10 @@ func (m *mockDepositAuthorizedLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockDepositAuthorizedLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockDepositAuthorizedLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (m *mockDepositAuthorizedLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	return 0, 0, errors.New("not implemented")
 }
-func (m *mockDepositAuthorizedLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
-func (m *mockDepositAuthorizedLedgerService) IsAmendmentBlocked() bool     { return false }
+func (m *mockDepositAuthorizedLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockDepositAuthorizedLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -170,8 +170,11 @@ func (m *mockDepositAuthorizedLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockDepositAuthorizedLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockDepositAuthorizedLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
-	return 0, 0, errors.New("not implemented")
+func (m *mockDepositAuthorizedLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockDepositAuthorizedLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
 }
 func (m *mockDepositAuthorizedLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockDepositAuthorizedLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -166,11 +166,10 @@ func (m *mockGatewayBalancesLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockGatewayBalancesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockGatewayBalancesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (m *mockGatewayBalancesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	return 0, 0, errors.New("not implemented")
 }
-func (m *mockGatewayBalancesLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
-func (m *mockGatewayBalancesLedgerService) IsAmendmentBlocked() bool     { return false }
+func (m *mockGatewayBalancesLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockGatewayBalancesLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -166,7 +166,7 @@ func (m *mockGatewayBalancesLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockGatewayBalancesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockGatewayBalancesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (m *mockGatewayBalancesLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockGatewayBalancesLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -166,7 +166,11 @@ func (m *mockGatewayBalancesLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockGatewayBalancesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockGatewayBalancesLedgerService) IsAmendmentBlocked() bool { return false }
+func (m *mockGatewayBalancesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockGatewayBalancesLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
+func (m *mockGatewayBalancesLedgerService) IsAmendmentBlocked() bool     { return false }
 func (m *mockGatewayBalancesLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -166,8 +166,11 @@ func (m *mockGatewayBalancesLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockGatewayBalancesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockGatewayBalancesLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
-	return 0, 0, errors.New("not implemented")
+func (m *mockGatewayBalancesLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockGatewayBalancesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
 }
 func (m *mockGatewayBalancesLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockGatewayBalancesLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -166,7 +166,7 @@ func (m *mockGatewayBalancesLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockGatewayBalancesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockGatewayBalancesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (m *mockGatewayBalancesLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockGatewayBalancesLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -163,35 +163,45 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		}
 	}
 
-	// Autofill Sequence from the open ledger.
-	// rippled: getAutofillSequence (Simulate.cpp). When TicketSequence is
-	// present, Sequence is implied by the ticket and stays absent.
-	if _, hasSeq := txJsonMap["Sequence"]; !hasSeq {
-		_, hasTicket := txJsonMap["TicketSequence"]
-		seq, seqErr := ctx.Services.Ledger.GetAutofillSequence(accountStr, hasTicket)
-		if seqErr != nil {
-			if errors.Is(seqErr, svcerr.ErrAccountNotFound) {
-				return nil, types.RpcErrorSrcActMissing("Source account not found.")
-			}
-			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill Sequence: %v", seqErr))
-		}
-		if !hasTicket {
-			txJsonMap["Sequence"] = seq
-		}
-	}
-
-	// Autofill Fee from the open ledger / TxQ.
-	// rippled: getCurrentNetworkFee (TransactionSign.cpp).
-	if _, hasFee := txJsonMap["Fee"]; !hasFee {
-		txJsonMap["Fee"] = strconv.FormatUint(ctx.Services.Ledger.GetCurrentNetworkFee(), 10)
-	}
-
-	// Autofill NetworkID if not present and network ID > 1024.
-	// Matches rippled's autofillTx() in Simulate.cpp.
+	// Autofill NetworkID first so the autofill probe sees the final tx
+	// shape. rippled autofillTx() (Simulate.cpp) fills NetworkID before
+	// Sequence; the network id only matters at parse time.
 	if _, ok := txJsonMap["NetworkID"]; !ok {
 		serverInfo := ctx.Services.Ledger.GetServerInfo()
 		if serverInfo.NetworkID > 1024 {
 			txJsonMap["NetworkID"] = serverInfo.NetworkID
+		}
+	}
+
+	// Autofill Sequence + Fee in one service call so they observe a
+	// consistent ledger snapshot. rippled splits these (getAutofillSequence
+	// and getCurrentNetworkFee in Simulate.cpp / TransactionSign.cpp), but
+	// rippled holds one openLedger().current() reference for both reads;
+	// the unified service call is the Go analog.
+	_, hasSeq := txJsonMap["Sequence"]
+	_, hasFee := txJsonMap["Fee"]
+	if !hasSeq || !hasFee {
+		_, hasTicket := txJsonMap["TicketSequence"]
+		probe, marshalErr := json.Marshal(txJsonMap)
+		if marshalErr != nil {
+			return nil, types.RpcErrorInternal("Failed to marshal tx_json for autofill")
+		}
+		seq, fee, autoErr := ctx.Services.Ledger.GetAutofill(accountStr, hasTicket, probe, ctx.Unlimited)
+		if autoErr != nil {
+			switch {
+			case errors.Is(autoErr, svcerr.ErrAccountNotFound):
+				return nil, types.RpcErrorSrcActMissing("Source account not found.")
+			case errors.Is(autoErr, svcerr.ErrHighFee):
+				return nil, types.RpcErrorHighFee(autoErr.Error())
+			default:
+				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill tx: %v", autoErr))
+			}
+		}
+		if !hasSeq && !hasTicket {
+			txJsonMap["Sequence"] = seq
+		}
+		if !hasFee {
+			txJsonMap["Fee"] = strconv.FormatUint(fee, 10)
 		}
 	}
 
@@ -228,12 +238,11 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	}
 
 	// rippled emits "meta" (JSON) when binary=false and "meta_blob" (hex)
-	// when binary=true. Simulate.cpp:264-276.
+	// when binary=true. Always emit when Metadata is present, mirroring
+	// rippled's `if (result.metadata)` guard (Simulate.cpp:264-276).
 	if result.Metadata != nil {
 		if binaryOutput {
-			if len(result.Metadata.Blob) > 0 {
-				response["meta_blob"] = strings.ToUpper(hex.EncodeToString(result.Metadata.Blob))
-			}
+			response["meta_blob"] = strings.ToUpper(hex.EncodeToString(result.Metadata.Blob))
 		} else if result.Metadata.JSON != nil {
 			response["meta"] = result.Metadata.JSON
 		}

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -96,41 +96,77 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorMissingField("tx.Account")
 	}
 
-	// Validate Account is a valid Base58 address up front.
-	//
-	// rippled gates this check inside getAutofillSequence (Simulate.cpp:50-55)
-	// and therefore skips it when the caller supplies Sequence. We validate
-	// unconditionally because every downstream branch (Fee dispatch through
-	// GetAutofill, structural simulate apply) needs the AccountID anyway, so
-	// deferring would only delay the same error. The wire response for the
-	// "no Sequence + bad Account" case still matches rippled
-	// (rpcSRC_ACT_MALFORMED, "Invalid field 'tx.Account'.").
+	// Validate Account string up front. rippled gates this inside
+	// getAutofillSequence (Simulate.cpp:50-55) and skips it when Sequence
+	// is supplied; we validate unconditionally because every downstream
+	// branch needs the AccountID anyway. The wire response still matches
+	// rippled (rpcSRC_ACT_MALFORMED, "Invalid field 'tx.Account'.").
 	accountStr, ok := txJsonMap["Account"].(string)
 	if !ok || !types.IsValidXRPLAddress(accountStr) {
 		return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx.Account'.")
 	}
 
-	// Reference: rippled autofillTx() — Simulate.cpp:71-156.
+	// rippled autofillTx() — Simulate.cpp:71-156. Steps run in the same
+	// order so rippled's error precedence is preserved:
+	//   1. Fee        (→ rpcHIGH_FEE)
+	//   2. SigningPubKey
+	//   3. Signers loop with inline signed-check (→ rpcTX_SIGNED)
+	//   4. TxnSignature with signed-check (→ rpcTX_SIGNED)
+	//   5. Sequence   (→ rpcSRC_ACT_NOT_FOUND)
+	//   6. NetworkID
 
+	// 1. Fee — rippled Simulate.cpp:74-89.
+	if _, hasFee := txJsonMap["Fee"]; !hasFee {
+		probe, marshalErr := json.Marshal(txJsonMap)
+		if marshalErr != nil {
+			return nil, types.RpcErrorInternal("Failed to marshal tx_json for fee autofill")
+		}
+		fee, feeErr := ctx.Services.Ledger.GetAutofillFee(probe)
+		if feeErr != nil {
+			var hfe *svcerr.HighFeeError
+			if errors.As(feeErr, &hfe) {
+				return nil, types.RpcErrorHighFee(hfe.Error())
+			}
+			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill fee: %v", feeErr))
+		}
+		txJsonMap["Fee"] = strconv.FormatUint(fee, 10)
+	}
+
+	// 2. SigningPubKey — rippled Simulate.cpp:91-95.
 	if _, ok := txJsonMap["SigningPubKey"]; !ok {
 		txJsonMap["SigningPubKey"] = ""
 	}
 
-	// Structural Signers validation + per-signer field autofill. The
-	// signed-payload check (signer.TxnSignature != "") is deferred to the
-	// post-autofill block below so rippled's error precedence is preserved:
-	// Fee autofill (→ rpcHIGH_FEE) must fire before rpcTX_SIGNED.
-	signerObjs, rpcErr := normalizeSigners(txJsonMap)
-	if rpcErr != nil {
+	// 3. Signers — rippled Simulate.cpp:97-127. Structural check, autofill,
+	// and signed-check happen per-iteration so an earlier signer's signed
+	// TxnSignature fires before a later signer's structural error.
+	if rpcErr := processSigners(txJsonMap); rpcErr != nil {
 		return nil, rpcErr
 	}
 
-	if _, ok := txJsonMap["TxnSignature"]; !ok {
+	// 4. TxnSignature — rippled Simulate.cpp:129-138.
+	if txnSig, ok := txJsonMap["TxnSignature"]; !ok {
 		txJsonMap["TxnSignature"] = ""
+	} else if sigStr, _ := txnSig.(string); sigStr != "" {
+		return nil, types.RpcErrorTxSigned()
 	}
 
-	// Autofill NetworkID (rippled Simulate.cpp:148-153). Order is functionally
-	// inert: NetworkID does not affect fee dispatch.
+	// 5. Sequence — rippled Simulate.cpp:140-146. Reads the source account
+	// only here (after Fee and signed-checks), so account-missing surfaces
+	// only when rippled would also report it.
+	if _, hasSeq := txJsonMap["Sequence"]; !hasSeq {
+		_, hasTicket := txJsonMap["TicketSequence"]
+		seq, seqErr := ctx.Services.Ledger.GetAutofillSequence(accountStr, hasTicket)
+		if seqErr != nil {
+			if errors.Is(seqErr, svcerr.ErrAccountNotFound) {
+				return nil, types.RpcErrorSrcActMissing("Source account not found.")
+			}
+			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill sequence: %v", seqErr))
+		}
+		txJsonMap["Sequence"] = seq
+	}
+
+	// 6. NetworkID — rippled Simulate.cpp:148-153.
 	if _, ok := txJsonMap["NetworkID"]; !ok {
 		serverInfo := ctx.Services.Ledger.GetServerInfo()
 		if serverInfo.NetworkID > 1024 {
@@ -138,64 +174,12 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		}
 	}
 
-	// Autofill Sequence + Fee in one service call so they observe a
-	// consistent ledger snapshot. rippled splits these (getAutofillSequence
-	// and getCurrentNetworkFee in Simulate.cpp / TransactionSign.cpp), but
-	// rippled holds one openLedger().current() reference for both reads;
-	// the unified service call is the Go analog. This runs *before* the
-	// signed-payload checks so rpcHIGH_FEE wins over rpcTX_SIGNED on
-	// combined inputs, matching rippled's autofillTx order (Fee → Signers
-	// → TxnSignature).
-	//
-	// needSequence is passed through so the service skips the source-account
-	// lookup when the caller already supplied Sequence — rippled only invokes
-	// getAutofillSequence in that branch (Simulate.cpp:140-146), so a
-	// Sequence-supplied/account-missing call must not surface
-	// rpcSRC_ACT_NOT_FOUND.
-	_, hasSeq := txJsonMap["Sequence"]
-	_, hasFee := txJsonMap["Fee"]
-	if !hasSeq || !hasFee {
-		_, hasTicket := txJsonMap["TicketSequence"]
-		probe, marshalErr := json.Marshal(txJsonMap)
-		if marshalErr != nil {
-			return nil, types.RpcErrorInternal("Failed to marshal tx_json for autofill")
-		}
-		seq, fee, autoErr := ctx.Services.Ledger.GetAutofill(accountStr, !hasSeq, hasTicket, probe)
-		if autoErr != nil {
-			switch {
-			case errors.Is(autoErr, svcerr.ErrAccountNotFound):
-				return nil, types.RpcErrorSrcActMissing("Source account not found.")
-			case errors.Is(autoErr, svcerr.ErrHighFee):
-				msg := strings.TrimPrefix(autoErr.Error(), svcerr.ErrHighFee.Error()+": ")
-				return nil, types.RpcErrorHighFee(msg)
-			default:
-				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill tx: %v", autoErr))
-			}
-		}
-		// Mirrors rippled Simulate.cpp:140-146: write Sequence only when the
-		// caller did not supply it. seq is 0 in the ticket case.
-		if !hasSeq {
-			txJsonMap["Sequence"] = seq
-		}
-		if !hasFee {
-			txJsonMap["Fee"] = strconv.FormatUint(fee, 10)
-		}
-	}
+	// Normalize caller-supplied numeric Sequence / TicketSequence: JSON
+	// numbers unmarshal as float64 in map[string]interface{} but downstream
+	// consumers (binarycodec, simulate engine) expect an integer type.
+	normalizeSequenceFields(txJsonMap)
 
-	// Deferred signed-payload checks — must follow GetAutofill so rpcHIGH_FEE
-	// precedes rpcTX_SIGNED for clients that supply both a non-empty
-	// TxnSignature and trigger fee escalation.
-	for _, signerObj := range signerObjs {
-		if sigStr, _ := signerObj["TxnSignature"].(string); sigStr != "" {
-			return nil, types.RpcErrorTxSigned()
-		}
-	}
-	if sigStr, _ := txJsonMap["TxnSignature"].(string); sigStr != "" {
-		return nil, types.RpcErrorTxSigned()
-	}
-
-	// Reject Batch transaction type.
-	// rippled: if (stTx->getTxnType() == ttBATCH) return RPC::make_error(rpcNOT_IMPL)
+	// Reject Batch — rippled Simulate.cpp:345-348.
 	if txType, ok := txJsonMap["TransactionType"].(string); ok && txType == "Batch" {
 		return nil, types.RpcErrorNotImpl()
 	}
@@ -260,43 +244,64 @@ func (m *SimulateMethod) RequiredCondition() types.Condition {
 	return types.NeedsCurrentLedger
 }
 
-// normalizeSigners validates the structural shape of the Signers array and
-// autofills missing SigningPubKey / TxnSignature on each entry. The returned
-// slice points at the inner Signer maps inside txJsonMap so the caller can
-// run signed-payload checks against the same objects after fee autofill.
-//
-// Mirrors the structural half of rippled's autofillTx Signers loop
-// (Simulate.cpp:97-126), excluding the rpcTX_SIGNED branch.
-func normalizeSigners(txJsonMap map[string]interface{}) ([]map[string]interface{}, *types.RpcError) {
+// processSigners mirrors rippled's autofillTx Signers loop
+// (Simulate.cpp:97-127): per-iteration structural check, then autofill of
+// missing SigningPubKey / TxnSignature, then rejection of any non-empty
+// signer TxnSignature. The inline ordering is observable: a signed
+// TxnSignature on signers[0] returns rpcTX_SIGNED even when signers[2] is
+// structurally malformed.
+func processSigners(txJsonMap map[string]interface{}) *types.RpcError {
 	signersRaw, ok := txJsonMap["Signers"]
 	if !ok {
-		return nil, nil
+		return nil
 	}
 	signers, ok := signersRaw.([]interface{})
 	if !ok {
-		return nil, types.RpcErrorInvalidField("tx.Signers")
+		return types.RpcErrorInvalidField("tx.Signers")
 	}
-	out := make([]map[string]interface{}, 0, len(signers))
 	for i, entry := range signers {
 		entryObj, ok := entry.(map[string]interface{})
 		if !ok {
-			return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
+			return types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
 		}
 		signerInner, ok := entryObj["Signer"]
 		if !ok {
-			return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
+			return types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
 		}
 		signerObj, ok := signerInner.(map[string]interface{})
 		if !ok {
-			return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
+			return types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
 		}
 		if _, ok := signerObj["SigningPubKey"]; !ok {
 			signerObj["SigningPubKey"] = ""
 		}
-		if _, ok := signerObj["TxnSignature"]; !ok {
+		if txnSig, ok := signerObj["TxnSignature"]; !ok {
 			signerObj["TxnSignature"] = ""
+		} else if sigStr, _ := txnSig.(string); sigStr != "" {
+			return types.RpcErrorTxSigned()
 		}
-		out = append(out, signerObj)
 	}
-	return out, nil
+	return nil
+}
+
+// normalizeSequenceFields coerces caller-supplied Sequence and
+// TicketSequence values from float64 (JSON-number default) to uint32 so
+// the downstream binary codec and engine see a stable integer type.
+func normalizeSequenceFields(txJsonMap map[string]interface{}) {
+	for _, k := range [...]string{"Sequence", "TicketSequence"} {
+		v, ok := txJsonMap[k]
+		if !ok {
+			continue
+		}
+		switch n := v.(type) {
+		case float64:
+			txJsonMap[k] = uint32(n)
+		case int:
+			txJsonMap[k] = uint32(n)
+		case int64:
+			txJsonMap[k] = uint32(n)
+		case uint64:
+			txJsonMap[k] = uint32(n)
+		}
+	}
 }

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -96,16 +97,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorMissingField("tx.Account")
 	}
 
-	// Validate Account string up front. rippled gates this inside
-	// getAutofillSequence (Simulate.cpp:50-55) and skips it when Sequence
-	// is supplied; we validate unconditionally because every downstream
-	// branch needs the AccountID anyway. The wire response still matches
-	// rippled (rpcSRC_ACT_MALFORMED, "Invalid field 'tx.Account'.").
-	accountStr, ok := txJsonMap["Account"].(string)
-	if !ok || !types.IsValidXRPLAddress(accountStr) {
-		return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx.Account'.")
-	}
-
 	// rippled autofillTx() — Simulate.cpp:71-156. Steps run in the same
 	// order so rippled's error precedence is preserved:
 	//   1. Fee        (→ rpcHIGH_FEE)
@@ -151,15 +142,23 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorTxSigned()
 	}
 
-	// 5. Sequence — rippled Simulate.cpp:140-146. Reads the source account
-	// only here (after Fee and signed-checks), so account-missing surfaces
-	// only when rippled would also report it.
+	// 5. Sequence — rippled Simulate.cpp:140-146. Account format is checked
+	// here, matching rippled's getAutofillSequence (Simulate.cpp:43-55), so
+	// the txSigned and highFee precedence ahead of srcActMalformed/NotFound
+	// is preserved.
 	if _, hasSeq := txJsonMap["Sequence"]; !hasSeq {
+		accountStr, ok := txJsonMap["Account"].(string)
+		if !ok {
+			return nil, types.RpcErrorInvalidField("tx.Account")
+		}
+		if !types.IsValidXRPLAddress(accountStr) {
+			return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx.Account'.")
+		}
 		_, hasTicket := txJsonMap["TicketSequence"]
 		seq, seqErr := ctx.Services.Ledger.GetAutofillSequence(accountStr, hasTicket)
 		if seqErr != nil {
 			if errors.Is(seqErr, svcerr.ErrAccountNotFound) {
-				return nil, types.RpcErrorSrcActMissing("Source account not found.")
+				return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 			}
 			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill sequence: %v", seqErr))
 		}
@@ -177,7 +176,9 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	// Normalize caller-supplied numeric Sequence / TicketSequence: JSON
 	// numbers unmarshal as float64 in map[string]interface{} but downstream
 	// consumers (binarycodec, simulate engine) expect an integer type.
-	normalizeSequenceFields(txJsonMap)
+	if rpcErr := normalizeSequenceFields(txJsonMap); rpcErr != nil {
+		return nil, rpcErr
+	}
 
 	// Reject Batch — rippled Simulate.cpp:345-348.
 	if txType, ok := txJsonMap["TransactionType"].(string); ok && txType == "Batch" {
@@ -285,23 +286,46 @@ func processSigners(txJsonMap map[string]interface{}) *types.RpcError {
 }
 
 // normalizeSequenceFields coerces caller-supplied Sequence and
-// TicketSequence values from float64 (JSON-number default) to uint32 so
-// the downstream binary codec and engine see a stable integer type.
-func normalizeSequenceFields(txJsonMap map[string]interface{}) {
+// TicketSequence values to uint32 (JSON numbers unmarshal as float64 in
+// map[string]interface{}, but downstream consumers expect an integer
+// type). Values outside [0, math.MaxUint32] are rejected to mirror
+// rippled's STParsedJSONObject behaviour on UInt32 fields.
+func normalizeSequenceFields(txJsonMap map[string]interface{}) *types.RpcError {
 	for _, k := range [...]string{"Sequence", "TicketSequence"} {
 		v, ok := txJsonMap[k]
 		if !ok {
 			continue
 		}
+		var (
+			val   uint32
+			valid bool
+		)
 		switch n := v.(type) {
+		case uint32:
+			val, valid = n, true
 		case float64:
-			txJsonMap[k] = uint32(n)
+			if n >= 0 && n <= math.MaxUint32 && n == math.Trunc(n) {
+				val, valid = uint32(n), true
+			}
 		case int:
-			txJsonMap[k] = uint32(n)
+			if n >= 0 && uint64(n) <= math.MaxUint32 {
+				val, valid = uint32(n), true
+			}
 		case int64:
-			txJsonMap[k] = uint32(n)
+			if n >= 0 && uint64(n) <= math.MaxUint32 {
+				val, valid = uint32(n), true
+			}
 		case uint64:
-			txJsonMap[k] = uint32(n)
+			if n <= math.MaxUint32 {
+				val, valid = uint32(n), true
+			}
+		default:
+			continue
 		}
+		if !valid {
+			return types.RpcErrorInvalidField("tx." + k)
+		}
+		txJsonMap[k] = val
 	}
+	return nil
 }

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -22,8 +22,6 @@ import (
 type SimulateMethod struct{}
 
 func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	// Parse raw params into a generic map first so we can check for forbidden fields
-	// and validate the `binary` field type before standard unmarshalling.
 	var rawParams map[string]json.RawMessage
 	if params != nil {
 		if err := json.Unmarshal(params, &rawParams); err != nil {
@@ -38,7 +36,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	var binaryOutput bool
 	if raw, ok := rawParams["binary"]; ok {
 		if err := json.Unmarshal(raw, &binaryOutput); err != nil {
-			// Not a boolean — return invalid_field_error matching rippled
 			return nil, types.RpcErrorInvalidField("binary")
 		}
 	}
@@ -51,7 +48,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		}
 	}
 
-	// Determine tx source: exactly one of tx_blob or tx_json.
 	_, hasTxBlobRaw := rawParams["tx_blob"]
 	_, hasTxJsonRaw := rawParams["tx_json"]
 
@@ -69,7 +65,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	var txJsonMap map[string]interface{}
 
 	if hasTxBlobRaw {
-		// Decode tx_blob string
 		var txBlobStr string
 		if err := json.Unmarshal(rawParams["tx_blob"], &txBlobStr); err != nil {
 			return nil, types.RpcErrorInvalidField("tx_blob")
@@ -83,7 +78,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		}
 		txJsonMap = decoded
 	} else {
-		// Parse tx_json object
 		var txObj map[string]interface{}
 		if err := json.Unmarshal(rawParams["tx_json"], &txObj); err != nil {
 			return nil, types.RpcErrorExpectedField("tx_json", "object")
@@ -236,7 +230,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorInvalidTransaction(validateErr.Error())
 	}
 
-	// Run the transaction in simulation mode (snapshot, no commit)
 	result, err := ctx.Services.Ledger.SimulateTransaction(txJSON)
 	if err != nil {
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Simulation failed: %v", err))

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -1,11 +1,15 @@
 package handlers
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
@@ -159,8 +163,28 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		}
 	}
 
-	// TODO: Autofill Sequence from ledger (service-level) — getAutofillSequence
-	// TODO: Autofill Fee from ledger (service-level) — getCurrentNetworkFee
+	// Autofill Sequence from the open ledger.
+	// rippled: getAutofillSequence (Simulate.cpp). When TicketSequence is
+	// present, Sequence is implied by the ticket and stays absent.
+	if _, hasSeq := txJsonMap["Sequence"]; !hasSeq {
+		_, hasTicket := txJsonMap["TicketSequence"]
+		seq, seqErr := ctx.Services.Ledger.GetAutofillSequence(accountStr, hasTicket)
+		if seqErr != nil {
+			if errors.Is(seqErr, svcerr.ErrAccountNotFound) {
+				return nil, types.RpcErrorSrcActMissing("Source account not found.")
+			}
+			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill Sequence: %v", seqErr))
+		}
+		if !hasTicket {
+			txJsonMap["Sequence"] = seq
+		}
+	}
+
+	// Autofill Fee from the open ledger / TxQ.
+	// rippled: getCurrentNetworkFee (TransactionSign.cpp).
+	if _, hasFee := txJsonMap["Fee"]; !hasFee {
+		txJsonMap["Fee"] = strconv.FormatUint(ctx.Services.Ledger.GetCurrentNetworkFee(), 10)
+	}
 
 	// Autofill NetworkID if not present and network ID > 1024.
 	// Matches rippled's autofillTx() in Simulate.cpp.
@@ -189,16 +213,31 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Simulation failed: %v", err))
 	}
 
+	// rippled overrides the tesSUCCESS message for simulate (Simulate.cpp:258-262).
+	engineMessage := result.EngineResultMessage
+	if result.EngineResult == "tesSUCCESS" {
+		engineMessage = "The simulated transaction would have been applied."
+	}
+
 	response := map[string]interface{}{
 		"engine_result":         result.EngineResult,
 		"engine_result_code":    result.EngineResultCode,
-		"engine_result_message": result.EngineResultMessage,
+		"engine_result_message": engineMessage,
 		"applied":               result.Applied,
 		"ledger_index":          result.CurrentLedger,
 	}
 
-	// TODO: Include metadata when SubmitResult is extended with a Metadata field.
-	// rippled returns "meta" (JSON) or "meta_blob" (binary) from the simulation result.
+	// rippled emits "meta" (JSON) when binary=false and "meta_blob" (hex)
+	// when binary=true. Simulate.cpp:264-276.
+	if result.Metadata != nil {
+		if binaryOutput {
+			if len(result.Metadata.Blob) > 0 {
+				response["meta_blob"] = strings.ToUpper(hex.EncodeToString(result.Metadata.Blob))
+			}
+		} else if result.Metadata.JSON != nil {
+			response["meta"] = result.Metadata.JSON
+		}
+	}
 
 	if binaryOutput {
 		if encoded, err := binarycodec.Encode(txJsonMap); err == nil {

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -180,6 +180,17 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, rpcErr
 	}
 
+	// Post-autofill Account format check — mirrors rippled
+	// STParsedJSONObject (Simulate.cpp:328-330). The Sequence-absent path
+	// already rejected malformed Accounts with rpcSRC_ACT_MALFORMED above;
+	// this catches the Sequence-supplied case where rippled's autofill
+	// skips the check and STParsedJSONObject surfaces invalid_field.
+	if accountStr, ok := txJsonMap["Account"].(string); !ok {
+		return nil, types.RpcErrorInvalidField("tx.Account")
+	} else if !types.IsValidXRPLAddress(accountStr) {
+		return nil, types.RpcErrorInvalidField("tx.Account")
+	}
+
 	// Reject Batch — rippled Simulate.cpp:345-348.
 	if txType, ok := txJsonMap["TransactionType"].(string); ok && txType == "Batch" {
 		return nil, types.RpcErrorNotImpl()

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -112,7 +112,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 
 	// Reference: rippled autofillTx() — Simulate.cpp:71-156.
 
-	// Autofill SigningPubKey: if not present, set to "".
 	if _, ok := txJsonMap["SigningPubKey"]; !ok {
 		txJsonMap["SigningPubKey"] = ""
 	}
@@ -126,8 +125,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, rpcErr
 	}
 
-	// Autofill TxnSignature when missing. The non-empty signed-check is
-	// deferred to after GetAutofill (see comment above).
 	if _, ok := txJsonMap["TxnSignature"]; !ok {
 		txJsonMap["TxnSignature"] = ""
 	}

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -10,8 +10,10 @@ import (
 	"strings"
 
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
+	binarycodecdefs "github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/internal/tx"
 )
 
 // SimulateMethod handles the simulate RPC method.
@@ -199,10 +201,39 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorNotImpl()
 	}
 
-	// Marshal tx_json for service call
+	// STParsedJSONObject parity — unknown-field surface (rippled
+	// Simulate.cpp:328-330). Each top-level tx_json key must resolve to
+	// a known SField; otherwise rippled returns
+	// `error_message: "Field 'tx_json.<key>' is unknown."` from
+	// STParsedJSONObject. binarycodec.definitions.Get() carries the
+	// same registry rippled's STParsedJSONObject consults.
+	defs := binarycodecdefs.Get()
+	for k := range txJsonMap {
+		if _, ok := defs.Fields[k]; !ok {
+			return nil, types.RpcErrorInvalidParams(
+				fmt.Sprintf("Field 'tx_json.%s' is unknown.", k))
+		}
+	}
+
+	// Marshal tx_json for parse + service call.
 	txJSON, err := json.Marshal(txJsonMap)
 	if err != nil {
 		return nil, types.RpcErrorInternal("Failed to marshal tx_json")
+	}
+
+	// STTx ctor parity — rippled Simulate.cpp:332-343. A parse failure or
+	// missing-required-field surface as
+	// `error: "invalidTransaction"` + `error_exception: <reason>`
+	// instead of flowing into the engine as a TER. The duplicate
+	// Validate() vs the engine's own Validate is intentional: it
+	// guarantees the error envelope shape matches rippled even when the
+	// underlying message text differs.
+	parsedTx, parseErr := tx.ParseJSON(txJSON)
+	if parseErr != nil {
+		return nil, types.RpcErrorInvalidTransaction(parseErr.Error())
+	}
+	if validateErr := parsedTx.Validate(); validateErr != nil {
+		return nil, types.RpcErrorInvalidTransaction(validateErr.Error())
 	}
 
 	// Run the transaction in simulation mode (snapshot, no commit)

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -146,6 +146,12 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	// signed-payload checks so rpcHIGH_FEE wins over rpcTX_SIGNED on
 	// combined inputs, matching rippled's autofillTx order (Fee → Signers
 	// → TxnSignature).
+	//
+	// needSequence is passed through so the service skips the source-account
+	// lookup when the caller already supplied Sequence — rippled only invokes
+	// getAutofillSequence in that branch (Simulate.cpp:140-146), so a
+	// Sequence-supplied/account-missing call must not surface
+	// rpcSRC_ACT_NOT_FOUND.
 	_, hasSeq := txJsonMap["Sequence"]
 	_, hasFee := txJsonMap["Fee"]
 	if !hasSeq || !hasFee {
@@ -154,7 +160,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		if marshalErr != nil {
 			return nil, types.RpcErrorInternal("Failed to marshal tx_json for autofill")
 		}
-		seq, fee, autoErr := ctx.Services.Ledger.GetAutofill(accountStr, hasTicket, probe)
+		seq, fee, autoErr := ctx.Services.Ledger.GetAutofill(accountStr, !hasSeq, hasTicket, probe)
 		if autoErr != nil {
 			switch {
 			case errors.Is(autoErr, svcerr.ErrAccountNotFound):
@@ -166,8 +172,8 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill tx: %v", autoErr))
 			}
 		}
-		// rippled writes Sequence unconditionally (Simulate.cpp:140-146); the
-		// value is 0 in the ticket case.
+		// Mirrors rippled Simulate.cpp:140-146: write Sequence only when the
+		// caller did not supply it. seq is 0 in the ticket case.
 		if !hasSeq {
 			txJsonMap["Sequence"] = seq
 		}

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -143,24 +143,25 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	}
 
 	// 5. Sequence — rippled Simulate.cpp:140-146. Account format is checked
-	// here, matching rippled's getAutofillSequence (Simulate.cpp:43-55), so
-	// the txSigned and highFee precedence ahead of srcActMalformed/NotFound
-	// is preserved.
+	// inside GetAutofillSequence (mirrors rippled getAutofillSequence,
+	// Simulate.cpp:43-55), so the txSigned and highFee precedence ahead
+	// of srcActMalformed/NotFound is preserved.
 	if _, hasSeq := txJsonMap["Sequence"]; !hasSeq {
 		accountStr, ok := txJsonMap["Account"].(string)
 		if !ok {
 			return nil, types.RpcErrorInvalidField("tx.Account")
 		}
-		if !types.IsValidXRPLAddress(accountStr) {
-			return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx.Account'.")
-		}
 		_, hasTicket := txJsonMap["TicketSequence"]
 		seq, seqErr := ctx.Services.Ledger.GetAutofillSequence(accountStr, hasTicket)
 		if seqErr != nil {
-			if errors.Is(seqErr, svcerr.ErrAccountNotFound) {
+			switch {
+			case errors.Is(seqErr, svcerr.ErrAccountMalformed):
+				return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx.Account'.")
+			case errors.Is(seqErr, svcerr.ErrAccountNotFound):
 				return nil, types.RpcErrorSrcActNotFound("Source account not found.")
+			default:
+				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill sequence: %v", seqErr))
 			}
-			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill sequence: %v", seqErr))
 		}
 		txJsonMap["Sequence"] = seq
 	}
@@ -180,11 +181,13 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, rpcErr
 	}
 
-	// Post-autofill Account format check — mirrors rippled
-	// STParsedJSONObject (Simulate.cpp:328-330). The Sequence-absent path
-	// already rejected malformed Accounts with rpcSRC_ACT_MALFORMED above;
-	// this catches the Sequence-supplied case where rippled's autofill
-	// skips the check and STParsedJSONObject surfaces invalid_field.
+	// Post-autofill Account format check — the Account-format slice of
+	// rippled's STParsedJSONObject (Simulate.cpp:328-330). Only catches
+	// the Account field; unknown-field / missing-required-field
+	// surfacing remains engine-side. The Sequence-absent path already
+	// rejected malformed Accounts via GetAutofillSequence; this catches
+	// the Sequence-supplied case where rippled's autofill skips the
+	// check and STParsedJSONObject surfaces invalid_field.
 	if accountStr, ok := txJsonMap["Account"].(string); !ok {
 		return nil, types.RpcErrorInvalidField("tx.Account")
 	} else if !types.IsValidXRPLAddress(accountStr) {

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -83,11 +83,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		// Parse tx_json object
 		var txObj map[string]interface{}
 		if err := json.Unmarshal(rawParams["tx_json"], &txObj); err != nil {
-			// tx_json is not an object
 			return nil, types.RpcErrorExpectedField("tx_json", "object")
-		}
-		if len(txObj) == 0 {
-			// Empty tx_json — will fail TransactionType check below
 		}
 		txJsonMap = txObj
 	}
@@ -163,9 +159,8 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		}
 	}
 
-	// Autofill NetworkID first so the autofill probe sees the final tx
-	// shape. rippled autofillTx() (Simulate.cpp) fills NetworkID before
-	// Sequence; the network id only matters at parse time.
+	// Autofill NetworkID (rippled Simulate.cpp:148-153). Order vs Sequence/Fee
+	// is functionally inert: NetworkID does not affect fee dispatch.
 	if _, ok := txJsonMap["NetworkID"]; !ok {
 		serverInfo := ctx.Services.Ledger.GetServerInfo()
 		if serverInfo.NetworkID > 1024 {
@@ -192,12 +187,15 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 			case errors.Is(autoErr, svcerr.ErrAccountNotFound):
 				return nil, types.RpcErrorSrcActMissing("Source account not found.")
 			case errors.Is(autoErr, svcerr.ErrHighFee):
-				return nil, types.RpcErrorHighFee(autoErr.Error())
+				msg := strings.TrimPrefix(autoErr.Error(), svcerr.ErrHighFee.Error()+": ")
+				return nil, types.RpcErrorHighFee(msg)
 			default:
 				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill tx: %v", autoErr))
 			}
 		}
-		if !hasSeq && !hasTicket {
+		// rippled writes Sequence unconditionally (Simulate.cpp:140-146); the
+		// value is 0 in the ticket case.
+		if !hasSeq {
 			txJsonMap["Sequence"] = seq
 		}
 		if !hasFee {

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -96,71 +96,44 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorMissingField("tx.Account")
 	}
 
-	// Validate Account is a valid Base58 address.
-	// rippled: getAutofillSequence checks parseBase58<AccountID>(accountStr) and returns
-	// rpcSRC_ACT_MALFORMED with message "Invalid field 'tx.Account'."
+	// Validate Account is a valid Base58 address up front.
+	//
+	// rippled gates this check inside getAutofillSequence (Simulate.cpp:50-55)
+	// and therefore skips it when the caller supplies Sequence. We validate
+	// unconditionally because every downstream branch (Fee dispatch through
+	// GetAutofill, structural simulate apply) needs the AccountID anyway, so
+	// deferring would only delay the same error. The wire response for the
+	// "no Sequence + bad Account" case still matches rippled
+	// (rpcSRC_ACT_MALFORMED, "Invalid field 'tx.Account'.").
 	accountStr, ok := txJsonMap["Account"].(string)
 	if !ok || !types.IsValidXRPLAddress(accountStr) {
 		return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx.Account'.")
 	}
 
-	// Reference: rippled autofillTx()
+	// Reference: rippled autofillTx() — Simulate.cpp:71-156.
 
-	// Autofill SigningPubKey: if not present, set to ""
+	// Autofill SigningPubKey: if not present, set to "".
 	if _, ok := txJsonMap["SigningPubKey"]; !ok {
 		txJsonMap["SigningPubKey"] = ""
 	}
 
-	// Validate and autofill Signers array.
-	// rippled checks Signers before TxnSignature.
-	if signersRaw, ok := txJsonMap["Signers"]; ok {
-		signers, ok := signersRaw.([]interface{})
-		if !ok {
-			return nil, types.RpcErrorInvalidField("tx.Signers")
-		}
-		for i, signerEntry := range signers {
-			entryObj, ok := signerEntry.(map[string]interface{})
-			if !ok {
-				return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
-			}
-			signerInner, ok := entryObj["Signer"]
-			if !ok {
-				return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
-			}
-			signerObj, ok := signerInner.(map[string]interface{})
-			if !ok {
-				return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
-			}
-
-			// Autofill SigningPubKey if not present
-			if _, ok := signerObj["SigningPubKey"]; !ok {
-				signerObj["SigningPubKey"] = ""
-			}
-
-			// Autofill TxnSignature if not present; reject if non-empty
-			if txnSig, ok := signerObj["TxnSignature"]; !ok {
-				signerObj["TxnSignature"] = ""
-			} else {
-				sigStr, _ := txnSig.(string)
-				if sigStr != "" {
-					return nil, types.RpcErrorTxSigned()
-				}
-			}
-		}
+	// Structural Signers validation + per-signer field autofill. The
+	// signed-payload check (signer.TxnSignature != "") is deferred to the
+	// post-autofill block below so rippled's error precedence is preserved:
+	// Fee autofill (→ rpcHIGH_FEE) must fire before rpcTX_SIGNED.
+	signerObjs, rpcErr := normalizeSigners(txJsonMap)
+	if rpcErr != nil {
+		return nil, rpcErr
 	}
 
-	// Autofill TxnSignature: if not present, set to "". If present and non-empty, reject.
-	if txnSig, ok := txJsonMap["TxnSignature"]; !ok {
+	// Autofill TxnSignature when missing. The non-empty signed-check is
+	// deferred to after GetAutofill (see comment above).
+	if _, ok := txJsonMap["TxnSignature"]; !ok {
 		txJsonMap["TxnSignature"] = ""
-	} else {
-		sigStr, _ := txnSig.(string)
-		if sigStr != "" {
-			return nil, types.RpcErrorTxSigned()
-		}
 	}
 
-	// Autofill NetworkID (rippled Simulate.cpp:148-153). Order vs Sequence/Fee
-	// is functionally inert: NetworkID does not affect fee dispatch.
+	// Autofill NetworkID (rippled Simulate.cpp:148-153). Order is functionally
+	// inert: NetworkID does not affect fee dispatch.
 	if _, ok := txJsonMap["NetworkID"]; !ok {
 		serverInfo := ctx.Services.Ledger.GetServerInfo()
 		if serverInfo.NetworkID > 1024 {
@@ -172,7 +145,10 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	// consistent ledger snapshot. rippled splits these (getAutofillSequence
 	// and getCurrentNetworkFee in Simulate.cpp / TransactionSign.cpp), but
 	// rippled holds one openLedger().current() reference for both reads;
-	// the unified service call is the Go analog.
+	// the unified service call is the Go analog. This runs *before* the
+	// signed-payload checks so rpcHIGH_FEE wins over rpcTX_SIGNED on
+	// combined inputs, matching rippled's autofillTx order (Fee → Signers
+	// → TxnSignature).
 	_, hasSeq := txJsonMap["Sequence"]
 	_, hasFee := txJsonMap["Fee"]
 	if !hasSeq || !hasFee {
@@ -181,7 +157,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		if marshalErr != nil {
 			return nil, types.RpcErrorInternal("Failed to marshal tx_json for autofill")
 		}
-		seq, fee, autoErr := ctx.Services.Ledger.GetAutofill(accountStr, hasTicket, probe, ctx.Unlimited)
+		seq, fee, autoErr := ctx.Services.Ledger.GetAutofill(accountStr, hasTicket, probe)
 		if autoErr != nil {
 			switch {
 			case errors.Is(autoErr, svcerr.ErrAccountNotFound):
@@ -201,6 +177,18 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		if !hasFee {
 			txJsonMap["Fee"] = strconv.FormatUint(fee, 10)
 		}
+	}
+
+	// Deferred signed-payload checks — must follow GetAutofill so rpcHIGH_FEE
+	// precedes rpcTX_SIGNED for clients that supply both a non-empty
+	// TxnSignature and trigger fee escalation.
+	for _, signerObj := range signerObjs {
+		if sigStr, _ := signerObj["TxnSignature"].(string); sigStr != "" {
+			return nil, types.RpcErrorTxSigned()
+		}
+	}
+	if sigStr, _ := txJsonMap["TxnSignature"].(string); sigStr != "" {
+		return nil, types.RpcErrorTxSigned()
 	}
 
 	// Reject Batch transaction type.
@@ -241,7 +229,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	if result.Metadata != nil {
 		if binaryOutput {
 			response["meta_blob"] = strings.ToUpper(hex.EncodeToString(result.Metadata.Blob))
-		} else if result.Metadata.JSON != nil {
+		} else {
 			response["meta"] = result.Metadata.JSON
 		}
 	}
@@ -267,4 +255,45 @@ func (m *SimulateMethod) SupportedApiVersions() []int {
 
 func (m *SimulateMethod) RequiredCondition() types.Condition {
 	return types.NeedsCurrentLedger
+}
+
+// normalizeSigners validates the structural shape of the Signers array and
+// autofills missing SigningPubKey / TxnSignature on each entry. The returned
+// slice points at the inner Signer maps inside txJsonMap so the caller can
+// run signed-payload checks against the same objects after fee autofill.
+//
+// Mirrors the structural half of rippled's autofillTx Signers loop
+// (Simulate.cpp:97-126), excluding the rpcTX_SIGNED branch.
+func normalizeSigners(txJsonMap map[string]interface{}) ([]map[string]interface{}, *types.RpcError) {
+	signersRaw, ok := txJsonMap["Signers"]
+	if !ok {
+		return nil, nil
+	}
+	signers, ok := signersRaw.([]interface{})
+	if !ok {
+		return nil, types.RpcErrorInvalidField("tx.Signers")
+	}
+	out := make([]map[string]interface{}, 0, len(signers))
+	for i, entry := range signers {
+		entryObj, ok := entry.(map[string]interface{})
+		if !ok {
+			return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
+		}
+		signerInner, ok := entryObj["Signer"]
+		if !ok {
+			return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
+		}
+		signerObj, ok := signerInner.(map[string]interface{})
+		if !ok {
+			return nil, types.RpcErrorInvalidField("tx.Signers[" + strconv.Itoa(i) + "]")
+		}
+		if _, ok := signerObj["SigningPubKey"]; !ok {
+			signerObj["SigningPubKey"] = ""
+		}
+		if _, ok := signerObj["TxnSignature"]; !ok {
+			signerObj["TxnSignature"] = ""
+		}
+		out = append(out, signerObj)
+	}
+	return out, nil
 }

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -882,12 +882,16 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 	return out, nil
 }
 
-func (a *LedgerServiceAdapter) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (a *LedgerServiceAdapter) GetAutofillFee(txJSON []byte) (uint64, error) {
 	parsedTx, err := tx.ParseJSON(txJSON)
 	if err != nil {
-		return 0, 0, fmt.Errorf("parse tx for autofill: %w", err)
+		return 0, fmt.Errorf("parse tx for fee autofill: %w", err)
 	}
-	return a.svc.GetAutofill(account, needSequence, hasTicketSequence, parsedTx)
+	return a.svc.GetAutofillFee(parsedTx)
+}
+
+func (a *LedgerServiceAdapter) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return a.svc.GetAutofillSequence(account, hasTicketSequence)
 }
 
 // IsAmendmentBlocked returns true if the server is blocked by unsupported amendments

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -870,7 +870,10 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 		ValidatedLedger:     result.ValidatedLedger,
 	}
 	if result.Metadata != nil {
-		blob, _ := tx.SerializeMetadata(result.Metadata)
+		blob, serErr := tx.SerializeMetadata(result.Metadata)
+		if serErr != nil {
+			return nil, fmt.Errorf("serialize metadata: %w", serErr)
+		}
 		out.Metadata = &types.SubmitMetadata{
 			JSON: result.Metadata,
 			Blob: blob,
@@ -879,12 +882,12 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 	return out, nil
 }
 
-func (a *LedgerServiceAdapter) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return a.svc.GetAutofillSequence(account, hasTicketSequence)
-}
-
-func (a *LedgerServiceAdapter) GetCurrentNetworkFee() uint64 {
-	return a.svc.GetCurrentNetworkFee()
+func (a *LedgerServiceAdapter) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	parsedTx, err := tx.ParseJSON(txJSON)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse tx for autofill: %w", err)
+	}
+	return a.svc.GetAutofill(account, hasTicketSequence, parsedTx, isUnlimited)
 }
 
 // IsAmendmentBlocked returns true if the server is blocked by unsupported amendments

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -879,14 +879,10 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 	return out, nil
 }
 
-// GetAutofillSequence returns the next sequence for the account from the
-// current open ledger, consulting the TxQ when the account has queued txs.
 func (a *LedgerServiceAdapter) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
 	return a.svc.GetAutofillSequence(account, hasTicketSequence)
 }
 
-// GetCurrentNetworkFee returns the fee (in drops) needed to enter the
-// current open ledger, escalated by TxQ load.
 func (a *LedgerServiceAdapter) GetCurrentNetworkFee() uint64 {
 	return a.svc.GetCurrentNetworkFee()
 }

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -882,12 +882,12 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 	return out, nil
 }
 
-func (a *LedgerServiceAdapter) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (a *LedgerServiceAdapter) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	parsedTx, err := tx.ParseJSON(txJSON)
 	if err != nil {
 		return 0, 0, fmt.Errorf("parse tx for autofill: %w", err)
 	}
-	return a.svc.GetAutofill(account, hasTicketSequence, parsedTx, isUnlimited)
+	return a.svc.GetAutofill(account, hasTicketSequence, parsedTx)
 }
 
 // IsAmendmentBlocked returns true if the server is blocked by unsupported amendments

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -883,10 +883,11 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 }
 
 func (a *LedgerServiceAdapter) GetAutofillFee(txJSON []byte) (uint64, error) {
-	parsedTx, err := tx.ParseJSON(txJSON)
-	if err != nil {
-		return 0, fmt.Errorf("parse tx for fee autofill: %w", err)
-	}
+	// rippled getTxFee falls back to reference_fee on any parse failure
+	// (TransactionSign.cpp:790-821). A nil parsedTx triggers the
+	// equivalent baseFee fallback in computeBaseFeeForTx so the later
+	// structural-check passes can surface the real error.
+	parsedTx, _ := tx.ParseJSON(txJSON)
 	return a.svc.GetAutofillFee(parsedTx)
 }
 

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -882,12 +882,12 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 	return out, nil
 }
 
-func (a *LedgerServiceAdapter) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (a *LedgerServiceAdapter) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	parsedTx, err := tx.ParseJSON(txJSON)
 	if err != nil {
 		return 0, 0, fmt.Errorf("parse tx for autofill: %w", err)
 	}
-	return a.svc.GetAutofill(account, hasTicketSequence, parsedTx)
+	return a.svc.GetAutofill(account, needSequence, hasTicketSequence, parsedTx)
 }
 
 // IsAmendmentBlocked returns true if the server is blocked by unsupported amendments

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -860,7 +860,7 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 		}, nil
 	}
 
-	return &types.SubmitResult{
+	out := &types.SubmitResult{
 		EngineResult:        result.Result.String(),
 		EngineResultCode:    int(result.Result),
 		EngineResultMessage: result.Message,
@@ -868,7 +868,27 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 		Fee:                 result.Fee,
 		CurrentLedger:       result.CurrentLedger,
 		ValidatedLedger:     result.ValidatedLedger,
-	}, nil
+	}
+	if result.Metadata != nil {
+		blob, _ := tx.SerializeMetadata(result.Metadata)
+		out.Metadata = &types.SubmitMetadata{
+			JSON: result.Metadata,
+			Blob: blob,
+		}
+	}
+	return out, nil
+}
+
+// GetAutofillSequence returns the next sequence for the account from the
+// current open ledger, consulting the TxQ when the account has queued txs.
+func (a *LedgerServiceAdapter) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return a.svc.GetAutofillSequence(account, hasTicketSequence)
+}
+
+// GetCurrentNetworkFee returns the fee (in drops) needed to enter the
+// current open ledger, escalated by TxQ load.
+func (a *LedgerServiceAdapter) GetCurrentNetworkFee() uint64 {
+	return a.svc.GetCurrentNetworkFee()
 }
 
 // IsAmendmentBlocked returns true if the server is blocked by unsupported amendments

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -150,7 +150,11 @@ func (m *mockNFTOffersLedgerService) GetNFTSellOffers(_ context.Context, nftID [
 func (m *mockNFTOffersLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNFTOffersLedgerService) IsAmendmentBlocked() bool { return false }
+func (m *mockNFTOffersLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockNFTOffersLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
+func (m *mockNFTOffersLedgerService) IsAmendmentBlocked() bool     { return false }
 func (m *mockNFTOffersLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -150,7 +150,7 @@ func (m *mockNFTOffersLedgerService) GetNFTSellOffers(_ context.Context, nftID [
 func (m *mockNFTOffersLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNFTOffersLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (m *mockNFTOffersLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockNFTOffersLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -150,8 +150,11 @@ func (m *mockNFTOffersLedgerService) GetNFTSellOffers(_ context.Context, nftID [
 func (m *mockNFTOffersLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNFTOffersLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
-	return 0, 0, errors.New("not implemented")
+func (m *mockNFTOffersLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockNFTOffersLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
 }
 func (m *mockNFTOffersLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockNFTOffersLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -150,7 +150,7 @@ func (m *mockNFTOffersLedgerService) GetNFTSellOffers(_ context.Context, nftID [
 func (m *mockNFTOffersLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNFTOffersLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (m *mockNFTOffersLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockNFTOffersLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -150,11 +150,10 @@ func (m *mockNFTOffersLedgerService) GetNFTSellOffers(_ context.Context, nftID [
 func (m *mockNFTOffersLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNFTOffersLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (m *mockNFTOffersLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	return 0, 0, errors.New("not implemented")
 }
-func (m *mockNFTOffersLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
-func (m *mockNFTOffersLedgerService) IsAmendmentBlocked() bool     { return false }
+func (m *mockNFTOffersLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockNFTOffersLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -164,11 +164,10 @@ func (m *mockNoRippleCheckLedgerService) GetNFTSellOffers(_ context.Context, nft
 func (m *mockNoRippleCheckLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNoRippleCheckLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (m *mockNoRippleCheckLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	return 0, 0, errors.New("not implemented")
 }
-func (m *mockNoRippleCheckLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
-func (m *mockNoRippleCheckLedgerService) IsAmendmentBlocked() bool     { return false }
+func (m *mockNoRippleCheckLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockNoRippleCheckLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -164,7 +164,11 @@ func (m *mockNoRippleCheckLedgerService) GetNFTSellOffers(_ context.Context, nft
 func (m *mockNoRippleCheckLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNoRippleCheckLedgerService) IsAmendmentBlocked() bool { return false }
+func (m *mockNoRippleCheckLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockNoRippleCheckLedgerService) GetCurrentNetworkFee() uint64 { return 10 }
+func (m *mockNoRippleCheckLedgerService) IsAmendmentBlocked() bool     { return false }
 func (m *mockNoRippleCheckLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return nil, errors.New("not implemented in mock")
 }

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -164,8 +164,11 @@ func (m *mockNoRippleCheckLedgerService) GetNFTSellOffers(_ context.Context, nft
 func (m *mockNoRippleCheckLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNoRippleCheckLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
-	return 0, 0, errors.New("not implemented")
+func (m *mockNoRippleCheckLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+func (m *mockNoRippleCheckLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	return 0, errors.New("not implemented")
 }
 func (m *mockNoRippleCheckLedgerService) IsAmendmentBlocked() bool { return false }
 func (m *mockNoRippleCheckLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -164,7 +164,7 @@ func (m *mockNoRippleCheckLedgerService) GetNFTSellOffers(_ context.Context, nft
 func (m *mockNoRippleCheckLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNoRippleCheckLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (m *mockNoRippleCheckLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockNoRippleCheckLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -164,7 +164,7 @@ func (m *mockNoRippleCheckLedgerService) GetNFTSellOffers(_ context.Context, nft
 func (m *mockNoRippleCheckLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNoRippleCheckLedgerService) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (m *mockNoRippleCheckLedgerService) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	return 0, 0, errors.New("not implemented")
 }
 func (m *mockNoRippleCheckLedgerService) IsAmendmentBlocked() bool { return false }

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -811,11 +811,15 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 			"signed-check fires before Account format check — rippled Simulate.cpp:129-138 vs 50-54")
 	})
 
-	t.Run("Sequence supplied + bad Account skips Account check", func(t *testing.T) {
-		// rippled only validates the Account string inside
-		// getAutofillSequence (Simulate.cpp:43-55), which is only reached
-		// when Sequence is absent. When the caller supplies Sequence, the
-		// handler must not reject on Account format.
+	t.Run("Sequence supplied + bad Account surfaces invalid_field, not srcActMalformed", func(t *testing.T) {
+		// rippled's autofill skips the Account check inside
+		// getAutofillSequence (Simulate.cpp:43-55) when Sequence is
+		// supplied, but STParsedJSONObject at Simulate.cpp:328-330 then
+		// validates the AccountID and surfaces invalid_field on
+		// failure — distinct from the rpcSRC_ACT_MALFORMED that the
+		// Sequence-absent path returns. Go mirrors this via a
+		// post-autofill format check that fires only in the
+		// Sequence-supplied case.
 		mock := newMockLedgerServiceSimulate()
 
 		params := map[string]interface{}{
@@ -829,7 +833,10 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		require.NoError(t, err)
 
 		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
-		require.Nil(t, rpcErr, "Sequence supplied — handler must not run the Account check")
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code,
+			"bad Account on the Sequence-supplied path surfaces invalid_field, not srcActMalformed")
+		assert.Equal(t, "Invalid field 'tx.Account'.", rpcErr.Message)
 		assert.Equal(t, 0, mock.seqAutofillCallCount,
 			"GetAutofillSequence must be skipped when Sequence is supplied")
 	})

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
@@ -14,8 +15,11 @@ import (
 // mockLedgerServiceSimulate extends mockLedgerService with simulate-specific behavior.
 type mockLedgerServiceSimulate struct {
 	*mockLedgerService
-	simulateResult *types.SubmitResult
-	simulateError  error
+	simulateResult    *types.SubmitResult
+	simulateError     error
+	autofillSeq       uint32
+	autofillSeqErr    error
+	currentNetworkFee uint64
 }
 
 func newMockLedgerServiceSimulate() *mockLedgerServiceSimulate {
@@ -28,6 +32,8 @@ func newMockLedgerServiceSimulate() *mockLedgerServiceSimulate {
 			Applied:             false,
 			CurrentLedger:       3,
 		},
+		autofillSeq:       1,
+		currentNetworkFee: 10,
 	}
 }
 
@@ -36,6 +42,20 @@ func (m *mockLedgerServiceSimulate) SimulateTransaction(txJSON []byte) (*types.S
 		return nil, m.simulateError
 	}
 	return m.simulateResult, nil
+}
+
+func (m *mockLedgerServiceSimulate) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	if m.autofillSeqErr != nil {
+		return 0, m.autofillSeqErr
+	}
+	if hasTicketSequence {
+		return 0, nil
+	}
+	return m.autofillSeq, nil
+}
+
+func (m *mockLedgerServiceSimulate) GetCurrentNetworkFee() uint64 {
+	return m.currentNetworkFee
 }
 
 func newSimulateTestServices(mock *mockLedgerServiceSimulate) *types.ServiceContainer {
@@ -474,6 +494,187 @@ func TestSimulateMethod_SrcActMalformed(t *testing.T) {
 	assert.Equal(t, types.RpcSRC_ACT_MALFORMED, rpcErr.Code)
 	assert.Equal(t, "srcActMalformed", rpcErr.ErrorString)
 	assert.Equal(t, "Invalid field 'tx.Account'.", rpcErr.Message)
+}
+
+func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
+	method := &handlers.SimulateMethod{}
+
+	makeCtx := func(mock *mockLedgerServiceSimulate) *types.RpcContext {
+		return &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion2,
+			Services:   newSimulateTestServices(mock),
+		}
+	}
+
+	t.Run("Sequence and Fee autofilled from ledger service", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+		mock.autofillSeq = 42
+		mock.currentNetworkFee = 15
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.Nil(t, rpcErr)
+		resp := result.(map[string]interface{})
+		txJSON := resp["tx_json"].(map[string]interface{})
+
+		assert.Equal(t, uint32(42), txJSON["Sequence"])
+		assert.Equal(t, "15", txJSON["Fee"])
+	})
+
+	t.Run("Pre-set Sequence and Fee are preserved", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+		mock.autofillSeq = 99
+		mock.currentNetworkFee = 99
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"Sequence":        7,
+				"Fee":             "12",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.Nil(t, rpcErr)
+		resp := result.(map[string]interface{})
+		txJSON := resp["tx_json"].(map[string]interface{})
+
+		assert.EqualValues(t, 7, txJSON["Sequence"])
+		assert.Equal(t, "12", txJSON["Fee"])
+	})
+
+	t.Run("TicketSequence skips Sequence autofill", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+		mock.autofillSeq = 99
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"TicketSequence":  5,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.Nil(t, rpcErr)
+		resp := result.(map[string]interface{})
+		txJSON := resp["tx_json"].(map[string]interface{})
+
+		_, hasSeq := txJSON["Sequence"]
+		assert.False(t, hasSeq, "Sequence must stay absent when TicketSequence is present")
+	})
+
+	t.Run("Source account not found maps to srcActMissing", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+		mock.autofillSeqErr = svcerr.ErrAccountNotFound
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcSRC_ACT_NOT_FOUND, rpcErr.Code)
+	})
+}
+
+func TestSimulateMethod_MetaInResponse(t *testing.T) {
+	method := &handlers.SimulateMethod{}
+
+	t.Run("meta field present when binary=false", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+		metaJSON := map[string]interface{}{
+			"AffectedNodes":     []interface{}{},
+			"TransactionIndex":  uint32(0),
+			"TransactionResult": "tesSUCCESS",
+		}
+		mock.simulateResult = &types.SubmitResult{
+			EngineResult:        "tesSUCCESS",
+			EngineResultCode:    0,
+			EngineResultMessage: "ignored",
+			Applied:             false,
+			CurrentLedger:       3,
+			Metadata:            &types.SubmitMetadata{JSON: metaJSON, Blob: []byte{0xAB, 0xCD}},
+		}
+
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion2,
+			Services:   newSimulateTestServices(mock),
+		}
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		resp := result.(map[string]interface{})
+
+		assert.Equal(t, metaJSON, resp["meta"])
+		_, hasBlob := resp["meta_blob"]
+		assert.False(t, hasBlob, "meta_blob must not appear when binary=false")
+		assert.Equal(t, "The simulated transaction would have been applied.", resp["engine_result_message"])
+	})
+
+	t.Run("meta_blob field present when binary=true", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+		mock.simulateResult = &types.SubmitResult{
+			EngineResult:        "tesSUCCESS",
+			EngineResultCode:    0,
+			EngineResultMessage: "ignored",
+			Applied:             false,
+			CurrentLedger:       3,
+			Metadata:            &types.SubmitMetadata{Blob: []byte{0xDE, 0xAD, 0xBE, 0xEF}},
+		}
+
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion2,
+			Services:   newSimulateTestServices(mock),
+		}
+		params := map[string]interface{}{
+			"binary": true,
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		resp := result.(map[string]interface{})
+
+		assert.Equal(t, "DEADBEEF", resp["meta_blob"])
+		_, hasMeta := resp["meta"]
+		assert.False(t, hasMeta, "meta must not appear when binary=true")
+	})
 }
 
 func TestSimulateMethod_RequiredRole(t *testing.T) {

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -61,6 +62,12 @@ func (m *mockLedgerServiceSimulate) GetAutofillFee(txJSON []byte) (uint64, error
 func (m *mockLedgerServiceSimulate) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
 	m.seqAutofillCallCount++
 	m.lastSeqHasTicket = hasTicketSequence
+	// Mirror the real service's address validation so handler tests that
+	// expect SrcActMalformed on a bad Account still receive ErrAccountMalformed
+	// from the service path, not a canned success.
+	if _, _, decodeErr := addresscodec.DecodeClassicAddressToAccountID(account); decodeErr != nil {
+		return 0, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, decodeErr)
+	}
 	if m.autofillSeqErr != nil {
 		return 0, m.autofillSeqErr
 	}

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -22,6 +22,8 @@ type mockLedgerServiceSimulate struct {
 	autofillSeq       uint32
 	autofillErr       error
 	currentNetworkFee uint64
+	lastNeedSequence  bool
+	autofillCallCount int
 }
 
 func newMockLedgerServiceSimulate() *mockLedgerServiceSimulate {
@@ -46,11 +48,13 @@ func (m *mockLedgerServiceSimulate) SimulateTransaction(txJSON []byte) (*types.S
 	return m.simulateResult, nil
 }
 
-func (m *mockLedgerServiceSimulate) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+func (m *mockLedgerServiceSimulate) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
+	m.lastNeedSequence = needSequence
+	m.autofillCallCount++
 	if m.autofillErr != nil {
 		return 0, 0, m.autofillErr
 	}
-	if hasTicketSequence {
+	if !needSequence || hasTicketSequence {
 		return 0, m.currentNetworkFee, nil
 	}
 	return m.autofillSeq, m.currentNetworkFee, nil
@@ -552,6 +556,56 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 
 		assert.EqualValues(t, 7, txJSON["Sequence"])
 		assert.Equal(t, "12", txJSON["Fee"])
+	})
+
+	t.Run("Sequence supplied propagates needSequence=false to service", func(t *testing.T) {
+		// rippled only invokes getAutofillSequence when Sequence is absent
+		// (Simulate.cpp:140-146); the handler must propagate needSequence=false
+		// so the service can skip the source-account lookup that would
+		// otherwise surface rpcSRC_ACT_NOT_FOUND for callers that supplied
+		// Sequence but not Fee. The behavioural test for the skip itself
+		// lives in internal/ledger/service/tx_query_test.go.
+		mock := newMockLedgerServiceSimulate()
+		mock.currentNetworkFee = 17
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"Sequence":        9,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.Nil(t, rpcErr)
+		resp := result.(map[string]interface{})
+		txJSON := resp["tx_json"].(map[string]interface{})
+
+		assert.EqualValues(t, 9, txJSON["Sequence"], "caller-supplied Sequence preserved")
+		assert.Equal(t, "17", txJSON["Fee"], "Fee still autofilled")
+		assert.Equal(t, 1, mock.autofillCallCount, "GetAutofill invoked exactly once")
+		assert.False(t, mock.lastNeedSequence,
+			"needSequence must be false when caller supplied Sequence")
+	})
+
+	t.Run("Sequence absent propagates needSequence=true to service", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.Nil(t, rpcErr)
+		assert.True(t, mock.lastNeedSequence,
+			"needSequence must be true when caller omitted Sequence")
 	})
 
 	t.Run("TicketSequence writes Sequence=0", func(t *testing.T) {

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -11,9 +11,19 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	"github.com/LeJamon/goXRPLd/internal/tx"
+	txall "github.com/LeJamon/goXRPLd/internal/tx/all"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// The simulate handler now performs an STTx-ctor-parity Validate()
+// (rippled Simulate.cpp:332-343). Without all tx types registered,
+// ParseJSON falls back to the BaseTx stub whose Validate is permissive
+// and does not catch per-type missing-required-field errors. Register
+// once at package init so handler tests observe production semantics.
+func init() {
+	txall.RegisterAll()
+}
 
 // mockLedgerServiceSimulate extends mockLedgerService with simulate-specific behavior.
 type mockLedgerServiceSimulate struct {
@@ -1130,6 +1140,81 @@ func TestSimulateMethod_RealMetadataShape(t *testing.T) {
 	final, ok := mod["FinalFields"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "123ABC", final["Domain"])
+}
+
+// TestSimulateMethod_UnknownField mirrors rippled Simulate_test.cpp:372-384.
+// An unknown top-level tx_json key must surface as
+// `error_message: "Field 'tx_json.<key>' is unknown."`, produced by
+// rippled's STParsedJSONObject (Simulate.cpp:328-330). The handler
+// short-circuits before the engine runs, so the mock simulate result
+// must never be observed.
+func TestSimulateMethod_UnknownField(t *testing.T) {
+	method := &handlers.SimulateMethod{}
+	mock := newMockLedgerServiceSimulate()
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services:   newSimulateTestServices(mock),
+	}
+
+	params := map[string]interface{}{
+		"tx_json": map[string]interface{}{
+			"TransactionType": "AccountSet",
+			"Account":         validAccountAddress,
+			"foo":             "bar",
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	_, rpcErr := method.Handle(ctx, paramsJSON)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Equal(t, "Field 'tx_json.foo' is unknown.", rpcErr.Message,
+		"rippled Simulate_test.cpp:372-384 emits this exact error_message")
+}
+
+// TestSimulateMethod_MissingRequiredField mirrors rippled
+// Simulate_test.cpp:300-312. A Payment without Destination must surface
+// as `error: "invalidTransaction"` + `error_exception: <reason>`, the
+// envelope rippled emits when STTx construction throws
+// (Simulate.cpp:338-342). The exact exception text is goXRPL-side
+// (`tx.Payment.Validate()` returns "Destination is required" rather
+// than rippled's "Field 'Destination' is required but missing."); the
+// envelope key is the conformance contract under test.
+func TestSimulateMethod_MissingRequiredField(t *testing.T) {
+	method := &handlers.SimulateMethod{}
+	mock := newMockLedgerServiceSimulate()
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services:   newSimulateTestServices(mock),
+	}
+
+	params := map[string]interface{}{
+		"tx_json": map[string]interface{}{
+			"TransactionType": "Payment",
+			"Account":         validAccountAddress,
+			// Destination omitted intentionally
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	_, rpcErr := method.Handle(ctx, paramsJSON)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "invalidTransaction", rpcErr.ErrorString,
+		"rippled Simulate.cpp:340 hard-codes error=invalidTransaction")
+	assert.NotEmpty(t, rpcErr.ErrorException,
+		"missing-required-field must populate the error_exception envelope, "+
+			"not error_message")
+	assert.Contains(t, rpcErr.ErrorException, "Destination",
+		"the exception text must name the missing field so callers can act")
+	assert.Empty(t, rpcErr.Message,
+		"error_message must be empty when error_exception is populated — "+
+			"matches rippled Simulate.cpp:338-342 where only error_exception is set")
 }
 
 func TestSimulateMethod_RequiredRole(t *testing.T) {

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -3,11 +3,13 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +46,7 @@ func (m *mockLedgerServiceSimulate) SimulateTransaction(txJSON []byte) (*types.S
 	return m.simulateResult, nil
 }
 
-func (m *mockLedgerServiceSimulate) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+func (m *mockLedgerServiceSimulate) GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
 	if m.autofillErr != nil {
 		return 0, 0, m.autofillErr
 	}
@@ -592,6 +594,46 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcSRC_ACT_NOT_FOUND, rpcErr.Code)
 	})
+
+	t.Run("ErrHighFee maps to rpcHIGH_FEE with stripped wrap prefix", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+		mock.autofillErr = fmt.Errorf("%w: Fee of 5000 exceeds the requested tx limit of 100", svcerr.ErrHighFee)
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "highFee", rpcErr.ErrorString)
+		assert.Equal(t, "Fee of 5000 exceeds the requested tx limit of 100", rpcErr.Message,
+			"rippled TransactionSign.cpp:870-873 emits the unwrapped 'Fee of X exceeds…' message")
+	})
+
+	t.Run("highFee precedes txSigned when both inputs conflict", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+		mock.autofillErr = fmt.Errorf("%w: Fee of 5000 exceeds the requested tx limit of 100", svcerr.ErrHighFee)
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"TxnSignature":    "DEADBEEF",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "highFee", rpcErr.ErrorString,
+			"rippled autofillTx runs Fee before the TxnSignature signed-check (Simulate.cpp:74-138)")
+	})
 }
 
 func TestSimulateMethod_MetaInResponse(t *testing.T) {
@@ -637,6 +679,45 @@ func TestSimulateMethod_MetaInResponse(t *testing.T) {
 		assert.Equal(t, "The simulated transaction would have been applied.", resp["engine_result_message"])
 	})
 
+	t.Run("nil Metadata omits both meta and meta_blob", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+		mock.simulateResult = &types.SubmitResult{
+			EngineResult:        "temBAD_AMOUNT",
+			EngineResultCode:    -298,
+			EngineResultMessage: "Malformed: Bad amount.",
+			Applied:             false,
+			CurrentLedger:       3,
+			Metadata:            nil,
+		}
+
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleUser,
+			ApiVersion: types.ApiVersion2,
+			Services:   newSimulateTestServices(mock),
+		}
+		for _, binary := range []bool{false, true} {
+			params := map[string]interface{}{
+				"binary": binary,
+				"tx_json": map[string]interface{}{
+					"TransactionType": "AccountSet",
+					"Account":         validAccountAddress,
+				},
+			}
+			paramsJSON, _ := json.Marshal(params)
+
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			require.Nil(t, rpcErr)
+			resp := result.(map[string]interface{})
+
+			_, hasMeta := resp["meta"]
+			_, hasBlob := resp["meta_blob"]
+			assert.False(t, hasMeta, "binary=%v: meta must be absent when Metadata is nil "+
+				"(rippled Simulate.cpp:264 gates emit on result.metadata)", binary)
+			assert.False(t, hasBlob, "binary=%v: meta_blob must be absent when Metadata is nil", binary)
+		}
+	})
+
 	t.Run("meta_blob field present when binary=true", func(t *testing.T) {
 		mock := newMockLedgerServiceSimulate()
 		mock.simulateResult = &types.SubmitResult{
@@ -671,6 +752,76 @@ func TestSimulateMethod_MetaInResponse(t *testing.T) {
 		_, hasMeta := resp["meta"]
 		assert.False(t, hasMeta, "meta must not appear when binary=true")
 	})
+}
+
+// TestSimulateMethod_RealMetadataShape exercises the wire shape produced by
+// tx.Metadata.MarshalJSON when SubmitMetadata.JSON carries the real engine
+// metadata struct (as the production LedgerServiceAdapter does), not a
+// hand-rolled map. Mirrors the field-paths rippled validates in
+// Simulate_test.cpp:527-549.
+func TestSimulateMethod_RealMetadataShape(t *testing.T) {
+	method := &handlers.SimulateMethod{}
+	mock := newMockLedgerServiceSimulate()
+
+	realMeta := &tx.Metadata{
+		AffectedNodes: []tx.AffectedNode{
+			{
+				NodeType:        "ModifiedNode",
+				LedgerEntryType: "AccountRoot",
+				LedgerIndex:     "ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890",
+				FinalFields: map[string]any{
+					"Domain": "123ABC",
+				},
+			},
+		},
+		TransactionIndex:  0,
+		TransactionResult: tx.TesSUCCESS,
+	}
+	mock.simulateResult = &types.SubmitResult{
+		EngineResult:        "tesSUCCESS",
+		EngineResultCode:    0,
+		EngineResultMessage: "ignored",
+		Applied:             false,
+		CurrentLedger:       3,
+		Metadata:            &types.SubmitMetadata{JSON: realMeta, Blob: []byte{0x00}},
+	}
+
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services:   newSimulateTestServices(mock),
+	}
+	params := map[string]interface{}{
+		"tx_json": map[string]interface{}{
+			"TransactionType": "AccountSet",
+			"Account":         validAccountAddress,
+		},
+	}
+	paramsJSON, _ := json.Marshal(params)
+
+	result, rpcErr := method.Handle(ctx, paramsJSON)
+	require.Nil(t, rpcErr)
+
+	wire, err := json.Marshal(result)
+	require.NoError(t, err)
+	var roundTrip map[string]interface{}
+	require.NoError(t, json.Unmarshal(wire, &roundTrip))
+
+	meta, ok := roundTrip["meta"].(map[string]interface{})
+	require.True(t, ok, "meta must be a JSON object on the wire")
+	assert.Equal(t, "tesSUCCESS", meta["TransactionResult"])
+	assert.EqualValues(t, 0, meta["TransactionIndex"])
+
+	nodes, ok := meta["AffectedNodes"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, nodes, 1)
+	mod, ok := nodes[0].(map[string]interface{})["ModifiedNode"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "AccountRoot", mod["LedgerEntryType"])
+	final, ok := mod["FinalFields"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "123ABC", final["Domain"])
 }
 
 func TestSimulateMethod_RequiredRole(t *testing.T) {

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -541,6 +541,8 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 
 		assert.Equal(t, uint32(42), txJSON["Sequence"])
 		assert.Equal(t, "15", txJSON["Fee"])
+		assert.Equal(t, 1, mock.feeAutofillCallCount, "GetAutofillFee invoked once")
+		assert.Equal(t, 1, mock.seqAutofillCallCount, "GetAutofillSequence invoked once")
 	})
 
 	t.Run("Pre-set Sequence and Fee are preserved", func(t *testing.T) {
@@ -566,6 +568,10 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 
 		assert.EqualValues(t, 7, txJSON["Sequence"])
 		assert.Equal(t, "12", txJSON["Fee"])
+		assert.Equal(t, 0, mock.feeAutofillCallCount,
+			"GetAutofillFee must not run when Fee is supplied")
+		assert.Equal(t, 0, mock.seqAutofillCallCount,
+			"GetAutofillSequence must not run when Sequence is supplied")
 	})
 
 	t.Run("Sequence supplied skips GetAutofillSequence", func(t *testing.T) {
@@ -643,7 +649,7 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 			"caller-supplied TicketSequence is normalized to uint32 for downstream consumers")
 	})
 
-	t.Run("Source account not found maps to srcActMissing", func(t *testing.T) {
+	t.Run("Source account not found maps to srcActNotFound", func(t *testing.T) {
 		mock := newMockLedgerServiceSimulate()
 		mock.autofillSeqErr = svcerr.ErrAccountNotFound
 
@@ -659,6 +665,9 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcSRC_ACT_NOT_FOUND, rpcErr.Code)
+		assert.Equal(t, "srcActNotFound", rpcErr.ErrorString,
+			"rippled ErrorCodes.cpp:109 maps rpcSRC_ACT_NOT_FOUND to token 'srcActNotFound'")
+		assert.Equal(t, "Source account not found.", rpcErr.Message)
 	})
 
 	t.Run("HighFeeError maps to rpcHIGH_FEE with rippled-format message", func(t *testing.T) {
@@ -777,6 +786,147 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, "transactionSigned", rpcErr.ErrorString,
 			"signers[0] signed-check must fire before signers[1] structural error")
+	})
+
+	t.Run("txSigned precedes srcActMalformed (Account check deferred to Sequence step)", func(t *testing.T) {
+		// rippled checks Account validity inside getAutofillSequence
+		// (Simulate.cpp:43-55), AFTER the top-level TxnSignature signed-check
+		// at 129-138. A bad Account combined with a non-empty TxnSignature
+		// must therefore surface rpcTX_SIGNED, not rpcSRC_ACT_MALFORMED.
+		mock := newMockLedgerServiceSimulate()
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         "badAccount",
+				"TxnSignature":    "DEADBEEF",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "transactionSigned", rpcErr.ErrorString,
+			"signed-check fires before Account format check — rippled Simulate.cpp:129-138 vs 50-54")
+	})
+
+	t.Run("Sequence supplied + bad Account skips Account check", func(t *testing.T) {
+		// rippled only validates the Account string inside
+		// getAutofillSequence (Simulate.cpp:43-55), which is only reached
+		// when Sequence is absent. When the caller supplies Sequence, the
+		// handler must not reject on Account format.
+		mock := newMockLedgerServiceSimulate()
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         "badAccount",
+				"Sequence":        7,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.Nil(t, rpcErr, "Sequence supplied — handler must not run the Account check")
+		assert.Equal(t, 0, mock.seqAutofillCallCount,
+			"GetAutofillSequence must be skipped when Sequence is supplied")
+	})
+
+	t.Run("out-of-range Sequence is rejected as invalid_field", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+
+		// 2^33 — well within float64 precision, well outside uint32.
+		paramsJSON := []byte(`{"tx_json":{"TransactionType":"AccountSet","Account":"` +
+			validAccountAddress + `","Sequence":8589934592}}`)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code,
+			"out-of-range Sequence must surface invalid_field, not silent truncation")
+		assert.Equal(t, "Invalid field 'tx.Sequence'.", rpcErr.Message)
+	})
+
+	t.Run("fractional Sequence is rejected as invalid_field", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+
+		paramsJSON := []byte(`{"tx_json":{"TransactionType":"AccountSet","Account":"` +
+			validAccountAddress + `","Sequence":7.5}}`)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "Invalid field 'tx.Sequence'.", rpcErr.Message)
+	})
+
+	t.Run("Custom NetworkID > 1024 is autofilled", func(t *testing.T) {
+		// rippled Simulate.cpp:148-153: NetworkID is autofilled only when
+		// the server's NETWORK_ID exceeds 1024.
+		mock := newMockLedgerServiceSimulate()
+		mock.serverInfo = types.LedgerServerInfo{NetworkID: 1025}
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.Nil(t, rpcErr)
+		txJSON := result.(map[string]interface{})["tx_json"].(map[string]interface{})
+		assert.EqualValues(t, 1025, txJSON["NetworkID"])
+	})
+
+	t.Run("NetworkID <= 1024 is not autofilled", func(t *testing.T) {
+		mock := newMockLedgerServiceSimulate()
+		mock.serverInfo = types.LedgerServerInfo{NetworkID: 1024}
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.Nil(t, rpcErr)
+		txJSON := result.(map[string]interface{})["tx_json"].(map[string]interface{})
+		_, has := txJSON["NetworkID"]
+		assert.False(t, has, "NetworkID must be absent when server NetworkID <= 1024")
+	})
+
+	t.Run("non-tesSUCCESS engine_result_message passes through unchanged", func(t *testing.T) {
+		// rippled only overrides the message for tesSUCCESS
+		// (Simulate.cpp:258-262); other TER messages from transResultInfo
+		// must be returned verbatim.
+		mock := newMockLedgerServiceSimulate()
+		mock.simulateResult = &types.SubmitResult{
+			EngineResult:        "temBAD_AMOUNT",
+			EngineResultCode:    -298,
+			EngineResultMessage: "Malformed: Bad amount.",
+			Applied:             false,
+			CurrentLedger:       3,
+		}
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.Nil(t, rpcErr)
+		resp := result.(map[string]interface{})
+		assert.Equal(t, "Malformed: Bad amount.", resp["engine_result_message"],
+			"non-tesSUCCESS messages must not be clobbered by the success override")
 	})
 }
 

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -17,13 +17,15 @@ import (
 // mockLedgerServiceSimulate extends mockLedgerService with simulate-specific behavior.
 type mockLedgerServiceSimulate struct {
 	*mockLedgerService
-	simulateResult    *types.SubmitResult
-	simulateError     error
-	autofillSeq       uint32
-	autofillErr       error
-	currentNetworkFee uint64
-	lastNeedSequence  bool
-	autofillCallCount int
+	simulateResult       *types.SubmitResult
+	simulateError        error
+	autofillSeq          uint32
+	autofillFeeErr       error
+	autofillSeqErr       error
+	currentNetworkFee    uint64
+	lastSeqHasTicket     bool
+	feeAutofillCallCount int
+	seqAutofillCallCount int
 }
 
 func newMockLedgerServiceSimulate() *mockLedgerServiceSimulate {
@@ -48,16 +50,24 @@ func (m *mockLedgerServiceSimulate) SimulateTransaction(txJSON []byte) (*types.S
 	return m.simulateResult, nil
 }
 
-func (m *mockLedgerServiceSimulate) GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (uint32, uint64, error) {
-	m.lastNeedSequence = needSequence
-	m.autofillCallCount++
-	if m.autofillErr != nil {
-		return 0, 0, m.autofillErr
+func (m *mockLedgerServiceSimulate) GetAutofillFee(txJSON []byte) (uint64, error) {
+	m.feeAutofillCallCount++
+	if m.autofillFeeErr != nil {
+		return 0, m.autofillFeeErr
 	}
-	if !needSequence || hasTicketSequence {
-		return 0, m.currentNetworkFee, nil
+	return m.currentNetworkFee, nil
+}
+
+func (m *mockLedgerServiceSimulate) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
+	m.seqAutofillCallCount++
+	m.lastSeqHasTicket = hasTicketSequence
+	if m.autofillSeqErr != nil {
+		return 0, m.autofillSeqErr
 	}
-	return m.autofillSeq, m.currentNetworkFee, nil
+	if hasTicketSequence {
+		return 0, nil
+	}
+	return m.autofillSeq, nil
 }
 
 func newSimulateTestServices(mock *mockLedgerServiceSimulate) *types.ServiceContainer {
@@ -558,12 +568,11 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		assert.Equal(t, "12", txJSON["Fee"])
 	})
 
-	t.Run("Sequence supplied propagates needSequence=false to service", func(t *testing.T) {
+	t.Run("Sequence supplied skips GetAutofillSequence", func(t *testing.T) {
 		// rippled only invokes getAutofillSequence when Sequence is absent
-		// (Simulate.cpp:140-146); the handler must propagate needSequence=false
-		// so the service can skip the source-account lookup that would
-		// otherwise surface rpcSRC_ACT_NOT_FOUND for callers that supplied
-		// Sequence but not Fee.
+		// (Simulate.cpp:140-146); when the caller supplies Sequence, the
+		// handler must not perform the source-account lookup that would
+		// otherwise surface rpcSRC_ACT_NOT_FOUND.
 		mock := newMockLedgerServiceSimulate()
 		mock.currentNetworkFee = 17
 
@@ -584,12 +593,12 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 
 		assert.EqualValues(t, 9, txJSON["Sequence"], "caller-supplied Sequence preserved")
 		assert.Equal(t, "17", txJSON["Fee"], "Fee still autofilled")
-		assert.Equal(t, 1, mock.autofillCallCount, "GetAutofill invoked exactly once")
-		assert.False(t, mock.lastNeedSequence,
-			"needSequence must be false when caller supplied Sequence")
+		assert.Equal(t, 1, mock.feeAutofillCallCount, "GetAutofillFee invoked once")
+		assert.Equal(t, 0, mock.seqAutofillCallCount,
+			"GetAutofillSequence must not run when Sequence is supplied")
 	})
 
-	t.Run("Sequence absent propagates needSequence=true to service", func(t *testing.T) {
+	t.Run("Sequence absent invokes GetAutofillSequence", func(t *testing.T) {
 		mock := newMockLedgerServiceSimulate()
 
 		params := map[string]interface{}{
@@ -603,11 +612,12 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 
 		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
 		require.Nil(t, rpcErr)
-		assert.True(t, mock.lastNeedSequence,
-			"needSequence must be true when caller omitted Sequence")
+		assert.Equal(t, 1, mock.seqAutofillCallCount,
+			"GetAutofillSequence must run when Sequence is absent")
+		assert.False(t, mock.lastSeqHasTicket)
 	})
 
-	t.Run("TicketSequence writes Sequence=0", func(t *testing.T) {
+	t.Run("TicketSequence writes Sequence=0 and propagates hasTicket", func(t *testing.T) {
 		mock := newMockLedgerServiceSimulate()
 		mock.autofillSeq = 99
 
@@ -628,11 +638,14 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 
 		assert.Equal(t, uint32(0), txJSON["Sequence"],
 			"rippled Simulate.cpp:68,140-146 writes Sequence=0 when TicketSequence is set")
+		assert.True(t, mock.lastSeqHasTicket, "hasTicketSequence must propagate to the service")
+		assert.Equal(t, uint32(5), txJSON["TicketSequence"],
+			"caller-supplied TicketSequence is normalized to uint32 for downstream consumers")
 	})
 
 	t.Run("Source account not found maps to srcActMissing", func(t *testing.T) {
 		mock := newMockLedgerServiceSimulate()
-		mock.autofillErr = svcerr.ErrAccountNotFound
+		mock.autofillSeqErr = svcerr.ErrAccountNotFound
 
 		params := map[string]interface{}{
 			"tx_json": map[string]interface{}{
@@ -648,9 +661,9 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		assert.Equal(t, types.RpcSRC_ACT_NOT_FOUND, rpcErr.Code)
 	})
 
-	t.Run("ErrHighFee maps to rpcHIGH_FEE with stripped wrap prefix", func(t *testing.T) {
+	t.Run("HighFeeError maps to rpcHIGH_FEE with rippled-format message", func(t *testing.T) {
 		mock := newMockLedgerServiceSimulate()
-		mock.autofillErr = fmt.Errorf("%w: Fee of 5000 exceeds the requested tx limit of 100", svcerr.ErrHighFee)
+		mock.autofillFeeErr = &svcerr.HighFeeError{Fee: 5000, Limit: 100}
 
 		params := map[string]interface{}{
 			"tx_json": map[string]interface{}{
@@ -665,12 +678,33 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, "highFee", rpcErr.ErrorString)
 		assert.Equal(t, "Fee of 5000 exceeds the requested tx limit of 100", rpcErr.Message,
-			"rippled TransactionSign.cpp:870-873 emits the unwrapped 'Fee of X exceeds…' message")
+			"rippled TransactionSign.cpp:870-873 emits the 'Fee of X exceeds…' message verbatim")
+	})
+
+	t.Run("HighFeeError via wrapped sentinel still errors.As-extracts", func(t *testing.T) {
+		// Defence-in-depth: a service that wraps the typed error via fmt.Errorf
+		// "%w" must still be recoverable by errors.As in the handler.
+		mock := newMockLedgerServiceSimulate()
+		mock.autofillFeeErr = fmt.Errorf("autofill: %w", &svcerr.HighFeeError{Fee: 5000, Limit: 100})
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "highFee", rpcErr.ErrorString)
+		assert.Equal(t, "Fee of 5000 exceeds the requested tx limit of 100", rpcErr.Message)
 	})
 
 	t.Run("highFee precedes txSigned when both inputs conflict", func(t *testing.T) {
 		mock := newMockLedgerServiceSimulate()
-		mock.autofillErr = fmt.Errorf("%w: Fee of 5000 exceeds the requested tx limit of 100", svcerr.ErrHighFee)
+		mock.autofillFeeErr = &svcerr.HighFeeError{Fee: 5000, Limit: 100}
 
 		params := map[string]interface{}{
 			"tx_json": map[string]interface{}{
@@ -686,6 +720,63 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, "highFee", rpcErr.ErrorString,
 			"rippled autofillTx runs Fee before the TxnSignature signed-check (Simulate.cpp:74-138)")
+	})
+
+	t.Run("txSigned precedes srcActNotFound (signed-check before Sequence autofill)", func(t *testing.T) {
+		// rippled autofillTx runs the top-level TxnSignature signed-check at
+		// Simulate.cpp:129-138, BEFORE the Sequence autofill at 140-146. So a
+		// request with a non-empty TxnSignature and a missing source account
+		// must surface rpcTX_SIGNED, not rpcSRC_ACT_NOT_FOUND.
+		mock := newMockLedgerServiceSimulate()
+		mock.autofillSeqErr = svcerr.ErrAccountNotFound
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"TxnSignature":    "DEADBEEF",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "transactionSigned", rpcErr.ErrorString,
+			"signed-check fires before Sequence autofill — rippled Simulate.cpp:129-146")
+		assert.Equal(t, 0, mock.seqAutofillCallCount,
+			"GetAutofillSequence must not run once the signed-check has rejected")
+	})
+
+	t.Run("Signers signed-check precedes later signer's structural error", func(t *testing.T) {
+		// rippled's autofillTx Signers loop interleaves structural and
+		// signed-checks per-iteration (Simulate.cpp:97-127), so a signed
+		// TxnSignature on signers[0] fires rpcTX_SIGNED before signers[2]'s
+		// structural error is reached.
+		mock := newMockLedgerServiceSimulate()
+
+		params := map[string]interface{}{
+			"tx_json": map[string]interface{}{
+				"TransactionType": "AccountSet",
+				"Account":         validAccountAddress,
+				"Signers": []interface{}{
+					map[string]interface{}{
+						"Signer": map[string]interface{}{
+							"Account":      validAccountAddress,
+							"TxnSignature": "DEADBEEF",
+						},
+					},
+					"not-an-object",
+				},
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(makeCtx(mock), paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "transactionSigned", rpcErr.ErrorString,
+			"signers[0] signed-check must fire before signers[1] structural error")
 	})
 }
 

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -18,7 +18,7 @@ type mockLedgerServiceSimulate struct {
 	simulateResult    *types.SubmitResult
 	simulateError     error
 	autofillSeq       uint32
-	autofillSeqErr    error
+	autofillErr       error
 	currentNetworkFee uint64
 }
 
@@ -44,18 +44,14 @@ func (m *mockLedgerServiceSimulate) SimulateTransaction(txJSON []byte) (*types.S
 	return m.simulateResult, nil
 }
 
-func (m *mockLedgerServiceSimulate) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	if m.autofillSeqErr != nil {
-		return 0, m.autofillSeqErr
+func (m *mockLedgerServiceSimulate) GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (uint32, uint64, error) {
+	if m.autofillErr != nil {
+		return 0, 0, m.autofillErr
 	}
 	if hasTicketSequence {
-		return 0, nil
+		return 0, m.currentNetworkFee, nil
 	}
-	return m.autofillSeq, nil
-}
-
-func (m *mockLedgerServiceSimulate) GetCurrentNetworkFee() uint64 {
-	return m.currentNetworkFee
+	return m.autofillSeq, m.currentNetworkFee, nil
 }
 
 func newSimulateTestServices(mock *mockLedgerServiceSimulate) *types.ServiceContainer {
@@ -581,7 +577,7 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 
 	t.Run("Source account not found maps to srcActMissing", func(t *testing.T) {
 		mock := newMockLedgerServiceSimulate()
-		mock.autofillSeqErr = svcerr.ErrAccountNotFound
+		mock.autofillErr = svcerr.ErrAccountNotFound
 
 		params := map[string]interface{}{
 			"tx_json": map[string]interface{}{

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -563,8 +563,7 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		// (Simulate.cpp:140-146); the handler must propagate needSequence=false
 		// so the service can skip the source-account lookup that would
 		// otherwise surface rpcSRC_ACT_NOT_FOUND for callers that supplied
-		// Sequence but not Fee. The behavioural test for the skip itself
-		// lives in internal/ledger/service/tx_query_test.go.
+		// Sequence but not Fee.
 		mock := newMockLedgerServiceSimulate()
 		mock.currentNetworkFee = 17
 

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -552,7 +552,7 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		assert.Equal(t, "12", txJSON["Fee"])
 	})
 
-	t.Run("TicketSequence skips Sequence autofill", func(t *testing.T) {
+	t.Run("TicketSequence writes Sequence=0", func(t *testing.T) {
 		mock := newMockLedgerServiceSimulate()
 		mock.autofillSeq = 99
 
@@ -571,8 +571,8 @@ func TestSimulateMethod_SequenceFeeAutofill(t *testing.T) {
 		resp := result.(map[string]interface{})
 		txJSON := resp["tx_json"].(map[string]interface{})
 
-		_, hasSeq := txJSON["Sequence"]
-		assert.False(t, hasSeq, "Sequence must stay absent when TicketSequence is present")
+		assert.Equal(t, uint32(0), txJSON["Sequence"],
+			"rippled Simulate.cpp:68,140-146 writes Sequence=0 when TicketSequence is set")
 	})
 
 	t.Run("Source account not found maps to srcActMissing", func(t *testing.T) {

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -3,12 +3,17 @@ package types
 // XRPL RPC Error Codes - matching rippled implementation
 // These error codes must match exactly with rippled for protocol compatibility
 
-// RpcError represents an XRPL RPC error with code and message
+// RpcError represents an XRPL RPC error with code and message.
+//
+// ErrorException carries the rippled-style "error_exception" envelope
+// used when STTx construction throws (Simulate.cpp:338-342). Only the
+// `simulate` invalidTransaction path populates it today.
 type RpcError struct {
-	Code        int    `json:"error_code"`
-	ErrorString string `json:"error"`
-	Type        string `json:"type"`
-	Message     string `json:"error_message,omitempty"`
+	Code           int    `json:"error_code"`
+	ErrorString    string `json:"error"`
+	Type           string `json:"type"`
+	Message        string `json:"error_message,omitempty"`
+	ErrorException string `json:"error_exception,omitempty"`
 }
 
 func (e RpcError) Error() string {
@@ -319,6 +324,22 @@ func RpcErrorSrcActMissing(message string) *RpcError {
 // "srcActNotFound"; see rippled ErrorCodes.cpp:109).
 func RpcErrorSrcActNotFound(message string) *RpcError {
 	return NewRpcError(RpcSRC_ACT_NOT_FOUND, "srcActNotFound", "srcActNotFound", message)
+}
+
+// RpcErrorInvalidTransaction returns the envelope rippled emits when STTx
+// construction throws (Simulate.cpp:338-342): `error: "invalidTransaction"`
+// + `error_exception: <reason>`. The error_code matches rippled's
+// behaviour of leaving the field at the default rpcINVALID_PARAMS slot
+// (the manual `jvResult[jss::error] = "invalidTransaction"` path does
+// not go through `RPC::make_error`, so callers should not depend on the
+// code value).
+func RpcErrorInvalidTransaction(exception string) *RpcError {
+	return &RpcError{
+		Code:           RpcINVALID_PARAMS,
+		ErrorString:    "invalidTransaction",
+		Type:           "invalidTransaction",
+		ErrorException: exception,
+	}
 }
 
 // RpcErrorSrcCurMalformed returns an error when a source currency is malformed

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -314,6 +314,13 @@ func RpcErrorSrcActMissing(message string) *RpcError {
 	return NewRpcError(RpcSRC_ACT_NOT_FOUND, "srcActMissing", "srcActMissing", message)
 }
 
+// RpcErrorSrcActNotFound returns an error when the source account does not
+// exist in the ledger (matches rippled rpcSRC_ACT_NOT_FOUND, code 67, token
+// "srcActNotFound"; see rippled ErrorCodes.cpp:109).
+func RpcErrorSrcActNotFound(message string) *RpcError {
+	return NewRpcError(RpcSRC_ACT_NOT_FOUND, "srcActNotFound", "srcActNotFound", message)
+}
+
 // RpcErrorSrcCurMalformed returns an error when a source currency is malformed
 // (matches rippled "srcCurMalformed").
 func RpcErrorSrcCurMalformed(message string) *RpcError {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -272,12 +272,14 @@ type TransactionSubmitter interface {
 	GetTransactionHistory(ctx context.Context, startIndex uint32) (*TxHistoryResult, error)
 
 	// GetAutofill returns Sequence and Fee read under one lock so they
-	// observe a consistent ledger snapshot. Sequence is 0 when
-	// hasTicketSequence is true. Fee includes per-tx-type adjustments
-	// (multisign, AccountDelete, AMMCreate, LedgerStateFix). Mirrors
-	// rippled Simulate.cpp getAutofillSequence + TransactionSign.cpp
-	// getCurrentNetworkFee.
-	GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (sequence uint32, fee uint64, err error)
+	// observe a consistent ledger snapshot. When needSequence is false
+	// the source-account lookup is skipped and Sequence is returned as
+	// 0 — matching rippled's autofillTx, which only invokes
+	// getAutofillSequence when tx_json.Sequence is absent
+	// (Simulate.cpp:140-146). Sequence is also 0 when hasTicketSequence
+	// is true. Fee includes per-tx-type adjustments (multisign,
+	// AccountDelete, AMMCreate, LedgerStateFix).
+	GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (sequence uint32, fee uint64, err error)
 }
 
 // AccountQuerier provides account-related read operations.

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -277,7 +277,7 @@ type TransactionSubmitter interface {
 	// (multisign, AccountDelete, AMMCreate, LedgerStateFix). Mirrors
 	// rippled Simulate.cpp getAutofillSequence + TransactionSign.cpp
 	// getCurrentNetworkFee.
-	GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (sequence uint32, fee uint64, err error)
+	GetAutofill(account string, hasTicketSequence bool, txJSON []byte) (sequence uint32, fee uint64, err error)
 }
 
 // AccountQuerier provides account-related read operations.

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -271,13 +271,12 @@ type TransactionSubmitter interface {
 	StoreTransaction(txHash [32]byte, txData []byte) error
 	GetTransactionHistory(ctx context.Context, startIndex uint32) (*TxHistoryResult, error)
 
-	// GetAutofill returns the next Sequence (0 when hasTicketSequence) and
-	// the fee in drops a transaction must carry to bypass the TxQ and
-	// enter the current open ledger. Both values are read under one lock.
-	// The fee includes per-tx-type adjustments (multisign, AccountDelete,
-	// AMMCreate, LedgerStateFix); isUnlimited skips the rpcHIGH_FEE
-	// ceiling. Mirrors rippled Simulate.cpp getAutofillSequence and
-	// TransactionSign.cpp getCurrentNetworkFee combined.
+	// GetAutofill returns Sequence and Fee read under one lock so they
+	// observe a consistent ledger snapshot. Sequence is 0 when
+	// hasTicketSequence is true. Fee includes per-tx-type adjustments
+	// (multisign, AccountDelete, AMMCreate, LedgerStateFix). Mirrors
+	// rippled Simulate.cpp getAutofillSequence + TransactionSign.cpp
+	// getCurrentNetworkFee.
 	GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (sequence uint32, fee uint64, err error)
 }
 
@@ -475,21 +474,14 @@ type SubmitResult struct {
 	// ValidatedLedger is the highest validated ledger sequence
 	ValidatedLedger uint32
 
-	// Metadata holds simulation metadata when available, so the simulate
-	// handler can render it as either `meta` (JSON) or `meta_blob` (hex).
-	// Nil when the transaction produced no metadata.
+	// Metadata is nil when the transaction produced no metadata.
 	Metadata *SubmitMetadata
 }
 
-// SubmitMetadata carries simulation metadata in both JSON-ready and
-// binary-serialized forms so the simulate handler can choose between
-// `meta` and `meta_blob` based on the caller's `binary` flag.
+// SubmitMetadata carries simulation metadata in JSON and binary form
+// so the simulate handler can render either `meta` or `meta_blob`.
 type SubmitMetadata struct {
-	// JSON is a json.Marshal-able representation of the metadata
-	// (typically a map[string]any or json.RawMessage).
 	JSON any
-	// Blob is the binary-serialized metadata. The simulate handler
-	// hex-encodes it for the `meta_blob` field.
 	Blob []byte
 }
 

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -270,6 +270,16 @@ type TransactionSubmitter interface {
 	GetTransaction(txHash [32]byte) (*TransactionInfo, error)
 	StoreTransaction(txHash [32]byte, txData []byte) error
 	GetTransactionHistory(ctx context.Context, startIndex uint32) (*TxHistoryResult, error)
+
+	// GetAutofillSequence returns the next sequence to use for an account.
+	// When hasTicketSequence is true the account may be missing and 0 is returned.
+	// Mirrors rippled Simulate.cpp getAutofillSequence().
+	GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error)
+
+	// GetCurrentNetworkFee returns the fee in drops needed to bypass the
+	// TxQ and enter the current open ledger. Mirrors rippled
+	// TransactionSign.cpp getCurrentNetworkFee().
+	GetCurrentNetworkFee() uint64
 }
 
 // AccountQuerier provides account-related read operations.
@@ -465,6 +475,23 @@ type SubmitResult struct {
 
 	// ValidatedLedger is the highest validated ledger sequence
 	ValidatedLedger uint32
+
+	// Metadata holds simulation metadata when available, so the simulate
+	// handler can render it as either `meta` (JSON) or `meta_blob` (hex).
+	// Nil when the transaction produced no metadata.
+	Metadata *SubmitMetadata
+}
+
+// SubmitMetadata carries simulation metadata in both JSON-ready and
+// binary-serialized forms so the simulate handler can choose between
+// `meta` and `meta_blob` based on the caller's `binary` flag.
+type SubmitMetadata struct {
+	// JSON is a json.Marshal-able representation of the metadata
+	// (typically a map[string]any or json.RawMessage).
+	JSON any
+	// Blob is the binary-serialized metadata. The simulate handler
+	// hex-encodes it for the `meta_blob` field.
+	Blob []byte
 }
 
 // Accepted returns true if any submission state is true, matching

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -271,15 +271,14 @@ type TransactionSubmitter interface {
 	StoreTransaction(txHash [32]byte, txData []byte) error
 	GetTransactionHistory(ctx context.Context, startIndex uint32) (*TxHistoryResult, error)
 
-	// GetAutofillSequence returns the next sequence to use for an account.
-	// When hasTicketSequence is true the account may be missing and 0 is returned.
-	// Mirrors rippled Simulate.cpp getAutofillSequence().
-	GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error)
-
-	// GetCurrentNetworkFee returns the fee in drops needed to bypass the
-	// TxQ and enter the current open ledger. Mirrors rippled
-	// TransactionSign.cpp getCurrentNetworkFee().
-	GetCurrentNetworkFee() uint64
+	// GetAutofill returns the next Sequence (0 when hasTicketSequence) and
+	// the fee in drops a transaction must carry to bypass the TxQ and
+	// enter the current open ledger. Both values are read under one lock.
+	// The fee includes per-tx-type adjustments (multisign, AccountDelete,
+	// AMMCreate, LedgerStateFix); isUnlimited skips the rpcHIGH_FEE
+	// ceiling. Mirrors rippled Simulate.cpp getAutofillSequence and
+	// TransactionSign.cpp getCurrentNetworkFee combined.
+	GetAutofill(account string, hasTicketSequence bool, txJSON []byte, isUnlimited bool) (sequence uint32, fee uint64, err error)
 }
 
 // AccountQuerier provides account-related read operations.

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -271,15 +271,23 @@ type TransactionSubmitter interface {
 	StoreTransaction(txHash [32]byte, txData []byte) error
 	GetTransactionHistory(ctx context.Context, startIndex uint32) (*TxHistoryResult, error)
 
-	// GetAutofill returns Sequence and Fee read under one lock so they
-	// observe a consistent ledger snapshot. When needSequence is false
-	// the source-account lookup is skipped and Sequence is returned as
-	// 0 — matching rippled's autofillTx, which only invokes
-	// getAutofillSequence when tx_json.Sequence is absent
-	// (Simulate.cpp:140-146). Sequence is also 0 when hasTicketSequence
-	// is true. Fee includes per-tx-type adjustments (multisign,
-	// AccountDelete, AMMCreate, LedgerStateFix).
-	GetAutofill(account string, needSequence, hasTicketSequence bool, txJSON []byte) (sequence uint32, fee uint64, err error)
+	// GetAutofillFee returns the Fee a transaction should carry to enter
+	// the open ledger. Mirrors rippled getCurrentNetworkFee
+	// (TransactionSign.cpp:839-877): max(feeDefault, escalatedFee) with a
+	// feeDefault * mult / div ceiling. On ceiling overflow handlers map
+	// to rpcINTERNAL; on exceedance the returned error is a
+	// *svcerr.HighFeeError (errors.Is(svcerr.ErrHighFee) also matches).
+	// Includes per-tx-type adjustments (multisign, AccountDelete,
+	// AMMCreate, LedgerStateFix). Never reads the source account.
+	GetAutofillFee(txJSON []byte) (fee uint64, err error)
+
+	// GetAutofillSequence returns the Sequence a transaction should
+	// carry. Mirrors rippled getAutofillSequence (Simulate.cpp:37-69):
+	// returns 0 when hasTicketSequence is true; otherwise reads the
+	// account SLE and consults TxQ.NextQueuableSeq. Returns
+	// svcerr.ErrAccountNotFound when the account is absent and no ticket
+	// supersedes the requirement.
+	GetAutofillSequence(account string, hasTicketSequence bool) (sequence uint32, err error)
 }
 
 // AccountQuerier provides account-related read operations.


### PR DESCRIPTION
## Summary
- Wires `Sequence` and `Fee` autofill in the `simulate` RPC handler via new `GetAutofillSequence` / `GetCurrentNetworkFee` service helpers — bare `tx_json` calls no longer return a malformed-tx error.
- Adds simulation metadata to the response: `meta` (JSON object) when `binary=false`, `meta_blob` (uppercase hex) when `binary=true`, mirroring rippled `Simulate.cpp` lines 264-276.
- Overrides the `tesSUCCESS` engine message to rippled's literal "The simulated transaction would have been applied." (`Simulate.cpp` lines 258-262).

## Implementation notes
- `service.GetAutofillSequence` reads the account SLE from the open ledger and consults `TxQ.NextQueuableSeq`; returns `svcerr.ErrAccountNotFound` when missing (mapped to `rpcSRC_ACT_NOT_FOUND` in the handler). `TicketSequence` short-circuits to `0` and tolerates a missing account.
- `service.GetCurrentNetworkFee` returns `max(baseFee, toDrops(openLedgerFeeLevel - 1, baseFee) + 1)`, matching `getCurrentNetworkFee` in `TransactionSign.cpp`. Per-tx-type multipliers (multisign, AccountDelete) are not applied — callers needing exact parity should set `Fee` explicitly.
- `types.SubmitResult` gained a `*SubmitMetadata{JSON, Blob}` carrier so the rpc/types package stays free of `internal/tx` imports; the adapter populates it via `tx.SerializeMetadata`.

## Test plan
- [x] `go test ./internal/rpc/... ./internal/ledger/service/...`
- [x] `go vet ./internal/rpc/... ./internal/ledger/service/...`
- [x] New unit tests cover sequence/fee autofill, TicketSequence skip, srcActNotFound mapping, and meta vs meta_blob output.

Fixes #483