### PR TITLE
test: stateful fuzzers for the transaction engine (invariant + determinism + differential)

### DIFF
--- a/internal/testing/conformance/fuzz_test.go
+++ b/internal/testing/conformance/fuzz_test.go
@@ -1,0 +1,146 @@
+package conformance
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// diffCorpusRoot resolves the recorded-rippled fixture corpus directory, or ""
+// if it cannot be found. GOXRPL_FIXTURES_DIR overrides the location (useful from
+// a git worktree, where the default relative path does not reach the sibling
+// fixtures tree); otherwise it falls back to the same default TestConformance
+// uses.
+func diffCorpusRoot() string {
+	if dir := os.Getenv("GOXRPL_FIXTURES_DIR"); dir != "" {
+		if abs, err := filepath.Abs(dir); err == nil && isDir(abs) {
+			return abs
+		}
+		return ""
+	}
+	if abs, err := filepath.Abs(fixturesRoot); err == nil && isDir(abs) {
+		return abs
+	}
+	return ""
+}
+
+func isDir(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.IsDir()
+}
+
+// outOfScopeSuites loads the suite paths conformance treats as out of scope
+// (scripts/conformance-out-of-scope.txt), so the differential fuzzer does not
+// flag intentional stubs / known gaps (e.g. Vault, XChain) as divergences.
+func outOfScopeSuites() map[string]bool {
+	set := map[string]bool{}
+	path, err := filepath.Abs("../../../scripts/conformance-out-of-scope.txt")
+	if err != nil {
+		return set
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return set
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		set[strings.ReplaceAll(line, " ", "")] = true
+	}
+	return set
+}
+
+// suiteOf returns the "app/<Suite>" (or "ledger/<Suite>") prefix of a fixture's
+// relative name, matching conformance-summary.sh's suite bucketing.
+func suiteOf(relName string) string {
+	parts := strings.Split(relName, "/")
+	if len(parts) < 2 {
+		return relName
+	}
+	return parts[0] + "/" + parts[1]
+}
+
+// inScopeFixtures returns the relative names and absolute paths of every fixture
+// under root that is in scope (suite not out of scope, and not in skipTests),
+// sorted by name for stable indexing.
+func inScopeFixtures(root string) (names, paths []string) {
+	oos := outOfScopeSuites()
+	relToPath := map[string]string{}
+	var rels []string
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil
+		}
+		name := strings.TrimSuffix(rel, ".json")
+		if oos[suiteOf(name)] || skipTests[name] != "" {
+			return nil
+		}
+		rels = append(rels, name)
+		relToPath[name] = path
+		return nil
+	})
+	sort.Strings(rels)
+	for _, r := range rels {
+		names = append(names, r)
+		paths = append(paths, relToPath[r])
+	}
+	return names, paths
+}
+
+// FuzzEngineDifferential is the differential-vs-rippled property (issue #682,
+// scope 2). It replays recorded rippled fixtures through the goXRPL engine and
+// fails when the per-step transaction result (TER) or recorded post-state does
+// not match rippled's recorded values -- an in-scope divergence is a
+// conformance/fork bug. The byte input selects which in-scope fixture to replay,
+// so coverage feedback steers toward fixtures that exercise new engine paths;
+// the recorded tx bytes are deliberately not mutated, which would change the
+// outcome and lose the rippled oracle.
+//
+// Out-of-scope suites (scripts/conformance-out-of-scope.txt) are excluded so the
+// fuzzer does not re-report intentional stubs. Requires the recorded-rippled
+// fixture corpus (the same `just conformance` uses): set GOXRPL_FIXTURES_DIR to
+// point at it, or run from the main checkout. Skips when the corpus is absent so
+// plain `go test` / CI stay green.
+func FuzzEngineDifferential(f *testing.F) {
+	root := diffCorpusRoot()
+	if root == "" {
+		f.Skip("recorded-rippled fixture corpus not found; set GOXRPL_FIXTURES_DIR")
+	}
+	names, paths := inScopeFixtures(root)
+	if len(names) == 0 {
+		f.Skip("no in-scope fixtures found in corpus")
+	}
+
+	// Seed with one fixture from each of a few suites conformance passes in
+	// full, so plain `go test` exercises the harness without tripping on a
+	// pre-existing in-scope gap. Active fuzzing explores the whole in-scope set.
+	for _, prefix := range []string{"app/Escrow/", "app/Oracle/", "app/Check/", "app/MultiSign/", "app/PayChan/"} {
+		for i, name := range names {
+			if strings.HasPrefix(name, prefix) {
+				f.Add(uint32(i))
+				break
+			}
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, sel uint32) {
+		idx := int(sel % uint32(len(paths)))
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("PANIC replaying %s: %v", names[idx], r)
+			}
+		}()
+		RunFixture(t, paths[idx])
+	})
+}

