### PR TITLE
Verify counterparty signatures

### DIFF
--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -229,9 +229,13 @@ func (e *Engine) verifySignatures(tx Transaction) Result {
 	}
 	// After the primary signature passes, recursively verify the counterparty
 	// signature when present. Mirrors rippled STTx::checkSign, which checks the
-	// transaction itself first, then sfCounterpartySignature.
-	if err := VerifyCounterpartySignature(tx); err != nil {
-		return TemBAD_SIGNATURE
+	// transaction itself first, then sfCounterpartySignature. The amendment rules
+	// are only needed (and fetched) when a counterparty object is present, to
+	// bound a multi-signed object's signer count.
+	if tx.GetCommon().CounterpartySignature != nil {
+		if err := VerifyCounterpartySignature(tx, e.rules()); err != nil {
+			return TemBAD_SIGNATURE
+		}
 	}
 	return TesSUCCESS
 }

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -220,11 +220,17 @@ func (e *Engine) verifySignatures(tx Transaction) Result {
 				return TefBAD_SIGNATURE
 			}
 		}
-		return TesSUCCESS
+	} else {
+		// Single-signed transaction — verify cryptographic signature validity.
+		// The signing key authorization (master vs regular key) is checked in preclaim.
+		if err := VerifySignature(tx); err != nil {
+			return TemBAD_SIGNATURE
+		}
 	}
