### PR TITLE
fix: reset roundStartTime at open→establish

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1902,6 +1902,14 @@ func (e *Engine) closeLedger() {
 	closeTime := e.adaptor.Now()
 	e.state.CloseTimes.Self = closeTime
 
+	// Reset the round-time clock at open→establish so prevRoundTime and the
+	// roundTime consumers in phaseEstablish (shouldPause, MIN_CONSENSUS gate,
+	// abandonDeadlineExceeded, convergePercent) measure only the establish
+	// phase — mirrors rippled's result_->roundTime.reset(clock_.now()) in
+	// Consensus.h:1446, placed before propose/createDisputes. Wall-clock
+	// rationale at line 571 still applies.
+	e.roundStartTime = time.Now()
+
 	// If proposing, create and broadcast our proposal
 	if e.mode == consensus.ModeProposing {
 		nodeID, err := e.adaptor.GetValidatorKey()
@@ -1961,13 +1969,6 @@ func (e *Engine) closeLedger() {
 		requested[p.TxSet] = struct{}{}
 		e.adaptor.RequestTxSet(p.TxSet)
 	}
-
-	// Reset the round-time clock at open→establish so prevRoundTime and the
-	// roundTime consumers in phaseEstablish (shouldPause, MIN_CONSENSUS gate,
-	// abandonDeadlineExceeded, convergePercent) measure only the establish
-	// phase — mirrors rippled's result_->roundTime.reset(clock_.now()) in
-	// Consensus.h:1446. Wall-clock rationale at line 571 still applies.
-	e.roundStartTime = time.Now()
 
 	// Move to establish phase
 	e.setPhase(consensus.PhaseEstablish)

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1962,6 +1962,13 @@ func (e *Engine) closeLedger() {
 		e.adaptor.RequestTxSet(p.TxSet)
 	}
 
+	// Reset the round-time clock at open→establish so prevRoundTime and the
+	// roundTime consumers in phaseEstablish (shouldPause, MIN_CONSENSUS gate,
+	// abandonDeadlineExceeded, convergePercent) measure only the establish
+	// phase — mirrors rippled's result_->roundTime.reset(clock_.now()) in
+	// Consensus.h:1446. Wall-clock rationale at line 571 still applies.
+	e.roundStartTime = time.Now()
+
 	// Move to establish phase
 	e.setPhase(consensus.PhaseEstablish)
 }


### PR DESCRIPTION
## Summary
- `closeLedger()` now resets `e.roundStartTime` right before transitioning to `PhaseEstablish`, mirroring rippled's `result_->roundTime.reset(clock_.now())` at `Consensus.h:1446`.
- Without this reset, `prevRoundTime` (exposed via `server_info.last_close.converge_time_s`) and the `roundTime` consumers in `phaseEstablish` (`shouldPause`, `ledgerMIN_CONSENSUS` gate, `abandonDeadlineExceeded`, `convergePercent` weighting) include the open phase, causing goXRPL to report ~1 s higher than rippled and subtly shifting convergence/timeout behavior.
- Wall-clock `time.Now()` is used (not `e.adaptor.Now()`) for the same reason documented at `engine.go:571–579`.

## Test plan
- [x] `just build`
- [x] `just test-pkg ./internal/consensus/rcl/...`
- [ ] Live network: compare `server_info.last_close.converge_time_s` against a rippled peer on the same network and confirm parity.

Fixes #490