### PR TITLE
feat: nodestore-lazy replay-range worker state + emit-finding-and-continue

### DIFF
--- a/internal/cli/replay_findings.go
+++ b/internal/cli/replay_findings.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	rtdebug "runtime/debug"
+)
+
+// findingSchema versions the findings record so the lab can evolve the format.
+const findingSchema = "goxrpl.replay.finding/v1"
+
+// Finding is one replay divergence, recorded in a structured, commit-tagged
+// form so the parallel fleet can survey every divergence in a single pass and
+// dedup by root cause downstream.
+type Finding struct {
+	Schema                 string            `json:"schema"`
+	GoXRPLCommit           string            `json:"goxrpl_commit"`
+	LedgerIndex            uint32            `json:"ledger_index"`
+	ParentLedgerHash       string            `json:"parent_ledger_hash"`
+	TxCount                int               `json:"tx_count"`
+	Hashes                 findingHashes     `json:"hashes"`
+	ReconstructionVerified bool              `json:"reconstruction_verified"`
+	DivergingObjects       []divergingObject `json:"diverging_objects"`
+	TxSet                  []findingTx       `json:"tx_set"`
+	Errors                 []string          `json:"errors,omitempty"`
+}
+
+type findingHashes struct {
+	LedgerGot           string `json:"ledger_got"`
+	LedgerExpected      string `json:"ledger_expected"`
+	AccountGot          string `json:"account_got"`
+	AccountExpected     string `json:"account_expected"`
+	TransactionGot      string `json:"transaction_got"`
+	TransactionExpected string `json:"transaction_expected"`
+	TotalCoinsGot       uint64 `json:"total_coins_got"`
+	TotalCoinsExpected  uint64 `json:"total_coins_expected"`
+}
+
+// divergingObject is a state object whose goXRPL value differs from mainnet's.
+// goXRPL/Mainnet hold the hex-encoded serialized SLE on each side; an empty
+// string means the object is absent on that side. Decoded carries the JSON
+// view of the mainnet object for readability.
+type divergingObject struct {
+	Index          string         `json:"index"`
+	GoXRPL         string         `json:"goxrpl,omitempty"`
+	Mainnet        string         `json:"mainnet,omitempty"`
+	GoXRPLDecoded  map[string]any `json:"goxrpl_decoded,omitempty"`
+	MainnetDecoded map[string]any `json:"mainnet_decoded,omitempty"`
+}
+
+type findingTx struct {
+	Index  int    `json:"index"`
+	Hash   string `json:"hash"`
+	Type   string `json:"type,omitempty"`
+	Result string `json:"result,omitempty"`
+}
+
+// findingsWriter appends Findings to a file as JSON Lines (one record per
+// line), so a long-running survey streams findings without buffering them all.
+type findingsWriter struct {
+	f   *os.File
+	enc *json.Encoder
+}
+
+func newFindingsWriter(path string) (*findingsWriter, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening findings file %s: %w", path, err)
+	}
+	return &findingsWriter{f: f, enc: json.NewEncoder(f)}, nil
+}
+
+func (w *findingsWriter) Write(finding *Finding) error {
+	return w.enc.Encode(finding)
+}
+
+func (w *findingsWriter) Close() error {
+	return w.f.Close()
+}
+
+// goxrplCommit resolves the commit tag stamped onto every finding so a run and
+// its findings are reproducible against a specific build. An explicit override
+// wins; otherwise it reads the VCS revision embedded by the Go toolchain.
+func goxrplCommit(override string) string {
+	if override != "" {
+		return override
+	}
+	if info, ok := rtdebug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				rev := setting.Value
+				if len(rev) > 12 {
+					rev = rev[:12]
+				}
+				return rev
+			}
+		}
+	}
+	return "unknown"
+}
+
+// buildFinding assembles a Finding from a divergent block result and the
+// reconstructed mainnet post-state. diverging holds the exact set of objects
+// that differ between goXRPL's post-state and mainnet's.
+func buildFinding(commit string, ledgerIndex uint32, parentHash [32]byte, result *BlockResult, reconstructionVerified bool, diverging []divergingObject) *Finding {
+	hexOf := func(b [32]byte) string { return hex.EncodeToString(b[:]) }
+
+	txSet := make([]findingTx, 0, len(result.TxResults))
+	for _, t := range result.TxResults {
+		txSet = append(txSet, findingTx{
+			Index:  t.Index,
+			Hash:   t.Hash,
+			Type:   t.TxType,
+			Result: t.Result,
+		})
+	}
+
+	return &Finding{
+		Schema:           findingSchema,
+		GoXRPLCommit:     commit,
+		LedgerIndex:      ledgerIndex,
+		ParentLedgerHash: hexOf(parentHash),
+		TxCount:          result.TxCount,
+		Hashes: findingHashes{
+			LedgerGot:           hexOf(result.LedgerHash),
+			LedgerExpected:      hexOf(result.ExpectedLedgerHash),
+			AccountGot:          hexOf(result.AccountHash),
+			AccountExpected:     hexOf(result.ExpectedAccountHash),
+			TransactionGot:      hexOf(result.TransactionHash),
+			TransactionExpected: hexOf(result.ExpectedTransactionHash),
+			TotalCoinsGot:       result.TotalCoins,
+			TotalCoinsExpected:  result.ExpectedTotalCoins,
+		},
+		ReconstructionVerified: reconstructionVerified,
+		DivergingObjects:       diverging,
+		TxSet:                  txSet,
+		Errors:                 result.Errors,
+	}
+}

