### PR TITLE
feat(book_offers): marker-based pagination

### DIFF
--- a/internal/ledger/service/offer_query.go
+++ b/internal/ledger/service/offer_query.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/keylet"
@@ -45,6 +46,14 @@ type BookOffersResult struct {
 	LedgerHash  [32]byte    `json:"ledger_hash"`
 	Offers      []BookOffer `json:"offers"`
 	Validated   bool        `json:"validated"`
+	// Marker is the resume token returned when the book has more offers than
+	// the request's limit. It is the 64-char hex `index` of the last offer
+	// emitted in this page; passing it back in a follow-up request continues
+	// the walk after that offer. goXRPL extension — rippled accepts a marker
+	// parameter (BookOffers.cpp:201-214) but its NetworkOPsImp::getBookPage
+	// implementation never reads or emits one (NetworkOPs.cpp:4627 comments
+	// out the response field).
+	Marker string `json:"marker,omitempty"`
 }
 
 var errStopBookWalk = errors.New("stop book walk")
@@ -64,7 +73,7 @@ var errStopBookWalk = errors.New("stop book walk")
 // fee adjustment. The domainHex argument is the optional permissioned-domain
 // uint256 hex string; passing it walks the domain-scoped book base instead of
 // the open book.
-func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amount, taker, domainHex, ledgerIndex string, limit uint32) (*BookOffersResult, error) {
+func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amount, taker, domainHex, ledgerIndex string, limit uint32, marker string) (*BookOffersResult, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -81,6 +90,34 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 		return nil, err
 	}
 
+	// Resolve the marker (if any) to a (resumeDir, skipUntil) pair. The marker
+	// is the 64-hex `index` of the last offer returned by the previous page;
+	// we look up that offer's BookDirectory and continue from there, skipping
+	// entries within that directory until we pass the marker key.
+	var skipUntil [32]byte
+	var resumeDir [32]byte
+	hasMarker := false
+	if marker != "" {
+		var markerKey [32]byte
+		if err := decodeHex32Into(marker, &markerKey); err != nil {
+			return nil, fmt.Errorf("%w: %v", svcerr.ErrInvalidMarker, err)
+		}
+		offerData, rerr := targetLedger.Read(keylet.Keylet{Type: entry.TypeOffer, Key: markerKey})
+		if rerr != nil || offerData == nil {
+			return nil, svcerr.ErrInvalidMarker
+		}
+		markerOffer, perr := state.ParseLedgerOfferFromBytes(offerData)
+		if perr != nil {
+			return nil, svcerr.ErrInvalidMarker
+		}
+		if !samePrefix24(markerOffer.BookDirectory, bookBase) {
+			return nil, svcerr.ErrInvalidMarker
+		}
+		resumeDir = markerOffer.BookDirectory
+		skipUntil = markerKey
+		hasMarker = true
+	}
+
 	getsIssuer := takerGets.Issuer
 	bGlobalFreeze := tx.IsGlobalFrozen(targetLedger, takerGets.Issuer) ||
 		tx.IsGlobalFrozen(targetLedger, takerPays.Issuer)
@@ -94,9 +131,17 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 	// Presence in the map mirrors rippled's umBalanceEntry lookup at
 	// NetworkOPs.cpp:4530-4537 — once an owner is in the map, subsequent
 	// offers from that owner in the *default* branch suppress owner_funds.
+	//
+	// On a resumed walk we start with an empty map: rippled rebuilds
+	// umBalance per call (NetworkOPs.cpp:4442), so we do the same. A
+	// consequence is that owner_funds is reported again for the first offer
+	// of each owner on a new page — same behaviour rippled exhibits when
+	// the same book is requested twice in a row.
 	balances := make(map[string]tx.Amount)
 
 	offers := make([]BookOffer, 0)
+	var lastOfferKey [32]byte
+	hitLimit := false
 
 	// remaining is the rippled-style iLimit counter — decremented once per
 	// directory entry visited regardless of whether the offer SLE could be
@@ -105,16 +150,30 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 	// still falls through to the next iteration.
 	remaining := limit
 	uTipIndex := bookBase
-	for remaining > 0 {
+	skipping := hasMarker
+	firstIteration := true
+	// The loop continues until Succ leaves the book OR DirForEach signals
+	// errStopBookWalk (which it raises the first time `remaining == 0` is
+	// observed). The peek-after-limit is what lets us set `hitLimit` and
+	// emit a marker rather than silently truncating the page.
+	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		nextKey, _, ok, serr := targetLedger.Succ(uTipIndex)
-		if serr != nil {
-			return nil, serr
-		}
-		if !ok {
-			break
+		var nextKey [32]byte
+		if firstIteration && hasMarker {
+			nextKey = resumeDir
+			firstIteration = false
+		} else {
+			nk, _, ok, serr := targetLedger.Succ(uTipIndex)
+			if serr != nil {
+				return nil, serr
+			}
+			if !ok {
+				break
+			}
+			nextKey = nk
+			firstIteration = false
 		}
 		// Once the high-24-byte book prefix changes we have left the book —
 		// mirrors rippled's `succ(uTipIndex, uBookEnd)` upper bound.
@@ -136,7 +195,14 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 			targetLedger,
 			keylet.Keylet{Type: entry.TypeDirectoryNode, Key: nextKey},
 			func(offerKey [32]byte) error {
+				if skipping {
+					if offerKey == skipUntil {
+						skipping = false
+					}
+					return nil
+				}
 				if remaining == 0 {
+					hitLimit = true
 					return errStopBookWalk
 				}
 				remaining--
@@ -157,6 +223,7 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 					return berr
 				}
 				offers = append(offers, bookOffer)
+				lastOfferKey = offerKey
 				return nil
 			},
 		)
@@ -168,12 +235,24 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 		}
 	}
 
-	return &BookOffersResult{
+	// If the supplied marker pointed at an offer that no longer exists in
+	// its directory (e.g. the offer was consumed between requests), we'll
+	// have walked the page without ever clearing `skipping`. That's an
+	// invalid marker from the caller's point of view.
+	if hasMarker && skipping {
+		return nil, svcerr.ErrInvalidMarker
+	}
+
+	result := &BookOffersResult{
 		LedgerIndex: targetLedger.Sequence(),
 		LedgerHash:  targetLedger.Hash(),
 		Offers:      offers,
 		Validated:   validated,
-	}, nil
+	}
+	if hitLimit {
+		result.Marker = hexUpper32(lastOfferKey)
+	}
+	return result, nil
 }
 
 // buildBookOffer is the per-offer payload + funded-amount computation,

--- a/internal/ledger/service/offer_query.go
+++ b/internal/ledger/service/offer_query.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/hex"
@@ -53,6 +54,13 @@ type BookOffersResult struct {
 	// parameter (BookOffers.cpp:201-214) but its NetworkOPsImp::getBookPage
 	// implementation never reads or emits one (NetworkOPs.cpp:4627 comments
 	// out the response field).
+	//
+	// Callers paginating across multiple pages should pin the ledger via
+	// ledger_index or ledger_hash on every follow-up call. The default
+	// "current" ledger advances between calls, so an offer indexed by the
+	// marker can be consumed by a concurrent Payment/OfferCreate; the next
+	// call then returns ErrStaleMarker. Pinning the ledger guarantees the
+	// marker resolves for the duration of the walk.
 	Marker string `json:"marker,omitempty"`
 }
 
@@ -94,6 +102,11 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 	// is the 64-hex `index` of the last offer returned by the previous page;
 	// we look up that offer's BookDirectory and continue from there, skipping
 	// entries within that directory until we pass the marker key.
