### PR TITLE
fix: deterministic tie-break when selecting the fallback tx set

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -3111,14 +3111,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 			}
 		}
 
-		var bestID consensus.TxSetID
-		bestCount := 0
-		for id, count := range txSetCounts {
-			if count > bestCount {
-				bestID = id
-				bestCount = count
-			}
-		}
+		bestID, _ := mostPopularTxSet(txSetCounts)
 
 		var err error
 		txSet, err = e.adaptor.GetTxSet(bestID)

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -209,8 +209,9 @@ func (pt *ProposalTracker) GetWinningTxSet() (consensus.TxSetID, int) {
 // mostPopularTxSet returns the tx set with the highest count. Ties are
 // broken deterministically by keeping the lexicographically smallest
 // TxSetID, so that Go's randomized map-iteration order can never seed a
-// fork or a replay mismatch. Returns the zero TxSetID and 0 for an empty
-// map.
+// fork or a replay mismatch. rippled defines no ordering here, so the
+// choice of "smallest" is arbitrary; all that matters is that every node
+// applies the same one. Returns the zero TxSetID and 0 for an empty map.
 func mostPopularTxSet(counts map[consensus.TxSetID]int) (consensus.TxSetID, int) {
 	var bestID consensus.TxSetID
 	bestCount := -1

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -1,6 +1,7 @@
 package rcl
 
 import (
+	"bytes"
 	"sync"
 	"time"
 
@@ -202,18 +203,26 @@ func (pt *ProposalTracker) TrustedTxSetCounts() map[consensus.TxSetID]int {
 
 // GetWinningTxSet returns the tx set with the most trusted support.
 func (pt *ProposalTracker) GetWinningTxSet() (consensus.TxSetID, int) {
-	counts := pt.TrustedTxSetCounts()
+	return mostPopularTxSet(pt.TrustedTxSetCounts())
+}
 
+// mostPopularTxSet returns the tx set with the highest count. Ties are
+// broken deterministically by keeping the lexicographically smallest
+// TxSetID, so that Go's randomized map-iteration order can never seed a
+// fork or a replay mismatch. Returns the zero TxSetID and 0 for an empty
+// map.
+func mostPopularTxSet(counts map[consensus.TxSetID]int) (consensus.TxSetID, int) {
 	var bestID consensus.TxSetID
-	bestCount := 0
-
-	for txSetID, count := range counts {
-		if count > bestCount {
-			bestID = txSetID
+	bestCount := -1
+	for id, count := range counts {
+		if count > bestCount || (count == bestCount && bytes.Compare(id[:], bestID[:]) < 0) {
+			bestID = id
 			bestCount = count
 		}
 	}
-
+	if bestCount < 0 {
+		bestCount = 0
+	}
 	return bestID, bestCount
 }
 

--- a/internal/consensus/rcl/txset_tiebreak_test.go
+++ b/internal/consensus/rcl/txset_tiebreak_test.go
@@ -7,19 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestMostPopularTxSet_DeterministicTieBreak pins the deterministic
-// tie-break used when selecting the most-supported transaction set
-// (issue #612).
-//
-// Bug history: both the acceptLedger fallback selector and
-// ProposalTracker.GetWinningTxSet iterated a Go map with a strict `>`
-// comparison. On equal counts the winner depended on Go's randomized
-// map-iteration order, so two nodes (or the same node replaying) could
-// pick different tx sets from an identical proposal distribution and
-// seed a fork or replay mismatch.
-//
-// Fix: on equal counts keep the lexicographically smallest TxSetID, so
-// every node converges on the same pick.
+// TestMostPopularTxSet_DeterministicTieBreak pins the issue #612 tie-break:
+// on equal counts the lexicographically smallest TxSetID must win, never
+// Go's randomized map-iteration order.
 func TestMostPopularTxSet_DeterministicTieBreak(t *testing.T) {
 	// Three tx sets tied at 2 votes each. The lexicographically smallest
 	// id ({0x01...}) must win every iteration despite map randomization.

--- a/internal/consensus/rcl/txset_tiebreak_test.go
+++ b/internal/consensus/rcl/txset_tiebreak_test.go
@@ -1,0 +1,53 @@
+package rcl
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/consensus"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMostPopularTxSet_DeterministicTieBreak pins the deterministic
+// tie-break used when selecting the most-supported transaction set
+// (issue #612).
+//
+// Bug history: both the acceptLedger fallback selector and
+// ProposalTracker.GetWinningTxSet iterated a Go map with a strict `>`
+// comparison. On equal counts the winner depended on Go's randomized
+// map-iteration order, so two nodes (or the same node replaying) could
+// pick different tx sets from an identical proposal distribution and
+// seed a fork or replay mismatch.
+//
+// Fix: on equal counts keep the lexicographically smallest TxSetID, so
+// every node converges on the same pick.
+func TestMostPopularTxSet_DeterministicTieBreak(t *testing.T) {
+	// Three tx sets tied at 2 votes each. The lexicographically smallest
+	// id ({0x01...}) must win every iteration despite map randomization.
+	a := consensus.TxSetID{0x01}
+	b := consensus.TxSetID{0x02}
+	c := consensus.TxSetID{0x03}
+	counts := map[consensus.TxSetID]int{a: 2, b: 2, c: 2}
+
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		id, count := mostPopularTxSet(counts)
+		assert.Equal(t, a, id,
+			"tie must always resolve to the lexicographically smallest TxSetID")
+		assert.Equal(t, 2, count)
+	}
+}
+
+// TestMostPopularTxSet_ClearWinner confirms a strict winner is selected
+// regardless of tie-break, and that an empty map yields the zero id / 0.
+func TestMostPopularTxSet_ClearWinner(t *testing.T) {
+	a := consensus.TxSetID{0x01}
+	b := consensus.TxSetID{0x02}
+
+	id, count := mostPopularTxSet(map[consensus.TxSetID]int{a: 1, b: 3})
+	assert.Equal(t, b, id)
+	assert.Equal(t, 3, count)
+
+	id, count = mostPopularTxSet(map[consensus.TxSetID]int{})
+	assert.Equal(t, consensus.TxSetID{}, id)
+	assert.Equal(t, 0, count)
+}


### PR DESCRIPTION
## Summary
- The `acceptLedger` fallback tx-set selector iterated a Go map with a strict `>` comparison, so on equal proposal counts the winner depended on Go's randomized map-iteration order — a latent fork / replay-mismatch seed (issue #612).
- `ProposalTracker.GetWinningTxSet` had the identical bug; both now share one `mostPopularTxSet` helper that breaks ties deterministically on the lexicographically smallest `TxSetID`.
- The `bestCount := -1` init ensures a genuine zero-count entry isn't skipped, while preserving the prior `(zeroID, 0)` contract for an empty map.

## Test plan
- [x] `just test-pkg ./internal/consensus/rcl/...` (or `go test ./internal/consensus/rcl/`) — full package passes
- [x] New `txset_tiebreak_test.go` pins deterministic selection across 100 iterations of a 3-way tie, plus clear-winner and empty-map cases
- [x] `go vet` / `gofmt` clean

Fixes #612