### PR TITLE
fix(invariants): close 5 audit-derived rippled gaps

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -492,6 +492,12 @@ func (l *Ledger) Rules() *amendment.Rules {
 	return nil
 }
 
+// LedgerSeq returns the current ledger's sequence number.
+// Reference: rippled ReadView::seq().
+func (l *Ledger) LedgerSeq() uint32 {
+	return l.Sequence()
+}
+
 // Close closes the ledger, making it immutable
 func (l *Ledger) Close(closeTime time.Time, closeFlags uint8) error {
 	l.mu.Lock()

--- a/internal/ledger/service/snapshot_view.go
+++ b/internal/ledger/service/snapshot_view.go
@@ -79,3 +79,10 @@ func (v *snapshotView) TxExists(txID [32]byte) bool {
 func (v *snapshotView) Rules() *amendment.Rules {
 	return nil
 }
+
+func (v *snapshotView) LedgerSeq() uint32 {
+	if v.ledger == nil {
+		return 0
+	}
+	return v.ledger.Sequence()
+}

--- a/internal/ledger/state/account_root.go
+++ b/internal/ledger/state/account_root.go
@@ -37,6 +37,14 @@ type AccountRoot struct {
 	PreviousTxnLgrSeq    uint32
 }
 
+// IsPseudoAccount reports whether this AccountRoot is a pseudo-account, mirroring
+// rippled's isPseudoAccount (View.cpp:1138) which tests whether any of the
+// pseudo-account owner fields (sfAMMID, sfVaultID) is present. goXRPL currently
+// surfaces only AMMID on AccountRoot; VaultID will land alongside featureSingleAssetVault.
+func (a *AccountRoot) IsPseudoAccount() bool {
+	return a != nil && a.AMMID != [32]byte{}
+}
+
 // Field type codes (exported for use by parent tx/ package)
 const (
 	FieldTypeUInt16    = 1
@@ -109,9 +117,10 @@ const (
 	// destination balance and payment amount are at or below the base reserve
 	LsfDepositAuth uint32 = 0x01000000
 
-	// LsfAMM indicates the account is an AMM (pseudo-account)
-	// AMM accounts cannot receive direct payments
-	LsfAMM uint32 = 0x02000000
+	// Bit 0x02000000 is intentionally not reserved. Rippled uses it for
+	// lsfTshCollect (hooks amendment) and lsfLowDeepFreeze (RippleState);
+	// pseudo-account detection in goXRPL uses sfAMMID/sfVaultID presence
+	// (AccountRoot.IsPseudoAccount), matching rippled's isPseudoAccount.
 
 	// LsfDisallowIncomingNFTokenOffer disallows incoming NFToken offers
 	LsfDisallowIncomingNFTokenOffer uint32 = 0x04000000

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -319,6 +319,7 @@ type LedgerStateView interface {
 	AdjustDropsDestroyed(d drops.XRPAmount)
 	TxExists(txID [32]byte) bool
 	Rules() *amendment.Rules
+	LedgerSeq() uint32
 }
 
 // DepositAuthorizedResult contains the result of deposit_authorized RPC

--- a/internal/testing/amm/amm_payment_test.go
+++ b/internal/testing/amm/amm_payment_test.go
@@ -293,11 +293,11 @@ func TestAMMFlags(t *testing.T) {
 		t.Fatal("AMM account not found in ledger")
 	}
 
-	// rippled sets lsfDisableMaster | lsfDefaultRipple | lsfDepositAuth.
-	// goXRPL additionally sets LsfAMM for fast pseudo-account detection.
-	expectedFlags := state.LsfDisableMaster | state.LsfDefaultRipple | state.LsfDepositAuth | state.LsfAMM
+	// rippled sets exactly lsfDisableMaster | lsfDefaultRipple | lsfDepositAuth
+	// on AMM pseudo-accounts (View.cpp:1128-1129).
+	expectedFlags := state.LsfDisableMaster | state.LsfDefaultRipple | state.LsfDepositAuth
 	if info.Flags != expectedFlags {
-		t.Fatalf("AMM account flags mismatch: got 0x%08X, want 0x%08X (lsfDisableMaster|lsfDefaultRipple|lsfDepositAuth|lsfAMM)",
+		t.Fatalf("AMM account flags mismatch: got 0x%08X, want 0x%08X (lsfDisableMaster|lsfDefaultRipple|lsfDepositAuth)",
 			info.Flags, expectedFlags)
 	}
 }
@@ -399,7 +399,7 @@ func TestAMMID(t *testing.T) {
 		t.Fatal("AMM account not found in ledger")
 	}
 
-	expectedFlags := state.LsfDisableMaster | state.LsfDefaultRipple | state.LsfDepositAuth | state.LsfAMM
+	expectedFlags := state.LsfDisableMaster | state.LsfDefaultRipple | state.LsfDepositAuth
 	if info.Flags != expectedFlags {
 		t.Fatalf("AMM account flags mismatch: got 0x%08X, want 0x%08X",
 			info.Flags, expectedFlags)

--- a/internal/tx/amm/amm_create.go
+++ b/internal/tx/amm/amm_create.go
@@ -246,10 +246,9 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled View.cpp createPseudoAccount (line 1112-1133).
 	// Sequence: 0 when featureSingleAssetVault is enabled, else the current
 	// ledger sequence — mirrors the seqno selection at View.cpp:1120-1123.
-	// goXRPL also sets LsfAMM as a fast-lookup flag (a non-rippled addition);
-	// the ValidNewAccountRoot flag-mask check is itself gated on
-	// featureSingleAssetVault, so this addition stays dormant until that
-	// amendment is active.
+	// Flags: exactly the three bits rippled sets at View.cpp:1128-1129.
+	// Pseudo-account identification is by AMMID presence (state.AccountRoot.IsPseudoAccount),
+	// matching rippled's isPseudoAccount (View.cpp:1138-1150).
 	var pseudoSeq uint32
 	if !ctx.Rules().Enabled(amendment.FeatureSingleAssetVault) {
 		pseudoSeq = ctx.Config.LedgerSequence
@@ -259,7 +258,7 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		Balance:    0,
 		Sequence:   pseudoSeq,
 		OwnerCount: 1, // For the AMM entry itself
-		Flags:      state.LsfDisableMaster | state.LsfDefaultRipple | state.LsfDepositAuth | state.LsfAMM,
+		Flags:      state.LsfDisableMaster | state.LsfDefaultRipple | state.LsfDepositAuth,
 		AMMID:      ammKey.Key, // Links pseudo-account to AMM entry (rippled View.cpp:1131)
 	}
 
@@ -607,8 +606,8 @@ func isLPToken(view tx.LedgerView, amount tx.Amount) bool {
 		return false
 	}
 
-	// AMM accounts have the lsfAMM flag set
-	return (issuerAccount.Flags & state.LsfAMM) != 0
+	// AMM pseudo-accounts are identified by the sfAMMID field (rippled View.cpp:1138 isPseudoAccount).
+	return issuerAccount.IsPseudoAccount()
 }
 
 // sortAssets returns assets and amounts in canonical order (minmax).

--- a/internal/tx/amm/amm_create.go
+++ b/internal/tx/amm/amm_create.go
@@ -243,14 +243,21 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		lptCurrency, ammAccountAddr)
 
 	// Create the AMM pseudo-account.
-	// Reference: rippled View.cpp createPseudoAccount (line 1112-1133)
-	// Ignore reserves requirement, disable the master key, allow default
-	// rippling, and enable deposit authorization to prevent payments into
-	// pseudo-account. Also set LsfAMM for fast AMM account detection.
+	// Reference: rippled View.cpp createPseudoAccount (line 1112-1133).
+	// Sequence: 0 when featureSingleAssetVault is enabled, else the current
+	// ledger sequence — mirrors the seqno selection at View.cpp:1120-1123.
+	// goXRPL also sets LsfAMM as a fast-lookup flag (a non-rippled addition);
+	// the ValidNewAccountRoot flag-mask check is itself gated on
+	// featureSingleAssetVault, so this addition stays dormant until that
+	// amendment is active.
+	var pseudoSeq uint32
+	if !ctx.Rules().Enabled(amendment.FeatureSingleAssetVault) {
+		pseudoSeq = ctx.Config.LedgerSequence
+	}
 	ammAccount := &state.AccountRoot{
 		Account:    ammAccountAddr,
 		Balance:    0,
-		Sequence:   0,
+		Sequence:   pseudoSeq,
 		OwnerCount: 1, // For the AMM entry itself
 		Flags:      state.LsfDisableMaster | state.LsfDefaultRipple | state.LsfDepositAuth | state.LsfAMM,
 		AMMID:      ammKey.Key, // Links pseudo-account to AMM entry (rippled View.cpp:1131)

--- a/internal/tx/apply_context.go
+++ b/internal/tx/apply_context.go
@@ -115,16 +115,15 @@ func (ctx *ApplyContext) LookupAccount(account string) (*state.AccountRoot, [20]
 }
 
 // LookupDestination loads and parses a destination account.
-// In addition to LookupAccount checks, it also rejects pseudo-accounts (LsfAMM).
-// Reference: rippled's common preclaim pattern for destination accounts.
+// In addition to LookupAccount checks, it also rejects pseudo-accounts
+// (AMM / Vault), matching rippled's isPseudoAccount test (View.cpp:1138).
 func (ctx *ApplyContext) LookupDestination(account string) (*state.AccountRoot, [20]byte, Result) {
 	dest, destID, result := ctx.LookupAccount(account)
 	if result != TesSUCCESS {
 		return nil, destID, result
 	}
 
-	// Pseudo-accounts (AMM) cannot be destinations
-	if (dest.Flags & state.LsfAMM) != 0 {
+	if dest.IsPseudoAccount() {
 		return nil, destID, TecNO_PERMISSION
 	}
 

--- a/internal/tx/apply_state_table.go
+++ b/internal/tx/apply_state_table.go
@@ -604,6 +604,12 @@ func (t *ApplyStateTable) Rules() *amendment.Rules {
 	return t.rules
 }
 
+// LedgerSeq returns the building ledger's sequence number.
+// Reference: rippled ReadView::seq().
+func (t *ApplyStateTable) LedgerSeq() uint32 {
+	return t.txSeq
+}
+
 // DropsDestroyed returns the amount of XRP destroyed
 func (t *ApplyStateTable) DropsDestroyed() drops.XRPAmount {
 	return t.drops

--- a/internal/tx/apply_state_table_test.go
+++ b/internal/tx/apply_state_table_test.go
@@ -49,6 +49,8 @@ func (m *mockBaseView) TxExists([32]byte) bool { return false }
 
 func (m *mockBaseView) Rules() *amendment.Rules { return nil }
 
+func (m *mockBaseView) LedgerSeq() uint32 { return 0 }
+
 func (m *mockBaseView) ForEach(fn func(key [32]byte, data []byte) bool) error {
 	for k, v := range m.data {
 		if !fn(k, v) {

--- a/internal/tx/engine.go
+++ b/internal/tx/engine.go
@@ -185,6 +185,10 @@ type LedgerView interface {
 	// Rules returns the amendment rules for this view.
 	// Returns nil if rules are not available.
 	Rules() *amendment.Rules
+
+	// LedgerSeq returns the building ledger's sequence number.
+	// Reference: rippled ReadView::seq().
+	LedgerSeq() uint32
 }
 
 // NewEngine creates a new transaction engine

--- a/internal/tx/invariants/basic.go
+++ b/internal/tx/invariants/basic.go
@@ -260,7 +260,7 @@ func checkValidNewAccountRoot(txType string, result Result, entries []InvariantE
 	// the new account.
 	permitted := false
 	switch txType {
-	case "Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttest", "Batch":
+	case "Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttestation", "Batch":
 		permitted = result == TesSUCCESS
 	}
 	if !permitted {
@@ -327,7 +327,8 @@ func checkValidNewAccountRoot(txType string, result Result, entries []InvariantE
 // extractNewAccountRootFields scans the binary SLE of a newly created
 // AccountRoot and returns its Sequence, Flags, and whether the entry is a
 // pseudo-account (sfAMMID or sfVaultID set). Returns ok=false if the binary
-// is malformed.
+// is malformed, if Sequence or Flags is missing, or if any UInt32 field code
+// appears more than once (which the XRPL STObject codec disallows).
 //
 // XRPL field serialization orders fields by (type_code, nth). We only need
 // fields up through Hash256 (type 5): Flags (UInt32, nth=2), Sequence
@@ -335,6 +336,8 @@ func checkValidNewAccountRoot(txType string, result Result, entries []InvariantE
 // Once we encounter a higher type code we know those fields don't exist.
 func extractNewAccountRootFields(data []byte) (seq, flags uint32, pseudo, ok bool) {
 	offset := 0
+	var seqSeen, flagsSeen bool
+	seenUint32 := make(map[int]struct{}, 4)
 	for offset < len(data) {
 		header := data[offset]
 		offset++
@@ -366,13 +369,19 @@ func extractNewAccountRootFields(data []byte) (seq, flags uint32, pseudo, ok boo
 			if offset+4 > len(data) {
 				return 0, 0, false, false
 			}
+			if _, dup := seenUint32[fieldCode]; dup {
+				return 0, 0, false, false
+			}
+			seenUint32[fieldCode] = struct{}{}
 			value := binary.BigEndian.Uint32(data[offset : offset+4])
 			offset += 4
 			switch fieldCode {
 			case 2:
 				flags = value
+				flagsSeen = true
 			case 4:
 				seq = value
+				seqSeen = true
 			}
 		case 3: // UInt64
 			if offset+8 > len(data) {
@@ -400,8 +409,14 @@ func extractNewAccountRootFields(data []byte) (seq, flags uint32, pseudo, ok boo
 		default:
 			// No fields we care about beyond type 5; everything past this
 			// point is irrelevant for ValidNewAccountRoot.
+			if !seqSeen || !flagsSeen {
+				return 0, 0, false, false
+			}
 			return seq, flags, pseudo, true
 		}
+	}
+	if !seqSeen || !flagsSeen {
+		return 0, 0, false, false
 	}
 	return seq, flags, pseudo, true
 }

--- a/internal/tx/invariants/basic.go
+++ b/internal/tx/invariants/basic.go
@@ -293,7 +293,6 @@ func checkValidNewAccountRoot(txType string, result Result, entries []InvariantE
 		pseudo = false
 	}
 
-	// Compute expected starting sequence.
 	var startingSeq uint32
 	switch {
 	case pseudo:

--- a/internal/tx/invariants/basic.go
+++ b/internal/tx/invariants/basic.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 )
 
@@ -95,12 +96,21 @@ func checkXRPNotCreated(result Result, fee uint64, entries []InvariantEntry) *In
 		}
 	}
 
-	// Net XRP change must be <= 0 (XRP destroyed = fee + any extra burns).
-	// It cannot be positive because that would mean XRP was created out of thin air.
+	// Net XRP change must equal exactly -fee. A positive net change means XRP
+	// was created out of thin air. A net change more negative than -fee means
+	// XRP was burned beyond what the fee accounts for — also a violation, since
+	// only the fee should destroy XRP.
+	// Reference: rippled InvariantCheck.cpp:153-166.
 	if netChange > 0 {
 		return &InvariantViolation{
 			Name:    "XRPNotCreated",
 			Message: fmt.Sprintf("net XRP change +%d drops: XRP was created (fee=%d)", netChange, fee),
+		}
+	}
+	if -netChange != int64(fee) {
+		return &InvariantViolation{
+			Name:    "XRPNotCreated",
+			Message: fmt.Sprintf("net XRP change of %d drops doesn't match fee %d", netChange, fee),
 		}
 	}
 	return nil
@@ -121,9 +131,11 @@ func checkAccountRootsNotDeleted(txType string, result Result, entries []Invaria
 	}
 
 	if result == TesSUCCESS {
-		// A successful AccountDelete/AMMDelete MUST delete exactly one account root.
+		// A successful AccountDelete/AMMDelete/VaultDelete MUST delete exactly
+		// one account root. VaultDelete removes the vault's pseudo-account.
+		// Reference: rippled InvariantCheck.cpp:382-385.
 		switch txType {
-		case "AccountDelete", "AMMDelete":
+		case "AccountDelete", "AMMDelete", "VaultDelete":
 			if deletedCount == 1 {
 				return nil
 			}
@@ -218,13 +230,17 @@ func checkLedgerEntryTypesMatch(entries []InvariantEntry) *InvariantViolation {
 }
 
 // checkValidNewAccountRoot verifies that new AccountRoot entries are only created
-// by Payment or AMMCreate transactions, and that at most one is created per tx.
-// Reference: rippled InvariantCheck.cpp — ValidNewAccountRoot
-func checkValidNewAccountRoot(txType string, entries []InvariantEntry) *InvariantViolation {
+// by a permitted transaction type, that at most one is created per transaction,
+// and that the new account has the expected starting Sequence (and Flags, for
+// pseudo-accounts).
+// Reference: rippled InvariantCheck.cpp — ValidNewAccountRoot (lines 930-1013).
+func checkValidNewAccountRoot(txType string, result Result, entries []InvariantEntry, view ReadView, rules *amendment.Rules) *InvariantViolation {
 	createdCount := 0
+	var newEntry []byte
 	for _, e := range entries {
 		if e.EntryType == "AccountRoot" && !e.IsDelete && e.Before == nil {
 			createdCount++
+			newEntry = e.After
 		}
 	}
 	if createdCount == 0 {
@@ -236,17 +252,167 @@ func checkValidNewAccountRoot(txType string, entries []InvariantEntry) *Invarian
 			Message: fmt.Sprintf("multiple AccountRoot entries created in one transaction (count=%d)", createdCount),
 		}
 	}
-	// Exactly one new AccountRoot — only Payment, AMMCreate, and Batch are allowed to create accounts.
-	// Batch can contain inner Payment transactions that create accounts.
+
+	// Only a successful transaction of a permitted type may create an
+	// AccountRoot. Batch is goXRPL's necessary carve-out: rippled runs each
+	// inner tx through its own invariant pass, but goXRPL applies the inner
+	// txs against the same engine table, so the outer Batch result inherits
+	// the new account.
+	permitted := false
 	switch txType {
-	case "Payment", "AMMCreate", "Batch":
-		return nil
+	case "Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttest", "Batch":
+		permitted = result == TesSUCCESS
 	}
-	return &InvariantViolation{
-		Name:    "ValidNewAccountRoot",
-		Message: fmt.Sprintf("transaction type %s created an AccountRoot (only Payment or AMMCreate may create accounts)", txType),
+	if !permitted {
+		return &InvariantViolation{
+			Name:    "ValidNewAccountRoot",
+			Message: fmt.Sprintf("account root created illegally by %s", txType),
+		}
 	}
+
+	seq, flags, pseudo, ok := extractNewAccountRootFields(newEntry)
+	if !ok {
+		return &InvariantViolation{
+			Name:    "ValidNewAccountRoot",
+			Message: "could not parse newly created AccountRoot",
+		}
+	}
+
+	// A pseudo-account (AMMID or VaultID set) may only be created by
+	// AMMCreate or VaultCreate. The flag is gated on featureSingleAssetVault:
+	// before that amendment, sfVaultID does not exist as a serialized field
+	// and pseudo-account semantics are not enforced.
+	if pseudo && rules != nil && rules.Enabled(amendment.FeatureSingleAssetVault) {
+		if txType != "AMMCreate" && txType != "VaultCreate" && txType != "Batch" {
+			return &InvariantViolation{
+				Name:    "ValidNewAccountRoot",
+				Message: fmt.Sprintf("pseudo-account created by a wrong transaction type %s", txType),
+			}
+		}
+	} else {
+		pseudo = false
+	}
+
+	// Compute expected starting sequence.
+	var startingSeq uint32
+	switch {
+	case pseudo:
+		startingSeq = 0
+	case rules != nil && rules.Enabled(amendment.FeatureDeletableAccounts):
+		if view != nil {
+			startingSeq = view.LedgerSeq()
+		}
+	default:
+		startingSeq = 1
+	}
+	if seq != startingSeq {
+		return &InvariantViolation{
+			Name:    "ValidNewAccountRoot",
+			Message: fmt.Sprintf("account created with wrong starting sequence %d (want %d)", seq, startingSeq),
+		}
+	}
+
+	if pseudo {
+		const expected = LsfDisableMaster | LsfDefaultRipple | LsfDepositAuth
+		if flags != expected {
+			return &InvariantViolation{
+				Name:    "ValidNewAccountRoot",
+				Message: fmt.Sprintf("pseudo-account created with wrong flags 0x%08x", flags),
+			}
+		}
+	}
+	return nil
 }
+
+// extractNewAccountRootFields scans the binary SLE of a newly created
+// AccountRoot and returns its Sequence, Flags, and whether the entry is a
+// pseudo-account (sfAMMID or sfVaultID set). Returns ok=false if the binary
+// is malformed.
+//
+// XRPL field serialization orders fields by (type_code, nth). We only need
+// fields up through Hash256 (type 5): Flags (UInt32, nth=2), Sequence
+// (UInt32, nth=4), AMMID (Hash256, nth=14), VaultID (Hash256, nth=35).
+// Once we encounter a higher type code we know those fields don't exist.
+func extractNewAccountRootFields(data []byte) (seq, flags uint32, pseudo, ok bool) {
+	offset := 0
+	for offset < len(data) {
+		header := data[offset]
+		offset++
+
+		typeCode := int((header >> 4) & 0x0F)
+		fieldCode := int(header & 0x0F)
+		if typeCode == 0 {
+			if offset >= len(data) {
+				return 0, 0, false, false
+			}
+			typeCode = int(data[offset])
+			offset++
+		}
+		if fieldCode == 0 {
+			if offset >= len(data) {
+				return 0, 0, false, false
+			}
+			fieldCode = int(data[offset])
+			offset++
+		}
+
+		switch typeCode {
+		case 1: // UInt16
+			if offset+2 > len(data) {
+				return 0, 0, false, false
+			}
+			offset += 2
+		case 2: // UInt32
+			if offset+4 > len(data) {
+				return 0, 0, false, false
+			}
+			value := binary.BigEndian.Uint32(data[offset : offset+4])
+			offset += 4
+			switch fieldCode {
+			case 2:
+				flags = value
+			case 4:
+				seq = value
+			}
+		case 3: // UInt64
+			if offset+8 > len(data) {
+				return 0, 0, false, false
+			}
+			offset += 8
+		case 4: // Hash128
+			if offset+16 > len(data) {
+				return 0, 0, false, false
+			}
+			offset += 16
+		case 5: // Hash256
+			if offset+32 > len(data) {
+				return 0, 0, false, false
+			}
+			if fieldCode == 14 || fieldCode == 35 { // sfAMMID or sfVaultID
+				for _, b := range data[offset : offset+32] {
+					if b != 0 {
+						pseudo = true
+						break
+					}
+				}
+			}
+			offset += 32
+		default:
+			// No fields we care about beyond type 5; everything past this
+			// point is irrelevant for ValidNewAccountRoot.
+			return seq, flags, pseudo, true
+		}
+	}
+	return seq, flags, pseudo, true
+}
+
+// AccountRoot flag bits used by ValidNewAccountRoot's pseudo-account check.
+// Reference: rippled LedgerFormats lsfDisableMaster / lsfDefaultRipple / lsfDepositAuth.
+const (
+	LsfDisableMaster uint32 = 0x00100000
+	LsfDefaultRipple uint32 = 0x00800000
+	LsfDepositAuth   uint32 = 0x01000000
+)
 
 // checkTransactionFee verifies that the fee charged is non-negative, does not
 // exceed the total XRP supply, and does not exceed what the transaction declared.

--- a/internal/tx/invariants/invariants.go
+++ b/internal/tx/invariants/invariants.go
@@ -58,6 +58,10 @@ type ReadView interface {
 	Read(k keylet.Keylet) ([]byte, error)
 	Exists(k keylet.Keylet) (bool, error)
 	Succ(key [32]byte) ([32]byte, []byte, bool, error)
+	// LedgerSeq returns the current (building) ledger sequence. Mirrors
+	// rippled ReadView::seq(), used by ValidNewAccountRoot when
+	// featureDeletableAccounts is enabled.
+	LedgerSeq() uint32
 }
 
 // TxType represents a transaction type code.
@@ -241,7 +245,9 @@ func CheckInvariants(tx Transaction, result Result, fee uint64, txDeclaredFee ui
 		},
 		func() *InvariantViolation { return checkNoBadOffers(entries) },
 		func() *InvariantViolation { return checkNoZeroEscrow(entries) },
-		func() *InvariantViolation { return checkValidNewAccountRoot(txType, entries) },
+		func() *InvariantViolation {
+			return checkValidNewAccountRoot(txType, result, entries, view, rules)
+		},
 		func() *InvariantViolation {
 			return checkNFTokenCountTracking(txType, result, entries)
 		},

--- a/internal/tx/invariants/invariants_test.go
+++ b/internal/tx/invariants/invariants_test.go
@@ -8,22 +8,6 @@ import (
 	"github.com/LeJamon/goXRPLd/keylet"
 )
 
-type stubTx struct {
-	typ  TxType
-	acct string
-	has  map[string]bool
-}
-
-func (t stubTx) TxType() TxType    { return t.typ }
-func (t stubTx) TxAccount() string { return t.acct }
-func (t stubTx) TxHasField(n string) bool {
-	if t.has == nil {
-		return false
-	}
-	return t.has[n]
-}
-func (t stubTx) Flatten() (map[string]any, error) { return map[string]any{}, nil }
-
 type stubView struct {
 	seq uint32
 }

--- a/internal/tx/invariants/invariants_test.go
+++ b/internal/tx/invariants/invariants_test.go
@@ -1,0 +1,148 @@
+package invariants
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/amendment"
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+	"github.com/LeJamon/goXRPLd/keylet"
+)
+
+type stubTx struct {
+	typ  TxType
+	acct string
+	has  map[string]bool
+}
+
+func (t stubTx) TxType() TxType    { return t.typ }
+func (t stubTx) TxAccount() string { return t.acct }
+func (t stubTx) TxHasField(n string) bool {
+	if t.has == nil {
+		return false
+	}
+	return t.has[n]
+}
+func (t stubTx) Flatten() (map[string]any, error) { return map[string]any{}, nil }
+
+type stubView struct {
+	seq uint32
+}
+
+func (v stubView) Read(k keylet.Keylet) ([]byte, error) { return nil, nil }
+func (v stubView) Exists(k keylet.Keylet) (bool, error) { return false, nil }
+func (v stubView) Succ(k [32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+func (v stubView) LedgerSeq() uint32 { return v.seq }
+
+func mustSerializeAccount(t *testing.T, a *state.AccountRoot) []byte {
+	t.Helper()
+	b, err := state.SerializeAccountRoot(a)
+	if err != nil {
+		t.Fatalf("SerializeAccountRoot: %v", err)
+	}
+	return b
+}
+
+func mustSerializeMPTIssuance(t *testing.T, m *state.MPTokenIssuanceData) []byte {
+	t.Helper()
+	b, err := state.SerializeMPTokenIssuance(m)
+	if err != nil {
+		t.Fatalf("SerializeMPTokenIssuance: %v", err)
+	}
+	return b
+}
+
+// TestXRPNotCreated_StrictEquality: a net XRP change more negative than -fee
+// (XRP burned beyond what the fee accounts for) must trip XRPNotCreated.
+// Reference: rippled InvariantCheck.cpp:161-166.
+func TestXRPNotCreated_StrictEquality(t *testing.T) {
+	before := mustSerializeAccount(t, &state.AccountRoot{
+		Account: "rrrrrrrrrrrrrrrrrrrrrhoLvTp", Balance: 1_000_000, Sequence: 5,
+	})
+	after := mustSerializeAccount(t, &state.AccountRoot{
+		Account: "rrrrrrrrrrrrrrrrrrrrrhoLvTp", Balance: 999_000, Sequence: 6,
+	})
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: before, After: after}}
+
+	if v := checkXRPNotCreated(TesSUCCESS, 10, entries); v == nil {
+		t.Fatalf("expected XRPNotCreated violation (net change -1000 doesn't match fee 10)")
+	}
+	if v := checkXRPNotCreated(TesSUCCESS, 1000, entries); v != nil {
+		t.Fatalf("unexpected XRPNotCreated violation when net change == -fee: %v", v)
+	}
+}
+
+// TestValidNewAccountRoot_PermittedTypes ensures the allow-list now covers
+// VaultCreate and the XChain attestation tx types in addition to Payment /
+// AMMCreate / Batch.
+// Reference: rippled InvariantCheck.cpp:964-967.
+func TestValidNewAccountRoot_PermittedTypes(t *testing.T) {
+	rules := amendment.AllSupportedRules()
+	view := stubView{seq: 100}
+	newAcct := mustSerializeAccount(t, &state.AccountRoot{
+		Account:  "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+		Balance:  1_000_000,
+		Sequence: 100,
+	})
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: nil, After: newAcct}}
+
+	for _, txType := range []string{"Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttest", "Batch"} {
+		if v := checkValidNewAccountRoot(txType, TesSUCCESS, entries, view, rules); v != nil {
+			t.Errorf("%s: unexpected violation %v", txType, v)
+		}
+	}
+	if v := checkValidNewAccountRoot("OfferCreate", TesSUCCESS, entries, view, rules); v == nil {
+		t.Fatalf("OfferCreate: expected violation creating AccountRoot")
+	}
+}
+
+// TestValidNewAccountRoot_WrongStartingSeq enforces accountSeq == startingSeq
+// when featureDeletableAccounts is enabled.
+// Reference: rippled InvariantCheck.cpp:981-993.
+func TestValidNewAccountRoot_WrongStartingSeq(t *testing.T) {
+	rules := amendment.AllSupportedRules()
+	view := stubView{seq: 100}
+	bad := mustSerializeAccount(t, &state.AccountRoot{
+		Account:  "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+		Balance:  1_000_000,
+		Sequence: 1, // should be view.seq() = 100
+	})
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: nil, After: bad}}
+	if v := checkValidNewAccountRoot("Payment", TesSUCCESS, entries, view, rules); v == nil {
+		t.Fatal("expected violation for wrong starting sequence")
+	}
+}
+
+// TestAccountRootsNotDeleted_VaultDelete: a successful VaultDelete must be
+// allowed to delete exactly one AccountRoot.
+// Reference: rippled InvariantCheck.cpp:382-385.
+func TestAccountRootsNotDeleted_VaultDelete(t *testing.T) {
+	before := mustSerializeAccount(t, &state.AccountRoot{
+		Account: "rrrrrrrrrrrrrrrrrrrrrhoLvTp", Balance: 0, Sequence: 0,
+	})
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: before, After: nil, IsDelete: true}}
+	if v := checkAccountRootsNotDeleted("VaultDelete", TesSUCCESS, entries); v != nil {
+		t.Fatalf("VaultDelete: unexpected violation %v", v)
+	}
+}
+
+// TestNoZeroEscrow_MPTokenIssuanceBounds enforces the MPTokenIssuance
+// OutstandingAmount / LockedAmount bounds added by issue #499.
+// Reference: rippled InvariantCheck.cpp:319-327.
+func TestNoZeroEscrow_MPTokenIssuanceBounds(t *testing.T) {
+	locked := uint64(50)
+	good := mustSerializeMPTIssuance(t, &state.MPTokenIssuanceData{
+		Sequence: 1, OutstandingAmount: 100, LockedAmount: &locked,
+	})
+	if v := checkNoZeroEscrow([]InvariantEntry{{EntryType: "MPTokenIssuance", After: good}}); v != nil {
+		t.Fatalf("balanced issuance: unexpected violation %v", v)
+	}
+	overLocked := uint64(150)
+	bad := mustSerializeMPTIssuance(t, &state.MPTokenIssuanceData{
+		Sequence: 1, OutstandingAmount: 100, LockedAmount: &overLocked,
+	})
+	if v := checkNoZeroEscrow([]InvariantEntry{{EntryType: "MPTokenIssuance", After: bad}}); v == nil {
+		t.Fatal("expected violation: LockedAmount > OutstandingAmount")
+	}
+}

--- a/internal/tx/invariants/invariants_test.go
+++ b/internal/tx/invariants/invariants_test.go
@@ -1,9 +1,12 @@
 package invariants
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/amendment"
+	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/keylet"
 )
@@ -71,7 +74,7 @@ func TestValidNewAccountRoot_PermittedTypes(t *testing.T) {
 	})
 	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: nil, After: newAcct}}
 
-	for _, txType := range []string{"Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttest", "Batch"} {
+	for _, txType := range []string{"Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttestation", "Batch"} {
 		if v := checkValidNewAccountRoot(txType, TesSUCCESS, entries, view, rules); v != nil {
 			t.Errorf("%s: unexpected violation %v", txType, v)
 		}
@@ -108,6 +111,161 @@ func TestAccountRootsNotDeleted_VaultDelete(t *testing.T) {
 	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: before, After: nil, IsDelete: true}}
 	if v := checkAccountRootsNotDeleted("VaultDelete", TesSUCCESS, entries); v != nil {
 		t.Fatalf("VaultDelete: unexpected violation %v", v)
+	}
+}
+
+// rulesWithSingleAssetVault returns Rules with featureSingleAssetVault and
+// featureDeletableAccounts both enabled. featureSingleAssetVault is
+// SupportedNo in the registry so AllSupportedRules() does not include it,
+// but the gap-fix invariant logic only kicks in when it's on.
+func rulesWithSingleAssetVault() *amendment.Rules {
+	return amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureDeletableAccounts,
+	})
+}
+
+// TestValidNewAccountRoot_PseudoAccountWrongTxType: when featureSingleAssetVault
+// is enabled, a pseudo-account (sfAMMID set) created by a tx type other than
+// AMMCreate / VaultCreate / Batch must violate.
+// Reference: rippled Invariants_test.cpp:965-980, InvariantCheck.cpp:973-979.
+func TestValidNewAccountRoot_PseudoAccountWrongTxType(t *testing.T) {
+	rules := rulesWithSingleAssetVault()
+	view := stubView{seq: 100}
+	pseudo := mustSerializeAccount(t, &state.AccountRoot{
+		Account:  "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+		Balance:  0,
+		Sequence: 0,
+		Flags:    LsfDisableMaster | LsfDefaultRipple | LsfDepositAuth,
+		AMMID:    [32]byte{1},
+	})
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: nil, After: pseudo}}
+
+	// Payment is in the general allow-list but must be rejected for pseudo accounts.
+	if v := checkValidNewAccountRoot("Payment", TesSUCCESS, entries, view, rules); v == nil {
+		t.Fatal("Payment: expected violation for pseudo-account created by non-AMM/Vault tx")
+	}
+
+	// AMMCreate is the allowed pseudo-creator.
+	if v := checkValidNewAccountRoot("AMMCreate", TesSUCCESS, entries, view, rules); v != nil {
+		t.Fatalf("AMMCreate: unexpected violation %v", v)
+	}
+}
+
+// TestValidNewAccountRoot_PseudoAccountWrongFlags: when featureSingleAssetVault
+// is enabled, a pseudo-account whose Flags are not exactly the canonical mask
+// must violate (here LsfAMM-shaped 0x02000000 added for back-compat).
+// Reference: rippled Invariants_test.cpp:999-1031, InvariantCheck.cpp:995-1006.
+func TestValidNewAccountRoot_PseudoAccountWrongFlags(t *testing.T) {
+	rules := rulesWithSingleAssetVault()
+	view := stubView{seq: 100}
+	const expected = LsfDisableMaster | LsfDefaultRipple | LsfDepositAuth
+	wrongFlags := expected | 0x02000000 // extra unrelated bit
+	bad := mustSerializeAccount(t, &state.AccountRoot{
+		Account:  "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+		Balance:  0,
+		Sequence: 0,
+		Flags:    wrongFlags,
+		AMMID:    [32]byte{1},
+	})
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: nil, After: bad}}
+	if v := checkValidNewAccountRoot("AMMCreate", TesSUCCESS, entries, view, rules); v == nil {
+		t.Fatal("expected violation for pseudo-account with wrong flag mask")
+	}
+
+	good := mustSerializeAccount(t, &state.AccountRoot{
+		Account:  "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+		Balance:  0,
+		Sequence: 0,
+		Flags:    expected,
+		AMMID:    [32]byte{1},
+	})
+	if v := checkValidNewAccountRoot("AMMCreate", TesSUCCESS, []InvariantEntry{{EntryType: "AccountRoot", Before: nil, After: good}}, view, rules); v != nil {
+		t.Fatalf("canonical pseudo-account flags: unexpected violation %v", v)
+	}
+}
+
+// TestValidNewAccountRoot_CrossGatingPreSingleAssetVault locks in the
+// gating contract: when featureSingleAssetVault is disabled, neither the
+// pseudo-account flag-mask check nor the wrong-tx-type pseudo guard runs.
+// AMMCreate must therefore install Sequence == view.seq() (not 0), matching
+// the pre-amendment branch at amm_create.go:253-256 and rippled View.cpp:1120-1123.
+func TestValidNewAccountRoot_CrossGatingPreSingleAssetVault(t *testing.T) {
+	rules := amendment.NewRules([][32]byte{amendment.FeatureDeletableAccounts})
+	view := stubView{seq: 100}
+
+	// A pseudo-shaped account (AMMID set) with non-canonical flags must NOT
+	// trip the flag-mask check pre-amendment.
+	ammNew := mustSerializeAccount(t, &state.AccountRoot{
+		Account:  "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+		Balance:  0,
+		Sequence: view.LedgerSeq(),
+		Flags:    LsfDisableMaster | LsfDefaultRipple | LsfDepositAuth | 0x02000000,
+		AMMID:    [32]byte{1},
+	})
+	if v := checkValidNewAccountRoot("AMMCreate", TesSUCCESS, []InvariantEntry{{EntryType: "AccountRoot", Before: nil, After: ammNew}}, view, rules); v != nil {
+		t.Fatalf("pre-singleAssetVault: unexpected violation %v", v)
+	}
+
+	// Conversely, AMMCreate with Sequence == 0 pre-amendment must violate
+	// because the starting-seq expectation falls back to view.seq().
+	zeroSeq := mustSerializeAccount(t, &state.AccountRoot{
+		Account:  "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+		Balance:  0,
+		Sequence: 0,
+		Flags:    LsfDisableMaster | LsfDefaultRipple | LsfDepositAuth,
+		AMMID:    [32]byte{1},
+	})
+	if v := checkValidNewAccountRoot("AMMCreate", TesSUCCESS, []InvariantEntry{{EntryType: "AccountRoot", Before: nil, After: zeroSeq}}, view, rules); v == nil {
+		t.Fatal("pre-singleAssetVault: expected violation when Sequence != view.seq()")
+	}
+}
+
+// TestNoZeroEscrow_IOUBadCurrency: IOU escrows holding the sentinel "XRP"
+// currency code must trip NoZeroEscrow. The codec rejects "XRP" as an IOU
+// currency at encode-time (as it should), so we build the canonical escrow
+// blob with USD and patch the 3-byte currency code in-place to exercise the
+// defense-in-depth invariant against future encoder bugs.
+// Reference: rippled InvariantCheck.cpp:286-292.
+func TestNoZeroEscrow_IOUBadCurrency(t *testing.T) {
+	const issuer = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+	const owner = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+
+	jsonObj := map[string]any{
+		"LedgerEntryType": "Escrow",
+		"Account":         owner,
+		"Destination":     owner,
+		"Amount": map[string]any{
+			"currency": "USD",
+			"issuer":   issuer,
+			"value":    "1",
+		},
+		"OwnerNode": "0",
+		"Flags":     uint32(0),
+	}
+	hexStr, err := binarycodec.Encode(jsonObj)
+	if err != nil {
+		t.Fatalf("binarycodec.Encode: %v", err)
+	}
+	good, err := hex.DecodeString(hexStr)
+	if err != nil {
+		t.Fatalf("hex.DecodeString: %v", err)
+	}
+	if v := checkNoZeroEscrow([]InvariantEntry{{EntryType: "Escrow", After: good}}); v != nil {
+		t.Fatalf("good IOU escrow: unexpected violation %v", v)
+	}
+
+	usdMarker := []byte{'U', 'S', 'D'}
+	idx := bytes.Index(good, usdMarker)
+	if idx < 0 {
+		t.Fatal("USD currency marker not found in encoded escrow")
+	}
+	bad := make([]byte, len(good))
+	copy(bad, good)
+	copy(bad[idx:idx+3], []byte{'X', 'R', 'P'})
+
+	if v := checkNoZeroEscrow([]InvariantEntry{{EntryType: "Escrow", After: bad}}); v == nil {
+		t.Fatal("expected violation: IOU escrow with bad (XRP) currency")
 	}
 }
 

