### PR TITLE
fix(amm): canonical XRP currency bytes + rippled-conformant keylet sort

### DIFF
--- a/internal/ledger/state/directory_test.go
+++ b/internal/ledger/state/directory_test.go
@@ -1,0 +1,27 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetCurrencyBytes_XRP_AllZero pins the canonical XRP-encoding contract.
+// AMMCreate (internal/tx/amm/keylet.go) and every AMM-side lookup path
+// (internal/rpc/handlers/amm_info.go, ledger_entry.go, internal/testing/amm/
+// helpers.go) all route through GetCurrencyBytes; if XRP ever stopped
+// round-tripping to the all-zero currency here, every XRP-paired AMM lookup
+// by asset would silently mis-key and surface as actNotFound.
+func TestGetCurrencyBytes_XRP_AllZero(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, [20]byte{}, GetCurrencyBytes("XRP"),
+		"XRP must encode to the all-zero currency to match AMMCreate's keylet")
+	assert.Equal(t, [20]byte{}, GetCurrencyBytes(""),
+		"empty currency must also encode to all-zero (defensive)")
+
+	var usd [20]byte
+	usd[12], usd[13], usd[14] = 'U', 'S', 'D'
+	assert.Equal(t, usd, GetCurrencyBytes("USD"),
+		"3-letter ISO codes encode as ASCII at bytes 12-14")
+}

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -518,9 +518,16 @@ func ammIssueFrozen(ctx *types.RpcContext, ledgerIndex string, ammAccountID [20]
 	return (rs.Flags & state.LsfLowFreeze) != 0
 }
 
-// currencyToBytes converts a currency code to its 20-byte representation
+// currencyToBytes converts a currency code to its 20-byte representation.
+// XRP must round-trip to the all-zero currency to match the AMM keylet
+// written by AMMCreate via state.GetCurrencyBytes; encoding the ASCII
+// "XRP" here would mis-key every XRP-paired AMM looked up by asset.
 func currencyToBytes(currency string) [20]byte {
 	var result [20]byte
+
+	if currency == "" || currency == "XRP" {
+		return result
+	}
 
 	if len(currency) == 3 {
 		// Standard currency code - ASCII in bytes 12-14

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -369,8 +369,10 @@ func parseIssue(issue map[string]interface{}) ([20]byte, [20]byte, error) {
 	}
 	copy(issuer[:], issuerBytes)
 
-	// Convert currency code to 20-byte format
-	currency = currencyToBytes(currencyStr)
+	// Convert currency code to 20-byte format. state.GetCurrencyBytes is the
+	// canonical write-path encoder used by AMMCreate (internal/tx/amm/keylet.go);
+	// using it here keeps lookup keying symmetric with the write path.
+	currency = state.GetCurrencyBytes(currencyStr)
 
 	return issuer, currency, nil
 }
@@ -516,31 +518,4 @@ func ammIssueFrozen(ctx *types.RpcContext, ledgerIndex string, ammAccountID [20]
 		return (rs.Flags & state.LsfHighFreeze) != 0
 	}
 	return (rs.Flags & state.LsfLowFreeze) != 0
-}
-
-// currencyToBytes converts a currency code to its 20-byte representation.
-// XRP must round-trip to the all-zero currency to match the AMM keylet
-// written by AMMCreate via state.GetCurrencyBytes; encoding the ASCII
-// "XRP" here would mis-key every XRP-paired AMM looked up by asset.
-func currencyToBytes(currency string) [20]byte {
-	var result [20]byte
-
-	if currency == "" || currency == "XRP" {
-		return result
-	}
-
-	if len(currency) == 3 {
-		// Standard currency code - ASCII in bytes 12-14
-		result[12] = currency[0]
-		result[13] = currency[1]
-		result[14] = currency[2]
-	} else if len(currency) == 40 {
-		// Hex-encoded currency (non-standard)
-		decoded, _ := hex.DecodeString(currency)
-		if len(decoded) == 20 {
-			copy(result[:], decoded)
-		}
-	}
-
-	return result
 }

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -369,9 +369,8 @@ func parseIssue(issue map[string]interface{}) ([20]byte, [20]byte, error) {
 	}
 	copy(issuer[:], issuerBytes)
 
