### PR TITLE
feat: wire AmendmentTable into the live node (vote sourcing, resync, persistence, RPC)

### DIFF
--- a/amendment/table.go
+++ b/amendment/table.go
@@ -340,6 +340,10 @@ func (t *AmendmentTable) LastVote() *LastVote {
 // ledger at seq. Amendment state can only change at flag ledgers (every 256),
 // so it returns true only when seq and the last folded-in ledger fall in
 // different 256-ledger windows. Mirrors AmendmentTableImpl::needValidatedLedger.
+//
+// The (seq-1) underflow at the initial lastUpdateSeq==0 is intentional and
+// matches rippled bit-for-bit: (0-1)/256 wraps to a sentinel window so the first
+// validated ledger always triggers a sync. Do not "fix" it.
 func (t *AmendmentTable) NeedValidatedLedger(seq uint32) bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/amendment/table.go
+++ b/amendment/table.go
@@ -45,6 +45,23 @@ type AmendmentTable struct {
 	// activate. nil when no unsupported amendment currently holds majority.
 	// Mirrors AmendmentTableImpl::firstUnsupportedExpected_.
 	firstUnsupportedExpected *uint32
+
+	// lastVote caches the tallies from the most recent voting round for RPC
+	// introspection (the `feature` command). nil until the first round.
+	// Mirrors AmendmentTableImpl::lastVote_.
+	lastVote *LastVote
+}
+
+// LastVote captures the per-amendment tallies from the most recent amendment
+// voting round, for admin `feature` RPC introspection. Mirrors rippled's
+// AmendmentSet (votes_, trustedValidations_, threshold_).
+type LastVote struct {
+	// TrustedValidations is the number of trusted validations counted.
+	TrustedValidations int
+	// Threshold is the yes-vote count an amendment needed to pass this round.
+	Threshold int
+	// Votes is the yes-vote count per amendment hash.
+	Votes map[[32]byte]int
 }
 
 // NewAmendmentTable creates a new AmendmentTable with no enabled amendments.
@@ -280,6 +297,45 @@ func (t *AmendmentTable) FirstUnsupportedExpected() (uint32, bool) {
 	return *t.firstUnsupportedExpected, true
 }
 
+// SetLastVote stores the tallies from the most recent voting round. The Votes
+// map is copied defensively. Mirrors stashing AmendmentSet into lastVote_.
+func (t *AmendmentTable) SetLastVote(v *LastVote) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if v == nil {
+		t.lastVote = nil
+		return
+	}
+	cp := &LastVote{
+		TrustedValidations: v.TrustedValidations,
+		Threshold:          v.Threshold,
+		Votes:              make(map[[32]byte]int, len(v.Votes)),
+	}
+	for id, n := range v.Votes {
+		cp.Votes[id] = n
+	}
+	t.lastVote = cp
+}
+
+// LastVote returns the most recent voting-round tallies, or nil if no round has
+// been recorded. The returned value is a defensive copy.
+func (t *AmendmentTable) LastVote() *LastVote {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.lastVote == nil {
+		return nil
+	}
+	cp := &LastVote{
+		TrustedValidations: t.lastVote.TrustedValidations,
+		Threshold:          t.lastVote.Threshold,
+		Votes:              make(map[[32]byte]int, len(t.lastVote.Votes)),
+	}
+	for id, n := range t.lastVote.Votes {
+		cp.Votes[id] = n
+	}
+	return cp
+}
+
 // NeedValidatedLedger reports whether DoValidatedLedger should run for the
 // ledger at seq. Amendment state can only change at flag ledgers (every 256),
 // so it returns true only when seq and the last folded-in ledger fall in
@@ -360,6 +416,17 @@ func (t *AmendmentTable) Clone() *AmendmentTable {
 	if t.firstUnsupportedExpected != nil {
 		v := *t.firstUnsupportedExpected
 		clone.firstUnsupportedExpected = &v
+	}
+	if t.lastVote != nil {
+		cp := &LastVote{
+			TrustedValidations: t.lastVote.TrustedValidations,
+			Threshold:          t.lastVote.Threshold,
+			Votes:              make(map[[32]byte]int, len(t.lastVote.Votes)),
+		}
+		for id, n := range t.lastVote.Votes {
+			cp.Votes[id] = n
+		}
+		clone.lastVote = cp
 	}
 	return clone
 }

--- a/amendment/table.go
+++ b/amendment/table.go
@@ -8,6 +8,11 @@ import (
 	"sync"
 )
 
+// majorityTimeSeconds is the duration an amendment must hold majority before it
+// is enabled (14 days). Mirrors rippled's DEFAULT_AMENDMENT_MAJORITY_TIME used
+// to project firstUnsupportedExpected.
+const majorityTimeSeconds uint32 = 14 * 24 * 60 * 60
+
 // AmendmentTable tracks which amendments are enabled and manages voting.
 // This is the central data structure for amendment management in the node.
 type AmendmentTable struct {
@@ -21,6 +26,25 @@ type AmendmentTable struct {
 
 	// upVoted tracks amendments explicitly voted for by the operator
 	upVoted map[[32]byte]bool
+
+	// unsupportedEnabled is set once an amendment this build does not support
+	// becomes enabled. Cached counterpart of HasUnsupportedEnabled.
+	// Mirrors rippled's AmendmentTableImpl::unsupportedEnabled_.
+	unsupportedEnabled bool
+
+	// blocked is sticky: once an unsupported amendment activates the node can no
+	// longer validate new ledgers. Mirrors NetworkOPs::amendmentBlocked_.
+	blocked bool
+
+	// lastUpdateSeq is the sequence of the last validated ledger folded into the
+	// table by DoValidatedLedger. Mirrors AmendmentTableImpl::lastUpdateSeq_.
+	lastUpdateSeq uint32
+
+	// firstUnsupportedExpected, when set, is the projected close time (XRPL epoch
+	// seconds) at which the earliest unsupported amendment holding majority would
+	// activate. nil when no unsupported amendment currently holds majority.
+	// Mirrors AmendmentTableImpl::firstUnsupportedExpected_.
+	firstUnsupportedExpected *uint32
 }
 
 // NewAmendmentTable creates a new AmendmentTable with no enabled amendments.
@@ -38,8 +62,18 @@ func NewAmendmentTableWithEnabled(enabledIDs [][32]byte) *AmendmentTable {
 	t := NewAmendmentTable()
 	for _, id := range enabledIDs {
 		t.enabled[id] = true
+		if !isSupported(id) {
+			t.unsupportedEnabled = true
+		}
 	}
 	return t
+}
+
+// isSupported reports whether the given amendment is recognised and supported
+// by this build.
+func isSupported(featureID [32]byte) bool {
+	f := GetFeature(featureID)
+	return f != nil && f.Supported == SupportedYes
 }
 
 // IsEnabled returns true if the amendment with the given ID is enabled.
@@ -65,6 +99,9 @@ func (t *AmendmentTable) Enable(featureID [32]byte) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.enabled[featureID] = true
+	if !isSupported(featureID) {
+		t.unsupportedEnabled = true
+	}
 }
 
 // Disable marks an amendment as not enabled. This is primarily for testing.
@@ -80,6 +117,9 @@ func (t *AmendmentTable) EnableMultiple(featureIDs [][32]byte) {
 	defer t.mu.Unlock()
 	for _, id := range featureIDs {
 		t.enabled[id] = true
+		if !isSupported(id) {
+			t.unsupportedEnabled = true
+		}
 	}
 }
 
@@ -211,6 +251,87 @@ func (t *AmendmentTable) GetUnsupportedEnabled() [][32]byte {
 	return result
 }
 
+// IsBlocked reports whether the node is amendment-blocked: an amendment this
+// build does not support has activated, so the node can no longer validate new
+// ledgers. Sticky once set. Mirrors NetworkOPs::isAmendmentBlocked.
+func (t *AmendmentTable) IsBlocked() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.blocked
+}
+
+// SetBlocked marks the node amendment-blocked. Mirrors
+// NetworkOPs::setAmendmentBlocked.
+func (t *AmendmentTable) SetBlocked() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.blocked = true
+}
+
+// FirstUnsupportedExpected returns the projected activation time (XRPL epoch
+// seconds) of the earliest unsupported amendment currently holding majority,
+// or (0, false) when none. Mirrors AmendmentTableImpl::firstUnsupportedExpected.
+func (t *AmendmentTable) FirstUnsupportedExpected() (uint32, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.firstUnsupportedExpected == nil {
+		return 0, false
+	}
+	return *t.firstUnsupportedExpected, true
+}
+
+// NeedValidatedLedger reports whether DoValidatedLedger should run for the
+// ledger at seq. Amendment state can only change at flag ledgers (every 256),
+// so it returns true only when seq and the last folded-in ledger fall in
+// different 256-ledger windows. Mirrors AmendmentTableImpl::needValidatedLedger.
+func (t *AmendmentTable) NeedValidatedLedger(seq uint32) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return ((seq - 1) / 256) != ((t.lastUpdateSeq - 1) / 256)
+}
+
+// DoValidatedLedger re-syncs the in-memory table from a validated flag ledger:
+// it enables every amendment in `enabled` and recomputes
+// firstUnsupportedExpected from `majorities` (amendment hash → majority close
+// time in XRPL epoch seconds). Blocking is engaged once an unsupported
+// amendment is enabled. Mirrors AmendmentTableImpl::doValidatedLedger.
+func (t *AmendmentTable) DoValidatedLedger(seq uint32, enabled map[[32]byte]bool, majorities map[[32]byte]uint32) {
+	// enable() locks internally; run it before taking the lock, as rippled does.
+	for id := range enabled {
+		t.Enable(id)
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.lastUpdateSeq = seq
+
+	var earliest uint32
+	haveEarliest := false
+	for hash, closeTime := range majorities {
+		if t.enabled[hash] {
+			continue
+		}
+		if isSupported(hash) {
+			continue
+		}
+		if !haveEarliest || closeTime < earliest {
+			earliest = closeTime
+			haveEarliest = true
+		}
+	}
+	if haveEarliest {
+		projected := earliest + majorityTimeSeconds
+		t.firstUnsupportedExpected = &projected
+	} else {
+		t.firstUnsupportedExpected = nil
+	}
+
+	if t.unsupportedEnabled {
+		t.blocked = true
+	}
+}
+
 // EnabledCount returns the number of enabled amendments.
 func (t *AmendmentTable) EnabledCount() int {
 	t.mu.RLock()
@@ -232,6 +353,13 @@ func (t *AmendmentTable) Clone() *AmendmentTable {
 	}
 	for id := range t.upVoted {
 		clone.upVoted[id] = true
+	}
+	clone.unsupportedEnabled = t.unsupportedEnabled
+	clone.blocked = t.blocked
+	clone.lastUpdateSeq = t.lastUpdateSeq
+	if t.firstUnsupportedExpected != nil {
+		v := *t.firstUnsupportedExpected
+		clone.firstUnsupportedExpected = &v
 	}
 	return clone
 }

--- a/amendment/table_resync_test.go
+++ b/amendment/table_resync_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2024-2025. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package amendment
+
+import "testing"
+
+// unknownAmendment is a hash not present in the registry.
+var unknownAmendment = [32]byte{0xDE, 0xAD, 0xBE, 0xEF}
+
+func TestEnable_TracksUnsupported(t *testing.T) {
+	tbl := NewAmendmentTable()
+
+	tbl.Enable(FeatureDID) // supported
+	if tbl.unsupportedEnabled {
+		t.Fatal("enabling a supported amendment must not set unsupportedEnabled")
+	}
+	if tbl.IsBlocked() {
+		t.Fatal("supported amendment must not block")
+	}
+
+	tbl.Enable(FeatureXChainBridge) // SupportedNo
+	if !tbl.unsupportedEnabled {
+		t.Fatal("enabling an unsupported amendment must set unsupportedEnabled")
+	}
+
+	tbl.Enable(unknownAmendment)
+	if !tbl.unsupportedEnabled {
+		t.Fatal("enabling an unknown amendment must set unsupportedEnabled")
+	}
+}
+
+func TestDoValidatedLedger_EnablesAndBlocks(t *testing.T) {
+	tbl := NewAmendmentTable()
+
+	enabled := map[[32]byte]bool{
+		FeatureDID:          true,
+		FeatureXChainBridge: true, // unsupported
+	}
+	tbl.DoValidatedLedger(256, enabled, nil)
+
+	if !tbl.IsEnabled(FeatureDID) || !tbl.IsEnabled(FeatureXChainBridge) {
+		t.Fatal("DoValidatedLedger must enable all amendments in the set")
+	}
+	if !tbl.HasUnsupportedEnabled() {
+		t.Fatal("expected HasUnsupportedEnabled after enabling XChainBridge")
+	}
+	if !tbl.IsBlocked() {
+		t.Fatal("node must be blocked once an unsupported amendment activates")
+	}
+	if _, ok := tbl.FirstUnsupportedExpected(); ok {
+		t.Fatal("no majorities supplied; firstUnsupportedExpected must be unset")
+	}
+}
+
+func TestDoValidatedLedger_FirstUnsupportedExpected(t *testing.T) {
+	tbl := NewAmendmentTable()
+
+	const unsupportedMajorityTime uint32 = 1_000_000
+	majorities := map[[32]byte]uint32{
+		FeatureXChainBridge: unsupportedMajorityTime,       // unsupported, not enabled
+		FeatureDID:          unsupportedMajorityTime - 100, // supported → ignored
+	}
+	tbl.DoValidatedLedger(256, nil, majorities)
+
+	exp, ok := tbl.FirstUnsupportedExpected()
+	if !ok {
+		t.Fatal("expected firstUnsupportedExpected to be set for an unsupported majority")
+	}
+	if want := unsupportedMajorityTime + majorityTimeSeconds; exp != want {
+		t.Fatalf("firstUnsupportedExpected = %d, want %d (majority time + 14d)", exp, want)
+	}
+	if tbl.IsBlocked() {
+		t.Fatal("an unsupported amendment only in majority (not enabled) must not block")
+	}
+
+	// Once the unsupported amendment is enabled and no longer in majority, the
+	// projection clears.
+	tbl.DoValidatedLedger(512, map[[32]byte]bool{FeatureXChainBridge: true}, nil)
+	if _, ok := tbl.FirstUnsupportedExpected(); ok {
+		t.Fatal("firstUnsupportedExpected must clear once majority no longer holds")
+	}
+	if !tbl.IsBlocked() {
+		t.Fatal("node must be blocked after the unsupported amendment activates")
+	}
+}
+
+func TestNeedValidatedLedger_Windowing(t *testing.T) {
+	tbl := NewAmendmentTable()
+
+	// Fresh table (lastUpdateSeq 0) always needs the first sync.
+	if !tbl.NeedValidatedLedger(100) {
+		t.Fatal("fresh table must need a validated-ledger sync")
+	}
+
+	tbl.DoValidatedLedger(100, nil, nil)
+
+	if tbl.NeedValidatedLedger(200) {
+		t.Fatal("seq 200 is in the same 256-window as 100; no sync needed")
+	}
+	if !tbl.NeedValidatedLedger(300) {
+		t.Fatal("seq 300 crosses into a new 256-window; sync needed")
+	}
+}

--- a/amendment/table_resync_test.go
+++ b/amendment/table_resync_test.go
@@ -86,6 +86,35 @@ func TestDoValidatedLedger_FirstUnsupportedExpected(t *testing.T) {
 	}
 }
 
