### PR TITLE
feat: unify checkConsensus + add Byzantine-stall predicates

### DIFF
--- a/internal/consensus/rcl/disputes_test.go
+++ b/internal/consensus/rcl/disputes_test.go
@@ -61,6 +61,82 @@ func buildMockTxSet(id consensus.TxSetID, txIDs ...consensus.TxID) *mockTxSet {
 // Acceptance criterion: issue #266 — "peers propose {A,B,C} and
 // {A,B,D}; engine disputes C and D, votes both in after threshold
 // ramps."
+// TestDisputeTracker_AllStalled pins the per-dispute Stalled
+// predicate and the AllStalled aggregator against the four
+// preconditions rippled enforces in DisputedTx::stalled
+// (DisputedTx.h:88-149):
+//
+//  1. Empty dispute set → NOT stalled (Consensus.h:1718 gate).
+//  2. Dispute not yet at the terminal AvalancheStuck cutoff → false.
+//  3. Dispute at terminal cutoff but with peers still flipping votes
+//     AND our own vote still flipping → false.
+//  4. Dispute at terminal cutoff, both sides frozen, ≥80% one-sided
+//     tally → true.
+func TestDisputeTracker_AllStalled(t *testing.T) {
+	parms := consensus.DefaultConsensusParms()
+
+	t.Run("empty set is not stalled", func(t *testing.T) {
+		dt := NewDisputeTracker()
+		if dt.AllStalled(parms, true, parms.StalledRounds+1) {
+			t.Fatalf("empty dispute set must not be stalled")
+		}
+	})
+
+	t.Run("non-terminal avalanche state is not stalled", func(t *testing.T) {
+		dt := NewDisputeTracker()
+		txID := makeTxID(1)
+		dt.CreateDispute(txID, nil, true)
+		d := dt.GetDispute(txID)
+		d.AvalancheState = consensus.AvalancheMid // not stuck
+		d.AvalancheCounter = parms.MinRounds + 5
+		d.CurrentVoteCounter = parms.StalledRounds + 5
+		// Heavy yes-tally to clear the percent threshold if reached.
+		d.Yays = 9
+		d.Nays = 0
+		if dt.AllStalled(parms, true, parms.StalledRounds+5) {
+			t.Fatalf("mid state must not stall regardless of tally")
+		}
+	})
+
+	t.Run("active flipping suppresses stall", func(t *testing.T) {
+		dt := NewDisputeTracker()
+		txID := makeTxID(2)
+		dt.CreateDispute(txID, nil, true)
+		d := dt.GetDispute(txID)
+		d.AvalancheState = consensus.AvalancheStuck
+		d.AvalancheCounter = parms.MinRounds + 1
+		d.CurrentVoteCounter = parms.MinRounds + 1 // still moving
+		d.Yays = 9
+		d.Nays = 0
+		// peersUnchanged below StalledRounds AND (proposing && our
+		// counter below StalledRounds) → not stalled.
+		if dt.AllStalled(parms, true, parms.StalledRounds-1) {
+			t.Fatalf("active flipping on both sides must not stall")
+		}
+	})
+
+	t.Run("frozen + one-sided tally stalls", func(t *testing.T) {
+		dt := NewDisputeTracker()
+		txID := makeTxID(3)
+		dt.CreateDispute(txID, nil, true)
+		d := dt.GetDispute(txID)
+		d.AvalancheState = consensus.AvalancheStuck
+		d.AvalancheCounter = parms.MinRounds + 1
+		d.CurrentVoteCounter = parms.StalledRounds + 1
+		d.Yays = 9
+		d.Nays = 0
+		if !dt.AllStalled(parms, true, parms.StalledRounds+1) {
+			t.Fatalf("frozen dispute with >80%% yes support must stall")
+		}
+		// Symmetrically for the no-side.
+		d.Yays = 0
+		d.Nays = 9
+		if !dt.AllStalled(parms, true, parms.StalledRounds+1) {
+			t.Fatalf("frozen dispute with >80%% no support must stall")
+		}
+	})
+}
+
 func TestConsensus_OverlappingDisjointProposals_Converges(t *testing.T) {
 	adaptor := newMockAdaptor()
 

--- a/internal/consensus/rcl/disputes_test.go
+++ b/internal/consensus/rcl/disputes_test.go
@@ -87,7 +87,7 @@ func TestDisputeTracker_AllStalled(t *testing.T) {
 		txID := makeTxID(1)
 		dt.CreateDispute(txID, nil, true)
 		d := dt.GetDispute(txID)
-		d.AvalancheState = consensus.AvalancheMid // not stuck
+		d.AvalancheState = consensus.AvalancheMid
 		d.AvalancheCounter = parms.MinRounds + 5
 		d.CurrentVoteCounter = parms.StalledRounds + 5
 		// Heavy yes-tally to clear the percent threshold if reached.
@@ -105,11 +105,9 @@ func TestDisputeTracker_AllStalled(t *testing.T) {
 		d := dt.GetDispute(txID)
 		d.AvalancheState = consensus.AvalancheStuck
 		d.AvalancheCounter = parms.MinRounds + 1
-		d.CurrentVoteCounter = parms.MinRounds + 1 // still moving
+		d.CurrentVoteCounter = parms.MinRounds + 1
 		d.Yays = 9
 		d.Nays = 0
-		// peersUnchanged below StalledRounds AND (proposing && our
-		// counter below StalledRounds) → not stalled.
 		if dt.AllStalled(parms, true, parms.StalledRounds-1) {
 			t.Fatalf("active flipping on both sides must not stall")
 		}
@@ -128,7 +126,6 @@ func TestDisputeTracker_AllStalled(t *testing.T) {
 		if !dt.AllStalled(parms, true, parms.StalledRounds+1) {
 			t.Fatalf("frozen dispute with >80%% yes support must stall")
 		}
-		// Symmetrically for the no-side.
 		d.Yays = 0
 		d.Nays = 9
 		if !dt.AllStalled(parms, true, parms.StalledRounds+1) {

--- a/internal/consensus/rcl/disputes_test.go
+++ b/internal/consensus/rcl/disputes_test.go
@@ -135,6 +135,57 @@ func TestDisputeTracker_AllStalled(t *testing.T) {
 			t.Fatalf("frozen dispute with >80%% no support must stall")
 		}
 	})
+
+	// Observer mode (proposing=false): rippled's "either side still
+	// flipping" gate at DisputedTx.h:116-118 degenerates — the inner
+	// `proposing && currentVoteCounter_ < avSTALLED_ROUNDS` clause is
+	// always false, so the gate is bypassed and the predicate falls
+	// through to the avMIN_ROUNDS dwell + tally checks. Pin both arms.
+	t.Run("observer mode falls through to tally", func(t *testing.T) {
+		dt := NewDisputeTracker()
+		txID := makeTxID(4)
+		dt.CreateDispute(txID, nil, false)
+		d := dt.GetDispute(txID)
+		d.AvalancheState = consensus.AvalancheStuck
+		d.AvalancheCounter = parms.MinRounds + 1
+		// CurrentVoteCounter is irrelevant when not proposing.
+		d.CurrentVoteCounter = 0
+		d.Yays = 9
+		d.Nays = 0
+		// peersUnchanged=0 — proposers may still be flipping, but the
+		// gate is disabled in observer mode so the tally still wins.
+		if !dt.AllStalled(parms, false, 0) {
+			t.Fatalf("observer must consider one-sided tally stalled")
+		}
+	})
+
+	// AllStalled is std::ranges::all_of (Consensus.h:1720-1728): any
+	// non-stalled dispute in the set must short-circuit the aggregate
+	// to false, regardless of how many siblings are stalled.
+	t.Run("mixed disputes — one not stalled — aggregate false", func(t *testing.T) {
+		dt := NewDisputeTracker()
+		stalledID := makeTxID(5)
+		dt.CreateDispute(stalledID, nil, true)
+		ds := dt.GetDispute(stalledID)
+		ds.AvalancheState = consensus.AvalancheStuck
+		ds.AvalancheCounter = parms.MinRounds + 1
+		ds.CurrentVoteCounter = parms.StalledRounds + 1
+		ds.Yays = 9
+		ds.Nays = 0
+
+		notStalledID := makeTxID(6)
+		dt.CreateDispute(notStalledID, nil, true)
+		dns := dt.GetDispute(notStalledID)
+		dns.AvalancheState = consensus.AvalancheMid // not terminal
+		dns.AvalancheCounter = parms.MinRounds + 5
+		dns.CurrentVoteCounter = parms.StalledRounds + 5
+		dns.Yays = 9
+		dns.Nays = 0
+
+		if dt.AllStalled(parms, true, parms.StalledRounds+1) {
+			t.Fatalf("AllStalled must be false when any dispute is not stalled")
+		}
+	})
 }
 
 func TestConsensus_OverlappingDisjointProposals_Converges(t *testing.T) {

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1218,8 +1218,16 @@ func (e *Engine) Events() <-chan consensus.Event {
 func (e *Engine) run() {
 	defer e.wg.Done()
 
-	interval := time.Second
-	if e.timing.LedgerMinClose < interval {
+	// Heartbeat cadence mirrors rippled's ledgerGRANULARITY (1s,
+	// ConsensusParms.h:101-102), the rate at which timerEntry
+	// re-evaluates phase work. Tests override LedgerMinClose to
+	// shrink rounds; honour that as a floor so the heartbeat keeps
+	// up with sub-granularity test configurations.
+	interval := e.timing.LedgerGranularity
+	if interval <= 0 {
+		interval = time.Second
+	}
+	if e.timing.LedgerMinClose > 0 && e.timing.LedgerMinClose < interval {
 		interval = e.timing.LedgerMinClose
 	}
 	e.heartbeat = time.NewTicker(interval)
@@ -2364,16 +2372,16 @@ func (e *Engine) abandonDeadlineExceeded(roundTime time.Duration) bool {
 }
 
 // consensusState mirrors rippled's ConsensusState enum
-// (ConsensusTypes.h:189-195). It is the decision produced by
-// checkConsensusState — the unified port of rippled's checkConsensus
-// (Consensus.cpp:176-269).
+// (ConsensusTypes.h:188-193) — same ordinal layout: No, MovedOn,
+// Expired, Yes. It is the decision produced by checkConsensusState,
+// the unified port of rippled's checkConsensus (Consensus.cpp:176-269).
 type consensusState int
 
 const (
 	consensusStateNo consensusState = iota
-	consensusStateYes
 	consensusStateMovedOn
 	consensusStateExpired
+	consensusStateYes
 )
 
 // checkConvergence drives the accept gate. Matches rippled's
@@ -2384,13 +2392,18 @@ const (
 //     EarlyConvergencePct (no rippled equivalent).
 //   - Computes the unified consensusState via checkConsensusState,
 //     mirroring rippled's checkConsensus result.
+//   - Applies the Expired retry gate (Consensus.h:1762-1779) before
+//     anything else; rippled folds the gate into haveConsensus's
+//     "return false" path so phaseEstablish never reaches accept
+//     while we are still inside the retry window.
+//   - Applies the haveCloseTimeConsensus gate uniformly to every
+//     non-No outcome, mirroring rippled phaseEstablish
+//     (Consensus.h:1402-1411) where Yes / MovedOn / Expired-post-retry
+//     all flow through the same `if (!haveCloseTimeConsensus_) return;`.
 //   - Dispatches:
-//   - Yes      → acceptLedger(ResultSuccess) (gated on close-time consensus).
+//   - Yes      → acceptLedger(ResultSuccess).
 //   - MovedOn  → acceptLedger(ResultMovedOn).
-//   - Expired  → leaveConsensus + acceptLedger(ResultAbandoned), unless
-//     establishCounter is below the per-avalanche-level
-//     minimum, in which case we keep trying
-//     (Consensus.h:1762-1779).
+//   - Expired  → leaveConsensus + acceptLedger(ResultAbandoned).
 //   - No       → return; the next heartbeat will re-evaluate.
 func (e *Engine) checkConvergence() {
 	if e.phase != consensus.PhaseEstablish {
@@ -2434,19 +2447,46 @@ func (e *Engine) checkConvergence() {
 
 	state := e.checkConsensusState(roundTime, agree, total)
 
+	if state == consensusStateNo {
+		return
+	}
+
+	// Expired retry gate runs *before* the close-time gate — rippled
+	// folds this into haveConsensus's "return false" path
+	// (Consensus.h:1762-1779), so phaseEstablish never reaches the
+	// haveCloseTimeConsensus_ check while we are still inside the
+	// per-avalanche-level minimum dwell window.
+	if state == consensusStateExpired {
+		minimumCounter := len(e.parms.AvalancheCutoffs) * e.parms.MinRounds
+		if e.establishCounter < minimumCounter {
+			slog.Warn("consensus expired but inside retry window — continuing",
+				"t", "consensus",
+				"event", "expired-retry",
+				"round", e.state.Round,
+				"establish_counter", e.establishCounter,
+				"minimum_counter", minimumCounter,
+				"round_time", roundTime,
+			)
+			return
+		}
+	}
+
+	// Close-time consensus is required before accepting any non-No
+	// outcome — match rippled phaseEstablish (Consensus.h:1402-1411),
+	// where Yes, MovedOn, and Expired-post-retry all flow through the
+	// same gate. updateCloseTimePosition runs on every heartbeat in
+	// phaseEstablish; we re-try once more here in case the caller
+	// (OnProposal/OnTxSet) reached this point without going through
+	// phaseEstablish.
+	if !e.haveCloseTimeConsensus {
+		e.updateCloseTimePosition()
+		if !e.haveCloseTimeConsensus {
+			return
+		}
+	}
+
 	switch state {
 	case consensusStateYes:
-		// Close-time consensus is required before accepting — match
-		// rippled Consensus.h:1406-1411. updateCloseTimePosition
-		// runs on every heartbeat in phaseEstablish; we re-try once
-		// more here in case the caller (OnProposal/OnTxSet) reached
-		// this point without going through phaseEstablish.
-		if !e.haveCloseTimeConsensus {
-			e.updateCloseTimePosition()
-			if !e.haveCloseTimeConsensus {
-				return
-			}
-		}
 		e.acceptLedger(consensus.ResultSuccess)
 	case consensusStateMovedOn:
 		finished := 0
@@ -2464,24 +2504,6 @@ func (e *Engine) checkConvergence() {
 		)
 		e.acceptLedger(consensus.ResultMovedOn)
 	case consensusStateExpired:
-		// ResultExpired retry gate: rippled Consensus.h:1762-1779
-		// refuses to expire if establishCounter_ < (number of
-		// avalanche cutoffs) * avMIN_ROUNDS. This guards against
-		// abandoning before each avalanche level has had its
-		// minimum dwell — which can happen when individual rounds
-		// take an inordinately long time (heavy disputes).
-		minimumCounter := len(e.parms.AvalancheCutoffs) * e.parms.MinRounds
-		if e.establishCounter < minimumCounter {
-			slog.Warn("consensus expired but inside retry window — continuing",
-				"t", "consensus",
-				"event", "expired-retry",
-				"round", e.state.Round,
-				"establish_counter", e.establishCounter,
-				"minimum_counter", minimumCounter,
-				"round_time", roundTime,
-			)
-			return
-		}
 		slog.Warn("consensus taken too long, abandoning round",
 			"t", "consensus",
 			"event", "expired",
@@ -2497,16 +2519,13 @@ func (e *Engine) checkConvergence() {
 			Timestamp: e.adaptor.Now(),
 		})
 		// Rippled's leaveConsensus: bow out of proposing if we were
-		// (Consensus.h:1802-1816). We don't have an active proposal
-		// "bowOut" wire flag in goXRPL, so dropping to Observing is
-		// the closest analog — the next round will not include us
-		// in proposers.
+		// (Consensus.h:1802-1816). goXRPL has no on-wire bowOut
+		// proposal flag yet, so dropping to Observing is the closest
+		// analog — the next round will not include us in proposers.
 		if e.mode == consensus.ModeProposing {
 			e.setMode(consensus.ModeObserving)
 		}
 		e.acceptLedger(consensus.ResultAbandoned)
-	case consensusStateNo:
-		// Not yet — wait for the next heartbeat or peer update.
 	}
 }
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -2550,18 +2550,16 @@ func (e *Engine) checkConvergence() {
 // "stalled" is gated on haveCloseTimeConsensus and on every active
 // dispute being individually Stalled — rippled Consensus.h:1718-1728.
 func (e *Engine) checkConsensusState(roundTime time.Duration, agree, currentProposers int) consensusState {
-	// 1. Minimum dwell.
 	if roundTime <= e.timing.LedgerMinConsensus {
 		return consensusStateNo
 	}
 
-	// 2. 3/4 prev-proposers pause. Rippled Consensus.cpp:208-218:
-	// if less than 3/4 of the last ledger's proposers are present,
-	// don't rush — wait at least one more MIN_CONSENSUS interval past
-	// the previous round time so slow validators can catch up. We
-	// skip this gate when prevProposers is 0 (first round / fresh
-	// startup); otherwise a single proposer disappearing on a 1-node
-	// soak would freeze consensus indefinitely.
+	// 3/4 prev-proposers pause (Consensus.cpp:208-218): if less than
+	// 3/4 of the last ledger's proposers are present, don't rush —
+	// wait at least one more MIN_CONSENSUS interval past the previous
+	// round time so slow validators can catch up. We skip this gate
+	// when prevProposers is 0; otherwise a single proposer
+	// disappearing on a 1-node soak would freeze consensus indefinitely.
 	if e.prevProposers > 0 && currentProposers < (e.prevProposers*3/4) {
 		if roundTime < (e.prevRoundTime + e.timing.LedgerMinConsensus) {
 			return consensusStateNo
@@ -2571,15 +2569,13 @@ func (e *Engine) checkConsensusState(roundTime time.Duration, agree, currentProp
 	reachedMax := e.timing.LedgerMaxConsensus > 0 && roundTime > e.timing.LedgerMaxConsensus
 	proposing := e.mode == consensus.ModeProposing
 
-	// 3. Yes path. Compute "stalled" first — rippled gates the bit
-	// on haveCloseTimeConsensus AND a non-empty dispute set where
-	// every dispute is individually stalled (Consensus.h:1718-1728).
-	//
 	// countSelf is false here: countAgreement already pre-includes
-	// our own +1 in (agree, currentProposers) when we are proposing,
-	// to match the legacy convergence/observability gate. Rippled's
-	// checkConsensusReached does that bump internally — we pass the
-	// already-adjusted tally and skip the duplicate.
+	// our own +1 in (agree, currentProposers) when we are proposing.
+	// Rippled's checkConsensusReached does that bump internally
+	// (Consensus.cpp:153-159); we pass the already-adjusted tally and
+	// skip the duplicate. "stalled" is gated on haveCloseTimeConsensus
+	// AND a non-empty dispute set where every dispute is individually
+	// stalled (Consensus.h:1718-1728).
 	stalled := false
 	if e.haveCloseTimeConsensus && e.disputeTracker != nil {
 		stalled = e.disputeTracker.AllStalled(e.parms, proposing, e.peerUnchangedCounter)
@@ -2588,11 +2584,9 @@ func (e *Engine) checkConsensusState(roundTime time.Duration, agree, currentProp
 		return consensusStateYes
 	}
 
-	// 4. MovedOn path: 80% of current-round proposer count have
-	// validated a ledger past our prev. Denominator is the current-
-	// round proposer count, not prevProposers (Consensus.h:1740-1751
-	// passes agree+disagree); peers stop proposing for our round as
-	// they advance.
+	// MovedOn denominator is the current-round proposer count, not
+	// prevProposers (Consensus.h:1740-1751 passes agree+disagree);
+	// peers stop proposing for our round as they advance.
 	if e.prevLedger != nil && e.validationTracker != nil {
 		finished := e.validationTracker.ProposersFinished(e.prevLedger)
 		if checkConsensusReached(finished, currentProposers, false, e.thresholds.MinConsensusPct, reachedMax, false) {
@@ -2600,7 +2594,6 @@ func (e *Engine) checkConsensusState(roundTime time.Duration, agree, currentProp
 		}
 	}
 
-	// 5. Expired path: roundTime past the clamped abandon deadline.
 	if e.timing.LedgerAbandonConsensus > 0 && e.abandonDeadlineExceeded(roundTime) {
 		return consensusStateExpired
 	}

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -2060,54 +2060,6 @@ func (e *Engine) phaseEstablish() {
 		return
 	}
 
-	// Absolute hard ceiling: abandon the round once we exceed the
-	// ledgerABANDON_CONSENSUS clamp. Rippled treats this state as
-	// ConsensusState::Expired (Consensus.cpp:253-263) and responds by
-	// calling leaveConsensus() (Consensus.h:1760-1785): bow out of
-	// proposing, then fall through to accept — do NOT restart the round
-	// with an empty set. We mirror that here: setMode(Observing) if we
-	// were proposing, then accept with ResultAbandoned so higher layers
-	// can distinguish a hard abandon from the soft LedgerMaxConsensus
-	// force-accept below.
-	if e.timing.LedgerAbandonConsensus > 0 && e.abandonDeadlineExceeded(roundTime) {
-		slog.Warn("consensus taken too long, abandoning round",
-			"t", "Consensus",
-			"round", e.state.Round,
-			"round_time", roundTime,
-			"prev_round_time", e.prevRoundTime,
-			"max_consensus", e.timing.LedgerMaxConsensus,
-			"abandon_consensus", e.timing.LedgerAbandonConsensus,
-		)
-		e.eventBus.Publish(&consensus.TimerFiredEvent{
-			Timer:     consensus.TimerRoundTimeout,
-			Round:     e.state.Round,
-			Timestamp: e.adaptor.Now(),
-		})
-		// Rippled's leaveConsensus: stop proposing if we were.
-		if e.mode == consensus.ModeProposing {
-			e.setMode(consensus.ModeObserving)
-		}
-		e.acceptLedger(consensus.ResultAbandoned)
-		return
-	}
-
-	// (No soft-timeout-to-accept here on purpose.) Rippled's
-	// phaseEstablish has exactly three terminal states — Yes / MovedOn
-	// / Expired (Consensus.cpp:176-263) — and Expired only fires at the
-	// clamp(prevRoundTime * factor, ledgerMAX_CONSENSUS, ledger
-	// ABANDON_CONSENSUS) deadline, which is the hard-abandon path
-	// above. There is no equivalent "soft" force-accept at
-	// ledgerMAX_CONSENSUS; rippled stays in establish as long as
-	// neither convergence nor the MovedOn-by-peer-finished threshold
-	// has fired. The earlier goxrpl soft-timeout at LedgerMaxConsensus
-	// was a goxrpl-only behavior that, combined with the old broad
-	// consensusFail rule, advanced the LCL on a never-emitted ledger
-	// every 15s and drifted closed_seq arbitrarily far past the
-	// validated tip in mixed UNL soaks (#451).
-
-	// Run convergence before MovedOn — rippled's checkConsensus picks
-	// Yes over MovedOn so a near-simultaneous-finish round still ends
-	// in Success rather than chronic 1-round lag.
 	e.establishCounter++
 	e.peerUnchangedCounter++
 
@@ -2116,43 +2068,6 @@ func (e *Engine) phaseEstablish() {
 	}
 	e.updateCloseTimePosition()
 	e.checkConvergence()
-	if e.phase != consensus.PhaseEstablish {
-		// checkConvergence accepted — round is over.
-		return
-	}
-
-	// MovedOn detection — checkConsensus at Consensus.cpp:239-246:
-	// 80% of prev proposers have validated a ledger past our prev.
-	// Denominator is current-round proposer count, not prevProposers
-	// (Consensus.h:1740-1751 passes agree+disagree); peers stop
-	// proposing for our round as they advance.
-	if e.prevLedger != nil && e.validationTracker != nil &&
-		roundTime > e.timing.LedgerMinConsensus {
-		finished := e.validationTracker.ProposersFinished(e.prevLedger)
-		currentProposers := len(e.proposals)
-
-		var fired bool
-		if currentProposers == 0 {
-			// checkConsensusReached(_, 0, ...) at Consensus.cpp:129-140.
-			fired = roundTime > e.timing.LedgerMaxConsensus
-		} else {
-			fired = finished*100 >= currentProposers*e.thresholds.MinConsensusPct
-		}
-
-		if fired {
-			slog.Info("consensus moved on, accepting",
-				"t", "consensus",
-				"event", "moved-on",
-				"seq", e.state.Round.Seq,
-				"finished", finished,
-				"current_proposers", currentProposers,
-				"prev_proposers", e.prevProposers,
-				"round_time_ms", roundTime.Milliseconds(),
-			)
-			e.acceptLedger(consensus.ResultMovedOn)
-			return
-		}
-	}
 }
 
 // shouldPause mirrors rippled's Consensus<T>::shouldPause at
@@ -2448,15 +2363,35 @@ func (e *Engine) abandonDeadlineExceeded(roundTime time.Duration) bool {
 	return roundTime > deadline
 }
 
+// consensusState mirrors rippled's ConsensusState enum
+// (ConsensusTypes.h:189-195). It is the decision produced by
+// checkConsensusState — the unified port of rippled's checkConsensus
+// (Consensus.cpp:176-269).
+type consensusState int
+
+const (
+	consensusStateNo consensusState = iota
+	consensusStateYes
+	consensusStateMovedOn
+	consensusStateExpired
+)
+
 // checkConvergence drives the accept gate. Matches rippled's
-// phaseEstablish → haveConsensus flow (Consensus.h:1400-1422):
-// once we've spent ledgerMIN_CONSENSUS in establish and enough peers
-// match our position, we accept. The popularity-of-whole-tx-set vote
-// that previously lived here was strictly coarser than per-tx
-// re-voting and would strand a node whose position differed from
-// every peer in the small-set symmetric-difference case (issue #266).
-// Per-tx migration now happens in updatePosition, driven by the
-// dispute tracker.
+// phaseEstablish → haveConsensus → checkConsensus flow
+// (Consensus.h:1400-1422, Consensus.cpp:176-269). The function:
+//
+//   - Maintains the goXRPL-local "converged" observability flag from
+//     EarlyConvergencePct (no rippled equivalent).
+//   - Computes the unified consensusState via checkConsensusState,
+//     mirroring rippled's checkConsensus result.
+//   - Dispatches:
+//   - Yes      → acceptLedger(ResultSuccess) (gated on close-time consensus).
+//   - MovedOn  → acceptLedger(ResultMovedOn).
+//   - Expired  → leaveConsensus + acceptLedger(ResultAbandoned), unless
+//     establishCounter is below the per-avalanche-level
+//     minimum, in which case we keep trying
+//     (Consensus.h:1762-1779).
+//   - No       → return; the next heartbeat will re-evaluate.
 func (e *Engine) checkConvergence() {
 	if e.phase != consensus.PhaseEstablish {
 		return
@@ -2484,40 +2419,196 @@ func (e *Engine) checkConvergence() {
 		return
 	}
 
-	// Minimum time in establish phase before accepting consensus.
-	// Matches rippled's checkConsensus(): currentAgreeTime <= ledgerMIN_CONSENSUS.
-	if e.adaptor.Now().Sub(e.state.PhaseStart) <= e.timing.LedgerMinConsensus {
-		return
-	}
-
+	roundTime := time.Since(e.roundStartTime)
 	agree, disagree := e.countAgreement()
 	total := agree + disagree
-	if total == 0 {
-		return
-	}
 
 	// EarlyConvergencePct is a goXRPL-local gate for flagging a round
 	// as "converged" for observability (e.g., server_info). Acceptance
-	// uses MinConsensusPct (rippled's minCONSENSUS_PCT=80).
-	if agree*100 >= total*e.thresholds.EarlyConvergencePct {
+	// uses MinConsensusPct (rippled's minCONSENSUS_PCT=80) inside
+	// checkConsensusState.
+	if total > 0 && agree*100 >= total*e.thresholds.EarlyConvergencePct {
 		e.converged = true
 		e.state.Converged = true
 	}
 
-	if agree*100 < total*e.thresholds.MinConsensusPct {
-		return
+	state := e.checkConsensusState(roundTime, agree, total)
+
+	switch state {
+	case consensusStateYes:
+		// Close-time consensus is required before accepting — match
+		// rippled Consensus.h:1406-1411. updateCloseTimePosition
+		// runs on every heartbeat in phaseEstablish; we re-try once
+		// more here in case the caller (OnProposal/OnTxSet) reached
+		// this point without going through phaseEstablish.
+		if !e.haveCloseTimeConsensus {
+			e.updateCloseTimePosition()
+			if !e.haveCloseTimeConsensus {
+				return
+			}
+		}
+		e.acceptLedger(consensus.ResultSuccess)
+	case consensusStateMovedOn:
+		finished := 0
+		if e.validationTracker != nil && e.prevLedger != nil {
+			finished = e.validationTracker.ProposersFinished(e.prevLedger)
+		}
+		slog.Info("consensus moved on, accepting",
+			"t", "consensus",
+			"event", "moved-on",
+			"seq", e.state.Round.Seq,
+			"finished", finished,
+			"current_proposers", total,
+			"prev_proposers", e.prevProposers,
+			"round_time_ms", roundTime.Milliseconds(),
+		)
+		e.acceptLedger(consensus.ResultMovedOn)
+	case consensusStateExpired:
+		// ResultExpired retry gate: rippled Consensus.h:1762-1779
+		// refuses to expire if establishCounter_ < (number of
+		// avalanche cutoffs) * avMIN_ROUNDS. This guards against
+		// abandoning before each avalanche level has had its
+		// minimum dwell — which can happen when individual rounds
+		// take an inordinately long time (heavy disputes).
+		minimumCounter := len(e.parms.AvalancheCutoffs) * e.parms.MinRounds
+		if e.establishCounter < minimumCounter {
+			slog.Warn("consensus expired but inside retry window — continuing",
+				"t", "consensus",
+				"event", "expired-retry",
+				"round", e.state.Round,
+				"establish_counter", e.establishCounter,
+				"minimum_counter", minimumCounter,
+				"round_time", roundTime,
+			)
+			return
+		}
+		slog.Warn("consensus taken too long, abandoning round",
+			"t", "consensus",
+			"event", "expired",
+			"round", e.state.Round,
+			"round_time", roundTime,
+			"prev_round_time", e.prevRoundTime,
+			"max_consensus", e.timing.LedgerMaxConsensus,
+			"abandon_consensus", e.timing.LedgerAbandonConsensus,
+		)
+		e.eventBus.Publish(&consensus.TimerFiredEvent{
+			Timer:     consensus.TimerRoundTimeout,
+			Round:     e.state.Round,
+			Timestamp: e.adaptor.Now(),
+		})
+		// Rippled's leaveConsensus: bow out of proposing if we were
+		// (Consensus.h:1802-1816). We don't have an active proposal
+		// "bowOut" wire flag in goXRPL, so dropping to Observing is
+		// the closest analog — the next round will not include us
+		// in proposers.
+		if e.mode == consensus.ModeProposing {
+			e.setMode(consensus.ModeObserving)
+		}
+		e.acceptLedger(consensus.ResultAbandoned)
+	case consensusStateNo:
+		// Not yet — wait for the next heartbeat or peer update.
+	}
+}
+
+// checkConsensusState mirrors rippled's checkConsensus
+// (Consensus.cpp:176-269), returning a state in {No, Yes, MovedOn,
+// Expired}. The arguments are computed by the caller so that
+// updates to e.converged remain on a consistent snapshot of the
+// agreement tally and round time.
+//
+// The state machine, in priority order:
+//
+//  1. roundTime <= ledgerMIN_CONSENSUS                       → No
+//  2. currentProposers < prevProposers * 3/4 AND
+//     roundTime < (prevRoundTime + ledgerMIN_CONSENSUS)      → No
+//  3. checkConsensusReached(agree, currentProposers, proposing,
+//     minPct, reachedMax, stalled) is true → Yes
+//  4. checkConsensusReached(finished, currentProposers, false,
+//     minPct, reachedMax, false) is true   → MovedOn
+//  5. roundTime > clamp(prevRoundTime*factor, MAX, ABANDON)   → Expired
+//  6. else                                                   → No
+//
+// "stalled" is gated on haveCloseTimeConsensus and on every active
+// dispute being individually Stalled — rippled Consensus.h:1718-1728.
+func (e *Engine) checkConsensusState(roundTime time.Duration, agree, currentProposers int) consensusState {
+	// 1. Minimum dwell.
+	if roundTime <= e.timing.LedgerMinConsensus {
+		return consensusStateNo
 	}
 
-	// Close-time consensus is required before accepting — match
-	// rippled Consensus.h:1406-1411.
-	if !e.haveCloseTimeConsensus {
-		e.updateCloseTimePosition()
-		if !e.haveCloseTimeConsensus {
-			return
+	// 2. 3/4 prev-proposers pause. Rippled Consensus.cpp:208-218:
+	// if less than 3/4 of the last ledger's proposers are present,
+	// don't rush — wait at least one more MIN_CONSENSUS interval past
+	// the previous round time so slow validators can catch up. We
+	// skip this gate when prevProposers is 0 (first round / fresh
+	// startup); otherwise a single proposer disappearing on a 1-node
+	// soak would freeze consensus indefinitely.
+	if e.prevProposers > 0 && currentProposers < (e.prevProposers*3/4) {
+		if roundTime < (e.prevRoundTime + e.timing.LedgerMinConsensus) {
+			return consensusStateNo
 		}
 	}
 
-	e.acceptLedger(consensus.ResultSuccess)
+	reachedMax := e.timing.LedgerMaxConsensus > 0 && roundTime > e.timing.LedgerMaxConsensus
+	proposing := e.mode == consensus.ModeProposing
+
+	// 3. Yes path. Compute "stalled" first — rippled gates the bit
+	// on haveCloseTimeConsensus AND a non-empty dispute set where
+	// every dispute is individually stalled (Consensus.h:1718-1728).
+	//
+	// countSelf is false here: countAgreement already pre-includes
+	// our own +1 in (agree, currentProposers) when we are proposing,
+	// to match the legacy convergence/observability gate. Rippled's
+	// checkConsensusReached does that bump internally — we pass the
+	// already-adjusted tally and skip the duplicate.
+	stalled := false
+	if e.haveCloseTimeConsensus && e.disputeTracker != nil {
+		stalled = e.disputeTracker.AllStalled(e.parms, proposing, e.peerUnchangedCounter)
+	}
+	if checkConsensusReached(agree, currentProposers, false, e.thresholds.MinConsensusPct, reachedMax, stalled) {
+		return consensusStateYes
+	}
+
+	// 4. MovedOn path: 80% of current-round proposer count have
+	// validated a ledger past our prev. Denominator is the current-
+	// round proposer count, not prevProposers (Consensus.h:1740-1751
+	// passes agree+disagree); peers stop proposing for our round as
+	// they advance.
+	if e.prevLedger != nil && e.validationTracker != nil {
+		finished := e.validationTracker.ProposersFinished(e.prevLedger)
+		if checkConsensusReached(finished, currentProposers, false, e.thresholds.MinConsensusPct, reachedMax, false) {
+			return consensusStateMovedOn
+		}
+	}
+
+	// 5. Expired path: roundTime past the clamped abandon deadline.
+	if e.timing.LedgerAbandonConsensus > 0 && e.abandonDeadlineExceeded(roundTime) {
+		return consensusStateExpired
+	}
+
+	return consensusStateNo
+}
+
+// checkConsensusReached mirrors rippled's free function at
+// Consensus.cpp:106-174. Returns true if the agreeing/total ratio
+// meets minPct, treating an empty proposer set as "consensus reached"
+// only once we've waited past ledgerMAX_CONSENSUS (reachedMax) — see
+// the alone-for-too-long carve-out at Consensus.cpp:129-140 — and
+// short-circuiting to true when callers report a stalled dispute set.
+func checkConsensusReached(agreeing, total int, countSelf bool, minPct int, reachedMax, stalled bool) bool {
+	if total == 0 {
+		// Alone for too long → consensus by default
+		// (Consensus.cpp:129-140).
+		return reachedMax
+	}
+	if stalled {
+		return true
+	}
+	if countSelf {
+		agreeing++
+		total++
+	}
+	return (agreeing*100)/total >= minPct
 }
 
 // countAgreement returns the number of participating proposers whose
@@ -3245,31 +3336,30 @@ func closeTimeAvalancheStateName(s avalancheState) string {
 	return "unknown"
 }
 
-// getCloseTimeNeededWeight returns the minimum vote percentage for close time
-// based on the avalanche state machine. Matches rippled's getNeededWeight()
-// in ConsensusParms.h:172-199.
+// getCloseTimeNeededWeight returns the minimum vote percentage for
+// close time consensus. Mirrors rippled's call at Consensus.h:1578-1581:
+//
+//	auto const [neededWeight, newState] = getNeededWeight(
+//	    parms, closeTimeAvalancheState_, convergePercent_, 0, 0);
+//	if (newState)
+//	    closeTimeAvalancheState_ = *newState;
+//
+// Close-time avalanche advancement is purely percent-based — rippled
+// passes currentRounds=0 and minimumRounds=0 so the round-dwell check
+// is trivially satisfied — matching that here keeps a single
+// canonical NeededWeight implementation across per-tx disputes and
+// close-time threshold escalation.
 func (e *Engine) getCloseTimeNeededWeight() int {
-	pct := e.convergePercent()
-	switch e.closeTimeAvalancheState {
-	case avalancheInit:
-		if pct >= 0 {
-			e.closeTimeAvalancheState = avalancheMid
-		}
-		return 50
-	case avalancheMid:
-		if pct >= 50 {
-			e.closeTimeAvalancheState = avalancheLate
-		}
-		return 65
-	case avalancheLate:
-		if pct >= 85 {
-			e.closeTimeAvalancheState = avalancheStuck
-		}
-		return 70
-	case avalancheStuck:
-		return 95
+	pct, newState := e.parms.NeededWeight(
+		consensus.AvalancheState(e.closeTimeAvalancheState),
+		e.convergePercent(),
+		0,
+		0,
+	)
+	if newState != nil {
+		e.closeTimeAvalancheState = avalancheState(*newState)
 	}
-	return 50
+	return pct
 }
 
 // convergePercent returns how far through the establish phase we are,

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -2534,6 +2534,111 @@ func TestCheckConsensusReached(t *testing.T) {
 	}
 }
 
+// TestCheckConsensusState walks all six priority-ordered outcomes of
+// checkConsensusState — the unified port of rippled's checkConsensus
+// (Consensus.cpp:176-269). Each subtest pins one branch:
+//
+//  1. roundTime <= LedgerMinConsensus                     → No
+//  2. currentProposers < prevProposers*3/4 AND
+//     roundTime < (prevRoundTime + LedgerMinConsensus)    → No
+//  3. agree threshold met                                 → Yes
+//  4. agree below threshold, ProposersFinished past prev  → MovedOn
+//  5. abandon deadline exceeded                           → Expired
+//  6. past min, below threshold, deadline not yet hit     → No
+func TestCheckConsensusState(t *testing.T) {
+	parms := consensus.DefaultConsensusParms()
+
+	newEngine := func() *Engine {
+		adaptor := newMockAdaptor()
+		adaptor.opMode = consensus.OpModeFull
+		config := DefaultConfig()
+		e := NewEngine(adaptor, config)
+		e.parms = parms
+		e.haveCloseTimeConsensus = true
+		return e
+	}
+
+	t.Run("1 too soon → No", func(t *testing.T) {
+		e := newEngine()
+		got := e.checkConsensusState(e.timing.LedgerMinConsensus, 10, 10)
+		if got != consensusStateNo {
+			t.Fatalf("got %v, want consensusStateNo", got)
+		}
+	})
+
+	t.Run("2 3/4 prev-proposers pause → No", func(t *testing.T) {
+		e := newEngine()
+		e.prevProposers = 8
+		e.prevRoundTime = 5 * time.Second
+		// 4 < 8*3/4=6, and roundTime < prevRoundTime+MinConsensus.
+		roundTime := e.timing.LedgerMinConsensus + 100*time.Millisecond
+		got := e.checkConsensusState(roundTime, 4, 4)
+		if got != consensusStateNo {
+			t.Fatalf("got %v, want consensusStateNo (3/4 pause)", got)
+		}
+	})
+
+	t.Run("3 majority agreement → Yes", func(t *testing.T) {
+		e := newEngine()
+		roundTime := e.timing.LedgerMinConsensus + time.Second
+		got := e.checkConsensusState(roundTime, 8, 10)
+		if got != consensusStateYes {
+			t.Fatalf("got %v, want consensusStateYes", got)
+		}
+	})
+
+	t.Run("4 peers moved on → MovedOn", func(t *testing.T) {
+		e := newEngine()
+		// Seed validationTracker with 4 trusted finished validators
+		// past prevSeq so ProposersFinished returns 4 ≥ 80% of 4.
+		prev := &mockLedger{id: consensus.LedgerID{0x10}, seq: 100}
+		e.prevLedger = prev
+		vt := NewValidationTracker(3, e.timing.ValidationFreshness)
+		for i := 0; i < 4; i++ {
+			nodeID := consensus.NodeID{byte(0xA0 + i)}
+			vt.trusted[nodeID] = true
+			vt.byNode[nodeID] = &consensus.Validation{
+				NodeID:    nodeID,
+				LedgerSeq: prev.Seq() + 1,
+				Full:      true,
+			}
+		}
+		e.validationTracker = vt
+
+		roundTime := e.timing.LedgerMinConsensus + time.Second
+		// agree*100/4 = 25% < 80% → fail Yes; finished=4*100/4=100% → MovedOn.
+		got := e.checkConsensusState(roundTime, 1, 4)
+		if got != consensusStateMovedOn {
+			t.Fatalf("got %v, want consensusStateMovedOn", got)
+		}
+	})
+
+	t.Run("5 abandon deadline exceeded → Expired", func(t *testing.T) {
+		e := newEngine()
+		e.prevRoundTime = 5 * time.Second
+		// abandonDeadlineExceeded clamps prevRoundTime*factor to
+		// [LedgerMaxConsensus, LedgerAbandonConsensus]; default factor
+		// is 10, max=15s, abandon=120s → clamp gives 50s, then min(50s,
+		// 120s)=50s. Push roundTime well past that.
+		roundTime := 200 * time.Second
+		got := e.checkConsensusState(roundTime, 1, 10)
+		if got != consensusStateExpired {
+			t.Fatalf("got %v, want consensusStateExpired", got)
+		}
+	})
+
+	t.Run("6 below threshold, deadline OK → No", func(t *testing.T) {
+		e := newEngine()
+		// No validationTracker → MovedOn arm cannot fire.
+		// roundTime past LedgerMinConsensus but well below abandon clamp.
+		roundTime := e.timing.LedgerMinConsensus + time.Second
+		got := e.checkConsensusState(roundTime, 1, 10)
+		if got != consensusStateNo {
+			t.Fatalf("got %v, want consensusStateNo (default fallthrough)", got)
+		}
+	})
+}
+
 // TestEngine_OnValidation_NoSelfDeadlockOnQuorum pins the issue
 // #381 root cause: ValidationTracker.Add fires the
 // fully-validated callback synchronously on the goroutine that

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -1008,15 +1008,16 @@ func TestEngine_PhaseTransitions(t *testing.T) {
 	adaptor.opMode = consensus.OpModeFull
 
 	config := DefaultConfig()
-	// Use very short timings for testing
+	// Short open/idle so the round closes within the sleep budget;
+	// keep MinConsensus large enough that the establish phase cannot
+	// accept and cycle back to open before the assertion runs.
 	config.Timing.LedgerMinClose = 10 * time.Millisecond
 	config.Timing.LedgerMaxClose = 100 * time.Millisecond
-	config.Timing.LedgerMinConsensus = 10 * time.Millisecond
+	config.Timing.LedgerMinConsensus = 200 * time.Millisecond
 	config.Timing.LedgerIdleInterval = 20 * time.Millisecond
 
 	engine := NewEngine(adaptor, config)
 
-	// Must call Start to initialize prevLedger
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if err := engine.Start(ctx); err != nil {
@@ -1027,15 +1028,15 @@ func TestEngine_PhaseTransitions(t *testing.T) {
 	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
 	engine.StartRound(round, true)
 
-	// Should start in Open phase
 	if engine.Phase() != consensus.PhaseOpen {
 		t.Errorf("Expected Open phase, got %v", engine.Phase())
 	}
 
-	// Wait for close timer (idle interval triggers close with no txs)
+	// Sleep past idleInterval (20ms) so the round closes, but well
+	// short of MinConsensus (200ms) so we observe the Establish phase
+	// before it accepts and cycles back to Open.
 	time.Sleep(50 * time.Millisecond)
 
-	// Should transition to Establish phase
 	if engine.Phase() != consensus.PhaseEstablish {
 		t.Errorf("Expected Establish phase, got %v", engine.Phase())
 	}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -2250,9 +2250,6 @@ drain:
 //     can tell a hard abandon from a soft force-accept.
 //
 // goXRPL surfaces (3) as ResultAbandoned.
-//
-// See TestConsensus_AbandonRetryGate below for the establish-counter
-// retry path that suppresses abandon when individual rounds are slow.
 func TestConsensus_AbandonHardTimeout(t *testing.T) {
 	adaptor := newMockAdaptor()
 	adaptor.validator = true
@@ -2317,7 +2314,7 @@ func TestConsensus_AbandonHardTimeout(t *testing.T) {
 			Round:    round,
 			NodeID:   nid,
 			Position: 1,
-			TxSet:    consensus.TxSetID{byte(0xB0 + i)}, // each peer different
+			TxSet:    consensus.TxSetID{byte(0xB0 + i)},
 		}
 	}
 	engine.phaseEstablish()
@@ -2489,7 +2486,7 @@ func TestConsensus_PrevProposersPause(t *testing.T) {
 
 	// roundTime past MIN_CONSENSUS but well below prevRoundTime + MIN.
 	roundTime := config.Timing.LedgerMinConsensus + 100*time.Millisecond
-	state := engine.checkConsensusState(roundTime, 4, 4) // all 4 agree
+	state := engine.checkConsensusState(roundTime, 4, 4)
 	if state != consensusStateNo {
 		t.Fatalf("expected consensusStateNo (3/4 pause), got %v", state)
 	}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -2238,7 +2238,8 @@ drain:
 
 // TestConsensus_AbandonHardTimeout pins the behavior of the E3 hard
 // deadline: once a round exceeds the ledgerABANDON_CONSENSUS clamp
-// (rippled's 15s..120s clamp, ConsensusParms.h:113), the engine
+// (rippled's 15s..120s clamp, ConsensusParms.h:113) AND establishCounter
+// has cleared the per-avalanche-level minimum dwell, the engine
 // abandons the round. Per rippled Consensus.cpp:253-263 + Consensus.h:
 // 1760-1785, this means:
 //
@@ -2249,6 +2250,9 @@ drain:
 //     can tell a hard abandon from a soft force-accept.
 //
 // goXRPL surfaces (3) as ResultAbandoned.
+//
+// See TestConsensus_AbandonRetryGate below for the establish-counter
+// retry path that suppresses abandon when individual rounds are slow.
 func TestConsensus_AbandonHardTimeout(t *testing.T) {
 	adaptor := newMockAdaptor()
 	adaptor.validator = true
@@ -2289,6 +2293,33 @@ func TestConsensus_AbandonHardTimeout(t *testing.T) {
 	engine.setPhase(consensus.PhaseEstablish)
 	engine.roundStartTime = time.Now().Add(-121 * time.Second)
 	engine.prevRoundTime = 60 * time.Second // factor×60s=600s, clamped down to 120s
+	// Clear the rippled-faithful retry gate (Consensus.h:1762-1779):
+	// abandon only fires once each avalanche level has had its minimum
+	// dwell. The +1 covers the increment phaseEstablish performs on
+	// entry.
+	engine.establishCounter = len(engine.parms.AvalancheCutoffs)*engine.parms.MinRounds + 1
+	// Inject disagreeing trusted peers so we don't hit the
+	// alone-too-long carve-out (which would resolve to Yes via
+	// checkConsensusReached(_, 0, ..., reachedMax=true, ...)).
+	// With OurPosition pinned to one tx set and 4 peers proposing two
+	// different alternatives, agree*100/total stays at 20% — well below
+	// the 80% gate — so the Expired arm wins.
+	ourSet := consensus.TxSetID{0xAA}
+	engine.state.OurPosition = &consensus.Proposal{
+		Round:    round,
+		Position: 1,
+		TxSet:    ourSet,
+	}
+	for i := 1; i <= 4; i++ {
+		nid := consensus.NodeID{byte(0x10 + i)}
+		adaptor.trusted[nid] = true
+		engine.proposals[nid] = &consensus.Proposal{
+			Round:    round,
+			NodeID:   nid,
+			Position: 1,
+			TxSet:    consensus.TxSetID{byte(0xB0 + i)}, // each peer different
+		}
+	}
 	engine.phaseEstablish()
 	phaseAfter := engine.phase
 	modeAfter := engine.mode
@@ -2346,6 +2377,160 @@ drain:
 	}
 	if sawTimeout {
 		t.Errorf("hard abandon must not emit ResultTimeout (that is the soft branch)")
+	}
+}
+
+// TestConsensus_AbandonRetryGate pins the rippled retry-gate from
+// Consensus.h:1762-1779: when checkConsensus would return Expired
+// but the round has not yet spent (len(avalancheCutoffs) * MinRounds)
+// ticks in establish, the engine keeps trying instead of abandoning.
+// This protects rounds with very long individual ticks (heavy disputes)
+// from being dropped before each avalanche level gets its minimum dwell.
+func TestConsensus_AbandonRetryGate(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+
+	config := DefaultConfig()
+	config.Timing.LedgerMaxConsensus = 15 * time.Second
+	config.Timing.LedgerMaxClose = 15 * time.Second
+	config.Timing.LedgerAbandonConsensus = 120 * time.Second
+	config.Timing.LedgerAbandonConsensusFactor = 10
+
+	engine := NewEngine(adaptor, config)
+	subscriber := &testSubscriber{events: make(chan consensus.Event, 32)}
+	engine.Subscribe(subscriber)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	engine.mu.Lock()
+	if engine.mode != consensus.ModeProposing {
+		engine.mu.Unlock()
+		t.Fatalf("setup: expected ModeProposing after StartRound, got %v", engine.mode)
+	}
+	// Drive the round past the hard ceiling but with establishCounter
+	// well below the per-avalanche-level minimum dwell. The retry gate
+	// must suppress abandon. We inject disagreeing peers so the Expired
+	// arm of checkConsensus is reached at all (otherwise the alone-too-
+	// long carve-out at checkConsensusReached(_, 0, ..., reachedMax=true)
+	// would resolve to Yes and bypass the Expired branch entirely).
+	engine.setPhase(consensus.PhaseEstablish)
+	engine.roundStartTime = time.Now().Add(-121 * time.Second)
+	engine.prevRoundTime = 60 * time.Second
+	engine.establishCounter = 0
+	ourSet := consensus.TxSetID{0xAA}
+	engine.state.OurPosition = &consensus.Proposal{
+		Round:    round,
+		Position: 1,
+		TxSet:    ourSet,
+	}
+	for i := 1; i <= 4; i++ {
+		nid := consensus.NodeID{byte(0x20 + i)}
+		adaptor.trusted[nid] = true
+		engine.proposals[nid] = &consensus.Proposal{
+			Round:    round,
+			NodeID:   nid,
+			Position: 1,
+			TxSet:    consensus.TxSetID{byte(0xC0 + i)},
+		}
+	}
+	engine.phaseEstablish()
+	phaseAfter := engine.phase
+	modeAfter := engine.mode
+	engine.mu.Unlock()
+
+	if phaseAfter != consensus.PhaseEstablish {
+		t.Errorf("retry gate: phase should remain Establish, got %v", phaseAfter)
+	}
+	if modeAfter != consensus.ModeProposing {
+		t.Errorf("retry gate: mode should remain Proposing (no bow-out), got %v", modeAfter)
+	}
+
+	deadline := time.After(200 * time.Millisecond)
+drain:
+	for {
+		select {
+		case ev := <-subscriber.events:
+			if cre, ok := ev.(*consensus.ConsensusReachedEvent); ok {
+				t.Errorf("retry gate: no consensus event should fire, got Result=%v", cre.Result)
+			}
+		case <-deadline:
+			break drain
+		}
+	}
+}
+
+// TestConsensus_PrevProposersPause covers the 3/4 prev-proposers
+// pause arm of checkConsensus (Consensus.cpp:208-218): when fewer
+// than 3/4 of the previous round's proposers are present AND the
+// round has not yet run for prevRoundTime + ledgerMIN_CONSENSUS, the
+// engine does NOT accept even with majority agreement — slower
+// validators get an extra MIN_CONSENSUS interval to catch up.
+func TestConsensus_PrevProposersPause(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.opMode = consensus.OpModeFull
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+	engine.parms = consensus.DefaultConsensusParms()
+
+	// 8 prev proposers; only 4 visible this round → 4 < 8*3/4=6 → pause.
+	engine.prevProposers = 8
+	engine.prevRoundTime = 5 * time.Second
+	engine.haveCloseTimeConsensus = true
+
+	// roundTime past MIN_CONSENSUS but well below prevRoundTime + MIN.
+	roundTime := config.Timing.LedgerMinConsensus + 100*time.Millisecond
+	state := engine.checkConsensusState(roundTime, 4, 4) // all 4 agree
+	if state != consensusStateNo {
+		t.Fatalf("expected consensusStateNo (3/4 pause), got %v", state)
+	}
+
+	// Once roundTime clears prevRoundTime + MIN_CONSENSUS, the gate
+	// releases and the same tally yields Yes.
+	roundTime = engine.prevRoundTime + config.Timing.LedgerMinConsensus + time.Second
+	state = engine.checkConsensusState(roundTime, 4, 4)
+	if state != consensusStateYes {
+		t.Fatalf("expected consensusStateYes once 3/4 gate clears, got %v", state)
+	}
+}
+
+// TestCheckConsensusReached covers the parity port of rippled's
+// checkConsensusReached free function (Consensus.cpp:106-174). Each
+// subtest pins one carve-out: alone-for-too-long, stalled
+// short-circuit, count-self math, and ordinary threshold.
+func TestCheckConsensusReached(t *testing.T) {
+	tests := []struct {
+		name      string
+		agreeing  int
+		total     int
+		countSelf bool
+		minPct    int
+		reachedMax,
+		stalled bool
+		want bool
+	}{
+		{"alone before max → no", 0, 0, true, 80, false, false, false},
+		{"alone past max → yes", 0, 0, true, 80, true, false, true},
+		{"stalled short-circuits", 1, 10, false, 80, false, true, true},
+		{"countSelf bumps agree+total", 7, 9, true, 80, false, false, true},
+		{"normal threshold met", 8, 10, false, 80, false, false, true},
+		{"normal threshold missed", 7, 10, false, 80, false, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checkConsensusReached(tt.agreeing, tt.total, tt.countSelf, tt.minPct, tt.reachedMax, tt.stalled); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -524,7 +524,6 @@ func disputeStalled(d *consensus.DisputedTx, parms consensus.ConsensusParms, pro
 	currentCutoff := parms.AvalancheCutoffs[d.AvalancheState]
 	nextCutoff := parms.AvalancheCutoffs[currentCutoff.Next]
 
-	// Not yet at the terminal cutoff, or not there long enough.
 	if nextCutoff.ConsensusTime > currentCutoff.ConsensusTime ||
 		d.AvalancheCounter < parms.MinRounds {
 		return false
@@ -532,9 +531,9 @@ func disputeStalled(d *consensus.DisputedTx, parms consensus.ConsensusParms, pro
 	if proposing && d.CurrentVoteCounter < parms.MinRounds {
 		return false
 	}
-	// Both peers AND (when proposing) we ourselves are still actively
-	// updating → not stalled. If either side has been frozen for
-	// StalledRounds, we treat the dispute as stalled.
+	// Stalled only when at least one side has frozen for StalledRounds.
+	// While peers AND (when proposing) we ourselves are both still
+	// flipping votes, the dispute is still moving.
 	if peersUnchanged < parms.StalledRounds &&
 		proposing && d.CurrentVoteCounter < parms.StalledRounds {
 		return false

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -489,6 +489,74 @@ func (dt *DisputeTracker) UpdateOurVote(percentTime int, proposing bool, parms c
 	return changed
 }
 
+// AllStalled reports whether every active dispute is stalled per
+// DisputedTx.Stalled. An empty dispute set returns false — rippled
+// gates the stalled bit on disputes being non-empty (Consensus.h:1718).
+//
+// Matches rippled's std::ranges::all_of stalled check at
+// Consensus.h:1720-1728.
+func (dt *DisputeTracker) AllStalled(parms consensus.ConsensusParms, proposing bool, peersUnchanged int) bool {
+	dt.mu.RLock()
+	defer dt.mu.RUnlock()
+	if len(dt.disputes) == 0 {
+		return false
+	}
+	for _, dispute := range dt.disputes {
+		if !disputeStalled(dispute, parms, proposing, peersUnchanged) {
+			return false
+		}
+	}
+	return true
+}
+
+// disputeStalled mirrors rippled's DisputedTx::stalled (DisputedTx.h:88-149).
+// A dispute is stalled when all of the following hold:
+//   - it has reached the terminal avalanche cutoff (the next state loops
+//     back to itself) and has been there for at least MinRounds;
+//   - if we are proposing, our own vote has been stable for at least
+//     MinRounds;
+//   - either our peers have not changed votes for StalledRounds OR
+//     (we are proposing AND our own vote has been stable for
+//     StalledRounds) — i.e. at least one side has stopped moving;
+//   - the tally is >MinConsensusPct one-sided (overwhelming yes or no
+//     support), so further flipping is unlikely.
+func disputeStalled(d *consensus.DisputedTx, parms consensus.ConsensusParms, proposing bool, peersUnchanged int) bool {
+	currentCutoff := parms.AvalancheCutoffs[d.AvalancheState]
+	nextCutoff := parms.AvalancheCutoffs[currentCutoff.Next]
+
+	// Not yet at the terminal cutoff, or not there long enough.
+	if nextCutoff.ConsensusTime > currentCutoff.ConsensusTime ||
+		d.AvalancheCounter < parms.MinRounds {
+		return false
+	}
+	if proposing && d.CurrentVoteCounter < parms.MinRounds {
+		return false
+	}
+	// Both peers AND (when proposing) we ourselves are still actively
+	// updating → not stalled. If either side has been frozen for
+	// StalledRounds, we treat the dispute as stalled.
+	if peersUnchanged < parms.StalledRounds &&
+		proposing && d.CurrentVoteCounter < parms.StalledRounds {
+		return false
+	}
+
+	ownYes := 0
+	selfTotal := 0
+	if proposing {
+		selfTotal = 1
+		if d.OurVote {
+			ownYes = 1
+		}
+	}
+	support := (d.Yays + ownYes) * 100
+	total := d.Nays + d.Yays + selfTotal
+	if total == 0 {
+		return false
+	}
+	weight := support / total
+	return weight > parms.MinConsensusPct || weight < (100-parms.MinConsensusPct)
+}
+
 // GetDispute returns a disputed transaction.
 func (dt *DisputeTracker) GetDispute(txID consensus.TxID) *consensus.DisputedTx {
 	dt.mu.RLock()

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -223,31 +223,6 @@ const (
 	validationCurrentEarly = 3 * time.Minute
 )
 
-// validationVALID_* mirror rippled's ConsensusParms freshness window
-// constants (ConsensusParms.h:51-66). Rippled declares them as a
-// distinct set from the isCurrent CURRENT_* family (Validations.h:56-71)
-// — both default to 5m/3m/3m, but the VALID_* set documents the
-// duration a validation remains *current after its ledger's close
-// time* and is reserved for callers that need to reason about a
-// validation's lifespan independent of the isCurrent gate.
-//
-// Kept as a separate constant from validationCurrentWall so a future
-// divergence between the two windows in rippled does not silently
-// inherit the wrong value here. Currently unused — surfaced for
-// parity and so the audit-derived gap noted in issue #498 cannot
-// regress.
-const (
-	validationValidWall  = 5 * time.Minute
-	validationValidLocal = 3 * time.Minute
-	validationValidEarly = 3 * time.Minute
-)
-
-var (
-	_ = validationValidWall
-	_ = validationValidLocal
-	_ = validationValidEarly
-)
-
 // isCurrent reports whether a validation's sign-time and seen-time are
 // close enough to now to be considered "current" in rippled's sense.
 // Exact mirror of Validations.h:148-166 isCurrent:

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -223,6 +223,31 @@ const (
 	validationCurrentEarly = 3 * time.Minute
 )
 
+// validationVALID_* mirror rippled's ConsensusParms freshness window
+// constants (ConsensusParms.h:51-66). Rippled declares them as a
+// distinct set from the isCurrent CURRENT_* family (Validations.h:56-71)
+// — both default to 5m/3m/3m, but the VALID_* set documents the
+// duration a validation remains *current after its ledger's close
+// time* and is reserved for callers that need to reason about a
+// validation's lifespan independent of the isCurrent gate.
+//
+// Kept as a separate constant from validationCurrentWall so a future
+// divergence between the two windows in rippled does not silently
+// inherit the wrong value here. Currently unused — surfaced for
+// parity and so the audit-derived gap noted in issue #498 cannot
+// regress.
+const (
+	validationValidWall  = 5 * time.Minute
+	validationValidLocal = 3 * time.Minute
+	validationValidEarly = 3 * time.Minute
+)
+
+var (
+	_ = validationValidWall
+	_ = validationValidLocal
+	_ = validationValidEarly
+)
+
 // isCurrent reports whether a validation's sign-time and seen-time are
 // close enough to now to be considered "current" in rippled's sense.
 // Exact mirror of Validations.h:148-166 isCurrent:

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -497,10 +497,10 @@ type Timing struct {
 
 	// ProposeInterval is how often we force generating a new proposal
 	// to keep ours fresh. Matches rippled's proposeINTERVAL
-	// (ConsensusParms.h:72 = 12s). Surfaced for parity; the engine's
-	// updatePosition path currently re-proposes whenever close-time or
-	// per-tx voting changes our position, so this field is observability-
-	// only — it does not yet drive a separate "force-refresh" timer.
+	// (ConsensusParms.h:72 = 12s). Observability-only today: the
+	// engine's updatePosition path re-proposes whenever close-time or
+	// per-tx voting changes our position, so this field does not yet
+	// drive a separate force-refresh timer.
 	ProposeInterval time.Duration
 
 	// ValidationFreshness is how long a validation is considered fresh

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -481,13 +481,31 @@ type Timing struct {
 	// Matches rippled's ledgerABANDON_CONSENSUS_FACTOR (ConsensusParms.h:105 = 10).
 	LedgerAbandonConsensusFactor int
 
-	// LedgerGranularity is the close time resolution.
+	// LedgerGranularity is how often the engine checks state or
+	// changes positions during a consensus round — the heartbeat
+	// interval. Matches rippled's ledgerGRANULARITY
+	// (ConsensusParms.h:102 = 1s). Dispute re-vote cadence and the
+	// peerUnchangedCounter advance once per granularity tick, so a
+	// value larger than rippled's 1s slows stall detection
+	// proportionally. (Close-time resolution is a distinct concept
+	// derived from getNextLedgerTimeResolution, not from this field.)
 	LedgerGranularity time.Duration
 
 	// ProposeFreshness is how long a proposal is considered fresh.
+	// Matches rippled's proposeFRESHNESS (ConsensusParms.h:69 = 20s).
 	ProposeFreshness time.Duration
 
-	// ValidationFreshness is how long a validation is considered fresh.
+	// ProposeInterval is how often we force generating a new proposal
+	// to keep ours fresh. Matches rippled's proposeINTERVAL
+	// (ConsensusParms.h:72 = 12s). Surfaced for parity; the engine's
+	// updatePosition path currently re-proposes whenever close-time or
+	// per-tx voting changes our position, so this field is observability-
+	// only — it does not yet drive a separate "force-refresh" timer.
+	ProposeInterval time.Duration
+
+	// ValidationFreshness is how long a validation is considered fresh
+	// for laggard accounting. Matches rippled's validationFRESHNESS
+	// (Validations.h:89 = 20s).
 	ValidationFreshness time.Duration
 }
 
@@ -501,8 +519,9 @@ func DefaultTiming() Timing {
 		LedgerAbandonConsensusFactor: 10,
 		LedgerMinConsensus:           1950 * time.Millisecond,
 		LedgerIdleInterval:           15 * time.Second,
-		LedgerGranularity:            10 * time.Second,
+		LedgerGranularity:            1 * time.Second,
 		ProposeFreshness:             20 * time.Second,
+		ProposeInterval:              12 * time.Second,
 		ValidationFreshness:          20 * time.Second,
 	}
 }

--- a/tasks/conformance-audit.md
+++ b/tasks/conformance-audit.md
@@ -168,3 +168,19 @@ incremental reviews instead of re-reading rippled from scratch.
 - Files cleanup-only (Phase 0 skipped Phase 1): none
 - Cleanup commit: 47f442c0 — chore: clean ai-generated comments (1 paraphrase line stripped from isZeroFee; all rippled cites and non-obvious whys preserved)
 - Notes: Zero blockers and zero minors across the incremental work — all seven prior-audit follow-ups are correctly anchored to rippled, and the new tfInnerBatchTxn + NetworkID gates byte-match Transactor.cpp:46-75. The three nits are advisory: lingering ZeroAccount literals exist only at non-pseudo-tx sites (payment.go path-element XRP detection, conformance/runner.go); isZeroFee is strictly more permissive than rippled at a Go-API boundary rippled never reaches; pseudoPreclaim's structural asymmetry between ttFEE and ttAMENDMENT/ttUNL_MODIFY would benefit from a one-line comment. None gate merge.
+
+## 2026-05-22 — PR #513 — feat/issue-498-consensus-audit
+- Rippled SHA at review: 1e89286a92
+- PR URL: https://github.com/LeJamon/go-xrpl/pull/513
+- Review comment: https://github.com/LeJamon/go-xrpl/pull/513#issuecomment-4520322007
+- Files reviewed (Phase 1):
+  - internal/consensus/rcl/engine.go — 2 Minor (M1 CT-consensus gate asymmetric across Yes/MovedOn/Expired; M2 LedgerGranularity wired only to csf), 1 Nit (N1 consensusState enum order mismatch), 0 blocking — all fixed in 7cf1b367
+  - internal/consensus/rcl/proposals.go — 0 findings
+  - internal/consensus/rcl/validations.go — 1 Nit (N2 dead validationValid* constants) — fixed in 7cf1b367 (constants removed); file's net delta vs main is now zero
+  - internal/consensus/rcl/disputes_test.go — 1 Nit (N3 missing proposing=false coverage) — fixed in 7cf1b367 (observer subtest + mixed-set subtest)
+  - internal/consensus/rcl/engine_test.go — 1 Nit (N4 no direct unit test for checkConsensusState) — fixed in 7cf1b367 (TestCheckConsensusState walking all 6 arms)
+  - internal/consensus/types.go — 0 findings (the LedgerGranularity doc-accuracy issue is filed under engine.go M2)
+- Files cleanup-only (Phase 0 skipped Phase 1): none
+- Cleanup commit: 8e7d4cc5 — chore: clean ai-generated comments (stripped 5 paraphrase / numbered-section / "see X below" lines across the 5 changed files; rippled cites and non-obvious whys preserved)
+- Branch was 97 commits behind main at finalize-start; rebased onto a8c4d86e before review. Final tip: 8e7d4cc5.
+- Notes: Yes-arm checkConsensusReached(count_self=false) verified intentional — Go's countAgreement pre-bumps `agree` when proposing, matching rippled's internal `++agreeing; ++total`. getCloseTimeNeededWeight refactor is a quiet bugfix: prior hand-written switch gated init→mid at pct>=0 (rippled: pct>=50) and late→stuck at pct>=85 (rippled: pct>=200), and returned the old-state pct on transition (rippled: new-state pct). All three pre-existing divergences are now correct via parms.NeededWeight.


### PR DESCRIPTION
## Summary

Closes the consensus-layer gaps surfaced in the audit-derived tracking issue. The previous engine had several rippled-faithful pieces missing or duplicated; this PR ports them into a single, unified checkConsensus state machine that mirrors `rippled/src/xrpld/consensus/Consensus.cpp:176-269` and `Consensus.h:1681-1798`.

### Byzantine-stall escape hatch
- **DisputedTx.Stalled() predicate** (new `disputeStalled` + `DisputeTracker.AllStalled` in `internal/consensus/rcl/proposals.go`). Mirrors rippled `DisputedTx.h:88-149`: gates on terminal avalanche cutoff + dwell, our-vote stability, peer-vote stability, and >80% one-sided tally.
- **ResultExpired retry gate** (`internal/consensus/rcl/engine.go` Expired arm of `checkConvergence`). Refuses to expire when `establishCounter < len(avalancheCutoffs) * MinRounds` — matches rippled `Consensus.h:1762-1779`.

### checkConvergence unification
- Single `checkConsensusState` helper returns the rippled `ConsensusState` (No/Yes/MovedOn/Expired). The old MovedOn detection block in `phaseEstablish` and the hand-rolled abandon path are folded into this state machine.
- **3/4 prev-proposers pause** added — rippled `Consensus.cpp:208-218`.
- Skipped when `prevProposers == 0` (cold start / 1-node soak) so we don't freeze on first round.

### Close-time threshold path
- `getCloseTimeNeededWeight` now calls the shared `ConsensusParms.NeededWeight` with `currentRounds=0, minimumRounds=0`, matching rippled `Consensus.h:1578-1581`. Fixes a latent advancement bug (the prior code unconditionally advanced from `AvalancheInit` because `pct >= 0` is always true).

### Parameter parity
- `LedgerGranularity` default 10s → 1s (rippled `ConsensusParms.h:102`). Field is currently config-only; production heartbeat is already 1s.
- New `Timing.ProposeInterval` (12s, rippled `ConsensusParms.h:72`) — surfaced for parity.
- New `validationVALID_WALL/LOCAL/EARLY` constants in `internal/consensus/rcl/validations.go` — separate from the isCurrent `validationCURRENT_*` family per rippled `ConsensusParms.h:51-66`. Currently 5m/3m/3m on both sides; kept as distinct constants so a future divergence in rippled doesn't silently inherit the wrong value here.

### Tests
- `TestDisputeTracker_AllStalled` — pins the four preconditions of the per-dispute Stalled predicate.
- `TestConsensus_AbandonHardTimeout` — updated to inject disagreeing peers so the Expired arm is actually reachable (the alone-too-long carve-out at `checkConsensusReached(_, 0, ..., reachedMax=true, ...)` correctly resolves to Yes per rippled `Consensus.cpp:129-140`).
- `TestConsensus_AbandonRetryGate` — new: verifies the establishCounter retry suppresses abandon.
- `TestConsensus_PrevProposersPause` — new: verifies the 3/4 gate releases at `prevRoundTime + MIN_CONSENSUS`.
- `TestCheckConsensusReached` — table tests covering all carve-outs of the parity helper.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/consensus/...`
- [x] `go test ./internal/tx/...` + `./internal/ledger/...`
- [x] Pre-existing MPT/integration failures verified to also fail on main (unrelated)

Fixes #498