### PR TITLE
SmartEscrow: fee parity + WASM extension fee-settings (#717)

### DIFF
--- a/codec/binarycodec/definitions/definitions.json
+++ b/codec/binarycodec/definitions/definitions.json
@@ -3449,6 +3449,36 @@
         "isVLEncoded": false,
         "type": "UInt32"
       }
+    ],
+    [
+      "ExtensionComputeLimit",
+      {
+        "nth": 69,
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "ExtensionSizeLimit",
+      {
+        "nth": 70,
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "GasPrice",
+      {
+        "nth": 71,
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "type": "UInt32"
+      }
     ]
   ],
   "LEDGER_ENTRY_TYPES": {

--- a/internal/ledger/genesis/dtos.go
+++ b/internal/ledger/genesis/dtos.go
@@ -27,6 +27,12 @@ type feeSettings struct {
 	ReferenceFeeUnits *uint32
 	ReserveBase       *uint32
 	ReserveIncrement  *uint32
+
+	// SmartEscrow / WASM extension fees, present only when the SmartEscrow
+	// amendment is active at genesis. Reference: rippled Config.h FeeSetup.
+	ExtensionComputeLimit *uint32
+	ExtensionSizeLimit    *uint32
+	GasPrice              *uint32
 }
 
 func newFeeSettings(baseFee, reserveBase, reserveIncrement drops.XRPAmount) *feeSettings {

--- a/internal/ledger/genesis/genesis.go
+++ b/internal/ledger/genesis/genesis.go
@@ -16,6 +16,7 @@ import (
 	secp256k1 "github.com/LeJamon/go-xrpl/crypto/secp256k1"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
@@ -121,6 +122,19 @@ func DefaultConfig() Config {
 func hasXRPFeesAmendment(amendments [][32]byte) bool {
 	for _, a := range amendments {
 		if a == amendment.FeatureXRPFees {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSmartEscrowAmendment reports whether the SmartEscrow amendment is active at
+// genesis, in which case the FeeSettings entry carries the WASM extension fee
+// fields seeded from the FeeSetup defaults. Reference: rippled writes
+// gasPrice/extension limits to FeeSettings once featureSmartEscrow is enabled.
+func hasSmartEscrowAmendment(amendments [][32]byte) bool {
+	for _, a := range amendments {
+		if a == amendment.FeatureSmartEscrow {
 			return true
 		}
 	}
@@ -380,6 +394,16 @@ func createFeeSettings(stateMap *shamap.SHAMap, cfg Config) error {
 		)
 	}
 
+	// SmartEscrow seeds the WASM extension fee fields from the FeeSetup defaults.
+	if hasSmartEscrowAmendment(cfg.Amendments) {
+		compute := state.DefaultExtensionComputeLimit
+		size := state.DefaultExtensionSizeLimit
+		gas := state.DefaultGasPrice
+		feeSettings.ExtensionComputeLimit = &compute
+		feeSettings.ExtensionSizeLimit = &size
+		feeSettings.GasPrice = &gas
+	}
+
 	// Serialize the fee settings entry
 	data, err := serializeFeeSettings(feeSettings)
 	if err != nil {
@@ -521,6 +545,17 @@ func serializeFeeSettings(f *feeSettings) ([]byte, error) {
 		if f.ReserveIncrement != nil {
 			jsonObj["ReserveIncrement"] = *f.ReserveIncrement
 		}
+	}
+
+	// SmartEscrow extension fees (UInt32), independent of the modern/legacy split.
+	if f.ExtensionComputeLimit != nil {
+		jsonObj["ExtensionComputeLimit"] = *f.ExtensionComputeLimit
+	}
+	if f.ExtensionSizeLimit != nil {
+		jsonObj["ExtensionSizeLimit"] = *f.ExtensionSizeLimit
+	}
+	if f.GasPrice != nil {
+		jsonObj["GasPrice"] = *f.GasPrice
 	}
 
 	// Encode using the binary codec

--- a/internal/ledger/genesis/smartescrow_fee_test.go
+++ b/internal/ledger/genesis/smartescrow_fee_test.go
@@ -1,0 +1,60 @@
+package genesis
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func readGenesisFeeSettings(t *testing.T, cfg Config) *state.FeeSettings {
+	t.Helper()
+	g, err := Create(cfg)
+	if err != nil {
+		t.Fatalf("Create genesis failed: %v", err)
+	}
+	item, found, err := g.StateMap.Get(keylet.Fees().Key)
+	if err != nil || !found {
+		t.Fatalf("FeeSettings not found in genesis state map (err=%v found=%v)", err, found)
+	}
+	fs, err := state.ParseFeeSettings(item.Data())
+	if err != nil {
+		t.Fatalf("Failed to parse FeeSettings: %v", err)
+	}
+	return fs
+}
+
+// TestGenesisFeeSettings_NoSmartEscrow guards conformance: without the
+// SmartEscrow amendment the FeeSettings entry must NOT carry the WASM extension
+// fee fields, so the genesis state hash is unchanged for existing networks.
+func TestGenesisFeeSettings_NoSmartEscrow(t *testing.T) {
+	t.Parallel()
+	fs := readGenesisFeeSettings(t, DefaultConfig())
+	if fs.HasExtensionFees {
+		t.Fatalf("FeeSettings unexpectedly carries extension fees without SmartEscrow")
+	}
+}
+
+// TestGenesisFeeSettings_SmartEscrow verifies that enabling SmartEscrow at
+// genesis seeds the WASM extension fee fields from the FeeSetup defaults.
+// Reference: rippled Config.h FeeSetup (1,000,000 / 100,000 / 1,000,000).
+func TestGenesisFeeSettings_SmartEscrow(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	cfg.Amendments = append(append([][32]byte{}, cfg.Amendments...), amendment.FeatureSmartEscrow)
+
+	fs := readGenesisFeeSettings(t, cfg)
+	if !fs.HasExtensionFees {
+		t.Fatalf("FeeSettings missing extension fees with SmartEscrow enabled")
+	}
+	if got := fs.GetExtensionComputeLimit(); got != state.DefaultExtensionComputeLimit {
+		t.Errorf("ExtensionComputeLimit = %d, want %d", got, state.DefaultExtensionComputeLimit)
+	}
+	if got := fs.GetExtensionSizeLimit(); got != state.DefaultExtensionSizeLimit {
+		t.Errorf("ExtensionSizeLimit = %d, want %d", got, state.DefaultExtensionSizeLimit)
+	}
+	if got := fs.GetGasPrice(); got != state.DefaultGasPrice {
+		t.Errorf("GasPrice = %d, want %d", got, state.DefaultGasPrice)
+	}
+}

--- a/internal/ledger/state/fee_settings.go
+++ b/internal/ledger/state/fee_settings.go
@@ -30,10 +30,30 @@ type FeeSettings struct {
 	// STObject::operator= (assignment) rather than a value-is-nonzero gate.
 	XRPFeesMode bool
 
+	// SmartEscrow / WASM extension fee fields. Present only once the SmartEscrow
+	// amendment is active (rippled writes them as a group via the SetFee
+	// pseudo-transaction). HasExtensionFees records whether they were present in
+	// the parsed entry so the getters can distinguish "absent" from "voted to 0".
+	// Reference: rippled Fees.h (extensionComputeLimit/extensionSizeLimit/gasPrice).
+	ExtensionComputeLimit uint32
+	ExtensionSizeLimit    uint32
+	GasPrice              uint32
+	HasExtensionFees      bool
+
 	// Tracking fields (not always present)
 	PreviousTxnID     [32]byte
 	PreviousTxnLgrSeq uint32
 }
+
+// FeeSetup default values for the WASM extension fee fields, matching rippled's
+// Config.h FeeSetup (extension_compute_limit/extension_size_limit/gas_price).
+// They populate the FeeSettings entry at genesis when SmartEscrow is active and
+// back the getters when the entry predates the SmartEscrow amendment.
+const (
+	DefaultExtensionComputeLimit uint32 = 1_000_000
+	DefaultExtensionSizeLimit    uint32 = 100_000
+	DefaultGasPrice              uint32 = 1_000_000
+)
 
 // Ledger entry type for FeeSettings
 const ledgerEntryTypeFeeSettings uint16 = 0x0073
@@ -45,6 +65,11 @@ const (
 	fieldCodeReferenceFeeUnits uint8 = 30 // sfReferenceFeeUnits
 	fieldCodeReserveBase       uint8 = 31 // sfReserveBase (legacy)
 	fieldCodeReserveIncrement  uint8 = 32 // sfReserveIncrement (legacy)
+
+	// UInt32 fields (SmartEscrow / WASM extension fees)
+	fieldCodeExtensionComputeLimit uint8 = 69 // sfExtensionComputeLimit
+	fieldCodeExtensionSizeLimit    uint8 = 70 // sfExtensionSizeLimit
+	fieldCodeGasPrice              uint8 = 71 // sfGasPrice
 
 	// UInt64 fields
 	fieldCodeBaseFee uint8 = 5 // sfBaseFee (legacy)
@@ -125,6 +150,15 @@ func ParseFeeSettings(data []byte) (*FeeSettings, error) {
 				fee.ReserveBase = value
 			case fieldCodeReserveIncrement:
 				fee.ReserveIncrement = value
+			case fieldCodeExtensionComputeLimit:
+				fee.ExtensionComputeLimit = value
+				fee.HasExtensionFees = true
+			case fieldCodeExtensionSizeLimit:
+				fee.ExtensionSizeLimit = value
+				fee.HasExtensionFees = true
+			case fieldCodeGasPrice:
+				fee.GasPrice = value
+				fee.HasExtensionFees = true
 			}
 
 		case FieldTypeUInt64:
@@ -203,6 +237,15 @@ func SerializeFeeSettings(fee *FeeSettings) ([]byte, error) {
 		jsonObj["ReserveIncrement"] = fee.ReserveIncrement
 	}
 
+	// SmartEscrow extension fees are emitted as a group once present, matching
+	// rippled's SetFee handler which writes all three together under
+	// featureSmartEscrow (Change.cpp).
+	if fee.HasExtensionFees {
+		jsonObj["ExtensionComputeLimit"] = fee.ExtensionComputeLimit
+		jsonObj["ExtensionSizeLimit"] = fee.ExtensionSizeLimit
+		jsonObj["GasPrice"] = fee.GasPrice
+	}
+
 	// Add tracking fields if present
 	var zeroHash [32]byte
 	if fee.PreviousTxnID != zeroHash {
@@ -261,4 +304,33 @@ func (f *FeeSettings) GetReserveIncrement() uint64 {
 // set. Authoritative source is XRPFeesMode (set at Parse and at Apply time).
 func (f *FeeSettings) IsUsingModernFees() bool {
 	return f.XRPFeesMode
+}
+
+// GetExtensionComputeLimit returns the WASM compute limit (instructions). When
+// the entry carries no extension fees (it predates SmartEscrow), the FeeSetup
+// default is returned so a SmartEscrow enabled post-genesis still resolves the
+// standard limit. A voted value of 0 (WASM disabled) is preserved.
+func (f *FeeSettings) GetExtensionComputeLimit() uint32 {
+	if f.HasExtensionFees {
+		return f.ExtensionComputeLimit
+	}
+	return DefaultExtensionComputeLimit
+}
+
+// GetExtensionSizeLimit returns the WASM size limit (bytes); see
+// GetExtensionComputeLimit for the absent-vs-zero semantics.
+func (f *FeeSettings) GetExtensionSizeLimit() uint32 {
+	if f.HasExtensionFees {
+		return f.ExtensionSizeLimit
+	}
+	return DefaultExtensionSizeLimit
+}
+
+// GetGasPrice returns the price of one unit of WASM gas in micro-drops; see
+// GetExtensionComputeLimit for the absent-vs-zero semantics.
+func (f *FeeSettings) GetGasPrice() uint32 {
+	if f.HasExtensionFees {
+		return f.GasPrice
+	}
+	return DefaultGasPrice
 }

--- a/internal/testing/escrow/smartescrow_fields_test.go
+++ b/internal/testing/escrow/smartescrow_fields_test.go
@@ -67,9 +67,11 @@ func TestSmartEscrow_FinishNoFunction(t *testing.T) {
 			Build()))
 	env.Close()
 
+	// The ComputationAllowance fee (#717) applies even though the escrow has no
+	// FinishFunction; pay above it so the finish reaches the tefNO_WASM check.
 	allowance := uint32(1_000_000)
 	ef := escrow.EscrowFinish(bob, alice, seq).
-		Fee(baseFee * 150).
+		Fee(2_000_000).
 		BuildEscrowFinish()
 	ef.ComputationAllowance = &allowance
 	require.Equal(t, "tefNO_WASM", env.Submit(ef).Code)

--- a/internal/testing/escrow/smartescrow_test.go
+++ b/internal/testing/escrow/smartescrow_test.go
@@ -44,9 +44,11 @@ func runComputationalEscrow(t *testing.T, finishFunctionHex string) string {
 	jtx.RequireTxSuccess(t, createRes)
 	env.Close()
 
+	// A 1,000,000-unit ComputationAllowance costs ~1,000,001 drops at the default
+	// gas price (#717), so the finish must pay well above the base fee.
 	allowance := uint32(1_000_000)
 	ef := escrow.EscrowFinish(bob, alice, seq).
-		Fee(baseFee * 150).
+		Fee(2_000_000).
 		BuildEscrowFinish()
 	ef.ComputationAllowance = &allowance
 	return env.Submit(ef).Code

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -134,6 +134,25 @@ func (e *EscrowCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(e)
 }
 
+// CalculateBaseFee mirrors rippled's EscrowCreate::calculateBaseFee: the
+// multisigned base fee plus, when a FinishFunction (SmartEscrow) is attached, a
+// surcharge of 9 base fees plus 5 drops per byte of WASM code.
+// Reference: rippled EscrowCreate.cpp calculateBaseFee lines 120-131
+func (e *EscrowCreate) CalculateBaseFee(view tx.LedgerView, config tx.EngineConfig) uint64 {
+	base := config.BaseFee
+	if fs := escrowFeeSettings(view); fs != nil {
+		base = fs.GetBaseFee()
+	}
+
+	fee := tx.CalculateMultiSigFee(base, len(e.GetCommon().Signers))
+
+	if e.FinishFunction != nil && *e.FinishFunction != "" {
+		fee += 9*base + 5*vlByteLen(*e.FinishFunction)
+	}
+
+	return fee
+}
+
 // Preclaim performs stateful validation for EscrowCreate before doApply.
 // Time checks are here so that the engine's TapRETRY gate can suppress
 // tec results during retry passes, matching rippled's likelyToClaimFee

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -106,23 +106,28 @@ func (e *EscrowFinish) Flatten() (map[string]any, error) {
 // dispatch in preclaim.go skips the multisig multiplier, so it is applied here.
 // Reference: rippled Escrow.cpp:682-693, Transactor.cpp:229-244
 func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConfig) uint64 {
+	fs := escrowFeeSettings(view)
+
 	base := config.BaseFee
-	if view != nil {
-		if data, err := view.Read(keylet.Fees()); err == nil && data != nil {
-			if fs, err := state.ParseFeeSettings(data); err == nil {
-				base = fs.GetBaseFee()
-			}
-		}
+	if fs != nil {
+		base = fs.GetBaseFee()
 	}
 
 	fee := tx.CalculateMultiSigFee(base, len(e.GetCommon().Signers))
 
 	if e.Fulfillment != nil {
-		fulfillmentLen := len(*e.Fulfillment) / 2
-		if decoded, err := hex.DecodeString(*e.Fulfillment); err == nil {
-			fulfillmentLen = len(decoded)
+		fee += base * (32 + vlByteLen(*e.Fulfillment)/16)
+	}
+
+	// SmartEscrow: the ComputationAllowance gas budget is priced at gasPrice
+	// micro-drops per unit, rounded up to whole drops.
+	// Reference: rippled EscrowFinish.cpp calculateBaseFee lines 167-174
+	if e.ComputationAllowance != nil {
+		gasPrice := uint64(state.DefaultGasPrice)
+		if fs != nil {
+			gasPrice = uint64(fs.GetGasPrice())
 		}
-		fee += base * (32 + uint64(fulfillmentLen)/16)
+		fee += (uint64(*e.ComputationAllowance)*gasPrice)/microDropsPerDrop + 1
 	}
 
 	return fee

--- a/internal/tx/escrow/smartescrow.go
+++ b/internal/tx/escrow/smartescrow.go
@@ -5,14 +5,47 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/wasm"
 	"github.com/LeJamon/go-xrpl/internal/wasm/host"
+	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // maxWasmDataLength bounds the escrow's mutable Data field, matching rippled's
 // Protocol.h (4KB).
 const maxWasmDataLength = 4 * 1024
+
+// microDropsPerDrop converts WASM gas cost (priced in micro-drops) to drops.
+// Reference: rippled Fees.h microDropsPerDrop.
+const microDropsPerDrop = 1_000_000
+
+// escrowFeeSettings reads the FeeSettings ledger entry used by the SmartEscrow
+// fee formulas. It returns nil when the entry is unavailable, in which case
+// callers fall back to EngineConfig / FeeSetup defaults.
+func escrowFeeSettings(view tx.LedgerView) *state.FeeSettings {
+	if view == nil {
+		return nil
+	}
+	data, err := view.Read(keylet.Fees())
+	if err != nil || data == nil {
+		return nil
+	}
+	fs, err := state.ParseFeeSettings(data)
+	if err != nil {
+		return nil
+	}
+	return fs
+}
+
+// vlByteLen returns the decoded byte length of a hex-encoded VL field, matching
+// rippled's tx[sfField].size() (the blob's byte count, not the hex length).
+func vlByteLen(hexStr string) uint64 {
+	if decoded, err := hex.DecodeString(hexStr); err == nil {
+		return uint64(len(decoded))
+	}
+	return uint64(len(hexStr) / 2)
+}
 
 // smartEscrowFinishPreclaim validates the FinishFunction/ComputationAllowance
 // pairing for an EscrowFinish. It runs in the preclaim portion of Apply, before

--- a/internal/tx/escrow/smartescrow_fee_test.go
+++ b/internal/tx/escrow/smartescrow_fee_test.go
@@ -1,0 +1,88 @@
+package escrow
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// A trivial finish function: (module (func (export "finish") (result i32) (i32.const 1))).
+const feeTestFinishFn = "0061736d010000000105016000017f03020100070a010666696e69736800000a0601040041010b"
+
+// TestEscrowCreateBaseFee_FinishFunctionSurcharge verifies the SmartEscrow
+// FinishFunction surcharge: base*(1+signers) + 9*base + 5*size.
+// Reference: rippled EscrowCreate.cpp calculateBaseFee lines 120-131.
+func TestEscrowCreateBaseFee_FinishFunctionSurcharge(t *testing.T) {
+	const base = uint64(10)
+	cfg := tx.EngineConfig{BaseFee: base}
+
+	ffBytes, err := hex.DecodeString(feeTestFinishFn)
+	if err != nil {
+		t.Fatalf("decode finish fn: %v", err)
+	}
+	ff := feeTestFinishFn
+
+	withFF := &EscrowCreate{
+		BaseTx:         *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
+		Amount:         tx.NewXRPAmount(1000000000),
+		Destination:    "rBob",
+		CancelAfter:    ptrUint32(700000000),
+		FinishFunction: &ff,
+	}
+	want := base + 9*base + 5*uint64(len(ffBytes))
+	if got := withFF.CalculateBaseFee(nil, cfg); got != want {
+		t.Fatalf("with FinishFunction: got %d, want %d", got, want)
+	}
+
+	// Without a FinishFunction the surcharge is absent (plain base fee).
+	plain := &EscrowCreate{
+		BaseTx:      *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
+		Amount:      tx.NewXRPAmount(1000000000),
+		Destination: "rBob",
+		FinishAfter: ptrUint32(700000000),
+	}
+	if got := plain.CalculateBaseFee(nil, cfg); got != base {
+		t.Fatalf("without FinishFunction: got %d, want %d", got, base)
+	}
+}
+
+// TestEscrowFinishBaseFee_ComputationAllowance verifies the SmartEscrow finish
+// fee: base + (allowance*gasPrice/microDropsPerDrop) + 1, using the default gas
+// price (1,000,000 micro-drops). Reference: rippled EscrowFinish.cpp lines
+// 167-174.
+func TestEscrowFinishBaseFee_ComputationAllowance(t *testing.T) {
+	const base = uint64(10)
+	cfg := tx.EngineConfig{BaseFee: base}
+
+	cases := []struct {
+		allowance uint32
+		want      uint64
+	}{
+		{allowance: 1_000_000, want: base + 1_000_001}, // 1e6*1e6/1e6 + 1
+		{allowance: 2, want: base + 3},                 // 2*1e6/1e6 + 1
+		{allowance: 0, want: base + 1},                 // 0 + 1 (round-up term)
+	}
+	for _, c := range cases {
+		a := c.allowance
+		ef := &EscrowFinish{
+			BaseTx:               *tx.NewBaseTx(tx.TypeEscrowFinish, "rBob"),
+			Owner:                "rAlice",
+			OfferSequence:        5,
+			ComputationAllowance: &a,
+		}
+		if got := ef.CalculateBaseFee(nil, cfg); got != c.want {
+			t.Fatalf("allowance=%d: got %d, want %d", c.allowance, got, c.want)
+		}
+	}
+
+	// Without a ComputationAllowance the finish pays only the base fee.
+	plain := &EscrowFinish{
+		BaseTx:        *tx.NewBaseTx(tx.TypeEscrowFinish, "rBob"),
+		Owner:         "rAlice",
+		OfferSequence: 5,
+	}
+	if got := plain.CalculateBaseFee(nil, cfg); got != base {
+		t.Fatalf("without ComputationAllowance: got %d, want %d", got, base)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the SmartEscrow fee surcharges and the WASM extension fee-settings group they depend on. Stacked on #716 (#705); base is `feat/issue-705-escrow-finish`.

- **WASM fee-settings fields** added to the `FeeSettings` ledger entry: `sfExtensionComputeLimit` (nth 69), `sfExtensionSizeLimit` (nth 70), `sfGasPrice` (nth 71), all `UInt32`, matching rippled's `sfields.macro`. Parsed/serialized as an optional group; getters fall back to the `FeeSetup` defaults so an amendment enabled post-genesis still resolves the standard limits, while a voted `0` is preserved.
- **Genesis** seeds the three fields from rippled's `FeeSetup` defaults (`1,000,000` compute / `100,000` size / `1,000,000` gas price) **only when SmartEscrow is in the genesis amendments**. Existing networks are byte-identical — a regression test asserts the fields are absent without the amendment.
- **EscrowCreate.CalculateBaseFee** adds the FinishFunction surcharge `9*base + 5*FinishFunction.size()` (rippled `EscrowCreate.cpp:120-131`).
- **EscrowFinish.CalculateBaseFee** adds the ComputationAllowance gas fee `(allowance*gasPrice / microDropsPerDrop) + 1` (rippled `EscrowFinish.cpp:158-177`).

The inherited #705 finish tests (which set a 1,000,000-unit allowance) now pay the resulting ~1 XRP gas fee.

Reference: rippled `ripple/smart-escrow` — `EscrowCreate.cpp`, `EscrowFinish.cpp`, `Fees.h`, `Config.h` (FeeSetup), `sfields.macro`.

## Test plan

- [x] `internal/tx/escrow` unit tests assert the exact create surcharge and finish gas fee (incl. the `+1` round-up term and no-field baselines)
- [x] `internal/ledger/genesis` tests: SmartEscrow genesis seeds the three fields; default genesis omits them (hash stability)
- [x] `internal/ledger/state` FeeSettings serialize→parse round-trip (present→preserved, absent→defaults)
- [x] `go test ./internal/tx/... ./internal/ledger/... ./internal/rpc/... ./codec/...` — 0 failures
- [x] `-tags wasmi ./internal/testing/escrow/...` — SmartEscrow e2e green with the new fees
- [x] Build matrix (default / `-tags wasmi` / `CGO_ENABLED=0`) + `golangci-lint` clean

Fixes #717