### PR TITLE
consensus: weight operating-mode promotion by validation-trie preferred LCL

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1691,10 +1691,17 @@ func (a *Adaptor) preferredLCL(ourLCL consensus.LedgerID, ourSeq uint32, mode co
 			id, seq, ok = h.PreferredFromValidations(minSeq)
 		}
 		if ok {
-			if seq >= minSeq {
+			// Reconcile the raw trie tip against our current ledger,
+			// mirroring getPreferred's curr-relative logic
+			// (Validations.h:881-898): a preferred ledger that is not
+			// ahead of us — our own ledger or a same-chain ancestor — is
+			// not a switch, so we stick with ours. Approximated as
+			// seq >= ourSeq, the same guard rcl/engine.go:3347 uses on
+			// this pair, since per-seq ancestry is not available here.
+			// The seq >= minSeq half is getPreferredLCL:946.
+			if id != ourLCL && seq >= ourSeq && seq >= minSeq {
 				return id
 			}
-			// Preferred ledger is in the past — stick with our own.
 			return ourLCL
 		}
 	}
@@ -1712,23 +1719,13 @@ func (a *Adaptor) preferredLCL(ourLCL consensus.LedgerID, ourSeq uint32, mode co
 	}
 	best := ourLCL
 	for id, c := range counts {
-		if c > counts[best] || (c == counts[best] && lexGreaterLgrID(id, best)) {
+		// Larger count wins; ties break on larger ID, matching rippled's
+		// max_element over std::tie(count, id) (Validations.h:951-954).
+		if c > counts[best] || (c == counts[best] && bytes.Compare(id[:], best[:]) > 0) {
 			best = id
 		}
 	}
 	return best
-}
-
-// lexGreaterLgrID reports whether a sorts after b in lexicographic
-// (big-endian) order, matching rippled's max_element tie-break on
-// ledger ID in getPreferredLCL (Validations.h:951-954).
-func lexGreaterLgrID(a, b consensus.LedgerID) bool {
-	for i := 0; i < len(a); i++ {
-		if a[i] != b[i] {
-			return a[i] > b[i]
-		}
-	}
-	return false
 }
 
 // OnLedgerFullyValidated fires when the engine's ValidationTracker sees

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1681,12 +1681,24 @@ func (a *Adaptor) preferredLCL(ourLCL consensus.LedgerID, ourSeq uint32, mode co
 		minSeq = a.ledgerService.GetValidatedLedgerIndex()
 	}
 
