### PR TITLE
test: cover internal/ledger/service account & NFT queries

### DIFF
--- a/internal/ledger/service/account_query.go
+++ b/internal/ledger/service/account_query.go
@@ -272,23 +272,23 @@ func (s *Service) GetAccountLines(ctx context.Context, account string, ledgerInd
 			line.Balance = rs.Balance.Negate().Value()
 			line.Limit = rs.LowLimit.Value()
 			line.LimitPeer = rs.HighLimit.Value()
-			line.NoRipple = (rs.Flags & 0x00020000) != 0       // lsfLowNoRipple
-			line.NoRipplePeer = (rs.Flags & 0x00040000) != 0   // lsfHighNoRipple
-			line.Authorized = (rs.Flags & 0x00010000) != 0     // lsfLowAuth
-			line.PeerAuthorized = (rs.Flags & 0x00080000) != 0 // lsfHighAuth
-			line.Freeze = (rs.Flags & 0x00400000) != 0         // lsfLowFreeze
-			line.FreezePeer = (rs.Flags & 0x00800000) != 0     // lsfHighFreeze
+			line.NoRipple = (rs.Flags & state.LsfLowNoRipple) != 0
+			line.NoRipplePeer = (rs.Flags & state.LsfHighNoRipple) != 0
+			line.Authorized = (rs.Flags & state.LsfLowAuth) != 0
+			line.PeerAuthorized = (rs.Flags & state.LsfHighAuth) != 0
+			line.Freeze = (rs.Flags & state.LsfLowFreeze) != 0
+			line.FreezePeer = (rs.Flags & state.LsfHighFreeze) != 0
 		} else {
 			// We are high account
 			line.Balance = rs.Balance.Value()
 			line.Limit = rs.HighLimit.Value()
 			line.LimitPeer = rs.LowLimit.Value()
-			line.NoRipple = (rs.Flags & 0x00040000) != 0       // lsfHighNoRipple
-			line.NoRipplePeer = (rs.Flags & 0x00020000) != 0   // lsfLowNoRipple
-			line.Authorized = (rs.Flags & 0x00080000) != 0     // lsfHighAuth
-			line.PeerAuthorized = (rs.Flags & 0x00010000) != 0 // lsfLowAuth
-			line.Freeze = (rs.Flags & 0x00800000) != 0         // lsfHighFreeze
-			line.FreezePeer = (rs.Flags & 0x00400000) != 0     // lsfLowFreeze
+			line.NoRipple = (rs.Flags & state.LsfHighNoRipple) != 0
+			line.NoRipplePeer = (rs.Flags & state.LsfLowNoRipple) != 0
+			line.Authorized = (rs.Flags & state.LsfHighAuth) != 0
+			line.PeerAuthorized = (rs.Flags & state.LsfLowAuth) != 0
+			line.Freeze = (rs.Flags & state.LsfHighFreeze) != 0
+			line.FreezePeer = (rs.Flags & state.LsfLowFreeze) != 0
 		}
 
 		line.QualityIn = rs.LowQualityIn

