### PR TITLE
cleanup(txq,feetrack,stringutil): remove dead field and method, trim comment (#805)

### DIFF
--- a/internal/feetrack/feetrack.go
+++ b/internal/feetrack/feetrack.go
@@ -113,14 +113,6 @@ func (t *LoadFeeTrack) IsLoadedLocal() bool {
 	return t.raiseCount != 0 || t.localFee != LoadBase
 }
 
-// IsLoadedCluster reports whether either the local node or the cluster is
-// inflating its fee.
-func (t *LoadFeeTrack) IsLoadedCluster() bool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.raiseCount != 0 || t.localFee != LoadBase || t.clusterFee != LoadBase
-}
-
 // RaiseLocalFee bumps the local fee factor and reports whether the stored
 // factor actually changed. The first call only arms raiseCount; the second and
 // subsequent calls scale the local fee up toward FeeMax, tracking the remote

--- a/internal/stringutil/domain.go
+++ b/internal/stringutil/domain.go
@@ -4,11 +4,8 @@ package stringutil
 
 import "regexp"
 
-// tomlDomainRe mirrors rippled's isProperlyFormedTomlDomain regex
-// (StringUtilities.cpp:142-153). Go's RE2 engine has no lookaround, so the
-// "must not begin/end with '-'" per-segment constraint is encoded by making
-// the trailing alphanumeric run optional rather than using the original
-// (?!-)...(?<!-) form.
+// tomlDomainRe validates xrpl.toml domains per rippled's grammar: dot-separated
+// alphanumeric labels (hyphens allowed inside, not at the edges) ending in a TLD.
 var tomlDomainRe = regexp.MustCompile(
 	`^([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$`,
 )

--- a/internal/txq/candidate.go
+++ b/internal/txq/candidate.go
@@ -52,7 +52,6 @@ type Candidate struct {
 	LastResult       tx.Result
 	// PreflightResult holds the result from the preflight check.
 	PreflightResult tx.Result
-	Fee             uint64
 	Consequences    TxConsequences
 }
 


### PR DESCRIPTION
## Summary
- Remove the dead `Candidate.Fee` field in `internal/txq/candidate.go` — never assigned (`NewCandidate` doesn't set it) and never read; the live fee is `Consequences.Fee`.
- Remove the dead exported `LoadFeeTrack.IsLoadedCluster()` method in `internal/feetrack/feetrack.go` — zero callers module-wide.
- Trim the `tomlDomainRe` comment in `internal/stringutil/domain.go` to a one-line behavioural note instead of the RE2-translation rationale.

## Test plan
- [x] `gofmt -l .` empty
- [x] `go vet ./internal/txq/... ./internal/feetrack/... ./internal/stringutil/...`
- [x] `go test ./internal/txq/... ./internal/feetrack/... ./internal/stringutil/...`
- [x] `go build ./...`

Fixes #805