### PR TITLE
fix: serialize DeliveredAmount metadata with the binary codec field name (#756)

### DIFF
--- a/internal/ledger/openledger/apply.go
+++ b/internal/ledger/openledger/apply.go
@@ -130,6 +130,16 @@ type ApplyConfig struct {
 func applyAndClassify(view *ledger.Ledger, bp *tx.BlockProcessor, transaction tx.Transaction, blob []byte, certainRetry bool, mode Mode, logger xrpllog.Logger) Result {
 	result, applyErr := bp.ApplyTransaction(transaction, blob)
 	if applyErr != nil {
+		// Surface the error rather than swallowing it. A non-nil applyErr
+		// drops the tx (no commit, no retry) while the engine may already
+		// have mutated state — yielding a ledger with advanced state but the
+		// tx absent from the tx tree (an empty/short-tx-tree consensus fork,
+		// e.g. metadata that failed to binary-serialize). Logged loud so a
+		// divergence shows the underlying error + tx.
+		logger.Warn("apply error — tx dropped (state may be mutated)",
+			"mode", mode,
+			"hash", fmt.Sprintf("%x", result.Hash[:8]),
+			"err", applyErr)
 		return ResultFailure
 	}
 	engineResult := result.ApplyResult.Result

--- a/internal/tx/serialize.go
+++ b/internal/tx/serialize.go
@@ -121,14 +121,20 @@ func MetadataToMap(meta *Metadata) map[string]any {
 		result["AffectedNodes"] = nodes
 	}
 
-	// DeliveredAmount (optional)
+	// DeliveredAmount (optional). The BINARY metadata field is sfDeliveredAmount
+	// (codec/definitions name "DeliveredAmount", type Amount). The snake_case
+	// "delivered_amount" is the RPC/JSON-only alias (see metadata.go ToMap) and
+	// is NOT a binarycodec field — emitting it here makes binarycodec.Encode
+	// fail with ErrUnknownField, which silently drops the tx from the consensus
+	// build while its state mutation persists, yielding a ledger with advanced
+	// state but an empty/short tx tree → transaction_hash fork.
 	if meta.DeliveredAmount != nil {
 		// Check if it's an XRP amount (no Currency field)
 		if meta.DeliveredAmount.Currency == "" {
-			result["delivered_amount"] = meta.DeliveredAmount.Value
+			result["DeliveredAmount"] = meta.DeliveredAmount.Value()
 		} else {
-			result["delivered_amount"] = map[string]any{
-				"value":    meta.DeliveredAmount.Value,
+			result["DeliveredAmount"] = map[string]any{
+				"value":    meta.DeliveredAmount.Value(),
 				"currency": meta.DeliveredAmount.Currency,
 				"issuer":   meta.DeliveredAmount.Issuer,
 			}

--- a/internal/tx/serialize_deliveredamount_test.go
+++ b/internal/tx/serialize_deliveredamount_test.go
@@ -1,0 +1,57 @@
+package tx
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+// Regression for the mixed-network empty-tx-tree fork: binary metadata
+// serialization keyed DeliveredAmount as the RPC/JSON name "delivered_amount"
+// (and read .Value as a method value, not a call), so binarycodec.Encode
+// failed with ErrUnknownField for any tx carrying a DeliveredAmount. That
+// error was swallowed in openledger.applyAndClassify (the tx was dropped from
+// the consensus build while its state mutation persisted), producing a ledger
+// with advanced state but a short/empty transaction tree → transaction_hash
+// divergence from rippled → consensus wedge.
+func TestSerializeMetadata_DeliveredAmount(t *testing.T) {
+	t.Run("XRP", func(t *testing.T) {
+		amt := state.NewXRPAmountFromInt(1_000_000)
+		meta := &Metadata{
+			TransactionResult: TesSUCCESS,
+			TransactionIndex:  0,
+			AffectedNodes:     []AffectedNode{},
+			DeliveredAmount:   &amt,
+		}
+		blob, err := SerializeMetadata(meta)
+		if err != nil {
+			t.Fatalf("SerializeMetadata with XRP DeliveredAmount must not error, got: %v", err)
+		}
+		if len(blob) == 0 {
+			t.Fatal("expected non-empty metadata blob")
+		}
+		decoded, err := binarycodec.Decode(strings.ToUpper(hex.EncodeToString(blob)))
+		if err != nil {
+			t.Fatalf("decode round-trip: %v", err)
+		}
+		if _, ok := decoded["DeliveredAmount"]; !ok {
+			t.Fatalf("DeliveredAmount missing from decoded binary metadata: %v", decoded)
+		}
+	})
+
+	t.Run("IOU", func(t *testing.T) {
+		amt := state.NewIssuedAmountFromValue(10, 0, "USD", "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
+		meta := &Metadata{
+			TransactionResult: TesSUCCESS,
+			TransactionIndex:  0,
+			AffectedNodes:     []AffectedNode{},
+			DeliveredAmount:   &amt,
+		}
+		if _, err := SerializeMetadata(meta); err != nil {
+			t.Fatalf("SerializeMetadata with IOU DeliveredAmount must not error, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Problem
On a mixed rippled+goXRPL network, goXRPL intermittently built a consensus ledger with **advanced state but an empty/short transaction tree** (`transaction_hash` diverges) → fork/wedge. Reproduced reliably early (cycle-2 of an instrumented soak driver, 3× in a row).

## Root cause
Binary metadata serialization keyed `DeliveredAmount` as the RPC/JSON name `"delivered_amount"` (and read `.Value` as a method value, not a call). The codec only knows `DeliveredAmount` (definitions.json, type Amount) → `binarycodec.Encode` returned `ErrUnknownField` for any tx carrying a `DeliveredAmount` (IOU partial payments, CheckCash DeliverMin). `applyAndClassify` **silently swallowed** the error (`ResultFailure`), dropping the tx from the build while its state mutation persisted → empty-tx-tree fork.

## Fix
- `serialize.go`: use codec field name `DeliveredAmount` + call `.Value()` in the binary path (`metadata.go` keeps `delivered_amount` for the RPC/JSON API — rippled-correct).
- `apply.go`: surface the previously-swallowed `applyErr` (a dropped tx with mutated state is a consensus hazard).
- Test: `TestSerializeMetadata_DeliveredAmount` (XRP + IOU round-trip; fails pre-fix).

## Verification
Instrumented soak (`build-prov`/`build-tx`, since removed) pinned it: forking ledger had `committed_txcount=0, pending=15, tx_root=0` + `applyErr "unknown field: delivered_amount"` ×N. `-race` build confirmed the consensus core is race-clean (deterministic). Post-fix: the cycle that forked 3× now runs clean; tx/payment/check/openledger/service suites + `go vet` pass.

## Not included (separate follow-up)
`applyAndClassify` leaving partial state on `applyErr` is a latent hazard — an internal apply error during a build should roll back/abort (rippled's apply is transactional) so no future serialization/internal error reproduces this class. And the remaining mixed-soak stall is the known #724 liveness (node-behind), orthogonal to this content fork.

Fixes #756