--- a/internal/cli/replay_findings_test.go
+++ b/internal/cli/replay_findings_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindingsWriter_JSONL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "findings.jsonl")
+	w, err := newFindingsWriter(path)
+	if err != nil {
+		t.Fatalf("newFindingsWriter: %v", err)
+	}
+
+	result := &BlockResult{
+		TxCount:             2,
+		ExpectedLedgerHash:  [32]byte{0xDE, 0xAD},
+		ExpectedAccountHash: [32]byte{0xBE, 0xEF},
+		AccountHash:         [32]byte{0x12},
+		TotalCoins:          99,
+		ExpectedTotalCoins:  100,
+		TxResults: []TxApplyInfo{
+			{Index: 0, Hash: "abc", TxType: "Payment", Result: "tesSUCCESS"},
+		},
+	}
+	diverging := []divergingObject{{Index: "00ff", GoXRPL: "aa", Mainnet: "bb"}}
+
+	var parent [32]byte
+	parent[0] = 0x77
+	f1 := buildFinding("deadbeef0001", 100, parent, result, true, diverging)
+	f2 := buildFinding("deadbeef0001", 200, parent, result, false, nil)
+	if err := w.Write(f1); err != nil {
+		t.Fatalf("write f1: %v", err)
+	}
+	if err := w.Write(f2); err != nil {
+		t.Fatalf("write f2: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer file.Close()
+
+	var lines int
+	scanner := bufio.NewScanner(file)
+	var first Finding
+	for scanner.Scan() {
+		var fd Finding
+		if err := json.Unmarshal(scanner.Bytes(), &fd); err != nil {
+			t.Fatalf("line %d not valid JSON: %v", lines, err)
+		}
+		if lines == 0 {
+			first = fd
+		}
+		lines++
+	}
+	if lines != 2 {
+		t.Fatalf("expected 2 JSONL lines, got %d", lines)
+	}
+	if first.Schema != findingSchema {
+		t.Fatalf("schema = %q, want %q", first.Schema, findingSchema)
+	}
+	if first.LedgerIndex != 100 || !first.ReconstructionVerified {
+		t.Fatalf("unexpected first finding: %+v", first)
+	}
+	if len(first.DivergingObjects) != 1 || first.DivergingObjects[0].Index != "00ff" {
+		t.Fatalf("diverging objects not recorded: %+v", first.DivergingObjects)
+	}
+	// account_expected is hex of [32]byte{0xBE,0xEF}: "beef" then zeros.
+	if len(first.Hashes.AccountExpected) != 64 || first.Hashes.AccountExpected[:4] != "beef" {
+		t.Fatalf("account_expected hex wrong: %s", first.Hashes.AccountExpected)
+	}
+}
+
+func TestGoxrplCommit_Override(t *testing.T) {
+	if got := goxrplCommit("my-tag"); got != "my-tag" {
+		t.Fatalf("override ignored: %q", got)
+	}
+	// Without an override the value is build-info dependent; it must at least
+	// be non-empty so findings are always tagged.
+	if got := goxrplCommit(""); got == "" {
+		t.Fatal("commit tag is empty")
+	}
+}

--- a/internal/cli/replay_range.go
+++ b/internal/cli/replay_range.go
@@ -25,14 +25,18 @@ import (
 )
 
 var (
-	replayRangeFrom               uint32
-	replayRangeTo                 uint32
-	replayRangeDumpDir            string
-	replayRangeVerbose            bool
-	replayRangeDecoded            bool
-	replayRangeCheckpointDir      string
-	replayRangeCheckpointInterval uint32
-	replayRangeResumeFrom         uint32
+	replayRangeFrom                 uint32
+	replayRangeTo                   uint32
+	replayRangeDumpDir              string
+	replayRangeVerbose              bool
+	replayRangeDecoded              bool
+	replayRangeCheckpointDir        string
+	replayRangeCheckpointInterval   uint32
+	replayRangeResumeFrom           uint32
+	replayRangeNodestoreDir         string
+	replayRangeContinueOnDivergence bool
+	replayRangeFindingsOut          string
+	replayRangeGoXRPLCommit         string
 )
 
 // replayRangeCmd represents the replay-range command
@@ -51,7 +55,8 @@ At each block, it verifies:
 - account_hash (state tree root)
 - transaction_hash (tx tree root)
 
-On any mismatch, it stops immediately and dumps debug information.
+On any mismatch, it stops immediately and dumps debug information, unless
+--continue-on-divergence is set (see below).
 
 The active amendment set is loaded from the Amendments ledger entry in the
 seed state and evolves automatically as flag-ledger EnableAmendment
@@ -59,6 +64,19 @@ pseudo-transactions are applied, so modern (post-amendment) ranges replay
 correctly. The seed state's tree root is verified against the known
 account_hash before replay starts, so an incomplete or corrupt import fails
 fast instead of looking like an execution bug at from+1.
+
+By default the whole state tree is held in RAM (~6-12 GB for a mainnet
+checkpoint). With --nodestore-dir the seed state is instead held lazily in a
+node-local pebble nodestore: a shared read-only base built once per checkpoint
+plus a per-run copy-on-write overlay for the segment's mutations. Re-seeding
+the same checkpoint then opens the nodestore instead of rebuilding the tree.
+
+With --continue-on-divergence the worker does not stop at the first hash
+mismatch: it records a structured, commit-tagged finding (--findings-out),
+resets to mainnet's ground-truth post-state reconstructed from the ledger's
+transaction metadata, and continues — so one pass surveys every divergence in
+the range. The reset is gated on the reconstructed state's account_hash, so
+replay only continues from a byte-exact state.
 
 Long runs can be checkpointed to disk (--checkpoint-dir) and resumed
 (--resume-from) so a crash or stop does not force a restart from --from.
@@ -90,6 +108,10 @@ func init() {
 	replayRangeCmd.Flags().StringVar(&replayRangeCheckpointDir, "checkpoint-dir", "", "Directory for periodic state checkpoints (enables checkpoint/resume)")
 	replayRangeCmd.Flags().Uint32Var(&replayRangeCheckpointInterval, "checkpoint-interval", 10000, "Write a checkpoint every N ledgers (requires --checkpoint-dir)")
 	replayRangeCmd.Flags().Uint32Var(&replayRangeResumeFrom, "resume-from", 0, "Resume from the checkpoint at this ledger seq (requires --checkpoint-dir)")
+	replayRangeCmd.Flags().StringVar(&replayRangeNodestoreDir, "nodestore-dir", "", "Node-local directory for the lazy pebble nodestore (shared read-only checkpoint base + per-run overlay). When set, seed state is held lazily instead of fully in RAM.")
+	replayRangeCmd.Flags().BoolVar(&replayRangeContinueOnDivergence, "continue-on-divergence", false, "On a hash mismatch, record a finding and reset to mainnet ground truth, then continue (survey all divergences) instead of stopping")
+	replayRangeCmd.Flags().StringVar(&replayRangeFindingsOut, "findings-out", "", "Path to the findings JSONL file (default <dump-dir>/findings.jsonl or ./debug/findings.jsonl); used with --continue-on-divergence")
+	replayRangeCmd.Flags().StringVar(&replayRangeGoXRPLCommit, "goxrpl-commit", "", "Commit/image tag recorded in findings (default: VCS revision from build info)")
 
 	replayRangeCmd.MarkFlagRequired("from")
 	replayRangeCmd.MarkFlagRequired("to")
@@ -100,6 +122,7 @@ type RangeReplayStats struct {
 	BlocksProcessed   int
 	BlocksSuccessful  int
 	TotalTransactions int
+	Divergences       int
 	TotalDuration     time.Duration
 	FailedAtBlock     uint32
 	FailureReason     string
@@ -164,10 +187,29 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 	}
 	fmt.Printf("      All %d ledgers present in database\n", replayRangeTo-startLedger+1)
 
+	source, err := newStateSource(client, replayRangeNodestoreDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to initialize state source: %v\n", err)
+		os.Exit(1)
+	}
+	defer source.Close()
+
+	var findings *findingsWriter
+	if replayRangeContinueOnDivergence {
+		findings, err = newFindingsWriter(findingsPath())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Failed to open findings file: %v\n", err)
+			os.Exit(1)
+		}
+		defer findings.Close()
+	}
+
 	var stateMap *shamap.SHAMap
 	var preSnapshot *statecompare.LedgerSnapshot
 	var fees drops.Fees
 	if replayRangeResumeFrom > 0 {
+		// Checkpoint-file resume seeds from goXRPL's own computed state, which
+		// is held in RAM; nodestore-lazy seeding applies to fresh --from loads.
 		fmt.Printf("[3/3] Resuming from checkpoint at ledger %d...\n", startLedger)
 		stateMap, preSnapshot, fees, err = resumeFromCheckpoint(ctx, client, replayRangeCheckpointDir, startLedger)
 		if err != nil {
@@ -176,14 +218,14 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 		}
 	} else {
 		fmt.Printf("[3/3] Loading initial state at ledger %d...\n", startLedger)
-		stateMap, preSnapshot, fees, err = loadInitialState(ctx, client, startLedger)
+		stateMap, preSnapshot, fees, err = source.Load(ctx, startLedger)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Failed to load initial state: %v\n", err)
 			os.Exit(1)
 		}
 	}
 
-	fmt.Printf("      Loaded %d state entries (root verified against account_hash)\n", stateMap.Size())
+	fmt.Printf("      Loaded seed state at ledger %d (root verified against account_hash)\n", startLedger)
 	fmt.Println()
 
 	// Start continuous replay
@@ -191,6 +233,7 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 	fmt.Println()
 
 	stats := &RangeReplayStats{}
+	commit := goxrplCommit(replayRangeGoXRPLCommit)
 	currentStateMap := stateMap
 	previousSnapshot := preSnapshot
 
@@ -212,15 +255,38 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 
 		// Check hashes
 		if !result.Success {
+			fmt.Printf("[%d] %3d txs | FAIL | %v\n", targetLedger, result.TxCount, blockDuration.Round(time.Millisecond))
+
+			if replayRangeContinueOnDivergence {
+				resumed, err := recordDivergenceAndReset(ctx, client, findings, commit, targetLedger, previousSnapshot.LedgerHash, result, currentStateMap, newStateMap)
+				if err != nil {
+					stats.FailedAtBlock = targetLedger
+					stats.FailureReason = err.Error()
+					fmt.Printf("[%d] ERROR recording divergence: %v\n", targetLedger, err)
+					break
+				}
+				stats.Divergences++
+				if resumed == nil {
+					// The ground-truth reconstruction did not match mainnet's
+					// account_hash, so continuing would build on a corrupt
+					// state; stop with the finding already recorded.
+					stats.FailedAtBlock = targetLedger
+					stats.FailureReason = "divergence; mainnet ground-truth reconstruction did not match account_hash, cannot continue"
+					fmt.Printf("[%d] divergence recorded; cannot reconstruct mainnet state, stopping\n", targetLedger)
+					break
+				}
+				fmt.Printf("[%d] divergence recorded; reset to mainnet ground truth, continuing\n", targetLedger)
+				currentStateMap = resumed
+				previousSnapshot = result.PostSnapshot
+				fees = ExtractFeesFromSHAMap(currentStateMap)
+				maybeCheckpoint(targetLedger, currentStateMap)
+				continue
+			}
+
 			stats.FailedAtBlock = targetLedger
 			stats.FailureReason = "hash mismatch"
-
-			fmt.Printf("[%d] %3d txs | FAIL | %v\n", targetLedger, result.TxCount, blockDuration.Round(time.Millisecond))
 			fmt.Println()
-
-			// Dump debug info
-			dumpRangeDebugInfo(targetLedger, result, currentStateMap)
-
+			dumpRangeDebugInfo(targetLedger, result, currentStateMap, newStateMap)
 			printRangeFailure(targetLedger, result)
 			break
 		}
