### PR TITLE
test: cover ledger header byte-format and manager range merge

### DIFF
--- a/internal/ledger/header/header_test.go
+++ b/internal/ledger/header/header_test.go
@@ -58,7 +58,6 @@ func TestAddRawByteExact(t *testing.T) {
 		CloseFlags:          0,
 	}
 
-	// Construct the expected slice explicitly.
 	var want []byte
 	want = binary.BigEndian.AppendUint32(want, 0x01020304)
 	want = binary.BigEndian.AppendUint64(want, 0x1122334455667788)

--- a/internal/ledger/header/header_test.go
+++ b/internal/ledger/header/header_test.go
@@ -1,0 +1,337 @@
+package header
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/protocol"
+)
+
+// xrplTime builds a time.Time that is an exact whole-second XRPL-epoch value, so
+// AddRaw -> DeserializeHeader round-trips losslessly. Serialization truncates to
+// 1-second granularity relative to the Ripple epoch.
+func xrplTime(epochSecs int64) time.Time {
+	return time.Unix(protocol.RippleEpochUnix+epochSecs, 0).UTC()
+}
+
+func fill(b *[32]byte, v byte) {
+	for i := range b {
+		b[i] = v
+	}
+}
+
+func TestSizeConstants(t *testing.T) {
+	// These encode the rippled wire contract (Ledger.cpp addRaw). A regression
+	// here means an instant fork against the network.
+	if SizeBase != 118 {
+		t.Errorf("SizeBase = %d, want 118", SizeBase)
+	}
+	if SizeWithHash != 150 {
+		t.Errorf("SizeWithHash = %d, want 150", SizeWithHash)
+	}
+}
+
+// TestAddRawByteExact builds the expected wire bytes by hand at known offsets and
+// asserts AddRaw matches them byte-for-byte. This guards the exact rippled layout:
+// seq(u32) drops(u64) parentHash(32) txHash(32) accountHash(32)
+// parentCloseTime(u32) closeTime(u32) closeTimeResolution(u8) closeFlags(u8).
+func TestAddRawByteExact(t *testing.T) {
+	var parentHash, txHash, accountHash [32]byte
+	fill(&parentHash, 0xAA)
+	fill(&txHash, 0xBB)
+	fill(&accountHash, 0xCC)
+
+	const parentCloseEpoch = 0x00111111
+	const closeEpoch = 0x00222222
+
+	h := LedgerHeader{
+		LedgerIndex:         0x01020304,
+		Drops:               0x1122334455667788,
+		ParentHash:          parentHash,
+		TxHash:              txHash,
+		AccountHash:         accountHash,
+		ParentCloseTime:     xrplTime(parentCloseEpoch),
+		CloseTime:           xrplTime(closeEpoch),
+		CloseTimeResolution: 10,
+		CloseFlags:          0,
+	}
+
+	// Construct the expected slice explicitly.
+	var want []byte
+	want = binary.BigEndian.AppendUint32(want, 0x01020304)
+	want = binary.BigEndian.AppendUint64(want, 0x1122334455667788)
+	want = append(want, parentHash[:]...)
+	want = append(want, txHash[:]...)
+	want = append(want, accountHash[:]...)
+	want = binary.BigEndian.AppendUint32(want, parentCloseEpoch)
+	want = binary.BigEndian.AppendUint32(want, closeEpoch)
+	want = append(want, 10) // CloseTimeResolution (uint8)
+	want = append(want, 0)  // CloseFlags (uint8)
+
+	if len(want) != SizeBase {
+		t.Fatalf("hand-built expected slice len = %d, want %d", len(want), SizeBase)
+	}
+
+	got := AddRaw(h, false)
+	if len(got) != SizeBase {
+		t.Fatalf("AddRaw len = %d, want %d", len(got), SizeBase)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("AddRaw bytes mismatch\n got = % X\nwant = % X", got, want)
+	}
+
+	// Verify specific offsets explicitly (defends ordering + big-endian).
+	if !bytes.Equal(got[0:4], []byte{0x01, 0x02, 0x03, 0x04}) {
+		t.Errorf("seq bytes = % X, want 01 02 03 04", got[0:4])
+	}
+	if !bytes.Equal(got[4:12], []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}) {
+		t.Errorf("drops bytes = % X, want 11 22 33 44 55 66 77 88", got[4:12])
+	}
+	if !bytes.Equal(got[12:44], parentHash[:]) {
+		t.Errorf("parentHash bytes = % X", got[12:44])
+	}
+	if !bytes.Equal(got[44:76], txHash[:]) {
+		t.Errorf("txHash bytes = % X", got[44:76])
+	}
+	if !bytes.Equal(got[76:108], accountHash[:]) {
+		t.Errorf("accountHash bytes = % X", got[76:108])
+	}
+	if got := binary.BigEndian.Uint32(got[108:112]); got != parentCloseEpoch {
+		t.Errorf("parentCloseTime = %#x, want %#x", got, parentCloseEpoch)
+	}
+	if got := binary.BigEndian.Uint32(got[112:116]); got != closeEpoch {
+		t.Errorf("closeTime = %#x, want %#x", got, closeEpoch)
+	}
+	if got[116] != 10 {
+		t.Errorf("closeTimeResolution = %d, want 10", got[116])
+	}
+	if got[117] != 0 {
+		t.Errorf("closeFlags = %d, want 0", got[117])
+	}
+}
+
+func TestAddRawWithHash(t *testing.T) {
+	var hash [32]byte
+	fill(&hash, 0xDD)
+
+	h := LedgerHeader{
+		LedgerIndex:         42,
+		Drops:               1000,
+		ParentCloseTime:     xrplTime(100),
+		CloseTime:           xrplTime(200),
+		CloseTimeResolution: 30,
+		CloseFlags:          0,
+		Hash:                hash,
+	}
+
+	base := AddRaw(h, false)
+	if len(base) != SizeBase {
+		t.Fatalf("AddRaw(includeHash=false) len = %d, want %d", len(base), SizeBase)
+	}
+
+	withHash := AddRaw(h, true)
+	if len(withHash) != SizeWithHash {
+		t.Fatalf("AddRaw(includeHash=true) len = %d, want %d", len(withHash), SizeWithHash)
+	}
+
+	// The first SizeBase bytes must be identical to the no-hash form.
+	if !bytes.Equal(withHash[:SizeBase], base) {
+		t.Errorf("withHash prefix != base form")
+	}
+
+	// The trailing 32 bytes must equal the Hash field.
+	if !bytes.Equal(withHash[SizeBase:], hash[:]) {
+		t.Errorf("trailing hash bytes = % X, want % X", withHash[SizeBase:], hash[:])
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	var parentHash, txHash, accountHash, hash [32]byte
+	fill(&parentHash, 0x01)
+	fill(&txHash, 0x02)
+	fill(&accountHash, 0x03)
+	fill(&hash, 0x04)
+
+	orig := LedgerHeader{
+		LedgerIndex:         123456,
+		Drops:               9876543210,
+		ParentHash:          parentHash,
+		TxHash:              txHash,
+		AccountHash:         accountHash,
+		ParentCloseTime:     xrplTime(555),
+		CloseTime:           xrplTime(666),
+		CloseTimeResolution: 10,
+		CloseFlags:          0,
+		Hash:                hash,
+	}
+
+	t.Run("no hash", func(t *testing.T) {
+		data := AddRaw(orig, false)
+		got, err := DeserializeHeader(data, false)
+		if err != nil {
+			t.Fatalf("DeserializeHeader error: %v", err)
+		}
+		assertHeaderFieldsEqual(t, got, orig, false)
+	})
+
+	t.Run("with hash", func(t *testing.T) {
+		data := AddRaw(orig, true)
+		got, err := DeserializeHeader(data, true)
+		if err != nil {
+			t.Fatalf("DeserializeHeader error: %v", err)
+		}
+		assertHeaderFieldsEqual(t, got, orig, true)
+	})
+}
+
+// assertHeaderFieldsEqual checks the fields that survive serialization. Validated
+// and Accepted are not serialized; Hash is only present when checkHash is true.
+func assertHeaderFieldsEqual(t *testing.T, got *LedgerHeader, want LedgerHeader, checkHash bool) {
+	t.Helper()
+	if got.LedgerIndex != want.LedgerIndex {
+		t.Errorf("LedgerIndex = %d, want %d", got.LedgerIndex, want.LedgerIndex)
+	}
+	if got.Drops != want.Drops {
+		t.Errorf("Drops = %d, want %d", got.Drops, want.Drops)
+	}
+	if got.ParentHash != want.ParentHash {
+		t.Errorf("ParentHash = % X, want % X", got.ParentHash, want.ParentHash)
+	}
+	if got.TxHash != want.TxHash {
+		t.Errorf("TxHash = % X, want % X", got.TxHash, want.TxHash)
+	}
+	if got.AccountHash != want.AccountHash {
+		t.Errorf("AccountHash = % X, want % X", got.AccountHash, want.AccountHash)
+	}
+	if !got.ParentCloseTime.Equal(want.ParentCloseTime) {
+		t.Errorf("ParentCloseTime = %v, want %v", got.ParentCloseTime, want.ParentCloseTime)
+	}
+	if !got.CloseTime.Equal(want.CloseTime) {
+		t.Errorf("CloseTime = %v, want %v", got.CloseTime, want.CloseTime)
+	}
+	if got.CloseTimeResolution != want.CloseTimeResolution {
+		t.Errorf("CloseTimeResolution = %d, want %d", got.CloseTimeResolution, want.CloseTimeResolution)
+	}
+	if got.CloseFlags != want.CloseFlags {
+		t.Errorf("CloseFlags = %d, want %d", got.CloseFlags, want.CloseFlags)
+	}
+	if checkHash && got.Hash != want.Hash {
+		t.Errorf("Hash = % X, want % X", got.Hash, want.Hash)
+	}
+}
+
+// TestZeroTimeHandling verifies zero-value close times serialize to 4 zero bytes
+// and deserialize back to the zero time.
+func TestZeroTimeHandling(t *testing.T) {
+	h := LedgerHeader{
+		LedgerIndex:         7,
+		Drops:               1,
+		CloseTimeResolution: 10,
+		// ParentCloseTime and CloseTime left as the zero time.
+	}
+
+	data := AddRaw(h, false)
+
+	// ParentCloseTime occupies bytes [108:112], CloseTime [112:116].
+	if !bytes.Equal(data[108:112], []byte{0, 0, 0, 0}) {
+		t.Errorf("zero ParentCloseTime serialized to % X, want 00 00 00 00", data[108:112])
+	}
+	if !bytes.Equal(data[112:116], []byte{0, 0, 0, 0}) {
+		t.Errorf("zero CloseTime serialized to % X, want 00 00 00 00", data[112:116])
+	}
+
+	got, err := DeserializeHeader(data, false)
+	if err != nil {
+		t.Fatalf("DeserializeHeader error: %v", err)
+	}
+	if !got.ParentCloseTime.IsZero() {
+		t.Errorf("ParentCloseTime = %v, want zero", got.ParentCloseTime)
+	}
+	if !got.CloseTime.IsZero() {
+		t.Errorf("CloseTime = %v, want zero", got.CloseTime)
+	}
+}
+
+func TestDeserializePrefixedHeader(t *testing.T) {
+	var hash [32]byte
+	fill(&hash, 0x55)
+
+	orig := LedgerHeader{
+		LedgerIndex:         99,
+		Drops:               42,
+		ParentCloseTime:     xrplTime(10),
+		CloseTime:           xrplTime(20),
+		CloseTimeResolution: 30,
+		Hash:                hash,
+	}
+
+	t.Run("matches unprefixed decode", func(t *testing.T) {
+		raw := AddRaw(orig, true)
+		prefix := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+		prefixed := append(append([]byte{}, prefix...), raw...)
+
+		fromPrefixed, err := DeserializePrefixedHeader(prefixed, true)
+		if err != nil {
+			t.Fatalf("DeserializePrefixedHeader error: %v", err)
+		}
+		fromPlain, err := DeserializeHeader(raw, true)
+		if err != nil {
+			t.Fatalf("DeserializeHeader error: %v", err)
+		}
+		assertHeaderFieldsEqual(t, fromPrefixed, *fromPlain, true)
+	})
+
+	t.Run("too short returns error", func(t *testing.T) {
+		_, err := DeserializePrefixedHeader([]byte{0x01, 0x02, 0x03}, false)
+		if err == nil {
+			t.Fatalf("expected error for <4 byte prefixed data, got nil")
+		}
+	})
+}
+
+func TestDeserializeHeaderErrors(t *testing.T) {
+	full := AddRaw(LedgerHeader{LedgerIndex: 1, CloseTimeResolution: 10}, true)
+
+	t.Run("shorter than SizeBase", func(t *testing.T) {
+		_, err := DeserializeHeader(full[:SizeBase-1], false)
+		if err == nil {
+			t.Fatalf("expected error for data shorter than SizeBase, got nil")
+		}
+	})
+
+	t.Run("hasHash but only SizeBase bytes", func(t *testing.T) {
+		_, err := DeserializeHeader(full[:SizeBase], true)
+		if err == nil {
+			t.Fatalf("expected error for hasHash=true with only SizeBase bytes, got nil")
+		}
+	})
+
+	t.Run("exactly SizeBase decodes without hash", func(t *testing.T) {
+		if _, err := DeserializeHeader(full[:SizeBase], false); err != nil {
+			t.Fatalf("unexpected error decoding exactly SizeBase bytes: %v", err)
+		}
+	})
+}
+
+func TestGetCloseAgree(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags uint8
+		want  bool
+	}{
+		{"consensus on close time", 0, true},
+		{"no consensus time", LCFNoConsensusTime, false},
+		{"other flags set but not LCFNoConsensusTime", 0x02, true},
+		{"LCFNoConsensusTime among other flags", LCFNoConsensusTime | 0x02, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := LedgerHeader{CloseFlags: tt.flags}
+			if got := h.GetCloseAgree(); got != tt.want {
+				t.Errorf("GetCloseAgree() = %v, want %v (flags=%#x)", got, tt.want, tt.flags)
+			}
+		})
+	}
+}

