### PR TITLE
test(storage): add memorydb, pebble, and postgres backend tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,6 +54,12 @@ test-pkg pkg:
 test-docker:
     PEERTLS_DOCKER_INTEROP=1 go test -tags docker -timeout 300s -v -run TestHandshake_Interop_RippledDocker ./internal/peermanagement/peertls/
 
+# PostgreSQL backend integration tests. Needs a reachable server; the DSN
+# points at a throwaway database (its tables are truncated between tests).
+# e.g. XRPLD_TEST_POSTGRES_DSN='postgres://xrpl:xrpl@localhost:5432/xrpl_test?sslmode=disable' just test-postgres
+test-postgres:
+    go test -tags postgres -v ./storage/relationaldb/postgres/
+
 # Run go vet on the module. The stdmethods analyzer is disabled because
 # it false-positives on gomock-generated recorder types: a recorder
 # method must be named after the mocked interface method (e.g.

--- a/storage/kvstore/kvstoretest/conformance.go
+++ b/storage/kvstore/kvstoretest/conformance.go
@@ -1,0 +1,395 @@
+// Package kvstoretest provides a shared, backend-agnostic conformance suite
+// for the kvstore.KeyValueStore contract. Each concrete backend (memorydb,
+// pebble, ...) runs RunConformance with a factory that returns a fresh,
+// empty store so the same behavioural guarantees are exercised everywhere.
+package kvstoretest
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/storage/kvstore"
+)
+
+// NewStoreFunc returns a fresh, empty store. The factory is responsible for
+// registering its own cleanup (e.g. t.Cleanup(store.Close)).
+type NewStoreFunc func(t *testing.T) kvstore.KeyValueStore
+
+// RunConformance runs the full KeyValueStore conformance suite against the
+// store produced by newStore. A new store is created for every subtest so
+// state never leaks between cases.
+func RunConformance(t *testing.T, newStore NewStoreFunc) {
+	t.Helper()
+
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, store kvstore.KeyValueStore)
+	}{
+		{"PutGet", testPutGet},
+		{"GetMissing", testGetMissing},
+		{"Has", testHas},
+		{"Overwrite", testOverwrite},
+		{"Delete", testDelete},
+		{"DeleteMissing", testDeleteMissing},
+		{"EmptyValue", testEmptyValue},
+		{"ValueIsolation", testValueIsolation},
+		{"Batch", testBatch},
+		{"BatchReset", testBatchReset},
+		{"IteratorFullScan", testIteratorFullScan},
+		{"IteratorPrefix", testIteratorPrefix},
+		{"IteratorStart", testIteratorStart},
+		{"IteratorEmpty", testIteratorEmpty},
+		{"Stat", testStat},
+		{"Compact", testCompact},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fn(t, newStore(t))
+		})
+	}
+
+	// Closed-store behaviour creates and closes its own store, so it is run
+	// separately from the cases above.
+	t.Run("Closed", func(t *testing.T) {
+		testClosed(t, newStore(t))
+	})
+}
+
+func testPutGet(t *testing.T, store kvstore.KeyValueStore) {
+	key, val := []byte("key"), []byte("value")
+	if err := store.Put(key, val); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, val) {
+		t.Fatalf("Get = %q, want %q", got, val)
+	}
+}
+
+func testGetMissing(t *testing.T, store kvstore.KeyValueStore) {
+	if _, err := store.Get([]byte("absent")); !errors.Is(err, kvstore.ErrNotFound) {
+		t.Fatalf("Get(absent) err = %v, want ErrNotFound", err)
+	}
+}
+
+func testHas(t *testing.T, store kvstore.KeyValueStore) {
+	key := []byte("key")
+	has, err := store.Has(key)
+	if err != nil {
+		t.Fatalf("Has(absent): %v", err)
+	}
+	if has {
+		t.Fatal("Has(absent) = true, want false")
+	}
+	if err := store.Put(key, []byte("v")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	has, err = store.Has(key)
+	if err != nil {
+		t.Fatalf("Has(present): %v", err)
+	}
+	if !has {
+		t.Fatal("Has(present) = false, want true")
+	}
+}
+
+func testOverwrite(t *testing.T, store kvstore.KeyValueStore) {
+	key := []byte("key")
+	if err := store.Put(key, []byte("first")); err != nil {
+		t.Fatalf("Put first: %v", err)
+	}
+	if err := store.Put(key, []byte("second")); err != nil {
+		t.Fatalf("Put second: %v", err)
+	}
+	got, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, []byte("second")) {
+		t.Fatalf("Get = %q, want %q", got, "second")
+	}
+}
+
+func testDelete(t *testing.T, store kvstore.KeyValueStore) {
+	key := []byte("key")
+	if err := store.Put(key, []byte("v")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Delete(key); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Get(key); !errors.Is(err, kvstore.ErrNotFound) {
+		t.Fatalf("Get after Delete err = %v, want ErrNotFound", err)
+	}
+	has, err := store.Has(key)
+	if err != nil {
+		t.Fatalf("Has after Delete: %v", err)
+	}
+	if has {
+		t.Fatal("Has after Delete = true, want false")
+	}
+}
+
+func testDeleteMissing(t *testing.T, store kvstore.KeyValueStore) {
+	if err := store.Delete([]byte("absent")); err != nil {
+		t.Fatalf("Delete(absent) = %v, want nil", err)
+	}
+}
+
+func testEmptyValue(t *testing.T, store kvstore.KeyValueStore) {
+	key := []byte("empty")
+	if err := store.Put(key, []byte{}); err != nil {
+		t.Fatalf("Put empty: %v", err)
+	}
+	got, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Get = %q, want empty", got)
+	}
+	has, err := store.Has(key)
+	if err != nil {
+		t.Fatalf("Has: %v", err)
+	}
+	if !has {
+		t.Fatal("Has(empty value) = false, want true")
+	}
+}
+
+// testValueIsolation verifies the documented contract that the store copies
+// keys and values: mutating a caller's buffer after Put, or mutating the slice
+// returned by Get, must never corrupt stored state.
+func testValueIsolation(t *testing.T, store kvstore.KeyValueStore) {
+	key := []byte("key")
+	val := []byte("value")
+	if err := store.Put(key, val); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Mutate caller buffers after Put.
+	key[0] = 'X'
+	val[0] = 'X'
+
+	got, err := store.Get([]byte("key"))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, []byte("value")) {
+		t.Fatalf("stored value mutated by caller buffer: got %q", got)
+	}
+
+	// Mutate the slice returned by Get.
+	got[0] = 'Z'
+	again, err := store.Get([]byte("key"))
+	if err != nil {
+		t.Fatalf("Get again: %v", err)
+	}
+	if !bytes.Equal(again, []byte("value")) {
+		t.Fatalf("stored value mutated by Get result: got %q", again)
+	}
+}
+
+func testBatch(t *testing.T, store kvstore.KeyValueStore) {
+	// Pre-existing key to be deleted by the batch.
+	if err := store.Put([]byte("del"), []byte("old")); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	b := store.NewBatch()
+	if err := b.Put([]byte("a"), []byte("1")); err != nil {
+		t.Fatalf("batch Put a: %v", err)
+	}
+	if err := b.Put([]byte("b"), []byte("22")); err != nil {
+		t.Fatalf("batch Put b: %v", err)
+	}
+	if err := b.Delete([]byte("del")); err != nil {
+		t.Fatalf("batch Delete: %v", err)
+	}
+
+	if got := b.ValueSize(); got != 3 {
+		t.Fatalf("ValueSize = %d, want 3", got)
+	}
+
+	// Nothing is visible until Write.
+	if has, _ := store.Has([]byte("a")); has {
+		t.Fatal("batched key visible before Write")
+	}
+
+	if err := b.Write(); err != nil {
+		t.Fatalf("batch Write: %v", err)
+	}
+
+	got, err := store.Get([]byte("a"))
+	if err != nil || !bytes.Equal(got, []byte("1")) {
+		t.Fatalf("after Write Get(a) = %q, %v; want \"1\"", got, err)
+	}
+	got, err = store.Get([]byte("b"))
+	if err != nil || !bytes.Equal(got, []byte("22")) {
+		t.Fatalf("after Write Get(b) = %q, %v; want \"22\"", got, err)
+	}
+	if has, _ := store.Has([]byte("del")); has {
+		t.Fatal("batched delete not applied after Write")
+	}
+}
+
+func testBatchReset(t *testing.T, store kvstore.KeyValueStore) {
+	b := store.NewBatch()
+	if err := b.Put([]byte("a"), []byte("1")); err != nil {
+		t.Fatalf("batch Put: %v", err)
+	}
+	b.Reset()
+	if got := b.ValueSize(); got != 0 {
+		t.Fatalf("ValueSize after Reset = %d, want 0", got)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write after Reset: %v", err)
+	}
+	if has, _ := store.Has([]byte("a")); has {
+		t.Fatal("Reset did not discard accumulated writes")
+	}
+}
+
+func testIteratorFullScan(t *testing.T, store kvstore.KeyValueStore) {
+	// Insert out of order; iteration must return ascending key order.
+	insert(t, store, map[string]string{"c": "3", "a": "1", "b": "2"})
+
+	it := store.NewIterator(nil, nil)
+	defer it.Release()
+
+	var keys, vals []string
+	for it.Next() {
+		keys = append(keys, string(it.Key()))
+		vals = append(vals, string(it.Value()))
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if want := []string{"a", "b", "c"}; !equalStrings(keys, want) {
+		t.Fatalf("keys = %v, want %v", keys, want)
+	}
+	if want := []string{"1", "2", "3"}; !equalStrings(vals, want) {
+		t.Fatalf("vals = %v, want %v", vals, want)
+	}
+}
+
+func testIteratorPrefix(t *testing.T, store kvstore.KeyValueStore) {
+	insert(t, store, map[string]string{
+		"a:1": "x", "a:2": "y", "b:1": "z", "c": "w",
+	})
+
+	it := store.NewIterator([]byte("a:"), nil)
+	defer it.Release()
+
+	var keys []string
+	for it.Next() {
+		keys = append(keys, string(it.Key()))
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if want := []string{"a:1", "a:2"}; !equalStrings(keys, want) {
+		t.Fatalf("prefix scan keys = %v, want %v", keys, want)
+	}
+}
+
+func testIteratorStart(t *testing.T, store kvstore.KeyValueStore) {
+	insert(t, store, map[string]string{
+		"p1": "1", "p2": "2", "p3": "3", "p4": "4", "p5": "5",
+	})
+
+	// start is relative to the prefix: prefix "p" + start "3" => seek "p3".
+	it := store.NewIterator([]byte("p"), []byte("3"))
+	defer it.Release()
+
+	var keys []string
+	for it.Next() {
+		keys = append(keys, string(it.Key()))
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if want := []string{"p3", "p4", "p5"}; !equalStrings(keys, want) {
+		t.Fatalf("start scan keys = %v, want %v", keys, want)
+	}
+}
+
+func testIteratorEmpty(t *testing.T, store kvstore.KeyValueStore) {
+	it := store.NewIterator(nil, nil)
+	defer it.Release()
+	if it.Next() {
+		t.Fatalf("Next on empty store = true, want false (key %q)", it.Key())
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+}
+
+func testStat(t *testing.T, store kvstore.KeyValueStore) {
+	s, err := store.Stat()
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if s == "" {
+		t.Fatal("Stat returned empty string")
+	}
+}
+
+func testCompact(t *testing.T, store kvstore.KeyValueStore) {
+	insert(t, store, map[string]string{"a": "1", "b": "2"})
+	if err := store.Compact([]byte{0x00}, []byte{0xff}); err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	// Data must survive compaction.
+	got, err := store.Get([]byte("a"))
+	if err != nil || !bytes.Equal(got, []byte("1")) {
+		t.Fatalf("after Compact Get(a) = %q, %v; want \"1\"", got, err)
+	}
+}
+
+func testClosed(t *testing.T, store kvstore.KeyValueStore) {
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := store.Get([]byte("k")); !errors.Is(err, kvstore.ErrClosed) {
+		t.Fatalf("Get on closed err = %v, want ErrClosed", err)
+	}
+	if err := store.Put([]byte("k"), []byte("v")); !errors.Is(err, kvstore.ErrClosed) {
+		t.Fatalf("Put on closed err = %v, want ErrClosed", err)
+	}
+	if err := store.Delete([]byte("k")); !errors.Is(err, kvstore.ErrClosed) {
+		t.Fatalf("Delete on closed err = %v, want ErrClosed", err)
+	}
+	if _, err := store.Has([]byte("k")); !errors.Is(err, kvstore.ErrClosed) {
+		t.Fatalf("Has on closed err = %v, want ErrClosed", err)
+	}
+	if _, err := store.Stat(); !errors.Is(err, kvstore.ErrClosed) {
+		t.Fatalf("Stat on closed err = %v, want ErrClosed", err)
+	}
+}
+
+func insert(t *testing.T, store kvstore.KeyValueStore, kv map[string]string) {
+	t.Helper()
+	for k, v := range kv {
+		if err := store.Put([]byte(k), []byte(v)); err != nil {
+			t.Fatalf("Put(%q): %v", k, err)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/storage/kvstore/memorydb/memorydb_test.go
+++ b/storage/kvstore/memorydb/memorydb_test.go
@@ -1,0 +1,47 @@
+package memorydb_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/storage/kvstore"
+	"github.com/LeJamon/goXRPLd/storage/kvstore/kvstoretest"
+	"github.com/LeJamon/goXRPLd/storage/kvstore/memorydb"
+)
+
+func TestMemDatabaseConformance(t *testing.T) {
+	kvstoretest.RunConformance(t, func(t *testing.T) kvstore.KeyValueStore {
+		store := memorydb.New()
+		t.Cleanup(func() { _ = store.Close() })
+		return store
+	})
+}
+
+func TestMemDatabaseLen(t *testing.T) {
+	db := memorydb.New()
+	defer db.Close()
+
+	if db.Len() != 0 {
+		t.Fatalf("empty Len = %d, want 0", db.Len())
+	}
+	for _, k := range []string{"a", "b", "c"} {
+		if err := db.Put([]byte(k), []byte("v")); err != nil {
+			t.Fatalf("Put(%q): %v", k, err)
+		}
+	}
+	if db.Len() != 3 {
+		t.Fatalf("Len = %d, want 3", db.Len())
+	}
+	// Overwriting an existing key must not grow the store.
+	if err := db.Put([]byte("a"), []byte("v2")); err != nil {
+		t.Fatalf("Put overwrite: %v", err)
+	}
+	if db.Len() != 3 {
+		t.Fatalf("Len after overwrite = %d, want 3", db.Len())
+	}
+	if err := db.Delete([]byte("a")); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if db.Len() != 2 {
+		t.Fatalf("Len after delete = %d, want 2", db.Len())
+	}
+}

--- a/storage/kvstore/pebble/pebble.go
+++ b/storage/kvstore/pebble/pebble.go
@@ -148,7 +148,11 @@ func (s *Store) NewIterator(prefix []byte, start []byte) kvstore.Iterator {
 	var seekKey []byte
 	if len(start) > 0 {
 		if len(prefix) > 0 {
-			seekKey = append(prefix, start...)
+			// Concatenate into a fresh slice; appending onto the caller's
+			// prefix could clobber its backing array.
+			seekKey = make([]byte, 0, len(prefix)+len(start))
+			seekKey = append(seekKey, prefix...)
+			seekKey = append(seekKey, start...)
 		} else {
 			seekKey = start
 		}
@@ -162,7 +166,9 @@ func (s *Store) NewIterator(prefix []byte, start []byte) kvstore.Iterator {
 		iter.First()
 	}
 
-	return &iterator{iter: iter, started: seekKey != nil}
+	// started stays false: the iterator is now positioned on its first
+	// element, so the first Next() must report it without advancing.
+	return &iterator{iter: iter}
 }
 
 // prefixUpperBound returns the upper bound for the given prefix (exclusive).

--- a/storage/kvstore/pebble/pebble_test.go
+++ b/storage/kvstore/pebble/pebble_test.go
@@ -1,0 +1,52 @@
+package pebble_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/storage/kvstore"
+	"github.com/LeJamon/goXRPLd/storage/kvstore/kvstoretest"
+	"github.com/LeJamon/goXRPLd/storage/kvstore/pebble"
+)
+
+func TestStoreConformance(t *testing.T) {
+	kvstoretest.RunConformance(t, func(t *testing.T) kvstore.KeyValueStore {
+		store, err := pebble.New(t.TempDir(), 0, 0, false)
+		if err != nil {
+			t.Fatalf("open pebble: %v", err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		return store
+	})
+}
+
+// TestStorePersistence verifies the production backend actually persists data
+// to disk across a close/reopen cycle.
+func TestStorePersistence(t *testing.T) {
+	dir := t.TempDir()
+
+	store, err := pebble.New(dir, 0, 0, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := store.Put([]byte("durable"), []byte("value")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := pebble.New(dir, 0, 0, false)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+
+	got, err := reopened.Get([]byte("durable"))
+	if err != nil {
+		t.Fatalf("Get after reopen: %v", err)
+	}
+	if !bytes.Equal(got, []byte("value")) {
+		t.Fatalf("Get after reopen = %q, want %q", got, "value")
+	}
+}

--- a/storage/relationaldb/postgres/postgres_test.go
+++ b/storage/relationaldb/postgres/postgres_test.go
@@ -1,0 +1,619 @@
+//go:build postgres
+
+// These tests exercise the PostgreSQL backend against a real server and are
+// gated behind the `postgres` build tag plus the XRPLD_TEST_POSTGRES_DSN
+// environment variable, mirroring how the SQLite suite is structured (SQLite
+// is embedded and needs no gating). Run with:
+//
+//	XRPLD_TEST_POSTGRES_DSN='postgres://user:pass@localhost:5432/xrpl_test?sslmode=disable' \
+//	    go test -tags postgres ./storage/relationaldb/postgres/
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/storage/relationaldb"
+)
+
+// Compile-time interface checks.
+var (
+	_ relationaldb.RepositoryManager            = (*RepositoryManager)(nil)
+	_ relationaldb.LedgerRepository             = (*LedgerRepository)(nil)
+	_ relationaldb.TransactionRepository        = (*TransactionRepository)(nil)
+	_ relationaldb.AccountTransactionRepository = (*AccountTransactionRepository)(nil)
+	_ relationaldb.SystemRepository             = (*SystemRepository)(nil)
+	_ relationaldb.ValidationRepository         = (*ValidationRepository)(nil)
+	_ relationaldb.AmendmentVoteRepository      = (*AmendmentVoteRepository)(nil)
+	_ relationaldb.TransactionContext           = (*TransactionContext)(nil)
+)
+
+const postgresDSNEnv = "XRPLD_TEST_POSTGRES_DSN"
+
+func setupTestDB(t *testing.T) *RepositoryManager {
+	t.Helper()
+	dsn := os.Getenv(postgresDSNEnv)
+	if dsn == "" {
+		t.Skipf("%s not set; skipping PostgreSQL integration tests", postgresDSNEnv)
+	}
+
+	cfg := relationaldb.PostgresConfig().WithConnectionString(dsn)
+	rm, err := NewRepositoryManager(cfg)
+	if err != nil {
+		t.Fatalf("new repository manager: %v", err)
+	}
+	if err := rm.Open(context.Background()); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	truncateAll(t, rm)
+	t.Cleanup(func() {
+		truncateAll(t, rm)
+		_ = rm.Close(context.Background())
+	})
+	return rm
+}
+
+// truncateAll clears every table so each test starts from a clean slate even
+// though the suite shares one database.
+func truncateAll(t *testing.T, rm *RepositoryManager) {
+	t.Helper()
+	_, err := rm.db.ExecContext(context.Background(),
+		`TRUNCATE ledgers, transactions, account_transactions, validations, feature_votes`)
+	if err != nil {
+		t.Fatalf("truncate tables: %v", err)
+	}
+}
+
+func makeLedgerInfo(seq uint32) *relationaldb.LedgerInfo {
+	var hash, parentHash, accountHash, txHash relationaldb.Hash
+	hash[0] = byte(seq)
+	parentHash[0] = byte(seq - 1)
+	accountHash[1] = byte(seq)
+	txHash[2] = byte(seq)
+	return &relationaldb.LedgerInfo{
+		Hash:            hash,
+		Sequence:        relationaldb.LedgerIndex(seq),
+		ParentHash:      parentHash,
+		AccountHash:     accountHash,
+		TransactionHash: txHash,
+		TotalCoins:      100000000000,
+		CloseTime:       time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		ParentCloseTime: time.Date(2024, 12, 31, 23, 59, 56, 0, time.UTC),
+		CloseTimeRes:    10,
+		CloseFlags:      0,
+	}
+}
+
+func TestPostgresOpenClosePing(t *testing.T) {
+	rm := setupTestDB(t)
+	if err := rm.System().Ping(context.Background()); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+}
+
+func TestPostgresLedgerCRUD(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	// Empty state.
+	minSeq, err := rm.Ledger().GetMinLedgerSeq(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if minSeq != nil {
+		t.Fatal("expected nil min seq on empty DB")
+	}
+
+	info := makeLedgerInfo(10)
+	if err := rm.Ledger().SaveValidatedLedger(ctx, info, true); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := rm.Ledger().GetLedgerInfoBySeq(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Sequence != 10 {
+		t.Fatalf("expected seq 10, got %d", got.Sequence)
+	}
+	if got.TotalCoins != 100000000000 {
+		t.Fatalf("expected total_coins 100000000000, got %d", got.TotalCoins)
+	}
+	if got.Hash != info.Hash {
+		t.Fatal("hash mismatch")
+	}
+
+	got2, err := rm.Ledger().GetLedgerInfoByHash(ctx, info.Hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got2.Sequence != 10 {
+		t.Fatalf("expected seq 10 from hash lookup, got %d", got2.Sequence)
+	}
+
+	newest, err := rm.Ledger().GetNewestLedgerInfo(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newest.Sequence != 10 {
+		t.Fatalf("expected newest seq 10, got %d", newest.Sequence)
+	}
+
+	stats, err := rm.Ledger().GetLedgerCountMinMax(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Count != 1 {
+		t.Fatalf("expected count 1, got %d", stats.Count)
+	}
+
+	// Upsert.
+	info.TotalCoins = 200000000000
+	if err := rm.Ledger().SaveValidatedLedger(ctx, info, true); err != nil {
+		t.Fatal(err)
+	}
+	got3, err := rm.Ledger().GetLedgerInfoBySeq(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got3.TotalCoins != 200000000000 {
+		t.Fatalf("expected upserted total_coins 200000000000, got %d", got3.TotalCoins)
+	}
+}
+
+func TestPostgresLedgerHashQueries(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	for i := uint32(1); i <= 5; i++ {
+		if err := rm.Ledger().SaveValidatedLedger(ctx, makeLedgerInfo(i), false); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	hash, err := rm.Ledger().GetHashByIndex(ctx, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash[0] != 3 {
+		t.Fatalf("expected hash[0]=3, got %d", hash[0])
+	}
+
+	pair, err := rm.Ledger().GetHashesByIndex(ctx, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pair.LedgerHash[0] != 3 || pair.ParentHash[0] != 2 {
+		t.Fatal("unexpected hash pair")
+	}
+
+	rangeResult, err := rm.Ledger().GetHashesByRange(ctx, 2, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rangeResult) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(rangeResult))
+	}
+}
+
+func TestPostgresLedgerDelete(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	for i := uint32(1); i <= 5; i++ {
+		if err := rm.Ledger().SaveValidatedLedger(ctx, makeLedgerInfo(i), false); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := rm.Ledger().DeleteLedgersBySeq(ctx, 3); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := rm.Ledger().GetLedgerCountMinMax(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Count != 2 {
+		t.Fatalf("expected 2 remaining, got %d", stats.Count)
+	}
+}
+
+func TestPostgresTransactionCRUD(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	txInfo := &relationaldb.TransactionInfo{
+		LedgerSeq: 10,
+		Status:    "validated",
+		RawTxn:    []byte("raw-data"),
+		TxnMeta:   []byte("meta-data"),
+	}
+	txInfo.Hash[0] = 0xAB
+
+	if err := rm.Transaction().SaveTransaction(ctx, txInfo); err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := rm.Transaction().GetTransactionCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected count 1, got %d", count)
+	}
+
+	got, searchResult, err := rm.Transaction().GetTransaction(ctx, txInfo.Hash, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if searchResult != relationaldb.TxSearchAll {
+		t.Fatalf("expected TxSearchAll, got %d", searchResult)
+	}
+	if got.LedgerSeq != 10 {
+		t.Fatalf("expected ledger_seq 10, got %d", got.LedgerSeq)
+	}
+	if string(got.RawTxn) != "raw-data" {
+		t.Fatal("raw_txn mismatch")
+	}
+	if string(got.TxnMeta) != "meta-data" {
+		t.Fatal("txn_meta mismatch")
+	}
+
+	var missingHash relationaldb.Hash
+	missingHash[0] = 0xFF
+	_, sr, err := rm.Transaction().GetTransaction(ctx, missingHash, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sr != relationaldb.TxSearchUnknown {
+		t.Fatalf("expected TxSearchUnknown, got %d", sr)
+	}
+}
+
+func TestPostgresTransactionHistory(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	for i := uint32(1); i <= 5; i++ {
+		tx := &relationaldb.TransactionInfo{
+			LedgerSeq: relationaldb.LedgerIndex(i),
+			Status:    "validated",
+			RawTxn:    []byte("data"),
+		}
+		tx.Hash[0] = byte(i)
+		if err := rm.Transaction().SaveTransaction(ctx, tx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	history, err := rm.Transaction().GetTxHistory(ctx, 0, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(history))
+	}
+	// Descending order.
+	if history[0].LedgerSeq != 5 || history[2].LedgerSeq != 3 {
+		t.Fatal("unexpected order")
+	}
+}
+
+func TestPostgresAccountTransactionCRUD(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	var accountID relationaldb.AccountID
+	accountID[0] = 0x01
+
+	txInfo := &relationaldb.TransactionInfo{
+		LedgerSeq: 10,
+		TxnSeq:    1,
+		Status:    "validated",
+		RawTxn:    []byte("raw"),
+	}
+	txInfo.Hash[0] = 0xAA
+
+	if err := rm.Transaction().SaveTransaction(ctx, txInfo); err != nil {
+		t.Fatal(err)
+	}
+	if err := rm.AccountTransaction().SaveAccountTransaction(ctx, accountID, txInfo); err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := rm.AccountTransaction().GetAccountTransactionCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1, got %d", count)
+	}
+
+	results, err := rm.AccountTransaction().GetOldestAccountTxs(ctx, relationaldb.AccountTxOptions{
+		Account: accountID,
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].LedgerSeq != 10 {
+		t.Fatalf("expected ledger_seq 10, got %d", results[0].LedgerSeq)
+	}
+}
+
+func TestPostgresAccountTransactionPagination(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	var accountID relationaldb.AccountID
+	accountID[0] = 0x01
+
+	for i := uint32(1); i <= 5; i++ {
+		tx := &relationaldb.TransactionInfo{
+			LedgerSeq: relationaldb.LedgerIndex(i),
+			TxnSeq:    i,
+			Status:    "validated",
+			RawTxn:    []byte("raw"),
+		}
+		tx.Hash[0] = byte(i)
+		if err := rm.Transaction().SaveTransaction(ctx, tx); err != nil {
+			t.Fatal(err)
+		}
+		if err := rm.AccountTransaction().SaveAccountTransaction(ctx, accountID, tx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page1, err := rm.AccountTransaction().GetOldestAccountTxsPage(ctx, relationaldb.AccountTxPageOptions{
+		Account: accountID,
+		Limit:   2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page1.Transactions) != 2 {
+		t.Fatalf("expected 2 txs, got %d", len(page1.Transactions))
+	}
+	if page1.Marker == nil {
+		t.Fatal("expected marker for more results")
+	}
+
+	page2, err := rm.AccountTransaction().GetOldestAccountTxsPage(ctx, relationaldb.AccountTxPageOptions{
+		Account: accountID,
+		Limit:   2,
+		Marker:  page1.Marker,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2.Transactions) != 2 {
+		t.Fatalf("expected 2 txs, got %d", len(page2.Transactions))
+	}
+
+	page3, err := rm.AccountTransaction().GetOldestAccountTxsPage(ctx, relationaldb.AccountTxPageOptions{
+		Account: accountID,
+		Limit:   2,
+		Marker:  page2.Marker,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page3.Transactions) != 1 {
+		t.Fatalf("expected 1 tx, got %d", len(page3.Transactions))
+	}
+	if page3.Marker != nil {
+		t.Fatal("expected no marker on last page")
+	}
+}
+
+func TestPostgresWithTransaction(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	// Commit path.
+	err := rm.WithTransaction(ctx, func(tc relationaldb.TransactionContext) error {
+		tx := &relationaldb.TransactionInfo{
+			LedgerSeq: 1,
+			Status:    "validated",
+			RawTxn:    []byte("data"),
+		}
+		tx.Hash[0] = 0x01
+		return tc.Transaction().SaveTransaction(ctx, tx)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, _ := rm.Transaction().GetTransactionCount(ctx)
+	if count != 1 {
+		t.Fatalf("expected 1 after commit, got %d", count)
+	}
+
+	// Rollback path.
+	err = rm.WithTransaction(ctx, func(tc relationaldb.TransactionContext) error {
+		tx := &relationaldb.TransactionInfo{
+			LedgerSeq: 2,
+			Status:    "validated",
+			RawTxn:    []byte("data"),
+		}
+		tx.Hash[0] = 0x02
+		if err := tc.Transaction().SaveTransaction(ctx, tx); err != nil {
+			return err
+		}
+		return context.Canceled // force rollback
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	count, _ = rm.Transaction().GetTransactionCount(ctx)
+	if count != 1 {
+		t.Fatalf("expected 1 after rollback, got %d", count)
+	}
+}
+
+func mkValidationRecord(ledgerSeq uint32, nodeByte byte) *relationaldb.ValidationRecord {
+	rec := &relationaldb.ValidationRecord{
+		LedgerSeq:  relationaldb.LedgerIndex(ledgerSeq),
+		InitialSeq: relationaldb.LedgerIndex(ledgerSeq - 1),
+		NodePubKey: make([]byte, 33),
+		SignTime:   time.Unix(1700000000, 0).UTC(),
+		SeenTime:   time.Unix(1700000005, 0).UTC(),
+		Flags:      0x80000001,
+		Raw:        []byte{0xDE, 0xAD, 0xBE, 0xEF, byte(ledgerSeq), nodeByte},
+	}
+	rec.LedgerHash[0] = byte(ledgerSeq)
+	rec.LedgerHash[31] = nodeByte
+	rec.NodePubKey[0] = 0x02
+	rec.NodePubKey[32] = nodeByte
+	return rec
+}
+
+func recordsEqual(a, b *relationaldb.ValidationRecord) bool {
+	if a.LedgerSeq != b.LedgerSeq || a.InitialSeq != b.InitialSeq || a.Flags != b.Flags {
+		return false
+	}
+	if a.LedgerHash != b.LedgerHash {
+		return false
+	}
+	if !a.SignTime.Equal(b.SignTime) || !a.SeenTime.Equal(b.SeenTime) {
+		return false
+	}
+	return byteEq(a.NodePubKey, b.NodePubKey) && byteEq(a.Raw, b.Raw)
+}
+
+func byteEq(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPostgresValidationRoundTrip(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+	repo := rm.Validation()
+
+	orig := mkValidationRecord(100, 0x01)
+	if err := repo.Save(ctx, orig); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.GetValidationsForLedger(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(got))
+	}
+	if !recordsEqual(orig, got[0]) {
+		t.Fatalf("roundtrip mismatch:\n got  %+v\n want %+v", got[0], orig)
+	}
+
+	// Duplicate save is a no-op.
+	if err := repo.Save(ctx, orig); err != nil {
+		t.Fatalf("duplicate save errored: %v", err)
+	}
+	count, err := repo.GetValidationCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 row after duplicate save, got %d", count)
+	}
+}
+
+func TestPostgresValidationBatchAndSweep(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+	repo := rm.Validation()
+
+	// Distinct validators so all rows land.
+	for seq := uint32(1); seq <= 20; seq++ {
+		if err := repo.Save(ctx, mkValidationRecord(seq, byte(seq))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	n, err := repo.DeleteOlderThanSeq(ctx, 15, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 5 {
+		t.Fatalf("expected 5 deletions, got %d", n)
+	}
+
+	count, err := repo.GetValidationCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 15 {
+		t.Fatalf("expected 15 rows remaining, got %d", count)
+	}
+}
+
+func TestPostgresAmendmentVoteRoundTrip(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+	repo := rm.Amendment()
+
+	got, err := repo.LoadAmendmentVotes(ctx)
+	if err != nil {
+		t.Fatalf("load empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no votes, got %d", len(got))
+	}
+
+	if err := repo.SaveAmendmentVote(ctx, &relationaldb.AmendmentVoteRecord{Amendment: "AA", Name: "Alpha", Vetoed: false}); err != nil {
+		t.Fatalf("save upvote: %v", err)
+	}
+	if err := repo.SaveAmendmentVote(ctx, &relationaldb.AmendmentVoteRecord{Amendment: "BB", Name: "Beta", Vetoed: true}); err != nil {
+		t.Fatalf("save veto: %v", err)
+	}
+
+	got, err = repo.LoadAmendmentVotes(ctx)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 votes, got %d", len(got))
+	}
+	byID := map[string]*relationaldb.AmendmentVoteRecord{}
+	for _, r := range got {
+		byID[r.Amendment] = r
+	}
+	if byID["AA"].Vetoed || byID["AA"].Name != "Alpha" {
+		t.Fatalf("AA roundtrip wrong: %+v", byID["AA"])
+	}
+	if !byID["BB"].Vetoed {
+		t.Fatalf("BB should be vetoed: %+v", byID["BB"])
+	}
+
+	// Upsert must not duplicate.
+	if err := repo.SaveAmendmentVote(ctx, &relationaldb.AmendmentVoteRecord{Amendment: "AA", Name: "Alpha", Vetoed: true}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, _ = repo.LoadAmendmentVotes(ctx)
+	if len(got) != 2 {
+		t.Fatalf("upsert must not duplicate; got %d rows", len(got))
+	}
+
+	// Delete.
+	if err := repo.DeleteAmendmentVote(ctx, "BB"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	got, _ = repo.LoadAmendmentVotes(ctx)
+	if len(got) != 1 || got[0].Amendment != "AA" {
+		t.Fatalf("after delete expected only AA, got %+v", got)
+	}
+}

--- a/storage/relationaldb/postgres/repository_manager.go
+++ b/storage/relationaldb/postgres/repository_manager.go
@@ -181,7 +181,7 @@ func (rm *RepositoryManager) initSchema(ctx context.Context) error {
 		// AccountTransactions table - matches rippled's AccountTransactions table
 		`CREATE TABLE IF NOT EXISTS account_transactions (
 			trans_id BYTEA NOT NULL,
-			account VARCHAR(34) NOT NULL,
+			account VARCHAR(40) NOT NULL,
 			ledger_seq BIGINT NOT NULL,
 			txn_seq INTEGER NOT NULL,
 			created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),


### PR DESCRIPTION
## Summary
- Adds a shared, table-driven **conformance suite** (`storage/kvstore/kvstoretest`) for the `KeyValueStore` contract and runs it against both **memorydb** and **pebble**: put/get/delete, overwrite, missing-key, empty value, value isolation, batch atomicity & reset, full/prefix/range iteration, stat, compact, and closed-store behaviour.
- Adds a **PostgreSQL** integration suite (`storage/relationaldb/postgres/postgres_test.go`) gated behind the `postgres` build tag + `XRPLD_TEST_POSTGRES_DSN`, mirroring how the embedded sqlite tests are structured (ledger/transaction/account-tx CRUD & pagination, `WithTransaction` commit/rollback, validations, amendment votes). Adds a `just test-postgres` recipe.
- Fixes **two real backend bugs** the suite surfaced (both in the storage subsystem):
  - **pebble iterator dropped the first matching key on every prefix/range scan.** The `started` flag was set to `true` whenever `SeekGE` positioned the cursor, so the first `Next()` advanced past the positioned element. Now `started` stays `false` so `Next()` reports it. Also build the seek key in a fresh slice instead of `append(prefix, …)`, which could clobber the caller's backing array. (memorydb was already correct — the conformance suite caught the divergence.)
  - **postgres `account_transactions.account` was `VARCHAR(34)`**, too small for the 40-char hex `AccountID.String()` the repository writes — every `SaveAccountTransaction` errored `value too long for type character varying(34)`. Widened to `VARCHAR(40)`, matching sqlite's unbounded `TEXT`. Verified: the 40-char value is rejected by `VARCHAR(34)` and accepted by `VARCHAR(40)`.

The pebble iterator bug was latent in production (nodestore wraps the KV store for hash→blob get/put only and never calls `NewIterator`), but it is exactly the "iteration bounds" corruption the issue warns an untested backend could hide.

## Test plan
- [x] `just test-libs` / `go test ./storage/...` — memorydb, pebble, nodestore, sqlite all green
- [x] `go vet ./storage/...` and `golangci-lint run` (incl. `--build-tags postgres`) — 0 issues
- [x] postgres suite run against a live PostgreSQL 16 — all 12 tests pass:
      `XRPLD_TEST_POSTGRES_DSN='postgres://…' just test-postgres`
- [x] postgres suite compiles under `-tags postgres` and skips cleanly when the DSN is unset

Fixes #624