### PR TITLE
refactor(ledger): dedup AccountRoot reads and held-tx canonical sort

### DIFF
--- a/internal/ledger/localtxs/localtxs.go
+++ b/internal/ledger/localtxs/localtxs.go
@@ -9,8 +9,6 @@
 package localtxs
 
 import (
-	"bytes"
-	"sort"
 	"sync"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger"
@@ -119,17 +117,8 @@ func (l *LocalTxs) Sweep(view *ledger.Ledger) {
 // (keep) when the account does not exist (e.g., a yet-unfunded AccountSet
 // destination — the create might still land in a later round).
 func seqAdvancedPast(view *ledger.Ledger, ptx openledger.PendingTx) bool {
-	k := keylet.Account(ptx.Account)
-	exists, err := view.Exists(k)
-	if err != nil || !exists {
-		return false
-	}
-	data, err := view.Read(k)
-	if err != nil {
-		return false
-	}
-	ar, err := state.ParseAccountRoot(data)
-	if err != nil || ar == nil {
+	ar, ok := state.ReadAccountRoot(view, ptx.Account)
+	if !ok {
 		return false
 	}
 	return ar.Sequence > ptx.Sequence
@@ -143,7 +132,7 @@ func seqAdvancedPast(view *ledger.Ledger, ptx openledger.PendingTx) bool {
 // consumed (SLE still present), in which case the held tx is still
 // applicable.
 func ticketBurned(view *ledger.Ledger, ptx openledger.PendingTx) bool {
-	ar, ok := readAccountRoot(view, ptx.Account)
+	ar, ok := state.ReadAccountRoot(view, ptx.Account)
 	if !ok {
 		return false
 	}
@@ -157,37 +146,10 @@ func ticketBurned(view *ledger.Ledger, ptx openledger.PendingTx) bool {
 	return !exists
 }
 
-func readAccountRoot(view *ledger.Ledger, accountID [20]byte) (*state.AccountRoot, bool) {
-	k := keylet.Account(accountID)
-	exists, err := view.Exists(k)
-	if err != nil || !exists {
-		return nil, false
-	}
-	data, err := view.Read(k)
-	if err != nil {
-		return nil, false
-	}
-	ar, err := state.ParseAccountRoot(data)
-	if err != nil || ar == nil {
-		return nil, false
-	}
-	return ar, true
-}
-
 // GetTxSet returns the current pool as a canonical-sorted slice ready
-// for OpenLedger.Accept's `locals` parameter. Mirrors rippled
-// LocalTxs.cpp:126 — `CanonicalTXSet tset(uint256{})` (zero salt).
-//
-// Sort key (zero-salt CanonicalTXSet):
-//  1. account bytes
-//  2. sequence
-//  3. tx hash
-//
-// The zero-salt XOR collapses accountKey to the raw 20-byte account
-// padded to 32 bytes, so this is equivalent to lexicographic compare on
-// account directly. Any future caller that needs a salt-aware sort
-// (e.g. the consensus build path's SHAMap-root salt) must call
-// openledger.CanonicalSort on the returned slice instead.
+// for OpenLedger.Accept's `locals` parameter. The zero salt mirrors
+// rippled LocalTxs.cpp:126 — `CanonicalTXSet tset(uint256{})`. A future
+// caller needing a salt-aware order passes its salt instead.
 func (l *LocalTxs) GetTxSet() []openledger.PendingTx {
 	l.mu.Lock()
 	snapshot := make([]openledger.PendingTx, len(l.txs))
@@ -196,20 +158,7 @@ func (l *LocalTxs) GetTxSet() []openledger.PendingTx {
 	}
 	l.mu.Unlock()
 
-	sort.SliceStable(snapshot, func(i, j int) bool {
-		if c := bytes.Compare(snapshot[i].Account[:], snapshot[j].Account[:]); c != 0 {
-			return c < 0
-		}
-		// Sequence-based before ticket-based for the same account
-		// (rippled SeqProxy::operator<).
-		if snapshot[i].IsTicket != snapshot[j].IsTicket {
-			return !snapshot[i].IsTicket
-		}
-		if snapshot[i].Sequence != snapshot[j].Sequence {
-			return snapshot[i].Sequence < snapshot[j].Sequence
-		}
-		return bytes.Compare(snapshot[i].Hash[:], snapshot[j].Hash[:]) < 0
-	})
+	openledger.CanonicalSort(snapshot, [32]byte{})
 	return snapshot
 }
 

--- a/internal/ledger/openledger/txqadapter.go
+++ b/internal/ledger/openledger/txqadapter.go
@@ -298,18 +298,5 @@ func (a *TxqAdapter) readAccountRoot(accountID [20]byte) (*state.AccountRoot, bo
 	if a.view == nil {
 		return nil, false
 	}
-	key := keylet.Account(accountID)
-	exists, err := a.view.Exists(key)
-	if err != nil || !exists {
-		return nil, false
-	}
-	data, err := a.view.Read(key)
-	if err != nil {
-		return nil, false
-	}
-	ar, err := state.ParseAccountRoot(data)
-	if err != nil {
-		return nil, false
-	}
-	return ar, true
+	return state.ReadAccountRoot(a.view, accountID)
 }

--- a/internal/ledger/state/account_root.go
+++ b/internal/ledger/state/account_root.go
@@ -9,7 +9,37 @@ import (
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/keylet"
 )
+
+// accountRootReader is the minimal read surface ReadAccountRoot needs:
+// entry existence plus a raw read by keylet. Both *ledger.Ledger and the
+// full LedgerView satisfy it.
+type accountRootReader interface {
+	Exists(k keylet.Keylet) (bool, error)
+	Read(k keylet.Keylet) ([]byte, error)
+}
+
+// ReadAccountRoot reads and parses the AccountRoot for accountID from view.
+// Returns (nil, false) when the account is absent or cannot be read or
+// parsed — the "look up an account, skip if it isn't there" idiom shared by
+// the held-tx sweep and the TxQ preclaim path.
+func ReadAccountRoot(view accountRootReader, accountID [20]byte) (*AccountRoot, bool) {
+	k := keylet.Account(accountID)
+	exists, err := view.Exists(k)
+	if err != nil || !exists {
+		return nil, false
+	}
+	data, err := view.Read(k)
+	if err != nil {
+		return nil, false
+	}
+	ar, err := ParseAccountRoot(data)
+	if err != nil || ar == nil {
+		return nil, false
+	}
+	return ar, true
+}
 
 // AccountRoot represents an account in the ledger
 type AccountRoot struct {


### PR DESCRIPTION
## Summary

Two small, behaviour-preserving dedup cleanups in the ledger packages, surfaced while auditing the `internal/ledger/localtxs` (rippled `LocalTxs`) pool against `internal/txq`.

### 1. Shared `state.ReadAccountRoot` helper
The `Exists → Read → ParseAccountRoot` idiom was copy-pasted in three spots. This adds `state.ReadAccountRoot(view, accountID) (*AccountRoot, bool)` over a minimal read-only interface (`Exists` + `Read`) and routes all three through it:
- `localtxs.seqAdvancedPast`
- `localtxs.readAccountRoot` (removed — folded into the helper)
- `openledger.TxqAdapter.readAccountRoot` (keeps its nil-view guard, delegates the rest)

`service/tx_query.go`'s account lookup is intentionally **left as-is**: it returns wrapped errors (not a bool), interleaves a ticket-sequence early-return between read and parse, and treats `data == nil` as not-found — different control flow, would be degraded by forcing it through the bool helper.

### 2. `LocalTxs.GetTxSet` → `openledger.CanonicalSort`
`GetTxSet` hand-rolled a zero-salt canonical sort that re-implemented the comparator `openledger.CanonicalSort` already provides (the code comment even pointed at it as the canonical impl). Replaced with `openledger.CanonicalSort(snapshot, [32]byte{})`. With a zero salt, `computeAccountKey` is just the padded account, so the ordering (account → seq-before-ticket → sequence → hash) is byte-identical.

## Why it's safe
- `ParseAccountRoot` never returns `(nil, nil)`, so the helper's added `ar == nil` guard cannot change any caller's result.
- The zero-salt `CanonicalSort` ordering is identical to the removed inline comparator; the existing `GetTxSet` ordering tests pin it.
- Net −34 lines.

## Testing
- `go build ./...` clean
- `go vet` clean on touched packages
- `go test` green: `internal/ledger/localtxs`, `internal/ledger/openledger`, `internal/ledger/state`, `internal/txq`, `internal/ledger/service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)