--- a/internal/testing/enginefuzz/determinism_test.go
+++ b/internal/testing/enginefuzz/determinism_test.go
@@ -1,0 +1,78 @@
+package enginefuzz
+
+import (
+	"fmt"
+	"testing"
+)
+
+// ledgerHashes captures the fork-critical hashes of a closed ledger.
+type ledgerHashes struct {
+	ledger [32]byte // overall ledger hash
+	state  [32]byte // state map hash (account_hash)
+	txs    [32]byte // transaction map hash
+}
+
+// buildAndClose applies the transaction sequence encoded by data to a fresh
+// seeded ledger, closes it once, and returns the closed ledger's hashes. The
+// generator is driven purely by the byte stream against an identically seeded
+// env, so two calls with the same data apply a byte-identical transaction set;
+// only engine nondeterminism can make their outputs differ. All transactions
+// land in a single ledger (no mid-stream closes) to maximise the tie-break
+// opportunities a fork bug would surface on.
+func buildAndClose(t testing.TB, data []byte) ledgerHashes {
+	t.Helper()
+	sc := newScenario(t)
+	s := &stream{data: data}
+	for i := 0; i < maxSteps && !s.drained(); i++ {
+		sc.step(s)
+	}
+	sc.env.Close()
+
+	lcl := sc.env.LastClosedLedger()
+	state, err := lcl.StateMapHash()
+	if err != nil {
+		t.Fatalf("StateMapHash: %v", err)
+	}
+	txs, err := lcl.TxMapHash()
+	if err != nil {
+		t.Fatalf("TxMapHash: %v", err)
+	}
+	return ledgerHashes{ledger: lcl.Hash(), state: state, txs: txs}
+}
+
+// runDeterminism is the determinism/fork property: closing a ledger built from
+// the same transaction set must be reproducible. Two independent runs use fresh
+// envs -- hence independently randomized Go-map iteration orders -- so a state
+// (account_hash) or transaction-metadata ordering that leaks map iteration order
+// into the result will diverge here. A mismatch is a fork bug: the class of
+// non-deterministic map tie-break that yielded issues #612 and #678.
+func runDeterminism(t testing.TB, data []byte) {
+	t.Helper()
+	a := buildAndClose(t, data)
+	b := buildAndClose(t, data)
+	if a != b {
+		t.Fatalf("non-deterministic ledger build:\n run1: ledger=%x state=%x txs=%x\n run2: ledger=%x state=%x txs=%x",
+			a.ledger, a.state, a.txs, b.ledger, b.state, b.txs)
+	}
+}
+
+// FuzzEngineDeterminism explores transaction sets and fails if ledger close+build
+// is not reproducible across two independent runs. See issue #682 (scope 3).
+func FuzzEngineDeterminism(f *testing.F) {
+	for _, seed := range seedCorpus() {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		runDeterminism(t, data)
+	})
+}
+
+// TestEngineDeterminism_SeedCorpus runs the determinism property over the seed
+// corpus deterministically so it is exercised by plain `go test` / CI.
+func TestEngineDeterminism_SeedCorpus(t *testing.T) {
+	for i, seed := range seedCorpus() {
+		t.Run(fmt.Sprintf("seed-%d", i), func(t *testing.T) {
+			runDeterminism(t, seed)
+		})
+	}
+}

