### PR TITLE
fix: AMMVote weight/fee use exact Number→int64 rounding

### DIFF
--- a/internal/tx/amm/amm_vote.go
+++ b/internal/tx/amm/amm_vote.go
@@ -155,9 +155,8 @@ func (a *AMMVote) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 
 		// Calculate new vote weight: voteWeight = lpTokens * scaleFactor / lptAMMBalance
-		// Reference: rippled AMMVote.cpp:137-139
-		voteWeightCalc := numberDiv(lpTokens.Mul(scaleFactorAmount, false), lptAMMBalance)
-		voteWeight := uint32(voteWeightCalc.Float64())
+		// Reference: rippled AMMVote.cpp:137-139 — static_cast<int64_t>(Number)
+		voteWeight := uint32(numberDivToInt64(lpTokens.Mul(scaleFactorAmount, false), lptAMMBalance))
 		if voteWeight == 0 && !lpTokens.IsZero() {
 			voteWeight = 1
 		}
@@ -186,8 +185,8 @@ func (a *AMMVote) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	// If account doesn't have a vote entry yet
 	if !foundAccount {
-		voteWeightCalc := numberDiv(lpTokensNew.Mul(scaleFactorAmount, false), lptAMMBalance)
-		voteWeight := uint32(voteWeightCalc.Float64())
+		// Reference: rippled AMMVote.cpp:164-168 — static_cast<int64_t>(Number)
+		voteWeight := uint32(numberDivToInt64(lpTokensNew.Mul(scaleFactorAmount, false), lptAMMBalance))
 		if voteWeight == 0 && !lpTokensNew.IsZero() {
 			voteWeight = 1
 		}
@@ -226,10 +225,10 @@ func (a *AMMVote) Apply(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	// Calculate weighted average trading fee: fee = num / den
+	// Reference: rippled AMMVote.cpp:209 — static_cast<int64_t>(num / den)
 	var newTradingFee uint16 = 0
 	if !den.IsZero() {
-		feeResult := numberDiv(num, den)
-		newTradingFee = uint16(feeResult.Float64())
+		newTradingFee = uint16(numberDivToInt64(num, den))
 	}
 
 	// Update AMM data

--- a/internal/tx/amm/math.go
+++ b/internal/tx/amm/math.go
@@ -167,6 +167,20 @@ func numberDiv(n, d tx.Amount) tx.Amount {
 	return state.NewIssuedAmountFromValue(iou.Mantissa(), iou.Exponent(), n.Currency, n.Issuer)
 }
 
+// numberDivToInt64 computes n / d in Number space and converts the quotient to
+// int64 using round-half-to-even, matching rippled's
+// static_cast<std::int64_t>(Number{...} / ...) (default to_nearest rounding).
+// Unlike numberDiv followed by Float64()+integer cast, this avoids both the
+// float64 precision loss and the truncation-toward-zero of a float cast.
+func numberDivToInt64(n, d tx.Amount) int64 {
+	if d.IsZero() || n.IsZero() {
+		return 0
+	}
+	nNum := state.NewXRPLNumber(n.Mantissa(), n.Exponent())
+	dNum := state.NewXRPLNumber(d.Mantissa(), d.Exponent())
+	return nNum.Div(dNum).ToInt64WithMode(state.RoundToNearest)
+}
+
 // stAmountDiv performs STAmount-style division: n / d.
 // This matches rippled's divide(STAmount, STAmount, Issue) which uses
 // muldiv with +5 rounding, unlike Number division (Guard-based).

--- a/internal/tx/amm/math_vote_test.go
+++ b/internal/tx/amm/math_vote_test.go
@@ -1,0 +1,42 @@
+package amm
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+)
+
+// TestNumberDivToInt64_RoundHalfToEven verifies that the vote-weight / trading-fee
+// quotient conversion matches rippled's static_cast<std::int64_t>(Number{...}),
+// which uses round-half-to-even — NOT float64 truncation toward zero. A divergence
+// here forks consensus because the result is serialized into the AMM ledger object.
+// Reference: rippled AMMVote.cpp:137-139,164-168,209.
+func TestNumberDivToInt64_RoundHalfToEven(t *testing.T) {
+	amt := func(v float64) state.Amount {
+		return state.NewIssuedAmountFromFloat64(v, "", "")
+	}
+
+	cases := []struct {
+		n, d float64
+		want int64
+	}{
+		{15, 2, 8},  // 7.5 -> 8 (truncation would yield 7)
+		{35, 10, 4}, // 3.5 -> 4 (truncation would yield 3)
+		{25, 10, 2}, // 2.5 -> 2 (round half to even; truncation also 2)
+		{45, 10, 4}, // 4.5 -> 4 (round half to even; truncation would yield 4)
+		{55, 10, 6}, // 5.5 -> 6 (round half to even; truncation would yield 5)
+		{14, 4, 4},  // 3.5 -> 4 (round half to even)
+		{10, 4, 2},  // 2.5 -> 2 (round half to even)
+		{7, 2, 4},   // 3.5 -> 4
+		{20, 8, 2},  // 2.5 -> 2
+		{0, 5, 0},   // zero numerator
+		{5, 0, 0},   // zero denominator
+	}
+
+	for _, c := range cases {
+		got := numberDivToInt64(amt(c.n), amt(c.d))
+		if got != c.want {
+			t.Errorf("numberDivToInt64(%v, %v) = %d, want %d", c.n, c.d, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `AMMVote.Apply` computed each `VoteWeight` and the AMM `TradingFee` by converting a Number-space quotient to `float64` and truncating toward zero, while rippled casts the `Number` directly to `int64` with round-half-to-even (`AMMVote.cpp:137-139,164-168,209`). The two differ in rounding direction and `float64` precision; both values are serialized into the AMM ledger object, so a divergence forks consensus.
- Added `numberDivToInt64` (Number-space division → `ToInt64WithMode(RoundToNearest)`) and applied it at all three sites, eliminating both the precision loss and the truncation.

## Test plan
- [x] `go test ./internal/tx/amm/... ./internal/testing/amm/...`
- [x] New regression test `TestNumberDivToInt64_RoundHalfToEven` covering `.5`-boundary quotients (e.g. 7.5→8, 5.5→6, 2.5→2 banker's rounding)

Fixes #594