### PR TITLE
implement ledger_request (trigger ledger acquisition from peers)

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -549,6 +549,7 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		if router := consensusComponents.Router; router != nil {
 			services.FetchInfo = router.FetchInfo
 			services.FetchInfoClear = router.ClearFetchInfo
+			services.RequestLedger = router.RequestLedger
 		}
 
 		// Expose the validator-manifest cache to the `manifest` RPC.

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -1807,7 +1807,7 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 		return
 	}
 
-	il, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
+	_, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
 		return inbound.New(hash, seq, peerID, r.logger)
 	})
 	if !created {
@@ -1825,7 +1825,6 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 		r.logger.Warn("failed to request ledger base from peer", "error", err)
 		r.fetchTracker.Remove(hash, false)
 	}
-	_ = il
 }
 
 // FetchInfo returns the inbound-ledger acquisition snapshot served by the
@@ -1841,39 +1840,78 @@ func (r *Router) ClearFetchInfo() {
 }
 
 // RequestLedger triggers (or joins) a generic acquisition of a ledger from
-// peers, backing the ledger_request RPC. It mirrors rippled
-// InboundLedgers::acquire(hash, seq, Reason::GENERIC): when hash is zero the
-// target is resolved from the validated ledger's skip list, a source peer is
-// selected, and a ReasonGeneric acquisition is started (or the in-flight one
-// reused). It returns the per-acquisition snapshot (rippled
-// InboundLedger::getJson shape) and started=true while the acquisition is in
-// flight, or (nil,false) when the target can't be resolved or no peer is
-// available. Safe to call from an RPC goroutine: the registry and each
-// acquisition guard their own state.
-func (r *Router) RequestLedger(hash [32]byte, seq uint32) (map[string]any, bool) {
-	// Resolve sequence → hash against the validated ledger when only a
-	// sequence was supplied (rippled's hashOfSeq via getLedgerByContext).
+// peers, backing the ledger_request RPC. It mirrors rippled getLedgerByContext
+// (RPCHelpers.cpp:1027) over InboundLedgers::acquire(..., Reason::GENERIC):
+// when hash is zero the target is resolved from the validated ledger's skip
+// list, and a ReasonGeneric acquisition is started (or the in-flight one
+// reused). started=true while an acquisition is in flight; (nil,false,false)
+// when the target can't be resolved or no peer is available.
+//
+// reference distinguishes rippled's two acquiring shapes: false when the
+// snapshot is the target ledger itself (rippled returns the bare getJson(0),
+// RPCHelpers.cpp:1137-1138); true when it is a 256-aligned reference ledger
+// being fetched only to learn the target's hash (rippled wraps it as
+// lgrNotFound + acquiring, RPCHelpers.cpp:1093-1110).
+//
+// Safe to call from an RPC goroutine: the registry and each acquisition guard
+// their own state.
+func (r *Router) RequestLedger(hash [32]byte, seq uint32) (acquiring map[string]any, started, reference bool) {
 	if hash == ([32]byte{}) {
 		if seq == 0 {
-			return nil, false
+			return nil, false, false
 		}
 		svc := r.adaptor.LedgerService()
 		if svc == nil {
-			return nil, false
+			return nil, false, false
 		}
 		vl := svc.GetValidatedLedger()
 		if vl == nil {
-			return nil, false
+			return nil, false, false
 		}
 		h, ok, err := vl.HashOfSeq(seq)
-		if err != nil || !ok {
-			return nil, false
+		if err != nil {
+			return nil, false, false
+		}
+		if !ok {
+			// seq is past the rolling window and not 256-aligned, so its hash
+			// isn't directly in the validated ledger. Resolve it through a
+			// 256-aligned reference ledger whose hash IS enshrined in the skip
+			// list (rippled getCandidateLedger, RPCHelpers.cpp:1081-1117).
+			refIndex := getCandidateLedger(seq)
+			refHash, refOK, err := vl.HashOfSeq(refIndex)
+			if err != nil || !refOK {
+				return nil, false, false
+			}
+			refLedger, err := svc.GetLedgerByHash(refHash)
+			if err != nil || refLedger == nil {
+				// We lack the reference ledger needed to learn the target's
+				// hash — acquire it and report it as the in-flight reference.
+				if snap, ok := r.startGenericAcquisition(refHash, refIndex); ok {
+					return snap, true, true
+				}
+				return nil, false, false
+			}
+			h, ok, err = refLedger.HashOfSeq(seq)
+			if err != nil || !ok {
+				return nil, false, false
+			}
 		}
 		hash = h
 	}
 
-	// Already acquiring this hash (consensus catch-up or a prior request)?
-	// Report its live progress rather than starting a duplicate.
+	if snap, ok := r.startGenericAcquisition(hash, seq); ok {
+		return snap, true, false
+	}
+	return nil, false, false
+}
+
+// startGenericAcquisition begins (or joins) a ReasonGeneric acquisition for
+// hash, issuing a base fetch from a selected peer only when it creates a fresh
+// one. Returns the acquisition snapshot, or ok=false when no peer is available
+// or the initial fetch could not be issued. The fetchTracker's GetOrCreate is
+// atomic, so a concurrent consensus catch-up arming the same hash is joined
+// rather than duplicated.
+func (r *Router) startGenericAcquisition(hash [32]byte, seq uint32) (map[string]any, bool) {
 	if il := r.fetchTracker.Find(hash); il != nil {
 		return inbound.AcquisitionJSON(il.Snapshot()), true
 	}
@@ -1899,6 +1937,14 @@ func (r *Router) RequestLedger(hash [32]byte, seq uint32) (map[string]any, bool)
 		}
 	}
 	return inbound.AcquisitionJSON(il.Snapshot()), true
+}
+
+// getCandidateLedger rounds seq up to the next multiple of 256 — the nearest
+// ancestor whose hash is enshrined in the historical skip list and is therefore
+// easy to resolve, then close enough (within 256) to hold seq's hash in its own
+// rolling list. Mirrors rippled getCandidateLedger (View.h:430).
+func getCandidateLedger(seq uint32) uint32 {
+	return (seq + 255) &^ 255
 }
 
 // selectAcquisitionPeer picks a connected peer to fetch a ledger from,

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -51,13 +51,6 @@ type Router struct {
 	peersMu    sync.RWMutex
 	peerStates map[peermanagement.PeerID]*peerLedgerState
 
-	// Active legacy inbound ledger acquisition (nil when not acquiring).
-	// Only one legacy acquisition runs at a time; the single-goroutine
-	// handleMessage loop keeps that invariant trivially. Orthogonal to
-	// replayer — a legacy acquisition and any number of replay-delta
-	// acquisitions can coexist.
-	inboundLedger *inbound.Ledger
-
 	// replayer coordinates concurrent mtREPLAY_DELTA_REQUEST acquisitions
 	// keyed by target ledger hash, under a configurable concurrency cap.
 	// Replaces the single-slot inboundReplayDelta field from Gap 6 so a
@@ -65,10 +58,17 @@ type Router struct {
 	// serializing. Mirrors rippled's LedgerReplayer.
 	replayer *inbound.Replayer
 
-	// fetchTracker aggregates the classic legacy acquisitions for the
-	// fetch_info RPC (rippled's InboundLedgers). Populated from this
-	// goroutine via Track; queried from RPC goroutines via FetchInfo,
-	// which reads the acquisitions' own mutex-guarded state.
+	// fetchTracker is the registry of classic header+state+tx ledger
+	// acquisitions, keyed by ledger hash — goXRPL's analogue of rippled's
+	// InboundLedgers. It is both the active in-flight set (the router routes
+	// inbound TMLedgerData to the matching acquisition via Find, and starts
+	// new ones via GetOrCreate) and the source of the fetch_info snapshot.
+	// Consensus catch-up drives it from the single inbox goroutine; the
+	// RPC-driven ledger_request path (RequestLedger) starts ReasonGeneric
+	// acquisitions from RPC goroutines. Both go through the tracker's own
+	// mutex, and each acquisition guards its own state, so concurrent access
+	// is safe. Orthogonal to replayer — legacy and replay-delta acquisitions
+	// can coexist.
 	fetchTracker *inbound.Tracker
 
 	// messageSeen dedups inbound proposal / validation payloads so the
@@ -419,18 +419,18 @@ func (r *Router) maintenanceTick() {
 		r.AbortActiveReplayTask(errors.New("skip-list timed out"))
 	}
 
-	// Reap a stuck legacy inbound ledger. Without this a single stalled
-	// acquisition blocks startLedgerAcquisitionLegacy from arming a new
-	// request for the SAME hash on the next statusChange — and blocks
-	// the replay-delta path too via isAcquiring's inboundLedger check.
-	// Matches the spirit of rippled's InboundLedgers timeout sweeps.
-	if il := r.inboundLedger; il != nil && il.IsTimedOut() {
+	// Reap stuck legacy inbound ledgers. Without this a stalled acquisition
+	// blocks startLedgerAcquisitionLegacy from arming a new request for the
+	// SAME hash on the next statusChange — and blocks the replay-delta path
+	// too via isAcquiring's registry check. Matches the spirit of rippled's
+	// InboundLedgers timeout sweeps.
+	for _, il := range r.fetchTracker.ActiveTimedOut() {
 		r.logger.Warn("legacy inbound ledger acquisition timed out",
 			"seq", il.Seq(),
 			"hash", fmt.Sprintf("%x", il.Hash()),
 			"peer", il.PeerID(),
 		)
-		r.inboundLedger = nil
+		r.fetchTracker.Remove(il.Hash(), false)
 		// Do NOT re-issue from here: legacy has no retry partner, and
 		// the next statusChange from any peer will naturally arm a
 		// fresh acquisition via startLedgerAcquisition once the stuck
@@ -1681,8 +1681,8 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 		// recovery path where the node asks a peer for the fork it's
 		// seeing network consensus on. Only fire if we're NOT already
 		// acquiring that hash (startLedgerAcquisition dedupes internally
-		// via the replayer / inboundLedger guards, but checking here
-		// saves a lookup in the hot path).
+		// via the replayer / acquisition-registry guards, but checking
+		// here saves a lookup in the hot path).
 		svc := r.adaptor.LedgerService()
 		if svc != nil && sc.LedgerSeq > 1 && len(sc.LedgerHash) == 32 {
 			closed := svc.GetClosedLedger()
@@ -1756,7 +1756,7 @@ func (r *Router) isAcquiring(hash [32]byte) bool {
 	if r.replayer.Has(hash) {
 		return true
 	}
-	if r.inboundLedger != nil && r.inboundLedger.Hash() == hash {
+	if r.fetchTracker.Find(hash) != nil {
 		return true
 	}
 	return false
@@ -1807,19 +1807,12 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 		return
 	}
 
-	// If already acquiring this exact hash, skip
-	if r.inboundLedger != nil {
-		if r.inboundLedger.Hash() == hash {
-			return
-		}
-		// Acquiring a different (older) hash — abandon it for the newer one
-		if r.inboundLedger.IsTimedOut() {
-			r.logger.Info("inbound ledger: timed out, retrying with new peer",
-				"old_seq", r.inboundLedger.Seq(),
-				"new_seq", seq,
-			)
-		}
-		r.inboundLedger = nil
+	il, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
+		return inbound.New(hash, seq, peerID, r.logger)
+	})
+	if !created {
+		// Already acquiring this hash (consensus or a prior arm).
+		return
 	}
 
 	r.logger.Info("starting ledger acquisition (legacy)",
@@ -1828,12 +1821,11 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 		"peer", peerID,
 	)
 
-	r.inboundLedger = inbound.New(hash, seq, peerID, r.logger)
-	r.fetchTracker.Track(r.inboundLedger)
 	if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, hash, seq); err != nil {
 		r.logger.Warn("failed to request ledger base from peer", "error", err)
-		r.inboundLedger = nil
+		r.fetchTracker.Remove(hash, false)
 	}
+	_ = il
 }
 
 // FetchInfo returns the inbound-ledger acquisition snapshot served by the
@@ -1846,6 +1838,89 @@ func (r *Router) FetchInfo() map[string]any {
 // backing fetch_info's `clear` param.
 func (r *Router) ClearFetchInfo() {
 	r.fetchTracker.Clear()
+}
+
+// RequestLedger triggers (or joins) a generic acquisition of a ledger from
+// peers, backing the ledger_request RPC. It mirrors rippled
+// InboundLedgers::acquire(hash, seq, Reason::GENERIC): when hash is zero the
+// target is resolved from the validated ledger's skip list, a source peer is
+// selected, and a ReasonGeneric acquisition is started (or the in-flight one
+// reused). It returns the per-acquisition snapshot (rippled
+// InboundLedger::getJson shape) and started=true while the acquisition is in
+// flight, or (nil,false) when the target can't be resolved or no peer is
+// available. Safe to call from an RPC goroutine: the registry and each
+// acquisition guard their own state.
+func (r *Router) RequestLedger(hash [32]byte, seq uint32) (map[string]any, bool) {
+	// Resolve sequence → hash against the validated ledger when only a
+	// sequence was supplied (rippled's hashOfSeq via getLedgerByContext).
+	if hash == ([32]byte{}) {
+		if seq == 0 {
+			return nil, false
+		}
+		svc := r.adaptor.LedgerService()
+		if svc == nil {
+			return nil, false
+		}
+		vl := svc.GetValidatedLedger()
+		if vl == nil {
+			return nil, false
+		}
+		h, ok, err := vl.HashOfSeq(seq)
+		if err != nil || !ok {
+			return nil, false
+		}
+		hash = h
+	}
+
+	// Already acquiring this hash (consensus catch-up or a prior request)?
+	// Report its live progress rather than starting a duplicate.
+	if il := r.fetchTracker.Find(hash); il != nil {
+		return inbound.AcquisitionJSON(il.Snapshot()), true
+	}
+
+	peerID, ok := r.selectAcquisitionPeer(seq)
+	if !ok {
+		return nil, false
+	}
+
+	il, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
+		return inbound.NewGeneric(hash, seq, peerID, r.logger)
+	})
+	if created {
+		r.logger.Info("starting ledger acquisition (generic, ledger_request)",
+			"seq", seq,
+			"hash", fmt.Sprintf("%x", hash[:8]),
+			"peer", peerID,
+		)
+		if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, hash, seq); err != nil {
+			r.logger.Warn("ledger_request: failed to request ledger base", "error", err)
+			r.fetchTracker.Remove(hash, false)
+			return nil, false
+		}
+	}
+	return inbound.AcquisitionJSON(il.Snapshot()), true
+}
+
+// selectAcquisitionPeer picks a connected peer to fetch a ledger from,
+// preferring one whose reported ledger is at or beyond the target sequence
+// (and therefore likely to hold it). When seq is unknown (0) or no peer is far
+// enough along, it falls back to any connected peer. Returns (0,false) when no
+// peer has reported a ledger state.
+func (r *Router) selectAcquisitionPeer(seq uint32) (uint64, bool) {
+	r.peersMu.RLock()
+	defer r.peersMu.RUnlock()
+
+	var fallback uint64
+	var haveFallback bool
+	for pid, st := range r.peerStates {
+		if !haveFallback {
+			fallback, haveFallback = uint64(pid), true
+		}
+		if seq == 0 || st.LedgerSeq >= seq {
+			return uint64(pid), true
+		}
+	}
+	return fallback, haveFallback
 }
 
 // handleReplayDeltaResponse verifies an inbound mtREPLAY_DELTA_RESPONSE
@@ -2199,12 +2274,20 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 		return
 	}
 
