### PR TITLE
cleanup: trim feetrack comments, reframe rippled source-of-truth rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,12 @@ maintaining behavioral parity with the XRPL protocol.
 
 ### Implementation Philosophy
 
-- **Rippled is the source of truth.** There is no formal XRPL specification, so the
-  C++ rippled implementation (kept locally at `../rippled`, read-only) is the de
-  facto spec. Before changing protocol behavior, check the corresponding rippled
-  behavior first. Match rippled's validation logic and error codes (TER codes).
+- **Rippled is the source of behavioural truth.** There is no formal XRPL
+  specification, so the C++ rippled implementation (kept locally at `../rippled`,
+  read-only) is the de facto spec for *protocol behaviour* — validation logic,
+  error/TER codes, and ledger effects. Check it before changing protocol behaviour.
+  It is **not** a template for code shape: go-xrpl is an idiomatic Go implementation
+  of XRPL, not a transliteration of rippled's C++.
 - **Idiomatic Go.** Prefer Go interfaces, composition, and table-driven designs over
   transliterated C++ idioms (templates, RAII, deep inheritance).
 - **Simplicity first.** Make every change as small as possible; impact minimal code.
@@ -155,4 +157,5 @@ unit tests, then implement matching Go tests under
 ## Comments
 
 Only add comments when strictly required. Do not comment code to explain trivial
-things.
+things. Don't cite rippled source paths or C++ symbol names in comments unless the
+reference genuinely aids understanding — document behaviour, not provenance.

--- a/internal/feetrack/feetrack.go
+++ b/internal/feetrack/feetrack.go
@@ -1,11 +1,10 @@
-// Package feetrack implements the local-node load-fee tracker.
+// Package feetrack implements the local-node load-fee tracker, mirroring the
+// behaviour of rippled's LoadFeeTrack.
 //