+	//
+	// Two failure modes are surfaced separately so handlers can map them to
+	// distinct rippled error codes (mirrors AccountOffers.cpp:107-132):
+	//   - syntactically bad / wrong-book → ErrInvalidMarker → invalid_field_error
+	//   - well-formed but referent gone → ErrStaleMarker → rpcINVALID_PARAMS
 	var skipUntil [32]byte
 	var resumeDir [32]byte
 	hasMarker := false
@@ -104,7 +117,7 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 		}
 		offerData, rerr := targetLedger.Read(keylet.Keylet{Type: entry.TypeOffer, Key: markerKey})
 		if rerr != nil || offerData == nil {
-			return nil, svcerr.ErrInvalidMarker
+			return nil, svcerr.ErrStaleMarker
 		}
 		markerOffer, perr := state.ParseLedgerOfferFromBytes(offerData)
 		if perr != nil {
@@ -132,11 +145,12 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 	// NetworkOPs.cpp:4530-4537 — once an owner is in the map, subsequent
 	// offers from that owner in the *default* branch suppress owner_funds.
 	//
-	// On a resumed walk we start with an empty map: rippled rebuilds
-	// umBalance per call (NetworkOPs.cpp:4442), so we do the same. A
-	// consequence is that owner_funds is reported again for the first offer
-	// of each owner on a new page — same behaviour rippled exhibits when
-	// the same book is requested twice in a row.
+	// On a resumed walk we start with an empty map. rippled never paginates
+	// book_offers (NetworkOPsImp::getBookPage ignores its marker arg), so
+	// there is no rippled precedent for the cross-page case; this is a
+	// goXRPL-specific choice. Consequence: the first offer of each owner
+	// in a new page re-emits owner_funds, which is harmless but means
+	// callers concatenating pages will see owner_funds repeated.
 	balances := make(map[string]tx.Amount)
 
 	offers := make([]BookOffer, 0)
@@ -151,7 +165,9 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 	remaining := limit
 	uTipIndex := bookBase
 	skipping := hasMarker
-	firstIteration := true
+	// resumePending consumes the marker's resumeDir on the first loop
+	// iteration; subsequent iterations advance via targetLedger.Succ.
+	resumePending := hasMarker
 	// The loop continues until Succ leaves the book OR DirForEach signals
 	// errStopBookWalk (which it raises the first time `remaining == 0` is
 	// observed). The peek-after-limit is what lets us set `hitLimit` and
@@ -161,9 +177,9 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 			return nil, err
 		}
 		var nextKey [32]byte
-		if firstIteration && hasMarker {
+		if resumePending {
 			nextKey = resumeDir
-			firstIteration = false
+			resumePending = false
 		} else {
 			nk, _, ok, serr := targetLedger.Succ(uTipIndex)
 			if serr != nil {
@@ -173,7 +189,6 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 				break
 			}
 			nextKey = nk
-			firstIteration = false
 		}
 		// Once the high-24-byte book prefix changes we have left the book —
 		// mirrors rippled's `succ(uTipIndex, uBookEnd)` upper bound.
@@ -237,10 +252,12 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 
 	// If the supplied marker pointed at an offer that no longer exists in
 	// its directory (e.g. the offer was consumed between requests), we'll
-	// have walked the page without ever clearing `skipping`. That's an
-	// invalid marker from the caller's point of view.
+	// have walked the page without ever clearing `skipping`. The marker
+	// itself was well-formed and resolved to a real (now-deleted) offer —
+	// surface this as ErrStaleMarker so the handler can map it to
+	// rpcINVALID_PARAMS rather than the malformed-marker error.
 	if hasMarker && skipping {
-		return nil, svcerr.ErrInvalidMarker
+		return nil, svcerr.ErrStaleMarker
 	}
 
 	result := &BookOffersResult{
@@ -249,7 +266,11 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 		Offers:      offers,
 		Validated:   validated,
 	}
-	if hitLimit {
+	// Emit the marker only when the limit was reached AND the page produced
+	// at least one offer. limit=0 hits errStopBookWalk before any offer is
+	// recorded; emitting hexUpper32(lastOfferKey) there would be 64 zeros,
+	// which round-trips as a bad marker on the next call.
+	if hitLimit && len(offers) > 0 {
 		result.Marker = hexUpper32(lastOfferKey)
 	}
 	return result, nil
@@ -440,12 +461,7 @@ func decodeHex32Into(s string, out *[32]byte) error {
 }
 
 func samePrefix24(a, b [32]byte) bool {
-	for i := 0; i < 24; i++ {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+	return bytes.Equal(a[:24], b[:24])
 }
 
 func amountToJSON(a tx.Amount) interface{} {

--- a/internal/ledger/service/offer_query_test.go
+++ b/internal/ledger/service/offer_query_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/keylet"
@@ -200,7 +202,7 @@ func TestGetBookOffers_XRP_OwnerFundsAndUnfunded(t *testing.T) {
 		tx.NewXRPAmount(10_000_000),
 	)
 
-	result, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 10)
+	result, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 10, "")
 	if err != nil {
 		t.Fatalf("GetBookOffers: %v", err)
 	}
@@ -264,7 +266,7 @@ func TestGetBookOffers_OwnerFundsOncePerOwner(t *testing.T) {
 	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
 	xrpModel := tx.NewXRPAmount(0)
 
-	result, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 10)
+	result, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 10, "")
 	if err != nil {
 		t.Fatalf("GetBookOffers: %v", err)
 	}
@@ -298,7 +300,7 @@ func TestGetBookOffers_IssuerOwnIOUFullyFunded(t *testing.T) {
 		state.NewIssuedAmountFromFloat64(50, "USD", issuerAddr),
 	)
 
-	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, "", "", "current", 10)
+	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, "", "", "current", 10, "")
 	if err != nil {
 		t.Fatalf("GetBookOffers: %v", err)
 	}
@@ -336,7 +338,7 @@ func TestGetBookOffers_IssuerOwnIOU_AllOffersEmitOwnerFunds(t *testing.T) {
 
 	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
 	xrpModel := tx.NewXRPAmount(0)
-	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, "", "", "current", 10)
+	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, "", "", "current", 10, "")
 	if err != nil {
 		t.Fatalf("GetBookOffers: %v", err)
 	}
@@ -442,7 +444,7 @@ func TestGetBookOffers_PermissionedOfferHiddenFromOpenBook(t *testing.T) {
 	xrpModel := tx.NewXRPAmount(0)
 
 	// Open book: only the open offer.
-	openResult, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 10)
+	openResult, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 10, "")
 	if err != nil {
 		t.Fatalf("open GetBookOffers: %v", err)
 	}
@@ -455,7 +457,7 @@ func TestGetBookOffers_PermissionedOfferHiddenFromOpenBook(t *testing.T) {
 
 	// Domain book: only the permissioned offer.
 	domainHex := strings.ToUpper(hex.EncodeToString(domainID[:]))
-	domResult, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", domainHex, "current", 10)
+	domResult, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", domainHex, "current", 10, "")
 	if err != nil {
 		t.Fatalf("domain GetBookOffers: %v", err)
 	}
@@ -497,7 +499,7 @@ func TestGetBookOffers_RunningBalanceConsumesAcrossOffers(t *testing.T) {
 
 	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
 	xrpModel := tx.NewXRPAmount(0)
-	result, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 10)
+	result, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 10, "")
 	if err != nil {
 		t.Fatalf("GetBookOffers: %v", err)
 	}
@@ -566,7 +568,7 @@ func TestGetBookOffers_GlobalFreezeMarksAllUnfunded(t *testing.T) {
 
 	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
 	xrpModel := tx.NewXRPAmount(0)
-	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, "", "", "current", 10)
+	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, "", "", "current", 10, "")
 	if err != nil {
 		t.Fatalf("GetBookOffers: %v", err)
 	}
