### PR TITLE
fix(tx): match rippled credential expiry semantics in AccountDelete and PayChanClaim (#824)

### DIFF
--- a/internal/testing/accountdelete/accountdelete_test.go
+++ b/internal/testing/accountdelete/accountdelete_test.go
@@ -344,7 +344,6 @@ func TestAccountDelete_RegularKey(t *testing.T) {
 	jtx.RequireAccountNotExists(t, env, becky)
 }
 
-// rippleTime returns the current Ripple epoch time from the test environment.
 func rippleTime(env *jtx.TestEnv) uint32 {
 	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
 }

--- a/internal/testing/accountdelete/accountdelete_test.go
+++ b/internal/testing/accountdelete/accountdelete_test.go
@@ -10,11 +10,16 @@ import (
 	"time"
 
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/credential"
+	"github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
 	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
 	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	acctx "github.com/LeJamon/go-xrpl/internal/tx/account"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/stretchr/testify/require"
 )
 
 const acctDelFee = uint64(50_000_000) // 50 XRP — matches rippled's owner reserve
@@ -337,6 +342,112 @@ func TestAccountDelete_RegularKey(t *testing.T) {
 	result := env.SubmitSignedWith(d, rk)
 	jtx.RequireTxSuccess(t, result)
 	jtx.RequireAccountNotExists(t, env, becky)
+}
+
+// rippleTime returns the current Ripple epoch time from the test environment.
+func rippleTime(env *jtx.TestEnv) uint32 {
+	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
+}
+
+// closeToParentCloseTime closes one ledger so that the new open ledger's
+// parent close time lands exactly on target (Ripple epoch seconds).
+func closeToParentCloseTime(t *testing.T, env *jtx.TestEnv, target uint32) {
+	t.Helper()
+	resolution := time.Duration(env.Ledger().CloseTimeResolution()) * time.Second
+	targetTime := time.Unix(int64(target)+protocol.RippleEpochUnix, 0).UTC()
+	env.SetTime(targetTime.Add(-resolution))
+	env.Close()
+	got := uint32(env.Ledger().ParentCloseTime().Unix() - protocol.RippleEpochUnix)
+	require.Equal(t, target, got, "parent close time must land exactly on target")
+}
+
+// TestAccountDelete_CredentialExpiry verifies rippled's credential expiry
+// semantics for AccountDelete: credentials::valid() in preclaim never checks
+// expiry; only removeExpired inside verifyDepositPreauth does, with a strict
+// closeTime > expiration comparison. Past the expiration the delete fails with
+// tecEXPIRED and the expired credential SLE is deleted; at the boundary
+// ParentCloseTime == Expiration the credential is still valid and the delete
+// succeeds.
+// Reference: rippled CredentialHelpers.cpp checkExpired()/removeExpired(),
+// verifyDepositPreauth(); AccountDelete_test.cpp "Expired credentials".
+func TestAccountDelete_CredentialExpiry(t *testing.T) {
+	credType := "abcde"
+
+	// Past expiration: tecEXPIRED, the account survives, and the expired
+	// credential is deleted even though the transaction failed.
+	t.Run("ExpiredCredential", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		carol := jtx.NewAccount("carol")
+		john := jtx.NewAccount("john")
+		env.Fund(alice, carol, john)
+		env.Close()
+
+		expiration := rippleTime(env) + 20
+		jtx.RequireTxSuccess(t, env.Submit(
+			credential.CredentialCreate(carol, john, credType).Expiration(expiration).Build()))
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAccept(john, carol, credType).Build()))
+		env.Close()
+
+		credIdx := depositpreauth.CredentialIndex(john, carol, credType)
+		credK := keylet.Credential(john.ID, carol.ID, []byte(credType))
+
+		// Advancing 256 ledgers also moves time far past the expiration.
+		env.IncLedgerSeqForAccDel(john)
+
+		d := newAccountDelete(john, alice)
+		d.CredentialIDs = []string{credIdx}
+		jtx.RequireTxFail(t, env.Submit(d), "tecEXPIRED")
+		env.Close()
+
+		jtx.RequireAccountExists(t, env, john)
+		require.False(t, env.LedgerEntryExists(credK),
+			"expired credential must be deleted on the tecEXPIRED path")
+	})
+
+	// Boundary: a credential expiring exactly at the parent close time is
+	// still valid (removeExpired uses strict ">"), so the delete succeeds.
+	t.Run("ExpirationAtParentCloseTime", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		carol := jtx.NewAccount("carol")
+		john := jtx.NewAccount("john")
+		env.Fund(alice, carol, john)
+		env.Close()
+
+		// Far enough out to stay in the future across the 256-ledger advance.
+		expiration := rippleTime(env) + 20000
+		jtx.RequireTxSuccess(t, env.Submit(
+			credential.CredentialCreate(carol, john, credType).Expiration(expiration).Build()))
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAccept(john, carol, credType).Build()))
+		env.Close()
+
+		credIdx := depositpreauth.CredentialIndex(john, carol, credType)
+		credK := keylet.Credential(john.ID, carol.ID, []byte(credType))
+
+		// Alice requires deposit authorization, satisfied via the credential,
+		// so the credential is load-bearing for the delete.
+		env.EnableDepositAuth(alice)
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(depositpreauth.AuthCredentials(alice, []depositpreauth.AuthorizeCredentials{
+			{Issuer: carol, CredType: credType},
+		}).Build()))
+		env.Close()
+
+		env.IncLedgerSeqForAccDel(john)
+		closeToParentCloseTime(t, env, expiration)
+
+		d := newAccountDelete(john, alice)
+		d.CredentialIDs = []string{credIdx}
+		jtx.RequireTxSuccess(t, env.Submit(d))
+		env.Close()
+
+		jtx.RequireAccountNotExists(t, env, john)
+		require.False(t, env.LedgerEntryExists(credK),
+			"credential must be cascade-deleted with the account")
+	})
 }
 
 // Suppress unused import warnings