-// Mirrors rippled's LoadFeeTrack (src/xrpld/app/misc/LoadFeeTrack.h /
-// LoadFeeTrack.cpp): the local server raises its load fee under
-// sustained job-queue overload, then decays it back to the normal
-// reference fee as the queue drains. Remote and cluster fees are set by
-// peers and the cluster announcement path. ScaleFeeLoad applies the
-// resulting factor at every fee-quoting boundary.
+// The local server raises its load fee under sustained job-queue overload,
+// then decays it back to the normal reference fee as the queue drains. Remote
+// and cluster fees are set by peers and the cluster announcement path.
+// ScaleFeeLoad applies the resulting factor at every fee-quoting boundary.
 package feetrack
 
 import (
@@ -14,31 +13,28 @@ import (
 	"sync"
 )
 
-// Reference constants from rippled LoadFeeTrack.h:141-147.
 const (
-	// LoadBase is the normal/minimum load factor. All load_factor_*
-	// values are expressed as multiples of this base.
+	// LoadBase is the normal/minimum load factor. All load factors are
+	// expressed as multiples of this base.
 	LoadBase uint32 = 256
 
-	// FeeIncFraction controls how fast localTxnLoadFee_ ramps up
-	// when raiseLocalFee is called: fee += fee / FeeIncFraction.
+	// FeeIncFraction controls how fast the local fee ramps up on a raise:
+	// fee += fee / FeeIncFraction.
 	FeeIncFraction uint32 = 4
 
-	// FeeDecFraction controls the decay step when lowerLocalFee runs:
+	// FeeDecFraction controls the decay step on a lower:
 	// fee -= fee / FeeDecFraction. Symmetric with FeeIncFraction.
 	FeeDecFraction uint32 = 4
 
-	// FeeMax caps the local fee at LoadBase * 1_000_000, matching
-	// rippled lftFeeMax (LoadFeeTrack.h:147).
+	// FeeMax caps the local fee at LoadBase * 1_000_000.
 	FeeMax uint32 = 256 * 1_000_000
 )
 
 // ErrOverflow indicates ScaleFeeLoad multiplication overflowed uint64.
-// Mirrors rippled's Throw<std::overflow_error>("scaleFeeLoad") path.
 var ErrOverflow = errors.New("feetrack: scaleFeeLoad overflow")
 
-// LoadFeeTrack tracks the local-node fee factor and accepts remote /
-// cluster reports. Safe for concurrent access.
+// LoadFeeTrack tracks the local-node fee factor and accepts remote / cluster
+// reports. Safe for concurrent access.
 type LoadFeeTrack struct {
 	mu         sync.RWMutex
 	localFee   uint32
@@ -47,9 +43,8 @@ type LoadFeeTrack struct {
 	raiseCount uint32
 }
 
-// New returns a LoadFeeTrack initialised to the normal fee with no
-// pending raises. Matches the rippled constructor at
-// LoadFeeTrack.h:47-55.
+// New returns a LoadFeeTrack initialised to the normal fee with no pending
+// raises.
 func New() *LoadFeeTrack {
 	return &LoadFeeTrack{
 		localFee:   LoadBase,
@@ -58,8 +53,7 @@ func New() *LoadFeeTrack {
 	}
 }
 
-// SetRemoteFee records a remote-reported fee factor, mirroring
-// LoadFeeTrack::setRemoteFee.
+// SetRemoteFee records a remote-reported fee factor.
 func (t *LoadFeeTrack) SetRemoteFee(f uint32) {
 	t.mu.Lock()
 	t.remoteFee = f
@@ -97,44 +91,40 @@ func (t *LoadFeeTrack) GetLocalFee() uint32 {
 // GetLoadBase returns the reference (normal) fee factor.
 func (t *LoadFeeTrack) GetLoadBase() uint32 { return LoadBase }
 
-// GetLoadFactor returns max(cluster, local, remote), mirroring
-// LoadFeeTrack::getLoadFactor (LoadFeeTrack.h:94-100).
+// GetLoadFactor returns max(cluster, local, remote).
 func (t *LoadFeeTrack) GetLoadFactor() uint32 {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return maxU32(t.clusterFee, maxU32(t.localFee, t.remoteFee))
 }
 
-// GetScalingFactors returns (max(local,remote), max(remote,cluster)),
-// the pair consumed by ScaleFeeLoad. Mirrors LoadFeeTrack::getScalingFactors
-// (LoadFeeTrack.h:102-110).
+// GetScalingFactors returns (max(local,remote), max(remote,cluster)), the pair
+// consumed by ScaleFeeLoad.
 func (t *LoadFeeTrack) GetScalingFactors() (feeFactor, remFee uint32) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return maxU32(t.localFee, t.remoteFee), maxU32(t.remoteFee, t.clusterFee)
 }
 
-// IsLoadedLocal reports whether the local node is currently inflating
-// its fee. Mirrors LoadFeeTrack::isLoadedLocal.
+// IsLoadedLocal reports whether the local node is currently inflating its fee.
 func (t *LoadFeeTrack) IsLoadedLocal() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.raiseCount != 0 || t.localFee != LoadBase
 }
 
-// IsLoadedCluster reports whether either the local node or the cluster
-// is inflating its fee. Mirrors LoadFeeTrack::isLoadedCluster.
+// IsLoadedCluster reports whether either the local node or the cluster is
+// inflating its fee.
 func (t *LoadFeeTrack) IsLoadedCluster() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.raiseCount != 0 || t.localFee != LoadBase || t.clusterFee != LoadBase
 }
 
-// RaiseLocalFee bumps the local fee factor. Returns true when the
-// stored factor actually changed. Mirrors LoadFeeTrack::raiseLocalFee
-// (LoadFeeTrack.cpp:33-58): the first call only increments raiseCount,
-// the second and subsequent calls actually scale localTxnLoadFee_ up
-// (toward FeeMax), tracking the remote fee floor.
+// RaiseLocalFee bumps the local fee factor and reports whether the stored
+// factor actually changed. The first call only arms raiseCount; the second and
+// subsequent calls scale the local fee up toward FeeMax, tracking the remote
+// fee floor.
 func (t *LoadFeeTrack) RaiseLocalFee() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -154,11 +144,9 @@ func (t *LoadFeeTrack) RaiseLocalFee() bool {
 	return orig != t.localFee
 }
 
-// LowerLocalFee decays the local fee back toward LoadBase. Returns true
-// when the stored factor actually changed. Mirrors
-// LoadFeeTrack::lowerLocalFee (LoadFeeTrack.cpp:60-79). Clears the
-// raiseCount latch so the next RaiseLocalFee requires two ticks to
-// take effect — same hysteresis as rippled.
+// LowerLocalFee decays the local fee back toward LoadBase and reports whether
+// the stored factor actually changed. It clears the raiseCount latch, so the
+// next RaiseLocalFee again needs two ticks to take effect (hysteresis).
 func (t *LoadFeeTrack) LowerLocalFee() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -171,17 +159,13 @@ func (t *LoadFeeTrack) LowerLocalFee() bool {
 	return orig != t.localFee
 }
 
-// ScaleFeeLoad scales fee by the current local/remote/cluster load,
-// mirroring rippled's free function scaleFeeLoad in
-// LoadFeeTrack.cpp:85-111.
+// ScaleFeeLoad scales fee by the current local/remote/cluster load.
 //
-// When unlimited is true and local-only load is moderate (less than 4x
-// the remote fee), the privileged caller pays the remote-rate factor
-// instead of the local one — matching rippled's bUnlimited branch.
-// Local load above 4x remote still applies in full.
+// When unlimited is true and local-only load is moderate (less than 4x the
+// remote fee), the privileged caller pays the remote-rate factor instead of
+// the local one; local load at or above 4x remote still applies in full.
 //
-// fee == 0 short-circuits to 0 to match rippled. Overflow surfaces as
-// ErrOverflow.
+// fee == 0 short-circuits to 0. Overflow surfaces as ErrOverflow.
 func ScaleFeeLoad(fee uint64, t *LoadFeeTrack, unlimited bool) (uint64, error) {
 	if fee == 0 {
 		return 0, nil
@@ -194,9 +178,8 @@ func ScaleFeeLoad(fee uint64, t *LoadFeeTrack, unlimited bool) (uint64, error) {
 		feeFactor = remFee
 	}
 
-	// fee * feeFactor / LoadBase, computed in big.Int to match
-	// rippled's checked mulDiv (no overflow, exact integer division
-	// truncation).
+	// fee * feeFactor / LoadBase in big.Int to avoid uint64 overflow and keep
+	// exact integer truncation.
 	num := new(big.Int).Mul(new(big.Int).SetUint64(fee), new(big.Int).SetUint64(uint64(feeFactor)))
 	num.Quo(num, new(big.Int).SetUint64(uint64(LoadBase)))
 	if !num.IsUint64() {

--- a/internal/feetrack/feetrack_test.go
+++ b/internal/feetrack/feetrack_test.go
@@ -4,10 +4,9 @@ import (
 	"testing"
 )
 
-// TestScaleFeeLoad_Identity mirrors rippled LoadFeeTrack_test.cpp: with
-// a fresh tracker the factor is LoadBase, so scaleFeeLoad returns the
-// input fee unchanged (including the 0 short-circuit and 1-drop
-// identity).
+// TestScaleFeeLoad_Identity: with a fresh tracker the factor is LoadBase,
+// so ScaleFeeLoad returns the input fee unchanged (including the 0
+// short-circuit).
 func TestScaleFeeLoad_Identity(t *testing.T) {
 	tr := New()
 	cases := []uint64{0, 1, 10, 10000, 1<<32 + 7}
@@ -31,9 +30,9 @@ func TestScaleFeeLoad_NilTracker(t *testing.T) {
 	}
 }
 
-// TestRaiseLowerLocalFee pins the rippled hysteresis: the first raise
-// only arms raiseCount, the second actually bumps the factor; lower
-// decays slowly back to LoadBase and clears raiseCount.
+// TestRaiseLowerLocalFee pins the hysteresis: the first raise only arms
+// raiseCount, the second actually bumps the factor; lower decays back to
+// LoadBase and clears raiseCount.
 func TestRaiseLowerLocalFee(t *testing.T) {
 	tr := New()
 	if changed := tr.RaiseLocalFee(); changed {
@@ -68,7 +67,7 @@ func TestRaiseLowerLocalFee(t *testing.T) {
 }
 
 // TestScaleFeeLoad_Loaded checks scaling under a raised local fee.
-// After two raises, local = LoadBase + LoadBase/4 = 320; scaleFeeLoad
+// After two raises, local = LoadBase + LoadBase/4 = 320; ScaleFeeLoad
 // applies fee * 320 / 256 = fee * 5/4.
 func TestScaleFeeLoad_Loaded(t *testing.T) {
 	tr := New()
@@ -83,9 +82,9 @@ func TestScaleFeeLoad_Loaded(t *testing.T) {
 	}
 }
 
-// TestScaleFeeLoad_UnlimitedBranch pins the bUnlimited carve-out at
-// LoadFeeTrack.cpp:97-100: when only local load is elevated and stays
-// under 4x remote, an unlimited caller pays the remote-rate factor.
+// TestScaleFeeLoad_UnlimitedBranch pins the unlimited carve-out: when
+// only local load is elevated and stays under 4x remote, an unlimited
+// caller pays the remote-rate factor.
 func TestScaleFeeLoad_UnlimitedBranch(t *testing.T) {
 	tr := New()
 	tr.RaiseLocalFee()
@@ -131,8 +130,7 @@ func TestScaleFeeLoad_Overflow(t *testing.T) {
 }
 
 // TestLoadFactorAggregates pins max(cluster, local, remote) and the
-// (max(local,remote), max(remote,cluster)) pair consumed by
-// ScaleFeeLoad. Mirrors LoadFeeTrack.h:94-110.
+// (max(local,remote), max(remote,cluster)) pair consumed by ScaleFeeLoad.
 func TestLoadFactorAggregates(t *testing.T) {
 	tr := New()
 	tr.SetRemoteFee(400)


### PR DESCRIPTION
## Summary

Codebase-cleanup pass with two related parts:

**1. Trim `feetrack` comments.** The package mirrored rippled's `LoadFeeTrack`
and carried a per-symbol citation on nearly every declaration — file:line refs
(`LoadFeeTrack.cpp:33-58`, `LoadFeeTrack.h:147`, …) and C++ symbol names
(`LoadFeeTrack::raiseLocalFee`, `localTxnLoadFee_`, `lftFeeMax`, `bUnlimited`).
This strips the redundant citations while keeping the behavioural docs that
actually explain non-obvious logic (the two-tick raise hysteresis, the
unlimited carve-out, the big.Int overflow guard), leaving a single
package-level pointer to rippled's `LoadFeeTrack`. No code behaviour changes.

**2. Reframe the "source of truth" rule.** `CLAUDE.md`: rippled is the source
of *behavioural* truth — the de facto spec for protocol behaviour (validation,
TER codes, ledger effects) — but **not** a template for code shape. go-xrpl is
an idiomatic Go implementation of XRPL, not a C++ transliteration. Adds a
comment guideline: document behaviour, not provenance — don't cite rippled
source paths / C++ symbols unless the reference genuinely aids understanding.

## Verification

- `gofmt -l internal/feetrack/` clean
- `go test ./internal/feetrack/...` passes
- Comments only; no behavioural change to the load-fee tracker