+	// Route to the matching acquisition by ledger hash (registry lookup).
+	var il *inbound.Ledger
+	if len(ld.LedgerHash) == 32 {
+		var h [32]byte
+		copy(h[:], ld.LedgerHash)
+		il = r.fetchTracker.Find(h)
+	}
+
 	r.logger.Info("received ledger data",
 		"peer", msg.PeerID,
 		"seq", ld.LedgerSeq,
 		"nodes", len(ld.Nodes),
 		"itype", ld.InfoType,
-		"has_inbound", r.inboundLedger != nil,
+		"has_inbound", il != nil,
 	)
 
 	// liTS_CANDIDATE response — InboundTransactions::gotData feeds the
@@ -2214,9 +2297,9 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 		return
 	}
 
-	// Feed data to active inbound ledger acquisition
-	if r.inboundLedger != nil {
-		if r.handleInboundLedgerData(ld) {
+	// Feed data to the matching inbound ledger acquisition
+	if il != nil {
+		if r.handleInboundLedgerData(il, ld) {
 			return
 		}
 		// If handleInboundLedgerData returned false (e.g. GotBase failed),
@@ -2253,22 +2336,12 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 	}
 }
 
-// handleInboundLedgerData feeds LedgerData to the active InboundLedger acquisition.
-// Returns true if the data was consumed by the acquisition.
-func (r *Router) handleInboundLedgerData(ld *message.LedgerData) bool {
-	il := r.inboundLedger
+// handleInboundLedgerData feeds LedgerData to the given InboundLedger
+// acquisition (already matched by hash in handleLedgerData). Returns true if
+// the data was consumed by the acquisition.
+func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerData) bool {
 	if il == nil {
 		return false
-	}
-
-	// Verify the response is for our active acquisition
-	if len(ld.LedgerHash) == 32 {
-		expectedHash := il.Hash()
-		var responseHash [32]byte
-		copy(responseHash[:], ld.LedgerHash)
-		if responseHash != expectedHash {
-			return false // Not for us
-		}
 	}
 
 	switch ld.InfoType {
@@ -2276,20 +2349,20 @@ func (r *Router) handleInboundLedgerData(ld *message.LedgerData) bool {
 		// Phase 1: Got header + root nodes
 		if len(ld.Nodes) < 2 {
 			// Response doesn't include root nodes — can't do full acquisition.
-			// Clear inbound and fall through to legacy adoption.
+			// Drop the acquisition and fall through to legacy adoption.
 			r.logger.Debug("inbound ledger: response has < 2 nodes, falling back", "nodes", len(ld.Nodes))
-			r.inboundLedger = nil
+			r.fetchTracker.Remove(il.Hash(), false)
 			return false
 		}
 		if err := il.GotBase(ld.Nodes); err != nil {
 			r.logger.Warn("inbound ledger: GotBase failed, falling back", "error", err)
 			r.adaptor.IncPeerBadData(il.PeerID(), "ledger-data-base")
-			r.inboundLedger = nil
+			r.fetchTracker.Remove(il.Hash(), false)
 			return false
 		}
 
 		if il.IsComplete() {
-			r.completeInboundLedger()
+			r.completeInboundLedger(il)
 			return true
 		}
 
@@ -2307,7 +2380,7 @@ func (r *Router) handleInboundLedgerData(ld *message.LedgerData) bool {
 		}
 
 		if il.IsComplete() {
-			r.completeInboundLedger()
+			r.completeInboundLedger(il)
 			return true
 		}
 
@@ -2323,7 +2396,7 @@ func (r *Router) handleInboundLedgerData(ld *message.LedgerData) bool {
 		}
 
 		if il.IsComplete() {
-			r.completeInboundLedger()
+			r.completeInboundLedger(il)
 			return true
 		}
 
@@ -2351,10 +2424,12 @@ func (r *Router) requestMissingAcquisitionNodes(il *inbound.Ledger) {
 	}
 }
 
-// completeInboundLedger finalizes an InboundLedger acquisition and adopts the ledger.
-func (r *Router) completeInboundLedger() {
-	il := r.inboundLedger
-	r.inboundLedger = nil
+// completeInboundLedger finalizes an InboundLedger acquisition and adopts the
+// ledger. A ReasonGeneric acquisition (RPC-driven, ledger_request) is persisted
+// for querying but does not flip operating mode or notify consensus, so an
+// arbitrary historical fetch can't disturb the active chain.
+func (r *Router) completeInboundLedger(il *inbound.Ledger) {
+	r.fetchTracker.Remove(il.Hash(), true)
 
 	h, stateMap, txMap, err := il.Result()
 	if err != nil {
@@ -2382,6 +2457,20 @@ func (r *Router) completeInboundLedger() {
 	res, err := svc.SubmitHeldAdoption(context.TODO(), h, stateMap, txMap)
 	if err != nil {
 		r.logger.Warn("inbound ledger: failed to adopt with state", "error", err)
+		return
+	}
+
+	// A generic (RPC-driven) acquisition is now persisted and queryable; it
+	// must not advance operating mode or feed consensus. rippled's
+	// InboundLedger with Reason::GENERIC likewise only stores the ledger.
+	if il.Reason() == inbound.ReasonGeneric {
+		r.logger.Info("acquired ledger (generic) with full state from peer",
+			"seq", h.LedgerIndex,
+			"hash", fmt.Sprintf("%x", h.Hash[:8]),
+		)
+		if res.Stashed {
+			r.armParentAcquisition(svc, res.ParentSeq, res.ParentHash, peerID)
+		}
 		return
 	}
 

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -68,7 +68,7 @@ func TestRouter_HashDivergenceAtSameSeq_AcquiresPeerTip(t *testing.T) {
 		"exactly one acquisition request must fire on hash divergence (replay=%d legacy=%d)",
 		len(replayCalls), len(legacyCalls))
 
-	assert.True(t, r.replayer.Has(peerHash) || r.inboundLedger != nil,
+	assert.True(t, r.replayer.Has(peerHash) || r.fetchTracker.Find(peerHash) != nil,
 		"an acquisition state machine must be armed for the peer's hash")
 
 	if len(replayCalls) > 0 {
@@ -96,7 +96,7 @@ func TestRouter_SameHashAtSameSeq_NoAcquisition(t *testing.T) {
 	assert.Empty(t, rs.replayCalls(), "no replay-delta request when hashes agree")
 	assert.Empty(t, rs.legacyCalls(), "no legacy request when hashes agree")
 	assert.Equal(t, 0, r.replayer.Count())
-	assert.Nil(t, r.inboundLedger)
+	assert.Nil(t, r.fetchTracker.Find(closed.Hash()))
 }
 
 // TestRouter_CheckBehindArmsAcquisition verifies the checkBehind fix:

--- a/internal/consensus/adaptor/router_ledger_request_test.go
+++ b/internal/consensus/adaptor/router_ledger_request_test.go
@@ -1,0 +1,62 @@
+package adaptor
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/inbound"
+	"github.com/LeJamon/goXRPLd/internal/peermanagement"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouter_RequestLedger_TriggersGenericAcquisition covers the ledger_request
+// coordinator: with a connected peer, a request for a missing ledger selects
+// that peer, issues a base fetch, registers a ReasonGeneric acquisition, and
+// reports the in-flight snapshot. A repeat request joins the same acquisition.
+func TestRouter_RequestLedger_TriggersGenericAcquisition(t *testing.T) {
+	r, _, rs, svc := makeRouter(t)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+
+	// Register a peer reporting our own tip — matching hash means no catch-up
+	// acquisition fires on its own, so any later base request is ours.
+	r.handleMessage(statusChangeMessage(t, peermanagement.PeerID(7), closed.Sequence(), closed.Hash()))
+	require.Empty(t, rs.legacyCalls())
+
+	var target [32]byte
+	target[0] = 0x42
+
+	snap, started := r.RequestLedger(target, 0)
+	require.True(t, started)
+	require.NotNil(t, snap)
+	assert.Equal(t, false, snap["have_header"])
+
+	calls := rs.legacyCalls()
+	require.Len(t, calls, 1, "exactly one base fetch must be issued")
+	assert.Equal(t, target, calls[0].hash)
+	assert.Equal(t, uint64(7), calls[0].peerID)
+
+	il := r.fetchTracker.Find(target)
+	require.NotNil(t, il, "the acquisition must be registered")
+	assert.Equal(t, inbound.ReasonGeneric, il.Reason())
+
+	// A second request joins the in-flight acquisition; no duplicate fetch.
+	_, started2 := r.RequestLedger(target, 0)
+	assert.True(t, started2)
+	assert.Len(t, rs.legacyCalls(), 1, "repeat request must not re-issue the fetch")
+}
+
+// TestRouter_RequestLedger_NoPeers verifies that with no connected peer the
+// coordinator reports it could not start an acquisition.
+func TestRouter_RequestLedger_NoPeers(t *testing.T) {
+	r, _, rs, _ := makeRouter(t)
+
+	var target [32]byte
+	target[0] = 0x99
+
+	snap, started := r.RequestLedger(target, 0)
+	assert.False(t, started)
+	assert.Nil(t, snap)
+	assert.Empty(t, rs.legacyCalls())
+	assert.Nil(t, r.fetchTracker.Find(target))
+}

--- a/internal/consensus/adaptor/router_ledger_request_test.go
+++ b/internal/consensus/adaptor/router_ledger_request_test.go
@@ -26,8 +26,9 @@ func TestRouter_RequestLedger_TriggersGenericAcquisition(t *testing.T) {
 	var target [32]byte
 	target[0] = 0x42
 
-	snap, started := r.RequestLedger(target, 0)
+	snap, started, reference := r.RequestLedger(target, 0)
 	require.True(t, started)
+	require.False(t, reference, "a by-hash request acquires the target itself, not a reference ledger")
 	require.NotNil(t, snap)
 	assert.Equal(t, false, snap["have_header"])
 
@@ -41,7 +42,7 @@ func TestRouter_RequestLedger_TriggersGenericAcquisition(t *testing.T) {
 	assert.Equal(t, inbound.ReasonGeneric, il.Reason())
 
 	// A second request joins the in-flight acquisition; no duplicate fetch.
-	_, started2 := r.RequestLedger(target, 0)
+	_, started2, _ := r.RequestLedger(target, 0)
 	assert.True(t, started2)
 	assert.Len(t, rs.legacyCalls(), 1, "repeat request must not re-issue the fetch")
 }
@@ -54,7 +55,7 @@ func TestRouter_RequestLedger_NoPeers(t *testing.T) {
 	var target [32]byte
 	target[0] = 0x99
 
-	snap, started := r.RequestLedger(target, 0)
+	snap, started, _ := r.RequestLedger(target, 0)
 	assert.False(t, started)
 	assert.Nil(t, snap)
 	assert.Empty(t, rs.legacyCalls())

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -308,7 +308,7 @@ func TestRouter_NoParent_FallsBackToLegacy(t *testing.T) {
 	assert.Equal(t, uint32(99999), calls[0].seq)
 	assert.Equal(t, target, calls[0].hash)
 	assert.Equal(t, uint64(7), calls[0].peerID)
-	assert.NotNil(t, r.inboundLedger)
+	assert.NotNil(t, r.fetchTracker.Find(target))
 	assert.Equal(t, 0, r.replayer.Count(), "no replay-delta acquisition when no parent is available")
 }
 
@@ -337,7 +337,7 @@ func TestRouter_PeerDoesNotSupportReplay_FallsBackToLegacy(t *testing.T) {
 	assert.Equal(t, target, calls[0].hash)
 	assert.Equal(t, uint64(11), calls[0].peerID)
 	assert.Equal(t, 0, r.replayer.Count(), "replay-delta must not be armed")
-	assert.NotNil(t, r.inboundLedger, "legacy acquisition must be armed")
+	assert.NotNil(t, r.fetchTracker.Find(target), "legacy acquisition must be armed")
 }
 
 // TestRouter_ReplayDeltaResponse_Routed verifies that an inbound
@@ -405,7 +405,7 @@ func TestRouter_FallsBackToLegacyOnReplayFailure(t *testing.T) {
 	assert.Equal(t, 0, r.replayer.Count(), "failed verification must clear the replay state")
 	require.Len(t, rs.legacyCalls(), 1, "router must fall back to the legacy path")
 	assert.Equal(t, target, rs.legacyCalls()[0].hash)
-	assert.NotNil(t, r.inboundLedger)
+	assert.NotNil(t, r.fetchTracker.Find(target))
 }
 
 // TestRouter_MaintenanceTick_TimeoutFallback verifies that a stalled
@@ -522,7 +522,7 @@ func TestRouter_ReplayDeltaApply_StateMismatchFallsBack(t *testing.T) {
 	require.Len(t, rs.legacyCalls(), 1,
 		"router must fall back to the legacy path on state-map mismatch")
 	assert.Equal(t, tampered, rs.legacyCalls()[0].hash)
-	assert.NotNil(t, r.inboundLedger, "legacy acquisition must be armed for retry")
+	assert.NotNil(t, r.fetchTracker.Find(tampered), "legacy acquisition must be armed for retry")
 }
 
 // TestRouter_ConcurrentAcquisitions_RouteCorrectly verifies that two

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -17,6 +17,21 @@ import (
 
 const acquisitionTimeout = 10 * time.Second
 
+// Reason records why an acquisition was started, mirroring rippled's
+// InboundLedger::Reason. It governs completion handling: a consensus-driven
+// acquisition adopts the ledger into the active chain, while a generic
+// (RPC-driven, e.g. ledger_request) acquisition only persists it so it can be
+// queried without disturbing consensus state.
+type Reason int
+
+const (
+	// ReasonConsensus is catch-up / consensus-driven acquisition. Zero value
+	// so existing callers keep their behavior.
+	ReasonConsensus Reason = iota
+	// ReasonGeneric is an RPC-driven acquisition (rippled Reason::GENERIC).
+	ReasonGeneric
+)
+
 // State tracks the acquisition progress.
 type State int
 
@@ -49,6 +64,7 @@ type Ledger struct {
 	haveState bool
 	haveTx    bool
 	peerID    uint64
+	reason    Reason
 	state     State
 	err       error
 	created   time.Time
@@ -57,6 +73,7 @@ type Ledger struct {
 }
 
 // New creates a new InboundLedger acquisition for the given ledger hash.
+// The acquisition reason defaults to ReasonConsensus.
 func New(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger) *Ledger {
 	return &Ledger{
 		hash:    hash,
@@ -66,6 +83,19 @@ func New(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger) *Ledger 
 		created: time.Now(),
 		logger:  logger,
 	}
+}
+
+// NewGeneric creates an RPC-driven (ReasonGeneric) acquisition: on completion
+// the ledger is persisted for querying but not adopted into the active chain.
+func NewGeneric(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger) *Ledger {
+	l := New(hash, seq, peerID, logger)
+	l.reason = ReasonGeneric
+	return l
+}
+
+// Reason returns why this acquisition was started.
+func (l *Ledger) Reason() Reason {
+	return l.reason
 }
 
 // IsTimedOut returns true if the acquisition has been running too long.

--- a/internal/ledger/inbound/registry_test.go
+++ b/internal/ledger/inbound/registry_test.go
@@ -1,0 +1,93 @@
+package inbound
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestTracker_GetOrCreateDedupesByHash(t *testing.T) {
+	tr := NewTracker()
+	h := hashN(1)
+
+	calls := 0
+	factory := func() *Ledger {
+		calls++
+		return New(h, 10, 7, slog.Default())
+	}
+
+	first, created := tr.GetOrCreate(h, factory)
+	if !created || first == nil {
+		t.Fatalf("first GetOrCreate: created=%v ledger=%v", created, first)
+	}
+	second, created2 := tr.GetOrCreate(h, factory)
+	if created2 {
+		t.Fatalf("second GetOrCreate must reuse the in-flight acquisition")
+	}
+	if second != first {
+		t.Fatalf("second GetOrCreate returned a different ledger")
+	}
+	if calls != 1 {
+		t.Fatalf("factory ran %d times, want 1", calls)
+	}
+	if got := tr.Find(h); got != first {
+		t.Fatalf("Find returned %v, want %v", got, first)
+	}
+}
+
+func TestTracker_GetOrCreateNilFactory(t *testing.T) {
+	tr := NewTracker()
+	h := hashN(2)
+	l, created := tr.GetOrCreate(h, func() *Ledger { return nil })
+	if l != nil || created {
+		t.Fatalf("nil factory must yield (nil,false), got (%v,%v)", l, created)
+	}
+	if tr.Find(h) != nil {
+		t.Fatalf("a nil acquisition must not be registered")
+	}
+}
+
+func TestTracker_RemoveComplete(t *testing.T) {
+	tr := NewTracker()
+	h := hashN(3)
+	tr.GetOrCreate(h, func() *Ledger { return New(h, 20, 7, slog.Default()) })
+
+	tr.Remove(h, true)
+	if tr.Find(h) != nil {
+		t.Fatalf("Remove must drop the acquisition from the in-flight set")
+	}
+	info := tr.Info()
+	// A real (post-genesis) sequence keys by decimal seq.
+	if _, ok := info["20"]; !ok {
+		t.Fatalf("completed acquisition must still appear in fetch_info, got %v", info)
+	}
+	if entry := info["20"].(map[string]any); entry["complete"] != true {
+		t.Fatalf("completed entry must report complete:true, got %v", entry)
+	}
+}
+
+func TestTracker_RemoveFailure(t *testing.T) {
+	tr := NewTracker()
+	h := hashN(4)
+	tr.GetOrCreate(h, func() *Ledger { return New(h, 21, 7, slog.Default()) })
+
+	tr.Remove(h, false)
+	if tr.Find(h) != nil {
+		t.Fatalf("Remove must drop the acquisition from the in-flight set")
+	}
+	info := tr.Info()
+	entry, ok := info["21"].(map[string]any)
+	if !ok {
+		t.Fatalf("failed acquisition must appear in fetch_info, got %v", info)
+	}
+	if entry["failed"] != true {
+		t.Fatalf("failed entry must report failed:true, got %v", entry)
+	}
+}
+
+func TestTracker_RemoveUnknownIsNoop(t *testing.T) {
+	tr := NewTracker()
+	tr.Remove(hashN(9), true) // must not panic
+	if len(tr.Info()) != 0 {
+		t.Fatalf("removing an unknown hash must not record anything")
+	}
+}

--- a/internal/ledger/inbound/tracker.go
+++ b/internal/ledger/inbound/tracker.go
@@ -65,6 +65,91 @@ func (t *Tracker) Track(l *Ledger) {
 	t.mu.Unlock()
 }
 
+// Find returns the in-flight acquisition for hash, or nil. Completed/failed
+// acquisitions (already finalized via Remove, or not yet swept) are not
+// returned, so callers route inbound data only to live acquisitions. Mirrors
+// rippled InboundLedgers::find.
+func (t *Tracker) Find(hash [32]byte) *Ledger {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.active[hash]
+}
+
+// GetOrCreate returns the existing in-flight acquisition for hash, or registers
+// a new one produced by factory (which must not block — peer I/O belongs to the
+// caller, issued only when created is true). Mirrors rippled
+// InboundLedgers::acquire's findCreate step. factory returning nil yields
+// (nil,false).
+func (t *Tracker) GetOrCreate(hash [32]byte, factory func() *Ledger) (l *Ledger, created bool) {
+	if t == nil {
+		return nil, false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if existing := t.active[hash]; existing != nil {
+		return existing, false
+	}
+	l = factory()
+	if l == nil {
+		return nil, false
+	}
+	t.active[hash] = l
+	return l, true
+}
+
+// Remove finalizes an in-flight acquisition: it records the terminal snapshot
+// for fetch_info retention (completed window when complete, failure window
+// otherwise) and drops it from the in-flight set. Idempotent — a no-op if the
+// hash is not currently active.
+func (t *Tracker) Remove(hash [32]byte, complete bool) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	l := t.active[hash]
+	if l == nil {
+		return
+	}
+	snap := l.Snapshot()
+	now := time.Now()
+	if complete {
+		// The caller's verdict is authoritative — stamp the terminal flag so
+		// the retained snapshot renders complete:true regardless of any race
+		// on the acquisition's own state read (symmetric with the failure
+		// branch below).
+		snap.Complete = true
+		snap.Failed = false
+		t.completed[hash] = completedRecord{snap: snap, at: now}
+	} else {
+		snap.Failed = true
+		snap.Complete = false
+		t.failures[hash] = failureRecord{snap: snap, at: now}
+	}
+	delete(t.active, hash)
+}
+
+// ActiveTimedOut returns the in-flight acquisitions that have exceeded the
+// acquisition timeout, for the router's maintenance reaper. The caller decides
+// recovery and finalizes each via Remove.
+func (t *Tracker) ActiveTimedOut() []*Ledger {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var out []*Ledger
+	for _, l := range t.active {
+		if l.IsTimedOut() {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
 // Clear resets both the in-flight set and the recent-failure history,
 // backing fetch_info's `clear` param (rippled InboundLedgers::clearFailures,
 // which clears mRecentFailures and mLedgers).
@@ -116,7 +201,7 @@ func (t *Tracker) Info() map[string]any {
 			t.failures[hash] = failureRecord{snap: snap, at: now}
 			delete(t.active, hash)
 		default:
-			live[acquisitionKey(snap.Seq, hash)] = acquisitionJSON(snap)
+			live[acquisitionKey(snap.Seq, hash)] = AcquisitionJSON(snap)
 		}
 	}
 
@@ -127,7 +212,7 @@ func (t *Tracker) Info() map[string]any {
 			delete(t.failures, hash)
 			continue
 		}
-		ret[acquisitionKey(rec.snap.Seq, hash)] = acquisitionJSON(rec.snap)
+		ret[acquisitionKey(rec.snap.Seq, hash)] = AcquisitionJSON(rec.snap)
 	}
 
 	for hash, rec := range t.completed {
@@ -135,7 +220,7 @@ func (t *Tracker) Info() map[string]any {
 			delete(t.completed, hash)
 			continue
 		}
-		ret[acquisitionKey(rec.snap.Seq, hash)] = acquisitionJSON(rec.snap)
+		ret[acquisitionKey(rec.snap.Seq, hash)] = AcquisitionJSON(rec.snap)
 	}
 
 	for key, entry := range live {
@@ -154,11 +239,11 @@ func acquisitionKey(seq uint32, hash [32]byte) string {
 	return fmt.Sprintf("%X", hash)
 }
 
-// acquisitionJSON mirrors rippled's InboundLedger::getJson
+// AcquisitionJSON mirrors rippled's InboundLedger::getJson
 // (InboundLedger.cpp:1302-1349): hash and timeouts always; complete/failed/peers
 // gated by state; and, once the header is in hand, have_state/have_transactions
 // plus the needed_*_hashes arrays for whichever tree is still outstanding.
-func acquisitionJSON(snap Snapshot) map[string]any {
+func AcquisitionJSON(snap Snapshot) map[string]any {
 	entry := map[string]any{
 		"hash":        fmt.Sprintf("%X", snap.Hash),
 		"have_header": snap.HaveHeader,

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -358,11 +358,13 @@ func (l *Ledger) SkipListHashes() ([][32]byte, error) {
 }
 
 // HashOfSeq returns the hash of ledger `seq` as recorded by this ledger,
-// mirroring rippled's hashOfSeq (View.cpp). It resolves this ledger's own
-// identity, its parent, and any ancestor still inside the rolling 256-entry
-// LedgerHashes skip list. Ledgers more than 256 behind are not resolved here
-// (rippled walks a reference ledger via getCandidateLedger for those); callers
-// treat (zero,false) as "unresolvable from this ledger".
+// mirroring rippled's hashOfSeq (View.cpp:959). It resolves this ledger's own
+// identity, its parent, any ancestor still inside the rolling 256-entry
+// LedgerHashes skip list, and 256-aligned ancestors enshrined in the historical
+// skip list. A non-256-aligned ancestor more than 256 behind is not directly
+// resolvable from a single ledger (rippled reaches it via a reference ledger
+// from getCandidateLedger); callers treat (zero,false) as "unresolvable from
+// this ledger".
 func (l *Ledger) HashOfSeq(seq uint32) ([32]byte, bool, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -386,6 +388,23 @@ func (l *Ledger) HashOfSeq(seq uint32) ([32]byte, bool, error) {
 	}
 	if diff := lseq - seq; diff <= uint32(len(hashes)) {
 		return hashes[uint32(len(hashes))-diff], true, nil
+	}
+
+	// Beyond the rolling window: only 256-aligned ancestors are enshrined in
+	// the historical skip list. Mirrors rippled hashOfSeq's deep branch
+	// (View.cpp:1005-1018): index back from the page's LastLedgerSequence in
+	// 256-ledger strides.
+	if seq&0xff != 0 {
+		return [32]byte{}, false, nil
+	}
+	histHashes, lastSeq, err := readLedgerHashesSLE(l.stateMap, keylet.LedgerHashesForSeq(seq).Key)
+	if err != nil {
+		return [32]byte{}, false, err
+	}
+	if lastSeq >= seq {
+		if d := (lastSeq - seq) >> 8; uint32(len(histHashes)) > d {
+			return histHashes[uint32(len(histHashes))-d-1], true, nil
+		}
 	}
 	return [32]byte{}, false, nil
 }

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -357,6 +357,39 @@ func (l *Ledger) SkipListHashes() ([][32]byte, error) {
 	return readSkipListHashes(l.stateMap, keylet.LedgerHashes().Key)
 }
 
+// HashOfSeq returns the hash of ledger `seq` as recorded by this ledger,
+// mirroring rippled's hashOfSeq (View.cpp). It resolves this ledger's own
+// identity, its parent, and any ancestor still inside the rolling 256-entry
+// LedgerHashes skip list. Ledgers more than 256 behind are not resolved here
+// (rippled walks a reference ledger via getCandidateLedger for those); callers
+// treat (zero,false) as "unresolvable from this ledger".
+func (l *Ledger) HashOfSeq(seq uint32) ([32]byte, bool, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	lseq := l.header.LedgerIndex
+	if seq == 0 || seq > lseq {
+		return [32]byte{}, false, nil
+	}
+	if seq == lseq {
+		return l.header.Hash, true, nil
+	}
+	if seq == lseq-1 {
+		return l.header.ParentHash, true, nil
+	}
+
+	// Rolling 256: this ledger's skip list holds hashes for seqs
+	// [lseq-len .. lseq-1], so hash(seq) sits at index len-diff.
+	hashes, _, err := readLedgerHashesSLE(l.stateMap, keylet.LedgerHashes().Key)
+	if err != nil {
+		return [32]byte{}, false, err
+	}
+	if diff := lseq - seq; diff <= uint32(len(hashes)) {
+		return hashes[uint32(len(hashes))-diff], true, nil
+	}
+	return [32]byte{}, false, nil
+}
+
 // Exists checks if a ledger entry exists
 func (l *Ledger) Exists(k keylet.Keylet) (bool, error) {
 	l.mu.RLock()

--- a/internal/ledger/ledger_hashofseq_test.go
+++ b/internal/ledger/ledger_hashofseq_test.go
@@ -1,0 +1,66 @@
+package ledger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
+)
+
+// TestLedger_HashOfSeq verifies seq → hash resolution against a ledger's own
+// identity, its parent, and the rolling 256-entry skip list, plus the
+// out-of-range cases. Mirrors rippled's hashOfSeq.
+func TestLedger_HashOfSeq(t *testing.T) {
+	res, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatalf("genesis.Create: %v", err)
+	}
+
+	parent := FromGenesis(res.Header, res.StateMap, res.TxMap, drops.Fees{})
+	hashes := map[uint32][32]byte{parent.Sequence(): parent.Hash()}
+
+	const target = uint32(10)
+	for parent.Sequence() < target {
+		closeTime := parent.CloseTime().Add(10 * time.Second)
+		child, err := NewOpen(parent, closeTime)
+		if err != nil {
+			t.Fatalf("NewOpen at seq %d: %v", parent.Sequence()+1, err)
+		}
+		if err := child.Close(closeTime, 0); err != nil {
+			t.Fatalf("Close at seq %d: %v", child.Sequence(), err)
+		}
+		hashes[child.Sequence()] = child.Hash()
+		parent = child
+	}
+	tip := parent // seq 10; rolling skip list covers ancestors 1..9
+
+	// Own identity.
+	if got, ok, err := tip.HashOfSeq(tip.Sequence()); err != nil || !ok || got != tip.Hash() {
+		t.Fatalf("HashOfSeq(self): got=%x ok=%v err=%v, want %x", got, ok, err, tip.Hash())
+	}
+
+	// Parent.
+	if got, ok, err := tip.HashOfSeq(tip.Sequence() - 1); err != nil || !ok || got != hashes[9] {
+		t.Fatalf("HashOfSeq(parent): got=%x ok=%v err=%v, want %x", got, ok, err, hashes[9])
+	}
+
+	// Every ancestor inside the rolling window (seq 1..9).
+	for seq := uint32(1); seq <= 9; seq++ {
+		got, ok, err := tip.HashOfSeq(seq)
+		if err != nil || !ok {
+			t.Fatalf("HashOfSeq(%d): ok=%v err=%v, want resolvable", seq, ok, err)
+		}
+		if got != hashes[seq] {
+			t.Fatalf("HashOfSeq(%d): got=%x, want %x", seq, got, hashes[seq])
+		}
+	}
+
+	// Out of range.
+	if _, ok, _ := tip.HashOfSeq(tip.Sequence() + 1); ok {
+		t.Fatalf("HashOfSeq(future) must be unresolvable")
+	}
+	if _, ok, _ := tip.HashOfSeq(0); ok {
+		t.Fatalf("HashOfSeq(0) must be unresolvable")
+	}
+}

--- a/internal/ledger/ledger_hashofseq_test.go
+++ b/internal/ledger/ledger_hashofseq_test.go
@@ -64,3 +64,60 @@ func TestLedger_HashOfSeq(t *testing.T) {
 		t.Fatalf("HashOfSeq(0) must be unresolvable")
 	}
 }
+
+// TestLedger_HashOfSeq_DeepSkipList verifies that 256-aligned ancestors well
+// outside the rolling 256 window resolve through the historical skip list,
+// while a non-aligned deep ancestor is reported unresolvable (rippled reaches
+// that one only via a reference ledger). Mirrors rippled hashOfSeq's deep
+// branch (View.cpp:1005-1018).
+func TestLedger_HashOfSeq_DeepSkipList(t *testing.T) {
+	res, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatalf("genesis.Create: %v", err)
+	}
+
+	parent := FromGenesis(res.Header, res.StateMap, res.TxMap, drops.Fees{})
+	hashes := map[uint32][32]byte{parent.Sequence(): parent.Hash()}
+
+	// Build past two 256 boundaries so seqs 256 and 512 are both behind the
+	// rolling window (tip-seq > 256) and only reachable via the deep skip list.
+	const target = uint32(800)
+	for parent.Sequence() < target {
+		closeTime := parent.CloseTime().Add(10 * time.Second)
+		child, err := NewOpen(parent, closeTime)
+		if err != nil {
+			t.Fatalf("NewOpen at seq %d: %v", parent.Sequence()+1, err)
+		}
+		if err := child.Close(closeTime, 0); err != nil {
+			t.Fatalf("Close at seq %d: %v", child.Sequence(), err)
+		}
+		hashes[child.Sequence()] = child.Hash()
+		parent = child
+	}
+	tip := parent // seq 800
+
+	// 256-aligned ancestors outside the rolling window resolve via the deep list.
+	for _, seq := range []uint32{256, 512} {
+		if tip.Sequence()-seq <= 256 {
+			t.Fatalf("test setup: seq %d still inside the rolling window", seq)
+		}
+		got, ok, err := tip.HashOfSeq(seq)
+		if err != nil || !ok {
+			t.Fatalf("HashOfSeq(%d): ok=%v err=%v, want resolvable via deep skip list", seq, ok, err)
+		}
+		if got != hashes[seq] {
+			t.Fatalf("HashOfSeq(%d): got=%x, want %x", seq, got, hashes[seq])
+		}
+	}
+
+	// A non-256-aligned ancestor outside the rolling window is unresolvable
+	// from this ledger alone.
+	if _, ok, _ := tip.HashOfSeq(300); ok {
+		t.Fatalf("HashOfSeq(300) must be unresolvable: non-aligned and beyond the rolling window")
+	}
+
+	// A recent ancestor still resolves via the rolling window.
+	if got, ok, err := tip.HashOfSeq(tip.Sequence() - 5); err != nil || !ok || got != hashes[tip.Sequence()-5] {
+		t.Fatalf("HashOfSeq(tip-5): got=%x ok=%v err=%v, want %x", got, ok, err, hashes[tip.Sequence()-5])
+	}
+}

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -94,42 +94,14 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (in
 		return nil, &types.RpcError{Code: -1, ErrorString: "lgrNotFound", Message: "Ledger not found"}
 	}
 
-	// Build ledger info
-	hash := targetLedger.Hash()
-	parent := targetLedger.ParentHash()
-	txHash := targetLedger.TxMapHash()
-	stateHash := targetLedger.StateMapHash()
-	ledgerHash := strings.ToUpper(hex.EncodeToString(hash[:]))
-	parentHash := strings.ToUpper(hex.EncodeToString(parent[:]))
-	txHashStr := strings.ToUpper(hex.EncodeToString(txHash[:]))
-	stateHashStr := strings.ToUpper(hex.EncodeToString(stateHash[:]))
+	// Build ledger info (shared with ledger_request).
+	ledgerInfo := ledgerInfoJSON(targetLedger)
+	ledgerHash := ledgerInfo["ledger_hash"].(string)
 
-	// Format close time
 	closeTimeSec := targetLedger.CloseTime()
-	closeTime := rippleEpochTime.Add(time.Duration(closeTimeSec) * time.Second)
-	closeTimeHuman := closeTime.UTC().Format("2006-Jan-02 15:04:05.000000000 UTC")
-	closeTimeISO := closeTime.UTC().Format(time.RFC3339)
+	closeTimeISO := rippleEpochTime.Add(time.Duration(closeTimeSec) * time.Second).UTC().Format(time.RFC3339)
 
 	_, reserveBase, reserveInc := ctx.Services.Ledger.GetCurrentFees()
-
-	ledgerInfo := map[string]interface{}{
-		"accepted":              true,
-		"account_hash":          stateHashStr,
-		"close_flags":           targetLedger.CloseFlags(),
-		"close_time":            closeTimeSec,
-		"close_time_human":      closeTimeHuman,
-		"close_time_iso":        closeTimeISO,
-		"close_time_resolution": targetLedger.CloseTimeResolution(),
-		"closed":                targetLedger.IsClosed(),
-		"ledger_hash":           ledgerHash,
-		"ledger_index":          strconv.FormatUint(uint64(targetLedger.Sequence()), 10),
-		"parent_close_time":     targetLedger.ParentCloseTime(),
-		"parent_hash":           parentHash,
-		"seqNum":                strconv.FormatUint(uint64(targetLedger.Sequence()), 10),
-		"totalCoins":            strconv.FormatUint(targetLedger.TotalDrops(), 10),
-		"total_coins":           strconv.FormatUint(targetLedger.TotalDrops(), 10),
-		"transaction_hash":      txHashStr,
-	}
 
 	if request.Transactions {
 		var txList []interface{}

--- a/internal/rpc/handlers/ledger_request.go
+++ b/internal/rpc/handlers/ledger_request.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+)
+
+// ledgerInfoJSON renders the closed-ledger header fields shared by the `ledger`
+// and `ledger_request` RPCs, mirroring rippled's LedgerFill at info level 0
+// (LedgerToJson.cpp fillJson).
+func ledgerInfoJSON(l types.LedgerReader) map[string]interface{} {
+	hash := l.Hash()
+	parent := l.ParentHash()
+	txHash := l.TxMapHash()
+	stateHash := l.StateMapHash()
+	closeTimeSec := l.CloseTime()
+	closeTime := rippleEpochTime.Add(time.Duration(closeTimeSec) * time.Second)
+	seqStr := strconv.FormatUint(uint64(l.Sequence()), 10)
+
+	return map[string]interface{}{
+		"accepted":              true,
+		"account_hash":          strings.ToUpper(hex.EncodeToString(stateHash[:])),
+		"close_flags":           l.CloseFlags(),
+		"close_time":            closeTimeSec,
+		"close_time_human":      closeTime.UTC().Format("2006-Jan-02 15:04:05.000000000 UTC"),
+		"close_time_iso":        closeTime.UTC().Format(time.RFC3339),
+		"close_time_resolution": l.CloseTimeResolution(),
+		"closed":                l.IsClosed(),
+		"ledger_hash":           strings.ToUpper(hex.EncodeToString(hash[:])),
+		"ledger_index":          seqStr,
+		"parent_close_time":     l.ParentCloseTime(),
+		"parent_hash":           strings.ToUpper(hex.EncodeToString(parent[:])),
+		"seqNum":                seqStr,
+		"totalCoins":            strconv.FormatUint(l.TotalDrops(), 10),
+		"total_coins":           strconv.FormatUint(l.TotalDrops(), 10),
+		"transaction_hash":      strings.ToUpper(hex.EncodeToString(txHash[:])),
+	}
+}
+
+// LedgerRequestMethod handles the ledger_request RPC method: it returns a
+// locally-available ledger, or triggers acquisition of a missing one from
+// peers and reports the in-progress acquisition.
+//
+// Mirrors rippled's getLedgerByContext (RPCHelpers.cpp:1027) / doLedgerRequest
+// (LedgerRequest.cpp:36): exactly one of ledger_hash / ledger_index, the
+// validated-ledger bounds on a sequence request, a generic
+// InboundLedgers::acquire when the ledger isn't local, and the `acquiring`
+// snapshot returned alongside lgrNotFound while a fetch is in flight.
+type LedgerRequestMethod struct{ AdminHandler }
+
+func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
+	var request struct {
+		LedgerHash  string          `json:"ledger_hash,omitempty"`
+		LedgerIndex json.RawMessage `json:"ledger_index,omitempty"`
+	}
+	if params != nil {
+		if err := json.Unmarshal(params, &request); err != nil {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters")
+		}
+	}
+
+	if err := RequireLedgerService(ctx.Services); err != nil {
+		return nil, err
+	}
+
+	hasHash := request.LedgerHash != ""
+	hasIndex := len(request.LedgerIndex) > 0
+	if (hasHash && hasIndex) || (!hasHash && !hasIndex) {
+		return nil, types.RpcErrorInvalidParams("Exactly one of ledger_hash and ledger_index can be set.")
+	}
+
+	var targetHash [32]byte
+	var targetSeq uint32
+
+	if hasHash {
+		hb, err := hex.DecodeString(request.LedgerHash)
+		if err != nil || len(hb) != 32 {
+			return nil, types.RpcErrorInvalidParams("Invalid field 'ledger_hash'.")
+		}
+		copy(targetHash[:], hb)
+
+		if l, err := ctx.Services.Ledger.GetLedgerByHash(targetHash); err == nil && l != nil {
+			return ledgerRequestSuccess(l), nil
+		}
+	} else {
+		var idx int64
+		if err := json.Unmarshal(request.LedgerIndex, &idx); err != nil {
+			return nil, types.RpcErrorInvalidParams("Invalid field 'ledger_index'.")
+		}
+
+		// A sequence request needs a validated ledger to bound it and to
+		// resolve the sequence to a hash (rippled's getValidatedLedger gate).
+		validatedSeq := ctx.Services.Ledger.GetValidatedLedgerIndex()
+		if validatedSeq == 0 {
+			return nil, types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
+				"Not synced to the network")
+		}
+		if idx <= 0 {
+			return nil, types.RpcErrorInvalidParams("Ledger index too small")
+		}
+		if uint32(idx) >= validatedSeq {
+			return nil, types.RpcErrorInvalidParams("Ledger index too large")
+		}
+		targetSeq = uint32(idx)
+
+		if l, err := ctx.Services.Ledger.GetLedgerBySequence(targetSeq); err == nil && l != nil {
+			return ledgerRequestSuccess(l), nil
+		}
+	}
+
+	// Not local — trigger (or join) a generic acquisition from peers. When no
+	// acquisition subsystem is wired (standalone / RPC-only) the ledger is
+	// simply reported as not found, matching rippled's standalone fallback.
+	if ctx.Services.RequestLedger != nil {
+		if acquiring, started := ctx.Services.RequestLedger(targetHash, targetSeq); started {
+			result := types.RpcErrorLgrNotFound("acquiring ledger containing requested index").ErrorObject()
+			if acquiring != nil {
+				result["acquiring"] = acquiring
+			}
+			return result, nil
+		}
+	}
+
+	return nil, types.RpcErrorLgrNotFound("Ledger not found")
+}
+
+// ledgerRequestSuccess builds the success response for a locally-available
+// ledger: {ledger_index, ledger} per rippled doLedgerRequest.
+func ledgerRequestSuccess(l types.LedgerReader) map[string]interface{} {
+	return map[string]interface{}{
+		"ledger_index": l.Sequence(),
+		"ledger":       ledgerInfoJSON(l),
+	}
+}

--- a/internal/rpc/handlers/ledger_request.go
+++ b/internal/rpc/handlers/ledger_request.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -48,9 +49,11 @@ func ledgerInfoJSON(l types.LedgerReader) map[string]interface{} {
 //
 // Mirrors rippled's getLedgerByContext (RPCHelpers.cpp:1027) / doLedgerRequest
 // (LedgerRequest.cpp:36): exactly one of ledger_hash / ledger_index, the
-// validated-ledger bounds on a sequence request, a generic
-// InboundLedgers::acquire when the ledger isn't local, and the `acquiring`
-// snapshot returned alongside lgrNotFound while a fetch is in flight.
+// validated-ledger bounds on a sequence request, and a generic
+// InboundLedgers::acquire when the ledger isn't local. While a fetch is in
+// flight it returns the bare acquisition snapshot for the target ledger, or
+// lgrNotFound + acquiring when a reference ledger is being fetched first to
+// resolve a deep sequence's hash.
 type LedgerRequestMethod struct{ AdminHandler }
 
 func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
@@ -95,15 +98,23 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 
 		// A sequence request needs a validated ledger to bound it and to
 		// resolve the sequence to a hash (rippled's getValidatedLedger gate).
+		// rippled distinguishes API v1 (rpcNO_CURRENT) from later versions
+		// (rpcNOT_SYNCED) here — RPCHelpers.cpp:1060-1062.
 		validatedSeq := ctx.Services.Ledger.GetValidatedLedgerIndex()
 		if validatedSeq == 0 {
+			if ctx.ApiVersion == types.ApiVersion1 {
+				return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
+					"Current ledger is unavailable.")
+			}
 			return nil, types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
 				"Not synced to the network")
 		}
 		if idx <= 0 {
 			return nil, types.RpcErrorInvalidParams("Ledger index too small")
 		}
-		if uint32(idx) >= validatedSeq {
+		// Bound before the uint32 cast so a value past uint32 range can't wrap
+		// to a small in-range sequence and silently target a different ledger.
+		if idx > math.MaxUint32 || uint32(idx) >= validatedSeq {
 			return nil, types.RpcErrorInvalidParams("Ledger index too large")
 		}
 		targetSeq = uint32(idx)
@@ -117,12 +128,20 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	// acquisition subsystem is wired (standalone / RPC-only) the ledger is
 	// simply reported as not found, matching rippled's standalone fallback.
 	if ctx.Services.RequestLedger != nil {
-		if acquiring, started := ctx.Services.RequestLedger(targetHash, targetSeq); started {
-			result := types.RpcErrorLgrNotFound("acquiring ledger containing requested index").ErrorObject()
-			if acquiring != nil {
-				result["acquiring"] = acquiring
+		if acquiring, started, reference := ctx.Services.RequestLedger(targetHash, targetSeq); started {
+			if reference {
+				// Acquiring a reference ledger only to learn the target's hash:
+				// rippled wraps the snapshot as lgrNotFound + acquiring
+				// (RPCHelpers.cpp:1096-1110).
+				result := types.RpcErrorLgrNotFound("acquiring ledger containing requested index").ErrorObject()
+				if acquiring != nil {
+					result["acquiring"] = acquiring
+				}
+				return result, nil
 			}
-			return result, nil
+			// Acquiring the target itself: rippled returns the bare acquisition
+			// snapshot as the result (RPCHelpers.cpp:1137-1138).
+			return acquiring, nil
 		}
 	}
 

--- a/internal/rpc/handlers/stubs_network.go
+++ b/internal/rpc/handlers/stubs_network.go
@@ -46,29 +46,6 @@ func (m *FetchInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	return response, nil
 }
 
-// LedgerRequestMethod handles the ledger_request RPC method.
-// STUB: Returns error. Network-only — requests missing ledgers from peers.
-//
-// TODO [network]: Implement when adding P2P networking layer.
-//   - Reference: rippled LedgerRequest.cpp
-//   - Triggers a fetch of a specific ledger from the network
-//   - In standalone mode, correctly returns notSynced
-type LedgerRequestMethod struct{ AdminHandler }
-
-func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (interface{}, *types.RpcError) {
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
-		return nil, types.RpcErrorInternal("Ledger service not available")
-	}
-
-	if ctx.Services.Ledger.IsStandalone() {
-		return nil, types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
-			"Not synced to the network")
-	}
-
-	return nil, types.NewRpcError(types.RpcNOT_IMPL, "notImplemented", "notImplemented",
-		"ledger_request is not yet implemented — requires network ledger fetching")
-}
-
 // TxReduceRelayMethod handles the tx_reduce_relay RPC method.
 // Mirrors rippled TxReduceRelay.cpp (returns overlay().txMetrics()): the
 // txr_* rolling-average metrics from rippled metrics::TxMetrics, emitted as

--- a/internal/rpc/ledger_request_test.go
+++ b/internal/rpc/ledger_request_test.go
@@ -90,7 +90,11 @@ func TestLedgerRequest_ServesLocalLedgerByIndex(t *testing.T) {
 	assert.Equal(t, uint32(1), resp["ledger_index"])
 }
 
-func TestLedgerRequest_AcquiringReturnsSnapshotUnderLgrNotFound(t *testing.T) {
+// TestLedgerRequest_AcquiringTargetReturnsBareSnapshot covers rippled's common
+// not-local path: when the target hash is known and its ledger is being
+// fetched, rippled returns the bare acquisition snapshot as the result, with no
+// error wrapper (RPCHelpers.cpp:1137-1138).
+func TestLedgerRequest_AcquiringTargetReturnsBareSnapshot(t *testing.T) {
 	var hash [32]byte
 	hash[0] = 0x42
 	hexHash := hex.EncodeToString(hash[:])
@@ -109,9 +113,48 @@ func TestLedgerRequest_AcquiringReturnsSnapshotUnderLgrNotFound(t *testing.T) {
 		ApiVersion: types.ApiVersion1,
 		Services: &types.ServiceContainer{
 			Ledger: mock,
-			RequestLedger: func(h [32]byte, seq uint32) (map[string]any, bool) {
+			RequestLedger: func(h [32]byte, seq uint32) (map[string]any, bool, bool) {
 				gotHash = h
-				return acquiring, true
+				return acquiring, true, false
+			},
+		},
+	}
+
+	result, rpcErr := (&handlers.LedgerRequestMethod{}).Handle(ctx,
+		json.RawMessage(`{"ledger_hash":"`+hexHash+`"}`))
+	require.Nil(t, rpcErr)
+
+	resp, ok := result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, acquiring, resp, "target acquisition returns the bare snapshot")
+	assert.Nil(t, resp["error"], "the bare snapshot must not carry an error field")
+	assert.Equal(t, hash, gotHash, "the requested hash must be forwarded to the acquisition coordinator")
+}
+
+// TestLedgerRequest_AcquiringReferenceReturnsLgrNotFound covers rippled's
+// deep-index path: when a reference ledger must be fetched to learn the
+// target's hash, rippled wraps the snapshot as lgrNotFound + acquiring
+// (RPCHelpers.cpp:1096-1110).
+func TestLedgerRequest_AcquiringReferenceReturnsLgrNotFound(t *testing.T) {
+	var hash [32]byte
+	hash[0] = 0x42
+	hexHash := hex.EncodeToString(hash[:])
+
+	acquiring := map[string]any{
+		"hash":        strings.ToUpper(hexHash),
+		"have_header": false,
+		"peers":       1,
+		"timeouts":    0,
+	}
+	mock := &ledgerRequestMock{mockLedgerService: newMockLedgerService()}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		ApiVersion: types.ApiVersion1,
+		Services: &types.ServiceContainer{
+			Ledger: mock,
+			RequestLedger: func(h [32]byte, seq uint32) (map[string]any, bool, bool) {
+				return acquiring, true, true
 			},
 		},
 	}
@@ -126,7 +169,6 @@ func TestLedgerRequest_AcquiringReturnsSnapshotUnderLgrNotFound(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "lgrNotFound", resp["error"])
 	assert.Equal(t, acquiring, resp["acquiring"])
-	assert.Equal(t, hash, gotHash, "the requested hash must be forwarded to the acquisition coordinator")
 }
 
 func TestLedgerRequest_NotFoundWithoutSubsystem(t *testing.T) {

--- a/internal/rpc/ledger_request_test.go
+++ b/internal/rpc/ledger_request_test.go
@@ -1,0 +1,148 @@
+package rpc
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/rpc/handlers"
+	"github.com/LeJamon/goXRPLd/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ledgerRequestMock overrides the by-hash / by-sequence lookups so a ledger can
+// be reported as locally present, while inheriting the rest of mockLedgerService.
+type ledgerRequestMock struct {
+	*mockLedgerService
+	byHash map[[32]byte]types.LedgerReader
+	bySeq  map[uint32]types.LedgerReader
+}
+
+func (m *ledgerRequestMock) GetLedgerByHash(h [32]byte) (types.LedgerReader, error) {
+	if l, ok := m.byHash[h]; ok {
+		return l, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (m *ledgerRequestMock) GetLedgerBySequence(seq uint32) (types.LedgerReader, error) {
+	if l, ok := m.bySeq[seq]; ok {
+		return l, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func TestLedgerRequest_ServesLocalLedgerByHash(t *testing.T) {
+	var hash [32]byte
+	hash[0], hash[31] = 0xAB, 0xCD
+	lr := &mockLedgerReader{seq: 5, hash: hash, closed: true, validated: true, totalDrops: 99000000}
+
+	mock := &ledgerRequestMock{
+		mockLedgerService: newMockLedgerService(),
+		byHash:            map[[32]byte]types.LedgerReader{hash: lr},
+	}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: mock},
+	}
+
+	result, rpcErr := (&handlers.LedgerRequestMethod{}).Handle(ctx,
+		json.RawMessage(`{"ledger_hash":"`+hex.EncodeToString(hash[:])+`"}`))
+	require.Nil(t, rpcErr)
+
+	resp, ok := result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, uint32(5), resp["ledger_index"])
+	ledger, ok := resp["ledger"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, strings.ToUpper(hex.EncodeToString(hash[:])), ledger["ledger_hash"])
+	assert.Equal(t, "5", ledger["ledger_index"])
+}
+
+func TestLedgerRequest_ServesLocalLedgerByIndex(t *testing.T) {
+	var hash [32]byte
+	hash[0] = 0x11
+	lr := &mockLedgerReader{seq: 1, hash: hash, closed: true, validated: true}
+
+	mock := &ledgerRequestMock{
+		mockLedgerService: newMockLedgerService(), // validated ledger is seq 2
+		bySeq:             map[uint32]types.LedgerReader{1: lr},
+	}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: mock},
+	}
+
+	result, rpcErr := (&handlers.LedgerRequestMethod{}).Handle(ctx,
+		json.RawMessage(`{"ledger_index": 1}`))
+	require.Nil(t, rpcErr)
+
+	resp, ok := result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, uint32(1), resp["ledger_index"])
+}
+
+func TestLedgerRequest_AcquiringReturnsSnapshotUnderLgrNotFound(t *testing.T) {
+	var hash [32]byte
+	hash[0] = 0x42
+	hexHash := hex.EncodeToString(hash[:])
+
+	acquiring := map[string]any{
+		"hash":        strings.ToUpper(hexHash),
+		"have_header": false,
+		"peers":       1,
+		"timeouts":    0,
+	}
+	var gotHash [32]byte
+	mock := &ledgerRequestMock{mockLedgerService: newMockLedgerService()}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		ApiVersion: types.ApiVersion1,
+		Services: &types.ServiceContainer{
+			Ledger: mock,
+			RequestLedger: func(h [32]byte, seq uint32) (map[string]any, bool) {
+				gotHash = h
+				return acquiring, true
+			},
+		},
+	}
+
+	result, rpcErr := (&handlers.LedgerRequestMethod{}).Handle(ctx,
+		json.RawMessage(`{"ledger_hash":"`+hexHash+`"}`))
+	// rippled returns this as a result body (error + acquiring members), not a
+	// transport-level error.
+	require.Nil(t, rpcErr)
+
+	resp, ok := result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "lgrNotFound", resp["error"])
+	assert.Equal(t, acquiring, resp["acquiring"])
+	assert.Equal(t, hash, gotHash, "the requested hash must be forwarded to the acquisition coordinator")
+}
+
+func TestLedgerRequest_NotFoundWithoutSubsystem(t *testing.T) {
+	var hash [32]byte
+	hash[0] = 0x77
+	mock := &ledgerRequestMock{mockLedgerService: newMockLedgerService()}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: mock}, // RequestLedger nil
+	}
+
+	result, rpcErr := (&handlers.LedgerRequestMethod{}).Handle(ctx,
+		json.RawMessage(`{"ledger_hash":"`+hex.EncodeToString(hash[:])+`"}`))
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcLGR_NOT_FOUND, rpcErr.Code)
+}

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -327,22 +328,43 @@ func TestLedgerRequestMethod(t *testing.T) {
 
 	method := &handlers.LedgerRequestMethod{}
 
-	t.Run("Returns not implemented error in standalone mode (stub)", func(t *testing.T) {
-		// ledger_request is a stub - it returns RpcNOT_IMPL until network ledger fetching is implemented
-		ctx := &types.RpcContext{
+	newCtx := func() *types.RpcContext {
+		return &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
 			Services:   services,
 		}
+	}
 
-		params := json.RawMessage(`{"ledger_index": 100}`)
-		result, rpcErr := method.Handle(ctx, params)
+	t.Run("Rejects both ledger_hash and ledger_index", func(t *testing.T) {
+		_, rpcErr := method.Handle(newCtx(), json.RawMessage(
+			`{"ledger_hash":"`+strings.Repeat("A", 64)+`","ledger_index":1}`))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	})
 
+	t.Run("Rejects neither ledger_hash nor ledger_index", func(t *testing.T) {
+		_, rpcErr := method.Handle(newCtx(), json.RawMessage(`{}`))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	})
+
+	t.Run("Rejects ledger_index at or beyond the validated ledger", func(t *testing.T) {
+		// The base mock's validated ledger is seq 2.
+		result, rpcErr := method.Handle(newCtx(), json.RawMessage(`{"ledger_index": 100}`))
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
-		// In standalone mode, returns notSynced; otherwise returns RpcNOT_IMPL
-		assert.True(t, rpcErr.Code == types.RpcNOT_SYNCED || rpcErr.Code == types.RpcNOT_IMPL)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	})
+
+	t.Run("Not found and no acquisition subsystem returns lgrNotFound", func(t *testing.T) {
+		// ledger_hash path: the mock has no ledger and no RequestLedger wired.
+		result, rpcErr := method.Handle(newCtx(), json.RawMessage(
+			`{"ledger_hash":"`+strings.Repeat("B", 64)+`"}`))
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcLGR_NOT_FOUND, rpcErr.Code)
 	})
 
 	t.Run("RequiredRole is Admin", func(t *testing.T) {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -346,6 +346,17 @@ type ServiceContainer struct {
 	// NetworkOPs::clearLedgerFetch → InboundLedgers::clearFailures). Nil-safe.
 	FetchInfoClear func()
 
+	// RequestLedger triggers (or joins) a generic acquisition of a ledger from
+	// peers, backing the ledger_request RPC (rippled
+	// InboundLedgers::acquire(..., Reason::GENERIC)). The target is identified
+	// by hash, or by seq when hash is zero (resolved against the validated
+	// ledger). It returns the per-acquisition progress snapshot (rippled
+	// InboundLedger::getJson shape) and started=true while an acquisition is in
+	// flight, or (nil,false) when the target can't be resolved or no peer is
+	// available. Nil in standalone / RPC-only mode (no acquisition subsystem) —
+	// the handler then reports the ledger as not found without acquiring.
+	RequestLedger func(ledgerHash [32]byte, ledgerSeq uint32) (acquiring map[string]any, started bool)
+
 	// LedgerCleanerConfigure configures and starts the background
 	// ledger-integrity verifier, returning its resulting status. Backs the
 	// admin ledger_cleaner RPC. Nil when no cleaner is wired — the handler

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -352,10 +352,14 @@ type ServiceContainer struct {
 	// by hash, or by seq when hash is zero (resolved against the validated
 	// ledger). It returns the per-acquisition progress snapshot (rippled
 	// InboundLedger::getJson shape) and started=true while an acquisition is in
-	// flight, or (nil,false) when the target can't be resolved or no peer is
-	// available. Nil in standalone / RPC-only mode (no acquisition subsystem) —
-	// the handler then reports the ledger as not found without acquiring.
-	RequestLedger func(ledgerHash [32]byte, ledgerSeq uint32) (acquiring map[string]any, started bool)
+	// flight, or (nil,false,false) when the target can't be resolved or no peer
+	// is available. reference is true when the snapshot describes a 256-aligned
+	// reference ledger being fetched only to resolve a deep target's hash —
+	// rippled wraps that case as lgrNotFound + acquiring, versus the bare
+	// snapshot it returns when acquiring the target itself. Nil in standalone /
+	// RPC-only mode (no acquisition subsystem) — the handler then reports the
+	// ledger as not found without acquiring.
+	RequestLedger func(ledgerHash [32]byte, ledgerSeq uint32) (acquiring map[string]any, started, reference bool)
 
 	// LedgerCleanerConfigure configures and starts the background
 	// ledger-integrity verifier, returning its resulting status. Backs the


### PR DESCRIPTION
## Summary
- Generalize the single-slot inbound-ledger acquisition into a rippled-style **InboundLedgers registry** (concurrent acquisitions keyed by ledger hash). The consensus router routes inbound `TMLedgerData` to the matching acquisition by hash, so consensus catch-up and RPC-driven fetches coexist.
- Implement **`ledger_request`** per rippled's `getLedgerByContext` / `doLedgerRequest`: serve a locally-available ledger, or trigger a generic acquisition from a selected peer and return the in-progress `acquiring` snapshot (rippled `InboundLedger::getJson` shape) alongside `lgrNotFound`.
- Acquisition gains a **`Reason`** (Consensus / Generic). `ReasonGeneric` (RPC-driven) completions persist the ledger for querying **without** flipping operating mode or notifying consensus, so an arbitrary historical fetch can't disturb the active chain.
- Add **`ledger.HashOfSeq`** (rippled `hashOfSeq`) to resolve a sequence request to a hash via the validated ledger's rolling skip list.
- Wire `RequestLedger` through the RPC `Services` container; the `ledger_request` stub becomes a real handler.

## Scope notes
- Ledgers more than 256 behind the validated ledger are not resolved here (rippled walks a reference ledger via `getCandidateLedger`); the handler degrades to `lgrNotFound`, matching rippled's terminal behavior when the reference isn't local. By-hash and by-recent-index acquisition are fully supported.
- A live multi-node integration test (acceptance criterion 4) is inherently network-driven; covered here by router-level round-trip tests against the existing fake adaptor/overlay seam.

## Test plan
- [x] `just test-pkg ./internal/ledger/...` — `HashOfSeq` + inbound registry (`Find`/`GetOrCreate`/`Remove`/timeout)
- [x] `just test-pkg ./internal/consensus/adaptor/...` — registry routing + `RequestLedger` trigger / no-peers / dedup; existing catch-up + replay-delta suites
- [x] `just test-pkg ./internal/rpc/...` — handler param validation, local serve (hash/index), `acquiring` snapshot, `lgrNotFound`
- [x] `go build ./...`, `go vet`, `gofmt` clean

Fixes #559