@@ -247,14 +313,7 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 		fees = ExtractFeesFromSHAMap(currentStateMap)
 
 		// Periodically checkpoint so a crash or stop can resume mid-range.
-		if replayRangeCheckpointDir != "" && replayRangeCheckpointInterval > 0 &&
-			targetLedger%replayRangeCheckpointInterval == 0 {
-			if err := writeCheckpoint(replayRangeCheckpointDir, targetLedger, currentStateMap); err != nil {
-				fmt.Printf("      WARNING: failed to write checkpoint at %d: %v\n", targetLedger, err)
-			} else if replayRangeVerbose {
-				fmt.Printf("      checkpoint written at ledger %d\n", targetLedger)
-			}
-		}
+		maybeCheckpoint(targetLedger, currentStateMap)
 	}
 
 	stats.TotalDuration = time.Since(startTime)
@@ -266,6 +325,65 @@ func runReplayRange(cmd *cobra.Command, args []string) {
 	if stats.FailedAtBlock > 0 {
 		os.Exit(1)
 	}
+}
+
+// maybeCheckpoint writes a checkpoint when checkpointing is enabled and the
+// ledger seq lands on the configured interval.
+func maybeCheckpoint(seq uint32, stateMap *shamap.SHAMap) {
+	if replayRangeCheckpointDir == "" || replayRangeCheckpointInterval == 0 ||
+		seq%replayRangeCheckpointInterval != 0 {
+		return
+	}
+	if err := writeCheckpoint(replayRangeCheckpointDir, seq, stateMap); err != nil {
+		fmt.Printf("      WARNING: failed to write checkpoint at %d: %v\n", seq, err)
+	} else if replayRangeVerbose {
+		fmt.Printf("      checkpoint written at ledger %d\n", seq)
+	}
+}
+
+// findingsPath resolves where divergence findings are written: an explicit
+// --findings-out, else findings.jsonl under the dump dir (or ./debug).
+func findingsPath() string {
+	if replayRangeFindingsOut != "" {
+		return replayRangeFindingsOut
+	}
+	dir := replayRangeDumpDir
+	if dir == "" {
+		dir = "./debug"
+	}
+	_ = os.MkdirAll(dir, 0o755)
+	return filepath.Join(dir, "findings.jsonl")
+}
+
+// recordDivergenceAndReset writes a finding for a divergent block and returns
+// the mainnet ground-truth post-state to continue from, or nil when that state
+// could not be reconstructed byte-exactly (in which case replay must stop).
+func recordDivergenceAndReset(
+	ctx context.Context,
+	client *statecompare.Client,
+	findings *findingsWriter,
+	commit string,
+	ledgerIndex uint32,
+	parentHash [32]byte,
+	result *BlockResult,
+	preState, goxrplPost *shamap.SHAMap,
+) (*shamap.SHAMap, error) {
+	corrected, verified, err := reconstructMainnetState(ctx, client, preState, ledgerIndex, result.ExpectedAccountHash)
+	if err != nil {
+		return nil, fmt.Errorf("reconstructing mainnet state: %w", err)
+	}
+	diverging, err := divergingObjects(goxrplPost, corrected)
+	if err != nil {
+		return nil, fmt.Errorf("computing diverging objects: %w", err)
+	}
+	finding := buildFinding(commit, ledgerIndex, parentHash, result, verified, diverging)
+	if err := findings.Write(finding); err != nil {
+		return nil, fmt.Errorf("writing finding: %w", err)
+	}
+	if !verified {
+		return nil, nil
+	}
+	return corrected, nil
 }
 
 // BlockResult holds the result of processing a single block
@@ -281,8 +399,6 @@ type BlockResult struct {
 	ExpectedTransactionHash [32]byte
 	ExpectedTotalCoins      uint64
 	PostSnapshot            *statecompare.LedgerSnapshot
-	PostState               map[string][]byte
-	PreState                map[string][]byte
 	TxResults               []TxApplyInfo
 	Errors                  []string
 }
