### PR TITLE
fix: guard nil wsServer in doShutdown (avoid masking startup errors with a panic)

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -1153,8 +1153,10 @@ func doShutdown(
 		_ = srv.Shutdown(ctx)
 	}
 
-	if err := wsServer.Close(ctx); err != nil {
-		logger.Warn("WebSocket server shutdown timed out", "err", err)
+	if wsServer != nil {
+		if err := wsServer.Close(ctx); err != nil {
+			logger.Warn("WebSocket server shutdown timed out", "err", err)
+		}
 	}
 
 	// Stop the background ledger-integrity verifier before tearing down the

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -89,3 +89,18 @@ func TestReloadTrustedValidators_NilComponentsIsNoOp(t *testing.T) {
 	// success criterion is simply "doesn't crash".
 	reloadTrustedValidators(xrpllog.Discard(), nil)
 }
+
+// TestDoShutdown_ToleratesNilComponents pins the partial-init teardown
+// contract: the deferred shutdown installed in runServer fires for whatever
+// the init path managed to populate, so any component — including wsServer —
+// may be nil when an early error return triggers it. doShutdown must drain
+// and log without dereferencing a nil component. Before the wsServer guard, a
+// startup that failed before the WebSocket server was constructed crashed
+// here on wsServer.Close(), masking the real startup error with a panic.
+func TestDoShutdown_ToleratesNilComponents(t *testing.T) {
+	// All components nil reproduces the earliest failure path. The success
+	// criterion is "doesn't crash": WebSocketServer.Close dereferences its
+	// receiver on the first line (connectionsMutex.Lock), so a nil wsServer
+	// would panic without the guard this test pins.
+	doShutdown(nil, nil, nil, nil, nil, nil, nil, nil, xrpllog.Discard())
+}


### PR DESCRIPTION
## Problem

`doShutdown` (`internal/cli/server.go`) runs as a deferred cleanup on **every** `runServer` return, including early error returns made *before* the WebSocket server is constructed — e.g. the storage-open failure at `server.go:142`.

Every component `doShutdown` touches is nil-guarded (`ledgerCleaner`, `consensusComponents`, `kvDB`, `repoManager`; the `httpSrvs`/`wsSrvs` loops are nil-safe) **except `wsServer`**:

```go
if err := wsServer.Close(ctx); err != nil { ... }
```

So when startup fails before `wsServer` is built, `wsServer.Close(ctx)` dereferences a nil receiver and SIGSEGVs in `WebSocketServer.Close` (`websocket.go:958`, nil `connectionsMutex`). The panic **masks the real startup error** — the node logs `Starting go-xrpl` → `Draining HTTP connections...` → nil-pointer crash, with the actual cause (e.g. storage open failed) never printed.

## Repro

Run the distroless image with a node_db path it can't open (e.g. a full disk). Instead of a clean `storage backend: ... no space left on device`, you get:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/LeJamon/go-xrpl/internal/rpc.(*WebSocketServer).Close(0x0, ...) websocket.go:958
github.com/LeJamon/go-xrpl/internal/cli.doShutdown(...) server.go:1156
github.com/LeJamon/go-xrpl/internal/cli.runServer.func3() server.go:134
```

## Fix

Guard the `Close` call like its siblings:

```go
if wsServer != nil {
    if err := wsServer.Close(ctx); err != nil {
        logger.Warn("WebSocket server shutdown timed out", "err", err)
    }
}
```

## Verification

Rebuilt the image and reran: the real startup error now prints cleanly instead of panicking, and the node boots normally once the underlying condition (disk space) is resolved.

Surfaced by xrpl-confluence fuzzing.