### PR TITLE
feat: implement fetch-pack subsystem

### DIFF
--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -128,9 +128,22 @@ func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 
 	now := time.Now()
 	stored := 0
+	// Mirror rippled's per-ledgerseq "late pack" short-circuit
+	// (PeerImp.cpp:2557-2575): skip caching nodes for a ledger we already
+	// hold (pLDo = !haveLedger(pLSeq)). go-xrpl packs are single-ledger, but
+	// track per-object like rippled so a multi-seq pack is handled too.
+	var pLSeq uint32
+	pLDo := true
 	for i := range gob.Objects {
 		obj := &gob.Objects[i]
 		if len(obj.Hash) != 32 || len(obj.Data) == 0 {
+			continue
+		}
+		if obj.LedgerSeq != 0 && obj.LedgerSeq != pLSeq {
+			pLSeq = obj.LedgerSeq
+			pLDo = !r.haveLedgerSeq(pLSeq)
+		}
+		if !pLDo {
 			continue
 		}
 		var hash [32]byte
@@ -138,7 +151,7 @@ func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 		// Only SHAMap tree nodes are useful for completing an acquisition;
 		// the leading header object (hash == ledger hash) is not a SHAMap
 		// node and is expected to fail verification, as is any poisoned blob.
-		if !shamap.VerifyWireNode(hash, obj.Data) {
+		if !shamap.VerifyFetchPackNode(hash, obj.Data) {
 			continue
 		}
 		r.fetchPacks.add(hash, obj.Data, now)
@@ -148,6 +161,21 @@ func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 		return
 	}
 	r.tryCompleteFromFetchPack(now)
+}
+
+// haveLedgerSeq reports whether a ledger at seq is already in our store, so a
+// late fetch-pack for an already-acquired ledger is not cached. Mirrors
+// rippled's pLDo = !haveLedger(pLSeq) gate (PeerImp.cpp:2563).
+func (r *Router) haveLedgerSeq(seq uint32) bool {
+	if seq == 0 {
+		return false
+	}
+	svc := r.adaptor.LedgerService()
+	if svc == nil {
+		return false
+	}
+	l, err := svc.GetLedgerBySequence(seq)
+	return err == nil && l != nil
 }
 
 // tryCompleteFromFetchPack runs CheckLocal against the fetch-pack cache for

