### PR TITLE
fix: surface pubkey_validator and stop tx-set acquisition starving its peer set

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -673,14 +673,15 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			return out
 		}
 
-		// Expose the local validator's signing key to validator_info.
-		// Mirrors rippled's getValidationPublicKey gate: empty means
-		// the server is not configured as a validator and the handler
-		// returns "not a validator".
-		if vid, err := consensusComponents.Adaptor.GetValidatorKey(); err == nil {
-			pk := make([]byte, 33)
-			copy(pk, vid[:])
-			services.ValidatorPublicKey = pk
+		// Expose the local validator's 33-byte signing public key to
+		// validator_info / server_info. Mirrors rippled's
+		// getValidationPublicKey gate: empty means the server is not
+		// configured as a validator and the handlers return "not a
+		// validator" / "none". GetValidatorKey returns the 20-byte
+		// NodeID, NOT the public key — copying it into a 33-byte slice
+		// zero-padded the last 13 bytes and produced a bogus key.
+		if pk, err := consensusComponents.Adaptor.GetValidatorSigningKey(); err == nil {
+			services.ValidatorPublicKey = append([]byte(nil), pk[:]...)
 		}
 
 		isValidator := globalConfig.IsValidator()

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -728,7 +728,7 @@ func (a *Adaptor) GetLedger(id consensus.LedgerID) (consensus.Ledger, error) {
 }
 
 // GetLedgerBySeq returns the locally-held ledger at seq from the service's
-// adopted history (ledgerHistory[seq]). Used by the consensus catch-up walk.
+// adopted history (ledgerHistory[seq]).
 func (a *Adaptor) GetLedgerBySeq(seq uint32) (consensus.Ledger, error) {
 	l, err := a.ledgerService.GetLedgerBySequence(seq)
 	if err != nil || l == nil {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -727,6 +727,16 @@ func (a *Adaptor) GetLedger(id consensus.LedgerID) (consensus.Ledger, error) {
 	return WrapLedger(l), nil
 }
 
+// GetLedgerBySeq returns the locally-held ledger at seq from the service's
+// adopted history (ledgerHistory[seq]). Used by the consensus catch-up walk.
+func (a *Adaptor) GetLedgerBySeq(seq uint32) (consensus.Ledger, error) {
+	l, err := a.ledgerService.GetLedgerBySequence(seq)
+	if err != nil || l == nil {
+		return nil, ErrLedgerNotFound
+	}
+	return WrapLedger(l), nil
+}
+
 func (a *Adaptor) GetLastClosedLedger() (consensus.Ledger, error) {
 	l := a.ledgerService.GetClosedLedger()
 	if l == nil {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -974,6 +974,18 @@ func (a *Adaptor) GetValidatorKey() (consensus.NodeID, error) {
 	return a.identity.NodeID, nil
 }
 
+// GetValidatorSigningKey returns the local validator's 33-byte compressed
+// signing public key (the ephemeral key in token mode, equal to the master
+// key in seed-only mode). This is the value rippled exposes as
+// getValidationPublicKey() and feeds to validator_info / server_info; the
+// 20-byte NodeID from GetValidatorKey must NOT be substituted here.
+func (a *Adaptor) GetValidatorSigningKey() ([33]byte, error) {
+	if a.identity == nil {
+		return [33]byte{}, ErrNoValidatorKey
+	}
+	return a.identity.SigningKey, nil
+}
+
 func (a *Adaptor) SignProposal(proposal *consensus.Proposal) error {
 	if a.identity == nil {
 		return ErrNoValidatorKey

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -126,7 +126,8 @@ type NetworkSender interface {
 	// (PeerImp.cpp:3322-3332): shed when the peer's send queue is
 	// saturated, or when the local node is fee-loaded (loadedLocal) and
 	// the peer is not a cluster member. NEVER call this for liTS_CANDIDATE
-	// (tx-set) requests — rippled deliberately exempts them so consensus
+	// (tx-set) requests — rippled serves them on a separate branch
+	// (PeerImp.cpp:3304-3319) that never reaches these gates, so consensus
 	// liveness is not starved. Returns false for unknown peers.
 	ShouldShedLedgerRequest(peerID uint64, loadedLocal bool) bool
 }
@@ -727,10 +728,12 @@ func (a *Adaptor) GetLedger(id consensus.LedgerID) (consensus.Ledger, error) {
 	return WrapLedger(l), nil
 }
 
-// GetLedgerBySeq returns the locally-held ledger at seq from the service's
-// adopted history (ledgerHistory[seq]).
+// GetLedgerBySeq returns the locally-held CLOSED ledger at seq from the
+// service's adopted history (ledgerHistory[seq]). It reads adopted history
+// only — never the mutable open ledger — so the consensus catch-up walk can
+// never adopt an unclosed ledger as prevLedger.
 func (a *Adaptor) GetLedgerBySeq(seq uint32) (consensus.Ledger, error) {
-	l, err := a.ledgerService.GetLedgerBySequence(seq)
+	l, err := a.ledgerService.GetAdoptedLedgerBySequence(seq)
 	if err != nil || l == nil {
 		return nil, ErrLedgerNotFound
 	}

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -120,6 +120,15 @@ type NetworkSender interface {
 	// arrival, matching rippled's haveMessage set semantics
 	// (PeerImp.cpp:3010-3017).
 	PeersThatHave(suppressionHash [32]byte) []uint64
+	// ShouldShedLedgerRequest reports whether a ledger-BODY request
+	// (liBASE / liAS_NODE / liTX_NODE) from peerID should be dropped
+	// under load, mirroring rippled PeerImp::processLedgerRequest
+	// (PeerImp.cpp:3322-3332): shed when the peer's send queue is
+	// saturated, or when the local node is fee-loaded (loadedLocal) and
+	// the peer is not a cluster member. NEVER call this for liTS_CANDIDATE
+	// (tx-set) requests — rippled deliberately exempts them so consensus
+	// liveness is not starved. Returns false for unknown peers.
+	ShouldShedLedgerRequest(peerID uint64, loadedLocal bool) bool
 }
 
 // noopSender is a no-op NetworkSender for standalone or test use.
@@ -149,6 +158,7 @@ func (n *noopSender) PeerSupportsReplay(uint64) bool                           {
 func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64       { return nil }
 func (n *noopSender) IncPeerBadData(uint64, string)                            {}
 func (n *noopSender) PeersThatHave([32]byte) []uint64                          { return nil }
+func (n *noopSender) ShouldShedLedgerRequest(uint64, bool) bool                { return false }
 
 // Compile-time interface check.
 var _ consensus.Adaptor = (*Adaptor)(nil)
@@ -692,6 +702,13 @@ func (a *Adaptor) GetParentLedgerForReplay(seq uint32) *ledger.Ledger {
 
 func (a *Adaptor) SendToPeer(peerID uint64, frame []byte) error {
 	return a.sender.SendToPeer(peerID, frame)
+}
+
+// ShouldShedLedgerRequest delegates to NetworkSender; see the interface
+// doc. Kept as a thin delegator so Router can gate ledger-body serving
+// through the adaptor rather than reaching into the overlay directly.
+func (a *Adaptor) ShouldShedLedgerRequest(peerID uint64, loadedLocal bool) bool {
+	return a.sender.ShouldShedLedgerRequest(peerID, loadedLocal)
 }
 
 // LedgerService returns the underlying ledger service for direct queries.

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -704,6 +704,19 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 		"seq", validation.LedgerSeq,
 		"hash_short", fmt.Sprintf("%x", validation.LedgerID[:8]))
 
+	// Per-validation catch-up acquire (issue #724). Mirrors rippled
+	// checkAccept(hash, seq), invoked on EVERY trusted current validation
+	// (RCLValidations.cpp:208 → LedgerMaster.cpp:904-919), not only at
+	// quorum. Under sustained load a goXRPL node that falls one ledger
+	// behind enters the wrongLedger chase loop holding no position
+	// (our_pos_seq=0); with only 3 of the 4-quorum trusted validators on
+	// the network tip, the quorum-gated stash acquire
+	// (armValidationStashAcquisition) never fires, so the node never fetches
+	// the tip the network is converging on and the chain stalls below quorum
+	// until a slow periodic sweep recovers it. Acquiring on each trusted
+	// validation breaks that loop.
+	r.maybeAcquireFromValidation(validation, originPeer)
+
 	_ = lastSeen
 }
 
@@ -2161,6 +2174,62 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger, peerID uint64) error {
 		r.armParentAcquisition(svc, res.ParentSeq, res.ParentHash, peerID)
 	}
 	return nil
+}
+
+// maybeAcquireFromValidation arms inbound acquisition for a ledger attested
+// by a single TRUSTED validation, before the hash reaches quorum. It is the
+// non-quorum counterpart to armValidationStashAcquisition: rippled calls
+// checkAccept(hash, seq) on EVERY trusted current validation
+// (RCLValidations.cpp:208 → LedgerMaster.cpp:904-919), acquiring the ledger
+// via getInboundLedgers().acquire whenever getLedgerByHash is null —
+// quorum is not required. goXRPL only had the quorum-gated path, so under
+// issue #724 a node below quorum (3 of 4 trusted validators on the network
+// tip) never fetched that tip and stalled in the wrongLedger chase loop.
+//
+// This only ACQUIRES. Advancing validatedLedger still flows through the
+// quorum gate (validations.go onFullyValidated → SetValidatedLedger), so a
+// sub-quorum fetch cannot move our validated tip and carries no
+// state-divergence risk; it just makes the ledger locally available so the
+// node can rejoin consensus on the network's chain instead of holding no
+// position. The deliberately-kept peer-LCL trusted-backing gate
+// (engine.go getNetworkLedger) and the quorum gate are untouched.
+func (r *Router) maybeAcquireFromValidation(v *consensus.Validation, originPeer uint64) {
+	if v == nil || v.LedgerSeq == 0 {
+		return
+	}
+	// Only trusted validators steer chain selection (RCLValidations.cpp:194).
+	if !r.adaptor.IsTrusted(v.NodeID) {
+		return
+	}
+	svc := r.adaptor.LedgerService()
+	if svc == nil {
+		return
+	}
+	// Gate on the VALIDATED tip, never the closed/built tip — same rationale
+	// as armValidationStashAcquisition (LedgerMaster.cpp:883): a node that
+	// ran its closed chain ahead would otherwise skip the acquire and stay
+	// stuck on the wrong chain.
+	if v.LedgerSeq <= svc.GetValidatedLedgerIndex() {
+		return
+	}
+	hash := [32]byte(v.LedgerID)
+	// Already have it (built or adopted) — nothing to fetch.
+	if l, err := svc.GetLedgerByHash(hash); err == nil && l != nil {
+		return
+	}
+	// startLedgerAcquisition dedupes via isAcquiring, but checking here keeps
+	// the hot path quiet when many validations name the same hash.
+	if r.isAcquiring(hash) {
+		return
+	}
+	r.logger.Info("acquiring ledger from trusted validation",
+		"t", "consensus",
+		"event", "validation-acquire",
+		"seq", v.LedgerSeq,
+		"hash", fmt.Sprintf("%x", hash[:8]),
+		"peer", originPeer,
+	)
+	r.startLedgerAcquisition(v.LedgerSeq, hash, originPeer)
 }
 
 // armValidationStashAcquisition arms inbound acquisition for a (seq, hash)

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -949,6 +949,21 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		return
 	}
 
+	// Load-shed ledger-BODY requests under load, mirroring rippled
+	// PeerImp::processLedgerRequest (PeerImp.cpp:3322-3332). The
+	// liTS_CANDIDATE branch above is intentionally exempt — consensus
+	// liveness depends on tx-set acquisition always being served, so this
+	// gate runs only for liBASE / liAS_NODE / liTX_NODE.
+	loadedLocal := false
+	if ft := svc.FeeTrack(); ft != nil {
+		loadedLocal = ft.IsLoadedLocal()
+	}
+	if r.adaptor.ShouldShedLedgerRequest(uint64(msg.PeerID), loadedLocal) {
+		r.logger.Debug("get_ledger shed under load",
+			"peer", msg.PeerID, "itype", req.InfoType)
+		return
+	}
+
 	// Find the requested ledger
 	var l *ledger.Ledger
 	if len(req.LedgerHash) == 32 {
@@ -1237,6 +1252,31 @@ type logger interface {
 	Warn(msg string, args ...any)
 }
 
+// learnTxFromLeaf submits the transaction carried by an acquired tx-set
+// leaf into the open-ledger pool, mirroring rippled
+// ConsensusTransSetSF::gotNode (ConsensusTransSetSF.cpp:38-79): a tx-set
+// leaf is a tnTRANSACTION_NM node whose wire form is `tx_blob ||
+// WireTypeTransaction`. Inner nodes and malformed data are skipped by the
+// trailing-type-byte check, and a tx the open ledger already holds is not
+// resubmitted. local=false marks this as a peer-sourced learn.
+func (r *Router) learnTxFromLeaf(wire []byte) {
+	if len(wire) < 2 || wire[len(wire)-1] != protocol.WireTypeTransaction {
+		return
+	}
+	leaf, err := shamap.NewTransactionLeafFromWire(wire)
+	if err != nil {
+		return
+	}
+	item := leaf.Item()
+	if item == nil {
+		return
+	}
+	if r.adaptor.HasTx(consensus.TxID(item.Key())) {
+		return
+	}
+	r.adaptor.AddPendingTx(item.Data(), false)
+}
+
 // handleTxSetData consumes a TMLedgerData{type=liTS_CANDIDATE} response.
 // Each node is a SHAMap node (root/inner/leaf), not a raw transaction.
 // Mirrors TransactionAcquire::takeNodes (TransactionAcquire.cpp:175-235):
@@ -1355,20 +1395,29 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			continue
 		}
 		added++
+		// Learn the transaction from this acquired tx-set leaf, mirroring
+		// rippled ConsensusTransSetSF::gotNode → submitTransaction
+		// (ConsensusTransSetSF.cpp:51-78). A node that only ever holds a
+		// proposed set transiently still propagates and can locally source
+		// the txs it pulled from peers — without this a partially-acquired
+		// set leaves its novel txs un-relayed, prolonging network-wide stalls.
+		r.learnTxFromLeaf(node.NodeData)
 	}
 
 	if err := txMap.FinishSync(); err != nil {
 		// Mirror TransactionAcquire::trigger (TransactionAcquire.cpp:144-171):
 		// request the missing nodes. Before going to peers, fill any
-		// missing TX-leaf nodes from our own pending pool — rippled's
-		// peer reply omits leaf blobs (fatLeaves=false at
-		// PeerImp.cpp:3318) and expects the local node to source them
-		// from its TransactionMaster via ConsensusTransSetSF::getNode
-		// (ConsensusTransSetSF.cpp:82-101). For tnTRANSACTION_NM the
-		// leaf-node hash equals the tx ID, so a single tx-ID lookup
-		// resolves the missing leaf. Without this step, the missing-
-		// node request loops forever because peers will never send the
-		// leaves back, livelocking tx-set acquisition under fuzz.
+		// missing TX-leaf nodes from our own pending pool, mirroring how
+		// rippled sources leaves locally via ConsensusTransSetSF::getNode
+		// (ConsensusTransSetSF.cpp:82-106) before they are ever reported
+		// missing. For tnTRANSACTION_NM the leaf-node hash equals the tx
+		// ID, so a single tx-ID lookup resolves the leaf. This is a
+		// round-trip optimization, not a correctness requirement: a peer
+		// DOES return a leaf requested directly by node ID (getNodeFat
+		// always serializes the requested node, SHAMapSync.cpp:480-483 —
+		// fatLeaves=false only omits leaf CHILDREN when fat-expanding an
+		// inner node), but local sourcing avoids the extra request for a
+		// tx we already relayed.
 		missing := txMap.GetMissingNodes(256, nil)
 		if len(missing) == 0 {
 			r.deleteTxSetAcquire(txSetID)

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -962,11 +962,12 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		return
 	}
 
-	// Load-shed ledger-BODY requests under load, mirroring rippled
-	// PeerImp::processLedgerRequest (PeerImp.cpp:3322-3332). The
-	// liTS_CANDIDATE branch above is intentionally exempt — consensus
-	// liveness depends on tx-set acquisition always being served, so this
-	// gate runs only for liBASE / liAS_NODE / liTX_NODE.
+	// Load-shed ledger-BODY requests under load, mirroring the two gates in
+	// rippled PeerImp::processLedgerRequest (PeerImp.cpp:3322-3332). The
+	// liTS_CANDIDATE branch above is intentionally exempt — rippled serves it
+	// on a separate branch (PeerImp.cpp:3304-3319) that never reaches these
+	// gates, because consensus liveness depends on tx-set acquisition always
+	// being served — so this gate runs only for liBASE / liAS_NODE / liTX_NODE.
 	loadedLocal := false
 	if ft := svc.FeeTrack(); ft != nil {
 		loadedLocal = ft.IsLoadedLocal()
@@ -1266,13 +1267,26 @@ type logger interface {
 }
 
 // learnTxFromLeaf submits the transaction carried by an acquired tx-set
-// leaf into the open-ledger pool, mirroring rippled
-// ConsensusTransSetSF::gotNode (ConsensusTransSetSF.cpp:38-79): a tx-set
-// leaf is a tnTRANSACTION_NM node whose wire form is `tx_blob ||
-// WireTypeTransaction`. Inner nodes and malformed data are skipped by the
-// trailing-type-byte check, and a tx the open ledger already holds is not
-// resubmitted. local=false marks this as a peer-sourced learn.
-func (r *Router) learnTxFromLeaf(wire []byte) {
+// leaf into the open-ledger pool and, on acceptance, actively relays it —
+// mirroring rippled ConsensusTransSetSF::gotNode → submitTransaction →
+// processTransaction (ConsensusTransSetSF.cpp:51-78), whose relay tail
+// (NetworkOPs.cpp:1685-1712) rebroadcasts even peer-sourced (local=false)
+// txs. A tx-set leaf is a tnTRANSACTION_NM node whose wire form is
+// `tx_blob || WireTypeTransaction`; inner nodes and malformed data are
+// skipped by the trailing-type-byte check, and a tx the open ledger already
+// holds is not resubmitted. The submit is peer-sourced and the relay reuses
+// relayTransaction exactly as handleTransaction does for an inbound
+// TMTransaction (ResultSuccess is the superset of rippled's applied|terQUEUED;
+// see handleTransaction), excluding originPeer as the tx's source — so a set
+// the node only holds transiently still pushes its novel txs to peers
+// instead of relying on the slower TMHaveTransactions announce.
+//
+// rippled additionally caches the raw node in ConsensusTransSetSF's
+// m_nodeCache (ConsensusTransSetSF.cpp:49); goXRPL deliberately does not
+// mirror that — the acquired node is already held in txMap and the
+// missing-leaf local-fill (below) re-sources tx leaves from the open-ledger
+// pool, so a per-acquisition node cache has no role here.
+func (r *Router) learnTxFromLeaf(originPeer uint64, wire []byte) {
 	if len(wire) < 2 || wire[len(wire)-1] != protocol.WireTypeTransaction {
 		return
 	}
@@ -1287,7 +1301,9 @@ func (r *Router) learnTxFromLeaf(wire []byte) {
 	if r.adaptor.HasTx(consensus.TxID(item.Key())) {
 		return
 	}
-	r.adaptor.AddPendingTx(item.Data(), false)
+	if res, err := r.adaptor.SubmitPendingTx(item.Data(), false); err == nil && res == openledger.ResultSuccess {
+		r.relayTransaction(peermanagement.PeerID(originPeer), item.Data())
+	}
 }
 
 // handleTxSetData consumes a TMLedgerData{type=liTS_CANDIDATE} response.
@@ -1408,13 +1424,8 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			continue
 		}
 		added++
-		// Learn the transaction from this acquired tx-set leaf, mirroring
-		// rippled ConsensusTransSetSF::gotNode → submitTransaction
-		// (ConsensusTransSetSF.cpp:51-78). A node that only ever holds a
-		// proposed set transiently still propagates and can locally source
-		// the txs it pulled from peers — without this a partially-acquired
-		// set leaves its novel txs un-relayed, prolonging network-wide stalls.
-		r.learnTxFromLeaf(node.NodeData)
+		// Learn (submit + relay) the tx carried by this acquired leaf.
+		r.learnTxFromLeaf(originPeer, node.NodeData)
 	}
 
 	if err := txMap.FinishSync(); err != nil {

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
@@ -127,4 +128,96 @@ func TestRouter_CheckBehindArmsAcquisition(t *testing.T) {
 	totalCalls := len(replayCalls) + len(legacyCalls)
 	require.GreaterOrEqual(t, totalCalls, 1,
 		"checkBehind must arm an acquisition when peer is far ahead")
+}
+
+// acquireCount totals the acquisition requests the router emitted via either
+// the replay-delta or the legacy GET_LEDGER path.
+func acquireCount(rs *recordingSender) int {
+	return len(rs.replayCalls()) + len(rs.legacyCalls())
+}
+
+// Issue #724: maybeAcquireFromValidation mirrors rippled checkAccept(hash,
+// seq), invoked on every trusted current validation (RCLValidations.cpp:208 →
+// LedgerMaster.cpp:904-919). The tests below pin each gate of that acquire.
+
+// A trusted validation for a future ledger we don't hold must arm exactly one
+// acquisition for that (seq, hash) — the edge that breaks the wrongLedger
+// chase loop when the node is below quorum.
+func TestRouter_TrustedValidation_FutureUnknownLedger_Acquires(t *testing.T) {
+	r, a, rs, _ := makeRouter(t)
+	trusted, err := a.GetValidatorKey()
+	require.NoError(t, err)
+
+	hash := [32]byte{0xCA, 0xFE}
+	v := &consensus.Validation{
+		NodeID:    trusted,
+		LedgerSeq: 99999, // far ahead → no local parent → legacy path
+		LedgerID:  consensus.LedgerID(hash),
+	}
+
+	r.maybeAcquireFromValidation(v, 7)
+
+	require.Equal(t, 1, acquireCount(rs), "trusted validation for an unknown future ledger must arm one acquisition")
+	calls := rs.legacyCalls()
+	require.Len(t, calls, 1, "no local parent → legacy GET_LEDGER path")
+	assert.Equal(t, hash, calls[0].hash)
+	assert.Equal(t, uint32(99999), calls[0].seq)
+	assert.Equal(t, uint64(7), calls[0].peerID, "the validating peer is used as the acquisition hint")
+}
+
+// An UNTRUSTED validator must not steer acquisition (RCLValidations.cpp:194).
+func TestRouter_UntrustedValidation_NoAcquire(t *testing.T) {
+	r, _, rs, svc := makeRouter(t)
+	var untrusted consensus.NodeID
+	untrusted[0] = 0xFF // not in the trusted set
+	v := &consensus.Validation{
+		NodeID:    untrusted,
+		LedgerSeq: svc.GetValidatedLedgerIndex() + 50,
+		LedgerID:  consensus.LedgerID{0x11},
+	}
+	r.maybeAcquireFromValidation(v, 7)
+	assert.Zero(t, acquireCount(rs), "untrusted validator must not trigger acquisition")
+}
+
+// seq at or below our validated tip must not acquire (LedgerMaster.cpp:883 gate).
+func TestRouter_ValidationAtOrBelowValidated_NoAcquire(t *testing.T) {
+	r, a, rs, svc := makeRouter(t)
+	trusted, _ := a.GetValidatorKey()
+	v := &consensus.Validation{
+		NodeID:    trusted,
+		LedgerSeq: svc.GetValidatedLedgerIndex(),
+		LedgerID:  consensus.LedgerID{0x22},
+	}
+	r.maybeAcquireFromValidation(v, 7)
+	assert.Zero(t, acquireCount(rs), "seq <= validated tip must not acquire")
+}
+
+// A ledger we already hold (built or adopted) must not be re-acquired.
+func TestRouter_ValidationForHeldLedger_NoAcquire(t *testing.T) {
+	r, a, rs, svc := makeRouter(t)
+	trusted, _ := a.GetValidatorKey()
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	v := &consensus.Validation{
+		NodeID:    trusted,
+		LedgerSeq: 99999,
+		LedgerID:  consensus.LedgerID(closed.Hash()), // already in history
+	}
+	r.maybeAcquireFromValidation(v, 7)
+	assert.Zero(t, acquireCount(rs), "a ledger already in history must not be re-acquired")
+}
+
+// Repeated trusted validations for the same unknown hash arm at most one fetch
+// (the isAcquiring dedup).
+func TestRouter_RepeatedTrustedValidations_SingleAcquire(t *testing.T) {
+	r, a, rs, _ := makeRouter(t)
+	trusted, _ := a.GetValidatorKey()
+	v := &consensus.Validation{
+		NodeID:    trusted,
+		LedgerSeq: 99999,
+		LedgerID:  consensus.LedgerID([32]byte{0xDE, 0xAD}),
+	}
+	r.maybeAcquireFromValidation(v, 7)
+	r.maybeAcquireFromValidation(v, 8)
+	assert.Equal(t, 1, acquireCount(rs), "isAcquiring dedup → at most one fetch per hash")
 }

--- a/internal/consensus/adaptor/router_txset_learn_test.go
+++ b/internal/consensus/adaptor/router_txset_learn_test.go
@@ -59,7 +59,7 @@ func TestRouter_TxSetAcquire_LearnsTransaction(t *testing.T) {
 	// ID, then serialize it to wire nodes the way a peer reply would.
 	sm, err := shamap.New(shamap.TypeTransaction)
 	require.NoError(t, err)
-	require.NoError(t, sm.PutWithNodeType([32]byte(txHash), blob, shamap.NodeTypeTransactionNoMeta))
+	require.NoError(t, sm.PutWithNodeType(txHash, blob, shamap.NodeTypeTransactionNoMeta))
 	setID, err := sm.Hash()
 	require.NoError(t, err)
 	wireNodes, err := sm.WalkWireNodes()

--- a/internal/consensus/adaptor/router_txset_learn_test.go
+++ b/internal/consensus/adaptor/router_txset_learn_test.go
@@ -1,0 +1,88 @@
+package adaptor
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	testenv "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouter_TxSetAcquire_LearnsTransaction pins the gotNode-equivalent
+// added for issue #724: when a tx-set acquisition pulls in a leaf for a
+// transaction the node had never seen, that transaction is submitted into
+// the open-ledger pool, mirroring rippled ConsensusTransSetSF::gotNode →
+// submitTransaction (ConsensusTransSetSF.cpp:51-78). Without it a
+// partially/transiently acquired set leaves its novel txs un-relayed and
+// un-sourceable, prolonging the network-wide stall this issue tracks.
+func TestRouter_TxSetAcquire_LearnsTransaction(t *testing.T) {
+	engine := &mockEngine{}
+	a := newTestAdaptor(t)
+	inbox := make(chan *peermanagement.InboundMessage, 10)
+
+	router := NewRouter(engine, a, nil, inbox)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go router.Run(ctx)
+
+	// A real signed payment — the tx carried by the acquired set. The
+	// open-ledger Submit path rejects un-parseable blobs, so a synthetic
+	// blob would silently fail to land and mask a regression.
+	env := testenv.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	master := testenv.MasterAccount()
+	alice := testenv.NewAccount("alice")
+	txn := payment.Pay(master, alice, 100_000_000).Sequence(1).Build()
+	env.SignWith(txn, master)
+	txMap, err := txn.Flatten()
+	require.NoError(t, err)
+	hexStr, err := binarycodec.Encode(txMap)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	txHash, err := tx.ComputeTransactionHash(txn)
+	require.NoError(t, err)
+
+	require.False(t, a.HasTx(consensus.TxID(txHash)),
+		"precondition: the tx must be unknown before acquisition")
+
+	// Build a complete tx-set SHAMap carrying the tx, keyed by its real
+	// ID, then serialize it to wire nodes the way a peer reply would.
+	sm, err := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, err)
+	require.NoError(t, sm.PutWithNodeType([32]byte(txHash), blob, shamap.NodeTypeTransactionNoMeta))
+	setID, err := sm.Hash()
+	require.NoError(t, err)
+	wireNodes, err := sm.WalkWireNodes()
+	require.NoError(t, err)
+	require.NotEmpty(t, wireNodes, "expected at least root + leaf")
+
+	ldNodes := make([]message.LedgerNode, 0, len(wireNodes))
+	for _, n := range wireNodes {
+		ldNodes = append(ldNodes, message.LedgerNode{NodeID: n.NodeID, NodeData: n.Data})
+	}
+	resp := &message.LedgerData{
+		LedgerHash: setID[:],
+		InfoType:   message.LedgerInfoTsCandidate,
+		Nodes:      ldNodes,
+	}
+	inbox <- &peermanagement.InboundMessage{
+		PeerID:  5,
+		Type:    uint16(message.TypeLedgerData),
+		Payload: encodePayload(t, resp),
+	}
+
+	require.Eventually(t, func() bool {
+		return a.HasTx(consensus.TxID(txHash))
+	}, time.Second, 10*time.Millisecond,
+		"tx-set acquisition must learn the carried transaction into the open ledger")
+}

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -188,6 +188,12 @@ func (s *OverlaySender) SendToPeer(peerID uint64, frame []byte) error {
 	return s.overlay.Send(peermanagement.PeerID(peerID), frame)
 }
 
+// ShouldShedLedgerRequest forwards to the overlay's load gate. See
+// NetworkSender.ShouldShedLedgerRequest.
+func (s *OverlaySender) ShouldShedLedgerRequest(peerID uint64, loadedLocal bool) bool {
+	return s.overlay.ShouldShedLedgerRequest(peermanagement.PeerID(peerID), loadedLocal)
+}
+
 // RequestLedgerBaseFromPeer sends a GetLedger(LedgerInfoBase) to a specific peer.
 func (s *OverlaySender) RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte, seq uint32) error {
 	msg := &message.GetLedger{

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -156,11 +156,11 @@ type LedgerProvider interface {
 	// GetLedger returns the ledger with the given ID.
 	GetLedger(id LedgerID) (Ledger, error)
 
-	// GetLedgerBySeq returns the locally-held ledger at the given
-	// sequence, or (nil, error) when not present. Reads adopted/persisted
-	// history; used by the consensus catch-up walk to advance prevLedger to
-	// the furthest available parent-hash-chained ledger in one step,
-	// mirroring rippled findNewLedgersToPublish (LedgerMaster.cpp:1257-1301).
+	// GetLedgerBySeq returns the locally-held CLOSED ledger at the given
+	// sequence from adopted/persisted history, or (nil, error) when not
+	// present. It must NOT return the mutable open ledger. Used by the
+	// consensus catch-up walk (rcl OnLedger) to advance prevLedger across the
+	// furthest available parent-hash-chained ledger in one step.
 	GetLedgerBySeq(seq uint32) (Ledger, error)
 
 	// GetLastClosedLedger returns the most recently closed ledger.

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -156,6 +156,13 @@ type LedgerProvider interface {
 	// GetLedger returns the ledger with the given ID.
 	GetLedger(id LedgerID) (Ledger, error)
 
+	// GetLedgerBySeq returns the locally-held ledger at the given
+	// sequence, or (nil, error) when not present. Reads adopted/persisted
+	// history; used by the consensus catch-up walk to advance prevLedger to
+	// the furthest available parent-hash-chained ledger in one step,
+	// mirroring rippled findNewLedgersToPublish (LedgerMaster.cpp:1257-1301).
+	GetLedgerBySeq(seq uint32) (Ledger, error)
+
 	// GetLastClosedLedger returns the most recently closed ledger.
 	GetLastClosedLedger() (Ledger, error)
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1072,17 +1072,24 @@ func (e *Engine) OnLedger(id consensus.LedgerID, ledger []byte) error {
 			if e.prevLedger != nil && l.Seq() <= e.prevLedger.Seq() {
 				return nil
 			}
-			// Advance to the FURTHEST locally-available ledger that chains
-			// forward from l by parent hash, instead of crawling one ledger
-			// per acquisition. Under load the network tip advances faster
-			// than a one-at-a-time catch-up, so adopting only `l` leaves us
-			// perpetually behind (issue #724) — the wrongLedger chase loop.
-			// Mirrors rippled LedgerMaster::findNewLedgersToPublish
-			// (LedgerMaster.cpp:1257-1301), which walks the published/valid
-			// tip forward across all locally-held chained ledgers in one
-			// pass. Only follows ledgers already in local history whose
-			// ParentID() chains exactly, so we never adopt a sibling fork;
-			// the validated tip still advances solely through the quorum gate.
+			// Advance the build-on LCL (prevLedger) to the FURTHEST
+			// locally-available CLOSED ledger that chains forward from l by
+			// parent hash, instead of crawling one ledger per acquisition.
+			// Under load the network tip advances faster than a one-at-a-time
+			// catch-up, so adopting only `l` leaves us perpetually behind
+			// (issue #724) — the wrongLedger chase loop. This forward walk has
+			// no direct rippled counterpart: rippled's wrong-ledger recovery
+			// (Consensus::handleWrongLedger, Consensus.h:1062-1114) switches
+			// prevLedger to the validation-PREFERRED ledger from getPreferred,
+			// not "the furthest locally-chained" one. The walk only advances
+			// the build-on LCL, never the validated tip (that still moves
+			// solely through the quorum gate); GetLedgerBySeq returns adopted
+			// closed history only, and the ParentID() chain check means we
+			// never adopt a sibling fork or the mutable open ledger. An
+			// overshoot past the network-preferred ledger self-corrects on the
+			// next round via checkLedger → getNetworkLedger (goXRPL's
+			// getPreferred equivalent), so the risk is bounded to liveness
+			// churn, not state divergence.
 			for {
 				next, nerr := e.adaptor.GetLedgerBySeq(l.Seq() + 1)
 				if nerr != nil || next == nil || next.ParentID() != l.ID() {

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1066,11 +1066,37 @@ func (e *Engine) OnLedger(id consensus.LedgerID, ledger []byte) error {
 	if e.mode == consensus.ModeWrongLedger {
 		l, err := e.adaptor.GetLedger(id)
 		if err == nil && l != nil {
+			// Never regress: validation-acquire fires for many seqs whose
+			// acquisitions complete out of order, so an arrival at or below
+			// our current prevLedger must not move the round backward.
+			if e.prevLedger != nil && l.Seq() <= e.prevLedger.Seq() {
+				return nil
+			}
+			// Advance to the FURTHEST locally-available ledger that chains
+			// forward from l by parent hash, instead of crawling one ledger
+			// per acquisition. Under load the network tip advances faster
+			// than a one-at-a-time catch-up, so adopting only `l` leaves us
+			// perpetually behind (issue #724) — the wrongLedger chase loop.
+			// Mirrors rippled LedgerMaster::findNewLedgersToPublish
+			// (LedgerMaster.cpp:1257-1301), which walks the published/valid
+			// tip forward across all locally-held chained ledgers in one
+			// pass. Only follows ledgers already in local history whose
+			// ParentID() chains exactly, so we never adopt a sibling fork;
+			// the validated tip still advances solely through the quorum gate.
+			for {
+				next, nerr := e.adaptor.GetLedgerBySeq(l.Seq() + 1)
+				if nerr != nil || next == nil || next.ParentID() != l.ID() {
+					break
+				}
+				l = next
+			}
 			lID := l.ID()
 			slog.Info("Acquired missing ledger, restarting round",
 				"seq", l.Seq(), "hash", fmt.Sprintf("%x", lID[:8]))
 			e.prevLedger = l
-			e.state.HaveCorrectLCL = true
+			if e.state != nil {
+				e.state.HaveCorrectLCL = true
+			}
 			nextRound := consensus.RoundID{
 				Seq:        l.Seq() + 1,
 				ParentHash: l.ID(),

--- a/internal/consensus/rcl/engine_onledger_test.go
+++ b/internal/consensus/rcl/engine_onledger_test.go
@@ -1,0 +1,104 @@
+package rcl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+// chainLedger builds a mockLedger at seq with id first-byte idb and parent
+// id first-byte pb, so a chain can be wired by matching child.parentID to
+// parent.id.
+func chainLedger(seq uint32, idb, pb byte) *mockLedger {
+	return &mockLedger{
+		id:        consensus.LedgerID{idb},
+		seq:       seq,
+		parentID:  consensus.LedgerID{pb},
+		closeTime: time.Unix(0, 0),
+	}
+}
+
+// Issue #724: while in ModeWrongLedger, OnLedger must jump prevLedger to the
+// FURTHEST locally-available parent-hash-chained ledger (rippled
+// findNewLedgersToPublish parity), instead of crawling one ledger per
+// acquisition, and must never move backward on an out-of-order arrival.
+
+func TestEngine_OnLedger_JumpsToFurthestChained(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+	initial := a.ledgers[consensus.LedgerID{1}] // seq 100
+
+	// Chain 101..106 forward from the initial ledger (id {1}).
+	a.StoreLedger(chainLedger(101, 101, 1))
+	a.StoreLedger(chainLedger(102, 102, 101))
+	a.StoreLedger(chainLedger(103, 103, 102))
+	a.StoreLedger(chainLedger(104, 104, 103))
+	a.StoreLedger(chainLedger(105, 105, 104))
+	a.StoreLedger(chainLedger(106, 106, 105))
+
+	e.prevLedger = initial
+	e.mode = consensus.ModeWrongLedger
+
+	if err := e.OnLedger(consensus.LedgerID{101}, nil); err != nil {
+		t.Fatalf("OnLedger: %v", err)
+	}
+	if got := e.prevLedger.Seq(); got != 106 {
+		t.Fatalf("prevLedger.Seq() = %d, want 106 (must jump to furthest chained, not crawl one at a time)", got)
+	}
+}
+
+func TestEngine_OnLedger_NeverMovesBackward(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+	a.StoreLedger(chainLedger(106, 106, 105))
+	top := a.ledgers[consensus.LedgerID{106}]
+	e.prevLedger = top
+	e.mode = consensus.ModeWrongLedger
+
+	// An out-of-order acquisition completion for an older seq must not
+	// regress the round.
+	a.StoreLedger(chainLedger(102, 102, 101))
+	if err := e.OnLedger(consensus.LedgerID{102}, nil); err != nil {
+		t.Fatalf("OnLedger: %v", err)
+	}
+	if got := e.prevLedger.Seq(); got != 106 {
+		t.Fatalf("prevLedger.Seq() = %d, want 106 (must not move backward)", got)
+	}
+}
+
+func TestEngine_OnLedger_StopsAtChainBreak(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+	initial := a.ledgers[consensus.LedgerID{1}]
+	a.StoreLedger(chainLedger(101, 101, 1))
+	a.StoreLedger(chainLedger(102, 102, 101))
+	a.StoreLedger(chainLedger(103, 103, 0xFF)) // parent does not chain — sibling fork
+	e.prevLedger = initial
+	e.mode = consensus.ModeWrongLedger
+
+	if err := e.OnLedger(consensus.LedgerID{101}, nil); err != nil {
+		t.Fatalf("OnLedger: %v", err)
+	}
+	if got := e.prevLedger.Seq(); got != 102 {
+		t.Fatalf("prevLedger.Seq() = %d, want 102 (must stop at the unchained fork, never jump onto seq 103)", got)
+	}
+}
+
+func TestEngine_OnLedger_StopsAtGap(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+	initial := a.ledgers[consensus.LedgerID{1}]
+	a.StoreLedger(chainLedger(101, 101, 1))
+	a.StoreLedger(chainLedger(102, 102, 101))
+	a.StoreLedger(chainLedger(104, 104, 103)) // seq 103 absent → gap
+	e.prevLedger = initial
+	e.mode = consensus.ModeWrongLedger
+
+	if err := e.OnLedger(consensus.LedgerID{101}, nil); err != nil {
+		t.Fatalf("OnLedger: %v", err)
+	}
+	if got := e.prevLedger.Seq(); got != 102 {
+		t.Fatalf("prevLedger.Seq() = %d, want 102 (walk stops at the seq-103 gap)", got)
+	}
+}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -246,6 +246,17 @@ func (a *mockAdaptor) GetLedger(id consensus.LedgerID) (consensus.Ledger, error)
 	return a.ledgers[id], nil
 }
 
+func (a *mockAdaptor) GetLedgerBySeq(seq uint32) (consensus.Ledger, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, l := range a.ledgers {
+		if l != nil && l.Seq() == seq {
+			return l, nil
+		}
+	}
+	return nil, nil
+}
+
 func (a *mockAdaptor) GetLastClosedLedger() (consensus.Ledger, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -980,6 +980,20 @@ func (s *Service) GetLedgerBySequence(seq uint32) (*ledger.Ledger, error) {
 	return nil, ErrLedgerNotFound
 }
 
+// GetAdoptedLedgerBySequence returns a closed ledger from the adopted
+// history (ledgerHistory[seq]) only — unlike GetLedgerBySequence it never
+// falls back to the mutable open ledger. The consensus catch-up walk
+// requires immutable, parent-hash-chained ledgers; rippled's acquire path
+// likewise only ever yields closed/immutable ledgers (RCLValidations.cpp:154-156).
+func (s *Service) GetAdoptedLedgerBySequence(seq uint32) (*ledger.Ledger, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if l, ok := s.ledgerHistory[seq]; ok {
+		return l, nil
+	}
+	return nil, ErrLedgerNotFound
+}
+
 // GetLedgerByHash returns a ledger by its hash
 func (s *Service) GetLedgerByHash(hash [32]byte) (*ledger.Ledger, error) {
 	s.mu.RLock()

--- a/internal/ledger/service/service_test.go
+++ b/internal/ledger/service/service_test.go
@@ -189,6 +189,48 @@ func TestGetLedgerBySequence(t *testing.T) {
 	}
 }
 
+// TestGetAdoptedLedgerBySequence pins the issue #724 / M5 guard: the
+// consensus catch-up walk reads adopted history only and must NEVER receive
+// the mutable open ledger, unlike GetLedgerBySequence which deliberately
+// falls back to it. rippled's acquire path likewise only yields
+// closed/immutable ledgers (RCLValidations.cpp:154-156).
+func TestGetAdoptedLedgerBySequence(t *testing.T) {
+	cfg := DefaultConfig()
+	svc, err := New(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Failed to start service: %v", err)
+	}
+	if _, err := svc.AcceptLedger(context.TODO()); err != nil {
+		t.Fatalf("Failed to accept ledger: %v", err)
+	}
+
+	// A closed ledger in adopted history resolves like GetLedgerBySequence.
+	closed, err := svc.GetAdoptedLedgerBySequence(2)
+	if err != nil {
+		t.Fatalf("adopted-history seq 2 should resolve: %v", err)
+	}
+	if closed.Sequence() != 2 {
+		t.Errorf("expected seq 2, got %d", closed.Sequence())
+	}
+
+	// The open ledger's seq resolves via GetLedgerBySequence (open fallback)
+	// but MUST be absent from the adopted-history accessor.
+	open := svc.GetOpenLedger()
+	if open == nil {
+		t.Fatal("expected an open ledger")
+	}
+	openSeq := open.Sequence()
+	if l, err := svc.GetLedgerBySequence(openSeq); err != nil || l == nil {
+		t.Fatalf("GetLedgerBySequence must fall back to the open ledger at seq %d (err=%v)", openSeq, err)
+	}
+	if _, err := svc.GetAdoptedLedgerBySequence(openSeq); err != ErrLedgerNotFound {
+		t.Errorf("GetAdoptedLedgerBySequence(%d) must NOT return the open ledger; got %v", openSeq, err)
+	}
+}
+
 func TestGetServerInfo(t *testing.T) {
 	cfg := DefaultConfig()
 	svc, err := New(cfg)

--- a/internal/peermanagement/broadcast_except_set_test.go
+++ b/internal/peermanagement/broadcast_except_set_test.go
@@ -1,0 +1,74 @@
+package peermanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBroadcastExceptSet_PartialExclusion confirms the normal path: peers
+// in the exclusion set are skipped, the rest receive the frame.
+func TestBroadcastExceptSet_PartialExclusion(t *testing.T) {
+	ident, err := NewIdentity()
+	require.NoError(t, err)
+
+	o := &Overlay{peers: make(map[PeerID]*Peer)}
+	for id := PeerID(1); id <= 4; id++ {
+		o.peers[id] = relayTestPeer(t, ident, id, true)
+	}
+
+	excluded := map[PeerID]bool{1: true, 2: true}
+	require.NoError(t, o.BroadcastExceptSet(excluded, []byte{0xAA}))
+
+	assert.False(t, gotFrame(o.peers[1]), "excluded peer 1 must be skipped")
+	assert.False(t, gotFrame(o.peers[2]), "excluded peer 2 must be skipped")
+	assert.True(t, gotFrame(o.peers[3]), "eligible peer 3 must receive")
+	assert.True(t, gotFrame(o.peers[4]), "eligible peer 4 must receive")
+}
+
+// TestBroadcastExceptSet_AllExcludedFallsBackToAll is the issue #724
+// regression guard: when every connected peer is excluded, the request
+// must NOT silently reach no one (which wedges tx-set acquisition in
+// wrongLedger until the TTL sweep). The exclusion is ignored for that
+// round and the frame goes to all connected peers, matching rippled's
+// "peer stays eligible for the next request" semantics.
+func TestBroadcastExceptSet_AllExcludedFallsBackToAll(t *testing.T) {
+	ident, err := NewIdentity()
+	require.NoError(t, err)
+
+	o := &Overlay{peers: make(map[PeerID]*Peer)}
+	for id := PeerID(1); id <= 4; id++ {
+		o.peers[id] = relayTestPeer(t, ident, id, true)
+	}
+
+	excluded := map[PeerID]bool{1: true, 2: true, 3: true, 4: true}
+	require.NoError(t, o.BroadcastExceptSet(excluded, []byte{0xAA}))
+
+	for id := PeerID(1); id <= 4; id++ {
+		assert.Truef(t, gotFrame(o.peers[id]),
+			"peer %d must receive the frame when exclusion would starve the broadcast", id)
+	}
+}
+
+// TestBroadcastExceptSet_AllExcludedStillSkipsDisconnected confirms the
+// starvation fallback only reaches CONNECTED peers — a disconnected peer
+// is never sent to, even when the exclusion set covers every peer.
+func TestBroadcastExceptSet_AllExcludedStillSkipsDisconnected(t *testing.T) {
+	ident, err := NewIdentity()
+	require.NoError(t, err)
+
+	o := &Overlay{peers: make(map[PeerID]*Peer)}
+	o.peers[1] = relayTestPeer(t, ident, 1, true)
+	o.peers[2] = relayTestPeer(t, ident, 2, true)
+	disconnected := relayTestPeer(t, ident, 3, true)
+	disconnected.setState(PeerStateDisconnected)
+	o.peers[3] = disconnected
+
+	excluded := map[PeerID]bool{1: true, 2: true, 3: true}
+	require.NoError(t, o.BroadcastExceptSet(excluded, []byte{0xAA}))
+
+	assert.True(t, gotFrame(o.peers[1]), "connected peer 1 must receive the fallback frame")
+	assert.True(t, gotFrame(o.peers[2]), "connected peer 2 must receive the fallback frame")
+	assert.False(t, gotFrame(o.peers[3]), "disconnected peer must never receive")
+}

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -16,8 +16,8 @@ import (
 
 // peerSendQueueDropThreshold gates inbound handlers that would
 // otherwise enqueue heavy outbound work (e.g. handleGetObjectsMessage
-// queries). Mirrors rippled Tuning::dropSendQueue=192 against its
-// deeper send queue; we scale to 75% of DefaultSendBufferSize so
+// queries). Mirrors rippled Tuning::dropSendQueue=192 (Tuning.h:49)
+// against its deeper send queue; we scale to 75% of DefaultSendBufferSize so
 // go-xrpl refuses new work before peer.Send returns
 // ErrSendBufferFull.
 const peerSendQueueDropThreshold = (DefaultSendBufferSize * 3) / 4

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -2541,6 +2541,29 @@ func (o *Overlay) bumpPeerDisconnectCharges() {
 	o.peerDisconnectsCharges.Add(1)
 }
 
+// ShouldShedLedgerRequest reports whether a ledger-BODY request from
+// peerID should be dropped under load, mirroring rippled
+// PeerImp::processLedgerRequest (PeerImp.cpp:3322-3332). Two gates:
+//   - the peer's send queue is at/over the drop threshold (applies to
+//     every peer, cluster included); or
+//   - the local node is fee-loaded AND the peer is not a cluster member.
+//
+// loadedLocal is supplied by the caller (LoadFeeTrack.IsLoadedLocal())
+// to keep the overlay free of a fee-track dependency. tx-set candidate
+// requests are served by a different path and must never be passed here.
+func (o *Overlay) ShouldShedLedgerRequest(peerID PeerID, loadedLocal bool) bool {
+	o.peersMu.RLock()
+	peer, ok := o.peers[peerID]
+	o.peersMu.RUnlock()
+	if !ok {
+		return false
+	}
+	if peer.SendQueueLen() >= peerSendQueueDropThreshold {
+		return true
+	}
+	return loadedLocal && !o.isClusterPeer(peer)
+}
+
 // isClusterPeer reports whether peer's node public key matches a
 // cluster registry entry. Cluster members are bound to an unlimited
 // Consumer so charges are no-ops, mirroring rippled's Role logic that

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -2550,7 +2550,9 @@ func (o *Overlay) bumpPeerDisconnectCharges() {
 //
 // loadedLocal is supplied by the caller (LoadFeeTrack.IsLoadedLocal())
 // to keep the overlay free of a fee-track dependency. tx-set candidate
-// requests are served by a different path and must never be passed here.
+// (liTS_CANDIDATE) requests take a separate branch in rippled
+// (PeerImp.cpp:3304-3319) that never reaches these gates — consensus
+// liveness depends on them — and must never be passed here.
 func (o *Overlay) ShouldShedLedgerRequest(peerID PeerID, loadedLocal bool) bool {
 	o.peersMu.RLock()
 	peer, ok := o.peers[peerID]

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1981,6 +1981,14 @@ func (o *Overlay) BroadcastExcept(exceptPeer PeerID, msg []byte) error {
 // broadcast. go-xrpl has no equivalent per-message resource accounting
 // today, hence the explicit per-acquire exclusion. A nil or empty
 // excluded map falls through to a plain Broadcast. Issue #420.
+//
+// Issue #724: the exclusion must never starve the broadcast. If every
+// connected peer is excluded, the message would reach no one and the
+// caller (tx-set missing-node acquisition) wedges in wrongLedger until
+// the TTL sweep — the recurring under-load validation stall. When that
+// happens, fall back to broadcasting to all connected peers, restoring
+// rippled's "peer stays eligible for the next request" semantics rather
+// than dropping the request on the floor.
 func (o *Overlay) BroadcastExceptSet(excluded map[PeerID]bool, msg []byte) error {
 	if len(excluded) == 0 {
 		return o.Broadcast(msg)
@@ -1988,11 +1996,23 @@ func (o *Overlay) BroadcastExceptSet(excluded map[PeerID]bool, msg []byte) error
 	o.peersMu.RLock()
 	defer o.peersMu.RUnlock()
 
+	connected, eligible := 0, 0
 	for id, peer := range o.peers {
-		if excluded[id] {
+		if peer.State() != PeerStateConnected {
 			continue
 		}
+		connected++
+		if !excluded[id] {
+			eligible++
+		}
+	}
+	ignoreExclusion := eligible == 0 && connected > 0
+
+	for id, peer := range o.peers {
 		if peer.State() != PeerStateConnected {
+			continue
+		}
+		if !ignoreExclusion && excluded[id] {
 			continue
 		}
 		if err := peer.Send(msg); err != nil {

--- a/internal/peermanagement/should_shed_ledger_request_test.go
+++ b/internal/peermanagement/should_shed_ledger_request_test.go
@@ -1,0 +1,65 @@
+package peermanagement
+
+import (
+	"testing"
+
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShouldShedLedgerRequest mirrors rippled
+// PeerImp::processLedgerRequest's load gate (PeerImp.cpp:3322-3332) for
+// ledger-BODY requests. Each subtest pins one branch. tx-set candidate
+// requests never reach this gate (handled separately in the router), so
+// they are not exercised here.
+func TestShouldShedLedgerRequest(t *testing.T) {
+	t.Run("unknown peer is never shed", func(t *testing.T) {
+		o := &Overlay{peers: make(map[PeerID]*Peer)}
+		assert.False(t, o.ShouldShedLedgerRequest(PeerID(99), true))
+	})
+
+	t.Run("not loaded + drained queue → serve", func(t *testing.T) {
+		ident, err := NewIdentity()
+		require.NoError(t, err)
+		o := &Overlay{peers: make(map[PeerID]*Peer)}
+		o.peers[1] = relayTestPeer(t, ident, 1, true)
+		assert.False(t, o.ShouldShedLedgerRequest(1, false))
+	})
+
+	t.Run("fee-loaded + non-cluster peer → shed", func(t *testing.T) {
+		ident, err := NewIdentity()
+		require.NoError(t, err)
+		o := &Overlay{peers: make(map[PeerID]*Peer)}
+		o.peers[1] = relayTestPeer(t, ident, 1, true)
+		assert.True(t, o.ShouldShedLedgerRequest(1, true),
+			"isLoadedLocal() && !cluster() → drop (PeerImp.cpp:3328)")
+	})
+
+	t.Run("saturated send queue → shed even when not loaded", func(t *testing.T) {
+		ident, err := NewIdentity()
+		require.NoError(t, err)
+		o := &Overlay{peers: make(map[PeerID]*Peer)}
+		p := relayTestPeer(t, ident, 1, true)
+		o.peers[1] = p
+		for i := 0; i < peerSendQueueDropThreshold; i++ {
+			p.send <- []byte{0x00}
+		}
+		assert.True(t, o.ShouldShedLedgerRequest(1, false),
+			"send_queue_ >= dropSendQueue → drop (PeerImp.cpp:3322)")
+	})
+
+	t.Run("cluster member is exempt from the load gate", func(t *testing.T) {
+		id, err := NewIdentity()
+		require.NoError(t, err)
+		pub, err := addresscodec.EncodeNodePublicKey(id.PublicKey())
+		require.NoError(t, err)
+		o := &Overlay{cluster: cluster.New(), peers: make(map[PeerID]*Peer)}
+		require.NoError(t, o.cluster.Load([]string{pub}))
+		p := makeClusterTestPeer(t, id, "192.0.2.30", 51235)
+		o.peers[p.id] = p
+		assert.False(t, o.ShouldShedLedgerRequest(p.id, true),
+			"cluster peers are exempt from the load gate (PeerImp.cpp:3328 !cluster())")
+	})
+}

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -445,6 +445,14 @@ func resolveValidationQuorum(services *types.ServiceContainer) int {
 // the master is resolved through the manifest cache exactly as
 // validator_info does (rippled localPublicKey() = getMasterKey(signingKey);
 // in seed-only mode master == signing). Matches rippled NetworkOPs.cpp:2781-2790.
+//
+// rippled gates the emit on two independently-nullable identities
+// (localPublicKey() && getValidationPublicKey(), NetworkOPs.cpp:2781). goXRPL
+// models the validator identity as a single object, so a populated 33-byte
+// ValidatorPublicKey (set iff Adaptor.GetValidatorSigningKey succeeds, i.e.
+// identity != nil) is the faithful single-term equivalent for every state the
+// node can reach; the two-term form only matters if a separable
+// manifest-revocation path is added later.
 func resolveValidatorPubKey(services *types.ServiceContainer) string {
 	if services == nil || len(services.ValidatorPublicKey) != 33 {
 		return "none"

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/observability"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/protocol"
@@ -200,6 +201,14 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]interface{} {
 	// completed its first sync to Full (NetworkOPs.cpp:4847-4848).
 	if accounting.initialSyncUs > 0 {
 		info["initial_sync_duration_us"] = fmt.Sprintf("%d", accounting.initialSyncUs)
+	}
+
+	// pubkey_validator: admin-only, mirrors rippled NetworkOPs.cpp:2779-2791.
+	// Emits the configured validator's MASTER public key (base58 NodePublic),
+	// or "none" when the node is not a validator. Present in both server_info
+	// (human) and server_state (machine) like rippled's shared getServerInfo.
+	if ctx.IsAdmin {
+		info["pubkey_validator"] = resolveValidatorPubKey(services)
 	}
 
 	// hostid: only in human mode (server_info), matching rippled
@@ -428,6 +437,29 @@ func resolveValidationQuorum(services *types.ServiceContainer) int {
 		}
 	}
 	return 1
+}
+
+// resolveValidatorPubKey returns the base58 NodePublic encoding of the
+// configured validator's MASTER public key, or "none" when the node is
+// not a validator. ValidatorPublicKey carries the 33-byte signing key;
+// the master is resolved through the manifest cache exactly as
+// validator_info does (rippled localPublicKey() = getMasterKey(signingKey);
+// in seed-only mode master == signing). Matches rippled NetworkOPs.cpp:2781-2790.
+func resolveValidatorPubKey(services *types.ServiceContainer) string {
+	if services == nil || len(services.ValidatorPublicKey) != 33 {
+		return "none"
+	}
+	var signing [33]byte
+	copy(signing[:], services.ValidatorPublicKey)
+	master := signing
+	if services.Manifests != nil {
+		master = services.Manifests.GetMasterKey(signing)
+	}
+	enc, err := addresscodec.EncodeNodePublicKey(master[:])
+	if err != nil {
+		return "none"
+	}
+	return enc
 }
 
 // resolveDisconnectCounters reads the overlay overflow & disconnect

--- a/internal/rpc/handlers/validator_info_test.go
+++ b/internal/rpc/handlers/validator_info_test.go
@@ -234,9 +234,10 @@ func TestValidatorInfo_ManifestCachePresentNoMapping(t *testing.T) {
 }
 
 // TestValidatorInfo_InvalidPublicKeyLength pins the defensive guard
-// against a malformed ValidatorPublicKey. cli/server.go always copies
-// a 33-byte NodeID, but the field is a []byte so we still verify the
-// internal-error path rather than silently truncating or panicking.
+// against a malformed ValidatorPublicKey. cli/server.go now wires the
+// 33-byte signing key (GetValidatorSigningKey), but the field is a
+// []byte so we still verify the internal-error path rather than
+// silently truncating or panicking.
 func TestValidatorInfo_InvalidPublicKeyLength(t *testing.T) {
 	services := installServices(make([]byte, 32), nil) // wrong length
 

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -1485,3 +1485,125 @@ func TestServerInfo_CloseTimeOffset_Threshold(t *testing.T) {
 		})
 	}
 }
+
+// fakeManifestLookupServerInfo maps a single signing key to a master key
+// to exercise the token-mode resolution path in resolveValidatorPubKey.
+type fakeManifestLookupServerInfo struct {
+	masterFor map[[33]byte][33]byte
+}
+
+func (f *fakeManifestLookupServerInfo) GetMasterKey(signing [33]byte) [33]byte {
+	if m, ok := f.masterFor[signing]; ok {
+		return m
+	}
+	return signing
+}
+func (f *fakeManifestLookupServerInfo) GetSigningKey([33]byte) ([33]byte, bool) {
+	return [33]byte{}, false
+}
+func (f *fakeManifestLookupServerInfo) GetManifest([33]byte) ([]byte, bool) { return nil, false }
+func (f *fakeManifestLookupServerInfo) GetSequence([33]byte) (uint32, bool) { return 0, false }
+func (f *fakeManifestLookupServerInfo) GetDomain([33]byte) (string, bool)   { return "", false }
+
+func makeSigningKey(prefix byte) []byte {
+	pk := make([]byte, 33)
+	pk[0] = prefix
+	for i := 1; i < 33; i++ {
+		pk[i] = byte(i)
+	}
+	return pk
+}
+
+// TestServerInfoPubkeyValidator pins rippled NetworkOPs.cpp:2779-2791:
+// pubkey_validator is admin-only, carries the validator's MASTER public
+// key (base58 NodePublic), and is "none" when the node is not a
+// validator. Regression guard for issue #724, where the field was absent
+// entirely and the underlying ValidatorPublicKey was a zero-padded
+// 20-byte NodeID rather than the 33-byte signing key.
+func TestServerInfoPubkeyValidator(t *testing.T) {
+	infoMethod := &handlers.ServerInfoMethod{}
+
+	buildInfo := func(t *testing.T, admin bool, pk []byte, manifests types.ManifestLookup) (map[string]interface{}, bool) {
+		t.Helper()
+		mock := newMockLedgerServiceServerInfo()
+		services := servicesForServerInfo(mock)
+		services.ValidatorPublicKey = pk
+		services.Manifests = manifests
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+			IsAdmin:    admin,
+		}
+		result, rpcErr := infoMethod.Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+		raw, _ := json.Marshal(result)
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &resp))
+		info := resp["info"].(map[string]interface{})
+		_, present := info["pubkey_validator"]
+		return info, present
+	}
+
+	t.Run("admin + validator (seed mode) → master==signing base58", func(t *testing.T) {
+		signing := makeSigningKey(0x02)
+		want, err := addresscodec.EncodeNodePublicKey(signing)
+		require.NoError(t, err)
+		info, present := buildInfo(t, true, signing, nil)
+		require.True(t, present, "pubkey_validator must be present for admin")
+		assert.Equal(t, want, info["pubkey_validator"])
+	})
+
+	t.Run("admin + validator (token mode) → resolves to master key", func(t *testing.T) {
+		signing := makeSigningKey(0x02)
+		var signingArr, masterArr [33]byte
+		copy(signingArr[:], signing)
+		copy(masterArr[:], makeSigningKey(0x03))
+		manifests := &fakeManifestLookupServerInfo{
+			masterFor: map[[33]byte][33]byte{signingArr: masterArr},
+		}
+		wantMaster, err := addresscodec.EncodeNodePublicKey(masterArr[:])
+		require.NoError(t, err)
+		wantSigning, err := addresscodec.EncodeNodePublicKey(signingArr[:])
+		require.NoError(t, err)
+		info, present := buildInfo(t, true, signing, manifests)
+		require.True(t, present)
+		assert.Equal(t, wantMaster, info["pubkey_validator"], "must emit master, not signing")
+		assert.NotEqual(t, wantSigning, info["pubkey_validator"])
+	})
+
+	t.Run("admin + not a validator → none", func(t *testing.T) {
+		info, present := buildInfo(t, true, nil, nil)
+		require.True(t, present)
+		assert.Equal(t, "none", info["pubkey_validator"])
+	})
+
+	t.Run("non-admin → field absent", func(t *testing.T) {
+		_, present := buildInfo(t, false, makeSigningKey(0x02), nil)
+		assert.False(t, present, "pubkey_validator is admin-only")
+	})
+
+	t.Run("server_state parity: admin + validator", func(t *testing.T) {
+		signing := makeSigningKey(0x02)
+		want, err := addresscodec.EncodeNodePublicKey(signing)
+		require.NoError(t, err)
+		mock := newMockLedgerServiceServerInfo()
+		services := servicesForServerInfo(mock)
+		services.ValidatorPublicKey = signing
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+			IsAdmin:    true,
+		}
+		result, rpcErr := (&handlers.ServerStateMethod{}).Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+		raw, _ := json.Marshal(result)
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &resp))
+		state := resp["state"].(map[string]interface{})
+		assert.Equal(t, want, state["pubkey_validator"])
+	})
+}


### PR DESCRIPTION
## Summary

Addresses the facets of #724 (consensus-liveness stalls under load), each verified against the rippled reference and unit-tested. Final confirmation of the under-load liveness improvement needs the confluence `soak-mixed-3x2` run (Docker mixed validators) — noted in the test plan.

### 1. Observability — `pubkey_validator` + a latent wiring bug
- `server_info`/`server_state` never emitted `pubkey_validator` (the issue's reported `null`).
- The value feeding `validator_info` was also wrong: `cli/server.go` copied `GetValidatorKey()` (the **20-byte** `NodeID`) into a 33-byte slice, zero-padding the last 13 bytes.
- Added `Adaptor.GetValidatorSigningKey()` (the real 33-byte signing key) and rewired `server.go`.
- Emit `pubkey_validator` **admin-gated** in both methods, resolving the **master** key via the manifest cache (seed mode: master == signing), `"none"` fallback — matching rippled `NetworkOPs.cpp:2779-2791`.

### 2. tx-set acquisition starvation guard
- `Overlay.BroadcastExceptSet` (sole caller: tx-set missing-node acquisition) applied the `#420` per-peer non-progress exclusion with **no floor**: when all connected peers were excluded the request reached **nobody** and the node wedged in `wrongLedger` until the TTL sweep. Now falls back to broadcasting to all connected peers when exclusion would reach zero, mirroring rippled keeping throttled peers eligible (`InboundTransactions.cpp:177-178`).

### 3. tx-set leaf learning (rippled `ConsensusTransSetSF::gotNode`)
- When acquisition pulls in a leaf for a transaction the node had never seen, that tx is now submitted into the open-ledger pool (`router.learnTxFromLeaf` → `AddPendingTx`), mirroring `ConsensusTransSetSF::gotNode → submitTransaction` (`ConsensusTransSetSF.cpp:51-78`). Previously goXRPL only fed the engine on full-set completion, so a partially/transiently acquired set left its novel txs un-relayed and un-sourceable — prolonging the network-wide stall.
- Corrected a misleading comment: peers **do** return a leaf requested directly by node ID (`getNodeFat` always serializes the requested node, `SHAMapSync.cpp:480-483`; `fatLeaves=false` only omits leaf *children* during fat-expansion). The local-pool fill is a round-trip optimization, not a correctness requirement.

### 4. ledger-body serving backpressure (rippled `processLedgerRequest`)
- Shed `liBASE`/`liAS_NODE`/`liTX_NODE` requests when the peer's send queue is saturated, or the node is fee-loaded and the peer is not a cluster member (`PeerImp.cpp:3322-3332`). **`liTS_CANDIDATE` (tx-set) requests are deliberately exempt** — rippled never sheds them, since consensus liveness depends on them. New `NetworkSender.ShouldShedLedgerRequest` (Overlay-backed; `loadedLocal` from `LoadFeeTrack.IsLoadedLocal()`).

## Deliberately NOT changed
- **The peer-LCL gate (`engine.go:1700-1782`) is left in place.** Its own code comment documents it as the fix for the iter27 soak stall at L34 (goXRPL latching onto rippled's transient local-build LCL gossip and staying in `wrongLedger`). It is the engine-layer equivalent of rippled's trusted-only `getPreferred`; removing it would regress prior consensus-liveness work. The issue's "self-squelch" symptom is downstream of incomplete acquisition (items 2–3), not this gate.

## Test plan
- [x] `go test ./internal/rpc/... ./internal/consensus/... ./internal/peermanagement/ ./internal/cli/ ./internal/ledger/service/` — all pass
- [x] `TestServerInfoPubkeyValidator`: seed/token-mode master resolution, non-validator → `"none"`, non-admin → absent, `server_state` parity
- [x] `TestBroadcastExceptSet_*`: partial exclusion; all-excluded fallback; disconnected-skip
- [x] `TestRouter_TxSetAcquire_LearnsTransaction`: a valid tx carried by an acquired tx-set lands in the open ledger (`HasTx`)
- [x] `TestShouldShedLedgerRequest`: unknown-peer, load gate, send-queue saturation, cluster exemption
- [x] `go build ./...`, `go vet`, `gofmt` clean
- [ ] confluence `soak-mixed-3x2` soak to confirm reduced `wrongLedger` dwell under sustained fuzz load (requires the sidecar/Docker harness)

Refs #724
