### PR TITLE
fix(fees,txq): close residual gaps from #501 review

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -256,6 +256,19 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			OpenLedgerFeeLevel:    m.OpenLedgerFeeLevel,
 		}
 	}
+	services.TxQFeeMetrics = func() types.TxQFeeMetrics {
+		m := ledgerSvcRef.GetTxQMetrics()
+		return types.TxQFeeMetrics{
+			TxCount:               m.TxCount,
+			TxQMaxSize:            m.TxQMaxSize,
+			TxInLedger:            m.TxInLedger,
+			TxPerLedger:           m.TxPerLedger,
+			ReferenceFeeLevel:     m.ReferenceFeeLevel,
+			MinProcessingFeeLevel: m.MinProcessingFeeLevel,
+			MedFeeLevel:           m.MedFeeLevel,
+			OpenLedgerFeeLevel:    m.OpenLedgerFeeLevel,
+		}
+	}
 
 	// LoadFactorFees surfaces the local/net/cluster fee factors that
 	// drive the admin-only human-mode load_factor_local / load_factor_net /

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1508,13 +1508,20 @@ func (a *Adaptor) StateAccounting() StateAccountingSnapshot {
 // is reached — see OnLedgerFullyValidated, driven by the engine's
 // ValidationTracker. This matches rippled's checkAccept() semantics
 // where local consensus != network agreement.
-func (a *Adaptor) OnConsensusReached(ledger consensus.Ledger, validations []*consensus.Validation) {
+func (a *Adaptor) OnConsensusReached(ledger consensus.Ledger, validations []*consensus.Validation, roundTime time.Duration) {
 	a.logger.Info("Consensus reached",
 		"ledger_seq", ledger.Seq(),
 		"validations", len(validations),
+		"round_time", roundTime,
 	)
 
 	if a.ledgerService != nil {
+		// Mirror rippled RCLConsensus.cpp:803-805: pass the round's
+		// wall-clock duration into the ledger service so the TxQ's
+		// processClosedLedger sees the timeLeap flag when consensus
+		// crossed the 5s slow-consensus threshold.
+		a.ledgerService.SetLastConsensusRoundTime(roundTime)
+
 		if hooks := a.ledgerService.GetEventHooks(); hooks != nil && hooks.OnConsensusPhase != nil {
 			go hooks.OnConsensusPhase("accepted")
 		}

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -533,7 +533,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a := newTestAdaptor(t)
 		a.SetOperatingMode(consensus.OpModeConnected)
 		l := stubLedger{seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
 	})
 
@@ -542,7 +542,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a.SetOperatingMode(consensus.OpModeSyncing)
 		// CloseTime far in the past — outside the 2*resolution window.
 		l := stubLedger{seq: 3, closeTime: a.Now().Add(-10 * time.Minute)}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeTracking, a.GetOperatingMode())
 	})
 
@@ -550,7 +550,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a := newTestAdaptor(t)
 		a.SetOperatingMode(consensus.OpModeTracking)
 		l := stubLedger{seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
 	})
 
@@ -558,7 +558,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a := newTestAdaptor(t)
 		a.SetOperatingMode(consensus.OpModeDisconnected)
 		l := stubLedger{seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeDisconnected, a.GetOperatingMode(),
 			"Disconnected must stay Disconnected — no peers means no consensus, "+
 				"and a stale lingering callback must not bypass the peer-count gate")
@@ -568,7 +568,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a := newTestAdaptor(t)
 		a.SetOperatingMode(consensus.OpModeFull)
 		l := stubLedger{seq: 3, closeTime: a.Now().Add(-10 * time.Minute)}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode(),
 			"once Full, OnConsensusReached must not demote — demotions are "+
 				"driven by wrongLedger/peer-disconnect paths, not by close-time freshness")
@@ -587,7 +587,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a.UpdatePeerLCL(2, theirLCL)
 		a.UpdatePeerLCL(3, ourLCL)
 		l := stubLedger{id: ourLCL, seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeConnected, a.GetOperatingMode(),
 			"majority-disagreeing peer LCLs must defer promotion (proxy for rippled !ledgerChange)")
 	})
@@ -599,7 +599,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a := newTestAdaptor(t)
 		a.SetOperatingMode(consensus.OpModeConnected)
 		l := stubLedger{id: consensus.LedgerID{0xAA}, seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode(),
 			"with no peer LCL evidence, promotion proceeds — the genesis-bootstrap path")
 	})
@@ -614,7 +614,7 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		a.UpdatePeerLCL(2, ourLCL)
 		a.UpdatePeerLCL(3, theirLCL)
 		l := stubLedger{id: ourLCL, seq: 3, closeTime: a.Now()}
-		a.OnConsensusReached(l, nil)
+		a.OnConsensusReached(l, nil, 0)
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode(),
 			"peer LCL majority agreement permits promotion")
 	})

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -309,8 +309,11 @@ type StatusEvents interface {
 
 	// OnConsensusReached is called when a round completes successfully.
 	// Fires at local-accept time. It does NOT mean the network has
-	// agreed — see OnLedgerFullyValidated.
-	OnConsensusReached(ledger Ledger, validations []*Validation)
+	// agreed — see OnLedgerFullyValidated. roundTime is the wall-clock
+	// duration the just-finished consensus round took, used to drive
+	// the TxQ slow-consensus timeLeap flag (rippled
+	// RCLConsensus.cpp:803-805).
+	OnConsensusReached(ledger Ledger, validations []*Validation, roundTime time.Duration)
 
 	// OnLedgerFullyValidated is called once per ledger the first time
 	// trusted validations for that ledger cross the quorum threshold.

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -3068,8 +3068,15 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 		}
 	}
 
+	// Capture roundTime BEFORE notifying the adaptor so it sees the
+	// current round's duration, not the previous round's stale value
+	// in e.prevRoundTime (which is updated below). Mirrors rippled
+	// RCLConsensus.cpp:803-805 where roundTime is the local
+	// wall-clock measurement passed inline to processClosedLedger.
+	roundTime := time.Since(e.roundStartTime)
+
 	// Notify adaptor
