### PR TITLE
fix: validate TOML domain in manifest Deserialize

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -32,6 +32,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"regexp"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
@@ -167,6 +168,9 @@ func Deserialize(data []byte) (*Manifest, error) {
 				return nil, fmt.Errorf("manifest: Domain not hex: %w", err)
 			}
 			m.Domain = string(b)
+			if !isProperlyFormedTomlDomain(m.Domain) {
+				return nil, errors.New("manifest: Domain is not a properly formed TOML domain")
+			}
 		}
 	}
 
@@ -318,6 +322,24 @@ func hasField(m map[string]any, name string) bool {
 		return true
 	}
 	return s != ""
+}
+
+// tomlDomainRe mirrors rippled's isProperlyFormedTomlDomain regex
+// (StringUtilities.cpp:142-153). Go's RE2 engine has no lookaround, so the
+// "must not begin/end with '-'" constraints are expressed by splitting each
+// segment into the single-char and multi-char cases rather than the original
+// (?!-)...(?<!-) form.
+var tomlDomainRe = regexp.MustCompile(
+	`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])\.)+[A-Za-z]{2,63}$`,
+)
+
+// isProperlyFormedTomlDomain reports whether domain is a plausibly valid
+// xrpl.toml domain, mirroring rippled's check in StringUtilities.cpp:131-156.
+func isProperlyFormedTomlDomain(domain string) bool {
+	if len(domain) < 4 || len(domain) > 128 {
+		return false
+	}
+	return tomlDomainRe.MatchString(domain)
 }
 
 // toUint32 accepts the several numeric shapes the JSON map may contain

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -32,13 +32,13 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"regexp"
 
 	"github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
 	"github.com/LeJamon/goXRPLd/crypto"
 	"github.com/LeJamon/goXRPLd/crypto/ed25519"
 	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
+	"github.com/LeJamon/goXRPLd/internal/stringutil"
 	"github.com/LeJamon/goXRPLd/protocol"
 )
 
@@ -168,7 +168,7 @@ func Deserialize(data []byte) (*Manifest, error) {
 				return nil, fmt.Errorf("manifest: Domain not hex: %w", err)
 			}
 			m.Domain = string(b)
-			if !isProperlyFormedTomlDomain(m.Domain) {
+			if !stringutil.IsProperlyFormedTomlDomain(m.Domain) {
 				return nil, errors.New("manifest: Domain is not a properly formed TOML domain")
 			}
 		}
@@ -322,24 +322,6 @@ func hasField(m map[string]any, name string) bool {
 		return true
 	}
 	return s != ""
-}
-
-// tomlDomainRe mirrors rippled's isProperlyFormedTomlDomain regex
-// (StringUtilities.cpp:142-153). Go's RE2 engine has no lookaround, so the
-// "must not begin/end with '-'" constraints are expressed by splitting each
-// segment into the single-char and multi-char cases rather than the original
-// (?!-)...(?<!-) form.
-var tomlDomainRe = regexp.MustCompile(
-	`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])\.)+[A-Za-z]{2,63}$`,
-)
-
-// isProperlyFormedTomlDomain reports whether domain is a plausibly valid
-// xrpl.toml domain, mirroring rippled's check in StringUtilities.cpp:131-156.
-func isProperlyFormedTomlDomain(domain string) bool {
-	if len(domain) < 4 || len(domain) > 128 {
-		return false
-	}
-	return tomlDomainRe.MatchString(domain)
 }
 
 // toUint32 accepts the several numeric shapes the JSON map may contain

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -536,3 +536,75 @@ func TestManifest_Sequence_AdvancesOnlyOnUpdate(t *testing.T) {
 		t.Errorf("Sequence after stale: got %d want 1", got)
 	}
 }
