### PR TITLE
fix: do not enforce lsfDisallowXRP in XRP Payment (#735)

### DIFF
--- a/internal/testing/env_flags.go
+++ b/internal/testing/env_flags.go
@@ -183,6 +183,25 @@ func (e *TestEnv) DisableRequireDest(acc *Account) {
 	}
 }
 
+// EnableDisallowXRP enables the DisallowXRP flag on an account.
+// This flag is advisory only: rippled does NOT enforce it in the Payment
+// transactor, so XRP payments to such an account still succeed.
+func (e *TestEnv) EnableDisallowXRP(acc *Account) {
+	e.t.Helper()
+
+	accountSet := account.NewAccountSet(acc.Address)
+	flag := account.AccountSetFlagDisallowXRP
+	accountSet.SetFlag = &flag
+	accountSet.Fee = formatUint64(e.baseFee)
+	seq := e.Seq(acc)
+	accountSet.Sequence = &seq
+
+	result := e.Submit(accountSet)
+	if !result.Success {
+		e.t.Fatalf("Failed to enable DisallowXRP for account %s: %s", acc.Name, result.Code)
+	}
+}
+
 // Preauthorize allows owner to preauthorize authorized for deposits.
 // This creates a DepositPreauth ledger entry.
 func (e *TestEnv) Preauthorize(owner, authorized *Account) {

--- a/internal/testing/payment/payment_test.go
+++ b/internal/testing/payment/payment_test.go
@@ -35,6 +35,39 @@ func TestPaymentXRPTransfer(t *testing.T) {
 	xrplgoTesting.RequireBalance(t, env, alice, xrplgoTesting.XRPMinusFees(env, 10000-100, 1))
 }
 
+// TestPaymentToDisallowXRP verifies that an XRP payment to a destination with the
+// lsfDisallowXRP flag set still SUCCEEDS and delivers the XRP. lsfDisallowXRP is an
+// advisory flag enforced only by client applications: rippled's Payment transactor
+// never checks it (Payment.cpp has no lsfDisallowXRP reference, and PayChan.cpp:234
+// notes "Obeying the lsfDisallowXRP flag was a bug"). Regression test for the
+// mixed-network ledger fork where goXRPL wrongly returned tecNO_TARGET for such a
+// payment, diverging account_hash and wedging consensus.
+func TestPaymentToDisallowXRP(t *testing.T) {
+	env := xrplgoTesting.NewTestEnv(t)
+
+	alice := xrplgoTesting.NewAccount("alice")
+	bob := xrplgoTesting.NewAccount("bob")
+
+	env.FundAmount(alice, uint64(xrplgoTesting.XRP(10000)))
+	env.FundAmount(bob, uint64(xrplgoTesting.XRP(10000)))
+	env.Close()
+
+	// Bob sets DisallowXRP (advisory only — must not block incoming XRP).
+	env.EnableDisallowXRP(bob)
+	env.Close()
+
+	// Alice sends Bob 100 XRP. Must succeed despite Bob's DisallowXRP flag.
+	payment := Pay(alice, bob, uint64(xrplgoTesting.XRP(100))).Build()
+	result := env.Submit(payment)
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	// Bob received the XRP (10000 + 100, minus the 1 fee from his AccountSet).
+	xrplgoTesting.RequireBalance(t, env, bob, xrplgoTesting.XRPMinusFees(env, 10000+100, 1))
+	// Alice sent 100 and paid 1 fee.
+	xrplgoTesting.RequireBalance(t, env, alice, xrplgoTesting.XRPMinusFees(env, 10000-100, 1))
+}
+
 // TestPaymentToNonexistent tests payment to a nonexistent account.
 // Reference: TrustAndBalance_test.cpp - testPayNonexistent
 func TestPaymentToNonexistent(t *testing.T) {

--- a/internal/tx/payment/payment_xrp.go
+++ b/internal/tx/payment/payment_xrp.go
@@ -78,17 +78,6 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 			return tx.TecNO_PERMISSION
 		}
 
-		// Check destination's lsfDisallowXRP flag
-		// Per rippled, if lsfDisallowXRP is set and sender != destination, return tecNO_TARGET
-		// This allows accounts to indicate they don't want to receive XRP
-		// Reference: this matches rippled behavior for direct XRP payments
-		if (destAccount.Flags & state.LsfDisallowXRP) != 0 {
-			// Only reject if sender is not the destination (self-payments are allowed)
-			if ctx.AccountID != destAccountID {
-				return tx.TecNO_TARGET
-			}
-		}
-
 		// Check if destination requires a tag
 		if (destAccount.Flags&state.LsfRequireDestTag) != 0 && p.DestinationTag == nil {
 			return tx.TecDST_TAG_NEEDED


### PR DESCRIPTION
## Problem

On the xrpl-confluence mixed-network soak (3 rippled 2.6.2 + 2 goXRPL, quorum 4), once
the #732 fix let the network advance past the old seq-29 wedge it **forked at ledger 42
and wedged consensus permanently** (`validated_seq` frozen at 41; control oracle fired
`consensus_liveness`).

Root cause: the identical consensus tx-set `de926b72` applied to the byte-identical
parent 41 produced different ledger 42 hashes (rippled `70E455C4…` vs goXRPL
`C1B5D135…`). State-delta diff isolated two plain XRP `Payment`s that goXRPL rejected
with `tecNO_TARGET` because their destinations had `lsfDisallowXRP` set — rippled
delivers them (`tesSUCCESS`). Withholding the XRP diverges balances and `account_hash`.

## Why goXRPL is wrong

`lsfDisallowXRP` is advisory (enforced by client apps, not the protocol):

- `rippled/.../Payment.cpp` has **no** `DisallowXRP` reference — destination checks are
  `tecNO_DST`, `tecNO_DST_INSUF_XRP`, and `lsfRequireDestTag → tecDST_TAG_NEEDED` only.
- `rippled/.../PayChan.cpp:234,550`: *"Obeying the lsfDisallowXRP flag was a bug."*

`internal/tx/payment/payment_xrp.go` enforced it anyway (with a comment falsely citing
rippled), returning `tecNO_TARGET`.

## Fix

Remove the `lsfDisallowXRP` enforcement block from `payment_xrp.go`.

## Test

`internal/testing/payment/payment_test.go::TestPaymentToDisallowXRP` — set
`asfDisallowXRP` on bob, pay bob 100 XRP; assert `tesSUCCESS` **and** bob's balance
increases by 100 (resulting state, not just the TER). Adds an `EnableDisallowXRP` env
helper.

Verified: payment, tx/payment, escrow, paychan, accountset, batch, enginefuzz suites
pass; `go vet` clean.

Fixes #735