### PR TITLE
fix: bound STObject/STArray decode nesting depth

### DIFF
--- a/codec/binarycodec/types/errors.go
+++ b/codec/binarycodec/types/errors.go
@@ -16,4 +16,9 @@ var (
 	// is consumed by STArray, so encountering one inside an object means
 	// malformed nesting at any depth, never a valid terminator.
 	errIllegalArrayEndMarker = errors.New("Illegal end-of-array marker in object")
+	// errMaxNestingDepth mirrors rippled's nesting cap (STVar.cpp:122,
+	// STObject.cpp:89): a STObject/STArray nested past maxNestingDepth is
+	// rejected. Without it a deeply nested blob recurses until the goroutine
+	// stack overflows — a fatal error recover() cannot catch.
+	errMaxNestingDepth = errors.New("Maximum nesting depth exceeded")
 )

--- a/codec/binarycodec/types/nesting_depth_test.go
+++ b/codec/binarycodec/types/nesting_depth_test.go
@@ -1,0 +1,99 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/codec/binarycodec/definitions"
+	"github.com/LeJamon/goXRPLd/codec/binarycodec/serdes"
+	"github.com/stretchr/testify/require"
+)
+
+// Single-byte field headers (type nibble | field nibble) used to hand-build
+// nested blobs: Memo is an STObject field (type 14, field 10) and Memos is an
+// STArray field (type 15, field 9).
+const (
+	memoFieldHeader  = 0xEA
+	memosFieldHeader = 0xF9
+)
+
+// nestedObjectBlob returns the canonical bytes for `depth` Memo STObjects nested
+// one inside the next, the innermost empty: depth open markers followed by depth
+// close markers.
+func nestedObjectBlob(depth int) []byte {
+	b := make([]byte, 0, depth*2)
+	for i := 0; i < depth; i++ {
+		b = append(b, memoFieldHeader)
+	}
+	for i := 0; i < depth; i++ {
+		b = append(b, ObjectEndMarker)
+	}
+	return b
+}
+
+func newParser(b []byte) *serdes.BinaryParser {
+	return serdes.NewBinaryParser(b, definitions.Get())
+}
+
+// TestSTObject_DecodeNestingDepthLimit pins the recursion bound that rippled
+// enforces (STVar.cpp:122, STObject.cpp:89). Decoding must reject an
+// over-nested blob with a clean error instead of recursing into a
+// stack-overflow fatal error, which recover() cannot catch.
+func TestSTObject_DecodeNestingDepthLimit(t *testing.T) {
+	t.Run("max depth decodes", func(t *testing.T) {
+		st := NewSTObject(serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec()))
+		_, err := st.ToJSONStrict(newParser(nestedObjectBlob(maxNestingDepth)))
+		require.NoError(t, err)
+	})
+
+	t.Run("one past max is rejected", func(t *testing.T) {
+		st := NewSTObject(serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec()))
+		_, err := st.ToJSONStrict(newParser(nestedObjectBlob(maxNestingDepth + 1)))
+		require.ErrorIs(t, err, errMaxNestingDepth)
+	})
+
+	// The DoS payload from the report: ~hundreds of KB of bare Memo headers.
+	// With the bound it is rejected after reading a handful of bytes; without
+	// it the decoder recurses until the goroutine stack overflows.
+	t.Run("deep payload is bounded, not crashing", func(t *testing.T) {
+		blob := bytes.Repeat([]byte{memoFieldHeader}, 200_000)
+		st := NewSTObject(serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec()))
+		_, err := st.ToJSONStrict(newParser(blob))
+		require.ErrorIs(t, err, errMaxNestingDepth)
+	})
+}
+
+// TestSTArray_DecodeNestingDepthLimit exercises the matching guard on the array
+// path: an STArray's STObject elements sit one level deeper than the array, so a
+// nested-too-deep element is rejected (STArray.cpp:95, STVar.cpp:122).
+func TestSTArray_DecodeNestingDepthLimit(t *testing.T) {
+	// One empty Memo object inside the array, then both end markers.
+	elementBlob := func() []byte {
+		return []byte{memoFieldHeader, ObjectEndMarker, ArrayEndMarker}
+	}
+
+	t.Run("element at max depth decodes", func(t *testing.T) {
+		// Array at depth 9 → element object at depth 10 (the limit).
+		res, err := (&STArray{}).ToJSON(newParser(elementBlob()), maxNestingDepth-1)
+		require.NoError(t, err)
+		require.Equal(t, []any{map[string]any{"Memo": map[string]any{}}}, res)
+	})
+
+	t.Run("element one past max is rejected", func(t *testing.T) {
+		// Array at depth 10 → element object at depth 11 (over the limit).
+		_, err := (&STArray{}).ToJSON(newParser(elementBlob()), maxNestingDepth)
+		require.ErrorIs(t, err, errMaxNestingDepth)
+	})
+
+	// Alternating Memos arrays and Memo objects through the full decode path
+	// must also stay bounded.
+	t.Run("alternating array/object payload is bounded", func(t *testing.T) {
+		var blob []byte
+		for i := 0; i < 50; i++ {
+			blob = append(blob, memosFieldHeader, memoFieldHeader)
+		}
+		st := NewSTObject(serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec()))
+		_, err := st.ToJSONStrict(newParser(blob))
+		require.ErrorIs(t, err, errMaxNestingDepth)
+	})
+}

