### PR TITLE
Bind SetRegularKey lsfPasswordSpent to the waived fee

### DIFF
--- a/codec/addresscodec/codec.go
+++ b/codec/addresscodec/codec.go
@@ -82,10 +82,17 @@ func Decode(b58string string, typePrefix []byte) ([]byte, error) {
 // EncodeClassicAddressFromPublicKeyHex returns the classic address from a public key hex string.
 func EncodeClassicAddressFromPublicKeyHex(pubkeyhex string) (string, error) {
 	pubkey, err := hex.DecodeString(pubkeyhex)
-
 	if err != nil {
 		return "", err
-	} else if len(pubkey) != AccountPublicKeyLength {
+	}
+	return EncodeClassicAddressFromPublicKey(pubkey)
+}
+
+// EncodeClassicAddressFromPublicKey returns the classic address from raw public
+// key bytes, letting callers that already hold the decoded key avoid a second
+// hex decode.
+func EncodeClassicAddressFromPublicKey(pubkey []byte) (string, error) {
+	if len(pubkey) != AccountPublicKeyLength {
 		return "", &EncodeLengthError{Instance: "PublicKey", Expected: AccountPublicKeyLength, Input: len(pubkey)}
 	}
 

--- a/internal/testing/setregularkey/setregularkey_test.go
+++ b/internal/testing/setregularkey/setregularkey_test.go
@@ -5,10 +5,13 @@
 package setregularkey_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/signerlist"
 )
 
 // TestSetRegularKey_Basic tests basic regular key operations.
@@ -188,6 +191,64 @@ func TestSetRegularKey_WithSignerList(t *testing.T) {
 	// 3. Multi-sign
 	payTx3 := payment.Pay(alice, becky, uint64(jtx.XRP(3))).Build()
 	jtx.RequireTxSuccess(t, env.SubmitMultiSigned(payTx3, []*jtx.Account{signer}))
+}
+
+// TestSetRegularKey_PasswordSpentFeeBinding pins rippled's binding between the
+// SetRegularKey free-password-change discount and lsfPasswordSpent: the flag is
+// set iff the base fee was waived, and the waiver is one-shot. Before #732 the
+// fee floor and the flag were derived independently and could disagree — a full
+// fee charged while lsfPasswordSpent was still set — forking account_hash under
+// fuzz load. Reference: rippled SetRegularKey.cpp calculateBaseFee + doApply.
+func TestSetRegularKey_PasswordSpentFeeBinding(t *testing.T) {
+	const baseFee = 10
+
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	rk1 := jtx.NewAccount("rk1")
+	rk2 := jtx.NewAccount("rk2")
+	env.Fund(alice)
+	env.Close()
+
+	submit := func(target *jtx.Account, fee uint64) jtx.TxResult {
+		setKey := signerlist.NewSetRegularKey(alice.Address)
+		setKey.SetKey(target.Address)
+		setKey.Fee = fmt.Sprintf("%d", fee)
+		seq := env.Seq(alice)
+		setKey.Sequence = &seq
+		return env.Submit(setKey)
+	}
+
+	// 1. The first master-signed change is free: the discount waives the fee
+	//    floor so a zero fee is accepted, and lsfPasswordSpent is set as a
+	//    result of that same waiver.
+	before := env.Balance(alice)
+	res := submit(rk1, 0)
+	jtx.RequireTxSuccess(t, res)
+	jtx.RequireFlagSet(t, env, alice, state.LsfPasswordSpent)
+	if got := env.Balance(alice); got != before {
+		t.Fatalf("free SetRegularKey charged a fee: balance %d -> %d", before, got)
+	}
+
+	// 2. The waiver is one-shot: with lsfPasswordSpent set, a zero-fee change is
+	//    now below the load floor and rejected — proving the floor honors the
+	//    flag the first change set (the two never drift).
+	res = submit(rk2, 0)
+	if res.Success {
+		t.Fatalf("second zero-fee SetRegularKey should be rejected, got success")
+	}
+	if res.Code != "telINSUF_FEE_P" {
+		t.Fatalf("second zero-fee SetRegularKey: expected telINSUF_FEE_P, got %s", res.Code)
+	}
+
+	// 3. Paying the full fee succeeds; the flag stays set and a normal fee is
+	//    charged (no fresh discount is wrongly granted).
+	before = env.Balance(alice)
+	res = submit(rk2, baseFee)
+	jtx.RequireTxSuccess(t, res)
+	jtx.RequireFlagSet(t, env, alice, state.LsfPasswordSpent)
+	if got := env.Balance(alice); got != before-baseFee {
+		t.Fatalf("paid SetRegularKey: expected balance %d, got %d", before-baseFee, got)
+	}
 }
 
 // Suppress unused import warnings

--- a/internal/tx/preclaim.go
+++ b/internal/tx/preclaim.go
@@ -263,7 +263,7 @@ func (e *Engine) preclaimBaseFee(tx Transaction, common *Common, account *state.
 	// with the master key while lsfPasswordSpent is clear. The same predicate
 	// gates the lsfPasswordSpent flag in doApply, so the fee and the flag can
 	// never disagree. Reference: rippled SetRegularKey.cpp calculateBaseFee.
-	if tx.TxType() == TypeRegularKeySet && SetRegularKeyFeeWaived(e.config, common, account) {
+	if tx.TxType() == TypeRegularKeySet && SetRegularKeyFeeWaived(e.config.SkipSignatureVerification, common, account) {
 		baseFeeForTx = 0
 	}
 	return baseFeeForTx

--- a/internal/tx/preclaim.go
+++ b/internal/tx/preclaim.go
@@ -259,21 +259,12 @@ func (e *Engine) preclaimBaseFee(tx Transaction, common *Common, account *state.
 			baseFeeForTx = CalculateMultiSigFee(e.config.BaseFee, len(common.Signers))
 		}
 	}
-	// SetRegularKey special case: free password change when lsfPasswordSpent not set.
-	// Reference: rippled SetRegularKey.cpp calculateBaseFee
-	if tx.TxType() == TypeRegularKeySet {
-		signedWithMaster := false
-		if spk := common.SigningPubKey; spk != "" {
-			sigAddr, sigErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(spk)
-			if sigErr == nil && sigAddr == common.Account {
-				signedWithMaster = true
-			}
-		} else if e.config.SkipSignatureVerification && !IsMultiSigned(tx) {
-			signedWithMaster = true
-		}
-		if signedWithMaster && account.Flags&state.LsfPasswordSpent == 0 {
-			baseFeeForTx = 0
-		}
+	// SetRegularKey free password change: the base fee is waived when signed
+	// with the master key while lsfPasswordSpent is clear. The same predicate
+	// gates the lsfPasswordSpent flag in doApply, so the fee and the flag can
+	// never disagree. Reference: rippled SetRegularKey.cpp calculateBaseFee.
+	if tx.TxType() == TypeRegularKeySet && SetRegularKeyFeeWaived(e.config, common, account) {
+		baseFeeForTx = 0
 	}
 	return baseFeeForTx
 }

--- a/internal/tx/setregularkey_fee.go
+++ b/internal/tx/setregularkey_fee.go
@@ -19,7 +19,7 @@ import (
 //
 // Reference: rippled SetRegularKey.cpp calculateBaseFee (lines 28-49) and
 // doApply (lines 83-84).
-func SetRegularKeyFeeWaived(config EngineConfig, common *Common, account *state.AccountRoot) bool {
+func SetRegularKeyFeeWaived(skipSigVerification bool, common *Common, account *state.AccountRoot) bool {
 	if common == nil || account == nil {
 		return false
 	}
@@ -36,11 +36,11 @@ func SetRegularKeyFeeWaived(config EngineConfig, common *Common, account *state.
 		if decErr != nil || !IsValidPublicKey(spkBytes) {
 			return false
 		}
-		sigAddr, addrErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(spk)
+		sigAddr, addrErr := addresscodec.EncodeClassicAddressFromPublicKey(spkBytes)
 		return addrErr == nil && sigAddr == common.Account
 	}
 	// No SigningPubKey: in standalone/test mode signature verification is
 	// skipped and a single-signed transaction is treated as master-signed. A
 	// multi-signed transaction (Signers present) is never master-signed.
-	return config.SkipSignatureVerification && len(common.Signers) == 0
+	return skipSigVerification && len(common.Signers) == 0
 }

--- a/internal/tx/setregularkey_fee.go
+++ b/internal/tx/setregularkey_fee.go
@@ -1,0 +1,46 @@
+package tx
+
+import (
+	"encoding/hex"
+
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+// SetRegularKeyFeeWaived reports whether a SetRegularKey qualifies for the free
+// password-change discount: it is signed with the account's master key while
+// lsfPasswordSpent is clear.
+//
+// This is the single source of truth shared by the preclaim fee floor
+// (preclaimBaseFee) and the doApply lsfPasswordSpent flag, so the fee charged
+// and the flag can never drift. It mirrors rippled, where both read the one
+// computed ctx_.baseFee: the flag is set iff !minimumFee(ctx_.baseFee), and
+// ctx_.baseFee is 0 iff this discount applies.
+//
+// Reference: rippled SetRegularKey.cpp calculateBaseFee (lines 28-49) and
+// doApply (lines 83-84).
+func SetRegularKeyFeeWaived(config EngineConfig, common *Common, account *state.AccountRoot) bool {
+	if common == nil || account == nil {
+		return false
+	}
+	// One-shot discount: once lsfPasswordSpent is set the master key must pay
+	// the full fee until a fee-paying transaction clears it.
+	if account.Flags&state.LsfPasswordSpent != 0 {
+		return false
+	}
+	if spk := common.SigningPubKey; spk != "" {
+		// Validate the public-key type before deriving an address, matching
+		// rippled's publicKeyType() guard — otherwise an arbitrary payload
+		// could hex-encode into a master-looking address.
+		spkBytes, decErr := hex.DecodeString(spk)
+		if decErr != nil || !IsValidPublicKey(spkBytes) {
+			return false
+		}
+		sigAddr, addrErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(spk)
+		return addrErr == nil && sigAddr == common.Account
+	}
+	// No SigningPubKey: in standalone/test mode signature verification is
+	// skipped and a single-signed transaction is treated as master-signed. A
+	// multi-signed transaction (Signers present) is never master-signed.
+	return config.SkipSignatureVerification && len(common.Signers) == 0
+}

--- a/internal/tx/setregularkey_fee_test.go
+++ b/internal/tx/setregularkey_fee_test.go
@@ -1,0 +1,100 @@
+package tx
+
+import (
+	"testing"
+
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+// TestSetRegularKeyFeeWaived pins the single predicate that both the preclaim
+// fee floor and the doApply lsfPasswordSpent flag now share. Keeping them in
+// lockstep is what prevents the #732 account_hash fork (a full fee charged
+// while the flag is still set). Reference: rippled SetRegularKey.cpp
+// calculateBaseFee + doApply.
+func TestSetRegularKeyFeeWaived(t *testing.T) {
+	// EncodeClassicAddressFromPublicKeyHex only hashes the bytes, so any valid
+	// 33-byte key (0xED/0x02/0x03 prefix) yields a deterministic address.
+	const masterPub = "ED0000000000000000000000000000000000000000000000000000000000000001"
+	const otherPub = "ED0000000000000000000000000000000000000000000000000000000000000002"
+	masterAddr, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(masterPub)
+	if err != nil {
+		t.Fatalf("derive master address: %v", err)
+	}
+
+	unflagged := &state.AccountRoot{}
+	spent := &state.AccountRoot{Flags: state.LsfPasswordSpent}
+
+	tests := []struct {
+		name    string
+		config  EngineConfig
+		common  *Common
+		account *state.AccountRoot
+		want    bool
+	}{
+		{
+			name:    "master-signed and unspent is waived",
+			common:  &Common{Account: masterAddr, SigningPubKey: masterPub},
+			account: unflagged,
+			want:    true,
+		},
+		{
+			name:    "master-signed but already spent is not waived",
+			common:  &Common{Account: masterAddr, SigningPubKey: masterPub},
+			account: spent,
+			want:    false,
+		},
+		{
+			name:    "signed with a non-master key is not waived",
+			common:  &Common{Account: masterAddr, SigningPubKey: otherPub},
+			account: unflagged,
+			want:    false,
+		},
+		{
+			name:    "malformed SigningPubKey is not waived",
+			common:  &Common{Account: masterAddr, SigningPubKey: "not-hex"},
+			account: unflagged,
+			want:    false,
+		},
+		{
+			name:    "invalid public-key type is not waived",
+			common:  &Common{Account: masterAddr, SigningPubKey: "00ABCD"},
+			account: unflagged,
+			want:    false,
+		},
+		{
+			name:    "no SigningPubKey with skip-verify is waived",
+			config:  EngineConfig{SkipSignatureVerification: true},
+			common:  &Common{Account: masterAddr},
+			account: unflagged,
+			want:    true,
+		},
+		{
+			name:    "no SigningPubKey, skip-verify, multi-signed is not waived",
+			config:  EngineConfig{SkipSignatureVerification: true},
+			common:  &Common{Account: masterAddr, Signers: []SignerWrapper{{}}},
+			account: unflagged,
+			want:    false,
+		},
+		{
+			name:    "no SigningPubKey without skip-verify is not waived",
+			common:  &Common{Account: masterAddr},
+			account: unflagged,
+			want:    false,
+		},
+		{
+			name:    "nil account is not waived",
+			common:  &Common{Account: masterAddr, SigningPubKey: masterPub},
+			account: nil,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SetRegularKeyFeeWaived(tt.config, tt.common, tt.account); got != tt.want {
+				t.Errorf("SetRegularKeyFeeWaived() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tx/setregularkey_fee_test.go
+++ b/internal/tx/setregularkey_fee_test.go
@@ -17,6 +17,12 @@ func TestSetRegularKeyFeeWaived(t *testing.T) {
 	// 33-byte key (0xED/0x02/0x03 prefix) yields a deterministic address.
 	const masterPub = "ED0000000000000000000000000000000000000000000000000000000000000001"
 	const otherPub = "ED0000000000000000000000000000000000000000000000000000000000000002"
+	// A syntactically valid 65-byte uncompressed secp256k1 key (0x04 prefix):
+	// IsValidPublicKey accepts it, but address derivation rejects len != 33, so
+	// the combined gate never waives — matching rippled's 33-byte publicKeyType.
+	const uncompressedPub = "04" +
+		"0000000000000000000000000000000000000000000000000000000000000000" +
+		"0000000000000000000000000000000000000000000000000000000000000000"
 	masterAddr, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(masterPub)
 	if err != nil {
 		t.Fatalf("derive master address: %v", err)
@@ -26,11 +32,11 @@ func TestSetRegularKeyFeeWaived(t *testing.T) {
 	spent := &state.AccountRoot{Flags: state.LsfPasswordSpent}
 
 	tests := []struct {
-		name    string
-		config  EngineConfig
-		common  *Common
-		account *state.AccountRoot
-		want    bool
+		name                string
+		skipSigVerification bool
+		common              *Common
+		account             *state.AccountRoot
+		want                bool
 	}{
 		{
 			name:    "master-signed and unspent is waived",
@@ -63,18 +69,24 @@ func TestSetRegularKeyFeeWaived(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "no SigningPubKey with skip-verify is waived",
-			config:  EngineConfig{SkipSignatureVerification: true},
-			common:  &Common{Account: masterAddr},
-			account: unflagged,
-			want:    true,
-		},
-		{
-			name:    "no SigningPubKey, skip-verify, multi-signed is not waived",
-			config:  EngineConfig{SkipSignatureVerification: true},
-			common:  &Common{Account: masterAddr, Signers: []SignerWrapper{{}}},
+			name:    "valid 65-byte uncompressed key is rejected by the address encoder",
+			common:  &Common{Account: masterAddr, SigningPubKey: uncompressedPub},
 			account: unflagged,
 			want:    false,
+		},
+		{
+			name:                "no SigningPubKey with skip-verify is waived",
+			skipSigVerification: true,
+			common:              &Common{Account: masterAddr},
+			account:             unflagged,
+			want:                true,
+		},
+		{
+			name:                "no SigningPubKey, skip-verify, multi-signed is not waived",
+			skipSigVerification: true,
+			common:              &Common{Account: masterAddr, Signers: []SignerWrapper{{}}},
+			account:             unflagged,
+			want:                false,
 		},
 		{
 			name:    "no SigningPubKey without skip-verify is not waived",
@@ -92,7 +104,7 @@ func TestSetRegularKeyFeeWaived(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SetRegularKeyFeeWaived(tt.config, tt.common, tt.account); got != tt.want {
+			if got := SetRegularKeyFeeWaived(tt.skipSigVerification, tt.common, tt.account); got != tt.want {
 				t.Errorf("SetRegularKeyFeeWaived() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/tx/signerlist/signer_list_set.go
+++ b/internal/tx/signerlist/signer_list_set.go
@@ -215,7 +215,7 @@ func (s *SetRegularKey) Apply(ctx *tx.ApplyContext) tx.Result {
 	// never disagree. Re-deriving "signed with master" here independently is
 	// what let the two drift and fork account_hash (#732).
 	// Reference: rippled SetRegularKey.cpp doApply lines 83-84.
-	if tx.SetRegularKeyFeeWaived(ctx.Config, s.GetCommon(), ctx.Account) {
+	if tx.SetRegularKeyFeeWaived(ctx.Config.SkipSignatureVerification, s.GetCommon(), ctx.Account) {
 		ctx.Account.Flags |= state.LsfPasswordSpent
 	}
 

--- a/internal/tx/signerlist/signer_list_set.go
+++ b/internal/tx/signerlist/signer_list_set.go
@@ -1,11 +1,9 @@
 package signerlist
 
 import (
-	"encoding/hex"
 	"sort"
 
 	"github.com/LeJamon/go-xrpl/amendment"
-	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -210,23 +208,14 @@ func (s *SetRegularKey) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Account.RegularKey = ""
 	}
 
-	// Set lsfPasswordSpent when the tx qualifies for the free
-	// password-change discount: signed by the master key. Rippled
-	// SetRegularKey.cpp doApply gates on mFeeDue == 0 (the calculated
-	// minimum fee), NOT the fee actually paid.
-	common := s.GetCommon()
-	signedWithMaster := false
-	if spk := common.SigningPubKey; spk != "" {
-		// publicKeyType() check (rippled PublicKey.cpp) before deriving
-		// an address — otherwise an arbitrary 33-byte payload could
-		// hex-encode into a valid-looking master address.
-		if spkBytes, decErr := hex.DecodeString(spk); decErr == nil && tx.IsValidPublicKey(spkBytes) {
-			if sigAddr, sigErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(spk); sigErr == nil && sigAddr == common.Account {
-				signedWithMaster = true
-			}
-		}
-	}
-	if signedWithMaster && (ctx.Account.Flags&state.LsfPasswordSpent) == 0 {
+	// Set lsfPasswordSpent iff this SetRegularKey received the free
+	// password-change discount (its computed base fee was waived). rippled
+	// binds the flag to !minimumFee(ctx_.baseFee) — the SAME base fee that
+	// drives the preclaim fee floor — so the fee charged and the flag can
+	// never disagree. Re-deriving "signed with master" here independently is
+	// what let the two drift and fork account_hash (#732).
+	// Reference: rippled SetRegularKey.cpp doApply lines 83-84.
+	if tx.SetRegularKeyFeeWaived(ctx.Config, s.GetCommon(), ctx.Account) {
 		ctx.Account.Flags |= state.LsfPasswordSpent
 	}
 


### PR DESCRIPTION
## Summary

- SetRegularKey's free password-change discount was derived **independently** in two production paths — the preclaim fee floor (`preclaimBaseFee`) and the doApply flag (`SetRegularKey.Apply`) — using **different** logic (one validated the public-key type, the other did not; one had a skip-verify branch). The two could disagree, so goXRPL could charge a **full fee** yet still set `lsfPasswordSpent`, serializing an `AccountRoot.Flags` value rippled never produces → **`account_hash` fork** under fuzz load. Because `lsfPasswordSpent` is a default/zero field omitted from tx-metadata `NewFields`, `transaction_hash` + metadata matched and only `account_hash` diverged (a silent split-brain — exactly the #729 class, here keyed on a fee-coupled flag).
- rippled computes `ctx_.baseFee` **once** and binds **both** the fee floor and the flag to it: `SetRegularKey::doApply` sets the flag iff `!minimumFee(ctx_.baseFee)`, i.e. iff the base fee was waived (`SetRegularKey.cpp:83-84`, `calculateBaseFee:28-49`).
- Introduce `tx.SetRegularKeyFeeWaived` as the **single predicate** both paths now call, so the fee charged and the flag can never drift.

Bug-class note: I audited every rippled `calculateBaseFee` override — SetRegularKey is the **only** transactor in rippled that couples ledger state to the computed base fee, so this PR closes the fee-coupled-state class. `lsfPasswordSpent` clear sites (Payment XRP-credit, AccountDelete) already match rippled.

## Test plan
- [x] `just test-pkg ./internal/tx/ -run TestSetRegularKeyFeeWaived` — new table-driven unit test pinning the shared predicate across all branches (master/non-master, already-spent, invalid pubkey, multi-sign, skip-verify).
- [x] `just test-pkg ./internal/testing/setregularkey/...` — new `TestSetRegularKey_PasswordSpentFeeBinding` asserts the end-to-end binding through the real engine: a free first change sets the flag and costs nothing; the waiver is one-shot (a second zero-fee change is rejected `telINSUF_FEE_P`); a full-fee change keeps the flag and charges a normal fee.
- [x] `go test ./internal/tx/... ./internal/testing/{setregularkey,multisign,accountset,accountdelete,batch,payment}/...` — green (27 packages), `go vet` clean.

Fixes #732