### PR TITLE
fix: emit sfDeliveredAmount only when delivered != requested (#760)

### DIFF
--- a/internal/testing/payment/delivered_amount_test.go
+++ b/internal/testing/payment/delivered_amount_test.go
@@ -1,0 +1,56 @@
+package payment
+
+import (
+	"testing"
+
+	testing_ "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// rippled sets sfDeliveredAmount in Payment metadata only when the delivered
+// amount differs from the requested Amount (Payment.cpp:495 actualAmountOut !=
+// dstAmount). A FULL delivery must omit it. goXRPL previously set it
+// unconditionally, which forked the transaction tree from rippled on full
+// (non-partial) IOU payments (identical account_hash, different
+// transaction_hash) — the mixed-network seq-~13 divergence.
+func TestPayment_DeliveredAmount_OnlyWhenPartial(t *testing.T) {
+	env := testing_.NewTestEnv(t)
+	gw := testing_.NewAccount("gw")
+	alice := testing_.NewAccount("alice")
+	bob := testing_.NewAccount("bob")
+	env.Fund(gw, alice, bob)
+
+	if r := env.Submit(trustset.TrustLine(alice, "USD", gw, "1000").Build()); !r.Success {
+		t.Fatalf("alice trustline: %s", r.Code)
+	}
+	if r := env.Submit(trustset.TrustLine(bob, "USD", gw, "1000").Build()); !r.Success {
+		t.Fatalf("bob trustline: %s", r.Code)
+	}
+	if r := env.Submit(PayIssued(gw, alice, tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)).Build()); !r.Success {
+		t.Fatalf("gw->alice issue: %s", r.Code)
+	}
+
+	// FULL payment: delivered == requested → NO DeliveredAmount.
+	full := env.Submit(PayIssued(alice, bob, tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)).Build())
+	if !full.Success {
+		t.Fatalf("full payment: %s", full.Code)
+	}
+	if full.Metadata != nil && full.Metadata.DeliveredAmount != nil {
+		t.Fatalf("FULL IOU payment must NOT set DeliveredAmount (rippled omits it); got %v",
+			full.Metadata.DeliveredAmount)
+	}
+
+	// PARTIAL payment: SendMax 20 < Amount 50 with tfPartialPayment → delivers
+	// 20 != 50 → DeliveredAmount IS set.
+	part := env.Submit(PayIssued(alice, bob, tx.NewIssuedAmountFromFloat64(50, "USD", gw.Address)).
+		SendMax(tx.NewIssuedAmountFromFloat64(20, "USD", gw.Address)).
+		PartialPayment().
+		Build())
+	if !part.Success {
+		t.Fatalf("partial payment: %s", part.Code)
+	}
+	if part.Metadata == nil || part.Metadata.DeliveredAmount == nil {
+		t.Fatal("PARTIAL IOU payment MUST set DeliveredAmount (delivered != requested)")
+	}
+}

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -401,9 +401,17 @@ func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destI
 		}
 	}
 
-	// Record delivered amount in metadata
+	// Record delivered amount in metadata only when it differs from the
+	// requested Amount. rippled sets sfDeliveredAmount only when
+	// actualAmountOut != dstAmount (Payment.cpp:495); a full delivery omits
+	// it. Emitting it unconditionally forks the transaction tree from rippled
+	// on full (non-partial) IOU payments — observed as a mixed-network
+	// transaction_hash divergence (identical account_hash) at low seqs before
+	// amendments settle.
 	deliveredAmt := FromEitherAmount(actualOut)
-	ctx.Metadata.DeliveredAmount = &deliveredAmt
+	if deliveredAmt.Compare(p.Amount) != 0 {
+		ctx.Metadata.DeliveredAmount = &deliveredAmt
+	}
 
 	// Offer deletions and trust line modifications tracked automatically by ApplyStateTable
 
@@ -539,7 +547,10 @@ func (p *Payment) applyIOUIssuePartial(ctx *tx.ApplyContext, dest *state.Account
 		return result, tx.Amount{}
 	}
 
-	ctx.Metadata.DeliveredAmount = &maxDeliverable
+	// Only when delivered != requested (rippled Payment.cpp:495).
+	if maxDeliverable.Compare(p.Amount) != 0 {
+		ctx.Metadata.DeliveredAmount = &maxDeliverable
+	}
 
 	return tx.TesSUCCESS, maxDeliverable
 }
@@ -630,7 +641,10 @@ func (p *Payment) applyIOURedeemPartial(ctx *tx.ApplyContext, dest *state.Accoun
 		return result, tx.Amount{}
 	}
 
-	ctx.Metadata.DeliveredAmount = &maxDeliverable
+	// Only when delivered != requested (rippled Payment.cpp:495).
+	if maxDeliverable.Compare(p.Amount) != 0 {
+		ctx.Metadata.DeliveredAmount = &maxDeliverable
+	}
 
 	return tx.TesSUCCESS, maxDeliverable
 }
@@ -848,7 +862,10 @@ func (p *Payment) applyIOUTransferPartial(ctx *tx.ApplyContext, dest *state.Acco
 		return tx.TefINTERNAL, tx.Amount{}
 	}
 
-	ctx.Metadata.DeliveredAmount = &maxDeliverable
+	// Only when delivered != requested (rippled Payment.cpp:495).
+	if maxDeliverable.Compare(p.Amount) != 0 {
+		ctx.Metadata.DeliveredAmount = &maxDeliverable
+	}
 
 	return tx.TesSUCCESS, maxDeliverable
 }


### PR DESCRIPTION
Gates the four `payment_iou.go` DeliveredAmount setters on `delivered.Compare(p.Amount) != 0`, matching rippled `Payment.cpp:495` (`actualAmountOut != dstAmount`). Full IOU payments previously emitted `sfDeliveredAmount` where rippled omits it → identical account_hash, different transaction_hash → mixed-network fork (captured live via binary meta_blob diff at seq ~13; JSON masked it because rippled's RPC computes delivered_amount for display). Test: `delivered_amount_test.go` (full omits, partial sets). Distinct from #756 (that fixed the binary field name; this fixes whether it's emitted). Fixes #760