### PR TITLE
fix(tx/batch): add temINVALID_INNER_BATCH and inner-tx preflight

### DIFF
--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -284,8 +284,7 @@ func TestPreflight(t *testing.T) {
 		require.False(t, result.Success)
 	})
 
-	// temINVALID_INNER_BATCH: inner tx preflight fails (e.g. negative amount).
-	// Reference: rippled Batch_test.cpp:398-406
+	// Reference: rippled Batch_test.cpp:398-406.
 	t.Run("temINVALID_INNER_BATCH - malformed inner tx", func(t *testing.T) {
 		env := xtesting.NewTestEnv(t)
 		alice := xtesting.NewAccount("alice")
@@ -296,9 +295,6 @@ func TestPreflight(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 
-		// Second inner Payment has a negative XRP amount → Payment.Validate()
-		// returns temBAD_AMOUNT, which surfaces as temINVALID_INNER_BATCH on
-		// the outer Batch.
 		badInner := payment.NewPayment(alice.Address, bob.Address, tx.NewXRPAmount(-1))
 		badInner.Fee = "0"
 		badInner.SigningPubKey = ""
@@ -314,9 +310,7 @@ func TestPreflight(t *testing.T) {
 		xtesting.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
 	})
 
-	// Per-inner structural rejections mirroring rippled Batch_test.cpp:410-501.
-	// Each subtest builds a 2-inner Batch where the second inner violates one
-	// specific rule and asserts the outer reports the rippled-specific TER.
+	// Reference: rippled Batch_test.cpp:410-501 (per-inner rejection cases).
 
 	t.Run("temBAD_FEE - inner fee non-zero", func(t *testing.T) {
 		env := xtesting.NewTestEnv(t)

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -284,6 +284,36 @@ func TestPreflight(t *testing.T) {
 		require.False(t, result.Success)
 	})
 
+	// temINVALID_INNER_BATCH: inner tx preflight fails (e.g. negative amount).
+	// Reference: rippled Batch_test.cpp:398-406
+	t.Run("temINVALID_INNER_BATCH - malformed inner tx", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+
+		// Second inner Payment has a negative XRP amount → Payment.Validate()
+		// returns temBAD_AMOUNT, which surfaces as temINVALID_INNER_BATCH on
+		// the outer Batch.
+		badInner := payment.NewPayment(alice.Address, bob.Address, tx.NewXRPAmount(-1))
+		badInner.Fee = "0"
+		badInner.SigningPubKey = ""
+		badInner.SetSequence(seq + 2)
+		badInner.SetFlags(tx.TfInnerBatchTxn)
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(badInner).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
+	})
+
 	t.Run("valid batch with all four mode flags individually", func(t *testing.T) {
 		for _, flag := range []uint32{
 			batchtx.BatchFlagAllOrNothing,

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -314,6 +314,222 @@ func TestPreflight(t *testing.T) {
 		xtesting.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
 	})
 
+	// Per-inner structural rejections mirroring rippled Batch_test.cpp:410-501.
+	// Each subtest builds a 2-inner Batch where the second inner violates one
+	// specific rule and asserts the outer reports the rippled-specific TER.
+
+	t.Run("temBAD_FEE - inner fee non-zero", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		badInner := MakeInnerPaymentXRP(alice, bob, 1, seq+2)
+		badInner.Fee = fmt.Sprintf("%d", env.BaseFee())
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(badInner).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temBAD_FEE")
+	})
+
+	t.Run("temSEQ_AND_TICKET - inner has both Sequence and TicketSequence", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		bothInner := MakeInnerPaymentXRP(alice, bob, 1, seq+2)
+		ticket := uint32(1)
+		bothInner.TicketSequence = &ticket
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(bothInner).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temSEQ_AND_TICKET")
+	})
+
+	t.Run("temSEQ_AND_TICKET - inner has neither Sequence nor TicketSequence", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		neitherInner := MakeInnerPaymentXRP(alice, bob, 1, 0)
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(neitherInner).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temSEQ_AND_TICKET")
+	})
+
+	t.Run("temBAD_SIGNATURE - inner has TxnSignature", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		signedInner := MakeInnerPaymentXRP(alice, bob, 1, seq+2)
+		signedInner.TxnSignature = "DEADBEEF"
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(signedInner).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temBAD_SIGNATURE")
+	})
+
+	t.Run("temBAD_SIGNER - inner has Signers", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		multiInner := MakeInnerPaymentXRP(alice, bob, 1, seq+2)
+		multiInner.Signers = []tx.SignerWrapper{
+			{Signer: tx.Signer{Account: bob.Address, SigningPubKey: bob.PublicKeyHex(), TxnSignature: "DEADBEEF"}},
+		}
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(multiInner).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temBAD_SIGNER")
+	})
+
+	t.Run("temBAD_REGKEY - inner has SigningPubKey", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		pkInner := MakeInnerPaymentXRP(alice, bob, 1, seq+2)
+		pkInner.SigningPubKey = alice.PublicKeyHex()
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(pkInner).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temBAD_REGKEY")
+	})
+
+	t.Run("temINVALID - inner is itself a Batch", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		innerBatch := batchtx.NewBatch(alice.Address)
+		innerBatch.Fee = "0"
+		innerBatch.SigningPubKey = ""
+		innerBatch.SetSequence(seq + 2)
+		innerBatch.SetFlags(tx.TfInnerBatchTxn | batchtx.BatchFlagAllOrNothing)
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(innerBatch).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temINVALID")
+	})
+
+	t.Run("temINVALID_FLAG - inner missing tfInnerBatchTxn", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		noFlagInner := MakeInnerPaymentXRP(alice, bob, 1, seq+2)
+		noFlag := uint32(0)
+		noFlagInner.Flags = &noFlag
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(noFlagInner).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temINVALID_FLAG")
+	})
+
+	t.Run("temREDUNDANT - duplicate inner transactions", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		// Two identical inner txns → identical hashes → temREDUNDANT.
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temREDUNDANT")
+	})
+
+	t.Run("temREDUNDANT - duplicate sequence per account under tfAllOrNothing", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		// Two distinct inner txns with the SAME Sequence for alice → temREDUNDANT.
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+1)).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temREDUNDANT")
+	})
+
 	t.Run("valid batch with all four mode flags individually", func(t *testing.T) {
 		for _, flag := range []uint32{
 			batchtx.BatchFlagAllOrNothing,
@@ -2750,11 +2966,12 @@ func TestBatchCalculateBaseFee(t *testing.T) {
 		env.Fund(alice)
 		env.Close()
 
+		bob := xtesting.NewAccount("bob")
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 9, 2)
 		builder := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeFakeInnerTx()).
-			AddInnerTx(MakeFakeInnerTx())
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2))
 		for i := 0; i < 9; i++ {
 			signer := xtesting.NewAccount(fmt.Sprintf("signer%d", i))
 			builder.AddSigner(signer, "DEADBEEF")

--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -80,14 +80,16 @@ const (
 	// tfAllowXRP allows XRP payments
 	AccountSetTxFlagAllowXRP uint32 = 0x00200000
 
-	// tfAccountSetMask is the mask for valid AccountSet transaction flags
+	// tfAccountSetMask is the mask for valid AccountSet transaction flags.
+	// Reference: rippled TxFlags.h tfAccountSetMask — carves out tfUniversal
+	// (tfFullyCanonicalSig | tfInnerBatchTxn) as well as the AccountSet-specific flags.
 	AccountSetTxFlagMask uint32 = ^(AccountSetTxFlagRequireDestTag |
 		AccountSetTxFlagOptionalDestTag |
 		AccountSetTxFlagRequireAuth |
 		AccountSetTxFlagOptionalAuth |
 		AccountSetTxFlagDisallowXRP |
 		AccountSetTxFlagAllowXRP |
-		TxFlagFullyCanonicalSig)
+		tx.TfUniversal)
 )
 
 // Domain length limits

