### PR TITLE
Implement ledger_cleaner integrity verifier

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -321,30 +321,38 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		}
 	}
 
-	// Background ledger-integrity verifier (admin ledger_cleaner). It walks
-	// ledger SHAMap trees against the content-addressed node store, so it is
-	// only wired when a node store is configured.
+	// Background ledger-integrity verifier (admin ledger_cleaner). rippled keeps
+	// this subsystem present in every instance (Application always constructs
+	// and starts its LedgerCleaner); mirror that by always wiring it, falling
+	// back to an in-memory content-addressed family when no persistent node
+	// store is configured (standalone / RPC-only). The RPC's own availability
+	// is then gated on network/sync state, as in rippled, not on storage.
+	var cleanerFamily shamap.Family
 	if db != nil {
-		ledgerCleaner = cleaner.New(&ledgerCleanerSource{
-			svc:    ledgerSvcRef,
-			family: shamap.NewNodeStoreFamily(db),
-		}, rootLogger)
-		ledgerCleaner.Start()
+		cleanerFamily = shamap.NewNodeStoreFamily(db)
+	} else {
+		memFamily, ferr := shamap.NewMemoryNodeStoreFamily()
+		if ferr != nil {
+			return fmt.Errorf("create ledger cleaner family: %w", ferr)
+		}
+		cleanerFamily = memFamily
+	}
+	ledgerCleaner = cleaner.New(&ledgerCleanerSource{svc: ledgerSvcRef, family: cleanerFamily}, rootLogger)
+	ledgerCleaner.Start()
 
-		cleanerRef := ledgerCleaner
-		services.LedgerCleanerConfigure = func(p types.LedgerCleanerParams) types.LedgerCleanerStatus {
-			return toCleanerStatus(cleanerRef.Clean(cleaner.Params{
-				Ledger:     p.Ledger,
-				MinLedger:  p.MinLedger,
-				MaxLedger:  p.MaxLedger,
-				Full:       p.Full,
-				CheckNodes: p.CheckNodes,
-				Stop:       p.Stop,
-			}))
-		}
-		services.LedgerCleanerStatusFn = func() types.LedgerCleanerStatus {
-			return toCleanerStatus(cleanerRef.Status())
-		}
+	cleanerRef := ledgerCleaner
+	services.LedgerCleanerConfigure = func(p types.LedgerCleanerParams) types.LedgerCleanerStatus {
+		return toCleanerStatus(cleanerRef.Clean(cleaner.Params{
+			Ledger:     p.Ledger,
+			MinLedger:  p.MinLedger,
+			MaxLedger:  p.MaxLedger,
+			Full:       p.Full,
+			CheckNodes: p.CheckNodes,
+			Stop:       p.Stop,
+		}))
+	}
+	services.LedgerCleanerStatusFn = func() types.LedgerCleanerStatus {
+		return toCleanerStatus(cleanerRef.Status())
 	}
 
 	// Start consensus/networking if not in standalone mode

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/LeJamon/goXRPLd/config"
 	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/LeJamon/goXRPLd/internal/consensus/adaptor"
+	"github.com/LeJamon/goXRPLd/internal/ledger/cleaner"
 	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
 	"github.com/LeJamon/goXRPLd/internal/ledger/service"
 	"github.com/LeJamon/goXRPLd/internal/manifest"
@@ -32,6 +33,7 @@ import (
 	validatorlist "github.com/LeJamon/goXRPLd/internal/validator/list"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
 	"github.com/LeJamon/goXRPLd/protocol"
+	"github.com/LeJamon/goXRPLd/shamap"
 	kvpebble "github.com/LeJamon/goXRPLd/storage/kvstore/pebble"
 	"github.com/LeJamon/goXRPLd/storage/nodestore"
 	"github.com/LeJamon/goXRPLd/storage/relationaldb"
@@ -110,13 +112,14 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		db                  nodestore.Database
 		repoManager         relationaldb.RepositoryManager
 		ledgerService       *service.Service
+		ledgerCleaner       *cleaner.Cleaner
 		consensusComponents *adaptor.Components
 		httpSrvs            []*http.Server
 		wsSrvs              []*http.Server
 		wsServer            *rpc.WebSocketServer
 	)
 	defer func() {
-		doShutdown(httpSrvs, wsSrvs, wsServer, ledgerService, consensusComponents, db, repoManager, serverLog)
+		doShutdown(httpSrvs, wsSrvs, wsServer, ledgerService, ledgerCleaner, consensusComponents, db, repoManager, serverLog)
 	}()
 
 	// Initialize storage from config
@@ -315,6 +318,32 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			Local:   ft.GetLocalFee(),
 			Net:     ft.GetRemoteFee(),
 			Cluster: ft.GetClusterFee(),
+		}
+	}
+
+	// Background ledger-integrity verifier (admin ledger_cleaner). It walks
+	// ledger SHAMap trees against the content-addressed node store, so it is
+	// only wired when a node store is configured.
+	if db != nil {
+		ledgerCleaner = cleaner.New(&ledgerCleanerSource{
+			svc:    ledgerSvcRef,
+			family: shamap.NewNodeStoreFamily(db),
+		}, rootLogger)
+		ledgerCleaner.Start()
+
+		cleanerRef := ledgerCleaner
+		services.LedgerCleanerConfigure = func(p types.LedgerCleanerParams) types.LedgerCleanerStatus {
+			return toCleanerStatus(cleanerRef.Clean(cleaner.Params{
+				Ledger:     p.Ledger,
+				MinLedger:  p.MinLedger,
+				MaxLedger:  p.MaxLedger,
+				Full:       p.Full,
+				CheckNodes: p.CheckNodes,
+				Stop:       p.Stop,
+			}))
+		}
+		services.LedgerCleanerStatusFn = func() types.LedgerCleanerStatus {
+			return toCleanerStatus(cleanerRef.Status())
 		}
 	}
 
