### PR TITLE
cleanup(testing): remove dead DecodeAddress framework helper (#810)

### DIFF
--- a/internal/testing/env_signing.go
+++ b/internal/testing/env_signing.go
@@ -11,18 +11,6 @@ import (
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
-// DecodeAddress decodes an XRPL address to a 20-byte account ID.
-func DecodeAddress(address string) ([20]byte, error) {
-	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(address)
-	if err != nil {
-		return [20]byte{}, err
-	}
-
-	var accountID [20]byte
-	copy(accountID[:], accountIDBytes)
-	return accountID, nil
-}
-
 // WithSeq sets the sequence number on a transaction manually.
 // This bypasses autofill and allows testing transactions from non-existent accounts.
 // Reference: rippled's seq(1) funclet in test/jtx/seq.h


### PR DESCRIPTION
## Summary
- Remove the exported `DecodeAddress` helper from `internal/testing/env_signing.go` — grep-verified zero callers across the module (the only other `DecodeAddress` is `genesis.DecodeAddress`, which it duplicated).
- The `addresscodec` import is retained as it is still used elsewhere in the file.
- The issue's skip/TODO inventory items are informational only and intentionally untouched.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./internal/testing/...`
- [x] `go build ./...`
- [x] `go test -count=1 -run XXX_nothing ./internal/testing/...` (compiles all 40 suite packages — nothing referenced the deleted helper)
- [x] `go test ./internal/testing/ticket/...` passes

Fixes #810