@@ -477,18 +593,9 @@ func processBlock(
 	fees drops.Fees,
 ) (*BlockResult, *shamap.SHAMap, error) {
 	result := &BlockResult{
-		PostState: make(map[string][]byte),
-		PreState:  make(map[string][]byte),
 		TxResults: make([]TxApplyInfo, 0),
 		Errors:    make([]string, 0),
 	}
-
-	// Capture pre-state for debugging
-	_ = preStateMap.ForEach(func(item *shamap.Item) bool {
-		key := item.Key()
-		result.PreState[hex.EncodeToString(key[:])] = item.Data()
-		return true
-	})
 
 	// Get expected values for this ledger
 	postSnapshot, err := client.GetSnapshot(ctx, targetLedger)
@@ -629,12 +736,6 @@ func processBlock(
 	result.TransactionHash, _ = openLedger.TxMapHash()
 	result.TotalCoins = openLedger.TotalDrops()
 
-	// Capture post-state
-	_ = openLedger.ForEach(func(key [32]byte, data []byte) bool {
-		result.PostState[hex.EncodeToString(key[:])] = data
-		return true
-	})
-
 	// Check all three hashes
 	ledgerHashMatch := result.LedgerHash == result.ExpectedLedgerHash
 	accountHashMatch := result.AccountHash == result.ExpectedAccountHash
@@ -651,7 +752,7 @@ func processBlock(
 	return result, newStateMap, nil
 }
 
-func dumpRangeDebugInfo(ledgerIndex uint32, result *BlockResult, preStateMap *shamap.SHAMap) {
+func dumpRangeDebugInfo(ledgerIndex uint32, result *BlockResult, preStateMap, postStateMap *shamap.SHAMap) {
 	dir := replayRangeDumpDir
 	if dir == "" {
 		dir = fmt.Sprintf("./debug/ledger_%d", ledgerIndex)
@@ -666,18 +767,30 @@ func dumpRangeDebugInfo(ledgerIndex uint32, result *BlockResult, preStateMap *sh
 		return
 	}
 
+	// Materializing a nodestore-lazy map would walk millions of nodes; skip
+	// the full state/diff dump and rely on --continue-on-divergence for
+	// targeted, object-level findings instead.
+	if preStateMap.IsBacked() || postStateMap.IsBacked() {
+		fmt.Printf("  Skipping full state/diff dump for nodestore-lazy state; use --continue-on-divergence for object-level findings\n")
+		dumpTxResults(dir, result)
+		return
+	}
+
+	preState := materializeState(preStateMap)
+	postState := materializeState(postStateMap)
+
 	// Dump post-state
 	postStateFile := filepath.Join(dir, "post_state.json")
 	postStateData := make([]map[string]interface{}, 0)
 
-	keys := make([]string, 0, len(result.PostState))
-	for k := range result.PostState {
+	keys := make([]string, 0, len(postState))
+	for k := range postState {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		data := result.PostState[key]
+		data := postState[key]
 		dataHex := hex.EncodeToString(data)
 
 		entry := map[string]interface{}{
@@ -706,13 +819,13 @@ func dumpRangeDebugInfo(ledgerIndex uint32, result *BlockResult, preStateMap *sh
 
 	// Build pre-state map for comparison
 	preStateKeys := make(map[string]string)
-	for key, data := range result.PreState {
+	for key, data := range preState {
 		preStateKeys[strings.ToLower(key)] = hex.EncodeToString(data)
 	}
 
 	for _, key := range keys {
 		keyLower := strings.ToLower(key)
-		postDataHex := hex.EncodeToString(result.PostState[key])
+		postDataHex := hex.EncodeToString(postState[key])
 
 		preDataHex, exists := preStateKeys[keyLower]
 		if !exists {
@@ -752,7 +865,23 @@ func dumpRangeDebugInfo(ledgerIndex uint32, result *BlockResult, preStateMap *sh
 	os.WriteFile(diffFile, diffJSON, 0644)
 	fmt.Printf("  Wrote %s\n", diffFile)
 
-	// Dump transaction results
+	dumpTxResults(dir, result)
+}
+
+// materializeState walks a state SHAMap into a key-hex -> data map. Only safe
+// for fully in-memory maps; a nodestore-lazy map would fetch the whole tree.
+func materializeState(stateMap *shamap.SHAMap) map[string][]byte {
+	out := make(map[string][]byte)
+	_ = stateMap.ForEach(func(item *shamap.Item) bool {
+		key := item.Key()
+		out[hex.EncodeToString(key[:])] = item.Data()
+		return true
+	})
+	return out
+}
+
+// dumpTxResults writes the per-transaction apply results for a block.
+func dumpTxResults(dir string, result *BlockResult) {
 	txResultsFile := filepath.Join(dir, "tx_results.json")
 	txResultsJSON, _ := json.MarshalIndent(result.TxResults, "", "  ")
 	os.WriteFile(txResultsFile, txResultsJSON, 0644)
@@ -813,12 +942,15 @@ func printRangeSummary(stats *RangeReplayStats) {
 	fmt.Println("================================================================================")
 	if stats.FailedAtBlock > 0 {
 		fmt.Printf("FAILED at block %d: %s\n", stats.FailedAtBlock, stats.FailureReason)
+	} else if stats.Divergences > 0 {
+		fmt.Printf("COMPLETED with %d divergence(s) recorded\n", stats.Divergences)
 	} else {
 		fmt.Println("SUCCESS: All blocks replayed successfully")
 	}
 	fmt.Println("================================================================================")
 	fmt.Printf("Blocks processed:    %d\n", stats.BlocksProcessed)
 	fmt.Printf("Blocks successful:   %d\n", stats.BlocksSuccessful)
+	fmt.Printf("Divergences found:   %d\n", stats.Divergences)
 	fmt.Printf("Total transactions:  %d\n", stats.TotalTransactions)
 	fmt.Printf("Total time:          %v\n", stats.TotalDuration.Round(time.Millisecond))
 	if stats.TotalDuration.Seconds() > 0 {

--- a/internal/cli/replay_reconstruct.go
+++ b/internal/cli/replay_reconstruct.go
@@ -1,0 +1,230 @@
+package cli
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/statecompare"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// reconstructMainnetState derives mainnet's exact post-transaction account
+// state for a ledger by applying the per-transaction metadata deltas to the
+// (mainnet-correct) pre-state. It returns the reconstructed map and whether its
+// root hash matches mainnet's expected account_hash.
+//
+// Transaction metadata stores deltas, not full objects (rippled emits only
+// changed/always fields per ApplyStateTable.cpp), so each ModifiedNode is
+// overlaid onto the decoded pre-object; CreatedNode/DeletedNode are applied
+// directly. The account_hash check is the gate that makes "reset to ground
+// truth and continue" safe: replay only resumes when the reconstruction is
+// byte-exact, never on a best-effort approximation.
+func reconstructMainnetState(
+	ctx context.Context,
+	client *statecompare.Client,
+	preState *shamap.SHAMap,
+	ledgerIndex uint32,
+	expectedAccountHash [32]byte,
+) (*shamap.SHAMap, bool, error) {
+	txs, err := client.GetTransactions(ctx, ledgerIndex)
+	if err != nil {
+		return nil, false, fmt.Errorf("getting transactions: %w", err)
+	}
+	metaBlobs := make([][]byte, len(txs))
+	for i, t := range txs {
+		metaBlobs[i] = t.MetaBlob
+	}
+
+	corrected, err := reconstructFromMeta(preState, metaBlobs)
+	if err != nil {
+		return nil, false, err
+	}
+
+	root, err := corrected.Hash()
+	if err != nil {
+		return nil, false, fmt.Errorf("computing reconstructed root: %w", err)
+	}
+	return corrected, root == expectedAccountHash, nil
+}
+
+// reconstructFromMeta applies an ordered list of transaction metadata blobs to
+// a copy of preState and returns the resulting state map. Blobs are the raw
+// per-transaction metadata in ledger (tx_index) order.
+func reconstructFromMeta(preState *shamap.SHAMap, metaBlobs [][]byte) (*shamap.SHAMap, error) {
+	corrected, err := preState.Snapshot(true)
+	if err != nil {
+		return nil, fmt.Errorf("snapshotting pre-state: %w", err)
+	}
+
+	for i, blob := range metaBlobs {
+		if len(blob) == 0 {
+			continue
+		}
+		meta, err := binarycodec.Decode(hex.EncodeToString(blob))
+		if err != nil {
+			return nil, fmt.Errorf("decoding metadata for tx %d: %w", i, err)
+		}
+		affected, ok := meta["AffectedNodes"].([]any)
+		if !ok {
+			continue
+		}
+		for _, node := range affected {
+			if err := applyAffectedNode(corrected, node); err != nil {
+				return nil, fmt.Errorf("applying metadata for tx %d: %w", i, err)
+			}
+		}
+	}
+	return corrected, nil
+}
+
+// applyAffectedNode applies one metadata AffectedNode (CreatedNode /
+// ModifiedNode / DeletedNode) to the state map.
+func applyAffectedNode(state *shamap.SHAMap, node any) error {
+	entry, ok := node.(map[string]any)
+	if !ok {
+		return nil
+	}
+	for kind, body := range entry {
+		fields, ok := body.(map[string]any)
+		if !ok {
+			continue
+		}
+		idxHex, _ := fields["LedgerIndex"].(string)
+		idx, err := decodeIndex(idxHex)
+		if err != nil {
+			return fmt.Errorf("bad LedgerIndex %q: %w", idxHex, err)
+		}
+
+		switch kind {
+		case "DeletedNode":
+			if err := state.Delete(idx); err != nil && !errors.Is(err, shamap.ErrItemNotFound) {
+				return fmt.Errorf("deleting %s: %w", idxHex, err)
+			}
+
+		case "CreatedNode":
+			obj := copyFields(fields["NewFields"])
+			if let, ok := fields["LedgerEntryType"]; ok {
+				obj["LedgerEntryType"] = let
+			}
+			if err := putEncoded(state, idx, obj); err != nil {
+				return fmt.Errorf("creating %s: %w", idxHex, err)
+			}
+
+		case "ModifiedNode":
+			obj, err := currentObject(state, idx, fields)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", idxHex, err)
+			}
+			final := asMap(fields["FinalFields"])
+			previous := asMap(fields["PreviousFields"])
+			// A field present in PreviousFields but absent from FinalFields
+			// was removed by the transaction.
+			for k := range previous {
+				if _, kept := final[k]; !kept {
+					delete(obj, k)
+				}
+			}
+			for k, v := range final {
+				obj[k] = v
+			}
+			if err := putEncoded(state, idx, obj); err != nil {
+				return fmt.Errorf("modifying %s: %w", idxHex, err)
+			}
+		}
+	}
+	return nil
+}
+
+// currentObject returns the decoded object at idx, or an empty object carrying
+// the AffectedNode's LedgerEntryType when the entry is not yet present.
+func currentObject(state *shamap.SHAMap, idx [32]byte, fields map[string]any) (map[string]any, error) {
+	item, found, err := state.Get(idx)
+	if err != nil {
+		return nil, err
+	}
+	if found && item != nil {
+		decoded, err := binarycodec.Decode(hex.EncodeToString(item.Data()))
+		if err != nil {
+			return nil, fmt.Errorf("decoding object: %w", err)
+		}
+		return decoded, nil
+	}
+	obj := map[string]any{}
+	if let, ok := fields["LedgerEntryType"]; ok {
+		obj["LedgerEntryType"] = let
+	}
+	return obj, nil
+}
+
+// putEncoded encodes obj to canonical SLE bytes and stores it at idx.
+func putEncoded(state *shamap.SHAMap, idx [32]byte, obj map[string]any) error {
+	encoded, err := binarycodec.Encode(obj)
+	if err != nil {
+		return fmt.Errorf("encoding object: %w", err)
+	}
+	raw, err := hex.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("decoding encoded hex: %w", err)
+	}
+	return state.Put(idx, raw)
+}
+
+// divergingObjects returns the objects that differ between goXRPL's post-state
+// and mainnet's reconstructed post-state, with both serialized sides and a
+// decoded view for readability.
+func divergingObjects(goxrpl, mainnet *shamap.SHAMap) ([]divergingObject, error) {
+	keys, err := goxrpl.FindDifference(mainnet)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]divergingObject, 0, len(keys))
+	for _, key := range keys {
+		obj := divergingObject{Index: hex.EncodeToString(key[:])}
+		if item, found, err := goxrpl.Get(key); err == nil && found && item != nil {
+			obj.GoXRPL = hex.EncodeToString(item.Data())
+			obj.GoXRPLDecoded = decodeEntryData(obj.GoXRPL)
+		}
+		if item, found, err := mainnet.Get(key); err == nil && found && item != nil {
+			obj.Mainnet = hex.EncodeToString(item.Data())
+			obj.MainnetDecoded = decodeEntryData(obj.Mainnet)
+		}
+		out = append(out, obj)
+	}
+	return out, nil
+}
+
+// decodeIndex parses a 32-byte hex ledger index.
+func decodeIndex(s string) ([32]byte, error) {
+	var idx [32]byte
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return idx, err
+	}
+	if len(b) != 32 {
+		return idx, fmt.Errorf("expected 32 bytes, got %d", len(b))
+	}
+	copy(idx[:], b)
+	return idx, nil
+}
+
+// asMap returns v as a map[string]any, or an empty map when v is absent.
+func asMap(v any) map[string]any {
+	if m, ok := v.(map[string]any); ok {
+		return m
+	}
+	return map[string]any{}
+}
+
+// copyFields returns a shallow copy of v as a map[string]any so the caller can
+// mutate it without aliasing the decoded metadata.
+func copyFields(v any) map[string]any {
+	src := asMap(v)
+	out := make(map[string]any, len(src))
+	for k, val := range src {
+		out[k] = val
+	}
+	return out
+}

--- a/internal/cli/replay_reconstruct_test.go
+++ b/internal/cli/replay_reconstruct_test.go
@@ -1,0 +1,242 @@
+package cli
+
+import (
+	"encoding/hex"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+const testAccount = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+func encodeSLE(t *testing.T, m map[string]any) []byte {
+	t.Helper()
+	h, err := binarycodec.Encode(m)
+	if err != nil {
+		t.Fatalf("encode %v: %v", m, err)
+	}
+	b, err := hex.DecodeString(h)
+	if err != nil {
+		t.Fatalf("decode hex: %v", err)
+	}
+	return b
+}
+
+func encodeMeta(t *testing.T, affected ...map[string]any) []byte {
+	t.Helper()
+	nodes := make([]any, len(affected))
+	for i, a := range affected {
+		nodes[i] = a
+	}
+	return encodeSLE(t, map[string]any{"AffectedNodes": nodes})
+}
+
+func mustIndex(t *testing.T, s string) [32]byte {
+	t.Helper()
+	idx, err := decodeIndex(s)
+	if err != nil {
+		t.Fatalf("decodeIndex %s: %v", s, err)
+	}
+	return idx
+}
+
+func stateRoot(t *testing.T, entries map[[32]byte][]byte) [32]byte {
+	t.Helper()
+	m, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatalf("shamap.New: %v", err)
+	}
+	for k, v := range entries {
+		if err := m.Put(k, v); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	root, err := m.Hash()
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	return root
+}
+
+func putAll(t *testing.T, entries map[[32]byte][]byte) *shamap.SHAMap {
+	t.Helper()
+	m, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatalf("shamap.New: %v", err)
+	}
+	for k, v := range entries {
+		if err := m.Put(k, v); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	return m
+}
+
+// TestReconstructFromMeta_ModifyWithFieldRemoval covers the hardest path: a
+// ModifiedNode whose FinalFields is a partial delta (Balance changed) and whose
+// PreviousFields names a field removed by the transaction (Domain). The
+// reconstruction must overlay the delta onto the pre-object and drop the
+// removed field, byte-for-byte.
+func TestReconstructFromMeta_ModifyWithFieldRemoval(t *testing.T) {
+	idxHex := "00000000000000000000000000000000000000000000000000000000000000AA"
+	idx := mustIndex(t, idxHex)
+
+	pre := map[string]any{
+		"LedgerEntryType": "AccountRoot",
+		"Account":         testAccount,
+		"Balance":         "1000000000",
+		"Flags":           0,
+		"OwnerCount":      0,
+		"Sequence":        1,
+		"Domain":          "6578616D706C65",
+	}
+	post := map[string]any{
+		"LedgerEntryType": "AccountRoot",
+		"Account":         testAccount,
+		"Balance":         "2000000000",
+		"Flags":           0,
+		"OwnerCount":      0,
+		"Sequence":        1,
+	}
+
+	preState := putAll(t, map[[32]byte][]byte{idx: encodeSLE(t, pre)})
+	wantRoot := stateRoot(t, map[[32]byte][]byte{idx: encodeSLE(t, post)})
+
+	meta := encodeMeta(t, map[string]any{
+		"ModifiedNode": map[string]any{
+			"LedgerEntryType": "AccountRoot",
+			"LedgerIndex":     idxHex,
+			"FinalFields":     map[string]any{"Balance": "2000000000"},
+			"PreviousFields":  map[string]any{"Balance": "1000000000", "Domain": "6578616D706C65"},
+		},
+	})
+
+	corrected, err := reconstructFromMeta(preState, [][]byte{meta})
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+	gotRoot, err := corrected.Hash()
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("reconstructed root %x != expected %x", gotRoot[:8], wantRoot[:8])
+	}
+}
+
+// TestReconstructFromMeta_CreateAndDelete covers CreatedNode (NewFields + the
+// node-level LedgerEntryType) and DeletedNode, while an untouched object must
+// be preserved verbatim.
+func TestReconstructFromMeta_CreateAndDelete(t *testing.T) {
+	idxKeep := mustIndex(t, "0000000000000000000000000000000000000000000000000000000000000001")
+	idxNew := mustIndex(t, "0000000000000000000000000000000000000000000000000000000000000002")
+	idxDel := mustIndex(t, "0000000000000000000000000000000000000000000000000000000000000003")
+
+	keep := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "AccountRoot", "Account": testAccount,
+		"Balance": "10", "Flags": 0, "OwnerCount": 0, "Sequence": 1,
+	})
+	del := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "AccountRoot", "Account": testAccount,
+		"Balance": "20", "Flags": 0, "OwnerCount": 0, "Sequence": 2,
+	})
+	newFields := map[string]any{
+		"Account": testAccount, "Balance": "30", "Flags": 0, "OwnerCount": 0, "Sequence": 3,
+	}
+	created := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "AccountRoot", "Account": testAccount,
+		"Balance": "30", "Flags": 0, "OwnerCount": 0, "Sequence": 3,
+	})
+
+	preState := putAll(t, map[[32]byte][]byte{idxKeep: keep, idxDel: del})
+	wantRoot := stateRoot(t, map[[32]byte][]byte{idxKeep: keep, idxNew: created})
+
+	meta := encodeMeta(t,
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "AccountRoot",
+			"LedgerIndex":     hex.EncodeToString(idxNew[:]),
+			"NewFields":       newFields,
+		}},
+		map[string]any{"DeletedNode": map[string]any{
+			"LedgerEntryType": "AccountRoot",
+			"LedgerIndex":     hex.EncodeToString(idxDel[:]),
+			"FinalFields":     map[string]any{"Account": testAccount, "Balance": "20"},
+		}},
+	)
+
+	corrected, err := reconstructFromMeta(preState, [][]byte{meta})
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+	gotRoot, err := corrected.Hash()
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("reconstructed root %x != expected %x", gotRoot[:8], wantRoot[:8])
+	}
+
+	if _, found, _ := corrected.Get(idxDel); found {
+		t.Fatal("deleted node still present")
+	}
+	if _, found, _ := corrected.Get(idxNew); !found {
+		t.Fatal("created node missing")
+	}
+}
+
+func TestReconstructFromMeta_EmptyMetaLeavesStateUnchanged(t *testing.T) {
+	idx := mustIndex(t, "00000000000000000000000000000000000000000000000000000000000000FF")
+	obj := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "AccountRoot", "Account": testAccount,
+		"Balance": "7", "Flags": 0, "OwnerCount": 0, "Sequence": 1,
+	})
+	preState := putAll(t, map[[32]byte][]byte{idx: obj})
+	preRoot, _ := preState.Hash()
+
+	corrected, err := reconstructFromMeta(preState, [][]byte{nil, {}})
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+	gotRoot, _ := corrected.Hash()
+	if gotRoot != preRoot {
+		t.Fatalf("empty meta changed root: %x != %x", gotRoot[:8], preRoot[:8])
+	}
+}
+
+func TestDivergingObjects(t *testing.T) {
+	idxSame := mustIndex(t, "0000000000000000000000000000000000000000000000000000000000000011")
+	idxDiff := mustIndex(t, "0000000000000000000000000000000000000000000000000000000000000012")
+	idxOnlyGo := mustIndex(t, "0000000000000000000000000000000000000000000000000000000000000013")
+
+	same := encodeSLE(t, map[string]any{"LedgerEntryType": "AccountRoot", "Account": testAccount, "Balance": "1", "Flags": 0, "OwnerCount": 0, "Sequence": 1})
+	goDiff := encodeSLE(t, map[string]any{"LedgerEntryType": "AccountRoot", "Account": testAccount, "Balance": "2", "Flags": 0, "OwnerCount": 0, "Sequence": 1})
+	mainDiff := encodeSLE(t, map[string]any{"LedgerEntryType": "AccountRoot", "Account": testAccount, "Balance": "3", "Flags": 0, "OwnerCount": 0, "Sequence": 1})
+	goOnly := encodeSLE(t, map[string]any{"LedgerEntryType": "AccountRoot", "Account": testAccount, "Balance": "4", "Flags": 0, "OwnerCount": 0, "Sequence": 1})
+
+	goxrpl := putAll(t, map[[32]byte][]byte{idxSame: same, idxDiff: goDiff, idxOnlyGo: goOnly})
+	mainnet := putAll(t, map[[32]byte][]byte{idxSame: same, idxDiff: mainDiff})
+
+	diverging, err := divergingObjects(goxrpl, mainnet)
+	if err != nil {
+		t.Fatalf("divergingObjects: %v", err)
+	}
+
+	byIndex := map[string]divergingObject{}
+	for _, d := range diverging {
+		byIndex[d.Index] = d
+	}
+	if _, ok := byIndex[hex.EncodeToString(idxSame[:])]; ok {
+		t.Fatal("identical object reported as diverging")
+	}
+
+	d, ok := byIndex[hex.EncodeToString(idxDiff[:])]
+	if !ok || d.GoXRPL == "" || d.Mainnet == "" || d.GoXRPL == d.Mainnet {
+		t.Fatalf("modified object not reported correctly: %+v", d)
+	}
+
+	d, ok = byIndex[hex.EncodeToString(idxOnlyGo[:])]
+	if !ok || d.GoXRPL == "" || d.Mainnet != "" {
+		t.Fatalf("go-only object should have empty mainnet side: %+v", d)
+	}
+}

