### PR TITLE
feat: back connect and black_list RPCs with the live overlay

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -409,6 +409,10 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			return overlayRef.PeerDisconnects(), overlayRef.PeerDisconnectsResources()
 		}
 		services.JqTransOverflow = overlayRef.DroppedTransactions
+		// Expose the overlay's outbound-connect and resource-reputation
+		// surfaces to the admin `connect` / `black_list` RPCs.
+		services.PeerConnect = overlayRef.Connect
+		services.ResourceBlacklist = overlayRef.BlacklistJSON
 		acctRef := consensusComponents.Adaptor
 		services.StateAccounting = func() types.StateAccountingSnapshot {
 			snap := acctRef.StateAccounting()

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -409,8 +409,6 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			return overlayRef.PeerDisconnects(), overlayRef.PeerDisconnectsResources()
 		}
 		services.JqTransOverflow = overlayRef.DroppedTransactions
-		// Expose the overlay's outbound-connect and resource-reputation
-		// surfaces to the admin `connect` / `black_list` RPCs.
 		services.PeerConnect = overlayRef.Connect
 		services.ResourceBlacklist = overlayRef.BlacklistJSON
 		acctRef := consensusComponents.Adaptor

--- a/internal/peermanagement/overlay_blacklist.go
+++ b/internal/peermanagement/overlay_blacklist.go
@@ -1,0 +1,23 @@
+package peermanagement
+
+import "github.com/LeJamon/goXRPLd/internal/peermanagement/resource"
+
+// BlacklistJSON returns the resource manager's per-endpoint reputation table
+// filtered by threshold, shaped like rippled's ResourceManager::getJson
+// (doBlackList): endpoint address → {local, remote, type}. A nil threshold
+// applies resource.WarningThreshold, matching rippled's getJson() default.
+func (o *Overlay) BlacklistJSON(threshold *int) map[string]any {
+	t := resource.WarningThreshold
+	if threshold != nil {
+		t = *threshold
+	}
+	ret := make(map[string]any)
+	for _, e := range o.resourceManager.Snapshot(t) {
+		ret[e.Address] = map[string]any{
+			"local":  e.Local,
+			"remote": e.Remote,
+			"type":   e.Type,
+		}
+	}
+	return ret
+}

--- a/internal/peermanagement/resource/blacklist.go
+++ b/internal/peermanagement/resource/blacklist.go
@@ -9,10 +9,16 @@ type BlacklistEntry struct {
 	Type    string
 }
 
-// Snapshot returns every tracked endpoint whose combined (local + remote)
+// Snapshot returns every active endpoint whose combined (local + remote)
 // balance is at or above threshold, mirroring rippled
 // Resource::Logic::getJson(threshold). Higher balances indicate heavier
 // accrued load; the black_list RPC's default threshold is WarningThreshold.
