### PR TITLE
fix: deterministic close-time tie-break in observer fallback

### DIFF
--- a/internal/consensus/rcl/close_time_tiebreak_test.go
+++ b/internal/consensus/rcl/close_time_tiebreak_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/goXRPLd/internal/consensus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,4 +78,46 @@ func TestCloseTimeTieBreak_DeterministicAcrossValidators(t *testing.T) {
 			"— if this varies across runs, goxrpl validators won't converge on tied votes")
 	assert.Zero(t, picks[smaller],
 		"smaller tied close-time must NEVER be picked under the deterministic rule")
+}
+
+// TestDetermineCloseTime_ObserverTieBreakDeterministic pins the
+// observer-path close-time tie-break (issue #678). determineCloseTime is
+// the fallback used when this node has no OurPosition this round — during
+// catch-up or as a non-proposing trusted validator. On a tied close-time
+// vote it must pick the SAME time as every other node, or honest
+// observers embed different close times in the ledger header → different
+// ledger_hash → a fork.
+//
+// Bug: the observer loop iterated roundedVotes (a Go map) with a strict
+// `count > bestCount`, so on a tie two observers picked different times
+// depending on randomized map order. Fix mirrors updateCloseTimePosition:
+// sort ascending and keep the LARGEST time on a tie.
+func TestDetermineCloseTime_ObserverTieBreakDeterministic(t *testing.T) {
+	adaptor := newMockAdaptor() // CloseTimeResolution() == 1s
+
+	// Two close-times tied at 3 votes, both already on a 1s boundary so
+	// roundCloseTime maps each to itself.
+	smaller := time.Unix(831802190, 0).UTC()
+	larger := time.Unix(831802200, 0).UTC()
+
+	eng := &Engine{
+		adaptor: adaptor,
+		state: &consensus.RoundState{
+			OurPosition: nil, // observer: forces the fallback path
+			CloseTimes: consensus.CloseTimes{
+				Peers: map[time.Time]int{smaller: 3, larger: 3},
+			},
+		},
+	}
+
+	// Go randomizes map iteration on every range, so the buggy strict-'>'
+	// loop would return `smaller` on roughly half of these calls.
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		got := eng.determineCloseTime()
+		assert.True(t, got.Equal(larger),
+			"observer must deterministically pick the LARGER tied close-time "+
+				"(matches updateCloseTimePosition / rippled's ascending std::map); "+
+				"got %v on iteration %d", got, i)
+	}
 }

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -3611,10 +3611,25 @@ func (e *Engine) determineCloseTime() time.Time {
 			roundedVotes[rounded] += count
 		}
 
+		// Iterate ascending so ties resolve deterministically. Go's map
+		// iteration is randomized, so without an explicit sort two observers
+		// could pick different close times from the same votes and finalize
+		// different ledger hashes — a fork. Mirrors updateCloseTimePosition /
+		// rippled's ascending std::map + "raise the bar" loop, which keeps the
+		// LARGEST time on a tie.
+		sortedTimes := make([]time.Time, 0, len(roundedVotes))
+		for t := range roundedVotes {
+			sortedTimes = append(sortedTimes, t)
+		}
+		sort.Slice(sortedTimes, func(i, j int) bool {
+			return sortedTimes[i].Before(sortedTimes[j])
+		})
+
 		var bestTime time.Time
 		bestCount := 0
