### PR TITLE
Amendment-aware replay-range with account_hash gate and checkpoint/resume

### DIFF
--- a/internal/cli/replay_checkpoint.go
+++ b/internal/cli/replay_checkpoint.go
@@ -16,7 +16,6 @@ const (
 	checkpointVersion = uint32(1)
 )
 
-// checkpointPath returns the on-disk path for a checkpoint at the given seq.
 func checkpointPath(dir string, seq uint32) string {
 	return filepath.Join(dir, fmt.Sprintf("checkpoint_%d.dat", seq))
 }

--- a/internal/cli/replay_checkpoint.go
+++ b/internal/cli/replay_checkpoint.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+const (
+	checkpointMagic   = "XRPLCKPT"
+	checkpointVersion = uint32(1)
+)
+
+// checkpointPath returns the on-disk path for a checkpoint at the given seq.
+func checkpointPath(dir string, seq uint32) string {
+	return filepath.Join(dir, fmt.Sprintf("checkpoint_%d.dat", seq))
+}
+
+// writeCheckpoint persists the full state map and its ledger sequence to disk.
+// The write is atomic: it serializes to a temp file in the same directory and
+// renames it into place so a crash mid-write never leaves a corrupt checkpoint.
+//
+// Format: magic | version(u32) | seq(u32) | count(u64) | count*(key[32] | len(u32) | data).
+func writeCheckpoint(dir string, seq uint32, stateMap *shamap.SHAMap) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating checkpoint dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, fmt.Sprintf("checkpoint_%d_*.tmp", seq))
+	if err != nil {
+		return fmt.Errorf("creating temp checkpoint: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename succeeds
+
+	w := bufio.NewWriter(tmp)
+
+	if _, err := w.WriteString(checkpointMagic); err != nil {
+		tmp.Close()
+		return err
+	}
+	for _, v := range []any{checkpointVersion, seq, uint64(stateMap.Size())} {
+		if err := binary.Write(w, binary.BigEndian, v); err != nil {
+			tmp.Close()
+			return err
+		}
+	}
+
+	var writeErr error
+	_ = stateMap.ForEach(func(item *shamap.Item) bool {
+		key := item.Key()
+		data := item.Data()
+		if _, writeErr = w.Write(key[:]); writeErr != nil {
+			return false
+		}
+		if writeErr = binary.Write(w, binary.BigEndian, uint32(len(data))); writeErr != nil {
+			return false
+		}
+		if _, writeErr = w.Write(data); writeErr != nil {
+			return false
+		}
+		return true
+	})
+	if writeErr != nil {
+		tmp.Close()
+		return fmt.Errorf("writing checkpoint entries: %w", writeErr)
+	}
+
+	if err := w.Flush(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpName, checkpointPath(dir, seq))
+}
+
+// loadCheckpoint reconstructs the state map and ledger sequence from a
+// checkpoint written by writeCheckpoint.
+func loadCheckpoint(path string) (*shamap.SHAMap, uint32, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("opening checkpoint %s: %w", path, err)
+	}
+	defer f.Close()
+	r := bufio.NewReader(f)
+
+	magic := make([]byte, len(checkpointMagic))
+	if _, err := io.ReadFull(r, magic); err != nil {
+		return nil, 0, fmt.Errorf("reading checkpoint magic: %w", err)
+	}
+	if string(magic) != checkpointMagic {
+		return nil, 0, fmt.Errorf("invalid checkpoint magic in %s", path)
+	}
+
+	var version, seq uint32
+	var count uint64
+	if err := binary.Read(r, binary.BigEndian, &version); err != nil {
+		return nil, 0, fmt.Errorf("reading checkpoint version: %w", err)
+	}
+	if version != checkpointVersion {
+		return nil, 0, fmt.Errorf("unsupported checkpoint version %d in %s", version, path)
+	}
+	if err := binary.Read(r, binary.BigEndian, &seq); err != nil {
+		return nil, 0, fmt.Errorf("reading checkpoint seq: %w", err)
+	}
+	if err := binary.Read(r, binary.BigEndian, &count); err != nil {
+		return nil, 0, fmt.Errorf("reading checkpoint count: %w", err)
+	}
+
+	stateMap, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		return nil, 0, fmt.Errorf("creating state map: %w", err)
+	}
+
+	for i := uint64(0); i < count; i++ {
+		var key [32]byte
+		if _, err := io.ReadFull(r, key[:]); err != nil {
+			return nil, 0, fmt.Errorf("reading entry %d key: %w", i, err)
+		}
+		var dataLen uint32
+		if err := binary.Read(r, binary.BigEndian, &dataLen); err != nil {
+			return nil, 0, fmt.Errorf("reading entry %d length: %w", i, err)
+		}
+		data := make([]byte, dataLen)
+		if _, err := io.ReadFull(r, data); err != nil {
+			return nil, 0, fmt.Errorf("reading entry %d data: %w", i, err)
+		}
+		if err := stateMap.Put(key, data); err != nil {
+			return nil, 0, fmt.Errorf("injecting entry %d: %w", i, err)
+		}
+	}
+
+	return stateMap, seq, nil
+}

