### PR TITLE
fix: re-trigger stalled tx-set acquisition on a timer (#724)

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -436,6 +436,13 @@ func (r *Router) maintenanceTick() {
 		// fresh acquisition via startLedgerAcquisition once the stuck
 		// reference is cleared.
 	}
+
+	// Timer-driven tx-set acquisition re-trigger (issue #724). go-xrpl's
+	// inbound retry (handleTxSetData) only advances when a TMLedgerData
+	// arrives; if a peer falls silent mid-acquire nothing re-requests the
+	// remaining nodes and the node stalls into wrongLedger. This is the
+	// missing analogue of rippled's TransactionAcquire::onTimer.
+	r.retryStalledTxSetAcquires()
 }
 
 func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
@@ -1646,6 +1653,110 @@ func (r *Router) sweepStaleTxSetAcquireLocked() {
 	for id, state := range r.txSetAcquire {
 		if state.lastUpdate.Before(cutoff) {
 			delete(r.txSetAcquire, id)
+		}
+	}
+}
+
+// retryStalledTxSetAcquires re-requests the still-missing nodes of any
+// in-flight tx-set acquisition whose inbound responses have gone quiet, and
+// sweeps entries past their TTL. It is the timer-driven analogue of rippled's
+// TransactionAcquire::onTimer (TransactionAcquire.cpp:89), which fires every
+// TX_ACQUIRE_TIMEOUT (250ms) and re-triggers the request up to MAX_TIMEOUTS.
+//
+// go-xrpl's inbound retry (handleTxSetData) only advances on an arriving
+// TMLedgerData. When a peer falls silent mid-acquire — or every reply is
+// throttled — nothing re-requests the remaining nodes, so the acquisition
+// stalls until the 60s TTL sweep; under load that drops the node into
+// wrongLedger and the mixed network below quorum (issue #724). This timer is
+// the missing driver. It reuses the same throttle/attempt-cap/peer-exclusion
+// knobs as the inbound path so the two never compound into a request storm:
+// because the inbound path keeps lastRequest fresh while it is making
+// progress, the MinInterval gate keeps this timer out of an actively
+// progressing acquire and only fires it once responses stop arriving.
+//
+// Runs on the Run() message-loop goroutine (same as handleTxSetData), so
+// reading state.txMap here never races the inbound path.
+func (r *Router) retryStalledTxSetAcquires() {
+	now := time.Now()
+	type txSetKick struct {
+		id       consensus.TxSetID
+		nodeIDs  [][]byte
+		excluded map[uint64]bool
+		attempts int
+		missing  int
+	}
+	type txSetDrop struct {
+		id       consensus.TxSetID
+		attempts int
+		missing  int
+	}
+	var kicks []txSetKick
+	var drops []txSetDrop
+
+	r.txSetAcquireMu.Lock()
+	r.sweepStaleTxSetAcquireLocked()
+	knobs := r.txSetRetryKnobs
+	for id, state := range r.txSetAcquire {
+		// Only re-trigger once the inbound path has been quiet for a full
+		// cadence window (rippled's TX_ACQUIRE_TIMEOUT). An actively
+		// progressing acquire keeps lastRequest fresh and is skipped here.
+		if !state.lastRequest.IsZero() && now.Sub(state.lastRequest) < knobs.MinInterval {
+			continue
+		}
+		missing := state.txMap.GetMissingNodes(256, nil)
+		if len(missing) == 0 {
+			// Tree is complete; the next inbound TMLedgerData (or a prior
+			// completion path) finalises it. Nothing to request.
+			continue
+		}
+		if state.attempts >= knobs.MaxAttempts {
+			delete(r.txSetAcquire, id)
+			drops = append(drops, txSetDrop{id: id, attempts: state.attempts, missing: len(missing)})
+			continue
+		}
+		state.attempts++
+		state.lastRequest = now
+		var excluded map[uint64]bool
+		for pid, count := range state.peerNonProgress {
+			if count >= knobs.PeerNonProgressThreshold {
+				if excluded == nil {
+					excluded = make(map[uint64]bool)
+				}
+				excluded[pid] = true
+			}
+		}
+		nodeIDs := make([][]byte, len(missing))
+		for i, m := range missing {
+			nodeIDs[i] = m.NodeID.Bytes()
+		}
+		kicks = append(kicks, txSetKick{id: id, nodeIDs: nodeIDs, excluded: excluded, attempts: state.attempts, missing: len(missing)})
+	}
+	r.txSetAcquireMu.Unlock()
+
+	for _, d := range drops {
+		// Drop rather than mark failed: if consensus still needs the set,
+		// the next inbound TMLedgerData / MarkTxSetStillNeeded starts a
+		// fresh acquire (mirrors handleTxSetData's max-attempts handling).
+		r.logger.Info("tx-set sync: max attempts exceeded (timer)",
+			"t", "consensus", "event", "txset-reject",
+			"txset", fmt.Sprintf("%x", d.id[:8]),
+			"attempts", d.attempts,
+			"missing", d.missing,
+		)
+	}
+	for _, k := range kicks {
+		r.logger.Info("tx-set sync: timer re-trigger",
+			"t", "consensus", "event", "txset-timer-retry",
+			"txset", fmt.Sprintf("%x", k.id[:8]),
+			"missing", k.missing,
+			"attempts", k.attempts,
+			"excluded_peers", len(k.excluded),
+		)
+		if err := r.adaptor.RequestTxSetMissingNodes(k.id, k.nodeIDs, k.excluded); err != nil {
+			r.logger.Info("tx-set sync: timer missing-nodes request failed",
+				"t", "consensus", "event", "txset-reject",
+				"txset", fmt.Sprintf("%x", k.id[:8]),
+				"error", err.Error())
 		}
 	}
 }

