### PR TITLE
Promote develop → main: metadata-determinism consensus-fork fixes (#745, #757, #758, #761)

### DIFF
--- a/internal/ledger/openledger/apply.go
+++ b/internal/ledger/openledger/apply.go
@@ -130,6 +130,16 @@ type ApplyConfig struct {
 func applyAndClassify(view *ledger.Ledger, bp *tx.BlockProcessor, transaction tx.Transaction, blob []byte, certainRetry bool, mode Mode, logger xrpllog.Logger) Result {
 	result, applyErr := bp.ApplyTransaction(transaction, blob)
 	if applyErr != nil {
+		// Surface the error rather than swallowing it. A non-nil applyErr
+		// drops the tx (no commit, no retry) while the engine may already
+		// have mutated state — yielding a ledger with advanced state but the
+		// tx absent from the tx tree (an empty/short-tx-tree consensus fork,
+		// e.g. metadata that failed to binary-serialize). Logged loud so a
+		// divergence shows the underlying error + tx.
+		logger.Warn("apply error — tx dropped (state may be mutated)",
+			"mode", mode,
+			"hash", fmt.Sprintf("%x", result.Hash[:8]),
+			"err", applyErr)
 		return ResultFailure
 	}
 	engineResult := result.ApplyResult.Result

--- a/internal/ledger/openledger/metadata_determinism_test.go
+++ b/internal/ledger/openledger/metadata_determinism_test.go
@@ -1,0 +1,148 @@
+package openledger_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
+	testenv "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/LeJamon/go-xrpl/internal/testing/offer"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// Reproduction for the mixed-soak non-deterministic metadata fork (iter-5
+// seq-70 / #724 core): two goXRPL nodes running the same binary built the same
+// agreed tx-set on the same parent and produced the SAME account_hash but
+// DIFFERENT transaction_hash (byte-identical JSON metadata, different binary
+// tx-tree). That is invisible to -race (map-iteration order, not a data race)
+// and normalized away in JSON. This builds the same set on the same parent N
+// times in ONE process (Go re-randomizes map iteration per range), asserting
+// transaction_hash is identical every time. A failure pins the divergence to
+// metadata generation; bisect the apply_state_table map iterations next.
+func TestBuildDeterminism_TransactionHash(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+
+	g := testenv.NewAccount("gateway")
+	a := testenv.NewAccount("alice")
+	b := testenv.NewAccount("bob")
+	d := testenv.NewAccount("dave")
+	c := testenv.NewAccount("carol")
+	env.Fund(g, a, b, d, c)
+
+	usd := func(v float64) tx.Amount { return tx.NewIssuedAmountFromFloat64(v, "USD", g.Address) }
+	gSeq, aSeq, bSeq, dSeq, cSeq := env.Seq(g), env.Seq(a), env.Seq(b), env.Seq(d), env.Seq(c)
+
+	// Offer-crossing set: A, B, D each rest a SAME-QUALITY sell-USD offer
+	// (10 USD for 10 XRP); C crosses all three with one 30-XRP-for-30-USD
+	// buy. Which resting offer C consumes first (and the per-offer fill
+	// metadata) must be a deterministic book order — if goXRPL selects
+	// candidates via a map, the crossing sequence (hence metadata) varies
+	// run-to-run while the final state is identical.
+	type spec struct {
+		txn    tx.Transaction
+		signer *testenv.Account
+	}
+	sellUSD := func(acct *testenv.Account, seq uint32) tx.Transaction {
+		// taker pays 10 XRP, gets 10 USD → owner gives USD, gets XRP.
+		return offer.OfferCreate(acct, tx.NewXRPAmount(10_000_000), usd(10)).Sequence(seq).Build()
+	}
+	specs := []spec{
+		{trustset.TrustSet(a, usd(1000)).Sequence(aSeq).Build(), a},
+		{trustset.TrustSet(b, usd(1000)).Sequence(bSeq).Build(), b},
+		{trustset.TrustSet(d, usd(1000)).Sequence(dSeq).Build(), d},
+		{trustset.TrustSet(c, usd(1000)).Sequence(cSeq).Build(), c},
+		{payment.PayIssued(g, a, usd(100)).Sequence(gSeq).Build(), g},
+		{payment.PayIssued(g, b, usd(100)).Sequence(gSeq + 1).Build(), g},
+		{payment.PayIssued(g, d, usd(100)).Sequence(gSeq + 2).Build(), g},
+		{sellUSD(a, aSeq+1), a},
+		{sellUSD(b, bSeq+1), b},
+		{sellUSD(d, dSeq+1), d},
+		// C crosses all three: taker pays 30 USD, gets 30 XRP → C gives 30 XRP, gets 30 USD.
+		{offer.OfferCreate(c, usd(30), tx.NewXRPAmount(30_000_000)).Sequence(cSeq + 1).Build(), c},
+	}
+
+	// Cross-account escrows (scenario focus): each threads the source AND
+	// destination owner directories — the multi-owner threading path
+	// (apply_state_table threadOwners) suspected of map-order leakage.
+	const finishAfter = uint32(4_000_000_000) // far future, won't finish
+	esc := func(from, to *testenv.Account, amt int64, seq uint32) tx.Transaction {
+		return escrow.EscrowCreate(from, to, amt).FinishAfter(finishAfter).Sequence(seq).Build()
+	}
+	specs = append(specs,
+		spec{esc(a, b, 1_000_000, aSeq+2), a},
+		spec{esc(a, c, 1_000_000, aSeq+3), a},
+		spec{esc(b, c, 1_000_000, bSeq+2), b},
+		spec{esc(b, d, 1_000_000, bSeq+3), b},
+		spec{esc(d, a, 1_000_000, dSeq+2), d},
+		spec{esc(d, c, 1_000_000, dSeq+3), d},
+		spec{esc(c, a, 1_000_000, cSeq+2), c},
+		spec{esc(c, b, 1_000_000, cSeq+3), c},
+	)
+
+	var pending []openledger.PendingTx
+	for _, s := range specs {
+		blob := buildSignedBlob(t, env, s.txn, s.signer)
+		pt, err := openledger.ParsePendingTx(blob)
+		if err != nil {
+			t.Fatalf("ParsePendingTx: %v", err)
+		}
+		pending = append(pending, pt)
+	}
+	openledger.CanonicalSort(pending, openledger.ComputeSalt(pending))
+
+	env.Close()
+	parent := env.LastClosedLedger()
+	if parent == nil {
+		t.Fatal("no parent ledger")
+	}
+	closeTime := time.Unix(1_000_000, 0)
+
+	cfg := openledger.ApplyConfig{
+		BaseFee:          10,
+		ReserveBase:      200_000_000,
+		ReserveIncrement: 50_000_000,
+		LedgerSequence:   parent.Sequence() + 1,
+		NetworkID:        0,
+		Rules:            amendment.AllSupportedRules(),
+		Mode:             openledger.BuildLedgerMode,
+	}
+
+	const N = 30
+	var firstTx, firstState [32]byte
+	var firstCommitted uint32
+	for i := 0; i < N; i++ {
+		view, err := ledger.NewOpen(parent, closeTime)
+		if err != nil {
+			t.Fatalf("NewOpen[%d]: %v", i, err)
+		}
+		var retries []openledger.PendingTx
+		if err := openledger.ApplyTxs(view, pending, &retries, cfg); err != nil {
+			t.Fatalf("ApplyTxs[%d]: %v", i, err)
+		}
+		if err := view.Close(closeTime, 0); err != nil {
+			t.Fatalf("Close[%d]: %v", i, err)
+		}
+		th, _ := view.TxMapHash()
+		sh, _ := view.StateMapHash()
+		cc := view.TxCount()
+		if i == 0 {
+			firstTx, firstState, firstCommitted = th, sh, cc
+			t.Logf("iter0: tx_root=%x state_root=%x committed=%d/%d", th[:8], sh[:8], cc, len(pending))
+			continue
+		}
+		if th != firstTx {
+			t.Fatalf("NON-DETERMINISTIC transaction_hash at iter %d: %x != %x (account_hash %x vs %x; committed %d vs %d) — metadata-generation map-iteration leak",
+				i, th[:8], firstTx[:8], sh[:8], firstState[:8], cc, firstCommitted)
+		}
+		if sh != firstState {
+			t.Fatalf("NON-DETERMINISTIC account_hash at iter %d: %x != %x", i, sh[:8], firstState[:8])
+		}
+	}
+	t.Logf("all %d in-process builds identical: tx_root=%x state_root=%x committed=%d", N, firstTx[:8], firstState[:8], firstCommitted)
+}

--- a/internal/testing/accountset/accounttxnid_tec_test.go
+++ b/internal/testing/accountset/accounttxnid_tec_test.go
@@ -1,0 +1,63 @@
+package accountset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// rippled updates sfAccountTxnID in the Transactor::apply() preamble
+// (Transactor.cpp:568) BEFORE doApply(). On a tec result that whole preamble
+// is rolled back by reset() (Transactor.cpp:1001 ctx_.discard()), which then
+// re-applies ONLY sfBalance (fee) and sfSequence — never sfAccountTxnID. So a
+// tec must leave AccountTxnID at its prior value; only a successful tx updates
+// it.
+//
+// Regression for the mixed-soak fork (iter-5 seq-70, soak#1 seq-39): goXRPL's
+// tec-recovery path updated AccountTxnID, so a tec tx from an asfAccountTxnID
+// account produced metadata (and, when it raced, a transaction_hash) that
+// diverged from rippled while account_hash matched — wedging consensus.
+func TestAccountTxnID_NotUpdatedOnTec(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	ghost := jtx.NewAccount("ghost") // unfunded → alice's payment to it tecs
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	readTxnID := func() [32]byte {
+		t.Helper()
+		data, err := env.LedgerEntry(keylet.Account(alice.ID))
+		require.NoError(t, err)
+		ar, err := state.ParseAccountRootFromBytes(data)
+		require.NoError(t, err)
+		return ar.AccountTxnID
+	}
+
+	// Enable asfAccountTxnID (present, value zero).
+	r := env.Submit(AccountSet(alice).SetFlag(5).Build())
+	jtx.RequireTxSuccess(t, r)
+	env.Close()
+
+	// A successful tx must update AccountTxnID (rippled preamble survives).
+	r = env.Submit(AccountSet(alice).Build()) // noop success
+	jtx.RequireTxSuccess(t, r)
+	env.Close()
+	afterSuccess := readTxnID()
+	require.NotEqual(t, [32]byte{}, afterSuccess, "a successful tx must set AccountTxnID")
+
+	// A tec tx must NOT change AccountTxnID (rippled reset() re-applies only
+	// fee+seq). Payment of 1 XRP to an unfunded account is below reserve →
+	// tecNO_DST_INSUF_XRP, applied (fee claimed) but unsuccessful.
+	r = env.Submit(payment.Pay(alice, ghost, uint64(jtx.XRP(1))).Build())
+	require.False(t, r.Success, "payment below reserve to an unfunded dest must tec, got %s", r.Code)
+	require.Contains(t, r.Code, "tec", "expected a tec result, got %s", r.Code)
+	env.Close()
+	afterTec := readTxnID()
+	require.Equal(t, afterSuccess, afterTec,
+		"a tec tx must NOT update AccountTxnID — rippled reset() discards the preamble and re-applies only fee+seq")
+}

--- a/internal/testing/payment/delivered_amount_test.go
+++ b/internal/testing/payment/delivered_amount_test.go
@@ -1,0 +1,56 @@
+package payment
+
+import (
+	"testing"
+
+	testing_ "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// rippled sets sfDeliveredAmount in Payment metadata only when the delivered
+// amount differs from the requested Amount (Payment.cpp:495 actualAmountOut !=
+// dstAmount). A FULL delivery must omit it. goXRPL previously set it
+// unconditionally, which forked the transaction tree from rippled on full
+// (non-partial) IOU payments (identical account_hash, different
+// transaction_hash) — the mixed-network seq-~13 divergence.
+func TestPayment_DeliveredAmount_OnlyWhenPartial(t *testing.T) {
+	env := testing_.NewTestEnv(t)
+	gw := testing_.NewAccount("gw")
+	alice := testing_.NewAccount("alice")
+	bob := testing_.NewAccount("bob")
+	env.Fund(gw, alice, bob)
+
+	if r := env.Submit(trustset.TrustLine(alice, "USD", gw, "1000").Build()); !r.Success {
+		t.Fatalf("alice trustline: %s", r.Code)
+	}
+	if r := env.Submit(trustset.TrustLine(bob, "USD", gw, "1000").Build()); !r.Success {
+		t.Fatalf("bob trustline: %s", r.Code)
+	}
+	if r := env.Submit(PayIssued(gw, alice, tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)).Build()); !r.Success {
+		t.Fatalf("gw->alice issue: %s", r.Code)
+	}
+
+	// FULL payment: delivered == requested → NO DeliveredAmount.
+	full := env.Submit(PayIssued(alice, bob, tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)).Build())
+	if !full.Success {
+		t.Fatalf("full payment: %s", full.Code)
+	}
+	if full.Metadata != nil && full.Metadata.DeliveredAmount != nil {
+		t.Fatalf("FULL IOU payment must NOT set DeliveredAmount (rippled omits it); got %v",
+			full.Metadata.DeliveredAmount)
+	}
+
+	// PARTIAL payment: SendMax 20 < Amount 50 with tfPartialPayment → delivers
+	// 20 != 50 → DeliveredAmount IS set.
+	part := env.Submit(PayIssued(alice, bob, tx.NewIssuedAmountFromFloat64(50, "USD", gw.Address)).
+		SendMax(tx.NewIssuedAmountFromFloat64(20, "USD", gw.Address)).
+		PartialPayment().
+		Build())
+	if !part.Success {
+		t.Fatalf("partial payment: %s", part.Code)
+	}
+	if part.Metadata == nil || part.Metadata.DeliveredAmount == nil {
+		t.Fatal("PARTIAL IOU payment MUST set DeliveredAmount (delivered != requested)")
+	}
+}

--- a/internal/tx/do_apply.go
+++ b/internal/tx/do_apply.go
@@ -593,18 +593,15 @@ func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *ApplyStateTable,
 	recoveredAccount.PreviousTxnID = st.txHash
 	recoveredAccount.PreviousTxnLgrSeq = e.config.LedgerSequence
 
-	// Update AccountTxnID if the account has tracking enabled (field present).
-	// On the success path, apply() sets this before doApply(). On the tec path,
-	// reset() discards all changes then re-applies fee/sequence. The AccountTxnID
-	// must also be updated here so the account tracks the last-applied transaction
-	// even when the result is a tec code. Keyed on presence, not non-zero, so a
-	// freshly-enabled present-zero field is still updated.
-	// Reference: rippled Transactor::apply() lines 568-569.
-	{
-		if recoveredAccount.HasAccountTxnID {
-			recoveredAccount.AccountTxnID = st.txHash
-		}
-	}
+	// Do NOT update sfAccountTxnID on the tec path. rippled updates it in the
+	// apply() preamble (Transactor.cpp:568) BEFORE doApply(); on a tec that
+	// whole preamble is rolled back by reset() (Transactor.cpp:1001
+	// ctx_.discard()), which then re-applies only sfBalance (fee) and
+	// sfSequence — never sfAccountTxnID. So a tec leaves AccountTxnID at its
+	// prior value. recoveredAccount is re-parsed from the original account, so
+	// simply not touching it preserves that prior value, matching rippled.
+	// (Updating it here forked account metadata on tec txs from asfAccountTxnID
+	// accounts — transaction_hash diverged while account_hash matched.)
 
 	updatedData, err := state.SerializeAccountRoot(recoveredAccount)
 	if err != nil {

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -401,9 +401,17 @@ func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destI
 		}
 	}
 
-	// Record delivered amount in metadata
+	// Record delivered amount in metadata only when it differs from the
+	// requested Amount. rippled sets sfDeliveredAmount only when
+	// actualAmountOut != dstAmount (Payment.cpp:495); a full delivery omits
+	// it. Emitting it unconditionally forks the transaction tree from rippled
+	// on full (non-partial) IOU payments — observed as a mixed-network
+	// transaction_hash divergence (identical account_hash) at low seqs before
+	// amendments settle.
 	deliveredAmt := FromEitherAmount(actualOut)
-	ctx.Metadata.DeliveredAmount = &deliveredAmt
+	if deliveredAmt.Compare(p.Amount) != 0 {
+		ctx.Metadata.DeliveredAmount = &deliveredAmt
+	}
 
 	// Offer deletions and trust line modifications tracked automatically by ApplyStateTable
 
@@ -539,7 +547,10 @@ func (p *Payment) applyIOUIssuePartial(ctx *tx.ApplyContext, dest *state.Account
 		return result, tx.Amount{}
 	}
 
-	ctx.Metadata.DeliveredAmount = &maxDeliverable
+	// Only when delivered != requested (rippled Payment.cpp:495).
+	if maxDeliverable.Compare(p.Amount) != 0 {
+		ctx.Metadata.DeliveredAmount = &maxDeliverable
+	}
 
 	return tx.TesSUCCESS, maxDeliverable
 }