--- a/internal/cli/replay_range.go
+++ b/internal/cli/replay_range.go
@@ -18,17 +18,21 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/statecompare"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/spf13/cobra"
 )
 
 var (
-	replayRangeFrom    uint32
-	replayRangeTo      uint32
-	replayRangeDumpDir string
-	replayRangeVerbose bool
-	replayRangeDecoded bool
+	replayRangeFrom               uint32
+	replayRangeTo                 uint32
+	replayRangeDumpDir            string
+	replayRangeVerbose            bool
+	replayRangeDecoded            bool
+	replayRangeCheckpointDir      string
+	replayRangeCheckpointInterval uint32
+	replayRangeResumeFrom         uint32
 )
 
 // replayRangeCmd represents the replay-range command
@@ -49,6 +53,16 @@ At each block, it verifies:
 
 On any mismatch, it stops immediately and dumps debug information.
 
+The active amendment set is loaded from the Amendments ledger entry in the
+seed state and evolves automatically as flag-ledger EnableAmendment
+pseudo-transactions are applied, so modern (post-amendment) ranges replay
+correctly. The seed state's tree root is verified against the known
+account_hash before replay starts, so an incomplete or corrupt import fails
+fast instead of looking like an execution bug at from+1.
+
+Long runs can be checkpointed to disk (--checkpoint-dir) and resumed
+(--resume-from) so a crash or stop does not force a restart from --from.
+
 Database configuration is read from environment variables:
 - POSTGRES_HOST (default: localhost)
 - POSTGRES_PORT (default: 5432)
@@ -59,7 +73,9 @@ Database configuration is read from environment variables:
 Example:
     xrpld replay-range --from 32750 --to 32800
     xrpld replay-range --from 32750 --to 32800 -v
-    xrpld replay-range --from 32750 --to 32800 --dump-dir ./debug`,
+    xrpld replay-range --from 32750 --to 32800 --dump-dir ./debug
+    xrpld replay-range --from 99226370 --to 99236370 --checkpoint-dir ./ckpt
+    xrpld replay-range --from 99226370 --to 99236370 --checkpoint-dir ./ckpt --resume-from 99230000`,
 	Run: runReplayRange,
 }
 