--- a/internal/tx/invariants/offers.go
+++ b/internal/tx/invariants/offers.go
@@ -127,17 +127,29 @@ func checkEscrowAmount(data []byte) *InvariantViolation {
 		}
 		return nil
 	}
-	// IOU escrow — must be strictly positive.
+	// IOU escrow — must be strictly positive and must not use the sentinel "bad"
+	// currency code ("XRP" as an IOU currency). Mirrors rippled InvariantCheck.cpp:286-292.
 	if esc.IOUAmount != nil {
-		if esc.IOUAmount.IsZero() || esc.IOUAmount.IsNegative() {
+		if esc.IOUAmount.Signum() <= 0 {
 			return &InvariantViolation{
 				Name:    "NoZeroEscrow",
 				Message: "Escrow IOU amount is not positive",
 			}
 		}
+		if esc.IOUAmount.Currency == badIOUCurrency {
+			return &InvariantViolation{
+				Name:    "NoZeroEscrow",
+				Message: "Escrow IOU amount uses the bad (XRP) currency code",
+			}
+		}
 	}
 	return nil
 }
+
+// badIOUCurrency is the sentinel currency code rejected as an IOU asset.
+// Mirrors rippled protocol/Issue.h badCurrency() — the 3-letter ASCII "XRP"
+// is reserved for native XRP and may not appear as an IOU currency.
+const badIOUCurrency = "XRP"
 
 func checkMPTokenIssuanceAmounts(data []byte) *InvariantViolation {
 	issuance, err := state.ParseMPTokenIssuance(data)

--- a/internal/tx/invariants/offers.go
+++ b/internal/tx/invariants/offers.go
@@ -8,79 +8,181 @@ import (
 )
 
 // checkNoBadOffers verifies that Offer entries have positive non-zero amounts
-// and that XRP/XRP offers don't exist.
-// Reference: rippled InvariantCheck.cpp — NoBadOffers
+// and that XRP/XRP offers don't exist. Both pre- and post-tx images are
+// inspected so the invariant catches pre-existing malformed offers as well as
+// newly written ones.
+// Reference: rippled InvariantCheck.cpp — NoBadOffers (lines 223-263).
 func checkNoBadOffers(entries []InvariantEntry) *InvariantViolation {
 	for _, e := range entries {
-		if e.EntryType != "Offer" || e.IsDelete {
+		if e.EntryType != "Offer" {
 			continue
 		}
-		offer, err := parseOfferForInvariant(e.After)
-		if err != nil {
-			continue
-		}
-		// Both sides XRP is disallowed
-		if offer.takerPaysIsXRP && offer.takerGetsIsXRP {
-			return &InvariantViolation{
-				Name:    "NoBadOffers",
-				Message: "Offer has XRP on both sides",
+		for _, data := range [][]byte{e.Before, e.After} {
+			if data == nil {
+				continue
 			}
-		}
-		// Amounts must be positive
-		if offer.takerPaysIsXRP && offer.takerPaysXRP == 0 {
-			return &InvariantViolation{
-				Name:    "NoBadOffers",
-				Message: "Offer TakerPays (XRP) is zero",
+			offer, err := parseOfferForInvariant(data)
+			if err != nil {
+				continue
 			}
-		}
-		if offer.takerGetsIsXRP && offer.takerGetsXRP == 0 {
-			return &InvariantViolation{
-				Name:    "NoBadOffers",
-				Message: "Offer TakerGets (XRP) is zero",
+			if offer.takerPaysIsXRP && offer.takerGetsIsXRP {
+				return &InvariantViolation{
+					Name:    "NoBadOffers",
+					Message: "Offer has XRP on both sides",
+				}
+			}
+			if offer.takerPaysIsXRP && offer.takerPaysXRP == 0 {
+				return &InvariantViolation{
+					Name:    "NoBadOffers",
+					Message: "Offer TakerPays (XRP) is zero",
+				}
+			}
+			if offer.takerGetsIsXRP && offer.takerGetsXRP == 0 {
+				return &InvariantViolation{
+					Name:    "NoBadOffers",
+					Message: "Offer TakerGets (XRP) is zero",
+				}
 			}
 		}
 	}
 	return nil
 }
 
-// checkNoZeroEscrow verifies that Escrow entries have a valid amount.
-// For XRP escrows, amount must be positive and not exceed InitialXRP.
-// For IOU escrows (TokenEscrow amendment), the IOU amount validity is
-// checked by the escrow transaction's own validation; we skip the
-// XRP-specific checks here.
-// Reference: rippled InvariantCheck.cpp — NoZeroEscrow (lines 267-356)
+// checkNoZeroEscrow verifies that Escrow, MPTokenIssuance, and MPToken entries
+// carry sane amount fields. XRP escrows must be strictly within (0, InitialXRP);
+// IOU escrows must be strictly positive; MPT escrows must be within
+// (0, MaxMPTokenAmount]. MPTokenIssuance.OutstandingAmount/LockedAmount and
+// MPToken.MPTAmount/LockedAmount must each fit within [0, MaxMPTokenAmount],
+// and OutstandingAmount must be >= LockedAmount.
+// Reference: rippled InvariantCheck.cpp — NoZeroEscrow (lines 267-356).
 func checkNoZeroEscrow(entries []InvariantEntry) *InvariantViolation {
 	for _, e := range entries {
-		if e.EntryType != "Escrow" {
-			continue
+		switch e.EntryType {
+		case "Escrow":
+			for _, data := range [][]byte{e.Before, e.After} {
+				if data == nil {
+					continue
+				}
+				if v := checkEscrowAmount(data); v != nil {
+					return v
+				}
+			}
+		case "MPTokenIssuance":
+			if e.After == nil {
+				continue
+			}
+			if v := checkMPTokenIssuanceAmounts(e.After); v != nil {
+				return v
+			}
+		case "MPToken":
+			if e.After == nil {
+				continue
+			}
+			if v := checkMPTokenAmounts(e.After); v != nil {
+				return v
+			}
 		}
-		// Check both before and after entries (matching rippled behavior)
-		for _, data := range [][]byte{e.Before, e.After} {
-			if data == nil {
-				continue
+	}
+	return nil
+}
+
+// MaxMPTokenAmount is the maximum representable MPT amount (2^63 - 1).
+// Reference: rippled maxMPTokenAmount constant.
+const MaxMPTokenAmount uint64 = 0x7FFFFFFFFFFFFFFF
+
+func checkEscrowAmount(data []byte) *InvariantViolation {
+	esc, err := state.ParseEscrow(data)
+	if err != nil {
+		return nil
+	}
+	if esc.IsXRP {
+		if esc.Amount == 0 {
+			return &InvariantViolation{
+				Name:    "NoZeroEscrow",
+				Message: "Escrow entry has zero XRP amount",
 			}
-			esc, err := state.ParseEscrow(data)
-			if err != nil {
-				continue
+		}
+		if esc.Amount >= InitialXRP {
+			return &InvariantViolation{
+				Name:    "NoZeroEscrow",
+				Message: fmt.Sprintf("Escrow XRP amount %d exceeds InitialXRP (%d)", esc.Amount, InitialXRP),
 			}
-			// Only apply XRP-specific checks for XRP escrows.
-			// IOU escrows have IsXRP=false and their amount validity is
-			// enforced by the transaction's own Preflight/Apply logic.
-			if !esc.IsXRP {
-				continue
+		}
+		return nil
+	}
+	// MPT escrow.
+	if esc.MPTAmount != nil {
+		v := *esc.MPTAmount
+		if v <= 0 {
+			return &InvariantViolation{
+				Name:    "NoZeroEscrow",
+				Message: fmt.Sprintf("Escrow MPT amount %d is not positive", v),
 			}
-			if esc.Amount == 0 {
-				return &InvariantViolation{
-					Name:    "NoZeroEscrow",
-					Message: "Escrow entry has zero XRP amount",
-				}
+		}
+		if uint64(v) > MaxMPTokenAmount {
+			return &InvariantViolation{
+				Name:    "NoZeroEscrow",
+				Message: fmt.Sprintf("Escrow MPT amount %d exceeds MaxMPTokenAmount", v),
 			}
-			if esc.Amount > InitialXRP {
-				return &InvariantViolation{
-					Name:    "NoZeroEscrow",
-					Message: fmt.Sprintf("Escrow amount %d exceeds InitialXRP (%d)", esc.Amount, InitialXRP),
-				}
+		}
+		return nil
+	}
+	// IOU escrow — must be strictly positive.
+	if esc.IOUAmount != nil {
+		if esc.IOUAmount.IsZero() || esc.IOUAmount.IsNegative() {
+			return &InvariantViolation{
+				Name:    "NoZeroEscrow",
+				Message: "Escrow IOU amount is not positive",
 			}
+		}
+	}
+	return nil
+}
+
+func checkMPTokenIssuanceAmounts(data []byte) *InvariantViolation {
+	issuance, err := state.ParseMPTokenIssuance(data)
+	if err != nil {
+		return nil
+	}
+	if issuance.OutstandingAmount > MaxMPTokenAmount {
+		return &InvariantViolation{
+			Name:    "NoZeroEscrow",
+			Message: fmt.Sprintf("MPTokenIssuance.OutstandingAmount %d exceeds MaxMPTokenAmount", issuance.OutstandingAmount),
+		}
+	}
+	if issuance.LockedAmount != nil {
+		locked := *issuance.LockedAmount
+		if locked > MaxMPTokenAmount {
+			return &InvariantViolation{
+				Name:    "NoZeroEscrow",
+				Message: fmt.Sprintf("MPTokenIssuance.LockedAmount %d exceeds MaxMPTokenAmount", locked),
+			}
+		}
+		if issuance.OutstandingAmount < locked {
+			return &InvariantViolation{
+				Name:    "NoZeroEscrow",
+				Message: fmt.Sprintf("MPTokenIssuance.OutstandingAmount %d < LockedAmount %d", issuance.OutstandingAmount, locked),
+			}
+		}
+	}
+	return nil
+}
+
+func checkMPTokenAmounts(data []byte) *InvariantViolation {
+	token, err := state.ParseMPToken(data)
+	if err != nil {
+		return nil
+	}
+	if token.MPTAmount > MaxMPTokenAmount {
+		return &InvariantViolation{
+			Name:    "NoZeroEscrow",
+			Message: fmt.Sprintf("MPToken.MPTAmount %d exceeds MaxMPTokenAmount", token.MPTAmount),
+		}
+	}
+	if token.LockedAmount != nil && *token.LockedAmount > MaxMPTokenAmount {
+		return &InvariantViolation{
+			Name:    "NoZeroEscrow",
+			Message: fmt.Sprintf("MPToken.LockedAmount %d exceeds MaxMPTokenAmount", *token.LockedAmount),
 		}
 	}
 	return nil

--- a/internal/tx/invariants/offers.go
+++ b/internal/tx/invariants/offers.go
@@ -110,7 +110,6 @@ func checkEscrowAmount(data []byte) *InvariantViolation {
 		}
 		return nil
 	}
-	// MPT escrow.
 	if esc.MPTAmount != nil {
 		v := *esc.MPTAmount
 		if v <= 0 {

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -62,6 +62,10 @@ func (m *paymentMockLedgerView) Rules() *amendment.Rules {
 	return nil
 }
 
+func (m *paymentMockLedgerView) LedgerSeq() uint32 {
+	return 0
+}
+
 func (m *paymentMockLedgerView) ForEach(fn func(key [32]byte, data []byte) bool) error {
 	for k, v := range m.data {
 		if !fn(k, v) {

--- a/internal/tx/payment/pathfinder/pathfinder_test.go
+++ b/internal/tx/payment/pathfinder/pathfinder_test.go
@@ -84,6 +84,8 @@ func (m *mockLedgerView) TxExists(_ [32]byte) bool { return false }
 
 func (m *mockLedgerView) Rules() *amendment.Rules { return nil }
 
+func (m *mockLedgerView) LedgerSeq() uint32 { return 0 }
+
 func compareKeys(a, b [32]byte) int {
 	for i := 0; i < 32; i++ {
 		if a[i] < b[i] {

--- a/internal/tx/payment/payment_xrp.go
+++ b/internal/tx/payment/payment_xrp.go
@@ -72,9 +72,9 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 			return tx.TefINTERNAL
 		}
 
-		// Check for pseudo-account (AMM accounts cannot receive direct payments)
-		// See rippled Payment.cpp:636-637: if (isPseudoAccount(sleDst)) return tecNO_PERMISSION
-		if (destAccount.Flags & state.LsfAMM) != 0 {
+		// Check for pseudo-account (AMM/Vault cannot receive direct payments).
+		// See rippled Payment.cpp:636-637: if (isPseudoAccount(sleDst)) return tecNO_PERMISSION.
+		if destAccount.IsPseudoAccount() {
 			return tx.TecNO_PERMISSION
 		}
 

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -348,6 +348,18 @@ func (s *PaymentSandbox) Rules() *amendment.Rules {
 	return nil
 }
 
+// LedgerSeq returns the building ledger sequence, delegating to parent or view.
+// Reference: rippled ReadView::seq().
+func (s *PaymentSandbox) LedgerSeq() uint32 {
+	if s.parent != nil {
+		return s.parent.LedgerSeq()
+	}
+	if s.view != nil {
+		return s.view.LedgerSeq()
+	}
+	return 0
+}
+
 // ForEach iterates over all state entries visible from this sandbox
 func (s *PaymentSandbox) ForEach(fn func(key [32]byte, data []byte) bool) error {
 	// Track visited keys to avoid duplicates

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -349,10 +349,15 @@ func (s *PaymentSandbox) Rules() *amendment.Rules {
 }
 
 // LedgerSeq returns the building ledger sequence, delegating to parent or view.
+// Falls through to the view if the parent reports 0 (e.g. a parent wrapped over
+// a snapshotView with no resolved ledger), so the engine's Config.LedgerSequence
+// can still surface through.
 // Reference: rippled ReadView::seq().
 func (s *PaymentSandbox) LedgerSeq() uint32 {
 	if s.parent != nil {
-		return s.parent.LedgerSeq()
+		if seq := s.parent.LedgerSeq(); seq != 0 {
+			return seq
+		}
 	}
 	if s.view != nil {
 		return s.view.LedgerSeq()

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -267,9 +267,8 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// unless the trust line already exists or it's an LP token trust line
 	// for a non-empty AMM.
 	// Reference: rippled SetTrust.cpp lines 273-309
-	var zeroHash [32]byte
-	if (issuerAccount.Flags & state.LsfAMM) != 0 {
-		if issuerAccount.AMMID != zeroHash {
+	if issuerAccount.IsPseudoAccount() {
+		if issuerAccount.AMMID != [32]byte{} {
 			if trustLineExists {
 				// Allow modification of existing trust lines to AMM accounts.
 			} else {

--- a/tasks/conformance-audit.md
+++ b/tasks/conformance-audit.md
@@ -27,3 +27,31 @@ incremental reviews instead of re-reading rippled from scratch.
 - Files cleanup-only (Phase 0 skipped Phase 1): none
 - Cleanup commit: none — prior commit dd54397 already covered the cleanup; cleaning-ai-comments pass was a no-op
 - Notes: All Minor findings are documented divergences with defensible rationale or near-term-correct heuristics; no blockers. Two flagged comment-accuracy nits (apply_state_table.go:2031-2032, shamap/shamap.go:558-569) left in place because the surrounding rationale is load-bearing and a surgical edit would be a content rewrite rather than a janitorial removal.
+
+## 2026-05-22 — PR #509 — fix/issue-499-invariant-gaps
+- Rippled SHA at review: 1e89286a92
+- PR URL: https://github.com/LeJamon/go-xrpl/pull/509
+- Review comment: https://github.com/LeJamon/go-xrpl/pull/509#issuecomment-4518444212
+- Files reviewed (Phase 1):
+  - internal/ledger/ledger.go — 0 new findings (prior #473 nits unchanged; +6-line delta)
+  - internal/ledger/service/snapshot_view.go — 0 findings
+  - internal/rpc/types/services.go — 0 findings (1-line interface method addition)
+  - internal/tx/amm/amm_create.go — 1 Blocking (LsfAMM flag-mask divergence)
+  - internal/tx/apply_state_table.go — 0 new findings (prior #473 nits unchanged; +6-line delta)
+  - internal/tx/apply_state_table_test.go — 0 findings
+  - internal/tx/engine.go — 0 findings (LedgerSeq interface addition)
+  - internal/tx/invariants/basic.go — 1 Blocking (XChainAddAccountCreateAttestation string typo), 2 Minor (M3 dup UInt32, M4 missing seq/flags), 0 Nit
+  - internal/tx/invariants/invariants.go — 0 findings
+  - internal/tx/invariants/invariants_test.go — 1 Blocking (mirror of basic.go B1), 1 Nit (missing test coverage)
+  - internal/tx/invariants/offers.go — 1 Minor (IOU badCurrency missing), 1 Minor (XRPNotCreated message fidelity, no-fix), 1 Nit (Signum cleanup)
+  - internal/tx/payment/flow_test.go — 0 findings
+  - internal/tx/payment/pathfinder/pathfinder_test.go — 0 findings
+  - internal/tx/payment/payment_xrp.go — 0 findings (LookupDestination switched to IsPseudoAccount via B2 fix)
+  - internal/tx/payment/sandbox.go — 1 Nit (LedgerSeq fallback ordering)
+  - internal/tx/trustset/trustset.go — 0 findings (switched to IsPseudoAccount via B2 fix)
+- Files cleanup-only (Phase 0 skipped Phase 1): none
+- Pre-Phase-1 commit: c1a63c6 — chore(invariants): drop unused stubTx test helper (unblocked just lint)
+- Review-fix commit: 3df37f3 — review(#499): address rippled-conformance findings (all 2 Blocking + 5 Minor + 3 Nit resolved, incl. AccountRoot.IsPseudoAccount helper + 4 new tests)
+- Cleanup commit: 3caa79e — chore: clean ai-generated comments (2 section-label removals; rest were rippled citations / non-obvious whys, kept as load-bearing)
+- Notes: B2 (LsfAMM) had broader blast radius than the review suggested — 4 production detection sites + 2 test assertions switched to AccountRoot.IsPseudoAccount() (mirrors rippled View.cpp:1138 isPseudoAccount). LsfAMM constant removed entirely; bit 0x02000000 collides with rippled's lsfTshCollect (hooks) and lsfLowDeepFreeze (RippleState). Wire-format collision risk surfaced by the review and tracked as out-of-scope for a future gap audit.
+


### PR DESCRIPTION
## Summary
Closes the five DIVERGENT items called out by the invariants section of `tasks/rippled-gap-audit.md`. Each invariant now mirrors rippled's `InvariantCheck.cpp` semantics:

- **`XRPNotCreated`** enforces `-netChange == fee` strict equality (was: only `netChange > 0`). Catches the no-XRP-mint guard with full fidelity.
- **`ValidNewAccountRoot`** allows `VaultCreate` and the two XChain attestation tx types; checks `accountSeq == startingSeq` (gated on `featureDeletableAccounts` via a new `ReadView.LedgerSeq()`) and the `lsfDisableMaster|lsfDefaultRipple|lsfDepositAuth` flag mask for pseudo-accounts (gated on `featureSingleAssetVault`). Pseudo-account detection inspects `sfAMMID` / `sfVaultID`.
- **`AccountRootsNotDeleted`** allows `VaultDelete` to delete exactly one AccountRoot.
- **`NoZeroEscrow`** now covers IOU and MPT escrow amount bounds plus `MPTokenIssuance` outstanding/locked bounds and `MPToken` amount bounds.
- **`NoBadOffers`** also inspects the pre-tx Offer image, closing a defense-in-depth gap.

To keep the new ValidNewAccountRoot strict checks consistent with rippled, AMM pseudo-account creation now matches rippled's `createPseudoAccount` (`View.cpp:1112-1133`): `Sequence = view.seq()` when `featureSingleAssetVault` is disabled, `0` when it is enabled.

## Test plan
- [x] `just build`
- [x] `just vet`
- [x] `just test-pkg ./internal/tx/invariants/...` (5 new unit tests for the changed checks)
- [x] `just test-pkg ./internal/testing/invariants/...`
- [x] `just test-pkg ./internal/testing/amm/...` (verifies AMM pseudo-account sequence fix)
- [x] `just test-pkg ./internal/testing/permissioneddex/...` (verifies AMM-create still works through engine)
- [x] `just test-integration` — no new failures (pre-existing MPT escrow / MPT payment failures on `main` unrelated to this change)

Fixes #499