--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -1,0 +1,224 @@
+package adaptor
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+const (
+	// fetchPackCacheMaxSize bounds the fetch-pack node cache, mirroring
+	// rippled's fetch_packs_ TaggedCache capacity (LedgerMaster.cpp:226,
+	// 65536 entries).
+	fetchPackCacheMaxSize = 65536
+	// fetchPackCacheTTL bounds how long an inbound fetch-pack node lingers,
+	// mirroring rippled's fetch_packs_ 45s expiry (LedgerMaster.cpp:226).
+	fetchPackCacheTTL = 45 * time.Second
+)
+
+// fetchPackCache is the go-xrpl analogue of rippled's LedgerMaster fetch_packs_
+// TaggedCache (LedgerMaster.cpp:2007-2009): inbound fetch-pack SHAMap nodes
+// keyed by node hash, held briefly so a stalled acquisition can complete
+// locally via inbound.Ledger.CheckLocal. Bounded by entry count and a TTL; the
+// router sweeps expired entries on its maintenance tick.
+type fetchPackCache struct {
+	mu      sync.Mutex
+	nodes   map[[32]byte]fetchPackEntry
+	maxSize int
+	ttl     time.Duration
+}
+
+type fetchPackEntry struct {
+	data []byte
+	at   time.Time
+}
+
+func newFetchPackCache() *fetchPackCache {
+	return &fetchPackCache{
+		nodes:   make(map[[32]byte]fetchPackEntry),
+		maxSize: fetchPackCacheMaxSize,
+		ttl:     fetchPackCacheTTL,
+	}
+}
+
+// add stores a node blob keyed by its hash, stamping it with now. Once the
+// cache is full a new key is dropped (rippled's TaggedCache evicts LRU; we
+// drop the newcomer to keep the add path lock-cheap — a dropped node simply
+// isn't available for local completion and the acquisition falls back to the
+// network). Refreshing an existing key is always allowed.
+func (c *fetchPackCache) add(hash [32]byte, data []byte, now time.Time) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.nodes[hash]; !ok && len(c.nodes) >= c.maxSize {
+		return
+	}
+	c.nodes[hash] = fetchPackEntry{data: append([]byte(nil), data...), at: now}
+}
+
+// get returns the cached blob for hash when present and unexpired, deleting it
+// when expired.
+func (c *fetchPackCache) get(hash [32]byte, now time.Time) ([]byte, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.nodes[hash]
+	if !ok {
+		return nil, false
+	}
+	if now.Sub(e.at) > c.ttl {
+		delete(c.nodes, hash)
+		return nil, false
+	}
+	return e.data, true
+}
+
+// sweep drops every entry older than the TTL.
+func (c *fetchPackCache) sweep(now time.Time) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for h, e := range c.nodes {
+		if now.Sub(e.at) > c.ttl {
+			delete(c.nodes, h)
+		}
+	}
+}
+
+func (c *fetchPackCache) size() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.nodes)
+}
+
+// handleFetchPackReply consumes an inbound mtGET_OBJECTS{otFETCH_PACK,
+// query=false}. Mirrors rippled's PeerImp::onMessage(TMGetObjectByHash) reply
+// path (PeerImp.cpp:2540-2593) feeding LedgerMaster::addFetchPack +
+// gotFetchPack: cache each verified SHAMap node by its hash, then give every
+// in-flight acquisition a chance to complete locally from the cache
+// (InboundLedger::checkLocal). The pack's leading ledger-header object and any
+// node that fails hash verification are dropped.
+func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
+	if r.fetchPacks == nil {
+		return
+	}
+	decoded, err := message.Decode(message.TypeGetObjects, msg.Payload)
+	if err != nil {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "fetch-pack-decode")
+		return
+	}
+	gob, ok := decoded.(*message.GetObjectByHash)
+	if !ok || gob.Query || gob.ObjType != message.ObjectTypeFetchPack {
+		return
+	}
+
+	now := time.Now()
+	stored := 0
+	for i := range gob.Objects {
+		obj := &gob.Objects[i]
+		if len(obj.Hash) != 32 || len(obj.Data) == 0 {
+			continue
+		}
+		var hash [32]byte
+		copy(hash[:], obj.Hash)
+		// Only SHAMap tree nodes are useful for completing an acquisition;
+		// the leading header object (hash == ledger hash) is not a SHAMap
+		// node and is expected to fail verification, as is any poisoned blob.
+		if !shamap.VerifyWireNode(hash, obj.Data) {
+			continue
+		}
+		r.fetchPacks.add(hash, obj.Data, now)
+		stored++
+	}
+	if stored == 0 {
+		return
+	}
+	r.tryCompleteFromFetchPack(now)
+}
+
+// tryCompleteFromFetchPack runs CheckLocal against the fetch-pack cache for
+// every in-flight acquisition, finalizing any that complete. Mirrors rippled's
+// InboundLedgers::gotFetchPack (InboundLedgers.cpp:359-380), which calls
+// checkLocal on each live acquisition after a pack arrives.
+func (r *Router) tryCompleteFromFetchPack(now time.Time) {
+	if r.fetchPacks == nil {
+		return
+	}
+	fetch := func(hash [32]byte) ([]byte, bool) { return r.fetchPacks.get(hash, now) }
+	for _, il := range r.fetchTracker.Active() {
+		if il.CheckLocal(fetch) && il.IsComplete() {
+			r.completeInboundLedger(il)
+		}
+	}
+}
+
+// tryFetchPackEscalation attempts, at most once per acquisition, to recover a
+// stalled legacy acquisition via a fetch-pack instead of reaping it. Mirrors
+// rippled's LedgerMaster::getFetchPack (LedgerMaster.cpp:700-746): the
+// requester must name a ledger it HAS whose PARENT is the ledger it wants, so
+// we locate the child of the stalled ledger (the ledger at il.Seq()+1 whose
+// ParentHash links back to it) and send its hash.
+//
+// Returns true when a request was sent and the acquisition's deadline was
+// extended for the reply, so the caller leaves it in flight; false when no
+// fetch-pack is possible — the common case for a forward tip acquisition whose
+// child does not exist yet — or one was already tried, so the caller reaps it.
+func (r *Router) tryFetchPackEscalation(il *inbound.Ledger) bool {
+	if r.fetchPacks == nil || il.FetchPackRequested() {
+		return false
+	}
+	svc := r.adaptor.LedgerService()
+	if svc == nil {
+		return false
+	}
+
+	wantHash := il.Hash()
+	child, err := svc.GetLedgerBySequence(il.Seq() + 1)
+	if err != nil || child == nil || child.Header().ParentHash != wantHash {
+		// No known child to key the pack on: nothing to request.
+		return false
+	}
+	childHash := child.Hash()
+
+	req := &message.GetObjectByHash{
+		ObjType:    message.ObjectTypeFetchPack,
+		Query:      true,
+		LedgerHash: childHash[:],
+	}
+	encoded, err := message.Encode(req)
+	if err != nil {
+		return false
+	}
+	frame, err := message.BuildWireMessage(message.TypeGetObjects, encoded)
+	if err != nil {
+		return false
+	}
+	if err := r.adaptor.SendToPeer(il.PeerID(), frame); err != nil {
+		r.logger.Debug("fetch-pack request send failed",
+			"seq", il.Seq(), "err", err)
+		return false
+	}
+
+	il.MarkFetchPackRequested()
+	r.logger.Info("requested fetch-pack for stalled acquisition",
+		"seq", il.Seq(),
+		"hash", fmt.Sprintf("%x", wantHash[:4]),
+		"child", fmt.Sprintf("%x", childHash[:4]),
+		"peer", il.PeerID(),
+	)
+	return true
+}

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -1,0 +1,219 @@
+package adaptor
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchPackCache_AddGetExpiry(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	h := [32]byte{1, 2, 3}
+	data := []byte{9, 8, 7}
+	t0 := time.Unix(1000, 0)
+
+	c.add(h, data, t0)
+	got, ok := c.get(h, t0)
+	require.True(t, ok)
+	require.Equal(t, []byte{9, 8, 7}, got)
+
+	// The cache must copy on insert so a caller mutating its buffer can't
+	// corrupt the stored node.
+	data[0] = 0xFF
+	got2, _ := c.get(h, t0)
+	require.Equal(t, byte(9), got2[0], "cache did not copy data on add")
+
+	// Expired entries are not returned and are evicted on read.
+	if _, ok := c.get(h, t0.Add(fetchPackCacheTTL+time.Second)); ok {
+		t.Error("expired entry returned")
+	}
+	if _, ok := c.get(h, t0); ok {
+		t.Error("expired entry not evicted on the expiring read")
+	}
+}
+
+func TestFetchPackCache_Sweep(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	t0 := time.Unix(1000, 0)
+	c.add([32]byte{1}, []byte{1}, t0)
+	c.add([32]byte{2}, []byte{2}, t0.Add(40*time.Second))
+	c.sweep(t0.Add(fetchPackCacheTTL + time.Second))
+	require.Equal(t, 1, c.size(), "sweep should drop only the expired entry")
+	if _, ok := c.get([32]byte{2}, t0.Add(40*time.Second)); !ok {
+		t.Error("sweep dropped a still-fresh entry")
+	}
+}
+
+func TestFetchPackCache_CapDropsNewcomers(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	c.maxSize = 2
+	t0 := time.Unix(1000, 0)
+	c.add([32]byte{1}, []byte{1}, t0)
+	c.add([32]byte{2}, []byte{2}, t0)
+	c.add([32]byte{3}, []byte{3}, t0) // over cap → dropped
+	require.Equal(t, 2, c.size())
+	if _, ok := c.get([32]byte{3}, t0); ok {
+		t.Error("newcomer stored over the cap")
+	}
+	// Refreshing an existing key stays allowed even at the cap.
+	c.add([32]byte{1}, []byte{0xAA}, t0)
+	got, _ := c.get([32]byte{1}, t0)
+	require.Equal(t, byte(0xAA), got[0], "refresh of an existing key was rejected at cap")
+}
+
+func TestFetchPackCache_NilReceiver(t *testing.T) {
+	t.Parallel()
+	var c *fetchPackCache
+	c.add([32]byte{1}, []byte{1}, time.Unix(1, 0))
+	if _, ok := c.get([32]byte{1}, time.Unix(1, 0)); ok {
+		t.Error("nil cache returned a hit")
+	}
+	c.sweep(time.Unix(1, 0))
+	require.Equal(t, 0, c.size())
+}
+
+// TestMakeFetchPack_PacksParentTree verifies the serve side packs the parent
+// ("want") of the requested ledger: a header object whose hash is want's
+// ledger hash, followed by SHAMap nodes that each verify against their hash,
+// all tagged with want's sequence.
+func TestMakeFetchPack_PacksParentTree(t *testing.T) {
+	t.Parallel()
+	want := makeGenesisLedger(t) // the ledger we expect to be packed
+	open, err := ledger.NewOpen(want, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, open.Close(time.Now(), 0))
+	have := open // child of want
+	require.True(t, have.IsImmutable())
+	require.Equal(t, want.Hash(), have.Header().ParentHash)
+
+	lookup := newFakeLookup()
+	lookup.add(want)
+	lookup.add(have)
+	p := newLedgerProviderForTest(lookup)
+
+	objs, err := p.MakeFetchPack(have.Hash(), 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, objs)
+
+	wantHash := want.Hash()
+	assert.Equal(t, wantHash[:], objs[0].Hash, "first object must be want's header node")
+	assert.Equal(t, want.Sequence(), objs[0].LedgerSeq)
+
+	for i := 1; i < len(objs); i++ {
+		var h [32]byte
+		copy(h[:], objs[i].Hash)
+		assert.Truef(t, shamap.VerifyWireNode(h, objs[i].Data), "object %d does not verify", i)
+		assert.Equal(t, want.Sequence(), objs[i].LedgerSeq, "object %d carries the wrong ledger seq", i)
+	}
+}
+
+func TestMakeFetchPack_UnknownOrOpenHaveYieldsNoPack(t *testing.T) {
+	t.Parallel()
+	lookup := newFakeLookup()
+	p := newLedgerProviderForTest(lookup)
+
+	// Unknown have.
+	objs, err := p.MakeFetchPack([32]byte{0xAB}, 0)
+	require.NoError(t, err)
+	require.Nil(t, objs)
+
+	// Open (not immutable) have is refused.
+	open := makeOpenLedger(t)
+	synthetic := [32]byte{0xCD}
+	lookup.byHash[synthetic] = open
+	objs, err = p.MakeFetchPack(synthetic, 0)
+	require.NoError(t, err)
+	require.Nil(t, objs)
+}
+
+// TestHandleFetchPackReply_VerifiesAndCaches drives a fetch-pack reply through
+// the router and asserts only verifiable SHAMap nodes are cached — the leading
+// header object and a tampered node are dropped.
+func TestHandleFetchPackReply_VerifiesAndCaches(t *testing.T) {
+	t.Parallel()
+	source, err := shamap.New(shamap.TypeState)
+	require.NoError(t, err)
+	for i := byte(1); i <= 12; i++ {
+		var key [32]byte
+		key[0] = i
+		key[31] = 0xA5
+		require.NoError(t, source.Put(key, []byte{i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB}))
+	}
+	_, err = source.Hash()
+	require.NoError(t, err)
+	valid, err := source.WalkFetchPackNodes(1 << 20)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(valid), 2)
+
+	objects := make([]message.IndexedObject, 0, len(valid)+2)
+	// A header-like object: hash != sha512Half(data) → must be dropped.
+	objects = append(objects, message.IndexedObject{
+		Hash: bytes.Repeat([]byte{0xEE}, 32),
+		Data: []byte{0x01, 0x02, 0x03},
+	})
+	for _, n := range valid {
+		objects = append(objects, message.IndexedObject{
+			Hash: append([]byte(nil), n.Hash[:]...),
+			Data: n.Data,
+		})
+	}
+	// A tampered node: valid hash, corrupted data → must be dropped.
+	tampered := append([]byte(nil), valid[len(valid)-1].Data...)
+	tampered[len(tampered)-1] ^= 0xFF
+	objects = append(objects, message.IndexedObject{
+		Hash: append([]byte(nil), valid[len(valid)-1].Hash[:]...),
+		Data: tampered,
+	})
+
+	payload, err := message.Encode(&message.GetObjectByHash{
+		ObjType: message.ObjectTypeFetchPack,
+		Query:   false,
+		Objects: objects,
+	})
+	require.NoError(t, err)
+
+	r := NewRouter(nil, newTestAdaptor(t), nil, make(chan *peermanagement.InboundMessage, 1))
+	r.handleFetchPackReply(&peermanagement.InboundMessage{
+		PeerID:  peermanagement.PeerID(5),
+		Type:    uint16(message.TypeGetObjects),
+		Payload: payload,
+	})
+
+	assert.Equal(t, len(valid), r.fetchPacks.size(), "only verifiable SHAMap nodes should be cached")
+	for _, n := range valid {
+		if _, ok := r.fetchPacks.get(n.Hash, time.Now()); !ok {
+			t.Errorf("valid node %x not cached", n.Hash[:8])
+		}
+	}
+	var headerHash [32]byte
+	copy(headerHash[:], bytes.Repeat([]byte{0xEE}, 32))
+	if _, ok := r.fetchPacks.get(headerHash, time.Now()); ok {
+		t.Error("non-SHAMap header object was cached")
+	}
+}
+
+// TestTryFetchPackEscalation_NoChildIsNoOp confirms the escalation is a no-op
+// (and does not consume its one-shot flag) when no child ledger is known to key
+// the pack request on — the common forward-tip case.
+func TestTryFetchPackEscalation_NoChildIsNoOp(t *testing.T) {
+	t.Parallel()
+	r := NewRouter(nil, newTestAdaptor(t), nil, make(chan *peermanagement.InboundMessage, 1))
+	il := inbound.New([32]byte{0x7A, 0x7B}, 999999, 3, serveTestLogger())
+	if r.tryFetchPackEscalation(il) {
+		t.Fatal("escalation reported a request sent without a known child ledger")
+	}
+	if il.FetchPackRequested() {
+		t.Error("escalation consumed the one-shot flag despite sending nothing")
+	}
+}

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -113,7 +113,7 @@ func TestMakeFetchPack_PacksParentTree(t *testing.T) {
 	for i := 1; i < len(objs); i++ {
 		var h [32]byte
 		copy(h[:], objs[i].Hash)
-		assert.Truef(t, shamap.VerifyWireNode(h, objs[i].Data), "object %d does not verify", i)
+		assert.Truef(t, shamap.VerifyFetchPackNode(h, objs[i].Data), "object %d does not verify", i)
 		assert.Equal(t, want.Sequence(), objs[i].LedgerSeq, "object %d carries the wrong ledger seq", i)
 	}
 }

--- a/internal/consensus/adaptor/ledger_provider.go
+++ b/internal/consensus/adaptor/ledger_provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
@@ -149,6 +150,99 @@ func (p *LedgerProvider) GetReplayDelta(ledgerHash []byte) ([]byte, [][]byte, er
 	}
 
 	return headerBytes, leaves, nil