@@ -608,7 +610,7 @@ func TestGetBookOffers_TransferRateAdjustsFunded(t *testing.T) {
 
 	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
 	xrpModel := tx.NewXRPAmount(0)
-	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, "", "", "current", 10)
+	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, "", "", "current", 10, "")
 	if err != nil {
 		t.Fatalf("GetBookOffers: %v", err)
 	}
@@ -627,5 +629,116 @@ func TestGetBookOffers_TransferRateAdjustsFunded(t *testing.T) {
 	if o.TakerGetsFunded == nil || o.TakerPaysFunded == nil {
 		t.Fatalf("transfer-rate adjustment must produce *_funded fields, got gets=%v pays=%v",
 			o.TakerGetsFunded, o.TakerPaysFunded)
+	}
+}
+
+// TestGetBookOffers_MarkerPagination walks a populated book in fixed-size
+// pages and verifies the full set of offers is returned exactly once across
+// the chain of (marker → next request) calls. This is a goXRPL extension —
+// rippled's NetworkOPsImp::getBookPage ignores its jvMarker parameter
+// (NetworkOPs.cpp:4627) so there is no rippled fixture to mirror.
+func TestGetBookOffers_MarkerPagination(t *testing.T) {
+	svc := newOfferTestService(t)
+
+	issuerAddr, _ := addressFromBytes(t, 0xA0)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	ownerAddr, _ := addressFromBytes(t, 0xB0)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+
+	// 12 offers at distinct qualities (so each lives in its own quality
+	// tier — different BookDirectory) plus a second offer per tier to also
+	// exercise mid-directory resume. We get 12 directories × 1 offer each,
+	// total 12 offers walked across multiple pages.
+	const totalOffers = 12
+	for i := 0; i < totalOffers; i++ {
+		insertOffer(t, svc, ownerAddr, uint32(i+1),
+			state.NewIssuedAmountFromFloat64(float64(100+i), "USD", issuerAddr),
+			tx.NewXRPAmount(10_000_000),
+		)
+	}
+
+	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
+	xrpModel := tx.NewXRPAmount(0)
+
+	const pageSize uint32 = 5
+	var collected []string
+	marker := ""
+	for page := 0; page < 10; page++ {
+		result, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", pageSize, marker)
+		if err != nil {
+			t.Fatalf("page %d: GetBookOffers: %v", page, err)
+		}
+		if marker == "" && len(result.Offers) == 0 {
+			t.Fatalf("first page must not be empty")
+		}
+		for _, o := range result.Offers {
+			collected = append(collected, o.Index)
+		}
+		if result.Marker == "" {
+			break
+		}
+		// The emitted marker must be the index of the last offer in the page.
+		if last := result.Offers[len(result.Offers)-1].Index; result.Marker != last {
+			t.Fatalf("page %d marker %q != last offer index %q", page, result.Marker, last)
+		}
+		marker = result.Marker
+		if page == 9 {
+			t.Fatalf("pagination did not terminate within 10 pages")
+		}
+	}
+
+	if len(collected) != totalOffers {
+		t.Fatalf("expected %d offers across all pages, got %d", totalOffers, len(collected))
+	}
+	seen := make(map[string]bool, len(collected))
+	for _, idx := range collected {
+		if seen[idx] {
+			t.Fatalf("offer %s returned twice across pages", idx)
+		}
+		seen[idx] = true
+	}
+}
+
+// TestGetBookOffers_MarkerInvalid verifies the four invalid-marker cases:
+// bad hex, wrong length, marker points at a non-offer key, marker offer
+// belongs to a different book.
+func TestGetBookOffers_MarkerInvalid(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, _ := addressFromBytes(t, 0xC0)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	ownerAddr, _ := addressFromBytes(t, 0xD0)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+
+	// One offer in the USD/XRP book so the book exists.
+	insertOffer(t, svc, ownerAddr, 1,
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+		tx.NewXRPAmount(10_000_000),
+	)
+	// One offer in a *different* book (USD/EUR) so we have a valid-format but
+	// wrong-book marker candidate.
+	eurOfferKey := insertOffer(t, svc, ownerAddr, 2,
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+		state.NewIssuedAmountFromFloat64(100, "EUR", issuerAddr),
+	)
+
+	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
+	xrpModel := tx.NewXRPAmount(0)
+
+	cases := []struct {
+		name   string
+		marker string
+	}{
+		{"non-hex", strings.Repeat("Z", 64)},
+		{"wrong-length", "DEADBEEF"},
+		{"unknown-key", strings.Repeat("0", 64)},
+		{"wrong-book", hexUpper32(eurOfferKey)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 5, tc.marker)
+			if !errors.Is(err, svcerr.ErrInvalidMarker) {
+				t.Fatalf("expected ErrInvalidMarker, got %v", err)
+			}
+		})
 	}
 }

--- a/internal/ledger/service/offer_query_test.go
+++ b/internal/ledger/service/offer_query_test.go
@@ -697,6 +697,12 @@ func TestGetBookOffers_MarkerPagination(t *testing.T) {
 	}
 }
 