--- a/internal/testing/enginefuzz/doc.go
+++ b/internal/testing/enginefuzz/doc.go
@@ -1,0 +1,18 @@
+// Package enginefuzz hosts a stateful, property-based fuzz harness over the
+// goXRPL transaction engine.
+//
+// Every other fuzz target in the repository covers a stateless decode surface
+// (codec, crypto, shamap-wire, peer-frame). This package adds the missing
+// stateful layer: it generates structurally-plausible transaction sequences
+// from the fuzzer's byte stream, applies them through internal/tx/engine
+// against a seeded ledger, and asserts after every apply that the engine never
+// reports an invariant violation (tec/tefINVARIANT_FAILED) and that total XRP
+// is never inflated.
+//
+// The engine runs the full internal/tx/invariants set on every apply -- the
+// same oracle rippled exercises under Antithesis -- so a fuzzer-found invariant
+// violation is, by construction, a consensus-safety bug.
+//
+// The harness and fuzz target live in this package's _test.go files; this file
+// exists only so the package has a non-test compilation unit. See issue #682.
+package enginefuzz

--- a/internal/testing/enginefuzz/fuzz_test.go
+++ b/internal/testing/enginefuzz/fuzz_test.go
@@ -1,0 +1,49 @@
+package enginefuzz
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+// FuzzEngineInvariants applies generated transaction sequences through the
+// engine and fails if any apply reports an invariant violation or inflates
+// total XRP. Run it with, e.g.:
+//
+//	go test -run x -fuzz FuzzEngineInvariants ./internal/testing/enginefuzz/
+//
+// See the package doc and issue #682 for the rationale.
+func FuzzEngineInvariants(f *testing.F) {
+	for _, seed := range seedCorpus() {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		run(t, data)
+	})
+}
+
+// TestEngineInvariants_SeedCorpus runs the seed corpus deterministically so the
+// harness is exercised by plain `go test` / CI without the -fuzz flag.
+func TestEngineInvariants_SeedCorpus(t *testing.T) {
+	for i, seed := range seedCorpus() {
+		t.Run(fmt.Sprintf("seed-%d", i), func(t *testing.T) {
+			run(t, seed)
+		})
+	}
+}
+
+// seedCorpus returns deterministic byte inputs that drive varied transaction
+// sequences. They seed the fuzzer's corpus and back the smoke test above.
+func seedCorpus() [][]byte {
+	ramp := make([]byte, 256)
+	for i := range ramp {
+		ramp[i] = byte(i)
+	}
+	return [][]byte{
+		{},
+		bytes.Repeat([]byte{0x00}, 16),
+		ramp,
+		bytes.Repeat([]byte{0x01, 0x40, 0x9a, 0x7f, 0x10, 0x33}, 24),
+		bytes.Repeat([]byte{0xff, 0x00, 0x80, 0x2a}, 32),
+	}
+}

