### PR TITLE
fix: fail invariants on SLE parse errors instead of swallowing them

### DIFF
--- a/internal/tx/invariants/amm.go
+++ b/internal/tx/invariants/amm.go
@@ -37,7 +37,6 @@ import (
 type ammInvariantFields struct {
 	accountID  [20]byte
 	lptBalance Amount
-	hasBalance bool
 }
 
 // isLikelyAMMBinary checks if binary data is an AMM SLE entry.
@@ -63,26 +62,30 @@ func parseAMMInvariantFields(data []byte) (*ammInvariantFields, error) {
 
 	result := &ammInvariantFields{}
 
-	// Account (r-address string → [20]byte). A decode failure must be
-	// propagated: leaving accountID zeroed would make ammPoolHoldsForInvariant
-	// read the wrong account and mis-evaluate the invariant. rippled accesses
-	// sfAccount as a typed field that throws on malformed data.
-	if acctStr, ok := fields["Account"].(string); ok {
-		id, err := state.DecodeAccountID(acctStr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode AMM Account ID: %w", err)
-		}
-		result.accountID = id
+	// Account and LPTokenBalance are both soeREQUIRED on the AMM ledger object
+	// (rippled ledger_entries.macro:387,391). ValidAMM::visitEntry reads them
+	// with getAccountID(sfAccount)/getFieldAmount(sfLPTokenBalance), which throw
+	// when the field is absent — ApplyContext's catch-all converts that to
+	// tecINVARIANT_FAILED. A successful decode missing either field is a
+	// serialization round-trip bug, so fail rather than default to zero.
+	acctStr, ok := fields["Account"].(string)
+	if !ok {
+		return nil, fmt.Errorf("AMM SLE missing required Account field")
 	}
+	id, err := state.DecodeAccountID(acctStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode AMM Account ID: %w", err)
+	}
+	result.accountID = id
 
-	// LPTokenBalance (Amount object)
-	if lptObj, ok := fields["LPTokenBalance"].(map[string]any); ok {
-		valueStr, _ := lptObj["value"].(string)
-		currency, _ := lptObj["currency"].(string)
-		issuer, _ := lptObj["issuer"].(string)
-		result.lptBalance = state.NewIssuedAmountFromDecimalString(valueStr, currency, issuer)
-		result.hasBalance = true
+	lptObj, ok := fields["LPTokenBalance"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("AMM SLE missing required LPTokenBalance field")
 	}
+	valueStr, _ := lptObj["value"].(string)
+	currency, _ := lptObj["currency"].(string)
+	issuer, _ := lptObj["issuer"].(string)
+	result.lptBalance = state.NewIssuedAmountFromDecimalString(valueStr, currency, issuer)
 
 	return result, nil
 }
@@ -311,10 +314,8 @@ func checkValidAMM(tx Transaction, result Result, entries []InvariantEntry, view
 				}
 				id := fields.accountID
 				ammAccount = &id
-				if fields.hasBalance {
-					bal := fields.lptBalance
-					lptAfter = &bal
-				}
+				bal := fields.lptBalance
+				lptAfter = &bal
 			} else if e.EntryType == "RippleState" {
 				// Check for lsfAMMNode flag
 				rs, err := state.ParseRippleState(e.After)
@@ -347,10 +348,8 @@ func checkValidAMM(tx Transaction, result Result, entries []InvariantEntry, view
 				if err != nil {
 					return ammParseViolation(err)
 				}
-				if fields.hasBalance {
-					bal := fields.lptBalance
-					lptBefore = &bal
-				}
+				bal := fields.lptBalance
+				lptBefore = &bal
 			}
 		}
 	}

--- a/internal/tx/invariants/amm.go
+++ b/internal/tx/invariants/amm.go
@@ -63,12 +63,16 @@ func parseAMMInvariantFields(data []byte) (*ammInvariantFields, error) {
 
 	result := &ammInvariantFields{}
 
-	// Account (r-address string → [20]byte)
+	// Account (r-address string → [20]byte). A decode failure must be
+	// propagated: leaving accountID zeroed would make ammPoolHoldsForInvariant
+	// read the wrong account and mis-evaluate the invariant. rippled accesses
+	// sfAccount as a typed field that throws on malformed data.
 	if acctStr, ok := fields["Account"].(string); ok {
 		id, err := state.DecodeAccountID(acctStr)
-		if err == nil {
-			result.accountID = id
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode AMM Account ID: %w", err)
 		}
+		result.accountID = id
 	}
 
 	// LPTokenBalance (Amount object)
@@ -246,6 +250,16 @@ func withinRelativeDistanceForInvariant(calc, req Amount) bool {
 	return rIOU.Compare(tIOU) < 0
 }
 
+// ammParseViolation reports a failure to decode an entry already identified as
+// an AMM SLE. The bytes were serialized by goXRPL moments earlier, so a decode
+// failure is a serialization round-trip bug that must fail the invariant.
+func ammParseViolation(err error) *InvariantViolation {
+	return &InvariantViolation{
+		Name:    "ValidAMM",
+		Message: fmt.Sprintf("could not parse AMM SLE: %v", err),
+	}
+}
+
 // checkValidAMM implements the ValidAMM invariant checker.
 // Reference: rippled InvariantCheck.cpp ValidAMM::visitEntry + ValidAMM::finalize (lines 1720-2023)
 func checkValidAMM(tx Transaction, result Result, entries []InvariantEntry, view ReadView, rules *amendment.Rules) *InvariantViolation {
@@ -286,15 +300,20 @@ func checkValidAMM(tx Transaction, result Result, entries []InvariantEntry, view
 			}
 
 			if isAMMEntry {
-				// AMM object changed — extract account ID and LPTokenBalance
+				// AMM object changed — extract account ID and LPTokenBalance.
+				// A decode failure of an entry we identified as an AMM SLE is a
+				// serialization round-trip bug and fails the invariant outright,
+				// regardless of fixAMMv1_3: rippled's visitEntry catch-all is not
+				// amendment-gated (ApplyContext.cpp).
 				fields, err := parseAMMInvariantFields(e.After)
-				if err == nil {
-					id := fields.accountID
-					ammAccount = &id
-					if fields.hasBalance {
-						bal := fields.lptBalance
-						lptAfter = &bal
-					}
+				if err != nil {
+					return ammParseViolation(err)
+				}
+				id := fields.accountID
+				ammAccount = &id
+				if fields.hasBalance {
+					bal := fields.lptBalance
+					lptAfter = &bal
 				}
 			} else if e.EntryType == "RippleState" {
 				// Check for lsfAMMNode flag
@@ -325,7 +344,10 @@ func checkValidAMM(tx Transaction, result Result, entries []InvariantEntry, view
 
 			if isAMMBefore {
 				fields, err := parseAMMInvariantFields(e.Before)
-				if err == nil && fields.hasBalance {
+				if err != nil {
+					return ammParseViolation(err)
+				}
+				if fields.hasBalance {
 					bal := fields.lptBalance
 					lptBefore = &bal
 				}

--- a/internal/tx/invariants/basic.go
+++ b/internal/tx/invariants/basic.go
@@ -21,7 +21,15 @@ func checkXRPBalances(entries []InvariantEntry) *InvariantViolation {
 		}
 		acct, err := state.ParseAccountRoot(data)
 		if err != nil {
-			continue
+			// These are bytes goXRPL serialized moments earlier; a parse
+			// failure signals a serialization round-trip bug and must fail the
+			// invariant, not silently skip the balance check. Mirrors rippled,
+			// where a bad field access in visitEntry throws and is caught as a
+			// hard invariant failure (ApplyContext.cpp catch-all).
+			return &InvariantViolation{
+				Name:    "XRPBalanceChecks",
+				Message: fmt.Sprintf("could not parse AccountRoot SLE: %v", err),
+			}
 		}
 		if acct.Balance > InitialXRP {
 			return &InvariantViolation{
@@ -48,14 +56,18 @@ func checkXRPNotCreated(result Result, fee uint64, entries []InvariantEntry) *In
 		case "AccountRoot":
 			var before, after uint64
 			if e.Before != nil {
-				if acct, err := state.ParseAccountRoot(e.Before); err == nil {
-					before = acct.Balance
+				acct, err := state.ParseAccountRoot(e.Before)
+				if err != nil {
+					return xrpNotCreatedParseViolation("AccountRoot", err)
 				}
+				before = acct.Balance
 			}
 			if e.After != nil {
-				if acct, err := state.ParseAccountRoot(e.After); err == nil {
-					after = acct.Balance
+				acct, err := state.ParseAccountRoot(e.After)
+				if err != nil {
+					return xrpNotCreatedParseViolation("AccountRoot", err)
 				}
+				after = acct.Balance
 			}
 			netChange += int64(after) - int64(before)
 
@@ -67,12 +79,20 @@ func checkXRPNotCreated(result Result, fee uint64, entries []InvariantEntry) *In
 			//   if (isXRP((*before)[sfAmount])) drops_ -= ...
 			var before, after uint64
 			if e.Before != nil {
-				if esc, err := state.ParseEscrow(e.Before); err == nil && esc.IsXRP {
+				esc, err := state.ParseEscrow(e.Before)
+				if err != nil {
+					return xrpNotCreatedParseViolation("Escrow", err)
+				}
+				if esc.IsXRP {
 					before = esc.Amount
 				}
 			}
 			if e.After != nil {
-				if esc, err := state.ParseEscrow(e.After); err == nil && esc.IsXRP {
+				esc, err := state.ParseEscrow(e.After)
+				if err != nil {
+					return xrpNotCreatedParseViolation("Escrow", err)
+				}
+				if esc.IsXRP {
 					after = esc.Amount
 				}
 			}
@@ -83,14 +103,18 @@ func checkXRPNotCreated(result Result, fee uint64, entries []InvariantEntry) *In
 			// Reference: rippled InvariantCheck.cpp:107-131
 			var before, after uint64
 			if e.Before != nil {
-				if pc, err := state.ParsePayChannel(e.Before); err == nil {
-					before = pc.Amount - pc.Balance
+				pc, err := state.ParsePayChannel(e.Before)
+				if err != nil {
+					return xrpNotCreatedParseViolation("PayChannel", err)
 				}
+				before = pc.Amount - pc.Balance
 			}
 			if e.After != nil && !e.IsDelete {
-				if pc, err := state.ParsePayChannel(e.After); err == nil {
-					after = pc.Amount - pc.Balance
+				pc, err := state.ParsePayChannel(e.After)
+				if err != nil {
+					return xrpNotCreatedParseViolation("PayChannel", err)
 				}
+				after = pc.Amount - pc.Balance
 			}
 			netChange += int64(after) - int64(before)
 		}
@@ -114,6 +138,18 @@ func checkXRPNotCreated(result Result, fee uint64, entries []InvariantEntry) *In
 		}
 	}
 	return nil
+}
+
+// xrpNotCreatedParseViolation reports a parse failure of an XRP-bearing SLE that
+// XRPNotCreated must account for. A decode failure on bytes goXRPL serialized
+// moments earlier would corrupt netChange (defaulting the balance to 0), so it
+// is treated as a hard invariant failure — mirroring rippled, where the field
+// access throws and ApplyContext's catch-all converts it to tecINVARIANT_FAILED.
+func xrpNotCreatedParseViolation(entryType string, err error) *InvariantViolation {
+	return &InvariantViolation{
+		Name:    "XRPNotCreated",
+		Message: fmt.Sprintf("could not parse %s SLE: %v", entryType, err),
+	}
 }
 
 // checkAccountRootsNotDeleted verifies that AccountRoot entries are only deleted

--- a/internal/tx/invariants/invariants_test.go
+++ b/internal/tx/invariants/invariants_test.go
@@ -22,6 +22,15 @@ func (v stubView) Succ(k [32]byte) ([32]byte, []byte, bool, error) {
 }
 func (v stubView) LedgerSeq() uint32 { return v.seq }
 
+type stubTx struct {
+	txType TxType
+}
+
+func (t stubTx) TxType() TxType                   { return t.txType }
+func (t stubTx) TxAccount() string                { return "" }
+func (t stubTx) TxHasField(name string) bool      { return false }
+func (t stubTx) Flatten() (map[string]any, error) { return map[string]any{}, nil }
+
 func mustSerializeAccount(t *testing.T, a *state.AccountRoot) []byte {
 	t.Helper()
 	b, err := state.SerializeAccountRoot(a)
@@ -286,5 +295,50 @@ func TestNoZeroEscrow_MPTokenIssuanceBounds(t *testing.T) {
 	})
 	if v := checkNoZeroEscrow([]InvariantEntry{{EntryType: "MPTokenIssuance", After: bad}}); v == nil {
 		t.Fatal("expected violation: LockedAmount > OutstandingAmount")
+	}
+}
+
+// TestXRPBalanceChecks_ParseFailure: a malformed AccountRoot SLE must trip the
+// invariant rather than be silently skipped. The bytes were serialized by
+// goXRPL moments earlier, so a parse failure is a round-trip bug that rippled
+// would catch as tecINVARIANT_FAILED. Reference: issue #597.
+func TestXRPBalanceChecks_ParseFailure(t *testing.T) {
+	garbage := []byte{0xde, 0xad, 0xbe, 0xef}
+	entries := []InvariantEntry{{EntryType: "AccountRoot", After: garbage}}
+	if v := checkXRPBalances(entries); v == nil {
+		t.Fatal("expected XRPBalanceChecks violation for unparseable AccountRoot SLE")
+	}
+}
+
+// TestXRPNotCreated_ParseFailure: a malformed XRP-bearing SLE must trip
+// XRPNotCreated instead of defaulting the balance to 0 (which could mask an
+// XRP-creation bug). Reference: issue #597.
+func TestXRPNotCreated_ParseFailure(t *testing.T) {
+	garbage := []byte{0xde, 0xad, 0xbe, 0xef}
+	for _, entryType := range []string{"AccountRoot", "Escrow", "PayChannel"} {
+		entries := []InvariantEntry{{EntryType: entryType, After: garbage}}
+		if v := checkXRPNotCreated(TesSUCCESS, 10, entries); v == nil {
+			t.Fatalf("%s: expected XRPNotCreated violation for unparseable SLE", entryType)
+		}
+	}
+}
+
+// TestValidAMM_ParseFailure: an entry identified as an AMM SLE that fails to
+// decode must trip ValidAMM unconditionally (rippled's visitEntry catch-all is
+// not amendment-gated), rather than leaving a zeroed account ID. Reference:
+// issue #597.
+func TestValidAMM_ParseFailure(t *testing.T) {
+	garbage := []byte{0xde, 0xad, 0xbe, 0xef}
+	rules := amendment.AllSupportedRules()
+	view := stubView{seq: 100}
+
+	after := []InvariantEntry{{EntryType: "AMM", After: garbage}}
+	if v := checkValidAMM(stubTx{txType: TypeAMMDeposit}, TesSUCCESS, after, view, rules); v == nil {
+		t.Fatal("expected ValidAMM violation for unparseable AMM SLE (after)")
+	}
+
+	before := []InvariantEntry{{EntryType: "AMM", Before: garbage}}
+	if v := checkValidAMM(stubTx{txType: TypeAMMDeposit}, TesSUCCESS, before, view, rules); v == nil {
+		t.Fatal("expected ValidAMM violation for unparseable AMM SLE (before)")
 	}
 }

--- a/internal/tx/invariants/invariants_test.go
+++ b/internal/tx/invariants/invariants_test.go
@@ -342,3 +342,44 @@ func TestValidAMM_ParseFailure(t *testing.T) {
 		t.Fatal("expected ValidAMM violation for unparseable AMM SLE (before)")
 	}
 }
+
+// TestValidAMM_MissingRequiredField: an AMM SLE that decodes successfully but
+// lacks a soeREQUIRED field (Account or LPTokenBalance, per rippled
+// ledger_entries.macro:387,391) must still trip ValidAMM. rippled reads these
+// with getAccountID(sfAccount)/getFieldAmount(sfLPTokenBalance), which throw on
+// absence — silently defaulting them to zero would mask the round-trip bug.
+// Reference: issue #597.
+func TestValidAMM_MissingRequiredField(t *testing.T) {
+	rules := amendment.AllSupportedRules()
+	view := stubView{seq: 100}
+
+	const acct = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+	const issuer = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+
+	encode := func(obj map[string]any) []byte {
+		t.Helper()
+		hexStr, err := binarycodec.Encode(obj)
+		if err != nil {
+			t.Fatalf("binarycodec.Encode: %v", err)
+		}
+		b, err := hex.DecodeString(hexStr)
+		if err != nil {
+			t.Fatalf("hex.DecodeString: %v", err)
+		}
+		return b
+	}
+
+	lpt := map[string]any{"currency": "USD", "issuer": issuer, "value": "1000"}
+
+	noAccount := encode(map[string]any{"LedgerEntryType": "AMM", "LPTokenBalance": lpt})
+	if v := checkValidAMM(stubTx{txType: TypeAMMDeposit}, TesSUCCESS,
+		[]InvariantEntry{{EntryType: "AMM", After: noAccount}}, view, rules); v == nil {
+		t.Fatal("expected ValidAMM violation for AMM SLE missing required Account")
+	}
+
+	noBalance := encode(map[string]any{"LedgerEntryType": "AMM", "Account": acct})
+	if v := checkValidAMM(stubTx{txType: TypeAMMDeposit}, TesSUCCESS,
+		[]InvariantEntry{{EntryType: "AMM", After: noBalance}}, view, rules); v == nil {
+		t.Fatal("expected ValidAMM violation for AMM SLE missing required LPTokenBalance")
+	}
+}


### PR DESCRIPTION
## Summary
- `XRPBalanceChecks`, `XRPNotCreated`, and `ValidAMM` treated a failure to decode a just-serialized SLE as `continue`/zero, silently skipping or corrupting the invariant.
- These entries are bytes goXRPL serialized moments earlier (`apply_state_table.go`), so a parse failure signals a serialization round-trip bug that must fail loud.
- Now each parse failure returns an `*InvariantViolation` — mirroring rippled, where a bad field access in `visitEntry` throws and `ApplyContext`'s catch-all converts it to a hard `tecINVARIANT_FAILED` (not amendment-gated for the AMM case).

## Test plan
- [x] `go test ./internal/tx/invariants/...` (added `TestXRPBalanceChecks_ParseFailure`, `TestXRPNotCreated_ParseFailure`, `TestValidAMM_ParseFailure`)
- [x] `go test ./internal/tx/... ./internal/testing/{amm,escrow,paychan,payment}/...` — no regressions
- [x] `gofmt` + `go vet ./internal/tx/invariants/...`

Fixes #597