### PR TITLE
fix: do not update sfAccountTxnID on the tec path (#744)

### DIFF
--- a/internal/testing/accountset/accounttxnid_tec_test.go
+++ b/internal/testing/accountset/accounttxnid_tec_test.go
@@ -1,0 +1,63 @@
+package accountset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// rippled updates sfAccountTxnID in the Transactor::apply() preamble
+// (Transactor.cpp:568) BEFORE doApply(). On a tec result that whole preamble
+// is rolled back by reset() (Transactor.cpp:1001 ctx_.discard()), which then
+// re-applies ONLY sfBalance (fee) and sfSequence — never sfAccountTxnID. So a
+// tec must leave AccountTxnID at its prior value; only a successful tx updates
+// it.
+//
+// Regression for the mixed-soak fork (iter-5 seq-70, soak#1 seq-39): goXRPL's
+// tec-recovery path updated AccountTxnID, so a tec tx from an asfAccountTxnID
+// account produced metadata (and, when it raced, a transaction_hash) that
+// diverged from rippled while account_hash matched — wedging consensus.
+func TestAccountTxnID_NotUpdatedOnTec(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	ghost := jtx.NewAccount("ghost") // unfunded → alice's payment to it tecs
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	readTxnID := func() [32]byte {
+		t.Helper()
+		data, err := env.LedgerEntry(keylet.Account(alice.ID))
+		require.NoError(t, err)
+		ar, err := state.ParseAccountRootFromBytes(data)
+		require.NoError(t, err)
+		return ar.AccountTxnID
+	}
+
+	// Enable asfAccountTxnID (present, value zero).
+	r := env.Submit(AccountSet(alice).SetFlag(5).Build())
+	jtx.RequireTxSuccess(t, r)
+	env.Close()
+
+	// A successful tx must update AccountTxnID (rippled preamble survives).
+	r = env.Submit(AccountSet(alice).Build()) // noop success
+	jtx.RequireTxSuccess(t, r)
+	env.Close()
+	afterSuccess := readTxnID()
+	require.NotEqual(t, [32]byte{}, afterSuccess, "a successful tx must set AccountTxnID")
+
+	// A tec tx must NOT change AccountTxnID (rippled reset() re-applies only
+	// fee+seq). Payment of 1 XRP to an unfunded account is below reserve →
+	// tecNO_DST_INSUF_XRP, applied (fee claimed) but unsuccessful.
+	r = env.Submit(payment.Pay(alice, ghost, uint64(jtx.XRP(1))).Build())
+	require.False(t, r.Success, "payment below reserve to an unfunded dest must tec, got %s", r.Code)
+	require.Contains(t, r.Code, "tec", "expected a tec result, got %s", r.Code)
+	env.Close()
+	afterTec := readTxnID()
+	require.Equal(t, afterSuccess, afterTec,
+		"a tec tx must NOT update AccountTxnID — rippled reset() discards the preamble and re-applies only fee+seq")
+}

--- a/internal/tx/do_apply.go
+++ b/internal/tx/do_apply.go
@@ -593,18 +593,15 @@ func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *ApplyStateTable,
 	recoveredAccount.PreviousTxnID = st.txHash
 	recoveredAccount.PreviousTxnLgrSeq = e.config.LedgerSequence
 
-	// Update AccountTxnID if the account has tracking enabled (field present).
-	// On the success path, apply() sets this before doApply(). On the tec path,
-	// reset() discards all changes then re-applies fee/sequence. The AccountTxnID
-	// must also be updated here so the account tracks the last-applied transaction
-	// even when the result is a tec code. Keyed on presence, not non-zero, so a
-	// freshly-enabled present-zero field is still updated.
-	// Reference: rippled Transactor::apply() lines 568-569.
-	{
-		if recoveredAccount.HasAccountTxnID {
-			recoveredAccount.AccountTxnID = st.txHash
-		}
-	}
+	// Do NOT update sfAccountTxnID on the tec path. rippled updates it in the
+	// apply() preamble (Transactor.cpp:568) BEFORE doApply(); on a tec that
+	// whole preamble is rolled back by reset() (Transactor.cpp:1001
+	// ctx_.discard()), which then re-applies only sfBalance (fee) and
+	// sfSequence — never sfAccountTxnID. So a tec leaves AccountTxnID at its
+	// prior value. recoveredAccount is re-parsed from the original account, so
+	// simply not touching it preserves that prior value, matching rippled.
+	// (Updating it here forked account metadata on tec txs from asfAccountTxnID
+	// accounts — transaction_hash diverged while account_hash matched.)
 
 	updatedData, err := state.SerializeAccountRoot(recoveredAccount)
 	if err != nil {


### PR DESCRIPTION
## Problem

A tec transaction from an `asfAccountTxnID` account forked the mixed-network soak (recurring seq-70 / seq-39 fork): byte-identical parent + identical tx-set + identical `account_hash`, but different `transaction_hash`. goXRPL updated `sfAccountTxnID` on the tec path; the validated chain (3 rippled + the other goXRPL node) did not.

## Root cause

rippled updates `sfAccountTxnID` in the `Transactor::apply()` preamble (`Transactor.cpp:568`) **before** `doApply()`. On a tec, `reset()` (`Transactor.cpp:1001`) does `ctx_.discard()` and re-applies **only `sfBalance` (fee) and `sfSequence`** — never `sfAccountTxnID`. So a tec leaves `AccountTxnID` unchanged. goXRPL's tec-recovery path (`do_apply.go writeRecoveryAccount`) wrongly re-applied the update.

## Fix

Remove the `sfAccountTxnID` update from `writeRecoveryAccount`. `recoveredAccount` is re-parsed from the original account, so not touching it preserves the prior value — matching rippled. The success path (apply preamble, `do_apply.go:211`) is unchanged and correct.

## Test

`internal/testing/accountset/accounttxnid_tec_test.go::TestAccountTxnID_NotUpdatedOnTec` — a successful tx updates `AccountTxnID`; a tec tx leaves it unchanged. tx/account/accountset/payment/escrow/offer suites pass; `go vet` clean.

Fixes #744