### PR TITLE
feat: implement logrotate via a reopenable file log writer

### DIFF
--- a/config/logging.go
+++ b/config/logging.go
@@ -134,11 +134,13 @@ func resolveOutput(output string) io.Writer {
 	case "stderr":
 		return os.Stderr
 	default:
-		f, err := os.OpenFile(output, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		// A rotatable writer so the logrotate RPC can close and reopen the
+		// file after external log-rotation tooling renames it.
+		fw, err := xrpllog.NewFileWriter(output)
 		if err != nil {
 			// Fall back to stdout and let the caller notice via startup logs.
 			return os.Stdout
 		}
-		return f
+		return fw
 	}
 }

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
@@ -141,7 +140,11 @@ func (m *LogRotateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 				"message": "logging is not file-backed; nothing to rotate",
 			}, nil
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("log rotation failed: %v", err))
+		// Mirror rippled's Logs::rotate(): a failed reopen yields a success
+		// result carrying the failure message, never an RPC error.
+		return map[string]interface{}{
+			"message": "The log file could not be closed and reopened.",
+		}, nil
 	}
 
 	return map[string]interface{}{

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
@@ -127,20 +129,22 @@ func (m *LogLevelMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 }
 
 // LogRotateMethod handles the log_rotate RPC method (logrotate).
-// STUB: Returns acknowledgment without actually rotating.
-//
-// TODO [admin]: Wire to actual log file rotation.
-//   - Reference: rippled LogRotate.cpp
-//   - Closes and reopens log files for external log rotation tools
-//   - Requires: File-based logging with rotation support
+// Mirrors rippled LogRotate.cpp: closes and reopens the log file so external
+// rotation tools can rename it and have writes continue against a fresh file.
+// When logging is not file-backed (stdout/stderr) there is nothing to rotate.
 type LogRotateMethod struct{ AdminHandler }
 
 func (m *LogRotateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
-		return nil, types.RpcErrorInternal("Ledger service not available")
+	if err := xrpllog.Rotate(); err != nil {
+		if errors.Is(err, xrpllog.ErrLogNotRotatable) {
+			return map[string]interface{}{
+				"message": "logging is not file-backed; nothing to rotate",
+			}, nil
+		}
+		return nil, types.RpcErrorInternal(fmt.Sprintf("log rotation failed: %v", err))
 	}
 
 	return map[string]interface{}{
-		"message": "Log rotation requested",
+		"message": "The log file was closed and reopened.",
 	}, nil
 }

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -1216,13 +1216,13 @@ func TestMissingMethodsNilLedgerService(t *testing.T) {
 		{"FetchInfoMethod", &handlers.FetchInfoMethod{}},
 		{"PrintMethod", &handlers.PrintMethod{}},
 		{"GetCountsMethod", &handlers.GetCountsMethod{}},
-		{"LogRotateMethod", &handlers.LogRotateMethod{}},
 		{"UnlListMethod", &handlers.UnlListMethod{}},
 		{"BlackListMethod", &handlers.BlackListMethod{}},
 	}
 
-	// Note: LogLevelMethod is excluded — it manages log levels without needing
-	// the ledger service, so it succeeds with nil ledger (returns current levels).
+	// Note: LogLevelMethod and LogRotateMethod are excluded — they drive the
+	// global logger, not the ledger service, so they succeed with a nil ledger
+	// (current levels / a rotate-or-not-applicable message).
 
 	for _, tc := range methods {
 		t.Run(tc.name+" handles nil Ledger", func(t *testing.T) {

--- a/log/filewriter.go
+++ b/log/filewriter.go
@@ -35,29 +35,29 @@ func openLogFile(path string) (*os.File, error) {
 	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 }
 
-// Write implements io.Writer.
+// Write implements io.Writer. When the descriptor is absent (a prior reopen
+// failed) writes are silently dropped, mirroring rippled's Logs::File::write
+// guard against a null stream (Log.cpp).
 func (w *FileWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.f == nil {
+		return len(p), nil
+	}
 	return w.f.Write(p)
-}
-
-// Path returns the configured log-file path.
-func (w *FileWriter) Path() string {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.path
 }
 
 // Rotate closes the current descriptor and reopens the configured path, so
 // writes continue against a freshly-created file after external rotation.
+// Like rippled's closeAndReopen (Log.cpp), the reopen is always attempted: the
+// close result is discarded (the descriptor is released regardless), and a
+// failed reopen leaves no live descriptor so subsequent writes drop silently.
 func (w *FileWriter) Rotate() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.f != nil {
-		if err := w.f.Close(); err != nil {
-			return err
-		}
+		_ = w.f.Close()
+		w.f = nil
 	}
 	f, err := openLogFile(w.path)
 	if err != nil {

--- a/log/filewriter.go
+++ b/log/filewriter.go
@@ -1,0 +1,83 @@
+package log
+
+import (
+	"errors"
+	"os"
+	"sync"
+)
+
+// ErrLogNotRotatable is returned by Rotate when the root logger does not write
+// to a rotatable file (e.g. it logs to stdout/stderr, or is not yet initialized).
+var ErrLogNotRotatable = errors.New("log output is not a rotatable file")
+
+// FileWriter is an io.Writer backed by an append-mode log file that can be
+// reopened on demand. It backs the logrotate RPC: external tooling renames the
+// active log file, then Rotate() closes the old descriptor and reopens the
+// original path so subsequent writes land in a freshly-created file. The
+// surrounding slog handler closes over the *FileWriter, so a rotation is
+// transparent to it.
+type FileWriter struct {
+	mu   sync.Mutex
+	path string
+	f    *os.File
+}
+
+// NewFileWriter opens path in append mode and returns a rotatable writer.
+func NewFileWriter(path string) (*FileWriter, error) {
+	f, err := openLogFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return &FileWriter{path: path, f: f}, nil
+}
+
+func openLogFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+}
+
+// Write implements io.Writer.
+func (w *FileWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.f.Write(p)
+}
+
+// Path returns the configured log-file path.
+func (w *FileWriter) Path() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.path
+}
+
+// Rotate closes the current descriptor and reopens the configured path, so
+// writes continue against a freshly-created file after external rotation.
+func (w *FileWriter) Rotate() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f != nil {
+		if err := w.f.Close(); err != nil {
+			return err
+		}
+	}
+	f, err := openLogFile(w.path)
+	if err != nil {
+		return err
+	}
+	w.f = f
+	return nil
+}
+
+// Rotate reopens the root logger's file output, returning ErrLogNotRotatable
+// when logging is not file-backed (stdout/stderr or before the root config is
+// set). Mirrors rippled's logs().rotate() (LogRotate.cpp).
+func Rotate() error {
+	cfg := rootCfg.Load()
+	if cfg == nil {
+		return ErrLogNotRotatable
+	}
+	fw, ok := cfg.Output.(*FileWriter)
+	if !ok {
+		return ErrLogNotRotatable
+	}
+	return fw.Rotate()
+}

--- a/log/filewriter_test.go
+++ b/log/filewriter_test.go
@@ -43,6 +43,33 @@ func TestFileWriterRotate(t *testing.T) {
 	}
 }
 
+func TestFileWriterRotateReopenFailure(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "logs")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	fw, err := NewFileWriter(filepath.Join(sub, "app.log"))
+	if err != nil {
+		t.Fatalf("NewFileWriter: %v", err)
+	}
+
+	// Drop the parent directory so the reopen during Rotate cannot succeed.
+	if err := os.RemoveAll(sub); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	if err := fw.Rotate(); err == nil {
+		t.Fatal("Rotate() = nil, want error when the reopen fails")
+	}
+
+	// A write after a failed reopen must drop silently (mirroring rippled's
+	// null-stream guard), never panic on a nil descriptor.
+	if n, err := fw.Write([]byte("dropped\n")); err != nil || n != len("dropped\n") {
+		t.Errorf("Write after failed rotate = (%d, %v), want (%d, nil)", n, err, len("dropped\n"))
+	}
+}
+
 func TestRotateRootConfig(t *testing.T) {
 	prev := rootCfg.Load()
 	t.Cleanup(func() { rootCfg.Store(prev) })

--- a/log/filewriter_test.go
+++ b/log/filewriter_test.go
@@ -1,0 +1,65 @@
+package log
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFileWriterRotate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "app.log")
+
+	fw, err := NewFileWriter(path)
+	if err != nil {
+		t.Fatalf("NewFileWriter: %v", err)
+	}
+	if _, err := fw.Write([]byte("first\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Simulate external rotation tooling renaming the active file, then ask
+	// the writer to reopen the original path.
+	rotated := path + ".1"
+	if err := os.Rename(path, rotated); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if err := fw.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	if _, err := fw.Write([]byte("second\n")); err != nil {
+		t.Fatalf("Write after rotate: %v", err)
+	}
+
+	newData, _ := os.ReadFile(path)
+	oldData, _ := os.ReadFile(rotated)
+	if !strings.Contains(string(newData), "second") || strings.Contains(string(newData), "first") {
+		t.Errorf("reopened file = %q, want only the post-rotate write", newData)
+	}
+	if !strings.Contains(string(oldData), "first") {
+		t.Errorf("rotated file = %q, want the pre-rotate write", oldData)
+	}
+}
+
+func TestRotateRootConfig(t *testing.T) {
+	prev := rootCfg.Load()
+	t.Cleanup(func() { rootCfg.Store(prev) })
+
+	// Not file-backed → ErrLogNotRotatable.
+	rootCfg.Store(&Config{Output: os.Stdout})
+	if err := Rotate(); !errors.Is(err, ErrLogNotRotatable) {
+		t.Errorf("Rotate() with stdout = %v, want ErrLogNotRotatable", err)
+	}
+
+	// File-backed → rotates cleanly.
+	fw, err := NewFileWriter(filepath.Join(t.TempDir(), "root.log"))
+	if err != nil {
+		t.Fatalf("NewFileWriter: %v", err)
+	}
+	rootCfg.Store(&Config{Output: fw})
+	if err := Rotate(); err != nil {
+		t.Errorf("Rotate() with file output = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

`logrotate` previously returned a fake `"Log rotation requested"` acknowledgment without doing anything. It now actually closes and reopens the log file, mirroring rippled `LogRotate.cpp` (`logs().rotate()`).

- New **`log.FileWriter`** wraps the append-mode log file and adds `Rotate()` (close + reopen the configured path under a mutex). The surrounding slog handler closes over the `*FileWriter`, so rotation is transparent to it.
- The logging config's `resolveOutput` now returns a `FileWriter` whenever `output` is a file path (stdout/stderr unchanged).
- A package-level **`log.Rotate()`** reopens the root logger's file and returns **`ErrLogNotRotatable`** when logging is not file-backed.
- The handler returns `"The log file was closed and reopened."` on success, or a clear `"logging is not file-backed; nothing to rotate"` message otherwise — no fabricated success. It no longer depends on the ledger service (it drives the global logger, like `log_level`).

This is the standard reopen-after-external-rename rotation model: an external tool renames the active file, then `logrotate` makes writes continue against a fresh file at the original path.

## Test plan
- [x] `go test ./log/... ./config/... ./internal/rpc/...` — passes
- [x] `go vet` — clean
- [x] `CGO_ENABLED=1 go build ./...` — passes
- Tests: `FileWriter.Rotate()` reopens after an external rename (old file keeps pre-rotate data, new file gets post-rotate writes); `log.Rotate()` returns `ErrLogNotRotatable` for stdout and nil for a file output. Removed `log_rotate` from the nil-ledger test (it no longer needs the ledger).

Refs #496