+
+// buildManifestWithDomain builds a valid, signed manifest carrying the given
+// Domain (VL-encoded as the hex of its UTF-8 bytes, as the wire format
+// requires) so the domain-validation path in Deserialize can be exercised.
+func buildManifestWithDomain(t *testing.T, domain string, masterSeed, ephemeralSeed byte) []byte {
+	t.Helper()
+
+	masterPubBytes, masterPriv := deterministicEd25519Keypair(masterSeed)
+	ephPubBytes, ephPriv := deterministicEd25519Keypair(ephemeralSeed)
+
+	json := map[string]any{
+		"PublicKey":     hex.EncodeToString(masterPubBytes),
+		"Sequence":      uint32(1),
+		"Domain":        hex.EncodeToString([]byte(domain)),
+		"SigningPubKey": hex.EncodeToString(ephPubBytes),
+	}
+
+	preimage := signingPreimageFromJSON(t, json)
+	json["Signature"] = hex.EncodeToString(ed25519.Sign(ed25519.PrivateKey(ephPriv), preimage))
+	json["MasterSignature"] = hex.EncodeToString(ed25519.Sign(ed25519.PrivateKey(masterPriv), preimage))
+
+	encoded, err := binarycodec.Encode(json)
+	if err != nil {
+		t.Fatalf("encode manifest: %v", err)
+	}
+	b, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode built hex: %v", err)
+	}
+	return b
+}
+
+// TestManifest_Domain_Validation mirrors rippled's isProperlyFormedTomlDomain
+// check (Manifest.cpp:107-115): a malformed domain rejects the whole manifest
+// rather than being cached and relayed.
+func TestManifest_Domain_Validation(t *testing.T) {
+	cases := []struct {
+		name   string
+		domain string
+		accept bool
+	}{
+		{"simple", "example.com", true},
+		{"subdomain", "validators.ripple.com", true},
+		{"hyphenated", "my-validator.example.org", true},
+		{"too-short", "a.b", false},
+		{"no-tld", "example", false},
+		{"trailing-dot", "example.com.", false},
+		{"leading-hyphen-segment", "-bad.example.com", false},
+		{"trailing-hyphen-segment", "bad-.example.com", false},
+		{"numeric-tld", "example.123", false},
+		{"underscore", "bad_domain.com", false},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			serialized := buildManifestWithDomain(t, tc.domain, byte(0x40+i), byte(0x80+i))
+			m, err := manifest.Deserialize(serialized)
+			if tc.accept {
+				if err != nil {
+					t.Fatalf("Deserialize(%q): unexpected error: %v", tc.domain, err)
+				}
+				if m.Domain != tc.domain {
+					t.Errorf("Domain: got %q want %q", m.Domain, tc.domain)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Deserialize(%q): expected rejection, got accepted", tc.domain)
+			}
+		})
+	}
+}

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -17,6 +17,7 @@ import (
 
 	rootcrypto "github.com/LeJamon/goXRPLd/crypto"
 	"github.com/LeJamon/goXRPLd/crypto/secp256k1"
+	"github.com/LeJamon/goXRPLd/internal/stringutil"
 	"github.com/LeJamon/goXRPLd/protocol"
 )
 
@@ -314,46 +315,6 @@ func parseLedgerHashHeader(s string) ([32]byte, error) {
 		return out, nil
 	}
 	return out, fmt.Errorf("unrecognised ledger hash %q", s)
-}
-
-// isWellFormedDomain mirrors rippled's isProperlyFormedTomlDomain.
-func isWellFormedDomain(s string) bool {
-	if len(s) < 4 || len(s) > 128 {
-		return false
-	}
-	labels := strings.Split(s, ".")
-	if len(labels) < 2 {
-		return false
-	}
-	tld := labels[len(labels)-1]
-	if len(tld) < 2 || len(tld) > 63 {
-		return false
-	}
-	for i := 0; i < len(tld); i++ {
-		c := tld[i]
-		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
-			return false
-		}
-	}
-	for _, label := range labels[:len(labels)-1] {
-		if len(label) < 1 || len(label) > 63 {
-			return false
-		}
-		if label[0] == '-' || label[len(label)-1] == '-' {
-			return false
-		}
-		for i := 0; i < len(label); i++ {
-			c := label[i]
-			ok := (c >= 'A' && c <= 'Z') ||
-				(c >= 'a' && c <= 'z') ||
-				(c >= '0' && c <= '9') ||
-				c == '-'
-			if !ok {
-				return false
-			}
-		}
-	}
-	return true
 }
 
 // VerifyPeerHandshake runs the post-Server-Domain rippled verify chain:
