### PR TITLE
test: wire internal/testing env into RPC handlers (jtx-style)

### DIFF
--- a/internal/testing/rpcenv/adapter.go
+++ b/internal/testing/rpcenv/adapter.go
@@ -2,12 +2,17 @@ package rpcenv
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	"github.com/LeJamon/goXRPLd/internal/testing"
 	"github.com/LeJamon/goXRPLd/keylet"
@@ -36,12 +41,13 @@ func (a *ledgerAdapter) resolveLedger(ledgerIndex string) (*ledger.Ledger, bool,
 	open := a.env.Ledger()
 	closed := a.env.LastClosedLedger()
 
+	validated := a.haveValidated()
 	switch ledgerIndex {
 	case "", "validated", "closed":
 		if closed == nil {
 			return nil, false, fmt.Errorf("rpcenv: no closed ledger available — call env.Close() before querying %q", ledgerIndex)
 		}
-		return closed, true, nil
+		return closed, validated, nil
 	case "current":
 		return open, false, nil
 	}
@@ -52,7 +58,7 @@ func (a *ledgerAdapter) resolveLedger(ledgerIndex string) (*ledger.Ledger, bool,
 	}
 	want := uint32(seq)
 	if closed != nil && closed.Sequence() == want {
-		return closed, true, nil
+		return closed, validated, nil
 	}
 	if open != nil && open.Sequence() == want {
 		return open, false, nil
@@ -68,6 +74,14 @@ func ledgerSeq(l *ledger.Ledger) uint32 {
 	return l.Sequence()
 }
 
+// haveValidated mirrors rippled's LedgerMaster::haveValidated() in
+// standalone mode: the genesis ledger does not count — a real close must
+// have advanced past it.
+func (a *ledgerAdapter) haveValidated() bool {
+	closed := a.env.LastClosedLedger()
+	return closed != nil && closed.Sequence() > genesis.GenesisLedgerSequence
+}
+
 func (a *ledgerAdapter) GetCurrentLedgerIndex() uint32 {
 	return a.env.LedgerSeq()
 }
@@ -77,6 +91,9 @@ func (a *ledgerAdapter) GetClosedLedgerIndex() uint32 {
 }
 
 func (a *ledgerAdapter) GetValidatedLedgerIndex() uint32 {
+	if !a.haveValidated() {
+		return 0
+	}
 	return ledgerSeq(a.env.LastClosedLedger())
 }
 
@@ -122,6 +139,8 @@ func (a *ledgerAdapter) GetServerInfo() types.LedgerServerInfo {
 	if closed != nil {
 		info.ClosedLedgerSeq = closed.Sequence()
 		info.ClosedLedgerHash = closed.Hash()
+	}
+	if a.haveValidated() {
 		info.HaveValidated = true
 		info.ValidatedLedgerSeq = closed.Sequence()
 		info.ValidatedLedgerHash = closed.Hash()
@@ -155,7 +174,7 @@ func (a *ledgerAdapter) GetLedgerEntry(ctx context.Context, entryKey [32]byte, l
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("rpcenv: ledger entry not found")
+		return nil, svcerr.ErrLedgerEntryNotFound
 	}
 	data, err := target.Read(k)
 	if err != nil {
@@ -212,9 +231,74 @@ func (a *ledgerAdapter) GetAutofillSequence(_ string, _ bool) (uint32, error) {
 	return 0, errNotImplemented
 }
 
-func (a *ledgerAdapter) GetAccountInfo(_ context.Context, _ string, _ string) (*types.AccountInfo, error) {
-	return nil, errNotImplemented
+// GetAccountInfo serves as the worked example for extending this adapter:
+// decode address → keylet.Account → Exists/Read → parse SLE → fill
+// types.AccountInfo with hex-formatted hashes and decimal-formatted balance.
+// Matches the conversion done by internal/rpc/ledger_adapter.go so
+// handlers see identical shapes whether they run against production or the
+// harness.
+func (a *ledgerAdapter) GetAccountInfo(ctx context.Context, account string, ledgerIndex string) (*types.AccountInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	target, validated, err := a.resolveLedger(ledgerIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, err)
+	}
+	var accountID [20]byte
+	copy(accountID[:], accountIDBytes)
+
+	accountKey := keylet.Account(accountID)
+	exists, err := target.Exists(accountKey)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, svcerr.ErrAccountNotFound
+	}
+	data, err := target.Read(accountKey)
+	if err != nil {
+		return nil, err
+	}
+	root, err := state.ParseAccountRootFromBytes(data)
+	if err != nil {
+		return nil, fmt.Errorf("rpcenv: parse AccountRoot: %w", err)
+	}
+
+	var prevTxnID string
+	if root.PreviousTxnID != ([32]byte{}) {
+		prevTxnID = fmt.Sprintf("%X", root.PreviousTxnID)
+	}
+	return &types.AccountInfo{
+		Account:           account,
+		Balance:           strconv.FormatUint(root.Balance, 10),
+		Flags:             root.Flags,
+		OwnerCount:        root.OwnerCount,
+		Sequence:          root.Sequence,
+		RegularKey:        root.RegularKey,
+		Domain:            root.Domain,
+		EmailHash:         root.EmailHash,
+		TransferRate:      root.TransferRate,
+		TickSize:          root.TickSize,
+		PreviousTxnID:     prevTxnID,
+		PreviousTxnLgrSeq: root.PreviousTxnLgrSeq,
+		LedgerIndex:       target.Sequence(),
+		LedgerHash:        fmt.Sprintf("%X", target.Hash()),
+		Validated:         validated,
+		RawData:           data,
+		Index:             hex.EncodeToString(accountKey.Key[:]),
+	}, nil
 }
+
+// Methods below return errNotImplemented. To wire one up, follow the
+// GetAccountInfo pattern above: derive the keylet, read the SLE, parse
+// it, and convert to the result type. internal/rpc/ledger_adapter.go has
+// the canonical service→types conversions for reference.
 
 func (a *ledgerAdapter) GetAccountLines(_ context.Context, _ string, _ string, _ string, _ uint32) (*types.AccountLinesResult, error) {
 	return nil, errNotImplemented
@@ -276,8 +360,15 @@ func (r *ledgerReaderAdapter) Sequence() uint32     { return r.l.Sequence() }
 func (r *ledgerReaderAdapter) Hash() [32]byte       { return r.l.Hash() }
 func (r *ledgerReaderAdapter) ParentHash() [32]byte { return r.l.ParentHash() }
 func (r *ledgerReaderAdapter) IsClosed() bool       { return r.l.IsClosed() }
-func (r *ledgerReaderAdapter) IsValidated() bool    { return r.l.IsClosed() }
-func (r *ledgerReaderAdapter) TotalDrops() uint64   { return r.l.TotalDrops() }
+
+// IsValidated treats any post-genesis closed ledger as validated. In
+// standalone there is no separate validation step; the genesis ledger
+// itself is excluded so callers can still distinguish "just spun up" from
+// "advanced at least one ledger".
+func (r *ledgerReaderAdapter) IsValidated() bool {
+	return r.l.IsClosed() && r.l.Sequence() > genesis.GenesisLedgerSequence
+}
+func (r *ledgerReaderAdapter) TotalDrops() uint64 { return r.l.TotalDrops() }
 
 func (r *ledgerReaderAdapter) CloseTime() int64 {
 	t := r.l.CloseTime()

--- a/internal/testing/rpcenv/adapter.go
+++ b/internal/testing/rpcenv/adapter.go
@@ -13,15 +13,10 @@ import (
 	"github.com/LeJamon/goXRPLd/keylet"
 )
 
-// errNotImplemented is returned by adapter methods that the canary harness
-// does not yet wire up. Integration tests that need the missing method
-// should extend the adapter rather than mock it.
 var errNotImplemented = errors.New("rpcenv: LedgerService method not implemented — extend the adapter when adding a consumer test")
 
-// ledgerAdapter is a types.LedgerService backed by a live testing.TestEnv.
-//
-// The goal mirrors rippled's jtx::Env: tests reach the same handlers that
-// production hits, against a real ledger that just had transactions
+// ledgerAdapter mirrors rippled's jtx::Env: tests reach the same handlers
+// that production hits, against a real ledger that just had transactions
 // applied. Methods not yet exercised by a consumer test return
 // errNotImplemented so the gap is obvious.
 type ledgerAdapter struct {
@@ -34,9 +29,9 @@ func newLedgerAdapter(env *testing.TestEnv) *ledgerAdapter {
 	return &ledgerAdapter{env: env}
 }
 
-// resolveLedger picks the *ledger.Ledger that matches the ledgerIndex
-// specifier ("validated"/"closed"/"current"/numeric). In standalone test
-// mode the most recent closed ledger plays the role of the validated one.
+// resolveLedger maps a ledgerIndex specifier to a ledger. In standalone
+// test mode the most recent closed ledger plays the role of the validated
+// one.
 func (a *ledgerAdapter) resolveLedger(ledgerIndex string) (*ledger.Ledger, bool, error) {
 	open := a.env.Ledger()
 	closed := a.env.LastClosedLedger()
@@ -73,8 +68,6 @@ func ledgerSeq(l *ledger.Ledger) uint32 {
 	return l.Sequence()
 }
 
-// --- LedgerNavigator ------------------------------------------------------
-
 func (a *ledgerAdapter) GetCurrentLedgerIndex() uint32 {
 	return a.env.LedgerSeq()
 }
@@ -97,8 +90,6 @@ func (a *ledgerAdapter) AcceptLedgerAt(ctx context.Context, _ time.Time) (uint32
 }
 
 func (a *ledgerAdapter) IsStandalone() bool { return true }
-
-// --- LedgerAccessor -------------------------------------------------------
 
 func (a *ledgerAdapter) GetLedgerBySequence(seq uint32) (types.LedgerReader, error) {
 	closed := a.env.LastClosedLedger()
@@ -193,8 +184,6 @@ func (a *ledgerAdapter) GetClosedLedgerView() (types.LedgerStateView, error) {
 
 func (a *ledgerAdapter) IsAmendmentBlocked() bool { return false }
 
-// --- TransactionSubmitter -------------------------------------------------
-
 func (a *ledgerAdapter) SubmitTransaction(_ []byte, _ ...string) (*types.SubmitResult, error) {
 	return nil, errNotImplemented
 }
@@ -222,8 +211,6 @@ func (a *ledgerAdapter) GetAutofillFee(_ []byte) (uint64, error) {
 func (a *ledgerAdapter) GetAutofillSequence(_ string, _ bool) (uint32, error) {
 	return 0, errNotImplemented
 }
-
-// --- AccountQuerier -------------------------------------------------------
 
 func (a *ledgerAdapter) GetAccountInfo(_ context.Context, _ string, _ string) (*types.AccountInfo, error) {
 	return nil, errNotImplemented
@@ -257,8 +244,6 @@ func (a *ledgerAdapter) GetAccountNFTs(_ context.Context, _ string, _ string, _ 
 	return nil, errNotImplemented
 }
 
-// --- Remaining LedgerService surface --------------------------------------
-
 func (a *ledgerAdapter) GetBookOffers(_ context.Context, _, _ types.Amount, _ string, _ string, _ string, _ uint32) (*types.BookOffersResult, error) {
 	return nil, errNotImplemented
 }
@@ -283,18 +268,16 @@ func (a *ledgerAdapter) GetNFTSellOffers(_ context.Context, _ [32]byte, _ string
 	return nil, errNotImplemented
 }
 
-// --- LedgerReader adapter -------------------------------------------------
-
 type ledgerReaderAdapter struct {
 	l *ledger.Ledger
 }
 
-func (r *ledgerReaderAdapter) Sequence() uint32   { return r.l.Sequence() }
-func (r *ledgerReaderAdapter) Hash() [32]byte     { return r.l.Hash() }
+func (r *ledgerReaderAdapter) Sequence() uint32     { return r.l.Sequence() }
+func (r *ledgerReaderAdapter) Hash() [32]byte       { return r.l.Hash() }
 func (r *ledgerReaderAdapter) ParentHash() [32]byte { return r.l.ParentHash() }
-func (r *ledgerReaderAdapter) IsClosed() bool     { return r.l.IsClosed() }
-func (r *ledgerReaderAdapter) IsValidated() bool  { return r.l.IsClosed() }
-func (r *ledgerReaderAdapter) TotalDrops() uint64 { return r.l.TotalDrops() }
+func (r *ledgerReaderAdapter) IsClosed() bool       { return r.l.IsClosed() }
+func (r *ledgerReaderAdapter) IsValidated() bool    { return r.l.IsClosed() }
+func (r *ledgerReaderAdapter) TotalDrops() uint64   { return r.l.TotalDrops() }
 
 func (r *ledgerReaderAdapter) CloseTime() int64 {
 	t := r.l.CloseTime()

--- a/internal/testing/rpcenv/adapter.go
+++ b/internal/testing/rpcenv/adapter.go
@@ -1,0 +1,330 @@
+package rpcenv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/keylet"
+)
+
+// errNotImplemented is returned by adapter methods that the canary harness
+// does not yet wire up. Integration tests that need the missing method
+// should extend the adapter rather than mock it.
+var errNotImplemented = errors.New("rpcenv: LedgerService method not implemented — extend the adapter when adding a consumer test")
+
+// ledgerAdapter is a types.LedgerService backed by a live testing.TestEnv.
+//
+// The goal mirrors rippled's jtx::Env: tests reach the same handlers that
+// production hits, against a real ledger that just had transactions
+// applied. Methods not yet exercised by a consumer test return
+// errNotImplemented so the gap is obvious.
+type ledgerAdapter struct {
+	env *testing.TestEnv
+}
+
+var _ types.LedgerService = (*ledgerAdapter)(nil)
+
+func newLedgerAdapter(env *testing.TestEnv) *ledgerAdapter {
+	return &ledgerAdapter{env: env}
+}
+
+// resolveLedger picks the *ledger.Ledger that matches the ledgerIndex
+// specifier ("validated"/"closed"/"current"/numeric). In standalone test
+// mode the most recent closed ledger plays the role of the validated one.
+func (a *ledgerAdapter) resolveLedger(ledgerIndex string) (*ledger.Ledger, bool, error) {
+	open := a.env.Ledger()
+	closed := a.env.LastClosedLedger()
+
+	switch ledgerIndex {
+	case "", "validated", "closed":
+		if closed == nil {
+			return nil, false, fmt.Errorf("rpcenv: no closed ledger available — call env.Close() before querying %q", ledgerIndex)
+		}
+		return closed, true, nil
+	case "current":
+		return open, false, nil
+	}
+
+	seq, err := strconv.ParseUint(ledgerIndex, 10, 32)
+	if err != nil {
+		return nil, false, fmt.Errorf("rpcenv: unsupported ledger_index %q", ledgerIndex)
+	}
+	want := uint32(seq)
+	if closed != nil && closed.Sequence() == want {
+		return closed, true, nil
+	}
+	if open != nil && open.Sequence() == want {
+		return open, false, nil
+	}
+	return nil, false, fmt.Errorf("rpcenv: ledger %d not available (open=%d closed=%d)", want,
+		ledgerSeq(open), ledgerSeq(closed))
+}
+
+func ledgerSeq(l *ledger.Ledger) uint32 {
+	if l == nil {
+		return 0
+	}
+	return l.Sequence()
+}
+
+// --- LedgerNavigator ------------------------------------------------------
+
+func (a *ledgerAdapter) GetCurrentLedgerIndex() uint32 {
+	return a.env.LedgerSeq()
+}
+
+func (a *ledgerAdapter) GetClosedLedgerIndex() uint32 {
+	return ledgerSeq(a.env.LastClosedLedger())
+}
+
+func (a *ledgerAdapter) GetValidatedLedgerIndex() uint32 {
+	return ledgerSeq(a.env.LastClosedLedger())
+}
+
+func (a *ledgerAdapter) AcceptLedger(ctx context.Context) (uint32, error) {
+	a.env.Close()
+	return a.GetClosedLedgerIndex(), nil
+}
+
+func (a *ledgerAdapter) AcceptLedgerAt(ctx context.Context, _ time.Time) (uint32, error) {
+	return a.AcceptLedger(ctx)
+}
+
+func (a *ledgerAdapter) IsStandalone() bool { return true }
+
+// --- LedgerAccessor -------------------------------------------------------
+
+func (a *ledgerAdapter) GetLedgerBySequence(seq uint32) (types.LedgerReader, error) {
+	closed := a.env.LastClosedLedger()
+	if closed != nil && closed.Sequence() == seq {
+		return &ledgerReaderAdapter{l: closed}, nil
+	}
+	if open := a.env.Ledger(); open != nil && open.Sequence() == seq {
+		return &ledgerReaderAdapter{l: open}, nil
+	}
+	return nil, fmt.Errorf("rpcenv: ledger %d not available", seq)
+}
+
+func (a *ledgerAdapter) GetLedgerByHash(hash [32]byte) (types.LedgerReader, error) {
+	if closed := a.env.LastClosedLedger(); closed != nil && closed.Hash() == hash {
+		return &ledgerReaderAdapter{l: closed}, nil
+	}
+	if open := a.env.Ledger(); open != nil && open.Hash() == hash {
+		return &ledgerReaderAdapter{l: open}, nil
+	}
+	return nil, fmt.Errorf("rpcenv: ledger %x not available", hash)
+}
+
+func (a *ledgerAdapter) GetServerInfo() types.LedgerServerInfo {
+	closed := a.env.LastClosedLedger()
+	info := types.LedgerServerInfo{
+		Standalone:    true,
+		ServerState:   "full",
+		OpenLedgerSeq: a.env.LedgerSeq(),
+	}
+	if closed != nil {
+		info.ClosedLedgerSeq = closed.Sequence()
+		info.ClosedLedgerHash = closed.Hash()
+		info.HaveValidated = true
+		info.ValidatedLedgerSeq = closed.Sequence()
+		info.ValidatedLedgerHash = closed.Hash()
+	}
+	return info
+}
+
+func (a *ledgerAdapter) GetGenesisAccount() (string, error) {
+	return a.env.MasterAccount().Address, nil
+}
+
+func (a *ledgerAdapter) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint64) {
+	return a.env.BaseFee(), a.env.ReserveBase(), a.env.ReserveIncrement()
+}
+
+func (a *ledgerAdapter) GetLedgerRange(_ context.Context, _, _ uint32) (*types.LedgerRangeResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetLedgerEntry(ctx context.Context, entryKey [32]byte, ledgerIndex string) (*types.LedgerEntryResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	target, validated, err := a.resolveLedger(ledgerIndex)
+	if err != nil {
+		return nil, err
+	}
+	k := keylet.Keylet{Key: entryKey}
+	exists, err := target.Exists(k)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("rpcenv: ledger entry not found")
+	}
+	data, err := target.Read(k)
+	if err != nil {
+		return nil, err
+	}
+	return &types.LedgerEntryResult{
+		Index:       fmt.Sprintf("%X", entryKey),
+		LedgerIndex: target.Sequence(),
+		LedgerHash:  target.Hash(),
+		Node:        data,
+		Validated:   validated,
+	}, nil
+}
+
+func (a *ledgerAdapter) GetLedgerData(_ context.Context, _ string, _ uint32, _ string) (*types.LedgerDataResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetClosedLedgerView() (types.LedgerStateView, error) {
+	closed := a.env.LastClosedLedger()
+	if closed == nil {
+		return nil, fmt.Errorf("rpcenv: no closed ledger — call env.Close() first")
+	}
+	return closed, nil
+}
+
+func (a *ledgerAdapter) IsAmendmentBlocked() bool { return false }
+
+// --- TransactionSubmitter -------------------------------------------------
+
+func (a *ledgerAdapter) SubmitTransaction(_ []byte, _ ...string) (*types.SubmitResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) SimulateTransaction(_ []byte) (*types.SubmitResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetTransaction(_ [32]byte) (*types.TransactionInfo, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) StoreTransaction(_ [32]byte, _ []byte) error {
+	return errNotImplemented
+}
+
+func (a *ledgerAdapter) GetTransactionHistory(_ context.Context, _ uint32) (*types.TxHistoryResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetAutofillFee(_ []byte) (uint64, error) {
+	return 0, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetAutofillSequence(_ string, _ bool) (uint32, error) {
+	return 0, errNotImplemented
+}
+
+// --- AccountQuerier -------------------------------------------------------
+
+func (a *ledgerAdapter) GetAccountInfo(_ context.Context, _ string, _ string) (*types.AccountInfo, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetAccountLines(_ context.Context, _ string, _ string, _ string, _ uint32) (*types.AccountLinesResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetAccountOffers(_ context.Context, _ string, _ string, _ uint32) (*types.AccountOffersResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetAccountTransactions(_ context.Context, _ string, _, _ int64, _ uint32, _ *types.AccountTxMarker, _ bool) (*types.AccountTxResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetAccountChannels(_ context.Context, _ string, _ string, _ string, _ uint32) (*types.AccountChannelsResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetAccountCurrencies(_ context.Context, _ string, _ string) (*types.AccountCurrenciesResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetAccountObjects(_ context.Context, _ string, _ string, _ string, _ uint32) (*types.AccountObjectsResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetAccountNFTs(_ context.Context, _ string, _ string, _ uint32) (*types.AccountNFTsResult, error) {
+	return nil, errNotImplemented
+}
+
+// --- Remaining LedgerService surface --------------------------------------
+
+func (a *ledgerAdapter) GetBookOffers(_ context.Context, _, _ types.Amount, _ string, _ string, _ string, _ uint32) (*types.BookOffersResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetGatewayBalances(_ context.Context, _ string, _ []string, _ string) (*types.GatewayBalancesResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetNoRippleCheck(_ context.Context, _ string, _ string, _ string, _ uint32, _ bool) (*types.NoRippleCheckResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetDepositAuthorized(_ context.Context, _ string, _ string, _ string, _ []string) (*types.DepositAuthorizedResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetNFTBuyOffers(_ context.Context, _ [32]byte, _ string, _ uint32, _ string) (*types.NFTOffersResult, error) {
+	return nil, errNotImplemented
+}
+
+func (a *ledgerAdapter) GetNFTSellOffers(_ context.Context, _ [32]byte, _ string, _ uint32, _ string) (*types.NFTOffersResult, error) {
+	return nil, errNotImplemented
+}
+
+// --- LedgerReader adapter -------------------------------------------------
+
+type ledgerReaderAdapter struct {
+	l *ledger.Ledger
+}
+
+func (r *ledgerReaderAdapter) Sequence() uint32   { return r.l.Sequence() }
+func (r *ledgerReaderAdapter) Hash() [32]byte     { return r.l.Hash() }
+func (r *ledgerReaderAdapter) ParentHash() [32]byte { return r.l.ParentHash() }
+func (r *ledgerReaderAdapter) IsClosed() bool     { return r.l.IsClosed() }
+func (r *ledgerReaderAdapter) IsValidated() bool  { return r.l.IsClosed() }
+func (r *ledgerReaderAdapter) TotalDrops() uint64 { return r.l.TotalDrops() }
+
+func (r *ledgerReaderAdapter) CloseTime() int64 {
+	t := r.l.CloseTime()
+	if t.IsZero() {
+		return 0
+	}
+	return rippleEpochSeconds(t)
+}
+
+func (r *ledgerReaderAdapter) CloseTimeResolution() uint32 { return r.l.Header().CloseTimeResolution }
+func (r *ledgerReaderAdapter) CloseFlags() uint8           { return r.l.Header().CloseFlags }
+
+func (r *ledgerReaderAdapter) ParentCloseTime() int64 {
+	t := r.l.ParentCloseTime()
+	if t.IsZero() {
+		return 0
+	}
+	return rippleEpochSeconds(t)
+}
+
+func (r *ledgerReaderAdapter) TxMapHash() [32]byte {
+	h, _ := r.l.TxMapHash()
+	return h
+}
+
+func (r *ledgerReaderAdapter) StateMapHash() [32]byte {
+	h, _ := r.l.StateMapHash()
+	return h
+}
+
+func (r *ledgerReaderAdapter) ForEachTransaction(fn func(txHash [32]byte, txData []byte) bool) error {
+	return r.l.ForEachTransaction(fn)
+}

--- a/internal/testing/rpcenv/amm_info_test.go
+++ b/internal/testing/rpcenv/amm_info_test.go
@@ -1,0 +1,107 @@
+package rpcenv_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/testing/amm"
+	"github.com/LeJamon/goXRPLd/internal/testing/rpcenv"
+
+	jtx "github.com/LeJamon/goXRPLd/internal/testing"
+)
+
+// TestAMMInfo_EndToEnd_ByAssetPair is the canary integration test for the
+// rpcenv harness. It builds a real XRP/USD AMM through the tx engine, then
+// asks the production amm_info handler for it via the same dispatcher the
+// HTTP server uses.
+//
+// This is exactly the bug class issue #482 exposed: amm_info passed its
+// mock-backed unit tests while shipping the wrong field shape against real
+// ledger state. With this test in place, future regressions in the
+// success path are caught in CI.
+func TestAMMInfo_EndToEnd_ByAssetPair(t *testing.T) {
+	amm.TestAMM(t, nil, 500, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
+		env := rpcenv.Wrap(t, ammEnv.TestEnv)
+
+		result, rpcErr := env.RPC("amm_info", map[string]any{
+			"asset":  map[string]any{"currency": "XRP"},
+			"asset2": map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address},
+		})
+		if rpcErr != nil {
+			t.Fatalf("amm_info: %s (code=%d)", rpcErr.Message, rpcErr.Code)
+		}
+
+		resp, ok := result.(map[string]interface{})
+		if !ok {
+			t.Fatalf("amm_info: response is %T, want map", result)
+		}
+
+		ammResult, ok := resp["amm"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("amm_info: missing or wrong-typed `amm` field: %#v", resp["amm"])
+		}
+
+		if got, ok := ammResult["account"].(string); !ok || got != ammAcc.Address {
+			t.Fatalf("amm.account = %v (%T), want %s", ammResult["account"], ammResult["account"], ammAcc.Address)
+		}
+		if got, ok := ammResult["trading_fee"]; !ok {
+			t.Errorf("amm.trading_fee missing: %#v", got)
+		}
+		if _, ok := ammResult["lp_token"]; !ok {
+			t.Errorf("amm.lp_token missing")
+		}
+		if _, ok := ammResult["amount"]; !ok {
+			t.Errorf("amm.amount missing")
+		}
+		if _, ok := ammResult["amount2"]; !ok {
+			t.Errorf("amm.amount2 missing")
+		}
+
+		if _, ok := resp["ledger_index"]; !ok {
+			t.Errorf("response.ledger_index missing")
+		}
+		if validated, _ := resp["validated"].(bool); !validated {
+			t.Errorf("response.validated = false, want true (closed ledger should be reported as validated in standalone)")
+		}
+	})
+}
+
+// TestAMMInfo_EndToEnd_ByAccount verifies the second discovery path —
+// look up the AMM by its pseudo-account, exercising the AMMID indirection
+// in the AccountRoot SLE that bug #482 also touched.
+func TestAMMInfo_EndToEnd_ByAccount(t *testing.T) {
+	amm.TestAMM(t, nil, 250, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
+		env := rpcenv.Wrap(t, ammEnv.TestEnv)
+
+		result, rpcErr := env.RPC("amm_info", map[string]any{
+			"amm_account": ammAcc.Address,
+		})
+		if rpcErr != nil {
+			t.Fatalf("amm_info: %s (code=%d)", rpcErr.Message, rpcErr.Code)
+		}
+
+		resp := result.(map[string]interface{})
+		ammResult := resp["amm"].(map[string]interface{})
+		if got := ammResult["account"]; got != ammAcc.Address {
+			t.Fatalf("amm.account = %v, want %s", got, ammAcc.Address)
+		}
+	})
+}
+
+// TestAMMInfo_EndToEnd_NotFound checks that querying a non-existent asset
+// pair surfaces actNotFound instead of crashing — confirming that the
+// adapter's error mapping behaves like rippled.
+func TestAMMInfo_EndToEnd_NotFound(t *testing.T) {
+	env := rpcenv.New(t)
+	gw := jtx.NewAccount("gw")
+	env.FundAmount(gw, uint64(jtx.XRP(1000)))
+	env.Close()
+
+	_, rpcErr := env.RPC("amm_info", map[string]any{
+		"asset":  map[string]any{"currency": "XRP"},
+		"asset2": map[string]any{"currency": "USD", "issuer": gw.Address},
+	})
+	if rpcErr == nil {
+		t.Fatalf("amm_info on missing pair: expected error, got nil")
+	}
+}
+

--- a/internal/testing/rpcenv/amm_info_test.go
+++ b/internal/testing/rpcenv/amm_info_test.go
@@ -69,8 +69,14 @@ func TestAMMInfo_EndToEnd_ByAccount(t *testing.T) {
 			t.Fatalf("amm_info: %s (code=%d)", rpcErr.Message, rpcErr.Code)
 		}
 
-		resp := result.(map[string]interface{})
-		ammResult := resp["amm"].(map[string]interface{})
+		resp, ok := result.(map[string]interface{})
+		if !ok {
+			t.Fatalf("amm_info: response is %T, want map", result)
+		}
+		ammResult, ok := resp["amm"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("amm_info: missing or wrong-typed `amm` field: %#v", resp["amm"])
+		}
 		if got := ammResult["account"]; got != ammAcc.Address {
 			t.Fatalf("amm.account = %v, want %s", got, ammAcc.Address)
 		}

--- a/internal/testing/rpcenv/amm_info_test.go
+++ b/internal/testing/rpcenv/amm_info_test.go
@@ -9,15 +9,6 @@ import (
 	jtx "github.com/LeJamon/goXRPLd/internal/testing"
 )
 
-// TestAMMInfo_EndToEnd_ByAssetPair is the canary integration test for the
-// rpcenv harness. It builds a real XRP/USD AMM through the tx engine, then
-// asks the production amm_info handler for it via the same dispatcher the
-// HTTP server uses.
-//
-// This is exactly the bug class issue #482 exposed: amm_info passed its
-// mock-backed unit tests while shipping the wrong field shape against real
-// ledger state. With this test in place, future regressions in the
-// success path are caught in CI.
 func TestAMMInfo_EndToEnd_ByAssetPair(t *testing.T) {
 	amm.TestAMM(t, nil, 500, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
 		env := rpcenv.Wrap(t, ammEnv.TestEnv)
@@ -65,9 +56,8 @@ func TestAMMInfo_EndToEnd_ByAssetPair(t *testing.T) {
 	})
 }
 
-// TestAMMInfo_EndToEnd_ByAccount verifies the second discovery path —
-// look up the AMM by its pseudo-account, exercising the AMMID indirection
-// in the AccountRoot SLE that bug #482 also touched.
+// TestAMMInfo_EndToEnd_ByAccount exercises lookup by AMM pseudo-account,
+// which goes through the AMMID indirection in AccountRoot.
 func TestAMMInfo_EndToEnd_ByAccount(t *testing.T) {
 	amm.TestAMM(t, nil, 250, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
 		env := rpcenv.Wrap(t, ammEnv.TestEnv)
@@ -87,9 +77,6 @@ func TestAMMInfo_EndToEnd_ByAccount(t *testing.T) {
 	})
 }
 
-// TestAMMInfo_EndToEnd_NotFound checks that querying a non-existent asset
-// pair surfaces actNotFound instead of crashing — confirming that the
-// adapter's error mapping behaves like rippled.
 func TestAMMInfo_EndToEnd_NotFound(t *testing.T) {
 	env := rpcenv.New(t)
 	gw := jtx.NewAccount("gw")
@@ -104,4 +91,3 @@ func TestAMMInfo_EndToEnd_NotFound(t *testing.T) {
 		t.Fatalf("amm_info on missing pair: expected error, got nil")
 	}
 }
-

--- a/internal/testing/rpcenv/rpcenv.go
+++ b/internal/testing/rpcenv/rpcenv.go
@@ -1,0 +1,115 @@
+// Package rpcenv wires the in-memory test ledger built by internal/testing
+// into the same RPC handler registry used by the production server, so
+// handlers can be exercised end-to-end against real ledger state.
+//
+// This mirrors rippled's jtx::Env, which gives tx-engine tests and RPC
+// tests one shared in-process Application. The handler registry is the
+// same one HTTP/WebSocket dispatch use (handlers.RegisterAll), so
+// integration tests catch the class of bug #482 hit — where a handler
+// passes its unit tests but reads ledger state in the wrong shape — by
+// asserting the response produced against a freshly-built ledger.
+package rpcenv
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	xrpltesting "github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/protocol"
+)
+
+// Env is a test harness that pairs a live testing.TestEnv with a
+// ServiceContainer wired to handle real RPC calls. Embedding TestEnv keeps
+// every fund/submit/close/query helper available; the additional RPC method
+// dispatches through the production handler registry.
+type Env struct {
+	*xrpltesting.TestEnv
+
+	t        testing.TB
+	services *types.ServiceContainer
+	registry *types.MethodRegistry
+}
+
+// New constructs an Env on top of a fresh TestEnv.
+func New(t testing.TB) *Env {
+	t.Helper()
+	return Wrap(t, xrpltesting.NewTestEnv(t))
+}
+
+// Wrap turns an existing TestEnv into an Env. Useful when a fixture already
+// has a custom TestEnv (custom genesis, TxQ, etc.) and the test needs to
+// add RPC dispatch on top.
+func Wrap(t testing.TB, env *xrpltesting.TestEnv) *Env {
+	t.Helper()
+	registry := types.NewMethodRegistry()
+	handlers.RegisterAll(registry)
+	adapter := newLedgerAdapter(env)
+	return &Env{
+		TestEnv:  env,
+		t:        t,
+		services: types.NewServiceContainer(adapter),
+		registry: registry,
+	}
+}
+
+// Services returns the underlying container, mainly so callers can attach
+// additional facets (manifest cache, validator-list reader, ...) for tests
+// that exercise admin/manifest handlers.
+func (e *Env) Services() *types.ServiceContainer { return e.services }
+
+// RPC dispatches an RPC method through the production registry. params is
+// marshaled to JSON the same way the HTTP server hands it to the handler,
+// so callers can pass a struct, a map[string]any, or pre-built RawMessage.
+//
+// The default RpcContext uses the user role and the default API version —
+// enough for any non-admin method.
+func (e *Env) RPC(method string, params any) (any, *types.RpcError) {
+	return e.RPCAs(method, params, types.RoleUser, types.DefaultApiVersion)
+}
+
+// RPCAs is RPC with explicit role/version control for tests that need
+// admin or a specific API version.
+func (e *Env) RPCAs(method string, params any, role types.Role, apiVersion int) (any, *types.RpcError) {
+	e.t.Helper()
+
+	handler, ok := e.registry.Get(method)
+	if !ok {
+		return nil, types.RpcErrorMethodNotFound(method)
+	}
+
+	var raw json.RawMessage
+	switch v := params.(type) {
+	case nil:
+		raw = json.RawMessage("{}")
+	case json.RawMessage:
+		raw = v
+	case []byte:
+		raw = v
+	default:
+		b, err := json.Marshal(params)
+		if err != nil {
+			return nil, types.RpcErrorInvalidParams("rpcenv: marshal params: " + err.Error())
+		}
+		raw = b
+	}
+
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       role,
+		ApiVersion: apiVersion,
+		IsAdmin:    role == types.RoleAdmin,
+		Unlimited:  role.IsUnlimited(),
+		Services:   e.services,
+	}
+	return handler.Handle(ctx, raw)
+}
+
+// rippleEpochSeconds converts a time.Time to seconds since the XRPL epoch.
+// Kept private to the package — RPC handlers convert at their own boundary.
+func rippleEpochSeconds(t time.Time) int64 {
+	return t.Unix() - protocol.RippleEpochUnix
+}

--- a/internal/testing/rpcenv/rpcenv.go
+++ b/internal/testing/rpcenv/rpcenv.go
@@ -52,11 +52,13 @@ func Wrap(t testing.TB, env *xrpltesting.TestEnv) *Env {
 // admin/manifest handlers.
 func (e *Env) Services() *types.ServiceContainer { return e.services }
 
-// RPC dispatches a method through the production registry under the user
-// role and default API version. params may be a struct, a map, or a
-// json.RawMessage — anything else is marshaled to JSON.
+// RPC dispatches a method through the production registry. Defaults to
+// admin role to match rippled jtx::Env's local-loopback rpcClient, which
+// authenticates via admin_user/admin_password (see rippled
+// RPCCall.cpp:1530). Use RPCAs to downgrade. params may be a struct, a
+// map, or a json.RawMessage — anything else is marshaled to JSON.
 func (e *Env) RPC(method string, params any) (any, *types.RpcError) {
-	return e.RPCAs(method, params, types.RoleUser, types.DefaultApiVersion)
+	return e.RPCAs(method, params, types.RoleAdmin, types.DefaultApiVersion)
 }
 
 // RPCAs is RPC with explicit role/version control.

--- a/internal/testing/rpcenv/rpcenv.go
+++ b/internal/testing/rpcenv/rpcenv.go
@@ -1,13 +1,7 @@
 // Package rpcenv wires the in-memory test ledger built by internal/testing
-// into the same RPC handler registry used by the production server, so
-// handlers can be exercised end-to-end against real ledger state.
-//
-// This mirrors rippled's jtx::Env, which gives tx-engine tests and RPC
-// tests one shared in-process Application. The handler registry is the
-// same one HTTP/WebSocket dispatch use (handlers.RegisterAll), so
-// integration tests catch the class of bug #482 hit — where a handler
-// passes its unit tests but reads ledger state in the wrong shape — by
-// asserting the response produced against a freshly-built ledger.
+// into the same RPC handler registry the production server uses, so
+// handlers can be exercised end-to-end against real ledger state. Mirrors
+// rippled's jtx::Env.
 package rpcenv
 
 import (
@@ -22,10 +16,9 @@ import (
 	"github.com/LeJamon/goXRPLd/protocol"
 )
 
-// Env is a test harness that pairs a live testing.TestEnv with a
-// ServiceContainer wired to handle real RPC calls. Embedding TestEnv keeps
-// every fund/submit/close/query helper available; the additional RPC method
-// dispatches through the production handler registry.
+// Env pairs a live testing.TestEnv with the production RPC handler
+// registry. Embedding TestEnv keeps every fund/submit/close/query helper
+// available alongside RPC dispatch.
 type Env struct {
 	*xrpltesting.TestEnv
 
@@ -34,15 +27,13 @@ type Env struct {
 	registry *types.MethodRegistry
 }
 
-// New constructs an Env on top of a fresh TestEnv.
 func New(t testing.TB) *Env {
 	t.Helper()
 	return Wrap(t, xrpltesting.NewTestEnv(t))
 }
 
-// Wrap turns an existing TestEnv into an Env. Useful when a fixture already
-// has a custom TestEnv (custom genesis, TxQ, etc.) and the test needs to
-// add RPC dispatch on top.
+// Wrap layers RPC dispatch on top of an existing TestEnv — for fixtures
+// with custom genesis, TxQ, etc.
 func Wrap(t testing.TB, env *xrpltesting.TestEnv) *Env {
 	t.Helper()
 	registry := types.NewMethodRegistry()
@@ -56,23 +47,19 @@ func Wrap(t testing.TB, env *xrpltesting.TestEnv) *Env {
 	}
 }
 
-// Services returns the underlying container, mainly so callers can attach
-// additional facets (manifest cache, validator-list reader, ...) for tests
-// that exercise admin/manifest handlers.
+// Services exposes the container so callers can attach additional facets
+// (manifest cache, validator-list reader, ...) for tests that exercise
+// admin/manifest handlers.
 func (e *Env) Services() *types.ServiceContainer { return e.services }
 
-// RPC dispatches an RPC method through the production registry. params is
-// marshaled to JSON the same way the HTTP server hands it to the handler,
-// so callers can pass a struct, a map[string]any, or pre-built RawMessage.
-//
-// The default RpcContext uses the user role and the default API version —
-// enough for any non-admin method.
+// RPC dispatches a method through the production registry under the user
+// role and default API version. params may be a struct, a map, or a
+// json.RawMessage — anything else is marshaled to JSON.
 func (e *Env) RPC(method string, params any) (any, *types.RpcError) {
 	return e.RPCAs(method, params, types.RoleUser, types.DefaultApiVersion)
 }
 
-// RPCAs is RPC with explicit role/version control for tests that need
-// admin or a specific API version.
+// RPCAs is RPC with explicit role/version control.
 func (e *Env) RPCAs(method string, params any, role types.Role, apiVersion int) (any, *types.RpcError) {
 	e.t.Helper()
 
@@ -108,8 +95,6 @@ func (e *Env) RPCAs(method string, params any, role types.Role, apiVersion int) 
 	return handler.Handle(ctx, raw)
 }
 
-// rippleEpochSeconds converts a time.Time to seconds since the XRPL epoch.
-// Kept private to the package — RPC handlers convert at their own boundary.
 func rippleEpochSeconds(t time.Time) int64 {
 	return t.Unix() - protocol.RippleEpochUnix
 }


### PR DESCRIPTION
## Summary
- Adds `internal/testing/rpcenv`, a jtx::Env-style harness that pairs the in-memory `testing.TestEnv` with the production handler registry. Tests can `Fund`/`Submit`/`Close` and then call any RPC method end-to-end against the same ledger.
- Includes a `ledgerAdapter` implementing `types.LedgerService` on top of the env's live `*ledger.Ledger`. Methods exercised by today's canary tests are wired through; everything else returns `errNotImplemented` so the gap is loud and follow-up integration tests can extend it incrementally — no big-bang backfill.
- Ships one canary integration test for `amm_info` covering the asset-pair lookup, the `amm_account` (AMMID indirection) lookup, and the missing-pair error path. This is exactly the bug class #482 surfaced: the handler passed its mock-backed unit tests while shipping the wrong field shape against real ledger state.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/testing/rpcenv/...`
- [x] `go test ./internal/testing/rpcenv/... -count=1`
- [x] `go test ./internal/rpc/... -count=1` (no regression)
- [x] Pre-existing failures in `./internal/testing/mpt/...` confirmed on `origin/main` and unrelated to this change

Fixes #508