--- a/internal/ledger/manager/cache_test.go
+++ b/internal/ledger/manager/cache_test.go
@@ -1,0 +1,249 @@
+package manager
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/drops"
+	"github.com/LeJamon/goXRPLd/internal/ledger"
+	"github.com/LeJamon/goXRPLd/internal/ledger/header"
+)
+
+// makeLedger builds a *ledger.Ledger whose Sequence() and Hash() are controllable.
+// NewFromHeader copies the header verbatim; Sequence() reads header.LedgerIndex
+// and Hash() reads header.Hash. The state/tx SHAMaps are unused by the cache, so
+// nil is fine.
+func makeLedger(seq uint32, hashByte byte) *ledger.Ledger {
+	var hash [32]byte
+	for i := range hash {
+		hash[i] = hashByte
+	}
+	// Encode the seq into the tail so distinct seqs always yield distinct hashes.
+	hash[28] = byte(seq >> 24)
+	hash[29] = byte(seq >> 16)
+	hash[30] = byte(seq >> 8)
+	hash[31] = byte(seq)
+	hdr := header.LedgerHeader{LedgerIndex: seq, Hash: hash}
+	return ledger.NewFromHeader(hdr, nil, nil, drops.Fees{})
+}
+
+func newCache(t *testing.T, maxRecent int) *LedgerCache {
+	t.Helper()
+	c, err := NewLedgerCache(LedgerCacheConfig{MaxRecentLedgers: maxRecent})
+	if err != nil {
+		t.Fatalf("NewLedgerCache error: %v", err)
+	}
+	return c
+}
+
+func TestPutGet(t *testing.T) {
+	c := newCache(t, 16)
+	l := makeLedger(5, 0xAB)
+	c.Put(l)
+
+	got, ok := c.Get(5)
+	if !ok {
+		t.Fatalf("Get(5) miss after Put")
+	}
+	if got != l {
+		t.Errorf("Get(5) returned a different ledger pointer")
+	}
+
+	gotByHash, ok := c.GetByHash(l.Hash())
+	if !ok {
+		t.Fatalf("GetByHash miss after Put")
+	}
+	if gotByHash != l {
+		t.Errorf("GetByHash returned a different ledger pointer")
+	}
+}
+
+func TestGetMissAndStats(t *testing.T) {
+	c := newCache(t, 16)
+	l := makeLedger(1, 0x11)
+	c.Put(l)
+
+	// Two hits (Get + GetByHash).
+	if _, ok := c.Get(1); !ok {
+		t.Fatalf("expected hit on Get(1)")
+	}
+	if _, ok := c.GetByHash(l.Hash()); !ok {
+		t.Fatalf("expected hit on GetByHash")
+	}
+
+	// Three misses.
+	if _, ok := c.Get(999); ok {
+		t.Fatalf("expected miss on Get(999)")
+	}
+	var absent [32]byte
+	absent[0] = 0xFF
+	if _, ok := c.GetByHash(absent); ok {
+		t.Fatalf("expected miss on GetByHash(absent)")
+	}
+	if _, ok := c.Get(1000); ok {
+		t.Fatalf("expected miss on Get(1000)")
+	}
+
+	stats := c.Stats()
+	if stats.Hits != 2 {
+		t.Errorf("Stats.Hits = %d, want 2", stats.Hits)
+	}
+	if stats.Misses != 3 {
+		t.Errorf("Stats.Misses = %d, want 3", stats.Misses)
+	}
+	wantRate := 2.0 / 5.0
+	if stats.HitRate != wantRate {
+		t.Errorf("Stats.HitRate = %v, want %v", stats.HitRate, wantRate)
+	}
+	if stats.SeqCacheLen != 1 {
+		t.Errorf("Stats.SeqCacheLen = %d, want 1", stats.SeqCacheLen)
+	}
+	if stats.HashCacheLen != 1 {
+		t.Errorf("Stats.HashCacheLen = %d, want 1", stats.HashCacheLen)
+	}
+}
+
+func TestStatsHitRateZeroWhenNoOps(t *testing.T) {
+	c := newCache(t, 16)
+	stats := c.Stats()
+	if stats.HitRate != 0 {
+		t.Errorf("Stats.HitRate = %v, want 0 with no ops", stats.HitRate)
+	}
+}
+
+func TestRemoveEvictsBothCaches(t *testing.T) {
+	c := newCache(t, 16)
+	l := makeLedger(3, 0x33)
+	c.Put(l)
+
+	c.Remove(3)
+
+	if _, ok := c.Get(3); ok {
+		t.Errorf("Get(3) hit after Remove")
+	}
+	if _, ok := c.GetByHash(l.Hash()); ok {
+		t.Errorf("GetByHash hit after Remove — hash cache not evicted")
+	}
+
+	stats := c.Stats()
+	if stats.SeqCacheLen != 0 {
+		t.Errorf("SeqCacheLen = %d, want 0 after Remove", stats.SeqCacheLen)
+	}
+	if stats.HashCacheLen != 0 {
+		t.Errorf("HashCacheLen = %d, want 0 after Remove", stats.HashCacheLen)
+	}
+}
+
+func TestRemoveAbsentIsNoOp(t *testing.T) {
+	c := newCache(t, 16)
+	c.Put(makeLedger(1, 0x01))
+	c.Remove(999) // absent — must not panic or evict the present entry
+	if _, ok := c.Get(1); !ok {
+		t.Errorf("Get(1) miss after Remove(999) — unrelated entry evicted")
+	}
+}
+
+func TestLRUEviction(t *testing.T) {
+	const maxRecent = 3
+	c := newCache(t, maxRecent)
+
+	l1 := makeLedger(1, 0x01)
+	l2 := makeLedger(2, 0x02)
+	l3 := makeLedger(3, 0x03)
+	l4 := makeLedger(4, 0x04)
+
+	c.Put(l1)
+	c.Put(l2)
+	c.Put(l3)
+	// Inserting the 4th distinct ledger evicts the least-recently-used (seq 1).
+	c.Put(l4)
+
+	if stats := c.Stats(); stats.SeqCacheLen != maxRecent {
+		t.Errorf("SeqCacheLen = %d, want %d", stats.SeqCacheLen, maxRecent)
+	}
+	if _, ok := c.Get(1); ok {
+		t.Errorf("Get(1) hit — LRU entry should have been evicted")
+	}
+	for _, seq := range []uint32{2, 3, 4} {
+		if _, ok := c.Get(seq); !ok {
+			t.Errorf("Get(%d) miss — should still be cached", seq)
+		}
+	}
+}
+
+func TestClearPreservesCompleteness(t *testing.T) {
+	c := newCache(t, 16)
+	c.Put(makeLedger(1, 0x01))
+	c.Put(makeLedger(2, 0x02))
+	c.MarkComplete(1)
+
+	c.Clear()
+
+	if stats := c.Stats(); stats.SeqCacheLen != 0 || stats.HashCacheLen != 0 {
+		t.Errorf("after Clear, caches not empty: seq=%d hash=%d", stats.SeqCacheLen, stats.HashCacheLen)
+	}
+	if !c.IsComplete(1) {
+		t.Errorf("IsComplete(1) = false after Clear — completeness must be preserved")
+	}
+}
+
+func TestCompletenessDelegation(t *testing.T) {
+	c := newCache(t, 16)
+
+	c.MarkComplete(5)
+	if !c.IsComplete(5) {
+		t.Errorf("IsComplete(5) = false after MarkComplete(5)")
+	}
+	if c.IsComplete(6) {
+		t.Errorf("IsComplete(6) = true, want false")
+	}
+
+	c.MarkCompleteRange(10, 15)
+	for seq := uint32(10); seq <= 15; seq++ {
+		if !c.IsComplete(seq) {
+			t.Errorf("IsComplete(%d) = false after MarkCompleteRange(10,15)", seq)
+		}
+	}
+
+	min, max, hasAny := c.GetCompleteRange()
+	if !hasAny || min != 5 || max != 15 {
+		t.Errorf("GetCompleteRange() = (%d, %d, %v), want (5, 15, true)", min, max, hasAny)
+	}
+
+	missing := c.FindMissingInRange(5, 15)
+	want := []uint32{6, 7, 8, 9}
+	if !reflect.DeepEqual(missing, want) {
+		t.Errorf("FindMissingInRange(5,15) = %v, want %v", missing, want)
+	}
+}
+
+func TestClearCompleteness(t *testing.T) {
+	c := newCache(t, 16)
+	c.MarkCompleteRange(1, 10)
+	if !c.IsComplete(5) {
+		t.Fatalf("setup: IsComplete(5) should be true")
+	}
+
+	c.ClearCompleteness()
+
+	if c.IsComplete(5) {
+		t.Errorf("IsComplete(5) = true after ClearCompleteness")
+	}
+	if _, _, hasAny := c.GetCompleteRange(); hasAny {
+		t.Errorf("GetCompleteRange() reports hasAny=true after ClearCompleteness")
+	}
+}
+
+func TestNewLedgerCacheDefaultsMaxRecent(t *testing.T) {
+	// MaxRecentLedgers <= 0 must default to 256 and still work.
+	for _, n := range []int{0, -1} {
+		c, err := NewLedgerCache(LedgerCacheConfig{MaxRecentLedgers: n})
+		if err != nil {
+			t.Fatalf("NewLedgerCache(MaxRecentLedgers=%d) error: %v", n, err)
+		}
+		c.Put(makeLedger(1, 0x01))
+		if _, ok := c.Get(1); !ok {
+			t.Errorf("cache with default capacity (from n=%d) failed to store a ledger", n)
+		}
+	}
+}

