### PR TITLE
refactor: remove dead exported errors in ledger/entry

### DIFF
--- a/internal/testing/payment/fund_new_account_test.go
+++ b/internal/testing/payment/fund_new_account_test.go
@@ -81,7 +81,7 @@ func TestRipplePayment_NewDest(t *testing.T) {
 		env.Close()
 
 		// Market maker offers to sell XRP for USD (1:1).
-		xrp300 := tx.NewXRPAmount(int64(xrplgoTesting.XRP(300)))
+		xrp300 := tx.NewXRPAmount(xrplgoTesting.XRP(300))
 		result = env.CreateOffer(mm, xrp300, usd300) // TakerGets=XRP, TakerPays=USD
 		xrplgoTesting.RequireTxSuccess(t, result)
 		env.Close()

--- a/ledger/entry/flags.go
+++ b/ledger/entry/flags.go
@@ -1,9 +1,5 @@
 package entry
 
-import (
-	"errors"
-)
-
 // LedgerSpecificFlags mirrors rippled's LedgerSpecificFlags enum.
 // Reference: rippled/include/xrpl/protocol/LedgerFormats.h (LedgerSpecificFlags).
 // Values are scoped per ledger entry type; identical numeric values are
@@ -125,11 +121,4 @@ const (
 	// MaxMPTokenAmount is the maximum amount for MPTokens (63-bit unsigned)
 	// Reference: rippled Protocol.h
 	MaxMPTokenAmount uint64 = 0x7FFFFFFFFFFFFFFF
-)
-
-// Errors returned by entry operations
-var (
-	ErrInvalidEntry = errors.New("invalid entry")
-	ErrInvalidFlags = errors.New("invalid flags")
-	ErrInvalidHash  = errors.New("invalid hash")
 )


### PR DESCRIPTION
## Summary
- Remove the unused exported error vars `ErrInvalidEntry`, `ErrInvalidFlags`, `ErrInvalidHash` from `ledger/entry/flags.go` — declared but never referenced anywhere in the codebase or tests.
- Drop the now-unused `"errors"` import (it was the only consumer).

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./ledger/entry/` clean
- [x] `gofmt -l` reports no changes

Fixes #619