### PR TITLE
Promote develop → main: 3 consensus-fork fixes (#736, #738, #739)

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -1690,8 +1690,14 @@ func (r *Router) retryStalledTxSetAcquires() {
 		attempts int
 		missing  int
 	}
+	type txSetComplete struct {
+		id     consensus.TxSetID
+		txMap  *shamap.SHAMap
+		filled int
+	}
 	var kicks []txSetKick
 	var drops []txSetDrop
+	var completes []txSetComplete
 
 	r.txSetAcquireMu.Lock()
 	r.sweepStaleTxSetAcquireLocked()
@@ -1707,6 +1713,39 @@ func (r *Router) retryStalledTxSetAcquires() {
 		if len(missing) == 0 {
 			// Tree is complete; the next inbound TMLedgerData (or a prior
 			// completion path) finalises it. Nothing to request.
+			continue
+		}
+		// Before re-requesting from peers, source any still-missing tx-leaf
+		// nodes from our own pending pool — the same local fill the inbound
+		// path performs (handleTxSetData), mirroring rippled's
+		// ConsensusTransSetSF::getNode. For tnTRANSACTION_NM the leaf hash
+		// equals the tx ID, so a single GetTx resolves the leaf. This avoids
+		// asking a peer for a tx we already hold; if the pool has grown since
+		// the last inbound reply it can complete the tree outright. GetTx is a
+		// local pool read and txMap is owned by this (Run) goroutine, so the
+		// fill is safe under txSetAcquireMu.
+		filled := 0
+		for _, m := range missing {
+			blob, getErr := r.adaptor.GetTx(consensus.TxID(m.Hash))
+			if getErr != nil || len(blob) == 0 {
+				continue
+			}
+			wire := make([]byte, len(blob)+1)
+			copy(wire, blob)
+			wire[len(blob)] = byte(protocol.WireTypeTransaction)
+			if addErr := state.txMap.AddKnownNode(m.Hash, wire); addErr == nil {
+				filled++
+			}
+		}
+		if filled > 0 {
+			_ = state.txMap.FinishSync()
+			missing = state.txMap.GetMissingNodes(256, nil)
+		}
+		if len(missing) == 0 {
+			// Completed from the local pool. Feed the engine just like the
+			// inbound completion path — peers are silent, so nothing else
+			// will. Finalised after the lock is released.
+			completes = append(completes, txSetComplete{id: id, txMap: state.txMap, filled: filled})
 			continue
 		}
 		if state.attempts >= knobs.MaxAttempts {
@@ -1733,6 +1772,9 @@ func (r *Router) retryStalledTxSetAcquires() {
 	}
 	r.txSetAcquireMu.Unlock()
 
+	for _, c := range completes {
+		r.finalizeLocalFilledTxSet(c.id, c.txMap, c.filled)
+	}
 	for _, d := range drops {
 		// Drop rather than mark failed: if consensus still needs the set,
 		// the next inbound TMLedgerData / MarkTxSetStillNeeded starts a
@@ -1758,6 +1800,38 @@ func (r *Router) retryStalledTxSetAcquires() {
 				"txset", fmt.Sprintf("%x", k.id[:8]),
 				"error", err.Error())
 		}
+	}
+}
+
+// finalizeLocalFilledTxSet feeds the engine a tx-set whose SHAMap the retry
+// timer completed from the local pending pool, mirroring the inbound completion
+// path in handleTxSetData. Runs on the Run() message-loop goroutine. The engine
+// re-checks the tx-set ID, so a stale or duplicate set is rejected with a log
+// rather than corrupting state.
+func (r *Router) finalizeLocalFilledTxSet(txSetID consensus.TxSetID, txMap *shamap.SHAMap, filled int) {
+	blobs := make([][]byte, 0)
+	if err := txMap.ForEach(func(item *shamap.Item) bool {
+		blobs = append(blobs, item.Data())
+		return true
+	}); err != nil {
+		r.deleteTxSetAcquire(txSetID)
+		return
+	}
+	r.deleteTxSetAcquire(txSetID)
+	if len(blobs) == 0 {
+		return
+	}
+	r.logger.Info("tx-set sync: completed via local pool (timer)",
+		"t", "consensus", "event", "txset-local-fill",
+		"txset", fmt.Sprintf("%x", txSetID[:8]),
+		"filled", filled,
+		"tx_count", len(blobs))
+	if err := r.engine.OnTxSet(txSetID, blobs); err != nil {
+		r.logger.Info("engine rejected tx-set",
+			"t", "consensus", "event", "txset-reject",
+			"error", err.Error(),
+			"txset", fmt.Sprintf("%x", txSetID[:8]),
+			"tx_count", len(blobs))
 	}
 }
 

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -436,6 +436,13 @@ func (r *Router) maintenanceTick() {
 		// fresh acquisition via startLedgerAcquisition once the stuck
 		// reference is cleared.
 	}
+
+	// Timer-driven tx-set acquisition re-trigger (issue #724). go-xrpl's
+	// inbound retry (handleTxSetData) only advances when a TMLedgerData
+	// arrives; if a peer falls silent mid-acquire nothing re-requests the
+	// remaining nodes and the node stalls into wrongLedger. This is the
+	// missing analogue of rippled's TransactionAcquire::onTimer.
+	r.retryStalledTxSetAcquires()
 }
 
 func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