--- a/internal/testing/enginefuzz/harness_test.go
+++ b/internal/testing/enginefuzz/harness_test.go
@@ -1,0 +1,306 @@
+package enginefuzz
+
+import (
+	"fmt"
+	"testing"
+
+	jtx "github.com/LeJamon/goXRPLd/internal/testing"
+	"github.com/LeJamon/goXRPLd/internal/testing/accountset"
+	"github.com/LeJamon/goXRPLd/internal/testing/offer"
+	"github.com/LeJamon/goXRPLd/internal/testing/payment"
+	"github.com/LeJamon/goXRPLd/internal/testing/trustset"
+	"github.com/LeJamon/goXRPLd/internal/tx"
+)
+
+// maxSteps bounds the number of generated transactions per fuzz iteration and
+// maxCloses the number of ledger closes. Each iteration rebuilds the seeded
+// ledger from scratch -- which keeps iterations independent and reproducible --
+// so these bounds cap the per-iteration heap, keeping many concurrent fuzz
+// workers within memory and the engine the dominant cost rather than setup.
+const (
+	maxSteps  = 40
+	maxCloses = 2
+)
+
+// invariantTec and invariantTef are the engine result codes that signal an
+// invariant check rejected the transaction. They are the harness's primary
+// oracle: the engine runs the full internal/tx/invariants set on every apply
+// and squashes any violation into one of these codes.
+var (
+	invariantTec = tx.TecINVARIANT_FAILED.String()
+	invariantTef = tx.TefINVARIANT_FAILED.String()
+)
+
+// run drives one fuzz iteration: build a seeded ledger and apply the
+// transaction sequence encoded by data, asserting after every apply that the
+// engine never reports an invariant violation and never inflates total XRP.
+func run(t testing.TB, data []byte) {
+	t.Helper()
+	sc := newScenario(t)
+	s := &stream{data: data}
+
+	baseline := sc.totalXRP()
+	closes := 0
+	for i := 0; i < maxSteps && !s.drained(); i++ {
+		sc.step(s)
+		sc.requireXRPNotInflated(baseline)
+		// Occasionally close the ledger to advance state and exercise
+		// cross-ledger behaviour (sequence threading, owner counts, retries).
+		if closes < maxCloses && !s.drained() && s.chance(24) {
+			sc.env.Close()
+			closes++
+		}
+	}
+}
+
+// scenario is a freshly seeded ledger: a gateway that has issued IOU balances to
+// a fixed set of funded user accounts, giving the generated transaction stream
+// liquidity to move XRP and IOUs and offers to cross.
+type scenario struct {
+	t          testing.TB
+	env        *jtx.TestEnv
+	gw         *jtx.Account
+	users      []*jtx.Account
+	currencies []string
+}
+
+func newScenario(t testing.TB) *scenario {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+
+	gw := jtx.NewAccount("gw")
+	users := []*jtx.Account{
+		jtx.NewAccount("alice"),
+		jtx.NewAccount("bob"),
+		jtx.NewAccount("carol"),
+		jtx.NewAccount("dave"),
+	}
+	currencies := []string{"USD", "EUR"}
+
+	// Fund the gateway and users generously so reserves rarely block setup and
+	// there is headroom for the generated stream.
+	env.FundAmount(gw, uint64(jtx.XRP(1_000_000)))
+	for _, u := range users {
+		env.FundAmount(u, uint64(jtx.XRP(1_000_000)))
+	}
+	env.Close()
+
+	// Trust the gateway and seed each user with an IOU balance so IOU payments
+	// and IOU/XRP offers have something to move. Both helpers self-assert
+	// success; gateway-issued IOUs against a high trust limit always succeed.
+	for _, u := range users {
+		for _, ccy := range currencies {
+			env.Trust(u, tx.NewIssuedAmountFromFloat64(1_000_000_000, ccy, gw.Address))
+			env.PayIOU(gw, u, gw, ccy, 1_000_000)
+		}
+	}
+	env.Close()
+
+	return &scenario{t: t, env: env, gw: gw, users: users, currencies: currencies}
+}
+
+// totalXRP sums the XRP held by every account the scenario can touch. The
+// generated transaction set (Payment/AccountSet/TrustSet/Offer*) never escrows
+// or locks XRP, so this sum is the full XRP supply under test and may only
+// decrease as fees are burned.
+func (sc *scenario) totalXRP() uint64 {
+	total := sc.env.Balance(sc.env.MasterAccount()) + sc.env.Balance(sc.gw)
+	for _, u := range sc.users {
+		total += sc.env.Balance(u)
+	}
+	return total
+}
+
+func (sc *scenario) requireXRPNotInflated(baseline uint64) {
+	if got := sc.totalXRP(); got > baseline {
+		sc.t.Fatalf("XRP inflated: total %d drops exceeds baseline %d drops", got, baseline)
+	}
+}
+
+// txKind enumerates the transaction shapes the generator emits. Extend this
+// (and the switch in step) with new kinds -- e.g. AMM, MPT, NFToken, Escrow --
+// to widen invariant coverage; all supported amendments are already enabled in
+// the seeded environment.
+type txKind int
+
+const (
+	kindPaymentXRP txKind = iota
+	kindPaymentIOU
+	kindAccountSet
+	kindTrustSet
+	kindOfferCreate
+	kindOfferCancel
+	numKinds
+)
+
+// step builds one transaction from the byte stream and submits it, failing only
+// if the engine reports an invariant violation. Any other result code (a
+// tem/tec/ter rejection of an implausible transaction) is expected and ignored.
+func (sc *scenario) step(s *stream) {
+	var (
+		built tx.Transaction
+		desc  string
+	)
+
+	switch txKind(s.intn(int(numKinds))) {
+	case kindPaymentXRP:
+		from, to := sc.pickPair(s)
+		b := payment.Pay(from, to, sc.xrpDrops(s))
+		if s.chance(32) {
+			b = b.PartialPayment()
+		}
+		built, desc = b.Build(), "payment-xrp"
+
+	case kindPaymentIOU:
+		from, to := sc.pickPair(s)
+		amt := tx.NewIssuedAmountFromFloat64(sc.iouValue(s), sc.pickCurrency(s), sc.gw.Address)
+		b := payment.PayIssued(from, to, amt)
+		if s.chance(32) {
+			b = b.PartialPayment()
+		}
+		built, desc = b.Build(), "payment-iou"
+
+	case kindAccountSet:
+		built, desc = sc.buildAccountSet(s), "accountset"
+
+	case kindTrustSet:
+		u := sc.pickUser(s)
+		limit := fmt.Sprintf("%d", 1+s.intn(1_000_000))
+		b := trustset.TrustLine(u, sc.pickCurrency(s), sc.gw, limit)
+		switch s.intn(4) {
+		case 1:
+			b = b.NoRipple()
+		case 2:
+			b = b.Freeze()
+		case 3:
+			b = b.ClearFreeze()
+		}
+		built, desc = b.Build(), "trustset"
+
+	case kindOfferCreate:
+		built, desc = sc.buildOfferCreate(s), "offercreate"
+
+	case kindOfferCancel:
+		u := sc.pickUser(s)
+		built, desc = offer.OfferCancel(u, 1+s.u32()%64).Build(), "offercancel"
+	}
+
+	if built == nil {
+		return
+	}
+	res := sc.env.Submit(built)
+	if res.Code == invariantTec || res.Code == invariantTef {
+		sc.t.Fatalf("engine reported invariant violation %q after %s: %s", res.Code, desc, res.Message)
+	}
+}
+
+func (sc *scenario) buildAccountSet(s *stream) tx.Transaction {
+	b := accountset.AccountSet(sc.pickUser(s))
+	switch s.intn(8) {
+	case 0:
+		b = b.RequireDest()
+	case 1:
+		b = b.DefaultRipple()
+	case 2:
+		b = b.DepositAuth()
+	case 3:
+		b = b.NoFreeze()
+	case 4:
+		b = b.GlobalFreeze()
+	case 5:
+		b = b.DisallowXRP()
+	default:
+		// A bare AccountSet still threads the account root through the engine.
+	}
+	return b.Build()
+}
+
+func (sc *scenario) buildOfferCreate(s *stream) tx.Transaction {
+	u := sc.pickUser(s)
+	iou := tx.NewIssuedAmountFromFloat64(sc.iouValue(s), sc.pickCurrency(s), sc.gw.Address)
+	b := offer.OfferCreateXRP(u, sc.xrpDrops(s), iou, s.chance(128))
+	switch s.intn(8) {
+	case 1:
+		b = b.Passive()
+	case 2:
+		b = b.ImmediateOrCancel()
+	case 3:
+		b = b.FillOrKill()
+	case 4:
+		b = b.Sell()
+	}
+	return b.Build()
+}
+
+func (sc *scenario) pickUser(s *stream) *jtx.Account {
+	return sc.users[s.intn(len(sc.users))]
+}
+
+// pickPair returns two distinct users (from != to) so self-payments don't
+// dominate the stream.
+func (sc *scenario) pickPair(s *stream) (from, to *jtx.Account) {
+	i := s.intn(len(sc.users))
+	j := s.intn(len(sc.users))
+	if i == j {
+		j = (j + 1) % len(sc.users)
+	}
+	return sc.users[i], sc.users[j]
+}
+
+func (sc *scenario) pickCurrency(s *stream) string {
+	return sc.currencies[s.intn(len(sc.currencies))]
+}
+
+// xrpDrops returns a bounded XRP amount in drops (1 .. ~10000 XRP) so amounts
+// stay plausible and never overflow.
+func (sc *scenario) xrpDrops(s *stream) uint64 {
+	return 1 + uint64(s.u32())%uint64(jtx.XRP(10_000))
+}
+
+// iouValue returns a bounded IOU value with 6 decimal places of precision.
+func (sc *scenario) iouValue(s *stream) float64 {
+	return float64(int64(s.u32())+1) / 1e6
+}
+
+// stream is a deterministic, drainable reader over the fuzzer's input bytes.
+// Each accessor consumes bytes; once the input is exhausted drained reports true
+// and the accessors return zero values, terminating generation. Being driven
+// purely by the input bytes (with a ManualClock and name-derived deterministic
+// accounts) makes every iteration fully reproducible.
+type stream struct {
+	data []byte
+	pos  int
+}
+
+func (s *stream) drained() bool { return s.pos >= len(s.data) }
+
+func (s *stream) u8() byte {
+	if s.pos >= len(s.data) {
+		s.pos++
+		return 0
+	}
+	b := s.data[s.pos]
+	s.pos++
+	return b
+}
+
+func (s *stream) u32() uint32 {
+	b0 := uint32(s.u8())
+	b1 := uint32(s.u8())
+	b2 := uint32(s.u8())
+	b3 := uint32(s.u8())
+	return b0<<24 | b1<<16 | b2<<8 | b3
+}
+
+// intn returns a value in [0, n); n must be positive.
+func (s *stream) intn(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	return int(s.u8()) % n
+}
+
+// chance returns true with probability ~ num/256.
+func (s *stream) chance(num int) bool {
+	return int(s.u8()) < num
+}