-		for t, count := range roundedVotes {
-			if count > bestCount {
+		for _, t := range sortedTimes {
+			count := roundedVotes[t]
+			if count >= bestCount {
 				bestTime = t
 				bestCount = count
 			}

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -3412,32 +3412,9 @@ func (e *Engine) updateCloseTimePosition() {
 	neededWeight := e.getCloseTimeNeededWeight()
 	threshVote := participantsNeeded(participants, neededWeight)
 	threshConsensus := participantsNeeded(participants, 75) // avCT_CONSENSUS_PCT
-	threshVoteInitial := threshVote
 
-	// Iterate ascending so ties are resolved deterministically — rippled's
-	// std::map<NetClock,int> iterates ascending and the "raise bar" loop
-	// picks the LAST (largest) candidate on a tie. Go's map iteration is
-	// randomized, so without an explicit sort validators diverge on ties.
-	sortedTimes := make([]time.Time, 0, len(closeTimeVotes))
-	for t := range closeTimeVotes {
-		sortedTimes = append(sortedTimes, t)
-	}
-	sort.Slice(sortedTimes, func(i, j int) bool {
-		return sortedTimes[i].Before(sortedTimes[j])
-	})
-
-	var consensusCloseTime time.Time
-	e.haveCloseTimeConsensus = false
-	for _, t := range sortedTimes {
-		count := closeTimeVotes[t]
-		if count >= threshVote {
-			consensusCloseTime = t
-			threshVote = count // raise bar to pick the MOST popular
-			if count >= threshConsensus {
-				e.haveCloseTimeConsensus = true
-			}
-		}
-	}
+	consensusCloseTime, winningVotes, haveWinner := mostVotedAscending(closeTimeVotes, threshVote)
+	e.haveCloseTimeConsensus = haveWinner && winningVotes >= threshConsensus
 
 	votesSummary := summarizeCloseTimeVotes(closeTimeVotes)
 	var consensusCT int64
@@ -3458,7 +3435,7 @@ func (e *Engine) updateCloseTimePosition() {
 		"converge_pct", e.convergePercent(),
 		"avalanche_state", closeTimeAvalancheStateName(e.closeTimeAvalancheState),
 		"needed_weight", neededWeight,
-		"thresh_vote", threshVoteInitial,
+		"thresh_vote", threshVote,
 		"thresh_consensus", threshConsensus,
 		"participants", participants,
 		"have_consensus", e.haveCloseTimeConsensus,
@@ -3584,6 +3561,36 @@ func participantsNeeded(participants, percent int) int {
 	return result
 }
 
+// mostVotedAscending returns the close time with the most votes, considering
+// only times whose count is >= minCount, and breaks ties toward the LARGEST
+// time. It iterates ascending so the result never depends on Go's randomized
+// map iteration: two nodes tallying the same votes must agree or they finalize
+// different ledger hashes (a fork). Mirrors rippled's std::map<NetClock,int>
+// "raise the bar" loop (Consensus.h:1605-1621). The bool reports whether any
+// time met minCount; callers must use it rather than best.IsZero(), since a
+// legitimate winner may be the zero time (unset close times round to zero).
+func mostVotedAscending(votes map[time.Time]int, minCount int) (time.Time, int, bool) {
+	sorted := make([]time.Time, 0, len(votes))
+	for t := range votes {
+		sorted = append(sorted, t)
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Before(sorted[j])
+	})
+
+	var best time.Time
+	bar := minCount
+	found := false
+	for _, t := range sorted {
+		if count := votes[t]; count >= bar {
+			best = t
+			bar = count
+			found = true
+		}
+	}
+	return best, bar, found
+}
+
 // determineCloseTime returns the consensus close time.
 // Uses the close time that was converged on by updateCloseTimePosition().
 // If we have a consensus position with a non-zero close time, use it.
@@ -3611,29 +3618,11 @@ func (e *Engine) determineCloseTime() time.Time {
 			roundedVotes[rounded] += count
 		}
 
-		// Iterate ascending so ties resolve deterministically. Go's map
-		// iteration is randomized, so without an explicit sort two observers
-		// could pick different close times from the same votes and finalize
-		// different ledger hashes — a fork. Mirrors updateCloseTimePosition /
-		// rippled's ascending std::map + "raise the bar" loop, which keeps the
-		// LARGEST time on a tie.
-		sortedTimes := make([]time.Time, 0, len(roundedVotes))
-		for t := range roundedVotes {
-			sortedTimes = append(sortedTimes, t)
-		}
-		sort.Slice(sortedTimes, func(i, j int) bool {
-			return sortedTimes[i].Before(sortedTimes[j])
-		})
-
-		var bestTime time.Time
-		bestCount := 0
-		for _, t := range sortedTimes {
-			count := roundedVotes[t]
-			if count >= bestCount {
-				bestTime = t
-				bestCount = count
-			}
-		}
+		// Keep the largest time on a tie, matching updateCloseTimePosition so
+		// an observer commits the same close time the proposing path
+		// determined; a non-deterministic pick here would finalize a different
+		// ledger hash — a fork.
+		bestTime, bestCount, _ := mostVotedAscending(roundedVotes, 0)
 		if bestCount > 0 {
 			return bestTime
 		}


### PR DESCRIPTION
## Summary
- `determineCloseTime()`'s observer fallback (used when this node has no `OurPosition` — catch-up or a non-proposing trusted validator) picked the most popular peer close time by iterating a Go `map[time.Time]int` with a strict `count > bestCount` and no tie-break.
- Go's randomized map iteration meant two honest observers could pick **different** close times on a vote tie → different ledger header → different `ledger_hash` → a reachable consensus fork. Same bug class as #612 (tx-set tie) and the sibling `updateCloseTimePosition`.
- Fix mirrors `updateCloseTimePosition` (engine.go:3417-3440) and rippled's ascending `std::map<NetClock,int>` + "raise the bar" loop: sort the rounded votes ascending and keep the **largest** time on a tie. Added a regression test driving the real observer path 100× to defeat map randomization.

## Test plan
- [x] `go test ./internal/consensus/rcl/` (full package passes)
- [x] `go test ./internal/consensus/rcl/ -run 'CloseTime|DetermineCloseTime' -v` — new `TestDetermineCloseTime_ObserverTieBreakDeterministic` passes
- [x] `go vet ./internal/consensus/rcl/` clean, `gofmt -l` clean

Fixes #678