### PR TITLE
fix: serialize WebSocket control writes via WriteControl

### DIFF
--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -49,6 +49,10 @@ type WebSocketServer struct {
 	services            *types.ServiceContainer
 	peerSource          atomic.Pointer[types.PeerSource]
 	loadTracker         *loadtrack.Tracker
+	// pingInterval is how often pingLoop sends a keepalive ping. Settable
+	// so concurrency tests can drive the ping path without waiting on the
+	// production cadence.
+	pingInterval time.Duration
 	// wg tracks per-connection goroutines (read loop, send pump, ping loop)
 	// so Close can join them on shutdown.
 	wg sync.WaitGroup
@@ -129,6 +133,7 @@ func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer)
 		timeout:        timeout,
 		services:       services,
 		loadTracker:    loadtrack.New(),
+		pingInterval:   30 * time.Second,
 	}
 }
 
@@ -247,7 +252,7 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 
 func (ws *WebSocketServer) pingLoop(wsConn *WebSocketConnection) {
 	defer recoverPanic("pingLoop", wsConn.ID)
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(ws.pingInterval)
 	defer ticker.Stop()
 
 	for {
@@ -255,8 +260,12 @@ func (ws *WebSocketServer) pingLoop(wsConn *WebSocketConnection) {
 		case <-wsConn.ctx.Done():
 			return
 		case <-ticker.C:
-			wsConn.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-			if err := wsConn.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+			// WriteControl carries its own deadline and serializes against
+			// the message-frame writer (handleSend) through gorilla's
+			// control-write lock. WriteMessage+SetWriteDeadline here would
+			// instead touch the unguarded single-writer state shared with
+			// handleSend, racing it (#746).
+			if err := wsConn.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(10*time.Second)); err != nil {
 				wsLog().Debug("WebSocket ping failed", "err", err)
 				return
 			}
@@ -957,9 +966,13 @@ func (ws *WebSocketServer) GetSubscriptionManager() *subscription.Manager {
 func (ws *WebSocketServer) Close(ctx context.Context) error {
 	ws.connectionsMutex.Lock()
 	for _, conn := range ws.connections {
-		conn.conn.WriteMessage(
+		// WriteControl (not WriteMessage) so the shutdown close frame
+		// serializes against a possibly-still-running handleSend instead of
+		// racing its message-frame write (#746).
+		conn.conn.WriteControl(
 			websocket.CloseMessage,
 			websocket.FormatCloseMessage(websocket.CloseGoingAway, "server shutdown"),
+			time.Now().Add(10*time.Second),
 		)
 		conn.cancel()
 		conn.conn.Close()

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -252,7 +252,14 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 
 func (ws *WebSocketServer) pingLoop(wsConn *WebSocketConnection) {
 	defer recoverPanic("pingLoop", wsConn.ID)
-	ticker := time.NewTicker(ws.pingInterval)
+	// Fall back to the default when constructed via struct literal: a zero
+	// pingInterval would panic NewTicker. Read into a local rather than
+	// mutating the shared field from this per-connection goroutine.
+	interval := ws.pingInterval
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -172,6 +172,76 @@ func TestWebSocketServer_FailedUpgrade_ReleasesSlot(t *testing.T) {
 	c.Close()
 }
 
+// TestWebSocketServer_ConcurrentWrites_NoRace drives the ping path and the
+// data-send path against the same gorilla *websocket.Conn at once. pingLoop
+// (and Close) must write their control frames via WriteControl so they
+// serialize against handleSend's message-frame writes; the old WriteMessage
+// calls touched gorilla's unguarded single-writer state and raced handleSend.
+// Run under -race to catch a regression. Regression test for issue #746.
+func TestWebSocketServer_ConcurrentWrites_NoRace(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ws.RegisterAllMethods()
+	ws.pingInterval = time.Millisecond // hammer the ping path during the test
+
+	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
+	defer httpSrv.Close()
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+
+	client, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	// Drain every frame the server sends (data frames, plus gorilla
+	// auto-responds to pings) so handleSend never blocks on a full buffer.
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		for {
+			if _, _, err := client.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Locate the server-side connection so we can push data frames through it.
+	var wsConn *WebSocketConnection
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ws.connectionsMutex.RLock()
+		for _, c := range ws.connections {
+			wsConn = c
+		}
+		ws.connectionsMutex.RUnlock()
+		if wsConn != nil {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if wsConn == nil {
+		t.Fatal("server connection never registered")
+	}
+
+	// Feed handleSend a steady stream of data frames while pingLoop fires.
+	for i := 0; i < 500; i++ {
+		select {
+		case wsConn.sendChannel <- []byte(`{"type":"race-probe"}`):
+		case <-time.After(2 * time.Second):
+			t.Fatal("send channel stalled")
+		}
+	}
+
+	// Close writes a control close frame, again concurrently with handleSend.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := ws.Close(ctx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	client.Close()
+	<-readDone
+}
+
 // Sanity: ensure we can call NewWebSocketServer concurrently without races.
 func TestWebSocketServer_New_Concurrent(t *testing.T) {
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Summary
- The WebSocket server wrote ping frames (`pingLoop`) and the shutdown close frame (`Close`) with `WriteMessage`, while `handleSend` wrote data frames with `WriteMessage` from another goroutine. `WriteMessage`/`SetWriteDeadline` touch gorilla's unguarded single-writer state (`writer`/`writeBuf`/`isWriting`/`writeDeadline`), so the two writers raced — the `-race` data race reported in #746.
- Ping and close are **control** frames, so route them through `conn.WriteControl`, which carries its own deadline and serializes against the message-frame writer via gorilla's internal control-write lock. `handleSend` stays the sole message-frame writer; no mutex, no hot-path lock contention (the issue's preferred Option 1).
- Added an injectable `pingInterval` (default 30s) so a regression test can drive the ping path on demand.

## Test plan
- [x] `go test -race ./internal/rpc/` — full package green, including the new `TestWebSocketServer_ConcurrentWrites_NoRace`.
- [x] Verified the new test **reproduces** the exact race (gorilla `conn.go:479` beginMessage read vs `conn.go:546` endMessage write, pingLoop vs handleSend) when `pingLoop` is reverted to `WriteMessage`, and is clean with the fix.
- [x] `go vet ./internal/rpc/` clean.

Fixes #746
