### PR TITLE
fix: index AMMVote minimum slot by output array position

### DIFF
--- a/internal/testing/amm/amm_vote_test.go
+++ b/internal/testing/amm/amm_vote_test.go
@@ -3,6 +3,7 @@
 package amm_test
 
 import (
+	"fmt"
 	"testing"
 
 	jtx "github.com/LeJamon/goXRPLd/internal/testing"
@@ -247,4 +248,96 @@ func TestFeeVote(t *testing.T) {
 
 		t.Log("Maximum fee vote passed")
 	})
+}
+
+// TestFeeVoteSlotReplacement fills all 8 vote slots, then has a new LP with more
+// tokens than the minimum-token holder vote. The minimum slot must be the one
+// replaced — not a different slot.
+//
+// This exercises the slot-replacement path in applyVote, where minPos must index
+// the OUTPUT (updatedVoteSlots) array, mirroring rippled's
+// minPos = updatedVoteSlots.size() captured before push_back, and the
+// replacement updatedVoteSlots[minPos] = ... (AMMVote.cpp:149,187,191).
+// Reference: rippled AMM_test.cpp testFeeVote (line 2745).
+func TestFeeVoteSlotReplacement(t *testing.T) {
+	// setupAMM: alice creates XRP(10000)/USD(10000); alice holds 10,000,000 LP
+	// tokens and occupies the first vote slot.
+	env := setupAMM(t)
+
+	fundLP := func(name string) *jtx.Account {
+		acct := jtx.NewAccount(name)
+		env.TestEnv.FundAmount(acct, uint64(jtx.XRP(30000)))
+		env.Close()
+		env.Trust(acct, env.GW, "USD", 100000)
+		env.Close()
+		env.PayIOU(env.GW, acct, "USD", 50000)
+		env.Close()
+		return acct
+	}
+
+	deposit := func(acct *jtx.Account, lpTokens float64) {
+		depositTx := amm.AMMDeposit(acct, amm.XRP(), env.USD).
+			LPTokenOut(amm.LPTokenAmount(env, amm.XRP(), env.USD, lpTokens)).
+			LPToken().
+			Build()
+		if r := env.Submit(depositTx); !r.Success {
+			t.Fatalf("%s deposit failed: %s - %s", acct.Name, r.Code, r.Message)
+		}
+		env.Close()
+	}
+
+	vote := func(acct *jtx.Account, fee uint16) {
+		if r := env.Submit(amm.AMMVote(acct, amm.XRP(), env.USD, fee).Build()); !r.Success {
+			t.Fatalf("%s vote failed: %s - %s", acct.Name, r.Code, r.Message)
+		}
+		env.Close()
+	}
+
+	voteSlots := func() (map[[20]byte]bool, int) {
+		data := env.ReadAMMData(amm.XRP(), env.USD)
+		set := make(map[[20]byte]bool, len(data.VoteSlots))
+		for _, slot := range data.VoteSlots {
+			set[slot.Account] = true
+		}
+		return set, len(data.VoteSlots)
+	}
+
+	// Seven additional LPs deposit strictly increasing LP-token amounts and vote.
+	// Together with alice (10,000,000 tokens) they fill all 8 vote slots. lp0
+	// holds the fewest tokens (100,000) and is therefore the global minimum slot.
+	lps := make([]*jtx.Account, 7)
+	for i := 0; i < 7; i++ {
+		acct := fundLP(fmt.Sprintf("lp%d", i))
+		deposit(acct, float64((i+1)*100000))
+		vote(acct, uint16(50*(i+1)))
+		lps[i] = acct
+	}
+
+	if set, n := voteSlots(); n != 8 {
+		t.Fatalf("expected 8 occupied vote slots, got %d", n)
+	} else if !set[lps[0].ID] {
+		t.Fatal("lp0 (minimum holder) should occupy a vote slot before replacement")
+	}
+
+	// A new LP deposits more tokens than the minimum holder (lp0) and votes.
+	// The slots are full, so applyVote must replace lp0's slot — the minimum.
+	outbidder := fundLP("outbidder")
+	deposit(outbidder, 1000000)
+	vote(outbidder, 600)
+
+	set, n := voteSlots()
+	if n != 8 {
+		t.Fatalf("expected 8 vote slots after replacement, got %d", n)
+	}
+	if set[lps[0].ID] {
+		t.Error("lp0 (minimum holder) should have been evicted from the vote slots")
+	}
+	if !set[outbidder.ID] {
+		t.Error("outbidder should occupy a vote slot after replacing the minimum")
+	}
+	for i := 1; i < 7; i++ {
+		if !set[lps[i].ID] {
+			t.Errorf("lp%d should still occupy a vote slot — only the minimum should be replaced", i)
+		}
+	}
 }

