### PR TITLE
fix: decode RFC1751 dictionary index 570 ("YOU")

### DIFF
--- a/crypto/rfc1751/rfc1751.go
+++ b/crypto/rfc1751/rfc1751.go
@@ -132,9 +132,19 @@ func etob(words []string) ([]byte, int) {
 
 		w := standard(word)
 
+		// The dictionary is two lexicographically-sorted groups: 1-3 letter
+		// words at [0, 570] and 4-letter words at [571, 2047]. wsrch's upper
+		// bound is exclusive, so the short-word range must be [0, 571) to reach
+		// index 570 ("YOU", the last 3-letter word). rippled caps it at 570
+		// (RFC1751.cpp:433), making "YOU" encodable by btoe but never decodable
+		// by etob — a recovery string fails for any seed whose entropy maps a
+		// word to index 570 (~0.6% of 16-byte seeds). This is a deliberate,
+		// non-consensus divergence: RFC1751 only backs wallet_propose /
+		// validation_create recovery strings, and decoding a superset of what
+		// rippled accepts cannot fork the ledger.
 		var minIdx, maxIdx int
 		if l < 4 {
-			minIdx, maxIdx = 0, 570
+			minIdx, maxIdx = 0, 571
 		} else {
 			minIdx, maxIdx = 571, 2048
 		}

--- a/crypto/rfc1751/rfc1751_test.go
+++ b/crypto/rfc1751/rfc1751_test.go
@@ -104,14 +104,6 @@ func TestKeyToEnglishRoundTrip(t *testing.T) {
 		}
 
 		decoded, err := EnglishToKey(words)
-		if containsWord(words, "YOU") {
-			// rippled-faithful quirk: "YOU" (dictionary index 570) can be
-			// encoded but never decoded — see TestIndex570NotDecodable.
-			if err == nil {
-				t.Errorf("EnglishToKey(%q): expected decode failure for index-570 word, got nil", words)
-			}
-			continue
-		}
 		if err != nil {
 			t.Fatalf("EnglishToKey(%q): unexpected error: %v", words, err)
 		}
@@ -133,12 +125,6 @@ func TestSeedToEnglishRoundTrip(t *testing.T) {
 		}
 
 		decoded, err := EnglishToSeed(words)
-		if containsWord(words, "YOU") {
-			if err == nil {
-				t.Errorf("EnglishToSeed(%q): expected decode failure for index-570 word, got nil", words)
-			}
-			continue
-		}
 		if err != nil {
 			t.Fatalf("EnglishToSeed(%q): unexpected error: %v", words, err)
 		}
@@ -270,33 +256,52 @@ func TestStandardNormalization(t *testing.T) {
 	}
 }
 
