### PR TITLE
Wire UNL-blocked into RPC conditionMet

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -555,6 +555,13 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		// that case rather than panicking.
 		services.ValidatorList = validatorlist.NewRPCReader(consensusComponents.ValidatorList)
 
+		// Surface UNL-blocked state (validator list expired) so conditionMet
+		// can return rpcEXPIRED_VALIDATOR_LIST, mirroring rippled's
+		// NetworkOPs::isUNLBlocked. Only when a publisher list is configured.
+		if consensusComponents.ValidatorList != nil {
+			services.UNLBlocked = consensusComponents.ValidatorList.IsUNLBlocked
+		}
+
 		// Expose static config validators, cached signing keys, and the
 		// negative-UNL set to the `validators` RPC so it returns the
 		// same shape rippled's ValidatorList::getJson does.

--- a/internal/rpc/condition_met_test.go
+++ b/internal/rpc/condition_met_test.go
@@ -109,6 +109,39 @@ func TestConditionMet_NonStandaloneCurrentLagsValidated(t *testing.T) {
 	assert.Equal(t, types.RpcNO_CURRENT, rpcErr.Code)
 }
 
+func TestConditionMet_UNLBlocked(t *testing.T) {
+	m := syncedStandalone()
+	ctx := &types.RpcContext{
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: m, UNLBlocked: func() bool { return true }},
+	}
+	rpcErr := conditionMet(types.NeedsCurrentLedger, ctx)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcEXPIRED_VALIDATOR_LIST, rpcErr.Code)
+	assert.Equal(t, "unlBlocked", rpcErr.ErrorString)
+}
+
+func TestConditionMet_UNLNotBlockedPasses(t *testing.T) {
+	m := syncedStandalone()
+	ctx := &types.RpcContext{
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: m, UNLBlocked: func() bool { return false }},
+	}
+	assert.Nil(t, conditionMet(types.NeedsCurrentLedger, ctx))
+}
+
+func TestConditionMet_AmendmentBlockedBeatsUNL(t *testing.T) {
+	m := syncedStandalone()
+	m.amendmentBlocked = true
+	ctx := &types.RpcContext{
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: m, UNLBlocked: func() bool { return true }},
+	}
+	rpcErr := conditionMet(types.NeedsCurrentLedger, ctx)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcAMENDMENT_BLOCKED, rpcErr.Code)
+}
+
 func TestConditionMet_NonStandaloneFreshPasses(t *testing.T) {
 	m := newMockLedgerService()
 	m.serverInfo = types.LedgerServerInfo{

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -410,9 +410,9 @@ const maxValidatedLedgerAge = 120 * time.Second
 // standalone), and holding a closed ledger.
 //
 // On failure it returns the apiVersion-1 code (rpcNO_NETWORK / rpcNO_CURRENT /
-// rpcNO_CLOSED) and rpcNOT_SYNCED for later versions, matching rippled. goxrpl
-// has no isUNLBlocked signal, so the rpcEXPIRED_VALIDATOR_LIST branch rippled
-// runs alongside the amendment-blocked check is omitted until one exists.
+// rpcNO_CLOSED) and rpcNOT_SYNCED for later versions, matching rippled. The
+// rpcEXPIRED_VALIDATOR_LIST branch fires when the UNL is blocked, driven by the
+// optional ServiceContainer.UNLBlocked signal (nil ⇒ never blocked).
 func conditionMet(cond types.Condition, ctx *types.RpcContext) *types.RpcError {
 	if cond == types.NoCondition {
 		return nil
@@ -425,6 +425,11 @@ func conditionMet(cond types.Condition, ctx *types.RpcContext) *types.RpcError {
 	if svc.IsAmendmentBlocked() {
 		return types.NewRpcError(types.RpcAMENDMENT_BLOCKED,
 			"amendmentBlocked", "amendmentBlocked", "Amendment blocked, need upgrade.")
+	}
+
+	if ctx.Services.UNLBlocked != nil && ctx.Services.UNLBlocked() {
+		return types.NewRpcError(types.RpcEXPIRED_VALIDATOR_LIST,
+			"unlBlocked", "unlBlocked", "Validator list expired.")
 	}
 
 	info := svc.GetServerInfo()

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -119,6 +119,10 @@ const (
 	RpcUNSUPPORTED_FEATURE = 39
 	RpcAMENDMENT_BLOCKED   = 14 // rippled: rpcAMENDMENT_BLOCKED = 14
 	RpcBAD_FEATURE         = 40 // rippled: rpcBAD_FEATURE = 40 ("badFeature")
+	// RpcEXPIRED_VALIDATOR_LIST is returned when a network-condition method is
+	// requested while the node's UNL is blocked (the validator list expired).
+	// Matches rippled rpcEXPIRED_VALIDATOR_LIST = 80, token "unlBlocked".
+	RpcEXPIRED_VALIDATOR_LIST = 80
 
 	// Database errors
 	RpcDB_DESERIALIZATION_ERROR = 41

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -344,6 +344,13 @@ type ServiceContainer struct {
 	// LedgerCleanerStatusFn returns the verifier's current status without
 	// reconfiguring it, backing a parameterless ledger_cleaner status query.
 	LedgerCleanerStatusFn func() LedgerCleanerStatus
+
+	// UNLBlocked reports whether the node's UNL is blocked (the configured
+	// validator list has expired), driving the rpcEXPIRED_VALIDATOR_LIST
+	// branch of conditionMet (mirrors rippled NetworkOPs::isUNLBlocked).
+	// Nil in standalone / RPC-only configurations (no validator list) — the
+	// gate then treats the node as not blocked.
+	UNLBlocked func() bool
 }
 
 // LedgerCleanerParams mirrors internal/ledger/cleaner.Params (layering

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -417,6 +417,37 @@ func (a *Aggregator) HasConfiguredPublishers() bool {
 	return len(a.publishers) > 0
 }
 
+// IsUNLBlocked reports whether the node has a configured UNL it can no longer
+// trust — the goXRPL analog of rippled's NetworkOPs UNL-blocked flag, set in
+// ValidatorList::updateTrusted (ValidatorList.cpp:1996-2001, 2095-2100). It is
+// true when at least one configured publisher has already produced a list (so
+// the UNL is "live") and either that list has expired or the effective trusted
+// union is now empty. A node that has never ingested a list (fresh startup) or
+// has no publishers configured is NOT blocked, mirroring rippled where the flag
+// only fires once publisherLists_ is non-empty.
+func (a *Aggregator) IsUNLBlocked() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	active := false
+	anyExpired := false
+	for _, s := range a.state {
+		switch s.Status {
+		case StatusUnavailable:
+			// Configured but no list ingested yet — does not count as live.
+		case StatusExpired:
+			active = true
+			anyExpired = true
+		default: // available / revoked — a list has been ingested
+			active = true
+		}
+	}
+	if !active {
+		return false
+	}
+	return anyExpired || len(a.lastEmitted) == 0
+}
+
 // PublisherSnapshot returns a deep copy of the per-publisher state for
 // RPC and observability. Order is sorted by publisher master key for
 // stable output. Safe to call concurrently with ingest.

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -254,6 +254,15 @@ type Aggregator struct {
 	// out of the union.
 	lastEmitted [][33]byte
 
+	// unlBlocked mirrors rippled's NetworkOPs unlBlocked_ flag
+	// (NetworkOPs.cpp:750). It is the sticky UNL lock-down maintained by
+	// updateTrusted: latched when a configured publisher's live list expires
+	// (ValidatorList.cpp:1996-2001) or the trusted union empties
+	// (ValidatorList.cpp:2096-2101), cleared only when every configured
+	// publisher again carries an available list (ValidatorList.cpp:2002-2006).
+	// Maintained under a.mu by recomputeAndEmitLocked; read via IsUNLBlocked.
+	unlBlocked bool
+
 	// clock returns the wall-clock time the aggregator uses to gate
 	// effective / expiration comparisons. Overridable for tests.
 	clock func() time.Time
@@ -417,35 +426,21 @@ func (a *Aggregator) HasConfiguredPublishers() bool {
 	return len(a.publishers) > 0
 }
 
-// IsUNLBlocked reports whether the node has a configured UNL it can no longer
-// trust — the goXRPL analog of rippled's NetworkOPs UNL-blocked flag, set in
-// ValidatorList::updateTrusted (ValidatorList.cpp:1996-2001, 2095-2100). It is
-// true when at least one configured publisher has already produced a list (so
-// the UNL is "live") and either that list has expired or the effective trusted
-// union is now empty. A node that has never ingested a list (fresh startup) or
-// has no publishers configured is NOT blocked, mirroring rippled where the flag
-// only fires once publisherLists_ is non-empty.
+// IsUNLBlocked reports rippled's NetworkOPs UNL-blocked flag
+// (NetworkOPs.cpp:1862-1864) — the sticky lock-down maintained by
+// ValidatorList::updateTrusted and mirrored here in recomputeAndEmitLocked. It
+// latches true the moment a configured publisher's live list expires
+// (ValidatorList.cpp:1996-2001) or the effective trusted union becomes empty
+// (ValidatorList.cpp:2096-2101), and clears only once every configured
+// publisher again carries an available list (ValidatorList.cpp:2002-2006). A
+// node with no publishers configured is never blocked. The flag is sticky on
+// purpose: rippled prioritizes safety over liveness, so e.g. a publisher
+// revoked after its list expired keeps the node blocked even while another
+// publisher stays healthy — a state a stateless snapshot cannot reproduce.
 func (a *Aggregator) IsUNLBlocked() bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-
-	active := false
-	anyExpired := false
-	for _, s := range a.state {
-		switch s.Status {
-		case StatusUnavailable:
-			// Configured but no list ingested yet — does not count as live.
-		case StatusExpired:
-			active = true
-			anyExpired = true
-		default: // available / revoked — a list has been ingested
-			active = true
-		}
-	}
-	if !active {
-		return false
-	}
-	return anyExpired || len(a.lastEmitted) == 0
+	return a.unlBlocked
 }
 
 // PublisherSnapshot returns a deep copy of the per-publisher state for
@@ -1106,6 +1101,30 @@ func (a *Aggregator) recomputeAndEmitLocked() {
 	for _, s := range a.state {
 		a.promoteRemainingLocked(s, now)
 	}
+
+	// UNL-blocked accounting — mirrors rippled updateTrusted's per-publisher
+	// expiry pass and lock-down flag (ValidatorList.cpp:1929-2006, 2096-2101).
+	// good holds only while every configured publisher carries a live list; a
+	// list that times out flips to expired and latches the block immediately
+	// (line 1970 clears the list, 1996-2001 sets the flag), and the flag clears
+	// only when all publishers are available again — safety over liveness. Run
+	// before the no-op early-out below so the flag tracks state even when the
+	// trusted union is unchanged.
+	good := true
+	for _, s := range a.state {
+		if s.Status == StatusAvailable && !s.Expiration.IsZero() && !s.Expiration.After(now) {
+			s.Status = StatusExpired
+			s.Validators = nil
+			a.unlBlocked = true
+		}
+		if s.Status != StatusAvailable {
+			good = false
+		}
+	}
+	if good {
+		a.unlBlocked = false
+	}
+
 	counts := make(map[[33]byte]int, 64)
 	for _, s := range a.state {
 		if s.Status != StatusAvailable {
@@ -1138,6 +1157,15 @@ func (a *Aggregator) recomputeAndEmitLocked() {
 	sort.Slice(trusted, func(i, j int) bool {
 		return string(trusted[i][:]) < string(trusted[j][:])
 	})
+
+	// "No validators. Lock down." — publishers are configured (guaranteed by
+	// the guard above) but the effective trusted union is empty
+	// (ValidatorList.cpp:2096-2101). Latch after the good/clear pass so an
+	// empty union always wins, matching rippled's ordering (clear at line 2006,
+	// then set at 2100).
+	if len(trusted) == 0 {
+		a.unlBlocked = true
+	}
 
 	if mastersEqual(trusted, a.lastEmitted) {
 		return

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -254,13 +254,9 @@ type Aggregator struct {
 	// out of the union.
 	lastEmitted [][33]byte
 
-	// unlBlocked mirrors rippled's NetworkOPs unlBlocked_ flag
-	// (NetworkOPs.cpp:750). It is the sticky UNL lock-down maintained by
-	// updateTrusted: latched when a configured publisher's live list expires
-	// (ValidatorList.cpp:1996-2001) or the trusted union empties
-	// (ValidatorList.cpp:2096-2101), cleared only when every configured
-	// publisher again carries an available list (ValidatorList.cpp:2002-2006).
-	// Maintained under a.mu by recomputeAndEmitLocked; read via IsUNLBlocked.
+	// unlBlocked mirrors rippled's NetworkOPs unlBlocked_ (NetworkOPs.cpp:750):
+	// the sticky UNL lock-down. Maintained under a.mu by recomputeAndEmitLocked;
+	// read via IsUNLBlocked, which documents the set/clear semantics.
 	unlBlocked bool
 
 	// clock returns the wall-clock time the aggregator uses to gate

--- a/internal/validator/list/unl_blocked_test.go
+++ b/internal/validator/list/unl_blocked_test.go
@@ -1,58 +1,166 @@
 package list
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
+// TestAggregator_IsUNLBlocked drives the sticky UNL-blocked flag through the
+// real Tick → recomputeAndEmitLocked path, asserting it mirrors rippled's
+// NetworkOPs unlBlocked_ as maintained by ValidatorList::updateTrusted
+// (ValidatorList.cpp:1929-2006, 2096-2101).
 func TestAggregator_IsUNLBlocked(t *testing.T) {
 	pk1 := PublisherKey{1}
 	pk2 := PublisherKey{2}
-	nonEmptyUnion := [][33]byte{{9}}
+	val := [][33]byte{{9}}
 
-	cases := []struct {
-		name        string
-		state       map[PublisherKey]*PublisherState
-		lastEmitted [][33]byte
-		want        bool
-	}{
-		{
-			name:  "no publishers configured",
-			state: map[PublisherKey]*PublisherState{},
-			want:  false,
-		},
-		{
-			name:  "configured but no list ingested yet",
-			state: map[PublisherKey]*PublisherState{pk1: {Status: StatusUnavailable}},
-			want:  false,
-		},
-		{
-			name:        "available list with non-empty union",
-			state:       map[PublisherKey]*PublisherState{pk1: {Status: StatusAvailable}},
-			lastEmitted: nonEmptyUnion,
-			want:        false,
-		},
-		{
-			name:  "available list but empty union",
-			state: map[PublisherKey]*PublisherState{pk1: {Status: StatusAvailable}},
-			want:  true,
-		},
-		{
-			name:        "expired list blocks even with a non-empty union",
-			state:       map[PublisherKey]*PublisherState{pk1: {Status: StatusAvailable}, pk2: {Status: StatusExpired}},
-			lastEmitted: nonEmptyUnion,
-			want:        true,
-		},
-		{
-			name:  "revoked sole publisher with empty union",
-			state: map[PublisherKey]*PublisherState{pk1: {Status: StatusRevoked}},
-			want:  true,
-		},
+	newAgg := func(now *time.Time, pubs ...PublisherKey) *Aggregator {
+		a := &Aggregator{
+			publishers: map[PublisherKey]struct{}{},
+			state:      map[PublisherKey]*PublisherState{},
+			threshold:  1,
+			clock:      func() time.Time { return *now },
+		}
+		for _, p := range pubs {
+			a.publishers[p] = struct{}{}
+			a.state[p] = &PublisherState{MasterKey: p, Status: StatusUnavailable}
+		}
+		return a
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			a := &Aggregator{state: tc.state, lastEmitted: tc.lastEmitted}
-			if got := a.IsUNLBlocked(); got != tc.want {
-				t.Errorf("IsUNLBlocked() = %v, want %v", got, tc.want)
-			}
-		})
-	}
+	t.Run("no publishers configured -> not blocked", func(t *testing.T) {
+		now := time.Unix(1000, 0)
+		a := newAgg(&now)
+		a.Tick()
+		if a.IsUNLBlocked() {
+			t.Fatal("a node with no configured publishers must never be blocked")
+		}
+	})
+
+	t.Run("fresh start, configured but no list ingested -> blocked", func(t *testing.T) {
+		now := time.Unix(1000, 0)
+		a := newAgg(&now, pk1)
+		a.Tick()
+		if !a.IsUNLBlocked() {
+			t.Fatal("rippled locks down when publishers are configured but the trusted union is empty (ValidatorList.cpp:2096-2101)")
+		}
+	})
+
+	t.Run("available publisher with non-empty union -> not blocked", func(t *testing.T) {
+		now := time.Unix(1000, 0)
+		a := newAgg(&now, pk1)
+		s := a.state[pk1]
+		s.Status = StatusAvailable
+		s.Validators = val
+		s.Expiration = now.Add(time.Hour)
+		a.Tick()
+		if a.IsUNLBlocked() {
+			t.Fatal("a healthy publisher with a non-empty union must clear the block")
+		}
+	})
+
+	t.Run("available publisher but empty union -> blocked", func(t *testing.T) {
+		now := time.Unix(1000, 0)
+		a := newAgg(&now, pk1)
+		s := a.state[pk1]
+		s.Status = StatusAvailable
+		s.Validators = nil
+		s.Expiration = now.Add(time.Hour)
+		a.Tick()
+		if !a.IsUNLBlocked() {
+			t.Fatal("an available publisher yielding no trusted validators must lock down")
+		}
+	})
+
+	t.Run("multi-publisher clock-expiry latches and stays blocked", func(t *testing.T) {
+		now := time.Unix(1000, 0)
+		a := newAgg(&now, pk1, pk2)
+		for _, p := range []PublisherKey{pk1, pk2} {
+			s := a.state[p]
+			s.Status = StatusAvailable
+			s.Validators = val
+		}
+		a.state[pk1].Expiration = now.Add(2 * time.Hour)
+		a.state[pk2].Expiration = now.Add(time.Hour)
+		a.Tick()
+		if a.IsUNLBlocked() {
+			t.Fatal("two healthy publishers must not be blocked")
+		}
+
+		// Advance past pk2's expiry; pk1 is still valid. rippled flips pk2 to
+		// expired and sets the block (1996-2001); because good is now false it
+		// never clears, even though pk1 still yields a non-empty union.
+		now = now.Add(90 * time.Minute)
+		a.Tick()
+		if !a.IsUNLBlocked() {
+			t.Fatal("a list expiring by clock must lock the node down even though pk1 is still healthy (ValidatorList.cpp:1996-2001, good=false)")
+		}
+		if a.state[pk2].Status != StatusExpired {
+			t.Fatalf("expected pk2 flipped to StatusExpired, got %v", a.state[pk2].Status)
+		}
+
+		// Stays latched on a subsequent tick while pk2 is non-available.
+		now = now.Add(time.Minute)
+		a.Tick()
+		if !a.IsUNLBlocked() {
+			t.Fatal("block must stay latched while any publisher is non-available")
+		}
+	})
+
+	t.Run("clears once every publisher available again", func(t *testing.T) {
+		now := time.Unix(1000, 0)
+		a := newAgg(&now, pk1)
+		s := a.state[pk1]
+		s.Status = StatusAvailable
+		s.Validators = val
+		s.Expiration = now.Add(time.Hour)
+		a.Tick()
+
+		now = now.Add(2 * time.Hour) // expire it
+		a.Tick()
+		if !a.IsUNLBlocked() {
+			t.Fatal("expected blocked after the sole publisher's list expired")
+		}
+
+		s.Status = StatusAvailable // renewed list
+		s.Validators = val
+		s.Expiration = now.Add(time.Hour)
+		a.Tick()
+		if a.IsUNLBlocked() {
+			t.Fatal("a renewed available list for every publisher must clear the block (ValidatorList.cpp:2002-2006)")
+		}
+	})
+
+	t.Run("expired-then-revoked stays blocked", func(t *testing.T) {
+		now := time.Unix(1000, 0)
+		a := newAgg(&now, pk1, pk2)
+		for _, p := range []PublisherKey{pk1, pk2} {
+			s := a.state[p]
+			s.Status = StatusAvailable
+			s.Validators = val
+			s.Expiration = now.Add(time.Hour)
+		}
+		a.Tick()
+		if a.IsUNLBlocked() {
+			t.Fatal("two healthy publishers must not be blocked")
+		}
+
+		// pk2 expires by clock; keep pk1 healthy with a future expiry.
+		now = now.Add(2 * time.Hour)
+		a.state[pk1].Status = StatusAvailable
+		a.state[pk1].Expiration = now.Add(time.Hour)
+		a.Tick()
+		if !a.IsUNLBlocked() {
+			t.Fatal("expected blocked after pk2 expiry")
+		}
+
+		// pk2's master key is now revoked — its status leaves Expired, so a
+		// stateless snapshot would clear the block. rippled stays blocked
+		// because clearing requires ALL publishers available (good=false).
+		a.state[pk2].Status = StatusRevoked
+		a.Tick()
+		if !a.IsUNLBlocked() {
+			t.Fatal("a revoked-after-expiry publisher must keep the node blocked while another stays healthy (ValidatorList.cpp:2002-2006)")
+		}
+	})
 }

--- a/internal/validator/list/unl_blocked_test.go
+++ b/internal/validator/list/unl_blocked_test.go
@@ -1,0 +1,58 @@
+package list
+
+import "testing"
+
+func TestAggregator_IsUNLBlocked(t *testing.T) {
+	pk1 := PublisherKey{1}
+	pk2 := PublisherKey{2}
+	nonEmptyUnion := [][33]byte{{9}}
+
+	cases := []struct {
+		name        string
+		state       map[PublisherKey]*PublisherState
+		lastEmitted [][33]byte
+		want        bool
+	}{
+		{
+			name:  "no publishers configured",
+			state: map[PublisherKey]*PublisherState{},
+			want:  false,
+		},
+		{
+			name:  "configured but no list ingested yet",
+			state: map[PublisherKey]*PublisherState{pk1: {Status: StatusUnavailable}},
+			want:  false,
+		},
+		{
+			name:        "available list with non-empty union",
+			state:       map[PublisherKey]*PublisherState{pk1: {Status: StatusAvailable}},
+			lastEmitted: nonEmptyUnion,
+			want:        false,
+		},
+		{
+			name:  "available list but empty union",
+			state: map[PublisherKey]*PublisherState{pk1: {Status: StatusAvailable}},
+			want:  true,
+		},
+		{
+			name:        "expired list blocks even with a non-empty union",
+			state:       map[PublisherKey]*PublisherState{pk1: {Status: StatusAvailable}, pk2: {Status: StatusExpired}},
+			lastEmitted: nonEmptyUnion,
+			want:        true,
+		},
+		{
+			name:  "revoked sole publisher with empty union",
+			state: map[PublisherKey]*PublisherState{pk1: {Status: StatusRevoked}},
+			want:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Aggregator{state: tc.state, lastEmitted: tc.lastEmitted}
+			if got := a.IsUNLBlocked(); got != tc.want {
+				t.Errorf("IsUNLBlocked() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #561 (merged). Completes the final branch of rippled's
`RPC::conditionMet` that #561 deliberately deferred: `rpcEXPIRED_VALIDATOR_LIST`
when the node's UNL is blocked.

## Summary
- Add `Aggregator.IsUNLBlocked`, the goXRPL analog of rippled's
  `NetworkOPs::isUNLBlocked` driven by `ValidatorList::updateTrusted`
  (ValidatorList.cpp:1996-2001, 2095-2100): true when a configured publisher has
  produced a list (the UNL is live) and that list has since expired **or** the
  effective trusted union is empty. A node that never ingested a list, or has no
  publishers configured, is **not** blocked — matching rippled, where the flag
  only fires once `publisherLists_` is non-empty.
- Add the `rpcEXPIRED_VALIDATOR_LIST` error code (token `"unlBlocked"`, matching
  rippled `rpcEXPIRED_VALIDATOR_LIST = 80`).
- Expose it via `ServiceContainer.UNLBlocked` (nil-safe; nil in standalone /
  RPC-only) and check it in `conditionMet` right after the amendment-blocked
  check, mirroring rippled's order.
- Wire `services.UNLBlocked` from the validator-list aggregator in the
  non-standalone server path, when a publisher list is configured.

## Test plan
- [x] `go build ./...`, `gofmt`, `go vet` clean
- [x] `Aggregator.IsUNLBlocked` table test (no publishers / not-yet-ingested /
      available+union / available+empty-union / expired / revoked)
- [x] `conditionMet` UNL cases: blocked → `rpcEXPIRED_VALIDATOR_LIST`; not
      blocked → passes; amendment-blocked takes precedence

Part of #557.