### PR TITLE
fix(rpc): align RpcNOT_ENABLED/RpcNOT_SUPPORTED with rippled codes

### DIFF
--- a/internal/rpc/handlers/path_find.go
+++ b/internal/rpc/handlers/path_find.go
@@ -6,7 +6,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// PathFindMethod handles the path_find RPC method (WebSocket only).
+// PathFindMethod handles the path_find RPC method.
 // STUB over plain JSON-RPC: returns noEvents, mirroring rippled
 // PathFind.cpp which returns rpcError(rpcNO_EVENTS) when context.infoSub is
 // null (the unconditional state for non-subscription transports).

--- a/internal/rpc/handlers/path_find.go
+++ b/internal/rpc/handlers/path_find.go
@@ -7,7 +7,9 @@ import (
 )
 
 // PathFindMethod handles the path_find RPC method (WebSocket only).
-// STUB: Returns notSupported over HTTP. WebSocket-only persistent subscription.
+// STUB over plain JSON-RPC: returns noEvents, mirroring rippled
+// PathFind.cpp which returns rpcError(rpcNO_EVENTS) when context.infoSub is
+// null (the unconditional state for non-subscription transports).
 //
 // TODO [pathfinding][websocket]: Implement when both pathfinding and WebSocket
 //
@@ -17,11 +19,10 @@ import (
 //	  that sends updated paths whenever the ledger changes
 //	- Subcommands: "create" (start tracking), "close" (stop), "status" (current paths)
 //	- Requires: Pathfinder engine + WebSocket session context
-//	- The HTTP handler should always return notSupported
 type PathFindMethod struct{}
 
 func (m *PathFindMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return nil, types.RpcErrorNotSupported("path_find is only available via WebSocket")
+	return nil, types.RpcErrorNoEvents("")
 }
 
 func (m *PathFindMethod) RequiredRole() types.Role {

--- a/internal/rpc/handlers/path_find.go
+++ b/internal/rpc/handlers/path_find.go
@@ -21,8 +21,7 @@ import (
 type PathFindMethod struct{}
 
 func (m *PathFindMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return nil, types.NewRpcError(types.RpcNOT_SUPPORTED, "notSupported", "notSupported",
-		"path_find is only available via WebSocket")
+	return nil, types.RpcErrorNotSupported("path_find is only available via WebSocket")
 }
 
 func (m *PathFindMethod) RequiredRole() types.Role {

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -53,8 +53,7 @@ func (m *PrintMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (int
 type CanDeleteMethod struct{ AdminHandler }
 
 func (m *CanDeleteMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return nil, types.NewRpcError(types.RpcNOT_ENABLED, "notEnabled", "notEnabled",
-		"Advisory delete is not enabled — requires SHAMapStore configuration")
+	return nil, types.RpcErrorNotEnabled("Advisory delete is not enabled — requires SHAMapStore configuration")
 }
 
 // GetCountsMethod handles the get_counts RPC method.

--- a/internal/rpc/handlers/subscribe.go
+++ b/internal/rpc/handlers/subscribe.go
@@ -6,14 +6,17 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// SubscribeMethod handles the subscribe RPC command (WebSocket only).
-// STUB over HTTP: Returns notSupported. The real implementation is in websocket.go.
+// SubscribeMethod handles the subscribe RPC command.
+// STUB over plain JSON-RPC: mirrors rippled Subscribe.cpp's
+// "Must be a JSON-RPC call." branch — when there is no infoSub and no `url`
+// parameter, rippled returns rpcError(rpcINVALID_PARAMS). The real
+// WebSocket-bound implementation lives in rpc/websocket.go.
 //
-// TODO [websocket]: This HTTP stub is correct — subscribe requires a persistent
+// TODO [websocket]: rippled also supports HTTP+url admin subscriptions
 //
-//	WebSocket connection. The WebSocket server (rpc/websocket.go) already has
-//	a working subscription system. This HTTP handler exists only so the method
-//	is registered and returns a meaningful error over HTTP.
+//	(Subscribe.cpp branch on context.params.isMember(jss::url) with
+//	Role::ADMIN). Once goxrpl wires up the RPCSub callback path that
+//	branch should be served here too.
 //	- Reference: rippled Subscribe.cpp
 //	- Streams: ledger, transactions, transactions_proposed, peer_status,
 //	  consensus, server, validations, manifests, book (order book)
@@ -21,5 +24,5 @@ import (
 type SubscribeMethod struct{ BaseHandler }
 
 func (m *SubscribeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return nil, types.RpcErrorNotSupported("subscribe is only available via WebSocket")
+	return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 }

--- a/internal/rpc/handlers/subscribe.go
+++ b/internal/rpc/handlers/subscribe.go
@@ -21,6 +21,5 @@ import (
 type SubscribeMethod struct{ BaseHandler }
 
 func (m *SubscribeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return nil, types.NewRpcError(types.RpcNOT_SUPPORTED, "notSupported", "notSupported",
-		"subscribe is only available via WebSocket")
+	return nil, types.RpcErrorNotSupported("subscribe is only available via WebSocket")
 }

--- a/internal/rpc/handlers/unsubscribe.go
+++ b/internal/rpc/handlers/unsubscribe.go
@@ -17,6 +17,5 @@ import (
 type UnsubscribeMethod struct{ BaseHandler }
 
 func (m *UnsubscribeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return nil, types.NewRpcError(types.RpcNOT_SUPPORTED, "notSupported", "notSupported",
-		"unsubscribe is only available via WebSocket")
+	return nil, types.RpcErrorNotSupported("unsubscribe is only available via WebSocket")
 }

--- a/internal/rpc/handlers/unsubscribe.go
+++ b/internal/rpc/handlers/unsubscribe.go
@@ -6,16 +6,21 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// UnsubscribeMethod handles the unsubscribe RPC command (WebSocket only).
-// STUB over HTTP: Returns notSupported. The real implementation is in websocket.go.
+// UnsubscribeMethod handles the unsubscribe RPC command.
+// STUB over plain JSON-RPC: mirrors rippled Unsubscribe.cpp's
+// "Must be a JSON-RPC call." branch — when there is no infoSub and no `url`
+// parameter, rippled returns rpcError(rpcINVALID_PARAMS). The real
+// WebSocket-bound implementation lives in rpc/websocket.go.
 //
-// TODO [websocket]: Same as subscribe — this HTTP stub is correct.
+// TODO [websocket]: rippled also supports HTTP+url admin unsubscribes
 //
-//	The WebSocket server handles actual unsubscriptions.
+//	(Unsubscribe.cpp branch on context.params.isMember(jss::url) with
+//	Role::ADMIN). Once goxrpl wires up the RPCSub callback path that
+//	branch should be served here too.
 //	- Reference: rippled Unsubscribe.cpp
 //	- Removes subscriptions created by subscribe command
 type UnsubscribeMethod struct{ BaseHandler }
 
 func (m *UnsubscribeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return nil, types.RpcErrorNotSupported("unsubscribe is only available via WebSocket")
+	return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 }

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -1148,7 +1148,9 @@ func TestGetSubscribeResponse(t *testing.T) {
 
 // Subscribe/Unsubscribe Method Tests (RPC Handler level)
 
-// TestSubscribeMethodRequiresWebSocket tests that subscribe returns error via HTTP
+// TestSubscribeMethodRequiresWebSocket tests that subscribe returns rippled's
+// rpcINVALID_PARAMS over plain JSON-RPC (Subscribe.cpp: "Must be a JSON-RPC
+// call." branch when context.infoSub is null and no `url` param is provided).
 func TestSubscribeMethodRequiresWebSocket(t *testing.T) {
 	method := &handlers.SubscribeMethod{}
 	ctx := &types.RpcContext{
@@ -1159,11 +1161,13 @@ func TestSubscribeMethodRequiresWebSocket(t *testing.T) {
 	result, err := method.Handle(ctx, nil)
 	assert.Nil(t, result)
 	require.NotNil(t, err)
-	assert.Equal(t, types.RpcNOT_SUPPORTED, err.Code)
-	assert.Contains(t, err.Message, "WebSocket")
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Equal(t, "invalidParams", err.ErrorString)
 }
 
-// TestUnsubscribeMethodRequiresWebSocket tests that unsubscribe returns error via HTTP
+// TestUnsubscribeMethodRequiresWebSocket tests that unsubscribe returns
+// rippled's rpcINVALID_PARAMS over plain JSON-RPC (Unsubscribe.cpp: same
+// "Must be a JSON-RPC call." gate as Subscribe.cpp).
 func TestUnsubscribeMethodRequiresWebSocket(t *testing.T) {
 	method := &handlers.UnsubscribeMethod{}
 	ctx := &types.RpcContext{
@@ -1174,8 +1178,8 @@ func TestUnsubscribeMethodRequiresWebSocket(t *testing.T) {
 	result, err := method.Handle(ctx, nil)
 	assert.Nil(t, result)
 	require.NotNil(t, err)
-	assert.Equal(t, types.RpcNOT_SUPPORTED, err.Code)
-	assert.Contains(t, err.Message, "WebSocket")
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Equal(t, "invalidParams", err.ErrorString)
 }
 
 // TestSubscribeMethodMetadata tests method metadata

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -49,7 +49,9 @@ const (
 	// Networking
 	RpcNOT_STANDALONE = 10
 	RpcSHUT_DOWN      = 11
-	RpcREPORTING      = 12
+
+	// Transport capability — rippled rpcNO_EVENTS = 7 (ErrorCodes.h, ErrorCodes.cpp errorInfo entry).
+	RpcNO_EVENTS = 7
 
 	// Ledger errors
 	RpcLGR_NOT_FOUND     = 15
@@ -221,19 +223,42 @@ func RpcErrorInvalidApiVersion(version string) *RpcError {
 	return NewRpcError(RpcINVALID_API_VERSION, "invalidApiVersion", "invalidApiVersion", "Invalid API version: "+version)
 }
 
-func RpcErrorNotEnabled(feature string) *RpcError {
-	return NewRpcError(RpcNOT_ENABLED, "notEnabled", "notEnabled", "Feature not enabled: "+feature)
+// RpcErrorNotEnabled returns rippled's rpcNOT_ENABLED (code 12, token
+// "notEnabled"). An empty message defaults to rippled's canonical
+// "Not enabled in configuration." string from ErrorCodes.cpp's errorInfo
+// array. Reference: rippled ErrorCodes.h (rpcNOT_ENABLED) +
+// ErrorCodes.cpp (errorInfo[rpcNOT_ENABLED]).
+func RpcErrorNotEnabled(message string) *RpcError {
+	if message == "" {
+		message = "Not enabled in configuration."
+	}
+	return NewRpcError(RpcNOT_ENABLED, "notEnabled", "notEnabled", message)
 }
 
 // RpcErrorNotSupported returns rippled's rpcNOT_SUPPORTED (code 75, token
-// "notSupported"). An empty message defaults to rippled's
-// ErrorCodes.cpp:93 string "Operation not supported.".
-// Reference: rippled ErrorCodes.h:132 + ErrorCodes.cpp:93.
+// "notSupported"). An empty message defaults to rippled's canonical
+// "Operation not supported." string from ErrorCodes.cpp's errorInfo array.
+// Reference: rippled ErrorCodes.h (rpcNOT_SUPPORTED) +
+// ErrorCodes.cpp (errorInfo[rpcNOT_SUPPORTED]).
 func RpcErrorNotSupported(message string) *RpcError {
 	if message == "" {
 		message = "Operation not supported."
 	}
 	return NewRpcError(RpcNOT_SUPPORTED, "notSupported", "notSupported", message)
+}
+
+// RpcErrorNoEvents returns rippled's rpcNO_EVENTS (code 7, token "noEvents"),
+// returned by handlers whose work requires a subscription-capable transport
+// (path_find, etc.) when invoked over plain JSON-RPC. An empty message
+// defaults to rippled's canonical "Current transport does not support events."
+// string. Reference: rippled ErrorCodes.h (rpcNO_EVENTS) +
+// ErrorCodes.cpp (errorInfo[rpcNO_EVENTS]) +
+// rippled handler PathFind.cpp (rpcError(rpcNO_EVENTS) on !context.infoSub).
+func RpcErrorNoEvents(message string) *RpcError {
+	if message == "" {
+		message = "Current transport does not support events."
+	}
+	return NewRpcError(RpcNO_EVENTS, "noEvents", "noEvents", message)
 }
 
 func RpcErrorAmendmentBlocked() *RpcError {

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -78,9 +78,10 @@ const (
 	RpcPATH_MALFORMED   = 27
 	RpcPATH_DRY         = 28
 
-	// Amendment errors
-	RpcNOT_ENABLED   = 31
-	RpcNOT_SUPPORTED = 32
+	// Feature / amendment errors — must match rippled exactly
+	// (rippled ErrorCodes.h: rpcNOT_ENABLED = 12, rpcNOT_SUPPORTED = 75).
+	RpcNOT_ENABLED   = 12
+	RpcNOT_SUPPORTED = 75
 
 	// WebSocket specific
 	RpcCOMMAND_MISSING = 34
@@ -222,6 +223,17 @@ func RpcErrorInvalidApiVersion(version string) *RpcError {
 
 func RpcErrorNotEnabled(feature string) *RpcError {
 	return NewRpcError(RpcNOT_ENABLED, "notEnabled", "notEnabled", "Feature not enabled: "+feature)
+}
+
+// RpcErrorNotSupported returns rippled's rpcNOT_SUPPORTED (code 75, token
+// "notSupported"). An empty message defaults to rippled's
+// ErrorCodes.cpp:93 string "Operation not supported.".
+// Reference: rippled ErrorCodes.h:132 + ErrorCodes.cpp:93.
+func RpcErrorNotSupported(message string) *RpcError {
+	if message == "" {
+		message = "Operation not supported."
+	}
+	return NewRpcError(RpcNOT_SUPPORTED, "notSupported", "notSupported", message)
 }
 
 func RpcErrorAmendmentBlocked() *RpcError {

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -438,14 +438,3 @@ func RpcErrorDomainMalformed(message string) *RpcError {
 func RpcErrorDstActNotFound(message string) *RpcError {
 	return NewRpcError(RpcDST_ACT_NOT_FOUND, "dstActNotFound", "dstActNotFound", message)
 }
-
-// RpcErrorNotSupported returns rippled's rpcNOT_SUPPORTED (code 75, token
-// "notSupported"). The legacy RpcNOT_SUPPORTED constant in this file is 32
-// (incorrectly mapped to an amendment-error slot, tracked in issue #532);
-// we emit the rippled code directly so handlers like book_offers can report
-// "feature accepted by the request shape but not honoured by this server"
-// with byte-compatible output.
-// Reference: rippled ErrorCodes.h:132 + ErrorCodes.cpp:93.
-func RpcErrorNotSupported(message string) *RpcError {
-	return NewRpcError(75, "notSupported", "notSupported", message)
-}


### PR DESCRIPTION
## Summary
- `RpcNOT_ENABLED` was `31` and `RpcNOT_SUPPORTED` was `32` — those slots are rippled's `rpcINVALID_PARAMS` / `rpcUNKNOWN_COMMAND`. Responses with `error_code: 32` would not be recognised by xrpl.js, xrpl-py, or any rippled-compatible client.
- Set them to rippled's actual values: `rpcNOT_ENABLED = 12`, `rpcNOT_SUPPORTED = 75` (`rippled/include/xrpl/protocol/ErrorCodes.h:59,132`).
- Add `RpcErrorNotSupported(message string)` constructor that routes through the fixed constant and defaults to rippled's `"Operation not supported."` message (`rippled/src/libxrpl/protocol/ErrorCodes.cpp:93`).
- Switch the three HTTP-stub callsites (`subscribe`, `unsubscribe`, `path_find`) to the constructor so the legacy direct `NewRpcError(RpcNOT_SUPPORTED, ...)` form is no longer in use.

Note: the issue body suggested `rpcNOT_ENABLED = 73`, but `73` is actually rippled's `rpcINTERNAL`. The correct value is `12`.

## Test plan
- [x] `go test ./internal/rpc/...` — passes (subscribe/unsubscribe HTTP-stub and CanDelete tests assert via the named constants, so they automatically pick up the new numeric codes).
- [x] `go build ./...`
- [x] `go vet ./internal/rpc/...` — clean.

Fixes #532