--- a/internal/testing/paychan/paychan_test.go
+++ b/internal/testing/paychan/paychan_test.go
@@ -2051,7 +2051,6 @@ func TestPayChan_CredentialExpirySemantics(t *testing.T) {
 	jtx.RequireTxSuccess(t, env.Submit(ChannelCreate(alice, bob, xrp(1000), 100, pk).Build()))
 	env.Close()
 
-	// Carol issues a credential to alice that expires at a known close time.
 	expiration := ToRippleTime(env.Now()) + 1000
 	jtx.RequireTxSuccess(t, env.Submit(
 		credential.CredentialCreate(carol, alice, credType).Expiration(expiration).Build()))

--- a/internal/testing/paychan/paychan_test.go
+++ b/internal/testing/paychan/paychan_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/credential"
 	"github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
@@ -2007,4 +2008,138 @@ func submitExpect(t *testing.T, env *jtx.TestEnv, txn tx.Transaction, expectedCo
 	result := env.Submit(txn)
 	require.Equal(t, expectedCode, result.Code,
 		fmt.Sprintf("expected %s but got %s", expectedCode, result.Code))
+}
+
+// closeToParentCloseTime closes one ledger so that the new open ledger's
+// parent close time lands exactly on target (Ripple epoch seconds).
+func closeToParentCloseTime(t *testing.T, env *jtx.TestEnv, target uint32) {
+	t.Helper()
+	resolution := time.Duration(env.Ledger().CloseTimeResolution()) * time.Second
+	targetTime := time.Unix(int64(target)+protocol.RippleEpochUnix, 0).UTC()
+	env.SetTime(targetTime.Add(-resolution))
+	env.Close()
+	got := uint32(env.Ledger().ParentCloseTime().Unix() - protocol.RippleEpochUnix)
+	require.Equal(t, target, got, "parent close time must land exactly on target")
+}
+
+// TestPayChan_CredentialExpirySemantics verifies rippled's credential expiry
+// semantics for PayChanClaim: expiry is only enforced by removeExpired inside
+// verifyDepositPreauth, which uses a strict closeTime > expiration comparison.
+// At the boundary ParentCloseTime == Expiration the credential is still valid;
+// past it the claim fails with tecEXPIRED and the expired credential SLE is
+// deleted even though the transaction fails.
+// Reference: rippled CredentialHelpers.cpp checkExpired()/removeExpired(),
+// verifyDepositPreauth(); PayChan_test.cpp testDepositAuthCreds.
+func TestPayChan_CredentialExpirySemantics(t *testing.T) {
+	credType := "abcde"
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+
+	env := jtx.NewTestEnv(t)
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.FundAmount(carol, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	pk := alice.PublicKeyHex()
+	seq := env.Seq(alice)
+	chanK := chanKeylet(alice, bob, seq)
+	chanIDHex := hex.EncodeToString(chanK.Key[:])
+
+	jtx.RequireTxSuccess(t, env.Submit(ChannelCreate(alice, bob, xrp(1000), 100, pk).Build()))
+	env.Close()
+
+	// Carol issues a credential to alice that expires at a known close time.
+	expiration := ToRippleTime(env.Now()) + 1000
+	jtx.RequireTxSuccess(t, env.Submit(
+		credential.CredentialCreate(carol, alice, credType).Expiration(expiration).Build()))
+	env.Close()
+	jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAccept(alice, carol, credType).Build()))
+	env.Close()
+
+	credIdx := depositpreauth.CredentialIndex(alice, carol, credType)
+	credK := keylet.Credential(alice.ID, carol.ID, []byte(credType))
+
+	// Bob requires deposit authorization, satisfied via the credential.
+	env.EnableDepositAuth(bob)
+	env.Close()
+	jtx.RequireTxSuccess(t, env.Submit(depositpreauth.AuthCredentials(bob, []depositpreauth.AuthorizeCredentials{
+		{Issuer: carol, CredType: credType},
+	}).Build()))
+	env.Close()
+
+	// At ParentCloseTime == Expiration the credential is still valid:
+	// removeExpired uses strict ">", so the claim succeeds.
+	closeToParentCloseTime(t, env, expiration)
+	delta := xrp(500)
+	jtx.RequireTxSuccess(t, env.Submit(ChannelClaim(alice, chanIDHex).
+		Balance(delta).Amount(delta).
+		CredentialIDs([]string{credIdx}).Build()))
+	require.True(t, env.LedgerEntryExists(credK),
+		"credential expiring exactly at parent close time must not be deleted")
+	require.Equal(t, uint64(delta), chanBalance(env, chanK))
+	env.Close()
+
+	// Past the expiration the claim fails with tecEXPIRED, and the expired
+	// credential SLE is deleted even though the transaction failed.
+	submitExpect(t, env, ChannelClaim(alice, chanIDHex).
+		Balance(2*delta).Amount(2*delta).
+		CredentialIDs([]string{credIdx}).Build(), "tecEXPIRED")
+	env.Close()
+	require.False(t, env.LedgerEntryExists(credK),
+		"expired credential must be deleted on the tecEXPIRED path")
+	require.Equal(t, uint64(delta), chanBalance(env, chanK),
+		"channel balance must be unchanged after the failed claim")
+}
+
+// TestPayChan_ExpiredCredentialWithoutBalanceClaim verifies that a PayChanClaim
+// that does not claim a Balance never checks credential expiry: rippled's
+// verifyDepositPreauth (and thus removeExpired) only runs on the Balance path,
+// and credentials::valid() in preclaim does not check expiry. A tfRenew claim
+// carrying an expired credential therefore succeeds and the credential remains.
+// Reference: rippled PayChan.cpp PayChanClaim::preclaim()/doApply().
+func TestPayChan_ExpiredCredentialWithoutBalanceClaim(t *testing.T) {
+	credType := "abcde"
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+
+	env := jtx.NewTestEnv(t)
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.FundAmount(carol, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	pk := alice.PublicKeyHex()
+	seq := env.Seq(alice)
+	chanK := chanKeylet(alice, bob, seq)
+	chanIDHex := hex.EncodeToString(chanK.Key[:])
+
+	jtx.RequireTxSuccess(t, env.Submit(ChannelCreate(alice, bob, xrp(1000), 100, pk).Build()))
+	env.Close()
+
+	expiration := ToRippleTime(env.Now()) + 20
+	jtx.RequireTxSuccess(t, env.Submit(
+		credential.CredentialCreate(carol, alice, credType).Expiration(expiration).Build()))
+	env.Close()
+	jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAccept(alice, carol, credType).Build()))
+	env.Close()
+
+	credIdx := depositpreauth.CredentialIndex(alice, carol, credType)
+	credK := keylet.Credential(alice.ID, carol.ID, []byte(credType))
+
+	// Advance well past the credential expiration.
+	for range 10 {
+		env.Close()
+	}
+
+	// No Balance claimed: deposit preauth (and credential expiry) is never
+	// checked, so the renew succeeds and the expired credential is untouched.
+	jtx.RequireTxSuccess(t, env.Submit(ChannelClaim(alice, chanIDHex).Renew().
+		CredentialIDs([]string{credIdx}).Build()))
+	require.True(t, env.LedgerEntryExists(credK),
+		"expired credential must not be deleted when no Balance is claimed")
 }