--- a/justfile
+++ b/justfile
@@ -60,6 +60,12 @@ test-docker:
 test-postgres:
     go test -tags postgres -v ./storage/relationaldb/postgres/
 
+# Stateful invariant fuzzer over the transaction engine (issue #682).
+# Generates randomized transaction sequences, applies them through the engine,
+# and asserts the invariant oracle never fires. e.g. `just fuzz-engine 5m`.
+fuzz-engine fuzztime="60s":
+    go test -run '^$' -fuzz '^FuzzEngineInvariants$' -fuzztime {{fuzztime}} ./internal/testing/enginefuzz/
+
 # Run go vet on the module. The stdmethods analyzer is disabled because
 # it false-positives on gomock-generated recorder types: a recorder
 # method must be named after the mocked interface method (e.g.

--- a/justfile
+++ b/justfile
@@ -60,11 +60,24 @@ test-docker:
 test-postgres:
     go test -tags postgres -v ./storage/relationaldb/postgres/
 
-# Stateful invariant fuzzer over the transaction engine (issue #682).
+# Stateful invariant fuzzer over the transaction engine (issue #682, scope 1).
 # Generates randomized transaction sequences, applies them through the engine,
 # and asserts the invariant oracle never fires. e.g. `just fuzz-engine 5m`.
 fuzz-engine fuzztime="60s":
     go test -run '^$' -fuzz '^FuzzEngineInvariants$' -fuzztime {{fuzztime}} ./internal/testing/enginefuzz/