@@ -71,6 +87,9 @@ func init() {
 	replayRangeCmd.Flags().StringVar(&replayRangeDumpDir, "dump-dir", "", "Directory for debug output on failure")
 	replayRangeCmd.Flags().BoolVarP(&replayRangeVerbose, "verbose", "v", false, "Verbose output")
 	replayRangeCmd.Flags().BoolVar(&replayRangeDecoded, "decoded", false, "Show decoded JSON for entries")
+	replayRangeCmd.Flags().StringVar(&replayRangeCheckpointDir, "checkpoint-dir", "", "Directory for periodic state checkpoints (enables checkpoint/resume)")
+	replayRangeCmd.Flags().Uint32Var(&replayRangeCheckpointInterval, "checkpoint-interval", 10000, "Write a checkpoint every N ledgers (requires --checkpoint-dir)")
+	replayRangeCmd.Flags().Uint32Var(&replayRangeResumeFrom, "resume-from", 0, "Resume from the checkpoint at this ledger seq (requires --checkpoint-dir)")
 
 	replayRangeCmd.MarkFlagRequired("from")
 	replayRangeCmd.MarkFlagRequired("to")
@@ -90,6 +109,21 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 	if replayRangeFrom >= replayRangeTo {
 		fmt.Fprintf(os.Stderr, "ERROR: --from must be less than --to\n")
 		os.Exit(1)
+	}
+
+	// Effective starting point. With --resume-from we seed from an on-disk
+	// checkpoint at that seq instead of loading the full state at --from.
+	startLedger := replayRangeFrom
+	if replayRangeResumeFrom > 0 {
+		if replayRangeCheckpointDir == "" {
+			fmt.Fprintf(os.Stderr, "ERROR: --resume-from requires --checkpoint-dir\n")
+			os.Exit(1)
+		}
+		if replayRangeResumeFrom <= replayRangeFrom || replayRangeResumeFrom >= replayRangeTo {
+			fmt.Fprintf(os.Stderr, "ERROR: --resume-from must be within (%d, %d)\n", replayRangeFrom, replayRangeTo)
+			os.Exit(1)
+		}
+		startLedger = replayRangeResumeFrom
 	}
 
 	ctx := context.Background()
@@ -114,28 +148,40 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 
 	// Validate range exists
 	fmt.Println("[2/3] Validating ledger range...")
-	valid, missingLedger, err := client.ValidateRange(ctx, replayRangeFrom, replayRangeTo)
+	valid, missingLedger, err := client.ValidateRange(ctx, startLedger, replayRangeTo)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: Failed to validate range: %v\n", err)
 		os.Exit(1)
 	}
 	if !valid {
 		fmt.Fprintf(os.Stderr, "ERROR: Ledger %d not found in database\n", missingLedger)
-		fmt.Fprintf(os.Stderr, "       Run 'python main.py sync-range %d %d' first\n", replayRangeFrom, replayRangeTo)
+		fmt.Fprintf(os.Stderr, "       Run 'python main.py sync-range %d %d' first\n", startLedger, replayRangeTo)
 		os.Exit(1)
 	}
-	fmt.Printf("      All %d ledgers present in database\n", replayRangeTo-replayRangeFrom+1)
+	fmt.Printf("      All %d ledgers present in database\n", replayRangeTo-startLedger+1)
 