-	// Single-signed transaction — verify cryptographic signature validity.
-	// The signing key authorization (master vs regular key) is checked in preclaim.
-	if err := VerifySignature(tx); err != nil {
+	// After the primary signature passes, recursively verify the counterparty
+	// signature when present. Mirrors rippled STTx::checkSign, which checks the
+	// transaction itself first, then sfCounterpartySignature.
+	if err := VerifyCounterpartySignature(tx); err != nil {
 		return TemBAD_SIGNATURE
 	}
 	return TesSUCCESS

--- a/internal/tx/signature.go
+++ b/internal/tx/signature.go
@@ -49,6 +49,24 @@ var (
 	ErrSignersNotSorted = errors.New("signers must be sorted by account")
 )
 
+// Nested signature-object errors. These mirror the semantics of rippled's
+// singleSignHelper / multiSignHelper (STTx.cpp) and are wrapped with the
+// counterpartySigPrefix to match rippled STTx::checkSign's "Counterparty: "
+// error wrapping.
+var (
+	errSigObjInvalid     = errors.New("invalid signature")
+	errSigObjBothSign    = errors.New("cannot both single- and multi-sign")
+	errSigObjEmptyPubKey = errors.New("empty SigningPubKey")
+	errSigObjUnsorted    = errors.New("unsorted Signers array")
+	errSigObjDuplicate   = errors.New("duplicate Signers not allowed")
+)
+
+// counterpartySigPrefix is the prefix rippled STTx::checkSign applies to a
+// failed counterparty signature check ("Counterparty: " + inner error). It is a
+// constant rather than an inline literal so the capitalized prefix is not
+// flagged by the error-string linter (ST1005).
+const counterpartySigPrefix = "Counterparty: "
+
 // SignerListLookup is the interface for looking up an account's signer list
 // This must be implemented by the ledger/state layer
 type SignerListLookup interface {
@@ -299,6 +317,107 @@ func VerifyMultiSignature(tx Transaction, lookup SignerListLookup) error {
 	return nil
 }
 
+// VerifyCounterpartySignature verifies the sfCounterpartySignature object when
+// present, mirroring the recursive branch of rippled STTx::checkSign:
+//
+//	if (isFieldPresent(sfCounterpartySignature)) {
+//	    auto const counterSig = getFieldObject(sfCounterpartySignature);
+//	    if (auto ret = checkSign(req, rules, counterSig); !ret)
+//	        return Unexpected("Counterparty: " + ret.error());
+//	}
+//
+// Only the cryptographic signature is verified (single- or multi-sig), against
+// the same signing data as the primary signer. Signer-list/quorum authorization
+// is intentionally not performed here, matching rippled where that lives in
+// Transactor::checkSign rather than STTx::checkSign. Returns nil when no
+// counterparty signature is present.
+func VerifyCounterpartySignature(tx Transaction) error {
+	cs := tx.GetCommon().CounterpartySignature
+	if cs == nil {
+		return nil
+	}
+	if err := checkSignatureObject(tx, cs.SigningPubKey, cs.TxnSignature, cs.Signers); err != nil {
+		return fmt.Errorf("%s%w", counterpartySigPrefix, err)
+	}
+	return nil
+}
+
+// checkSignatureObject cryptographically verifies a signature object — a nested
+// object such as CounterpartySignature — against tx's signing data. It mirrors
+// rippled STTx::checkSign(req, rules, STObject const&): an empty SigningPubKey
+// selects multi-signing, otherwise single-signing.
+func checkSignatureObject(tx Transaction, signingPubKey, txnSignature string, signers []SignerWrapper) error {
+	if signingPubKey == "" {
+		return checkMultiSignObject(tx, txnSignature, signers)
+	}
+	return checkSingleSignObject(tx, signingPubKey, txnSignature, signers)
+}
+
+// checkSingleSignObject mirrors rippled singleSignHelper: a single signature is
+// verified against the transaction's signing data. A SigningPubKey present
+// alongside Signers means the object is signed two ways and is rejected.
+func checkSingleSignObject(tx Transaction, signingPubKey, txnSignature string, signers []SignerWrapper) error {
+	if len(signers) > 0 {
+		return errSigObjBothSign
+	}
+	signingPayload, err := getSigningPayload(tx)
+	if err != nil {
+		return fmt.Errorf("failed to get signing payload: %w", err)
+	}
+	if !verifySignatureForKey(signingPayload, signingPubKey, txnSignature) {
+		return errSigObjInvalid
+	}
+	return nil
+}
+
+// checkMultiSignObject mirrors rippled multiSignHelper (crypto only): each
+// signer's signature is verified against the multi-signing data for that signer.
+// The "account owner may not multisign for themselves" guard does not apply to a
+// nested signature object — rippled passes txnAccountID == nullopt when the
+// signature object is not the transaction itself (STTx.cpp checkMultiSign).
+// Structural checks (sorted, no duplicates) match the top-level multi-sign path;
+// like VerifyMultiSignature, the signer count is bounded by the signer list and
+// quorum rather than an explicit size cap at this layer.
+func checkMultiSignObject(tx Transaction, txnSignature string, signers []SignerWrapper) error {
+	if len(signers) == 0 {
+		return errSigObjEmptyPubKey
+	}
+	if txnSignature != "" {
+		return errSigObjBothSign
+	}
+
+	txMap, err := tx.Flatten()
+	if err != nil {
+		return fmt.Errorf("failed to flatten transaction: %w", err)
+	}
+
+	var lastAccountID [20]byte
+	for _, sw := range signers {
+		signer := sw.Signer
+		accountID, decErr := state.DecodeAccountID(signer.Account)
+		if decErr != nil {
+			return errSigObjInvalid
+		}
+		// Signers must be in sorted order by binary AccountID, no duplicates.
+		if accountID == lastAccountID {
+			return errSigObjDuplicate
+		}
+		if bytes.Compare(lastAccountID[:], accountID[:]) > 0 {
+			return errSigObjUnsorted
+		}
+		lastAccountID = accountID
+
+		signingPayload, encErr := binarycodec.EncodeForMultisigning(copyMap(txMap), signer.Account)
+		if encErr != nil {
+			return fmt.Errorf("failed to encode for multi-signing: %w", encErr)
+		}
+		if !verifySignatureForKey(signingPayload, signer.SigningPubKey, signer.TxnSignature) {
+			return fmt.Errorf("invalid signature on account %s", signer.Account)
+		}
+	}
+	return nil
+}
+
 // copyMap creates a shallow copy of a map to avoid modifying the original
 func copyMap(m map[string]any) map[string]any {
 	result := make(map[string]any, len(m))
@@ -410,6 +529,23 @@ func SignTransaction(tx Transaction, privateKeyHex string) (string, error) {
 	}
 
 	return strings.ToUpper(signature), nil
+}
+
+// SignCounterparty signs the transaction's signing data with the counterparty's
+// key and stores the resulting SigningPubKey + TxnSignature in the transaction's
+// CounterpartySignature object. It mirrors rippled STTx::sign with a
+// signatureTarget of sfCounterpartySignature: the counterparty signs the same
+// signing data as the primary signer; only the storage location differs.
+func SignCounterparty(tx Transaction, publicKeyHex, privateKeyHex string) error {
+	sig, err := SignTransaction(tx, privateKeyHex)
+	if err != nil {
+		return err
+	}
+	tx.GetCommon().CounterpartySignature = &CounterpartySignature{
+		SigningPubKey: publicKeyHex,
+		TxnSignature:  sig,
+	}
+	return nil
 }
 
 // DeriveAddressFromPublicKey derives a classic address from a public key

--- a/internal/tx/signature.go
+++ b/internal/tx/signature.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/crypto/ed25519"
@@ -59,6 +60,7 @@ var (
 	errSigObjEmptyPubKey = errors.New("empty SigningPubKey")
 	errSigObjUnsorted    = errors.New("unsorted Signers array")
 	errSigObjDuplicate   = errors.New("duplicate Signers not allowed")
+	errSigObjArraySize   = errors.New("invalid Signers array size")
 )
 
 // counterpartySigPrefix is the prefix rippled STTx::checkSign applies to a
@@ -329,14 +331,16 @@ func VerifyMultiSignature(tx Transaction, lookup SignerListLookup) error {
 // Only the cryptographic signature is verified (single- or multi-sig), against
 // the same signing data as the primary signer. Signer-list/quorum authorization
 // is intentionally not performed here, matching rippled where that lives in
-// Transactor::checkSign rather than STTx::checkSign. Returns nil when no
-// counterparty signature is present.
-func VerifyCounterpartySignature(tx Transaction) error {
+// Transactor::checkSign rather than STTx::checkSign. rules supplies the active
+// amendment set, used to bound a multi-signed counterparty object's signer count
+// (see checkMultiSignObject). Returns nil when no counterparty signature is
+// present.
+func VerifyCounterpartySignature(tx Transaction, rules *amendment.Rules) error {
 	cs := tx.GetCommon().CounterpartySignature
 	if cs == nil {
 		return nil
 	}
-	if err := checkSignatureObject(tx, cs.SigningPubKey, cs.TxnSignature, cs.Signers); err != nil {
+	if err := checkSignatureObject(tx, cs.SigningPubKey, cs.TxnSignature, cs.Signers, rules); err != nil {
 		return fmt.Errorf("%s%w", counterpartySigPrefix, err)
 	}
 	return nil
@@ -346,9 +350,9 @@ func VerifyCounterpartySignature(tx Transaction) error {
 // object such as CounterpartySignature — against tx's signing data. It mirrors
 // rippled STTx::checkSign(req, rules, STObject const&): an empty SigningPubKey
 // selects multi-signing, otherwise single-signing.
-func checkSignatureObject(tx Transaction, signingPubKey, txnSignature string, signers []SignerWrapper) error {
+func checkSignatureObject(tx Transaction, signingPubKey, txnSignature string, signers []SignerWrapper, rules *amendment.Rules) error {
 	if signingPubKey == "" {
-		return checkMultiSignObject(tx, txnSignature, signers)
+		return checkMultiSignObject(tx, txnSignature, signers, rules)
 	}
 	return checkSingleSignObject(tx, signingPubKey, txnSignature, signers)
 }
@@ -375,15 +379,22 @@ func checkSingleSignObject(tx Transaction, signingPubKey, txnSignature string, s
 // The "account owner may not multisign for themselves" guard does not apply to a
 // nested signature object — rippled passes txnAccountID == nullopt when the
 // signature object is not the transaction itself (STTx.cpp checkMultiSign).
-// Structural checks (sorted, no duplicates) match the top-level multi-sign path;
-// like VerifyMultiSignature, the signer count is bounded by the signer list and
-// quorum rather than an explicit size cap at this layer.
-func checkMultiSignObject(tx Transaction, txnSignature string, signers []SignerWrapper) error {
+// Unlike the top-level multi-sign path (VerifyMultiSignature), there is no
+// signer-list lookup here to implicitly bound the signer count, so the explicit
+// min/max bound from multiSignHelper (STTx.cpp:495-497) is enforced directly:
+// 1..maxMultiSigners (8, or 32 with featureExpandedSignerList). Structural checks
+// (sorted, no duplicates) match the top-level path.
+func checkMultiSignObject(tx Transaction, txnSignature string, signers []SignerWrapper, rules *amendment.Rules) error {
 	if len(signers) == 0 {
 		return errSigObjEmptyPubKey
 	}
 	if txnSignature != "" {
 		return errSigObjBothSign
+	}
+	// Bound the signer count, mirroring rippled multiSignHelper (STTx.cpp:495-497).
+	// The lower bound (minMultiSigners == 1) is already covered by the empty check.
+	if len(signers) > maxMultiSigners(rules) {
+		return errSigObjArraySize
 	}
 
 	txMap, err := tx.Flatten()
@@ -416,6 +427,17 @@ func checkMultiSignObject(tx Transaction, txnSignature string, signers []SignerW
 		}
 	}
 	return nil
+}
+
+// maxMultiSigners mirrors rippled STTx::maxMultiSigners (STTx.h:55-63): the cap
+// is 8 unless featureExpandedSignerList is enabled, in which case it is 32. A nil
+// rules set is treated as most-permissive (32), matching rippled's contract that
+// the largest possible value is returned when rules are not supplied.
+func maxMultiSigners(rules *amendment.Rules) int {
+	if rules != nil && !rules.ExpandedSignerListEnabled() {
+		return 8
+	}
+	return 32
 }
 
 // copyMap creates a shallow copy of a map to avoid modifying the original

--- a/internal/tx/signature_counterparty_test.go
+++ b/internal/tx/signature_counterparty_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/crypto/ed25519"
 	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
@@ -89,10 +90,10 @@ func flipLastNibble(s string) string {
 func TestCounterpartySignature_AbsentUnchanged(t *testing.T) {
 	tx := newSignedTx(t, deriveKey(t, "primary", "ed25519"))
 
-	if err := VerifyCounterpartySignature(tx); err != nil {
+	if err := VerifyCounterpartySignature(tx, amendment.AllSupportedRules()); err != nil {
 		t.Fatalf("absent counterparty signature should pass, got %v", err)
 	}
-	e := &Engine{config: EngineConfig{SkipSignatureVerification: false}}
+	e := &Engine{config: EngineConfig{SkipSignatureVerification: false, Rules: amendment.AllSupportedRules()}}
 	if r := e.verifySignatures(tx); r != TesSUCCESS {
 		t.Fatalf("verifySignatures = %v, want TesSUCCESS", r)
 	}
@@ -106,10 +107,10 @@ func TestCounterpartySignature_ValidSingle(t *testing.T) {
 			if err := SignCounterparty(tx, cp.pub, cp.priv); err != nil {
 				t.Fatalf("SignCounterparty: %v", err)
 			}
-			if err := VerifyCounterpartySignature(tx); err != nil {
+			if err := VerifyCounterpartySignature(tx, amendment.AllSupportedRules()); err != nil {
 				t.Fatalf("valid counterparty signature should pass, got %v", err)
 			}
-			e := &Engine{config: EngineConfig{SkipSignatureVerification: false}}
+			e := &Engine{config: EngineConfig{SkipSignatureVerification: false, Rules: amendment.AllSupportedRules()}}
 			if r := e.verifySignatures(tx); r != TesSUCCESS {
 				t.Fatalf("verifySignatures = %v, want TesSUCCESS", r)
 			}
@@ -126,14 +127,14 @@ func TestCounterpartySignature_InvalidSingle(t *testing.T) {
 	// Corrupt the counterparty signature.
 	tx.Common.CounterpartySignature.TxnSignature = flipLastNibble(tx.Common.CounterpartySignature.TxnSignature)
 
-	err := VerifyCounterpartySignature(tx)
+	err := VerifyCounterpartySignature(tx, amendment.AllSupportedRules())
 	if err == nil {
 		t.Fatal("invalid counterparty signature should fail")
 	}
 	if !strings.HasPrefix(err.Error(), "Counterparty: ") {
 		t.Fatalf("error %q must be prefixed with \"Counterparty: \"", err.Error())
 	}
-	e := &Engine{config: EngineConfig{SkipSignatureVerification: false}}
+	e := &Engine{config: EngineConfig{SkipSignatureVerification: false, Rules: amendment.AllSupportedRules()}}
 	if r := e.verifySignatures(tx); r != TemBAD_SIGNATURE {
 		t.Fatalf("verifySignatures = %v, want TemBAD_SIGNATURE", r)
 	}
@@ -151,7 +152,7 @@ func TestCounterpartySignature_InvalidTopLevel(t *testing.T) {
 	// Corrupt the top-level signature; counterparty remains valid.
 	tx.Common.TxnSignature = flipLastNibble(tx.Common.TxnSignature)
 
-	e := &Engine{config: EngineConfig{SkipSignatureVerification: false}}
+	e := &Engine{config: EngineConfig{SkipSignatureVerification: false, Rules: amendment.AllSupportedRules()}}
 	if r := e.verifySignatures(tx); r != TemBAD_SIGNATURE {
 		t.Fatalf("verifySignatures = %v, want TemBAD_SIGNATURE", r)
 	}
@@ -188,7 +189,7 @@ func TestCounterpartySignature_ValidMulti(t *testing.T) {
 	}
 	signCounterpartyMulti(t, tx, signers)
 
-	if err := VerifyCounterpartySignature(tx); err != nil {
+	if err := VerifyCounterpartySignature(tx, amendment.AllSupportedRules()); err != nil {
 		t.Fatalf("valid multi-signed counterparty should pass, got %v", err)
 	}
 }
@@ -204,12 +205,44 @@ func TestCounterpartySignature_InvalidMulti(t *testing.T) {
 	cs := tx.Common.CounterpartySignature
 	cs.Signers[0].Signer.TxnSignature = flipLastNibble(cs.Signers[0].Signer.TxnSignature)
 
-	err := VerifyCounterpartySignature(tx)
+	err := VerifyCounterpartySignature(tx, amendment.AllSupportedRules())
 	if err == nil {
 		t.Fatal("invalid multi-signed counterparty should fail")
 	}
 	if !strings.HasPrefix(err.Error(), "Counterparty: ") {
 		t.Fatalf("error %q must be prefixed with \"Counterparty: \"", err.Error())
+	}
+}
+
+// TestCounterpartySignature_SignerCountBound enforces rippled multiSignHelper's
+// signer-count bound (STTx.cpp:495-497) on a multi-signed counterparty object:
+// the array is rejected above maxMultiSigners, which is rules-aware (8 by
+// default, 32 with featureExpandedSignerList). Unlike the top-level path there is
+// no signer list to implicitly bound the count, so the cap is enforced directly.
+func TestCounterpartySignature_SignerCountBound(t *testing.T) {
+	tx := newSignedTx(t, deriveKey(t, "primary", "ed25519"))
+	signers := make([]keypair, 9)
+	for i := range signers {
+		signers[i] = deriveKey(t, "cp-many-"+string(rune('a'+i)), "ed25519")
+	}
+	signCounterpartyMulti(t, tx, signers)
+
+	// 9 signers exceed the default cap of 8 (ExpandedSignerList disabled). The
+	// signatures are all valid, so a rejection proves the size bound fires first.
+	noExpanded := amendment.NewRules(nil)
+	err := VerifyCounterpartySignature(tx, noExpanded)
+	if err == nil {
+		t.Fatal("9-signer counterparty must be rejected when the cap is 8")
+	}
+	if !strings.HasPrefix(err.Error(), "Counterparty: ") ||
+		!strings.Contains(err.Error(), "invalid Signers array size") {
+		t.Fatalf("expected wrapped array-size error, got %v", err)
+	}
+
+	// The same 9 signers are within the expanded cap of 32.
+	withExpanded := amendment.NewRules([][32]byte{amendment.FeatureExpandedSignerList})
+	if err := VerifyCounterpartySignature(tx, withExpanded); err != nil {
+		t.Fatalf("9-signer counterparty must pass when the cap is 32, got %v", err)
 	}
 }
 
@@ -232,7 +265,7 @@ func TestCounterpartySignature_BothSign(t *testing.T) {
 		TxnSignature:  sig,
 	}}}
 
-	err = VerifyCounterpartySignature(tx)
+	err = VerifyCounterpartySignature(tx, amendment.AllSupportedRules())
 	if err == nil || !strings.Contains(err.Error(), "cannot both single- and multi-sign") {
 		t.Fatalf("expected cannot-both-sign error, got %v", err)
 	}
@@ -270,7 +303,7 @@ func TestCounterpartySignature_WireRoundTrip(t *testing.T) {
 	if got.SigningPubKey != cp.pub || got.TxnSignature != tx.Common.CounterpartySignature.TxnSignature {
 		t.Fatalf("round-trip mismatch: got %+v", got)
 	}
-	if err := VerifyCounterpartySignature(parsed); err != nil {
+	if err := VerifyCounterpartySignature(parsed, amendment.AllSupportedRules()); err != nil {
 		t.Fatalf("round-tripped counterparty signature should verify, got %v", err)
 	}
 }

--- a/internal/tx/signature_counterparty_test.go
+++ b/internal/tx/signature_counterparty_test.go
@@ -1,0 +1,276 @@
+package tx
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/ed25519"
+	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+// keypair holds a prefixed private key, public key and classic address derived
+// deterministically from a name.
+type keypair struct {
+	priv string
+	pub  string
+	addr string
+}
+
+// deriveKey produces a deterministic ed25519 or secp256k1 keypair for a name,
+// mirroring the seed derivation used by the test environment (account.go).
+func deriveKey(t *testing.T, name, keyType string) keypair {
+	t.Helper()
+	hash := sha512.Sum512([]byte(name))
+	seed := hash[:16]
+
+	var priv, pub string
+	var err error
+	switch keyType {
+	case "ed25519":
+		priv, pub, err = ed25519.ED25519().DeriveKeypair(seed, false)
+	case "secp256k1":
+		priv, pub, err = secp256k1.SECP256K1().DeriveKeypair(seed, false)
+	default:
+		t.Fatalf("unsupported key type %q", keyType)
+	}
+	if err != nil {
+		t.Fatalf("DeriveKeypair(%s, %s): %v", name, keyType, err)
+	}
+	addr, err := DeriveAddressFromPublicKey(pub)
+	if err != nil {
+		t.Fatalf("DeriveAddressFromPublicKey(%s): %v", name, err)
+	}
+	return keypair{priv: priv, pub: pub, addr: addr}
+}
+
+// newSignedTx builds a minimal single-signed AccountSet signed by primary.
+func newSignedTx(t *testing.T, primary keypair) *BaseTx {
+	t.Helper()
+	seq := uint32(1)
+	tx := &BaseTx{Common: Common{
+		Account:         primary.addr,
+		TransactionType: "AccountSet",
+		Fee:             "10",
+		Sequence:        &seq,
+		SigningPubKey:   primary.pub,
+	}}
+	sig, err := SignTransaction(tx, primary.priv)
+	if err != nil {
+		t.Fatalf("SignTransaction: %v", err)
+	}
+	tx.Common.TxnSignature = sig
+	if err := VerifySignature(tx); err != nil {
+		t.Fatalf("primary signature should be valid: %v", err)
+	}
+	return tx
+}
+
+// flipLastNibble corrupts a hex string while keeping it valid hex, guaranteeing
+// the decoded value changes.
+func flipLastNibble(s string) string {
+	if s == "" {
+		return "FF"
+	}
+	b := []byte(s)
+	if b[len(b)-1] == '0' {
+		b[len(b)-1] = '1'
+	} else {
+		b[len(b)-1] = '0'
+	}
+	return string(b)
+}
+
+func TestCounterpartySignature_AbsentUnchanged(t *testing.T) {
+	tx := newSignedTx(t, deriveKey(t, "primary", "ed25519"))
+
+	if err := VerifyCounterpartySignature(tx); err != nil {
+		t.Fatalf("absent counterparty signature should pass, got %v", err)
+	}
+	e := &Engine{config: EngineConfig{SkipSignatureVerification: false}}
+	if r := e.verifySignatures(tx); r != TesSUCCESS {
+		t.Fatalf("verifySignatures = %v, want TesSUCCESS", r)
+	}
+}
+
+func TestCounterpartySignature_ValidSingle(t *testing.T) {
+	for _, kt := range []string{"ed25519", "secp256k1"} {
+		t.Run(kt, func(t *testing.T) {
+			tx := newSignedTx(t, deriveKey(t, "primary", "ed25519"))
+			cp := deriveKey(t, "counterparty", kt)
+			if err := SignCounterparty(tx, cp.pub, cp.priv); err != nil {
+				t.Fatalf("SignCounterparty: %v", err)
+			}
+			if err := VerifyCounterpartySignature(tx); err != nil {
+				t.Fatalf("valid counterparty signature should pass, got %v", err)
+			}
+			e := &Engine{config: EngineConfig{SkipSignatureVerification: false}}
+			if r := e.verifySignatures(tx); r != TesSUCCESS {
+				t.Fatalf("verifySignatures = %v, want TesSUCCESS", r)
+			}
+		})
+	}
+}
+
+func TestCounterpartySignature_InvalidSingle(t *testing.T) {
+	tx := newSignedTx(t, deriveKey(t, "primary", "ed25519"))
+	cp := deriveKey(t, "counterparty", "ed25519")
+	if err := SignCounterparty(tx, cp.pub, cp.priv); err != nil {
+		t.Fatalf("SignCounterparty: %v", err)
+	}
+	// Corrupt the counterparty signature.
+	tx.Common.CounterpartySignature.TxnSignature = flipLastNibble(tx.Common.CounterpartySignature.TxnSignature)
+
+	err := VerifyCounterpartySignature(tx)
+	if err == nil {
+		t.Fatal("invalid counterparty signature should fail")
+	}
+	if !strings.HasPrefix(err.Error(), "Counterparty: ") {
+		t.Fatalf("error %q must be prefixed with \"Counterparty: \"", err.Error())
+	}
+	e := &Engine{config: EngineConfig{SkipSignatureVerification: false}}
+	if r := e.verifySignatures(tx); r != TemBAD_SIGNATURE {
+		t.Fatalf("verifySignatures = %v, want TemBAD_SIGNATURE", r)
+	}
+}
+
+// TestCounterpartySignature_InvalidTopLevel proves the primary signature is
+// checked first: a bad top-level signature is rejected even when the counterparty
+// signature is valid, mirroring rippled STTx::checkSign ordering.
+func TestCounterpartySignature_InvalidTopLevel(t *testing.T) {
+	tx := newSignedTx(t, deriveKey(t, "primary", "ed25519"))
+	cp := deriveKey(t, "counterparty", "ed25519")
+	if err := SignCounterparty(tx, cp.pub, cp.priv); err != nil {
+		t.Fatalf("SignCounterparty: %v", err)
+	}
+	// Corrupt the top-level signature; counterparty remains valid.
+	tx.Common.TxnSignature = flipLastNibble(tx.Common.TxnSignature)
+
+	e := &Engine{config: EngineConfig{SkipSignatureVerification: false}}
+	if r := e.verifySignatures(tx); r != TemBAD_SIGNATURE {
+		t.Fatalf("verifySignatures = %v, want TemBAD_SIGNATURE", r)
+	}
+}
+
+// signCounterpartyMulti attaches a sorted multi-signed counterparty object.
+func signCounterpartyMulti(t *testing.T, tx *BaseTx, signers []keypair) {
+	t.Helper()
+	wrappers := make([]SignerWrapper, 0, len(signers))
+	for _, s := range signers {
+		sig, err := SignTransactionForMultiSign(tx, s.addr, s.priv)
+		if err != nil {
+			t.Fatalf("SignTransactionForMultiSign(%s): %v", s.addr, err)
+		}
+		wrappers = append(wrappers, SignerWrapper{Signer: Signer{
+			Account:       s.addr,
+			SigningPubKey: s.pub,
+			TxnSignature:  sig,
+		}})
+	}
+	sort.Slice(wrappers, func(i, j int) bool {
+		idI, _ := state.DecodeAccountID(wrappers[i].Signer.Account)
+		idJ, _ := state.DecodeAccountID(wrappers[j].Signer.Account)
+		return bytes.Compare(idI[:], idJ[:]) < 0
+	})
+	tx.Common.CounterpartySignature = &CounterpartySignature{Signers: wrappers}
+}
+
+func TestCounterpartySignature_ValidMulti(t *testing.T) {
+	tx := newSignedTx(t, deriveKey(t, "primary", "ed25519"))
+	signers := []keypair{
+		deriveKey(t, "cp-signer-1", "ed25519"),
+		deriveKey(t, "cp-signer-2", "secp256k1"),
+	}
+	signCounterpartyMulti(t, tx, signers)
+
+	if err := VerifyCounterpartySignature(tx); err != nil {
+		t.Fatalf("valid multi-signed counterparty should pass, got %v", err)
+	}
+}
+
+func TestCounterpartySignature_InvalidMulti(t *testing.T) {
+	tx := newSignedTx(t, deriveKey(t, "primary", "ed25519"))
+	signers := []keypair{
+		deriveKey(t, "cp-signer-1", "ed25519"),
+		deriveKey(t, "cp-signer-2", "ed25519"),
+	}
+	signCounterpartyMulti(t, tx, signers)
+	// Corrupt one signer's signature.
+	cs := tx.Common.CounterpartySignature
+	cs.Signers[0].Signer.TxnSignature = flipLastNibble(cs.Signers[0].Signer.TxnSignature)
+
+	err := VerifyCounterpartySignature(tx)
+	if err == nil {
+		t.Fatal("invalid multi-signed counterparty should fail")
+	}
+	if !strings.HasPrefix(err.Error(), "Counterparty: ") {
+		t.Fatalf("error %q must be prefixed with \"Counterparty: \"", err.Error())
+	}
+}
+
+// TestCounterpartySignature_BothSign rejects an object that carries both a
+// SigningPubKey and Signers, mirroring rippled singleSignHelper.
+func TestCounterpartySignature_BothSign(t *testing.T) {
+	tx := newSignedTx(t, deriveKey(t, "primary", "ed25519"))
+	cp := deriveKey(t, "counterparty", "ed25519")
+	if err := SignCounterparty(tx, cp.pub, cp.priv); err != nil {
+		t.Fatalf("SignCounterparty: %v", err)
+	}
+	signer := deriveKey(t, "cp-signer-1", "ed25519")
+	sig, err := SignTransactionForMultiSign(tx, signer.addr, signer.priv)
+	if err != nil {
+		t.Fatalf("SignTransactionForMultiSign: %v", err)
+	}
+	tx.Common.CounterpartySignature.Signers = []SignerWrapper{{Signer: Signer{
+		Account:       signer.addr,
+		SigningPubKey: signer.pub,
+		TxnSignature:  sig,
+	}}}
+
+	err = VerifyCounterpartySignature(tx)
+	if err == nil || !strings.Contains(err.Error(), "cannot both single- and multi-sign") {
+		t.Fatalf("expected cannot-both-sign error, got %v", err)
+	}
+}
+
+// TestCounterpartySignature_WireRoundTrip confirms the field survives an
+// encode/decode cycle so a node verifies what it received off the wire.
+func TestCounterpartySignature_WireRoundTrip(t *testing.T) {
+	tx := newSignedTx(t, deriveKey(t, "primary", "ed25519"))
+	cp := deriveKey(t, "counterparty", "ed25519")
+	if err := SignCounterparty(tx, cp.pub, cp.priv); err != nil {
+		t.Fatalf("SignCounterparty: %v", err)
+	}
+
+	flat, err := tx.Flatten()
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	encoded, err := binarycodec.Encode(flat)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	blob, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode hex: %v", err)
+	}
+	parsed, err := ParseFromBinary(blob)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+	got := parsed.GetCommon().CounterpartySignature
+	if got == nil {
+		t.Fatal("CounterpartySignature dropped on round-trip")
+	}
+	if got.SigningPubKey != cp.pub || got.TxnSignature != tx.Common.CounterpartySignature.TxnSignature {
+		t.Fatalf("round-trip mismatch: got %+v", got)
+	}
+	if err := VerifyCounterpartySignature(parsed); err != nil {
+		t.Fatalf("round-tripped counterparty signature should verify, got %v", err)
+	}
+}

--- a/internal/tx/signature_counterparty_test.go
+++ b/internal/tx/signature_counterparty_test.go
@@ -124,7 +124,6 @@ func TestCounterpartySignature_InvalidSingle(t *testing.T) {
 	if err := SignCounterparty(tx, cp.pub, cp.priv); err != nil {
 		t.Fatalf("SignCounterparty: %v", err)
 	}
-	// Corrupt the counterparty signature.
 	tx.Common.CounterpartySignature.TxnSignature = flipLastNibble(tx.Common.CounterpartySignature.TxnSignature)
 
 	err := VerifyCounterpartySignature(tx, amendment.AllSupportedRules())
@@ -149,7 +148,6 @@ func TestCounterpartySignature_InvalidTopLevel(t *testing.T) {
 	if err := SignCounterparty(tx, cp.pub, cp.priv); err != nil {
 		t.Fatalf("SignCounterparty: %v", err)
 	}
-	// Corrupt the top-level signature; counterparty remains valid.
 	tx.Common.TxnSignature = flipLastNibble(tx.Common.TxnSignature)
 
 	e := &Engine{config: EngineConfig{SkipSignatureVerification: false, Rules: amendment.AllSupportedRules()}}
@@ -201,7 +199,6 @@ func TestCounterpartySignature_InvalidMulti(t *testing.T) {
 		deriveKey(t, "cp-signer-2", "ed25519"),
 	}
 	signCounterpartyMulti(t, tx, signers)
-	// Corrupt one signer's signature.
 	cs := tx.Common.CounterpartySignature
 	cs.Signers[0].Signer.TxnSignature = flipLastNibble(cs.Signers[0].Signer.TxnSignature)
 

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -152,6 +152,42 @@ type SignerWrapper struct {
 	Signer Signer `json:"Signer"`
 }
 
+// CounterpartySignature is the sfCounterpartySignature inner object: a second
+// signature over the same signing data as the primary signer. It is either
+// single-signed (SigningPubKey + TxnSignature) or multi-signed (Signers),
+// mirroring the top-level signing fields.
+// Reference: rippled STTx.cpp checkSign recursion.
+type CounterpartySignature struct {
+	SigningPubKey string          `json:"SigningPubKey,omitempty"`
+	TxnSignature  string          `json:"TxnSignature,omitempty"`
+	Signers       []SignerWrapper `json:"Signers,omitempty"`
+}
+
+// ToMap renders the counterparty signature object for binary encoding.
+func (cs *CounterpartySignature) ToMap() map[string]any {
+	m := map[string]any{}
+	if cs.SigningPubKey != "" {
+		m["SigningPubKey"] = cs.SigningPubKey
+	}
+	if cs.TxnSignature != "" {
+		m["TxnSignature"] = cs.TxnSignature
+	}
+	if len(cs.Signers) > 0 {
+		signers := make([]map[string]any, len(cs.Signers))
+		for i, sw := range cs.Signers {
+			signers[i] = map[string]any{
+				"Signer": map[string]any{
+					"Account":       sw.Signer.Account,
+					"SigningPubKey": sw.Signer.SigningPubKey,
+					"TxnSignature":  sw.Signer.TxnSignature,
+				},
+			}
+		}
+		m["Signers"] = signers
+	}
+	return m
+}
+
 // Common contains fields common to all transaction types
 type Common struct {
 	// Required fields
@@ -181,6 +217,13 @@ type Common struct {
 	// against the delegate's keys.
 	// Reference: rippled Transactor.cpp sfDelegate
 	Delegate string `json:"Delegate,omitempty"`
+
+	// CounterpartySignature holds a second signature (sfCounterpartySignature)
+	// that is verified recursively after the primary signature passes. It is a
+	// wire-level field with no activated transaction type that uses it yet, but
+	// a node must reject invalid counterparty signatures to avoid divergence.
+	// Reference: rippled STTx.cpp checkSign.
+	CounterpartySignature *CounterpartySignature `json:"CounterpartySignature,omitempty"`
 
 	// RawBytes stores the original serialized bytes for hash computation
 	RawBytes []byte `json:"-"`
@@ -334,6 +377,9 @@ func (c *Common) ToMap() map[string]any {
 	}
 	if c.Delegate != "" {
 		m["Delegate"] = c.Delegate
+	}
+	if c.CounterpartySignature != nil {
+		m["CounterpartySignature"] = c.CounterpartySignature.ToMap()
 	}
 
 	return m


### PR DESCRIPTION
## Summary

- Recursively verify `sfCounterpartySignature` after the primary signature in preflight, mirroring rippled 3.0.0 `STTx::checkSign` (the `rippled-3.0.0` oracle, not local 2.6.2). The primary signature is checked first; when a counterparty signature is present it is verified against the **same** signing data as the primary signer, single- or multi-signed, and failures are wrapped with the exact `"Counterparty: "` prefix.
- Only cryptographic verification is performed here (no signer-list/quorum lookup), matching rippled where that authorization lives in `Transactor::checkSign` rather than `STTx::checkSign`.
- Adds the parsed `CounterpartySignature` inner object to the `Common` struct (+ `ToMap` emit) — the minimal data-model plumbing needed so a node can detect and verify the field it received off the wire. The binary codec round-trip itself landed in #275.
- A node must reject invalid counterparty signatures even though no activated transaction type uses the field yet, to avoid consensus divergence.

## Test plan

- [x] `go test ./internal/tx/... ` — new `signature_counterparty_test.go` covers: absent (unchanged behavior), valid single (ed25519 + secp256k1), invalid single (fails with `Counterparty:` prefix), invalid top-level fails before the counterparty check, valid/invalid multi-signed counterparty, both-single-and-multi rejection, and a wire encode/decode round-trip.
- [x] `golangci-lint run ./internal/tx/` — 0 issues
- [x] Engine signature-path suites: `internal/ledger/openledger`, `internal/consensus/adaptor`, `internal/ledger/service`, `internal/testing/multisign`

Fixes #276