--- a/internal/testing/payment/fund_new_account_test.go
+++ b/internal/testing/payment/fund_new_account_test.go
@@ -81,7 +81,7 @@ func TestRipplePayment_NewDest(t *testing.T) {
 		env.Close()
 
 		// Market maker offers to sell XRP for USD (1:1).
-		xrp300 := tx.NewXRPAmount(int64(xrplgoTesting.XRP(300)))
+		xrp300 := tx.NewXRPAmount(xrplgoTesting.XRP(300))
 		result = env.CreateOffer(mm, xrp300, usd300) // TakerGets=XRP, TakerPays=USD
 		xrplgoTesting.RequireTxSuccess(t, result)
 		env.Close()

--- a/internal/tx/amm/amm_vote.go
+++ b/internal/tx/amm/amm_vote.go
@@ -135,7 +135,7 @@ func (a *AMMVote) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	// Iterate over current vote entries
 	// Reference: rippled AMMVote.cpp:111-154 — reads actual LP balance via ammLPHolds
-	for i, slot := range amm.VoteSlots {
+	for _, slot := range amm.VoteSlots {
 		// Read actual LP token balance from trust line (NOT reconstructed from VoteWeight)
 		// Reference: rippled AMMVote.cpp:113 — ammLPHolds(view, ammSle, votedAccount)
 		lpTokens := ammLPHolds(ctx.View, amm, slot.Account)
@@ -171,7 +171,10 @@ func (a *AMMVote) Apply(ctx *tx.ApplyContext) tx.Result {
 			(lpTokens.Compare(minTokens) == 0 && feeVal < minFee) ||
 			(lpTokens.Compare(minTokens) == 0 && feeVal == minFee && compareAccountIDs(slot.Account, minAccount) < 0) {
 			minTokens = lpTokens
-			minPos = i
+			// Index into the OUTPUT slice (where this entry will be appended),
+			// matching rippled's minPos = updatedVoteSlots.size() before push_back.
+			// Using the source index diverges when zero-balance voters are skipped.
+			minPos = len(updatedVoteSlots)
 			minAccount = slot.Account
 			minFee = feeVal
 		}


### PR DESCRIPTION
## Summary
- `applyVote` tracked the minimum-token vote slot (`minPos`) by the **source** `amm.VoteSlots` index; rippled captures the **output** index via `updatedVoteSlots.size()` before `push_back` (`AMMVote.cpp:149`, replacement at `:187,191`). This change reads `len(updatedVoteSlots)` instead, matching the reference form exactly.
- Adds `TestFeeVoteSlotReplacement`: fills all 8 vote slots (alice + 7 LPs with strictly increasing balances), then has a new LP outbid the minimum-token holder and vote, asserting that **exactly** the minimum slot is evicted and all others (plus the outbidder) remain.

## Reachability note (transparency)
Investigation showed the consensus fork described in #593 is **not actually reachable**, and the prior `minPos = i` produced correct results in every reachable state:

- The replacement branch requires `len(updatedVoteSlots) == VOTE_MAX_SLOTS (8)`.
- `len(updatedVoteSlots) = storedSlots − skipped`, and `storedSlots ≤ 8` is invariant (every writer caps at 8).
- Skipping a stale zero-balance voter makes `len < 8`, which routes the new voter to the **append** branch — the replacement branch is never reached with a skip.
- When the replacement branch *is* reached, `skipped == 0`, so the source index and output index are identical and `minPos` was already correct.

The change is therefore **defensive rippled-parity hardening** (no behavioral change in any reachable state), removing the fragile reliance on the ≤8-slot invariant and aligning with the C++ source of truth. The `severity:critical`/`consensus` framing on #593 is a false positive.

## Test plan
- [x] `go test ./internal/testing/amm/... ./internal/tx/amm/...` — all pass
- [x] `TestFeeVoteSlotReplacement` reaches the replacement branch and verifies the minimum slot is the one replaced
- [x] `gofmt` clean, `go vet` clean

Fixes #593