### PR TITLE
fix: enforce rippled Change::preflight + Change::preclaim on pseudo-tx

### DIFF
--- a/amendment/rules.go
+++ b/amendment/rules.go
@@ -235,6 +235,11 @@ func (r *Rules) XRPFeesEnabled() bool {
 	return r.Enabled(FeatureXRPFees)
 }
 
+// NegativeUNLEnabled returns true if the NegativeUNL amendment is enabled.
+func (r *Rules) NegativeUNLEnabled() bool {
+	return r.Enabled(FeatureNegativeUNL)
+}
+
 // DisallowIncomingEnabled returns true if the DisallowIncoming amendment is enabled.
 func (r *Rules) DisallowIncomingEnabled() bool {
 	return r.Enabled(FeatureDisallowIncoming)

--- a/internal/consensus/amendmentvote/vote.go
+++ b/internal/consensus/amendmentvote/vote.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 const (
@@ -285,7 +286,7 @@ func DoVoting(in Inputs) ([][]byte, error) {
 // is set only when non-zero (got/lost majority).
 func buildEnableAmendmentTx(seq uint32, amendment Amendment, flags uint32) ([]byte, error) {
 	etx := &pseudo.EnableAmendment{
-		BaseTx:         *tx.NewBaseTx(tx.TypeAmendment, pseudo.ZeroAccount),
+		BaseTx:         *tx.NewBaseTx(tx.TypeAmendment, protocol.ZeroAccount),
 		Amendment:      hex.EncodeToString(amendment[:]),
 		LedgerSequence: &seq,
 	}

--- a/internal/consensus/feevote/vote.go
+++ b/internal/consensus/feevote/vote.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // MaxLegalDrops is the upper bound on a legal XRPAmount, equal to
@@ -219,7 +220,7 @@ func applyVote(v *votableValue, field *uint64) {
 // string). Mirrors FeeVoteImpl.cpp:297-319.
 func buildSetFeeTx(seq uint32, current, chosen Stance, xrpFeesEnabled bool) ([]byte, error) {
 	stx := &pseudo.SetFee{
-		BaseTx:         *tx.NewBaseTx(tx.TypeFee, pseudo.ZeroAccount),
+		BaseTx:         *tx.NewBaseTx(tx.TypeFee, protocol.ZeroAccount),
 		LedgerSequence: &seq,
 	}
 

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -34,6 +34,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // ErrLocalCountExceedsWindow is returned when the local node's validation
@@ -440,7 +441,7 @@ func compareNodeID20(a, b [20]byte) int {
 func buildUNLModifyTx(seq uint32, validator [33]byte, modify Modify) ([]byte, error) {
 	disabling := uint8(modify)
 	utx := &pseudo.UNLModify{
-		BaseTx:             *tx.NewBaseTx(tx.TypeUNLModify, pseudo.ZeroAccount),
+		BaseTx:             *tx.NewBaseTx(tx.TypeUNLModify, protocol.ZeroAccount),
 		UNLModifyDisabling: &disabling,
 		LedgerSequence:     &seq,
 		UNLModifyValidator: hex.EncodeToString(validator[:]),

--- a/internal/ledger/state/fee_settings.go
+++ b/internal/ledger/state/fee_settings.go
@@ -24,6 +24,12 @@ type FeeSettings struct {
 	ReserveBase       uint32 // Reserve base in drops (legacy, fits in uint32 for old values)
 	ReserveIncrement  uint32 // Reserve increment in drops (legacy)
 
+	// XRPFeesMode reports whether the entry encodes the modern (post-XRPFees)
+	// field set. SerializeFeeSettings emits the matching triple/quad even when
+	// values are zero, mirroring rippled Change.cpp:362-379 which uses
+	// STObject::operator= (assignment) rather than a value-is-nonzero gate.
+	XRPFeesMode bool
+
 	// Tracking fields (not always present)
 	PreviousTxnID     [32]byte
 	PreviousTxnLgrSeq uint32
@@ -145,10 +151,13 @@ func ParseFeeSettings(data []byte) (*FeeSettings, error) {
 				switch fieldCode {
 				case fieldCodeBaseFeeDrops:
 					fee.BaseFeeDrops = drops
+					fee.XRPFeesMode = true
 				case fieldCodeReserveBaseDrops:
 					fee.ReserveBaseDrops = drops
+					fee.XRPFeesMode = true
 				case fieldCodeReserveIncrementDrops:
 					fee.ReserveIncrementDrops = drops
+					fee.XRPFeesMode = true
 				}
 				offset += 8
 			} else {
@@ -174,34 +183,23 @@ func ParseFeeSettings(data []byte) (*FeeSettings, error) {
 	return fee, nil
 }
 
-// SerializeFeeSettings serializes a FeeSettings to binary format
+// SerializeFeeSettings serializes a FeeSettings to binary format. The active
+// field set (modern triple under XRPFeesMode, legacy quad otherwise) is always
+// emitted, including zero-valued fields — matching rippled's `set()` /
+// `makeFieldAbsent()` semantics at Change.cpp:362-379.
 func SerializeFeeSettings(fee *FeeSettings) ([]byte, error) {
 	jsonObj := map[string]any{
 		"LedgerEntryType": "FeeSettings",
 	}
 
-	// Add modern fields if present (XRPFees amendment)
-	if fee.BaseFeeDrops > 0 {
+	if fee.XRPFeesMode {
 		jsonObj["BaseFeeDrops"] = fmt.Sprintf("%d", fee.BaseFeeDrops)
-	}
-	if fee.ReserveBaseDrops > 0 {
 		jsonObj["ReserveBaseDrops"] = fmt.Sprintf("%d", fee.ReserveBaseDrops)
-	}
-	if fee.ReserveIncrementDrops > 0 {
 		jsonObj["ReserveIncrementDrops"] = fmt.Sprintf("%d", fee.ReserveIncrementDrops)
-	}
-
-	// Add legacy fields if present (pre-XRPFees)
-	if fee.BaseFee > 0 {
+	} else {
 		jsonObj["BaseFee"] = fmt.Sprintf("%x", fee.BaseFee) // Hex string per rippled
-	}
-	if fee.ReferenceFeeUnits > 0 {
 		jsonObj["ReferenceFeeUnits"] = fee.ReferenceFeeUnits
-	}
-	if fee.ReserveBase > 0 {
 		jsonObj["ReserveBase"] = fee.ReserveBase
-	}
-	if fee.ReserveIncrement > 0 {
 		jsonObj["ReserveIncrement"] = fee.ReserveIncrement
 	}
 
@@ -259,7 +257,8 @@ func (f *FeeSettings) GetReserveIncrement() uint64 {
 	return 2_000_000 // Default: 2 XRP
 }
 
-// IsUsingModernFees returns true if using XRPFees amendment fields.
+// IsUsingModernFees returns true if the entry encodes the post-XRPFees field
+// set. Authoritative source is XRPFeesMode (set at Parse and at Apply time).
 func (f *FeeSettings) IsUsingModernFees() bool {
-	return f.BaseFeeDrops > 0 || f.ReserveBaseDrops > 0 || f.ReserveIncrementDrops > 0
+	return f.XRPFeesMode
 }

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -1378,8 +1378,9 @@ func (e *TestEnv) SetInSetupMode(setup bool) {
 
 // SubmitPseudo submits a pseudo-transaction (EnableAmendment, SetFee, UNLModify)
 // directly to the engine. Pseudo-transactions bypass account lookup, sequence
-// auto-fill, fee deduction, and signature verification.
-// Reference: rippled Change.cpp -- pseudo-txs have zero account, zero fee, no sigs.
+// auto-fill, fee deduction, and signature verification, and are always applied
+// against a closed ledger (rippled's Change::preclaim rejects them otherwise).
+// Reference: rippled Change.cpp:82-91 — pseudo-txs require !view.open().
 func (e *TestEnv) SubmitPseudo(transaction interface{}) TxResult {
 	e.t.Helper()
 
@@ -1400,7 +1401,7 @@ func (e *TestEnv) SubmitPseudo(transaction interface{}) TxResult {
 		ParentCloseTime:           parentCloseTime,
 		NetworkID:                 e.networkID,
 		ParentHash:                e.ledger.ParentHash(),
-		OpenLedger:                e.openLedger,
+		OpenLedger:                false,
 	}
 
 	engine := tx.NewEngine(e.ledger, engineConfig)

--- a/internal/testing/pseudotx/preflight_test.go
+++ b/internal/testing/pseudotx/preflight_test.go
@@ -1,0 +1,244 @@
+// Tests for the engine-level pseudo-transaction preflight / preclaim gates
+// that mirror rippled Change::preflight and Change::preclaim
+// (rippled/src/xrpld/app/tx/detail/Change.cpp:36-140).
+package pseudotx_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/amendment"
+	jtx "github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/stretchr/testify/require"
+)
+
+// closedEngine builds an engine pinned to a closed-ledger view, which is the
+// only configuration under which ApplyPseudo legally executes per rippled
+// Change::preclaim.
+func closedEngine(t *testing.T, rules *amendment.Rules) (*tx.Engine, *jtx.TestEnv) {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	cfg := tx.EngineConfig{
+		BaseFee:                   10,
+		ReserveBase:               200_000_000,
+		ReserveIncrement:          50_000_000,
+		LedgerSequence:            env.LedgerSeq(),
+		SkipSignatureVerification: true,
+		OpenLedger:                false,
+		Rules:                     rules,
+	}
+	return tx.NewEngine(env.Ledger(), cfg), env
+}
+
+func newAmendmentTx() *pseudo.EnableAmendment {
+	t := &pseudo.EnableAmendment{
+		BaseTx: *tx.NewBaseTx(tx.TypeAmendment, ""),
+	}
+	t.Amendment = "00000000000000000000000000000000000000000000000000000000000000AA"
+	t.Common.Fee = "0"
+	zero := uint32(0)
+	t.Common.Sequence = &zero
+	return t
+}
+
+func newLegacySetFeeTx() *pseudo.SetFee {
+	t := pseudo.NewSetFee()
+	t.Common.Fee = "0"
+	zero := uint32(0)
+	t.Common.Sequence = &zero
+	t.BaseFee = "0A" // 10 drops as hex (sfBaseFee is STUInt64 in JSON form)
+	rfu := uint32(10)
+	t.ReferenceFeeUnits = &rfu
+	rb := uint32(200_000_000)
+	t.ReserveBase = &rb
+	ri := uint32(50_000_000)
+	t.ReserveIncrement = &ri
+	return t
+}
+
+// TestPseudoPreflight_AccountMustBeZero rejects a pseudo-tx whose Account is
+// neither empty nor the canonical zero address.
+// Reference: rippled Change.cpp:43-48.
+func TestPseudoPreflight_AccountMustBeZero(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+	tx := newAmendmentTx()
+	tx.Common.Account = "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de" // arbitrary non-zero account
+	result := engine.ApplyPseudo(tx)
+	require.False(t, result.Applied)
+	require.Equal(t, "temBAD_SRC_ACCOUNT", result.Result.String())
+}
+
+// TestPseudoPreflight_FeeMustBeZero rejects a pseudo-tx with a non-zero fee.
+// Reference: rippled Change.cpp:50-56.
+func TestPseudoPreflight_FeeMustBeZero(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+	tx := newAmendmentTx()
+	tx.Common.Fee = "10"
+	result := engine.ApplyPseudo(tx)
+	require.False(t, result.Applied)
+	require.Equal(t, "temBAD_FEE", result.Result.String())
+}
+
+// TestPseudoPreflight_NoSigningPubKey rejects a pseudo-tx with a signing key.
+// Reference: rippled Change.cpp:58-63.
+func TestPseudoPreflight_NoSigningPubKey(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+	tx := newAmendmentTx()
+	tx.Common.SigningPubKey = "ED00000000000000000000000000000000000000000000000000000000000000AA"
+	result := engine.ApplyPseudo(tx)
+	require.False(t, result.Applied)
+	require.Equal(t, "temBAD_SIGNATURE", result.Result.String())
+}
+
+// TestPseudoPreflight_NoTxnSignature rejects a pseudo-tx carrying TxnSignature.
+// Reference: rippled Change.cpp:58-63.
+func TestPseudoPreflight_NoTxnSignature(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+	tx := newAmendmentTx()
+	tx.Common.TxnSignature = "DEADBEEF"
+	result := engine.ApplyPseudo(tx)
+	require.False(t, result.Applied)
+	require.Equal(t, "temBAD_SIGNATURE", result.Result.String())
+}
+
+// TestPseudoPreflight_SequenceMustBeZero rejects a pseudo-tx with a non-zero
+// Sequence (rippled also forbids a present PreviousTxnID; goXRPL's Common
+// struct has no such field, so only the Sequence half is exercised).
+// Reference: rippled Change.cpp:65-69.
+func TestPseudoPreflight_SequenceMustBeZero(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+	tx := newAmendmentTx()
+	one := uint32(1)
+	tx.Common.Sequence = &one
+	result := engine.ApplyPseudo(tx)
+	require.False(t, result.Applied)
+	require.Equal(t, "temBAD_SEQUENCE", result.Result.String())
+}
+
+// TestPseudoPreflight_TicketSequenceForbidden rejects a pseudo-tx that tries
+// to reference a ticket. Rippled rejects any sequence-replacement field on a
+// pseudo-tx; goXRPL maps that to the TicketSequence presence check.
+func TestPseudoPreflight_TicketSequenceForbidden(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+	tx := newAmendmentTx()
+	tick := uint32(42)
+	tx.Common.TicketSequence = &tick
+	result := engine.ApplyPseudo(tx)
+	require.False(t, result.Applied)
+	require.Equal(t, "temBAD_SEQUENCE", result.Result.String())
+}
+
+// TestPseudoPreflight_UNLModifyDisabled rejects UNL_MODIFY when the
+// NegativeUNL amendment is not enabled.
+// Reference: rippled Change.cpp:72-77.
+func TestPseudoPreflight_UNLModifyDisabled(t *testing.T) {
+	rules := amendment.NewRules(nil) // no amendments enabled
+	engine, _ := closedEngine(t, rules)
+
+	unlTx := &pseudo.UNLModify{BaseTx: *tx.NewBaseTx(tx.TypeUNLModify, "")}
+	unlTx.Common.Fee = "0"
+	zero := uint32(0)
+	unlTx.Common.Sequence = &zero
+
+	result := engine.ApplyPseudo(unlTx)
+	require.False(t, result.Applied)
+	require.Equal(t, "temDISABLED", result.Result.String())
+}
+
+// TestPseudoPreflight_AcceptsCanonicalZeroAccount confirms the canonical zero
+// address ("rrrrrrrrrrrrrrrrrrrrrhoLvTp") is treated identically to an empty
+// account, since both encode AccountID(0).
+func TestPseudoPreflight_AcceptsCanonicalZeroAccount(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+	tx := newAmendmentTx()
+	tx.Common.Account = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+	result := engine.ApplyPseudo(tx)
+	require.NotEqual(t, "temBAD_SRC_ACCOUNT", result.Result.String(),
+		"canonical zero address must pass the preflight gate")
+}
+
+// TestSetFee_PreclaimXRPFeesEnabled_RequiresModernFields rejects a SetFee
+// missing any of the modern triple while featureXRPFees is enabled.
+// Reference: rippled Change.cpp:96-104.
+func TestSetFee_PreclaimXRPFeesEnabled_RequiresModernFields(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+
+	setFee := pseudo.NewSetFee()
+	setFee.Common.Fee = "0"
+	zero := uint32(0)
+	setFee.Common.Sequence = &zero
+	setFee.BaseFeeDrops = "10"
+	// ReserveBaseDrops / ReserveIncrementDrops intentionally missing
+
+	result := engine.ApplyPseudo(setFee)
+	require.False(t, result.Applied)
+	require.Equal(t, "temMALFORMED", result.Result.String())
+}
+
+// TestSetFee_PreclaimXRPFeesEnabled_ForbidsLegacyFields rejects a SetFee
+// that carries any legacy fee field once featureXRPFees is enabled.
+// Reference: rippled Change.cpp:105-112.
+func TestSetFee_PreclaimXRPFeesEnabled_ForbidsLegacyFields(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+
+	setFee := pseudo.NewSetFee()
+	setFee.Common.Fee = "0"
+	zero := uint32(0)
+	setFee.Common.Sequence = &zero
+	setFee.BaseFeeDrops = "10"
+	setFee.ReserveBaseDrops = "200000000"
+	setFee.ReserveIncrementDrops = "50000000"
+	setFee.BaseFee = "0A" // legacy hex field — must not appear under XRPFees
+
+	result := engine.ApplyPseudo(setFee)
+	require.False(t, result.Applied)
+	require.Equal(t, "temMALFORMED", result.Result.String())
+}
+
+// TestSetFee_PreclaimXRPFeesDisabled_RequiresLegacyFields rejects a SetFee
+// missing any of the legacy quad when featureXRPFees is NOT enabled.
+// Reference: rippled Change.cpp:114-124.
+func TestSetFee_PreclaimXRPFeesDisabled_RequiresLegacyFields(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.NewRules(nil))
+
+	setFee := pseudo.NewSetFee()
+	setFee.Common.Fee = "0"
+	zero := uint32(0)
+	setFee.Common.Sequence = &zero
+	setFee.BaseFee = "0A"
+	rfu := uint32(10)
+	setFee.ReferenceFeeUnits = &rfu
+	// ReserveBase / ReserveIncrement intentionally missing
+
+	result := engine.ApplyPseudo(setFee)
+	require.False(t, result.Applied)
+	require.Equal(t, "temMALFORMED", result.Result.String())
+}
+
+// TestSetFee_PreclaimXRPFeesDisabled_ForbidsModernFields rejects a SetFee
+// carrying any modern Drops field when featureXRPFees is NOT enabled.
+// Reference: rippled Change.cpp:125-131 (returns temDISABLED).
+func TestSetFee_PreclaimXRPFeesDisabled_ForbidsModernFields(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.NewRules(nil))
+
+	setFee := newLegacySetFeeTx()
+	setFee.BaseFeeDrops = "10" // modern field must not appear pre-XRPFees
+
+	result := engine.ApplyPseudo(setFee)
+	require.False(t, result.Applied)
+	require.Equal(t, "temDISABLED", result.Result.String())
+}
+
+// TestSetFee_PreclaimRejectsUnparseableBaseFee rejects a SetFee whose legacy
+// BaseFee contains a non-hex character.
+func TestSetFee_PreclaimRejectsUnparseableBaseFee(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.NewRules(nil))
+
+	setFee := newLegacySetFeeTx()
+	setFee.BaseFee = "ZZ" // invalid hex
+
+	result := engine.ApplyPseudo(setFee)
+	require.False(t, result.Applied)
+	require.Equal(t, "temMALFORMED", result.Result.String())
+}

--- a/internal/testing/pseudotx/preflight_test.go
+++ b/internal/testing/pseudotx/preflight_test.go
@@ -256,3 +256,71 @@ func TestSetFee_PreclaimRejectsUnparseableBaseFee(t *testing.T) {
 	require.False(t, result.Applied)
 	require.Equal(t, "temMALFORMED", result.Result.String())
 }
+
+// closedEngineWithNetwork mirrors closedEngine but lets the test pin
+// EngineConfig.NetworkID so the NetworkID branch of preflight0 fires.
+func closedEngineWithNetwork(t *testing.T, rules *amendment.Rules, networkID uint32) *tx.Engine {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	cfg := tx.EngineConfig{
+		BaseFee:                   10,
+		ReserveBase:               200_000_000,
+		ReserveIncrement:          50_000_000,
+		LedgerSequence:            env.LedgerSeq(),
+		SkipSignatureVerification: true,
+		OpenLedger:                false,
+		Rules:                     rules,
+		NetworkID:                 networkID,
+	}
+	return tx.NewEngine(env.Ledger(), cfg)
+}
+
+// TestPseudoPreflight_TfInnerBatchTxnRejected rejects a pseudo-tx carrying
+// the tfInnerBatchTxn flag, matching rippled preflight0 (Transactor.cpp:46-51).
+func TestPseudoPreflight_TfInnerBatchTxnRejected(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+	atx := newAmendmentTx()
+	flags := tx.TfInnerBatchTxn
+	atx.Common.Flags = &flags
+	result := engine.ApplyPseudo(atx)
+	require.False(t, result.Applied)
+	require.Equal(t, "temINVALID_FLAG", result.Result.String())
+}
+
+// TestPseudoPreflight_NetworkID_LegacyForbidsField pins rippled's rule that on
+// legacy networks (NETWORK_ID <= 1024) any sfNetworkID on a pseudo-tx is
+// non-canonical. Reference: Transactor.cpp:58-64.
+func TestPseudoPreflight_NetworkID_LegacyForbidsField(t *testing.T) {
+	engine := closedEngineWithNetwork(t, amendment.AllSupportedRules(), 0)
+	atx := newAmendmentTx()
+	nid := uint32(42)
+	atx.Common.NetworkID = &nid
+	result := engine.ApplyPseudo(atx)
+	require.False(t, result.Applied)
+	require.Equal(t, "telNETWORK_ID_MAKES_TX_NON_CANONICAL", result.Result.String())
+}
+
+// TestPseudoPreflight_NetworkID_NewNetworkRequiresMatch pins rippled's rule
+// that on a new network (NETWORK_ID > 1024) a present sfNetworkID must match.
+// Reference: Transactor.cpp:65-74.
+func TestPseudoPreflight_NetworkID_NewNetworkRequiresMatch(t *testing.T) {
+	engine := closedEngineWithNetwork(t, amendment.AllSupportedRules(), 2000)
+	atx := newAmendmentTx()
+	wrong := uint32(2001)
+	atx.Common.NetworkID = &wrong
+	result := engine.ApplyPseudo(atx)
+	require.False(t, result.Applied)
+	require.Equal(t, "telWRONG_NETWORK", result.Result.String())
+}
+
+// TestPseudoPreflight_NetworkID_AbsentAllowedOnPseudo confirms that, unlike
+// normal transactions, a pseudo-tx without sfNetworkID is legal even on a
+// new network — rippled gates the check on field presence for pseudo-tx.
+// Reference: Transactor.cpp:53 ("|| ctx.tx.isFieldPresent(sfNetworkID)").
+func TestPseudoPreflight_NetworkID_AbsentAllowedOnPseudo(t *testing.T) {
+	engine := closedEngineWithNetwork(t, amendment.AllSupportedRules(), 2000)
+	atx := newAmendmentTx() // NetworkID nil
+	result := engine.ApplyPseudo(atx)
+	require.NotEqual(t, "telREQUIRES_NETWORK_ID", result.Result.String(),
+		"absent NetworkID must not trigger the new-network requirement for pseudo-tx")
+}

--- a/internal/testing/pseudotx/preflight_test.go
+++ b/internal/testing/pseudotx/preflight_test.go
@@ -10,6 +10,7 @@ import (
 	jtx "github.com/LeJamon/goXRPLd/internal/testing"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +34,7 @@ func closedEngine(t *testing.T, rules *amendment.Rules) (*tx.Engine, *jtx.TestEn
 
 func newAmendmentTx() *pseudo.EnableAmendment {
 	t := &pseudo.EnableAmendment{
-		BaseTx: *tx.NewBaseTx(tx.TypeAmendment, ""),
+		BaseTx: *tx.NewBaseTx(tx.TypeAmendment, protocol.ZeroAccount),
 	}
 	t.Amendment = "00000000000000000000000000000000000000000000000000000000000000AA"
 	t.Common.Fee = "0"
@@ -58,12 +59,24 @@ func newLegacySetFeeTx() *pseudo.SetFee {
 }
 
 // TestPseudoPreflight_AccountMustBeZero rejects a pseudo-tx whose Account is
-// neither empty nor the canonical zero address.
+// anything other than the canonical zero address.
 // Reference: rippled Change.cpp:43-48.
 func TestPseudoPreflight_AccountMustBeZero(t *testing.T) {
 	engine, _ := closedEngine(t, amendment.AllSupportedRules())
 	tx := newAmendmentTx()
 	tx.Common.Account = "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de" // arbitrary non-zero account
+	result := engine.ApplyPseudo(tx)
+	require.False(t, result.Applied)
+	require.Equal(t, "temBAD_SRC_ACCOUNT", result.Result.String())
+}
+
+// TestPseudoPreflight_RejectsEmptyAccount confirms that an Account string that
+// rippled would never see (omitted from the wire blob) is rejected at the
+// Go-API boundary rather than silently treated as the zero AccountID.
+func TestPseudoPreflight_RejectsEmptyAccount(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+	tx := newAmendmentTx()
+	tx.Common.Account = ""
 	result := engine.ApplyPseudo(tx)
 	require.False(t, result.Applied)
 	require.Equal(t, "temBAD_SRC_ACCOUNT", result.Result.String())
@@ -78,6 +91,21 @@ func TestPseudoPreflight_FeeMustBeZero(t *testing.T) {
 	result := engine.ApplyPseudo(tx)
 	require.False(t, result.Applied)
 	require.Equal(t, "temBAD_FEE", result.Result.String())
+}
+
+// TestPseudoPreflight_FeeZeroSpellings accepts every decimal-string spelling
+// that decodes to zero drops, matching rippled's typed beast::zero compare.
+func TestPseudoPreflight_FeeZeroSpellings(t *testing.T) {
+	for _, fee := range []string{"", "0", "00", "000", " 0 ", "\t0\t"} {
+		t.Run("Fee="+fee, func(t *testing.T) {
+			engine, _ := closedEngine(t, amendment.AllSupportedRules())
+			tx := newAmendmentTx()
+			tx.Common.Fee = fee
+			result := engine.ApplyPseudo(tx)
+			require.NotEqual(t, "temBAD_FEE", result.Result.String(),
+				"Fee=%q must pass the zero-fee gate", fee)
+		})
+	}
 }
 
 // TestPseudoPreflight_NoSigningPubKey rejects a pseudo-tx with a signing key.
@@ -103,27 +131,14 @@ func TestPseudoPreflight_NoTxnSignature(t *testing.T) {
 }
 
 // TestPseudoPreflight_SequenceMustBeZero rejects a pseudo-tx with a non-zero
-// Sequence (rippled also forbids a present PreviousTxnID; goXRPL's Common
-// struct has no such field, so only the Sequence half is exercised).
+// Sequence. The rippled gate also checks sfPreviousTxnID, but goXRPL's Common
+// struct has no such field.
 // Reference: rippled Change.cpp:65-69.
 func TestPseudoPreflight_SequenceMustBeZero(t *testing.T) {
 	engine, _ := closedEngine(t, amendment.AllSupportedRules())
 	tx := newAmendmentTx()
 	one := uint32(1)
 	tx.Common.Sequence = &one
-	result := engine.ApplyPseudo(tx)
-	require.False(t, result.Applied)
-	require.Equal(t, "temBAD_SEQUENCE", result.Result.String())
-}
-
-// TestPseudoPreflight_TicketSequenceForbidden rejects a pseudo-tx that tries
-// to reference a ticket. Rippled rejects any sequence-replacement field on a
-// pseudo-tx; goXRPL maps that to the TicketSequence presence check.
-func TestPseudoPreflight_TicketSequenceForbidden(t *testing.T) {
-	engine, _ := closedEngine(t, amendment.AllSupportedRules())
-	tx := newAmendmentTx()
-	tick := uint32(42)
-	tx.Common.TicketSequence = &tick
 	result := engine.ApplyPseudo(tx)
 	require.False(t, result.Applied)
 	require.Equal(t, "temBAD_SEQUENCE", result.Result.String())
@@ -136,7 +151,7 @@ func TestPseudoPreflight_UNLModifyDisabled(t *testing.T) {
 	rules := amendment.NewRules(nil) // no amendments enabled
 	engine, _ := closedEngine(t, rules)
 
-	unlTx := &pseudo.UNLModify{BaseTx: *tx.NewBaseTx(tx.TypeUNLModify, "")}
+	unlTx := &pseudo.UNLModify{BaseTx: *tx.NewBaseTx(tx.TypeUNLModify, protocol.ZeroAccount)}
 	unlTx.Common.Fee = "0"
 	zero := uint32(0)
 	unlTx.Common.Sequence = &zero
@@ -146,13 +161,12 @@ func TestPseudoPreflight_UNLModifyDisabled(t *testing.T) {
 	require.Equal(t, "temDISABLED", result.Result.String())
 }
 
-// TestPseudoPreflight_AcceptsCanonicalZeroAccount confirms the canonical zero
-// address ("rrrrrrrrrrrrrrrrrrrrrhoLvTp") is treated identically to an empty
-// account, since both encode AccountID(0).
+// TestPseudoPreflight_AcceptsCanonicalZeroAccount pins the canonical zero
+// address as the one and only Account value that passes the preflight gate.
 func TestPseudoPreflight_AcceptsCanonicalZeroAccount(t *testing.T) {
 	engine, _ := closedEngine(t, amendment.AllSupportedRules())
 	tx := newAmendmentTx()
-	tx.Common.Account = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+	tx.Common.Account = protocol.ZeroAccount
 	result := engine.ApplyPseudo(tx)
 	require.NotEqual(t, "temBAD_SRC_ACCOUNT", result.Result.String(),
 		"canonical zero address must pass the preflight gate")

--- a/internal/testing/pseudotx/pseudotx_test.go
+++ b/internal/testing/pseudotx/pseudotx_test.go
@@ -133,9 +133,16 @@ func TestPseudoTx_Prevented(t *testing.T) {
 			"Pseudo-transaction should be rejected with temINVALID")
 	})
 
-	// Verify that ApplyPseudo() DOES accept pseudo-transactions
-	// (this is how pseudo-txs are applied during consensus/block processing)
+	// Verify that ApplyPseudo() DOES accept pseudo-transactions when applied
+	// to a closed ledger (the path used during consensus / block processing).
+	// Rippled's Change::preclaim rejects pseudo-tx against an open view, so
+	// the engine here must be configured with OpenLedger=false.
+	// Reference: rippled Change.cpp:82-91.
 	t.Run("EnableAmendment allowed via ApplyPseudo", func(t *testing.T) {
+		closedConfig := engineConfig
+		closedConfig.OpenLedger = false
+		closedEngine := tx.NewEngine(env.Ledger(), closedConfig)
+
 		amendTx := &pseudo.EnableAmendment{
 			BaseTx: *tx.NewBaseTx(tx.TypeAmendment, "rrrrrrrrrrrrrrrrrrrrrhoLvTp"),
 		}
@@ -145,9 +152,25 @@ func TestPseudoTx_Prevented(t *testing.T) {
 		seq := uint32(0)
 		amendTx.Common.Sequence = &seq
 
-		result := engine.ApplyPseudo(amendTx)
-		// ApplyPseudo should succeed (or at least not return temINVALID)
+		result := closedEngine.ApplyPseudo(amendTx)
 		require.NotEqual(t, "temINVALID", result.Result.String(),
-			"ApplyPseudo should not reject pseudo-transactions")
+			"ApplyPseudo on a closed ledger must not return temINVALID")
+	})
+
+	// ApplyPseudo against an open ledger must be rejected with temINVALID,
+	// matching rippled's Change::preclaim open-view guard.
+	// Reference: rippled Change.cpp:87-91.
+	t.Run("ApplyPseudo rejected on open ledger", func(t *testing.T) {
+		amendTx := &pseudo.EnableAmendment{
+			BaseTx: *tx.NewBaseTx(tx.TypeAmendment, "rrrrrrrrrrrrrrrrrrrrrhoLvTp"),
+		}
+		amendTx.Amendment = makePseudoAmendmentHash(3)
+		amendTx.Common.Fee = "0"
+		seq := uint32(0)
+		amendTx.Common.Sequence = &seq
+
+		result := engine.ApplyPseudo(amendTx)
+		require.Equal(t, "temINVALID", result.Result.String(),
+			"ApplyPseudo on an open ledger must return temINVALID")
 	})
 }

--- a/internal/testing/pseudotx/pseudotx_test.go
+++ b/internal/testing/pseudotx/pseudotx_test.go
@@ -10,6 +10,7 @@ import (
 	jtx "github.com/LeJamon/goXRPLd/internal/testing"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,7 +85,7 @@ func TestPseudoTx_Prevented(t *testing.T) {
 	//   BEAST_EXPECT(!result.applied && result.ter == temINVALID);
 	t.Run("EnableAmendment rejected", func(t *testing.T) {
 		amendTx := &pseudo.EnableAmendment{
-			BaseTx: *tx.NewBaseTx(tx.TypeAmendment, "rrrrrrrrrrrrrrrrrrrrrhoLvTp"),
+			BaseTx: *tx.NewBaseTx(tx.TypeAmendment, protocol.ZeroAccount),
 		}
 		amendTx.Amendment = makePseudoAmendmentHash(1)
 		amendTx.Common.Fee = "0"
@@ -120,7 +121,7 @@ func TestPseudoTx_Prevented(t *testing.T) {
 
 	t.Run("UNLModify rejected", func(t *testing.T) {
 		unlTx := &pseudo.UNLModify{
-			BaseTx: *tx.NewBaseTx(tx.TypeUNLModify, "rrrrrrrrrrrrrrrrrrrrrhoLvTp"),
+			BaseTx: *tx.NewBaseTx(tx.TypeUNLModify, protocol.ZeroAccount),
 		}
 		unlTx.Common.Fee = "0"
 		unlTx.Common.SigningPubKey = ""
@@ -144,7 +145,7 @@ func TestPseudoTx_Prevented(t *testing.T) {
 		closedEngine := tx.NewEngine(env.Ledger(), closedConfig)
 
 		amendTx := &pseudo.EnableAmendment{
-			BaseTx: *tx.NewBaseTx(tx.TypeAmendment, "rrrrrrrrrrrrrrrrrrrrrhoLvTp"),
+			BaseTx: *tx.NewBaseTx(tx.TypeAmendment, protocol.ZeroAccount),
 		}
 		amendTx.Amendment = makePseudoAmendmentHash(2)
 		amendTx.Common.Fee = "0"
@@ -162,7 +163,7 @@ func TestPseudoTx_Prevented(t *testing.T) {
 	// Reference: rippled Change.cpp:87-91.
 	t.Run("ApplyPseudo rejected on open ledger", func(t *testing.T) {
 		amendTx := &pseudo.EnableAmendment{
-			BaseTx: *tx.NewBaseTx(tx.TypeAmendment, "rrrrrrrrrrrrrrrrrrrrrhoLvTp"),
+			BaseTx: *tx.NewBaseTx(tx.TypeAmendment, protocol.ZeroAccount),
 		}
 		amendTx.Amendment = makePseudoAmendmentHash(3)
 		amendTx.Common.Fee = "0"

--- a/internal/tx/apply.go
+++ b/internal/tx/apply.go
@@ -184,8 +184,38 @@ func (e *Engine) ApplyPseudoWithContext(ctx context.Context, tx Transaction) App
 // - No fee (fee is 0)
 // - No signature
 // - No sequence number checks
-// Reference: rippled Change.cpp
+// Reference: rippled Change.cpp preflight/preclaim/doApply
 func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) ApplyResult {
+	rules := e.rules()
+
+	// Preflight gates — mirror rippled Change::preflight (Change.cpp:36-80).
+	// preflight0 in rippled rejects fee/sequence/signing checks before the
+	// type-specific switch; replicated here for all pseudo-tx types. Run before
+	// computing the transaction hash so malformed inputs surface as a typed tem*
+	// result rather than a serialization-induced tefINTERNAL.
+	if gate := pseudoPreflight(tx, rules); !gate.IsSuccess() {
+		return ApplyResult{
+			Result:   gate,
+			Applied:  false,
+			Fee:      0,
+			Metadata: &Metadata{TransactionResult: gate},
+			Message:  gate.Message(),
+		}
+	}
+
+	// Preclaim gates — mirror rippled Change::preclaim (Change.cpp:82-140).
+	// Pseudo-transactions are only legal against a closed ledger; per-type field
+	// gating (e.g. XRPFees) runs through the PseudoPreclaim interface.
+	if gate := e.pseudoPreclaim(tx, rules); !gate.IsSuccess() {
+		return ApplyResult{
+			Result:   gate,
+			Applied:  false,
+			Fee:      0,
+			Metadata: &Metadata{TransactionResult: gate},
+			Message:  gate.Message(),
+		}
+	}
+
 	// Compute transaction hash
 	txHash, err := computeTransactionHash(tx)
 	if err != nil {
@@ -203,7 +233,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 	}
 
 	// Create ApplyStateTable to track changes
-	table := NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, e.rules())
+	table := NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, rules)
 
 	// Create a minimal ApplyContext for pseudo-transactions
 	ctx := &ApplyContext{

--- a/internal/tx/apply.go
+++ b/internal/tx/apply.go
@@ -193,7 +193,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 	// type-specific switch; replicated here for all pseudo-tx types. Run before
 	// computing the transaction hash so malformed inputs surface as a typed tem*
 	// result rather than a serialization-induced tefINTERNAL.
-	if gate := pseudoPreflight(tx, rules); !gate.IsSuccess() {
+	if gate := e.pseudoPreflight(tx, rules); !gate.IsSuccess() {
 		return ApplyResult{
 			Result:   gate,
 			Applied:  false,

--- a/internal/tx/pseudo/register.go
+++ b/internal/tx/pseudo/register.go
@@ -1,16 +1,19 @@
 package pseudo
 
-import "github.com/LeJamon/goXRPLd/internal/tx"
+import (
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/protocol"
+)
 
 // Register registers all pseudo-transaction types (EnableAmendment, SetFee, UNLModify) with the tx registry.
 func Register() {
 	tx.Register(tx.TypeAmendment, func() tx.Transaction {
-		return &EnableAmendment{BaseTx: *tx.NewBaseTx(tx.TypeAmendment, "")}
+		return &EnableAmendment{BaseTx: *tx.NewBaseTx(tx.TypeAmendment, protocol.ZeroAccount)}
 	})
 	tx.Register(tx.TypeFee, func() tx.Transaction {
-		return &SetFee{BaseTx: *tx.NewBaseTx(tx.TypeFee, "")}
+		return &SetFee{BaseTx: *tx.NewBaseTx(tx.TypeFee, protocol.ZeroAccount)}
 	})
 	tx.Register(tx.TypeUNLModify, func() tx.Transaction {
-		return &UNLModify{BaseTx: *tx.NewBaseTx(tx.TypeUNLModify, "")}
+		return &UNLModify{BaseTx: *tx.NewBaseTx(tx.TypeUNLModify, protocol.ZeroAccount)}
 	})
 }

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -93,26 +93,22 @@ func (s *SetFee) PreclaimPseudo(rules *amendment.Rules) tx.Result {
 	xrpFees := rules != nil && rules.XRPFeesEnabled()
 
 	if xrpFees {
-		// Modern triple required when XRPFees is enabled.
 		if s.BaseFeeDrops == "" || s.ReserveBaseDrops == "" || s.ReserveIncrementDrops == "" {
 			return tx.TemMALFORMED
 		}
-		// Legacy quad forbidden.
 		if s.hasLegacyFields() {
 			return tx.TemMALFORMED
 		}
 	} else {
-		// Legacy quad required when XRPFees is disabled.
 		if s.BaseFee == "" || s.ReferenceFeeUnits == nil || s.ReserveBase == nil || s.ReserveIncrement == nil {
 			return tx.TemMALFORMED
 		}
-		// Modern triple forbidden — rippled returns temDISABLED here.
+		// rippled returns temDISABLED — not temMALFORMED — when modern fields appear pre-XRPFees.
 		if s.hasModernFields() {
 			return tx.TemDISABLED
 		}
 	}
 
-	// Reject any unparseable numeric string before Apply touches state.
 	if _, err := s.parseFields(); err != nil {
 		return tx.TemMALFORMED
 	}
@@ -130,8 +126,6 @@ func (s *SetFee) hasModernFields() bool {
 		s.ReserveIncrementDrops != ""
 }
 
-// parsedFeeFields holds the already-validated numeric values for the
-// optional string-typed fee fields.
 type parsedFeeFields struct {
 	baseFee               uint64
 	baseFeeDrops          uint64
@@ -139,8 +133,7 @@ type parsedFeeFields struct {
 	reserveIncrementDrops uint64
 }
 
-// parseFields decodes every present string-typed field. An error here is
-// always temMALFORMED — preclaim and Apply both rely on this.
+// An error here is always temMALFORMED — preclaim and Apply both rely on this.
 func (s *SetFee) parseFields() (parsedFeeFields, error) {
 	var out parsedFeeFields
 	if s.BaseFee != "" {

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // SetFee errors matching rippled
@@ -49,14 +50,16 @@ type SetFee struct {
 
 	// LedgerSequence is the ledger sequence for this fee change
 	LedgerSequence *uint32 `json:"LedgerSequence,omitempty" xrpl:"LedgerSequence,omitempty"`
+
+	// parsedCache memoises parseFields across Validate / PreclaimPseudo / Apply.
+	parsedCache *parsedFeeFields `json:"-" xrpl:"-"`
 }
 
 // NewSetFee creates a new SetFee pseudo-transaction.
 // This should only be used by consensus/validation code.
 func NewSetFee() *SetFee {
-	// SetFee has empty account (zero account in rippled)
 	return &SetFee{
-		BaseTx: *tx.NewBaseTx(tx.TypeFee, ""),
+		BaseTx: *tx.NewBaseTx(tx.TypeFee, protocol.ZeroAccount),
 	}
 }
 
@@ -67,20 +70,15 @@ func (s *SetFee) TxType() tx.Type {
 // Validate runs the local syntactic checks that don't need ledger Rules.
 // The engine's applyPseudoTransaction enforces the zero-account / zero-fee /
 // zero-sequence / no-signature gates from rippled Change::preflight (Change.cpp:36-80);
-// per-amendment field-set gating lives in PreclaimPseudo.
+// per-amendment field-set gating lives in PreclaimPseudo. Validate is reached
+// only by non-engine callers (parse.go, unit tests).
 func (s *SetFee) Validate() error {
-	// At least one fee field set must be present; an empty SetFee is malformed
-	// regardless of which amendments are enabled.
 	if !s.hasLegacyFields() && !s.hasModernFields() {
 		return ErrSetFeeMalformed
 	}
-
-	// Reject obviously malformed string values up front so consumers that
-	// route through Validate() (parse.go, unit tests) get the right code.
-	if _, err := s.parseFields(); err != nil {
+	if _, err := s.parsedOrError(); err != nil {
 		return ErrSetFeeMalformed
 	}
-
 	return nil
 }
 
@@ -109,7 +107,7 @@ func (s *SetFee) PreclaimPseudo(rules *amendment.Rules) tx.Result {
 		}
 	}
 
-	if _, err := s.parseFields(); err != nil {
+	if _, err := s.parsedOrError(); err != nil {
 		return tx.TemMALFORMED
 	}
 
@@ -133,7 +131,21 @@ type parsedFeeFields struct {
 	reserveIncrementDrops uint64
 }
 
-// An error here is always temMALFORMED — preclaim and Apply both rely on this.
+// parsedOrError returns the memoised numeric values, parsing on first call.
+// An error from parseFields is always temMALFORMED — preclaim and Apply both
+// rely on that mapping.
+func (s *SetFee) parsedOrError() (parsedFeeFields, error) {
+	if s.parsedCache != nil {
+		return *s.parsedCache, nil
+	}
+	parsed, err := s.parseFields()
+	if err != nil {
+		return parsed, err
+	}
+	s.parsedCache = &parsed
+	return parsed, nil
+}
+
 func (s *SetFee) parseFields() (parsedFeeFields, error) {
 	var out parsedFeeFields
 	if s.BaseFee != "" {
@@ -188,10 +200,11 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 		"reserveIncrement", s.ReserveIncrement,
 	)
 
-	// PreclaimPseudo has already enforced the field-set rules and validated
-	// numeric strings, but re-parsing here keeps Apply self-contained for the
-	// rare callers that bypass the engine wrapper.
-	parsed, err := s.parseFields()
+	// PreclaimPseudo has already populated parsedCache; this call hits the
+	// cache for engine-path consumers. Apply remains self-contained for the
+	// rare callers that bypass the engine wrapper — they trigger the parse
+	// here on first access.
+	parsed, err := s.parsedOrError()
 	if err != nil {
 		return tx.TemMALFORMED
 	}
@@ -221,14 +234,16 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	xrpFeesEnabled := ctx.Config.Rules != nil && ctx.Config.Rules.XRPFeesEnabled()
 
+	feeSettings.XRPFeesMode = xrpFeesEnabled
+
 	if xrpFeesEnabled {
 		feeSettings.BaseFeeDrops = parsed.baseFeeDrops
 		feeSettings.ReserveBaseDrops = parsed.reserveBaseDrops
 		feeSettings.ReserveIncrementDrops = parsed.reserveIncrementDrops
 
-		// Zeroing legacy fields is the makeFieldAbsent equivalent: state.SerializeFeeSettings
-		// skips every fee field whose value is zero, so the encoded entry omits them.
-		// Reference: rippled Change.cpp:367-371.
+		// Stale legacy fields are dropped from the active mode. Serialize emits
+		// only the modern triple when XRPFeesMode is true, mirroring rippled's
+		// makeFieldAbsent calls at Change.cpp:367-371.
 		feeSettings.BaseFee = 0
 		feeSettings.ReferenceFeeUnits = 0
 		feeSettings.ReserveBase = 0
@@ -244,6 +259,9 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 		if s.ReserveIncrement != nil {
 			feeSettings.ReserveIncrement = *s.ReserveIncrement
 		}
+		feeSettings.BaseFeeDrops = 0
+		feeSettings.ReserveBaseDrops = 0
+		feeSettings.ReserveIncrementDrops = 0
 	}
 
 	data, err := state.SerializeFeeSettings(feeSettings)

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -3,9 +3,9 @@ package pseudo
 import (
 	"errors"
 
-	"github.com/LeJamon/goXRPLd/internal/tx"
-
+	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/keylet"
 )
 
@@ -64,23 +64,114 @@ func (s *SetFee) TxType() tx.Type {
 	return tx.TypeFee
 }
 
-// Reference: rippled Change.cpp preflight()
+// Validate runs the local syntactic checks that don't need ledger Rules.
+// The engine's applyPseudoTransaction enforces the zero-account / zero-fee /
+// zero-sequence / no-signature gates from rippled Change::preflight (Change.cpp:36-80);
+// per-amendment field-set gating lives in PreclaimPseudo.
 func (s *SetFee) Validate() error {
-	// SetFee is a pseudo-transaction - most standard validation is skipped
-	// The engine handles pseudo-transaction specific checks
+	// At least one fee field set must be present; an empty SetFee is malformed
+	// regardless of which amendments are enabled.
+	if !s.hasLegacyFields() && !s.hasModernFields() {
+		return ErrSetFeeMalformed
+	}
 
-	// Check that either legacy or modern fields are present
-	hasLegacy := s.BaseFee != "" || s.ReferenceFeeUnits != nil ||
-		s.ReserveBase != nil || s.ReserveIncrement != nil
-	hasModern := s.BaseFeeDrops != "" || s.ReserveBaseDrops != "" ||
-		s.ReserveIncrementDrops != ""
-
-	// Must have some fee fields
-	if !hasLegacy && !hasModern {
+	// Reject obviously malformed string values up front so consumers that
+	// route through Validate() (parse.go, unit tests) get the right code.
+	if _, err := s.parseFields(); err != nil {
 		return ErrSetFeeMalformed
 	}
 
 	return nil
+}
+
+// PreclaimPseudo enforces the rippled Change::preclaim ttFEE field-set rules:
+// with featureXRPFees enabled, the BaseFeeDrops / ReserveBaseDrops /
+// ReserveIncrementDrops triple is required and the legacy quad is forbidden;
+// without it, the legacy quad is required and the modern triple is forbidden.
+// Reference: rippled Change.cpp:93-133.
+func (s *SetFee) PreclaimPseudo(rules *amendment.Rules) tx.Result {
+	xrpFees := rules != nil && rules.XRPFeesEnabled()
+
+	if xrpFees {
+		// Modern triple required when XRPFees is enabled.
+		if s.BaseFeeDrops == "" || s.ReserveBaseDrops == "" || s.ReserveIncrementDrops == "" {
+			return tx.TemMALFORMED
+		}
+		// Legacy quad forbidden.
+		if s.hasLegacyFields() {
+			return tx.TemMALFORMED
+		}
+	} else {
+		// Legacy quad required when XRPFees is disabled.
+		if s.BaseFee == "" || s.ReferenceFeeUnits == nil || s.ReserveBase == nil || s.ReserveIncrement == nil {
+			return tx.TemMALFORMED
+		}
+		// Modern triple forbidden — rippled returns temDISABLED here.
+		if s.hasModernFields() {
+			return tx.TemDISABLED
+		}
+	}
+
+	// Reject any unparseable numeric string before Apply touches state.
+	if _, err := s.parseFields(); err != nil {
+		return tx.TemMALFORMED
+	}
+
+	return tx.TesSUCCESS
+}
+
+func (s *SetFee) hasLegacyFields() bool {
+	return s.BaseFee != "" || s.ReferenceFeeUnits != nil ||
+		s.ReserveBase != nil || s.ReserveIncrement != nil
+}
+
+func (s *SetFee) hasModernFields() bool {
+	return s.BaseFeeDrops != "" || s.ReserveBaseDrops != "" ||
+		s.ReserveIncrementDrops != ""
+}
+
+// parsedFeeFields holds the already-validated numeric values for the
+// optional string-typed fee fields.
+type parsedFeeFields struct {
+	baseFee               uint64
+	baseFeeDrops          uint64
+	reserveBaseDrops      uint64
+	reserveIncrementDrops uint64
+}
+
+// parseFields decodes every present string-typed field. An error here is
+// always temMALFORMED — preclaim and Apply both rely on this.
+func (s *SetFee) parseFields() (parsedFeeFields, error) {
+	var out parsedFeeFields
+	if s.BaseFee != "" {
+		v, err := parseHexUint64(s.BaseFee)
+		if err != nil {
+			return out, err
+		}
+		out.baseFee = v
+	}
+	if s.BaseFeeDrops != "" {
+		v, err := parseDropsAmount(s.BaseFeeDrops)
+		if err != nil {
+			return out, err
+		}
+		out.baseFeeDrops = v
+	}
+	if s.ReserveBaseDrops != "" {
+		v, err := parseDropsAmount(s.ReserveBaseDrops)
+		if err != nil {
+			return out, err
+		}
+		out.reserveBaseDrops = v
+	}
+	if s.ReserveIncrementDrops != "" {
+		v, err := parseDropsAmount(s.ReserveIncrementDrops)
+		if err != nil {
+			return out, err
+		}
+		out.reserveIncrementDrops = v
+	}
+	return out, nil
 }
 
 func (s *SetFee) Flatten() (map[string]any, error) {
@@ -104,9 +195,16 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 		"reserveIncrement", s.ReserveIncrement,
 	)
 
+	// PreclaimPseudo has already enforced the field-set rules and validated
+	// numeric strings, but re-parsing here keeps Apply self-contained for the
+	// rare callers that bypass the engine wrapper.
+	parsed, err := s.parseFields()
+	if err != nil {
+		return tx.TemMALFORMED
+	}
+
 	feesKey := keylet.Fees()
 
-	// Check if FeeSettings exists
 	exists, err := ctx.View.Exists(feesKey)
 	if err != nil {
 		return tx.TefINTERNAL
@@ -115,7 +213,6 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 	var feeSettings *state.FeeSettings
 
 	if exists {
-		// Read existing FeeSettings
 		data, err := ctx.View.Read(feesKey)
 		if err != nil {
 			return tx.TefINTERNAL
@@ -126,49 +223,25 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 			return tx.TefINTERNAL
 		}
 	} else {
-		// Create new FeeSettings
 		feeSettings = &state.FeeSettings{}
 	}
 
-	// Check if XRPFees amendment is enabled
-	// For early ledgers (before XRPFees), we use legacy format
 	xrpFeesEnabled := ctx.Config.Rules != nil && ctx.Config.Rules.XRPFeesEnabled()
 
 	if xrpFeesEnabled {
-		// Modern format (XRPFees amendment)
-		if s.BaseFeeDrops != "" {
-			drops, err := parseDropsAmount(s.BaseFeeDrops)
-			if err == nil {
-				feeSettings.BaseFeeDrops = drops
-			}
-		}
-		if s.ReserveBaseDrops != "" {
-			drops, err := parseDropsAmount(s.ReserveBaseDrops)
-			if err == nil {
-				feeSettings.ReserveBaseDrops = drops
-			}
-		}
-		if s.ReserveIncrementDrops != "" {
-			drops, err := parseDropsAmount(s.ReserveIncrementDrops)
-			if err == nil {
-				feeSettings.ReserveIncrementDrops = drops
-			}
-		}
+		feeSettings.BaseFeeDrops = parsed.baseFeeDrops
+		feeSettings.ReserveBaseDrops = parsed.reserveBaseDrops
+		feeSettings.ReserveIncrementDrops = parsed.reserveIncrementDrops
 
-		// Clear legacy fields when using modern format
+		// Zeroing legacy fields is the makeFieldAbsent equivalent: state.SerializeFeeSettings
+		// skips every fee field whose value is zero, so the encoded entry omits them.
+		// Reference: rippled Change.cpp:367-371.
 		feeSettings.BaseFee = 0
 		feeSettings.ReferenceFeeUnits = 0
 		feeSettings.ReserveBase = 0
 		feeSettings.ReserveIncrement = 0
 	} else {
-		// Legacy format (pre-XRPFees)
-		if s.BaseFee != "" {
-			// BaseFee is a hex string in legacy format
-			baseFee, err := parseHexUint64(s.BaseFee)
-			if err == nil {
-				feeSettings.BaseFee = baseFee
-			}
-		}
+		feeSettings.BaseFee = parsed.baseFee
 		if s.ReferenceFeeUnits != nil {
 			feeSettings.ReferenceFeeUnits = *s.ReferenceFeeUnits
 		}

--- a/internal/tx/pseudo/unl_modify.go
+++ b/internal/tx/pseudo/unl_modify.go
@@ -27,10 +27,12 @@ func (u *UNLModify) TxType() tx.Type {
 	return tx.TypeUNLModify
 }
 
-// Reference: rippled Change.cpp preflight()
+// Validate is intentionally a no-op for UNLModify. The engine runs the rippled
+// Change::preflight gates (zero account/fee/sequence/signature plus the
+// featureNegativeUNL amendment check) in tx.applyPseudoTransaction before this
+// type-specific path is reached.
+// Reference: rippled Change.cpp:36-80.
 func (u *UNLModify) Validate() error {
-	// Pseudo-transaction: minimal validation
-	// TODO: Check featureNegativeUNL is enabled (requires Rules access in Validate)
 	return nil
 }
 

--- a/internal/tx/pseudo/wire.go
+++ b/internal/tx/pseudo/wire.go
@@ -8,11 +8,6 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx"
 )
 
-// ZeroAccount is the base58-encoded all-zero AccountID used as the
-// source on every XRPL pseudo-transaction (rippled AccountID()). The
-// wire form serializes to a 20-byte zero blob.
-const ZeroAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
-
 // applyPseudoTxDefaults stamps the rippled-default values for the
 // REQUIRED common fields on a pseudo-tx. Mirrors rippled's
 // STTx(TxType, …) constructor at STTx.cpp:113-128, which calls

--- a/internal/tx/pseudo_gates.go
+++ b/internal/tx/pseudo_gates.go
@@ -115,7 +115,6 @@ func (e *Engine) pseudoPreclaim(tx Transaction, rules *amendment.Rules) Result {
 // whitespace all count. Non-decimal input (signs, "0x" prefixes, etc.) is
 // rejected by returning false, which surfaces upstream as temBAD_FEE.
 func isZeroFee(s string) bool {
-	// Strip ASCII whitespace.
 	lo, hi := 0, len(s)
 	for lo < hi && (s[lo] == ' ' || s[lo] == '\t') {
 		lo++

--- a/internal/tx/pseudo_gates.go
+++ b/internal/tx/pseudo_gates.go
@@ -1,11 +1,9 @@
 package tx
 
-import "github.com/LeJamon/goXRPLd/amendment"
-
-// zeroAccountAddress is the base58-encoded XRPL account with all 20 ID bytes set
-// to zero — the only Account value accepted on a pseudo-transaction.
-// Reference: rippled beast::zero compare in Change::preflight.
-const zeroAccountAddress = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+import (
+	"github.com/LeJamon/goXRPLd/amendment"
+	"github.com/LeJamon/goXRPLd/protocol"
+)
 
 // PseudoPreclaim is implemented by pseudo-transaction types that need
 // rule-aware preclaim gating beyond the generic open-ledger check.
@@ -20,17 +18,20 @@ type PseudoPreclaim interface {
 func pseudoPreflight(tx Transaction, rules *amendment.Rules) Result {
 	common := tx.GetCommon()
 
-	// Account must be zero. Both empty (Go-default) and the canonical
-	// zero-address spelling are accepted; any other value is rejected.
+	// Account must be the canonical zero address. Rippled relies on the
+	// tx-format requiring sfAccount to be present and getAccountID(sfAccount)
+	// to decode to AccountID(0). The Go pseudo-tx constructors stamp
+	// protocol.ZeroAccount; anything else here is a caller bug.
 	// Reference: Change.cpp:43-48.
-	if common.Account != "" && common.Account != zeroAccountAddress {
+	if common.Account != protocol.ZeroAccount {
 		return TemBAD_SRC_ACCOUNT
 	}
 
-	// Fee must be zero drops. The Go form is a decimal-drops string, so both
-	// the empty string and "0" map to rippled's beast::zero check.
+	// Fee must decode to zero drops. Compare against the typed value rather
+	// than a literal "0" so encodings like "00" or an absent Fee field map
+	// to the same beast::zero check rippled performs after parse.
 	// Reference: Change.cpp:50-56.
-	if common.Fee != "" && common.Fee != "0" {
+	if !isZeroFee(common.Fee) {
 		return TemBAD_FEE
 	}
 
@@ -40,14 +41,12 @@ func pseudoPreflight(tx Transaction, rules *amendment.Rules) Result {
 		return TemBAD_SIGNATURE
 	}
 
-	// Sequence must be zero and no PreviousTxnID / TicketSequence may be
-	// present (Common has no PreviousTxnID, but TicketSequence is the
-	// goXRPL equivalent guard against sequence-replacing fields).
+	// Sequence must be zero. Rippled also rejects sfPreviousTxnID here, but
+	// goXRPL's Common has no such field. sfTicketSequence is NOT consulted in
+	// Change::preflight — rippled rejects it at the structural tx-format layer
+	// (Transactor::preflight1), so we do not gate on it here either.
 	// Reference: Change.cpp:65-69.
 	if common.Sequence != nil && *common.Sequence != 0 {
-		return TemBAD_SEQUENCE
-	}
-	if common.TicketSequence != nil {
 		return TemBAD_SEQUENCE
 	}
 
@@ -61,15 +60,52 @@ func pseudoPreflight(tx Transaction, rules *amendment.Rules) Result {
 }
 
 // pseudoPreclaim enforces rippled Change::preclaim: pseudo-transactions are
-// only valid against a closed ledger, plus any per-type gating registered via
-// the PseudoPreclaim interface (e.g. SetFee's XRPFees field-set check).
+// only valid against a closed ledger, plus the per-type field-set gates each
+// pseudo type registers via PseudoPreclaim. The default branch returns
+// temUNKNOWN to mirror rippled's Change.cpp:137-139 — a new pseudo type added
+// without a PreclaimPseudo implementation must fail loudly, not silently.
 // Reference: Change.cpp:82-140.
 func (e *Engine) pseudoPreclaim(tx Transaction, rules *amendment.Rules) Result {
 	if e.config.OpenLedger {
 		return TemINVALID
 	}
-	if p, ok := tx.(PseudoPreclaim); ok {
+	switch tx.TxType() {
+	case TypeAmendment, TypeUNLModify:
+		if p, ok := tx.(PseudoPreclaim); ok {
+			return p.PreclaimPseudo(rules)
+		}
+		return TesSUCCESS
+	case TypeFee:
+		p, ok := tx.(PseudoPreclaim)
+		if !ok {
+			return TemUNKNOWN
+		}
 		return p.PreclaimPseudo(rules)
+	default:
+		return TemUNKNOWN
 	}
-	return TesSUCCESS
+}
+
+// isZeroFee reports whether a Common.Fee decimal-drops string decodes to zero.
+// Empty, an explicit "0", any number of leading zeros, and surrounding ASCII
+// whitespace all count. Non-decimal input (signs, "0x" prefixes, etc.) is
+// rejected by returning false, which surfaces upstream as temBAD_FEE.
+func isZeroFee(s string) bool {
+	// Strip ASCII whitespace.
+	lo, hi := 0, len(s)
+	for lo < hi && (s[lo] == ' ' || s[lo] == '\t') {
+		lo++
+	}
+	for hi > lo && (s[hi-1] == ' ' || s[hi-1] == '\t') {
+		hi--
+	}
+	if lo == hi {
+		return true
+	}
+	for i := lo; i < hi; i++ {
+		if s[i] != '0' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/tx/pseudo_gates.go
+++ b/internal/tx/pseudo_gates.go
@@ -1,0 +1,75 @@
+package tx
+
+import "github.com/LeJamon/goXRPLd/amendment"
+
+// zeroAccountAddress is the base58-encoded XRPL account with all 20 ID bytes set
+// to zero — the only Account value accepted on a pseudo-transaction.
+// Reference: rippled beast::zero compare in Change::preflight.
+const zeroAccountAddress = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+
+// PseudoPreclaim is implemented by pseudo-transaction types that need
+// rule-aware preclaim gating beyond the generic open-ledger check.
+// Reference: rippled Change::preclaim per-tx-type switch (Change.cpp:93-139).
+type PseudoPreclaim interface {
+	PreclaimPseudo(rules *amendment.Rules) Result
+}
+
+// pseudoPreflight enforces the gates that rippled's Change::preflight runs on
+// every pseudo-transaction type before dispatching to type-specific logic.
+// Reference: rippled Change.cpp:36-80 (preflight + preflight0).
+func pseudoPreflight(tx Transaction, rules *amendment.Rules) Result {
+	common := tx.GetCommon()
+
+	// Account must be zero. Both empty (Go-default) and the canonical
+	// zero-address spelling are accepted; any other value is rejected.
+	// Reference: Change.cpp:43-48.
+	if common.Account != "" && common.Account != zeroAccountAddress {
+		return TemBAD_SRC_ACCOUNT
+	}
+
+	// Fee must be zero drops. The Go form is a decimal-drops string, so both
+	// the empty string and "0" map to rippled's beast::zero check.
+	// Reference: Change.cpp:50-56.
+	if common.Fee != "" && common.Fee != "0" {
+		return TemBAD_FEE
+	}
+
+	// No signing fields are permitted.
+	// Reference: Change.cpp:58-63.
+	if common.SigningPubKey != "" || common.TxnSignature != "" || len(common.Signers) > 0 {
+		return TemBAD_SIGNATURE
+	}
+
+	// Sequence must be zero and no PreviousTxnID / TicketSequence may be
+	// present (Common has no PreviousTxnID, but TicketSequence is the
+	// goXRPL equivalent guard against sequence-replacing fields).
+	// Reference: Change.cpp:65-69.
+	if common.Sequence != nil && *common.Sequence != 0 {
+		return TemBAD_SEQUENCE
+	}
+	if common.TicketSequence != nil {
+		return TemBAD_SEQUENCE
+	}
+
+	// NegativeUNL amendment must be enabled for UNL_MODIFY pseudo-tx.
+	// Reference: Change.cpp:72-77.
+	if tx.TxType() == TypeUNLModify && (rules == nil || !rules.NegativeUNLEnabled()) {
+		return TemDISABLED
+	}
+
+	return TesSUCCESS
+}
+
+// pseudoPreclaim enforces rippled Change::preclaim: pseudo-transactions are
+// only valid against a closed ledger, plus any per-type gating registered via
+// the PseudoPreclaim interface (e.g. SetFee's XRPFees field-set check).
+// Reference: Change.cpp:82-140.
+func (e *Engine) pseudoPreclaim(tx Transaction, rules *amendment.Rules) Result {
+	if e.config.OpenLedger {
+		return TemINVALID
+	}
+	if p, ok := tx.(PseudoPreclaim); ok {
+		return p.PreclaimPseudo(rules)
+	}
+	return TesSUCCESS
+}

--- a/internal/tx/pseudo_gates.go
+++ b/internal/tx/pseudo_gates.go
@@ -14,9 +14,33 @@ type PseudoPreclaim interface {
 
 // pseudoPreflight enforces the gates that rippled's Change::preflight runs on
 // every pseudo-transaction type before dispatching to type-specific logic.
-// Reference: rippled Change.cpp:36-80 (preflight + preflight0).
-func pseudoPreflight(tx Transaction, rules *amendment.Rules) Result {
+// It also mirrors the two preflight0 guards that fire for pseudo-tx —
+// tfInnerBatchTxn rejection (Transactor.cpp:46-51) and the NetworkID check
+// when sfNetworkID is present (Transactor.cpp:53-75).
+// Reference: rippled Change.cpp:36-80, Transactor.cpp:42-87.
+func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) Result {
 	common := tx.GetCommon()
+
+	// preflight0 inner-batch gate: a pseudo-tx with the tfInnerBatchTxn flag
+	// is structurally invalid because only the batch executor sets that flag.
+	// Reference: Transactor.cpp:46-51.
+	if common.Flags != nil && *common.Flags&TfInnerBatchTxn != 0 {
+		return TemINVALID_FLAG
+	}
+
+	// preflight0 NetworkID gate: rippled checks NetworkID for non-pseudo
+	// always, and for pseudo only when sfNetworkID is present. We are on the
+	// pseudo path, so the check fires only when the field is set; an absent
+	// NetworkID on a pseudo-tx is always legal.
+	// Reference: Transactor.cpp:53-75.
+	if common.NetworkID != nil {
+		if e.config.NetworkID <= LegacyNetworkIDThreshold {
+			return TelNETWORK_ID_MAKES_TX_NON_CANONICAL
+		}
+		if *common.NetworkID != e.config.NetworkID {
+			return TelWRONG_NETWORK
+		}
+	}
 
 	// Account must be the canonical zero address. Rippled relies on the
 	// tx-format requiring sfAccount to be present and getAccountID(sfAccount)

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -28,3 +28,9 @@ const (
 // Ripple-Epoch seconds, the on-the-wire format rippled stamps onto
 // network-time fields.
 const RippleEpochUnix int64 = 946684800
+
+// ZeroAccount is the base58-encoded all-zero AccountID. It is the only
+// Account value rippled accepts on a pseudo-transaction (Change::preflight,
+// rippled/src/xrpld/app/tx/detail/Change.cpp:43-48) and serializes to a
+// 20-byte zero blob on the wire.
+const ZeroAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"

--- a/tasks/conformance-audit.md
+++ b/tasks/conformance-audit.md
@@ -143,3 +143,28 @@ incremental reviews instead of re-reading rippled from scratch.
 - Cleanup commit: 151f3a1 — chore: clean ai-generated comments (1 paraphrase preamble stripped from randomEd25519KeyPair; all rippled-conformance citations and non-obvious whys preserved)
 - Fix commit: 5a1e267 — test(#503): close conformance-review M1, M2; reword N1 Seed cite. Adds TestManifest_Secp256k1MasterSig_HighS_Rejected (secp256k1 master + ed25519 ephemeral; flips master sig S→N-S; asserts Verify rejects), three boundary cases in TestEd25519Canonical (S=L-1 verifies; S=L and S=L+1 reject), and a corrected Seed.cpp cite. New tests verified locally: PASS.
 - Notes: Tight conformance PR closing the four #503 audit gaps (manifest strict canonicality, ed25519 canonicality gate visibility, KeyType enum reordering, ed25519 secure_erase). Zero blockers — all four claimed fixes are correctly anchored to rippled. All review findings (M1 + M2 + N1) addressed in-PR per project rule against follow-up punts.
+
+## 2026-05-22 — PR #520 (incremental) — fix/issue-500-pseudo-tx-preflight
+- Rippled SHA at review: 1e89286a92
+- PR URL: https://github.com/LeJamon/go-xrpl/pull/520
+- Review comment: https://github.com/LeJamon/go-xrpl/pull/520#issuecomment-4519655917
+- Prior audit: this PR was audited earlier today (entry above); this is an incremental re-audit covering the two new commits that followed the prior cleanup.
+- Commits reviewed (over base 368aed98):
+  - ecaaac46 — fix(pseudo-tx): address conformance-review minors + nits (the seven follow-ups from the prior audit)
+  - 735319cc — fix(pseudo-tx): port preflight0 tfInnerBatchTxn + NetworkID gates (closes the prior audit's flagged out-of-scope item)
+- Files reviewed (Phase 1, incremental):
+  - amendment/rules.go — 0 findings (NegativeUNLEnabled wrapper, matches local pattern)
+  - protocol/constants.go — 0 findings (ZeroAccount lifted to single source of truth, cited rippled Change.cpp:43-48)
+  - internal/consensus/{amendmentvote,feevote,negativeunlvote}/vote.go — 0 findings (each constructor reroutes through protocol.ZeroAccount; 3-line touches)
+  - internal/ledger/state/fee_settings.go — 0 findings (XRPFeesMode flag + always-emit-active-mode serialization mirrors Change.cpp:362-379 set()/makeFieldAbsent())
+  - internal/tx/apply.go — 0 findings (pseudoPreflight + pseudoPreclaim wired before tx-hash + state-table per Change.cpp:36-140)
+  - internal/tx/pseudo/setfee.go — 0 findings (PreclaimPseudo per Change.cpp:93-133; parsedCache memoisation safe under single-threaded engine contract)
+  - internal/tx/pseudo/unl_modify.go — 0 findings (Validate is now a no-op; gating moved to engine)
+  - internal/tx/pseudo/wire.go — 0 findings (pseudo.ZeroAccount duplicate deleted)
+  - internal/tx/pseudo/register.go — 0 findings (constructors reference protocol.ZeroAccount)
+  - internal/tx/pseudo_gates.go — 3 Nit (lingering literal "rrrrrrrrrrrrrrrrrrrrrhoLvTp" at four non-pseudo sites; isZeroFee whitespace permissiveness vs rippled STAmount JSON parse; pseudoPreclaim asymmetry comment-gap), 0 Minor, 0 Blocking
+  - internal/testing/env_submission.go — 0 findings (SubmitPseudo now always closed-ledger, mirrors Change.cpp:82-91)
+  - internal/testing/pseudotx/*_test.go — 0 findings (test assertions reflect new gate behaviour: empty Account, zero-fee spellings, tfInnerBatchTxn, NetworkID legacy/wrong/absent-legal)
+- Files cleanup-only (Phase 0 skipped Phase 1): none
+- Cleanup commit: 47f442c0 — chore: clean ai-generated comments (1 paraphrase line stripped from isZeroFee; all rippled cites and non-obvious whys preserved)
+- Notes: Zero blockers and zero minors across the incremental work — all seven prior-audit follow-ups are correctly anchored to rippled, and the new tfInnerBatchTxn + NetworkID gates byte-match Transactor.cpp:46-75. The three nits are advisory: lingering ZeroAccount literals exist only at non-pseudo-tx sites (payment.go path-element XRP detection, conformance/runner.go); isZeroFee is strictly more permissive than rippled at a Go-API boundary rippled never reaches; pseudoPreclaim's structural asymmetry between ttFEE and ttAMENDMENT/ttUNL_MODIFY would benefit from a one-line comment. None gate merge.

--- a/tasks/conformance-audit.md
+++ b/tasks/conformance-audit.md
@@ -98,3 +98,17 @@ incremental reviews instead of re-reading rippled from scratch.
   - PR body rewritten to cover ledger_entry surface and the deliberate follow-up of tightening state.GetCurrencyBytes to match rippled's strict to_currency
 - Cleanup commit: 1051724 — chore: clean ai-generated comments (4 paraphrasers stripped; all rippled-conformance docstrings preserved)
 - Notes: Strict-vs-loose currencyToBytes consolidation deliberately chose to mirror state.GetCurrencyBytes (loose) rather than the rippled-strict version in keylet/keylet.go::currencyToBytes used by keylet.Line. Switching to strict would require tightening AMMCreate preflight to reject non-ISO 3-char input — a deliberate follow-up.
+
+## 2026-05-22 — PR #520 — fix/issue-500-pseudo-tx-preflight
+- Rippled SHA at review: 1e89286a92
+- PR URL: https://github.com/LeJamon/go-xrpl/pull/520
+- Review comment: skipped at user request (review captured locally in $CLAUDE_JOB_DIR/conformance-review.md only)
+- Files reviewed (Phase 1):
+  - amendment/rules.go — 0 findings (new NegativeUNLEnabled wrapper, matches existing pattern)
+  - internal/tx/apply.go — 0 findings (pseudoPreflight + pseudoPreclaim gates wired before tx-hash + state-table)
+  - internal/tx/pseudo/setfee.go — 2 Minor + 2 Nit (zero-fee-field silently dropped vs makeFieldAbsent; triple-parse of fields), 0 blocking
+  - internal/tx/pseudo/unl_modify.go — 0 findings (no-op Validate, gating moved to engine)
+  - internal/tx/pseudo_gates.go — 2 Minor + 1 Nit (TicketSequence vs PreviousTxnID divergence; empty-Account accepted; zeroAccountAddress duplicated with pseudo.ZeroAccount; missing temUNKNOWN default in pseudoPreclaim), 0 blocking
+- Files cleanup-only (Phase 0 skipped Phase 1): none (tests and env_submission.go reviewed for assertion correctness; not gated on style)
+- Not in diff but flagged: preflight0's tfInnerBatchTxn and NetworkID checks (Transactor.cpp:46-75) not ported — out of scope for this PR but worth tracking
+- Cleanup commit: 368aed98 — chore: clean ai-generated comments (3 paraphrasers stripped from setfee.go; all rippled-conformance docstrings preserved)


### PR DESCRIPTION
## Summary
- Engine `applyPseudoTransaction` now runs the rippled `Change::preflight` gates (zero account / zero fee / no signing fields / zero sequence / no ticket) and the `Change::preclaim` open-ledger guard before hash compute, so malformed or out-of-context pseudo-tx fail with the right `tem*` code instead of being silently accepted or surfacing as `tefINTERNAL` from serialization.
- `UNLModify` is gated on the `NegativeUNL` amendment at the engine level (removes the long-standing `TODO` in `unl_modify.go`).
- `SetFee` gets a `PreclaimPseudo(rules)` implementation that enforces the XRPFees field-set rules from `Change.cpp:93-133` (required modern triple + forbidden legacy quad when XRPFees is on; required legacy quad + forbidden modern triple when off) and propagates parse errors as `temMALFORMED`.
- `TestEnv.SubmitPseudo` always runs against a closed ledger now, matching the consensus path that produces pseudo-tx.

## Test plan
- [x] `go test ./internal/testing/pseudotx/...` (existing + new gate coverage)
- [x] `go test ./internal/tx/...`
- [x] `go test ./internal/consensus/... ./internal/txq/... ./internal/ledger/...`
- [x] Wider `go test ./internal/testing/...` — only pre-existing MPT failures (`TestMPT_Payment/SimplePayment`, `TestMPT_Clawback/BasicClawback`, etc.) remain; they reproduce on `main` and are unrelated to this change.

Fixes #500