### PR TITLE
fix(consensus): rejoin from wrongLedger when the validated tip becomes available (#724)

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1649,17 +1649,19 @@ func (e *Engine) checkLedger() {
 			}
 		}
 
-		// Already targeting this ledger. If it has since become locally
-		// available — a held-adoption or acquisition that completed without
-		// firing OnLedger (e.g. a stashed out-of-order ledger whose parent is
-		// still missing) — fall through to handleWrongLedger to COMPLETE the
-		// switch now. Otherwise we stay pinned on a target we already hold and
-		// spin in wrongLedger forever (issue #724: the double-fault rejoin —
-		// a node that forked during a quorum-loss restart never abandons its
-		// fork to adopt the network's validated tip). If it is still not
-		// available, don't spam the acquire.
+		// Already targeting this ledger. Re-resolve it once: if it has
+		// since become locally available — a held-adoption or acquisition
+		// that completed without firing OnLedger (e.g. a stashed
+		// out-of-order ledger whose parent is still missing) — fall through
+		// to handleWrongLedger to COMPLETE the switch now, reusing the
+		// resolved ledger. Otherwise we stay pinned on a target we already
+		// hold and spin in wrongLedger forever (issue #724: the
+		// double-fault rejoin — a node that forked during a quorum-loss
+		// restart never abandons its fork to adopt the network's validated
+		// tip). If it is still not available, don't spam the acquire.
+		var target consensus.Ledger
 		if e.mode == consensus.ModeWrongLedger && e.wrongLedgerID == netLgr {
-			if l, err := e.adaptor.GetLedger(netLgr); err != nil || l == nil {
+			if target = e.resolveTargetLedger(netLgr); target == nil {
 				return
 			}
 		}
@@ -1669,7 +1671,7 @@ func (e *Engine) checkLedger() {
 			"our", fmt.Sprintf("%x", ourID[:8]),
 			"net", fmt.Sprintf("%x", netLgr[:8]),
 		)
-		e.handleWrongLedger(netLgr)
+		e.handleWrongLedger(netLgr, target)
 	}
 }
 
@@ -1851,9 +1853,26 @@ func (e *Engine) getNetworkLedger() consensus.LedgerID {
 	return ourID
 }
 
+// resolveTargetLedger returns the locally-available ledger for id, or nil
+// when it is not yet held. It tries the by-hash store first, then the
+// just-adopted LCL — the held-adoption path where an inbound ledger
+// updated the closed-ledger pointer (e.g. via the router) without the
+// by-hash lookup having been exercised yet.
+func (e *Engine) resolveTargetLedger(id consensus.LedgerID) consensus.Ledger {
+	if l, err := e.adaptor.GetLedger(id); err == nil && l != nil {
+		return l
+	}
+	if lcl, err := e.adaptor.GetLastClosedLedger(); err == nil && lcl != nil && lcl.ID() == id {
+		return lcl
+	}
+	return nil
+}
+
 // handleWrongLedger switches the engine to the network's preferred ledger.
-// Matches rippled's handleWrongLedger() (Consensus.h:1062-1113).
-func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID) {
+// Matches rippled's handleWrongLedger() (Consensus.h:1062-1113). When the
+// caller has already resolved the target ledger it is passed as target to
+// avoid a second lookup; pass nil to have it resolved here.
+func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID, target consensus.Ledger) {
 	// Step 1: Stop proposing (like rippled's leaveConsensus)
 	if e.mode == consensus.ModeProposing {
 		e.setMode(consensus.ModeObserving)
@@ -1891,17 +1910,13 @@ func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID) {
 		}
 	}
 
