### PR TITLE
refactor: extract replay CLI commands into internal/replaytool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,10 @@ The server exposes JSON-RPC at `http://localhost:8080/`, WebSocket subscriptions
 ### Internal packages
 
 - `cmd/xrpld/` — CLI entry point (Cobra)
-- `internal/cli/` — CLI commands (server, rpc, replay, compare)
+- `internal/cli/` — CLI commands (server, rpc, compare) and root command wiring
+- `internal/replaytool/` — offline `replay`/`replay-range` developer commands
+  (mainnet/fixture replay and state-divergence reporting; distinct from the
+  node's production inbound-ledger replay)
 - `internal/tx/` — Transaction engine, types, and processing
   - One subpackage per tx type: `account/`, `amm/`, `batch/`, `check/`, `clawback/`,
     `credential/`, `delegate/`, `depositpreauth/`, `did/`, `escrow/`,

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/LeJamon/go-xrpl/config"
+	"github.com/LeJamon/go-xrpl/internal/replaytool"
 	"github.com/LeJamon/go-xrpl/internal/tx/all"
 	"github.com/LeJamon/go-xrpl/version"
 	"github.com/spf13/cobra"
@@ -60,6 +61,12 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose logging")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress output to console after startup")
 	rootCmd.PersistentFlags().Bool("silent", false, "no output to console after startup")
+
+	// The replay developer commands live in their own package; register
+	// them here rather than via self-registration into this package's root.
+	for _, c := range replaytool.NewCommands() {
+		rootCmd.AddCommand(c)
+	}
 }
 
 // initConfig loads the configuration file when --conf is set; load

