### PR TITLE
refactor(tx): dedup credential validation into shared helpers (#808)

### DIFF
--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -79,7 +79,7 @@ func (a *AccountDelete) Flatten() (map[string]any, error) { return tx.ReflectFla
 // sandbox is rolled back for tec results.
 // Reference: rippled Transactor.cpp - tecEXPIRED re-applies removeExpiredCredentials
 func (a *AccountDelete) ApplyOnTec(ctx *tx.ApplyContext) tx.Result {
-	adRemoveExpiredCredentials(ctx, a.CredentialIDs)
+	credential.RemoveExpiredCredentials(ctx, a.CredentialIDs)
 	return tx.TecEXPIRED
 }
 
@@ -102,7 +102,7 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecDST_TAG_NEEDED
 	}
 	if len(a.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if result := adValidateCredentials(ctx, a.CredentialIDs); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, a.CredentialIDs, true); result != tx.TesSUCCESS {
 			return result
 		}
 	}
@@ -367,42 +367,13 @@ func keyLessEqual(a, b [32]byte) bool {
 	return true
 }
 
-func adValidateCredentials(ctx *tx.ApplyContext, credentialIDs []string) tx.Result {
-	for _, h := range credentialIDs {
-		cb, err := hex.DecodeString(h)
-		if err != nil || len(cb) != 32 {
-			return tx.TecBAD_CREDENTIALS
-		}
-		var k [32]byte
-		copy(k[:], cb)
-		d, err := ctx.View.Read(keylet.Keylet{Key: k})
-		if err != nil || d == nil {
-			return tx.TecBAD_CREDENTIALS
-		}
-		ce, err := credential.ParseCredentialEntry(d)
-		if err != nil {
-			return tx.TecBAD_CREDENTIALS
-		}
-		if ce.Subject != ctx.AccountID {
-			return tx.TecBAD_CREDENTIALS
-		}
-		if (ce.Flags & credential.LsfCredentialAccepted) == 0 {
-			return tx.TecBAD_CREDENTIALS
-		}
-		if ce.Expiration != nil && ctx.Config.ParentCloseTime >= *ce.Expiration {
-			return tx.TecEXPIRED
-		}
-	}
-	return tx.TesSUCCESS
-}
-
 func adVerifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src, dst [20]byte, da *state.AccountRoot) tx.Result {
 	// Remove expired credentials first, before any deposit auth checks.
 	// Reference: rippled verifyDepositPreauth() in CredentialHelpers.cpp
 	// calls credentials::removeExpired() at the top, which deletes expired
 	// credential SLEs and adjusts owner counts even on tec results.
 	if len(credentialIDs) > 0 {
-		if adRemoveExpiredCredentials(ctx, credentialIDs) {
+		if credential.RemoveExpiredCredentials(ctx, credentialIDs) {
 			return tx.TecEXPIRED
 		}
 	}
@@ -420,41 +391,6 @@ func adVerifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src, d
 		return adAuthorizedDepositPreauth(ctx, credentialIDs, dst)
 	}
 	return tx.TecNO_PERMISSION
-}
-
-// adRemoveExpiredCredentials checks for expired credentials and deletes them.
-// Returns true if any credentials were expired.
-// Reference: rippled credentials::removeExpired() in CredentialHelpers.cpp
-func adRemoveExpiredCredentials(ctx *tx.ApplyContext, credentialIDs []string) bool {
-	closeTime := ctx.Config.ParentCloseTime
-	anyExpired := false
-
-	for _, idHex := range credentialIDs {
-		credIDBytes, err := hex.DecodeString(idHex)
-		if err != nil || len(credIDBytes) != 32 {
-			continue
-		}
-		var credID [32]byte
-		copy(credID[:], credIDBytes)
-
-		credKey := keylet.CredentialByID(credID)
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			continue
-		}
-
-		cred, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			continue
-		}
-
-		if cred.Expiration != nil && closeTime > *cred.Expiration {
-			_ = credential.DeleteSLE(ctx.View, credKey, cred)
-			anyExpired = true
-		}
-	}
-
-	return anyExpired
 }
 
 func adAuthorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst [20]byte) tx.Result {

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -209,6 +209,83 @@ func CheckCredentialExpired(cred *CredentialEntry, closeTime uint32) bool {
 	return closeTime > *cred.Expiration
 }
 
+// ValidateCredentialIDs validates a transaction's CredentialIDs: each
+// credential must exist in the ledger, have the transaction sender as its
+// Subject, and be accepted, otherwise tecBAD_CREDENTIALS. When checkExpiry is
+// set, a credential whose Expiration is at or before the parent close time
+// returns tecEXPIRED.
+// Reference: rippled CredentialHelpers.cpp credentials::valid()
+func ValidateCredentialIDs(ctx *tx.ApplyContext, credentialIDs []string, checkExpiry bool) tx.Result {
+	for _, idHex := range credentialIDs {
+		credIDBytes, err := hex.DecodeString(idHex)
+		if err != nil || len(credIDBytes) != 32 {
+			return tx.TecBAD_CREDENTIALS
+		}
+		var credID [32]byte
+		copy(credID[:], credIDBytes)
+
+		credData, err := ctx.View.Read(keylet.CredentialByID(credID))
+		if err != nil || credData == nil {
+			return tx.TecBAD_CREDENTIALS
+		}
+
+		cred, err := ParseCredentialEntry(credData)
+		if err != nil {
+			return tx.TecBAD_CREDENTIALS
+		}
+
+		if cred.Subject != ctx.AccountID {
+			return tx.TecBAD_CREDENTIALS
+		}
+
+		if !cred.IsAccepted() {
+			return tx.TecBAD_CREDENTIALS
+		}
+
+		if checkExpiry && cred.Expiration != nil && ctx.Config.ParentCloseTime >= *cred.Expiration {
+			return tx.TecEXPIRED
+		}
+	}
+
+	return tx.TesSUCCESS
+}
+
+// RemoveExpiredCredentials deletes any expired credentials in credentialIDs
+// from the ledger, adjusting owner directories and counts. It returns true if
+// at least one credential was expired.
+// Reference: rippled CredentialHelpers.cpp credentials::removeExpired()
+func RemoveExpiredCredentials(ctx *tx.ApplyContext, credentialIDs []string) bool {
+	closeTime := ctx.Config.ParentCloseTime
+	anyExpired := false
+
+	for _, idHex := range credentialIDs {
+		credIDBytes, err := hex.DecodeString(idHex)
+		if err != nil || len(credIDBytes) != 32 {
+			continue
+		}
+		var credID [32]byte
+		copy(credID[:], credIDBytes)
+
+		credKey := keylet.CredentialByID(credID)
+		credData, err := ctx.View.Read(credKey)
+		if err != nil || credData == nil {
+			continue
+		}
+
+		cred, err := ParseCredentialEntry(credData)
+		if err != nil {
+			continue
+		}
+
+		if CheckCredentialExpired(cred, closeTime) {
+			_ = DeleteSLE(ctx.View, credKey, cred)
+			anyExpired = true
+		}
+	}
+
+	return anyExpired
+}
+
 // DeleteSLE deletes a credential from the ledger, removing it from both the
 // issuer's and subject's owner directories and adjusting owner counts.
 // Reference: rippled CredentialHelpers.cpp credentials::deleteSLE()

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -211,10 +211,12 @@ func CheckCredentialExpired(cred *CredentialEntry, closeTime uint32) bool {
 
 // ValidateCredentialIDs validates a transaction's CredentialIDs: each
 // credential must exist in the ledger, have the transaction sender as its
-// Subject, and be accepted, otherwise tecBAD_CREDENTIALS. When checkExpiry is
-// set, a credential whose Expiration is at or before the parent close time
-// returns tecEXPIRED.
-// Reference: rippled CredentialHelpers.cpp credentials::valid()
+// Subject, and be accepted, otherwise tecBAD_CREDENTIALS. With checkExpiry
+// false this matches rippled's credentials::valid(), which never checks
+// expiry (that is deferred to RemoveExpiredCredentials). With checkExpiry
+// true, a credential whose Expiration is at or before the parent close time
+// returns tecEXPIRED — a validate-time check rippled's valid() does not
+// perform, preserved from the pre-refactor account and paychan transactors.
 func ValidateCredentialIDs(ctx *tx.ApplyContext, credentialIDs []string, checkExpiry bool) tx.Result {
 	for _, idHex := range credentialIDs {
 		credIDBytes, err := hex.DecodeString(idHex)

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -130,7 +130,7 @@ func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConf
 // sandbox is rolled back for tec results.
 // Reference: rippled Transactor.cpp - tecEXPIRED re-applies removeExpiredCredentials
 func (e *EscrowFinish) ApplyOnTec(ctx *tx.ApplyContext) tx.Result {
-	removeExpiredCredentials(ctx, e.CredentialIDs)
+	credential.RemoveExpiredCredentials(ctx, e.CredentialIDs)
 	return tx.TecEXPIRED
 }
 
@@ -156,7 +156,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// This must run before doApply's time checks because rippled's preclaim
 	// runs before doApply.
 	if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if result := validateCredentials(ctx, e.CredentialIDs); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, e.CredentialIDs, false); result != tx.TesSUCCESS {
 			return result
 		}
 	}
@@ -285,7 +285,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled verifyDepositPreauth() — first calls removeExpired(),
 	// returns tecEXPIRED if any credentials were expired.
 	if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if removeExpiredCredentials(ctx, e.CredentialIDs) {
+		if credential.RemoveExpiredCredentials(ctx, e.CredentialIDs) {
 			return tx.TecEXPIRED
 		}
 	}
@@ -450,87 +450,6 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	adjustOwnerCount(ctx, ownerID, -1)
 
 	return tx.TesSUCCESS
-}
-
-// validateCredentials implements rippled's credentials::valid() preclaim check.
-// For each credential ID, it reads the Credential SLE and validates:
-// 1. The credential exists
-// 2. The credential's Subject matches the transaction sender (src)
-// 3. The credential has been accepted (lsfAccepted flag)
-// Reference: rippled CredentialHelpers.cpp credentials::valid()
-func validateCredentials(ctx *tx.ApplyContext, credentialIDs []string) tx.Result {
-	for _, credIDHex := range credentialIDs {
-		credHash, err := hex.DecodeString(credIDHex)
-		if err != nil || len(credHash) != 32 {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		var credID [32]byte
-		copy(credID[:], credHash)
-
-		credKey := keylet.CredentialByID(credID)
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			// Credential doesn't exist
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		credEntry, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		// Subject must match the transaction sender
-		if credEntry.Subject != ctx.AccountID {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		// Credential must be accepted
-		if (credEntry.Flags & credential.LsfCredentialAccepted) == 0 {
-			return tx.TecBAD_CREDENTIALS
-		}
-	}
-
-	return tx.TesSUCCESS
-}
-
-// removeExpiredCredentials checks for expired credentials and deletes them.
-// Returns true if any credentials were expired.
-// Reference: rippled credentials::removeExpired() in CredentialHelpers.cpp
-func removeExpiredCredentials(ctx *tx.ApplyContext, credentialIDs []string) bool {
-	if len(credentialIDs) == 0 {
-		return false
-	}
-
-	closeTime := ctx.Config.ParentCloseTime
-	anyExpired := false
-
-	for _, idHex := range credentialIDs {
-		credIDBytes, err := hex.DecodeString(idHex)
-		if err != nil || len(credIDBytes) != 32 {
-			continue
-		}
-		var credID [32]byte
-		copy(credID[:], credIDBytes)
-
-		credKey := keylet.CredentialByID(credID)
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			continue
-		}
-
-		cred, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			continue
-		}
-
-		if cred.Expiration != nil && closeTime > *cred.Expiration {
-			_ = credential.DeleteSLE(ctx.View, credKey, cred)
-			anyExpired = true
-		}
-	}
-
-	return anyExpired
 }
 
 // authorizedDepositPreauth implements rippled's credentials::authorizedDepositPreauth().

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -207,7 +207,7 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	// Reference: rippled PayChan.cpp PayChanClaim::preclaim() credentials::valid()
 	if len(p.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if result := validateCredentials(ctx, p.CredentialIDs); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs, true); result != tx.TesSUCCESS {
 			return result
 		}
 	}
