### PR TITLE
SmartEscrow: create-time validation + bounds (#718)

### DIFF
--- a/internal/testing/escrow/smartescrow_fields_test.go
+++ b/internal/testing/escrow/smartescrow_fields_test.go
@@ -76,3 +76,46 @@ func TestSmartEscrow_FinishNoFunction(t *testing.T) {
 	ef.ComputationAllowance = &allowance
 	require.Equal(t, "tefNO_WASM", env.Submit(ef).Code)
 }
+
+// finishPlainEscrowAllowance creates a plain time-based escrow and finishes it
+// with the given ComputationAllowance, returning the finish result code. Used to
+// exercise the ComputationAllowance bound checks, which run before the escrow's
+// FinishFunction is consulted.
+func finishPlainEscrowAllowance(t *testing.T, allowance uint32, fee uint64) string {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	seq := env.Seq(alice)
+	jtx.RequireTxSuccess(t, env.Submit(
+		escrow.EscrowCreate(alice, bob, xrp(1000)).
+			FinishTime(env.Now().Add(1*time.Second)).
+			Build()))
+	env.Close()
+
+	ef := escrow.EscrowFinish(bob, alice, seq).
+		Fee(fee).
+		BuildEscrowFinish()
+	ef.ComputationAllowance = &allowance
+	return env.Submit(ef).Code
+}
+
+// TestSmartEscrow_AllowanceZero: a zero ComputationAllowance is temBAD_LIMIT.
+// Reference: rippled EscrowFinish.cpp preflight lines 109-112.
+func TestSmartEscrow_AllowanceZero(t *testing.T) {
+	require.Equal(t, "temBAD_LIMIT", finishPlainEscrowAllowance(t, 0, baseFee*150))
+}
+
+// TestSmartEscrow_AllowanceTooLarge: a ComputationAllowance above the extension
+// compute limit (default 1,000,000) is temBAD_LIMIT.
+// Reference: rippled EscrowFinish.cpp preflight lines 113-116.
+func TestSmartEscrow_AllowanceTooLarge(t *testing.T) {
+	// Fee must cover the gas fee for the (over-limit) allowance so the finish
+	// reaches the bound check rather than failing on fee adequacy first.
+	require.Equal(t, "temBAD_LIMIT", finishPlainEscrowAllowance(t, 1_000_001, 2_000_000))
+}

--- a/internal/testing/escrow/smartescrow_test.go
+++ b/internal/testing/escrow/smartescrow_test.go
@@ -65,3 +65,44 @@ func TestSmartEscrow_FinishAccepts(t *testing.T) {
 func TestSmartEscrow_FinishRejects(t *testing.T) {
 	require.Equal(t, "tecWASM_REJECTED", runComputationalEscrow(t, finishReturns0))
 }
+
+// Malformed FinishFunction WASM rejected at create time (preflightEscrowWasm),
+// only validated when the wasmi engine is linked.
+const (
+	// Not a valid WASM module (no magic header).
+	finishGarbage = "deadbeefdeadbeef"
+	// Valid module, but the export is named "fonish" — no "finish" entry point.
+	finishWrongExport = "0061736d010000000105016000017f03020100070a0106666f6e69736800000a0601040041010b"
+)
+
+// createWithFinishFunction creates an escrow carrying finishFunctionHex and
+// returns the EscrowCreate result code.
+func createWithFinishFunction(t *testing.T, finishFunctionHex string) string {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	ec := escrow.EscrowCreate(alice, bob, xrp(1000)).
+		CancelTime(env.Now().Add(1000 * time.Second)).
+		Fee(baseFee * 150).
+		BuildEscrowCreate()
+	ec.FinishFunction = &finishFunctionHex
+	return env.Submit(ec).Code
+}
+
+// TestSmartEscrow_CreateBadWasm: a FinishFunction that is not a well-formed
+// module is rejected at create time with temBAD_WASM.
+func TestSmartEscrow_CreateBadWasm(t *testing.T) {
+	require.Equal(t, "temBAD_WASM", createWithFinishFunction(t, finishGarbage))
+}
+
+// TestSmartEscrow_CreateMissingFinishExport: a module that does not export
+// finish() is rejected at create time with temBAD_WASM.
+func TestSmartEscrow_CreateMissingFinishExport(t *testing.T) {
+	require.Equal(t, "temBAD_WASM", createWithFinishFunction(t, finishWrongExport))
+}

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -159,7 +159,7 @@ func (e *EscrowCreate) CalculateBaseFee(view tx.LedgerView, config tx.EngineConf
 // semantics. Without this, replay-on-close would apply tecNO_PERMISSION
 // on the final pass even though the initial apply succeeded.
 // Reference: rippled Escrow.cpp EscrowCreate::doApply() lines 457-489
-func (e *EscrowCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (e *EscrowCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result {
 	rules := config.GetRules()
 	closeTime := config.ParentCloseTime
 
@@ -178,6 +178,29 @@ func (e *EscrowCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Resu
 	}
 	if e.Data != nil && len(*e.Data)/2 > maxWasmDataLength {
 		return tx.TemMALFORMED
+	}
+
+	// FinishFunction size + WASM-runtime bounds. The extension limits come from
+	// the FeeSettings entry; fee voting can disable the WASM runtime by setting a
+	// limit to 0. The module is then validated (compiles + exports finish()).
+	// Reference: rippled EscrowCreate.cpp preflight lines 214-231 + preflightSigValidated
+	if e.FinishFunction != nil {
+		sizeLimit := state.DefaultExtensionSizeLimit
+		computeLimit := state.DefaultExtensionComputeLimit
+		if fs := escrowFeeSettings(view); fs != nil {
+			sizeLimit = fs.GetExtensionSizeLimit()
+			computeLimit = fs.GetExtensionComputeLimit()
+		}
+		if sizeLimit == 0 || computeLimit == 0 {
+			return tx.TemTEMP_DISABLED
+		}
+		code, err := hex.DecodeString(*e.FinishFunction)
+		if err != nil || len(code) == 0 || uint64(len(code)) > uint64(sizeLimit) {
+			return tx.TemMALFORMED
+		}
+		if r := validateFinishFunctionWasm(code); r != tx.TesSUCCESS {
+			return r
+		}
 	}
 
 	// Time validation against parent close time

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -166,6 +166,22 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TemDISABLED
 	}
 
+	// ComputationAllowance bounds: the WASM runtime can be disabled by fee voting
+	// (compute limit 0), and the allowance must be a positive value within that
+	// limit. Reference: rippled EscrowFinish.cpp preflight lines 101-117
+	if e.ComputationAllowance != nil {
+		computeLimit := state.DefaultExtensionComputeLimit
+		if fs := escrowFeeSettings(ctx.View); fs != nil {
+			computeLimit = fs.GetExtensionComputeLimit()
+		}
+		if computeLimit == 0 {
+			return tx.TemTEMP_DISABLED
+		}
+		if *e.ComputationAllowance == 0 || *e.ComputationAllowance > computeLimit {
+			return tx.TemBAD_LIMIT
+		}
+	}
+
 	// --- Preclaim: credential validation (before time checks) ---
 	// Reference: rippled EscrowFinish::preclaim() calls credentials::valid()
 	// This must run before doApply's time checks because rippled's preclaim

--- a/internal/tx/escrow/smartescrow.go
+++ b/internal/tx/escrow/smartescrow.go
@@ -2,6 +2,7 @@ package escrow
 
 import (
 	"encoding/hex"
+	"errors"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -11,6 +12,27 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/wasm/host"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
+
+// escrowFunctionName is the WASM export a SmartEscrow finish function must
+// provide. Reference: rippled WasmVM.h escrowFunctionName.
+const escrowFunctionName = "finish"
+
+// validateFinishFunctionWasm checks that the FinishFunction WASM compiles and
+// exports a finish() -> i32 entry point, mirroring rippled's preflightEscrowWasm
+// (run after the size checks at create time). In a build without the wasmi
+// engine the module cannot be validated here; the check is skipped and the
+// finish-time execution rejects a malformed module instead.
+// Reference: rippled EscrowCreate.cpp preflightSigValidated lines 237-254
+func validateFinishFunctionWasm(code []byte) tx.Result {
+	engine := wasm.New()
+	defer engine.Close()
+	switch err := engine.Check(code, escrowFunctionName); {
+	case err == nil, errors.Is(err, wasm.ErrCGODisabled):
+		return tx.TesSUCCESS
+	default:
+		return tx.TemBAD_WASM
+	}
+}
 
 // maxWasmDataLength bounds the escrow's mutable Data field, matching rippled's
 // Protocol.h (4KB).

--- a/internal/tx/escrow/smartescrow_validation_test.go
+++ b/internal/tx/escrow/smartescrow_validation_test.go
@@ -1,0 +1,91 @@
+package escrow
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// feeOnlyView is a minimal LedgerView that serves one FeeSettings entry (for
+// keylet.Fees()) and is empty otherwise — enough to drive the Preclaim
+// extension-limit bounds against custom voted values without a full ledger.
+type feeOnlyView struct{ feeData []byte }
+
+func (v *feeOnlyView) Read(k keylet.Keylet) ([]byte, error) {
+	if k.Key == keylet.Fees().Key {
+		return v.feeData, nil
+	}
+	return nil, nil
+}
+func (v *feeOnlyView) Exists(keylet.Keylet) (bool, error)                 { return false, nil }
+func (v *feeOnlyView) Insert(keylet.Keylet, []byte) error                 { return nil }
+func (v *feeOnlyView) Update(keylet.Keylet, []byte) error                 { return nil }
+func (v *feeOnlyView) Erase(keylet.Keylet) error                          { return nil }
+func (v *feeOnlyView) AdjustDropsDestroyed(drops.XRPAmount)               {}
+func (v *feeOnlyView) ForEach(func(key [32]byte, data []byte) bool) error { return nil }
+func (v *feeOnlyView) Succ([32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+func (v *feeOnlyView) TxExists([32]byte) bool  { return false }
+func (v *feeOnlyView) Rules() *amendment.Rules { return nil }
+func (v *feeOnlyView) LedgerSeq() uint32       { return 0 }
+
+func feeViewWith(t *testing.T, fs *state.FeeSettings) *feeOnlyView {
+	t.Helper()
+	data, err := state.SerializeFeeSettings(fs)
+	if err != nil {
+		t.Fatalf("serialize fee settings: %v", err)
+	}
+	return &feeOnlyView{feeData: data}
+}
+
+func smartEscrowRules() *amendment.Rules {
+	return amendment.NewRulesBuilder().
+		Enable(amendment.FeatureSmartEscrow).
+		Enable(amendment.FeatureFix1571).
+		Build()
+}
+
+func finishFnEscrow(ff string) *EscrowCreate {
+	code := ff
+	return &EscrowCreate{
+		BaseTx:         *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
+		Amount:         tx.NewXRPAmount(1000000000),
+		Destination:    "rBob",
+		CancelAfter:    ptrUint32(700000000),
+		FinishFunction: &code,
+	}
+}
+
+// TestEscrowCreatePreclaim_FinishFunctionTooLarge: a FinishFunction larger than
+// the voted extension size limit is temMALFORMED.
+// Reference: rippled EscrowCreate.cpp preflight lines 222-228.
+func TestEscrowCreatePreclaim_FinishFunctionTooLarge(t *testing.T) {
+	view := feeViewWith(t, &state.FeeSettings{
+		XRPFeesMode: true, BaseFeeDrops: 10,
+		HasExtensionFees: true, ExtensionComputeLimit: 1_000_000, ExtensionSizeLimit: 10, GasPrice: 1_000_000,
+	})
+	cfg := tx.EngineConfig{BaseFee: 10, Rules: smartEscrowRules()}
+	// feeTestFinishFn is 39 bytes, over the 10-byte limit.
+	if got := finishFnEscrow(feeTestFinishFn).Preclaim(view, cfg); got != tx.TemMALFORMED {
+		t.Fatalf("got %v, want temMALFORMED", got)
+	}
+}
+
+// TestEscrowCreatePreclaim_RuntimeDisabled: a zero extension limit (WASM disabled
+// by fee voting) makes a FinishFunction create temTEMP_DISABLED.
+// Reference: rippled EscrowCreate.cpp preflight lines 216-220.
+func TestEscrowCreatePreclaim_RuntimeDisabled(t *testing.T) {
+	view := feeViewWith(t, &state.FeeSettings{
+		XRPFeesMode: true, BaseFeeDrops: 10,
+		HasExtensionFees: true, ExtensionComputeLimit: 0, ExtensionSizeLimit: 100_000, GasPrice: 1_000_000,
+	})
+	cfg := tx.EngineConfig{BaseFee: 10, Rules: smartEscrowRules()}
+	if got := finishFnEscrow(feeTestFinishFn).Preclaim(view, cfg); got != tx.TemTEMP_DISABLED {
+		t.Fatalf("got %v, want temTEMP_DISABLED", got)
+	}
+}

--- a/internal/tx/result.go
+++ b/internal/tx/result.go
@@ -241,6 +241,10 @@ const (
 	TemARRAY_TOO_LARGE                             Result = -252
 	TemBAD_TRANSFER_FEE                            Result = -251
 	TemINVALID_INNER_BATCH                         Result = -250
+	// SmartEscrow validation. Values match rippled's smart-escrow TER.h; -249
+	// (temBAD_MPT) is reserved there and left as a gap here.
+	TemBAD_WASM      Result = -248
+	TemTEMP_DISABLED Result = -247
 
 	// terRETRY and related codes (-99 to -1)
 	// Retry later
@@ -443,6 +447,8 @@ var resultNames = map[Result]string{
 	TemARRAY_TOO_LARGE:                             "temARRAY_TOO_LARGE",
 	TemBAD_TRANSFER_FEE:                            "temBAD_TRANSFER_FEE",
 	TemINVALID_INNER_BATCH:                         "temINVALID_INNER_BATCH",
+	TemBAD_WASM:                                    "temBAD_WASM",
+	TemTEMP_DISABLED:                               "temTEMP_DISABLED",
 	TerRETRY:                                       "terRETRY",
 	TerFUNDS_SPENT:                                 "terFUNDS_SPENT",
 	TerINSUF_FEE_B:                                 "terINSUF_FEE_B",

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -170,6 +170,34 @@ static wasm_trap_t* make_trap(wasm_store_t* store, const char* msg) {
     wasm_byte_vec_delete(&m);
     return t;
 }
+
+// check_export_func verifies the module exports a function named fname with the
+// signature () -> i32 (the escrow finish-function shape), inspecting export
+// types only — no instantiation, mirroring rippled's preflightEscrowWasm.
+// Returns 1 on match, 0 otherwise.
+static int check_export_func(const wasm_module_t* module, const char* fname) {
+    wasm_exporttype_vec_t exporttypes;
+    wasm_module_exports(module, &exporttypes);
+    int ok = 0;
+    size_t flen = strlen(fname);
+    for (size_t i = 0; i < exporttypes.size; ++i) {
+        const wasm_name_t* n = wasm_exporttype_name(exporttypes.data[i]);
+        if (n->size != flen || memcmp(n->data, fname, flen) != 0) continue;
+        const wasm_externtype_t* et = wasm_exporttype_type(exporttypes.data[i]);
+        const wasm_functype_t* ft = wasm_externtype_as_functype_const(et);
+        if (ft) {
+            const wasm_valtype_vec_t* params = wasm_functype_params(ft);
+            const wasm_valtype_vec_t* results = wasm_functype_results(ft);
+            if (params->size == 0 && results->size == 1 &&
+                wasm_valtype_kind(results->data[0]) == WASM_I32) {
+                ok = 1;
+            }
+        }
+        break;
+    }
+    wasm_exporttype_vec_delete(&exporttypes);
+    return ok;
+}
 */
 import "C"
 
@@ -282,6 +310,32 @@ func (e *Engine) Run(code []byte, funcName string, params []Param, hf HostFuncti
 	cost := int64(uint64(initialFuel) - uint64(remaining))
 
 	return Result{Result: result, Cost: cost}, nil
+}
+
+// Check validates that code compiles to a well-formed module exporting funcName
+// with the escrow finish signature () -> i32, without executing it. It mirrors
+// rippled's preflightEscrowWasm (WasmEngine::check), which compiles the module
+// and verifies the entry function rather than instantiating it. It returns
+// ErrInvalidWasm for a malformed module or a missing/mistyped entry function.
+func (e *Engine) Check(code []byte, funcName string) error {
+	store := C.wasm_store_new_with_memory_max_pages(e.engine, C.uint32_t(maxPages))
+	if store == nil {
+		return ErrExecution
+	}
+	defer C.wasm_store_delete(store)
+
+	module := compileModule(store, code)
+	if module == nil {
+		return ErrInvalidWasm
+	}
+	defer C.wasm_module_delete(module)
+
+	cname := C.CString(funcName)
+	defer C.free(unsafe.Pointer(cname))
+	if C.check_export_func(module, cname) == 0 {
+		return ErrInvalidWasm
+	}
+	return nil
 }
 
 func compileModule(store *C.wasm_store_t, code []byte) *C.wasm_module_t {

--- a/internal/wasm/engine_stub.go
+++ b/internal/wasm/engine_stub.go
@@ -19,3 +19,9 @@ func (e *Engine) Close() {}
 func (e *Engine) Run(code []byte, funcName string, params []Param, hf HostFunctions, gasLimit int64) (Result, error) {
 	return Result{}, ErrCGODisabled
 }
+
+// Check always reports ErrCGODisabled without cgo; callers treat this as "WASM
+// validation unavailable in this build" rather than a validation failure.
+func (e *Engine) Check(code []byte, funcName string) error {
+	return ErrCGODisabled
+}

--- a/internal/wasm/engine_test.go
+++ b/internal/wasm/engine_test.go
@@ -36,6 +36,30 @@ func TestEngineFibParity(t *testing.T) {
 	}
 }
 
+// TestEngineCheck exercises create-time module validation (preflightEscrowWasm):
+// a well-formed module exporting finish() -> i32 passes; non-WASM bytes and a
+// module without the finish export return ErrInvalidWasm — all without running
+// the code.
+func TestEngineCheck(t *testing.T) {
+	e := New()
+	defer e.Close()
+
+	// (module (func (export "finish") (result i32) (i32.const 1)))
+	const finishI32 = "0061736d010000000105016000017f03020100070a010666696e69736800000a0601040041010b"
+	// Same module, but the export is named "fonish" — no finish entry point.
+	const wrongName = "0061736d010000000105016000017f03020100070a0106666f6e69736800000a0601040041010b"
+
+	if err := e.Check(mustDecode(t, finishI32), "finish"); err != nil {
+		t.Errorf("valid module: unexpected error %v", err)
+	}
+	if err := e.Check([]byte("not-wasm-bytes!"), "finish"); err == nil {
+		t.Error("garbage module: expected error, got nil")
+	}
+	if err := e.Check(mustDecode(t, wrongName), "finish"); err == nil {
+		t.Error("missing finish export: expected error, got nil")
+	}
+}
+
 // TestEngineDisabledFloatRejected proves the float-disabling config flag is
 // wired: a module using f32 ops must fail to load, matching rippled's
 // tecFAILED_PROCESSING.

--- a/internal/wasm/wasm.go
+++ b/internal/wasm/wasm.go
@@ -26,6 +26,11 @@ var ErrCGODisabled = errors.New("wasm: execution unavailable (build with cgo and
 // tecFAILED_PROCESSING.
 var ErrExecution = errors.New("wasm: execution failed")
 
+// ErrInvalidWasm is returned by Check when code is not a well-formed module or
+// does not export the expected entry function. It mirrors rippled's
+// preflightEscrowWasm returning a temBAD_WASM-class result.
+var ErrInvalidWasm = errors.New("wasm: invalid module")
+
 // Result is the outcome of a successful WASM run: the i32 the entry function
 // returned, and the gas (fuel) it consumed.
 type Result struct {


### PR DESCRIPTION
## Summary

Adds the SmartEscrow preflight validation that #705 deferred. Stacked on #720 (#717); base is `feat/issue-717-smartescrow-fees`.

**EscrowCreate (FinishFunction):**
- WASM runtime disabled by fee voting (extension compute/size limit `0`) → `temTEMP_DISABLED` (rippled `EscrowCreate.cpp:214-221`).
- FinishFunction empty or larger than the voted extension size limit → `temMALFORMED` (`EscrowCreate.cpp:222-228`).
- FinishFunction is not a well-formed module exporting `finish() -> i32` → `temBAD_WASM` (`preflightSigValidated` / `preflightEscrowWasm`).

**EscrowFinish (ComputationAllowance):**
- Runtime disabled → `temTEMP_DISABLED`; allowance `0` or above the extension compute limit → `temBAD_LIMIT` (rippled `EscrowFinish.cpp:101-117`).

**Engine:** new `wasm.Engine.Check(code, funcName)` compiles the module and inspects its export types (no instantiation), mirroring rippled's `WasmEngine::check`. The non-wasmi stub returns `ErrCGODisabled`, which the escrow code treats as "validation unavailable in this build" (finish-time execution still rejects malformed WASM) — so the default build is unaffected.

New TER codes `temBAD_WASM` (-248) and `temTEMP_DISABLED` (-247) match rippled's smart-escrow `TER.h` (the -249 `temBAD_MPT` slot is left as a gap).

## Test plan

- [x] `internal/tx/escrow` unit tests: size-over-limit → `temMALFORMED`; zero limit → `temTEMP_DISABLED` (via a custom FeeSettings view)
- [x] `internal/testing/escrow` (default): allowance `0` and over-limit → `temBAD_LIMIT`
- [x] `-tags wasmi` integration: garbage and missing-`finish`-export FinishFunction → `temBAD_WASM`; valid modules still create/finish
- [x] `internal/wasm` (`-tags wasmi`): direct `Engine.Check` unit test (valid / non-WASM / wrong export)
- [x] Build matrix (default / `-tags wasmi` / `CGO_ENABLED=0`), `internal/tx` + `internal/ledger` regression, `golangci-lint` clean (both tag sets)

Fixes #718