+func TestLastVote_RoundTripAndDefensiveCopy(t *testing.T) {
+	tbl := NewAmendmentTable()
+	if tbl.LastVote() != nil {
+		t.Fatal("fresh table must have no last vote")
+	}
+
+	src := &LastVote{
+		TrustedValidations: 5,
+		Threshold:          4,
+		Votes:              map[[32]byte]int{FeatureDID: 3},
+	}
+	tbl.SetLastVote(src)
+
+	// Mutating the source after SetLastVote must not affect the stored copy.
+	src.Votes[FeatureDID] = 99
+	src.TrustedValidations = 0
+
+	got := tbl.LastVote()
+	if got == nil || got.TrustedValidations != 5 || got.Threshold != 4 || got.Votes[FeatureDID] != 3 {
+		t.Fatalf("stored last vote not isolated from source: %+v", got)
+	}
+
+	// Mutating the returned copy must not affect the stored value.
+	got.Votes[FeatureDID] = 1
+	if again := tbl.LastVote(); again.Votes[FeatureDID] != 3 {
+		t.Fatal("LastVote must return a defensive copy")
+	}
+}
+
 func TestNeedValidatedLedger_Windowing(t *testing.T) {
 	tbl := NewAmendmentTable()
 

--- a/config/amendments.go
+++ b/config/amendments.go
@@ -1,0 +1,37 @@
+package config
+
+import "fmt"
+
+// AmendmentsConfig represents the [amendments] section: the operator's
+// amendment voting preferences. Entries are amendment names as defined in the
+// amendment registry. Mirrors rippled's [amendments] (upvote) and
+// [veto_amendments] (veto) stanzas.
+type AmendmentsConfig struct {
+	// Upvote lists amendments this node actively votes FOR, beyond the registry
+	// defaults. Equivalent to rippled's [amendments] stanza.
+	Upvote []string `toml:"upvote" mapstructure:"upvote"`
+
+	// Veto lists amendments this node refuses to vote for. Equivalent to
+	// rippled's [veto_amendments] stanza.
+	Veto []string `toml:"veto" mapstructure:"veto"`
+}
+
+// Validate rejects an amendment listed in both upvote and veto, which is
+// contradictory.
+func (a *AmendmentsConfig) Validate() error {
+	up := make(map[string]struct{}, len(a.Upvote))
+	for _, n := range a.Upvote {
+		up[n] = struct{}{}
+	}
+	for _, n := range a.Veto {
+		if _, ok := up[n]; ok {
+			return fmt.Errorf("amendment %q is listed in both upvote and veto", n)
+		}
+	}
+	return nil
+}
+
+// IsEmpty returns true when no operator amendment preferences are configured.
+func (a *AmendmentsConfig) IsEmpty() bool {
+	return len(a.Upvote) == 0 && len(a.Veto) == 0
+}

--- a/config/amendments_test.go
+++ b/config/amendments_test.go
@@ -1,0 +1,23 @@
+package config
+
+import "testing"
+
+func TestAmendmentsConfig_Validate(t *testing.T) {
+	ok := AmendmentsConfig{Upvote: []string{"a", "b"}, Veto: []string{"c"}}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("disjoint lists should validate, got %v", err)
+	}
+
+	clash := AmendmentsConfig{Upvote: []string{"a", "b"}, Veto: []string{"b"}}
+	if err := clash.Validate(); err == nil {
+		t.Fatal("an amendment in both upvote and veto must be rejected")
+	}
+
+	empty := AmendmentsConfig{}
+	if !empty.IsEmpty() {
+		t.Fatal("zero-value AmendmentsConfig should be empty")
+	}
+	if empty.Validate() != nil {
+		t.Fatal("empty config should validate")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,9 @@ type Config struct {
 	// 8. Voting
 	Voting VotingConfig `toml:"voting" mapstructure:"voting"`
 
+	// Amendments holds the operator's amendment voting preferences.
+	Amendments AmendmentsConfig `toml:"amendments" mapstructure:"amendments"`
+
 	// 9. Misc Settings
 	NodeSize       string      `toml:"node_size" mapstructure:"node_size"`
 	SigningSupport bool        `toml:"signing_support" mapstructure:"signing_support"`

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -226,3 +226,11 @@ zero_basefee_transaction_feelevel = 256000
 # Validator list endpoint (optional)
 # [vl]
 # enable = 1
+
+# Operator amendment voting preferences (optional). Names match the amendment
+# registry. `upvote` actively votes FOR an amendment (rippled's [amendments]
+# stanza); `veto` refuses to vote for it (rippled's [veto_amendments] stanza).
+# An amendment must not appear in both lists.
+# [amendments]
+# upvote = ["fixReducedOffersV2"]
+# veto   = ["DeepFreeze"]

--- a/config/validation.go
+++ b/config/validation.go
@@ -64,6 +64,9 @@ func ValidateConfig(config *Config) error {
 	if err := config.Voting.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("voting: %w", err))
 	}
+	if err := config.Amendments.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("amendments: %w", err))
+	}
 
 	// 8. Validate misc settings
 	if err := validateMiscSettings(config); err != nil {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/codec/addresscodec"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/config"
@@ -214,13 +215,20 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		return fmt.Errorf("get network ID: %w", err)
 	}
 
+	// Build the live amendment table from the operator's [amendments] config.
+	// One instance is shared between the ledger service (which folds validated
+	// flag ledgers into it) and the consensus adaptor (which sources vote
+	// stances from it).
+	amendmentTable := buildAmendmentTable(globalConfig.Amendments, serverLog)
+
 	// Initialize ledger service
 	cfg := service.Config{
-		Standalone:   standalone,
-		NetworkID:    uint32(networkID),
-		NodeStore:    db,
-		RelationalDB: repoManager,
-		Logger:       rootLogger,
+		Standalone:     standalone,
+		NetworkID:      uint32(networkID),
+		NodeStore:      db,
+		RelationalDB:   repoManager,
+		Logger:         rootLogger,
+		AmendmentTable: amendmentTable,
 	}
 	cfg.GenesisConfig = genesisConfig
 
@@ -1435,4 +1443,30 @@ func parseVLLength(data []byte) (int, int) {
 		return 0, 0
 	}
 	return 12481 + ((b1 - 241) * 65536) + (int(data[1]) * 256) + int(data[2]), 3
+}
+
+// buildAmendmentTable constructs the live amendment table from the operator's
+// [amendments] config, resolving names to registry feature IDs (unknown names
+// are logged and ignored). The returned table owns operator veto/upvote and the
+// enabled/blocked state, and is shared between the ledger service and the
+// consensus adaptor.
+func buildAmendmentTable(cfg config.AmendmentsConfig, log xrpllog.Logger) *amendment.AmendmentTable {
+	t := amendment.NewAmendmentTable()
+	for _, name := range cfg.Upvote {
+		f := amendment.GetFeatureByName(name)
+		if f == nil {
+			log.Warn("unknown amendment in [amendments].upvote; ignoring", "name", name)
+			continue
+		}
+		t.UpVote(f.ID)
+	}
+	for _, name := range cfg.Veto {
+		f := amendment.GetFeatureByName(name)
+		if f == nil {
+			log.Warn("unknown amendment in [amendments].veto; ignoring", "name", name)
+			continue
+		}
+		t.Veto(f.ID)
+	}
+	return t
 }

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -219,7 +219,7 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	// One instance is shared between the ledger service (which folds validated
 	// flag ledgers into it) and the consensus adaptor (which sources vote
 	// stances from it).