--- a/internal/ledger/service/account_query_more_test.go
+++ b/internal/ledger/service/account_query_more_test.go
@@ -1,0 +1,309 @@
+package service
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// lsfCredentialAccepted mirrors credential.LsfCredentialAccepted; duplicated
+// here to avoid importing the tx/credential package into the service tests.
+const lsfCredentialAccepted uint32 = 0x00010000
+
+// buildNFTokenID composes a 32-byte NFTokenID with the supplied flags, transfer
+// fee, issuer, (deciphered) taxon and serial, applying rippled's taxon cipher so
+// extractNFTInfo recovers the same taxon.
+func buildNFTokenID(flags, transferFee uint16, issuerID [20]byte, taxon, serial uint32) [32]byte {
+	var id [32]byte
+	binary.BigEndian.PutUint16(id[0:2], flags)
+	binary.BigEndian.PutUint16(id[2:4], transferFee)
+	copy(id[4:24], issuerID[:])
+	cipheredTaxon := taxon ^ ((serial ^ 384160001) * 2357503715)
+	binary.BigEndian.PutUint32(id[24:28], cipheredTaxon)
+	binary.BigEndian.PutUint32(id[28:32], serial)
+	return id
+}
+
+// insertNFTokenPageEntry inserts an NFTokenPage owned by the account holding the
+// given tokens. The page key carries the account ID in its first 20 bytes, which
+// is how GetAccountNFTs attributes the page.
+func insertNFTokenPageEntry(t *testing.T, svc *Service, ownerAddr string, tokens []state.NFTokenData) {
+	t.Helper()
+	_, ownerBytes, err := addresscodec.DecodeClassicAddressToAccountID(ownerAddr)
+	if err != nil {
+		t.Fatalf("decode owner: %v", err)
+	}
+	var ownerID [20]byte
+	copy(ownerID[:], ownerBytes)
+
+	nftArray := make([]any, 0, len(tokens))
+	for _, tok := range tokens {
+		nftArray = append(nftArray, map[string]any{
+			"NFToken": map[string]any{
+				"NFTokenID": strings.ToUpper(hex.EncodeToString(tok.NFTokenID[:])),
+				"URI":       tok.URI,
+			},
+		})
+	}
+	jsonObj := map[string]any{
+		"LedgerEntryType": "NFTokenPage",
+		"NFTokens":        nftArray,
+	}
+	data, err := binarycodec.EncodeBytes(jsonObj)
+	if err != nil {
+		t.Fatalf("encode NFTokenPage: %v", err)
+	}
+	if err := svc.openLedger.Insert(keylet.NFTokenPageMax(ownerID), data); err != nil {
+		t.Fatalf("insert NFTokenPage: %v", err)
+	}
+}
+
+func TestGetAccountNFTs_DecodesTokenFields(t *testing.T) {
+	svc := newOfferTestService(t)
+	ownerAddr, _ := addressFromBytes(t, 0x20)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+
+	issuerAddr, issuerID := addressFromBytes(t, 0x40)
+	const (
+		flags       = uint16(0x0001)
+		transferFee = uint16(314)
+		taxon       = uint32(98765)
+		serial      = uint32(7)
+	)
+	tokenID := buildNFTokenID(flags, transferFee, issuerID, taxon, serial)
+	uriHex := hex.EncodeToString([]byte("ipfs://test"))
+
+	insertNFTokenPageEntry(t, svc, ownerAddr, []state.NFTokenData{
+		{NFTokenID: tokenID, URI: uriHex},
+	})
+
+	res, err := svc.GetAccountNFTs(context.Background(), ownerAddr, "current", 0)
+	if err != nil {
+		t.Fatalf("GetAccountNFTs: %v", err)
+	}
+	if len(res.AccountNFTs) != 1 {
+		t.Fatalf("expected 1 NFT, got %d", len(res.AccountNFTs))
+	}
+	nft := res.AccountNFTs[0]
+	if nft.Flags != flags {
+		t.Errorf("flags = %d, want %d", nft.Flags, flags)
+	}
+	if nft.TransferFee != transferFee {
+		t.Errorf("transfer_fee = %d, want %d", nft.TransferFee, transferFee)
+	}
+	if nft.NFTokenTaxon != taxon {
+		t.Errorf("taxon = %d, want %d (cipher round-trip)", nft.NFTokenTaxon, taxon)
+	}
+	if nft.NFTSerial != serial {
+		t.Errorf("serial = %d, want %d", nft.NFTSerial, serial)
+	}
+	if nft.Issuer != issuerAddr {
+		t.Errorf("issuer = %s, want %s", nft.Issuer, issuerAddr)
+	}
+	if nft.NFTokenID != strings.ToUpper(hex.EncodeToString(tokenID[:])) {
+		t.Errorf("NFTokenID = %s, want hex of tokenID", nft.NFTokenID)
+	}
+
+	t.Run("account not found", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x99)
+		_, err := svc.GetAccountNFTs(context.Background(), stranger, "current", 0)
+		if !errors.Is(err, svcerr.ErrAccountNotFound) {
+			t.Fatalf("want ErrAccountNotFound, got %v", err)
+		}
+	})
+}
+
+// insertCredentialEntry inserts a Credential ledger entry and returns its key.
+// The hex of that key is the credential ID a client passes to deposit_authorized.
+func insertCredentialEntry(t *testing.T, svc *Service, subjectID, issuerID [20]byte, credType []byte, accepted bool, expiration *uint32) [32]byte {
+	t.Helper()
+	subjectAddr, err := addresscodec.EncodeAccountIDToClassicAddress(subjectID[:])
+	if err != nil {
+		t.Fatalf("encode subject: %v", err)
+	}
+	issuerAddr, err := addresscodec.EncodeAccountIDToClassicAddress(issuerID[:])
+	if err != nil {
+		t.Fatalf("encode issuer: %v", err)
+	}
+	jsonObj := map[string]any{
+		"LedgerEntryType": "Credential",
+		"Subject":         subjectAddr,
+		"Issuer":          issuerAddr,
+		"CredentialType":  hex.EncodeToString(credType),
+		"IssuerNode":      "0",
+		"SubjectNode":     "0",
+	}
+	if accepted {
+		jsonObj["Flags"] = lsfCredentialAccepted
+	}
+	if expiration != nil {
+		jsonObj["Expiration"] = *expiration
+	}
+	data, err := binarycodec.EncodeBytes(jsonObj)
+	if err != nil {
+		t.Fatalf("encode credential: %v", err)
+	}
+	k := keylet.Credential(subjectID, issuerID, credType)
+	if err := svc.openLedger.Insert(k, data); err != nil {
+		t.Fatalf("insert credential: %v", err)
+	}
+	return k.Key
+}
+
+func TestGetDepositAuthorized_AccountChecks(t *testing.T) {
+	svc := newOfferTestService(t)
+	srcAddr, _ := addressFromBytes(t, 0x10)
+	dstAddr, _ := addressFromBytes(t, 0x20)
+	insertAccountRoot(t, svc, srcAddr, 1_000_000_000, 0)
+	insertAccountRoot(t, svc, dstAddr, 1_000_000_000, 0)
+
+	t.Run("no deposit auth → authorized", func(t *testing.T) {
+		res, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current", nil)
+		if err != nil {
+			t.Fatalf("GetDepositAuthorized: %v", err)
+		}
+		if !res.DepositAuthorized {
+			t.Errorf("absent DepositAuth flag must authorize")
+		}
+	})
+
+	t.Run("source not found", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x98)
+		_, err := svc.GetDepositAuthorized(context.Background(), stranger, dstAddr, "current", nil)
+		if !errors.Is(err, svcerr.ErrSrcAccountNotFound) {
+			t.Fatalf("want ErrSrcAccountNotFound, got %v", err)
+		}
+	})
+
+	t.Run("destination not found", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x97)
+		_, err := svc.GetDepositAuthorized(context.Background(), srcAddr, stranger, "current", nil)
+		if !errors.Is(err, svcerr.ErrDstAccountNotFound) {
+			t.Fatalf("want ErrDstAccountNotFound, got %v", err)
+		}
+	})
+}
+
+func TestGetDepositAuthorized_DepositAuthFlag(t *testing.T) {
+	svc := newOfferTestService(t)
+	srcAddr, srcID := addressFromBytes(t, 0x10)
+	dstAddr, dstID := addressFromBytes(t, 0x20)
+	insertAccountRoot(t, svc, srcAddr, 1_000_000_000, 0)
+	insertAccountRootWithFlags(t, svc, dstAddr, 1_000_000_000, 0, state.LsfDepositAuth)
+
+	t.Run("required but no preauth → not authorized", func(t *testing.T) {
+		res, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current", nil)
+		if err != nil {
+			t.Fatalf("GetDepositAuthorized: %v", err)
+		}
+		if res.DepositAuthorized {
+			t.Errorf("DepositAuth set without preauth must NOT authorize")
+		}
+	})
+
+	t.Run("self deposit always authorized", func(t *testing.T) {
+		res, err := svc.GetDepositAuthorized(context.Background(), dstAddr, dstAddr, "current", nil)
+		if err != nil {
+			t.Fatalf("GetDepositAuthorized: %v", err)
+		}
+		if !res.DepositAuthorized {
+			t.Errorf("self-deposit must always authorize")
+		}
+	})
+
+	t.Run("direct preauth → authorized", func(t *testing.T) {
+		preauthKey := keylet.DepositPreauth(dstID, srcID)
+		if err := svc.openLedger.Insert(preauthKey, make([]byte, 16)); err != nil {
+			t.Fatalf("insert deposit preauth: %v", err)
+		}
+		res, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current", nil)
+		if err != nil {
+			t.Fatalf("GetDepositAuthorized: %v", err)
+		}
+		if !res.DepositAuthorized {
+			t.Errorf("direct DepositPreauth entry must authorize")
+		}
+	})
+}
+
+func TestGetDepositAuthorized_Credentials(t *testing.T) {
+	svc := newOfferTestService(t)
+	srcAddr, srcID := addressFromBytes(t, 0x10)
+	dstAddr, dstID := addressFromBytes(t, 0x20)
+	_, issuerID := addressFromBytes(t, 0x40)
+	insertAccountRoot(t, svc, srcAddr, 1_000_000_000, 0)
+	insertAccountRootWithFlags(t, svc, dstAddr, 1_000_000_000, 0, state.LsfDepositAuth)
+
+	credType := []byte("KYC")
+
+	t.Run("malformed credential hex", func(t *testing.T) {
+		_, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current", []string{"nothex!!"})
+		if !errors.Is(err, svcerr.ErrBadCredentials) {
+			t.Fatalf("want ErrBadCredentials, got %v", err)
+		}
+	})
+
+	t.Run("non-existent credential", func(t *testing.T) {
+		_, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current",
+			[]string{strings.Repeat("AB", 32)})
+		if !errors.Is(err, svcerr.ErrBadCredentials) {
+			t.Fatalf("want ErrBadCredentials, got %v", err)
+		}
+	})
+
+	t.Run("unaccepted credential", func(t *testing.T) {
+		key := insertCredentialEntry(t, svc, srcID, issuerID, []byte("PENDING"), false, nil)
+		_, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current",
+			[]string{formatHashHex(key)})
+		if !errors.Is(err, svcerr.ErrBadCredentials) {
+			t.Fatalf("want ErrBadCredentials (not accepted), got %v", err)
+		}
+	})
+
+	t.Run("wrong subject", func(t *testing.T) {
+		// Credential whose subject is NOT the source account.
+		_, otherID := addressFromBytes(t, 0x50)
+		key := insertCredentialEntry(t, svc, otherID, issuerID, []byte("OTHER"), true, nil)
+		_, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current",
+			[]string{formatHashHex(key)})
+		if !errors.Is(err, svcerr.ErrBadCredentials) {
+			t.Fatalf("want ErrBadCredentials (wrong subject), got %v", err)
+		}
+	})
+
+	t.Run("duplicate credentials", func(t *testing.T) {
+		key := insertCredentialEntry(t, svc, srcID, issuerID, []byte("DUP"), true, nil)
+		hexID := formatHashHex(key)
+		_, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current",
+			[]string{hexID, hexID})
+		if !errors.Is(err, svcerr.ErrBadCredentials) {
+			t.Fatalf("want ErrBadCredentials (duplicate), got %v", err)
+		}
+	})
+
+	t.Run("valid credential with credential preauth → authorized", func(t *testing.T) {
+		key := insertCredentialEntry(t, svc, srcID, issuerID, credType, true, nil)
+		pairs := []keylet.CredentialPair{{Issuer: issuerID, CredentialType: credType}}
+		credPreauthKey := keylet.DepositPreauthCredentials(dstID, pairs)
+		if err := svc.openLedger.Insert(credPreauthKey, make([]byte, 16)); err != nil {
+			t.Fatalf("insert credential preauth: %v", err)
+		}
+		res, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current",
+			[]string{formatHashHex(key)})
+		if err != nil {
+			t.Fatalf("GetDepositAuthorized: %v", err)
+		}
+		if !res.DepositAuthorized {
+			t.Errorf("valid credential + credential preauth must authorize")
+		}
+	})
+}