@@ -1646,6 +1653,110 @@ func (r *Router) sweepStaleTxSetAcquireLocked() {
 	for id, state := range r.txSetAcquire {
 		if state.lastUpdate.Before(cutoff) {
 			delete(r.txSetAcquire, id)
+		}
+	}
+}
+
+// retryStalledTxSetAcquires re-requests the still-missing nodes of any
+// in-flight tx-set acquisition whose inbound responses have gone quiet, and
+// sweeps entries past their TTL. It is the timer-driven analogue of rippled's
+// TransactionAcquire::onTimer (TransactionAcquire.cpp:89), which fires every
+// TX_ACQUIRE_TIMEOUT (250ms) and re-triggers the request up to MAX_TIMEOUTS.
+//
+// go-xrpl's inbound retry (handleTxSetData) only advances on an arriving
+// TMLedgerData. When a peer falls silent mid-acquire — or every reply is
+// throttled — nothing re-requests the remaining nodes, so the acquisition
+// stalls until the 60s TTL sweep; under load that drops the node into
+// wrongLedger and the mixed network below quorum (issue #724). This timer is
+// the missing driver. It reuses the same throttle/attempt-cap/peer-exclusion
+// knobs as the inbound path so the two never compound into a request storm:
+// because the inbound path keeps lastRequest fresh while it is making
+// progress, the MinInterval gate keeps this timer out of an actively
+// progressing acquire and only fires it once responses stop arriving.
+//
+// Runs on the Run() message-loop goroutine (same as handleTxSetData), so
+// reading state.txMap here never races the inbound path.
+func (r *Router) retryStalledTxSetAcquires() {
+	now := time.Now()
+	type txSetKick struct {
+		id       consensus.TxSetID
+		nodeIDs  [][]byte
+		excluded map[uint64]bool
+		attempts int
+		missing  int
+	}
+	type txSetDrop struct {
+		id       consensus.TxSetID
+		attempts int
+		missing  int
+	}
+	var kicks []txSetKick
+	var drops []txSetDrop
+
+	r.txSetAcquireMu.Lock()
+	r.sweepStaleTxSetAcquireLocked()
+	knobs := r.txSetRetryKnobs
+	for id, state := range r.txSetAcquire {
+		// Only re-trigger once the inbound path has been quiet for a full
+		// cadence window (rippled's TX_ACQUIRE_TIMEOUT). An actively
+		// progressing acquire keeps lastRequest fresh and is skipped here.
+		if !state.lastRequest.IsZero() && now.Sub(state.lastRequest) < knobs.MinInterval {
+			continue
+		}
+		missing := state.txMap.GetMissingNodes(256, nil)
+		if len(missing) == 0 {
+			// Tree is complete; the next inbound TMLedgerData (or a prior
+			// completion path) finalises it. Nothing to request.
+			continue
+		}
+		if state.attempts >= knobs.MaxAttempts {
+			delete(r.txSetAcquire, id)
+			drops = append(drops, txSetDrop{id: id, attempts: state.attempts, missing: len(missing)})
+			continue
+		}
+		state.attempts++
+		state.lastRequest = now
+		var excluded map[uint64]bool
+		for pid, count := range state.peerNonProgress {
+			if count >= knobs.PeerNonProgressThreshold {
+				if excluded == nil {
+					excluded = make(map[uint64]bool)
+				}
+				excluded[pid] = true
+			}
+		}
+		nodeIDs := make([][]byte, len(missing))
+		for i, m := range missing {
+			nodeIDs[i] = m.NodeID.Bytes()
+		}
+		kicks = append(kicks, txSetKick{id: id, nodeIDs: nodeIDs, excluded: excluded, attempts: state.attempts, missing: len(missing)})
+	}
+	r.txSetAcquireMu.Unlock()
+
+	for _, d := range drops {
+		// Drop rather than mark failed: if consensus still needs the set,
+		// the next inbound TMLedgerData / MarkTxSetStillNeeded starts a
+		// fresh acquire (mirrors handleTxSetData's max-attempts handling).
+		r.logger.Info("tx-set sync: max attempts exceeded (timer)",
+			"t", "consensus", "event", "txset-reject",
+			"txset", fmt.Sprintf("%x", d.id[:8]),
+			"attempts", d.attempts,
+			"missing", d.missing,
+		)
+	}
+	for _, k := range kicks {
+		r.logger.Info("tx-set sync: timer re-trigger",
+			"t", "consensus", "event", "txset-timer-retry",
+			"txset", fmt.Sprintf("%x", k.id[:8]),
+			"missing", k.missing,
+			"attempts", k.attempts,
+			"excluded_peers", len(k.excluded),
+		)
+		if err := r.adaptor.RequestTxSetMissingNodes(k.id, k.nodeIDs, k.excluded); err != nil {
+			r.logger.Info("tx-set sync: timer missing-nodes request failed",
+				"t", "consensus", "event", "txset-reject",
+				"txset", fmt.Sprintf("%x", k.id[:8]),
+				"error", err.Error())
 		}
 	}
 }

--- a/internal/consensus/adaptor/router_txset_timer_test.go
+++ b/internal/consensus/adaptor/router_txset_timer_test.go
@@ -86,3 +86,62 @@ func TestTxSetAcquire_TimerDropsAtMaxAttempts(t *testing.T) {
 		require.Equal(t, n, rs.calledN(), "no re-requests after the acquire is dropped")
 	})
 }
