### PR TITLE
SmartEscrow: get_nft NFTokenPage traversal (#719)

### DIFF
--- a/internal/testing/nft/findtokenuri_test.go
+++ b/internal/testing/nft/findtokenuri_test.go
@@ -1,0 +1,46 @@
+package nft_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/nft"
+	"github.com/LeJamon/go-xrpl/internal/tx/nftoken"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindTokenURI verifies nftoken.FindTokenURI, which backs the SmartEscrow
+// get_nft host function: it walks an owner's NFTokenPages and returns the raw
+// URI of a minted token, and reports not-found for an unminted id.
+func TestFindTokenURI(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+	env.Close()
+
+	const uri = "https://example.com/nft/metadata.json"
+	flags := nftoken.NFTokenFlagTransferable
+	nftIDHex := nft.GetNextNFTokenID(env, alice, 0, flags, 0)
+
+	env.Submit(nft.NFTokenMint(alice, 0).Transferable().URI(uri).Build())
+	env.Close()
+
+	var nftID [32]byte
+	raw, err := hex.DecodeString(nftIDHex)
+	require.NoError(t, err)
+	require.Len(t, raw, 32)
+	copy(nftID[:], raw)
+
+	owner := alice.AccountID()
+
+	got, ok := nftoken.FindTokenURI(env.Ledger(), owner, nftID)
+	require.True(t, ok, "minted NFT URI should be found")
+	require.Equal(t, uri, string(got))
+
+	// An unminted token id is not found.
+	var missing [32]byte
+	missing[0] = 0xAB
+	_, ok = nftoken.FindTokenURI(env.Ledger(), owner, missing)
+	require.False(t, ok, "unminted NFT should not be found")
+}

--- a/internal/tx/escrow/escrow_view.go
+++ b/internal/tx/escrow/escrow_view.go
@@ -2,6 +2,7 @@ package escrow
 
 import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/nftoken"
 	"github.com/LeJamon/go-xrpl/internal/wasm/host"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -32,8 +33,8 @@ func (v *escrowView) ReadSLE(index [32]byte) ([]byte, bool) {
 	return data, true
 }
 
-// FindNFTURI is not yet wired (NFTokenPage traversal); get_nft from a finish
-// function returns not-found for now.
-func (v *escrowView) FindNFTURI(_ [20]byte, _ [32]byte) ([]byte, bool) {
-	return nil, false
+// FindNFTURI returns the URI of the NFToken held by account, walking its
+// NFTokenPages. It backs the get_nft host function a finish function calls.
+func (v *escrowView) FindNFTURI(account [20]byte, nftID [32]byte) ([]byte, bool) {
+	return nftoken.FindTokenURI(v.ctx.View, account, nftID)
 }

--- a/internal/tx/nftoken/nftoken_page.go
+++ b/internal/tx/nftoken/nftoken_page.go
@@ -2,6 +2,7 @@ package nftoken
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -77,6 +78,27 @@ func findToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte) (keylet.Key
 	}
 
 	return keylet.Keylet{}, nil, -1, false
+}
+
+// FindTokenURI returns the raw (decoded) URI of the NFToken identified by
+// tokenID and held by owner, walking the owner's NFTokenPages. It returns
+// (nil, false) when the token is absent or carries no URI. This backs the
+// SmartEscrow get_nft host function.
+// Reference: rippled nft::findToken + WasmHostFunctionsImpl::getNFT (sfURI).
+func FindTokenURI(view tx.LedgerView, owner [20]byte, tokenID [32]byte) ([]byte, bool) {
+	_, page, idx, found := findToken(view, owner, tokenID)
+	if !found {
+		return nil, false
+	}
+	uriHex := page.NFTokens[idx].URI
+	if uriHex == "" {
+		return nil, false
+	}
+	raw, err := hex.DecodeString(uriHex)
+	if err != nil {
+		return nil, false
+	}
+	return raw, true
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces the `escrowView.FindNFTURI` not-found stub with a real NFTokenPage traversal, so the `get_nft` host function a SmartEscrow finish function calls returns an actual NFToken URI. Independent of #717/#718; base is `feat/issue-705-escrow-finish`.

- New `nftoken.FindTokenURI(view, owner, tokenID)` helper walks the owner's NFTokenPages (reusing the existing `findToken`/`locatePage` traversal) and returns the token's decoded URI, or not-found when the token is absent or carries no URI.
- `escrowView.FindNFTURI` now delegates to it.

Reference: rippled `nft::findToken` + `WasmHostFunctionsImpl::getNFT` (sfURI).

Note: the host `View.FindNFTURI` contract is `(uri, ok)`, so a token found without a URI reports not-found rather than rippled's separate `FieldNotFound`; the common case (NFT with URI) matches.

## Test plan

- [x] `internal/testing/nft`: `TestFindTokenURI` mints an NFT with a URI and asserts `FindTokenURI` returns it; an unminted id is not found
- [x] `internal/wasm/host`: existing `GetNFT` test covers the host → `View.FindNFTURI` path
- [x] Build matrix (default / `-tags wasmi` / `CGO_ENABLED=0`); nftoken/nft/escrow/host tests; `golangci-lint` clean

Fixes #719