### PR TITLE
fix(rpc): emit proper error tokens for malformed/not-found account errors (#823)

### DIFF
--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -238,7 +238,7 @@ func TestAccountChannelsErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "n9MJkEKHDhy5eTLuHUQeAAjo382frHNbFK4C8hcwN4nwM2SrLdBj",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -204,6 +204,7 @@ func TestAccountCurrenciesBadInput(t *testing.T) {
 		params        any
 		expectedError string
 		expectedCode  int
+		expectedToken string
 		setupMock     func()
 	}{
 		{
@@ -272,6 +273,20 @@ func TestAccountCurrenciesBadInput(t *testing.T) {
 				mock.accountCurrenciesErr = svcerr.ErrAccountNotFound
 			},
 		},
+		{
+			// service-level address rejection must carry the actMalformed
+			// wire token, not an empty error string
+			name: "Malformed account - service rejects address (actMalformed token)",
+			params: map[string]any{
+				"account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			},
+			expectedError: "Account malformed.",
+			expectedCode:  types.RpcACT_MALFORMED,
+			expectedToken: "actMalformed",
+			setupMock: func() {
+				mock.accountCurrenciesErr = errors.New("invalid account address: rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK")
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -301,6 +316,10 @@ func TestAccountCurrenciesBadInput(t *testing.T) {
 				"Error message should contain expected text")
 			assert.Equal(t, tc.expectedCode, rpcErr.Code,
 				"Error code should match expected")
+			if tc.expectedToken != "" {
+				assert.Equal(t, tc.expectedToken, rpcErr.ErrorString,
+					"Error token should match expected")
+			}
 		})
 	}
 }

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -248,7 +248,7 @@ func TestAccountCurrenciesBadInput(t *testing.T) {
 			params: map[string]any{
 				"account": "llIIOO",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -258,7 +258,7 @@ func TestAccountCurrenciesBadInput(t *testing.T) {
 			params: map[string]any{
 				"account": "Bob",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -274,8 +274,6 @@ func TestAccountCurrenciesBadInput(t *testing.T) {
 			},
 		},
 		{
-			// service-level address rejection must carry the actMalformed
-			// wire token, not an empty error string
 			name: "Malformed account - service rejects address (actMalformed token)",
 			params: map[string]any{
 				"account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -251,7 +251,7 @@ func TestAccountInfoErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "n94JNrQYkDrpt62bbSR7nVEhdyAvcJXRAsjEkFYyqRkh9SUTYEqV",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -259,7 +259,7 @@ func TestAccountInfoErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "foo",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -268,7 +268,7 @@ func TestAccountLinesErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "n9MJkEKHDhy5eTLuHUQeAAjo382frHNbFK4C8hcwN4nwM2SrLdBj",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -237,7 +237,7 @@ func TestAccountNFTsErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "n9MJkEKHDhy5eTLuHUQeAAjo382frHNbFK4C8hcwN4nwM2SrLdBj",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{

--- a/internal/rpc/account_objects_test.go
+++ b/internal/rpc/account_objects_test.go
@@ -129,7 +129,7 @@ func TestAccountObjectsErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "n94JNrQYkDrpt62bbSR7nVEhdyAvcJXRAsjEkFYyqRkh9SUTYEqV",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -152,7 +152,7 @@ func TestAccountObjectsErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "foo",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 	}

--- a/internal/rpc/account_offers_test.go
+++ b/internal/rpc/account_offers_test.go
@@ -130,7 +130,7 @@ func TestAccountOffersErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "n94JNrQYkDrpt62bbSR7nVEhdyAvcJXRAsjEkFYyqRkh9SUTYEqV",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -138,7 +138,7 @@ func TestAccountOffersErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "foo",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{

--- a/internal/rpc/account_tx_test.go
+++ b/internal/rpc/account_tx_test.go
@@ -79,7 +79,7 @@ func TestAccountTxErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "0xDEADBEEF",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  35, // actMalformed (address validation)
 		},
 		{
@@ -87,7 +87,7 @@ func TestAccountTxErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"account": "rN7n3473SaZBCG4dFL83w7a1RXtXtbk2D9",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  35, // actMalformed (address validation)
 		},
 		{
@@ -1019,8 +1019,9 @@ func TestAccountTxTransactionHistoryNotAvailable(t *testing.T) {
 
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
-	assert.Equal(t, 73, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Transaction history not available")
+	assert.Equal(t, types.RpcNOT_ENABLED, rpcErr.Code)
+	assert.Equal(t, "notEnabled", rpcErr.ErrorString)
+	assert.Equal(t, "Not enabled in configuration.", rpcErr.Message)
 }
 
 // Method Metadata Tests
@@ -1256,8 +1257,9 @@ func TestAccountTxServiceErrors(t *testing.T) {
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
-		assert.Equal(t, 73, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Transaction history not available")
+		assert.Equal(t, types.RpcNOT_ENABLED, rpcErr.Code)
+		assert.Equal(t, "notEnabled", rpcErr.ErrorString)
+		assert.Equal(t, "Not enabled in configuration.", rpcErr.Message)
 	})
 }
 

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -233,7 +233,7 @@ func TestDepositAuthorizedErrorValidation(t *testing.T) {
 			// No setupMock needed — handler-level ValidateAccount catches this
 			// before the service is called.
 			expectError:   true,
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -245,7 +245,7 @@ func TestDepositAuthorizedErrorValidation(t *testing.T) {
 			// No setupMock needed — handler-level ValidateAccount catches this
 			// before the service is called.
 			expectError:   true,
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -590,7 +590,7 @@ func TestDepositAuthorizedAddressValidation(t *testing.T) {
 				"source_account":      "rG1QQv2nh2gr7RCZ!P8YYcBUKCCN633jCn",
 				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -599,7 +599,7 @@ func TestDepositAuthorizedAddressValidation(t *testing.T) {
 				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 				"destination_account": "rP6P9ypfAmc!pw8SZHNwM4nvZHFXDraQas",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -608,7 +608,7 @@ func TestDepositAuthorizedAddressValidation(t *testing.T) {
 				"source_account":      "rHb9",
 				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -617,7 +617,7 @@ func TestDepositAuthorizedAddressValidation(t *testing.T) {
 				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 				"destination_account": "r",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -626,7 +626,7 @@ func TestDepositAuthorizedAddressValidation(t *testing.T) {
 				"source_account":      "not_a_valid_address",
 				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 		{
@@ -635,7 +635,7 @@ func TestDepositAuthorizedAddressValidation(t *testing.T) {
 				"source_account":      "INVALID",
 				"destination_account": "ALSO_INVALID",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 	}

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -302,6 +302,8 @@ func TestGatewayBalancesInvalidHotwallet(t *testing.T) {
 
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_HOTWALLET, rpcErr.Code)
+		assert.Equal(t, "invalidHotWallet", rpcErr.ErrorString)
 		assert.Contains(t, rpcErr.Message, "Invalid hotwallet")
 	})
 

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -235,7 +235,7 @@ func TestGatewayBalancesErrorValidation(t *testing.T) {
 				// n-prefix address is not a valid account address -- caught by ValidateAccount
 				"account": "n9MJkEKHDhy5eTLuHUQeAAjo382frHNbFK4C8hcwN4nwM2SrLdBj",
 			},
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 			expectedCode:  types.RpcACT_MALFORMED,
 		},
 	}

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -330,6 +330,63 @@ func TestGatewayBalancesInvalidHotwallet(t *testing.T) {
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
 	})
+
+	// rippled rejects an empty-string hotwallet (parseBase58 failure) but
+	// treats JSON null as a valid empty hotwallet set.
+	t.Run("Empty-string hotwallet - api version 1 returns invalidHotwallet error", func(t *testing.T) {
+		mock.gatewayBalancesErr = nil
+
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+		}
+
+		paramsJSON := json.RawMessage(`{"account": "` + aliceAccount + `", "hotwallet": ""}`)
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_HOTWALLET, rpcErr.Code)
+		assert.Equal(t, "invalidHotWallet", rpcErr.ErrorString)
+		assert.Equal(t, "Invalid hotwallet.", rpcErr.Message)
+	})
+
+	t.Run("Empty-string hotwallet - api version 2 returns invalidParams error", func(t *testing.T) {
+		mock.gatewayBalancesErr = nil
+
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion2,
+			Services:   services,
+		}
+
+		paramsJSON := json.RawMessage(`{"account": "` + aliceAccount + `", "hotwallet": ""}`)
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	})
+
+	t.Run("Null hotwallet is a valid empty hotwallet set", func(t *testing.T) {
+		mock.gatewayBalancesErr = nil
+
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+		}
+
+		paramsJSON := json.RawMessage(`{"account": "` + aliceAccount + `", "hotwallet": null}`)
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+
+		require.Nil(t, rpcErr)
+		assert.NotNil(t, result)
+	})
 }
 
 // TestGatewayBalancesBasic tests basic gateway balance functionality

--- a/internal/rpc/handlers/account_currencies.go
+++ b/internal/rpc/handlers/account_currencies.go
@@ -45,10 +45,7 @@ func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawM
 			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		if len(err.Error()) > 24 && err.Error()[:24] == "invalid account address:" {
-			return nil, &types.RpcError{
-				Code:    types.RpcACT_NOT_FOUND,
-				Message: "Account malformed.",
-			}
+			return nil, types.RpcErrorActMalformed("Account malformed.")
 		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account currencies: %v", err))
 	}

--- a/internal/rpc/handlers/account_nfts.go
+++ b/internal/rpc/handlers/account_nfts.go
@@ -46,10 +46,7 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		if len(err.Error()) > 24 && err.Error()[:24] == "invalid account address:" {
-			return nil, &types.RpcError{
-				Code:    types.RpcACT_NOT_FOUND,
-				Message: "Account malformed.",
-			}
+			return nil, types.RpcErrorActMalformed("Account malformed.")
 		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account NFTs: %v", err))
 	}

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -109,7 +109,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	)
 	if err != nil {
 		if err.Error() == "transaction history not available (no database configured)" {
-			return nil, types.RpcErrorInternal("Transaction history not available. Database not configured.")
+			return nil, types.RpcErrorNotEnabled("")
 		}
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
 			return nil, types.RpcErrorActNotFound("Account not found.")

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -109,10 +109,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	)
 	if err != nil {
 		if err.Error() == "transaction history not available (no database configured)" {
-			return nil, &types.RpcError{
-				Code:    73,
-				Message: "Transaction history not available. Database not configured.",
-			}
+			return nil, types.RpcErrorInternal("Transaction history not available. Database not configured.")
 		}
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
 			return nil, types.RpcErrorActNotFound("Account not found.")

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -80,7 +80,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 
 		ammIDHex, ok := decoded["AMMID"].(string)
 		if !ok || ammIDHex == "" {
-			return nil, types.RpcErrorActNotFound("Account is not an AMM account")
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 
 		ammIDBytes, hexErr := hex.DecodeString(ammIDHex)

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -65,12 +65,11 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		copy(accountIDArray[:], accountID)
 		accountKey := keylet.Account(accountIDArray)
 
+		// rippled AMMInfo returns actMalformed (not actNotFound) when the
+		// amm_account does not exist in the ledger.
 		accountEntry, lookupErr := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, accountKey.Key, ledgerIndex)
 		if lookupErr != nil {
-			return nil, &types.RpcError{
-				Code:    19,
-				Message: "AMM account not found",
-			}
+			return nil, types.RpcErrorActMalformed("Account malformed.")
 		}
 
 		// Decode the account to get AMMID
@@ -81,10 +80,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 
 		ammIDHex, ok := decoded["AMMID"].(string)
 		if !ok || ammIDHex == "" {
-			return nil, &types.RpcError{
-				Code:    19,
-				Message: "Account is not an AMM account",
-			}
+			return nil, types.RpcErrorActNotFound("Account is not an AMM account")
 		}
 
 		ammIDBytes, hexErr := hex.DecodeString(ammIDHex)

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -55,18 +55,18 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	var err error
 
 	if hasAMMAccount {
-		// Look up AMM by account
+		// rippled AMMInfo returns actMalformed (not invalidParams or
+		// actNotFound) both when the amm_account does not parse and when it
+		// does not exist in the ledger.
 		_, accountID, decErr := addresscodec.DecodeClassicAddressToAccountID(request.AMMAccount)
 		if decErr != nil {
-			return nil, types.RpcErrorInvalidParams("Invalid amm_account: " + decErr.Error())
+			return nil, types.RpcErrorActMalformed("Account malformed.")
 		}
 
 		var accountIDArray [20]byte
 		copy(accountIDArray[:], accountID)
 		accountKey := keylet.Account(accountIDArray)
 
-		// rippled AMMInfo returns actMalformed (not actNotFound) when the
-		// amm_account does not exist in the ledger.
 		accountEntry, lookupErr := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, accountKey.Key, ledgerIndex)
 		if lookupErr != nil {
 			return nil, types.RpcErrorActMalformed("Account malformed.")

--- a/internal/rpc/handlers/deposit_authorized.go
+++ b/internal/rpc/handlers/deposit_authorized.go
@@ -83,15 +83,9 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	if err != nil {
 		switch {
 		case errors.Is(err, svcerr.ErrSrcAccountNotFound):
-			return nil, &types.RpcError{
-				Code:    types.RpcSRC_ACT_NOT_FOUND,
-				Message: "Source account not found.",
-			}
+			return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 		case errors.Is(err, svcerr.ErrDstAccountNotFound):
-			return nil, &types.RpcError{
-				Code:    types.RpcDST_ACT_NOT_FOUND,
-				Message: "Destination account not found.",
-			}
+			return nil, types.RpcErrorDstActNotFound("Destination account not found.")
 		case errors.Is(err, svcerr.ErrBadCredentials):
 			// Detail follows the sentinel as "bad credentials: <detail>";
 			// strip the prefix so the wire message matches rippled's

--- a/internal/rpc/handlers/gateway_balances.go
+++ b/internal/rpc/handlers/gateway_balances.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -38,8 +39,16 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 		// Try to parse as a single string first
 		var singleWallet string
 		if err := json.Unmarshal(request.HotWallet, &singleWallet); err == nil {
+			// JSON null also unmarshals to ""; rippled treats null as a valid
+			// empty hotwallet set but an empty-string hotwallet as an
+			// unparseable address.
 			if singleWallet != "" {
 				hotWallets = []string{singleWallet}
+			} else if string(bytes.TrimSpace(request.HotWallet)) != "null" {
+				if ctx.ApiVersion < 2 {
+					return nil, types.RpcErrorInvalidHotWallet()
+				}
+				return nil, types.RpcErrorInvalidParams("Invalid field 'hotwallet'.")
 			}
 		} else {
 			// Try to parse as an array of strings

--- a/internal/rpc/handlers/gateway_balances.go
+++ b/internal/rpc/handlers/gateway_balances.go
@@ -49,10 +49,7 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 			} else {
 				// Invalid hotwallet format
 				if ctx.ApiVersion < 2 {
-					return nil, &types.RpcError{
-						Code:    types.RpcINVALID_PARAMS,
-						Message: "Invalid hotwallet.",
-					}
+					return nil, types.RpcErrorInvalidHotWallet()
 				}
 				return nil, types.RpcErrorInvalidParams("Invalid field 'hotwallet'.")
 			}
@@ -73,17 +70,11 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		if len(err.Error()) > 24 && err.Error()[:24] == "invalid account address:" {
-			return nil, &types.RpcError{
-				Code:    types.RpcACT_NOT_FOUND,
-				Message: "Account malformed.",
-			}
+			return nil, types.RpcErrorActMalformed("Account malformed.")
 		}
 		if len(err.Error()) > 20 && err.Error()[:20] == "invalid hotwallet ad" {
 			if ctx.ApiVersion < 2 {
-				return nil, &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: "Invalid hotwallet.",
-				}
+				return nil, types.RpcErrorInvalidHotWallet()
 			}
 			return nil, types.RpcErrorInvalidParams("Invalid field 'hotwallet'.")
 		}

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -113,7 +113,7 @@ func ValidateAccount(account string) *types.RpcError {
 		return types.RpcErrorInvalidParams("Missing required parameter: account")
 	}
 	if !types.IsValidXRPLAddress(account) {
-		return types.RpcErrorActMalformed("Malformed account.")
+		return types.RpcErrorActMalformed("Account malformed.")
 	}
 	return nil
 }

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -35,20 +35,18 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		}
 	}
 
-	// Validate required fields
+	// Validate the signer's account before tx_json, matching rippled's
+	// transactionSignFor order. An unparseable account is srcActMalformed
+	// ("Invalid field 'account'."), not the generic actMalformed.
 	if request.Account == "" {
 		return nil, types.RpcErrorMissingField("account")
+	}
+	if !addresscodec.IsValidClassicAddress(request.Account) {
+		return nil, types.RpcErrorSrcActMalformed("Invalid field 'account'.")
 	}
 
 	if len(request.TxJson) == 0 {
 		return nil, types.RpcErrorMissingField("tx_json")
-	}
-
-	// Validate the signer's account address. rippled's transactionSignFor
-	// returns srcActMalformed ("Invalid field 'account'.") here, not the
-	// generic actMalformed.
-	if !addresscodec.IsValidClassicAddress(request.Account) {
-		return nil, types.RpcErrorSrcActMalformed("Invalid field 'account'.")
 	}
 
 	// Parse credentials and derive keypair using the shared helper

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -44,14 +44,11 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		return nil, types.RpcErrorMissingField("tx_json")
 	}
 
-	// Validate account address
+	// Validate the signer's account address. rippled's transactionSignFor
+	// returns srcActMalformed ("Invalid field 'account'.") here, not the
+	// generic actMalformed.
 	if !addresscodec.IsValidClassicAddress(request.Account) {
-		return nil, &types.RpcError{
-			Code:        types.RpcACT_MALFORMED,
-			ErrorString: "actMalformed",
-			Type:        "actMalformed",
-			Message:     "Account malformed.",
-		}
+		return nil, types.RpcErrorSrcActMalformed("Invalid field 'account'.")
 	}
 
 	// Parse credentials and derive keypair using the shared helper

--- a/internal/rpc/handlers/tx_history.go
+++ b/internal/rpc/handlers/tx_history.go
@@ -29,10 +29,7 @@ func (m *TxHistoryMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	result, err := ctx.Services.Ledger.GetTransactionHistory(ctx.Context, request.Start)
 	if err != nil {
 		if err.Error() == "transaction history not available (no database configured)" {
-			return nil, &types.RpcError{
-				Code:    73,
-				Message: "Transaction history not available. Database not configured.",
-			}
+			return nil, types.RpcErrorInternal("Transaction history not available. Database not configured.")
 		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get transaction history: %v", err))
 	}

--- a/internal/rpc/handlers/tx_history.go
+++ b/internal/rpc/handlers/tx_history.go
@@ -29,7 +29,7 @@ func (m *TxHistoryMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	result, err := ctx.Services.Ledger.GetTransactionHistory(ctx.Context, request.Start)
 	if err != nil {
 		if err.Error() == "transaction history not available (no database configured)" {
-			return nil, types.RpcErrorInternal("Transaction history not available. Database not configured.")
+			return nil, types.RpcErrorNotEnabled("")
 		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get transaction history: %v", err))
 	}

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -1335,6 +1335,26 @@ func TestAMMInfoMethod(t *testing.T) {
 		assert.Equal(t, "Account malformed.", rpcErr.Message)
 	})
 
+	t.Run("Returns actMalformed when amm_account is unparseable", func(t *testing.T) {
+		// rippled's AMMInfo also returns actMalformed (not invalidParams)
+		// when the amm_account fails to parse as an account.
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+		}
+
+		params := json.RawMessage(`{"amm_account": "not-a-valid-address"}`)
+		result, rpcErr := method.Handle(ctx, params)
+
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcACT_MALFORMED, rpcErr.Code)
+		assert.Equal(t, "actMalformed", rpcErr.ErrorString)
+		assert.Equal(t, "Account malformed.", rpcErr.Message)
+	})
+
 	t.Run("Returns AMM not found when looking up by assets", func(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -1314,8 +1314,10 @@ func TestAMMInfoMethod(t *testing.T) {
 
 	method := &handlers.AMMInfoMethod{}
 
-	t.Run("Returns AMM not found when AMM does not exist", func(t *testing.T) {
-		// The mock returns "not implemented" for GetLedgerEntry, which becomes AMM not found
+	t.Run("Returns actMalformed when amm_account does not exist", func(t *testing.T) {
+		// The mock returns "not implemented" for GetLedgerEntry; rippled's
+		// AMMInfo returns actMalformed when the amm_account is absent from
+		// the ledger.
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
@@ -1328,8 +1330,9 @@ func TestAMMInfoMethod(t *testing.T) {
 
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
-		// Returns 19 (actNotFound) when account lookup fails
-		assert.True(t, rpcErr.Code == 19 || rpcErr.Message == "AMM account not found")
+		assert.Equal(t, types.RpcACT_MALFORMED, rpcErr.Code)
+		assert.Equal(t, "actMalformed", rpcErr.ErrorString)
+		assert.Equal(t, "Account malformed.", rpcErr.Message)
 	})
 
 	t.Run("Returns AMM not found when looking up by assets", func(t *testing.T) {
@@ -1348,8 +1351,8 @@ func TestAMMInfoMethod(t *testing.T) {
 
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
-		// Returns 19 (actNotFound/entryNotFound) when AMM lookup fails
-		assert.True(t, rpcErr.Code == 19 || rpcErr.Message == "AMM not found")
+		assert.Equal(t, types.RpcACT_NOT_FOUND, rpcErr.Code)
+		assert.Equal(t, "actNotFound", rpcErr.ErrorString)
 	})
 
 	t.Run("Invalid parameters - neither assets nor amm_account", func(t *testing.T) {

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -248,7 +248,7 @@ func TestNoRippleCheckErrorValidation(t *testing.T) {
 			},
 			// ValidateAccount catches this before the service call
 			expectError:   true,
-			expectedError: "Malformed account.",
+			expectedError: "Account malformed.",
 		},
 	}
 

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -900,8 +900,11 @@ func TestSignFor_InvalidAccountAddress(t *testing.T) {
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Equal(t, types.RpcACT_MALFORMED, err.Code)
-	assert.Equal(t, "actMalformed", err.ErrorString)
+	// rippled's transactionSignFor emits srcActMalformed with
+	// "Invalid field 'account'." for an unparseable signer account.
+	assert.Equal(t, types.RpcSRC_ACT_MALFORMED, err.Code)
+	assert.Equal(t, "srcActMalformed", err.ErrorString)
+	assert.Equal(t, "Invalid field 'account'.", err.Message)
 }
 
 func TestSignFor_InvalidKeyType(t *testing.T) {

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -907,6 +907,27 @@ func TestSignFor_InvalidAccountAddress(t *testing.T) {
 	assert.Equal(t, "Invalid field 'account'.", err.Message)
 }
 
+// rippled's transactionSignFor validates the signer account before checking
+// tx_json presence, so a malformed account with no tx_json is srcActMalformed,
+// not a missing-field error.
+func TestSignFor_InvalidAccountPrecedesMissingTxJson(t *testing.T) {
+	handler := &handlers.SignForMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"account": "invalid_address",
+		"secret": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcSRC_ACT_MALFORMED, err.Code)
+	assert.Equal(t, "srcActMalformed", err.ErrorString)
+	assert.Equal(t, "Invalid field 'account'.", err.Message)
+}
+
 func TestSignFor_InvalidKeyType(t *testing.T) {
 	handler := &handlers.SignForMethod{}
 	ctx := &types.RpcContext{

--- a/internal/rpc/tx_history_test.go
+++ b/internal/rpc/tx_history_test.go
@@ -237,7 +237,9 @@ func TestTxHistoryDatabaseNotConfigured(t *testing.T) {
 
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
-	assert.Equal(t, 73, rpcErr.Code, "Should return error code 73 for no database")
+	assert.Equal(t, types.RpcNOT_ENABLED, rpcErr.Code, "Should return notEnabled (12) for no database")
+	assert.Equal(t, "notEnabled", rpcErr.ErrorString)
+	assert.Equal(t, "Not enabled in configuration.", rpcErr.Message)
 }
 
 // TestTxHistoryServiceUnavailable tests behavior when the ledger service is not available.

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -221,6 +221,12 @@ func RpcErrorTxnNotFound(message string) *RpcError {
 	return NewRpcError(RpcTXN_NOT_FOUND, "txnNotFound", "txnNotFound", message)
 }
 
+// RpcErrorInvalidHotWallet matches rippled rpcINVALID_HOTWALLET (code 30,
+// token "invalidHotWallet", message "Invalid hotwallet.").
+func RpcErrorInvalidHotWallet() *RpcError {
+	return NewRpcError(RpcINVALID_HOTWALLET, "invalidHotWallet", "invalidHotWallet", "Invalid hotwallet.")
+}
+
 func RpcErrorInternal(message string) *RpcError {
 	return NewRpcError(RpcINTERNAL, "internal", "internal", message)
 }

--- a/internal/rpc/types/errors_test.go
+++ b/internal/rpc/types/errors_test.go
@@ -147,6 +147,7 @@ func TestErrorConstructorsTokenCodePairs(t *testing.T) {
 		{RpcErrorActNotFound("x"), "actNotFound", 19},
 		{RpcErrorActMalformed("x"), "actMalformed", 35},
 		{RpcErrorTxnNotFound("x"), "txnNotFound", 29},
+		{RpcErrorInvalidHotWallet(), "invalidHotWallet", 30},
 		{RpcErrorInternal("x"), "internal", 73},
 		{RpcErrorNoPermission("m"), "noPermission", 6},
 		{RpcErrorForbidden("m"), "forbidden", 3},


### PR DESCRIPTION
## Summary

Several handlers built the error as an inline `&types.RpcError{Code: ..., Message: ...}` with `ErrorString` left empty, so the wire response carried `"error": ""` instead of the rippled token. All such sites are converted to the existing constructors (one new constructor added for `invalidHotWallet`).

Converted sites (old → new wire token):

- `handlers/account_currencies.go` — service-level address rejection: code 19/empty token → `actMalformed` (35, "Account malformed."), matching rippled `AccountCurrenciesHandler.cpp` (`rpcACT_MALFORMED`). Note: the old code also carried the wrong numeric code (`rpcACT_NOT_FOUND`).
- `handlers/account_nfts.go` — same fix; rippled `doAccountNFTs` (AccountObjects.cpp:62) returns `rpcACT_MALFORMED`.
- `handlers/gateway_balances.go` — same fix for the account path (rippled GatewayBalances.cpp:75). The two `api_version < 2` invalid-hotwallet sites previously emitted code 31/empty token; rippled injects `rpcINVALID_HOTWALLET` there, so they now use a new `types.RpcErrorInvalidHotWallet()` helper (code 30, token `invalidHotWallet`, message "Invalid hotwallet." — identical message to before). The `api_version >= 2` branch keeps `invalidParams`.
- `handlers/sign_for.go` — **rippled mismatch found**: the site emitted `actMalformed`/"Account malformed.", but rippled's `transactionSignFor` (TransactionSign.cpp:1135-1138) returns `rpcSRC_ACT_MALFORMED` with `invalid_field_message("account")`. Now `types.RpcErrorSrcActMalformed("Invalid field 'account'.")` → token `srcActMalformed`.
- `handlers/amm_info.go` — **rippled mismatch found** for the first site: rippled AMMInfo returns `rpcACT_MALFORMED` (not `actNotFound`) when the `amm_account` is absent from the ledger, so the "AMM account not found" site (code 19/empty token) is now `types.RpcErrorActMalformed("Account malformed.")` (35, `actMalformed`). The AMMID-missing site correctly maps to `rpcACT_NOT_FOUND` per rippled and is now `types.RpcErrorActNotFound("Account is not an AMM account")` — the AMM-specific message is kept (rippled would emit its default "Account not found.").
- `handlers/deposit_authorized.go` — code-only 67/50 errors → `srcActNotFound` / `dstActNotFound` helpers (messages already matched rippled's defaults).
- `handlers/account_tx.go`, `handlers/tx_history.go` — go-xrpl-specific no-database errors (code 73, empty token) → `types.RpcErrorInternal(...)`, token `internal`.

Remaining inline `types.RpcError{...}` constructions in handlers (credentials.go, wallet_propose.go, channel_authorize.go, channel_verify.go, validation_create.go, book_offers.go) all set `ErrorString` already and were left as-is.

## Test plan

- New table case in `account_currencies_test.go` asserting `ErrorString == "actMalformed"` for the converted service-level malformed site.
- `missing_methods_test.go` AMMInfo tests now pin the exact code + token for both amm_info paths (`actMalformed` for missing amm_account, `actNotFound` for the asset-pair lookup).
- `sign_test.go` `TestSignFor_InvalidAccountAddress` updated to the rippled-aligned `srcActMalformed` / "Invalid field 'account'.".
- `gateway_balances_test.go` api_version 1 test now asserts code 30 + token `invalidHotWallet`.
- `types/errors_test.go` pins the new `RpcErrorInvalidHotWallet` token/code pair.
- Verified: `gofmt -l .` clean, `go vet ./internal/rpc/...`, `go build ./...`, `go test ./internal/rpc/...`, `go test ./internal/testing/rpcenv/... ./internal/testing/amm/...` all pass.

Fixes #823

## Review follow-up

- `account_tx` / `tx_history` no-transaction-database errors now return `notEnabled` (rpcNOT_ENABLED, code 12, "Not enabled in configuration.") instead of `internal`, matching rippled's `!useTxTables()` handling (AccountTx.cpp:407, TxHistory.cpp:42).
- `ValidateAccount` (handlers/helpers.go) now emits rippled's actMalformed default message "Account malformed." instead of "Malformed account." (ErrorCodes.cpp:52); all test expectations across the rpc suite updated to the rippled wording.
- `amm_info` non-AMM-account error now uses rippled's actNotFound default message "Account not found." instead of the custom "Account is not an AMM account" (AMMInfo.cpp:138).