--- a/internal/ledger/service/account_query_test.go
+++ b/internal/ledger/service/account_query_test.go
@@ -1,0 +1,684 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// insertLineRaw inserts a RippleState (trust line) with full control over the
+// raw sfBalance (from the low account's stored perspective), both limits, and
+// flags. lowAddr must sort before highAddr per the trust-line ordering rule.
+func insertLineRaw(t *testing.T, svc *Service, lowAddr, highAddr, currency, rawBalance, lowLimit, highLimit string, flags uint32) {
+	t.Helper()
+	_, lowBytes, err := addresscodec.DecodeClassicAddressToAccountID(lowAddr)
+	if err != nil {
+		t.Fatalf("decode low: %v", err)
+	}
+	_, highBytes, err := addresscodec.DecodeClassicAddressToAccountID(highAddr)
+	if err != nil {
+		t.Fatalf("decode high: %v", err)
+	}
+	var lowID, highID [20]byte
+	copy(lowID[:], lowBytes)
+	copy(highID[:], highBytes)
+	if state.CompareAccountIDsForLine(lowID, highID) >= 0 {
+		t.Fatalf("lowAddr %s must sort before highAddr %s", lowAddr, highAddr)
+	}
+
+	rs := &state.RippleState{
+		Balance:   state.NewIssuedAmountFromDecimalString(rawBalance, currency, state.AccountOneAddress),
+		LowLimit:  state.NewIssuedAmountFromDecimalString(lowLimit, currency, lowAddr),
+		HighLimit: state.NewIssuedAmountFromDecimalString(highLimit, currency, highAddr),
+		Flags:     flags,
+	}
+	data, err := state.SerializeRippleState(rs)
+	if err != nil {
+		t.Fatalf("serialize ripple state: %v", err)
+	}
+	if err := svc.openLedger.Insert(keylet.Line(lowID, highID, currency), data); err != nil {
+		t.Fatalf("insert ripple state: %v", err)
+	}
+}
+
+// insertPayChannelEntry inserts a PayChannel ledger entry between src and dst.
+func insertPayChannelEntry(t *testing.T, svc *Service, srcAddr, dstAddr string, seq uint32, mutate func(*state.PayChannelData)) [32]byte {
+	t.Helper()
+	_, srcBytes, err := addresscodec.DecodeClassicAddressToAccountID(srcAddr)
+	if err != nil {
+		t.Fatalf("decode src: %v", err)
+	}
+	_, dstBytes, err := addresscodec.DecodeClassicAddressToAccountID(dstAddr)
+	if err != nil {
+		t.Fatalf("decode dst: %v", err)
+	}
+	var srcID, dstID [20]byte
+	copy(srcID[:], srcBytes)
+	copy(dstID[:], dstBytes)
+
+	pc := &state.PayChannelData{
+		Account:       srcID,
+		DestinationID: dstID,
+		Amount:        1_000_000,
+		Balance:       0,
+		SettleDelay:   60,
+	}
+	if mutate != nil {
+		mutate(pc)
+	}
+	data, err := state.SerializePayChannelFromData(pc)
+	if err != nil {
+		t.Fatalf("serialize pay channel: %v", err)
+	}
+	k := keylet.PayChannel(srcID, dstID, seq)
+	if err := svc.openLedger.Insert(k, data); err != nil {
+		t.Fatalf("insert pay channel: %v", err)
+	}
+	return k.Key
+}
+
+func TestGetAccountInfo_FieldsAndErrors(t *testing.T) {
+	svc := newOfferTestService(t)
+	addr, idBytes := addressFromBytes(t, 0x10)
+
+	root := &state.AccountRoot{
+		Account:    addr,
+		Balance:    250_000_000,
+		Sequence:   7,
+		OwnerCount: 3,
+		Flags:      state.LsfDefaultRipple,
+	}
+	data, err := state.SerializeAccountRoot(root)
+	if err != nil {
+		t.Fatalf("serialize account root: %v", err)
+	}
+	if err := svc.openLedger.Insert(keylet.Account(idBytes), data); err != nil {
+		t.Fatalf("insert account root: %v", err)
+	}
+
+	info, err := svc.GetAccountInfo(context.Background(), addr, "current")
+	if err != nil {
+		t.Fatalf("GetAccountInfo: %v", err)
+	}
+	if info.Balance != 250_000_000 {
+		t.Errorf("balance = %d, want 250000000", info.Balance)
+	}
+	if info.Sequence != 7 {
+		t.Errorf("sequence = %d, want 7", info.Sequence)
+	}
+	if info.OwnerCount != 3 {
+		t.Errorf("owner_count = %d, want 3", info.OwnerCount)
+	}
+	if info.Flags&state.LsfDefaultRipple == 0 {
+		t.Errorf("DefaultRipple flag not reflected, flags = %#x", info.Flags)
+	}
+	if info.Validated {
+		t.Errorf("current ledger must report validated=false")
+	}
+	if len(info.RawData) == 0 {
+		t.Errorf("RawData must be populated")
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x99)
+		_, err := svc.GetAccountInfo(context.Background(), stranger, "current")
+		if !errors.Is(err, svcerr.ErrAccountNotFound) {
+			t.Fatalf("want ErrAccountNotFound, got %v", err)
+		}
+	})
+
+	t.Run("malformed address", func(t *testing.T) {
+		_, err := svc.GetAccountInfo(context.Background(), "not-an-address", "current")
+		if !errors.Is(err, svcerr.ErrAccountMalformed) {
+			t.Fatalf("want ErrAccountMalformed, got %v", err)
+		}
+	})
+
+	t.Run("invalid ledger_index", func(t *testing.T) {
+		_, err := svc.GetAccountInfo(context.Background(), addr, "bogus")
+		if err == nil || err.Error() != "invalid ledger_index" {
+			t.Fatalf("want invalid ledger_index error, got %v", err)
+		}
+	})
+
+	t.Run("numeric ledger not found", func(t *testing.T) {
+		_, err := svc.GetAccountInfo(context.Background(), addr, "999999")
+		if !errors.Is(err, ErrLedgerNotFound) {
+			t.Fatalf("want ErrLedgerNotFound, got %v", err)
+		}
+	})
+
+	t.Run("cancelled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := svc.GetAccountInfo(ctx, addr, "current")
+		if err == nil {
+			t.Fatalf("want context error, got nil")
+		}
+	})
+}
+
+// TestGetAccountLines_FlagMapping pins the per-side flag mapping fixed for #750:
+// no_ripple / authorized must read lsfLowNoRipple (0x00100000) / lsfLowAuth
+// (0x00040000) — not the reserve bits that were previously hardcoded. A single
+// trust line is queried from both sides to exercise the low and high branches.
+func TestGetAccountLines_FlagMapping(t *testing.T) {
+	svc := newOfferTestService(t)
+
+	// 0x10-account sorts before 0x40-account, so low = A, high = B.
+	aAddr, _ := addressFromBytes(t, 0x10)
+	bAddr, _ := addressFromBytes(t, 0x40)
+	insertAccountRoot(t, svc, aAddr, 1_000_000_000, 0)
+	insertAccountRoot(t, svc, bAddr, 1_000_000_000, 0)
+
+	// Low side sets NoRipple; high side sets Auth and Freeze.
+	flags := state.LsfLowNoRipple | state.LsfHighAuth | state.LsfHighFreeze
+	insertLineRaw(t, svc, aAddr, bAddr, "USD", "0", "100", "200", flags)
+
+	t.Run("low account perspective", func(t *testing.T) {
+		res, err := svc.GetAccountLines(context.Background(), aAddr, "current", "", 0)
+		if err != nil {
+			t.Fatalf("GetAccountLines: %v", err)
+		}
+		if len(res.Lines) != 1 {
+			t.Fatalf("expected 1 line, got %d", len(res.Lines))
+		}
+		ln := res.Lines[0]
+		if ln.Account != bAddr {
+			t.Errorf("peer = %s, want %s", ln.Account, bAddr)
+		}
+		if ln.Currency != "USD" {
+			t.Errorf("currency = %s, want USD", ln.Currency)
+		}
+		if ln.Limit != "100" || ln.LimitPeer != "200" {
+			t.Errorf("limits = %s / %s, want 100 / 200", ln.Limit, ln.LimitPeer)
+		}
+		if !ln.NoRipple {
+			t.Errorf("low side NoRipple must be true (lsfLowNoRipple)")
+		}
+		if ln.NoRipplePeer {
+			t.Errorf("peer (high) did not set NoRipple")
+		}
+		if ln.Authorized {
+			t.Errorf("low side did not set Auth")
+		}
+		if !ln.PeerAuthorized {
+			t.Errorf("peer (high) set Auth → peer_authorized must be true (lsfHighAuth)")
+		}
+		if ln.Freeze {
+			t.Errorf("low side did not freeze")
+		}
+		if !ln.FreezePeer {
+			t.Errorf("peer (high) froze → freeze_peer must be true (lsfHighFreeze)")
+		}
+	})
+
+	t.Run("high account perspective", func(t *testing.T) {
+		res, err := svc.GetAccountLines(context.Background(), bAddr, "current", "", 0)
+		if err != nil {
+			t.Fatalf("GetAccountLines: %v", err)
+		}
+		if len(res.Lines) != 1 {
+			t.Fatalf("expected 1 line, got %d", len(res.Lines))
+		}
+		ln := res.Lines[0]
+		if ln.Account != aAddr {
+			t.Errorf("peer = %s, want %s", ln.Account, aAddr)
+		}
+		if ln.NoRipple {
+			t.Errorf("high side did not set NoRipple")
+		}
+		if !ln.NoRipplePeer {
+			t.Errorf("peer (low) set NoRipple → no_ripple_peer must be true (lsfLowNoRipple)")
+		}
+		if !ln.Authorized {
+			t.Errorf("high side set Auth → authorized must be true (lsfHighAuth)")
+		}
+		if !ln.Freeze {
+			t.Errorf("high side froze → freeze must be true (lsfHighFreeze)")
+		}
+	})
+}
+
+func TestGetAccountLines_PeerFilterAndErrors(t *testing.T) {
+	svc := newOfferTestService(t)
+	aAddr, _ := addressFromBytes(t, 0x10)
+	bAddr, _ := addressFromBytes(t, 0x40)
+	cAddr, _ := addressFromBytes(t, 0x60)
+	insertAccountRoot(t, svc, aAddr, 1_000_000_000, 0)
+
+	insertLineRaw(t, svc, aAddr, bAddr, "USD", "0", "100", "100", 0)
+	insertLineRaw(t, svc, aAddr, cAddr, "EUR", "0", "100", "100", 0)
+
+	t.Run("no filter returns both", func(t *testing.T) {
+		res, err := svc.GetAccountLines(context.Background(), aAddr, "current", "", 0)
+		if err != nil {
+			t.Fatalf("GetAccountLines: %v", err)
+		}
+		if len(res.Lines) != 2 {
+			t.Fatalf("expected 2 lines, got %d", len(res.Lines))
+		}
+	})
+
+	t.Run("peer filter narrows to one", func(t *testing.T) {
+		res, err := svc.GetAccountLines(context.Background(), aAddr, "current", bAddr, 0)
+		if err != nil {
+			t.Fatalf("GetAccountLines: %v", err)
+		}
+		if len(res.Lines) != 1 || res.Lines[0].Account != bAddr {
+			t.Fatalf("peer filter failed: %+v", res.Lines)
+		}
+	})
+
+	t.Run("invalid peer address", func(t *testing.T) {
+		_, err := svc.GetAccountLines(context.Background(), aAddr, "current", "nope", 0)
+		if err == nil {
+			t.Fatalf("want error for invalid peer, got nil")
+		}
+	})
+
+	t.Run("malformed account", func(t *testing.T) {
+		_, err := svc.GetAccountLines(context.Background(), "bad", "current", "", 0)
+		if !errors.Is(err, svcerr.ErrAccountMalformed) {
+			t.Fatalf("want ErrAccountMalformed, got %v", err)
+		}
+	})
+}
+
+func TestGetAccountCurrencies_SendAndReceive(t *testing.T) {
+	svc := newOfferTestService(t)
+	aAddr, _ := addressFromBytes(t, 0x10)
+	bAddr, _ := addressFromBytes(t, 0x40)
+	insertAccountRoot(t, svc, aAddr, 1_000_000_000, 0)
+
+	// A is the low account. Raw balance -50 means (from A's perspective,
+	// negated) A holds +50 → can send. LowLimit 100 > 50 → can also receive.
+	insertLineRaw(t, svc, aAddr, bAddr, "USD", "-50", "100", "100", 0)
+
+	res, err := svc.GetAccountCurrencies(context.Background(), aAddr, "current")
+	if err != nil {
+		t.Fatalf("GetAccountCurrencies: %v", err)
+	}
+	if !containsString(res.SendCurrencies, "USD") {
+		t.Errorf("USD should be sendable, got %v", res.SendCurrencies)
+	}
+	if !containsString(res.ReceiveCurrencies, "USD") {
+		t.Errorf("USD should be receivable, got %v", res.ReceiveCurrencies)
+	}
+
+	t.Run("account not found", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x99)
+		_, err := svc.GetAccountCurrencies(context.Background(), stranger, "current")
+		if !errors.Is(err, svcerr.ErrAccountNotFound) {
+			t.Fatalf("want ErrAccountNotFound, got %v", err)
+		}
+	})
+}
+
+func TestGetAccountObjects_TypeFilterAndErrors(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, _ := addressFromBytes(t, 0x10)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	ownerAddr, _ := addressFromBytes(t, 0x20)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+
+	insertOffer(t, svc, ownerAddr, 1,
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+		tx.NewXRPAmount(10_000_000),
+	)
+	insertOffer(t, svc, ownerAddr, 2,
+		state.NewIssuedAmountFromFloat64(200, "USD", issuerAddr),
+		tx.NewXRPAmount(10_000_000),
+	)
+
+	t.Run("all objects", func(t *testing.T) {
+		res, err := svc.GetAccountObjects(context.Background(), ownerAddr, "current", "", 0)
+		if err != nil {
+			t.Fatalf("GetAccountObjects: %v", err)
+		}
+		offerCount := 0
+		for _, o := range res.AccountObjects {
+			if o.LedgerEntryType == "Offer" {
+				offerCount++
+			}
+		}
+		if offerCount != 2 {
+			t.Fatalf("expected 2 Offer objects, got %d (of %d total)", offerCount, len(res.AccountObjects))
+		}
+	})
+
+	t.Run("snake_case type filter", func(t *testing.T) {
+		res, err := svc.GetAccountObjects(context.Background(), ownerAddr, "current", "offer", 0)
+		if err != nil {
+			t.Fatalf("GetAccountObjects: %v", err)
+		}
+		if len(res.AccountObjects) != 2 {
+			t.Fatalf("expected 2 offers, got %d", len(res.AccountObjects))
+		}
+	})
+
+	t.Run("filter excludes other types", func(t *testing.T) {
+		res, err := svc.GetAccountObjects(context.Background(), ownerAddr, "current", "check", 0)
+		if err != nil {
+			t.Fatalf("GetAccountObjects: %v", err)
+		}
+		if len(res.AccountObjects) != 0 {
+			t.Fatalf("expected 0 checks, got %d", len(res.AccountObjects))
+		}
+	})
+
+	t.Run("limit honored", func(t *testing.T) {
+		res, err := svc.GetAccountObjects(context.Background(), ownerAddr, "current", "offer", 1)
+		if err != nil {
+			t.Fatalf("GetAccountObjects: %v", err)
+		}
+		if len(res.AccountObjects) != 1 {
+			t.Fatalf("limit=1 must cap at 1 object, got %d", len(res.AccountObjects))
+		}
+	})
+
+	t.Run("account not found", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x99)
+		_, err := svc.GetAccountObjects(context.Background(), stranger, "current", "", 0)
+		if !errors.Is(err, svcerr.ErrAccountNotFound) {
+			t.Fatalf("want ErrAccountNotFound, got %v", err)
+		}
+	})
+}
+
+func TestGetAccountChannels_FilterAndFields(t *testing.T) {
+	svc := newOfferTestService(t)
+	srcAddr, _ := addressFromBytes(t, 0x10)
+	dst1Addr, _ := addressFromBytes(t, 0x40)
+	dst2Addr, _ := addressFromBytes(t, 0x60)
+	insertAccountRoot(t, svc, srcAddr, 1_000_000_000_000, 0)
+
+	insertPayChannelEntry(t, svc, srcAddr, dst1Addr, 1, func(pc *state.PayChannelData) {
+		pc.Amount = 5_000_000
+		pc.Balance = 1_000_000
+		pc.SettleDelay = 120
+		pc.Expiration = 700000000
+		pc.SourceTag = 42
+		pc.HasSourceTag = true
+	})
+	insertPayChannelEntry(t, svc, srcAddr, dst2Addr, 2, func(pc *state.PayChannelData) {
+		pc.Amount = 9_000_000
+	})
+
+	t.Run("all channels", func(t *testing.T) {
+		res, err := svc.GetAccountChannels(context.Background(), srcAddr, "", "current", 0)
+		if err != nil {
+			t.Fatalf("GetAccountChannels: %v", err)
+		}
+		if len(res.Channels) != 2 {
+			t.Fatalf("expected 2 channels, got %d", len(res.Channels))
+		}
+	})
+
+	t.Run("destination filter + field decode", func(t *testing.T) {
+		res, err := svc.GetAccountChannels(context.Background(), srcAddr, dst1Addr, "current", 0)
+		if err != nil {
+			t.Fatalf("GetAccountChannels: %v", err)
+		}
+		if len(res.Channels) != 1 {
+			t.Fatalf("expected 1 channel, got %d", len(res.Channels))
+		}
+		ch := res.Channels[0]
+		if ch.DestinationAccount != dst1Addr {
+			t.Errorf("destination = %s, want %s", ch.DestinationAccount, dst1Addr)
+		}
+		if ch.Amount != "5000000" {
+			t.Errorf("amount = %s, want 5000000", ch.Amount)
+		}
+		if ch.Balance != "1000000" {
+			t.Errorf("balance = %s, want 1000000", ch.Balance)
+		}
+		if ch.SettleDelay != 120 {
+			t.Errorf("settle_delay = %d, want 120", ch.SettleDelay)
+		}
+		if ch.Expiration != 700000000 {
+			t.Errorf("expiration = %d, want 700000000", ch.Expiration)
+		}
+		if !ch.HasSourceTag || ch.SourceTag != 42 {
+			t.Errorf("source_tag = %d (has=%v), want 42", ch.SourceTag, ch.HasSourceTag)
+		}
+	})
+
+	t.Run("account not found", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x99)
+		_, err := svc.GetAccountChannels(context.Background(), stranger, "", "current", 0)
+		if !errors.Is(err, svcerr.ErrAccountNotFound) {
+			t.Fatalf("want ErrAccountNotFound, got %v", err)
+		}
+	})
+
+	t.Run("invalid destination", func(t *testing.T) {
+		_, err := svc.GetAccountChannels(context.Background(), srcAddr, "bad", "current", 0)
+		if err == nil {
+			t.Fatalf("want error for invalid destination, got nil")
+		}
+	})
+}
+
+func TestGetGatewayBalances_Categories(t *testing.T) {
+	svc := newOfferTestService(t)
+	// Gateway is the low account on every line (smaller seed).
+	gwAddr, _ := addressFromBytes(t, 0x10)
+	insertAccountRoot(t, svc, gwAddr, 1_000_000_000_000, 0)
+
+	obligPeer, _ := addressFromBytes(t, 0x40) // normal obligation
+	hotPeer, _ := addressFromBytes(t, 0x50)   // hot wallet
+	assetPeer, _ := addressFromBytes(t, 0x60) // gateway holds (asset)
+	frozenPeer, _ := addressFromBytes(t, 0x70)
+
+	// gateway low; raw balance negative ⇒ gateway owes the peer (obligation).
+	insertLineRaw(t, svc, gwAddr, obligPeer, "USD", "-100", "0", "1000", 0)
+	insertLineRaw(t, svc, gwAddr, hotPeer, "USD", "-25", "0", "1000", 0)
+	// positive ⇒ gateway holds the peer's currency (asset).
+	insertLineRaw(t, svc, gwAddr, assetPeer, "EUR", "30", "1000", "0", 0)
+	// negative + low-side freeze ⇒ frozen obligation.
+	insertLineRaw(t, svc, gwAddr, frozenPeer, "USD", "-40", "0", "1000", state.LsfLowFreeze)
+
+	res, err := svc.GetGatewayBalances(context.Background(), gwAddr, []string{hotPeer}, "current")
+	if err != nil {
+		t.Fatalf("GetGatewayBalances: %v", err)
+	}
+
+	if res.Obligations["USD"] != "100" {
+		t.Errorf("USD obligation = %q, want 100", res.Obligations["USD"])
+	}
+	if len(res.Balances[hotPeer]) != 1 || res.Balances[hotPeer][0].Value != "25" {
+		t.Errorf("hot wallet balance not reported correctly: %+v", res.Balances[hotPeer])
+	}
+	if len(res.Assets[assetPeer]) != 1 || res.Assets[assetPeer][0].Currency != "EUR" {
+		t.Errorf("asset not reported correctly: %+v", res.Assets[assetPeer])
+	}
+	if len(res.FrozenBalances[frozenPeer]) != 1 || res.FrozenBalances[frozenPeer][0].Value != "40" {
+		t.Errorf("frozen balance not reported correctly: %+v", res.FrozenBalances[frozenPeer])
+	}
+
+	t.Run("account not found", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x99)
+		_, err := svc.GetGatewayBalances(context.Background(), stranger, nil, "current")
+		if !errors.Is(err, svcerr.ErrAccountNotFound) {
+			t.Fatalf("want ErrAccountNotFound, got %v", err)
+		}
+	})
+
+	t.Run("invalid hot wallet", func(t *testing.T) {
+		_, err := svc.GetGatewayBalances(context.Background(), gwAddr, []string{"bad"}, "current")
+		if err == nil {
+			t.Fatalf("want error for invalid hot wallet, got nil")
+		}
+	})
+}
+
+func TestGetNoRippleCheck_RolesAndProblems(t *testing.T) {
+	svc := newOfferTestService(t)
+	gwAddr, _ := addressFromBytes(t, 0x10)
+	peerAddr, _ := addressFromBytes(t, 0x40)
+	// Gateway without DefaultRipple, with a low-side NoRipple line.
+	insertAccountRoot(t, svc, gwAddr, 1_000_000_000, 0)
+	insertLineRaw(t, svc, gwAddr, peerAddr, "USD", "0", "100", "100", state.LsfLowNoRipple)
+
+	t.Run("gateway role flags default-ripple and no-ripple line", func(t *testing.T) {
+		res, err := svc.GetNoRippleCheck(context.Background(), gwAddr, "gateway", "current", 0, true)
+		if err != nil {
+			t.Fatalf("GetNoRippleCheck: %v", err)
+		}
+		if len(res.Problems) < 2 {
+			t.Fatalf("expected >=2 problems, got %v", res.Problems)
+		}
+		if len(res.Transactions) == 0 {
+			t.Fatalf("transactions=true must yield suggested transactions")
+		}
+		var sawAccountSet, sawTrustSet bool
+		for _, tx := range res.Transactions {
+			switch tx.TransactionType {
+			case "AccountSet":
+				sawAccountSet = true
+			case "TrustSet":
+				sawTrustSet = true
+			}
+		}
+		if !sawAccountSet || !sawTrustSet {
+			t.Errorf("expected both AccountSet and TrustSet suggestions, got %+v", res.Transactions)
+		}
+	})
+
+	t.Run("invalid role", func(t *testing.T) {
+		_, err := svc.GetNoRippleCheck(context.Background(), gwAddr, "banker", "current", 0, false)
+		if err == nil {
+			t.Fatalf("want error for invalid role, got nil")
+		}
+	})
+
+	t.Run("account not found", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x99)
+		_, err := svc.GetNoRippleCheck(context.Background(), stranger, "user", "current", 0, false)
+		if !errors.Is(err, svcerr.ErrAccountNotFound) {
+			t.Fatalf("want ErrAccountNotFound, got %v", err)
+		}
+	})
+}
+
+func TestGetLedgerForQuery_Branches(t *testing.T) {
+	svc := newOfferTestService(t)
+
+	t.Run("current resolves open ledger", func(t *testing.T) {
+		l, validated, err := svc.getLedgerForQuery("current")
+		if err != nil || l == nil {
+			t.Fatalf("current: l=%v err=%v", l, err)
+		}
+		if validated {
+			t.Errorf("current must not be validated")
+		}
+	})
+	t.Run("empty string resolves open ledger", func(t *testing.T) {
+		l, _, err := svc.getLedgerForQuery("")
+		if err != nil || l == nil {
+			t.Fatalf("empty: l=%v err=%v", l, err)
+		}
+	})
+	t.Run("validated", func(t *testing.T) {
+		l, validated, err := svc.getLedgerForQuery("validated")
+		if err != nil || l == nil {
+			t.Fatalf("validated: l=%v err=%v", l, err)
+		}
+		if !validated {
+			t.Errorf("validated branch must report validated=true")
+		}
+	})
+	t.Run("closed", func(t *testing.T) {
+		l, _, err := svc.getLedgerForQuery("closed")
+		if err != nil || l == nil {
+			t.Fatalf("closed: l=%v err=%v", l, err)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		_, _, err := svc.getLedgerForQuery("xyz")
+		if err == nil || err.Error() != "invalid ledger_index" {
+			t.Fatalf("want invalid ledger_index, got %v", err)
+		}
+	})
+	t.Run("numeric not found", func(t *testing.T) {
+		_, _, err := svc.getLedgerForQuery("123456789")
+		if !errors.Is(err, ErrLedgerNotFound) {
+			t.Fatalf("want ErrLedgerNotFound, got %v", err)
+		}
+	})
+}
+
+func TestGetAccountOffers_FormatsAmounts(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, _ := addressFromBytes(t, 0x10)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	ownerAddr, _ := addressFromBytes(t, 0x20)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+
+	// Offer: TakerGets XRP (native), TakerPays IOU.
+	insertOffer(t, svc, ownerAddr, 1,
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+		tx.NewXRPAmount(10_000_000),
+	)
+	// Offer from a different owner must be excluded.
+	otherAddr, _ := addressFromBytes(t, 0x30)
+	insertAccountRoot(t, svc, otherAddr, 1_000_000_000_000, 0)
+	insertOffer(t, svc, otherAddr, 1,
+		state.NewIssuedAmountFromFloat64(50, "USD", issuerAddr),
+		tx.NewXRPAmount(10_000_000),
+	)
+
+	res, err := svc.GetAccountOffers(context.Background(), ownerAddr, "current", 0)
+	if err != nil {
+		t.Fatalf("GetAccountOffers: %v", err)
+	}
+	if len(res.Offers) != 1 {
+		t.Fatalf("expected 1 offer for owner, got %d", len(res.Offers))
+	}
+	o := res.Offers[0]
+	if o.Seq != 1 {
+		t.Errorf("seq = %d, want 1", o.Seq)
+	}
+	// TakerGets is native → emitted as a drops string.
+	if _, ok := o.TakerGets.(string); !ok {
+		t.Errorf("native taker_gets should be a string, got %T", o.TakerGets)
+	}
+	// TakerPays is an IOU → emitted as a map.
+	pays, ok := o.TakerPays.(map[string]string)
+	if !ok {
+		t.Fatalf("IOU taker_pays should be a map, got %T", o.TakerPays)
+	}
+	if pays["currency"] != "USD" || pays["issuer"] != issuerAddr {
+		t.Errorf("taker_pays = %+v, want USD/%s", pays, issuerAddr)
+	}
+	if o.Quality == "" {
+		t.Errorf("quality must be computed")
+	}
+
+	t.Run("unknown account yields empty offers", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x99)
+		res, err := svc.GetAccountOffers(context.Background(), stranger, "current", 0)
+		if err != nil {
+			t.Fatalf("GetAccountOffers(stranger): %v", err)
+		}
+		if len(res.Offers) != 0 {
+			t.Fatalf("stranger must have 0 offers, got %d", len(res.Offers))
+		}
+	})
+}
+
+func containsString(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ledger/service/nft_query_test.go
+++ b/internal/ledger/service/nft_query_test.go
@@ -1,0 +1,250 @@
+package service
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// nftIDFromByte builds a deterministic 32-byte NFTokenID from a seed.
+func nftIDFromByte(seed byte) [32]byte {
+	var id [32]byte
+	for i := range id {
+		id[i] = seed + byte(i)
+	}
+	return id
+}
+
+// insertNFTokenOfferEntry serializes an NFTokenOffer ledger entry the way the
+// goXRPL apply path does (sfAccount carries the owner) and inserts it under a
+// real NFTokenOffer keylet. The returned key is what the NFT directory must
+// reference. amount is either a drops string (XRP) or a {currency,issuer,value}
+// map (IOU).
+func insertNFTokenOfferEntry(t *testing.T, svc *Service, ownerAddr string, seq uint32, tokenID [32]byte, amount any, flags uint32, dest string, expiration *uint32) [32]byte {
+	t.Helper()
+	_, ownerBytes, err := addresscodec.DecodeClassicAddressToAccountID(ownerAddr)
+	if err != nil {
+		t.Fatalf("decode owner: %v", err)
+	}
+	var ownerID [20]byte
+	copy(ownerID[:], ownerBytes)
+
+	jsonObj := map[string]any{
+		"LedgerEntryType":  "NFTokenOffer",
+		"Account":          ownerAddr,
+		"Amount":           amount,
+		"NFTokenID":        strings.ToUpper(hex.EncodeToString(tokenID[:])),
+		"OwnerNode":        "0",
+		"NFTokenOfferNode": "0",
+		"Flags":            flags,
+	}
+	if expiration != nil {
+		jsonObj["Expiration"] = *expiration
+	}
+	if dest != "" {
+		jsonObj["Destination"] = dest
+	}
+
+	data, err := binarycodec.EncodeBytes(jsonObj)
+	if err != nil {
+		t.Fatalf("encode NFTokenOffer: %v", err)
+	}
+	k := keylet.NFTokenOffer(ownerID, seq)
+	if err := svc.openLedger.Insert(k, data); err != nil {
+		t.Fatalf("insert NFTokenOffer: %v", err)
+	}
+	return k.Key
+}
+
+// insertNFTDir creates the buy/sell offer directory for an NFToken containing
+// the given offer keys (in order), so parseDirectoryIndexesForNFT can walk it.
+func insertNFTDir(t *testing.T, svc *Service, nftID [32]byte, offerKeys [][32]byte, isSell bool) {
+	t.Helper()
+	var dirKey keylet.Keylet
+	if isSell {
+		dirKey = keylet.NFTSells(nftID)
+	} else {
+		dirKey = keylet.NFTBuys(nftID)
+	}
+	dir := &state.DirectoryNode{
+		RootIndex: dirKey.Key,
+		Indexes:   offerKeys,
+	}
+	data, err := state.SerializeDirectoryNode(dir, false)
+	if err != nil {
+		t.Fatalf("serialize directory: %v", err)
+	}
+	if err := svc.openLedger.Insert(dirKey, data); err != nil {
+		t.Fatalf("insert NFT directory: %v", err)
+	}
+}
+
+func TestGetNFTOffers_DirectoryNotFound(t *testing.T) {
+	svc := newOfferTestService(t)
+	nftID := nftIDFromByte(0x10)
+
+	_, err := svc.GetNFTBuyOffers(context.Background(), nftID, "current", 0, "")
+	if !errors.Is(err, svcerr.ErrObjectNotFound) {
+		t.Fatalf("missing buy directory must yield ErrObjectNotFound, got %v", err)
+	}
+	_, err = svc.GetNFTSellOffers(context.Background(), nftID, "current", 0, "")
+	if !errors.Is(err, svcerr.ErrObjectNotFound) {
+		t.Fatalf("missing sell directory must yield ErrObjectNotFound, got %v", err)
+	}
+}
+
+func TestGetNFTOffers_EmptyDirectory(t *testing.T) {
+	svc := newOfferTestService(t)
+	nftID := nftIDFromByte(0x20)
+	insertNFTDir(t, svc, nftID, nil, false)
+
+	res, err := svc.GetNFTBuyOffers(context.Background(), nftID, "current", 0, "")
+	if err != nil {
+		t.Fatalf("GetNFTBuyOffers: %v", err)
+	}
+	if len(res.Offers) != 0 {
+		t.Fatalf("empty directory must return 0 offers, got %d", len(res.Offers))
+	}
+	if res.NFTID != strings.ToUpper(hex.EncodeToString(nftID[:])) {
+		t.Errorf("NFTID = %s, want hex of nftID", res.NFTID)
+	}
+}
+
+func TestGetNFTSellOffers_XRPAndIOU(t *testing.T) {
+	svc := newOfferTestService(t)
+	ownerAddr, _ := addressFromBytes(t, 0x30)
+	issuerAddr, _ := addressFromBytes(t, 0x40)
+	nftID := nftIDFromByte(0x50)
+
+	exp := uint32(800000000)
+	destAddr, _ := addressFromBytes(t, 0x60)
+
+	xrpKey := insertNFTokenOfferEntry(t, svc, ownerAddr, 1, nftID, "2500000", 1, "", nil)
+	iouKey := insertNFTokenOfferEntry(t, svc, ownerAddr, 2, nftID,
+		map[string]any{"currency": "USD", "issuer": issuerAddr, "value": "100"},
+		1, destAddr, &exp)
+	insertNFTDir(t, svc, nftID, [][32]byte{xrpKey, iouKey}, true)
+
+	res, err := svc.GetNFTSellOffers(context.Background(), nftID, "current", 10, "")
+	if err != nil {
+		t.Fatalf("GetNFTSellOffers: %v", err)
+	}
+	if len(res.Offers) != 2 {
+		t.Fatalf("expected 2 sell offers, got %d", len(res.Offers))
+	}
+
+	byIndex := map[string]NFTOfferInfo{}
+	for _, o := range res.Offers {
+		byIndex[o.NFTOfferIndex] = o
+	}
+
+	xrpOffer := byIndex[formatHashHex(xrpKey)]
+	if amt, ok := xrpOffer.Amount.(string); !ok || amt != "2500000" {
+		t.Errorf("XRP offer amount = %v (%T), want \"2500000\"", xrpOffer.Amount, xrpOffer.Amount)
+	}
+	if xrpOffer.Owner != ownerAddr {
+		t.Errorf("XRP offer owner = %s, want %s", xrpOffer.Owner, ownerAddr)
+	}
+
+	iouOffer := byIndex[formatHashHex(iouKey)]
+	amtMap, ok := iouOffer.Amount.(map[string]string)
+	if !ok {
+		t.Fatalf("IOU offer amount should be a map, got %T", iouOffer.Amount)
+	}
+	if amtMap["currency"] != "USD" || amtMap["issuer"] != issuerAddr {
+		t.Errorf("IOU amount = %+v, want USD/%s", amtMap, issuerAddr)
+	}
+	if iouOffer.Destination != destAddr {
+		t.Errorf("destination = %s, want %s", iouOffer.Destination, destAddr)
+	}
+	if iouOffer.Expiration != exp {
+		t.Errorf("expiration = %d, want %d", iouOffer.Expiration, exp)
+	}
+}
+
+func TestGetNFTBuyOffers_Pagination(t *testing.T) {
+	svc := newOfferTestService(t)
+	ownerAddr, _ := addressFromBytes(t, 0x30)
+	nftID := nftIDFromByte(0x70)
+
+	const total = 3
+	keys := make([][32]byte, 0, total)
+	for i := 0; i < total; i++ {
+		k := insertNFTokenOfferEntry(t, svc, ownerAddr, uint32(i+1), nftID, "1000000", 0, "", nil)
+		keys = append(keys, k)
+	}
+	insertNFTDir(t, svc, nftID, keys, false)
+
+	// Page 1: limit 2 over 3 offers → 2 returned plus a marker.
+	page1, err := svc.GetNFTBuyOffers(context.Background(), nftID, "current", 2, "")
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if len(page1.Offers) != 2 {
+		t.Fatalf("page1 expected 2 offers, got %d", len(page1.Offers))
+	}
+	if page1.Marker == "" {
+		t.Fatalf("page1 must emit a marker when more offers remain")
+	}
+
+	// Page 2: feed the marker back → remaining offer, no further marker.
+	page2, err := svc.GetNFTBuyOffers(context.Background(), nftID, "current", 2, page1.Marker)
+	if err != nil {
+		t.Fatalf("page2: %v", err)
+	}
+	if page2.Marker != "" {
+		t.Errorf("page2 should not emit a marker, got %q", page2.Marker)
+	}
+
+	seen := map[string]bool{}
+	for _, o := range page1.Offers {
+		seen[o.NFTOfferIndex] = true
+	}
+	for _, o := range page2.Offers {
+		seen[o.NFTOfferIndex] = true
+	}
+	if len(seen) != total {
+		t.Fatalf("expected %d distinct offers across pages, got %d", total, len(seen))
+	}
+}
+
+func TestGetNFTOffers_InvalidMarkers(t *testing.T) {
+	svc := newOfferTestService(t)
+	ownerAddr, _ := addressFromBytes(t, 0x30)
+	nftID := nftIDFromByte(0x80)
+	otherNFT := nftIDFromByte(0x90)
+
+	k1 := insertNFTokenOfferEntry(t, svc, ownerAddr, 1, nftID, "1000000", 0, "", nil)
+	insertNFTDir(t, svc, nftID, [][32]byte{k1}, false)
+
+	// An offer for a different NFT, not in this directory.
+	wrongNFTKey := insertNFTokenOfferEntry(t, svc, ownerAddr, 2, otherNFT, "1000000", 0, "", nil)
+	// A well-formed offer for THIS nft but absent from the directory.
+	notInDirKey := insertNFTokenOfferEntry(t, svc, ownerAddr, 3, nftID, "1000000", 0, "", nil)
+
+	cases := []struct {
+		name   string
+		marker string
+	}{
+		{"non-hex", strings.Repeat("Z", 64)},
+		{"wrong-length", "DEADBEEF"},
+		{"wrong-nft", formatHashHex(wrongNFTKey)},
+		{"not-in-directory", formatHashHex(notInDirKey)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.GetNFTBuyOffers(context.Background(), nftID, "current", 2, tc.marker)
+			if !errors.Is(err, svcerr.ErrInvalidMarker) {
+				t.Fatalf("marker %q: want ErrInvalidMarker, got %v", tc.marker, err)
+			}
+		})
+	}
+}

