### PR TITLE
fix: isolate TxQ account-queue clearing in an OpenView sandbox (#566)

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -479,6 +479,34 @@ func (l *Ledger) AdjustDropsDestroyed(drops drops.XRPAmount) {
 	l.dropsDestroyed = l.dropsDestroyed.Add(drops)
 }
 
+// AdoptState replaces this ledger's state map, transaction map, and
+// destroyed-drops tally with those of src. It is the analogue of rippled's
+// OpenView::apply(view) — committing a sandbox's accumulated changes back
+// into the parent view in one shot (TxQ.cpp:1218 `sandbox.apply(view)`).
+//
+// src is expected to be a MutableSnapshot of this ledger that has since
+// been mutated; on commit it surrenders ownership of its maps to the
+// parent. Header and fees are unchanged (apply only touches state, the tx
+// tree, and dropsDestroyed before close).
+func (l *Ledger) AdoptState(src *Ledger) error {
+	if src == nil {
+		return errors.New("ledger: AdoptState from nil source")
+	}
+
+	src.mu.RLock()
+	stateMap := src.stateMap
+	txMap := src.txMap
+	dropsDestroyed := src.dropsDestroyed
+	src.mu.RUnlock()
+
+	l.mu.Lock()
+	l.stateMap = stateMap
+	l.txMap = txMap
+	l.dropsDestroyed = dropsDestroyed
+	l.mu.Unlock()
+	return nil
+}
+
 // AddTransaction adds a transaction to the transaction tree
 func (l *Ledger) AddTransaction(txHash [32]byte, txData []byte) error {
 	l.mu.Lock()

--- a/internal/ledger/openledger/txqadapter.go
+++ b/internal/ledger/openledger/txqadapter.go
@@ -1,9 +1,12 @@
 package openledger
 
 import (
+	"errors"
+
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/txq"
 	"github.com/LeJamon/goXRPLd/keylet"
 )
 
@@ -242,6 +245,44 @@ func (a *TxqAdapter) PreclaimTransaction(txn tx.Transaction, accountID [20]byte,
 	}
 	engine := tx.NewEngine(clone, engineCfg)
 	return engine.Preclaim(txn, txHash)
+}
+
+// NewSandbox returns an isolated child context over a mutable snapshot of
+// this adapter's view. Transactions applied to the sandbox stay isolated
+// until Commit folds them back into the parent view. Mirrors rippled's
+// `OpenView sandbox(open_ledger, &view, view.rules())` and
+// `sandbox.apply(view)` (TxQ.cpp:1202, 1218).
+func (a *TxqAdapter) NewSandbox() (txq.SandboxContext, error) {
+	if a.view == nil {
+		return nil, errors.New("txqadapter: cannot sandbox a nil view")
+	}
+	snap, err := a.view.MutableSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	return &txqSandbox{parent: a, child: NewTxqAdapter(snap, a.cfg)}, nil
+}
+
+// txqSandbox isolates a batch of TxQ applies against a snapshot view. It
+// implements txq.SandboxContext.
+type txqSandbox struct {
+	parent *TxqAdapter
+	child  *TxqAdapter
+}
+
+func (s *txqSandbox) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
+	return s.child.ApplyTransaction(txn)
+}
+
+// Commit folds the sandbox's accumulated state back into the parent view and
+// propagates the last engine ApplyResult so the RPC submit path still reads
+// the submitted tx's Fee/Metadata/Message after a successful queue clear.
+func (s *txqSandbox) Commit() error {
+	if err := s.parent.view.AdoptState(s.child.view); err != nil {
+		return err
+	}
+	s.parent.lastApply = s.child.lastApply
+	return nil
 }
 
 func (a *TxqAdapter) readAccountRoot(accountID [20]byte) (*state.AccountRoot, bool) {

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -1074,8 +1074,32 @@ func (c *testClosedLedgerContext) GetLedgerSequence() uint32               { ret
 func (c *testClosedLedgerContext) GetTransactionFeeLevels() []txq.FeeLevel { return c.feeLevels }
 
 // testTxQApplyContext implements txq.ApplyContext for the test environment.
+//
+// When view is non-nil the context is operating as a sandbox child: applies
+// target that isolated snapshot instead of env.ledger, and the env counter
+// mutations (txInLedger / closingTxTotal / fee-level metrics) are deferred
+// into accum so they roll back with the sandbox unless Commit is called.
 type testTxQApplyContext struct {
-	env *TestEnv
+	env   *TestEnv
+	view  *ledger.Ledger
+	accum *txqSandboxAccum
+}
+
+// txqSandboxAccum buffers the env-counter side effects produced while applying
+// a batch into a sandbox, so they take effect only on Commit.
+type txqSandboxAccum struct {
+	txInLedger     uint32
+	closingTxTotal uint32
+	feeLevelTxns   []tx.Transaction
+}
+
+// applyView returns the ledger this context applies transactions to: the
+// sandbox snapshot when set, otherwise the live env ledger.
+func (c *testTxQApplyContext) applyView() *ledger.Ledger {
+	if c.view != nil {
+		return c.view
+	}
+	return c.env.ledger
 }
 
 func (c *testTxQApplyContext) GetAccountSequence(account [20]byte) uint32 {
@@ -1172,32 +1196,80 @@ func (c *testTxQApplyContext) ApplyTransaction(txn tx.Transaction) (tx.Result, b
 	// Reference: rippled NetworkOPsImp::apply (flags = tapNONE),
 	//   TxQ::tryDirectApply (uses same flags as NetworkOPs),
 	//   TxQ::tryClearAccountQueueUpThruTx (uses stored MaybeTx flags)
+	view := c.applyView()
 	engineConfig := tx.EngineConfig{
 		BaseFee:                   c.env.baseFee,
 		ReserveBase:               c.env.reserveBase,
 		ReserveIncrement:          c.env.reserveIncrement,
-		LedgerSequence:            c.env.ledger.Sequence(),
+		LedgerSequence:            view.Sequence(),
 		SkipSignatureVerification: !c.env.VerifySignatures,
 		Rules:                     c.env.rulesBuilder.Build(),
 		ParentCloseTime:           parentCloseTime,
 		NetworkID:                 c.env.networkID,
-		ParentHash:                c.env.ledger.ParentHash(),
+		ParentHash:                view.ParentHash(),
 		OpenLedger:                false,
 	}
 
-	engine := tx.NewEngine(c.env.ledger, engineConfig)
+	engine := tx.NewEngine(view, engineConfig)
 	applyResult := engine.Apply(txn)
 
 	applied := applyResult.Result.IsApplied()
 	if applied {
-		c.env.txInLedger++
-		c.env.closingTxTotal++
-		c.env.recordTxFeeLevel(txn)
+		innerCount := uint32(0)
 		if counter, ok := txn.(innerTxCounter); ok {
-			c.env.closingTxTotal += uint32(counter.InnerTxCount())
+			innerCount = uint32(counter.InnerTxCount())
+		}
+		if c.accum != nil {
+			// Sandbox child: defer the env-counter side effects until Commit.
+			c.accum.txInLedger++
+			c.accum.closingTxTotal += 1 + innerCount
+			c.accum.feeLevelTxns = append(c.accum.feeLevelTxns, txn)
+		} else {
+			c.env.txInLedger++
+			c.env.closingTxTotal += 1 + innerCount
+			c.env.recordTxFeeLevel(txn)
 		}
 	}
 	return applyResult.Result, applied
+}
+
+// NewSandbox returns an isolated child context over a mutable snapshot of the
+// context's current view, mirroring the production TxqAdapter sandbox. Applies
+// land on the snapshot and env-counter mutations are buffered until Commit.
+func (c *testTxQApplyContext) NewSandbox() (txq.SandboxContext, error) {
+	snap, err := c.applyView().MutableSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	accum := &txqSandboxAccum{}
+	child := &testTxQApplyContext{env: c.env, view: snap, accum: accum}
+	return &testTxQSandbox{parent: c, child: child, snap: snap, accum: accum}, nil
+}
+
+// testTxQSandbox implements txq.SandboxContext for the test environment.
+type testTxQSandbox struct {
+	parent *testTxQApplyContext
+	child  *testTxQApplyContext
+	snap   *ledger.Ledger
+	accum  *txqSandboxAccum
+}
+
+func (s *testTxQSandbox) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
+	return s.child.ApplyTransaction(txn)
+}
+
+// Commit folds the sandbox snapshot back into the parent view and applies the
+// buffered env-counter side effects.
+func (s *testTxQSandbox) Commit() error {
+	if err := s.parent.applyView().AdoptState(s.snap); err != nil {
+		return err
+	}
+	s.parent.env.txInLedger += s.accum.txInLedger
+	s.parent.env.closingTxTotal += s.accum.closingTxTotal
+	for _, txn := range s.accum.feeLevelTxns {
+		s.parent.env.recordTxFeeLevel(txn)
+	}
+	return nil
 }
 
 func (c *testTxQApplyContext) PreclaimTransaction(txn tx.Transaction, account [20]byte, adjustedBalance uint64, adjustedSeq uint32) tx.Result {

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -62,6 +62,27 @@ type ApplyContext interface {
 	// adapters) can return 0; TxQ only inspects TapFAIL_HARD to mirror
 	// rippled TxQ.cpp:393-399 (fail-hard txs are never held).
 	GetApplyFlags() tx.ApplyFlags
+
+	// NewSandbox returns an isolated child context backed by a mutable
+	// snapshot of this view. Transactions applied to the sandbox do not
+	// touch the live view until Commit folds them back in; discarding the
+	// sandbox (letting it fall out of scope) rolls everything back. Mirrors
+	// rippled's `OpenView sandbox(open_ledger, &view, view.rules())` and
+	// `sandbox.apply(view)` (TxQ.cpp:1202, 1216-1218).
+	NewSandbox() (SandboxContext, error)
+}
+
+// SandboxContext is an isolated view used to apply a batch of transactions
+// atomically. Apply each transaction via ApplyTransaction; call Commit only
+// when the whole batch succeeds to fold the accumulated state back into the
+// parent view. If Commit is never called the sandbox is simply discarded.
+type SandboxContext interface {
+	// ApplyTransaction applies txn to the sandbox view, returning the result
+	// and whether it was applied (same semantics as ApplyContext).
+	ApplyTransaction(txn tx.Transaction) (tx.Result, bool)
+
+	// Commit folds the sandbox's accumulated state back into the parent view.
+	Commit() error
 }
 
 // Apply attempts to apply a transaction or queue it for later.
@@ -478,7 +499,14 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		q.erase(replacingCandidate)
 	}
 
-	if !exists {
+	// q.erase drops the account from byAccount once its queue is empty — which
+	// happens when replacingCandidate was the account's only queued tx. Re-check
+	// the live map rather than the stale `exists` snapshot, otherwise the new
+	// candidate is added to an orphaned AccountQueue and byFee/byAccount diverge,
+	// hiding the queued tx from later blocker checks.
+	if liveAq, stillInMap := q.byAccount[account]; stillInMap {
+		aq = liveAq
+	} else {
 		aq = NewAccountQueue(account)
 		q.byAccount[account] = aq
 	}
@@ -551,53 +579,64 @@ func (q *TxQ) tryClearAccountQueue(
 		return nil
 	}
 
-	// Total fee is sufficient. Try to apply all preceding transactions in order.
-	// TODO: use sandbox view for full atomicity (matching rippled's OpenView).
-	// Currently, successfully-applied preceding txns cannot be rolled back if a
-	// later one fails. We track applied candidates to keep the queue consistent.
-	var applied []*Candidate
+	// Total fee is sufficient. Apply the whole batch into an isolated sandbox
+	// so a later failure leaves the live view untouched — mirroring rippled's
+	// `OpenView sandbox(...)` (TxQ.cpp:1202). The sandbox is committed to the
+	// live view only when the new tx applies; any failure discards it.
+	sandbox, err := ctx.NewSandbox()
+	if err != nil {
+		// Can't isolate the batch — fall through to normal queuing rather
+		// than risk mutating the live view non-atomically.
+		return nil
+	}
+
 	for _, c := range preceding {
-		result, ok := ctx.ApplyTransaction(c.Txn)
+		result, ok := sandbox.ApplyTransaction(c.Txn)
+		// Succeed or fail, use up a retry: if the overall process fails we
+		// want the attempt to count; on success the candidate is erased
+		// below. Bookkeeping lives on the queued candidate, not the sandbox,
+		// so it persists across a discard (rippled TxQ.cpp:566-571).
 		c.RetriesRemaining--
 		c.LastResult = result
 
 		if result == tx.TefNO_TICKET {
-			// Ticket was already consumed; treat as success for clearing purposes.
-			applied = append(applied, c)
+			// A ticketed tx that is both queued and already in the ledger can
+			// never succeed; treat it as cleared so the rest of the batch can
+			// proceed and the dead entry is erased (rippled TxQ.cpp:573-590).
 			continue
 		}
 
 		if !ok {
-			// A preceding transaction failed to apply. Erase already-applied
-			// candidates from the queue to stay consistent with ledger state.
-			for _, a := range applied {
-				q.erase(a)
-			}
+			// A preceding transaction failed. Discard the sandbox (the live
+			// view is untouched) and fall through to normal queuing. The queue
+			// is left intact, exactly as rippled does (TxQ.cpp:592-596).
 			return nil
 		}
-		applied = append(applied, c)
 	}
 
-	// All preceding transactions applied. Now apply the new transaction.
-	result, ok := ctx.ApplyTransaction(txn)
-	if ok {
-		// Remove all applied preceding transactions from the queue.
-		for _, c := range applied {
-			q.erase(c)
-		}
-		// Also remove the replacement if one exists at the new tx's seqProxy.
-		if c, exists := aq.Transactions[seqProxy]; exists {
-			q.erase(c)
-		}
-		return &ApplyResult{Result: result, Applied: true}
+	// All preceding transactions applied in the sandbox. Now apply the new
+	// transaction. Because the sandbox state has changed, this re-runs the
+	// full apply (rippled TxQ.cpp:598-600).
+	result, ok := sandbox.ApplyTransaction(txn)
+	if !ok {
+		// New transaction failed. Discard the sandbox so no state persists
+		// (the caller commits only on result.applied — TxQ.cpp:1216-1218).
+		return &ApplyResult{Result: result, Applied: false}
 	}
 
-	// New transaction failed but preceding ones were applied.
-	// Remove the applied preceding transactions from the queue.
-	for _, c := range applied {
+	// The whole batch applied. Commit the sandbox to the live view, then
+	// remove the cleared transactions from the queue (rippled TxQ.cpp:602-611).
+	if err := sandbox.Commit(); err != nil {
+		return nil
+	}
+	for _, c := range preceding {
 		q.erase(c)
 	}
-	return &ApplyResult{Result: result, Applied: false}
+	// Also remove the replacement if one exists at the new tx's seqProxy.
+	if c, exists := aq.Transactions[seqProxy]; exists {
+		q.erase(c)
+	}
+	return &ApplyResult{Result: result, Applied: true}
 }
 
 // canBeHeld checks whether the account queue can accept a new transaction

--- a/internal/txq/sandbox_test.go
+++ b/internal/txq/sandbox_test.go
@@ -1,0 +1,209 @@
+package txq
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/tx"
+)
+
+// mockTx is a minimal tx.Transaction used to drive tryClearAccountQueue in
+// isolation. Behavior keyed on identity, not contents.
+type mockTx struct{ id byte }
+
+func (m *mockTx) TxType() tx.Type                  { return tx.TypeAccountSet }
+func (m *mockTx) GetCommon() *tx.Common            { return &tx.Common{Fee: "10"} }
+func (m *mockTx) Validate() error                  { return nil }
+func (m *mockTx) Flatten() (map[string]any, error) { return map[string]any{}, nil }
+func (m *mockTx) GetRawBytes() []byte              { return []byte{m.id} }
+func (m *mockTx) SetRawBytes([]byte)               {}
+func (m *mockTx) RequiredAmendments() [][32]byte   { return nil }
+
+// mockSandbox records what was applied and whether the batch was committed.
+type mockSandbox struct {
+	results map[*mockTx]struct {
+		res     tx.Result
+		applied bool
+	}
+	appliedTo []*mockTx
+	committed bool
+}
+
+func (s *mockSandbox) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
+	mt := txn.(*mockTx)
+	s.appliedTo = append(s.appliedTo, mt)
+	r := s.results[mt]
+	return r.res, r.applied
+}
+
+func (s *mockSandbox) Commit() error {
+	s.committed = true
+	return nil
+}
+
+// mockClearCtx is an ApplyContext whose only meaningful method is NewSandbox.
+// tryClearAccountQueue applies the whole batch through the sandbox, so the
+// remaining methods are never reached and return zero values.
+type mockClearCtx struct {
+	sandbox *mockSandbox
+	newErr  error
+}
+
+func (c *mockClearCtx) GetAccountSequence([20]byte) uint32 { return 0 }
+func (c *mockClearCtx) AccountExists([20]byte) bool        { return true }
+func (c *mockClearCtx) TicketExists([20]byte, uint32) bool { return true }
+func (c *mockClearCtx) GetAccountBalance([20]byte) uint64  { return 0 }
+func (c *mockClearCtx) GetAccountReserve(uint32) uint64    { return 0 }
+func (c *mockClearCtx) GetBaseFee(tx.Transaction) uint64   { return 10 }
+func (c *mockClearCtx) GetTxInLedger() uint32              { return 0 }
+func (c *mockClearCtx) GetLedgerSequence() uint32          { return 0 }
+func (c *mockClearCtx) ApplyTransaction(tx.Transaction) (tx.Result, bool) {
+	return tx.TefINTERNAL, false
+}
+func (c *mockClearCtx) PreclaimTransaction(tx.Transaction, [20]byte, uint64, uint32) tx.Result {
+	return 0
+}
+func (c *mockClearCtx) GetApplyFlags() tx.ApplyFlags { return 0 }
+func (c *mockClearCtx) NewSandbox() (SandboxContext, error) {
+	return c.sandbox, c.newErr
+}
+
+// setupClearQueue builds a TxQ with one preceding queued tx (seq 1) for the
+// account and returns the queue, account queue, the preceding candidate, and
+// the new tx submitted at seq 2. Fee levels are set far above the escalated
+// series requirement so tryClearAccountQueue always advances to the apply
+// stage.
+func setupClearQueue() (*TxQ, *AccountQueue, *Candidate, *mockTx, [20]byte, SeqProxy) {
+	q := New(DefaultConfig())
+	account := [20]byte{1}
+	aq := NewAccountQueue(account)
+
+	precedingTx := &mockTx{id: 1}
+	preceding := &Candidate{
+		Txn:              precedingTx,
+		Account:          account,
+		FeeLevel:         FeeLevel(1_000_000),
+		SeqProxy:         NewSeqProxySequence(1),
+		RetriesRemaining: RetriesAllowed,
+	}
+	aq.Add(preceding)
+	q.byAccount[account] = aq
+	q.byFee = append(q.byFee, preceding)
+
+	newTx := &mockTx{id: 2}
+	return q, aq, preceding, newTx, account, NewSeqProxySequence(2)
+}
+
+func mkResults(entries ...struct {
+	tx      *mockTx
+	res     tx.Result
+	applied bool
+}) map[*mockTx]struct {
+	res     tx.Result
+	applied bool
+} {
+	m := make(map[*mockTx]struct {
+		res     tx.Result
+		applied bool
+	})
+	for _, e := range entries {
+		m[e.tx] = struct {
+			res     tx.Result
+			applied bool
+		}{e.res, e.applied}
+	}
+	return m
+}
+
+// TestTryClearAccountQueue_RollbackOnPrecedingFailure verifies that when a
+// preceding queued tx fails to apply, the sandbox is discarded (never
+// committed) and the queue is left intact — mirroring rippled TxQ.cpp:592-596.
+func TestTryClearAccountQueue_RollbackOnPrecedingFailure(t *testing.T) {
+	q, aq, preceding, newTx, account, seqProxy := setupClearQueue()
+	sb := &mockSandbox{results: mkResults(
+		struct {
+			tx      *mockTx
+			res     tx.Result
+			applied bool
+		}{preceding.Txn.(*mockTx), tx.TelCAN_NOT_QUEUE, false},
+	)}
+	ctx := &mockClearCtx{sandbox: sb}
+
+	result := q.tryClearAccountQueue(ctx, aq, newTx, seqProxy, FeeLevel(1_000_000), 4, account)
+
+	if result != nil {
+		t.Fatalf("expected nil (fall through to queuing), got %+v", *result)
+	}
+	if sb.committed {
+		t.Errorf("sandbox must NOT be committed when a preceding tx fails")
+	}
+	if len(sb.appliedTo) != 1 {
+		t.Errorf("only the failing preceding tx should be applied, got %d applies", len(sb.appliedTo))
+	}
+	if _, stillQueued := aq.Transactions[NewSeqProxySequence(1)]; !stillQueued {
+		t.Errorf("preceding tx must stay queued after a failed clear attempt")
+	}
+}
+
+// TestTryClearAccountQueue_RollbackOnNewTxFailure verifies that when all
+// preceding txs apply but the new tx fails, the sandbox is discarded and the
+// queue is left intact (rippled commits only on result.applied, TxQ.cpp:1216).
+func TestTryClearAccountQueue_RollbackOnNewTxFailure(t *testing.T) {
+	q, aq, preceding, newTx, account, seqProxy := setupClearQueue()
+	sb := &mockSandbox{results: mkResults(
+		struct {
+			tx      *mockTx
+			res     tx.Result
+			applied bool
+		}{preceding.Txn.(*mockTx), tx.TesSUCCESS, true},
+		struct {
+			tx      *mockTx
+			res     tx.Result
+			applied bool
+		}{newTx, tx.TelCAN_NOT_QUEUE, false},
+	)}
+	ctx := &mockClearCtx{sandbox: sb}
+
+	result := q.tryClearAccountQueue(ctx, aq, newTx, seqProxy, FeeLevel(1_000_000), 4, account)
+
+	if result == nil || result.Applied {
+		t.Fatalf("expected a non-applied result, got %v", result)
+	}
+	if sb.committed {
+		t.Errorf("sandbox must NOT be committed when the new tx fails")
+	}
+	if _, stillQueued := aq.Transactions[NewSeqProxySequence(1)]; !stillQueued {
+		t.Errorf("preceding tx must stay queued after a failed clear attempt")
+	}
+}
+
+// TestTryClearAccountQueue_CommitOnFullSuccess verifies the happy path: every
+// tx applies, the sandbox is committed exactly once, and the cleared preceding
+// txs are removed from the queue (rippled TxQ.cpp:602-611, 1218).
+func TestTryClearAccountQueue_CommitOnFullSuccess(t *testing.T) {
+	q, aq, preceding, newTx, account, seqProxy := setupClearQueue()
+	sb := &mockSandbox{results: mkResults(
+		struct {
+			tx      *mockTx
+			res     tx.Result
+			applied bool
+		}{preceding.Txn.(*mockTx), tx.TesSUCCESS, true},
+		struct {
+			tx      *mockTx
+			res     tx.Result
+			applied bool
+		}{newTx, tx.TesSUCCESS, true},
+	)}
+	ctx := &mockClearCtx{sandbox: sb}
+
+	result := q.tryClearAccountQueue(ctx, aq, newTx, seqProxy, FeeLevel(1_000_000), 4, account)
+
+	if result == nil || !result.Applied {
+		t.Fatalf("expected an applied result, got %v", result)
+	}
+	if !sb.committed {
+		t.Errorf("sandbox MUST be committed on full success")
+	}
+	if _, stillQueued := aq.Transactions[NewSeqProxySequence(1)]; stillQueued {
+		t.Errorf("preceding tx must be erased from the queue after a successful clear")
+	}
+}


### PR DESCRIPTION
## Summary

- **Atomic sandbox for `tryClearAccountQueue` (the issue's subject).** The clear-queue path applied each preceding queued tx directly to the live open-ledger view, so a later failure in the batch could not be rolled back — leaving partially-applied state committed and diverging from rippled (consensus risk). It now applies the whole batch into an isolated `OpenView`-style sandbox and commits to the live view **only** on full success, mirroring rippled `TxQ.cpp:1202` + `sandbox.apply(view)` at `1216-1218`. Any failure discards the sandbox; both the ledger and the queue are left untouched.
- **New abstraction:** `ApplyContext.NewSandbox() (SandboxContext, error)` + `Ledger.AdoptState` (the analogue of `OpenView::apply`). Implemented for the production `TxqAdapter` and the test `ApplyContext` (which defers its env-counter side effects until commit so they roll back with the sandbox).
- **Queue index-consistency fix (bonus).** While verifying the conformance impact I found an unrelated bug: replacing an account's *only* queued tx caused `q.erase` to drop the account from `byAccount`, but the stale `exists` snapshot kept the new candidate from re-registering — orphaning the `AccountQueue` so later blocker checks missed the queued tx. Now re-checks the live map.

## A note on the issue's "9 conformance failures"

The issue attributes 9 TxQ conformance failures to the missing sandbox. Investigation shows the sandbox is a genuine atomicity/consensus bug but is **not** what drives those failures (the failing set is byte-identical with and without the sandbox fix). The 9 have three independent root causes:

| Test | Root cause | Status |
|------|-----------|--------|
| `blockers_sequence`, `blockers_ticket` | queue index-consistency bug | **Fixed here** |
| `clear_queue_failure_(load)`, `Queue_full_drop_penalty`, `Re-execute_preflight` | conformance harness models no `LoadFeeTrack`/remote-fee escalation (the `setRemoteFee(origFee*5)` load event in rippled's C++ test isn't reproduced) | test-infra follow-up |
| `multi_tx_per_account` | multiTxn in-flight fee/balance accounting differs upstream of the preclaim (verified a faithful preclaim changes nothing) | follow-up |
| `Sequence_/Ticket_in_queue_and_open_ledger`, `unexpected_balance_change` | tx-execution divergences (balance/owner_count differ **before** the TxQ decision) — not TxQ bugs | separate |

Net conformance effect of this PR, measured across the **entire** suite: **2 fixed, 0 regressed** (263 → 261 failing subtests).

## Test plan

- [x] `go test ./internal/txq/... -run TestTryClearAccountQueue` — new unit tests assert sandbox rollback-on-failure (preceding fails / new tx fails) and commit-on-success.
- [x] `go test ./internal/txq/... ./internal/ledger/...` — green.
- [x] TxQ conformance: 9 → 7 failing (`blockers_sequence`/`blockers_ticket` now pass).
- [x] Full conformance diff vs `main`: exactly 2 fixed, 0 regressed.
- [x] `go build ./...`, `go vet`, `gofmt`; broad shared-env smoke (`internal/testing/offer`) green.

Fixes #566