### PR TITLE
fix: enforce framing-marker invariants in DecodeHeader

### DIFF
--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -78,8 +78,18 @@ const (
 	// CompressionNone indicates no compression.
 	CompressionNone = 0x00
 
-	// CompressionLZ4 indicates LZ4 compression.
-	CompressionLZ4 = 0x80 // First bit set + algorithm bits
+	// CompressionLZ4 is the first-byte algorithm nibble for LZ4 compression
+	// (compression bit set + algorithm bits), matching rippled's
+	// compression::Algorithm::LZ4.
+	CompressionLZ4 = 0x90
+
+	// CompressionReservedMask covers the two reserved bits of the first byte
+	// that must be zero in a compressed frame (rippled rejects them).
+	CompressionReservedMask = 0x0C
+
+	// UncompressedFlagMask covers the six flag bits of the first byte that
+	// must all be zero in an uncompressed frame.
+	UncompressedFlagMask = 0xFC
 )
 
 var (
@@ -194,17 +204,24 @@ func DecodeHeader(buf []byte) (*Header, error) {
 	// Parse first 4 bytes
 	firstFour := binary.BigEndian.Uint32(buf[0:4])
 
-	// Check compression flag (first bit)
+	// Validate the framing marker, mirroring rippled's parseMessageHeader.
 	if buf[0]&0x80 != 0 {
-		h.Compressed = true
-		// Extract algorithm from bits 1-3
-		h.Algorithm = CompressionAlgorithm((buf[0] >> 4) & 0x07)
-		if h.Algorithm != AlgorithmLZ4 {
+		// Compressed frame: the two reserved bits must be clear and the
+		// algorithm nibble must be exactly LZ4.
+		if buf[0]&CompressionReservedMask != 0 {
+			return nil, ErrInvalidHeader
+		}
+		if buf[0]&CompressionFlagMask != CompressionLZ4 {
 			return nil, ErrUnknownCompression
 		}
+		h.Compressed = true
+		h.Algorithm = AlgorithmLZ4
+	} else if buf[0]&UncompressedFlagMask != 0 {
+		// Uncompressed frame: the top six bits must all be zero.
+		return nil, ErrInvalidHeader
 	}
 
-	// Extract payload size (26 bits)
+	// Extract payload size (26 bits); the mask strips the flag/algorithm bits.
 	h.PayloadSize = firstFour & MaxPayloadSize
 
 	// Extract message type (2 bytes)
@@ -216,11 +233,6 @@ func DecodeHeader(buf []byte) (*Header, error) {
 			return nil, ErrTruncatedMessage
 		}
 		h.UncompressedSize = binary.BigEndian.Uint32(buf[6:10])
-	}
-
-	// Validate size
-	if h.PayloadSize > MaxMessageSize {
-		return nil, ErrMessageTooLarge
 	}
 
 	return h, nil

--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -72,16 +72,9 @@ const (
 	// MaxPayloadSize is the maximum payload size that can be encoded.
 	MaxPayloadSize = (1 << MaxPayloadSizeBits) - 1
 
-	// CompressionFlagMask is the mask for compression flags in the first byte.
+	// CompressionFlagMask isolates the first byte's algorithm nibble
+	// (compression flag + 3 algorithm bits).
 	CompressionFlagMask = 0xF0
-
-	// CompressionNone indicates no compression.
-	CompressionNone = 0x00
-
-	// CompressionLZ4 is the first-byte algorithm nibble for LZ4 compression
-	// (compression bit set + algorithm bits), matching rippled's
-	// compression::Algorithm::LZ4.
-	CompressionLZ4 = 0x90
 
 	// CompressionReservedMask covers the two reserved bits of the first byte
 	// that must be zero in a compressed frame (rippled rejects them).
@@ -120,11 +113,15 @@ type Header struct {
 // CompressionAlgorithm represents a compression algorithm.
 type CompressionAlgorithm uint8
 
+// Algorithm values are the first-byte nibble carried on the wire, matching
+// rippled's compression::Algorithm (Compression.h): None=0x00, LZ4=0x90 (the
+// high bit is the compression flag). Keeping them identical to the wire byte
+// lets the header pack/unpack the algorithm without a separate translation.
 const (
 	// AlgorithmNone means no compression.
-	AlgorithmNone CompressionAlgorithm = 0
+	AlgorithmNone CompressionAlgorithm = 0x00
 	// AlgorithmLZ4 means LZ4 compression.
-	AlgorithmLZ4 CompressionAlgorithm = 1
+	AlgorithmLZ4 CompressionAlgorithm = 0x90
 )
 
 // HeaderSize returns the size of the header based on compression.
@@ -159,15 +156,13 @@ func EncodeHeader(buf []byte, payloadSize uint32, msgType MessageType, algorithm
 		return fmt.Errorf("buffer too small: need %d, got %d", requiredSize, len(buf))
 	}
 
-	// Pack the first 4 bytes: compression flags (6 bits) + payload size (26 bits)
-	// For uncompressed: first 6 bits are 0
-	// For compressed: first bit is 1, next 3 bits are algorithm, next 2 bits reserved
+	// First 4 bytes: the top byte holds the algorithm nibble, the low 26 bits
+	// hold the payload size. The algorithm value already carries the
+	// compression flag in its high bit, mirroring rippled setHeader's
+	// `*h |= compression`.
 	sizeWithFlags := payloadSize
 	if compressed {
-		// Set compression bit and algorithm
-		// Bit layout: [1][alg][alg][alg][0][0][size...26 bits]
-		// bit 7 = compression flag, bits 4-6 = algorithm
-		sizeWithFlags |= uint32(0x80|(uint8(algorithm)<<4)) << 24
+		sizeWithFlags |= uint32(algorithm) << 24
 	}
 
 	buf[0] = byte((sizeWithFlags >> 24) & 0xFF)
@@ -209,7 +204,7 @@ func DecodeHeader(buf []byte) (*Header, error) {
 		if buf[0]&CompressionReservedMask != 0 {
 			return nil, ErrInvalidHeader
 		}
-		if buf[0]&CompressionFlagMask != CompressionLZ4 {
+		if buf[0]&CompressionFlagMask != byte(AlgorithmLZ4) {
 			return nil, ErrUnknownCompression
 		}
 		h.Compressed = true

--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -206,8 +206,6 @@ func DecodeHeader(buf []byte) (*Header, error) {
 
 	// Validate the framing marker, mirroring rippled's parseMessageHeader.
 	if buf[0]&0x80 != 0 {
-		// Compressed frame: the two reserved bits must be clear and the
-		// algorithm nibble must be exactly LZ4.
 		if buf[0]&CompressionReservedMask != 0 {
 			return nil, ErrInvalidHeader
 		}
@@ -217,7 +215,6 @@ func DecodeHeader(buf []byte) (*Header, error) {
 		h.Compressed = true
 		h.Algorithm = AlgorithmLZ4
 	} else if buf[0]&UncompressedFlagMask != 0 {
-		// Uncompressed frame: the top six bits must all be zero.
 		return nil, ErrInvalidHeader
 	}
 

--- a/internal/peermanagement/message/codec_test.go
+++ b/internal/peermanagement/message/codec_test.go
@@ -120,6 +120,51 @@ func TestDecodeHeaderTruncated(t *testing.T) {
 	}
 }
 
+// TestDecodeHeaderFramingMarker exercises the first-byte framing-marker
+// invariants from rippled's parseMessageHeader: compressed frames must have
+// clear reserved bits and the exact LZ4 algorithm nibble (0x90); uncompressed
+// frames must have all six top bits clear.
+func TestDecodeHeaderFramingMarker(t *testing.T) {
+	tests := []struct {
+		name      string
+		firstByte byte
+		wantErr   error
+	}{
+		{"uncompressed_zero_flags", 0x00, nil},
+		{"uncompressed_payload_top_bits", 0x03, nil},
+		{"uncompressed_reserved_0x40", 0x40, ErrInvalidHeader},
+		{"uncompressed_reserved_0x04", 0x04, ErrInvalidHeader},
+		{"uncompressed_reserved_0x08", 0x08, ErrInvalidHeader},
+		{"compressed_lz4", 0x90, nil},
+		{"compressed_reserved_0x04", 0x94, ErrInvalidHeader},
+		{"compressed_reserved_0x08", 0x98, ErrInvalidHeader},
+		{"compressed_reserved_0x0C", 0x9C, ErrInvalidHeader},
+		{"compressed_bad_algo_0x80", 0x80, ErrUnknownCompression},
+		{"compressed_bad_algo_0xB0", 0xB0, ErrUnknownCompression},
+		{"compressed_bad_algo_0xD0", 0xD0, ErrUnknownCompression},
+		{"compressed_bad_algo_0xF0", 0xF0, ErrUnknownCompression},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := make([]byte, HeaderSizeCompressed)
+			buf[0] = tt.firstByte
+
+			header, err := DecodeHeader(buf)
+			if err != tt.wantErr {
+				t.Fatalf("DecodeHeader(first byte %#02x) error = %v, want %v", tt.firstByte, err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				return
+			}
+			wantCompressed := tt.firstByte&0x80 != 0
+			if header.Compressed != wantCompressed {
+				t.Errorf("Compressed = %v, want %v", header.Compressed, wantCompressed)
+			}
+		})
+	}
+}
+
 func TestReadWriteMessage(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/peermanagement/message/fuzz_test.go
+++ b/internal/peermanagement/message/fuzz_test.go
@@ -227,10 +227,13 @@ func FuzzHeaderRoundTrip(f *testing.F) {
 			t.Skip("payload size exceeds maximum")
 		}
 		if algorithm > 1 {
-			t.Skip("only AlgorithmNone (0) and AlgorithmLZ4 (1) are valid")
+			t.Skip("fuzz input maps only 0 and 1 to valid algorithms")
 		}
 
-		algo := CompressionAlgorithm(algorithm)
+		algo := AlgorithmNone
+		if algorithm == 1 {
+			algo = AlgorithmLZ4
+		}
 		mt := MessageType(msgType)
 
 		bufSize := HeaderSizeUncompressed


### PR DESCRIPTION
## Summary
- `DecodeHeader` now mirrors rippled's `parseMessageHeader` framing-marker validation: compressed frames must have clear reserved bits (`0x0C`) and an algorithm nibble of exactly LZ4 (`0x90`); uncompressed frames must have all six top flag bits clear (`buf[0]&0xFC == 0`). Frames rippled drops are now rejected (`ErrInvalidHeader` / `ErrUnknownCompression`) instead of silently accepted.
- Removed the dead `PayloadSize > MaxMessageSize` check — the 26-bit payload mask caps the value one below the 64 MiB limit, so it could never fire.
- Added table-driven first-byte tests covering reserved-bit and algorithm-nibble divergences.

Note: the issue body cites the LZ4 nibble as `0x80`, but rippled's enum is `Algorithm{ None = 0x00, LZ4 = 0x90 }` and goXRPL's encoder already emits `0x90`; the fix follows rippled (source of truth) so the round-trip is preserved.

## Test plan
- [x] `go test ./internal/peermanagement/message/`
- [x] `go build ./internal/peermanagement/...`

Fixes #613