-	// Step 3: Try to acquire the correct ledger.
-	// First try by hash, then check if the adaptor's LCL has already been
-	// updated (e.g., by inbound ledger adoption in the router).
-	newLedger, err := e.adaptor.GetLedger(netLedgerID)
-	if err != nil || newLedger == nil {
-		if lcl, lclErr := e.adaptor.GetLastClosedLedger(); lclErr == nil && lcl != nil && lcl.ID() == netLedgerID {
-			newLedger = lcl
-			err = nil
-		}
+	// Step 3: Adopt the correct ledger. checkLedger may have already
+	// resolved it (held-adoption completion); otherwise resolve it here.
+	newLedger := target
+	if newLedger == nil {
+		newLedger = e.resolveTargetLedger(netLedgerID)
 	}
-	if err == nil && newLedger != nil {
+	if newLedger != nil {
 		// Found — restart the round with the correct ledger AND flag
 		// recovering=true so the engine enters ModeSwitchedLedger for
 		// exactly one round. That mirrors rippled (Consensus.h:1107): a
@@ -3403,7 +3418,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 						"preferred_seq", candidateSeq,
 						"preferred_hash", fmt.Sprintf("%x", candidateID[:8]),
 					)
-					e.handleWrongLedger(candidateID)
+					e.handleWrongLedger(candidateID, nil)
 					return
 				}
 			}

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1649,9 +1649,19 @@ func (e *Engine) checkLedger() {
 			}
 		}
 