@@ -630,7 +641,10 @@ func (p *Payment) applyIOURedeemPartial(ctx *tx.ApplyContext, dest *state.Accoun
 		return result, tx.Amount{}
 	}
 
-	ctx.Metadata.DeliveredAmount = &maxDeliverable
+	// Only when delivered != requested (rippled Payment.cpp:495).
+	if maxDeliverable.Compare(p.Amount) != 0 {
+		ctx.Metadata.DeliveredAmount = &maxDeliverable
+	}
 
 	return tx.TesSUCCESS, maxDeliverable
 }
@@ -848,7 +862,10 @@ func (p *Payment) applyIOUTransferPartial(ctx *tx.ApplyContext, dest *state.Acco
 		return tx.TefINTERNAL, tx.Amount{}
 	}
 
-	ctx.Metadata.DeliveredAmount = &maxDeliverable
+	// Only when delivered != requested (rippled Payment.cpp:495).
+	if maxDeliverable.Compare(p.Amount) != 0 {
+		ctx.Metadata.DeliveredAmount = &maxDeliverable
+	}
 
 	return tx.TesSUCCESS, maxDeliverable
 }

--- a/internal/tx/serialize.go
+++ b/internal/tx/serialize.go
@@ -121,14 +121,20 @@ func MetadataToMap(meta *Metadata) map[string]any {
 		result["AffectedNodes"] = nodes
 	}
 