+
+# Determinism/fork fuzzer (issue #682, scope 3): builds a ledger from a
+# generated tx-set twice and asserts identical close hashes. e.g. `just
+# fuzz-determinism 5m`.
+fuzz-determinism fuzztime="60s":
+    go test -run '^$' -fuzz '^FuzzEngineDeterminism$' -fuzztime {{fuzztime}} ./internal/testing/enginefuzz/
+
+# Differential-vs-rippled fuzzer (issue #682, scope 2): replays recorded rippled
+# fixtures and diffs goXRPL's TER + post-state. Needs the conformance corpus;
+# set GOXRPL_FIXTURES_DIR or run from the main checkout. e.g.
+# `GOXRPL_FIXTURES_DIR=../fixtures/rippled-2.6.2-v2 just fuzz-differential 5m`.
+fuzz-differential fuzztime="60s":
+    go test -run '^$' -fuzz '^FuzzEngineDifferential$' -fuzztime {{fuzztime}} ./internal/testing/conformance/
 
 # Run go vet on the module. The stdmethods analyzer is disabled because
 # it false-positives on gomock-generated recorder types: a recorder


### PR DESCRIPTION
## Summary
Adds the three stateful fuzzers issue #682 asks for — the first generative coverage of the transaction engine. Every prior fuzz target covered a *stateless* decode surface (codec, crypto, shamap-wire, peer-frame).

