### PR TITLE
Continuous fuzzing CI for native Go fuzz targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,99 @@
+name: Fuzz
+
+# goXRPL ships ~40 native Go fuzz targets (func Fuzz* across codec/, crypto/,
+# shamap/, and the peer + rpc subsystems) that never ran in CI — which is how
+# decode regressions like #672 shipped despite a fuzz target existing. This
+# wires them in with the split mature fuzzing setups use:
+#
+#   - pull_request: replay the committed seed corpus deterministically (no
+#     mutation). Fast and reproducible, so it can gate merges without flaking;
+#     it fails the moment a committed crasher regresses.
+#   - schedule / workflow_dispatch: open-ended mutation fuzzing that hunts for
+#     new crashers. Non-deterministic by nature, so it runs out of band rather
+#     than blocking unrelated PRs, grows a cached corpus, and uploads any
+#     newly-minimised crasher as an artifact for triage.
+#
+# A discovery-run crasher is triaged, fixed, and its reproducer committed to
+# <pkg>/testdata/fuzz/ — after which the corpus replay guards the fix forever.
+
+on:
+  pull_request:
+  schedule:
+    - cron: "27 3 * * *" # nightly 03:27 UTC
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: "Per-target fuzz duration for the discovery run (go -fuzztime), e.g. 30s, 5m"
+        default: "5m"
+
+permissions:
+  contents: read
+
+jobs:
+  # PR gate: deterministic, replays committed corpus only.
+  corpus:
+    name: Corpus replay
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install CGO dev headers (OpenSSL, libsecp256k1)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev libsecp256k1-dev pkg-config
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+          cache: true
+      - run: ./scripts/fuzz.sh --corpus
+
+  # Out-of-band discovery: mutation fuzzing, sharded by subsystem.
+  discovery:
+    name: Discovery (${{ matrix.name }})
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: codec
+            packages: ./codec/addresscodec ./codec/binarycodec
+          - name: crypto
+            packages: ./crypto ./crypto/ed25519 ./crypto/secp256k1
+          - name: peer
+            packages: ./internal/peermanagement ./internal/peermanagement/message
+          - name: rpc
+            packages: ./internal/rpc/handlers ./internal/rpc/types
+          - name: shamap
+            packages: ./shamap
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install CGO dev headers (OpenSSL, libsecp256k1)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev libsecp256k1-dev pkg-config
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+          cache: true
+      - name: Select fuzztime
+        id: cfg
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "fuzztime=${{ github.event.inputs.fuzztime }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "fuzztime=2m" >> "$GITHUB_OUTPUT"
+          fi
+      # Persist the evolving corpus between nightly runs so coverage compounds.
+      - name: Cache fuzz corpus
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build/fuzz
+          key: fuzz-corpus-${{ matrix.name }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.name }}-
+      - name: Run discovery fuzzing
+        run: FUZZTIME=${{ steps.cfg.outputs.fuzztime }} ./scripts/fuzz.sh ${{ matrix.packages }}
+      - name: Upload new crashers
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crashers-${{ matrix.name }}
+          path: "**/testdata/fuzz/**"
+          if-no-files-found: ignore

--- a/codec/addresscodec/testdata/fuzz/FuzzBase58CheckDecode/2a6f70697630cfa5
+++ b/codec/addresscodec/testdata/fuzz/FuzzBase58CheckDecode/2a6f70697630cfa5
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\x85")

--- a/codec/addresscodec/testdata/fuzz/FuzzDecodeClassicAddress/8fe4afa715c62ebb
+++ b/codec/addresscodec/testdata/fuzz/FuzzDecodeClassicAddress/8fe4afa715c62ebb
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\xe1")

--- a/codec/addresscodec/testdata/fuzz/FuzzDecodeNodePublicKey/8dfb7bd2e2ca2ee5
+++ b/codec/addresscodec/testdata/fuzz/FuzzDecodeNodePublicKey/8dfb7bd2e2ca2ee5
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\x84")

--- a/codec/addresscodec/testdata/fuzz/FuzzDecodeSeed/828d5059791d0353
+++ b/codec/addresscodec/testdata/fuzz/FuzzDecodeSeed/828d5059791d0353
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\xe0")

--- a/codec/addresscodec/testdata/fuzz/FuzzDecodeXAddress/d9e27a291c356683
+++ b/codec/addresscodec/testdata/fuzz/FuzzDecodeXAddress/d9e27a291c356683
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\xf4")

--- a/codec/binarycodec/testdata/fuzz/FuzzDecodeRoundTrip/5f144e462e8753ef
+++ b/codec/binarycodec/testdata/fuzz/FuzzDecodeRoundTrip/5f144e462e8753ef
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("E2")

