### PR TITLE
Unconditional inner-batch relay reject and SHAMap leaf-position check

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/tx"
 	validatorlist "github.com/LeJamon/go-xrpl/internal/validator/list"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
@@ -806,6 +807,25 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) {
 			"peer", msg.PeerID,
 			"status", txMsg.Status)
 		return
+	}
+
+	// A tfInnerBatchTxn transaction must never be relayed standalone over
+	// the peer protocol — it is only valid embedded inside a Batch. Reject
+	// before submission, unconditionally: if Batch is disabled the flag is
+	// malformed; if enabled, inner txns must never leak onto the wire.
+	// Either way the sender is misbehaving, so charge it. Mirrors rippled
+	// PeerImp::handleTransaction (PeerImp.cpp:1287-1296), which charges
+	// feeModerateBurdenPeer and drops before any processing.
+	if parsed, perr := tx.ParseFromBinary(blob); perr == nil {
+		if common := parsed.GetCommon(); common != nil && common.Flags != nil &&
+			*common.Flags&tx.TfInnerBatchTxn != 0 {
+			r.logger.Warn("ignoring relayed tx with tfInnerBatchTxn",
+				"t", "consensus",
+				"event", "tx-inner-batch-rejected",
+				"peer", msg.PeerID)
+			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "inner-batch-txn")
+			return
+		}
 	}
 
 	// Peer-relay path — the originating peer manages its own resends,

