### PR TITLE
refactor: drop dead TransferRate range re-check in AccountSet Apply

### DIFF
--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -511,14 +511,10 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	// TransferRate
+	// Range is validated in preflight; doApply only chooses unset vs set.
+	// Reference: rippled SetAccount.cpp:582-597
 	if a.TransferRate != nil {
 		rate := *a.TransferRate
-		if rate != 0 && rate < qualityOne {
-			return tx.TemBAD_TRANSFER_RATE
-		}
-		if rate > 2*qualityOne {
-			return tx.TemBAD_TRANSFER_RATE
-		}
 		if rate == 0 || rate == qualityOne {
 			account.TransferRate = 0
 		} else {


### PR DESCRIPTION
## Summary
- `AccountSet.Apply` re-checked the `TransferRate` range and returned `temBAD_TRANSFER_RATE`, but that range is already validated in `AccountSet.Validate` (preflight), which always runs first — so the Apply check was unreachable dead code.
- Removed the duplicate bounds check; `Apply` now only chooses unset vs set (`rate == 0 || rate == qualityOne` → unset, else set), matching rippled's `doApply` (`SetAccount.cpp:582-597`), which performs no range re-validation.
- Eliminates duplicated literals (`qualityOne`/`2*qualityOne` vs `protocol.TransferRateMin/Max`) that could drift over time.

## Test plan
- [x] `go build ./internal/tx/account/...` and `go vet`
- [x] `go test ./internal/tx/account/...`
- [x] `go test ./internal/testing/accountset/...`

Fixes #618