### PR TITLE
fix: repair stale goXRPLd imports + drop stale tx-flag claim in ledger/entry doc

### DIFF
--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/LeJamon/goXRPLd/internal/observability"
-	"github.com/LeJamon/goXRPLd/version"
+	"github.com/LeJamon/go-xrpl/internal/observability"
+	"github.com/LeJamon/go-xrpl/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/LeJamon/goXRPLd/version"
+	"github.com/LeJamon/go-xrpl/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/internal/testing/enginefuzz/harness_test.go
+++ b/internal/testing/enginefuzz/harness_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	jtx "github.com/LeJamon/goXRPLd/internal/testing"
-	"github.com/LeJamon/goXRPLd/internal/testing/accountset"
-	"github.com/LeJamon/goXRPLd/internal/testing/offer"
-	"github.com/LeJamon/goXRPLd/internal/testing/payment"
-	"github.com/LeJamon/goXRPLd/internal/testing/trustset"
-	"github.com/LeJamon/goXRPLd/internal/tx"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
+	"github.com/LeJamon/go-xrpl/internal/testing/offer"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
+	"github.com/LeJamon/go-xrpl/internal/tx"
 )
 
 // maxSteps bounds the number of generated transactions per fuzz iteration and

--- a/ledger/entry/doc.go
+++ b/ledger/entry/doc.go
@@ -7,8 +7,8 @@
 //     rippled/include/xrpl/protocol/detail/ledger_entries.macro.
 //   - LedgerSpecificFlags: the per-entry-type flag constants mirroring
 //     rippled/include/xrpl/protocol/LedgerFormats.h (Lsf* prefix).
-//   - MPToken-related transaction flag constants, masks, and protocol
-//     limits used by MPT transaction handlers.
+//   - MPToken-related protocol limits (metadata length, transfer fee, and
+//     maximum amount) used by MPT transaction handlers.
 //
 // Typed SLE structs (with Encode / Hash methods) are not yet defined here.
 // Decode-only typed views currently live under internal/tx/ledgerfields/


### PR DESCRIPTION
## Summary
Two cleanups, the first of which unblocks CI:

1. **Build fix (CI-blocking).** The module rename in #692 (`goXRPLd` → `go-xrpl`) missed three files whose branches predated it and merged afterward — `internal/cli/metrics.go` & `metrics_test.go` (#223) and `internal/testing/enginefuzz/harness_test.go` (#687). They still imported `github.com/LeJamon/goXRPLd/...`, which breaks `go build ./...` and every CI run on `main`. Repointed them at the current module path. (897 files already use `go-xrpl`; only these 3 lagged.)
2. **Issue #670.** The core of #670 — removing the stale duplicate `TfUniversal`, the `TfMPT*` transaction flags, and the four `TfMPToken*Mask` constants from `ledger/entry/flags.go` plus their characterization tests — already landed in #663 (`264a4602`). This PR finishes the one piece that PR missed: `ledger/entry/doc.go` still advertised *"transaction flag constants, masks"*, which no longer exist. Reworded the bullet to describe only the surviving MPToken protocol limits.

## Test plan
- [x] `go build ./...` (exit 0; previously failed on the stale imports)
- [x] `go vet ./internal/cli/ ./internal/testing/enginefuzz/`
- [x] `go test ./internal/cli/ ./internal/testing/enginefuzz/ ./ledger/entry/`
- [x] `git grep LeJamon/goXRPLd` → no matches

Fixes #670