### PR TITLE
fix: guard total-drops update against unsigned underflow

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -614,7 +614,6 @@ func (l *Ledger) Close(closeTime time.Time, closeFlags uint8) error {
 		return fmt.Errorf("failed to make tx map immutable: %w", err)
 	}
 
-	// Update drops (subtract destroyed). Underflow was checked up-front.
 	l.header.Drops -= uint64(l.dropsDestroyed)
 
 	// Get hashes

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -587,6 +587,19 @@ func (l *Ledger) Close(closeTime time.Time, closeFlags uint8) error {
 		return ErrInvalidState
 	}
 
+	// Guard the total-drops update against unsigned underflow before
+	// mutating any state: header.Drops is uint64, so an over-subtraction
+	// would silently wrap to a huge value and be hashed into the header,
+	// forking the chain. rippled subtracts on a signed int64 (XRPAmount),
+	// where the same bug goes negative and is detectable. Under correct
+	// operation the XRPNotCreated/fee invariants bound destroyed XRP well
+	// below supply, so this never triggers; if it does, hard-stop before
+	// any side effects to keep a latent accounting bug loud.
+	if l.dropsDestroyed < 0 || uint64(l.dropsDestroyed) > l.header.Drops {
+		return fmt.Errorf("ledger: drops underflow closing ledger %d: destroyed %d exceeds total %d",
+			l.header.LedgerIndex, int64(l.dropsDestroyed), l.header.Drops)
+	}
+
 	// Update LedgerHashes skiplist before making state immutable.
 	// Matches rippled's updateSkipList() in Ledger.cpp:878-943.
 	if err := l.updateSkipList(); err != nil {
@@ -601,7 +614,7 @@ func (l *Ledger) Close(closeTime time.Time, closeFlags uint8) error {
 		return fmt.Errorf("failed to make tx map immutable: %w", err)
 	}
 
-	// Update drops (subtract destroyed)
+	// Update drops (subtract destroyed). Underflow was checked up-front.
 	l.header.Drops -= uint64(l.dropsDestroyed)
 
 	// Get hashes

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -146,3 +146,64 @@ func TestLedger_Close_DynamicResolution_DisagreeSaturatedAtCoarsest(t *testing.T
 		t.Errorf("saturated coarsest: got %d want %d", got, want)
 	}
 }
+
+// newOpenChild returns a freshly opened child of a genesis-derived
+// parent, ready for Close().
+func newOpenChild(t *testing.T) *Ledger {
+	t.Helper()
+	parent := newParentAt(t, 2, 30, true)
+	child, err := NewOpen(parent, parent.CloseTime().Add(10*time.Second))
+	if err != nil {
+		t.Fatalf("NewOpen: %v", err)
+	}
+	return child
+}
+
+// TestLedger_Close_DropsUnderflow_Wrap guards issue #605: when
+// destroyed drops exceed the header total, Close must hard-stop
+// instead of letting the uint64 subtraction wrap to a huge value
+// that silently forks the chain.
+func TestLedger_Close_DropsUnderflow_Wrap(t *testing.T) {
+	child := newOpenChild(t)
+	child.header.Drops = 100
+	child.dropsDestroyed = drops.XRPAmount(101)
+
+	if err := child.Close(child.CloseTime(), 0); err == nil {
+		t.Fatalf("Close: expected underflow error, got nil (header.Drops wrapped to %d)", child.header.Drops)
+	}
+	if child.header.Drops != 100 {
+		t.Errorf("header.Drops mutated on rejected close: got %d want 100", child.header.Drops)
+	}
+	if child.state != StateOpen {
+		t.Errorf("ledger state changed on rejected close: got %v want StateOpen", child.state)
+	}
+}
+
+// TestLedger_Close_DropsUnderflow_Negative covers the signed path: a
+// negative dropsDestroyed (which would cast to a huge uint64) must
+// also be rejected rather than inflating the total supply.
+func TestLedger_Close_DropsUnderflow_Negative(t *testing.T) {
+	child := newOpenChild(t)
+	child.header.Drops = 100
+	child.dropsDestroyed = drops.XRPAmount(-1)
+
+	if err := child.Close(child.CloseTime(), 0); err == nil {
+		t.Fatalf("Close: expected error on negative dropsDestroyed, got nil (header.Drops=%d)", child.header.Drops)
+	}
+}
+
+// TestLedger_Close_DropsValidSubtraction confirms the guard does not
+// regress the normal path: a destroyed amount within the total
+// subtracts cleanly and the ledger closes.
+func TestLedger_Close_DropsValidSubtraction(t *testing.T) {
+	child := newOpenChild(t)
+	child.header.Drops = 100
+	child.dropsDestroyed = drops.XRPAmount(30)
+
+	if err := child.Close(child.CloseTime(), 0); err != nil {
+		t.Fatalf("Close: unexpected error on valid subtraction: %v", err)
+	}
+	if got, want := child.header.Drops, uint64(70); got != want {
+		t.Errorf("header.Drops: got %d want %d", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- `Ledger.Close()` subtracted destroyed drops from the `uint64` header total with no guard, so an over-subtraction would wrap to a huge value hashed into the header — silently forking the chain. rippled does the same subtraction on a signed `int64` (`XRPAmount`), where an equivalent underflow goes negative and is detectable.
- Added an underflow guard: if destroyed drops are negative or exceed the header total, `Close()` returns an error and hard-stops rather than wrapping, keeping any latent accounting bug loud.
- Added regression tests for the wrap case, the negative-destroyed case, and the normal valid-subtraction path.

## Test plan
- [x] `just test-pkg ./internal/ledger/...` (9 `TestLedger_Close*` pass, full package green)
- [x] `go vet ./internal/ledger/`

Fixes #605