**Scope 1 — invariant property fuzzer** (`internal/testing/enginefuzz/`)
Generates randomized, structurally-plausible transaction sequences from the fuzzer's byte stream (reusing the existing per-type builders: Payment XRP/IOU, AccountSet, TrustSet, OfferCreate/Cancel), applies them through `internal/tx/engine` against a seeded ledger (gateway + funded users with trust lines & IOU balances), and after **every apply** asserts (a) the engine never returns `tec/tefINVARIANT_FAILED`, and (b) total XRP is never inflated. The engine already runs the full `internal/tx/invariants` oracle on each apply — the same one rippled exercises under Antithesis — so a hit is by construction a consensus-safety bug.

**Scope 3 — determinism/fork fuzzer** (`internal/testing/enginefuzz/determinism_test.go`)
Builds a ledger from the same generated tx-set **twice** in independent envs (hence independently randomized Go-map iteration orders), closes both, and asserts identical ledger / account (state) / transaction hashes. A mismatch is a fork bug — the class of non-deterministic map tie-break behind #612 and #678.

**Scope 2 — differential vs rippled** (`internal/testing/conformance/fuzz_test.go`)
Replays the recorded rippled fixture corpus through the goXRPL engine and diffs the per-step **TER + post-state** against rippled's recorded values; the byte input selects which in-scope fixture to replay, so coverage feedback steers toward fixtures hitting new engine paths. Out-of-scope suites (`scripts/conformance-out-of-scope.txt`, e.g. Vault/XChain stubs) are excluded so intentional stubs aren't re-reported. The recorded tx bytes are not mutated (that would lose the rippled oracle).

## Running
`just fuzz-engine [dur]`, `just fuzz-determinism [dur]`, `just fuzz-differential [dur]`. The differential needs the conformance corpus (the one `just conformance` uses); set `GOXRPL_FIXTURES_DIR` or run from the main checkout — it skips cleanly when absent.

## Notes / scope boundaries
- Scopes 1 & 3 are fully in-process and run under plain `go test` / CI (deterministic seed-corpus tests). Verified on `main`@`278e67bd`: invariant fuzzer ~45k execs → zero violations/panics; determinism fuzzer → zero divergence; both reproducible (`ManualClock` + name-derived accounts), with `maxSteps`/`maxCloses` bounding per-iteration heap so concurrent workers stay within memory.
- Scope 2 reuses the existing `TestConformance` replay (`RunFixture`) — which already is the recorded-rippled differential for TER + post-state — and adds the fuzz entry + coverage-guided fixture selection. The shipped corpus records TER + post-state but **not** `account_hash`/`AffectedNodes`; diffing those awaits a richer corpus (the `internal/cli/replay` state-transition format already defines per-tx `meta_blob` + `account_hash`). Active `-fuzz` over the in-scope set will also surface **pre-existing** in-scope conformance gaps (Offer/AMM/TxQ partials visible in `just conformance --failing`); the seed corpus is drawn from fully-green suites so plain `go test` stays green.

## Test plan
- [x] `go test ./internal/testing/enginefuzz/` — invariant + determinism seed corpora pass (~0.6s); runs in CI via `just test-integration`
- [x] `go test ./internal/testing/conformance/` — green; differential target skips when corpus absent
- [x] `GOXRPL_FIXTURES_DIR=… go test -run FuzzEngineDifferential ./internal/testing/conformance/` — green seeds replay & match rippled
- [x] `just fuzz-engine 60s` / `just fuzz-determinism 45s` — pass, no crasher
- [x] `go vet` / `gofmt` clean

Fixes #682