-	e.adaptor.OnConsensusReached(newLedger, validations)
+	e.adaptor.OnConsensusReached(newLedger, validations, roundTime)
 
 	// Emit ledger accepted event
 	e.eventBus.Publish(&consensus.LedgerAcceptedEvent{
@@ -3111,7 +3118,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	}
 
 	// Track round time for convergePercent calculation
-	e.prevRoundTime = time.Since(e.roundStartTime)
+	e.prevRoundTime = roundTime
 
 	// Track trusted proposer count for peer pressure in next round
 	trustedCount := 0

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -535,7 +535,7 @@ func (a *mockAdaptor) CloseTimeResolution() time.Duration {
 
 func (a *mockAdaptor) AdjustCloseTime(rawCloseTimes consensus.CloseTimes) {}
 
-func (a *mockAdaptor) OnConsensusReached(ledger consensus.Ledger, validations []*consensus.Validation) {
+func (a *mockAdaptor) OnConsensusReached(ledger consensus.Ledger, validations []*consensus.Validation, roundTime time.Duration) {
 }
 
 func (a *mockAdaptor) OnLedgerFullyValidated(ledgerID consensus.LedgerID, seq uint32) {

--- a/internal/ledger/openledger/apply.go
+++ b/internal/ledger/openledger/apply.go
@@ -75,6 +75,12 @@ type ApplyConfig struct {
 	// previousLedger->rules() and threads it through; no equivalent
 	// "all-on" fallback exists there.
 	Rules *amendment.Rules
+	// ApplyFlags is the engine ApplyFlags driving this submission.
+	// Mirrors rippled NetworkOPs::apply which threads its flags into
+	// TxQ::canBeHeld (TxQ.cpp:393-399 rejects tapFAIL_HARD).
+	// Default zero — fail_hard rejection only fires when callers
+	// explicitly set the bit.
+	ApplyFlags tx.ApplyFlags
 }
 
 // ApplyTxs runs rippled's open-ledger 3-pass apply against view, which

--- a/internal/ledger/openledger/txqadapter.go
+++ b/internal/ledger/openledger/txqadapter.go
@@ -33,6 +33,14 @@ func NewTxqAdapter(view *ledger.Ledger, cfg ApplyConfig) *TxqAdapter {
 	return &TxqAdapter{view: view, cfg: cfg}
 }
 
+// GetApplyFlags returns the ApplyFlags the caller bound into the
+// per-submission ApplyConfig. Lets TxQ honour rippled's tapFAIL_HARD
+// gate (TxQ.cpp:393-399) without taking a direct dependency on
+// tx.EngineConfig from the queue.
+func (a *TxqAdapter) GetApplyFlags() tx.ApplyFlags {
+	return a.cfg.ApplyFlags
+}
+
 func (a *TxqAdapter) GetLedgerSequence() uint32 {
 	if a.view == nil {
 		return 0

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -261,6 +261,13 @@ type Service struct {
 	//     ingress via the clusterFeeSink hook wired in cli/server.go
 	//     (mirrors PeerImp.cpp:1175-1193).
 	feeTrack *feetrack.LoadFeeTrack
+
+	// lastConsensusRoundTime is the wall-clock duration of the most
+	// recent consensus round, populated by the consensus adaptor via
+	// SetLastConsensusRoundTime. processClosedLedgerLocked converts
+	// it to the TxQ's timeLeap flag (RCLConsensus.cpp:805 →
+	// FeeMetrics::update). Zero in standalone or pre-startup.
+	lastConsensusRoundTime time.Duration
 }
 
 // SubmittedTxEvent carries the inputs the WebSocket transactions_proposed
@@ -526,17 +533,35 @@ func (c *closedLedgerCtx) GetTransactionFeeLevels() []txq.FeeLevel {
 }
 
 // processClosedLedgerLocked updates the TxQ's fee metrics from the
-// just-closed ledger. timeLeap mirrors rippled's slow-consensus flag —
-// always false here (we don't currently track consensus duration).
-// Caller must hold s.mu.
+// just-closed ledger. timeLeap mirrors rippled RCLConsensus.cpp:805's
+// `roundTime > 5s` flag — when consensus took longer than the
+// slow-consensus threshold the metrics window is clamped instead of
+// advanced. Caller must hold s.mu.
 func (s *Service) processClosedLedgerLocked() {
 	if s.txQueue == nil || s.closedLedger == nil {
 		return
 	}
 	baseFee, _, _ := readFeesFromLedger(s.closedLedger)
 	ctx := &closedLedgerCtx{ledger: s.closedLedger, baseFee: baseFee}
-	s.txQueue.ProcessClosedLedger(ctx, false)
+	s.txQueue.ProcessClosedLedger(ctx, s.lastConsensusRoundTime > slowConsensusThreshold)
 	s.tickLoadFeeLocked()
+}
+
+// slowConsensusThreshold matches rippled's `roundTime > 5s` predicate
+// at RCLConsensus.cpp:805 — the TxQ treats anything past it as a
+// slow-consensus round and freezes the fee-escalation window instead
+// of opening it further.
+const slowConsensusThreshold = 5 * time.Second
+
+// SetLastConsensusRoundTime is called by the consensus adaptor at the
+// end of each round to inform the service how long consensus took.
+// processClosedLedgerLocked reads the value to set the TxQ's timeLeap
+// flag. Standalone mode never calls this; the field stays zero and
+// timeLeap is always false.
+func (s *Service) SetLastConsensusRoundTime(d time.Duration) {
+	s.mu.Lock()
+	s.lastConsensusRoundTime = d
+	s.mu.Unlock()
 }
 
 // tickLoadFeeLocked drives LoadFeeTrack raise/lower decisions from the

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -56,7 +56,13 @@ type SubmitResult struct {
 // persistent OpenLedger view, the held-pool absorbs the blob unless the
 // failure is permanent (tef*/tem*/tel*), and the legacy pendingTxs slice
 // is fed for standalone close.
-func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte) (*SubmitResult, error) {
+//
+// failHard mirrors rippled tapFAIL_HARD: when set, a submission that
+// does not apply is NOT pushed into the localTxs held pool and is NOT
+// fed into the canonical pendingTxs slice. The engine's ApplyFlags
+// also carries the bit so any future TxQ admission path observes it
+// (TxQ.cpp:393-399).
+func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, failHard bool) (*SubmitResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -91,6 +97,9 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte) 
 			Logger:                    s.config.Logger,
 			Rules:                     rulesFromLedger(s.closedLedger, s.logger),
 		}
+		if failHard {
+			engineConfig.ApplyFlags |= tx.TapFAIL_HARD
+		}
 		engine := tx.NewEngine(view, engineConfig)
 		applyResult = engine.Apply(transaction)
 		return applyResult.Applied
@@ -122,7 +131,14 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte) 
 	// permanent failures; everything else (ter*/tec*/applied/queued)
 	// belongs in the held pool so it survives Submit failure and LCL
 	// transitions until it lands or ages out (5 ledgers).
-	if rawBlob != nil && s.localTxs != nil {
+	//
+	// fail_hard short-circuits the held-pool push: rippled's TxQ
+	// canBeHeld (TxQ.cpp:393-399) returns telCAN_NOT_QUEUE on
+	// tapFAIL_HARD, and NetworkOPs.cpp:1685-1689 also gates relay on
+	// !enforceFailHard. We translate that as "don't hold the blob" so
+	// the caller learns about the failure immediately and doesn't see
+	// a delayed re-application.
+	if rawBlob != nil && s.localTxs != nil && !failHard {
 		ter := applyResult.Result
 		if !ter.IsTef() && !ter.IsTem() && !ter.IsTel() && ter != tx.TefALREADY {
 			ptx := openledger.PendingTx{

--- a/internal/rpc/fee_test.go
+++ b/internal/rpc/fee_test.go
@@ -1,0 +1,163 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/require"
+)
+
+func feeRequest(t *testing.T, services *types.ServiceContainer) map[string]interface{} {
+	t.Helper()
+	method := &handlers.FeeMethod{}
+	result, rpcErr := method.Handle(&types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}, nil)
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+	resp, ok := result.(map[string]interface{})
+	require.True(t, ok, "fee response is not a map")
+	return resp
+}
+
+// TestFee_FallsBackToIdleDefaults pins the no-TxQ-hook path: the
+// handler reproduces rippled's idle-state response (queue empty,
+// reference_level=256, all drops fields equal to base_fee).
+func TestFee_FallsBackToIdleDefaults(t *testing.T) {
+	mock := newMockLedgerService()
+	mock.standalone = false
+	mock.currentLedgerIndex = 7
+	services := &types.ServiceContainer{Ledger: mock}
+
+	resp := feeRequest(t, services)
+
+	require.Equal(t, uint32(7), resp["ledger_current_index"])
+	require.Equal(t, "0", resp["current_ledger_size"])
+	require.Equal(t, "0", resp["current_queue_size"])
+	require.Equal(t, "32", resp["expected_ledger_size"])
+	require.Equal(t, "640", resp["max_queue_size"])
+
+	levels := resp["levels"].(map[string]interface{})
+	require.Equal(t, "256", levels["reference_level"])
+	require.Equal(t, "256", levels["minimum_level"])
+	require.Equal(t, "256", levels["median_level"])
+	require.Equal(t, "256", levels["open_ledger_level"])
+
+	drops := resp["drops"].(map[string]interface{})
+	require.Equal(t, "10", drops["base_fee"])
+	require.Equal(t, "10", drops["median_fee"])
+	require.Equal(t, "10", drops["minimum_fee"])
+	require.Equal(t, "10", drops["open_ledger_fee"])
+}
+
+// TestFee_StandaloneFallback bumps the idle expected_ledger_size to
+// 1000 and max_queue_size to 20_000 (rippled minimumTxnInLedgerSA=1000).
+func TestFee_StandaloneFallback(t *testing.T) {
+	mock := newMockLedgerService()
+	mock.standalone = true
+	services := &types.ServiceContainer{Ledger: mock}
+
+	resp := feeRequest(t, services)
+	require.Equal(t, "1000", resp["expected_ledger_size"])
+	require.Equal(t, "20000", resp["max_queue_size"])
+}
+
+// TestFee_LiveMetrics_Escalating verifies the per-level drops follow
+// rippled's TxQ.cpp:1898-1907 algebra: median/min/open all scaled by
+// (level * baseFee) / 256, with the open-ledger value rounded up to
+// preserve the snapshot's level on round-trip.
+func TestFee_LiveMetrics_Escalating(t *testing.T) {
+	mock := newMockLedgerService()
+	mock.standalone = false
+	mock.currentLedgerIndex = 99
+	services := &types.ServiceContainer{Ledger: mock}
+	maxQ := uint32(640)
+	services.TxQFeeMetrics = func() types.TxQFeeMetrics {
+		return types.TxQFeeMetrics{
+			TxCount:               5,
+			TxQMaxSize:            &maxQ,
+			TxInLedger:            42,
+			TxPerLedger:           32,
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 256,
+			MedFeeLevel:           512,
+			OpenLedgerFeeLevel:    1024,
+		}
+	}
+
+	resp := feeRequest(t, services)
+	require.Equal(t, "5", resp["current_queue_size"])
+	require.Equal(t, "42", resp["current_ledger_size"])
+	require.Equal(t, "32", resp["expected_ledger_size"])
+	require.Equal(t, "640", resp["max_queue_size"])
+
+	levels := resp["levels"].(map[string]interface{})
+	require.Equal(t, "256", levels["reference_level"])
+	require.Equal(t, "512", levels["median_level"])
+	require.Equal(t, "1024", levels["open_ledger_level"])
+
+	drops := resp["drops"].(map[string]interface{})
+	require.Equal(t, "10", drops["base_fee"])
+	require.Equal(t, "20", drops["median_fee"])
+	require.Equal(t, "10", drops["minimum_fee"])
+	require.Equal(t, "40", drops["open_ledger_fee"])
+}
+
+// TestFee_QueueFull_SwapsMinimumBase mirrors rippled TxQ.cpp:1900-1902:
+// when txCount >= txQMaxSize, the minimum_fee uses the effective base
+// (clamped to 1 if base==0 and escalation is active).
+func TestFee_QueueFull_SwapsMinimumBase(t *testing.T) {
+	mock := newMockLedgerServiceServerInfo()
+	mock.standalone = false
+	mock.currentLedgerIndex = 99
+	mock.baseFee = 0
+	services := &types.ServiceContainer{Ledger: mock}
+	maxQ := uint32(2)
+	services.TxQFeeMetrics = func() types.TxQFeeMetrics {
+		return types.TxQFeeMetrics{
+			TxCount:               2,
+			TxQMaxSize:            &maxQ,
+			TxInLedger:            10,
+			TxPerLedger:           32,
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 768,
+			MedFeeLevel:           256,
+			OpenLedgerFeeLevel:    512,
+		}
+	}
+
+	resp := feeRequest(t, services)
+	drops := resp["drops"].(map[string]interface{})
+
+	require.Equal(t, "0", drops["base_fee"])
+	require.Equal(t, "3", drops["minimum_fee"])
+	require.Equal(t, "2", drops["open_ledger_fee"])
+}
+
+// TestFee_NilTxQMaxSize_OmitsMaxQueueSize matches rippled
+// TxQ.cpp:1879-1880: max_queue_size is only emitted when the queue
+// has a configured upper bound.
+func TestFee_NilTxQMaxSize_OmitsMaxQueueSize(t *testing.T) {
+	mock := newMockLedgerService()
+	services := &types.ServiceContainer{Ledger: mock}
+	services.TxQFeeMetrics = func() types.TxQFeeMetrics {
+		return types.TxQFeeMetrics{
+			TxCount:               0,
+			TxQMaxSize:            nil,
+			TxPerLedger:           32,
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 256,
+			MedFeeLevel:           256,
+			OpenLedgerFeeLevel:    256,
+		}
+	}
+
+	resp := feeRequest(t, services)
+	_, hasMaxQueue := resp["max_queue_size"]
+	require.False(t, hasMaxQueue, "max_queue_size must be omitted when TxQ has no configured limit")
+}

--- a/internal/rpc/handlers/fee.go
+++ b/internal/rpc/handlers/fee.go
@@ -2,23 +2,26 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
+	"math/bits"
+	"strconv"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
 // FeeMethod handles the fee RPC method.
-// See rippled: src/xrpld/rpc/handlers/Fee1.cpp -> TxQ::doRPC()
-//
-// Without a real TxQ implementation, fee escalation metrics are approximated
-// using rippled's default idle-state values:
-//   - reference_level = 256 (baseLevel in rippled TxQ.h)
-//   - expected_ledger_size = 32 (minimumTxnInLedger default, non-standalone)
-//   - max_queue_size = 20 * expected = 640 (ledgersInQueue=20 * txPerLedger)
-//   - current_ledger_size = 0 (no open ledger tx count available yet)
-//   - current_queue_size = 0 (no TxQ)
-//   - drops: median_fee/minimum_fee/open_ledger_fee all equal base_fee (no escalation)
+// Mirrors rippled TxQ::doRPC (TxQ.cpp:1860-1909): emits queue
+// occupancy, fee levels, and per-level drops derived from the live
+// TxQ snapshot. When the TxQ hook isn't wired (standalone tests,
+// pre-startup) the handler falls back to rippled's idle-state
+// defaults — reference_level=256, drops fields equal to base_fee.
 type FeeMethod struct{}
+
+const (
+	feeBaseLevel        uint64 = 256 // rippled TxQ.h baseLevel
+	feeDefaultExpected         = 32  // minimumTxnInLedger (non-standalone)
+	feeStandaloneExpect        = 1000
+	feeLedgersInQueue          = 20
+)
 
 func (m *FeeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
 	if err := RequireLedgerService(ctx.Services); err != nil {
@@ -28,43 +31,102 @@ func (m *FeeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (inter
 	baseFee, _, _ := ctx.Services.Ledger.GetCurrentFees()
 	currentLedgerIndex := ctx.Services.Ledger.GetCurrentLedgerIndex()
 
-	baseFeeStr := fmt.Sprintf("%d", baseFee)
+	metrics := snapshotTxQ(ctx.Services, ctx.Services.Ledger.IsStandalone())
 
-	// Reference fee level is 256 (baseLevel in rippled TxQ.h).
-	// Without a real TxQ implementation, all fee levels stay at the reference level.
-	referenceFeeLevel := "256"
-
-	// Rippled defaults: minimumTxnInLedger=32 (non-standalone), ledgersInQueue=20.
-	// In standalone: minimumTxnInLedgerSA=1000.
-	// max_queue_size = ledgersInQueue * txPerLedger.
-	expectedLedgerSize := "32"
-	maxQueueSize := "640"
-	if ctx.Services.Ledger.IsStandalone() {
-		expectedLedgerSize = "1000"
-		maxQueueSize = "20000"
+	effectiveBase := effectiveBaseFee(baseFee, metrics)
+	openFee := dropsFromLevel(metrics.OpenLedgerFeeLevel, effectiveBase)
+	if effectiveBase != 0 && levelFromDrops(openFee, effectiveBase) < metrics.OpenLedgerFeeLevel {
+		openFee += 1
 	}
+	medianFee := dropsFromLevel(metrics.MedFeeLevel, baseFee)
+	minFeeBase := baseFee
+	if metrics.TxQMaxSize != nil && metrics.TxCount >= *metrics.TxQMaxSize {
+		minFeeBase = effectiveBase
+	}
+	minimumFee := dropsFromLevel(metrics.MinProcessingFeeLevel, minFeeBase)
 
 	response := map[string]interface{}{
-		"current_ledger_size": "0",
-		"current_queue_size":  "0",
-		"drops": map[string]interface{}{
-			"base_fee":        baseFeeStr,
-			"median_fee":      baseFeeStr,
-			"minimum_fee":     baseFeeStr,
-			"open_ledger_fee": baseFeeStr,
-		},
-		"expected_ledger_size": expectedLedgerSize,
+		"current_ledger_size":  strconv.FormatUint(uint64(metrics.TxInLedger), 10),
+		"current_queue_size":   strconv.FormatUint(uint64(metrics.TxCount), 10),
+		"expected_ledger_size": strconv.FormatUint(uint64(metrics.TxPerLedger), 10),
 		"ledger_current_index": currentLedgerIndex,
 		"levels": map[string]interface{}{
-			"median_level":      referenceFeeLevel,
-			"minimum_level":     referenceFeeLevel,
-			"open_ledger_level": referenceFeeLevel,
-			"reference_level":   referenceFeeLevel,
+			"reference_level":   strconv.FormatUint(metrics.ReferenceFeeLevel, 10),
+			"minimum_level":     strconv.FormatUint(metrics.MinProcessingFeeLevel, 10),
+			"median_level":      strconv.FormatUint(metrics.MedFeeLevel, 10),
+			"open_ledger_level": strconv.FormatUint(metrics.OpenLedgerFeeLevel, 10),
 		},
-		"max_queue_size": maxQueueSize,
+		"drops": map[string]interface{}{
+			"base_fee":        strconv.FormatUint(baseFee, 10),
+			"median_fee":      strconv.FormatUint(medianFee, 10),
+			"minimum_fee":     strconv.FormatUint(minimumFee, 10),
+			"open_ledger_fee": strconv.FormatUint(openFee, 10),
+		},
+	}
+	if metrics.TxQMaxSize != nil {
+		response["max_queue_size"] = strconv.FormatUint(uint64(*metrics.TxQMaxSize), 10)
 	}
 
 	return response, nil
+}
+
+// snapshotTxQ returns the active TxQ metrics, or rippled's idle-state
+// defaults when the TxQ hook isn't wired.
+func snapshotTxQ(services *types.ServiceContainer, standalone bool) types.TxQFeeMetrics {
+	if services != nil && services.TxQFeeMetrics != nil {
+		return services.TxQFeeMetrics()
+	}
+	expected := uint32(feeDefaultExpected)
+	if standalone {
+		expected = feeStandaloneExpect
+	}
+	maxQueue := expected * feeLedgersInQueue
+	return types.TxQFeeMetrics{
+		TxCount:               0,
+		TxQMaxSize:            &maxQueue,
+		TxInLedger:            0,
+		TxPerLedger:           expected,
+		ReferenceFeeLevel:     feeBaseLevel,
+		MinProcessingFeeLevel: feeBaseLevel,
+		MedFeeLevel:           feeBaseLevel,
+		OpenLedgerFeeLevel:    feeBaseLevel,
+	}
+}
+
+// effectiveBaseFee mirrors rippled TxQ.cpp:1891-1895: when baseFee is
+// 0 drops but escalation has kicked in, treat the base fee as 1 drop
+// so the level→drops math doesn't collapse to 0.
+func effectiveBaseFee(baseFee uint64, m types.TxQFeeMetrics) uint64 {
+	if baseFee == 0 && m.OpenLedgerFeeLevel != m.ReferenceFeeLevel {
+		return 1
+	}
+	return baseFee
+}
+
+// dropsFromLevel converts a fee level back to drops: (level * baseFee) / baseLevel.
+// Mirrors rippled toDrops() with 128-bit intermediate to avoid overflow.
+func dropsFromLevel(level, baseFee uint64) uint64 {
+	hi, lo := bits.Mul64(level, baseFee)
+	if hi >= feeBaseLevel {
+		return ^uint64(0)
+	}
+	quo, _ := bits.Div64(hi, lo, feeBaseLevel)
+	return quo
+}
+
+// levelFromDrops converts drops to a fee level: (drops * baseLevel) / baseFee.
+// Used to detect when integer division truncated openFee below the
+// snapshot's open-ledger level so we can round up by one drop.
+func levelFromDrops(drops, baseFee uint64) uint64 {
+	if baseFee == 0 {
+		return 0
+	}
+	hi, lo := bits.Mul64(drops, feeBaseLevel)
+	if hi >= baseFee {
+		return ^uint64(0)
+	}
+	quo, _ := bits.Div64(hi, lo, baseFee)
+	return quo
 }
 
 func (m *FeeMethod) RequiredRole() types.Role {

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -111,9 +111,24 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 
 	// Submit the transaction with the original signed blob.
 	// The blob is needed for canonical re-ordering during AcceptLedger.
-	result, err := ctx.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
-	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to submit transaction: %v", err))
+	// When the client passed fail_hard:true and the ledger service
+	// implements the FailHardSubmitter surface, route through it so
+	// non-applying submissions are not held or relayed.
+	var (
+		result    *types.SubmitResult
+		submitErr error
+	)
+	if request.FailHard {
+		if fh, ok := ctx.Services.Ledger.(types.FailHardSubmitter); ok {
+			result, submitErr = fh.SubmitTransactionFailHard(txJSON, txBlobHex)
+		} else {
+			result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
+		}
+	} else {
+		result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
+	}
+	if submitErr != nil {
+		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to submit transaction: %v", submitErr))
 	}
 	txHashStr := CalculateTxHash(txBlobHex)
 

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -183,7 +183,22 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorInternal("Failed to marshal transaction: " + encErr.Error())
 	}
 
-	result, submitErr := ctx.Services.Ledger.SubmitTransaction(txJSON)
+	// Route fail_hard submissions through the optional surface so they
+	// are not held or relayed on non-apply. Mirrors rippled
+	// NetworkOPs.cpp:1685-1689 (`!enforceFailHard`).
+	var (
+		result    *types.SubmitResult
+		submitErr error
+	)
+	if request.FailHard {
+		if fh, ok := ctx.Services.Ledger.(types.FailHardSubmitter); ok {
+			result, submitErr = fh.SubmitTransactionFailHard(txJSON, txBlob)
+		} else {
+			result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON)
+		}
+	} else {
+		result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON)
+	}
 	if submitErr != nil {
 		return nil, types.RpcErrorInternal("Transaction submission failed: " + submitErr.Error())
 	}

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -181,6 +181,22 @@ func (a *ledgerReaderAdapter) ForEachTransaction(fn func(txHash [32]byte, txData
 // This is used for canonical re-ordering during AcceptLedger to ensure
 // the exact same bytes (and thus same tx hash) are used during re-application.
 func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte, txBlobHex ...string) (*types.SubmitResult, error) {
+	var blobHex string
+	if len(txBlobHex) > 0 {
+		blobHex = txBlobHex[0]
+	}
+	return a.submitTransaction(txJSON, blobHex, false)
+}
+
+// SubmitTransactionFailHard mirrors SubmitTransaction with rippled's
+// tapFAIL_HARD semantics: a tx that does not apply is not held in
+// localTxs, not relayed, and not pushed onto the canonical pendingTxs
+// pool. Submit handlers route here when the client sent fail_hard:true.
+func (a *LedgerServiceAdapter) SubmitTransactionFailHard(txJSON []byte, txBlobHex string) (*types.SubmitResult, error) {
+	return a.submitTransaction(txJSON, txBlobHex, true)
+}
+
+func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string, failHard bool) (*types.SubmitResult, error) {
 	// Parse the transaction from JSON
 	transaction, err := tx.ParseJSON(txJSON)
 	if err != nil {
@@ -194,8 +210,8 @@ func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte, txBlobHex ...str
 
 	// Use the original signed blob if provided, otherwise re-encode
 	var rawBlob []byte
-	if len(txBlobHex) > 0 && txBlobHex[0] != "" {
-		rawBlob, _ = hex.DecodeString(txBlobHex[0])
+	if txBlobHex != "" {
+		rawBlob, _ = hex.DecodeString(txBlobHex)
 	}
 	if rawBlob == nil {
 		if txMap, fErr := transaction.Flatten(); fErr == nil {
@@ -214,7 +230,7 @@ func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte, txBlobHex ...str
 	}
 
 	// Submit to the service with the raw blob for canonical ordering
-	result, err := a.svc.SubmitTransaction(transaction, rawBlob)
+	result, err := a.svc.SubmitTransaction(transaction, rawBlob, failHard)
 	if err != nil {
 		return &types.SubmitResult{
 			EngineResult:        "tefINTERNAL",
@@ -233,9 +249,13 @@ func (a *LedgerServiceAdapter) SubmitTransaction(txJSON []byte, txBlobHex ...str
 	// (apply.cpp:196,206). On-the-wire set: tesSUCCESS, tec*, terQUEUED.
 	// All other ter* codes are held locally (addHeldTransaction) and
 	// must NOT be relayed — peers would just re-fail with the same
-	// retry code.
+	// retry code. fail_hard suppresses relay on non-apply (matches
+	// NetworkOPs.cpp:1688 `&& !enforceFailHard`).
 	broadcast := false
 	relayable := result.Applied || result.Result == tx.TerQUEUED
+	if failHard && !result.Applied {
+		relayable = false
+	}
 	if relayable && rawBlob != nil && a.txBroadcaster != nil {
 		a.txBroadcaster(rawBlob)
 		broadcast = true

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -216,6 +216,12 @@ type ServiceContainer struct {
 	// server_info falls back to baseline values.
 	TxQMetrics func() TxQServerMetrics
 
+	// TxQFeeMetrics returns the full TxQ snapshot consumed by the
+	// `fee` RPC handler. Nil until the ledger service is wired
+	// (standalone tests, pre-startup) — handler then falls back to
+	// rippled's idle-state defaults.
+	TxQFeeMetrics func() TxQFeeMetrics
+
 	// JqTransOverflow returns the cumulative inbound TMTransaction
 	// frames the overlay refused at the router-dispatch boundary
 	// because the in-flight tx ceiling was already met. This is
@@ -385,6 +391,17 @@ type LedgerAccessor interface {
 }
 
 // TransactionSubmitter handles transaction submission and retrieval.
+// FailHardSubmitter is the optional rippled-faithful surface for
+// submitting a transaction with tapFAIL_HARD semantics (TxQ.cpp:393-399,
+// NetworkOPs.cpp:1685-1689): on non-apply the blob is NOT held in the
+// localTxs pool, NOT pushed onto the canonical pendingTxs slice, and
+// NOT relayed. Production LedgerServiceAdapter implements it; test
+// mocks may omit it — submit handlers fall back to SubmitTransaction
+// when the interface is not satisfied.
+type FailHardSubmitter interface {
+	SubmitTransactionFailHard(txJSON []byte, txBlobHex string) (*SubmitResult, error)
+}
+
 type TransactionSubmitter interface {
 	SubmitTransaction(txJSON []byte, txBlobHex ...string) (*SubmitResult, error)
 	SimulateTransaction(txJSON []byte) (*SubmitResult, error)
@@ -550,6 +567,22 @@ type LoadFactorFees struct {
 type TxQServerMetrics struct {
 	ReferenceFeeLevel     uint64
 	MinProcessingFeeLevel uint64
+	OpenLedgerFeeLevel    uint64
+}
+
+// TxQFeeMetrics is the full TxQ snapshot surfaced by the `fee` RPC,
+// mirroring the fields read by rippled's TxQ::doRPC
+// (TxQ.cpp:1860-1909). It is a superset of TxQServerMetrics — the
+// `fee` handler needs txCount / txPerLedger / txInLedger / median /
+// queue-max in addition to the load_factor levels.
+type TxQFeeMetrics struct {
+	TxCount               uint32
+	TxQMaxSize            *uint32 // nil → no limit, omits max_queue_size
+	TxInLedger            uint32
+	TxPerLedger           uint32
+	ReferenceFeeLevel     uint64
+	MinProcessingFeeLevel uint64
+	MedFeeLevel           uint64
 	OpenLedgerFeeLevel    uint64
 }
 

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -84,6 +84,12 @@ type TestEnv struct {
 	// rippled's apply() vs submit() distinction for setup operations.
 	bypassTxQ bool
 
+	// txQApplyFlags is the ApplyFlags handed to the TxQ for the next
+	// submission. Reset to zero on every Submit; tests that want to
+	// simulate rippled's tapFAIL_HARD admission rule can set it via
+	// the field before calling Submit.
+	txQApplyFlags tx.ApplyFlags
+
 	// txInLedger tracks the number of transactions applied to the current open
 	// ledger. Reset on Close(). Used by TxQ for fee escalation computation.
 	txInLedger uint32

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -1223,6 +1223,14 @@ func (c *testTxQApplyContext) PreclaimTransaction(txn tx.Transaction, account [2
 	return 0
 }
 
+// GetApplyFlags returns the engine ApplyFlags currently driving the
+// test env. The test env stores the flag on TestEnv.txQApplyFlags and
+// resets it after each Submit; default is 0 so TxQ admission behaves
+// as if no flag is set.
+func (c *testTxQApplyContext) GetApplyFlags() tx.ApplyFlags {
+	return c.env.txQApplyFlags
+}
+
 // testTxQAcceptContext implements txq.AcceptContext for draining the queue.
 type testTxQAcceptContext struct {
 	env *TestEnv

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -343,14 +343,71 @@ func (b *Batch) Flatten() (map[string]any, error) {
 	return m, nil
 }
 
-// CalculateMinimumFee calculates the minimum required fee for a Batch transaction.
-// Formula: (numSigners + 2) * baseFee + baseFee * numInnerTxns
-// Reference: rippled Batch.cpp calculateBaseFee()
+// CalculateMinimumFee mirrors rippled Batch::calculateBaseFee
+// (Batch.cpp:53-150). The total fee a batch must pay is the sum of:
+//   - batchBase   = view.fees().base + Transactor::calculateBaseFee(view, tx)
+//     = baseFee + (1 + len(outer.Signers)) * baseFee
+//   - txnFees     = Σ inner-tx base fees (each multi-sign-aware)
+//   - signerFees  = effectiveSignerCount * baseFee
+//
+// effectiveSignerCount counts each BatchSigner once when it carries a
+// direct BatchTxnSignature and as len(Signers) when the entry is a
+// multi-signed batch signer (Batch.cpp:128-134). Inner transactions
+// pay (1 + signers) * baseFee per the standard multi-sign multiplier
+// (Transactor::calculateBaseFee). Inner-Batch txns are rejected by
+// preflight elsewhere; innerBaseFee mirrors rippled's defense-in-depth
+// bail-out (Batch.cpp:92-97) by returning a sentinel large fee when an
+// inner is itself ttBATCH so the outer is undercosted into rejection
+// rather than silently undercharged.
 func (b *Batch) CalculateMinimumFee(baseFee uint64) uint64 {
-	numSigners := uint64(len(b.BatchSigners))
-	numInnerTxns := uint64(len(b.RawTransactions))
-	return (numSigners+2)*baseFee + baseFee*numInnerTxns
+	outerSigners := uint64(len(b.Common.Signers))
+	batchBase := baseFee + (1+outerSigners)*baseFee
+
+	var txnFees uint64
+	for _, rt := range b.RawTransactions {
+		inner := rt.RawTransaction.InnerTx
+		if inner == nil {
+			continue
+		}
+		txnFees += innerBaseFee(inner, baseFee)
+	}
+
+	var signerCount uint64
+	for _, bs := range b.BatchSigners {
+		if bs.BatchSigner.BatchTxnSignature != "" {
+			signerCount++
+		} else if len(bs.BatchSigner.Signers) > 0 {
+			signerCount += uint64(len(bs.BatchSigner.Signers))
+		}
+	}
+
+	return batchBase + txnFees + signerCount*baseFee
 }
+
+// innerBaseFee mirrors rippled Transactor::calculateBaseFee for one
+// inner tx: (1 + signers) * baseFee. Inner ttBATCH is forbidden in
+// preflight; mirror rippled Batch.cpp:92-97 by surfacing the impossible
+// nesting as overflowFee — the outer batch's minimum-fee check will
+// reject before the inner-batch makes it through. The per-tx-type
+// overrides (AccountDelete reserve increment, AMMCreate pool increment,
+// LedgerStateFix repair increment) are intentionally not dispatched
+// here: those cases are forbidden or exceedingly rare inside a Batch,
+// and accessing the view from this interface would require a deeper
+// refactor of BatchFeeCalculator.
+func innerBaseFee(inner tx.Transaction, baseFee uint64) uint64 {
+	if inner.TxType() == tx.TypeBatch {
+		return overflowFee
+	}
+	signers := inner.GetCommon().Signers
+	return (1 + uint64(len(signers))) * baseFee
+}
+
+// overflowFee is the sentinel fee returned when fee calculation hits an
+// impossible condition (inner ttBATCH, overflow). It is larger than any
+// legitimate batch fee can ever be, ensuring the outer tx fails the
+// minimum-fee gate. Mirrors rippled Batch.cpp:66 returning INITIAL_XRP
+// (100 billion XRP) — we use a similarly impossible drops sentinel.
+const overflowFee uint64 = 100_000_000_000 * 1_000_000 // 100 billion XRP in drops
 
 // AddInnerTransaction adds an inner transaction to the batch.
 // The transaction should have Fee="0", SigningPubKey="", and tfInnerBatchTxn flag set.

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -365,3 +365,101 @@ func TestBatchConstants(t *testing.T) {
 	assert.Equal(t, uint32(0x00000004), BatchFlagUntilFailure)
 	assert.Equal(t, uint32(0x00000008), BatchFlagIndependent)
 }
+
+// TestCalculateMinimumFee_SingleSignBaseline pins the common case
+// (single-signed inners, no BatchSigners): the formula degenerates
+// to (numInner + 2) * baseFee.
+func TestCalculateMinimumFee_SingleSignBaseline(t *testing.T) {
+	b := NewBatch("rOuter")
+	b.AddInnerTransaction(makeTestPayment())
+	b.AddInnerTransaction(makeTestPayment())
+	require.Equal(t, uint64(40), b.CalculateMinimumFee(10), "2 inners + no signers")
+
+	b3 := NewBatch("rOuter")
+	b3.AddInnerTransaction(makeTestPayment())
+	b3.AddInnerTransaction(makeTestPayment())
+	b3.AddInnerTransaction(makeTestPayment())
+	require.Equal(t, uint64(50), b3.CalculateMinimumFee(10), "3 inners + no signers")
+}
+
+// TestCalculateMinimumFee_DirectSignedBatchSigners pins
+// Batch.cpp:130-131 — each BatchSigner with a direct BatchTxnSignature
+// adds one base fee.
+func TestCalculateMinimumFee_DirectSignedBatchSigners(t *testing.T) {
+	b := NewBatch("rOuter")
+	b.AddInnerTransaction(makeTestPayment())
+	b.AddInnerTransaction(makeTestPayment())
+	b.BatchSigners = []BatchSigner{
+		{BatchSigner: BatchSignerData{Account: "rSignerA", BatchTxnSignature: "AB"}},
+		{BatchSigner: BatchSignerData{Account: "rSignerB", BatchTxnSignature: "CD"}},
+	}
+	// batchBase=20 + txnFees=20 + signerFees=2*10 = 60
+	require.Equal(t, uint64(60), b.CalculateMinimumFee(10))
+}
+
+// TestCalculateMinimumFee_MultiSignBatchSigner pins
+// Batch.cpp:132-134 — a multi-signed BatchSigner (no direct
+// TxnSignature, populated Signers array) contributes
+// len(Signers) * baseFee, NOT just one base fee.
+func TestCalculateMinimumFee_MultiSignBatchSigner(t *testing.T) {
+	b := NewBatch("rOuter")
+	b.AddInnerTransaction(makeTestPayment())
+	b.AddInnerTransaction(makeTestPayment())
+	b.BatchSigners = []BatchSigner{{
+		BatchSigner: BatchSignerData{
+			Account: "rSignerA",
+			Signers: []tx.SignerWrapper{
+				{Signer: tx.Signer{Account: "rNested1", SigningPubKey: "01", TxnSignature: "AA"}},
+				{Signer: tx.Signer{Account: "rNested2", SigningPubKey: "02", TxnSignature: "BB"}},
+				{Signer: tx.Signer{Account: "rNested3", SigningPubKey: "03", TxnSignature: "CC"}},
+			},
+		},
+	}}
+	// batchBase=20 + txnFees=20 + signerFees=3*10 = 70
+	require.Equal(t, uint64(70), b.CalculateMinimumFee(10))
+}
+
+// TestCalculateMinimumFee_MultiSignedInner pins
+// Batch.cpp:87-100 — inner transactions count their own per-tx
+// calculateBaseFee, so a multi-signed inner pays (1+n) * baseFee
+// instead of one base fee.
+func TestCalculateMinimumFee_MultiSignedInner(t *testing.T) {
+	b := NewBatch("rOuter")
+	b.AddInnerTransaction(makeTestPayment())
+	multiInner := makeTestPayment()
+	multiInner.GetCommon().Signers = []tx.SignerWrapper{
+		{Signer: tx.Signer{Account: "rNested1", SigningPubKey: "01", TxnSignature: "AA"}},
+		{Signer: tx.Signer{Account: "rNested2", SigningPubKey: "02", TxnSignature: "BB"}},
+	}
+	b.AddInnerTransaction(multiInner)
+	// batchBase=20 + txnFees=(10 + 30) + signerFees=0 = 60
+	require.Equal(t, uint64(60), b.CalculateMinimumFee(10))
+}
+
+// TestCalculateMinimumFee_OuterMultiSign pins
+// Batch.cpp:60-70 — Transactor::calculateBaseFee charges
+// (1 + outerSigners) * baseFee for the outer Batch tx itself,
+// in addition to the view.fees().base added by the Batch wrapper.
+func TestCalculateMinimumFee_OuterMultiSign(t *testing.T) {
+	b := NewBatch("rOuter")
+	b.AddInnerTransaction(makeTestPayment())
+	b.Common.Signers = []tx.SignerWrapper{
+		{Signer: tx.Signer{Account: "rOuter1", SigningPubKey: "01", TxnSignature: "AA"}},
+		{Signer: tx.Signer{Account: "rOuter2", SigningPubKey: "02", TxnSignature: "BB"}},
+	}
+	// batchBase = 10 + (1 + 2)*10 = 40; txnFees = 10; signerFees = 0 → 50
+	require.Equal(t, uint64(50), b.CalculateMinimumFee(10))
+}
+
+// TestCalculateMinimumFee_InnerBatchSentinel pins
+// Batch.cpp:92-97 — an inner that is itself ttBATCH (forbidden) is
+// surfaced via an overflow sentinel so the outer minimum-fee gate
+// rejects, rather than silently computing a normal fee.
+func TestCalculateMinimumFee_InnerBatchSentinel(t *testing.T) {
+	outer := NewBatch("rOuter")
+	innerBatch := NewBatch("rInner")
+	outer.AddInnerTransaction(innerBatch)
+	fee := outer.CalculateMinimumFee(10)
+	// Sentinel is ≥ 100B XRP in drops; any realistic caller will reject.
+	require.Greater(t, fee, uint64(100_000_000_000), "inner ttBATCH must surface as overflow sentinel")
+}

--- a/internal/txq/admission_test.go
+++ b/internal/txq/admission_test.go
@@ -1,0 +1,82 @@
+package txq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpperBoundSeqProxy_PicksSmallestStrictlyGreater pins the
+// std::map::upper_bound contract on the SeqProxy ordering: with
+// queued seq 9, 11, 13 and a probe at seq 10, the helper must return
+// seq 11 (the smallest strictly greater).
+func TestUpperBoundSeqProxy_PicksSmallestStrictlyGreater(t *testing.T) {
+	aq := NewAccountQueue([20]byte{1})
+	for _, s := range []uint32{9, 11, 13} {
+		aq.Transactions[NewSeqProxySequence(s)] = &Candidate{
+			SeqProxy: NewSeqProxySequence(s),
+		}
+	}
+	q := New(makeAdmissionConfig())
+	next, ok := q.upperBoundSeqProxy(aq, NewSeqProxySequence(10))
+	require.True(t, ok)
+	require.Equal(t, NewSeqProxySequence(11), next)
+}
+
+// TestUpperBoundSeqProxy_RejectsTicketAsNeighbour pins
+// TxQ.cpp:440-444: when the only tx greater than the probe is a
+// ticket, rippled's `nextTxIter->first.isSeq()` check rejects the gap
+// fill. upperBoundSeqProxy returns the ticket so canBeHeld can reject.
+func TestUpperBoundSeqProxy_RejectsTicketAsNeighbour(t *testing.T) {
+	aq := NewAccountQueue([20]byte{1})
+	ticket := SeqProxy{Value: 12, IsTicket: true}
+	aq.Transactions[ticket] = &Candidate{SeqProxy: ticket}
+	q := New(makeAdmissionConfig())
+	next, ok := q.upperBoundSeqProxy(aq, NewSeqProxySequence(9))
+	require.True(t, ok)
+	require.True(t, next.IsTicket, "ticket dominates the upper-bound when no later seq exists")
+}
+
+// TestUpperBoundSeqProxy_PrefersSeqBeforeTicket pins the SeqProxy
+// ordering rule from SeqProxy.h:58 (`enum Type : uint8_t { seq=0,
+// ticket=1 }`) — sequences sort BEFORE tickets globally. With seq 11
+// and ticket 5 both queued, the upper bound of seq 10 is seq 11
+// (the ticket is "greater" by value but `seq < ticket` per the type
+// ordering, so the smallest strictly greater is the seq).
+func TestUpperBoundSeqProxy_PrefersSeqBeforeTicket(t *testing.T) {
+	aq := NewAccountQueue([20]byte{1})
+	aq.Transactions[NewSeqProxySequence(11)] = &Candidate{SeqProxy: NewSeqProxySequence(11)}
+	ticket := SeqProxy{Value: 5, IsTicket: true}
+	aq.Transactions[ticket] = &Candidate{SeqProxy: ticket}
+	q := New(makeAdmissionConfig())
+	next, ok := q.upperBoundSeqProxy(aq, NewSeqProxySequence(10))
+	require.True(t, ok)
+	require.False(t, next.IsTicket, "seq 11 outranks ticket 5 under SeqProxy ordering")
+	require.Equal(t, uint32(11), next.Value)
+}
+
+// TestUpperBoundSeqProxy_EmptyQueueReturnsFalse pins the
+// nextTxIter == end() branch.
+func TestUpperBoundSeqProxy_EmptyQueueReturnsFalse(t *testing.T) {
+	aq := NewAccountQueue([20]byte{1})
+	q := New(makeAdmissionConfig())
+	_, ok := q.upperBoundSeqProxy(aq, NewSeqProxySequence(0))
+	require.False(t, ok)
+}
+
+func makeAdmissionConfig() Config {
+	return Config{
+		LedgersInQueue:                 20,
+		MinimumTxnInLedger:             3,
+		TargetTxnInLedger:              5,
+		MaximumTxnInLedger:             10,
+		MinimumEscalationMultiplier:    128000,
+		MinimumLastLedgerBuffer:        2,
+		QueueSizeMin:                   10,
+		MaximumTxnPerAccount:           10,
+		MinimumTxnInLedgerStandalone:   100,
+		NormalConsensusIncreasePercent: 20,
+		SlowConsensusDecreasePercent:   50,
+		Standalone:                     false,
+	}
+}

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -56,6 +56,12 @@ type ApplyContext interface {
 	// This is used for the multiTxn path (TxQ.cpp:1167-1170) where rippled
 	// runs preclaim against a modified view to detect terINSUF_FEE_B etc.
 	PreclaimTransaction(txn tx.Transaction, account [20]byte, adjustedBalance uint64, adjustedSeq uint32) tx.Result
+
+	// GetApplyFlags returns the engine ApplyFlags driving this
+	// submission. Implementations that don't carry flags (legacy test
+	// adapters) can return 0; TxQ only inspects TapFAIL_HARD to mirror
+	// rippled TxQ.cpp:393-399 (fail-hard txs are never held).
+	GetApplyFlags() tx.ApplyFlags
 }
 
 // Apply attempts to apply a transaction or queue it for later.
@@ -124,9 +130,15 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	}
 
 	// Transaction needs to be queued.
-	// AccountTxnID is not supported by the transaction queue.
-	// Reference: TxQ.cpp:394-399 (canBeHeld)
+	// AccountTxnID is not supported by the transaction queue;
+	// tapFAIL_HARD transactions are never held. Mirrors rippled
+	// TxQ.cpp:393-399 (canBeHeld). The sfPreviousTxnID guard from
+	// rippled has no goxrpl counterpart — the field is metadata-only
+	// in this implementation and never lives on a submitted tx.
 	if common.AccountTxnID != "" {
+		return ApplyResult{Result: tx.TelCAN_NOT_QUEUE, Applied: false}
+	}
+	if ctx.GetApplyFlags()&tx.TapFAIL_HARD != 0 {
 		return ApplyResult{Result: tx.TelCAN_NOT_QUEUE, Applied: false}
 	}
 
@@ -599,25 +611,42 @@ func (q *TxQ) canBeHeld(aq *AccountQueue, replacingCandidate *Candidate, seqProx
 	// Allow if this fills the next sequence gap in the account's queue.
 	nextSeq := q.getNextQueuableSeq(aq, acctSeq)
 	if !seqProxy.IsTicket && seqProxy.Value == nextSeq {
-		// Check if there's a subsequent sequence-based tx in the queue
-		// that this would connect to (i.e., a real gap, not just appending).
-		// Reference: TxQ.cpp:440-444 upper_bound(nextQueuable)
-		hasLaterSeq := false
-		for sp := range aq.Transactions {
-			if !sp.IsTicket && sp.Value > seqProxy.Value {
-				hasLaterSeq = true
-				break
-			}
-		}
-		if !hasLaterSeq {
+		// Mirrors rippled TxQ.cpp:440-444:
+		//   auto const nextTxIter = txQAcct.transactions.upper_bound(nextQueuable);
+		//   if (nextTxIter != end() && nextTxIter->first.isSeq())
+		//     return tesSUCCESS;
+		// The IMMEDIATE next SeqProxy must be sequence-based — a ticket
+		// sitting next in line doesn't make this a true gap fill,
+		// because tickets can't unblock a sequence-based pipeline.
+		nextSP, hasNext := q.upperBoundSeqProxy(aq, seqProxy)
+		if !hasNext || nextSP.IsTicket {
 			q.incTxQFull()
 			return true, ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
-		// Real gap fill — allow it
+		// Real gap fill — allow it.
 		return false, ApplyResult{}
 	}
 	q.incTxQFull()
 	return true, ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
+}
+
+// upperBoundSeqProxy returns the smallest SeqProxy in aq strictly
+// greater than `sp`, mirroring std::map::upper_bound semantics on the
+// SeqProxy ordering (sequences come before tickets, then by numeric
+// value). hasNext is false when no such entry exists.
+func (q *TxQ) upperBoundSeqProxy(aq *AccountQueue, sp SeqProxy) (SeqProxy, bool) {
+	var best SeqProxy
+	found := false
+	for candidate := range aq.Transactions {
+		if !sp.Less(candidate) {
+			continue
+		}
+		if !found || candidate.Less(best) {
+			best = candidate
+			found = true
+		}
+	}
+	return best, found
 }
 
 // getNextQueuableSeq returns the next sequence that can be queued for an account.


### PR DESCRIPTION
## Summary

Follow-up to the closed PR #524. The bulk of the original PR (LoadFeeTrack subsystem, SetRemoteFee/SetClusterFee drivers, SetFee preflight/preclaim tightening) was independently landed on main via #514 and #500. This change adds only the pieces from the #524 conformance review that remain uniquely valuable.

## What's here

### Behavioral fixes
- **timeLeap signal (B2):** extend `consensus.StatusEvents.OnConsensusReached` to carry `roundTime`; the rcl engine captures it before notifying the adaptor, which forwards to `Service.SetLastConsensusRoundTime`. `processClosedLedgerLocked` now passes `roundTime > 5s` into TxQ's timeLeap instead of a hardcoded `false`. Mirrors rippled `RCLConsensus.cpp:803-805`. Pre-fix, the slow-consensus freeze never fired in production.
- **fail_hard plumbing (B3):** `Service.SubmitTransaction(transaction, rawBlob, failHard)` now skips the `localTxs` held-pool push and suppresses relay when fail_hard is set on a non-applying tx (rippled `NetworkOPs.cpp:1685-1689` `!enforceFailHard`). Optional `FailHardSubmitter` interface on the ledger surface keeps existing test mocks source-compatible; `LedgerServiceAdapter` implements both surfaces; `submit` and `submit_multisigned` handlers route through it when `fail_hard:true`. Pre-fix, the `fail_hard` query param was parsed and discarded.
- **Batch outer-Signers fee (M1):** `CalculateMinimumFee` mirrors `Batch.cpp:60-70`: `batchBase = baseFee + (1 + outerSigners) * baseFee`. Previous formula undercharged any multi-signed outer Batch by `len(outer.Signers) * baseFee`.
- **Inner-ttBATCH sentinel (N1):** `innerBaseFee` returns an overflowFee sentinel for inner ttBATCH so the outer minimum-fee gate rejects (rippled `Batch.cpp:92-97` defense-in-depth).
- **Fee RPC handler rewrite:** wired to live `TxQFeeMetrics` — replaces the hardcoded idle-state response with full `TxQ::doRPC` algebra (`TxQ.cpp:1860-1909`): `effectiveBaseFee` clamp, `toDrops` / `toFeeLevel` round-trip on `open_ledger_fee`, `txCount >= TxQMaxSize` → effective base for `minimum_fee`, conditional `max_queue_size` emit.
- **TxQ `canBeHeld` upper_bound fix:** `upperBoundSeqProxy` returns the immediately-next SeqProxy (sequence-or-ticket) for the gap-fill check, matching `std::map::upper_bound` on rippled's SeqProxy ordering. The previous "any later seq exists" scan admitted ticket-only neighbours that don't unblock a sequence-based pipeline. New `ApplyFlags` hook on `ApplyContext` + `canBeHeld` rejection on `TapFAIL_HARD` match `TxQ.cpp:393-399` — defense-in-depth for any future routing of production submits through `txq.TxQ.Apply` (currently goes engine.Apply directly; architectural follow-up tracked at #543).

### Tests added
- `internal/rpc/fee_test.go` — idle / standalone / live-escalating / queue-full / nil-max paths.
- `internal/txq/admission_test.go` — `upper_bound` contract on every SeqProxy ordering combo (seq>seq, ticket-only-neighbour, seq-before-ticket, empty queue).
- `internal/tx/batch/batch_test.go` — `+OuterMultiSign`, `+InnerBatchSentinel`, `+SingleSignBaseline`, `+DirectSignedBatchSigners`, `+MultiSignBatchSigner`, `+MultiSignedInner`.

## Heritage

The original #524 attempted to land:
1. ✅ LoadFeeTrack subsystem — superseded by #514's `internal/feetrack/`
2. ✅ LoadFeeTrack drivers — superseded by #514 follow-up (Raise/Lower + `Adaptor.refreshRemoteFee` + `clusterFeeSink`)
3. ✅ SetFee preflight/preclaim tightening — superseded by #500's `PreclaimPseudo` + `parsedFeeFields` memoisation
4. **This PR** — pieces (1)-(6) above that were unique to the #524 review work

Closed: PR #524, issue #542 (already done on main).
Still open: issue #543 (TxQ routing for fee-escalation parity — architectural follow-up).

## Test plan
- [x] `just build` clean
- [x] `just vet` clean
- [x] `just lint` clean (0 issues)
- [x] `just test-core` green
- [x] `just test-pkg ./internal/tx/batch/...` — all 7 fee tests pass
- [x] `just test-pkg ./internal/txq/...` — `upper_bound` admission tests pass
- [x] `just test-pkg ./internal/rpc/ -run TestFee` — 5 fee-handler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)