+	// largestIssued is rippled's localSeqEnforcer_.largest() — the
+	// highest seq THIS node has issued a validation for — used to seed
+	// the trie's uncommitted support (Validations.h:855, trie.GetPreferred
+	// floor). A non-validator observer issues none, so its value is 0;
+	// a validator's tracks the ledgers it signed, for which the just-
+	// closed seq is the faithful proxy (same value rcl/engine.go:3347
+	// passes from its FULL-mode round boundary).
+	var largestIssued uint32
+	if a.IsValidator() {
+		largestIssued = ourSeq
+	}
+
 	// Trusted-validation branch (getPreferredLCL:941-946). GetPreferred
 	// consults the ancestry trie; PreferredFromValidations is its
 	// no-trie fallback, matching the engine's round-boundary jump
 	// (engine.go GetPreferred → PreferredFromValidations).
 	if h := a.validationHistorian; h != nil {
-		id, seq, ok := h.GetPreferred(ourSeq)
+		id, seq, ok := h.GetPreferred(largestIssued)
 		if !ok {
 			id, seq, ok = h.PreferredFromValidations(minSeq)
 		}

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1599,14 +1599,15 @@ func (a *Adaptor) OnConsensusReached(ledger consensus.Ledger, validations []*con
 //	                            evaluated on the new open child, since the
 //	                            argument here IS rippled's `current->parent`)
 //
-// Both branches are gated on !peerLCLDisagrees(ledger.ID()) — a
-// goXRPL proxy for rippled's `!ledgerChange` (NetworkOPs.cpp:2192,
-// 2203). rippled's `ledgerChange` is computed by
-// checkLastClosedLedger collating trusted validations + peer LCL
-// hashes; we approximate using PeerReportedLedgers because the full
-// validation-trie + inbound-ledger pathway is not yet ported. The
-// proxy is conservative: when peer LCL data is absent (typical
-// fresh-bootstrap), we fall through and promote as before.
+// Both branches are gated on !networkLedgerDiffers(ledger) — goXRPL's
+// realization of rippled's `!ledgerChange` (NetworkOPs.cpp:2192, 2203).
+// rippled's `ledgerChange` falls out of checkLastClosedLedger, which
+// picks the preferred LCL via validations.getPreferredLCL — trusted
+// validations weighted through the ancestry trie, with peer-reported
+// LCLs as the fallback when no trusted validations exist. We mirror
+// that ordering. The gate stays conservative: when neither trusted
+// validations nor peer LCL data are available (typical fresh-bootstrap),
+// the preferred LCL is our own and we promote as before.
 //
 // rippled additionally gates the TRACKING promotion on
 // `!needNetworkLedger_` (NetworkOPs.cpp:2197); goXRPL has no
@@ -1627,8 +1628,8 @@ func (a *Adaptor) maybePromoteAfterConsensus(ledger consensus.Ledger) {
 		return
 	}
 
-	if a.peerLCLDisagrees(ledger.ID()) {
-		a.logger.Info("operating mode promotion deferred — peer LCL disagrees",
+	if a.networkLedgerDiffers(ledger, current) {
+		a.logger.Info("operating mode promotion deferred — network prefers a different LCL",
 			"mode", current.String(),
 			"ledger_seq", ledger.Seq(),
 		)
@@ -1656,29 +1657,78 @@ func (a *Adaptor) maybePromoteAfterConsensus(ledger consensus.Ledger) {
 	)
 }
 
-// peerLCLDisagrees reports whether more known peers have a
-// last-closed-ledger hash different from `ourLCL` than agree with
-// it. Returns false when no peer LCL data is available — without
-// evidence to the contrary we trust the local consensus result.
-//
-// Approximates rippled's checkLastClosedLedger
-// (NetworkOPs.cpp:1881-1946) peer-LCL collation; a faithful port
-// would also weight trusted validations via the validation trie's
-// getPreferredLCL, which is not yet exposed here.
-func (a *Adaptor) peerLCLDisagrees(ourLCL consensus.LedgerID) bool {
-	peers := a.PeerReportedLedgers()
-	if len(peers) == 0 {
-		return false
+// networkLedgerDiffers reports whether the network-preferred last
+// closed ledger differs from the one we just closed — goXRPL's
+// equivalent of rippled's `switchLedgers` (the `ledgerChange` the
+// promotion gate keys off, NetworkOPs.cpp:1931). It returns false when
+// the preferred LCL is our own ledger, so promotion proceeds.
+func (a *Adaptor) networkLedgerDiffers(ledger consensus.Ledger, mode consensus.OperatingMode) bool {
+	ourLCL := ledger.ID()
+	return a.preferredLCL(ourLCL, ledger.Seq(), mode) != ourLCL
+}
+
+// preferredLCL mirrors rippled's validations.getPreferredLCL
+// (Validations.h:936-960) as collated by checkLastClosedLedger
+// (NetworkOPs.cpp:1902-1933). Trusted validations weighted through the
+// ancestry trie take priority; peer-reported LCL counts are the
+// fallback used only when no trusted validations are available.
+func (a *Adaptor) preferredLCL(ourLCL consensus.LedgerID, ourSeq uint32, mode consensus.OperatingMode) consensus.LedgerID {
+	// minSeq is rippled's getValidLedgerIndex() (NetworkOPs.cpp:1928):
+	// the trie's preferred ledger is only adopted when it is at least
+	// our last fully-validated sequence, never rewinding behind it.
+	var minSeq uint32
+	if a.ledgerService != nil {
+		minSeq = a.ledgerService.GetValidatedLedgerIndex()
 	}
-	var agree, disagree int
-	for _, p := range peers {
-		if p == ourLCL {
-			agree++
-		} else {
-			disagree++
+
+	// Trusted-validation branch (getPreferredLCL:941-946). GetPreferred
+	// consults the ancestry trie; PreferredFromValidations is its
+	// no-trie fallback, matching the engine's round-boundary jump
+	// (engine.go GetPreferred → PreferredFromValidations).
+	if h := a.validationHistorian; h != nil {
+		id, seq, ok := h.GetPreferred(ourSeq)
+		if !ok {
+			id, seq, ok = h.PreferredFromValidations(minSeq)
+		}
+		if ok {
+			if seq >= minSeq {
+				return id
+			}
+			// Preferred ledger is in the past — stick with our own.
+			return ourLCL
 		}
 	}
-	return disagree > agree
+
+	// Peer-LCL fallback (getPreferredLCL:948-959). Seed our own LCL at
+	// zero and increment it when we are already >= TRACKING, mirroring
+	// peerCounts in checkLastClosedLedger (NetworkOPs.cpp:1911-1913),
+	// then pick the dominant ledger (ties broken by larger ID).
+	counts := map[consensus.LedgerID]uint32{ourLCL: 0}
+	if mode >= consensus.OpModeTracking {
+		counts[ourLCL]++
+	}
+	for _, p := range a.PeerReportedLedgers() {
+		counts[p]++
+	}
+	best := ourLCL
+	for id, c := range counts {
+		if c > counts[best] || (c == counts[best] && lexGreaterLgrID(id, best)) {
+			best = id
+		}
+	}
+	return best
+}
+
+// lexGreaterLgrID reports whether a sorts after b in lexicographic
+// (big-endian) order, matching rippled's max_element tie-break on
+// ledger ID in getPreferredLCL (Validations.h:951-954).
+func lexGreaterLgrID(a, b consensus.LedgerID) bool {
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return a[i] > b[i]
+		}
+	}
+	return false
 }
 
 // OnLedgerFullyValidated fires when the engine's ValidationTracker sees

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -663,4 +663,28 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode(),
 			"trusted-validation preferred LCL matching ours permits promotion despite peer disagreement")
 	})
+
+	// trusted_ancestor_sticks_with_current mirrors rippled's
+	// "Parent of preferred → stick with ledger" (Validations_test.cpp:840-845
+	// / Validations.h:881-898): when the trie's preferred tip is behind our
+	// just-closed ledger (a same-chain ancestor — typical right after close,
+	// before trusted validations for our seq land), getPreferredLCL returns
+	// our own LCL, so promotion must proceed rather than defer.
+	t.Run("trusted_ancestor_sticks_with_current", func(t *testing.T) {
+		a := newTestAdaptor(t)
+		a.SetOperatingMode(consensus.OpModeConnected)
+		ourLCL := consensus.LedgerID{0xAA}
+		parentLCL := consensus.LedgerID{0x99}
+		a.UpdatePeerLCL(1, ourLCL)
+		a.UpdatePeerLCL(2, ourLCL)
+		a.SetValidationHistorian(&stubHistorian{
+			preferredID:  parentLCL,
+			preferredSeq: 2,
+			preferredOK:  true,
+		})
+		l := stubLedger{id: ourLCL, seq: 3, closeTime: a.Now()}
+		a.OnConsensusReached(l, nil, 0)
+		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode(),
+			"a preferred LCL behind our just-closed ledger is not a switch — promotion must proceed")
+	})
 }

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -618,4 +618,49 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode(),
 			"peer LCL majority agreement permits promotion")
 	})
