### PR TITLE
feat: wire cluster peer resource gossip into the resource manager

### DIFF
--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -11,6 +11,7 @@ import (
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -35,8 +36,10 @@ const peerSendQueueDropThreshold = (DefaultSendBufferSize * 3) / 4
 // loop we recompute the cluster-fee median over members reported
 // within the last clusterFeeWindow and forward it through
 // clusterFeeSink, mirroring rippled PeerImp.cpp:1175-1193 which calls
-// getFeeTrack().setClusterFee(median). The LoadSource gossip
-// (resource-manager bytes accounting) is still unimplemented.
+// getFeeTrack().setClusterFee(median). The trailing LoadSource gossip
+// is imported into the resource manager so per-source charge
+// accounting is shared across the cluster, mirroring rippled
+// PeerImp.cpp:1157-1172.
 func (o *Overlay) handleClusterMessage(evt Event) {
 	o.peersMu.RLock()
 	peer, exists := o.peers[evt.PeerID]
@@ -52,7 +55,8 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 		o.IncPeerBadData(evt.PeerID, "cluster-no-pubkey")
 		return
 	}
-	if _, ok := o.cluster.Member(pubToken.Bytes()); !ok {
+	member, isMember := o.cluster.Member(pubToken.Bytes())
+	if !isMember {
 		slog.Debug("TMCluster from non-cluster peer; dropping",
 			"t", "Overlay", "peer", evt.PeerID)
 		o.IncPeerBadData(evt.PeerID, "cluster-not-member")
@@ -99,10 +103,66 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 		}
 	}
 
-	// LoadSource gossip → Resource::Manager: not implemented in
-	// go-xrpl. The field is parsed by message.Decode so we don't
-	// re-validate, but we don't propagate it anywhere. When go-xrpl
-	// grows a resource manager this is the call site to wire in.
+	// LoadSource gossip → resource manager. Mirrors rippled
+	// PeerImp.cpp:1157-1172: when the frame carries at least one
+	// TMLoadSource, build a resource.Gossip from the entries whose
+	// name parses as an IP endpoint (rippled drops the rest via the
+	// `item.address != Endpoint()` guard at PeerImp.cpp:1168 while
+	// keeping the rest of the frame) and import it under this cluster
+	// peer's identity. importConsumers is then called for the whole
+	// frame even if every item was filtered out, matching rippled's
+	// gate on the raw loadsources count rather than the surviving set.
+	if o.resourceManager != nil && len(cm.LoadSources) != 0 {
+		gossip := resource.Gossip{Items: make([]resource.GossipItem, 0, len(cm.LoadSources))}
+		for _, src := range cm.LoadSources {
+			if !validGossipAddress(src.Name) {
+				continue
+			}
+			gossip.Items = append(gossip.Items, resource.GossipItem{
+				Address: src.Name,
+				Balance: int(src.Cost),
+			})
+		}
+		o.resourceManager.ImportConsumers(clusterGossipOrigin(member.Name, pubToken), gossip)
+	}
+}
+
+// validGossipAddress reports whether name parses as the IP endpoint that
+// a TMLoadSource carries. Mirrors rippled's
+// beast::IP::Endpoint::from_string + `!= Endpoint()` guard at
+// PeerImp.cpp:1166-1168, which silently drops a load source whose name
+// is not an address. Both the rippled "ip:port" form (its exported keys
+// canonicalise to port 0) and go-xrpl's bare-host form (resource keys
+// strip the inbound port — see resource.normalizeAddr) are accepted so
+// cluster gossip round-trips between the two implementations.
+func validGossipAddress(name string) bool {
+	if name == "" {
+		return false
+	}
+	if host, _, err := net.SplitHostPort(name); err == nil {
+		return net.ParseIP(host) != nil
+	}
+	return net.ParseIP(name) != nil
+}
+
+// clusterGossipOrigin derives the stable per-peer key under which a
+// cluster member's gossip is imported, so a later snapshot from the
+// same member replaces (rather than stacks onto) its prior
+// contribution. Mirrors rippled's use of PeerImp::name() — the
+// configured cluster-node name — at PeerImp.cpp:1171. When that name is
+// empty we fall back to the peer's base58 node identity so two unnamed
+// cluster members don't collide on the empty-string origin and corrupt
+// each other's import accounting.
+func clusterGossipOrigin(name string, pub *PublicKeyToken) string {
+	if name != "" {
+		return name
+	}
+	if pub != nil {
+		if encoded, err := addresscodec.EncodeNodePublicKey(pub.Bytes()); err == nil {
+			return encoded
+		}
+	}
+	return name
 }
 
 // handleGetObjectsMessage processes mtGET_OBJECTS from a peer. Mirrors

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -7,6 +7,7 @@ package peermanagement
 import (
 	"log/slog"
 	"net"
+	"strconv"
 	"time"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -109,9 +110,11 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 	// name parses as an IP endpoint (rippled drops the rest via the
 	// `item.address != Endpoint()` guard at PeerImp.cpp:1168 while
 	// keeping the rest of the frame) and import it under this cluster
-	// peer's identity. importConsumers is then called for the whole
-	// frame even if every item was filtered out, matching rippled's
-	// gate on the raw loadsources count rather than the surviving set.
+	// peer's configured name — rippled's importConsumers(name(), …) at
+	// PeerImp.cpp:1171, where name() is the empty string for an unnamed
+	// member. importConsumers is then called for the whole frame even if
+	// every item was filtered out, matching rippled's gate on the raw
+	// loadsources count rather than the surviving set.
 	if o.resourceManager != nil && len(cm.LoadSources) != 0 {
 		gossip := resource.Gossip{Items: make([]resource.GossipItem, 0, len(cm.LoadSources))}
 		for _, src := range cm.LoadSources {
@@ -123,7 +126,7 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 				Balance: int(src.Cost),
 			})
 		}