@@ -1054,6 +1083,7 @@ func doShutdown(
 	httpSrvs, wsSrvs []*http.Server,
 	wsServer *rpc.WebSocketServer,
 	ledgerService *service.Service,
+	ledgerCleaner *cleaner.Cleaner,
 	consensusComponents *adaptor.Components,
 	kvDB nodestore.Database,
 	repoManager relationaldb.RepositoryManager,
@@ -1075,6 +1105,13 @@ func doShutdown(
 		logger.Warn("WebSocket server shutdown timed out", "err", err)
 	}
 
+	// Stop the background ledger-integrity verifier before tearing down the
+	// node store it walks.
+	if ledgerCleaner != nil {
+		ledgerCleaner.Stop()
+		logger.Info("Ledger cleaner stopped")
+	}
+
 	// Stop consensus components (if running)
 	if consensusComponents != nil {
 		consensusComponents.Stop()
@@ -1091,6 +1128,52 @@ func doShutdown(
 	}
 
 	logger.Info("Shutdown complete")
+}
+
+// ledgerCleanerSource adapts the ledger service + node store to the
+// cleaner.LedgerSource interface the ledger-integrity verifier consumes.
+type ledgerCleanerSource struct {
+	svc    *service.Service
+	family shamap.Family
+}
+
+func (s *ledgerCleanerSource) AvailableRange() (uint32, uint32, bool) {
+	return s.svc.AvailableLedgerRange()
+}
+
+func (s *ledgerCleanerSource) LedgerRoots(seq uint32) (stateRoot, txRoot [32]byte, ok bool) {
+	l, err := s.svc.GetLedgerBySequence(seq)
+	if err != nil || l == nil {
+		return [32]byte{}, [32]byte{}, false
+	}
+	sr, err := l.StateMapHash()
+	if err != nil {
+		return [32]byte{}, [32]byte{}, false
+	}
+	tr, err := l.TxMapHash()
+	if err != nil {
+		return [32]byte{}, [32]byte{}, false
+	}
+	return sr, tr, true
+}
+
+func (s *ledgerCleanerSource) Family() shamap.Family { return s.family }
+
+// toCleanerStatus translates the cleaner package's status into the RPC-types
+// mirror struct (see ServiceContainer.LedgerCleanerConfigure for the layering
+// boundary).
+func toCleanerStatus(s cleaner.Status) types.LedgerCleanerStatus {
+	return types.LedgerCleanerStatus{
+		State:          s.State,
+		MinLedger:      s.MinLedger,
+		MaxLedger:      s.MaxLedger,
+		CheckNodes:     s.CheckNodes,
+		Failures:       s.Failures,
+		LedgersChecked: s.LedgersChecked,
+		NodesChecked:   s.NodesChecked,
+		MissingNodes:   s.MissingNodes,
+		LastError:      s.LastError,
+	}
 }
 
 // ledgerInfoAdapter adapts the ledger service to the LedgerInfoProvider interface

--- a/internal/ledger/cleaner/cleaner.go
+++ b/internal/ledger/cleaner/cleaner.go
@@ -1,0 +1,345 @@
+// Package cleaner implements a background ledger-integrity verifier, the
+// goXRPL analog of rippled's LedgerCleaner
+// (rippled/src/xrpld/app/ledger/detail/LedgerCleaner.cpp).
+//
+// It walks the state and transaction SHAMap trees of a ledger (or a ledger
+// range) against the content-addressed node store, reporting nodes that are
+// missing or corrupt. This is rippled's `check_nodes` / walkLedger behaviour.
+//
+// Divergence from rippled, by design: rippled re-acquires missing nodes from
+// peers and loops on a ledger until it is whole. goXRPL has no inbound-ledger
+// acquisition wired here, so the worker reports gaps and advances rather than
+// blocking — every ledger in the range is checked exactly once. Re-acquisition
+// (and rippled's fix_txns relational-index repair) are follow-ups that land
+// with the content-addressed persistence migration.
+package cleaner
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	xrpllog "github.com/LeJamon/goXRPLd/log"
+	"github.com/LeJamon/goXRPLd/shamap"
+)
+
+// errNoFamily is returned when the cleaner has no node store to walk against.
+var errNoFamily = errors.New("ledger_cleaner: no node store configured")
+
+// interLedgerPause is the small courtesy delay between ledgers so the verifier
+// never monopolises the node store. Mirrors the 100ms success pause in
+// rippled's LedgerCleaner::doLedgerCleaner.
+const interLedgerPause = 50 * time.Millisecond
+
+// LedgerSource supplies everything the cleaner needs to verify a ledger's
+// trees against the node store. Implemented by an adapter over the ledger
+// service; kept narrow so this package does not depend on the service.
+type LedgerSource interface {
+	// AvailableRange returns the inclusive [min, max] range of ledgers the
+	// node can verify locally, mirroring rippled getFullValidatedRange.
+	// ok is false when no ledger is available.
+	AvailableRange() (min, max uint32, ok bool)
+
+	// LedgerRoots returns the state-tree and transaction-tree root hashes for
+	// a ledger sequence. ok is false when the ledger is unknown locally. A
+	// zero hash denotes an empty tree.
+	LedgerRoots(seq uint32) (stateRoot, txRoot [32]byte, ok bool)
+
+	// Family is the content-addressed node store the trees are walked against.
+	Family() shamap.Family
+}
+
+// Params configures a cleaning run, mirroring the JSON parameters rippled's
+// ledger_cleaner accepts (LedgerCleaner.cpp:136-211).
+type Params struct {
+	Ledger     *uint32 // single ledger; sets min==max and forces a deep check
+	MinLedger  *uint32 // lower bound of the range
+	MaxLedger  *uint32 // upper bound of the range
+	Full       bool    // deep check: walk every node (implies CheckNodes)
+	CheckNodes bool    // walk every node rather than just the roots
+	Stop       bool    // stop an in-progress run
+}
+
+// Status is a snapshot of the cleaner's state, mirroring the fields rippled
+// exposes via its PropertyStream (LedgerCleaner.cpp:110-127) plus progress
+// counters.
+type Status struct {
+	State          string // "idle" or "running"
+	MinLedger      uint32
+	MaxLedger      uint32
+	CheckNodes     bool
+	Failures       int
+	LedgersChecked uint64
+	NodesChecked   uint64
+	MissingNodes   uint64
+	LastError      string
+}
+
+// Cleaner is the background ledger-integrity verifier.
+type Cleaner struct {
+	src    LedgerSource
+	logger xrpllog.Logger
+
+	mu       sync.Mutex
+	cond     *sync.Cond
+	running  bool // worker goroutine is processing a range
+	started  bool
+	exit     bool
+	min, max uint32
+	deep     bool
+	failures int
+
+	ledgersChecked uint64
+	nodesChecked   uint64
+	missingNodes   uint64
+	lastError      string
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// New creates a Cleaner. The worker does not run until Start is called.
+func New(src LedgerSource, logger xrpllog.Logger) *Cleaner {
+	c := &Cleaner{
+		src:    src,
+		logger: logger,
+		done:   make(chan struct{}),
+	}
+	c.cond = sync.NewCond(&c.mu)
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+	return c
+}
+
+// Start launches the background worker. Idempotent.
+func (c *Cleaner) Start() {
+	c.mu.Lock()
+	if c.started {
+		c.mu.Unlock()
+		return
+	}
+	c.started = true
+	c.mu.Unlock()
+	go c.run()
+}
+
+// Stop signals the worker to exit and waits for it to finish. Idempotent.
+func (c *Cleaner) Stop() {
+	c.mu.Lock()
+	if !c.started || c.exit {
+		c.mu.Unlock()
+		return
+	}
+	c.exit = true
+	c.cancel()
+	c.cond.Broadcast()
+	c.mu.Unlock()
+	<-c.done
+}
+
+// Clean configures and (unless Stop is set) starts a verification run, then
+// returns the resulting status. Mirrors rippled LedgerCleaner::clean.
+func (c *Cleaner) Clean(p Params) Status {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if p.Stop {
+		c.running = false
+		c.min, c.max = 0, 0
+		c.cond.Broadcast()
+		return c.statusLocked()
+	}
+
+	// Default the range to the locally-available validated range, then let
+	// explicit parameters narrow it (rippled LedgerCleaner.cpp:138-149).
+	min, max, ok := c.src.AvailableRange()
+	if !ok {
+		c.lastError = "no ledgers available to verify"
+		return c.statusLocked()
+	}
+
+	c.deep = p.Full || p.CheckNodes
+	c.failures = 0
+	c.lastError = ""
+
+	if p.MinLedger != nil && *p.MinLedger > min {
+		min = *p.MinLedger
+	}
+	if p.MaxLedger != nil && *p.MaxLedger < max {
+		max = *p.MaxLedger
+	}
+	if p.Ledger != nil {
+		// A single ledger forces a deep check, as in rippled.
+		min, max = *p.Ledger, *p.Ledger
+		c.deep = true
+	}
+
+	c.min, c.max = min, max
+	c.running = true
+	c.cond.Broadcast()
+	return c.statusLocked()
+}
+
+// Status returns a snapshot of the current state.
+func (c *Cleaner) Status() Status {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.statusLocked()
+}
+
+func (c *Cleaner) statusLocked() Status {
+	state := "idle"
+	if c.running {
+		state = "running"
+	}
+	return Status{
+		State:          state,
+		MinLedger:      c.min,
+		MaxLedger:      c.max,
+		CheckNodes:     c.deep,
+		Failures:       c.failures,
+		LedgersChecked: c.ledgersChecked,
+		NodesChecked:   c.nodesChecked,
+		MissingNodes:   c.missingNodes,
+		LastError:      c.lastError,
+	}
+}
+
+// run is the worker loop: it sleeps until a run is configured, then drains the
+// range one ledger at a time. Mirrors LedgerCleaner::run / doLedgerCleaner.
+func (c *Cleaner) run() {
+	defer close(c.done)
+	for {
+		c.mu.Lock()
+		for !c.exit && !c.running {
+			c.cond.Wait()
+		}
+		if c.exit {
+			c.mu.Unlock()
+			return
+		}
+		// Process from the top of the range downward, as rippled does.
+		if c.min > c.max {
+			c.running = false
+			c.mu.Unlock()
+			continue
+		}
+		seq := c.max
+		deep := c.deep
+		c.mu.Unlock()
+
+		nodes, missing, err := c.cleanLedger(c.ctx, seq, deep)
+
+		c.mu.Lock()
+		if c.exit {
+			c.mu.Unlock()
+			return
+		}
+		c.ledgersChecked++
+		c.nodesChecked += nodes
+		c.missingNodes += missing
+		if err != nil {
+			c.failures++
+			c.lastError = err.Error()
+			if c.logger != nil {
+				c.logger.Warn("ledger_cleaner: ledger verification failed", "seq", seq, "err", err)
+			}
+		} else if missing > 0 {
+			c.failures++
+			if c.logger != nil {
+				c.logger.Warn("ledger_cleaner: incomplete ledger", "seq", seq, "missing_nodes", missing)
+			}
+		} else if c.logger != nil {
+			c.logger.Debug("ledger_cleaner: ledger verified complete", "seq", seq, "nodes", nodes)
+		}
+		// Advance regardless of outcome: with no peer re-acquisition there is
+		// nothing to retry, so draining the range guarantees termination.
+		if seq == c.min {
+			c.min++
+		}
+		if seq == c.max && c.max > 0 {
+			c.max--
+		}
+		if c.min > c.max {
+			c.running = false
+			if c.logger != nil {
+				c.logger.Info("ledger_cleaner: run complete",
+					"ledgers_checked", c.ledgersChecked,
+					"missing_nodes", c.missingNodes,
+					"failures", c.failures)
+			}
+		}
+		c.mu.Unlock()
+
+		if c.sleep(interLedgerPause) {
+			return
+		}
+	}
+}
+
+// sleep pauses for d, returning true if the cleaner was stopped meanwhile.
+func (c *Cleaner) sleep(d time.Duration) (stopped bool) {
+	select {
+	case <-c.ctx.Done():
+		return true
+	case <-time.After(d):
+		return false
+	}
+}
+
+// cleanLedger verifies one ledger's state and transaction trees. With deep
+// set it walks every node (rippled walkLedger); otherwise it only confirms the
+// tree roots are present (a shallow check). It returns the number of nodes
+// inspected and the number found missing or corrupt.
+func (c *Cleaner) cleanLedger(ctx context.Context, seq uint32, deep bool) (nodes, missing uint64, err error) {
+	stateRoot, txRoot, ok := c.src.LedgerRoots(seq)
+	if !ok {
+		return 0, 1, nil // ledger unavailable locally; counts as one gap
+	}
+	family := c.src.Family()
+	if family == nil {
+		return 0, 0, errNoFamily
+	}
+
+	for _, t := range []struct {
+		root    [32]byte
+		mapType shamap.Type
+	}{
+		{stateRoot, shamap.TypeState},
+		{txRoot, shamap.TypeTransaction},
+	} {
+		if isZeroHash(t.root) {
+			continue // empty tree
+		}
+
+		sm, ferr := shamap.NewFromRootHash(t.mapType, t.root, family)
+		if ferr != nil {
+			// The root node itself is missing or unreadable.
+			missing++
+			continue
+		}
+
+		if !deep {
+			nodes++ // root present; shallow check stops here
+			continue
+		}
+
+		res, cerr := sm.CheckComplete(ctx)
+		if cerr != nil {
+			return nodes, missing, cerr
+		}
+		nodes += uint64(res.InnerNodes + res.LeafNodes)
+		missing += uint64(len(res.Missing) + len(res.Corrupt))
+	}
+	return nodes, missing, nil
+}
+
+func isZeroHash(h [32]byte) bool {
+	for _, b := range h {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/ledger/cleaner/cleaner_test.go
+++ b/internal/ledger/cleaner/cleaner_test.go
@@ -1,0 +1,309 @@
+package cleaner
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/shamap"
+)
+
+// fakeFamily is a controllable in-memory Family the test can mutate to induce
+// missing/corrupt nodes.
+type fakeFamily struct {
+	mu    sync.RWMutex
+	store map[[32]byte][]byte
+}
+
+func newFakeFamily() *fakeFamily { return &fakeFamily{store: map[[32]byte][]byte{}} }
+
+func (f *fakeFamily) Fetch(_ context.Context, hash [32]byte) ([]byte, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	data, ok := f.store[hash]
+	if !ok {
+		return nil, nil
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	return cp, nil
+}
+
+func (f *fakeFamily) StoreBatch(_ context.Context, entries []shamap.FlushEntry) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, e := range entries {
+		cp := make([]byte, len(e.Data))
+		copy(cp, e.Data)
+		f.store[e.Hash] = cp
+	}
+	return nil
+}
+
+func (f *fakeFamily) delete(h [32]byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.store, h)
+}
+
+func (f *fakeFamily) deleteOneNonRoot(root [32]byte) (deleted [32]byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for h := range f.store {
+		if h != root {
+			delete(f.store, h)
+			return h
+		}
+	}
+	return [32]byte{}
+}
+
+// fakeSource implements LedgerSource over a fakeFamily and a per-seq root table.
+type fakeSource struct {
+	family   *fakeFamily
+	roots    map[uint32][2][32]byte // seq -> {stateRoot, txRoot}
+	min, max uint32
+	hasRange bool
+}
+
+func (s *fakeSource) AvailableRange() (uint32, uint32, bool) { return s.min, s.max, s.hasRange }
+func (s *fakeSource) Family() shamap.Family                  { return s.family }
+func (s *fakeSource) LedgerRoots(seq uint32) ([32]byte, [32]byte, bool) {
+	r, ok := s.roots[seq]
+	return r[0], r[1], ok
+}
+
+// putStateTree builds a state map from keys, flushes it into family, and
+// returns the root hash.
+func putStateTree(t *testing.T, family *fakeFamily, keys []string) [32]byte {
+	t.Helper()
+	sm, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, k := range keys {
+		var key [32]byte
+		copy(key[:], mustHex(t, k))
+		data := make([]byte, 16)
+		data[0] = byte(i + 1)
+		if err := sm.Put(key, data); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	root, err := sm.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch, err := sm.FlushDirty(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := family.StoreBatch(context.Background(), batch.Entries); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b := make([]byte, 32)
+	for i := 0; i < 32 && i*2+1 < len(s); i++ {
+		b[i] = hexByte(s[i*2])<<4 | hexByte(s[i*2+1])
+	}
+	return b
+}
+
+func hexByte(c byte) byte {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0'
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10
+	}
+	return 0
+}
+
+var sampleKeys = []string{
+	"092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7",
+	"436ccbac3347baa1f1e53baeef1f43334da88f1f6d70d963b833afd6dfa289fe",
+	"b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8",
+}
+
+// waitIdle polls until the cleaner reports idle or the deadline passes.
+func waitIdle(t *testing.T, c *Cleaner) Status {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if s := c.Status(); s.State == "idle" && s.LedgersChecked > 0 {
+			return s
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("cleaner did not reach idle in time; status=%+v", c.Status())
+	return Status{}
+}
+
+func TestCleaner_VerifiesCompleteRange(t *testing.T) {
+	family := newFakeFamily()
+	root := putStateTree(t, family, sampleKeys)
+	src := &fakeSource{
+		family:   family,
+		roots:    map[uint32][2][32]byte{10: {root, {}}},
+		min:      10,
+		max:      10,
+		hasRange: true,
+	}
+
+	c := New(src, nil)
+	c.Start()
+	defer c.Stop()
+
+	st := c.Clean(Params{Full: true})
+	if st.State != "running" {
+		t.Fatalf("expected running after Clean, got %q", st.State)
+	}
+
+	final := waitIdle(t, c)
+	if final.MissingNodes != 0 {
+		t.Errorf("expected 0 missing nodes, got %d", final.MissingNodes)
+	}
+	if final.Failures != 0 {
+		t.Errorf("expected 0 failures, got %d", final.Failures)
+	}
+	if final.NodesChecked == 0 {
+		t.Errorf("expected some nodes checked")
+	}
+	if final.LedgersChecked != 1 {
+		t.Errorf("expected 1 ledger checked, got %d", final.LedgersChecked)
+	}
+}
+
+func TestCleaner_DetectsMissingNode(t *testing.T) {
+	family := newFakeFamily()
+	root := putStateTree(t, family, sampleKeys)
+	if del := family.deleteOneNonRoot(root); del == ([32]byte{}) {
+		t.Fatal("failed to delete a non-root node")
+	}
+
+	src := &fakeSource{
+		family:   family,
+		roots:    map[uint32][2][32]byte{10: {root, {}}},
+		min:      10,
+		max:      10,
+		hasRange: true,
+	}
+	c := New(src, nil)
+	c.Start()
+	defer c.Stop()
+
+	c.Clean(Params{Full: true})
+	final := waitIdle(t, c)
+	if final.MissingNodes == 0 {
+		t.Errorf("expected missing nodes after deleting one, got 0")
+	}
+	if final.Failures == 0 {
+		t.Errorf("expected failures recorded for an incomplete ledger")
+	}
+}
+
+func TestCleaner_ShallowSkipsDeepWalk(t *testing.T) {
+	family := newFakeFamily()
+	root := putStateTree(t, family, sampleKeys)
+	// Delete a non-root node: a shallow check only looks at the root, so it
+	// should still report the ledger complete.
+	family.deleteOneNonRoot(root)
+
+	src := &fakeSource{
+		family:   family,
+		roots:    map[uint32][2][32]byte{10: {root, {}}},
+		min:      10,
+		max:      10,
+		hasRange: true,
+	}
+	c := New(src, nil)
+	c.Start()
+	defer c.Stop()
+
+	c.Clean(Params{CheckNodes: false}) // shallow
+	final := waitIdle(t, c)
+	if final.MissingNodes != 0 {
+		t.Errorf("shallow check should not walk into the deleted node; missing=%d", final.MissingNodes)
+	}
+	if final.CheckNodes {
+		t.Errorf("shallow run should report CheckNodes=false")
+	}
+}
+
+func TestCleaner_ShallowDetectsMissingRoot(t *testing.T) {
+	family := newFakeFamily()
+	root := putStateTree(t, family, sampleKeys)
+	family.delete(root) // remove the root itself
+
+	src := &fakeSource{
+		family:   family,
+		roots:    map[uint32][2][32]byte{10: {root, {}}},
+		min:      10,
+		max:      10,
+		hasRange: true,
+	}
+	c := New(src, nil)
+	c.Start()
+	defer c.Stop()
+
+	c.Clean(Params{CheckNodes: false})
+	final := waitIdle(t, c)
+	if final.MissingNodes == 0 {
+		t.Errorf("shallow check must detect a missing root")
+	}
+}
+
+func TestCleaner_RangeDrainsAcrossLedgers(t *testing.T) {
+	family := newFakeFamily()
+	roots := map[uint32][2][32]byte{}
+	for seq := uint32(5); seq <= 8; seq++ {
+		roots[seq] = [2][32]byte{putStateTree(t, family, sampleKeys), {}}
+	}
+	src := &fakeSource{family: family, roots: roots, min: 5, max: 8, hasRange: true}
+
+	c := New(src, nil)
+	c.Start()
+	defer c.Stop()
+
+	c.Clean(Params{Full: true})
+	final := waitIdle(t, c)
+	if final.LedgersChecked != 4 {
+		t.Errorf("expected 4 ledgers checked across the range, got %d", final.LedgersChecked)
+	}
+	if final.MissingNodes != 0 || final.Failures != 0 {
+		t.Errorf("expected a clean drain, got missing=%d failures=%d", final.MissingNodes, final.Failures)
+	}
+}
+
+func TestCleaner_StopHaltsRun(t *testing.T) {
+	src := &fakeSource{family: newFakeFamily(), roots: map[uint32][2][32]byte{}, min: 1, max: 100, hasRange: true}
+	c := New(src, nil)
+	c.Start()
+	c.Clean(Params{Full: true})
+	st := c.Clean(Params{Stop: true})
+	if st.State != "idle" {
+		t.Errorf("expected idle after Stop param, got %q", st.State)
+	}
+	c.Stop() // must not hang
+}
+
+func TestCleaner_NoRangeAvailable(t *testing.T) {
+	src := &fakeSource{family: newFakeFamily(), roots: map[uint32][2][32]byte{}, hasRange: false}
+	c := New(src, nil)
+	c.Start()
+	defer c.Stop()
+	st := c.Clean(Params{Full: true})
+	if st.State != "idle" {
+		t.Errorf("expected idle when no range available, got %q", st.State)
+	}
+	if st.LastError == "" {
+		t.Errorf("expected a LastError explaining nothing to verify")
+	}
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1013,6 +1013,30 @@ func (s *Service) GetClosedLedgerIndex() uint32 {
 	return s.closedLedger.Sequence()
 }
 
+// AvailableLedgerRange returns the inclusive [min, max] sequence range of
+// ledgers held locally (the in-memory history), or ok=false when none are
+// available. Used by the ledger-integrity verifier to bound a cleaning run,
+// mirroring rippled's getFullValidatedRange.
+func (s *Service) AvailableLedgerRange() (min, max uint32, ok bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if len(s.ledgerHistory) == 0 {
+		return 0, 0, false
+	}
+	first := true
+	for seq := range s.ledgerHistory {
+		if first || seq < min {
+			min = seq
+		}
+		if first || seq > max {
+			max = seq
+		}
+		first = false
+	}
+	return min, max, true
+}
+
 // GetValidatedLedgerIndex returns the highest validated ledger index
 func (s *Service) GetValidatedLedgerIndex() uint32 {
 	s.mu.RLock()

--- a/internal/rpc/amendment_blocked_test.go
+++ b/internal/rpc/amendment_blocked_test.go
@@ -34,6 +34,7 @@ var blockedMethods = []string{
 	"simulate",
 	"tx",
 	"ripple_path_find",
+	"ledger_cleaner",
 }
 
 // unblockedMethods are methods with NO_CONDITION that should continue working.
@@ -230,7 +231,7 @@ func TestAmendmentBlockedConditionClassification(t *testing.T) {
 	// Verify specific condition counts based on rippled
 	assert.Equal(t, 11, counts[types.NeedsCurrentLedger], "NeedsCurrentLedger count")
 	assert.Equal(t, 1, counts[types.NeedsClosedLedger], "NeedsClosedLedger count")
-	assert.Equal(t, 1, counts[types.NeedsNetworkConnection], "NeedsNetworkConnection count")
+	assert.Equal(t, 2, counts[types.NeedsNetworkConnection], "NeedsNetworkConnection count")
 
 	t.Logf("Condition distribution: NoCondition=%d, NeedsCurrentLedger=%d, NeedsClosedLedger=%d, NeedsNetworkConnection=%d",
 		counts[types.NoCondition], counts[types.NeedsCurrentLedger],

--- a/internal/rpc/condition_met_test.go
+++ b/internal/rpc/condition_met_test.go
@@ -1,0 +1,123 @@
+package rpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/LeJamon/goXRPLd/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxWith builds a minimal RpcContext for conditionMet, wiring the mock as the
+// ledger service.
+func ctxWith(apiVersion int, mock *mockLedgerService) *types.RpcContext {
+	return &types.RpcContext{
+		ApiVersion: apiVersion,
+		Services:   &types.ServiceContainer{Ledger: mock},
+	}
+}
+
+func rippleNow() int64 { return time.Now().Unix() - protocol.RippleEpochUnix }
+
+// syncedStandalone is a node that satisfies every condition: standalone, full,
+// with a closed ledger.
+func syncedStandalone() *mockLedgerService {
+	m := newMockLedgerService()
+	m.serverInfo = types.LedgerServerInfo{
+		Standalone:      true,
+		ServerState:     "full",
+		ClosedLedgerSeq: 2,
+	}
+	return m
+}
+
+func TestConditionMet_NoConditionAlwaysAllowed(t *testing.T) {
+	// A completely unsynced node still allows NoCondition methods.
+	m := newMockLedgerService() // zero serverInfo: disconnected, no closed ledger
+	assert.Nil(t, conditionMet(types.NoCondition, ctxWith(types.ApiVersion1, m)))
+}
+
+func TestConditionMet_AmendmentBlocked(t *testing.T) {
+	m := syncedStandalone()
+	m.amendmentBlocked = true
+	rpcErr := conditionMet(types.NeedsCurrentLedger, ctxWith(types.ApiVersion1, m))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcAMENDMENT_BLOCKED, rpcErr.Code)
+}
+
+func TestConditionMet_NotSynced(t *testing.T) {
+	m := newMockLedgerService()
+	m.serverInfo = types.LedgerServerInfo{ServerState: "connected", ClosedLedgerSeq: 2}
+
+	t.Run("apiVersion1 returns noNetwork", func(t *testing.T) {
+		rpcErr := conditionMet(types.NeedsNetworkConnection, ctxWith(types.ApiVersion1, m))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcNO_NETWORK, rpcErr.Code)
+		assert.Equal(t, "noNetwork", rpcErr.ErrorString)
+	})
+	t.Run("apiVersion2 returns notSynced", func(t *testing.T) {
+		rpcErr := conditionMet(types.NeedsNetworkConnection, ctxWith(types.ApiVersion2, m))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcNOT_SYNCED, rpcErr.Code)
+	})
+}
+
+func TestConditionMet_NoClosedLedger(t *testing.T) {
+	// Standalone + full but no closed ledger: skips the age/gap checks, still
+	// refused by the closed-ledger check.
+	m := newMockLedgerService()
+	m.serverInfo = types.LedgerServerInfo{Standalone: true, ServerState: "full", ClosedLedgerSeq: 0}
+
+	rpcErr := conditionMet(types.NeedsCurrentLedger, ctxWith(types.ApiVersion1, m))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcNO_CLOSED, rpcErr.Code)
+	assert.Equal(t, "noClosed", rpcErr.ErrorString)
+}
+
+func TestConditionMet_StandaloneSyncedPasses(t *testing.T) {
+	assert.Nil(t, conditionMet(types.NeedsCurrentLedger, ctxWith(types.ApiVersion1, syncedStandalone())))
+}
+
+func TestConditionMet_NonStandaloneStaleValidated(t *testing.T) {
+	// Networked node, full, with a closed ledger, but no validated ledger →
+	// validated-ledger-age check fails with noCurrent.
+	m := newMockLedgerService()
+	m.serverInfo = types.LedgerServerInfo{
+		ServerState:     "full",
+		ClosedLedgerSeq: 100,
+		HaveValidated:   false,
+	}
+	rpcErr := conditionMet(types.NeedsCurrentLedger, ctxWith(types.ApiVersion1, m))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcNO_CURRENT, rpcErr.Code)
+}
+
+func TestConditionMet_NonStandaloneCurrentLagsValidated(t *testing.T) {
+	m := newMockLedgerService()
+	m.serverInfo = types.LedgerServerInfo{
+		ServerState:              "full",
+		OpenLedgerSeq:            100,
+		ClosedLedgerSeq:          99,
+		HaveValidated:            true,
+		ValidatedLedgerSeq:       200, // current (100) + 10 < 200
+		ValidatedLedgerCloseTime: rippleNow(),
+	}
+	rpcErr := conditionMet(types.NeedsCurrentLedger, ctxWith(types.ApiVersion1, m))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcNO_CURRENT, rpcErr.Code)
+}
+
+func TestConditionMet_NonStandaloneFreshPasses(t *testing.T) {
+	m := newMockLedgerService()
+	m.serverInfo = types.LedgerServerInfo{
+		ServerState:              "full",
+		OpenLedgerSeq:            200,
+		ClosedLedgerSeq:          199,
+		HaveValidated:            true,
+		ValidatedLedgerSeq:       199,
+		ValidatedLedgerCloseTime: rippleNow(),
+	}
+	assert.Nil(t, conditionMet(types.NeedsCurrentLedger, ctxWith(types.ApiVersion1, m)))
+}

--- a/internal/rpc/handlers/ledger_cleaner.go
+++ b/internal/rpc/handlers/ledger_cleaner.go
@@ -18,9 +18,8 @@ type LedgerCleanerMethod struct{ AdminHandler }
 
 // RequiredCondition mirrors rippled's handler-table entry
 // {"ledger_cleaner", …, NEEDS_NETWORK_CONNECTION} (Handler.cpp:121-124): the
-// command is unavailable until the node has network state. goXRPL's dispatcher
-// enforces only the amendment-blocked half of rippled's conditionMet, so the
-// network/sync half is applied in Handle via requireNetworkConnection.
+// command is unavailable until the node has network state. The dispatcher's
+// conditionMet enforces the network/sync gate before Handle runs.
 func (m *LedgerCleanerMethod) RequiredCondition() types.Condition {
 	return types.NeedsNetworkConnection
 }
@@ -28,9 +27,6 @@ func (m *LedgerCleanerMethod) RequiredCondition() types.Condition {
 func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
 	if ctx.Services == nil || ctx.Services.LedgerCleanerConfigure == nil {
 		return nil, types.RpcErrorInternal("Ledger cleaner service not available")
-	}
-	if rpcErr := requireNetworkConnection(ctx); rpcErr != nil {
-		return nil, rpcErr
 	}
 
 	var req struct {
@@ -66,41 +62,6 @@ func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		Stop:       req.Stop != nil && *req.Stop,
 	})
 	return statusResponse(st, true), nil
-}
-
-// requireNetworkConnection mirrors the NEEDS_NETWORK_CONNECTION half of
-// rippled's conditionMet (Handler.h:94-136): the command is refused until the
-// node is at least SYNCING and holds a closed ledger. Standalone always
-// satisfies this (server state "full", a closed ledger present), matching
-// rippled where the standalone carve-out only skips the validated-ledger-age
-// checks, not the operating-mode floor. Returns rpcNO_NETWORK on apiVersion 1
-// and rpcNOT_SYNCED otherwise; goXRPL has no rpcNO_CLOSED, so the
-// missing-closed-ledger edge maps to the same not-synced error.
-func requireNetworkConnection(ctx *types.RpcContext) *types.RpcError {
-	if ctx.Services.Ledger == nil {
-		return nil
-	}
-	info := ctx.Services.Ledger.GetServerInfo()
-	if atLeastSyncing(info.ServerState) && info.ClosedLedgerSeq != 0 {
-		return nil
-	}
-	if ctx.ApiVersion == types.ApiVersion1 {
-		return types.NewRpcError(types.RpcNO_NETWORK, "noNetwork", "noNetwork",
-			"Not synced to the network.")
-	}
-	return types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
-		"Not synced to the network.")
-}
-
-// atLeastSyncing reports whether the operating-mode string is SYNCING or
-// higher (the rippled OperatingMode >= SYNCING floor).
-func atLeastSyncing(serverState string) bool {
-	switch serverState {
-	case "syncing", "tracking", "full":
-		return true
-	default:
-		return false
-	}
 }
 
 // statusResponse renders a cleaner status as the RPC result. configured marks a