+
+	// trusted_preferred_overrides_peer_agreement is the core of #611:
+	// trusted validations weighted through the ancestry trie take
+	// priority over a raw peer-LCL majority (getPreferredLCL:941-946).
+	// Even though every peer agrees with our ledger, a trusted preferred
+	// LCL on a different chain must defer promotion.
+	t.Run("trusted_preferred_overrides_peer_agreement", func(t *testing.T) {
+		a := newTestAdaptor(t)
+		a.SetOperatingMode(consensus.OpModeConnected)
+		ourLCL := consensus.LedgerID{0xAA}
+		theirLCL := consensus.LedgerID{0xBB}
+		a.UpdatePeerLCL(1, ourLCL)
+		a.UpdatePeerLCL(2, ourLCL)
+		a.SetValidationHistorian(&stubHistorian{
+			preferredID:  theirLCL,
+			preferredSeq: 3,
+			preferredOK:  true,
+		})
+		l := stubLedger{id: ourLCL, seq: 3, closeTime: a.Now()}
+		a.OnConsensusReached(l, nil, 0)
+		assert.Equal(t, consensus.OpModeConnected, a.GetOperatingMode(),
+			"trusted-validation preferred LCL on a different chain must defer promotion despite peer agreement")
+	})
+
+	// trusted_preferred_overrides_peer_disagreement is the inverse: peers
+	// majority-disagree, but the trusted preferred LCL is our own ledger,
+	// so promotion proceeds — the trie's verdict supersedes peer counts.
+	t.Run("trusted_preferred_overrides_peer_disagreement", func(t *testing.T) {
+		a := newTestAdaptor(t)
+		a.SetOperatingMode(consensus.OpModeConnected)
+		ourLCL := consensus.LedgerID{0xAA}
+		theirLCL := consensus.LedgerID{0xBB}
+		a.UpdatePeerLCL(1, theirLCL)
+		a.UpdatePeerLCL(2, theirLCL)
+		a.UpdatePeerLCL(3, theirLCL)
+		a.SetValidationHistorian(&stubHistorian{
+			preferredID:  ourLCL,
+			preferredSeq: 3,
+			preferredOK:  true,
+		})
+		l := stubLedger{id: ourLCL, seq: 3, closeTime: a.Now()}
+		a.OnConsensusReached(l, nil, 0)
+		assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode(),
+			"trusted-validation preferred LCL matching ours permits promotion despite peer disagreement")
+	})
 }

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -38,13 +38,26 @@ func (s *stubSkipListProvider) SkipListHashes() ([][32]byte, error) {
 }
 
 // stubHistorian implements consensus.ValidationHistorian by returning