-		// Already targeting this ledger — don't spam
+		// Already targeting this ledger. If it has since become locally
+		// available — a held-adoption or acquisition that completed without
+		// firing OnLedger (e.g. a stashed out-of-order ledger whose parent is
+		// still missing) — fall through to handleWrongLedger to COMPLETE the
+		// switch now. Otherwise we stay pinned on a target we already hold and
+		// spin in wrongLedger forever (issue #724: the double-fault rejoin —
+		// a node that forked during a quorum-loss restart never abandons its
+		// fork to adopt the network's validated tip). If it is still not
+		// available, don't spam the acquire.
 		if e.mode == consensus.ModeWrongLedger && e.wrongLedgerID == netLgr {
-			return
+			if l, err := e.adaptor.GetLedger(netLgr); err != nil || l == nil {
+				return
+			}
 		}
 		slog.Warn("Consensus view changed",
 			"phase", e.phase,

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -1178,10 +1178,11 @@ func TestEngine_WrongLedgerRecovery_ModeSequence(t *testing.T) {
 	// transition straight through WrongLedger into SwitchedLedger.
 	engine.wrongLedgerID = targetID
 	engine.setMode(consensus.ModeWrongLedger)
-	// Drive the full recovery: handleWrongLedger finds the target
+	// Drive the full recovery: handleWrongLedger resolves the target
 	// ledger via the adaptor (we seeded it above) and promotes to
-	// switchedLedger via startRoundLocked(recovering=true).
-	engine.handleWrongLedger(targetID)
+	// switchedLedger via startRoundLocked(recovering=true). Passing nil
+	// lets handleWrongLedger resolve it itself (the non-checkLedger path).
+	engine.handleWrongLedger(targetID, nil)
 	engine.mu.Unlock()
 
 	if mode := engine.Mode(); mode != consensus.ModeSwitchedLedger {
@@ -1247,6 +1248,117 @@ func TestEngine_WrongLedgerRecovery_ModeSequence(t *testing.T) {
 	if !fullFull {
 		t.Fatalf("Proposing validation must have Full=true")
 	}
+}
+
+// TestEngine_CheckLedger_CompletesHeldWrongLedgerSwitch pins the issue
+// #724 guard fix in checkLedger. When the engine is already in
+// ModeWrongLedger targeting the network's preferred ledger, checkLedger
+// must no longer return unconditionally: it completes the switch (→
+// ModeSwitchedLedger, wrongLedgerID cleared) once the target is locally
+// available, and stays put (still ModeWrongLedger, no re-request) while it
+// is not — mirroring rippled's handleWrongLedger re-attempt
+// (Consensus.h:1094-1112). The other recovery tests call handleWrongLedger
+// directly and so never traverse the guard itself; this drives
+// checkLedger() end to end.
+func TestEngine_CheckLedger_CompletesHeldWrongLedgerSwitch(t *testing.T) {
+	ourID := consensus.LedgerID{0x0c}
+	targetID := consensus.LedgerID{0xAA}
+
+	// run wedges an engine in ModeWrongLedger targeting targetID: two
+	// trusted peers proposing targetID make getNetworkLedger() return it,
+	// and two trusted validations clear the support gate (targetID has
+	// strictly more support than our stale fork). available controls
+	// whether the target ledger is held locally. The mutation, the
+	// checkLedger() call, and the result capture all happen under a single
+	// e.mu hold so a background round tick cannot race the assertion.
+	run := func(t *testing.T, available bool) (consensus.Mode, consensus.LedgerID, int) {
+		t.Helper()
+		adaptor := newMockAdaptor()
+		adaptor.validator = true
+		adaptor.opMode = consensus.OpModeFull
+		adaptor.nodeID = consensus.NodeID{0x01}
+		peerA := consensus.NodeID{0x02}
+		peerB := consensus.NodeID{0x03}
+		adaptor.trusted[adaptor.nodeID] = true
+		adaptor.trusted[peerA] = true
+		adaptor.trusted[peerB] = true
+		adaptor.quorum = 3
+		if available {
+			adaptor.ledgers[targetID] = &mockLedger{id: targetID, seq: 101, closeTime: time.Now()}
+		}
+
+		engine := NewEngine(adaptor, DefaultConfig())
+		ctx, cancel := context.WithCancel(context.Background())
+		if err := engine.Start(ctx); err != nil {
+			cancel()
+			t.Fatalf("Start: %v", err)
+		}
+		defer func() {
+			engine.Stop()
+			cancel()
+		}()
+
+		engine.StartRound(consensus.RoundID{Seq: 101, ParentHash: ourID}, true)
+
+		adaptor.mu.Lock()
+		adaptor.ledgersRequested = nil
+		now := adaptor.now
+		adaptor.mu.Unlock()
+
+		engine.mu.Lock()
+		// We hold a stale fork; the network prefers targetID.
+		engine.prevLedger = &mockLedger{id: ourID, seq: 100, parentID: consensus.LedgerID{0x99}, closeTime: now}
+		engine.wrongLedgerID = targetID
+		engine.setMode(consensus.ModeWrongLedger)
+		if engine.state != nil {
+			engine.state.OurPosition = nil // no self-vote — let the peer majority decide
+		}
+		engine.recentProposals = map[consensus.NodeID][]*consensus.Proposal{
+			peerA: {{NodeID: peerA, PreviousLedger: targetID, Timestamp: now}},
+			peerB: {{NodeID: peerB, PreviousLedger: targetID, Timestamp: now}},
+		}
+		if engine.validationTracker != nil {
+			engine.validationTracker.SetTrusted([]consensus.NodeID{adaptor.nodeID, peerA, peerB})
+			engine.validationTracker.Add(&consensus.Validation{NodeID: peerA, LedgerID: targetID, LedgerSeq: 101, Full: true, SignTime: now, SeenTime: now})
+			engine.validationTracker.Add(&consensus.Validation{NodeID: peerB, LedgerID: targetID, LedgerSeq: 101, Full: true, SignTime: now, SeenTime: now})
+		}
+		engine.checkLedger()
+		gotMode := engine.mode
+		gotWrongID := engine.wrongLedgerID
+		engine.mu.Unlock()
+
+		adaptor.mu.RLock()
+		reqs := len(adaptor.ledgersRequested)
+		adaptor.mu.RUnlock()
+		return gotMode, gotWrongID, reqs
+	}
+
+	t.Run("available_completes_switch", func(t *testing.T) {
+		gotMode, gotWrongID, _ := run(t, true)
+		if gotMode != consensus.ModeSwitchedLedger {
+			t.Fatalf("available target: checkLedger must complete the switch to "+
+				"SwitchedLedger, got %v (the old guard returned unconditionally "+
+				"and stayed wedged in WrongLedger — issue #724)", gotMode)
+		}
+		if gotWrongID != (consensus.LedgerID{}) {
+			t.Fatalf("available target: wrongLedgerID must be cleared after the "+
+				"switch, got %x", gotWrongID[:8])
+		}
+	})
+
+	t.Run("unavailable_stays_without_respam", func(t *testing.T) {
+		gotMode, gotWrongID, reqs := run(t, false)
+		if gotMode != consensus.ModeWrongLedger {
+			t.Fatalf("unavailable target: checkLedger must stay in WrongLedger, got %v", gotMode)
+		}
+		if gotWrongID != targetID {
+			t.Fatalf("unavailable target: wrongLedgerID must remain the target, got %x want %x", gotWrongID[:8], targetID[:8])
+		}
+		if reqs != 0 {
+			t.Fatalf("unavailable target: checkLedger must not re-request the acquire "+
+				"while already targeting it (no-spam guard), got %d requests", reqs)
+		}
+	})
 }
 
 // TestEngine_OnLedger_PromotesToSwitchedLedger pins the SECOND entry


### PR DESCRIPTION
## Summary

Fixes the goXRPL-specific half of #724: a node that **forks during a quorum-loss restart cannot rejoin** — it stays pinned in `wrongLedger` and never adopts the network's validated tip, even after acquiring it.

`checkLedger` returned early on every timer tick once `wrongLedgerID == netLgr` (the no-spam gate), so when that ledger *later* became locally available — via a held-adoption or an acquisition that completed without firing `OnLedger` — the switch was never completed. The node spun in `wrongLedger` (`our_pos_seq=0`) while the closed tip raced ahead.

The fix re-attempts the switch when `GetLedger(netLgr)` now succeeds (falls through to `handleWrongLedger`); otherwise it keeps the no-spam early return. The switch remains guarded by the existing trusted-support gate, so it only moves toward the network-preferred ledger — mirroring rippled re-evaluating `checkAccept` on each validation arrival. One-line behavioral change, +12/-2.

## How #724 was scoped (full write-up on the issue)

- **Catch-up itself is sound.** Isolation test (4 rippled + 1 goXRPL, network validates without goXRPL): paused goXRPL 45 s, network advanced 15 ledgers, unpaused → goXRPL caught up to the validated tip in ~20 s and resumed lockstep. PR #725 forward-walk + #771 fetch-pack work.
- **The residual wedge is a quorum-loss double-fault rejoin.** When both quorum-critical goXRPL fall behind together, validation freezes (no validated tip), and a node that forked during the restart couldn't recover.
- **Confirmed goXRPL-specific via controls:** clean paused-validator double-fault — rippled-only (5 rippled) recovers fully; mixed (3 rippled + 2 goXRPL) left one goXRPL wedged at `validated=8`. **With this fix, both goXRPL recover to lockstep.**

## Verification

- ✅ Control B reproducer: both goXRPL now recover (was: one wedged forever).
- ✅ Core suite green: `consensus/`, `ledger/`, `txq/` — 22 packages, 0 fail; `rcl` unit tests pass.
- ✅ Non-regressive: the unpatched baseline wedges identically on the (machine-degraded) clean soak, so this change does not introduce the early-wedge.
- ⚠️ **Full clean-network lockstep gate not run locally** — the dev machine is load-degraded after an extended soak session (even known-good pre-fetch-pack `0270d4e4`, which reached 200 lockstep earlier, now wedges at ~18 there). This is environmental, not a code regression. **Please run the mixed-network lockstep soak on fresh CI before merge.**

Refs #724. Targets `main`. Do not merge until the full lockstep gate runs clean on fresh infra.