+}
+
+// fetchPackMaxObjects caps the SHAMap nodes a single fetch-pack reply carries.
+// Rippled bounds a pack at 512 objects across a backward walk of several
+// ledgers' DIFFS (LedgerMaster.cpp:2178-2210); go-xrpl packs a single ledger's
+// FULL state+tx tree (it has no node-hash store to let a receiver supply
+// un-sent shared nodes — see shamap.SHAMap.WalkFetchPackNodes), so the cap is
+// sized to cover a moderate ledger's tree in one pack while still bounding the
+// reply. Matches rippled's hardMaxReplyNodes (Tuning.h:42).
+const fetchPackMaxObjects = 12288
+
+// MakeFetchPack builds a fetch-pack for the parent of the ledger named by
+// haveLedgerHash, mirroring rippled's LedgerMaster::makeFetchPack
+// (LedgerMaster.cpp:2096-2225): the requester supplies a ledger hash it HAS,
+// and we serve its predecessor ("want"). The reply carries want's header
+// object (hash == want's ledger hash) followed by its account-state and, when
+// non-empty, its transaction SHAMap tree nodes, each tagged with want's
+// sequence. Returns (nil, nil) — drop, no charge — when have is unknown, not
+// yet immutable, or its parent is unavailable, matching the silent-drop stance
+// of the other serve paths.
+func (p *LedgerProvider) MakeFetchPack(haveLedgerHash [32]byte, maxObjects int) ([]message.IndexedObject, error) {
+	have, err := p.svc.GetLedgerByHash(haveLedgerHash)
+	if err != nil || have == nil || !have.IsImmutable() {
+		return nil, nil
+	}
+	want, err := p.svc.GetLedgerByHash(have.Header().ParentHash)
+	if err != nil || want == nil {
+		return nil, nil
+	}
+	if maxObjects <= 0 || maxObjects > fetchPackMaxObjects {
+		maxObjects = fetchPackMaxObjects
+	}
+
+	seq := want.Sequence()
+	wantHdr := want.Header()
+	objects := make([]message.IndexedObject, 0, maxObjects)
+
+	// Lead with the ledger-header object, mirroring rippled's
+	// HashPrefix::ledgerMaster + addRaw(info) header node at
+	// LedgerMaster.cpp:2180-2188. Its hash is want's ledger hash and
+	// sha512Half(data) reproduces it, so a rippled peer treats it as the
+	// pack's header node. go-xrpl receivers already hold the header (via the
+	// acquisition's GotBase) and simply ignore it.
+	wantHash := want.Hash()
+	headerData := append(protocol.HashPrefixLedgerMaster.Bytes(), header.AddRaw(wantHdr, false)...)
+	objects = append(objects, message.IndexedObject{
+		Hash:      append([]byte(nil), wantHash[:]...),
+		Data:      headerData,
+		LedgerSeq: seq,
+	})
+
+	stateMap, err := want.StateMapSnapshot()
+	if err != nil {
+		return nil, fmt.Errorf("snapshot state map: %w", err)
+	}
+	objects, err = appendFetchPackNodes(objects, stateMap, maxObjects, seq)
+	if err != nil {
+		return nil, fmt.Errorf("walk state map: %w", err)
+	}
+
+	if wantHdr.TxHash != ([32]byte{}) {
+		txMap, err := want.TxMapSnapshot()
+		if err != nil {
+			return nil, fmt.Errorf("snapshot tx map: %w", err)
+		}
+		objects, err = appendFetchPackNodes(objects, txMap, maxObjects, seq)
+		if err != nil {
+			return nil, fmt.Errorf("walk tx map: %w", err)
+		}
+	}
+
+	return objects, nil
+}
+
+// appendFetchPackNodes walks up to the remaining-object budget of m's SHAMap
+// tree nodes and appends each as a fetch-pack object tagged with seq.
+func appendFetchPackNodes(objects []message.IndexedObject, m *shamap.SHAMap, maxObjects int, seq uint32) ([]message.IndexedObject, error) {
+	remaining := maxObjects - len(objects)
+	if remaining <= 0 {
+		return objects, nil
+	}
+	nodes, err := m.WalkFetchPackNodes(remaining)
+	if err != nil {
+		return objects, err
+	}
+	for i := range nodes {
+		objects = append(objects, message.IndexedObject{
+			Hash:      append([]byte(nil), nodes[i].Hash[:]...),
+			Data:      nodes[i].Data,
+			LedgerSeq: seq,
+		})
+	}
+	return objects, nil
 }
 
 // GetProofPath serves an mtPROOF_PATH_REQ. Mirrors rippled's

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -71,6 +71,14 @@ type Router struct {
 	// can coexist.
 	fetchTracker *inbound.Tracker
 
+	// fetchPacks caches inbound fetch-pack SHAMap nodes keyed by node hash so
+	// a stalled acquisition can complete locally (inbound.Ledger.CheckLocal)
+	// instead of node-by-node over the network. go-xrpl's analogue of
+	// rippled's LedgerMaster fetch_packs_ (LedgerMaster.cpp:2007-2009). Driven
+	// from the single inbox goroutine (handleFetchPackReply / maintenanceTick)
+	// and guarded by its own mutex.
+	fetchPacks *fetchPackCache
+
 	// messageSeen dedups inbound proposal / validation payloads so the
 	// reduce-relay slot only feeds on DUPLICATE arrivals, mirroring
 	// rippled's HashRouter::addSuppressionPeer !added branch at
@@ -234,6 +242,7 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManag
 		peerStates:      make(map[peermanagement.PeerID]*peerLedgerState),
 		replayer:        inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
 		fetchTracker:    inbound.NewTracker(),
+		fetchPacks:      newFetchPackCache(),
 		messageSeen:     newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
 		txSetAcquire:    make(map[consensus.TxSetID]*txSetAcquireState),
 		txSetRetryKnobs: defaultTxSetRetryKnobs(),
@@ -425,6 +434,14 @@ func (r *Router) maintenanceTick() {
 	// too via isAcquiring's registry check. Matches the spirit of rippled's
 	// InboundLedgers timeout sweeps.
 	for _, il := range r.fetchTracker.ActiveTimedOut() {
+		// Before giving up, try a fetch-pack: if we can name a child ledger
+		// of the stalled one, ask a peer for a bulk pack and grant one more
+		// timeout window for it to arrive and complete the acquisition
+		// locally (handleFetchPackReply → CheckLocal). Attempted at most once
+		// per acquisition; on the next timeout it reaps as before.
+		if r.tryFetchPackEscalation(il) {
+			continue
+		}
 		r.logger.Warn("legacy inbound ledger acquisition timed out",
 			"seq", il.Seq(),
 			"hash", fmt.Sprintf("%x", il.Hash()),
@@ -436,6 +453,10 @@ func (r *Router) maintenanceTick() {
 		// fresh acquisition via startLedgerAcquisition once the stuck
 		// reference is cleared.
 	}
+
+	// Expire stale fetch-pack nodes so the cache doesn't retain a stalled
+	// acquisition's nodes past their usefulness (rippled's fetch_packs_ sweep).
+	r.fetchPacks.sweep(time.Now())
 
 	// Timer-driven tx-set acquisition re-trigger (issue #724). go-xrpl's
 	// inbound retry (handleTxSetData) only advances when a TMLedgerData
@@ -463,6 +484,12 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 		r.handleGetLedger(msg)
 	case message.TypeLedgerData:
 		r.handleLedgerData(msg)
+	case message.TypeGetObjects:
+		// Only fetch-pack REPLIES reach the router; the overlay serves
+		// otFETCH_PACK requests inline and forwards replies here (see
+		// handleGetObjectsMessage). handleFetchPackReply ignores anything
+		// that isn't an otFETCH_PACK reply.
+		r.handleFetchPackReply(msg)
 	case message.TypeReplayDeltaResponse:
 		r.handleReplayDeltaResponse(msg)
 	case message.TypeProofPathResponse:

--- a/internal/ledger/inbound/fetchpack_test.go
+++ b/internal/ledger/inbound/fetchpack_test.go
@@ -1,0 +1,146 @@
+package inbound
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// buildSourceStateMap builds a multi-level state tree and returns it together
+// with its root hash and serialized root.
+func buildSourceStateMap(t *testing.T) (*shamap.SHAMap, [32]byte, []byte) {
+	t.Helper()
+	source, err := shamap.New(shamap.TypeState)
+	if err != nil {
+		t.Fatalf("new source: %v", err)
+	}
+	for branch := byte(0); branch < 4; branch++ {
+		for sub := byte(0); sub < 4; sub++ {
+			for i := byte(0); i < 4; i++ {
+				var key [32]byte
+				key[0] = (branch << 4) | sub
+				key[1] = i << 4
+				key[31] = 0xA5
+				if err := source.Put(key, []byte{branch, sub, i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}); err != nil {
+					t.Fatalf("put: %v", err)
+				}
+			}
+		}
+	}
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("serialize root: %v", err)
+	}
+	return source, rootHash, rootData
+}
+
+// TestCheckLocal_CompletesStateFromCache drives an acquisition to WantState
+// with only the header + state root, then completes it purely from a local
+// node source (the fetch-pack cache analogue) via CheckLocal.
+func TestCheckLocal_CompletesStateFromCache(t *testing.T) {
+	t.Parallel()
+	source, rootHash, rootData := buildSourceStateMap(t)
+
+	packNodes, err := source.WalkFetchPackNodes(1 << 20)
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	cache := make(map[[32]byte][]byte, len(packNodes))
+	for _, n := range packNodes {
+		cache[n.Hash] = n.Data
+	}
+	fetch := func(h [32]byte) ([]byte, bool) { d, ok := cache[h]; return d, ok }
+
+	hdr := header.LedgerHeader{LedgerIndex: 321, AccountHash: rootHash}
+	hdrBytes, ledgerHash := encodeHeader(hdr)
+	il := New(ledgerHash, 321, 7, discardLogger())
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdrBytes}, {NodeData: rootData}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+	if il.State() == StateComplete {
+		t.Fatal("setup: tree completed from root alone; need a multi-level tree")
+	}
+
+	if !il.CheckLocal(fetch) {
+		t.Fatal("CheckLocal reported no progress")
+	}
+	if !il.IsComplete() {
+		t.Fatalf("acquisition not complete after CheckLocal: state=%d", il.State())
+	}
+	gotHash, err := il.stateMap.Hash()
+	if err != nil {
+		t.Fatalf("dest hash: %v", err)
+	}
+	if gotHash != rootHash {
+		t.Errorf("reconstructed state hash mismatch: want %x got %x", rootHash[:8], gotHash[:8])
+	}
+}
+
+// TestCheckLocal_NoSourceNoProgress confirms an empty source leaves the
+// acquisition incomplete and reports no progress (no false completion).
+func TestCheckLocal_NoSourceNoProgress(t *testing.T) {
+	t.Parallel()
+	_, rootHash, rootData := buildSourceStateMap(t)
+
+	hdr := header.LedgerHeader{LedgerIndex: 322, AccountHash: rootHash}
+	hdrBytes, ledgerHash := encodeHeader(hdr)
+	il := New(ledgerHash, 322, 7, discardLogger())
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdrBytes}, {NodeData: rootData}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+
+	empty := func([32]byte) ([]byte, bool) { return nil, false }
+	if il.CheckLocal(empty) {
+		t.Error("CheckLocal reported progress from an empty source")
+	}
+	if il.IsComplete() {
+		t.Error("acquisition completed with no nodes supplied")
+	}
+	if il.CheckLocal(nil) {
+		t.Error("CheckLocal with a nil fetch reported progress")
+	}
+}
+
+// TestFetchPackRequested_OneShot pins the one-shot escalation flag and its
+// deadline extension.
+func TestFetchPackRequested_OneShot(t *testing.T) {
+	t.Parallel()
+	il := New([32]byte{1}, 5, 7, discardLogger())
+	if il.FetchPackRequested() {
+		t.Fatal("a fresh acquisition reports fetch-pack already requested")
+	}
+	il.MarkFetchPackRequested()
+	if !il.FetchPackRequested() {
+		t.Fatal("MarkFetchPackRequested was not recorded")
+	}
+	// Extending the deadline must clear a timed-out state at the moment of marking.
+	if il.IsTimedOut() {
+		t.Error("acquisition still reports timed-out immediately after deadline extension")
+	}
+}
+
+// TestTrackerActive_ReturnsInFlight covers the Active iterator used by the
+// router to run CheckLocal on every live acquisition.
+func TestTrackerActive_ReturnsInFlight(t *testing.T) {
+	t.Parallel()
+	tr := NewTracker()
+	if len(tr.Active()) != 0 {
+		t.Fatal("empty tracker should have no active acquisitions")
+	}
+	il := New([32]byte{9}, 5, 7, discardLogger())
+	tr.Track(il)
+	active := tr.Active()
+	if len(active) != 1 || active[0] != il {
+		t.Fatalf("Active did not return the tracked acquisition (got %d)", len(active))
+	}
+	tr.Remove(il.Hash(), false)
+	if len(tr.Active()) != 0 {
+		t.Fatal("removed acquisition is still reported active")
+	}
+}

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -579,9 +579,9 @@ func (l *Ledger) MarkFetchPackRequested() {
 // missing node hashes and feeds back any the supplied fetch func can satisfy,
 // until the source is exhausted or the tree is complete.
 //
-// fetch returns the wire bytes for a SHAMap node hash and whether it was
-// found. CheckLocal returns true if it placed at least one node, so the caller
-// can re-check completion (IsComplete) and finalize.
+// fetch returns the prefix-format (serializeWithPrefix) bytes for a SHAMap node
+// hash and whether it was found. CheckLocal returns true if it placed at least
+// one node, so the caller can re-check completion (IsComplete) and finalize.
 func (l *Ledger) CheckLocal(fetch func(hash [32]byte) ([]byte, bool)) bool {
 	if fetch == nil {
 		return false
@@ -635,7 +635,7 @@ func fillFromLocal(m *shamap.SHAMap, fetch func(hash [32]byte) ([]byte, bool)) b
 			if !ok {
 				continue
 			}
-			if err := m.AddKnownNode(missing[i].Hash, data); err == nil {
+			if err := m.AddKnownNodeFromPrefix(missing[i].Hash, data); err == nil {
 				passAdded++
 			}
 		}

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -91,6 +91,10 @@ type Ledger struct {
 	created   time.Time
 	mu        sync.Mutex
 	logger    *slog.Logger
+
+	// fetchPackRequested records that the router escalated this stalled
+	// acquisition to a fetch-pack (at most once). Guarded by mu.
+	fetchPackRequested bool
 }
 
 // New creates a new InboundLedger acquisition for the given ledger hash.
@@ -539,4 +543,105 @@ func (l *Ledger) Err() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.err
+}
+
+// localFillBatch caps how many missing node hashes CheckLocal pulls per
+// SHAMap descent pass. Larger than missingNodeBatch because the source is a
+// local cache, not a network round-trip, so a wider frontier per pass means
+// fewer descents to drain the tree.
+const localFillBatch = 256
+
+// FetchPackRequested reports whether a fetch-pack has already been requested
+// for this acquisition, so the router escalates at most once.
+func (l *Ledger) FetchPackRequested() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.fetchPackRequested
+}
+
+// MarkFetchPackRequested records that a fetch-pack was requested and grants
+// one more acquisitionTimeout window for the reply to arrive and complete the
+// acquisition locally via CheckLocal. Mirrors rippled arming an aggressive
+// fetch-pack fallback (LedgerMaster::getFetchPack) without immediately
+// abandoning the InboundLedger.
+func (l *Ledger) MarkFetchPackRequested() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.fetchPackRequested = true
+	l.created = time.Now()
+}
+
+// CheckLocal attempts to complete the still-outstanding trees from a local
+// node source instead of the network, mirroring rippled's
+// InboundLedger::tryDB / checkLocal which drains missing SHAMap nodes from the
+// node store after a fetch-pack populates it (InboundLedger.cpp:162-178,
+// 284-296). For each outstanding tree it repeatedly asks the SHAMap for its
+// missing node hashes and feeds back any the supplied fetch func can satisfy,
+// until the source is exhausted or the tree is complete.
+//
+// fetch returns the wire bytes for a SHAMap node hash and whether it was
+// found. CheckLocal returns true if it placed at least one node, so the caller
+// can re-check completion (IsComplete) and finalize.
+func (l *Ledger) CheckLocal(fetch func(hash [32]byte) ([]byte, bool)) bool {
+	if fetch == nil {
+		return false
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.state != StateWantState {
+		return false
+	}
+
+	progressed := false
+	if !l.haveState && l.stateMap != nil {
+		if fillFromLocal(l.stateMap, fetch) {
+			progressed = true
+			if l.stateMap.FinishSync() == nil {
+				l.haveState = true
+			}
+		}
+	}
+	if !l.haveTx && l.txMap != nil {
+		if fillFromLocal(l.txMap, fetch) {
+			progressed = true
+			if l.txMap.FinishSync() == nil {
+				l.haveTx = true
+			}
+		}
+	}
+	if progressed {
+		l.recomputeComplete()
+	}
+	return progressed
+}
+
+// fillFromLocal repeatedly pulls a map's missing node hashes from fetch and
+// attaches any that resolve, until a pass attaches nothing. Returns whether it
+// attached at least one node. Each pass widens the resolved frontier — an
+// attached inner node exposes its children as the next batch's missing set —
+// so a connected subtree present in the source drains fully.
+func fillFromLocal(m *shamap.SHAMap, fetch func(hash [32]byte) ([]byte, bool)) bool {
+	added := false
+	for {
+		missing := m.GetMissingNodes(localFillBatch, nil)
+		if len(missing) == 0 {
+			return added
+		}
+		passAdded := 0
+		for i := range missing {
+			data, ok := fetch(missing[i].Hash)
+			if !ok {
+				continue
+			}
+			if err := m.AddKnownNode(missing[i].Hash, data); err == nil {
+				passAdded++
+			}
+		}
+		if passAdded == 0 {
+			return added
+		}
+		added = true
+	}
 }

--- a/internal/ledger/inbound/tracker.go
+++ b/internal/ledger/inbound/tracker.go
@@ -150,6 +150,23 @@ func (t *Tracker) ActiveTimedOut() []*Ledger {
 	return out
 }
 
+// Active returns every in-flight acquisition currently tracked. The router
+// iterates these to attempt local completion from the fetch-pack cache
+// (Ledger.CheckLocal), mirroring rippled's InboundLedgers::gotFetchPack which
+// calls checkLocal on each live acquisition (InboundLedgers.cpp:359-380).
+func (t *Tracker) Active() []*Ledger {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]*Ledger, 0, len(t.active))
+	for _, l := range t.active {
+		out = append(out, l)
+	}
+	return out
+}
+
 // Clear resets both the in-flight set and the recent-failure history,
 // backing fetch_info's `clear` param (rippled InboundLedgers::clearFailures,
 // which clears mRecentFailures and mLedgers).