--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -102,7 +102,7 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecDST_TAG_NEEDED
 	}
 	if len(a.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if result := credential.ValidateCredentialIDs(ctx, a.CredentialIDs, true); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, a.CredentialIDs); result != tx.TesSUCCESS {
 			return result
 		}
 	}

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -211,13 +211,10 @@ func CheckCredentialExpired(cred *CredentialEntry, closeTime uint32) bool {
 
 // ValidateCredentialIDs validates a transaction's CredentialIDs: each
 // credential must exist in the ledger, have the transaction sender as its
-// Subject, and be accepted, otherwise tecBAD_CREDENTIALS. With checkExpiry
-// false this matches rippled's credentials::valid(), which never checks
-// expiry (that is deferred to RemoveExpiredCredentials). With checkExpiry
-// true, a credential whose Expiration is at or before the parent close time
-// returns tecEXPIRED — a validate-time check rippled's valid() does not
-// perform, preserved from the pre-refactor account and paychan transactors.
-func ValidateCredentialIDs(ctx *tx.ApplyContext, credentialIDs []string, checkExpiry bool) tx.Result {
+// Subject, and be accepted, otherwise tecBAD_CREDENTIALS. Expiry is never
+// checked here — it is deferred to RemoveExpiredCredentials.
+// Reference: rippled CredentialHelpers.cpp credentials::valid()
+func ValidateCredentialIDs(ctx *tx.ApplyContext, credentialIDs []string) tx.Result {
 	for _, idHex := range credentialIDs {
 		credIDBytes, err := hex.DecodeString(idHex)
 		if err != nil || len(credIDBytes) != 32 {
@@ -242,10 +239,6 @@ func ValidateCredentialIDs(ctx *tx.ApplyContext, credentialIDs []string, checkEx
 
 		if !cred.IsAccepted() {
 			return tx.TecBAD_CREDENTIALS
-		}
-
-		if checkExpiry && cred.Expiration != nil && ctx.Config.ParentCloseTime >= *cred.Expiration {
-			return tx.TecEXPIRED
 		}
 	}
 

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -156,7 +156,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// This must run before doApply's time checks because rippled's preclaim
 	// runs before doApply.
 	if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if result := credential.ValidateCredentialIDs(ctx, e.CredentialIDs, false); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, e.CredentialIDs); result != tx.TesSUCCESS {
 			return result
 		}
 	}

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -207,7 +207,7 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	// Reference: rippled PayChan.cpp PayChanClaim::preclaim() credentials::valid()
 	if len(p.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs, true); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs); result != tx.TesSUCCESS {
 			return result
 		}
 	}
@@ -414,6 +414,13 @@ func (p *PaymentChannelClaim) ApplyOnTec(ctx *tx.ApplyContext) tx.Result {
 // verifyDepositPreauth implements rippled's verifyDepositPreauth() from CredentialHelpers.cpp.
 // Reference: rippled CredentialHelpers.cpp verifyDepositPreauth() lines 357-391
 func verifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src [20]byte, dst [20]byte, destAccount *state.AccountRoot) tx.Result {
+	// Remove expired credentials first, before any deposit auth checks. This
+	// deletes expired credential SLEs (re-applied on the tec path) and fails
+	// the transaction with tecEXPIRED if any credential was expired.
+	if len(credentialIDs) > 0 && credential.RemoveExpiredCredentials(ctx, credentialIDs) {
+		return tx.TecEXPIRED
+	}
+
 	// Only check if destination has lsfDepositAuth set
 	if (destAccount.Flags & state.LsfDepositAuth) == 0 {
 		return tx.TesSUCCESS

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -146,7 +146,7 @@ func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	// Validate credentials (preclaim)
-	if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs, false); result != tx.TesSUCCESS {
+	if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs); result != tx.TesSUCCESS {
 		return result
 	}
 
@@ -298,7 +298,7 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 	}
 
 	// Validate credentials
-	if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs, false); result != tx.TesSUCCESS {
+	if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs); result != tx.TesSUCCESS {
 		return result
 	}
 