-		o.resourceManager.ImportConsumers(clusterGossipOrigin(member.Name, pubToken), gossip)
+		o.resourceManager.ImportConsumers(member.Name, gossip)
 	}
 }
 
@@ -131,38 +134,27 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 // a TMLoadSource carries. Mirrors rippled's
 // beast::IP::Endpoint::from_string + `!= Endpoint()` guard at
 // PeerImp.cpp:1166-1168, which silently drops a load source whose name
-// is not an address. Both the rippled "ip:port" form (its exported keys
-// canonicalise to port 0) and go-xrpl's bare-host form (resource keys
-// strip the inbound port — see resource.normalizeAddr) are accepted so
-// cluster gossip round-trips between the two implementations.
+// is not a valid endpoint. Both the rippled "ip:port" form (its exported
+// keys canonicalise to port 0) and go-xrpl's bare-host form (resource
+// keys strip the inbound port — see resource.normalizeAddr) round-trip.
+// The port is range-checked as a uint16 to match from_string, which
+// parses it into a uint16 and fails on an out-of-range or non-numeric
+// port (IPEndpoint.cpp:179-182); net.ParseIP already rejects anything
+// longer than from_string_checked's 64-char cap, so no separate guard.
 func validGossipAddress(name string) bool {
 	if name == "" {
 		return false
 	}
-	if host, _, err := net.SplitHostPort(name); err == nil {
-		return net.ParseIP(host) != nil
-	}
-	return net.ParseIP(name) != nil
-}
-
-// clusterGossipOrigin derives the stable per-peer key under which a
-// cluster member's gossip is imported, so a later snapshot from the
-// same member replaces (rather than stacks onto) its prior
-// contribution. Mirrors rippled's use of PeerImp::name() — the
-// configured cluster-node name — at PeerImp.cpp:1171. When that name is
-// empty we fall back to the peer's base58 node identity so two unnamed
-// cluster members don't collide on the empty-string origin and corrupt
-// each other's import accounting.
-func clusterGossipOrigin(name string, pub *PublicKeyToken) string {
-	if name != "" {
-		return name
-	}
-	if pub != nil {
-		if encoded, err := addresscodec.EncodeNodePublicKey(pub.Bytes()); err == nil {
-			return encoded
+	host := name
+	if h, port, err := net.SplitHostPort(name); err == nil {
+		if port != "" {
+			if _, err := strconv.ParseUint(port, 10, 16); err != nil {
+				return false
+			}
 		}
+		host = h
 	}
-	return name
+	return net.ParseIP(host) != nil
 }
 
 // handleGetObjectsMessage processes mtGET_OBJECTS from a peer. Mirrors

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -11,6 +11,7 @@ import (
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 )
 
 // TestHandleClusterMessage_DropsNonClusterPeer pins issue #497 audit
@@ -122,6 +123,68 @@ func TestHandleClusterMessage_FiresClusterFeeSink(t *testing.T) {
 
 	require.Len(t, sinkCalls, 1, "clusterFeeSink must fire exactly once per ingress")
 	assert.Equal(t, uint32(400), sinkCalls[0])
+}
+
+// TestHandleClusterMessage_ImportsLoadSourceGossip pins issue #765: a
+// TMCluster frame from a registered cluster peer must fold its
+// TMLoadSource entries into the resource manager (importConsumers),
+// mirroring rippled PeerImp.cpp:1157-1172. Entries whose name does not
+// parse as an IP endpoint are dropped while the rest are kept — rippled's
+// `item.address != Endpoint()` guard at PeerImp.cpp:1168.
+func TestHandleClusterMessage_ImportsLoadSourceGossip(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	peerIdentity, err := NewIdentity()
+	require.NoError(t, err)
+	peerToken := NewPublicKeyTokenFromBtcec(peerIdentity.BtcecPublicKey())
+
+	clusterReg := cluster.New()
+	peerNodePubEncoded, err := addresscodec.EncodeNodePublicKey(peerToken.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, clusterReg.Load([]string{peerNodePubEncoded + " peer"}))
+
+	rm := resource.NewManager(nil, nil)
+	o := &Overlay{
+		peers:           make(map[PeerID]*Peer),
+		events:          make(chan Event, 8),
+		cluster:         clusterReg,
+		resourceManager: rm,
+	}
+
+	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
+	peer := NewPeer(PeerID(44), endpoint, false, id, make(chan Event, 1))
+	peer.remotePubKey = peerToken
+	o.peers[peer.ID()] = peer
+
+	const balance = resource.MinimumGossipBalance * 4
+	cm := &message.Cluster{
+		LoadSources: []message.LoadSource{
+			{Name: "203.0.113.7:0", Cost: balance},  // rippled "ip:port" form
+			{Name: "198.51.100.9", Cost: balance},   // go-xrpl bare-host form
+			{Name: "not-an-address", Cost: balance}, // dropped by the Endpoint() guard
+		},
+	}
+	payload, err := message.Encode(cm)
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeCluster),
+		Payload:     payload,
+	})
+
+	// Only the two parseable addresses are imported; the malformed one
+	// is dropped (rippled PeerImp.cpp:1168).
+	assert.Equal(t, 2, rm.EntryCount(),
+		"only parseable load-source addresses must be imported")
+
+	// The imported remote balance lands on the matching inbound
+	// consumer — the "ip:port" key is normalised to its bare host by
+	// resource.normalizeAddr, so the port-9999 reconnect inherits it.
+	c := rm.NewInboundEndpoint("203.0.113.7:9999")
+	defer c.Release()
+	assert.Equal(t, int(balance), c.Balance(),
+		"imported gossip balance must show up on the inbound consumer")
 }
 
 // TestHandleHaveTransactionsMessage_GatedOnFeatureNegotiation pins the

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -187,6 +187,88 @@ func TestHandleClusterMessage_ImportsLoadSourceGossip(t *testing.T) {
 		"imported gossip balance must show up on the inbound consumer")
 }
 
