### PR TITLE
fix: set fix1623 delivered_amount metadata for CheckCash

### DIFF
--- a/internal/testing/check/check_test.go
+++ b/internal/testing/check/check_test.go
@@ -1733,7 +1733,6 @@ func TestCheck_Fix1623Enable(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Without fix1623, there should be NO delivered_amount in metadata.
 		require.NotNil(t, result.Metadata)
 		require.Nil(t, result.Metadata.DeliveredAmount, "delivered_amount must not be set without fix1623")
 	})

--- a/internal/testing/check/check_test.go
+++ b/internal/testing/check/check_test.go
@@ -660,6 +660,30 @@ func TestCheck_CashXRP(t *testing.T) {
 		jtx.RequireOwnerCount(t, env, alice, 0)
 		jtx.RequireOwnerCount(t, env, bob, 0)
 	})
+
+	t.Run("DeliverMinUnderfundedSource", func(t *testing.T) {
+		// SendMax exceeds the source's liquid XRP and DeliverMin sits above
+		// that liquid amount. rippled returns tecPATH_PARTIAL here (its
+		// preclaim funds check at CashCheck.cpp:179 pre-empts the doApply
+		// tecUNFUNDED_PAYMENT at :319, since availableFunds there equals the
+		// xrpLiquid used in doApply), so goXRPL must return tecPATH_PARTIAL too.
+		fund := jtx.NewAccount("alice2")
+		dst := jtx.NewAccount("bob2")
+		env.FundAmount(fund, uint64(jtx.XRP(260))+baseFee)
+		env.Fund(dst)
+		env.Close()
+
+		chkID := check.GetCheckID(fund, env.Seq(fund))
+		result := env.Submit(check.CheckCreate(fund, dst, tx.NewXRPAmount(jtx.XRP(200))).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// fund's liquid XRP is ~60 (260 balance - 200 base reserve), below the
+		// 150 DeliverMin but under SendMax(200).
+		result = env.Submit(check.CheckCashDeliverMin(dst, chkID, tx.NewXRPAmount(jtx.XRP(150))).Build())
+		require.Equal(t, "tecPATH_PARTIAL", result.Code)
+		env.Close()
+	})
 }
 
 // TestCheck_CashIOU tests many valid ways to cash a check for an IOU.
