### PR TITLE
test: cover internal/cli replay/compare command logic

### DIFF
--- a/internal/cli/compare_test.go
+++ b/internal/cli/compare_test.go
@@ -1,0 +1,318 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+// feeSettingsHex returns a binary-codec-encoded FeeSettings entry as a hex
+// string. It is a convenient known-good blob for exercising the decode paths.
+func feeSettingsHex(t *testing.T) string {
+	t.Helper()
+	blob, err := state.SerializeFeeSettings(&state.FeeSettings{
+		XRPFeesMode:           true,
+		BaseFeeDrops:          10,
+		ReserveBaseDrops:      10_000_000,
+		ReserveIncrementDrops: 2_000_000,
+	})
+	if err != nil {
+		t.Fatalf("serializing fee settings: %v", err)
+	}
+	return hex.EncodeToString(blob)
+}
+
+func TestLoadStateFile_Formats(t *testing.T) {
+	dir := t.TempDir()
+
+	// 1. StateFile wrapper format with entries.
+	wrapped := filepath.Join(dir, "wrapped.json")
+	if err := os.WriteFile(wrapped, []byte(`{"ledger_index":100,"entries":[{"index":"AB","data":"CD"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := loadStateFile(wrapped)
+	if err != nil || len(entries) != 1 || entries[0].Index != "AB" {
+		t.Fatalf("wrapped format: entries=%v err=%v", entries, err)
+	}
+
+	// 2. Bare array of StateFileEntry.
+	bareArr := filepath.Join(dir, "bare.json")
+	if err := os.WriteFile(bareArr, []byte(`[{"index":"11","data_hex":"22"}]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err = loadStateFile(bareArr)
+	if err != nil || len(entries) != 1 || entries[0].DataHex != "22" {
+		t.Fatalf("bare array format: entries=%v err=%v", entries, err)
+	}
+
+	// 3. Map-fallback path: content that does not unmarshal cleanly into
+	// []StateFileEntry (here `decoded` is a string, not an object) falls back to
+	// generic-map parsing, which keeps only entries carrying a non-empty index.
+	mapArr := filepath.Join(dir, "maps.json")
+	content := `[{"index":"33","data":"44","decoded":"not-an-object"},{"index":"","data":"noindex"}]`
+	if err := os.WriteFile(mapArr, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err = loadStateFile(mapArr)
+	if err != nil {
+		t.Fatalf("map array format: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Index != "33" || entries[0].Data != "44" {
+		t.Fatalf("map array format: unexpected entries %+v", entries)
+	}
+
+	// 4. Missing file → error.
+	if _, err := loadStateFile(filepath.Join(dir, "nope.json")); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+
+	// 5. Unrecognized content → error.
+	junk := filepath.Join(dir, "junk.json")
+	if err := os.WriteFile(junk, []byte(`"just a string"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadStateFile(junk); err == nil {
+		t.Fatal("expected unrecognized-format error")
+	}
+}
+
+func TestDecodeStateData(t *testing.T) {
+	if got := decodeStateData(feeSettingsHex(t)); got == nil || got["LedgerEntryType"] != "FeeSettings" {
+		t.Fatalf("expected FeeSettings decode, got %v", got)
+	}
+	if got := decodeStateData("nothex!!"); got != nil {
+		t.Fatalf("expected nil for invalid hex, got %v", got)
+	}
+}
+
+func TestBuildStateMap(t *testing.T) {
+	feeHex := feeSettingsHex(t)
+	entries := []StateFileEntry{
+		// data present → decoded lazily from the codec.
+		{Index: "AA", Data: feeHex},
+		// only data_hex present → falls back to DataHex.
+		{Index: "BB", DataHex: feeHex},
+		// pre-decoded → used as-is, codec not invoked.
+		{Index: "CC", Decoded: map[string]interface{}{"LedgerEntryType": "AccountRoot"}},
+		// nothing decodable.
+		{Index: "DD"},
+	}
+	m := buildStateMap(entries)
+	if len(m) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(m))
+	}
+	if m["aa"].Decoded["LedgerEntryType"] != "FeeSettings" {
+		t.Errorf("aa not decoded from Data: %+v", m["aa"])
+	}
+	if m["bb"].DataHex != feeHex || m["bb"].Decoded == nil {
+		t.Errorf("bb not decoded from DataHex: %+v", m["bb"])
+	}
+	if m["cc"].Decoded["LedgerEntryType"] != "AccountRoot" {
+		t.Errorf("cc pre-decoded value lost: %+v", m["cc"])
+	}
+	if m["dd"].Decoded != nil {
+		t.Errorf("dd should have no decoded data: %+v", m["dd"])
+	}
+}
+
+func TestCompareStates(t *testing.T) {
+	map1 := map[string]stateEntry{
+		"aa": {Index: "AA", DataHex: "1111", Decoded: map[string]interface{}{"LedgerEntryType": "AccountRoot", "Balance": "1"}},
+		"bb": {Index: "BB", DataHex: "2222", Decoded: map[string]interface{}{"Balance": "1", "Flags": "0"}},
+		"cc": {Index: "CC", DataHex: "3333"},
+	}
+	map2 := map[string]stateEntry{
+		"aa": {Index: "AA", DataHex: "1111", Decoded: map[string]interface{}{"LedgerEntryType": "AccountRoot", "Balance": "1"}},
+		"bb": {Index: "BB", DataHex: "22FF", Decoded: map[string]interface{}{"Balance": "2", "Flags": "0"}},
+		"dd": {Index: "DD", DataHex: "4444"},
+	}
+
+	added, removed, modified, unchanged := compareStates(map1, map2)
+	if len(added) != 1 || added[0].Index != "DD" {
+		t.Errorf("added = %+v", added)
+	}
+	if len(removed) != 1 || removed[0].Index != "CC" {
+		t.Errorf("removed = %+v", removed)
+	}
+	if len(unchanged) != 1 || unchanged[0].Index != "AA" {
+		t.Errorf("unchanged = %+v", unchanged)
+	}
+	if len(modified) != 1 || modified[0].Index != "BB" {
+		t.Fatalf("modified = %+v", modified)
+	}
+	if len(modified[0].ChangedKeys) != 1 || modified[0].ChangedKeys[0] != "Balance" {
+		t.Errorf("changed keys = %v", modified[0].ChangedKeys)
+	}
+}
+
+func TestFindChangedKeys(t *testing.T) {
+	if got := findChangedKeys(nil, map[string]interface{}{"a": 1}); got != nil {
+		t.Errorf("nil old should yield nil, got %v", got)
+	}
+	if got := findChangedKeys(map[string]interface{}{"a": 1}, nil); got != nil {
+		t.Errorf("nil new should yield nil, got %v", got)
+	}
+	old := map[string]interface{}{"same": 1, "changed": 1, "removed": 1}
+	new := map[string]interface{}{"same": 1, "changed": 2, "added": 1}
+	got := findChangedKeys(old, new)
+	want := []string{"added", "changed", "removed"} // sorted
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	}
+}
+
+func TestFilterByType(t *testing.T) {
+	entries := []stateEntry{
+		{Index: "A", Decoded: map[string]interface{}{"LedgerEntryType": "AccountRoot"}},
+		{Index: "B", Decoded: map[string]interface{}{"LedgerEntryType": "Offer"}},
+		{Index: "C", Decoded: nil},
+	}
+	got := filterByType(entries, "accountroot") // case-insensitive
+	if len(got) != 1 || got[0].Index != "A" {
+		t.Fatalf("filterByType = %+v", got)
+	}
+
+	mods := []modifiedEntry{
+		{Index: "A", NewDecoded: map[string]interface{}{"LedgerEntryType": "Offer"}},
+		{Index: "B", NewDecoded: map[string]interface{}{"LedgerEntryType": "AccountRoot"}},
+		{Index: "C", NewDecoded: nil},
+	}
+	gotMod := filterModifiedByType(mods, "Offer")
+	if len(gotMod) != 1 || gotMod[0].Index != "A" {
+		t.Fatalf("filterModifiedByType = %+v", gotMod)
+	}
+}
+
+func TestFormatValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   interface{}
+		want string
+	}{
+		{"iou with issuer", map[string]interface{}{"currency": "USD", "value": "100", "issuer": "rIssuerAccount"}, "100 USD (rIssuerA...)"},
+		{"iou no issuer", map[string]interface{}{"currency": "USD", "value": "100"}, "100 USD"},
+		{"array", []interface{}{1, 2, 3}, "[3 items]"},
+		{"scalar", uint32(42), "42"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatValue(tc.in); got != tc.want {
+				t.Errorf("formatValue(%v) = %q want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	// A map that is not an Amount falls back to JSON marshalling.
+	if got := formatValue(map[string]interface{}{"x": "y"}); got != `{"x":"y"}` {
+		t.Errorf("non-amount map = %q", got)
+	}
+}
+
+func TestPrintFunctions(t *testing.T) {
+	restore := silenceStdout(t)
+	defer restore()
+
+	idx := "00000000000000000000000000000000000000000000000000000000000000FF"
+	added := []stateEntry{{Index: idx, Decoded: map[string]interface{}{
+		"LedgerEntryType": "AccountRoot", "Account": "rAcct", "Balance": "1", "Sequence": uint32(1), "OwnerCount": uint32(0), "Flags": uint32(0),
+	}}}
+	removed := []stateEntry{{Index: idx, Decoded: nil}} // exercises the "unable to decode" branch
+	modified := []modifiedEntry{{
+		Index:       idx,
+		OldDecoded:  map[string]interface{}{"LedgerEntryType": "RippleState", "Balance": "1"},
+		NewDecoded:  map[string]interface{}{"LedgerEntryType": "RippleState", "Balance": "2"},
+		ChangedKeys: []string{"Balance"},
+	}}
+	unchanged := []stateEntry{{Index: idx, Decoded: map[string]interface{}{"LedgerEntryType": "Offer"}}}
+
+	// compareShowAll/compareShowDecoded influence the print depth; restore after.
+	prevAll, prevDecoded := compareShowAll, compareShowDecoded
+	defer func() { compareShowAll, compareShowDecoded = prevAll, prevDecoded }()
+	compareShowAll, compareShowDecoded = true, true
+
+	printAddedEntries(added)
+	printRemovedEntries(removed)
+	printModifiedEntries(modified)
+	printUnchangedEntries(unchanged)
+
+	// Exercise printKeyFields for each well-known entry type.
+	for _, d := range []map[string]interface{}{
+		{"LedgerEntryType": "AccountRoot", "Account": "rA", "Balance": "1", "Sequence": uint32(1), "OwnerCount": uint32(0), "Flags": uint32(0)},
+		{"LedgerEntryType": "RippleState", "Balance": map[string]interface{}{"currency": "USD", "value": "1", "issuer": "rIssuerAcct"}, "LowLimit": "0", "HighLimit": "0", "Flags": uint32(0)},
+		{"LedgerEntryType": "Offer", "Account": "rA", "TakerGets": "1", "TakerPays": "2", "Sequence": uint32(1)},
+		{"LedgerEntryType": "DirectoryNode", "Owner": "rA", "RootIndex": "X"},
+		{"LedgerEntryType": "FeeSettings", "BaseFeeDrops": "10", "ReserveBaseDrops": "1", "ReserveIncrementDrops": "1"},
+		{"LedgerEntryType": "Amendments", "Amendments": []interface{}{"a", "b"}},
+		{"LedgerEntryType": "SomethingUnknown", "FieldOne": "v", "FieldTwo": uint32(3)},
+	} {
+		printEntryDetails(d)
+	}
+}
+
+func TestWriteDiffJSON(t *testing.T) {
+	restore := silenceStdout(t)
+	defer restore()
+
+	out := filepath.Join(t.TempDir(), "diff.json")
+	added := []stateEntry{{Index: "A", Decoded: map[string]interface{}{"k": "v"}}}
+	removed := []stateEntry{{Index: "B"}}
+	modified := []modifiedEntry{{Index: "C", ChangedKeys: []string{"Balance"}, OldDecoded: map[string]interface{}{"Balance": "1"}, NewDecoded: map[string]interface{}{"Balance": "2"}}}
+
+	writeDiffJSON(out, added, removed, modified)
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading diff: %v", err)
+	}
+	var parsed struct {
+		Added    []map[string]interface{} `json:"added"`
+		Removed  []map[string]interface{} `json:"removed"`
+		Modified []map[string]interface{} `json:"modified"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshalling diff: %v", err)
+	}
+	if len(parsed.Added) != 1 || len(parsed.Removed) != 1 || len(parsed.Modified) != 1 {
+		t.Fatalf("unexpected diff contents: %+v", parsed)
+	}
+	if parsed.Modified[0]["index"] != "C" {
+		t.Errorf("modified index = %v", parsed.Modified[0]["index"])
+	}
+}
+
+func TestRunCompare_IdenticalFiles(t *testing.T) {
+	restore := silenceStdout(t)
+	defer restore()
+
+	// Reset the command flags to defaults so a prior test cannot trigger the
+	// os.Exit(1) diff path or a stray file write.
+	prevAll, prevDecoded, prevFilter, prevOut := compareShowAll, compareShowDecoded, compareFilterType, compareOutputFormat
+	defer func() {
+		compareShowAll, compareShowDecoded, compareFilterType, compareOutputFormat = prevAll, prevDecoded, prevFilter, prevOut
+	}()
+	compareShowAll, compareShowDecoded, compareFilterType, compareOutputFormat = false, true, "", ""
+
+	dir := t.TempDir()
+	content := []byte(`{"entries":[{"index":"00000000000000000000000000000000000000000000000000000000000000FF","data":"` + feeSettingsHex(t) + `"}]}`)
+	f1 := filepath.Join(dir, "a.json")
+	f2 := filepath.Join(dir, "b.json")
+	if err := os.WriteFile(f1, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f2, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Identical files produce no differences, so runCompare returns normally
+	// (it only calls os.Exit when added/removed/modified is non-empty).
+	runCompare(nil, []string{f1, f2})
+}

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateConfigContent(t *testing.T) {
+	cases := []struct {
+		network string
+		wantIPs string // a substring expected only in that network's ips block
+	}{
+		{"main", "r.ripple.com 51235"},
+		{"testnet", "r.altnet.rippletest.net 51235"},
+		{"devnet", "ips = []"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.network, func(t *testing.T) {
+			content := generateConfigContent(tc.network)
+			if !strings.Contains(content, tc.wantIPs) {
+				t.Errorf("missing ips marker %q for %s", tc.wantIPs, tc.network)
+			}
+			if !strings.Contains(content, `network_id = "`+tc.network+`"`) {
+				t.Errorf("missing network_id for %s", tc.network)
+			}
+			// A few required structural sections every generated file must carry.
+			for _, section := range []string{"[logging]", "[server]", "[node_db]", "[transaction_queue]"} {
+				if !strings.Contains(content, section) {
+					t.Errorf("%s: generated config missing section %s", tc.network, section)
+				}
+			}
+		})
+	}
+}
+
+func TestRunGenerateConfig(t *testing.T) {
+	restore := silenceStdout(t)
+	defer restore()
+
+	prevNet, prevOut := generateNetwork, generateOutput
+	defer func() { generateNetwork, generateOutput = prevNet, prevOut }()
+
+	out := filepath.Join(t.TempDir(), "xrpld.toml")
+	generateNetwork = "testnet"
+	generateOutput = out
+
+	// Valid network: writes the file and returns without exiting.
+	runGenerateConfig(nil, nil)
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	if string(data) != generateConfigContent("testnet") {
+		t.Error("written config does not match generateConfigContent output")
+	}
+}

--- a/internal/cli/replay.go
+++ b/internal/cli/replay.go
@@ -904,9 +904,13 @@ func updateSkipList(l *ledger.Ledger, parentHash [32]byte, currentSeq uint32) er
 // If rolling is true, it removes the oldest hash when at 256 hashes (rolling window).
 // If rolling is false, it just appends (for the every-256th ledger skip list).
 func updateOrCreateSkipListEntry(l *ledger.Ledger, k keylet.Keylet, parentHash [32]byte, prevIndex uint32, rolling bool) error {
-	// Read the existing entry
+	// Read the existing entry. Ledger.Read reports an absent key as (nil, nil),
+	// so a missing entry is detected by data == nil — not by a non-nil error.
 	data, err := l.Read(k)
 	if err != nil {
+		return fmt.Errorf("reading LedgerHashes: %w", err)
+	}
+	if data == nil {
 		// Entry doesn't exist - create a new one
 		return createSkipListEntry(l, k, parentHash, prevIndex)
 	}

--- a/internal/cli/replay_helpers_test.go
+++ b/internal/cli/replay_helpers_test.go
@@ -1,0 +1,279 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// feeSettingsIndexHex is keylet::fees() — the singleton FeeSettings key the
+// replay fee extractors look the entry up by.
+const feeSettingsIndexHex = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A651"
+
+func TestParseHexOrDecimal(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint64
+		ok   bool
+	}{
+		{"255", 255, true},
+		{"0x1F", 31, true},
+		{"0", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := parseHexOrDecimal(tc.in)
+		if (err == nil) != tc.ok || got != tc.want {
+			t.Errorf("parseHexOrDecimal(%q) = (%d,%v) want (%d,ok=%v)", tc.in, got, err, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestParseDrops(t *testing.T) {
+	if got, err := parseDrops("12345"); err != nil || got != 12345 {
+		t.Errorf("parseDrops(12345) = (%d,%v)", got, err)
+	}
+	if _, err := parseDrops("not-a-number"); err == nil {
+		t.Error("expected error for non-numeric drops")
+	}
+}
+
+func TestHexToHash32(t *testing.T) {
+	good := "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF"
+	h, err := hexToHash32(good)
+	if err != nil {
+		t.Fatalf("hexToHash32: %v", err)
+	}
+	if h[0] != 0x00 || h[1] != 0x11 || h[31] != 0xFF {
+		t.Errorf("unexpected hash bytes: %x", h)
+	}
+	if _, err := hexToHash32("00"); err == nil {
+		t.Error("expected length error for short hex")
+	}
+	if _, err := hexToHash32("zz"); err == nil {
+		t.Error("expected decode error for non-hex")
+	}
+}
+
+func TestStatusEmoji(t *testing.T) {
+	if statusEmoji(true) != "[OK]" {
+		t.Error("statusEmoji(true)")
+	}
+	if statusEmoji(false) != "[MISMATCH]" {
+		t.Error("statusEmoji(false)")
+	}
+}
+
+func TestDecodeEntryData(t *testing.T) {
+	blob, err := state.SerializeFeeSettings(&state.FeeSettings{XRPFeesMode: true, BaseFeeDrops: 10, ReserveBaseDrops: 1, ReserveIncrementDrops: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := decodeEntryData(hex.EncodeToString(blob)); got == nil || got["LedgerEntryType"] != "FeeSettings" {
+		t.Errorf("decodeEntryData = %v", got)
+	}
+	if got := decodeEntryData("zzzz"); got != nil {
+		t.Errorf("invalid hex should decode to nil, got %v", got)
+	}
+}
+
+func TestBuildRulesFromAmendments(t *testing.T) {
+	// Empty list → no amendments enabled.
+	empty := buildRulesFromAmendments(nil)
+	if empty.Enabled(amendment.FeatureID("Flow")) {
+		t.Error("empty rules should enable nothing")
+	}
+
+	// By name.
+	flowID := amendment.FeatureID("Flow")
+	byName := buildRulesFromAmendments([]string{"Flow"})
+	if !byName.Enabled(flowID) {
+		t.Error("Flow should be enabled by name")
+	}
+
+	// By 64-char hex id, plus an unknown name that must be ignored without error.
+	idHex := hex.EncodeToString(flowID[:])
+	byID := buildRulesFromAmendments([]string{idHex, "NotARealAmendmentName"})
+	if !byID.Enabled(flowID) {
+		t.Error("Flow should be enabled by hex id")
+	}
+}
+
+func TestWriteResultJSON(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "result.json")
+	res := &ReplayResult{
+		Success:         true,
+		LedgerHash:      [32]byte{0xDE, 0xAD},
+		AccountHash:     [32]byte{0xBE, 0xEF},
+		TransactionHash: [32]byte{0xCA, 0xFE},
+		TotalCoins:      99,
+		PreStateCount:   3,
+		PostStateCount:  4,
+		Duration:        5 * time.Millisecond,
+		Errors:          []string{},
+		TxResults:       []TxApplyInfo{{Index: 0, Hash: "abc"}},
+	}
+	if err := writeResultJSON(out, res); err != nil {
+		t.Fatalf("writeResultJSON: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("result not valid JSON: %v", err)
+	}
+	if parsed["success"] != true {
+		t.Errorf("success = %v", parsed["success"])
+	}
+	if parsed["transaction_count"].(float64) != 1 {
+		t.Errorf("transaction_count = %v", parsed["transaction_count"])
+	}
+	if parsed["ledger_hash"].(string)[:4] != "dead" {
+		t.Errorf("ledger_hash = %v", parsed["ledger_hash"])
+	}
+}
+
+func TestExtractFeesFromState(t *testing.T) {
+	// No FeeSettings entry → defaults.
+	def := extractFeesFromState(nil)
+	if def.Base != 10 || def.Reserve != 10_000_000 || def.Increment != 2_000_000 {
+		t.Errorf("default fees = %+v", def)
+	}
+
+	// Modern XRPFees entry stored at the fees keylet → read back exactly.
+	blob, err := state.SerializeFeeSettings(&state.FeeSettings{
+		XRPFeesMode:           true,
+		BaseFeeDrops:          15,
+		ReserveBaseDrops:      5_000_000,
+		ReserveIncrementDrops: 1_000_000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries := []StateEntry{{Index: feeSettingsIndexHex, Data: hex.EncodeToString(blob)}}
+	fees := extractFeesFromState(entries)
+	if fees.Base != 15 || fees.Reserve != 5_000_000 || fees.Increment != 1_000_000 {
+		t.Errorf("modern fees = %+v", fees)
+	}
+}
+
+func TestLoadJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "obj.json")
+	if err := os.WriteFile(path, []byte(`{"ledger_index":42,"account_hash":"ABCD"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var sf StateFixture
+	if err := loadJSON(path, &sf); err != nil {
+		t.Fatalf("loadJSON: %v", err)
+	}
+	if sf.LedgerIndex != 42 || sf.AccountHash != "ABCD" {
+		t.Errorf("loaded fixture = %+v", sf)
+	}
+	if err := loadJSON(filepath.Join(dir, "missing.json"), &sf); err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestLoadFixtures(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"state.json":    `{"ledger_index":100,"account_hash":"AA","entries":[]}`,
+		"env.json":      `{"ledger_index":100,"parent_hash":"BB","total_coins":"100"}`,
+		"txs.json":      `{"transactions":[]}`,
+		"expected.json": `{"ledger_index":100,"ledger_hash":"CC"}`,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stateFx, env, txs, expected, err := loadFixtures(dir)
+	if err != nil {
+		t.Fatalf("loadFixtures: %v", err)
+	}
+	if stateFx.LedgerIndex != 100 || env.ParentHash != "BB" || txs == nil || expected.LedgerHash != "CC" {
+		t.Errorf("unexpected fixtures: state=%+v env=%+v expected=%+v", stateFx, env, expected)
+	}
+
+	// Removing a required file surfaces an error rather than partial fixtures.
+	if err := os.Remove(filepath.Join(dir, "txs.json")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, _, err := loadFixtures(dir); err == nil {
+		t.Error("expected error when a fixture file is missing")
+	}
+}
+
+// newReplayTestLedger builds a minimal open ledger suitable for exercising the
+// skip-list mutators, mirroring replay.go's NewOpenWithHeader construction.
+func newReplayTestLedger(t *testing.T, seq uint32) *ledger.Ledger {
+	t.Helper()
+	stateMap, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatalf("state map: %v", err)
+	}
+	txMap, err := shamap.New(shamap.TypeTransaction)
+	if err != nil {
+		t.Fatalf("tx map: %v", err)
+	}
+	hdr := header.LedgerHeader{
+		LedgerIndex: seq,
+		CloseTime:   time.Unix(0, 0).UTC(),
+	}
+	fees := drops.Fees{Base: 10, Reserve: 10_000_000, Increment: 2_000_000}
+	return ledger.NewOpenWithHeader(hdr, stateMap, txMap, fees)
+}
+
+func TestUpdateSkipList(t *testing.T) {
+	l := newReplayTestLedger(t, 2)
+
+	// Genesis (seq 0) has no parent: a complete no-op.
+	if err := updateSkipList(l, [32]byte{0x01}, 0); err != nil {
+		t.Fatalf("genesis skip list: %v", err)
+	}
+
+	// seq 1: prevIndex 0 is a multiple of 256, so BOTH the every-256th and the
+	// rolling skip lists are created.
+	if err := updateSkipList(l, [32]byte{0xAA}, 1); err != nil {
+		t.Fatalf("seq 1 skip list: %v", err)
+	}
+	// seq 2: prevIndex 1 only touches the rolling list, exercising the
+	// read-decode-append-update path of updateOrCreateSkipListEntry.
+	if err := updateSkipList(l, [32]byte{0xBB}, 2); err != nil {
+		t.Fatalf("seq 2 skip list: %v", err)
+	}
+
+	// The rolling LedgerHashes entry must now record two parent hashes.
+	data, err := l.Read(keylet.LedgerHashes())
+	if err != nil {
+		t.Fatalf("reading rolling skip list: %v", err)
+	}
+	decoded, err := binarycodec.Decode(hex.EncodeToString(data))
+	if err != nil {
+		t.Fatalf("decoding rolling skip list: %v", err)
+	}
+	hashes, ok := decoded["Hashes"].([]string)
+	if !ok {
+		t.Fatalf("Hashes is %T, want []string", decoded["Hashes"])
+	}
+	if len(hashes) != 2 {
+		t.Fatalf("rolling skip list has %d hashes, want 2", len(hashes))
+	}
+	if decoded["LastLedgerSequence"].(uint32) != 1 {
+		t.Errorf("LastLedgerSequence = %v, want 1", decoded["LastLedgerSequence"])
+	}
+}

--- a/internal/cli/replay_range_helpers_test.go
+++ b/internal/cli/replay_range_helpers_test.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"encoding/hex"
+	"path/filepath"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+func TestDefaultFees(t *testing.T) {
+	f := defaultFees()
+	if f.Base != 10 || f.Reserve != 10_000_000 || f.Increment != 2_000_000 {
+		t.Errorf("defaultFees = %+v", f)
+	}
+}
+
+func feeIndexKey(t *testing.T) [32]byte {
+	t.Helper()
+	b, err := hex.DecodeString(feeSettingsIndexHex)
+	if err != nil || len(b) != 32 {
+		t.Fatalf("decoding fee index: %v", err)
+	}
+	var key [32]byte
+	copy(key[:], b)
+	return key
+}
+
+func TestExtractFeesFromSHAMap_Default(t *testing.T) {
+	sm, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No FeeSettings entry → defaults.
+	f := ExtractFeesFromSHAMap(sm)
+	if f != defaultFees() {
+		t.Errorf("ExtractFeesFromSHAMap (empty) = %+v want defaults", f)
+	}
+}
+
+func TestExtractFeesFromSHAMap_Modern(t *testing.T) {
+	sm, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := state.SerializeFeeSettings(&state.FeeSettings{
+		XRPFeesMode:           true,
+		BaseFeeDrops:          20,
+		ReserveBaseDrops:      7_500_000,
+		ReserveIncrementDrops: 1_500_000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sm.Put(feeIndexKey(t), blob); err != nil {
+		t.Fatalf("seeding fee settings: %v", err)
+	}
+	f := ExtractFeesFromSHAMap(sm)
+	if f.Base != 20 || f.Reserve != 7_500_000 || f.Increment != 1_500_000 {
+		t.Errorf("ExtractFeesFromSHAMap (modern) = %+v", f)
+	}
+}
+
+func TestFindingsPath(t *testing.T) {
+	prevOut, prevDump := replayRangeFindingsOut, replayRangeDumpDir
+	defer func() { replayRangeFindingsOut, replayRangeDumpDir = prevOut, prevDump }()
+
+	// Explicit --findings-out wins verbatim.
+	explicit := filepath.Join(t.TempDir(), "custom.jsonl")
+	replayRangeFindingsOut = explicit
+	if got := findingsPath(); got != explicit {
+		t.Errorf("explicit findings path = %q want %q", got, explicit)
+	}
+
+	// Otherwise it falls back to <dump-dir>/findings.jsonl, creating the dir.
+	dumpDir := filepath.Join(t.TempDir(), "debug")
+	replayRangeFindingsOut = ""
+	replayRangeDumpDir = dumpDir
+	want := filepath.Join(dumpDir, "findings.jsonl")
+	if got := findingsPath(); got != want {
+		t.Errorf("derived findings path = %q want %q", got, want)
+	}
+}

--- a/internal/cli/rpc_test.go
+++ b/internal/cli/rpc_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInitMethodRegistry_Idempotent(t *testing.T) {
+	r1 := initMethodRegistry()
+	if r1 == nil {
+		t.Fatal("registry is nil")
+	}
+	// The CLI shares handlers.RegisterAll with the servers, so a core method
+	// must be present.
+	if _, ok := r1.Get("ping"); !ok {
+		t.Error("ping not registered")
+	}
+	// Memoized: a second call returns the same instance.
+	if r2 := initMethodRegistry(); r2 != r1 {
+		t.Error("initMethodRegistry should memoize the registry")
+	}
+}
+
+func TestExecuteMethod_UnknownMethod(t *testing.T) {
+	err := executeMethod("definitely_not_a_method", nil)
+	if err == nil || !strings.Contains(err.Error(), "unknown method") {
+		t.Fatalf("expected unknown-method error, got %v", err)
+	}
+}
+
+func TestExecuteMethod_Ping(t *testing.T) {
+	restore := silenceStdout(t)
+	defer restore()
+
+	// ping is fully self-contained (no ledger/services), so it exercises the
+	// success path of executeMethod end to end.
+	if err := executeMethod("ping", nil); err != nil {
+		t.Fatalf("ping without params: %v", err)
+	}
+	if err := executeMethod("ping", map[string]interface{}{"unused": true}); err != nil {
+		t.Fatalf("ping with params: %v", err)
+	}
+}

--- a/internal/cli/server_helpers_test.go
+++ b/internal/cli/server_helpers_test.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/cleaner"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	"github.com/LeJamon/go-xrpl/internal/rpc"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+func TestConsensusPhaseName(t *testing.T) {
+	cases := []struct {
+		phase consensus.Phase
+		want  string
+	}{
+		{consensus.PhaseOpen, rpc.ConsensusPhaseOpen},
+		{consensus.PhaseEstablish, rpc.ConsensusPhaseEstablish},
+		{consensus.PhaseAccepted, rpc.ConsensusPhaseAccepted},
+	}
+	for _, tc := range cases {
+		if got := consensusPhaseName(tc.phase); got != tc.want {
+			t.Errorf("consensusPhaseName(%v) = %q want %q", tc.phase, got, tc.want)
+		}
+	}
+	// An out-of-range phase falls through to Phase.String().
+	if got := consensusPhaseName(consensus.Phase(99)); got == "" {
+		t.Error("default phase name should be non-empty")
+	}
+}
+
+func TestCurrencySpecFromAmount(t *testing.T) {
+	// A string amount is XRP.
+	if got := currencySpecFromAmount("1000000"); got.Currency != "XRP" || got.Issuer != "" {
+		t.Errorf("string amount = %+v, want XRP", got)
+	}
+	// An object amount carries currency + issuer.
+	iou := map[string]interface{}{"currency": "USD", "issuer": "rIssuer", "value": "10"}
+	if got := currencySpecFromAmount(iou); got.Currency != "USD" || got.Issuer != "rIssuer" {
+		t.Errorf("iou amount = %+v", got)
+	}
+	// Anything else is empty.
+	if got := currencySpecFromAmount(nil); got.Currency != "" || got.Issuer != "" {
+		t.Errorf("nil amount = %+v, want empty", got)
+	}
+}
+
+func TestParseVLLength(t *testing.T) {
+	cases := []struct {
+		name     string
+		data     []byte
+		wantLen  int
+		wantPfix int
+	}{
+		{"empty", nil, 0, 0},
+		{"single byte", []byte{100}, 100, 1},
+		{"boundary 192", []byte{192}, 192, 1},
+		{"two byte", []byte{193, 0}, 193, 2},
+		{"two byte truncated", []byte{200}, 0, 0},
+		{"three byte", []byte{241, 0, 0}, 12481, 3},
+		{"three byte truncated", []byte{250, 0}, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLen, gotPfix := parseVLLength(tc.data)
+			if gotLen != tc.wantLen || gotPfix != tc.wantPfix {
+				t.Errorf("parseVLLength(%v) = (%d,%d) want (%d,%d)", tc.data, gotLen, gotPfix, tc.wantLen, tc.wantPfix)
+			}
+		})
+	}
+}
+
+func TestMetaTransactionResult(t *testing.T) {
+	if got := metaTransactionResult(nil); got != "tesSUCCESS" {
+		t.Errorf("nil meta = %q, want default tesSUCCESS", got)
+	}
+	if got := metaTransactionResult(json.RawMessage(`{"TransactionResult":"tecUNFUNDED"}`)); got != "tecUNFUNDED" {
+		t.Errorf("explicit result = %q", got)
+	}
+	if got := metaTransactionResult(json.RawMessage(`{"Other":1}`)); got != "tesSUCCESS" {
+		t.Errorf("missing field = %q, want default", got)
+	}
+	if got := metaTransactionResult(json.RawMessage(`not json`)); got != "tesSUCCESS" {
+		t.Errorf("invalid json = %q, want default", got)
+	}
+}
+
+func TestDecodeTxWithMetaToJSON(t *testing.T) {
+	// Empty input yields empty JSON objects.
+	txJSON, metaJSON := decodeTxWithMetaToJSON(nil)
+	if string(txJSON) != "{}" || string(metaJSON) != "{}" {
+		t.Fatalf("empty input = (%s,%s)", txJSON, metaJSON)
+	}
+
+	blob, err := hex.DecodeString(feeSettingsHex(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blob) > 192 {
+		t.Fatalf("blob too long for single-byte VL framing: %d", len(blob))
+	}
+
+	// Tx field only (single-byte VL prefix == length).
+	data := append([]byte{byte(len(blob))}, blob...)
+	txJSON, metaJSON = decodeTxWithMetaToJSON(data)
+	if !strings.Contains(string(txJSON), "FeeSettings") {
+		t.Errorf("tx not decoded: %s", txJSON)
+	}
+	if string(metaJSON) != "{}" {
+		t.Errorf("expected empty meta, got %s", metaJSON)
+	}
+
+	// Tx + meta fields.
+	withMeta := append(data, byte(len(blob)))
+	withMeta = append(withMeta, blob...)
+	txJSON, metaJSON = decodeTxWithMetaToJSON(withMeta)
+	if !strings.Contains(string(txJSON), "FeeSettings") || !strings.Contains(string(metaJSON), "FeeSettings") {
+		t.Errorf("tx+meta not decoded: tx=%s meta=%s", txJSON, metaJSON)
+	}
+}
+
+func TestExtractBookPairsFromTxData(t *testing.T) {
+	// No data → no pairs; a blob with no Offer-bearing metadata → no pairs.
+	if got := extractBookPairsFromTxData(nil); got != nil {
+		t.Errorf("nil data = %+v, want nil", got)
+	}
+	blob, _ := hex.DecodeString(feeSettingsHex(t))
+	data := append([]byte{byte(len(blob))}, blob...)
+	if got := extractBookPairsFromTxData(data); got != nil {
+		t.Errorf("non-offer meta = %+v, want nil", got)
+	}
+}
+
+func TestToCleanerStatus(t *testing.T) {
+	in := cleaner.Status{
+		State:          "running",
+		MinLedger:      10,
+		MaxLedger:      20,
+		CheckNodes:     true,
+		Failures:       2,
+		LedgersChecked: 5,
+		NodesChecked:   100,
+		MissingNodes:   1,
+		LastError:      "boom",
+	}
+	got := toCleanerStatus(in)
+	want := types.LedgerCleanerStatus{
+		State:          "running",
+		MinLedger:      10,
+		MaxLedger:      20,
+		CheckNodes:     true,
+		Failures:       2,
+		LedgersChecked: 5,
+		NodesChecked:   100,
+		MissingNodes:   1,
+		LastError:      "boom",
+	}
+	if got != want {
+		t.Errorf("toCleanerStatus = %+v want %+v", got, want)
+	}
+}
+
+func TestBuildProposedTxEvent_NoBlob(t *testing.T) {
+	ev := buildProposedTxEvent(service.SubmittedTxEvent{
+		CurrentLedger: 7,
+		Result:        service.Result{Code: 0, Name: "tesSUCCESS", Message: "The transaction was applied."},
+	})
+	if ev == nil {
+		t.Fatal("nil event")
+	}
+	if ev.EngineResult != "tesSUCCESS" || ev.LedgerCurrentIndex != 7 {
+		t.Errorf("unexpected event: %+v", ev)
+	}
+	if ev.Account != "" || string(ev.Transaction) != "{}" {
+		t.Errorf("no-blob event should carry empty account/tx: %+v", ev)
+	}
+}
+
+func TestBuildManifestEvent_Nil(t *testing.T) {
+	if ev := buildManifestEvent(nil); ev != nil {
+		t.Errorf("nil manifest should yield nil event, got %+v", ev)
+	}
+}
+
+func TestAcceptedLedgerView_Nil(t *testing.T) {
+	v := newAcceptedLedgerView(nil)
+	if v.Sequence() != 0 || v.Hash() != ([32]byte{}) || v.CloseTime() != 0 || v.IsValidated() {
+		t.Error("nil view should return zero values")
+	}
+	// ForEachTransaction must not panic and must visit nothing.
+	if err := v.ForEachTransaction(func([32]byte, []byte) bool { t.Fatal("callback ran on nil view"); return true }); err != nil {
+		t.Errorf("ForEachTransaction on nil view: %v", err)
+	}
+}
+
+func TestAcceptedLedgerView_Populated(t *testing.T) {
+	closeTime := time.Unix(protocol.RippleEpochUnix+1000, 0).UTC()
+	event := &service.LedgerAcceptedEvent{
+		LedgerInfo: &service.LedgerInfo{
+			Sequence:  42,
+			Hash:      [32]byte{0xAB},
+			CloseTime: closeTime,
+			Validated: true,
+		},
+		TransactionResults: []service.TransactionResultEvent{
+			{TxHash: [32]byte{0x01}, TxData: []byte{0xDE, 0xAD}},
+			{TxHash: [32]byte{0x02}, TxData: []byte{0xBE, 0xEF}},
+		},
+	}
+	v := newAcceptedLedgerView(event)
+	if v.Sequence() != 42 {
+		t.Errorf("Sequence = %d", v.Sequence())
+	}
+	if v.Hash() != ([32]byte{0xAB}) {
+		t.Errorf("Hash = %x", v.Hash())
+	}
+	if v.CloseTime() != 1000 {
+		t.Errorf("CloseTime = %d want 1000", v.CloseTime())
+	}
+	if !v.IsValidated() {
+		t.Error("IsValidated = false")
+	}
+
+	var visited int
+	if err := v.ForEachTransaction(func(h [32]byte, d []byte) bool { visited++; return true }); err != nil {
+		t.Fatalf("ForEachTransaction: %v", err)
+	}
+	if visited != 2 {
+		t.Errorf("visited %d transactions, want 2", visited)
+	}
+
+	// Returning false from the callback stops iteration early.
+	visited = 0
+	_ = v.ForEachTransaction(func(h [32]byte, d []byte) bool { visited++; return false })
+	if visited != 1 {
+		t.Errorf("early-stop visited %d, want 1", visited)
+	}
+}

--- a/internal/cli/testutil_test.go
+++ b/internal/cli/testutil_test.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+// silenceStdout redirects os.Stdout to a discarded pipe for the duration of a
+// test. CLI helpers print their results to os.Stdout via the fmt package; the
+// returned restore function reinstates the original stdout and must be deferred.
+func silenceStdout(t *testing.T) (restore func()) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, r)
+		close(done)
+	}()
+	return func() {
+		_ = w.Close()
+		<-done
+		_ = r.Close()
+		os.Stdout = orig
+	}
+}


### PR DESCRIPTION
## Summary

- Add unit tests for the **pure logic** in the `xrpld` CLI commands — `replay`, `replay-range`, `compare`, `generate-config`, `rpc`, plus the testable `server.go` seams — with no live node and no external services (PostgreSQL, peers, sockets).
- Covers: state-dump comparison/diff (`compare.go`), config generation (`generate.go`), RPC method dispatch (`rpc.go`), fixture/result (de)serialization, fee/amendment/skip-list helpers (`replay.go`), fee extraction & findings path (`replay_range.go`), and VL/meta decoding, currency/phase/cleaner mappers and the accepted-ledger view (`server.go`).
- Fix a latent bug in `updateOrCreateSkipListEntry` surfaced by the new skip-list test: `Ledger.Read` reports an absent key as `(nil, nil)`, but the create-if-missing branch was gated on `err != nil`, so a genuinely-missing `LedgerHashes` page (the real replay-range case at a 256-ledger boundary) never got created and `Update` failed with `ErrEntryNotFound`. Now it creates the page, matching the function's documented intent and rippled's `Ledger::updateSkipList`.

## Coverage

Measured per the issue's command (`-coverpkg=./...`, CGO on), aggregated for `internal/cli`:

| | covered / total | % |
|---|---|---|
| before | 249 / 2452 | 10.2% |
| after | 752 / 2454 | **30.6%** |

Per-file highlights (cross-package): `compare.go` ~2%→96%, `generate.go` 0%→91%, `rpc.go` 0.8%→95%, `replay.go`→63%, `server.go`→58%. `server.go`/`rpc.go` end-to-end startup remains integration-gated, as the issue scopes.

## Test plan
- [x] `go test ./internal/cli/` (CGO on) — all pass
- [x] `gofmt -l internal/cli/` — clean; `go vet ./internal/cli/` — clean
- [x] `go build ./cmd/xrpld` — builds
- [x] Coverage: `go test ./internal/cli/ -coverpkg=./... -coverprofile=cross.out && go tool cover -func=cross.out | grep internal/cli`

Fixes #748