### PR TITLE
fix: saturate positive OwnerCount overflow

### DIFF
--- a/internal/tx/owner_count.go
+++ b/internal/tx/owner_count.go
@@ -2,18 +2,34 @@ package tx
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 	"github.com/LeJamon/goXRPLd/keylet"
 )
 
+// confineOwnerCount applies adjustment to current, saturating to math.MaxUint32
+// on positive overflow and clamping to 0 on negative underflow. Mirrors
+// rippled's confineOwnerCount (src/xrpld/ledger/detail/View.cpp).
+func confineOwnerCount(current uint32, adjustment int) uint32 {
+	if adjustment >= 0 {
+		if uint64(current)+uint64(adjustment) > math.MaxUint32 {
+			return math.MaxUint32
+		}
+		return current + uint32(adjustment)
+	}
+	if int64(current)+int64(adjustment) < 0 {
+		return 0
+	}
+	return current - uint32(-adjustment)
+}
+
 // AdjustOwnerCount adjusts an account's OwnerCount by delta on a LedgerView
 // without updating PreviousTxn fields.
 // Returns an error if the account cannot be read or serialized.
 // If the account does not exist, returns nil (account may have been deleted).
-// Handles both positive (increment) and negative (decrement) deltas.
-// For negative deltas, each unit decrements by 1 only if OwnerCount > 0,
-// preventing underflow.
+// Handles both positive (increment) and negative (decrement) deltas, saturating
+// to math.MaxUint32 on overflow and clamping to 0 on underflow.
 func AdjustOwnerCount(view LedgerView, accountID [20]byte, delta int) error {
 	if delta == 0 {
 		return nil
@@ -30,15 +46,7 @@ func AdjustOwnerCount(view LedgerView, accountID [20]byte, delta int) error {
 		return fmt.Errorf("failed to parse account root: %w", err)
 	}
 
-	if delta > 0 {
-		account.OwnerCount += uint32(delta)
-	} else {
-		for i := 0; i < -delta; i++ {
-			if account.OwnerCount > 0 {
-				account.OwnerCount--
-			}
-		}
-	}
+	account.OwnerCount = confineOwnerCount(account.OwnerCount, delta)
 
 	updated, err := state.SerializeAccountRoot(account)
 	if err != nil {
@@ -50,7 +58,7 @@ func AdjustOwnerCount(view LedgerView, accountID [20]byte, delta int) error {
 
 // AdjustOwnerCountWithTx adjusts an account's OwnerCount by delta and updates
 // PreviousTxnID and PreviousTxnLgrSeq fields on the account.
-// Clamps owner count to 0 if the result would go negative.
+// Saturates to math.MaxUint32 on overflow and clamps to 0 on underflow.
 // Returns an error if the account cannot be read or serialized.
 // If the account does not exist, returns nil.
 func AdjustOwnerCountWithTx(view LedgerView, accountID [20]byte, delta int, txHash [32]byte, ledgerSeq uint32) error {
@@ -65,11 +73,7 @@ func AdjustOwnerCountWithTx(view LedgerView, accountID [20]byte, delta int, txHa
 		return fmt.Errorf("failed to parse account root: %w", err)
 	}
 
-	newCount := int(account.OwnerCount) + delta
-	if newCount < 0 {
-		newCount = 0
-	}
-	account.OwnerCount = uint32(newCount)
+	account.OwnerCount = confineOwnerCount(account.OwnerCount, delta)
 	account.PreviousTxnID = txHash
 	account.PreviousTxnLgrSeq = ledgerSeq
 

--- a/internal/tx/owner_count_test.go
+++ b/internal/tx/owner_count_test.go
@@ -1,0 +1,33 @@
+package tx
+
+import (
+	"math"
+	"testing"
+)
+
+func TestConfineOwnerCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		current    uint32
+		adjustment int
+		want       uint32
+	}{
+		{"increment", 5, 3, 8},
+		{"decrement", 5, -3, 2},
+		{"zero adjustment", 5, 0, 5},
+		{"decrement to zero", 5, -5, 0},
+		{"underflow clamps to zero", 2, -5, 0},
+		{"underflow from zero", 0, -1, 0},
+		{"increment to max", math.MaxUint32 - 1, 1, math.MaxUint32},
+		{"overflow saturates to max", math.MaxUint32, 1, math.MaxUint32},
+		{"large overflow saturates", math.MaxUint32 - 1, 100, math.MaxUint32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := confineOwnerCount(tt.current, tt.adjustment); got != tt.want {
+				t.Errorf("confineOwnerCount(%d, %d) = %d, want %d", tt.current, tt.adjustment, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `AdjustOwnerCount` incremented `OwnerCount` with unchecked unsigned arithmetic that silently wrapped on overflow, diverging from rippled's `confineOwnerCount` (`src/xrpld/ledger/detail/View.cpp`), which saturates to `uint32` max.
- Added a shared `confineOwnerCount(current uint32, adjustment int) uint32` helper mirroring rippled — saturates to `math.MaxUint32` on positive overflow, clamps to 0 on underflow.
- Used it in both `AdjustOwnerCount` and `AdjustOwnerCountWithTx`, replacing the ad-hoc increment/decrement loops so both paths now match rippled exactly.

## Test plan
- [x] `go test ./internal/tx/` (full package passes)
- [x] `go vet ./internal/tx/`
- [x] New `TestConfineOwnerCount` covers increment, decrement, underflow clamp, and overflow saturation boundaries.

Fixes #607