### PR TITLE
fix: scale open-ledger fee floor by LoadFeeTrack in checkFee

### DIFF
--- a/internal/ledger/openledger/apply.go
+++ b/internal/ledger/openledger/apply.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/LeJamon/goXRPLd/amendment"
+	"github.com/LeJamon/goXRPLd/internal/feetrack"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
@@ -81,6 +82,14 @@ type ApplyConfig struct {
 	// Default zero — fail_hard rejection only fires when callers
 	// explicitly set the bit.
 	ApplyFlags tx.ApplyFlags
+	// FeeTrack is the node-local LoadFeeTrack. Threaded into
+	// tx.EngineConfig so the open-ledger fee floor reflects local /
+	// cluster / global load (scaleFeeLoad), matching rippled's
+	// Transactor::minimumFee. Nil leaves the floor at the raw base fee.
+	// Only takes effect on open-ledger applies (EngineConfig gates the
+	// fee-adequacy check on OpenLedger); the consensus-build path leaves
+	// it ignored.
+	FeeTrack *feetrack.LoadFeeTrack
 }
 
 // ApplyTxs runs rippled's open-ledger 3-pass apply against view, which
@@ -166,6 +175,7 @@ func applyOneSingle(view *ledger.Ledger, transaction tx.Transaction, blob []byte
 		Logger:                    cfg.Logger,
 		SkipSignatureVerification: cfg.SkipSignatureVerification,
 		Rules:                     cfg.Rules,
+		FeeTrack:                  cfg.FeeTrack,
 	}
 	if retry {
 		engineConfig.ApplyFlags |= tx.TapRETRY
@@ -223,6 +233,7 @@ func ApplyTxs(view *ledger.Ledger, txs []PendingTx, retries *[]PendingTx, cfg Ap
 			Logger:                    cfg.Logger,
 			SkipSignatureVerification: skipSig,
 			Rules:                     cfg.Rules,
+			FeeTrack:                  cfg.FeeTrack,
 		}
 		if certainRetry {
 			engineConfig.ApplyFlags |= tx.TapRETRY

--- a/internal/ledger/openledger/txqadapter.go
+++ b/internal/ledger/openledger/txqadapter.go
@@ -158,6 +158,7 @@ func (a *TxqAdapter) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
 		Logger:                    a.cfg.Logger,
 		SkipSignatureVerification: a.cfg.SkipSignatureVerification,
 		Rules:                     a.cfg.Rules,
+		FeeTrack:                  a.cfg.FeeTrack,
 	}
 	engine := tx.NewEngine(a.view, engineCfg)
 	bp := tx.NewBlockProcessor(engine)
@@ -239,6 +240,7 @@ func (a *TxqAdapter) PreclaimTransaction(txn tx.Transaction, accountID [20]byte,
 		SkipSignatureVerification: a.cfg.SkipSignatureVerification,
 		OpenLedger:                true,
 		Rules:                     a.cfg.Rules,
+		FeeTrack:                  a.cfg.FeeTrack,
 	}
 	engine := tx.NewEngine(clone, engineCfg)
 	return engine.Preclaim(txn, txHash)

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -732,6 +732,7 @@ func (s *Service) acceptOpenLedgerViewLocked(closedSeq uint32, buildRetries []op
 		ParentCloseTime:  parentCloseTimeRippleEpoch(s.closedLedger),
 		Logger:           s.config.Logger,
 		Rules:            rulesFromLedger(s.closedLedger, s.logger),
+		FeeTrack:         s.feeTrack,
 	}
 	// Modifier closure mirrors rippled OpenLedger.cpp:113 calling
 	// app_.getTxQ().accept(app_, view) after the replay phases — this is
@@ -796,6 +797,7 @@ func (s *Service) applyConfigLocked() (openledger.ApplyConfig, error) {
 		ParentCloseTime:  parentCloseTimeRippleEpoch(s.closedLedger),
 		Logger:           s.config.Logger,
 		Rules:            rulesFromLedger(s.closedLedger, s.logger),
+		FeeTrack:         s.feeTrack,
 	}, nil
 }
 

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -539,6 +539,7 @@ func (s *Service) SimulateTransaction(transaction tx.Transaction) (*SubmitResult
 		NetworkID:                 s.config.NetworkID,
 		Logger:                    s.config.Logger,
 		Rules:                     rulesFromLedger(s.closedLedger, s.logger),
+		FeeTrack:                  s.feeTrack,
 	}
 
 	// Create engine with the snapshot view

