### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.15.0 // indirect
+	github.com/prometheus/client_golang v1.15.0
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/LeJamon/goXRPLd/internal/observability"
+	"github.com/LeJamon/goXRPLd/version"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const metricsNamespace = "goxrpl"
+
+// newMetricsRegistry builds a Prometheus registry holding the standard Go
+// runtime and process collectors plus goXRPL node-level metrics. A
+// dedicated registry (rather than prometheus.DefaultRegisterer) keeps
+// registration self-contained, so the metrics server can be stood up more
+// than once without colliding on the package-global default registry.
+func newMetricsRegistry() *prometheus.Registry {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+	)
+
+	buildInfo := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   metricsNamespace,
+		Name:        "build_info",
+		Help:        "Constant 1, labelled with the running goXRPLd build version.",
+		ConstLabels: prometheus.Labels{"version": version.Version},
+	})
+	buildInfo.Set(1)
+
+	schedLatency := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Name:      "sched_latency_milliseconds",
+		Help:      "Most recent goroutine-scheduler latency sample in milliseconds (rippled io_latency_probe analog).",
+	}, func() float64 {
+		return float64(observability.SchedLatencyMs())
+	})
+
+	ioLatencyEvents := prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Name:      "io_latency_events_total",
+		Help:      "Scheduler-latency samples that crossed the 10ms reporting threshold.",
+	}, func() float64 {
+		return float64(observability.IOLatencyEventStats().Count)
+	})
+
+	reg.MustRegister(buildInfo, schedLatency, ioLatencyEvents)
+	return reg
+}
+
+// startMetricsServer serves Prometheus metrics at /metrics on addr. It
+// mirrors startPProfServer: a standalone auxiliary HTTP server enabled
+// out-of-band (via the GOXRPL_METRICS env var) and never mounted on the
+// public JSON-RPC ports, keeping scrape traffic and internal telemetry off
+// the client-facing API surface.
+func startMetricsServer(addr string) error {
+	reg := newMetricsRegistry()
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return srv.ListenAndServe()
+}

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/goXRPLd/version"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func TestMetricsRegistry(t *testing.T) {
+	reg := newMetricsRegistry()
+	srv := httptest.NewServer(promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("scrape metrics: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("metrics status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("metrics content-type = %q, want Prometheus text exposition", ct)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	out := string(body)
+
+	// Standard Go runtime collector (always present, platform-independent).
+	if !strings.Contains(out, "go_goroutines") {
+		t.Errorf("metrics output missing go_goroutines:\n%s", out)
+	}
+	// Node-level collectors registered by newMetricsRegistry.
+	for _, name := range []string{
+		"goxrpl_build_info",
+		"goxrpl_sched_latency_milliseconds",
+		"goxrpl_io_latency_events_total",
+	} {
+		if !strings.Contains(out, name) {
+			t.Errorf("metrics output missing %s:\n%s", name, out)
+		}
+	}
+	// build_info must carry the running version as a label.
+	if want := "version=\"" + version.Version + "\""; !strings.Contains(out, want) {
+		t.Errorf("goxrpl_build_info missing label %s:\n%s", want, out)
+	}
+}

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -39,7 +39,6 @@ func TestMetricsRegistry(t *testing.T) {
 	if !strings.Contains(out, "go_goroutines") {
 		t.Errorf("metrics output missing go_goroutines:\n%s", out)
 	}
-	// Node-level collectors registered by newMetricsRegistry.
 	for _, name := range []string{
 		"goxrpl_build_info",
 		"goxrpl_sched_latency_milliseconds",
@@ -49,7 +48,6 @@ func TestMetricsRegistry(t *testing.T) {
 			t.Errorf("metrics output missing %s:\n%s", name, out)
 		}
 	}
-	// build_info must carry the running version as a label.
 	if want := "version=\"" + version.Version + "\""; !strings.Contains(out, want) {
 		t.Errorf("goxrpl_build_info missing label %s:\n%s", want, out)
 	}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -106,6 +106,17 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		serverLog.Info("pprof enabled", "addr", addr)
 	}
 
+	// Set GOXRPL_METRICS=:9100 (or any addr:port) to expose Prometheus
+	// metrics at /metrics. Off by default.
+	if addr := os.Getenv("GOXRPL_METRICS"); addr != "" {
+		go func() {
+			if err := startMetricsServer(addr); err != nil {
+				serverLog.Warn("metrics server failed", "addr", addr, "err", err)
+			}
+		}()
+		serverLog.Info("prometheus metrics enabled", "addr", addr)
+	}
+
 	// Pre-declared so the deferred shutdown can clean up whatever the
 	// init path managed to populate before any error return. doShutdown
 	// tolerates nil components for the partial-init case.


### PR DESCRIPTION
## Summary
- Adds a Prometheus `/metrics` endpoint exposing the standard Go runtime + process collectors, plus node-level metrics: `goxrpl_build_info` (version label), `goxrpl_sched_latency_milliseconds`, and `goxrpl_io_latency_events_total`.
- Runs as a standalone auxiliary HTTP server gated by the `GOXRPL_METRICS` env var (e.g. `GOXRPL_METRICS=:9100`), mirroring the existing `GOXRPL_PPROF` pprof pattern in `internal/cli/server.go`. Off by default; never mounted on the public JSON-RPC ports.
- Uses a dedicated `prometheus.Registry` (not the global default) so the server is self-contained and testable. The io_latency bridge surfaces the telemetry the `observability` package already collects — its docs explicitly anticipate a Prometheus forwarder.

The issue had no body/acceptance criteria, so the scope was kept minimal and conventional: a standard `/metrics` exposition surfacing real node telemetry, wired exactly like the existing debug-server precedent.

## Test plan
- [x] `go test ./internal/cli/` — new `TestMetricsRegistry` scrapes the handler over real HTTP and asserts Go runtime + all three node metrics + the version label
- [x] `go vet ./internal/cli/` and `gofmt` clean
- [x] `go build ./cmd/xrpld` (full binary)

Fixes #223