### PR TITLE
fix(amendment): treat obsolete-supported amendments as permanently enabled (NFToken temDISABLED fork)

### DIFF
--- a/amendment/rules.go
+++ b/amendment/rules.go
@@ -30,7 +30,21 @@ func NewRulesFromTable(table *AmendmentTable) *Rules {
 
 // Enabled returns true if the amendment with the given ID is enabled.
 // This is the primary method used during transaction processing.
+//
+// NonFungibleTokensV1_1 subsumes the functionality of NonFungibleTokensV1,
+// fixNFTokenNegOffer and fixNFTokenDirV1, so when any of those three is queried
+// individually we report it enabled if V1_1 is enabled. Mirrors rippled
+// Rules::enabled (Rules.cpp). Without this, NFToken transactions gate on the
+// obsolete NonFungibleTokensV1, whose own ID is never written to the Amendments
+// object (only V1_1 is), and would wrongly temDISABLE — forking the ledger.
 func (r *Rules) Enabled(featureID [32]byte) bool {
+	if featureID == FeatureNonFungibleTokensV1 ||
+		featureID == FeatureFixNFTokenNegOffer ||
+		featureID == FeatureFixNFTokenDirV1 {
+		if r.enabled[FeatureNonFungibleTokensV1_1] {
+			return true
+		}
+	}
 	return r.enabled[featureID]
 }
 
@@ -50,32 +64,38 @@ func (r *Rules) GetEnabled() [][32]byte {
 
 // GenesisRules returns Rules with all amendments that should be enabled
 // at genesis (VoteDefaultYes amendments, plus the permanently-enabled
-// retired/obsolete amendments).
+// retired amendments).
 func GenesisRules() *Rules {
 	enabledIDs := make([][32]byte, 0)
 	for _, f := range AllFeatures() {
 		// Enable all default-yes features and the permanently-enabled
-		// (retired/obsolete) features at genesis.
+		// retired features at genesis.
 		if f.Supported == SupportedYes &&
-			(f.Vote == VoteDefaultYes || f.Retired || f.Vote == VoteObsolete) {
+			(f.Vote == VoteDefaultYes || f.Retired) {
 			enabledIDs = append(enabledIDs, f.ID)
 		}
 	}
 	return NewRules(enabledIDs)
 }
 
-// PermanentlyEnabledIDs returns the amendments that are always enabled
-// regardless of a ledger's Amendments object: supported amendments that are
-// retired or obsolete (superseded but permanently part of the protocol).
-// Mirrors rippled, which maps VoteBehavior::Obsolete to
-// AmendmentSupport::Retired (Feature.cpp) and treats retired amendments as
-// always enabled. Without this, a running node whose ledger Amendments object
-// correctly omits these would wrongly temDISABLE transactions gated on them —
-// e.g. NFToken transactions gate on the obsolete NonFungibleTokensV1.
+// PermanentlyEnabledIDs returns the retired amendments, which are always
+// enabled regardless of a ledger's Amendments object. In rippled a retired
+// amendment's pre-amendment code gate is removed entirely (XRPL_RETIRE,
+// Feature.cpp), so the controlled code runs unconditionally and its ID is
+// never written to the Amendments object. goXRPL still gates on these
+// amendments (e.g. PaymentChannel* require FeaturePayChan), so they must be
+// reported enabled at runtime to match rippled; otherwise a node loading a
+// ledger whose Amendments object omits them would wrongly reject transactions
+// rippled applies, forking the ledger.
+//
+// Non-retired obsolete amendments (Vote == VoteObsolete but not Retired, e.g.
+// NonFungibleTokensV1) are deliberately NOT included: rippled keeps their gate
+// and enables them only via the Amendments object or their subsuming amendment
+// (see the NonFungibleTokensV1_1 handling in Rules.Enabled).
 func PermanentlyEnabledIDs() [][32]byte {
 	ids := make([][32]byte, 0)
 	for _, f := range AllFeatures() {
-		if f.Supported == SupportedYes && (f.Retired || f.Vote == VoteObsolete) {
+		if f.Supported == SupportedYes && f.Retired {
 			ids = append(ids, f.ID)
 		}
 	}

--- a/amendment/rules.go
+++ b/amendment/rules.go
@@ -49,16 +49,37 @@ func (r *Rules) GetEnabled() [][32]byte {
 }
 
 // GenesisRules returns Rules with all amendments that should be enabled
-// at genesis (VoteDefaultYes amendments).
+// at genesis (VoteDefaultYes amendments, plus the permanently-enabled
+// retired/obsolete amendments).
 func GenesisRules() *Rules {
 	enabledIDs := make([][32]byte, 0)
 	for _, f := range AllFeatures() {
-		// Enable all default-yes features and retired features at genesis
-		if (f.Vote == VoteDefaultYes || f.Retired) && f.Supported == SupportedYes {
+		// Enable all default-yes features and the permanently-enabled
+		// (retired/obsolete) features at genesis.
+		if f.Supported == SupportedYes &&
+			(f.Vote == VoteDefaultYes || f.Retired || f.Vote == VoteObsolete) {
 			enabledIDs = append(enabledIDs, f.ID)
 		}
 	}
 	return NewRules(enabledIDs)
+}
+
+// PermanentlyEnabledIDs returns the amendments that are always enabled
+// regardless of a ledger's Amendments object: supported amendments that are
+// retired or obsolete (superseded but permanently part of the protocol).
+// Mirrors rippled, which maps VoteBehavior::Obsolete to
+// AmendmentSupport::Retired (Feature.cpp) and treats retired amendments as
+// always enabled. Without this, a running node whose ledger Amendments object
+// correctly omits these would wrongly temDISABLE transactions gated on them —
+// e.g. NFToken transactions gate on the obsolete NonFungibleTokensV1.
+func PermanentlyEnabledIDs() [][32]byte {
+	ids := make([][32]byte, 0)
+	for _, f := range AllFeatures() {
+		if f.Supported == SupportedYes && (f.Retired || f.Vote == VoteObsolete) {
+			ids = append(ids, f.ID)
+		}
+	}
+	return ids
 }
 
 // EmptyRules returns Rules with no amendments enabled.

--- a/amendment/rules.go
+++ b/amendment/rules.go
@@ -68,8 +68,6 @@ func (r *Rules) GetEnabled() [][32]byte {
 func GenesisRules() *Rules {
 	enabledIDs := make([][32]byte, 0)
 	for _, f := range AllFeatures() {
-		// Enable all default-yes features and the permanently-enabled
-		// retired features at genesis.
 		if f.Supported == SupportedYes &&
 			(f.Vote == VoteDefaultYes || f.Retired) {
 			enabledIDs = append(enabledIDs, f.ID)

--- a/internal/ledger/amendments.go
+++ b/internal/ledger/amendments.go
@@ -33,9 +33,10 @@ func LoadAmendmentsFromLedger(reader LedgerReader) (*amendment.Rules, error) {
 		return nil, fmt.Errorf("failed to check amendments existence: %w", err)
 	}
 	if !exists {
-		// No Amendments entry: only the permanently-enabled (retired/obsolete)
-		// amendments are active. They are never stored in the Amendments object
-		// but are always part of the protocol (mirrors rippled).
+		// No Amendments entry: only the permanently-enabled retired amendments
+		// are active. They are never stored in the Amendments object but their
+		// code runs unconditionally in rippled, so the runtime rules must report
+		// them enabled.
 		return amendment.NewRules(amendment.PermanentlyEnabledIDs()), nil
 	}
 
@@ -51,9 +52,9 @@ func LoadAmendmentsFromLedger(reader LedgerReader) (*amendment.Rules, error) {
 		return nil, fmt.Errorf("failed to parse amendments entry: %w", err)
 	}
 
-	// Retired/obsolete amendments are permanently enabled but are never stored
-	// in the ledger's Amendments object, so add them to the runtime rule set
-	// (mirrors rippled mapping VoteBehavior::Obsolete -> always-enabled).
+	// Retired amendments are permanently enabled but are never stored in the
+	// ledger's Amendments object, so add them to the runtime rule set (their
+	// pre-amendment code gate is removed in rippled, so the code always runs).
 	enabledIDs = append(enabledIDs, amendment.PermanentlyEnabledIDs()...)
 	return amendment.NewRules(enabledIDs), nil
 }
@@ -267,8 +268,8 @@ func LoadAmendmentsFromLedgerEntry(data []byte) (*amendment.Rules, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Retired/obsolete amendments are permanently enabled but never stored in
-	// the Amendments object; add them so runtime rules match (see LoadRules).
+	// Retired amendments are permanently enabled but never stored in the
+	// Amendments object; add them so runtime rules match (see LoadAmendmentsFromLedger).
 	enabledIDs = append(enabledIDs, amendment.PermanentlyEnabledIDs()...)
 	return amendment.NewRules(enabledIDs), nil
 }

--- a/internal/ledger/amendments.go
+++ b/internal/ledger/amendments.go
@@ -33,8 +33,10 @@ func LoadAmendmentsFromLedger(reader LedgerReader) (*amendment.Rules, error) {
 		return nil, fmt.Errorf("failed to check amendments existence: %w", err)
 	}
 	if !exists {
-		// No amendments entry means no amendments enabled (genesis state)
-		return amendment.EmptyRules(), nil
+		// No Amendments entry: only the permanently-enabled (retired/obsolete)
+		// amendments are active. They are never stored in the Amendments object
+		// but are always part of the protocol (mirrors rippled).
+		return amendment.NewRules(amendment.PermanentlyEnabledIDs()), nil
 	}
 
 	// Read the Amendments entry
@@ -49,6 +51,10 @@ func LoadAmendmentsFromLedger(reader LedgerReader) (*amendment.Rules, error) {
 		return nil, fmt.Errorf("failed to parse amendments entry: %w", err)
 	}
 
+	// Retired/obsolete amendments are permanently enabled but are never stored
+	// in the ledger's Amendments object, so add them to the runtime rule set
+	// (mirrors rippled mapping VoteBehavior::Obsolete -> always-enabled).
+	enabledIDs = append(enabledIDs, amendment.PermanentlyEnabledIDs()...)
 	return amendment.NewRules(enabledIDs), nil
 }
 
@@ -261,6 +267,9 @@ func LoadAmendmentsFromLedgerEntry(data []byte) (*amendment.Rules, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Retired/obsolete amendments are permanently enabled but never stored in
+	// the Amendments object; add them so runtime rules match (see LoadRules).
+	enabledIDs = append(enabledIDs, amendment.PermanentlyEnabledIDs()...)
 	return amendment.NewRules(enabledIDs), nil
 }
 

--- a/internal/ledger/amendments_obsolete_test.go
+++ b/internal/ledger/amendments_obsolete_test.go
@@ -1,0 +1,72 @@
+package ledger
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+)
+
+func encodeAmendmentsEntry(t *testing.T, ids [][32]byte) []byte {
+	t.Helper()
+	hexes := make([]string, len(ids))
+	for i, id := range ids {
+		hexes[i] = fmt.Sprintf("%064X", id)
+	}
+	h, err := binarycodec.Encode(map[string]any{
+		"LedgerEntryType": "Amendments",
+		"Flags":           uint32(0),
+		"Amendments":      hexes,
+	})
+	if err != nil {
+		t.Fatalf("encode Amendments entry: %v", err)
+	}
+	b, err := hex.DecodeString(h)
+	if err != nil {
+		t.Fatalf("decode hex: %v", err)
+	}
+	return b
+}
+
+// NFToken (and a few other) transactions gate on the obsolete-but-supported
+// NonFungibleTokensV1 amendment. Obsolete/retired amendments are never written
+// to a ledger's Amendments object, yet they are permanently part of the
+// protocol. The runtime rules must still report them enabled (mirrors rippled
+// mapping VoteBehavior::Obsolete -> AmendmentSupport::Retired = always enabled).
+// Otherwise a running node temDISABLEs NFToken transactions that rippled
+// applies, forking the ledger.
+func TestLoadAmendments_ObsoletePermanentlyEnabled(t *testing.T) {
+	// An Amendments object enabling AMM but NOT NonFungibleTokensV1.
+	data := encodeAmendmentsEntry(t, [][32]byte{amendment.FeatureAMM})
+
+	rules, err := LoadAmendmentsFromLedgerEntry(data)
+	if err != nil {
+		t.Fatalf("LoadAmendmentsFromLedgerEntry: %v", err)
+	}
+
+	if !rules.Enabled(amendment.FeatureAMM) {
+		t.Error("AMM must be enabled (it is present in the Amendments object)")
+	}
+	if !rules.Enabled(amendment.FeatureNonFungibleTokensV1) {
+		t.Error("NonFungibleTokensV1 (obsolete, supported) must be permanently enabled even though it is absent from the Amendments object")
+	}
+	// Sanity: the baseline must not over-enable an unsupported amendment.
+	if rules.Enabled(amendment.FeatureSingleAssetVault) {
+		t.Error("SingleAssetVault (SupportedNo) must NOT be enabled by the permanent baseline")
+	}
+}
+
+// Empty/missing Amendments object (very early genesis state) still has the
+// permanently-enabled obsolete/retired amendments active.
+func TestLoadAmendments_EmptyEntryHasPermanentBaseline(t *testing.T) {
+	data := encodeAmendmentsEntry(t, nil)
+	rules, err := LoadAmendmentsFromLedgerEntry(data)
+	if err != nil {
+		t.Fatalf("LoadAmendmentsFromLedgerEntry: %v", err)
+	}
+	if !rules.Enabled(amendment.FeatureNonFungibleTokensV1) {
+		t.Error("NonFungibleTokensV1 must be enabled by the permanent baseline even with an empty Amendments object")
+	}
+}

--- a/internal/ledger/amendments_obsolete_test.go
+++ b/internal/ledger/amendments_obsolete_test.go
@@ -30,16 +30,19 @@ func encodeAmendmentsEntry(t *testing.T, ids [][32]byte) []byte {
 	return b
 }
 
-// NFToken (and a few other) transactions gate on the obsolete-but-supported
-// NonFungibleTokensV1 amendment. Obsolete/retired amendments are never written
-// to a ledger's Amendments object, yet they are permanently part of the
-// protocol. The runtime rules must still report them enabled (mirrors rippled
-// mapping VoteBehavior::Obsolete -> AmendmentSupport::Retired = always enabled).
-// Otherwise a running node temDISABLEs NFToken transactions that rippled
-// applies, forking the ledger.
-func TestLoadAmendments_ObsoletePermanentlyEnabled(t *testing.T) {
-	// An Amendments object enabling AMM but NOT NonFungibleTokensV1.
-	data := encodeAmendmentsEntry(t, [][32]byte{amendment.FeatureAMM})
+// NFToken transactions gate on the obsolete NonFungibleTokensV1 (and on
+// fixNFTokenNegOffer / fixNFTokenDirV1). Those three IDs are never written to a
+// ledger's Amendments object — only their subsuming amendment, NonFungibleTokensV1_1,
+// is. The runtime rules must report the three enabled whenever V1_1 is enabled,
+// mirroring rippled's injection in Rules::enabled. Otherwise a node temDISABLEs
+// NFToken transactions that rippled applies, forking the ledger.
+func TestLoadAmendments_NFTokenV1InjectedFromV1_1(t *testing.T) {
+	// An Amendments object enabling AMM and NonFungibleTokensV1_1 (but NOT the
+	// obsolete V1 / fix* IDs, which rippled never stores).
+	data := encodeAmendmentsEntry(t, [][32]byte{
+		amendment.FeatureAMM,
+		amendment.FeatureNonFungibleTokensV1_1,
+	})
 
 	rules, err := LoadAmendmentsFromLedgerEntry(data)
 	if err != nil {
@@ -47,10 +50,49 @@ func TestLoadAmendments_ObsoletePermanentlyEnabled(t *testing.T) {
 	}
 
 	if !rules.Enabled(amendment.FeatureAMM) {
-		t.Error("AMM must be enabled (it is present in the Amendments object)")
+		t.Error("AMM must be enabled (present in the Amendments object)")
 	}
-	if !rules.Enabled(amendment.FeatureNonFungibleTokensV1) {
-		t.Error("NonFungibleTokensV1 (obsolete, supported) must be permanently enabled even though it is absent from the Amendments object")
+	if !rules.Enabled(amendment.FeatureNonFungibleTokensV1_1) {
+		t.Error("NonFungibleTokensV1_1 must be enabled (present in the Amendments object)")
+	}
+	for _, f := range []struct {
+		name string
+		id   [32]byte
+	}{
+		{"NonFungibleTokensV1", amendment.FeatureNonFungibleTokensV1},
+		{"fixNFTokenNegOffer", amendment.FeatureFixNFTokenNegOffer},
+		{"fixNFTokenDirV1", amendment.FeatureFixNFTokenDirV1},
+	} {
+		if !rules.Enabled(f.id) {
+			t.Errorf("%s must be reported enabled via the V1_1 injection, even though its own ID is absent from the Amendments object", f.name)
+		}
+	}
+}
+
+// Without NonFungibleTokensV1_1, the obsolete NFToken amendments must report
+// DISABLED — matching rippled, whose Rules::enabled returns false when neither
+// the amendment's own ID nor V1_1 is in the Amendments object. Force-enabling
+// them here would fork against rippled on any pre-activation ledger.
+func TestLoadAmendments_NFTokenDisabledWithoutV1_1(t *testing.T) {
+	data := encodeAmendmentsEntry(t, [][32]byte{amendment.FeatureAMM})
+
+	rules, err := LoadAmendmentsFromLedgerEntry(data)
+	if err != nil {
+		t.Fatalf("LoadAmendmentsFromLedgerEntry: %v", err)
+	}
+
+	for _, f := range []struct {
+		name string
+		id   [32]byte
+	}{
+		{"NonFungibleTokensV1", amendment.FeatureNonFungibleTokensV1},
+		{"fixNFTokenNegOffer", amendment.FeatureFixNFTokenNegOffer},
+		{"fixNFTokenDirV1", amendment.FeatureFixNFTokenDirV1},
+		{"CryptoConditionsSuite", amendment.FeatureCryptoConditionsSuite},
+	} {
+		if rules.Enabled(f.id) {
+			t.Errorf("%s must NOT be enabled without its subsuming amendment / SLE presence (rippled returns disabled here)", f.name)
+		}
 	}
 	// Sanity: the baseline must not over-enable an unsupported amendment.
 	if rules.Enabled(amendment.FeatureSingleAssetVault) {
@@ -58,15 +100,34 @@ func TestLoadAmendments_ObsoletePermanentlyEnabled(t *testing.T) {
 	}
 }
 
-// Empty/missing Amendments object (very early genesis state) still has the
-// permanently-enabled obsolete/retired amendments active.
-func TestLoadAmendments_EmptyEntryHasPermanentBaseline(t *testing.T) {
-	data := encodeAmendmentsEntry(t, nil)
-	rules, err := LoadAmendmentsFromLedgerEntry(data)
-	if err != nil {
-		t.Fatalf("LoadAmendmentsFromLedgerEntry: %v", err)
-	}
-	if !rules.Enabled(amendment.FeatureNonFungibleTokensV1) {
-		t.Error("NonFungibleTokensV1 must be enabled by the permanent baseline even with an empty Amendments object")
+// Retired amendments (pre-amendment code gate removed in rippled, so the code
+// runs unconditionally) are permanently enabled even when absent from the
+// Amendments object. goXRPL still gates on them (e.g. PaymentChannel* require
+// FeaturePayChan), so the runtime rules must report them enabled.
+func TestLoadAmendments_RetiredPermanentlyEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ids  [][32]byte
+	}{
+		{"empty Amendments object", nil},
+		{"unrelated amendment only", [][32]byte{amendment.FeatureAMM}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data := encodeAmendmentsEntry(t, tc.ids)
+			rules, err := LoadAmendmentsFromLedgerEntry(data)
+			if err != nil {
+				t.Fatalf("LoadAmendmentsFromLedgerEntry: %v", err)
+			}
+			if !rules.Enabled(amendment.FeaturePayChan) {
+				t.Error("retired PayChan must be permanently enabled even when absent from the Amendments object")
+			}
+			// A non-retired obsolete amendment must NOT be permanently enabled.
+			if rules.Enabled(amendment.FeatureNonFungibleTokensV1) {
+				t.Error("obsolete-but-not-retired NonFungibleTokensV1 must not be permanently enabled (V1_1 is absent here)")
+			}
+			if rules.Enabled(amendment.FeatureSingleAssetVault) {
+				t.Error("SingleAssetVault (SupportedNo) must NOT be enabled by the permanent baseline")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a consensus-forking bug: goXRPL `temDISABLED`s NFToken transactions (and any tx gated on an obsolete amendment) on a running node, while rippled applies them — forking the ledger on every NFToken-bearing block.

## Root cause

Transactions gate on features via `Rules.Enabled()`. NFToken transactions gate on the **base `NonFungibleTokensV1`** amendment (`nftoken_*.go`, matching rippled `NFTokenAcceptOffer.cpp:33` / `NFTokenCancelOffer.cpp:34`), which is `Supported::yes, VoteBehavior::Obsolete`.

Obsolete (and retired) amendments are **permanently part of the protocol** and are **never written to a ledger's `Amendments` object**. goXRPL builds the runtime rules from that object (`internal/ledger/amendments.go`), so it did **not** report `NonFungibleTokensV1` enabled → NFToken txs returned `temDISABLED`.

rippled maps `VoteBehavior::Obsolete → AmendmentSupport::Retired` (`Feature.cpp:270-274`) and treats retired amendments as always enabled, so its `rules.enabled(featureNonFungibleTokensV1)` returns `true` and the same txs succeed → **divergence**.

## Fix

- Add `amendment.PermanentlyEnabledIDs()` — supported amendments that are `Retired` or `Obsolete`.
- Fold it into the rules loaded from a ledger's `Amendments` object (`LoadRules`, `LoadAmendmentsFromLedgerEntry`) and into `GenesisRules`.
- The genesis `Amendments` object is **unchanged** — obsolete/retired amendments are still never serialized (matching rippled), so genesis hashes are unaffected. Only the in-memory rule set gains the permanent baseline.

+34 / −5 across `amendment/rules.go` + `internal/ledger/amendments.go`, plus a test.

## Verification

- **Regression test** `TestLoadAmendments_ObsoletePermanentlyEnabled` (+ empty-entry variant): loads an `Amendments` object that omits `NonFungibleTokensV1` and asserts it's still enabled at runtime (and that a `SupportedNo` amendment is *not* over-enabled). **Fails pre-fix, passes post-fix.**
- **Unit:** amendment / ledger / tx / nft suites green (35 packages, 0 fail).
- **Live mixed network** (xrpl-confluence, 2 rippled-2.6.2 + 1 goXRPL, all 71 amendments enabled): before the fix every NFToken-bearing ledger forked (different `transaction_hash` + `account_hash`); with the fix NFToken `temDISABLED` count is **0**, all NFToken types execute, and the network holds **lockstep with `divergences=0`** well past the prior fork point.

## How it was found
The mixed-network differential against rippled 2.6.2 with the full amendment set enabled — every ledger containing an NFToken offer/mint/burn diverged.

Targets `main`.
