### PR TITLE
test(book_offers): pin handler domain forwarding for PermissionedDEX lookup

### DIFF
--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -550,13 +550,10 @@ func TestBookOffersXRPAmountHandling(t *testing.T) {
 	}
 }
 
-// TestBookOffersDomainForwarding pins the handler→service `domain` threading for
-// the PermissionedDEX-aware book lookup. Before issue #526, a non-zero domain
-// short-circuited to `notSupported`; rippled BookOffers.cpp:175-214 instead
-// decodes the hex uint256 and forwards it via the Book struct so getBookBase
-// picks the domain-scoped order book. The three cases mirror the acceptance
-// criteria: open-market (no domain), the literal "0" (normalized to 64 zero
-// hex per base_uint.h:228), and a non-zero 64-char domain forwarded verbatim.
+// TestBookOffersDomainForwarding pins handler→service `domain` threading for
+// PermissionedDEX-aware book lookups (issue #526). rippled
+// BookOffers.cpp:175-214 decodes the hex uint256 and forwards it via the Book
+// struct; the literal "0" normalises to 64-zero hex per base_uint.h:228.
 func TestBookOffersDomainForwarding(t *testing.T) {
 	mock := newBookOffersMock()
 	services := newBookOffersTestServices(mock)

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -550,6 +550,87 @@ func TestBookOffersXRPAmountHandling(t *testing.T) {
 	}
 }
 
+// TestBookOffersDomainForwarding pins the handler→service `domain` threading for
+// the PermissionedDEX-aware book lookup. Before issue #526, a non-zero domain
+// short-circuited to `notSupported`; rippled BookOffers.cpp:175-214 instead
+// decodes the hex uint256 and forwards it via the Book struct so getBookBase
+// picks the domain-scoped order book. The three cases mirror the acceptance
+// criteria: open-market (no domain), the literal "0" (normalized to 64 zero
+// hex per base_uint.h:228), and a non-zero 64-char domain forwarded verbatim.
+func TestBookOffersDomainForwarding(t *testing.T) {
+	mock := newBookOffersMock()
+	services := newBookOffersTestServices(mock)
+
+	method := &handlers.BookOffersMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	var capturedDomain string
+	mock.getBookOffersFn = func(_, _ types.Amount, _, domain, _ string, _ uint32) (*types.BookOffersResult, error) {
+		capturedDomain = domain
+		return &types.BookOffersResult{
+			LedgerIndex: 2,
+			Offers:      []types.BookOffer{},
+			Validated:   true,
+		}, nil
+	}
+
+	baseParams := func() map[string]interface{} {
+		return map[string]interface{}{
+			"taker_pays": map[string]interface{}{"currency": "XRP"},
+			"taker_gets": map[string]interface{}{
+				"currency": "USD",
+				"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			},
+		}
+	}
+
+	const zeroHex = "0000000000000000000000000000000000000000000000000000000000000000"
+	const domainHex = "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+
+	tests := []struct {
+		name           string
+		setParam       func(map[string]interface{})
+		expectedDomain string
+	}{
+		{
+			name:           "Absent domain - open-market book",
+			setParam:       func(p map[string]interface{}) {},
+			expectedDomain: "",
+		},
+		{
+			name:           "Literal \"0\" normalizes to 64-zero hex",
+			setParam:       func(p map[string]interface{}) { p["domain"] = "0" },
+			expectedDomain: zeroHex,
+		},
+		{
+			name:           "Valid non-zero 64-hex forwarded verbatim",
+			setParam:       func(p map[string]interface{}) { p["domain"] = domainHex },
+			expectedDomain: domainHex,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			capturedDomain = "<unset>"
+			params := baseParams()
+			tc.setParam(params)
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			require.Nil(t, rpcErr, "Expected no RPC error, got: %v", rpcErr)
+			require.NotNil(t, result, "Expected result")
+			assert.Equal(t, tc.expectedDomain, capturedDomain,
+				"domain forwarded to GetBookOffers should match the decoded uint256 hex")
+		})
+	}
+}
+
 // TestBookOffersValidRequestWithOffers tests a valid request with offers returned
 // Based on rippled Book_test.cpp testTrackOffers() book_offers call
 func TestBookOffersValidRequestWithOffers(t *testing.T) {


### PR DESCRIPTION
## Summary
- Issue #526 called out the M4 `notSupported` short-circuit in `internal/rpc/handlers/book_offers.go` and asked for the `domain` parameter to be threaded through to a PermissionedDEX-aware book lookup.
- The threading itself already landed across earlier PRs (handler → `Service.GetBookOffers` → `keylet.BookDirWithDomain`, mirroring rippled `Indexes.cpp:114-138` `getBookBase` with the domain in the hash). Service-layer domain isolation is covered in `internal/ledger/service/offer_query_test.go::TestGetBookOffers_PermissionedOfferHiddenFromOpenBook`.
- This PR closes the remaining acceptance gap: a handler-layer happy-path test (`TestBookOffersDomainForwarding`) that captures the `domain` argument forwarded to the service and pins all three rippled-defined cases — absent domain → open-market, literal `"0"` → 64 zero-hex, valid 64-char hex → forwarded verbatim.

## Test plan
- [x] `go test -run TestBookOffersDomainForwarding -v ./internal/rpc/...`
- [x] `go test ./internal/rpc/... ./internal/ledger/service/... ./keylet/...`

Fixes #526