-	// DeliveredAmount (optional)
+	// DeliveredAmount (optional). The BINARY metadata field is sfDeliveredAmount
+	// (codec/definitions name "DeliveredAmount", type Amount). The snake_case
+	// "delivered_amount" is the RPC/JSON-only alias (see metadata.go ToMap) and
+	// is NOT a binarycodec field — emitting it here makes binarycodec.Encode
+	// fail with ErrUnknownField, which silently drops the tx from the consensus
+	// build while its state mutation persists, yielding a ledger with advanced
+	// state but an empty/short tx tree → transaction_hash fork.
 	if meta.DeliveredAmount != nil {
 		// Check if it's an XRP amount (no Currency field)
 		if meta.DeliveredAmount.Currency == "" {
-			result["delivered_amount"] = meta.DeliveredAmount.Value
+			result["DeliveredAmount"] = meta.DeliveredAmount.Value()
 		} else {
-			result["delivered_amount"] = map[string]any{
-				"value":    meta.DeliveredAmount.Value,
+			result["DeliveredAmount"] = map[string]any{
+				"value":    meta.DeliveredAmount.Value(),
 				"currency": meta.DeliveredAmount.Currency,
 				"issuer":   meta.DeliveredAmount.Issuer,
 			}

--- a/internal/tx/serialize_deliveredamount_test.go
+++ b/internal/tx/serialize_deliveredamount_test.go
@@ -1,0 +1,57 @@
+package tx
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+// Regression for the mixed-network empty-tx-tree fork: binary metadata
+// serialization keyed DeliveredAmount as the RPC/JSON name "delivered_amount"
+// (and read .Value as a method value, not a call), so binarycodec.Encode
+// failed with ErrUnknownField for any tx carrying a DeliveredAmount. That
+// error was swallowed in openledger.applyAndClassify (the tx was dropped from
+// the consensus build while its state mutation persisted), producing a ledger
+// with advanced state but a short/empty transaction tree → transaction_hash
+// divergence from rippled → consensus wedge.
+func TestSerializeMetadata_DeliveredAmount(t *testing.T) {
+	t.Run("XRP", func(t *testing.T) {
+		amt := state.NewXRPAmountFromInt(1_000_000)
+		meta := &Metadata{
+			TransactionResult: TesSUCCESS,
+			TransactionIndex:  0,
+			AffectedNodes:     []AffectedNode{},
+			DeliveredAmount:   &amt,
+		}
+		blob, err := SerializeMetadata(meta)
+		if err != nil {
+			t.Fatalf("SerializeMetadata with XRP DeliveredAmount must not error, got: %v", err)
+		}
+		if len(blob) == 0 {
+			t.Fatal("expected non-empty metadata blob")
+		}
+		decoded, err := binarycodec.Decode(strings.ToUpper(hex.EncodeToString(blob)))
+		if err != nil {
+			t.Fatalf("decode round-trip: %v", err)
+		}
+		if _, ok := decoded["DeliveredAmount"]; !ok {
+			t.Fatalf("DeliveredAmount missing from decoded binary metadata: %v", decoded)
+		}
+	})
+
+	t.Run("IOU", func(t *testing.T) {
+		amt := state.NewIssuedAmountFromValue(10, 0, "USD", "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
+		meta := &Metadata{
+			TransactionResult: TesSUCCESS,
+			TransactionIndex:  0,
+			AffectedNodes:     []AffectedNode{},
+			DeliveredAmount:   &amt,
+		}
+		if _, err := SerializeMetadata(meta); err != nil {
+			t.Fatalf("SerializeMetadata with IOU DeliveredAmount must not error, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Promotes the verified consensus-determinism fixes accumulated on `develop` since the last promotion. All are root-caused against rippled, unit-tested, and confirmed on the mixed rippled 2.6.2 + go-xrpl soak.

## Fixes (develop → main)
- **#744 / PR #745** — do **not** update `sfAccountTxnID` on the tec path. rippled's `reset()` discards the apply preamble and re-applies only fee+sequence (Transactor.cpp:1001); goXRPL wrongly re-applied AccountTxnID → tec txs from asfAccountTxnID accounts forked `transaction_hash`.
- **#756 / PR #757** — serialize `DeliveredAmount` metadata under the **binary codec field name** (`DeliveredAmount`, not the RPC snake_case `delivered_amount`) and call `.Value()`. The wrong key made `binarycodec.Encode` error; the error was silently swallowed in `applyAndClassify`, dropping the tx from the build while state was mutated → empty/short tx tree → fork.
- **PR #758** — consensus-build metadata-determinism **regression guard** (test only): builds the same agreed set N× and asserts identical `transaction_hash`/`account_hash`.
- **#760 / PR #761** — emit `sfDeliveredAmount` **only when delivered != requested** (rippled Payment.cpp:495 `actualAmountOut != dstAmount`); goXRPL set it unconditionally on every IOU payment → full IOU payments forked `transaction_hash` (identical `account_hash`) from rippled.

## Verification
Each fix: rippled-rule match + unit test + green suites. The two DeliveredAmount bugs and the tec-AccountTxnID bug were **caught live** via a `spread>0` binary-ledger-capture watcher and pinned by byte-diffing the divergent meta blobs (the RPC JSON masked them — rippled computes `delivered_amount` for display on both sides). Post-fix, **5 consecutive capture-cycle soaks ran with zero content forks** (the fork reliably appeared by cycle 3 before).

## Status
The deterministic **content-fork** class that blocked every prior soak is, as far as live binary capture can find, resolved. The remaining mixed-soak stalls are the known **#724 liveness/catch-up** class (a goXRPL node falls behind → `tracking`, `applyErr=0`, hashes agree — not a content fork), which is a separate effort.

## Note
`main` already contains the WebSocket concurrent-write fix (#746 / PR #747) which is **not** on `develop`; this promotion does not touch it (different files), and `develop` should be synced with `main` afterward so it carries #747.