+// TestHandleClusterMessage_ReimportReplacesPriorGossip pins that a second
+// TMCluster frame from the same cluster member REPLACES its prior
+// load-source contribution rather than stacking. go-xrpl keys the import
+// by the member's configured name (rippled importConsumers(name(), …) at
+// PeerImp.cpp:1171) — a stable origin across frames — so
+// ResourceManager.ImportConsumers subtracts the old balance before adding
+// the new, matching Resource Logic.h:282-336.
+func TestHandleClusterMessage_ReimportReplacesPriorGossip(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	peerIdentity, err := NewIdentity()
+	require.NoError(t, err)
+	peerToken := NewPublicKeyTokenFromBtcec(peerIdentity.BtcecPublicKey())
+
+	clusterReg := cluster.New()
+	peerNodePubEncoded, err := addresscodec.EncodeNodePublicKey(peerToken.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, clusterReg.Load([]string{peerNodePubEncoded + " peer"}))
+
+	rm := resource.NewManager(nil, nil)
+	o := &Overlay{
+		peers:           make(map[PeerID]*Peer),
+		events:          make(chan Event, 8),
+		cluster:         clusterReg,
+		resourceManager: rm,
+	}
+
+	peer := NewPeer(PeerID(45), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	peer.remotePubKey = peerToken
+	o.peers[peer.ID()] = peer
+
+	send := func(cost uint32) {
+		cm := &message.Cluster{LoadSources: []message.LoadSource{{Name: "203.0.113.7", Cost: cost}}}
+		payload, err := message.Encode(cm)
+		require.NoError(t, err)
+		o.onMessageReceived(Event{
+			PeerID:      peer.ID(),
+			MessageType: uint16(message.TypeCluster),
+			Payload:     payload,
+		})
+	}
+
+	const first = resource.MinimumGossipBalance * 2
+	const second = resource.MinimumGossipBalance * 5
+	send(first)
+	send(second)
+
+	c := rm.NewInboundEndpoint("203.0.113.7:9999")
+	defer c.Release()
+	assert.Equal(t, int(second), c.Balance(),
+		"re-import from the same member must replace, not stack, the gossip balance")
+}
+
+// TestValidGossipAddress pins the load-source name filter against rippled's
+// beast::IP::Endpoint::from_string + `!= Endpoint()` guard
+// (PeerImp.cpp:1166-1168, IPEndpoint.cpp:179-182): a non-IP host or an
+// out-of-range / non-numeric port is dropped, while the bare-host and
+// ip:port forms (including the port-0 canonical) are accepted.
+func TestValidGossipAddress(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"bare ipv4", "203.0.113.7", true},
+		{"ipv4 port zero", "203.0.113.7:0", true},
+		{"ipv4 high port", "203.0.113.7:51235", true},
+		{"ipv4 trailing colon", "203.0.113.7:", true},
+		{"non-ip host", "not-an-address", false},
+		{"out-of-range port", "203.0.113.7:99999", false},
+		{"non-numeric port", "203.0.113.7:abc", false},
+		{"bare ipv6", "2001:db8::1", true},
+		{"bracketed ipv6 with port", "[2001:db8::1]:51235", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, validGossipAddress(tc.in))
+		})
+	}
+}
+
 // TestHandleHaveTransactionsMessage_GatedOnFeatureNegotiation pins the
 // rippled gate at PeerImp.cpp:2598-2606: a TMHaveTransactions frame from
 // a peer that did NOT negotiate tx-reduce-relay must be dropped and the

