### PR TITLE
feat: port rippled LoadFeeTrack for load-scaled fees

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -258,14 +258,18 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	// drive the admin-only human-mode load_factor_local / load_factor_net /
 	// load_factor_cluster emissions (NetworkOPs.cpp:2887-2901). Net here
 	// mirrors rippled's "remote" axis — LoadFeeTrack stores it under
-	// remoteFee_.
-	if ft := ledgerSvcRef.FeeTrack(); ft != nil {
-		services.LoadFactorFees = func() types.LoadFactorFees {
-			return types.LoadFactorFees{
-				Local:   ft.GetLocalFee(),
-				Net:     ft.GetRemoteFee(),
-				Cluster: ft.GetClusterFee(),
-			}
+	// remoteFee_. The closure re-reads on every server_info call so the
+	// hook tracks live tracker state without rewiring.
+	services.LoadFactorFees = func() types.LoadFactorFees {
+		ft := ledgerSvcRef.FeeTrack()
+		if ft == nil {
+			base := uint32(256)
+			return types.LoadFactorFees{Local: base, Net: base, Cluster: base}
+		}
+		return types.LoadFactorFees{
+			Local:   ft.GetLocalFee(),
+			Net:     ft.GetRemoteFee(),
+			Cluster: ft.GetClusterFee(),
 		}
 	}
 
@@ -357,6 +361,15 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		// config flag doesn't require a restart-and-rewire.
 		overlay.SetTxProvider(ledgerService.OpenLedgerGetTx)
 		overlay.SetOpenLedgerHashesProvider(ledgerService.OpenLedgerTxHashes)
+
+		// LoadFeeTrack ingress + outbound self-load advertisement.
+		// Mirrors the rippled wiring split:
+		//   - PeerImp.cpp:1193 setClusterFee(median) on inbound TMCluster
+		//   - NetworkOPs.cpp:1126-1132 self-entry sources getLocalFee()
+		if ft := ledgerSvcRef.FeeTrack(); ft != nil {
+			overlay.SetClusterFeeSink(ft.SetClusterFee)
+			overlay.SetLocalLoadFeeProvider(ft.GetLocalFee)
+		}
 
 		// Expose node identity and consensus stats to RPC handlers.
 		services.NodePublicKey = consensusComponents.Overlay.Identity().EncodedPublicKey()

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -254,6 +254,21 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		}
 	}
 
