### PR TITLE
test(book_offers): backfill conformance coverage from Book_test.cpp

### DIFF
--- a/internal/ledger/service/offer_query_test.go
+++ b/internal/ledger/service/offer_query_test.go
@@ -680,3 +680,253 @@ func TestGetBookOffers_HashFieldsAreUppercaseHex(t *testing.T) {
 	assertHash("BookDirectory", o.BookDirectory)
 	assertHash("PreviousTxnID", o.PreviousTxnID)
 }
+
+// TestGetBookOffers_TransferRateSkippedWhenTakerIsIssuer pins the carve-out at
+// rippled NetworkOPs.cpp:4569: `if (rate != parityRate && uTakerID !=
+// book.out.account && book.out.account != uOfferOwnerID)`. When the taker IS
+// the issuer of taker_gets, the transfer-fee adjustment must be skipped even
+// for a non-issuer owner with a non-parity rate — `taker_gets_funded` stays
+// equal to taker_gets.
+func TestGetBookOffers_TransferRateSkippedWhenTakerIsIssuer(t *testing.T) {
+	svc := newOfferTestService(t)
+
+	issuerAddr, _ := addressFromBytes(t, 0xC0)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 1_200_000_000)
+
+	ownerAddr, _ := addressFromBytes(t, 0xC2)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+	insertTrustLine(t, svc, ownerAddr, issuerAddr, "USD", "100")
+
+	insertOffer(t, svc, ownerAddr, 1,
+		tx.NewXRPAmount(10_000_000),
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+	)
+
+	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
+	xrpModel := tx.NewXRPAmount(0)
+	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, issuerAddr, "", "current", 10)
+	if err != nil {
+		t.Fatalf("GetBookOffers: %v", err)
+	}
+	if len(result.Offers) != 1 {
+		t.Fatalf("expected 1 offer, got %d", len(result.Offers))
+	}
+	o := result.Offers[0]
+	if o.TakerGetsFunded != nil || o.TakerPaysFunded != nil {
+		t.Errorf("taker==issuer must skip the rate adjustment, got gets=%v pays=%v",
+			o.TakerGetsFunded, o.TakerPaysFunded)
+	}
+}
+
+// TestGetBookOffers_TransferRateAcrossOwners covers the multi-issuer angle: two
+// distinct non-issuer owners, each with a balance equal to the offer face
+// value, both reduced by the same issuer transfer rate. The running-balance
+// map only suppresses owner_funds on a second offer from the SAME owner, so
+// both owners must surface owner_funds AND both must be reported partially
+// funded.
+func TestGetBookOffers_TransferRateAcrossOwners(t *testing.T) {
+	svc := newOfferTestService(t)
+
+	issuerAddr, _ := addressFromBytes(t, 0xD0)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 1_200_000_000)
+
+	owner1Addr, _ := addressFromBytes(t, 0xD2)
+	insertAccountRoot(t, svc, owner1Addr, 1_000_000_000_000, 0)
+	insertTrustLine(t, svc, owner1Addr, issuerAddr, "USD", "100")
+
+	owner2Addr, _ := addressFromBytes(t, 0xD4)
+	insertAccountRoot(t, svc, owner2Addr, 1_000_000_000_000, 0)
+	insertTrustLine(t, svc, owner2Addr, issuerAddr, "USD", "100")
+
+	insertOffer(t, svc, owner1Addr, 1,
+		tx.NewXRPAmount(10_000_000),
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+	)
+	insertOffer(t, svc, owner2Addr, 1,
+		tx.NewXRPAmount(20_000_000),
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+	)
+
+	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
+	xrpModel := tx.NewXRPAmount(0)
+	// Pass a third-party taker so the issuer-skip carve-out doesn't kick in.
+	thirdParty, _ := addressFromBytes(t, 0xDE)
+	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, thirdParty, "", "current", 10)
+	if err != nil {
+		t.Fatalf("GetBookOffers: %v", err)
+	}
+	if len(result.Offers) != 2 {
+		t.Fatalf("expected 2 offers, got %d", len(result.Offers))
+	}
+	for i, o := range result.Offers {
+		if o.OwnerFunds == "" {
+			t.Errorf("offer %d: distinct owners must each emit owner_funds, got empty", i)
+		}
+		if o.TakerGetsFunded == nil || o.TakerPaysFunded == nil {
+			t.Errorf("offer %d: rate-adjusted offer must be reported partially funded", i)
+		}
+	}
+}
+
+// TestGetBookOffers_BothSidesFrozen pins the `||` in
+// `bGlobalFreeze := IsGlobalFrozen(takerGets.Issuer) || IsGlobalFrozen(takerPays.Issuer)`
+// (offer_query.go:85-86). Freezing the takerPays issuer must also trip the
+// freeze branch even though the offer's owner has plenty of takerGets.
+func TestGetBookOffers_BothSidesFrozen(t *testing.T) {
+	svc := newOfferTestService(t)
+
+	getsIssuerAddr, _ := addressFromBytes(t, 0xE0)
+	insertAccountRoot(t, svc, getsIssuerAddr, 1_000_000_000_000, 0)
+	paysIssuerAddr, _ := addressFromBytes(t, 0xE2)
+	insertAccountRootWithFlags(t, svc, paysIssuerAddr, 1_000_000_000_000, 0, state.LsfGlobalFreeze)
+
+	ownerAddr, _ := addressFromBytes(t, 0xE4)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+	insertTrustLine(t, svc, ownerAddr, getsIssuerAddr, "USD", "1000")
+
+	insertOffer(t, svc, ownerAddr, 1,
+		state.NewIssuedAmountFromFloat64(50, "EUR", paysIssuerAddr),
+		state.NewIssuedAmountFromFloat64(100, "USD", getsIssuerAddr),
+	)
+
+	usd := state.NewIssuedAmountFromFloat64(0, "USD", getsIssuerAddr)
+	eur := state.NewIssuedAmountFromFloat64(0, "EUR", paysIssuerAddr)
+	result, err := svc.GetBookOffers(context.Background(), usd, eur, "", "", "current", 10)
+	if err != nil {
+		t.Fatalf("GetBookOffers: %v", err)
+	}
+	if len(result.Offers) != 1 {
+		t.Fatalf("expected 1 offer, got %d", len(result.Offers))
+	}
+	o := result.Offers[0]
+	if o.OwnerFunds != "0" {
+		t.Errorf("pays-side global freeze must report owner_funds=\"0\", got %q", o.OwnerFunds)
+	}
+	if o.TakerGetsFunded == nil || o.TakerPaysFunded == nil {
+		t.Errorf("pays-side global freeze must emit zeroed *_funded fields")
+	}
+}
+
+// TestGetBookOffers_FrozenIssuerDistinctFromOwner verifies the freeze branch
+// when the offer owner is NOT the frozen issuer — the third party with a
+// healthy USD trustline must still be reported unfunded because the issuer of
+// taker_gets is globally frozen. This pins NetworkOPs.cpp:4522-4527 against a
+// regression that might key the freeze branch off the owner instead of the
+// issuer.
+func TestGetBookOffers_FrozenIssuerDistinctFromOwner(t *testing.T) {
+	svc := newOfferTestService(t)
+
+	issuerAddr, _ := addressFromBytes(t, 0xF0)
+	insertAccountRootWithFlags(t, svc, issuerAddr, 1_000_000_000_000, 0, state.LsfGlobalFreeze)
+
+	ownerAddr, _ := addressFromBytes(t, 0xF2)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+	insertTrustLine(t, svc, ownerAddr, issuerAddr, "USD", "1000")
+
+	insertOffer(t, svc, ownerAddr, 1,
+		tx.NewXRPAmount(10_000_000),
+		state.NewIssuedAmountFromFloat64(50, "USD", issuerAddr),
+	)
+
+	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
+	xrpModel := tx.NewXRPAmount(0)
+	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, "", "", "current", 10)
+	if err != nil {
+		t.Fatalf("GetBookOffers: %v", err)
+	}
+	if len(result.Offers) != 1 {
+		t.Fatalf("expected 1 offer, got %d", len(result.Offers))
+	}
+	o := result.Offers[0]
+	if o.Account != ownerAddr {
+		t.Fatalf("unexpected offer owner %s", o.Account)
+	}
+	if o.OwnerFunds != "0" {
+		t.Errorf("frozen issuer (distinct from owner) must report owner_funds=\"0\", got %q", o.OwnerFunds)
+	}
+}
+
+// TestGetBookOffers_MultiOwnerDrainsTrustline mirrors rippled's nFundedFunded
+// scenario: two distinct non-issuer owners both holding the same issuer's
+// trust line, each placing offers in the same book. Owners are independent
+// for funding purposes — running-balance suppression is keyed on owner, so
+// each owner reports its own owner_funds independently, and each owner's
+// second offer reuses the running balance from its first.
+func TestGetBookOffers_MultiOwnerDrainsTrustline(t *testing.T) {
+	svc := newOfferTestService(t)
+
+	issuerAddr, _ := addressFromBytes(t, 0xA8)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+
+	aliceAddr, _ := addressFromBytes(t, 0xAA)
+	insertAccountRoot(t, svc, aliceAddr, 1_000_000_000_000, 0)
+	insertTrustLine(t, svc, aliceAddr, issuerAddr, "USD", "60")
+
+	bobAddr, _ := addressFromBytes(t, 0xAC)
+	insertAccountRoot(t, svc, bobAddr, 1_000_000_000_000, 0)
+	insertTrustLine(t, svc, bobAddr, issuerAddr, "USD", "30")
+
+	// Alice: two offers selling 50 USD then 20 USD — total > balance so the
+	// second offer must come back partially funded.
+	insertOffer(t, svc, aliceAddr, 1,
+		tx.NewXRPAmount(10_000_000),
+		state.NewIssuedAmountFromFloat64(50, "USD", issuerAddr),
+	)
+	insertOffer(t, svc, aliceAddr, 2,
+		tx.NewXRPAmount(20_000_000),
+		state.NewIssuedAmountFromFloat64(20, "USD", issuerAddr),
+	)
+	// Bob: one fully-funded offer at a different price.
+	insertOffer(t, svc, bobAddr, 1,
+		tx.NewXRPAmount(15_000_000),
+		state.NewIssuedAmountFromFloat64(25, "USD", issuerAddr),
+	)
+
+	usd := state.NewIssuedAmountFromFloat64(0, "USD", issuerAddr)
+	xrpModel := tx.NewXRPAmount(0)
+	result, err := svc.GetBookOffers(context.Background(), usd, xrpModel, "", "", "current", 10)
+	if err != nil {
+		t.Fatalf("GetBookOffers: %v", err)
+	}
+	if len(result.Offers) != 3 {
+		t.Fatalf("expected 3 offers, got %d", len(result.Offers))
+	}
+
+	var aliceOffers, bobOffers []BookOffer
+	for _, o := range result.Offers {
+		switch o.Account {
+		case aliceAddr:
+			aliceOffers = append(aliceOffers, o)
+		case bobAddr:
+			bobOffers = append(bobOffers, o)
+		}
+	}
+	if len(aliceOffers) != 2 || len(bobOffers) != 1 {
+		t.Fatalf("offer attribution mismatch: alice=%d bob=%d", len(aliceOffers), len(bobOffers))
+	}
+	// Alice's first offer (best price): owner_funds present, fully funded.
+	if aliceOffers[0].OwnerFunds == "" {
+		t.Errorf("alice[0] should emit owner_funds, got empty")
+	}
+	if aliceOffers[0].TakerGetsFunded != nil {
+		t.Errorf("alice[0] should be fully funded, got gets_funded=%v", aliceOffers[0].TakerGetsFunded)
+	}
+	// Alice's second offer: owner_funds omitted (running balance), partially
+	// funded (60 USD trust line - 50 USD consumed = 10 USD left for a 20 USD offer).
+	if aliceOffers[1].OwnerFunds != "" {
+		t.Errorf("alice[1] should omit owner_funds (running balance), got %q", aliceOffers[1].OwnerFunds)
+	}
+	if aliceOffers[1].TakerGetsFunded == nil || aliceOffers[1].TakerPaysFunded == nil {
+		t.Errorf("alice[1] must report partial funding, got gets=%v pays=%v",
+			aliceOffers[1].TakerGetsFunded, aliceOffers[1].TakerPaysFunded)
+	}
+	// Bob's offer: owner_funds present (different owner), fully funded against
+	// his own 30 USD trustline.
+	if bobOffers[0].OwnerFunds == "" {
+		t.Errorf("bob's offer should emit owner_funds (distinct owner), got empty")
+	}
+	if bobOffers[0].TakerGetsFunded != nil {
+		t.Errorf("bob's 25 USD offer is below his 30 USD trustline; expected fully funded, got gets_funded=%v",
+			bobOffers[0].TakerGetsFunded)
+	}
+}

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
@@ -15,7 +16,8 @@ import (
 // bookOffersMock wraps mockLedgerService to provide custom GetBookOffers behavior
 type bookOffersMock struct {
 	*mockLedgerService
-	getBookOffersFn func(takerGets, takerPays types.Amount, taker, domain, ledgerIndex string, limit uint32) (*types.BookOffersResult, error)
+	getBookOffersFn   func(takerGets, takerPays types.Amount, taker, domain, ledgerIndex string, limit uint32) (*types.BookOffersResult, error)
+	getLedgerByHashFn func(hash [32]byte) (types.LedgerReader, error)
 }
 
 func (m *bookOffersMock) GetBookOffers(_ context.Context, takerGets, takerPays types.Amount, taker, domain, ledgerIndex string, limit uint32) (*types.BookOffersResult, error) {
@@ -34,6 +36,16 @@ func (m *bookOffersMock) GetLedgerBySequence(seq uint32) (types.LedgerReader, er
 		return nil, errors.New("ledger not found")
 	}
 	return &stubLedgerReader{seq: seq}, nil
+}
+
+// GetLedgerByHash mirrors the rippled BookOffers.cpp:45-49 pre-resolve path.
+// Returns a stub reader when the test installs a custom `getLedgerByHashFn`,
+// otherwise reports "not found" so unmatched hashes surface lgrNotFound.
+func (m *bookOffersMock) GetLedgerByHash(hash [32]byte) (types.LedgerReader, error) {
+	if m.getLedgerByHashFn != nil {
+		return m.getLedgerByHashFn(hash)
+	}
+	return nil, errors.New("ledger not found")
 }
 
 func newBookOffersMock() *bookOffersMock {
@@ -1367,4 +1379,295 @@ func TestBookOffersNilOffersArray(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, resp, "offers", "Response must contain offers key even when nil")
+}
+
+// TestBookOffersLimitClampingConformance pins the rippled
+// `readLimitField(rmin=0, rdefault=60, rmax=100)` semantics from
+// RPCHelpers.cpp:703-712, exercised by Book_test.cpp testBookOfferLimits.
+// Non-admin (Unlimited=false) callers see the value clamped into [0, 100];
+// admin/unlimited callers (Unlimited=true) bypass the upper bound entirely.
+// The existing TestBookOffersLimitParameter covers the lower end (0 / default
+// / small values); this case nails down the upper-bound clamp and the
+// asAdmin=true bypass — the part of testBookOfferLimits that varies behaviour
+// based on role.
+func TestBookOffersLimitClampingConformance(t *testing.T) {
+	mock := newBookOffersMock()
+	services := newBookOffersTestServices(mock)
+	method := &handlers.BookOffersMethod{}
+
+	var capturedLimit uint32
+	mock.getBookOffersFn = func(_, _ types.Amount, _, _, _ string, limit uint32) (*types.BookOffersResult, error) {
+		capturedLimit = limit
+		return &types.BookOffersResult{LedgerIndex: 2, Offers: []types.BookOffer{}, Validated: true}, nil
+	}
+
+	tests := []struct {
+		name          string
+		role          types.Role
+		unlimited     bool
+		limit         interface{}
+		expectedLimit uint32
+	}{
+		{
+			// Book_test.cpp:1713-1716 — explicit 0 stays 0 for either role.
+			name:          "limit 0 (admin)",
+			role:          types.RoleAdmin,
+			unlimited:     true,
+			limit:         0,
+			expectedLimit: 0,
+		},
+		{
+			// Book_test.cpp:1718-1723 — limit rmax+1 (101) clamps to rmax (100)
+			// for non-admin callers (asAdmin=false branch).
+			name:          "rmax+1 clamps to rmax for guest",
+			role:          types.RoleGuest,
+			unlimited:     false,
+			limit:         101,
+			expectedLimit: 100,
+		},
+		{
+			// Book_test.cpp:1718-1723 — same value passes through for admin
+			// (asAdmin=true branch).
+			name:          "rmax+1 passes through for admin",
+			role:          types.RoleAdmin,
+			unlimited:     true,
+			limit:         101,
+			expectedLimit: 101,
+		},
+		{
+			// Far-above-rmax for non-admin still clamps to rmax — the clamp
+			// is unconditional, not a "soft" hint.
+			name:          "large limit clamps to rmax for guest",
+			role:          types.RoleGuest,
+			unlimited:     false,
+			limit:         100000,
+			expectedLimit: 100,
+		},
+		{
+			// Book_test.cpp:1725-1730 — null/omitted limit yields rdefault (60)
+			// for either role.
+			name:          "omitted limit yields default for admin",
+			role:          types.RoleAdmin,
+			unlimited:     true,
+			limit:         nil,
+			expectedLimit: 60,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			capturedLimit = 0
+			ctx := &types.RpcContext{
+				Context:    context.Background(),
+				Role:       tc.role,
+				Unlimited:  tc.unlimited,
+				ApiVersion: types.ApiVersion1,
+				Services:   services,
+			}
+			params := map[string]interface{}{
+				"taker_pays": map[string]interface{}{"currency": "XRP"},
+				"taker_gets": map[string]interface{}{
+					"currency": "USD",
+					"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				},
+			}
+			if tc.limit != nil {
+				params["limit"] = tc.limit
+			}
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			require.Nil(t, rpcErr, "Expected no RPC error, got: %v", rpcErr)
+			require.NotNil(t, result)
+			assert.Equal(t, tc.expectedLimit, capturedLimit,
+				"Limit passed to service should match clamp/passthrough rule")
+		})
+	}
+}
+
+// TestBookOffersTakerXAddressRejected nails down that the `taker` field rejects
+// X-addresses. rippled BookOffers.cpp:170 calls `parseBase58<AccountID>(taker)`
+// which only accepts classic addresses (X-address parsing is a separate code
+// path it never invokes). goxrpld mirrors this via
+// DecodeClassicAddressToAccountID, which fails on the "X" / "T" prefix.
+// Pinning this behaviour with a real X-address row prevents a regression that
+// might silently accept X-addresses and resolve them to their classic form —
+// a no-op for mainnet but an information-leak for testnet/tags.
+func TestBookOffersTakerXAddressRejected(t *testing.T) {
+	mock := newBookOffersMock()
+	services := newBookOffersTestServices(mock)
+	method := &handlers.BookOffersMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	tests := []struct {
+		name  string
+		taker string
+	}{
+		// Standard mainnet X-address (no tag).
+		{name: "mainnet X-address", taker: "X7AcgcsBL6XDcUb289X4mJ8djcdyKaB5hJDWMArnXr61cqZ"},
+		// Testnet T-address.
+		{name: "testnet T-address", taker: "T7v6j4nJpDtCT6F6tWzCcdpHGiE2qLeUFG29CnFmaR7Pj1J"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]interface{}{
+				"taker_pays": map[string]interface{}{"currency": "XRP"},
+				"taker_gets": map[string]interface{}{
+					"currency": "USD",
+					"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				},
+				"taker": tc.taker,
+			}
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			assert.Nil(t, result)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code,
+				"X-address taker must surface invalidParams")
+			assert.Contains(t, rpcErr.Message, "Invalid field 'taker'",
+				"error message should match rippled BookOffers.cpp:172")
+		})
+	}
+}
+
+// TestBookOffersLedgerHashBranches exercises the three rippled
+// RPC::lookupLedger outcomes for `ledger_hash` (BookOffers.cpp:45-49 →
+// LookupLedger):
+//   - malformed (non-hex or wrong length) → invalidParams "ledgerHashMalformed"
+//   - well-formed but not found             → lgrNotFound "ledgerNotFound"
+//   - well-formed and found                 → falls through to per-field validation
+//
+// The pre-resolve happens BEFORE taker_pays/taker_gets validation, so a
+// malformed ledger_hash combined with missing taker_pays must still surface
+// the ledger_hash error first — matching the M2 path proven for ledger_index
+// elsewhere in this file.
+func TestBookOffersLedgerHashBranches(t *testing.T) {
+	mock := newBookOffersMock()
+	services := newBookOffersTestServices(mock)
+	method := &handlers.BookOffersMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	// Stub a "found" ledger only for one specific hash — every other valid hex
+	// hash falls through to the "not found" branch.
+	const foundHashHex = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652"
+	var foundHash [32]byte
+	for i := 0; i < 32; i++ {
+		_, _ = fmt.Sscanf(foundHashHex[i*2:i*2+2], "%x", &foundHash[i])
+	}
+	mock.getLedgerByHashFn = func(hash [32]byte) (types.LedgerReader, error) {
+		if hash == foundHash {
+			return &stubLedgerReader{seq: 2}, nil
+		}
+		return nil, errors.New("ledger not found")
+	}
+	mock.getBookOffersFn = func(_, _ types.Amount, _, _, _ string, _ uint32) (*types.BookOffersResult, error) {
+		return &types.BookOffersResult{LedgerIndex: 2, Offers: []types.BookOffer{}, Validated: true}, nil
+	}
+
+	t.Run("malformed ledger_hash returns ledgerHashMalformed", func(t *testing.T) {
+		// 63 hex chars (one short) — wrong length, hex.DecodeString won't even
+		// try (we return the message early on length mismatch).
+		params := map[string]interface{}{
+			"ledger_hash": "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A65",
+			"taker_pays":  map[string]interface{}{"currency": "XRP"},
+			"taker_gets": map[string]interface{}{
+				"currency": "USD",
+				"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Contains(t, rpcErr.Message, "ledgerHashMalformed",
+			"malformed length must surface ledgerHashMalformed")
+	})
+
+	t.Run("malformed ledger_hash pre-empts missing-field errors", func(t *testing.T) {
+		// Wrong length + missing taker_pays. rippled checks lookupLedger
+		// BEFORE taker_pays validation, so the ledger error must win.
+		params := map[string]interface{}{
+			"ledger_hash": "DEADBEEF",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Contains(t, rpcErr.Message, "ledgerHashMalformed")
+	})
+
+	t.Run("non-hex ledger_hash returns ledgerHashMalformed", func(t *testing.T) {
+		// Length-64 but contains non-hex characters.
+		params := map[string]interface{}{
+			"ledger_hash": "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+			"taker_pays":  map[string]interface{}{"currency": "XRP"},
+			"taker_gets": map[string]interface{}{
+				"currency": "USD",
+				"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Contains(t, rpcErr.Message, "ledgerHashMalformed")
+	})
+
+	t.Run("valid ledger_hash not found returns lgrNotFound", func(t *testing.T) {
+		// Length-64, valid hex, but not the hash the mock stubs as found.
+		params := map[string]interface{}{
+			"ledger_hash": "0000000000000000000000000000000000000000000000000000000000000001",
+			"taker_pays":  map[string]interface{}{"currency": "XRP"},
+			"taker_gets": map[string]interface{}{
+				"currency": "USD",
+				"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcLGR_NOT_FOUND, rpcErr.Code)
+		assert.Contains(t, rpcErr.Message, "ledgerNotFound")
+	})
+
+	t.Run("valid ledger_hash found falls through to query", func(t *testing.T) {
+		params := map[string]interface{}{
+			"ledger_hash": foundHashHex,
+			"taker_pays":  map[string]interface{}{"currency": "XRP"},
+			"taker_gets": map[string]interface{}{
+				"currency": "USD",
+				"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			},
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr, "found hash should pass pre-resolve; got %v", rpcErr)
+		require.NotNil(t, result)
+	})
 }

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -561,6 +561,83 @@ func TestSubscribeBooksInvalidCurrency(t *testing.T) {
 	}
 }
 
+// TestSubscribeBooksCrossConformanceWithBookOffers pins the validation
+// surface that subscribe.cpp shares with book_offers (rippled
+// Subscribe.cpp:188-225 → makeBookSpec → BookOffers.cpp:51-199). The two RPCs
+// must reject the same malformed currency / issuer / market shapes, otherwise
+// a subscribe books request can succeed against an order book that book_offers
+// would refuse to query.
+//
+// Subtests marked t.Skip document the cross-conformance gaps that still need
+// to be plugged in subscription.Manager — they're left wired up so the day
+// the gap closes, the skip can simply be removed.
+func TestSubscribeBooksCrossConformanceWithBookOffers(t *testing.T) {
+	type bookSpec struct {
+		takerPays map[string]interface{}
+		takerGets map[string]interface{}
+	}
+	tests := []struct {
+		name     string
+		skipNote string
+		book     bookSpec
+	}{
+		{
+			// Book_test.cpp:1606-1618 — book_offers returns badMarket.
+			// subscribe.cpp:200 normalises both sides via makeBookSpec and
+			// would refuse this market. goxrpl's subscribe manager does NOT
+			// check this yet (#533 follow-up).
+			name:     "same currency and issuer is badMarket",
+			skipNote: "subscribe.Manager does not yet enforce badMarket (#533 follow-up)",
+			book: bookSpec{
+				takerPays: map[string]interface{}{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+				takerGets: map[string]interface{}{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			},
+		},
+		{
+			// Book_test.cpp:1547-1561 — book_offers refuses XRP currency with a
+			// non-XRP issuer ("Unneeded field 'taker_pays.issuer'").
+			name:     "XRP pay with non-XRP issuer is unneeded",
+			skipNote: "subscribe.Manager treats XRP+issuer as a valid IOU (#533 follow-up)",
+			book: bookSpec{
+				takerPays: map[string]interface{}{"currency": "XRP", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+				takerGets: map[string]interface{}{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			},
+		},
+		{
+			// Book_test.cpp:1505-1517 — ACCOUNT_ONE (noAccount sentinel) is
+			// rejected by book_offers with rpcSRC_ISR_MALFORMED.
+			name:     "ACCOUNT_ONE issuer is rejected",
+			skipNote: "subscribe.Manager does not yet refuse noAccount() sentinel (#533 follow-up)",
+			book: bookSpec{
+				takerPays: map[string]interface{}{"currency": "USD", "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"},
+				takerGets: map[string]interface{}{"currency": "EUR", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skipNote != "" {
+				t.Skip(tc.skipNote)
+			}
+			sm := newTestSubscriptionManager()
+			conn := newTestConnection("test-conn-1")
+			sm.AddConnection(conn)
+
+			takerPays, _ := json.Marshal(tc.book.takerPays)
+			takerGets, _ := json.Marshal(tc.book.takerGets)
+
+			request := types.SubscriptionRequest{
+				Books: []types.BookRequest{
+					{TakerPays: takerPays, TakerGets: takerGets},
+				},
+			}
+			err := sm.HandleSubscribe(conn, request, true)
+			require.NotNil(t, err, "subscribe should reject the same malformed shape book_offers refuses")
+		})
+	}
+}
+
 // TestSubscribeBooksMultiple tests subscribing to multiple order books
 func TestSubscribeBooksMultiple(t *testing.T) {
 	sm := newTestSubscriptionManager()


### PR DESCRIPTION
## Summary
- Backfills the missing rippled `Book_test.cpp` scenarios called out in the PR #492 conformance review.
- Service-level (`internal/ledger/service/offer_query_test.go`): transfer-rate carve-out when `taker == issuer`, multi-issuer rate adjustment across distinct owners, both-sides global freeze, frozen-issuer ≠ owner, multi-owner trustline draining (nFundedFunded).
- Handler-level (`internal/rpc/book_offers_test.go`): `testBookOfferLimits` clamping at `rmin / rmax / rdefault` across `Unlimited` true/false, X-address rejection on `taker`, three `ledger_hash` branches (malformed / valid-not-found / valid-found).
- Subscribe books cross-conformance (`internal/rpc/subscribe_test.go`): documents the still-open gaps with `book_offers` (badMarket, XRP+issuer, ACCOUNT_ONE) as `t.Skip` rows with explicit pointers, so the suite flips on for free once the subscription manager catches up to rippled's `makeBookSpec`.

## Test plan
- [x] `go test ./internal/ledger/service/...`
- [x] `go test ./internal/rpc/...`
- [x] `go vet ./internal/ledger/service/... ./internal/rpc/...`
- [x] `gofmt -l` (clean)
- [x] `go build ./...` (full module compile)

Fixes #533