### PR TITLE
SmartEscrow (computational escrow): EscrowFinish WASM, fees, validation, get_nft — combined (#705,#717,#718,#719)

### DIFF
--- a/amendment/registry.go
+++ b/amendment/registry.go
@@ -28,6 +28,11 @@ var (
 // above — there is no separate init() write-back, so cross-package callers
 // observing FeatureXxx never see a zero ID.
 var (
+	// SmartEscrow must stay SupportedNo until WASM finish-function validation is
+	// available in every shipped build: create-time validation is skipped in
+	// non-wasmi builds (see escrow.validateFinishFunctionWasm), so a SupportedYes
+	// non-wasmi node would fork against a wasmi node on FinishFunction
+	// admissibility. SupportedNo makes such a node amendment-block instead.
 	FeatureSmartEscrow                   = registerFeature("SmartEscrow", SupportedNo, VoteDefaultNo)
 	FeatureFixDirectoryLimit             = registerFix("fixDirectoryLimit", SupportedYes, VoteDefaultNo)
 	FeatureFixPriceOracleOrder           = registerFix("fixPriceOracleOrder", SupportedNo, VoteDefaultNo)

--- a/codec/binarycodec/definitions/definitions.json
+++ b/codec/binarycodec/definitions/definitions.json
@@ -3479,6 +3479,16 @@
         "isVLEncoded": false,
         "type": "UInt32"
       }
+    ],
+    [
+      "GasUsed",
+      {
+        "nth": 73,
+        "isSerialized": true,
+        "isSigningField": false,
+        "isVLEncoded": false,
+        "type": "UInt32"
+      }
     ]
   ],
   "LEDGER_ENTRY_TYPES": {
@@ -3555,7 +3565,6 @@
     "tecNFTOKEN_OFFER_TYPE_MISMATCH": 157,
     "tecNO_ALTERNATIVE_KEY": 130,
     "tecNO_AUTH": 134,
-    "tecNO_DELEGATE_PERMISSION": 198,
     "tecNO_DST": 124,
     "tecNO_DST_INSUF_XRP": 125,
     "tecNO_ENTRY": 140,
@@ -3581,6 +3590,7 @@
     "tecUNFUNDED_AMM": 162,
     "tecUNFUNDED_OFFER": 103,
     "tecUNFUNDED_PAYMENT": 104,
+    "tecWASM_REJECTED": 198,
     "tecWRONG_ASSET": 194,
     "tecXCHAIN_ACCOUNT_CREATE_PAST": 181,
     "tecXCHAIN_ACCOUNT_CREATE_TOO_MANY": 182,
@@ -3618,8 +3628,10 @@
     "tefNOT_MULTI_SIGNING": -184,
     "tefNO_AUTH_REQUIRED": -191,
     "tefNO_TICKET": -180,
+    "tefNO_WASM": -177,
     "tefPAST_SEQ": -190,
     "tefTOO_BIG": -181,
+    "tefWASM_FIELD_NOT_INCLUDED": -176,
     "tefWRONG_PRIOR": -189,
     "telBAD_DOMAIN": -398,
     "telBAD_PATH_COUNT": -397,
@@ -3665,6 +3677,7 @@
     "temBAD_TICK_SIZE": -269,
     "temBAD_TRANSFER_FEE": -251,
     "temBAD_TRANSFER_RATE": -280,
+    "temBAD_WASM": -248,
     "temBAD_WEIGHT": -270,
     "temCANNOT_PREAUTH_SELF": -267,
     "temDISABLED": -273,
@@ -3680,6 +3693,7 @@
     "temREDUNDANT": -275,
     "temRIPPLE_EMPTY": -274,
     "temSEQ_AND_TICKET": -263,
+    "temTEMP_DISABLED": -247,
     "temUNCERTAIN": -265,
     "temUNKNOWN": -264,
     "temXCHAIN_BAD_PROOF": -259,

--- a/codec/binarycodec/definitions/definitions.json
+++ b/codec/binarycodec/definitions/definitions.json
@@ -3429,6 +3429,56 @@
         "nth": 257,
         "type": "Metadata"
       }