--- a/internal/tx/payment/payment_xrp.go
+++ b/internal/tx/payment/payment_xrp.go
@@ -82,7 +82,7 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 		}
 
 		// Validate credentials (preclaim)
-		if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs, false); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs); result != tx.TesSUCCESS {
 			return result
 		}
 


### PR DESCRIPTION
## Summary

AccountDelete and PayChanClaim checked credential expiry at validate time with `ParentCloseTime >= Expiration → tecEXPIRED` (the `checkExpiry=true` mode of `credential.ValidateCredentialIDs`). rippled's `credentials::valid()` never checks expiry — for all four consuming transactors it is enforced solely by `credentials::removeExpired()` (strict `closeTime > expiration`) inside `verifyDepositPreauth`, which also deletes the expired credential SLEs even when the transaction fails.

Observable behaviour changes:

- **Boundary case `ParentCloseTime == Expiration`**: the credential is still valid (strict `>`). AccountDelete and PayChanClaim now **succeed** where they previously returned `tecEXPIRED` (and, for PayChanClaim, left the credential undeleted on that tec path).
- **PayChanClaim without a Balance claim** (e.g. `tfRenew`/`tfClose`): `verifyDepositPreauth` never runs in rippled, so an expired credential is ignored — the claim now **succeeds** and the credential SLE is left untouched, instead of failing `tecEXPIRED`.
- **Past expiration with a Balance claim / AccountDelete**: still `tecEXPIRED`, now produced by the removeExpired flow; the expired credential SLE is deleted on the tec path (via the existing `ApplyOnTec` re-application), matching rippled.

