### PR TITLE
cleanup(rpc): remove dead exports, unify actNotFound errors, dedup ledger-index default (#809)

### DIFF
--- a/internal/rpc/handlers/account_channels.go
+++ b/internal/rpc/handlers/account_channels.go
@@ -9,7 +9,9 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// AccountChannelsMethod handles the account_channels RPC method
+// AccountChannelsMethod handles account_channels: it lists the payment
+// channels where the account is the source, optionally filtered by
+// destination_account.
 type AccountChannelsMethod struct{ BaseHandler }
 
 func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
@@ -39,11 +41,7 @@ func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMes
 		return nil, err
 	}
 
-	// Determine ledger index to use
-	ledgerIndex := "current"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(request.LedgerIndex)
 
 	// Get account channels from the ledger service
 	limit := ClampLimit(request.Limit, LimitAccountChannels, ctx.Unlimited)

--- a/internal/rpc/handlers/account_currencies.go
+++ b/internal/rpc/handlers/account_currencies.go
@@ -9,7 +9,8 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// AccountCurrenciesMethod handles the account_currencies RPC method
+// AccountCurrenciesMethod handles account_currencies: it reports the
+// currencies the account can send and receive, derived from its trust lines.
 type AccountCurrenciesMethod struct{ BaseHandler }
 
 func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
@@ -31,11 +32,7 @@ func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, err
 	}
 
-	// Determine ledger index to use
-	ledgerIndex := "current"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(request.LedgerIndex)
 
 	// Get account currencies from the ledger service
 	result, err := ctx.Services.Ledger.GetAccountCurrencies(
@@ -45,10 +42,7 @@ func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawM
 	)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
-			return nil, &types.RpcError{
-				Code:    types.RpcACT_NOT_FOUND,
-				Message: "Account not found.",
-			}
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		if len(err.Error()) > 24 && err.Error()[:24] == "invalid account address:" {
 			return nil, &types.RpcError{

--- a/internal/rpc/handlers/account_lines.go
+++ b/internal/rpc/handlers/account_lines.go
@@ -9,7 +9,9 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// AccountLinesMethod handles the account_lines RPC method
+// AccountLinesMethod handles account_lines: it returns the account's trust
+// lines, optionally filtered by peer; ignore_default drops lines that are in
+// default state on the account's side.
 type AccountLinesMethod struct{ BaseHandler }
 
 func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
@@ -40,20 +42,13 @@ func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, err
 	}
 
-	// Determine ledger index to use
-	ledgerIndex := "current"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(request.LedgerIndex)
 
 	limit := ClampLimit(request.Limit, LimitAccountLines, ctx.Unlimited)
 	result, err := ctx.Services.Ledger.GetAccountLines(ctx.Context, request.Account, ledgerIndex, request.Peer, limit)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
-			return nil, &types.RpcError{
-				Code:    19, // actNotFound
-				Message: "Account not found.",
-			}
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account lines: %v", err))
 	}

--- a/internal/rpc/handlers/account_nfts.go
+++ b/internal/rpc/handlers/account_nfts.go
@@ -9,7 +9,8 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// AccountNftsMethod handles the account_nfts RPC method
+// AccountNftsMethod handles account_nfts: it enumerates the NFTs the account
+// owns, read from its NFTokenPage entries.
 type AccountNftsMethod struct{ BaseHandler }
 
 func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
@@ -31,11 +32,7 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, err
 	}
 
-	// Determine ledger index to use
-	ledgerIndex := "current"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(request.LedgerIndex)
 
 	limit := ClampLimit(request.Limit, LimitAccountNFTokens, ctx.Unlimited)
 	result, err := ctx.Services.Ledger.GetAccountNFTs(
@@ -46,10 +43,7 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
-			return nil, &types.RpcError{
-				Code:    types.RpcACT_NOT_FOUND,
-				Message: "Account not found.",
-			}
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		if len(err.Error()) > 24 && err.Error()[:24] == "invalid account address:" {
 			return nil, &types.RpcError{

--- a/internal/rpc/handlers/account_objects.go
+++ b/internal/rpc/handlers/account_objects.go
@@ -12,7 +12,8 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// AccountObjectsMethod handles the account_objects RPC method
+// AccountObjectsMethod handles account_objects: it enumerates the raw ledger
+// entries owned by the account, with type and deletion_blockers_only filters.
 type AccountObjectsMethod struct{ BaseHandler }
 
 // deletionBlockerTypes lists SLE types that block account deletion.
@@ -118,10 +119,7 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		return nil, err
 	}
 
-	ledgerIndex := "current"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(request.LedgerIndex)
 
 	limit := ClampLimit(request.Limit, LimitAccountObjects, ctx.Unlimited)
 
@@ -169,10 +167,7 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	result, err := ctx.Services.Ledger.GetAccountObjects(ctx.Context, request.Account, ledgerIndex, effectiveType, limit)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
-			return nil, &types.RpcError{
-				Code:    19,
-				Message: "Account not found.",
-			}
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account objects: %v", err))
 	}

--- a/internal/rpc/handlers/account_offers.go
+++ b/internal/rpc/handlers/account_offers.go
@@ -9,7 +9,8 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// AccountOffersMethod handles the account_offers RPC method
+// AccountOffersMethod handles account_offers: it lists the Offer ledger
+// entries the account currently owns.
 type AccountOffersMethod struct{ BaseHandler }
 
 func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
@@ -32,20 +33,13 @@ func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, err
 	}
 