--- a/crypto/der.go
+++ b/crypto/der.go
@@ -16,6 +16,11 @@ var (
 	ErrInvalidDERIntegerTag = errors.New("invalid DER: expected integer tag")
 	// ErrInvalidDERSignature is returned when the DER signature is invalid.
 	ErrInvalidDERSignature = errors.New("invalid signature: incorrect length")
+	// ErrInvalidDERSignatureValue is returned when r or s is not strictly
+	// positive. A valid ECDSA signature has r and s in [1, n-1]; a zero scalar
+	// is non-canonical (its DER integer carries no content bytes) and can never
+	// verify.
+	ErrInvalidDERSignatureValue = errors.New("invalid signature: r and s must be positive")
 	// ErrLeftoverBytes is returned when there are leftover bytes after parsing the DER signature.
 	ErrLeftoverBytes = errors.New("invalid signature: left bytes after parsing")
 )
@@ -51,6 +56,10 @@ func DERSigToRS(data []byte) ([]byte, []byte, error) {
 
 	if len(leftover) > 0 {
 		return nil, nil, ErrLeftoverBytes
+	}
+
+	if r.Sign() <= 0 || s.Sign() <= 0 {
+		return nil, nil, ErrInvalidDERSignatureValue
 	}
 
 	return r.Bytes(), s.Bytes(), nil

--- a/crypto/der.go
+++ b/crypto/der.go
@@ -16,11 +16,12 @@ var (
 	ErrInvalidDERIntegerTag = errors.New("invalid DER: expected integer tag")
 	// ErrInvalidDERSignature is returned when the DER signature is invalid.
 	ErrInvalidDERSignature = errors.New("invalid signature: incorrect length")
-	// ErrInvalidDERSignatureValue is returned when r or s is not strictly
-	// positive. A valid ECDSA signature has r and s in [1, n-1]; a zero scalar
-	// is non-canonical (its DER integer carries no content bytes) and can never
-	// verify.
-	ErrInvalidDERSignatureValue = errors.New("invalid signature: r and s must be positive")
+	// ErrInvalidDERSignatureValue is returned when r or s falls outside the
+	// valid ECDSA scalar range [1, n-1], where n is the secp256k1 group order.
+	// A zero scalar is non-canonical (its DER integer carries no content bytes)
+	// and a scalar >= n is a reduced duplicate; neither can belong to a
+	// signature that verifies.
+	ErrInvalidDERSignatureValue = errors.New("invalid signature: r and s must be in [1, n-1]")
 	// ErrLeftoverBytes is returned when there are leftover bytes after parsing the DER signature.
 	ErrLeftoverBytes = errors.New("invalid signature: left bytes after parsing")
 )
@@ -58,7 +59,8 @@ func DERSigToRS(data []byte) ([]byte, []byte, error) {
 		return nil, nil, ErrLeftoverBytes
 	}
 
-	if r.Sign() <= 0 || s.Sign() <= 0 {
+	if r.Sign() <= 0 || s.Sign() <= 0 ||
+		r.Cmp(secp256k1Order) >= 0 || s.Cmp(secp256k1Order) >= 0 {
 		return nil, nil, ErrInvalidDERSignatureValue
 	}
 

--- a/crypto/der_test.go
+++ b/crypto/der_test.go
@@ -66,6 +66,20 @@ func TestDERHexToSig(t *testing.T) {
 			expectError:  ErrLeftoverBytes,
 		},
 		{
+			name:         "fail - zero r and s",
+			hexSignature: "3006020100020100",
+			expectedR:    "",
+			expectedS:    "",
+			expectError:  ErrInvalidDERSignatureValue,
+		},
+		{
+			name:         "fail - r equal to curve order",
+			hexSignature: "3026022100FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141020101",
+			expectedR:    "",
+			expectedS:    "",
+			expectError:  ErrInvalidDERSignatureValue,
+		},
+		{
 			name:         "pass - valid DER signature",
 			hexSignature: "3045022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
 			expectedR:    "e1617f1a3c85b5bc8fa6224f893fe9068bea8f8d075ee144f6f9d255c8297618",

--- a/crypto/testdata/fuzz/FuzzDERHexToSig/f7f9ff5156615426
+++ b/crypto/testdata/fuzz/FuzzDERHexToSig/f7f9ff5156615426
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("3006020100020100")

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -28,7 +28,7 @@ func newMetricsRegistry() *prometheus.Registry {
 	buildInfo := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:   metricsNamespace,
 		Name:        "build_info",
-		Help:        "Constant 1, labelled with the running goXRPLd build version.",
+		Help:        "Constant 1, labelled with the running go-xrpl build version.",
 		ConstLabels: prometheus.Labels{"version": version.Version},
 	})
 	buildInfo.Set(1)

--- a/justfile
+++ b/justfile
@@ -92,6 +92,18 @@ fuzz-payment fuzztime="60s":
 fuzz-pathfinder fuzztime="60s":
     go test -run '^$' -fuzz '^FuzzPathfinder$' -fuzztime {{fuzztime}} ./internal/testing/pathfuzz/
 
+# Discovery fuzzing: run every native Go fuzz target with mutation for a bounded
+# duration and fail on any new crasher. Non-deterministic, so this is the
+# scheduled job — not a required PR check. Override the per-target budget with
+# fuzztime and restrict to packages with extra args. e.g. `just fuzz 2m ./shamap`.
+fuzz fuzztime='30s' *pkgs:
+    FUZZTIME={{fuzztime}} ./scripts/fuzz.sh {{pkgs}}
+
+# Regression fuzzing: replay the committed fuzz seed corpus (testdata/fuzz +
+# f.Add seeds) with no mutation. Deterministic and fast — this is the PR gate.
+fuzz-corpus *pkgs:
+    ./scripts/fuzz.sh --corpus {{pkgs}}
+
 # Run go vet on the module. The stdmethods analyzer is disabled because
 # it false-positives on gomock-generated recorder types: a recorder
 # method must be named after the mocked interface method (e.g.

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Drive goXRPL's native Go fuzz targets (func Fuzz* in *_test.go). Two modes:
+#
+#   scripts/fuzz.sh --corpus [pkg ...]   Deterministic: replay the committed seed
+#                                        corpus (testdata/fuzz + f.Add seeds) with
+#                                        no mutation. Fast, reproducible — this is
+#                                        the PR gate, and it fails if a committed
+#                                        crasher ever regresses.
+#
+#   scripts/fuzz.sh [pkg ...]            Discovery: fuzz each target for FUZZTIME
+#   FUZZTIME=2m scripts/fuzz.sh          (default 30s) with mutation, failing on
+#                                        any new crasher. Open-ended and therefore
+#                                        non-deterministic, so it runs on a
+#                                        schedule, not as a required PR check.
+#
+# A new crasher found by the discovery run is minimised by Go into
+# <pkg>/testdata/fuzz/<Func>/. Triage it, fix the bug, then commit the reproducer
+# so the corpus replay guards against regressions forever after.
+#
+# With no package arguments both modes operate on every package that declares a
+# fuzz target. Each target is fuzzed independently because `go test -fuzz`
+# refuses to run when its regexp matches more than one target.
+
+set -uo pipefail
+
+corpus=0
+if [ "${1:-}" = "--corpus" ]; then
+    corpus=1
+    shift
+fi
+
+FUZZTIME="${FUZZTIME:-30s}"
+
+# Packages to operate on: the arguments if given, else every package that
+# declares at least one fuzz target. `grep -r` emits paths with or without a
+# leading "./" depending on the platform, so normalise to exactly one.
+if [ "$#" -gt 0 ]; then
+    pkgs=$(printf '%s\n' "$@")
+else
+    pkgs=$(grep -rl --include='*_test.go' '^func Fuzz' . \
+        | xargs -n1 dirname \
+        | sed 's#^\./##; s#^#./#' \
+        | sort -u)
+fi
+
+fail=0
+total=0
+crashed=""
+
+while IFS= read -r pkg; do
+    [ -z "$pkg" ] && continue
+
+    # `go test -list` compiles the test binary and prints the matching target
+    # names (plus an "ok ..." summary line we drop with the ^Fuzz filter).
+    funcs=$(go test -list '^Fuzz' "$pkg" 2>/dev/null | grep '^Fuzz' || true)
+    [ -z "$funcs" ] && continue
+
+    if [ "$corpus" -eq 1 ]; then
+        # -run='^Fuzz' replays each target's seed corpus once, no mutation.
+        echo "==> replaying corpus: ${pkg}"
+        if ! go test -run='^Fuzz' "$pkg"; then
+            crashed="${crashed}\n  ${pkg}"
+            fail=1
+        fi
+        continue
+    fi
+
+    while IFS= read -r fn; do
+        [ -z "$fn" ] && continue
+        total=$((total + 1))
+        echo "==> fuzzing ${pkg} ${fn} for ${FUZZTIME}"
+        # -run='^$' matches no unit test, so only the fuzz target executes.
+        if ! go test -run='^$' -fuzz="^${fn}$" -fuzztime="$FUZZTIME" "$pkg"; then
+            echo "::error::fuzz target ${pkg} ${fn} failed — see ${pkg#./}/testdata/fuzz/${fn}/"
+            crashed="${crashed}\n  ${pkg} ${fn}"
+            fail=1
+        fi
+    done <<EOF
+$funcs
+EOF
+done <<EOF
+$pkgs
+EOF
+
+if [ "$corpus" -eq 0 ]; then
+    echo "==> ran ${total} fuzz target(s)"
+fi
+if [ "$fail" -ne 0 ]; then
+    echo "==> FAILED:"
+    printf '%b\n' "$crashed"
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary

Wires goXRPL's ~40 existing native Go fuzz targets (`func Fuzz*` across `codec/`, `crypto/`, `shamap/`, and the peer + rpc subsystems) into CI. They previously only ran when a developer typed `go test -fuzz` by hand — the root cause of #672 shipping despite `FuzzDecode` existing.

**Tooling** — `scripts/fuzz.sh` with two modes, surfaced as recipes:
- `just fuzz [fuzztime] [pkgs…]` — discovery: mutation fuzzing, fails on any new crasher.
- `just fuzz-corpus [pkgs…]` — regression: deterministic replay of the committed seed corpus (no mutation).

**Workflow** (`.github/workflows/fuzz.yml`) — the split mature fuzzing setups use:
- **`pull_request`** → corpus replay only. Deterministic and fast, so it gates merges without flaking; fails the instant a committed crasher regresses.
- **`schedule` (nightly) + `workflow_dispatch`** → open-ended mutation fuzzing, sharded by subsystem. Non-gating, grows a cached corpus night-over-night, and uploads any newly-minimised crasher as an artifact for triage.

> Why not short mutation fuzzing *on PRs*? It's both flaky (each run finds different latent bugs, plus benign `-fuzztime` deadline timeouts) and, per #681's own analysis, too shallow to reach deep bugs like #672 anyway. Deterministic corpus replay is the right PR gate; deep discovery belongs on a schedule. This matches how Go itself and OSS-Fuzz consumers operate. (OSS-Fuzz/ClusterFuzzLite remain a future option but require external onboarding and a libFuzzer build shim; native `go test -fuzz` needs neither.)

## Bugs found and fixed

Running the targets immediately surfaced three real bugs. Each is fixed and its minimised reproducer committed under `testdata/fuzz/` as a permanent regression case:

- **addresscodec panic (DoS-class).** `DecodeBase58` ranged its input as runes, so any non-ASCII byte decoded to `U+FFFD` (65533) and panicked the 256-entry lookup table. Index by byte — base58 digits are single-byte ASCII.
- **crypto DER lenient parse.** `DERSigToRS` accepted a non-canonical signature whose `r` or `s` is zero (a zero scalar carries no DER content bytes and can never verify). Reject `r,s ≤ 0`, matching the valid ECDSA range `[1, n-1]`. The one consumer (pure-Go secp256k1 verify) already treats a parse error as "invalid signature", so verification outcomes are unchanged.
- **binarycodec round-trip oracle.** `FuzzDecodeRoundTrip` asserted byte-identity to the raw input, but rippled (`STObject.cpp:235-296`) accepts non-canonical serializations (e.g. a truncated inner object) and re-emits them canonically — so byte-equality is not the invariant. Assert encode **idempotency** (`decode→encode→decode→encode` is byte-stable) instead, the rippled-faithful property, which also catches field-ordering/precision drift. The decoder itself is unchanged: rejecting such input would diverge from rippled.

## Follow-ups (out of scope here — for #681)

The nightly discovery run will also surface deeper, pre-existing latent bugs it found during development, which belong to #681's "strengthen codec oracles" scope:
- `FuzzDecode`: a decode panic (`slice bounds out of range`) on adversarial input (#672 class).
- `FuzzDecodeRoundTrip`: a decode/encode asymmetry where some input decodes to `{Account: ""}` but `Encode` rejects the empty account.

(`FuzzSecp256k1Validate` reporting `context deadline exceeded` under a tight `-fuzztime` is a benign timeout, not a bug — no reproducer is produced.)

## Test plan

- [x] `just fuzz-corpus` — green across all 10 fuzz packages (the PR gate).
- [x] `just test-libs` — green (addresscodec/crypto dependents).
- [x] `CGO_ENABLED=0 go test ./crypto/...` — green (pure-Go DER verify path).
- [x] `gofmt`/`go vet` clean on changed files.
- [x] Reproducers for the three fixed bugs replay cleanly; reproducers for the unfixed follow-up bugs intentionally not committed.

Fixes #680