@@ -794,9 +818,10 @@ func TestCheck_CashIOU(t *testing.T) {
 		require.Equal(t, "tecPATH_PARTIAL", result.Code)
 		env.Close()
 
-		// Lower DeliverMin succeeds, delivers what's available
+		// Lower DeliverMin succeeds, delivering all USD(8) alice holds.
 		result = env.Submit(check.CheckCashDeliverMin(bob, chkID9, USD(7)).Build())
 		jtx.RequireTxSuccess(t, result)
+		requireDeliveredAmount(t, result, USD(8))
 		env.Close()
 
 		// Pay alice back some funds for next test
@@ -807,6 +832,7 @@ func TestCheck_CashIOU(t *testing.T) {
 		// Exact match with DeliverMin
 		result = env.Submit(check.CheckCashDeliverMin(bob, chkID7, USD(7)).Build())
 		jtx.RequireTxSuccess(t, result)
+		requireDeliveredAmount(t, result, USD(7))
 		env.Close()
 
 		// Fund alice for next test
@@ -814,14 +840,53 @@ func TestCheck_CashIOU(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Partial cash with lower DeliverMin
+		// Partial cash with lower DeliverMin delivers the full SendMax USD(6).
 		result = env.Submit(check.CheckCashDeliverMin(bob, chkID6, USD(4)).Build())
+		jtx.RequireTxSuccess(t, result)
+		requireDeliveredAmount(t, result, USD(6))
+		env.Close()
+
+		// Last check with minimal DeliverMin delivers the USD(2) alice has left.
+		result = env.Submit(check.CheckCashDeliverMin(bob, chkID8, USD(2)).Build())
+		jtx.RequireTxSuccess(t, result)
+		requireDeliveredAmount(t, result, USD(2))
+		env.Close()
+	})
+
+	t.Run("MakesTrustLineSetsDeliveredAmount", func(t *testing.T) {
+		// With CheckCashMakesTrustLine enabled (the default), delivered_amount
+		// is set for every IOU cash, including an exact Amount with no
+		// pre-existing trust line. Reference: CashCheck.cpp L477-480.
+		env := jtx.NewTestEnv(t)
+
+		gw := jtx.NewAccount("gateway")
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		USD := func(value float64) tx.Amount {
+			return tx.NewIssuedAmountFromFloat64(value, "USD", gw.Address)
+		}
+
+		env.Fund(gw, alice, bob)
+		env.Close()
+
+		result := env.Submit(trustset.TrustSet(alice, USD(20)).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		result = env.Submit(payment.PayIssued(gw, alice, USD(10)).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Last check with minimal DeliverMin
-		result = env.Submit(check.CheckCashDeliverMin(bob, chkID8, USD(2)).Build())
+		chkID := check.GetCheckID(alice, env.Seq(alice))
+		result = env.Submit(check.CheckCreate(alice, bob, USD(10)).Build())
 		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// bob has no USD trust line; CheckCashMakesTrustLine creates it and
+		// delivered_amount is set even though this is an exact Amount, not a
+		// DeliverMin.
+		result = env.Submit(check.CheckCashAmount(bob, chkID, USD(8)).Build())
+		jtx.RequireTxSuccess(t, result)
+		requireDeliveredAmount(t, result, USD(8))
 		env.Close()
 	})
 
@@ -1709,6 +1774,21 @@ func TestCheck_CancelInvalid(t *testing.T) {
 		require.Equal(t, "tecNO_ENTRY", result.Code)
 		env.Close()
 	})
+}
+
+// requireDeliveredAmount asserts the metadata carries the expected
+// delivered_amount. Mirrors rippled's verifyDeliveredAmount (Check_test.cpp:117).
+func requireDeliveredAmount(t *testing.T, result jtx.TxResult, expected tx.Amount) {
+	t.Helper()
+	require.NotNil(t, result.Metadata)
+	require.NotNil(t, result.Metadata.DeliveredAmount, "delivered_amount must be set")
+	got := *result.Metadata.DeliveredAmount
+	require.Equal(t, expected.IsNative(), got.IsNative())
+	require.Equal(t, 0, expected.Compare(got), "delivered_amount = %s, want %s", got.Value(), expected.Value())
+	if !expected.IsNative() {
+		require.Equal(t, expected.Currency, got.Currency)
+		require.Equal(t, expected.Issuer, got.Issuer)
+	}
 }
 
 // TestCheck_Fix1623Enable tests the fix1623 amendment for DeliveredAmount.

--- a/internal/testing/check/check_test.go
+++ b/internal/testing/check/check_test.go
@@ -1733,8 +1733,9 @@ func TestCheck_Fix1623Enable(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Without fix1623, there should be NO DeliveredAmount in metadata
-		// TODO: Verify metadata when RPC is available
+		// Without fix1623, there should be NO delivered_amount in metadata.
+		require.NotNil(t, result.Metadata)
+		require.Nil(t, result.Metadata.DeliveredAmount, "delivered_amount must not be set without fix1623")
 	})
 
 	t.Run("WithFix1623", func(t *testing.T) {
@@ -1755,8 +1756,14 @@ func TestCheck_Fix1623Enable(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// With fix1623, DeliveredAmount and delivered_amount should be in metadata
-		// TODO: Verify metadata when RPC is available
+		// With fix1623, delivered_amount must be set to the amount actually
+		// delivered, which is the full SendMax (200 XRP) since alice's liquid
+		// XRP exceeds it. Reference: CashCheck.cpp L322-324.
+		expected := tx.NewXRPAmount(jtx.XRP(200))
+		require.NotNil(t, result.Metadata)
+		require.NotNil(t, result.Metadata.DeliveredAmount, "delivered_amount must be set with fix1623")
+		require.True(t, result.Metadata.DeliveredAmount.IsNative())
+		require.Equal(t, expected.Value(), result.Metadata.DeliveredAmount.Value())
 	})
 }
 

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -289,6 +289,13 @@ func (c *CheckCash) applyCashXRPDeliverMin(ctx *tx.ApplyContext, check *state.Ch
 		return tx.TecPATH_PARTIAL
 	}
 