@@ -407,78 +407,7 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 // When tecEXPIRED is returned, expired credentials must still be deleted from the ledger.
 // Reference: rippled CredentialHelpers.cpp removeExpired() — called from verifyDepositPreauth()
 func (p *PaymentChannelClaim) ApplyOnTec(ctx *tx.ApplyContext) tx.Result {
-	if len(p.CredentialIDs) == 0 {
-		return tx.TesSUCCESS
-	}
-
-	closeTime := ctx.Config.ParentCloseTime
-	for _, credIDHex := range p.CredentialIDs {
-		credHash, err := hex.DecodeString(credIDHex)
-		if err != nil || len(credHash) != 32 {
-			continue
-		}
-
-		var credKeyBytes [32]byte
-		copy(credKeyBytes[:], credHash)
-		credKey := keylet.Keylet{Key: credKeyBytes}
-
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			continue
-		}
-
-		credEntry, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			continue
-		}
-
-		// Only delete if actually expired
-		if credEntry.Expiration != nil && closeTime > *credEntry.Expiration {
-			credential.DeleteSLE(ctx.View, credKey, credEntry)
-		}
-	}
-
-	return tx.TesSUCCESS
-}
-
-// validateCredentials implements rippled's credentials::valid() preclaim check.
-// Reference: rippled CredentialHelpers.cpp credentials::valid()
-func validateCredentials(ctx *tx.ApplyContext, credentialIDs []string) tx.Result {
-	for _, credIDHex := range credentialIDs {
-		credHash, err := hex.DecodeString(credIDHex)
-		if err != nil || len(credHash) != 32 {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		var credKeyBytes [32]byte
-		copy(credKeyBytes[:], credHash)
-		credKey := keylet.Keylet{Key: credKeyBytes}
-
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		credEntry, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		// Subject must match the transaction sender
-		if credEntry.Subject != ctx.AccountID {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		// Credential must be accepted
-		if (credEntry.Flags & credential.LsfCredentialAccepted) == 0 {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		if credEntry.Expiration != nil && ctx.Config.ParentCloseTime >= *credEntry.Expiration {
-			return tx.TecEXPIRED
-		}
-	}
-
+	credential.RemoveExpiredCredentials(ctx, p.CredentialIDs)
 	return tx.TesSUCCESS
 }
 

--- a/internal/tx/payment/payment_credential.go
+++ b/internal/tx/payment/payment_credential.go
@@ -11,93 +11,11 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// validateCredentials performs preclaim-level validation of CredentialIDs.
-// Checks each credential exists in the ledger, belongs to the sender, and is accepted.
-// Reference: rippled credentials::valid() in CredentialHelpers.cpp
-func (p *Payment) validateCredentials(ctx *tx.ApplyContext) tx.Result {
-	if len(p.CredentialIDs) == 0 {
-		return tx.TesSUCCESS
-	}
-
-	for _, idHex := range p.CredentialIDs {
-		credIDBytes, err := hex.DecodeString(idHex)
-		if err != nil || len(credIDBytes) != 32 {
-			return tx.TecBAD_CREDENTIALS
-		}
-		var credID [32]byte
-		copy(credID[:], credIDBytes)
-
-		credKey := keylet.CredentialByID(credID)
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		cred, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		// Subject must be the transaction sender
-		if cred.Subject != ctx.AccountID {
-			return tx.TecBAD_CREDENTIALS
-		}
-
-		// Credential must be accepted
-		if !cred.IsAccepted() {
-			return tx.TecBAD_CREDENTIALS
-		}
-	}
-
-	return tx.TesSUCCESS
-}
-
-// removeExpiredCredentials checks for expired credentials and deletes them.
-// Returns true if any credentials were expired.
-// Reference: rippled credentials::removeExpired() in CredentialHelpers.cpp
-func (p *Payment) removeExpiredCredentials(ctx *tx.ApplyContext) bool {
-	if len(p.CredentialIDs) == 0 {
-		return false
-	}
-
-	closeTime := ctx.Config.ParentCloseTime
-	anyExpired := false
-
-	for _, idHex := range p.CredentialIDs {
-		credIDBytes, err := hex.DecodeString(idHex)
-		if err != nil || len(credIDBytes) != 32 {
-			continue
-		}
-		var credID [32]byte
-		copy(credID[:], credIDBytes)
-
-		credKey := keylet.CredentialByID(credID)
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			continue
-		}
-
-		cred, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			continue
-		}
-
-		// Check expiration
-		if cred.Expiration != nil && closeTime > *cred.Expiration {
-			// Delete expired credential from ledger
-			_ = credential.DeleteSLE(ctx.View, credKey, cred)
-			anyExpired = true
-		}
-	}
-
-	return anyExpired
-}
-
 // ApplyOnTec implements TecApplier. When tecEXPIRED is returned, this re-runs
 // credential expiration deletion against the engine's view so the side-effects persist.
 // Reference: rippled Transactor.cpp - tecEXPIRED re-applies removeExpiredCredentials
 func (p *Payment) ApplyOnTec(ctx *tx.ApplyContext) tx.Result {
-	p.removeExpiredCredentials(ctx)
+	credential.RemoveExpiredCredentials(ctx, p.CredentialIDs)
 	return tx.TecEXPIRED
 }
 
@@ -181,7 +99,7 @@ func (p *Payment) verifyDepositPreauth(ctx *tx.ApplyContext, srcAccountID, dstAc
 
 	// Remove expired credentials first
 	if credentialsPresent {
-		if p.removeExpiredCredentials(ctx) {
+		if credential.RemoveExpiredCredentials(ctx, p.CredentialIDs) {
 			return tx.TecEXPIRED
 		}
 	}

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/credential"
 	"github.com/LeJamon/go-xrpl/internal/tx/permissioneddomain"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -145,7 +146,7 @@ func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	// Validate credentials (preclaim)
-	if result := p.validateCredentials(ctx); result != tx.TesSUCCESS {
+	if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs, false); result != tx.TesSUCCESS {
 		return result
 	}
 
@@ -297,7 +298,7 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 	}
 
 	// Validate credentials
-	if result := p.validateCredentials(ctx); result != tx.TesSUCCESS {
+	if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs, false); result != tx.TesSUCCESS {
 		return result
 	}
 

--- a/internal/tx/payment/payment_xrp.go
+++ b/internal/tx/payment/payment_xrp.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/credential"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -81,7 +82,7 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 		}
 
 		// Validate credentials (preclaim)
-		if result := p.validateCredentials(ctx); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs, false); result != tx.TesSUCCESS {
 			return result
 		}
 
@@ -99,7 +100,7 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 			}
 		} else if len(p.CredentialIDs) > 0 {
 			// Even without lsfDepositAuth, remove expired credentials if present
-			if p.removeExpiredCredentials(ctx) {
+			if credential.RemoveExpiredCredentials(ctx, p.CredentialIDs) {
 				return tx.TecEXPIRED
 			}
 		}


### PR DESCRIPTION
## Summary
- Extract `credential.ValidateCredentialIDs(ctx, ids, checkExpiry)` and `credential.RemoveExpiredCredentials(ctx, ids)` into `internal/tx/credential/credential_helpers.go`. `RemoveExpiredCredentials` mirrors rippled's `credentials::removeExpired()`; `ValidateCredentialIDs` with `checkExpiry=false` mirrors `credentials::valid()` (which never checks expiry — that is deferred to remove-expired).
- Replace all four parallel copies with calls to the shared helpers: `account/account_delete.go` (`adValidateCredentials` + `adRemoveExpiredCredentials`), `escrow/escrow_finish.go` (`validateCredentials` + `removeExpiredCredentials`), `paychan/payment_channel_claim.go` (`validateCredentials` + the inline `ApplyOnTec` remove-expired loop), and `payment/payment_credential.go` (method-receiver variants, including the `payment_xrp.go` / `payment_iou.go` call sites).
- The only behavioural difference between copies was the inline expiry check: AccountDelete and PayChanClaim return `tecEXPIRED` for `ParentCloseTime >= Expiration` during validation; EscrowFinish and Payment defer expiry to remove-expired like rippled. The `checkExpiry=true` mode preserves the account/paychan validate-time check exactly as it was — note that this check has **no counterpart in rippled's `valid()`**, i.e. it is a pre-existing goXRPL divergence carried over unchanged (tracked separately in #824). Every call site keeps identical behaviour, including paychan's `ApplyOnTec` returning `tesSUCCESS`. Net: -219 LoC.

## Test plan
- [x] `gofmt -l .` clean, `go vet ./internal/tx/...`, `go build ./...`
- [x] `go test ./internal/tx/...` — all pass
- [x] Conformance suites: `go test ./internal/testing/credential/... ./internal/testing/depositpreauth/... ./internal/testing/escrow/... ./internal/testing/paychan/... ./internal/testing/payment/... ./internal/testing/accountdelete/...` — all pass

Fixes #808