-	// Determine ledger index to use
-	ledgerIndex := "current"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(request.LedgerIndex)
 
 	limit := ClampLimit(request.Limit, LimitAccountOffers, ctx.Unlimited)
 	result, err := ctx.Services.Ledger.GetAccountOffers(ctx.Context, request.Account, ledgerIndex, limit)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
-			return nil, &types.RpcError{
-				Code:    19, // actNotFound
-				Message: "Account not found.",
-			}
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account offers: %v", err))
 	}

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -13,7 +13,8 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// AccountTxMethod handles the account_tx RPC method
+// AccountTxMethod handles account_tx: it pages through the transactions that
+// affected the account over a validated-ledger range, oldest- or newest-first.
 type AccountTxMethod struct{ BaseHandler }
 
 func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
@@ -114,10 +115,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 			}
 		}
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
-			return nil, &types.RpcError{
-				Code:    19,
-				Message: "Account not found.",
-			}
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account transactions: %v", err))
 	}

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -194,10 +194,7 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid ledger_index: %v", err))
 		}
 	}
-	ledgerIndex := "current"
-	if spec.LedgerIndex != "" {
-		ledgerIndex = spec.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(spec.LedgerIndex)
 
 	takerPays := types.Amount{Currency: paysCurrency, Issuer: canonIssuerString(paysIssuerStr, paysCurrency)}
 	takerGets := types.Amount{Currency: getsCurrency, Issuer: canonIssuerString(getsIssuerStr, getsCurrency)}
@@ -252,28 +249,6 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		response["limit"] = limit
 	}
 	return response, nil
-}
-
-func ParseAmountFromJSON(data json.RawMessage) (types.Amount, error) {
-	var xrpAmount string
-	if err := json.Unmarshal(data, &xrpAmount); err == nil {
-		return types.Amount{Value: xrpAmount}, nil
-	}
-
-	var iouAmount struct {
-		Currency string `json:"currency"`
-		Issuer   string `json:"issuer"`
-		Value    string `json:"value,omitempty"`
-	}
-	if err := json.Unmarshal(data, &iouAmount); err != nil {
-		return types.Amount{}, err
-	}
-
-	return types.Amount{
-		Currency: iouAmount.Currency,
-		Issuer:   iouAmount.Issuer,
-		Value:    iouAmount.Value,
-	}, nil
 }
 
 // isValidCurrencyCode reports whether a currency code is acceptable per

--- a/internal/rpc/handlers/channel_verify.go
+++ b/internal/rpc/handlers/channel_verify.go
@@ -14,8 +14,9 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// ChannelVerifyMethod handles the channel_verify RPC method
-// This verifies a signature that can be used to redeem a specific amount from a payment channel.
+// ChannelVerifyMethod handles channel_verify: it checks a payment-channel
+// claim signature against the channel ID, amount, and public key, without
+// touching ledger state.
 type ChannelVerifyMethod struct{ BaseHandler }
 
 // channelVerifyRequest represents the request parameters

--- a/internal/rpc/handlers/gateway_balances.go
+++ b/internal/rpc/handlers/gateway_balances.go
@@ -59,11 +59,7 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 		}
 	}
 