--- a/internal/peermanagement/fetchpack_test.go
+++ b/internal/peermanagement/fetchpack_test.go
@@ -1,0 +1,181 @@
+package peermanagement
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFetchPackProvider implements LedgerProvider; only MakeFetchPack is
+// exercised, the rest are inert stubs.
+type fakeFetchPackProvider struct {
+	objects []message.IndexedObject
+	gotHave [32]byte
+	calls   int
+}
+
+func (f *fakeFetchPackProvider) GetLedgerHeader(_ []byte, _ uint32) ([]byte, error) {
+	return nil, nil
+}
+func (f *fakeFetchPackProvider) GetAccountStateNode(_ []byte, _ []byte) ([]byte, error) {
+	return nil, nil
+}
+func (f *fakeFetchPackProvider) GetTransactionNode(_ []byte, _ []byte) ([]byte, error) {
+	return nil, nil
+}
+func (f *fakeFetchPackProvider) GetReplayDelta(_ []byte) ([]byte, [][]byte, error) {
+	return nil, nil, nil
+}
+func (f *fakeFetchPackProvider) GetProofPath(_ []byte, _ []byte, _ message.LedgerMapType) ([]byte, [][]byte, error) {
+	return nil, nil, nil
+}
+func (f *fakeFetchPackProvider) MakeFetchPack(have [32]byte, _ int) ([]message.IndexedObject, error) {
+	f.calls++
+	f.gotHave = have
+	return f.objects, nil
+}
+
+func newFetchPackTestOverlay(t *testing.T, prov LedgerProvider) (*Overlay, *Peer) {
+	t.Helper()
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	events := make(chan Event, 8)
+	o := &Overlay{
+		cfg:        Config{},
+		peers:      make(map[PeerID]*Peer),
+		events:     events,
+		messages:   make(chan *InboundMessage, 8),
+		cluster:    cluster.New(),
+		ledgerSync: NewLedgerSyncHandler(events),
+	}
+	o.ledgerSync.SetProvider(prov)
+	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	o.peers[peer.ID()] = peer
+	return o, peer
+}
+
+// TestServeFetchPack_RepliesWithPack pins the serve path: an otFETCH_PACK
+// request invokes the provider and ships a query=false reply carrying the pack.
+func TestServeFetchPack_RepliesWithPack(t *testing.T) {
+	prov := &fakeFetchPackProvider{objects: []message.IndexedObject{
+		{Hash: bytes.Repeat([]byte{0xAB}, 32), Data: []byte{1, 2, 3}, LedgerSeq: 42},
+		{Hash: bytes.Repeat([]byte{0xCD}, 32), Data: []byte{4, 5, 6}, LedgerSeq: 42},
+	}}
+	o, peer := newFetchPackTestOverlay(t, prov)
+
+	haveHash := bytes.Repeat([]byte{0x11}, 32)
+	payload, err := message.Encode(&message.GetObjectByHash{
+		ObjType:    message.ObjectTypeFetchPack,
+		Query:      true,
+		LedgerHash: haveHash,
+	})
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeGetObjects),
+		Payload:     payload,
+	})
+
+	require.Equal(t, 1, prov.calls, "MakeFetchPack must be invoked once")
+	require.Equal(t, haveHash, prov.gotHave[:], "the have-hash must be forwarded to the provider")
+
+	select {
+	case frame := <-peer.send:
+		require.GreaterOrEqual(t, len(frame), message.HeaderSizeUncompressed)
+		msgType := (uint16(frame[4]) << 8) | uint16(frame[5])
+		require.Equal(t, uint16(message.TypeGetObjects), msgType)
+		decoded, err := message.Decode(message.TypeGetObjects, frame[message.HeaderSizeUncompressed:])
+		require.NoError(t, err)
+		gob, ok := decoded.(*message.GetObjectByHash)
+		require.True(t, ok)
+		assert.False(t, gob.Query, "reply must be query=false")
+		assert.Equal(t, message.ObjectTypeFetchPack, gob.ObjType)
+		assert.Equal(t, haveHash, gob.LedgerHash)
+		assert.Len(t, gob.Objects, 2)
+	default:
+		t.Fatal("no fetch-pack reply was sent to the peer")
+	}
+}
+
+// TestServeFetchPack_EmptyPackNoReply: an empty pack (unknown ledger) yields no
+// reply and no charge.
+func TestServeFetchPack_EmptyPackNoReply(t *testing.T) {
+	prov := &fakeFetchPackProvider{objects: nil}
+	o, peer := newFetchPackTestOverlay(t, prov)
+
+	payload, err := message.Encode(&message.GetObjectByHash{
+		ObjType:    message.ObjectTypeFetchPack,
+		Query:      true,
+		LedgerHash: bytes.Repeat([]byte{0x22}, 32),
+	})
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeGetObjects),
+		Payload:     payload,
+	})
+
+	require.Equal(t, 1, prov.calls)
+	select {
+	case <-peer.send:
+		t.Fatal("an empty pack must not produce a reply")
+	default:
+	}
+	assert.Zero(t, peer.BadDataCount(), "an unknown ledger is not a bad-data charge")
+}
+
+// TestServeFetchPack_BadHashCharged: a malformed (non-32-byte) ledger hash is
+// charged as bad data and never reaches the provider.
+func TestServeFetchPack_BadHashCharged(t *testing.T) {
+	prov := &fakeFetchPackProvider{}
+	o, peer := newFetchPackTestOverlay(t, prov)
+
+	payload, err := message.Encode(&message.GetObjectByHash{
+		ObjType:    message.ObjectTypeFetchPack,
+		Query:      true,
+		LedgerHash: []byte{0x01, 0x02, 0x03},
+	})
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeGetObjects),
+		Payload:     payload,
+	})
+
+	assert.Zero(t, prov.calls, "a malformed hash must not reach the provider")
+	assert.NotZero(t, peer.BadDataCount(), "a malformed fetch-pack hash must be charged")
+}
+
+// TestHandleGetObjects_FetchPackReplyForwardedToRouter: a query=false
+// fetch-pack reply is forwarded to the overlay→router channel for consumption.
+func TestHandleGetObjects_FetchPackReplyForwardedToRouter(t *testing.T) {
+	o, peer := newFetchPackTestOverlay(t, &fakeFetchPackProvider{})
+
+	payload, err := message.Encode(&message.GetObjectByHash{
+		ObjType: message.ObjectTypeFetchPack,
+		Query:   false,
+		Objects: []message.IndexedObject{{Hash: bytes.Repeat([]byte{0x01}, 32), Data: []byte{0x09}}},
+	})
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeGetObjects),
+		Payload:     payload,
+	})
+
+	select {
+	case got := <-o.messages:
+		assert.Equal(t, uint16(message.TypeGetObjects), got.Type)
+		assert.Equal(t, peer.ID(), got.PeerID)
+	default:
+		t.Fatal("fetch-pack reply was not forwarded to the router channel")
+	}
+}