-	// Load initial state
-	fmt.Printf("[3/3] Loading initial state at ledger %d...\n", replayRangeFrom)
-	stateMap, preSnapshot, fees, err := loadInitialState(ctx, client, replayRangeFrom)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: Failed to load initial state: %v\n", err)
-		os.Exit(1)
+	// Load the seed state, either from the database (--from) or from an
+	// on-disk checkpoint (--resume-from).
+	var stateMap *shamap.SHAMap
+	var preSnapshot *statecompare.LedgerSnapshot
+	var fees drops.Fees
+	if replayRangeResumeFrom > 0 {
+		fmt.Printf("[3/3] Resuming from checkpoint at ledger %d...\n", startLedger)
+		stateMap, preSnapshot, fees, err = resumeFromCheckpoint(ctx, client, replayRangeCheckpointDir, startLedger)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Failed to resume from checkpoint: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		fmt.Printf("[3/3] Loading initial state at ledger %d...\n", startLedger)
+		stateMap, preSnapshot, fees, err = loadInitialState(ctx, client, startLedger)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Failed to load initial state: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
-	stateCount, _ := client.GetStateEntryCount(ctx, replayRangeFrom)
-	fmt.Printf("      Loaded %d state entries\n", stateCount)
+	fmt.Printf("      Loaded %d state entries (root verified against account_hash)\n", stateMap.Size())
 	fmt.Println()
 
 	// Start continuous replay
@@ -146,7 +192,7 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 	currentStateMap := stateMap
 	previousSnapshot := preSnapshot
 
-	for targetLedger := replayRangeFrom + 1; targetLedger <= replayRangeTo; targetLedger++ {
+	for targetLedger := startLedger + 1; targetLedger <= replayRangeTo; targetLedger++ {
 		blockStart := time.Now()
 
 		// Process this block
@@ -197,6 +243,16 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 
 		// Update fees from the new state (in case a SetFee transaction was processed)
 		fees = ExtractFeesFromSHAMap(currentStateMap)
+
+		// Periodically checkpoint so a crash or stop can resume mid-range.
+		if replayRangeCheckpointDir != "" && replayRangeCheckpointInterval > 0 &&
+			targetLedger%replayRangeCheckpointInterval == 0 {
+			if err := writeCheckpoint(replayRangeCheckpointDir, targetLedger, currentStateMap); err != nil {
+				fmt.Printf("      WARNING: failed to write checkpoint at %d: %v\n", targetLedger, err)
+			} else if replayRangeVerbose {
+				fmt.Printf("      checkpoint written at ledger %d\n", targetLedger)
+			}
+		}
 	}
 
 	stats.TotalDuration = time.Since(startTime)
@@ -255,10 +311,77 @@ func loadInitialState(ctx context.Context, client *statecompare.Client, ledgerIn
 		}
 	}
 
+	// Verify the imported tree root against the known account_hash. The SHAMap
+	// root is a Merkle commitment over the whole state, so a match proves the
+	// import is complete and correct; a mismatch means a partial or corrupt
+	// seed and is failed fast so it is not misread as an execution bug at
+	// from+1.
+	if err := verifyStateRoot(stateMap, snapshot.AccountHash, ledgerIndex); err != nil {
+		return nil, nil, drops.Fees{}, err
+	}
+
 	// Extract fees from state (use defaults if not found)
 	fees := ExtractFeesFromState(entries)
 
 	return stateMap, snapshot, fees, nil
+}
+
+// verifyStateRoot fails if the state map's tree root does not match the
+// expected account_hash for the given ledger.
+func verifyStateRoot(stateMap *shamap.SHAMap, expected [32]byte, ledgerIndex uint32) error {
+	root, err := stateMap.Hash()
+	if err != nil {
+		return fmt.Errorf("computing state root hash: %w", err)
+	}
+	if root != expected {
+		return fmt.Errorf("seed state account_hash mismatch at ledger %d: imported root %s != expected %s (incomplete or corrupt state import)",
+			ledgerIndex, hex.EncodeToString(root[:]), hex.EncodeToString(expected[:]))
+	}
+	return nil
+}
+
+// resumeFromCheckpoint loads the seed state from an on-disk checkpoint at seq,
+// validates its root against the known account_hash, and returns the snapshot
+// and fees needed to continue replay from seq+1.
+func resumeFromCheckpoint(ctx context.Context, client *statecompare.Client, dir string, seq uint32) (*shamap.SHAMap, *statecompare.LedgerSnapshot, drops.Fees, error) {
+	path := checkpointPath(dir, seq)
+	stateMap, ckptSeq, err := loadCheckpoint(path)
+	if err != nil {
+		return nil, nil, drops.Fees{}, err
+	}
+	if ckptSeq != seq {
+		return nil, nil, drops.Fees{}, fmt.Errorf("checkpoint %s holds ledger %d, expected %d", path, ckptSeq, seq)
+	}
+
+	snapshot, err := client.GetSnapshot(ctx, seq)
+	if err != nil {
+		return nil, nil, drops.Fees{}, fmt.Errorf("getting snapshot: %w", err)
+	}
+
+	if err := verifyStateRoot(stateMap, snapshot.AccountHash, seq); err != nil {
+		return nil, nil, drops.Fees{}, err
+	}
+
+	fees := ExtractFeesFromSHAMap(stateMap)
+	return stateMap, snapshot, fees, nil
+}
+
+// loadRulesFromState builds the amendment Rules from the Amendments singleton
+// entry in the given state map. An absent entry means no amendments are
+// enabled (pre-amendment / genesis ledgers), which yields EmptyRules().
+func loadRulesFromState(stateMap *shamap.SHAMap) (*amendment.Rules, error) {
+	item, found, err := stateMap.Get(keylet.Amendments().Key)
+	if err != nil {
+		return nil, fmt.Errorf("reading amendments entry: %w", err)
+	}
+	if !found || item == nil {
+		return amendment.EmptyRules(), nil
+	}
+	rules, err := ledger.LoadAmendmentsFromLedgerEntry(item.Data())
+	if err != nil {
+		return nil, fmt.Errorf("parsing amendments entry: %w", err)
+	}
+	return rules, nil
 }
 
 func ExtractFeesFromState(entries []statecompare.StateEntry) drops.Fees {
@@ -442,10 +565,17 @@ func processBlock(
 	// Create open ledger with current state
 	openLedger := ledger.NewOpenWithHeader(ledgerHeader, preStateMap, txMap, fees)
 
+	// Derive the active amendment set from the parent (pre) state's Amendments
+	// entry, mirroring rippled, where a ledger's rules come from its parent.
+	// Flag-ledger EnableAmendment pseudo-transactions applied in this block
+	// update the Amendments entry in the post state, so the rule set evolves
+	// automatically as the range advances.
+	rules, err := loadRulesFromState(preStateMap)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading amendments: %w", err)
+	}
+
 	// Setup engine
-	// TODO: Load amendments from the Amendments ledger entry in the state.
-	// For now, use EmptyRules() which is correct for early historical ledgers
-	// before amendments were enabled on mainnet.
 	engineConfig := tx.EngineConfig{
 		BaseFee:                   uint64(fees.Base),
 		ReserveBase:               uint64(fees.Reserve),
@@ -453,7 +583,7 @@ func processBlock(
 		LedgerSequence:            targetLedger,
 		SkipSignatureVerification: true,
 		Standalone:                true,
-		Rules:                     amendment.EmptyRules(),
+		Rules:                     rules,
 	}
 
 	engine := tx.NewEngine(openLedger, engineConfig)

--- a/internal/cli/replay_range.go
+++ b/internal/cli/replay_range.go
@@ -123,6 +123,10 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "ERROR: --resume-from must be within (%d, %d)\n", replayRangeFrom, replayRangeTo)
 			os.Exit(1)
 		}
