### PR TITLE
fix(ledger/service): dedup hash formatter, pin hex shape of book_offers JSON

### DIFF
--- a/internal/ledger/service/helpers.go
+++ b/internal/ledger/service/helpers.go
@@ -8,7 +8,9 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/tx"
 )
 
-// formatHashHex formats a hash as hex string
+// formatHashHex renders a 32-byte hash as a 64-char uppercase hex string,
+// matching rippled's uint256 JSON emit (uint256::to_string). Use this for any
+// [32]byte value that crosses a JSON boundary (RPC response, marker, key).
 func formatHashHex(hash [32]byte) string {
 	const hexChars = "0123456789ABCDEF"
 	result := make([]byte, 64)

--- a/internal/ledger/service/offer_query.go
+++ b/internal/ledger/service/offer_query.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
@@ -196,20 +195,20 @@ func (s *Service) buildBookOffer(
 ) (BookOffer, error) {
 	bookOffer := BookOffer{
 		Account:           offer.Account,
-		BookDirectory:     hexUpper32(offer.BookDirectory),
+		BookDirectory:     formatHashHex(offer.BookDirectory),
 		BookNode:          fmt.Sprintf("%x", offer.BookNode),
 		Expiration:        offer.Expiration,
 		Flags:             offer.Flags,
 		LedgerEntryType:   "Offer",
 		OwnerNode:         fmt.Sprintf("%x", offer.OwnerNode),
-		PreviousTxnID:     hexUpper32(offer.PreviousTxnID),
+		PreviousTxnID:     formatHashHex(offer.PreviousTxnID),
 		PreviousTxnLgrSeq: offer.PreviousTxnLgrSeq,
 		Sequence:          offer.Sequence,
-		Index:             hexUpper32(key),
+		Index:             formatHashHex(key),
 		Quality:           qualityFromDirKey(dirQuality),
 	}
 	if offer.DomainID != ([32]byte{}) {
-		bookOffer.DomainID = hexUpper32(offer.DomainID)
+		bookOffer.DomainID = formatHashHex(offer.DomainID)
 	}
 	// Hybrid permissioned offers carry an AdditionalBooks array pointing at
 	// the open book entry the offer is also placed in. Rippled emits this
@@ -220,7 +219,7 @@ func (s *Service) buildBookOffer(
 		bookOffer.AdditionalBooks = []map[string]interface{}{
 			{
 				"Book": map[string]interface{}{
-					"BookDirectory": hexUpper32(offer.AdditionalBookDirectory),
+					"BookDirectory": formatHashHex(offer.AdditionalBookDirectory),
 					"BookNode":      fmt.Sprintf("%x", offer.AdditionalBookNode),
 				},
 			},
@@ -385,11 +384,6 @@ func zeroLike(model tx.Amount) tx.Amount {
 		return tx.NewXRPAmount(0)
 	}
 	return tx.NewIssuedAmount(0, 0, model.Currency, model.Issuer)
-}
-
-// hexUpper32 matches rippled's uint256 JSON emit (uint256::to_string).
-func hexUpper32(b [32]byte) string {
-	return strings.ToUpper(hex.EncodeToString(b[:]))
 }
 
 // qualityFromDirKey formats an offer's directory key as the STAmount text

--- a/internal/ledger/service/offer_query_test.go
+++ b/internal/ledger/service/offer_query_test.go
@@ -629,3 +629,54 @@ func TestGetBookOffers_TransferRateAdjustsFunded(t *testing.T) {
 			o.TakerGetsFunded, o.TakerPaysFunded)
 	}
 }
+
+// TestGetBookOffers_HashFieldsAreUppercaseHex pins the wire shape of every
+// [32]byte field emitted by book_offers: rippled's uint256::to_string returns
+// a 64-char uppercase hex string, and clients parse it that way. This guards
+// the formatHashHex consolidation done for issue #531 — a regression that
+// leaks raw bytes through any of these fields would corrupt every JSON
+// response that flows through GetBookOffers.
+func TestGetBookOffers_HashFieldsAreUppercaseHex(t *testing.T) {
+	svc := newOfferTestService(t)
+
+	issuerAddr, _ := addressFromBytes(t, 0x10)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+
+	sellerAddr, _ := addressFromBytes(t, 0x20)
+	insertAccountRoot(t, svc, sellerAddr, 1_000_000_000_000, 0)
+
+	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
+	xrpModel := tx.NewXRPAmount(0)
+
+	insertOffer(t, svc, sellerAddr, 1,
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+		tx.NewXRPAmount(10_000_000),
+	)
+
+	result, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 10)
+	if err != nil {
+		t.Fatalf("GetBookOffers: %v", err)
+	}
+	if len(result.Offers) != 1 {
+		t.Fatalf("expected 1 offer, got %d", len(result.Offers))
+	}
+
+	assertHash := func(name, v string) {
+		t.Helper()
+		if len(v) != 64 {
+			t.Errorf("%s: want 64 hex chars, got %d (%q)", name, len(v), v)
+			return
+		}
+		if _, err := hex.DecodeString(v); err != nil {
+			t.Errorf("%s: not valid hex: %v (%q)", name, err, v)
+		}
+		if v != strings.ToUpper(v) {
+			t.Errorf("%s: want uppercase hex, got %q", name, v)
+		}
+	}
+
+	o := result.Offers[0]
+	assertHash("index", o.Index)
+	assertHash("BookDirectory", o.BookDirectory)
+	assertHash("PreviousTxnID", o.PreviousTxnID)
+}


### PR DESCRIPTION
## Summary
- `internal/ledger/service` carried two duplicate `[32]byte`→hex helpers (`formatHashHex` in `helpers.go` and `hexUpper32` in `offer_query.go`). Issue #531's literal bug (a `formatHash` variant that returned raw bytes) was already cleaned up upstream, but the duplication and lack of regression coverage remained — leaving room for any future helper to silently leak raw bytes through JSON.
- Consolidated on `formatHashHex`: route every `offer_query.go` caller through it, delete `hexUpper32`, drop the now-unused `strings` import, and document on `formatHashHex` that it matches rippled's `uint256::to_string` and must be used for any `[32]byte` crossing a JSON boundary.
- Added `TestGetBookOffers_HashFieldsAreUppercaseHex` that drives the real `service.GetBookOffers` and asserts `index`, `BookDirectory`, `PreviousTxnID` are valid 64-char uppercase hex — exactly the regression test the issue asked for.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/ledger/service/...`
- [x] `go test ./internal/ledger/service/...`

Fixes #531