### PR TITLE
test: de-flake AcceptConsensusResult validation-first race test

### DIFF
--- a/internal/ledger/service/pending_ledger_validation_test.go
+++ b/internal/ledger/service/pending_ledger_validation_test.go
@@ -446,41 +446,35 @@ func TestAcceptConsensusResult_EventCallbackFiresAfterValidationFirstRace(t *tes
 		}
 	})
 
-	// Predict the hash that AcceptConsensusResult will compute so we can
-	// stash a matching validation. The openLedger already chains off the
-	// current closedLedger via Start() — closing it with (closeTime, 0)
-	// and no txs is deterministic, so we can snapshot+close a clone to
-	// derive the exact hash. Simpler alternative: stash the *seq* with a
-	// wrong hash first to verify validation-first no-ops, then do the
-	// real-race test below. But the cleanest form is to perform the close
-	// twice: once discarded to capture the hash, then re-close for real.
+	// Predict the hash svc's consensus close will compute so we can stash a
+	// matching validation first. A no-tx close is a deterministic function of
+	// (parent, closeTime), so we drive a throwaway probe service over svc's
+	// OWN parent ledger: fed that parent, the probe's AcceptConsensusResult
+	// takes the chain-switch path and produces the exact hash svc will
+	// compute when it closes the same parent at the same closeTime.
 	//
-	// Even simpler: do the real close first, observe the produced hash,
-	// then drive AcceptConsensusResult on a fresh service where we can
-	// pre-stash that hash. That keeps the test free of internal cloning.
+	// The probe must close svc's parent, not its own. Each service's seq-2
+	// ledger is stamped with time.Now() in Start(), so two services' genesis
+	// chains hash identically only when both Start() calls land in the same
+	// close-time bucket — closing the probe's own parent made this test flake
+	// whenever the two Start()s straddled a bucket boundary.
+	parentReal := svc.GetClosedLedger()
+	require.NotNil(t, parentReal)
+	expectedSeq := parentReal.Sequence() + 1
+	closeTime := time.Unix(1700000000, 0)
+
 	probeSvc, err := New(DefaultConfig())
 	require.NoError(t, err)
 	require.NoError(t, probeSvc.Start())
-
-	parent := probeSvc.GetClosedLedger()
-	require.NotNil(t, parent)
-	expectedSeq := parent.Sequence() + 1
-	closeTime := time.Unix(1700000000, 0)
-	_, err = probeSvc.AcceptConsensusResult(context.TODO(), parent, nil, closeTime, true)
+	_, err = probeSvc.AcceptConsensusResult(context.TODO(), parentReal, nil, closeTime, true)
 	require.NoError(t, err)
 
-	// Capture the hash that the deterministic close produced.
 	probeSvc.mu.RLock()
 	expectedHash := probeSvc.closedLedger.Hash()
 	probeSvc.mu.RUnlock()
 	require.NotEqual(t, [32]byte{}, expectedHash)
 
-	// Back to the real svc: stash the validation BEFORE AcceptConsensusResult.
-	parentReal := svc.GetClosedLedger()
-	require.NotNil(t, parentReal)
-	require.Equal(t, parent.Sequence(), parentReal.Sequence(),
-		"probe and real service must start from the same closedLedger seq")
-
+	// Stash the validation BEFORE svc's AcceptConsensusResult.
 	svc.SetValidatedLedger(expectedSeq, expectedHash)
 
 	svc.mu.RLock()


### PR DESCRIPTION
## Problem

`TestAcceptConsensusResult_EventCallbackFiresAfterValidationFirstRace` (internal/ledger/service) is flaky on CI — observed as `expected: 0x3, actual: 0x2` ("F4 drain must promote validatedLedger on matching consensus close").

## Root cause

The test predicted the consensus-close hash by closing a **separate probe service's own** genesis-chain parent, then stashed that hash on the real service and asserted the F4 drain promotes `validatedLedger` inline. But each service's seq-2 ledger is closed with `time.Now()` in `Start()` (service.go:539), so two independently-started services' genesis chains hash identically **only when both `Start()` calls land in the same close-time bucket**. When they straddle a bucket boundary, the predicted hash ≠ the real close hash → the F4 drain finds no matching stash → `validatedLedgerIndex` stays at the parent seq → assertion fails. Pure wall-clock flake; unrelated to behavior.

## Fix

Drive the throwaway probe over the **real service's own parent** instead of the probe's. A no-tx close is a deterministic function of `(parent, closeTime)`, so the probe — fed the same parent via `AcceptConsensusResult`'s chain-switch path — yields the exact hash the real service computes. No production change.

Test-only; the production `time.Now()` genesis-chain stamp in `Start()` is intended for standalone/fresh nodes and is left as-is.

## Verification

- `go test -race -count=200 -run TestAcceptConsensusResult_EventCallbackFiresAfterValidationFirstRace ./internal/ledger/service/` → 200/200 pass
- Full `internal/ledger/service` package green under `-race`; module builds; vet/lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)