### PR TITLE
fix: close fees / TxQ audit gaps

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -253,6 +253,28 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			OpenLedgerFeeLevel:    m.OpenLedgerFeeLevel,
 		}
 	}
+	services.TxQFeeMetrics = func() types.TxQFeeMetrics {
+		m := ledgerSvcRef.GetTxQMetrics()
+		return types.TxQFeeMetrics{
+			TxCount:               m.TxCount,
+			TxQMaxSize:            m.TxQMaxSize,
+			TxInLedger:            m.TxInLedger,
+			TxPerLedger:           m.TxPerLedger,
+			ReferenceFeeLevel:     m.ReferenceFeeLevel,
+			MinProcessingFeeLevel: m.MinProcessingFeeLevel,
+			MedFeeLevel:           m.MedFeeLevel,
+			OpenLedgerFeeLevel:    m.OpenLedgerFeeLevel,
+		}
+	}
+	if lft := ledgerSvcRef.GetLoadFeeTrack(); lft != nil {
+		services.LoadFactorFees = func() types.LoadFactorFees {
+			return types.LoadFactorFees{
+				Local:   lft.GetLocalFee(),
+				Net:     lft.GetRemoteFee(),
+				Cluster: lft.GetClusterFee(),
+			}
+		}
+	}
 
 	// Start consensus/networking if not in standalone mode
 	if !standalone {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1490,13 +1490,20 @@ func (a *Adaptor) StateAccounting() StateAccountingSnapshot {
 // is reached — see OnLedgerFullyValidated, driven by the engine's
 // ValidationTracker. This matches rippled's checkAccept() semantics
 // where local consensus != network agreement.
-func (a *Adaptor) OnConsensusReached(ledger consensus.Ledger, validations []*consensus.Validation) {
+func (a *Adaptor) OnConsensusReached(ledger consensus.Ledger, validations []*consensus.Validation, roundTime time.Duration) {
 	a.logger.Info("Consensus reached",
 		"ledger_seq", ledger.Seq(),
 		"validations", len(validations),
+		"round_time", roundTime,
 	)
 
 	if a.ledgerService != nil {
+		// Mirror rippled RCLConsensus.cpp:803-805: pass the round's
+		// wall-clock duration into the ledger service so the TxQ's
+		// processClosedLedger sees the timeLeap flag when consensus
+		// crossed the 5s slow-consensus threshold.
+		a.ledgerService.SetLastConsensusRoundTime(roundTime)
+
 		if hooks := a.ledgerService.GetEventHooks(); hooks != nil && hooks.OnConsensusPhase != nil {
 			go hooks.OnConsensusPhase("accepted")
 		}

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -533,7 +533,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a := newTestAdaptor(t)
 		a.SetOperatingMode(consensus.OpModeConnected)
 		l := stubLedger{seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
 	})
 
@@ -542,7 +542,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a.SetOperatingMode(consensus.OpModeSyncing)
 		// CloseTime far in the past — outside the 2*resolution window.
 		l := stubLedger{seq: 3, closeTime: a.Now().Add(-10 * time.Minute)}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeTracking, a.GetOperatingMode())
 	})
 
@@ -550,7 +550,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a := newTestAdaptor(t)
 		a.SetOperatingMode(consensus.OpModeTracking)
 		l := stubLedger{seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
 	})
 
@@ -558,7 +558,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a := newTestAdaptor(t)
 		a.SetOperatingMode(consensus.OpModeDisconnected)
 		l := stubLedger{seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeDisconnected, a.GetOperatingMode(),
 			"Disconnected must stay Disconnected — no peers means no consensus, "+
 				"and a stale lingering callback must not bypass the peer-count gate")
@@ -568,7 +568,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a := newTestAdaptor(t)
 		a.SetOperatingMode(consensus.OpModeFull)
 		l := stubLedger{seq: 3, closeTime: a.Now().Add(-10 * time.Minute)}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode(),
 			"once Full, OnConsensusReached must not demote — demotions are "+
 				"driven by wrongLedger/peer-disconnect paths, not by close-time freshness")
@@ -587,7 +587,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a.UpdatePeerLCL(2, theirLCL)
 		a.UpdatePeerLCL(3, ourLCL)
 		l := stubLedger{id: ourLCL, seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeConnected, a.GetOperatingMode(),
 			"majority-disagreeing peer LCLs must defer promotion (proxy for rippled !ledgerChange)")
 	})
@@ -599,7 +599,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a := newTestAdaptor(t)
 		a.SetOperatingMode(consensus.OpModeConnected)
 		l := stubLedger{id: consensus.LedgerID{0xAA}, seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode(),
 			"with no peer LCL evidence, promotion proceeds — the genesis-bootstrap path")
 	})
@@ -614,7 +614,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a.UpdatePeerLCL(2, ourLCL)
 		a.UpdatePeerLCL(3, theirLCL)
 		l := stubLedger{id: ourLCL, seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode(),
 			"peer LCL majority agreement permits promotion")
 	})

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -301,8 +301,11 @@ type StatusEvents interface {
 
 	// OnConsensusReached is called when a round completes successfully.
 	// Fires at local-accept time. It does NOT mean the network has
-	// agreed — see OnLedgerFullyValidated.
-	OnConsensusReached(ledger Ledger, validations []*Validation)
+	// agreed — see OnLedgerFullyValidated. roundTime is the wall-clock
+	// duration the just-finished consensus round took, used to drive
+	// the TxQ slow-consensus timeLeap flag (rippled
+	// RCLConsensus.cpp:803-805).
+	OnConsensusReached(ledger Ledger, validations []*Validation, roundTime time.Duration)
 
 	// OnLedgerFullyValidated is called once per ledger the first time
 	// trusted validations for that ledger cross the quorum threshold.

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -2965,8 +2965,15 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 		}
 	}
 
+	// Capture roundTime BEFORE notifying the adaptor so it sees the
+	// current round's duration, not the previous round's stale value
+	// in e.prevRoundTime (which is updated below). Mirrors rippled
+	// RCLConsensus.cpp:803-805 where roundTime is the local
+	// wall-clock measurement passed inline to processClosedLedger.
+	roundTime := time.Since(e.roundStartTime)
+
 	// Notify adaptor
-	e.adaptor.OnConsensusReached(newLedger, validations)
+	e.adaptor.OnConsensusReached(newLedger, validations, roundTime)
 
 	// Emit ledger accepted event
 	e.eventBus.Publish(&consensus.LedgerAcceptedEvent{
@@ -3007,8 +3014,9 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 		}
 	}
 