+
+// The timer must not compound with an actively-progressing inbound path. While
+// the inbound lastRequest is still fresh (inside the cadence window), repeated
+// maintenance ticks add ZERO extra missing-nodes requests. This pins the
+// anti-compounding invariant the timer relies on: the inbound path keeps
+// lastRequest fresh while making progress, and the MinInterval gate keeps the
+// timer out until responses actually stop.
+func TestTxSetAcquire_TimerStaysOutWhileInboundFresh(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	ld, _ := rootOnlyTxSetLedgerData(t, 8)
+
+	// Real (large) cadence window: the inbound request just set lastRequest, so
+	// every tick below falls inside the window.
+	withRetryKnobs(router, time.Hour, 20, 3, func() {
+		router.handleTxSetData(ld, 4)
+		afterInbound := rs.calledN()
+		require.GreaterOrEqual(t, afterInbound, 1, "inbound path issues the first request")
+
+		for i := 0; i < 5; i++ {
+			router.maintenanceTick()
+		}
+		require.Equal(t, afterInbound, rs.calledN(),
+			"timer must add zero requests while the inbound lastRequest is fresh "+
+				"(anti-compounding invariant)")
+	})
+}
+
+// A timer drop is revivable, not terminal: after the timer drops an acquire at
+// the attempt cap, a fresh inbound TMLedgerData for the same tx-set must
+// re-create the acquire and resume requesting — mirroring rippled's stillNeed
+// reset path (TransactionAcquire.cpp:256-264). Without this, consensus
+// oscillating back to a dropped set would wait out the 60s TTL.
+func TestTxSetAcquire_TimerDropIsRevivableByInbound(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+
+	withRetryKnobs(router, 0, 3, 3, func() {
+		// Create the acquire, then drive ticks past the cap to drop it.
+		router.handleTxSetData(ld, 4)
+		for i := 0; i < 10; i++ {
+			router.maintenanceTick()
+		}
+		router.txSetAcquireMu.Lock()
+		_, tracked := router.txSetAcquire[txSetID]
+		router.txSetAcquireMu.Unlock()
+		require.False(t, tracked, "acquire must be dropped by the timer after exceeding MaxAttempts")
+
+		n := rs.calledN()
+
+		// A fresh inbound reply re-creates the acquire and broadcasts again.
+		router.handleTxSetData(ld, 5)
+		require.Greater(t, rs.calledN(), n,
+			"a fresh inbound reply after a timer drop must re-create the acquire and resume requesting")
+		router.txSetAcquireMu.Lock()
+		_, tracked = router.txSetAcquire[txSetID]
+		router.txSetAcquireMu.Unlock()
+		require.True(t, tracked, "the acquire is tracked again after the reviving inbound reply")
+	})
+}

--- a/internal/consensus/adaptor/router_txset_timer_test.go
+++ b/internal/consensus/adaptor/router_txset_timer_test.go
@@ -1,0 +1,88 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #724: tx-set acquisition must keep re-requesting missing nodes on a
+// timer even when no further TMLedgerData arrives. The inbound path
+// (handleTxSetData) only fires on an arriving response; if the serving peer
+// falls silent mid-acquire, maintenanceTick's retryStalledTxSetAcquires is
+// the only thing that re-drives the request — mirroring rippled's
+// TransactionAcquire::onTimer.
+
+// When inbound responses stop, the timer re-requests the still-missing nodes
+// on each tick while the acquire is incomplete.
+func TestTxSetAcquire_TimerRetriggersWhenInboundQuiet(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+
+	// MinInterval=0 so each tick is eligible to fire (no production wait).
+	withRetryKnobs(router, 0, 20, 3, func() {
+		// First inbound response: creates the acquire (root only → incomplete)
+		// and issues the inbound missing-nodes request.
+		router.handleTxSetData(ld, 4)
+		firstN := rs.calledN()
+		require.GreaterOrEqual(t, firstN, 1, "inbound path issues the first missing-nodes request")
+
+		// Peer goes silent. The timer must re-request without any new inbound.
+		router.maintenanceTick()
+		require.Greater(t, rs.calledN(), firstN,
+			"timer must re-request missing nodes when inbound responses stop (issue #724)")
+
+		// And it keeps re-driving on subsequent ticks while still incomplete.
+		n2 := rs.calledN()
+		router.maintenanceTick()
+		require.Greater(t, rs.calledN(), n2,
+			"timer keeps re-requesting each tick until the acquire completes or hits the cap")
+
+		require.Equal(t, txSetID, rs.lastCall().txSetID, "re-request targets the same tx-set")
+		require.NotEmpty(t, rs.lastCall().nodeIDs, "re-request carries the missing node IDs")
+	})
+}
+
+// The timer respects the MinInterval cadence: an acquire whose inbound path
+// just requested (fresh lastRequest) is not re-fired by a tick inside the
+// window, mirroring rippled's 250ms TX_ACQUIRE_TIMEOUT spacing.
+func TestTxSetAcquire_TimerRespectsMinInterval(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	ld, _ := rootOnlyTxSetLedgerData(t, 8)
+
+	withRetryKnobs(router, time.Hour, 20, 3, func() {
+		router.handleTxSetData(ld, 4)
+		afterInbound := rs.calledN()
+		// lastRequest was just set; a tick inside the (1h) window must not fire.
+		router.maintenanceTick()
+		require.Equal(t, afterInbound, rs.calledN(),
+			"timer must not re-request inside the MinInterval cadence window")
+	})
+}
+
+// Once the attempt cap is reached with no progress, the timer drops the
+// acquire instead of spinning forever (mirrors the inbound max-attempts path
+// and rippled's MAX_TIMEOUTS).
+func TestTxSetAcquire_TimerDropsAtMaxAttempts(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+
+	withRetryKnobs(router, 0, 3, 3, func() {
+		router.handleTxSetData(ld, 4)
+		// Drive ticks well past the cap; the acquire must be dropped and
+		// re-requests must stop.
+		for i := 0; i < 10; i++ {
+			router.maintenanceTick()
+		}
+		router.txSetAcquireMu.Lock()
+		_, stillTracked := router.txSetAcquire[txSetID]
+		router.txSetAcquireMu.Unlock()
+		require.False(t, stillTracked, "acquire must be dropped after exceeding MaxAttempts")
+
+		// No further re-requests once dropped.
+		n := rs.calledN()
+		router.maintenanceTick()
+		require.Equal(t, n, rs.calledN(), "no re-requests after the acquire is dropped")
+	})
+}