-	amendmentTable := buildAmendmentTable(globalConfig.Amendments, serverLog)
+	amendmentTable := buildAmendmentTable(globalConfig.Amendments, repoManager, serverLog)
 
 	// Initialize ledger service
 	cfg := service.Config{
@@ -1446,11 +1446,13 @@ func parseVLLength(data []byte) (int, int) {
 }
 
 // buildAmendmentTable constructs the live amendment table from the operator's
-// [amendments] config, resolving names to registry feature IDs (unknown names
-// are logged and ignored). The returned table owns operator veto/upvote and the
-// enabled/blocked state, and is shared between the ledger service and the
-// consensus adaptor.
-func buildAmendmentTable(cfg config.AmendmentsConfig, log xrpllog.Logger) *amendment.AmendmentTable {
+// [amendments] config and any persisted runtime votes. Config preferences are
+// applied first, then persisted votes (from the `feature` RPC) override them so
+// runtime changes win across restarts — mirroring rippled, where the FeatureVotes
+// DB takes precedence over the config stanzas. Unknown names are logged and
+// ignored. The returned table owns operator veto/upvote and the enabled/blocked
+// state, and is shared between the ledger service and the consensus adaptor.
+func buildAmendmentTable(cfg config.AmendmentsConfig, repo relationaldb.RepositoryManager, log xrpllog.Logger) *amendment.AmendmentTable {
 	t := amendment.NewAmendmentTable()
 	for _, name := range cfg.Upvote {
 		f := amendment.GetFeatureByName(name)
@@ -1467,6 +1469,29 @@ func buildAmendmentTable(cfg config.AmendmentsConfig, log xrpllog.Logger) *amend
 			continue
 		}
 		t.Veto(f.ID)
+	}
+
+	if repo == nil || repo.Amendment() == nil {
+		return t
+	}
+	recs, err := repo.Amendment().LoadAmendmentVotes(context.Background())
+	if err != nil {
+		log.Warn("failed to load persisted amendment votes; using config only", "err", err)
+		return t
+	}
+	for _, rec := range recs {
+		idBytes, derr := hex.DecodeString(rec.Amendment)
+		if derr != nil || len(idBytes) != 32 {
+			log.Warn("skipping malformed persisted amendment vote", "amendment", rec.Amendment)
+			continue
+		}
+		var id [32]byte
+		copy(id[:], idBytes)
+		if rec.Vetoed {
+			t.Veto(id)
+		} else {
+			t.UpVote(id)
+		}
 	}
 	return t
 }

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -235,6 +235,13 @@ type Adaptor struct {
 	// overridden to VoteUp.
 	amendmentStances map[[32]byte]amendmentvote.Stance
 
+	// amendmentTable, when set, is the live amendment table this validator
+	// sources vote stances from each round (so operator veto/upvote changes —
+	// config or runtime feature RPC — take effect without restart) and into
+	// which it stashes the per-round vote tallies (lastVote). nil falls back to
+	// the construction-time amendmentStances map.
+	amendmentTable *amendment.AmendmentTable
+
 	// trustedVotes caches per-validator amendment votes for 24h to
 	// dampen amendment "flapping" when a flaky validator drops
 	// briefly. See trusted_votes.go and rippled's TrustedVotes at
@@ -410,24 +417,6 @@ func New(cfg Config) *Adaptor {
 		amendmentStances[f.ID] = amendmentvote.VoteUp
 	}
 
-	// When a live AmendmentTable is supplied it owns the operator preferences:
-	// layer its veto (→ abstain) and upvote (→ VoteUp) over the registry
-	// defaults. Obsolete amendments are never promoted. Mirrors rippled sourcing
-	// votes from the amendment table rather than a static list.
-	if cfg.AmendmentTable != nil {
-		for _, f := range amendment.AllFeatures() {
-			if f.Vote == amendment.VoteObsolete {
-				continue
-			}
-			switch {
-			case cfg.AmendmentTable.IsVetoed(f.ID):
-				delete(amendmentStances, f.ID)
-			case cfg.AmendmentTable.IsUpVoted(f.ID):
-				amendmentStances[f.ID] = amendmentvote.VoteUp
-			}
-		}
-	}
-
 	// Seed the amendment-vote cache with the initial UNL so
 	// RecordVotes accepts validations from round one. Re-call
 	// TrustChanged whenever the trusted set mutates at runtime.
@@ -483,6 +472,7 @@ func New(cfg Config) *Adaptor {
 		cookie:            cookie,
 		feeVote:           feeVote,
 		amendmentStances:  amendmentStances,
+		amendmentTable:    cfg.AmendmentTable,
 		trustedVotes:      trustedVotes,
 		logger:            logger,
 	}
@@ -1295,8 +1285,34 @@ func (a *Adaptor) GetFeeVote() (baseFee, reserveBase, reserveIncrement uint64, p
 // Output is a freshly-allocated slice; the result is canonically
 // sorted by amendment ID so two validators with the same stance
 // produce byte-identical validations.
+// currentAmendmentStances returns the validator's live per-amendment vote
+// stances. When a live amendment table is wired, stances are derived fresh from
+// it (registry defaults, then operator veto → abstain and upvote → VoteUp) so
+// config or runtime feature-RPC changes take effect without restart; otherwise
+// the construction-time map is returned.
+func (a *Adaptor) currentAmendmentStances() map[[32]byte]amendmentvote.Stance {
+	if a.amendmentTable == nil {
+		return a.amendmentStances
+	}
+	stances := make(map[[32]byte]amendmentvote.Stance)
+	for _, f := range amendment.AllFeatures() {
+		switch {
+		case f.Vote == amendment.VoteObsolete:
+			stances[f.ID] = amendmentvote.VoteObsolete
+		case a.amendmentTable.IsVetoed(f.ID):
+			// vetoed → abstain (leave unset)
+		case a.amendmentTable.IsUpVoted(f.ID):
+			stances[f.ID] = amendmentvote.VoteUp
+		case f.Supported == amendment.SupportedYes && f.Vote == amendment.VoteDefaultYes && !f.Retired:
+			stances[f.ID] = amendmentvote.VoteUp
+		}
+	}
+	return stances
+}
+
 func (a *Adaptor) GetAmendmentVote() [][32]byte {
-	if len(a.amendmentStances) == 0 {
+	stances := a.currentAmendmentStances()
+	if len(stances) == 0 {
 		return nil
 	}
 
@@ -1310,8 +1326,8 @@ func (a *Adaptor) GetAmendmentVote() [][32]byte {
 		}
 	}
 
-	out := make([][32]byte, 0, len(a.amendmentStances))
-	for id, stance := range a.amendmentStances {
+	out := make([][32]byte, 0, len(stances))
+	for id, stance := range stances {
 		if stance != amendmentvote.VoteUp {
 			continue
 		}

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -328,6 +328,13 @@ type Config struct {
 	// changes over time. Same semantics as rippled's [amendments]
 	// stanza.
 	AmendmentVote []string
+	// AmendmentTable, when supplied, is the live amendment table that owns the
+	// operator's veto/upvote preferences and the enabled/blocked state. When set
+	// it is authoritative for amendment stances: vetoed amendments abstain and
+	// upvoted amendments vote up, layered over the registry defaults. The same
+	// instance is shared with the ledger service, which folds validated flag
+	// ledgers into it via DoValidatedLedger.
+	AmendmentTable *amendment.AmendmentTable
 }
 
 // New creates a new Adaptor.
@@ -401,6 +408,24 @@ func New(cfg Config) *Adaptor {
 			continue
 		}
 		amendmentStances[f.ID] = amendmentvote.VoteUp
+	}
+
+	// When a live AmendmentTable is supplied it owns the operator preferences:
+	// layer its veto (→ abstain) and upvote (→ VoteUp) over the registry
+	// defaults. Obsolete amendments are never promoted. Mirrors rippled sourcing
+	// votes from the amendment table rather than a static list.
+	if cfg.AmendmentTable != nil {
+		for _, f := range amendment.AllFeatures() {
+			if f.Vote == amendment.VoteObsolete {
+				continue
+			}
+			switch {
+			case cfg.AmendmentTable.IsVetoed(f.ID):
+				delete(amendmentStances, f.ID)
+			case cfg.AmendmentTable.IsUpVoted(f.ID):
+				amendmentStances[f.ID] = amendmentvote.VoteUp
+			}
+		}
 	}
 
 	// Seed the amendment-vote cache with the initial UNL so

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -414,6 +414,12 @@ func New(cfg Config) *Adaptor {
 			logger.Warn("obsolete amendment cannot be voted up; ignoring", "name", name)
 			continue
 		}
+		if f.Supported != amendment.SupportedYes {
+			// rippled's doValidation only votes for supported amendments
+			// (AmendmentTable.cpp:822); an unsupported upvote is never broadcast.
+			logger.Warn("unsupported amendment cannot be voted up; ignoring", "name", name)
+			continue
+		}
 		amendmentStances[f.ID] = amendmentvote.VoteUp
 	}
 
@@ -1301,7 +1307,10 @@ func (a *Adaptor) currentAmendmentStances() map[[32]byte]amendmentvote.Stance {
 			stances[f.ID] = amendmentvote.VoteObsolete
 		case a.amendmentTable.IsVetoed(f.ID):
 			// vetoed → abstain (leave unset)
-		case a.amendmentTable.IsUpVoted(f.ID):
+		case f.Supported == amendment.SupportedYes && a.amendmentTable.IsUpVoted(f.ID):
+			// operator upvote, but only for supported amendments — rippled's
+			// doValidation gates on `supported && vote==up` (AmendmentTable.cpp:822),
+			// so an unsupported amendment is never voted for however it was voted.
 			stances[f.ID] = amendmentvote.VoteUp
 		case f.Supported == amendment.SupportedYes && f.Vote == amendment.VoteDefaultYes && !f.Retired:
 			stances[f.ID] = amendmentvote.VoteUp

--- a/internal/consensus/adaptor/flag_ledger_vote.go
+++ b/internal/consensus/adaptor/flag_ledger_vote.go
@@ -245,9 +245,20 @@ func (a *Adaptor) runAmendmentVote(
 		votes[k] = v
 	}
 
-	stances := make(map[amendmentvote.Amendment]amendmentvote.Stance, len(a.amendmentStances))
-	for id, stance := range a.amendmentStances {
-		stances[id] = stance
+	stances := a.currentAmendmentStances()
+	strict := enabled[amendment.FeatureFixAmendmentMajorityCalc]
+
+	// Stash this round's tallies for `feature` RPC introspection.
+	if a.amendmentTable != nil {
+		snapshot := &amendment.LastVote{
+			TrustedValidations: available,
+			Threshold:          amendmentvote.Threshold(available, strict),
+			Votes:              make(map[[32]byte]int, len(votes)),
+		}
+		for id, n := range votes {
+			snapshot.Votes[id] = n
+		}
+		a.amendmentTable.SetLastVote(snapshot)
 	}
 
 	in := amendmentvote.Inputs{
@@ -259,7 +270,7 @@ func (a *Adaptor) runAmendmentVote(
 		Enabled:            enabled,
 		Majority:           majority,
 		Stances:            stances,
-		StrictMajority:     enabled[amendment.FeatureFixAmendmentMajorityCalc],
+		StrictMajority:     strict,
 	}
 	blobs, err := amendmentvote.DoVoting(in)
 	if err != nil {

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -271,6 +271,10 @@ func NewFromConfig(
 		Identity:            identity,
 		Validators:          validators,
 		ValidatorMasterKeys: masterKeys,
+		// Source vote stances from the same amendment table the ledger service
+		// resyncs from validated ledgers, so operator veto/upvote ([amendments]
+		// config) drives consensus voting.
+		AmendmentTable: ledgerSvc.AmendmentTable(),
 	})
 
 	modeManager := NewModeManager(adaptor)

--- a/internal/ledger/service/amendment_resync_test.go
+++ b/internal/ledger/service/amendment_resync_test.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/amendment"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestService_AmendmentTableResync verifies that AcceptLedger folds the
+// validated ledger's amendment set into the shared amendment table and that the
+// node is not blocked when every enabled amendment is supported.
+func TestService_AmendmentTableResync(t *testing.T) {
+	tbl := amendment.NewAmendmentTable()
+	cfg := DefaultConfig()
+	cfg.AmendmentTable = tbl
+
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	require.False(t, svc.IsAmendmentBlocked(), "fresh node must not be amendment-blocked")
+
+	closedSeq, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+
+	validated := svc.GetClosedLedger()
+	require.NotNil(t, validated)
+
+	// Every amendment enabled in the validated ledger must now be reflected in
+	// the table — proof the resync copied the SLE into the in-memory table.
+	data, err := validated.Read(keylet.Amendments())
+	require.NoError(t, err)
+	if data != nil {
+		sle, perr := pseudo.ParseAmendmentsSLE(data)
+		require.NoError(t, perr)
+		for _, id := range sle.Amendments {
+			require.True(t, tbl.IsEnabled(id), "table must reflect validated-ledger amendment %x", id)
+		}
+	}
+
+	// DoValidatedLedger ran, so a same-window resync is no longer needed.
+	require.False(t, tbl.NeedValidatedLedger(closedSeq),
+		"lastUpdateSeq must advance after the resync")
+
+	require.False(t, svc.IsAmendmentBlocked(), "all genesis amendments are supported")
+	if _, ok := svc.AmendmentFirstUnsupportedExpected(); ok {
+		t.Fatal("no unsupported amendment holds majority")
+	}
+}
+
+// TestService_NilAmendmentTable verifies the accessors are safe when no table
+// is configured.
+func TestService_NilAmendmentTable(t *testing.T) {
+	var s Service
+	require.False(t, s.IsAmendmentBlocked())
+	if _, ok := s.AmendmentFirstUnsupportedExpected(); ok {
+		t.Fatal("nil table must report no projection")
+	}
+	require.Nil(t, s.AmendmentTable())
+}

--- a/internal/ledger/service/amendment_resync_test.go
+++ b/internal/ledger/service/amendment_resync_test.go
@@ -52,6 +52,31 @@ func TestService_AmendmentTableResync(t *testing.T) {
 	}
 }
 
+// TestService_SetAmendmentVote verifies operator veto/upvote mutate the table.
+// (Persistence is exercised by the relationaldb repository tests; here
+// RelationalDB is nil, so SetAmendmentVote applies in-memory and returns nil.)
+func TestService_SetAmendmentVote(t *testing.T) {
+	tbl := amendment.NewAmendmentTable()
+	cfg := DefaultConfig()
+	cfg.AmendmentTable = tbl
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	id := amendment.FeatureDID
+	require.NoError(t, svc.SetAmendmentVote(context.Background(), id, true))
+	require.True(t, tbl.IsVetoed(id))
+	require.False(t, tbl.IsUpVoted(id))
+
+	require.NoError(t, svc.SetAmendmentVote(context.Background(), id, false))
+	require.True(t, tbl.IsUpVoted(id))
+	require.False(t, tbl.IsVetoed(id))
+
+	var s2 Service
+	require.Error(t, s2.SetAmendmentVote(context.Background(), id, true),
+		"no table configured must error")
+}
+
 // TestService_NilAmendmentTable verifies the accessors are safe when no table
 // is configured.
 func TestService_NilAmendmentTable(t *testing.T) {

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -385,6 +386,33 @@ func (s *Service) syncAmendmentTable(l *ledger.Ledger) {
 // adaptor, or nil when none is configured.
 func (s *Service) AmendmentTable() *amendment.AmendmentTable {
 	return s.amendmentTable
+}
+
+// SetAmendmentVote records an operator veto (vetoed=true) or upvote
+// (vetoed=false) for the amendment in the live table and persists it so the
+// preference survives restarts. The in-memory change always applies; an error
+// is returned only when persistence fails. Mirrors rippled's veto()/unVeto().
+func (s *Service) SetAmendmentVote(ctx context.Context, id [32]byte, vetoed bool) error {
+	if s.amendmentTable == nil {
+		return errors.New("amendment table not configured")
+	}
+	if vetoed {
+		s.amendmentTable.Veto(id)
+	} else {
+		s.amendmentTable.UpVote(id)
+	}
+	if s.relationalDB == nil || s.relationalDB.Amendment() == nil {
+		return nil
+	}
+	name := ""
+	if f := amendment.GetFeature(id); f != nil {
+		name = f.Name
+	}
+	return s.relationalDB.Amendment().SaveAmendmentVote(ctx, &relationaldb.AmendmentVoteRecord{
+		Amendment: strings.ToUpper(hex.EncodeToString(id[:])),
+		Name:      name,
+		Vetoed:    vetoed,
+	})
 }
 
 // IsAmendmentBlocked reports whether an unsupported amendment has activated,

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -20,7 +20,9 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/openledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service/svcerr"
 	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
 	"github.com/LeJamon/goXRPLd/internal/txq"
+	"github.com/LeJamon/goXRPLd/keylet"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
 	"github.com/LeJamon/goXRPLd/protocol"
 	"github.com/LeJamon/goXRPLd/shamap"
@@ -60,6 +62,11 @@ type Config struct {
 	// Logger is the logger for the ledger service.
 	// If nil, xrpllog.Discard() is used.
 	Logger xrpllog.Logger
+
+	// AmendmentTable, when supplied, is the live amendment table the service
+	// folds each validated flag ledger into (enabled set + majority projection +
+	// blocked state). Optional — nil disables amendment-table resync.
+	AmendmentTable *amendment.AmendmentTable
 }
 
 // DefaultConfig returns the default service configuration
@@ -121,6 +128,10 @@ type Service struct {
 
 	// RelationalDB for transaction indexing (nil if not configured)
 	relationalDB relationaldb.RepositoryManager
+
+	// amendmentTable is the live amendment table folded by each validated flag
+	// ledger (nil disables resync). Has its own internal mutex.
+	amendmentTable *amendment.AmendmentTable
 
 	// Current open ledger (accepting transactions)
 	openLedger *ledger.Ledger
@@ -316,6 +327,7 @@ func New(cfg Config) (*Service, error) {
 		logger:                   logger.Named(xrpllog.PartitionLedger),
 		nodeStore:                cfg.NodeStore,
 		relationalDB:             cfg.RelationalDB,
+		amendmentTable:           cfg.AmendmentTable,
 		ledgerHistory:            make(map[uint32]*ledger.Ledger),
 		txIndex:                  make(map[[32]byte]uint32),
 		txPositionIndex:          make(map[[32]byte]uint32),
@@ -328,6 +340,71 @@ func New(cfg Config) (*Service, error) {
 	}
 
 	return s, nil
+}
+
+// syncAmendmentTable folds a newly-validated ledger into the live amendment
+// table: it enables the ledger's amendment set, refreshes the majority
+// projection, and engages amendment-block if an unsupported amendment has
+// activated. Gated to flag-ledger windows by NeedValidatedLedger; no-op when no
+// table is configured. Mirrors rippled LedgerMaster::doValidatedLedger →
+// AmendmentTable::doValidatedLedger.
+func (s *Service) syncAmendmentTable(l *ledger.Ledger) {
+	if s.amendmentTable == nil || l == nil {
+		return
+	}
+	seq := l.Sequence()
+	if !s.amendmentTable.NeedValidatedLedger(seq) {
+		return
+	}
+
+	enabled := map[[32]byte]bool{}
+	majorities := map[[32]byte]uint32{}
+	if data, err := l.Read(keylet.Amendments()); err == nil && data != nil {
+		sle, perr := pseudo.ParseAmendmentsSLE(data)
+		if perr != nil {
+			s.logger.Warn("amendment-table resync: failed to parse Amendments SLE",
+				"seq", seq, "err", perr)
+			return
+		}
+		for _, id := range sle.Amendments {
+			enabled[id] = true
+		}
+		for _, m := range sle.Majorities {
+			majorities[m.Amendment] = m.CloseTime
+		}
+	}
+
+	s.amendmentTable.DoValidatedLedger(seq, enabled, majorities)
+	if s.amendmentTable.IsBlocked() {
+		s.logger.Error("amendment blocked: an unsupported amendment has activated; "+
+			"node can no longer validate new ledgers", "seq", seq)
+	}
+}
+
+// AmendmentTable returns the live amendment table shared with the consensus
+// adaptor, or nil when none is configured.
+func (s *Service) AmendmentTable() *amendment.AmendmentTable {
+	return s.amendmentTable
+}
+
+// IsAmendmentBlocked reports whether an unsupported amendment has activated,
+// blocking the node from validating new ledgers. False when no amendment table
+// is configured.
+func (s *Service) IsAmendmentBlocked() bool {
+	if s.amendmentTable == nil {
+		return false
+	}
+	return s.amendmentTable.IsBlocked()
+}
+
+// AmendmentFirstUnsupportedExpected returns the projected activation time (XRPL
+// epoch seconds) of the earliest unsupported amendment currently holding
+// majority, or (0, false) when none or no table is configured.
+func (s *Service) AmendmentFirstUnsupportedExpected() (uint32, bool) {
+	if s.amendmentTable == nil {
+		return 0, false
+	}
+	return s.amendmentTable.FirstUnsupportedExpected()
 }
 
 // SetEventCallback sets the callback function for ledger events
@@ -1019,6 +1096,10 @@ func (s *Service) AcceptLedgerAt(ctx context.Context, explicitCloseTime time.Tim
 	s.validatedLedger = s.openLedger
 	s.ledgerHistory[closedSeq] = s.openLedger
 	s.evictOldHistoryLocked(closedSeq)
+
+	// Standalone validates immediately; fold the validated ledger into the
+	// amendment table (enabled set + majority projection + block detection).
+	s.syncAmendmentTable(s.validatedLedger)
 
 	// Standalone already promotes to validated above, so any stashed
 	// validation at this seq is redundant — but drain it so the entry
@@ -1980,6 +2061,10 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	event := s.drainPendingValidationLocked(expectedHash)
 	callback := s.eventCallback
 	s.mu.Unlock()
+
+	// Fold the just-validated ledger into the amendment table outside the lock
+	// (the table has its own mutex). Mirrors LedgerMaster::doValidatedLedger.
+	s.syncAmendmentTable(l)
 
 	if pool != nil {
 		pool.Sweep(l)

--- a/internal/rpc/admin_role_test.go
+++ b/internal/rpc/admin_role_test.go
@@ -17,7 +17,6 @@ type adminMethodEntry struct {
 // allAdminMethods returns every handler that MUST declare RoleAdmin.
 func allAdminMethods() []adminMethodEntry {
 	return []adminMethodEntry{
-		{"feature", &handlers.FeatureMethod{}},
 		{"connect", &handlers.ConnectMethod{}},
 		{"stop", &handlers.StopMethod{}},
 		{"ledger_accept", &handlers.LedgerAcceptMethod{}},
@@ -81,6 +80,9 @@ func allGuestMethods() []guestMethodEntry {
 		{"server_state", &handlers.ServerStateMethod{}},
 		{"server_definitions", &handlers.ServerDefinitionsMethod{}},
 		{"version", &handlers.VersionMethod{}},
+		// feature is a public (USER) read command; the admin-only fields and the
+		// `vetoed` mutation are gated inside the handler (rippled Handler.cpp).
+		{"feature", &handlers.FeatureMethod{}},
 		{"deposit_authorized", &handlers.DepositAuthorizedMethod{}},
 		{"gateway_balances", &handlers.GatewayBalancesMethod{}},
 		{"noripple_check", &handlers.NoRippleCheckMethod{}},

--- a/internal/rpc/admin_role_test.go
+++ b/internal/rpc/admin_role_test.go
@@ -163,7 +163,7 @@ func TestUserMethodsRequireUserRole(t *testing.T) {
 // added to the handlers package but forgotten in this test catalogue.
 // Update the expected count when adding new admin handlers.
 func TestAdminMethodCount(t *testing.T) {
-	const expectedAdminCount = 28
+	const expectedAdminCount = 27
 
 	got := len(allAdminMethods())
 	assert.Equal(t, expectedAdminCount, got,
@@ -176,7 +176,7 @@ func TestAdminMethodCount(t *testing.T) {
 // added to the handlers package but forgotten in this test catalogue.
 // Update the expected count when adding new guest handlers.
 func TestGuestMethodCount(t *testing.T) {
-	const expectedGuestCount = 40
+	const expectedGuestCount = 41
 
 	got := len(allGuestMethods())
 	assert.Equal(t, expectedGuestCount, got,

--- a/internal/rpc/amendment_blocked_test.go
+++ b/internal/rpc/amendment_blocked_test.go
@@ -14,7 +14,7 @@ import (
 // Reference: rippled/src/test/rpc/AmendmentBlocked_test.cpp
 //
 // When the server is amendment-blocked, methods with any Condition other than
-// NoCondition are blocked with rpcAMENDMENT_BLOCKED (code 40).
+// NoCondition are blocked with rpcAMENDMENT_BLOCKED (code 14).
 // Methods with NoCondition continue to work normally.
 
 // blockedMethods are methods that require a condition (NEEDS_CURRENT_LEDGER,
@@ -83,7 +83,7 @@ func newTestServer() *Server {
 }
 
 // TestAmendmentBlockedMethodsReturnError verifies that methods with conditions
-// return rpcAMENDMENT_BLOCKED (code 40) when the server is amendment-blocked.
+// return rpcAMENDMENT_BLOCKED (code 14) when the server is amendment-blocked.
 // Reference: rippled AmendmentBlocked_test.cpp testBlockedMethods - step 3
 func TestAmendmentBlockedMethodsReturnError(t *testing.T) {
 	mock := newMockLedgerService()
@@ -136,7 +136,7 @@ func TestAmendmentBlockedUnblockedMethodsStillWork(t *testing.T) {
 			_, rpcErr := server.executeMethod(method, params, ctx)
 
 			// The method should NOT return amendmentBlocked.
-			// It may return other errors (e.g., missing params), but never code 40.
+			// It may return other errors (e.g., missing params), but never the amendment-blocked code.
 			if rpcErr != nil {
 				assert.NotEqual(t, types.RpcAMENDMENT_BLOCKED, rpcErr.Code,
 					"Method %s should NOT be amendment-blocked (NoCondition), got error: %s", method, rpcErr.Message)

--- a/internal/rpc/amendment_blocked_test.go
+++ b/internal/rpc/amendment_blocked_test.go
@@ -196,7 +196,7 @@ func TestAmendmentBlockedErrorFormat(t *testing.T) {
 	_, rpcErr := server.executeMethod("submit", json.RawMessage(`{}`), ctx)
 
 	require.NotNil(t, rpcErr)
-	assert.Equal(t, 40, rpcErr.Code)
+	assert.Equal(t, types.RpcAMENDMENT_BLOCKED, rpcErr.Code) // rippled: rpcAMENDMENT_BLOCKED = 14
 	assert.Equal(t, "amendmentBlocked", rpcErr.ErrorString)
 	assert.Equal(t, "amendmentBlocked", rpcErr.Type)
 	assert.Equal(t, "Amendment blocked, need upgrade.", rpcErr.Message)

--- a/internal/rpc/amendment_warnings_test.go
+++ b/internal/rpc/amendment_warnings_test.go
@@ -1,0 +1,252 @@
+package rpc
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/amendment"
+	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/internal/tx/pseudo"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unsupportedAmendmentID is a hash absent from the registry, so isSupported()
+// reports false — used to drive firstUnsupportedExpected.
+var unsupportedAmendmentID = [32]byte{0xAB, 0xCD, 0xEF, 0x01}
+
+// stubAmendmentsView is a minimal LedgerStateView that serves one Amendments
+// SLE for Read(keylet.Amendments()); every other operation is a no-op.
+type stubAmendmentsView struct {
+	amendmentsData []byte
+}
+
+func (v *stubAmendmentsView) Read(k keylet.Keylet) ([]byte, error) {
+	if k == keylet.Amendments() {
+		return v.amendmentsData, nil
+	}
+	return nil, nil
+}
+func (v *stubAmendmentsView) Exists(keylet.Keylet) (bool, error)                 { return false, nil }
+func (v *stubAmendmentsView) Insert(keylet.Keylet, []byte) error                 { return nil }
+func (v *stubAmendmentsView) Update(keylet.Keylet, []byte) error                 { return nil }
+func (v *stubAmendmentsView) Erase(keylet.Keylet) error                          { return nil }
+func (v *stubAmendmentsView) ForEach(func(key [32]byte, data []byte) bool) error { return nil }
+func (v *stubAmendmentsView) Succ([32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+func (v *stubAmendmentsView) AdjustDropsDestroyed(drops.XRPAmount) {}
+func (v *stubAmendmentsView) TxExists([32]byte) bool               { return false }
+func (v *stubAmendmentsView) Rules() *amendment.Rules              { return nil }
+func (v *stubAmendmentsView) LedgerSeq() uint32                    { return 0 }
+
+// mockServerInfoWarnings adds a live amendment table to the server_info mock so
+// buildAmendmentWarnings can read firstUnsupportedExpected.
+type mockServerInfoWarnings struct {
+	*mockLedgerServiceServerInfo
+	table *amendment.AmendmentTable
+}
+
+func (m *mockServerInfoWarnings) AmendmentTable() *amendment.AmendmentTable { return m.table }
+
+// serverInfoWarnings runs server_info and returns the parsed warnings array.
+func serverInfoWarnings(t *testing.T, mock *mockServerInfoWarnings, isAdmin bool) []map[string]interface{} {
+	t.Helper()
+	services := &types.ServiceContainer{Ledger: mock, NodePublicKey: testNodePublicKey()}
+	method := &handlers.ServerInfoMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		IsAdmin:    isAdmin,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	result, rpcErr := method.Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+
+	resultJSON, err := json.Marshal(result)
+	require.NoError(t, err)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(resultJSON, &resp))
+
+	raw, ok := resp["warnings"].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(raw))
+	for _, w := range raw {
+		out = append(out, w.(map[string]interface{}))
+	}
+	return out
+}
+
+func warningByID(warnings []map[string]interface{}, id int) map[string]interface{} {
+	for _, w := range warnings {
+		if int(w["id"].(float64)) == id {
+			return w
+		}
+	}
+	return nil
+}
+
+// TestServerInfoAmendmentWarnings exercises the server_info warning wire shape
+// end-to-end through ServerInfoMethod.Handle. Mirrors rippled
+// NetworkOPsImp::getServerInfo (NetworkOPs.cpp:2644-2676).
+func TestServerInfoAmendmentWarnings(t *testing.T) {
+	// Build a table holding an unsupported amendment in majority (not enabled),
+	// so firstUnsupportedExpected is set but the node is not blocked.
+	tbl := amendment.NewAmendmentTable()
+	const majorityClose uint32 = 800_000_000
+	tbl.DoValidatedLedger(256, nil, map[[32]byte]uint32{unsupportedAmendmentID: majorityClose})
+	expDate, ok := tbl.FirstUnsupportedExpected()
+	require.True(t, ok, "test setup: firstUnsupportedExpected must be set")
+	wantUTC := time.Unix(int64(expDate)+protocol.RippleEpochUnix, 0).UTC().Format("2006-Jan-02 15:04:05 UTC")
+
+	t.Run("admin sees unsupported-majority (1001) with rippled date format", func(t *testing.T) {
+		mock := &mockServerInfoWarnings{mockLedgerServiceServerInfo: newMockLedgerServiceServerInfo(), table: tbl}
+		warnings := serverInfoWarnings(t, mock, true)
+
+		w := warningByID(warnings, types.WarningUnsupportedAmendmentsMajority)
+		require.NotNil(t, w, "admin must see the 1001 warning")
+		assert.Equal(t,
+			"One or more unsupported amendments have reached majority. Upgrade to the latest version before they are activated to avoid being amendment blocked.",
+			w["message"])
+
+		details := w["details"].(map[string]interface{})
+		assert.Equal(t, float64(expDate), details["expected_date"],
+			"expected_date is XRPL-epoch seconds (rippled time_since_epoch().count())")
+		gotUTC, _ := details["expected_date_UTC"].(string)
+		assert.Equal(t, wantUTC, gotUTC,
+			"expected_date_UTC uses rippled's %%Y-%%b-%%d %%T %%Z form, not RFC3339")
+		assert.Contains(t, gotUTC, "May",
+			"rippled renders the abbreviated month name (%%b); RFC3339 would be numeric")
+
+		assert.Nil(t, warningByID(warnings, types.WarningAmendmentBlocked),
+			"node is not blocked, so no 1002")
+	})
+
+	t.Run("non-admin does not see 1001", func(t *testing.T) {
+		mock := &mockServerInfoWarnings{mockLedgerServiceServerInfo: newMockLedgerServiceServerInfo(), table: tbl}
+		warnings := serverInfoWarnings(t, mock, false)
+		assert.Nil(t, warningByID(warnings, types.WarningUnsupportedAmendmentsMajority),
+			"unsupported-majority warning is admin-only (rippled: admin && isAmendmentWarned)")
+	})
+
+	t.Run("blocked node emits 1002 and suppresses 1001", func(t *testing.T) {
+		mock := &mockServerInfoWarnings{mockLedgerServiceServerInfo: newMockLedgerServiceServerInfo(), table: tbl}
+		mock.amendmentBlocked = true
+		warnings := serverInfoWarnings(t, mock, true) // admin, but blocked
+
+		blocked := warningByID(warnings, types.WarningAmendmentBlocked)
+		require.NotNil(t, blocked, "blocked node must emit 1002")
+		assert.Equal(t,
+			"This server is amendment blocked, and must be updated to be able to stay in sync with the network.",
+			blocked["message"])
+
+		assert.Nil(t, warningByID(warnings, types.WarningUnsupportedAmendmentsMajority),
+			"1001 is suppressed while blocked (isAmendmentWarned == !blocked && warned)")
+	})
+
+	t.Run("healthy node emits no amendment warnings", func(t *testing.T) {
+		mock := &mockServerInfoWarnings{mockLedgerServiceServerInfo: newMockLedgerServiceServerInfo(), table: amendment.NewAmendmentTable()}
+		warnings := serverInfoWarnings(t, mock, true)
+		assert.Nil(t, warningByID(warnings, types.WarningUnsupportedAmendmentsMajority))
+		assert.Nil(t, warningByID(warnings, types.WarningAmendmentBlocked))
+	})
+}
+
+// mockFeatureLedger serves an Amendments SLE so the feature handler can surface
+// the per-amendment `majority` field end-to-end.
+type mockFeatureLedger struct {
+	*mockLedgerService
+	view *stubAmendmentsView
+}
+
+func (m *mockFeatureLedger) GetClosedLedgerView() (types.LedgerStateView, error) {
+	return m.view, nil
+}
+
+// TestFeatureMajorityFieldEndToEnd drives FeatureMethod.Handle against a ledger
+// whose Amendments SLE lists an amendment in majority, and asserts the `majority`
+// close time is surfaced. Mirrors rippled doFeature (Feature1.cpp:52,62,95).
+func TestFeatureMajorityFieldEndToEnd(t *testing.T) {
+	did := amendment.GetFeatureByName("DID")
+	require.NotNil(t, did)
+
+	const majorityClose uint32 = 700_000_000
+	sleData, err := pseudo.SerializeAmendmentsSLE(&pseudo.AmendmentsSLE{
+		// DID is in majority but NOT in the enabled set.
+		Majorities: []pseudo.MajorityEntry{{Amendment: did.ID, CloseTime: majorityClose}},
+	})
+	require.NoError(t, err)
+
+	mock := &mockFeatureLedger{
+		mockLedgerService: newMockLedgerService(),
+		view:              &stubAmendmentsView{amendmentsData: sleData},
+	}
+	services := &types.ServiceContainer{Ledger: mock}
+	method := &handlers.FeatureMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest, // majority is emitted to all callers, not admin-gated
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	didHex := strings.ToUpper(hex.EncodeToString(did.ID[:]))
+
+	t.Run("single feature lookup surfaces majority close time", func(t *testing.T) {
+		params, _ := json.Marshal(map[string]interface{}{"feature": "DID"})
+		result, rpcErr := method.Handle(ctx, params)
+		require.Nil(t, rpcErr)
+
+		resp := marshalToMap(t, result)
+		feature := resp[didHex].(map[string]interface{})
+		require.Contains(t, feature, "majority", "amendment in majority must report majority")
+		assert.Equal(t, float64(majorityClose), feature["majority"])
+		assert.Equal(t, false, feature["enabled"], "DID is not in the enabled set")
+	})
+
+	t.Run("all-features response surfaces majority only for the majority amendment", func(t *testing.T) {
+		result, rpcErr := method.Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+
+		resp := marshalToMap(t, result)
+		features := resp["features"].(map[string]interface{})
+
+		didEntry := features[didHex].(map[string]interface{})
+		assert.Equal(t, float64(majorityClose), didEntry["majority"])
+
+		// A different, not-in-majority amendment must omit the field entirely.
+		var other *amendment.Feature
+		for _, f := range amendment.AllFeatures() {
+			if f.ID != did.ID {
+				other = f
+				break
+			}
+		}
+		require.NotNil(t, other)
+		otherHex := strings.ToUpper(hex.EncodeToString(other.ID[:]))
+		assert.NotContains(t, features[otherHex].(map[string]interface{}), "majority",
+			"amendment not in majority must omit majority")
+	})
+}
+
+func marshalToMap(t *testing.T, v interface{}) map[string]interface{} {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m
+}

--- a/internal/rpc/feature_test.go
+++ b/internal/rpc/feature_test.go
@@ -24,6 +24,7 @@ func TestFeatureNoParams(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
+		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -58,7 +59,6 @@ func TestFeatureNoParams(t *testing.T) {
 		assert.Contains(t, feature, "name", "Feature %s should have 'name'", hexID)
 		assert.Contains(t, feature, "enabled", "Feature %s should have 'enabled'", hexID)
 		assert.Contains(t, feature, "supported", "Feature %s should have 'supported'", hexID)
-		assert.Contains(t, feature, "vetoed", "Feature %s should have 'vetoed'", hexID)
 
 		// Name should be a non-empty string
 		name, ok := feature["name"].(string)
@@ -66,10 +66,18 @@ func TestFeatureNoParams(t *testing.T) {
 		assert.NotEmpty(t, name, "Feature name should not be empty")
 
 		// enabled and supported should be booleans
-		_, ok = feature["enabled"].(bool)
+		enabled, ok := feature["enabled"].(bool)
 		assert.True(t, ok, "Feature enabled should be a boolean")
 		_, ok = feature["supported"].(bool)
 		assert.True(t, ok, "Feature supported should be a boolean")
+
+		// vetoed is admin-only and only for not-yet-enabled amendments
+		// (rippled injectJson). This ctx is admin, so vetoed is present iff !enabled.
+		if enabled {
+			assert.NotContains(t, feature, "vetoed", "enabled feature %s must not report vetoed", hexID)
+		} else {
+			assert.Contains(t, feature, "vetoed", "not-enabled feature %s should report vetoed for admin", hexID)
+		}
 	}
 }
 
@@ -82,6 +90,7 @@ func TestFeatureNoParamsEmptyObject(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
+		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -115,6 +124,7 @@ func TestFeatureSingleLookupByName(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
+		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -151,7 +161,12 @@ func TestFeatureSingleLookupByName(t *testing.T) {
 	assert.Equal(t, testFeature.Name, feature["name"], "Feature name should match")
 	assert.Contains(t, feature, "enabled")
 	assert.Contains(t, feature, "supported")
-	assert.Contains(t, feature, "vetoed")
+	// vetoed is admin-only and only for not-yet-enabled amendments (ctx is admin).
+	if enabled, _ := feature["enabled"].(bool); enabled {
+		assert.NotContains(t, feature, "vetoed")
+	} else {
+		assert.Contains(t, feature, "vetoed")
+	}
 }
 
 // TestFeatureSingleLookupByHexID tests looking up a single feature by hex ID.
@@ -164,6 +179,7 @@ func TestFeatureSingleLookupByHexID(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
+		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -200,7 +216,12 @@ func TestFeatureSingleLookupByHexID(t *testing.T) {
 	assert.Equal(t, testFeature.Name, feature["name"])
 	assert.Contains(t, feature, "enabled")
 	assert.Contains(t, feature, "supported")
-	assert.Contains(t, feature, "vetoed")
+	// vetoed is admin-only and only for not-yet-enabled amendments (ctx is admin).
+	if enabled, _ := feature["enabled"].(bool); enabled {
+		assert.NotContains(t, feature, "vetoed")
+	} else {
+		assert.Contains(t, feature, "vetoed")
+	}
 }
 
 // TestFeatureInvalidName tests that looking up a non-existent feature name returns error.
@@ -213,6 +234,7 @@ func TestFeatureInvalidName(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
+		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -239,7 +261,7 @@ func TestFeatureInvalidName(t *testing.T) {
 
 			assert.Nil(t, result, "Expected nil result for invalid feature name")
 			require.NotNil(t, rpcErr, "Expected error for invalid feature name")
-			assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+			assert.Equal(t, types.RpcBAD_FEATURE, rpcErr.Code, "rippled returns rpcBAD_FEATURE for an unknown feature")
 			assert.Contains(t, rpcErr.Message, "Feature not found")
 		})
 	}
@@ -255,6 +277,7 @@ func TestFeatureResponseStructure(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
+		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -292,29 +315,37 @@ func TestFeatureResponseStructure(t *testing.T) {
 				assert.True(t, supported, "Enabled feature %s must be supported", name)
 			}
 
-			// vetoed can be bool or string "Obsolete"
-			vetoed := feature["vetoed"]
-			switch v := vetoed.(type) {
-			case bool:
-				// Valid
-				_ = v
-			case string:
-				assert.Equal(t, "Obsolete", v, "String vetoed value should be 'Obsolete'")
-			default:
-				t.Errorf("vetoed for feature %s has unexpected type %T", name, vetoed)
+			// vetoed is admin-only and only for not-yet-enabled amendments
+			// (rippled injectJson). This ctx is admin: present iff !enabled.
+			vetoed, hasVetoed := feature["vetoed"]
+			if enabled {
+				assert.False(t, hasVetoed, "enabled feature %s must not report vetoed", name)
+			} else {
+				require.True(t, hasVetoed, "not-enabled feature %s should report vetoed for admin", name)
+				// vetoed can be bool or string "Obsolete"
+				switch v := vetoed.(type) {
+				case bool:
+					// Valid
+					_ = v
+				case string:
+					assert.Equal(t, "Obsolete", v, "String vetoed value should be 'Obsolete'")
+				default:
+					t.Errorf("vetoed for feature %s has unexpected type %T", name, vetoed)
+				}
 			}
 		})
 	}
 }
 
 // TestFeatureMethodMetadata tests the method's metadata functions.
-// Verifies admin-only access requirement.
+// Verifies the public (USER) access role; admin-only fields are gated inside the
+// handler, not at the command level (rippled Handler.cpp: {"feature", Role::USER}).
 func TestFeatureMethodMetadata(t *testing.T) {
 	method := &handlers.FeatureMethod{}
 
-	t.Run("RequiredRole is Admin", func(t *testing.T) {
-		assert.Equal(t, types.RoleAdmin, method.RequiredRole(),
-			"feature should require admin role")
+	t.Run("RequiredRole is Guest", func(t *testing.T) {
+		assert.Equal(t, types.RoleGuest, method.RequiredRole(),
+			"feature should be a public (USER) command, not admin-gated")
 	})
 
 	t.Run("SupportedApiVersions", func(t *testing.T) {

--- a/internal/rpc/handlers/feature.go
+++ b/internal/rpc/handlers/feature.go
@@ -14,10 +14,11 @@ import (
 
 // FeatureMethod handles the feature RPC method.
 // Returns information about amendments including their status, support, and voting.
-// Admins may set/clear a veto via the `vetoed` param, and see per-amendment
-// vote tallies (count/validations/threshold) for amendments not yet enabled.
+// Registered at USER role (rippled Handler.cpp: {"feature", ..., Role::USER}): any
+// caller may read amendment status, but the admin-only fields (vetoed, count,
+// validations, threshold) and the `vetoed` mutation require admin.
 // Reference: rippled Feature1.cpp
-type FeatureMethod struct{ AdminHandler }
+type FeatureMethod struct{ BaseHandler }
 
 // amendmentVoteController is the optional capability the live ledger-service
 // adapter implements to expose the amendment table and accept vote mutations.
@@ -36,7 +37,7 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		_ = json.Unmarshal(params, &request)
 	}
 
-	enabledSet := m.getEnabledAmendments(ctx.Services)
+	enabledSet, majorities := m.getAmendmentState(ctx.Services)
 	ctrl := amendmentController(ctx.Services)
 	var tbl *amendment.AmendmentTable
 	if ctrl != nil {
@@ -49,12 +50,15 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 
 	// Admin vote mutation: set or clear a veto on a specific amendment.
 	if request.Vetoed != nil {
+		if !ctx.IsAdmin {
+			return nil, types.RpcErrorNoPermission("feature")
+		}
 		if request.Feature == "" {
 			return nil, types.RpcErrorInvalidParams("feature required to set a vote")
 		}
 		f := resolveFeature(request.Feature)
 		if f == nil {
-			return nil, types.RpcErrorInvalidParams("Feature not found: " + request.Feature)
+			return nil, types.RpcErrorBadFeature("Feature not found: " + request.Feature)
 		}
 		if ctrl == nil || tbl == nil {
 			return nil, types.RpcErrorNotSupported("amendment voting is not available on this server")
@@ -64,7 +68,7 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		}
 		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
 		return map[string]interface{}{
-			hexID: buildFeatureInfo(f, enabledSet, tbl, lastVote, ctx.IsAdmin),
+			hexID: buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.IsAdmin),
 		}, nil
 	}
 
@@ -72,11 +76,11 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	if request.Feature != "" {
 		f := resolveFeature(request.Feature)
 		if f == nil {
-			return nil, types.RpcErrorInvalidParams("Feature not found: " + request.Feature)
+			return nil, types.RpcErrorBadFeature("Feature not found: " + request.Feature)
 		}
 		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
 		return map[string]interface{}{
-			hexID: buildFeatureInfo(f, enabledSet, tbl, lastVote, ctx.IsAdmin),
+			hexID: buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.IsAdmin),
 		}, nil
 	}
 
@@ -85,7 +89,7 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 	features := make(map[string]interface{}, len(allFeatures))
 	for _, f := range allFeatures {
 		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
-		features[hexID] = buildFeatureInfo(f, enabledSet, tbl, lastVote, ctx.IsAdmin)
+		features[hexID] = buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.IsAdmin)
 	}
 	return map[string]interface{}{
 		"features": features,
@@ -117,43 +121,52 @@ func amendmentController(services *types.ServiceContainer) amendmentVoteControll
 	return nil
 }
 
-// getEnabledAmendments reads the Amendments SLE from the closed ledger and returns
-// the set of amendment hashes that are actually enabled on-ledger.
-// Returns nil if the ledger is unavailable, meaning the caller should fall back
+// getAmendmentState reads the Amendments SLE from the closed ledger and returns
+// the set of amendment hashes enabled on-ledger together with the majority map
+// (amendment hash → close time at which it reached majority, XRPL epoch seconds).
+// Both are nil if the ledger is unavailable, meaning the caller should fall back
 // to deriving enabled status from the registry defaults.
-func (m *FeatureMethod) getEnabledAmendments(services *types.ServiceContainer) map[[32]byte]bool {
+func (m *FeatureMethod) getAmendmentState(services *types.ServiceContainer) (enabled map[[32]byte]bool, majorities map[[32]byte]uint32) {
 	if services == nil || services.Ledger == nil {
-		return nil
+		return nil, nil
 	}
 
 	view, err := services.Ledger.GetClosedLedgerView()
 	if err != nil || view == nil {
-		return nil
+		return nil, nil
 	}
 
 	data, err := view.Read(keylet.Amendments())
 	if err != nil || data == nil {
-		return nil
+		return nil, nil
 	}
 
 	sle, err := pseudo.ParseAmendmentsSLE(data)
 	if err != nil || sle == nil {
-		return nil
+		return nil, nil
 	}
 
-	enabled := make(map[[32]byte]bool, len(sle.Amendments))
+	enabled = make(map[[32]byte]bool, len(sle.Amendments))
 	for _, hash := range sle.Amendments {
 		enabled[hash] = true
 	}
-	return enabled
+	majorities = make(map[[32]byte]uint32, len(sle.Majorities))
+	for _, mj := range sle.Majorities {
+		majorities[mj.Amendment] = mj.CloseTime
+	}
+	return enabled, majorities
 }
 
 // buildFeatureInfo constructs the response map for a single amendment feature.
-// `enabledSet` (nil ⇒ fall back to registry defaults) gives the on-ledger
-// enabled status; `tbl` (nil ⇒ registry defaults) provides operator veto/upvote
-// overrides; when admin and the amendment is not yet enabled, `lastVote`
-// supplies the vote tallies.
-func buildFeatureInfo(f *amendment.Feature, enabledSet map[[32]byte]bool, tbl *amendment.AmendmentTable, lastVote *amendment.LastVote, isAdmin bool) map[string]interface{} {
+// `enabledSet` (nil ⇒ fall back to registry defaults) gives the on-ledger enabled
+// status; `majorities` (amendment hash → majority close time) yields the `majority`
+// field for amendments holding ledger majority; `tbl` (nil ⇒ registry defaults)
+// provides operator veto/upvote overrides; when admin and the amendment is not yet
+// enabled, `lastVote` supplies the vote tallies. Field emission mirrors rippled
+// AmendmentTableImpl::injectJson + doFeature: `name`/`enabled`/`supported` always;
+// `vetoed` and `count`/`validations`/`threshold` only for an admin viewing a
+// not-yet-enabled amendment; `majority` whenever the amendment is in the majority set.
+func buildFeatureInfo(f *amendment.Feature, enabledSet map[[32]byte]bool, majorities map[[32]byte]uint32, tbl *amendment.AmendmentTable, lastVote *amendment.LastVote, isAdmin bool) map[string]interface{} {
 	supported := f.Supported == amendment.SupportedYes
 
 	var enabled bool
@@ -164,10 +177,22 @@ func buildFeatureInfo(f *amendment.Feature, enabledSet map[[32]byte]bool, tbl *a
 	}
 
 	info := map[string]interface{}{
-		"name":      f.Name,
 		"enabled":   enabled,
 		"supported": supported,
-		"vetoed":    featureVetoed(f, tbl, supported),
+	}
+	if f.Name != "" {
+		info["name"] = f.Name
+	}
+
+	// `vetoed` is admin-only and only for amendments not yet enabled.
+	if !enabled && isAdmin {
+		info["vetoed"] = featureVetoed(f, tbl, supported)
+	}
+
+	// `majority` is the close time at which the amendment reached majority,
+	// present only for amendments currently in the ledger's sfMajorities set.
+	if ct, ok := majorities[f.ID]; ok {
+		info["majority"] = ct
 	}
 
 	// Admin-only vote tallies for amendments not yet enabled.

--- a/internal/rpc/handlers/feature.go
+++ b/internal/rpc/handlers/feature.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"strings"
@@ -13,8 +14,18 @@ import (
 
 // FeatureMethod handles the feature RPC method.
 // Returns information about amendments including their status, support, and voting.
+// Admins may set/clear a veto via the `vetoed` param, and see per-amendment
+// vote tallies (count/validations/threshold) for amendments not yet enabled.
 // Reference: rippled Feature1.cpp
 type FeatureMethod struct{ AdminHandler }
+
+// amendmentVoteController is the optional capability the live ledger-service
+// adapter implements to expose the amendment table and accept vote mutations.
+// Test mocks don't implement it, so handlers degrade gracefully.
+type amendmentVoteController interface {
+	AmendmentTable() *amendment.AmendmentTable
+	SetAmendmentVote(ctx context.Context, id [32]byte, vetoed bool) error
+}
 
 func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
 	var request struct {
@@ -25,53 +36,85 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (i
 		_ = json.Unmarshal(params, &request)
 	}
 
-	// Read the enabled amendments from the ledger.
 	enabledSet := m.getEnabledAmendments(ctx.Services)
-
-	// If a specific feature is requested, return just that one
-	if request.Feature != "" {
-		return m.handleSingleFeature(request.Feature, enabledSet)
+	ctrl := amendmentController(ctx.Services)
+	var tbl *amendment.AmendmentTable
+	if ctrl != nil {
+		tbl = ctrl.AmendmentTable()
+	}
+	var lastVote *amendment.LastVote
+	if tbl != nil {
+		lastVote = tbl.LastVote()
 	}
 
-	// Return all features wrapped in "features" key (matches rippled)
+	// Admin vote mutation: set or clear a veto on a specific amendment.
+	if request.Vetoed != nil {
+		if request.Feature == "" {
+			return nil, types.RpcErrorInvalidParams("feature required to set a vote")
+		}
+		f := resolveFeature(request.Feature)
+		if f == nil {
+			return nil, types.RpcErrorInvalidParams("Feature not found: " + request.Feature)
+		}
+		if ctrl == nil || tbl == nil {
+			return nil, types.RpcErrorNotSupported("amendment voting is not available on this server")
+		}
+		if err := ctrl.SetAmendmentVote(ctx.Context, f.ID, *request.Vetoed); err != nil {
+			return nil, types.RpcErrorInternal("failed to record amendment vote: " + err.Error())
+		}
+		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
+		return map[string]interface{}{
+			hexID: buildFeatureInfo(f, enabledSet, tbl, lastVote, ctx.IsAdmin),
+		}, nil
+	}
+
+	// Single feature lookup.
+	if request.Feature != "" {
+		f := resolveFeature(request.Feature)
+		if f == nil {
+			return nil, types.RpcErrorInvalidParams("Feature not found: " + request.Feature)
+		}
+		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
+		return map[string]interface{}{
+			hexID: buildFeatureInfo(f, enabledSet, tbl, lastVote, ctx.IsAdmin),
+		}, nil
+	}
+
+	// All features wrapped in "features" (matches rippled).
 	allFeatures := amendment.AllFeatures()
 	features := make(map[string]interface{}, len(allFeatures))
-
 	for _, f := range allFeatures {
 		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
-		features[hexID] = buildFeatureInfo(f, enabledSet)
+		features[hexID] = buildFeatureInfo(f, enabledSet, tbl, lastVote, ctx.IsAdmin)
 	}
-
 	return map[string]interface{}{
 		"features": features,
 	}, nil
 }
 
-// handleSingleFeature looks up a single feature by name or hex ID.
-func (m *FeatureMethod) handleSingleFeature(feature string, enabledSet map[[32]byte]bool) (interface{}, *types.RpcError) {
-	var f *amendment.Feature
-
-	// Try by name first
-	f = amendment.GetFeatureByName(feature)
-
-	// Try by hex ID
-	if f == nil {
-		idBytes, err := hex.DecodeString(feature)
-		if err == nil && len(idBytes) == 32 {
-			var id [32]byte
-			copy(id[:], idBytes)
-			f = amendment.GetFeature(id)
-		}
+// resolveFeature looks up an amendment by registry name or 64-char hex ID.
+func resolveFeature(feature string) *amendment.Feature {
+	if f := amendment.GetFeatureByName(feature); f != nil {
+		return f
 	}
-
-	if f == nil {
-		return nil, types.RpcErrorInvalidParams("Feature not found: " + feature)
+	if idBytes, err := hex.DecodeString(feature); err == nil && len(idBytes) == 32 {
+		var id [32]byte
+		copy(id[:], idBytes)
+		return amendment.GetFeature(id)
 	}
+	return nil
+}
 
-	hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
-	return map[string]interface{}{
-		hexID: buildFeatureInfo(f, enabledSet),
-	}, nil
+// amendmentController returns the live amendment-vote controller if the wired
+// ledger service exposes one, else nil (e.g. test mocks).
+func amendmentController(services *types.ServiceContainer) amendmentVoteController {
+	if services == nil || services.Ledger == nil {
+		return nil
+	}
+	if c, ok := services.Ledger.(amendmentVoteController); ok {
+		return c
+	}
+	return nil
 }
 
 // getEnabledAmendments reads the Amendments SLE from the closed ledger and returns
@@ -106,24 +149,13 @@ func (m *FeatureMethod) getEnabledAmendments(services *types.ServiceContainer) m
 }
 
 // buildFeatureInfo constructs the response map for a single amendment feature.
-// If enabledSet is non-nil, the "enabled" field is looked up from the ledger.
-// If enabledSet is nil (ledger unavailable), it falls back to registry defaults.
-func buildFeatureInfo(f *amendment.Feature, enabledSet map[[32]byte]bool) map[string]interface{} {
+// `enabledSet` (nil ⇒ fall back to registry defaults) gives the on-ledger
+// enabled status; `tbl` (nil ⇒ registry defaults) provides operator veto/upvote
+// overrides; when admin and the amendment is not yet enabled, `lastVote`
+// supplies the vote tallies.
+func buildFeatureInfo(f *amendment.Feature, enabledSet map[[32]byte]bool, tbl *amendment.AmendmentTable, lastVote *amendment.LastVote, isAdmin bool) map[string]interface{} {
 	supported := f.Supported == amendment.SupportedYes
 
-	// Determine vetoed status.
-	// In rippled, "vetoed" can be true, false, or "Obsolete".
-	var vetoed interface{}
-	if f.Vote == amendment.VoteObsolete {
-		vetoed = "Obsolete"
-	} else if f.Vote == amendment.VoteDefaultNo && supported {
-		vetoed = true
-	} else {
-		vetoed = false
-	}
-
-	// Determine enabled status from the ledger if available,
-	// otherwise fall back to the registry default.
 	var enabled bool
 	if enabledSet != nil {
 		enabled = enabledSet[f.ID]
@@ -131,10 +163,38 @@ func buildFeatureInfo(f *amendment.Feature, enabledSet map[[32]byte]bool) map[st
 		enabled = supported && f.Vote == amendment.VoteDefaultYes
 	}
 
-	return map[string]interface{}{
+	info := map[string]interface{}{
 		"name":      f.Name,
 		"enabled":   enabled,
 		"supported": supported,
-		"vetoed":    vetoed,
+		"vetoed":    featureVetoed(f, tbl, supported),
 	}
+
+	// Admin-only vote tallies for amendments not yet enabled.
+	if isAdmin && !enabled && lastVote != nil {
+		info["count"] = lastVote.Votes[f.ID]
+		info["validations"] = lastVote.TrustedValidations
+		if lastVote.Threshold > 0 {
+			info["threshold"] = lastVote.Threshold
+		}
+	}
+
+	return info
+}
+
+// featureVetoed reports an amendment's veto status: "Obsolete", or a bool. The
+// operator table (when present) takes precedence over the registry default.
+func featureVetoed(f *amendment.Feature, tbl *amendment.AmendmentTable, supported bool) interface{} {
+	if f.Vote == amendment.VoteObsolete {
+		return "Obsolete"
+	}
+	if tbl != nil {
+		if tbl.IsVetoed(f.ID) {
+			return true
+		}
+		if tbl.IsUpVoted(f.ID) {
+			return false
+		}
+	}
+	return f.Vote == amendment.VoteDefaultNo && supported
 }

--- a/internal/rpc/handlers/feature_test.go
+++ b/internal/rpc/handlers/feature_test.go
@@ -13,24 +13,38 @@ func TestBuildFeatureInfo_TableVetoOverride(t *testing.T) {
 	}
 	tbl := amendment.NewAmendmentTable()
 
-	// Default (no table): DefaultNo + supported → vetoed true.
-	info := buildFeatureInfo(f, map[[32]byte]bool{}, nil, nil, false)
+	// vetoed is admin-only and only for not-yet-enabled amendments
+	// (rippled injectJson: `if (!fs.enabled && isAdmin)`).
+	// Admin, not enabled, no table override: DefaultNo + supported → vetoed true.
+	info := buildFeatureInfo(f, map[[32]byte]bool{}, nil, nil, nil, true)
 	if info["vetoed"] != true {
 		t.Fatalf("default vetoed = %v, want true", info["vetoed"])
 	}
 
 	// Operator upvote → vetoed false.
 	tbl.UpVote(f.ID)
-	info = buildFeatureInfo(f, map[[32]byte]bool{}, tbl, nil, false)
+	info = buildFeatureInfo(f, map[[32]byte]bool{}, nil, tbl, nil, true)
 	if info["vetoed"] != false {
 		t.Fatalf("upvoted vetoed = %v, want false", info["vetoed"])
 	}
 
 	// Operator veto → vetoed true.
 	tbl.Veto(f.ID)
-	info = buildFeatureInfo(f, map[[32]byte]bool{}, tbl, nil, false)
+	info = buildFeatureInfo(f, map[[32]byte]bool{}, nil, tbl, nil, true)
 	if info["vetoed"] != true {
 		t.Fatalf("vetoed = %v, want true", info["vetoed"])
+	}
+
+	// Non-admin must never see vetoed.
+	info = buildFeatureInfo(f, map[[32]byte]bool{}, nil, tbl, nil, false)
+	if _, ok := info["vetoed"]; ok {
+		t.Fatal("non-admin must not see vetoed")
+	}
+
+	// Admin but already enabled must not see vetoed.
+	info = buildFeatureInfo(f, map[[32]byte]bool{f.ID: true}, nil, tbl, nil, true)
+	if _, ok := info["vetoed"]; ok {
+		t.Fatal("enabled amendment must not report vetoed")
 	}
 }
 
@@ -45,21 +59,39 @@ func TestBuildFeatureInfo_AdminCounts(t *testing.T) {
 	lastVote := tbl.LastVote()
 
 	// Non-admin: no tallies.
-	info := buildFeatureInfo(f, map[[32]byte]bool{}, tbl, lastVote, false)
+	info := buildFeatureInfo(f, map[[32]byte]bool{}, nil, tbl, lastVote, false)
 	if _, ok := info["count"]; ok {
 		t.Fatal("non-admin must not see count")
 	}
 
 	// Admin, not enabled: tallies present.
-	info = buildFeatureInfo(f, map[[32]byte]bool{}, tbl, lastVote, true)
+	info = buildFeatureInfo(f, map[[32]byte]bool{}, nil, tbl, lastVote, true)
 	if info["count"] != 5 || info["validations"] != 10 || info["threshold"] != 8 {
 		t.Fatalf("admin tallies wrong: %+v", info)
 	}
 
 	// Admin but enabled: no tallies (rippled only reports for not-enabled).
-	info = buildFeatureInfo(f, map[[32]byte]bool{f.ID: true}, tbl, lastVote, true)
+	info = buildFeatureInfo(f, map[[32]byte]bool{f.ID: true}, nil, tbl, lastVote, true)
 	if _, ok := info["count"]; ok {
 		t.Fatal("enabled amendment must not report tallies")
+	}
+}
+
+func TestBuildFeatureInfo_Majority(t *testing.T) {
+	f := amendment.GetFeatureByName("DID")
+
+	// Not in the majority set → no `majority` field.
+	info := buildFeatureInfo(f, map[[32]byte]bool{}, nil, nil, nil, false)
+	if _, ok := info["majority"]; ok {
+		t.Fatal("amendment not in majority set must not report majority")
+	}
+
+	// In the majority set → `majority` is the close time (XRPL epoch seconds),
+	// emitted to all callers (rippled doFeature, not admin-gated).
+	const closeTime uint32 = 750_000_000
+	info = buildFeatureInfo(f, map[[32]byte]bool{}, map[[32]byte]uint32{f.ID: closeTime}, nil, nil, false)
+	if info["majority"] != closeTime {
+		t.Fatalf("majority = %v, want %d", info["majority"], closeTime)
 	}
 }
 

--- a/internal/rpc/handlers/feature_test.go
+++ b/internal/rpc/handlers/feature_test.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/amendment"
+)
+
+func TestBuildFeatureInfo_TableVetoOverride(t *testing.T) {
+	f := amendment.GetFeatureByName("DID") // supported, DefaultNo
+	if f == nil {
+		t.Fatal("DID feature must exist")
+	}
+	tbl := amendment.NewAmendmentTable()
+
+	// Default (no table): DefaultNo + supported → vetoed true.
+	info := buildFeatureInfo(f, map[[32]byte]bool{}, nil, nil, false)
+	if info["vetoed"] != true {
+		t.Fatalf("default vetoed = %v, want true", info["vetoed"])
+	}
+
+	// Operator upvote → vetoed false.
+	tbl.UpVote(f.ID)
+	info = buildFeatureInfo(f, map[[32]byte]bool{}, tbl, nil, false)
+	if info["vetoed"] != false {
+		t.Fatalf("upvoted vetoed = %v, want false", info["vetoed"])
+	}
+
+	// Operator veto → vetoed true.
+	tbl.Veto(f.ID)
+	info = buildFeatureInfo(f, map[[32]byte]bool{}, tbl, nil, false)
+	if info["vetoed"] != true {
+		t.Fatalf("vetoed = %v, want true", info["vetoed"])
+	}
+}
+
+func TestBuildFeatureInfo_AdminCounts(t *testing.T) {
+	f := amendment.GetFeatureByName("DID")
+	tbl := amendment.NewAmendmentTable()
+	tbl.SetLastVote(&amendment.LastVote{
+		TrustedValidations: 10,
+		Threshold:          8,
+		Votes:              map[[32]byte]int{f.ID: 5},
+	})
+	lastVote := tbl.LastVote()
+
+	// Non-admin: no tallies.
+	info := buildFeatureInfo(f, map[[32]byte]bool{}, tbl, lastVote, false)
+	if _, ok := info["count"]; ok {
+		t.Fatal("non-admin must not see count")
+	}
+
+	// Admin, not enabled: tallies present.
+	info = buildFeatureInfo(f, map[[32]byte]bool{}, tbl, lastVote, true)
+	if info["count"] != 5 || info["validations"] != 10 || info["threshold"] != 8 {
+		t.Fatalf("admin tallies wrong: %+v", info)
+	}
+
+	// Admin but enabled: no tallies (rippled only reports for not-enabled).
+	info = buildFeatureInfo(f, map[[32]byte]bool{f.ID: true}, tbl, lastVote, true)
+	if _, ok := info["count"]; ok {
+		t.Fatal("enabled amendment must not report tallies")
+	}
+}
+
+func TestFeatureVetoed_Obsolete(t *testing.T) {
+	// Find an obsolete amendment in the registry, if any.
+	var obsolete *amendment.Feature
+	for _, f := range amendment.AllFeatures() {
+		if f.Vote == amendment.VoteObsolete {
+			obsolete = f
+			break
+		}
+	}
+	if obsolete == nil {
+		t.Skip("no obsolete amendment registered")
+	}
+	if got := featureVetoed(obsolete, nil, obsolete.Supported == amendment.SupportedYes); got != "Obsolete" {
+		t.Fatalf("obsolete vetoed = %v, want \"Obsolete\"", got)
+	}
+}

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/amendment"
 	"github.com/LeJamon/goXRPLd/internal/observability"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	"github.com/LeJamon/goXRPLd/protocol"
@@ -86,8 +87,47 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	response := map[string]interface{}{
 		"info": info,
 	}
+	if warnings := buildAmendmentWarnings(ctx.Services); len(warnings) > 0 {
+		response["warnings"] = warnings
+	}
 
 	return response, nil
+}
+
+// buildAmendmentWarnings surfaces the rippled-conformant amendment warnings:
+// warnRPC_AMENDMENT_BLOCKED (1002) when the node is blocked, and
+// warnRPC_UNSUPPORTED_MAJORITY (1001) — with the projected activation date —
+// when an unsupported amendment is holding majority.
+func buildAmendmentWarnings(services *types.ServiceContainer) []types.WarningObject {
+	if services == nil || services.Ledger == nil {
+		return nil
+	}
+
+	var warnings []types.WarningObject
+	if services.Ledger.IsAmendmentBlocked() {
+		warnings = append(warnings, types.WarningObject{
+			ID:      types.WarningAmendmentBlocked,
+			Message: "This server is amendment blocked, and must be updated to be able to stay in sync with the network.",
+		})
+	}
+
+	if p, ok := services.Ledger.(interface {
+		AmendmentTable() *amendment.AmendmentTable
+	}); ok {
+		if tbl := p.AmendmentTable(); tbl != nil {
+			if exp, has := tbl.FirstUnsupportedExpected(); has {
+				warnings = append(warnings, types.WarningObject{
+					ID:      types.WarningUnsupportedAmendmentsMajority,
+					Message: "One or more unsupported amendments have reached majority. Upgrade before they are activated to avoid becoming amendment blocked.",
+					Details: map[string]interface{}{
+						"expected_date":     exp,
+						"expected_date_UTC": time.Unix(int64(exp)+protocol.RippleEpochUnix, 0).UTC().Format(time.RFC3339),
+					},
+				})
+			}
+		}
+	}
+	return warnings
 }
 
 // buildServerInfo constructs the info/state object.

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -87,7 +87,7 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	response := map[string]interface{}{
 		"info": info,
 	}
-	if warnings := buildAmendmentWarnings(ctx.Services); len(warnings) > 0 {
+	if warnings := buildAmendmentWarnings(ctx.Services, ctx.IsAdmin); len(warnings) > 0 {
 		response["warnings"] = warnings
 	}
 
@@ -97,33 +97,40 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 // buildAmendmentWarnings surfaces the rippled-conformant amendment warnings:
 // warnRPC_AMENDMENT_BLOCKED (1002) when the node is blocked, and
 // warnRPC_UNSUPPORTED_MAJORITY (1001) — with the projected activation date —
-// when an unsupported amendment is holding majority.
-func buildAmendmentWarnings(services *types.ServiceContainer) []types.WarningObject {
+// when an unsupported amendment is holding majority. Mirrors
+// NetworkOPsImp::getServerInfo (NetworkOPs.cpp:2644-2676): the blocked warning is
+// emitted to all callers, while the unsupported-majority warning is admin-only and
+// suppressed while blocked (rippled's `admin && isAmendmentWarned()`, where
+// isAmendmentWarned() == !amendmentBlocked_ && amendmentWarned_).
+func buildAmendmentWarnings(services *types.ServiceContainer, isAdmin bool) []types.WarningObject {
 	if services == nil || services.Ledger == nil {
 		return nil
 	}
 
 	var warnings []types.WarningObject
-	if services.Ledger.IsAmendmentBlocked() {
+	blocked := services.Ledger.IsAmendmentBlocked()
+	if blocked {
 		warnings = append(warnings, types.WarningObject{
 			ID:      types.WarningAmendmentBlocked,
 			Message: "This server is amendment blocked, and must be updated to be able to stay in sync with the network.",
 		})
 	}
 
-	if p, ok := services.Ledger.(interface {
-		AmendmentTable() *amendment.AmendmentTable
-	}); ok {
-		if tbl := p.AmendmentTable(); tbl != nil {
-			if exp, has := tbl.FirstUnsupportedExpected(); has {
-				warnings = append(warnings, types.WarningObject{
-					ID:      types.WarningUnsupportedAmendmentsMajority,
-					Message: "One or more unsupported amendments have reached majority. Upgrade before they are activated to avoid becoming amendment blocked.",
-					Details: map[string]interface{}{
-						"expected_date":     exp,
-						"expected_date_UTC": time.Unix(int64(exp)+protocol.RippleEpochUnix, 0).UTC().Format(time.RFC3339),
-					},
-				})
+	if isAdmin && !blocked {
+		if p, ok := services.Ledger.(interface {
+			AmendmentTable() *amendment.AmendmentTable
+		}); ok {
+			if tbl := p.AmendmentTable(); tbl != nil {
+				if exp, has := tbl.FirstUnsupportedExpected(); has {
+					warnings = append(warnings, types.WarningObject{
+						ID:      types.WarningUnsupportedAmendmentsMajority,
+						Message: "One or more unsupported amendments have reached majority. Upgrade to the latest version before they are activated to avoid being amendment blocked.",
+						Details: map[string]interface{}{
+							"expected_date":     exp,
+							"expected_date_UTC": time.Unix(int64(exp)+protocol.RippleEpochUnix, 0).UTC().Format("2006-Jan-02 15:04:05 UTC"),
+						},
+					})
+				}
 			}
 		}
 	}

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -923,7 +923,7 @@ func (a *LedgerServiceAdapter) GetAutofillSequence(account string, hasTicketSequ
 
 // IsAmendmentBlocked returns true if the server is blocked by unsupported amendments
 func (a *LedgerServiceAdapter) IsAmendmentBlocked() bool {
-	return false
+	return a.svc.IsAmendmentBlocked()
 }
 
 // GetNFTSellOffers retrieves sell offers for an NFToken

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/amendment"
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
@@ -924,6 +925,17 @@ func (a *LedgerServiceAdapter) GetAutofillSequence(account string, hasTicketSequ
 // IsAmendmentBlocked returns true if the server is blocked by unsupported amendments
 func (a *LedgerServiceAdapter) IsAmendmentBlocked() bool {
 	return a.svc.IsAmendmentBlocked()
+}
+
+// AmendmentTable exposes the live amendment table for RPC introspection
+// (feature command, server_info warnings). May be nil.
+func (a *LedgerServiceAdapter) AmendmentTable() *amendment.AmendmentTable {
+	return a.svc.AmendmentTable()
+}
+
+// SetAmendmentVote records an operator veto/upvote and persists it.
+func (a *LedgerServiceAdapter) SetAmendmentVote(ctx context.Context, id [32]byte, vetoed bool) error {
+	return a.svc.SetAmendmentVote(ctx, id, vetoed)
 }
 
 // GetNFTSellOffers retrieves sell offers for an NFToken

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -94,10 +94,11 @@ const (
 	// Oracle errors — must match rippled exactly (rpcORACLE_MALFORMED = 94)
 	RpcORACLE_MALFORMED = 94
 
-	// Amendment and feature errors
+	// Amendment and feature errors — codes match rippled ErrorCodes.h.
 	RpcINVALID_API_VERSION = 38
 	RpcUNSUPPORTED_FEATURE = 39
-	RpcAMENDMENT_BLOCKED   = 40
+	RpcAMENDMENT_BLOCKED   = 14 // rippled: rpcAMENDMENT_BLOCKED = 14
+	RpcBAD_FEATURE         = 40 // rippled: rpcBAD_FEATURE = 40 ("badFeature")
 
 	// Database errors
 	RpcDB_DESERIALIZATION_ERROR = 41
@@ -267,6 +268,12 @@ func RpcErrorNoEvents(message string) *RpcError {
 
 func RpcErrorAmendmentBlocked() *RpcError {
 	return NewRpcError(RpcAMENDMENT_BLOCKED, "amendmentBlocked", "amendmentBlocked", "Amendment blocked, need upgrade.")
+}
+
+// RpcErrorBadFeature returns rippled's rpcBAD_FEATURE (code 40, token
+// "badFeature"): the requested amendment is unknown or invalid.
+func RpcErrorBadFeature(message string) *RpcError {
+	return NewRpcError(RpcBAD_FEATURE, "badFeature", "badFeature", message)
 }
 
 // RpcErrorNoPathRequest returns an error when close/status is called without an active path_find session

--- a/internal/testing/pseudotx/trust_lines_to_self_test.go
+++ b/internal/testing/pseudotx/trust_lines_to_self_test.go
@@ -1,0 +1,140 @@
+// Tests for the fixTrustLinesToSelf activation side-effect of the
+// EnableAmendment pseudo-tx.
+// Reference: rippled/src/xrpld/app/tx/detail/Change.cpp activateTrustLinesToSelfFix()
+package pseudotx_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+	jtx "github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+// The two RippleState ledger keys fixTrustLinesToSelf deletes on mainnet.
+const (
+	selfTrustLineKey1 = "2F8F21EFCAFD7ACFB07D5BB04F0D2E18587820C7611305BB674A64EAB0FA71E1"
+	selfTrustLineKey2 = "326035D5C0560A9DA8636545DD5A1B0DFCFF63E68D491B5522B767BB00564B1A"
+)
+
+func mustKeylet(t *testing.T, hexKey string) keylet.Keylet {
+	t.Helper()
+	b, err := hex.DecodeString(hexKey)
+	require.NoError(t, err)
+	require.Len(t, b, 32)
+	var k [32]byte
+	copy(k[:], b)
+	return keylet.Keylet{Key: k}
+}
+
+func ownerCount(t *testing.T, env *jtx.TestEnv, id [20]byte) uint32 {
+	t.Helper()
+	data, err := env.Ledger().Read(keylet.Account(id))
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	ar, err := state.ParseAccountRoot(data)
+	require.NoError(t, err)
+	return ar.OwnerCount
+}
+
+func setOwnerCount(t *testing.T, env *jtx.TestEnv, id [20]byte, n uint32) {
+	t.Helper()
+	data, err := env.Ledger().Read(keylet.Account(id))
+	require.NoError(t, err)
+	ar, err := state.ParseAccountRoot(data)
+	require.NoError(t, err)
+	ar.OwnerCount = n
+	out, err := state.SerializeAccountRoot(ar)
+	require.NoError(t, err)
+	require.NoError(t, env.Ledger().Update(keylet.Account(id), out))
+}
+
+// plantTrustLine writes a RippleState at an arbitrary ledger key whose limits
+// are issued by lowIssuer/highIssuer (classic addresses).
+func plantTrustLine(t *testing.T, env *jtx.TestEnv, key keylet.Keylet, lowIssuer, highIssuer string, flags uint32, lowNode, highNode uint64) {
+	t.Helper()
+	rs := &state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(0, 0, "USD", state.AccountOneAddress),
+		LowLimit:  state.NewIssuedAmountFromValue(0, 0, "USD", lowIssuer),
+		HighLimit: state.NewIssuedAmountFromValue(0, 0, "USD", highIssuer),
+		Flags:     flags,
+		LowNode:   lowNode,
+		HighNode:  highNode,
+	}
+	data, err := state.SerializeRippleState(rs)
+	require.NoError(t, err)
+	require.NoError(t, env.Ledger().Insert(key, data))
+}
+
+// TestEnableAmendment_FixTrustLinesToSelf_Removes verifies that enabling
+// fixTrustLinesToSelf deletes a trust line to self at the known key, removes it
+// from the owner directory, and releases both reserves.
+// Reference: rippled Change.cpp activateTrustLinesToSelfFix lines 166-246.
+func TestEnableAmendment_FixTrustLinesToSelf_Removes(t *testing.T) {
+	env := newAmendmentTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+
+	key := mustKeylet(t, selfTrustLineKey1)
+	ownerDir := keylet.OwnerDir(alice.ID)
+	res, err := state.DirInsert(env.Ledger(), ownerDir, key.Key, false, nil)
+	require.NoError(t, err)
+
+	plantTrustLine(t, env, key, alice.Address, alice.Address,
+		state.LsfLowReserve|state.LsfHighReserve, res.Page, res.Page)
+
+	base := ownerCount(t, env, alice.ID)
+	setOwnerCount(t, env, alice.ID, base+2)
+
+	result := env.SubmitPseudo(newEnableAmendment(makeAmendmentHash("fixTrustLinesToSelf"), 0))
+	jtx.RequireTxSuccess(t, result)
+
+	require.False(t, env.LedgerEntryExists(key), "self trust line should be erased")
+	require.Equal(t, base, ownerCount(t, env, alice.ID), "both reserves should be released")
+	require.False(t, env.LedgerEntryExists(ownerDir), "emptied owner dir root should be deleted")
+}
+
+// TestEnableAmendment_FixTrustLinesToSelf_SkipsNonSelf verifies that a normal
+// trust line (low account != high account) parked at the known key is NOT
+// touched. Mirrors rippled's `lo != hi` guard returning success without delete.
+func TestEnableAmendment_FixTrustLinesToSelf_SkipsNonSelf(t *testing.T) {
+	env := newAmendmentTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+
+	key := mustKeylet(t, selfTrustLineKey2)
+	plantTrustLine(t, env, key, alice.Address, bob.Address, 0, 0, 0)
+
+	result := env.SubmitPseudo(newEnableAmendment(makeAmendmentHash("fixTrustLinesToSelf"), 0))
+	jtx.RequireTxSuccess(t, result)
+
+	require.True(t, env.LedgerEntryExists(key), "non-self trust line must survive")
+}
+
+// TestEnableAmendment_FixTrustLinesToSelf_OnlyOnThatAmendment verifies the
+// migration runs only for fixTrustLinesToSelf, not for other amendments.
+func TestEnableAmendment_FixTrustLinesToSelf_OnlyOnThatAmendment(t *testing.T) {
+	env := newAmendmentTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+
+	key := mustKeylet(t, selfTrustLineKey1)
+	plantTrustLine(t, env, key, alice.Address, alice.Address, 0, 0, 0)
+
+	result := env.SubmitPseudo(newEnableAmendment(makeAmendmentHash("fixNFTokenPageLinks"), 0))
+	jtx.RequireTxSuccess(t, result)
+
+	require.True(t, env.LedgerEntryExists(key), "unrelated amendment must not run the migration")
+}
+
+// TestEnableAmendment_FixTrustLinesToSelf_NoEntries verifies enabling the
+// amendment with neither known key present still succeeds (best-effort).
+func TestEnableAmendment_FixTrustLinesToSelf_NoEntries(t *testing.T) {
+	env := newAmendmentTestEnv(t)
+
+	result := env.SubmitPseudo(newEnableAmendment(makeAmendmentHash("fixTrustLinesToSelf"), 0))
+	jtx.RequireTxSuccess(t, result)
+}

--- a/internal/tx/pseudo/enable_amendment.go
+++ b/internal/tx/pseudo/enable_amendment.go
@@ -9,11 +9,8 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/keylet"
+	"github.com/LeJamon/goXRPLd/ledger/entry"
 )
-
-// ledgerEntryTypeRippleState is the LedgerEntryType code for a RippleState
-// (trust line) object. Mirrors rippled's ltRIPPLE_STATE.
-const ledgerEntryTypeRippleState uint16 = 0x0072
 
 // fixTrustLinesToSelfIndexes are the two RippleState ledger entries that
 // existed on mainnet whose LowLimit and HighLimit belong to the same account
@@ -219,16 +216,19 @@ func activateTrustLinesToSelfFix(ctx *tx.ApplyContext) {
 		if readErr != nil || data == nil {
 			continue // missing entry -> skip
 		}
-		if typeCode, typeErr := state.GetLedgerEntryType(data); typeErr != nil || typeCode != ledgerEntryTypeRippleState {
+		if typeCode, typeErr := state.GetLedgerEntryType(data); typeErr != nil || typeCode != uint16(entry.TypeRippleState) {
 			continue // not a trust line -> skip
 		}
 		rs, parseErr := state.ParseRippleState(data)
 		if parseErr != nil {
 			continue
 		}
-		// Only a genuine trust line to self: both limits issued by the same
-		// account. Mirrors rippled's `sfLowLimit != sfHighLimit` guard.
-		if rs.LowLimit.Issuer != rs.HighLimit.Issuer {
+		// Only a genuine trust line to self: rippled treats the entry as such only
+		// when sfLowLimit == sfHighLimit as full STAmounts — currency, issuer, AND
+		// value all equal (Change.cpp:187-194 / STAmount::operator==).
+		if rs.LowLimit.Issuer != rs.HighLimit.Issuer ||
+			rs.LowLimit.Currency != rs.HighLimit.Currency ||
+			rs.LowLimit.Value() != rs.HighLimit.Value() {
 			continue
 		}
 		lowID, lowErr := state.DecodeAccountID(rs.LowLimit.Issuer)
@@ -237,8 +237,17 @@ func activateTrustLinesToSelfFix(ctx *tx.ApplyContext) {
 			continue
 		}
 
-		state.DirRemove(ctx.View, keylet.OwnerDir(lowID), rs.LowNode, index, false)
-		state.DirRemove(ctx.View, keylet.OwnerDir(highID), rs.HighNode, index, false)
+		// Remove from both owner directories first. Rippled aborts the migration
+		// if either dirRemove fails (Change.cpp:196-212); lacking an all-or-nothing
+		// sandbox, we skip the entry on failure rather than leave it half-removed.
+		if _, derr := state.DirRemove(ctx.View, keylet.OwnerDir(lowID), rs.LowNode, index, false); derr != nil {
+			ctx.Log.Warn("fixTrustLinesToSelf: low owner-dir remove failed; skipping", "index", indexHex, "err", derr)
+			continue
+		}
+		if _, derr := state.DirRemove(ctx.View, keylet.OwnerDir(highID), rs.HighNode, index, false); derr != nil {
+			ctx.Log.Warn("fixTrustLinesToSelf: high owner-dir remove failed; skipping", "index", indexHex, "err", derr)
+			continue
+		}
 
 		// Release the reserve held by each side that paid it.
 		// Reference: rippled Change.cpp:214-220.

--- a/internal/tx/pseudo/enable_amendment.go
+++ b/internal/tx/pseudo/enable_amendment.go
@@ -5,9 +5,24 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/LeJamon/goXRPLd/amendment"
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/keylet"
 )
+
+// ledgerEntryTypeRippleState is the LedgerEntryType code for a RippleState
+// (trust line) object. Mirrors rippled's ltRIPPLE_STATE.
+const ledgerEntryTypeRippleState uint16 = 0x0072
+
+// fixTrustLinesToSelfIndexes are the two RippleState ledger entries that
+// existed on mainnet whose LowLimit and HighLimit belong to the same account
+// (a trust line to self). fixTrustLinesToSelf deletes them on activation.
+// Reference: rippled Change.cpp activateTrustLinesToSelfFix (lines 233-239).
+var fixTrustLinesToSelfIndexes = [...]string{
+	"2F8F21EFCAFD7ACFB07D5BB04F0D2E18587820C7611305BB674A64EAB0FA71E1",
+	"326035D5C0560A9DA8636545DD5A1B0DFCFF63E68D491B5522B767BB00564B1A",
+}
 
 var (
 	ErrAmendmentMissing = tx.Errorf(tx.TemMALFORMED, "EnableAmendment missing amendment hash")
@@ -153,9 +168,17 @@ func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
 		)
 		sle.Amendments = append(sle.Amendments, amendmentHash)
 
-		// Note: activateTrustLinesToSelfFix() and AmendmentTable.enable() are
-		// not implemented since they require full network infrastructure.
-		// The amendment is recorded in the ledger state which is the primary goal.
+		// Reference: rippled Change.cpp:324-325 — fixTrustLinesToSelf runs a
+		// one-off ledger migration when it activates.
+		if amendmentHash == amendment.FeatureFixTrustLinesToSelf {
+			activateTrustLinesToSelfFix(ctx)
+		}
+
+		// The in-memory AmendmentTable.enable() notification (Change.cpp:327)
+		// and setAmendmentBlocked() on unsupported activation (Change.cpp:329-334)
+		// are driven by the validated-ledger resync in the ledger service
+		// (AmendmentTable.DoValidatedLedger), not from the pseudo-tx — the
+		// ledger SLE remains the single source of truth for enabled amendments.
 	}
 
 	// Reference: rippled lines 337-340
@@ -177,6 +200,61 @@ func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	return tx.TesSUCCESS
+}
+
+// activateTrustLinesToSelfFix removes the known trust-lines-to-self when the
+// fixTrustLinesToSelf amendment activates. It is best-effort and never fails
+// the enable: a missing, wrong-typed, or non-self entry is skipped, mirroring
+// rippled's removeTrustLineToSelf returning success in those cases.
+// Reference: rippled Change.cpp:166-246.
+func activateTrustLinesToSelfFix(ctx *tx.ApplyContext) {
+	for _, indexHex := range fixTrustLinesToSelfIndexes {
+		index, err := parseAmendmentHash(indexHex)
+		if err != nil {
+			continue
+		}
+		k := keylet.Keylet{Key: index}
+
+		data, readErr := ctx.View.Read(k)
+		if readErr != nil || data == nil {
+			continue // missing entry -> skip
+		}
+		if typeCode, typeErr := state.GetLedgerEntryType(data); typeErr != nil || typeCode != ledgerEntryTypeRippleState {
+			continue // not a trust line -> skip
+		}
+		rs, parseErr := state.ParseRippleState(data)
+		if parseErr != nil {
+			continue
+		}
+		// Only a genuine trust line to self: both limits issued by the same
+		// account. Mirrors rippled's `sfLowLimit != sfHighLimit` guard.
+		if rs.LowLimit.Issuer != rs.HighLimit.Issuer {
+			continue
+		}
+		lowID, lowErr := state.DecodeAccountID(rs.LowLimit.Issuer)
+		highID, highErr := state.DecodeAccountID(rs.HighLimit.Issuer)
+		if lowErr != nil || highErr != nil {
+			continue
+		}
+
+		state.DirRemove(ctx.View, keylet.OwnerDir(lowID), rs.LowNode, index, false)
+		state.DirRemove(ctx.View, keylet.OwnerDir(highID), rs.HighNode, index, false)
+
+		// Release the reserve held by each side that paid it.
+		// Reference: rippled Change.cpp:214-220.
+		if rs.Flags&state.LsfLowReserve != 0 {
+			_ = tx.AdjustOwnerCount(ctx.View, lowID, -1)
+		}
+		if rs.Flags&state.LsfHighReserve != 0 {
+			_ = tx.AdjustOwnerCount(ctx.View, highID, -1)
+		}
+
+		if eraseErr := ctx.View.Erase(k); eraseErr != nil {
+			ctx.Log.Warn("fixTrustLinesToSelf: failed to erase trust line to self", "index", indexHex)
+			continue
+		}
+		ctx.Log.Info("fixTrustLinesToSelf: removed trust line to self", "index", indexHex)
+	}
 }
 
 // parseAmendmentHash parses a hex-encoded amendment hash string into [32]byte.

--- a/storage/relationaldb/amendment_votes.go
+++ b/storage/relationaldb/amendment_votes.go
@@ -1,0 +1,32 @@
+package relationaldb
+
+import "context"
+
+// AmendmentVoteRecord is one operator amendment-vote preference: the node's
+// persisted decision to upvote or veto a single amendment. Mirrors a row of
+// rippled's wallet.db FeatureVotes table. The preference survives restarts so
+// runtime `feature <amendment> reject/accept` overrides config until changed.
+type AmendmentVoteRecord struct {
+	// Amendment is the 64-char uppercase hex amendment ID.
+	Amendment string
+	// Name is the amendment's registry name (informational; may be empty for
+	// amendments unknown to this build).
+	Name string
+	// Vetoed is true for a veto (down vote), false for an upvote (up vote).
+	Vetoed bool
+}
+
+// AmendmentVoteRepository persists operator amendment-vote preferences. Writes
+// are keyed by amendment ID (one preference per amendment); Save upserts the
+// latest preference. Backends guarantee idempotent writes.
+type AmendmentVoteRepository interface {
+	// LoadAmendmentVotes returns every persisted operator preference.
+	LoadAmendmentVotes(ctx context.Context) ([]*AmendmentVoteRecord, error)
+
+	// SaveAmendmentVote upserts one operator preference (keyed by Amendment).
+	SaveAmendmentVote(ctx context.Context, rec *AmendmentVoteRecord) error
+
+	// DeleteAmendmentVote removes the preference for the given amendment ID,
+	// returning it to the registry default. No-op when absent.
+	DeleteAmendmentVote(ctx context.Context, amendment string) error
+}

--- a/storage/relationaldb/interface.go
+++ b/storage/relationaldb/interface.go
@@ -177,6 +177,7 @@ type RepositoryManager interface {
 	Transaction() TransactionRepository
 	AccountTransaction() AccountTransactionRepository
 	Validation() ValidationRepository
+	Amendment() AmendmentVoteRepository
 	System() SystemRepository
 
 	// Connection management

--- a/storage/relationaldb/postgres/amendment_vote_repository.go
+++ b/storage/relationaldb/postgres/amendment_vote_repository.go
@@ -1,0 +1,64 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+// AmendmentVoteRepository is the PostgreSQL-backed store of operator
+// amendment-vote preferences (the feature_votes table).
+type AmendmentVoteRepository struct {
+	db *sql.DB
+}
+
+// Compile-time interface check.
+var _ relationaldb.AmendmentVoteRepository = (*AmendmentVoteRepository)(nil)
+
+func NewAmendmentVoteRepository(db *sql.DB) *AmendmentVoteRepository {
+	return &AmendmentVoteRepository{db: db}
+}
+
+func (r *AmendmentVoteRepository) LoadAmendmentVotes(ctx context.Context) ([]*relationaldb.AmendmentVoteRecord, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT amendment, name, vetoed FROM feature_votes`)
+	if err != nil {
+		return nil, relationaldb.NewQueryError("amendment_vote_load", "failed to query feature votes", err)
+	}
+	defer rows.Close()
+
+	var result []*relationaldb.AmendmentVoteRecord
+	for rows.Next() {
+		var rec relationaldb.AmendmentVoteRecord
+		if err := rows.Scan(&rec.Amendment, &rec.Name, &rec.Vetoed); err != nil {
+			return nil, relationaldb.NewQueryError("amendment_vote_load", "failed to scan row", err)
+		}
+		result = append(result, &rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, relationaldb.NewQueryError("amendment_vote_load", "row iteration error", err)
+	}
+	return result, nil
+}
+
+func (r *AmendmentVoteRepository) SaveAmendmentVote(ctx context.Context, rec *relationaldb.AmendmentVoteRecord) error {
+	if rec == nil {
+		return relationaldb.NewDataError("amendment_vote_save", "nil record", nil)
+	}
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO feature_votes (amendment, name, vetoed) VALUES ($1, $2, $3)
+		ON CONFLICT (amendment) DO UPDATE SET name = excluded.name, vetoed = excluded.vetoed
+	`, rec.Amendment, rec.Name, rec.Vetoed)
+	if err != nil {
+		return relationaldb.NewQueryError("amendment_vote_save", "failed to upsert feature vote", err)
+	}
+	return nil
+}
+
+func (r *AmendmentVoteRepository) DeleteAmendmentVote(ctx context.Context, amendment string) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM feature_votes WHERE amendment = $1`, amendment)
+	if err != nil {
+		return relationaldb.NewQueryError("amendment_vote_delete", "failed to delete feature vote", err)
+	}
+	return nil
+}

--- a/storage/relationaldb/postgres/repository_manager.go
+++ b/storage/relationaldb/postgres/repository_manager.go
@@ -19,6 +19,7 @@ type RepositoryManager struct {
 	accountTransactionRepo *AccountTransactionRepository
 	systemRepo             *SystemRepository
 	validationRepo         *ValidationRepository
+	amendmentVoteRepo      *AmendmentVoteRepository
 }
 
 // NewRepositoryManager creates a new PostgreSQL repository manager
@@ -72,6 +73,7 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 	rm.accountTransactionRepo = NewAccountTransactionRepository(rm.db)
 	rm.systemRepo = NewSystemRepository(rm.db)
 	rm.validationRepo = NewValidationRepository(rm.db)
+	rm.amendmentVoteRepo = NewAmendmentVoteRepository(rm.db)
 
 	return nil
 }
@@ -90,6 +92,7 @@ func (rm *RepositoryManager) Close(ctx context.Context) error {
 	rm.accountTransactionRepo = nil
 	rm.systemRepo = nil
 	rm.validationRepo = nil
+	rm.amendmentVoteRepo = nil
 
 	if err != nil {
 		return relationaldb.NewConnectionError("close", "failed to close database connection", err)
@@ -116,6 +119,10 @@ func (rm *RepositoryManager) System() relationaldb.SystemRepository {
 
 func (rm *RepositoryManager) Validation() relationaldb.ValidationRepository {
 	return rm.validationRepo
+}
+
+func (rm *RepositoryManager) Amendment() relationaldb.AmendmentVoteRepository {
+	return rm.amendmentVoteRepo
 }
 
 func (rm *RepositoryManager) WithTransaction(ctx context.Context, fn func(relationaldb.TransactionContext) error) error {
@@ -194,6 +201,14 @@ func (rm *RepositoryManager) initSchema(ctx context.Context) error {
 			raw          BYTEA NOT NULL,
 			created_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
 			PRIMARY KEY (ledger_hash, node_pubkey)
+		)`,
+
+		// Operator amendment-vote preferences (one row per upvoted/vetoed
+		// amendment). Mirrors rippled's wallet.db FeatureVotes.
+		`CREATE TABLE IF NOT EXISTS feature_votes (
+			amendment VARCHAR(64) PRIMARY KEY,
+			name      TEXT NOT NULL,
+			vetoed    BOOLEAN NOT NULL
 		)`,
 
 		// Indexes matching rippled's performance optimizations

--- a/storage/relationaldb/sqlite/amendment_vote_repository.go
+++ b/storage/relationaldb/sqlite/amendment_vote_repository.go
@@ -1,0 +1,70 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+// AmendmentVoteRepository is the SQLite-backed store of operator amendment-vote
+// preferences (the feature_votes table in ledger.db).
+type AmendmentVoteRepository struct {
+	db *sql.DB
+}
+
+// Compile-time interface check.
+var _ relationaldb.AmendmentVoteRepository = (*AmendmentVoteRepository)(nil)
+
+func NewAmendmentVoteRepository(db *sql.DB) *AmendmentVoteRepository {
+	return &AmendmentVoteRepository{db: db}
+}
+
+func (r *AmendmentVoteRepository) LoadAmendmentVotes(ctx context.Context) ([]*relationaldb.AmendmentVoteRecord, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT amendment, name, vetoed FROM feature_votes`)
+	if err != nil {
+		return nil, relationaldb.NewQueryError("amendment_vote_load", "failed to query feature votes", err)
+	}
+	defer rows.Close()
+
+	var result []*relationaldb.AmendmentVoteRecord
+	for rows.Next() {
+		var rec relationaldb.AmendmentVoteRecord
+		var vetoed int64
+		if err := rows.Scan(&rec.Amendment, &rec.Name, &vetoed); err != nil {
+			return nil, relationaldb.NewQueryError("amendment_vote_load", "failed to scan row", err)
+		}
+		rec.Vetoed = vetoed != 0
+		result = append(result, &rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, relationaldb.NewQueryError("amendment_vote_load", "row iteration error", err)
+	}
+	return result, nil
+}
+
+func (r *AmendmentVoteRepository) SaveAmendmentVote(ctx context.Context, rec *relationaldb.AmendmentVoteRecord) error {
+	if rec == nil {
+		return relationaldb.NewDataError("amendment_vote_save", "nil record", nil)
+	}
+	vetoed := 0
+	if rec.Vetoed {
+		vetoed = 1
+	}
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO feature_votes (amendment, name, vetoed) VALUES (?, ?, ?)
+		ON CONFLICT(amendment) DO UPDATE SET name = excluded.name, vetoed = excluded.vetoed
+	`, rec.Amendment, rec.Name, vetoed)
+	if err != nil {
+		return relationaldb.NewQueryError("amendment_vote_save", "failed to upsert feature vote", err)
+	}
+	return nil
+}
+
+func (r *AmendmentVoteRepository) DeleteAmendmentVote(ctx context.Context, amendment string) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM feature_votes WHERE amendment = ?`, amendment)
+	if err != nil {
+		return relationaldb.NewQueryError("amendment_vote_delete", "failed to delete feature vote", err)
+	}
+	return nil
+}

--- a/storage/relationaldb/sqlite/amendment_vote_repository_test.go
+++ b/storage/relationaldb/sqlite/amendment_vote_repository_test.go
@@ -1,0 +1,67 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+func TestAmendmentVoteRepository_RoundTrip(t *testing.T) {
+	rm := setupTestDB(t)
+	repo := rm.Amendment()
+	ctx := context.Background()
+
+	// Empty to start.
+	got, err := repo.LoadAmendmentVotes(ctx)
+	if err != nil {
+		t.Fatalf("load empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no votes, got %d", len(got))
+	}
+
+	// Save an upvote and a veto.
+	if err := repo.SaveAmendmentVote(ctx, &relationaldb.AmendmentVoteRecord{Amendment: "AA", Name: "Alpha", Vetoed: false}); err != nil {
+		t.Fatalf("save upvote: %v", err)
+	}
+	if err := repo.SaveAmendmentVote(ctx, &relationaldb.AmendmentVoteRecord{Amendment: "BB", Name: "Beta", Vetoed: true}); err != nil {
+		t.Fatalf("save veto: %v", err)
+	}
+
+	got, err = repo.LoadAmendmentVotes(ctx)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 votes, got %d", len(got))
+	}
+	byID := map[string]*relationaldb.AmendmentVoteRecord{}
+	for _, r := range got {
+		byID[r.Amendment] = r
+	}
+	if byID["AA"].Vetoed || byID["AA"].Name != "Alpha" {
+		t.Fatalf("AA roundtrip wrong: %+v", byID["AA"])
+	}
+	if !byID["BB"].Vetoed {
+		t.Fatalf("BB should be vetoed: %+v", byID["BB"])
+	}
+
+	// Upsert: flip AA to vetoed.
+	if err := repo.SaveAmendmentVote(ctx, &relationaldb.AmendmentVoteRecord{Amendment: "AA", Name: "Alpha", Vetoed: true}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, _ = repo.LoadAmendmentVotes(ctx)
+	if len(got) != 2 {
+		t.Fatalf("upsert must not duplicate; got %d rows", len(got))
+	}
+
+	// Delete BB.
+	if err := repo.DeleteAmendmentVote(ctx, "BB"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	got, _ = repo.LoadAmendmentVotes(ctx)
+	if len(got) != 1 || got[0].Amendment != "AA" {
+		t.Fatalf("after delete expected only AA, got %+v", got)
+	}
+}

--- a/storage/relationaldb/sqlite/repository_manager.go
+++ b/storage/relationaldb/sqlite/repository_manager.go
@@ -24,6 +24,7 @@ type RepositoryManager struct {
 	accountTransactionRepo *AccountTransactionRepository
 	systemRepo             *SystemRepository
 	validationRepo         *ValidationRepository
+	amendmentVoteRepo      *AmendmentVoteRepository
 }
 
 // Compile-time interface check
@@ -85,6 +86,10 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 		rm.close()
 		return relationaldb.NewSchemaError("open", "failed to initialize validation schema", err)
 	}
+	if err := rm.initAmendmentVoteSchema(ctx); err != nil {
+		rm.close()
+		return relationaldb.NewSchemaError("open", "failed to initialize amendment-vote schema", err)
+	}
 	if err := rm.initTxSchema(ctx); err != nil {
 		rm.close()
 		return relationaldb.NewSchemaError("open", "failed to initialize transaction schema", err)
@@ -95,6 +100,7 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 	rm.accountTransactionRepo = NewAccountTransactionRepository(rm.txDB)
 	rm.systemRepo = NewSystemRepository(rm.ledgerDB, rm.txDB)
 	rm.validationRepo = NewValidationRepository(rm.ledgerDB)
+	rm.amendmentVoteRepo = NewAmendmentVoteRepository(rm.ledgerDB)
 
 	return nil
 }
@@ -122,6 +128,7 @@ func (rm *RepositoryManager) close() error {
 	rm.accountTransactionRepo = nil
 	rm.systemRepo = nil
 	rm.validationRepo = nil
+	rm.amendmentVoteRepo = nil
 
 	if firstErr != nil {
 		return relationaldb.NewConnectionError("close", "failed to close database", firstErr)
@@ -147,6 +154,10 @@ func (rm *RepositoryManager) System() relationaldb.SystemRepository {
 
 func (rm *RepositoryManager) Validation() relationaldb.ValidationRepository {
 	return rm.validationRepo
+}
+
+func (rm *RepositoryManager) Amendment() relationaldb.AmendmentVoteRepository {
+	return rm.amendmentVoteRepo
 }
 
 func (rm *RepositoryManager) WithTransaction(ctx context.Context, fn func(relationaldb.TransactionContext) error) error {
@@ -240,6 +251,21 @@ func (rm *RepositoryManager) initValidationSchema(ctx context.Context) error {
 		if _, err := rm.ledgerDB.ExecContext(ctx, q); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// initAmendmentVoteSchema installs the operator amendment-vote preference table
+// (cohabits ledger.db). One row per amendment the operator has explicitly
+// upvoted or vetoed. Mirrors rippled's wallet.db FeatureVotes.
+func (rm *RepositoryManager) initAmendmentVoteSchema(ctx context.Context) error {
+	q := `CREATE TABLE IF NOT EXISTS feature_votes (
+		amendment TEXT PRIMARY KEY,
+		name      TEXT NOT NULL,
+		vetoed    INTEGER NOT NULL
+	)`
+	if _, err := rm.ledgerDB.ExecContext(ctx, q); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Makes `amendment.AmendmentTable` the live owner of operator amendment vote preferences, enabled/blocked state, and per-round vote tallies (previously a test-only struct). Addresses the audit gaps in #504, **except** the XChainBridge `SupportedNo→Yes` flip (per request, XChain stays unimplemented).

### Core wiring
- **`activateTrustLinesToSelfFix`** — ports rippled `Change.cpp:166-246` (two known self-trustline keys: verify `ltRIPPLE_STATE` + `LowLimit==HighLimit` → remove from both owner dirs → release reserves → erase), wired into the EnableAmendment enable branch.
- **`AmendmentTable`** gains `NeedValidatedLedger`/`DoValidatedLedger` resync, `firstUnsupportedExpected`, `unsupportedEnabled`, `IsBlocked`/`SetBlocked`, and a `LastVote` cache.
- **`[amendments]` config** (`upvote`/`veto`) builds one shared table in `server.go`, shared by the ledger service and the consensus adaptor.
- **Ledger service** folds each validated flag ledger into the table via `syncAmendmentTable`, engaging amendment-block on unsupported activation. `IsAmendmentBlocked()` is now real (feeds the existing RPC condition gating + `server_info`).

### Operator vote control + introspection
- **Live vote sourcing**: the adaptor builds stances from the table each round (`currentAmendmentStances`), so config/runtime veto/upvote take effect without restart.
- **Persistence**: new `relationaldb.AmendmentVoteRepository` (`feature_votes` table, SQLite + PostgreSQL). Loaded at startup (config first, persisted votes override); persisted on mutation.
- **Runtime mutation**: admin `feature` RPC `vetoed` param → `service.SetAmendmentVote` (table + persist).
- **`lastVote` introspection**: adaptor stashes each round's tallies; admin `feature` reports `count`/`validations`/`threshold` for not-enabled amendments, and `vetoed` reflects the operator's effective preference.
- **`server_info` warnings**: `warnRPC_AMENDMENT_BLOCKED` (1002) and `warnRPC_UNSUPPORTED_MAJORITY` (1001) with `expected_date`/`expected_date_UTC`.

The RPC layer reaches the new capabilities via an optional controller interface that only the live adapter implements — so the `LedgerService` interface and all test mocks are unchanged.

## Test plan

- [x] `go build ./...` clean; `go vet ./...` clean (one pre-existing generated-mock warning, unrelated); gofmt-clean
- [x] New tests: trustlines-to-self (4), table resync/blocked/firstUnsupportedExpected, lastVote round-trip, `[amendments]` config, sqlite vote-repo round-trip, service resync + SetAmendmentVote, feature-RPC presentation
- [x] Green incl. CGO `cli`: amendment, config, storage/relationaldb/..., internal/consensus/..., internal/ledger/service/..., internal/rpc/..., internal/testing/pseudotx/..., internal/testing/consensus/..., internal/cli/...

Fixes #504