### PR TITLE
feat: implement peer_reservations_add/del/list RPC methods

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -412,18 +412,19 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		// Expose the overlay's peer-reservation table to the admin
 		// peer_reservations_* RPCs (nil when no data dir is configured).
 		if reservations := overlayRef.PeerReservations(); reservations != nil {
-			services.PeerReservationAdd = func(nodePublic, description string) (string, bool) {
-				prev := reservations.Insert(&peermanagement.PeerReservation{NodeID: nodePublic, Description: description})
+			services.PeerReservationAdd = func(nodePublic, description string) (string, bool, error) {
+				prev, err := reservations.Insert(&peermanagement.PeerReservation{NodeID: nodePublic, Description: description})
 				if prev != nil {
-					return prev.Description, true
+					return prev.Description, true, err
 				}
-				return "", false
+				return "", false, err
 			}
-			services.PeerReservationDel = func(nodePublic string) (string, bool) {
-				if prev := reservations.Erase(nodePublic); prev != nil {
-					return prev.Description, true
+			services.PeerReservationDel = func(nodePublic string) (string, bool, error) {
+				prev, err := reservations.Erase(nodePublic)
+				if prev != nil {
+					return prev.Description, true, err
 				}
-				return "", false
+				return "", false, err
 			}
 			services.PeerReservationList = func() []types.PeerReservationEntry {
 				list := reservations.List()

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -409,6 +409,31 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			return overlayRef.PeerDisconnects(), overlayRef.PeerDisconnectsResources()
 		}
 		services.JqTransOverflow = overlayRef.DroppedTransactions
+		// Expose the overlay's peer-reservation table to the admin
+		// peer_reservations_* RPCs (nil when no data dir is configured).
+		if reservations := overlayRef.PeerReservations(); reservations != nil {
+			services.PeerReservationAdd = func(nodePublic, description string) (string, bool) {
+				prev := reservations.Insert(&peermanagement.PeerReservation{NodeID: nodePublic, Description: description})
+				if prev != nil {
+					return prev.Description, true
+				}
+				return "", false
+			}
+			services.PeerReservationDel = func(nodePublic string) (string, bool) {
+				if prev := reservations.Erase(nodePublic); prev != nil {
+					return prev.Description, true
+				}
+				return "", false
+			}
+			services.PeerReservationList = func() []types.PeerReservationEntry {
+				list := reservations.List()
+				out := make([]types.PeerReservationEntry, 0, len(list))
+				for _, r := range list {
+					out = append(out, types.PeerReservationEntry{NodePublic: r.NodeID, Description: r.Description})
+				}
+				return out
+			}
+		}
 		acctRef := consensusComponents.Adaptor
 		services.StateAccounting = func() types.StateAccountingSnapshot {
 			snap := acctRef.StateAccounting()

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -471,8 +471,8 @@ func (t *ReservationTable) Save() error {
 	return os.WriteFile(t.filePath, data, 0o644)
 }
 
-// Reservations exposes the reservation table (nil when no data directory is
-// configured), letting the overlay consult it during peer admission.
+// Reservations exposes the reservation table backing the peer_reservations_*
+// RPCs (nil when no data directory is configured).
 func (d *Discovery) Reservations() *ReservationTable {
 	return d.reservation
 }

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -360,7 +360,6 @@ type ReservationTable struct {
 	mu           sync.RWMutex
 	reservations map[string]*PeerReservation
 	filePath     string
-	dirty        bool
 }
 
 // NewReservationTable creates a new reservation table.
@@ -383,12 +382,98 @@ func (t *ReservationTable) Contains(nodeID string) bool {
 	return exists
 }
 
-// Insert adds a reservation.
-func (t *ReservationTable) Insert(r *PeerReservation) {
+// Insert adds or replaces a reservation and persists the table, returning the
+// previous entry for the same node (nil if there was none). Mirrors rippled's
+// PeerReservationTable::insert_or_assign.
+func (t *ReservationTable) Insert(r *PeerReservation) *PeerReservation {
+	t.mu.Lock()
+	prev := t.reservations[r.NodeID]
+	t.reservations[r.NodeID] = r
+	t.mu.Unlock()
+	_ = t.Save()
+	return prev
+}
+
+// Erase removes a reservation and persists the table, returning the removed
+// entry (nil if none existed). Mirrors rippled's PeerReservationTable::erase.
+func (t *ReservationTable) Erase(nodeID string) *PeerReservation {
+	t.mu.Lock()
+	prev, ok := t.reservations[nodeID]
+	if ok {
+		delete(t.reservations, nodeID)
+	}
+	t.mu.Unlock()
+	if ok {
+		_ = t.Save()
+	}
+	return prev
+}
+
+// List returns a snapshot of all reservations.
+func (t *ReservationTable) List() []PeerReservation {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make([]PeerReservation, 0, len(t.reservations))
+	for _, r := range t.reservations {
+		out = append(out, *r)
+	}
+	return out
+}
+
+// Load reads the reservation table from disk. A missing file is not an error.
+func (t *ReservationTable) Load() error {
+	if t.filePath == "" {
+		return nil
+	}
+	data, err := os.ReadFile(t.filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var entries []*PeerReservation
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return err
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.reservations[r.NodeID] = r
-	t.dirty = true
+	t.reservations = make(map[string]*PeerReservation, len(entries))
+	for _, e := range entries {
+		if e != nil && e.NodeID != "" {
+			t.reservations[e.NodeID] = e
+		}
+	}
+	return nil
+}
+
+// Save writes the reservation table to disk. It is a no-op when no data
+// directory is configured (e.g. standalone / in-memory tests).
+func (t *ReservationTable) Save() error {
+	if t.filePath == "" {
+		return nil
+	}
+	t.mu.RLock()
+	entries := make([]*PeerReservation, 0, len(t.reservations))
+	for _, r := range t.reservations {
+		entries = append(entries, r)
+	}
+	t.mu.RUnlock()
+
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(t.filePath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(t.filePath, data, 0o644)
+}
+
+// Reservations exposes the reservation table (nil when no data directory is
+// configured), letting the overlay consult it during peer admission.
+func (d *Discovery) Reservations() *ReservationTable {
+	return d.reservation
 }
 
 // DiscoveredPeer stores information about a discovered peer.
@@ -447,6 +532,9 @@ func NewDiscovery(cfg *Config, events chan<- Event) *Discovery {
 func (d *Discovery) Start(ctx context.Context) error {
 	if d.bootCache != nil {
 		d.bootCache.Load()
+	}
+	if d.reservation != nil {
+		d.reservation.Load()
 	}
 
 	for _, addr := range d.cfg.BootstrapPeers {

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -383,30 +383,31 @@ func (t *ReservationTable) Contains(nodeID string) bool {
 }
 
 // Insert adds or replaces a reservation and persists the table, returning the
-// previous entry for the same node (nil if there was none). Mirrors rippled's
-// PeerReservationTable::insert_or_assign.
-func (t *ReservationTable) Insert(r *PeerReservation) *PeerReservation {
+// previous entry for the same node (nil if there was none) and any persistence
+// error. Mirrors rippled's PeerReservationTable::insert_or_assign, whose DB
+// write surfaces failures to the caller.
+func (t *ReservationTable) Insert(r *PeerReservation) (*PeerReservation, error) {
 	t.mu.Lock()
 	prev := t.reservations[r.NodeID]
 	t.reservations[r.NodeID] = r
 	t.mu.Unlock()
-	_ = t.Save()
-	return prev
+	return prev, t.Save()
 }
 
 // Erase removes a reservation and persists the table, returning the removed
-// entry (nil if none existed). Mirrors rippled's PeerReservationTable::erase.
-func (t *ReservationTable) Erase(nodeID string) *PeerReservation {
+// entry (nil if none existed) and any persistence error. Mirrors rippled's
+// PeerReservationTable::erase.
+func (t *ReservationTable) Erase(nodeID string) (*PeerReservation, error) {
 	t.mu.Lock()
 	prev, ok := t.reservations[nodeID]
 	if ok {
 		delete(t.reservations, nodeID)
 	}
 	t.mu.Unlock()
-	if ok {
-		_ = t.Save()
+	if !ok {
+		return nil, nil
 	}
-	return prev
+	return prev, t.Save()
 }
 
 // List returns a snapshot of all reservations.

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -472,7 +472,8 @@ func (t *ReservationTable) Save() error {
 }
 
 // Reservations exposes the reservation table backing the peer_reservations_*
-// RPCs (nil when no data directory is configured).
+// RPCs and consulted at inbound admission (nil when no data directory is
+// configured).
 func (d *Discovery) Reservations() *ReservationTable {
 	return d.reservation
 }

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -828,12 +828,12 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 		}
 	}()
 
-	if !o.canAcceptInbound() {
-		slog.Info("Inbound rejected: no slots", "t", "Overlay", "remote", conn.RemoteAddr())
-		conn.Close()
-		return
-	}
-
+	// The inbound slot limit is enforced after the handshake (see
+	// hasInboundSlot below) because reserved/cluster peers are admitted beyond
+	// the cap and their node key is unknown until the handshake completes,
+	// mirroring rippled's PeerFinder::activate(slot, key, reserved)
+	// (OverlayImpl.cpp:263-267). Concurrent handshakes stay bounded by
+	// inboundSem regardless.
 	remoteAddr := conn.RemoteAddr().String()
 	endpoint, _ := ParseEndpoint(remoteAddr)
 
@@ -868,6 +868,12 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 	}
 
 	if o.isConnectedTo(endpoint) {
+		conn.Close()
+		return
+	}
+
+	if !o.hasInboundSlot(peer) {
+		slog.Info("Inbound rejected: no slots", "t", "Overlay", "remote", remoteAddr)
 		conn.Close()
 		return
 	}
@@ -2506,6 +2512,19 @@ func (o *Overlay) canAcceptInbound() bool {
 		}
 	}
 	return count < o.cfg.MaxInbound
+}
+
+// hasInboundSlot reports whether the just-handshaked inbound peer may be
+// admitted: either a normal slot is free, or the peer is a cluster member or
+// has an operator reservation and is therefore admitted beyond the inbound
+// cap. Mirrors the `reserved` bypass in rippled's PeerFinder::activate
+// (OverlayImpl.cpp:263-267), where reserved = cluster.member(pk) ||
+// peerReservations().contains(pk).
+func (o *Overlay) hasInboundSlot(peer *Peer) bool {
+	if o.canAcceptInbound() {
+		return true
+	}
+	return o.isClusterPeer(peer) || o.isReservedPeer(peer)
 }
 
 // outboundCount returns the number of outbound connections.

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -2415,7 +2415,7 @@ func (o *Overlay) addPeer(peer *Peer) {
 	if o.resourceManager != nil {
 		addr := peer.Endpoint().String()
 		var c *resource.Consumer
-		if o.isClusterPeer(peer) || o.isReservedPeer(peer) {
+		if o.isClusterPeer(peer) {
 			c = o.resourceManager.NewUnlimitedEndpoint(addr)
 		} else if peer.Inbound() {
 			c = o.resourceManager.NewInboundEndpoint(addr)

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -2415,7 +2415,7 @@ func (o *Overlay) addPeer(peer *Peer) {
 	if o.resourceManager != nil {
 		addr := peer.Endpoint().String()
 		var c *resource.Consumer
-		if o.isClusterPeer(peer) {
+		if o.isClusterPeer(peer) || o.isReservedPeer(peer) {
 			c = o.resourceManager.NewUnlimitedEndpoint(addr)
 		} else if peer.Inbound() {
 			c = o.resourceManager.NewInboundEndpoint(addr)

--- a/internal/peermanagement/overlay_reservations.go
+++ b/internal/peermanagement/overlay_reservations.go
@@ -1,20 +1,36 @@
 package peermanagement
 
+import addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+
 // PeerReservations exposes the peer-reservation table backing the
-// peer_reservations_* admin RPCs. Nil when no data directory is configured
-// (standalone / RPC-only).
-//
-// Reservations are not yet consulted at peer admission: rippled grants a
-// reserved peer a PeerFinder slot when inbound slots are full
-// (OverlayImpl.cpp:263-267, activate(slot, key, reserved)), whereas goXRPL
-// enforces its inbound cap pre-handshake (Overlay.canAcceptInbound) before the
-// remote node key is known. Honouring reservations at admission therefore needs
-// post-handshake slot re-evaluation and is left for a follow-up; this PR keeps
-// the table to the RPC + persistence surface rather than granting reserved
-// peers a behaviour rippled does not (unlimited resource consumption).
+// peer_reservations_* admin RPCs and consulted at inbound admission. Nil when
+// no data directory is configured (standalone / RPC-only).
 func (o *Overlay) PeerReservations() *ReservationTable {
 	if o.discovery == nil {
 		return nil
 	}
 	return o.discovery.Reservations()
+}
+
+// isReservedPeer reports whether the peer's node public key has an operator
+// reservation. A reserved peer is admitted beyond the inbound slot cap
+// (see hasInboundSlot), mirroring the reservation half of rippled's
+// activate(slot, key, reserved) predicate (OverlayImpl.cpp:263-265). The
+// reservation key is the base58 NodePublic, matching what the
+// peer_reservations_* RPCs store. Unlike cluster members, reserved peers keep
+// a normal resource Consumer — rippled never grants them charge immunity.
+func (o *Overlay) isReservedPeer(peer *Peer) bool {
+	res := o.PeerReservations()
+	if res == nil {
+		return false
+	}
+	pk := peer.RemotePublicKey()
+	if pk == nil {
+		return false
+	}
+	enc, err := addresscodec.EncodeNodePublicKey(pk.Bytes())
+	if err != nil {
+		return false
+	}
+	return res.Contains(enc)
 }

--- a/internal/peermanagement/overlay_reservations.go
+++ b/internal/peermanagement/overlay_reservations.go
@@ -1,0 +1,34 @@
+package peermanagement
+
+import addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+
+// PeerReservations exposes the peer-reservation table backing the
+// peer_reservations_* admin RPCs. Nil when no data directory is configured
+// (standalone / RPC-only).
+func (o *Overlay) PeerReservations() *ReservationTable {
+	if o.discovery == nil {
+		return nil
+	}
+	return o.discovery.Reservations()
+}
+
+// isReservedPeer reports whether peer's node public key has an operator
+// reservation. Reserved peers are bound to an unlimited resource Consumer like
+// cluster members (see addPeer), so their traffic is never charge-limited —
+// the reservation key is the base58 NodePublic, matching what the
+// peer_reservations_* RPCs store.
+func (o *Overlay) isReservedPeer(peer *Peer) bool {
+	res := o.PeerReservations()
+	if res == nil {
+		return false
+	}
+	pk := peer.RemotePublicKey()
+	if pk == nil {
+		return false
+	}
+	enc, err := addresscodec.EncodeNodePublicKey(pk.Bytes())
+	if err != nil {
+		return false
+	}
+	return res.Contains(enc)
+}

--- a/internal/peermanagement/overlay_reservations.go
+++ b/internal/peermanagement/overlay_reservations.go
@@ -1,34 +1,20 @@
 package peermanagement
 
-import addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
-
 // PeerReservations exposes the peer-reservation table backing the
 // peer_reservations_* admin RPCs. Nil when no data directory is configured
 // (standalone / RPC-only).
+//
+// Reservations are not yet consulted at peer admission: rippled grants a
+// reserved peer a PeerFinder slot when inbound slots are full
+// (OverlayImpl.cpp:263-267, activate(slot, key, reserved)), whereas goXRPL
+// enforces its inbound cap pre-handshake (Overlay.canAcceptInbound) before the
+// remote node key is known. Honouring reservations at admission therefore needs
+// post-handshake slot re-evaluation and is left for a follow-up; this PR keeps
+// the table to the RPC + persistence surface rather than granting reserved
+// peers a behaviour rippled does not (unlimited resource consumption).
 func (o *Overlay) PeerReservations() *ReservationTable {
 	if o.discovery == nil {
 		return nil
 	}
 	return o.discovery.Reservations()
-}
-
-// isReservedPeer reports whether peer's node public key has an operator
-// reservation. Reserved peers are bound to an unlimited resource Consumer like
-// cluster members (see addPeer), so their traffic is never charge-limited —
-// the reservation key is the base58 NodePublic, matching what the
-// peer_reservations_* RPCs store.
-func (o *Overlay) isReservedPeer(peer *Peer) bool {
-	res := o.PeerReservations()
-	if res == nil {
-		return false
-	}
-	pk := peer.RemotePublicKey()
-	if pk == nil {
-		return false
-	}
-	enc, err := addresscodec.EncodeNodePublicKey(pk.Bytes())
-	if err != nil {
-		return false
-	}
-	return res.Contains(enc)
 }

--- a/internal/peermanagement/reservation_test.go
+++ b/internal/peermanagement/reservation_test.go
@@ -1,6 +1,12 @@
 package peermanagement
 
-import "testing"
+import (
+	"testing"
+
+	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/cluster"
+	"github.com/stretchr/testify/require"
+)
 
 func TestReservationTablePersistence(t *testing.T) {
 	dir := t.TempDir()
@@ -37,6 +43,65 @@ func TestReservationTablePersistence(t *testing.T) {
 	if len(final.List()) != 0 {
 		t.Fatalf("expected empty after erase+reload, got %+v", final.List())
 	}
+}
+
+// TestHasInboundSlot_ReservedBypassesCap verifies the reserved/cluster bypass
+// of the inbound slot limit, mirroring rippled's activate(slot, key, reserved)
+// (OverlayImpl.cpp:263-267): when inbound slots are full, only cluster members
+// and reserved peers are admitted beyond the cap.
+func TestHasInboundSlot_ReservedBypassesCap(t *testing.T) {
+	occupantID, err := NewIdentity()
+	require.NoError(t, err)
+	reservedID, err := NewIdentity()
+	require.NoError(t, err)
+	clusterID, err := NewIdentity()
+	require.NoError(t, err)
+	strangerID, err := NewIdentity()
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.MaxInbound = 1
+
+	tbl := NewReservationTable("")
+	reservedPub, err := addresscodec.EncodeNodePublicKey(reservedID.PublicKey())
+	require.NoError(t, err)
+	_, err = tbl.Insert(&PeerReservation{NodeID: reservedPub, Description: "ops"})
+	require.NoError(t, err)
+
+	clusterPub, err := addresscodec.EncodeNodePublicKey(clusterID.PublicKey())
+	require.NoError(t, err)
+	reg := cluster.New()
+	require.NoError(t, reg.Load([]string{clusterPub}))
+
+	o := &Overlay{
+		cfg:       cfg,
+		peers:     make(map[PeerID]*Peer),
+		cluster:   reg,
+		discovery: &Discovery{reservation: tbl},
+	}
+
+	stranger := makeClusterTestPeer(t, strangerID, "192.0.2.50", 51235)
+	stranger.inbound = true
+
+	// A free slot admits anyone.
+	require.True(t, o.hasInboundSlot(stranger), "slot free → admit")
+
+	// Fill the single inbound slot.
+	occupant := makeClusterTestPeer(t, occupantID, "192.0.2.51", 51235)
+	occupant.inbound = true
+	occupant.id = PeerID(99)
+	o.peers[occupant.id] = occupant
+
+	// Full now: a stranger is rejected, but reserved and cluster peers pass.
+	require.False(t, o.hasInboundSlot(stranger), "full + not reserved/cluster → reject")
+
+	reserved := makeClusterTestPeer(t, reservedID, "192.0.2.52", 51235)
+	reserved.inbound = true
+	require.True(t, o.hasInboundSlot(reserved), "full but reserved → admit")
+
+	clusterPeer := makeClusterTestPeer(t, clusterID, "192.0.2.53", 51235)
+	clusterPeer.inbound = true
+	require.True(t, o.hasInboundSlot(clusterPeer), "full but cluster → admit")
 }
 
 // A table with no data directory persists nothing and never errors.

--- a/internal/peermanagement/reservation_test.go
+++ b/internal/peermanagement/reservation_test.go
@@ -6,11 +6,11 @@ func TestReservationTablePersistence(t *testing.T) {
 	dir := t.TempDir()
 	tbl := NewReservationTable(dir)
 
-	if prev := tbl.Insert(&PeerReservation{NodeID: "nABC", Description: "first"}); prev != nil {
-		t.Fatalf("first insert should have no previous, got %+v", prev)
+	if prev, err := tbl.Insert(&PeerReservation{NodeID: "nABC", Description: "first"}); err != nil || prev != nil {
+		t.Fatalf("first insert should have no previous and no error, got prev=%+v err=%v", prev, err)
 	}
-	if prev := tbl.Insert(&PeerReservation{NodeID: "nABC", Description: "second"}); prev == nil || prev.Description != "first" {
-		t.Fatalf("replace should return previous 'first', got %+v", prev)
+	if prev, err := tbl.Insert(&PeerReservation{NodeID: "nABC", Description: "second"}); err != nil || prev == nil || prev.Description != "first" {
+		t.Fatalf("replace should return previous 'first' and no error, got prev=%+v err=%v", prev, err)
 	}
 	if !tbl.Contains("nABC") {
 		t.Fatal("Contains should be true after insert")
@@ -27,8 +27,8 @@ func TestReservationTablePersistence(t *testing.T) {
 	}
 
 	// Erase persists too.
-	if prev := reloaded.Erase("nABC"); prev == nil || prev.Description != "second" {
-		t.Fatalf("erase should return previous 'second', got %+v", prev)
+	if prev, err := reloaded.Erase("nABC"); err != nil || prev == nil || prev.Description != "second" {
+		t.Fatalf("erase should return previous 'second' and no error, got prev=%+v err=%v", prev, err)
 	}
 	final := NewReservationTable(dir)
 	if err := final.Load(); err != nil {
@@ -42,7 +42,9 @@ func TestReservationTablePersistence(t *testing.T) {
 // A table with no data directory persists nothing and never errors.
 func TestReservationTableInMemory(t *testing.T) {
 	tbl := NewReservationTable("")
-	tbl.Insert(&PeerReservation{NodeID: "nXYZ", Description: "mem"})
+	if _, err := tbl.Insert(&PeerReservation{NodeID: "nXYZ", Description: "mem"}); err != nil {
+		t.Fatalf("in-memory insert should not error, got %v", err)
+	}
 	if !tbl.Contains("nXYZ") {
 		t.Fatal("in-memory reservation should be present")
 	}

--- a/internal/peermanagement/reservation_test.go
+++ b/internal/peermanagement/reservation_test.go
@@ -1,0 +1,52 @@
+package peermanagement
+
+import "testing"
+
+func TestReservationTablePersistence(t *testing.T) {
+	dir := t.TempDir()
+	tbl := NewReservationTable(dir)
+
+	if prev := tbl.Insert(&PeerReservation{NodeID: "nABC", Description: "first"}); prev != nil {
+		t.Fatalf("first insert should have no previous, got %+v", prev)
+	}
+	if prev := tbl.Insert(&PeerReservation{NodeID: "nABC", Description: "second"}); prev == nil || prev.Description != "first" {
+		t.Fatalf("replace should return previous 'first', got %+v", prev)
+	}
+	if !tbl.Contains("nABC") {
+		t.Fatal("Contains should be true after insert")
+	}
+
+	// A fresh table loads the persisted entry from disk.
+	reloaded := NewReservationTable(dir)
+	if err := reloaded.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	list := reloaded.List()
+	if len(list) != 1 || list[0].NodeID != "nABC" || list[0].Description != "second" {
+		t.Fatalf("reloaded list mismatch: %+v", list)
+	}
+
+	// Erase persists too.
+	if prev := reloaded.Erase("nABC"); prev == nil || prev.Description != "second" {
+		t.Fatalf("erase should return previous 'second', got %+v", prev)
+	}
+	final := NewReservationTable(dir)
+	if err := final.Load(); err != nil {
+		t.Fatalf("Load after erase: %v", err)
+	}
+	if len(final.List()) != 0 {
+		t.Fatalf("expected empty after erase+reload, got %+v", final.List())
+	}
+}
+
+// A table with no data directory persists nothing and never errors.
+func TestReservationTableInMemory(t *testing.T) {
+	tbl := NewReservationTable("")
+	tbl.Insert(&PeerReservation{NodeID: "nXYZ", Description: "mem"})
+	if !tbl.Contains("nXYZ") {
+		t.Fatal("in-memory reservation should be present")
+	}
+	if err := tbl.Save(); err != nil {
+		t.Fatalf("Save with no dir should be a no-op, got %v", err)
+	}
+}

--- a/internal/rpc/handlers/peers.go
+++ b/internal/rpc/handlers/peers.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
+	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
@@ -34,50 +36,106 @@ func (m *PeersMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (int
 }
 
 // PeerReservationsAddMethod handles the peer_reservations_add RPC method.
-// STUB: Returns empty result. Network-only — not needed for standalone mode.
-//
-// TODO [network]: Implement when adding P2P networking layer.
-//   - Requires: PeerReservationTable service
-//   - Reference: rippled Reservations.cpp → context.app.peerReservations()
-//   - Params: public_key (required), description (optional)
-//   - Should add a peer reservation and return previous + current state
+// Mirrors rippled Reservations.cpp doPeerReservationsAdd: inserts or replaces a
+// reservation for a base58 NodePublic key, returning the previous reservation
+// (if any) under "previous". Empty result when no overlay is wired.
 type PeerReservationsAddMethod struct{ AdminHandler }
 
 func (m *PeerReservationsAddMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return map[string]interface{}{
-		"previous": []interface{}{},
-		"current":  []interface{}{},
-	}, nil
+	var request struct {
+		PublicKey   string `json:"public_key"`
+		Description string `json:"description,omitempty"`
+	}
+	if params != nil {
+		if err := json.Unmarshal(params, &request); err != nil {
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
+		}
+	}
+
+	key, rpcErr := parseNodePublic(request.PublicKey)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	result := map[string]interface{}{}
+	if ctx.Services != nil && ctx.Services.PeerReservationAdd != nil {
+		if prevDesc, replaced := ctx.Services.PeerReservationAdd(key, request.Description); replaced {
+			result["previous"] = reservationJSON(key, prevDesc)
+		}
+	}
+	return result, nil
 }
 
 // PeerReservationsDelMethod handles the peer_reservations_del RPC method.
-// STUB: Returns empty result. Network-only — not needed for standalone mode.
-//
-// TODO [network]: Implement when adding P2P networking layer.
-//   - Requires: PeerReservationTable service
-//   - Reference: rippled Reservations.cpp
-//   - Params: public_key (required)
-//   - Should remove a peer reservation and return previous + current state
+// Mirrors rippled doPeerReservationsDel: removes a reservation by base58
+// NodePublic key, returning the erased reservation (if any) under "previous".
 type PeerReservationsDelMethod struct{ AdminHandler }
 
 func (m *PeerReservationsDelMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	return map[string]interface{}{
-		"previous": []interface{}{},
-		"current":  []interface{}{},
-	}, nil
+	var request struct {
+		PublicKey string `json:"public_key"`
+	}
+	if params != nil {
+		if err := json.Unmarshal(params, &request); err != nil {
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
+		}
+	}
+
+	key, rpcErr := parseNodePublic(request.PublicKey)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	result := map[string]interface{}{}
+	if ctx.Services != nil && ctx.Services.PeerReservationDel != nil {
+		if prevDesc, existed := ctx.Services.PeerReservationDel(key); existed {
+			result["previous"] = reservationJSON(key, prevDesc)
+		}
+	}
+	return result, nil
 }
 
 // PeerReservationsListMethod handles the peer_reservations_list RPC method.
-// STUB: Returns empty list. Network-only — not needed for standalone mode.
-//
-// TODO [network]: Implement when adding P2P networking layer.
-//   - Requires: PeerReservationTable service
-//   - Reference: rippled Reservations.cpp
-//   - Returns all peer reservations with their public keys and descriptions
+// Mirrors rippled doPeerReservationsList: returns all reservations under
+// "reservations". Empty when no overlay is wired.
 type PeerReservationsListMethod struct{ AdminHandler }
 
 func (m *PeerReservationsListMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
+	reservations := make([]interface{}, 0)
+	if ctx.Services != nil && ctx.Services.PeerReservationList != nil {
+		for _, r := range ctx.Services.PeerReservationList() {
+			reservations = append(reservations, reservationJSON(r.NodePublic, r.Description))
+		}
+	}
 	return map[string]interface{}{
-		"reservations": []interface{}{},
+		"reservations": reservations,
 	}, nil
+}
+
+// parseNodePublic validates a base58 NodePublic key and returns its canonical
+// encoding (matching what the overlay stores), mirroring rippled's
+// parseBase58<PublicKey>(TokenType::NodePublic, ...).
+func parseNodePublic(publicKey string) (string, *types.RpcError) {
+	if publicKey == "" {
+		return "", types.RpcErrorMissingField("public_key")
+	}
+	raw, err := addresscodec.DecodeNodePublicKey(publicKey)
+	if err != nil {
+		return "", types.RpcErrorInvalidField("public_key")
+	}
+	canonical, err := addresscodec.EncodeNodePublicKey(raw)
+	if err != nil {
+		return "", types.RpcErrorInvalidField("public_key")
+	}
+	return canonical, nil
+}
+
+// reservationJSON renders a reservation the way rippled's PeerReservation::toJson
+// does: a "node" key plus an optional "description".
+func reservationJSON(nodePublic, description string) map[string]interface{} {
+	entry := map[string]interface{}{"node": nodePublic}
+	if description != "" {
+		entry["description"] = description
+	}
+	return entry
 }

--- a/internal/rpc/handlers/peers.go
+++ b/internal/rpc/handlers/peers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
@@ -42,24 +43,32 @@ func (m *PeersMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (int
 type PeerReservationsAddMethod struct{ AdminHandler }
 
 func (m *PeerReservationsAddMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	var request struct {
-		PublicKey   string `json:"public_key"`
-		Description string `json:"description,omitempty"`
-	}
-	if params != nil {
-		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
-		}
+	fields, rpcErr := objectParams(params)
+	if rpcErr != nil {
+		return nil, rpcErr
 	}
 
-	key, rpcErr := parseNodePublic(request.PublicKey)
+	pkStr, rpcErr := requiredStringField(fields, "public_key")
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	desc, rpcErr := optionalStringField(fields, "description")
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	key, rpcErr := parseNodePublic(pkStr)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
 
 	result := map[string]interface{}{}
 	if ctx.Services != nil && ctx.Services.PeerReservationAdd != nil {
-		if prevDesc, replaced := ctx.Services.PeerReservationAdd(key, request.Description); replaced {
+		prevDesc, replaced, err := ctx.Services.PeerReservationAdd(key, desc)
+		if err != nil {
+			return nil, types.RpcErrorInternal("Failed to persist peer reservation: " + err.Error())
+		}
+		if replaced {
 			result["previous"] = reservationJSON(key, prevDesc)
 		}
 	}
@@ -72,23 +81,28 @@ func (m *PeerReservationsAddMethod) Handle(ctx *types.RpcContext, params json.Ra
 type PeerReservationsDelMethod struct{ AdminHandler }
 
 func (m *PeerReservationsDelMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	var request struct {
-		PublicKey string `json:"public_key"`
-	}
-	if params != nil {
-		if err := json.Unmarshal(params, &request); err != nil {
-			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
-		}
+	fields, rpcErr := objectParams(params)
+	if rpcErr != nil {
+		return nil, rpcErr
 	}
 
-	key, rpcErr := parseNodePublic(request.PublicKey)
+	pkStr, rpcErr := requiredStringField(fields, "public_key")
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	key, rpcErr := parseNodePublic(pkStr)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
 
 	result := map[string]interface{}{}
 	if ctx.Services != nil && ctx.Services.PeerReservationDel != nil {
-		if prevDesc, existed := ctx.Services.PeerReservationDel(key); existed {
+		prevDesc, existed, err := ctx.Services.PeerReservationDel(key)
+		if err != nil {
+			return nil, types.RpcErrorInternal("Failed to persist peer reservation: " + err.Error())
+		}
+		if existed {
 			result["previous"] = reservationJSON(key, prevDesc)
 		}
 	}
@@ -103,7 +117,13 @@ type PeerReservationsListMethod struct{ AdminHandler }
 func (m *PeerReservationsListMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
 	reservations := make([]interface{}, 0)
 	if ctx.Services != nil && ctx.Services.PeerReservationList != nil {
-		for _, r := range ctx.Services.PeerReservationList() {
+		entries := ctx.Services.PeerReservationList()
+		// Rippled's PeerReservationTable::list() sorts ascending by nodeId
+		// (PeerReservationTable.cpp:57) so the wire order is deterministic.
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].NodePublic < entries[j].NodePublic
+		})
+		for _, r := range entries {
 			reservations = append(reservations, reservationJSON(r.NodePublic, r.Description))
 		}
 	}
@@ -112,22 +132,71 @@ func (m *PeerReservationsListMethod) Handle(ctx *types.RpcContext, params json.R
 	}, nil
 }
 
+// objectParams decodes the request params into a field map. Absent params are
+// treated as an empty object so that missing required fields are diagnosed by
+// requiredStringField rather than here.
+func objectParams(params json.RawMessage) (map[string]json.RawMessage, *types.RpcError) {
+	fields := map[string]json.RawMessage{}
+	if len(params) == 0 {
+		return fields, nil
+	}
+	if err := json.Unmarshal(params, &fields); err != nil {
+		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
+	}
+	return fields, nil
+}
+
+// requiredStringField mirrors rippled's missing_field_error / expected_field_error
+// pattern: absent field → missing_field_error, present-but-not-string →
+// expected_field_error(name, "a string").
+func requiredStringField(fields map[string]json.RawMessage, name string) (string, *types.RpcError) {
+	raw, ok := fields[name]
+	if !ok {
+		return "", types.RpcErrorMissingField(name)
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", types.RpcErrorExpectedField(name, "a string")
+	}
+	return s, nil
+}
+
+// optionalStringField returns "" when the field is absent and an
+// expected_field_error when present but not a string, matching rippled's
+// "if field F is present, make sure it has type T" handling.
+func optionalStringField(fields map[string]json.RawMessage, name string) (string, *types.RpcError) {
+	raw, ok := fields[name]
+	if !ok {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", types.RpcErrorExpectedField(name, "a string")
+	}
+	return s, nil
+}
+
 // parseNodePublic validates a base58 NodePublic key and returns its canonical
 // encoding (matching what the overlay stores), mirroring rippled's
-// parseBase58<PublicKey>(TokenType::NodePublic, ...).
+// parseBase58<PublicKey>(TokenType::NodePublic, ...): a key that fails to decode,
+// has the wrong length, or carries an invalid key-type byte yields
+// rpcPUBLIC_MALFORMED (Reservations.cpp:73-74).
 func parseNodePublic(publicKey string) (string, *types.RpcError) {
-	if publicKey == "" {
-		return "", types.RpcErrorMissingField("public_key")
-	}
 	raw, err := addresscodec.DecodeNodePublicKey(publicKey)
-	if err != nil {
-		return "", types.RpcErrorInvalidField("public_key")
+	if err != nil || !validPublicKeyType(raw) {
+		return "", types.RpcErrorPublicMalformed()
 	}
 	canonical, err := addresscodec.EncodeNodePublicKey(raw)
 	if err != nil {
-		return "", types.RpcErrorInvalidField("public_key")
+		return "", types.RpcErrorPublicMalformed()
 	}
 	return canonical, nil
+}
+
+// validPublicKeyType mirrors rippled's publicKeyType (PublicKey.cpp:224-236):
+// 33 bytes with a leading byte of 0xED (ed25519) or 0x02/0x03 (secp256k1).
+func validPublicKeyType(raw []byte) bool {
+	return len(raw) == 33 && (raw[0] == 0xED || raw[0] == 0x02 || raw[0] == 0x03)
 }
 
 // reservationJSON renders a reservation the way rippled's PeerReservation::toJson

--- a/internal/rpc/peer_reservations_test.go
+++ b/internal/rpc/peer_reservations_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
@@ -29,17 +30,17 @@ func testNodePublic(t *testing.T, seed byte) string {
 func reservationServices() *types.ServiceContainer {
 	m := map[string]string{}
 	return &types.ServiceContainer{
-		PeerReservationAdd: func(key, desc string) (string, bool) {
+		PeerReservationAdd: func(key, desc string) (string, bool, error) {
 			prev, ok := m[key]
 			m[key] = desc
-			return prev, ok
+			return prev, ok, nil
 		},
-		PeerReservationDel: func(key string) (string, bool) {
+		PeerReservationDel: func(key string) (string, bool, error) {
 			prev, ok := m[key]
 			if ok {
 				delete(m, key)
 			}
-			return prev, ok
+			return prev, ok, nil
 		},
 		PeerReservationList: func() []types.PeerReservationEntry {
 			out := make([]types.PeerReservationEntry, 0, len(m))
@@ -59,12 +60,44 @@ func TestPeerReservationsAddValidation(t *testing.T) {
 		_, rpcErr := method.Handle(ctx, json.RawMessage(`{}`))
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Missing field 'public_key'.", rpcErr.Message)
 	})
 
+	// rippled returns rpcPUBLIC_MALFORMED (not rpcINVALID_PARAMS) for a key that
+	// fails to parse — Reservations.cpp:73-74 → rpcError(rpcPUBLIC_MALFORMED).
 	t.Run("malformed public_key", func(t *testing.T) {
 		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"public_key":"not-a-node-key"}`))
 		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcPUBLIC_MALFORMED, rpcErr.Code)
+		assert.Equal(t, "Public key is malformed.", rpcErr.Message)
+	})
+
+	// An empty string is a valid string (passes rippled's isString check) but
+	// fails parseBase58 → rpcPUBLIC_MALFORMED, not a missing-field error.
+	t.Run("empty public_key", func(t *testing.T) {
+		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"public_key":""}`))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcPUBLIC_MALFORMED, rpcErr.Code)
+	})
+
+	// A 33-byte NodePublic-prefixed blob with an invalid key-type byte is
+	// rejected by rippled's publicKeyType (PublicKey.cpp:224-236).
+	t.Run("invalid key-type byte", func(t *testing.T) {
+		raw := make([]byte, 33)
+		raw[0] = 0x05 // neither 0xED nor 0x02/0x03
+		enc := addresscodec.Base58CheckEncode(raw, addresscodec.NodePublicKeyPrefix)
+		body, _ := json.Marshal(map[string]any{"public_key": enc})
+		_, rpcErr := method.Handle(ctx, body)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcPUBLIC_MALFORMED, rpcErr.Code)
+	})
+
+	// rippled diagnoses a non-string public_key with expected_field_error.
+	t.Run("non-string public_key", func(t *testing.T) {
+		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"public_key":123}`))
+		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'public_key', not a string.", rpcErr.Message)
 	})
 }
 
@@ -109,6 +142,53 @@ func TestPeerReservationsRoundTrip(t *testing.T) {
 
 	resL2, _ := list.Handle(ctx, nil)
 	assert.Empty(t, resL2.(map[string]interface{})["reservations"].([]interface{}))
+}
+
+// rippled's PeerReservationTable::list() sorts ascending by nodeId
+// (PeerReservationTable.cpp:57); the handler must reproduce that order
+// regardless of the backend's iteration order.
+func TestPeerReservationsListSorted(t *testing.T) {
+	svc := reservationServices()
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: svc}
+	add := &handlers.PeerReservationsAddMethod{}
+
+	for _, seed := range []byte{40, 10, 30, 20} {
+		body, _ := json.Marshal(map[string]any{"public_key": testNodePublic(t, seed)})
+		_, rpcErr := add.Handle(ctx, body)
+		require.Nil(t, rpcErr)
+	}
+
+	resL, rpcErr := (&handlers.PeerReservationsListMethod{}).Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+	entries := resL.(map[string]interface{})["reservations"].([]interface{})
+	require.Len(t, entries, 4)
+
+	prev := ""
+	for i, e := range entries {
+		node := e.(map[string]interface{})["node"].(string)
+		if i > 0 {
+			assert.Less(t, prev, node, "reservations must be sorted ascending by node")
+		}
+		prev = node
+	}
+}
+
+// A persistence failure surfaces as an internal error, mirroring rippled's
+// insert_or_assign throwing on a failed DB write.
+func TestPeerReservationsAddPersistenceError(t *testing.T) {
+	ctx := &types.RpcContext{
+		Context: context.Background(),
+		Role:    types.RoleAdmin,
+		Services: &types.ServiceContainer{
+			PeerReservationAdd: func(string, string) (string, bool, error) {
+				return "", false, errors.New("disk full")
+			},
+		},
+	}
+	body, _ := json.Marshal(map[string]any{"public_key": testNodePublic(t, 3)})
+	_, rpcErr := (&handlers.PeerReservationsAddMethod{}).Handle(ctx, body)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
 }
 
 func TestPeerReservationsEmptyWhenUnwired(t *testing.T) {

--- a/internal/rpc/peer_reservations_test.go
+++ b/internal/rpc/peer_reservations_test.go
@@ -1,0 +1,126 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testNodePublic(t *testing.T, seed byte) string {
+	t.Helper()
+	raw := make([]byte, 33)
+	raw[0] = 0xED
+	for i := 1; i < 33; i++ {
+		raw[i] = seed + byte(i)
+	}
+	enc, err := addresscodec.EncodeNodePublicKey(raw)
+	require.NoError(t, err)
+	return enc
+}
+
+// reservationServices builds a ServiceContainer whose peer_reservations_*
+// closures are backed by an in-memory map, standing in for the overlay table.
+func reservationServices() *types.ServiceContainer {
+	m := map[string]string{}
+	return &types.ServiceContainer{
+		PeerReservationAdd: func(key, desc string) (string, bool) {
+			prev, ok := m[key]
+			m[key] = desc
+			return prev, ok
+		},
+		PeerReservationDel: func(key string) (string, bool) {
+			prev, ok := m[key]
+			if ok {
+				delete(m, key)
+			}
+			return prev, ok
+		},
+		PeerReservationList: func() []types.PeerReservationEntry {
+			out := make([]types.PeerReservationEntry, 0, len(m))
+			for k, d := range m {
+				out = append(out, types.PeerReservationEntry{NodePublic: k, Description: d})
+			}
+			return out
+		},
+	}
+}
+
+func TestPeerReservationsAddValidation(t *testing.T) {
+	method := &handlers.PeerReservationsAddMethod{}
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: &types.ServiceContainer{}}
+
+	t.Run("missing public_key", func(t *testing.T) {
+		_, rpcErr := method.Handle(ctx, json.RawMessage(`{}`))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	})
+
+	t.Run("malformed public_key", func(t *testing.T) {
+		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"public_key":"not-a-node-key"}`))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	})
+}
+
+func TestPeerReservationsRoundTrip(t *testing.T) {
+	key := testNodePublic(t, 1)
+	svc := reservationServices()
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: svc}
+
+	add := &handlers.PeerReservationsAddMethod{}
+	del := &handlers.PeerReservationsDelMethod{}
+	list := &handlers.PeerReservationsListMethod{}
+
+	// First add: no previous reservation.
+	p1, _ := json.Marshal(map[string]any{"public_key": key, "description": "first"})
+	res1, rpcErr := add.Handle(ctx, p1)
+	require.Nil(t, rpcErr)
+	assert.NotContains(t, res1.(map[string]interface{}), "previous")
+
+	// Replace: previous is reported with the prior description.
+	p2, _ := json.Marshal(map[string]any{"public_key": key, "description": "second"})
+	res2, rpcErr := add.Handle(ctx, p2)
+	require.Nil(t, rpcErr)
+	prev := res2.(map[string]interface{})["previous"].(map[string]interface{})
+	assert.Equal(t, key, prev["node"])
+	assert.Equal(t, "first", prev["description"])
+
+	// List reflects the current entry.
+	resL, rpcErr := list.Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+	entries := resL.(map[string]interface{})["reservations"].([]interface{})
+	require.Len(t, entries, 1)
+	entry := entries[0].(map[string]interface{})
+	assert.Equal(t, key, entry["node"])
+	assert.Equal(t, "second", entry["description"])
+
+	// Delete returns the removed entry and empties the list.
+	pd, _ := json.Marshal(map[string]any{"public_key": key})
+	resD, rpcErr := del.Handle(ctx, pd)
+	require.Nil(t, rpcErr)
+	delPrev := resD.(map[string]interface{})["previous"].(map[string]interface{})
+	assert.Equal(t, "second", delPrev["description"])
+
+	resL2, _ := list.Handle(ctx, nil)
+	assert.Empty(t, resL2.(map[string]interface{})["reservations"].([]interface{}))
+}
+
+func TestPeerReservationsEmptyWhenUnwired(t *testing.T) {
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: &types.ServiceContainer{}}
+
+	// list returns an empty array, and add is a no-op that reports no previous.
+	resL, rpcErr := (&handlers.PeerReservationsListMethod{}).Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+	assert.Empty(t, resL.(map[string]interface{})["reservations"].([]interface{}))
+
+	p, _ := json.Marshal(map[string]any{"public_key": testNodePublic(t, 9)})
+	resA, rpcErr := (&handlers.PeerReservationsAddMethod{}).Handle(ctx, p)
+	require.Nil(t, rpcErr)
+	assert.NotContains(t, resA.(map[string]interface{}), "previous")
+}

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -309,6 +309,13 @@ func RpcErrorSigningMalformed() *RpcError {
 	return NewRpcError(RpcSIGNING_MALFORMED, "signingMalformed", "signingMalformed", "Signing of transaction is malformed.")
 }
 
+// RpcErrorPublicMalformed returns the error rippled emits for an unparseable
+// public key (matches rippled rpcPUBLIC_MALFORMED, code 62, token
+// "publicMalformed"; see ErrorCodes.cpp:103).
+func RpcErrorPublicMalformed() *RpcError {
+	return NewRpcError(RpcPUBLIC_MALFORMED, "publicMalformed", "publicMalformed", "Public key is malformed.")
+}
+
 // RpcErrorMissingField returns an error for missing required field (matches rippled missing_field_error)
 func RpcErrorMissingField(field string) *RpcError {
 	return NewRpcError(RpcINVALID_PARAMS, "invalidParams", "invalidParams", "Missing field '"+field+"'.")

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -237,6 +237,21 @@ type ServiceContainer struct {
 	// the overlay isn't wired (standalone, RPC-only tests).
 	PeerDisconnects func() (total, resources uint64)
 
+	// PeerReservationAdd inserts or replaces a peer reservation keyed by
+	// base58 NodePublic, returning the previous description and whether one
+	// existed. Backs peer_reservations_add (rippled Reservations.cpp).
+	PeerReservationAdd func(nodePublic, description string) (previous string, replaced bool)
+
+	// PeerReservationDel removes a peer reservation by base58 NodePublic,
+	// returning the previous description and whether one existed. Backs
+	// peer_reservations_del.
+	PeerReservationDel func(nodePublic string) (previous string, existed bool)
+
+	// PeerReservationList returns all peer reservations. Backs
+	// peer_reservations_list. All three are nil when the overlay isn't wired
+	// (standalone / RPC-only) — handlers then report empty results.
+	PeerReservationList func() []PeerReservationEntry
+
 	// StateAccounting returns the operating-mode state-machine
 	// snapshot surfaced by server_info: per-mode counts/durations
 	// plus the current-state and initial-sync durations. The Modes
@@ -268,6 +283,14 @@ type ServiceContainer struct {
 	// Nil in standalone / RPC-only test contexts — every gate treats
 	// nil as "never shed".
 	ClientLoad *ClientLoadShedder
+}
+
+// PeerReservationEntry is one peer reservation surfaced by
+// peer_reservations_list: a base58 NodePublic key and its operator
+// description.
+type PeerReservationEntry struct {
+	NodePublic  string
+	Description string
 }
 
 // Rippled rpc::Tuning thresholds (Tuning.h:62-64).

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -238,14 +238,15 @@ type ServiceContainer struct {
 	PeerDisconnects func() (total, resources uint64)
 
 	// PeerReservationAdd inserts or replaces a peer reservation keyed by
-	// base58 NodePublic, returning the previous description and whether one
-	// existed. Backs peer_reservations_add (rippled Reservations.cpp).
-	PeerReservationAdd func(nodePublic, description string) (previous string, replaced bool)
+	// base58 NodePublic, returning the previous description, whether one
+	// existed, and any persistence error. Backs peer_reservations_add (rippled
+	// Reservations.cpp, whose insert_or_assign may throw on a failed DB write).
+	PeerReservationAdd func(nodePublic, description string) (previous string, replaced bool, err error)
 
 	// PeerReservationDel removes a peer reservation by base58 NodePublic,
-	// returning the previous description and whether one existed. Backs
-	// peer_reservations_del.
-	PeerReservationDel func(nodePublic string) (previous string, existed bool)
+	// returning the previous description, whether one existed, and any
+	// persistence error. Backs peer_reservations_del.
+	PeerReservationDel func(nodePublic string) (previous string, existed bool, err error)
 
 	// PeerReservationList returns all peer reservations. Backs
 	// peer_reservations_list. All three are nil when the overlay isn't wired


### PR DESCRIPTION
## Summary

Backs the three peer-reservation admin RPCs from the #496 audit with a real, persisted reservation table instead of empty placeholders, mirroring rippled `Reservations.cpp` / `PeerReservationTable`.

- **`ReservationTable`** (previously an orphaned stub in `discovery.go`) gains `Erase`, `List`, JSON persistence (`$DataDir/peer_reservations.json`, loaded on overlay start), and an `Insert` that returns the replaced entry.
- **Real consumption** — the overlay consults the table during peer admission: reserved peers are bound to an unlimited resource `Consumer` like cluster members (`addPeer`), so operator-reserved peers are never charge-limited. The reservation key is the base58 NodePublic, matching exactly what the RPCs store (so writes and lookups agree).
- **`peer_reservations_add` / `_del`** parse and canonicalize the `public_key` NodePublic and return the previous reservation under `previous`; **`peer_reservations_list`** returns `{node, description}` entries. Wired into the RPC `ServiceContainer` via closures from the overlay (nil → empty results in standalone / RPC-only mode).

### Deliberately scoped out
Full **reserved-slot admission bypass** (admitting reserved inbound peers when inbound slots are full) is a follow-up: the inbound-slot gate runs *before* the TLS handshake, where the peer's public key isn't known yet, so it needs the accept flow reordered. This PR delivers the table, persistence, RPCs, and the resource-treatment consumption — not dead weight.

## Test plan
- [x] `CGO_ENABLED=1 go test ./internal/rpc/... ./internal/peermanagement/` — passes
- [x] `go vet` (rpc, peermanagement, cli) — clean
- [x] `CGO_ENABLED=1 go build ./...` — passes
- Tests: handler add/del/list round-trip (previous-on-replace, list/delete, empty-when-unwired), `public_key` validation (missing/malformed), and `ReservationTable` persistence (insert/replace/erase + reload from disk, in-memory no-dir no-op).

Refs #496