+//
+// Released endpoints (refcount 0) are skipped: rippled's release() moves an
+// entry out of the inbound_/outbound_/admin_ lists into inactive_ the moment
+// its last Consumer drops (Logic.h:420-447), and getJson only iterates the
+// active lists, so a disconnected endpoint disappears immediately rather than
+// lingering until expiry. Imported entries carry a refcount and so remain.
 func (m *Manager) Snapshot(threshold int) []BlacklistEntry {
 	now := m.clock()
 	m.mu.Lock()
@@ -20,6 +26,9 @@ func (m *Manager) Snapshot(threshold int) []BlacklistEntry {
 
 	out := make([]BlacklistEntry, 0, len(m.entries))
 	for _, e := range m.entries {
+		if e.refcount == 0 {
+			continue
+		}
 		local := e.localBalance.valueAt(now)
 		if local+e.remoteBalance < threshold {
 			continue

--- a/internal/peermanagement/resource/blacklist.go
+++ b/internal/peermanagement/resource/blacklist.go
@@ -1,0 +1,44 @@
+package resource
+
+// BlacklistEntry is one endpoint's resource reputation, mirroring an entry in
+// rippled's Resource::Logic::getJson output (Logic.h:208-254).
+type BlacklistEntry struct {
+	Address string
+	Local   int
+	Remote  int
+	Type    string
+}
+
+// Snapshot returns every tracked endpoint whose combined (local + remote)
+// balance is at or above threshold, mirroring rippled
+// Resource::Logic::getJson(threshold). Higher balances indicate heavier
+// accrued load; the black_list RPC's default threshold is WarningThreshold.
+func (m *Manager) Snapshot(threshold int) []BlacklistEntry {
+	now := m.clock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	out := make([]BlacklistEntry, 0, len(m.entries))
+	for _, e := range m.entries {
+		local := e.localBalance.valueAt(now)
+		if local+e.remoteBalance < threshold {
+			continue
+		}
+		out = append(out, BlacklistEntry{
+			Address: e.k.addr,
+			Local:   local,
+			Remote:  e.remoteBalance,
+			Type:    blacklistType(e.k.kind),
+		})
+	}
+	return out
+}
+
+// blacklistType maps a Kind to rippled's getJson "type" label. KindUnlimited
+// corresponds to rippled's admin_ table.
+func blacklistType(k Kind) string {
+	if k == KindUnlimited {
+		return "admin"
+	}
+	return k.String()
+}

--- a/internal/peermanagement/resource/blacklist_test.go
+++ b/internal/peermanagement/resource/blacklist_test.go
@@ -1,0 +1,36 @@
+package resource
+
+import "testing"
+
+func TestSnapshot_FiltersByThreshold(t *testing.T) {
+	m, _ := newTestManager()
+
+	c := m.NewInboundEndpoint("192.0.2.50:51000")
+	defer c.Release()
+	// The decaying sample scales a charge down by the decay window, so a
+	// burst sized by DecayWindowSeconds yields a steady-state value near
+	// WarningThreshold (mirrors the burst pattern in manager_test.go).
+	c.Charge(NewCharge(WarningThreshold*DecayWindowSeconds, "load"), "")
+
+	// At threshold 0 the loaded endpoint is listed, keyed by host (the
+	// inbound port is normalized away) with the inbound type label.
+	low := m.Snapshot(0)
+	if len(low) != 1 {
+		t.Fatalf("expected 1 entry at threshold 0, got %d", len(low))
+	}
+	got := low[0]
+	if got.Address != "192.0.2.50" {
+		t.Errorf("address = %q, want host without port", got.Address)
+	}
+	if got.Type != "inbound" {
+		t.Errorf("type = %q, want inbound", got.Type)
+	}
+	if got.Local <= 0 {
+		t.Errorf("local = %d, want positive balance", got.Local)
+	}
+
+	// A threshold above the combined balance filters the endpoint out.
+	if hi := m.Snapshot(got.Local + got.Remote + 1); len(hi) != 0 {
+		t.Errorf("expected 0 entries above balance, got %d", len(hi))
+	}
+}

--- a/internal/peermanagement/resource/blacklist_test.go
+++ b/internal/peermanagement/resource/blacklist_test.go
@@ -34,3 +34,44 @@ func TestSnapshot_FiltersByThreshold(t *testing.T) {
 		t.Errorf("expected 0 entries above balance, got %d", len(hi))
 	}
 }
+
+func TestSnapshot_ExcludesReleasedEntries(t *testing.T) {
+	m, _ := newTestManager()
+
+	c := m.NewInboundEndpoint("203.0.113.9:40000")
+	c.Charge(NewCharge(WarningThreshold*DecayWindowSeconds, "load"), "")
+
+	// While the Consumer is held the endpoint is active and listed.
+	if got := m.Snapshot(0); len(got) != 1 {
+		t.Fatalf("active endpoint: expected 1 entry, got %d", len(got))
+	}
+
+	// Releasing the last Consumer drops the refcount to 0. The entry stays
+	// resident (so a reconnect inherits its balance) but, like rippled moving
+	// it into inactive_, it must no longer appear in the black_list snapshot.
+	c.Release()
+	if got := m.Snapshot(0); len(got) != 0 {
+		t.Errorf("released endpoint should be excluded, got %d entries", len(got))
+	}
+}
+
+func TestSnapshot_AdminEndpointKeyedWithPortOne(t *testing.T) {
+	m, _ := newTestManager()
+
+	// An unlimited (admin/cluster) endpoint is keyed at port 1, matching
+	// rippled's at_port(1), so it never collides with the port-0 inbound key
+	// for the same host. It surfaces at threshold 0 even with a zero balance.
+	c := m.NewUnlimitedEndpoint("198.51.100.7:51235")
+	defer c.Release()
+
+	got := m.Snapshot(0)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 admin entry, got %d", len(got))
+	}
+	if got[0].Address != "198.51.100.7:1" {
+		t.Errorf("address = %q, want host with admin port :1", got[0].Address)
+	}
+	if got[0].Type != "admin" {
+		t.Errorf("type = %q, want admin", got[0].Type)
+	}
+}

--- a/internal/peermanagement/resource/manager.go
+++ b/internal/peermanagement/resource/manager.go
@@ -163,19 +163,21 @@ func (m *Manager) NewOutboundEndpoint(addr string) *Consumer {
 // Mirrors rippled's Consumer::charge short-circuit: charges on an
 // unlimited Consumer are no-ops — local balance stays at zero and
 // the Manager's charge / warn / disconnect entries are never touched.
-// Used for cluster members and admin sources.
+// Used for cluster members and admin sources. The key is canonicalised
+// to port 1 (rippled's at_port(1), Logic.h:182) so an admin endpoint
+// never shares a key — or a black_list output address — with the port-0
+// inbound entry for the same host.
 func (m *Manager) NewUnlimitedEndpoint(addr string) *Consumer {
-	return m.acquire(KindUnlimited, normalizeAddr(addr, true))
+	return m.acquire(KindUnlimited, adminAddr(addr))
 }
 
-// normalizeAddr canonicalises an endpoint key. For inbound and
-// unlimited endpoints the numeric port is dropped so a peer that
-// reconnects on a fresh ephemeral port inherits its prior balance —
-// without this, the blacklist would be trivially defeated. Mirrors
-// rippled's at_port(0) / at_port(1) normalisation in Logic.h:119/182.
-// Uses net.SplitHostPort so IPv6 brackets and bare addresses are
-// handled correctly; falls back to the input verbatim when there is
-// no port to strip.
+// normalizeAddr canonicalises an inbound endpoint key by dropping the
+// numeric port so a peer that reconnects on a fresh ephemeral port
+// inherits its prior balance — without this, the blacklist would be
+// trivially defeated. Mirrors rippled's at_port(0) normalisation in
+// Logic.h:119. Uses net.SplitHostPort so IPv6 brackets and bare
+// addresses are handled correctly; falls back to the input verbatim
+// when there is no port to strip.
 func normalizeAddr(addr string, stripPort bool) string {
 	if !stripPort {
 		return addr
@@ -185,6 +187,19 @@ func normalizeAddr(addr string, stripPort bool) string {
 		return addr
 	}
 	return host
+}
+
+// adminAddr canonicalises an unlimited/admin endpoint key to port 1,
+// mirroring rippled's at_port(1) normalisation (Logic.h:182). The
+// distinct port keeps admin entries from colliding with the port-0
+// inbound key for the same host, both internally and in the
+// address-keyed black_list output.
+func adminAddr(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	return net.JoinHostPort(host, "1")
 }
 
 func (m *Manager) acquire(k Kind, addr string) *Consumer {

--- a/internal/rpc/handlers/stubs_network.go
+++ b/internal/rpc/handlers/stubs_network.go
@@ -96,13 +96,9 @@ func (m *TxReduceRelayMethod) RequiredCondition() types.Condition {
 	return types.NoCondition
 }
 
-// ConnectMethod handles the connect RPC method.
-// STUB: Returns message without actually connecting. Network-only.
-//
-// TODO [network]: Implement when adding P2P networking layer.
-//   - Reference: rippled Connect.cpp → context.app.overlay().connect()
-//   - Params: ip (required), port (optional, default 51235)
-//   - Should initiate an outbound peer connection
+// ConnectMethod handles the connect RPC method. When the overlay is wired it
+// initiates a real background outbound connection (rippled Connect.cpp →
+// overlay().connect()); otherwise it reports that peers are unavailable.
 type ConnectMethod struct{ AdminHandler }
 
 func (m *ConnectMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {

--- a/internal/rpc/handlers/stubs_network.go
+++ b/internal/rpc/handlers/stubs_network.go
@@ -113,39 +113,54 @@ func (m *ConnectMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		}
 	}
 
-	if request.IP == "" {
-		return nil, types.RpcErrorInvalidParams("Missing required parameter: ip")
-	}
-
-	port := request.Port
-	if port == 0 {
-		port = 51235
-	}
-
-	// When the overlay is wired (consensus mode), initiate a real outbound
-	// connection. rippled's overlay().connect() schedules the attempt and
-	// returns immediately, so run the handshake in the background and reply
-	// right away (rippled Connect.cpp).
+	// When the overlay is wired (consensus mode, i.e. rippled's
+	// non-standalone path) initiate a real outbound connection. rippled's
+	// overlay().connect() schedules the attempt and returns immediately, so
+	// run the handshake in the background and reply right away (Connect.cpp).
 	if ctx.Services != nil && ctx.Services.PeerConnect != nil {
+		if request.IP == "" {
+			return nil, types.RpcErrorInvalidParams("Missing required parameter: ip")
+		}
+		port := connectPort(request.Port)
 		addr := net.JoinHostPort(request.IP, strconv.Itoa(port))
 		go func() { _ = ctx.Services.PeerConnect(addr) }()
-		return map[string]interface{}{
-			"message": fmt.Sprintf("connecting to %s", addr),
-		}, nil
+		return connectMessage(request.IP, port), nil
 	}
 
+	// No overlay wired. Mirror rippled's standalone guard, which precedes the
+	// ip check (Connect.cpp:41), so connect in standalone reports notSynced
+	// regardless of the supplied params.
 	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
-
 	if ctx.Services.Ledger.IsStandalone() {
 		return nil, types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
-			"Cannot connect to peers in standalone mode")
+			"Not synced to the network.")
 	}
+	if request.IP == "" {
+		return nil, types.RpcErrorInvalidParams("Missing required parameter: ip")
+	}
+	return connectMessage(request.IP, connectPort(request.Port)), nil
+}
 
+// connectPort applies the default peer port when the caller omits it. rippled
+// uses DEFAULT_PEER_PORT (Connect.cpp:60); goXRPL's peer protocol listens on
+// 51235 network-wide (peermanagement.DefaultListenAddr and the bootstrap
+// hubs), so the connect default mirrors "use the system peer port" with
+// goXRPL's deployed value rather than rippled's IANA-registered 2459.
+func connectPort(port int) int {
+	if port == 0 {
+		return 51235
+	}
+	return port
+}
+
+// connectMessage formats the reply rippled returns from doConnect
+// (Connect.cpp:68-70).
+func connectMessage(ip string, port int) map[string]interface{} {
 	return map[string]interface{}{
-		"message": fmt.Sprintf("attempting connection to IP:%s port:%d", request.IP, port),
-	}, nil
+		"message": fmt.Sprintf("attempting connection to IP:%s port: %d", ip, port),
+	}
 }
 
 // UnlListMethod handles the unl_list RPC method.

--- a/internal/rpc/handlers/stubs_network.go
+++ b/internal/rpc/handlers/stubs_network.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
@@ -119,6 +121,23 @@ func (m *ConnectMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		return nil, types.RpcErrorInvalidParams("Missing required parameter: ip")
 	}
 
+	port := request.Port
+	if port == 0 {
+		port = 51235
+	}
+
+	// When the overlay is wired (consensus mode), initiate a real outbound
+	// connection. rippled's overlay().connect() schedules the attempt and
+	// returns immediately, so run the handshake in the background and reply
+	// right away (rippled Connect.cpp).
+	if ctx.Services != nil && ctx.Services.PeerConnect != nil {
+		addr := net.JoinHostPort(request.IP, strconv.Itoa(port))
+		go func() { _ = ctx.Services.PeerConnect(addr) }()
+		return map[string]interface{}{
+			"message": fmt.Sprintf("connecting to %s", addr),
+		}, nil
+	}
+
 	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, types.RpcErrorInternal("Ledger service not available")
 	}
@@ -126,11 +145,6 @@ func (m *ConnectMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	if ctx.Services.Ledger.IsStandalone() {
 		return nil, types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
 			"Cannot connect to peers in standalone mode")
-	}
-
-	port := request.Port
-	if port == 0 {
-		port = 51235
 	}
 
 	return map[string]interface{}{
@@ -158,20 +172,27 @@ func (m *UnlListMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 }
 
 // BlackListMethod handles the black_list (blacklist) RPC method.
-// STUB: Returns empty list. Network-only — manages IP blacklisting.
-//
-// TODO [network]: Implement when adding P2P networking layer.
-//   - Reference: rippled BlackList.cpp
-//   - Returns/manages the peer IP blacklist
-//   - Params: threshold (int) — auto-blacklist peers above this score
+// Mirrors rippled BlackList.cpp: returns the overlay resource manager's
+// per-endpoint reputation table, optionally filtered by a `threshold` score.
+// The response is keyed by endpoint address (rippled returns the getJson
+// object directly). Empty when no overlay is wired (standalone / RPC-only).
 type BlackListMethod struct{ AdminHandler }
 
 func (m *BlackListMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
-		return nil, types.RpcErrorInternal("Ledger service not available")
+	var request struct {
+		Threshold *int `json:"threshold,omitempty"`
+	}
+	if params != nil {
+		if err := json.Unmarshal(params, &request); err != nil {
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
+		}
 	}
 
-	return map[string]interface{}{
-		"blacklist": []interface{}{},
-	}, nil
+	if ctx.Services != nil && ctx.Services.ResourceBlacklist != nil {
+		if result := ctx.Services.ResourceBlacklist(request.Threshold); result != nil {
+			return result, nil
+		}
+	}
+
+	return map[string]interface{}{}, nil
 }

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -425,6 +426,58 @@ func TestConnectMethod(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	})
+
+	t.Run("Wired overlay initiates background connection", func(t *testing.T) {
+		got := make(chan string, 1)
+		svc := &types.ServiceContainer{
+			Ledger: mock,
+			PeerConnect: func(addr string) error {
+				got <- addr
+				return nil
+			},
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleAdmin,
+			ApiVersion: types.ApiVersion1,
+			Services:   svc,
+		}
+
+		params := json.RawMessage(`{"ip": "10.0.0.1", "port": 2459}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+		select {
+		case addr := <-got:
+			assert.Equal(t, "10.0.0.1:2459", addr)
+		case <-time.After(time.Second):
+			t.Fatal("PeerConnect was not invoked")
+		}
+	})
+
+	t.Run("Wired overlay defaults the port", func(t *testing.T) {
+		got := make(chan string, 1)
+		svc := &types.ServiceContainer{
+			Ledger:      mock,
+			PeerConnect: func(addr string) error { got <- addr; return nil },
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleAdmin,
+			ApiVersion: types.ApiVersion1,
+			Services:   svc,
+		}
+
+		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"ip": "10.0.0.2"}`))
+		require.Nil(t, rpcErr)
+		select {
+		case addr := <-got:
+			assert.Equal(t, "10.0.0.2:51235", addr)
+		case <-time.After(time.Second):
+			t.Fatal("PeerConnect was not invoked")
+		}
 	})
 
 	t.Run("RequiredRole is Admin", func(t *testing.T) {
@@ -1107,7 +1160,7 @@ func TestBlackListMethod(t *testing.T) {
 
 	method := &handlers.BlackListMethod{}
 
-	t.Run("Returns blacklist array", func(t *testing.T) {
+	t.Run("Returns empty object when overlay not wired", func(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
@@ -1118,25 +1171,56 @@ func TestBlackListMethod(t *testing.T) {
 		result, rpcErr := method.Handle(ctx, nil)
 
 		require.Nil(t, rpcErr)
-		require.NotNil(t, result)
-
 		resultMap := result.(map[string]interface{})
-		assert.Contains(t, resultMap, "blacklist")
+		assert.Empty(t, resultMap)
 	})
 
-	t.Run("Accepts threshold parameter", func(t *testing.T) {
+	t.Run("Returns resource manager entries when wired", func(t *testing.T) {
+		var gotThreshold *int
+		svc := &types.ServiceContainer{
+			Ledger: mock,
+			ResourceBlacklist: func(threshold *int) map[string]any {
+				gotThreshold = threshold
+				return map[string]any{
+					"1.2.3.4": map[string]any{"local": 6000, "remote": 0, "type": "inbound"},
+				}
+			},
+		}
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   services,
+			Services:   svc,
 		}
 
-		params := json.RawMessage(`{"threshold": 100}`)
-		result, rpcErr := method.Handle(ctx, params)
+		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"threshold": 100}`))
 
 		require.Nil(t, rpcErr)
-		require.NotNil(t, result)
+		resultMap := result.(map[string]interface{})
+		assert.Contains(t, resultMap, "1.2.3.4")
+		require.NotNil(t, gotThreshold)
+		assert.Equal(t, 100, *gotThreshold)
+	})
+
+	t.Run("Omitting threshold passes nil", func(t *testing.T) {
+		sawNil := false
+		svc := &types.ServiceContainer{
+			Ledger: mock,
+			ResourceBlacklist: func(threshold *int) map[string]any {
+				sawNil = threshold == nil
+				return map[string]any{}
+			},
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleAdmin,
+			ApiVersion: types.ApiVersion1,
+			Services:   svc,
+		}
+
+		_, rpcErr := method.Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+		assert.True(t, sawNil, "absent threshold should pass nil to the resource reader")
 	})
 
 	t.Run("RequiredRole is Admin", func(t *testing.T) {
@@ -1218,11 +1302,12 @@ func TestMissingMethodsNilLedgerService(t *testing.T) {
 		{"GetCountsMethod", &handlers.GetCountsMethod{}},
 		{"LogRotateMethod", &handlers.LogRotateMethod{}},
 		{"UnlListMethod", &handlers.UnlListMethod{}},
-		{"BlackListMethod", &handlers.BlackListMethod{}},
 	}
 
 	// Note: LogLevelMethod is excluded — it manages log levels without needing
 	// the ledger service, so it succeeds with nil ledger (returns current levels).
+	// BlackListMethod is excluded — it reads the overlay resource manager, not
+	// the ledger, so it returns an empty object (not an error) with nil Ledger.
 
 	for _, tc := range methods {
 		t.Run(tc.name+" handles nil Ledger", func(t *testing.T) {

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -410,9 +410,13 @@ func TestConnectMethod(t *testing.T) {
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcNOT_SYNCED, rpcErr.Code)
 		assert.Equal(t, "notSynced", rpcErr.ErrorString)
+		assert.Equal(t, "Not synced to the network.", rpcErr.Message)
 	})
 
-	t.Run("Missing ip parameter returns error", func(t *testing.T) {
+	t.Run("Standalone with empty params returns notSynced", func(t *testing.T) {
+		// rippled checks standalone before the ip field (Connect.cpp:41), so
+		// connect "{}" in standalone is notSynced, not a missing-field error
+		// (Connect_test.cpp::testErrors).
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
@@ -420,8 +424,28 @@ func TestConnectMethod(t *testing.T) {
 			Services:   services,
 		}
 
-		params := json.RawMessage(`{}`)
-		result, rpcErr := method.Handle(ctx, params)
+		result, rpcErr := method.Handle(ctx, json.RawMessage(`{}`))
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcNOT_SYNCED, rpcErr.Code)
+	})
+
+	t.Run("Missing ip parameter returns error", func(t *testing.T) {
+		// On the live (wired-overlay) path rippled is non-standalone, so a
+		// missing ip surfaces as a missing-field error.
+		svc := &types.ServiceContainer{
+			Ledger:      mock,
+			PeerConnect: func(string) error { return nil },
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleAdmin,
+			ApiVersion: types.ApiVersion1,
+			Services:   svc,
+		}
+
+		result, rpcErr := method.Handle(ctx, json.RawMessage(`{}`))
 
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -237,6 +237,22 @@ type ServiceContainer struct {
 	// the overlay isn't wired (standalone, RPC-only tests).
 	PeerDisconnects func() (total, resources uint64)
 
+	// PeerConnect initiates an outbound peer connection to a host:port,
+	// backing the admin `connect` RPC (rippled Connect.cpp →
+	// overlay().connect()). The attempt runs in the background, mirroring
+	// rippled's non-blocking connect. Nil in standalone / RPC-only
+	// configurations (no overlay) — the handler falls back to reporting
+	// that peers are unavailable.
+	PeerConnect func(addr string) error
+
+	// ResourceBlacklist returns the overlay resource manager's per-endpoint
+	// reputation table filtered by an optional threshold (nil applies the
+	// WarningThreshold default), backing the admin `black_list` RPC
+	// (rippled BlackList.cpp → ResourceManager::getJson). Keyed by endpoint
+	// address with {local, remote, type} values. Nil when the overlay isn't
+	// wired — the handler returns an empty object.
+	ResourceBlacklist func(threshold *int) map[string]any
+
 	// StateAccounting returns the operating-mode state-machine
 	// snapshot surfaced by server_info: per-mode counts/durations
 	// plus the current-state and initial-sync durations. The Modes


### PR DESCRIPTION
## Summary

Wires the running peer overlay into the RPC `ServiceContainer` so two admin methods from the #496 audit return real data instead of placeholders:

- **`connect`** — initiates a real outbound peer connection via `Overlay.Connect`. The TLS handshake runs in the background and the handler replies immediately, mirroring rippled's non-blocking `overlay().connect()` (`Connect.cpp`). In standalone / RPC-only mode (no overlay wired) it keeps the prior `notSynced` behaviour.
- **`black_list`** — returns the overlay resource manager's per-endpoint reputation table, keyed by endpoint address → `{local, remote, type}`, filtered by an optional `threshold` (default `WarningThreshold`). Mirrors rippled `BlackList.cpp` → `ResourceManager::getJson`. Returns the bare object rippled returns (the previous `{"blacklist": []}` wrapper was non-rippled). Empty `{}` when no overlay is wired.

### Wiring
Follows the established closure-field pattern on `ServiceContainer` (like `PeerDisconnects`, `TxQMetrics`):
- New `Manager.Snapshot(threshold)` in `internal/peermanagement/resource` returns the reputation entries (KindUnlimited → rippled's `admin` type).
- New `Overlay.BlacklistJSON(*int)` shapes them into rippled's JSON.
- `server.go` sets `services.PeerConnect = overlay.Connect` and `services.ResourceBlacklist = overlay.BlacklistJSON` in the non-standalone branch (where the overlay is created and `Run`).

### Deliberately not included
- **`tx_reduce_relay`** — the overlay/relay subsystem exists and runs, but tracks **no** quantitative tx metrics (rippled's `txr_*` counters). Returning them would be fabricated zeros, so it stays stubbed pending real relay instrumentation.

## Test plan
- [x] `CGO_ENABLED=1 go test ./internal/rpc/... ./internal/peermanagement/resource/` — passes
- [x] `go vet` (rpc, resource, cli) — clean
- [x] `CGO_ENABLED=1 go build ./...` — passes
- Tests: `black_list` empty-when-unwired / entries-when-wired / threshold passthrough (incl. nil); `connect` background-connect + port default; `resource.Snapshot` threshold filtering, host normalization, and type label. Removed `black_list` from the nil-ledger test (it reads the overlay, not the ledger).

> Note: touches `stubs_network.go` and `missing_methods_test.go`, which PR #548 also touches — minor merge conflict expected depending on merge order.

Refs #496