-// per-ledger trusted validations from a pre-seeded map.
+// per-ledger trusted validations from a pre-seeded map. The preferred*
+// fields drive the preferred-LCL lookups; left zero they report "no
+// trusted validations available" so the peer-LCL fallback is exercised.
 type stubHistorian struct {
-	byLedger map[consensus.LedgerID][]*consensus.Validation
+	byLedger     map[consensus.LedgerID][]*consensus.Validation
+	preferredID  consensus.LedgerID
+	preferredSeq uint32
+	preferredOK  bool
 }
 
 func (s *stubHistorian) GetTrustedValidations(id consensus.LedgerID) []*consensus.Validation {
 	return s.byLedger[id]
+}
+
+func (s *stubHistorian) GetPreferred(largestIssued uint32) (consensus.LedgerID, uint32, bool) {
+	return s.preferredID, s.preferredSeq, s.preferredOK
+}
+
+func (s *stubHistorian) PreferredFromValidations(minSeq uint32) (consensus.LedgerID, uint32, bool) {
+	return s.preferredID, s.preferredSeq, s.preferredOK
 }
 
 func TestAdaptor_NegativeUNL_NilVoterReturnsNil(t *testing.T) {

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -71,15 +71,24 @@ type Engine interface {
 	Subscribe(sub EventSubscriber)
 }
 
-// ValidationHistorian provides historical, per-ledger trusted
-// validation lookups for NegativeUNL score-table building. Implemented
-// by rcl.ValidationTracker; an adaptor that wants to participate in
-// NegativeUNL voting receives one via the WireableAdaptor extension.
-// Mirrors rippled's `validations.getTrustedForLedger(hash, seq)` at
-// NegativeUNLVote.cpp:208 — goXRPL's tracker keys validations by
-// LedgerID, so the (hash, seq) tuple collapses to a single lookup.
+// ValidationHistorian exposes the validation subsystem to an adaptor:
+// per-ledger trusted-validation lookups (NegativeUNL score tables,
+// remote-fee median) and trie-based preferred-LCL selection (the
+// operating-mode promotion gate). Implemented by rcl.ValidationTracker;
+// an adaptor receives one via the WireableAdaptor extension.
+//
+//   - GetTrustedValidations mirrors rippled's
+//     `validations.getTrustedForLedger(hash, seq)` at
+//     NegativeUNLVote.cpp:208 — goXRPL's tracker keys validations by
+//     LedgerID, so the (hash, seq) tuple collapses to a single lookup.
+//   - GetPreferred / PreferredFromValidations expose the validation
+//     ancestry trie's preferred-ledger pick (and its no-trie fallback),
+//     the goXRPL realization of rippled's
+//     `validations.getPreferredLCL` (Validations.h:936).
 type ValidationHistorian interface {
 	GetTrustedValidations(ledgerID LedgerID) []*Validation
+	GetPreferred(largestIssued uint32) (LedgerID, uint32, bool)
+	PreferredFromValidations(minSeq uint32) (LedgerID, uint32, bool)
 }
 
 // WireableAdaptor is an optional extension that engine wires up after


### PR DESCRIPTION
## Summary
- The operating-mode promotion gate (`maybePromoteAfterConsensus`) previously deferred only on a raw peer-reported LCL agree/disagree majority (`peerLCLDisagrees`), omitting the trusted-validation weighting rippled applies via the validation trie's `getPreferredLCL`.
- Exposes the trie's preferred-ledger pick (`GetPreferred` / `PreferredFromValidations`, already implemented by `rcl.ValidationTracker`) on the `consensus.ValidationHistorian` interface — making the validation trie available to the adaptor.
- Rewrites the gate (`networkLedgerDiffers` → `preferredLCL`) to mirror rippled's `checkLastClosedLedger` + `getPreferredLCL` (NetworkOPs.cpp:1902-1933, Validations.h:936-960): trusted validations decide the preferred LCL first (adopted only when at least our validated index, `minSeq`), with peer-reported LCL counts as the fallback used only when no trusted validations exist (our own LCL seeded, incremented when ≥ TRACKING, ties broken by larger ID).

## Test plan
- [x] `just test-pkg ./internal/consensus/...` — all green
- [x] New subtests in `TestOnConsensusReached_AutoPromote`: trusted-validation preferred LCL overrides both peer agreement (defers) and peer disagreement (promotes)
- [x] `go build ./...`, `go vet ./internal/consensus/...` clean

Fixes #611