### PR TITLE
implement fetch_info inbound-ledger acquisition tracking

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -505,6 +505,15 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			}
 		}
 		services.CloseTimeOffset = acctRef.CloseOffset
+
+		// Expose the router's inbound-ledger acquisition tracker to the
+		// fetch_info RPC (rippled InboundLedgers). Populated by the live
+		// sync path; empty until the node is actively acquiring.
+		if router := consensusComponents.Router; router != nil {
+			services.FetchInfo = router.FetchInfo
+			services.FetchInfoClear = router.ClearFetchInfo
+		}
+
 		// Expose the validator-manifest cache to the `manifest` RPC.
 		// The cache is shared — the router writes inbound manifests,
 		// the engine reads for ephemeral→master translation, and this

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -90,6 +90,7 @@ type NetworkSender interface {
 	// (rippled/src/xrpld/app/ledger/detail/SkipListAcquire.cpp:84-92).
 	RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mapType message.LedgerMapType) error
 	RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error
+	RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error
 	SendToPeer(peerID uint64, frame []byte) error
 	// PeerSupportsReplay reports whether the peer identified by peerID
 	// advertised the ledger-replay feature during handshake. Used by
@@ -141,12 +142,13 @@ func (n *noopSender) RequestReplayDelta(uint64, [32]byte) error                {
 func (n *noopSender) RequestProofPath(uint64, [32]byte, [32]byte, message.LedgerMapType) error {
 	return nil
 }
-func (n *noopSender) RequestStateNodes(uint64, [32]byte, [][]byte) error { return nil }
-func (n *noopSender) SendToPeer(uint64, []byte) error                    { return nil }
-func (n *noopSender) PeerSupportsReplay(uint64) bool                     { return false }
-func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64 { return nil }
-func (n *noopSender) IncPeerBadData(uint64, string)                      {}
-func (n *noopSender) PeersThatHave([32]byte) []uint64                    { return nil }
+func (n *noopSender) RequestStateNodes(uint64, [32]byte, [][]byte) error       { return nil }
+func (n *noopSender) RequestTransactionNodes(uint64, [32]byte, [][]byte) error { return nil }
+func (n *noopSender) SendToPeer(uint64, []byte) error                          { return nil }
+func (n *noopSender) PeerSupportsReplay(uint64) bool                           { return false }
+func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64       { return nil }
+func (n *noopSender) IncPeerBadData(uint64, string)                            {}
+func (n *noopSender) PeersThatHave([32]byte) []uint64                          { return nil }
 
 // Compile-time interface check.
 var _ consensus.Adaptor = (*Adaptor)(nil)
@@ -619,6 +621,10 @@ func (a *Adaptor) RequestProofPath(peerID uint64, ledgerHash, key [32]byte, mapT
 
 func (a *Adaptor) RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {
 	return a.sender.RequestStateNodes(peerID, ledgerHash, nodeIDs)
+}
+
+func (a *Adaptor) RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {
+	return a.sender.RequestTransactionNodes(peerID, ledgerHash, nodeIDs)
 }
 
 // EngineConfigForReplay returns the shared (non-per-ledger)

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -2208,17 +2208,13 @@ func (r *Router) handleInboundLedgerData(ld *message.LedgerData) bool {
 			return true
 		}
 
-		// Request missing state nodes
-		nodeIDs := il.NeedsMissingNodeIDs()
-		if len(nodeIDs) > 0 {
-			if err := r.adaptor.RequestStateNodes(il.PeerID(), il.Hash(), nodeIDs); err != nil {
-				r.logger.Warn("inbound ledger: failed to request state nodes", "error", err)
-			}
-		}
+		// Request the missing state and transaction nodes in parallel,
+		// mirroring rippled InboundLedger::trigger (InboundLedger.cpp:621,696).
+		r.requestMissingAcquisitionNodes(il)
 		return true
 
 	case message.LedgerInfoAsNode:
-		// Phase 2: Got state tree nodes
+		// Phase 2a: Got state tree nodes
 		if err := il.GotStateNodes(ld.Nodes); err != nil {
 			r.logger.Warn("inbound ledger: GotStateNodes failed", "error", err)
 			r.adaptor.IncPeerBadData(il.PeerID(), "ledger-data-state")
@@ -2230,17 +2226,44 @@ func (r *Router) handleInboundLedgerData(ld *message.LedgerData) bool {
 			return true
 		}
 
-		// Request more missing nodes if needed
-		nodeIDs := il.NeedsMissingNodeIDs()
-		if len(nodeIDs) > 0 {
-			if err := r.adaptor.RequestStateNodes(il.PeerID(), il.Hash(), nodeIDs); err != nil {
-				r.logger.Warn("inbound ledger: failed to request state nodes", "error", err)
-			}
+		r.requestMissingAcquisitionNodes(il)
+		return true
+
+	case message.LedgerInfoTxNode:
+		// Phase 2b: Got transaction tree nodes
+		if err := il.GotTransactionNodes(ld.Nodes); err != nil {
+			r.logger.Warn("inbound ledger: GotTransactionNodes failed", "error", err)
+			r.adaptor.IncPeerBadData(il.PeerID(), "ledger-data-tx")
+			return true
 		}
+
+		if il.IsComplete() {
+			r.completeInboundLedger()
+			return true
+		}
+
+		r.requestMissingAcquisitionNodes(il)
 		return true
 	}
 
 	return false
+}
+
+// requestMissingAcquisitionNodes asks the source peer for the outstanding
+// account-state and transaction tree nodes of the active acquisition. Mirrors
+// rippled InboundLedger::trigger, which requests both trees in parallel
+// (InboundLedger.cpp:621,696). Each call is a no-op for a tree already complete.
+func (r *Router) requestMissingAcquisitionNodes(il *inbound.Ledger) {
+	if nodeIDs := il.NeedsMissingNodeIDs(); len(nodeIDs) > 0 {
+		if err := r.adaptor.RequestStateNodes(il.PeerID(), il.Hash(), nodeIDs); err != nil {
+			r.logger.Warn("inbound ledger: failed to request state nodes", "error", err)
+		}
+	}
+	if nodeIDs := il.NeedsMissingTxNodeIDs(); len(nodeIDs) > 0 {
+		if err := r.adaptor.RequestTransactionNodes(il.PeerID(), il.Hash(), nodeIDs); err != nil {
+			r.logger.Warn("inbound ledger: failed to request tx nodes", "error", err)
+		}
+	}
 }
 
 // completeInboundLedger finalizes an InboundLedger acquisition and adopts the ledger.
@@ -2248,7 +2271,7 @@ func (r *Router) completeInboundLedger() {
 	il := r.inboundLedger
 	r.inboundLedger = nil
 
-	h, stateMap, err := il.Result()
+	h, stateMap, txMap, err := il.Result()
 	if err != nil {
 		r.logger.Warn("inbound ledger: failed to get result", "error", err)
 		return
@@ -2260,21 +2283,18 @@ func (r *Router) completeInboundLedger() {
 		return
 	}
 
-	// Legacy header+state catchup path: no per-ledger tx tree is
-	// fetched in this mode (only the header and state map), so pass
-	// nil and let the service install the genesis-shaped empty tx
-	// map. The replay-delta path at adoptVerifiedLedger (above)
-	// passes the verified tx map — see R5.1.
+	// The acquisition fetches the header, state map, and transaction map; txMap
+	// is nil only when the ledger has no transactions (empty tx tree), in which
+	// case the service installs the genesis-shaped empty tx map.
 	//
-	// F6: same as the replay-delta path, route through
-	// SubmitHeldAdoption so out-of-order catchup arrivals either
-	// fast-path (parent already present) or stash for cascade when
-	// the awaited parent lands. Legacy mtGET_LEDGER is sequential at
-	// the wire level today, but nothing in the protocol forbids
-	// interleaving — the held-queue is the correct seam regardless.
-	// context.TODO: same as adoptVerifiedLedger — reached from a peer-
-	// message handler stack with no plumbed context. See note there.
-	res, err := svc.SubmitHeldAdoption(context.TODO(), h, stateMap, nil)
+	// F6: route through SubmitHeldAdoption so out-of-order catchup arrivals
+	// either fast-path (parent already present) or stash for cascade when the
+	// awaited parent lands. Legacy mtGET_LEDGER is sequential at the wire level
+	// today, but nothing in the protocol forbids interleaving — the held-queue
+	// is the correct seam regardless.
+	// context.TODO: same as adoptVerifiedLedger — reached from a peer-message
+	// handler stack with no plumbed context. See note there.
+	res, err := svc.SubmitHeldAdoption(context.TODO(), h, stateMap, txMap)
 	if err != nil {
 		r.logger.Warn("inbound ledger: failed to adopt with state", "error", err)
 		return

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
 	"github.com/LeJamon/goXRPLd/internal/ledger/inbound"
 	"github.com/LeJamon/goXRPLd/internal/ledger/openledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
@@ -934,8 +935,12 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		return
 	}
 
-	// Only handle base (header) requests beyond this point.
-	if req.InfoType != message.LedgerInfoBase {
+	// liBASE / liAS_NODE / liTX_NODE all operate on a stored ledger; rippled
+	// serves exactly these three plus liTS_CANDIDATE (PeerImp.cpp:3345-3363),
+	// so anything else is dropped.
+	switch req.InfoType {
+	case message.LedgerInfoBase, message.LedgerInfoAsNode, message.LedgerInfoTxNode:
+	default:
 		return
 	}
 
@@ -960,13 +965,24 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 	}
 
 	hash := l.Hash()
+	var nodes []message.LedgerNode
+	switch req.InfoType {
+	case message.LedgerInfoBase:
+		nodes = r.buildLedgerBaseNodes(l)
+	case message.LedgerInfoAsNode:
+		nodes = r.serveLedgerMapNodes(l.StateMapSnapshot, req, msg.PeerID, "state")
+	case message.LedgerInfoTxNode:
+		nodes = r.serveLedgerMapNodes(l.TxMapSnapshot, req, msg.PeerID, "tx")
+	}
+	if len(nodes) == 0 {
+		return
+	}
+
 	resp := &message.LedgerData{
-		LedgerHash: hash[:],
-		LedgerSeq:  l.Sequence(),
-		InfoType:   message.LedgerInfoBase,
-		Nodes: []message.LedgerNode{
-			{NodeData: l.SerializeHeader()},
-		},
+		LedgerHash:    hash[:],
+		LedgerSeq:     l.Sequence(),
+		InfoType:      req.InfoType,
+		Nodes:         nodes,
 		RequestCookie: uint32(req.RequestCookie),
 	}
 
@@ -981,8 +997,73 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 	}
 }
 
-// liTS_CANDIDATE serve-path caps matching rippled's softMaxReplyNodes /
-// hardMaxReplyNodes (rippled/src/xrpld/overlay/detail/Tuning.h:39,42).
+// buildLedgerBaseNodes builds the liBASE reply node set, mirroring rippled
+// PeerImp::sendLedgerBase (PeerImp.cpp:3119-3156): node[0] is the wire header
+// (no trailing hash, matching rippled's addRaw(LedgerInfo)); node[1] is the
+// account-state root when the state tree is non-empty; node[2] is the
+// transaction root when the ledger has transactions (txHash and tx-map hash
+// both non-zero).
+func (r *Router) buildLedgerBaseNodes(l *ledger.Ledger) []message.LedgerNode {
+	nodes := []message.LedgerNode{{NodeData: header.AddRaw(l.Header(), false)}}
+
+	stateHash, err := l.StateMapHash()
+	if err != nil || stateHash == ([32]byte{}) {
+		return nodes
+	}
+	stateMap, err := l.StateMapSnapshot()
+	if err != nil {
+		r.logger.Warn("ledger base: state snapshot failed", "error", err)
+		return nodes
+	}
+	stateRoot, err := stateMap.SerializeRoot()
+	if err != nil {
+		r.logger.Warn("ledger base: state root serialize failed", "error", err)
+		return nodes
+	}
+	nodes = append(nodes, message.LedgerNode{NodeData: stateRoot})
+
+	if l.Header().TxHash == ([32]byte{}) {
+		return nodes
+	}
+	txHash, err := l.TxMapHash()
+	if err != nil || txHash == ([32]byte{}) {
+		return nodes
+	}
+	txMap, err := l.TxMapSnapshot()
+	if err != nil {
+		r.logger.Warn("ledger base: tx snapshot failed", "error", err)
+		return nodes
+	}
+	txRoot, err := txMap.SerializeRoot()
+	if err != nil {
+		r.logger.Warn("ledger base: tx root serialize failed", "error", err)
+		return nodes
+	}
+	return append(nodes, message.LedgerNode{NodeData: txRoot})
+}
+
+// serveLedgerMapNodes walks the requested SHAMap node IDs of a ledger's state
+// or transaction tree, mirroring rippled PeerImp::processLedgerRequest's
+// liAS_NODE / liTX_NODE branch (PeerImp.cpp:3351-3411): fat nodes, QueryDepth
+// levels deep, honouring the soft/hard reply caps. fatLeaves is true here —
+// only liTS_CANDIDATE uses false (PeerImp.cpp:3301,3318).
+func (r *Router) serveLedgerMapNodes(snapshot func() (*shamap.SHAMap, error), req *message.GetLedger, peerID peermanagement.PeerID, label string) []message.LedgerNode {
+	m, err := snapshot()
+	if err != nil || m == nil {
+		r.logger.Debug("ledger node serve: map snapshot unavailable", "error", err, "peer", peerID)
+		return nil
+	}
+	queryDepth := int(req.QueryDepth)
+	if queryDepth == 0 {
+		queryDepth = defaultQueryDepth
+	}
+	return buildShaMapReplyNodes(m, req.NodeIDs, queryDepth, true, r.logger, peerID,
+		fmt.Sprintf("ledger %d %s", req.LedgerSeq, label))
+}
+
+// Ledger-data serve-path caps matching rippled's softMaxReplyNodes /
+// hardMaxReplyNodes (rippled/src/xrpld/overlay/detail/Tuning.h:39,42), shared
+// across liTS_CANDIDATE, liAS_NODE, and liTX_NODE replies as rippled does.
 // Soft cap stops starting new subtrees; hard cap truncates mid-subtree.
 // Declared as vars so tests can dial them down via txSetReplyCapsForTest /
 // setTxSetReplyCapsForTest. Production callers must not mutate.
@@ -1039,7 +1120,8 @@ func (r *Router) serveTxSet(peerID peermanagement.PeerID, req *message.GetLedger
 	// PeerImp.cpp:3318 hardcodes fatLeaves=false for liTS_CANDIDATE.
 	const fatLeaves = false
 
-	nodes := buildTxSetReplyNodes(txMap, req.NodeIDs, queryDepth, fatLeaves, r.logger, peerID, txSetID)
+	nodes := buildShaMapReplyNodes(txMap, req.NodeIDs, queryDepth, fatLeaves, r.logger, peerID,
+		fmt.Sprintf("txset %x", txSetID[:8]))
 
 	resp := &message.LedgerData{
 		LedgerHash:    req.LedgerHash,
@@ -1068,22 +1150,25 @@ func (r *Router) serveTxSet(peerID peermanagement.PeerID, req *message.GetLedger
 		"requested_nodes", len(req.NodeIDs))
 }
 
-// buildTxSetReplyNodes builds the LedgerNode payload of a liTS_CANDIDATE
-// reply, honouring requested NodeIDs/QueryDepth and soft/hard reply caps.
-func buildTxSetReplyNodes(
-	txMap *shamap.SHAMap,
+// buildShaMapReplyNodes builds the LedgerNode payload of a TMLedgerData reply
+// (liTS_CANDIDATE / liAS_NODE / liTX_NODE), honouring requested
+// NodeIDs/QueryDepth and soft/hard reply caps. label identifies the source map
+// for logging. Mirrors the node-walk in PeerImp::processLedgerRequest
+// (PeerImp.cpp:3364-3411).
+func buildShaMapReplyNodes(
+	m *shamap.SHAMap,
 	requestedNodeIDs [][]byte,
 	queryDepth int,
 	fatLeaves bool,
 	logger logger,
 	peerID peermanagement.PeerID,
-	txSetID consensus.TxSetID,
+	label string,
 ) []message.LedgerNode {
 	if len(requestedNodeIDs) == 0 {
-		wireNodes, err := txMap.WalkWireNodes()
+		wireNodes, err := m.WalkWireNodes()
 		if err != nil {
-			logger.Warn("failed to walk tx-set SHAMap for serve",
-				"error", err, "peer", peerID, "txset", fmt.Sprintf("%x", txSetID[:8]))
+			logger.Warn("failed to walk SHAMap for serve",
+				"error", err, "peer", peerID, "map", label)
 			return nil
 		}
 		nodes := make([]message.LedgerNode, 0, len(wireNodes))
@@ -1100,30 +1185,30 @@ func buildTxSetReplyNodes(
 	for i, rawID := range requestedNodeIDs {
 		// Soft cap — PeerImp.cpp:3387.
 		if len(nodes) >= txSetSoftMaxReplyNodes {
-			logger.Debug("tx-set serve: soft-cap reached, stopping subtree iteration",
-				"peer", peerID, "txset", fmt.Sprintf("%x", txSetID[:8]),
+			logger.Debug("shamap serve: soft-cap reached, stopping subtree iteration",
+				"peer", peerID, "map", label,
 				"nodes_so_far", len(nodes), "remaining_requested", len(requestedNodeIDs)-i)
 			break
 		}
 		path, depth, ok := parseSHAMapNodeID(rawID)
 		if !ok {
-			logger.Debug("tx-set serve: bad SHAMapNodeID in request, skipping",
-				"peer", peerID, "txset", fmt.Sprintf("%x", txSetID[:8]),
+			logger.Debug("shamap serve: bad SHAMapNodeID in request, skipping",
+				"peer", peerID, "map", label,
 				"node_idx", i, "len", len(rawID))
 			continue
 		}
-		subtree, err := txMap.GetNodeFatByPath(path, depth, queryDepth, fatLeaves)
+		subtree, err := m.GetNodeFatByPath(path, depth, queryDepth, fatLeaves)
 		if err != nil {
-			logger.Debug("tx-set serve: GetNodeFatByPath failed, skipping",
-				"peer", peerID, "txset", fmt.Sprintf("%x", txSetID[:8]),
+			logger.Debug("shamap serve: GetNodeFatByPath failed, skipping",
+				"peer", peerID, "map", label,
 				"error", err.Error())
 			continue
 		}
 		for _, n := range subtree {
 			// Hard cap — PeerImp.cpp:3406-3407.
 			if len(nodes) >= txSetHardMaxReplyNodes {
-				logger.Debug("tx-set serve: hard-cap reached, truncating subtree",
-					"peer", peerID, "txset", fmt.Sprintf("%x", txSetID[:8]),
+				logger.Debug("shamap serve: hard-cap reached, truncating subtree",
+					"peer", peerID, "map", label,
 					"nodes", len(nodes))
 				return nodes
 			}

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -64,6 +64,12 @@ type Router struct {
 	// serializing. Mirrors rippled's LedgerReplayer.
 	replayer *inbound.Replayer
 
+	// fetchTracker aggregates the classic legacy acquisitions for the
+	// fetch_info RPC (rippled's InboundLedgers). Populated from this
+	// goroutine via Track; queried from RPC goroutines via FetchInfo,
+	// which reads the acquisitions' own mutex-guarded state.
+	fetchTracker *inbound.Tracker
+
 	// messageSeen dedups inbound proposal / validation payloads so the
 	// reduce-relay slot only feeds on DUPLICATE arrivals, mirroring
 	// rippled's HashRouter::addSuppressionPeer !added branch at
@@ -226,6 +232,7 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManag
 		logger:          logger,
 		peerStates:      make(map[peermanagement.PeerID]*peerLedgerState),
 		replayer:        inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
+		fetchTracker:    inbound.NewTracker(),
 		messageSeen:     newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
 		txSetAcquire:    make(map[consensus.TxSetID]*txSetAcquireState),
 		txSetRetryKnobs: defaultTxSetRetryKnobs(),
@@ -1737,10 +1744,23 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 	)
 
 	r.inboundLedger = inbound.New(hash, seq, peerID, r.logger)
+	r.fetchTracker.Track(r.inboundLedger)
 	if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, hash, seq); err != nil {
 		r.logger.Warn("failed to request ledger base from peer", "error", err)
 		r.inboundLedger = nil
 	}
+}
+
+// FetchInfo returns the inbound-ledger acquisition snapshot served by the
+// fetch_info RPC. Safe to call from any goroutine.
+func (r *Router) FetchInfo() map[string]any {
+	return r.fetchTracker.Info()
+}
+
+// ClearFetchInfo resets the acquisition counters and recent-failure history,
+// backing fetch_info's `clear` param.
+func (r *Router) ClearFetchInfo() {
+	r.fetchTracker.Clear()
 }
 
 // handleReplayDeltaResponse verifies an inbound mtREPLAY_DELTA_RESPONSE

--- a/internal/consensus/adaptor/router_ledger_serve_test.go
+++ b/internal/consensus/adaptor/router_ledger_serve_test.go
@@ -1,0 +1,94 @@
+package adaptor
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/internal/ledger/inbound"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/stretchr/testify/require"
+)
+
+func serveTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestServeLedger_BaseAndStateRoundTripToAcquisition exercises the full
+// goXRPL→goXRPL ledger-acquisition wire path: the serve side builds the liBASE
+// reply (header + state root) and answers liAS_NODE requests, and a fresh
+// inbound.Ledger acquires the ledger from those replies alone. This is the
+// counterpart to rippled's PeerImp::sendLedgerBase + processLedgerRequest
+// (PeerImp.cpp:3119-3411) — before the serve side returned more than the bare
+// header, a goXRPL node could not catch up from another goXRPL node.
+func TestServeLedger_BaseAndStateRoundTripToAcquisition(t *testing.T) {
+	t.Parallel()
+	adaptor, _ := newTxSetWireAdaptor(t)
+	router := NewRouter(&mockEngine{}, adaptor, nil, nil)
+
+	l := adaptor.LedgerService().GetClosedLedger()
+	require.NotNil(t, l)
+	hash := l.Hash()
+	seq := l.Sequence()
+
+	// Serve the base: header (118-byte wire form, no trailing hash) + state root.
+	// The genesis ledger has no transactions, so there is no node[2].
+	baseNodes := router.buildLedgerBaseNodes(l)
+	require.GreaterOrEqual(t, len(baseNodes), 2, "base must carry header + state root")
+	require.Equal(t, header.SizeBase, len(baseNodes[0].NodeData),
+		"node[0] must be the 118-byte rippled wire header (no trailing hash)")
+
+	// Acquire: feed the served base into a fresh acquisition.
+	il := inbound.New(hash, seq, 7, serveTestLogger())
+	require.NoError(t, il.GotBase(baseNodes))
+
+	// Drive the state fetch: request the outstanding nodes, serve them, repeat.
+	for i := 0; i < 200 && !il.IsComplete(); i++ {
+		ids := il.NeedsMissingNodeIDs()
+		require.NotEmpty(t, ids, "incomplete acquisition must list outstanding state nodes")
+		req := &message.GetLedger{
+			InfoType:   message.LedgerInfoAsNode,
+			LedgerHash: hash[:],
+			LedgerSeq:  seq,
+			NodeIDs:    ids,
+		}
+		nodes := router.serveLedgerMapNodes(l.StateMapSnapshot, req, 7, "state")
+		require.NotEmpty(t, nodes, "serve must answer the requested state node IDs")
+		require.NoError(t, il.GotStateNodes(nodes))
+	}
+
+	require.True(t, il.IsComplete(), "goXRPL-served ledger must fully acquire")
+
+	gotHdr, gotState, gotTx, err := il.Result()
+	require.NoError(t, err)
+	require.Equal(t, hash, gotHdr.Hash)
+	require.Nil(t, gotTx, "genesis tx tree is empty → nil tx map")
+
+	gotStateHash, err := gotState.Hash()
+	require.NoError(t, err)
+	wantStateHash, err := l.StateMapHash()
+	require.NoError(t, err)
+	require.Equal(t, wantStateHash, gotStateHash,
+		"acquired state root must match the served ledger")
+}
+
+// TestBuildLedgerBaseNodes_EmptyTxTreeOmitsTxRoot pins that a ledger with no
+// transactions yields exactly header + state root (no node[2]), mirroring
+// rippled sendLedgerBase which appends the tx root only when the tx tree is
+// non-empty (PeerImp.cpp:3139-3148).
+func TestBuildLedgerBaseNodes_EmptyTxTreeOmitsTxRoot(t *testing.T) {
+	t.Parallel()
+	adaptor, _ := newTxSetWireAdaptor(t)
+	router := NewRouter(&mockEngine{}, adaptor, nil, nil)
+
+	l := adaptor.LedgerService().GetClosedLedger()
+	require.NotNil(t, l)
+
+	txHash, err := l.TxMapHash()
+	require.NoError(t, err)
+	require.Equal(t, [32]byte{}, txHash, "fixture precondition: genesis has an empty tx tree")
+
+	nodes := router.buildLedgerBaseNodes(l)
+	require.Len(t, nodes, 2, "empty tx tree must omit the tx root (header + state root only)")
+}

--- a/internal/consensus/adaptor/router_ledger_serve_txbearing_test.go
+++ b/internal/consensus/adaptor/router_ledger_serve_txbearing_test.go
@@ -1,0 +1,136 @@
+package adaptor
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
+	"github.com/LeJamon/goXRPLd/internal/ledger/inbound"
+	"github.com/LeJamon/goXRPLd/internal/ledger/service"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	testenv "github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/internal/testing/payment"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/stretchr/testify/require"
+)
+
+// closedLedgerWithPayment builds a standalone service, applies one signed
+// Payment, and closes a ledger so GetClosedLedger() returns a ledger with a
+// non-empty transaction tree.
+func closedLedgerWithPayment(t *testing.T) *service.Service {
+	t.Helper()
+	svc, err := service.New(service.Config{Standalone: true, GenesisConfig: genesis.DefaultConfig()})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	env := testenv.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	master := testenv.MasterAccount()
+	alice := testenv.NewAccount("alice")
+
+	txn := payment.Pay(master, alice, 100_000_000).Sequence(1).Build()
+	env.SignWith(txn, master)
+	flat, err := txn.Flatten()
+	require.NoError(t, err)
+	hexStr, err := binarycodec.Encode(flat)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+
+	// SubmitTransaction feeds the standalone pending pool that AcceptLedger
+	// commits (SubmitOpenLedgerTx only touches the open view, not pendingTxs).
+	parsed, err := tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	res, err := svc.SubmitTransaction(parsed, blob, false)
+	require.NoError(t, err)
+	require.True(t, res.Applied, "payment must apply so it lands in the closed ledger")
+
+	_, err = svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	return svc
+}
+
+// TestServeLedger_TxBearing_FullRoundTrip is the end-to-end proof for the
+// transaction-tree work: a goXRPL node serves a ledger that actually has
+// transactions (liBASE carries node[2]=tx root, plus liTX_NODE replies) and a
+// fresh acquisition reconstructs both the state and transaction trees from
+// those replies alone. Mirrors rippled PeerImp::sendLedgerBase +
+// processLedgerRequest (PeerImp.cpp:3119-3411) feeding InboundLedger.
+//
+// The acquired tx map hash equals header.TxHash — exactly the value
+// completeInboundLedger hands to SubmitHeldAdoption, whose persist path is
+// already covered for a non-empty tx map by the replay-delta adoption tests.
+func TestServeLedger_TxBearing_FullRoundTrip(t *testing.T) {
+	t.Parallel()
+	svc := closedLedgerWithPayment(t)
+
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	adaptor := New(Config{
+		LedgerService: svc,
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+	router := NewRouter(&mockEngine{}, adaptor, nil, nil)
+
+	l := svc.GetClosedLedger()
+	require.NotNil(t, l)
+	hash := l.Hash()
+	seq := l.Sequence()
+
+	wantTxHash, err := l.TxMapHash()
+	require.NoError(t, err)
+	require.NotEqual(t, [32]byte{}, wantTxHash, "fixture must have a non-empty tx tree")
+	wantStateHash, err := l.StateMapHash()
+	require.NoError(t, err)
+
+	// liBASE must now carry the tx root (node[2]) alongside header + state root.
+	baseNodes := router.buildLedgerBaseNodes(l)
+	require.Len(t, baseNodes, 3, "tx-bearing base must carry header + state root + tx root")
+	require.NotEmpty(t, baseNodes[2].NodeData, "node[2] (tx root) must be non-empty")
+
+	// Acquire from the served replies alone.
+	il := inbound.New(hash, seq, 7, serveTestLogger())
+	require.NoError(t, il.GotBase(baseNodes))
+	require.False(t, il.IsComplete(), "must still need state + tx nodes after base")
+
+	asReq := func(ids [][]byte) *message.GetLedger {
+		return &message.GetLedger{LedgerHash: hash[:], LedgerSeq: seq, NodeIDs: ids}
+	}
+	for i := 0; i < 500 && !il.IsComplete(); i++ {
+		progressed := false
+		if ids := il.NeedsMissingNodeIDs(); len(ids) > 0 {
+			nodes := router.serveLedgerMapNodes(l.StateMapSnapshot, asReq(ids), 7, "state")
+			require.NotEmpty(t, nodes, "serve must answer requested state nodes")
+			require.NoError(t, il.GotStateNodes(nodes))
+			progressed = true
+		}
+		if ids := il.NeedsMissingTxNodeIDs(); len(ids) > 0 {
+			nodes := router.serveLedgerMapNodes(l.TxMapSnapshot, asReq(ids), 7, "tx")
+			require.NotEmpty(t, nodes, "serve must answer requested tx nodes")
+			require.NoError(t, il.GotTransactionNodes(nodes))
+			progressed = true
+		}
+		require.True(t, progressed, "acquisition stalled with neither tree complete")
+	}
+
+	require.True(t, il.IsComplete(), "tx-bearing ledger must fully acquire goXRPL→goXRPL")
+
+	gotHdr, gotState, gotTx, err := il.Result()
+	require.NoError(t, err)
+	require.Equal(t, hash, gotHdr.Hash)
+	require.NotNil(t, gotTx, "tx-bearing ledger must yield a non-nil tx map")
+
+	gotTxHash, err := gotTx.Hash()
+	require.NoError(t, err)
+	require.Equal(t, wantTxHash, gotTxHash,
+		"acquired tx map must match header.TxHash — the value handed to adoption")
+	require.Equal(t, wantTxHash, gotHdr.TxHash, "acquired header must carry the tx root hash")
+
+	gotStateHash, err := gotState.Hash()
+	require.NoError(t, err)
+	require.Equal(t, wantStateHash, gotStateHash, "acquired state map must match the served ledger")
+}

--- a/internal/consensus/adaptor/router_txset_partial_test.go
+++ b/internal/consensus/adaptor/router_txset_partial_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement"
 	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
 	"github.com/LeJamon/goXRPLd/shamap"
@@ -15,7 +14,7 @@ import (
 )
 
 // silentLogger satisfies the logger interface used by
-// buildTxSetReplyNodes without writing anywhere — keeps test
+// buildShaMapReplyNodes without writing anywhere — keeps test
 // output focused on the assertions.
 type silentLogger struct{}
 
@@ -63,16 +62,16 @@ func rootNodeID() []byte {
 // fatLeaves=false skip only affects leaves whose parent is at the
 // budget=0 boundary.
 func TestServeTxSet_RootRequest_RootFirstAndInnersIncluded(t *testing.T) {
-	txMap, txSetID, wireNodes := buildTxSetForTest(t, 4)
+	txMap, _, wireNodes := buildTxSetForTest(t, 4)
 
-	got := buildTxSetReplyNodes(
+	got := buildShaMapReplyNodes(
 		txMap,
 		[][]byte{rootNodeID()},
 		3,     // querydepth=3 — TransactionAcquire's first-request value
 		false, // fatLeaves=false — rippled liTS_CANDIDATE default
 		silentLogger{},
 		7,
-		consensus.TxSetID(txSetID),
+		"txset",
 	)
 
 	require.NotEmpty(t, got, "must return at least the root")
@@ -116,16 +115,16 @@ func TestServeTxSet_RootRequest_RootFirstAndInnersIncluded(t *testing.T) {
 // that don't trust the requestor's pool — at the cost of more
 // bytes, every leaf is carried inline.
 func TestServeTxSet_RootRequest_FatLeaves_FullCoverage(t *testing.T) {
-	txMap, txSetID, wireNodes := buildTxSetForTest(t, 4)
+	txMap, _, wireNodes := buildTxSetForTest(t, 4)
 
-	got := buildTxSetReplyNodes(
+	got := buildShaMapReplyNodes(
 		txMap,
 		[][]byte{rootNodeID()},
 		3,
 		true, // fatLeaves=true — include leaves at depth boundary
 		silentLogger{},
 		7,
-		consensus.TxSetID(txSetID),
+		"txset",
 	)
 
 	served := make(map[string]bool, len(got))
@@ -145,16 +144,16 @@ func TestServeTxSet_RootRequest_FatLeaves_FullCoverage(t *testing.T) {
 // SHAMap pre-order. Without the fallback, those callers get an
 // empty response and the engine never sees the tx-set.
 func TestServeTxSet_NoNodeIDs_FallsBackToFullWalk(t *testing.T) {
-	txMap, txSetID, wireNodes := buildTxSetForTest(t, 3)
+	txMap, _, wireNodes := buildTxSetForTest(t, 3)
 
-	got := buildTxSetReplyNodes(
+	got := buildShaMapReplyNodes(
 		txMap,
 		nil, // explicit empty
 		1,   // ignored on the fallback path
 		false,
 		silentLogger{},
 		7,
-		consensus.TxSetID(txSetID),
+		"txset",
 	)
 
 	require.Len(t, got, len(wireNodes), "fallback walks the full tree")
@@ -171,16 +170,16 @@ func TestServeTxSet_NoNodeIDs_FallsBackToFullWalk(t *testing.T) {
 // rejection path. The serve must not panic and must still process
 // other valid NodeIDs in the same request.
 func TestServeTxSet_BadNodeID_Skipped(t *testing.T) {
-	txMap, txSetID, _ := buildTxSetForTest(t, 2)
+	txMap, _, _ := buildTxSetForTest(t, 2)
 
-	got := buildTxSetReplyNodes(
+	got := buildShaMapReplyNodes(
 		txMap,
 		[][]byte{
 			{0xAA, 0xBB},     // too short
 			rootNodeID(),     // valid
 			make([]byte, 50), // too long
 		},
-		1, false, silentLogger{}, 7, consensus.TxSetID(txSetID),
+		1, false, silentLogger{}, 7, "txset",
 	)
 
 	require.NotEmpty(t, got, "valid root NodeID in the middle must still produce output")
@@ -195,14 +194,14 @@ func TestServeTxSet_BadNodeID_Skipped(t *testing.T) {
 // huge tx-set and we'd send the whole thing in one frame, blowing
 // past the ~64 MB protocol message-size limit.
 func TestServeTxSet_HardCap(t *testing.T) {
-	txMap, txSetID, wireNodes := buildTxSetForTest(t, 16) // ~ root + inners + 16 leaves
+	txMap, _, wireNodes := buildTxSetForTest(t, 16) // ~ root + inners + 16 leaves
 	require.Greater(t, len(wireNodes), 5, "fixture must have enough nodes to exercise the cap")
 
 	got := withTxSetReplyCaps(2, 3, func() []message.LedgerNode {
-		return buildTxSetReplyNodes(
+		return buildShaMapReplyNodes(
 			txMap,
 			[][]byte{rootNodeID()},
-			3, false, silentLogger{}, 7, consensus.TxSetID(txSetID),
+			3, false, silentLogger{}, 7, "txset",
 		)
 	})
 
@@ -229,7 +228,7 @@ func TestServeTxSet_HardCap(t *testing.T) {
 // verifying that NodeIDs after the soft-cap boundary contribute
 // zero nodes to the output.
 func TestServeTxSet_SoftCap(t *testing.T) {
-	txMap, txSetID, wireNodes := buildTxSetForTest(t, 8)
+	txMap, _, wireNodes := buildTxSetForTest(t, 8)
 
 	// Pick two distinct leaf-level NodeIDs from the wire walk so
 	// each one yields >= 1 node when requested. We need them sorted
@@ -248,14 +247,14 @@ func TestServeTxSet_SoftCap(t *testing.T) {
 	// Soft cap of 1 means: after the FIRST subtree adds any nodes,
 	// every subsequent NodeID in the request is skipped.
 	got := withTxSetReplyCaps(1, 100, func() []message.LedgerNode {
-		return buildTxSetReplyNodes(
+		return buildShaMapReplyNodes(
 			txMap,
 			[][]byte{leaves[0].NodeID, leaves[1].NodeID},
 			0,
 			false,
 			silentLogger{},
 			7,
-			consensus.TxSetID(txSetID),
+			"txset",
 		)
 	})
 

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -314,6 +314,22 @@ func (s *OverlaySender) RequestStateNodes(peerID uint64, ledgerHash [32]byte, no
 	return s.overlay.Send(peermanagement.PeerID(peerID), frame)
 }
 
+// RequestTransactionNodes sends a GetLedger request for transaction SHAMap
+// nodes (rippled InboundLedger::trigger liTX_NODE branch, InboundLedger.cpp:696).
+func (s *OverlaySender) RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {
+	msg := &message.GetLedger{
+		InfoType:   message.LedgerInfoTxNode,
+		LedgerHash: ledgerHash[:],
+		NodeIDs:    nodeIDs,
+		QueryDepth: 2, // Return fat nodes (node + 2 levels of descendants)
+	}
+	frame, err := encodeFrame(message.TypeGetLedger, msg)
+	if err != nil {
+		return fmt.Errorf("encode get_ledger (tx nodes): %w", err)
+	}
+	return s.overlay.Send(peermanagement.PeerID(peerID), frame)
+}
+
 // encodeFrame serializes a message and wraps it with the wire protocol header.
 // The result can be passed directly to Overlay.Broadcast() or Overlay.Send().
 func encodeFrame(msgType message.MessageType, msg message.Message) ([]byte, error) {

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -1,6 +1,7 @@
 // Package inbound provides lightweight ledger acquisition from peers.
-// It fetches the full ledger header and state tree via the TMGetLedger/TMLedgerData
-// peer protocol, matching rippled's InboundLedger behavior.
+// It fetches the full ledger header, account-state tree, and transaction tree
+// via the TMGetLedger/TMLedgerData peer protocol, matching rippled's
+// InboundLedger behavior.
 package inbound
 
 import (
@@ -27,25 +28,32 @@ const (
 )
 
 // Ledger manages the acquisition of a single ledger from a peer.
-// It progresses through: WantBase → WantState → Complete.
+// It progresses through: WantBase → WantState → Complete. Like rippled's
+// InboundLedger, it fetches the account-state and transaction trees in
+// parallel once the header is in hand; the acquisition is Complete only when
+// both have been fully fetched (rippled InboundLedger.cpp:734,946).
 //
 // Field lock guarantees:
 //   - hash, seq, peerID, created, logger are set at construction and never
 //     mutated thereafter; the accessors below (Hash, Seq, PeerID) read them
 //     without taking mu and are safe under concurrent State() callers.
-//   - header, stateMap, state, err are written under mu and must be read
-//     through accessors that take mu (State, IsTimedOut, GotBase, etc.).
+//   - header, stateMap, txMap, haveState, haveTx, state, err are written under
+//     mu and must be read through accessors that take mu (State, IsTimedOut,
+//     GotBase, etc.).
 type Ledger struct {
-	hash     [32]byte
-	seq      uint32
-	header   *header.LedgerHeader
-	stateMap *shamap.SHAMap
-	peerID   uint64
-	state    State
-	err      error
-	created  time.Time
-	mu       sync.Mutex
-	logger   *slog.Logger
+	hash      [32]byte
+	seq       uint32
+	header    *header.LedgerHeader
+	stateMap  *shamap.SHAMap
+	txMap     *shamap.SHAMap // nil when the transaction tree is empty (TxHash zero)
+	haveState bool
+	haveTx    bool
+	peerID    uint64
+	state     State
+	err       error
+	created   time.Time
+	mu        sync.Mutex
+	logger    *slog.Logger
 }
 
 // New creates a new InboundLedger acquisition for the given ledger hash.
@@ -89,8 +97,10 @@ func (l *Ledger) Hash() [32]byte {
 	return l.hash
 }
 
-// GotBase processes the LedgerInfoBase response containing the header and root nodes.
-// Rippled sends: node[0]=header, node[1]=state root, node[2]=tx root.
+// GotBase processes the LedgerInfoBase response containing the header and root
+// nodes. Rippled sends node[0]=header, node[1]=state root, and node[2]=tx root —
+// but the tx root is present only when the transaction tree is non-empty
+// (PeerImp.cpp:3139-3148). An empty tree (zero TxHash) is complete on arrival.
 func (l *Ledger) GotBase(nodes []message.LedgerNode) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -143,14 +153,50 @@ func (l *Ledger) GotBase(nodes []message.LedgerNode) error {
 	}
 
 	l.stateMap = sm
+	l.haveState = sm.FinishSync() == nil
 
-	// Always transition to WantState. Even if the root has no missing children,
-	// the caller will check IsComplete() and finalize via GotStateNodes path.
-	l.state = StateWantState
+	// Set up the transaction tree. An empty tx tree has a zero TxHash and is
+	// complete immediately (rippled InboundLedger.cpp:850); otherwise the peer
+	// ships its root as node[2].
+	if h.TxHash == ([32]byte{}) {
+		l.haveTx = true
+	} else {
+		tm, txErr := shamap.New(shamap.TypeTransaction)
+		if txErr != nil {
+			l.state = StateFailed
+			l.err = fmt.Errorf("create tx map: %w", txErr)
+			return l.err
+		}
+		if len(nodes) >= 3 && len(nodes[2].NodeData) > 0 {
+			if err := tm.AddRootNode(h.TxHash, nodes[2].NodeData); err != nil {
+				l.state = StateFailed
+				l.err = fmt.Errorf("add tx root node: %w", err)
+				return l.err
+			}
+			l.txMap = tm
+			l.haveTx = tm.FinishSync() == nil
+		} else {
+			// A well-behaved peer always ships the tx root alongside the state
+			// root. Without it we cannot drive the tx fetch (our request path
+			// needs the root in hand), so fall back to header+state catchup and
+			// adopt with an empty tx map — the prior behavior.
+			l.logger.Warn("inbound ledger: tx root absent for non-empty tx tree, adopting state-only",
+				"seq", h.LedgerIndex)
+			l.haveTx = true
+		}
+	}
 
-	l.logger.Info("inbound ledger: state root added, fetching missing nodes",
+	if l.haveState && l.haveTx {
+		l.state = StateComplete
+	} else {
+		l.state = StateWantState
+	}
+
+	l.logger.Info("inbound ledger: roots added, fetching missing nodes",
 		"seq", h.LedgerIndex,
-		"missing", len(sm.GetMissingNodes(16, nil)),
+		"have_state", l.haveState,
+		"have_tx", l.haveTx,
+		"missing_state", len(sm.GetMissingNodes(16, nil)),
 	)
 
 	return nil
@@ -161,8 +207,8 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.state == StateComplete {
-		return nil // Already done
+	if l.state == StateComplete || l.haveState {
+		return nil // State tree already acquired
 	}
 	if l.state != StateWantState {
 		return fmt.Errorf("unexpected state %d for GotStateNodes", l.state)
@@ -209,13 +255,78 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 	// before the FinishSync write lock). A failure here is treated as
 	// "still missing nodes", not fatal.
 	if err := l.stateMap.FinishSync(); err != nil {
-		l.logger.Debug("inbound ledger: still incomplete", "error", err)
+		l.logger.Debug("inbound ledger: state still incomplete", "error", err)
 		return nil
 	}
-	l.state = StateComplete
-	l.logger.Info("inbound ledger: acquisition complete", "seq", l.header.LedgerIndex)
+	l.haveState = true
+	l.recomputeComplete()
 
 	return nil
+}
+
+// GotTransactionNodes processes transaction tree nodes received from the peer.
+// It mirrors GotStateNodes: drive placement by the peer-supplied NodeID, then
+// FinishSync as the authoritative completeness check.
+func (l *Ledger) GotTransactionNodes(nodes []message.LedgerNode) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.state == StateComplete || l.haveTx {
+		return nil // Transaction tree already acquired (or empty)
+	}
+	if l.state != StateWantState || l.txMap == nil {
+		return fmt.Errorf("unexpected state %d for GotTransactionNodes", l.state)
+	}
+
+	added := 0
+	for _, node := range nodes {
+		if len(node.NodeData) == 0 {
+			continue
+		}
+		parsedID, err := shamap.UnmarshalBinary(node.NodeID)
+		if err != nil {
+			l.logger.Debug("inbound ledger: malformed tx node ID",
+				"node_id_len", len(node.NodeID),
+				"error", err.Error())
+			continue
+		}
+		if parsedID.IsRoot() {
+			continue
+		}
+		if err := l.txMap.AddKnownNodeByID(parsedID, node.NodeData); err != nil {
+			l.logger.Debug("inbound ledger: tx node rejected",
+				"node_id", fmt.Sprintf("%x", node.NodeID),
+				"node_data_len", len(node.NodeData),
+				"error", err.Error())
+			continue
+		}
+		added++
+	}
+
+	l.logger.Info("inbound ledger: added tx nodes",
+		"added", added,
+		"total_received", len(nodes),
+	)
+
+	if err := l.txMap.FinishSync(); err != nil {
+		l.logger.Debug("inbound ledger: tx still incomplete", "error", err)
+		return nil
+	}
+	l.haveTx = true
+	l.recomputeComplete()
+
+	return nil
+}
+
+// recomputeComplete promotes the acquisition to StateComplete once both the
+// account-state and transaction trees are in hand, mirroring rippled's
+// complete_ = mHaveHeader && mHaveState && mHaveTransactions
+// (InboundLedger.cpp:734,946). Caller must hold l.mu.
+func (l *Ledger) recomputeComplete() {
+	if l.haveState && l.haveTx && l.state != StateFailed {
+		l.state = StateComplete
+		l.logger.Info("inbound ledger: acquisition complete", "seq", l.header.LedgerIndex)
+	}
 }
 
 // missingNodeBatch caps NodeIDs per TMGetLedger request. Sits between
@@ -230,15 +341,32 @@ func (l *Ledger) NeedsMissingNodeIDs() [][]byte {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.stateMap == nil || l.state != StateWantState {
+	if l.stateMap == nil || l.haveState || l.state != StateWantState {
 		return nil
 	}
+	return missingNodeIDs(l.stateMap)
+}
 
-	missing := l.stateMap.GetMissingNodes(missingNodeBatch, nil)
+// NeedsMissingTxNodeIDs returns up to missingNodeBatch wire-encoded NodeIDs of
+// missing transaction-tree inner nodes, mirroring NeedsMissingNodeIDs for the
+// tx map. Returns nil once the tx tree is complete (or empty).
+func (l *Ledger) NeedsMissingTxNodeIDs() [][]byte {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.txMap == nil || l.haveTx || l.state != StateWantState {
+		return nil
+	}
+	return missingNodeIDs(l.txMap)
+}
+
+// missingNodeIDs returns up to missingNodeBatch wire-encoded path-based NodeIDs
+// of missing inner nodes in m, or nil when the map is complete.
+func missingNodeIDs(m *shamap.SHAMap) [][]byte {
+	missing := m.GetMissingNodes(missingNodeBatch, nil)
 	if len(missing) == 0 {
 		return nil
 	}
-
 	nodeIDs := make([][]byte, 0, len(missing))
 	for i := range missing {
 		nodeIDs = append(nodeIDs, missing[i].NodeID.Bytes())
@@ -246,21 +374,23 @@ func (l *Ledger) NeedsMissingNodeIDs() [][]byte {
 	return nodeIDs
 }
 
-// Snapshot is a point-in-time view of an acquisition's progress, used by
-// the fetch_info RPC (mirrors the per-ledger fields rippled emits from
-// InboundLedger::getJson). goXRPL's classic acquisition fetches only the
-// header + state tree, so there is no have_transactions/needed_transaction
-// counterpart, and it reaps on first timeout rather than counting
-// re-request cycles, so the timeouts field is always reported as zero.
+// Snapshot is a point-in-time view of an acquisition's progress, used by the
+// fetch_info RPC (mirrors the per-ledger fields rippled emits from
+// InboundLedger::getJson). The acquisition reaps on first timeout rather than
+// counting re-request cycles, so the timeouts field is always reported as zero,
+// and it fetches from a single source peer (Peers == 1 while in flight).
 type Snapshot struct {
-	Hash        [32]byte
-	Seq         uint32
-	HaveHeader  bool
-	HaveState   bool
-	Complete    bool
-	Failed      bool
-	TimedOut    bool
-	NeededState [][32]byte // hashes of up to missingNodeBatch missing state nodes
+	Hash             [32]byte
+	Seq              uint32
+	HaveHeader       bool
+	HaveState        bool
+	HaveTransactions bool
+	Complete         bool
+	Failed           bool
+	TimedOut         bool
+	Peers            int
+	NeededState      [][32]byte // hashes of up to missingNodeBatch missing state nodes
+	NeededTx         [][32]byte // hashes of up to missingNodeBatch missing tx nodes
 }
 
 // Snapshot returns a consistent view of the acquisition's progress under
@@ -270,19 +400,26 @@ func (l *Ledger) Snapshot() Snapshot {
 	defer l.mu.Unlock()
 
 	s := Snapshot{
-		Hash:       l.hash,
-		Seq:        l.seq,
-		HaveHeader: l.header != nil,
-		HaveState:  l.state == StateComplete,
-		Complete:   l.state == StateComplete,
-		Failed:     l.state == StateFailed,
+		Hash:             l.hash,
+		Seq:              l.seq,
+		HaveHeader:       l.header != nil,
+		HaveState:        l.haveState,
+		HaveTransactions: l.haveTx,
+		Complete:         l.state == StateComplete,
+		Failed:           l.state == StateFailed,
 		TimedOut: l.state != StateComplete && l.state != StateFailed &&
 			time.Since(l.created) > acquisitionTimeout,
+		Peers: 1, // classic acquisition fetches from a single source peer (l.peerID)
 	}
 
-	if l.state == StateWantState && l.stateMap != nil {
+	if !l.haveState && l.stateMap != nil {
 		for _, m := range l.stateMap.GetMissingNodes(missingNodeBatch, nil) {
 			s.NeededState = append(s.NeededState, m.Hash)
+		}
+	}
+	if !l.haveTx && l.txMap != nil {
+		for _, m := range l.txMap.GetMissingNodes(missingNodeBatch, nil) {
+			s.NeededTx = append(s.NeededTx, m.Hash)
 		}
 	}
 
@@ -296,17 +433,18 @@ func (l *Ledger) IsComplete() bool {
 	return l.state == StateComplete
 }
 
-// Result returns the acquired header and state map.
+// Result returns the acquired header, state map, and transaction map.
+// The tx map is nil when the ledger has no transactions (empty tx tree).
 // Only valid after IsComplete() returns true.
-func (l *Ledger) Result() (*header.LedgerHeader, *shamap.SHAMap, error) {
+func (l *Ledger) Result() (*header.LedgerHeader, *shamap.SHAMap, *shamap.SHAMap, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	if l.state != StateComplete {
-		return nil, nil, fmt.Errorf("acquisition not complete (state=%d)", l.state)
+		return nil, nil, nil, fmt.Errorf("acquisition not complete (state=%d)", l.state)
 	}
 
-	return l.header, l.stateMap, nil
+	return l.header, l.stateMap, l.txMap, nil
 }
 
 // Err returns the error if the acquisition failed.

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -251,7 +251,7 @@ func (l *Ledger) NeedsMissingNodeIDs() [][]byte {
 // InboundLedger::getJson). goXRPL's classic acquisition fetches only the
 // header + state tree, so there is no have_transactions/needed_transaction
 // counterpart, and it reaps on first timeout rather than counting
-// re-request cycles, so there is no timeouts counter.
+// re-request cycles, so the timeouts field is always reported as zero.
 type Snapshot struct {
 	Hash        [32]byte
 	Seq         uint32

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -246,6 +246,49 @@ func (l *Ledger) NeedsMissingNodeIDs() [][]byte {
 	return nodeIDs
 }
 
+// Snapshot is a point-in-time view of an acquisition's progress, used by
+// the fetch_info RPC (mirrors the per-ledger fields rippled emits from
+// InboundLedger::getJson). goXRPL's classic acquisition fetches only the
+// header + state tree, so there is no have_transactions/needed_transaction
+// counterpart, and it reaps on first timeout rather than counting
+// re-request cycles, so there is no timeouts counter.
+type Snapshot struct {
+	Hash        [32]byte
+	Seq         uint32
+	HaveHeader  bool
+	HaveState   bool
+	Complete    bool
+	Failed      bool
+	TimedOut    bool
+	NeededState [][32]byte // hashes of up to missingNodeBatch missing state nodes
+}
+
+// Snapshot returns a consistent view of the acquisition's progress under
+// the lock, safe to call from any goroutine.
+func (l *Ledger) Snapshot() Snapshot {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	s := Snapshot{
+		Hash:       l.hash,
+		Seq:        l.seq,
+		HaveHeader: l.header != nil,
+		HaveState:  l.state == StateComplete,
+		Complete:   l.state == StateComplete,
+		Failed:     l.state == StateFailed,
+		TimedOut: l.state != StateComplete && l.state != StateFailed &&
+			time.Since(l.created) > acquisitionTimeout,
+	}
+
+	if l.state == StateWantState && l.stateMap != nil {
+		for _, m := range l.stateMap.GetMissingNodes(missingNodeBatch, nil) {
+			s.NeededState = append(s.NeededState, m.Hash)
+		}
+	}
+
+	return s
+}
+
 // IsComplete returns true if the ledger has been fully acquired.
 func (l *Ledger) IsComplete() bool {
 	l.mu.Lock()

--- a/internal/ledger/inbound/tracker.go
+++ b/internal/ledger/inbound/tracker.go
@@ -25,9 +25,9 @@ const completedRetention = time.Minute
 // safe to query from an RPC goroutine while the router drives acquisition
 // from its own goroutine.
 //
-// Only the classic header+state acquisitions are tracked here; the replay
-// delta / skip-list paths map to rippled's separate LedgerReplayer, which
-// fetch_info does not cover.
+// Only the classic header + state + transaction acquisitions are tracked here;
+// the replay delta / skip-list paths map to rippled's separate LedgerReplayer,
+// which fetch_info does not cover.
 type Tracker struct {
 	mu        sync.Mutex
 	active    map[[32]byte]*Ledger
@@ -36,8 +36,8 @@ type Tracker struct {
 }
 
 type failureRecord struct {
-	seq uint32
-	at  time.Time
+	snap Snapshot
+	at   time.Time
 }
 
 type completedRecord struct {
@@ -81,11 +81,12 @@ func (t *Tracker) Clear() {
 
 // Info returns the fetch_info snapshot keyed by ledger sequence (decimal, when
 // seq > 1) or hash, mirroring rippled InboundLedgers::getInfo. In-flight entries
-// report have_header/have_state/peers/needed_state_hashes; completed entries
-// report complete:true until their retention window elapses; recent failures
-// report {"failed": true}. Reconciling the active set (move completed to the
-// retained set, demote failed/timed-out to failures) and expiring stale
-// completed/failure entries happens here.
+// report have_header/have_state/have_transactions/peers and the needed_*_hashes
+// for whichever tree is outstanding; completed entries report complete:true
+// until their retention window elapses; recent failures report failed:true with
+// the same per-tree fields (mirroring rippled's still-in-mLedgers getJson).
+// Reconciling the active set (move completed to the retained set, demote
+// failed/timed-out to failures) and expiring stale entries happens here.
 func (t *Tracker) Info() map[string]any {
 	if t == nil {
 		return map[string]any{}
@@ -108,7 +109,11 @@ func (t *Tracker) Info() map[string]any {
 			t.completed[hash] = completedRecord{snap: snap, at: now}
 			delete(t.active, hash)
 		case snap.Failed || snap.TimedOut:
-			t.failures[hash] = failureRecord{seq: snap.Seq, at: now}
+			// A timed-out acquisition reports as failed for fetch_info (goXRPL
+			// reaps on first timeout); mark it before retaining the snapshot so
+			// the failure entry mirrors rippled's still-in-mLedgers getJson.
+			snap.Failed = true
+			t.failures[hash] = failureRecord{snap: snap, at: now}
 			delete(t.active, hash)
 		default:
 			live[acquisitionKey(snap.Seq, hash)] = acquisitionJSON(snap)
@@ -122,7 +127,7 @@ func (t *Tracker) Info() map[string]any {
 			delete(t.failures, hash)
 			continue
 		}
-		ret[acquisitionKey(rec.seq, hash)] = map[string]any{"failed": true}
+		ret[acquisitionKey(rec.snap.Seq, hash)] = acquisitionJSON(rec.snap)
 	}
 
 	for hash, rec := range t.completed {
@@ -149,6 +154,10 @@ func acquisitionKey(seq uint32, hash [32]byte) string {
 	return fmt.Sprintf("%X", hash)
 }
 
+// acquisitionJSON mirrors rippled's InboundLedger::getJson
+// (InboundLedger.cpp:1302-1349): hash and timeouts always; complete/failed/peers
+// gated by state; and, once the header is in hand, have_state/have_transactions
+// plus the needed_*_hashes arrays for whichever tree is still outstanding.
 func acquisitionJSON(snap Snapshot) map[string]any {
 	entry := map[string]any{
 		"hash":        fmt.Sprintf("%X", snap.Hash),
@@ -157,22 +166,33 @@ func acquisitionJSON(snap Snapshot) map[string]any {
 		// zero; emit it for wire-shape parity with InboundLedger::getJson.
 		"timeouts": 0,
 	}
-	if snap.Complete {
+	switch {
+	case snap.Complete:
 		entry["complete"] = true
-	} else {
+	case snap.Failed:
+		entry["failed"] = true
+	default:
 		// peers appears only while in flight, matching rippled's
 		// !complete_ && !failed_ gate. Classic acquisition uses one source peer.
-		entry["peers"] = 1
+		entry["peers"] = snap.Peers
 	}
 	if snap.HaveHeader {
 		entry["have_state"] = snap.HaveState
+		entry["have_transactions"] = snap.HaveTransactions
 		if !snap.HaveState {
-			needed := make([]any, 0, len(snap.NeededState))
-			for _, h := range snap.NeededState {
-				needed = append(needed, fmt.Sprintf("%X", h))
-			}
-			entry["needed_state_hashes"] = needed
+			entry["needed_state_hashes"] = hashList(snap.NeededState)
+		}
+		if !snap.HaveTransactions {
+			entry["needed_transaction_hashes"] = hashList(snap.NeededTx)
 		}
 	}
 	return entry
+}
+
+func hashList(hs [][32]byte) []any {
+	out := make([]any, 0, len(hs))
+	for _, h := range hs {
+		out = append(out, fmt.Sprintf("%X", h))
+	}
+	return out
 }

--- a/internal/ledger/inbound/tracker.go
+++ b/internal/ledger/inbound/tracker.go
@@ -1,0 +1,135 @@
+package inbound
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// reacquireInterval bounds how long a failed acquisition is remembered, so
+// fetch_info reports a recently-failed ledger before letting it expire.
+// Mirrors rippled's kReacquireInterval expiry on InboundLedgers::mRecentFailures.
+const reacquireInterval = 5 * time.Minute
+
+// Tracker aggregates the in-flight classic ledger acquisitions and a short
+// history of recent failures, producing the JSON snapshot served by the
+// fetch_info RPC. It is the goXRPL analogue of rippled's InboundLedgers:
+// the router registers each legacy acquisition via Track, and Tracker reads
+// the acquisitions' own mutex-guarded state to build the snapshot — so it is
+// safe to query from an RPC goroutine while the router drives acquisition
+// from its own goroutine.
+//
+// Only the classic header+state acquisitions are tracked here; the replay
+// delta / skip-list paths map to rippled's separate LedgerReplayer, which
+// fetch_info does not cover.
+type Tracker struct {
+	mu       sync.Mutex
+	active   map[[32]byte]*Ledger
+	failures map[[32]byte]failureRecord
+}
+
+type failureRecord struct {
+	seq uint32
+	at  time.Time
+}
+
+// NewTracker returns an empty Tracker.
+func NewTracker() *Tracker {
+	return &Tracker{
+		active:   make(map[[32]byte]*Ledger),
+		failures: make(map[[32]byte]failureRecord),
+	}
+}
+
+// Track registers an acquisition. Completed/failed/timed-out acquisitions are
+// swept out lazily on the next Info call, so callers never need to untrack.
+func (t *Tracker) Track(l *Ledger) {
+	if t == nil || l == nil {
+		return
+	}
+	t.mu.Lock()
+	t.active[l.Hash()] = l
+	t.mu.Unlock()
+}
+
+// Clear resets both the in-flight set and the recent-failure history,
+// backing fetch_info's `clear` param (rippled InboundLedgers::clearFailures,
+// which clears mRecentFailures and mLedgers).
+func (t *Tracker) Clear() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.active = make(map[[32]byte]*Ledger)
+	t.failures = make(map[[32]byte]failureRecord)
+	t.mu.Unlock()
+}
+
+// Info returns the fetch_info snapshot keyed by ledger sequence (decimal, when
+// seq > 1) or hash, mirroring rippled InboundLedgers::getInfo. Each in-flight
+// entry reports have_header/have_state/peers/needed_state_hashes; each recent
+// failure reports {"failed": true}. Sweeping (drop completed, demote
+// failed/timed-out to failures, expire stale failures) happens here.
+func (t *Tracker) Info() map[string]any {
+	if t == nil {
+		return map[string]any{}
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := time.Now()
+	ret := make(map[string]any)
+
+	for hash, l := range t.active {
+		snap := l.Snapshot()
+		switch {
+		case snap.Complete:
+			delete(t.active, hash)
+		case snap.Failed || snap.TimedOut:
+			t.failures[hash] = failureRecord{seq: snap.Seq, at: now}
+			delete(t.active, hash)
+		default:
+			ret[acquisitionKey(snap.Seq, hash)] = acquisitionJSON(snap)
+		}
+	}
+
+	for hash, rec := range t.failures {
+		if now.Sub(rec.at) > reacquireInterval {
+			delete(t.failures, hash)
+			continue
+		}
+		ret[acquisitionKey(rec.seq, hash)] = map[string]any{"failed": true}
+	}
+
+	return ret
+}
+
+// acquisitionKey mirrors rippled's getInfo keying: by sequence number when it
+// is a real (post-genesis) sequence, otherwise by hash.
+func acquisitionKey(seq uint32, hash [32]byte) string {
+	if seq > 1 {
+		return strconv.FormatUint(uint64(seq), 10)
+	}
+	return fmt.Sprintf("%X", hash)
+}
+
+func acquisitionJSON(snap Snapshot) map[string]any {
+	entry := map[string]any{
+		"hash":        fmt.Sprintf("%X", snap.Hash),
+		"peers":       1, // classic acquisition fetches from a single source peer
+		"have_header": snap.HaveHeader,
+	}
+	if snap.HaveHeader {
+		entry["have_state"] = snap.HaveState
+		if !snap.HaveState {
+			needed := make([]any, 0, len(snap.NeededState))
+			for _, h := range snap.NeededState {
+				needed = append(needed, fmt.Sprintf("%X", h))
+			}
+			entry["needed_state_hashes"] = needed
+		}
+	}
+	return entry
+}

--- a/internal/ledger/inbound/tracker.go
+++ b/internal/ledger/inbound/tracker.go
@@ -12,6 +12,11 @@ import (
 // Mirrors rippled's kReacquireInterval expiry on InboundLedgers::mRecentFailures.
 const reacquireInterval = 5 * time.Minute
 
+// completedRetention bounds how long a finished acquisition keeps appearing in
+// fetch_info before being dropped, mirroring rippled's ~1-minute mLedgers sweep
+// window (InboundLedgers::sweep) during which getInfo still reports complete:true.
+const completedRetention = time.Minute
+
 // Tracker aggregates the in-flight classic ledger acquisitions and a short
 // history of recent failures, producing the JSON snapshot served by the
 // fetch_info RPC. It is the goXRPL analogue of rippled's InboundLedgers:
@@ -24,9 +29,10 @@ const reacquireInterval = 5 * time.Minute
 // delta / skip-list paths map to rippled's separate LedgerReplayer, which
 // fetch_info does not cover.
 type Tracker struct {
-	mu       sync.Mutex
-	active   map[[32]byte]*Ledger
-	failures map[[32]byte]failureRecord
+	mu        sync.Mutex
+	active    map[[32]byte]*Ledger
+	completed map[[32]byte]completedRecord
+	failures  map[[32]byte]failureRecord
 }
 
 type failureRecord struct {
@@ -34,11 +40,17 @@ type failureRecord struct {
 	at  time.Time
 }
 
+type completedRecord struct {
+	snap Snapshot
+	at   time.Time
+}
+
 // NewTracker returns an empty Tracker.
 func NewTracker() *Tracker {
 	return &Tracker{
-		active:   make(map[[32]byte]*Ledger),
-		failures: make(map[[32]byte]failureRecord),
+		active:    make(map[[32]byte]*Ledger),
+		completed: make(map[[32]byte]completedRecord),
+		failures:  make(map[[32]byte]failureRecord),
 	}
 }
 
@@ -62,15 +74,18 @@ func (t *Tracker) Clear() {
 	}
 	t.mu.Lock()
 	t.active = make(map[[32]byte]*Ledger)
+	t.completed = make(map[[32]byte]completedRecord)
 	t.failures = make(map[[32]byte]failureRecord)
 	t.mu.Unlock()
 }
 
 // Info returns the fetch_info snapshot keyed by ledger sequence (decimal, when
-// seq > 1) or hash, mirroring rippled InboundLedgers::getInfo. Each in-flight
-// entry reports have_header/have_state/peers/needed_state_hashes; each recent
-// failure reports {"failed": true}. Sweeping (drop completed, demote
-// failed/timed-out to failures, expire stale failures) happens here.
+// seq > 1) or hash, mirroring rippled InboundLedgers::getInfo. In-flight entries
+// report have_header/have_state/peers/needed_state_hashes; completed entries
+// report complete:true until their retention window elapses; recent failures
+// report {"failed": true}. Reconciling the active set (move completed to the
+// retained set, demote failed/timed-out to failures) and expiring stale
+// completed/failure entries happens here.
 func (t *Tracker) Info() map[string]any {
 	if t == nil {
 		return map[string]any{}
@@ -80,20 +95,27 @@ func (t *Tracker) Info() map[string]any {
 	defer t.mu.Unlock()
 
 	now := time.Now()
-	ret := make(map[string]any)
 
+	// Reconcile the active set first, then assemble the result. Live entries
+	// are written last so they take precedence over a same-key completed or
+	// failure entry, matching rippled's getInfo which writes failures before
+	// the mLedgers acquisitions that can overwrite them.
+	live := make(map[string]map[string]any)
 	for hash, l := range t.active {
 		snap := l.Snapshot()
 		switch {
 		case snap.Complete:
+			t.completed[hash] = completedRecord{snap: snap, at: now}
 			delete(t.active, hash)
 		case snap.Failed || snap.TimedOut:
 			t.failures[hash] = failureRecord{seq: snap.Seq, at: now}
 			delete(t.active, hash)
 		default:
-			ret[acquisitionKey(snap.Seq, hash)] = acquisitionJSON(snap)
+			live[acquisitionKey(snap.Seq, hash)] = acquisitionJSON(snap)
 		}
 	}
+
+	ret := make(map[string]any)
 
 	for hash, rec := range t.failures {
 		if now.Sub(rec.at) > reacquireInterval {
@@ -101,6 +123,18 @@ func (t *Tracker) Info() map[string]any {
 			continue
 		}
 		ret[acquisitionKey(rec.seq, hash)] = map[string]any{"failed": true}
+	}
+
+	for hash, rec := range t.completed {
+		if now.Sub(rec.at) > completedRetention {
+			delete(t.completed, hash)
+			continue
+		}
+		ret[acquisitionKey(rec.snap.Seq, hash)] = acquisitionJSON(rec.snap)
+	}
+
+	for key, entry := range live {
+		ret[key] = entry
 	}
 
 	return ret
@@ -118,8 +152,17 @@ func acquisitionKey(seq uint32, hash [32]byte) string {
 func acquisitionJSON(snap Snapshot) map[string]any {
 	entry := map[string]any{
 		"hash":        fmt.Sprintf("%X", snap.Hash),
-		"peers":       1, // classic acquisition fetches from a single source peer
 		"have_header": snap.HaveHeader,
+		// goXRPL reaps on the first timeout, so rippled's retry count is always
+		// zero; emit it for wire-shape parity with InboundLedger::getJson.
+		"timeouts": 0,
+	}
+	if snap.Complete {
+		entry["complete"] = true
+	} else {
+		// peers appears only while in flight, matching rippled's
+		// !complete_ && !failed_ gate. Classic acquisition uses one source peer.
+		entry["peers"] = 1
 	}
 	if snap.HaveHeader {
 		entry["have_state"] = snap.HaveState

--- a/internal/ledger/inbound/tracker_test.go
+++ b/internal/ledger/inbound/tracker_test.go
@@ -1,0 +1,205 @@
+package inbound
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement/message"
+	"github.com/LeJamon/goXRPLd/shamap"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// buildSourceState returns a multi-level state SHAMap plus its root hash,
+// serialized root, and wire nodes — enough to drive a real acquisition.
+func buildSourceState(t *testing.T) (rootHash [32]byte, rootData []byte, wire []message.LedgerNode) {
+	t.Helper()
+	source, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatalf("new source map: %v", err)
+	}
+	for branch := byte(0); branch < 4; branch++ {
+		for sub := byte(0); sub < 4; sub++ {
+			for i := byte(0); i < 4; i++ {
+				var key [32]byte
+				key[0] = (branch << 4) | sub
+				key[1] = i << 4
+				key[31] = 0xA5
+				if err := source.Put(key, []byte{branch, sub, i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}); err != nil {
+					t.Fatalf("put: %v", err)
+				}
+			}
+		}
+	}
+	rootHash, err = source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err = source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("serialize root: %v", err)
+	}
+	wireNodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("walk wire nodes: %v", err)
+	}
+	wire = make([]message.LedgerNode, 0, len(wireNodes))
+	for _, w := range wireNodes {
+		wire = append(wire, message.LedgerNode{NodeID: w.NodeID, NodeData: w.Data})
+	}
+	return rootHash, rootData, wire
+}
+
+// newAcquiring returns a Ledger that has received its header + state root and
+// is mid-acquisition (StateWantState), with missing state nodes outstanding.
+func newAcquiring(t *testing.T, seq uint32, hash [32]byte) *Ledger {
+	t.Helper()
+	rootHash, rootData, _ := buildSourceState(t)
+	hdrBytes := header.AddRaw(header.LedgerHeader{LedgerIndex: seq, AccountHash: rootHash}, false)
+	il := New(hash, seq, 7, discardLogger())
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdrBytes}, {NodeData: rootData}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+	if il.State() != StateWantState {
+		t.Fatalf("state = %d, want StateWantState", il.State())
+	}
+	return il
+}
+
+func TestTracker_ActiveAcquisitionSnapshot(t *testing.T) {
+	t.Parallel()
+	var hash [32]byte
+	hash[0] = 0xAB
+	il := newAcquiring(t, 200, hash)
+
+	tr := NewTracker()
+	tr.Track(il)
+
+	info := tr.Info()
+	entry, ok := info["200"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected entry keyed by seq %q, got %#v", "200", info)
+	}
+	if entry["have_header"] != true {
+		t.Errorf("have_header = %v, want true", entry["have_header"])
+	}
+	if entry["have_state"] != false {
+		t.Errorf("have_state = %v, want false", entry["have_state"])
+	}
+	if entry["peers"] != 1 {
+		t.Errorf("peers = %v, want 1", entry["peers"])
+	}
+	needed, ok := entry["needed_state_hashes"].([]any)
+	if !ok || len(needed) == 0 {
+		t.Errorf("needed_state_hashes = %#v, want non-empty array", entry["needed_state_hashes"])
+	}
+}
+
+func TestTracker_CompleteIsSwept(t *testing.T) {
+	t.Parallel()
+	var hash [32]byte
+	hash[0] = 0xCD
+	rootHash, rootData, wire := buildSourceState(t)
+	hdrBytes := header.AddRaw(header.LedgerHeader{LedgerIndex: 300, AccountHash: rootHash}, false)
+	il := New(hash, 300, 9, discardLogger())
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdrBytes}, {NodeData: rootData}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+
+	tr := NewTracker()
+	tr.Track(il)
+
+	if err := il.GotStateNodes(wire); err != nil {
+		t.Fatalf("GotStateNodes: %v", err)
+	}
+	if !il.IsComplete() {
+		t.Fatalf("acquisition not complete")
+	}
+
+	if info := tr.Info(); len(info) != 0 {
+		t.Errorf("completed acquisition should be swept, got %#v", info)
+	}
+}
+
+func TestTracker_FailedReportedThenCleared(t *testing.T) {
+	t.Parallel()
+	var hash [32]byte
+	hash[0] = 0xEF
+	il := New(hash, 400, 3, discardLogger())
+	// Too few nodes drives the acquisition to StateFailed.
+	if err := il.GotBase([]message.LedgerNode{{NodeData: []byte{0x00}}}); err == nil {
+		t.Fatal("expected GotBase to fail with a single node")
+	}
+	if il.State() != StateFailed {
+		t.Fatalf("state = %d, want StateFailed", il.State())
+	}
+
+	tr := NewTracker()
+	tr.Track(il)
+
+	entry, ok := tr.Info()["400"].(map[string]any)
+	if !ok || entry["failed"] != true {
+		t.Fatalf("expected {failed:true} for failed acquisition, got %#v", tr.Info())
+	}
+
+	tr.Clear()
+	if info := tr.Info(); len(info) != 0 {
+		t.Errorf("Clear should empty the tracker, got %#v", info)
+	}
+}
+
+func TestTracker_TimedOutDemotedToFailure(t *testing.T) {
+	t.Parallel()
+	var hash [32]byte
+	hash[0] = 0x11
+	il := New(hash, 500, 4, discardLogger())
+	il.created = time.Now().Add(-2 * acquisitionTimeout) // white-box: force timeout
+
+	tr := NewTracker()
+	tr.Track(il)
+
+	entry, ok := tr.Info()["500"].(map[string]any)
+	if !ok || entry["failed"] != true {
+		t.Fatalf("timed-out acquisition should report {failed:true}, got %#v", tr.Info())
+	}
+	// It must have moved out of the active set into the failure history.
+	tr.mu.Lock()
+	_, stillActive := tr.active[hash]
+	tr.mu.Unlock()
+	if stillActive {
+		t.Error("timed-out acquisition should be removed from the active set")
+	}
+}
+
+func TestTracker_GenesisKeyedByHash(t *testing.T) {
+	t.Parallel()
+	var hash [32]byte
+	hash[0] = 0x22
+	il := New(hash, 1, 5, discardLogger())
+	if err := il.GotBase([]message.LedgerNode{{NodeData: []byte{0x00}}}); err == nil {
+		t.Fatal("expected GotBase to fail")
+	}
+
+	tr := NewTracker()
+	tr.Track(il)
+
+	wantKey := acquisitionKey(1, hash)
+	if _, ok := tr.Info()[wantKey].(map[string]any); !ok {
+		t.Fatalf("seq<=1 should be keyed by hash %q, got %#v", wantKey, tr.Info())
+	}
+}
+
+func TestTracker_NilSafe(t *testing.T) {
+	t.Parallel()
+	var tr *Tracker
+	tr.Track(New([32]byte{}, 1, 0, discardLogger())) // must not panic
+	tr.Clear()
+	if info := tr.Info(); len(info) != 0 {
+		t.Errorf("nil tracker Info should be empty, got %#v", info)
+	}
+}

--- a/internal/ledger/inbound/tracker_test.go
+++ b/internal/ledger/inbound/tracker_test.go
@@ -98,9 +98,12 @@ func TestTracker_ActiveAcquisitionSnapshot(t *testing.T) {
 	if !ok || len(needed) == 0 {
 		t.Errorf("needed_state_hashes = %#v, want non-empty array", entry["needed_state_hashes"])
 	}
+	if entry["timeouts"] != 0 {
+		t.Errorf("timeouts = %v, want 0", entry["timeouts"])
+	}
 }
 
-func TestTracker_CompleteIsSwept(t *testing.T) {
+func TestTracker_CompletedReportedThenSwept(t *testing.T) {
 	t.Parallel()
 	var hash [32]byte
 	hash[0] = 0xCD
@@ -121,8 +124,60 @@ func TestTracker_CompleteIsSwept(t *testing.T) {
 		t.Fatalf("acquisition not complete")
 	}
 
+	// rippled keeps a completed acquisition in mLedgers until sweep, so
+	// fetch_info reports complete:true for a short window.
+	entry, ok := tr.Info()["300"].(map[string]any)
+	if !ok {
+		t.Fatalf("completed acquisition should be reported, got %#v", tr.Info())
+	}
+	if entry["complete"] != true {
+		t.Errorf("complete = %v, want true", entry["complete"])
+	}
+	if entry["have_state"] != true {
+		t.Errorf("have_state = %v, want true", entry["have_state"])
+	}
+	if _, hasPeers := entry["peers"]; hasPeers {
+		t.Errorf("completed entry must not report peers, got %#v", entry)
+	}
+
+	// Once the retention window elapses it is dropped.
+	tr.mu.Lock()
+	rec := tr.completed[hash]
+	rec.at = time.Now().Add(-2 * completedRetention)
+	tr.completed[hash] = rec
+	tr.mu.Unlock()
 	if info := tr.Info(); len(info) != 0 {
-		t.Errorf("completed acquisition should be swept, got %#v", info)
+		t.Errorf("completed acquisition should be swept after retention, got %#v", info)
+	}
+}
+
+func TestTracker_LiveAcquisitionOverwritesSameSeqFailure(t *testing.T) {
+	t.Parallel()
+	var failHash, liveHash [32]byte
+	failHash[0] = 0x33
+	liveHash[0] = 0x44
+
+	// A prior attempt at seq 600 (failHash) failed and is remembered.
+	failed := New(failHash, 600, 3, discardLogger())
+	if err := failed.GotBase([]message.LedgerNode{{NodeData: []byte{0x00}}}); err == nil {
+		t.Fatal("expected GotBase to fail")
+	}
+	// A fresh attempt at the same seq (liveHash) is now in flight.
+	live := newAcquiring(t, 600, liveHash)
+
+	tr := NewTracker()
+	tr.Track(failed)
+	tr.Track(live)
+
+	entry, ok := tr.Info()["600"].(map[string]any)
+	if !ok {
+		t.Fatalf("seq 600 should be present, got %#v", tr.Info())
+	}
+	if entry["failed"] == true {
+		t.Errorf("live re-acquisition must win over a stale same-seq failure, got %#v", entry)
+	}
+	if entry["have_header"] != true {
+		t.Errorf("expected the live acquisition entry, got %#v", entry)
 	}
 }
 

--- a/internal/ledger/inbound/tracker_test.go
+++ b/internal/ledger/inbound/tracker_test.go
@@ -19,7 +19,15 @@ func discardLogger() *slog.Logger {
 // serialized root, and wire nodes — enough to drive a real acquisition.
 func buildSourceState(t *testing.T) (rootHash [32]byte, rootData []byte, wire []message.LedgerNode) {
 	t.Helper()
-	source, err := shamap.New(shamap.TypeState)
+	return buildSourceMap(t, shamap.TypeState)
+}
+
+// buildSourceMap builds a multi-level SHAMap of the given type and returns its
+// root hash, serialized root, and wire nodes — enough to drive a real
+// state-tree or transaction-tree acquisition.
+func buildSourceMap(t *testing.T, mapType shamap.Type) (rootHash [32]byte, rootData []byte, wire []message.LedgerNode) {
+	t.Helper()
+	source, err := shamap.New(mapType)
 	if err != nil {
 		t.Fatalf("new source map: %v", err)
 	}
@@ -256,5 +264,142 @@ func TestTracker_NilSafe(t *testing.T) {
 	tr.Clear()
 	if info := tr.Info(); len(info) != 0 {
 		t.Errorf("nil tracker Info should be empty, got %#v", info)
+	}
+}
+
+// TestInbound_FullAcquisitionWithTransactions drives a ledger with both a
+// non-empty state tree and a non-empty transaction tree through the full
+// acquisition. fetch_info reports have_transactions + needed_transaction_hashes
+// while the tx tree is outstanding, and the acquisition is complete only once
+// both trees are in hand.
+func TestInbound_FullAcquisitionWithTransactions(t *testing.T) {
+	t.Parallel()
+	stateRootHash, stateRoot, stateWire := buildSourceMap(t, shamap.TypeState)
+	txRootHash, txRoot, txWire := buildSourceMap(t, shamap.TypeTransaction)
+
+	var hash [32]byte
+	hash[0] = 0x77
+	hdr := header.AddRaw(header.LedgerHeader{LedgerIndex: 700, AccountHash: stateRootHash, TxHash: txRootHash}, false)
+	il := New(hash, 700, 7, discardLogger())
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdr}, {NodeData: stateRoot}, {NodeData: txRoot}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+	if il.State() != StateWantState {
+		t.Fatalf("state = %d, want StateWantState", il.State())
+	}
+	if il.NeedsMissingTxNodeIDs() == nil {
+		t.Fatal("expected outstanding tx nodes to request")
+	}
+
+	tr := NewTracker()
+	tr.Track(il)
+
+	entry := tr.Info()["700"].(map[string]any)
+	if entry["have_transactions"] != false {
+		t.Errorf("have_transactions = %v, want false", entry["have_transactions"])
+	}
+	if needed, ok := entry["needed_transaction_hashes"].([]any); !ok || len(needed) == 0 {
+		t.Errorf("needed_transaction_hashes = %#v, want non-empty", entry["needed_transaction_hashes"])
+	}
+
+	// State completes first; the acquisition must still wait for the tx tree.
+	if err := il.GotStateNodes(stateWire); err != nil {
+		t.Fatalf("GotStateNodes: %v", err)
+	}
+	if il.IsComplete() {
+		t.Fatal("acquisition complete before tx tree fetched")
+	}
+
+	// Tx completes; the acquisition is now complete.
+	if err := il.GotTransactionNodes(txWire); err != nil {
+		t.Fatalf("GotTransactionNodes: %v", err)
+	}
+	if !il.IsComplete() {
+		t.Fatal("acquisition not complete after both trees fetched")
+	}
+	if _, _, gotTx, err := il.Result(); err != nil || gotTx == nil {
+		t.Fatalf("Result tx map = %v (err %v), want the acquired tree", gotTx, err)
+	}
+
+	entry = tr.Info()["700"].(map[string]any)
+	if entry["complete"] != true {
+		t.Errorf("complete = %v, want true", entry["complete"])
+	}
+	if entry["have_transactions"] != true {
+		t.Errorf("have_transactions = %v, want true", entry["have_transactions"])
+	}
+	if _, has := entry["needed_transaction_hashes"]; has {
+		t.Errorf("needed_transaction_hashes must be absent once tx acquired, got %#v", entry["needed_transaction_hashes"])
+	}
+}
+
+// TestInbound_EmptyTxTreeImmediatelyComplete confirms a ledger with no
+// transactions (zero TxHash) reports have_transactions:true on arrival and
+// completes on the state tree alone, with no tx round-trip and a nil tx map.
+func TestInbound_EmptyTxTreeImmediatelyComplete(t *testing.T) {
+	t.Parallel()
+	stateRootHash, stateRoot, stateWire := buildSourceMap(t, shamap.TypeState)
+
+	var hash [32]byte
+	hash[0] = 0x88
+	hdr := header.AddRaw(header.LedgerHeader{LedgerIndex: 800, AccountHash: stateRootHash}, false) // TxHash zero
+	il := New(hash, 800, 7, discardLogger())
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdr}, {NodeData: stateRoot}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+	if il.NeedsMissingTxNodeIDs() != nil {
+		t.Error("empty tx tree must not request tx nodes")
+	}
+
+	tr := NewTracker()
+	tr.Track(il)
+	entry := tr.Info()["800"].(map[string]any)
+	if entry["have_transactions"] != true {
+		t.Errorf("have_transactions = %v, want true (empty tx tree)", entry["have_transactions"])
+	}
+	if _, has := entry["needed_transaction_hashes"]; has {
+		t.Error("needed_transaction_hashes must be absent for an empty tx tree")
+	}
+
+	if err := il.GotStateNodes(stateWire); err != nil {
+		t.Fatalf("GotStateNodes: %v", err)
+	}
+	if !il.IsComplete() {
+		t.Fatal("acquisition with empty tx tree should complete on state")
+	}
+	if _, _, gotTx, err := il.Result(); err != nil || gotTx != nil {
+		t.Fatalf("Result tx map = %v (err %v), want nil for empty tx tree", gotTx, err)
+	}
+}
+
+// TestTracker_FailedEntryCarriesRichShape confirms a failed/timed-out
+// acquisition reports the full per-tree getJson shape (failed:true plus
+// have_header, no peers), mirroring rippled's still-in-mLedgers failed ledger
+// rather than a bare {failed:true}.
+func TestTracker_FailedEntryCarriesRichShape(t *testing.T) {
+	t.Parallel()
+	stateRootHash, stateRoot, _ := buildSourceMap(t, shamap.TypeState)
+	txRootHash, txRoot, _ := buildSourceMap(t, shamap.TypeTransaction)
+
+	var hash [32]byte
+	hash[0] = 0x9A
+	hdr := header.AddRaw(header.LedgerHeader{LedgerIndex: 950, AccountHash: stateRootHash, TxHash: txRootHash}, false)
+	il := New(hash, 950, 7, discardLogger())
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdr}, {NodeData: stateRoot}, {NodeData: txRoot}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+	il.created = time.Now().Add(-2 * acquisitionTimeout) // white-box: force timeout
+
+	tr := NewTracker()
+	tr.Track(il)
+	entry := tr.Info()["950"].(map[string]any)
+	if entry["failed"] != true {
+		t.Errorf("failed = %v, want true", entry["failed"])
+	}
+	if entry["have_header"] != true {
+		t.Errorf("failed entry should carry have_header, got %#v", entry)
+	}
+	if _, hasPeers := entry["peers"]; hasPeers {
+		t.Errorf("failed entry must not report peers, got %#v", entry)
 	}
 }

--- a/internal/rpc/handlers/fetch_info_test.go
+++ b/internal/rpc/handlers/fetch_info_test.go
@@ -1,0 +1,75 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchInfoMethod_EmptyWhenNotAcquiring(t *testing.T) {
+	m := &handlers.FetchInfoMethod{}
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, IsAdmin: true}
+
+	result, rpcErr := m.Handle(ctx, json.RawMessage(`{}`))
+	require.Nil(t, rpcErr)
+
+	resp, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{}, resp["info"],
+		"fetch_info returns an empty info object when not acquiring (rippled behavior)")
+	_, hasClear := resp["clear"]
+	assert.False(t, hasClear, "clear must be absent unless requested")
+}
+
+func TestFetchInfoMethod_PassesThroughSnapshot(t *testing.T) {
+	snap := map[string]any{
+		"42": map[string]any{
+			"hash":        "ABCD",
+			"have_header": true,
+			"have_state":  false,
+			"peers":       1,
+		},
+	}
+	m := &handlers.FetchInfoMethod{}
+	ctx := &types.RpcContext{
+		Context: context.Background(),
+		Role:    types.RoleAdmin,
+		IsAdmin: true,
+		Services: &types.ServiceContainer{
+			FetchInfo: func() map[string]any { return snap },
+		},
+	}
+
+	result, rpcErr := m.Handle(ctx, json.RawMessage(`{}`))
+	require.Nil(t, rpcErr)
+
+	resp := result.(map[string]any)
+	assert.Equal(t, snap, resp["info"])
+}
+
+func TestFetchInfoMethod_ClearInvokesResetAndEchoes(t *testing.T) {
+	cleared := false
+	m := &handlers.FetchInfoMethod{}
+	ctx := &types.RpcContext{
+		Context: context.Background(),
+		Role:    types.RoleAdmin,
+		IsAdmin: true,
+		Services: &types.ServiceContainer{
+			FetchInfo:      func() map[string]any { return map[string]any{} },
+			FetchInfoClear: func() { cleared = true },
+		},
+	}
+
+	result, rpcErr := m.Handle(ctx, json.RawMessage(`{"clear":true}`))
+	require.Nil(t, rpcErr)
+
+	resp := result.(map[string]any)
+	assert.True(t, cleared, "clear=true must invoke FetchInfoClear")
+	assert.Equal(t, true, resp["clear"], "clear must be echoed back")
+	assert.Equal(t, map[string]any{}, resp["info"])
+}

--- a/internal/rpc/handlers/stubs_network.go
+++ b/internal/rpc/handlers/stubs_network.go
@@ -10,13 +10,12 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 )
 
-// FetchInfoMethod handles the fetch_info RPC method.
-// STUB: Returns empty info. Network-only — not needed for standalone mode.
-//
-// TODO [network]: Implement when adding P2P networking layer.
-//   - Reference: rippled FetchInfo.cpp → context.app.getFetchPack()
-//   - Returns info about current fetch operations for missing ledger data
-//   - Params: clear (bool) — resets fetch counters
+// FetchInfoMethod handles the fetch_info RPC method. Mirrors rippled
+// FetchInfo.cpp: reports the ledgers currently being acquired from peers
+// (NetworkOPs::getLedgerFetchInfo → InboundLedgers::getInfo), and honors the
+// `clear` param by resetting the acquisition counters. The `info` object is
+// empty when the node isn't acquiring (e.g. standalone / RPC-only), which is
+// rippled's behavior too.
 type FetchInfoMethod struct{ AdminHandler }
 
 func (m *FetchInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
@@ -27,15 +26,22 @@ func (m *FetchInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		_ = json.Unmarshal(params, &request)
 	}
 
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
-		return nil, types.RpcErrorInternal("Ledger service not available")
-	}
-
 	response := make(map[string]interface{})
+
 	if request.Clear {
+		if ctx.Services != nil && ctx.Services.FetchInfoClear != nil {
+			ctx.Services.FetchInfoClear()
+		}
 		response["clear"] = true
 	}
-	response["info"] = map[string]interface{}{}
+
+	info := map[string]interface{}{}
+	if ctx.Services != nil && ctx.Services.FetchInfo != nil {
+		if snap := ctx.Services.FetchInfo(); snap != nil {
+			info = snap
+		}
+	}
+	response["info"] = info
 
 	return response, nil
 }

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -1654,11 +1654,13 @@ func TestMissingMethodsNilLedgerService(t *testing.T) {
 		name   string
 		method types.MethodHandler
 	}{
-		{"FetchInfoMethod", &handlers.FetchInfoMethod{}},
 		{"PrintMethod", &handlers.PrintMethod{}},
 		{"GetCountsMethod", &handlers.GetCountsMethod{}},
 	}
 
+	// Note: FetchInfoMethod is excluded — it reads the router's inbound-ledger
+	// tracker, not the ledger, so it returns an empty info object (not an error)
+	// with nil Ledger, matching rippled's empty result on a node not acquiring.
 	// Note: UnlListMethod is excluded — it reads the validator-list service,
 	// not the ledger, so it returns an empty UNL (not an error) with nil Ledger.
 	// Note: LogLevelMethod and LogRotateMethod are excluded — they drive the

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -330,6 +330,20 @@ type ServiceContainer struct {
 	// averages surfaced by the tx_reduce_relay RPC. Nil when the overlay
 	// isn't wired (standalone / RPC-only) — the handler then reports zeros.
 	TxReduceRelayMetrics func() TxReduceRelayMetrics
+
+	// FetchInfo returns the inbound-ledger acquisition snapshot served by
+	// fetch_info (rippled InboundLedgers::getInfo): a map keyed by ledger
+	// sequence (or hash) whose values report have_header/have_state/peers/
+	// needed_state_hashes for in-flight acquisitions and {failed:true} for
+	// recent failures. Nil in standalone / RPC-only mode (no acquisition
+	// subsystem) — the handler then returns an empty object, matching
+	// rippled's empty result on a node that isn't acquiring.
+	FetchInfo func() map[string]any
+
+	// FetchInfoClear resets the inbound-ledger acquisition counters and
+	// failure history, backing fetch_info's `clear` param (rippled
+	// NetworkOPs::clearLedgerFetch → InboundLedgers::clearFailures). Nil-safe.
+	FetchInfoClear func()
 }
 
 // CountsResult is the subset of rippled's get_counts that goXRPL has real data

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -333,11 +333,12 @@ type ServiceContainer struct {
 
 	// FetchInfo returns the inbound-ledger acquisition snapshot served by
 	// fetch_info (rippled InboundLedgers::getInfo): a map keyed by ledger
-	// sequence (or hash) whose values report have_header/have_state/peers/
-	// needed_state_hashes for in-flight acquisitions and {failed:true} for
-	// recent failures. Nil in standalone / RPC-only mode (no acquisition
-	// subsystem) — the handler then returns an empty object, matching
-	// rippled's empty result on a node that isn't acquiring.
+	// sequence (or hash) whose values report have_header/have_state/
+	// have_transactions/peers and the needed_state_hashes/needed_transaction_hashes
+	// for in-flight acquisitions, and the same fields with failed:true for recent
+	// failures. Nil in standalone / RPC-only mode (no acquisition subsystem) —
+	// the handler then returns an empty object, matching rippled's empty result
+	// on a node that isn't acquiring.
 	FetchInfo func() map[string]any
 
 	// FetchInfoClear resets the inbound-ledger acquisition counters and


### PR DESCRIPTION
## Summary
- Replaces the empty `fetch_info` stub with a real snapshot of in-flight classic ledger acquisitions, mirroring rippled's `InboundLedgers::getInfo` (`FetchInfo.cpp` → `NetworkOPs::getLedgerFetchInfo`).
- Adds a thread-safe `inbound.Tracker` that aggregates the router's legacy header+state acquisitions. The router registers each acquisition with a single `Track` call; the tracker reads each acquisition's own mutex-guarded state, so it's safe to query from an RPC goroutine while the router drives acquisition from its own goroutine — no churn at the consensus-critical call sites.
- Snapshot is keyed by ledger sequence (or hash for seq ≤ 1) per rippled. In-flight entries report `hash`/`peers`/`have_header`/`have_state`/`needed_state_hashes`; completed acquisitions are swept; failed/timed-out ones are demoted to a short recent-failure history (`{"failed": true}`, expiring after 5 min like rippled's `mRecentFailures`).
- Handler honors the `clear` param via a `FetchInfoClear` closure (rippled `clearLedgerFetch` → `clearFailures`) and returns an empty `info` object when the node isn't acquiring (standalone / RPC-only), matching rippled.

### Scope / fidelity notes
- Faithful mapping: goXRPL's classic `inbound.Ledger` == rippled's `InboundLedger`. The router's replay-delta / skip-list `Replayer` maps to rippled's separate `LedgerReplayer`, which `fetch_info` does **not** cover, so it is intentionally excluded.
- `timeouts` / `have_transactions` / `needed_transaction_hashes` are omitted: goXRPL's classic acquisition fetches only header+state and reaps on first timeout rather than counting re-request cycles, so those rippled fields don't apply here.
- Exposed via the existing `ServiceContainer` closure pattern, wired from `Components.Router` in the non-standalone branch of `cli/server.go`.

## Test plan
- [x] `go test ./internal/ledger/inbound/...` — new `tracker_test.go` drives real acquisitions (GotBase/GotStateNodes) through the tracker: active snapshot, complete-swept, failed→cleared, timed-out demotion, genesis keyed-by-hash, nil-safety. Also passes under `-race`.
- [x] `go test ./internal/rpc/...` — new `fetch_info_test.go` (empty-when-not-acquiring, snapshot passthrough, clear invokes reset + echoes) and updated `missing_methods_test.go` (fetch_info no longer requires the ledger service).
- [x] `go test ./internal/consensus/adaptor/...`, `go build ./...`, `go vet`, `gofmt` all clean.

Note: a full multi-node "induced fetch" interop test (live acquisition data only exists during real peer sync) is left to the existing docker/interop harness; the acquisition lifecycle itself is exercised by the unit tests against the same `inbound.Ledger` the live path uses.

Fixes #558