--- a/internal/ledger/manager/completeness_test.go
+++ b/internal/ledger/manager/completeness_test.go
@@ -1,0 +1,377 @@
+package manager
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLedgerRangeContains(t *testing.T) {
+	r := LedgerRange{Start: 5, End: 10}
+	tests := []struct {
+		seq  uint32
+		want bool
+	}{
+		{4, false},  // below
+		{5, true},   // at start boundary
+		{7, true},   // inside
+		{10, true},  // at end boundary
+		{11, false}, // above
+		{0, false},
+	}
+	for _, tt := range tests {
+		if got := r.Contains(tt.seq); got != tt.want {
+			t.Errorf("LedgerRange{5,10}.Contains(%d) = %v, want %v", tt.seq, got, tt.want)
+		}
+	}
+}
+
+func TestLedgerRangeLength(t *testing.T) {
+	tests := []struct {
+		r    LedgerRange
+		want uint32
+	}{
+		{LedgerRange{Start: 5, End: 5}, 1},
+		{LedgerRange{Start: 5, End: 10}, 6},
+		{LedgerRange{Start: 1, End: 100}, 100},
+	}
+	for _, tt := range tests {
+		if got := tt.r.Length(); got != tt.want {
+			t.Errorf("%v.Length() = %d, want %d", tt.r, got, tt.want)
+		}
+	}
+}
+
+func TestLedgerRangeString(t *testing.T) {
+	tests := []struct {
+		r    LedgerRange
+		want string
+	}{
+		{LedgerRange{Start: 5, End: 5}, "5"},
+		{LedgerRange{Start: 5, End: 10}, "5-10"},
+	}
+	for _, tt := range tests {
+		if got := tt.r.String(); got != tt.want {
+			t.Errorf("%v.String() = %q, want %q", tt.r, got, tt.want)
+		}
+	}
+}
+
+// TestAddRangeMerging exercises the range merge engine exhaustively. After each
+// scenario it asserts both the canonical String() (sorted, comma-joined) and the
+// total Count().
+func TestAddRangeMerging(t *testing.T) {
+	type op struct{ start, end uint32 }
+	tests := []struct {
+		name      string
+		ops       []op
+		wantStr   string
+		wantCount uint32
+	}{
+		{
+			name:      "single range",
+			ops:       []op{{1, 5}},
+			wantStr:   "1-5",
+			wantCount: 5,
+		},
+		{
+			name:      "disjoint ranges stay separate",
+			ops:       []op{{1, 5}, {10, 15}},
+			wantStr:   "1-5,10-15",
+			wantCount: 11,
+		},
+		{
+			name:      "overlapping ranges merge",
+			ops:       []op{{1, 5}, {3, 8}},
+			wantStr:   "1-8",
+			wantCount: 8,
+		},
+		{
+			name:      "adjacent ranges merge (end+1 == next start)",
+			ops:       []op{{1, 5}, {6, 10}},
+			wantStr:   "1-10",
+			wantCount: 10,
+		},
+		{
+			name:      "adjacent in reverse order merge",
+			ops:       []op{{6, 10}, {1, 5}},
+			wantStr:   "1-10",
+			wantCount: 10,
+		},
+		{
+			name:      "out of order produces sorted minimal set",
+			ops:       []op{{20, 25}, {1, 5}, {10, 15}},
+			wantStr:   "1-5,10-15,20-25",
+			wantCount: 17,
+		},
+		{
+			name:      "new range bridges and swallows multiple ranges",
+			ops:       []op{{1, 5}, {10, 15}, {20, 25}, {3, 22}},
+			wantStr:   "1-25",
+			wantCount: 25,
+		},
+		{
+			name:      "new range bridges via adjacency between two ranges",
+			ops:       []op{{1, 5}, {10, 15}, {6, 9}},
+			wantStr:   "1-15",
+			wantCount: 15,
+		},
+		{
+			name:      "fully contained range is a no-op",
+			ops:       []op{{1, 20}, {5, 10}},
+			wantStr:   "1-20",
+			wantCount: 20,
+		},
+		{
+			name:      "duplicate range is a no-op",
+			ops:       []op{{1, 5}, {1, 5}},
+			wantStr:   "1-5",
+			wantCount: 5,
+		},
+		{
+			name:      "start > end is ignored",
+			ops:       []op{{5, 1}},
+			wantStr:   "empty",
+			wantCount: 0,
+		},
+		{
+			name:      "start > end ignored among valid ranges",
+			ops:       []op{{1, 5}, {10, 8}, {10, 15}},
+			wantStr:   "1-5,10-15",
+			wantCount: 11,
+		},
+		{
+			name:      "extend an existing range on the left",
+			ops:       []op{{5, 10}, {1, 7}},
+			wantStr:   "1-10",
+			wantCount: 10,
+		},
+		{
+			name:      "extend an existing range on the right",
+			ops:       []op{{1, 7}, {5, 10}},
+			wantStr:   "1-10",
+			wantCount: 10,
+		},
+		{
+			name:      "single ledger adds via Add path",
+			ops:       []op{{3, 3}, {4, 4}, {5, 5}},
+			wantStr:   "3-5",
+			wantCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCompleteLedgerSet()
+			for _, o := range tt.ops {
+				c.AddRange(o.start, o.end)
+			}
+			if got := c.String(); got != tt.wantStr {
+				t.Errorf("String() = %q, want %q", got, tt.wantStr)
+			}
+			if got := c.Count(); got != tt.wantCount {
+				t.Errorf("Count() = %d, want %d", got, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestAddSingle(t *testing.T) {
+	c := NewCompleteLedgerSet()
+	c.Add(7)
+	if !c.Contains(7) {
+		t.Errorf("Contains(7) = false after Add(7)")
+	}
+	if got := c.String(); got != "7" {
+		t.Errorf("String() = %q, want %q", got, "7")
+	}
+	if got := c.Count(); got != 1 {
+		t.Errorf("Count() = %d, want 1", got)
+	}
+}
+
+func TestContains(t *testing.T) {
+	c := NewCompleteLedgerSet()
+	c.AddRange(1, 5)
+	c.AddRange(10, 15)
+	c.AddRange(20, 20)
+
+	tests := []struct {
+		seq  uint32
+		want bool
+	}{
+		{1, true}, {5, true}, // boundaries of first range
+		{6, false}, {9, false}, // gap
+		{10, true}, {12, true}, {15, true}, // second range
+		{16, false}, {19, false}, // gap
+		{20, true},  // single-ledger range
+		{21, false}, // just outside last range
+		{0, false},
+	}
+	for _, tt := range tests {
+		if got := c.Contains(tt.seq); got != tt.want {
+			t.Errorf("Contains(%d) = %v, want %v", tt.seq, got, tt.want)
+		}
+	}
+}
+
+func TestRange(t *testing.T) {
+	t.Run("empty set", func(t *testing.T) {
+		c := NewCompleteLedgerSet()
+		min, max, hasAny := c.Range()
+		if hasAny || min != 0 || max != 0 {
+			t.Errorf("Range() = (%d, %d, %v), want (0, 0, false)", min, max, hasAny)
+		}
+	})
+
+	t.Run("populated set", func(t *testing.T) {
+		c := NewCompleteLedgerSet()
+		c.AddRange(10, 15)
+		c.AddRange(1, 5)
+		c.AddRange(20, 25)
+		min, max, hasAny := c.Range()
+		if !hasAny || min != 1 || max != 25 {
+			t.Errorf("Range() = (%d, %d, %v), want (1, 25, true)", min, max, hasAny)
+		}
+	})
+}
+
+func TestFindMissing(t *testing.T) {
+	tests := []struct {
+		name       string
+		ranges     [][2]uint32
+		start, end uint32
+		want       []uint32
+	}{
+		{
+			name:   "empty set returns whole range",
+			ranges: nil,
+			start:  1, end: 5,
+			want: []uint32{1, 2, 3, 4, 5},
+		},
+		{
+			name:   "fully covered returns nil",
+			ranges: [][2]uint32{{1, 10}},
+			start:  3, end: 7,
+			want: nil,
+		},
+		{
+			name:   "gap between ranges",
+			ranges: [][2]uint32{{1, 3}, {7, 10}},
+			start:  1, end: 10,
+			want: []uint32{4, 5, 6},
+		},
+		{
+			name:   "partial overlap at both ends",
+			ranges: [][2]uint32{{3, 7}},
+			start:  1, end: 10,
+			want: []uint32{1, 2, 8, 9, 10},
+		},
+		{
+			name:   "missing before first range only",
+			ranges: [][2]uint32{{5, 10}},
+			start:  1, end: 10,
+			want: []uint32{1, 2, 3, 4},
+		},
+		{
+			name:   "missing after last range only",
+			ranges: [][2]uint32{{1, 5}},
+			start:  1, end: 10,
+			want: []uint32{6, 7, 8, 9, 10},
+		},
+		{
+			name:   "multiple gaps",
+			ranges: [][2]uint32{{2, 3}, {6, 7}},
+			start:  1, end: 9,
+			want: []uint32{1, 4, 5, 8, 9},
+		},
+		{
+			name:   "start > end returns nil",
+			ranges: nil,
+			start:  10, end: 1,
+			want: nil,
+		},
+		{
+			name:   "single missing sequence",
+			ranges: [][2]uint32{{1, 4}, {6, 10}},
+			start:  1, end: 10,
+			want: []uint32{5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCompleteLedgerSet()
+			for _, r := range tt.ranges {
+				c.AddRange(r[0], r[1])
+			}
+			got := c.FindMissing(tt.start, tt.end)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindMissing(%d, %d) = %v, want %v", tt.start, tt.end, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindNextMissing(t *testing.T) {
+	t.Run("returns first gap after the given sequence", func(t *testing.T) {
+		c := NewCompleteLedgerSet()
+		c.AddRange(1, 5)
+		c.AddRange(7, 10)
+		next, found := c.FindNextMissing(1)
+		if !found || next != 6 {
+			t.Errorf("FindNextMissing(1) = (%d, %v), want (6, true)", next, found)
+		}
+	})
+
+	t.Run("skips over a complete tail", func(t *testing.T) {
+		c := NewCompleteLedgerSet()
+		c.AddRange(1, 10)
+		// next missing after 5 is 11 (first uncovered after the range)
+		next, found := c.FindNextMissing(5)
+		if !found || next != 11 {
+			t.Errorf("FindNextMissing(5) = (%d, %v), want (11, true)", next, found)
+		}
+	})
+
+	t.Run("false when look-ahead window fully complete", func(t *testing.T) {
+		c := NewCompleteLedgerSet()
+		// FindNextMissing looks ahead after+1 .. after+1000.
+		c.AddRange(1, 2000)
+		next, found := c.FindNextMissing(100)
+		if found {
+			t.Errorf("FindNextMissing(100) = (%d, true), want (_, false)", next)
+		}
+	})
+}
+
+func TestClear(t *testing.T) {
+	c := NewCompleteLedgerSet()
+	c.AddRange(1, 10)
+	c.Clear()
+
+	if got := c.String(); got != "empty" {
+		t.Errorf("String() after Clear = %q, want %q", got, "empty")
+	}
+	if got := c.Count(); got != 0 {
+		t.Errorf("Count() after Clear = %d, want 0", got)
+	}
+	if _, _, hasAny := c.Range(); hasAny {
+		t.Errorf("Range() after Clear reports hasAny=true, want false")
+	}
+
+	// Reusable after Clear.
+	c.AddRange(5, 8)
+	if got := c.String(); got != "5-8" {
+		t.Errorf("String() after reuse = %q, want %q", got, "5-8")
+	}
+	if got := c.Count(); got != 4 {
+		t.Errorf("Count() after reuse = %d, want 4", got)
+	}
+}
+
+func TestStringEmpty(t *testing.T) {
+	c := NewCompleteLedgerSet()
+	if got := c.String(); got != "empty" {
+		t.Errorf("String() on empty set = %q, want %q", got, "empty")
+	}
+}


### PR DESCRIPTION
## Summary
Adds unit tests for two previously-untested ledger packages flagged by the readiness audit (#620). No production code is changed.

- **`internal/ledger/header/header_test.go`** — byte-exact wire format: size constants (`SizeBase`=118, `SizeWithHash`=150), an explicit per-offset expected-byte assertion confirming big-endian field order matches rippled `addRaw` (seq, drops, parentHash, txHash, accountHash, parentCloseTime, closeTime, closeTimeResolution, closeFlags), round-trip identity with/without hash, zero-time handling, `DeserializePrefixedHeader`, and short-buffer error paths. `GetCloseAgree` flag check.
- **`internal/ledger/manager/completeness_test.go`** — exhaustive `CompleteLedgerSet`/`LedgerRange` range-merge: disjoint / overlapping / adjacent / out-of-order / bridge-and-swallow / fully-contained / `start>end` no-op, plus `Contains` (binary search), `Range`, `FindMissing` (exact slices), `FindNextMissing` window behavior, and `Clear` reuse.
- **`internal/ledger/manager/cache_test.go`** — `LedgerCache`: Put/Get by seq and hash, miss/stat accounting, `Remove` evicting both seq and hash caches, LRU eviction, `Clear` preserving completeness, completeness delegation, `ClearCompleteness`, and the `MaxRecentLedgers<=0` default.

`storage.go` is the `LedgerStorage` interface only (no in-package implementer), so it has no dedicated test.

## Test plan
- [x] `go test ./internal/ledger/header/... ./internal/ledger/manager/...` — all pass
- [x] `go vet ./internal/ledger/header/... ./internal/ledger/manager/...` — clean
- [x] `gofmt -l` on the new files — empty

Fixes #628