+	// Set delivered_amount metadata for the DeliverMin XRP path when fix1623
+	// is enabled. Reference: CashCheck.cpp L322-324.
+	if ctx.Rules().Enabled(amendment.FeatureFix1623) {
+		deliveredAmt := tx.NewXRPAmount(int64(cashAmount))
+		ctx.Metadata.DeliveredAmount = &deliveredAmt
+	}
+
 	// Transfer XRP
 	creatorAccount.Balance -= cashAmount
 	ctx.Account.Balance += cashAmount
@@ -564,6 +571,15 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	// Reference: CashCheck.cpp scope_exit at L426-429
 	if savedLimit != nil {
 		restoreTrustLineLimit(ctx, accountID, issuerID, sendMax.Currency, destLow, *savedLimit)
+	}
+
+	// Set delivered_amount metadata. Reference: CashCheck.cpp L463-480.
+	// - DeliverMin without CheckCashMakesTrustLine: set when fix1623 enabled.
+	// - CheckCashMakesTrustLine: always set, regardless of fix1623/DeliverMin.
+	if checkCashMakesTrustLine ||
+		(isDeliverMin && ctx.Rules().Enabled(amendment.FeatureFix1623)) {
+		deliveredAmt := payment.FromEitherAmount(actualOut)
+		ctx.Metadata.DeliveredAmount = &deliveredAmt
 	}
 
 	// Remove check from directories before erasing.

--- a/tasks/conformance-audit.md
+++ b/tasks/conformance-audit.md
@@ -305,3 +305,14 @@ incremental reviews instead of re-reading rippled from scratch.
 - Files cleanup-only (Phase 0 skipped Phase 1): none
 - Cleanup commit: da2f4a5c — chore: clean ai-generated comments (removed 1 restated-assertion comment in missing_methods_test.go; PrintMethod doc comment kept — load-bearing rippled Print.cpp rationale + design-divergence why). No behavior change.
 - Notes: Zero blocking findings → Phase 2 ran automatically. No review-fix commit (Minor + Nit do not gate). Local gates build/vet/lint all green; tests delegated to CI per finalize policy. Branch was 5 commits behind origin/main at finalize (under the 50 threshold; no rebase prompted).
+
+## 2026-05-29 — PR #587 — fix/issue-569-checkcash-delivered-amount
+- Rippled SHA at review: 1e89286a92
+- PR URL: https://github.com/LeJamon/go-xrpl/pull/587
+- Review comment: https://github.com/LeJamon/go-xrpl/pull/587#issuecomment-4574775560
+- Files reviewed (Phase 1):
+  - internal/tx/check/check_cash.go — 2 findings, 0 blocking. PR sets `delivered_amount` metadata for CheckCash per fix1623 in two paths. XRP DeliverMin (`applyCashXRPDeliverMin:294-297`): emit gated on fix1623 (DeliverMin implicit by function), value `min(sendMax,srcLiquid)` == rippled `xrpDeliver` on success path — matches CashCheck.cpp:322-324. IOU (`applyCashIOUAmount:579-583`): `checkCashMakesTrustLine || (isDeliverMin && fix1623)` proven equivalent (full truth table) to rippled's two branches CashCheck.cpp:472-474 + :479-480; value = flow `actualOut`. Minor: IOU delivered_amount paths have NO Go test coverage (rippled Check_test.cpp:904,919,934,945,1008,1137 assert verifyDeliveredAmount across IOU cases; Go TestCheck_Fix1623Enable covers only native XRP DeliverMin). Nit (pre-existing, out of diff scope): XRP DeliverMin underfunded source returns tecPATH_PARTIAL (check_cash.go:283-290) where rippled returns tecUNFUNDED_PAYMENT (CashCheck.cpp:307-319) — no delivered_amount impact (errors before any deliver()).
+- Wire-shape verify pass: not run — diff touches neither internal/rpc/handlers/ nor internal/peermanagement/, so the verify trigger did not fire. delivered_amount JSON serialization is pre-existing metadata infra untouched by this PR.
+- Files cleanup-only (Phase 0 not skipped; this file is non-protocol-bearing): internal/testing/check/check_test.go
+- Cleanup commit: c46f3cec — chore: clean ai-generated comments (removed 1 restated-next-line comment in check_test.go that duplicated the adjacent require message; reference-bearing comments in check_cash.go and the WithFix1623 "why 200 XRP" comment kept). No behavior change.
+- Notes: Zero blocking findings → Phase 2 ran automatically. No review-fix commit (Minor + Nit do not gate). Local gates build/vet/lint all green; tests delegated to CI per finalize policy. Branch was 0 commits behind origin/main at finalize (fresh; no rebase prompted).