--- a/internal/tx/amm/constants.go
+++ b/internal/tx/amm/constants.go
@@ -24,8 +24,14 @@ const (
 // Transaction flags
 
 const (
-	// AMMCreate has no valid transaction flags
-	tfAMMCreateMask uint32 = 0xFFFFFFFF
+	// AMM* masks mirror rippled: any non-universal bit is rejected, allowing
+	// universal flags (tfFullyCanonicalSig, tfInnerBatchTxn) through. References:
+	// rippled AMMCreate.cpp:43, AMMVote.cpp:46, AMMBid.cpp:42, AMMDelete.cpp:39
+	// (each `getFlags() & tfUniversalMask`); TxFlags.h:222-227 for the *Mask
+	// constants used here.
+
+	// AMMCreate has no valid transaction flags beyond universal.
+	tfAMMCreateMask uint32 = tx.TfUniversalMask
 
 	// AMMDeposit flags
 	tfLPToken         uint32 = 0x00010000
@@ -36,25 +42,25 @@ const (
 	tfTwoAssetIfEmpty uint32 = 0x00800000
 	// tfDepositSubTx is the combination of all deposit mode flags (used for popcount check)
 	tfDepositSubTx   uint32 = tfLPToken | tfSingleAsset | tfTwoAsset | tfOneAssetLPToken | tfLimitLPToken | tfTwoAssetIfEmpty
-	tfAMMDepositMask uint32 = ^tfDepositSubTx
+	tfAMMDepositMask uint32 = ^(tx.TfUniversal | tfDepositSubTx)
 
 	// AMMWithdraw flags
 	tfWithdrawAll         uint32 = 0x00020000
 	tfOneAssetWithdrawAll uint32 = 0x00040000
-	tfAMMWithdrawMask     uint32 = ^(tfLPToken | tfWithdrawAll | tfOneAssetWithdrawAll | tfSingleAsset | tfTwoAsset | tfOneAssetLPToken | tfLimitLPToken)
+	tfAMMWithdrawMask     uint32 = ^(tx.TfUniversal | tfLPToken | tfWithdrawAll | tfOneAssetWithdrawAll | tfSingleAsset | tfTwoAsset | tfOneAssetLPToken | tfLimitLPToken)
 
-	// AMMVote has no valid transaction flags
-	tfAMMVoteMask uint32 = 0xFFFFFFFF
+	// AMMVote has no valid transaction flags beyond universal.
+	tfAMMVoteMask uint32 = tx.TfUniversalMask
 
-	// AMMBid has no valid transaction flags
-	tfAMMBidMask uint32 = 0xFFFFFFFF
+	// AMMBid has no valid transaction flags beyond universal.
+	tfAMMBidMask uint32 = tx.TfUniversalMask
 
-	// AMMDelete has no valid transaction flags
-	tfAMMDeleteMask uint32 = 0xFFFFFFFF
+	// AMMDelete has no valid transaction flags beyond universal.
+	tfAMMDeleteMask uint32 = tx.TfUniversalMask
 
 	// AMMClawback flags
 	tfClawTwoAssets   uint32 = 0x00000001
-	tfAMMClawbackMask uint32 = ^tfClawTwoAssets
+	tfAMMClawbackMask uint32 = ^(tx.TfUniversal | tfClawTwoAssets)
 )
 
 // Internal constants (lowercase aliases of exported AMM constants)

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -96,6 +96,17 @@ func (b *Batch) InnerTxCount() int {
 	return len(b.RawTransactions)
 }
 
+// InnerTransactions returns the inner transactions wrapped by this batch.
+// Implements tx.BatchOuter so the engine's preflight pipeline can run each
+// inner tx through its own preflight (mirroring rippled Batch.cpp:303-312).
+func (b *Batch) InnerTransactions() []tx.Transaction {
+	txns := make([]tx.Transaction, len(b.RawTransactions))
+	for i, rt := range b.RawTransactions {
+		txns[i] = rt.RawTransaction.InnerTx
+	}
+	return txns
+}
+
 // Reference: rippled Batch.cpp preflight()
 func (b *Batch) Validate() error {
 	if err := b.BaseTx.Validate(); err != nil {

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -2,6 +2,7 @@ package batch
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
@@ -66,16 +67,27 @@ const (
 	MaxBatchTransactions = 8
 )
 
-// Batch errors
+// Batch errors. Inner-tx errors mirror the per-inner rejections in rippled
+// Batch.cpp:249-374 (Batch::preflight inner loop).
 var (
-	ErrBatchTooFewTxns      = tx.Errorf(tx.TemARRAY_EMPTY, "batch must have at least 2 transactions")
-	ErrBatchTooManyTxns     = tx.Errorf(tx.TemARRAY_TOO_LARGE, "batch exceeds 8 transactions")
-	ErrBatchInvalidFlags    = tx.Errorf(tx.TemINVALID_FLAG, "invalid batch flags")
-	ErrBatchMustHaveOneFlag = tx.Errorf(tx.TemINVALID_FLAG, "exactly one batch mode flag required")
-	ErrBatchTooManySigners  = tx.Errorf(tx.TemARRAY_TOO_LARGE, "batch signers exceeds 8 entries")
-	ErrBatchDuplicateSigner = tx.Errorf(tx.TemREDUNDANT, "duplicate batch signer")
-	ErrBatchSignerIsOuter   = tx.Errorf(tx.TemBAD_SIGNER, "batch signer cannot be outer account")
-	ErrBatchNilInnerTx      = tx.Errorf(tx.TemMALFORMED, "inner transaction cannot be nil")
+	ErrBatchTooFewTxns            = tx.Errorf(tx.TemARRAY_EMPTY, "batch must have at least 2 transactions")
+	ErrBatchTooManyTxns           = tx.Errorf(tx.TemARRAY_TOO_LARGE, "batch exceeds 8 transactions")
+	ErrBatchInvalidFlags          = tx.Errorf(tx.TemINVALID_FLAG, "invalid batch flags")
+	ErrBatchMustHaveOneFlag       = tx.Errorf(tx.TemINVALID_FLAG, "exactly one batch mode flag required")
+	ErrBatchTooManySigners        = tx.Errorf(tx.TemARRAY_TOO_LARGE, "batch signers exceeds 8 entries")
+	ErrBatchDuplicateSigner       = tx.Errorf(tx.TemREDUNDANT, "duplicate batch signer")
+	ErrBatchSignerIsOuter         = tx.Errorf(tx.TemBAD_SIGNER, "batch signer cannot be outer account")
+	ErrBatchNilInnerTx            = tx.Errorf(tx.TemMALFORMED, "inner transaction cannot be nil")
+	ErrBatchDuplicateInnerTx      = tx.Errorf(tx.TemREDUNDANT, "duplicate inner transaction")
+	ErrBatchInnerIsBatch          = tx.Errorf(tx.TemINVALID, "inner transaction cannot itself be a Batch")
+	ErrBatchInnerMissingFlag      = tx.Errorf(tx.TemINVALID_FLAG, "inner transaction missing tfInnerBatchTxn flag")
+	ErrBatchInnerHasTxnSignature  = tx.Errorf(tx.TemBAD_SIGNATURE, "inner transaction cannot include TxnSignature")
+	ErrBatchInnerHasSigners       = tx.Errorf(tx.TemBAD_SIGNER, "inner transaction cannot include Signers")
+	ErrBatchInnerHasSigningPubKey = tx.Errorf(tx.TemBAD_REGKEY, "inner transaction SigningPubKey must be empty")
+	ErrBatchInnerBadFee           = tx.Errorf(tx.TemBAD_FEE, "inner transaction must have a fee of 0")
+	ErrBatchInnerSeqAndTicket     = tx.Errorf(tx.TemSEQ_AND_TICKET, "inner transaction must have exactly one of Sequence and TicketSequence")
+	ErrBatchInnerDupSeqOrTicket   = tx.Errorf(tx.TemREDUNDANT, "duplicate inner Sequence or TicketSequence for account")
+	ErrBatchInnerHashUncomputable = tx.Errorf(tx.TemINVALID, "failed to compute inner transaction hash")
 )
 
 // NewBatch creates a new Batch transaction
@@ -105,6 +117,108 @@ func (b *Batch) InnerTransactions() []tx.Transaction {
 		txns[i] = rt.RawTransaction.InnerTx
 	}
 	return txns
+}
+
+// validateInnerTransactions performs the per-inner structural checks that
+// rippled does in Batch::preflight (Batch.cpp:249-374): duplicate-hash,
+// inner-is-not-Batch, tfInnerBatchTxn presence, no TxnSignature / Signers /
+// SigningPubKey, fee==0, exactly one of Sequence/TicketSequence, and (under
+// tfAllOrNothing | tfUntilFailure) duplicate Sequence/TicketSequence per
+// inner account.
+func (b *Batch) validateInnerTransactions() error {
+	flags := b.GetFlags()
+	enforceUnique := flags&(BatchFlagAllOrNothing|BatchFlagUntilFailure) != 0
+
+	uniqueHashes := make(map[[32]byte]struct{}, len(b.RawTransactions))
+	accountSeqTicket := make(map[string]map[uint32]struct{})
+
+	for _, rt := range b.RawTransactions {
+		inner := rt.RawTransaction.InnerTx
+		if inner == nil {
+			return ErrBatchNilInnerTx
+		}
+
+		hash, err := tx.ComputeTransactionHash(inner)
+		if err != nil {
+			return ErrBatchInnerHashUncomputable
+		}
+		if _, dup := uniqueHashes[hash]; dup {
+			return ErrBatchDuplicateInnerTx
+		}
+		uniqueHashes[hash] = struct{}{}
+
+		if inner.TxType() == tx.TypeBatch {
+			return ErrBatchInnerIsBatch
+		}
+
+		innerCommon := inner.GetCommon()
+
+		if innerCommon.GetFlags()&tx.TfInnerBatchTxn == 0 {
+			return ErrBatchInnerMissingFlag
+		}
+		if innerCommon.TxnSignature != "" {
+			return ErrBatchInnerHasTxnSignature
+		}
+		if len(innerCommon.Signers) > 0 {
+			return ErrBatchInnerHasSigners
+		}
+		if innerCommon.SigningPubKey != "" {
+			return ErrBatchInnerHasSigningPubKey
+		}
+		if err := validateInnerFee(innerCommon.Fee); err != nil {
+			return err
+		}
+
+		// rippled treats sfSequence absent and sfSequence==0 identically via
+		// getFieldU32; Go's *uint32 nil and *0 collapse the same way here.
+		seqVal := uint32(0)
+		if innerCommon.Sequence != nil {
+			seqVal = *innerCommon.Sequence
+		}
+		hasTicket := innerCommon.TicketSequence != nil
+		if hasTicket && seqVal != 0 {
+			return ErrBatchInnerSeqAndTicket
+		}
+		if !hasTicket && seqVal == 0 {
+			return ErrBatchInnerSeqAndTicket
+		}
+
+		if enforceUnique {
+			acct := innerCommon.Account
+			seen, ok := accountSeqTicket[acct]
+			if !ok {
+				seen = make(map[uint32]struct{})
+				accountSeqTicket[acct] = seen
+			}
+			if seqVal != 0 {
+				if _, dup := seen[seqVal]; dup {
+					return ErrBatchInnerDupSeqOrTicket
+				}
+				seen[seqVal] = struct{}{}
+			}
+			if hasTicket {
+				ticket := *innerCommon.TicketSequence
+				if _, dup := seen[ticket]; dup {
+					return ErrBatchInnerDupSeqOrTicket
+				}
+				seen[ticket] = struct{}{}
+			}
+		}
+	}
+	return nil
+}
+
+// validateInnerFee enforces rippled Batch.cpp:314-322: inner fee must be
+// present and equal to native XRP zero. Empty/non-numeric/non-zero rejects.
+func validateInnerFee(fee string) error {
+	if fee == "" {
+		return ErrBatchInnerBadFee
+	}
+	feeInt, err := strconv.ParseInt(fee, 10, 64)
+	if err != nil || feeInt != 0 {
+		return ErrBatchInnerBadFee
+	}
+	return nil
 }
 
 // Reference: rippled Batch.cpp preflight()
@@ -147,11 +261,13 @@ func (b *Batch) Validate() error {
 		return ErrBatchTooManyTxns
 	}
 
-	// Validate each raw transaction has a non-nil inner transaction
-	for _, rt := range b.RawTransactions {
-		if rt.RawTransaction.InnerTx == nil {
-			return ErrBatchNilInnerTx
-		}
+	// Per-inner structural checks (rippled Batch.cpp:249-374).
+	// These run before the engine's BatchOuter loop calls preflightInner,
+	// so a malformed inner is rejected with its specific TER (temBAD_SIGNATURE,
+	// temBAD_FEE, temSEQ_AND_TICKET, temREDUNDANT…) rather than the generic
+	// temINVALID_INNER_BATCH.
+	if err := b.validateInnerTransactions(); err != nil {
+		return err
 	}
 
 	// Validate BatchSigners if present

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -108,9 +108,8 @@ func (b *Batch) InnerTxCount() int {
 	return len(b.RawTransactions)
 }
 
-// InnerTransactions returns the inner transactions wrapped by this batch.
-// Implements tx.BatchOuter so the engine's preflight pipeline can run each
-// inner tx through its own preflight (mirroring rippled Batch.cpp:303-312).
+// InnerTransactions implements tx.BatchOuter.
+// Reference: rippled Batch.cpp:303-312.
 func (b *Batch) InnerTransactions() []tx.Transaction {
 	txns := make([]tx.Transaction, len(b.RawTransactions))
 	for i, rt := range b.RawTransactions {
@@ -119,12 +118,7 @@ func (b *Batch) InnerTransactions() []tx.Transaction {
 	return txns
 }
 
-// validateInnerTransactions performs the per-inner structural checks that
-// rippled does in Batch::preflight (Batch.cpp:249-374): duplicate-hash,
-// inner-is-not-Batch, tfInnerBatchTxn presence, no TxnSignature / Signers /
-// SigningPubKey, fee==0, exactly one of Sequence/TicketSequence, and (under
-// tfAllOrNothing | tfUntilFailure) duplicate Sequence/TicketSequence per
-// inner account.
+// Reference: rippled Batch.cpp:249-374 (per-inner checks in Batch::preflight).
 func (b *Batch) validateInnerTransactions() error {
 	flags := b.GetFlags()
 	enforceUnique := flags&(BatchFlagAllOrNothing|BatchFlagUntilFailure) != 0
@@ -208,8 +202,7 @@ func (b *Batch) validateInnerTransactions() error {
 	return nil
 }
 
-// validateInnerFee enforces rippled Batch.cpp:314-322: inner fee must be
-// present and equal to native XRP zero. Empty/non-numeric/non-zero rejects.
+// Reference: rippled Batch.cpp:314-322 — inner fee must be present and 0.
 func validateInnerFee(fee string) error {
 	if fee == "" {
 		return ErrBatchInnerBadFee
@@ -261,11 +254,9 @@ func (b *Batch) Validate() error {
 		return ErrBatchTooManyTxns
 	}
 
-	// Per-inner structural checks (rippled Batch.cpp:249-374).
-	// These run before the engine's BatchOuter loop calls preflightInner,
-	// so a malformed inner is rejected with its specific TER (temBAD_SIGNATURE,
-	// temBAD_FEE, temSEQ_AND_TICKET, temREDUNDANT…) rather than the generic
-	// temINVALID_INNER_BATCH.
+	// Runs before the engine's BatchOuter loop so malformed inners surface
+	// with their specific TER instead of generic temINVALID_INNER_BATCH.
+	// Reference: rippled Batch.cpp:249-374.
 	if err := b.validateInnerTransactions(); err != nil {
 		return err
 	}

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -11,12 +11,10 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx/payment"
 )
 
-// makeTestPaymentSeq is incremented on every makeTestPayment() call so that
-// successive inners have distinct hashes. Batch.Validate rejects duplicate
-// inner txns per rippled Batch.cpp:253-259.
+// Auto-incremented so successive inners hash uniquely (Batch.Validate rejects
+// duplicates per rippled Batch.cpp:253-259).
 var makeTestPaymentSeq uint32
 
-// makeTestPayment creates a minimal valid inner Payment transaction for testing.
 func makeTestPayment() tx.Transaction {
 	makeTestPaymentSeq++
 	seq := makeTestPaymentSeq

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -11,8 +11,15 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx/payment"
 )
 
+// makeTestPaymentSeq is incremented on every makeTestPayment() call so that
+// successive inners have distinct hashes. Batch.Validate rejects duplicate
+// inner txns per rippled Batch.cpp:253-259.
+var makeTestPaymentSeq uint32
+
 // makeTestPayment creates a minimal valid inner Payment transaction for testing.
 func makeTestPayment() tx.Transaction {
+	makeTestPaymentSeq++
+	seq := makeTestPaymentSeq
 	p := payment.NewPayment(
 		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -20,7 +27,6 @@ func makeTestPayment() tx.Transaction {
 	)
 	p.Fee = "0"
 	p.SigningPubKey = ""
-	seq := uint32(1)
 	p.Sequence = &seq
 	flags := tx.TfInnerBatchTxn
 	p.Flags = &flags

--- a/internal/tx/nftoken/nftoken_create_offer.go
+++ b/internal/tx/nftoken/nftoken_create_offer.go
@@ -34,8 +34,9 @@ const (
 	// tfSellNFToken indicates this is a sell offer
 	NFTokenCreateOfferFlagSellNFToken uint32 = 0x00000001
 
-	// tfNFTokenCreateOfferMask is the mask for invalid flags
-	tfNFTokenCreateOfferMask uint32 = ^NFTokenCreateOfferFlagSellNFToken
+	// tfNFTokenCreateOfferMask is the mask for invalid flags.
+	// Reference: rippled TxFlags.h tfNFTokenCreateOfferMask = ~(tfUniversal | tfSellNFToken).
+	tfNFTokenCreateOfferMask uint32 = ^(tx.TfUniversal | NFTokenCreateOfferFlagSellNFToken)
 )
 
 // NewNFTokenCreateOffer creates a new NFTokenCreateOffer transaction

--- a/internal/tx/nftoken/nftoken_mint.go
+++ b/internal/tx/nftoken/nftoken_mint.go
@@ -46,12 +46,11 @@ const (
 	// tfMutable allows the URI to be modified (requires DynamicNFT amendment)
 	NFTokenMintFlagMutable uint32 = 0x00000010
 
-	// tfNFTokenMintMask is the mask for valid flags (with fixRemoveNFTokenAutoTrustLine)
-	tfNFTokenMintMask uint32 = ^(NFTokenMintFlagBurnable | NFTokenMintFlagOnlyXRP | NFTokenMintFlagTransferable)
-	// tfNFTokenMintMaskWithMutable includes mutable flag
-	tfNFTokenMintMaskWithMutable uint32 = ^(NFTokenMintFlagBurnable | NFTokenMintFlagOnlyXRP | NFTokenMintFlagTransferable | NFTokenMintFlagMutable)
-	// tfNFTokenMintOldMaskWithMutable includes mutable flag
-	tfNFTokenMintOldMaskWithMutable uint32 = ^(NFTokenMintFlagBurnable | NFTokenMintFlagOnlyXRP | NFTokenMintFlagTrustLine | NFTokenMintFlagTransferable | NFTokenMintFlagMutable)
+	// Reference: rippled TxFlags.h tfNFTokenMintMask — all masks carve out
+	// tfUniversal so inner Batch txs (which carry tfInnerBatchTxn) aren't rejected.
+	tfNFTokenMintMask               uint32 = ^(tx.TfUniversal | NFTokenMintFlagBurnable | NFTokenMintFlagOnlyXRP | NFTokenMintFlagTransferable)
+	tfNFTokenMintMaskWithMutable    uint32 = ^(tx.TfUniversal | NFTokenMintFlagBurnable | NFTokenMintFlagOnlyXRP | NFTokenMintFlagTransferable | NFTokenMintFlagMutable)
+	tfNFTokenMintOldMaskWithMutable uint32 = ^(tx.TfUniversal | NFTokenMintFlagBurnable | NFTokenMintFlagOnlyXRP | NFTokenMintFlagTrustLine | NFTokenMintFlagTransferable | NFTokenMintFlagMutable)
 )
 
 // NewNFTokenMint creates a new NFTokenMint transaction

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -44,6 +44,74 @@ func (e *Engine) preflight(tx Transaction) Result {
 		return parseValidationError(err)
 	}
 
+	// Inner-batch preflight: each inner tx of a Batch must independently pass
+	// preflight. Any failure surfaces as temINVALID_INNER_BATCH on the outer.
+	// Reference: rippled Batch.cpp:303-312
+	if outer, ok := tx.(BatchOuter); ok {
+		for _, inner := range outer.InnerTransactions() {
+			if inner == nil {
+				return TemINVALID_INNER_BATCH
+			}
+			if r := e.preflightInner(inner); r != TesSUCCESS {
+				return TemINVALID_INNER_BATCH
+			}
+		}
+	}
+
+	return TesSUCCESS
+}
+
+// BatchOuter is implemented by transaction types whose inner transactions
+// must each pass preflight as part of the outer preflight pipeline.
+// Reference: rippled Batch.cpp preflight() — calls ripple::preflight() on
+// each inner STTx with tapBATCH and rejects with temINVALID_INNER_BATCH on
+// any failure.
+type BatchOuter interface {
+	InnerTransactions() []Transaction
+}
+
+// preflightInner runs the subset of preflight applicable to a Batch inner
+// transaction. Inner txs have Fee=0, no signature, no multi-signers, and the
+// tfInnerBatchTxn flag set, so the fee/signature/multi-sign/inner-flag
+// rejections from the regular pipeline are skipped here. Amendment and
+// per-tx-type Validate() checks still run.
+// Reference: rippled preflight(stx, tapBATCH) invoked from Batch.cpp:303.
+func (e *Engine) preflightInner(innerTx Transaction) Result {
+	common := innerTx.GetCommon()
+
+	if common.Account == "" {
+		return TemBAD_SRC_ACCOUNT
+	}
+	if common.TransactionType == "" {
+		return TemINVALID
+	}
+
+	if result := e.validateNetworkID(common); result != TesSUCCESS {
+		return result
+	}
+
+	for _, featureID := range innerTx.RequiredAmendments() {
+		if !e.rules().Enabled(featureID) {
+			return TemDISABLED
+		}
+	}
+
+	if common.TicketSequence != nil && !e.rules().Enabled(amendment.FeatureTicketBatch) {
+		return TemMALFORMED
+	}
+
+	if common.Delegate != "" {
+		if !e.rules().Enabled(amendment.FeaturePermissionDelegation) {
+			return TemDISABLED
+		}
+		if common.Delegate == common.Account {
+			return TemBAD_SIGNER
+		}
+	}
+
+	if err := innerTx.Validate(); err != nil {
+		return parseValidationError(err)
+	}
 	return TesSUCCESS
 }
 

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -77,38 +77,9 @@ type BatchOuter interface {
 // per-tx-type Validate() checks still run.
 // Reference: rippled preflight(stx, tapBATCH) invoked from Batch.cpp:303.
 func (e *Engine) preflightInner(innerTx Transaction) Result {
-	common := innerTx.GetCommon()
-
-	if common.Account == "" {
-		return TemBAD_SRC_ACCOUNT
-	}
-	if common.TransactionType == "" {
-		return TemINVALID
-	}
-
-	if result := e.validateNetworkID(common); result != TesSUCCESS {
+	if result := e.preflightCommon(innerTx, innerTx.GetCommon()); result != TesSUCCESS {
 		return result
 	}
-
-	for _, featureID := range innerTx.RequiredAmendments() {
-		if !e.rules().Enabled(featureID) {
-			return TemDISABLED
-		}
-	}
-
-	if common.TicketSequence != nil && !e.rules().Enabled(amendment.FeatureTicketBatch) {
-		return TemMALFORMED
-	}
-
-	if common.Delegate != "" {
-		if !e.rules().Enabled(amendment.FeaturePermissionDelegation) {
-			return TemDISABLED
-		}
-		if common.Delegate == common.Account {
-			return TemBAD_SIGNER
-		}
-	}
-
 	if err := innerTx.Validate(); err != nil {
 		return parseValidationError(err)
 	}
@@ -116,46 +87,11 @@ func (e *Engine) preflightInner(innerTx Transaction) Result {
 }
 
 // preflightCommonFields handles the trivial common-field, amendment, and flag
-// checks that rippled performs in preflight0/early preflight1.
+// checks that rippled performs in preflight0/early preflight1, plus the
+// outer-only rejection of tfInnerBatchTxn on directly-submitted transactions.
 func (e *Engine) preflightCommonFields(tx Transaction, common *Common) Result {
-	// Account is required
-	if common.Account == "" {
-		return TemBAD_SRC_ACCOUNT
-	}
-
-	// TransactionType is required
-	if common.TransactionType == "" {
-		return TemINVALID
-	}
-
-	// NetworkID validation (matching rippled's preflight0)
-	if result := e.validateNetworkID(common); result != TesSUCCESS {
+	if result := e.preflightCommon(tx, common); result != TesSUCCESS {
 		return result
-	}
-
-	// Amendment check - verify all required amendments are enabled
-	// Reference: rippled checks this in each transaction's preflight() method
-	for _, featureID := range tx.RequiredAmendments() {
-		if !e.rules().Enabled(featureID) {
-			return TemDISABLED
-		}
-	}
-
-	// TicketSequence with disabled TicketBatch feature → temMALFORMED
-	// Reference: rippled Transactor.cpp preflight1() line 92
-	if common.TicketSequence != nil && !e.rules().Enabled(amendment.FeatureTicketBatch) {
-		return TemMALFORMED
-	}
-
-	// Delegate field validation
-	// Reference: rippled Transactor.cpp preflight1() lines 101-108
-	if common.Delegate != "" {
-		if !e.rules().Enabled(amendment.FeaturePermissionDelegation) {
-			return TemDISABLED
-		}
-		if common.Delegate == common.Account {
-			return TemBAD_SIGNER
-		}
 	}
 
 	// tfInnerBatchTxn flag validation
@@ -163,6 +99,43 @@ func (e *Engine) preflightCommonFields(tx Transaction, common *Common) Result {
 	// when processing inner batch transactions, never on directly submitted transactions.
 	if common.Flags != nil && *common.Flags&TfInnerBatchTxn != 0 {
 		return TemINVALID_FLAG
+	}
+
+	return TesSUCCESS
+}
+
+// preflightCommon performs the field/amendment/delegate checks that apply to
+// both outer and inner transactions. The tfInnerBatchTxn rejection lives only
+// in preflightCommonFields because inner txs must carry that flag.
+func (e *Engine) preflightCommon(tx Transaction, common *Common) Result {
+	if common.Account == "" {
+		return TemBAD_SRC_ACCOUNT
+	}
+	if common.TransactionType == "" {
+		return TemINVALID
+	}
+
+	if result := e.validateNetworkID(common); result != TesSUCCESS {
+		return result
+	}
+
+	for _, featureID := range tx.RequiredAmendments() {
+		if !e.rules().Enabled(featureID) {
+			return TemDISABLED
+		}
+	}
+
+	if common.TicketSequence != nil && !e.rules().Enabled(amendment.FeatureTicketBatch) {
+		return TemMALFORMED
+	}
+
+	if common.Delegate != "" {
+		if !e.rules().Enabled(amendment.FeaturePermissionDelegation) {
+			return TemDISABLED
+		}
+		if common.Delegate == common.Account {
+			return TemBAD_SIGNER
+		}
 	}
 
 	return TesSUCCESS

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -44,9 +44,7 @@ func (e *Engine) preflight(tx Transaction) Result {
 		return parseValidationError(err)
 	}
 
-	// Inner-batch preflight: each inner tx of a Batch must independently pass
-	// preflight. Any failure surfaces as temINVALID_INNER_BATCH on the outer.
-	// Reference: rippled Batch.cpp:303-312
+	// Reference: rippled Batch.cpp:303-312.
 	if outer, ok := tx.(BatchOuter); ok {
 		for _, inner := range outer.InnerTransactions() {
 			if inner == nil {
@@ -62,20 +60,17 @@ func (e *Engine) preflight(tx Transaction) Result {
 }
 
 // BatchOuter is implemented by transaction types whose inner transactions
-// must each pass preflight as part of the outer preflight pipeline.
-// Reference: rippled Batch.cpp preflight() — calls ripple::preflight() on
-// each inner STTx with tapBATCH and rejects with temINVALID_INNER_BATCH on
-// any failure.
+// each need to pass preflight as part of the outer's preflight pipeline.
+// Reference: rippled Batch.cpp preflight() — `ripple::preflight(..., tapBATCH)`
+// per inner STTx; any failure → temINVALID_INNER_BATCH on the outer.
 type BatchOuter interface {
 	InnerTransactions() []Transaction
 }
 
-// preflightInner runs the subset of preflight applicable to a Batch inner
-// transaction. Inner txs have Fee=0, no signature, no multi-signers, and the
-// tfInnerBatchTxn flag set, so the fee/signature/multi-sign/inner-flag
-// rejections from the regular pipeline are skipped here. Amendment and
-// per-tx-type Validate() checks still run.
 // Reference: rippled preflight(stx, tapBATCH) invoked from Batch.cpp:303.
+// Fee/signature/multi-sign/inner-flag rejections are skipped here because
+// inner txs have Fee=0, no signature, no multi-signers, and tfInnerBatchTxn
+// set; the corresponding presence checks live in Batch.Validate().
 func (e *Engine) preflightInner(innerTx Transaction) Result {
 	if result := e.preflightCommon(innerTx, innerTx.GetCommon()); result != TesSUCCESS {
 		return result
@@ -86,17 +81,15 @@ func (e *Engine) preflightInner(innerTx Transaction) Result {
 	return TesSUCCESS
 }
 
-// preflightCommonFields handles the trivial common-field, amendment, and flag
-// checks that rippled performs in preflight0/early preflight1, plus the
-// outer-only rejection of tfInnerBatchTxn on directly-submitted transactions.
+// Reference: rippled Transactor.cpp preflight0/early preflight1, plus the
+// outer-only tfInnerBatchTxn rejection on directly-submitted transactions.
 func (e *Engine) preflightCommonFields(tx Transaction, common *Common) Result {
 	if result := e.preflightCommon(tx, common); result != TesSUCCESS {
 		return result
 	}
 
-	// tfInnerBatchTxn flag validation
-	// Reference: rippled Transactor.cpp preflight0() - tfInnerBatchTxn can only be set
-	// when processing inner batch transactions, never on directly submitted transactions.
+	// tfInnerBatchTxn must never appear on a directly-submitted transaction.
+	// Reference: rippled Transactor.cpp preflight0().
 	if common.Flags != nil && *common.Flags&TfInnerBatchTxn != 0 {
 		return TemINVALID_FLAG
 	}
@@ -104,9 +97,9 @@ func (e *Engine) preflightCommonFields(tx Transaction, common *Common) Result {
 	return TesSUCCESS
 }
 
-// preflightCommon performs the field/amendment/delegate checks that apply to
-// both outer and inner transactions. The tfInnerBatchTxn rejection lives only
-// in preflightCommonFields because inner txs must carry that flag.
+// Shared between outer (preflightCommonFields) and inner (preflightInner).
+// The tfInnerBatchTxn rejection lives only in the outer path because inner
+// txs are required to carry that flag.
 func (e *Engine) preflightCommon(tx Transaction, common *Common) Result {
 	if common.Account == "" {
 		return TemBAD_SRC_ACCOUNT
@@ -125,10 +118,12 @@ func (e *Engine) preflightCommon(tx Transaction, common *Common) Result {
 		}
 	}
 
+	// Reference: rippled Transactor.cpp preflight1() line 92.
 	if common.TicketSequence != nil && !e.rules().Enabled(amendment.FeatureTicketBatch) {
 		return TemMALFORMED
 	}
 
+	// Reference: rippled Transactor.cpp preflight1() lines 101-108.
 	if common.Delegate != "" {
 		if !e.rules().Enabled(amendment.FeaturePermissionDelegation) {
 			return TemDISABLED

--- a/internal/tx/result.go
+++ b/internal/tx/result.go
@@ -227,6 +227,7 @@ const (
 	TemARRAY_EMPTY                                 Result = -253
 	TemARRAY_TOO_LARGE                             Result = -252
 	TemBAD_TRANSFER_FEE                            Result = -251
+	TemINVALID_INNER_BATCH                         Result = -250
 
 	// terRETRY and related codes (-99 to -1)
 	// Retry later
@@ -425,6 +426,7 @@ var resultNames = map[Result]string{
 	TemARRAY_EMPTY:                                 "temARRAY_EMPTY",
 	TemARRAY_TOO_LARGE:                             "temARRAY_TOO_LARGE",
 	TemBAD_TRANSFER_FEE:                            "temBAD_TRANSFER_FEE",
+	TemINVALID_INNER_BATCH:                         "temINVALID_INNER_BATCH",
 	TerRETRY:                                       "terRETRY",
 	TerFUNDS_SPENT:                                 "terFUNDS_SPENT",
 	TerINSUF_FEE_B:                                 "terINSUF_FEE_B",

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -41,7 +41,9 @@ const (
 	// tfClearDeepFreeze clears the deep freeze flag
 	TrustSetFlagClearDeepFreeze uint32 = 0x00800000
 
-	// tfTrustSetMask is the mask for valid TrustSet transaction flags
+	// tfTrustSetMask is the mask for valid TrustSet transaction flags.
+	// Reference: rippled TxFlags.h tfTrustSetMask — carves out tfUniversal
+	// (tfFullyCanonicalSig | tfInnerBatchTxn) so inner Batch txs aren't rejected.
 	TrustSetFlagMask uint32 = ^(TrustSetFlagSetfAuth |
 		TrustSetFlagSetNoRipple |
 		TrustSetFlagClearNoRipple |
@@ -49,7 +51,7 @@ const (
 		TrustSetFlagClearFreeze |
 		TrustSetFlagSetDeepFreeze |
 		TrustSetFlagClearDeepFreeze |
-		tx.TfFullyCanonicalSig)
+		tx.TfUniversal)
 )
 
 // NewTrustSet creates a new TrustSet transaction


### PR DESCRIPTION
## Summary

- Add the `temINVALID_INNER_BATCH` result code (rippled value `-250`, string `"temINVALID_INNER_BATCH"`) to `internal/tx/result.go`.
- Wire inner-tx preflight into the engine pipeline via a new `BatchOuter` interface, mirroring `rippled/src/xrpld/app/tx/detail/Batch.cpp:303-312`. Any inner-tx preflight failure now surfaces on the outer Batch as `temINVALID_INNER_BATCH`.
- Fix `AccountSet`'s flag mask to allow the `tfUniversal` bits (including `tfInnerBatchTxn`). Inner txns carry `tfInnerBatchTxn`, and `AccountSet.Validate()` previously rejected it because the mask only excluded `tfFullyCanonicalSig`. Exposed by this change because inner txns now go through `Validate()`.

## Test plan

- [x] `go test ./internal/testing/batch/...` — new `TestPreflight/temINVALID_INNER_BATCH_-_malformed_inner_tx` mirrors `Batch_test.cpp:398-406` (Batch with `pay(alice, bob, XRP(-1))` → `temINVALID_INNER_BATCH`).
- [x] `go test ./internal/tx/... ./internal/testing/...` — no new regressions; the two pre-existing MPT failures also fail on `main`.
- [x] `go vet ./...` — only the pre-existing `mock_binary_parser.go` warning, unchanged.

Fixes #452