--- a/internal/rpc/handlers/ledger_cleaner.go
+++ b/internal/rpc/handlers/ledger_cleaner.go
@@ -1,0 +1,86 @@
+package handlers
+
+import (
+	"encoding/json"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+)
+
+// LedgerCleanerMethod handles the ledger_cleaner admin RPC. It configures the
+// background ledger-integrity verifier and returns its status, mirroring
+// rippled's ledger_cleaner (LedgerCleaner.cpp). A request with no parameters is
+// treated as a non-destructive status query.
+//
+// Parameters (all optional, mirroring rippled): ledger (single sequence,
+// forces a deep check), min_ledger, max_ledger, full (bool, deep check),
+// check_nodes (bool, walk every node), stop (bool, halt an in-progress run).
+type LedgerCleanerMethod struct{ AdminHandler }
+
+func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
+	if ctx.Services == nil || ctx.Services.LedgerCleanerConfigure == nil {
+		return nil, types.RpcErrorInternal("Ledger cleaner service not available")
+	}
+
+	var req struct {
+		Ledger     *uint32 `json:"ledger,omitempty"`
+		MinLedger  *uint32 `json:"min_ledger,omitempty"`
+		MaxLedger  *uint32 `json:"max_ledger,omitempty"`
+		Full       *bool   `json:"full,omitempty"`
+		CheckNodes *bool   `json:"check_nodes,omitempty"`
+		Stop       *bool   `json:"stop,omitempty"`
+	}
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, types.RpcErrorInvalidParams("ledger_cleaner: malformed params")
+		}
+	}
+
+	// No parameters at all → non-destructive status query.
+	hasParams := req.Ledger != nil || req.MinLedger != nil || req.MaxLedger != nil ||
+		req.Full != nil || req.CheckNodes != nil || req.Stop != nil
+	if !hasParams {
+		if ctx.Services.LedgerCleanerStatusFn != nil {
+			return statusResponse(ctx.Services.LedgerCleanerStatusFn(), false), nil
+		}
+		return statusResponse(types.LedgerCleanerStatus{State: "idle"}, false), nil
+	}
+
+	st := ctx.Services.LedgerCleanerConfigure(types.LedgerCleanerParams{
+		Ledger:     req.Ledger,
+		MinLedger:  req.MinLedger,
+		MaxLedger:  req.MaxLedger,
+		Full:       req.Full != nil && *req.Full,
+		CheckNodes: req.CheckNodes != nil && *req.CheckNodes,
+		Stop:       req.Stop != nil && *req.Stop,
+	})
+	return statusResponse(st, true), nil
+}
+
+// statusResponse renders a cleaner status as the RPC result. configured marks a
+// request that changed the cleaner's state (vs a pure status query). The
+// status / min_ledger / max_ledger / check_nodes / fail_counts fields mirror
+// rippled's PropertyStream output (LedgerCleaner.cpp:110-127); the *_checked /
+// missing_nodes progress counters are the goXRPL addition the issue asks for.
+func statusResponse(st types.LedgerCleanerStatus, configured bool) map[string]interface{} {
+	resp := map[string]interface{}{
+		"status":          st.State,
+		"check_nodes":     st.CheckNodes,
+		"ledgers_checked": st.LedgersChecked,
+		"nodes_checked":   st.NodesChecked,
+		"missing_nodes":   st.MissingNodes,
+	}
+	if configured {
+		resp["message"] = "Ledger cleaner configured"
+	}
+	if st.State == "running" {
+		resp["min_ledger"] = st.MinLedger
+		resp["max_ledger"] = st.MaxLedger
+	}
+	if st.Failures > 0 {
+		resp["fail_counts"] = st.Failures
+	}
+	if st.LastError != "" {
+		resp["last_error"] = st.LastError
+	}
+	return resp
+}