--- a/internal/tx/checkfee_loadfeetrack_test.go
+++ b/internal/tx/checkfee_loadfeetrack_test.go
@@ -1,0 +1,86 @@
+package tx
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/feetrack"
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+)
+
+// newFeeTestTx builds a minimal AccountSet-typed transaction carrying the
+// given Fee (drops, decimal string). AccountSet has no custom base-fee
+// calculator, so preclaimBaseFee resolves to EngineConfig.BaseFee.
+func newFeeTestTx(fee string) Transaction {
+	t := NewBaseTx(TypeAccountSet, "rTestAccount")
+	t.Fee = fee
+	return t
+}
+
+// TestCheckFee_LoadFeeTrackScaling verifies that checkFee scales the
+// open-ledger fee floor by the LoadFeeTrack factor (rippled's
+// Transactor::minimumFee → scaleFeeLoad), and that the scaling is gated on
+// OpenLedger and a non-nil tracker.
+func TestCheckFee_LoadFeeTrackScaling(t *testing.T) {
+	const baseFee = 10
+	account := &state.AccountRoot{Balance: 1_000_000}
+
+	// Remote fee at 2x the load base raises the effective floor to 2*baseFee.
+	loaded := feetrack.New()
+	loaded.SetRemoteFee(2 * feetrack.LoadBase)
+
+	tests := []struct {
+		name       string
+		fee        string
+		feeTrack   *feetrack.LoadFeeTrack
+		openLedger bool
+		want       Result
+	}{
+		{name: "nil tracker, fee meets base", fee: "10", feeTrack: nil, openLedger: true, want: TesSUCCESS},
+		{name: "nil tracker, fee below base", fee: "9", feeTrack: nil, openLedger: true, want: TelINSUF_FEE_P},
+		{name: "loaded, fee below scaled floor", fee: "10", feeTrack: loaded, openLedger: true, want: TelINSUF_FEE_P},
+		{name: "loaded, fee meets scaled floor", fee: "20", feeTrack: loaded, openLedger: true, want: TesSUCCESS},
+		{name: "loaded but ledger closed: no scaling", fee: "10", feeTrack: loaded, openLedger: false, want: TesSUCCESS},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Engine{config: EngineConfig{
+				BaseFee:    baseFee,
+				OpenLedger: tt.openLedger,
+				FeeTrack:   tt.feeTrack,
+			}}
+			txn := newFeeTestTx(tt.fee)
+			if got := e.checkFee(txn, txn.GetCommon(), account); got != tt.want {
+				t.Errorf("checkFee(fee=%s) = %v, want %v", tt.fee, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCheckFee_UnlimitedCarveOut verifies that TapUNLIMITED is threaded into
+// scaleFeeLoad: under moderate local-only load (between 1x and 4x remote) a
+// privileged source pays the remote-rate floor instead of the local one,
+// mirroring rippled's bUnlimited branch in scaleFeeLoad.
+func TestCheckFee_UnlimitedCarveOut(t *testing.T) {
+	const baseFee = 10
+	account := &state.AccountRoot{Balance: 1_000_000}
+
+	// Two raises lift the local fee to 320 (256 + 256/4) while remote and
+	// cluster stay at the load base (256). feeFactor=320, remFee=256.
+	tr := feetrack.New()
+	tr.RaiseLocalFee() // first raise only arms the latch (raiseCount=1)
+	tr.RaiseLocalFee() // second raise actually scales local up to 320
+
+	// Non-unlimited floor: 10*320/256 = 12 (truncated). fee=10 is short.
+	e := &Engine{config: EngineConfig{BaseFee: baseFee, OpenLedger: true, FeeTrack: tr}}
+	txn := newFeeTestTx("10")
+	if got := e.checkFee(txn, txn.GetCommon(), account); got != TelINSUF_FEE_P {
+		t.Fatalf("checkFee(non-unlimited) = %v, want TelINSUF_FEE_P", got)
+	}
+
+	// Unlimited floor: carve-out drops feeFactor to remFee (256), so the
+	// floor is 10*256/256 = 10 and fee=10 now suffices.
+	eUnlimited := &Engine{config: EngineConfig{BaseFee: baseFee, OpenLedger: true, FeeTrack: tr, ApplyFlags: TapUNLIMITED}}
+	if got := eUnlimited.checkFee(txn, txn.GetCommon(), account); got != TesSUCCESS {
+		t.Fatalf("checkFee(unlimited) = %v, want TesSUCCESS", got)
+	}
+}

--- a/internal/tx/engine.go
+++ b/internal/tx/engine.go
@@ -8,6 +8,7 @@ import (
 	binarycodec "github.com/LeJamon/goXRPLd/codec/binarycodec"
 	"github.com/LeJamon/goXRPLd/crypto/common"
 	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/feetrack"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/keylet"
 	xrpllog "github.com/LeJamon/goXRPLd/log"
@@ -136,6 +137,18 @@ type EngineConfig struct {
 	// Logger is the logger to use for this engine instance.
 	// If nil, xrpllog.Discard() is used — safe for tests and zero-value construction.
 	Logger xrpllog.Logger
+
+	// FeeTrack is the node-local LoadFeeTrack snapshot. When set and the
+	// ledger is open, checkFee scales the per-tx base fee by the local /
+	// cluster / global load factor (scaleFeeLoad) before the fee-adequacy
+	// comparison, mirroring rippled's Transactor::minimumFee. When nil,
+	// the open-ledger floor is the raw base fee — feetrack.ScaleFeeLoad
+	// returns its input unchanged for a nil tracker, so paths that do not
+	// plumb it keep their prior behaviour. Only consulted when OpenLedger
+	// is true (rippled gates minimumFee on ctx.view.open()).
+	// Reference: rippled Transactor.cpp minimumFee → scaleFeeLoad,
+	// LoadFeeTrack.cpp:85.
+	FeeTrack *feetrack.LoadFeeTrack
 }
 
 // GetRules returns the amendment rules, falling back to AllSupportedRules if nil.

--- a/internal/tx/preclaim.go
+++ b/internal/tx/preclaim.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/goXRPLd/amendment"
 	addresscodec "github.com/LeJamon/goXRPLd/codec/addresscodec"
+	"github.com/LeJamon/goXRPLd/internal/feetrack"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/keylet"
 )
@@ -173,9 +174,19 @@ func (e *Engine) checkFee(tx Transaction, common *Common, account *state.Account
 	// Fee adequacy check: only when the ledger is open.
 	// Reference: rippled Transactor::checkFee lines 277-290:
 	//   "Only check fee is sufficient when the ledger is open."
+	//   feeDue = minimumFee = scaleFeeLoad(baseFee, feeTrack, unlimited)
 	//   When the view is NOT open, fee=0 is accepted (line 292-293).
 	if e.config.OpenLedger {
-		if fee < baseFeeForTx {
+		unlimited := e.config.ApplyFlags&TapUNLIMITED != 0
+		feeDue, scaleErr := feetrack.ScaleFeeLoad(baseFeeForTx, e.config.FeeTrack, unlimited)
+		if scaleErr != nil {
+			// scaleFeeLoad overflow: the load-scaled floor exceeds any
+			// payable fee, so no fee can satisfy it. rippled throws here;
+			// reject with the same insufficient-fee code the comparison
+			// would otherwise yield.
+			return TelINSUF_FEE_P
+		}
+		if fee < feeDue {
 			return TelINSUF_FEE_P
 		}
 	}

--- a/tasks/conformance-audit.md
+++ b/tasks/conformance-audit.md
@@ -305,3 +305,20 @@ incremental reviews instead of re-reading rippled from scratch.
 - Files cleanup-only (Phase 0 skipped Phase 1): none
 - Cleanup commit: da2f4a5c — chore: clean ai-generated comments (removed 1 restated-assertion comment in missing_methods_test.go; PrintMethod doc comment kept — load-bearing rippled Print.cpp rationale + design-divergence why). No behavior change.
 - Notes: Zero blocking findings → Phase 2 ran automatically. No review-fix commit (Minor + Nit do not gate). Local gates build/vet/lint all green; tests delegated to CI per finalize policy. Branch was 5 commits behind origin/main at finalize (under the 50 threshold; no rebase prompted).
+
+## 2026-05-29 — PR #585 — fix/issue-572-checkfee-loadfeetrack
+- Rippled SHA at review: 1e89286a92
+- PR URL: https://github.com/LeJamon/go-xrpl/pull/585
+- Review comment: https://github.com/LeJamon/go-xrpl/pull/585#issuecomment-4574781173
+- Files reviewed (Phase 1):
+  - internal/tx/preclaim.go — 1 Nit, 0 blocking. checkFee now computes feeDue = ScaleFeeLoad(baseFeeForTx, FeeTrack, unlimited) before the open-ledger fee-adequacy compare, faithfully mirroring Transactor::checkFee (Transactor.cpp:258-290) → minimumFee (Transactor.cpp:247-255) → scaleFeeLoad (LoadFeeTrack.cpp:85-111). Open-ledger gate, ordering (feeDue before fee==0 short-circuit), and TelINSUF_FEE_P all match. N1: overflow path returns TelINSUF_FEE_P where rippled Throw<std::overflow_error> propagates as a tef-class result (LoadFeeTrack.cpp:108-109) — unreachable in practice (baseFee*feeFactor ~1e11 « 2^64), documented in-code; no action.
+  - internal/tx/engine.go — 0 findings. EngineConfig.FeeTrack field (exported, doc carries nil-fallback why + rippled cite).
+  - internal/feetrack/feetrack.go — NOT in this PR's diff (pre-existing); ScaleFeeLoad/GetScalingFactors verified against LoadFeeTrack.cpp:85-111 / LoadFeeTrack.h:102-110 as the key dependency of the change.
+  - internal/ledger/openledger/apply.go, txqadapter.go — 0 findings (FeeTrack threaded into every open-ledger engine config: apply.go:178,236; txqadapter.go:161,243).
+  - internal/ledger/service/service.go, tx_query.go — 0 findings (s.feeTrack → engine configs at service.go:735,800 and tx_query.go:542 simulate; s.feeTrack always non-nil via feetrack.New() at service.go:355).
+  - internal/tx/checkfee_loadfeetrack_test.go — 0 findings. Covers nil-tracker pass/fail, loaded scaling pass/fail, OpenLedger gating, unlimited carve-out both directions.
+  - M1 (Minor, not introduced by this PR): the TapUNLIMITED carve-out (preclaim.go:180) is implemented and tested correctly but dormant in production — no goXRPL path sets TapUNLIMITED, whereas rippled sets it on admin submissions (NetworkOPs.cpp:1513). Pre-existing submission-ingress gap; effect is conservative (admins pay the full local floor). Not a merge blocker.
+- Wire-shape verify pass: skipped (justified) — no files under internal/rpc/handlers/ or internal/peermanagement/; the change is a preclaim fee-floor computation with no JSON/wire-shape surface.
+- Files cleanup-only (Phase 0 skipped Phase 1): none
+- Cleanup commit: none — Phase 2 was a no-op. All PR-introduced comments are load-bearing (rippled cites, nil-fallback/overflow-divergence why, test-setup arithmetic + raise-latch hysteresis); no banner/temporal/restatement/next-line cruft to strip. Per cleaning-ai-comments keep-rules they stay.
+- Notes: Zero blocking findings → Phase 2 ran automatically; Minor/Nit do not gate. Verified the no-load no-op property: at construction all three factors = LoadBase so ScaleFeeLoad returns baseFee unchanged → byte-identical to the pre-PR raw-floor compare on an idle network (no regression). Tracker is fed in production (Raise/LowerLocalFee per close service.go:704/706, SetRemoteFee adaptor.go:1743, SetClusterFee overlay sink cli/server.go:452). Local gates build/vet/lint all green (lint 0 issues); tests delegated to CI per finalize policy. Branch 0 commits behind origin/main at finalize.


### PR DESCRIPTION
## Summary
- `Engine.checkFee` enforced only the static base fee as the open-ledger floor, omitting rippled's node-local load multiplier (`minimumFee = scaleFeeLoad(baseFee, feeTrack, tapUNLIMITED)`). Under elevated local/cluster/global load a tx reaching the engine in an open ledger could be accepted with a fee rippled would reject with `telINSUF_FEE_P`.
- `checkFee` now derives the open-ledger floor via `feetrack.ScaleFeeLoad` over the per-tx base fee, honouring `tapUNLIMITED`. The `LoadFeeTrack` snapshot is plumbed through `tx.EngineConfig` and `openledger.ApplyConfig` from the `Service`'s `feeTrack` on the open-ledger apply, TxQ preclaim, and simulate paths.
- A nil tracker leaves the floor at the raw base fee, so closed-ledger (consensus) application and any path that doesn't plumb the tracker are unchanged — matching rippled's `ctx.view.open()` gate.

## Test plan
- [x] `go test ./internal/tx/ -run TestCheckFee -v` — new unit tests cover scaled-floor rejection/acceptance, the `OpenLedger` + nil-tracker gates, and the `tapUNLIMITED` carve-out.
- [x] `go test ./internal/tx/... ./internal/ledger/openledger/... ./internal/ledger/service/... ./internal/feetrack/... ./internal/rpc/... ./internal/txq/...` — all pass.
- [x] `go vet` + full `go build ./...` clean.

Fixes #572