--- a/internal/peermanagement/outbound_emit.go
+++ b/internal/peermanagement/outbound_emit.go
@@ -120,6 +120,19 @@ func (o *Overlay) sendClusterUpdate() {
 		return
 	}
 
+	// Attach our resource-manager gossip so cluster peers fold our
+	// per-source charge accounting into theirs. Mirrors rippled
+	// NetworkOPs.cpp:1151-1157, which appends one TMLoadSource per
+	// exportConsumers() item (name=address, cost=balance).
+	if o.resourceManager != nil {
+		for _, item := range o.resourceManager.ExportConsumers().Items {
+			clusterMsg.LoadSources = append(clusterMsg.LoadSources, message.LoadSource{
+				Name: item.Address,
+				Cost: uint32(item.Balance),
+			})
+		}
+	}
+
 	encoded, err := message.Encode(clusterMsg)
 	if err != nil {
 		slog.Debug("TMCluster encode failed", "t", "Overlay", "err", err)

--- a/internal/peermanagement/outbound_emit_test.go
+++ b/internal/peermanagement/outbound_emit_test.go
@@ -1,6 +1,7 @@
 package peermanagement
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 )
 
 // TestSendClusterUpdate_NoClusterConfigured_NoOp pins the
@@ -37,6 +39,66 @@ func TestSendClusterUpdate_NoClusterConfigured_NoOp(t *testing.T) {
 	o.sendClusterUpdate()
 	assert.Zero(t, o.cluster.Size(),
 		"sendClusterUpdate must not register members in an empty registry")
+}
+
+// TestSendClusterUpdate_EmitsExportedConsumerGossip pins issue #765: the
+// periodic cluster broadcast must carry our resource-manager gossip as
+// TMLoadSource entries, mirroring rippled NetworkOPs.cpp:1151-1157
+// (exportConsumers → add_loadsources). A consumer over the export
+// threshold must appear, keyed by its normalised inbound address.
+func TestSendClusterUpdate_EmitsExportedConsumerGossip(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	peerIdentity, err := NewIdentity()
+	require.NoError(t, err)
+	peerToken := NewPublicKeyTokenFromBtcec(peerIdentity.BtcecPublicKey())
+
+	// Register the receiving peer as a cluster member so it both appears
+	// in the broadcast registry and is selected as a send target.
+	clusterReg := cluster.New()
+	require.True(t, clusterReg.Update(peerToken.Bytes(), "peer", 0, time.Now()))
+
+	// Seed the resource manager with an inbound consumer whose balance
+	// clears the gossip-export threshold.
+	rm := resource.NewManager(nil, nil)
+	seed := rm.NewInboundEndpoint("203.0.113.7:9999")
+	seed.Charge(resource.NewCharge(resource.MinimumGossipBalance*resource.DecayWindowSeconds*2, "seed"), "")
+	defer seed.Release()
+
+	o := &Overlay{
+		cfg:             Config{},
+		peers:           make(map[PeerID]*Peer),
+		events:          make(chan Event, 8),
+		cluster:         clusterReg,
+		resourceManager: rm,
+	}
+
+	peer := NewPeer(PeerID(303), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	peer.remotePubKey = peerToken
+	peer.setState(PeerStateConnected)
+	o.peers[peer.ID()] = peer
+
+	o.sendClusterUpdate()
+
+	var frame []byte
+	select {
+	case frame = <-peer.send:
+	default:
+		t.Fatal("cluster-member peer did not receive a TMCluster frame")
+	}
+
+	_, payload, err := message.ReadMessage(bytes.NewReader(frame))
+	require.NoError(t, err)
+	decoded, err := message.Decode(message.TypeCluster, payload)
+	require.NoError(t, err)
+	cm, ok := decoded.(*message.Cluster)
+	require.True(t, ok)
+
+	require.Len(t, cm.LoadSources, 1, "exported consumer must appear as a load source")
+	assert.Equal(t, "203.0.113.7", cm.LoadSources[0].Name,
+		"load-source name must be the normalised inbound address (port stripped)")
+	assert.GreaterOrEqual(t, cm.LoadSources[0].Cost, uint32(resource.MinimumGossipBalance),
+		"exported cost must clear the gossip threshold")
 }
 
 // TestSendTxQueueAnnounce_FeatureDisabled_NoEmit pins the


### PR DESCRIPTION
## Summary
- A `TMCluster` frame carries per-source load gossip (`TMLoadSource`). rippled imports it into its `Resource::Manager` so per-source charge accounting is shared across `[cluster_nodes]` peers; go-xrpl parsed the field but dropped it (`ImportConsumers`/`ExportConsumers` existed with no non-test callers).
- **Inbound** (`handleClusterMessage`): when the frame carries ≥1 load source, build a `resource.Gossip` from the entries whose name parses as an IP endpoint and `ImportConsumers` it under the cluster peer's identity. Mirrors `PeerImp.cpp:1157-1172` (including the `item.address != Endpoint()` filter at `:1168` and the gate on the raw `loadsources` count).
- **Outbound** (`sendClusterUpdate`): append one `LoadSource` per `ExportConsumers()` item (`name=address`, `cost=balance`) to the periodic broadcast. Mirrors `NetworkOPs.cpp:1151-1157`.
- Import origin uses the configured cluster-node name (rippled's `PeerImp::name()`), falling back to the base58 node identity when the name is empty so two unnamed members don't collide on the empty-string origin.

## Test plan
- [x] `go test ./internal/peermanagement/...` (cluster, resource, message all green)
- [x] `TestHandleClusterMessage_ImportsLoadSourceGossip` — load sources imported into the manager; malformed addresses filtered; balance lands on the matching inbound consumer (port-stripped key)
- [x] `TestSendClusterUpdate_EmitsExportedConsumerGossip` — broadcast frame carries the exported consumer as a `TMLoadSource`
- [x] `go vet` + `gofmt` clean; full-module `go build ./...` passes

Fixes #765