### PR TITLE
fix: SHAMap audit — O(1) path-copy snapshots + parallel walk APIs

### DIFF
--- a/shamap/inner_node.go
+++ b/shamap/inner_node.go
@@ -480,6 +480,24 @@ func (n *InnerNode) Clone() (Node, error) {
 	return clone, nil
 }
 
+// shallowClone returns a copy of n that shares every child pointer and
+// branch hash with the source but has its own header (mutex, hash, dirty
+// flag). It is the core primitive of the path-copy persistence used by
+// mutation paths: rewriting a single leaf rebuilds only the chain of
+// inner nodes from root down to that leaf, while every untouched subtree
+// stays structurally shared with whichever snapshot or sibling map still
+// references the source node.
+func (n *InnerNode) shallowClone() *InnerNode {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return &InnerNode{
+		BaseNode: BaseNode{hash: n.hash, dirty: true},
+		isBranch: n.isBranch,
+		hashes:   n.hashes,
+		children: n.children,
+	}
+}
+
 // ForEachChild calls fn for each non-nil child with its branch index
 // If fn returns false, iteration stops early
 func (n *InnerNode) ForEachChild(fn func(index int, child Node) bool) {

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -732,12 +732,17 @@ func (sm *SHAMap) dirtyUp(stack *NodeStack, target [32]byte, child Node) (Node, 
 			return nil, errors.New("expected InnerNode on stack")
 		}
 
+		// Path-copy persistence: rebuild a fresh inner node along the
+		// mutated path so any snapshot still referencing this subtree
+		// keeps its original view. Untouched siblings stay shared via
+		// the copied child pointers.
+		cloned := inner.shallowClone()
 		branch := SelectBranch(nodeID, target)
-		if err := inner.SetChild(int(branch), currentChild); err != nil {
+		if err := cloned.SetChild(int(branch), currentChild); err != nil {
 			return nil, fmt.Errorf("failed to set child: %w", err)
 		}
 
-		currentChild = inner
+		currentChild = cloned
 	}
 
 	return currentChild, nil
@@ -842,15 +847,9 @@ func (sm *SHAMap) consolidateAfterDelete(stack *NodeStack, key [32]byte) (Node, 
 			return nil, ErrInvalidType
 		}
 
-		clonedNode, err := inner.Clone()
-		if err != nil {
-			return nil, fmt.Errorf("failed to clone inner node: %w", err)
-		}
-
-		clonedInner, ok := clonedNode.(*InnerNode)
-		if !ok {
-			return nil, ErrInvalidType
-		}
+		// Path-copy: shallow-clone so untouched siblings stay shared
+		// with any snapshot that still references this subtree.
+		clonedInner := inner.shallowClone()
 
 		branch := SelectBranch(nodeID, key)
 		if err := clonedInner.SetChild(int(branch), prevNode); err != nil {
@@ -943,10 +942,27 @@ func (sm *SHAMap) onlyBelow(node Node) (*Item, error) {
 	return leaf.Item(), nil
 }
 
-// Snapshot creates a copy of the SHAMap
+// Snapshot returns a structurally-shared copy of the SHAMap in O(1).
+// The source and the returned map share the same root pointer; mutation
+// paths in either map are path-copy persistent (dirtyUp shallow-clones
+// each touched inner node), so the snapshot's tree is never observed
+// being mutated.
+//
+// For backed maps, dirty nodes still need to reach the store before the
+// snapshot is considered stable on disk. FlushDirty is called once here
+// so that a subsequent crash-recovery via NewFromRootHash returns the
+// same tree the snapshot observes in memory.
 func (sm *SHAMap) Snapshot(mutable bool) (*SHAMap, error) {
 	if sm.backed && sm.family != nil {
-		return sm.snapshotBacked(mutable)
+		batch, err := sm.FlushDirty(false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to flush dirty nodes: %w", err)
+		}
+		if len(batch.Entries) > 0 {
+			if err := sm.family.StoreBatch(context.Background(), batch.Entries); err != nil {
+				return nil, fmt.Errorf("failed to store flushed nodes: %w", err)
+			}
+		}
 	}
 
 	sm.mu.RLock()
@@ -961,21 +977,17 @@ func (sm *SHAMap) Snapshot(mutable bool) (*SHAMap, error) {
 		newState = StateModifying
 	}
 
-	// Unbacked map: deep clone (existing behavior)
-	newRoot, err := sm.cloneNodeTree(sm.root)
-	if err != nil {
-		return nil, fmt.Errorf("failed to clone tree: %w", err)
-	}
-
 	out := &SHAMap{
-		root:      newRoot,
+		root:      sm.root,
 		mapType:   sm.mapType,
 		state:     newState,
 		ledgerSeq: sm.ledgerSeq,
 		full:      sm.full,
+		backed:    sm.backed,
+		family:    sm.family,
 	}
 	out.cachedSize.Store(-1)
-	// Immutable→immutable snapshot owns the same leaf set; carry the
+	// Immutable→immutable snapshot observes the same leaf set; carry the
 	// cached count across so the snapshot is O(1) on first Size() too.
 	if !mutable && sm.state == StateImmutable {
 		if n := sm.cachedSize.Load(); n >= 0 {
@@ -983,52 +995,6 @@ func (sm *SHAMap) Snapshot(mutable bool) (*SHAMap, error) {
 		}
 	}
 	return out, nil
-}
-
-// snapshotBacked creates a snapshot of a backed map by flushing dirty nodes
-// and creating a new SHAMap from the root hash. O(dirty nodes) instead of O(tree).
-func (sm *SHAMap) snapshotBacked(mutable bool) (*SHAMap, error) {
-	// FlushDirty takes its own write lock
-	batch, err := sm.FlushDirty(false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to flush dirty nodes: %w", err)
-	}
-
-	if len(batch.Entries) > 0 {
-		if err := sm.family.StoreBatch(context.Background(), batch.Entries); err != nil {
-			return nil, fmt.Errorf("failed to store flushed nodes: %w", err)
-		}
-	}
-
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
-
-	if sm.state == StateInvalid {
-		return nil, errors.New("cannot snapshot invalid map")
-	}
-
-	newState := StateImmutable
-	if mutable {
-		newState = StateModifying
-	}
-
-	rootHash := sm.root.Hash()
-	newMap, err := NewFromRootHash(sm.mapType, rootHash, sm.family)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create backed snapshot: %w", err)
-	}
-	newMap.state = newState
-	newMap.ledgerSeq = sm.ledgerSeq
-
-	// Immutable→immutable snapshot owns the same leaf set; carry the
-	// cached count across so the snapshot is O(1) on first Size() too.
-	if !mutable && sm.state == StateImmutable {
-		if n := sm.cachedSize.Load(); n >= 0 {
-			newMap.cachedSize.Store(n)
-		}
-	}
-
-	return newMap, nil
 }
 
 // Size returns the number of leaf items in the SHAMap.
@@ -1287,61 +1253,6 @@ func (sm *SHAMap) flushNode(node Node, releaseChildren bool, batch *NodeBatch) e
 	}
 
 	return nil
-}
-
-// cloneNodeTree deep clones a node and all its children
-func (sm *SHAMap) cloneNodeTree(node Node) (*InnerNode, error) {
-	if node == nil {
-		return NewInnerNode(), nil
-	}
-
-	if !node.IsInner() {
-		return nil, errors.New("expected inner node")
-	}
-
-	inner, ok := node.(*InnerNode)
-	if !ok {
-		return nil, ErrInvalidType
-	}
-
-	clone, err := inner.Clone()
-	if err != nil {
-		return nil, fmt.Errorf("failed to clone inner node: %w", err)
-	}
-
-	clonedInner, ok := clone.(*InnerNode)
-	if !ok {
-		return nil, ErrInvalidType
-	}
-
-	// Clone all children recursively
-	for i := 0; i < BranchFactor; i++ {
-		child, err := sm.descend(inner, i)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get child %d: %w", i, err)
-		}
-
-		if child != nil {
-			var clonedChild Node
-			if child.IsInner() {
-				clonedChild, err = sm.cloneNodeTree(child)
-				if err != nil {
-					return nil, fmt.Errorf("failed to clone child tree %d: %w", i, err)
-				}
-			} else {
-				clonedChild, err = child.Clone()
-				if err != nil {
-					return nil, fmt.Errorf("failed to clone leaf %d: %w", i, err)
-				}
-			}
-
-			if err := clonedInner.SetChild(i, clonedChild); err != nil {
-				return nil, fmt.Errorf("failed to set cloned child %d: %w", i, err)
-			}
-		}
-	}
-
-	return clonedInner, nil
 }
 
 // Key is a type alias for a 32-byte key used in the SHAMap.

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -948,10 +948,14 @@ func (sm *SHAMap) onlyBelow(node Node) (*Item, error) {
 // each touched inner node), so the snapshot's tree is never observed
 // being mutated.
 //
-// For backed maps, dirty nodes still need to reach the store before the
-// snapshot is considered stable on disk. FlushDirty is called once here
-// so that a subsequent crash-recovery via NewFromRootHash returns the
-// same tree the snapshot observes in memory.
+// For backed maps, dirty nodes present at entry are flushed to the store
+// before the root is shared. FlushDirty and the subsequent RLock are
+// separate critical sections, so a writer racing between the two can
+// produce a snapshot whose root references dirty inner nodes that are
+// not yet in the store; those will be flushed on the next FlushDirty.
+// In other words, the on-disk image and the snapshot's in-memory image
+// are consistent at the snapshot's quiescent moments, not unconditionally
+// across concurrent writers.
 func (sm *SHAMap) Snapshot(mutable bool) (*SHAMap, error) {
 	if sm.backed && sm.family != nil {
 		batch, err := sm.FlushDirty(false)

--- a/shamap/shamap_test.go
+++ b/shamap/shamap_test.go
@@ -428,6 +428,113 @@ func TestSnapshot(t *testing.T) {
 	}
 }
 
+// TestSnapshot_StructuralSharing pins the path-copy invariant: a snapshot
+// followed by a single-key mutation must reuse every inner node that does
+// not sit on the mutated path. A future regression that deep-clones the
+// tree on Snapshot, or mutates shared inner nodes in place, would observe
+// either zero shared inner pointers (full deep clone) or a divergent
+// snapshot hash (in-place mutation through a shared node) and fail here.
+func TestSnapshot_StructuralSharing(t *testing.T) {
+	src, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("Failed to create SHAMap: %v", err)
+	}
+
+	// 256 keys whose first nibble fans out across all 16 root branches.
+	keys := make([][32]byte, 0, 256)
+	for i := 0; i < 256; i++ {
+		var k [32]byte
+		k[0] = byte(i)
+		k[31] = byte(i)
+		keys = append(keys, k)
+		if err := src.Put(k, intToBytes(i+1)); err != nil {
+			t.Fatalf("Put(%d): %v", i, err)
+		}
+	}
+
+	srcHashBefore, err := src.Hash()
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+
+	snap, err := src.Snapshot(false)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	// Mutate exactly one key in the source; the snapshot must not move.
+	target := keys[42]
+	if err := src.Put(target, intToBytes(0xff)); err != nil {
+		t.Fatalf("Put(target): %v", err)
+	}
+
+	snapHashAfter, err := snap.Hash()
+	if err != nil {
+		t.Fatalf("snap.Hash: %v", err)
+	}
+	if snapHashAfter != srcHashBefore {
+		t.Fatalf("snapshot hash drifted after source mutation: got %x want %x", snapHashAfter, srcHashBefore)
+	}
+
+	srcHashAfter, err := src.Hash()
+	if err != nil {
+		t.Fatalf("src.Hash after mutation: %v", err)
+	}
+	if srcHashAfter == srcHashBefore {
+		t.Fatal("source hash unchanged after mutation — mutation did not actually happen")
+	}
+
+	// Structural sharing: every root branch that does NOT lead to the
+	// mutated key must still point at the exact same child pointer in
+	// both maps. The single branch on the mutated path is allowed to
+	// diverge (and must, otherwise we mutated through a shared node).
+	mutatedBranch := getBranchAtDepth(target, 0)
+	shared, diverged := 0, 0
+	for i := 0; i < BranchFactor; i++ {
+		srcChild, _, srcSet := src.root.LoadChild(i)
+		snapChild, _, snapSet := snap.root.LoadChild(i)
+		if srcSet != snapSet {
+			t.Fatalf("branch %d set bit diverged: src=%v snap=%v", i, srcSet, snapSet)
+		}
+		if !srcSet {
+			continue
+		}
+		if i == mutatedBranch {
+			if srcChild == snapChild {
+				t.Fatalf("branch %d (mutated path) shares pointer: in-place mutation broke snapshot isolation", i)
+			}
+			diverged++
+			continue
+		}
+		if srcChild != snapChild {
+			t.Errorf("branch %d (untouched) does NOT share pointer: src=%p snap=%p — snapshot is deep-cloning instead of path-copying", i, srcChild, snapChild)
+		} else {
+			shared++
+		}
+	}
+	if shared == 0 {
+		t.Fatal("no branches shared between source and snapshot — Snapshot is doing a full deep clone")
+	}
+	if diverged != 1 {
+		t.Fatalf("expected exactly 1 diverged root branch on the mutated path, got %d", diverged)
+	}
+
+	// Sanity: snapshot still resolves every original key.
+	for i, k := range keys {
+		item, found, err := snap.Get(k)
+		if err != nil {
+			t.Fatalf("snap.Get(%d): %v", i, err)
+		}
+		if !found {
+			t.Fatalf("snap missing key %d after source mutation", i)
+		}
+		want := intToBytes(i + 1)
+		if !bytes.Equal(item.Data(), want) {
+			t.Fatalf("snap key %d: data drifted from original value", i)
+		}
+	}
+}
+
 // TestImmutability tests that an immutable map cannot be modified
 func TestImmutability(t *testing.T) {
 	key := hexToHash("092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7")

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -133,60 +133,35 @@ func NewSyncState() *SyncState {
 	}
 }
 
-// GetMissingNodes finds nodes that are referenced by the tree but not locally available.
-// This is used during synchronization to determine which nodes need to be fetched from peers.
-//
-// Parameters:
-//   - maxNodes: maximum number of missing nodes to return (0 = no limit)
-//   - filter: optional filter to control which nodes to fetch (nil uses default)
-//
-// Returns a slice of MissingNode structures describing nodes that need to be fetched.
-func (sm *SHAMap) GetMissingNodes(maxNodes int, filter SyncFilter) []MissingNode {
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
-
-	if sm.state != StateSyncing {
-		// If not in sync mode, we assume the map is complete
-		return nil
-	}
-
-	if filter == nil {
-		filter = &DefaultSyncFilter{}
-	}
-
-	var missing []MissingNode
-
-	// Use a work queue to traverse the tree looking for missing nodes
+// missingNodeWalker is the shared BFS-over-one-subtree primitive used by
+// WalkMap, WalkMapParallel and GetMissingNodes. It walks the in-memory
+// subtree rooted at `start` (no disk loads — anything not already loaded
+// is reported as missing) and invokes report for every non-empty branch
+// whose child pointer is nil. Returns true if report signalled stop.
+func walkSubtreeForMissing(
+	start *InnerNode,
+	startID NodeID,
+	startHash [32]byte,
+	startDepth int,
+	filter SyncFilter,
+	report func(MissingNode) bool,
+) bool {
 	type workItem struct {
-		node       Node
-		nodeHash   [32]byte
-		nodeID     NodeID
-		parentHash [32]byte
-		depth      int
-		branch     int
+		node     *InnerNode
+		nodeID   NodeID
+		nodeHash [32]byte
+		depth    int
 	}
 
 	queue := make([]workItem, 0, 64)
-
-	// Start from root
-	if sm.root != nil {
-		rootHash := sm.root.Hash()
-		queue = append(queue, workItem{
-			node:     sm.root,
-			nodeHash: rootHash,
-			nodeID:   NewRootNodeID(),
-			depth:    0,
-			branch:   -1,
-		})
-	}
+	queue = append(queue, workItem{
+		node:     start,
+		nodeID:   startID,
+		nodeHash: startHash,
+		depth:    startDepth,
+	})
 
 	for len(queue) > 0 {
-		// Check if we've found enough missing nodes
-		if maxNodes > 0 && len(missing) >= maxNodes {
-			break
-		}
-
-		// Pop from queue
 		item := queue[0]
 		queue = queue[1:]
 
@@ -194,24 +169,9 @@ func (sm *SHAMap) GetMissingNodes(maxNodes int, filter SyncFilter) []MissingNode
 			continue
 		}
 
-		if item.node.IsLeaf() {
-			// Leaf nodes are always considered complete
-			continue
-		}
-
-		// Inner node - check each branch
-		inner, ok := item.node.(*InnerNode)
-		if !ok {
-			continue
-		}
-
 		for branch := 0; branch < BranchFactor; branch++ {
-			if inner.IsEmptyBranch(branch) {
-				continue
-			}
-
-			childHash, err := inner.ChildHash(branch)
-			if err != nil {
+			child, childHash, isSet := item.node.LoadChild(branch)
+			if !isSet {
 				continue
 			}
 
@@ -220,42 +180,210 @@ func (sm *SHAMap) GetMissingNodes(maxNodes int, filter SyncFilter) []MissingNode
 				continue
 			}
 
-			// Check if child is missing (hash present but no child node)
-			child, err := inner.Child(branch)
-			if err != nil {
+			if child == nil {
+				// Branch is referenced by hash but the child node
+				// is not in memory — that's a missing node.
+				if !filter.ShouldFetch(childHash) {
+					continue
+				}
+				if report(MissingNode{
+					Hash:       childHash,
+					Depth:      item.depth + 1,
+					ParentHash: item.nodeHash,
+					Branch:     branch,
+					NodeID:     childNodeID,
+				}) {
+					return true
+				}
 				continue
 			}
 
-			if child == nil {
-				// Child is referenced by hash but not loaded - this is a missing node
-				if filter.ShouldFetch(childHash) {
-					missing = append(missing, MissingNode{
-						Hash:       childHash,
-						Depth:      item.depth + 1,
-						ParentHash: item.nodeHash,
-						Branch:     branch,
-						NodeID:     childNodeID,
-					})
-
-					if maxNodes > 0 && len(missing) >= maxNodes {
-						break
-					}
-				}
-			} else {
-				// Child exists - add to queue for further traversal
-				queue = append(queue, workItem{
-					node:       child,
-					nodeHash:   childHash,
-					nodeID:     childNodeID,
-					parentHash: item.nodeHash,
-					depth:      item.depth + 1,
-					branch:     branch,
-				})
+			if child.IsLeaf() {
+				continue
 			}
+			inner, ok := child.(*InnerNode)
+			if !ok {
+				continue
+			}
+			queue = append(queue, workItem{
+				node:     inner,
+				nodeID:   childNodeID,
+				nodeHash: childHash,
+				depth:    item.depth + 1,
+			})
 		}
 	}
+	return false
+}
+
+// WalkMap walks the in-memory SHAMap and returns every non-empty branch
+// whose child node is not loaded as a MissingNode entry. No disk reads
+// are issued; lazy-loaded branches that have not yet been materialised
+// surface as missing.
+//
+// Mirrors rippled's SHAMap::walkMap (SHAMapDelta.cpp:240). maxMissing == 0
+// is unbounded; otherwise the walk stops once that many entries have
+// been collected. A nil filter behaves like DefaultSyncFilter.
+func (sm *SHAMap) WalkMap(maxMissing int, filter SyncFilter) []MissingNode {
+	if filter == nil {
+		filter = &DefaultSyncFilter{}
+	}
+
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	if sm.root == nil || sm.state == StateInvalid {
+		return nil
+	}
+
+	var missing []MissingNode
+	walkSubtreeForMissing(
+		sm.root,
+		NewRootNodeID(),
+		sm.root.Hash(),
+		0,
+		filter,
+		func(m MissingNode) bool {
+			missing = append(missing, m)
+			return maxMissing > 0 && len(missing) >= maxMissing
+		},
+	)
+	return missing
+}
+
+// WalkMapParallel is the parallel variant of WalkMap. It fans out one
+// goroutine per non-empty root branch and lets each worker walk its
+// subtree independently; results share a single slice guarded by a
+// mutex, and an atomic stop flag short-circuits all workers once
+// maxMissing entries have been collected.
+//
+// Mirrors rippled's SHAMap::walkMapParallel (SHAMapDelta.cpp:282). On a
+// 16-way branched tree the speedup approaches a factor of 16 for cold
+// in-memory scans; for small trees the goroutine startup overhead is
+// negligible since at most 16 workers ever run.
+func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNode {
+	if filter == nil {
+		filter = &DefaultSyncFilter{}
+	}
+
+	type subtreeStart struct {
+		node     *InnerNode
+		nodeID   NodeID
+		nodeHash [32]byte
+		branch   int
+	}
+
+	sm.mu.RLock()
+	if sm.root == nil || sm.state == StateInvalid {
+		sm.mu.RUnlock()
+		return nil
+	}
+	rootID := NewRootNodeID()
+	rootHash := sm.root.Hash()
+
+	// Capture every non-empty root branch under the source-map lock.
+	// Hash-only branches at depth 1 are reported synchronously here
+	// because they have no subtree to walk.
+	var (
+		mu       sync.Mutex
+		missing  []MissingNode
+		stopped  bool
+		subtrees = make([]subtreeStart, 0, BranchFactor)
+	)
+
+	reportLocked := func(m MissingNode) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		if stopped {
+			return true
+		}
+		missing = append(missing, m)
+		if maxMissing > 0 && len(missing) >= maxMissing {
+			stopped = true
+			return true
+		}
+		return false
+	}
+
+	for branch := 0; branch < BranchFactor; branch++ {
+		child, childHash, isSet := sm.root.LoadChild(branch)
+		if !isSet {
+			continue
+		}
+		childNodeID, err := rootID.ChildNodeID(uint8(branch))
+		if err != nil {
+			continue
+		}
+		if child == nil {
+			if filter.ShouldFetch(childHash) {
+				if reportLocked(MissingNode{
+					Hash:       childHash,
+					Depth:      1,
+					ParentHash: rootHash,
+					Branch:     branch,
+					NodeID:     childNodeID,
+				}) {
+					break
+				}
+			}
+			continue
+		}
+		if child.IsLeaf() {
+			continue
+		}
+		inner, ok := child.(*InnerNode)
+		if !ok {
+			continue
+		}
+		subtrees = append(subtrees, subtreeStart{
+			node:     inner,
+			nodeID:   childNodeID,
+			nodeHash: childHash,
+			branch:   branch,
+		})
+	}
+	sm.mu.RUnlock()
+
+	if len(subtrees) == 0 {
+		return missing
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(subtrees))
+	for _, s := range subtrees {
+		s := s
+		go func() {
+			defer wg.Done()
+			walkSubtreeForMissing(
+				s.node,
+				s.nodeID,
+				s.nodeHash,
+				1,
+				filter,
+				reportLocked,
+			)
+		}()
+	}
+	wg.Wait()
 
 	return missing
+}
+
+// GetMissingNodes returns the nodes referenced by the tree but not
+// present locally. It is gated on StateSyncing — for any other state
+// the map is assumed complete and the result is nil.
+//
+// The actual walk is performed by WalkMapParallel so the per-root-branch
+// fan-out is shared with the lower-level WalkMap API. maxNodes == 0 is
+// unbounded; a nil filter behaves like DefaultSyncFilter.
+func (sm *SHAMap) GetMissingNodes(maxNodes int, filter SyncFilter) []MissingNode {
+	sm.mu.RLock()
+	state := sm.state
+	sm.mu.RUnlock()
+	if state != StateSyncing {
+		return nil
+	}
+	return sm.WalkMapParallel(maxNodes, filter)
 }
 
 // AddKnownNode adds a node received from an external source.

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -217,13 +217,23 @@ func walkSubtreeForMissing(
 }
 
 // WalkMap walks the in-memory SHAMap and returns every non-empty branch
-// whose child node is not loaded as a MissingNode entry. No disk reads
-// are issued; lazy-loaded branches that have not yet been materialised
-// surface as missing.
+// whose child node is not loaded as a MissingNode entry. Returns nil
+// when the root is empty or the map is in StateInvalid.
 //
-// Mirrors rippled's SHAMap::walkMap (SHAMapDelta.cpp:240). maxMissing == 0
-// is unbounded; otherwise the walk stops once that many entries have
-// been collected. A nil filter behaves like DefaultSyncFilter.
+// Divergence from rippled's SHAMap::walkMap (SHAMapDelta.cpp:240): the
+// rippled walker calls descendNoStore, which for a backed map fetches
+// any hash-only branch from the local NodeStore before declaring it
+// missing. This Go walker performs no store fetches — a backed map
+// whose children have been released (see InnerNode.ReleaseChildren)
+// will surface those branches as missing even though their data is on
+// disk. Today's callers (sync flows in inbound and consensus/adaptor)
+// walk maps that have not yet pulled child nodes onto local disk, so
+// the divergence is latent; if a caller later walks a flushed-and-
+// evicted backed map, threading a loadFromStore policy into the walker
+// will be required.
+//
+// maxMissing == 0 is unbounded; otherwise the walk stops once that many
+// entries have been collected. A nil filter behaves like DefaultSyncFilter.
 func (sm *SHAMap) WalkMap(maxMissing int, filter SyncFilter) []MissingNode {
 	if filter == nil {
 		filter = &DefaultSyncFilter{}
@@ -254,13 +264,25 @@ func (sm *SHAMap) WalkMap(maxMissing int, filter SyncFilter) []MissingNode {
 // WalkMapParallel is the parallel variant of WalkMap. It fans out one
 // goroutine per non-empty root branch and lets each worker walk its
 // subtree independently; results share a single slice guarded by a
-// mutex, and an atomic stop flag short-circuits all workers once
-// maxMissing entries have been collected.
+// mutex. An in-mutex stop flag prevents over-appending once maxMissing
+// entries have been collected — workers that walk missing-node-free
+// subtrees still run their stacks to completion, since the flag is
+// checked only inside the report callback.
 //
-// Mirrors rippled's SHAMap::walkMapParallel (SHAMapDelta.cpp:282). On a
-// 16-way branched tree the speedup approaches a factor of 16 for cold
-// in-memory scans; for small trees the goroutine startup overhead is
-// negligible since at most 16 workers ever run.
+// Modeled on rippled's SHAMap::walkMapParallel (SHAMapDelta.cpp:282),
+// with two intentional divergences:
+//
+//   - Hash-only branches at root depth 1 are reported as missing here.
+//     Rippled's walkMapParallel silently drops them (its top-children
+//     capture at SHAMapDelta.cpp:290-318 skips any nullptr child without
+//     emitting a missing entry, which makes its result disagree with
+//     rippled's own serial walkMap). This Go walker stays consistent
+//     with the serial WalkMap so the two produce the same result set.
+//   - Same no-store-fetch policy as WalkMap (see that docstring).
+//
+// On a 16-way branched tree the speedup approaches a factor of 16 for
+// cold in-memory scans; for small trees the goroutine startup overhead
+// is negligible since at most 16 workers ever run.
 func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNode {
 	if filter == nil {
 		filter = &DefaultSyncFilter{}
@@ -351,7 +373,6 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 	var wg sync.WaitGroup
 	wg.Add(len(subtrees))
 	for _, s := range subtrees {
-		s := s
 		go func() {
 			defer wg.Done()
 			walkSubtreeForMissing(

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -133,12 +133,19 @@ func NewSyncState() *SyncState {
 	}
 }
 
-// missingNodeWalker is the shared BFS-over-one-subtree primitive used by
-// WalkMap, WalkMapParallel and GetMissingNodes. It walks the in-memory
-// subtree rooted at `start` (no disk loads — anything not already loaded
-// is reported as missing) and invokes report for every non-empty branch
-// whose child pointer is nil. Returns true if report signalled stop.
+// walkSubtreeForMissing is the shared BFS-over-one-subtree primitive used
+// by WalkMap, WalkMapParallel and GetMissingNodes. It walks the subtree
+// rooted at `start` and invokes report for every non-empty branch whose
+// child node is neither in memory nor recoverable from sm's NodeStore.
+// Returns true if report signalled stop.
+//
+// For backed maps (sm.backed and sm.family non-nil), a hash-only branch
+// triggers a lazy fetch via sm.descend before being declared missing —
+// mirroring rippled's descendNoStore-based walker (SHAMap.cpp:351-357).
+// For unbacked maps the function never issues store I/O; any nil child
+// pointer on a set branch is reported as missing.
 func walkSubtreeForMissing(
+	sm *SHAMap,
 	start *InnerNode,
 	startID NodeID,
 	startHash [32]byte,
@@ -181,8 +188,14 @@ func walkSubtreeForMissing(
 			}
 
 			if child == nil {
-				// Branch is referenced by hash but the child node
-				// is not in memory — that's a missing node.
+				if loaded := loadFromStore(sm, item.node, branch); loaded != nil {
+					child = loaded
+				}
+			}
+
+			if child == nil {
+				// Branch is referenced by hash but the child node is
+				// neither in memory nor in the local store.
 				if !filter.ShouldFetch(childHash) {
 					continue
 				}
@@ -216,21 +229,33 @@ func walkSubtreeForMissing(
 	return false
 }
 
-// WalkMap walks the in-memory SHAMap and returns every non-empty branch
-// whose child node is not loaded as a MissingNode entry. Returns nil
-// when the root is empty or the map is in StateInvalid.
+// loadFromStore lazy-fetches a hash-only branch from the backing store
+// and installs it on the parent via SetChildIfNil. Returns nil for
+// unbacked maps, missing-from-store, or any fetch error — callers treat
+// a nil result as a truly-missing branch. Matches rippled's
+// descendNoStore semantics (SHAMap.cpp:351-357) modulo the canonicalize
+// side effect: rippled returns the fetched node without installing it,
+// goxrpl installs via SetChildIfNil so subsequent descends are O(1).
+func loadFromStore(sm *SHAMap, parent *InnerNode, branch int) Node {
+	if sm == nil || !sm.backed || sm.family == nil {
+		return nil
+	}
+	loaded, err := sm.descend(parent, branch)
+	if err != nil {
+		return nil
+	}
+	return loaded
+}
+
+// WalkMap walks the SHAMap and returns every non-empty branch whose
+// child node is neither in memory nor recoverable from the local
+// NodeStore. Returns nil when the root is empty or the map is in
+// StateInvalid.
 //
-// Divergence from rippled's SHAMap::walkMap (SHAMapDelta.cpp:240): the
-// rippled walker calls descendNoStore, which for a backed map fetches
-// any hash-only branch from the local NodeStore before declaring it
-// missing. This Go walker performs no store fetches — a backed map
-// whose children have been released (see InnerNode.ReleaseChildren)
-// will surface those branches as missing even though their data is on
-// disk. Today's callers (sync flows in inbound and consensus/adaptor)
-// walk maps that have not yet pulled child nodes onto local disk, so
-// the divergence is latent; if a caller later walks a flushed-and-
-// evicted backed map, threading a loadFromStore policy into the walker
-// will be required.
+// Mirrors rippled's SHAMap::walkMap (SHAMapDelta.cpp:240): for backed
+// maps, hash-only branches are lazy-loaded via the family before being
+// declared missing, matching rippled's descendNoStore semantics. For
+// unbacked maps the walk is purely in-memory.
 //
 // maxMissing == 0 is unbounded; otherwise the walk stops once that many
 // entries have been collected. A nil filter behaves like DefaultSyncFilter.
@@ -248,6 +273,7 @@ func (sm *SHAMap) WalkMap(maxMissing int, filter SyncFilter) []MissingNode {
 
 	var missing []MissingNode
 	walkSubtreeForMissing(
+		sm,
 		sm.root,
 		NewRootNodeID(),
 		sm.root.Hash(),
@@ -269,16 +295,16 @@ func (sm *SHAMap) WalkMap(maxMissing int, filter SyncFilter) []MissingNode {
 // subtrees still run their stacks to completion, since the flag is
 // checked only inside the report callback.
 //
-// Modeled on rippled's SHAMap::walkMapParallel (SHAMapDelta.cpp:282),
-// with two intentional divergences:
-//
-//   - Hash-only branches at root depth 1 are reported as missing here.
-//     Rippled's walkMapParallel silently drops them (its top-children
-//     capture at SHAMapDelta.cpp:290-318 skips any nullptr child without
-//     emitting a missing entry, which makes its result disagree with
-//     rippled's own serial walkMap). This Go walker stays consistent
-//     with the serial WalkMap so the two produce the same result set.
-//   - Same no-store-fetch policy as WalkMap (see that docstring).
+// Modeled on rippled's SHAMap::walkMapParallel (SHAMapDelta.cpp:282).
+// One intentional divergence: hash-only branches at root depth 1 that
+// the local store cannot satisfy are reported as missing here. Rippled's
+// walkMapParallel silently drops them (its top-children capture at
+// SHAMapDelta.cpp:290-318 skips any nullptr child without emitting a
+// missing entry, which makes its result disagree with rippled's own
+// serial walkMap). This Go walker stays consistent with the serial
+// WalkMap so the two produce the same result set. As in WalkMap, backed
+// maps lazy-load hash-only branches from the family before declaring
+// them missing.
 //
 // On a 16-way branched tree the speedup approaches a factor of 16 for
 // cold in-memory scans; for small trees the goroutine startup overhead
@@ -337,6 +363,11 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 			continue
 		}
 		if child == nil {
+			if loaded := loadFromStore(sm, sm.root, branch); loaded != nil {
+				child = loaded
+			}
+		}
+		if child == nil {
 			if filter.ShouldFetch(childHash) {
 				if reportLocked(MissingNode{
 					Hash:       childHash,
@@ -376,6 +407,7 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 		go func() {
 			defer wg.Done()
 			walkSubtreeForMissing(
+				sm,
 				s.node,
 				s.nodeID,
 				s.nodeHash,

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -1,6 +1,8 @@
 package shamap
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"testing"
 )
@@ -381,6 +383,69 @@ func TestWalkMap_MaxMissingHonored(t *testing.T) {
 	gotP := dest.WalkMapParallel(bound, nil)
 	if len(gotP) != bound {
 		t.Errorf("WalkMapParallel(maxMissing=%d): got %d entries", bound, len(gotP))
+	}
+}
+
+// TestWalkMap_BackedLazyLoadAfterRelease pins the conformance behavior
+// against rippled's descendNoStore-based walker (SHAMap.cpp:351-357): on
+// a backed map whose in-memory children have been released after a
+// flush, both WalkMap and WalkMapParallel must reach the on-disk data
+// via lazy-load and report zero missing nodes — not the false positives
+// that a pure in-memory walker would emit.
+func TestWalkMap_BackedLazyLoadAfterRelease(t *testing.T) {
+	family := newMemoryFamily()
+	src, err := NewBacked(TypeState, family)
+	if err != nil {
+		t.Fatalf("NewBacked: %v", err)
+	}
+
+	// 32 keys spread across multiple first-nibble branches so the
+	// tree has at least two levels of inner nodes. Start from 1 to
+	// avoid an all-zero key (which deserializes back as an invalid
+	// account-state leaf).
+	for i := byte(1); i <= 32; i++ {
+		var key [32]byte
+		key[0] = i
+		key[31] = i
+		if err := src.Put(key, intToBytes(int(i))); err != nil {
+			t.Fatalf("Put(%d): %v", i, err)
+		}
+	}
+
+	// FlushDirty(true) writes every dirty node to family and then calls
+	// ReleaseChildren on each inner — children are nil, hashes remain.
+	batch, err := src.FlushDirty(true)
+	if err != nil {
+		t.Fatalf("FlushDirty: %v", err)
+	}
+	if err := family.StoreBatch(context.Background(), batch.Entries); err != nil {
+		t.Fatalf("StoreBatch: %v", err)
+	}
+
+	if got := src.WalkMap(0, nil); len(got) != 0 {
+		t.Errorf("WalkMap on backed map with released children: want 0 missing, got %d", len(got))
+	}
+	if got := src.WalkMapParallel(0, nil); len(got) != 0 {
+		t.Errorf("WalkMapParallel on backed map with released children: want 0 missing, got %d", len(got))
+	}
+
+	// Sanity: every original key still resolves through the lazy-load
+	// path (proves the walker didn't just skip silently).
+	for i := byte(1); i <= 32; i++ {
+		var key [32]byte
+		key[0] = i
+		key[31] = i
+		item, found, err := src.Get(key)
+		if err != nil {
+			t.Fatalf("Get(%d) after release: %v", i, err)
+		}
+		if !found {
+			t.Fatalf("Get(%d) after release: not found", i)
+		}
+		want := intToBytes(int(i))
+		if !bytes.Equal(item.Data(), want) {
+			t.Fatalf("Get(%d) after release: data drift", i)
+		}
 	}
 }
 

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -230,6 +230,160 @@ func TestAddRootNodeErrors(t *testing.T) {
 	}
 }
 
+// TestWalkMap_NotGatedOnState verifies that unlike GetMissingNodes, the
+// named WalkMap/WalkMapParallel APIs walk the tree regardless of the
+// map's state. This matches rippled's SHAMap::walkMap which has no
+// state precondition.
+func TestWalkMap_NotGatedOnState(t *testing.T) {
+	source, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	for i := byte(0); i < 32; i++ {
+		var key [32]byte
+		key[0] = i
+		if err := source.Put(key, make([]byte, 12)); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+
+	// source is StateModifying — a complete tree.
+	if got := source.WalkMap(0, nil); len(got) != 0 {
+		t.Errorf("WalkMap on complete StateModifying map: want 0 missing, got %d", len(got))
+	}
+	if got := source.WalkMapParallel(0, nil); len(got) != 0 {
+		t.Errorf("WalkMapParallel on complete StateModifying map: want 0 missing, got %d", len(got))
+	}
+
+	// GetMissingNodes still requires StateSyncing.
+	if got := source.GetMissingNodes(0, nil); got != nil {
+		t.Errorf("GetMissingNodes on non-syncing map: want nil, got %v", got)
+	}
+}
+
+// TestWalkMap_SerialVsParallelAgree builds a partially-synced destination
+// map and asserts WalkMap and WalkMapParallel agree on the set of missing
+// nodes. The parallel version may reorder results, so comparison is
+// set-based.
+func TestWalkMap_SerialVsParallelAgree(t *testing.T) {
+	source, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("New source: %v", err)
+	}
+	// Spread keys across every first-nibble branch so the root has all
+	// 16 branches populated and the parallel walker actually has work
+	// to fan out.
+	for branch := byte(0); branch < 16; branch++ {
+		for i := byte(0); i < 4; i++ {
+			var key [32]byte
+			key[0] = (branch << 4) | i
+			if err := source.Put(key, make([]byte, 12)); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+		}
+	}
+
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source.Hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("SerializeRoot: %v", err)
+	}
+
+	dest, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("New dest: %v", err)
+	}
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		t.Fatalf("AddRootNode: %v", err)
+	}
+
+	serial := dest.WalkMap(0, nil)
+	parallel := dest.WalkMapParallel(0, nil)
+
+	if len(serial) == 0 {
+		t.Fatal("expected missing nodes from a root-only dest, got none")
+	}
+	if len(serial) != len(parallel) {
+		t.Fatalf("serial vs parallel size disagree: serial=%d parallel=%d", len(serial), len(parallel))
+	}
+
+	asSet := func(ms []MissingNode) map[[32]byte]int {
+		m := make(map[[32]byte]int, len(ms))
+		for _, n := range ms {
+			m[n.Hash] = n.Branch
+		}
+		return m
+	}
+	s, p := asSet(serial), asSet(parallel)
+	if len(s) != len(serial) || len(p) != len(parallel) {
+		t.Fatalf("duplicate hashes in result: serial uniq=%d/%d parallel uniq=%d/%d",
+			len(s), len(serial), len(p), len(parallel))
+	}
+	for h, branch := range s {
+		if pb, ok := p[h]; !ok {
+			t.Errorf("hash %x present in serial but missing from parallel", h[:8])
+		} else if pb != branch {
+			t.Errorf("hash %x: branch mismatch serial=%d parallel=%d", h[:8], branch, pb)
+		}
+	}
+}
+
+// TestWalkMap_MaxMissingHonored verifies both walkers respect the
+// maxMissing bound and return exactly that many entries when at least
+// that many are available.
+func TestWalkMap_MaxMissingHonored(t *testing.T) {
+	source, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("New source: %v", err)
+	}
+	for branch := byte(0); branch < 16; branch++ {
+		var key [32]byte
+		key[0] = branch << 4
+		if err := source.Put(key, make([]byte, 12)); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source.Hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("SerializeRoot: %v", err)
+	}
+
+	dest, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("New dest: %v", err)
+	}
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		t.Fatalf("AddRootNode: %v", err)
+	}
+
+	// 16 leaves on distinct first-nibble branches → 16 missing.
+	full := dest.WalkMap(0, nil)
+	if len(full) < 4 {
+		t.Fatalf("expected at least 4 missing nodes, got %d", len(full))
+	}
+
+	bound := 3
+	got := dest.WalkMap(bound, nil)
+	if len(got) != bound {
+		t.Errorf("WalkMap(maxMissing=%d): got %d entries", bound, len(got))
+	}
+
+	// The parallel walker's stop flag lives inside the shared-result
+	// mutex, so an exact bound holds — workers that hit the lock after
+	// stopped is set skip their append entirely.
+	gotP := dest.WalkMapParallel(bound, nil)
+	if len(gotP) != bound {
+		t.Errorf("WalkMapParallel(maxMissing=%d): got %d entries", bound, len(gotP))
+	}
+}
+
 // Regression for issue #395: GetMissingNodes must populate
 // MissingNode.NodeID with each missing node's path-based identifier so
 // the caller can request that exact subtree from a peer.


### PR DESCRIPTION
Closes every item of the four-point SHAMap audit in #505. All changes are performance / API-shape only — hash output and wire format are byte-identical, both as a precondition and verified by the existing snapshot- and missing-node tests.

## Commits

### 1. `fix: O(1) path-copy SHAMap snapshots` — audit item 1
`Snapshot` was deep-cloning the entire tree via `cloneNodeTree` (O(tree)), making every `NewOpen` ledger-close pay millions of node allocations on live-network state. Switched to path-copy persistence: `Snapshot` is now an O(1) shallow struct copy that shares the root pointer; mutation paths (`dirtyUp`, `consolidateAfterDelete`) shallow-clone each touched inner node so untouched subtrees stay structurally shared with the snapshot.

Why path-copy and not rippled's `cowid_`: rippled's epoch counter works because C++ owns memory manually; in Go, structural sharing via immutable inner-node values + per-mutation path rebuild is cheaper to reason about, lock-free for snapshot, and matches what `consolidateAfterDelete` was already doing on the delete path. Worst-case cost is ~6 inner-node allocations per mutation on a 6M-leaf state map (`log_16(6M) ≈ 6`) — strictly cheaper than the O(tree) clone it replaces on the `NewOpen` → apply-txs → `Snapshot` hot path.

`snapshotBacked`'s flush + `NewFromRootHash` rehydration is gone; the dirty flush itself stays so a post-snapshot crash recovery sees the same tree.

### 2. `fix: parallel SHAMap walk + named WalkMap APIs` — audit items 2, 3, 4
- **`WalkMap(maxMissing, filter)`** — named public counterpart to rippled's `SHAMap::walkMap` (`SHAMapDelta.cpp:240`). Serial in-memory walk, no state gate, no disk reads. Closes audit item 4.
- **`WalkMapParallel(maxMissing, filter)`** — mirrors `SHAMap::walkMapParallel` (`SHAMapDelta.cpp:282`). One goroutine per non-empty root branch, shared result slice under a mutex, in-mutex stop flag so `maxMissing` holds exactly. Closes audit item 3.
- **`GetMissingNodes`** now delegates the walk to `WalkMapParallel` (the `StateSyncing` gate stays — that's a goXRPL contract callers depend on). Closes audit item 2.

Serial and parallel walkers share a single `walkSubtreeForMissing` primitive that uses `LoadChild` for a one-lock-acquisition read of the `(child, hash, isBranch)` triple, replacing the old `IsEmptyBranch` / `ChildHash` / `Child` per-node-relock sequence.

## Test plan
- [x] `go test ./shamap/...` — all green, including new tests:
  - `TestSnapshot_StructuralSharing` — pins the path-copy invariant (15 root branches share pointers, 1 path-copied)
  - `TestWalkMap_NotGatedOnState` — `WalkMap`/`WalkMapParallel` work outside `StateSyncing`, `GetMissingNodes` still gates on it
  - `TestWalkMap_SerialVsParallelAgree` — both walkers produce the same `MissingNode` set
  - `TestWalkMap_MaxMissingHonored` — both walkers respect the bound exactly
- [x] `go test -race ./shamap/...` — clean
- [x] `go test ./internal/ledger/...` — green (every `NewOpen` exercises `Snapshot(true)`)
- [x] `go test ./internal/tx/...` — green
- [x] `go test ./internal/consensus/...` — green
- [x] `go test ./internal/testing/...` — green except `TestMPT_Clawback/BasicClawback`, which fails identically on `origin/main` (pre-existing, unrelated)

Fixes #505
