### PR TITLE
feat: serve generic TMGetObjectByHash node-object requests

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -468,6 +468,21 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		overlay.SetTxProvider(ledgerService.OpenLedgerGetTx)
 		overlay.SetOpenLedgerHashesProvider(ledgerService.OpenLedgerTxHashes)
 
+		// Wire the generic node-object lookup used by the
+		// TMGetObjectByHash by-hash serve path (PeerImp.cpp:2483-2538).
+		// Only wired when a node store is configured; an in-memory
+		// deployment leaves the provider nil and the serve path drops
+		// the request without charging.
+		if db != nil {
+			overlay.SetNodeObjectProvider(func(hash [32]byte) ([]byte, bool) {
+				node, err := db.Fetch(context.Background(), nodestore.Hash256(hash))
+				if err != nil || node == nil {
+					return nil, false
+				}
+				return node.Data, true
+			})
+		}
+
 		// LoadFeeTrack ingress + outbound self-load advertisement.
 		// Mirrors the rippled wiring split:
 		//   - PeerImp.cpp:1193 setClusterFee(median) on inbound TMCluster

--- a/internal/peermanagement/get_objects_serve_test.go
+++ b/internal/peermanagement/get_objects_serve_test.go
@@ -1,0 +1,178 @@
+package peermanagement
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+)
+
+// decodeGetObjectsReply pops the single frame the overlay queued for the
+// peer and decodes it back into a TMGetObjectByHash. Fails the test if no
+// frame is waiting.
+func decodeGetObjectsReply(t *testing.T, peer *Peer) *message.GetObjectByHash {
+	t.Helper()
+	select {
+	case frame := <-peer.send:
+		hdr, payload, err := message.ReadMessage(bytes.NewReader(frame))
+		require.NoError(t, err)
+		require.Equal(t, message.TypeGetObjects, hdr.MessageType)
+		decoded, err := message.Decode(message.TypeGetObjects, payload)
+		require.NoError(t, err)
+		reply, ok := decoded.(*message.GetObjectByHash)
+		require.True(t, ok)
+		return reply
+	default:
+		t.Fatal("expected a TMGetObjectByHash reply frame, got none")
+		return nil
+	}
+}
+
+func newServeTestPeer(t *testing.T, id PeerID) *Peer {
+	t.Helper()
+	identity, err := NewIdentity()
+	require.NoError(t, err)
+	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
+	return NewPeer(id, endpoint, true, identity, make(chan Event, 1))
+}
+
+// TestServeGetObjects_FetchesAndReplies covers the happy path of the
+// generic TMGetObjectByHash serve branch (rippled PeerImp.cpp:2483-2538):
+// found hashes are packed into a query=false reply echoing the request's
+// type/seq, missing hashes are skipped, malformed (wrong-size) hashes are
+// never looked up, and the request's nodeid/ledgerseq are echoed back.
+func TestServeGetObjects_FetchesAndReplies(t *testing.T) {
+	knownHash := [32]byte{0xAA}
+	knownBlob := []byte{0x11, 0x22, 0x33, 0x44}
+	missingHash := [32]byte{0xBB}
+
+	lookups := 0
+	o := &Overlay{
+		peers: make(map[PeerID]*Peer),
+		nodeObjectProvider: func(h [32]byte) ([]byte, bool) {
+			lookups++
+			if h == knownHash {
+				return knownBlob, true
+			}
+			return nil, false
+		},
+	}
+	peer := newServeTestPeer(t, PeerID(401))
+	o.peers[peer.ID()] = peer
+
+	nodeID := []byte{0x09, 0x08, 0x07}
+	req := &message.GetObjectByHash{
+		ObjType: message.ObjectTypeUnknown,
+		Query:   true,
+		Seq:     7,
+		Objects: []message.IndexedObject{
+			{Hash: knownHash[:], NodeID: nodeID, LedgerSeq: 42},
+			{Hash: missingHash[:]},
+			{Hash: []byte{0x01, 0x02}}, // malformed: not 32 bytes
+		},
+	}
+	o.serveGetObjects(peer.ID(), req)
+
+	// Only the two uint256-sized hashes are looked up; the malformed
+	// object is skipped before consulting the provider.
+	assert.Equal(t, 2, lookups, "provider must be consulted only for valid 32-byte hashes")
+
+	reply := decodeGetObjectsReply(t, peer)
+	assert.False(t, reply.Query, "reply must have query=false")
+	assert.Equal(t, message.ObjectTypeUnknown, reply.ObjType, "reply must echo the request type")
+	assert.Equal(t, uint32(7), reply.Seq, "reply must echo the request seq")
+	require.Len(t, reply.Objects, 1, "only the found object belongs in the reply")
+	got := reply.Objects[0]
+	assert.Equal(t, knownHash[:], got.Hash)
+	assert.Equal(t, knownBlob, got.Data)
+	assert.Equal(t, nodeID, got.Index, "request nodeid is echoed into the reply index")
+	assert.Equal(t, uint32(42), got.LedgerSeq, "request ledgerseq is echoed back")
+
+	// A generic by-hash request is charged feeModerateBurdenPeer.
+	assert.Positive(t, peer.Load(), "serving a by-hash request must charge the peer")
+}
+
+// TestServeGetObjects_AlwaysRepliesEvenWhenEmpty verifies the rippled
+// contract that the generic branch always sends a reply (PeerImp.cpp:2538),
+// even when none of the requested hashes are held — so a requester can
+// distinguish "I have none" from a silent peer.
+func TestServeGetObjects_AlwaysRepliesEvenWhenEmpty(t *testing.T) {
+	o := &Overlay{
+		peers: make(map[PeerID]*Peer),
+		nodeObjectProvider: func([32]byte) ([]byte, bool) {
+			return nil, false
+		},
+	}
+	peer := newServeTestPeer(t, PeerID(402))
+	o.peers[peer.ID()] = peer
+
+	hash := [32]byte{0xCC}
+	req := &message.GetObjectByHash{
+		Query:   true,
+		Objects: []message.IndexedObject{{Hash: hash[:]}},
+	}
+	o.serveGetObjects(peer.ID(), req)
+
+	reply := decodeGetObjectsReply(t, peer)
+	assert.False(t, reply.Query)
+	assert.Empty(t, reply.Objects, "no held objects → empty reply, but a reply nonetheless")
+}
+
+// TestServeGetObjects_NilProviderDropsWithoutCharge verifies that an
+// overlay with no node store wired drops the request without replying and
+// without charging the peer — honest peers are not punished for a
+// capability we don't run.
+func TestServeGetObjects_NilProviderDropsWithoutCharge(t *testing.T) {
+	o := &Overlay{peers: make(map[PeerID]*Peer)} // nodeObjectProvider stays nil
+	peer := newServeTestPeer(t, PeerID(403))
+	o.peers[peer.ID()] = peer
+
+	hash := [32]byte{0xDD}
+	req := &message.GetObjectByHash{
+		Query:   true,
+		Objects: []message.IndexedObject{{Hash: hash[:]}},
+	}
+	o.serveGetObjects(peer.ID(), req)
+
+	select {
+	case frame := <-peer.send:
+		t.Fatalf("no reply expected when no node store is wired, got %d bytes", len(frame))
+	default:
+	}
+	assert.Zero(t, peer.Load(), "unserved request must not charge the peer")
+}
+
+// TestServeGetObjects_BadLedgerHashCharged verifies that a wrong-sized
+// optional ledger hash is rejected with a malformed-request charge and no
+// reply, mirroring rippled PeerImp.cpp:2492-2501.
+func TestServeGetObjects_BadLedgerHashCharged(t *testing.T) {
+	lookups := 0
+	o := &Overlay{
+		peers: make(map[PeerID]*Peer),
+		nodeObjectProvider: func([32]byte) ([]byte, bool) {
+			lookups++
+			return nil, false
+		},
+	}
+	peer := newServeTestPeer(t, PeerID(404))
+	o.peers[peer.ID()] = peer
+
+	hash := [32]byte{0xEE}
+	req := &message.GetObjectByHash{
+		Query:      true,
+		LedgerHash: []byte{0x01, 0x02, 0x03}, // not 32 bytes
+		Objects:    []message.IndexedObject{{Hash: hash[:]}},
+	}
+	o.serveGetObjects(peer.ID(), req)
+
+	assert.Zero(t, lookups, "a malformed ledger hash short-circuits before any fetch")
+	select {
+	case frame := <-peer.send:
+		t.Fatalf("no reply expected for a malformed ledger hash, got %d bytes", len(frame))
+	default:
+	}
+	assert.Positive(t, peer.Load(), "a malformed ledger hash must charge the peer")
+}

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -11,6 +11,7 @@ import (
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -115,9 +116,10 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 //
 // go-xrpl does not implement fetch-packs (no LedgerMaster::gotFetchPack
 // path) and does not advertise txReduceRelay by default (config.go
-// EnableTxReduceRelay defaults to false). We therefore mirror rippled's
-// rejection branches faithfully but stop short of the success paths
-// they gate.
+// EnableTxReduceRelay defaults to false), so those two branches mirror
+// rippled's rejection paths. The generic node-store object fetch is
+// served from the local node store via serveGetObjects when a provider
+// is wired.
 func (o *Overlay) handleGetObjectsMessage(evt Event) {
 	decoded, err := message.Decode(message.TypeGetObjects, evt.Payload)
 	if err != nil {
@@ -176,19 +178,9 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 			return
 		}
 
-		// Generic node-store lookup. Rippled walks
-		// app_.getNodeStore().fetchNodeObject for each requested
-		// hash and replies inline (PeerImp.cpp:2483-2538). go-xrpl
-		// has the NodeStore but no peer-protocol surface that exposes
-		// it — wiring requires plumbing nodestore.Store through to
-		// the overlay. Out of scope for #497; drop without charging
-		// and log so operators see the gap.
-		slog.Debug("TMGetObjects query (nodestore lookup) unsupported; dropping",
-			"t", "Overlay",
-			"peer", evt.PeerID,
-			"obj_type", gob.ObjType,
-			"requested", len(gob.Objects),
-		)
+		// Generic node-store object fetch by hash. Mirrors rippled's
+		// fetchNodeObject loop at PeerImp.cpp:2483-2538.
+		o.serveGetObjects(evt.PeerID, gob)
 		return
 	}
 
@@ -432,6 +424,106 @@ func (o *Overlay) serveDoTransactions(peerID PeerID, req *message.GetObjectByHas
 	}
 	if sendErr := peer.Send(frame); sendErr != nil {
 		slog.Debug("TMTransactions reply send failed",
+			"t", "Overlay", "peer", peerID, "err", sendErr)
+	}
+}
+
+// serveGetObjects answers an inbound mtGET_OBJECTS query for generic
+// node-store objects by hash. Mirrors rippled
+// PeerImp::onMessage(TMGetObjectByHash) generic branch
+// (PeerImp.cpp:2483-2538): echo the request's type/seq/ledger-hash into
+// a query=false reply, look each requested hash up in the local node
+// store, and append the blobs we hold.
+//
+// Unlike serveDoTransactions, this path ALWAYS sends a reply — even an
+// empty one — mirroring rippled's unconditional send at
+// PeerImp.cpp:2538 so a requester polling several peers can tell "I
+// don't have these" from a peer that never answered.
+func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
+	o.peersMu.RLock()
+	peer, exists := o.peers[peerID]
+	o.peersMu.RUnlock()
+	if !exists {
+		return
+	}
+
+	fetch := o.nodeObjectProviderSnapshot()
+	if fetch == nil {
+		// No node store wired (tests, or an overlay deployed without a
+		// backing store). Drop without charging — the peer issued a
+		// legitimate request we simply can't serve, and a charge would
+		// punish honest peers for a capability we don't run.
+		slog.Debug("TMGetObjects nodestore lookup unserved: no node store wired",
+			"t", "Overlay", "peer", peerID)
+		return
+	}
+
+	// Validate the optional ledger hash before doing any work. Rippled
+	// charges feeMalformedRequest "ledger hash" on a wrong-sized field
+	// and returns (PeerImp.cpp:2492-2501).
+	if len(req.LedgerHash) != 0 && len(req.LedgerHash) != 32 {
+		o.IncPeerBadData(peerID, "get-objects-ledgerhash")
+		return
+	}
+
+	// A generic by-hash request is legitimate but moderately burdensome
+	// to serve. Rippled charges feeModerateBurdenPeer once it reaches
+	// this branch, ahead of the fetch loop (PeerImp.cpp:2503-2505).
+	peer.Charge(resource.FeeModerateBurdenPeer, "get object by hash request")
+
+	reply := &message.GetObjectByHash{
+		Query:   false,
+		ObjType: req.ObjType,
+		Objects: make([]message.IndexedObject, 0, len(req.Objects)),
+	}
+	if req.Seq != 0 {
+		reply.Seq = req.Seq
+	}
+	if len(req.LedgerHash) != 0 {
+		reply.LedgerHash = append([]byte(nil), req.LedgerHash...)
+	}
+
+	for _, obj := range req.Objects {
+		// Rippled only processes objects carrying a uint256-sized hash
+		// (PeerImp.cpp:2511); others are silently skipped.
+		if len(obj.Hash) != 32 {
+			continue
+		}
+		var hash [32]byte
+		copy(hash[:], obj.Hash)
+		blob, ok := fetch(hash)
+		if !ok {
+			continue
+		}
+		out := message.IndexedObject{
+			Hash: append([]byte(nil), obj.Hash...),
+			Data: blob,
+		}
+		// Rippled echoes the request's nodeid into the reply's index
+		// field and copies the ledger seq back (PeerImp.cpp:2526-2529).
+		if len(obj.NodeID) != 0 {
+			out.Index = append([]byte(nil), obj.NodeID...)
+		}
+		if obj.LedgerSeq != 0 {
+			out.LedgerSeq = obj.LedgerSeq
+		}
+		reply.Objects = append(reply.Objects, out)
+	}
+
+	encoded, err := message.Encode(reply)
+	if err != nil {
+		slog.Debug("TMGetObjectByHash reply encode failed",
+			"t", "Overlay", "peer", peerID, "err", err)
+		return
+	}
+	frame, err := message.BuildWireMessage(message.TypeGetObjects, encoded)
+	if err != nil {
+		slog.Debug("TMGetObjectByHash reply frame build failed",
+			"t", "Overlay", "peer", peerID, "err", err)
+		return
+	}
+	if sendErr := peer.Send(frame); sendErr != nil {
+		slog.Debug("TMGetObjectByHash reply send failed",
 			"t", "Overlay", "peer", peerID, "err", sendErr)
 	}
 }

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -474,10 +474,8 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 	reply := &message.GetObjectByHash{
 		Query:   false,
 		ObjType: req.ObjType,
+		Seq:     req.Seq,
 		Objects: make([]message.IndexedObject, 0, len(req.Objects)),
-	}
-	if req.Seq != 0 {
-		reply.Seq = req.Seq
 	}
 	if len(req.LedgerHash) != 0 {
 		reply.LedgerHash = append([]byte(nil), req.LedgerHash...)
@@ -495,17 +493,15 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 		if !ok {
 			continue
 		}
-		out := message.IndexedObject{
-			Hash: append([]byte(nil), obj.Hash...),
-			Data: blob,
-		}
 		// Rippled echoes the request's nodeid into the reply's index
 		// field and copies the ledger seq back (PeerImp.cpp:2526-2529).
+		out := message.IndexedObject{
+			Hash:      append([]byte(nil), obj.Hash...),
+			Data:      blob,
+			LedgerSeq: obj.LedgerSeq,
+		}
 		if len(obj.NodeID) != 0 {
 			out.Index = append([]byte(nil), obj.NodeID...)
-		}
-		if obj.LedgerSeq != 0 {
-			out.LedgerSeq = obj.LedgerSeq
 		}
 		reply.Objects = append(reply.Objects, out)
 	}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -155,6 +155,16 @@ type Overlay struct {
 	// overlay without a ledger backend). Guarded by providersMu.
 	txProvider func(hash [32]byte) ([]byte, bool)
 
+	// nodeObjectProvider returns the raw node-store blob for a content
+	// hash, mirroring rippled app_.getNodeStore().fetchNodeObject. Wired
+	// by the server at startup so the generic TMGetObjectByHash serve
+	// path (handleGetObjectsMessage → serveGetObjects) can answer a
+	// peer's by-hash query without importing storage/nodestore lifecycle
+	// into this package. nil-safe — the serve path drops without
+	// charging when unwired (an overlay deployed without a backing
+	// store, or tests). Guarded by providersMu.
+	nodeObjectProvider func(hash [32]byte) ([]byte, bool)
+
 	// openLedgerHashesProvider returns the set of tx hashes currently
 	// in the open-ledger view. Drives the periodic tx-reduce-relay
 	// TMHaveTransactions emission in sendTxQueueAnnounce. nil-safe —
@@ -2245,6 +2255,25 @@ func (o *Overlay) txProviderSnapshot() func(hash [32]byte) ([]byte, bool) {
 	o.providersMu.RLock()
 	defer o.providersMu.RUnlock()
 	return o.txProvider
+}
+
+// SetNodeObjectProvider installs the node-store lookup used by the
+// generic TMGetObjectByHash serve path (handleGetObjectsMessage →
+// serveGetObjects). The provider receives a requested 32-byte content
+// hash and returns (blob, true) when the object is present in the local
+// node store. Wiring is optional — when nil the serve path drops
+// without charging, matching an overlay deployed without a backing
+// store. Mirrors rippled app_.getNodeStore().fetchNodeObject.
+func (o *Overlay) SetNodeObjectProvider(fn func(hash [32]byte) ([]byte, bool)) {
+	o.providersMu.Lock()
+	o.nodeObjectProvider = fn
+	o.providersMu.Unlock()
+}
+
+func (o *Overlay) nodeObjectProviderSnapshot() func(hash [32]byte) ([]byte, bool) {
+	o.providersMu.RLock()
+	defer o.providersMu.RUnlock()
+	return o.nodeObjectProvider
 }
 
 // SetOpenLedgerHashesProvider installs the tx-hash snapshot reader

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -1155,6 +1155,7 @@ func chargeForReason(reason string) resource.Charge {
 		"replay-delta-req-unnegotiated",
 		"replay-delta-resp-unnegotiated",
 		"proof-path-resp-unnegotiated",
+		"get-objects-ledgerhash",
 		"proposal-decode",
 		"validation-decode",
 		"validation-parse",


### PR DESCRIPTION
## Summary

- Implements the generic node-object-by-hash branch of `TMGetObjectByHash`, which previously logged-and-dropped because the overlay held no reference to the node store (`inbound_handlers.go` generic branch).
- Plumbs a node-object read provider into the `Overlay` (`SetNodeObjectProvider`), mirroring the existing `SetTxProvider` injection idiom so the overlay stays decoupled from `storage/nodestore` lifecycle and the path is nil-safe + testable.
- Adds `serveGetObjects`, faithfully mirroring rippled `PeerImp::onMessage(TMGetObjectByHash)` generic branch (`PeerImp.cpp:2483-2538`): echoes the request `type`/`seq`/`ledger-hash` into a `query=false` reply, validates the optional ledger hash (charges `feeMalformedRequest` on a bad size), charges `feeModerateBurdenPeer`, fetches each requested hash, echoes `nodeid`→`index` and `ledgerseq`, and **always** replies (even empty, per rippled's unconditional send).
- Wires the provider to the configured nodestore in `cmd/xrpld` server startup; an in-memory deployment leaves the provider nil and the path drops without charging.

## Test plan

- [x] `go test ./internal/peermanagement/` (full package green)
- [x] New `internal/peermanagement/get_objects_serve_test.go` covers: found/missing/malformed-hash handling with reply decode + field echo, always-reply-even-when-empty, nil-provider drop-without-charge, and bad-ledger-hash charge.
- [x] `go vet ./internal/peermanagement/... ./internal/cli/...` clean

Fixes #764