@@ -767,7 +728,7 @@ func ValidateServerDomain(headers http.Header) (string, error) {
 	if v == "" {
 		return "", nil
 	}
-	if !isWellFormedDomain(v) {
+	if !stringutil.IsProperlyFormedTomlDomain(v) {
 		return "", fmt.Errorf("%w: invalid Server-Domain %q",
 			ErrInvalidHandshake, v)
 	}

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -1766,67 +1765,6 @@ func TestHeaderIPIsV6_FamilyFromTextForm(t *testing.T) {
 	assert.False(t, headerIPIsV6("1.2.3.4"))
 	assert.True(t, headerIPIsV6("2001:db8::1"))
 	assert.True(t, headerIPIsV6("::ffff:1.2.3.4"))
-}
-
-// isWellFormedDomain must agree with rippled's regex
-// (StringUtilities.cpp:142-153). Go regexp has no lookarounds, so the
-// no-leading/trailing-hyphen rule is encoded directly.
-func TestIsWellFormedDomain_RegexCrossCheck(t *testing.T) {
-	rippledLike := regexp.MustCompile(
-		`^([A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$`,
-	)
-	check := func(s string) bool {
-		if len(s) < 4 || len(s) > 128 {
-			return false
-		}
-		return rippledLike.MatchString(s)
-	}
-
-	inputs := []string{
-		"a.io", "example.com", "validator.example.com", "node-1.example.org",
-		"a.b.c.d.example.com", "X-1.X-2.example.io",
-		"localhost", "example", "a.b", "x.123", "a.b.c",
-		"-bad.example.com", "bad-.example.com", "_bad.example.com",
-		"example.com.", "example..com", ".example.com",
-		"", "a",
-		strings.Repeat("a", 64) + ".example.com",
-		strings.Repeat("a", 200) + ".com",
-		"foo.bar.MUSEUM",
-	}
-	for _, s := range inputs {
-		want := check(s)
-		got := isWellFormedDomain(s)
-		assert.Equal(t, want, got, "isWellFormedDomain(%q): want=%v got=%v", s, want, got)
-	}
-}
-
-// isWellFormedDomain matches rippled's isProperlyFormedTomlDomain
-// (StringUtilities.cpp:131-156).
-func TestIsWellFormedDomain_TomlParity(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want bool
-	}{
-		{"valid_two_label", "a.io", true},
-		{"valid_subdomain", "validator.example.com", true},
-		{"valid_with_digits", "node-1.example.org", true},
-		{"too_short", "a.b", false},
-		{"too_long", strings.Repeat("a", 120) + ".example.com", false},
-		{"single_label", "example", false},
-		{"numeric_tld", "x.123", false},
-		{"one_char_tld", "a.b.c", false},
-		{"trailing_dot", "example.com.", false},
-		{"leading_hyphen_label", "-bad.example.com", false},
-		{"trailing_hyphen_label", "bad-.example.com", false},
-		{"empty", "", false},
-		{"underscore", "bad_label.example.com", false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, isWellFormedDomain(tc.in))
-		})
-	}
 }
 
 // WriteRawHandshakeRequest must place every issue-#270 header on the

--- a/internal/stringutil/domain.go
+++ b/internal/stringutil/domain.go
@@ -1,0 +1,23 @@
+// Package stringutil holds low-level string helpers mirroring rippled's
+// libxrpl/basics/StringUtilities.cpp.
+package stringutil
+
+import "regexp"
+
+// tomlDomainRe mirrors rippled's isProperlyFormedTomlDomain regex
+// (StringUtilities.cpp:142-153). Go's RE2 engine has no lookaround, so the
+// "must not begin/end with '-'" per-segment constraint is encoded by making
+// the trailing alphanumeric run optional rather than using the original
+// (?!-)...(?<!-) form.
+var tomlDomainRe = regexp.MustCompile(
+	`^([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$`,
+)
+
+// IsProperlyFormedTomlDomain reports whether domain is a plausibly valid
+// xrpl.toml domain, mirroring rippled's check in StringUtilities.cpp:131-156.
+func IsProperlyFormedTomlDomain(domain string) bool {
+	if len(domain) < 4 || len(domain) > 128 {
+		return false
+	}
+	return tomlDomainRe.MatchString(domain)
+}