--- a/internal/ledger/service/query_helpers_test.go
+++ b/internal/ledger/service/query_helpers_test.go
@@ -1,0 +1,280 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func TestNormalizeObjectType(t *testing.T) {
+	cases := map[string]string{
+		"account":             "AccountRoot",
+		"amendments":          "Amendments",
+		"amm":                 "AMM",
+		"bridge":              "Bridge",
+		"check":               "Check",
+		"credential":          "Credential",
+		"delegate":            "Delegate",
+		"deposit_preauth":     "DepositPreauth",
+		"did":                 "DID",
+		"directory":           "DirectoryNode",
+		"escrow":              "Escrow",
+		"fee":                 "FeeSettings",
+		"hashes":              "LedgerHashes",
+		"mptoken":             "MPToken",
+		"mpt_issuance":        "MPTokenIssuance",
+		"nft_offer":           "NFTokenOffer",
+		"nft_page":            "NFTokenPage",
+		"nunl":                "NegativeUNL",
+		"offer":               "Offer",
+		"oracle":              "Oracle",
+		"payment_channel":     "PayChannel",
+		"permissioned_domain": "PermissionedDomain",
+		"state":               "RippleState",
+		"signer_list":         "SignerList",
+		"ticket":              "Ticket",
+		"vault":               "Vault",
+		"":                    "", // passthrough default
+		"AlreadyPascal":       "AlreadyPascal",
+	}
+	for in, want := range cases {
+		if got := normalizeObjectType(in); got != want {
+			t.Errorf("normalizeObjectType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestGetLedgerEntryType(t *testing.T) {
+	codes := map[uint16]string{
+		55: "NFTokenOffer", 67: "Check", 73: "DID", 78: "NegativeUNL",
+		80: "NFTokenPage", 83: "SignerList", 84: "Ticket", 97: "AccountRoot",
+		100: "DirectoryNode", 102: "Amendments", 104: "LedgerHashes", 105: "Bridge",
+		111: "Offer", 112: "DepositPreauth", 113: "XChainOwnedClaimID", 114: "RippleState",
+		115: "FeeSettings", 117: "Escrow", 120: "PayChannel", 121: "AMM",
+		126: "MPTokenIssuance", 127: "MPToken", 128: "Oracle", 129: "Credential",
+		130: "PermissionedDomain", 131: "Delegate", 132: "Vault",
+	}
+	for code, want := range codes {
+		data := []byte{0x11, byte(code >> 8), byte(code & 0xff)}
+		if got := getLedgerEntryType(data); got != want {
+			t.Errorf("getLedgerEntryType(code=%d) = %q, want %q", code, got, want)
+		}
+	}
+
+	if got := getLedgerEntryType([]byte{0x11}); got != "" {
+		t.Errorf("short data must yield empty type, got %q", got)
+	}
+	if got := getLedgerEntryType([]byte{0x22, 0x00, 0x61}); got != "" {
+		t.Errorf("wrong field header must yield empty type, got %q", got)
+	}
+	if got := getLedgerEntryType([]byte{0x11, 0x00, 0x01}); got != "" {
+		t.Errorf("unknown type code must yield empty type, got %q", got)
+	}
+}
+
+func TestCalculateOfferQualityAndAmountValue(t *testing.T) {
+	q := calculateOfferQuality(tx.NewXRPAmount(200), tx.NewXRPAmount(100))
+	if q != "2" {
+		t.Errorf("quality 200/100 = %q, want 2", q)
+	}
+	if z := calculateOfferQuality(tx.NewXRPAmount(100), tx.NewXRPAmount(0)); z != "0" {
+		t.Errorf("zero gets must yield quality 0, got %q", z)
+	}
+	if v := parseAmountValue(tx.NewXRPAmount(42)); v != 42 {
+		t.Errorf("parseAmountValue(XRP 42) = %v, want 42", v)
+	}
+}
+
+func TestFormatRangeAndHashHex(t *testing.T) {
+	if r := formatRange(3, 9); r != "3-9" {
+		t.Errorf("formatRange = %q, want 3-9", r)
+	}
+	var h [32]byte
+	h[0] = 0xAB
+	h[31] = 0xCD
+	got := formatHashHex(h)
+	if len(got) != 64 || got != strings.ToUpper(got) {
+		t.Errorf("formatHashHex must be 64 upper-hex chars, got %q", got)
+	}
+	if got[:2] != "AB" || got[62:] != "CD" {
+		t.Errorf("formatHashHex byte mapping wrong: %q", got)
+	}
+}
+
+func TestHexDecode(t *testing.T) {
+	b, err := hexDecode("00AbCd")
+	if err != nil || len(b) != 3 || b[1] != 0xAB || b[2] != 0xCD {
+		t.Fatalf("hexDecode(00AbCd) = %x err=%v", b, err)
+	}
+	if _, err := hexDecode("ABC"); err == nil {
+		t.Errorf("odd-length hex must error")
+	}
+	if _, err := hexDecode("ZZ"); err == nil {
+		t.Errorf("invalid hex char must error")
+	}
+}
+
+func TestDecodeAccountIDLocal(t *testing.T) {
+	if _, err := decodeAccountIDLocal(""); err == nil {
+		t.Errorf("empty address must error")
+	}
+	if _, err := decodeAccountIDLocal("not-valid"); err == nil {
+		t.Errorf("invalid address must error")
+	}
+	addr, want := addressFromBytes(t, 0x33)
+	got, err := decodeAccountIDLocal(addr)
+	if err != nil || got != want {
+		t.Fatalf("decodeAccountIDLocal(%s) = %x err=%v, want %x", addr, got, err, want)
+	}
+}
+
+func TestSortStrings(t *testing.T) {
+	s := []string{"USD", "AAA", "EUR"}
+	sortStrings(s)
+	if s[0] != "AAA" || s[1] != "EUR" || s[2] != "USD" {
+		t.Errorf("sortStrings result = %v", s)
+	}
+}
+
+func TestGetLedgerEntry(t *testing.T) {
+	svc := newOfferTestService(t)
+	addr, idBytes := addressFromBytes(t, 0x10)
+	insertAccountRoot(t, svc, addr, 500_000_000, 0)
+
+	accKey := keylet.Account(idBytes)
+	res, err := svc.GetLedgerEntry(context.Background(), accKey.Key, "current")
+	if err != nil {
+		t.Fatalf("GetLedgerEntry: %v", err)
+	}
+	if len(res.Node) == 0 {
+		t.Errorf("Node data must be populated")
+	}
+	if res.Index != formatHashHex(accKey.Key) {
+		t.Errorf("index = %s, want %s", res.Index, formatHashHex(accKey.Key))
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		var missing [32]byte
+		missing[0] = 0xFE
+		_, err := svc.GetLedgerEntry(context.Background(), missing, "current")
+		if !errors.Is(err, svcerr.ErrLedgerEntryNotFound) {
+			t.Fatalf("want ErrLedgerEntryNotFound, got %v", err)
+		}
+	})
+}
+
+func TestGetLedgerData_HeaderAndPagination(t *testing.T) {
+	svc := newOfferTestService(t)
+	for i := byte(0x10); i <= 0x14; i++ {
+		addr, _ := addressFromBytes(t, i)
+		insertAccountRoot(t, svc, addr, 1_000_000_000, 0)
+	}
+
+	first, err := svc.GetLedgerData(context.Background(), "current", 1, "")
+	if err != nil {
+		t.Fatalf("GetLedgerData: %v", err)
+	}
+	if first.LedgerHeader == nil {
+		t.Errorf("first page (no marker) must include the ledger header")
+	}
+	if len(first.State) != 1 {
+		t.Fatalf("limit=1 must return 1 entry, got %d", len(first.State))
+	}
+	if first.Marker == "" {
+		t.Fatalf("more entries remain → marker must be set")
+	}
+
+	second, err := svc.GetLedgerData(context.Background(), "current", 1, first.Marker)
+	if err != nil {
+		t.Fatalf("GetLedgerData page2: %v", err)
+	}
+	if second.LedgerHeader != nil {
+		t.Errorf("marker page must omit the ledger header")
+	}
+	if len(second.State) == 0 {
+		t.Errorf("second page must return entries")
+	}
+	if second.State[0].Index == first.State[0].Index {
+		t.Errorf("pagination returned the marker entry again")
+	}
+}
+
+func TestGetLedgerRange(t *testing.T) {
+	svc := newOfferTestService(t)
+	res, err := svc.GetLedgerRange(context.Background(), 1, 3)
+	if err != nil {
+		t.Fatalf("GetLedgerRange: %v", err)
+	}
+	if res.LedgerFirst != 1 || res.LedgerLast != 3 {
+		t.Errorf("range = %d..%d, want 1..3", res.LedgerFirst, res.LedgerLast)
+	}
+	if res.Hashes == nil {
+		t.Errorf("Hashes map must be initialized")
+	}
+}
+
+func TestGetAutofillSequence(t *testing.T) {
+	svc := newOfferTestService(t)
+	addr, _ := addressFromBytes(t, 0x10)
+	insertAccountRoot(t, svc, addr, 1_000_000_000, 0) // Sequence = 1
+
+	t.Run("existing account", func(t *testing.T) {
+		seq, err := svc.GetAutofillSequence(addr, false)
+		if err != nil {
+			t.Fatalf("GetAutofillSequence: %v", err)
+		}
+		if seq != 1 {
+			t.Errorf("sequence = %d, want 1", seq)
+		}
+	})
+
+	t.Run("malformed address", func(t *testing.T) {
+		_, err := svc.GetAutofillSequence("bad", false)
+		if !errors.Is(err, svcerr.ErrAccountMalformed) {
+			t.Fatalf("want ErrAccountMalformed, got %v", err)
+		}
+	})
+
+	t.Run("missing account without ticket", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x99)
+		_, err := svc.GetAutofillSequence(stranger, false)
+		if !errors.Is(err, svcerr.ErrAccountNotFound) {
+			t.Fatalf("want ErrAccountNotFound, got %v", err)
+		}
+	})
+
+	t.Run("missing account with ticket → zero", func(t *testing.T) {
+		stranger, _ := addressFromBytes(t, 0x99)
+		seq, err := svc.GetAutofillSequence(stranger, true)
+		if err != nil {
+			t.Fatalf("ticket path must not error: %v", err)
+		}
+		if seq != 0 {
+			t.Errorf("ticket sequence must be 0, got %d", seq)
+		}
+	})
+}
+
+func TestGetTransaction_NotFound(t *testing.T) {
+	svc := newOfferTestService(t)
+	var hash [32]byte
+	hash[0] = 0xAA
+	_, err := svc.GetTransaction(hash)
+	if err == nil {
+		t.Fatalf("unknown transaction must error")
+	}
+}
+
+func TestGetCurrentFees_Defaults(t *testing.T) {
+	svc := newOfferTestService(t)
+	baseFee, reserveBase, reserveInc := svc.GetCurrentFees()
+	if baseFee == 0 || reserveBase == 0 || reserveInc == 0 {
+		t.Errorf("fees must be non-zero, got base=%d reserveBase=%d reserveInc=%d",
+			baseFee, reserveBase, reserveInc)
+	}
+}


