### PR TITLE
fix: gate book_offers currency by rippled isoCharSet

### DIFF
--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -214,8 +214,7 @@ func TestBookOffersErrorValidation(t *testing.T) {
 		},
 		{
 			// 3-char code with a character outside rippled's isoCharSet
-			// (UintTypes.cpp:39-43) must be rejected — the previous
-			// len==3 shortcut admitted "a/b" by mistake.
+			// (UintTypes.cpp:39-43) must be rejected.
 			name: "taker_pays.currency 3-char with non-isoCharSet rune",
 			params: map[string]interface{}{
 				"taker_pays": map[string]interface{}{"currency": "a/b"},

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -213,6 +213,27 @@ func TestBookOffersErrorValidation(t *testing.T) {
 			expectedCode:  types.RpcDST_AMT_MALFORMED,
 		},
 		{
+			// 3-char code with a character outside rippled's isoCharSet
+			// (UintTypes.cpp:39-43) must be rejected — the previous
+			// len==3 shortcut admitted "a/b" by mistake.
+			name: "taker_pays.currency 3-char with non-isoCharSet rune",
+			params: map[string]interface{}{
+				"taker_pays": map[string]interface{}{"currency": "a/b"},
+				"taker_gets": map[string]interface{}{"currency": "XRP"},
+			},
+			expectedError: "Invalid field 'taker_pays.currency', bad currency.",
+			expectedCode:  types.RpcSRC_CUR_MALFORMED,
+		},
+		{
+			name: "taker_gets.currency 3-char with non-isoCharSet rune",
+			params: map[string]interface{}{
+				"taker_pays": map[string]interface{}{"currency": "XRP"},
+				"taker_gets": map[string]interface{}{"currency": "a/b"},
+			},
+			expectedError: "Invalid field 'taker_gets.currency', bad currency.",
+			expectedCode:  types.RpcDST_AMT_MALFORMED,
+		},
+		{
 			// Book_test.cpp:1463-1475 — gets.issuer non-string.
 			name: "taker_gets.issuer not string",
 			params: map[string]interface{}{

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -203,14 +203,20 @@ func ParseAmountFromJSON(data json.RawMessage) (types.Amount, error) {
 }
 
 // isValidCurrencyCode reports whether a currency code is acceptable per
-// rippled rules: empty or "XRP" (native), exactly 3 characters (ISO), or
-// exactly 40 hex characters (issued-currency hex form).
+// rippled rules: empty or "XRP" (native), exactly 3 characters from
+// rippled's isoCharSet (UintTypes.cpp:39-43, :93-96), or exactly 40 hex
+// characters (issued-currency hex form).
 // Reference: rippled UintTypes.cpp to_currency().
 func isValidCurrencyCode(currency string) bool {
 	if currency == "" || currency == "XRP" {
 		return true
 	}
 	if len(currency) == 3 {
+		for _, c := range currency {
+			if !isIsoCurrencyChar(c) {
+				return false
+			}
+		}
 		return true
 	}
 	if len(currency) == 40 {

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -206,7 +206,6 @@ func ParseAmountFromJSON(data json.RawMessage) (types.Amount, error) {
 // rippled rules: empty or "XRP" (native), exactly 3 characters from
 // rippled's isoCharSet (UintTypes.cpp:39-43, :93-96), or exactly 40 hex
 // characters (issued-currency hex form).
-// Reference: rippled UintTypes.cpp to_currency().
 func isValidCurrencyCode(currency string) bool {
 	if currency == "" || currency == "XRP" {
 		return true


### PR DESCRIPTION
## Summary
- `isValidCurrencyCode` in `internal/rpc/handlers/book_offers.go` previously accepted any 3-byte string, admitting `"a/b"`, `"AB\x00"`, etc. — values rippled rejects in `UintTypes.cpp::to_currency`.
- Apply the `isoCharSet` predicate (reusing the existing `isIsoCurrencyChar` helper from the same `handlers` package) inside the 3-char branch.
- Out-of-set 3-char codes now return `rpcSRC_CUR_MALFORMED` on `taker_pays` and `rpcDST_AMT_MALFORMED` on `taker_gets`, matching rippled (`BookOffers.cpp:51-199`).

## Test plan
- [x] `go test ./internal/rpc/... ./internal/rpc/handlers/... -count=1` — passes
- [x] New rows in `TestBookOffersErrorValidation` cover `"a/b"` on both `taker_pays` and `taker_gets`
- [x] Existing `"USD"`, `"EUR"`, `"XRP"` cases still pass

Fixes #530