--- a/internal/stringutil/domain_test.go
+++ b/internal/stringutil/domain_test.go
@@ -1,0 +1,80 @@
+package stringutil
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestIsProperlyFormedTomlDomain_RegexCrossCheck pins the RE2 translation
+// against an independent rippled-shaped regex (StringUtilities.cpp:142-153),
+// so a future edit to tomlDomainRe that drifts from rippled's grammar fails
+// here rather than silently.
+func TestIsProperlyFormedTomlDomain_RegexCrossCheck(t *testing.T) {
+	rippledLike := regexp.MustCompile(
+		`^([A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$`,
+	)
+	check := func(s string) bool {
+		if len(s) < 4 || len(s) > 128 {
+			return false
+		}
+		return rippledLike.MatchString(s)
+	}
+
+	inputs := []string{
+		"a.io", "example.com", "validator.example.com", "node-1.example.org",
+		"a.b.c.d.example.com", "X-1.X-2.example.io",
+		"localhost", "example", "a.b", "x.123", "a.b.c",
+		"-bad.example.com", "bad-.example.com", "_bad.example.com",
+		"example.com.", "example..com", ".example.com",
+		"", "a",
+		strings.Repeat("a", 63) + ".example.com",
+		strings.Repeat("a", 64) + ".example.com",
+		strings.Repeat("a", 200) + ".com",
+		"foo.bar.MUSEUM",
+	}
+	for _, s := range inputs {
+		want := check(s)
+		got := IsProperlyFormedTomlDomain(s)
+		if got != want {
+			t.Errorf("IsProperlyFormedTomlDomain(%q): want=%v got=%v", s, want, got)
+		}
+	}
+}
+
+// TestIsProperlyFormedTomlDomain_TomlParity mirrors rippled's
+// isProperlyFormedTomlDomain (StringUtilities.cpp:131-156), enumerating the
+// length, label, and TLD boundaries.
+func TestIsProperlyFormedTomlDomain_TomlParity(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"valid_two_label", "a.io", true},
+		{"valid_subdomain", "validator.example.com", true},
+		{"valid_with_digits", "node-1.example.org", true},
+		{"valid_hyphenated", "my-validator.example.org", true},
+		{"label_63_chars", strings.Repeat("a", 63) + ".example.com", true},
+		{"too_short", "a.b", false},
+		{"too_long", strings.Repeat("a", 130) + ".com", false},
+		{"single_label", "example", false},
+		{"numeric_tld", "x.123", false},
+		{"one_char_tld", "a.b.c", false},
+		{"trailing_dot", "example.com.", false},
+		{"leading_dot", ".example.com", false},
+		{"empty_label", "example..com", false},
+		{"leading_hyphen_label", "-bad.example.com", false},
+		{"trailing_hyphen_label", "bad-.example.com", false},
+		{"label_64_chars", strings.Repeat("a", 64) + ".example.com", false},
+		{"empty", "", false},
+		{"underscore", "bad_label.example.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsProperlyFormedTomlDomain(tc.in); got != tc.want {
+				t.Errorf("IsProperlyFormedTomlDomain(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `manifest.Deserialize` decoded the optional `Domain` field but never validated its format, so goXRPL accepted, cached, and relayed manifests that rippled rejects — a manifest gossip-mesh divergence.
- Add `isProperlyFormedTomlDomain`, mirroring rippled's check in `StringUtilities.cpp:131-156` (length 4–128 + DNS segment/TLD regex). Go's RE2 has no lookaround, so the no-leading/trailing-hyphen constraint is expressed by splitting each segment into single-char and multi-char cases.
- In `Deserialize`, reject the whole manifest when the domain is malformed, matching rippled's `std::nullopt` in `Manifest.cpp:107-115`.

## Test plan
- [x] `just test-pkg ./internal/manifest/...` — added `TestManifest_Domain_Validation` (10 cases: valid simple/subdomain/hyphenated; rejected too-short/no-tld/trailing-dot/leading+trailing hyphen/numeric-tld/underscore)
- [x] `go vet` / `gofmt` clean

Fixes #573