### PR TITLE
refactor(tx): unify deposit-preauth verification into credential helpers (#822)

### DIFF
--- a/internal/testing/depositpreauth/verify_deposit_preauth_test.go
+++ b/internal/testing/depositpreauth/verify_deposit_preauth_test.go
@@ -1,0 +1,248 @@
+// Tests pinning rippled's verifyDepositPreauth() call-site gating: when the
+// deposit-authorization check (and the expired-credential removal inside it)
+// runs for each Payment variant.
+// Reference: rippled Payment.cpp doApply() + CredentialHelpers.cpp verifyDepositPreauth()
+package depositpreauth_test
+
+import (
+	"testing"
+	"time"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/credential"
+	dp "github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
+	"github.com/LeJamon/go-xrpl/internal/testing/mpt"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDepositAuth_ExpiredCredentialsReserveExemption verifies that for direct
+// XRP payments the deposit-authorization check — including expired-credential
+// removal — only runs when the payment amount or the destination balance
+// exceeds the base reserve. Within the wedge exemption an expired credential
+// is ignored and left on ledger.
+// Reference: rippled Payment.cpp:641-678
+func TestDepositAuth_ExpiredCredentialsReserveExemption(t *testing.T) {
+	credType := "abcde"
+	issuer := jtx.NewAccount("issuer")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+
+	env := jtx.NewTestEnv(t)
+	env.FundAmount(issuer, uint64(jtx.XRP(10000)))
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	// Issuer creates a soon-to-expire credential for alice; alice accepts.
+	expiration := rippleTime(env) + 50
+	result := env.Submit(
+		credential.CredentialCreate(issuer, alice, credType).
+			Expiration(expiration).
+			Build(),
+	)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	result = env.Submit(credential.CredentialAccept(alice, issuer, credType).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	credIdx := dp.CredentialIndex(alice, issuer, credType)
+	credKey := credentialKeylet(alice, issuer, credType)
+
+	// Bring bob's XRP balance down to exactly the base reserve.
+	// bob does NOT have lsfDepositAuth set.
+	{
+		bobPaysXRP := env.Balance(bob) - reserve(env, 1)
+		bobPaysFee := reserve(env, 1) - reserve(env, 0)
+		result = env.Submit(payment.Pay(bob, alice, bobPaysXRP).Fee(bobPaysFee).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+	}
+	require.Equal(t, reserve(env, 0), env.Balance(bob))
+
+	// Let the credential expire.
+	env.AdvanceTime(60 * time.Second)
+	env.Close()
+
+	// Payment amount and destination balance are both <= base reserve, so
+	// deposit preauth is not checked at all: the payment succeeds and the
+	// expired credential is left untouched.
+	result = env.Submit(
+		payment.Pay(alice, bob, 1).
+			CredentialIDs([]string{credIdx}).
+			Build(),
+	)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	require.True(t, env.LedgerEntryExists(credKey),
+		"expired credential must survive a payment inside the reserve exemption")
+
+	// bob is now above the base reserve, so the check runs: the expired
+	// credential fails the payment with tecEXPIRED and is deleted.
+	require.Equal(t, reserve(env, 0)+1, env.Balance(bob))
+	result = env.Submit(
+		payment.Pay(alice, bob, 1).
+			CredentialIDs([]string{credIdx}).
+			Build(),
+	)
+	require.Equal(t, "tecEXPIRED", result.Code)
+	env.Close()
+	require.False(t, env.LedgerEntryExists(credKey),
+		"expired credential must be deleted once the check runs")
+	require.Equal(t, reserve(env, 0)+1, env.Balance(bob))
+}
+
+// TestPayment_ExpiredCredentialsNoDepositAuthDestination verifies that an IOU
+// payment carrying expired credentials fails with tecEXPIRED (deleting the
+// credential) even when the destination does NOT have lsfDepositAuth set:
+// rippled runs verifyDepositPreauth for every ripple payment when the
+// DepositPreauth and DepositAuth amendments are enabled, and removeExpired
+// fires before the destination flags are consulted.
+// Reference: rippled Payment.cpp:448-464, CredentialHelpers.cpp verifyDepositPreauth()
+func TestPayment_ExpiredCredentialsNoDepositAuthDestination(t *testing.T) {
+	credType := "abcde"
+	issuer := jtx.NewAccount("issuer")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	gw := jtx.NewAccount("gw")
+
+	env := jtx.NewTestEnv(t)
+	env.FundAmount(issuer, uint64(jtx.XRP(10000)))
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.FundAmount(gw, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	result := env.Submit(trustset.TrustLine(alice, "USD", gw, "1000").Build())
+	jtx.RequireTxSuccess(t, result)
+	result = env.Submit(trustset.TrustLine(bob, "USD", gw, "1000").Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	usd150 := tx.NewIssuedAmountFromFloat64(150, "USD", gw.Address)
+	result = env.Submit(payment.PayIssued(gw, alice, usd150).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	// Issuer creates a soon-to-expire credential for alice; alice accepts.
+	expiration := rippleTime(env) + 50
+	result = env.Submit(
+		credential.CredentialCreate(issuer, alice, credType).
+			Expiration(expiration).
+			Build(),
+	)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	result = env.Submit(credential.CredentialAccept(alice, issuer, credType).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	credIdx := dp.CredentialIndex(alice, issuer, credType)
+	credKey := credentialKeylet(alice, issuer, credType)
+
+	// Let the credential expire.
+	env.AdvanceTime(60 * time.Second)
+	env.Close()
+
+	// bob does NOT have lsfDepositAuth, yet the expired credential still
+	// fails the payment and is removed from the ledger.
+	usd50 := tx.NewIssuedAmountFromFloat64(50, "USD", gw.Address)
+	result = env.Submit(
+		payment.PayIssued(alice, bob, usd50).
+			CredentialIDs([]string{credIdx}).
+			Build(),
+	)
+	require.Equal(t, "tecEXPIRED", result.Code)
+	env.Close()
+
+	require.False(t, env.LedgerEntryExists(credKey),
+		"expired credential must be deleted even when the destination has no DepositAuth")
+	require.InDelta(t, 0.0, env.BalanceIOU(bob, "USD", gw), 1e-10)
+}
+
+// TestMPTPayment_CanTransferCheckedBeforeDepositPreauth verifies that for MPT
+// direct payments the CanTransfer check precedes verifyDepositPreauth: a
+// holder-to-holder payment of a non-transferable MPT fails with tecNO_AUTH and
+// an attached expired credential is left untouched.
+// Reference: rippled Payment.cpp:526-539
+func TestMPTPayment_CanTransferCheckedBeforeDepositPreauth(t *testing.T) {
+	credType := "abcde"
+	issuer := jtx.NewAccount("issuer")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	cindy := jtx.NewAccount("cindy")
+
+	env := jtx.NewTestEnv(t)
+	env.Fund(alice)
+	env.Fund(bob)
+	env.Fund(cindy)
+	env.FundAmount(issuer, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	// alice creates a non-transferable MPT (no CanTransfer flag).
+	mptAlice := mpt.NewMPTTester(t, env, alice, mpt.MPTInit{Holders: []*jtx.Account{bob, cindy}})
+	mptAlice.Create(mpt.CreateOpts{OwnerCount: mpt.PtrUint32(1), HolderCount: mpt.PtrUint32(0)})
+	mptAlice.Authorize(mpt.AuthorizeOpts{Account: bob})
+	mptAlice.Authorize(mpt.AuthorizeOpts{Account: cindy})
+	mptAlice.Pay(alice, bob, 100)
+
+	// Issuer creates a soon-to-expire credential for bob; bob accepts.
+	expiration := rippleTime(env) + 50
+	result := env.Submit(
+		credential.CredentialCreate(issuer, bob, credType).
+			Expiration(expiration).
+			Build(),
+	)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	result = env.Submit(credential.CredentialAccept(bob, issuer, credType).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	credIdx := dp.CredentialIndex(bob, issuer, credType)
+	credKey := credentialKeylet(bob, issuer, credType)
+
+	// Let the credential expire.
+	env.AdvanceTime(60 * time.Second)
+	env.Close()
+
+	// Holder-to-holder transfer is rejected by the CanTransfer check before
+	// deposit preauth runs, so the expired credential is NOT deleted.
+	result = env.Submit(
+		payment.PayIssued(bob, cindy, mptAlice.MPTAmount(10)).
+			MPTIssuanceID(mptAlice.IssuanceID()).
+			CredentialIDs([]string{credIdx}).
+			Build(),
+	)
+	require.Equal(t, "tecNO_AUTH", result.Code)
+	env.Close()
+	require.True(t, env.LedgerEntryExists(credKey),
+		"credential must be untouched when CanTransfer fails first")
+}
+
+// TestPayment_SelfRipplePaymentDepositPreauthDisabled verifies that without
+// the DepositPreauth amendment, a ripple (cross-currency) payment to a
+// destination with lsfDepositAuth set fails with tecNO_PERMISSION even when
+// source == destination — the bug the DepositPreauth amendment later fixed.
+// Reference: rippled Payment.cpp:440-441
+func TestPayment_SelfRipplePaymentDepositPreauthDisabled(t *testing.T) {
+	alice := jtx.NewAccount("alice")
+	gw := jtx.NewAccount("gw")
+
+	env := jtx.NewTestEnv(t)
+	env.DisableFeature("DepositPreauth")
+
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(gw, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	env.EnableDepositAuth(alice)
+	env.Close()
+
+	usd1 := tx.NewIssuedAmountFromFloat64(1, "USD", gw.Address)
+	result := env.Submit(payment.Pay(alice, alice, 1).SendMax(usd1).Build())
+	require.Equal(t, "tecNO_PERMISSION", result.Code)
+}

--- a/internal/testing/escrow/escrow_credential_expiry_test.go
+++ b/internal/testing/escrow/escrow_credential_expiry_test.go
@@ -1,0 +1,75 @@
+package escrow_test
+
+import (
+	"testing"
+	"time"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/credential"
+	dp "github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEscrowFinish_ExpiredCredentialsDepositAuthDisabled verifies that with
+// the DepositAuth amendment disabled, EscrowFinish never runs the deposit
+// authorization check, so an attached expired credential is ignored: the
+// finish succeeds and the credential is left on ledger. With the amendment
+// enabled the same finish would fail with tecEXPIRED and delete the credential.
+// Reference: rippled Escrow.cpp doApply() — verifyDepositPreauth is gated on
+// featureDepositAuth.
+func TestEscrowFinish_ExpiredCredentialsDepositAuthDisabled(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.DisableFeature("DepositAuth")
+
+	issuer := jtx.NewAccount("issuer")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	fund5000(env, issuer, alice, bob, carol)
+	env.Close()
+
+	credType := "abcde"
+
+	// Issuer creates a soon-to-expire credential for carol; carol accepts.
+	expiration := escrow.ToRippleTime(env.Now()) + 50
+	result := env.Submit(
+		credential.CredentialCreate(issuer, carol, credType).
+			Expiration(expiration).
+			Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	result = env.Submit(credential.CredentialAccept(carol, issuer, credType).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	credIdx := dp.CredentialIndex(carol, issuer, credType)
+	credKey := keylet.Credential(carol.ID, issuer.ID, []byte(credType))
+
+	seq := env.Seq(alice)
+	result = env.Submit(
+		escrow.EscrowCreate(alice, bob, xrp(1000)).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	bobBalance := env.Balance(bob)
+
+	// Let the credential expire.
+	env.AdvanceTime(60 * time.Second)
+	env.Close()
+
+	// Without featureDepositAuth the expired credential is ignored.
+	result = env.Submit(
+		escrow.EscrowFinish(carol, alice, seq).
+			CredentialIDs([]string{credIdx}).
+			Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	require.True(t, env.LedgerEntryExists(credKey),
+		"expired credential must be untouched when DepositAuth is disabled")
+	require.Equal(t, bobBalance+uint64(xrp(1000)), env.Balance(bob))
+}

--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -1,10 +1,6 @@
 package account
 
 import (
-	"bytes"
-	"encoding/hex"
-	"sort"
-
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
@@ -161,7 +157,7 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled DeleteAccount.cpp doApply() — verifyDepositPreauth
 	// is called before cleanupOnAccountDelete.
 	if rules.Enabled(amendment.FeatureDepositAuth) && len(a.CredentialIDs) > 0 {
-		if r := adVerifyDepositPreauth(ctx, a.CredentialIDs, ctx.AccountID, destID, destAccount); r != tx.TesSUCCESS {
+		if r := credential.VerifyDepositPreauth(ctx, a.CredentialIDs, ctx.AccountID, destID, destAccount); r != tx.TesSUCCESS {
 			return r
 		}
 	}
@@ -365,70 +361,4 @@ func keyLessEqual(a, b [32]byte) bool {
 		}
 	}
 	return true
-}
-
-func adVerifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src, dst [20]byte, da *state.AccountRoot) tx.Result {
-	// Remove expired credentials first, before any deposit auth checks.
-	// Reference: rippled verifyDepositPreauth() in CredentialHelpers.cpp
-	// calls credentials::removeExpired() at the top, which deletes expired
-	// credential SLEs and adjusts owner counts even on tec results.
-	if len(credentialIDs) > 0 {
-		if credential.RemoveExpiredCredentials(ctx, credentialIDs) {
-			return tx.TecEXPIRED
-		}
-	}
-
-	if (da.Flags & state.LsfDepositAuth) == 0 {
-		return tx.TesSUCCESS
-	}
-	if src == dst {
-		return tx.TesSUCCESS
-	}
-	if exists, _ := ctx.View.Exists(keylet.DepositPreauth(dst, src)); exists {
-		return tx.TesSUCCESS
-	}
-	if len(credentialIDs) > 0 && ctx.Rules().Enabled(amendment.FeatureCredentials) {
-		return adAuthorizedDepositPreauth(ctx, credentialIDs, dst)
-	}
-	return tx.TecNO_PERMISSION
-}
-
-func adAuthorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst [20]byte) tx.Result {
-	type cp struct {
-		issuer   [20]byte
-		credType []byte
-	}
-	pairs := make([]cp, 0, len(credentialIDs))
-	for _, h := range credentialIDs {
-		cb, err := hex.DecodeString(h)
-		if err != nil || len(cb) != 32 {
-			return tx.TefINTERNAL
-		}
-		var k [32]byte
-		copy(k[:], cb)
-		d, err := ctx.View.Read(keylet.Keylet{Key: k})
-		if err != nil || d == nil {
-			return tx.TefINTERNAL
-		}
-		ce, err := credential.ParseCredentialEntry(d)
-		if err != nil {
-			return tx.TefINTERNAL
-		}
-		pairs = append(pairs, cp{issuer: ce.Issuer, credType: ce.CredentialType})
-	}
-	sort.Slice(pairs, func(i, j int) bool {
-		c := bytes.Compare(pairs[i].issuer[:], pairs[j].issuer[:])
-		if c != 0 {
-			return c < 0
-		}
-		return bytes.Compare(pairs[i].credType, pairs[j].credType) < 0
-	})
-	sc := make([]keylet.CredentialPair, len(pairs))
-	for i, p := range pairs {
-		sc[i] = keylet.CredentialPair{Issuer: p.issuer, CredentialType: p.credType}
-	}
-	if exists, _ := ctx.View.Exists(keylet.DepositPreauthCredentials(dst, sc)); !exists {
-		return tx.TecNO_PERMISSION
-	}
-	return tx.TesSUCCESS
 }

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -1,8 +1,10 @@
 package credential
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
+	"sort"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -279,6 +281,86 @@ func RemoveExpiredCredentials(ctx *tx.ApplyContext, credentialIDs []string) bool
 	}
 
 	return anyExpired
+}
+
+// VerifyDepositPreauth enforces deposit authorization for a transaction
+// moving funds from src to dst. Expired credentials in credentialIDs are
+// deleted first, failing the transaction with tecEXPIRED if any were expired
+// (the deletion is re-applied on the tec path via ApplyOnTec). If dst has
+// lsfDepositAuth set and src != dst, the deposit must be preauthorized by
+// dst, either by account or by the supplied credentials.
+// Reference: rippled CredentialHelpers.cpp verifyDepositPreauth()
+func VerifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src, dst [20]byte, dstAccount *state.AccountRoot) tx.Result {
+	credentialsPresent := len(credentialIDs) > 0
+
+	if credentialsPresent && RemoveExpiredCredentials(ctx, credentialIDs) {
+		return tx.TecEXPIRED
+	}
+
+	if dstAccount != nil && (dstAccount.Flags&state.LsfDepositAuth) != 0 && src != dst {
+		if exists, _ := ctx.View.Exists(keylet.DepositPreauth(dst, src)); !exists {
+			if !credentialsPresent {
+				return tx.TecNO_PERMISSION
+			}
+			return authorizedDepositPreauth(ctx, credentialIDs, dst)
+		}
+	}
+
+	return tx.TesSUCCESS
+}
+
+// authorizedDepositPreauth checks whether the (Issuer, CredentialType) pairs
+// of the supplied credentials match a credential-based DepositPreauth entry
+// on dst. A duplicate pair is reported as tefINTERNAL: it cannot occur for
+// credentials that passed preflight and preclaim, since credential IDs are
+// deduplicated there and all credentials share the sender as Subject.
+// Reference: rippled CredentialHelpers.cpp credentials::authorizedDepositPreauth()
+func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst [20]byte) tx.Result {
+	pairs := make([]keylet.CredentialPair, 0, len(credentialIDs))
+	seen := make(map[string]bool, len(credentialIDs))
+
+	for _, idHex := range credentialIDs {
+		credIDBytes, err := hex.DecodeString(idHex)
+		if err != nil || len(credIDBytes) != 32 {
+			return tx.TefINTERNAL
+		}
+		var credID [32]byte
+		copy(credID[:], credIDBytes)
+
+		// Credential existence was already checked in preclaim.
+		credData, err := ctx.View.Read(keylet.CredentialByID(credID))
+		if err != nil || credData == nil {
+			return tx.TefINTERNAL
+		}
+
+		cred, err := ParseCredentialEntry(credData)
+		if err != nil {
+			return tx.TefINTERNAL
+		}
+
+		pairKey := hex.EncodeToString(cred.Issuer[:]) + ":" + hex.EncodeToString(cred.CredentialType)
+		if seen[pairKey] {
+			return tx.TefINTERNAL
+		}
+		seen[pairKey] = true
+
+		pairs = append(pairs, keylet.CredentialPair{Issuer: cred.Issuer, CredentialType: cred.CredentialType})
+	}
+
+	// Sort pairs by (Issuer, CredentialType) to match rippled's sorted set,
+	// which the credential-based DepositPreauth keylet is computed over.
+	sort.Slice(pairs, func(i, j int) bool {
+		if c := bytes.Compare(pairs[i].Issuer[:], pairs[j].Issuer[:]); c != 0 {
+			return c < 0
+		}
+		return bytes.Compare(pairs[i].CredentialType, pairs[j].CredentialType) < 0
+	})
+
+	if exists, _ := ctx.View.Exists(keylet.DepositPreauthCredentials(dst, pairs)); !exists {
+		return tx.TecNO_PERMISSION
+	}
+
+	return tx.TesSUCCESS
 }
 
 // DeleteSLE deletes a credential from the ledger, removing it from both the

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -2,7 +2,6 @@ package escrow
 
 import (
 	"encoding/hex"
-	"sort"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -281,33 +280,12 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	// Check for expired credentials BEFORE deposit auth check.
-	// Reference: rippled verifyDepositPreauth() — first calls removeExpired(),
-	// returns tecEXPIRED if any credentials were expired.
-	if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if credential.RemoveExpiredCredentials(ctx, e.CredentialIDs) {
-			return tx.TecEXPIRED
-		}
-	}
-
-	// Deposit authorization check
-	// Reference: rippled verifyDepositPreauth() in CredentialHelpers.cpp
+	// Deposit authorization check. Runs only under the DepositAuth amendment,
+	// matching rippled; expired-credential removal happens inside.
+	// Reference: rippled Escrow.cpp doApply() — verifyDepositPreauth()
 	if rules.Enabled(amendment.FeatureDepositAuth) {
-		if (destAccount.Flags & state.LsfDepositAuth) != 0 {
-			if ctx.AccountID != escrowEntry.DestinationID {
-				// Check account-based DepositPreauth
-				preauthKey := keylet.DepositPreauth(escrowEntry.DestinationID, ctx.AccountID)
-				if exists, _ := ctx.View.Exists(preauthKey); !exists {
-					// No account-based preauth — check credential-based
-					if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-						if result := authorizedDepositPreauth(ctx, e.CredentialIDs, escrowEntry.DestinationID); result != tx.TesSUCCESS {
-							return result
-						}
-					} else {
-						return tx.TecNO_PERMISSION
-					}
-				}
-			}
+		if result := credential.VerifyDepositPreauth(ctx, e.CredentialIDs, ctx.AccountID, escrowEntry.DestinationID, destAccount); result != tx.TesSUCCESS {
+			return result
 		}
 	}
 
@@ -450,90 +428,6 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	adjustOwnerCount(ctx, ownerID, -1)
 
 	return tx.TesSUCCESS
-}
-
-// authorizedDepositPreauth implements rippled's credentials::authorizedDepositPreauth().
-// It reads each credential, extracts the (Issuer, CredentialType) pairs,
-// sorts them, and checks if a credential-based DepositPreauth exists for the destination.
-// Reference: rippled CredentialHelpers.cpp credentials::authorizedDepositPreauth()
-func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst [20]byte) tx.Result {
-	type credPair struct {
-		issuer   [20]byte
-		credType []byte
-	}
-
-	pairs := make([]credPair, 0, len(credentialIDs))
-	for _, credIDHex := range credentialIDs {
-		credHash, err := hex.DecodeString(credIDHex)
-		if err != nil || len(credHash) != 32 {
-			return tx.TefINTERNAL
-		}
-
-		var credID [32]byte
-		copy(credID[:], credHash)
-
-		credKey := keylet.CredentialByID(credID)
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			return tx.TefINTERNAL
-		}
-
-		credEntry, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			return tx.TefINTERNAL
-		}
-
-		pairs = append(pairs, credPair{
-			issuer:   credEntry.Issuer,
-			credType: credEntry.CredentialType,
-		})
-	}
-
-	// Sort by (issuer, credType) to match rippled's sorted set
-	sort.Slice(pairs, func(i, j int) bool {
-		cmp := compareBytesSlice(pairs[i].issuer[:], pairs[j].issuer[:])
-		if cmp != 0 {
-			return cmp < 0
-		}
-		return compareBytesSlice(pairs[i].credType, pairs[j].credType) < 0
-	})
-
-	// Convert to keylet.CredentialPair for keylet computation
-	sortedCreds := make([]keylet.CredentialPair, len(pairs))
-	for i, p := range pairs {
-		sortedCreds[i] = keylet.CredentialPair{
-			Issuer:         p.issuer,
-			CredentialType: p.credType,
-		}
-	}
-
-	// Check if credential-based DepositPreauth exists
-	dpKey := keylet.DepositPreauthCredentials(dst, sortedCreds)
-	if exists, _ := ctx.View.Exists(dpKey); !exists {
-		return tx.TecNO_PERMISSION
-	}
-
-	return tx.TesSUCCESS
-}
-
-// compareBytesSlice compares two byte slices lexicographically.
-func compareBytesSlice(a, b []byte) int {
-	minLen := min(len(b), len(a))
-	for i := range minLen {
-		if a[i] < b[i] {
-			return -1
-		}
-		if a[i] > b[i] {
-			return 1
-		}
-	}
-	if len(a) < len(b) {
-		return -1
-	}
-	if len(a) > len(b) {
-		return 1
-	}
-	return 0
 }
 
 // adjustOwnerCount adjusts the OwnerCount of the given account by delta.

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -1,9 +1,7 @@
 package paychan
 
 import (
-	"bytes"
 	"encoding/hex"
-	"sort"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -337,7 +335,7 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 		// DepositAuth check — when DepositAuth IS enabled
 		// Reference: rippled PayChan.cpp doApply() lines 553-563
 		if depositAuth {
-			if result := verifyDepositPreauth(ctx, p.CredentialIDs, accountID, channel.DestinationID, destAccount); result != tx.TesSUCCESS {
+			if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, accountID, channel.DestinationID, destAccount); result != tx.TesSUCCESS {
 				return result
 			}
 		}
@@ -408,99 +406,5 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 // Reference: rippled CredentialHelpers.cpp removeExpired() — called from verifyDepositPreauth()
 func (p *PaymentChannelClaim) ApplyOnTec(ctx *tx.ApplyContext) tx.Result {
 	credential.RemoveExpiredCredentials(ctx, p.CredentialIDs)
-	return tx.TesSUCCESS
-}
-
-// verifyDepositPreauth implements rippled's verifyDepositPreauth() from CredentialHelpers.cpp.
-// Reference: rippled CredentialHelpers.cpp verifyDepositPreauth() lines 357-391
-func verifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src [20]byte, dst [20]byte, destAccount *state.AccountRoot) tx.Result {
-	// Remove expired credentials first, before any deposit auth checks. This
-	// deletes expired credential SLEs (re-applied on the tec path) and fails
-	// the transaction with tecEXPIRED if any credential was expired.
-	if len(credentialIDs) > 0 && credential.RemoveExpiredCredentials(ctx, credentialIDs) {
-		return tx.TecEXPIRED
-	}
-
-	// Only check if destination has lsfDepositAuth set
-	if (destAccount.Flags & state.LsfDepositAuth) == 0 {
-		return tx.TesSUCCESS
-	}
-
-	// Self-deposits don't need preauth
-	if src == dst {
-		return tx.TesSUCCESS
-	}
-
-	preauthKey := keylet.DepositPreauth(dst, src)
-	if exists, _ := ctx.View.Exists(preauthKey); exists {
-		return tx.TesSUCCESS
-	}
-
-	// No account-based preauth — check credential-based
-	if len(credentialIDs) > 0 && ctx.Rules().Enabled(amendment.FeatureCredentials) {
-		return authorizedDepositPreauth(ctx, credentialIDs, dst)
-	}
-
-	return tx.TecNO_PERMISSION
-}
-
-// authorizedDepositPreauth implements rippled's credentials::authorizedDepositPreauth().
-// Reference: rippled CredentialHelpers.cpp credentials::authorizedDepositPreauth()
-func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst [20]byte) tx.Result {
-	type credPair struct {
-		issuer   [20]byte
-		credType []byte
-	}
-
-	pairs := make([]credPair, 0, len(credentialIDs))
-	for _, credIDHex := range credentialIDs {
-		credHash, err := hex.DecodeString(credIDHex)
-		if err != nil || len(credHash) != 32 {
-			return tx.TefINTERNAL
-		}
-
-		var credKeyBytes [32]byte
-		copy(credKeyBytes[:], credHash)
-		credKey := keylet.Keylet{Key: credKeyBytes}
-
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			return tx.TefINTERNAL
-		}
-
-		credEntry, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			return tx.TefINTERNAL
-		}
-
-		pairs = append(pairs, credPair{
-			issuer:   credEntry.Issuer,
-			credType: credEntry.CredentialType,
-		})
-	}
-
-	// Sort pairs by (issuer, credType) for deterministic lookup
-	sort.Slice(pairs, func(i, j int) bool {
-		cmp := bytes.Compare(pairs[i].issuer[:], pairs[j].issuer[:])
-		if cmp != 0 {
-			return cmp < 0
-		}
-		return bytes.Compare(pairs[i].credType, pairs[j].credType) < 0
-	})
-
-	sortedCreds := make([]keylet.CredentialPair, len(pairs))
-	for i, p := range pairs {
-		sortedCreds[i] = keylet.CredentialPair{
-			Issuer:         p.issuer,
-			CredentialType: p.credType,
-		}
-	}
-
-	// Check if credential-based DepositPreauth exists
-	dpKey := keylet.DepositPreauthCredentials(dst, sortedCreds)
-	if exists, _ := ctx.View.Exists(dpKey); !exists {
-		return tx.TecNO_PERMISSION
-	}
-
 	return tx.TesSUCCESS
 }

--- a/internal/tx/payment/payment_credential.go
+++ b/internal/tx/payment/payment_credential.go
@@ -1,14 +1,8 @@
 package payment
 
 import (
-	"bytes"
-	"encoding/hex"
-	"sort"
-
-	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
-	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // ApplyOnTec implements TecApplier. When tecEXPIRED is returned, this re-runs
@@ -17,108 +11,4 @@ import (
 func (p *Payment) ApplyOnTec(ctx *tx.ApplyContext) tx.Result {
 	credential.RemoveExpiredCredentials(ctx, p.CredentialIDs)
 	return tx.TecEXPIRED
-}
-
-// authorizedDepositPreauth checks if the provided credentials match a
-// credential-based DepositPreauth entry on the destination account.
-// Reference: rippled credentials::authorizedDepositPreauth() in CredentialHelpers.cpp
-func (p *Payment) authorizedDepositPreauth(ctx *tx.ApplyContext, dstAccountID [20]byte) tx.Result {
-	// Read each credential, extract (Issuer, CredentialType) pairs
-	type credPair struct {
-		issuer   [20]byte
-		credType []byte
-	}
-	pairs := make([]credPair, 0, len(p.CredentialIDs))
-
-	seen := make(map[string]bool)
-	for _, idHex := range p.CredentialIDs {
-		credIDBytes, err := hex.DecodeString(idHex)
-		if err != nil || len(credIDBytes) != 32 {
-			return tx.TefINTERNAL
-		}
-		var credID [32]byte
-		copy(credID[:], credIDBytes)
-
-		credKey := keylet.CredentialByID(credID)
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			return tx.TefINTERNAL
-		}
-
-		cred, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			return tx.TefINTERNAL
-		}
-
-		// Build a dedup key from (Issuer, CredentialType)
-		pairKey := credentialPairKey(cred.Issuer, cred.CredentialType)
-		if seen[pairKey] {
-			return tx.TefINTERNAL
-		}
-		seen[pairKey] = true
-
-		pairs = append(pairs, credPair{issuer: cred.Issuer, credType: cred.CredentialType})
-	}
-
-	// Sort pairs by (issuer, credType) to match keylet computation
-	sort.Slice(pairs, func(i, j int) bool {
-		cmp := bytes.Compare(pairs[i].issuer[:], pairs[j].issuer[:])
-		if cmp != 0 {
-			return cmp < 0
-		}
-		return bytes.Compare(pairs[i].credType, pairs[j].credType) < 0
-	})
-
-	// Convert to keylet.CredentialPair
-	keyletPairs := make([]keylet.CredentialPair, len(pairs))
-	for i, cp := range pairs {
-		keyletPairs[i] = keylet.CredentialPair{
-			Issuer:         cp.issuer,
-			CredentialType: cp.credType,
-		}
-	}
-
-	// Check if credential-based DepositPreauth exists for destination
-	preauthKey := keylet.DepositPreauthCredentials(dstAccountID, keyletPairs)
-	if exists, _ := ctx.View.Exists(preauthKey); !exists {
-		return tx.TecNO_PERMISSION
-	}
-
-	return tx.TesSUCCESS
-}
-
-// credentialPairKey returns a unique string key for deduplication of (issuer, credType) pairs.
-func credentialPairKey(issuer [20]byte, credType []byte) string {
-	return hex.EncodeToString(issuer[:]) + ":" + hex.EncodeToString(credType)
-}
-
-// verifyDepositPreauth checks deposit authorization for a payment.
-// Reference: rippled verifyDepositPreauth() in Payment.cpp
-func (p *Payment) verifyDepositPreauth(ctx *tx.ApplyContext, srcAccountID, dstAccountID [20]byte, dstAccount *state.AccountRoot) tx.Result {
-	credentialsPresent := len(p.CredentialIDs) > 0
-
-	// Remove expired credentials first
-	if credentialsPresent {
-		if credential.RemoveExpiredCredentials(ctx, p.CredentialIDs) {
-			return tx.TecEXPIRED
-		}
-	}
-
-	// Check if destination requires deposit authorization
-	if dstAccount != nil && (dstAccount.Flags&state.LsfDepositAuth) != 0 {
-		// Self-payments always allowed
-		if srcAccountID != dstAccountID {
-			// Try account-based DepositPreauth first
-			preauthKey := keylet.DepositPreauth(dstAccountID, srcAccountID)
-			if exists, _ := ctx.View.Exists(preauthKey); !exists {
-				// Account-based preauth not found — try credential-based
-				if !credentialsPresent {
-					return tx.TecNO_PERMISSION
-				}
-				return p.authorizedDepositPreauth(ctx, dstAccountID)
-			}
-		}
-	}
-
-	return tx.TesSUCCESS
 }

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -152,8 +152,9 @@ func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) tx.Result {
 
 	// Check deposit authorization for IOU payments (including path-finding payments)
 	// Reference: rippled Payment.cpp:429-464
+	depositAuth := ctx.Rules().Enabled(amendment.FeatureDepositAuth)
 	depositPreauth := ctx.Rules().Enabled(amendment.FeatureDepositPreauth)
-	reqDepositAuth := (destAccount.Flags & state.LsfDepositAuth) != 0
+	reqDepositAuth := (destAccount.Flags&state.LsfDepositAuth) != 0 && depositAuth
 
 	// Before DepositPreauth amendment: ALL ripple payments to accounts with
 	// DepositAuth are blocked (including self-payments). This was a bug that
@@ -163,9 +164,11 @@ func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) tx.Result {
 		return tx.TecNO_PERMISSION
 	}
 
-	// With DepositPreauth amendment: self-payments and preauthorized accounts are allowed.
-	if depositPreauth && reqDepositAuth {
-		if result := p.verifyDepositPreauth(ctx, senderAccountID, destAccountID, destAccount); result != tx.TesSUCCESS {
+	// With DepositPreauth amendment: self-payments and preauthorized accounts
+	// are allowed. The check runs regardless of the destination's flags so
+	// that expired credentials are removed (tecEXPIRED).
+	if depositPreauth && depositAuth {
+		if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, senderAccountID, destAccountID, destAccount); result != tx.TesSUCCESS {
 			return result
 		}
 	}
@@ -303,8 +306,19 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 	}
 
 	// Check deposit authorization
-	if result := p.verifyDepositPreauth(ctx, senderID, destID, destAccount); result != tx.TesSUCCESS {
-		return result
+	// Reference: rippled Payment.cpp:429-464 (ripple == true)
+	depositAuth := ctx.Rules().Enabled(amendment.FeatureDepositAuth)
+	depositPreauth := ctx.Rules().Enabled(amendment.FeatureDepositPreauth)
+	reqDepositAuth := (destAccount.Flags&state.LsfDepositAuth) != 0 && depositAuth
+
+	if !depositPreauth && reqDepositAuth {
+		return tx.TecNO_PERMISSION
+	}
+
+	if depositPreauth && depositAuth {
+		if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, senderID, destID, destAccount); result != tx.TesSUCCESS {
+			return result
+		}
 	}
 
 	// Use the flow engine (issuerID is unused for XRP amount, pass zero)

--- a/internal/tx/payment/payment_mpt.go
+++ b/internal/tx/payment/payment_mpt.go
@@ -75,9 +75,21 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 		return res
 	}
 
+	senderIsIssuer := ctx.AccountID == issuerID
+	destIsIssuer := destAccountID == issuerID
+
+	// canTransfer: holder-to-holder requires CanTransfer flag.
+	// Checked BEFORE deposit preauth, matching rippled's ordering.
+	// Reference: rippled Payment.cpp:526-529
+	if !senderIsIssuer && !destIsIssuer {
+		if issuance.Flags&entry.LsfMPTCanTransfer == 0 {
+			return tx.TecNO_AUTH
+		}
+	}
+
 	// Verify deposit preauth
 	// Reference: rippled Payment.cpp:531-539
-	if result := p.verifyDepositPreauth(ctx, ctx.AccountID, destAccountID, destAccount); result != tx.TesSUCCESS {
+	if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, ctx.AccountID, destAccountID, destAccount); result != tx.TesSUCCESS {
 		return result
 	}
 
@@ -85,17 +97,6 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 	dstAmount := mptAmountToUint64(p.Amount)
 	if dstAmount == 0 {
 		return tx.TemBAD_AMOUNT
-	}
-
-	senderIsIssuer := ctx.AccountID == issuerID
-	destIsIssuer := destAccountID == issuerID
-
-	// canTransfer: holder-to-holder requires CanTransfer flag
-	// Reference: rippled Payment.cpp:526-529
-	if !senderIsIssuer && !destIsIssuer {
-		if issuance.Flags&entry.LsfMPTCanTransfer == 0 {
-			return tx.TecNO_AUTH
-		}
 	}
 
 	// Compute transfer rate for holder-to-holder transfers

--- a/internal/tx/payment/payment_xrp.go
+++ b/internal/tx/payment/payment_xrp.go
@@ -3,6 +3,7 @@ package payment
 import (
 	"strconv"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
@@ -87,21 +88,17 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 		}
 
 		// Check deposit authorization
-		// Reference: rippled Payment.cpp:641-677
+		// Reference: rippled Payment.cpp:641-678
 		// XRP payments have a wedge-prevention exemption: if BOTH the payment amount
-		// AND destination balance are <= base reserve, deposit preauth is NOT required.
-		if (destAccount.Flags & state.LsfDepositAuth) != 0 {
+		// AND destination balance are <= base reserve, deposit preauth is NOT
+		// checked at all (expired credentials are left untouched too).
+		if ctx.Rules().Enabled(amendment.FeatureDepositAuth) {
 			dstReserve := ctx.Config.ReserveBase
 
 			if amountDrops > dstReserve || destAccount.Balance > dstReserve {
-				if result := p.verifyDepositPreauth(ctx, ctx.AccountID, destAccountID, destAccount); result != tx.TesSUCCESS {
+				if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, ctx.AccountID, destAccountID, destAccount); result != tx.TesSUCCESS {
 					return result
 				}
-			}
-		} else if len(p.CredentialIDs) > 0 {
-			// Even without lsfDepositAuth, remove expired credentials if present
-			if credential.RemoveExpiredCredentials(ctx, p.CredentialIDs) {
-				return tx.TecEXPIRED
 			}
 		}
 


### PR DESCRIPTION
Was stacked on #826 (branched from `fix/issue-824-credential-expiry`); #826 has since merged into main, so this targets main directly and the diff contains only this change.

## Summary

rippled implements `verifyDepositPreauth()` / `credentials::authorizedDepositPreauth()` once in CredentialHelpers.cpp; we carried four near-parallel copies. This PR extracts shared helpers into `internal/tx/credential/credential_helpers.go` (next to `ValidateCredentialIDs` / `RemoveExpiredCredentials`) and routes all four transactors through them, so the deposit-preauth checking logic now lives in exactly one place.

**What the rippled comparison showed for the known differences:**

- **Pair dedup (payment's `seen` map)**: rippled's `authorizedDepositPreauth` inserts `(Issuer, CredentialType)` pairs into a `std::set` and returns `tefINTERNAL` on a duplicate — it does NOT dedup-and-continue. The payment copy matched this; escrow/paychan/account silently kept duplicates (which would corrupt the keylet). The unified helper uses the payment/rippled semantics. The path is unreachable through the engine — preflight rejects duplicate credential IDs and a credential ID is `H(subject, issuer, type)` with subject fixed to the sender, so distinct IDs cannot produce duplicate pairs — hence defensive only, no conformance test possible.
- **Ordering**: all four already ran `removeExpired` → account-preauth → credential-preauth after #826; the unified helper pins rippled's exact shape (including the nil-safe `sleDst` check).
- **`FeatureCredentials` gates inside the helpers** (escrow/paychan/account): dead code — all four transactors already return `temDISABLED` at preflight when `CredentialIDs` is present without the amendment, matching rippled. Dropped; the helper matches rippled's, which has no such gate.

**Call-site gating drift against rippled Payment.cpp / Escrow.cpp, fixed with pinning tests** (each test fails on the pre-refactor code):

- **XRP payments** gated the check on the destination's `lsfDepositAuth` flag and removed expired credentials in an `else` branch. rippled gates only on `featureDepositAuth` + the base-reserve wedge exemption (`Payment.cpp:641-678`); inside the exemption an expired credential is ignored and left on ledger. → `TestDepositAuth_ExpiredCredentialsReserveExemption`
- **IOU/ripple payments** gated the check on the destination flag; rippled runs it for every ripple payment when DepositPreauth+DepositAuth are enabled, so expired credentials fail with `tecEXPIRED` (and are deleted) even when the destination has no DepositAuth. → `TestPayment_ExpiredCredentialsNoDepositAuthDestination`
- **`applyRipplePayment`** (XRP delivered via SendMax/paths) called the check unconditionally, missing rippled's `!depositPreauth && reqDepositAuth → tecNO_PERMISSION` pre-amendment bug behaviour (`Payment.cpp:440-441`). → `TestPayment_SelfRipplePaymentDepositPreauthDisabled`
- **MPT payments** ran the check before `canTransfer`; rippled checks CanTransfer first (`Payment.cpp:526-539`), so a non-transferable holder-to-holder payment fails `tecNO_AUTH` with the expired credential untouched. → `TestMPTPayment_CanTransferCheckedBeforeDepositPreauth`
- **EscrowFinish** ran `removeExpired` outside the `featureDepositAuth` gate; rippled only calls `verifyDepositPreauth` under the amendment, so without it an expired credential is ignored. → `TestEscrowFinish_ExpiredCredentialsDepositAuthDisabled`

PayChanClaim and AccountDelete call sites were already rippled-shaped after #826 and convert mechanically.

## Test plan

- 5 new conformance tests (above) in `internal/testing/depositpreauth` and `internal/testing/escrow`; all verified to fail with the pre-refactor implementations and pass after.
- `gofmt -l .` clean, `go vet ./internal/tx/...`, `go build ./...`, `golangci-lint run` on changed packages: 0 issues.
- `go test ./internal/tx/...` passes; full `go test ./internal/testing/...` (43 packages, incl. depositpreauth, credential, escrow, paychan, payment, accountdelete) passes — including the #826 expiry tests (`TestAccountDelete_CredentialExpiry`, `TestPayChan_CredentialExpirySemantics`, `TestPayChan_ExpiredCredentialWithoutBalanceClaim`), proving the just-fixed semantics are preserved.

Fixes #822