-// TestIndex570NotDecodable pins a latent quirk of RFC1751's length-bounded
-// binary search that go-xrpl faithfully ports from rippled. etob searches
-// 1-3 letter words in [0, 570) (rippled RFC1751.cpp:433, wsrch :381-406) —
-// exclusive of index 570, the last 3-letter word "YOU". btoe can emit "YOU",
-// but etob can never find it. Every other dictionary index round-trips.
-//
-// This test guards against a dictionary reordering or bounds edit silently
-// changing which words are decodable, and documents the boundary so any
-// deliberate fix (diverging from rippled) is a conscious change here.
-func TestIndex570NotDecodable(t *testing.T) {
+// TestEveryDictionaryWordDecodable proves the etob length-bounded binary search
+// reaches every dictionary index, including 570 ("YOU", the last 3-letter word).
+// rippled caps the short-word range at 570 exclusive (RFC1751.cpp:433), so its
+// etob can encode but never decode "YOU"; go-xrpl deliberately diverges with an
+// upper bound of 571 (rfc1751.go etob) so the recovery string for any seed that
+// maps a word to index 570 round-trips. RFC1751 is RPC/wallet-recovery only, so
+// this non-consensus divergence cannot fork the ledger.
+func TestEveryDictionaryWordDecodable(t *testing.T) {
 	if dictionary[570] != "YOU" {
 		t.Fatalf("dictionary[570] = %q, want %q (boundary assumption broken)", dictionary[570], "YOU")
 	}
-	if got := wsrch("YOU", 0, 570); got != -1 {
-		t.Errorf("wsrch(YOU, 0, 570) = %d, want -1 (unreachable per rippled bounds)", got)
+	if got := wsrch("YOU", 0, 571); got != 570 {
+		t.Errorf("wsrch(YOU, 0, 571) = %d, want 570 (index 570 must be decodable)", got)
 	}
 
 	for i, w := range dictionary {
-		if i == 570 {
-			continue
-		}
 		lo, hi := 571, 2048
 		if len(w) < 4 {
-			lo, hi = 0, 570
+			lo, hi = 0, 571
 		}
 		if got := wsrch(standard(w), lo, hi); got != i {
 			t.Errorf("wsrch(%q) = %d, want %d (index should be decodable)", w, got, i)
 		}
+	}
+}
+
+// TestIndex570RoundTrips is the concrete regression for the index-570 decode
+// bug: a 16-byte key whose 7th word encodes to "YOU" must decode back to the
+// same key. Under rippled's bounds EnglishToKey(words) would fail here.
+func TestIndex570RoundTrips(t *testing.T) {
+	const keyHex = "BB27F5BC497BD654474DCB862AB4DD68"
+	key := mustHex(t, keyHex)
+
+	words, err := KeyToEnglish(key)
+	if err != nil {
+		t.Fatalf("KeyToEnglish(%s): %v", keyHex, err)
+	}
+	if !containsWord(words, "YOU") {
+		t.Fatalf("KeyToEnglish(%s) = %q, expected it to contain \"YOU\"", keyHex, words)
+	}
+
+	decoded, err := EnglishToKey(words)
+	if err != nil {
+		t.Fatalf("EnglishToKey(%q): unexpected error: %v", words, err)
+	}
+	if !bytes.Equal(decoded, key) {
+		t.Errorf("round-trip mismatch: %q decoded to %X, want %s", words, decoded, keyHex)
 	}
 }


### PR DESCRIPTION
## Summary
- RFC1751's dictionary is two lexicographically-sorted groups: 1–3 letter words at indices `[0, 570]` and 4-letter words at `[571, 2047]`. `etob`'s short-word binary search used the half-open range `[0, 570)`, **excluding index 570** (`"YOU"`, the last 3-letter word). This is a verbatim port of rippled's bug (`RFC1751.cpp:433`).
- `btoe` happily *encodes* `"YOU"`, but `etob` could never *decode* it, so any recovery string whose entropy maps a word to index 570 (~0.6% of 16-byte seeds) failed to decode. Worse: in `validation_create` the failed decode falls through to the passphrase path (`Sha512Half`), **silently deriving the wrong seed** rather than erroring.
- Fix: widen the short-word search upper bound to `571` so index 570 round-trips. One-character change in `etob`.

## Deliberate divergence from rippled
This intentionally diverges from rippled, which leaves index 570 undecodable. It is **safe and non-consensus**: RFC1751 is used only by the `wallet_propose` / `validation_create` RPC handlers for human-readable recovery strings — never in signing, ledger hashing, consensus, or the wire protocol. The encoding is byte-identical to rippled; we only *decode a strict superset* of what rippled accepts, so this cannot fork the ledger or break interop. The divergence is documented inline in `etob` so future conformance reviews don't revert it.

## Context
- The quirk was flagged in PR #634's reviewer note (rfc1751 test coverage) and was pinned by `TestIndex570NotDecodable` rather than fixed. That pin test is inverted here into `TestEveryDictionaryWordDecodable`, plus a concrete round-trip vector `TestIndex570RoundTrips` (`BB27F5BC…` → `"… NAB YOU CUTS …"`).
- The two random round-trip tests no longer special-case `"YOU"` as a decode failure.

## Test plan
- [x] `go test ./crypto/rfc1751/ -cover` → PASS (96.3%), incl. `TestEveryDictionaryWordDecodable`, `TestIndex570RoundTrips`
- [x] `go test ./crypto/...` and `go test ./internal/rpc/handlers/` → PASS
- [x] `go vet` clean, `gofmt -l` clean

Refs #634, #644