--- a/internal/consensus/adaptor/router_inner_batch_test.go
+++ b/internal/consensus/adaptor/router_inner_batch_test.go
@@ -1,0 +1,79 @@
+package adaptor
+
+import (
+	"encoding/hex"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	testenv "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildPaymentBlob builds a serialized Payment carrying the given flags, signed
+// by the genesis master key so it round-trips through the binary codec.
+func buildPaymentBlob(t *testing.T, flags uint32) []byte {
+	t.Helper()
+	env := testenv.NewTestEnv(t)
+	master := testenv.MasterAccount()
+	alice := testenv.NewAccount("alice")
+	txn := payment.Pay(master, alice, 100_000_000).Sequence(1).Flags(flags).Build()
+	env.SignWith(txn, master)
+	txMap, err := txn.Flatten()
+	require.NoError(t, err)
+	hexStr, err := binarycodec.Encode(txMap)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	return blob
+}
+
+func feedTransaction(t *testing.T, r *Router, peerID uint64, blob []byte) {
+	t.Helper()
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  peermanagement.PeerID(peerID),
+		Type:    uint16(message.TypeTransaction),
+		Payload: encodePayload(t, &message.Transaction{RawTransaction: blob, Status: message.TxStatusNew}),
+	})
+}
+
+func innerBatchCharges(calls []badDataCall) []badDataCall {
+	var out []badDataCall
+	for _, c := range calls {
+		if c.reason == "inner-batch-txn" {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// TestRouter_HandleTransaction_RejectsInnerBatchTxn verifies a peer-relayed
+// transaction carrying tfInnerBatchTxn is dropped before submission and the
+// sender is charged for bad data — unconditionally, with the Batch amendment
+// disabled (the default test rules). Mirrors rippled
+// PeerImp::handleTransaction (PeerImp.cpp:1287-1296).
+func TestRouter_HandleTransaction_RejectsInnerBatchTxn(t *testing.T) {
+	r, rs := makeRouterWithBadDataRecorder(t)
+
+	feedTransaction(t, r, 42, buildPaymentBlob(t, tx.TfInnerBatchTxn))
+
+	charges := innerBatchCharges(rs.getBadDataCalls())
+	require.Len(t, charges, 1, "an inner-batch tx relayed by a peer must charge the sender exactly once")
+	assert.Equal(t, uint64(42), charges[0].peerID,
+		"the charge must be attributed to the peer that relayed the inner-batch tx")
+}
+
+// TestRouter_HandleTransaction_AllowsNormalTxn is the control: a transaction
+// without the inner-batch flag is never charged as an inner-batch relay.
+func TestRouter_HandleTransaction_AllowsNormalTxn(t *testing.T) {
+	r, rs := makeRouterWithBadDataRecorder(t)
+
+	feedTransaction(t, r, 7, buildPaymentBlob(t, 0))
+
+	assert.Empty(t, innerBatchCharges(rs.getBadDataCalls()),
+		"a normal tx must not be charged as an inner-batch relay")
+}

--- a/internal/consensus/adaptor/router_txset_wire_test.go
+++ b/internal/consensus/adaptor/router_txset_wire_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/crypto/common"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -267,9 +269,11 @@ func TestRouter_LedgerData_TsCandidate_FeedsEngine(t *testing.T) {
 	}
 	txMap, err := shamap.New(shamap.TypeTransaction)
 	require.NoError(t, err, "shamap.New")
-	for i, blob := range blobs {
-		var key [32]byte
-		key[0] = byte(0x10 + i) // distinct keys to land in different branches
+	for _, blob := range blobs {
+		// Key each leaf by its canonical tx ID (sha512Half(TXN, blob)), as
+		// production tx sets do — a tx leaf re-derives its key from the blob
+		// on the wire, so AddKnownNodeByID requires the tree position to match.
+		key := common.Sha512Half(protocol.HashPrefixTransactionID[:], blob)
 		require.NoError(t,
 			txMap.PutWithNodeType(key, blob, shamap.NodeTypeTransactionNoMeta),
 			"PutWithNodeType")

--- a/internal/ledger/inbound/tracker_test.go
+++ b/internal/ledger/inbound/tracker_test.go
@@ -45,11 +45,21 @@ func buildSourceMap(t *testing.T, mapType shamap.Type) (rootHash [32]byte, rootD
 	for branch := byte(0); branch < 4; branch++ {
 		for sub := byte(0); sub < 4; sub++ {
 			for i := byte(0); i < 4; i++ {
+				data := []byte{branch, sub, i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}
 				var key [32]byte
-				key[0] = (branch << 4) | sub
-				key[1] = i << 4
-				key[31] = 0xA5
-				if err := source.Put(key, []byte{branch, sub, i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}); err != nil {
+				if mapType == shamap.TypeTransaction {
+					// A tx leaf re-derives its key from the blob on the wire, so
+					// the tree must be keyed by the canonical tx ID for the
+					// reconstructed leaves to land at their claimed positions
+					// (AddKnownNodeByID enforces this). Production tx sets are
+					// always keyed this way.
+					key = common.Sha512Half(protocol.HashPrefixTransactionID[:], data)
+				} else {
+					key[0] = (branch << 4) | sub
+					key[1] = i << 4
+					key[31] = 0xA5
+				}
+				if err := source.Put(key, data); err != nil {
 					t.Fatalf("put: %v", err)
 				}
 			}

--- a/internal/peermanagement/charge_inner_batch_test.go
+++ b/internal/peermanagement/charge_inner_batch_test.go
@@ -1,0 +1,17 @@
+package peermanagement
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestChargeForReason_InnerBatchTxn pins the resource fee for a peer that
+// relays a standalone tfInnerBatchTxn to feeModerateBurdenPeer (250), matching
+// rippled PeerImp::handleTransaction (PeerImp.cpp:1293). Without an explicit
+// mapping the reason falls through to FeeInvalidData (400), over-charging the
+// peer relative to rippled.
+func TestChargeForReason_InnerBatchTxn(t *testing.T) {
+	assert.Equal(t, resource.FeeModerateBurdenPeer, chargeForReason("inner-batch-txn"))
+}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -1163,6 +1163,8 @@ func chargeForReason(reason string) resource.Charge {
 		return resource.FeeMalformedRequest
 	case "no-reply":
 		return resource.FeeRequestNoReply
+	case "inner-batch-txn":
+		return resource.FeeModerateBurdenPeer
 	}
 	switch {
 	case reason == "vl-coll-no-blobs",

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -563,7 +563,7 @@ func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) error {
 			// peer can otherwise graft a hash-valid leaf at the wrong slot
 			// (e.g. via a corrupt parent inner node received earlier in the
 			// sync) and silently corrupt the map. Mirrors rippled's
-			// SHAMap::addKnownNode leaf-position check (PR #5938).
+			// SHAMap::addKnownNode leaf-position check (PR #5951).
 			if leaf, ok := newNode.(LeafNode); ok {
 				actualKey := leaf.Item().Key()
 				expectedID, idErr := CreateNodeID(uint8(targetDepth), actualKey)

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -17,6 +17,7 @@ var (
 	ErrUnexpectedNode    = errors.New("unexpected node received")
 	ErrEmptyBranchOnPath = errors.New("path descends into an empty branch")
 	ErrParentNotInTree   = errors.New("parent node not yet loaded for path")
+	ErrLeafWrongPosition = errors.New("leaf node key does not derive to the claimed tree position")
 )
 
 // SyncFilter is an interface for filtering which nodes should be fetched during sync.
@@ -495,6 +496,8 @@ func (sm *SHAMap) AddKnownNode(nodeHash [32]byte, data []byte) error {
 //     still a hash-only stub — caller must acquire ancestors first
 //   - ErrNodeHashMismatch when the computed hash doesn't match what the
 //     parent expects at the target branch
+//   - ErrLeafWrongPosition when a received leaf's key does not derive to
+//     the claimed position — a hash-valid leaf grafted at the wrong slot
 //   - ErrSyncNotInProgress / ErrInvalidNodeData on misuse
 func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) error {
 	sm.mu.Lock()
@@ -554,6 +557,23 @@ func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) error {
 			}
 			if newNode.Hash() != childHash {
 				return ErrNodeHashMismatch
+			}
+			// A leaf whose key does not derive to the position we walked to
+			// is rejected even though its hash matched — a buggy or hostile
+			// peer can otherwise graft a hash-valid leaf at the wrong slot
+			// (e.g. via a corrupt parent inner node received earlier in the
+			// sync) and silently corrupt the map. Mirrors rippled's
+			// SHAMap::addKnownNode leaf-position check (PR #5938).
+			if leaf, ok := newNode.(LeafNode); ok {
+				actualKey := leaf.Item().Key()
+				expectedID, idErr := CreateNodeID(uint8(targetDepth), actualKey)
+				if idErr != nil {
+					return fmt.Errorf("%w: %v", ErrInvalidNodeData, idErr)
+				}
+				wantID, _ := CreateNodeID(uint8(targetDepth), targetPath)
+				if expectedID.ID() != wantID.ID() {
+					return ErrLeafWrongPosition
+				}
 			}
 			// rippled SHAMapSync.cpp:653 canonicalizeChild
 			parent.SetChildIfNil(branch, newNode)

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -841,7 +841,7 @@ func TestAddKnownNodeErrors(t *testing.T) {
 }
 
 // TestAddKnownNodeByID_LeafWrongPosition exercises the leaf-position guard
-// added to mirror rippled's SHAMap::addKnownNode (PR #5938): a leaf whose key
+// added to mirror rippled's SHAMap::addKnownNode (PR #5951): a leaf whose key
 // does not derive to the position the descent walked to is rejected even when
 // its hash matches the parent's stored child hash. This can only arise from a
 // buggy or hostile peer (a correct tree never stores a leaf hash at a branch

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/LeJamon/go-xrpl/crypto/common"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 func TestSyncFilter(t *testing.T) {
@@ -518,10 +521,13 @@ func TestAddKnownNodeByID_RippledStyleReconstruct(t *testing.T) {
 	for branch := byte(0); branch < 4; branch++ {
 		for sub := byte(0); sub < 4; sub++ {
 			for i := byte(0); i < 4; i++ {
-				var key [32]byte
-				key[0] = (branch << 4) | sub
-				key[1] = i << 4
-				if err := source.Put(key, []byte{branch, sub, i, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66}); err != nil {
+				data := []byte{branch, sub, i, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+				// Key the leaf canonically (tx ID = sha512Half(TXN, blob)) as
+				// production does: a tx leaf's key is re-derived from its blob on
+				// the wire, so its tree position must equal that derived key —
+				// AddKnownNodeByID now enforces this.
+				key := common.Sha512Half(protocol.HashPrefixTransactionID[:], data)
+				if err := source.Put(key, data); err != nil {
 					t.Fatalf("Put: %v", err)
 				}
 			}
@@ -756,11 +762,12 @@ func TestAddKnownNodeByID_LeafMidPathReturnsDuplicate(t *testing.T) {
 		t.Fatalf("New source: %v", err)
 	}
 	// Single key → root has a single leaf child at the path's first
-	// nibble, consolidated at depth 1.
-	var k [32]byte
-	k[0] = 0x12
-	k[1] = 0x34
-	if err := source.Put(k, []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}); err != nil {
+	// nibble, consolidated at depth 1. Key it canonically (tx ID) so the
+	// leaf's position matches its wire-derived key — see AddKnownNodeByID's
+	// leaf-position guard.
+	data := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	k := common.Sha512Half(protocol.HashPrefixTransactionID[:], data)
+	if err := source.Put(k, data); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 	rootHash, err := source.Hash()
@@ -831,4 +838,86 @@ func TestAddKnownNodeErrors(t *testing.T) {
 	if err := sMap.AddKnownNode([32]byte{}, []byte{}); err == nil {
 		t.Error("Empty data should fail")
 	}
+}
+
+// TestAddKnownNodeByID_LeafWrongPosition exercises the leaf-position guard
+// added to mirror rippled's SHAMap::addKnownNode (PR #5938): a leaf whose key
+// does not derive to the position the descent walked to is rejected even when
+// its hash matches the parent's stored child hash. This can only arise from a
+// buggy or hostile peer (a correct tree never stores a leaf hash at a branch
+// inconsistent with the leaf's key), so the corrupt parent is forged directly.
+func TestAddKnownNodeByID_LeafWrongPosition(t *testing.T) {
+	// An AccountState leaf whose key's first nibble is 1 — it belongs under
+	// the root at branch 1. The key is carried explicitly in the wire form,
+	// so we can place the leaf wherever we like to forge the corrupt parent.
+	var key [32]byte
+	key[0] = 0x10 // nibble0 = 1
+	key[1] = 0xAB
+	leaf, err := NewAccountStateLeafNode(NewItem(key,
+		[]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE}))
+	if err != nil {
+		t.Fatalf("NewAccountStateLeafNode: %v", err)
+	}
+	leafWire, err := leaf.SerializeForWire()
+	if err != nil {
+		t.Fatalf("SerializeForWire: %v", err)
+	}
+
+	// forgeRoot builds a single-branch root that stores leaf at the given
+	// branch, returning the root hash + wire data so a dest map can ingest it
+	// as a hash-only stub via AddRootNode.
+	forgeRoot := func(branch int) ([32]byte, []byte) {
+		root := NewInnerNode()
+		if err := root.SetChild(branch, leaf); err != nil {
+			t.Fatalf("SetChild: %v", err)
+		}
+		wire, err := root.SerializeForWire()
+		if err != nil {
+			t.Fatalf("root SerializeForWire: %v", err)
+		}
+		return root.Hash(), wire
+	}
+
+	newDest := func(rootHash [32]byte, rootData []byte) *SHAMap {
+		dest, err := New(TypeState)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if err := dest.StartSync(); err != nil {
+			t.Fatalf("StartSync: %v", err)
+		}
+		if err := dest.AddRootNode(rootHash, rootData); err != nil {
+			t.Fatalf("AddRootNode: %v", err)
+		}
+		return dest
+	}
+
+	t.Run("accepts leaf at correct position", func(t *testing.T) {
+		rootHash, rootData := forgeRoot(1) // branch 1 == key's first nibble
+		dest := newDest(rootHash, rootData)
+		nid, err := CreateNodeID(1, key)
+		if err != nil {
+			t.Fatalf("CreateNodeID: %v", err)
+		}
+		if err := dest.AddKnownNodeByID(nid, leafWire); err != nil {
+			t.Fatalf("want nil (leaf belongs here), got %v", err)
+		}
+	})
+
+	t.Run("rejects hash-valid leaf at wrong position", func(t *testing.T) {
+		rootHash, rootData := forgeRoot(2) // branch 2 != key's first nibble (1)
+		dest := newDest(rootHash, rootData)
+		// Request the leaf at branch 2. The forged stub hash there matches the
+		// leaf's hash, so the hash check passes — but the leaf's key derives
+		// to branch 1, so the position guard must reject it.
+		var branch2Key [32]byte
+		branch2Key[0] = 0x20 // nibble0 = 2
+		nid, err := CreateNodeID(1, branch2Key)
+		if err != nil {
+			t.Fatalf("CreateNodeID: %v", err)
+		}
+		if err := dest.AddKnownNodeByID(nid, leafWire); !errors.Is(err, ErrLeafWrongPosition) {
+			t.Fatalf("want ErrLeafWrongPosition, got %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

v3.0.0 Phase D behavior changes (parent #274), two non-amendment-gated correctness fixes:

- **D.1 — `tfInnerBatchTxn` relay rejection is unconditional.** Added an early reject in `Router.handleTransaction` (the `PeerImp::handleTransaction` equivalent): a peer-relayed transaction carrying `tfInnerBatchTxn` is dropped *before* submission and the sender is charged, regardless of whether the `Batch` amendment is enabled. Mirrors rippled `PeerImp.cpp:1287-1296` (PR #5670). The directly-submitted path (`preflight.go`) and the open-ledger re-broadcast path (`openledger.go`) were already unconditional.
- **D.2 — SHAMap sync leaf-position validation.** `SHAMap.AddKnownNodeByID` now rejects a received leaf whose key does not derive to the claimed tree position, even when its hash matches the parent's stored child hash. Guards against a buggy/hostile peer grafting a hash-valid leaf at the wrong slot via a corrupt parent inner node. Mirrors rippled `SHAMapSync.cpp` `addKnownNode` (PR #5938).

### Audit notes (D.1 task 2 — publish/broadcast paths)
The proposed/validated subscription-publish paths were audited: they contain **no** `Batch`-amendment conditional, and an inner-batch tx is structurally unable to reach them — the proposed-publish callback fires only for *applied* txns (`tx_query.go`) and preflight rejects inner-batch with `temINVALID_FLAG` before that, while inner txns never appear as standalone entries in a closed-ledger tx set. No guard added there to avoid dead, untestable code.

### Note on the test changes
The new leaf-position check requires transaction SHAMaps to be keyed canonically (`key == sha512Half(TXN, blob)`), which production always does (`TxSetImpl.Add`, closed-ledger/replay paths — verified). Three existing reconstruction tests built `TypeTransaction` trees with arbitrary, non-canonical keys (only possible in tests, since a tx leaf re-derives its key from its blob on the wire); they now key canonically, which is both correct and more representative.

## Test plan
- [x] `just test-pkg ./shamap/...` — new `TestAddKnownNodeByID_LeafWrongPosition` (accepts correct position, rejects hash-valid leaf at wrong position) + existing sync/reconstruct tests
- [x] `just test-pkg ./internal/consensus/adaptor/...` — new `TestRouter_HandleTransaction_RejectsInnerBatchTxn` (charged, Batch disabled) + `..._AllowsNormalTxn` control
- [x] `just test-pkg ./internal/ledger/inbound/...`
- [x] `go build ./...`, `go vet`, and the full `./internal/consensus/...` + `./internal/ledger/...` trees pass

Fixes #277