+// TestGetBookOffers_MarkerInvalid covers markers that fail at the malformed /
+// wrong-scope tier — they map to rippled's invalid_field_error("marker"). The
+// stale-marker tier (well-formed marker whose offer was consumed between
+// pages) is exercised separately in TestGetBookOffers_MarkerStale; the two
+// must produce distinct sentinels so handlers can distinguish them
+// (AccountOffers.cpp:107-132).
 func TestGetBookOffers_MarkerInvalid(t *testing.T) {
 	svc := newOfferTestService(t)
 	issuerAddr, _ := addressFromBytes(t, 0xC0)
@@ -704,13 +710,11 @@ func TestGetBookOffers_MarkerInvalid(t *testing.T) {
 	ownerAddr, _ := addressFromBytes(t, 0xD0)
 	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
 
-	// One offer in the USD/XRP book so the book exists.
 	insertOffer(t, svc, ownerAddr, 1,
 		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
 		tx.NewXRPAmount(10_000_000),
 	)
-	// One offer in a *different* book (USD/EUR) so we have a valid-format but
-	// wrong-book marker candidate.
+	// Offer in a *different* book (USD/EUR) for the wrong-book case.
 	eurOfferKey := insertOffer(t, svc, ownerAddr, 2,
 		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
 		state.NewIssuedAmountFromFloat64(100, "EUR", issuerAddr),
@@ -725,7 +729,6 @@ func TestGetBookOffers_MarkerInvalid(t *testing.T) {
 	}{
 		{"non-hex", strings.Repeat("Z", 64)},
 		{"wrong-length", "DEADBEEF"},
-		{"unknown-key", strings.Repeat("0", 64)},
 		{"wrong-book", hexUpper32(eurOfferKey)},
 	}
 	for _, tc := range cases {
@@ -734,6 +737,74 @@ func TestGetBookOffers_MarkerInvalid(t *testing.T) {
 			if !errors.Is(err, svcerr.ErrInvalidMarker) {
 				t.Fatalf("expected ErrInvalidMarker, got %v", err)
 			}
+			if errors.Is(err, svcerr.ErrStaleMarker) {
+				t.Fatalf("malformed marker must not match ErrStaleMarker")
+			}
 		})
+	}
+}
+
+// TestGetBookOffers_MarkerStale pins the stale-marker sentinel. A well-formed
+// 64-hex marker that does not resolve to any offer in the ledger is treated
+// as a referent-gone condition, not a malformed marker — mirrors rippled's
+// AccountOffers.cpp:128-132 "object pointed to by the marker does not exist"
+// branch, which rippled returns as rpcINVALID_PARAMS rather than
+// invalid_field_error.
+func TestGetBookOffers_MarkerStale(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, _ := addressFromBytes(t, 0xC4)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	ownerAddr, _ := addressFromBytes(t, 0xD4)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+
+	insertOffer(t, svc, ownerAddr, 1,
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+		tx.NewXRPAmount(10_000_000),
+	)
+
+	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
+	xrpModel := tx.NewXRPAmount(0)
+
+	_, err := svc.GetBookOffers(
+		context.Background(), xrpModel, usd, "", "", "current", 5,
+		strings.Repeat("0", 64),
+	)
+	if !errors.Is(err, svcerr.ErrStaleMarker) {
+		t.Fatalf("unknown-key marker must surface as ErrStaleMarker, got %v", err)
+	}
+	if errors.Is(err, svcerr.ErrInvalidMarker) {
+		t.Fatalf("stale marker must not match ErrInvalidMarker — handler distinguishes the two")
+	}
+}
+
+// TestGetBookOffers_LimitZeroEmitsNoMarker pins the M1 fix: limit=0 is a legal
+// request (rippled Tuning.h:49 declares bookOffers={0,60,100}) and must
+// return zero offers with no marker. The pre-fix code emitted a 64-zero
+// marker because hitLimit flipped true before any offer was recorded, which
+// then broke the caller's next paginated request.
+func TestGetBookOffers_LimitZeroEmitsNoMarker(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, _ := addressFromBytes(t, 0xC8)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	ownerAddr, _ := addressFromBytes(t, 0xD8)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+
+	insertOffer(t, svc, ownerAddr, 1,
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+		tx.NewXRPAmount(10_000_000),
+	)
+
+	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
+	xrpModel := tx.NewXRPAmount(0)
+
+	result, err := svc.GetBookOffers(context.Background(), xrpModel, usd, "", "", "current", 0, "")
+	if err != nil {
+		t.Fatalf("GetBookOffers(limit=0): %v", err)
+	}
+	if len(result.Offers) != 0 {
+		t.Fatalf("limit=0 must return zero offers, got %d", len(result.Offers))
+	}
+	if result.Marker != "" {
+		t.Fatalf("limit=0 must not emit a marker, got %q", result.Marker)
 	}
 }

--- a/internal/ledger/service/offer_query_test.go
+++ b/internal/ledger/service/offer_query_test.go
@@ -698,11 +698,9 @@ func TestGetBookOffers_MarkerPagination(t *testing.T) {
 }
 
 // TestGetBookOffers_MarkerInvalid covers markers that fail at the malformed /
-// wrong-scope tier — they map to rippled's invalid_field_error("marker"). The
-// stale-marker tier (well-formed marker whose offer was consumed between
-// pages) is exercised separately in TestGetBookOffers_MarkerStale; the two
-// must produce distinct sentinels so handlers can distinguish them
-// (AccountOffers.cpp:107-132).
+// wrong-scope tier — they must map to ErrInvalidMarker (rippled's
+// invalid_field_error("marker"), AccountOffers.cpp:107-121). The
+// stale-marker tier is exercised separately in TestGetBookOffers_MarkerStale.
 func TestGetBookOffers_MarkerInvalid(t *testing.T) {
 	svc := newOfferTestService(t)
 	issuerAddr, _ := addressFromBytes(t, 0xC0)
@@ -744,12 +742,11 @@ func TestGetBookOffers_MarkerInvalid(t *testing.T) {
 	}
 }
 
-// TestGetBookOffers_MarkerStale pins the stale-marker sentinel. A well-formed
-// 64-hex marker that does not resolve to any offer in the ledger is treated
-// as a referent-gone condition, not a malformed marker — mirrors rippled's
-// AccountOffers.cpp:128-132 "object pointed to by the marker does not exist"
-// branch, which rippled returns as rpcINVALID_PARAMS rather than
-// invalid_field_error.
+// TestGetBookOffers_MarkerStale: a well-formed 64-hex marker that does not
+// resolve to any offer in the ledger must surface as ErrStaleMarker, not
+// ErrInvalidMarker — mirrors rippled's AccountOffers.cpp:128-132 "object
+// pointed to by the marker does not exist" branch, which rippled returns
+// as rpcINVALID_PARAMS rather than invalid_field_error.
 func TestGetBookOffers_MarkerStale(t *testing.T) {
 	svc := newOfferTestService(t)
 	issuerAddr, _ := addressFromBytes(t, 0xC4)
@@ -777,11 +774,11 @@ func TestGetBookOffers_MarkerStale(t *testing.T) {
 	}
 }
 
-// TestGetBookOffers_LimitZeroEmitsNoMarker pins the M1 fix: limit=0 is a legal
-// request (rippled Tuning.h:49 declares bookOffers={0,60,100}) and must
-// return zero offers with no marker. The pre-fix code emitted a 64-zero
-// marker because hitLimit flipped true before any offer was recorded, which
-// then broke the caller's next paginated request.
+// TestGetBookOffers_LimitZeroEmitsNoMarker: limit=0 is a legal request
+// (rippled Tuning.h:49 declares bookOffers={0,60,100}) and must return
+// zero offers with no marker. Without this guard, hitLimit flips true
+// before any offer is recorded and the result carries a 64-zero marker
+// that breaks the next paginated request.
 func TestGetBookOffers_LimitZeroEmitsNoMarker(t *testing.T) {
 	svc := newOfferTestService(t)
 	issuerAddr, _ := addressFromBytes(t, 0xC8)

--- a/internal/ledger/service/offer_query_test.go
+++ b/internal/ledger/service/offer_query_test.go
@@ -645,10 +645,8 @@ func TestGetBookOffers_MarkerPagination(t *testing.T) {
 	ownerAddr, _ := addressFromBytes(t, 0xB0)
 	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
 
-	// 12 offers at distinct qualities (so each lives in its own quality
-	// tier — different BookDirectory) plus a second offer per tier to also
-	// exercise mid-directory resume. We get 12 directories × 1 offer each,
-	// total 12 offers walked across multiple pages.
+	// Distinct qualities so each offer lives in its own BookDirectory; the
+	// page size below straddles directory boundaries.
 	const totalOffers = 12
 	for i := 0; i < totalOffers; i++ {
 		insertOffer(t, svc, ownerAddr, uint32(i+1),
@@ -699,9 +697,6 @@ func TestGetBookOffers_MarkerPagination(t *testing.T) {
 	}
 }
 
-// TestGetBookOffers_MarkerInvalid verifies the four invalid-marker cases:
-// bad hex, wrong length, marker points at a non-offer key, marker offer
-// belongs to a different book.
 func TestGetBookOffers_MarkerInvalid(t *testing.T) {
 	svc := newOfferTestService(t)
 	issuerAddr, _ := addressFromBytes(t, 0xC0)

--- a/internal/ledger/service/svcerr/svcerr.go
+++ b/internal/ledger/service/svcerr/svcerr.go
@@ -55,8 +55,18 @@ var (
 	ErrObjectNotFound = errors.New("object not found")
 
 	// ErrInvalidMarker is returned when a paginated query supplies a
-	// marker that does not parse or does not match an existing entry.
+	// marker that is syntactically bad or refers to an entry in the
+	// wrong scope (e.g. an offer in a different book). Maps to rippled's
+	// invalid_field_error("marker") at AccountOffers.cpp:107-121.
 	ErrInvalidMarker = errors.New("invalid marker")
+
+	// ErrStaleMarker is returned when a paginated query supplies a
+	// well-formed marker that pointed at an entry which has since been
+	// removed (e.g. an offer consumed by a Payment between pages). It is
+	// recoverable by retrying against a pinned ledger_index/ledger_hash.
+	// Maps to rippled's rpcINVALID_PARAMS "object pointed to by the
+	// marker does not exist" at AccountOffers.cpp:128-132.
+	ErrStaleMarker = errors.New("stale marker")
 
 	// ErrHighFee is the sentinel matched by errors.Is for any high-fee
 	// failure. The fee-autofill path returns the structured HighFeeError

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -106,7 +106,7 @@ func (m *mockAccountChannelsLedgerService) GetAccountLines(_ context.Context, ac
 func (m *mockAccountChannelsLedgerService) GetAccountOffers(_ context.Context, account string, ledgerIndex string, limit uint32) (*types.AccountOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountChannelsLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (m *mockAccountChannelsLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
 func (m *mockAccountChannelsLedgerService) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -108,7 +108,7 @@ func (m *mockAccountCurrenciesLedgerService) GetAccountLines(_ context.Context, 
 func (m *mockAccountCurrenciesLedgerService) GetAccountOffers(_ context.Context, account string, ledgerIndex string, limit uint32) (*types.AccountOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountCurrenciesLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (m *mockAccountCurrenciesLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
 func (m *mockAccountCurrenciesLedgerService) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -99,7 +99,7 @@ func (m *mockLedgerService) GetAccountLines(_ context.Context, account string, l
 func (m *mockLedgerService) GetAccountOffers(_ context.Context, account string, ledgerIndex string, limit uint32) (*types.AccountOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (m *mockLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
 func (m *mockLedgerService) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -115,7 +115,7 @@ func (m *mockAccountLinesLedgerService) GetAccountLines(_ context.Context, accou
 func (m *mockAccountLinesLedgerService) GetAccountOffers(_ context.Context, account string, ledgerIndex string, limit uint32) (*types.AccountOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountLinesLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (m *mockAccountLinesLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
 func (m *mockAccountLinesLedgerService) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -104,7 +104,7 @@ func (m *mockAccountNFTsLedgerService) GetAccountLines(_ context.Context, accoun
 func (m *mockAccountNFTsLedgerService) GetAccountOffers(_ context.Context, account string, ledgerIndex string, limit uint32) (*types.AccountOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountNFTsLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (m *mockAccountNFTsLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
 func (m *mockAccountNFTsLedgerService) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -643,7 +643,7 @@ func TestBookOffersDomainForwarding(t *testing.T) {
 	}
 
 	var capturedDomain string
-	mock.getBookOffersFn = func(_, _ types.Amount, _, domain, _ string, _ uint32) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(_, _ types.Amount, _, domain, _ string, _ uint32, _ string, _ bool) (*types.BookOffersResult, error) {
 		capturedDomain = domain
 		return &types.BookOffersResult{
 			LedgerIndex: 2,

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -1190,10 +1190,10 @@ func TestBookOffersMarkerPassthrough(t *testing.T) {
 	assert.False(t, hasLimit, "response must omit limit when no marker is emitted")
 }
 
-// TestBookOffersStaleMarkerMapping pins the M2 split: a well-formed marker
-// pointing at an entry that no longer exists in the ledger maps to
-// rpcINVALID_PARAMS (not invalid_field_error). Mirrors rippled's
-// AccountOffers.cpp:128-132 distinction.
+// TestBookOffersStaleMarkerMapping: a well-formed marker pointing at an entry
+// that no longer exists in the ledger must map to rpcINVALID_PARAMS (not
+// invalid_field_error). Mirrors rippled's AccountOffers.cpp:128-132
+// distinction between malformed marker and missing-referent marker.
 func TestBookOffersStaleMarkerMapping(t *testing.T) {
 	mock := newBookOffersMock()
 	services := newBookOffersTestServices(mock)

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
@@ -817,13 +818,15 @@ func TestBookOffersLimitParameter(t *testing.T) {
 
 			assert.Equal(t, tc.expectedLimit, capturedLimit, "Limit passed to service should match")
 
-			// rippled book_offers never echoes a "limit" field in the response.
+			// limit is echoed only on paginated responses (alongside marker),
+			// matching rippled's account_offers convention. With no marker
+			// returned by the mock above, the response must omit limit.
 			resultJSON, err := json.Marshal(result)
 			require.NoError(t, err)
 			var resp map[string]interface{}
 			err = json.Unmarshal(resultJSON, &resp)
 			require.NoError(t, err)
-			assert.NotContains(t, resp, "limit", "limit should never be echoed in response")
+			assert.NotContains(t, resp, "limit", "limit must not be echoed when no marker is returned")
 		})
 	}
 }
@@ -1140,10 +1143,12 @@ func TestBookOffersMarkerPassthrough(t *testing.T) {
 	}
 
 	var capturedMarker string
+	var capturedLimit uint32
 	const reqMarker = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
 	const respMarker = "FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210"
-	mock.getBookOffersFn = func(_, _ types.Amount, _, _ string, _ string, _ uint32, marker string) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(_, _ types.Amount, _, _ string, _ string, limit uint32, marker string) (*types.BookOffersResult, error) {
 		capturedMarker = marker
+		capturedLimit = limit
 		return &types.BookOffersResult{LedgerIndex: 5, Offers: []types.BookOffer{}, Validated: true, Marker: respMarker}, nil
 	}
 
@@ -1151,6 +1156,7 @@ func TestBookOffersMarkerPassthrough(t *testing.T) {
 		"taker_pays": map[string]interface{}{"currency": "XRP"},
 		"taker_gets": map[string]interface{}{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
 		"marker":     reqMarker,
+		"limit":      7,
 	}
 	paramsJSON, err := json.Marshal(params)
 	require.NoError(t, err)
@@ -1159,12 +1165,16 @@ func TestBookOffersMarkerPassthrough(t *testing.T) {
 	require.Nil(t, rpcErr)
 	require.NotNil(t, result)
 	assert.Equal(t, reqMarker, capturedMarker)
+	assert.Equal(t, uint32(7), capturedLimit)
 	resp, ok := result.(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, respMarker, resp["marker"])
+	// Paginated response pairs marker with limit echo (account_offers
+	// convention, AccountOffers.cpp:172-176).
+	assert.Equal(t, uint32(7), resp["limit"], "paginated response must echo limit alongside marker")
 
 	// Verify the inverse: when the service emits no marker, the response
-	// does not contain a marker key (rather than an empty string).
+	// contains neither a marker nor a limit key.
 	mock.getBookOffersFn = func(_, _ types.Amount, _, _ string, _ string, _ uint32, _ string) (*types.BookOffersResult, error) {
 		return &types.BookOffersResult{LedgerIndex: 6, Offers: []types.BookOffer{}, Validated: true}, nil
 	}
@@ -1176,6 +1186,54 @@ func TestBookOffersMarkerPassthrough(t *testing.T) {
 	resp = result.(map[string]interface{})
 	_, hasMarker := resp["marker"]
 	assert.False(t, hasMarker, "response must omit marker when service returned none")
+	_, hasLimit := resp["limit"]
+	assert.False(t, hasLimit, "response must omit limit when no marker is emitted")
+}
+
+// TestBookOffersStaleMarkerMapping pins the M2 split: a well-formed marker
+// pointing at an entry that no longer exists in the ledger maps to
+// rpcINVALID_PARAMS (not invalid_field_error). Mirrors rippled's
+// AccountOffers.cpp:128-132 distinction.
+func TestBookOffersStaleMarkerMapping(t *testing.T) {
+	mock := newBookOffersMock()
+	services := newBookOffersTestServices(mock)
+	method := &handlers.BookOffersMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	mock.getBookOffersFn = func(_, _ types.Amount, _, _ string, _ string, _ uint32, _ string) (*types.BookOffersResult, error) {
+		return nil, svcerr.ErrStaleMarker
+	}
+
+	params := map[string]interface{}{
+		"taker_pays": map[string]interface{}{"currency": "XRP"},
+		"taker_gets": map[string]interface{}{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+		"marker":     "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	result, rpcErr := method.Handle(ctx, paramsJSON)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Contains(t, rpcErr.Message, "marker")
+	assert.NotEqual(t, "Invalid field 'marker'.", rpcErr.Message,
+		"stale marker must not collapse into invalid_field_error")
+
+	// Sanity: the malformed-marker branch still produces the invalid_field
+	// shape so callers can distinguish the two on the wire.
+	mock.getBookOffersFn = func(_, _ types.Amount, _, _ string, _ string, _ uint32, _ string) (*types.BookOffersResult, error) {
+		return nil, svcerr.ErrInvalidMarker
+	}
+	result, rpcErr = method.Handle(ctx, paramsJSON)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "Invalid field 'marker'.", rpcErr.Message)
 }
 
 // TestBookOffersMarkerValidation checks that the handler rejects malformed

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -15,12 +15,12 @@ import (
 // bookOffersMock wraps mockLedgerService to provide custom GetBookOffers behavior
 type bookOffersMock struct {
 	*mockLedgerService
-	getBookOffersFn func(takerGets, takerPays types.Amount, taker, domain, ledgerIndex string, limit uint32) (*types.BookOffersResult, error)
+	getBookOffersFn func(takerGets, takerPays types.Amount, taker, domain, ledgerIndex string, limit uint32, marker string) (*types.BookOffersResult, error)
 }
 
-func (m *bookOffersMock) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, taker, domain, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (m *bookOffersMock) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, taker, domain, ledgerIndex string, limit uint32, marker string) (*types.BookOffersResult, error) {
 	if m.getBookOffersFn != nil {
-		return m.getBookOffersFn(takerGets, takerPays, taker, domain, ledgerIndex, limit)
+		return m.getBookOffersFn(takerGets, takerPays, taker, domain, ledgerIndex, limit, marker)
 	}
 	return nil, errors.New("not implemented")
 }
@@ -472,7 +472,7 @@ func TestBookOffersXRPAmountHandling(t *testing.T) {
 
 	// Track what arguments are passed to GetBookOffers
 	var capturedGets, capturedPays types.Amount
-	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 		capturedGets = takerGets
 		capturedPays = takerPays
 		return &types.BookOffersResult{
@@ -603,7 +603,7 @@ func TestBookOffersValidRequestWithOffers(t *testing.T) {
 		},
 	}
 
-	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 		return &types.BookOffersResult{
 			LedgerIndex: 2,
 			LedgerHash:  [32]byte{0x4B, 0xC5, 0x0C, 0x9B, 0x0D, 0x85, 0x15, 0xD3, 0xEA, 0xAE, 0x1E, 0x74, 0xB2, 0x9A, 0x95, 0x80, 0x43, 0x46, 0xC4, 0x91, 0xEE, 0x1A, 0x95, 0xBF, 0x25, 0xE4, 0xAA, 0xB8, 0x54, 0xA6, 0xA6, 0x52},
@@ -682,7 +682,7 @@ func TestBookOffersEmptyOrderBook(t *testing.T) {
 		Services:   services,
 	}
 
-	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 		return &types.BookOffersResult{
 			LedgerIndex: 2,
 			LedgerHash:  [32]byte{0x4B, 0xC5, 0x0C, 0x9B},
@@ -737,7 +737,7 @@ func TestBookOffersLimitParameter(t *testing.T) {
 
 	// Track the limit passed to GetBookOffers
 	var capturedLimit uint32
-	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 		capturedLimit = limit
 		// Return as many offers as requested (up to our mock max)
 		offers := []types.BookOffer{}
@@ -842,7 +842,7 @@ func TestBookOffersResponseStructure(t *testing.T) {
 		Services:   services,
 	}
 
-	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 		return &types.BookOffersResult{
 			LedgerIndex: 2,
 			LedgerHash:  [32]byte{0x4B, 0xC5, 0x0C, 0x9B, 0x0D, 0x85, 0x15, 0xD3, 0xEA, 0xAE, 0x1E, 0x74, 0xB2, 0x9A, 0x95, 0x80, 0x43, 0x46, 0xC4, 0x91, 0xEE, 0x1A, 0x95, 0xBF, 0x25, 0xE4, 0xAA, 0xB8, 0x54, 0xA6, 0xA6, 0x52},
@@ -931,7 +931,7 @@ func TestBookOffersOfferFields(t *testing.T) {
 		Services:   services,
 	}
 
-	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 		return &types.BookOffersResult{
 			LedgerIndex: 2,
 			LedgerHash:  [32]byte{0x01, 0x02},
@@ -1101,7 +1101,7 @@ func TestBookOffersServiceError(t *testing.T) {
 		Services:   services,
 	}
 
-	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 		return nil, errors.New("ledger not found")
 	}
 
@@ -1123,6 +1123,103 @@ func TestBookOffersServiceError(t *testing.T) {
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
 	assert.Contains(t, rpcErr.Message, "Failed to get book offers")
+}
+
+// TestBookOffersMarkerPassthrough exercises the handler's marker handling:
+// the request marker is forwarded to GetBookOffers, an emitted response
+// marker is surfaced in the JSON, and an absent marker is omitted.
+func TestBookOffersMarkerPassthrough(t *testing.T) {
+	mock := newBookOffersMock()
+	services := newBookOffersTestServices(mock)
+	method := &handlers.BookOffersMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	var capturedMarker string
+	const reqMarker = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+	const respMarker = "FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210"
+	mock.getBookOffersFn = func(_, _ types.Amount, _, _ string, _ string, _ uint32, marker string) (*types.BookOffersResult, error) {
+		capturedMarker = marker
+		return &types.BookOffersResult{LedgerIndex: 5, Offers: []types.BookOffer{}, Validated: true, Marker: respMarker}, nil
+	}
+
+	params := map[string]interface{}{
+		"taker_pays": map[string]interface{}{"currency": "XRP"},
+		"taker_gets": map[string]interface{}{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+		"marker":     reqMarker,
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	result, rpcErr := method.Handle(ctx, paramsJSON)
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+	assert.Equal(t, reqMarker, capturedMarker)
+	resp, ok := result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, respMarker, resp["marker"])
+
+	// Verify the inverse: when the service emits no marker, the response
+	// does not contain a marker key (rather than an empty string).
+	mock.getBookOffersFn = func(_, _ types.Amount, _, _ string, _ string, _ uint32, _ string) (*types.BookOffersResult, error) {
+		return &types.BookOffersResult{LedgerIndex: 6, Offers: []types.BookOffer{}, Validated: true}, nil
+	}
+	delete(params, "marker")
+	paramsJSON, err = json.Marshal(params)
+	require.NoError(t, err)
+	result, rpcErr = method.Handle(ctx, paramsJSON)
+	require.Nil(t, rpcErr)
+	resp = result.(map[string]interface{})
+	_, hasMarker := resp["marker"]
+	assert.False(t, hasMarker, "response must omit marker when service returned none")
+}
+
+// TestBookOffersMarkerValidation checks that the handler rejects malformed
+// markers before invoking the service.
+func TestBookOffersMarkerValidation(t *testing.T) {
+	mock := newBookOffersMock()
+	services := newBookOffersTestServices(mock)
+	method := &handlers.BookOffersMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+	// Fail the test if the service is reached: every case below must
+	// short-circuit inside the handler.
+	mock.getBookOffersFn = func(_, _ types.Amount, _, _ string, _ string, _ uint32, _ string) (*types.BookOffersResult, error) {
+		t.Fatalf("service must not be called for invalid markers")
+		return nil, nil
+	}
+
+	cases := []struct {
+		name   string
+		marker interface{}
+	}{
+		{"non-string", 123},
+		{"short", "ABCD"},
+		{"non-hex", "GG23456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]interface{}{
+				"taker_pays": map[string]interface{}{"currency": "XRP"},
+				"taker_gets": map[string]interface{}{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+				"marker":     tc.marker,
+			}
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			assert.Nil(t, result)
+			require.NotNil(t, rpcErr)
+			assert.Contains(t, rpcErr.Message, "marker")
+		})
+	}
 }
 
 // TestBookOffersMethodMetadata tests the method's metadata functions
@@ -1156,7 +1253,7 @@ func TestBookOffersLedgerIndexPassthrough(t *testing.T) {
 	}
 
 	var capturedLedgerIndex string
-	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 		capturedLedgerIndex = ledgerIndex
 		return &types.BookOffersResult{
 			LedgerIndex: 2,
@@ -1233,7 +1330,7 @@ func TestBookOffersNilOffersArray(t *testing.T) {
 		Services:   services,
 	}
 
-	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+	mock.getBookOffersFn = func(takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 		return &types.BookOffersResult{
 			LedgerIndex: 2,
 			Offers:      nil, // nil slice

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -108,7 +108,7 @@ func (m *mockDepositAuthorizedLedgerService) GetAccountLines(_ context.Context, 
 func (m *mockDepositAuthorizedLedgerService) GetAccountOffers(_ context.Context, account string, ledgerIndex string, limit uint32) (*types.AccountOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockDepositAuthorizedLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (m *mockDepositAuthorizedLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
 func (m *mockDepositAuthorizedLedgerService) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -106,7 +106,7 @@ func (m *mockGatewayBalancesLedgerService) GetAccountLines(_ context.Context, ac
 func (m *mockGatewayBalancesLedgerService) GetAccountOffers(_ context.Context, account string, ledgerIndex string, limit uint32) (*types.AccountOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockGatewayBalancesLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (m *mockGatewayBalancesLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
 func (m *mockGatewayBalancesLedgerService) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -192,6 +192,14 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 
 	result, err := ctx.Services.Ledger.GetBookOffers(ctx.Context, takerGets, takerPays, takerStr, domain, ledgerIndex, limit, markerStr)
 	if err != nil {
+		// Mirrors rippled AccountOffers.cpp:107-132 two-tier mapping:
+		// malformed / wrong-scope marker → invalid_field_error("marker");
+		// well-formed marker whose referent was consumed between pages →
+		// rpcINVALID_PARAMS with a distinct message so clients can retry
+		// against a pinned ledger.
+		if errors.Is(err, svcerr.ErrStaleMarker) {
+			return nil, types.RpcErrorInvalidParams("Invalid marker: object pointed to by marker is gone; retry with a pinned ledger_index or ledger_hash.")
+		}
 		if errors.Is(err, svcerr.ErrInvalidMarker) {
 			return nil, types.RpcErrorInvalidField("marker")
 		}
@@ -205,7 +213,10 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		"validated":    result.Validated,
 	}
 	if result.Marker != "" {
+		// Pair marker with limit echo, matching rippled's account_offers
+		// convention (AccountOffers.cpp:172-176 emits both fields together).
 		response["marker"] = result.Marker
+		response["limit"] = limit
 	}
 	return response, nil
 }

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
@@ -167,17 +169,45 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	takerPays := types.Amount{Currency: paysCurrency, Issuer: canonIssuerString(paysIssuerStr, paysCurrency)}
 	takerGets := types.Amount{Currency: getsCurrency, Issuer: canonIssuerString(getsIssuerStr, getsCurrency)}
 
-	result, err := ctx.Services.Ledger.GetBookOffers(ctx.Context, takerGets, takerPays, takerStr, domain, ledgerIndex, limit)
+	// marker is a goXRPL extension. rippled's handler (BookOffers.cpp:201-214)
+	// reads `marker` from params and threads it through to getBookPage, but
+	// NetworkOPsImp::getBookPage doesn't actually use it (NetworkOPs.cpp:4627
+	// shows the response field is commented out). We treat it as an opaque
+	// 64-hex offer-index resume token; the service rejects non-matching shapes.
+	var markerStr string
+	if rawMarker, ok := probe["marker"]; ok && !isJSONNull(rawMarker) {
+		if !isJSONString(rawMarker) {
+			return nil, types.RpcErrorInvalidField("marker")
+		}
+		if err := json.Unmarshal(rawMarker, &markerStr); err != nil {
+			return nil, types.RpcErrorInvalidField("marker")
+		}
+		if len(markerStr) != 64 {
+			return nil, types.RpcErrorInvalidField("marker")
+		}
+		if _, err := hex.DecodeString(markerStr); err != nil {
+			return nil, types.RpcErrorInvalidField("marker")
+		}
+	}
+
+	result, err := ctx.Services.Ledger.GetBookOffers(ctx.Context, takerGets, takerPays, takerStr, domain, ledgerIndex, limit, markerStr)
 	if err != nil {
+		if errors.Is(err, svcerr.ErrInvalidMarker) {
+			return nil, types.RpcErrorInvalidField("marker")
+		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get book offers: %v", err))
 	}
 
-	return map[string]interface{}{
+	response := map[string]interface{}{
 		"ledger_hash":  FormatLedgerHash(result.LedgerHash),
 		"ledger_index": result.LedgerIndex,
 		"offers":       result.Offers,
 		"validated":    result.Validated,
-	}, nil
+	}
+	if result.Marker != "" {
+		response["marker"] = result.Marker
+	}
+	return response, nil
 }
 
 func ParseAmountFromJSON(data json.RawMessage) (types.Amount, error) {

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -383,7 +383,7 @@ func (a *LedgerServiceAdapter) GetAccountOffers(ctx context.Context, account str
 }
 
 // GetBookOffers retrieves offers from an order book
-func (a *LedgerServiceAdapter) GetBookOffers(ctx context.Context, takerGets, takerPays types.Amount, taker, domain string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (a *LedgerServiceAdapter) GetBookOffers(ctx context.Context, takerGets, takerPays types.Amount, taker, domain string, ledgerIndex string, limit uint32, marker string) (*types.BookOffersResult, error) {
 	// Convert RPC types.Amount to tx.Amount
 	var txTakerGets, txTakerPays tx.Amount
 	if takerGets.Currency == "" || takerGets.Currency == "XRP" {
@@ -397,7 +397,7 @@ func (a *LedgerServiceAdapter) GetBookOffers(ctx context.Context, takerGets, tak
 		txTakerPays = tx.NewIssuedAmountFromFloat64(0, takerPays.Currency, takerPays.Issuer)
 	}
 
-	result, err := a.svc.GetBookOffers(ctx, txTakerGets, txTakerPays, taker, domain, ledgerIndex, limit)
+	result, err := a.svc.GetBookOffers(ctx, txTakerGets, txTakerPays, taker, domain, ledgerIndex, limit, marker)
 	if err != nil {
 		return nil, err
 	}
@@ -432,6 +432,7 @@ func (a *LedgerServiceAdapter) GetBookOffers(ctx context.Context, takerGets, tak
 		LedgerHash:  result.LedgerHash,
 		Offers:      offers,
 		Validated:   result.Validated,
+		Marker:      result.Marker,
 	}, nil
 }
 

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -87,7 +87,7 @@ func (m *mockNFTOffersLedgerService) GetAccountLines(_ context.Context, account 
 func (m *mockNFTOffersLedgerService) GetAccountOffers(_ context.Context, account string, ledgerIndex string, limit uint32) (*types.AccountOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNFTOffersLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (m *mockNFTOffersLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
 func (m *mockNFTOffersLedgerService) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -104,7 +104,7 @@ func (m *mockNoRippleCheckLedgerService) GetAccountLines(_ context.Context, acco
 func (m *mockNoRippleCheckLedgerService) GetAccountOffers(_ context.Context, account string, ledgerIndex string, limit uint32) (*types.AccountOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNoRippleCheckLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
+func (m *mockNoRippleCheckLedgerService) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, _, _ string, ledgerIndex string, limit uint32, _ string) (*types.BookOffersResult, error) {
 	return nil, errors.New("not implemented")
 }
 func (m *mockNoRippleCheckLedgerService) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -325,7 +325,7 @@ type LedgerService interface {
 	AccountQuerier
 
 	// Book and market data
-	GetBookOffers(ctx context.Context, takerGets, takerPays Amount, taker, domain string, ledgerIndex string, limit uint32) (*BookOffersResult, error)
+	GetBookOffers(ctx context.Context, takerGets, takerPays Amount, taker, domain string, ledgerIndex string, limit uint32, marker string) (*BookOffersResult, error)
 
 	// Gateway operations
 	GetGatewayBalances(ctx context.Context, account string, hotWallets []string, ledgerIndex string) (*GatewayBalancesResult, error)
@@ -628,6 +628,11 @@ type BookOffersResult struct {
 	LedgerHash  [32]byte    `json:"ledger_hash"`
 	Offers      []BookOffer `json:"offers"`
 	Validated   bool        `json:"validated"`
+	// Marker is the resume token for the next page (64-hex offer index).
+	// Empty when the book has been fully walked. goXRPL extension —
+	// rippled's BookOffers handler accepts a marker parameter but never
+	// emits one.
+	Marker string `json:"marker,omitempty"`
 }
 
 // AccountTxMarker is used for pagination in account_tx

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -632,6 +632,13 @@ type BookOffersResult struct {
 	// Empty when the book has been fully walked. goXRPL extension —
 	// rippled's BookOffers handler accepts a marker parameter but never
 	// emits one.
+	//
+	// To paginate safely, callers should pin the ledger by passing
+	// ledger_index or ledger_hash on every follow-up call. The default
+	// "current" ledger advances between calls, so the offer indexed by
+	// the marker can be consumed by a concurrent transaction; the next
+	// call then returns rpcINVALID_PARAMS ("object pointed to by marker
+	// is gone").
 	Marker string `json:"marker,omitempty"`
 }
 

--- a/internal/testing/rpcenv/adapter.go
+++ b/internal/testing/rpcenv/adapter.go
@@ -328,7 +328,7 @@ func (a *ledgerAdapter) GetAccountNFTs(_ context.Context, _ string, _ string, _ 
 	return nil, errNotImplemented
 }
 
-func (a *ledgerAdapter) GetBookOffers(_ context.Context, _, _ types.Amount, _ string, _ string, _ string, _ uint32) (*types.BookOffersResult, error) {
+func (a *ledgerAdapter) GetBookOffers(_ context.Context, _, _ types.Amount, _ string, _ string, _ string, _ uint32, _ string) (*types.BookOffersResult, error) {
 	return nil, errNotImplemented
 }
 

--- a/tasks/conformance-audit.md
+++ b/tasks/conformance-audit.md
@@ -168,3 +168,19 @@ incremental reviews instead of re-reading rippled from scratch.
 - Files cleanup-only (Phase 0 skipped Phase 1): none
 - Cleanup commit: 47f442c0 — chore: clean ai-generated comments (1 paraphrase line stripped from isZeroFee; all rippled cites and non-obvious whys preserved)
 - Notes: Zero blockers and zero minors across the incremental work — all seven prior-audit follow-ups are correctly anchored to rippled, and the new tfInnerBatchTxn + NetworkID gates byte-match Transactor.cpp:46-75. The three nits are advisory: lingering ZeroAccount literals exist only at non-pseudo-tx sites (payment.go path-element XRP detection, conformance/runner.go); isZeroFee is strictly more permissive than rippled at a Go-API boundary rippled never reaches; pseudoPreclaim's structural asymmetry between ttFEE and ttAMENDMENT/ttUNL_MODIFY would benefit from a one-line comment. None gate merge.
+
+## 2026-05-22 — PR #538 — fix/issue-527-book-offers-marker
+- Rippled SHA at review: 1e89286a92
+- PR URL: https://github.com/LeJamon/go-xrpl/pull/538
+- Review comment: https://github.com/LeJamon/go-xrpl/pull/538#issuecomment-4520319673
+- Files reviewed (Phase 1):
+  - internal/ledger/service/offer_query.go — 4 Minor (M1 limit=0 emits malformed all-zero marker; M2 stale-marker conflated with malformed-marker error; M3 paginated response omits `limit` echo vs rippled account_offers; M4 marker-survival-across-ledger-advancement undocumented), 0 Blocking
+  - internal/ledger/service/offer_query_test.go — covered alongside offer_query.go
+  - internal/rpc/handlers/book_offers.go — 0 new findings (error funnel handler:195-197 correctly routes svcerr.ErrInvalidMarker → invalid_field_error("marker"))
+  - internal/rpc/ledger_adapter.go — 0 findings (interface plumbing only)
+  - internal/rpc/types/services.go — 0 findings (BookOffersResult.Marker addition; `json:"marker,omitempty"` verified absent on empty result via live verify)
+  - internal/rpc/book_offers_test.go — 3 Nit (N1 comment claims rippled rebuilds umBalance, but rippled never paginates so the rationale is mis-cited; N2 firstIteration flag is redundant; N3 samePrefix24 could use bytes.Equal)
+- Wire-shape verify pass: server booted on 127.0.0.1:5005; empty-book book_offers returns marker absent (correct, omitempty); bad-marker (4 probes: non-hex, wrong length, valid-shape-not-in-ledger, numeric) all return `Invalid field 'marker'.` matching rippled's invalid_field_error. No field-name surprises. Marker round-trip with ≥2 pages not driven (would require populating offers via standalone-mode OfferCreate).
+- Files cleanup-only (Phase 0 skipped Phase 1): none
+- Cleanup commit: 8da5b78a — chore(#527): clean ai-generated comments (-5 net lines; 1 self-contradictory test setup comment rewritten to capture actual load-bearing why; 1 redundant docstring stripped. All NetworkOPs.cpp cites, marker-divergence docs, and "wrong book" fixture intents preserved as conformance evidence)
+- Notes: PR adds marker pagination as a deliberate goXRPL extension — rippled's `book_offers` accepts the marker parameter (BookOffers.cpp:201-214) but its handler ignores it (NetworkOPs.cpp:4627) and rippled's own Book_test.cpp:1711 documents "a marker field is not returned for this method". Review judged the extension against the closest paginated rippled handler (account_offers) and against rippled's directory-walk invariants. Zero blockers; the four Minors are quality issues the user can address in-PR or as a follow-up — M1 (limit=0 → bad marker) is the most actionable, fix is gating marker emit on `hitLimit && len(offers) > 0`.


### PR DESCRIPTION
## Summary

- `book_offers` now accepts and emits a `marker` resume token so a paginated client can walk a book larger than its `limit` across multiple requests. The marker is the 64-hex `index` of the last offer returned by the previous page.
- On resume the service looks up that offer's `BookDirectory`, verifies the book base matches, skips entries within that directory up to and including the marker, then continues the existing quality-tier walk via `Succ`.
- Documented goXRPL extension. rippled's handler (`BookOffers.cpp:201-214`) accepts a `marker` parameter and threads it through to `getBookPage`, but `NetworkOPsImp::getBookPage` never reads or emits one (the result-field line at `NetworkOPs.cpp:4627` is commented out). Callers chaining requests against rippled get a single page; against goXRPL they can walk the full book.
- Bad hex, wrong length, an offer key that doesn't resolve, or a marker offer belonging to a different book all return `Invalid field 'marker'.`

## Test plan

- [x] `go test ./internal/ledger/service/...` — passes (new tests: `TestGetBookOffers_MarkerPagination`, `TestGetBookOffers_MarkerInvalid`).
- [x] `go test ./internal/rpc/...` — passes (new tests: `TestBookOffersMarkerPassthrough`, `TestBookOffersMarkerValidation`).
- [x] `go test ./internal/testing/offer/...` — passes (Offer transaction integration tests unaffected).
- [x] `go build ./...` — clean.

Fixes #527