-	// Determine ledger index to use
-	ledgerIndex := "current"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(request.LedgerIndex)
 
 	// Get gateway balances from the ledger service
 	result, err := ctx.Services.Ledger.GetGatewayBalances(
@@ -74,10 +70,7 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 	)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
-			return nil, &types.RpcError{
-				Code:    types.RpcACT_NOT_FOUND,
-				Message: "Account not found.",
-			}
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		if len(err.Error()) > 24 && err.Error()[:24] == "invalid account address:" {
 			return nil, &types.RpcError{

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -118,6 +118,15 @@ func ValidateAccount(account string) *types.RpcError {
 	return nil
 }
 
+// resolveLedgerIndex returns the ledger selector for a request, defaulting
+// to "current" when no ledger_index was supplied.
+func resolveLedgerIndex(li types.LedgerIndex) string {
+	if li != "" {
+		return li.String()
+	}
+	return "current"
+}
+
 // FormatLedgerHash formats a 32-byte hash as uppercase hex string (matching rippled).
 func FormatLedgerHash(hash [32]byte) string {
 	return strings.ToUpper(hex.EncodeToString(hash[:]))

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -40,11 +40,7 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	}
 	limit := ClampLimit(request.Limit, limitRange, ctx.Unlimited)
 
-	// Determine ledger index to use
-	ledgerIndex := "current"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(request.LedgerIndex)
 
 	// Parse marker as string
 	markerStr := ""

--- a/internal/rpc/handlers/nft_buy_offers.go
+++ b/internal/rpc/handlers/nft_buy_offers.go
@@ -50,11 +50,7 @@ func (m *NftBuyOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, err
 	}
 
-	// Determine ledger index to use
-	ledgerIndex := "current"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(request.LedgerIndex)
 
 	// Apply limit clamping matching rippled's readLimitField with nftOffers tuning.
 	// Reference: NFTOffers.cpp line 69: readLimitField(limit, RPC::Tuning::nftOffers, context)

--- a/internal/rpc/handlers/nft_sell_offers.go
+++ b/internal/rpc/handlers/nft_sell_offers.go
@@ -50,11 +50,7 @@ func (m *NftSellOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, err
 	}
 
-	// Determine ledger index to use
-	ledgerIndex := "current"
-	if request.LedgerIndex != "" {
-		ledgerIndex = request.LedgerIndex.String()
-	}
+	ledgerIndex := resolveLedgerIndex(request.LedgerIndex)
 
 	// Apply limit clamping matching rippled's readLimitField with nftOffers tuning.
 	// Reference: NFTOffers.cpp line 69: readLimitField(limit, RPC::Tuning::nftOffers, context)

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -727,13 +727,6 @@ func (ws *WebSocketServer) handleRPCMethod(wsConn *WebSocketConnection, ctx *typ
 	}
 }
 
-// WebSocketResponseOptions contains optional fields for WebSocket responses
-type WebSocketResponseOptions struct {
-	Warning   string                // "load" when approaching rate limit
-	Warnings  []types.WarningObject // Array of warning objects
-	Forwarded bool                  // True if forwarded from Clio to P2P server
-}
-
 func (ws *WebSocketServer) sendResponse(wsConn *WebSocketConnection, response types.WebSocketResponse) {
 	ws.sendResponseWithOptions(wsConn, response, nil)
 }


### PR DESCRIPTION
## Summary
- Remove dead `ParseAmountFromJSON` from `handlers/book_offers.go` (zero callers) and the duplicate local `WebSocketResponseOptions` type in `websocket.go` (all call sites already use `types.WebSocketResponseOptions`).
- Replace every inline `&types.RpcError{Code: ACT_NOT_FOUND, Message: "Account not found."}` with the existing `types.RpcErrorActNotFound` helper (account_currencies, account_lines, account_nfts, account_objects, account_offers, account_tx, plus gateway_balances which had the identical inline pattern). The inline versions left `ErrorString` empty, so these handlers emitted `"error": ""` on the wire; they now emit `"error": "actNotFound"` like rippled and like account_channels/account_info already did. The neighboring `"Account malformed."` inline errors were left untouched (different message, out of issue scope).
- Add a `resolveLedgerIndex` helper in `handlers/helpers.go` pinning the `"current"` default, and use it at every byte-identical site (the six account handlers plus book_offers, gateway_balances, ledger_data, nft_buy_offers, nft_sell_offers). `account_info.go` keeps its own logic since it additionally falls back to `"validated"` on `ledger_hash`.
- Enrich the trivial "XxxMethod handles the xxx RPC method" doc comments on the touched handlers with one behavioural fact each (package convention is to keep doc comments); `consensus_info.go` and `fee.go` already had enriched comments, so only their unchanged lead sentences remain.

## Test plan
- [x] `gofmt -l .` empty
- [x] `go vet ./internal/rpc/...`
- [x] `go build ./...`
- [x] `go test ./internal/rpc/...`
- [x] `go test ./internal/testing/rpcenv/... ./internal/testing/nft/...`

Fixes #809