+    ],
+    [
+      "FinishFunction",
+      {
+        "nth": 32,
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "type": "Blob"
+      }
+    ],
+    [
+      "ComputationAllowance",
+      {
+        "nth": 72,
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "ExtensionComputeLimit",
+      {
+        "nth": 69,
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "ExtensionSizeLimit",
+      {
+        "nth": 70,
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "GasPrice",
+      {
+        "nth": 71,
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "type": "UInt32"
+      }
     ]
   ],
   "LEDGER_ENTRY_TYPES": {

--- a/codec/binarycodec/definitions/smartescrow_results_test.go
+++ b/codec/binarycodec/definitions/smartescrow_results_test.go
@@ -1,0 +1,41 @@
+package definitions
+
+import "testing"
+
+// TestSmartEscrowTransactionResults pins the SmartEscrow TER codes in
+// TRANSACTION_RESULTS so the metadata codec can round-trip them. The escrow
+// transactors emit these names via Result.String(); a missing entry breaks
+// SerializeMetadata for an applied tecWASM_REJECTED finish.
+// Reference: rippled-smart-escrow include/xrpl/protocol/TER.h.
+func TestSmartEscrowTransactionResults(t *testing.T) {
+	defs := Get()
+	want := map[string]int32{
+		"tecWASM_REJECTED":           198,
+		"tefNO_WASM":                 -177,
+		"tefWASM_FIELD_NOT_INCLUDED": -176,
+		"temBAD_WASM":                -248,
+		"temTEMP_DISABLED":           -247,
+		"terNO_DELEGATE_PERMISSION":  -85,
+	}
+	for name, code := range want {
+		got, err := defs.GetTransactionResultTypeCodeByTransactionResultName(name)
+		if err != nil {
+			t.Errorf("%s: unexpected error %v", name, err)
+			continue
+		}
+		if got != code {
+			t.Errorf("%s = %d, want %d", name, got, code)
+		}
+		rname, rerr := defs.GetTransactionResultNameByTransactionResultTypeCode(code)
+		if rerr != nil || rname != name {
+			t.Errorf("reverse %d = %q (err %v), want %q", code, rname, rerr, name)
+		}
+	}
+
+	// 198 was tecNO_DELEGATE_PERMISSION before SmartEscrow; it is now
+	// tecWASM_REJECTED, and the old name must no longer resolve (the Go side
+	// carries NO_DELEGATE_PERMISSION as terNO_DELEGATE_PERMISSION at -85).
+	if _, err := defs.GetTransactionResultTypeCodeByTransactionResultName("tecNO_DELEGATE_PERMISSION"); err == nil {
+		t.Error("tecNO_DELEGATE_PERMISSION should no longer resolve (repurposed to tecWASM_REJECTED at 198)")
+	}
+}

--- a/internal/ledger/genesis/dtos.go
+++ b/internal/ledger/genesis/dtos.go
@@ -27,6 +27,12 @@ type feeSettings struct {
 	ReferenceFeeUnits *uint32
 	ReserveBase       *uint32
 	ReserveIncrement  *uint32
+
+	// SmartEscrow / WASM extension fees, present only when the SmartEscrow
+	// amendment is active at genesis. Reference: rippled Config.h FeeSetup.
+	ExtensionComputeLimit *uint32
+	ExtensionSizeLimit    *uint32
+	GasPrice              *uint32
 }
 
 func newFeeSettings(baseFee, reserveBase, reserveIncrement drops.XRPAmount) *feeSettings {

--- a/internal/ledger/genesis/genesis.go
+++ b/internal/ledger/genesis/genesis.go
@@ -16,6 +16,7 @@ import (
 	secp256k1 "github.com/LeJamon/go-xrpl/crypto/secp256k1"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
@@ -121,6 +122,19 @@ func DefaultConfig() Config {
 func hasXRPFeesAmendment(amendments [][32]byte) bool {
 	for _, a := range amendments {
 		if a == amendment.FeatureXRPFees {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSmartEscrowAmendment reports whether the SmartEscrow amendment is active at
+// genesis, in which case the FeeSettings entry carries the WASM extension fee
+// fields seeded from the FeeSetup defaults. Reference: rippled writes
+// gasPrice/extension limits to FeeSettings once featureSmartEscrow is enabled.
+func hasSmartEscrowAmendment(amendments [][32]byte) bool {
+	for _, a := range amendments {
+		if a == amendment.FeatureSmartEscrow {
 			return true
 		}
 	}
@@ -380,6 +394,16 @@ func createFeeSettings(stateMap *shamap.SHAMap, cfg Config) error {
 		)
 	}
 
+	// SmartEscrow seeds the WASM extension fee fields from the FeeSetup defaults.
+	if hasSmartEscrowAmendment(cfg.Amendments) {
+		compute := state.DefaultExtensionComputeLimit
+		size := state.DefaultExtensionSizeLimit
+		gas := state.DefaultGasPrice
+		feeSettings.ExtensionComputeLimit = &compute
+		feeSettings.ExtensionSizeLimit = &size
+		feeSettings.GasPrice = &gas
+	}
+
 	// Serialize the fee settings entry
 	data, err := serializeFeeSettings(feeSettings)
 	if err != nil {
@@ -521,6 +545,17 @@ func serializeFeeSettings(f *feeSettings) ([]byte, error) {
 		if f.ReserveIncrement != nil {
 			jsonObj["ReserveIncrement"] = *f.ReserveIncrement
 		}
+	}
+
+	// SmartEscrow extension fees (UInt32), independent of the modern/legacy split.
+	if f.ExtensionComputeLimit != nil {
+		jsonObj["ExtensionComputeLimit"] = *f.ExtensionComputeLimit
+	}
+	if f.ExtensionSizeLimit != nil {
+		jsonObj["ExtensionSizeLimit"] = *f.ExtensionSizeLimit
+	}
+	if f.GasPrice != nil {
+		jsonObj["GasPrice"] = *f.GasPrice
 	}
 
 	// Encode using the binary codec

--- a/internal/ledger/genesis/smartescrow_fee_test.go
+++ b/internal/ledger/genesis/smartescrow_fee_test.go
@@ -1,0 +1,60 @@
+package genesis
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func readGenesisFeeSettings(t *testing.T, cfg Config) *state.FeeSettings {
+	t.Helper()
+	g, err := Create(cfg)
+	if err != nil {
+		t.Fatalf("Create genesis failed: %v", err)
+	}
+	item, found, err := g.StateMap.Get(keylet.Fees().Key)
+	if err != nil || !found {
+		t.Fatalf("FeeSettings not found in genesis state map (err=%v found=%v)", err, found)
+	}
+	fs, err := state.ParseFeeSettings(item.Data())
+	if err != nil {
+		t.Fatalf("Failed to parse FeeSettings: %v", err)
+	}
+	return fs
+}
+
+// TestGenesisFeeSettings_NoSmartEscrow guards conformance: without the
+// SmartEscrow amendment the FeeSettings entry must NOT carry the WASM extension
+// fee fields, so the genesis state hash is unchanged for existing networks.
+func TestGenesisFeeSettings_NoSmartEscrow(t *testing.T) {
+	t.Parallel()
+	fs := readGenesisFeeSettings(t, DefaultConfig())
+	if fs.HasExtensionFees {
+		t.Fatalf("FeeSettings unexpectedly carries extension fees without SmartEscrow")
+	}
+}
+
+// TestGenesisFeeSettings_SmartEscrow verifies that enabling SmartEscrow at
+// genesis seeds the WASM extension fee fields from the FeeSetup defaults.
+// Reference: rippled Config.h FeeSetup (1,000,000 / 100,000 / 1,000,000).
+func TestGenesisFeeSettings_SmartEscrow(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	cfg.Amendments = append(append([][32]byte{}, cfg.Amendments...), amendment.FeatureSmartEscrow)
+
+	fs := readGenesisFeeSettings(t, cfg)
+	if !fs.HasExtensionFees {
+		t.Fatalf("FeeSettings missing extension fees with SmartEscrow enabled")
+	}
+	if got := fs.GetExtensionComputeLimit(); got != state.DefaultExtensionComputeLimit {
+		t.Errorf("ExtensionComputeLimit = %d, want %d", got, state.DefaultExtensionComputeLimit)
+	}
+	if got := fs.GetExtensionSizeLimit(); got != state.DefaultExtensionSizeLimit {
+		t.Errorf("ExtensionSizeLimit = %d, want %d", got, state.DefaultExtensionSizeLimit)
+	}
+	if got := fs.GetGasPrice(); got != state.DefaultGasPrice {
+		t.Errorf("GasPrice = %d, want %d", got, state.DefaultGasPrice)
+	}
+}

--- a/internal/ledger/state/fee_settings.go
+++ b/internal/ledger/state/fee_settings.go
@@ -30,10 +30,30 @@ type FeeSettings struct {
 	// STObject::operator= (assignment) rather than a value-is-nonzero gate.
 	XRPFeesMode bool
 
+	// SmartEscrow / WASM extension fee fields. Present only once the SmartEscrow
+	// amendment is active (rippled writes them as a group via the SetFee
+	// pseudo-transaction). HasExtensionFees records whether they were present in
+	// the parsed entry so the getters can distinguish "absent" from "voted to 0".
+	// Reference: rippled Fees.h (extensionComputeLimit/extensionSizeLimit/gasPrice).
+	ExtensionComputeLimit uint32
+	ExtensionSizeLimit    uint32
+	GasPrice              uint32
+	HasExtensionFees      bool
+
 	// Tracking fields (not always present)
 	PreviousTxnID     [32]byte
 	PreviousTxnLgrSeq uint32
 }
+
+// FeeSetup default values for the WASM extension fee fields, matching rippled's
+// Config.h FeeSetup (extension_compute_limit/extension_size_limit/gas_price).
+// They populate the FeeSettings entry at genesis when SmartEscrow is active and
+// back the getters when the entry predates the SmartEscrow amendment.
+const (
+	DefaultExtensionComputeLimit uint32 = 1_000_000
+	DefaultExtensionSizeLimit    uint32 = 100_000
+	DefaultGasPrice              uint32 = 1_000_000
+)
 
 // Ledger entry type for FeeSettings
 const ledgerEntryTypeFeeSettings uint16 = 0x0073
@@ -45,6 +65,11 @@ const (
 	fieldCodeReferenceFeeUnits uint8 = 30 // sfReferenceFeeUnits
 	fieldCodeReserveBase       uint8 = 31 // sfReserveBase (legacy)
 	fieldCodeReserveIncrement  uint8 = 32 // sfReserveIncrement (legacy)
+
+	// UInt32 fields (SmartEscrow / WASM extension fees)
+	fieldCodeExtensionComputeLimit uint8 = 69 // sfExtensionComputeLimit
+	fieldCodeExtensionSizeLimit    uint8 = 70 // sfExtensionSizeLimit
+	fieldCodeGasPrice              uint8 = 71 // sfGasPrice
 
 	// UInt64 fields
 	fieldCodeBaseFee uint8 = 5 // sfBaseFee (legacy)
@@ -125,6 +150,15 @@ func ParseFeeSettings(data []byte) (*FeeSettings, error) {
 				fee.ReserveBase = value
 			case fieldCodeReserveIncrement:
 				fee.ReserveIncrement = value
+			case fieldCodeExtensionComputeLimit:
+				fee.ExtensionComputeLimit = value
+				fee.HasExtensionFees = true
+			case fieldCodeExtensionSizeLimit:
+				fee.ExtensionSizeLimit = value
+				fee.HasExtensionFees = true
+			case fieldCodeGasPrice:
+				fee.GasPrice = value
+				fee.HasExtensionFees = true
 			}
 
 		case FieldTypeUInt64:
@@ -203,6 +237,15 @@ func SerializeFeeSettings(fee *FeeSettings) ([]byte, error) {
 		jsonObj["ReserveIncrement"] = fee.ReserveIncrement
 	}
 
+	// SmartEscrow extension fees are emitted as a group once present, matching
+	// rippled's SetFee handler which writes all three together under
+	// featureSmartEscrow (Change.cpp).
+	if fee.HasExtensionFees {
+		jsonObj["ExtensionComputeLimit"] = fee.ExtensionComputeLimit
+		jsonObj["ExtensionSizeLimit"] = fee.ExtensionSizeLimit
+		jsonObj["GasPrice"] = fee.GasPrice
+	}
+
 	// Add tracking fields if present
 	var zeroHash [32]byte
 	if fee.PreviousTxnID != zeroHash {
@@ -261,4 +304,33 @@ func (f *FeeSettings) GetReserveIncrement() uint64 {
 // set. Authoritative source is XRPFeesMode (set at Parse and at Apply time).
 func (f *FeeSettings) IsUsingModernFees() bool {
 	return f.XRPFeesMode
+}
+
+// GetExtensionComputeLimit returns the WASM compute limit (instructions). When
+// the entry carries no extension fees (it predates SmartEscrow), the FeeSetup
+// default is returned so a SmartEscrow enabled post-genesis still resolves the
+// standard limit. A voted value of 0 (WASM disabled) is preserved.
+func (f *FeeSettings) GetExtensionComputeLimit() uint32 {
+	if f.HasExtensionFees {
+		return f.ExtensionComputeLimit
+	}
+	return DefaultExtensionComputeLimit
+}
+
+// GetExtensionSizeLimit returns the WASM size limit (bytes); see
+// GetExtensionComputeLimit for the absent-vs-zero semantics.
+func (f *FeeSettings) GetExtensionSizeLimit() uint32 {
+	if f.HasExtensionFees {
+		return f.ExtensionSizeLimit
+	}
+	return DefaultExtensionSizeLimit
+}
+
+// GetGasPrice returns the price of one unit of WASM gas in micro-drops; see
+// GetExtensionComputeLimit for the absent-vs-zero semantics.
+func (f *FeeSettings) GetGasPrice() uint32 {
+	if f.HasExtensionFees {
+		return f.GasPrice
+	}
+	return DefaultGasPrice
 }

--- a/internal/testing/escrow/smartescrow_fields_test.go
+++ b/internal/testing/escrow/smartescrow_fields_test.go
@@ -1,0 +1,160 @@
+// SmartEscrow field-pairing validation tests. The FinishFunction/
+// ComputationAllowance pairing is checked in preclaim, before the WASM engine
+// runs, so these reject without invoking the engine and build in the default
+// (non-wasmi) toolchain.
+package escrow_test
+
+import (
+	"testing"
+	"time"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/stretchr/testify/require"
+)
+
+// A trivial finish function returning 1; never executed in these tests since
+// the finish is rejected at field validation before the engine runs.
+const finishFnTrivial = "0061736d010000000105016000017f03020100070a010666696e69736800000a0601040041010b"
+
+// TestSmartEscrow_FinishMissingAllowance: finishing an escrow that carries a
+// FinishFunction without a ComputationAllowance is rejected with
+// tefWASM_FIELD_NOT_INCLUDED.
+// Reference: rippled EscrowSmart_test.cpp line 470
+func TestSmartEscrow_FinishMissingAllowance(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	seq := env.Seq(alice)
+	ff := finishFnTrivial
+	ec := escrow.EscrowCreate(alice, bob, xrp(1000)).
+		CancelTime(env.Now().Add(1000 * time.Second)).
+		Fee(baseFee * 150).
+		BuildEscrowCreate()
+	ec.FinishFunction = &ff
+	jtx.RequireTxSuccess(t, env.Submit(ec))
+	env.Close()
+
+	// Finish without a ComputationAllowance.
+	ef := escrow.EscrowFinish(bob, alice, seq).
+		Fee(baseFee * 150).
+		BuildEscrowFinish()
+	require.Equal(t, "tefWASM_FIELD_NOT_INCLUDED", env.Submit(ef).Code)
+}
+
+// TestSmartEscrow_FinishNoFunction: supplying a ComputationAllowance when the
+// escrow has no FinishFunction is rejected with tefNO_WASM.
+// Reference: rippled EscrowSmart_test.cpp line 514
+func TestSmartEscrow_FinishNoFunction(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	// A plain time-based escrow, no FinishFunction.
+	seq := env.Seq(alice)
+	jtx.RequireTxSuccess(t, env.Submit(
+		escrow.EscrowCreate(alice, bob, xrp(1000)).
+			FinishTime(env.Now().Add(1*time.Second)).
+			Build()))
+	env.Close()
+
+	// The ComputationAllowance fee (#717) applies even though the escrow has no
+	// FinishFunction; pay above it so the finish reaches the tefNO_WASM check.
+	allowance := uint32(1_000_000)
+	ef := escrow.EscrowFinish(bob, alice, seq).
+		Fee(2_000_000).
+		BuildEscrowFinish()
+	ef.ComputationAllowance = &allowance
+	require.Equal(t, "tefNO_WASM", env.Submit(ef).Code)
+}
+
+// finishPlainEscrowAllowance creates a plain time-based escrow and finishes it
+// with the given ComputationAllowance, returning the finish result code. Used to
+// exercise the ComputationAllowance bound checks, which run before the escrow's
+// FinishFunction is consulted.
+func finishPlainEscrowAllowance(t *testing.T, allowance uint32, fee uint64) string {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	seq := env.Seq(alice)
+	jtx.RequireTxSuccess(t, env.Submit(
+		escrow.EscrowCreate(alice, bob, xrp(1000)).
+			FinishTime(env.Now().Add(1*time.Second)).
+			Build()))
+	env.Close()
+
+	ef := escrow.EscrowFinish(bob, alice, seq).
+		Fee(fee).
+		BuildEscrowFinish()
+	ef.ComputationAllowance = &allowance
+	return env.Submit(ef).Code
+}
+
+// TestSmartEscrow_AllowanceZero: a zero ComputationAllowance is temBAD_LIMIT.
+// Reference: rippled EscrowFinish.cpp preflight lines 109-112.
+func TestSmartEscrow_AllowanceZero(t *testing.T) {
+	require.Equal(t, "temBAD_LIMIT", finishPlainEscrowAllowance(t, 0, baseFee*150))
+}
+
+// TestSmartEscrow_AllowanceTooLarge: a ComputationAllowance above the extension
+// compute limit (default 1,000,000) is temBAD_LIMIT.
+// Reference: rippled EscrowFinish.cpp preflight lines 113-116.
+func TestSmartEscrow_AllowanceTooLarge(t *testing.T) {
+	// Fee must cover the gas fee for the (over-limit) allowance so the finish
+	// reaches the bound check rather than failing on fee adequacy first.
+	require.Equal(t, "temBAD_LIMIT", finishPlainEscrowAllowance(t, 1_000_001, 2_000_000))
+}
+
+// TestSmartEscrow_FinishDepositAuth: under SmartEscrow, deposit-authorization is
+// still enforced — rippled relocates verifyDepositPreauth to before the WASM
+// step, it does not skip it. An unauthorized finisher is rejected with
+// tecNO_PERMISSION before the finish function runs, so this builds in the
+// default (non-wasmi) toolchain too.
+// Reference: rippled-smart-escrow EscrowFinish.cpp:328-338
+func TestSmartEscrow_FinishDepositAuth(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	zelda := jtx.NewAccount("zelda")
+	fund5000(env, alice, bob, zelda)
+
+	// Bob (the escrow destination) requires deposit authorization.
+	env.EnableDepositAuth(bob)
+	env.Close()
+
+	seq := env.Seq(alice)
+	ff := finishFnTrivial
+	ec := escrow.EscrowCreate(alice, bob, xrp(1000)).
+		CancelTime(env.Now().Add(1000 * time.Second)).
+		Fee(baseFee * 150).
+		BuildEscrowCreate()
+	ec.FinishFunction = &ff
+	jtx.RequireTxSuccess(t, env.Submit(ec))
+	env.Close()
+
+	// Zelda is not authorized to deposit to Bob: the finish is rejected before
+	// the WASM function runs. The allowance fee (#717) applies, so pay above it.
+	allowance := uint32(1_000_000)
+	ef := escrow.EscrowFinish(zelda, alice, seq).
+		Fee(2_000_000).
+		BuildEscrowFinish()
+	ef.ComputationAllowance = &allowance
+	require.Equal(t, "tecNO_PERMISSION", env.Submit(ef).Code)
+}

--- a/internal/testing/escrow/smartescrow_reserve_test.go
+++ b/internal/testing/escrow/smartescrow_reserve_test.go
@@ -1,0 +1,59 @@
+//go:build !wasmi
+
+// SmartEscrow owner-reserve test. The reserve a FinishFunction escrow consumes
+// is engine-independent, and the test uses a non-WASM blob as the FinishFunction
+// to drive the reserve math without standing up the engine — so it runs only in
+// the default (non-wasmi) build, where create-time WASM validation is skipped.
+package escrow_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSmartEscrow_FinishFunctionReserve: a FinishFunction escrow consumes
+// additional owner reserve — one slot plus one per 500 bytes of code — matching
+// rippled's calculateAdditionalReserve. A ~600-byte FinishFunction therefore
+// costs two owner-count slots on create and releases both on cancel.
+// Reference: rippled-smart-escrow EscrowHelpers.h:232-239
+func TestSmartEscrow_FinishFunctionReserve(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	require.Equal(t, uint32(0), env.OwnerCount(alice))
+
+	ff := strings.Repeat("00", 600) // 600 bytes → 1 + 600/500 = 2 reserve slots
+	ts := env.Now().Add(20 * time.Second)
+	seq := env.Seq(alice)
+	ec := escrow.EscrowCreate(alice, bob, xrp(1000)).
+		CancelTime(ts).
+		Fee(baseFee * 1000). // covers the per-byte create fee for a 600-byte FinishFunction
+		BuildEscrowCreate()
+	ec.FinishFunction = &ff
+	jtx.RequireTxSuccess(t, env.Submit(ec))
+	env.Close()
+
+	require.Equal(t, uint32(2), env.OwnerCount(alice))
+
+	// Advance strictly past the cancel time, then cancel — releasing the full
+	// reserve. The margin clears the close-time resolution rounding so the
+	// parent close time is strictly greater than CancelAfter.
+	for !env.Now().After(ts.Add(10 * time.Second)) {
+		env.Close()
+	}
+	jtx.RequireTxSuccess(t, env.Submit(
+		escrow.EscrowCancel(alice, alice, seq).Fee(baseFee*150).Build()))
+	env.Close()
+
+	require.Equal(t, uint32(0), env.OwnerCount(alice))
+}

--- a/internal/testing/escrow/smartescrow_test.go
+++ b/internal/testing/escrow/smartescrow_test.go
@@ -1,0 +1,108 @@
+//go:build cgo && wasmi
+
+// SmartEscrow (computational escrow) end-to-end tests. Built with -tags wasmi so
+// the real wasmi engine runs the escrow's FinishFunction.
+package escrow_test
+
+import (
+	"testing"
+	"time"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/stretchr/testify/require"
+)
+
+// Minimal finish functions compiled with wat2wasm:
+//
+//	(module (func (export "finish") (result i32) (i32.const N)))
+const (
+	finishReturns1 = "0061736d010000000105016000017f03020100070a010666696e69736800000a0601040041010b"
+	finishReturns0 = "0061736d010000000105016000017f03020100070a010666696e69736800000a0601040041000b"
+)
+
+func runComputationalEscrow(t *testing.T, finishFunctionHex string) string {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	// A FinishFunction requires a CancelAfter; no FinishAfter, so the escrow can
+	// be finished immediately (the finish function governs).
+	seq := env.Seq(alice)
+	ec := escrow.EscrowCreate(alice, bob, xrp(1000)).
+		CancelTime(env.Now().Add(1000 * time.Second)).
+		Fee(baseFee * 150).
+		BuildEscrowCreate()
+	ec.FinishFunction = &finishFunctionHex
+	createRes := env.Submit(ec)
+	t.Logf("create result: %s", createRes.Code)
+	jtx.RequireTxSuccess(t, createRes)
+	env.Close()
+
+	// A 1,000,000-unit ComputationAllowance costs ~1,000,001 drops at the default
+	// gas price (#717), so the finish must pay well above the base fee.
+	allowance := uint32(1_000_000)
+	ef := escrow.EscrowFinish(bob, alice, seq).
+		Fee(2_000_000).
+		BuildEscrowFinish()
+	ef.ComputationAllowance = &allowance
+	return env.Submit(ef).Code
+}
+
+// TestSmartEscrow_FinishAccepts: a finish function returning 1 lets the escrow
+// finish.
+func TestSmartEscrow_FinishAccepts(t *testing.T) {
+	require.Equal(t, "tesSUCCESS", runComputationalEscrow(t, finishReturns1))
+}
+
+// TestSmartEscrow_FinishRejects: a finish function returning 0 rejects the
+// finish with tecWASM_REJECTED.
+func TestSmartEscrow_FinishRejects(t *testing.T) {
+	require.Equal(t, "tecWASM_REJECTED", runComputationalEscrow(t, finishReturns0))
+}
+
+// Malformed FinishFunction WASM rejected at create time (preflightEscrowWasm),
+// only validated when the wasmi engine is linked.
+const (
+	// Not a valid WASM module (no magic header).
+	finishGarbage = "deadbeefdeadbeef"
+	// Valid module, but the export is named "fonish" — no "finish" entry point.
+	finishWrongExport = "0061736d010000000105016000017f03020100070a0106666f6e69736800000a0601040041010b"
+)
+
+// createWithFinishFunction creates an escrow carrying finishFunctionHex and
+// returns the EscrowCreate result code.
+func createWithFinishFunction(t *testing.T, finishFunctionHex string) string {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	ec := escrow.EscrowCreate(alice, bob, xrp(1000)).
+		CancelTime(env.Now().Add(1000 * time.Second)).
+		Fee(baseFee * 150).
+		BuildEscrowCreate()
+	ec.FinishFunction = &finishFunctionHex
+	return env.Submit(ec).Code
+}
+
+// TestSmartEscrow_CreateBadWasm: a FinishFunction that is not a well-formed
+// module is rejected at create time with temBAD_WASM.
+func TestSmartEscrow_CreateBadWasm(t *testing.T) {
+	require.Equal(t, "temBAD_WASM", createWithFinishFunction(t, finishGarbage))
+}
+
+// TestSmartEscrow_CreateMissingFinishExport: a module that does not export
+// finish() is rejected at create time with temBAD_WASM.
+func TestSmartEscrow_CreateMissingFinishExport(t *testing.T) {
+	require.Equal(t, "temBAD_WASM", createWithFinishFunction(t, finishWrongExport))
+}

--- a/internal/testing/nft/findtokenuri_test.go
+++ b/internal/testing/nft/findtokenuri_test.go
@@ -1,0 +1,47 @@
+package nft_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/nft"
+	"github.com/LeJamon/go-xrpl/internal/tx/nftoken"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindTokenURI verifies nftoken.FindTokenURI, which backs the SmartEscrow
+// get_nft host function: it walks an owner's NFTokenPages and returns the raw
+// URI of a minted token, and reports not-found for an unminted id.
+func TestFindTokenURI(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+	env.Close()
+
+	const uri = "https://example.com/nft/metadata.json"
+	flags := nftoken.NFTokenFlagTransferable
+	nftIDHex := nft.GetNextNFTokenID(env, alice, 0, flags, 0)
+
+	env.Submit(nft.NFTokenMint(alice, 0).Transferable().URI(uri).Build())
+	env.Close()
+
+	var nftID [32]byte
+	raw, err := hex.DecodeString(nftIDHex)
+	require.NoError(t, err)
+	require.Len(t, raw, 32)
+	copy(nftID[:], raw)
+
+	owner := alice.AccountID()
+
+	got, found, hasURI := nftoken.FindTokenURI(env.Ledger(), owner, nftID)
+	require.True(t, found, "minted NFT should be found")
+	require.True(t, hasURI, "minted NFT should carry a URI")
+	require.Equal(t, uri, string(got))
+
+	// An unminted token id is not found.
+	var missing [32]byte
+	missing[0] = 0xAB
+	_, found, _ = nftoken.FindTokenURI(env.Ledger(), owner, missing)
+	require.False(t, found, "unminted NFT should not be found")
+}

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -749,21 +749,21 @@ func checkDelegatePermission(ctx *tx.ApplyContext, accountID [20]byte, innerTx t
 	common := innerTx.GetCommon()
 	delegateID, delegateErr := state.DecodeAccountID(common.Delegate)
 	if delegateErr != nil {
-		return tx.TecNO_DELEGATE_PERMISSION
+		return tx.TerNO_DELEGATE_PERMISSION
 	}
 	delegateKeylet := keylet.DelegateKeylet(accountID, delegateID)
 	delegateData, readErr := ctx.View.Read(delegateKeylet)
 	if readErr != nil || delegateData == nil {
-		return tx.TecNO_DELEGATE_PERMISSION
+		return tx.TerNO_DELEGATE_PERMISSION
 	}
 	delegateEntry, parseErr := state.ParseDelegate(delegateData)
 	if parseErr != nil {
-		return tx.TecNO_DELEGATE_PERMISSION
+		return tx.TerNO_DELEGATE_PERMISSION
 	}
 	// Check if the delegate SLE grants permission for this tx type.
 	txTypeValue := uint32(innerTx.TxType())
 	if !delegateEntry.HasTxPermission(txTypeValue) {
-		return tx.TecNO_DELEGATE_PERMISSION
+		return tx.TerNO_DELEGATE_PERMISSION
 	}
 	return 0 // success (no error)
 }

--- a/internal/tx/escrow/escrow_cancel.go
+++ b/internal/tx/escrow/escrow_cancel.go
@@ -268,9 +268,10 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Decrement owner count
-	// Reference: rippled Escrow.cpp doApply() line 1401
-	adjustOwnerCount(ctx, ownerID, -1)
+	// Decrement owner count, releasing the reserve the escrow held (a
+	// FinishFunction escrow may have consumed more than one slot).
+	// Reference: rippled-smart-escrow EscrowCancel.cpp:213
+	adjustOwnerCount(ctx, ownerID, -int(escrowDataReserve(escrowData)))
 
 	// Delete the escrow
 	// Reference: rippled Escrow.cpp doApply() line 1405

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -39,6 +39,12 @@ type EscrowCreate struct {
 	// Condition is the crypto-condition that must be fulfilled (optional).
 	// Pointer to distinguish "not set" (nil) from "set to empty" (ptr to "").
 	Condition *string `json:"Condition,omitempty" xrpl:"Condition,omitempty"`
+
+	// FinishFunction is the WASM code run at finish time (SmartEscrow, optional).
+	FinishFunction *string `json:"FinishFunction,omitempty" xrpl:"FinishFunction,omitempty"`
+
+	// Data is the escrow's initial mutable data (SmartEscrow, optional).
+	Data *string `json:"Data,omitempty" xrpl:"Data,omitempty"`
 }
 
 func NewEscrowCreate(account, destination string, amount tx.Amount) *EscrowCreate {
@@ -128,15 +134,74 @@ func (e *EscrowCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(e)
 }
 
+// CalculateBaseFee mirrors rippled's EscrowCreate::calculateBaseFee: the
+// multisigned base fee plus, when a FinishFunction (SmartEscrow) is attached, a
+// surcharge of 9 base fees plus 5 drops per byte of WASM code.
+// Reference: rippled EscrowCreate.cpp calculateBaseFee lines 120-131
+func (e *EscrowCreate) CalculateBaseFee(view tx.LedgerView, config tx.EngineConfig) uint64 {
+	base := config.BaseFee
+	if fs := escrowFeeSettings(view); fs != nil {
+		base = fs.GetBaseFee()
+	}
+
+	fee := tx.CalculateMultiSigFee(base, len(e.GetCommon().Signers))
+
+	if e.FinishFunction != nil && *e.FinishFunction != "" {
+		fee += 9*base + 5*vlByteLen(*e.FinishFunction)
+	}
+
+	return fee
+}
+
 // Preclaim performs stateful validation for EscrowCreate before doApply.
 // Time checks are here so that the engine's TapRETRY gate can suppress
 // tec results during retry passes, matching rippled's likelyToClaimFee
 // semantics. Without this, replay-on-close would apply tecNO_PERMISSION
 // on the final pass even though the initial apply succeeded.
 // Reference: rippled Escrow.cpp EscrowCreate::doApply() lines 457-489
-func (e *EscrowCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (e *EscrowCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result {
 	rules := config.GetRules()
 	closeTime := config.ParentCloseTime
+
+	// SmartEscrow field gating. FinishFunction/Data require the amendment; a
+	// FinishFunction requires a CancelAfter; Data requires a FinishFunction; and
+	// Data is bounded by maxWasmDataLength.
+	if (e.FinishFunction != nil || e.Data != nil) && !rules.Enabled(amendment.FeatureSmartEscrow) {
+		return tx.TemDISABLED
+	}
+	if e.FinishFunction != nil && e.CancelAfter == nil {
+		// Reference: rippled EscrowCreate.cpp preflight line 171
+		return tx.TemBAD_EXPIRATION
+	}
+	if e.Data != nil && e.FinishFunction == nil {
+		return tx.TemMALFORMED
+	}
+	if e.Data != nil && len(*e.Data)/2 > maxWasmDataLength {
+		return tx.TemMALFORMED
+	}
+
+	// FinishFunction size + WASM-runtime bounds. The extension limits come from
+	// the FeeSettings entry; fee voting can disable the WASM runtime by setting a
+	// limit to 0. The module is then validated (compiles + exports finish()).
+	// Reference: rippled EscrowCreate.cpp preflight lines 214-231 + preflightSigValidated
+	if e.FinishFunction != nil {
+		sizeLimit := state.DefaultExtensionSizeLimit
+		computeLimit := state.DefaultExtensionComputeLimit
+		if fs := escrowFeeSettings(view); fs != nil {
+			sizeLimit = fs.GetExtensionSizeLimit()
+			computeLimit = fs.GetExtensionComputeLimit()
+		}
+		if sizeLimit == 0 || computeLimit == 0 {
+			return tx.TemTEMP_DISABLED
+		}
+		code, err := hex.DecodeString(*e.FinishFunction)
+		if err != nil || len(code) == 0 || uint64(len(code)) > uint64(sizeLimit) {
+			return tx.TemMALFORMED
+		}
+		if r := validateFinishFunctionWasm(code); r != tx.TesSUCCESS {
+			return r
+		}
+	}
 
 	// Time validation against parent close time
 	// Reference: rippled Escrow.cpp:457-489
@@ -205,10 +270,11 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Amendment-gated preflight: fix1571 requires FinishAfter or Condition
-	// Reference: rippled Escrow.cpp:160-167
+	// Amendment-gated preflight: fix1571 requires FinishAfter or Condition.
+	// SmartEscrow additionally accepts a FinishFunction as the completion gate.
+	// Reference: rippled EscrowCreate.cpp preflight line 178
 	if rules.Enabled(amendment.FeatureFix1571) {
-		if e.FinishAfter == nil && (e.Condition == nil || *e.Condition == "") {
+		if e.FinishAfter == nil && (e.Condition == nil || *e.Condition == "") && e.FinishFunction == nil {
 			return tx.TemMALFORMED
 		}
 	}
@@ -257,9 +323,16 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Reserve check
-	// Reference: rippled Escrow.cpp:496-509
-	reserve := ctx.AccountReserve(ctx.Account.OwnerCount + 1)
+	// Reserve check. A FinishFunction escrow consumes additional reserve beyond
+	// the base one slot (1 per 500 bytes of code), matching rippled's
+	// calculateAdditionalReserve.
+	// Reference: rippled-smart-escrow EscrowCreate.cpp:511-513
+	ffBytes := 0
+	if e.FinishFunction != nil {
+		ffBytes = len(*e.FinishFunction) / 2
+	}
+	reserveToAdd := calculateAdditionalReserve(ffBytes)
+	reserve := ctx.AccountReserve(ctx.Account.OwnerCount + reserveToAdd)
 	if ctx.Account.Balance < reserve {
 		ctx.Log.Warn("escrow create: insufficient reserve",
 			"balance", ctx.Account.Balance,
@@ -399,8 +472,10 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Increase owner count for the escrow creator
-	ctx.Account.OwnerCount++
+	// Increase owner count for the escrow creator by the reserve the escrow
+	// consumes (a FinishFunction may require more than one slot).
+	// Reference: rippled-smart-escrow EscrowCreate.cpp:616
+	ctx.Account.OwnerCount += reserveToAdd
 
 	return tx.TesSUCCESS
 }
@@ -464,6 +539,14 @@ func serializeEscrow(txn *EscrowCreate, ownerID, destID [20]byte, sequence uint3
 
 	if txn.Condition != nil && *txn.Condition != "" {
 		jsonObj["Condition"] = *txn.Condition
+	}
+
+	if txn.FinishFunction != nil && *txn.FinishFunction != "" {
+		jsonObj["FinishFunction"] = *txn.FinishFunction
+	}
+
+	if txn.Data != nil && *txn.Data != "" {
+		jsonObj["Data"] = *txn.Data
 	}
 
 	// SourceTag from Common fields

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -34,6 +34,10 @@ type EscrowFinish struct {
 	// Used for deposit preauth with credentials.
 	// Reference: rippled sfCredentialIDs
 	CredentialIDs []string `json:"CredentialIDs,omitempty" xrpl:"CredentialIDs,omitempty"`
+
+	// ComputationAllowance is the gas budget for the escrow's FinishFunction
+	// (SmartEscrow). Required when finishing an escrow that has a FinishFunction.
+	ComputationAllowance *uint32 `json:"ComputationAllowance,omitempty" xrpl:"ComputationAllowance,omitempty"`
 }
 
 func NewEscrowFinish(account, owner string, offerSequence uint32) *EscrowFinish {
@@ -102,23 +106,28 @@ func (e *EscrowFinish) Flatten() (map[string]any, error) {
 // dispatch in preclaim.go skips the multisig multiplier, so it is applied here.
 // Reference: rippled Escrow.cpp:682-693, Transactor.cpp:229-244
 func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConfig) uint64 {
+	fs := escrowFeeSettings(view)
+
 	base := config.BaseFee
-	if view != nil {
-		if data, err := view.Read(keylet.Fees()); err == nil && data != nil {
-			if fs, err := state.ParseFeeSettings(data); err == nil {
-				base = fs.GetBaseFee()
-			}
-		}
+	if fs != nil {
+		base = fs.GetBaseFee()
 	}
 
 	fee := tx.CalculateMultiSigFee(base, len(e.GetCommon().Signers))
 
 	if e.Fulfillment != nil {
-		fulfillmentLen := len(*e.Fulfillment) / 2
-		if decoded, err := hex.DecodeString(*e.Fulfillment); err == nil {
-			fulfillmentLen = len(decoded)
+		fee += base * (32 + vlByteLen(*e.Fulfillment)/16)
+	}
+
+	// SmartEscrow: the ComputationAllowance gas budget is priced at gasPrice
+	// micro-drops per unit, rounded up to whole drops.
+	// Reference: rippled EscrowFinish.cpp calculateBaseFee lines 167-174
+	if e.ComputationAllowance != nil {
+		gasPrice := uint64(state.DefaultGasPrice)
+		if fs != nil {
+			gasPrice = uint64(fs.GetGasPrice())
 		}
-		fee += base * (32 + uint64(fulfillmentLen)/16)
+		fee += (uint64(*e.ComputationAllowance)*gasPrice)/microDropsPerDrop + 1
 	}
 
 	return fee
@@ -149,6 +158,28 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled Escrow.cpp preflight() credential check
 	if len(e.CredentialIDs) > 0 && !rules.Enabled(amendment.FeatureCredentials) {
 		return tx.TemDISABLED
+	}
+
+	// ComputationAllowance requires the SmartEscrow amendment.
+	// Reference: rippled EscrowFinish.cpp preflight line 80
+	if e.ComputationAllowance != nil && !rules.Enabled(amendment.FeatureSmartEscrow) {
+		return tx.TemDISABLED
+	}
+
+	// ComputationAllowance bounds: the WASM runtime can be disabled by fee voting
+	// (compute limit 0), and the allowance must be a positive value within that
+	// limit. Reference: rippled EscrowFinish.cpp preflight lines 101-117
+	if e.ComputationAllowance != nil {
+		computeLimit := state.DefaultExtensionComputeLimit
+		if fs := escrowFeeSettings(ctx.View); fs != nil {
+			computeLimit = fs.GetExtensionComputeLimit()
+		}
+		if computeLimit == 0 {
+			return tx.TemTEMP_DISABLED
+		}
+		if *e.ComputationAllowance == 0 || *e.ComputationAllowance > computeLimit {
+			return tx.TemBAD_LIMIT
+		}
 	}
 
 	// --- Preclaim: credential validation (before time checks) ---
@@ -186,6 +217,15 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	isXRP := escrowEntry.IsXRP
 
+	// SmartEscrow preclaim: the escrow's FinishFunction and the transaction's
+	// ComputationAllowance must be present together. Done in preclaim ordering
+	// (before the time/condition checks) so a field mismatch is reported even
+	// when the fulfillment is also wrong.
+	// Reference: rippled EscrowFinish::preclaim() lines 260-278
+	if result := smartEscrowFinishPreclaim(ctx, e, escrowData); result != tx.TesSUCCESS {
+		return result
+	}
+
 	// Token escrow preclaim
 	// Reference: rippled EscrowFinish::preclaim() lines 760-793
 	if !isXRP && rules.Enabled(amendment.FeatureTokenEscrow) {
@@ -221,6 +261,43 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 		if escrowEntry.CancelAfter > 0 && closeTime <= escrowEntry.CancelAfter {
 			return tx.TecNO_PERMISSION
+		}
+	}
+
+	// Load the destination account once: it is needed for the deposit-auth
+	// check(s) and for the final transfer. rippled peeks sled here.
+	// Reference: rippled-smart-escrow EscrowFinish.cpp:326-327
+	destIsSelf := ctx.AccountID == escrowEntry.DestinationID
+	destKey := keylet.Account(escrowEntry.DestinationID)
+	var destAccount *state.AccountRoot
+	destMissing := false
+	if destIsSelf {
+		destAccount = ctx.Account
+	} else {
+		destData, readErr := ctx.View.Read(destKey)
+		if readErr != nil || destData == nil {
+			destMissing = true
+		} else {
+			parsed, parseErr := state.ParseAccountRoot(destData)
+			if parseErr != nil {
+				return tx.TefINTERNAL
+			}
+			destAccount = parsed
+		}
+	}
+
+	// SmartEscrow relocates deposit-authorization to BEFORE the crypto-condition
+	// and WASM steps, so an unauthorized finisher is rejected before the contract
+	// runs. Without SmartEscrow the same check runs after the condition (below).
+	// rippled gates the two positions on the amendment; it does not skip the
+	// check under SmartEscrow.
+	// Reference: rippled-smart-escrow EscrowFinish.cpp:328-338
+	if rules.Enabled(amendment.FeatureSmartEscrow) {
+		if destMissing {
+			return tx.TecNO_DST
+		}
+		if result := checkEscrowDepositAuth(ctx, e, escrowEntry, destAccount); result != tx.TesSUCCESS {
+			return result
 		}
 	}
 
@@ -262,52 +339,25 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Debug("escrow finish: fulfillment verified successfully")
 	}
 
-	// Determine if finisher is the destination and/or the owner.
-	destIsSelf := ctx.AccountID == escrowEntry.DestinationID
+	// SmartEscrow: if the escrow carries a finish function, execute it now that
+	// the condition (if any) has been verified and — under SmartEscrow — deposit
+	// authorization has already passed (checked above). A non-positive result
+	// rejects the finish (tecWASM_REJECTED). Field pairing was checked in preclaim.
+	// Reference: rippled EscrowFinish::doApply() lines 406-457
+	if r := runSmartEscrow(ctx, e, escrowData); r != tx.TesSUCCESS {
+		return r
+	}
 
-	// Read destination account for deposit auth check
-	var destAccount *state.AccountRoot
-	destKey := keylet.Account(escrowEntry.DestinationID)
-	if destIsSelf {
-		destAccount = ctx.Account
-	} else {
-		destData, err := ctx.View.Read(destKey)
-		if err != nil {
+	// Deposit-authorization (non-SmartEscrow): runs after the condition check.
+	// Under SmartEscrow this already ran earlier (before the WASM step); the two
+	// positions are the complementary halves of rippled's amendment-gated layout.
+	// Reference: rippled-smart-escrow EscrowFinish.cpp:393-403
+	if !rules.Enabled(amendment.FeatureSmartEscrow) {
+		if destMissing {
 			return tx.TecNO_DST
 		}
-		destAccount, err = state.ParseAccountRoot(destData)
-		if err != nil {
-			return tx.TefINTERNAL
-		}
-	}
-
-	// Check for expired credentials BEFORE deposit auth check.
-	// Reference: rippled verifyDepositPreauth() — first calls removeExpired(),
-	// returns tecEXPIRED if any credentials were expired.
-	if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if removeExpiredCredentials(ctx, e.CredentialIDs) {
-			return tx.TecEXPIRED
-		}
-	}
-
-	// Deposit authorization check
-	// Reference: rippled verifyDepositPreauth() in CredentialHelpers.cpp
-	if rules.Enabled(amendment.FeatureDepositAuth) {
-		if (destAccount.Flags & state.LsfDepositAuth) != 0 {
-			if ctx.AccountID != escrowEntry.DestinationID {
-				// Check account-based DepositPreauth
-				preauthKey := keylet.DepositPreauth(escrowEntry.DestinationID, ctx.AccountID)
-				if exists, _ := ctx.View.Exists(preauthKey); !exists {
-					// No account-based preauth — check credential-based
-					if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-						if result := authorizedDepositPreauth(ctx, e.CredentialIDs, escrowEntry.DestinationID); result != tx.TesSUCCESS {
-							return result
-						}
-					} else {
-						return tx.TecNO_PERMISSION
-					}
-				}
-			}
+		if result := checkEscrowDepositAuth(ctx, e, escrowEntry, destAccount); result != tx.TesSUCCESS {
+			return result
 		}
 	}
 
@@ -445,9 +495,46 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TefINTERNAL
 	}
 
-	// Decrement OwnerCount for escrow owner only.
-	// Reference: rippled Escrow.cpp doApply() lines 1188-1191
-	adjustOwnerCount(ctx, ownerID, -1)
+	// Decrement OwnerCount for the escrow owner, releasing the reserve the escrow
+	// held (a FinishFunction escrow may have consumed more than one slot).
+	// Reference: rippled-smart-escrow EscrowFinish.cpp:534-538
+	adjustOwnerCount(ctx, ownerID, -int(escrowDataReserve(escrowData)))
+
+	return tx.TesSUCCESS
+}
+
+// checkEscrowDepositAuth runs the expired-credential pass and the deposit-
+// authorization check for an EscrowFinish, mirroring rippled's
+// verifyDepositPreauth: removeExpired (→ tecEXPIRED) followed by the
+// lsfDepositAuth / DepositPreauth / credential-preauth checks. destAccount is
+// the already-loaded destination account.
+// Reference: rippled CredentialHelpers.cpp verifyDepositPreauth()
+func checkEscrowDepositAuth(ctx *tx.ApplyContext, e *EscrowFinish, escrowEntry *state.EscrowData, destAccount *state.AccountRoot) tx.Result {
+	rules := ctx.Rules()
+
+	// Expired credentials are removed first and yield tecEXPIRED.
+	if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
+		if removeExpiredCredentials(ctx, e.CredentialIDs) {
+			return tx.TecEXPIRED
+		}
+	}
+
+	if rules.Enabled(amendment.FeatureDepositAuth) {
+		if (destAccount.Flags&state.LsfDepositAuth) != 0 && ctx.AccountID != escrowEntry.DestinationID {
+			// Account-based DepositPreauth.
+			preauthKey := keylet.DepositPreauth(escrowEntry.DestinationID, ctx.AccountID)
+			if exists, _ := ctx.View.Exists(preauthKey); !exists {
+				// Fall back to credential-based preauth.
+				if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
+					if result := authorizedDepositPreauth(ctx, e.CredentialIDs, escrowEntry.DestinationID); result != tx.TesSUCCESS {
+						return result
+					}
+				} else {
+					return tx.TecNO_PERMISSION
+				}
+			}
+		}
+	}
 
 	return tx.TesSUCCESS
 }
@@ -626,10 +713,14 @@ func compareBytesSlice(a, b []byte) int {
 // tx.AdjustOwnerCount which reads/writes through the view.
 func adjustOwnerCount(ctx *tx.ApplyContext, accountID [20]byte, delta int) {
 	if accountID == ctx.AccountID {
-		if delta > 0 {
+		if delta >= 0 {
 			ctx.Account.OwnerCount += uint32(delta)
-		} else if ctx.Account.OwnerCount > 0 {
-			ctx.Account.OwnerCount--
+		} else {
+			dec := uint32(-delta)
+			if ctx.Account.OwnerCount < dec {
+				dec = ctx.Account.OwnerCount
+			}
+			ctx.Account.OwnerCount -= dec
 		}
 		return
 	}

--- a/internal/tx/escrow/escrow_view.go
+++ b/internal/tx/escrow/escrow_view.go
@@ -1,0 +1,41 @@
+package escrow
+
+import (
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/nftoken"
+	"github.com/LeJamon/go-xrpl/internal/wasm/host"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// escrowView adapts an ApplyContext and the escrow being finished to the
+// host.View interface the WASM finish function reads ledger state through.
+type escrowView struct {
+	ctx         *tx.ApplyContext
+	txBytes     []byte // the EscrowFinish transaction, serialized
+	escrowBytes []byte // the escrow ledger object, serialized (the current object)
+}
+
+var _ host.View = (*escrowView)(nil)
+
+func (v *escrowView) LedgerSeq() uint32                 { return v.ctx.Config.LedgerSequence }
+func (v *escrowView) ParentCloseTime() uint32           { return v.ctx.Config.ParentCloseTime }
+func (v *escrowView) ParentHash() [32]byte              { return v.ctx.Config.ParentHash }
+func (v *escrowView) BaseFee() uint32                   { return uint32(v.ctx.Config.BaseFee) }
+func (v *escrowView) AmendmentEnabled(id [32]byte) bool { return v.ctx.Rules().Enabled(id) }
+func (v *escrowView) TxBytes() []byte                   { return v.txBytes }
+func (v *escrowView) CurrentObjBytes() ([]byte, bool)   { return v.escrowBytes, v.escrowBytes != nil }
+
+func (v *escrowView) ReadSLE(index [32]byte) ([]byte, bool) {
+	data, err := v.ctx.View.Read(keylet.Keylet{Key: index})
+	if err != nil || data == nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// FindNFTURI returns the URI of the NFToken held by account, walking its
+// NFTokenPages. found reports whether the token exists; hasURI whether it
+// carries a URI. It backs the get_nft host function a finish function calls.
+func (v *escrowView) FindNFTURI(account [20]byte, nftID [32]byte) (uri []byte, found, hasURI bool) {
+	return nftoken.FindTokenURI(v.ctx.View, account, nftID)
+}

--- a/internal/tx/escrow/smartescrow.go
+++ b/internal/tx/escrow/smartescrow.go
@@ -22,6 +22,14 @@ const escrowFunctionName = "finish"
 // (run after the size checks at create time). In a build without the wasmi
 // engine the module cannot be validated here; the check is skipped and the
 // finish-time execution rejects a malformed module instead.
+//
+// Skipping validation is safe ONLY because FeatureSmartEscrow is registered
+// SupportedNo (amendment/registry.go): a non-wasmi node can neither validate
+// nor execute finish functions, so once the amendment activates it becomes
+// amendment-blocked rather than processing SmartEscrow transactions with a
+// divergent verdict. Flipping SmartEscrow to SupportedYes therefore MUST be
+// gated to wasmi builds — a SupportedYes non-wasmi node would fork against a
+// wasmi node on FinishFunction admissibility.
 // Reference: rippled EscrowCreate.cpp preflightSigValidated lines 237-254
 func validateFinishFunctionWasm(code []byte) tx.Result {
 	engine := wasm.New()
@@ -147,6 +155,19 @@ func runSmartEscrow(ctx *tx.ApplyContext, e *EscrowFinish, escrowData []byte) tx
 		return tx.TecFAILED_PROCESSING
 	}
 	ctx.Log.Debug("escrow finish: wasm ran", "result", res.Result, "cost", res.Cost)
+
+	// Record the gas consumed in the transaction metadata (sfGasUsed, field 73)
+	// before the reject check, so both successful and tecWASM_REJECTED finishes
+	// carry it — matching rippled, which calls setGasUsed before testing the
+	// result. Reference: rippled EscrowFinish.cpp:443-447.
+	if res.Cost < 0 || res.Cost > 0xFFFF_FFFF {
+		return tx.TecINTERNAL
+	}
+	if ctx.Metadata != nil {
+		gasUsed := uint32(res.Cost)
+		ctx.Metadata.GasUsed = &gasUsed
+	}
+
 	if res.Result <= 0 {
 		return tx.TecWASM_REJECTED
 	}

--- a/internal/tx/escrow/smartescrow.go
+++ b/internal/tx/escrow/smartescrow.go
@@ -1,0 +1,168 @@
+package escrow
+
+import (
+	"encoding/hex"
+	"errors"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/wasm"
+	"github.com/LeJamon/go-xrpl/internal/wasm/host"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// escrowFunctionName is the WASM export a SmartEscrow finish function must
+// provide. Reference: rippled WasmVM.h escrowFunctionName.
+const escrowFunctionName = "finish"
+
+// validateFinishFunctionWasm checks that the FinishFunction WASM compiles and
+// exports a finish() -> i32 entry point, mirroring rippled's preflightEscrowWasm
+// (run after the size checks at create time). In a build without the wasmi
+// engine the module cannot be validated here; the check is skipped and the
+// finish-time execution rejects a malformed module instead.
+// Reference: rippled EscrowCreate.cpp preflightSigValidated lines 237-254
+func validateFinishFunctionWasm(code []byte) tx.Result {
+	engine := wasm.New()
+	defer engine.Close()
+	switch err := engine.Check(code, escrowFunctionName); {
+	case err == nil, errors.Is(err, wasm.ErrCGODisabled):
+		return tx.TesSUCCESS
+	default:
+		return tx.TemBAD_WASM
+	}
+}
+
+// maxWasmDataLength bounds the escrow's mutable Data field, matching rippled's
+// Protocol.h (4KB).
+const maxWasmDataLength = 4 * 1024
+
+// microDropsPerDrop converts WASM gas cost (priced in micro-drops) to drops.
+// Reference: rippled Fees.h microDropsPerDrop.
+const microDropsPerDrop = 1_000_000
+
+// escrowFeeSettings reads the FeeSettings ledger entry used by the SmartEscrow
+// fee formulas. It returns nil when the entry is unavailable, in which case
+// callers fall back to EngineConfig / FeeSetup defaults.
+func escrowFeeSettings(view tx.LedgerView) *state.FeeSettings {
+	if view == nil {
+		return nil
+	}
+	data, err := view.Read(keylet.Fees())
+	if err != nil || data == nil {
+		return nil
+	}
+	fs, err := state.ParseFeeSettings(data)
+	if err != nil {
+		return nil
+	}
+	return fs
+}
+
+// vlByteLen returns the decoded byte length of a hex-encoded VL field, matching
+// rippled's tx[sfField].size() (the blob's byte count, not the hex length).
+func vlByteLen(hexStr string) uint64 {
+	if decoded, err := hex.DecodeString(hexStr); err == nil {
+		return uint64(len(decoded))
+	}
+	return uint64(len(hexStr) / 2)
+}
+
+// calculateAdditionalReserve returns the number of owner-reserve slots an escrow
+// consumes: a base of 1, plus 1 for each additional 500 bytes of FinishFunction
+// code beyond the first 500. finishFunctionBytes is the decoded FinishFunction
+// length (0 for a plain escrow with no finish function).
+// Reference: rippled-smart-escrow EscrowHelpers.h:232-239
+func calculateAdditionalReserve(finishFunctionBytes int) uint32 {
+	return 1 + uint32(finishFunctionBytes/500)
+}
+
+// escrowDataReserve returns the owner-reserve slots held by a serialized escrow
+// ledger object, derived from the byte length of its FinishFunction.
+func escrowDataReserve(escrowData []byte) uint32 {
+	bytes := 0
+	if ffHex, ok := escrowFinishFunctionHex(escrowData); ok {
+		bytes = len(ffHex) / 2
+	}
+	return calculateAdditionalReserve(bytes)
+}
+
+// smartEscrowFinishPreclaim validates the FinishFunction/ComputationAllowance
+// pairing for an EscrowFinish. It runs in the preclaim portion of Apply, before
+// the doApply-stage condition and WASM checks, so a field mismatch is reported
+// even when the fulfillment is also wrong. escrowData is the serialized escrow
+// ledger object being finished.
+// Reference: rippled EscrowFinish.cpp preclaim lines 260-278
+func smartEscrowFinishPreclaim(ctx *tx.ApplyContext, e *EscrowFinish, escrowData []byte) tx.Result {
+	if !ctx.Rules().Enabled(amendment.FeatureSmartEscrow) {
+		return tx.TesSUCCESS
+	}
+	_, hasFF := escrowFinishFunctionHex(escrowData)
+	hasCA := e.ComputationAllowance != nil
+	switch {
+	case hasFF && !hasCA:
+		return tx.TefWASM_FIELD_NOT_INCLUDED
+	case !hasFF && hasCA:
+		return tx.TefNO_WASM
+	}
+	return tx.TesSUCCESS
+}
+
+// runSmartEscrow executes the escrow's FinishFunction, mirroring the WASM block
+// of rippled's EscrowFinish::doApply. It assumes smartEscrowFinishPreclaim has
+// already validated field presence. It returns TesSUCCESS when SmartEscrow is
+// disabled or the escrow has no finish function, tecWASM_REJECTED when the
+// function returns a non-positive result, or a tec/tef on execution failure.
+//
+// The engine is reached through internal/wasm, a stub unless built with
+// -tags wasmi; in a stub build engine.Run reports ErrCGODisabled, mapped here
+// to tecFAILED_PROCESSING (only reachable once SmartEscrow is enabled).
+// Reference: rippled EscrowFinish.cpp doApply lines 406-457
+func runSmartEscrow(ctx *tx.ApplyContext, e *EscrowFinish, escrowData []byte) tx.Result {
+	if !ctx.Rules().Enabled(amendment.FeatureSmartEscrow) {
+		return tx.TesSUCCESS
+	}
+	ffHex, hasFF := escrowFinishFunctionHex(escrowData)
+	if !hasFF {
+		return tx.TesSUCCESS
+	}
+	if e.ComputationAllowance == nil {
+		// Already validated in smartEscrowFinishPreclaim; defensive, matching
+		// rippled's "just in case" tecINTERNAL.
+		return tx.TecINTERNAL
+	}
+
+	wasmBytes, err := hex.DecodeString(ffHex)
+	if err != nil {
+		return tx.TefINTERNAL
+	}
+
+	view := &escrowView{ctx: ctx, txBytes: e.GetRawBytes(), escrowBytes: escrowData}
+	engine := wasm.New()
+	defer engine.Close()
+	res, runErr := engine.Run(wasmBytes, "finish", nil, host.New(view), int64(*e.ComputationAllowance))
+	if runErr != nil {
+		ctx.Log.Debug("escrow finish: wasm execution failed", "error", runErr)
+		return tx.TecFAILED_PROCESSING
+	}
+	ctx.Log.Debug("escrow finish: wasm ran", "result", res.Result, "cost", res.Cost)
+	if res.Result <= 0 {
+		return tx.TecWASM_REJECTED
+	}
+	return tx.TesSUCCESS
+}
+
+// escrowFinishFunctionHex extracts the FinishFunction (hex string) from a
+// serialized escrow ledger object.
+func escrowFinishFunctionHex(escrowData []byte) (string, bool) {
+	m, err := binarycodec.DecodeBytes(escrowData)
+	if err != nil {
+		return "", false
+	}
+	ff, ok := m["FinishFunction"].(string)
+	if !ok || ff == "" {
+		return "", false
+	}
+	return ff, true
+}

--- a/internal/tx/escrow/smartescrow_fee_test.go
+++ b/internal/tx/escrow/smartescrow_fee_test.go
@@ -1,0 +1,88 @@
+package escrow
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// A trivial finish function: (module (func (export "finish") (result i32) (i32.const 1))).
+const feeTestFinishFn = "0061736d010000000105016000017f03020100070a010666696e69736800000a0601040041010b"
+
+// TestEscrowCreateBaseFee_FinishFunctionSurcharge verifies the SmartEscrow
+// FinishFunction surcharge: base*(1+signers) + 9*base + 5*size.
+// Reference: rippled EscrowCreate.cpp calculateBaseFee lines 120-131.
+func TestEscrowCreateBaseFee_FinishFunctionSurcharge(t *testing.T) {
+	const base = uint64(10)
+	cfg := tx.EngineConfig{BaseFee: base}
+
+	ffBytes, err := hex.DecodeString(feeTestFinishFn)
+	if err != nil {
+		t.Fatalf("decode finish fn: %v", err)
+	}
+	ff := feeTestFinishFn
+
+	withFF := &EscrowCreate{
+		BaseTx:         *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
+		Amount:         tx.NewXRPAmount(1000000000),
+		Destination:    "rBob",
+		CancelAfter:    ptrUint32(700000000),
+		FinishFunction: &ff,
+	}
+	want := base + 9*base + 5*uint64(len(ffBytes))
+	if got := withFF.CalculateBaseFee(nil, cfg); got != want {
+		t.Fatalf("with FinishFunction: got %d, want %d", got, want)
+	}
+
+	// Without a FinishFunction the surcharge is absent (plain base fee).
+	plain := &EscrowCreate{
+		BaseTx:      *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
+		Amount:      tx.NewXRPAmount(1000000000),
+		Destination: "rBob",
+		FinishAfter: ptrUint32(700000000),
+	}
+	if got := plain.CalculateBaseFee(nil, cfg); got != base {
+		t.Fatalf("without FinishFunction: got %d, want %d", got, base)
+	}
+}
+
+// TestEscrowFinishBaseFee_ComputationAllowance verifies the SmartEscrow finish
+// fee: base + (allowance*gasPrice/microDropsPerDrop) + 1, using the default gas
+// price (1,000,000 micro-drops). Reference: rippled EscrowFinish.cpp lines
+// 167-174.
+func TestEscrowFinishBaseFee_ComputationAllowance(t *testing.T) {
+	const base = uint64(10)
+	cfg := tx.EngineConfig{BaseFee: base}
+
+	cases := []struct {
+		allowance uint32
+		want      uint64
+	}{
+		{allowance: 1_000_000, want: base + 1_000_001}, // 1e6*1e6/1e6 + 1
+		{allowance: 2, want: base + 3},                 // 2*1e6/1e6 + 1
+		{allowance: 0, want: base + 1},                 // 0 + 1 (round-up term)
+	}
+	for _, c := range cases {
+		a := c.allowance
+		ef := &EscrowFinish{
+			BaseTx:               *tx.NewBaseTx(tx.TypeEscrowFinish, "rBob"),
+			Owner:                "rAlice",
+			OfferSequence:        5,
+			ComputationAllowance: &a,
+		}
+		if got := ef.CalculateBaseFee(nil, cfg); got != c.want {
+			t.Fatalf("allowance=%d: got %d, want %d", c.allowance, got, c.want)
+		}
+	}
+
+	// Without a ComputationAllowance the finish pays only the base fee.
+	plain := &EscrowFinish{
+		BaseTx:        *tx.NewBaseTx(tx.TypeEscrowFinish, "rBob"),
+		Owner:         "rAlice",
+		OfferSequence: 5,
+	}
+	if got := plain.CalculateBaseFee(nil, cfg); got != base {
+		t.Fatalf("without ComputationAllowance: got %d, want %d", got, base)
+	}
+}

--- a/internal/tx/escrow/smartescrow_validation_test.go
+++ b/internal/tx/escrow/smartescrow_validation_test.go
@@ -1,0 +1,91 @@
+package escrow
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// feeOnlyView is a minimal LedgerView that serves one FeeSettings entry (for
+// keylet.Fees()) and is empty otherwise — enough to drive the Preclaim
+// extension-limit bounds against custom voted values without a full ledger.
+type feeOnlyView struct{ feeData []byte }
+
+func (v *feeOnlyView) Read(k keylet.Keylet) ([]byte, error) {
+	if k.Key == keylet.Fees().Key {
+		return v.feeData, nil
+	}
+	return nil, nil
+}
+func (v *feeOnlyView) Exists(keylet.Keylet) (bool, error)                 { return false, nil }
+func (v *feeOnlyView) Insert(keylet.Keylet, []byte) error                 { return nil }
+func (v *feeOnlyView) Update(keylet.Keylet, []byte) error                 { return nil }
+func (v *feeOnlyView) Erase(keylet.Keylet) error                          { return nil }
+func (v *feeOnlyView) AdjustDropsDestroyed(drops.XRPAmount)               {}
+func (v *feeOnlyView) ForEach(func(key [32]byte, data []byte) bool) error { return nil }
+func (v *feeOnlyView) Succ([32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+func (v *feeOnlyView) TxExists([32]byte) bool  { return false }
+func (v *feeOnlyView) Rules() *amendment.Rules { return nil }
+func (v *feeOnlyView) LedgerSeq() uint32       { return 0 }
+
+func feeViewWith(t *testing.T, fs *state.FeeSettings) *feeOnlyView {
+	t.Helper()
+	data, err := state.SerializeFeeSettings(fs)
+	if err != nil {
+		t.Fatalf("serialize fee settings: %v", err)
+	}
+	return &feeOnlyView{feeData: data}
+}
+
+func smartEscrowRules() *amendment.Rules {
+	return amendment.NewRulesBuilder().
+		Enable(amendment.FeatureSmartEscrow).
+		Enable(amendment.FeatureFix1571).
+		Build()
+}
+
+func finishFnEscrow(ff string) *EscrowCreate {
+	code := ff
+	return &EscrowCreate{
+		BaseTx:         *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
+		Amount:         tx.NewXRPAmount(1000000000),
+		Destination:    "rBob",
+		CancelAfter:    ptrUint32(700000000),
+		FinishFunction: &code,
+	}
+}
+
+// TestEscrowCreatePreclaim_FinishFunctionTooLarge: a FinishFunction larger than
+// the voted extension size limit is temMALFORMED.
+// Reference: rippled EscrowCreate.cpp preflight lines 222-228.
+func TestEscrowCreatePreclaim_FinishFunctionTooLarge(t *testing.T) {
+	view := feeViewWith(t, &state.FeeSettings{
+		XRPFeesMode: true, BaseFeeDrops: 10,
+		HasExtensionFees: true, ExtensionComputeLimit: 1_000_000, ExtensionSizeLimit: 10, GasPrice: 1_000_000,
+	})
+	cfg := tx.EngineConfig{BaseFee: 10, Rules: smartEscrowRules()}
+	// feeTestFinishFn is 39 bytes, over the 10-byte limit.
+	if got := finishFnEscrow(feeTestFinishFn).Preclaim(view, cfg); got != tx.TemMALFORMED {
+		t.Fatalf("got %v, want temMALFORMED", got)
+	}
+}
+
+// TestEscrowCreatePreclaim_RuntimeDisabled: a zero extension limit (WASM disabled
+// by fee voting) makes a FinishFunction create temTEMP_DISABLED.
+// Reference: rippled EscrowCreate.cpp preflight lines 216-220.
+func TestEscrowCreatePreclaim_RuntimeDisabled(t *testing.T) {
+	view := feeViewWith(t, &state.FeeSettings{
+		XRPFeesMode: true, BaseFeeDrops: 10,
+		HasExtensionFees: true, ExtensionComputeLimit: 0, ExtensionSizeLimit: 100_000, GasPrice: 1_000_000,
+	})
+	cfg := tx.EngineConfig{BaseFee: 10, Rules: smartEscrowRules()}
+	if got := finishFnEscrow(feeTestFinishFn).Preclaim(view, cfg); got != tx.TemTEMP_DISABLED {
+		t.Fatalf("got %v, want temTEMP_DISABLED", got)
+	}
+}

--- a/internal/tx/ledgerfields/escrow_gen.go
+++ b/internal/tx/ledgerfields/escrow_gen.go
@@ -28,6 +28,8 @@ type Escrow struct {
 	Condition         string // Blob (uppercase hex)
 	CancelAfter       uint32
 	FinishAfter       uint32
+	FinishFunction    string // Blob (uppercase hex)
+	Data              string // Blob (uppercase hex)
 	SourceTag         uint32
 	DestinationTag    uint32
 	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
@@ -46,6 +48,8 @@ const (
 	escrowBitCondition
 	escrowBitCancelAfter
 	escrowBitFinishAfter
+	escrowBitFinishFunction
+	escrowBitData
 	escrowBitSourceTag
 	escrowBitDestinationTag
 	escrowBitOwnerNode
@@ -169,6 +173,12 @@ func (e *Escrow) Decode(data []byte) error {
 			case 17:
 				e.Condition = val
 				e.present |= escrowBitCondition
+			case 27:
+				e.Data = val
+				e.present |= escrowBitData
+			case 32:
+				e.FinishFunction = val
+				e.present |= escrowBitFinishFunction
 			default:
 				return newErrUnknownField("Escrow", typeCode, fieldCode)
 			}
@@ -215,6 +225,12 @@ func (e *Escrow) emitAll(out map[string]any, skipDefault bool) {
 	}
 	if e.present&escrowBitFinishAfter != 0 && !(skipDefault && e.FinishAfter == 0) {
 		out["FinishAfter"] = e.FinishAfter
+	}
+	if e.present&escrowBitFinishFunction != 0 && !(skipDefault && e.FinishFunction == "") {
+		out["FinishFunction"] = e.FinishFunction
+	}
+	if e.present&escrowBitData != 0 && !(skipDefault && e.Data == "") {
+		out["Data"] = e.Data
 	}
 	if e.present&escrowBitSourceTag != 0 && !(skipDefault && e.SourceTag == 0) {
 		out["SourceTag"] = e.SourceTag
@@ -264,6 +280,8 @@ func (e *Escrow) EmitPreviousFields(prev Entry, out map[string]any) {
 	emitIfChangedString(out, "Condition", p.Condition, e.Condition, p.present&escrowBitCondition, e.present&escrowBitCondition)
 	emitIfChangedUint32(out, "CancelAfter", p.CancelAfter, e.CancelAfter, p.present&escrowBitCancelAfter, e.present&escrowBitCancelAfter)
 	emitIfChangedUint32(out, "FinishAfter", p.FinishAfter, e.FinishAfter, p.present&escrowBitFinishAfter, e.present&escrowBitFinishAfter)
+	emitIfChangedString(out, "FinishFunction", p.FinishFunction, e.FinishFunction, p.present&escrowBitFinishFunction, e.present&escrowBitFinishFunction)
+	emitIfChangedString(out, "Data", p.Data, e.Data, p.present&escrowBitData, e.present&escrowBitData)
 	emitIfChangedUint32(out, "SourceTag", p.SourceTag, e.SourceTag, p.present&escrowBitSourceTag, e.present&escrowBitSourceTag)
 	emitIfChangedUint32(out, "DestinationTag", p.DestinationTag, e.DestinationTag, p.present&escrowBitDestinationTag, e.present&escrowBitDestinationTag)
 	emitIfChangedString(out, "OwnerNode", p.OwnerNode, e.OwnerNode, p.present&escrowBitOwnerNode, e.present&escrowBitOwnerNode)
@@ -296,6 +314,12 @@ func (e *Escrow) EmitChangeOrigFields(out map[string]any) {
 	}
 	if e.present&escrowBitFinishAfter != 0 {
 		out["FinishAfter"] = e.FinishAfter
+	}
+	if e.present&escrowBitFinishFunction != 0 {
+		out["FinishFunction"] = e.FinishFunction
+	}
+	if e.present&escrowBitData != 0 {
+		out["Data"] = e.Data
 	}
 	if e.present&escrowBitSourceTag != 0 {
 		out["SourceTag"] = e.SourceTag
@@ -376,6 +400,12 @@ func (e *Escrow) ToMap() map[string]any {
 	}
 	if e.present&escrowBitFinishAfter != 0 {
 		out["FinishAfter"] = e.FinishAfter
+	}
+	if e.present&escrowBitFinishFunction != 0 {
+		out["FinishFunction"] = e.FinishFunction
+	}
+	if e.present&escrowBitData != 0 {
+		out["Data"] = e.Data
 	}
 	if e.present&escrowBitSourceTag != 0 {
 		out["SourceTag"] = e.SourceTag

--- a/internal/tx/ledgerfields/spec/spec.go
+++ b/internal/tx/ledgerfields/spec/spec.go
@@ -342,6 +342,8 @@ var Specs = []Entry{
 			{Name: "Condition"},
 			{Name: "CancelAfter"},
 			{Name: "FinishAfter"},
+			{Name: "FinishFunction"},
+			{Name: "Data"},
 			{Name: "SourceTag"},
 			{Name: "DestinationTag"},
 			{Name: "OwnerNode"},

--- a/internal/tx/metadata.go
+++ b/internal/tx/metadata.go
@@ -41,6 +41,11 @@ type Metadata struct {
 	// DeliveredAmount is the actual amount delivered (for partial payments)
 	DeliveredAmount *Amount
 
+	// GasUsed is the WASM gas consumed by a SmartEscrow FinishFunction, recorded
+	// in the metadata for both successful and tecWASM_REJECTED finishes.
+	// Reference: rippled EscrowFinish.cpp setGasUsed → TxMeta sfGasUsed (field 73).
+	GasUsed *uint32
+
 	// ParentBatchID is the hash of the parent batch transaction.
 	// Set only for inner transactions within a batch.
 	// Reference: rippled TxMeta.h mParentBatchId
@@ -83,6 +88,11 @@ func (m Metadata) MarshalJSON() ([]byte, error) {
 	// Use "unavailable" for legacy compatibility when not explicitly set
 	if m.DeliveredAmount != nil {
 		output["delivered_amount"] = m.DeliveredAmount
+	}
+
+	// GasUsed (SmartEscrow FinishFunction gas), when present.
+	if m.GasUsed != nil {
+		output["GasUsed"] = *m.GasUsed
 	}
 
 	// ParentBatchID for inner batch transactions

--- a/internal/tx/metadata_gasused_test.go
+++ b/internal/tx/metadata_gasused_test.go
@@ -1,0 +1,57 @@
+package tx
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+)
+
+// TestSerializeMetadata_WASMRejectedWithGasUsed pins the SmartEscrow metadata
+// path end to end: a tecWASM_REJECTED result (an applied tec, so its metadata
+// must serialize) round-trips through the binary codec, and a GasUsed field
+// (sfGasUsed, field 73) is carried alongside it.
+func TestSerializeMetadata_WASMRejectedWithGasUsed(t *testing.T) {
+	gas := uint32(1137)
+	meta := &Metadata{
+		TransactionResult: TecWASM_REJECTED,
+		TransactionIndex:  2,
+		GasUsed:           &gas,
+	}
+
+	blob, err := SerializeMetadata(meta)
+	if err != nil {
+		t.Fatalf("SerializeMetadata(tecWASM_REJECTED + GasUsed): %v", err)
+	}
+	if len(blob) == 0 {
+		t.Fatal("empty metadata blob")
+	}
+
+	decoded, err := binarycodec.DecodeBytes(blob)
+	if err != nil {
+		t.Fatalf("decode metadata blob: %v", err)
+	}
+	if got, ok := decoded["TransactionResult"].(string); !ok || got != "tecWASM_REJECTED" {
+		t.Errorf("TransactionResult = %v (%T), want %q", decoded["TransactionResult"], decoded["TransactionResult"], "tecWASM_REJECTED")
+	}
+	if got, ok := decoded["GasUsed"].(uint32); !ok || got != gas {
+		t.Errorf("GasUsed = %v (%T), want uint32 %d", decoded["GasUsed"], decoded["GasUsed"], gas)
+	}
+}
+
+// TestSerializeMetadata_NoGasUsedWhenAbsent confirms GasUsed is omitted from the
+// metadata when no FinishFunction ran, so non-SmartEscrow metadata is unchanged.
+func TestSerializeMetadata_NoGasUsedWhenAbsent(t *testing.T) {
+	meta := &Metadata{TransactionResult: TesSUCCESS, TransactionIndex: 0}
+
+	blob, err := SerializeMetadata(meta)
+	if err != nil {
+		t.Fatalf("SerializeMetadata: %v", err)
+	}
+	decoded, err := binarycodec.DecodeBytes(blob)
+	if err != nil {
+		t.Fatalf("decode metadata blob: %v", err)
+	}
+	if _, present := decoded["GasUsed"]; present {
+		t.Error("GasUsed should be absent when no FinishFunction ran")
+	}
+}

--- a/internal/tx/nftoken/nftoken_page.go
+++ b/internal/tx/nftoken/nftoken_page.go
@@ -2,6 +2,7 @@ package nftoken
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -77,6 +78,28 @@ func findToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte) (keylet.Key
 	}
 
 	return keylet.Keylet{}, nil, -1, false
+}
+
+// FindTokenURI returns the raw (decoded) URI of the NFToken identified by
+// tokenID and held by owner, walking the owner's NFTokenPages. found reports
+// whether the token exists; hasURI whether it carries a URI (uri holds the
+// decoded URI when hasURI). This backs the SmartEscrow get_nft host function,
+// which distinguishes a missing token from a token with no URI.
+// Reference: rippled nft::findToken + WasmHostFunctionsImpl::getNFT (sfURI).
+func FindTokenURI(view tx.LedgerView, owner [20]byte, tokenID [32]byte) (uri []byte, found, hasURI bool) {
+	_, page, idx, ok := findToken(view, owner, tokenID)
+	if !ok {
+		return nil, false, false
+	}
+	uriHex := page.NFTokens[idx].URI
+	if uriHex == "" {
+		return nil, true, false
+	}
+	raw, err := hex.DecodeString(uriHex)
+	if err != nil {
+		return nil, true, false
+	}
+	return raw, true, true
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tx/preclaim.go
+++ b/internal/tx/preclaim.go
@@ -312,17 +312,17 @@ func (e *Engine) checkPermission(tx Transaction, common *Common, accountID [20]b
 	delegateKeylet := keylet.DelegateKeylet(accountID, delegateID)
 	delegateData, readErr := e.view.Read(delegateKeylet)
 	if readErr != nil || delegateData == nil {
-		return TecNO_DELEGATE_PERMISSION
+		return TerNO_DELEGATE_PERMISSION
 	}
 	delegateEntry, parseErr := state.ParseDelegate(delegateData)
 	if parseErr != nil {
-		return TecNO_DELEGATE_PERMISSION
+		return TerNO_DELEGATE_PERMISSION
 	}
 	// Check if the delegate SLE grants permission for this tx type.
 	// In rippled: permissionValue == tx.getTxnType() + 1
 	txTypeValue := uint32(tx.TxType())
 	if !delegateEntry.HasTxPermission(txTypeValue) {
-		return TecNO_DELEGATE_PERMISSION
+		return TerNO_DELEGATE_PERMISSION
 	}
 	return TesSUCCESS
 }

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -48,6 +48,13 @@ type SetFee struct {
 	// ReserveIncrementDrops is the owner reserve increment in drops
 	ReserveIncrementDrops string `json:"ReserveIncrementDrops,omitempty" xrpl:"ReserveIncrementDrops,omitempty"`
 
+	// SmartEscrow / WASM extension fees (featureSmartEscrow). Required together
+	// once the amendment is active, forbidden otherwise.
+	// Reference: rippled Change.cpp preclaim:126-139, applyFee:301-305.
+	ExtensionComputeLimit *uint32 `json:"ExtensionComputeLimit,omitempty" xrpl:"ExtensionComputeLimit,omitempty"`
+	ExtensionSizeLimit    *uint32 `json:"ExtensionSizeLimit,omitempty" xrpl:"ExtensionSizeLimit,omitempty"`
+	GasPrice              *uint32 `json:"GasPrice,omitempty" xrpl:"GasPrice,omitempty"`
+
 	// LedgerSequence is the ledger sequence for this fee change
 	LedgerSequence *uint32 `json:"LedgerSequence,omitempty" xrpl:"LedgerSequence,omitempty"`
 
@@ -105,6 +112,16 @@ func (s *SetFee) PreclaimPseudo(rules *amendment.Rules) tx.Result {
 		if s.hasModernFields() {
 			return tx.TemDISABLED
 		}
+	}
+
+	// SmartEscrow extension fees: required as a triple once the amendment is
+	// active, forbidden otherwise. Reference: rippled Change.cpp:126-139.
+	if rules != nil && rules.Enabled(amendment.FeatureSmartEscrow) {
+		if s.ExtensionComputeLimit == nil || s.ExtensionSizeLimit == nil || s.GasPrice == nil {
+			return tx.TemMALFORMED
+		}
+	} else if s.ExtensionComputeLimit != nil || s.ExtensionSizeLimit != nil || s.GasPrice != nil {
+		return tx.TemDISABLED
 	}
 
 	if _, err := s.parsedOrError(); err != nil {
@@ -262,6 +279,22 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 		feeSettings.BaseFeeDrops = 0
 		feeSettings.ReserveBaseDrops = 0
 		feeSettings.ReserveIncrementDrops = 0
+	}
+
+	// SmartEscrow extension fees: persist them while the amendment is active,
+	// mirroring rippled's applyFee set() calls. PreclaimPseudo guarantees the
+	// triple is present in that case. Reference: rippled Change.cpp:301-305.
+	if ctx.Config.Rules != nil && ctx.Config.Rules.Enabled(amendment.FeatureSmartEscrow) {
+		if s.ExtensionComputeLimit != nil {
+			feeSettings.ExtensionComputeLimit = *s.ExtensionComputeLimit
+		}
+		if s.ExtensionSizeLimit != nil {
+			feeSettings.ExtensionSizeLimit = *s.ExtensionSizeLimit
+		}
+		if s.GasPrice != nil {
+			feeSettings.GasPrice = *s.GasPrice
+		}
+		feeSettings.HasExtensionFees = true
 	}
 
 	data, err := state.SerializeFeeSettings(feeSettings)

--- a/internal/tx/pseudo/setfee_smartescrow_test.go
+++ b/internal/tx/pseudo/setfee_smartescrow_test.go
@@ -1,0 +1,59 @@
+package pseudo
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+func feeU32(v uint32) *uint32 { return &v }
+
+// legacySetFee builds a well-formed legacy (pre-XRPFees) SetFee so PreclaimPseudo
+// reaches the SmartEscrow extension-fee gate.
+func legacySetFee() *SetFee {
+	s := NewSetFee()
+	s.BaseFee = "a" // 10 drops, hex
+	s.ReferenceFeeUnits = feeU32(10)
+	s.ReserveBase = feeU32(200000)
+	s.ReserveIncrement = feeU32(50000)
+	return s
+}
+
+// TestSetFeePreclaim_SmartEscrowExtensionFees pins the SmartEscrow extension-fee
+// field-set rule: the triple is required together once the amendment is active,
+// and forbidden otherwise. Reference: rippled Change.cpp preclaim:126-139.
+func TestSetFeePreclaim_SmartEscrowExtensionFees(t *testing.T) {
+	withSE := amendment.NewRulesBuilder().Enable(amendment.FeatureSmartEscrow).Build()
+	withoutSE := amendment.NewRulesBuilder().Build()
+
+	// SmartEscrow active + full extension triple → success.
+	full := legacySetFee()
+	full.ExtensionComputeLimit = feeU32(1_000_000)
+	full.ExtensionSizeLimit = feeU32(100_000)
+	full.GasPrice = feeU32(1_000_000)
+	if got := full.PreclaimPseudo(withSE); got != tx.TesSUCCESS {
+		t.Errorf("full triple under SmartEscrow: got %v, want tesSUCCESS", got)
+	}
+
+	// SmartEscrow active + a missing field → temMALFORMED.
+	missing := legacySetFee()
+	missing.ExtensionComputeLimit = feeU32(1_000_000)
+	missing.ExtensionSizeLimit = feeU32(100_000) // GasPrice omitted
+	if got := missing.PreclaimPseudo(withSE); got != tx.TemMALFORMED {
+		t.Errorf("missing GasPrice under SmartEscrow: got %v, want temMALFORMED", got)
+	}
+
+	// SmartEscrow inactive + an extension field present → temDISABLED.
+	present := legacySetFee()
+	present.GasPrice = feeU32(1_000_000)
+	if got := present.PreclaimPseudo(withoutSE); got != tx.TemDISABLED {
+		t.Errorf("extension field without SmartEscrow: got %v, want temDISABLED", got)
+	}
+
+	// SmartEscrow inactive + no extension fields → success (plain legacy SetFee).
+	plain := legacySetFee()
+	if got := plain.PreclaimPseudo(withoutSE); got != tx.TesSUCCESS {
+		t.Errorf("plain legacy SetFee without SmartEscrow: got %v, want tesSUCCESS", got)
+	}
+}

--- a/internal/tx/result.go
+++ b/internal/tx/result.go
@@ -130,7 +130,11 @@ const (
 	TecLIMIT_EXCEEDED                     Result = 195
 	TecPSEUDO_ACCOUNT                     Result = 196
 	TecPRECISION_LOSS                     Result = 197
-	TecNO_DELEGATE_PERMISSION             Result = 198
+	// TecWASM_REJECTED: a contract's WASM finish function rejected the
+	// transaction. PermissionDelegation was deferred on mainnet, freeing tec 198,
+	// so NO_DELEGATE_PERMISSION is a ter (see TerNO_DELEGATE_PERMISSION) and
+	// WASM_REJECTED takes 198 — matching rippled's smart-escrow TER.h.
+	TecWASM_REJECTED Result = 198
 
 	// tefFAILURE and related codes (-199 to -100)
 	// Transaction failed, fee claimed but tx not applied
@@ -156,6 +160,12 @@ const (
 	TefNO_TICKET                   Result = -180
 	TefNFTOKEN_IS_NOT_TRANSFERABLE Result = -179
 	TefINVALID_LEDGER_FIX_TYPE     Result = -178
+	// SmartEscrow field-mismatch rejects (fee claimed): a WASM-specific field
+	// was present without finish-function code, or vice versa. Values match
+	// rippled's smart-escrow TER.h (auto-numbered after
+	// tefINVALID_LEDGER_FIX_TYPE=-178).
+	TefNO_WASM                 Result = -177
+	TefWASM_FIELD_NOT_INCLUDED Result = -176
 
 	// telLOCAL_ERROR and related codes (-399 to -300)
 	// Local error, transaction not sent to network
@@ -228,6 +238,10 @@ const (
 	TemARRAY_TOO_LARGE                             Result = -252
 	TemBAD_TRANSFER_FEE                            Result = -251
 	TemINVALID_INNER_BATCH                         Result = -250
+	// SmartEscrow validation. Values match rippled's smart-escrow TER.h; -249
+	// (temBAD_MPT) is reserved there and left as a gap here.
+	TemBAD_WASM      Result = -248
+	TemTEMP_DISABLED Result = -247
 
 	// terRETRY and related codes (-99 to -1)
 	// Retry later
@@ -245,6 +259,11 @@ const (
 	TerPRE_TICKET        Result = -88
 	TerNO_AMM            Result = -87
 	TerADDRESS_COLLISION Result = -86
+	// TerNO_DELEGATE_PERMISSION: a delegated transaction lacks the required
+	// permission. PermissionDelegation was deferred on mainnet and rippled's
+	// smart-escrow branch carries this as a ter (not a tec), freeing tec 198 for
+	// TecWASM_REJECTED. Reference: rippled-smart-escrow TER.h terNO_DELEGATE_PERMISSION.
+	TerNO_DELEGATE_PERMISSION Result = -85
 )
 
 // resultNames maps every Result code to its canonical rippled string.
@@ -338,7 +357,7 @@ var resultNames = map[Result]string{
 	TecLIMIT_EXCEEDED:                     "tecLIMIT_EXCEEDED",
 	TecPSEUDO_ACCOUNT:                     "tecPSEUDO_ACCOUNT",
 	TecPRECISION_LOSS:                     "tecPRECISION_LOSS",
-	TecNO_DELEGATE_PERMISSION:             "tecNO_DELEGATE_PERMISSION",
+	TecWASM_REJECTED:                      "tecWASM_REJECTED",
 	TefFAILURE:                            "tefFAILURE",
 	TefALREADY:                            "tefALREADY",
 	TefBAD_ADD_AUTH:                       "tefBAD_ADD_AUTH",
@@ -361,6 +380,8 @@ var resultNames = map[Result]string{
 	TefNO_TICKET:                          "tefNO_TICKET",
 	TefNFTOKEN_IS_NOT_TRANSFERABLE:        "tefNFTOKEN_IS_NOT_TRANSFERABLE",
 	TefINVALID_LEDGER_FIX_TYPE:            "tefINVALID_LEDGER_FIX_TYPE",
+	TefNO_WASM:                            "tefNO_WASM",
+	TefWASM_FIELD_NOT_INCLUDED:            "tefWASM_FIELD_NOT_INCLUDED",
 	TelLOCAL_ERROR:                        "telLOCAL_ERROR",
 	TelBAD_DOMAIN:                         "telBAD_DOMAIN",
 	TelBAD_PATH_COUNT:                     "telBAD_PATH_COUNT",
@@ -427,6 +448,8 @@ var resultNames = map[Result]string{
 	TemARRAY_TOO_LARGE:                             "temARRAY_TOO_LARGE",
 	TemBAD_TRANSFER_FEE:                            "temBAD_TRANSFER_FEE",
 	TemINVALID_INNER_BATCH:                         "temINVALID_INNER_BATCH",
+	TemBAD_WASM:                                    "temBAD_WASM",
+	TemTEMP_DISABLED:                               "temTEMP_DISABLED",
 	TerRETRY:                                       "terRETRY",
 	TerFUNDS_SPENT:                                 "terFUNDS_SPENT",
 	TerINSUF_FEE_B:                                 "terINSUF_FEE_B",
@@ -441,6 +464,7 @@ var resultNames = map[Result]string{
 	TerPRE_TICKET:                                  "terPRE_TICKET",
 	TerNO_AMM:                                      "terNO_AMM",
 	TerADDRESS_COLLISION:                           "terADDRESS_COLLISION",
+	TerNO_DELEGATE_PERMISSION:                      "terNO_DELEGATE_PERMISSION",
 }
 
 // String returns the canonical rippled name for this result code.

--- a/internal/tx/serialize.go
+++ b/internal/tx/serialize.go
@@ -135,6 +135,11 @@ func MetadataToMap(meta *Metadata) map[string]any {
 		}
 	}
 
+	// GasUsed (sfGasUsed, field 73) — SmartEscrow FinishFunction gas.
+	if meta.GasUsed != nil {
+		result["GasUsed"] = *meta.GasUsed
+	}
+
 	return result
 }
 

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -170,6 +170,34 @@ static wasm_trap_t* make_trap(wasm_store_t* store, const char* msg) {
     wasm_byte_vec_delete(&m);
     return t;
 }
+
+// check_export_func verifies the module exports a function named fname with the
+// signature () -> i32 (the escrow finish-function shape), inspecting export
+// types only — no instantiation, mirroring rippled's preflightEscrowWasm.
+// Returns 1 on match, 0 otherwise.
+static int check_export_func(const wasm_module_t* module, const char* fname) {
+    wasm_exporttype_vec_t exporttypes;
+    wasm_module_exports(module, &exporttypes);
+    int ok = 0;
+    size_t flen = strlen(fname);
+    for (size_t i = 0; i < exporttypes.size; ++i) {
+        const wasm_name_t* n = wasm_exporttype_name(exporttypes.data[i]);
+        if (n->size != flen || memcmp(n->data, fname, flen) != 0) continue;
+        const wasm_externtype_t* et = wasm_exporttype_type(exporttypes.data[i]);
+        const wasm_functype_t* ft = wasm_externtype_as_functype_const(et);
+        if (ft) {
+            const wasm_valtype_vec_t* params = wasm_functype_params(ft);
+            const wasm_valtype_vec_t* results = wasm_functype_results(ft);
+            if (params->size == 0 && results->size == 1 &&
+                wasm_valtype_kind(results->data[0]) == WASM_I32) {
+                ok = 1;
+            }
+        }
+        break;
+    }
+    wasm_exporttype_vec_delete(&exporttypes);
+    return ok;
+}
 */
 import "C"
 
@@ -282,6 +310,32 @@ func (e *Engine) Run(code []byte, funcName string, params []Param, hf HostFuncti
 	cost := int64(uint64(initialFuel) - uint64(remaining))
 
 	return Result{Result: result, Cost: cost}, nil
+}
+
+// Check validates that code compiles to a well-formed module exporting funcName
+// with the escrow finish signature () -> i32, without executing it. It mirrors
+// rippled's preflightEscrowWasm (WasmEngine::check), which compiles the module
+// and verifies the entry function rather than instantiating it. It returns
+// ErrInvalidWasm for a malformed module or a missing/mistyped entry function.
+func (e *Engine) Check(code []byte, funcName string) error {
+	store := C.wasm_store_new_with_memory_max_pages(e.engine, C.uint32_t(maxPages))
+	if store == nil {
+		return ErrExecution
+	}
+	defer C.wasm_store_delete(store)
+
+	module := compileModule(store, code)
+	if module == nil {
+		return ErrInvalidWasm
+	}
+	defer C.wasm_module_delete(module)
+
+	cname := C.CString(funcName)
+	defer C.free(unsafe.Pointer(cname))
+	if C.check_export_func(module, cname) == 0 {
+		return ErrInvalidWasm
+	}
+	return nil
 }
 
 func compileModule(store *C.wasm_store_t, code []byte) *C.wasm_module_t {

--- a/internal/wasm/engine_stub.go
+++ b/internal/wasm/engine_stub.go
@@ -19,3 +19,9 @@ func (e *Engine) Close() {}
 func (e *Engine) Run(code []byte, funcName string, params []Param, hf HostFunctions, gasLimit int64) (Result, error) {
 	return Result{}, ErrCGODisabled
 }
+
+// Check always reports ErrCGODisabled without cgo; callers treat this as "WASM
+// validation unavailable in this build" rather than a validation failure.
+func (e *Engine) Check(code []byte, funcName string) error {
+	return ErrCGODisabled
+}

--- a/internal/wasm/engine_test.go
+++ b/internal/wasm/engine_test.go
@@ -36,6 +36,30 @@ func TestEngineFibParity(t *testing.T) {
 	}
 }
 
+// TestEngineCheck exercises create-time module validation (preflightEscrowWasm):
+// a well-formed module exporting finish() -> i32 passes; non-WASM bytes and a
+// module without the finish export return ErrInvalidWasm — all without running
+// the code.
+func TestEngineCheck(t *testing.T) {
+	e := New()
+	defer e.Close()
+
+	// (module (func (export "finish") (result i32) (i32.const 1)))
+	const finishI32 = "0061736d010000000105016000017f03020100070a010666696e69736800000a0601040041010b"
+	// Same module, but the export is named "fonish" — no finish entry point.
+	const wrongName = "0061736d010000000105016000017f03020100070a0106666f6e69736800000a0601040041010b"
+
+	if err := e.Check(mustDecode(t, finishI32), "finish"); err != nil {
+		t.Errorf("valid module: unexpected error %v", err)
+	}
+	if err := e.Check([]byte("not-wasm-bytes!"), "finish"); err == nil {
+		t.Error("garbage module: expected error, got nil")
+	}
+	if err := e.Check(mustDecode(t, wrongName), "finish"); err == nil {
+		t.Error("missing finish export: expected error, got nil")
+	}
+}
+
 // TestEngineDisabledFloatRejected proves the float-disabling config flag is
 // wired: a module using f32 ops must fail to load, matching rippled's
 // tecFAILED_PROCESSING.

--- a/internal/wasm/wasm.go
+++ b/internal/wasm/wasm.go
@@ -26,6 +26,11 @@ var ErrCGODisabled = errors.New("wasm: execution unavailable (build with cgo and
 // tecFAILED_PROCESSING.
 var ErrExecution = errors.New("wasm: execution failed")
 
+// ErrInvalidWasm is returned by Check when code is not a well-formed module or
+// does not export the expected entry function. It mirrors rippled's
+// preflightEscrowWasm returning a temBAD_WASM-class result.
+var ErrInvalidWasm = errors.New("wasm: invalid module")
+
 // Result is the outcome of a successful WASM run: the i32 the entry function
 // returned, and the gas (fuel) it consumed.
 type Result struct {


### PR DESCRIPTION
## SmartEscrow (computational escrow) — single combined PR

Collapses the SmartEscrow transactor stack (previously #716 → #720 → #721, plus #722) into **one** PR on top of the WASM engine + host (`wasm`, #708). Stacked PRs were painful to maintain — every fix to the base required a cascade of re-merges. This is the full feature in one squashed diff.

### What's included
- **#705 — EscrowFinish WASM execution.** `FinishFunction`/`Data` on EscrowCreate, `ComputationAllowance` on EscrowFinish; the escrow finish function runs in `doApply` (`tecWASM_REJECTED` on a non-positive result); field-pairing preclaim (`tefNO_WASM` / `tefWASM_FIELD_NOT_INCLUDED`); SFields + Escrow SLE fields.
- **#717 — fee parity.** WASM extension fee-settings SFields + FeeSettings/genesis wiring; EscrowCreate/EscrowFinish base-fee surcharges.
- **#718 — create-time validation.** FinishFunction size / `temBAD_WASM` / `temTEMP_DISABLED`; `ComputationAllowance` bounds (`temBAD_LIMIT`); `wasm.Engine.Check`.
- **#719 — get_nft.** `nftoken.FindTokenURI` NFTokenPage traversal behind the escrow host view.

### Conformance fixes folded in (from the #716 finalize review, vs rippled smart-escrow `d3550fac60`)
- **Deposit-auth under SmartEscrow is enforced**, not skipped — `verifyDepositPreauth` is relocated *before* the condition/WASM steps (rippled `EscrowFinish.cpp:328-338`/`:393-403`), so an unauthorized finisher is rejected before the contract runs.
- **FinishFunction owner reserve** = `1 + size/500` slots on create/finish/cancel (rippled `EscrowHelpers.h:232-239`), not a flat ±1.
- **`tecWASM_REJECTED = 198`**; `NO_DELEGATE_PERMISSION` → `terNO_DELEGATE_PERMISSION` (PermissionDelegation deferred on mainnet), matching the smart-escrow TER layout.
- **`FindTokenURI` upgraded** to the `(uri, found, hasURI)` contract the host `get_nft` expects — distinguishes a missing token from a token with no URI (the latest `wasm` host interface had drifted past #719).

### Verification
`go build ./...`, `go vet`, `golangci-lint` (0 issues) all clean. escrow / nft / batch / genesis / tx test suites pass locally (non-wasmi); the wasmi-tagged e2e + engine tests run in CI. Regression tests added for the deposit-auth rejection and the multi-slot FinishFunction reserve.

Closes the stacked PRs #720, #721, #722 (and supersedes the already-closed #716). The WASM engine + host remains its own PR (#708 → `main`).