--- a/internal/consensus/adaptor/router_txset_timer_test.go
+++ b/internal/consensus/adaptor/router_txset_timer_test.go
@@ -1,0 +1,88 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #724: tx-set acquisition must keep re-requesting missing nodes on a
+// timer even when no further TMLedgerData arrives. The inbound path
+// (handleTxSetData) only fires on an arriving response; if the serving peer
+// falls silent mid-acquire, maintenanceTick's retryStalledTxSetAcquires is
+// the only thing that re-drives the request — mirroring rippled's
+// TransactionAcquire::onTimer.
+
+// When inbound responses stop, the timer re-requests the still-missing nodes
+// on each tick while the acquire is incomplete.
+func TestTxSetAcquire_TimerRetriggersWhenInboundQuiet(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+
+	// MinInterval=0 so each tick is eligible to fire (no production wait).
+	withRetryKnobs(router, 0, 20, 3, func() {
+		// First inbound response: creates the acquire (root only → incomplete)
+		// and issues the inbound missing-nodes request.
+		router.handleTxSetData(ld, 4)
+		firstN := rs.calledN()
+		require.GreaterOrEqual(t, firstN, 1, "inbound path issues the first missing-nodes request")
+
+		// Peer goes silent. The timer must re-request without any new inbound.
+		router.maintenanceTick()
+		require.Greater(t, rs.calledN(), firstN,
+			"timer must re-request missing nodes when inbound responses stop (issue #724)")
+
+		// And it keeps re-driving on subsequent ticks while still incomplete.
+		n2 := rs.calledN()
+		router.maintenanceTick()
+		require.Greater(t, rs.calledN(), n2,
+			"timer keeps re-requesting each tick until the acquire completes or hits the cap")
+
+		require.Equal(t, txSetID, rs.lastCall().txSetID, "re-request targets the same tx-set")
+		require.NotEmpty(t, rs.lastCall().nodeIDs, "re-request carries the missing node IDs")
+	})
+}
+
+// The timer respects the MinInterval cadence: an acquire whose inbound path
+// just requested (fresh lastRequest) is not re-fired by a tick inside the
+// window, mirroring rippled's 250ms TX_ACQUIRE_TIMEOUT spacing.
+func TestTxSetAcquire_TimerRespectsMinInterval(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	ld, _ := rootOnlyTxSetLedgerData(t, 8)
+
+	withRetryKnobs(router, time.Hour, 20, 3, func() {
+		router.handleTxSetData(ld, 4)
+		afterInbound := rs.calledN()
+		// lastRequest was just set; a tick inside the (1h) window must not fire.
+		router.maintenanceTick()
+		require.Equal(t, afterInbound, rs.calledN(),
+			"timer must not re-request inside the MinInterval cadence window")
+	})
+}
+
+// Once the attempt cap is reached with no progress, the timer drops the
+// acquire instead of spinning forever (mirrors the inbound max-attempts path
+// and rippled's MAX_TIMEOUTS).
+func TestTxSetAcquire_TimerDropsAtMaxAttempts(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+
+	withRetryKnobs(router, 0, 3, 3, func() {
+		router.handleTxSetData(ld, 4)
+		// Drive ticks well past the cap; the acquire must be dropped and
+		// re-requests must stop.
+		for i := 0; i < 10; i++ {
+			router.maintenanceTick()
+		}
+		router.txSetAcquireMu.Lock()
+		_, stillTracked := router.txSetAcquire[txSetID]
+		router.txSetAcquireMu.Unlock()
+		require.False(t, stillTracked, "acquire must be dropped after exceeding MaxAttempts")
+
+		// No further re-requests once dropped.
+		n := rs.calledN()
+		router.maintenanceTick()
+		require.Equal(t, n, rs.calledN(), "no re-requests after the acquire is dropped")
+	})
+}


### PR DESCRIPTION
## Problem

On the xrpl-confluence mixed soak, a go-xrpl node falls behind during consensus, can't reconstruct the agreed transaction set, enters `wrongLedger`, and drops the network below quorum (issue #724, NODE-BEHIND / tx-set-acquisition).

## Root cause

go-xrpl's tx-set acquisition advanced **only** when an inbound `TMLedgerData` arrived (`handleTxSetData`). When a serving peer falls silent mid-acquire — or every reply is throttled by the issue-#420 cadence gate — nothing re-requests the remaining SHAMap nodes, so `missing=N` never drains and the node closes its own (wrong) ledger. The struct comment even noted the retry was "event-driven … rather than directly mirror rippled's timer-driven cadence." rippled has the missing driver: `TransactionAcquire::onTimer` (TransactionAcquire.cpp:89) fires every `TX_ACQUIRE_TIMEOUT` (250ms) up to `MAX_TIMEOUTS` and re-triggers the request (+ rotates peers).

## Fix

Add `retryStalledTxSetAcquires()`, driven from the `Run()` message-loop's `maintenanceTick` (100ms), reusing the existing `MinInterval`/`MaxAttempts`/peer-exclusion knobs:
- runs on the same goroutine as `handleTxSetData` (single-writer select loop), so reading `state.txMap` never races the inbound path;
- the `MinInterval` gate keeps it out of an actively-progressing acquire (whose `lastRequest` stays fresh) and fires only once inbound responses stop — exactly rippled's `onTimer` safety-net semantics;
- the TTL sweep now also runs on the timer, so a fully silent acquire is reaped without inbound traffic.

## Tests

`internal/consensus/adaptor/router_txset_timer_test.go`: timer re-requests when inbound goes quiet, respects the MinInterval cadence window, and drops the acquire past MaxAttempts. Full consensus suite + vet clean.

Refs #724