### PR TITLE
fix: add EscrowFinish crypto-condition fulfillment fee surcharge

### DIFF
--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -111,7 +111,6 @@ func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConf
 		}
 	}
 
-	// Transactor::calculateBaseFee: base * (1 + signerCount).
 	fee := tx.CalculateMultiSigFee(base, len(e.GetCommon().Signers))
 
 	if e.Fulfillment != nil {

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -95,6 +95,36 @@ func (e *EscrowFinish) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(e)
 }
 
+// CalculateBaseFee mirrors rippled's EscrowFinish::calculateBaseFee: the
+// multisigned base fee plus, for a fulfillment-bearing EscrowFinish, a
+// crypto-condition surcharge of base * (32 + fulfillment.size()/16), where
+// fulfillment.size() is the decoded byte length. The CustomBaseFeeCalculator
+// dispatch in preclaim.go skips the multisig multiplier, so it is applied here.
+// Reference: rippled Escrow.cpp:682-693, Transactor.cpp:229-244
+func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConfig) uint64 {
+	base := config.BaseFee
+	if view != nil {
+		if data, err := view.Read(keylet.Fees()); err == nil && data != nil {
+			if fs, err := state.ParseFeeSettings(data); err == nil {
+				base = fs.GetBaseFee()
+			}
+		}
+	}
+
+	// Transactor::calculateBaseFee: base * (1 + signerCount).
+	fee := tx.CalculateMultiSigFee(base, len(e.GetCommon().Signers))
+
+	if e.Fulfillment != nil {
+		fulfillmentLen := len(*e.Fulfillment) / 2
+		if decoded, err := hex.DecodeString(*e.Fulfillment); err == nil {
+			fulfillmentLen = len(decoded)
+		}
+		fee += base * (32 + uint64(fulfillmentLen)/16)
+	}
+
+	return fee
+}
+
 // ApplyOnTec implements TecApplier. When tecEXPIRED is returned, this re-runs
 // credential expiration deletion against the engine's view so the side-effects
 // (credential deletion, owner count adjustment) persist even though the tx

--- a/internal/tx/escrow/escrow_test.go
+++ b/internal/tx/escrow/escrow_test.go
@@ -1,6 +1,7 @@
 package escrow
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
@@ -324,6 +325,68 @@ func TestEscrowFinishValidation(t *testing.T) {
 				if err != nil {
 					t.Errorf("expected no error, got %v", err)
 				}
+			}
+		})
+	}
+}
+
+// TestEscrowFinishCalculateBaseFee verifies the crypto-condition fulfillment
+// fee surcharge and multisig multiplier.
+// Reference: rippled Escrow.cpp EscrowFinish::calculateBaseFee.
+func TestEscrowFinishCalculateBaseFee(t *testing.T) {
+	const base = uint64(10)
+	config := tx.EngineConfig{BaseFee: base}
+
+	tests := []struct {
+		name        string
+		fulfillment *string
+		numSigners  int
+		expected    uint64
+	}{
+		{
+			name:     "unconditional, single-signed",
+			expected: base, // base * (1 + 0)
+		},
+		{
+			// "A0028000" decodes to 4 bytes -> 4/16 == 0 -> base * 32 surcharge.
+			name:        "small fulfillment, single-signed",
+			fulfillment: ptrString("A0028000"),
+			expected:    base + base*(32+0),
+		},
+		{
+			// 128-byte fulfillment -> 128/16 == 8 -> base * (32 + 8) surcharge.
+			name:        "large fulfillment, single-signed",
+			fulfillment: ptrString(strings.Repeat("AB", 128)),
+			expected:    base + base*(32+8),
+		},
+		{
+			name:       "unconditional, three signers",
+			numSigners: 2,
+			expected:   base * (1 + 2),
+		},
+		{
+			name:        "fulfillment with two signers",
+			fulfillment: ptrString("A0028000"),
+			numSigners:  2,
+			expected:    base*(1+2) + base*(32+0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &EscrowFinish{
+				BaseTx:        *tx.NewBaseTx(tx.TypeEscrowFinish, "rBob"),
+				Owner:         "rAlice",
+				OfferSequence: 1,
+				Fulfillment:   tt.fulfillment,
+			}
+			if tt.numSigners > 0 {
+				e.Common.Signers = make([]tx.SignerWrapper, tt.numSigners)
+			}
+
+			got := e.CalculateBaseFee(nil, config)
+			if got != tt.expected {
+				t.Errorf("CalculateBaseFee = %d, want %d", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- `EscrowFinish` now implements `CalculateBaseFee`, mirroring rippled's `EscrowFinish::calculateBaseFee` (`Escrow.cpp:682-693`): the multisigned base fee `base * (1 + signerCount)` plus, for a fulfillment-bearing tx, a surcharge of `base * (32 + fulfillment.size()/16)` using the **decoded** byte length.
- Because the `CustomBaseFeeCalculator` dispatch in `preclaim.go` bypasses the multisig multiplier, the override applies it itself.
- Base fee is read from the `Fees` ledger object when a view is present (matching `AccountDelete`), falling back to `config.BaseFee`.

Previously a fulfillment-bearing `EscrowFinish` was charged only the flat base fee, so large fulfillments were massively under-priced and the open-ledger fee-adequacy check passed transactions rippled would reject.

## Test plan
- [x] `go test ./internal/tx/escrow/...` — new `TestEscrowFinishCalculateBaseFee` covers unconditional, small/large fulfillment, and multisig combinations
- [x] `go vet ./internal/tx/escrow/...`
- Note: `TestMPTEscrow_CancelPreclaim/AccountDeauthorizedAfterCreate` fails in `internal/testing/escrow`, but it is **pre-existing on `main`** (verified by stashing this change) and unrelated to `EscrowFinish`.

Fixes #567