-	// Convert currency code to 20-byte format. state.GetCurrencyBytes is the
-	// canonical write-path encoder used by AMMCreate (internal/tx/amm/keylet.go);
-	// using it here keeps lookup keying symmetric with the write path.
+	// state.GetCurrencyBytes is the canonical write-path encoder used by
+	// AMMCreate; routing the lookup through it keeps the keying symmetric.
 	currency = state.GetCurrencyBytes(currencyStr)
 
 	return issuer, currency, nil

--- a/internal/rpc/handlers/amm_info_test.go
+++ b/internal/rpc/handlers/amm_info_test.go
@@ -278,3 +278,20 @@ func TestExtractIssue_NotAMap(t *testing.T) {
 	_, ok = extractIssue(nil)
 	assert.False(t, ok)
 }
+
+// Regression for the XRP-pair AMM keylet mismatch. AMMCreate writes the AMM
+// SLE under a keylet computed via state.GetCurrencyBytes("XRP") = all-zero;
+// the amm_info handler must match that encoding. Encoding "XRP" as ASCII into
+// bytes 12-14 (the previous behavior) mis-keys every XRP-paired AMM looked up
+// by asset and surfaces as actNotFound. This test pins the contract.
+func TestCurrencyToBytes_XRP_AllZero(t *testing.T) {
+	assert.Equal(t, [20]byte{}, currencyToBytes("XRP"),
+		"XRP must round-trip to the all-zero currency to match AMMCreate's keylet")
+	assert.Equal(t, [20]byte{}, currencyToBytes(""),
+		"empty currency must also round-trip to all-zero (defensive)")
+
+	// Sanity: a real 3-letter code still ASCII-encodes into bytes 12-14.
+	var usd [20]byte
+	usd[12], usd[13], usd[14] = 'U', 'S', 'D'
+	assert.Equal(t, usd, currencyToBytes("USD"))
+}

--- a/internal/rpc/handlers/amm_info_test.go
+++ b/internal/rpc/handlers/amm_info_test.go
@@ -278,20 +278,3 @@ func TestExtractIssue_NotAMap(t *testing.T) {
 	_, ok = extractIssue(nil)
 	assert.False(t, ok)
 }
-
-// Regression for the XRP-pair AMM keylet mismatch. AMMCreate writes the AMM
-// SLE under a keylet computed via state.GetCurrencyBytes("XRP") = all-zero;
-// the amm_info handler must match that encoding. Encoding "XRP" as ASCII into
-// bytes 12-14 (the previous behavior) mis-keys every XRP-paired AMM looked up
-// by asset and surfaces as actNotFound. This test pins the contract.
-func TestCurrencyToBytes_XRP_AllZero(t *testing.T) {
-	assert.Equal(t, [20]byte{}, currencyToBytes("XRP"),
-		"XRP must round-trip to the all-zero currency to match AMMCreate's keylet")
-	assert.Equal(t, [20]byte{}, currencyToBytes(""),
-		"empty currency must also round-trip to all-zero (defensive)")
-
-	// Sanity: a real 3-letter code still ASCII-encodes into bytes 12-14.
-	var usd [20]byte
-	usd[12], usd[13], usd[14] = 'U', 'S', 'D'
-	assert.Equal(t, usd, currencyToBytes("USD"))
-}

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -10,6 +10,7 @@ import (
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	"github.com/LeJamon/goXRPLd/keylet"
 )
@@ -816,9 +817,9 @@ func parseCurrencyIssuer(raw json.RawMessage) (currency [20]byte, issuer [20]byt
 		return currency, issuer, err
 	}
 
