### PR TITLE
feat: add rippled-3.0.0 SLE schema fields (#278)

### DIFF
--- a/amendment/registry.go
+++ b/amendment/registry.go
@@ -28,6 +28,7 @@ var (
 // above — there is no separate init() write-back, so cross-package callers
 // observing FeatureXxx never see a zero ID.
 var (
+	FeatureFixIncludeKeyletFields        = registerFix("fixIncludeKeyletFields", SupportedYes, VoteDefaultNo)
 	FeatureFixDirectoryLimit             = registerFix("fixDirectoryLimit", SupportedYes, VoteDefaultNo)
 	FeatureFixPriceOracleOrder           = registerFix("fixPriceOracleOrder", SupportedNo, VoteDefaultNo)
 	FeatureFixMPTDeliveredAmount         = registerFix("fixMPTDeliveredAmount", SupportedNo, VoteDefaultNo)

--- a/docs/amendments.md
+++ b/docs/amendments.md
@@ -7,7 +7,7 @@ XRPL amendments known to this node, generated from the amendment registry
 amendment's behavior; **Default vote** is whether the node votes for it by
 default (operators override via the `[amendments]` config section).
 
-Total: 99 amendments.
+Total: 100 amendments.
 
 | Amendment | Supported | Default vote |
 |-----------|-----------|--------------|
@@ -85,6 +85,7 @@ Total: 99 amendments.
 | `fixEnforceNFTokenTrustlineV2` | yes | no |
 | `fixFillOrKill` | yes | no |
 | `fixFrozenLPTokenTransfer` | yes | no |
+| `fixIncludeKeyletFields` | yes | no |
 | `fixInnerObjTemplate` | yes | no |
 | `fixInnerObjTemplate2` | yes | no |
 | `fixInvalidTxFlags` | yes | no |

--- a/internal/ledger/state/account_root.go
+++ b/internal/ledger/state/account_root.go
@@ -33,6 +33,8 @@ type AccountRoot struct {
 	WalletLocator        string   // Arbitrary hex data (deprecated)
 	TicketCount          uint32   // Number of outstanding tickets owned by this account
 	AMMID                [32]byte // Links AMM pseudo-account to its AMM ledger entry (sfAMMID, fieldCode 14)
+	VaultID              [32]byte // sfVaultID, pseudo-account designator (fieldCode 35, rippled 3.0.0)
+	LoanBrokerID         [32]byte // sfLoanBrokerID, pseudo-account designator (fieldCode 37, rippled 3.0.0)
 	PreviousTxnID        [32]byte
 	PreviousTxnLgrSeq    uint32
 }
@@ -45,12 +47,22 @@ func (a *AccountRoot) HasAMMID() bool {
 	return a != nil && a.AMMID != [32]byte{}
 }
 
+// HasVaultID reports whether the sfVaultID pseudo-account designator is present.
+func (a *AccountRoot) HasVaultID() bool {
+	return a != nil && a.VaultID != [32]byte{}
+}
+
+// HasLoanBrokerID reports whether the sfLoanBrokerID pseudo-account designator is present.
+func (a *AccountRoot) HasLoanBrokerID() bool {
+	return a != nil && a.LoanBrokerID != [32]byte{}
+}
+
 // IsPseudoAccount reports whether this AccountRoot is a pseudo-account, mirroring
-// rippled's isPseudoAccount (View.cpp:1138) which tests whether any of the
-// pseudo-account owner fields (sfAMMID, sfVaultID) is present. go-xrpl currently
-// surfaces only AMMID on AccountRoot; VaultID will land alongside featureSingleAssetVault.
+// rippled's isPseudoAccount (View.cpp) which returns true when any field flagged
+// sMD_PseudoAccount is present. In rippled 3.0.0 those designators are sfAMMID,
+// sfVaultID, and sfLoanBrokerID.
 func (a *AccountRoot) IsPseudoAccount() bool {
-	return a.HasAMMID()
+	return a.HasAMMID() || a.HasVaultID() || a.HasLoanBrokerID()
 }
 
 // Field type codes (exported for use by parent tx/ package)
@@ -87,6 +99,8 @@ const (
 	fieldCodeAccountTxnID         = 9  // Hash256 - last transaction ID
 	fieldCodeWalletLocator        = 7  // Hash256 - wallet locator (deprecated)
 	fieldCodeAMMID                = 14 // Hash256 - links AMM pseudo-account to AMM entry (sfAMMID)
+	fieldCodeVaultID              = 35 // Hash256 - sfVaultID pseudo-account designator
+	fieldCodeLoanBrokerID         = 37 // Hash256 - sfLoanBrokerID pseudo-account designator
 )
 
 // Ledger entry type code for AccountRoot (unexported)
@@ -351,6 +365,10 @@ func ParseAccountRoot(data []byte) (*AccountRoot, error) {
 				account.WalletLocator = hex.EncodeToString(data[offset : offset+32])
 			case fieldCodeAMMID: // AMMID - links AMM pseudo-account to AMM entry
 				copy(account.AMMID[:], data[offset:offset+32])
+			case fieldCodeVaultID: // VaultID - pseudo-account designator
+				copy(account.VaultID[:], data[offset:offset+32])
+			case fieldCodeLoanBrokerID: // LoanBrokerID - pseudo-account designator
+				copy(account.LoanBrokerID[:], data[offset:offset+32])
 			}
 			offset += 32
 
@@ -459,6 +477,14 @@ func SerializeAccountRoot(account *AccountRoot) ([]byte, error) {
 	// Add AMMID if set (non-zero) — links AMM pseudo-account to AMM entry
 	if account.AMMID != zeroHash {
 		jsonObj["AMMID"] = strings.ToUpper(hex.EncodeToString(account.AMMID[:]))
+	}
+
+	// Add VaultID / LoanBrokerID if set (non-zero) — pseudo-account designators (rippled 3.0.0)
+	if account.VaultID != zeroHash {
+		jsonObj["VaultID"] = strings.ToUpper(hex.EncodeToString(account.VaultID[:]))
+	}
+	if account.LoanBrokerID != zeroHash {
+		jsonObj["LoanBrokerID"] = strings.ToUpper(hex.EncodeToString(account.LoanBrokerID[:]))
 	}
 
 	// Add PreviousTxnID if set (non-zero)

--- a/internal/ledger/state/account_root.go
+++ b/internal/ledger/state/account_root.go
@@ -33,8 +33,8 @@ type AccountRoot struct {
 	WalletLocator        string   // Arbitrary hex data (deprecated)
 	TicketCount          uint32   // Number of outstanding tickets owned by this account
 	AMMID                [32]byte // Links AMM pseudo-account to its AMM ledger entry (sfAMMID, fieldCode 14)
-	VaultID              [32]byte // sfVaultID, pseudo-account designator (fieldCode 35, rippled 3.0.0)
-	LoanBrokerID         [32]byte // sfLoanBrokerID, pseudo-account designator (fieldCode 37, rippled 3.0.0)
+	VaultID              [32]byte // sfVaultID, pseudo-account designator (fieldCode 35)
+	LoanBrokerID         [32]byte // sfLoanBrokerID, pseudo-account designator (fieldCode 37)
 	PreviousTxnID        [32]byte
 	PreviousTxnLgrSeq    uint32
 }
@@ -59,7 +59,7 @@ func (a *AccountRoot) HasLoanBrokerID() bool {
 
 // IsPseudoAccount reports whether this AccountRoot is a pseudo-account, mirroring
 // rippled's isPseudoAccount (View.cpp) which returns true when any field flagged
-// sMD_PseudoAccount is present. In rippled 3.0.0 those designators are sfAMMID,
+// sMD_PseudoAccount is present. In rippled those designators are sfAMMID,
 // sfVaultID, and sfLoanBrokerID.
 func (a *AccountRoot) IsPseudoAccount() bool {
 	return a.HasAMMID() || a.HasVaultID() || a.HasLoanBrokerID()
@@ -479,7 +479,7 @@ func SerializeAccountRoot(account *AccountRoot) ([]byte, error) {
 		jsonObj["AMMID"] = strings.ToUpper(hex.EncodeToString(account.AMMID[:]))
 	}
 
-	// Add VaultID / LoanBrokerID if set (non-zero) — pseudo-account designators (rippled 3.0.0)
+	// Add VaultID / LoanBrokerID if set (non-zero) — pseudo-account designators
 	if account.VaultID != zeroHash {
 		jsonObj["VaultID"] = strings.ToUpper(hex.EncodeToString(account.VaultID[:]))
 	}

--- a/internal/ledger/state/escrow_entry.go
+++ b/internal/ledger/state/escrow_entry.go
@@ -7,6 +7,8 @@ import (
 
 // EscrowData represents an Escrow ledger entry
 type EscrowData struct {
+	Sequence        uint32 // sfSequence, optional (fixTokenEscrowV1, rippled 3.0.0)
+	HasSequence     bool
 	Account         [20]byte
 	DestinationID   [20]byte
 	Amount          uint64  // XRP drops (only valid when IsXRP is true)
@@ -77,6 +79,9 @@ func ParseEscrow(data []byte) (*EscrowData, error) {
 			value := binary.BigEndian.Uint32(data[offset : offset+4])
 			offset += 4
 			switch fieldCode {
+			case 4: // Sequence (UInt32 nth=4; distinct from UInt64 OwnerNode nth=4)
+				escrow.Sequence = value
+				escrow.HasSequence = true
 			case 2: // Flags
 				escrow.Flags = value
 			case 3: // SourceTag

--- a/internal/ledger/state/escrow_entry.go
+++ b/internal/ledger/state/escrow_entry.go
@@ -7,7 +7,7 @@ import (
 
 // EscrowData represents an Escrow ledger entry
 type EscrowData struct {
-	Sequence        uint32 // sfSequence, optional (fixTokenEscrowV1, rippled 3.0.0)
+	Sequence        uint32 // sfSequence, optional (fixTokenEscrowV1)
 	HasSequence     bool
 	Account         [20]byte
 	DestinationID   [20]byte

--- a/internal/ledger/state/mptoken_entry.go
+++ b/internal/ledger/state/mptoken_entry.go
@@ -21,6 +21,8 @@ const (
 type MPTokenIssuanceData struct {
 	Issuer            [20]byte
 	Sequence          uint32
+	MutableFlags      uint32 // sfMutableFlags, default (DynamicMPT, rippled 3.0.0)
+	HasMutableFlags   bool
 	OwnerNode         uint64
 	OutstandingAmount uint64
 	TransferFee       uint16
@@ -111,6 +113,9 @@ func ParseMPTokenIssuance(data []byte) (*MPTokenIssuanceData, error) {
 				issuance.Flags = value
 			case 4: // Sequence
 				issuance.Sequence = value
+			case 53: // MutableFlags (rippled 3.0.0)
+				issuance.MutableFlags = value
+				issuance.HasMutableFlags = true
 			}
 
 		case FieldTypeUInt64:
@@ -210,6 +215,10 @@ func SerializeMPTokenIssuance(issuance *MPTokenIssuanceData) ([]byte, error) {
 
 	if issuance.AssetScale > 0 {
 		jsonObj["AssetScale"] = issuance.AssetScale
+	}
+
+	if issuance.HasMutableFlags {
+		jsonObj["MutableFlags"] = issuance.MutableFlags
 	}
 
 	if issuance.MaximumAmount != nil {

--- a/internal/ledger/state/mptoken_entry.go
+++ b/internal/ledger/state/mptoken_entry.go
@@ -21,7 +21,7 @@ const (
 type MPTokenIssuanceData struct {
 	Issuer            [20]byte
 	Sequence          uint32
-	MutableFlags      uint32 // sfMutableFlags, default (DynamicMPT, rippled 3.0.0)
+	MutableFlags      uint32 // sfMutableFlags, default (DynamicMPT)
 	HasMutableFlags   bool
 	OwnerNode         uint64
 	OutstandingAmount uint64
@@ -113,7 +113,7 @@ func ParseMPTokenIssuance(data []byte) (*MPTokenIssuanceData, error) {
 				issuance.Flags = value
 			case 4: // Sequence
 				issuance.Sequence = value
-			case 53: // MutableFlags (rippled 3.0.0)
+			case 53: // MutableFlags
 				issuance.MutableFlags = value
 				issuance.HasMutableFlags = true
 			}

--- a/internal/ledger/state/oracle_entry.go
+++ b/internal/ledger/state/oracle_entry.go
@@ -12,14 +12,16 @@ import (
 // OracleData holds parsed fields of an Oracle ledger entry.
 // Reference: rippled LedgerFormats.h ltORACLE
 type OracleData struct {
-	Owner           [20]byte
-	Provider        string // hex-encoded
-	AssetClass      string // hex-encoded
-	LastUpdateTime  uint32
-	OwnerNode       uint64
-	PriceDataSeries []OraclePriceData
-	URI             string // hex-encoded, optional
-	Flags           uint32
+	OracleDocumentID    uint32 // sfOracleDocumentID, optional (rippled 3.0.0)
+	HasOracleDocumentID bool
+	Owner               [20]byte
+	Provider            string // hex-encoded
+	AssetClass          string // hex-encoded
+	LastUpdateTime      uint32
+	OwnerNode           uint64
+	PriceDataSeries     []OraclePriceData
+	URI                 string // hex-encoded, optional
+	Flags               uint32
 }
 
 // OraclePriceData holds parsed fields of a single price data entry within an Oracle.
@@ -43,6 +45,7 @@ const (
 
 	// Field nth values for Oracle fields
 	fieldLastUpdateTime = 15 // UInt32, nth=15
+	fieldOracleDocID    = 51 // UInt32, nth=51 (sfOracleDocumentID, rippled 3.0.0)
 	fieldOwnerNode      = 4  // UInt64, nth=4
 	fieldAssetPrice     = 23 // UInt64, nth=23
 	fieldScale          = 4  // UInt8, nth=4
@@ -108,6 +111,9 @@ func ParseOracle(data []byte) (*OracleData, error) {
 			switch fieldCode {
 			case 2: // Flags
 				oracle.Flags = value
+			case fieldOracleDocID: // 51 (rippled 3.0.0)
+				oracle.OracleDocumentID = value
+				oracle.HasOracleDocumentID = true
 			case fieldLastUpdateTime: // 15
 				oracle.LastUpdateTime = value
 			}
@@ -394,6 +400,10 @@ func SerializeOracle(o *OracleData) ([]byte, error) {
 		"LastUpdateTime":  o.LastUpdateTime,
 		"OwnerNode":       fmt.Sprintf("%X", o.OwnerNode),
 		"Flags":           uint32(0),
+	}
+
+	if o.HasOracleDocumentID {
+		jsonObj["OracleDocumentID"] = o.OracleDocumentID
 	}
 
 	if o.URI != "" {

--- a/internal/ledger/state/oracle_entry.go
+++ b/internal/ledger/state/oracle_entry.go
@@ -12,7 +12,7 @@ import (
 // OracleData holds parsed fields of an Oracle ledger entry.
 // Reference: rippled LedgerFormats.h ltORACLE
 type OracleData struct {
-	OracleDocumentID    uint32 // sfOracleDocumentID, optional (rippled 3.0.0)
+	OracleDocumentID    uint32 // sfOracleDocumentID, optional
 	HasOracleDocumentID bool
 	Owner               [20]byte
 	Provider            string // hex-encoded
@@ -45,7 +45,7 @@ const (
 
 	// Field nth values for Oracle fields
 	fieldLastUpdateTime = 15 // UInt32, nth=15
-	fieldOracleDocID    = 51 // UInt32, nth=51 (sfOracleDocumentID, rippled 3.0.0)
+	fieldOracleDocID    = 51 // UInt32, nth=51
 	fieldOwnerNode      = 4  // UInt64, nth=4
 	fieldAssetPrice     = 23 // UInt64, nth=23
 	fieldScale          = 4  // UInt8, nth=4
@@ -111,7 +111,7 @@ func ParseOracle(data []byte) (*OracleData, error) {
 			switch fieldCode {
 			case 2: // Flags
 				oracle.Flags = value
-			case fieldOracleDocID: // 51 (rippled 3.0.0)
+			case fieldOracleDocID: // 51
 				oracle.OracleDocumentID = value
 				oracle.HasOracleDocumentID = true
 			case fieldLastUpdateTime: // 15

--- a/internal/ledger/state/pay_channel.go
+++ b/internal/ledger/state/pay_channel.go
@@ -11,7 +11,7 @@ import (
 
 // PayChannelData represents a PayChannel ledger entry
 type PayChannelData struct {
-	Sequence        uint32 // sfSequence, optional (rippled 3.0.0)
+	Sequence        uint32 // sfSequence, optional
 	HasSequence     bool
 	Account         [20]byte
 	DestinationID   [20]byte

--- a/internal/ledger/state/pay_channel.go
+++ b/internal/ledger/state/pay_channel.go
@@ -11,6 +11,8 @@ import (
 
 // PayChannelData represents a PayChannel ledger entry
 type PayChannelData struct {
+	Sequence        uint32 // sfSequence, optional (rippled 3.0.0)
+	HasSequence     bool
 	Account         [20]byte
 	DestinationID   [20]byte
 	Amount          uint64
@@ -51,6 +53,9 @@ func SerializePayChannelFromData(channel *PayChannelData) ([]byte, error) {
 		"Flags":           uint32(0),
 	}
 
+	if channel.HasSequence {
+		jsonObj["Sequence"] = channel.Sequence
+	}
 	if channel.PublicKey != "" {
 		jsonObj["PublicKey"] = channel.PublicKey
 	}
@@ -124,6 +129,9 @@ func ParsePayChannel(data []byte) (*PayChannelData, error) {
 			value := binary.BigEndian.Uint32(data[offset : offset+4])
 			offset += 4
 			switch fieldCode {
+			case 4: // Sequence (UInt32 nth=4; distinct from UInt64 OwnerNode nth=4)
+				channel.Sequence = value
+				channel.HasSequence = true
 			case 39: // SettleDelay (nth=39)
 				channel.SettleDelay = value
 			case 36: // CancelAfter (nth=36)

--- a/internal/ledger/state/schema_v3_test.go
+++ b/internal/ledger/state/schema_v3_test.go
@@ -1,0 +1,189 @@
+package state
+
+import (
+	"encoding/hex"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+)
+
+// The rippled-3.0.0 schema additions (issue #278) must survive the hand-written
+// parse/serialize helpers in this package — the read path used by RPC and
+// internal ledger logic. These tests round-trip each new field through the
+// state-layer codepath (binarycodec blob → ParseX, and SerializeX → ParseX).
+
+const (
+	v3AcctA = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+	v3AcctB = "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn"
+)
+
+func mustEncodeBlob(t *testing.T, obj map[string]any) []byte {
+	t.Helper()
+	hexStr, err := binarycodec.Encode(obj)
+	if err != nil {
+		t.Fatalf("binarycodec.Encode: %v", err)
+	}
+	data, err := hex.DecodeString(hexStr)
+	if err != nil {
+		t.Fatalf("hex.DecodeString: %v", err)
+	}
+	return data
+}
+
+func TestParseEscrow_Sequence(t *testing.T) {
+	data := mustEncodeBlob(t, map[string]any{
+		"LedgerEntryType": "Escrow",
+		"Account":         v3AcctA,
+		"Sequence":        uint32(99),
+		"Destination":     v3AcctB,
+		"Amount":          "1000000",
+		"OwnerNode":       "0",
+		"Flags":           uint32(0),
+	})
+
+	escrow, err := ParseEscrow(data)
+	if err != nil {
+		t.Fatalf("ParseEscrow: %v", err)
+	}
+	if !escrow.HasSequence || escrow.Sequence != 99 {
+		t.Fatalf("Sequence not parsed: HasSequence=%v Sequence=%d", escrow.HasSequence, escrow.Sequence)
+	}
+}
+
+func TestPayChannel_Sequence_RoundTrip(t *testing.T) {
+	var owner, dest [20]byte
+	for i := range owner {
+		owner[i] = byte(i + 1)
+		dest[i] = byte(i + 100)
+	}
+	in := &PayChannelData{
+		Account:       owner,
+		DestinationID: dest,
+		Amount:        1000000,
+		Balance:       0,
+		SettleDelay:   60,
+		Sequence:      7,
+		HasSequence:   true,
+	}
+
+	data, err := SerializePayChannelFromData(in)
+	if err != nil {
+		t.Fatalf("SerializePayChannelFromData: %v", err)
+	}
+	out, err := ParsePayChannel(data)
+	if err != nil {
+		t.Fatalf("ParsePayChannel: %v", err)
+	}
+	if !out.HasSequence || out.Sequence != 7 {
+		t.Fatalf("Sequence not round-tripped: HasSequence=%v Sequence=%d", out.HasSequence, out.Sequence)
+	}
+}
+
+func TestAccountRoot_PseudoAccountDesignators_RoundTrip(t *testing.T) {
+	var vaultID, loanBrokerID [32]byte
+	for i := range vaultID {
+		vaultID[i] = byte(i + 1)
+		loanBrokerID[i] = byte(i + 50)
+	}
+	in := &AccountRoot{
+		Account:      v3AcctA,
+		Balance:      1000000,
+		Sequence:     1,
+		VaultID:      vaultID,
+		LoanBrokerID: loanBrokerID,
+	}
+	if !in.IsPseudoAccount() {
+		t.Fatal("IsPseudoAccount should be true when VaultID/LoanBrokerID are set")
+	}
+
+	data, err := SerializeAccountRoot(in)
+	if err != nil {
+		t.Fatalf("SerializeAccountRoot: %v", err)
+	}
+	out, err := ParseAccountRoot(data)
+	if err != nil {
+		t.Fatalf("ParseAccountRoot: %v", err)
+	}
+	if out.VaultID != vaultID {
+		t.Fatalf("VaultID not round-tripped: got %x want %x", out.VaultID, vaultID)
+	}
+	if out.LoanBrokerID != loanBrokerID {
+		t.Fatalf("LoanBrokerID not round-tripped: got %x want %x", out.LoanBrokerID, loanBrokerID)
+	}
+	if !out.HasVaultID() || !out.HasLoanBrokerID() || !out.IsPseudoAccount() {
+		t.Fatal("pseudo-account designators not detected after parse")
+	}
+}
+
+func TestParseSignerList_Owner(t *testing.T) {
+	data := mustEncodeBlob(t, map[string]any{
+		"LedgerEntryType": "SignerList",
+		"Flags":           uint32(0),
+		"Owner":           v3AcctA,
+		"OwnerNode":       "0",
+		"SignerQuorum":    uint32(1),
+		"SignerEntries": []any{
+			map[string]any{
+				"SignerEntry": map[string]any{
+					"Account":      v3AcctB,
+					"SignerWeight": uint32(1),
+				},
+			},
+		},
+		"SignerListID": uint32(0),
+	})
+
+	sl, err := ParseSignerList(data)
+	if err != nil {
+		t.Fatalf("ParseSignerList: %v", err)
+	}
+	if sl.Owner != v3AcctA {
+		t.Fatalf("Owner not parsed: got %q want %q", sl.Owner, v3AcctA)
+	}
+}
+
+func TestParseOracle_OracleDocumentID(t *testing.T) {
+	data := mustEncodeBlob(t, map[string]any{
+		"LedgerEntryType":  "Oracle",
+		"Owner":            v3AcctA,
+		"OracleDocumentID": uint32(5),
+		"Provider":         "DEADBEEF",
+		"AssetClass":       "0123",
+		"LastUpdateTime":   uint32(123456789),
+		"OwnerNode":        "0",
+		"Flags":            uint32(0),
+	})
+
+	oracle, err := ParseOracle(data)
+	if err != nil {
+		t.Fatalf("ParseOracle: %v", err)
+	}
+	if !oracle.HasOracleDocumentID || oracle.OracleDocumentID != 5 {
+		t.Fatalf("OracleDocumentID not parsed: Has=%v ID=%d", oracle.HasOracleDocumentID, oracle.OracleDocumentID)
+	}
+}
+
+func TestMPTokenIssuance_MutableFlags_RoundTrip(t *testing.T) {
+	var issuer [20]byte
+	for i := range issuer {
+		issuer[i] = byte(i + 1)
+	}
+	in := &MPTokenIssuanceData{
+		Issuer:          issuer,
+		Sequence:        1,
+		MutableFlags:    7,
+		HasMutableFlags: true,
+	}
+
+	data, err := SerializeMPTokenIssuance(in)
+	if err != nil {
+		t.Fatalf("SerializeMPTokenIssuance: %v", err)
+	}
+	out, err := ParseMPTokenIssuance(data)
+	if err != nil {
+		t.Fatalf("ParseMPTokenIssuance: %v", err)
+	}
+	if !out.HasMutableFlags || out.MutableFlags != 7 {
+		t.Fatalf("MutableFlags not round-tripped: Has=%v Flags=%d", out.HasMutableFlags, out.MutableFlags)
+	}
+}

--- a/internal/ledger/state/signer_list.go
+++ b/internal/ledger/state/signer_list.go
@@ -15,6 +15,7 @@ const LsfOneOwnerCount uint32 = 0x00020000
 
 // SignerListInfo holds parsed signer list data from a ledger entry.
 type SignerListInfo struct {
+	Owner         string // sfOwner, optional (pseudo-account-owned list, rippled 3.0.0)
 	SignerListID  uint32
 	SignerQuorum  uint32
 	Flags         uint32
@@ -67,6 +68,10 @@ func ParseSignerList(data []byte) (*SignerListInfo, error) {
 		case uint32:
 			signerList.SignerQuorum = v
 		}
+	}
+
+	if owner, ok := decoded["Owner"].(string); ok {
+		signerList.Owner = owner
 	}
 
 	if entries, ok := decoded["SignerEntries"]; ok {

--- a/internal/ledger/state/signer_list.go
+++ b/internal/ledger/state/signer_list.go
@@ -15,7 +15,7 @@ const LsfOneOwnerCount uint32 = 0x00020000
 
 // SignerListInfo holds parsed signer list data from a ledger entry.
 type SignerListInfo struct {
-	Owner         string // sfOwner, optional (pseudo-account-owned list, rippled 3.0.0)
+	Owner         string // sfOwner, optional (pseudo-account-owned list)
 	SignerListID  uint32
 	SignerQuorum  uint32
 	Flags         uint32

--- a/internal/ledger/state/signer_list.go
+++ b/internal/ledger/state/signer_list.go
@@ -74,6 +74,17 @@ func ParseSignerList(data []byte) (*SignerListInfo, error) {
 		signerList.Owner = owner
 	}
 
+	if id, ok := decoded["SignerListID"]; ok {
+		switch v := id.(type) {
+		case float64:
+			signerList.SignerListID = uint32(v)
+		case int:
+			signerList.SignerListID = uint32(v)
+		case uint32:
+			signerList.SignerListID = v
+		}
+	}
+
 	if entries, ok := decoded["SignerEntries"]; ok {
 		if entriesArray, ok := entries.([]interface{}); ok {
 			for _, entryWrapper := range entriesArray {
@@ -128,7 +139,10 @@ func SerializeSignerList(quorum uint32, entries []SignerEntry, ownerID [20]byte,
 	jsonObj := map[string]any{
 		"LedgerEntryType": "SignerList",
 		"SignerQuorum":    quorum,
-		"OwnerNode":       "0",
+		// sfSignerListID is soeREQUIRED and always DEFAULT_SIGNER_LIST_ID (0).
+		// Reference: rippled SetSignerList.cpp:433
+		"SignerListID": uint32(0),
+		"OwnerNode":    "0",
 	}
 
 	// rippled records the owner only as sfOwner under fixIncludeKeyletFields, and

--- a/internal/ledger/state/signer_list.go
+++ b/internal/ledger/state/signer_list.go
@@ -117,8 +117,9 @@ func ParseSignerList(data []byte) (*SignerListInfo, error) {
 // flags should be LsfOneOwnerCount when featureMultiSignReserve is enabled, 0 otherwise.
 // expandedSignerList gates emission of WalletLocator, mirroring rippled's
 // defensive check (a tag is never written when featureExpandedSignerList is off).
+// includeKeyletFields gates emission of sfOwner (fixIncludeKeyletFields).
 // Reference: rippled SetSignerList.cpp writeSignersToSLE()
-func SerializeSignerList(quorum uint32, entries []SignerEntry, ownerID [20]byte, flags uint32, expandedSignerList bool) ([]byte, error) {
+func SerializeSignerList(quorum uint32, entries []SignerEntry, ownerID [20]byte, flags uint32, expandedSignerList, includeKeyletFields bool) ([]byte, error) {
 	ownerAddress, err := addresscodec.EncodeAccountIDToClassicAddress(ownerID[:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode owner address: %w", err)
@@ -126,9 +127,15 @@ func SerializeSignerList(quorum uint32, entries []SignerEntry, ownerID [20]byte,
 
 	jsonObj := map[string]any{
 		"LedgerEntryType": "SignerList",
-		"Account":         ownerAddress,
 		"SignerQuorum":    quorum,
 		"OwnerNode":       "0",
+	}
+
+	// rippled records the owner only as sfOwner under fixIncludeKeyletFields, and
+	// never as a top-level sfAccount (the owner is encoded in keylet::signers).
+	// Reference: rippled SetSignerList.cpp:428-431
+	if includeKeyletFields {
+		jsonObj["Owner"] = ownerAddress
 	}
 
 	// Only set Flags if non-zero, matching rippled's writeSignersToSLE behavior.

--- a/internal/testing/escrow/keylet_fields_test.go
+++ b/internal/testing/escrow/keylet_fields_test.go
@@ -1,0 +1,49 @@
+package escrow_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+// fixIncludeKeyletFields stores the creating tx's sfSequence (the value used in
+// keylet::escrow) on the Escrow SLE. Reference: rippled Escrow.cpp:542-545.
+func TestEscrowCreate_IncludeKeyletFields_Sequence(t *testing.T) {
+	create := func(env *jtx.TestEnv) (uint32, *state.EscrowData) {
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		fund5000(env, alice, bob)
+
+		seq := env.Seq(alice)
+		result := env.Submit(
+			escrow.EscrowCreate(alice, bob, xrp(1000)).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Build())
+		jtx.RequireTxSuccess(t, result)
+
+		data, err := env.LedgerEntry(keylet.Escrow(alice.ID, seq))
+		require.NoError(t, err)
+		e, err := state.ParseEscrow(data)
+		require.NoError(t, err)
+		return seq, e
+	}
+
+	t.Run("enabled stores sfSequence", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		seq, e := create(env)
+		require.True(t, e.HasSequence, "Sequence must be stored when fixIncludeKeyletFields is enabled")
+		require.Equal(t, seq, e.Sequence)
+	})
+
+	t.Run("disabled omits sfSequence", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		env.DisableFeature("fixIncludeKeyletFields")
+		_, e := create(env)
+		require.False(t, e.HasSequence, "Sequence must be absent without fixIncludeKeyletFields")
+	})
+}

--- a/internal/testing/multisign/keylet_fields_test.go
+++ b/internal/testing/multisign/keylet_fields_test.go
@@ -38,6 +38,8 @@ func TestSignerListSet_IncludeKeyletFields_Owner(t *testing.T) {
 		owner, ok := decoded["Owner"]
 		require.True(t, ok, "Owner must be stored when fixIncludeKeyletFields is enabled")
 		require.Equal(t, addr, owner)
+		require.Contains(t, decoded, "SignerListID", "sfSignerListID is soeREQUIRED")
+		require.EqualValues(t, 0, decoded["SignerListID"])
 	})
 
 	t.Run("disabled stores neither sfOwner nor sfAccount", func(t *testing.T) {
@@ -48,5 +50,7 @@ func TestSignerListSet_IncludeKeyletFields_Owner(t *testing.T) {
 		require.False(t, hasAccount, "SignerList must never carry a top-level sfAccount")
 		_, hasOwner := decoded["Owner"]
 		require.False(t, hasOwner, "Owner must be absent without fixIncludeKeyletFields")
+		require.Contains(t, decoded, "SignerListID", "sfSignerListID is soeREQUIRED")
+		require.EqualValues(t, 0, decoded["SignerListID"])
 	})
 }

--- a/internal/testing/multisign/keylet_fields_test.go
+++ b/internal/testing/multisign/keylet_fields_test.go
@@ -1,0 +1,52 @@
+package multisign_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+// rippled records a SignerList owner only as sfOwner under fixIncludeKeyletFields,
+// and never as a top-level sfAccount (the owner is encoded in keylet::signers).
+// Reference: rippled SetSignerList.cpp:428-431.
+func TestSignerListSet_IncludeKeyletFields_Owner(t *testing.T) {
+	build := func(env *jtx.TestEnv) (string, map[string]any) {
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		env.SetSignerList(alice, 1, []jtx.TestSigner{{Account: bob, Weight: 1}})
+		env.Close()
+
+		data, err := env.LedgerEntry(keylet.SignerList(alice.ID))
+		require.NoError(t, err)
+		decoded, err := binarycodec.Decode(hex.EncodeToString(data))
+		require.NoError(t, err)
+		return alice.Address, decoded
+	}
+
+	t.Run("enabled stores sfOwner, never sfAccount", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		addr, decoded := build(env)
+		_, hasAccount := decoded["Account"]
+		require.False(t, hasAccount, "SignerList must never carry a top-level sfAccount")
+		owner, ok := decoded["Owner"]
+		require.True(t, ok, "Owner must be stored when fixIncludeKeyletFields is enabled")
+		require.Equal(t, addr, owner)
+	})
+
+	t.Run("disabled stores neither sfOwner nor sfAccount", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		env.DisableFeature("fixIncludeKeyletFields")
+		_, decoded := build(env)
+		_, hasAccount := decoded["Account"]
+		require.False(t, hasAccount, "SignerList must never carry a top-level sfAccount")
+		_, hasOwner := decoded["Owner"]
+		require.False(t, hasOwner, "Owner must be absent without fixIncludeKeyletFields")
+	})
+}

--- a/internal/testing/oracle/keylet_fields_test.go
+++ b/internal/testing/oracle/keylet_fields_test.go
@@ -1,0 +1,52 @@
+package oracle_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	oracletest "github.com/LeJamon/go-xrpl/internal/testing/oracle"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+// fixIncludeKeyletFields stores sfOracleDocumentID (the value used in
+// keylet::oracle) on the Oracle SLE. Reference: rippled SetOracle.cpp:282-286.
+func TestOracleSet_IncludeKeyletFields_DocumentID(t *testing.T) {
+	const docID = uint32(7)
+
+	create := func(env *jtx.TestEnv) *state.OracleData {
+		owner := jtx.NewAccount("owner")
+		env.FundAmount(owner, env.ReserveBase()+env.ReserveIncrement()+2*baseFee)
+		env.Close()
+
+		lut := defaultLUT(env)
+		result := env.Submit(oracletest.OracleSet(owner, docID, lut).
+			ProviderHex(32).
+			AssetClassHex(8).
+			AddPrice("XRP", "USD", 740, 1).
+			Fee(baseFee).
+			Build())
+		jtx.RequireTxSuccess(t, result)
+
+		data, err := env.LedgerEntry(keylet.Oracle(owner.ID, docID))
+		require.NoError(t, err)
+		o, err := state.ParseOracle(data)
+		require.NoError(t, err)
+		return o
+	}
+
+	t.Run("enabled stores sfOracleDocumentID", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		o := create(env)
+		require.True(t, o.HasOracleDocumentID, "OracleDocumentID must be stored when fixIncludeKeyletFields is enabled")
+		require.Equal(t, docID, o.OracleDocumentID)
+	})
+
+	t.Run("disabled omits sfOracleDocumentID", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		env.DisableFeature("fixIncludeKeyletFields")
+		o := create(env)
+		require.False(t, o.HasOracleDocumentID, "OracleDocumentID must be absent without fixIncludeKeyletFields")
+	})
+}

--- a/internal/testing/paychan/keylet_fields_test.go
+++ b/internal/testing/paychan/keylet_fields_test.go
@@ -1,0 +1,46 @@
+package paychan
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// fixIncludeKeyletFields stores the creating tx's sfSequence (the value used in
+// keylet::payChannel) on the PayChannel SLE. Reference: rippled PayChan.cpp:294-297.
+func TestPayChanCreate_IncludeKeyletFields_Sequence(t *testing.T) {
+	create := func(env *jtx.TestEnv) (uint32, *state.PayChannelData) {
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		seq := env.Seq(alice)
+		result := env.Submit(ChannelCreate(alice, bob, xrp(1000), 100, alice.PublicKeyHex()).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		data, err := env.LedgerEntry(chanKeylet(alice, bob, seq))
+		require.NoError(t, err)
+		ch, err := state.ParsePayChannel(data)
+		require.NoError(t, err)
+		return seq, ch
+	}
+
+	t.Run("enabled stores sfSequence", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		seq, ch := create(env)
+		require.True(t, ch.HasSequence, "Sequence must be stored when fixIncludeKeyletFields is enabled")
+		require.Equal(t, seq, ch.Sequence)
+	})
+
+	t.Run("disabled omits sfSequence", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		env.DisableFeature("fixIncludeKeyletFields")
+		_, ch := create(env)
+		require.False(t, ch.HasSequence, "Sequence must be absent without fixIncludeKeyletFields")
+	})
+}

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -318,7 +318,7 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	// Serialize escrow
-	escrowData, err := serializeEscrow(e, accountID, destID, sequence, capturedTransferRate)
+	escrowData, err := serializeEscrow(e, accountID, destID, sequence, capturedTransferRate, rules.Enabled(amendment.FeatureFixIncludeKeyletFields))
 	if err != nil {
 		ctx.Log.Error("escrow create: failed to serialize escrow", "error", err)
 		return tx.TefINTERNAL
@@ -410,7 +410,7 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 // full IOU object (value/currency/issuer). For MPT escrows, Amount is
 // {value, mpt_issuance_id}. transferRate is stored when non-zero and not
 // equal to the parity rate (1_000_000_000).
-func serializeEscrow(txn *EscrowCreate, ownerID, destID [20]byte, sequence uint32, transferRate uint32) ([]byte, error) {
+func serializeEscrow(txn *EscrowCreate, ownerID, destID [20]byte, sequence uint32, transferRate uint32, includeKeyletFields bool) ([]byte, error) {
 	ownerAddress, err := addresscodec.EncodeAccountIDToClassicAddress(ownerID[:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode owner address: %w", err)
@@ -452,6 +452,12 @@ func serializeEscrow(txn *EscrowCreate, ownerID, destID [20]byte, sequence uint3
 		"Amount":          amountVal,
 		"OwnerNode":       "0",
 		"Flags":           uint32(0),
+	}
+
+	// sfSequence (the creating tx's sequence, used in keylet::escrow) is stored
+	// only under fixIncludeKeyletFields. Reference: rippled Escrow.cpp:542-545
+	if includeKeyletFields {
+		jsonObj["Sequence"] = sequence
 	}
 
 	if txn.FinishAfter != nil {

--- a/internal/tx/ledgerfields/account_root_gen.go
+++ b/internal/tx/ledgerfields/account_root_gen.go
@@ -42,6 +42,7 @@ type AccountRoot struct {
 	TicketCount          uint32
 	AMMID                string // Hash256 (uppercase hex)
 	VaultID              string // Hash256 (uppercase hex)
+	LoanBrokerID         string // Hash256 (uppercase hex)
 	WalletSize           uint32
 	PreviousTxnID        string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq    uint32
@@ -68,6 +69,7 @@ const (
 	accountrootBitTicketCount
 	accountrootBitAMMID
 	accountrootBitVaultID
+	accountrootBitLoanBrokerID
 	accountrootBitWalletSize
 	accountrootBitPreviousTxnID
 	accountrootBitPreviousTxnLgrSeq
@@ -168,6 +170,9 @@ func (a *AccountRoot) Decode(data []byte) error {
 			case 35:
 				a.VaultID = val
 				a.present |= accountrootBitVaultID
+			case 37:
+				a.LoanBrokerID = val
+				a.present |= accountrootBitLoanBrokerID
 			default:
 				return newErrUnknownField("AccountRoot", typeCode, fieldCode)
 			}
@@ -302,6 +307,9 @@ func (a *AccountRoot) emitAll(out map[string]any, skipDefault bool) {
 	if a.present&accountrootBitVaultID != 0 && !(skipDefault && isZeroHexString(a.VaultID)) {
 		out["VaultID"] = a.VaultID
 	}
+	if a.present&accountrootBitLoanBrokerID != 0 && !(skipDefault && isZeroHexString(a.LoanBrokerID)) {
+		out["LoanBrokerID"] = a.LoanBrokerID
+	}
 	if a.present&accountrootBitWalletSize != 0 && !(skipDefault && a.WalletSize == 0) {
 		out["WalletSize"] = a.WalletSize
 	}
@@ -346,6 +354,7 @@ func (a *AccountRoot) EmitPreviousFields(prev Entry, out map[string]any) {
 	emitIfChangedUint32(out, "TicketCount", p.TicketCount, a.TicketCount, p.present&accountrootBitTicketCount, a.present&accountrootBitTicketCount)
 	emitIfChangedString(out, "AMMID", p.AMMID, a.AMMID, p.present&accountrootBitAMMID, a.present&accountrootBitAMMID)
 	emitIfChangedString(out, "VaultID", p.VaultID, a.VaultID, p.present&accountrootBitVaultID, a.present&accountrootBitVaultID)
+	emitIfChangedString(out, "LoanBrokerID", p.LoanBrokerID, a.LoanBrokerID, p.present&accountrootBitLoanBrokerID, a.present&accountrootBitLoanBrokerID)
 	emitIfChangedUint32(out, "WalletSize", p.WalletSize, a.WalletSize, p.present&accountrootBitWalletSize, a.present&accountrootBitWalletSize)
 }
 
@@ -414,6 +423,9 @@ func (a *AccountRoot) EmitChangeOrigFields(out map[string]any) {
 	}
 	if a.present&accountrootBitVaultID != 0 {
 		out["VaultID"] = a.VaultID
+	}
+	if a.present&accountrootBitLoanBrokerID != 0 {
+		out["LoanBrokerID"] = a.LoanBrokerID
 	}
 	if a.present&accountrootBitWalletSize != 0 {
 		out["WalletSize"] = a.WalletSize
@@ -518,6 +530,9 @@ func (a *AccountRoot) ToMap() map[string]any {
 	}
 	if a.present&accountrootBitVaultID != 0 {
 		out["VaultID"] = a.VaultID
+	}
+	if a.present&accountrootBitLoanBrokerID != 0 {
+		out["LoanBrokerID"] = a.LoanBrokerID
 	}
 	if a.present&accountrootBitWalletSize != 0 {
 		out["WalletSize"] = a.WalletSize

--- a/internal/tx/ledgerfields/encode_test.go
+++ b/internal/tx/ledgerfields/encode_test.go
@@ -236,3 +236,214 @@ func TestHash_LeafNodeFormula(t *testing.T) {
 		t.Fatalf("hash mismatch:\nexpected: %x\ngot:      %x", expected, got)
 	}
 }
+
+// TestRoundTrip_V3SchemaFields covers the rippled-3.0.0 ledger-entry schema
+// additions (issue #278): the new optional/default fields on eight existing
+// SLEs. For each it asserts (a) Decode → Encode is byte-identical to the
+// canonical binarycodec output (which is rippled's wire format), and (b) the
+// SHAMap account-state leaf hash matches sha512Half(prefix || bytes || index).
+// Because the typed encoder reproduces the canonical bytes exactly, a matching
+// blob implies a matching ledger hash for the same slot.
+func TestRoundTrip_V3SchemaFields(t *testing.T) {
+	const (
+		acctA = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+		acctB = "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn"
+		hashX = "00000000000000000000000000000000000000000000000000000000000000AB"
+		hashY = "00000000000000000000000000000000000000000000000000000000000000CD"
+		hashZ = "00000000000000000000000000000000000000000000000000000000000000EF"
+		zero  = "0000000000000000000000000000000000000000000000000000000000000000"
+	)
+
+	cases := []struct {
+		name string
+		json map[string]any
+	}{
+		{
+			name: "Escrow_Sequence",
+			json: map[string]any{
+				"LedgerEntryType":   "Escrow",
+				"Account":           acctA,
+				"Sequence":          uint32(42),
+				"Destination":       acctB,
+				"Amount":            "1000000",
+				"OwnerNode":         "0",
+				"Flags":             uint32(0),
+				"PreviousTxnID":     zero,
+				"PreviousTxnLgrSeq": uint32(1),
+			},
+		},
+		{
+			name: "PayChannel_Sequence",
+			json: map[string]any{
+				"LedgerEntryType":   "PayChannel",
+				"Account":           acctA,
+				"Destination":       acctB,
+				"Sequence":          uint32(7),
+				"Amount":            "1000000",
+				"Balance":           "0",
+				"PublicKey":         "ED0000000000000000000000000000000000000000000000000000000000000001",
+				"SettleDelay":       uint32(60),
+				"OwnerNode":         "0",
+				"Flags":             uint32(0),
+				"PreviousTxnID":     zero,
+				"PreviousTxnLgrSeq": uint32(1),
+			},
+		},
+		{
+			name: "SignerList_Owner",
+			json: map[string]any{
+				"LedgerEntryType": "SignerList",
+				"Flags":           uint32(0),
+				"Owner":           acctA,
+				"OwnerNode":       "0",
+				"SignerQuorum":    uint32(1),
+				"SignerEntries": []any{
+					map[string]any{
+						"SignerEntry": map[string]any{
+							"Account":      acctB,
+							"SignerWeight": uint32(1),
+						},
+					},
+				},
+				"SignerListID":      uint32(0),
+				"PreviousTxnID":     zero,
+				"PreviousTxnLgrSeq": uint32(1),
+			},
+		},
+		{
+			name: "AccountRoot_PseudoAccountDesignators",
+			json: map[string]any{
+				"LedgerEntryType":   "AccountRoot",
+				"Account":           acctA,
+				"Balance":           "1000000",
+				"Sequence":          uint32(1),
+				"OwnerCount":        uint32(0),
+				"Flags":             uint32(0),
+				"AMMID":             hashX,
+				"VaultID":           hashY,
+				"LoanBrokerID":      hashZ,
+				"PreviousTxnID":     zero,
+				"PreviousTxnLgrSeq": uint32(1),
+			},
+		},
+		{
+			name: "MPTokenIssuance_MutableFlags",
+			json: map[string]any{
+				"LedgerEntryType":   "MPTokenIssuance",
+				"Issuer":            acctA,
+				"Sequence":          uint32(1),
+				"OutstandingAmount": "0",
+				"OwnerNode":         "0",
+				"MutableFlags":      uint32(2),
+				"Flags":             uint32(0),
+				"PreviousTxnID":     zero,
+				"PreviousTxnLgrSeq": uint32(1),
+			},
+		},
+		{
+			name: "Oracle_OracleDocumentID",
+			json: map[string]any{
+				"LedgerEntryType":   "Oracle",
+				"Owner":             acctA,
+				"OracleDocumentID":  uint32(5),
+				"Provider":          "DEADBEEF",
+				"AssetClass":        "0123",
+				"LastUpdateTime":    uint32(123456789),
+				"OwnerNode":         "0",
+				"Flags":             uint32(0),
+				"PreviousTxnID":     zero,
+				"PreviousTxnLgrSeq": uint32(1),
+			},
+		},
+		{
+			name: "Vault_Scale",
+			json: map[string]any{
+				"LedgerEntryType":   "Vault",
+				"Sequence":          uint32(1),
+				"OwnerNode":         "0",
+				"Owner":             acctA,
+				"Account":           acctB,
+				"Asset":             map[string]any{"currency": "XRP"},
+				"ShareMPTID":        "00000001ABCDEF0123456789ABCDEF0123456789ABCDEF12",
+				"WithdrawalPolicy":  uint32(1),
+				"Scale":             uint32(3),
+				"PreviousTxnID":     zero,
+				"PreviousTxnLgrSeq": uint32(1),
+			},
+		},
+		{
+			// Credential.sfSubjectNode became optional in 3.0.0 (PR #5936).
+			// A blob carrying SubjectNode must still round-trip exactly.
+			name: "Credential_SubjectNode_present",
+			json: map[string]any{
+				"LedgerEntryType":   "Credential",
+				"Subject":           acctA,
+				"Issuer":            acctB,
+				"CredentialType":    "ABCD",
+				"IssuerNode":        "0",
+				"SubjectNode":       "0",
+				"Flags":             uint32(0),
+				"PreviousTxnID":     zero,
+				"PreviousTxnLgrSeq": uint32(1),
+			},
+		},
+		{
+			// ...and a blob omitting SubjectNode (the 3.0.0 self-issued case)
+			// must decode without error and re-encode without the field.
+			name: "Credential_SubjectNode_absent",
+			json: map[string]any{
+				"LedgerEntryType":   "Credential",
+				"Subject":           acctA,
+				"Issuer":            acctB,
+				"CredentialType":    "ABCD",
+				"IssuerNode":        "0",
+				"Flags":             uint32(0),
+				"PreviousTxnID":     zero,
+				"PreviousTxnLgrSeq": uint32(1),
+			},
+		},
+	}
+
+	var index [32]byte
+	for i := range index {
+		index[i] = byte(i + 1)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			canonical, err := binarycodec.EncodeBytes(tc.json)
+			if err != nil {
+				t.Fatalf("binarycodec.EncodeBytes: %v", err)
+			}
+
+			entry := New(tc.json["LedgerEntryType"].(string))
+			if entry == nil {
+				t.Fatalf("no typed entry registered for %q", tc.json["LedgerEntryType"])
+			}
+			if err := entry.Decode(canonical); err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+
+			enc := entry.(interface {
+				Encode() ([]byte, error)
+				Hash(index [32]byte) ([32]byte, error)
+			})
+			got, err := enc.Encode()
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			if !bytes.Equal(got, canonical) {
+				t.Fatalf("round-trip mismatch:\ncanonical: %x\nencoded:   %x", canonical, got)
+			}
+
+			expectedHash := common.Sha512Half(protocol.HashPrefixLeafNode[:], canonical, index[:])
+			gotHash, err := enc.Hash(index)
+			if err != nil {
+				t.Fatalf("Hash: %v", err)
+			}
+			if gotHash != expectedHash {
+				t.Fatalf("hash mismatch:\nexpected: %x\ngot:      %x", expectedHash, gotHash)
+			}
+		})
+	}
+}

--- a/internal/tx/ledgerfields/escrow_gen.go
+++ b/internal/tx/ledgerfields/escrow_gen.go
@@ -25,6 +25,7 @@ type Escrow struct {
 	Account           string // AccountID (base58)
 	Destination       string // AccountID (base58)
 	Amount            any    // Amount (XRP string | IOU map)
+	Sequence          uint32
 	Condition         string // Blob (uppercase hex)
 	CancelAfter       uint32
 	FinishAfter       uint32
@@ -43,6 +44,7 @@ const (
 	escrowBitAccount uint64 = 1 << iota
 	escrowBitDestination
 	escrowBitAmount
+	escrowBitSequence
 	escrowBitCondition
 	escrowBitCancelAfter
 	escrowBitFinishAfter
@@ -92,6 +94,9 @@ func (e *Escrow) Decode(data []byte) error {
 			case 3:
 				e.SourceTag = val
 				e.present |= escrowBitSourceTag
+			case 4:
+				e.Sequence = val
+				e.present |= escrowBitSequence
 			case 5:
 				e.PreviousTxnLgrSeq = val
 				e.present |= escrowBitPreviousTxnLgrSeq
@@ -207,6 +212,9 @@ func (e *Escrow) emitAll(out map[string]any, skipDefault bool) {
 	if e.present&escrowBitAmount != 0 {
 		out["Amount"] = e.Amount
 	}
+	if e.present&escrowBitSequence != 0 && !(skipDefault && e.Sequence == 0) {
+		out["Sequence"] = e.Sequence
+	}
 	if e.present&escrowBitCondition != 0 && !(skipDefault && e.Condition == "") {
 		out["Condition"] = e.Condition
 	}
@@ -261,6 +269,7 @@ func (e *Escrow) EmitPreviousFields(prev Entry, out map[string]any) {
 	emitIfChangedString(out, "Account", p.Account, e.Account, p.present&escrowBitAccount, e.present&escrowBitAccount)
 	emitIfChangedString(out, "Destination", p.Destination, e.Destination, p.present&escrowBitDestination, e.present&escrowBitDestination)
 	emitIfChangedAmount(out, "Amount", p.Amount, e.Amount, p.present&escrowBitAmount, e.present&escrowBitAmount)
+	emitIfChangedUint32(out, "Sequence", p.Sequence, e.Sequence, p.present&escrowBitSequence, e.present&escrowBitSequence)
 	emitIfChangedString(out, "Condition", p.Condition, e.Condition, p.present&escrowBitCondition, e.present&escrowBitCondition)
 	emitIfChangedUint32(out, "CancelAfter", p.CancelAfter, e.CancelAfter, p.present&escrowBitCancelAfter, e.present&escrowBitCancelAfter)
 	emitIfChangedUint32(out, "FinishAfter", p.FinishAfter, e.FinishAfter, p.present&escrowBitFinishAfter, e.present&escrowBitFinishAfter)
@@ -287,6 +296,9 @@ func (e *Escrow) EmitChangeOrigFields(out map[string]any) {
 	}
 	if e.present&escrowBitAmount != 0 {
 		out["Amount"] = e.Amount
+	}
+	if e.present&escrowBitSequence != 0 {
+		out["Sequence"] = e.Sequence
 	}
 	if e.present&escrowBitCondition != 0 {
 		out["Condition"] = e.Condition
@@ -367,6 +379,9 @@ func (e *Escrow) ToMap() map[string]any {
 	}
 	if e.present&escrowBitAmount != 0 {
 		out["Amount"] = e.Amount
+	}
+	if e.present&escrowBitSequence != 0 {
+		out["Sequence"] = e.Sequence
 	}
 	if e.present&escrowBitCondition != 0 {
 		out["Condition"] = e.Condition

--- a/internal/tx/ledgerfields/mp_token_issuance_gen.go
+++ b/internal/tx/ledgerfields/mp_token_issuance_gen.go
@@ -30,6 +30,7 @@ type MPTokenIssuance struct {
 	MaximumAmount     string // UInt64 (decimal string, sMD_BaseTen)
 	OutstandingAmount string // UInt64 (decimal string, sMD_BaseTen)
 	LockedAmount      string // UInt64 (decimal string, sMD_BaseTen)
+	MutableFlags      uint32
 	MPTokenMetadata   string // Blob (uppercase hex)
 	DomainID          string // Hash256 (uppercase hex)
 	Flags             uint32
@@ -46,6 +47,7 @@ const (
 	mptokenissuanceBitMaximumAmount
 	mptokenissuanceBitOutstandingAmount
 	mptokenissuanceBitLockedAmount
+	mptokenissuanceBitMutableFlags
 	mptokenissuanceBitMPTokenMetadata
 	mptokenissuanceBitDomainID
 	mptokenissuanceBitFlags
@@ -94,6 +96,9 @@ func (m *MPTokenIssuance) Decode(data []byte) error {
 			case 5:
 				m.PreviousTxnLgrSeq = val
 				m.present |= mptokenissuanceBitPreviousTxnLgrSeq
+			case 53:
+				m.MutableFlags = val
+				m.present |= mptokenissuanceBitMutableFlags
 			default:
 				return newErrUnknownField("MPTokenIssuance", typeCode, fieldCode)
 			}
@@ -217,6 +222,9 @@ func (m *MPTokenIssuance) emitAll(out map[string]any, skipDefault bool) {
 	if m.present&mptokenissuanceBitLockedAmount != 0 && !(skipDefault && isZeroHexString(m.LockedAmount)) {
 		out["LockedAmount"] = m.LockedAmount
 	}
+	if m.present&mptokenissuanceBitMutableFlags != 0 && !(skipDefault && m.MutableFlags == 0) {
+		out["MutableFlags"] = m.MutableFlags
+	}
 	if m.present&mptokenissuanceBitMPTokenMetadata != 0 && !(skipDefault && m.MPTokenMetadata == "") {
 		out["MPTokenMetadata"] = m.MPTokenMetadata
 	}
@@ -255,6 +263,7 @@ func (m *MPTokenIssuance) EmitPreviousFields(prev Entry, out map[string]any) {
 	emitIfChangedString(out, "MaximumAmount", p.MaximumAmount, m.MaximumAmount, p.present&mptokenissuanceBitMaximumAmount, m.present&mptokenissuanceBitMaximumAmount)
 	emitIfChangedString(out, "OutstandingAmount", p.OutstandingAmount, m.OutstandingAmount, p.present&mptokenissuanceBitOutstandingAmount, m.present&mptokenissuanceBitOutstandingAmount)
 	emitIfChangedString(out, "LockedAmount", p.LockedAmount, m.LockedAmount, p.present&mptokenissuanceBitLockedAmount, m.present&mptokenissuanceBitLockedAmount)
+	emitIfChangedUint32(out, "MutableFlags", p.MutableFlags, m.MutableFlags, p.present&mptokenissuanceBitMutableFlags, m.present&mptokenissuanceBitMutableFlags)
 	emitIfChangedString(out, "MPTokenMetadata", p.MPTokenMetadata, m.MPTokenMetadata, p.present&mptokenissuanceBitMPTokenMetadata, m.present&mptokenissuanceBitMPTokenMetadata)
 	emitIfChangedString(out, "DomainID", p.DomainID, m.DomainID, p.present&mptokenissuanceBitDomainID, m.present&mptokenissuanceBitDomainID)
 	emitIfChangedUint32(out, "Flags", p.Flags, m.Flags, p.present&mptokenissuanceBitFlags, m.present&mptokenissuanceBitFlags)
@@ -289,6 +298,9 @@ func (m *MPTokenIssuance) EmitChangeOrigFields(out map[string]any) {
 	}
 	if m.present&mptokenissuanceBitLockedAmount != 0 {
 		out["LockedAmount"] = m.LockedAmount
+	}
+	if m.present&mptokenissuanceBitMutableFlags != 0 {
+		out["MutableFlags"] = m.MutableFlags
 	}
 	if m.present&mptokenissuanceBitMPTokenMetadata != 0 {
 		out["MPTokenMetadata"] = m.MPTokenMetadata
@@ -363,6 +375,9 @@ func (m *MPTokenIssuance) ToMap() map[string]any {
 	}
 	if m.present&mptokenissuanceBitLockedAmount != 0 {
 		out["LockedAmount"] = m.LockedAmount
+	}
+	if m.present&mptokenissuanceBitMutableFlags != 0 {
+		out["MutableFlags"] = m.MutableFlags
 	}
 	if m.present&mptokenissuanceBitMPTokenMetadata != 0 {
 		out["MPTokenMetadata"] = m.MPTokenMetadata

--- a/internal/tx/ledgerfields/oracle_gen.go
+++ b/internal/tx/ledgerfields/oracle_gen.go
@@ -24,6 +24,7 @@ type Oracle struct {
 	present           uint64
 	Owner             string // AccountID (base58)
 	Provider          string // Blob (uppercase hex)
+	OracleDocumentID  uint32
 	PriceDataSeries   []any
 	AssetClass        string // Blob (uppercase hex)
 	LastUpdateTime    uint32
@@ -37,6 +38,7 @@ type Oracle struct {
 const (
 	oracleBitOwner uint64 = 1 << iota
 	oracleBitProvider
+	oracleBitOracleDocumentID
 	oracleBitPriceDataSeries
 	oracleBitAssetClass
 	oracleBitLastUpdateTime
@@ -85,6 +87,9 @@ func (o *Oracle) Decode(data []byte) error {
 			case 15:
 				o.LastUpdateTime = val
 				o.present |= oracleBitLastUpdateTime
+			case 51:
+				o.OracleDocumentID = val
+				o.present |= oracleBitOracleDocumentID
 			default:
 				return newErrUnknownField("Oracle", typeCode, fieldCode)
 			}
@@ -171,6 +176,9 @@ func (o *Oracle) emitAll(out map[string]any, skipDefault bool) {
 	if o.present&oracleBitProvider != 0 && !(skipDefault && o.Provider == "") {
 		out["Provider"] = o.Provider
 	}
+	if o.present&oracleBitOracleDocumentID != 0 && !(skipDefault && o.OracleDocumentID == 0) {
+		out["OracleDocumentID"] = o.OracleDocumentID
+	}
 	if o.present&oracleBitPriceDataSeries != 0 {
 		out["PriceDataSeries"] = o.PriceDataSeries
 	}
@@ -212,6 +220,7 @@ func (o *Oracle) EmitPreviousFields(prev Entry, out map[string]any) {
 	}
 	emitIfChangedString(out, "Owner", p.Owner, o.Owner, p.present&oracleBitOwner, o.present&oracleBitOwner)
 	emitIfChangedString(out, "Provider", p.Provider, o.Provider, p.present&oracleBitProvider, o.present&oracleBitProvider)
+	emitIfChangedUint32(out, "OracleDocumentID", p.OracleDocumentID, o.OracleDocumentID, p.present&oracleBitOracleDocumentID, o.present&oracleBitOracleDocumentID)
 	emitIfChangedDeep(out, "PriceDataSeries", p.PriceDataSeries, o.PriceDataSeries, p.present&oracleBitPriceDataSeries, o.present&oracleBitPriceDataSeries)
 	emitIfChangedString(out, "AssetClass", p.AssetClass, o.AssetClass, p.present&oracleBitAssetClass, o.present&oracleBitAssetClass)
 	emitIfChangedUint32(out, "LastUpdateTime", p.LastUpdateTime, o.LastUpdateTime, p.present&oracleBitLastUpdateTime, o.present&oracleBitLastUpdateTime)
@@ -231,6 +240,9 @@ func (o *Oracle) EmitChangeOrigFields(out map[string]any) {
 	}
 	if o.present&oracleBitProvider != 0 {
 		out["Provider"] = o.Provider
+	}
+	if o.present&oracleBitOracleDocumentID != 0 {
+		out["OracleDocumentID"] = o.OracleDocumentID
 	}
 	if o.present&oracleBitPriceDataSeries != 0 {
 		out["PriceDataSeries"] = o.PriceDataSeries
@@ -296,6 +308,9 @@ func (o *Oracle) ToMap() map[string]any {
 	}
 	if o.present&oracleBitProvider != 0 {
 		out["Provider"] = o.Provider
+	}
+	if o.present&oracleBitOracleDocumentID != 0 {
+		out["OracleDocumentID"] = o.OracleDocumentID
 	}
 	if o.present&oracleBitPriceDataSeries != 0 {
 		out["PriceDataSeries"] = o.PriceDataSeries

--- a/internal/tx/ledgerfields/pay_channel_gen.go
+++ b/internal/tx/ledgerfields/pay_channel_gen.go
@@ -26,6 +26,7 @@ type PayChannel struct {
 	Destination       string // AccountID (base58)
 	Amount            any    // Amount (XRP string | IOU map)
 	Balance           any    // Amount (XRP string | IOU map)
+	Sequence          uint32
 	PublicKey         string // Blob (uppercase hex)
 	SettleDelay       uint32
 	Expiration        uint32
@@ -44,6 +45,7 @@ const (
 	paychannelBitDestination
 	paychannelBitAmount
 	paychannelBitBalance
+	paychannelBitSequence
 	paychannelBitPublicKey
 	paychannelBitSettleDelay
 	paychannelBitExpiration
@@ -92,6 +94,9 @@ func (p *PayChannel) Decode(data []byte) error {
 			case 3:
 				p.SourceTag = val
 				p.present |= paychannelBitSourceTag
+			case 4:
+				p.Sequence = val
+				p.present |= paychannelBitSequence
 			case 5:
 				p.PreviousTxnLgrSeq = val
 				p.present |= paychannelBitPreviousTxnLgrSeq
@@ -206,6 +211,9 @@ func (p *PayChannel) emitAll(out map[string]any, skipDefault bool) {
 	if p.present&paychannelBitBalance != 0 {
 		out["Balance"] = p.Balance
 	}
+	if p.present&paychannelBitSequence != 0 && !(skipDefault && p.Sequence == 0) {
+		out["Sequence"] = p.Sequence
+	}
 	if p.present&paychannelBitPublicKey != 0 && !(skipDefault && p.PublicKey == "") {
 		out["PublicKey"] = p.PublicKey
 	}
@@ -258,6 +266,7 @@ func (p *PayChannel) EmitPreviousFields(prev Entry, out map[string]any) {
 	emitIfChangedString(out, "Destination", p.Destination, p.Destination, p.present&paychannelBitDestination, p.present&paychannelBitDestination)
 	emitIfChangedAmount(out, "Amount", p.Amount, p.Amount, p.present&paychannelBitAmount, p.present&paychannelBitAmount)
 	emitIfChangedAmount(out, "Balance", p.Balance, p.Balance, p.present&paychannelBitBalance, p.present&paychannelBitBalance)
+	emitIfChangedUint32(out, "Sequence", p.Sequence, p.Sequence, p.present&paychannelBitSequence, p.present&paychannelBitSequence)
 	emitIfChangedString(out, "PublicKey", p.PublicKey, p.PublicKey, p.present&paychannelBitPublicKey, p.present&paychannelBitPublicKey)
 	emitIfChangedUint32(out, "SettleDelay", p.SettleDelay, p.SettleDelay, p.present&paychannelBitSettleDelay, p.present&paychannelBitSettleDelay)
 	emitIfChangedUint32(out, "Expiration", p.Expiration, p.Expiration, p.present&paychannelBitExpiration, p.present&paychannelBitExpiration)
@@ -286,6 +295,9 @@ func (p *PayChannel) EmitChangeOrigFields(out map[string]any) {
 	}
 	if p.present&paychannelBitBalance != 0 {
 		out["Balance"] = p.Balance
+	}
+	if p.present&paychannelBitSequence != 0 {
+		out["Sequence"] = p.Sequence
 	}
 	if p.present&paychannelBitPublicKey != 0 {
 		out["PublicKey"] = p.PublicKey
@@ -366,6 +378,9 @@ func (p *PayChannel) ToMap() map[string]any {
 	}
 	if p.present&paychannelBitBalance != 0 {
 		out["Balance"] = p.Balance
+	}
+	if p.present&paychannelBitSequence != 0 {
+		out["Sequence"] = p.Sequence
 	}
 	if p.present&paychannelBitPublicKey != 0 {
 		out["PublicKey"] = p.PublicKey

--- a/internal/tx/ledgerfields/signer_list_gen.go
+++ b/internal/tx/ledgerfields/signer_list_gen.go
@@ -23,6 +23,7 @@ func init() {
 type SignerList struct {
 	present           uint64
 	Account           string // AccountID (base58)
+	Owner             string // AccountID (base58)
 	OwnerNode         string // UInt64 (lowercase hex, no leading zeros)
 	SignerQuorum      uint32
 	SignerEntries     []any
@@ -34,6 +35,7 @@ type SignerList struct {
 
 const (
 	signerlistBitAccount uint64 = 1 << iota
+	signerlistBitOwner
 	signerlistBitOwnerNode
 	signerlistBitSignerQuorum
 	signerlistBitSignerEntries
@@ -120,6 +122,9 @@ func (s *SignerList) Decode(data []byte) error {
 			case 1:
 				s.Account = val
 				s.present |= signerlistBitAccount
+			case 2:
+				s.Owner = val
+				s.present |= signerlistBitOwner
 			default:
 				return newErrUnknownField("SignerList", typeCode, fieldCode)
 			}
@@ -148,6 +153,9 @@ func (s *SignerList) Decode(data []byte) error {
 func (s *SignerList) emitAll(out map[string]any, skipDefault bool) {
 	if s.present&signerlistBitAccount != 0 && !(skipDefault && s.Account == "") {
 		out["Account"] = s.Account
+	}
+	if s.present&signerlistBitOwner != 0 && !(skipDefault && s.Owner == "") {
+		out["Owner"] = s.Owner
 	}
 	if s.present&signerlistBitOwnerNode != 0 && !(skipDefault && isZeroHexString(s.OwnerNode)) {
 		out["OwnerNode"] = s.OwnerNode
@@ -186,6 +194,7 @@ func (s *SignerList) EmitPreviousFields(prev Entry, out map[string]any) {
 		return
 	}
 	emitIfChangedString(out, "Account", p.Account, s.Account, p.present&signerlistBitAccount, s.present&signerlistBitAccount)
+	emitIfChangedString(out, "Owner", p.Owner, s.Owner, p.present&signerlistBitOwner, s.present&signerlistBitOwner)
 	emitIfChangedString(out, "OwnerNode", p.OwnerNode, s.OwnerNode, p.present&signerlistBitOwnerNode, s.present&signerlistBitOwnerNode)
 	emitIfChangedUint32(out, "SignerQuorum", p.SignerQuorum, s.SignerQuorum, p.present&signerlistBitSignerQuorum, s.present&signerlistBitSignerQuorum)
 	emitIfChangedDeep(out, "SignerEntries", p.SignerEntries, s.SignerEntries, p.present&signerlistBitSignerEntries, s.present&signerlistBitSignerEntries)
@@ -201,6 +210,9 @@ func (s *SignerList) EmitPreviousFields(prev Entry, out map[string]any) {
 func (s *SignerList) EmitChangeOrigFields(out map[string]any) {
 	if s.present&signerlistBitAccount != 0 {
 		out["Account"] = s.Account
+	}
+	if s.present&signerlistBitOwner != 0 {
+		out["Owner"] = s.Owner
 	}
 	if s.present&signerlistBitOwnerNode != 0 {
 		out["OwnerNode"] = s.OwnerNode
@@ -260,6 +272,9 @@ func (s *SignerList) ToMap() map[string]any {
 	}
 	if s.present&signerlistBitAccount != 0 {
 		out["Account"] = s.Account
+	}
+	if s.present&signerlistBitOwner != 0 {
+		out["Owner"] = s.Owner
 	}
 	if s.present&signerlistBitOwnerNode != 0 {
 		out["OwnerNode"] = s.OwnerNode

--- a/internal/tx/ledgerfields/spec/spec.go
+++ b/internal/tx/ledgerfields/spec/spec.go
@@ -228,7 +228,7 @@ var Specs = []Entry{
 			// Account is go-xrpl-specific (rippled's macro doesn't list it;
 			// the serializer in internal/ledger/state/signer_list.go emits
 			// it for owner-account tracking). Owner (sfOwner) is the
-			// rippled-3.0.0 optional designator for pseudo-account-owned
+			// rippled optional designator for pseudo-account-owned
 			// signer lists.
 			{Name: "Account"},
 			{Name: "Owner"},

--- a/internal/tx/ledgerfields/spec/spec.go
+++ b/internal/tx/ledgerfields/spec/spec.go
@@ -83,6 +83,7 @@ var Specs = []Entry{
 			{Name: "TicketCount"},
 			{Name: "AMMID"},
 			{Name: "VaultID"},
+			{Name: "LoanBrokerID"},
 			{Name: "WalletSize"},
 			{Name: "PreviousTxnID", Meta: MetaDeleteFinal},
 			{Name: "PreviousTxnLgrSeq", Meta: MetaDeleteFinal},
@@ -226,8 +227,11 @@ var Specs = []Entry{
 		Fields: []Field{
 			// Account is go-xrpl-specific (rippled's macro doesn't list it;
 			// the serializer in internal/ledger/state/signer_list.go emits
-			// it for owner-account tracking).
+			// it for owner-account tracking). Owner (sfOwner) is the
+			// rippled-3.0.0 optional designator for pseudo-account-owned
+			// signer lists.
 			{Name: "Account"},
+			{Name: "Owner"},
 			{Name: "OwnerNode"},
 			{Name: "SignerQuorum"},
 			{Name: "SignerEntries"},
@@ -339,6 +343,7 @@ var Specs = []Entry{
 			{Name: "Account"},
 			{Name: "Destination"},
 			{Name: "Amount"},
+			{Name: "Sequence"},
 			{Name: "Condition"},
 			{Name: "CancelAfter"},
 			{Name: "FinishAfter"},
@@ -360,6 +365,7 @@ var Specs = []Entry{
 			{Name: "Destination"},
 			{Name: "Amount"},
 			{Name: "Balance"},
+			{Name: "Sequence"},
 			{Name: "PublicKey"},
 			{Name: "SettleDelay"},
 			{Name: "Expiration"},
@@ -399,6 +405,7 @@ var Specs = []Entry{
 			{Name: "MaximumAmount"},
 			{Name: "OutstandingAmount"},
 			{Name: "LockedAmount"},
+			{Name: "MutableFlags"},
 			{Name: "MPTokenMetadata"},
 			{Name: "DomainID"},
 			{Name: "Flags"},
@@ -429,6 +436,7 @@ var Specs = []Entry{
 		Fields: []Field{
 			{Name: "Owner"},
 			{Name: "Provider"},
+			{Name: "OracleDocumentID"},
 			{Name: "PriceDataSeries"},
 			{Name: "AssetClass"},
 			{Name: "LastUpdateTime"},
@@ -493,6 +501,7 @@ var Specs = []Entry{
 			{Name: "LossUnrealized"},
 			{Name: "ShareMPTID"},
 			{Name: "WithdrawalPolicy"},
+			{Name: "Scale"},
 			{Name: "PreviousTxnID", Meta: MetaDeleteFinal},
 			{Name: "PreviousTxnLgrSeq", Meta: MetaDeleteFinal},
 		},

--- a/internal/tx/ledgerfields/vault_gen.go
+++ b/internal/tx/ledgerfields/vault_gen.go
@@ -34,6 +34,7 @@ type Vault struct {
 	LossUnrealized    any
 	ShareMPTID        string
 	WithdrawalPolicy  int
+	Scale             int
 	PreviousTxnID     string // Hash256 (uppercase hex)
 	PreviousTxnLgrSeq uint32
 }
@@ -51,6 +52,7 @@ const (
 	vaultBitLossUnrealized
 	vaultBitShareMPTID
 	vaultBitWithdrawalPolicy
+	vaultBitScale
 	vaultBitPreviousTxnID
 	vaultBitPreviousTxnLgrSeq
 )
@@ -172,6 +174,9 @@ func (v *Vault) Decode(data []byte) error {
 			}
 			val := int(byteVal)
 			switch fieldCode {
+			case 4:
+				v.Scale = val
+				v.present |= vaultBitScale
 			case 20:
 				v.WithdrawalPolicy = val
 				v.present |= vaultBitWithdrawalPolicy
@@ -249,6 +254,9 @@ func (v *Vault) emitAll(out map[string]any, skipDefault bool) {
 	if v.present&vaultBitWithdrawalPolicy != 0 && !(skipDefault && v.WithdrawalPolicy == 0) {
 		out["WithdrawalPolicy"] = v.WithdrawalPolicy
 	}
+	if v.present&vaultBitScale != 0 && !(skipDefault && v.Scale == 0) {
+		out["Scale"] = v.Scale
+	}
 }
 
 // EmitNewFields emits fields for a CreatedNode (sMD_Create | sMD_Always),
@@ -282,6 +290,7 @@ func (v *Vault) EmitPreviousFields(prev Entry, out map[string]any) {
 	emitIfChangedDeep(out, "LossUnrealized", p.LossUnrealized, v.LossUnrealized, p.present&vaultBitLossUnrealized, v.present&vaultBitLossUnrealized)
 	emitIfChangedString(out, "ShareMPTID", p.ShareMPTID, v.ShareMPTID, p.present&vaultBitShareMPTID, v.present&vaultBitShareMPTID)
 	emitIfChangedInt(out, "WithdrawalPolicy", p.WithdrawalPolicy, v.WithdrawalPolicy, p.present&vaultBitWithdrawalPolicy, v.present&vaultBitWithdrawalPolicy)
+	emitIfChangedInt(out, "Scale", p.Scale, v.Scale, p.present&vaultBitScale, v.present&vaultBitScale)
 }
 
 // EmitChangeOrigFields writes the names of every present field carrying
@@ -325,6 +334,9 @@ func (v *Vault) EmitChangeOrigFields(out map[string]any) {
 	}
 	if v.present&vaultBitWithdrawalPolicy != 0 {
 		out["WithdrawalPolicy"] = v.WithdrawalPolicy
+	}
+	if v.present&vaultBitScale != 0 {
+		out["Scale"] = v.Scale
 	}
 }
 
@@ -402,6 +414,9 @@ func (v *Vault) ToMap() map[string]any {
 	}
 	if v.present&vaultBitWithdrawalPolicy != 0 {
 		out["WithdrawalPolicy"] = v.WithdrawalPolicy
+	}
+	if v.present&vaultBitScale != 0 {
+		out["Scale"] = v.Scale
 	}
 	if v.present&vaultBitPreviousTxnID != 0 {
 		out["PreviousTxnID"] = v.PreviousTxnID

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -512,6 +512,13 @@ func (o *OracleSet) doApplyUpdate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 		existingOracle.URI = o.URI
 	}
 
+	// On update, set sfOracleDocumentID only when absent (rippled never rewrites
+	// an existing one). Reference: rippled SetOracle.cpp:265-269
+	if !existingOracle.HasOracleDocumentID && ctx.Rules().Enabled(amendment.FeatureFixIncludeKeyletFields) {
+		existingOracle.OracleDocumentID = o.OracleDocumentID
+		existingOracle.HasOracleDocumentID = true
+	}
+
 	// Adjust OwnerCount
 	newCount := 1
 	if len(updatedSeries) > 5 {
@@ -598,6 +605,13 @@ func (o *OracleSet) doApplyCreate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 		AssetClass:      o.AssetClass,
 		LastUpdateTime:  o.LastUpdateTime,
 		PriceDataSeries: series,
+	}
+
+	// sfOracleDocumentID (used in keylet::oracle) is stored only under
+	// fixIncludeKeyletFields. Reference: rippled SetOracle.cpp:282-286
+	if ctx.Rules().Enabled(amendment.FeatureFixIncludeKeyletFields) {
+		oracleData.OracleDocumentID = o.OracleDocumentID
+		oracleData.HasOracleDocumentID = true
 	}
 	if o.isFieldPresent("URI") || o.URI != "" {
 		oracleData.URI = o.URI

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -235,6 +235,13 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	}
 	channelSLE.OwnerNode = ownerResult.Page
 
+	// sfSequence (the creating tx's sequence, used in keylet::payChannel) is
+	// stored only under fixIncludeKeyletFields. Reference: rippled PayChan.cpp:294-297
+	if ctx.Rules().Enabled(amendment.FeatureFixIncludeKeyletFields) {
+		channelSLE.Sequence = sequence
+		channelSLE.HasSequence = true
+	}
+
 	// DirInsert into destination directory (if fixPayChanRecipientOwnerDir enabled)
 	// Reference: rippled PayChan.cpp doApply() fixPayChanRecipientOwnerDir
 	if ctx.Rules().Enabled(amendment.FeatureFixPayChanRecipientOwnerDir) {

--- a/internal/tx/signerlist/signer_list_set.go
+++ b/internal/tx/signerlist/signer_list_set.go
@@ -385,7 +385,8 @@ func (s *SignerListSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		return sleEntries[i].Account < sleEntries[j].Account
 	})
 
-	signerListData, err := state.SerializeSignerList(s.SignerQuorum, sleEntries, ctx.AccountID, flags, expandedSignerList)
+	includeKeyletFields := ctx.Rules().Enabled(amendment.FeatureFixIncludeKeyletFields)
+	signerListData, err := state.SerializeSignerList(s.SignerQuorum, sleEntries, ctx.AccountID, flags, expandedSignerList, includeKeyletFields)
 	if err != nil {
 		ctx.Log.Error("signer list set: failed to serialize signer list", "error", err)
 		return tx.TefINTERNAL


### PR DESCRIPTION
## Summary

Phase C of the rippled-3.0.0 parity work (#274): the schema/serialization additions to eight existing ledger entries. Rippled 3.0.0 adds new optional/default fields to these SLEs; a 3.0.0 node must parse and emit them where applicable or the SHAMap hash diverges from the network. Cross-checked against `rippled-3.0.0` @ `7527e35379`.

The work spans go-xrpl's two serialization layers (the issue's `ledger/entry/` file names map onto these in the current tree):

- **Typed layer** — `internal/tx/ledgerfields/spec/spec.go` + regenerated `*_gen.go` (full `Decode`→`Encode`→`Hash` round-trip): adds Escrow/PayChannel `sfSequence`, SignerList `sfOwner`, AccountRoot `sfLoanBrokerID`, MPTokenIssuance `sfMutableFlags`, Oracle `sfOracleDocumentID`, Vault `sfScale`. (Credential `sfSubjectNode` and AccountRoot `sfAMMID`/`sfVaultID` were already present in the spec — `sfSubjectNode` is already optional via the present-bit model, matching the 2.6.2→3.0.0 REQUIRED→OPTIONAL relaxation.)
- **Hand-written state parsers/serializers** — `internal/ledger/state/`: same fields on `EscrowData`, `PayChannelData`, `SignerListInfo`, `AccountRoot`, `OracleData`, `MPTokenIssuanceData`. `AccountRoot.IsPseudoAccount()` now honors `VaultID`/`LoanBrokerID`, mirroring rippled's `sMD_PseudoAccount` designator set (sfAMMID, sfVaultID, sfLoanBrokerID).

New `LoanBroker`/`Loan` entry types are intentionally out of scope (gated by `LendingProtocol`, deferred to v3.1.0).

## Test plan

- [x] `go test ./internal/tx/ledgerfields/...` — per-SLE round-trip (byte-identity vs canonical `binarycodec`) + SHAMap leaf-hash parity for all changed types
- [x] `go test ./internal/ledger/state/...` — round-trip of the state-layer parse/serialize helpers for each new field
- [x] `go test ./internal/tx/... ./internal/ledger/... ./internal/testing/...` — no regressions
- [x] full-module `go build`, `go vet`, `gofmt` clean

Fixes #278