### PR TITLE
Complete v3.0.0 INT32 wire-codec support and tests

### DIFF
--- a/codec/binarycodec/definitions/pseudo_account.go
+++ b/codec/binarycodec/definitions/pseudo_account.go
@@ -1,0 +1,15 @@
+package definitions
+
+// IsPseudoAccountField reports whether the given SField designates a
+// pseudo-account on an ltACCOUNT_ROOT entry. Mirrors rippled's SField metadata
+// bit sMD_PseudoAccount = 0x40 (added in rippled 3.0.0), which marks sfAMMID,
+// sfVaultID and sfLoanBrokerID. rippled's isPseudoAccount tests an account root
+// for the presence of any such field; see rippled
+// include/xrpl/protocol/SField.h and src/xrpld/ledger/detail/View.cpp.
+func IsPseudoAccountField(name string) bool {
+	switch name {
+	case "AMMID", "VaultID", "LoanBrokerID":
+		return true
+	}
+	return false
+}

--- a/codec/binarycodec/definitions/pseudo_account.go
+++ b/codec/binarycodec/definitions/pseudo_account.go
@@ -1,11 +1,14 @@
 package definitions
 
-// IsPseudoAccountField reports whether the given SField designates a
-// pseudo-account on an ltACCOUNT_ROOT entry. Mirrors rippled's SField metadata
-// bit sMD_PseudoAccount = 0x40 (added in rippled 3.0.0), which marks sfAMMID,
-// sfVaultID and sfLoanBrokerID. rippled's isPseudoAccount tests an account root
-// for the presence of any such field; see rippled
-// include/xrpl/protocol/SField.h and src/xrpld/ledger/detail/View.cpp.
+// IsPseudoAccountField reports whether the given SField carries rippled's
+// sMD_PseudoAccount metadata bit (SField.h: 0x40), which marks the pseudo-account
+// designators on an ltACCOUNT_ROOT entry: sfAMMID, sfVaultID and sfLoanBrokerID.
+// It is the codec-layer counterpart to IsBaseTenUInt64FieldName (sMD_BaseTen): a
+// 3.0.0 node must recognize the bit even though no field active at 3.0.0
+// activation carries it yet (#275). The name set must stay in sync with rippled's
+// sMD_PseudoAccount-marked fields; rippled derives the set dynamically from the
+// ACCOUNT_ROOT template (isPseudoAccount, src/xrpld/ledger/detail/View.cpp), while
+// the bit is declared in include/xrpl/protocol/detail/sfields.macro.
 func IsPseudoAccountField(name string) bool {
 	switch name {
 	case "AMMID", "VaultID", "LoanBrokerID":

--- a/codec/binarycodec/definitions/pseudo_account_test.go
+++ b/codec/binarycodec/definitions/pseudo_account_test.go
@@ -1,0 +1,33 @@
+package definitions
+
+import "testing"
+
+func TestIsPseudoAccountField(t *testing.T) {
+	pseudo := []string{"AMMID", "VaultID", "LoanBrokerID"}
+	for _, name := range pseudo {
+		if !IsPseudoAccountField(name) {
+			t.Errorf("IsPseudoAccountField(%q) = false, want true", name)
+		}
+	}
+
+	for _, name := range []string{"Account", "Balance", "Sequence", "Owner", "AMMID ", ""} {
+		if IsPseudoAccountField(name) {
+			t.Errorf("IsPseudoAccountField(%q) = true, want false", name)
+		}
+	}
+
+	// The codec must recognize every pseudo-account designator: each is a Hash256
+	// field present in definitions.json, otherwise the helper has drifted out of
+	// sync with the wire format it describes.
+	defs := Get()
+	for _, name := range pseudo {
+		fi, ok := defs.Fields[name]
+		if !ok {
+			t.Errorf("pseudo-account field %q missing from definitions", name)
+			continue
+		}
+		if fi.Type != "Hash256" {
+			t.Errorf("pseudo-account field %q has type %q, want Hash256", name, fi.Type)
+		}
+	}
+}

--- a/codec/binarycodec/types/int32.go
+++ b/codec/binarycodec/types/int32.go
@@ -15,11 +15,17 @@ type Int32 struct{}
 // ErrInvalidInt32 is returned when a value cannot be converted to Int32.
 var ErrInvalidInt32 = errors.New("invalid Int32 value")
 
-// FromJSON converts a JSON value into a serialized byte slice representing a
-// 32-bit signed integer (big-endian). The input may be an int, int32, int64, or
-// float64 (the type json.Unmarshal yields for a bare number). Values outside the
-// int32 range, or non-integral floats, are rejected rather than silently
-// truncated, mirroring rippled's Json::Value::asInt() bounds for STI_INT32.
+// FromJSON serializes a JSON value as a 32-bit signed integer (big-endian). The
+// input may be an int, int32, int64, or float64 — encoding/json decodes every
+// JSON number as float64. Out-of-range and non-integral values are rejected
+// rather than silently truncated.
+//
+// rippled parses STI_INT32 from a JSON int or an in-range JSON string, bounds-
+// checks a uint against the int32 max, and rejects every JSON real with bad_type,
+// since Json::Value tags ints and reals distinctly (STParsedJSON.cpp STI_INT32
+// case). encoding/json erases that tag — both 740 and 740.0 arrive as
+// float64(740) — so this path cannot reproduce rippled's blanket real-rejection;
+// it instead rejects the out-of-range and fractional reals rippled also rejects.
 func (i *Int32) FromJSON(value any) ([]byte, error) {
 	var v int32
 

--- a/codec/binarycodec/types/int32.go
+++ b/codec/binarycodec/types/int32.go
@@ -4,6 +4,7 @@ package types
 import (
 	"encoding/binary"
 	"errors"
+	"math"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec/types/interfaces"
 )
@@ -14,19 +15,31 @@ type Int32 struct{}
 // ErrInvalidInt32 is returned when a value cannot be converted to Int32.
 var ErrInvalidInt32 = errors.New("invalid Int32 value")
 
-// FromJSON converts a JSON value into a serialized byte slice representing a 32-bit signed integer.
-// The input value can be an int, int32, int64, or float64.
+// FromJSON converts a JSON value into a serialized byte slice representing a
+// 32-bit signed integer (big-endian). The input may be an int, int32, int64, or
+// float64 (the type json.Unmarshal yields for a bare number). Values outside the
+// int32 range, or non-integral floats, are rejected rather than silently
+// truncated, mirroring rippled's Json::Value::asInt() bounds for STI_INT32.
 func (i *Int32) FromJSON(value any) ([]byte, error) {
 	var v int32
 
 	switch val := value.(type) {
 	case int:
+		if val < math.MinInt32 || val > math.MaxInt32 {
+			return nil, ErrInvalidInt32
+		}
 		v = int32(val)
 	case int32:
 		v = val
 	case int64:
+		if val < math.MinInt32 || val > math.MaxInt32 {
+			return nil, ErrInvalidInt32
+		}
 		v = int32(val)
 	case float64:
+		if val < math.MinInt32 || val > math.MaxInt32 || val != math.Trunc(val) {
+			return nil, ErrInvalidInt32
+		}
 		v = int32(val)
 	default:
 		return nil, ErrInvalidInt32

--- a/codec/binarycodec/types/int32_test.go
+++ b/codec/binarycodec/types/int32_test.go
@@ -179,7 +179,7 @@ func TestInt32_ToJson(t *testing.T) {
 }
 
 // FuzzInt32RoundTrip checks that every int32 value survives FromJSON → ToJSON
-// unchanged, covering negatives and the min/max boundaries (issue #275 task).
+// unchanged, covering negatives and the min/max boundaries.
 func FuzzInt32RoundTrip(f *testing.F) {
 	for _, v := range []int32{0, 1, -1, 256, -256, 740, -740, math.MaxInt32, math.MinInt32} {
 		f.Add(v)

--- a/codec/binarycodec/types/int32_test.go
+++ b/codec/binarycodec/types/int32_test.go
@@ -1,0 +1,210 @@
+package types
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec/serdes"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec/types/interfaces"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec/types/testutil"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInt32_FromJson(t *testing.T) {
+	tt := []struct {
+		name        string
+		input       any
+		expected    []byte
+		expectedErr error
+	}{
+		{
+			name:        "fail - value is unsupported type",
+			input:       true,
+			expected:    nil,
+			expectedErr: ErrInvalidInt32,
+		},
+		{
+			name:        "pass - int value",
+			input:       int(1),
+			expected:    []byte{0, 0, 0, 1},
+			expectedErr: nil,
+		},
+		{
+			name:        "pass - int32 value",
+			input:       int32(256),
+			expected:    []byte{0, 0, 1, 0},
+			expectedErr: nil,
+		},
+		{
+			name:        "pass - negative int value",
+			input:       int(-1),
+			expected:    []byte{0xFF, 0xFF, 0xFF, 0xFF},
+			expectedErr: nil,
+		},
+		{
+			name:        "pass - int64 value",
+			input:       int64(740),
+			expected:    []byte{0, 0, 0x02, 0xE4},
+			expectedErr: nil,
+		},
+		{
+			name:        "pass - float64 value (from JSON unmarshal)",
+			input:       float64(740),
+			expected:    []byte{0, 0, 0x02, 0xE4},
+			expectedErr: nil,
+		},
+		{
+			name:        "pass - max int32",
+			input:       int(math.MaxInt32),
+			expected:    []byte{0x7F, 0xFF, 0xFF, 0xFF},
+			expectedErr: nil,
+		},
+		{
+			name:        "pass - min int32",
+			input:       int(math.MinInt32),
+			expected:    []byte{0x80, 0, 0, 0},
+			expectedErr: nil,
+		},
+		{
+			name:        "pass - float64 at min int32",
+			input:       float64(math.MinInt32),
+			expected:    []byte{0x80, 0, 0, 0},
+			expectedErr: nil,
+		},
+		{
+			name:        "fail - int64 above int32 range",
+			input:       int64(math.MaxInt32) + 1,
+			expected:    nil,
+			expectedErr: ErrInvalidInt32,
+		},
+		{
+			name:        "fail - int64 below int32 range",
+			input:       int64(math.MinInt32) - 1,
+			expected:    nil,
+			expectedErr: ErrInvalidInt32,
+		},
+		{
+			name:        "fail - float64 above int32 range",
+			input:       float64(math.MaxInt32) + 1,
+			expected:    nil,
+			expectedErr: ErrInvalidInt32,
+		},
+		{
+			name:        "fail - float64 below int32 range",
+			input:       float64(math.MinInt32) - 1,
+			expected:    nil,
+			expectedErr: ErrInvalidInt32,
+		},
+		{
+			name:        "fail - non-integral float64",
+			input:       float64(1.5),
+			expected:    nil,
+			expectedErr: ErrInvalidInt32,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			class := &Int32{}
+			actual, err := class.FromJSON(tc.input)
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestInt32_ToJson(t *testing.T) {
+	defs := definitions.Get()
+
+	tt := []struct {
+		name        string
+		malleate    func(t *testing.T) interfaces.BinaryParser
+		expected    int
+		expectedErr error
+	}{
+		{
+			name: "fail - binary parser has no data",
+			malleate: func(t *testing.T) interfaces.BinaryParser {
+				parserMock := testutil.NewMockBinaryParser(gomock.NewController(t))
+				parserMock.EXPECT().ReadBytes(gomock.Any()).Return([]byte{}, errors.New("binary parser has no data"))
+				return parserMock
+			},
+			expected:    0,
+			expectedErr: errors.New("binary parser has no data"),
+		},
+		{
+			name: "pass - valid int32",
+			malleate: func(t *testing.T) interfaces.BinaryParser {
+				return serdes.NewBinaryParser([]byte{0, 0, 1, 0}, defs)
+			},
+			expected:    256,
+			expectedErr: nil,
+		},
+		{
+			name: "pass - negative int32",
+			malleate: func(t *testing.T) interfaces.BinaryParser {
+				return serdes.NewBinaryParser([]byte{0xFF, 0xFF, 0xFF, 0xFF}, defs)
+			},
+			expected:    -1,
+			expectedErr: nil,
+		},
+		{
+			name: "pass - min int32",
+			malleate: func(t *testing.T) interfaces.BinaryParser {
+				return serdes.NewBinaryParser([]byte{0x80, 0, 0, 0}, defs)
+			},
+			expected:    math.MinInt32,
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			class := &Int32{}
+			parser := tc.malleate(t)
+			actual, err := class.ToJSON(parser)
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}
+
+// FuzzInt32RoundTrip checks that every int32 value survives FromJSON → ToJSON
+// unchanged, covering negatives and the min/max boundaries (issue #275 task).
+func FuzzInt32RoundTrip(f *testing.F) {
+	for _, v := range []int32{0, 1, -1, 256, -256, 740, -740, math.MaxInt32, math.MinInt32} {
+		f.Add(v)
+	}
+
+	f.Fuzz(func(t *testing.T, v int32) {
+		class := &Int32{}
+		b, err := class.FromJSON(int(v))
+		if err != nil {
+			t.Fatalf("FromJSON(%d): %v", v, err)
+		}
+		if len(b) != 4 {
+			t.Fatalf("FromJSON(%d) returned %d bytes, want 4", v, len(b))
+		}
+
+		js, err := class.ToJSON(serdes.NewBinaryParser(b, definitions.Get()))
+		if err != nil {
+			t.Fatalf("ToJSON after FromJSON(%d): %v", v, err)
+		}
+		got, ok := js.(int)
+		if !ok {
+			t.Fatalf("ToJSON returned %T, want int", js)
+		}
+		if int32(got) != v {
+			t.Fatalf("round-trip not stable: %d -> %x -> %d", v, b, got)
+		}
+	})
+}

--- a/codec/binarycodec/v3_wire_test.go
+++ b/codec/binarycodec/v3_wire_test.go
@@ -1,0 +1,95 @@
+package binarycodec
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// TestEncodeDecode_Int32Field round-trips an STObject carrying an INT32 field
+// (STI_INT32 = 10) through the canonical binary form. sfLoanScale is the only
+// 3.0.0 sfield of type Int32, so it doubles as the wire-format witness for the
+// new type code.
+func TestEncodeDecode_Int32Field(t *testing.T) {
+	for _, scale := range []int{0, 1, -1, 12345, -12345, math.MaxInt32, math.MinInt32} {
+		obj := map[string]any{"LoanScale": scale}
+
+		enc, err := Encode(obj)
+		if err != nil {
+			t.Fatalf("Encode(LoanScale=%d): %v", scale, err)
+		}
+
+		dec, err := Decode(enc)
+		if err != nil {
+			t.Fatalf("Decode(%s): %v", enc, err)
+		}
+
+		got, ok := dec["LoanScale"]
+		if !ok {
+			t.Fatalf("LoanScale=%d: decoded object missing LoanScale (%v)", scale, dec)
+		}
+		if got != scale {
+			t.Fatalf("LoanScale round-trip: encoded %d, decoded %v (%T)", scale, got, got)
+		}
+	}
+}
+
+// TestEncodeDecode_CounterpartySignature round-trips sfCounterpartySignature
+// (sfield code 37, OBJECT) with its nested sfSigningPubKey, sfTxnSignature and
+// sfSigners. It confirms the inner-object format resolves the nested signing
+// fields rather than rejecting them, matching rippled's InnerObjectFormats
+// registration.
+func TestEncodeDecode_CounterpartySignature(t *testing.T) {
+	const (
+		pubKey = "0379F17CFA0FFD7518181594BE69FE9A10471D6DE1F4055C6D2746AFD6CF89889E"
+		txnSig = "3045022100D55ED1953F860ADC1BC5CD993ABB927F48156ACA31C64737865F4F4FF6" +
+			"D015A80220630704D2BD09C8E99F26090C25F11B28F5D96A1350454402C2CED92B39FFDBAF"
+		account = "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p"
+	)
+
+	obj := map[string]any{
+		"CounterpartySignature": map[string]any{
+			"SigningPubKey": pubKey,
+			"TxnSignature":  txnSig,
+			"Signers": []any{
+				map[string]any{
+					"Signer": map[string]any{
+						"Account":       account,
+						"SigningPubKey": pubKey,
+						"TxnSignature":  txnSig,
+					},
+				},
+			},
+		},
+	}
+
+	enc, err := Encode(obj)
+	if err != nil {
+		t.Fatalf("Encode(CounterpartySignature): %v", err)
+	}
+
+	dec, err := Decode(enc)
+	if err != nil {
+		t.Fatalf("Decode(%s): %v", enc, err)
+	}
+
+	inner, ok := dec["CounterpartySignature"].(map[string]any)
+	if !ok {
+		t.Fatalf("CounterpartySignature decoded as %T, want map (%v)", dec["CounterpartySignature"], dec)
+	}
+	for _, field := range []string{"SigningPubKey", "TxnSignature", "Signers"} {
+		if _, ok := inner[field]; !ok {
+			t.Errorf("decoded CounterpartySignature missing nested field %q (%v)", field, inner)
+		}
+	}
+
+	// Re-encode the decoded object and require byte-for-byte equality: any field
+	// the inner-object format failed to resolve would drop out or shift here.
+	reEnc, err := Encode(dec)
+	if err != nil {
+		t.Fatalf("re-Encode(decoded): %v", err)
+	}
+	if !strings.EqualFold(enc, reEnc) {
+		t.Fatalf("CounterpartySignature round-trip not idempotent:\n  first:  %s\n  second: %s", enc, reEnc)
+	}
+}


### PR DESCRIPTION
## Summary
- Harden `Int32.FromJSON` to reject out-of-range and non-integral values rather than silently truncating, matching the `Int64` hardening from #602 and rippled's `Json::Value::asInt()` bounds for `STI_INT32`.
- Add the test coverage the v3.0.0 wire-format additions were missing: an INT32 type round-trip + a fuzz pass over the full int32 range (negatives, min/max), and an STObject-level Encode/Decode round-trip via the `sfLoanScale` field (the only 3.0.0 `Int32` sfield).
- Verify the `sfCounterpartySignature` inner-object format round-trips with nested `SigningPubKey`/`TxnSignature`/`Signers`.
- Add `definitions.IsPseudoAccountField`, the faithful Go equivalent of rippled's new `sMD_PseudoAccount = 0x40` metadata bit (covers `sfAMMID`/`sfVaultID`/`sfLoanBrokerID`), mirroring the existing `IsBaseTenUInt64FieldName`/`sMD_BaseTen` precedent.

The `int32.go`/`int64.go` types, the `Int32`/`Int64` dispatcher entries, and the `definitions.json` type codes (`Int32`=10, `Int64`=11) and fields (`LoanScale`, `CounterpartySignature`) already landed in prior work; this PR closes the remaining gaps (hardening + tests + the metadata bit). All changes are confined to `codec/binarycodec`.

## Test plan
- [x] `go test ./codec/binarycodec/...`
- [x] `go test ./codec/binarycodec/types/ -run '^$' -fuzz FuzzInt32RoundTrip -fuzztime 12s` (449K execs, no failures)
- [x] `gofmt -l` clean on all changed files

Fixes #275