+	// LoadFactorFees surfaces the local/net/cluster fee factors that
+	// drive the admin-only human-mode load_factor_local / load_factor_net /
+	// load_factor_cluster emissions (NetworkOPs.cpp:2887-2901). Net here
+	// mirrors rippled's "remote" axis — LoadFeeTrack stores it under
+	// remoteFee_.
+	if ft := ledgerSvcRef.FeeTrack(); ft != nil {
+		services.LoadFactorFees = func() types.LoadFactorFees {
+			return types.LoadFactorFees{
+				Local:   ft.GetLocalFee(),
+				Net:     ft.GetRemoteFee(),
+				Cluster: ft.GetClusterFee(),
+			}
+		}
+	}
+
 	// Start consensus/networking if not in standalone mode
 	if !standalone {
 		var compErr error

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1224,12 +1224,23 @@ func (a *Adaptor) GetServerVersion() uint64 {
 // Zero stance values mean "no vote" and the serializer will omit the
 // fields.
 // GetLoadFee returns the local load_fee advertised on outbound
-// validations. Today we have no feedback loop so we always return 0
-// — the serializer treats that as "omit", matching rippled's
-// behavior on a validator with minimum load. Future work can wire
-// this to a LoadFeeTrack-equivalent.
+// validations. Sources the value from the local LoadFeeTrack — under
+// no load the tracker returns LoadBase, which the serializer treats as
+// "omit" once normalised (matches rippled NetworkOPs.cpp:1130 which
+// emits localFee on validations).
 func (a *Adaptor) GetLoadFee() uint32 {
-	return 0
+	if a.ledgerService == nil {
+		return 0
+	}
+	ft := a.ledgerService.FeeTrack()
+	if ft == nil {
+		return 0
+	}
+	fee := ft.GetLocalFee()
+	if fee == ft.GetLoadBase() {
+		return 0
+	}
+	return fee
 }
 
 func (a *Adaptor) GetFeeVote() (baseFee, reserveBase, reserveIncrement uint64, postXRPFees bool) {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1224,10 +1224,14 @@ func (a *Adaptor) GetServerVersion() uint64 {
 // Zero stance values mean "no vote" and the serializer will omit the
 // fields.
 // GetLoadFee returns the local load_fee advertised on outbound
-// validations. Sources the value from the local LoadFeeTrack — under
-// no load the tracker returns LoadBase, which the serializer treats as
-// "omit" once normalised (matches rippled NetworkOPs.cpp:1130 which
-// emits localFee on validations).
+// validations. Mirrors rippled RCLConsensus.cpp:870-875:
+//
+//	auto const fee = std::max(ft.getLocalFee(), ft.getClusterFee());
+//	if (fee > ft.getLoadBase()) v.setFieldU32(sfLoadFee, fee);
+//
+// We return 0 — which the serializer treats as "omit" — whenever the
+// max collapses to LoadBase, equivalent to rippled's `> getLoadBase()`
+// gate (the local/cluster floors prevent values below LoadBase).
 func (a *Adaptor) GetLoadFee() uint32 {
 	if a.ledgerService == nil {
 		return 0
@@ -1237,7 +1241,10 @@ func (a *Adaptor) GetLoadFee() uint32 {
 		return 0
 	}
 	fee := ft.GetLocalFee()
-	if fee == ft.GetLoadBase() {
+	if c := ft.GetClusterFee(); c > fee {
+		fee = c
+	}
+	if fee <= ft.GetLoadBase() {
 		return 0
 	}
 	return fee
@@ -1616,14 +1623,61 @@ func (a *Adaptor) peerLCLDisagrees(ourLCL consensus.LedgerID) bool {
 // validated_ledger only if our stored ledger at that seq has the matching
 // hash — fork safety, matching rippled's checkAccept which operates on
 // the specific ledger pointer, not seq alone.
+//
+// After marking validated, we also refresh the LoadFeeTrack remoteFee
+// from the median LoadFee across trusted validations for this ledger.
+// Mirrors rippled LedgerMaster::checkAccept (LedgerMaster.cpp:977-1006):
+// collect sfLoadFee from trusted validations (defaulting to LoadBase
+// when omitted), take the median, and call setRemoteFee. Validations
+// for the parent hash are also folded in by rippled; goXRPL keys
+// validations by the attested LedgerID, so we collect for the current
+// hash only — the median converges identically once a few ledgers'
+// worth of validations accumulate.
 func (a *Adaptor) OnLedgerFullyValidated(ledgerID consensus.LedgerID, seq uint32) {
 	var hash [32]byte
 	copy(hash[:], ledgerID[:])
 	a.ledgerService.SetValidatedLedger(seq, hash)
+	a.refreshRemoteFee(ledgerID)
 	a.logger.Info("Ledger fully validated",
 		"seq", seq,
 		"hash", fmt.Sprintf("%x", hash[:8]),
 	)
+}
+
+// refreshRemoteFee mirrors rippled LedgerMaster::checkAccept's
+// post-validation block (LedgerMaster.cpp:977-1006). For each trusted
+// validation, the sfLoadFee value is taken (defaulting to LoadBase when
+// the validator omitted the field, matching rippled validations.fees's
+// substitution). The median is then forwarded to LoadFeeTrack.
+func (a *Adaptor) refreshRemoteFee(ledgerID consensus.LedgerID) {
+	if a.ledgerService == nil || a.validationHistorian == nil {
+		return
+	}
+	ft := a.ledgerService.FeeTrack()
+	if ft == nil {
+		return
+	}
+	vals := a.validationHistorian.GetTrustedValidations(ledgerID)
+	if len(vals) == 0 {
+		return
+	}
+	base := ft.GetLoadBase()
+	fees := make([]uint32, 0, len(vals))
+	for _, v := range vals {
+		if v == nil {
+			continue
+		}
+		fee := v.LoadFee
+		if fee == 0 {
+			fee = base
+		}
+		fees = append(fees, fee)
+	}
+	if len(fees) == 0 {
+		return
+	}
+	sort.Slice(fees, func(i, j int) bool { return fees[i] < fees[j] })
+	ft.SetRemoteFee(fees[len(fees)/2])
 }
 
 func (a *Adaptor) OnModeChange(oldMode, newMode consensus.Mode) {

--- a/internal/consensus/adaptor/refresh_remote_fee_test.go
+++ b/internal/consensus/adaptor/refresh_remote_fee_test.go
@@ -1,0 +1,98 @@
+package adaptor
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/feetrack"
+)
+
+// TestRefreshRemoteFee_MedianOverTrustedValidations pins the
+// LedgerMaster.cpp:977-1006 port: collect LoadFee from trusted
+// validations (substituting LoadBase for any that omitted the field),
+// sort, and forward the median to FeeTrack.SetRemoteFee.
+func TestRefreshRemoteFee_MedianOverTrustedValidations(t *testing.T) {
+	a := newTestAdaptor(t)
+	ft := a.ledgerService.FeeTrack()
+	if ft == nil {
+		t.Fatal("FeeTrack must be non-nil from service.New")
+	}
+
+	id := consensus.LedgerID{0xAA}
+	a.SetValidationHistorian(&stubHistorian{
+		byLedger: map[consensus.LedgerID][]*consensus.Validation{
+			id: {
+				{LoadFee: 320},
+				{LoadFee: 0}, // omitted → substituted with LoadBase=256
+				{LoadFee: 500},
+			},
+		},
+	})
+
+	a.refreshRemoteFee(id)
+
+	// Sorted set: {256, 320, 500}; middle = 320.
+	if got := ft.GetRemoteFee(); got != 320 {
+		t.Fatalf("RemoteFee = %d; want 320", got)
+	}
+}
+
+// TestRefreshRemoteFee_NoHistorian no-ops without crashing when the
+// historian isn't wired (early-startup, unit-test paths).
+func TestRefreshRemoteFee_NoHistorian(t *testing.T) {
+	a := newTestAdaptor(t)
+	ft := a.ledgerService.FeeTrack()
+	if ft == nil {
+		t.Fatal("FeeTrack must be non-nil")
+	}
+	before := ft.GetRemoteFee()
+	a.refreshRemoteFee(consensus.LedgerID{0xBB})
+	if got := ft.GetRemoteFee(); got != before {
+		t.Fatalf("RemoteFee changed without historian: before=%d after=%d", before, got)
+	}
+}
+
+// TestRefreshRemoteFee_EmptyValidations leaves the remote fee untouched
+// when the historian has no validations for the ledger — matches the
+// "no signal → no change" pattern (rippled also short-circuits when
+// fees is empty by falling through to base, but the median we'd compute
+// over a single base-only sample is meaningless).
+func TestRefreshRemoteFee_EmptyValidations(t *testing.T) {
+	a := newTestAdaptor(t)
+	ft := a.ledgerService.FeeTrack()
+	ft.SetRemoteFee(777)
+	a.SetValidationHistorian(&stubHistorian{
+		byLedger: map[consensus.LedgerID][]*consensus.Validation{},
+	})
+	a.refreshRemoteFee(consensus.LedgerID{0xCC})
+	if got := ft.GetRemoteFee(); got != 777 {
+		t.Fatalf("RemoteFee mutated on empty validations: got %d, want 777", got)
+	}
+}
+
+// TestGetLoadFee_MaxLocalCluster pins RCLConsensus.cpp:872 port: the
+// validation-side load fee takes max(local, cluster), and emits 0
+// (= "omit") when the max collapses to LoadBase.
+func TestGetLoadFee_MaxLocalCluster(t *testing.T) {
+	a := newTestAdaptor(t)
+	ft := a.ledgerService.FeeTrack()
+
+	// Default state: both at LoadBase → omit (0).
+	if got := a.GetLoadFee(); got != 0 {
+		t.Fatalf("default GetLoadFee = %d; want 0", got)
+	}
+
+	// Cluster > local → returned value is the cluster fee.
+	ft.SetClusterFee(feetrack.LoadBase * 3)
+	if got := a.GetLoadFee(); got != feetrack.LoadBase*3 {
+		t.Fatalf("cluster-dominated GetLoadFee = %d; want %d", got, feetrack.LoadBase*3)
+	}
+
+	// Local > cluster → returned value is the local fee.
+	ft.SetClusterFee(feetrack.LoadBase)
+	ft.RaiseLocalFee() // raise latch
+	ft.RaiseLocalFee() // local = 320
+	if got := a.GetLoadFee(); got != ft.GetLocalFee() {
+		t.Fatalf("local-dominated GetLoadFee = %d; want %d", got, ft.GetLocalFee())
+	}
+}

--- a/internal/feetrack/feetrack.go
+++ b/internal/feetrack/feetrack.go
@@ -1,0 +1,213 @@
+// Package feetrack implements the local-node load-fee tracker.
+//
+// Mirrors rippled's LoadFeeTrack (src/xrpld/app/misc/LoadFeeTrack.h /
+// LoadFeeTrack.cpp): the local server raises its load fee under
+// sustained job-queue overload, then decays it back to the normal
+// reference fee as the queue drains. Remote and cluster fees are set by
+// peers and the cluster announcement path. ScaleFeeLoad applies the
+// resulting factor at every fee-quoting boundary.
+package feetrack
+
+import (
+	"errors"
+	"math/big"
+	"sync"
+)
+
+// Reference constants from rippled LoadFeeTrack.h:141-147.
+const (
+	// LoadBase is the normal/minimum load factor. All load_factor_*
+	// values are expressed as multiples of this base.
+	LoadBase uint32 = 256
+
+	// FeeIncFraction controls how fast localTxnLoadFee_ ramps up
+	// when raiseLocalFee is called: fee += fee / FeeIncFraction.
+	FeeIncFraction uint32 = 4
+
+	// FeeDecFraction controls the decay step when lowerLocalFee runs:
+	// fee -= fee / FeeDecFraction. Symmetric with FeeIncFraction.
+	FeeDecFraction uint32 = 4
+
+	// FeeMax caps the local fee at LoadBase * 1_000_000, matching
+	// rippled lftFeeMax (LoadFeeTrack.h:147).
+	FeeMax uint32 = 256 * 1_000_000
+)
+
+// ErrOverflow indicates ScaleFeeLoad multiplication overflowed uint64.
+// Mirrors rippled's Throw<std::overflow_error>("scaleFeeLoad") path.
+var ErrOverflow = errors.New("feetrack: scaleFeeLoad overflow")
+
+// LoadFeeTrack tracks the local-node fee factor and accepts remote /
+// cluster reports. Safe for concurrent access.
+type LoadFeeTrack struct {
+	mu         sync.RWMutex
+	localFee   uint32
+	remoteFee  uint32
+	clusterFee uint32
+	raiseCount uint32
+}
+
+// New returns a LoadFeeTrack initialised to the normal fee with no
+// pending raises. Matches the rippled constructor at
+// LoadFeeTrack.h:47-55.
+func New() *LoadFeeTrack {
+	return &LoadFeeTrack{
+		localFee:   LoadBase,
+		remoteFee:  LoadBase,
+		clusterFee: LoadBase,
+	}
+}
+
+// SetRemoteFee records a remote-reported fee factor, mirroring
+// LoadFeeTrack::setRemoteFee.
+func (t *LoadFeeTrack) SetRemoteFee(f uint32) {
+	t.mu.Lock()
+	t.remoteFee = f
+	t.mu.Unlock()
+}
+
+// GetRemoteFee returns the last remote-reported fee factor.
+func (t *LoadFeeTrack) GetRemoteFee() uint32 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.remoteFee
+}
+
+// SetClusterFee records the cluster-aggregated fee factor.
+func (t *LoadFeeTrack) SetClusterFee(f uint32) {
+	t.mu.Lock()
+	t.clusterFee = f
+	t.mu.Unlock()
+}
+
+// GetClusterFee returns the last cluster-reported fee factor.
+func (t *LoadFeeTrack) GetClusterFee() uint32 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.clusterFee
+}
+
+// GetLocalFee returns the current local load factor.
+func (t *LoadFeeTrack) GetLocalFee() uint32 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.localFee
+}
+
+// GetLoadBase returns the reference (normal) fee factor.
+func (t *LoadFeeTrack) GetLoadBase() uint32 { return LoadBase }
+
+// GetLoadFactor returns max(cluster, local, remote), mirroring
+// LoadFeeTrack::getLoadFactor (LoadFeeTrack.h:94-100).
+func (t *LoadFeeTrack) GetLoadFactor() uint32 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return maxU32(t.clusterFee, maxU32(t.localFee, t.remoteFee))
+}
+
+// GetScalingFactors returns (max(local,remote), max(remote,cluster)),
+// the pair consumed by ScaleFeeLoad. Mirrors LoadFeeTrack::getScalingFactors
+// (LoadFeeTrack.h:102-110).
+func (t *LoadFeeTrack) GetScalingFactors() (feeFactor, remFee uint32) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return maxU32(t.localFee, t.remoteFee), maxU32(t.remoteFee, t.clusterFee)
+}
+
+// IsLoadedLocal reports whether the local node is currently inflating
+// its fee. Mirrors LoadFeeTrack::isLoadedLocal.
+func (t *LoadFeeTrack) IsLoadedLocal() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.raiseCount != 0 || t.localFee != LoadBase
+}
+
+// IsLoadedCluster reports whether either the local node or the cluster
+// is inflating its fee. Mirrors LoadFeeTrack::isLoadedCluster.
+func (t *LoadFeeTrack) IsLoadedCluster() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.raiseCount != 0 || t.localFee != LoadBase || t.clusterFee != LoadBase
+}
+
+// RaiseLocalFee bumps the local fee factor. Returns true when the
+// stored factor actually changed. Mirrors LoadFeeTrack::raiseLocalFee
+// (LoadFeeTrack.cpp:33-58): the first call only increments raiseCount,
+// the second and subsequent calls actually scale localTxnLoadFee_ up
+// (toward FeeMax), tracking the remote fee floor.
+func (t *LoadFeeTrack) RaiseLocalFee() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.raiseCount++
+	if t.raiseCount < 2 {
+		return false
+	}
+
+	orig := t.localFee
+	if t.localFee < t.remoteFee {
+		t.localFee = t.remoteFee
+	}
+	t.localFee += t.localFee / FeeIncFraction
+	if t.localFee > FeeMax {
+		t.localFee = FeeMax
+	}
+	return orig != t.localFee
+}
+
+// LowerLocalFee decays the local fee back toward LoadBase. Returns true
+// when the stored factor actually changed. Mirrors
+// LoadFeeTrack::lowerLocalFee (LoadFeeTrack.cpp:60-79). Clears the
+// raiseCount latch so the next RaiseLocalFee requires two ticks to
+// take effect — same hysteresis as rippled.
+func (t *LoadFeeTrack) LowerLocalFee() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	orig := t.localFee
+	t.raiseCount = 0
+	t.localFee -= t.localFee / FeeDecFraction
+	if t.localFee < LoadBase {
+		t.localFee = LoadBase
+	}
+	return orig != t.localFee
+}
+
+// ScaleFeeLoad scales fee by the current local/remote/cluster load,
+// mirroring rippled's free function scaleFeeLoad in
+// LoadFeeTrack.cpp:85-111.
+//
+// When unlimited is true and local-only load is moderate (less than 4x
+// the remote fee), the privileged caller pays the remote-rate factor
+// instead of the local one — matching rippled's bUnlimited branch.
+// Local load above 4x remote still applies in full.
+//
+// fee == 0 short-circuits to 0 to match rippled. Overflow surfaces as
+// ErrOverflow.
+func ScaleFeeLoad(fee uint64, t *LoadFeeTrack, unlimited bool) (uint64, error) {
+	if fee == 0 {
+		return 0, nil
+	}
+	if t == nil {
+		return fee, nil
+	}
+	feeFactor, remFee := t.GetScalingFactors()
+	if unlimited && feeFactor > remFee && feeFactor < 4*remFee {
+		feeFactor = remFee
+	}
+
+	// fee * feeFactor / LoadBase, computed in big.Int to match
+	// rippled's checked mulDiv (no overflow, exact integer division
+	// truncation).
+	num := new(big.Int).Mul(new(big.Int).SetUint64(fee), new(big.Int).SetUint64(uint64(feeFactor)))
+	num.Quo(num, new(big.Int).SetUint64(uint64(LoadBase)))
+	if !num.IsUint64() {
+		return 0, ErrOverflow
+	}
+	return num.Uint64(), nil
+}
+
+func maxU32(a, b uint32) uint32 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/feetrack/feetrack_test.go
+++ b/internal/feetrack/feetrack_test.go
@@ -1,0 +1,153 @@
+package feetrack
+
+import (
+	"testing"
+)
+
+// TestScaleFeeLoad_Identity mirrors rippled LoadFeeTrack_test.cpp: with
+// a fresh tracker the factor is LoadBase, so scaleFeeLoad returns the
+// input fee unchanged (including the 0 short-circuit and 1-drop
+// identity).
+func TestScaleFeeLoad_Identity(t *testing.T) {
+	tr := New()
+	cases := []uint64{0, 1, 10, 10000, 1<<32 + 7}
+	for _, fee := range cases {
+		got, err := ScaleFeeLoad(fee, tr, false)
+		if err != nil {
+			t.Fatalf("ScaleFeeLoad(%d) err: %v", fee, err)
+		}
+		if got != fee {
+			t.Fatalf("ScaleFeeLoad(%d) = %d; want identity", fee, got)
+		}
+	}
+}
+
+// TestScaleFeeLoad_NilTracker keeps fee handling safe when no tracker
+// is wired (services starting up, simulate paths during construction).
+func TestScaleFeeLoad_NilTracker(t *testing.T) {
+	got, err := ScaleFeeLoad(123, nil, false)
+	if err != nil || got != 123 {
+		t.Fatalf("nil tracker = (%d,%v); want (123,nil)", got, err)
+	}
+}
+
+// TestRaiseLowerLocalFee pins the rippled hysteresis: the first raise
+// only arms raiseCount, the second actually bumps the factor; lower
+// decays slowly back to LoadBase and clears raiseCount.
+func TestRaiseLowerLocalFee(t *testing.T) {
+	tr := New()
+	if changed := tr.RaiseLocalFee(); changed {
+		t.Fatal("first raise must not change fee yet (raiseCount latch)")
+	}
+	if tr.GetLocalFee() != LoadBase {
+		t.Fatalf("local fee after first raise = %d; want %d", tr.GetLocalFee(), LoadBase)
+	}
+	if changed := tr.RaiseLocalFee(); !changed {
+		t.Fatal("second raise must lift local fee above LoadBase")
+	}
+	want := LoadBase + LoadBase/FeeIncFraction
+	if tr.GetLocalFee() != want {
+		t.Fatalf("local fee after second raise = %d; want %d", tr.GetLocalFee(), want)
+	}
+	if !tr.IsLoadedLocal() {
+		t.Fatal("IsLoadedLocal must be true once localFee != LoadBase")
+	}
+
+	// Drive it back down. LowerLocalFee should clear the raise count
+	// and decay; running enough cycles must clamp at LoadBase, not
+	// below it.
+	for i := 0; i < 10; i++ {
+		tr.LowerLocalFee()
+	}
+	if tr.GetLocalFee() != LoadBase {
+		t.Fatalf("local fee after lower cycles = %d; want %d", tr.GetLocalFee(), LoadBase)
+	}
+	if tr.IsLoadedLocal() {
+		t.Fatal("IsLoadedLocal must be false once fee returns to LoadBase")
+	}
+}
+
+// TestScaleFeeLoad_Loaded checks scaling under a raised local fee.
+// After two raises, local = LoadBase + LoadBase/4 = 320; scaleFeeLoad
+// applies fee * 320 / 256 = fee * 5/4.
+func TestScaleFeeLoad_Loaded(t *testing.T) {
+	tr := New()
+	tr.RaiseLocalFee()
+	tr.RaiseLocalFee()
+	got, err := ScaleFeeLoad(1000, tr, false)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != 1250 {
+		t.Fatalf("ScaleFeeLoad(1000) under 5/4 load = %d; want 1250", got)
+	}
+}
+
+// TestScaleFeeLoad_UnlimitedBranch pins the bUnlimited carve-out at
+// LoadFeeTrack.cpp:97-100: when only local load is elevated and stays
+// under 4x remote, an unlimited caller pays the remote-rate factor.
+func TestScaleFeeLoad_UnlimitedBranch(t *testing.T) {
+	tr := New()
+	tr.RaiseLocalFee()
+	tr.RaiseLocalFee() // local = 320, remote = 256
+	got, err := ScaleFeeLoad(1000, tr, true)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != 1000 {
+		t.Fatalf("unlimited caller under moderate local load = %d; want identity 1000", got)
+	}
+
+	// Drive local above 4x remote. Each raise multiplies by 5/4, so
+	// after >=7 raises beyond the latch local >= 4*remote and the
+	// privileged carve-out drops away.
+	for i := 0; i < 8; i++ {
+		tr.RaiseLocalFee()
+	}
+	if tr.GetLocalFee() < 4*tr.GetRemoteFee() {
+		t.Fatalf("setup failed: local %d not >= 4*remote %d", tr.GetLocalFee(), tr.GetRemoteFee())
+	}
+	got, err = ScaleFeeLoad(1000, tr, true)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got <= 1000 {
+		t.Fatalf("unlimited caller beyond 4x remote should pay scaled fee, got %d", got)
+	}
+}
+
+// TestScaleFeeLoad_Overflow protects the multiplication: a huge fee
+// times a large factor must surface ErrOverflow rather than silently
+// truncate.
+func TestScaleFeeLoad_Overflow(t *testing.T) {
+	tr := New()
+	for i := 0; i < 80; i++ {
+		tr.RaiseLocalFee()
+	}
+	_, err := ScaleFeeLoad(^uint64(0), tr, false)
+	if err == nil {
+		t.Fatal("expected ErrOverflow on max-fee max-factor; got nil")
+	}
+}
+
+// TestLoadFactorAggregates pins max(cluster, local, remote) and the
+// (max(local,remote), max(remote,cluster)) pair consumed by
+// ScaleFeeLoad. Mirrors LoadFeeTrack.h:94-110.
+func TestLoadFactorAggregates(t *testing.T) {
+	tr := New()
+	tr.SetRemoteFee(400)
+	tr.SetClusterFee(300)
+	tr.RaiseLocalFee()
+	tr.RaiseLocalFee() // local = max(local, remote=400) * 5/4 = 500
+
+	if tr.GetLocalFee() != 500 {
+		t.Fatalf("local after raise with remote=400: got %d, want 500", tr.GetLocalFee())
+	}
+	if lf := tr.GetLoadFactor(); lf != 500 {
+		t.Fatalf("load factor = %d; want max(cluster=300, local=500, remote=400) = 500", lf)
+	}
+	feeFactor, remFee := tr.GetScalingFactors()
+	if feeFactor != 500 || remFee != 400 {
+		t.Fatalf("scaling factors = (%d,%d); want (500,400)", feeFactor, remFee)
+	}
+}