--- a/internal/cli/replay_state_source.go
+++ b/internal/cli/replay_state_source.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/statecompare"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// StateSource loads the seed account-state SHAMap for a ledger. It exists so
+// the SHAMap's backing — fully in-memory versus nodestore-lazy — is swappable
+// without touching the replay loop, as the mainnet-replay design requires
+// ("load state behind an interface, not loadInitialState's Put loop").
+type StateSource interface {
+	// Load returns the verified seed state map for the ledger, its snapshot,
+	// and the fee schedule extracted from the state.
+	Load(ctx context.Context, ledgerIndex uint32) (*shamap.SHAMap, *statecompare.LedgerSnapshot, drops.Fees, error)
+	// Close releases any resources held by the source (pebble handles, the
+	// ephemeral overlay directory, ...).
+	Close() error
+}
+
+// memoryStateSource holds the whole state tree in the Go heap, the historical
+// replay-range behaviour. It is the default when no node store is configured.
+type memoryStateSource struct {
+	client *statecompare.Client
+}
+
+func (s *memoryStateSource) Load(ctx context.Context, ledgerIndex uint32) (*shamap.SHAMap, *statecompare.LedgerSnapshot, drops.Fees, error) {
+	return loadInitialState(ctx, s.client, ledgerIndex)
+}
+
+func (s *memoryStateSource) Close() error { return nil }
+
+// nodestoreStateSource backs the state SHAMap with a node-local pebble
+// nodestore. Each checkpoint's state is built into a durable, shared
+// read-only base store once; subsequent seeds open it lazily (no rebuild),
+// and a fresh per-run overlay captures the segment's mutations so the base
+// stays pristine and shareable.
+type nodestoreStateSource struct {
+	client     *statecompare.Client
+	dir        string
+	overlay    *shamap.NodeStoreFamily
+	overlayDir string
+	opened     []*shamap.NodeStoreFamily
+}
+
+// baseCacheMB / overlayCacheMB bound the resident node cache for the base and
+// overlay pebble stores. The base is read-heavy (the whole checkpoint); the
+// overlay only sees a segment's mutations.
+const (
+	baseCacheMB    = 1024
+	overlayCacheMB = 256
+)
+
+func newNodestoreStateSource(client *statecompare.Client, dir string) (*nodestoreStateSource, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating nodestore dir: %w", err)
+	}
+	// The overlay is ephemeral per run: a fresh directory guarantees the
+	// segment starts from the base checkpoint with no stale mutations.
+	overlayDir, err := os.MkdirTemp(dir, "overlay-")
+	if err != nil {
+		return nil, fmt.Errorf("creating overlay dir: %w", err)
+	}
+	overlay, err := shamap.NewPebbleNodeStoreFamily(overlayDir, overlayCacheMB)
+	if err != nil {
+		os.RemoveAll(overlayDir)
+		return nil, fmt.Errorf("opening overlay nodestore: %w", err)
+	}
+	return &nodestoreStateSource{
+		client:     client,
+		dir:        dir,
+		overlay:    overlay,
+		overlayDir: overlayDir,
+		opened:     []*shamap.NodeStoreFamily{overlay},
+	}, nil
+}
+
+func (s *nodestoreStateSource) Load(ctx context.Context, ledgerIndex uint32) (*shamap.SHAMap, *statecompare.LedgerSnapshot, drops.Fees, error) {
+	snapshot, err := s.client.GetSnapshot(ctx, ledgerIndex)
+	if err != nil {
+		return nil, nil, drops.Fees{}, fmt.Errorf("getting snapshot: %w", err)
+	}
+
+	basePath := filepath.Join(s.dir, fmt.Sprintf("ckpt-%d", ledgerIndex))
+	base, err := shamap.NewPebbleNodeStoreFamily(basePath, baseCacheMB)
+	if err != nil {
+		return nil, nil, drops.Fees{}, fmt.Errorf("opening base nodestore %s: %w", basePath, err)
+	}
+	s.opened = append(s.opened, base)
+
+	stateMap, err := buildOrOpenLazyState(ctx, base, s.overlay, snapshot.AccountHash, func() ([]statecompare.StateEntry, error) {
+		return s.client.GetStateEntries(ctx, ledgerIndex)
+	})
+	if err != nil {
+		return nil, nil, drops.Fees{}, err
+	}
+
+	// Targeted lookup; lazily fetches only the FeeSettings path, not the tree.
+	fees := ExtractFeesFromSHAMap(stateMap)
+	return stateMap, snapshot, fees, nil
+}
+
+func (s *nodestoreStateSource) Close() error {
+	var firstErr error
+	for _, fam := range s.opened {
+		if err := fam.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if err := os.RemoveAll(s.overlayDir); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+// buildOrOpenLazyState returns a state SHAMap whose backing is a shared
+// read-only base plus a writable overlay. If the base already holds the root
+// node for accountHash it is opened lazily with no rebuild; otherwise the tree
+// is built once from loadEntries, flushed into the base, verified against
+// accountHash, and then re-opened over the base+overlay so replay mutations
+// land only in the overlay.
+func buildOrOpenLazyState(
+	ctx context.Context,
+	base, overlay shamap.Family,
+	accountHash [32]byte,
+	loadEntries func() ([]statecompare.StateEntry, error),
+) (*shamap.SHAMap, error) {
+	// Warm path: the root node is content-addressed by accountHash, so its
+	// presence means the derived store was built and the root commitment
+	// matches. Children are verified-by-hash as they are fetched on demand.
+	root, err := base.Fetch(ctx, accountHash)
+	if err != nil {
+		return nil, fmt.Errorf("probing base nodestore: %w", err)
+	}
+	if root != nil {
+		return shamap.NewFromRootHash(shamap.TypeState, accountHash, shamap.NewOverlayFamily(base, overlay))
+	}
+
+	// Cold path: build the derived nodestore once from the raw state entries.
+	entries, err := loadEntries()
+	if err != nil {
+		return nil, fmt.Errorf("getting state entries: %w", err)
+	}
+	buildMap, err := shamap.NewBacked(shamap.TypeState, base)
+	if err != nil {
+		return nil, fmt.Errorf("creating build map: %w", err)
+	}
+
+	// Flush+release in chunks so building a ~14M-entry tree does not require
+	// holding it all in the heap at once: released subtrees are re-fetched
+	// from the base on demand.
+	const flushChunk = 100_000
+	for i, entry := range entries {
+		if err := buildMap.Put(entry.Index, entry.Data); err != nil {
+			return nil, fmt.Errorf("injecting entry: %w", err)
+		}
+		if (i+1)%flushChunk == 0 {
+			if err := flushToFamily(ctx, buildMap, base); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := flushToFamily(ctx, buildMap, base); err != nil {
+		return nil, err
+	}
+
+	// Verify-gate: the built tree root is a Merkle commitment over the whole
+	// state, so a match proves the seed is complete and correct. The hash is
+	// read from the retained root, not by re-walking the tree.
+	builtRoot, err := buildMap.Hash()
+	if err != nil {
+		return nil, fmt.Errorf("computing build root hash: %w", err)
+	}
+	if builtRoot != accountHash {
+		return nil, fmt.Errorf("seed state account_hash mismatch: built root %x != expected %x (incomplete or corrupt state import)", builtRoot[:8], accountHash[:8])
+	}
+
+	return shamap.NewFromRootHash(shamap.TypeState, accountHash, shamap.NewOverlayFamily(base, overlay))
+}
+
+// flushToFamily flushes the map's dirty nodes into fam, releasing child
+// pointers so the heap stays bounded during a cold build.
+func flushToFamily(ctx context.Context, m *shamap.SHAMap, fam shamap.Family) error {
+	batch, err := m.FlushDirty(true)
+	if err != nil {
+		return fmt.Errorf("flushing nodes: %w", err)
+	}
+	if len(batch.Entries) == 0 {
+		return nil
+	}
+	if err := fam.StoreBatch(ctx, batch.Entries); err != nil {
+		return fmt.Errorf("storing nodes: %w", err)
+	}
+	return nil
+}
+
+// newStateSource returns the nodestore-lazy source when dir is set, otherwise
+// the in-memory source.
+func newStateSource(client *statecompare.Client, nodestoreDir string) (StateSource, error) {
+	if nodestoreDir == "" {
+		return &memoryStateSource{client: client}, nil
+	}
+	return newNodestoreStateSource(client, nodestoreDir)
+}

--- a/internal/cli/replay_state_source_test.go
+++ b/internal/cli/replay_state_source_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/statecompare"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// syntheticEntries returns n state entries with distinct keys and >=12-byte
+// data, plus the account_hash they hash to (the in-memory state root).
+func syntheticEntries(t *testing.T, n int) ([]statecompare.StateEntry, [32]byte) {
+	t.Helper()
+	entries := make([]statecompare.StateEntry, n)
+	ref, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatalf("shamap.New: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		var key [32]byte
+		key[0] = byte(i)
+		key[1] = byte(i >> 8)
+		key[31] = 0xA5
+		data := make([]byte, 24)
+		for j := range data {
+			data[j] = byte(i + j)
+		}
+		entries[i] = statecompare.StateEntry{Index: key, Data: data}
+		if err := ref.Put(key, data); err != nil {
+			t.Fatalf("ref.Put: %v", err)
+		}
+	}
+	root, err := ref.Hash()
+	if err != nil {
+		t.Fatalf("ref.Hash: %v", err)
+	}
+	return entries, root
+}
+
+func TestBuildOrOpenLazyState_ColdBuildThenLazyRead(t *testing.T) {
+	ctx := context.Background()
+	entries, accountHash := syntheticEntries(t, 250)
+
+	base, err := shamap.NewMemoryNodeStoreFamily()
+	if err != nil {
+		t.Fatalf("base family: %v", err)
+	}
+	overlay, err := shamap.NewMemoryNodeStoreFamily()
+	if err != nil {
+		t.Fatalf("overlay family: %v", err)
+	}
+
+	loads := 0
+	state, err := buildOrOpenLazyState(ctx, base, overlay, accountHash, func() ([]statecompare.StateEntry, error) {
+		loads++
+		return entries, nil
+	})
+	if err != nil {
+		t.Fatalf("cold build: %v", err)
+	}
+	if loads != 1 {
+		t.Fatalf("expected 1 entry load on cold build, got %d", loads)
+	}
+
+	root, err := state.Hash()
+	if err != nil || root != accountHash {
+		t.Fatalf("lazy state root %x != account_hash %x (err %v)", root[:8], accountHash[:8], err)
+	}
+
+	// Every entry must be readable through the lazy (overlay-over-base) map.
+	for _, e := range entries {
+		item, found, err := state.Get(e.Index)
+		if err != nil || !found {
+			t.Fatalf("Get %x: found=%v err=%v", e.Index[:4], found, err)
+		}
+		if string(item.Data()) != string(e.Data) {
+			t.Fatalf("Get %x: data mismatch", e.Index[:4])
+		}
+	}
+}
+
+func TestBuildOrOpenLazyState_WarmOpenSkipsRebuild(t *testing.T) {
+	ctx := context.Background()
+	entries, accountHash := syntheticEntries(t, 64)
+
+	base, err := shamap.NewMemoryNodeStoreFamily()
+	if err != nil {
+		t.Fatalf("base family: %v", err)
+	}
+	overlay, err := shamap.NewMemoryNodeStoreFamily()
+	if err != nil {
+		t.Fatalf("overlay family: %v", err)
+	}
+
+	if _, err := buildOrOpenLazyState(ctx, base, overlay, accountHash, func() ([]statecompare.StateEntry, error) {
+		return entries, nil
+	}); err != nil {
+		t.Fatalf("cold build: %v", err)
+	}
+
+	// A second open over the now-populated base must not rebuild: loadEntries
+	// failing the test if called proves the open path is "open the nodestore".
+	overlay2, err := shamap.NewMemoryNodeStoreFamily()
+	if err != nil {
+		t.Fatalf("overlay2 family: %v", err)
+	}
+	state, err := buildOrOpenLazyState(ctx, base, overlay2, accountHash, func() ([]statecompare.StateEntry, error) {
+		t.Fatalf("loadEntries called on warm open")
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("warm open: %v", err)
+	}
+	root, err := state.Hash()
+	if err != nil || root != accountHash {
+		t.Fatalf("warm state root %x != account_hash %x (err %v)", root[:8], accountHash[:8], err)
+	}
+}
+
+func TestBuildOrOpenLazyState_VerifyGate(t *testing.T) {
+	ctx := context.Background()
+	entries, accountHash := syntheticEntries(t, 32)
+
+	base, err := shamap.NewMemoryNodeStoreFamily()
+	if err != nil {
+		t.Fatalf("base family: %v", err)
+	}
+	overlay, err := shamap.NewMemoryNodeStoreFamily()
+	if err != nil {
+		t.Fatalf("overlay family: %v", err)
+	}
+
+	// Claim a wrong account_hash: the built root must not match and the build
+	// must fail rather than hand back an unverified seed.
+	wrong := accountHash
+	wrong[0] ^= 0xFF
+	if _, err := buildOrOpenLazyState(ctx, base, overlay, wrong, func() ([]statecompare.StateEntry, error) {
+		return entries, nil
+	}); err == nil {
+		t.Fatal("expected account_hash mismatch error, got nil")
+	}
+}

--- a/shamap/overlay_family.go
+++ b/shamap/overlay_family.go
@@ -19,6 +19,9 @@ type OverlayFamily struct {
 // NewOverlayFamily returns a Family that reads overlay-then-base and writes
 // only to overlay. Both must be non-nil.
 func NewOverlayFamily(base, overlay Family) *OverlayFamily {
+	if base == nil || overlay == nil {
+		panic("shamap: NewOverlayFamily requires non-nil base and overlay")
+	}
 	return &OverlayFamily{base: base, overlay: overlay}
 }
 
@@ -29,7 +32,9 @@ func (f *OverlayFamily) Fetch(ctx context.Context, hash [32]byte) ([]byte, error
 	if err != nil {
 		return nil, err
 	}
-	if data != nil {
+	// A present node always carries bytes, so a zero-length overlay hit means
+	// absent: fall through to the base rather than shadowing it with empty data.
+	if len(data) > 0 {
 		return data, nil
 	}
 	return f.base.Fetch(ctx, hash)

--- a/shamap/overlay_family.go
+++ b/shamap/overlay_family.go
@@ -1,0 +1,41 @@
+package shamap
+
+import "context"
+
+// OverlayFamily layers a writable overlay Family over a read-only base Family,
+// mirroring geth's disk-layer / diff-layer split. Fetch consults the overlay
+// first and falls back to the base; StoreBatch writes only to the overlay, so
+// the base is never mutated and can back many workers read-only and be shared
+// across a node's checkpoint cache.
+//
+// In the mainnet-replay worker this gives the "shared read-only base checkpoint
+// + per-worker copy-on-write overlay" model: the base holds the immutable
+// checkpoint state and the overlay holds only a segment's mutations.
+type OverlayFamily struct {
+	base    Family
+	overlay Family
+}
+
+// NewOverlayFamily returns a Family that reads overlay-then-base and writes
+// only to overlay. Both must be non-nil.
+func NewOverlayFamily(base, overlay Family) *OverlayFamily {
+	return &OverlayFamily{base: base, overlay: overlay}
+}
+
+// Fetch returns the node from the overlay if present, otherwise from the base.
+// Returns (nil, nil) when absent from both, matching the Family contract.
+func (f *OverlayFamily) Fetch(ctx context.Context, hash [32]byte) ([]byte, error) {
+	data, err := f.overlay.Fetch(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	if data != nil {
+		return data, nil
+	}
+	return f.base.Fetch(ctx, hash)
+}
+
+// StoreBatch persists nodes to the overlay only, leaving the shared base intact.
+func (f *OverlayFamily) StoreBatch(ctx context.Context, entries []FlushEntry) error {
+	return f.overlay.StoreBatch(ctx, entries)
+}

--- a/shamap/overlay_family_test.go
+++ b/shamap/overlay_family_test.go
@@ -2,6 +2,7 @@ package shamap
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -70,5 +71,67 @@ func TestOverlayFamily_WritesOnlyToOverlay(t *testing.T) {
 	}
 	if data, err := overlay.Fetch(ctx, h); err != nil || string(data) != "written" {
 		t.Fatalf("overlay missing write: got %q err %v", data, err)
+	}
+}
+
+// stubFamily returns canned Fetch results, for exercising OverlayFamily's
+// overlay-error and empty-hit paths that a real nodestore never produces.
+type stubFamily struct {
+	data []byte
+	err  error
+}
+
+func (s stubFamily) Fetch(context.Context, [32]byte) ([]byte, error) { return s.data, s.err }
+func (s stubFamily) StoreBatch(context.Context, []FlushEntry) error  { return nil }
+
+func TestOverlayFamily_PropagatesOverlayError(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("overlay boom")
+	of := NewOverlayFamily(mustMemFamily(t), stubFamily{err: sentinel})
+
+	var h [32]byte
+	h[0] = 0x01
+	if _, err := of.Fetch(ctx, h); !errors.Is(err, sentinel) {
+		t.Fatalf("Fetch error = %v, want %v (must not fall through to base)", err, sentinel)
+	}
+}
+
+func TestOverlayFamily_EmptyOverlayHitFallsThroughToBase(t *testing.T) {
+	ctx := context.Background()
+	base := mustMemFamily(t)
+	var h [32]byte
+	h[0] = 0x02
+	if err := base.StoreBatch(ctx, []FlushEntry{{Hash: h, Data: []byte("from-base")}}); err != nil {
+		t.Fatalf("base StoreBatch: %v", err)
+	}
+	// A non-nil zero-length overlay value must be treated as absent, not as a
+	// hit that shadows the base.
+	of := NewOverlayFamily(base, stubFamily{data: []byte{}})
+
+	got, err := of.Fetch(ctx, h)
+	if err != nil || string(got) != "from-base" {
+		t.Fatalf("empty overlay hit did not fall through: got %q err %v", got, err)
+	}
+}
+
+func TestNewOverlayFamily_NilArgsPanic(t *testing.T) {
+	base := mustMemFamily(t)
+	cases := []struct {
+		name          string
+		base, overlay Family
+	}{
+		{"nil base", nil, base},
+		{"nil overlay", base, nil},
+		{"both nil", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected panic on nil family argument")
+				}
+			}()
+			NewOverlayFamily(tc.base, tc.overlay)
+		})
 	}
 }

--- a/shamap/overlay_family_test.go
+++ b/shamap/overlay_family_test.go
@@ -1,0 +1,74 @@
+package shamap
+
+import (
+	"context"
+	"testing"
+)
+
+func mustMemFamily(t *testing.T) *NodeStoreFamily {
+	t.Helper()
+	fam, err := NewMemoryNodeStoreFamily()
+	if err != nil {
+		t.Fatalf("NewMemoryNodeStoreFamily: %v", err)
+	}
+	return fam
+}
+
+func TestOverlayFamily_ReadsOverlayThenBase(t *testing.T) {
+	ctx := context.Background()
+	base := mustMemFamily(t)
+	overlay := mustMemFamily(t)
+	of := NewOverlayFamily(base, overlay)
+
+	var hBase, hBoth [32]byte
+	hBase[0], hBoth[0] = 0x01, 0x02
+
+	// Seed the base only.
+	if err := base.StoreBatch(ctx, []FlushEntry{{Hash: hBase, Data: []byte("from-base")}}); err != nil {
+		t.Fatalf("base StoreBatch: %v", err)
+	}
+	// Seed both with different bytes; overlay must win.
+	if err := base.StoreBatch(ctx, []FlushEntry{{Hash: hBoth, Data: []byte("base-version")}}); err != nil {
+		t.Fatalf("base StoreBatch: %v", err)
+	}
+	if err := overlay.StoreBatch(ctx, []FlushEntry{{Hash: hBoth, Data: []byte("overlay-version")}}); err != nil {
+		t.Fatalf("overlay StoreBatch: %v", err)
+	}
+
+	got, err := of.Fetch(ctx, hBase)
+	if err != nil || string(got) != "from-base" {
+		t.Fatalf("base fallback: got %q err %v", got, err)
+	}
+	got, err = of.Fetch(ctx, hBoth)
+	if err != nil || string(got) != "overlay-version" {
+		t.Fatalf("overlay precedence: got %q err %v", got, err)
+	}
+
+	var missing [32]byte
+	missing[0] = 0xFF
+	got, err = of.Fetch(ctx, missing)
+	if err != nil || got != nil {
+		t.Fatalf("absent node: got %q err %v, want nil/nil", got, err)
+	}
+}
+
+func TestOverlayFamily_WritesOnlyToOverlay(t *testing.T) {
+	ctx := context.Background()
+	base := mustMemFamily(t)
+	overlay := mustMemFamily(t)
+	of := NewOverlayFamily(base, overlay)
+
+	var h [32]byte
+	h[0] = 0xAB
+	if err := of.StoreBatch(ctx, []FlushEntry{{Hash: h, Data: []byte("written")}}); err != nil {
+		t.Fatalf("OverlayFamily StoreBatch: %v", err)
+	}
+
+	// The base must remain untouched so it can stay read-only and shared.
+	if data, err := base.Fetch(ctx, h); err != nil || data != nil {
+		t.Fatalf("base mutated: got %q err %v, want nil/nil", data, err)
+	}
+	if data, err := overlay.Fetch(ctx, h); err != nil || string(data) != "written" {
+		t.Fatalf("overlay missing write: got %q err %v", data, err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the two remaining goXRPL pieces of the mainnet-replay differential lab worker (design: `docs/mainnet-replay-architecture.md`).

- **Nodestore-lazy worker state (M3).** Seed state now loads behind a swappable `StateSource` interface instead of `loadInitialState`'s in-memory `Put` loop. With `--nodestore-dir`, the state SHAMap is backed by a node-local pebble store via the new `shamap.OverlayFamily` (geth disk-layer/diff-layer pattern): a **shared read-only checkpoint base** built once, plus a **per-run copy-on-write overlay** holding only the segment's mutations. Re-seeding a checkpoint *opens the nodestore* rather than rebuilding the ~14M-entry tree; the cold build flushes in chunks and is verify-gated against the seed `account_hash`. The per-block full-state captures that would have defeated lazy backing are removed from the happy path (failure dumps materialize on demand).
- **emit-finding-and-continue.** With `--continue-on-divergence`, a hash mismatch no longer halts the run: the worker writes a structured, commit-tagged finding (JSONL via `--findings-out`) and **resets to mainnet's ground-truth post-state**, reconstructed from the ledger's transaction metadata, then continues — so one pass surveys every divergence. The reset is **gated on the reconstructed state's `account_hash`**, so replay only continues from a byte-exact state and a single early bug never cascades into thousands of false findings.

Metadata reconstruction matches rippled (`ApplyStateTable.cpp`): `FinalFields`/`NewFields` are partial deltas, so `ModifiedNode` is overlaid onto the decoded pre-object (with `PreviousFields`-only fields treated as removed), and `CreatedNode`/`DeletedNode` applied directly.

Default behavior (no new flags) is unchanged: fully in-memory seed, stop-and-dump on first mismatch.

## Test plan

- [x] `go test ./shamap/... ./internal/cli/...` — full suites pass
- [x] New unit tests:
  - `OverlayFamily` read-overlay-then-base / write-overlay-only
  - `buildOrOpenLazyState` cold-build→lazy-read, warm-open-skips-rebuild, account_hash verify-gate
  - `reconstructFromMeta` byte-exact for modify-with-field-removal, create+delete, empty-meta; `divergingObjects`
  - findings JSONL round-trip + commit tagging
- [x] `go build ./...`, `go vet`, `gofmt`, `golangci-lint run` (0 issues)

> Note: end-to-end `replay-range` exercises a populated PostgreSQL `xrpl_state` mainnet dataset, which isn't available in CI/local here; the new components are covered by isolated unit tests (in-memory nodestore + synthetic state/metadata).

Fixes #700