--- a/internal/rpc/handlers/ledger_cleaner.go
+++ b/internal/rpc/handlers/ledger_cleaner.go
@@ -16,9 +16,21 @@ import (
 // check_nodes (bool, walk every node), stop (bool, halt an in-progress run).
 type LedgerCleanerMethod struct{ AdminHandler }
 
+// RequiredCondition mirrors rippled's handler-table entry
+// {"ledger_cleaner", …, NEEDS_NETWORK_CONNECTION} (Handler.cpp:121-124): the
+// command is unavailable until the node has network state. goXRPL's dispatcher
+// enforces only the amendment-blocked half of rippled's conditionMet, so the
+// network/sync half is applied in Handle via requireNetworkConnection.
+func (m *LedgerCleanerMethod) RequiredCondition() types.Condition {
+	return types.NeedsNetworkConnection
+}
+
 func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
 	if ctx.Services == nil || ctx.Services.LedgerCleanerConfigure == nil {
 		return nil, types.RpcErrorInternal("Ledger cleaner service not available")
+	}
+	if rpcErr := requireNetworkConnection(ctx); rpcErr != nil {
+		return nil, rpcErr
 	}
 
 	var req struct {
@@ -54,6 +66,41 @@ func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		Stop:       req.Stop != nil && *req.Stop,
 	})
 	return statusResponse(st, true), nil