--- a/codec/binarycodec/types/st_array.go
+++ b/codec/binarycodec/types/st_array.go
@@ -57,7 +57,14 @@ func (t *STArray) FromJSON(json any) ([]byte, error) {
 // the serialized byte data back to a JSON value.
 // The method loops until the BinaryParser has no more data, and for each loop,
 // it calls the ToJSON method of an STObject, appending the resulting JSON value to a "value" slice.
-func (t *STArray) ToJSON(p interfaces.BinaryParser, _ ...int) (any, error) {
+// When decoded as a nested field, opts[0] carries the array's depth so the nesting cap is
+// enforced on its STObject elements, mirroring rippled (STArray.cpp:95, STVar.cpp:122).
+func (t *STArray) ToJSON(p interfaces.BinaryParser, opts ...int) (any, error) {
+	depth := 0
+	if len(opts) > 0 {
+		depth = opts[0]
+	}
+
 	// Initialize as empty slice (not nil) so empty arrays marshal to [] not null
 	value := make([]any, 0)
 
@@ -77,8 +84,15 @@ func (t *STArray) ToJSON(p interfaces.BinaryParser, _ ...int) (any, error) {
 			return nil, ErrNotSTObjectInSTArray
 		}
 
+		// Elements sit one level deeper than the array; reject past the cap
+		// before recursing into the element (STVar.cpp:122).
+		childDepth := depth + 1
+		if childDepth > maxNestingDepth {
+			return nil, errMaxNestingDepth
+		}
+
 		st := GetSerializedType(fi.Type)
-		res, err := st.ToJSON(p)
+		res, err := st.ToJSON(p, childDepth)
 		if err != nil {
 			return nil, err
 		}

--- a/codec/binarycodec/types/st_object.go
+++ b/codec/binarycodec/types/st_object.go
@@ -11,6 +11,11 @@ import (
 	"github.com/LeJamon/goXRPLd/codec/binarycodec/types/interfaces"
 )
 
+// maxNestingDepth caps how deeply STObject/STArray containers may nest during
+// decoding, mirroring rippled's limit (STVar.cpp:122, STObject.cpp:89). A field
+// constructed at depth > maxNestingDepth is rejected.
+const maxNestingDepth = 10
+
 // STObject represents a map of serialized field instances, where each key is a field name
 // and the associated value is the field's value. This structure allows us to represent nested
 // and complex structures of the Ripple protocol.
@@ -60,9 +65,15 @@ func (t *STObject) FromJSON(json any) ([]byte, error) {
 
 // ToJSON takes a BinaryParser and optional parameters, and converts the serialized byte data
 // back to a JSON value. It continues parsing until it encounters an object end marker or runs
-// out of data; an array end marker inside an object is rejected as malformed nesting.
-func (t *STObject) ToJSON(p interfaces.BinaryParser, _ ...int) (any, error) {
-	m, _, err := t.toJSON(p)
+// out of data; an array end marker inside an object is rejected as malformed nesting. When
+// decoded as a nested field, opts[0] carries the container's depth so the nesting cap is
+// enforced across the whole tree (see toJSON).
+func (t *STObject) ToJSON(p interfaces.BinaryParser, opts ...int) (any, error) {
+	depth := 0
+	if len(opts) > 0 {
+		depth = opts[0]
+	}
+	m, _, err := t.toJSON(p, depth)
 	return m, err
 }
 
@@ -74,7 +85,7 @@ func (t *STObject) ToJSON(p interfaces.BinaryParser, _ ...int) (any, error) {
 // well-formed serialization carries a top-level terminator, so this never rejects
 // valid input. Nested objects consume their own end marker through ToJSON.
 func (t *STObject) ToJSONStrict(p interfaces.BinaryParser) (map[string]any, error) {
-	m, sawEndMarker, err := t.toJSON(p)
+	m, sawEndMarker, err := t.toJSON(p, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -84,11 +95,13 @@ func (t *STObject) ToJSONStrict(p interfaces.BinaryParser) (map[string]any, erro
 	return m, nil
 }
 
-// toJSON parses fields until an object end marker or end of data. It reports
-// whether parsing stopped on an object end marker so the top-level caller can
-// reject one while nested containers treat it as the normal terminator. An array
-// end marker inside an object is malformed (STObject.cpp:259-263) and errors.
-func (t *STObject) toJSON(p interfaces.BinaryParser) (map[string]any, bool, error) {
+// toJSON parses fields until an object end marker or end of data. depth is this
+// object's nesting level (0 at the top); each field it reads sits one level
+// deeper. It reports whether parsing stopped on an object end marker so the
+// top-level caller can reject one while nested containers treat it as the normal
+// terminator. An array end marker inside an object is malformed
+// (STObject.cpp:259-263) and errors.
+func (t *STObject) toJSON(p interfaces.BinaryParser, depth int) (map[string]any, bool, error) {
 	m := make(map[string]any)
 
 	for p.HasMore() {
@@ -102,6 +115,14 @@ func (t *STObject) toJSON(p interfaces.BinaryParser) (map[string]any, bool, erro
 		}
 		if fi.FieldName == "ArrayEndMarker" {
 			return nil, false, errIllegalArrayEndMarker
+		}
+
+		// Each field is constructed one level deeper than its parent. rippled
+		// rejects here, before parsing the field's value, when that level exceeds
+		// the cap (STVar.cpp:122) — the guard that prevents unbounded recursion.
+		childDepth := depth + 1
+		if childDepth > maxNestingDepth {
+			return nil, false, errMaxNestingDepth
 		}
 
 		st := GetSerializedType(fi.Type)
@@ -120,7 +141,15 @@ func (t *STObject) toJSON(p interfaces.BinaryParser) (map[string]any, bool, erro
 				return nil, false, fmt.Errorf("ToJSON error for VL field %q (type=%s, vlen=%d): %w", fi.FieldName, fi.Type, vlen, err)
 			}
 		} else {
-			res, err = st.ToJSON(p)
+			// Only containers (STObject/STArray) recurse, so only they receive
+			// the nesting depth. Leaf types keep their original call: some read
+			// opts[0] as a byte length (Currency, XChainBridge) and would
+			// misinterpret a depth value.
+			var depthOpt []int
+			if fi.Type == "STObject" || fi.Type == "STArray" {
+				depthOpt = []int{childDepth}
+			}
+			res, err = st.ToJSON(p, depthOpt...)
 			if err != nil {
 				return nil, false, fmt.Errorf("ToJSON error for field %q (type=%s): %w", fi.FieldName, fi.Type, err)
 			}


### PR DESCRIPTION
## Summary
- The binary decoder threaded **no nesting-depth limit**: a deeply nested `STObject`/`STArray` blob recursed without bound and crashed the node with `fatal error: stack overflow` — uncatchable by `recover()`, so it bypassed the engine's panic guard. Reachable from peer-supplied tx/meta blobs (`TypeReplayDeltaResponse`, 16 MB cap) and `tx_blob` submits, making it a remote, unauthenticated DoS.
- Thread a `depth` counter through `STObject.toJSON` / `STArray.ToJSON` and reject any container nested past depth 10, mirroring rippled (`STVar.cpp:122`, `STObject.cpp:89`). The cap is checked per field, before the value is parsed, exactly where rippled's `STVar` constructor throws.
- Depth is passed **only** to the recursing container types (`STObject`/`STArray`); leaf types that read `opts[0]` as a byte length (`Currency`, `XChainBridge`) keep their original call and are unaffected.

## Test plan
- [x] `go test ./codec/binarycodec/...` — new `nesting_depth_test.go`: 10-deep decodes, 11-deep returns a clean `errMaxNestingDepth`, a 200 KB bare-header DoS payload is rejected (no crash), and the STArray element guard is covered at the boundary.
- [x] `go test ./internal/testing/oracle/...` — confirms `Currency` decode (which reads `opts[0]` as a length) is unchanged.
- [x] `go test ./internal/testing/amm/... ./internal/testing/nft/... ./internal/tx/batch/...` — STArray/nested-STObject decode paths still pass.

Fixes #672