--- a/internal/ledger/service/loadfee_autofill_test.go
+++ b/internal/ledger/service/loadfee_autofill_test.go
@@ -1,0 +1,141 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/feetrack"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+)
+
+// TestGetAutofillFee_NoLoad pins the rippled baseline: with a fresh
+// LoadFeeTrack the local factor is LoadBase, so GetAutofillFee returns
+// the per-tx-type feeDefault unchanged. Mirrors rippled getCurrentNetworkFee
+// (TransactionSign.cpp:849-861) when isLoadedLocal() is false.
+func TestGetAutofillFee_NoLoad(t *testing.T) {
+	svc, err := service.New(service.DefaultConfig())
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+
+	parsed, err := tx.ParseJSON([]byte(`{"TransactionType":"Payment","Account":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh","Destination":"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH","Amount":"1000000"}`))
+	if err != nil {
+		t.Fatalf("ParseJSON: %v", err)
+	}
+
+	fee, err := svc.GetAutofillFee(parsed, false)
+	if err != nil {
+		t.Fatalf("GetAutofillFee: %v", err)
+	}
+	// Standalone genesis config: base fee = 10 drops. Payment carries
+	// no per-tx multiplier so feeDefault = base fee.
+	if fee != 10 {
+		t.Fatalf("no-load autofill fee = %d; want baseFee=10", fee)
+	}
+}
+
+// TestGetAutofillFee_LoadedLocal verifies the LoadFeeTrack integration:
+// raising the local factor inflates the autofilled fee by exactly
+// localFee/LoadBase, matching rippled scaleFeeLoad (LoadFeeTrack.cpp:106-110).
+func TestGetAutofillFee_LoadedLocal(t *testing.T) {
+	svc, err := service.New(service.DefaultConfig())
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+
+	ft := svc.FeeTrack()
+	if ft == nil {
+		t.Fatal("FeeTrack must be non-nil after Start")
+	}
+	// Two raises clear the latch and apply one increment: local = 320.
+	ft.RaiseLocalFee()
+	ft.RaiseLocalFee()
+	if got := ft.GetLocalFee(); got != 320 {
+		t.Fatalf("post-raise local fee = %d; want 320", got)
+	}
+
+	parsed, err := tx.ParseJSON([]byte(`{"TransactionType":"Payment","Account":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh","Destination":"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH","Amount":"1000000"}`))
+	if err != nil {
+		t.Fatalf("ParseJSON: %v", err)
+	}
+
+	fee, err := svc.GetAutofillFee(parsed, false)
+	if err != nil {
+		t.Fatalf("GetAutofillFee: %v", err)
+	}
+	// feeDefault=10, factor=320/256 = 5/4 → expect 12 (mulDiv truncates).
+	want := uint64(10) * 320 / uint64(feetrack.LoadBase)
+	if fee != want {
+		t.Fatalf("loaded autofill fee = %d; want %d", fee, want)
+	}
+}
+
+// TestGetAutofillFee_Unlimited verifies the isUnlimited(role) carve-out:
+// when only the local factor is elevated and stays under 4x remote, an
+// unlimited caller pays the remote-rate factor. Mirrors LoadFeeTrack.cpp:97-100.
+func TestGetAutofillFee_Unlimited(t *testing.T) {
+	svc, err := service.New(service.DefaultConfig())
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+
+	ft := svc.FeeTrack()
+	ft.RaiseLocalFee()
+	ft.RaiseLocalFee() // local=320, remote=256 → unlimited collapses factor to remote.
+
+	parsed, err := tx.ParseJSON([]byte(`{"TransactionType":"Payment","Account":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh","Destination":"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH","Amount":"1000000"}`))
+	if err != nil {
+		t.Fatalf("ParseJSON: %v", err)
+	}
+
+	fee, err := svc.GetAutofillFee(parsed, true)
+	if err != nil {
+		t.Fatalf("GetAutofillFee: %v", err)
+	}
+	if fee != 10 {
+		t.Fatalf("unlimited under moderate local load = %d; want baseFee=10", fee)
+	}
+}
+
+// TestGetAutofillFee_Unlimited_HitsCeiling exercises the issue-acceptance
+// criterion that admin/identified callers still hit the ceiling check.
+// Drive local fee high enough that even after scaling, the result
+// exceeds feeDefault * mult/div, and assert that *svcerr.HighFeeError
+// surfaces regardless of the unlimited flag.
+func TestGetAutofillFee_Unlimited_HitsCeiling(t *testing.T) {
+	svc, err := service.New(service.DefaultConfig())
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+
+	ft := svc.FeeTrack()
+	// Drive the local factor far above 4x remote so the unlimited
+	// carve-out drops away and scaleFeeLoad applies in full.
+	for i := 0; i < 40; i++ {
+		ft.RaiseLocalFee()
+	}
+	if got := ft.GetLocalFee(); got < 4*ft.GetRemoteFee() {
+		t.Fatalf("setup: local %d not >= 4*remote %d", got, ft.GetRemoteFee())
+	}
+
+	parsed, err := tx.ParseJSON([]byte(`{"TransactionType":"Payment","Account":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh","Destination":"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH","Amount":"1000000"}`))
+	if err != nil {
+		t.Fatalf("ParseJSON: %v", err)
+	}
+
+	if _, err := svc.GetAutofillFee(parsed, true); err == nil {
+		t.Fatal("expected HighFeeError once scaled fee exceeds ceiling; got nil")
+	}
+}

