### PR TITLE
cleanup(cli): remove no-op --quiet and --silent flags, dedup port-config parsing

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -58,7 +58,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&configFile, "conf", "", "configuration file path (required)")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable normally suppressed debug logging")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose logging")
-	rootCmd.PersistentFlags().Bool("silent", false, "no output to console after startup")
 
 	// The replay developer commands live in their own package; register
 	// them here rather than via self-registration into this package's root.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,7 +16,6 @@ var (
 	configFile string
 	debug      bool
 	verbose    bool
-	quiet      bool
 
 	// globalConfig holds the loaded configuration, available to all subcommands.
 	// It is nil until initConfig() runs (which happens before any command's Run function).
@@ -59,7 +58,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&configFile, "conf", "", "configuration file path (required)")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable normally suppressed debug logging")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose logging")
-	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress output to console after startup")
 	rootCmd.PersistentFlags().Bool("silent", false, "no output to console after startup")
 
 	// The replay developer commands live in their own package; register

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -964,25 +964,13 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 
 	// Start WebSocket listeners — each port gets its own mux with PortMiddleware
 	for name, p := range wsPorts {
-		portCfg := p
-		adminNets, err := portCfg.ParseAdminNets()
+		pc, err := parsePortConfig("ws", name, p)
 		if err != nil {
-			return fmt.Errorf("parse admin nets for ws port %q: %w", name, err)
-		}
-		secureGW, err := portCfg.ParseSecureGatewayNets()
-		if err != nil {
-			return fmt.Errorf("parse secure_gateway nets for ws port %q: %w", name, err)
-		}
-		pc := &rpc.PortContext{
-			PortName:          name,
-			AdminNets:         adminNets,
-			SecureGatewayNets: secureGW,
-			Limit:             portCfg.Limit,
-			SendQueue:         portCfg.SendQueueLimit,
+			return err
 		}
 		mux := http.NewServeMux()
 		mux.Handle("/", rpc.PortMiddleware(pc, connLimiter, wsServer))
-		srv := &http.Server{Addr: portCfg.GetBindAddress(), Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+		srv := &http.Server{Addr: p.GetBindAddress(), Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 		wsSrvs = append(wsSrvs, srv)
 		go func(n string, s *http.Server) {
 			serverLog.Info("Listening", "protocol", "ws", "name", n, "addr", s.Addr)
@@ -1007,27 +995,15 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		addr string
 	}, 0, len(httpPorts))
 	for name, p := range httpPorts {
-		portCfg := p
-		adminNets, err := portCfg.ParseAdminNets()
+		pc, err := parsePortConfig("http", name, p)
 		if err != nil {
-			return fmt.Errorf("parse admin nets for http port %q: %w", name, err)
-		}
-		secureGW, err := portCfg.ParseSecureGatewayNets()
-		if err != nil {
-			return fmt.Errorf("parse secure_gateway nets for http port %q: %w", name, err)
-		}
-		pc := &rpc.PortContext{
-			PortName:          name,
-			AdminNets:         adminNets,
-			SecureGatewayNets: secureGW,
-			Limit:             portCfg.Limit,
-			SendQueue:         portCfg.SendQueueLimit,
+			return err
 		}
 		httpPortList = append(httpPortList, struct {
 			name string
 			pc   *rpc.PortContext
 			addr string
-		}{name, pc, portCfg.GetBindAddress()})
+		}{name, pc, p.GetBindAddress()})
 	}
 
 	if len(httpPortList) == 0 {
@@ -1096,6 +1072,27 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			reloadTrustedValidators(serverLog, consensusComponents)
 		}
 	}
+}
+
+// parsePortConfig builds the per-port RPC context (admin and
+// secure_gateway nets, connection limits) for a listener of the given
+// protocol ("ws" or "http").
+func parsePortConfig(protocol, name string, p config.PortConfig) (*rpc.PortContext, error) {
+	adminNets, err := p.ParseAdminNets()
+	if err != nil {
+		return nil, fmt.Errorf("parse admin nets for %s port %q: %w", protocol, name, err)
+	}
+	secureGW, err := p.ParseSecureGatewayNets()
+	if err != nil {
+		return nil, fmt.Errorf("parse secure_gateway nets for %s port %q: %w", protocol, name, err)
+	}
+	return &rpc.PortContext{
+		PortName:          name,
+		AdminNets:         adminNets,
+		SecureGatewayNets: secureGW,
+		Limit:             p.Limit,
+		SendQueue:         p.SendQueueLimit,
+	}, nil
 }
 
 // staticValidatorReloader is the writable surface


### PR DESCRIPTION
## Summary
- Remove the `--quiet`/`-q` persistent flag and its backing variable: it was bound in `root.go` but never read anywhere in the module, so it silently did nothing. **Decision: remove rather than wire up** — a flag that promises to suppress output and doesn't is worse than no flag; if console-suppression is wanted later it can be added as real behaviour. Reviewers: object here if you'd rather wire it up.
- Remove the `--silent` persistent flag for the same reason: it was bound in `root.go` (return value discarded) and never read anywhere in the module.
- Extract the duplicated ~13-line port-config parsing (`ParseAdminNets` + `ParseSecureGatewayNets` + `rpc.PortContext` construction) from the WebSocket and HTTP listener setups in `server.go` into a single `parsePortConfig(protocol, name string, p config.PortConfig)` helper. The two blocks differed only in the "ws"/"http" word in error messages, so the protocol is parameterized and error wording is preserved exactly.

## Test plan
- [x] `gofmt -l .` — empty
- [x] `go vet ./internal/cli/...` — clean
- [x] `go test ./internal/cli/...` — pass
- [x] `go build ./...` — pass

Fixes #803