+}
+
+// requireNetworkConnection mirrors the NEEDS_NETWORK_CONNECTION half of
+// rippled's conditionMet (Handler.h:94-136): the command is refused until the
+// node is at least SYNCING and holds a closed ledger. Standalone always
+// satisfies this (server state "full", a closed ledger present), matching
+// rippled where the standalone carve-out only skips the validated-ledger-age
+// checks, not the operating-mode floor. Returns rpcNO_NETWORK on apiVersion 1
+// and rpcNOT_SYNCED otherwise; goXRPL has no rpcNO_CLOSED, so the
+// missing-closed-ledger edge maps to the same not-synced error.
+func requireNetworkConnection(ctx *types.RpcContext) *types.RpcError {
+	if ctx.Services.Ledger == nil {
+		return nil
+	}
+	info := ctx.Services.Ledger.GetServerInfo()
+	if atLeastSyncing(info.ServerState) && info.ClosedLedgerSeq != 0 {
+		return nil
+	}
+	if ctx.ApiVersion == types.ApiVersion1 {
+		return types.NewRpcError(types.RpcNO_NETWORK, "noNetwork", "noNetwork",
+			"Not synced to the network.")
+	}
+	return types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
+		"Not synced to the network.")
+}
+
+// atLeastSyncing reports whether the operating-mode string is SYNCING or
+// higher (the rippled OperatingMode >= SYNCING floor).
+func atLeastSyncing(serverState string) bool {
+	switch serverState {
+	case "syncing", "tracking", "full":
+		return true
+	default:
+		return false
+	}
 }
 
 // statusResponse renders a cleaner status as the RPC result. configured marks a

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -12,25 +12,6 @@ import (
 	xrpllog "github.com/LeJamon/goXRPLd/log"
 )
 
