### PR TITLE
fix: record sfDestinationNode on cross-account EscrowCreate (#729)

### DIFF
--- a/internal/testing/escrow/escrow_destination_node_test.go
+++ b/internal/testing/escrow/escrow_destination_node_test.go
@@ -116,3 +116,46 @@ func TestEscrowCreate_CrossAccount_FinishesCleanly(t *testing.T) {
 	require.False(t, env.LedgerEntryExists(keylet.Escrow(alice.ID, seq)),
 		"escrow object should be removed after finish")
 }
+
+// An IOU escrow with a third-party issuer records sfIssuerNode (the page in the
+// issuer's owner directory) alongside sfOwnerNode and sfDestinationNode. Omitting
+// it diverges account_hash exactly as the missing sfDestinationNode did.
+// Reference: rippled Escrow.cpp:576-583 (issuer != account_ && issuer != dest).
+func TestEscrowCreate_SetsIssuerNode_IOU(t *testing.T) {
+	env, gw, alice, bob := setupIOUEscrowEnv(t)
+
+	seq := env.Seq(alice)
+	r := env.Submit(escrow.EscrowCreate(alice, bob, 0).
+		IOUAmount(usd(1000, gw)).
+		FinishTime(env.Now().Add(1 * time.Second)).Build())
+	jtx.RequireTxSuccess(t, r)
+
+	esc := parseEscrowSLE(t, env, alice, seq)
+	require.True(t, esc.HasIssuerNode, "IOU escrow with a third-party issuer must carry sfIssuerNode")
+	require.Equal(t, uint64(0), esc.IssuerNode, "fresh issuer dir → page 0")
+	require.True(t, esc.HasDestNode, "cross-account IOU escrow must also carry sfDestinationNode")
+	require.Equal(t, uint64(0), esc.DestinationNode, "fresh destination dir → page 0")
+	require.Equal(t, uint64(0), esc.OwnerNode, "fresh owner dir → page 0")
+}
+
+// A cross-account IOU escrow finishes cleanly: EscrowFinish reads sfIssuerNode and
+// sfDestinationNode to remove the escrow from the issuer's and destination's owner
+// directories. Reference: rippled Escrow.cpp:1132-1140 (dest), 1175-1183 (issuer).
+func TestEscrowCreate_IOU_FinishesCleanly(t *testing.T) {
+	env, gw, alice, bob := setupIOUEscrowEnv(t)
+
+	seq := env.Seq(alice)
+	r := env.Submit(escrow.EscrowCreate(alice, bob, 0).
+		IOUAmount(usd(1000, gw)).
+		FinishTime(env.Now().Add(1 * time.Second)).Build())
+	jtx.RequireTxSuccess(t, r)
+	require.True(t, parseEscrowSLE(t, env, alice, seq).HasIssuerNode)
+	env.Close()
+
+	// Advance past FinishAfter.
+	env.Close()
+	fin := env.Submit(escrow.EscrowFinish(bob, alice, seq).Build())
+	jtx.RequireTxSuccess(t, fin)
+	require.False(t, env.LedgerEntryExists(keylet.Escrow(alice.ID, seq)),
+		"IOU escrow object should be removed after finish")
+}

--- a/internal/testing/escrow/escrow_destination_node_test.go
+++ b/internal/testing/escrow/escrow_destination_node_test.go
@@ -1,0 +1,118 @@
+// Regression tests for issue #729: EscrowCreate must record sfDestinationNode
+// on the Escrow ledger object for cross-account escrows, and sfOwnerNode must
+// reflect the actual owner-directory page (not a hardcoded 0). Omitting
+// sfDestinationNode changes the Escrow SLE serialization, diverging account_hash
+// from rippled while transaction_hash still matches — a silent consensus fork.
+// Reference: rippled src/xrpld/app/tx/detail/Escrow.cpp:548-584.
+package escrow_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func parseEscrowSLE(t *testing.T, env *jtx.TestEnv, owner *jtx.Account, seq uint32) *state.EscrowData {
+	t.Helper()
+	key := keylet.Escrow(owner.ID, seq)
+	require.True(t, env.LedgerEntryExists(key), "escrow entry should exist")
+	data, err := env.LedgerEntry(key)
+	require.NoError(t, err)
+	esc, err := state.ParseEscrow(data)
+	require.NoError(t, err)
+	return esc
+}
+
+// Cross-account escrow records sfDestinationNode (page 0 for a fresh dir).
+func TestEscrowCreate_SetsDestinationNode_CrossAccount(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	seq := env.Seq(alice)
+	r := env.Submit(escrow.EscrowCreate(alice, bob, xrp(1000)).
+		FinishTime(env.Now().Add(1 * time.Second)).Build())
+	jtx.RequireTxSuccess(t, r)
+
+	esc := parseEscrowSLE(t, env, alice, seq)
+	require.True(t, esc.HasDestNode, "cross-account escrow must carry sfDestinationNode")
+	require.Equal(t, uint64(0), esc.DestinationNode, "fresh destination dir → page 0")
+	require.Equal(t, uint64(0), esc.OwnerNode, "fresh owner dir → page 0")
+}
+
+// Self-escrow (destination == account) must NOT carry sfDestinationNode,
+// mirroring rippled's `if (dest != account_)` guard.
+func TestEscrowCreate_NoDestinationNode_SelfEscrow(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	fund5000(env, alice)
+	env.Close()
+
+	seq := env.Seq(alice)
+	r := env.Submit(escrow.EscrowCreate(alice, alice, xrp(1000)).
+		FinishTime(env.Now().Add(1 * time.Second)).Build())
+	jtx.RequireTxSuccess(t, r)
+
+	esc := parseEscrowSLE(t, env, alice, seq)
+	require.False(t, esc.HasDestNode, "self-escrow must not carry sfDestinationNode")
+}
+
+// When the destination's owner directory paginates, sfDestinationNode must hold
+// the actual page index (proving it is captured from DirInsert, not hardcoded).
+func TestEscrowCreate_DestinationNode_Pagination(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.FundAmount(alice, uint64(xrp(100000)))
+	env.FundAmount(bob, uint64(xrp(100000)))
+	env.Close()
+
+	// A directory page holds 32 entries; the 33rd escrow lands on page 1 of
+	// both alice's and bob's owner directories.
+	const n = 33
+	var lastSeq uint32
+	for i := 0; i < n; i++ {
+		lastSeq = env.Seq(alice)
+		r := env.Submit(escrow.EscrowCreate(alice, bob, xrp(1)).
+			FinishTime(env.Now().Add(1 * time.Second)).Build())
+		jtx.RequireTxSuccess(t, r)
+		env.Close()
+	}
+
+	esc := parseEscrowSLE(t, env, alice, lastSeq)
+	require.True(t, esc.HasDestNode)
+	require.Equal(t, uint64(1), esc.DestinationNode, "33rd escrow → destination dir page 1")
+	require.Equal(t, uint64(1), esc.OwnerNode, "33rd escrow → owner dir page 1")
+}
+
+// A cross-account escrow created with sfDestinationNode must finish cleanly:
+// EscrowFinish reads sfDestinationNode to remove the escrow from the
+// destination's owner directory.
+func TestEscrowCreate_CrossAccount_FinishesCleanly(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	seq := env.Seq(alice)
+	r := env.Submit(escrow.EscrowCreate(alice, bob, xrp(1000)).
+		FinishTime(env.Now().Add(1 * time.Second)).Build())
+	jtx.RequireTxSuccess(t, r)
+	require.True(t, parseEscrowSLE(t, env, alice, seq).HasDestNode)
+	env.Close()
+
+	// Advance past FinishAfter.
+	env.Close()
+	fin := env.Submit(escrow.EscrowFinish(bob, alice, seq).Build())
+	jtx.RequireTxSuccess(t, fin)
+	require.False(t, env.LedgerEntryExists(keylet.Escrow(alice.ID, seq)),
+		"escrow object should be removed after finish")
+}

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -325,7 +325,6 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// inserts must precede serialization. DirInsert only references the escrow
 	// key (not the object), so the ordering is equivalent.
 
-	// Owner directory: insert escrow into owner's directory.
 	// Reference: rippled Escrow.cpp:550-559
 	ownerDirKey := keylet.OwnerDir(accountID)
 	ownerResult, err := state.DirInsert(ctx.View, ownerDirKey, escrowKey.Key, false, func(dir *state.DirectoryNode) {
@@ -378,7 +377,6 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Serialize the escrow now that all directory page indices are known.
 	escrowData, err := serializeEscrow(e, accountID, destID, sequence, capturedTransferRate,
 		ownerNode, destNode, hasDestNode, issuerNode, hasIssuerNode)
 	if err != nil {

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -317,8 +317,70 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Serialize escrow
-	escrowData, err := serializeEscrow(e, accountID, destID, sequence, capturedTransferRate)
+	// Insert the escrow into the owner directories BEFORE serializing it, so
+	// the page indices are known and can be recorded on the Escrow object as
+	// sfOwnerNode / sfDestinationNode / sfIssuerNode. rippled inserts the SLE
+	// first and then mutates these node fields on it (Escrow.cpp:548-584);
+	// because goXRPL serializes the SLE to bytes up front, the directory
+	// inserts must precede serialization. DirInsert only references the escrow
+	// key (not the object), so the ordering is equivalent.
+
+	// Owner directory: insert escrow into owner's directory.
+	// Reference: rippled Escrow.cpp:550-559
+	ownerDirKey := keylet.OwnerDir(accountID)
+	ownerResult, err := state.DirInsert(ctx.View, ownerDirKey, escrowKey.Key, false, func(dir *state.DirectoryNode) {
+		dir.Owner = accountID
+	})
+	if err != nil {
+		ctx.Log.Error("escrow create: owner directory full", "error", err)
+		return tx.TecDIR_FULL
+	}
+	ownerNode := ownerResult.Page
+
+	// If cross-account, insert into destination's owner directory and record the
+	// page in sfDestinationNode. Without it the Escrow SLE serializes differently
+	// from rippled, diverging account_hash (issue #729). Note: rippled does NOT
+	// increment the destination's OwnerCount for XRP escrows — only the creator's.
+	// Reference: rippled Escrow.cpp:561-570
+	var destNode uint64
+	var hasDestNode bool
+	if destID != accountID {
+		destDirKey := keylet.OwnerDir(destID)
+		destResult, derr := state.DirInsert(ctx.View, destDirKey, escrowKey.Key, false, func(dir *state.DirectoryNode) {
+			dir.Owner = destID
+		})
+		if derr != nil {
+			ctx.Log.Error("escrow create: destination directory full", "error", derr)
+			return tx.TecDIR_FULL
+		}
+		destNode = destResult.Page
+		hasDestNode = true
+	}
+
+	// For IOU escrows, also insert into the issuer's owner directory and record
+	// the page in sfIssuerNode. This helps track the total locked balance.
+	// Reference: rippled Escrow.cpp:572-584
+	var issuerNode uint64
+	var hasIssuerNode bool
+	if !isNative && !e.Amount.IsMPT() {
+		issuerID, issuerErr := state.DecodeAccountID(e.Amount.Issuer)
+		if issuerErr == nil && issuerID != accountID && issuerID != destID {
+			issuerDirKey := keylet.OwnerDir(issuerID)
+			issuerResult, ierr := state.DirInsert(ctx.View, issuerDirKey, escrowKey.Key, false, func(dir *state.DirectoryNode) {
+				dir.Owner = issuerID
+			})
+			if ierr != nil {
+				ctx.Log.Error("escrow create: issuer directory full", "error", ierr)
+				return tx.TecDIR_FULL
+			}
+			issuerNode = issuerResult.Page
+			hasIssuerNode = true
+		}
+	}
+
+	// Serialize the escrow now that all directory page indices are known.
+	escrowData, err := serializeEscrow(e, accountID, destID, sequence, capturedTransferRate,
+		ownerNode, destNode, hasDestNode, issuerNode, hasIssuerNode)
 	if err != nil {
 		ctx.Log.Error("escrow create: failed to serialize escrow", "error", err)
 		return tx.TefINTERNAL
@@ -328,49 +390,6 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	if err := ctx.View.Insert(escrowKey, escrowData); err != nil {
 		ctx.Log.Error("escrow create: failed to insert escrow", "error", err)
 		return tx.TefINTERNAL
-	}
-
-	// Owner directory: insert escrow into owner's directory
-	// Reference: rippled Escrow.cpp:550-558
-	ownerDirKey := keylet.OwnerDir(accountID)
-	_, err = state.DirInsert(ctx.View, ownerDirKey, escrowKey.Key, false, func(dir *state.DirectoryNode) {
-		dir.Owner = accountID
-	})
-	if err != nil {
-		ctx.Log.Error("escrow create: owner directory full", "error", err)
-		return tx.TecDIR_FULL
-	}
-
-	// If cross-account, insert into destination's owner directory.
-	// Note: rippled does NOT increment the destination's OwnerCount for
-	// XRP escrows. Only the creator's OwnerCount is incremented.
-	// Reference: rippled Escrow.cpp:561-569
-	if destID != accountID {
-		destDirKey := keylet.OwnerDir(destID)
-		_, err = state.DirInsert(ctx.View, destDirKey, escrowKey.Key, false, func(dir *state.DirectoryNode) {
-			dir.Owner = destID
-		})
-		if err != nil {
-			ctx.Log.Error("escrow create: destination directory full", "error", err)
-			return tx.TecDIR_FULL
-		}
-	}
-
-	// For IOU escrows, also insert into the issuer's owner directory.
-	// This helps track the total locked balance.
-	// Reference: rippled Escrow.cpp:575-584
-	if !isNative && !e.Amount.IsMPT() {
-		issuerID, issuerErr := state.DecodeAccountID(e.Amount.Issuer)
-		if issuerErr == nil && issuerID != accountID && issuerID != destID {
-			issuerDirKey := keylet.OwnerDir(issuerID)
-			_, err = state.DirInsert(ctx.View, issuerDirKey, escrowKey.Key, false, func(dir *state.DirectoryNode) {
-				dir.Owner = issuerID
-			})
-			if err != nil {
-				ctx.Log.Error("escrow create: issuer directory full", "error", err)
-				return tx.TecDIR_FULL
-			}
-		}
 	}
 
 	// Deduct the escrow amount from the sender.
@@ -410,7 +429,8 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 // full IOU object (value/currency/issuer). For MPT escrows, Amount is
 // {value, mpt_issuance_id}. transferRate is stored when non-zero and not
 // equal to the parity rate (1_000_000_000).
-func serializeEscrow(txn *EscrowCreate, ownerID, destID [20]byte, sequence uint32, transferRate uint32) ([]byte, error) {
+func serializeEscrow(txn *EscrowCreate, ownerID, destID [20]byte, sequence uint32, transferRate uint32,
+	ownerNode uint64, destNode uint64, hasDestNode bool, issuerNode uint64, hasIssuerNode bool) ([]byte, error) {
 	ownerAddress, err := addresscodec.EncodeAccountIDToClassicAddress(ownerID[:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode owner address: %w", err)
@@ -450,8 +470,19 @@ func serializeEscrow(txn *EscrowCreate, ownerID, destID [20]byte, sequence uint3
 		"Account":         ownerAddress,
 		"Destination":     destAddress,
 		"Amount":          amountVal,
-		"OwnerNode":       "0",
+		"OwnerNode":       fmt.Sprintf("%x", ownerNode),
 		"Flags":           uint32(0),
+	}
+
+	// sfDestinationNode: the page in the destination's owner directory holding
+	// this escrow (cross-account only). sfIssuerNode: the page in the issuer's
+	// owner directory (IOU escrows with a third-party issuer). Both are UInt64
+	// fields serialized as hex, mirroring rippled Escrow.cpp:569,583.
+	if hasDestNode {
+		jsonObj["DestinationNode"] = fmt.Sprintf("%x", destNode)
+	}
+	if hasIssuerNode {
+		jsonObj["IssuerNode"] = fmt.Sprintf("%x", issuerNode)
 	}
 
 	if txn.FinishAfter != nil {


### PR DESCRIPTION
## Summary
- EscrowCreate omitted **`sfDestinationNode`** on the created Escrow ledger object (and hardcoded **`sfOwnerNode`** to `0`). For a cross-account escrow this makes the Escrow SLE serialize differently from rippled → **`account_hash` diverges** while `transaction_hash` and tx metadata still match. Tx/metadata-level checks see agreement while consensus forks — the root cause of the `wrongLedger` stalls in #724.
- Fix mirrors rippled `Escrow.cpp:548-584`: do the owner / destination / issuer directory inserts **first**, capture each `DirInsert` page, then serialize the escrow with `sfOwnerNode`, `sfDestinationNode` (cross-account only) and `sfIssuerNode` (third-party IOU only) set to the **real page indices**.

## Why earlier diagnoses missed it
rippled's tx metadata `NewFields` omits zero-valued fields, so the tx tree (and `transaction_hash`) matched regardless — the divergence lives only in the **state SLE** serialization (`account_hash`). It surfaces only on a per-SLE `ledger_entry` / per-node `account_hash` diff, not a `tx`/metadata comparison. Confirmed: rippled threads the destination `AccountRoot` and goXRPL already matched it byte-for-byte; that was never the bug.

## Test plan
- [x] `go test ./internal/testing/escrow/... ./internal/tx/escrow/...`
- [x] New `escrow_destination_node_test.go`: cross-account sets `sfDestinationNode`; self-escrow does not; **pagination** asserts the captured page (`DestinationNode == 1`, `OwnerNode == 1`) proving it is read from `DirInsert`, not hardcoded; cross-account escrow finishes cleanly (finish reads `sfDestinationNode` to remove the dest-dir entry).
- [x] Escrow-adjacent suites green: `accountdelete`, `amm`, `invariants`, `batch`.

Fixes #729