--- a/internal/ledger/state/account_root.go
+++ b/internal/ledger/state/account_root.go
@@ -30,6 +30,7 @@ type AccountRoot struct {
 	FirstNFTokenSequence uint32   // First NFToken sequence (set by fixNFTokenRemint)
 	HasFirstNFTSeq       bool     // Whether FirstNFTokenSequence is set (zero is a valid value)
 	AccountTxnID         [32]byte // Hash of the last transaction this account submitted (when enabled)
+	HasAccountTxnID      bool     // Whether sfAccountTxnID is present (zero is a valid value after asfAccountTxnID is enabled)
 	WalletLocator        string   // Arbitrary hex data (deprecated)
 	TicketCount          uint32   // Number of outstanding tickets owned by this account
 	AMMID                [32]byte // Links AMM pseudo-account to its AMM ledger entry (sfAMMID, fieldCode 14)
@@ -347,6 +348,7 @@ func ParseAccountRoot(data []byte) (*AccountRoot, error) {
 				copy(account.PreviousTxnID[:], data[offset:offset+32])
 			case fieldCodeAccountTxnID: // AccountTxnID
 				copy(account.AccountTxnID[:], data[offset:offset+32])
+				account.HasAccountTxnID = true
 			case fieldCodeWalletLocator: // WalletLocator
 				account.WalletLocator = hex.EncodeToString(data[offset : offset+32])
 			case fieldCodeAMMID: // AMMID - links AMM pseudo-account to AMM entry
@@ -445,9 +447,12 @@ func SerializeAccountRoot(account *AccountRoot) ([]byte, error) {
 		jsonObj["TicketCount"] = account.TicketCount
 	}
 
-	// Add AccountTxnID if set (non-zero)
+	// Add AccountTxnID if present. Once asfAccountTxnID is enabled the field is
+	// present even while still zero (before the account's next transaction),
+	// mirroring rippled's makeFieldPresent(sfAccountTxnID). Keyed on presence,
+	// not non-zero, so a present-zero value round-trips.
 	var zeroHash [32]byte
-	if account.AccountTxnID != zeroHash {
+	if account.HasAccountTxnID {
 		jsonObj["AccountTxnID"] = strings.ToUpper(hex.EncodeToString(account.AccountTxnID[:]))
 	}
 

--- a/internal/testing/accountset/accountset_test.go
+++ b/internal/testing/accountset/accountset_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
+	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // asfToLsf maps an AccountSet flag (asf*) to the corresponding ledger flag (lsf*).
@@ -189,22 +190,33 @@ func TestAccountSet_SetAndResetAccountTxnID(t *testing.T) {
 
 	origFlags := env.AccountInfo(alice).Flags
 
-	// AccountTxnID should not be present initially
-	var zeroHash [32]byte
-	info := env.AccountInfo(alice)
-	require.Equal(t, zeroHash, info.AccountTxnID, "AccountTxnID should not be present initially")
+	// asfAccountTxnID controls field PRESENCE (rippled isFieldPresent), not a
+	// value: enable makes sfAccountTxnID present with value zero, clear removes
+	// it. Check presence via the raw AccountRoot, mirroring rippled's
+	// AccountSet_test.cpp checks.
+	hasAccountTxnID := func() bool {
+		t.Helper()
+		data, err := env.LedgerEntry(keylet.Account(alice.ID))
+		require.NoError(t, err)
+		ar, err := state.ParseAccountRootFromBytes(data)
+		require.NoError(t, err)
+		return ar.HasAccountTxnID
+	}
 
-	// Set asfAccountTxnID — field should become present
+	// AccountTxnID should not be present initially.
+	require.False(t, hasAccountTxnID(), "AccountTxnID should not be present initially")
+
+	// Set asfAccountTxnID — field should become present (value zero).
 	result := env.Submit(AccountSet(alice).SetFlag(accounttx.AccountSetFlagAccountTxnID).Build())
 	jtx.RequireTxSuccess(t, result)
-	info = env.AccountInfo(alice)
-	require.NotEqual(t, zeroHash, info.AccountTxnID, "AccountTxnID should be present after set")
+	env.Close()
+	require.True(t, hasAccountTxnID(), "AccountTxnID should be present after set")
 
-	// Clear asfAccountTxnID — field should be removed
+	// Clear asfAccountTxnID — field should be removed.
 	result = env.Submit(AccountSet(alice).ClearFlag(accounttx.AccountSetFlagAccountTxnID).Build())
 	jtx.RequireTxSuccess(t, result)
-	info = env.AccountInfo(alice)
-	require.Equal(t, zeroHash, info.AccountTxnID, "AccountTxnID should not be present after clear")
+	env.Close()
+	require.False(t, hasAccountTxnID(), "AccountTxnID should not be present after clear")
 
 	// Flags should be unchanged
 	nowFlags := env.AccountInfo(alice).Flags

--- a/internal/testing/accountset/accounttxnid_test.go
+++ b/internal/testing/accountset/accounttxnid_test.go
@@ -1,0 +1,69 @@
+package accountset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// Regression for the seq-N account_hash fork found in the mixed soak:
+// enabling asfAccountTxnID must make sfAccountTxnID PRESENT with value zero
+// (rippled SetAccount.cpp makeFieldPresent(sfAccountTxnID)), and the account's
+// next transaction must update that present-zero field to the tx id (rippled
+// Transactor::apply isFieldPresent(sfAccountTxnID), Transactor.cpp:568-569).
+//
+// go-xrpl previously tracked presence as "non-zero", setting AccountTxnID to
+// the enabling tx's hash and updating only when non-zero. That both diverged
+// from rippled's present-zero value at enable time AND silently dropped the
+// update for a present-zero field adopted from a rippled-built ledger — forking
+// account_hash while transaction_hash matched.
+func TestAccountSet_AccountTxnID_PresentZeroAndUpdate(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.FundNoRipple(alice)
+	env.Close()
+
+	readAR := func() *state.AccountRoot {
+		t.Helper()
+		data, err := env.LedgerEntry(keylet.Account(alice.ID))
+		require.NoError(t, err)
+		ar, err := state.ParseAccountRootFromBytes(data)
+		require.NoError(t, err)
+		return ar
+	}
+	var zero [32]byte
+
+	// Enable asfAccountTxnID → field present, value zero.
+	r := env.Submit(AccountSet(alice).SetFlag(accounttx.AccountSetFlagAccountTxnID).Build())
+	jtx.RequireTxSuccess(t, r)
+	env.Close()
+
+	ar := readAR()
+	require.True(t, ar.HasAccountTxnID, "enable must make sfAccountTxnID present")
+	require.Equal(t, zero, ar.AccountTxnID,
+		"enable must leave AccountTxnID zero, not the enabling tx hash (rippled makeFieldPresent)")
+
+	// Next transaction must update the present-zero field to the tx id.
+	r = env.Submit(AccountSet(alice).Build()) // noop AccountSet
+	jtx.RequireTxSuccess(t, r)
+	env.Close()
+
+	ar = readAR()
+	require.True(t, ar.HasAccountTxnID, "AccountTxnID must remain present after the update")
+	require.NotEqual(t, zero, ar.AccountTxnID,
+		"the account's next tx must update present-zero AccountTxnID to the tx id")
+
+	// Clearing removes the field entirely.
+	r = env.Submit(AccountSet(alice).ClearFlag(accounttx.AccountSetFlagAccountTxnID).Build())
+	jtx.RequireTxSuccess(t, r)
+	env.Close()
+
+	ar = readAR()
+	require.False(t, ar.HasAccountTxnID, "clear must remove sfAccountTxnID")
+	require.Equal(t, zero, ar.AccountTxnID)
+}

--- a/internal/testing/env_flags.go
+++ b/internal/testing/env_flags.go
@@ -183,6 +183,25 @@ func (e *TestEnv) DisableRequireDest(acc *Account) {
 	}
 }
 
+// EnableDisallowXRP enables the DisallowXRP flag on an account.
+// This flag is advisory only: rippled does NOT enforce it in the Payment
+// transactor, so XRP payments to such an account still succeed.
+func (e *TestEnv) EnableDisallowXRP(acc *Account) {
+	e.t.Helper()
+
+	accountSet := account.NewAccountSet(acc.Address)
+	flag := account.AccountSetFlagDisallowXRP
+	accountSet.SetFlag = &flag
+	accountSet.Fee = formatUint64(e.baseFee)
+	seq := e.Seq(acc)
+	accountSet.Sequence = &seq
+
+	result := e.Submit(accountSet)
+	if !result.Success {
+		e.t.Fatalf("Failed to enable DisallowXRP for account %s: %s", acc.Name, result.Code)
+	}
+}
+
 // Preauthorize allows owner to preauthorize authorized for deposits.
 // This creates a DepositPreauth ledger entry.
 func (e *TestEnv) Preauthorize(owner, authorized *Account) {

--- a/internal/testing/env_queries.go
+++ b/internal/testing/env_queries.go
@@ -329,6 +329,7 @@ func (e *TestEnv) AccountInfo(acc *Account) *AccountInfo {
 		MessageKey:           accountRoot.MessageKey,
 		WalletLocator:        accountRoot.WalletLocator,
 		AccountTxnID:         accountRoot.AccountTxnID,
+		HasAccountTxnID:      accountRoot.HasAccountTxnID,
 		TransferRate:         accountRoot.TransferRate,
 		TicketCount:          accountRoot.TicketCount,
 	}
@@ -350,6 +351,7 @@ type AccountInfo struct {
 	MessageKey           string
 	WalletLocator        string
 	AccountTxnID         [32]byte
+	HasAccountTxnID      bool
 	TransferRate         uint32
 	TicketCount          uint32
 }

--- a/internal/testing/payment/payment_test.go
+++ b/internal/testing/payment/payment_test.go
@@ -35,6 +35,39 @@ func TestPaymentXRPTransfer(t *testing.T) {
 	xrplgoTesting.RequireBalance(t, env, alice, xrplgoTesting.XRPMinusFees(env, 10000-100, 1))
 }
 
+// TestPaymentToDisallowXRP verifies that an XRP payment to a destination with the
+// lsfDisallowXRP flag set still SUCCEEDS and delivers the XRP. lsfDisallowXRP is an
+// advisory flag enforced only by client applications: rippled's Payment transactor
+// never checks it (Payment.cpp has no lsfDisallowXRP reference, and PayChan.cpp:234
+// notes "Obeying the lsfDisallowXRP flag was a bug"). Regression test for the
+// mixed-network ledger fork where goXRPL wrongly returned tecNO_TARGET for such a
+// payment, diverging account_hash and wedging consensus.
+func TestPaymentToDisallowXRP(t *testing.T) {
+	env := xrplgoTesting.NewTestEnv(t)
+
+	alice := xrplgoTesting.NewAccount("alice")
+	bob := xrplgoTesting.NewAccount("bob")
+
+	env.FundAmount(alice, uint64(xrplgoTesting.XRP(10000)))
+	env.FundAmount(bob, uint64(xrplgoTesting.XRP(10000)))
+	env.Close()
+
+	// Bob sets DisallowXRP (advisory only — must not block incoming XRP).
+	env.EnableDisallowXRP(bob)
+	env.Close()
+
+	// Alice sends Bob 100 XRP. Must succeed despite Bob's DisallowXRP flag.
+	payment := Pay(alice, bob, uint64(xrplgoTesting.XRP(100))).Build()
+	result := env.Submit(payment)
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	// Bob received the XRP (10000 + 100, minus the 1 fee from his AccountSet).
+	xrplgoTesting.RequireBalance(t, env, bob, xrplgoTesting.XRPMinusFees(env, 10000+100, 1))
+	// Alice sent 100 and paid 1 fee.
+	xrplgoTesting.RequireBalance(t, env, alice, xrplgoTesting.XRPMinusFees(env, 10000-100, 1))
+}
+
 // TestPaymentToNonexistent tests payment to a nonexistent account.
 // Reference: TrustAndBalance_test.cpp - testPayNonexistent
 func TestPaymentToNonexistent(t *testing.T) {

--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -390,14 +390,17 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// AccountTxnID
-	if uSetFlag == AccountSetFlagAccountTxnID {
-		var zeroHash [32]byte
-		if account.AccountTxnID == zeroHash {
-			account.AccountTxnID = ctx.TxHash
-		}
+	// AccountTxnID: enabling makes the field present (initial value zero),
+	// mirroring rippled SetAccount.cpp makeFieldPresent(sfAccountTxnID); the
+	// account's next transaction updates it to that tx's ID. Clearing removes
+	// the field. Presence is tracked separately so a present-zero value (after
+	// enable, before the next tx) round-trips instead of being treated as absent.
+	if uSetFlag == AccountSetFlagAccountTxnID && !account.HasAccountTxnID {
+		account.HasAccountTxnID = true
+		account.AccountTxnID = [32]byte{}
 	}
 	if uClearFlag == AccountSetFlagAccountTxnID {
+		account.HasAccountTxnID = false
 		account.AccountTxnID = [32]byte{}
 	}
 

--- a/internal/tx/do_apply.go
+++ b/internal/tx/do_apply.go
@@ -201,15 +201,15 @@ func (e *Engine) applyPreApplyAccountChanges(st *applyState) Result {
 	st.account.PreviousTxnID = st.txHash
 	st.account.PreviousTxnLgrSeq = e.config.LedgerSequence
 
-	// Update AccountTxnID if the account has tracking enabled (field is present/non-zero).
+	// Update AccountTxnID if the account has tracking enabled (field present).
+	// Keyed on presence, not non-zero: a freshly-enabled asfAccountTxnID is
+	// present-but-zero until this update, and rippled updates it on the very
+	// next transaction.
 	// Reference: rippled Transactor::apply() line 568-569:
 	//   if (sle->isFieldPresent(sfAccountTxnID))
 	//       sle->setFieldH256(sfAccountTxnID, ctx_.tx.getTransactionID());
-	{
-		var zeroHash [32]byte
-		if st.account.AccountTxnID != zeroHash {
-			st.account.AccountTxnID = st.txHash
-		}
+	if st.account.HasAccountTxnID {
+		st.account.AccountTxnID = st.txHash
 	}
 
 	// Write the fee-deducted, sequence-incremented account to the table BEFORE Apply().
@@ -593,15 +593,15 @@ func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *ApplyStateTable,
 	recoveredAccount.PreviousTxnID = st.txHash
 	recoveredAccount.PreviousTxnLgrSeq = e.config.LedgerSequence
 
-	// Update AccountTxnID if the account has tracking enabled (field is present/non-zero).
+	// Update AccountTxnID if the account has tracking enabled (field present).
 	// On the success path, apply() sets this before doApply(). On the tec path,
 	// reset() discards all changes then re-applies fee/sequence. The AccountTxnID
 	// must also be updated here so the account tracks the last-applied transaction
-	// even when the result is a tec code.
+	// even when the result is a tec code. Keyed on presence, not non-zero, so a
+	// freshly-enabled present-zero field is still updated.
 	// Reference: rippled Transactor::apply() lines 568-569.
 	{
-		var zeroHash [32]byte
-		if recoveredAccount.AccountTxnID != zeroHash {
+		if recoveredAccount.HasAccountTxnID {
 			recoveredAccount.AccountTxnID = st.txHash
 		}
 	}

--- a/internal/tx/escrow/token_helpers.go
+++ b/internal/tx/escrow/token_helpers.go
@@ -8,11 +8,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
-	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
-	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -1276,113 +1273,15 @@ func accountHoldsMPT(view tx.LedgerView, issuanceKey keylet.Keylet, accountID [2
 	return int64(token.MPTAmount)
 }
 
-// adjustOwnerCountViaView adjusts an account's OwnerCount by reading, modifying,
-// and writing back the AccountRoot. adj can be positive or negative.
+// adjustOwnerCountViaView adjusts an account's OwnerCount by delta, delegating
+// to the canonical tx.AdjustOwnerCount so the write-back goes through the single
+// shared AccountRoot serializer (state.SerializeAccountRoot). A hand-rolled
+// serializer here previously dropped a present-but-zero sfAccountTxnID and
+// mis-encoded sfDomain, diverging from the canonical path on the token-escrow
+// finish owner-count bump and forking account_hash (#741 review). Mirrors how
+// the nftoken package delegates the same operation.
 func adjustOwnerCountViaView(view tx.LedgerView, accountID [20]byte, adj int) {
-	acctKey := keylet.Account(accountID)
-	data, err := view.Read(acctKey)
-	if err != nil || data == nil {
-		return
-	}
-
-	acct, err := state.ParseAccountRoot(data)
-	if err != nil {
-		return
-	}
-
-	if adj > 0 {
-		acct.OwnerCount += uint32(adj)
-	} else if adj < 0 {
-		decrement := uint32(-adj)
-		if acct.OwnerCount >= decrement {
-			acct.OwnerCount -= decrement
-		} else {
-			acct.OwnerCount = 0
-		}
-	}
-
-	// Re-serialize and update
-	address, err := addresscodec.EncodeAccountIDToClassicAddress(accountID[:])
-	if err != nil {
-		return
-	}
-
-	jsonObj := buildAccountRootJSON(acct, address)
-	hexStr, err := binarycodec.Encode(jsonObj)
-	if err != nil {
-		return
-	}
-
-	updated, err := hex.DecodeString(hexStr)
-	if err != nil {
-		return
-	}
-
-	_ = view.Update(acctKey, updated)
-}
-
-// buildAccountRootJSON creates a JSON map for AccountRoot serialization.
-// This replicates the pattern used elsewhere in the codebase.
-func buildAccountRootJSON(acct *state.AccountRoot, address string) map[string]any {
-	jsonObj := map[string]any{
-		"LedgerEntryType": "AccountRoot",
-		"Account":         address,
-		"Balance":         fmt.Sprintf("%d", acct.Balance),
-		"Sequence":        acct.Sequence,
-		"OwnerCount":      acct.OwnerCount,
-		"Flags":           acct.Flags,
-	}
-
-	if acct.TransferRate != 0 {
-		jsonObj["TransferRate"] = acct.TransferRate
-	}
-	if acct.Domain != "" {
-		jsonObj["Domain"] = strings.ToUpper(acct.Domain)
-	}
-	if acct.RegularKey != "" {
-		jsonObj["RegularKey"] = acct.RegularKey
-	}
-	if acct.NFTokenMinter != "" {
-		jsonObj["NFTokenMinter"] = acct.NFTokenMinter
-	}
-	if acct.MintedNFTokens != 0 {
-		jsonObj["MintedNFTokens"] = acct.MintedNFTokens
-	}
-	if acct.BurnedNFTokens != 0 {
-		jsonObj["BurnedNFTokens"] = acct.BurnedNFTokens
-	}
-	if acct.HasFirstNFTSeq {
-		jsonObj["FirstNFTokenSequence"] = acct.FirstNFTokenSequence
-	}
-	if acct.TickSize != 0 {
-		jsonObj["TickSize"] = acct.TickSize
-	}
-	if acct.TicketCount != 0 {
-		jsonObj["TicketCount"] = acct.TicketCount
-	}
-	if acct.PreviousTxnID != [32]byte{} {
-		jsonObj["PreviousTxnID"] = strings.ToUpper(hex.EncodeToString(acct.PreviousTxnID[:]))
-	}
-	if acct.PreviousTxnLgrSeq != 0 {
-		jsonObj["PreviousTxnLgrSeq"] = acct.PreviousTxnLgrSeq
-	}
-	if acct.AccountTxnID != [32]byte{} {
-		jsonObj["AccountTxnID"] = strings.ToUpper(hex.EncodeToString(acct.AccountTxnID[:]))
-	}
-	if acct.AMMID != [32]byte{} {
-		jsonObj["AMMID"] = strings.ToUpper(hex.EncodeToString(acct.AMMID[:]))
-	}
-	if acct.WalletLocator != "" {
-		jsonObj["WalletLocator"] = acct.WalletLocator
-	}
-	if acct.EmailHash != "" {
-		jsonObj["EmailHash"] = acct.EmailHash
-	}
-	if acct.MessageKey != "" {
-		jsonObj["MessageKey"] = acct.MessageKey
-	}
-
-	return jsonObj
+	_ = tx.AdjustOwnerCount(view, accountID, adj)
 }
 
 // computeMPTTransferFee computes the final amount after applying MPT transfer fee.

--- a/internal/tx/escrow/token_owner_count_test.go
+++ b/internal/tx/escrow/token_owner_count_test.go
@@ -1,0 +1,83 @@
+package escrow
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+// mapView is a minimal map-backed tx.LedgerView for unit-testing the escrow
+// owner-count write-back path in isolation.
+type mapView struct {
+	data map[[32]byte][]byte
+}
+
+func newMapView() *mapView { return &mapView{data: make(map[[32]byte][]byte)} }
+
+func (m *mapView) Read(k keylet.Keylet) ([]byte, error)      { return m.data[k.Key], nil }
+func (m *mapView) Exists(k keylet.Keylet) (bool, error)      { _, ok := m.data[k.Key]; return ok, nil }
+func (m *mapView) Insert(k keylet.Keylet, data []byte) error { m.data[k.Key] = data; return nil }
+func (m *mapView) Update(k keylet.Keylet, data []byte) error { m.data[k.Key] = data; return nil }
+func (m *mapView) Erase(k keylet.Keylet) error               { delete(m.data, k.Key); return nil }
+func (m *mapView) AdjustDropsDestroyed(drops.XRPAmount)      {}
+func (m *mapView) ForEach(fn func(key [32]byte, data []byte) bool) error {
+	for k, v := range m.data {
+		if !fn(k, v) {
+			break
+		}
+	}
+	return nil
+}
+func (m *mapView) Succ([32]byte) ([32]byte, []byte, bool, error) { return [32]byte{}, nil, false, nil }
+func (m *mapView) TxExists([32]byte) bool                        { return false }
+func (m *mapView) Rules() *amendment.Rules                       { return nil }
+func (m *mapView) LedgerSeq() uint32                             { return 0 }
+
+// TestAdjustOwnerCountViaView_PreservesPresentZeroAccountTxnID is a regression
+// for the #741 account_hash fork. A token-escrow finish that creates the
+// destination's trust line / MPToken bumps the destination's OwnerCount via
+// adjustOwnerCountViaView, which re-serializes its AccountRoot. The previous
+// hand-rolled serializer emitted sfAccountTxnID only when non-zero, so a
+// present-but-zero AccountTxnID (asfAccountTxnID enabled, account not used
+// since — rippled makeFieldPresent semantics) was silently dropped, forking
+// account_hash from rippled, which keeps every present field. The fix delegates
+// to the canonical tx.AdjustOwnerCount / state.SerializeAccountRoot, which key
+// on presence.
+func TestAdjustOwnerCountViaView_PreservesPresentZeroAccountTxnID(t *testing.T) {
+	view := newMapView()
+	var dest [20]byte
+	dest[0], dest[19] = 0xab, 0xcd
+	addr, err := addresscodec.EncodeAccountIDToClassicAddress(dest[:])
+	require.NoError(t, err)
+	key := keylet.Account(dest)
+
+	acct := &state.AccountRoot{
+		Account:         addr,
+		Balance:         100_000_000,
+		Sequence:        7,
+		OwnerCount:      2,
+		HasAccountTxnID: true,       // present...
+		AccountTxnID:    [32]byte{}, // ...but still zero (rippled makeFieldPresent)
+	}
+	blob, err := state.SerializeAccountRoot(acct)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(key, blob))
+
+	// The token-escrow finish trust-line / MPToken create path.
+	adjustOwnerCountViaView(view, dest, 1)
+
+	out, err := view.Read(key)
+	require.NoError(t, err)
+	got, err := state.ParseAccountRoot(out)
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(3), got.OwnerCount, "owner count must increment")
+	require.True(t, got.HasAccountTxnID,
+		"present-zero sfAccountTxnID must survive the owner-count write-back (#741 account_hash fork)")
+	require.Equal(t, [32]byte{}, got.AccountTxnID, "the preserved value stays zero")
+}

--- a/internal/tx/payment/payment_xrp.go
+++ b/internal/tx/payment/payment_xrp.go
@@ -78,17 +78,6 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 			return tx.TecNO_PERMISSION
 		}
 
-		// Check destination's lsfDisallowXRP flag
-		// Per rippled, if lsfDisallowXRP is set and sender != destination, return tecNO_TARGET
-		// This allows accounts to indicate they don't want to receive XRP
-		// Reference: this matches rippled behavior for direct XRP payments
-		if (destAccount.Flags & state.LsfDisallowXRP) != 0 {
-			// Only reject if sender is not the destination (self-payments are allowed)
-			if ctx.AccountID != destAccountID {
-				return tx.TecNO_TARGET
-			}
-		}
-
 		// Check if destination requires a tag
 		if (destAccount.Flags&state.LsfRequireDestTag) != 0 && p.DestinationTag == nil {
 			return tx.TecDST_TAG_NEEDED


### PR DESCRIPTION
Promotes the `develop` integration batch to `main`. Each change was root-caused against rippled 2.6.2, unit-tested, and merged to `develop` via its own PR; all were surfaced by the xrpl-confluence mixed-network fuzz soak.

## Included fixes

| Fix | PR | Issue | Class |
|---|---|---|---|
| Payment must not enforce the advisory `lsfDisallowXRP` flag (was returning `tecNO_TARGET`; rippled delivers) | #736 | #735 | state fork (balances) |
| Track `sfAccountTxnID` presence so a present-zero value round-trips (was dropped → not updated on the next tx) | #738 | #737 | `account_hash` fork |
| Re-trigger stalled tx-set acquisition on a timer (no analogue of rippled `TransactionAcquire::onTimer` → wrongLedger wedge) | #739 | #724 | liveness wedge |

Also retracted (no code change): the long-standing "EscrowCreate emits a spurious empty destination-AccountRoot ModifiedNode" theory — verified rippled-correct four ways (rippled source `ApplyStateTable::threadOwners`, rippled 2.6.2 standalone, a goXRPL test, and a live soak). Memory/notes corrected so it isn't re-chased.

Each fix advanced the soak measurably: with #736 the network now sails past the ledger-42 DisallowXRP fork; with #738 it sails past the ledger-76 AccountTxnID fork.

## Verification

- Per-fix: `just test-pkg` on affected packages + `just vet` green; rippled-conformance checked against `rippled/` 2.6.2.
- Full module builds; payment / escrow / accountset / consensus-adaptor / tx-engine suites pass.

## Honest status — NOT a fully-clean batch

The 5-clean-soak DONE gate is **not** met. The mixed soak still forks under load due to **#740** — a confirmed data race on the `Number` switchover/rounding **package-globals** (`xrpl_number.go`), which rippled keeps thread-local. This is a **pre-existing** defect already latent in `main` (the known-open "engine package-globals race"), not introduced by this PR; reproduced and root-caused this session via `go test -race`. It needs its own reviewed, architectural refactor (per-engine Number state) and is tracked in #740.

So this batch is **strictly better than current `main`** (three real consensus forks fixed) but does not yet make the mixed network fully wedge-free. Promotion is a maintainer decision — merge if you want the three fixes on `main` now, or hold for #740.