### PR TITLE
fix: de-race Number switchover and rounding mode

### DIFF
--- a/internal/ledger/state/amount.go
+++ b/internal/ledger/state/amount.go
@@ -128,15 +128,8 @@ func ZeroIOUValue() IOUAmountValue {
 	return IOUAmountValue{mantissa: 0, exponent: zeroExponent}
 }
 
-// normalize adjusts the mantissa and exponent to the proper range using
-// banker's rounding. Use normalizeRounded to normalize under a different mode.
-// Matches rippled's IOUAmount::normalize().
-func (v *IOUAmountValue) normalize() {
-	v.normalizeRounded(RoundToNearest)
-}
-
 // normalizeRounded adjusts the mantissa and exponent to the proper range under
-// mode.
+// mode, matching rippled's IOUAmount::normalize().
 // When fixUniversalNumber is enabled, delegates to XRPLNumber for Guard-based rounding.
 // Reference: IOUAmount.cpp lines 75-126
 func (v *IOUAmountValue) normalizeRounded(mode RoundingMode) {

--- a/internal/ledger/state/amount.go
+++ b/internal/ledger/state/amount.go
@@ -115,8 +115,6 @@ func NewIOUAmountValue(mantissa int64, exponent int) IOUAmountValue {
 	return newIOUAmountValueRounded(mantissa, exponent, RoundToNearest)
 }
 
-// newIOUAmountValueRounded creates a new IOU amount value and normalizes it
-// under mode.
 func newIOUAmountValueRounded(mantissa int64, exponent int, mode RoundingMode) IOUAmountValue {
 	v := IOUAmountValue{mantissa: mantissa, exponent: exponent}
 	v.normalizeRounded(mode)

--- a/internal/ledger/state/amount.go
+++ b/internal/ledger/state/amount.go
@@ -109,10 +109,17 @@ type IOUAmountValue struct {
 	exponent int   // Exponent in range [-96, 80] for non-zero values
 }
 
-// NewIOUAmountValue creates a new IOU amount value and normalizes it
+// NewIOUAmountValue creates a new IOU amount value and normalizes it using
+// banker's rounding.
 func NewIOUAmountValue(mantissa int64, exponent int) IOUAmountValue {
+	return newIOUAmountValueRounded(mantissa, exponent, RoundToNearest)
+}
+
+// newIOUAmountValueRounded creates a new IOU amount value and normalizes it
+// under mode.
+func newIOUAmountValueRounded(mantissa int64, exponent int, mode RoundingMode) IOUAmountValue {
 	v := IOUAmountValue{mantissa: mantissa, exponent: exponent}
-	v.normalize()
+	v.normalizeRounded(mode)
 	return v
 }
 
@@ -121,11 +128,18 @@ func ZeroIOUValue() IOUAmountValue {
 	return IOUAmountValue{mantissa: 0, exponent: zeroExponent}
 }
 
-// normalize adjusts the mantissa and exponent to the proper range
-// Matches rippled's IOUAmount::normalize()
+// normalize adjusts the mantissa and exponent to the proper range using
+// banker's rounding. Use normalizeRounded to normalize under a different mode.
+// Matches rippled's IOUAmount::normalize().
+func (v *IOUAmountValue) normalize() {
+	v.normalizeRounded(RoundToNearest)
+}
+
+// normalizeRounded adjusts the mantissa and exponent to the proper range under
+// mode.
 // When fixUniversalNumber is enabled, delegates to XRPLNumber for Guard-based rounding.
 // Reference: IOUAmount.cpp lines 75-126
-func (v *IOUAmountValue) normalize() {
+func (v *IOUAmountValue) normalizeRounded(mode RoundingMode) {
 	if v.mantissa == 0 {
 		v.mantissa = 0
 		v.exponent = zeroExponent
@@ -135,7 +149,7 @@ func (v *IOUAmountValue) normalize() {
 	// When switchover is on, delegate to XRPLNumber (Guard-based precision)
 	// Reference: IOUAmount.cpp lines 83-93
 	if GetNumberSwitchover() {
-		n := NewXRPLNumber(v.mantissa, v.exponent)
+		n := NewXRPLNumberRounded(v.mantissa, v.exponent, mode)
 		v.mantissa = n.mantissa
 		v.exponent = n.exponent
 		if v.exponent > MaxExponent {
@@ -313,9 +327,18 @@ func NewXRPAmountFromInt(drops int64) Amount {
 	}
 }
 
-// NewIssuedAmountFromValue creates an issued currency amount from mantissa/exponent
+// NewIssuedAmountFromValue creates an issued currency amount from
+// mantissa/exponent, normalizing with banker's rounding.
 func NewIssuedAmountFromValue(mantissa int64, exponent int, currency, issuer string) Amount {
-	iouVal := NewIOUAmountValue(mantissa, exponent)
+	return NewIssuedAmountFromValueRounded(mantissa, exponent, currency, issuer, RoundToNearest)
+}
+
+// NewIssuedAmountFromValueRounded creates an issued currency amount from
+// mantissa/exponent, normalizing under mode. The strict-rounding (mulRound /
+// divRound) and AMM paths use this to reproduce rippled's NumberRoundModeGuard
+// without a shared global mode.
+func NewIssuedAmountFromValueRounded(mantissa int64, exponent int, currency, issuer string, mode RoundingMode) Amount {
+	iouVal := newIOUAmountValueRounded(mantissa, exponent, mode)
 	result := Amount{
 		iou:      iouVal,
 		Currency: currency,

--- a/internal/ledger/state/amount_arithmetic.go
+++ b/internal/ledger/state/amount_arithmetic.go
@@ -29,6 +29,12 @@ import (
 // consumes do not normalise the issuer the way rippled View.cpp:469-484
 // does. The result is tagged with `a`'s currency and issuer.
 func (a Amount) Add(b Amount) (Amount, error) {
+	return a.AddRounded(b, RoundToNearest)
+}
+
+// AddRounded returns a + b, rounding the IOU result under mode. The AMM math
+// uses this to reproduce rippled's NumberRoundModeGuard around additions.
+func (a Amount) AddRounded(b Amount, mode RoundingMode) (Amount, error) {
 	if a.IsNative() != b.IsNative() {
 		return Amount{}, fmt.Errorf("temBAD_AMOUNT: cannot add XRP and IOU amounts")
 	}
@@ -41,7 +47,7 @@ func (a Amount) Add(b Amount) (Amount, error) {
 			Native: true,
 		}, nil
 	}
-	result := addIOUValues(a.iou, b.iou)
+	result := addIOUValuesRounded(a.iou, b.iou, mode)
 	return Amount{
 		iou:      result,
 		Currency: a.Currency,
@@ -55,10 +61,20 @@ func (a Amount) Sub(b Amount) (Amount, error) {
 	return a.Add(b.Negate())
 }
 
-// addIOUValues adds two IOU values with proper exponent handling.
+// SubRounded returns a - b, rounding the IOU result under mode.
+func (a Amount) SubRounded(b Amount, mode RoundingMode) (Amount, error) {
+	return a.AddRounded(b.Negate(), mode)
+}
+
+// addIOUValues adds two IOU values using banker's rounding.
+func addIOUValues(a, b IOUAmountValue) IOUAmountValue {
+	return addIOUValuesRounded(a, b, RoundToNearest)
+}
+
+// addIOUValuesRounded adds two IOU values with proper exponent handling under mode.
 // When fixUniversalNumber is enabled, delegates to XRPLNumber.Add() for Guard-based precision.
 // Reference: IOUAmount::operator+= in IOUAmount.cpp lines 137-181
-func addIOUValues(a, b IOUAmountValue) IOUAmountValue {
+func addIOUValuesRounded(a, b IOUAmountValue, mode RoundingMode) IOUAmountValue {
 	if a.IsZero() {
 		return b
 	}
@@ -69,9 +85,9 @@ func addIOUValues(a, b IOUAmountValue) IOUAmountValue {
 	// When switchover is on, delegate to XRPLNumber (Guard-based precision)
 	// Reference: IOUAmount.cpp lines 149-153
 	if GetNumberSwitchover() {
-		na := NewXRPLNumber(a.mantissa, a.exponent)
-		nb := NewXRPLNumber(b.mantissa, b.exponent)
-		result := na.Add(nb)
+		na := NewXRPLNumberRounded(a.mantissa, a.exponent, mode)
+		nb := NewXRPLNumberRounded(b.mantissa, b.exponent, mode)
+		result := na.AddRounded(nb, mode)
 		r := result.ToIOUAmountValue()
 		return r
 	}
@@ -312,11 +328,18 @@ func pow10Big(n int) *big.Int {
 	return result
 }
 
-// Mul multiplies this Amount by another Amount.
+// Mul multiplies this Amount by another Amount using banker's rounding.
+func (a Amount) Mul(other Amount, roundUp bool) Amount {
+	return a.MulRounded(other, roundUp, RoundToNearest)
+}
+
+// MulRounded multiplies this Amount by another Amount, rounding the IOU result
+// under mode. The AMM math uses this to reproduce rippled's
+// NumberRoundModeGuard around multiplications.
 // Reference: rippled's mulRound() in STAmount.cpp
 // For IOU * IOU: result = (m1 * m2) * 10^(e1 + e2)
 // When fixUniversalNumber is enabled, delegates to XRPLNumber.Mul() for Guard-based rounding.
-func (a Amount) Mul(other Amount, roundUp bool) Amount {
+func (a Amount) MulRounded(other Amount, roundUp bool, mode RoundingMode) Amount {
 	if a.IsZero() || other.IsZero() {
 		if a.IsNative() {
 			return NewXRPAmountFromInt(0)
@@ -346,15 +369,15 @@ func (a Amount) Mul(other Amount, roundUp bool) Amount {
 		if m2 < 0 {
 			m2 = -m2
 		}
-		na := NewXRPLNumber(m1, e1)
-		nb := NewXRPLNumber(m2, e2)
-		result := na.Mul(nb)
+		na := NewXRPLNumberRounded(m1, e1, mode)
+		nb := NewXRPLNumberRounded(m2, e2, mode)
+		result := na.MulRounded(nb, mode)
 		iou := result.ToIOUAmountValue()
 		rm := iou.mantissa
 		if negative {
 			rm = -rm
 		}
-		return NewIssuedAmountFromValue(rm, iou.exponent, a.Currency, a.Issuer)
+		return NewIssuedAmountFromValueRounded(rm, iou.exponent, a.Currency, a.Issuer, mode)
 	}
 
 	// Handle sign

--- a/internal/ledger/state/amount_round.go
+++ b/internal/ledger/state/amount_round.go
@@ -68,15 +68,13 @@ func MulRoundStrict(v1, v2 Amount, currency, issuer string, roundUp bool) Amount
 		}
 	}
 
-	// Create the result with Number in towards_zero mode
-	// This affects how normalization rounds during STAmount construction
-	guard := NewNumberRoundModeGuard(RoundTowardsZero)
+	// Create the result with Number in towards_zero mode.
+	// This affects how normalization rounds during STAmount construction.
 	mantissa := int64(amount)
 	if resultNegative {
 		mantissa = -mantissa
 	}
-	result := NewIssuedAmountFromValue(mantissa, offset, currency, issuer)
-	guard.Release()
+	result := NewIssuedAmountFromValueRounded(mantissa, offset, currency, issuer, RoundTowardsZero)
 
 	// If roundUp and positive and result is zero, return minimum value
 	if roundUp && !resultNegative && result.IsZero() {
@@ -515,21 +513,19 @@ func DivRoundStrict(num, den Amount, currency, issuer string, roundUp bool) Amou
 		}
 	}
 
-	// Create result with appropriate Number rounding mode
-	// divRoundStrict uses upward if (roundUp ^ resultNegative), else downward
+	// Create result with appropriate Number rounding mode.
+	// divRoundStrict uses upward if (roundUp ^ resultNegative), else downward.
 	var mode RoundingMode
 	if roundUp != resultNegative {
 		mode = RoundUpward
 	} else {
 		mode = RoundDownward
 	}
-	guard := NewNumberRoundModeGuard(mode)
 	mantissa := int64(amount)
 	if resultNegative {
 		mantissa = -mantissa
 	}
-	result := NewIssuedAmountFromValue(mantissa, offset, currency, issuer)
-	guard.Release()
+	result := NewIssuedAmountFromValueRounded(mantissa, offset, currency, issuer, mode)
 
 	// If roundUp and positive and result is zero, return minimum value
 	if roundUp && !resultNegative && result.IsZero() {

--- a/internal/ledger/state/amount_sqrt.go
+++ b/internal/ledger/state/amount_sqrt.go
@@ -17,12 +17,19 @@ func (a Amount) Exponent() int {
 	return a.iou.Exponent()
 }
 
-// Sqrt returns the square root of this Amount.
+// Sqrt returns the square root of this Amount using banker's rounding.
+func (a Amount) Sqrt() Amount {
+	return a.SqrtRounded(RoundToNearest)
+}
+
+// SqrtRounded returns the square root of this Amount, rounding every
+// intermediate operation under mode. The AMM math uses this to reproduce
+// rippled's NumberRoundModeGuard around root2().
 // Reference: rippled's root2() function in Number.cpp
 // Uses Newton-Raphson iteration for precision.
 // Panics if the amount is negative.
 // When fixUniversalNumber is enabled, delegates to XRPLNumber.root2().
-func (a Amount) Sqrt() Amount {
+func (a Amount) SqrtRounded(mode RoundingMode) Amount {
 	// Handle special cases
 	if a.IsZero() {
 		if a.IsNative() {
@@ -44,10 +51,10 @@ func (a Amount) Sqrt() Amount {
 
 	// When switchover is on, delegate to XRPLNumber.root2()
 	if GetNumberSwitchover() {
-		n := NewXRPLNumber(a.iou.Mantissa(), a.iou.Exponent())
-		result := n.root2()
+		n := NewXRPLNumberRounded(a.iou.Mantissa(), a.iou.Exponent(), mode)
+		result := n.root2Rounded(mode)
 		iou := result.ToIOUAmountValue()
-		return NewIssuedAmountFromValue(iou.mantissa, iou.exponent, a.Currency, a.Issuer)
+		return NewIssuedAmountFromValueRounded(iou.mantissa, iou.exponent, a.Currency, a.Issuer, mode)
 	}
 
 	// For IOU amounts, use Newton-Raphson iteration

--- a/internal/ledger/state/number_race_test.go
+++ b/internal/ledger/state/number_race_test.go
@@ -1,0 +1,107 @@
+package state
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestNumberRounding_ConcurrentDeterministic is the -race regression guard for
+// issue #740: the Number switchover flag and rounding mode must never be shared
+// mutable package globals.
+//
+// Many goroutines perform amount arithmetic under different rounding modes at
+// the same time, mirroring a live node where the apply goroutine and the
+// concurrent RPC/path-find goroutines both run Number math. Two properties must
+// hold:
+//
+//   - No data race. The switchover flag (atomic.Bool, written only by apply) and
+//     the rounding mode (threaded explicitly, never shared) leave nothing to
+//     race on. If the rounding mode regressed to a package global, the per-step
+//     setround()/getround() of concurrent goroutines would be flagged by -race.
+//   - Determinism. Each goroutine rounding the same expression under a fixed
+//     mode must reproduce the sequential golden result. A shared global mode
+//     would let an Upward goroutine clobber a Downward goroutine mid-computation,
+//     producing a different amount — the root cause of the #724 non-deterministic
+//     consensus forks.
+//
+// Run with `go test -race` (CI does) to exercise the race detector.
+func TestNumberRounding_ConcurrentDeterministic(t *testing.T) {
+	SetNumberSwitchover(true)
+
+	a := NewIssuedAmountFromValue(7333333333333333, -16, "USD", "rIssuer") // ~0.7333333333333333
+	b := NewIssuedAmountFromValue(3141592653589793, -15, "USD", "rIssuer") // ~3.141592653589793
+
+	// Golden values, computed sequentially. The three multiply modes and the
+	// two sqrt modes must actually differ, otherwise the test would pass even if
+	// the mode were ignored entirely.
+	wantNearest := a.MulRounded(b, false, RoundToNearest)
+	wantUp := a.MulRounded(b, false, RoundUpward)
+	wantDown := a.MulRounded(b, false, RoundDownward)
+	wantSqrtDown := b.SqrtRounded(RoundDownward)
+	wantSqrtUp := b.SqrtRounded(RoundUpward)
+
+	if wantUp.Compare(wantDown) == 0 {
+		t.Fatalf("test setup is not mode-sensitive: up == down (%s)", wantUp.Value())
+	}
+	if wantSqrtUp.Compare(wantSqrtDown) == 0 {
+		t.Fatalf("test setup is not mode-sensitive: sqrt up == down (%s)", wantSqrtUp.Value())
+	}
+
+	const (
+		goroutines = 16
+		iterations = 200
+	)
+
+	var wg sync.WaitGroup
+
+	// Writers: mirror the apply goroutine establishing the (constant per ledger)
+	// switchover. Concurrent with the readers below, this would trip -race
+	// against a plain bool global.
+	for w := 0; w < goroutines; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				SetNumberSwitchover(true)
+			}
+		}()
+	}
+
+	// Readers: each independently rounds the same expressions and must agree
+	// with the golden values bit-for-bit.
+	errs := make(chan string, goroutines)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if a.MulRounded(b, false, RoundToNearest).Compare(wantNearest) != 0 {
+					errs <- "mul to-nearest mismatch"
+					return
+				}
+				if a.MulRounded(b, false, RoundUpward).Compare(wantUp) != 0 {
+					errs <- "mul upward mismatch"
+					return
+				}
+				if a.MulRounded(b, false, RoundDownward).Compare(wantDown) != 0 {
+					errs <- "mul downward mismatch"
+					return
+				}
+				if b.SqrtRounded(RoundDownward).Compare(wantSqrtDown) != 0 {
+					errs <- "sqrt downward mismatch"
+					return
+				}
+				if b.SqrtRounded(RoundUpward).Compare(wantSqrtUp) != 0 {
+					errs <- "sqrt upward mismatch"
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+	for msg := range errs {
+		t.Errorf("non-deterministic rounding under concurrency: %s", msg)
+	}
+}

--- a/internal/ledger/state/xrpl_number.go
+++ b/internal/ledger/state/xrpl_number.go
@@ -162,7 +162,6 @@ func NewXRPLNumber(mantissa int64, exponent int) XRPLNumber {
 	return NewXRPLNumberRounded(mantissa, exponent, RoundToNearest)
 }
 
-// NewXRPLNumberRounded creates a new XRPLNumber and normalizes it under mode.
 func NewXRPLNumberRounded(mantissa int64, exponent int, mode RoundingMode) XRPLNumber {
 	n := XRPLNumber{mantissa: mantissa, exponent: exponent}
 	n.normalize(mode)

--- a/internal/ledger/state/xrpl_number.go
+++ b/internal/ledger/state/xrpl_number.go
@@ -17,6 +17,7 @@ package state
 
 import (
 	"math/big"
+	"sync/atomic"
 )
 
 // XRPLNumber constants matching rippled's Number.h
@@ -29,24 +30,44 @@ const (
 	xrplNumZeroExponent = -2147483648 // math.MinInt32, matching Number{} default
 )
 
-// Package-level switchover flag.
-// Matches rippled's thread-local getSTNumberSwitchover() / setSTNumberSwitchover().
-// Safe as package-level var because Go transaction processing is single-threaded.
-var numberSwitchoverEnabled bool
+// Package-level switchover flag, the Go equivalent of rippled's per-thread
+// getSTNumberSwitchover() / setSTNumberSwitchover() (LocalValue<bool>).
+//
+// Unlike the rounding mode, the switchover is written only by the single
+// transaction-apply goroutine (do_apply.go, from rules().Enabled(
+// fixUniversalNumber)) and is constant for the duration of a ledger, since
+// amendments do not flip mid-ledger. Concurrent readers are the RPC/path-find
+// goroutines, which only ever read it. An atomic.Bool therefore removes the
+// data race while preserving exact behavior: every reader observes the value
+// the apply goroutine established for the current ledger.
+//
+// The rounding mode, by contrast, is mutated mid-computation by both the apply
+// and RPC goroutines, so it cannot be a shared global — it is threaded
+// explicitly through the arithmetic call path (see RoundingMode below).
+var numberSwitchoverEnabled atomic.Bool
 
 // SetNumberSwitchover enables or disables the XRPLNumber switchover.
 // When enabled, IOUAmount arithmetic uses Guard-based precision.
 func SetNumberSwitchover(enabled bool) {
-	numberSwitchoverEnabled = enabled
+	numberSwitchoverEnabled.Store(enabled)
 }
 
 // GetNumberSwitchover returns whether the XRPLNumber switchover is enabled.
 func GetNumberSwitchover() bool {
-	return numberSwitchoverEnabled
+	return numberSwitchoverEnabled.Load()
 }
 
 // RoundingMode controls how XRPLNumber rounds during normalization.
-// Reference: Number::rounding_mode in Number.h line 196
+// Reference: Number::rounding_mode in Number.h line 196.
+//
+// rippled stores the active mode in a thread_local (Number::mode_) and mutates
+// it via the NumberRoundModeGuard RAII helper. go-xrpl has no thread-local
+// storage and a live node performs amount arithmetic concurrently (apply vs.
+// RPC/path-find goroutines), so the mode is instead threaded explicitly as an
+// argument: every operation defaults to RoundToNearest, and the mode-sensitive
+// strict-rounding and AMM paths call the matching *Rounded variant with the
+// desired mode. This keeps the arithmetic race-free and deterministic without
+// any shared mutable rounding state.
 type RoundingMode int
 
 const (
@@ -55,37 +76,6 @@ const (
 	RoundDownward                        // round towards negative infinity
 	RoundUpward                          // round towards positive infinity
 )
-
-// Package-level rounding mode, matching rippled's thread_local Number::mode_.
-var numberRoundingMode RoundingMode = RoundToNearest
-
-// GetNumberRound returns the current rounding mode.
-func GetNumberRound() RoundingMode {
-	return numberRoundingMode
-}
-
-// SetNumberRound sets the rounding mode and returns the previous mode.
-func SetNumberRound(mode RoundingMode) RoundingMode {
-	prev := numberRoundingMode
-	numberRoundingMode = mode
-	return prev
-}
-
-// NumberRoundModeGuard sets the rounding mode and restores it on Release().
-// Matches rippled's NumberRoundModeGuard RAII class.
-type NumberRoundModeGuard struct {
-	saved RoundingMode
-}
-
-// NewNumberRoundModeGuard sets the rounding mode and returns a guard.
-func NewNumberRoundModeGuard(mode RoundingMode) NumberRoundModeGuard {
-	return NumberRoundModeGuard{saved: SetNumberRound(mode)}
-}
-
-// Release restores the previous rounding mode.
-func (g NumberRoundModeGuard) Release() {
-	SetNumberRound(g.saved)
-}
 
 // XRPLNumber represents a decimal floating-point number with Guard-based rounding.
 // Reference: rippled Number class in Number.h / Number.cpp
@@ -121,12 +111,10 @@ func (g *xrplGuard) pop() uint {
 	return d
 }
 
-// round returns the rounding direction based on the current rounding mode.
+// round returns the rounding direction for the given mode.
 // Returns: 1 if round up, -1 if round down, 0 if exactly half.
 // Reference: Number.cpp lines 137-171
-func (g *xrplGuard) round() int {
-	mode := GetNumberRound()
-
+func (g *xrplGuard) round(mode RoundingMode) int {
 	if mode == RoundTowardsZero {
 		return -1
 	}
@@ -166,11 +154,18 @@ func (g *xrplGuard) round() int {
 	return 0
 }
 
-// NewXRPLNumber creates a new XRPLNumber and normalizes it.
+// NewXRPLNumber creates a new XRPLNumber and normalizes it using banker's
+// rounding (RoundToNearest). Use NewXRPLNumberRounded to normalize under a
+// different mode.
 // Reference: Number::Number(rep mantissa, int exponent) in Number.h line 219-223
 func NewXRPLNumber(mantissa int64, exponent int) XRPLNumber {
+	return NewXRPLNumberRounded(mantissa, exponent, RoundToNearest)
+}
+
+// NewXRPLNumberRounded creates a new XRPLNumber and normalizes it under mode.
+func NewXRPLNumberRounded(mantissa int64, exponent int, mode RoundingMode) XRPLNumber {
 	n := XRPLNumber{mantissa: mantissa, exponent: exponent}
-	n.normalize()
+	n.normalize(mode)
 	return n
 }
 
@@ -200,9 +195,10 @@ func (n XRPLNumber) Negate() XRPLNumber {
 	return XRPLNumber{mantissa: -n.mantissa, exponent: n.exponent}
 }
 
-// normalize adjusts mantissa and exponent to the proper range using Guard-based rounding.
+// normalize adjusts mantissa and exponent to the proper range using Guard-based
+// rounding under mode.
 // Reference: Number.cpp lines 177-227
-func (n *XRPLNumber) normalize() {
+func (n *XRPLNumber) normalize(mode RoundingMode) {
 	if n.mantissa == 0 {
 		*n = xrplNumberZero()
 		return
@@ -245,7 +241,7 @@ func (n *XRPLNumber) normalize() {
 	}
 
 	// Apply guard rounding (round-half-to-even)
-	r := g.round()
+	r := g.round(mode)
 	if r == 1 || (r == 0 && (n.mantissa&1) == 1) {
 		n.mantissa++
 		if n.mantissa > xrplNumMaxMantissa {
@@ -263,9 +259,14 @@ func (n *XRPLNumber) normalize() {
 	}
 }
 
-// Add returns the sum of two XRPLNumbers.
-// Reference: Number::operator+= in Number.cpp lines 229-345
+// Add returns the sum of two XRPLNumbers using banker's rounding.
 func (n XRPLNumber) Add(y XRPLNumber) XRPLNumber {
+	return n.AddRounded(y, RoundToNearest)
+}
+
+// AddRounded returns the sum of two XRPLNumbers rounded under mode.
+// Reference: Number::operator+= in Number.cpp lines 229-345
+func (n XRPLNumber) AddRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 	// Handle zero operands
 	if y.IsZero() {
 		return n
@@ -325,7 +326,7 @@ func (n XRPLNumber) Add(y XRPLNumber) XRPLNumber {
 			xm /= 10
 			xe++
 		}
-		r := g.round()
+		r := g.round(mode)
 		if r == 1 || (r == 0 && (xm&1) == 1) {
 			xm++
 			if xm > xrplNumMaxMantissa {
@@ -351,7 +352,7 @@ func (n XRPLNumber) Add(y XRPLNumber) XRPLNumber {
 			xm -= int64(g.pop())
 			xe--
 		}
-		r := g.round()
+		r := g.round(mode)
 		if r == 1 || (r == 0 && (xm&1) == 1) {
 			xm--
 			if xm < xrplNumMinMantissa {
@@ -372,9 +373,14 @@ func (n XRPLNumber) Sub(y XRPLNumber) XRPLNumber {
 	return n.Add(y.Negate())
 }
 
-// Mul returns the product of two XRPLNumbers.
-// Reference: Number::operator*= in Number.cpp lines 375-445
+// Mul returns the product of two XRPLNumbers using banker's rounding.
 func (n XRPLNumber) Mul(y XRPLNumber) XRPLNumber {
+	return n.MulRounded(y, RoundToNearest)
+}
+
+// MulRounded returns the product of two XRPLNumbers rounded under mode.
+// Reference: Number::operator*= in Number.cpp lines 375-445
+func (n XRPLNumber) MulRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 	if n.IsZero() {
 		return n
 	}
@@ -421,7 +427,7 @@ func (n XRPLNumber) Mul(y XRPLNumber) XRPLNumber {
 	xe = ze
 
 	// Apply guard rounding
-	r := g.round()
+	r := g.round(mode)
 	if r == 1 || (r == 0 && (xm&1) == 1) {
 		xm++
 		if xm > xrplNumMaxMantissa {
@@ -441,9 +447,14 @@ func (n XRPLNumber) Mul(y XRPLNumber) XRPLNumber {
 	return XRPLNumber{mantissa: xm * zn, exponent: xe}
 }
 
-// Div returns n / y.
-// Reference: Number::operator/= in Number.cpp lines 447-478
+// Div returns n / y using banker's rounding.
 func (n XRPLNumber) Div(y XRPLNumber) XRPLNumber {
+	return n.DivRounded(y, RoundToNearest)
+}
+
+// DivRounded returns n / y rounded under mode.
+// Reference: Number::operator/= in Number.cpp lines 447-478
+func (n XRPLNumber) DivRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 	if y.IsZero() {
 		panic("XRPLNumber: divide by zero")
 	}
@@ -479,7 +490,7 @@ func (n XRPLNumber) Div(y XRPLNumber) XRPLNumber {
 		mantissa: quotient.Int64() * np * dp,
 		exponent: ne - de - 17,
 	}
-	result.normalize()
+	result.normalize(mode)
 	return result
 }
 
@@ -498,9 +509,9 @@ func (n XRPLNumber) ToIOUAmountValue() IOUAmountValue {
 	return IOUAmountValue{mantissa: n.mantissa, exponent: n.exponent}
 }
 
-// ToInt64WithMode converts this Number to an int64 using Guard-based rounding,
-// matching rippled's Number::operator rep() (Number.cpp lines 480-512).
-// The mode parameter overrides the global rounding mode for this conversion.
+// ToInt64WithMode converts this Number to an int64 using Guard-based rounding
+// under mode, matching rippled's Number::operator rep() (Number.cpp lines
+// 480-512).
 func (n XRPLNumber) ToInt64WithMode(mode RoundingMode) int64 {
 	drops := n.mantissa
 	offset := n.exponent
@@ -522,9 +533,7 @@ func (n XRPLNumber) ToInt64WithMode(mode RoundingMode) int64 {
 		}
 
 		// Apply rounding with the specified mode
-		savedMode := SetNumberRound(mode)
-		r := g.round()
-		SetNumberRound(savedMode)
+		r := g.round(mode)
 
 		if r == 1 || (r == 0 && (drops&1) == 1) {
 			drops++
@@ -536,9 +545,15 @@ func (n XRPLNumber) ToInt64WithMode(mode RoundingMode) int64 {
 	return drops
 }
 
-// root2 computes the square root of n using Newton-Raphson iteration.
-// Reference: root2() in Number.cpp lines 700-736
+// root2 computes the square root of n using banker's rounding.
 func (n XRPLNumber) root2() XRPLNumber {
+	return n.root2Rounded(RoundToNearest)
+}
+
+// root2Rounded computes the square root of n using Newton-Raphson iteration,
+// rounding every intermediate operation under mode.
+// Reference: root2() in Number.cpp lines 700-736
+func (n XRPLNumber) root2Rounded(mode RoundingMode) XRPLNumber {
 	one := NewXRPLNumber(xrplNumMinMantissa, -15) // Number{1}
 	if n.Equal(one) {
 		return n
@@ -557,7 +572,7 @@ func (n XRPLNumber) root2() XRPLNumber {
 		e++
 	}
 	f = XRPLNumber{mantissa: f.mantissa, exponent: f.exponent - e}
-	f.normalize()
+	f.normalize(mode)
 
 	// Quadratic least squares curve fit: r = ((a2*f + a1)*f + a0) / D
 	// where D=105, a0=18, a1=144, a2=-60
@@ -565,7 +580,7 @@ func (n XRPLNumber) root2() XRPLNumber {
 	a1 := NewXRPLNumberFromInt(144)
 	a2 := NewXRPLNumberFromInt(-60)
 	D := NewXRPLNumberFromInt(105)
-	r := a2.Mul(f).Add(a1).Mul(f).Add(a0).Div(D)
+	r := a2.MulRounded(f, mode).AddRounded(a1, mode).MulRounded(f, mode).AddRounded(a0, mode).DivRounded(D, mode)
 
 	// Newton-Raphson iteration: r = (r + f/r) / 2
 	two := NewXRPLNumberFromInt(2)
@@ -573,7 +588,7 @@ func (n XRPLNumber) root2() XRPLNumber {
 	for {
 		rm2 = rm1
 		rm1 = r
-		r = r.Add(f.Div(r)).Div(two)
+		r = r.AddRounded(f.DivRounded(r, mode), mode).DivRounded(two, mode)
 		if r.Equal(rm1) || r.Equal(rm2) {
 			break
 		}

--- a/internal/ledger/state/xrpl_number_test.go
+++ b/internal/ledger/state/xrpl_number_test.go
@@ -76,7 +76,7 @@ func TestXRPLGuard_Round(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var g xrplGuard
 			tt.setup(&g)
-			got := g.round()
+			got := g.round(RoundToNearest)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/testing/amm/helpers.go
+++ b/internal/testing/amm/helpers.go
@@ -454,14 +454,14 @@ func (e *AMMTestEnv) CheckInvariant(asset1, asset2 tx.Asset, fixAMMv1_3 bool, sh
 	bal1, bal2, lptBalance := e.AMMBalances(asset1, asset2)
 
 	// Set rounding mode for the invariant check
+	mode := state.RoundToNearest
 	if fixAMMv1_3 {
-		guard := state.NewNumberRoundModeGuard(state.RoundUpward)
-		defer guard.Release()
+		mode = state.RoundUpward
 	}
 
 	// Compute sqrt(amount1 * amount2)
-	product := bal1.Mul(bal2, false)
-	result := product.Sqrt()
+	product := bal1.MulRounded(bal2, false, mode)
+	result := product.SqrtRounded(mode)
 
 	cmp := result.Compare(lptBalance)
 	if shouldFail {

--- a/internal/tx/amm/amm_deposit.go
+++ b/internal/tx/amm/amm_deposit.go
@@ -744,7 +744,9 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 		amountDeposit := getRoundedAssetCb(fixV1_3,
 			func() tx.Amount { return f1.Mul(assetBalIOU, false).Mul(solveQuadraticEq(a1, b1, c1), false) },
 			assetBalance,
-			func() tx.Amount { return f1.Mul(solveQuadraticEq(a1, b1, c1), false) },
+			func(mode state.RoundingMode) tx.Amount {
+				return f1.MulRounded(solveQuadraticEqRounded(a1, b1, c1, mode), false, mode)
+			},
 			true)
 		if amountDeposit.IsZero() || amountDeposit.IsNegative() {
 			return tx.TecAMM_FAILED
@@ -753,7 +755,9 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 		tokens := getRoundedLPTokensCb(fixV1_3,
 			func() tx.Amount { return numberDiv(toIOUForCalc(amountDeposit), ePriceIOU) },
 			lptBalance,
-			func() tx.Amount { return numberDiv(toIOUForCalc(amountDeposit), ePriceIOU) },
+			func(mode state.RoundingMode) tx.Amount {
+				return numberDivRounded(toIOUForCalc(amountDeposit), ePriceIOU, mode)
+			},
 			true)
 
 		// factor in the adjusted tokens

--- a/internal/tx/amm/amm_withdraw.go
+++ b/internal/tx/amm/amm_withdraw.go
@@ -627,7 +627,9 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		tokensAdj := getRoundedLPTokensCb(fixV1_3,
 			func() tx.Amount { return numberDiv(lptBalIOU.Mul(tPlusAE, false), tfMinusAE) },
 			lptBalance,
-			func() tx.Amount { return numberDiv(tPlusAE, tfMinusAE) },
+			func(mode state.RoundingMode) tx.Amount {
+				return numberDivRounded(tPlusAE, tfMinusAE, mode)
+			},
 			false)
 
 		if tokensAdj.IsZero() || tokensAdj.IsNegative() {
@@ -641,7 +643,9 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		amountWithdraw := getRoundedAssetCb(fixV1_3,
 			func() tx.Amount { return numberDiv(tokensAdjIOU, ePriceIOU) },
 			amount1,
-			func() tx.Amount { return numberDiv(tokensAdjIOU, ePriceIOU) },
+			func(mode state.RoundingMode) tx.Amount {
+				return numberDivRounded(tokensAdjIOU, ePriceIOU, mode)
+			},
 			false)
 
 		if amount1.IsZero() || toIOUForCalc(amountWithdraw).Compare(toIOUForCalc(amount1)) >= 0 {

--- a/internal/tx/amm/formulas.go
+++ b/internal/tx/amm/formulas.go
@@ -60,21 +60,20 @@ func feeMultHalf(tfee uint16) tx.Amount {
 // from the AMM balance.
 // Reference: rippled AMMHelpers.cpp adjustLPTokens()
 func adjustLPTokens(lptAMMBalance, lpTokens tx.Amount, isDeposit bool) tx.Amount {
-	g := state.NewNumberRoundModeGuard(state.RoundDownward)
-	defer g.Release()
+	const mode = state.RoundDownward
 
 	lptBalIOU := toIOUForCalc(lptAMMBalance)
 	lpTokIOU := toIOUForCalc(lpTokens)
 
 	if isDeposit {
 		// (lptAMMBalance + lpTokens) - lptAMMBalance
-		sum, _ := lptBalIOU.Add(lpTokIOU)
-		result, _ := sum.Sub(lptBalIOU)
+		sum, _ := lptBalIOU.AddRounded(lpTokIOU, mode)
+		result, _ := sum.SubRounded(lptBalIOU, mode)
 		return toSTAmountIssue(lptAMMBalance, result)
 	}
 	// (lpTokens - lptAMMBalance) + lptAMMBalance
-	diff, _ := lpTokIOU.Sub(lptBalIOU)
-	result, _ := diff.Add(lptBalIOU)
+	diff, _ := lpTokIOU.SubRounded(lptBalIOU, mode)
+	result, _ := diff.AddRounded(lptBalIOU, mode)
 	return toSTAmountIssue(lptAMMBalance, result)
 }
 
@@ -164,20 +163,22 @@ func getRoundedAsset(fixAMMv1_3 bool, balance, frac tx.Amount, isDeposit bool) t
 }
 
 // getRoundedAssetCb rounds an AMM single deposit/withdrawal amount using callbacks.
+// productCb receives the rounding mode under which it must evaluate its
+// Number expression (rippled runs the callback inside a NumberRoundModeGuard).
 // Reference: rippled AMMHelpers.cpp getRoundedAsset() (callback version)
-func getRoundedAssetCb(fixAMMv1_3 bool, noRoundCb func() tx.Amount, balance tx.Amount, productCb func() tx.Amount, isDeposit bool) tx.Amount {
+func getRoundedAssetCb(fixAMMv1_3 bool, noRoundCb func() tx.Amount, balance tx.Amount, productCb func(state.RoundingMode) tx.Amount, isDeposit bool) tx.Amount {
 	if !fixAMMv1_3 {
 		result := noRoundCb()
 		return toSTAmountIssue(balance, result)
 	}
 	rm := getAssetRounding(isDeposit)
 	if isDeposit {
-		return mulRoundForAsset(toIOUForCalc(balance), productCb(), rm, balance)
+		// rippled multiplies under rm but evaluates the product callback in
+		// the ambient (to_nearest) mode.
+		return mulRoundForAsset(toIOUForCalc(balance), productCb(state.RoundToNearest), rm, balance)
 	}
-	g := state.NewNumberRoundModeGuard(rm)
-	defer g.Release()
-	result := productCb()
-	return toSTAmountIssueRounded(balance, result)
+	result := productCb(rm)
+	return toSTAmountIssueRounded(balance, result, rm)
 }
 
 // getRoundedLPTokens rounds LPTokens for equal deposit/withdrawal.
@@ -195,8 +196,10 @@ func getRoundedLPTokens(fixAMMv1_3 bool, balance, frac tx.Amount, isDeposit bool
 }
 
 // getRoundedLPTokensCb rounds LPTokens for single deposit/withdrawal using callbacks.
+// productCb receives the rounding mode under which it must evaluate its
+// Number expression (rippled runs the callback inside a NumberRoundModeGuard).
 // Reference: rippled AMMHelpers.cpp getRoundedLPTokens() (callback version)
-func getRoundedLPTokensCb(fixAMMv1_3 bool, noRoundCb func() tx.Amount, lptAMMBalance tx.Amount, productCb func() tx.Amount, isDeposit bool) tx.Amount {
+func getRoundedLPTokensCb(fixAMMv1_3 bool, noRoundCb func() tx.Amount, lptAMMBalance tx.Amount, productCb func(state.RoundingMode) tx.Amount, isDeposit bool) tx.Amount {
 	lptBalIOU := toIOUForCalc(lptAMMBalance)
 	if !fixAMMv1_3 {
 		result := noRoundCb()
@@ -205,12 +208,12 @@ func getRoundedLPTokensCb(fixAMMv1_3 bool, noRoundCb func() tx.Amount, lptAMMBal
 	rm := getLPTokenRounding(isDeposit)
 	var tokens tx.Amount
 	if isDeposit {
-		g := state.NewNumberRoundModeGuard(rm)
-		result := productCb()
+		result := productCb(rm)
 		tokens = toSTAmountIssue(lptAMMBalance, result)
-		g.Release()
 	} else {
-		tokens = multiplyWithRounding(lptBalIOU, productCb(), rm)
+		// rippled multiplies under rm but evaluates the product callback in
+		// the ambient (to_nearest) mode.
+		tokens = multiplyWithRounding(lptBalIOU, productCb(state.RoundToNearest), rm)
 	}
 	return adjustLPTokens(lptAMMBalance, tokens, isDeposit)
 }

--- a/internal/tx/amm/math.go
+++ b/internal/tx/amm/math.go
@@ -156,7 +156,6 @@ func numberDiv(n, d tx.Amount) tx.Amount {
 	return numberDivRounded(n, d, state.RoundToNearest)
 }
 
-// numberDivRounded performs Number-based division n / d, rounding under mode.
 func numberDivRounded(n, d tx.Amount, mode state.RoundingMode) tx.Amount {
 	if d.IsZero() {
 		return state.NewIssuedAmountFromValue(0, -100, "", "")

--- a/internal/tx/amm/math.go
+++ b/internal/tx/amm/math.go
@@ -21,13 +21,12 @@ func calculateLPTokens(amount1, amount2 tx.Amount, fixV1_3 ...bool) tx.Amount {
 		return state.NewIssuedAmountFromValue(0, -100, "", "")
 	}
 
-	// With fixAMMv1_3 enabled, set rounding mode to downward to maintain
-	// the AMM invariant: sqrt(asset1 * asset2) >= LPTokensBalance
+	// With fixAMMv1_3 enabled, round downward to maintain the AMM invariant:
+	// sqrt(asset1 * asset2) >= LPTokensBalance.
 	// Reference: rippled AMMHelpers.cpp ammLPTokens() line 31-33
-	roundDown := len(fixV1_3) > 0 && fixV1_3[0]
-	if roundDown {
-		g := state.NewNumberRoundModeGuard(state.RoundDownward)
-		defer g.Release()
+	mode := state.RoundToNearest
+	if len(fixV1_3) > 0 && fixV1_3[0] {
+		mode = state.RoundDownward
 	}
 
 	// Convert amounts to IOU representation for consistent calculation
@@ -73,9 +72,9 @@ func calculateLPTokens(amount1, amount2 tx.Amount, fixV1_3 ...bool) tx.Amount {
 	}
 
 	// product = iou1 * iou2
-	product := iou1.Mul(iou2, false)
+	product := iou1.MulRounded(iou2, false, mode)
 	// result = sqrt(product)
-	return product.Sqrt()
+	return product.SqrtRounded(mode)
 }
 
 // GenerateAMMLPTCurrency generates the LP token currency code from two asset currencies.
@@ -154,17 +153,22 @@ func addToOne(x tx.Amount) tx.Amount {
 // All AMM formula divisions must use this function because rippled's AMM code
 // operates entirely in Number space.
 func numberDiv(n, d tx.Amount) tx.Amount {
+	return numberDivRounded(n, d, state.RoundToNearest)
+}
+
+// numberDivRounded performs Number-based division n / d, rounding under mode.
+func numberDivRounded(n, d tx.Amount, mode state.RoundingMode) tx.Amount {
 	if d.IsZero() {
 		return state.NewIssuedAmountFromValue(0, -100, "", "")
 	}
 	if n.IsZero() {
 		return state.NewIssuedAmountFromValue(0, -100, "", "")
 	}
-	nNum := state.NewXRPLNumber(n.Mantissa(), n.Exponent())
-	dNum := state.NewXRPLNumber(d.Mantissa(), d.Exponent())
-	result := nNum.Div(dNum)
+	nNum := state.NewXRPLNumberRounded(n.Mantissa(), n.Exponent(), mode)
+	dNum := state.NewXRPLNumberRounded(d.Mantissa(), d.Exponent(), mode)
+	result := nNum.DivRounded(dNum, mode)
 	iou := result.ToIOUAmountValue()
-	return state.NewIssuedAmountFromValue(iou.Mantissa(), iou.Exponent(), n.Currency, n.Issuer)
+	return state.NewIssuedAmountFromValueRounded(iou.Mantissa(), iou.Exponent(), n.Currency, n.Issuer, mode)
 }
 
 // numberDivToInt64 computes n / d in Number space and converts the quotient to
@@ -178,7 +182,7 @@ func numberDivToInt64(n, d tx.Amount) int64 {
 	}
 	nNum := state.NewXRPLNumber(n.Mantissa(), n.Exponent())
 	dNum := state.NewXRPLNumber(d.Mantissa(), d.Exponent())
-	return nNum.Div(dNum).ToInt64WithMode(state.RoundToNearest)
+	return nNum.DivRounded(dNum, state.RoundToNearest).ToInt64WithMode(state.RoundToNearest)
 }
 
 // stAmountDiv performs STAmount-style division: n / d.
@@ -206,31 +210,36 @@ func stAmountDiv(n, d tx.Amount) tx.Amount {
 //
 // Reference: rippled AMMHelpers.cpp solveQuadraticEq()
 func solveQuadraticEq(a, b, c tx.Amount) tx.Amount {
+	return solveQuadraticEqRounded(a, b, c, state.RoundToNearest)
+}
+
+// solveQuadraticEqRounded solves the positive root, rounding every operation
+// under mode (rippled runs the whole expression under the ambient
+// NumberRoundModeGuard).
+func solveQuadraticEqRounded(a, b, c tx.Amount, mode state.RoundingMode) tx.Amount {
 	two := numAmount(2)
 	four := numAmount(4)
 	// discriminant = b*b - 4*a*c
-	bb := b.Mul(b, false)
-	fourAC := four.Mul(a, false).Mul(c, false)
-	disc, _ := bb.Sub(fourAC)
+	bb := b.MulRounded(b, false, mode)
+	fourAC := four.MulRounded(a, false, mode).MulRounded(c, false, mode)
+	disc, _ := bb.SubRounded(fourAC, mode)
 	// Guard against negative discriminant (no real root)
 	if disc.IsNegative() {
 		return state.NewIssuedAmountFromValue(0, -100, "", "")
 	}
-	sqrtDisc := disc.Sqrt()
+	sqrtDisc := disc.SqrtRounded(mode)
 	// (-b + sqrtDisc) / (2*a)
 	negB := b.Negate()
-	numerator, _ := negB.Add(sqrtDisc)
-	denominator := two.Mul(a, false)
-	return numberDiv(numerator, denominator)
+	numerator, _ := negB.AddRounded(sqrtDisc, mode)
+	denominator := two.MulRounded(a, false, mode)
+	return numberDivRounded(numerator, denominator, mode)
 }
 
 // multiplyWithRounding multiplies an amount by a fractional Number
 // using an explicit rounding mode.
 // Reference: rippled AMMHelpers.cpp multiply(amount, frac, rm)
 func multiplyWithRounding(amount, frac tx.Amount, rm state.RoundingMode) tx.Amount {
-	g := state.NewNumberRoundModeGuard(rm)
-	defer g.Release()
-	result := amount.Mul(frac, rm == state.RoundUpward)
+	result := amount.MulRounded(frac, rm == state.RoundUpward, rm)
 	return toSTAmount(amount, result)
 }
 
@@ -251,9 +260,7 @@ func toSTAmount(original, result tx.Amount) tx.Amount {
 // Reference: rippled AmountConversions.h toSTAmount(issue, number, mode=getround())
 func toSTAmountIssue(amt tx.Amount, result tx.Amount) tx.Amount {
 	if amt.IsNative() {
-		g := state.NewNumberRoundModeGuard(state.RoundToNearest)
-		drops := iouToDropsRounded(result)
-		g.Release()
+		drops := iouToDropsRounded(result, state.RoundToNearest)
 		return state.NewXRPAmountFromInt(drops)
 	}
 	return state.NewIssuedAmountFromValue(result.Mantissa(), result.Exponent(),
@@ -261,12 +268,11 @@ func toSTAmountIssue(amt tx.Amount, result tx.Amount) tx.Amount {
 }
 
 // toSTAmountIssueRounded converts a result to the issue of the given amount,
-// using the current global rounding mode for XRP drops conversion.
-// Must be called while the appropriate NumberRoundModeGuard is active.
+// using mode for XRP drops conversion.
 // Reference: rippled's Number::operator rep() rounding behavior.
-func toSTAmountIssueRounded(amt tx.Amount, result tx.Amount) tx.Amount {
+func toSTAmountIssueRounded(amt tx.Amount, result tx.Amount, mode state.RoundingMode) tx.Amount {
 	if amt.IsNative() {
-		return state.NewXRPAmountFromInt(iouToDropsRounded(result))
+		return state.NewXRPAmountFromInt(iouToDropsRounded(result, mode))
 	}
 	return state.NewIssuedAmountFromValue(result.Mantissa(), result.Exponent(),
 		amt.Currency, amt.Issuer)
@@ -285,9 +291,7 @@ func mulRoundForAsset(amount, frac tx.Amount, rm state.RoundingMode, asset tx.Am
 		return state.NewXRPAmountFromInt(multiplyRawToDrops(amount, frac, rm))
 	}
 	// For IOU: rounding mode active during multiplication normalization
-	g := state.NewNumberRoundModeGuard(rm)
-	defer g.Release()
-	result := amount.Mul(frac, rm == state.RoundUpward)
+	result := amount.MulRounded(frac, rm == state.RoundUpward, rm)
 	return state.NewIssuedAmountFromValue(result.Mantissa(), result.Exponent(),
 		asset.Currency, asset.Issuer)
 }
@@ -469,12 +473,12 @@ func iouToDrops(amt tx.Amount) int64 {
 	return mantissa
 }
 
-// iouToDropsRounded converts an IOU representation back to XRP drops,
-// using the current global rounding mode with full Guard-style digit tracking.
+// iouToDropsRounded converts an IOU representation back to XRP drops, using mode
+// with full Guard-style digit tracking.
 // Reference: rippled Number::operator rep() — accumulates ALL discarded digits
 // into a Guard, then rounds using the most significant discarded digit plus
 // a sticky bit for any earlier non-zero digits.
-func iouToDropsRounded(amt tx.Amount) int64 {
+func iouToDropsRounded(amt tx.Amount, mode state.RoundingMode) int64 {
 	if amt.IsNative() {
 		return amt.Drops()
 	}
@@ -511,7 +515,6 @@ func iouToDropsRounded(amt tx.Amount) int64 {
 	}
 
 	// Apply rounding using accumulated guard info
-	mode := state.GetNumberRound()
 	mantissa = applyGuardRound(mantissa, guardDigit, hasRemainder, neg, mode)
 
 	if neg {

--- a/internal/tx/offer/offer_quality.go
+++ b/internal/tx/offer/offer_quality.go
@@ -225,7 +225,6 @@ func offerDivRoundStrict(num, den tx.Amount, native bool, currency, issuer strin
 		return tx.NewXRPAmount(drops)
 	}
 
-	// Normalize the result under the appropriate Number rounding mode.
 	var mode state.RoundingMode
 	if roundUp != resultNegative {
 		mode = state.RoundUpward

--- a/internal/tx/offer/offer_quality.go
+++ b/internal/tx/offer/offer_quality.go
@@ -225,20 +225,18 @@ func offerDivRoundStrict(num, den tx.Amount, native bool, currency, issuer strin
 		return tx.NewXRPAmount(drops)
 	}
 
-	// NumberRoundModeGuard with appropriate mode
+	// Normalize the result under the appropriate Number rounding mode.
 	var mode state.RoundingMode
 	if roundUp != resultNegative {
 		mode = state.RoundUpward
 	} else {
 		mode = state.RoundDownward
 	}
-	guard := state.NewNumberRoundModeGuard(mode)
 	mantissa := int64(amount)
 	if resultNegative {
 		mantissa = -mantissa
 	}
-	result := state.NewIssuedAmountFromValue(mantissa, offset, currency, issuer)
-	guard.Release()
+	result := state.NewIssuedAmountFromValueRounded(mantissa, offset, currency, issuer, mode)
 
 	if roundUp && !resultNegative && result.IsZero() {
 		if native {

--- a/internal/tx/payment/amm_swap.go
+++ b/internal/tx/payment/amm_swap.go
@@ -585,7 +585,9 @@ func getAMMOfferStartWithTakerPays(poolIn, poolOut tx.Amount, quality Quality, t
 func reduceOffer(amount tx.Amount) tx.Amount {
 	pct := state.NewIssuedAmountFromValue(9999e12, -16, "", "") // 0.9999
 	n := toNumber(amount)
-	return fromNumber(n.Mul(pct, false), amount)
+	// towards_zero so the result is always less than amount or zero,
+	// matching rippled detail::reduceOffer (AMMHelpers.h).
+	return fromNumber(n.MulRounded(pct, false, state.RoundTowardsZero), amount)
 }
 
 // WithinRelativeDistance checks if two qualities are within a relative distance threshold.

--- a/internal/tx/payment/amm_swap.go
+++ b/internal/tx/payment/amm_swap.go
@@ -111,38 +111,60 @@ func fromNumberWithGuard(num tx.Amount, original tx.Amount, mode state.RoundingM
 
 // ammAdd adds two amounts, ignoring errors (types always match in AMM math).
 func ammAdd(a, b tx.Amount) tx.Amount {
-	r, _ := a.Add(b)
+	return ammAddRounded(a, b, state.RoundToNearest)
+}
+
+// ammAddRounded adds two amounts, rounding the IOU result under mode.
+func ammAddRounded(a, b tx.Amount, mode state.RoundingMode) tx.Amount {
+	r, _ := a.AddRounded(b, mode)
 	return r
 }
 
 // ammSub subtracts b from a, ignoring errors.
 func ammSub(a, b tx.Amount) tx.Amount {
-	r, _ := a.Sub(b)
+	return ammSubRounded(a, b, state.RoundToNearest)
+}
+
+// ammSubRounded subtracts b from a, rounding the IOU result under mode.
+func ammSubRounded(a, b tx.Amount, mode state.RoundingMode) tx.Amount {
+	r, _ := a.SubRounded(b, mode)
 	return r
 }
 
-// numberMul multiplies two IOU-like amounts using XRPLNumber arithmetic.
-// This ensures Guard-based rounding is used, respecting the global rounding mode.
-// Reference: rippled Number::operator*= in Number.cpp
+// numberMul multiplies two IOU-like amounts using XRPLNumber arithmetic with
+// banker's rounding.
 func numberMul(a, b tx.Amount) tx.Amount {
-	na := state.NewXRPLNumber(a.Mantissa(), a.Exponent())
-	nb := state.NewXRPLNumber(b.Mantissa(), b.Exponent())
-	result := na.Mul(nb)
-	iou := result.ToIOUAmountValue()
-	return state.NewIssuedAmountFromValue(iou.Mantissa(), iou.Exponent(), a.Currency, a.Issuer)
+	return numberMulRounded(a, b, state.RoundToNearest)
 }
 
-// numberDiv divides two IOU-like amounts using XRPLNumber arithmetic.
-// This ensures Guard-based rounding is used, respecting the global rounding mode.
+// numberMulRounded multiplies two IOU-like amounts using XRPLNumber arithmetic,
+// rounding under mode.
+// Reference: rippled Number::operator*= in Number.cpp
+func numberMulRounded(a, b tx.Amount, mode state.RoundingMode) tx.Amount {
+	na := state.NewXRPLNumberRounded(a.Mantissa(), a.Exponent(), mode)
+	nb := state.NewXRPLNumberRounded(b.Mantissa(), b.Exponent(), mode)
+	result := na.MulRounded(nb, mode)
+	iou := result.ToIOUAmountValue()
+	return state.NewIssuedAmountFromValueRounded(iou.Mantissa(), iou.Exponent(), a.Currency, a.Issuer, mode)
+}
+
+// numberDiv divides two IOU-like amounts using XRPLNumber arithmetic with
+// banker's rounding.
 // Amount.Div() does NOT use XRPLNumber even when NumberSwitchover is on;
 // this function provides the correct Number/Guard-based division for AMM math.
-// Reference: rippled Number::operator/= in Number.cpp
 func numberDiv(a, b tx.Amount) tx.Amount {
-	na := state.NewXRPLNumber(a.Mantissa(), a.Exponent())
-	nb := state.NewXRPLNumber(b.Mantissa(), b.Exponent())
-	result := na.Div(nb)
+	return numberDivRounded(a, b, state.RoundToNearest)
+}
+
+// numberDivRounded divides two IOU-like amounts using XRPLNumber arithmetic,
+// rounding under mode.
+// Reference: rippled Number::operator/= in Number.cpp
+func numberDivRounded(a, b tx.Amount, mode state.RoundingMode) tx.Amount {
+	na := state.NewXRPLNumberRounded(a.Mantissa(), a.Exponent(), mode)
+	nb := state.NewXRPLNumberRounded(b.Mantissa(), b.Exponent(), mode)
+	result := na.DivRounded(nb, mode)
 	iou := result.ToIOUAmountValue()
-	return state.NewIssuedAmountFromValue(iou.Mantissa(), iou.Exponent(), a.Currency, a.Issuer)
+	return state.NewIssuedAmountFromValueRounded(iou.Mantissa(), iou.Exponent(), a.Currency, a.Issuer, mode)
 }
 
 // AMMFeeMult returns (1 - tfee/100000) as a fee multiplier.
@@ -162,15 +184,20 @@ func AMMFeeMultHalf(tfee uint16) tx.Amount {
 	return ammSub(ammOne(), result)
 }
 
-// AMMGetFee returns tfee/100000 as an Amount.
+// AMMGetFee returns tfee/100000 as an Amount using banker's rounding.
 // Reference: rippled AMMCore.h getFee()
 func AMMGetFee(tfee uint16) tx.Amount {
+	return AMMGetFeeRounded(tfee, state.RoundToNearest)
+}
+
+// AMMGetFeeRounded returns tfee/100000 as an Amount, rounding under mode.
+func AMMGetFeeRounded(tfee uint16, mode state.RoundingMode) tx.Amount {
 	if tfee == 0 {
 		return state.NewIssuedAmountFromValue(0, -100, "", "")
 	}
 	numerator := state.NewIssuedAmountFromValue(int64(tfee), 0, "", "")
 	denominator := state.NewIssuedAmountFromValue(1e15, -10, "", "") // 100000
-	return numberDiv(numerator, denominator)
+	return numberDivRounded(numerator, denominator, mode)
 }
 
 // SwapAssetIn calculates how much you get out when swapping assetIn into the pool.
@@ -185,33 +212,28 @@ func SwapAssetIn(poolIn, poolOut, assetIn tx.Amount, tfee uint16, fixAMMv1_1 boo
 	nAssetIn := toNumber(assetIn)
 
 	if fixAMMv1_1 {
-		// Save and restore rounding mode -- rippled uses saveNumberRoundMode RAII.
+		// Each sub-computation rounds to favor the AMM (minimize output),
+		// matching rippled's per-step Number::setround() calls.
 		// Reference: rippled AMMHelpers.h swapAssetIn() lines 493-514
-		savedMode := state.SetNumberRound(state.RoundUpward)
-		defer state.SetNumberRound(savedMode)
 
 		// Number::setround(Number::upward)
-		state.SetNumberRound(state.RoundUpward)
-		numerator := numberMul(nPoolIn, nPoolOut)
-		fee := AMMGetFee(tfee)
+		numerator := numberMulRounded(nPoolIn, nPoolOut, state.RoundUpward)
+		fee := AMMGetFeeRounded(tfee, state.RoundUpward)
 
 		// Number::setround(Number::downward)
-		state.SetNumberRound(state.RoundDownward)
-		fMult := ammSub(ammOne(), fee)
-		assetFee := numberMul(nAssetIn, fMult)
-		denom := ammAdd(nPoolIn, assetFee)
+		fMult := ammSubRounded(ammOne(), fee, state.RoundDownward)
+		assetFee := numberMulRounded(nAssetIn, fMult, state.RoundDownward)
+		denom := ammAddRounded(nPoolIn, assetFee, state.RoundDownward)
 
 		if denom.Signum() <= 0 {
 			return zeroLikeAmount(poolOut)
 		}
 
 		// Number::setround(Number::upward)
-		state.SetNumberRound(state.RoundUpward)
-		ratio := numberDiv(numerator, denom)
+		ratio := numberDivRounded(numerator, denom, state.RoundUpward)
 
 		// Number::setround(Number::downward)
-		state.SetNumberRound(state.RoundDownward)
-		swapOut := ammSub(nPoolOut, ratio)
+		swapOut := ammSubRounded(nPoolOut, ratio, state.RoundDownward)
 
 		if swapOut.Signum() < 0 {
 			return zeroLikeAmount(poolOut)
@@ -253,35 +275,29 @@ func SwapAssetOut(poolIn, poolOut, assetOut tx.Amount, tfee uint16, fixAMMv1_1 b
 	nAssetOut := toNumber(assetOut)
 
 	if fixAMMv1_1 {
-		// Save and restore rounding mode -- rippled uses saveNumberRoundMode RAII.
+		// Each sub-computation rounds to favor the AMM (maximize input),
+		// matching rippled's per-step Number::setround() calls.
 		// Reference: rippled AMMHelpers.h swapAssetOut() lines 562-587
-		savedMode := state.SetNumberRound(state.RoundUpward)
-		defer state.SetNumberRound(savedMode)
 
 		// Number::setround(Number::upward)
-		state.SetNumberRound(state.RoundUpward)
-		numerator := numberMul(nPoolIn, nPoolOut)
+		numerator := numberMulRounded(nPoolIn, nPoolOut, state.RoundUpward)
 
 		// Number::setround(Number::downward)
-		state.SetNumberRound(state.RoundDownward)
-		denom := ammSub(nPoolOut, nAssetOut)
+		denom := ammSubRounded(nPoolOut, nAssetOut, state.RoundDownward)
 		if denom.Signum() <= 0 {
 			return toMaxAmount(poolIn)
 		}
 
 		// Number::setround(Number::upward)
-		state.SetNumberRound(state.RoundUpward)
-		ratio := numberDiv(numerator, denom)
-		numerator2 := ammSub(ratio, nPoolIn)
-		fee := AMMGetFee(tfee)
+		ratio := numberDivRounded(numerator, denom, state.RoundUpward)
+		numerator2 := ammSubRounded(ratio, nPoolIn, state.RoundUpward)
+		fee := AMMGetFeeRounded(tfee, state.RoundUpward)
 
 		// Number::setround(Number::downward)
-		state.SetNumberRound(state.RoundDownward)
-		fMult := ammSub(ammOne(), fee)
+		fMult := ammSubRounded(ammOne(), fee, state.RoundDownward)
 
 		// Number::setround(Number::upward)
-		state.SetNumberRound(state.RoundUpward)
-		swapIn := numberDiv(numerator2, fMult)
+		swapIn := numberDivRounded(numerator2, fMult, state.RoundUpward)
 
 		if swapIn.Signum() < 0 {
 			return zeroLikeAmount(poolIn)
@@ -445,9 +461,9 @@ func getAMMOfferStartWithTakerGets(poolIn, poolOut tx.Amount, quality Quality, t
 		return tx.Amount{}, tx.Amount{}, false
 	}
 
-	// NumberRoundModeGuard mg(Number::to_nearest) -- all quadratic solving uses to_nearest
-	savedMode := state.SetNumberRound(state.RoundToNearest)
-	defer state.SetNumberRound(savedMode)
+	// All quadratic solving below uses to_nearest, which is the default rounding
+	// mode of the number* / amm* helpers (rippled: NumberRoundModeGuard
+	// mg(Number::to_nearest)).
 
 	// Convert to Number for uniform arithmetic
 	nPoolIn := toNumber(poolIn)
@@ -513,9 +529,9 @@ func getAMMOfferStartWithTakerPays(poolIn, poolOut tx.Amount, quality Quality, t
 		return tx.Amount{}, tx.Amount{}, false
 	}
 
-	// NumberRoundModeGuard mg(Number::to_nearest) -- all quadratic solving uses to_nearest
-	savedMode := state.SetNumberRound(state.RoundToNearest)
-	defer state.SetNumberRound(savedMode)
+	// All quadratic solving below uses to_nearest, which is the default rounding
+	// mode of the number* / amm* helpers (rippled: NumberRoundModeGuard
+	// mg(Number::to_nearest)).
 
 	// Convert to Number for uniform arithmetic
 	nPoolIn := toNumber(poolIn)

--- a/internal/tx/payment/amm_swap.go
+++ b/internal/tx/payment/amm_swap.go
@@ -190,7 +190,6 @@ func AMMGetFee(tfee uint16) tx.Amount {
 	return AMMGetFeeRounded(tfee, state.RoundToNearest)
 }
 
-// AMMGetFeeRounded returns tfee/100000 as an Amount, rounding under mode.
 func AMMGetFeeRounded(tfee uint16, mode state.RoundingMode) tx.Amount {
 	if tfee == 0 {
 		return state.NewIssuedAmountFromValue(0, -100, "", "")


### PR DESCRIPTION
## Summary

The `XRPLNumber` **switchover flag** and **rounding mode** were mutable package-level globals — the Go equivalent of rippled's per-thread `getSTNumberSwitchover()` (`LocalValue<bool>`) and `Number::mode_` (`thread_local`). A live node performs amount arithmetic concurrently (the single transaction-apply goroutine vs. the RPC / path-find goroutines), so both globals data-raced under `-race`. The rounding mode is the dangerous one: a concurrent goroutine can flip it mid-computation in another goroutine, yielding a different amount → divergent state/metadata → the kind of non-deterministic consensus fork tracked in #724.

Transaction apply is single-threaded in both rippled and go-xrpl, so the hazard is purely apply-vs-concurrent-reader. The fix removes the shared mutable state without changing any rounding/normalisation semantics:

- **Switchover → `atomic.Bool`.** It is written only by the apply goroutine (`do_apply.go`, from `rules().Enabled(fixUniversalNumber)`) and is constant for the duration of a ledger, so an atomic flag removes the race while every reader still observes the value apply established for the current ledger.
- **Rounding mode → threaded explicitly.** The global mode and `NumberRoundModeGuard` are gone. Every operation defaults to `RoundToNearest`; the strict-rounding (`mulRound`/`divRound`), offer, and AMM paths call a matching `*Rounded` variant (`MulRounded`/`AddRounded`/`SqrtRounded`/`DivRounded`/`NewIssuedAmountFromValueRounded`/…) with the desired mode. This mirrors rippled's `NumberRoundModeGuard` scope with no shared state. The AMM per-step `setround()` flips in `SwapAssetIn`/`SwapAssetOut` and the `getRounded*Cb` product closures are threaded the same way.

The `*Rounded` dual-API follows the codebase's existing idiom (`ToInt64WithMode`, `multiplyWithRounding`, `mulRoundForAsset`) and keeps every non-mode-sensitive call site (other tx types, tests) untouched.

## Test plan

- [x] `go test -race ./internal/ledger/state/... ./internal/tx/amm/... ./internal/tx/offer/... ./internal/tx/payment/... ./internal/testing/amm/...` — all pass (incl. the 508-test AMM suite, the main rounding validator)
- [x] `go test ./...` — full module suite passes, no regressions
- [x] New `-race` regression guard `TestNumberRounding_ConcurrentDeterministic`: 16 goroutines run mode-varied arithmetic concurrently and must reproduce the sequential golden results bit-for-bit (fails + races if the mode regresses to a global)
- [x] `go build ./...`, `gofmt` clean

Fixes #740