-	// Convert currency string to 20-byte representation
-	// Reuse currencyToBytes from amm_info.go (same package)
-	currency = currencyToBytes(req.Currency)
+	// Convert currency string to 20-byte representation via the canonical
+	// state.GetCurrencyBytes used by every write path.
+	currency = state.GetCurrencyBytes(req.Currency)
 
 	if req.Issuer != "" {
 		issuer, err = decodeAccountID(req.Issuer)

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -817,8 +817,7 @@ func parseCurrencyIssuer(raw json.RawMessage) (currency [20]byte, issuer [20]byt
 		return currency, issuer, err
 	}
 
-	// Convert currency string to 20-byte representation via the canonical
-	// state.GetCurrencyBytes used by every write path.
+	// Canonical write-path encoder; matches AMMCreate's keying.
 	currency = state.GetCurrencyBytes(req.Currency)
 
 	if req.Issuer != "" {

--- a/internal/testing/amm/helpers.go
+++ b/internal/testing/amm/helpers.go
@@ -597,9 +597,9 @@ func (e *AMMTestEnv) ReadAMMData(asset1, asset2 tx.Asset) *coreAmm.AMMData {
 	e.T.Helper()
 	// Build the keylet the same way the amm code does internally
 	issuer1 := decodeIssuer(asset1.Issuer)
-	currency1 := currencyToBytes(asset1.Currency)
+	currency1 := state.GetCurrencyBytes(asset1.Currency)
 	issuer2 := decodeIssuer(asset2.Issuer)
-	currency2 := currencyToBytes(asset2.Currency)
+	currency2 := state.GetCurrencyBytes(asset2.Currency)
 
 	ammKey := keylet.AMM(issuer1, currency1, issuer2, currency2)
 	data, err := e.Ledger().Read(ammKey)
@@ -625,16 +625,6 @@ func decodeIssuer(issuer string) [20]byte {
 	var id [20]byte
 	copy(id[:], bytes)
 	return id
-}
-
-// currencyToBytes converts a 3-letter currency code to [20]byte (ISO at bytes 12-14).
-func currencyToBytes(currency string) [20]byte {
-	if currency == "XRP" || currency == "" {
-		return [20]byte{}
-	}
-	var b [20]byte
-	copy(b[12:15], []byte(currency))
-	return b
 }
 
 // AMMAssetOut computes the asset amount received for burning LP tokens.

--- a/keylet/keylet.go
+++ b/keylet/keylet.go
@@ -453,15 +453,16 @@ func PayChannel(srcAccountID, dstAccountID [20]byte, sequence uint32) Keylet {
 }
 
 // AMM returns the keylet for an AMM entry.
-// Sort key matches rippled's Issue::operator<=> (currency primary, then
-// issuer): rippled/include/xrpl/protocol/Issue.h. Hash input order per Issue
-// is (account, currency, account, currency) matching std::minmax feeding
-// indexHash in rippled/src/libxrpl/protocol/Indexes.cpp amm().
+// Sort key mirrors rippled's Issue::operator<=>
+// (rippled/include/xrpl/protocol/Issue.h:99-108): compare currency; on a
+// currency tie, return equivalent if the currency is XRP, otherwise compare
+// account. Hash input order is (account, currency, account, currency) per
+// std::minmax feeding indexHash in
+// rippled/src/libxrpl/protocol/Indexes.cpp:446-456 amm().
 func AMM(issue1Issuer, issue1Currency, issue2Issuer, issue2Currency [20]byte) Keylet {
 	var minIssuer, minCurrency, maxIssuer, maxCurrency [20]byte
 
-	cmp := bytes.Compare(issue1Currency[:], issue2Currency[:])
-	if cmp < 0 || (cmp == 0 && bytes.Compare(issue1Issuer[:], issue2Issuer[:]) < 0) {
+	if issue1LessEqualIssue2(issue1Currency, issue1Issuer, issue2Currency, issue2Issuer) {
 		minIssuer, minCurrency = issue1Issuer, issue1Currency
 		maxIssuer, maxCurrency = issue2Issuer, issue2Currency
 	} else {
@@ -473,6 +474,23 @@ func AMM(issue1Issuer, issue1Currency, issue2Issuer, issue2Currency [20]byte) Ke
 		Type: entry.TypeAMM,
 		Key:  indexHash(spaceAMM, minIssuer[:], minCurrency[:], maxIssuer[:], maxCurrency[:]),
 	}
+}
+
+// issue1LessEqualIssue2 reports whether issue1 sorts at-or-before issue2 under
+// rippled's Issue::operator<=>. A true result preserves the original argument
+// order through std::minmax — including the equivalent case (currency tie on
+// XRP, or full Issue equality) where rippled returns
+// std::weak_ordering::equivalent and std::minmax keeps (a, b).
+func issue1LessEqualIssue2(currency1, issuer1, currency2, issuer2 [20]byte) bool {
+	if c := bytes.Compare(currency1[:], currency2[:]); c != 0 {
+		return c < 0
+	}
+	if currency1 == ([20]byte{}) {
+		// Both currencies are XRP — Issue.h:104 returns equivalent without
+		// comparing accounts. std::minmax then keeps original order.
+		return true
+	}
+	return bytes.Compare(issuer1[:], issuer2[:]) <= 0
 }
 
 // AMMByID returns an AMM keylet for a known AMM ID.

--- a/keylet/keylet.go
+++ b/keylet/keylet.go
@@ -453,14 +453,15 @@ func PayChannel(srcAccountID, dstAccountID [20]byte, sequence uint32) Keylet {
 }
 
 // AMM returns the keylet for an AMM entry.
-// The keylet is computed from the sorted asset pair (issuer + currency).
-// Reference: rippled Indexes.cpp amm(Asset const& issue1, Asset const& issue2)
+// Sort key matches rippled's Issue::operator<=> (currency primary, then
+// issuer): rippled/include/xrpl/protocol/Issue.h. Hash input order per Issue
+// is (account, currency, account, currency) matching std::minmax feeding
+// indexHash in rippled/src/libxrpl/protocol/Indexes.cpp amm().
 func AMM(issue1Issuer, issue1Currency, issue2Issuer, issue2Currency [20]byte) Keylet {
-	// Sort the issues (compare issuer first, then currency)
 	var minIssuer, minCurrency, maxIssuer, maxCurrency [20]byte
 
-	cmp := bytes.Compare(issue1Issuer[:], issue2Issuer[:])
-	if cmp < 0 || (cmp == 0 && bytes.Compare(issue1Currency[:], issue2Currency[:]) < 0) {
+	cmp := bytes.Compare(issue1Currency[:], issue2Currency[:])
+	if cmp < 0 || (cmp == 0 && bytes.Compare(issue1Issuer[:], issue2Issuer[:]) < 0) {
 		minIssuer, minCurrency = issue1Issuer, issue1Currency
 		maxIssuer, maxCurrency = issue2Issuer, issue2Currency
 	} else {

--- a/keylet/keylet_test.go
+++ b/keylet/keylet_test.go
@@ -42,7 +42,6 @@ func TestBookDirKey(t *testing.T) {
 // IOU+IOU pair where issuer-order and currency-order disagree, the two sorts
 // produce DIFFERENT keylets — this test pins the rippled-conformant behavior.
 func TestAMM_SortOrder_IOUPair_CurrencyPrimary(t *testing.T) {
-	// Currency A < Currency B
 	var curA, curB [20]byte
 	copy(curA[12:], []byte("AAA"))
 	copy(curB[12:], []byte("BBB"))
@@ -84,7 +83,6 @@ func TestAMM_XRPPair_UsesAllZeroCurrency(t *testing.T) {
 	var usdCurrency [20]byte
 	copy(usdCurrency[12:], []byte("USD"))
 
-	// The canonical XRP+USD AMM keylet uses all-zero XRP currency.
 	canonical := AMM([20]byte{}, [20]byte{}, issuer, usdCurrency)
 
 	// An ASCII-encoded "XRP" (the bug we're guarding against) would put

--- a/keylet/keylet_test.go
+++ b/keylet/keylet_test.go
@@ -97,3 +97,29 @@ func TestAMM_XRPPair_UsesAllZeroCurrency(t *testing.T) {
 		t.Fatalf("canonical XRP keylet must differ from ASCII-encoded XRP keylet")
 	}
 }
+
+// Mirrors rippled's Issue::operator<=> XRP shortcut
+// (rippled/include/xrpl/protocol/Issue.h:104): on a currency tie, if the
+// currency is XRP the comparison returns equivalent without touching the
+// account, and std::minmax keeps original argument order. No real caller
+// can produce an XRP/XRP AMM with a non-zero issuer (XRP's issuer is always
+// all-zero), but this test pins the literal port: swapping args must NOT be
+// "normalized" by the keylet — the hash should change, exactly as rippled's
+// does. The previous Go implementation incorrectly produced symmetric
+// keylets here by falling through to compare issuers.
+func TestAMM_SortOrder_XRPCurrencyTie_KeepsOriginalOrder(t *testing.T) {
+	xrp := [20]byte{}
+
+	var issA, issB [20]byte
+	issA[0] = 0x01
+	issB[0] = 0xFF
+
+	k1 := AMM(issA, xrp, issB, xrp)
+	k2 := AMM(issB, xrp, issA, xrp)
+	if k1.Key == k2.Key {
+		t.Fatalf("XRP/XRP tie with distinct issuers must NOT be normalized — "+
+			"rippled returns weak_ordering::equivalent and std::minmax keeps "+
+			"the original arg order, so the hashes differ; got\n  k1=%x\n  k2=%x",
+			k1.Key, k2.Key)
+	}
+}

--- a/keylet/keylet_test.go
+++ b/keylet/keylet_test.go
@@ -34,3 +34,66 @@ func TestBookDirKey(t *testing.T) {
 		t.Errorf("Book base mismatch\n  got:      %s\n  expected: %s", gotPrefix, expectedPrefix)
 	}
 }
+
+// AMM keylet sort key matches rippled's Issue::operator<=> — currency primary,
+// then account. A previous implementation sorted issuer-primary, which produced
+// the same keylet only when the asset pair was XRP+IOU (both sides tied on
+// XRP's all-zero issuer and fell through to currency comparison). For an
+// IOU+IOU pair where issuer-order and currency-order disagree, the two sorts
+// produce DIFFERENT keylets — this test pins the rippled-conformant behavior.
+func TestAMM_SortOrder_IOUPair_CurrencyPrimary(t *testing.T) {
+	// Currency A < Currency B
+	var curA, curB [20]byte
+	copy(curA[12:], []byte("AAA"))
+	copy(curB[12:], []byte("BBB"))
+
+	// Issuer X > Issuer Y. With the OLD (issuer-primary) sort, Y would have
+	// sorted first; with the rippled-conformant (currency-primary) sort, the
+	// pair with curA wins regardless of issuer order.
+	var issX, issY [20]byte
+	issX[0] = 0xFF
+	issY[0] = 0x01
+
+	// pair1: (issX, curA) + (issY, curB) — currency-primary picks (issX, curA) first.
+	pair1 := AMM(issX, curA, issY, curB)
+	// pair2: same pair, supplied in reverse order. Sort must be symmetric.
+	pair2 := AMM(issY, curB, issX, curA)
+	if pair1.Key != pair2.Key {
+		t.Fatalf("AMM keylet must be symmetric under argument order; got\n  pair1=%x\n  pair2=%x",
+			pair1.Key, pair2.Key)
+	}
+
+	// A different pair (issY first by issuer, but curA wins by currency) must
+	// still produce a keylet seeded with curA-side as "min" — i.e. swapping
+	// issuers does not change the sort outcome.
+	pair3 := AMM(issY, curA, issX, curB)
+	if pair1.Key == pair3.Key {
+		t.Fatalf("different issuer assignment must produce different AMM keylet")
+	}
+}
+
+// Regression guard: XRP must round-trip through the AMM keylet via the
+// all-zero currency. AMMCreate uses state.GetCurrencyBytes which returns
+// all-zero for XRP; if any caller encodes "XRP" as ASCII bytes 12-14, the
+// asset-pair lookup mis-keys and amm_info returns actNotFound.
+func TestAMM_XRPPair_UsesAllZeroCurrency(t *testing.T) {
+	var issuer [20]byte
+	copy(issuer[:], []byte{0x35, 0xdd, 0x7d, 0xf1, 0x46, 0x89, 0x34, 0x56, 0x29, 0x6b,
+		0xf4, 0x06, 0x1f, 0xbe, 0x68, 0x73, 0x5d, 0x28, 0xf3, 0x28})
+
+	var usdCurrency [20]byte
+	copy(usdCurrency[12:], []byte("USD"))
+
+	// The canonical XRP+USD AMM keylet uses all-zero XRP currency.
+	canonical := AMM([20]byte{}, [20]byte{}, issuer, usdCurrency)
+
+	// An ASCII-encoded "XRP" (the bug we're guarding against) would put
+	// 'X','R','P' into bytes 12-14 of the currency.
+	var brokenXRP [20]byte
+	brokenXRP[12], brokenXRP[13], brokenXRP[14] = 'X', 'R', 'P'
+	broken := AMM([20]byte{}, brokenXRP, issuer, usdCurrency)
+
+	if canonical.Key == broken.Key {
+		t.Fatalf("canonical XRP keylet must differ from ASCII-encoded XRP keylet")
+	}
+}


### PR DESCRIPTION
## Summary
- `keylet.AMM` previously sorted issuer-primary, then currency-secondary. Rippled's `Issue::operator<=>` (`rippled/include/xrpl/protocol/Issue.h:99-108`) sorts currency primary, then account, with an `isXRP(currency) → equivalent` shortcut on a currency tie. For an IOU+IOU pair where issuer-order and currency-order disagree, the old Go produced a different keylet from the one rippled would key — and from the one goXRPL's own `AMMCreate` writes (via `internal/tx/amm/keylet.go` → `state.GetCurrencyBytes`).
- `currencyToBytes` in the `amm_info` handler (and the same helper reused by `ledger_entry`) encoded `"XRP"` as ASCII into bytes 12-14 of the 20-byte currency. `AMMCreate` writes the AMM SLE under a keylet computed with `state.GetCurrencyBytes("XRP") == [20]byte{}` (all zero). Result: every XRP-paired AMM looked up by `asset` / `asset2` (in either `amm_info` *or* `ledger_entry`) returned `actNotFound`. The `amm_account` locator path was unaffected (it reads the AMM keylet from `sfAMMID` directly), which is likely why integration tests didn't catch it.

Both bugs were surfaced in the conformance review on PR #486; that PR is being closed because PR #495 already shipped the `amm_info` feature rewrite with a different shape. These two fixes are the orthogonal conformance work that #495 didn't pick up.

## Changes
- `keylet/keylet.go`: swap the AMM sort key to currency-primary, issuer-secondary, and mirror rippled's `isXRP(currency) → equivalent` shortcut on a currency tie. Sort moved into a small `issue1LessEqualIssue2` helper that reads like `Issue::operator<=>`. Hash input order per Issue remains `(account, currency, account, currency)` matching `std::minmax` feeding `indexHash` in `rippled/src/libxrpl/protocol/Indexes.cpp:446-456` `amm()`.
- `internal/rpc/handlers/amm_info.go` and `internal/rpc/handlers/ledger_entry.go`: drop the local `currencyToBytes` helper and route both handlers through `state.GetCurrencyBytes`, the canonical write-path encoder used by `AMMCreate`. This eliminates the duplicate implementation and structurally enforces lookup ⇔ write symmetry: a future regression would have to break `state.GetCurrencyBytes` itself, which is exercised on every AMM write.
- `internal/testing/amm/helpers.go`: drop the test-helper's private `currencyToBytes` and use `state.GetCurrencyBytes` for the same reason.
- Regression tests:
  - `keylet/keylet_test.go::TestAMM_SortOrder_IOUPair_CurrencyPrimary` — pins the currency-primary sort and asserts symmetry under argument order for IOU pairs.
  - `keylet/keylet_test.go::TestAMM_XRPPair_UsesAllZeroCurrency` — pins the canonical XRP-side keylet against the ASCII-XRP variant.
  - `keylet/keylet_test.go::TestAMM_SortOrder_XRPCurrencyTie_KeepsOriginalOrder` — pins the literal port of rippled's `isXRP → equivalent` shortcut: an XRP/XRP tie with distinct issuers must NOT be normalized by the keylet, because rippled's `std::minmax` on an equivalent pair keeps the original argument order.
  - `internal/ledger/state/directory_test.go::TestGetCurrencyBytes_XRP_AllZero` — pins the contract at the canonical encoder site, replacing the per-handler regression test that targeted the now-deleted helper.

## Why surgical fixes instead of a larger rewrite
PR #486 carried a broader `amm_info` rewrite (single ledger snapshot, apiVersion-gated combo ordering, `json.RawMessage`-friendly asset parsing, `lp_token` shape unification). #495 landed a different rewrite that covers the surface feature, so #486's rewrite would conflict. The issues in this PR are independent of the rewrite shape: they sit beneath whichever `amm_info` body is on `main`, and they break protocol conformance against rippled.

Tightening `state.GetCurrencyBytes` (and `AMMCreate`'s preflight) to reject malformed input the way rippled's `to_currency` does — i.e. matching the stricter version already in `keylet/keylet.go:283-313` `currencyToBytes` used by `keylet.Line` — is a deliberate follow-up. Doing it here would expand the blast radius into AMMCreate validation.

## Test plan
- [ ] CI: `just build`, `just vet`, `just lint` — all clean locally
- [ ] CI: `./keylet/...` tests — pass locally
- [ ] CI: `./internal/ledger/state/...` tests — pass locally
- [ ] CI: `./internal/rpc/handlers/...` tests — pass locally
- [ ] CI: `./internal/testing/amm/...` integration tests — pass locally
- [ ] Optional: hit `amm_info` against a running node with `{"asset":{"currency":"XRP"},"asset2":{"currency":"USD","issuer":"..."}}` and confirm the SLE is found (was returning `actNotFound` on `main`).