### PR DESCRIPTION
## Summary

- Raises `internal/ledger/service` coverage from **37.9% → 71.6%** (cross-package, `-covermode=atomic`). `account_query.go` (was 6%) and `nft_query.go` (was 0%) are no longer near-zero — both now ~75–80%.
- Adds focused tests for the read RPCs backed by this package: `account_info`, `account_lines`, `account_offers`, `account_objects`, `account_channels`, `account_currencies`, `account_nfts`, `gateway_balances`, `noripple_check`, `deposit_authorized` (including on-ledger credential validation), and `nft_buy_offers`/`nft_sell_offers` pagination + marker handling. Also covers `ledger_query`/`tx_query` lookup helpers and `helpers.go` branch logic.
- **Bug fix uncovered while writing the tests:** `GetAccountLines` read the reserve bits (`lsfLowReserve`/`lsfHighReserve`) for the `no_ripple` and `authorized` response fields instead of `lsfLowNoRipple` (`0x00100000`) / `lsfLowAuth` (`0x00040000`). Verified against rippled `LedgerFormats.h`; replaced the hardcoded literals with the named `state` constants already used elsewhere in the file. `TestGetAccountLines_FlagMapping` pins the corrected mapping from both the low and high account perspectives.

## Test plan

- [x] `go test ./internal/ledger/service/... -count=1` — all green
- [x] `go test ./internal/ledger/service/... ./internal/rpc/... -coverpkg=./internal/ledger/service/... -covermode=atomic` → **71.6%**
- [x] `gofmt -l` clean, `go vet ./internal/ledger/service/` clean
- [x] rpc handler tests still pass (flag-bit fix introduces no regressions)

Fixes #750