### PR TITLE
fix: track sfAccountTxnID presence so present-zero round-trips (#737)

### DIFF
--- a/internal/ledger/state/account_root.go
+++ b/internal/ledger/state/account_root.go
@@ -30,6 +30,7 @@ type AccountRoot struct {
 	FirstNFTokenSequence uint32   // First NFToken sequence (set by fixNFTokenRemint)
 	HasFirstNFTSeq       bool     // Whether FirstNFTokenSequence is set (zero is a valid value)
 	AccountTxnID         [32]byte // Hash of the last transaction this account submitted (when enabled)
+	HasAccountTxnID      bool     // Whether sfAccountTxnID is present (zero is a valid value after asfAccountTxnID is enabled)
 	WalletLocator        string   // Arbitrary hex data (deprecated)
 	TicketCount          uint32   // Number of outstanding tickets owned by this account
 	AMMID                [32]byte // Links AMM pseudo-account to its AMM ledger entry (sfAMMID, fieldCode 14)
@@ -347,6 +348,7 @@ func ParseAccountRoot(data []byte) (*AccountRoot, error) {
 				copy(account.PreviousTxnID[:], data[offset:offset+32])
 			case fieldCodeAccountTxnID: // AccountTxnID
 				copy(account.AccountTxnID[:], data[offset:offset+32])
+				account.HasAccountTxnID = true
 			case fieldCodeWalletLocator: // WalletLocator
 				account.WalletLocator = hex.EncodeToString(data[offset : offset+32])
 			case fieldCodeAMMID: // AMMID - links AMM pseudo-account to AMM entry
@@ -445,9 +447,12 @@ func SerializeAccountRoot(account *AccountRoot) ([]byte, error) {
 		jsonObj["TicketCount"] = account.TicketCount
 	}
 
-	// Add AccountTxnID if set (non-zero)
+	// Add AccountTxnID if present. Once asfAccountTxnID is enabled the field is
+	// present even while still zero (before the account's next transaction),
+	// mirroring rippled's makeFieldPresent(sfAccountTxnID). Keyed on presence,
+	// not non-zero, so a present-zero value round-trips.
 	var zeroHash [32]byte
-	if account.AccountTxnID != zeroHash {
+	if account.HasAccountTxnID {
 		jsonObj["AccountTxnID"] = strings.ToUpper(hex.EncodeToString(account.AccountTxnID[:]))
 	}
 

--- a/internal/testing/accountset/accountset_test.go
+++ b/internal/testing/accountset/accountset_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
+	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // asfToLsf maps an AccountSet flag (asf*) to the corresponding ledger flag (lsf*).
@@ -189,22 +190,33 @@ func TestAccountSet_SetAndResetAccountTxnID(t *testing.T) {
 
 	origFlags := env.AccountInfo(alice).Flags
 
-	// AccountTxnID should not be present initially
-	var zeroHash [32]byte
-	info := env.AccountInfo(alice)
-	require.Equal(t, zeroHash, info.AccountTxnID, "AccountTxnID should not be present initially")
+	// asfAccountTxnID controls field PRESENCE (rippled isFieldPresent), not a
+	// value: enable makes sfAccountTxnID present with value zero, clear removes
+	// it. Check presence via the raw AccountRoot, mirroring rippled's
+	// AccountSet_test.cpp checks.
+	hasAccountTxnID := func() bool {
+		t.Helper()
+		data, err := env.LedgerEntry(keylet.Account(alice.ID))
+		require.NoError(t, err)
+		ar, err := state.ParseAccountRootFromBytes(data)
+		require.NoError(t, err)
+		return ar.HasAccountTxnID
+	}
 
-	// Set asfAccountTxnID — field should become present
+	// AccountTxnID should not be present initially.
+	require.False(t, hasAccountTxnID(), "AccountTxnID should not be present initially")
+
+	// Set asfAccountTxnID — field should become present (value zero).
 	result := env.Submit(AccountSet(alice).SetFlag(accounttx.AccountSetFlagAccountTxnID).Build())
 	jtx.RequireTxSuccess(t, result)
-	info = env.AccountInfo(alice)
-	require.NotEqual(t, zeroHash, info.AccountTxnID, "AccountTxnID should be present after set")
+	env.Close()
+	require.True(t, hasAccountTxnID(), "AccountTxnID should be present after set")
 
-	// Clear asfAccountTxnID — field should be removed
+	// Clear asfAccountTxnID — field should be removed.
 	result = env.Submit(AccountSet(alice).ClearFlag(accounttx.AccountSetFlagAccountTxnID).Build())
 	jtx.RequireTxSuccess(t, result)
-	info = env.AccountInfo(alice)
-	require.Equal(t, zeroHash, info.AccountTxnID, "AccountTxnID should not be present after clear")
+	env.Close()
+	require.False(t, hasAccountTxnID(), "AccountTxnID should not be present after clear")
 
 	// Flags should be unchanged
 	nowFlags := env.AccountInfo(alice).Flags

--- a/internal/testing/accountset/accounttxnid_test.go
+++ b/internal/testing/accountset/accounttxnid_test.go
@@ -1,0 +1,69 @@
+package accountset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// Regression for the seq-N account_hash fork found in the mixed soak:
+// enabling asfAccountTxnID must make sfAccountTxnID PRESENT with value zero
+// (rippled SetAccount.cpp makeFieldPresent(sfAccountTxnID)), and the account's
+// next transaction must update that present-zero field to the tx id (rippled
+// Transactor::apply isFieldPresent(sfAccountTxnID), Transactor.cpp:568-569).
+//
+// go-xrpl previously tracked presence as "non-zero", setting AccountTxnID to
+// the enabling tx's hash and updating only when non-zero. That both diverged
+// from rippled's present-zero value at enable time AND silently dropped the
+// update for a present-zero field adopted from a rippled-built ledger — forking
+// account_hash while transaction_hash matched.
+func TestAccountSet_AccountTxnID_PresentZeroAndUpdate(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.FundNoRipple(alice)
+	env.Close()
+
+	readAR := func() *state.AccountRoot {
+		t.Helper()
+		data, err := env.LedgerEntry(keylet.Account(alice.ID))
+		require.NoError(t, err)
+		ar, err := state.ParseAccountRootFromBytes(data)
+		require.NoError(t, err)
+		return ar
+	}
+	var zero [32]byte
+
+	// Enable asfAccountTxnID → field present, value zero.
+	r := env.Submit(AccountSet(alice).SetFlag(accounttx.AccountSetFlagAccountTxnID).Build())
+	jtx.RequireTxSuccess(t, r)
+	env.Close()
+
+	ar := readAR()
+	require.True(t, ar.HasAccountTxnID, "enable must make sfAccountTxnID present")
+	require.Equal(t, zero, ar.AccountTxnID,
+		"enable must leave AccountTxnID zero, not the enabling tx hash (rippled makeFieldPresent)")
+
+	// Next transaction must update the present-zero field to the tx id.
+	r = env.Submit(AccountSet(alice).Build()) // noop AccountSet
+	jtx.RequireTxSuccess(t, r)
+	env.Close()
+
+	ar = readAR()
+	require.True(t, ar.HasAccountTxnID, "AccountTxnID must remain present after the update")
+	require.NotEqual(t, zero, ar.AccountTxnID,
+		"the account's next tx must update present-zero AccountTxnID to the tx id")
+
+	// Clearing removes the field entirely.
+	r = env.Submit(AccountSet(alice).ClearFlag(accounttx.AccountSetFlagAccountTxnID).Build())
+	jtx.RequireTxSuccess(t, r)
+	env.Close()
+
+	ar = readAR()
+	require.False(t, ar.HasAccountTxnID, "clear must remove sfAccountTxnID")
+	require.Equal(t, zero, ar.AccountTxnID)
+}

--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -390,14 +390,17 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// AccountTxnID
-	if uSetFlag == AccountSetFlagAccountTxnID {
-		var zeroHash [32]byte
-		if account.AccountTxnID == zeroHash {
-			account.AccountTxnID = ctx.TxHash
-		}
+	// AccountTxnID: enabling makes the field present (initial value zero),
+	// mirroring rippled SetAccount.cpp makeFieldPresent(sfAccountTxnID); the
+	// account's next transaction updates it to that tx's ID. Clearing removes
+	// the field. Presence is tracked separately so a present-zero value (after
+	// enable, before the next tx) round-trips instead of being treated as absent.
+	if uSetFlag == AccountSetFlagAccountTxnID && !account.HasAccountTxnID {
+		account.HasAccountTxnID = true
+		account.AccountTxnID = [32]byte{}
 	}
 	if uClearFlag == AccountSetFlagAccountTxnID {
+		account.HasAccountTxnID = false
 		account.AccountTxnID = [32]byte{}
 	}
 

--- a/internal/tx/do_apply.go
+++ b/internal/tx/do_apply.go
@@ -201,15 +201,15 @@ func (e *Engine) applyPreApplyAccountChanges(st *applyState) Result {
 	st.account.PreviousTxnID = st.txHash
 	st.account.PreviousTxnLgrSeq = e.config.LedgerSequence
 
-	// Update AccountTxnID if the account has tracking enabled (field is present/non-zero).
+	// Update AccountTxnID if the account has tracking enabled (field present).
+	// Keyed on presence, not non-zero: a freshly-enabled asfAccountTxnID is
+	// present-but-zero until this update, and rippled updates it on the very
+	// next transaction.
 	// Reference: rippled Transactor::apply() line 568-569:
 	//   if (sle->isFieldPresent(sfAccountTxnID))
 	//       sle->setFieldH256(sfAccountTxnID, ctx_.tx.getTransactionID());
-	{
-		var zeroHash [32]byte
-		if st.account.AccountTxnID != zeroHash {
-			st.account.AccountTxnID = st.txHash
-		}
+	if st.account.HasAccountTxnID {
+		st.account.AccountTxnID = st.txHash
 	}
 
 	// Write the fee-deducted, sequence-incremented account to the table BEFORE Apply().
@@ -593,15 +593,15 @@ func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *ApplyStateTable,
 	recoveredAccount.PreviousTxnID = st.txHash
 	recoveredAccount.PreviousTxnLgrSeq = e.config.LedgerSequence
 
-	// Update AccountTxnID if the account has tracking enabled (field is present/non-zero).
+	// Update AccountTxnID if the account has tracking enabled (field present).
 	// On the success path, apply() sets this before doApply(). On the tec path,
 	// reset() discards all changes then re-applies fee/sequence. The AccountTxnID
 	// must also be updated here so the account tracks the last-applied transaction
-	// even when the result is a tec code.
+	// even when the result is a tec code. Keyed on presence, not non-zero, so a
+	// freshly-enabled present-zero field is still updated.
 	// Reference: rippled Transactor::apply() lines 568-569.
 	{
-		var zeroHash [32]byte
-		if recoveredAccount.AccountTxnID != zeroHash {
+		if recoveredAccount.HasAccountTxnID {
 			recoveredAccount.AccountTxnID = st.txHash
 		}
 	}


### PR DESCRIPTION
## Problem

On the xrpl-confluence mixed soak (3 rippled 2.6.2 + 2 go-xrpl, quorum 4), ledger 76 forked: the two go-xrpl nodes built an identical ledger the 3 rippled rejected → split-brain, validated frozen at 75. State-delta isolated account `rKt7YE…`: it had `asfAccountTxnID` enabled (present-zero in the agreed parent 75) and submitted txs in 76; rippled updates `AccountTxnID` to the tx id, go-xrpl dropped the field → divergent AccountRoot → `account_hash` fork (transaction_hash matched).

## Root cause

`asfAccountTxnID` controls field *presence*, not a value. rippled enable = `makeFieldPresent` (present, value **zero**) and updates per-tx via `isFieldPresent`. go-xrpl used "non-zero == present" with no presence bit, so a present-zero AccountTxnID (rippled's post-enable state, inherited when go-xrpl adopts a rippled ledger) was skipped by the per-tx update and omitted by the serializer.

## Fix

Add `AccountRoot.HasAccountTxnID` (mirrors the existing `HasFirstNFTSeq` pattern); key parse/serialize/enable/clear/update on presence:
- enable → present + value zero (rippled `makeFieldPresent`), not the enabling tx hash
- clear → field absent
- per-tx update (success + tec recovery) → `if present`
- serialize → emit if present, so present-zero round-trips

## Tests

`internal/testing/accountset/accounttxnid_test.go::TestAccountSet_AccountTxnID_PresentZeroAndUpdate` (enable→present-zero, next-tx→tx id, clear→absent). Corrected `TestAccountSet_SetAndResetAccountTxnID` which had pinned the non-zero behavior. Full module builds; state/account/tx/payment/escrow/accountset suites pass; vet clean.

Fixes #737