### PR TITLE
fix: cap TMLedgerData node count at hardMaxReplyNodes

### DIFF
--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -19,11 +19,24 @@ import (
 
 const acquisitionTimeout = 10 * time.Second
 
-// hardMaxReplyNodes is the hard cap on the number of nodes a peer may pack into
-// a single TMLedgerData reply. A reply exceeding it is rejected and the peer is
-// charged badData, mirroring rippled's PeerImp::onMessage(TMLedgerData) guard
-// (PeerImp.cpp:1628) and Tuning::hardMaxReplyNodes (Tuning.h:42).
+// hardMaxReplyNodes is rippled's per-message cap on the nodes a peer may pack
+// into a single TMLedgerData reply (Tuning::hardMaxReplyNodes, Tuning.h:42).
 const hardMaxReplyNodes = 12288
+
+// checkReplyNodeCount enforces the bounds rippled places on a single
+// TMLedgerData reply — at least one node, at most hardMaxReplyNodes — so the
+// router can charge an offending peer badData. Mirrors the ingress guard in
+// rippled's PeerImp::onMessage(TMLedgerData) (PeerImp.cpp:1628), which rejects
+// both nodes_size() <= 0 and nodes_size() > Tuning::hardMaxReplyNodes.
+func checkReplyNodeCount(nodes []message.LedgerNode) error {
+	switch n := len(nodes); {
+	case n <= 0:
+		return fmt.Errorf("ledger data reply has no nodes")
+	case n > hardMaxReplyNodes:
+		return fmt.Errorf("ledger data exceeds hardMaxReplyNodes: %d > %d", n, hardMaxReplyNodes)
+	}
+	return nil
+}
 
 // Reason records why an acquisition was started, mirroring rippled's
 // InboundLedger::Reason. It governs completion handling: a consensus-driven
@@ -148,6 +161,12 @@ func (l *Ledger) GotBase(nodes []message.LedgerNode) error {
 		return nil
 	}
 
+	if len(nodes) > hardMaxReplyNodes {
+		l.state = StateFailed
+		l.err = fmt.Errorf("ledger data exceeds hardMaxReplyNodes: %d > %d", len(nodes), hardMaxReplyNodes)
+		return l.err
+	}
+
 	if len(nodes) < 2 {
 		l.state = StateFailed
 		l.err = fmt.Errorf("need at least 2 nodes (header + state root), got %d", len(nodes))
@@ -264,8 +283,8 @@ func (l *Ledger) GotBase(nodes []message.LedgerNode) error {
 
 // GotStateNodes processes state tree nodes received from the peer.
 func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
-	if len(nodes) > hardMaxReplyNodes {
-		return fmt.Errorf("ledger data exceeds hardMaxReplyNodes: %d > %d", len(nodes), hardMaxReplyNodes)
+	if err := checkReplyNodeCount(nodes); err != nil {
+		return err
 	}
 
 	l.mu.Lock()
@@ -332,8 +351,8 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 // It mirrors GotStateNodes: drive placement by the peer-supplied NodeID, then
 // FinishSync as the authoritative completeness check.
 func (l *Ledger) GotTransactionNodes(nodes []message.LedgerNode) error {
-	if len(nodes) > hardMaxReplyNodes {
-		return fmt.Errorf("ledger data exceeds hardMaxReplyNodes: %d > %d", len(nodes), hardMaxReplyNodes)
+	if err := checkReplyNodeCount(nodes); err != nil {
+		return err
 	}
 
 	l.mu.Lock()

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -19,6 +19,12 @@ import (
 
 const acquisitionTimeout = 10 * time.Second
 
+// hardMaxReplyNodes is the hard cap on the number of nodes a peer may pack into
+// a single TMLedgerData reply. A reply exceeding it is rejected and the peer is
+// charged badData, mirroring rippled's PeerImp::onMessage(TMLedgerData) guard
+// (PeerImp.cpp:1628) and Tuning::hardMaxReplyNodes (Tuning.h:42).
+const hardMaxReplyNodes = 12288
+
 // Reason records why an acquisition was started, mirroring rippled's
 // InboundLedger::Reason. It governs completion handling: a consensus-driven
 // acquisition adopts the ledger into the active chain, while a generic
@@ -258,6 +264,10 @@ func (l *Ledger) GotBase(nodes []message.LedgerNode) error {
 
 // GotStateNodes processes state tree nodes received from the peer.
 func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
+	if len(nodes) > hardMaxReplyNodes {
+		return fmt.Errorf("ledger data exceeds hardMaxReplyNodes: %d > %d", len(nodes), hardMaxReplyNodes)
+	}
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -322,6 +332,10 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 // It mirrors GotStateNodes: drive placement by the peer-supplied NodeID, then
 // FinishSync as the authoritative completeness check.
 func (l *Ledger) GotTransactionNodes(nodes []message.LedgerNode) error {
+	if len(nodes) > hardMaxReplyNodes {
+		return fmt.Errorf("ledger data exceeds hardMaxReplyNodes: %d > %d", len(nodes), hardMaxReplyNodes)
+	}
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/internal/ledger/inbound/inbound_test.go
+++ b/internal/ledger/inbound/inbound_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/goXRPLd/internal/ledger/header"
@@ -144,6 +145,43 @@ func TestGotStateNodes_DeepNodesUnderStubs(t *testing.T) {
 	}
 	if gotHash != rootHash {
 		t.Errorf("reconstructed state hash mismatch: want %x got %x", rootHash[:8], gotHash[:8])
+	}
+}
+
+// Regression for issue #674: GotStateNodes/GotTransactionNodes must reject a
+// peer reply whose node count exceeds hardMaxReplyNodes, mirroring rippled's
+// PeerImp::onMessage(TMLedgerData) guard (PeerImp.cpp:1628, Tuning.h:42). The
+// router translates the returned error into an IncPeerBadData charge.
+func TestGotNodes_RejectOverHardMaxReplyNodes(t *testing.T) {
+	t.Parallel()
+	il := New([32]byte{0x01}, 300, 11, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	over := make([]message.LedgerNode, hardMaxReplyNodes+1)
+	for _, tc := range []struct {
+		name string
+		got  error
+	}{
+		{"GotStateNodes", il.GotStateNodes(over)},
+		{"GotTransactionNodes", il.GotTransactionNodes(over)},
+	} {
+		if tc.got == nil || !strings.Contains(tc.got.Error(), "hardMaxReplyNodes") {
+			t.Errorf("%s(over cap): got %v, want hardMaxReplyNodes rejection", tc.name, tc.got)
+		}
+	}
+
+	// A reply exactly at the cap must pass the count guard (it may still fail
+	// later for unrelated acquisition-state reasons, but not with the cap error).
+	atCap := make([]message.LedgerNode, hardMaxReplyNodes)
+	for _, tc := range []struct {
+		name string
+		got  error
+	}{
+		{"GotStateNodes", il.GotStateNodes(atCap)},
+		{"GotTransactionNodes", il.GotTransactionNodes(atCap)},
+	} {
+		if tc.got != nil && strings.Contains(tc.got.Error(), "hardMaxReplyNodes") {
+			t.Errorf("%s(at cap): unexpectedly rejected by count guard: %v", tc.name, tc.got)
+		}
 	}
 }
 

--- a/internal/ledger/inbound/inbound_test.go
+++ b/internal/ledger/inbound/inbound_test.go
@@ -185,6 +185,41 @@ func TestGotNodes_RejectOverHardMaxReplyNodes(t *testing.T) {
 	}
 }
 
+// Regression for the empty-reply half of rippled's TMLedgerData guard
+// (PeerImp.cpp:1628, nodes_size() <= 0): GotStateNodes/GotTransactionNodes must
+// reject a peer reply carrying no nodes so the router charges badData.
+func TestGotNodes_RejectEmptyReply(t *testing.T) {
+	t.Parallel()
+	il := New([32]byte{0x02}, 300, 11, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	for _, tc := range []struct {
+		name string
+		got  error
+	}{
+		{"GotStateNodes", il.GotStateNodes(nil)},
+		{"GotTransactionNodes", il.GotTransactionNodes(nil)},
+	} {
+		if tc.got == nil || !strings.Contains(tc.got.Error(), "no nodes") {
+			t.Errorf("%s(empty): got %v, want no-nodes rejection", tc.name, tc.got)
+		}
+	}
+}
+
+// GotBase must also enforce rippled's per-message node cap (PeerImp.cpp:1628):
+// the guard runs at message ingress for every ledger info type, base included.
+func TestGotBase_RejectOverHardMaxReplyNodes(t *testing.T) {
+	t.Parallel()
+	il := New([32]byte{0x03}, 300, 11, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	err := il.GotBase(make([]message.LedgerNode, hardMaxReplyNodes+1))
+	if err == nil || !strings.Contains(err.Error(), "hardMaxReplyNodes") {
+		t.Fatalf("GotBase(over cap): got %v, want hardMaxReplyNodes rejection", err)
+	}
+	if il.state != StateFailed {
+		t.Errorf("GotBase(over cap): state = %d, want StateFailed", il.state)
+	}
+}
+
 // Regression for issue #577: the classic acquisition path must recompute the
 // header hash and reject a peer that returns a header whose true hash differs
 // from the requested hash, mirroring rippled's takeHeader (InboundLedger.cpp:830).


### PR DESCRIPTION
## Summary
- `GotStateNodes`/`GotTransactionNodes` iterated the peer-supplied node list with no per-message count cap, processing far more nodes per `TMLedgerData` message than rippled tolerates.
- Add a `len(nodes) > hardMaxReplyNodes` (12288) guard at the start of both functions; on violation they return an error, which the router (`router.go:2424,2440`) already translates into an `IncPeerBadData` charge + dropped message — mirroring rippled's `PeerImp::onMessage(TMLedgerData)` guard (`PeerImp.cpp:1628`, `Tuning.h:42`).

## Test plan
- [x] `go test ./internal/ledger/inbound/` (incl. new `TestGotNodes_RejectOverHardMaxReplyNodes`)
- [x] `go vet ./internal/ledger/inbound/` + `gofmt`
- [x] `go build ./internal/consensus/adaptor/` (router caller)

Fixes #674