### PR TITLE
fix: route jq_trans_overflow to overlay tx-ingress drop counter

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -248,7 +248,7 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	services.TxQMetrics = func() types.TxQServerMetrics {
 		m := ledgerSvcRef.GetTxQMetrics()
 		return types.TxQServerMetrics{
-			JqTransOverflow:       m.JqTransOverflow,
+			TxQFull:               m.TxQFull,
 			ReferenceFeeLevel:     m.ReferenceFeeLevel,
 			MinProcessingFeeLevel: m.MinProcessingFeeLevel,
 			OpenLedgerFeeLevel:    m.OpenLedgerFeeLevel,
@@ -347,6 +347,7 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		services.PeerDisconnects = func() (uint64, uint64) {
 			return overlayRef.PeerDisconnects(), overlayRef.PeerDisconnectsResources()
 		}
+		services.JqTransOverflow = overlayRef.DroppedTransactions
 		acctRef := consensusComponents.Adaptor
 		services.StateAccounting = func() types.StateAccountingSnapshot {
 			snap := acctRef.StateAccounting()

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -248,7 +248,6 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	services.TxQMetrics = func() types.TxQServerMetrics {
 		m := ledgerSvcRef.GetTxQMetrics()
 		return types.TxQServerMetrics{
-			TxQFull:               m.TxQFull,
 			ReferenceFeeLevel:     m.ReferenceFeeLevel,
 			MinProcessingFeeLevel: m.MinProcessingFeeLevel,
 			OpenLedgerFeeLevel:    m.OpenLedgerFeeLevel,

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -595,6 +595,15 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 		opts = append(opts, peermanagement.WithClusterNodes(appCfg.ClusterNodes...))
 	}
 
+	// Max in-flight TMTransaction frames the overlay will hand to the
+	// router before refusing new ones (jq_trans_overflow trigger).
+	// Mirrors rippled's [max_transactions] (Config.h:226, Config.cpp:791-793).
+	// appCfg validation clamps to [100, 1000] when set; zero falls
+	// through to peermanagement's DefaultMaxTransactions (250).
+	if appCfg.MaxTransactions > 0 {
+		opts = append(opts, peermanagement.WithMaxTransactions(appCfg.MaxTransactions))
+	}
+
 	return opts
 }
 

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -22,6 +22,14 @@ const (
 	DefaultMessageBufferSize = 256
 	DefaultSendBufferSize    = 64
 
+	// DefaultMaxTransactions matches rippled's Config::MAX_TRANSACTIONS
+	// default (rippled/src/xrpld/core/Config.h:226). It is the per-type
+	// in-flight ceiling consulted at TMTransaction ingress before
+	// dispatching to the router; the rippled-analog of the comparator
+	// at PeerImp.cpp:1349-1355 (`getJobCount(jtTRANSACTION) >
+	// MAX_TRANSACTIONS`).
+	DefaultMaxTransactions = 250
+
 	DefaultUserAgent = "goXRPL/0.1.0"
 )
 
@@ -57,6 +65,17 @@ type Config struct {
 	EventBufferSize   int
 	MessageBufferSize int
 	SendBufferSize    int
+
+	// MaxTransactions is the rippled-analog of Config::MAX_TRANSACTIONS
+	// (rippled/src/xrpld/core/Config.h:226, [max_transactions] in
+	// rippled.cfg). It caps the per-type in-flight TMTransaction frames
+	// the overlay will hand to the router before refusing new ones and
+	// bumping droppedTransactions — mirroring PeerImp.cpp:1349-1355
+	// where rippled refuses to schedule a jtTRANSACTION job when the
+	// JobQueue already has more than MAX_TRANSACTIONS in flight.
+	// Non-positive disables the gate (channel-saturation drop remains
+	// the defensive backstop).
+	MaxTransactions int
 
 	// Features — advertised via X-Protocol-Ctl during handshake so
 	// peers know which optional protocol extensions we speak. Matches
@@ -130,6 +149,7 @@ func DefaultConfig() Config {
 		EventBufferSize:   DefaultEventBufferSize,
 		MessageBufferSize: DefaultMessageBufferSize,
 		SendBufferSize:    DefaultSendBufferSize,
+		MaxTransactions:   DefaultMaxTransactions,
 
 		// Reduce-relay is opt-in; rippled defaults all three to false
 		// (Config.h:248, Config.h:258, Config.cpp:755-762). Leaving
@@ -334,6 +354,15 @@ func WithEventBufferSize(size int) Option {
 func WithMessageBufferSize(size int) Option {
 	return func(c *Config) {
 		c.MessageBufferSize = size
+	}
+}
+
+// WithMaxTransactions sets the in-flight TMTransaction ceiling at the
+// overlay → router boundary. Mirrors rippled's [max_transactions]
+// (Config.h:226). Non-positive disables the gate. Default 250.
+func WithMaxTransactions(n int) Option {
+	return func(c *Config) {
+		c.MaxTransactions = n
 	}
 }
 

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -303,6 +303,16 @@ type Overlay struct {
 	// slow consumer silently loses events with only a debug-level log.
 	droppedMessages atomic.Uint64
 
+	// droppedTransactions is the TMTransaction-specific slice of
+	// droppedMessages: incremented when the dropped inbound message
+	// was a TMTransaction frame. This is goxrpl's analog of rippled's
+	// OverlayImpl::jqTransOverflow_, bumped at PeerImp.cpp:1353 when
+	// the JobQueue refuses a jtTRANSACTION job. The wire site is the
+	// same shape (peer ingress can't hand work to the next stage),
+	// even though the next stage is a bounded channel here rather
+	// than a JobQueue. Surfaced via server_info as jq_trans_overflow.
+	droppedTransactions atomic.Uint64
+
 	// droppedLedgerResponses counts the same shape for the ledger-sync
 	// response send path (EventLedgerResponse). Separate from
 	// droppedMessages so the two traffic classes can be distinguished.
@@ -644,6 +654,18 @@ func (o *Overlay) ListenAddr() string {
 	return l.Addr().String()
 }
 
+// messageBufferSize returns the inbound-message channel capacity,
+// falling back to DefaultMessageBufferSize when the configured value
+// is non-positive. A non-positive size would create an unbuffered
+// channel, turning the non-blocking send in handlePeerMessage into a
+// drop-every-message path under any load.
+func messageBufferSize(configured int) int {
+	if configured <= 0 {
+		return DefaultMessageBufferSize
+	}
+	return configured
+}
+
 // New creates a new Overlay with the provided options.
 func New(opts ...Option) (*Overlay, error) {
 	cfg := DefaultConfig()
@@ -691,7 +713,7 @@ func New(opts ...Option) (*Overlay, error) {
 		ledgerSync:     NewLedgerSyncHandler(events),
 		peers:          make(map[PeerID]*Peer),
 		events:         events,
-		messages:       make(chan *InboundMessage, 256),
+		messages:       make(chan *InboundMessage, messageBufferSize(cfg.MessageBufferSize)),
 		relayedIndex:   make(map[[32]byte]*relayedEntry),
 		clockForIndex:  time.Now,
 		inboundSem:     make(chan struct{}, inboundCap),
@@ -1304,8 +1326,22 @@ func (o *Overlay) onMessageReceived(evt Event) {
 	}:
 	default:
 		o.droppedMessages.Add(1)
+		if msgType == message.TypeTransaction {
+			o.droppedTransactions.Add(1)
+		}
 		slog.Warn("Message dropped: channel full", "t", "Overlay", "type", msgType.String())
 	}
+}
+
+// DroppedTransactions returns the cumulative count of TMTransaction
+// frames the overlay had to drop because the downstream consumer
+// channel was full. Surfaced via server_info as jq_trans_overflow —
+// the rippled-analog signal for "inbound transaction processing fell
+// behind". See rippled OverlayImpl::getJqTransOverflow / PeerImp.cpp:1353
+// for the upstream counter; the goxrpl shape is a bounded channel
+// rather than a JobQueue, but the operator signal is the same.
+func (o *Overlay) DroppedTransactions() uint64 {
+	return o.droppedTransactions.Load()
 }
 
 // DroppedMessages returns the cumulative count of inbound messages the

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -280,6 +280,12 @@ type Overlay struct {
 	events   chan Event
 	messages chan *InboundMessage
 
+	// maxTransactions caches cfg.MaxTransactions, the per-type
+	// in-flight TMTransaction ceiling consulted at the overlay → router
+	// boundary. Mirrors rippled's MAX_TRANSACTIONS check at
+	// PeerImp.cpp:1349-1355. Non-positive disables the gate.
+	maxTransactions int
+
 	// Peer lifecycle callbacks wired by higher layers (e.g., consensus
 	// router) that need to clean up per-peer state on disconnect. Fired
 	// from the event-loop goroutine AFTER the peer has been removed from
@@ -303,14 +309,20 @@ type Overlay struct {
 	// slow consumer silently loses events with only a debug-level log.
 	droppedMessages atomic.Uint64
 
-	// droppedTransactions is the TMTransaction-specific slice of
-	// droppedMessages: incremented when the dropped inbound message
-	// was a TMTransaction frame. This is goxrpl's analog of rippled's
-	// OverlayImpl::jqTransOverflow_, bumped at PeerImp.cpp:1353 when
-	// the JobQueue refuses a jtTRANSACTION job. The wire site is the
-	// same shape (peer ingress can't hand work to the next stage),
-	// even though the next stage is a bounded channel here rather
-	// than a JobQueue. Surfaced via server_info as jq_trans_overflow.
+	// droppedTransactions is goxrpl's analog of rippled's
+	// OverlayImpl::jqTransOverflow_ (OverlayImpl.h:121), bumped at
+	// PeerImp.cpp:1353 when rippled's gate
+	// `getJobCount(jtTRANSACTION) > config().MAX_TRANSACTIONS` trips
+	// and the inbound tx job is refused. The goxrpl analog gate is
+	// applied at onMessageReceived (see the per-type ceiling check
+	// against cfg.MaxTransactions): when the messages-channel depth
+	// already meets the configured ceiling, a new TMTransaction frame
+	// is refused before the channel send and this counter increments.
+	// The hard channel-full drop branch in onMessageReceived is the
+	// defensive backstop: if the ceiling gate is disabled (cfg.MaxTransactions
+	// <= 0) or fails to fire for any reason, the channel-saturation
+	// path still records the drop. Surfaced via server_info as
+	// jq_trans_overflow.
 	droppedTransactions atomic.Uint64
 
 	// droppedLedgerResponses counts the same shape for the ledger-sync
@@ -705,19 +717,20 @@ func New(opts ...Option) (*Overlay, error) {
 	}
 
 	o := &Overlay{
-		cfg:            cfg,
-		identity:       identity,
-		cluster:        clusterReg,
-		instanceCookie: cookie,
-		discovery:      NewDiscovery(&cfg, events),
-		ledgerSync:     NewLedgerSyncHandler(events),
-		peers:          make(map[PeerID]*Peer),
-		events:         events,
-		messages:       make(chan *InboundMessage, messageBufferSize(cfg.MessageBufferSize)),
-		relayedIndex:   make(map[[32]byte]*relayedEntry),
-		clockForIndex:  time.Now,
-		inboundSem:     make(chan struct{}, inboundCap),
-		outboundSem:    make(chan struct{}, outboundCap),
+		cfg:             cfg,
+		identity:        identity,
+		cluster:         clusterReg,
+		instanceCookie:  cookie,
+		discovery:       NewDiscovery(&cfg, events),
+		ledgerSync:      NewLedgerSyncHandler(events),
+		peers:           make(map[PeerID]*Peer),
+		events:          events,
+		messages:        make(chan *InboundMessage, messageBufferSize(cfg.MessageBufferSize)),
+		maxTransactions: cfg.MaxTransactions,
+		relayedIndex:    make(map[[32]byte]*relayedEntry),
+		clockForIndex:   time.Now,
+		inboundSem:      make(chan struct{}, inboundCap),
+		outboundSem:     make(chan struct{}, outboundCap),
 	}
 
 	// Wire reduce-relay callbacks. The squelch callback constructs and
@@ -1315,6 +1328,22 @@ func (o *Overlay) onMessageReceived(evt Event) {
 
 	slog.Debug("Message received", "t", "Overlay", "type", msgType.String(), "peer", evt.PeerID, "size", len(evt.Payload))
 
+	// Rippled-faithful per-type ingress gate. Mirrors PeerImp.cpp:1349-1355
+	// where `getJobCount(jtTRANSACTION) > config().MAX_TRANSACTIONS`
+	// causes the inbound transaction to be refused (counter incremented,
+	// info log emitted). goxrpl has no JobQueue; the closest analog is
+	// the messages-channel depth at check time. Refusing before the
+	// channel send keeps non-tx traffic flowing when the dispatch
+	// pipeline is tx-saturated — matching rippled's per-type semantics.
+	// Gate is disabled when maxTransactions <= 0; the channel-saturation
+	// branch below is the defensive backstop.
+	if msgType == message.TypeTransaction && o.maxTransactions > 0 && len(o.messages) >= o.maxTransactions {
+		o.droppedTransactions.Add(1)
+		slog.Info("Transaction queue is full", "t", "Overlay",
+			"pending", len(o.messages), "max", o.maxTransactions, "peer", evt.PeerID)
+		return
+	}
+
 	// Forward to external consumers. On back-pressure (channel full),
 	// increment a visible counter rather than silently dropping — the
 	// warn log alone is easy to miss at production log levels.
@@ -1334,12 +1363,14 @@ func (o *Overlay) onMessageReceived(evt Event) {
 }
 
 // DroppedTransactions returns the cumulative count of TMTransaction
-// frames the overlay had to drop because the downstream consumer
-// channel was full. Surfaced via server_info as jq_trans_overflow —
-// the rippled-analog signal for "inbound transaction processing fell
-// behind". See rippled OverlayImpl::getJqTransOverflow / PeerImp.cpp:1353
-// for the upstream counter; the goxrpl shape is a bounded channel
-// rather than a JobQueue, but the operator signal is the same.
+// frames refused at the overlay → router boundary. Surfaced via
+// server_info as jq_trans_overflow, mirroring rippled's
+// OverlayImpl::getJqTransOverflow (OverlayImpl.h:359-363) which is
+// bumped at PeerImp.cpp:1353 when
+// `getJobCount(jtTRANSACTION) > config().MAX_TRANSACTIONS`. The
+// goxrpl gate consults the messages-channel depth against
+// cfg.MaxTransactions in lieu of a JobQueue, but the operator signal
+// — "inbound transaction processing fell behind" — is the same.
 func (o *Overlay) DroppedTransactions() uint64 {
 	return o.droppedTransactions.Load()
 }

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -313,16 +313,10 @@ type Overlay struct {
 	// OverlayImpl::jqTransOverflow_ (OverlayImpl.h:121), bumped at
 	// PeerImp.cpp:1353 when rippled's gate
 	// `getJobCount(jtTRANSACTION) > config().MAX_TRANSACTIONS` trips
-	// and the inbound tx job is refused. The goxrpl analog gate is
-	// applied at onMessageReceived (see the per-type ceiling check
-	// against cfg.MaxTransactions): when the messages-channel depth
-	// already meets the configured ceiling, a new TMTransaction frame
-	// is refused before the channel send and this counter increments.
-	// The hard channel-full drop branch in onMessageReceived is the
-	// defensive backstop: if the ceiling gate is disabled (cfg.MaxTransactions
-	// <= 0) or fails to fire for any reason, the channel-saturation
-	// path still records the drop. Surfaced via server_info as
-	// jq_trans_overflow.
+	// and the inbound tx job is refused. goxrpl applies the analog
+	// gate in onMessageReceived against cfg.MaxTransactions; the
+	// channel-saturation drop is the backstop when the gate is
+	// disabled. Surfaced via server_info as jq_trans_overflow.
 	droppedTransactions atomic.Uint64
 
 	// droppedLedgerResponses counts the same shape for the ledger-sync
@@ -1328,15 +1322,10 @@ func (o *Overlay) onMessageReceived(evt Event) {
 
 	slog.Debug("Message received", "t", "Overlay", "type", msgType.String(), "peer", evt.PeerID, "size", len(evt.Payload))
 
-	// Rippled-faithful per-type ingress gate. Mirrors PeerImp.cpp:1349-1355
-	// where `getJobCount(jtTRANSACTION) > config().MAX_TRANSACTIONS`
-	// causes the inbound transaction to be refused (counter incremented,
-	// info log emitted). goxrpl has no JobQueue; the closest analog is
-	// the messages-channel depth at check time. Refusing before the
-	// channel send keeps non-tx traffic flowing when the dispatch
-	// pipeline is tx-saturated — matching rippled's per-type semantics.
-	// Gate is disabled when maxTransactions <= 0; the channel-saturation
-	// branch below is the defensive backstop.
+	// Per-type ingress gate mirroring PeerImp.cpp:1349-1355: refuse
+	// before the channel send so non-tx traffic keeps flowing when
+	// the dispatch pipeline is tx-saturated. Channel-saturation
+	// branch below is the backstop when the gate is disabled.
 	if msgType == message.TypeTransaction && o.maxTransactions > 0 && len(o.messages) >= o.maxTransactions {
 		o.droppedTransactions.Add(1)
 		slog.Info("Transaction queue is full", "t", "Overlay",
@@ -1364,13 +1353,8 @@ func (o *Overlay) onMessageReceived(evt Event) {
 
 // DroppedTransactions returns the cumulative count of TMTransaction
 // frames refused at the overlay → router boundary. Surfaced via
-// server_info as jq_trans_overflow, mirroring rippled's
-// OverlayImpl::getJqTransOverflow (OverlayImpl.h:359-363) which is
-// bumped at PeerImp.cpp:1353 when
-// `getJobCount(jtTRANSACTION) > config().MAX_TRANSACTIONS`. The
-// goxrpl gate consults the messages-channel depth against
-// cfg.MaxTransactions in lieu of a JobQueue, but the operator signal
-// — "inbound transaction processing fell behind" — is the same.
+// server_info as jq_trans_overflow; see the droppedTransactions
+// field doc for the rippled-mapping rationale.
 func (o *Overlay) DroppedTransactions() uint64 {
 	return o.droppedTransactions.Load()
 }

--- a/internal/peermanagement/tx_ingress_test.go
+++ b/internal/peermanagement/tx_ingress_test.go
@@ -1,0 +1,128 @@
+package peermanagement
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+)
+
+// TestOverlay_TxIngress_OverflowCounter pins the rippled-shape
+// jq_trans_overflow signal: when the overlay→router messages channel
+// is saturated and the dropped frame is a TMTransaction, the per-type
+// DroppedTransactions counter increments (in addition to the
+// aggregate DroppedMessages). This is the operator signal surfaced as
+// server_info.jq_trans_overflow per issue #494.
+func TestOverlay_TxIngress_OverflowCounter(t *testing.T) {
+	const capacity = 4
+	const flooded = 64
+
+	o := &Overlay{
+		messages: make(chan *InboundMessage, capacity),
+	}
+
+	// First `capacity` sends fit in the buffer; the rest fall through
+	// to the default branch and bump droppedTransactions.
+	for i := 0; i < flooded; i++ {
+		o.onMessageReceived(Event{
+			Type:        EventMessageReceived,
+			PeerID:      PeerID(1),
+			MessageType: uint16(message.TypeTransaction),
+			Payload:     []byte{0xde, 0xad, 0xbe, 0xef},
+		})
+	}
+
+	wantDropped := uint64(flooded - capacity)
+	assert.Equal(t, wantDropped, o.DroppedTransactions(),
+		"DroppedTransactions must count overflowed TMTransaction frames")
+	assert.Equal(t, wantDropped, o.DroppedMessages(),
+		"DroppedMessages aggregate must equal the type-specific count when only tx frames overflow")
+
+	// The accepted frames must have actually landed in the channel.
+	assert.Equal(t, capacity, len(o.messages),
+		"messages channel must be full after a flood that exceeds capacity")
+}
+
+// TestOverlay_TxIngress_OnlyTxCounterMovesForTx confirms the
+// droppedTransactions counter is TMTransaction-specific: dropping a
+// non-tx frame bumps droppedMessages but leaves droppedTransactions
+// untouched. Without this discrimination the jq_trans_overflow signal
+// would conflate transaction backpressure with unrelated traffic
+// (ledger_data, validations, etc.) and confuse operators.
+func TestOverlay_TxIngress_OnlyTxCounterMovesForTx(t *testing.T) {
+	o := &Overlay{
+		messages: make(chan *InboundMessage, 1),
+	}
+
+	nonTxType := uint16(message.TypeLedgerData)
+	// Fill the channel with a non-tx frame, then overflow with another.
+	for i := 0; i < 4; i++ {
+		o.onMessageReceived(Event{
+			Type:        EventMessageReceived,
+			PeerID:      PeerID(1),
+			MessageType: nonTxType,
+			Payload:     []byte{0x00},
+		})
+	}
+
+	assert.Equal(t, uint64(0), o.DroppedTransactions(),
+		"DroppedTransactions must not move when only non-tx frames overflow")
+	assert.Greater(t, o.DroppedMessages(), uint64(0),
+		"DroppedMessages aggregate must still record the non-tx drops")
+}
+
+// TestOverlay_TxIngress_BoundedGoroutines is the bounded-backpressure
+// soak: flood thousands of TMTransaction frames at a tiny channel and
+// confirm no goroutine fans out per-message. The single-writer ingest
+// path is the structural bound on memory growth — if a future change
+// fans out per-frame, the goroutine count would scale with the flood
+// size and this test would fail.
+func TestOverlay_TxIngress_BoundedGoroutines(t *testing.T) {
+	const capacity = 8
+	const flooded = 10_000
+	const writers = 16
+
+	o := &Overlay{
+		messages: make(chan *InboundMessage, capacity),
+	}
+
+	// Settle the runtime before sampling baseline goroutines.
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < flooded/writers; i++ {
+				o.onMessageReceived(Event{
+					Type:        EventMessageReceived,
+					PeerID:      PeerID(1),
+					MessageType: uint16(message.TypeTransaction),
+					Payload:     []byte{0x01},
+				})
+			}
+		}()
+	}
+	wg.Wait()
+	runtime.GC()
+
+	// After the flood, in-flight goroutines must not have ballooned in
+	// proportion to message count. Allow generous slack to absorb the
+	// runtime's bookkeeping goroutines; the assertion fails only on
+	// per-message fan-out (which would push the delta into the thousands).
+	delta := runtime.NumGoroutine() - baseline
+	assert.LessOrEqual(t, delta, writers+8,
+		"per-message goroutine fan-out detected: delta=%d, baseline=%d", delta, baseline)
+
+	// Sanity: counter advanced. Exact value isn't deterministic under
+	// concurrent producers (consumer never runs, but writes are
+	// non-blocking), so just assert progress.
+	require.Greater(t, o.DroppedTransactions(), uint64(0),
+		"flood must have triggered at least one TMTransaction drop")
+}

--- a/internal/peermanagement/tx_ingress_test.go
+++ b/internal/peermanagement/tx_ingress_test.go
@@ -11,22 +11,64 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 )
 
-// TestOverlay_TxIngress_OverflowCounter pins the rippled-shape
-// jq_trans_overflow signal: when the overlay→router messages channel
-// is saturated and the dropped frame is a TMTransaction, the per-type
-// DroppedTransactions counter increments (in addition to the
-// aggregate DroppedMessages). This is the operator signal surfaced as
-// server_info.jq_trans_overflow per issue #494.
-func TestOverlay_TxIngress_OverflowCounter(t *testing.T) {
+// TestOverlay_TxIngress_RippledGate pins the rippled-shape
+// jq_trans_overflow trigger: when the in-flight TMTransaction count
+// (proxied by messages-channel depth) already meets the configured
+// MaxTransactions ceiling, the next TMTransaction frame is refused
+// BEFORE the channel send and droppedTransactions increments.
+// Mirrors PeerImp.cpp:1349-1355 where
+// `getJobCount(jtTRANSACTION) > config().MAX_TRANSACTIONS` causes
+// rippled to bump jqTransOverflow_ and skip dispatching the job.
+func TestOverlay_TxIngress_RippledGate(t *testing.T) {
+	const maxTx = 4
+	const flooded = 64
+
+	// Channel cap is intentionally larger than maxTx so the ceiling
+	// gate fires before any hard channel-saturation drop — matching
+	// the production case where MessageBufferSize > MaxTransactions.
+	o := &Overlay{
+		messages:        make(chan *InboundMessage, 32),
+		maxTransactions: maxTx,
+	}
+
+	for i := 0; i < flooded; i++ {
+		o.onMessageReceived(Event{
+			Type:        EventMessageReceived,
+			PeerID:      PeerID(1),
+			MessageType: uint16(message.TypeTransaction),
+			Payload:     []byte{0xde, 0xad, 0xbe, 0xef},
+		})
+	}
+
+	// First `maxTx` sends land in the channel; the rest are refused
+	// at the rippled-faithful ingress gate.
+	wantDropped := uint64(flooded - maxTx)
+	assert.Equal(t, wantDropped, o.DroppedTransactions(),
+		"DroppedTransactions must count refusals at the MaxTransactions ceiling")
+	assert.Equal(t, maxTx, len(o.messages),
+		"messages channel must hold exactly MaxTransactions accepted frames")
+
+	// The aggregate droppedMessages counter does NOT move for ceiling
+	// refusals — only hard channel-saturation drops bump it, matching
+	// the field invariant that droppedMessages tracks send-side failures.
+	assert.Equal(t, uint64(0), o.DroppedMessages(),
+		"DroppedMessages must not move when refusals happen at the per-type gate")
+}
+
+// TestOverlay_TxIngress_ChannelSaturationBackstop verifies that when
+// the rippled-faithful gate is disabled (maxTransactions <= 0), the
+// channel-saturation drop branch still records refused TMTransaction
+// frames. This is the defensive backstop: even without an explicit
+// ceiling, a slow consumer cannot silently lose tx-ingress signal.
+func TestOverlay_TxIngress_ChannelSaturationBackstop(t *testing.T) {
 	const capacity = 4
 	const flooded = 64
 
 	o := &Overlay{
 		messages: make(chan *InboundMessage, capacity),
+		// maxTransactions intentionally zero — gate disabled.
 	}
 
-	// First `capacity` sends fit in the buffer; the rest fall through
-	// to the default branch and bump droppedTransactions.
 	for i := 0; i < flooded; i++ {
 		o.onMessageReceived(Event{
 			Type:        EventMessageReceived,
@@ -38,13 +80,9 @@ func TestOverlay_TxIngress_OverflowCounter(t *testing.T) {
 
 	wantDropped := uint64(flooded - capacity)
 	assert.Equal(t, wantDropped, o.DroppedTransactions(),
-		"DroppedTransactions must count overflowed TMTransaction frames")
+		"DroppedTransactions must count channel-full drops when ceiling gate is disabled")
 	assert.Equal(t, wantDropped, o.DroppedMessages(),
 		"DroppedMessages aggregate must equal the type-specific count when only tx frames overflow")
-
-	// The accepted frames must have actually landed in the channel.
-	assert.Equal(t, capacity, len(o.messages),
-		"messages channel must be full after a flood that exceeds capacity")
 }
 
 // TestOverlay_TxIngress_OnlyTxCounterMovesForTx confirms the
@@ -75,6 +113,32 @@ func TestOverlay_TxIngress_OnlyTxCounterMovesForTx(t *testing.T) {
 		"DroppedMessages aggregate must still record the non-tx drops")
 }
 
+// TestOverlay_TxIngress_NonTxBypassesGate confirms the
+// rippled-faithful gate is per-type: non-TMTransaction frames are
+// never refused at the ceiling, matching PeerImp.cpp where the
+// jq_trans_overflow check is inside `onMessage(TMTransaction)` and
+// other handlers (proposal, validation, ledger_data) ignore it.
+func TestOverlay_TxIngress_NonTxBypassesGate(t *testing.T) {
+	o := &Overlay{
+		messages:        make(chan *InboundMessage, 32),
+		maxTransactions: 2,
+	}
+
+	// Saturate the channel above maxTransactions with NON-tx frames.
+	for i := 0; i < 16; i++ {
+		o.onMessageReceived(Event{
+			Type:        EventMessageReceived,
+			PeerID:      PeerID(1),
+			MessageType: uint16(message.TypeLedgerData),
+			Payload:     []byte{0x00},
+		})
+	}
+	require.Equal(t, 16, len(o.messages),
+		"non-tx frames must not trip the per-type ceiling")
+	assert.Equal(t, uint64(0), o.DroppedTransactions(),
+		"non-tx traffic must not bump the TMTransaction counter")
+}
+
 // TestOverlay_TxIngress_BoundedGoroutines is the bounded-backpressure
 // soak: flood thousands of TMTransaction frames at a tiny channel and
 // confirm no goroutine fans out per-message. The single-writer ingest
@@ -87,7 +151,8 @@ func TestOverlay_TxIngress_BoundedGoroutines(t *testing.T) {
 	const writers = 16
 
 	o := &Overlay{
-		messages: make(chan *InboundMessage, capacity),
+		messages:        make(chan *InboundMessage, capacity),
+		maxTransactions: capacity, // exercise the rippled-faithful gate
 	}
 
 	// Settle the runtime before sampling baseline goroutines.
@@ -114,15 +179,37 @@ func TestOverlay_TxIngress_BoundedGoroutines(t *testing.T) {
 
 	// After the flood, in-flight goroutines must not have ballooned in
 	// proportion to message count. Allow generous slack to absorb the
-	// runtime's bookkeeping goroutines; the assertion fails only on
-	// per-message fan-out (which would push the delta into the thousands).
+	// runtime's bookkeeping goroutines on loaded CI runners; the
+	// assertion fails only on per-message fan-out (which would push
+	// the delta into the thousands).
 	delta := runtime.NumGoroutine() - baseline
-	assert.LessOrEqual(t, delta, writers+8,
+	assert.LessOrEqual(t, delta, writers+64,
 		"per-message goroutine fan-out detected: delta=%d, baseline=%d", delta, baseline)
 
 	// Sanity: counter advanced. Exact value isn't deterministic under
 	// concurrent producers (consumer never runs, but writes are
 	// non-blocking), so just assert progress.
 	require.Greater(t, o.DroppedTransactions(), uint64(0),
-		"flood must have triggered at least one TMTransaction drop")
+		"flood must have triggered at least one TMTransaction refusal")
+}
+
+// TestMessageBufferSize_NonPositiveFallback pins the helper's
+// non-positive → DefaultMessageBufferSize contract. Without this,
+// a non-positive cfg.MessageBufferSize would create an unbuffered
+// channel and turn the non-blocking send into a drop-every-message
+// path under any load.
+func TestMessageBufferSize_NonPositiveFallback(t *testing.T) {
+	cases := []struct {
+		in   int
+		want int
+	}{
+		{0, DefaultMessageBufferSize},
+		{-1, DefaultMessageBufferSize},
+		{1, 1},
+		{1024, 1024},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, messageBufferSize(tc.in),
+			"messageBufferSize(%d)", tc.in)
+	}
 }

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -138,8 +138,6 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		"peers":             getPeerCount(ctx),
 
 		// Overflow/disconnect counters (string in rippled).
-		// jq_trans_overflow sources from the overlay's inbound-tx
-		// refusal counter, matching rippled's PeerImp.cpp:1353 trigger.
 		"jq_trans_overflow":          fmt.Sprintf("%d", overflow),
 		"peer_disconnects":           fmt.Sprintf("%d", peerDisc),
 		"peer_disconnects_resources": fmt.Sprintf("%d", peerDiscRes),

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -124,7 +124,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	// Fallback used only when consensus hasn't wired a state-accounting tracker.
 	uptimeUs := uptimeDuration.Microseconds()
 
-	overflow, txqFull, peerDisc, peerDiscRes := resolveDisconnectCounters(services)
+	overflow, peerDisc, peerDiscRes := resolveDisconnectCounters(services)
 	accounting := resolveStateAccounting(services, serverState, uptimeUs)
 
 	info := map[string]interface{}{
@@ -139,11 +139,8 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 
 		// Overflow/disconnect counters (string in rippled).
 		// jq_trans_overflow sources from the overlay's inbound-tx
-		// drop counter to match rippled's PeerImp.cpp:1353 signal
-		// shape; txq_full carries the distinct TxQ admission-control
-		// rejection count under its own accurate name.
+		// refusal counter, matching rippled's PeerImp.cpp:1353 trigger.
 		"jq_trans_overflow":          fmt.Sprintf("%d", overflow),
-		"txq_full":                   fmt.Sprintf("%d", txqFull),
 		"peer_disconnects":           fmt.Sprintf("%d", peerDisc),
 		"peer_disconnects_resources": fmt.Sprintf("%d", peerDiscRes),
 
@@ -381,27 +378,22 @@ func resolveValidationQuorum(services *types.ServiceContainer) int {
 	return 1
 }
 
-// resolveDisconnectCounters reads the overlay/TxQ overflow &
-// disconnect counters via service hooks. Returns zeros when hooks
-// aren't wired so server_info still produces a complete shape.
-//
-// overflow sources from the overlay's TMTransaction-drop counter
-// (the rippled-shape jq_trans_overflow signal); txqFull is the
-// TxQ-saturation counter surfaced separately as server_info.txq_full.
-func resolveDisconnectCounters(services *types.ServiceContainer) (overflow, txqFull, peerDisc, peerDiscRes uint64) {
+// resolveDisconnectCounters reads the overlay overflow & disconnect
+// counters via service hooks. Returns zeros when hooks aren't wired
+// so server_info still produces a complete shape. overflow sources
+// from the overlay's TMTransaction-refusal counter (the rippled-shape
+// jq_trans_overflow signal at PeerImp.cpp:1353).
+func resolveDisconnectCounters(services *types.ServiceContainer) (overflow, peerDisc, peerDiscRes uint64) {
 	if services == nil {
-		return 0, 0, 0, 0
+		return 0, 0, 0
 	}
 	if services.JqTransOverflow != nil {
 		overflow = services.JqTransOverflow()
 	}
-	if services.TxQMetrics != nil {
-		txqFull = services.TxQMetrics().TxQFull
-	}
 	if services.PeerDisconnects != nil {
 		peerDisc, peerDiscRes = services.PeerDisconnects()
 	}
-	return overflow, txqFull, peerDisc, peerDiscRes
+	return overflow, peerDisc, peerDiscRes
 }
 
 // resolveLoadFactorFees returns (escalation, queue, reference) levels

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -124,7 +124,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	// Fallback used only when consensus hasn't wired a state-accounting tracker.
 	uptimeUs := uptimeDuration.Microseconds()
 
-	overflow, peerDisc, peerDiscRes := resolveDisconnectCounters(services)
+	overflow, txqFull, peerDisc, peerDiscRes := resolveDisconnectCounters(services)
 	accounting := resolveStateAccounting(services, serverState, uptimeUs)
 
 	info := map[string]interface{}{
@@ -138,7 +138,12 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		"peers":             getPeerCount(ctx),
 
 		// Overflow/disconnect counters (string in rippled).
+		// jq_trans_overflow sources from the overlay's inbound-tx
+		// drop counter to match rippled's PeerImp.cpp:1353 signal
+		// shape; txq_full carries the distinct TxQ admission-control
+		// rejection count under its own accurate name.
 		"jq_trans_overflow":          fmt.Sprintf("%d", overflow),
+		"txq_full":                   fmt.Sprintf("%d", txqFull),
 		"peer_disconnects":           fmt.Sprintf("%d", peerDisc),
 		"peer_disconnects_resources": fmt.Sprintf("%d", peerDiscRes),
 
@@ -376,20 +381,27 @@ func resolveValidationQuorum(services *types.ServiceContainer) int {
 	return 1
 }
 
-// resolveDisconnectCounters reads the overlay/TxQ disconnect &
-// overflow counters via service hooks. Returns zeros when hooks aren't
-// wired so server_info still produces a complete shape.
-func resolveDisconnectCounters(services *types.ServiceContainer) (overflow, peerDisc, peerDiscRes uint64) {
+// resolveDisconnectCounters reads the overlay/TxQ overflow &
+// disconnect counters via service hooks. Returns zeros when hooks
+// aren't wired so server_info still produces a complete shape.
+//
+// overflow sources from the overlay's TMTransaction-drop counter
+// (the rippled-shape jq_trans_overflow signal); txqFull is the
+// TxQ-saturation counter surfaced separately as server_info.txq_full.
+func resolveDisconnectCounters(services *types.ServiceContainer) (overflow, txqFull, peerDisc, peerDiscRes uint64) {
 	if services == nil {
-		return 0, 0, 0
+		return 0, 0, 0, 0
+	}
+	if services.JqTransOverflow != nil {
+		overflow = services.JqTransOverflow()
 	}
 	if services.TxQMetrics != nil {
-		overflow = services.TxQMetrics().JqTransOverflow
+		txqFull = services.TxQMetrics().TxQFull
 	}
 	if services.PeerDisconnects != nil {
 		peerDisc, peerDiscRes = services.PeerDisconnects()
 	}
-	return overflow, peerDisc, peerDiscRes
+	return overflow, txqFull, peerDisc, peerDiscRes
 }
 
 // resolveLoadFactorFees returns (escalation, queue, reference) levels

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -1055,12 +1055,13 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	services := servicesForServerInfo(mock)
 	services.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
-			JqTransOverflow:       7,
+			TxQFull:               7,
 			ReferenceFeeLevel:     256,
 			MinProcessingFeeLevel: 512,
 			OpenLedgerFeeLevel:    1024,
 		}
 	}
+	services.JqTransOverflow = func() uint64 { return 13 }
 	services.PeerDisconnects = func() (uint64, uint64) { return 42, 9 }
 	services.StateAccounting = func() types.StateAccountingSnapshot {
 		return types.StateAccountingSnapshot{
@@ -1098,7 +1099,8 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	require.NoError(t, json.Unmarshal(raw, &resp))
 	info := resp["info"].(map[string]interface{})
 
-	assert.Equal(t, "7", info["jq_trans_overflow"])
+	assert.Equal(t, "13", info["jq_trans_overflow"])
+	assert.Equal(t, "7", info["txq_full"])
 	assert.Equal(t, "42", info["peer_disconnects"])
 	assert.Equal(t, "9", info["peer_disconnects_resources"])
 
@@ -1131,7 +1133,7 @@ func TestServerInfo_MachineMode_LoadFactorFees(t *testing.T) {
 	services := servicesForServerInfo(mock)
 	services.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
-			JqTransOverflow:       0,
+			TxQFull:               0,
 			ReferenceFeeLevel:     256,
 			MinProcessingFeeLevel: 768,
 			OpenLedgerFeeLevel:    2048,

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -1055,7 +1055,6 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	services := servicesForServerInfo(mock)
 	services.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
-			TxQFull:               7,
 			ReferenceFeeLevel:     256,
 			MinProcessingFeeLevel: 512,
 			OpenLedgerFeeLevel:    1024,
@@ -1100,7 +1099,8 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	info := resp["info"].(map[string]interface{})
 
 	assert.Equal(t, "13", info["jq_trans_overflow"])
-	assert.Equal(t, "7", info["txq_full"])
+	_, hasTxqFull := info["txq_full"]
+	assert.False(t, hasTxqFull, "txq_full must NOT be emitted — rippled NetworkOPs.cpp:2986-2991 surfaces no such field")
 	assert.Equal(t, "42", info["peer_disconnects"])
 	assert.Equal(t, "9", info["peer_disconnects_resources"])
 
@@ -1133,7 +1133,6 @@ func TestServerInfo_MachineMode_LoadFactorFees(t *testing.T) {
 	services := servicesForServerInfo(mock)
 	services.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
-			TxQFull:               0,
 			ReferenceFeeLevel:     256,
 			MinProcessingFeeLevel: 768,
 			OpenLedgerFeeLevel:    2048,

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -210,10 +210,19 @@ type ServiceContainer struct {
 	NegativeUNLBase58 func() []string
 
 	// TxQMetrics returns the current transaction-queue metrics used by
-	// server_info for jq_trans_overflow and the load_factor_fee_*
-	// triple. Nil until the ledger service is wired (standalone tests,
-	// pre-startup) — server_info falls back to baseline values.
+	// server_info for txq_full and the load_factor_fee_* triple. Nil
+	// until the ledger service is wired (standalone tests, pre-startup)
+	// — server_info falls back to baseline values.
 	TxQMetrics func() TxQServerMetrics
+
+	// JqTransOverflow returns the cumulative inbound TMTransaction
+	// frames dropped at the overlay → router dispatch boundary because
+	// the downstream consumer channel was full. This is goxrpl's
+	// analog of rippled's OverlayImpl::getJqTransOverflow (bumped at
+	// PeerImp.cpp:1353 when jtTRANSACTION jobs can't be scheduled) and
+	// drives server_info.jq_trans_overflow. Nil in standalone / RPC-
+	// only configurations (no overlay) — handler reads zero.
+	JqTransOverflow func() uint64
 
 	// PeerDisconnects returns cumulative peer-disconnect counters
 	// surfaced by server_info: (total, resources-driven). Nil when
@@ -399,8 +408,14 @@ type LoadFactorFees struct {
 }
 
 // TxQServerMetrics is the subset of TxQ metrics surfaced by server_info.
+//
+// TxQFull is the cumulative count of submissions rejected with
+// telCAN_NOT_QUEUE_FULL (TxQ admission-control saturation). It is
+// emitted as the txq_full field — distinct from jq_trans_overflow,
+// which sources from the overlay ingress-drop counter
+// (services.JqTransOverflow) to match the rippled signal shape.
 type TxQServerMetrics struct {
-	JqTransOverflow       uint64
+	TxQFull               uint64
 	ReferenceFeeLevel     uint64
 	MinProcessingFeeLevel uint64
 	OpenLedgerFeeLevel    uint64

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -210,18 +210,19 @@ type ServiceContainer struct {
 	NegativeUNLBase58 func() []string
 
 	// TxQMetrics returns the current transaction-queue metrics used by
-	// server_info for txq_full and the load_factor_fee_* triple. Nil
-	// until the ledger service is wired (standalone tests, pre-startup)
-	// — server_info falls back to baseline values.
+	// server_info for the load_factor_fee_* triple. Nil until the
+	// ledger service is wired (standalone tests, pre-startup) —
+	// server_info falls back to baseline values.
 	TxQMetrics func() TxQServerMetrics
 
 	// JqTransOverflow returns the cumulative inbound TMTransaction
-	// frames dropped at the overlay → router dispatch boundary because
-	// the downstream consumer channel was full. This is goxrpl's
-	// analog of rippled's OverlayImpl::getJqTransOverflow (bumped at
-	// PeerImp.cpp:1353 when jtTRANSACTION jobs can't be scheduled) and
-	// drives server_info.jq_trans_overflow. Nil in standalone / RPC-
-	// only configurations (no overlay) — handler reads zero.
+	// frames the overlay refused at the router-dispatch boundary
+	// because the in-flight tx ceiling was already met. This is
+	// goxrpl's analog of rippled's OverlayImpl::getJqTransOverflow
+	// (bumped at PeerImp.cpp:1353 when
+	// `getJobCount(jtTRANSACTION) > MAX_TRANSACTIONS`) and drives
+	// server_info.jq_trans_overflow. Nil in standalone / RPC-only
+	// configurations (no overlay) — handler reads zero.
 	JqTransOverflow func() uint64
 
 	// PeerDisconnects returns cumulative peer-disconnect counters
@@ -408,14 +409,11 @@ type LoadFactorFees struct {
 }
 
 // TxQServerMetrics is the subset of TxQ metrics surfaced by server_info.
-//
-// TxQFull is the cumulative count of submissions rejected with
-// telCAN_NOT_QUEUE_FULL (TxQ admission-control saturation). It is
-// emitted as the txq_full field — distinct from jq_trans_overflow,
-// which sources from the overlay ingress-drop counter
-// (services.JqTransOverflow) to match the rippled signal shape.
+// The TxQ admission-control saturation counter (txq.Metrics.TxQFull)
+// is intentionally not exposed here: rippled has no analogous public
+// field, and conflating it with jq_trans_overflow misled operators
+// pre-#494. The counter remains internal for logs / diagnostics.
 type TxQServerMetrics struct {
-	TxQFull               uint64
 	ReferenceFeeLevel     uint64
 	MinProcessingFeeLevel uint64
 	OpenLedgerFeeLevel    uint64

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -414,7 +414,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		}
 
 		if lowestOther == nil {
-			q.incJqTransOverflow()
+			q.incTxQFull()
 			return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
 
@@ -457,7 +457,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 				q.erase(dropCandidate)
 			}
 		} else {
-			q.incJqTransOverflow()
+			q.incTxQFull()
 			return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
 	}
@@ -610,13 +610,13 @@ func (q *TxQ) canBeHeld(aq *AccountQueue, replacingCandidate *Candidate, seqProx
 			}
 		}
 		if !hasLaterSeq {
-			q.incJqTransOverflow()
+			q.incTxQFull()
 			return true, ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
 		// Real gap fill — allow it
 		return false, ApplyResult{}
 	}
-	q.incJqTransOverflow()
+	q.incTxQFull()
 	return true, ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
 }
 

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -35,15 +35,16 @@ type TxQ struct {
 	// This ensures different validators build similar queues.
 	parentHash [32]byte
 
-	// jqTransOverflow counts transactions rejected because the TxQ
-	// was full at submission time (telCAN_NOT_QUEUE_FULL). Surfaced
-	// via server_info as jq_trans_overflow. Note rippled's same-named
-	// counter (OverlayImpl::getJqTransOverflow, bumped at
-	// PeerImp.cpp:1353) tracks JobQueue jtTRANSACTION overflow on
-	// inbound TMTransaction processing, not TxQ saturation — goxrpl
-	// has no JobQueue subsystem, so the TxQ-full count is the closest
-	// available analog until that lands.
-	jqTransOverflow atomic.Uint64
+	// txqFull counts transactions rejected because the TxQ was full
+	// at submission time (telCAN_NOT_QUEUE_FULL). Surfaced via
+	// server_info as the txq_full field. This is distinct from
+	// rippled's OverlayImpl::jqTransOverflow_ (PeerImp.cpp:1353),
+	// which tracks JobQueue jtTRANSACTION-job refusal on the inbound
+	// peer path; goxrpl's analog for that signal lives at the overlay
+	// (see Overlay.DroppedTransactions). Keeping the TxQ-saturation
+	// signal under its own name avoids conflating admission-control
+	// pressure with ingress backpressure.
+	txqFull atomic.Uint64
 }
 
 // New creates a new transaction queue with the given configuration.
@@ -68,17 +69,20 @@ type Metrics struct {
 	MinProcessingFeeLevel uint64
 	MedFeeLevel           uint64
 	OpenLedgerFeeLevel    uint64
-	JqTransOverflow       uint64
+	TxQFull               uint64
 }
 
-// JqTransOverflow returns the counter surfaced as server_info.jq_trans_overflow.
-// See the jqTransOverflow field doc for the rippled-vs-goxrpl semantic difference.
-func (q *TxQ) JqTransOverflow() uint64 {
-	return q.jqTransOverflow.Load()
+// TxQFull returns the cumulative count of transactions rejected
+// because the TxQ was full at submission time
+// (telCAN_NOT_QUEUE_FULL). Surfaced via server_info as txq_full.
+// See the txqFull field doc for why this is a separate signal from
+// the rippled jq_trans_overflow analog (Overlay.DroppedTransactions).
+func (q *TxQ) TxQFull() uint64 {
+	return q.txqFull.Load()
 }
 
-func (q *TxQ) incJqTransOverflow() {
-	q.jqTransOverflow.Add(1)
+func (q *TxQ) incTxQFull() {
+	q.txqFull.Add(1)
 }
 
 // GetMetrics returns the current queue metrics.
@@ -103,7 +107,7 @@ func (q *TxQ) GetMetrics(txInLedger uint32) Metrics {
 		MinProcessingFeeLevel: minProcessingFeeLevel,
 		MedFeeLevel:           snapshot.EscalationMultiplier,
 		OpenLedgerFeeLevel:    uint64(openLedgerFeeLevel),
-		JqTransOverflow:       q.jqTransOverflow.Load(),
+		TxQFull:               q.txqFull.Load(),
 	}
 }
 

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -36,14 +36,12 @@ type TxQ struct {
 	parentHash [32]byte
 
 	// txqFull counts transactions rejected because the TxQ was full
-	// at submission time (telCAN_NOT_QUEUE_FULL). Surfaced via
-	// server_info as the txq_full field. This is distinct from
-	// rippled's OverlayImpl::jqTransOverflow_ (PeerImp.cpp:1353),
-	// which tracks JobQueue jtTRANSACTION-job refusal on the inbound
-	// peer path; goxrpl's analog for that signal lives at the overlay
-	// (see Overlay.DroppedTransactions). Keeping the TxQ-saturation
-	// signal under its own name avoids conflating admission-control
-	// pressure with ingress backpressure.
+	// at submission time (telCAN_NOT_QUEUE_FULL). Kept as an internal
+	// diagnostic counter only — rippled has no analogous server_info
+	// field for TxQ-admission-control saturation, so goxrpl does not
+	// surface it either (conflating it with jq_trans_overflow misled
+	// operators pre-#494; the rippled-shape signal lives at the
+	// overlay, see Overlay.DroppedTransactions).
 	txqFull atomic.Uint64
 }
 
@@ -74,9 +72,8 @@ type Metrics struct {
 
 // TxQFull returns the cumulative count of transactions rejected
 // because the TxQ was full at submission time
-// (telCAN_NOT_QUEUE_FULL). Surfaced via server_info as txq_full.
-// See the txqFull field doc for why this is a separate signal from
-// the rippled jq_trans_overflow analog (Overlay.DroppedTransactions).
+// (telCAN_NOT_QUEUE_FULL). Internal diagnostic only — see the
+// txqFull field doc for why this is not surfaced via server_info.
 func (q *TxQ) TxQFull() uint64 {
 	return q.txqFull.Load()
 }


### PR DESCRIPTION
## Summary

- Audit confirms the inbound TMTransaction path is structurally bounded: peer read goroutines fan into a single 256-slot `Overlay.messages` channel via non-blocking send, drained synchronously by `Router.Run` and `handleTransaction → AddPendingTx`. No per-message goroutine spawn anywhere on the path.
- Repoint `server_info.jq_trans_overflow` from the TxQ-full counter (PR #488) to the overlay's new `droppedTransactions` counter — the goxrpl analog of rippled's `OverlayImpl::jqTransOverflow_` bumped at `PeerImp.cpp:1353` when a `jtTRANSACTION` job is refused. The TxQ-saturation counter is preserved under its own accurate name, `txq_full`, since admission-control rejection and ingress backpressure are distinct signals.
- Wire `cfg.MessageBufferSize` into the `messages` channel capacity (previously hardcoded to 256, with the config option dead).

## Test plan

- [x] `just test-pkg ./internal/peermanagement/...` — overlay tests + new `tx_ingress_test.go`
- [x] `just test-pkg ./internal/txq/...` — `TxQFull` rename
- [x] `just test-pkg ./internal/rpc/...` — `jq_trans_overflow` + new `txq_full` field assertions
- [x] `just test-pkg ./internal/cli/...` — service hook wiring
- [x] `just test-pkg ./internal/consensus/... ./internal/ledger/...` — regression sweep
- [x] New soak test `TestOverlay_TxIngress_BoundedGoroutines` floods 10k frames across 16 concurrent producers at an 8-slot channel; goroutine count stays bounded.

Fixes #494