### PR TITLE
Guard onPeerConnect/onPeerDisconnect callbacks with providersMu

### DIFF
--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -231,7 +231,8 @@ func (o *Overlay) handleHaveTransactionsMessage(evt Event) {
 	// hash would amplify network load for a load-reduction feature.
 	// Drop the announcement silently in that case (the peer that
 	// negotiated tx-reduce-relay isn't malformed).
-	if o.txProvider == nil {
+	txProvider := o.txProviderSnapshot()
+	if txProvider == nil {
 		return
 	}
 
@@ -243,7 +244,7 @@ func (o *Overlay) handleHaveTransactionsMessage(evt Event) {
 		}
 		var hash [32]byte
 		copy(hash[:], h)
-		if _, present := o.txProvider(hash); present {
+		if _, present := txProvider(hash); present {
 			continue
 		}
 		missing = append(missing, message.IndexedObject{
@@ -379,7 +380,8 @@ func (o *Overlay) serveDoTransactions(peerID PeerID, req *message.GetObjectByHas
 		o.IncPeerBadData(peerID, "get-objects-txn-too-big")
 		return
 	}
-	if o.txProvider == nil {
+	txProvider := o.txProviderSnapshot()
+	if txProvider == nil {
 		// Negotiated tx-reduce-relay but no lookup wired — silently
 		// drop. An operator who flipped EnableTxReduceRelay but
 		// hasn't wired SetTxProvider would otherwise spam this log.
@@ -396,7 +398,7 @@ func (o *Overlay) serveDoTransactions(peerID PeerID, req *message.GetObjectByHas
 		}
 		var hash [32]byte
 		copy(hash[:], obj.Hash)
-		blob, ok := o.txProvider(hash)
+		blob, ok := txProvider(hash)
 		if !ok {
 			continue
 		}

--- a/internal/peermanagement/outbound_emit.go
+++ b/internal/peermanagement/outbound_emit.go
@@ -167,11 +167,12 @@ func (o *Overlay) sendTxQueueAnnounce() {
 	if !o.cfg.EnableTxReduceRelay {
 		return
 	}
-	if o.openLedgerHashesProvider == nil {
+	provider := o.openLedgerHashesProviderSnapshot()
+	if provider == nil {
 		return
 	}
 
-	hashes := o.openLedgerHashesProvider()
+	hashes := provider()
 	if len(hashes) == 0 {
 		return
 	}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -133,7 +133,7 @@ type Overlay struct {
 	// router) that need to clean up per-peer state on disconnect. Fired
 	// from the event-loop goroutine AFTER the peer has been removed from
 	// the map, so callees can assume the peer is already gone. nil when
-	// no subscriber is registered.
+	// no subscriber is registered. Guarded by providersMu.
 	onPeerDisconnect func(PeerID)
 
 	// onPeerConnect fires once a peer has finished its handshake and
@@ -142,7 +142,7 @@ type Overlay struct {
 	// (#372 / rippled OverlayImpl::sendEndpoints which emits manifests
 	// alongside endpoints in the post-handshake window). Same blocking
 	// contract as onPeerDisconnect: runs on the event loop, must not
-	// block.
+	// block. Guarded by providersMu.
 	onPeerConnect func(PeerID)
 
 	// txProvider returns the raw tx blob for hash if it is in the
@@ -1069,7 +1069,7 @@ func (o *Overlay) onPeerConnected(evt Event) {
 	// Notify higher layers AFTER discovery state is updated so any work
 	// they do (e.g. sending us-originated frames to the peer) sees a
 	// fully-bookkept overlay. Mirrors the disconnect callback ordering.
-	if cb := o.onPeerConnect; cb != nil {
+	if cb := o.onPeerConnectSnapshot(); cb != nil {
 		cb(evt.PeerID)
 	}
 }
@@ -1087,7 +1087,7 @@ func (o *Overlay) onPeerDisconnected(evt Event) {
 	// Without this the peer's last-reported ledger stays in the
 	// engine's getNetworkLedger vote set indefinitely, biasing
 	// consensus toward the view of a peer that's no longer here.
-	if cb := o.onPeerDisconnect; cb != nil {
+	if cb := o.onPeerDisconnectSnapshot(); cb != nil {
 		cb(evt.PeerID)
 	}
 }
@@ -1101,7 +1101,15 @@ func (o *Overlay) onPeerDisconnected(evt Event) {
 // router) are notified of disconnects so they can clean their own
 // per-peer state. Prefer this over polling Peers().
 func (o *Overlay) SetPeerDisconnectCallback(cb func(PeerID)) {
+	o.providersMu.Lock()
 	o.onPeerDisconnect = cb
+	o.providersMu.Unlock()
+}
+
+func (o *Overlay) onPeerDisconnectSnapshot() func(PeerID) {
+	o.providersMu.RLock()
+	defer o.providersMu.RUnlock()
+	return o.onPeerDisconnect
 }
 
 // SetPeerConnectCallback registers a callback fired after a peer's
@@ -1114,7 +1122,15 @@ func (o *Overlay) SetPeerDisconnectCallback(cb func(PeerID)) {
 // validator-list publishing can resolve our signing key back to the
 // trusted master.
 func (o *Overlay) SetPeerConnectCallback(cb func(PeerID)) {
+	o.providersMu.Lock()
 	o.onPeerConnect = cb
+	o.providersMu.Unlock()
+}
+
+func (o *Overlay) onPeerConnectSnapshot() func(PeerID) {
+	o.providersMu.RLock()
+	defer o.providersMu.RUnlock()
+	return o.onPeerConnect
 }
 
 func (o *Overlay) onPeerFailed(evt Event) {

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -152,7 +152,7 @@ type Overlay struct {
 	// query without importing internal/ledger/service into this
 	// package. nil-safe — the reply path drops without charging when
 	// the provider isn't wired (tests, or operators running the
-	// overlay without a ledger backend).
+	// overlay without a ledger backend). Guarded by providersMu.
 	txProvider func(hash [32]byte) ([]byte, bool)
 
 	// openLedgerHashesProvider returns the set of tx hashes currently
@@ -160,6 +160,7 @@ type Overlay struct {
 	// TMHaveTransactions emission in sendTxQueueAnnounce. nil-safe —
 	// the emitter skips when unwired, matching the rippled gate
 	// `app_.config().TX_REDUCE_RELAY_ENABLE` at OverlayImpl.cpp:107.
+	// Guarded by providersMu.
 	openLedgerHashesProvider func() [][32]byte
 
 	// clusterFeeSink is invoked by handleClusterMessage after the
@@ -2211,7 +2212,15 @@ func (o *Overlay) Cluster() *cluster.Registry { return o.cluster }
 // reply path drops without charging, matching the pre-existing
 // "feature gated off" behaviour.
 func (o *Overlay) SetTxProvider(fn func(hash [32]byte) ([]byte, bool)) {
+	o.providersMu.Lock()
 	o.txProvider = fn
+	o.providersMu.Unlock()
+}
+
+func (o *Overlay) txProviderSnapshot() func(hash [32]byte) ([]byte, bool) {
+	o.providersMu.RLock()
+	defer o.providersMu.RUnlock()
+	return o.txProvider
 }
 
 // SetOpenLedgerHashesProvider installs the tx-hash snapshot reader
@@ -2220,7 +2229,15 @@ func (o *Overlay) SetTxProvider(fn func(hash [32]byte) ([]byte, bool)) {
 // the open-ledger view. The emitter only fires when EnableTxReduceRelay
 // is true AND this provider is wired; nil leaves the gossip dark.
 func (o *Overlay) SetOpenLedgerHashesProvider(fn func() [][32]byte) {
+	o.providersMu.Lock()
 	o.openLedgerHashesProvider = fn
+	o.providersMu.Unlock()
+}
+
+func (o *Overlay) openLedgerHashesProviderSnapshot() func() [][32]byte {
+	o.providersMu.RLock()
+	defer o.providersMu.RUnlock()
+	return o.openLedgerHashesProvider
 }
 
 // SetClusterFeeSink installs the callback invoked from handleClusterMessage

--- a/internal/peermanagement/overlay_callbacks_test.go
+++ b/internal/peermanagement/overlay_callbacks_test.go
@@ -1,0 +1,83 @@
+package peermanagement
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestPeerLifecycleCallbacksConcurrentAccess guards the providersMu
+// discipline added for onPeerConnect/onPeerDisconnect: a higher layer
+// re-wiring the callbacks must not race the event-loop goroutine that
+// reads and fires them. Run with -race to catch a regression.
+func TestPeerLifecycleCallbacksConcurrentAccess(t *testing.T) {
+	o := &Overlay{}
+
+	const iterations = 2000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			o.SetPeerConnectCallback(func(PeerID) {})
+			o.SetPeerDisconnectCallback(func(PeerID) {})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if cb := o.onPeerConnectSnapshot(); cb != nil {
+				cb(PeerID(0))
+			}
+			if cb := o.onPeerDisconnectSnapshot(); cb != nil {
+				cb(PeerID(0))
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestPeerLifecycleCallbacksSetAndClear verifies the setter/snapshot
+// roundtrip: wiring delivers the peer id, and passing nil clears it.
+func TestPeerLifecycleCallbacksSetAndClear(t *testing.T) {
+	o := &Overlay{}
+
+	if cb := o.onPeerConnectSnapshot(); cb != nil {
+		t.Fatal("expected nil connect callback before wiring")
+	}
+	if cb := o.onPeerDisconnectSnapshot(); cb != nil {
+		t.Fatal("expected nil disconnect callback before wiring")
+	}
+
+	var gotConnect, gotDisconnect PeerID
+	o.SetPeerConnectCallback(func(id PeerID) { gotConnect = id })
+	o.SetPeerDisconnectCallback(func(id PeerID) { gotDisconnect = id })
+
+	if cb := o.onPeerConnectSnapshot(); cb != nil {
+		cb(PeerID(7))
+	} else {
+		t.Fatal("expected connect callback after wiring")
+	}
+	if cb := o.onPeerDisconnectSnapshot(); cb != nil {
+		cb(PeerID(9))
+	} else {
+		t.Fatal("expected disconnect callback after wiring")
+	}
+	if gotConnect != 7 {
+		t.Errorf("connect callback got id %d, want 7", gotConnect)
+	}
+	if gotDisconnect != 9 {
+		t.Errorf("disconnect callback got id %d, want 9", gotDisconnect)
+	}
+
+	o.SetPeerConnectCallback(nil)
+	o.SetPeerDisconnectCallback(nil)
+	if cb := o.onPeerConnectSnapshot(); cb != nil {
+		t.Error("expected nil connect callback after clearing")
+	}
+	if cb := o.onPeerDisconnectSnapshot(); cb != nil {
+		t.Error("expected nil disconnect callback after clearing")
+	}
+}

--- a/internal/peermanagement/overlay_callbacks_test.go
+++ b/internal/peermanagement/overlay_callbacks_test.go
@@ -81,3 +81,37 @@ func TestPeerLifecycleCallbacksSetAndClear(t *testing.T) {
 		t.Error("expected nil disconnect callback after clearing")
 	}
 }
+
+// TestProviderSettersConcurrentAccess extends the providersMu discipline to
+// the tx-reduce-relay provider hooks: SetTxProvider/SetOpenLedgerHashesProvider
+// must not race the inbound/outbound goroutines that read them via the
+// snapshot accessors. Run with -race to catch a regression.
+func TestProviderSettersConcurrentAccess(t *testing.T) {
+	o := &Overlay{}
+
+	const iterations = 2000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			o.SetTxProvider(func([32]byte) ([]byte, bool) { return nil, false })
+			o.SetOpenLedgerHashesProvider(func() [][32]byte { return nil })
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if p := o.txProviderSnapshot(); p != nil {
+				p([32]byte{})
+			}
+			if p := o.openLedgerHashesProviderSnapshot(); p != nil {
+				p()
+			}
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- The overlay peer-lifecycle callbacks `onPeerConnect`/`onPeerDisconnect` were assigned by their setters without a lock while the event-loop goroutine read them in `onPeerConnected`/`onPeerDisconnected`. That is an unguarded write/read by contract and turns into a data race if a callback is ever re-wired at runtime.
- Guard both fields with the existing `providersMu`: the setters now lock on write, and the read sites go through `onPeerConnectSnapshot()`/`onPeerDisconnectSnapshot()` RLock getters, mirroring the adjacent provider fields (`ledgerHintProvider`, `validLedgerProvider`, `peerStatusPublisher`).
- The snapshot is taken under the lock and the callback is invoked after the lock is released, so the event-loop's no-block contract is preserved.

## Test plan
- [ ] `go test -race -run TestPeerLifecycleCallbacks ./internal/peermanagement/`
- [ ] `go vet ./internal/peermanagement/`
- [ ] `go test -race ./internal/peermanagement/`

Fixes #675