-// LedgerCleanerMethod handles the ledger_cleaner RPC method.
-// STUB: Returns error. Admin-only maintenance tool.
-//
-// TODO [admin]: Implement when adding ledger integrity checking.
-//   - Reference: rippled LedgerCleaner.cpp
-//   - Schedules verification and repair of stored ledger data
-//   - Params: ledger (sequence), max_ledger, min_ledger, full (bool)
-//   - Requires: LedgerCleaner background service
-type LedgerCleanerMethod struct{ AdminHandler }
-
-func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
-		return nil, types.RpcErrorInternal("Ledger service not available")
-	}
-
-	return nil, types.NewRpcError(types.RpcNOT_IMPL, "notImplemented", "notImplemented",
-		"ledger_cleaner is not yet implemented — requires LedgerCleaner service")
-}
-
 // PrintMethod handles the print RPC method.
 // Mirrors rippled Print.cpp, which returns the root of a property-stream tree
 // of internal subsystem state. goXRPL has no property-stream registry, so this

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -375,6 +375,9 @@ func TestLedgerCleanerMethod(t *testing.T) {
 	})
 
 	t.Run("Configures and reports status when wired", func(t *testing.T) {
+		// A synced node with a closed ledger satisfies the network-connection
+		// gate (mirrors rippled NEEDS_NETWORK_CONNECTION).
+		mock.serverInfo = types.LedgerServerInfo{ServerState: "full", ClosedLedgerSeq: 10}
 		var gotParams types.LedgerCleanerParams
 		services.LedgerCleanerConfigure = func(p types.LedgerCleanerParams) types.LedgerCleanerStatus {
 			gotParams = p
@@ -406,6 +409,31 @@ func TestLedgerCleanerMethod(t *testing.T) {
 		assert.True(t, gotParams.Full)
 		require.NotNil(t, gotParams.MinLedger)
 		assert.Equal(t, uint32(5), *gotParams.MinLedger)
+	})
+
+	t.Run("Refused when not synced to the network", func(t *testing.T) {
+		// A wired cleaner but a node below SYNCING must be refused, mirroring
+		// rippled's NEEDS_NETWORK_CONNECTION condition.
+		mock.serverInfo = types.LedgerServerInfo{ServerState: "connected"}
+		services.LedgerCleanerConfigure = func(p types.LedgerCleanerParams) types.LedgerCleanerStatus {
+			t.Fatal("configure must not be called when not synced")
+			return types.LedgerCleanerStatus{}
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleAdmin,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+		}
+
+		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"full":true}`))
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcNO_NETWORK, rpcErr.Code)
+	})
+
+	t.Run("RequiredCondition is NeedsNetworkConnection", func(t *testing.T) {
+		assert.Equal(t, types.NeedsNetworkConnection, method.RequiredCondition())
 	})
 
 	t.Run("RequiredRole is Admin", func(t *testing.T) {

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -358,8 +358,9 @@ func TestLedgerCleanerMethod(t *testing.T) {
 
 	method := &handlers.LedgerCleanerMethod{}
 
-	t.Run("Returns not implemented error (stub)", func(t *testing.T) {
-		// ledger_cleaner is a stub - requires LedgerCleaner service
+	t.Run("Unavailable when no cleaner is wired", func(t *testing.T) {
+		// The verifier is only wired when a node store is configured; with no
+		// cleaner the handler reports the service unavailable.
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
@@ -371,7 +372,40 @@ func TestLedgerCleanerMethod(t *testing.T) {
 
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
-		assert.Equal(t, types.RpcNOT_IMPL, rpcErr.Code)
+	})
+
+	t.Run("Configures and reports status when wired", func(t *testing.T) {
+		var gotParams types.LedgerCleanerParams
+		services.LedgerCleanerConfigure = func(p types.LedgerCleanerParams) types.LedgerCleanerStatus {
+			gotParams = p
+			return types.LedgerCleanerStatus{
+				State:        "running",
+				MinLedger:    5,
+				MaxLedger:    9,
+				CheckNodes:   true,
+				MissingNodes: 2,
+				Failures:     1,
+			}
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleAdmin,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+		}
+
+		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"min_ledger":5,"max_ledger":9,"full":true}`))
+		require.Nil(t, rpcErr)
+		resp, ok := result.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "running", resp["status"])
+		assert.Equal(t, true, resp["check_nodes"])
+		assert.Equal(t, uint64(2), resp["missing_nodes"])
+		assert.Equal(t, 1, resp["fail_counts"])
+		assert.Equal(t, "Ledger cleaner configured", resp["message"])
+		assert.True(t, gotParams.Full)
+		require.NotNil(t, gotParams.MinLedger)
+		assert.Equal(t, uint32(5), *gotParams.MinLedger)
 	})
 
 	t.Run("RequiredRole is Admin", func(t *testing.T) {

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -375,9 +375,8 @@ func TestLedgerCleanerMethod(t *testing.T) {
 	})
 
 	t.Run("Configures and reports status when wired", func(t *testing.T) {
-		// A synced node with a closed ledger satisfies the network-connection
-		// gate (mirrors rippled NEEDS_NETWORK_CONNECTION).
-		mock.serverInfo = types.LedgerServerInfo{ServerState: "full", ClosedLedgerSeq: 10}
+		// The network/sync gate is enforced by the dispatcher (conditionMet);
+		// calling Handle directly here exercises the handler in isolation.
 		var gotParams types.LedgerCleanerParams
 		services.LedgerCleanerConfigure = func(p types.LedgerCleanerParams) types.LedgerCleanerStatus {
 			gotParams = p
@@ -409,27 +408,6 @@ func TestLedgerCleanerMethod(t *testing.T) {
 		assert.True(t, gotParams.Full)
 		require.NotNil(t, gotParams.MinLedger)
 		assert.Equal(t, uint32(5), *gotParams.MinLedger)
-	})
-
-	t.Run("Refused when not synced to the network", func(t *testing.T) {
-		// A wired cleaner but a node below SYNCING must be refused, mirroring
-		// rippled's NEEDS_NETWORK_CONNECTION condition.
-		mock.serverInfo = types.LedgerServerInfo{ServerState: "connected"}
-		services.LedgerCleanerConfigure = func(p types.LedgerCleanerParams) types.LedgerCleanerStatus {
-			t.Fatal("configure must not be called when not synced")
-			return types.LedgerCleanerStatus{}
-		}
-		ctx := &types.RpcContext{
-			Context:    context.Background(),
-			Role:       types.RoleAdmin,
-			ApiVersion: types.ApiVersion1,
-			Services:   services,
-		}
-
-		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"full":true}`))
-		assert.Nil(t, result)
-		require.NotNil(t, rpcErr)
-		assert.Equal(t, types.RpcNO_NETWORK, rpcErr.Code)
 	})
 
 	t.Run("RequiredCondition is NeedsNetworkConnection", func(t *testing.T) {

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/rpc/loadtrack"
 	"github.com/LeJamon/goXRPLd/internal/rpc/types"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
+	"github.com/LeJamon/goXRPLd/protocol"
 )
 
 // MaxRequestBytes caps the size of a single JSON-RPC request body.
@@ -362,17 +363,10 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 		return nil, types.RpcErrorNoPermission(method)
 	}
 
-	// Check amendment blocking - matching rippled's conditionMet() in Handler.h
-	// When the server is amendment-blocked, methods with any condition
-	// other than NoCondition are blocked with rpcAMENDMENT_BLOCKED.
-	if handler.RequiredCondition() != types.NoCondition {
-		if ctx.Services != nil && ctx.Services.Ledger != nil {
-			if ctx.Services.Ledger.IsAmendmentBlocked() {
-				return nil, types.NewRpcError(types.RpcAMENDMENT_BLOCKED,
-					"amendmentBlocked", "amendmentBlocked",
-					"Amendment blocked, need upgrade.")
-			}
-		}
+	// Enforce the method's precondition, mirroring rippled's RPC::conditionMet
+	// (Handler.h:78-139).
+	if rpcErr := conditionMet(handler.RequiredCondition(), ctx); rpcErr != nil {
+		return nil, rpcErr
 	}
 
 	supportedVersions := handler.SupportedApiVersions()
@@ -402,6 +396,90 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 	result, rpcErr := handler.Handle(ctx, params)
 	finalizeLoad(s.loadTracker, ctx, method, handler, rpcErr, rpcLog())
 	return result, rpcErr
+}
+
+// maxValidatedLedgerAge mirrors rippled's Tuning::maxValidatedLedgerAge
+// (2 minutes): a non-standalone node whose validated ledger is older than this
+// is treated as out of sync.
+const maxValidatedLedgerAge = 120 * time.Second
+
+// conditionMet mirrors rippled's RPC::conditionMet (Handler.h:78-139). A method
+// whose RequiredCondition is NoCondition is always allowed. Otherwise the node
+// must be usable: not amendment-blocked, at least SYNCING, not lagging the
+// validated ledger (the age / current-vs-valid checks are skipped in
+// standalone), and holding a closed ledger.
+//
+// On failure it returns the apiVersion-1 code (rpcNO_NETWORK / rpcNO_CURRENT /
+// rpcNO_CLOSED) and rpcNOT_SYNCED for later versions, matching rippled. goxrpl
+// has no isUNLBlocked signal, so the rpcEXPIRED_VALIDATOR_LIST branch rippled
+// runs alongside the amendment-blocked check is omitted until one exists.
+func conditionMet(cond types.Condition, ctx *types.RpcContext) *types.RpcError {
+	if cond == types.NoCondition {
+		return nil
+	}
+	if ctx.Services == nil || ctx.Services.Ledger == nil {
+		return nil
+	}
+	svc := ctx.Services.Ledger
+
+	if svc.IsAmendmentBlocked() {
+		return types.NewRpcError(types.RpcAMENDMENT_BLOCKED,
+			"amendmentBlocked", "amendmentBlocked", "Amendment blocked, need upgrade.")
+	}
+
+	info := svc.GetServerInfo()
+
+	if !atLeastSyncing(info.ServerState) {
+		return notSyncedError(ctx.ApiVersion, types.RpcNO_NETWORK, "noNetwork",
+			"Not synced to the network.")
+	}
+
+	if !info.Standalone {
+		if validatedLedgerStale(info) || info.OpenLedgerSeq+10 < info.ValidatedLedgerSeq {
+			return notSyncedError(ctx.ApiVersion, types.RpcNO_CURRENT, "noCurrent",
+				"Current ledger is unavailable.")
+		}
+	}
+
+	if info.ClosedLedgerSeq == 0 {
+		return notSyncedError(ctx.ApiVersion, types.RpcNO_CLOSED, "noClosed",
+			"Closed ledger is unavailable.")
+	}
+
+	return nil
+}
+
+// atLeastSyncing reports whether the operating-mode string is SYNCING or higher
+// (rippled's OperatingMode >= SYNCING floor).
+func atLeastSyncing(serverState string) bool {
+	switch serverState {
+	case "syncing", "tracking", "full":
+		return true
+	default:
+		return false
+	}
+}
+
+// validatedLedgerStale reports whether the node lacks a validated ledger or its
+// validated ledger is older than maxValidatedLedgerAge (rippled
+// getValidatedLedgerAge > Tuning::maxValidatedLedgerAge).
+func validatedLedgerStale(info types.LedgerServerInfo) bool {
+	if !info.HaveValidated || info.ValidatedLedgerCloseTime == 0 {
+		return true
+	}
+	nowRipple := time.Now().Unix() - protocol.RippleEpochUnix
+	age := nowRipple - info.ValidatedLedgerCloseTime
+	return age > int64(maxValidatedLedgerAge/time.Second)
+}
+
+// notSyncedError returns the apiVersion-1 code with its token/message, or
+// rpcNOT_SYNCED for later versions, mirroring rippled conditionMet.
+func notSyncedError(apiVersion, v1Code int, v1Token, v1Message string) *types.RpcError {
+	if apiVersion == types.ApiVersion1 {
+		return types.NewRpcError(v1Code, v1Token, v1Token, v1Message)
+	}
+	return types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
+		"Not synced to the network.")
 }
 
 // gateLoad is the pre-dispatch admission check. It does NOT charge the

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -56,9 +56,15 @@ const (
 	RpcCOMMAND_UNTRUSTED = 3
 	RpcNO_CURRENT        = 4
 	RpcNO_NETWORK        = 5
-	RpcNO_PERMISSION     = 6  // rippled: rpcNO_PERMISSION = 6
-	RpcTOO_BUSY          = 9  // rippled: rpcTOO_BUSY = 9
-	RpcSLOW_DOWN         = 10 // rippled: rpcSLOW_DOWN = 10
+	// RpcNO_CLOSED is returned when a method needs a network condition but no
+	// closed ledger is available (rippled conditionMet, Handler.h:130-136).
+	// rippled numbers it rpcNO_CLOSED = 15 with token "noClosed"; goxrpl's
+	// network-error codes already diverge from rippled's enum (NO_CURRENT=4,
+	// NO_NETWORK=5), so this takes the free local slot 8 and keeps the token.
+	RpcNO_CLOSED     = 8
+	RpcNO_PERMISSION = 6  // rippled: rpcNO_PERMISSION = 6
+	RpcTOO_BUSY      = 9  // rippled: rpcTOO_BUSY = 9
+	RpcSLOW_DOWN     = 10 // rippled: rpcSLOW_DOWN = 10
 
 	// Networking
 	RpcNOT_STANDALONE = 10

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -330,6 +330,46 @@ type ServiceContainer struct {
 	// averages surfaced by the tx_reduce_relay RPC. Nil when the overlay
 	// isn't wired (standalone / RPC-only) — the handler then reports zeros.
 	TxReduceRelayMetrics func() TxReduceRelayMetrics
+
+	// LedgerCleanerConfigure configures and starts the background
+	// ledger-integrity verifier, returning its resulting status. Backs the
+	// admin ledger_cleaner RPC. Nil when no cleaner is wired — the handler
+	// then reports the service unavailable.
+	//
+	// LedgerCleanerParams / LedgerCleanerStatus mirror the structs of the same
+	// shape in internal/ledger/cleaner: this RPC-types package must not import
+	// the cleaner, so the wiring in cmd/server translates between the two.
+	LedgerCleanerConfigure func(LedgerCleanerParams) LedgerCleanerStatus
+
+	// LedgerCleanerStatusFn returns the verifier's current status without
+	// reconfiguring it, backing a parameterless ledger_cleaner status query.
+	LedgerCleanerStatusFn func() LedgerCleanerStatus
+}
+
+// LedgerCleanerParams mirrors internal/ledger/cleaner.Params (layering
+// boundary — see LedgerCleanerConfigure). Pointer fields are nil when the
+// caller omits the corresponding JSON parameter.
+type LedgerCleanerParams struct {
+	Ledger     *uint32
+	MinLedger  *uint32
+	MaxLedger  *uint32
+	Full       bool
+	CheckNodes bool
+	Stop       bool
+}
+
+// LedgerCleanerStatus mirrors internal/ledger/cleaner.Status (layering
+// boundary). State is "idle" or "running".
+type LedgerCleanerStatus struct {
+	State          string
+	MinLedger      uint32
+	MaxLedger      uint32
+	CheckNodes     bool
+	Failures       int
+	LedgersChecked uint64
+	NodesChecked   uint64
+	MissingNodes   uint64
+	LastError      string
 }
 
 // CountsResult is the subset of rippled's get_counts that goXRPL has real data

--- a/internal/testing/cleaner/cleaner_integration_test.go
+++ b/internal/testing/cleaner/cleaner_integration_test.go
@@ -1,0 +1,201 @@
+package cleaner_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/cleaner"
+	jtx "github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/shamap"
+)
+
+// ctrlFamily is a content-addressed store the test fully controls, so it can
+// induce a missing node by deleting one entry.
+type ctrlFamily struct {
+	mu    sync.RWMutex
+	store map[[32]byte][]byte
+}
+
+func newCtrlFamily() *ctrlFamily { return &ctrlFamily{store: map[[32]byte][]byte{}} }
+
+func (f *ctrlFamily) Fetch(_ context.Context, hash [32]byte) ([]byte, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	data, ok := f.store[hash]
+	if !ok {
+		return nil, nil
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	return cp, nil
+}
+
+func (f *ctrlFamily) StoreBatch(_ context.Context, entries []shamap.FlushEntry) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, e := range entries {
+		cp := make([]byte, len(e.Data))
+		copy(cp, e.Data)
+		f.store[e.Hash] = cp
+	}
+	return nil
+}
+
+func (f *ctrlFamily) deleteOneNonRoot(root [32]byte) (deleted [32]byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for h := range f.store {
+		if h != root {
+			delete(f.store, h)
+			return h
+		}
+	}
+	return [32]byte{}
+}
+
+// integrationSource feeds the cleaner the state root of one real ledger, walked
+// against the content-addressed family the test materialised from that ledger.
+type integrationSource struct {
+	family    shamap.Family
+	seq       uint32
+	stateRoot [32]byte
+}
+
+func (s *integrationSource) AvailableRange() (uint32, uint32, bool) { return s.seq, s.seq, true }
+func (s *integrationSource) Family() shamap.Family                  { return s.family }
+func (s *integrationSource) LedgerRoots(seq uint32) ([32]byte, [32]byte, bool) {
+	if seq != s.seq {
+		return [32]byte{}, [32]byte{}, false
+	}
+	return s.stateRoot, [32]byte{}, true // tx tree empty for this fixture
+}
+
+// materializeState rebuilds the closed ledger's state tree into a fresh
+// content-addressed family — exactly what the content-addressed persistence
+// migration will do at chain-advance time — and asserts the rebuilt root hash
+// equals the real ledger's account_hash, proving it is genuinely that ledger's
+// state.
+func materializeState(t *testing.T, env *jtx.TestEnv) (*ctrlFamily, [32]byte) {
+	t.Helper()
+	closed := env.LastClosedLedger()
+	if closed == nil {
+		t.Fatal("no closed ledger")
+	}
+	wantRoot, err := closed.StateMapHash()
+	if err != nil {
+		t.Fatalf("StateMapHash: %v", err)
+	}
+
+	rebuilt, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaves := 0
+	if err := closed.ForEach(func(key [32]byte, data []byte) bool {
+		if perr := rebuilt.Put(key, data); perr != nil {
+			t.Fatalf("Put state entry: %v", perr)
+		}
+		leaves++
+		return true
+	}); err != nil {
+		t.Fatalf("ForEach state: %v", err)
+	}
+	if leaves == 0 {
+		t.Fatal("expected real ledger state entries, got none")
+	}
+
+	gotRoot, err := rebuilt.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("rebuilt state root %x != ledger account_hash %x", gotRoot[:8], wantRoot[:8])
+	}
+
+	family := newCtrlFamily()
+	batch, err := rebuilt.FlushDirty(false)
+	if err != nil {
+		t.Fatalf("FlushDirty: %v", err)
+	}
+	if err := family.StoreBatch(context.Background(), batch.Entries); err != nil {
+		t.Fatalf("StoreBatch: %v", err)
+	}
+	return family, wantRoot
+}
+
+func runToIdle(t *testing.T, c *cleaner.Cleaner) cleaner.Status {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if s := c.Status(); s.State == "idle" && s.LedgersChecked > 0 {
+			return s
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("cleaner did not finish; status=%+v", c.Status())
+	return cleaner.Status{}
+}
+
+// TestLedgerCleaner_VerifiesRealLedger builds a real ledger with funded
+// accounts, materialises its state tree into a content-addressed store, and
+// confirms the verifier walks it complete.
+func TestLedgerCleaner_VerifiesRealLedger(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	env.Fund(alice, bob, carol)
+	env.Close()
+
+	family, root := materializeState(t, env)
+	src := &integrationSource{family: family, seq: env.LedgerSeq(), stateRoot: root}
+
+	c := cleaner.New(src, nil)
+	c.Start()
+	defer c.Stop()
+
+	c.Clean(cleaner.Params{Full: true})
+	final := runToIdle(t, c)
+
+	if final.MissingNodes != 0 {
+		t.Errorf("real ledger should verify complete, got %d missing", final.MissingNodes)
+	}
+	if final.Failures != 0 {
+		t.Errorf("expected 0 failures, got %d", final.Failures)
+	}
+	if final.NodesChecked == 0 {
+		t.Errorf("expected the walk to inspect nodes")
+	}
+}
+
+// TestLedgerCleaner_DetectsInducedMissingNode removes one node from the store
+// of a real ledger and confirms the verifier reports the gap.
+func TestLedgerCleaner_DetectsInducedMissingNode(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	for _, name := range []string{"a", "b", "c", "d", "e"} {
+		env.Fund(jtx.NewAccount(name))
+	}
+	env.Close()
+
+	family, root := materializeState(t, env)
+	if del := family.deleteOneNonRoot(root); del == ([32]byte{}) {
+		t.Fatal("could not induce a missing node (no non-root node stored)")
+	}
+
+	src := &integrationSource{family: family, seq: env.LedgerSeq(), stateRoot: root}
+	c := cleaner.New(src, nil)
+	c.Start()
+	defer c.Stop()
+
+	c.Clean(cleaner.Params{Full: true})
+	final := runToIdle(t, c)
+
+	if final.MissingNodes == 0 {
+		t.Errorf("expected the verifier to detect the induced missing node")
+	}
+	if final.Failures == 0 {
+		t.Errorf("expected a failure recorded for the incomplete ledger")
+	}
+}

--- a/shamap/completeness.go
+++ b/shamap/completeness.go
@@ -1,0 +1,130 @@
+package shamap
+
+import (
+	"context"
+	"fmt"
+)
+
+// CompletenessResult summarises a CheckComplete walk: how many inner and leaf
+// nodes were visited, every referenced node the store does not have (Missing),
+// and every referenced node the store has but cannot deserialize (Corrupt).
+// Mirrors the missing-node accounting rippled performs in SHAMap::walkMap
+// (SHAMap.cpp) / Ledger::walkLedger.
+type CompletenessResult struct {
+	InnerNodes int
+	LeafNodes  int
+	Missing    []MissingNode
+	Corrupt    []MissingNode
+}
+
+// Complete reports whether the walk found the tree fully present and readable.
+func (r *CompletenessResult) Complete() bool {
+	return len(r.Missing) == 0 && len(r.Corrupt) == 0
+}
+
+// maxWalkDepth bounds the recursion. A SHAMap key is 256 bits / 4 bits per
+// branch = 64 levels; the guard only fires on a corrupt store that returns an
+// inner node where a leaf belongs, so it is reported as an error, not a panic.
+const maxWalkDepth = 64
+
+// CheckComplete walks the tree depth-first, forcing every referenced node to be
+// resolved from the backing store, and reports any node that is missing or
+// corrupt. It is the goXRPL analog of rippled's SHAMap::walkMap: it verifies
+// that the content-addressed store holds the complete Merkle tree rooted at
+// this map.
+//
+// For an unbacked (purely in-memory) map every node is already resolved, so the
+// walk only counts nodes and always reports complete. For a map built via
+// NewFromRootHash the children are hash-only until fetched, so the walk drives
+// the lazy resolution and records branches whose node the store cannot supply.
+//
+// A genuine store I/O error aborts the walk and is returned; a node the store
+// simply does not have is recorded in Missing and the walk continues, so a
+// single call enumerates every gap in one pass.
+func (sm *SHAMap) CheckComplete(ctx context.Context) (*CompletenessResult, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	res := &CompletenessResult{}
+	if sm.root == nil {
+		return res, nil
+	}
+	if err := sm.checkNodeComplete(ctx, sm.root, 0, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// checkNodeComplete recurses into node. The caller holds sm.mu.RLock; node is
+// an already-resolved node (the root, an in-memory child, or one just fetched
+// from the store), so it is never itself missing — only its referenced
+// children can be.
+func (sm *SHAMap) checkNodeComplete(ctx context.Context, node Node, depth int, res *CompletenessResult) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if depth > maxWalkDepth {
+		return fmt.Errorf("shamap: walk exceeded max depth %d (corrupt tree?)", maxWalkDepth)
+	}
+
+	inner, ok := node.(*InnerNode)
+	if !ok {
+		res.LeafNodes++
+		return nil
+	}
+	res.InnerNodes++
+	parentHash := inner.Hash()
+
+	// Snapshot the branch table under the inner node's own lock so the walk
+	// reads a consistent view without holding it across child fetches.
+	inner.mu.RLock()
+	isBranch := inner.isBranch
+	hashes := inner.hashes
+	children := inner.children
+	inner.mu.RUnlock()
+
+	for branch := 0; branch < BranchFactor; branch++ {
+		if isBranch&(1<<branch) == 0 {
+			continue
+		}
+
+		if child := children[branch]; child != nil {
+			// Already resolved in memory — descend without touching the store.
+			if err := sm.checkNodeComplete(ctx, child, depth+1, res); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Hash-only branch: the node must come from the store.
+		miss := MissingNode{
+			Hash:       hashes[branch],
+			Depth:      depth + 1,
+			ParentHash: parentHash,
+			Branch:     branch,
+		}
+		if !sm.backed || sm.family == nil {
+			res.Missing = append(res.Missing, miss)
+			continue
+		}
+
+		data, err := sm.family.Fetch(ctx, miss.Hash)
+		if err != nil {
+			return fmt.Errorf("shamap: fetch node %x at depth %d: %w", miss.Hash[:8], miss.Depth, err)
+		}
+		if data == nil {
+			res.Missing = append(res.Missing, miss)
+			continue
+		}
+
+		child, err := DeserializeFromPrefix(data)
+		if err != nil {
+			res.Corrupt = append(res.Corrupt, miss)
+			continue
+		}
+		if err := sm.checkNodeComplete(ctx, child, depth+1, res); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/shamap/completeness_test.go
+++ b/shamap/completeness_test.go
@@ -1,0 +1,183 @@
+package shamap
+
+import (
+	"context"
+	"testing"
+)
+
+// buildBackedStateMap puts the given keys into a fresh state map, flushes it to
+// family, and returns the root hash plus a backed map reconstructed from it.
+func buildBackedStateMap(t *testing.T, family *memoryFamily, keys []string) ([32]byte, *SHAMap) {
+	t.Helper()
+	sMap, err := New(TypeState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, keyHex := range keys {
+		if err := sMap.Put(hexToHash(keyHex), intToBytes(i+1)); err != nil {
+			t.Fatalf("Put %d: %v", i, err)
+		}
+	}
+	rootHash, err := sMap.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := flushToFamily(sMap, family); err != nil {
+		t.Fatal(err)
+	}
+	backed, err := NewFromRootHash(TypeState, rootHash, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rootHash, backed
+}
+
+func TestCheckComplete_BackedMapFullyPresent(t *testing.T) {
+	family := newMemoryFamily()
+	keys := []string{
+		"092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7",
+		"436ccbac3347baa1f1e53baeef1f43334da88f1f6d70d963b833afd6dfa289fe",
+		"b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8",
+	}
+	_, backed := buildBackedStateMap(t, family, keys)
+
+	res, err := backed.CheckComplete(context.Background())
+	if err != nil {
+		t.Fatalf("CheckComplete: %v", err)
+	}
+	if !res.Complete() {
+		t.Errorf("expected complete tree, got %d missing: %+v", len(res.Missing), res.Missing)
+	}
+	if res.LeafNodes != len(keys) {
+		t.Errorf("expected %d leaves, got %d", len(keys), res.LeafNodes)
+	}
+	if res.InnerNodes < 1 {
+		t.Errorf("expected at least the root inner node, got %d", res.InnerNodes)
+	}
+}
+
+func TestCheckComplete_DetectsMissingNode(t *testing.T) {
+	family := newMemoryFamily()
+	keys := []string{
+		"092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7",
+		"436ccbac3347baa1f1e53baeef1f43334da88f1f6d70d963b833afd6dfa289fe",
+		"b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8",
+	}
+	rootHash, _ := buildBackedStateMap(t, family, keys)
+
+	// Induce a missing node: delete one stored node that is NOT the root, so
+	// the root still deserializes but a referenced child is unresolvable.
+	var deleted [32]byte
+	family.mu.Lock()
+	for h := range family.store {
+		if h != rootHash {
+			delete(family.store, h)
+			deleted = h
+			break
+		}
+	}
+	family.mu.Unlock()
+
+	// Reconstruct fresh so no children are cached in memory from a prior walk.
+	backed, err := NewFromRootHash(TypeState, rootHash, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := backed.CheckComplete(context.Background())
+	if err != nil {
+		t.Fatalf("CheckComplete: %v", err)
+	}
+	if res.Complete() {
+		t.Fatal("expected an incomplete tree after deleting a node")
+	}
+	if len(res.Corrupt) != 0 {
+		t.Errorf("a deleted (absent) node must not be reported as corrupt: %+v", res.Corrupt)
+	}
+	found := false
+	for _, m := range res.Missing {
+		if m.Hash == deleted {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing-node report %+v did not include the deleted node %x", res.Missing, deleted[:8])
+	}
+}
+
+func TestCheckComplete_DetectsCorruptNode(t *testing.T) {
+	family := newMemoryFamily()
+	keys := []string{
+		"092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7",
+		"436ccbac3347baa1f1e53baeef1f43334da88f1f6d70d963b833afd6dfa289fe",
+	}
+	rootHash, _ := buildBackedStateMap(t, family, keys)
+
+	// Corrupt one non-root node: keep the key, replace the bytes with garbage
+	// that DeserializeFromPrefix rejects.
+	var corrupted [32]byte
+	family.mu.Lock()
+	for h := range family.store {
+		if h != rootHash {
+			family.store[h] = []byte{0xde, 0xad, 0xbe, 0xef}
+			corrupted = h
+			break
+		}
+	}
+	family.mu.Unlock()
+
+	backed, err := NewFromRootHash(TypeState, rootHash, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := backed.CheckComplete(context.Background())
+	if err != nil {
+		t.Fatalf("CheckComplete: %v", err)
+	}
+	if res.Complete() {
+		t.Fatal("expected an incomplete tree after corrupting a node")
+	}
+	corruptReported := false
+	for _, m := range res.Corrupt {
+		if m.Hash == corrupted {
+			corruptReported = true
+		}
+	}
+	if !corruptReported {
+		t.Errorf("expected corrupt node %x flagged, got missing=%+v corrupt=%+v", corrupted[:8], res.Missing, res.Corrupt)
+	}
+}
+
+func TestCheckComplete_UnbackedMapIsComplete(t *testing.T) {
+	sMap, err := New(TypeState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sMap.Put(hexToHash("092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7"), intToBytes(1)); err != nil {
+		t.Fatal(err)
+	}
+	res, err := sMap.CheckComplete(context.Background())
+	if err != nil {
+		t.Fatalf("CheckComplete: %v", err)
+	}
+	if !res.Complete() {
+		t.Errorf("unbacked in-memory map must always be complete, got %+v", res.Missing)
+	}
+	if res.LeafNodes != 1 {
+		t.Errorf("expected 1 leaf, got %d", res.LeafNodes)
+	}
+}
+
+func TestCheckComplete_EmptyMap(t *testing.T) {
+	sMap, err := New(TypeState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := sMap.CheckComplete(context.Background())
+	if err != nil {
+		t.Fatalf("CheckComplete: %v", err)
+	}
+	if !res.Complete() || res.LeafNodes != 0 {
+		t.Errorf("empty map should be complete with no leaves, got %+v", res)
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces the `ledger_cleaner` stub with a content-addressed **ledger-integrity verifier**, the goXRPL analog of rippled's `LedgerCleaner`. A background worker walks a ledger's state/transaction SHAMap trees against the node store and reports missing/corrupt nodes — mirroring rippled's `walkLedger`.
- `shamap.CheckComplete`: depth-first walk that force-fetches every referenced node, reporting absent (`Missing`) and undeserializable (`Corrupt`) nodes by hash (analog of `SHAMap::walkMap`).
- `internal/ledger/cleaner`: start/stop background service with an idle/running state machine, min/max range, failure + progress counters, and interruptible backoff. `Clean(Params)`/`Status()` mirror rippled `clean()`/PropertyStream.
- Admin `ledger_cleaner` RPC: parses `ledger`, `min_ledger`, `max_ledger`, `full`, `check_nodes`, `stop`; returns status (state/range/`check_nodes`/`fail_counts` + ledgers/nodes/missing counts). A parameterless request is a non-destructive status query.
- Wired via the established `ServiceContainer` func-field pattern over a `NodeStoreFamily`, started/stopped with the server when a node store is configured.

## Design note
The issue assumes rippled's content-addressed NodeStore (walk the tree, fetch each node by hash). goXRPL's `shamap` package already implements that model (`FlushDirty`/`NewFromRootHash`/`NodeStoreFamily`), but the **live chain-advance persistence** (`service/persistence.go`) currently stores SLE leaves by SLE-index rather than content-addressed SHAMap nodes. This PR builds the rippled-faithful verifier on the content-addressed model. Migrating live persistence to content-addressed storage (and adding peer re-acquisition of missing nodes, rippled's loop-until-whole behaviour) is the documented follow-up; the worker here advances rather than blocking, so a run always terminates.

## Test plan
- [x] `go build ./...`, `gofmt`, `go vet` clean
- [x] `shamap` unit tests: complete / missing / corrupt / unbacked / empty
- [x] `internal/ledger/cleaner` state-machine tests (incl. `-race`)
- [x] Integration (`internal/testing/cleaner`): a real funded ledger materialised into a content-addressed store is walked complete; an induced missing node is detected
- [x] `internal/rpc/...` suites pass (handler reports status; admin-only)

Fixes #557