### PR TITLE
feat: add Batch hash prefix to protocol mirror

### DIFF
--- a/internal/testing/payment/fund_new_account_test.go
+++ b/internal/testing/payment/fund_new_account_test.go
@@ -81,7 +81,7 @@ func TestRipplePayment_NewDest(t *testing.T) {
 		env.Close()
 
 		// Market maker offers to sell XRP for USD (1:1).
-		xrp300 := tx.NewXRPAmount(int64(xrplgoTesting.XRP(300)))
+		xrp300 := tx.NewXRPAmount(xrplgoTesting.XRP(300))
 		result = env.CreateOffer(mm, xrp300, usd300) // TakerGets=XRP, TakerPays=USD
 		xrplgoTesting.RequireTxSuccess(t, result)
 		env.Close()

--- a/protocol/hash_prefix.go
+++ b/protocol/hash_prefix.go
@@ -18,6 +18,7 @@ var (
 	HashPrefixManifest            = HashPrefix{'M', 'A', 'N', 0x00}
 	HashPrefixPaymentChannelClaim = HashPrefix{'C', 'L', 'M', 0x00}
 	HashPrefixCredential          = HashPrefix{'C', 'R', 'D', 0x00}
+	HashPrefixBatch               = HashPrefix{'B', 'C', 'H', 0x00}
 )
 
 // Bytes returns the prefix as a byte slice.

--- a/protocol/hash_prefix_test.go
+++ b/protocol/hash_prefix_test.go
@@ -1,0 +1,43 @@
+package protocol_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/crypto"
+	"github.com/LeJamon/goXRPLd/protocol"
+)
+
+// TestHashPrefixSyncWithCrypto guards against the two hash-prefix mirrors
+// drifting apart. The protocol package exposes prefixes as [4]byte while
+// crypto encodes the same domain-separation values as big-endian uint32;
+// every shared prefix must agree byte-for-byte.
+func TestHashPrefixSyncWithCrypto(t *testing.T) {
+	cases := []struct {
+		name     string
+		protocol protocol.HashPrefix
+		crypto   crypto.HashPrefix
+	}{
+		{"LedgerMaster", protocol.HashPrefixLedgerMaster, crypto.HashPrefixLedgerMaster},
+		{"InnerNode", protocol.HashPrefixInnerNode, crypto.HashPrefixInnerNode},
+		{"LeafNode", protocol.HashPrefixLeafNode, crypto.HashPrefixLeafNode},
+		{"TxNode", protocol.HashPrefixTxNode, crypto.HashPrefixTxNode},
+		{"TxSign", protocol.HashPrefixTxSign, crypto.HashPrefixTxSign},
+		{"TxMultiSign", protocol.HashPrefixTxMultiSign, crypto.HashPrefixTxMultiSign},
+		{"TransactionID", protocol.HashPrefixTransactionID, crypto.HashPrefixTransactionID},
+		{"Validation", protocol.HashPrefixValidation, crypto.HashPrefixValidation},
+		{"Proposal", protocol.HashPrefixProposal, crypto.HashPrefixProposal},
+		{"Manifest", protocol.HashPrefixManifest, crypto.HashPrefixManifest},
+		{"PaymentChannelClaim", protocol.HashPrefixPaymentChannelClaim, crypto.HashPrefixPaymentChannelClaim},
+		{"Credential", protocol.HashPrefixCredential, crypto.HashPrefixCredential},
+		{"Batch", protocol.HashPrefixBatch, crypto.HashPrefixBatch},
+	}
+
+	for _, tc := range cases {
+		var want [4]byte
+		binary.BigEndian.PutUint32(want[:], uint32(tc.crypto))
+		if protocol.HashPrefix(want) != tc.protocol {
+			t.Errorf("%s prefix mismatch: protocol=%v crypto=%#08x", tc.name, tc.protocol, uint32(tc.crypto))
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `HashPrefixBatch = {'B','C','H',0x00}` to `protocol/hash_prefix.go`, restoring parity with rippled's `HashPrefix.h` (`batch = make_hash_prefix('B','C','H')`) and with the functional values already in `crypto` and `binarycodec`.
- Adds a `protocol`↔`crypto` sync test so the two hash-prefix mirrors can no longer drift silently — the exact maintainability concern raised in the issue.

## Test plan
- [x] `go test ./protocol/...`
- [x] `go vet ./protocol/...`
- [x] `gofmt -l` clean

Fixes #614