### PR TITLE
Resolve TxQ fixture balance/owner_count divergences

### DIFF
--- a/internal/testing/conformance/runner.go
+++ b/internal/testing/conformance/runner.go
@@ -597,9 +597,6 @@ func RunFixture(t *testing.T, fixturePath string) {
 
 	// Execute steps sequentially
 	for i := 0; i < len(fixture.Steps); i++ {
-		// Replay any open-ledger txns rippled applied via openLedger().modify()
-		// that the fixture exporter dropped, so the upcoming step's post-state
-		// (which reflects those txns) lines up.
 		r.injectOpenLedgerTxs(i)
 
 		step := fixture.Steps[i]

--- a/internal/testing/conformance/runner.go
+++ b/internal/testing/conformance/runner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	jtx "github.com/LeJamon/goXRPLd/internal/testing"
 	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/internal/tx/account"
 	"github.com/LeJamon/goXRPLd/internal/tx/amm"
 	"github.com/LeJamon/goXRPLd/internal/tx/trustset"
 	"github.com/LeJamon/goXRPLd/internal/txq"
@@ -197,6 +198,9 @@ type runner struct {
 	// rippled tests that use openLedger().modify() to apply transactions
 	// without TxQ routing.
 	directApplySteps map[int]bool
+
+	// testcase is the fixture's testcase name, used for per-fixture lookups.
+	testcase string
 
 	// lastEnvCfg stores the most recent env config for implicit scope resets.
 	lastEnvCfg EnvConfig
@@ -378,6 +382,29 @@ var txqDirectApplyLookup = map[string][]int{
 	"Ticket in queue and open ledger":   {5},
 }
 
+// openLedgerInject describes a synthetic noop transaction that rippled's TxQ
+// tests apply via env.app().openLedger().modify() — a direct write to the open
+// ledger (bypassing the queue) that the fixture exporter does not capture.
+// Its effect is nonetheless baked into the following step's expected post-state
+// (a consumed ticket/sequence and an openLedgerCost fee charge), so the runner
+// must replay it to stay in sync.
+type openLedgerInject struct {
+	beforeStep int
+	account    string
+	ticketSeq  uint32 // 0 => use the account's current sequence
+}
+
+// txqOpenLedgerInjectLookup maps TxQ fixture testcase names to the synthetic
+// open-ledger transactions that must be replayed before a given step.
+// Reference: TxQ_test.cpp testInLedgerSeq / testInLedgerTicket — the
+// env.app().openLedger().modify() calls that apply a noop bypassing the queue.
+// In the ticket test the injected tx reuses the queued tx's ticket
+// (tktSeq0+1 == 5); in the sequence test it consumes the queued sequence.
+var txqOpenLedgerInjectLookup = map[string][]openLedgerInject{
+	"Sequence in queue and open ledger": {{beforeStep: 5, account: "alice"}},
+	"Ticket in queue and open ledger":   {{beforeStep: 5, account: "alice", ticketSeq: 5}},
+}
+
 // txqInitFeeConfig maps TxQ fixture test case names that use initFee()
 // to the resulting fee configuration (base, reserve, increment) after
 // the fee vote completes. initFee() runs 257 ledger closes to reach the
@@ -520,6 +547,7 @@ func RunFixture(t *testing.T, fixturePath string) {
 		enableReplay:              !isTxQSuite, // TxQ suites need direct close for correct fee metrics
 		txqCfg:                    txqCfg,
 		directApplySteps:          directApplySet,
+		testcase:                  fixture.Testcase,
 		ammAddrMap:                make(map[string]string),
 		fixtureAMMAddrs:           fixtureAddrs,
 		fixtureAMMPairs:           fixturePairs,
@@ -569,6 +597,11 @@ func RunFixture(t *testing.T, fixturePath string) {
 
 	// Execute steps sequentially
 	for i := 0; i < len(fixture.Steps); i++ {
+		// Replay any open-ledger txns rippled applied via openLedger().modify()
+		// that the fixture exporter dropped, so the upcoming step's post-state
+		// (which reflects those txns) lines up.
+		r.injectOpenLedgerTxs(i)
+
 		step := fixture.Steps[i]
 		switch step.Op {
 		case "fund":
@@ -1072,6 +1105,46 @@ func (r *runner) execClose(stepIdx int, step Step) {
 	// Skip for TxQ-enabled suites — the real TxQ handles retries there.
 	if !r.enableTxQ {
 		r.retryQueuedTxs()
+	}
+}
+
+// injectOpenLedgerTxs replays the synthetic open-ledger transactions (if any)
+// registered for this fixture at the given step index. rippled's TxQ tests
+// apply these via env.app().openLedger().modify(), which the fixture exporter
+// does not capture; replaying them here keeps the engine's balances and owner
+// counts aligned with the fixture's expected post-state.
+func (r *runner) injectOpenLedgerTxs(stepIdx int) {
+	for _, inj := range txqOpenLedgerInjectLookup[r.testcase] {
+		if inj.beforeStep != stepIdx {
+			continue
+		}
+		acc := r.accounts[inj.account]
+		if acc == nil {
+			r.t.Fatalf("Step %d: open-ledger injection references unknown account %q", stepIdx, inj.account)
+		}
+
+		noop := &account.AccountSet{}
+		common := noop.GetCommon()
+		common.Account = acc.Address
+		common.TransactionType = "AccountSet"
+		common.Fee = strconv.FormatUint(r.env.OpenLedgerFee(r.env.BaseFee()), 10)
+		if inj.ticketSeq != 0 {
+			zero := uint32(0)
+			ticket := inj.ticketSeq
+			common.Sequence = &zero
+			common.TicketSequence = &ticket
+		} else {
+			seq := r.env.Seq(acc)
+			common.Sequence = &seq
+		}
+
+		signed := r.env.SignWith(noop, acc)
+		r.env.SetBypassTxQ(true)
+		result := r.env.Submit(signed)
+		r.env.SetBypassTxQ(false)
+		if !result.Success {
+			r.t.Fatalf("Step %d: injected open-ledger tx failed: %s", stepIdx, result.Code)
+		}
 	}
 }
 

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -7,9 +7,11 @@ import (
 	"github.com/LeJamon/goXRPLd/drops"
 	"github.com/LeJamon/goXRPLd/internal/ledger"
 	"github.com/LeJamon/goXRPLd/internal/ledger/genesis"
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/internal/tx"
 	"github.com/LeJamon/goXRPLd/internal/tx/all"
 	"github.com/LeJamon/goXRPLd/internal/txq"
+	"github.com/LeJamon/goXRPLd/keylet"
 	"github.com/LeJamon/goXRPLd/shamap"
 )
 
@@ -347,6 +349,7 @@ func (e *TestEnv) ResetTxQMaxSize() {
 // Used to apply post-initFee() fee changes in conformance tests.
 func (e *TestEnv) SetBaseFee(baseFee uint64) {
 	e.baseFee = baseFee
+	e.syncFeeSettings()
 }
 
 // SetReserves changes the reserve base and increment for subsequent transactions.
@@ -354,6 +357,39 @@ func (e *TestEnv) SetBaseFee(baseFee uint64) {
 func (e *TestEnv) SetReserves(reserveBase, reserveIncrement uint64) {
 	e.reserveBase = reserveBase
 	e.reserveIncrement = reserveIncrement
+	e.syncFeeSettings()
+}
+
+// syncFeeSettings writes the env's current fee/reserve values into the ledger's
+// FeeSettings entry. rippled changes reserves via a fee vote that rewrites the
+// FeeSettings ledger object; the conformance harness shortcuts that vote with
+// SetBaseFee/SetReserves, so without this sync the engine (which reads reserves
+// from the FeeSettings object, e.g. payment.GetLedgerReserves) would keep seeing
+// the stale genesis values and misclassify offers as unfunded.
+func (e *TestEnv) syncFeeSettings() {
+	feesKey := keylet.Fees()
+	data, err := e.ledger.Read(feesKey)
+	if err != nil || len(data) == 0 {
+		return
+	}
+	fs, err := state.ParseFeeSettings(data)
+	if err != nil {
+		return
+	}
+	if fs.XRPFeesMode {
+		fs.BaseFeeDrops = e.baseFee
+		fs.ReserveBaseDrops = e.reserveBase
+		fs.ReserveIncrementDrops = e.reserveIncrement
+	} else {
+		fs.BaseFee = e.baseFee
+		fs.ReserveBase = uint32(e.reserveBase)
+		fs.ReserveIncrement = uint32(e.reserveIncrement)
+	}
+	newData, err := state.SerializeFeeSettings(fs)
+	if err != nil {
+		return
+	}
+	_ = e.ledger.Update(feesKey, newData)
 }
 
 // SetNextCloseSalt sets the canonical sort salt for the next replay close.


### PR DESCRIPTION
## Summary
The three TxQ-fixture divergences reported in #592 are **conformance-harness gaps, not transaction-execution bugs** — goXRPL's engine matches rippled in all three cases. Verified against `rippled/src/test/app/TxQ_test.cpp`.

- **`TxQPosNegFlows/unexpected_balance_change`** — `SetReserves`/`SetBaseFee` updated only the env's private fields, never the `FeeSettings` ledger entry. rippled lowers reserves via a fee vote that *rewrites that object*, and the offer engine reads reserves from it (`payment.GetLedgerReserves`). So the engine kept seeing genesis 200 XRP and classified alice's resting offer as unfunded → bob's offer never crossed (owner_count 0 vs 1, alice 4950 vs 250). Now both setters sync the `FeeSettings` entry.

- **`TxQMetaInfo/{Ticket,Sequence}_in_queue_and_open_ledger`** — rippled applies a noop via `env.app().openLedger().modify()` (a direct open-ledger write, bypassing the queue; see `testInLedgerSeq`/`testInLedgerTicket`). The fixture exporter doesn't capture that write, but its effect (a consumed ticket/sequence + `openLedgerCost` fee) is baked into the next step's expected post-state. The runner now replays that synthetic tx, fixing the balance (8889 / 5000) and owner_count (4 vs 3) mismatches.

Changes are confined to the test harness (`internal/testing/env.go`, `internal/testing/conformance/runner.go`); no engine/protocol code is touched.

## Test plan
- [x] All three target fixtures now pass: `go test ./internal/testing/conformance/ -run 'TestConformance/app/(TxQMetaInfo/(Ticket|Sequence)_in_queue_and_open_ledger|TxQPosNegFlows/unexpected_balance_change)'`
- [x] Full conformance suite: zero new failures vs baseline (243 → 240 failing); the 4 remaining TxQ failures (`clear_queue_failure`, `Queue_full_drop_penalty`, `Re-execute_preflight`, `multi_tx_per_account`) are pre-existing and unrelated.
- [x] No regressions in `./internal/txq/...`, `./internal/testing/offer/...`, `./internal/testing/payment/...`

Fixes #592