### PR TITLE
test(tx/nftoken): add in-package unit tests for ID/page math

### DIFF
--- a/internal/tx/nftoken/nftoken_id.go
+++ b/internal/tx/nftoken/nftoken_id.go
@@ -66,7 +66,7 @@ func getNFTFlagsFromID(nftokenID [32]byte) uint16 {
 }
 
 // CipheredTaxon ciphers a taxon using rippled's algorithm to prevent enumeration.
-// Matching rippled: (taxon ^ ((tokenSeq ^ 384160001) * 2357503715))
+// Matching rippled nft.h cipheredTaxon: taxon ^ ((384160001 * tokenSeq) + 2459)
 func CipheredTaxon(tokenSeq uint32, taxon uint32) uint32 {
 	return cipheredTaxon(tokenSeq, taxon)
 }

--- a/internal/tx/nftoken/nftoken_id_test.go
+++ b/internal/tx/nftoken/nftoken_id_test.go
@@ -36,9 +36,12 @@ func mustHexIssuer(t *testing.T, s string) [20]byte {
 }
 
 // TestGenerateNFTokenID_KnownVectors pins the NFTokenID composition against
-// known-good vectors. The first is lifted from a rippled-signed conformance
-// fixture (NFTokenAllFeatures/Enabled.json); the second is the all-zero case
-// where the scrambled taxon reduces to the cipher constant c = 2459 (0x099B).
+// known-good vectors. The first is the NFTokenID rippled mints in its
+// NFTokenAllFeatures conformance suite; the suite's JSON lives in rippled's
+// external test vectors, but the signed burn blob carrying this exact ID is
+// vendored in-repo at internal/testing/nft/conformance_debug_test.go. The
+// second is the all-zero case where the scrambled taxon reduces to the cipher
+// constant c = 2459 (0x099B).
 // Reference: rippled nft.h cipheredTaxon / NFTokenMint.cpp createNFTokenID.
 func TestGenerateNFTokenID_KnownVectors(t *testing.T) {
 	tests := []struct {
@@ -51,7 +54,7 @@ func TestGenerateNFTokenID_KnownVectors(t *testing.T) {
 		want        string
 	}{
 		{
-			// From conformance fixture: seq=1, taxon=0, scrambled = cipheredTaxon(1,0) = 0x16E5DA9C.
+			// From the NFTokenAllFeatures conformance suite: seq=1, taxon=0, scrambled = cipheredTaxon(1,0) = 0x16E5DA9C.
 			name:     "conformance_fixture",
 			issuer:   "B5F762798A53D543A014CAF8B297CFF8F2F937E8",
 			taxon:    0,

--- a/internal/tx/nftoken/nftoken_id_test.go
+++ b/internal/tx/nftoken/nftoken_id_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/LeJamon/goXRPLd/internal/ledger/state"
 )
 
-// mustHexID decodes a 64-char hex string into a [32]byte NFTokenID.
 func mustHexID(t *testing.T, s string) [32]byte {
 	t.Helper()
 	b, err := hex.DecodeString(s)
@@ -22,7 +21,6 @@ func mustHexID(t *testing.T, s string) [32]byte {
 	return id
 }
 
-// mustHexIssuer decodes a 40-char hex string into a [20]byte AccountID.
 func mustHexIssuer(t *testing.T, s string) [20]byte {
 	t.Helper()
 	b, err := hex.DecodeString(s)

--- a/internal/tx/nftoken/nftoken_id_test.go
+++ b/internal/tx/nftoken/nftoken_id_test.go
@@ -1,0 +1,340 @@
+package nftoken
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+)
+
+// mustHexID decodes a 64-char hex string into a [32]byte NFTokenID.
+func mustHexID(t *testing.T, s string) [32]byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	if len(b) != 32 {
+		t.Fatalf("hex %q decodes to %d bytes, want 32", s, len(b))
+	}
+	var id [32]byte
+	copy(id[:], b)
+	return id
+}
+
+// mustHexIssuer decodes a 40-char hex string into a [20]byte AccountID.
+func mustHexIssuer(t *testing.T, s string) [20]byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	if len(b) != 20 {
+		t.Fatalf("hex %q decodes to %d bytes, want 20", s, len(b))
+	}
+	var acct [20]byte
+	copy(acct[:], b)
+	return acct
+}
+
+// TestGenerateNFTokenID_KnownVectors pins the NFTokenID composition against
+// known-good vectors. The first is lifted from a rippled-signed conformance
+// fixture (NFTokenAllFeatures/Enabled.json); the second is the all-zero case
+// where the scrambled taxon reduces to the cipher constant c = 2459 (0x099B).
+// Reference: rippled nft.h cipheredTaxon / NFTokenMint.cpp createNFTokenID.
+func TestGenerateNFTokenID_KnownVectors(t *testing.T) {
+	tests := []struct {
+		name        string
+		issuer      string
+		taxon       uint32
+		sequence    uint32
+		flags       uint16
+		transferFee uint16
+		want        string
+	}{
+		{
+			// From conformance fixture: seq=1, taxon=0, scrambled = cipheredTaxon(1,0) = 0x16E5DA9C.
+			name:     "conformance_fixture",
+			issuer:   "B5F762798A53D543A014CAF8B297CFF8F2F937E8",
+			taxon:    0,
+			sequence: 1,
+			want:     "00000000B5F762798A53D543A014CAF8B297CFF8F2F937E816E5DA9C00000001",
+		},
+		{
+			// seq=0, taxon=0 → scrambled = c = 2459 = 0x0000099B.
+			name:     "zero_seq_zero_taxon",
+			issuer:   "0000000000000000000000000000000000000000",
+			taxon:    0,
+			sequence: 0,
+			want:     "0000000000000000000000000000000000000000000000000000099B00000000",
+		},
+		{
+			// Non-zero flags + transfer fee occupy the first four bytes.
+			name:        "flags_and_fee",
+			issuer:      "B5F762798A53D543A014CAF8B297CFF8F2F937E8",
+			taxon:       0,
+			sequence:    1,
+			flags:       nftFlagBurnable | nftFlagOnlyXRP | nftFlagTransferable, // 0x000B
+			transferFee: 314,                                                    // 0x013A
+			want:        "000B013AB5F762798A53D543A014CAF8B297CFF8F2F937E816E5DA9C00000001",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			issuer := mustHexIssuer(t, tc.issuer)
+			got := generateNFTokenID(issuer, tc.taxon, tc.sequence, tc.flags, tc.transferFee)
+			want := mustHexID(t, tc.want)
+			if got != want {
+				t.Errorf("generateNFTokenID = %X, want %X", got, want)
+			}
+			// Exported wrapper must agree with the package-internal generator.
+			if GenerateNFTokenID(issuer, tc.taxon, tc.sequence, tc.flags, tc.transferFee) != got {
+				t.Errorf("GenerateNFTokenID disagrees with generateNFTokenID")
+			}
+		})
+	}
+}
+
+// TestGenerateNFTokenID_FieldLayout verifies each field lands at its documented
+// byte offset: Flags[0:2] | TransferFee[2:4] | Issuer[4:24] | scrambledTaxon[24:28] | Sequence[28:32].
+func TestGenerateNFTokenID_FieldLayout(t *testing.T) {
+	issuer := mustHexIssuer(t, "0102030405060708090A0B0C0D0E0F1011121314")
+	const (
+		taxon       = uint32(0xDEADBEEF)
+		sequence    = uint32(0x01020304)
+		flags       = uint16(0x000B)
+		transferFee = uint16(0x1388) // 5000 = 5%
+	)
+	id := generateNFTokenID(issuer, taxon, sequence, flags, transferFee)
+
+	if got := getNFTFlagsFromID(id); got != flags {
+		t.Errorf("flags = %#04x, want %#04x", got, flags)
+	}
+	if got := getNFTTransferFee(id); got != transferFee {
+		t.Errorf("transferFee = %d, want %d", got, transferFee)
+	}
+	if got := getNFTIssuer(id); got != issuer {
+		t.Errorf("issuer = %X, want %X", got, issuer)
+	}
+	// The plaintext taxon is recovered by reversing the cipher over bytes [24:28].
+	scrambled := uint32(id[24])<<24 | uint32(id[25])<<16 | uint32(id[26])<<8 | uint32(id[27])
+	if got := cipheredTaxon(sequence, scrambled); got != taxon {
+		t.Errorf("recovered taxon = %#08x, want %#08x", got, taxon)
+	}
+	// Sequence occupies the final four bytes, big-endian.
+	gotSeq := uint32(id[28])<<24 | uint32(id[29])<<16 | uint32(id[30])<<8 | uint32(id[31])
+	if gotSeq != sequence {
+		t.Errorf("sequence = %#08x, want %#08x", gotSeq, sequence)
+	}
+}
+
+// TestCipheredTaxon_Vectors pins the LCG output for known (sequence, taxon) pairs.
+func TestCipheredTaxon_Vectors(t *testing.T) {
+	tests := []struct {
+		seq, taxon, want uint32
+	}{
+		{0, 0, 2459},       // c = 2459
+		{1, 0, 0x16E5DA9C}, // m + c = 384160001 + 2459
+		{0, 0xFFFFFFFF, ^uint32(2459)},
+	}
+	for _, tc := range tests {
+		if got := cipheredTaxon(tc.seq, tc.taxon); got != tc.want {
+			t.Errorf("cipheredTaxon(%d, %#x) = %#x, want %#x", tc.seq, tc.taxon, got, tc.want)
+		}
+		// The exported wrapper must match.
+		if got := CipheredTaxon(tc.seq, tc.taxon); got != tc.want {
+			t.Errorf("CipheredTaxon(%d, %#x) = %#x, want %#x", tc.seq, tc.taxon, got, tc.want)
+		}
+	}
+}
+
+// TestCipheredTaxon_Involution verifies the cipher is its own inverse — applying
+// it twice with the same sequence recovers the original taxon (it is an XOR).
+// Reference: rippled nft.h getTaxon comment.
+func TestCipheredTaxon_Involution(t *testing.T) {
+	seqs := []uint32{0, 1, 2, 100, 0x7FFFFFFF, 0xFFFFFFFF}
+	taxons := []uint32{0, 1, 42, 0xDEADBEEF, 0xFFFFFFFF}
+	for _, seq := range seqs {
+		for _, taxon := range taxons {
+			scrambled := cipheredTaxon(seq, taxon)
+			if got := cipheredTaxon(seq, scrambled); got != taxon {
+				t.Errorf("cipheredTaxon(%d, cipheredTaxon(%d, %#x)) = %#x, want %#x",
+					seq, seq, taxon, got, taxon)
+			}
+		}
+	}
+}
+
+// TestGetNFTokenFlags_HexParse checks the string-based flag extractor (first
+// four hex chars) and its agreement with the byte-based extractor.
+func TestGetNFTokenFlags_HexParse(t *testing.T) {
+	tests := []struct {
+		id   string
+		want uint16
+	}{
+		{"000B013AB5F762798A53D543A014CAF8B297CFF8F2F937E816E5DA9C00000001", 0x000B},
+		{"0008000000000000000000000000000000000000000000000000099B00000000", 0x0008},
+		{"abcd", 0xABCD}, // lowercase
+		{"00", 0},        // too short → 0
+		{"", 0},
+	}
+	for _, tc := range tests {
+		if got := getNFTokenFlags(tc.id); got != tc.want {
+			t.Errorf("getNFTokenFlags(%q) = %#04x, want %#04x", tc.id, got, tc.want)
+		}
+	}
+
+	// String and byte extractors must agree for a full ID.
+	full := "000B013AB5F762798A53D543A014CAF8B297CFF8F2F937E816E5DA9C00000001"
+	if getNFTokenFlags(full) != getNFTFlagsFromID(mustHexID(t, full)) {
+		t.Errorf("string and byte flag extractors disagree")
+	}
+}
+
+// TestGetNFTPageKey verifies that the page key keeps only the low 96 bits
+// (bytes 20-31) and zeroes the high 160 bits.
+func TestGetNFTPageKey(t *testing.T) {
+	id := mustHexID(t, "000B013AB5F762798A53D543A014CAF8B297CFF8F2F937E816E5DA9C00000001")
+	key := getNFTPageKey(id)
+
+	for i := 0; i < 20; i++ {
+		if key[i] != 0 {
+			t.Errorf("page key byte %d = %#02x, want 0 (high 160 bits must be zero)", i, key[i])
+		}
+	}
+	for i := 20; i < 32; i++ {
+		if key[i] != id[i] {
+			t.Errorf("page key byte %d = %#02x, want %#02x (low 96 bits preserved)", i, key[i], id[i])
+		}
+	}
+
+	// All-ones low bits, arbitrary high bits → only low 96 bits survive.
+	allOnes := mustHexID(t, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+	k2 := getNFTPageKey(allOnes)
+	for i := 0; i < 20; i++ {
+		if k2[i] != 0 {
+			t.Errorf("byte %d = %#02x, want 0", i, k2[i])
+		}
+	}
+	for i := 20; i < 32; i++ {
+		if k2[i] != 0xFF {
+			t.Errorf("byte %d = %#02x, want 0xFF", i, k2[i])
+		}
+	}
+}
+
+// TestCompareNFTokenID checks rippled's sort order: low 96 bits first, then the
+// full 256-bit ID as tiebreaker.
+// Reference: rippled NFTokenUtils.cpp compareTokens.
+func TestCompareNFTokenID(t *testing.T) {
+	// a and b share low 96 bits; they differ only in the high bytes, so the
+	// full-ID tiebreaker decides (a < b).
+	a := mustHexID(t, "0000000000000000000000000000000000000000000000000000000000000001")
+	b := mustHexID(t, "0100000000000000000000000000000000000000000000000000000000000001")
+	if got := compareNFTokenID(a, b); got >= 0 {
+		t.Errorf("compareNFTokenID(a,b) = %d, want < 0 (tiebreak on full ID)", got)
+	}
+	if got := compareNFTokenID(b, a); got <= 0 {
+		t.Errorf("compareNFTokenID(b,a) = %d, want > 0", got)
+	}
+	if got := compareNFTokenID(a, a); got != 0 {
+		t.Errorf("compareNFTokenID(a,a) = %d, want 0", got)
+	}
+
+	// c has larger low 96 bits than a; low-96 comparison dominates even though
+	// c's high bytes are smaller.
+	c := mustHexID(t, "0000000000000000000000000000000000000000000000000000000000000002")
+	if got := compareNFTokenID(a, c); got >= 0 {
+		t.Errorf("compareNFTokenID(a,c) = %d, want < 0 (low 96 bits dominate)", got)
+	}
+}
+
+// TestInsertNFTokenSorted checks that insertion maintains compareNFTokenID order
+// regardless of insertion sequence.
+func TestInsertNFTokenSorted(t *testing.T) {
+	ids := []string{
+		"0000000000000000000000000000000000000000000000000000000000000003",
+		"0000000000000000000000000000000000000000000000000000000000000001",
+		"0000000000000000000000000000000000000000000000000000000000000004",
+		"0000000000000000000000000000000000000000000000000000000000000002",
+	}
+	var tokens []state.NFTokenData
+	for _, s := range ids {
+		tokens = insertNFTokenSorted(tokens, state.NFTokenData{NFTokenID: mustHexID(t, s)})
+	}
+
+	if len(tokens) != len(ids) {
+		t.Fatalf("got %d tokens, want %d", len(tokens), len(ids))
+	}
+	for i := 1; i < len(tokens); i++ {
+		if compareNFTokenID(tokens[i-1].NFTokenID, tokens[i].NFTokenID) >= 0 {
+			t.Errorf("tokens not sorted at index %d: %X >= %X",
+				i, tokens[i-1].NFTokenID, tokens[i].NFTokenID)
+		}
+	}
+}
+
+// TestUint256Next checks 256-bit increment with carry propagation.
+func TestUint256Next(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no_carry",
+			in:   "0000000000000000000000000000000000000000000000000000000000000001",
+			want: "0000000000000000000000000000000000000000000000000000000000000002",
+		},
+		{
+			name: "carry_low_byte",
+			in:   "00000000000000000000000000000000000000000000000000000000000000FF",
+			want: "0000000000000000000000000000000000000000000000000000000000000100",
+		},
+		{
+			name: "carry_multi_byte",
+			in:   "000000000000000000000000000000000000000000000000000000000000FFFF",
+			want: "0000000000000000000000000000000000000000000000000000000000010000",
+		},
+		{
+			name: "wrap_around",
+			in:   "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+			want: "0000000000000000000000000000000000000000000000000000000000000000",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := uint256Next(mustHexID(t, tc.in)); got != mustHexID(t, tc.want) {
+				t.Errorf("uint256Next(%s) = %X, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNFTransferFeeXRP exercises the round-half-even (banker's rounding) used
+// for the issuer's XRP transfer-fee cut.
+// Reference: rippled Rate2.cpp / Number.cpp operator rep().
+func TestNFTransferFeeXRP(t *testing.T) {
+	tests := []struct {
+		name   string
+		amount uint64
+		fee    uint16
+		want   uint64
+	}{
+		{"zero_fee", 1_000_000, 0, 0},
+		{"exact_half", 1_000_000, 50000, 500_000}, // 1e6 * 0.5, no remainder
+		{"five_percent", 1_000_000, 5000, 50_000},
+		{"round_down_below_half", 2, 20000, 0}, // 40000/100000 = 0.4 → 0
+		{"round_up_above_half", 2, 30000, 1},   // 60000/100000 = 0.6 → 1
+		{"tie_to_even_down", 1, 50000, 0},      // 50000/100000 = 0.5 → ties to even (0)
+		{"tie_to_even_up", 3, 50000, 2},        // 150000/100000 = 1.5 → ties to even (2)
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nftTransferFeeXRP(tc.amount, tc.fee); got != tc.want {
+				t.Errorf("nftTransferFeeXRP(%d, %d) = %d, want %d", tc.amount, tc.fee, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tx/nftoken/nftoken_page_test.go
+++ b/internal/tx/nftoken/nftoken_page_test.go
@@ -83,8 +83,6 @@ func (m *mockView) TxExists([32]byte) bool  { return false }
 func (m *mockView) Rules() *amendment.Rules { return nil }
 func (m *mockView) LedgerSeq() uint32       { return 0 }
 
-// pageStats parses every NFTokenPage in the view and reports the page count,
-// total token count, and the largest single-page token count.
 func pageStats(t *testing.T, view *mockView) (pages, tokens, maxPerPage int) {
 	t.Helper()
 	_ = view.ForEach(func(_ [32]byte, data []byte) bool {

--- a/internal/tx/nftoken/nftoken_page_test.go
+++ b/internal/tx/nftoken/nftoken_page_test.go
@@ -1,0 +1,215 @@
+package nftoken
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/amendment"
+	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/ledger/state"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+	"github.com/LeJamon/goXRPLd/keylet"
+)
+
+// mockView is an in-memory tx.LedgerView backed by a flat key→bytes map. It
+// implements just enough of the interface (Read/Insert/Update/Erase/Succ) to
+// exercise NFTokenPage split/merge logic without a full ledger.
+type mockView struct {
+	store map[[32]byte][]byte
+}
+
+func newMockView() *mockView {
+	return &mockView{store: make(map[[32]byte][]byte)}
+}
+
+func (m *mockView) Read(k keylet.Keylet) ([]byte, error) {
+	if d, ok := m.store[k.Key]; ok {
+		return d, nil
+	}
+	return nil, nil
+}
+
+func (m *mockView) Exists(k keylet.Keylet) (bool, error) {
+	_, ok := m.store[k.Key]
+	return ok, nil
+}
+
+func (m *mockView) Insert(k keylet.Keylet, data []byte) error {
+	m.store[k.Key] = append([]byte(nil), data...)
+	return nil
+}
+
+func (m *mockView) Update(k keylet.Keylet, data []byte) error {
+	m.store[k.Key] = append([]byte(nil), data...)
+	return nil
+}
+
+func (m *mockView) Erase(k keylet.Keylet) error {
+	delete(m.store, k.Key)
+	return nil
+}
+
+func (m *mockView) AdjustDropsDestroyed(drops.XRPAmount) {}
+
+func (m *mockView) ForEach(fn func(key [32]byte, data []byte) bool) error {
+	for k, v := range m.store {
+		if !fn(k, v) {
+			break
+		}
+	}
+	return nil
+}
+
+// Succ returns the first stored key strictly greater than the given key.
+func (m *mockView) Succ(key [32]byte) ([32]byte, []byte, bool, error) {
+	var best [32]byte
+	found := false
+	for k := range m.store {
+		if bytes.Compare(k[:], key[:]) <= 0 {
+			continue
+		}
+		if !found || bytes.Compare(k[:], best[:]) < 0 {
+			best = k
+			found = true
+		}
+	}
+	if !found {
+		return [32]byte{}, nil, false, nil
+	}
+	return best, m.store[best], true, nil
+}
+
+func (m *mockView) TxExists([32]byte) bool  { return false }
+func (m *mockView) Rules() *amendment.Rules { return nil }
+func (m *mockView) LedgerSeq() uint32       { return 0 }
+
+// pageStats parses every NFTokenPage in the view and reports the page count,
+// total token count, and the largest single-page token count.
+func pageStats(t *testing.T, view *mockView) (pages, tokens, maxPerPage int) {
+	t.Helper()
+	_ = view.ForEach(func(_ [32]byte, data []byte) bool {
+		page, err := state.ParseNFTokenPage(data)
+		if err != nil {
+			t.Fatalf("ParseNFTokenPage: %v", err)
+		}
+		pages++
+		tokens += len(page.NFTokens)
+		if len(page.NFTokens) > maxPerPage {
+			maxPerPage = len(page.NFTokens)
+		}
+		return true
+	})
+	return
+}
+
+// TestNFTokenPageKeylets verifies the unhashed page-key layout
+// [owner_20 | low_96_bits]:
+//   - min  → [owner | 0x00...]
+//   - max  → [owner | 0xFF...]
+//   - token → [owner | tokenID[20:32]]
+//
+// Reference: rippled Indexes.cpp nftpage_min / nftpage_max / nftpage.
+func TestNFTokenPageKeylets(t *testing.T) {
+	owner := mustHexIssuer(t, "0102030405060708090A0B0C0D0E0F1011121314")
+
+	min := keylet.NFTokenPageMin(owner)
+	if !bytes.Equal(min.Key[:20], owner[:]) {
+		t.Errorf("min key prefix = %X, want owner %X", min.Key[:20], owner)
+	}
+	for i := 20; i < 32; i++ {
+		if min.Key[i] != 0x00 {
+			t.Errorf("min key byte %d = %#02x, want 0x00", i, min.Key[i])
+		}
+	}
+
+	max := keylet.NFTokenPageMax(owner)
+	if !bytes.Equal(max.Key[:20], owner[:]) {
+		t.Errorf("max key prefix = %X, want owner %X", max.Key[:20], owner)
+	}
+	for i := 20; i < 32; i++ {
+		if max.Key[i] != 0xFF {
+			t.Errorf("max key byte %d = %#02x, want 0xFF", i, max.Key[i])
+		}
+	}
+
+	tokenID := mustHexID(t, "000B013AB5F762798A53D543A014CAF8B297CFF8F2F937E816E5DA9C00000001")
+	forToken := keylet.NFTokenPageForToken(min, tokenID)
+	if !bytes.Equal(forToken.Key[:20], owner[:]) {
+		t.Errorf("token page key prefix = %X, want owner %X", forToken.Key[:20], owner)
+	}
+	if !bytes.Equal(forToken.Key[20:], tokenID[20:]) {
+		t.Errorf("token page key low 96 = %X, want %X", forToken.Key[20:], tokenID[20:])
+	}
+
+	// All three keylets share the NFTokenPage type.
+	if forToken.Type != min.Type || max.Type != min.Type {
+		t.Errorf("keylet types disagree: min=%v max=%v token=%v", min.Type, max.Type, forToken.Type)
+	}
+}
+
+// TestPageSplitAndMergeThresholds exercises the dirMaxTokensPerPage threshold:
+// a page holds up to 32 tokens; the 33rd forces a split into two pages, and a
+// subsequent removal that brings the combined size back to <= 32 merges them.
+// Reference: rippled NFTokenUtils.cpp getPageForToken / removeToken.
+func TestPageSplitAndMergeThresholds(t *testing.T) {
+	view := newMockView()
+	owner := mustHexIssuer(t, "B5F762798A53D543A014CAF8B297CFF8F2F937E8")
+
+	ids := make([][32]byte, 0, dirMaxTokensPerPage+1)
+
+	// Fill exactly one page. Distinct sequences give distinct low-96 bits, so
+	// the split can always find a page boundary.
+	for i := 0; i < dirMaxTokensPerPage; i++ {
+		id := generateNFTokenID(owner, 0, uint32(i), nftFlagTransferable, 0)
+		ids = append(ids, id)
+		res := insertNFToken(owner, state.NFTokenData{NFTokenID: id}, view, true)
+		if res.Result != tx.TesSUCCESS {
+			t.Fatalf("insert %d: result %v", i, res.Result)
+		}
+	}
+
+	if pages, tokens, _ := pageStats(t, view); pages != 1 || tokens != dirMaxTokensPerPage {
+		t.Fatalf("after filling one page: pages=%d tokens=%d, want 1 page / %d tokens",
+			pages, tokens, dirMaxTokensPerPage)
+	}
+
+	// The 33rd token overflows the page and triggers a split.
+	overflow := generateNFTokenID(owner, 0, uint32(dirMaxTokensPerPage), nftFlagTransferable, 0)
+	ids = append(ids, overflow)
+	res := insertNFToken(owner, state.NFTokenData{NFTokenID: overflow}, view, true)
+	if res.Result != tx.TesSUCCESS {
+		t.Fatalf("overflow insert: result %v", res.Result)
+	}
+	if res.PagesCreated != 1 {
+		t.Errorf("overflow insert PagesCreated = %d, want 1 (split)", res.PagesCreated)
+	}
+
+	pages, tokens, maxPer := pageStats(t, view)
+	if pages != 2 {
+		t.Errorf("after split: pages = %d, want 2", pages)
+	}
+	if tokens != dirMaxTokensPerPage+1 {
+		t.Errorf("after split: tokens = %d, want %d", tokens, dirMaxTokensPerPage+1)
+	}
+	if maxPer > dirMaxTokensPerPage {
+		t.Errorf("after split: a page holds %d tokens, exceeds max %d", maxPer, dirMaxTokensPerPage)
+	}
+
+	// Removing one token returns the total to 32; the two pages (combined size
+	// <= dirMaxTokensPerPage) must merge back into one.
+	result, removed := removeToken(view, owner, ids[0], true)
+	if result != tx.TesSUCCESS {
+		t.Fatalf("removeToken: result %v", result)
+	}
+	if removed != 1 {
+		t.Errorf("removeToken pagesRemoved = %d, want 1 (merge)", removed)
+	}
+
+	pages, tokens, _ = pageStats(t, view)
+	if pages != 1 {
+		t.Errorf("after merge: pages = %d, want 1", pages)
+	}
+	if tokens != dirMaxTokensPerPage {
+		t.Errorf("after merge: tokens = %d, want %d", tokens, dirMaxTokensPerPage)
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/tx/nftoken/` had 14 source files but zero in-package `*_test.go`; the byte-exact NFTokenID composition and unhashed page-key layout were only covered indirectly through `internal/testing/nft/`. This adds white-box unit tests that isolate those helpers.
- `nftoken_id_test.go`: NFTokenID composition/round-trip against a rippled-signed conformance vector (`00000000…16E5DA9C00000001`), the taxon LCG cipher (pinned vectors + involution), field extractors, low-96 page-key math, `compareNFTokenID` sort order, `insertNFTokenSorted`, `uint256Next`, and the `nftTransferFeeXRP` banker's-rounding helper.
- `nftoken_page_test.go`: the `[owner_20 | low_96]` keylet layout, plus page split/merge thresholds (`dirMaxTokensPerPage`) driven through `insertNFToken`/`removeToken` against an in-memory `tx.LedgerView` mock — 32 fills one page, the 33rd splits, and a removal that returns the combined size to ≤32 merges them back.
- Also corrects a stale doc comment on `CipheredTaxon` that described the wrong formula; the code itself already matched rippled `nft.h`.

## Test plan
- [x] `go test ./internal/tx/nftoken/...` (11 new test functions pass)
- [x] `go test ./internal/testing/nft/...` (integration suite still green)
- [x] `go vet ./internal/tx/nftoken/` and `gofmt` clean

Fixes #626