+		if _, err := os.Stat(checkpointPath(replayRangeCheckpointDir, replayRangeResumeFrom)); err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: no checkpoint for ledger %d in %s; --resume-from must equal a ledger seq checkpointed in a prior run (a multiple of --checkpoint-interval)\n", replayRangeResumeFrom, replayRangeCheckpointDir)
+			os.Exit(1)
+		}
 		startLedger = replayRangeResumeFrom
 	}
 
@@ -318,8 +322,10 @@ func loadInitialState(ctx context.Context, client *statecompare.Client, ledgerIn
 		return nil, nil, drops.Fees{}, err
 	}
 
-	// Extract fees from state (use defaults if not found)
-	fees := ExtractFeesFromState(entries)
+	// Seed fees from the verified state. ExtractFeesFromSHAMap honors both the
+	// modern XRPFees format and the legacy FeeSettings fields, so post-amendment
+	// ranges seed the correct fees instead of silently falling back to defaults.
+	fees := ExtractFeesFromSHAMap(stateMap)
 
 	return stateMap, snapshot, fees, nil
 }
@@ -382,39 +388,9 @@ func loadRulesFromState(stateMap *shamap.SHAMap) (*amendment.Rules, error) {
 	return rules, nil
 }
 
-func ExtractFeesFromState(entries []statecompare.StateEntry) drops.Fees {
-	// FeeSettings keylet index
-	feeSettingsIndex := [32]byte{}
-	feeSettingsIndexBytes, _ := hex.DecodeString("4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A651")
-	copy(feeSettingsIndex[:], feeSettingsIndexBytes)
-
-	for _, entry := range entries {
-		if entry.Index == feeSettingsIndex {
-			// Decode the entry
-			decoded, err := binarycodec.Decode(hex.EncodeToString(entry.Data))
-			if err != nil {
-				break
-			}
-
-			fees := drops.Fees{}
-
-			if baseFee, ok := decoded["BaseFee"].(string); ok {
-				if val, err := parseHexOrDecimal(baseFee); err == nil {
-					fees.Base = drops.XRPAmount(val)
-				}
-			}
-			if reserveBase, ok := decoded["ReserveBase"].(uint32); ok {
-				fees.Reserve = drops.XRPAmount(reserveBase)
-			}
-			if reserveInc, ok := decoded["ReserveIncrement"].(uint32); ok {
-				fees.Increment = drops.XRPAmount(reserveInc)
-			}
-
-			return fees
-		}
-	}
-
-	// Return defaults
+// defaultFees is the fallback fee schedule used when a ledger has no readable
+// FeeSettings entry.
+func defaultFees() drops.Fees {
 	return drops.Fees{
 		Base:      10,
 		Reserve:   10_000_000,
@@ -433,12 +409,7 @@ func ExtractFeesFromSHAMap(stateMap *shamap.SHAMap) drops.Fees {
 	// Try to get the FeeSettings entry from the state map
 	item, found, err := stateMap.Get(feeSettingsIndex)
 	if err != nil || !found || item == nil {
-		// Return defaults if not found
-		return drops.Fees{
-			Base:      10,
-			Reserve:   10_000_000,
-			Increment: 2_000_000,
-		}
+		return defaultFees()
 	}
 
 	// Get the data from the item
@@ -447,11 +418,7 @@ func ExtractFeesFromSHAMap(stateMap *shamap.SHAMap) drops.Fees {
 	// Decode the entry
 	decoded, err := binarycodec.Decode(hex.EncodeToString(data))
 	if err != nil {
-		return drops.Fees{
-			Base:      10,
-			Reserve:   10_000_000,
-			Increment: 2_000_000,
-		}
+		return defaultFees()
 	}
 
 	fees := drops.Fees{}
@@ -487,14 +454,15 @@ func ExtractFeesFromSHAMap(stateMap *shamap.SHAMap) drops.Fees {
 	}
 
 	// Use defaults for any unset values
+	d := defaultFees()
 	if fees.Base == 0 {
-		fees.Base = 10
+		fees.Base = d.Base
 	}
 	if fees.Reserve == 0 {
-		fees.Reserve = 10_000_000
+		fees.Reserve = d.Reserve
 	}
 	if fees.Increment == 0 {
-		fees.Increment = 2_000_000
+		fees.Increment = d.Increment
 	}
 
 	return fees

--- a/internal/cli/replay_range.go
+++ b/internal/cli/replay_range.go
@@ -160,8 +160,6 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 	}
 	fmt.Printf("      All %d ledgers present in database\n", replayRangeTo-startLedger+1)
 
-	// Load the seed state, either from the database (--from) or from an
-	// on-disk checkpoint (--resume-from).
 	var stateMap *shamap.SHAMap
 	var preSnapshot *statecompare.LedgerSnapshot
 	var fees drops.Fees

--- a/internal/cli/replay_range_test.go
+++ b/internal/cli/replay_range_test.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// buildReplayStateMap creates a state SHAMap seeded with the given entries.
+func buildReplayStateMap(t *testing.T, entries map[[32]byte][]byte) *shamap.SHAMap {
+	t.Helper()
+	sm, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatalf("creating state map: %v", err)
+	}
+	for key, data := range entries {
+		if err := sm.Put(key, data); err != nil {
+			t.Fatalf("putting entry: %v", err)
+		}
+	}
+	return sm
+}
+
+// entry returns a state-entry payload of at least the SHAMap minimum item
+// size (12 bytes), filled with the given seed byte.
+func entry(seed byte) []byte {
+	b := make([]byte, 16)
+	for i := range b {
+		b[i] = seed
+	}
+	return b
+}
+
+func TestVerifyStateRoot(t *testing.T) {
+	sm := buildReplayStateMap(t, map[[32]byte][]byte{
+		{0x01}: entry(0xaa),
+		{0x02}: entry(0xcc),
+	})
+	root, err := sm.Hash()
+	if err != nil {
+		t.Fatalf("hashing: %v", err)
+	}
+
+	if err := verifyStateRoot(sm, root, 42); err != nil {
+		t.Fatalf("expected matching root to pass, got: %v", err)
+	}
+
+	var wrong [32]byte
+	wrong[0] = 0xff
+	if err := verifyStateRoot(sm, wrong, 42); err == nil {
+		t.Fatal("expected mismatched root to fail, got nil")
+	}
+}
+
+func TestLoadRulesFromState_Empty(t *testing.T) {
+	// A state with no Amendments entry yields EmptyRules().
+	sm := buildReplayStateMap(t, map[[32]byte][]byte{
+		{0x01}: entry(0xaa),
+	})
+	rules, err := loadRulesFromState(sm)
+	if err != nil {
+		t.Fatalf("loadRulesFromState: %v", err)
+	}
+	if rules.Enabled(amendment.FeatureID("Flow")) {
+		t.Fatal("expected no amendments enabled for empty state")
+	}
+}
+
+func TestLoadRulesFromState_Populated(t *testing.T) {
+	flowID := amendment.FeatureID("Flow")
+	checksID := amendment.FeatureID("Checks")
+	disabledID := amendment.FeatureID("DepositAuth")
+
+	data, err := pseudo.SerializeAmendmentsSLE(&pseudo.AmendmentsSLE{
+		Amendments: [][32]byte{flowID, checksID},
+	})
+	if err != nil {
+		t.Fatalf("serializing amendments SLE: %v", err)
+	}
+
+	sm := buildReplayStateMap(t, map[[32]byte][]byte{
+		keylet.Amendments().Key: data,
+	})
+
+	rules, err := loadRulesFromState(sm)
+	if err != nil {
+		t.Fatalf("loadRulesFromState: %v", err)
+	}
+	if !rules.Enabled(flowID) {
+		t.Error("expected Flow to be enabled")
+	}
+	if !rules.Enabled(checksID) {
+		t.Error("expected Checks to be enabled")
+	}
+	if rules.Enabled(disabledID) {
+		t.Error("expected DepositAuth to be disabled")
+	}
+}
+
+func TestCheckpointRoundTrip(t *testing.T) {
+	const seq = uint32(99230000)
+	entries := map[[32]byte][]byte{
+		{0x01}:       entry(0xaa),
+		{0x02, 0x03}: append(entry(0xde), 0x01, 0x02, 0x03),
+		{0xff}:       entry(0x00),
+	}
+	sm := buildReplayStateMap(t, entries)
+	wantRoot, err := sm.Hash()
+	if err != nil {
+		t.Fatalf("hashing: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := writeCheckpoint(dir, seq, sm); err != nil {
+		t.Fatalf("writeCheckpoint: %v", err)
+	}
+
+	loaded, gotSeq, err := loadCheckpoint(filepath.Join(dir, "checkpoint_99230000.dat"))
+	if err != nil {
+		t.Fatalf("loadCheckpoint: %v", err)
+	}
+	if gotSeq != seq {
+		t.Fatalf("seq mismatch: got %d want %d", gotSeq, seq)
+	}
+
+	gotRoot, err := loaded.Hash()
+	if err != nil {
+		t.Fatalf("hashing loaded map: %v", err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("root mismatch after round-trip: got %x want %x", gotRoot, wantRoot)
+	}
+
+	if loaded.Size() != len(entries) {
+		t.Fatalf("entry count mismatch: got %d want %d", loaded.Size(), len(entries))
+	}
+
+	// checkpointPath must agree with the file writeCheckpoint produced.
+	if got := checkpointPath(dir, seq); got != filepath.Join(dir, "checkpoint_99230000.dat") {
+		t.Fatalf("unexpected checkpoint path: %s", got)
+	}
+}
+
+func TestLoadCheckpoint_BadMagic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checkpoint_1.dat")
+	if err := os.WriteFile(path, []byte("NOTACKPTxxxxxxxx"), 0o644); err != nil {
+		t.Fatalf("seeding bad file: %v", err)
+	}
+	if _, _, err := loadCheckpoint(path); err == nil {
+		t.Fatal("expected error for bad magic, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Makes the `replay-range` mainnet state-replay harness (`internal/cli/replay_range.go`) usable for **modern (post-amendment) ranges** and practical for long runs, addressing all three items in #698.

- **Load amendments from state (the blocker).** The engine's amendment `Rules` are now derived from the parent (pre) state's `Amendments` ledger entry instead of `EmptyRules()`. This mirrors rippled, where a ledger's rules come from its parent. Flag-ledger `EnableAmendment` pseudo-transactions (already in the tx set and applied via `ApplyPseudo()`) update the `Amendments` entry in the post state, so the rule set **evolves automatically** as the range advances — the amendment's behavior takes effect the block after the flag ledger, matching rippled. No separate flag-ledger bookkeeping is needed. The old `TODO`/`EmptyRules()` is gone.
- **Seed-state account_hash gate.** `loadInitialState` now asserts the imported state tree root equals the known `account_hash(--from)` before replay starts (the SHAMap root is a Merkle commitment over the whole state). A partial/corrupt import now fails fast instead of looking like an execution bug at `from+1`. The same gate validates a resumed checkpoint.
- **Checkpoint / resume.** New `--checkpoint-dir` / `--checkpoint-interval` flags periodically persist the full state + seq to disk (atomic temp-file + rename); `--resume-from <seq>` reloads a checkpoint and continues from `seq+1`, so a crash or stop no longer forces a restart from `--from`. (Nodestore-backed checkpointing remains the efficient follow-up noted in the issue.)

## Test plan

- [x] `go build ./...` (CGO) — full module compiles
- [x] `go vet ./internal/cli/...` — clean
- [x] `go test ./internal/cli/` — passes, incl. new `replay_range_test.go`:
  - `TestLoadRulesFromState_{Empty,Populated}` — end-to-end amendments round-trip (`SerializeAmendmentsSLE` → state map → `loadRulesFromState`)
  - `TestVerifyStateRoot` — root match passes, mismatch fails
  - `TestCheckpointRoundTrip` / `TestLoadCheckpoint_BadMagic` — checkpoint serialization
- [x] `xrpld replay-range --help` renders the new flags
- Validate on a ~10k sub-range against the state DB, e.g. `xrpld replay-range --from 99226370 --to 99236370 --checkpoint-dir ./ckpt` (requires the `xrpl-state-compare` PostgreSQL DB synced for the range).

Fixes #698