### PR TITLE
WASM: wire engine into EscrowFinish (computational finish, SmartEscrow-gated) (#705)

### DIFF
--- a/codec/binarycodec/definitions/definitions.json
+++ b/codec/binarycodec/definitions/definitions.json
@@ -3429,6 +3429,26 @@
         "nth": 257,
         "type": "Metadata"
       }
+    ],
+    [
+      "FinishFunction",
+      {
+        "nth": 32,
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "type": "Blob"
+      }
+    ],
+    [
+      "ComputationAllowance",
+      {
+        "nth": 72,
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "type": "UInt32"
+      }
     ]
   ],
   "LEDGER_ENTRY_TYPES": {

--- a/internal/testing/escrow/smartescrow_fields_test.go
+++ b/internal/testing/escrow/smartescrow_fields_test.go
@@ -1,0 +1,76 @@
+// SmartEscrow field-pairing validation tests. The FinishFunction/
+// ComputationAllowance pairing is checked in preclaim, before the WASM engine
+// runs, so these reject without invoking the engine and build in the default
+// (non-wasmi) toolchain.
+package escrow_test
+
+import (
+	"testing"
+	"time"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/stretchr/testify/require"
+)
+
+// A trivial finish function returning 1; never executed in these tests since
+// the finish is rejected at field validation before the engine runs.
+const finishFnTrivial = "0061736d010000000105016000017f03020100070a010666696e69736800000a0601040041010b"
+
+// TestSmartEscrow_FinishMissingAllowance: finishing an escrow that carries a
+// FinishFunction without a ComputationAllowance is rejected with
+// tefWASM_FIELD_NOT_INCLUDED.
+// Reference: rippled EscrowSmart_test.cpp line 470
+func TestSmartEscrow_FinishMissingAllowance(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	seq := env.Seq(alice)
+	ff := finishFnTrivial
+	ec := escrow.EscrowCreate(alice, bob, xrp(1000)).
+		CancelTime(env.Now().Add(1000 * time.Second)).
+		Fee(baseFee * 150).
+		BuildEscrowCreate()
+	ec.FinishFunction = &ff
+	jtx.RequireTxSuccess(t, env.Submit(ec))
+	env.Close()
+
+	// Finish without a ComputationAllowance.
+	ef := escrow.EscrowFinish(bob, alice, seq).
+		Fee(baseFee * 150).
+		BuildEscrowFinish()
+	require.Equal(t, "tefWASM_FIELD_NOT_INCLUDED", env.Submit(ef).Code)
+}
+
+// TestSmartEscrow_FinishNoFunction: supplying a ComputationAllowance when the
+// escrow has no FinishFunction is rejected with tefNO_WASM.
+// Reference: rippled EscrowSmart_test.cpp line 514
+func TestSmartEscrow_FinishNoFunction(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	// A plain time-based escrow, no FinishFunction.
+	seq := env.Seq(alice)
+	jtx.RequireTxSuccess(t, env.Submit(
+		escrow.EscrowCreate(alice, bob, xrp(1000)).
+			FinishTime(env.Now().Add(1*time.Second)).
+			Build()))
+	env.Close()
+
+	allowance := uint32(1_000_000)
+	ef := escrow.EscrowFinish(bob, alice, seq).
+		Fee(baseFee * 150).
+		BuildEscrowFinish()
+	ef.ComputationAllowance = &allowance
+	require.Equal(t, "tefNO_WASM", env.Submit(ef).Code)
+}

--- a/internal/testing/escrow/smartescrow_test.go
+++ b/internal/testing/escrow/smartescrow_test.go
@@ -1,0 +1,65 @@
+//go:build cgo && wasmi
+
+// SmartEscrow (computational escrow) end-to-end tests. Built with -tags wasmi so
+// the real wasmi engine runs the escrow's FinishFunction.
+package escrow_test
+
+import (
+	"testing"
+	"time"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/stretchr/testify/require"
+)
+
+// Minimal finish functions compiled with wat2wasm:
+//
+//	(module (func (export "finish") (result i32) (i32.const N)))
+const (
+	finishReturns1 = "0061736d010000000105016000017f03020100070a010666696e69736800000a0601040041010b"
+	finishReturns0 = "0061736d010000000105016000017f03020100070a010666696e69736800000a0601040041000b"
+)
+
+func runComputationalEscrow(t *testing.T, finishFunctionHex string) string {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	// A FinishFunction requires a CancelAfter; no FinishAfter, so the escrow can
+	// be finished immediately (the finish function governs).
+	seq := env.Seq(alice)
+	ec := escrow.EscrowCreate(alice, bob, xrp(1000)).
+		CancelTime(env.Now().Add(1000 * time.Second)).
+		Fee(baseFee * 150).
+		BuildEscrowCreate()
+	ec.FinishFunction = &finishFunctionHex
+	createRes := env.Submit(ec)
+	t.Logf("create result: %s", createRes.Code)
+	jtx.RequireTxSuccess(t, createRes)
+	env.Close()
+
+	allowance := uint32(1_000_000)
+	ef := escrow.EscrowFinish(bob, alice, seq).
+		Fee(baseFee * 150).
+		BuildEscrowFinish()
+	ef.ComputationAllowance = &allowance
+	return env.Submit(ef).Code
+}
+
+// TestSmartEscrow_FinishAccepts: a finish function returning 1 lets the escrow
+// finish.
+func TestSmartEscrow_FinishAccepts(t *testing.T) {
+	require.Equal(t, "tesSUCCESS", runComputationalEscrow(t, finishReturns1))
+}
+
+// TestSmartEscrow_FinishRejects: a finish function returning 0 rejects the
+// finish with tecWASM_REJECTED.
+func TestSmartEscrow_FinishRejects(t *testing.T) {
+	require.Equal(t, "tecWASM_REJECTED", runComputationalEscrow(t, finishReturns0))
+}

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -39,6 +39,12 @@ type EscrowCreate struct {
 	// Condition is the crypto-condition that must be fulfilled (optional).
 	// Pointer to distinguish "not set" (nil) from "set to empty" (ptr to "").
 	Condition *string `json:"Condition,omitempty" xrpl:"Condition,omitempty"`
+
+	// FinishFunction is the WASM code run at finish time (SmartEscrow, optional).
+	FinishFunction *string `json:"FinishFunction,omitempty" xrpl:"FinishFunction,omitempty"`
+
+	// Data is the escrow's initial mutable data (SmartEscrow, optional).
+	Data *string `json:"Data,omitempty" xrpl:"Data,omitempty"`
 }
 
 func NewEscrowCreate(account, destination string, amount tx.Amount) *EscrowCreate {
@@ -138,6 +144,23 @@ func (e *EscrowCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Resu
 	rules := config.GetRules()
 	closeTime := config.ParentCloseTime
 
+	// SmartEscrow field gating. FinishFunction/Data require the amendment; a
+	// FinishFunction requires a CancelAfter; Data requires a FinishFunction; and
+	// Data is bounded by maxWasmDataLength.
+	if (e.FinishFunction != nil || e.Data != nil) && !rules.Enabled(amendment.FeatureSmartEscrow) {
+		return tx.TemDISABLED
+	}
+	if e.FinishFunction != nil && e.CancelAfter == nil {
+		// Reference: rippled EscrowCreate.cpp preflight line 171
+		return tx.TemBAD_EXPIRATION
+	}
+	if e.Data != nil && e.FinishFunction == nil {
+		return tx.TemMALFORMED
+	}
+	if e.Data != nil && len(*e.Data)/2 > maxWasmDataLength {
+		return tx.TemMALFORMED
+	}
+
 	// Time validation against parent close time
 	// Reference: rippled Escrow.cpp:457-489
 	if rules.Enabled(amendment.FeatureFix1571) {
@@ -205,10 +228,11 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Amendment-gated preflight: fix1571 requires FinishAfter or Condition
-	// Reference: rippled Escrow.cpp:160-167
+	// Amendment-gated preflight: fix1571 requires FinishAfter or Condition.
+	// SmartEscrow additionally accepts a FinishFunction as the completion gate.
+	// Reference: rippled EscrowCreate.cpp preflight line 178
 	if rules.Enabled(amendment.FeatureFix1571) {
-		if e.FinishAfter == nil && (e.Condition == nil || *e.Condition == "") {
+		if e.FinishAfter == nil && (e.Condition == nil || *e.Condition == "") && e.FinishFunction == nil {
 			return tx.TemMALFORMED
 		}
 	}
@@ -464,6 +488,14 @@ func serializeEscrow(txn *EscrowCreate, ownerID, destID [20]byte, sequence uint3
 
 	if txn.Condition != nil && *txn.Condition != "" {
 		jsonObj["Condition"] = *txn.Condition
+	}
+
+	if txn.FinishFunction != nil && *txn.FinishFunction != "" {
+		jsonObj["FinishFunction"] = *txn.FinishFunction
+	}
+
+	if txn.Data != nil && *txn.Data != "" {
+		jsonObj["Data"] = *txn.Data
 	}
 
 	// SourceTag from Common fields

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -34,6 +34,10 @@ type EscrowFinish struct {
 	// Used for deposit preauth with credentials.
 	// Reference: rippled sfCredentialIDs
 	CredentialIDs []string `json:"CredentialIDs,omitempty" xrpl:"CredentialIDs,omitempty"`
+
+	// ComputationAllowance is the gas budget for the escrow's FinishFunction
+	// (SmartEscrow). Required when finishing an escrow that has a FinishFunction.
+	ComputationAllowance *uint32 `json:"ComputationAllowance,omitempty" xrpl:"ComputationAllowance,omitempty"`
 }
 
 func NewEscrowFinish(account, owner string, offerSequence uint32) *EscrowFinish {
@@ -151,6 +155,12 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TemDISABLED
 	}
 
+	// ComputationAllowance requires the SmartEscrow amendment.
+	// Reference: rippled EscrowFinish.cpp preflight line 80
+	if e.ComputationAllowance != nil && !rules.Enabled(amendment.FeatureSmartEscrow) {
+		return tx.TemDISABLED
+	}
+
 	// --- Preclaim: credential validation (before time checks) ---
 	// Reference: rippled EscrowFinish::preclaim() calls credentials::valid()
 	// This must run before doApply's time checks because rippled's preclaim
@@ -185,6 +195,15 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	isXRP := escrowEntry.IsXRP
+
+	// SmartEscrow preclaim: the escrow's FinishFunction and the transaction's
+	// ComputationAllowance must be present together. Done in preclaim ordering
+	// (before the time/condition checks) so a field mismatch is reported even
+	// when the fulfillment is also wrong.
+	// Reference: rippled EscrowFinish::preclaim() lines 260-278
+	if result := smartEscrowFinishPreclaim(ctx, e, escrowData); result != tx.TesSUCCESS {
+		return result
+	}
 
 	// Token escrow preclaim
 	// Reference: rippled EscrowFinish::preclaim() lines 760-793
@@ -262,6 +281,14 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Debug("escrow finish: fulfillment verified successfully")
 	}
 
+	// SmartEscrow: if the escrow carries a finish function, execute it now that
+	// the condition (if any) has been verified. A non-positive result rejects
+	// the finish (tecWASM_REJECTED). Field pairing was checked in preclaim.
+	// Reference: rippled EscrowFinish::doApply() lines 406-457
+	if r := runSmartEscrow(ctx, e, escrowData); r != tx.TesSUCCESS {
+		return r
+	}
+
 	// Determine if finisher is the destination and/or the owner.
 	destIsSelf := ctx.AccountID == escrowEntry.DestinationID
 
@@ -281,30 +308,37 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Check for expired credentials BEFORE deposit auth check.
-	// Reference: rippled verifyDepositPreauth() — first calls removeExpired(),
-	// returns tecEXPIRED if any credentials were expired.
-	if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if removeExpiredCredentials(ctx, e.CredentialIDs) {
-			return tx.TecEXPIRED
+	// Deposit-authorization is skipped under SmartEscrow: when a finish function
+	// governs the escrow, authorization is delegated to the contract. This
+	// mirrors rippled gating the whole verifyDepositPreauth (including the
+	// expired-credential pass) on !featureSmartEscrow.
+	// Reference: rippled EscrowFinish.cpp doApply lines 393-403
+	if !rules.Enabled(amendment.FeatureSmartEscrow) {
+		// Check for expired credentials BEFORE deposit auth check.
+		// Reference: rippled verifyDepositPreauth() — first calls removeExpired(),
+		// returns tecEXPIRED if any credentials were expired.
+		if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
+			if removeExpiredCredentials(ctx, e.CredentialIDs) {
+				return tx.TecEXPIRED
+			}
 		}
-	}
 
-	// Deposit authorization check
-	// Reference: rippled verifyDepositPreauth() in CredentialHelpers.cpp
-	if rules.Enabled(amendment.FeatureDepositAuth) {
-		if (destAccount.Flags & state.LsfDepositAuth) != 0 {
-			if ctx.AccountID != escrowEntry.DestinationID {
-				// Check account-based DepositPreauth
-				preauthKey := keylet.DepositPreauth(escrowEntry.DestinationID, ctx.AccountID)
-				if exists, _ := ctx.View.Exists(preauthKey); !exists {
-					// No account-based preauth — check credential-based
-					if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-						if result := authorizedDepositPreauth(ctx, e.CredentialIDs, escrowEntry.DestinationID); result != tx.TesSUCCESS {
-							return result
+		// Deposit authorization check
+		// Reference: rippled verifyDepositPreauth() in CredentialHelpers.cpp
+		if rules.Enabled(amendment.FeatureDepositAuth) {
+			if (destAccount.Flags & state.LsfDepositAuth) != 0 {
+				if ctx.AccountID != escrowEntry.DestinationID {
+					// Check account-based DepositPreauth
+					preauthKey := keylet.DepositPreauth(escrowEntry.DestinationID, ctx.AccountID)
+					if exists, _ := ctx.View.Exists(preauthKey); !exists {
+						// No account-based preauth — check credential-based
+						if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
+							if result := authorizedDepositPreauth(ctx, e.CredentialIDs, escrowEntry.DestinationID); result != tx.TesSUCCESS {
+								return result
+							}
+						} else {
+							return tx.TecNO_PERMISSION
 						}
-					} else {
-						return tx.TecNO_PERMISSION
 					}
 				}
 			}

--- a/internal/tx/escrow/escrow_view.go
+++ b/internal/tx/escrow/escrow_view.go
@@ -1,0 +1,39 @@
+package escrow
+
+import (
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/wasm/host"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// escrowView adapts an ApplyContext and the escrow being finished to the
+// host.View interface the WASM finish function reads ledger state through.
+type escrowView struct {
+	ctx         *tx.ApplyContext
+	txBytes     []byte // the EscrowFinish transaction, serialized
+	escrowBytes []byte // the escrow ledger object, serialized (the current object)
+}
+
+var _ host.View = (*escrowView)(nil)
+
+func (v *escrowView) LedgerSeq() uint32                 { return v.ctx.Config.LedgerSequence }
+func (v *escrowView) ParentCloseTime() uint32           { return v.ctx.Config.ParentCloseTime }
+func (v *escrowView) ParentHash() [32]byte              { return v.ctx.Config.ParentHash }
+func (v *escrowView) BaseFee() uint32                   { return uint32(v.ctx.Config.BaseFee) }
+func (v *escrowView) AmendmentEnabled(id [32]byte) bool { return v.ctx.Rules().Enabled(id) }
+func (v *escrowView) TxBytes() []byte                   { return v.txBytes }
+func (v *escrowView) CurrentObjBytes() []byte           { return v.escrowBytes }
+
+func (v *escrowView) ReadSLE(index [32]byte) ([]byte, bool) {
+	data, err := v.ctx.View.Read(keylet.Keylet{Key: index})
+	if err != nil || data == nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// FindNFTURI is not yet wired (NFTokenPage traversal); get_nft from a finish
+// function returns not-found for now.
+func (v *escrowView) FindNFTURI(_ [20]byte, _ [32]byte) ([]byte, bool) {
+	return nil, false
+}

--- a/internal/tx/escrow/smartescrow.go
+++ b/internal/tx/escrow/smartescrow.go
@@ -1,0 +1,94 @@
+package escrow
+
+import (
+	"encoding/hex"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/wasm"
+	"github.com/LeJamon/go-xrpl/internal/wasm/host"
+)
+
+// maxWasmDataLength bounds the escrow's mutable Data field, matching rippled's
+// Protocol.h (4KB).
+const maxWasmDataLength = 4 * 1024
+
+// smartEscrowFinishPreclaim validates the FinishFunction/ComputationAllowance
+// pairing for an EscrowFinish. It runs in the preclaim portion of Apply, before
+// the doApply-stage condition and WASM checks, so a field mismatch is reported
+// even when the fulfillment is also wrong. escrowData is the serialized escrow
+// ledger object being finished.
+// Reference: rippled EscrowFinish.cpp preclaim lines 260-278
+func smartEscrowFinishPreclaim(ctx *tx.ApplyContext, e *EscrowFinish, escrowData []byte) tx.Result {
+	if !ctx.Rules().Enabled(amendment.FeatureSmartEscrow) {
+		return tx.TesSUCCESS
+	}
+	_, hasFF := escrowFinishFunctionHex(escrowData)
+	hasCA := e.ComputationAllowance != nil
+	switch {
+	case hasFF && !hasCA:
+		return tx.TefWASM_FIELD_NOT_INCLUDED
+	case !hasFF && hasCA:
+		return tx.TefNO_WASM
+	}
+	return tx.TesSUCCESS
+}
+
+// runSmartEscrow executes the escrow's FinishFunction, mirroring the WASM block
+// of rippled's EscrowFinish::doApply. It assumes smartEscrowFinishPreclaim has
+// already validated field presence. It returns TesSUCCESS when SmartEscrow is
+// disabled or the escrow has no finish function, tecWASM_REJECTED when the
+// function returns a non-positive result, or a tec/tef on execution failure.
+//
+// The engine is reached through internal/wasm, a stub unless built with
+// -tags wasmi; in a stub build engine.Run reports ErrCGODisabled, mapped here
+// to tecFAILED_PROCESSING (only reachable once SmartEscrow is enabled).
+// Reference: rippled EscrowFinish.cpp doApply lines 406-457
+func runSmartEscrow(ctx *tx.ApplyContext, e *EscrowFinish, escrowData []byte) tx.Result {
+	if !ctx.Rules().Enabled(amendment.FeatureSmartEscrow) {
+		return tx.TesSUCCESS
+	}
+	ffHex, hasFF := escrowFinishFunctionHex(escrowData)
+	if !hasFF {
+		return tx.TesSUCCESS
+	}
+	if e.ComputationAllowance == nil {
+		// Already validated in smartEscrowFinishPreclaim; defensive, matching
+		// rippled's "just in case" tecINTERNAL.
+		return tx.TecINTERNAL
+	}
+
+	wasmBytes, err := hex.DecodeString(ffHex)
+	if err != nil {
+		return tx.TefINTERNAL
+	}
+
+	view := &escrowView{ctx: ctx, txBytes: e.GetRawBytes(), escrowBytes: escrowData}
+	engine := wasm.New()
+	defer engine.Close()
+	res, runErr := engine.Run(wasmBytes, "finish", nil, host.New(view), int64(*e.ComputationAllowance))
+	if runErr != nil {
+		ctx.Log.Debug("escrow finish: wasm execution failed", "error", runErr)
+		return tx.TecFAILED_PROCESSING
+	}
+	ctx.Log.Debug("escrow finish: wasm ran", "result", res.Result, "cost", res.Cost)
+	if res.Result <= 0 {
+		return tx.TecWASM_REJECTED
+	}
+	return tx.TesSUCCESS
+}
+
+// escrowFinishFunctionHex extracts the FinishFunction (hex string) from a
+// serialized escrow ledger object.
+func escrowFinishFunctionHex(escrowData []byte) (string, bool) {
+	m, err := binarycodec.DecodeBytes(escrowData)
+	if err != nil {
+		return "", false
+	}
+	ff, ok := m["FinishFunction"].(string)
+	if !ok || ff == "" {
+		return "", false
+	}
+	return ff, true
+}

--- a/internal/tx/ledgerfields/escrow_gen.go
+++ b/internal/tx/ledgerfields/escrow_gen.go
@@ -28,6 +28,8 @@ type Escrow struct {
 	Condition         string // Blob (uppercase hex)
 	CancelAfter       uint32
 	FinishAfter       uint32
+	FinishFunction    string // Blob (uppercase hex)
+	Data              string // Blob (uppercase hex)
 	SourceTag         uint32
 	DestinationTag    uint32
 	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
@@ -46,6 +48,8 @@ const (
 	escrowBitCondition
 	escrowBitCancelAfter
 	escrowBitFinishAfter
+	escrowBitFinishFunction
+	escrowBitData
 	escrowBitSourceTag
 	escrowBitDestinationTag
 	escrowBitOwnerNode
@@ -169,6 +173,12 @@ func (e *Escrow) Decode(data []byte) error {
 			case 17:
 				e.Condition = val
 				e.present |= escrowBitCondition
+			case 27:
+				e.Data = val
+				e.present |= escrowBitData
+			case 32:
+				e.FinishFunction = val
+				e.present |= escrowBitFinishFunction
 			default:
 				return newErrUnknownField("Escrow", typeCode, fieldCode)
 			}
@@ -215,6 +225,12 @@ func (e *Escrow) emitAll(out map[string]any, skipDefault bool) {
 	}
 	if e.present&escrowBitFinishAfter != 0 && !(skipDefault && e.FinishAfter == 0) {
 		out["FinishAfter"] = e.FinishAfter
+	}
+	if e.present&escrowBitFinishFunction != 0 && !(skipDefault && e.FinishFunction == "") {
+		out["FinishFunction"] = e.FinishFunction
+	}
+	if e.present&escrowBitData != 0 && !(skipDefault && e.Data == "") {
+		out["Data"] = e.Data
 	}
 	if e.present&escrowBitSourceTag != 0 && !(skipDefault && e.SourceTag == 0) {
 		out["SourceTag"] = e.SourceTag
@@ -264,6 +280,8 @@ func (e *Escrow) EmitPreviousFields(prev Entry, out map[string]any) {
 	emitIfChangedString(out, "Condition", p.Condition, e.Condition, p.present&escrowBitCondition, e.present&escrowBitCondition)
 	emitIfChangedUint32(out, "CancelAfter", p.CancelAfter, e.CancelAfter, p.present&escrowBitCancelAfter, e.present&escrowBitCancelAfter)
 	emitIfChangedUint32(out, "FinishAfter", p.FinishAfter, e.FinishAfter, p.present&escrowBitFinishAfter, e.present&escrowBitFinishAfter)
+	emitIfChangedString(out, "FinishFunction", p.FinishFunction, e.FinishFunction, p.present&escrowBitFinishFunction, e.present&escrowBitFinishFunction)
+	emitIfChangedString(out, "Data", p.Data, e.Data, p.present&escrowBitData, e.present&escrowBitData)
 	emitIfChangedUint32(out, "SourceTag", p.SourceTag, e.SourceTag, p.present&escrowBitSourceTag, e.present&escrowBitSourceTag)
 	emitIfChangedUint32(out, "DestinationTag", p.DestinationTag, e.DestinationTag, p.present&escrowBitDestinationTag, e.present&escrowBitDestinationTag)
 	emitIfChangedString(out, "OwnerNode", p.OwnerNode, e.OwnerNode, p.present&escrowBitOwnerNode, e.present&escrowBitOwnerNode)
@@ -296,6 +314,12 @@ func (e *Escrow) EmitChangeOrigFields(out map[string]any) {
 	}
 	if e.present&escrowBitFinishAfter != 0 {
 		out["FinishAfter"] = e.FinishAfter
+	}
+	if e.present&escrowBitFinishFunction != 0 {
+		out["FinishFunction"] = e.FinishFunction
+	}
+	if e.present&escrowBitData != 0 {
+		out["Data"] = e.Data
 	}
 	if e.present&escrowBitSourceTag != 0 {
 		out["SourceTag"] = e.SourceTag
@@ -376,6 +400,12 @@ func (e *Escrow) ToMap() map[string]any {
 	}
 	if e.present&escrowBitFinishAfter != 0 {
 		out["FinishAfter"] = e.FinishAfter
+	}
+	if e.present&escrowBitFinishFunction != 0 {
+		out["FinishFunction"] = e.FinishFunction
+	}
+	if e.present&escrowBitData != 0 {
+		out["Data"] = e.Data
 	}
 	if e.present&escrowBitSourceTag != 0 {
 		out["SourceTag"] = e.SourceTag

--- a/internal/tx/ledgerfields/spec/spec.go
+++ b/internal/tx/ledgerfields/spec/spec.go
@@ -342,6 +342,8 @@ var Specs = []Entry{
 			{Name: "Condition"},
 			{Name: "CancelAfter"},
 			{Name: "FinishAfter"},
+			{Name: "FinishFunction"},
+			{Name: "Data"},
 			{Name: "SourceTag"},
 			{Name: "DestinationTag"},
 			{Name: "OwnerNode"},

--- a/internal/tx/result.go
+++ b/internal/tx/result.go
@@ -131,6 +131,13 @@ const (
 	TecPSEUDO_ACCOUNT                     Result = 196
 	TecPRECISION_LOSS                     Result = 197
 	TecNO_DELEGATE_PERMISSION             Result = 198
+	// TecWASM_REJECTED: a contract's WASM finish function rejected the
+	// transaction. rippled's smart-escrow branch numbers this 198, but that
+	// collides with the already-landed PermissionDelegation tecNO_DELEGATE_
+	// PERMISSION=198 (the two are separate, not-yet-merged rippled feature
+	// branches that each claimed 198). Assigned the next free slot here pending
+	// upstream reconciliation; only observable once SmartEscrow is enabled.
+	TecWASM_REJECTED Result = 199
 
 	// tefFAILURE and related codes (-199 to -100)
 	// Transaction failed, fee claimed but tx not applied
@@ -156,6 +163,12 @@ const (
 	TefNO_TICKET                   Result = -180
 	TefNFTOKEN_IS_NOT_TRANSFERABLE Result = -179
 	TefINVALID_LEDGER_FIX_TYPE     Result = -178
+	// SmartEscrow field-mismatch rejects (fee claimed): a WASM-specific field
+	// was present without finish-function code, or vice versa. Values match
+	// rippled's smart-escrow TER.h (auto-numbered after
+	// tefINVALID_LEDGER_FIX_TYPE=-178).
+	TefNO_WASM                 Result = -177
+	TefWASM_FIELD_NOT_INCLUDED Result = -176
 
 	// telLOCAL_ERROR and related codes (-399 to -300)
 	// Local error, transaction not sent to network
@@ -339,6 +352,7 @@ var resultNames = map[Result]string{
 	TecPSEUDO_ACCOUNT:                     "tecPSEUDO_ACCOUNT",
 	TecPRECISION_LOSS:                     "tecPRECISION_LOSS",
 	TecNO_DELEGATE_PERMISSION:             "tecNO_DELEGATE_PERMISSION",
+	TecWASM_REJECTED:                      "tecWASM_REJECTED",
 	TefFAILURE:                            "tefFAILURE",
 	TefALREADY:                            "tefALREADY",
 	TefBAD_ADD_AUTH:                       "tefBAD_ADD_AUTH",
@@ -361,6 +375,8 @@ var resultNames = map[Result]string{
 	TefNO_TICKET:                          "tefNO_TICKET",
 	TefNFTOKEN_IS_NOT_TRANSFERABLE:        "tefNFTOKEN_IS_NOT_TRANSFERABLE",
 	TefINVALID_LEDGER_FIX_TYPE:            "tefINVALID_LEDGER_FIX_TYPE",
+	TefNO_WASM:                            "tefNO_WASM",
+	TefWASM_FIELD_NOT_INCLUDED:            "tefWASM_FIELD_NOT_INCLUDED",
 	TelLOCAL_ERROR:                        "telLOCAL_ERROR",
 	TelBAD_DOMAIN:                         "telBAD_DOMAIN",
 	TelBAD_PATH_COUNT:                     "telBAD_PATH_COUNT",


### PR DESCRIPTION
## Summary

Wires the WASM engine (host layer from #704) into the escrow transactors, completing the SmartEscrow computational-finish flow.

- **EscrowCreate** gains `FinishFunction` (WASM code) and `Data` (initial mutable state), gated behind `featureSmartEscrow`. A `FinishFunction` requires a `CancelAfter` (`temBAD_EXPIRATION`) and now satisfies the fix1571 "must have FinishAfter/Condition/FinishFunction" requirement; `Data` requires a `FinishFunction` and is bounded by `maxWasmDataLength` (4 KB).
- **EscrowFinish** gains `ComputationAllowance` (the WASM gas budget). The `FinishFunction`/`ComputationAllowance` pairing is validated in preclaim ordering (`tefWASM_FIELD_NOT_INCLUDED` / `tefNO_WASM`), before the time/condition checks.
- When the escrow carries a finish function, it runs through `internal/wasm` in `doApply` **after** the crypto-condition check; a non-positive return rejects the finish (`tecWASM_REJECTED`). Under SmartEscrow, `verifyDepositPreauth` is skipped — authorization is delegated to the contract, mirroring rippled `EscrowFinish.cpp:393-403`.
- New TER codes `tecWASM_REJECTED`, `tefNO_WASM`, `tefWASM_FIELD_NOT_INCLUDED`. The tef values match rippled's smart-escrow `TER.h`; `tecWASM_REJECTED` is 199 (rippled 198 collides with the already-landed `tecNO_DELEGATE_PERMISSION=198`).

All SmartEscrow behavior is gated behind the `Supported::No` / `DefaultNo` amendment, so the default build, conformance, and testnet are unaffected.

Reference: rippled `ripple/smart-escrow` — `EscrowCreate.cpp`, `EscrowFinish.cpp`, `EscrowSmart_test.cpp`.

Stacked on #714 (#704 host functions); base is `feat/issue-704-wasm-host`.

## Test plan

- [x] `go test ./internal/tx/... ./internal/testing/escrow/...` (default build) — 0 failures
- [x] `go test -tags wasmi ./internal/testing/escrow/... ./internal/wasm/...` — engine actually runs the finish function
  - `TestSmartEscrow_FinishAccepts` (WASM returns 1) → `tesSUCCESS`
  - `TestSmartEscrow_FinishRejects` (WASM returns 0) → `tecWASM_REJECTED`
  - `TestSmartEscrow_FinishMissingAllowance` → `tefWASM_FIELD_NOT_INCLUDED` (default build)
  - `TestSmartEscrow_FinishNoFunction` → `tefNO_WASM` (default build)
- [x] Build matrix: default (cgo), `-tags wasmi`, `CGO_ENABLED=0` all build
- [x] `golangci-lint` clean (default and `--build-tags wasmi`)

Fixes #705