### PR DESCRIPTION
## Summary
- Populate `delivered_amount` transaction metadata for `CheckCash`, mirroring rippled's `CashCheck` doApply:
  - **XRP DeliverMin** (`CashCheck.cpp:322-324`): set `DeliveredAmount` to the cashed amount when `fix1623` is enabled.
  - **IOU DeliverMin** (`CashCheck.cpp:472-474`): set to `actualAmountOut` when `fix1623` is enabled and `CheckCashMakesTrustLine` is not.
  - **IOU + CheckCashMakesTrustLine** (`CashCheck.cpp:479-480`): always set to `actualAmountOut`, regardless of `fix1623`/DeliverMin.
- Upgrade the previously stubbed `TestCheck_Fix1623Enable` to assert `delivered_amount` is present with `fix1623` and absent without it (replacing TODOs).

## The TER claim in #569 is not a bug — left unchanged
The issue also reported that the XRP insufficient-funds branch should return `tecUNFUNDED_PAYMENT` instead of `tecPATH_PARTIAL`. That is a misreading of rippled:

- rippled's **preclaim** (`CashCheck.cpp:179-184`) returns `tecPATH_PARTIAL` whenever `value > availableFunds` — i.e. for insufficient funds — *before* doApply's `tecUNFUNDED_PAYMENT` (`CashCheck.cpp:312-319`) is ever reached.
- For native XRP, `accountFunds(...)` resolves to `xrpLiquid(view, account, 0)` and preclaim adds one reserve increment, which is exactly `xrpLiquid(view, srcId, -1)` used by doApply. So the doApply check `srcLiquid < xrpDeliver` is **unreachable** for the insufficient-funds condition; it is defensive code.
- The same holds for the DeliverMin case: `xrpDeliver = max(deliverMin, min(sendMax, srcLiquid)) ≤ srcLiquid` once preclaim passes.

Confirmed by rippled's own test and goXRPL's mirror, both expecting `tecPATH_PARTIAL`:
- rippled `src/test/app/Check_test.cpp:669` — "alice is one drop shy of funding the check" → `tecPATH_PARTIAL`.
- goXRPL `internal/testing/check/check_test.go:649` (`CheckPastBalance`) → `tecPATH_PARTIAL`.

Changing the TER would diverge from rippled and break the existing conformance test, so the TER is intentionally left as-is. The `delivered_amount` gap is the only valid item, and it is fixed here.

## Test plan
- [x] `go test ./internal/tx/check/... ./internal/testing/check/...`
- [x] `TestCheck_Fix1623Enable/WithFix1623` asserts `delivered_amount == 200 XRP`; `WithoutFix1623` asserts it is absent
- [x] `gofmt` clean, `go vet ./internal/tx/check/...` clean

Fixes #569