### PR TITLE
refactor(validator): dedup key extraction, raw-bytes refresh, trusted-set counting (#801)

### DIFF
--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -1072,10 +1072,10 @@ func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
 	a.recomputeAndEmitLocked()
 }
 
-// computeValidatorCounts counts, per validator master key, how many
+// computeValidatorCountsLocked counts, per validator master key, how many
 // publishers with a live (available, effective, unexpired) list carry
 // it. Caller must hold a.mu and filters by threshold afterwards.
-func (a *Aggregator) computeValidatorCounts(now time.Time) map[[33]byte]int {
+func (a *Aggregator) computeValidatorCountsLocked(now time.Time) map[[33]byte]int {
 	counts := make(map[[33]byte]int, 64)
 	for _, s := range a.state {
 		if s.Status != StatusAvailable {
@@ -1148,7 +1148,7 @@ func (a *Aggregator) recomputeAndEmitLocked() {
 		a.unlBlocked = false
 	}
 
-	counts := a.computeValidatorCounts(now)
+	counts := a.computeValidatorCountsLocked(now)
 
 	trusted := make([][33]byte, 0, len(counts))
 	for k, c := range counts {
@@ -1209,7 +1209,7 @@ func (a *Aggregator) TrustedValidators() ([]consensus.NodeID, [][33]byte) {
 	for _, s := range a.state {
 		a.promoteRemainingLocked(s, now)
 	}
-	counts := a.computeValidatorCounts(now)
+	counts := a.computeValidatorCountsLocked(now)
 
 	masters := make([][33]byte, 0, len(counts))
 	for k, c := range counts {

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -794,6 +794,40 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	return Accepted, pubKey, parsedBlob.Sequence
 }
 
+// updateRawBytes refreshes the retained wire-form bytes, reusing the
+// existing backing arrays so the caller may keep its own slices.
+func (s *PublisherState) updateRawBytes(manifest, blob, signature []byte) {
+	s.RawManifest = append(s.RawManifest[:0], manifest...)
+	s.RawBlob = append(s.RawBlob[:0], blob...)
+	s.RawSignature = append(s.RawSignature[:0], signature...)
+}
+
+// extractValidatorKeys decodes and canonically sorts the validator
+// master keys from a parsed blob. logMsg is the debug message emitted
+// for skipped entries.
+func (a *Aggregator) extractValidatorKeys(blob *blobJSON, logMsg string) [][33]byte {
+	keys := make([][33]byte, 0, len(blob.Validators))
+	for i, v := range blob.Validators {
+		raw, err := hex.DecodeString(v.ValidationPublicKey)
+		if err != nil || !validatorKeyValid(raw) {
+			// Mirrors rippled ValidatorList.cpp:1250-1273 which logs
+			// `Invalid node identity` and silently skips the entry
+			// rather than rejecting the surrounding blob.
+			a.logger.Debug(logMsg,
+				"index", i,
+				"pubkey", v.ValidationPublicKey)
+			continue
+		}
+		var k [33]byte
+		copy(k[:], raw)
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return string(keys[i][:]) < string(keys[j][:])
+	})
+	return keys
+}
+
 // applyAcceptedLocked materializes the parsed blob into the
 // publisher's state. Caller must hold a.mu. Does NOT emit OnChange —
 // that's done by recomputeAndEmitLocked once the caller has decided
@@ -816,29 +850,9 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 	if version > s.Version {
 		s.Version = version
 	}
-	s.RawManifest = append(s.RawManifest[:0], rawManifest...)
-	s.RawBlob = append(s.RawBlob[:0], rawBlob...)
-	s.RawSignature = append(s.RawSignature[:0], rawSignature...)
+	s.updateRawBytes(rawManifest, rawBlob, rawSignature)
 
-	keys := make([][33]byte, 0, len(blob.Validators))
-	for i, v := range blob.Validators {
-		raw, err := hex.DecodeString(v.ValidationPublicKey)
-		if err != nil || !validatorKeyValid(raw) {
-			// Mirrors rippled ValidatorList.cpp:1250-1273 which logs
-			// `Invalid node identity` and silently skips the entry
-			// rather than rejecting the surrounding blob.
-			a.logger.Debug("validator list: skipping invalid validator entry",
-				"index", i,
-				"pubkey", v.ValidationPublicKey)
-			continue
-		}
-		var k [33]byte
-		copy(k[:], raw)
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return string(keys[i][:]) < string(keys[j][:])
-	})
+	keys := a.extractValidatorKeys(blob, "validator list: skipping invalid validator entry")
 	s.Validators = keys
 
 	// Also seed any embedded validator manifests into the manifest
@@ -919,22 +933,7 @@ func (a *Aggregator) applyPendingLocked(s *PublisherState, blob *blobJSON, signi
 		return KnownSequence
 	}
 
-	keys := make([][33]byte, 0, len(blob.Validators))
-	for i, v := range blob.Validators {
-		raw, err := hex.DecodeString(v.ValidationPublicKey)
-		if err != nil || !validatorKeyValid(raw) {
-			a.logger.Debug("validator list: skipping invalid validator entry in pending blob",
-				"index", i,
-				"pubkey", v.ValidationPublicKey)
-			continue
-		}
-		var k [33]byte
-		copy(k[:], raw)
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return string(keys[i][:]) < string(keys[j][:])
-	})
+	keys := a.extractValidatorKeys(blob, "validator list: skipping invalid validator entry in pending blob")
 
 	if s.Remaining == nil {
 		s.Remaining = make(map[uint32]*PendingList, 2)
@@ -1009,9 +1008,7 @@ func (a *Aggregator) promoteRemainingLocked(s *PublisherState, now time.Time) (p
 	if chosen.Version > s.Version {
 		s.Version = chosen.Version
 	}
-	s.RawManifest = append(s.RawManifest[:0], chosen.RawManifest...)
-	s.RawBlob = append(s.RawBlob[:0], chosen.RawBlob...)
-	s.RawSignature = append(s.RawSignature[:0], chosen.RawSignature...)
+	s.updateRawBytes(chosen.RawManifest, chosen.RawBlob, chosen.RawSignature)
 	s.Validators = append([][33]byte(nil), chosen.Validators...)
 	s.Status = StatusAvailable
 	// Mirrors rippled ValidatorList.cpp:1970 — if the promoted list is
@@ -1075,6 +1072,35 @@ func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
 	a.recomputeAndEmitLocked()
 }
 
+// computeValidatorCounts counts, per validator master key, how many
+// publishers with a live (available, effective, unexpired) list carry
+// it. Caller must hold a.mu and filters by threshold afterwards.
+func (a *Aggregator) computeValidatorCounts(now time.Time) map[[33]byte]int {
+	counts := make(map[[33]byte]int, 64)
+	for _, s := range a.state {
+		if s.Status != StatusAvailable {
+			continue
+		}
+		if !s.Expiration.IsZero() && !s.Expiration.After(now) {
+			continue
+		}
+		if !s.Effective.IsZero() && s.Effective.After(now) {
+			continue
+		}
+		// Use a set per publisher so duplicate entries in one
+		// publisher's list don't double-count toward the threshold.
+		seen := make(map[[33]byte]struct{}, len(s.Validators))
+		for _, k := range s.Validators {
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			counts[k]++
+		}
+	}
+	return counts
+}
+
 // recomputeAndEmitLocked walks the per-publisher state, computes the
 // union of validators present in at least `threshold` publishers' lists,
 // and — if the result differs from the last emitted set — invokes the
@@ -1122,28 +1148,7 @@ func (a *Aggregator) recomputeAndEmitLocked() {
 		a.unlBlocked = false
 	}
 
-	counts := make(map[[33]byte]int, 64)
-	for _, s := range a.state {
-		if s.Status != StatusAvailable {
-			continue
-		}
-		if !s.Expiration.IsZero() && !s.Expiration.After(now) {
-			continue
-		}
-		if !s.Effective.IsZero() && s.Effective.After(now) {
-			continue
-		}
-		// Use a set per publisher so duplicate entries in one
-		// publisher's list don't double-count toward the threshold.
-		seen := make(map[[33]byte]struct{}, len(s.Validators))
-		for _, k := range s.Validators {
-			if _, dup := seen[k]; dup {
-				continue
-			}
-			seen[k] = struct{}{}
-			counts[k]++
-		}
-	}
+	counts := a.computeValidatorCounts(now)
 
 	trusted := make([][33]byte, 0, len(counts))
 	for k, c := range counts {
@@ -1204,26 +1209,7 @@ func (a *Aggregator) TrustedValidators() ([]consensus.NodeID, [][33]byte) {
 	for _, s := range a.state {
 		a.promoteRemainingLocked(s, now)
 	}
-	counts := make(map[[33]byte]int, 64)
-	for _, s := range a.state {
-		if s.Status != StatusAvailable {
-			continue
-		}
-		if !s.Expiration.IsZero() && !s.Expiration.After(now) {
-			continue
-		}
-		if !s.Effective.IsZero() && s.Effective.After(now) {
-			continue
-		}
-		seen := make(map[[33]byte]struct{}, len(s.Validators))
-		for _, k := range s.Validators {
-			if _, dup := seen[k]; dup {
-				continue
-			}
-			seen[k] = struct{}{}
-			counts[k]++
-		}
-	}
+	counts := a.computeValidatorCounts(now)
 
 	masters := make([][33]byte, 0, len(counts))
 	for k, c := range counts {


### PR DESCRIPTION
## Summary
- Extract `(a *Aggregator) extractValidatorKeys(blob, logMsg)` — the hex-decode + `validatorKeyValid` filter + `[33]byte` copy + canonical sort block previously duplicated in `applyAcceptedLocked` and `applyPendingLocked`; each call site keeps its own debug log message.
- Extract `(s *PublisherState) updateRawBytes(manifest, blob, signature)` — the slice-reuse `append(s.X[:0], src...)` refresh of `RawManifest`/`RawBlob`/`RawSignature` previously duplicated in `applyAcceptedLocked` and `promoteRemainingLocked`.
- Extract `(a *Aggregator) computeValidatorCounts(now)` — the status/expiration/effective filter + per-publisher dedup counting loop previously duplicated in `recomputeAndEmitLocked` and `TrustedValidators`; both call sites keep their own threshold filtering.

Pure extraction — behaviour is byte-identical.

## Test plan
- [x] `gofmt -l .` empty
- [x] `go vet ./internal/validator/...`
- [x] `go test ./internal/validator/...`
- [x] `go build ./...`

Fixes #801