--- a/internal/replaytool/replay.go
+++ b/internal/replaytool/replay.go
@@ -175,7 +175,7 @@ func runReplay(cmd *cobra.Command, args []string) {
 	printFixtureInfo(state, env, txs, expected)
 
 	// Execute replay
-	result, openLedger, err := executeReplayVerbose(state, env, txs, expected)
+	result, openLedger, err := executeReplayVerbose(state, env, txs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: Replay execution failed: %v\n", err)
 		os.Exit(1)
@@ -184,12 +184,12 @@ func runReplay(cmd *cobra.Command, args []string) {
 	result.Duration = time.Since(startTime)
 
 	// Print detailed results
-	printDetailedResults(result, expected, state)
+	printDetailedResults(result, expected)
 
 	// Dump state if requested or on failure
 	shouldDump := dumpState || (verboseReplay && !result.Success) || !result.Success
 	if shouldDump && openLedger != nil {
-		dumpDebugInfo(result, state, expected, openLedger)
+		dumpDebugInfo(result, state)
 	}
 
 	// Write output if requested
@@ -265,7 +265,7 @@ func loadJSON(path string, v any) error {
 	return json.Unmarshal(data, v)
 }
 
-func executeReplayVerbose(state *StateFixture, env *EnvFixture, txs *TxsFixture, expected *ExpectedFixture) (*ReplayResult, *ledger.Ledger, error) {
+func executeReplayVerbose(state *StateFixture, env *EnvFixture, txs *TxsFixture) (*ReplayResult, *ledger.Ledger, error) {
 	result := &ReplayResult{
 		Success:       true,
 		Errors:        make([]string, 0),
@@ -493,7 +493,7 @@ func executeReplayVerbose(state *StateFixture, env *EnvFixture, txs *TxsFixture,
 	return result, openLedger, nil
 }
 
-func printDetailedResults(result *ReplayResult, expected *ExpectedFixture, preState *StateFixture) {
+func printDetailedResults(result *ReplayResult, expected *ExpectedFixture) {
 	fmt.Println("================================================================================")
 	fmt.Println("                              RESULTS")
 	fmt.Println("================================================================================")
@@ -610,7 +610,7 @@ func statusEmoji(match bool) string {
 	return "[MISMATCH]"
 }
 
-func dumpDebugInfo(result *ReplayResult, preState *StateFixture, expected *ExpectedFixture, openLedger *ledger.Ledger) {
+func dumpDebugInfo(result *ReplayResult, preState *StateFixture) {
 	dir := dumpDir
 	if dir == "" {
 		dir = filepath.Join(fixtureDir, "debug")
@@ -730,7 +730,7 @@ func dumpDebugInfo(result *ReplayResult, preState *StateFixture, expected *Expec
 					}
 				}
 			}
-		} else if strings.ToLower(preDataHex) != strings.ToLower(postDataHex) {
+		} else if !strings.EqualFold(preDataHex, postDataHex) {
 			// Modified entry
 			modifiedCount++
 			entry := map[string]any{
@@ -928,7 +928,7 @@ func updateOrCreateSkipListEntry(l *ledger.Ledger, k keylet.Keylet, parentHash [
 			hashes = make([]string, len(arr))
 			copy(hashes, arr)
 		case []any:
-			// Handle []interface{} case (e.g., from JSON unmarshaling)
+			// Handle []any case (e.g., from JSON unmarshaling)
 			hashes = make([]string, 0, len(arr))
 			for _, h := range arr {
 				if hashStr, ok := h.(string); ok {

--- a/internal/replaytool/replay.go
+++ b/internal/replaytool/replay.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"encoding/hex"
@@ -147,8 +147,6 @@ Example:
 }
 
 func init() {
-	rootCmd.AddCommand(replayCmd)
-
 	replayCmd.Flags().StringVarP(&outputResult, "output", "o", "", "Output file for results (JSON)")
 	replayCmd.Flags().BoolVarP(&verboseReplay, "verbose", "v", false, "Verbose output")
 	replayCmd.Flags().BoolVar(&dumpState, "dump", false, "Dump full state on failure (or always with -v)")

--- a/internal/replaytool/replay.go
+++ b/internal/replaytool/replay.go
@@ -125,11 +125,12 @@ var (
 	showDecoded   bool
 )
 
-// replayCmd represents the replay command
-var replayCmd = &cobra.Command{
-	Use:   "replay [fixture-dir]",
-	Short: "Replay transactions from fixtures for state transition testing",
-	Long: `Replay executes state transition tests using fixture files.
+// newReplayCmd builds the `replay` command and its flags.
+func newReplayCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "replay [fixture-dir]",
+		Short: "Replay transactions from fixtures for state transition testing",
+		Long: `Replay executes state transition tests using fixture files.
 
 It loads pre-state from state.json, execution context from env.json,
 transactions from txs.json, and compares results against expected.json.
@@ -142,16 +143,17 @@ Example:
     xrpld replay ./fixtures/ledger_32750 -v
     xrpld replay ./fixtures/ledger_32750 --dump --dump-dir ./debug
     xrpld replay ./fixtures/ledger_32750 --decoded`,
-	Args: cobra.ExactArgs(1),
-	Run:  runReplay,
-}
+		Args: cobra.ExactArgs(1),
+		Run:  runReplay,
+	}
 
-func init() {
-	replayCmd.Flags().StringVarP(&outputResult, "output", "o", "", "Output file for results (JSON)")
-	replayCmd.Flags().BoolVarP(&verboseReplay, "verbose", "v", false, "Verbose output")
-	replayCmd.Flags().BoolVar(&dumpState, "dump", false, "Dump full state on failure (or always with -v)")
-	replayCmd.Flags().StringVar(&dumpDir, "dump-dir", "", "Directory to write state dumps (default: fixture-dir/debug)")
-	replayCmd.Flags().BoolVar(&showDecoded, "decoded", false, "Show decoded JSON for transactions and state entries")
+	cmd.Flags().StringVarP(&outputResult, "output", "o", "", "Output file for results (JSON)")
+	cmd.Flags().BoolVarP(&verboseReplay, "verbose", "v", false, "Verbose output")
+	cmd.Flags().BoolVar(&dumpState, "dump", false, "Dump full state on failure (or always with -v)")
+	cmd.Flags().StringVar(&dumpDir, "dump-dir", "", "Directory to write state dumps (default: fixture-dir/debug)")
+	cmd.Flags().BoolVar(&showDecoded, "decoded", false, "Show decoded JSON for transactions and state entries")
+
+	return cmd
 }
 
 func runReplay(cmd *cobra.Command, args []string) {

--- a/internal/replaytool/replay_checkpoint.go
+++ b/internal/replaytool/replay_checkpoint.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"bufio"

--- a/internal/replaytool/replay_findings.go
+++ b/internal/replaytool/replay_findings.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"encoding/hex"

--- a/internal/replaytool/replay_findings_test.go
+++ b/internal/replaytool/replay_findings_test.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"bufio"

--- a/internal/replaytool/replay_findings_test.go
+++ b/internal/replaytool/replay_findings_test.go
@@ -61,6 +61,9 @@ func TestFindingsWriter_JSONL(t *testing.T) {
 		}
 		lines++
 	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
 	if lines != 2 {
 		t.Fatalf("expected 2 JSONL lines, got %d", lines)
 	}

--- a/internal/replaytool/replay_helpers_test.go
+++ b/internal/replaytool/replay_helpers_test.go
@@ -131,7 +131,7 @@ func TestWriteResultJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("result not valid JSON: %v", err)
 	}

--- a/internal/replaytool/replay_helpers_test.go
+++ b/internal/replaytool/replay_helpers_test.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"encoding/hex"

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -835,7 +835,7 @@ func dumpRangeDebugInfo(ledgerIndex uint32, result *BlockResult, preStateMap, po
 				entry["decoded"] = decoded
 			}
 			diff["added"] = append(diff["added"].([]map[string]any), entry)
-		} else if strings.ToLower(preDataHex) != strings.ToLower(postDataHex) {
+		} else if !strings.EqualFold(preDataHex, postDataHex) {
 			entry := map[string]any{
 				"index":         key,
 				"pre_data_hex":  preDataHex,

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"context"
@@ -98,8 +98,6 @@ Example:
 }
 
 func init() {
-	rootCmd.AddCommand(replayRangeCmd)
-
 	replayRangeCmd.Flags().Uint32Var(&replayRangeFrom, "from", 0, "Starting ledger index (pre-state)")
 	replayRangeCmd.Flags().Uint32Var(&replayRangeTo, "to", 0, "Ending ledger index (last block to process)")
 	replayRangeCmd.Flags().StringVar(&replayRangeDumpDir, "dump-dir", "", "Directory for debug output on failure")

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -39,11 +39,12 @@ var (
 	replayRangeGoXRPLCommit         string
 )
 
-// replayRangeCmd represents the replay-range command
-var replayRangeCmd = &cobra.Command{
-	Use:   "replay-range",
-	Short: "Continuously replay transactions from a range of ledgers",
-	Long: `Replay-range executes continuous state transition tests by reading
+// newReplayRangeCmd builds the `replay-range` command and its flags.
+func newReplayRangeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "replay-range",
+		Short: "Continuously replay transactions from a range of ledgers",
+		Long: `Replay-range executes continuous state transition tests by reading
 directly from the xrpl-state-compare PostgreSQL database.
 
 It loads the initial state at ledger --from, then continuously applies
@@ -94,25 +95,26 @@ Example:
     xrpld replay-range --from 32750 --to 32800 --dump-dir ./debug
     xrpld replay-range --from 99226370 --to 99236370 --checkpoint-dir ./ckpt
     xrpld replay-range --from 99226370 --to 99236370 --checkpoint-dir ./ckpt --resume-from 99230000`,
-	Run: runReplayRange,
-}
+		Run: runReplayRange,
+	}
 
-func init() {
-	replayRangeCmd.Flags().Uint32Var(&replayRangeFrom, "from", 0, "Starting ledger index (pre-state)")
-	replayRangeCmd.Flags().Uint32Var(&replayRangeTo, "to", 0, "Ending ledger index (last block to process)")
-	replayRangeCmd.Flags().StringVar(&replayRangeDumpDir, "dump-dir", "", "Directory for debug output on failure")
-	replayRangeCmd.Flags().BoolVarP(&replayRangeVerbose, "verbose", "v", false, "Verbose output")
-	replayRangeCmd.Flags().BoolVar(&replayRangeDecoded, "decoded", false, "Show decoded JSON for entries")
-	replayRangeCmd.Flags().StringVar(&replayRangeCheckpointDir, "checkpoint-dir", "", "Directory for periodic state checkpoints (enables checkpoint/resume)")
-	replayRangeCmd.Flags().Uint32Var(&replayRangeCheckpointInterval, "checkpoint-interval", 10000, "Write a checkpoint every N ledgers (requires --checkpoint-dir)")
-	replayRangeCmd.Flags().Uint32Var(&replayRangeResumeFrom, "resume-from", 0, "Resume from the checkpoint at this ledger seq (requires --checkpoint-dir)")
-	replayRangeCmd.Flags().StringVar(&replayRangeNodestoreDir, "nodestore-dir", "", "Node-local directory for the lazy pebble nodestore (shared read-only checkpoint base + per-run overlay). When set, seed state is held lazily instead of fully in RAM.")
-	replayRangeCmd.Flags().BoolVar(&replayRangeContinueOnDivergence, "continue-on-divergence", false, "On a hash mismatch, record a finding and reset to mainnet ground truth, then continue (survey all divergences) instead of stopping")
-	replayRangeCmd.Flags().StringVar(&replayRangeFindingsOut, "findings-out", "", "Path to the findings JSONL file (default <dump-dir>/findings.jsonl or ./debug/findings.jsonl); used with --continue-on-divergence")
-	replayRangeCmd.Flags().StringVar(&replayRangeGoXRPLCommit, "goxrpl-commit", "", "Commit/image tag recorded in findings (default: VCS revision from build info)")
+	cmd.Flags().Uint32Var(&replayRangeFrom, "from", 0, "Starting ledger index (pre-state)")
+	cmd.Flags().Uint32Var(&replayRangeTo, "to", 0, "Ending ledger index (last block to process)")
+	cmd.Flags().StringVar(&replayRangeDumpDir, "dump-dir", "", "Directory for debug output on failure")
+	cmd.Flags().BoolVarP(&replayRangeVerbose, "verbose", "v", false, "Verbose output")
+	cmd.Flags().BoolVar(&replayRangeDecoded, "decoded", false, "Show decoded JSON for entries")
+	cmd.Flags().StringVar(&replayRangeCheckpointDir, "checkpoint-dir", "", "Directory for periodic state checkpoints (enables checkpoint/resume)")
+	cmd.Flags().Uint32Var(&replayRangeCheckpointInterval, "checkpoint-interval", 10000, "Write a checkpoint every N ledgers (requires --checkpoint-dir)")
+	cmd.Flags().Uint32Var(&replayRangeResumeFrom, "resume-from", 0, "Resume from the checkpoint at this ledger seq (requires --checkpoint-dir)")
+	cmd.Flags().StringVar(&replayRangeNodestoreDir, "nodestore-dir", "", "Node-local directory for the lazy pebble nodestore (shared read-only checkpoint base + per-run overlay). When set, seed state is held lazily instead of fully in RAM.")
+	cmd.Flags().BoolVar(&replayRangeContinueOnDivergence, "continue-on-divergence", false, "On a hash mismatch, record a finding and reset to mainnet ground truth, then continue (survey all divergences) instead of stopping")
+	cmd.Flags().StringVar(&replayRangeFindingsOut, "findings-out", "", "Path to the findings JSONL file (default <dump-dir>/findings.jsonl or ./debug/findings.jsonl); used with --continue-on-divergence")
+	cmd.Flags().StringVar(&replayRangeGoXRPLCommit, "goxrpl-commit", "", "Commit/image tag recorded in findings (default: VCS revision from build info)")
 
-	replayRangeCmd.MarkFlagRequired("from")
-	replayRangeCmd.MarkFlagRequired("to")
+	cmd.MarkFlagRequired("from")
+	cmd.MarkFlagRequired("to")
+
+	return cmd
 }
 
 // RangeReplayStats holds statistics for the replay run

--- a/internal/replaytool/replay_range_helpers_test.go
+++ b/internal/replaytool/replay_range_helpers_test.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"encoding/hex"

--- a/internal/replaytool/replay_range_test.go
+++ b/internal/replaytool/replay_range_test.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"os"

--- a/internal/replaytool/replay_reconstruct.go
+++ b/internal/replaytool/replay_reconstruct.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"context"

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"encoding/hex"

--- a/internal/replaytool/replay_state_source.go
+++ b/internal/replaytool/replay_state_source.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"context"

--- a/internal/replaytool/replay_state_source_test.go
+++ b/internal/replaytool/replay_state_source_test.go
@@ -1,4 +1,4 @@
-package cli
+package replaytool
 
 import (
 	"context"

--- a/internal/replaytool/replaytool.go
+++ b/internal/replaytool/replaytool.go
@@ -1,0 +1,15 @@
+// Package replaytool implements the offline mainnet-replay and fixture-replay
+// developer commands (`replay`, `replay-range`). It re-executes captured
+// rippled ledgers against the Go transaction engine and reports state-tree
+// divergences; it is a development and conformance tool, distinct from the
+// node's production inbound-ledger replay (internal/ledger/inbound and
+// internal/consensus/adaptor).
+package replaytool
+
+import "github.com/spf13/cobra"
+
+// NewCommands returns the replay tool's cobra commands for registration on a
+// root command. The commands' flags are configured at package init time.
+func NewCommands() []*cobra.Command {
+	return []*cobra.Command{replayCmd, replayRangeCmd}
+}

--- a/internal/replaytool/replaytool.go
+++ b/internal/replaytool/replaytool.go
@@ -8,8 +8,10 @@ package replaytool
 
 import "github.com/spf13/cobra"
 
-// NewCommands returns the replay tool's cobra commands for registration on a
-// root command. The commands' flags are configured at package init time.
+// NewCommands returns freshly-constructed replay tool commands for registration
+// on a root command. Each call builds new *cobra.Command instances, so the
+// result can be added to a parent without the aliasing hazard of shared
+// package-level command singletons.
 func NewCommands() []*cobra.Command {
-	return []*cobra.Command{replayCmd, replayRangeCmd}
+	return []*cobra.Command{newReplayCmd(), newReplayRangeCmd()}
 }


### PR DESCRIPTION
## What

Extracts the offline replay developer commands (`replay`, `replay-range`) out of
`internal/cli` into a dedicated `internal/replaytool` package, and cleans up the
lint debt that rode along with the move.

This is the `replay`/`replay-range` divergence-hunting tool — distinct from the
node's **production** inbound-ledger replay (`internal/ledger/inbound`,
`internal/consensus/adaptor`), which is untouched.

## Why

The replay code (~2.8k LOC across 6 files) was the biggest single concern in
`internal/cli`, yet had **zero coupling** to the rest of the package beyond
`rootCmd.AddCommand`. It polluted the `cli` namespace with ~50 helpers and ~15
exported types meaningful only to replay. Pulling it into its own package keeps
the CLI layer thin (command wiring) and gives this dev/conformance tool a
first-class home.

## How

- `internal/replaytool/` — the 6 source files + 6 test files moved as pure git
  renames (only the `package` clause changed). New `replaytool.go` adds a
  disambiguating package doc and `func NewCommands() []*cobra.Command`.
- `internal/cli/root.go` — registers `replaytool.NewCommands()` on the root
  command (replacing the two self-registrations that moved out). `cli` no longer
  references any replay symbol; `replaytool` no longer touches `rootCmd`.
- `CLAUDE.md` — architecture list updated.

### Lint cleanup (second commit)

- `interface{}` → `any` across the moved files
- `strings.ToLower(a) != strings.ToLower(b)` → `!strings.EqualFold(a, b)` for the
  two hex-comparison sites (SA6005); the remaining `ToLower`/`ToUpper` are
  map-key normalization / output formatting and were left alone
- dropped genuinely-unused params from `executeReplayVerbose`,
  `printDetailedResults`, `dumpDebugInfo` (single call site each)
- check `bufio.Scanner.Err()` after the scan loop in a findings test

## Verification

- `CGO_ENABLED=0 go build ./...` — builds
- `go vet ./internal/replaytool/ ./internal/cli/` — clean
- `golangci-lint run ./internal/replaytool/...` (CI-pinned v2.11.3) — **0 issues**
- `go test ./internal/replaytool/ ./internal/cli/` — both pass
- Built binary registers `replay` + `replay-range` with all flags intact

## Note

Base is `worktree-ci-cd-improvements` (where this work is stacked), so the diff is
just the 2 replaytool commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