-	// Track round time for convergePercent calculation
-	e.prevRoundTime = time.Since(e.roundStartTime)
+	// Track round time for convergePercent calculation. Same value
+	// already published to the adaptor a few lines above.
+	e.prevRoundTime = roundTime
 
 	// Track trusted proposer count for peer pressure in next round
 	trustedCount := 0

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -535,7 +535,7 @@ func (a *mockAdaptor) CloseTimeResolution() time.Duration {
 
 func (a *mockAdaptor) AdjustCloseTime(rawCloseTimes consensus.CloseTimes) {}
 
-func (a *mockAdaptor) OnConsensusReached(ledger consensus.Ledger, validations []*consensus.Validation) {
+func (a *mockAdaptor) OnConsensusReached(ledger consensus.Ledger, validations []*consensus.Validation, roundTime time.Duration) {
 }
 
 func (a *mockAdaptor) OnLedgerFullyValidated(ledgerID consensus.LedgerID, seq uint32) {

--- a/internal/ledger/openledger/apply.go
+++ b/internal/ledger/openledger/apply.go
@@ -75,6 +75,12 @@ type ApplyConfig struct {
 	// previousLedger->rules() and threads it through; no equivalent
 	// "all-on" fallback exists there.
 	Rules *amendment.Rules
+	// ApplyFlags is the engine ApplyFlags driving this submission.
+	// Mirrors rippled NetworkOPs::apply which threads its flags into
+	// TxQ::canBeHeld (TxQ.cpp:393-399 rejects tapFAIL_HARD).
+	// Default zero — fail_hard rejection only fires when callers
+	// explicitly set the bit.
+	ApplyFlags tx.ApplyFlags
 }
 
 // ApplyTxs runs rippled's open-ledger 3-pass apply against view, which

--- a/internal/ledger/openledger/txqadapter.go
+++ b/internal/ledger/openledger/txqadapter.go
@@ -33,6 +33,14 @@ func NewTxqAdapter(view *ledger.Ledger, cfg ApplyConfig) *TxqAdapter {
 	return &TxqAdapter{view: view, cfg: cfg}
 }
 
+// GetApplyFlags returns the ApplyFlags the caller bound into the
+// per-submission ApplyConfig. Lets TxQ honour rippled's tapFAIL_HARD
+// gate (TxQ.cpp:393-399) without taking a direct dependency on
+// tx.EngineConfig from the queue.
+func (a *TxqAdapter) GetApplyFlags() tx.ApplyFlags {
+	return a.cfg.ApplyFlags
+}
+
 func (a *TxqAdapter) GetLedgerSequence() uint32 {
 	if a.view == nil {
 		return 0

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/localtxs"
 	"github.com/LeJamon/goXRPLd/internal/ledger/openledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
+	"github.com/LeJamon/goXRPLd/internal/loadfeetrack"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/txq"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
@@ -238,6 +239,20 @@ type Service struct {
 	// app.overlay().relay for each non-inner-batch tx surviving the
 	// rebuild). Nil when overlay broadcast is unwired (tests).
 	txRelay func(blob []byte)
+
+	// loadFeeTrack ports rippled's LoadFeeTrack subsystem
+	// (LoadFeeTrack.cpp). Surfaces the local / remote / cluster load
+	// fees the server_info handler emits as load_factor_local /
+	// load_factor_net / load_factor_cluster, and scales autofill fees
+	// when the node reports local load. Always non-nil after New().
+	loadFeeTrack *loadfeetrack.Tracker
+
+	// lastConsensusRoundTime is the wall-clock duration of the most
+	// recent consensus round, populated by the consensus adaptor via
+	// SetLastConsensusRoundTime. processClosedLedgerLocked converts
+	// it to the TxQ's timeLeap flag (RCLConsensus.cpp:805 →
+	// FeeMetrics::update). Zero in standalone or pre-startup.
+	lastConsensusRoundTime time.Duration
 }
 
 // New creates a new LedgerService
@@ -268,6 +283,7 @@ func New(cfg Config) (*Service, error) {
 		heldAdoptions:            make(map[uint32]*pendingAdopt),
 		txQueue:                  txq.New(txqCfg),
 		localTxs:                 localtxs.New(),
+		loadFeeTrack:             loadfeetrack.New(),
 	}
 
 	return s, nil
@@ -467,16 +483,34 @@ func (c *closedLedgerCtx) GetTransactionFeeLevels() []txq.FeeLevel {
 }
 
 // processClosedLedgerLocked updates the TxQ's fee metrics from the
-// just-closed ledger. timeLeap mirrors rippled's slow-consensus flag —
-// always false here (we don't currently track consensus duration).
-// Caller must hold s.mu.
+// just-closed ledger. timeLeap mirrors rippled RCLConsensus.cpp:805's
+// `roundTime > 5s` flag — when consensus took longer than the
+// slow-consensus threshold the metrics window is clamped instead of
+// advanced. Caller must hold s.mu.
 func (s *Service) processClosedLedgerLocked() {
 	if s.txQueue == nil || s.closedLedger == nil {
 		return
 	}
 	baseFee, _, _ := readFeesFromLedger(s.closedLedger)
 	ctx := &closedLedgerCtx{ledger: s.closedLedger, baseFee: baseFee}
-	s.txQueue.ProcessClosedLedger(ctx, false)
+	s.txQueue.ProcessClosedLedger(ctx, s.lastConsensusRoundTime > slowConsensusThreshold)
+}
+
+// slowConsensusThreshold matches rippled's `roundTime > 5s` predicate
+// at RCLConsensus.cpp:805 — the TxQ treats anything past it as a
+// slow-consensus round and freezes the fee-escalation window instead
+// of opening it further.
+const slowConsensusThreshold = 5 * time.Second
+
+// SetLastConsensusRoundTime is called by the consensus adaptor at the
+// end of each round to inform the service how long consensus took.
+// processClosedLedgerLocked reads the value to set the TxQ's timeLeap
+// flag. Standalone mode never calls this; the field stays zero and
+// timeLeap is always false.
+func (s *Service) SetLastConsensusRoundTime(d time.Duration) {
+	s.mu.Lock()
+	s.lastConsensusRoundTime = d
+	s.mu.Unlock()
 }
 
 // acceptOpenLedgerViewLocked invokes OpenLedger.Accept on the LCL
@@ -1375,6 +1409,14 @@ func (s *Service) IsStandalone() bool {
 func (s *Service) GetGenesisAccount() (string, error) {
 	_, address, err := genesis.GenerateGenesisAccountID()
 	return address, err
+}
+
+// GetLoadFeeTrack returns the service's LoadFeeTrack subsystem. Used
+// by the cli wiring to surface load_factor_local / load_factor_net /
+// load_factor_cluster on server_info, and by callers that want to
+// drive the local-fee bumps from job-queue saturation.
+func (s *Service) GetLoadFeeTrack() *loadfeetrack.Tracker {
+	return s.loadFeeTrack
 }
 
 // GetTxQMetrics returns the current TxQ metrics, or the zero value when

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -487,6 +487,15 @@ func (c *closedLedgerCtx) GetTransactionFeeLevels() []txq.FeeLevel {
 // `roundTime > 5s` flag — when consensus took longer than the
 // slow-consensus threshold the metrics window is clamped instead of
 // advanced. Caller must hold s.mu.
+//
+// driveLoadFeeTrackLocked is also invoked here so the local-fee
+// scaling factor reflects the just-observed open-ledger pressure —
+// when the open ledger filled past the reference fee level we raise;
+// otherwise we decay back toward NormalFee. This mirrors rippled in
+// spirit: rippled raises localTxnLoadFee_ from JobQueue saturation
+// (OverlayImpl / Server), while goxrpl currently has no JobQueue port,
+// so the on-chain escalation signal (the symptom rippled's JobQueue
+// also causes) is the cleanest available proxy.
 func (s *Service) processClosedLedgerLocked() {
 	if s.txQueue == nil || s.closedLedger == nil {
 		return
@@ -494,6 +503,24 @@ func (s *Service) processClosedLedgerLocked() {
 	baseFee, _, _ := readFeesFromLedger(s.closedLedger)
 	ctx := &closedLedgerCtx{ledger: s.closedLedger, baseFee: baseFee}
 	s.txQueue.ProcessClosedLedger(ctx, s.lastConsensusRoundTime > slowConsensusThreshold)
+	s.driveLoadFeeTrackLocked()
+}
+
+// driveLoadFeeTrackLocked raises the local fee when the just-closed
+// ledger showed open-ledger escalation, and decays it otherwise.
+// Caller must hold s.mu (ProcessClosedLedger is the only caller and
+// runs under the write lock). Bounded cost: each call is one TxQ
+// metrics snapshot + one Raise/Lower step on the tracker.
+func (s *Service) driveLoadFeeTrackLocked() {
+	if s.loadFeeTrack == nil || s.txQueue == nil {
+		return
+	}
+	metrics := s.txQueue.GetMetrics(0)
+	if metrics.OpenLedgerFeeLevel > metrics.ReferenceFeeLevel {
+		s.loadFeeTrack.RaiseLocalFee()
+	} else {
+		s.loadFeeTrack.LowerLocalFee()
+	}
 }
 
 // slowConsensusThreshold matches rippled's `roundTime > 5s` predicate

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/openledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+	"github.com/LeJamon/goXRPLd/internal/loadfeetrack"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/txq"
 	"github.com/LeJamon/goXRPLd/keylet"
@@ -214,10 +215,13 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 // (TransactionSign.cpp:765-836), so callers that have already supplied
 // Sequence must not receive an account-related error from this path.
 //
-// scaleFeeLoad (rippled's load-fee tracker) and the isUnlimited(role)
-// exemption have no Go equivalent and are intentionally omitted: goXRPL
-// never inflates fees for cluster load, and admin/identified callers
-// are not exempt from the ceiling check.
+// scaleFeeLoad (rippled's load-fee tracker) is applied to feeDefault
+// before the TxQ escalation comparison so a node reporting local /
+// remote / cluster load inflates the autofilled fee in lockstep with
+// rippled's TransactionSign.cpp:849-862. The isUnlimited(role)
+// exemption is intentionally not threaded here: goXRPL has no
+// admin-fee-bypass concept distinct from the ceiling check, so we
+// always pass bUnlimited=false.
 func (s *Service) GetAutofillFee(parsedTx tx.Transaction) (uint64, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -237,6 +241,11 @@ func (s *Service) GetAutofillFee(parsedTx tx.Transaction) (uint64, error) {
 
 	feeDefault := computeBaseFeeForTx(s.openLedger, parsedTx, feeCfg)
 	fee := feeDefault
+	if s.loadFeeTrack != nil {
+		if scaled, ok := loadfeetrack.ScaleFee(feeDefault, s.loadFeeTrack, false); ok {
+			fee = scaled
+		}
+	}
 	if s.txQueue != nil {
 		feeLevel := s.txQueue.GetRequiredFeeLevel(s.openLedger.TxCount())
 		if uint64(feeLevel) > txq.BaseLevel {

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -56,7 +56,13 @@ type SubmitResult struct {
 // persistent OpenLedger view, the held-pool absorbs the blob unless the
 // failure is permanent (tef*/tem*/tel*), and the legacy pendingTxs slice
 // is fed for standalone close.
-func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte) (*SubmitResult, error) {
+//
+// failHard mirrors rippled tapFAIL_HARD: when set, a submission that
+// does not apply is NOT pushed into the localTxs held pool and is NOT
+// fed into the canonical pendingTxs slice. The engine's ApplyFlags
+// also carries the bit so any future TxQ admission path observes it
+// (TxQ.cpp:393-399).
+func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, failHard bool) (*SubmitResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -91,6 +97,9 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte) 
 			Logger:                    s.config.Logger,
 			Rules:                     rulesFromLedger(s.closedLedger, s.logger),
 		}
+		if failHard {
+			engineConfig.ApplyFlags |= tx.TapFAIL_HARD
+		}
 		engine := tx.NewEngine(view, engineConfig)
 		applyResult = engine.Apply(transaction)
 		return applyResult.Applied
@@ -122,7 +131,14 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte) 
 	// permanent failures; everything else (ter*/tec*/applied/queued)
 	// belongs in the held pool so it survives Submit failure and LCL
 	// transitions until it lands or ages out (5 ledgers).
-	if rawBlob != nil && s.localTxs != nil {
+	//
+	// fail_hard short-circuits the held-pool push: rippled's TxQ
+	// canBeHeld (TxQ.cpp:393-399) returns telCAN_NOT_QUEUE on
+	// tapFAIL_HARD, and NetworkOPs.cpp:1685-1689 also gates relay on
+	// !enforceFailHard. We translate that as "don't hold the blob" so
+	// the caller learns about the failure immediately and doesn't see
+	// a delayed re-application.
+	if rawBlob != nil && s.localTxs != nil && !failHard {
 		ter := applyResult.Result
 		if !ter.IsTef() && !ter.IsTem() && !ter.IsTel() && ter != tx.TefALREADY {
 			ptx := openledger.PendingTx{
@@ -218,10 +234,13 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 // scaleFeeLoad (rippled's load-fee tracker) is applied to feeDefault
 // before the TxQ escalation comparison so a node reporting local /
 // remote / cluster load inflates the autofilled fee in lockstep with
-// rippled's TransactionSign.cpp:849-862. The isUnlimited(role)
-// exemption is intentionally not threaded here: goXRPL has no
-// admin-fee-bypass concept distinct from the ceiling check, so we
-// always pass bUnlimited=false.
+// rippled's TransactionSign.cpp:849-862. ScaleFee overflow propagates
+// as an error (matches rippled's Throw<std::overflow_error> in
+// LoadFeeTrack.cpp:108-110); silently returning the unscaled fee
+// would underprice a tx the network already rejects. The
+// isUnlimited(role) exemption is intentionally not threaded here:
+// goXRPL has no admin-fee-bypass concept distinct from the ceiling
+// check, so we always pass bUnlimited=false.
 func (s *Service) GetAutofillFee(parsedTx tx.Transaction) (uint64, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -242,9 +261,11 @@ func (s *Service) GetAutofillFee(parsedTx tx.Transaction) (uint64, error) {
 	feeDefault := computeBaseFeeForTx(s.openLedger, parsedTx, feeCfg)
 	fee := feeDefault
 	if s.loadFeeTrack != nil {
-		if scaled, ok := loadfeetrack.ScaleFee(feeDefault, s.loadFeeTrack, false); ok {
-			fee = scaled
+		scaled, ok := loadfeetrack.ScaleFee(feeDefault, s.loadFeeTrack, false)
+		if !ok {
+			return 0, fmt.Errorf("autofill fee: ScaleFee overflow (feeDefault=%d)", feeDefault)
 		}
+		fee = scaled
 	}
 	if s.txQueue != nil {
 		feeLevel := s.txQueue.GetRequiredFeeLevel(s.openLedger.TxCount())

--- a/internal/loadfeetrack/loadfeetrack.go
+++ b/internal/loadfeetrack/loadfeetrack.go
@@ -8,11 +8,25 @@
 // scaleFeeLoad (ScaleFee here) to inflate per-tx fees when the local
 // or wider XRPL network reports load.
 //
-// This package owns the data and arithmetic only; raising / lowering
-// is driven externally (e.g. by a job-queue size guard wired into
-// peer / RPC dispatch). server_info reads the per-source fees via the
-// rpc/types.LoadFactorFees hook so the load_factor_local /
-// load_factor_net / load_factor_cluster fields surface when active.
+// Production drivers in goxrpl:
+//
+//   - RaiseLocalFee / LowerLocalFee — driven on every consensus close
+//     by Service.driveLoadFeeTrackLocked: raises when the just-closed
+//     ledger showed open-ledger escalation (TxQ.OpenLedgerFeeLevel >
+//     ReferenceFeeLevel), decays otherwise. Stands in for rippled's
+//     JobQueue-saturation driver: goxrpl has no JobQueue port, and the
+//     on-chain escalation signal is the symptom rippled's JobQueue
+//     would cause anyway.
+//   - SetRemoteFee — not yet wired. Rippled sources this from
+//     TMPing.loadFactor on each peer ping; goxrpl's peer protobuf
+//     does not yet carry a LoadFactor field. The setter is exported
+//     so a future protobuf-extension PR can wire it.
+//   - SetClusterFee — not yet wired. Rippled sources this from
+//     ClusterNode updates; goxrpl has no cluster subsystem yet.
+//
+// server_info reads the per-source fees via the rpc/types.LoadFactorFees
+// hook so the load_factor_local / load_factor_net / load_factor_cluster
+// fields surface when active.
 package loadfeetrack
 
 import (
@@ -26,11 +40,11 @@ import (
 // (1_000_000× the base load); the inc/dec fractions reflect the 1/4
 // step rippled uses on each raise / lower call.
 const (
-	NormalFee       uint32 = 256
-	FeeIncFraction  uint32 = 4
-	FeeDecFraction  uint32 = 4
-	FeeMax          uint32 = NormalFee * 1_000_000
-	raiseThreshold         = 2 // raiseLocalFee returns false on the first call
+	NormalFee      uint32 = 256
+	FeeIncFraction uint32 = 4
+	FeeDecFraction uint32 = 4
+	FeeMax         uint32 = NormalFee * 1_000_000
+	raiseThreshold        = 2 // raiseLocalFee returns false on the first call
 )
 
 // Tracker is the concurrent-safe port of rippled's LoadFeeTrack.

--- a/internal/loadfeetrack/loadfeetrack.go
+++ b/internal/loadfeetrack/loadfeetrack.go
@@ -17,12 +17,16 @@
 //     JobQueue-saturation driver: goxrpl has no JobQueue port, and the
 //     on-chain escalation signal is the symptom rippled's JobQueue
 //     would cause anyway.
-//   - SetRemoteFee — not yet wired. Rippled sources this from
-//     TMPing.loadFactor on each peer ping; goxrpl's peer protobuf
-//     does not yet carry a LoadFactor field. The setter is exported
-//     so a future protobuf-extension PR can wire it.
-//   - SetClusterFee — not yet wired. Rippled sources this from
-//     ClusterNode updates; goxrpl has no cluster subsystem yet.
+//   - SetRemoteFee — not yet wired. Rippled sources this from the
+//     median of sfLoadFee fields carried in trusted validations,
+//     aggregated in LedgerMaster::checkAccept (LedgerMaster.cpp:977-
+//     1006). STValidation already carries sfLoadFee in goxrpl, so the
+//     hook is reachable without protobuf changes — see follow-up
+//     issue.
+//   - SetClusterFee — not yet wired. Rippled sources this from the
+//     TMCluster peer-protocol message (ClusterNode.getLoadFee
+//     median; PeerImp.cpp:1175-1193). Requires the cluster subsystem
+//     which goxrpl does not port today.
 //
 // server_info reads the per-source fees via the rpc/types.LoadFactorFees
 // hook so the load_factor_local / load_factor_net / load_factor_cluster

--- a/internal/loadfeetrack/loadfeetrack.go
+++ b/internal/loadfeetrack/loadfeetrack.go
@@ -21,8 +21,7 @@
 //     median of sfLoadFee fields carried in trusted validations,
 //     aggregated in LedgerMaster::checkAccept (LedgerMaster.cpp:977-
 //     1006). STValidation already carries sfLoadFee in goxrpl, so the
-//     hook is reachable without protobuf changes — see follow-up
-//     issue.
+//     hook is reachable without protobuf changes — tracked at #542.
 //   - SetClusterFee — not yet wired. Rippled sources this from the
 //     TMCluster peer-protocol message (ClusterNode.getLoadFee
 //     median; PeerImp.cpp:1175-1193). Requires the cluster subsystem

--- a/internal/loadfeetrack/loadfeetrack.go
+++ b/internal/loadfeetrack/loadfeetrack.go
@@ -1,0 +1,222 @@
+// Package loadfeetrack ports rippled's LoadFeeTrack subsystem
+// (src/xrpld/app/misc/detail/LoadFeeTrack.cpp).
+//
+// LoadFeeTrack manages the server-load fee multiplier: a transient,
+// per-node fee bump driven by job-queue saturation (raiseLocalFee /
+// lowerLocalFee) plus mirrored remote- and cluster-wide bumps
+// (setRemoteFee / setClusterFee). The current factor is fed into
+// scaleFeeLoad (ScaleFee here) to inflate per-tx fees when the local
+// or wider XRPL network reports load.
+//
+// This package owns the data and arithmetic only; raising / lowering
+// is driven externally (e.g. by a job-queue size guard wired into
+// peer / RPC dispatch). server_info reads the per-source fees via the
+// rpc/types.LoadFactorFees hook so the load_factor_local /
+// load_factor_net / load_factor_cluster fields surface when active.
+package loadfeetrack
+
+import (
+	"math/bits"
+	"sync"
+)
+
+// Constants mirror rippled LoadFeeTrack.h:141-147. NormalFee is the
+// load-factor scale unit; a tracker reporting NormalFee means "no
+// load". FeeMax caps how high RaiseLocalFee can drive the local fee
+// (1_000_000× the base load); the inc/dec fractions reflect the 1/4
+// step rippled uses on each raise / lower call.
+const (
+	NormalFee       uint32 = 256
+	FeeIncFraction  uint32 = 4
+	FeeDecFraction  uint32 = 4
+	FeeMax          uint32 = NormalFee * 1_000_000
+	raiseThreshold         = 2 // raiseLocalFee returns false on the first call
+)
+
+// Tracker is the concurrent-safe port of rippled's LoadFeeTrack.
+// The zero value is NOT ready for use — construct one with New().
+type Tracker struct {
+	mu sync.Mutex
+
+	localFee   uint32 // localTxnLoadFee_
+	remoteFee  uint32 // remoteTxnLoadFee_
+	clusterFee uint32 // clusterTxnLoadFee_
+	raiseCount uint32
+}
+
+// New returns a Tracker initialised to the no-load state: all three
+// per-source fees equal NormalFee and raiseCount is zero. Mirrors
+// rippled LoadFeeTrack.h:47-55.
+func New() *Tracker {
+	return &Tracker{
+		localFee:   NormalFee,
+		remoteFee:  NormalFee,
+		clusterFee: NormalFee,
+	}
+}
+
+// SetRemoteFee mirrors rippled setRemoteFee (LoadFeeTrack.h:59-65) —
+// the network-aggregate remote load fee, updated from peer pings.
+func (t *Tracker) SetRemoteFee(f uint32) {
+	t.mu.Lock()
+	t.remoteFee = f
+	t.mu.Unlock()
+}
+
+// GetRemoteFee mirrors rippled getRemoteFee (LoadFeeTrack.h:67-72).
+func (t *Tracker) GetRemoteFee() uint32 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.remoteFee
+}
+
+// GetLocalFee mirrors rippled getLocalFee (LoadFeeTrack.h:74-79).
+func (t *Tracker) GetLocalFee() uint32 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.localFee
+}
+
+// GetClusterFee mirrors rippled getClusterFee (LoadFeeTrack.h:81-86).
+func (t *Tracker) GetClusterFee() uint32 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.clusterFee
+}
+
+// SetClusterFee mirrors rippled setClusterFee (LoadFeeTrack.h:112-118).
+func (t *Tracker) SetClusterFee(f uint32) {
+	t.mu.Lock()
+	t.clusterFee = f
+	t.mu.Unlock()
+}
+
+// GetLoadBase mirrors rippled getLoadBase (LoadFeeTrack.h:88-92) and
+// returns NormalFee. Callers should compare scaling factors against
+// this base — equality means "no load contribution from this source".
+func (t *Tracker) GetLoadBase() uint32 {
+	return NormalFee
+}
+
+// GetLoadFactor mirrors rippled getLoadFactor (LoadFeeTrack.h:94-100):
+// the max of the three per-source fees, used for the consolidated
+// load_factor / load_factor_server emit.
+func (t *Tracker) GetLoadFactor() uint32 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return max3(t.clusterFee, t.localFee, t.remoteFee)
+}
+
+// GetScalingFactors mirrors rippled getScalingFactors
+// (LoadFeeTrack.h:102-110): returns the (feeFactor, uRemFee) pair
+// ScaleFee uses to scale the per-tx fee.
+//   - feeFactor: max(local, remote) drives the user-visible scaling
+//   - uRemFee:   max(remote, cluster) is the privileged-user floor
+func (t *Tracker) GetScalingFactors() (feeFactor, uRemFee uint32) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return max2(t.localFee, t.remoteFee), max2(t.remoteFee, t.clusterFee)
+}
+
+// IsLoadedLocal mirrors rippled isLoadedLocal (LoadFeeTrack.h:125-130).
+func (t *Tracker) IsLoadedLocal() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.raiseCount != 0 || t.localFee != NormalFee
+}
+
+// IsLoadedCluster mirrors rippled isLoadedCluster (LoadFeeTrack.h:132-138).
+func (t *Tracker) IsLoadedCluster() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.raiseCount != 0 || t.localFee != NormalFee || t.clusterFee != NormalFee
+}
+
+// RaiseLocalFee mirrors rippled LoadFeeTrack::raiseLocalFee
+// (LoadFeeTrack.cpp:32-58). The first call bumps raiseCount only; the
+// second and later calls grow localFee by ~25% (subject to a
+// remoteFee floor and the FeeMax ceiling). Returns true when the
+// effective localFee changes.
+func (t *Tracker) RaiseLocalFee() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.raiseCount++
+	if t.raiseCount < raiseThreshold {
+		return false
+	}
+
+	orig := t.localFee
+	if t.localFee < t.remoteFee {
+		t.localFee = t.remoteFee
+	}
+	t.localFee += t.localFee / FeeIncFraction
+	if t.localFee > FeeMax {
+		t.localFee = FeeMax
+	}
+	return orig != t.localFee
+}
+
+// LowerLocalFee mirrors rippled LoadFeeTrack::lowerLocalFee
+// (LoadFeeTrack.cpp:60-79). Clears the raiseCount and shrinks
+// localFee toward NormalFee in 1/FeeDecFraction (25%) steps; never
+// dips below NormalFee. Returns true when the effective localFee
+// changes.
+func (t *Tracker) LowerLocalFee() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	orig := t.localFee
+	t.raiseCount = 0
+	t.localFee -= t.localFee / FeeDecFraction
+	if t.localFee < NormalFee {
+		t.localFee = NormalFee
+	}
+	return orig != t.localFee
+}
+
+// ScaleFee mirrors rippled scaleFeeLoad (LoadFeeTrack.cpp:84-111):
+// fee * feeFactor / loadBase, with the bUnlimited privileged-user
+// clamp that lets identified callers pay the remote floor unless
+// local load exceeds 4× the remote. Returns the scaled fee; the
+// caller is responsible for any subsequent ceiling check. ok=false
+// signals an overflow; the caller should reject the transaction.
+func ScaleFee(fee uint64, t *Tracker, bUnlimited bool) (scaled uint64, ok bool) {
+	if fee == 0 {
+		return 0, true
+	}
+
+	feeFactor, uRemFee := t.GetScalingFactors()
+	if bUnlimited && feeFactor > uRemFee && feeFactor < 4*uRemFee {
+		feeFactor = uRemFee
+	}
+
+	scaled, ok = mulDiv64(fee, uint64(feeFactor), uint64(t.GetLoadBase()))
+	return scaled, ok
+}
+
+// mulDiv64 computes (a * b) / c using a 128-bit intermediate so the
+// product can grow beyond uint64. Mirrors rippled's mulDiv overflow
+// contract: ok=false on overflow or c==0.
+func mulDiv64(a, b, c uint64) (uint64, bool) {
+	if c == 0 {
+		return 0, false
+	}
+	hi, lo := bits.Mul64(a, b)
+	if hi >= c {
+		return 0, false
+	}
+	q, _ := bits.Div64(hi, lo, c)
+	return q, true
+}
+
+func max2(a, b uint32) uint32 {
+	if a >= b {
+		return a
+	}
+	return b
+}
+
+func max3(a, b, c uint32) uint32 {
+	return max2(max2(a, b), c)
+}

--- a/internal/loadfeetrack/loadfeetrack_test.go
+++ b/internal/loadfeetrack/loadfeetrack_test.go
@@ -1,0 +1,148 @@
+package loadfeetrack_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/loadfeetrack"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNew_NoLoad pins the constructor initial state: all three
+// per-source fees equal NormalFee, no raise pending, neither
+// IsLoadedLocal nor IsLoadedCluster fires.
+func TestNew_NoLoad(t *testing.T) {
+	tr := loadfeetrack.New()
+	require.Equal(t, loadfeetrack.NormalFee, tr.GetLocalFee())
+	require.Equal(t, loadfeetrack.NormalFee, tr.GetRemoteFee())
+	require.Equal(t, loadfeetrack.NormalFee, tr.GetClusterFee())
+	require.Equal(t, loadfeetrack.NormalFee, tr.GetLoadFactor())
+	require.False(t, tr.IsLoadedLocal())
+	require.False(t, tr.IsLoadedCluster())
+}
+
+// TestScaleFee_NoLoad mirrors LoadFeeTrack_test.cpp:36-86 — under a
+// no-load tracker, scaleFeeLoad is the identity for any input fee.
+func TestScaleFee_NoLoad(t *testing.T) {
+	tr := loadfeetrack.New()
+	for _, f := range []uint64{0, 1, 10, 10_000, 1 << 32} {
+		scaled, ok := loadfeetrack.ScaleFee(f, tr, false)
+		require.True(t, ok)
+		require.Equal(t, f, scaled, "fee=%d should be identity under no-load", f)
+	}
+}
+
+// TestRaiseLocalFee_FirstCallIsNoOp pins
+// LoadFeeTrack.cpp:37-38 — the first RaiseLocalFee call increments
+// raiseCount but does not change localFee.
+func TestRaiseLocalFee_FirstCallIsNoOp(t *testing.T) {
+	tr := loadfeetrack.New()
+	changed := tr.RaiseLocalFee()
+	require.False(t, changed, "first raise must not bump localFee")
+	require.Equal(t, loadfeetrack.NormalFee, tr.GetLocalFee())
+	// raiseCount > 0 → IsLoadedLocal flips even though the fee hasn't grown.
+	require.True(t, tr.IsLoadedLocal())
+}
+
+// TestRaiseLocalFee_SecondCallBumps pins
+// LoadFeeTrack.cpp:42-47 — the second call raises localFee by ~25%
+// (subject to the remoteFee floor).
+func TestRaiseLocalFee_SecondCallBumps(t *testing.T) {
+	tr := loadfeetrack.New()
+	tr.RaiseLocalFee()
+	changed := tr.RaiseLocalFee()
+	require.True(t, changed)
+	// 256 + 256/4 = 320
+	require.Equal(t, uint32(320), tr.GetLocalFee())
+}
+
+// TestRaiseLocalFee_RemoteFloor pins the
+// LoadFeeTrack.cpp:43-44 floor: localFee gets pulled up to remoteFee
+// before the 25% bump when remote currently outpaces local.
+func TestRaiseLocalFee_RemoteFloor(t *testing.T) {
+	tr := loadfeetrack.New()
+	tr.SetRemoteFee(1024)
+	tr.RaiseLocalFee()
+	tr.RaiseLocalFee()
+	// localFee was bumped to 1024 then grown by 1024/4 = 1280.
+	require.Equal(t, uint32(1280), tr.GetLocalFee())
+}
+
+// TestRaiseLocalFee_CappedAtMax pins the
+// LoadFeeTrack.cpp:49-50 ceiling: localFee never exceeds FeeMax.
+func TestRaiseLocalFee_CappedAtMax(t *testing.T) {
+	tr := loadfeetrack.New()
+	// Drive far past FeeMax via the remote-fee floor (which only
+	// requires a single second-call raise to overshoot the cap).
+	tr.SetRemoteFee(loadfeetrack.FeeMax)
+	tr.RaiseLocalFee()
+	tr.RaiseLocalFee()
+	require.Equal(t, loadfeetrack.FeeMax, tr.GetLocalFee(),
+		"FeeMax ceiling must clamp localFee")
+}
+
+// TestLowerLocalFee_StepsDown pins
+// LoadFeeTrack.cpp:67-71 — LowerLocalFee shrinks localFee by 1/4 each
+// call and clears raiseCount.
+func TestLowerLocalFee_StepsDown(t *testing.T) {
+	tr := loadfeetrack.New()
+	tr.RaiseLocalFee()
+	tr.RaiseLocalFee()
+	require.Equal(t, uint32(320), tr.GetLocalFee())
+	require.True(t, tr.LowerLocalFee())
+	// 320 - 320/4 = 240, clamped up to NormalFee=256.
+	require.Equal(t, uint32(256), tr.GetLocalFee())
+	require.False(t, tr.IsLoadedLocal(), "raiseCount cleared and localFee==NormalFee")
+}
+
+// TestLowerLocalFee_AtNormalIsNoOp pins
+// LoadFeeTrack.cpp:73-74 — LowerLocalFee at NormalFee returns false.
+func TestLowerLocalFee_AtNormalIsNoOp(t *testing.T) {
+	tr := loadfeetrack.New()
+	require.False(t, tr.LowerLocalFee())
+	require.Equal(t, loadfeetrack.NormalFee, tr.GetLocalFee())
+}
+
+// TestScaleFee_LocalLoad verifies fee inflation when local load
+// exceeds the base: ScaleFee(fee) = fee * feeFactor / loadBase.
+func TestScaleFee_LocalLoad(t *testing.T) {
+	tr := loadfeetrack.New()
+	tr.RaiseLocalFee()
+	tr.RaiseLocalFee() // localFee=320, base=256
+	scaled, ok := loadfeetrack.ScaleFee(10, tr, false)
+	require.True(t, ok)
+	require.Equal(t, uint64(12), scaled) // 10*320/256 = 12 (truncated)
+}
+
+// TestScaleFee_UnlimitedClampsToRemoteFloor pins
+// LoadFeeTrack.cpp:98-100 — when bUnlimited is true and the local
+// factor exceeds the remote floor but not by 4×, the privileged
+// caller pays only the remote-floor scaling.
+func TestScaleFee_UnlimitedClampsToRemoteFloor(t *testing.T) {
+	tr := loadfeetrack.New()
+	tr.SetRemoteFee(300)
+	tr.RaiseLocalFee()
+	tr.RaiseLocalFee() // local jumps to 300 then 375 (<1200=4*300)
+	require.Equal(t, uint32(375), tr.GetLocalFee())
+
+	// Without the unlimited clamp the user pays 10*375/256 = 14.
+	gen, ok := loadfeetrack.ScaleFee(10, tr, false)
+	require.True(t, ok)
+	require.Equal(t, uint64(14), gen)
+
+	// With the unlimited clamp the user pays 10*max(remote,cluster)/256 = 10*300/256 = 11.
+	priv, ok := loadfeetrack.ScaleFee(10, tr, true)
+	require.True(t, ok)
+	require.Equal(t, uint64(11), priv)
+}
+
+// TestScaleFee_OverflowSafe pins the mulDiv overflow contract:
+// (maxUint64 / loadBase) * loadBase fits, but maxUint64 * 2 doesn't.
+func TestScaleFee_OverflowSafe(t *testing.T) {
+	tr := loadfeetrack.New()
+	// Drive local way up so feeFactor > loadBase.
+	tr.SetRemoteFee(2 * loadfeetrack.NormalFee)
+	tr.RaiseLocalFee()
+	tr.RaiseLocalFee()
+	_, ok := loadfeetrack.ScaleFee(^uint64(0), tr, false)
+	require.False(t, ok, "scaling MaxUint64 by a >1 factor must overflow-flag")
+}

--- a/internal/rpc/fee_test.go
+++ b/internal/rpc/fee_test.go
@@ -1,0 +1,163 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/require"
+)
+
+func feeRequest(t *testing.T, services *types.ServiceContainer) map[string]interface{} {
+	t.Helper()
+	method := &handlers.FeeMethod{}
+	result, rpcErr := method.Handle(&types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}, nil)
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+	resp, ok := result.(map[string]interface{})
+	require.True(t, ok, "fee response is not a map")
+	return resp
+}
+
+// TestFee_FallsBackToIdleDefaults pins the no-TxQ-hook path: the
+// handler reproduces rippled's idle-state response (queue empty,
+// reference_level=256, all drops fields equal to base_fee).
+func TestFee_FallsBackToIdleDefaults(t *testing.T) {
+	mock := newMockLedgerService()
+	mock.standalone = false
+	mock.currentLedgerIndex = 7
+	services := &types.ServiceContainer{Ledger: mock}
+
+	resp := feeRequest(t, services)
+
+	require.Equal(t, uint32(7), resp["ledger_current_index"])
+	require.Equal(t, "0", resp["current_ledger_size"])
+	require.Equal(t, "0", resp["current_queue_size"])
+	require.Equal(t, "32", resp["expected_ledger_size"])
+	require.Equal(t, "640", resp["max_queue_size"])
+
+	levels := resp["levels"].(map[string]interface{})
+	require.Equal(t, "256", levels["reference_level"])
+	require.Equal(t, "256", levels["minimum_level"])
+	require.Equal(t, "256", levels["median_level"])
+	require.Equal(t, "256", levels["open_ledger_level"])
+
+	drops := resp["drops"].(map[string]interface{})
+	require.Equal(t, "10", drops["base_fee"])
+	require.Equal(t, "10", drops["median_fee"])
+	require.Equal(t, "10", drops["minimum_fee"])
+	require.Equal(t, "10", drops["open_ledger_fee"])
+}
+
+// TestFee_StandaloneFallback bumps the idle expected_ledger_size to
+// 1000 and max_queue_size to 20_000 (rippled minimumTxnInLedgerSA=1000).
+func TestFee_StandaloneFallback(t *testing.T) {
+	mock := newMockLedgerService()
+	mock.standalone = true
+	services := &types.ServiceContainer{Ledger: mock}
+
+	resp := feeRequest(t, services)
+	require.Equal(t, "1000", resp["expected_ledger_size"])
+	require.Equal(t, "20000", resp["max_queue_size"])
+}
+
+// TestFee_LiveMetrics_Escalating verifies the per-level drops follow
+// rippled's TxQ.cpp:1898-1907 algebra: median/min/open all scaled by
+// (level * baseFee) / 256, with the open-ledger value rounded up to
+// preserve the snapshot's level on round-trip.
+func TestFee_LiveMetrics_Escalating(t *testing.T) {
+	mock := newMockLedgerService()
+	mock.standalone = false
+	mock.currentLedgerIndex = 99
+	services := &types.ServiceContainer{Ledger: mock}
+	maxQ := uint32(640)
+	services.TxQFeeMetrics = func() types.TxQFeeMetrics {
+		return types.TxQFeeMetrics{
+			TxCount:               5,
+			TxQMaxSize:            &maxQ,
+			TxInLedger:            42,
+			TxPerLedger:           32,
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 256,
+			MedFeeLevel:           512,
+			OpenLedgerFeeLevel:    1024,
+		}
+	}
+
+	resp := feeRequest(t, services)
+	require.Equal(t, "5", resp["current_queue_size"])
+	require.Equal(t, "42", resp["current_ledger_size"])
+	require.Equal(t, "32", resp["expected_ledger_size"])
+	require.Equal(t, "640", resp["max_queue_size"])
+
+	levels := resp["levels"].(map[string]interface{})
+	require.Equal(t, "256", levels["reference_level"])
+	require.Equal(t, "512", levels["median_level"])
+	require.Equal(t, "1024", levels["open_ledger_level"])
+
+	drops := resp["drops"].(map[string]interface{})
+	require.Equal(t, "10", drops["base_fee"])
+	require.Equal(t, "20", drops["median_fee"])
+	require.Equal(t, "10", drops["minimum_fee"])
+	require.Equal(t, "40", drops["open_ledger_fee"])
+}
+
+// TestFee_QueueFull_SwapsMinimumBase mirrors rippled TxQ.cpp:1900-1902:
+// when txCount >= txQMaxSize, the minimum_fee uses the effective base
+// (clamped to 1 if base==0 and escalation is active).
+func TestFee_QueueFull_SwapsMinimumBase(t *testing.T) {
+	mock := newMockLedgerServiceServerInfo()
+	mock.standalone = false
+	mock.currentLedgerIndex = 99
+	mock.baseFee = 0
+	services := &types.ServiceContainer{Ledger: mock}
+	maxQ := uint32(2)
+	services.TxQFeeMetrics = func() types.TxQFeeMetrics {
+		return types.TxQFeeMetrics{
+			TxCount:               2,
+			TxQMaxSize:            &maxQ,
+			TxInLedger:            10,
+			TxPerLedger:           32,
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 768,
+			MedFeeLevel:           256,
+			OpenLedgerFeeLevel:    512,
+		}
+	}
+
+	resp := feeRequest(t, services)
+	drops := resp["drops"].(map[string]interface{})
+
+	require.Equal(t, "0", drops["base_fee"])
+	require.Equal(t, "3", drops["minimum_fee"])
+	require.Equal(t, "2", drops["open_ledger_fee"])
+}
+
+// TestFee_NilTxQMaxSize_OmitsMaxQueueSize matches rippled
+// TxQ.cpp:1879-1880: max_queue_size is only emitted when the queue
+// has a configured upper bound.
+func TestFee_NilTxQMaxSize_OmitsMaxQueueSize(t *testing.T) {
+	mock := newMockLedgerService()
+	services := &types.ServiceContainer{Ledger: mock}
+	services.TxQFeeMetrics = func() types.TxQFeeMetrics {
+		return types.TxQFeeMetrics{
+			TxCount:               0,
+			TxQMaxSize:            nil,
+			TxPerLedger:           32,
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 256,
+			MedFeeLevel:           256,
+			OpenLedgerFeeLevel:    256,
+		}
+	}
+
+	resp := feeRequest(t, services)
+	_, hasMaxQueue := resp["max_queue_size"]
+	require.False(t, hasMaxQueue, "max_queue_size must be omitted when TxQ has no configured limit")
+}

--- a/internal/rpc/handlers/fee.go
+++ b/internal/rpc/handlers/fee.go
@@ -2,23 +2,26 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
+	"math/bits"
+	"strconv"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
 // FeeMethod handles the fee RPC method.
-// See rippled: src/xrpld/rpc/handlers/Fee1.cpp -> TxQ::doRPC()
-//
-// Without a real TxQ implementation, fee escalation metrics are approximated
-// using rippled's default idle-state values:
-//   - reference_level = 256 (baseLevel in rippled TxQ.h)
-//   - expected_ledger_size = 32 (minimumTxnInLedger default, non-standalone)
-//   - max_queue_size = 20 * expected = 640 (ledgersInQueue=20 * txPerLedger)
-//   - current_ledger_size = 0 (no open ledger tx count available yet)
-//   - current_queue_size = 0 (no TxQ)
-//   - drops: median_fee/minimum_fee/open_ledger_fee all equal base_fee (no escalation)
+// Mirrors rippled TxQ::doRPC (TxQ.cpp:1860-1909): emits queue
+// occupancy, fee levels, and per-level drops derived from the live
+// TxQ snapshot. When the TxQ hook isn't wired (standalone tests,
+// pre-startup) the handler falls back to rippled's idle-state
+// defaults — reference_level=256, drops fields equal to base_fee.
 type FeeMethod struct{}
+
+const (
+	feeBaseLevel        uint64 = 256 // rippled TxQ.h baseLevel
+	feeDefaultExpected         = 32  // minimumTxnInLedger (non-standalone)
+	feeStandaloneExpect        = 1000
+	feeLedgersInQueue          = 20
+)
 
 func (m *FeeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
 	if err := RequireLedgerService(ctx.Services); err != nil {
@@ -28,43 +31,102 @@ func (m *FeeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inter
 	baseFee, _, _ := ctx.Services.Ledger.GetCurrentFees()
 	currentLedgerIndex := ctx.Services.Ledger.GetCurrentLedgerIndex()
 
-	baseFeeStr := fmt.Sprintf("%d", baseFee)
+	metrics := snapshotTxQ(ctx.Services, ctx.Services.Ledger.IsStandalone())
 
-	// Reference fee level is 256 (baseLevel in rippled TxQ.h).
-	// Without a real TxQ implementation, all fee levels stay at the reference level.
-	referenceFeeLevel := "256"
-
-	// Rippled defaults: minimumTxnInLedger=32 (non-standalone), ledgersInQueue=20.
-	// In standalone: minimumTxnInLedgerSA=1000.
-	// max_queue_size = ledgersInQueue * txPerLedger.
-	expectedLedgerSize := "32"
-	maxQueueSize := "640"
-	if ctx.Services.Ledger.IsStandalone() {
-		expectedLedgerSize = "1000"
-		maxQueueSize = "20000"
+	effective := effectiveBaseFee(baseFee, metrics)
+	openFee := dropsFromLevel(metrics.OpenLedgerFeeLevel, effective)
+	if effective != 0 && levelFromDrops(openFee, effective) < metrics.OpenLedgerFeeLevel {
+		openFee += 1
 	}
+	medianFee := dropsFromLevel(metrics.MedFeeLevel, baseFee)
+	minFeeBase := baseFee
+	if metrics.TxQMaxSize != nil && metrics.TxCount >= *metrics.TxQMaxSize {
+		minFeeBase = effective
+	}
+	minimumFee := dropsFromLevel(metrics.MinProcessingFeeLevel, minFeeBase)
 
 	response := map[string]interface{}{
-		"current_ledger_size": "0",
-		"current_queue_size":  "0",
-		"drops": map[string]interface{}{
-			"base_fee":        baseFeeStr,
-			"median_fee":      baseFeeStr,
-			"minimum_fee":     baseFeeStr,
-			"open_ledger_fee": baseFeeStr,
-		},
-		"expected_ledger_size": expectedLedgerSize,
+		"current_ledger_size":  strconv.FormatUint(uint64(metrics.TxInLedger), 10),
+		"current_queue_size":   strconv.FormatUint(uint64(metrics.TxCount), 10),
+		"expected_ledger_size": strconv.FormatUint(uint64(metrics.TxPerLedger), 10),
 		"ledger_current_index": currentLedgerIndex,
 		"levels": map[string]interface{}{
-			"median_level":      referenceFeeLevel,
-			"minimum_level":     referenceFeeLevel,
-			"open_ledger_level": referenceFeeLevel,
-			"reference_level":   referenceFeeLevel,
+			"reference_level":   strconv.FormatUint(metrics.ReferenceFeeLevel, 10),
+			"minimum_level":     strconv.FormatUint(metrics.MinProcessingFeeLevel, 10),
+			"median_level":      strconv.FormatUint(metrics.MedFeeLevel, 10),
+			"open_ledger_level": strconv.FormatUint(metrics.OpenLedgerFeeLevel, 10),
 		},
-		"max_queue_size": maxQueueSize,
+		"drops": map[string]interface{}{
+			"base_fee":        strconv.FormatUint(baseFee, 10),
+			"median_fee":      strconv.FormatUint(medianFee, 10),
+			"minimum_fee":     strconv.FormatUint(minimumFee, 10),
+			"open_ledger_fee": strconv.FormatUint(openFee, 10),
+		},
+	}
+	if metrics.TxQMaxSize != nil {
+		response["max_queue_size"] = strconv.FormatUint(uint64(*metrics.TxQMaxSize), 10)
 	}
 
 	return response, nil
+}
+
+// snapshotTxQ returns the active TxQ metrics, or rippled's idle-state
+// defaults when the TxQ hook isn't wired.
+func snapshotTxQ(services *types.ServiceContainer, standalone bool) types.TxQFeeMetrics {
+	if services != nil && services.TxQFeeMetrics != nil {
+		return services.TxQFeeMetrics()
+	}
+	expected := uint32(feeDefaultExpected)
+	if standalone {
+		expected = feeStandaloneExpect
+	}
+	maxQueue := expected * feeLedgersInQueue
+	return types.TxQFeeMetrics{
+		TxCount:               0,
+		TxQMaxSize:            &maxQueue,
+		TxInLedger:            0,
+		TxPerLedger:           expected,
+		ReferenceFeeLevel:     feeBaseLevel,
+		MinProcessingFeeLevel: feeBaseLevel,
+		MedFeeLevel:           feeBaseLevel,
+		OpenLedgerFeeLevel:    feeBaseLevel,
+	}
+}
+
+// effectiveBaseFee mirrors rippled TxQ.cpp:1891-1895: when baseFee is
+// 0 drops but escalation has kicked in, treat the base fee as 1 drop
+// so the level→drops math doesn't collapse to 0.
+func effectiveBaseFee(baseFee uint64, m types.TxQFeeMetrics) uint64 {
+	if baseFee == 0 && m.OpenLedgerFeeLevel != m.ReferenceFeeLevel {
+		return 1
+	}
+	return baseFee
+}
+
+// dropsFromLevel converts a fee level back to drops: (level * baseFee) / baseLevel.
+// Mirrors rippled toDrops() with 128-bit intermediate to avoid overflow.
+func dropsFromLevel(level, baseFee uint64) uint64 {
+	hi, lo := bits.Mul64(level, baseFee)
+	if hi >= feeBaseLevel {
+		return ^uint64(0)
+	}
+	quo, _ := bits.Div64(hi, lo, feeBaseLevel)
+	return quo
+}
+
+// levelFromDrops converts drops to a fee level: (drops * baseLevel) / baseFee.
+// Used to detect when integer division truncated openFee below the
+// snapshot's open-ledger level so we can round up by one drop.
+func levelFromDrops(drops, baseFee uint64) uint64 {
+	if baseFee == 0 {
+		return 0
+	}
+	hi, lo := bits.Mul64(drops, feeBaseLevel)
+	if hi >= baseFee {
+		return ^uint64(0)
+	}
+	quo, _ := bits.Div64(hi, lo, baseFee)
+	return quo
 }
 
 func (m *FeeMethod) RequiredRole() types.Role {

--- a/internal/rpc/handlers/fee.go
+++ b/internal/rpc/handlers/fee.go
@@ -33,15 +33,15 @@ func (m *FeeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inter
 
 	metrics := snapshotTxQ(ctx.Services, ctx.Services.Ledger.IsStandalone())
 
-	effective := effectiveBaseFee(baseFee, metrics)
-	openFee := dropsFromLevel(metrics.OpenLedgerFeeLevel, effective)
-	if effective != 0 && levelFromDrops(openFee, effective) < metrics.OpenLedgerFeeLevel {
+	effectiveBase := effectiveBaseFee(baseFee, metrics)
+	openFee := dropsFromLevel(metrics.OpenLedgerFeeLevel, effectiveBase)
+	if effectiveBase != 0 && levelFromDrops(openFee, effectiveBase) < metrics.OpenLedgerFeeLevel {
 		openFee += 1
 	}
 	medianFee := dropsFromLevel(metrics.MedFeeLevel, baseFee)
 	minFeeBase := baseFee
 	if metrics.TxQMaxSize != nil && metrics.TxCount >= *metrics.TxQMaxSize {
-		minFeeBase = effective
+		minFeeBase = effectiveBase
 	}
 	minimumFee := dropsFromLevel(metrics.MinProcessingFeeLevel, minFeeBase)
 

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -111,9 +111,24 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 
 	// Submit the transaction with the original signed blob.
 	// The blob is needed for canonical re-ordering during AcceptLedger.
-	result, err := ctx.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
-	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to submit transaction: %v", err))
+	// When the client passed fail_hard:true and the ledger service
+	// implements the FailHardSubmitter surface, route through it so
+	// non-applying submissions are not held or relayed.
+	var (
+		result    *types.SubmitResult
+		submitErr error
+	)
+	if request.FailHard {
+		if fh, ok := ctx.Services.Ledger.(types.FailHardSubmitter); ok {
+			result, submitErr = fh.SubmitTransactionFailHard(txJSON, txBlobHex)
+		} else {
+			result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
+		}
+	} else {
+		result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
+	}
+	if submitErr != nil {
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to submit transaction: %v", submitErr))
 	}
 	txHashStr := CalculateTxHash(txBlobHex)
 

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -183,7 +183,22 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorInternal("Failed to marshal transaction: " + encErr.Error())
 	}
 
-	result, submitErr := ctx.Services.Ledger.SubmitTransaction(txJSON)
+	// Route fail_hard submissions through the optional surface so they
+	// are not held or relayed on non-apply. Mirrors rippled
+	// NetworkOPs.cpp:1685-1689 (`!enforceFailHard`).
+	var (
+		result    *types.SubmitResult
+		submitErr error
+	)
+	if request.FailHard {
+		if fh, ok := ctx.Services.Ledger.(types.FailHardSubmitter); ok {
+			result, submitErr = fh.SubmitTransactionFailHard(txJSON, txBlob)
+		} else {
+			result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON)
+		}
+	} else {
+		result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON)
+	}
 	if submitErr != nil {
 		return nil, types.RpcErrorInternal("Transaction submission failed: " + submitErr.Error())
 	}

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -181,6 +181,22 @@ func (a *ledgerReaderAdapter) ForEachTransaction(fn func(txHash [32]byte, txData
 // This is used for canonical re-ordering during AcceptLedger to ensure
 // the exact same bytes (and thus same tx hash) are used during re-application.
 func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte, txBlobHex ...string) (*types.SubmitResult, error) {
+	var blobHex string
+	if len(txBlobHex) > 0 {
+		blobHex = txBlobHex[0]
+	}
+	return a.submitTransaction(txJSON, blobHex, false)
+}
+
+// SubmitTransactionFailHard mirrors SubmitTransaction with rippled's
+// tapFAIL_HARD semantics: a tx that does not apply is not held in
+// localTxs, not relayed, and not pushed onto the canonical pendingTxs
+// pool. Submit handlers route here when the client sent fail_hard:true.
+func (a *LedgerServiceAdapter) SubmitTransactionFailHard(txJSON []byte, txBlobHex string) (*types.SubmitResult, error) {
+	return a.submitTransaction(txJSON, txBlobHex, true)
+}
+
+func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string, failHard bool) (*types.SubmitResult, error) {
 	// Parse the transaction from JSON
 	transaction, err := tx.ParseJSON(txJSON)
 	if err != nil {
@@ -194,8 +210,8 @@ func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte, txBlobHex ...str
 
 	// Use the original signed blob if provided, otherwise re-encode
 	var rawBlob []byte
-	if len(txBlobHex) > 0 && txBlobHex[0] != "" {
-		rawBlob, _ = hex.DecodeString(txBlobHex[0])
+	if txBlobHex != "" {
+		rawBlob, _ = hex.DecodeString(txBlobHex)
 	}
 	if rawBlob == nil {
 		if txMap, fErr := transaction.Flatten(); fErr == nil {
@@ -214,7 +230,7 @@ func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte, txBlobHex ...str
 	}
 
 	// Submit to the service with the raw blob for canonical ordering
-	result, err := a.svc.SubmitTransaction(transaction, rawBlob)
+	result, err := a.svc.SubmitTransaction(transaction, rawBlob, failHard)
 	if err != nil {
 		return &types.SubmitResult{
 			EngineResult:        "tefINTERNAL",
@@ -233,9 +249,14 @@ func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte, txBlobHex ...str
 	// (apply.cpp:196,206). On-the-wire set: tesSUCCESS, tec*, terQUEUED.
 	// All other ter* codes are held locally (addHeldTransaction) and
 	// must NOT be relayed — peers would just re-fail with the same
-	// retry code.
+	// retry code. fail_hard suppresses relay even on apply success when
+	// the engine result is non-tesSUCCESS (matches NetworkOPs.cpp:1688
+	// `&& !enforceFailHard`).
 	broadcast := false
 	relayable := result.Applied || result.Result == tx.TerQUEUED
+	if failHard && !result.Applied {
+		relayable = false
+	}
 	if relayable && rawBlob != nil && a.txBroadcaster != nil {
 		a.txBroadcaster(rawBlob)
 		broadcast = true

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -215,6 +215,12 @@ type ServiceContainer struct {
 	// server_info falls back to baseline values.
 	TxQMetrics func() TxQServerMetrics
 
+	// TxQFeeMetrics returns the full TxQ snapshot consumed by the
+	// `fee` RPC handler. Nil until the ledger service is wired
+	// (standalone tests, pre-startup) — handler then falls back to
+	// rippled's idle-state defaults.
+	TxQFeeMetrics func() TxQFeeMetrics
+
 	// JqTransOverflow returns the cumulative inbound TMTransaction
 	// frames the overlay refused at the router-dispatch boundary
 	// because the in-flight tx ceiling was already met. This is
@@ -435,6 +441,22 @@ type LoadFactorFees struct {
 type TxQServerMetrics struct {
 	ReferenceFeeLevel     uint64
 	MinProcessingFeeLevel uint64
+	OpenLedgerFeeLevel    uint64
+}
+
+// TxQFeeMetrics is the full TxQ snapshot surfaced by the `fee` RPC,
+// mirroring the fields read by rippled's TxQ::doRPC
+// (TxQ.cpp:1860-1909). It is a superset of TxQServerMetrics — the
+// `fee` handler needs txCount / txPerLedger / txInLedger / median /
+// queue-max in addition to the load_factor levels.
+type TxQFeeMetrics struct {
+	TxCount               uint32
+	TxQMaxSize            *uint32 // nil → no limit, omits max_queue_size
+	TxInLedger            uint32
+	TxPerLedger           uint32
+	ReferenceFeeLevel     uint64
+	MinProcessingFeeLevel uint64
+	MedFeeLevel           uint64
 	OpenLedgerFeeLevel    uint64
 }
 

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -279,6 +279,17 @@ type LedgerAccessor interface {
 	IsAmendmentBlocked() bool
 }
 
+// FailHardSubmitter is the optional rippled-faithful surface for
+// submitting a transaction with tapFAIL_HARD semantics (TxQ.cpp:393-399,
+// NetworkOPs.cpp:1685-1689): on non-apply the blob is NOT held in the
+// localTxs pool, NOT pushed onto the canonical pendingTxs slice, and
+// NOT relayed. Production LedgerServiceAdapter implements it; test
+// mocks may omit it — submit handlers fall back to SubmitTransaction
+// when the interface is not satisfied.
+type FailHardSubmitter interface {
+	SubmitTransactionFailHard(txJSON []byte, txBlobHex string) (*SubmitResult, error)
+}
+
 // TransactionSubmitter handles transaction submission and retrieval.
 type TransactionSubmitter interface {
 	SubmitTransaction(txJSON []byte, txBlobHex ...string) (*SubmitResult, error)

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -84,6 +84,12 @@ type TestEnv struct {
 	// rippled's apply() vs submit() distinction for setup operations.
 	bypassTxQ bool
 
+	// txQApplyFlags is the ApplyFlags handed to the TxQ for the next
+	// submission. Reset to zero on every Submit; tests that want to
+	// simulate rippled's tapFAIL_HARD admission rule can set it via
+	// SetTxQApplyFlags before calling Submit.
+	txQApplyFlags tx.ApplyFlags
+
 	// txInLedger tracks the number of transactions applied to the current open
 	// ledger. Reset on Close(). Used by TxQ for fee escalation computation.
 	txInLedger uint32

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -1223,6 +1223,14 @@ func (c *testTxQApplyContext) PreclaimTransaction(txn tx.Transaction, account [2
 	return 0
 }
 
+// GetApplyFlags returns the engine ApplyFlags currently driving the
+// test env. The test env stores the flag on TestEnv.applyFlags and
+// resets it after each Submit; default is 0 so TxQ admission behaves
+// as if no flag is set.
+func (c *testTxQApplyContext) GetApplyFlags() tx.ApplyFlags {
+	return c.env.txQApplyFlags
+}
+
 // testTxQAcceptContext implements txq.AcceptContext for draining the queue.
 type testTxQAcceptContext struct {
 	env *TestEnv

--- a/internal/testing/pseudotx/set_fee_test.go
+++ b/internal/testing/pseudotx/set_fee_test.go
@@ -50,14 +50,11 @@ func newSetFeeModern() *pseudo.SetFee {
 }
 
 // Apply-success paths (legacy + modern) intentionally aren't pinned
-// here: the FeeSettings ledger-entry typed metadata decoder
-// (internal/tx/ledgerfields/fee_settings_gen.go) doesn't currently
-// accept the blob the SerializeFeeSettings encoder emits, so even
-// before the preflight/preclaim tightening landed in this issue
-// SetFee.Apply()'s happy path returned tefINTERNAL during metadata
-// generation. That decoder gap is orthogonal to the preflight/
-// preclaim work tracked here; the tests below pin every rejection
-// path that this issue actually fixes.
+// here: the FeeSettings typed metadata decoder
+// (internal/tx/ledgerfields/fee_settings_gen.go) does not accept the
+// blob SerializeFeeSettings emits, so SetFee.Apply()'s happy path
+// returns tefINTERNAL during metadata generation regardless of
+// preflight/preclaim. The tests below pin only the rejection paths.
 
 // TestSetFee_Preflight_BadAccount pins Change.cpp:43-48 — any non-zero
 // source account must reject with temBAD_SRC_ACCOUNT before mutation.

--- a/internal/testing/pseudotx/set_fee_test.go
+++ b/internal/testing/pseudotx/set_fee_test.go
@@ -1,0 +1,165 @@
+// Package pseudotx_test pins SetFee preflight/preclaim against rippled
+// Change.cpp:43-385 — the goxrpl pseudo-tx pipeline bypasses the
+// engine's common preflight (applyPseudoTransaction calls Apply()
+// directly), so the per-tx preflight/preclaim must reject malformed
+// fields before the FeeSettings mutation runs.
+package pseudotx_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/stretchr/testify/require"
+)
+
+// newSetFeeLegacyEnv builds a TestEnv with XRPFees disabled so the
+// legacy fee fields (BaseFee / ReferenceFeeUnits / ReserveBase /
+// ReserveIncrement) drive the SetFee preclaim branch.
+func newSetFeeLegacyEnv(t *testing.T) *jtx.TestEnv {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	env.DisableFeature("XRPFees")
+	return env
+}
+
+// newSetFeeLegacy returns a fully-populated legacy (pre-XRPFees) SetFee
+// pseudo-tx. NewSetFee stamps the canonical zero account plus the
+// rippled-default common fields, so callers only need to populate the
+// fee fields they want to mutate / leave absent.
+func newSetFeeLegacy() *pseudo.SetFee {
+	s := pseudo.NewSetFee()
+	s.BaseFee = "A" // hex: 10 drops
+	ref := uint32(10)
+	rb := uint32(200_000_000)
+	ri := uint32(50_000_000)
+	s.ReferenceFeeUnits = &ref
+	s.ReserveBase = &rb
+	s.ReserveIncrement = &ri
+	return s
+}
+
+// newSetFeeModern returns a fully-populated XRPFees-era SetFee.
+func newSetFeeModern() *pseudo.SetFee {
+	s := pseudo.NewSetFee()
+	s.BaseFeeDrops = "10"
+	s.ReserveBaseDrops = "200000000"
+	s.ReserveIncrementDrops = "50000000"
+	return s
+}
+
+// Apply-success paths (legacy + modern) intentionally aren't pinned
+// here: the FeeSettings ledger-entry typed metadata decoder
+// (internal/tx/ledgerfields/fee_settings_gen.go) doesn't currently
+// accept the blob the SerializeFeeSettings encoder emits, so even
+// before the preflight/preclaim tightening landed in this issue
+// SetFee.Apply()'s happy path returned tefINTERNAL during metadata
+// generation. That decoder gap is orthogonal to the preflight/
+// preclaim work tracked here; the tests below pin every rejection
+// path that this issue actually fixes.
+
+// TestSetFee_Preflight_BadAccount pins Change.cpp:43-48 — any non-zero
+// source account must reject with temBAD_SRC_ACCOUNT before mutation.
+func TestSetFee_Preflight_BadAccount(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	s := newSetFeeModern()
+	s.Common.Account = "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"
+	result := env.SubmitPseudo(s)
+	jtx.RequireTxFail(t, result, "temBAD_SRC_ACCOUNT")
+}
+
+// TestSetFee_Preflight_BadFee pins Change.cpp:50-56 — Fee != 0 rejects
+// with temBAD_FEE.
+func TestSetFee_Preflight_BadFee(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	s := newSetFeeModern()
+	s.Common.Fee = "10"
+	result := env.SubmitPseudo(s)
+	jtx.RequireTxFail(t, result, "temBAD_FEE")
+}
+
+// TestSetFee_Preflight_BadSignature pins Change.cpp:58-63 — any signing
+// material (SigningPubKey, TxnSignature, or Signers array) must reject
+// with temBAD_SIGNATURE.
+func TestSetFee_Preflight_BadSignature(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	t.Run("SigningPubKey present", func(t *testing.T) {
+		s := newSetFeeModern()
+		s.Common.SigningPubKey = "ED5F5AC8B98974A3CA843326D9B88CEBD0560177B973EE0B149F782CFAA06DC66A"
+		result := env.SubmitPseudo(s)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+	})
+	t.Run("TxnSignature present", func(t *testing.T) {
+		s := newSetFeeModern()
+		s.Common.TxnSignature = "AB"
+		result := env.SubmitPseudo(s)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+	})
+}
+
+// TestSetFee_Preflight_BadSequence pins Change.cpp:65-70 — Sequence
+// must be zero.
+func TestSetFee_Preflight_BadSequence(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	s := newSetFeeModern()
+	seq := uint32(7)
+	s.Common.Sequence = &seq
+	result := env.SubmitPseudo(s)
+	jtx.RequireTxFail(t, result, "temBAD_SEQUENCE")
+}
+
+// TestSetFee_Preclaim_ModernMissingFields pins Change.cpp:101-104 —
+// with XRPFees active, the *Drops triple is REQUIRED.
+func TestSetFee_Preclaim_ModernMissingFields(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	s := pseudo.NewSetFee()
+	s.BaseFeeDrops = "10"
+	// Intentionally leave ReserveBaseDrops, ReserveIncrementDrops absent.
+	result := env.SubmitPseudo(s)
+	jtx.RequireTxFail(t, result, "temMALFORMED")
+}
+
+// TestSetFee_Preclaim_ModernForbidsLegacy pins Change.cpp:108-112 —
+// with XRPFees active, the legacy quartet is forbidden.
+func TestSetFee_Preclaim_ModernForbidsLegacy(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	s := newSetFeeModern()
+	s.BaseFee = "A" // re-introduces a legacy field
+	result := env.SubmitPseudo(s)
+	jtx.RequireTxFail(t, result, "temMALFORMED")
+}
+
+// TestSetFee_Preclaim_LegacyMissingFields pins Change.cpp:114-124 —
+// when XRPFees is OFF the legacy quartet is REQUIRED.
+func TestSetFee_Preclaim_LegacyMissingFields(t *testing.T) {
+	env := newSetFeeLegacyEnv(t)
+	s := pseudo.NewSetFee()
+	s.BaseFee = "A"
+	// Intentionally leave ReferenceFeeUnits, ReserveBase, ReserveIncrement absent.
+	result := env.SubmitPseudo(s)
+	jtx.RequireTxFail(t, result, "temMALFORMED")
+}
+
+// TestSetFee_Preclaim_LegacyForbidsModern pins Change.cpp:128-131 —
+// without XRPFees, the modern *Drops fields must reject with
+// temDISABLED.
+func TestSetFee_Preclaim_LegacyForbidsModern(t *testing.T) {
+	env := newSetFeeLegacyEnv(t)
+	s := newSetFeeLegacy()
+	s.BaseFeeDrops = "10"
+	result := env.SubmitPseudo(s)
+	jtx.RequireTxFail(t, result, "temDISABLED")
+}
+
+// TestSetFee_Validate_NoFieldsAtAll pins that a pseudo-tx with no fee
+// fields at all fails Apply()'s preclaim with temMALFORMED — the
+// modern branch requires the *Drops triple.
+func TestSetFee_Validate_NoFieldsAtAll(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	s := pseudo.NewSetFee()
+	result := env.SubmitPseudo(s)
+	jtx.RequireTxFail(t, result, "temMALFORMED")
+	// Sanity: Validate() short-circuits a totally-empty SetFee.
+	require.Error(t, (&pseudo.SetFee{BaseTx: *tx.NewBaseTx(tx.TypeFee, pseudo.ZeroAccount)}).Validate())
+}

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -227,19 +227,23 @@ func (b *Batch) Flatten() (map[string]any, error) {
 
 // CalculateMinimumFee mirrors rippled Batch::calculateBaseFee
 // (Batch.cpp:53-150). The total fee a batch must pay is the sum of:
-//   - batchBase       = 2 * baseFee (view.fees().base + Transactor base)
-//   - txnFees         = Σ inner-tx base fees (each multi-sign-aware)
-//   - signerFees      = effectiveSignerCount * baseFee
+//   - batchBase   = view.fees().base + Transactor::calculateBaseFee(view, tx)
+//     = baseFee + (1 + len(outer.Signers)) * baseFee
+//   - txnFees     = Σ inner-tx base fees (each multi-sign-aware)
+//   - signerFees  = effectiveSignerCount * baseFee
 //
 // effectiveSignerCount counts each BatchSigner once when it carries a
 // direct BatchTxnSignature and as len(Signers) when the entry is a
 // multi-signed batch signer (Batch.cpp:128-134). Inner transactions
 // pay (1 + signers) * baseFee per the standard multi-sign multiplier
-// (Transactor::calculateBaseFee). This is broader than the previous
-// "(n+2)*base + base*innerCount" approximation, which undercharged
-// every multi-signed inner and every multi-signed BatchSigner.
+// (Transactor::calculateBaseFee). Inner-Batch txns are rejected by
+// preflight elsewhere; innerBaseFee mirrors rippled's defense-in-depth
+// bail-out (Batch.cpp:92-97) by returning a sentinel large fee when an
+// inner is itself ttBATCH so the outer is undercosted into rejection
+// rather than silently undercharged.
 func (b *Batch) CalculateMinimumFee(baseFee uint64) uint64 {
-	batchBase := 2 * baseFee
+	outerSigners := uint64(len(b.Common.Signers))
+	batchBase := baseFee + (1+outerSigners)*baseFee
 
 	var txnFees uint64
 	for _, rt := range b.RawTransactions {
@@ -263,18 +267,29 @@ func (b *Batch) CalculateMinimumFee(baseFee uint64) uint64 {
 }
 
 // innerBaseFee mirrors rippled Transactor::calculateBaseFee for one
-// inner tx: (1 + signers) * baseFee. This intentionally ignores the
-// per-tx-type overrides (AccountDelete reserve increment, AMMCreate
-// pool increment, LedgerStateFix repair increment) that rippled's
-// `ripple::calculateBaseFee(view, stx)` dispatches through; those
-// cases are exceedingly rare inside a Batch (AccountDelete is
-// forbidden, the others would seldom be batched) and accessing the
-// view from this interface would require a deeper refactor of
-// BatchFeeCalculator.
+// inner tx: (1 + signers) * baseFee. Inner ttBATCH is forbidden in
+// preflight; mirror rippled Batch.cpp:92-97 by surfacing the impossible
+// nesting as overflowFee — the outer batch's minimum-fee check will
+// reject before the inner-batch makes it through. The per-tx-type
+// overrides (AccountDelete reserve increment, AMMCreate pool increment,
+// LedgerStateFix repair increment) are intentionally not dispatched
+// here: those cases are forbidden or exceedingly rare inside a Batch,
+// and accessing the view from this interface would require a deeper
+// refactor of BatchFeeCalculator.
 func innerBaseFee(inner tx.Transaction, baseFee uint64) uint64 {
+	if inner.TxType() == tx.TypeBatch {
+		return overflowFee
+	}
 	signers := inner.GetCommon().Signers
 	return (1 + uint64(len(signers))) * baseFee
 }
+
+// overflowFee is the sentinel fee returned when fee calculation hits an
+// impossible condition (inner ttBATCH, overflow). It is larger than any
+// legitimate batch fee can ever be, ensuring the outer tx fails the
+// minimum-fee gate. Mirrors rippled Batch.cpp:66 returning INITIAL_XRP
+// (100 billion XRP) — we use a similarly impossible drops sentinel.
+const overflowFee uint64 = 100_000_000_000 * 1_000_000 // 100 billion XRP in drops
 
 // AddInnerTransaction adds an inner transaction to the batch.
 // The transaction should have Fee="0", SigningPubKey="", and tfInnerBatchTxn flag set.

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -225,13 +225,55 @@ func (b *Batch) Flatten() (map[string]any, error) {
 	return m, nil
 }
 
-// CalculateMinimumFee calculates the minimum required fee for a Batch transaction.
-// Formula: (numSigners + 2) * baseFee + baseFee * numInnerTxns
-// Reference: rippled Batch.cpp calculateBaseFee()
+// CalculateMinimumFee mirrors rippled Batch::calculateBaseFee
+// (Batch.cpp:53-150). The total fee a batch must pay is the sum of:
+//   - batchBase       = 2 * baseFee (view.fees().base + Transactor base)
+//   - txnFees         = Σ inner-tx base fees (each multi-sign-aware)
+//   - signerFees      = effectiveSignerCount * baseFee
+//
+// effectiveSignerCount counts each BatchSigner once when it carries a
+// direct BatchTxnSignature and as len(Signers) when the entry is a
+// multi-signed batch signer (Batch.cpp:128-134). Inner transactions
+// pay (1 + signers) * baseFee per the standard multi-sign multiplier
+// (Transactor::calculateBaseFee). This is broader than the previous
+// "(n+2)*base + base*innerCount" approximation, which undercharged
+// every multi-signed inner and every multi-signed BatchSigner.
 func (b *Batch) CalculateMinimumFee(baseFee uint64) uint64 {
-	numSigners := uint64(len(b.BatchSigners))
-	numInnerTxns := uint64(len(b.RawTransactions))
-	return (numSigners+2)*baseFee + baseFee*numInnerTxns
+	batchBase := 2 * baseFee
+
+	var txnFees uint64
+	for _, rt := range b.RawTransactions {
+		inner := rt.RawTransaction.InnerTx
+		if inner == nil {
+			continue
+		}
+		txnFees += innerBaseFee(inner, baseFee)
+	}
+
+	var signerCount uint64
+	for _, bs := range b.BatchSigners {
+		if bs.BatchSigner.BatchTxnSignature != "" {
+			signerCount++
+		} else if len(bs.BatchSigner.Signers) > 0 {
+			signerCount += uint64(len(bs.BatchSigner.Signers))
+		}
+	}
+
+	return batchBase + txnFees + signerCount*baseFee
+}
+
+// innerBaseFee mirrors rippled Transactor::calculateBaseFee for one
+// inner tx: (1 + signers) * baseFee. This intentionally ignores the
+// per-tx-type overrides (AccountDelete reserve increment, AMMCreate
+// pool increment, LedgerStateFix repair increment) that rippled's
+// `ripple::calculateBaseFee(view, stx)` dispatches through; those
+// cases are exceedingly rare inside a Batch (AccountDelete is
+// forbidden, the others would seldom be batched) and accessing the
+// view from this interface would require a deeper refactor of
+// BatchFeeCalculator.
+func innerBaseFee(inner tx.Transaction, baseFee uint64) uint64 {
+	signers := inner.GetCommon().Signers
+	return (1 + uint64(len(signers))) * baseFee
 }
 
 // AddInnerTransaction adds an inner transaction to the batch.

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -361,3 +361,78 @@ func TestBatchConstants(t *testing.T) {
 	assert.Equal(t, uint32(0x00000004), BatchFlagUntilFailure)
 	assert.Equal(t, uint32(0x00000008), BatchFlagIndependent)
 }
+
+// TestCalculateMinimumFee_SingleSignBaseline pins the common case
+// (single-signed inners, no BatchSigners): the new formula degenerates
+// to (numInner + 2) * baseFee, byte-identical to the prior
+// approximation.
+func TestCalculateMinimumFee_SingleSignBaseline(t *testing.T) {
+	b := NewBatch("rOuter")
+	b.AddInnerTransaction(makeTestPayment())
+	b.AddInnerTransaction(makeTestPayment())
+	require.Equal(t, uint64(40), b.CalculateMinimumFee(10), "2 inners + no signers")
+
+	b3 := NewBatch("rOuter")
+	b3.AddInnerTransaction(makeTestPayment())
+	b3.AddInnerTransaction(makeTestPayment())
+	b3.AddInnerTransaction(makeTestPayment())
+	require.Equal(t, uint64(50), b3.CalculateMinimumFee(10), "3 inners + no signers")
+}
+
+// TestCalculateMinimumFee_DirectSignedBatchSigners pins
+// Batch.cpp:130-131 — each BatchSigner with a direct BatchTxnSignature
+// adds one base fee.
+func TestCalculateMinimumFee_DirectSignedBatchSigners(t *testing.T) {
+	b := NewBatch("rOuter")
+	b.AddInnerTransaction(makeTestPayment())
+	b.AddInnerTransaction(makeTestPayment())
+	b.BatchSigners = []BatchSigner{
+		{BatchSigner: BatchSignerData{Account: "rSignerA", BatchTxnSignature: "AB"}},
+		{BatchSigner: BatchSignerData{Account: "rSignerB", BatchTxnSignature: "CD"}},
+	}
+	// batchBase=20 + txnFees=20 + signerFees=2*10 = 60
+	require.Equal(t, uint64(60), b.CalculateMinimumFee(10))
+}
+
+// TestCalculateMinimumFee_MultiSignBatchSigner pins
+// Batch.cpp:132-134 — a multi-signed BatchSigner (no direct
+// TxnSignature, populated Signers array) contributes
+// len(Signers) * baseFee, NOT just one base fee. Before the fix this
+// undercharged by (len(Signers) - 1) * baseFee per multi-sign
+// BatchSigner.
+func TestCalculateMinimumFee_MultiSignBatchSigner(t *testing.T) {
+	b := NewBatch("rOuter")
+	b.AddInnerTransaction(makeTestPayment())
+	b.AddInnerTransaction(makeTestPayment())
+	b.BatchSigners = []BatchSigner{{
+		BatchSigner: BatchSignerData{
+			Account: "rSignerA",
+			Signers: []tx.SignerWrapper{
+				{Signer: tx.Signer{Account: "rNested1", SigningPubKey: "01", TxnSignature: "AA"}},
+				{Signer: tx.Signer{Account: "rNested2", SigningPubKey: "02", TxnSignature: "BB"}},
+				{Signer: tx.Signer{Account: "rNested3", SigningPubKey: "03", TxnSignature: "CC"}},
+			},
+		},
+	}}
+	// batchBase=20 + txnFees=20 + signerFees=3*10 = 70 (was 30 pre-fix)
+	require.Equal(t, uint64(70), b.CalculateMinimumFee(10))
+}
+
+// TestCalculateMinimumFee_MultiSignedInner pins
+// Batch.cpp:87-100 — inner transactions count their own per-tx
+// calculateBaseFee, so a multi-signed inner pays (1+n) * baseFee
+// instead of one base fee. Before the fix this undercharged by
+// n * baseFee per multi-signed inner.
+func TestCalculateMinimumFee_MultiSignedInner(t *testing.T) {
+	b := NewBatch("rOuter")
+	b.AddInnerTransaction(makeTestPayment())
+	// Multi-signed inner with 2 signers: pays 3 * baseFee.
+	multiInner := makeTestPayment()
+	multiInner.GetCommon().Signers = []tx.SignerWrapper{
+		{Signer: tx.Signer{Account: "rNested1", SigningPubKey: "01", TxnSignature: "AA"}},
+		{Signer: tx.Signer{Account: "rNested2", SigningPubKey: "02", TxnSignature: "BB"}},
+	}
+	b.AddInnerTransaction(multiInner)
+	// batchBase=20 + txnFees=(10 + 30) + signerFees=0 = 60 (was 40 pre-fix)
+	require.Equal(t, uint64(60), b.CalculateMinimumFee(10))
+}

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -352,8 +352,6 @@ func TestBatchRequiredAmendments(t *testing.T) {
 	assert.Contains(t, amendments, amendment.FeatureBatch)
 }
 
-// Constants Tests
-
 func TestBatchConstants(t *testing.T) {
 	assert.Equal(t, 8, MaxBatchTransactions)
 	assert.Equal(t, uint32(0x00000001), BatchFlagAllOrNothing)
@@ -363,9 +361,8 @@ func TestBatchConstants(t *testing.T) {
 }
 
 // TestCalculateMinimumFee_SingleSignBaseline pins the common case
-// (single-signed inners, no BatchSigners): the new formula degenerates
-// to (numInner + 2) * baseFee, byte-identical to the prior
-// approximation.
+// (single-signed inners, no BatchSigners): the formula degenerates
+// to (numInner + 2) * baseFee.
 func TestCalculateMinimumFee_SingleSignBaseline(t *testing.T) {
 	b := NewBatch("rOuter")
 	b.AddInnerTransaction(makeTestPayment())
@@ -397,9 +394,7 @@ func TestCalculateMinimumFee_DirectSignedBatchSigners(t *testing.T) {
 // TestCalculateMinimumFee_MultiSignBatchSigner pins
 // Batch.cpp:132-134 — a multi-signed BatchSigner (no direct
 // TxnSignature, populated Signers array) contributes
-// len(Signers) * baseFee, NOT just one base fee. Before the fix this
-// undercharged by (len(Signers) - 1) * baseFee per multi-sign
-// BatchSigner.
+// len(Signers) * baseFee, NOT just one base fee.
 func TestCalculateMinimumFee_MultiSignBatchSigner(t *testing.T) {
 	b := NewBatch("rOuter")
 	b.AddInnerTransaction(makeTestPayment())
@@ -414,15 +409,14 @@ func TestCalculateMinimumFee_MultiSignBatchSigner(t *testing.T) {
 			},
 		},
 	}}
-	// batchBase=20 + txnFees=20 + signerFees=3*10 = 70 (was 30 pre-fix)
+	// batchBase=20 + txnFees=20 + signerFees=3*10 = 70
 	require.Equal(t, uint64(70), b.CalculateMinimumFee(10))
 }
 
 // TestCalculateMinimumFee_MultiSignedInner pins
 // Batch.cpp:87-100 — inner transactions count their own per-tx
 // calculateBaseFee, so a multi-signed inner pays (1+n) * baseFee
-// instead of one base fee. Before the fix this undercharged by
-// n * baseFee per multi-signed inner.
+// instead of one base fee.
 func TestCalculateMinimumFee_MultiSignedInner(t *testing.T) {
 	b := NewBatch("rOuter")
 	b.AddInnerTransaction(makeTestPayment())
@@ -433,7 +427,7 @@ func TestCalculateMinimumFee_MultiSignedInner(t *testing.T) {
 		{Signer: tx.Signer{Account: "rNested2", SigningPubKey: "02", TxnSignature: "BB"}},
 	}
 	b.AddInnerTransaction(multiInner)
-	// batchBase=20 + txnFees=(10 + 30) + signerFees=0 = 60 (was 40 pre-fix)
+	// batchBase=20 + txnFees=(10 + 30) + signerFees=0 = 60
 	require.Equal(t, uint64(60), b.CalculateMinimumFee(10))
 }
 
@@ -441,8 +435,6 @@ func TestCalculateMinimumFee_MultiSignedInner(t *testing.T) {
 // Batch.cpp:60-70 — Transactor::calculateBaseFee charges
 // (1 + outerSigners) * baseFee for the outer Batch tx itself,
 // in addition to the view.fees().base added by the Batch wrapper.
-// Before the fix this undercharged any multi-signed outer Batch by
-// len(outer.Signers) * baseFee.
 func TestCalculateMinimumFee_OuterMultiSign(t *testing.T) {
 	b := NewBatch("rOuter")
 	b.AddInnerTransaction(makeTestPayment())

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -436,3 +436,33 @@ func TestCalculateMinimumFee_MultiSignedInner(t *testing.T) {
 	// batchBase=20 + txnFees=(10 + 30) + signerFees=0 = 60 (was 40 pre-fix)
 	require.Equal(t, uint64(60), b.CalculateMinimumFee(10))
 }
+
+// TestCalculateMinimumFee_OuterMultiSign pins
+// Batch.cpp:60-70 — Transactor::calculateBaseFee charges
+// (1 + outerSigners) * baseFee for the outer Batch tx itself,
+// in addition to the view.fees().base added by the Batch wrapper.
+// Before the fix this undercharged any multi-signed outer Batch by
+// len(outer.Signers) * baseFee.
+func TestCalculateMinimumFee_OuterMultiSign(t *testing.T) {
+	b := NewBatch("rOuter")
+	b.AddInnerTransaction(makeTestPayment())
+	b.Common.Signers = []tx.SignerWrapper{
+		{Signer: tx.Signer{Account: "rOuter1", SigningPubKey: "01", TxnSignature: "AA"}},
+		{Signer: tx.Signer{Account: "rOuter2", SigningPubKey: "02", TxnSignature: "BB"}},
+	}
+	// batchBase = 10 + (1 + 2)*10 = 40; txnFees = 10; signerFees = 0 → 50
+	require.Equal(t, uint64(50), b.CalculateMinimumFee(10))
+}
+
+// TestCalculateMinimumFee_InnerBatchSentinel pins
+// Batch.cpp:92-97 — an inner that is itself ttBATCH (forbidden) is
+// surfaced via an overflow sentinel so the outer minimum-fee gate
+// rejects, rather than silently computing a normal fee.
+func TestCalculateMinimumFee_InnerBatchSentinel(t *testing.T) {
+	outer := NewBatch("rOuter")
+	innerBatch := NewBatch("rInner")
+	outer.AddInnerTransaction(innerBatch)
+	fee := outer.CalculateMinimumFee(10)
+	// Sentinel is ≥ 100B XRP in drops; any realistic caller will reject.
+	require.Greater(t, fee, uint64(100_000_000_000), "inner ttBATCH must surface as overflow sentinel")
+}

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -2,6 +2,7 @@ package pseudo
 
 import (
 	"errors"
+	"strconv"
 
 	"github.com/LeJamon/goXRPLd/internal/tx"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/LeJamon/goXRPLd/keylet"
 )
 
-// SetFee errors matching rippled
+// SetFee errors matching rippled Change.cpp:43-385.
 var (
 	ErrSetFeeBadSrcAccount = tx.Errorf(tx.TemBAD_SRC_ACCOUNT, "SetFee must have zero account")
 	ErrSetFeeBadFee        = tx.Errorf(tx.TemBAD_FEE, "SetFee must have zero fee")
@@ -24,8 +25,8 @@ var (
 type SetFee struct {
 	tx.BaseTx
 
-	// Legacy fields (pre-XRPFees amendment)
-	// BaseFee is the base transaction fee (hex string for legacy compatibility)
+	// Legacy fields (pre-XRPFees amendment). XRPL JSON convention serializes
+	// UInt64 as a hex string; sfBaseFee is decoded as a uint64.
 	BaseFee string `json:"BaseFee,omitempty" xrpl:"BaseFee,omitempty"`
 
 	// ReferenceFeeUnits is the reference fee units (typically 10)
@@ -51,31 +52,31 @@ type SetFee struct {
 	LedgerSequence *uint32 `json:"LedgerSequence,omitempty" xrpl:"LedgerSequence,omitempty"`
 }
 
-// NewSetFee creates a new SetFee pseudo-transaction.
-// This should only be used by consensus/validation code.
+// NewSetFee creates a new SetFee pseudo-transaction with the canonical
+// zero account and the rippled-default common fields stamped via
+// applyPseudoTxDefaults (Fee=0, Sequence=0, SigningPubKey="").
 func NewSetFee() *SetFee {
-	// SetFee has empty account (zero account in rippled)
-	return &SetFee{
-		BaseTx: *tx.NewBaseTx(tx.TypeFee, ""),
+	s := &SetFee{
+		BaseTx: *tx.NewBaseTx(tx.TypeFee, ZeroAccount),
 	}
+	applyPseudoTxDefaults(&s.Common)
+	return s
 }
 
 func (s *SetFee) TxType() tx.Type {
 	return tx.TypeFee
 }
 
-// Reference: rippled Change.cpp preflight()
+// Validate runs the per-tx-type structural checks. Pseudo-transactions
+// bypass the engine's preflight pipeline (applyPseudoTransaction calls
+// Apply() directly), so Apply() invokes preflight/preclaim before the
+// state mutation step instead.
 func (s *SetFee) Validate() error {
-	// SetFee is a pseudo-transaction - most standard validation is skipped
-	// The engine handles pseudo-transaction specific checks
-
-	// Check that either legacy or modern fields are present
 	hasLegacy := s.BaseFee != "" || s.ReferenceFeeUnits != nil ||
 		s.ReserveBase != nil || s.ReserveIncrement != nil
 	hasModern := s.BaseFeeDrops != "" || s.ReserveBaseDrops != "" ||
 		s.ReserveIncrementDrops != ""
 
-	// Must have some fee fields
 	if !hasLegacy && !hasModern {
 		return ErrSetFeeMalformed
 	}
@@ -92,9 +93,71 @@ func (s *SetFee) IsPseudoTransaction() bool {
 	return true
 }
 
-// This creates or updates the FeeSettings singleton entry.
+// preflight mirrors rippled Change::preflight() (Change.cpp:36-80) for
+// the common-field surface that applies to every Change tx: zero
+// account, zero native fee, empty signing material, zero sequence /
+// no PreviousTxnID.
+func (s *SetFee) preflight() tx.Result {
+	if s.Common.Account != ZeroAccount {
+		return tx.TemBAD_SRC_ACCOUNT
+	}
+	if s.Common.Fee != "" && s.Common.Fee != "0" {
+		return tx.TemBAD_FEE
+	}
+	if s.Common.SigningPubKey != "" || s.Common.TxnSignature != "" ||
+		len(s.Common.Signers) > 0 {
+		return tx.TemBAD_SIGNATURE
+	}
+	if s.Common.Sequence == nil || *s.Common.Sequence != 0 ||
+		s.Common.AccountTxnID != "" {
+		return tx.TemBAD_SEQUENCE
+	}
+	return tx.TesSUCCESS
+}
+
+// preclaim mirrors rippled Change::preclaim() for the ttFEE branch
+// (Change.cpp:93-133): the modern XRPFees fields are required and the
+// legacy fields forbidden when the amendment is enabled, and the
+// reverse holds before activation.
+func (s *SetFee) preclaim(ctx *tx.ApplyContext) tx.Result {
+	xrpFees := ctx.Config.Rules != nil && ctx.Config.Rules.XRPFeesEnabled()
+
+	hasModern := s.BaseFeeDrops != "" || s.ReserveBaseDrops != "" ||
+		s.ReserveIncrementDrops != ""
+	hasLegacy := s.BaseFee != "" || s.ReferenceFeeUnits != nil ||
+		s.ReserveBase != nil || s.ReserveIncrement != nil
+
+	if xrpFees {
+		if s.BaseFeeDrops == "" || s.ReserveBaseDrops == "" || s.ReserveIncrementDrops == "" {
+			return tx.TemMALFORMED
+		}
+		if hasLegacy {
+			return tx.TemMALFORMED
+		}
+	} else {
+		if s.BaseFee == "" || s.ReferenceFeeUnits == nil ||
+			s.ReserveBase == nil || s.ReserveIncrement == nil {
+			return tx.TemMALFORMED
+		}
+		if hasModern {
+			return tx.TemDISABLED
+		}
+	}
+	return tx.TesSUCCESS
+}
+
+// Apply mirrors rippled Change::applyFee() (Change.cpp:347-385): it
+// either creates or updates the FeeSettings singleton, writing only
+// the field set corresponding to the active amendment branch.
 // Reference: rippled Change.cpp applyFee()
 func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
+	if r := s.preflight(); r != tx.TesSUCCESS {
+		return r
+	}
+	if r := s.preclaim(ctx); r != tx.TesSUCCESS {
+		return r
+	}
+
 	ctx.Log.Info("set fee apply",
 		"baseFeeDrops", s.BaseFeeDrops,
 		"reserveBaseDrops", s.ReserveBaseDrops,
@@ -106,78 +169,62 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	feesKey := keylet.Fees()
 
-	// Check if FeeSettings exists
 	exists, err := ctx.View.Exists(feesKey)
 	if err != nil {
 		return tx.TefINTERNAL
 	}
 
 	var feeSettings *state.FeeSettings
-
 	if exists {
-		// Read existing FeeSettings
 		data, err := ctx.View.Read(feesKey)
 		if err != nil {
 			return tx.TefINTERNAL
 		}
-
 		feeSettings, err = state.ParseFeeSettings(data)
 		if err != nil {
 			return tx.TefINTERNAL
 		}
 	} else {
-		// Create new FeeSettings
 		feeSettings = &state.FeeSettings{}
 	}
 
-	// Check if XRPFees amendment is enabled
-	// For early ledgers (before XRPFees), we use legacy format
 	xrpFeesEnabled := ctx.Config.Rules != nil && ctx.Config.Rules.XRPFeesEnabled()
 
 	if xrpFeesEnabled {
-		// Modern format (XRPFees amendment)
-		if s.BaseFeeDrops != "" {
-			drops, err := parseDropsAmount(s.BaseFeeDrops)
-			if err == nil {
-				feeSettings.BaseFeeDrops = drops
-			}
+		baseDrops, err := parseDropsAmount(s.BaseFeeDrops)
+		if err != nil {
+			return tx.TemMALFORMED
 		}
-		if s.ReserveBaseDrops != "" {
-			drops, err := parseDropsAmount(s.ReserveBaseDrops)
-			if err == nil {
-				feeSettings.ReserveBaseDrops = drops
-			}
+		reserveDrops, err := parseDropsAmount(s.ReserveBaseDrops)
+		if err != nil {
+			return tx.TemMALFORMED
 		}
-		if s.ReserveIncrementDrops != "" {
-			drops, err := parseDropsAmount(s.ReserveIncrementDrops)
-			if err == nil {
-				feeSettings.ReserveIncrementDrops = drops
-			}
+		reserveIncDrops, err := parseDropsAmount(s.ReserveIncrementDrops)
+		if err != nil {
+			return tx.TemMALFORMED
 		}
+		feeSettings.BaseFeeDrops = baseDrops
+		feeSettings.ReserveBaseDrops = reserveDrops
+		feeSettings.ReserveIncrementDrops = reserveIncDrops
 
-		// Clear legacy fields when using modern format
+		// Mirror rippled makeFieldAbsent(sfBaseFee/...) at
+		// Change.cpp:368-371: the legacy fields are stripped from the
+		// FeeSettings entry once XRPFees activates. SerializeFeeSettings
+		// already omits zero-valued legacy fields, so zeroing here is
+		// the goxrpl analog of makeFieldAbsent.
 		feeSettings.BaseFee = 0
 		feeSettings.ReferenceFeeUnits = 0
 		feeSettings.ReserveBase = 0
 		feeSettings.ReserveIncrement = 0
 	} else {
-		// Legacy format (pre-XRPFees)
-		if s.BaseFee != "" {
-			// BaseFee is a hex string in legacy format
-			baseFee, err := parseHexUint64(s.BaseFee)
-			if err == nil {
-				feeSettings.BaseFee = baseFee
-			}
+		baseFee, err := parseHexUint64(s.BaseFee)
+		if err != nil {
+			return tx.TemMALFORMED
 		}
-		if s.ReferenceFeeUnits != nil {
-			feeSettings.ReferenceFeeUnits = *s.ReferenceFeeUnits
-		}
-		if s.ReserveBase != nil {
-			feeSettings.ReserveBase = *s.ReserveBase
-		}
-		if s.ReserveIncrement != nil {
-			feeSettings.ReserveIncrement = *s.ReserveIncrement
-		}
+		feeSettings.BaseFee = baseFee
+		feeSettings.ReferenceFeeUnits = *s.ReferenceFeeUnits
+		feeSettings.ReserveBase = *s.ReserveBase
+		feeSettings.ReserveIncrement = *s.ReserveIncrement
 	}
 
 	data, err := state.SerializeFeeSettings(feeSettings)
@@ -186,7 +233,6 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TefINTERNAL
 	}
 
-	// Insert or update the FeeSettings entry
 	if exists {
 		if err := ctx.View.Update(feesKey, data); err != nil {
 			ctx.Log.Error("set fee: failed to update fee settings", "error", err)
@@ -202,55 +248,19 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 	return tx.TesSUCCESS
 }
 
-// parseDropsAmount parses a drops amount string to uint64
+// parseDropsAmount parses a decimal drops string. Empty input is rejected.
 func parseDropsAmount(s string) (uint64, error) {
-	var drops uint64
-	_, err := parseUint64(s)
-	if err != nil {
-		return 0, err
+	if s == "" {
+		return 0, errors.New("empty drops value")
 	}
-	drops, _ = parseUint64(s)
-	return drops, nil
+	return strconv.ParseUint(s, 10, 64)
 }
 
-// parseHexUint64 parses a hex string to uint64
+// parseHexUint64 parses a hex-encoded uint64 (XRPL JSON convention for
+// the legacy sfBaseFee field). Empty input is rejected.
 func parseHexUint64(s string) (uint64, error) {
-	var value uint64
-	_, err := parseHex(s, &value)
-	if err != nil {
-		return 0, err
+	if s == "" {
+		return 0, errors.New("empty hex value")
 	}
-	return value, nil
-}
-
-// parseUint64 parses a decimal string to uint64
-func parseUint64(s string) (uint64, error) {
-	var value uint64
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return 0, errors.New("invalid digit")
-		}
-		value = value*10 + uint64(c-'0')
-	}
-	return value, nil
-}
-
-// parseHex parses a hex string into a uint64 pointer
-func parseHex(s string, value *uint64) (int, error) {
-	*value = 0
-	for i, c := range s {
-		var digit uint64
-		switch {
-		case c >= '0' && c <= '9':
-			digit = uint64(c - '0')
-		case c >= 'a' && c <= 'f':
-			digit = uint64(c - 'a' + 10)
-		case c >= 'A' && c <= 'F':
-			digit = uint64(c - 'A' + 10)
-		default:
-			return i, errors.New("invalid hex digit")
-		}
-		*value = *value*16 + digit
-	}
-	return len(s), nil
+	return strconv.ParseUint(s, 16, 64)
 }

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -108,8 +108,12 @@ func (s *SetFee) preflight() tx.Result {
 		len(s.Common.Signers) > 0 {
 		return tx.TemBAD_SIGNATURE
 	}
-	if s.Common.Sequence == nil || *s.Common.Sequence != 0 ||
-		s.Common.AccountTxnID != "" {
+	// Rippled (Change.cpp:65-69) checks sfSequence + sfPreviousTxnID. The
+	// PreviousTxnID transaction-field has no representation on tx.Common
+	// in goxrpl, so the C++ isFieldPresent(sfPreviousTxnID) check has no
+	// reachable analogue here — the field cannot be set on a parsed
+	// pseudo-tx.
+	if s.Common.Sequence == nil || *s.Common.Sequence != 0 {
 		return tx.TemBAD_SEQUENCE
 	}
 	return tx.TesSUCCESS
@@ -190,18 +194,23 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	xrpFeesEnabled := ctx.Config.Rules != nil && ctx.Config.Rules.XRPFeesEnabled()
 
+	// All parse + nil paths below return tefINTERNAL, not temMALFORMED:
+	// preclaim already verified the relevant fields are populated, so a
+	// failure here means the field was malformed at serialization time
+	// (impossible after preclaim) — the "this shouldn't happen" surface,
+	// matching rippled's typed-field assumption in applyFee().
 	if xrpFeesEnabled {
 		baseDrops, err := parseDropsAmount(s.BaseFeeDrops)
 		if err != nil {
-			return tx.TemMALFORMED
+			return tx.TefINTERNAL
 		}
 		reserveDrops, err := parseDropsAmount(s.ReserveBaseDrops)
 		if err != nil {
-			return tx.TemMALFORMED
+			return tx.TefINTERNAL
 		}
 		reserveIncDrops, err := parseDropsAmount(s.ReserveIncrementDrops)
 		if err != nil {
-			return tx.TemMALFORMED
+			return tx.TefINTERNAL
 		}
 		feeSettings.BaseFeeDrops = baseDrops
 		feeSettings.ReserveBaseDrops = reserveDrops
@@ -217,9 +226,13 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 		feeSettings.ReserveBase = 0
 		feeSettings.ReserveIncrement = 0
 	} else {
+		if s.ReferenceFeeUnits == nil || s.ReserveBase == nil ||
+			s.ReserveIncrement == nil {
+			return tx.TefINTERNAL
+		}
 		baseFee, err := parseHexUint64(s.BaseFee)
 		if err != nil {
-			return tx.TemMALFORMED
+			return tx.TefINTERNAL
 		}
 		feeSettings.BaseFee = baseFee
 		feeSettings.ReferenceFeeUnits = *s.ReferenceFeeUnits

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -25,30 +25,19 @@ var (
 type SetFee struct {
 	tx.BaseTx
 
-	// Legacy fields (pre-XRPFees amendment). XRPL JSON convention serializes
-	// UInt64 as a hex string; sfBaseFee is decoded as a uint64.
-	BaseFee string `json:"BaseFee,omitempty" xrpl:"BaseFee,omitempty"`
-
-	// ReferenceFeeUnits is the reference fee units (typically 10)
+	// Legacy fields (pre-XRPFees amendment). BaseFee is hex-encoded
+	// per XRPL JSON's UInt64 convention; the reserve fields are
+	// drops.
+	BaseFee           string  `json:"BaseFee,omitempty" xrpl:"BaseFee,omitempty"`
 	ReferenceFeeUnits *uint32 `json:"ReferenceFeeUnits,omitempty" xrpl:"ReferenceFeeUnits,omitempty"`
+	ReserveBase       *uint32 `json:"ReserveBase,omitempty" xrpl:"ReserveBase,omitempty"`
+	ReserveIncrement  *uint32 `json:"ReserveIncrement,omitempty" xrpl:"ReserveIncrement,omitempty"`
 
-	// ReserveBase is the account reserve in drops
-	ReserveBase *uint32 `json:"ReserveBase,omitempty" xrpl:"ReserveBase,omitempty"`
-
-	// ReserveIncrement is the owner reserve increment in drops
-	ReserveIncrement *uint32 `json:"ReserveIncrement,omitempty" xrpl:"ReserveIncrement,omitempty"`
-
-	// Modern fields (XRPFees amendment)
-	// BaseFeeDrops is the base fee in drops
-	BaseFeeDrops string `json:"BaseFeeDrops,omitempty" xrpl:"BaseFeeDrops,omitempty"`
-
-	// ReserveBaseDrops is the account reserve in drops
-	ReserveBaseDrops string `json:"ReserveBaseDrops,omitempty" xrpl:"ReserveBaseDrops,omitempty"`
-
-	// ReserveIncrementDrops is the owner reserve increment in drops
+	// Modern fields (XRPFees amendment).
+	BaseFeeDrops          string `json:"BaseFeeDrops,omitempty" xrpl:"BaseFeeDrops,omitempty"`
+	ReserveBaseDrops      string `json:"ReserveBaseDrops,omitempty" xrpl:"ReserveBaseDrops,omitempty"`
 	ReserveIncrementDrops string `json:"ReserveIncrementDrops,omitempty" xrpl:"ReserveIncrementDrops,omitempty"`
 
-	// LedgerSequence is the ledger sequence for this fee change
 	LedgerSequence *uint32 `json:"LedgerSequence,omitempty" xrpl:"LedgerSequence,omitempty"`
 }
 
@@ -88,7 +77,6 @@ func (s *SetFee) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(s)
 }
 
-// IsPseudoTransaction returns true as SetFee is a pseudo-transaction
 func (s *SetFee) IsPseudoTransaction() bool {
 	return true
 }
@@ -153,7 +141,6 @@ func (s *SetFee) preclaim(ctx *tx.ApplyContext) tx.Result {
 // Apply mirrors rippled Change::applyFee() (Change.cpp:347-385): it
 // either creates or updates the FeeSettings singleton, writing only
 // the field set corresponding to the active amendment branch.
-// Reference: rippled Change.cpp applyFee()
 func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 	if r := s.preflight(); r != tx.TesSUCCESS {
 		return r

--- a/internal/txq/admission_test.go
+++ b/internal/txq/admission_test.go
@@ -1,0 +1,84 @@
+package txq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpperBoundSeqProxy_PicksSmallestStrictlyGreater pins the
+// std::map::upper_bound contract on the SeqProxy ordering: with
+// queued seq 9, 11, 13 and a probe at seq 10, the helper must return
+// seq 11 (the smallest strictly greater).
+func TestUpperBoundSeqProxy_PicksSmallestStrictlyGreater(t *testing.T) {
+	aq := NewAccountQueue([20]byte{1})
+	for _, s := range []uint32{9, 11, 13} {
+		aq.Transactions[NewSeqProxySequence(s)] = &Candidate{
+			SeqProxy: NewSeqProxySequence(s),
+		}
+	}
+	q := New(makeAdmissionConfig())
+	next, ok := q.upperBoundSeqProxy(aq, NewSeqProxySequence(10))
+	require.True(t, ok)
+	require.Equal(t, NewSeqProxySequence(11), next)
+}
+
+// TestUpperBoundSeqProxy_RejectsTicketAsNeighbour pins the bugfix:
+// when the only tx greater than the probe is a ticket, rippled's
+// `nextTxIter->first.isSeq()` check rejects the gap fill. The old
+// goxrpl scan admitted any later sequence — even one that didn't
+// neighbour the probe. The new helper returns the ticket so the
+// caller can reject it.
+func TestUpperBoundSeqProxy_RejectsTicketAsNeighbour(t *testing.T) {
+	aq := NewAccountQueue([20]byte{1})
+	ticket := SeqProxy{Value: 12, IsTicket: true}
+	aq.Transactions[ticket] = &Candidate{SeqProxy: ticket}
+	q := New(makeAdmissionConfig())
+	next, ok := q.upperBoundSeqProxy(aq, NewSeqProxySequence(9))
+	require.True(t, ok)
+	require.True(t, next.IsTicket, "ticket dominates the upper-bound when no later seq exists")
+}
+
+// TestUpperBoundSeqProxy_PrefersSeqBeforeTicket pins the SeqProxy
+// ordering rule from SeqProxy.h:58 (`enum Type : uint8_t { seq=0,
+// ticket=1 }`) — sequences sort BEFORE tickets globally. With seq 11
+// and ticket 5 both queued, the upper bound of seq 10 is seq 11
+// (the ticket is "greater" by value but `seq < ticket` per the type
+// ordering, so the smallest strictly greater is the seq).
+func TestUpperBoundSeqProxy_PrefersSeqBeforeTicket(t *testing.T) {
+	aq := NewAccountQueue([20]byte{1})
+	aq.Transactions[NewSeqProxySequence(11)] = &Candidate{SeqProxy: NewSeqProxySequence(11)}
+	ticket := SeqProxy{Value: 5, IsTicket: true}
+	aq.Transactions[ticket] = &Candidate{SeqProxy: ticket}
+	q := New(makeAdmissionConfig())
+	next, ok := q.upperBoundSeqProxy(aq, NewSeqProxySequence(10))
+	require.True(t, ok)
+	require.False(t, next.IsTicket, "seq 11 outranks ticket 5 under SeqProxy ordering")
+	require.Equal(t, uint32(11), next.Value)
+}
+
+// TestUpperBoundSeqProxy_EmptyQueueReturnsFalse pins the
+// nextTxIter == end() branch.
+func TestUpperBoundSeqProxy_EmptyQueueReturnsFalse(t *testing.T) {
+	aq := NewAccountQueue([20]byte{1})
+	q := New(makeAdmissionConfig())
+	_, ok := q.upperBoundSeqProxy(aq, NewSeqProxySequence(0))
+	require.False(t, ok)
+}
+
+func makeAdmissionConfig() Config {
+	return Config{
+		LedgersInQueue:                 20,
+		MinimumTxnInLedger:             3,
+		TargetTxnInLedger:              5,
+		MaximumTxnInLedger:             10,
+		MinimumEscalationMultiplier:    128000,
+		MinimumLastLedgerBuffer:        2,
+		QueueSizeMin:                   10,
+		MaximumTxnPerAccount:           10,
+		MinimumTxnInLedgerStandalone:   100,
+		NormalConsensusIncreasePercent: 20,
+		SlowConsensusDecreasePercent:   50,
+		Standalone:                     false,
+	}
+}

--- a/internal/txq/admission_test.go
+++ b/internal/txq/admission_test.go
@@ -23,12 +23,10 @@ func TestUpperBoundSeqProxy_PicksSmallestStrictlyGreater(t *testing.T) {
 	require.Equal(t, NewSeqProxySequence(11), next)
 }
 
-// TestUpperBoundSeqProxy_RejectsTicketAsNeighbour pins the bugfix:
-// when the only tx greater than the probe is a ticket, rippled's
-// `nextTxIter->first.isSeq()` check rejects the gap fill. The old
-// goxrpl scan admitted any later sequence — even one that didn't
-// neighbour the probe. The new helper returns the ticket so the
-// caller can reject it.
+// TestUpperBoundSeqProxy_RejectsTicketAsNeighbour pins
+// TxQ.cpp:440-444: when the only tx greater than the probe is a
+// ticket, rippled's `nextTxIter->first.isSeq()` check rejects the gap
+// fill. upperBoundSeqProxy returns the ticket so canBeHeld can reject.
 func TestUpperBoundSeqProxy_RejectsTicketAsNeighbour(t *testing.T) {
 	aq := NewAccountQueue([20]byte{1})
 	ticket := SeqProxy{Value: 12, IsTicket: true}

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -56,6 +56,12 @@ type ApplyContext interface {
 	// This is used for the multiTxn path (TxQ.cpp:1167-1170) where rippled
 	// runs preclaim against a modified view to detect terINSUF_FEE_B etc.
 	PreclaimTransaction(txn tx.Transaction, account [20]byte, adjustedBalance uint64, adjustedSeq uint32) tx.Result
+
+	// GetApplyFlags returns the engine ApplyFlags driving this
+	// submission. Implementations that don't carry flags (legacy test
+	// adapters) can return 0; TxQ only inspects TapFAIL_HARD to mirror
+	// rippled TxQ.cpp:393-399 (fail-hard txs are never held).
+	GetApplyFlags() tx.ApplyFlags
 }
 
 // Apply attempts to apply a transaction or queue it for later.
@@ -124,9 +130,15 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	}
 
 	// Transaction needs to be queued.
-	// AccountTxnID is not supported by the transaction queue.
-	// Reference: TxQ.cpp:394-399 (canBeHeld)
+	// AccountTxnID is not supported by the transaction queue;
+	// tapFAIL_HARD transactions are never held. Mirrors rippled
+	// TxQ.cpp:393-399 (canBeHeld). The sfPreviousTxnID guard from
+	// rippled has no goxrpl counterpart — the field is metadata-only
+	// in this implementation and never lives on a submitted tx.
 	if common.AccountTxnID != "" {
+		return ApplyResult{Result: tx.TelCAN_NOT_QUEUE, Applied: false}
+	}
+	if ctx.GetApplyFlags()&tx.TapFAIL_HARD != 0 {
 		return ApplyResult{Result: tx.TelCAN_NOT_QUEUE, Applied: false}
 	}
 
@@ -599,25 +611,42 @@ func (q *TxQ) canBeHeld(aq *AccountQueue, replacingCandidate *Candidate, seqProx
 	// Allow if this fills the next sequence gap in the account's queue.
 	nextSeq := q.getNextQueuableSeq(aq, acctSeq)
 	if !seqProxy.IsTicket && seqProxy.Value == nextSeq {
-		// Check if there's a subsequent sequence-based tx in the queue
-		// that this would connect to (i.e., a real gap, not just appending).
-		// Reference: TxQ.cpp:440-444 upper_bound(nextQueuable)
-		hasLaterSeq := false
-		for sp := range aq.Transactions {
-			if !sp.IsTicket && sp.Value > seqProxy.Value {
-				hasLaterSeq = true
-				break
-			}
-		}
-		if !hasLaterSeq {
+		// Mirrors rippled TxQ.cpp:440-444:
+		//   auto const nextTxIter = txQAcct.transactions.upper_bound(nextQueuable);
+		//   if (nextTxIter != end() && nextTxIter->first.isSeq())
+		//     return tesSUCCESS;
+		// The IMMEDIATE next SeqProxy must be sequence-based — a ticket
+		// sitting next in line doesn't make this a true gap fill,
+		// because tickets can't unblock a sequence-based pipeline.
+		nextSP, hasNext := q.upperBoundSeqProxy(aq, seqProxy)
+		if !hasNext || nextSP.IsTicket {
 			q.incTxQFull()
 			return true, ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
-		// Real gap fill — allow it
+		// Real gap fill — allow it.
 		return false, ApplyResult{}
 	}
 	q.incTxQFull()
 	return true, ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
+}
+
+// upperBoundSeqProxy returns the smallest SeqProxy in aq strictly
+// greater than `sp`, mirroring std::map::upper_bound semantics on the
+// SeqProxy ordering (sequences come before tickets, then by numeric
+// value). hasNext is false when no such entry exists.
+func (q *TxQ) upperBoundSeqProxy(aq *AccountQueue, sp SeqProxy) (SeqProxy, bool) {
+	var best SeqProxy
+	found := false
+	for candidate := range aq.Transactions {
+		if !sp.Less(candidate) {
+			continue
+		}
+		if !found || candidate.Less(best) {
+			best = candidate
+			found = true
+		}
+	}
+	return best, found
 }
 
 // getNextQueuableSeq returns the next sequence that can be queued for an account.


### PR DESCRIPTION
## Summary
- Port rippled's LoadFeeTrack subsystem under `internal/loadfeetrack/` and surface it via the server_info `LoadFactorFees` hook + `GetAutofillFee` scaling.
- Wire the `fee` RPC handler to live `Service.GetTxQMetrics()` (TxQ::doRPC parity, including open-ledger drops rounding).
- Tighten SetFee preflight / preclaim / parsing to match `Change.cpp:43-385` (account / fee / signature / sequence guards, XRPFees-aware field requirements, surfaced parse errors).
- Replace Batch.CalculateMinimumFee approximation with the rippled `Batch.cpp:53-150` formula: per-inner multi-sign-aware base + per-BatchSigner expansion counting nested signers.
- TxQ admission: reject queued `tapFAIL_HARD` submissions via a new `GetApplyFlags` hook, fix the sequence-gap exception to use `upper_bound` semantics (so a neighbouring ticket no longer counts), and plumb `SetLastConsensusRoundTime` → `timeLeap` so slow-consensus rounds freeze the fee window.

Closes the LoadFeeTrack-only follow-up tracked at #514.

## Test plan
- [x] `just test-pkg ./internal/loadfeetrack/...` — 11 ScaleFee / raise / lower / overflow pins.
- [x] `just test-pkg ./internal/txq/...` — new upper_bound admission helper coverage.
- [x] `just test-pkg ./internal/tx/batch/...` — single-sign baseline + multi-sign BatchSigner + multi-signed inner cases.
- [x] `just test-pkg ./internal/testing/pseudotx/... -run TestSetFee` — every preflight / preclaim reject path.
- [x] `just test-pkg ./internal/rpc/... -run TestFee` — idle / standalone / live / queue-full / nil-max paths.
- [x] Full suite on touched packages (`internal/cli`, `internal/ledger/openledger`, `internal/ledger/service`, `internal/rpc`, `internal/testing/{batch,feetrack,txq,pseudotx}`, `internal/tx/{batch,pseudo}`, `internal/txq`, `internal/loadfeetrack`) passes; pre-existing `internal/testing/{escrow,mpt}` MPT failures are unchanged on `main` and unrelated to this PR.

Fixes #501
Closes #514