Code changes:

- `internal/tx/account/account_delete.go`, `internal/tx/paychan/payment_channel_claim.go`: drop the validate-time expiry check; paychan's `verifyDepositPreauth` now calls `RemoveExpiredCredentials` first (rippled's ordering), as account's `adVerifyDepositPreauth` already did.
- `internal/tx/credential/credential_helpers.go`: the `checkExpiry` parameter of `ValidateCredentialIDs` had no remaining users and is removed — the helper now matches `credentials::valid()` exactly; the doc comment documenting the divergence is gone with the divergence. Call sites in escrow/payment updated mechanically.

## Test plan

- New conformance tests (written first, asserting rippled behaviour; the divergent cases failed with `tecEXPIRED` before the fix):
  - `internal/testing/accountdelete`: `TestAccountDelete_CredentialExpiry` — expired credential → `tecEXPIRED`, account survives, credential SLE deleted (mirrors rippled `AccountDelete_test.cpp` "Expired credentials"); boundary `ParentCloseTime == Expiration` → delete succeeds (failed before fix).
  - `internal/testing/paychan`: `TestPayChan_CredentialExpirySemantics` — boundary claim succeeds with the credential intact (failed before fix), then past expiry `tecEXPIRED` + credential deleted + channel balance unchanged; `TestPayChan_ExpiredCredentialWithoutBalanceClaim` — `tfRenew` claim with expired credential succeeds, credential untouched (failed before fix).
- `gofmt -l .` clean, `go vet ./internal/tx/...`, `go build ./...` pass.
- `go test ./internal/tx/...` and the full `go test ./internal/testing/...` (43 packages, incl. accountdelete, paychan, credential, depositpreauth, escrow, payment) pass.

Fixes #824