--- a/internal/peermanagement/fetchpack_test.go
+++ b/internal/peermanagement/fetchpack_test.go
@@ -103,7 +103,9 @@ func TestServeFetchPack_RepliesWithPack(t *testing.T) {
 }
 
 // TestServeFetchPack_EmptyPackNoReply: an empty pack (unknown ledger) yields no
-// reply and no charge.
+// reply, but the valid request is still charged feeHeavyBurdenPeer up front —
+// mirroring rippled's doFetchPack, which sets the heavy-burden fee before the
+// build regardless of whether the ledger is found (PeerImp.cpp:2773).
 func TestServeFetchPack_EmptyPackNoReply(t *testing.T) {
 	prov := &fakeFetchPackProvider{objects: nil}
 	o, peer := newFetchPackTestOverlay(t, prov)
@@ -127,7 +129,8 @@ func TestServeFetchPack_EmptyPackNoReply(t *testing.T) {
 		t.Fatal("an empty pack must not produce a reply")
 	default:
 	}
-	assert.Zero(t, peer.BadDataCount(), "an unknown ledger is not a bad-data charge")
+	assert.NotZero(t, peer.BadDataCount(),
+		"a valid fetch-pack request is charged feeHeavyBurdenPeer up front even when the pack is empty")
 }
 
 // TestServeFetchPack_BadHashCharged: a malformed (non-32-byte) ledger hash is

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -161,16 +161,17 @@ func validGossipAddress(name string) bool {
 // rippled PeerImp::onMessage(TMGetObjectByHash) at PeerImp.cpp:2442-2595.
 //
 // The wire object covers three feature surfaces:
-//   - otFETCH_PACK requests (block-acceleration prefetch);
+//   - otFETCH_PACK requests/replies (bulk SHAMap-node prefetch);
 //   - otTRANSACTIONS requests/replies (tx-reduce-relay back-fill);
 //   - generic node-store object fetch by hash.
 //
-// go-xrpl does not implement fetch-packs (no LedgerMaster::gotFetchPack
-// path) and does not advertise txReduceRelay by default (config.go
-// EnableTxReduceRelay defaults to false), so those two branches mirror
-// rippled's rejection paths. The generic node-store object fetch is
-// served from the local node store via serveGetObjects when a provider
-// is wired.
+// Fetch-pack requests are served from the ledger provider (serveFetchPack)
+// and fetch-pack replies are forwarded to the consensus router, which owns
+// ledger acquisitions and the fetch-pack cache. tx-reduce-relay back-fill is
+// gated on the operator opt-in (config.go EnableTxReduceRelay defaults to
+// false), so that branch mirrors rippled's rejection path when off. The
+// generic node-store object fetch is served from the local node store via
+// serveGetObjects when a provider is wired.
 func (o *Overlay) handleGetObjectsMessage(evt Event) {
 	decoded, err := message.Decode(message.TypeGetObjects, evt.Payload)
 	if err != nil {
@@ -202,14 +203,10 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 		}
 		switch gob.ObjType {
 		case message.ObjectTypeFetchPack:
-			// Rippled at PeerImp.cpp:2458-2462 forwards to
-			// doFetchPack. go-xrpl has no fetch-pack subsystem;
-			// treat as an unsupported request and drop without
-			// charging — the peer is using a feature we never
-			// advertise and a charge here would punish honest
-			// gossip-driven peers.
-			slog.Debug("TMGetObjects fetch-pack request unsupported; dropping",
-				"t", "Overlay", "peer", evt.PeerID)
+			// Rippled at PeerImp.cpp:2458-2462 forwards to doFetchPack.
+			// Build a pack of the predecessor ledger's SHAMap nodes and
+			// reply (serveFetchPack), mirroring makeFetchPack.
+			o.serveFetchPack(evt.PeerID, gob)
 			return
 		case message.ObjectTypeTransactions:
 			// Tx-reduce-relay back-fill request. Rippled gates on
@@ -235,12 +232,86 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 		return
 	}
 
-	// Reply branch (query=false). Rippled adds the inbound objects to
-	// the fetch-pack cache at PeerImp.cpp:2547-2593. go-xrpl has no
-	// fetch-pack acquisition state — an unsolicited reply means the
-	// peer is malformed or buggy.
+	// Reply branch (query=false). Rippled adds the inbound objects to the
+	// fetch-pack cache at PeerImp.cpp:2547-2593. The acquisition state and
+	// the fetch-pack cache live in the consensus router, so forward the reply
+	// onto the overlay→router channel exactly as every other peer-originated
+	// reply (TMLedgerData, TMTransaction) is delivered. Other reply types have
+	// no consumer and are dropped.
+	if gob.ObjType == message.ObjectTypeFetchPack {
+		select {
+		case o.messages <- &InboundMessage{
+			PeerID:  evt.PeerID,
+			Type:    evt.MessageType,
+			Payload: evt.Payload,
+		}:
+		default:
+			o.droppedMessages.Add(1)
+			slog.Warn("TMGetObjects fetch-pack reply dropped: channel full",
+				"t", "Overlay", "peer", evt.PeerID)
+		}
+		return
+	}
 	slog.Debug("TMGetObjects reply received without outstanding request; dropping",
 		"t", "Overlay", "peer", evt.PeerID)
+}
+
+// serveFetchPack answers an inbound mtGET_OBJECTS{otFETCH_PACK, query=true}.
+// Mirrors rippled PeerImp::doFetchPack → LedgerMaster::makeFetchPack
+// (PeerImp.cpp:2753-2784, LedgerMaster.cpp:2096-2225): build a pack of the
+// SHAMap nodes for the predecessor of the requested ledger and reply with a
+// query=false TMGetObjectByHash. The requested ledger hash must be 32 bytes;
+// an unknown ledger or unavailable parent yields an empty pack which is
+// dropped (rippled charges the peer there; we mirror the more permissive
+// go-xrpl stance taken by serveDoTransactions and only charge a malformed hash).
+func (o *Overlay) serveFetchPack(peerID PeerID, req *message.GetObjectByHash) {
+	if len(req.LedgerHash) != 32 {
+		o.IncPeerBadData(peerID, "fetch-pack-bad-hash")
+		return
+	}
+	var haveHash [32]byte
+	copy(haveHash[:], req.LedgerHash)
+
+	// maxObjects=0 lets the provider apply its own per-pack cap.
+	objects, err := o.ledgerSync.MakeFetchPack(haveHash, 0)
+	if err != nil {
+		slog.Debug("fetch-pack build failed",
+			"t", "Overlay", "peer", peerID, "err", err)
+		return
+	}
+	if len(objects) == 0 {
+		return
+	}
+
+	reply := &message.GetObjectByHash{
+		ObjType:    message.ObjectTypeFetchPack,
+		Query:      false,
+		Seq:        req.Seq,
+		LedgerHash: append([]byte(nil), req.LedgerHash...),
+		Objects:    objects,
+	}
+	encoded, err := message.Encode(reply)
+	if err != nil {
+		slog.Debug("fetch-pack reply encode failed",
+			"t", "Overlay", "peer", peerID, "err", err)
+		return
+	}
+	frame, err := message.BuildWireMessage(message.TypeGetObjects, encoded)
+	if err != nil {
+		slog.Debug("fetch-pack reply frame build failed",
+			"t", "Overlay", "peer", peerID, "err", err)
+		return
+	}
+	o.peersMu.RLock()
+	peer, exists := o.peers[peerID]
+	o.peersMu.RUnlock()
+	if !exists {
+		return
+	}
+	if sendErr := peer.Send(frame); sendErr != nil {
+		slog.Debug("fetch-pack reply send failed",
+			"t", "Overlay", "peer", peerID, "err", sendErr)
+	}
 }
 
 // handleHaveTransactionsMessage processes mtHAVE_TRANSACTIONS from a

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -260,15 +260,30 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 // Mirrors rippled PeerImp::doFetchPack → LedgerMaster::makeFetchPack
 // (PeerImp.cpp:2753-2784, LedgerMaster.cpp:2096-2225): build a pack of the
 // SHAMap nodes for the predecessor of the requested ledger and reply with a
-// query=false TMGetObjectByHash. The requested ledger hash must be 32 bytes;
-// an unknown ledger or unavailable parent yields an empty pack which is
-// dropped (rippled charges the peer there; we mirror the more permissive
-// go-xrpl stance taken by serveDoTransactions and only charge a malformed hash).
+// query=false TMGetObjectByHash. The requested ledger hash must be 32 bytes; an
+// unknown ledger or unavailable parent yields an empty pack which is dropped
+// (rippled charges the peer there; we mirror the more permissive go-xrpl stance
+// taken by serveDoTransactions and only charge a malformed hash there). A valid
+// request is charged feeHeavyBurdenPeer up front, mirroring rippled's
+// doFetchPack (PeerImp.cpp:2773): building a pack snapshots the want ledger's
+// full state+tx tree and walks up to fetchPackMaxObjects nodes — heavier than
+// rippled's diff. go-xrpl builds the pack inline (no jtPACK job queue to bound),
+// so the send-queue back-pressure gate in handleGetObjectsMessage stands in for
+// rippled's isLoadedLocal / jtPACK busy guards (PeerImp.cpp:2758-2762).
 func (o *Overlay) serveFetchPack(peerID PeerID, req *message.GetObjectByHash) {
 	if len(req.LedgerHash) != 32 {
 		o.IncPeerBadData(peerID, "fetch-pack-bad-hash")
 		return
 	}
+
+	o.peersMu.RLock()
+	peer, exists := o.peers[peerID]
+	o.peersMu.RUnlock()
+	if !exists {
+		return
+	}
+	peer.Charge(resource.FeeHeavyBurdenPeer, "fetch pack request")
+
 	var haveHash [32]byte
 	copy(haveHash[:], req.LedgerHash)
 
@@ -300,12 +315,6 @@ func (o *Overlay) serveFetchPack(peerID PeerID, req *message.GetObjectByHash) {
 	if err != nil {
 		slog.Debug("fetch-pack reply frame build failed",
 			"t", "Overlay", "peer", peerID, "err", err)
-		return
-	}
-	o.peersMu.RLock()
-	peer, exists := o.peers[peerID]
-	o.peersMu.RUnlock()
-	if !exists {
 		return
 	}
 	if sendErr := peer.Send(frame); sendErr != nil {

--- a/internal/peermanagement/ledgersync.go
+++ b/internal/peermanagement/ledgersync.go
@@ -142,6 +142,16 @@ type LedgerProvider interface {
 	//   - any other error → handler emits ReplyErrorBadRequest and logs
 	//     at warn.
 	GetProofPath(ledgerHash []byte, key []byte, mapType message.LedgerMapType) (header []byte, path [][]byte, err error)
+	// MakeFetchPack builds a fetch-pack for the predecessor of the ledger
+	// named by haveLedgerHash, mirroring rippled's LedgerMaster::makeFetchPack
+	// (LedgerMaster.cpp:2096-2225): the requester supplies a ledger hash it
+	// HAS, and the provider returns the SHAMap nodes of its parent ("want") —
+	// a header object followed by the account-state and transaction tree
+	// nodes, each tagged with want's sequence. Returns (nil, nil) when the
+	// ledger is unknown, still open, or its parent is unavailable, so the
+	// handler drops the request without replying. maxObjects <= 0 lets the
+	// provider apply its own cap.
+	MakeFetchPack(haveLedgerHash [32]byte, maxObjects int) ([]message.IndexedObject, error)
 }
 
 // LedgerSyncHandler handles ledger synchronization messages.
@@ -204,6 +214,20 @@ func (h *LedgerSyncHandler) SetProvider(provider LedgerProvider) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.provider = provider
+}
+
+// MakeFetchPack delegates to the configured provider so the overlay's
+// otFETCH_PACK serve path can build a pack without importing the ledger
+// layer. Returns (nil, nil) when no provider is wired (the handler then drops
+// the request), matching the silent-drop stance of the other serve paths.
+func (h *LedgerSyncHandler) MakeFetchPack(haveLedgerHash [32]byte, maxObjects int) ([]message.IndexedObject, error) {
+	h.mu.RLock()
+	provider := h.provider
+	h.mu.RUnlock()
+	if provider == nil {
+		return nil, nil
+	}
+	return provider.MakeFetchPack(haveLedgerHash, maxObjects)
 }
 
 // PreferredPeersForLedger returns peer IDs whose last-known

--- a/internal/peermanagement/proof_path_test.go
+++ b/internal/peermanagement/proof_path_test.go
@@ -45,6 +45,9 @@ func (f *fakeProofPathProvider) GetProofPath(ledgerHash []byte, key []byte, mapT
 	f.gotMapType = mapType
 	return f.header, f.path, f.err
 }
+func (f *fakeProofPathProvider) MakeFetchPack(_ [32]byte, _ int) ([]message.IndexedObject, error) {
+	return nil, nil
+}
 
 // fixedKey returns a deterministic 32-byte key distinct from fixedHash so
 // assertions can distinguish the two fields.

--- a/internal/peermanagement/replay_delta_test.go
+++ b/internal/peermanagement/replay_delta_test.go
@@ -37,6 +37,9 @@ func (f *fakeReplayDeltaProvider) GetReplayDelta(_ []byte) ([]byte, [][]byte, er
 func (f *fakeReplayDeltaProvider) GetProofPath(_ []byte, _ []byte, _ message.LedgerMapType) ([]byte, [][]byte, error) {
 	return nil, nil, nil
 }
+func (f *fakeReplayDeltaProvider) MakeFetchPack(_ [32]byte, _ int) ([]message.IndexedObject, error) {
+	return nil, nil
+}
 
 // fixedHash returns a 32-byte ledger hash whose contents are predictable
 // so test assertions remain stable across runs.

--- a/internal/testing/p2p/two_overlay_test.go
+++ b/internal/testing/p2p/two_overlay_test.go
@@ -149,6 +149,66 @@ func (p *lookupProvider) GetProofPath(_ []byte, _ []byte, _ message.LedgerMapTyp
 	return nil, nil, nil
 }
 
+// MakeFetchPack builds a fetch-pack for the parent of haveLedgerHash, mirroring
+// adaptor.LedgerProvider.MakeFetchPack against the in-memory lookup so the
+// two-overlay harness can exercise the serve path end-to-end.
+func (p *lookupProvider) MakeFetchPack(haveLedgerHash [32]byte, maxObjects int) ([]message.IndexedObject, error) {
+	have := p.lookup.byHash[haveLedgerHash]
+	if have == nil || !have.IsImmutable() {
+		return nil, nil
+	}
+	want := p.lookup.byHash[have.Header().ParentHash]
+	if want == nil {
+		return nil, nil
+	}
+	if maxObjects <= 0 {
+		maxObjects = 12288
+	}
+	seq := want.Sequence()
+	wantHdr := want.Header()
+	wantHash := want.Hash()
+	objects := []message.IndexedObject{{
+		Hash:      append([]byte(nil), wantHash[:]...),
+		Data:      append(protocol.HashPrefixLedgerMaster.Bytes(), header.AddRaw(wantHdr, false)...),
+		LedgerSeq: seq,
+	}}
+	appendNodes := func(m *shamap.SHAMap) error {
+		remaining := maxObjects - len(objects)
+		if remaining <= 0 || m == nil {
+			return nil
+		}
+		nodes, err := m.WalkFetchPackNodes(remaining)
+		if err != nil {
+			return err
+		}
+		for i := range nodes {
+			objects = append(objects, message.IndexedObject{
+				Hash:      append([]byte(nil), nodes[i].Hash[:]...),
+				Data:      nodes[i].Data,
+				LedgerSeq: seq,
+			})
+		}
+		return nil
+	}
+	stateMap, err := want.StateMapSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	if err := appendNodes(stateMap); err != nil {
+		return nil, err
+	}
+	if wantHdr.TxHash != ([32]byte{}) {
+		txMap, err := want.TxMapSnapshot()
+		if err != nil {
+			return nil, err
+		}
+		if err := appendNodes(txMap); err != nil {
+			return nil, err
+		}
+	}
+	return objects, nil
+}
+
 func to32(b []byte) ([32]byte, bool) {
 	var out [32]byte
 	if len(b) != 32 {
@@ -608,6 +668,9 @@ func (p *proofPathLookupProvider) GetProofPath(h, k []byte, m message.LedgerMapT
 		return nil, nil, peermanagement.ErrKeyNotFound
 	}
 	return p.tx(h, k)
+}
+func (p *proofPathLookupProvider) MakeFetchPack(haveLedgerHash [32]byte, maxObjects int) ([]message.IndexedObject, error) {
+	return p.base.MakeFetchPack(haveLedgerHash, maxObjects)
 }
 
 func toArr32(b []byte) [32]byte {

--- a/shamap/fetchpack.go
+++ b/shamap/fetchpack.go
@@ -1,0 +1,101 @@
+package shamap
+
+// FetchPackNode is a single SHAMap tree node packaged for a fetch-pack: its
+// node hash (the TMIndexedObject.hash carried on the wire) and its wire
+// serialization (SerializeForWire — the same blob TMLedgerData carries and
+// AddKnownNode consumes).
+type FetchPackNode struct {
+	Hash [32]byte
+	Data []byte
+}
+
+// WalkFetchPackNodes returns up to maxNodes SHAMap tree nodes (inner and
+// leaf) in pre-order, each paired with its node hash and wire serialization.
+//
+// This is the serve-side building block for a fetch-pack. Rippled's
+// LedgerMaster::populateFetchPack (LedgerMaster.cpp:2063-2093) walks
+// want->stateMap() emitting each node's serializeWithPrefix() bytes; go-xrpl
+// peers exchange SHAMap nodes in the SerializeForWire() format (the format
+// AddKnownNode round-trips), so fetch-pack nodes use that format and a peer
+// reconstructs the tree by feeding each blob to AddKnownNode keyed by Hash.
+//
+// Pre-order guarantees the root precedes its descendants, so a result
+// truncated at maxNodes is always a connected prefix of the tree the receiver
+// can use. Unlike rippled, the walk does NOT diff against a "have" ledger:
+// rippled sends only want-vs-have differences because the receiver's node DB
+// supplies the unchanged nodes, but a go-xrpl acquisition fills an in-memory
+// SHAMap with no node-hash-keyed backing store to supply un-sent shared nodes
+// — so a diff would leave it unable to complete. Sending want's full (capped)
+// tree is correct for any receiver: a node it already holds is simply ignored.
+func (sm *SHAMap) WalkFetchPackNodes(maxNodes int) ([]FetchPackNode, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	if sm.root == nil || maxNodes <= 0 {
+		return nil, nil
+	}
+	// An empty map's root is an empty inner node that has no wire form; there
+	// is nothing to pack. Production never walks an empty map (state maps are
+	// non-empty and tx maps are skipped when the tx tree is empty), but guard
+	// it so the walk is total.
+	if !sm.root.HasChildren() {
+		return nil, nil
+	}
+	out := make([]FetchPackNode, 0, maxNodes)
+	if err := walkFetchPackRec(sm.root, maxNodes, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func walkFetchPackRec(node Node, maxNodes int, out *[]FetchPackNode) error {
+	if node == nil || len(*out) >= maxNodes {
+		return nil
+	}
+	data, err := node.SerializeForWire()
+	if err != nil {
+		return err
+	}
+	*out = append(*out, FetchPackNode{Hash: node.Hash(), Data: data})
+
+	inner, ok := node.(*InnerNode)
+	if !ok {
+		return nil
+	}
+	inner.mu.RLock()
+	defer inner.mu.RUnlock()
+	for branch := 0; branch < BranchFactor; branch++ {
+		if len(*out) >= maxNodes {
+			break
+		}
+		child := inner.children[branch]
+		if child == nil {
+			continue
+		}
+		if err := walkFetchPackRec(child, maxNodes, out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// VerifyWireNode reports whether data deserializes to a SHAMap node whose
+// computed hash equals expected. The fetch-pack consume path uses it to reject
+// poisoned (hash != data) nodes before caching them, mirroring rippled's
+// LedgerMaster::getFetchPack sha512Half(data) == hash check
+// (LedgerMaster.cpp:680-698). The leading ledger-header object of a pack is
+// not a SHAMap node and is expected to fail here; only SHAMap tree nodes are
+// needed to complete an acquisition.
+func VerifyWireNode(expected [32]byte, data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	node, err := DeserializeNodeFromWire(data)
+	if err != nil {
+		return false
+	}
+	if err := node.UpdateHash(); err != nil {
+		return false
+	}
+	return node.Hash() == expected
+}

--- a/shamap/fetchpack.go
+++ b/shamap/fetchpack.go
@@ -1,23 +1,25 @@
 package shamap
 
 // FetchPackNode is a single SHAMap tree node packaged for a fetch-pack: its
-// node hash (the TMIndexedObject.hash carried on the wire) and its wire
-// serialization (SerializeForWire — the same blob TMLedgerData carries and
-// AddKnownNode consumes).
+// node hash (the TMIndexedObject.hash carried on the wire) and its prefix
+// serialization (SerializeWithPrefix — the [HashPrefix][body] blob whose
+// sha512Half is the node hash, matching rippled's fetch-pack node format).
 type FetchPackNode struct {
 	Hash [32]byte
 	Data []byte
 }
 
 // WalkFetchPackNodes returns up to maxNodes SHAMap tree nodes (inner and
-// leaf) in pre-order, each paired with its node hash and wire serialization.
+// leaf) in pre-order, each paired with its node hash and prefix serialization.
 //
 // This is the serve-side building block for a fetch-pack. Rippled's
 // LedgerMaster::populateFetchPack (LedgerMaster.cpp:2063-2093) walks
-// want->stateMap() emitting each node's serializeWithPrefix() bytes; go-xrpl
-// peers exchange SHAMap nodes in the SerializeForWire() format (the format
-// AddKnownNode round-trips), so fetch-pack nodes use that format and a peer
-// reconstructs the tree by feeding each blob to AddKnownNode keyed by Hash.
+// want->stateMap() emitting each node's serializeWithPrefix() bytes — the
+// [HashPrefix][body] form whose sha512Half is the node hash. go-xrpl emits the
+// identical SerializeWithPrefix() bytes so a rippled peer's consume check
+// (hash == sha512Half(data), LedgerMaster.cpp:2019) accepts every node, and a
+// go-xrpl receiver verifies and reconstructs the tree by feeding each blob to
+// AddKnownNodeFromPrefix keyed by Hash.
 //
 // Pre-order guarantees the root precedes its descendants, so a result
 // truncated at maxNodes is always a connected prefix of the tree the receiver
@@ -34,10 +36,10 @@ func (sm *SHAMap) WalkFetchPackNodes(maxNodes int) ([]FetchPackNode, error) {
 	if sm.root == nil || maxNodes <= 0 {
 		return nil, nil
 	}
-	// An empty map's root is an empty inner node that has no wire form; there
-	// is nothing to pack. Production never walks an empty map (state maps are
-	// non-empty and tx maps are skipped when the tx tree is empty), but guard
-	// it so the walk is total.
+	// An empty map's root is an empty inner node with no serialized form;
+	// there is nothing to pack. Production never walks an empty map (state
+	// maps are non-empty and tx maps are skipped when the tx tree is empty),
+	// but guard it so the walk is total.
 	if !sm.root.HasChildren() {
 		return nil, nil
 	}
@@ -52,7 +54,7 @@ func walkFetchPackRec(node Node, maxNodes int, out *[]FetchPackNode) error {
 	if node == nil || len(*out) >= maxNodes {
 		return nil
 	}
-	data, err := node.SerializeForWire()
+	data, err := node.SerializeWithPrefix()
 	if err != nil {
 		return err
 	}
@@ -79,18 +81,19 @@ func walkFetchPackRec(node Node, maxNodes int, out *[]FetchPackNode) error {
 	return nil
 }
 
-// VerifyWireNode reports whether data deserializes to a SHAMap node whose
-// computed hash equals expected. The fetch-pack consume path uses it to reject
-// poisoned (hash != data) nodes before caching them, mirroring rippled's
-// LedgerMaster::getFetchPack sha512Half(data) == hash check
-// (LedgerMaster.cpp:680-698). The leading ledger-header object of a pack is
-// not a SHAMap node and is expected to fail here; only SHAMap tree nodes are
+// VerifyFetchPackNode reports whether data is the prefix (serializeWithPrefix)
+// serialization of a SHAMap node whose computed hash equals expected. The
+// fetch-pack consume path uses it to reject poisoned (hash != data) nodes
+// before caching them, mirroring rippled's LedgerMaster::getFetchPack
+// sha512Half(data) == hash check (LedgerMaster.cpp:2019). The leading
+// ledger-header object of a pack carries the ledgerMaster prefix, not a SHAMap
+// node prefix, so it fails here and is dropped; only SHAMap tree nodes are
 // needed to complete an acquisition.
-func VerifyWireNode(expected [32]byte, data []byte) bool {
+func VerifyFetchPackNode(expected [32]byte, data []byte) bool {
 	if len(data) == 0 {
 		return false
 	}
-	node, err := DeserializeNodeFromWire(data)
+	node, err := DeserializeFromPrefix(data)
 	if err != nil {
 		return false
 	}

--- a/shamap/fetchpack_test.go
+++ b/shamap/fetchpack_test.go
@@ -30,7 +30,7 @@ func buildFetchPackTestMap(t *testing.T) *SHAMap {
 }
 
 // TestWalkFetchPackNodes_AllNodesVerify checks that every node the serve side
-// emits round-trips through VerifyWireNode — i.e. a consumer can verify each
+// emits round-trips through VerifyFetchPackNode — i.e. a consumer can verify each
 // node against its advertised hash — and that tampering is rejected.
 func TestWalkFetchPackNodes_AllNodesVerify(t *testing.T) {
 	t.Parallel()
@@ -44,25 +44,25 @@ func TestWalkFetchPackNodes_AllNodesVerify(t *testing.T) {
 		t.Fatalf("want a multi-level tree, got %d nodes", len(nodes))
 	}
 	for i, n := range nodes {
-		if !VerifyWireNode(n.Hash, n.Data) {
-			t.Errorf("node %d failed VerifyWireNode", i)
+		if !VerifyFetchPackNode(n.Hash, n.Data) {
+			t.Errorf("node %d failed VerifyFetchPackNode", i)
 		}
 	}
 
 	// Wrong hash must be rejected.
 	var bad [32]byte
-	if VerifyWireNode(bad, nodes[0].Data) {
-		t.Error("VerifyWireNode accepted a node under the wrong hash")
+	if VerifyFetchPackNode(bad, nodes[0].Data) {
+		t.Error("VerifyFetchPackNode accepted a node under the wrong hash")
 	}
 	// Tampered data must be rejected.
 	corrupt := append([]byte(nil), nodes[len(nodes)-1].Data...)
 	corrupt[len(corrupt)-1] ^= 0xFF
-	if VerifyWireNode(nodes[len(nodes)-1].Hash, corrupt) {
-		t.Error("VerifyWireNode accepted tampered data")
+	if VerifyFetchPackNode(nodes[len(nodes)-1].Hash, corrupt) {
+		t.Error("VerifyFetchPackNode accepted tampered data")
 	}
 	// Empty data must be rejected.
-	if VerifyWireNode(nodes[0].Hash, nil) {
-		t.Error("VerifyWireNode accepted empty data")
+	if VerifyFetchPackNode(nodes[0].Hash, nil) {
+		t.Error("VerifyFetchPackNode accepted empty data")
 	}
 }
 
@@ -114,8 +114,8 @@ func TestWalkFetchPackNodes_Bounds(t *testing.T) {
 		t.Fatalf("walk empty: %v", err)
 	}
 	for i, n := range nodes {
-		if !VerifyWireNode(n.Hash, n.Data) {
-			t.Errorf("empty-map node %d failed VerifyWireNode", i)
+		if !VerifyFetchPackNode(n.Hash, n.Data) {
+			t.Errorf("empty-map node %d failed VerifyFetchPackNode", i)
 		}
 	}
 }

--- a/shamap/fetchpack_test.go
+++ b/shamap/fetchpack_test.go
@@ -1,0 +1,121 @@
+package shamap
+
+import "testing"
+
+// buildFetchPackTestMap builds a multi-level state SHAMap with deterministic,
+// non-zero keys so the tree has inner nodes above the leaves.
+func buildFetchPackTestMap(t *testing.T) *SHAMap {
+	t.Helper()
+	sm, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	for branch := byte(0); branch < 4; branch++ {
+		for sub := byte(0); sub < 4; sub++ {
+			for i := byte(0); i < 4; i++ {
+				var key [32]byte
+				key[0] = (branch << 4) | sub
+				key[1] = i << 4
+				key[31] = 0xA5 // keep the leaf key non-zero (TypeState rejects zero)
+				if err := sm.Put(key, []byte{branch, sub, i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}); err != nil {
+					t.Fatalf("put: %v", err)
+				}
+			}
+		}
+	}
+	if _, err := sm.Hash(); err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	return sm
+}
+
+// TestWalkFetchPackNodes_AllNodesVerify checks that every node the serve side
+// emits round-trips through VerifyWireNode — i.e. a consumer can verify each
+// node against its advertised hash — and that tampering is rejected.
+func TestWalkFetchPackNodes_AllNodesVerify(t *testing.T) {
+	t.Parallel()
+	sm := buildFetchPackTestMap(t)
+
+	nodes, err := sm.WalkFetchPackNodes(1 << 20)
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(nodes) < 3 {
+		t.Fatalf("want a multi-level tree, got %d nodes", len(nodes))
+	}
+	for i, n := range nodes {
+		if !VerifyWireNode(n.Hash, n.Data) {
+			t.Errorf("node %d failed VerifyWireNode", i)
+		}
+	}
+
+	// Wrong hash must be rejected.
+	var bad [32]byte
+	if VerifyWireNode(bad, nodes[0].Data) {
+		t.Error("VerifyWireNode accepted a node under the wrong hash")
+	}
+	// Tampered data must be rejected.
+	corrupt := append([]byte(nil), nodes[len(nodes)-1].Data...)
+	corrupt[len(corrupt)-1] ^= 0xFF
+	if VerifyWireNode(nodes[len(nodes)-1].Hash, corrupt) {
+		t.Error("VerifyWireNode accepted tampered data")
+	}
+	// Empty data must be rejected.
+	if VerifyWireNode(nodes[0].Hash, nil) {
+		t.Error("VerifyWireNode accepted empty data")
+	}
+}
+
+// TestWalkFetchPackNodes_RespectsCapAndOrder checks the maxNodes cap and that
+// the walk is pre-order (root first), so a truncated pack is a connected prefix.
+func TestWalkFetchPackNodes_RespectsCapAndOrder(t *testing.T) {
+	t.Parallel()
+	sm := buildFetchPackTestMap(t)
+
+	all, err := sm.WalkFetchPackNodes(1 << 20)
+	if err != nil {
+		t.Fatalf("walk all: %v", err)
+	}
+	capped, err := sm.WalkFetchPackNodes(3)
+	if err != nil {
+		t.Fatalf("walk capped: %v", err)
+	}
+	if len(capped) != 3 {
+		t.Fatalf("cap not honored: got %d, want 3", len(capped))
+	}
+	for i := range capped {
+		if capped[i].Hash != all[i].Hash {
+			t.Errorf("node %d: capped walk diverges from full pre-order walk", i)
+		}
+	}
+	rootHash, err := sm.Hash()
+	if err != nil {
+		t.Fatalf("root hash: %v", err)
+	}
+	if capped[0].Hash != rootHash {
+		t.Errorf("first walked node is not the root: got %x want %x", capped[0].Hash[:8], rootHash[:8])
+	}
+}
+
+// TestWalkFetchPackNodes_Bounds covers the degenerate inputs.
+func TestWalkFetchPackNodes_Bounds(t *testing.T) {
+	t.Parallel()
+	sm := buildFetchPackTestMap(t)
+	if nodes, err := sm.WalkFetchPackNodes(0); err != nil || nodes != nil {
+		t.Fatalf("maxNodes=0: got (%v, %v), want (nil, nil)", nodes, err)
+	}
+
+	empty, err := New(TypeState)
+	if err != nil {
+		t.Fatalf("new empty: %v", err)
+	}
+	nodes, err := empty.WalkFetchPackNodes(10)
+	if err != nil {
+		t.Fatalf("walk empty: %v", err)
+	}
+	for i, n := range nodes {
+		if !VerifyWireNode(n.Hash, n.Data) {
+			t.Errorf("empty-map node %d failed VerifyWireNode", i)
+		}
+	}
+}

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -479,6 +479,40 @@ func (sm *SHAMap) AddKnownNode(nodeHash [32]byte, data []byte) error {
 	return sm.insertKnownNode(nodeHash, node)
 }
 
+// AddKnownNodeFromPrefix adds a node received in a fetch-pack, whose blob is in
+// prefix (serializeWithPrefix) format — the format rippled's makeFetchPack
+// emits and verifies via sha512Half(data) == hash. It mirrors AddKnownNode but
+// parses the prefixed serialization (DeserializeFromPrefix) instead of the
+// compact wire form, leaving the network-acquisition wire path untouched.
+func (sm *SHAMap) AddKnownNodeFromPrefix(nodeHash [32]byte, data []byte) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.state != StateSyncing {
+		return ErrSyncNotInProgress
+	}
+
+	if len(data) == 0 {
+		return ErrInvalidNodeData
+	}
+
+	node, err := DeserializeFromPrefix(data)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidNodeData, err)
+	}
+
+	if err := node.UpdateHash(); err != nil {
+		return fmt.Errorf("failed to compute node hash: %w", err)
+	}
+
+	computedHash := node.Hash()
+	if !bytes.Equal(computedHash[:], nodeHash[:]) {
+		return ErrNodeHashMismatch
+	}
+
+	return sm.insertKnownNode(nodeHash, node)
+}
+
 // AddKnownNodeByID inserts a node from wire data at the position specified
 // by the peer-supplied SHAMap NodeID (path + depth). The node's computed
 // hash must match the parent's stored child hash at the target branch.


### PR DESCRIPTION
## Summary

Implements the bulk SHAMap-node prefetch ("fetch-pack") path that go-xrpl was missing (#763). go-xrpl can now both **serve** fetch-packs to peers and **consume** them to accelerate a stalled ledger acquisition, mirroring rippled's `makeFetchPack` / `addFetchPack` / `gotFetchPack` flow. Not a consensus-correctness change — sync efficiency and overlay reciprocity.

Three parts:

- **Serve** — `SHAMap.WalkFetchPackNodes` walks a ledger's tree nodes; `LedgerProvider.MakeFetchPack(haveHash)` packs the *predecessor* ("want") ledger (header object + state/tx tree nodes, capped), mirroring `LedgerMaster::makeFetchPack`. Wired into the overlay's `otFETCH_PACK` request branch (`serveFetchPack`).
- **Consume** — a `fetchPackCache` (go-xrpl's `fetch_packs_`) holds hash-verified nodes; the reply is forwarded overlay→router, which caches verified nodes and runs `inbound.Ledger.CheckLocal` (rippled's `tryDB`/`checkLocal`) on every in-flight acquisition, finalizing any that complete via the existing `completeInboundLedger`.
- **Trigger** — a stalled legacy acquisition escalates **once** to a fetch-pack request in the router's `maintenanceTick` (locating the child ledger to satisfy rippled's "parent-of-have" request semantics) and gets one more window instead of being reaped immediately.

### Notes / deliberate divergences
- Nodes are exchanged in go-xrpl's native `SerializeForWire` format (the same one `TMLedgerData`/`AddKnownNode` use), and the serve side sends `want`'s **full** (capped) tree rather than rippled's `want`-vs-`have` diff. A diff only completes for a receiver with a node-hash-keyed store to supply the un-sent shared nodes; go-xrpl fills an in-memory acquisition SHAMap, so the full tree is correct for any receiver (a node it already holds is ignored). Documented at the call sites.
- The catch-up auto-trigger fires when the child ledger is known (backward-fill); it's a safe no-op for forward-tip acquisitions whose child doesn't exist yet, leaving the prior reap behavior intact.

## Test plan
- [x] `shamap`: `WalkFetchPackNodes` (pre-order, cap, bounds) + `VerifyWireNode` round-trip / tamper rejection
- [x] `inbound`: `CheckLocal` completes an acquisition from a local node source; no-source no-progress; one-shot `FetchPackRequested`; `Tracker.Active`
- [x] `adaptor`: `fetchPackCache` add/get/TTL/sweep/cap; `MakeFetchPack` packs the parent tree (header hash + verified nodes); `handleFetchPackReply` caches only verified nodes; escalation no-op without a child
- [x] `peermanagement`: serve replies with a pack; empty pack / bad hash; fetch-pack reply forwarded to the router
- [x] full affected suites pass under `-race`; `go vet`, `gofmt`, `golangci-lint` (0 issues) clean; full-module build green

Fixes #763