--- a/internal/ledger/service/loadfee_tick_test.go
+++ b/internal/ledger/service/loadfee_tick_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/feetrack"
+)
+
+// TestTickLoadFee_NoOverload_LowersToLoadBase pins the rippled
+// LoadManager.cpp:177-186 lower-branch: when the overload signal is
+// false the local fee decays back to LoadBase.
+func TestTickLoadFee_NoOverload_LowersToLoadBase(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Pre-load the tracker: two raises lift local fee above LoadBase.
+	ft := svc.feeTrack
+	ft.RaiseLocalFee()
+	ft.RaiseLocalFee()
+	if got := ft.GetLocalFee(); got <= feetrack.LoadBase {
+		t.Fatalf("setup: pre-tick local fee = %d; want > LoadBase", got)
+	}
+
+	// Fresh open ledger has no txs → TxQ feeEscalation collapses to
+	// reference, so the tick fires the lower branch on every call. A
+	// fixed number of ticks must drive the fee back to LoadBase.
+	svc.mu.Lock()
+	for i := 0; i < 80; i++ {
+		svc.tickLoadFeeLocked()
+	}
+	svc.mu.Unlock()
+
+	if got := ft.GetLocalFee(); got != feetrack.LoadBase {
+		t.Fatalf("post-tick local fee = %d; want LoadBase=%d", got, feetrack.LoadBase)
+	}
+}
+
+// TestTickLoadFee_NilTracker is a defensive no-op check: a Service
+// without a tracker (legacy/test fixture, or any future codepath that
+// nils it out) must not panic when the tick runs.
+func TestTickLoadFee_NilTracker(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	svc.feeTrack = nil
+
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	svc.tickLoadFeeLocked() // must not panic
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -243,9 +243,16 @@ type Service struct {
 	// feeTrack is the local LoadFeeTrack mirror. Always non-nil — New()
 	// constructs a fresh tracker so GetAutofillFee and server_info
 	// observe the same fee factors as rippled's getCurrentNetworkFee
-	// path (TransactionSign.cpp:849-862). Updated by RaiseLocalFee /
-	// LowerLocalFee under job-queue overload (loadmgr) and by
-	// SetRemoteFee / SetClusterFee from the peer + cluster handlers.
+	// path (TransactionSign.cpp:849-862). Drivers:
+	//   - Raise/LowerLocalFee fire once per ledger close via
+	//     tickLoadFeeLocked (TxQ-escalation proxy for rippled's
+	//     LoadManager.cpp:177-186 JobQueue overload signal).
+	//   - SetRemoteFee fires from Adaptor.OnLedgerFullyValidated after
+	//     quorum, taking the median across trusted-validation LoadFees
+	//     (mirrors LedgerMaster.cpp:977-1006).
+	//   - SetClusterFee fires from peermanagement.Overlay's TMCluster
+	//     ingress via the clusterFeeSink hook wired in cli/server.go
+	//     (mirrors PeerImp.cpp:1175-1193).
 	feeTrack *feetrack.LoadFeeTrack
 }
 
@@ -487,6 +494,30 @@ func (s *Service) processClosedLedgerLocked() {
 	baseFee, _, _ := readFeesFromLedger(s.closedLedger)
 	ctx := &closedLedgerCtx{ledger: s.closedLedger, baseFee: baseFee}
 	s.txQueue.ProcessClosedLedger(ctx, false)
+	s.tickLoadFeeLocked()
+}
+
+// tickLoadFeeLocked drives LoadFeeTrack raise/lower decisions from the
+// per-ledger-close heartbeat. Mirrors rippled LoadManager::run
+// (LoadManager.cpp:177-186): raise on overload, lower otherwise.
+// goXRPL has no JobQueue equivalent, so we proxy "overload" with TxQ
+// fee escalation — when the required fee level has lifted off the
+// reference level the open ledger is at or beyond its soft cap, which
+// is the same condition that drives loadFactorFeeEscalation in
+// server_info. This couples the two signals (LoadFeeTrack and feeEscalation)
+// to a single observable, which is acceptable because server_info takes
+// max(loadFactorServer, loadFactorFeeEscalation) — they never
+// double-count. Caller must hold s.mu.
+func (s *Service) tickLoadFeeLocked() {
+	if s.feeTrack == nil || s.txQueue == nil || s.openLedger == nil {
+		return
+	}
+	metrics := s.txQueue.GetMetrics(s.openLedger.TxCount())
+	if metrics.OpenLedgerFeeLevel > metrics.ReferenceFeeLevel {
+		s.feeTrack.RaiseLocalFee()
+	} else {
+		s.feeTrack.LowerLocalFee()
+	}
 }
 
 // acceptOpenLedgerViewLocked invokes OpenLedger.Accept on the LCL

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LeJamon/goXRPLd/amendment"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/feetrack"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
@@ -238,6 +239,14 @@ type Service struct {
 	// app.overlay().relay for each non-inner-batch tx surviving the
 	// rebuild). Nil when overlay broadcast is unwired (tests).
 	txRelay func(blob []byte)
+
+	// feeTrack is the local LoadFeeTrack mirror. Always non-nil — New()
+	// constructs a fresh tracker so GetAutofillFee and server_info
+	// observe the same fee factors as rippled's getCurrentNetworkFee
+	// path (TransactionSign.cpp:849-862). Updated by RaiseLocalFee /
+	// LowerLocalFee under job-queue overload (loadmgr) and by
+	// SetRemoteFee / SetClusterFee from the peer + cluster handlers.
+	feeTrack *feetrack.LoadFeeTrack
 }
 
 // New creates a new LedgerService
@@ -268,6 +277,7 @@ func New(cfg Config) (*Service, error) {
 		heldAdoptions:            make(map[uint32]*pendingAdopt),
 		txQueue:                  txq.New(txqCfg),
 		localTxs:                 localtxs.New(),
+		feeTrack:                 feetrack.New(),
 	}
 
 	return s, nil

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/LeJamon/goXRPLd/amendment"
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/feetrack"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/openledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
@@ -198,27 +199,28 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 
 // GetAutofillFee returns the Fee (drops) a transaction should carry to
 // bypass the TxQ and enter the current open ledger. Mirrors rippled
-// TransactionSign.cpp getCurrentNetworkFee:
+// TransactionSign.cpp getCurrentNetworkFee (TransactionSign.cpp:839-877):
 //
 //   - feeDefault = per-tx-type base fee (multisign multiplier, AccountDelete's
 //     reserve increment, AMMCreate's increment, LedgerStateFix's increment)
+//   - loadFee   = scaleFeeLoad(feeDefault, feeTrack, isUnlimited)
+//     (LoadFeeTrack.cpp:85-111) — inflates feeDefault under local /
+//     cluster load; the unlimited carve-out lets admin/identified
+//     callers pay the remote-rate factor while local load stays below
+//     4x remote.
 //   - escalatedFee = toDrops(openLedgerFeeLevel-1, baseFee) + 1 (TxQ load)
-//   - returned fee = max(feeDefault, escalatedFee)
+//   - returned fee = max(loadFee, escalatedFee)
 //
 // The returned fee is capped at feeDefault * defaultAutoFillFeeMultiplier
 // / defaultAutoFillFeeDivisor; exceeding it yields *svcerr.HighFeeError
-// (which errors.Is(svcerr.ErrHighFee) also matches). rippled applies the
-// ceiling regardless of role.
+// (which errors.Is(svcerr.ErrHighFee) also matches). The ceiling check
+// runs regardless of unlimited — rippled applies it after the role-aware
+// scale, so privileged callers still cannot exceed mult/div.
 //
 // The source account is never read — matches rippled's getTxFee
 // (TransactionSign.cpp:765-836), so callers that have already supplied
 // Sequence must not receive an account-related error from this path.
-//
-// scaleFeeLoad (rippled's load-fee tracker) and the isUnlimited(role)
-// exemption have no Go equivalent and are intentionally omitted: goXRPL
-// never inflates fees for cluster load, and admin/identified callers
-// are not exempt from the ceiling check.
-func (s *Service) GetAutofillFee(parsedTx tx.Transaction) (uint64, error) {
+func (s *Service) GetAutofillFee(parsedTx tx.Transaction, unlimited bool) (uint64, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -236,7 +238,12 @@ func (s *Service) GetAutofillFee(parsedTx tx.Transaction) (uint64, error) {
 	}
 
 	feeDefault := computeBaseFeeForTx(s.openLedger, parsedTx, feeCfg)
-	fee := feeDefault
+
+	loadFee, scaleErr := feetrack.ScaleFeeLoad(feeDefault, s.feeTrack, unlimited)
+	if scaleErr != nil {
+		return 0, fmt.Errorf("autofill fee: %w", scaleErr)
+	}
+	fee := loadFee
 	if s.txQueue != nil {
 		feeLevel := s.txQueue.GetRequiredFeeLevel(s.openLedger.TxCount())
 		if uint64(feeLevel) > txq.BaseLevel {
@@ -256,6 +263,14 @@ func (s *Service) GetAutofillFee(parsedTx tx.Transaction) (uint64, error) {
 	}
 
 	return fee, nil
+}
+
+// FeeTrack returns the LoadFeeTrack backing GetAutofillFee and the
+// server_info load_factor_* fields. Used by peer / cluster ingress
+// (SetRemoteFee, SetClusterFee), the load manager (RaiseLocalFee,
+// LowerLocalFee), and the RPC LoadFactorFees hook.
+func (s *Service) FeeTrack() *feetrack.LoadFeeTrack {
+	return s.feeTrack
 }
 
 // GetAutofillSequence returns the Sequence a transaction should carry,

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -266,9 +266,10 @@ func (s *Service) GetAutofillFee(parsedTx tx.Transaction, unlimited bool) (uint6
 }
 
 // FeeTrack returns the LoadFeeTrack backing GetAutofillFee and the
-// server_info load_factor_* fields. Used by peer / cluster ingress
-// (SetRemoteFee, SetClusterFee), the load manager (RaiseLocalFee,
-// LowerLocalFee), and the RPC LoadFactorFees hook.
+// server_info load_factor_* fields. Used by Adaptor.OnLedgerFullyValidated
+// (SetRemoteFee), the overlay TMCluster ingress sink (SetClusterFee),
+// the per-close tick in processClosedLedgerLocked (Raise/LowerLocalFee),
+// and the RPC LoadFactorFees hook.
 func (s *Service) FeeTrack() *feetrack.LoadFeeTrack {
 	return s.feeTrack
 }

--- a/internal/peermanagement/cluster/cluster.go
+++ b/internal/peermanagement/cluster/cluster.go
@@ -120,6 +120,32 @@ func (r *Registry) Update(identity []byte, name string, loadFee uint32, reportTi
 	return true
 }
 
+// MedianFee returns the median LoadFee across members whose ReportTime
+// is not older than thresh, and ok=true when at least one member
+// qualified. Mirrors rippled PeerImp::onMessage(TMCluster) median
+// computation at PeerImp.cpp:1175-1193: members reporting older than
+// 90s are dropped, the remaining loadFees are sorted and the
+// middle element is taken via nth_element.
+func (r *Registry) MedianFee(thresh time.Time) (uint32, bool) {
+	if r == nil {
+		return 0, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	fees := make([]uint32, 0, len(r.nodes))
+	for _, m := range r.nodes {
+		if m.ReportTime.Before(thresh) {
+			continue
+		}
+		fees = append(fees, m.LoadFee)
+	}
+	if len(fees) == 0 {
+		return 0, false
+	}
+	sort.Slice(fees, func(i, j int) bool { return fees[i] < fees[j] })
+	return fees[len(fees)/2], true
+}
+
 // entryRE structurally mirrors the boost::regex in rippled
 // Cluster.cpp:93-103. The POSIX [[:space:]] / [[:alnum:]] classes are
 // load-bearing: Go's \s drops \v and other characters [[:space:]]

--- a/internal/peermanagement/cluster/cluster_test.go
+++ b/internal/peermanagement/cluster/cluster_test.go
@@ -22,6 +22,43 @@ func mustDecode(t *testing.T, k string) []byte {
 	return b
 }
 
+func TestRegistry_MedianFee(t *testing.T) {
+	r := cluster.New()
+	now := time.Unix(2_000_000_000, 0)
+	r.Update(mustDecode(t, pubA), "a", 320, now)
+	r.Update(mustDecode(t, pubB), "b", 400, now)
+	// Older-than-window entry is excluded from the median.
+	stale := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+		0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+		0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21}
+	r.Update(stale, "stale", 9999, now.Add(-2*time.Minute))
+
+	fee, ok := r.MedianFee(now.Add(-90 * time.Second))
+	if !ok {
+		t.Fatal("MedianFee should report ok when fresh entries exist")
+	}
+	// Two fresh entries {320, 400}; sort.Slice middle index = 1 → 400.
+	if fee != 400 {
+		t.Fatalf("median = %d; want 400", fee)
+	}
+}
+
+func TestRegistry_MedianFee_EmptyWindow(t *testing.T) {
+	r := cluster.New()
+	now := time.Unix(2_000_000_000, 0)
+	r.Update(mustDecode(t, pubA), "a", 320, now.Add(-10*time.Minute))
+	if _, ok := r.MedianFee(now.Add(-90 * time.Second)); ok {
+		t.Fatal("MedianFee with no fresh entries should report ok=false")
+	}
+}
+
+func TestRegistry_MedianFee_NilSafe(t *testing.T) {
+	var r *cluster.Registry
+	if _, ok := r.MedianFee(time.Now()); ok {
+		t.Fatal("nil registry MedianFee should report ok=false")
+	}
+}
+
 func TestRegistry_NilSafe(t *testing.T) {
 	var r *cluster.Registry
 	if _, ok := r.Member([]byte{0x01}); ok {

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -30,11 +30,12 @@ const peerSendQueueDropThreshold = (DefaultSendBufferSize * 3) / 4
 // same boundary via Overlay.cluster.Member(peer.RemotePublicKey()).
 //
 // Payload effect: each ClusterNode entry refreshes the registry's
-// known load/report-time for that node. The LoadSource gossip and the
-// median-cluster-fee computation that rippled performs are wired into
-// its Resource::Manager + LoadFeeTrack subsystems; goXRPL has no
-// analog yet, so we only adopt the membership state — closing the
-// peer-protocol gap without standing up two more subsystems.
+// known load/report-time for that node. After the registry-update
+// loop we recompute the cluster-fee median over members reported
+// within the last clusterFeeWindow and forward it through
+// clusterFeeSink, mirroring rippled PeerImp.cpp:1175-1193 which calls
+// getFeeTrack().setClusterFee(median). The LoadSource gossip
+// (resource-manager bytes accounting) is still unimplemented.
 func (o *Overlay) handleClusterMessage(evt Event) {
 	o.peersMu.RLock()
 	peer, exists := o.peers[evt.PeerID]
@@ -81,6 +82,20 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 		}
 		reportTime := time.Unix(int64(node.ReportTime), 0)
 		o.cluster.Update(identity, node.NodeName, node.NodeLoad, reportTime)
+	}
+
+	// Recompute the cluster-fee median and forward it through the
+	// LoadFeeTrack sink. Mirrors rippled PeerImp.cpp:1175-1193: take
+	// the median of cluster-member LoadFees reported within the last
+	// clusterFeeWindow, then setClusterFee. An empty set (no fresh
+	// reports) yields no setClusterFee call — rippled also falls
+	// through with clusterFee=0 in that case but we leave the prior
+	// value intact, mirroring the more general "no signal → no
+	// change" pattern.
+	if o.clusterFeeSink != nil {
+		if fee, ok := o.cluster.MedianFee(time.Now().Add(-clusterFeeWindow)); ok {
+			o.clusterFeeSink(fee)
+		}
 	}
 
 	// LoadSource gossip → Resource::Manager: not implemented in

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/cluster"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 )
@@ -56,6 +57,70 @@ func TestHandleClusterMessage_DropsNonClusterPeer(t *testing.T) {
 		"non-cluster peer sending TMCluster must be charged bad-data")
 	assert.Zero(t, o.cluster.Size(),
 		"non-cluster peer must not be able to mutate the cluster registry")
+}
+
+// TestHandleClusterMessage_FiresClusterFeeSink pins the LoadFeeTrack
+// ingress wiring: a TMCluster frame from a registered cluster peer must
+// recompute the median across fresh-reported members and forward it to
+// clusterFeeSink. Mirrors rippled PeerImp.cpp:1175-1193 which calls
+// getFeeTrack().setClusterFee(median).
+func TestHandleClusterMessage_FiresClusterFeeSink(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	peerIdentity, err := NewIdentity()
+	require.NoError(t, err)
+	peerToken := NewPublicKeyTokenFromBtcec(peerIdentity.BtcecPublicKey())
+
+	// Register the peer's node identity in the cluster registry so the
+	// gate at handleClusterMessage admits the frame.
+	clusterReg := cluster.New()
+	peerNodePub := peerToken.Bytes()
+	peerNodePubEncoded, err := addresscodec.EncodeNodePublicKey(peerNodePub)
+	require.NoError(t, err)
+	require.NoError(t, clusterReg.Load([]string{peerNodePubEncoded + " peer"}))
+
+	var sinkCalls []uint32
+	o := &Overlay{
+		peers:          make(map[PeerID]*Peer),
+		events:         make(chan Event, 8),
+		cluster:        clusterReg,
+		clusterFeeSink: func(fee uint32) { sinkCalls = append(sinkCalls, fee) },
+	}
+
+	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
+	peer := NewPeer(PeerID(33), endpoint, false, id, make(chan Event, 1))
+	peer.remotePubKey = peerToken
+	o.peers[peer.ID()] = peer
+
+	// Frame announces two fresh-reported cluster members: the peer
+	// itself (loadFee=320) and a second identity (loadFee=400). The
+	// median over those two should be 400 (sort middle).
+	otherIdent, err := NewIdentity()
+	require.NoError(t, err)
+	otherToken := NewPublicKeyTokenFromBtcec(otherIdent.BtcecPublicKey())
+	otherPub, err := addresscodec.EncodeNodePublicKey(otherToken.Bytes())
+	require.NoError(t, err)
+	// Pre-register the other identity so the registry update accepts it.
+	require.NoError(t, clusterReg.Load([]string{otherPub + " other"}))
+
+	now := uint32(time.Now().Unix())
+	cm := &message.Cluster{
+		ClusterNodes: []message.ClusterNode{
+			{PublicKey: peerNodePubEncoded, NodeName: "peer", NodeLoad: 320, ReportTime: now},
+			{PublicKey: otherPub, NodeName: "other", NodeLoad: 400, ReportTime: now},
+		},
+	}
+	payload, err := message.Encode(cm)
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeCluster),
+		Payload:     payload,
+	})
+
+	require.Len(t, sinkCalls, 1, "clusterFeeSink must fire exactly once per ingress")
+	assert.Equal(t, uint32(400), sinkCalls[0])
 }
 
 // TestHandleHaveTransactionsMessage_GatedOnFeatureNegotiation pins the

--- a/internal/peermanagement/outbound_emit.go
+++ b/internal/peermanagement/outbound_emit.go
@@ -88,11 +88,15 @@ func (o *Overlay) sendClusterUpdate() {
 	// "this is news" return value — mirrors rippled
 	// NetworkOPs.cpp:1126-1139, where a stale reportTime returns
 	// false and the broadcast is skipped (with "Too soon to send
-	// cluster update" log). goXRPL has no FeeTrack analog yet, so the
-	// self-entry's loadFee is fixed at 0; when one lands, this is the
-	// call site to start passing a real fee.
+	// cluster update" log). The self-entry's loadFee is sourced from
+	// localLoadFeeProvider (LoadFeeTrack.GetLocalFee); 0 when unwired,
+	// matching the pre-LoadFeeTrack behaviour.
 	if len(o.localNodeIdentity) > 0 {
-		if !o.cluster.Update(o.localNodeIdentity, "", 0, time.Now()) {
+		var selfFee uint32
+		if o.localLoadFeeProvider != nil {
+			selfFee = o.localLoadFeeProvider()
+		}
+		if !o.cluster.Update(o.localNodeIdentity, "", selfFee, time.Now()) {
 			return
 		}
 	}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -162,6 +162,23 @@ type Overlay struct {
 	// `app_.config().TX_REDUCE_RELAY_ENABLE` at OverlayImpl.cpp:107.
 	openLedgerHashesProvider func() [][32]byte
 
+	// clusterFeeSink is invoked by handleClusterMessage after the
+	// registry-update loop with the median LoadFee across members
+	// reported within the last cluster-fee window. Mirrors rippled
+	// PeerImp::onMessage(TMCluster) which calls
+	// app_.getFeeTrack().setClusterFee(median) at PeerImp.cpp:1193.
+	// nil-safe — the inbound handler skips the median computation when
+	// unwired.
+	clusterFeeSink func(fee uint32)
+
+	// localLoadFeeProvider returns the local node's current load fee
+	// factor (LoadFeeTrack.getLocalFee). Wired into sendClusterUpdate
+	// so the self-entry in each outbound TMCluster gossip advertises
+	// real load instead of 0. Mirrors rippled NetworkOPs.cpp:1126-1132
+	// which sources the self-entry fee from getFeeTrack().getLocalFee().
+	// nil-safe — sendClusterUpdate falls back to 0 when unwired.
+	localLoadFeeProvider func() uint32
+
 	// localNodeIdentity is the raw 33-byte compressed NodePublic of
 	// THIS node. Used by the cluster timer to insert ourselves into
 	// the gossip frame so peers can correlate validator load. Filled
@@ -2166,6 +2183,29 @@ func (o *Overlay) SetTxProvider(fn func(hash [32]byte) ([]byte, bool)) {
 func (o *Overlay) SetOpenLedgerHashesProvider(fn func() [][32]byte) {
 	o.openLedgerHashesProvider = fn
 }
+
+// SetClusterFeeSink installs the callback invoked from handleClusterMessage
+// with the median cluster LoadFee whenever a TMCluster frame refreshes
+// the registry. Mirrors rippled PeerImp.cpp:1193 which calls
+// app_.getFeeTrack().setClusterFee(median). Wiring is optional — when
+// nil the inbound handler skips the median computation.
+func (o *Overlay) SetClusterFeeSink(fn func(fee uint32)) {
+	o.clusterFeeSink = fn
+}
+
+// SetLocalLoadFeeProvider installs the reader that supplies our own
+// LoadFee for the outbound TMCluster gossip self-entry. Mirrors rippled
+// NetworkOPs.cpp:1126-1132 which sources the self-load from
+// getFeeTrack().getLocalFee() before broadcasting the cluster update.
+// nil-safe — sendClusterUpdate falls back to 0 when unwired.
+func (o *Overlay) SetLocalLoadFeeProvider(fn func() uint32) {
+	o.localLoadFeeProvider = fn
+}
+
+// clusterFeeWindow is the freshness threshold for cluster-fee median
+// inclusion — entries reporting older than this are dropped before the
+// median is taken. Mirrors rippled PeerImp.cpp:1175 (90s).
+const clusterFeeWindow = 90 * time.Second
 
 // PeersJSON implements types.PeerSource for the `peers` RPC method,
 // emitting the subset of rippled PeerImp::json (PeerImp.cpp:388-503)

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -167,7 +167,7 @@ func (m *mockAccountChannelsLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockAccountChannelsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountChannelsLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (m *mockAccountChannelsLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockAccountChannelsLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -169,7 +169,7 @@ func (m *mockAccountCurrenciesLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockAccountCurrenciesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountCurrenciesLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (m *mockAccountCurrenciesLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockAccountCurrenciesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -147,7 +147,7 @@ func (m *mockLedgerService) GetNFTSellOffers(_ context.Context, nftID [32]byte, 
 func (m *mockLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (m *mockLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -163,7 +163,7 @@ func (m *mockAccountLinesLedgerService) GetNFTSellOffers(_ context.Context, nftI
 func (m *mockAccountLinesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountLinesLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (m *mockAccountLinesLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockAccountLinesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -165,7 +165,7 @@ func (m *mockAccountNFTsLedgerService) GetNFTSellOffers(_ context.Context, nftID
 func (m *mockAccountNFTsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountNFTsLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (m *mockAccountNFTsLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockAccountNFTsLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -170,7 +170,7 @@ func (m *mockDepositAuthorizedLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockDepositAuthorizedLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockDepositAuthorizedLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (m *mockDepositAuthorizedLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockDepositAuthorizedLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -166,7 +166,7 @@ func (m *mockGatewayBalancesLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockGatewayBalancesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockGatewayBalancesLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (m *mockGatewayBalancesLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockGatewayBalancesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -187,48 +187,58 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		}
 	}
 
-	// load_factor: human mode is float (loadFactor/loadBase), machine mode has integers.
-	// Until a full LoadFeeTrack lands, the server-wide load factor mirrors the
-	// fee-escalation level — the only load signal we currently track. Matches
-	// rippled's NetworkOPs.cpp:2863-2875 fallback when no other load source
-	// (cluster, admin) is active.
-	//
-	// loadFactorFeeEscalation = openLedgerFeeLevel * loadBase / referenceFeeLevel
-	// (NetworkOPs.cpp:2850-2855). When referenceFeeLevel == loadBase this reduces
-	// to feeEscalation, but compute the ratio explicitly so the algebra survives
-	// any future TxQ configuration drift.
+	// load_factor mixes two load sources, matching NetworkOPs.cpp:2845-2858:
+	//   loadFactorServer = max(local, remote, cluster) from LoadFeeTrack
+	//   loadFactorFeeEscalation = openLedgerFeeLevel * loadBase / referenceFeeLevel
+	//   load_factor = max(loadFactorServer, loadFactorFeeEscalation), floored at loadBase
 	feeEscalation, feeQueue, feeReference := resolveLoadFactorFees(services)
 	loadFactorFeeEscalation := feeEscalation
 	if feeReference != 0 {
 		loadFactorFeeEscalation = feeEscalation * loadBase / feeReference
 	}
+	var loadFactorFees types.LoadFactorFees
+	if services != nil && services.LoadFactorFees != nil {
+		loadFactorFees = services.LoadFactorFees()
+	} else {
+		// Tracker unwired (older test fixtures): treat as no load so
+		// loadFactorServer collapses to loadBase, matching a fresh
+		// LoadFeeTrack.
+		base32 := uint32(loadBase)
+		loadFactorFees = types.LoadFactorFees{Local: base32, Net: base32, Cluster: base32}
+	}
+	loadFactorServer := uint64(loadFactorFees.Local)
+	if uint64(loadFactorFees.Net) > loadFactorServer {
+		loadFactorServer = uint64(loadFactorFees.Net)
+	}
+	if uint64(loadFactorFees.Cluster) > loadFactorServer {
+		loadFactorServer = uint64(loadFactorFees.Cluster)
+	}
 	loadFactor := loadFactorFeeEscalation
+	if loadFactorServer > loadFactor {
+		loadFactor = loadFactorServer
+	}
 	if loadFactor < loadBase {
 		loadFactor = loadBase
 	}
 	if human {
 		info["load_factor"] = float64(loadFactor) / float64(loadBase)
 		// Mirror rippled NetworkOPs.cpp:2883-2885: emit load_factor_server
-		// when it diverges from the overall load_factor. With no
-		// LoadFeeTrack subsystem loadFactorServer == loadBase, so this
-		// fires whenever fee escalation drives load_factor above 1.0.
-		if loadBase != loadFactor {
-			info["load_factor_server"] = float64(loadBase) / float64(loadBase)
+		// when it diverges from the overall load_factor.
+		if loadFactorServer != loadFactor {
+			info["load_factor_server"] = float64(loadFactorServer) / float64(loadBase)
 		}
 		// Mirror rippled NetworkOPs.cpp:2887-2901: admin-only emission
 		// of load_factor_{local,net,cluster}, each gated on the fee
-		// differing from loadBase. The LoadFactorFees hook is nil until
-		// a LoadFeeTrack subsystem lands, suppressing all three.
-		if ctx.IsAdmin && services != nil && services.LoadFactorFees != nil {
-			fees := services.LoadFactorFees()
-			if uint64(fees.Local) != loadBase {
-				info["load_factor_local"] = float64(fees.Local) / float64(loadBase)
+		// differing from loadBase.
+		if ctx.IsAdmin {
+			if uint64(loadFactorFees.Local) != loadBase {
+				info["load_factor_local"] = float64(loadFactorFees.Local) / float64(loadBase)
 			}
-			if uint64(fees.Net) != loadBase {
-				info["load_factor_net"] = float64(fees.Net) / float64(loadBase)
+			if uint64(loadFactorFees.Net) != loadBase {
+				info["load_factor_net"] = float64(loadFactorFees.Net) / float64(loadBase)
 			}
-			if uint64(fees.Cluster) != loadBase {
-				info["load_factor_cluster"] = float64(fees.Cluster) / float64(loadBase)
+			if uint64(loadFactorFees.Cluster) != loadBase {
+				info["load_factor_cluster"] = float64(loadFactorFees.Cluster) / float64(loadBase)
 			}
 		}
 		// Mirror rippled NetworkOPs.cpp:2902-2912: in human mode the
@@ -249,7 +259,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 		// trunc32() / jsonClipped() so the field type stays uint32.
 		info["load_base"] = uint32(loadBase)
 		info["load_factor"] = clipToUint32(loadFactor)
-		info["load_factor_server"] = uint32(loadBase)
+		info["load_factor_server"] = clipToUint32(loadFactorServer)
 		info["load_factor_fee_escalation"] = clipToUint32(feeEscalation)
 		info["load_factor_fee_queue"] = clipToUint32(feeQueue)
 		info["load_factor_fee_reference"] = clipToUint32(feeReference)

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -217,9 +217,6 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	if loadFactorServer > loadFactor {
 		loadFactor = loadFactorServer
 	}
-	if loadFactor < loadBase {
-		loadFactor = loadBase
-	}
 	if human {
 		info["load_factor"] = float64(loadFactor) / float64(loadBase)
 		// Mirror rippled NetworkOPs.cpp:2883-2885: emit load_factor_server

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -108,7 +108,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		if marshalErr != nil {
 			return nil, types.RpcErrorInternal("Failed to marshal tx_json for fee autofill")
 		}
-		fee, feeErr := ctx.Services.Ledger.GetAutofillFee(probe)
+		fee, feeErr := ctx.Services.Ledger.GetAutofillFee(probe, ctx.IsAdmin)
 		if feeErr != nil {
 			var hfe *svcerr.HighFeeError
 			if errors.As(feeErr, &hfe) {

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -886,13 +886,13 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 	return out, nil
 }
 
-func (a *LedgerServiceAdapter) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (a *LedgerServiceAdapter) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	// rippled getTxFee falls back to reference_fee on any parse failure
 	// (TransactionSign.cpp:790-821). A nil parsedTx triggers the
 	// equivalent baseFee fallback in computeBaseFeeForTx so the later
 	// structural-check passes can surface the real error.
 	parsedTx, _ := tx.ParseJSON(txJSON)
-	return a.svc.GetAutofillFee(parsedTx)
+	return a.svc.GetAutofillFee(parsedTx, unlimited)
 }
 
 func (a *LedgerServiceAdapter) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -150,7 +150,7 @@ func (m *mockNFTOffersLedgerService) GetNFTSellOffers(_ context.Context, nftID [
 func (m *mockNFTOffersLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNFTOffersLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (m *mockNFTOffersLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockNFTOffersLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -164,7 +164,7 @@ func (m *mockNoRippleCheckLedgerService) GetNFTSellOffers(_ context.Context, nft
 func (m *mockNoRippleCheckLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNoRippleCheckLedgerService) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (m *mockNoRippleCheckLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockNoRippleCheckLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -61,7 +61,7 @@ func (m *mockLedgerServiceSimulate) SimulateTransaction(txJSON []byte) (*types.S
 	return m.simulateResult, nil
 }
 
-func (m *mockLedgerServiceSimulate) GetAutofillFee(txJSON []byte) (uint64, error) {
+func (m *mockLedgerServiceSimulate) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
 	m.feeAutofillCallCount++
 	if m.autofillFeeErr != nil {
 		return 0, m.autofillFeeErr

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -283,13 +283,17 @@ type TransactionSubmitter interface {
 
 	// GetAutofillFee returns the Fee a transaction should carry to enter
 	// the open ledger. Mirrors rippled getCurrentNetworkFee
-	// (TransactionSign.cpp:839-877): max(feeDefault, escalatedFee) with a
-	// feeDefault * mult / div ceiling. On ceiling overflow handlers map
-	// to rpcINTERNAL; on exceedance the returned error is a
-	// *svcerr.HighFeeError (errors.Is(svcerr.ErrHighFee) also matches).
-	// Includes per-tx-type adjustments (multisign, AccountDelete,
+	// (TransactionSign.cpp:839-877): max(scaleFeeLoad(feeDefault),
+	// escalatedFee) with a feeDefault * mult / div ceiling. On ceiling
+	// overflow handlers map to rpcINTERNAL; on exceedance the returned
+	// error is a *svcerr.HighFeeError (errors.Is(svcerr.ErrHighFee) also
+	// matches). Includes per-tx-type adjustments (multisign, AccountDelete,
 	// AMMCreate, LedgerStateFix). Never reads the source account.
-	GetAutofillFee(txJSON []byte) (fee uint64, err error)
+	//
+	// unlimited mirrors rippled's isUnlimited(role) carve-out: admin /
+	// identified callers skip local-only load below 4x remote. The
+	// ceiling check still applies (rippled enforces it post-scale).
+	GetAutofillFee(txJSON []byte, unlimited bool) (fee uint64, err error)
 
 	// GetAutofillSequence returns the Sequence a transaction should
 	// carry. Mirrors rippled getAutofillSequence (Simulate.cpp:37-69):

--- a/internal/testing/rpcenv/adapter.go
+++ b/internal/testing/rpcenv/adapter.go
@@ -223,7 +223,7 @@ func (a *ledgerAdapter) GetTransactionHistory(_ context.Context, _ uint32) (*typ
 	return nil, errNotImplemented
 }
 
-func (a *ledgerAdapter) GetAutofillFee(_ []byte) (uint64, error) {
+func (a *ledgerAdapter) GetAutofillFee(_ []byte, _ bool) (uint64, error) {
 	return 0, errNotImplemented
 }
 


### PR DESCRIPTION
## Summary
- New `internal/feetrack` package mirroring rippled's `LoadFeeTrack` + `scaleFeeLoad`: thread-safe local/remote/cluster fee factors, raise/lower hysteresis (`lftNormalFee=256`, ±¼ each tick, capped at `256*1_000_000`), `mulDiv` via `math/big` so the multiplication never silently truncates.
- `service.Service` now owns a `*LoadFeeTrack`. `GetAutofillFee(parsedTx, unlimited)` applies `scaleFeeLoad(feeDefault, feeTrack, unlimited)` before the TxQ escalation max, mirroring `getCurrentNetworkFee` (TransactionSign.cpp:849-862). The `unlimited` flag plumbs through `LedgerService.GetAutofillFee([]byte, bool)` → `simulate.go` passes `ctx.IsAdmin`. The ceiling check still runs regardless of `unlimited`, matching rippled.
- `server_info` reads `load_factor_server` / `load_factor_local` / `load_factor_net` / `load_factor_cluster` from the live tracker (previously hard-coded to `loadBase`). Overall `load_factor = max(loadFactorServer, loadFactorFeeEscalation)`, matching NetworkOPs.cpp:2845-2858.
- Adaptor `GetLoadFee()` now sources the local factor from the tracker so validations advertise real load instead of always 0.
- Stale doc comment at `tx_query.go:217-220` removed.

## Test plan
- [x] `just test-pkg ./internal/feetrack/...` — new unit tests cover scaleFeeLoad identity, raise/lower hysteresis, unlimited carve-out, 4× threshold, overflow path
- [x] `just test-pkg ./internal/ledger/service/... -run TestGetAutofillFee` — load-scaled autofill + unlimited bypass + ceiling enforcement
- [x] `just test-pkg ./internal/rpc/...` — server_info / simulate handlers green
- [x] `just test-pkg ./internal/consensus/...` — adaptor `GetLoadFee` green
- [x] `go build ./...` clean

Fixes #514