### PR TITLE
fix(rpc): resolve multisig RPC TODOs with rippled-parity validation

### DIFF
--- a/docs/rpc-methods.md
+++ b/docs/rpc-methods.md
@@ -5,86 +5,84 @@
 The JSON-RPC and WebSocket methods registered by the server, generated from
 the method registry (`internal/rpc/handlers`). **Role** is the minimum role a
 caller needs; **API versions** are the API versions each method supports.
-Methods marked WS-only are available only over a WebSocket session (the HTTP
-server returns `methodNotFound` for them, matching rippled).
 
 Total: 76 methods.
 
-| Method | Role | API versions | WS-only |
-|--------|------|--------------|---------|
-| `account_channels` | guest | 1, 2, 3 |  |
-| `account_currencies` | guest | 1, 2, 3 |  |
-| `account_info` | guest | 1, 2, 3 |  |
-| `account_lines` | guest | 1, 2, 3 |  |
-| `account_nfts` | guest | 1, 2, 3 |  |
-| `account_objects` | guest | 1, 2, 3 |  |
-| `account_offers` | guest | 1, 2, 3 |  |
-| `account_tx` | guest | 1, 2, 3 |  |
-| `amm_info` | guest | 1, 2, 3 |  |
-| `blacklist` | admin | 1, 2, 3 |  |
-| `book_changes` | guest | 1, 2, 3 |  |
-| `book_offers` | guest | 1, 2, 3 |  |
-| `can_delete` | admin | 1, 2, 3 |  |
-| `channel_authorize` | user | 1, 2, 3 |  |
-| `channel_verify` | guest | 1, 2, 3 |  |
-| `connect` | admin | 1, 2, 3 |  |
-| `consensus_info` | admin | 1, 2, 3 |  |
-| `crawl_shards` | admin | 1, 2, 3 |  |
-| `deposit_authorized` | guest | 1, 2, 3 |  |
-| `download_shard` | admin | 1, 2, 3 |  |
-| `feature` | guest | 1, 2, 3 |  |
-| `fee` | guest | 1, 2, 3 |  |
-| `fetch_info` | admin | 1, 2, 3 |  |
-| `gateway_balances` | guest | 1, 2, 3 |  |
-| `get_aggregate_price` | guest | 1, 2, 3 |  |
-| `get_counts` | admin | 1, 2, 3 |  |
-| `json` | guest | 1, 2, 3 |  |
-| `ledger` | guest | 1, 2, 3 |  |
-| `ledger_accept` | admin | 1, 2, 3 |  |
-| `ledger_cleaner` | admin | 1, 2, 3 |  |
-| `ledger_closed` | guest | 1, 2, 3 |  |
-| `ledger_current` | guest | 1, 2, 3 |  |
-| `ledger_data` | guest | 1, 2, 3 |  |
-| `ledger_entry` | guest | 1, 2, 3 |  |
-| `ledger_header` | guest | 1 |  |
-| `ledger_range` | admin | 1, 2, 3 |  |
-| `ledger_request` | admin | 1, 2, 3 |  |
-| `log_level` | admin | 1, 2, 3 |  |
-| `logrotate` | admin | 1, 2, 3 |  |
-| `manifest` | user | 1, 2, 3 |  |
-| `nft_buy_offers` | guest | 1, 2, 3 |  |
-| `nft_sell_offers` | guest | 1, 2, 3 |  |
-| `noripple_check` | guest | 1, 2, 3 |  |
-| `owner_info` | guest | 1, 2, 3 |  |
-| `path_find` | guest | 1, 2, 3 |  |
-| `peer_reservations_add` | admin | 1, 2, 3 |  |
-| `peer_reservations_del` | admin | 1, 2, 3 |  |
-| `peer_reservations_list` | admin | 1, 2, 3 |  |
-| `peers` | admin | 1, 2, 3 |  |
-| `ping` | guest | 1, 2, 3 |  |
-| `print` | admin | 1, 2, 3 |  |
-| `random` | guest | 1, 2, 3 |  |
-| `ripple_path_find` | guest | 1, 2, 3 |  |
-| `server_definitions` | guest | 1, 2, 3 |  |
-| `server_info` | guest | 1, 2, 3 |  |
-| `server_state` | guest | 1, 2, 3 |  |
-| `sign` | user | 1, 2, 3 |  |
-| `sign_for` | user | 1, 2, 3 |  |
-| `simulate` | guest | 1, 2, 3 |  |
-| `stop` | admin | 1, 2, 3 |  |
-| `submit` | user | 1, 2, 3 |  |
-| `submit_multisigned` | user | 1, 2, 3 |  |
-| `subscribe` | guest | 1, 2, 3 | ✓ |
-| `transaction_entry` | user | 1, 2, 3 |  |
-| `tx` | user | 1, 2, 3 |  |
-| `tx_history` | user | 1 |  |
-| `tx_reduce_relay` | user | 1, 2, 3 |  |
-| `unl_list` | admin | 1, 2, 3 |  |
-| `unsubscribe` | guest | 1, 2, 3 | ✓ |
-| `validation_create` | admin | 1, 2, 3 |  |
-| `validator_info` | admin | 1, 2, 3 |  |
-| `validator_list_sites` | admin | 1, 2, 3 |  |
-| `validators` | admin | 1, 2, 3 |  |
-| `vault_info` | guest | 1, 2, 3 |  |
-| `version` | guest | 1, 2, 3 |  |
-| `wallet_propose` | admin | 1, 2, 3 |  |
+| Method | Role | API versions |
+|--------|------|--------------|
+| `account_channels` | guest | 1, 2, 3 |
+| `account_currencies` | guest | 1, 2, 3 |
+| `account_info` | guest | 1, 2, 3 |
+| `account_lines` | guest | 1, 2, 3 |
+| `account_nfts` | guest | 1, 2, 3 |
+| `account_objects` | guest | 1, 2, 3 |
+| `account_offers` | guest | 1, 2, 3 |
+| `account_tx` | guest | 1, 2, 3 |
+| `amm_info` | guest | 1, 2, 3 |
+| `blacklist` | admin | 1, 2, 3 |
+| `book_changes` | guest | 1, 2, 3 |
+| `book_offers` | guest | 1, 2, 3 |
+| `can_delete` | admin | 1, 2, 3 |
+| `channel_authorize` | user | 1, 2, 3 |
+| `channel_verify` | guest | 1, 2, 3 |
+| `connect` | admin | 1, 2, 3 |
+| `consensus_info` | admin | 1, 2, 3 |
+| `crawl_shards` | admin | 1, 2, 3 |
+| `deposit_authorized` | guest | 1, 2, 3 |
+| `download_shard` | admin | 1, 2, 3 |
+| `feature` | guest | 1, 2, 3 |
+| `fee` | guest | 1, 2, 3 |
+| `fetch_info` | admin | 1, 2, 3 |
+| `gateway_balances` | guest | 1, 2, 3 |
+| `get_aggregate_price` | guest | 1, 2, 3 |
+| `get_counts` | admin | 1, 2, 3 |
+| `json` | guest | 1, 2, 3 |
+| `ledger` | guest | 1, 2, 3 |
+| `ledger_accept` | admin | 1, 2, 3 |
+| `ledger_cleaner` | admin | 1, 2, 3 |
+| `ledger_closed` | guest | 1, 2, 3 |
+| `ledger_current` | guest | 1, 2, 3 |
+| `ledger_data` | guest | 1, 2, 3 |
+| `ledger_entry` | guest | 1, 2, 3 |
+| `ledger_header` | guest | 1 |
+| `ledger_range` | admin | 1, 2, 3 |
+| `ledger_request` | admin | 1, 2, 3 |
+| `log_level` | admin | 1, 2, 3 |
+| `logrotate` | admin | 1, 2, 3 |
+| `manifest` | user | 1, 2, 3 |
+| `nft_buy_offers` | guest | 1, 2, 3 |
+| `nft_sell_offers` | guest | 1, 2, 3 |
+| `noripple_check` | guest | 1, 2, 3 |
+| `owner_info` | guest | 1, 2, 3 |
+| `path_find` | guest | 1, 2, 3 |
+| `peer_reservations_add` | admin | 1, 2, 3 |
+| `peer_reservations_del` | admin | 1, 2, 3 |
+| `peer_reservations_list` | admin | 1, 2, 3 |
+| `peers` | admin | 1, 2, 3 |
+| `ping` | guest | 1, 2, 3 |
+| `print` | admin | 1, 2, 3 |
+| `random` | guest | 1, 2, 3 |
+| `ripple_path_find` | guest | 1, 2, 3 |
+| `server_definitions` | guest | 1, 2, 3 |
+| `server_info` | guest | 1, 2, 3 |
+| `server_state` | guest | 1, 2, 3 |
+| `sign` | user | 1, 2, 3 |
+| `sign_for` | user | 1, 2, 3 |
+| `simulate` | guest | 1, 2, 3 |
+| `stop` | admin | 1, 2, 3 |
+| `submit` | user | 1, 2, 3 |
+| `submit_multisigned` | user | 1, 2, 3 |
+| `subscribe` | guest | 1, 2, 3 |
+| `transaction_entry` | user | 1, 2, 3 |
+| `tx` | user | 1, 2, 3 |
+| `tx_history` | user | 1 |
+| `tx_reduce_relay` | user | 1, 2, 3 |
+| `unl_list` | admin | 1, 2, 3 |
+| `unsubscribe` | guest | 1, 2, 3 |
+| `validation_create` | admin | 1, 2, 3 |
+| `validator_info` | admin | 1, 2, 3 |
+| `validator_list_sites` | admin | 1, 2, 3 |
+| `validators` | admin | 1, 2, 3 |
+| `vault_info` | guest | 1, 2, 3 |
+| `version` | guest | 1, 2, 3 |
+| `wallet_propose` | admin | 1, 2, 3 |

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"fmt"
 	"runtime"
+	rdebug "runtime/debug" // aliased: the cli package has a `debug` flag variable
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -12,15 +14,47 @@ var versionCmd = &cobra.Command{
 	Short: "Show version information",
 	Long:  `Display version information for go-xrpl including build details and Go version.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("go-xrpl version %s\n", rootCmd.Version)
-		fmt.Printf("Go version: %s\n", runtime.Version())
-		fmt.Printf("OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-
-		// TODO: Add build information like rippled
-		// fmt.Printf("Git commit hash: %s\n", gitCommitHash)
-		// fmt.Printf("Git build branch: %s\n", gitBranch)
-		// fmt.Printf("Build timestamp: %s\n", buildTime)
+		fmt.Print(versionText(rootCmd.Version))
 	},
+}
+
+// versionText renders the version command output. VCS details (commit,
+// commit time, dirty marker) come from the binary's embedded build info
+// and are omitted when absent (e.g. `go run` or non-VCS builds), keeping
+// the base output stable.
+func versionText(version string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "go-xrpl version %s\n", version)
+	fmt.Fprintf(&b, "Go version: %s\n", runtime.Version())
+	fmt.Fprintf(&b, "OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	if info, ok := rdebug.ReadBuildInfo(); ok {
+		b.WriteString(vcsText(info.Settings))
+	}
+	return b.String()
+}
+
+// vcsText formats the vcs.* build settings: short commit hash with a
+// "(modified)" marker for dirty worktrees, plus the commit timestamp.
+func vcsText(settings []rdebug.BuildSetting) string {
+	kv := make(map[string]string, len(settings))
+	for _, s := range settings {
+		kv[s.Key] = s.Value
+	}
+
+	var b strings.Builder
+	if rev := kv["vcs.revision"]; rev != "" {
+		if len(rev) > 12 {
+			rev = rev[:12]
+		}
+		if kv["vcs.modified"] == "true" {
+			rev += " (modified)"
+		}
+		fmt.Fprintf(&b, "Git commit: %s\n", rev)
+	}
+	if t := kv["vcs.time"]; t != "" {
+		fmt.Fprintf(&b, "Commit time: %s\n", t)
+	}
+	return b.String()
 }
 
 func init() {

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"runtime"
+	rdebug "runtime/debug"
+	"strings"
+	"testing"
+)
+
+func TestVersionText_BaseLines(t *testing.T) {
+	out := versionText("1.2.3")
+	for _, want := range []string{
+		"go-xrpl version 1.2.3\n",
+		"Go version: " + runtime.Version() + "\n",
+		"OS/Arch: " + runtime.GOOS + "/" + runtime.GOARCH + "\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("versionText missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestVCSText(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings []rdebug.BuildSetting
+		want     string
+	}{
+		{
+			name:     "no vcs info keeps output stable",
+			settings: nil,
+			want:     "",
+		},
+		{
+			name: "clean revision with time",
+			settings: []rdebug.BuildSetting{
+				{Key: "vcs.revision", Value: "81f392511234abcd81f392511234abcd81f39251"},
+				{Key: "vcs.time", Value: "2026-06-09T10:00:00Z"},
+				{Key: "vcs.modified", Value: "false"},
+			},
+			want: "Git commit: 81f392511234\nCommit time: 2026-06-09T10:00:00Z\n",
+		},
+		{
+			name: "dirty worktree marked modified",
+			settings: []rdebug.BuildSetting{
+				{Key: "vcs.revision", Value: "81f392511234abcd81f392511234abcd81f39251"},
+				{Key: "vcs.modified", Value: "true"},
+			},
+			want: "Git commit: 81f392511234 (modified)\n",
+		},
+		{
+			name: "short revision not truncated",
+			settings: []rdebug.BuildSetting{
+				{Key: "vcs.revision", Value: "81f3925"},
+			},
+			want: "Git commit: 81f3925\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := vcsText(tt.settings); got != tt.want {
+				t.Errorf("vcsText = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ledger/service/account_query.go
+++ b/internal/ledger/service/account_query.go
@@ -1727,16 +1727,16 @@ func validateCredentialsOnLedger(targetLedger *ledger.Ledger, credentials []stri
 	seen := make(map[credKey]struct{})
 	pairs := make([]keylet.CredentialPair, 0, len(credentials))
 
-	// Get parent close time for expiry check.
-	// rippled uses ledger->info().parentCloseTime
-	parentCloseTime := targetLedger.ParentCloseTime()
-	parentCloseTimeSecs := uint32(parentCloseTime.Unix())
-	// Clamp to max uint32 if negative (shouldn't happen, but be safe)
-	if parentCloseTime.Unix() < 0 {
-		parentCloseTimeSecs = 0
-	}
-	if parentCloseTime.Unix() > math.MaxUint32 {
-		parentCloseTimeSecs = math.MaxUint32
+	// Parent close time in Ripple-epoch seconds for the expiry check;
+	// credential Expiration is stored in Ripple-epoch seconds.
+	var parentCloseTimeSecs uint32
+	if t := targetLedger.ParentCloseTime(); !t.IsZero() {
+		switch secs := toRippleTime(t); {
+		case secs > math.MaxUint32:
+			parentCloseTimeSecs = math.MaxUint32
+		case secs > 0:
+			parentCloseTimeSecs = uint32(secs)
+		}
 	}
 
 	for _, credHex := range credentials {
@@ -1769,7 +1769,7 @@ func validateCredentialsOnLedger(targetLedger *ledger.Ledger, credentials []stri
 
 		// Check expiry
 		// Reference: rippled DepositAuthorized.cpp: if (credentials::checkExpired(sleCred, ...))
-		if credEntry.Expiration != nil && parentCloseTimeSecs > *credEntry.Expiration {
+		if credential.CheckCredentialExpired(credEntry, parentCloseTimeSecs) {
 			return nil, fmt.Errorf("%w: credentials are expired", svcerr.ErrBadCredentials)
 		}
 

--- a/internal/ledger/service/account_query_more_test.go
+++ b/internal/ledger/service/account_query_more_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -260,6 +261,20 @@ func TestGetDepositAuthorized_Credentials(t *testing.T) {
 		}
 	})
 
+	t.Run("duplicate non-existent hashes report don't exist", func(t *testing.T) {
+		// rippled detects duplicates by (issuer, credentialType) read from the
+		// ledger, so identical unknown hashes fail the existence check first.
+		id := strings.Repeat("CD", 32)
+		_, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current",
+			[]string{id, id})
+		if !errors.Is(err, svcerr.ErrBadCredentials) {
+			t.Fatalf("want ErrBadCredentials, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "credentials don't exist") {
+			t.Fatalf("want \"credentials don't exist\" detail, got %v", err)
+		}
+	})
+
 	t.Run("unaccepted credential", func(t *testing.T) {
 		key := insertCredentialEntry(t, svc, srcID, issuerID, []byte("PENDING"), false, nil)
 		_, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current",
@@ -287,6 +302,39 @@ func TestGetDepositAuthorized_Credentials(t *testing.T) {
 			[]string{hexID, hexID})
 		if !errors.Is(err, svcerr.ErrBadCredentials) {
 			t.Fatalf("want ErrBadCredentials (duplicate), got %v", err)
+		}
+		if !strings.Contains(err.Error(), "duplicates in credentials") {
+			t.Fatalf("want \"duplicates in credentials\" detail, got %v", err)
+		}
+	})
+
+	t.Run("expired credential", func(t *testing.T) {
+		// Expiration in the distant past (Ripple epoch): parentCloseTime > exp.
+		exp := uint32(1)
+		key := insertCredentialEntry(t, svc, srcID, issuerID, []byte("EXPIRED"), true, &exp)
+		_, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current",
+			[]string{formatHashHex(key)})
+		if !errors.Is(err, svcerr.ErrBadCredentials) {
+			t.Fatalf("want ErrBadCredentials (expired), got %v", err)
+		}
+		if !strings.Contains(err.Error(), "credentials are expired") {
+			t.Fatalf("want \"credentials are expired\" detail, got %v", err)
+		}
+	})
+
+	t.Run("future expiration is not expired", func(t *testing.T) {
+		// Expiration one hour ahead in Ripple-epoch seconds. Guards against
+		// comparing a Ripple-epoch expiration with Unix-epoch close time,
+		// which would falsely expire every credential.
+		exp := uint32(toRippleTime(time.Now().Add(time.Hour)))
+		key := insertCredentialEntry(t, svc, srcID, issuerID, []byte("FUTURE"), true, &exp)
+		res, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current",
+			[]string{formatHashHex(key)})
+		if err != nil {
+			t.Fatalf("GetDepositAuthorized: %v", err)
+		}
+		if res.DepositAuthorized {
+			t.Errorf("no credential preauth entry: must not authorize")
 		}
 	})
 

--- a/internal/ledger/service/loadfee_autofill_test.go
+++ b/internal/ledger/service/loadfee_autofill_test.go
@@ -26,7 +26,7 @@ func TestGetAutofillFee_NoLoad(t *testing.T) {
 		t.Fatalf("ParseJSON: %v", err)
 	}
 
-	fee, err := svc.GetAutofillFee(parsed, false)
+	fee, err := svc.GetAutofillFee(parsed, false, 10, 1)
 	if err != nil {
 		t.Fatalf("GetAutofillFee: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestGetAutofillFee_LoadedLocal(t *testing.T) {
 		t.Fatalf("ParseJSON: %v", err)
 	}
 
-	fee, err := svc.GetAutofillFee(parsed, false)
+	fee, err := svc.GetAutofillFee(parsed, false, 10, 1)
 	if err != nil {
 		t.Fatalf("GetAutofillFee: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestGetAutofillFee_Unlimited(t *testing.T) {
 		t.Fatalf("ParseJSON: %v", err)
 	}
 
-	fee, err := svc.GetAutofillFee(parsed, true)
+	fee, err := svc.GetAutofillFee(parsed, true, 10, 1)
 	if err != nil {
 		t.Fatalf("GetAutofillFee: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestGetAutofillFee_Unlimited_HitsCeiling(t *testing.T) {
 		t.Fatalf("ParseJSON: %v", err)
 	}
 
-	if _, err := svc.GetAutofillFee(parsed, true); err == nil {
+	if _, err := svc.GetAutofillFee(parsed, true, 10, 1); err == nil {
 		t.Fatal("expected HighFeeError once scaled fee exceeds ceiling; got nil")
 	}
 }

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -19,13 +19,6 @@ import (
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
-// Autofill fee ceiling: feeDefault * mult / div. Mirrors rippled
-// Tuning.h:60-61.
-const (
-	defaultAutoFillFeeMultiplier uint64 = 10
-	defaultAutoFillFeeDivisor    uint64 = 1
-)
-
 // SubmitResult contains the result of submitting a transaction
 type SubmitResult struct {
 	// Result is the engine result code
@@ -240,16 +233,21 @@ func (s *Service) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint6
 //   - escalatedFee = toDrops(openLedgerFeeLevel-1, baseFee) + 1 (TxQ load)
 //   - returned fee = max(loadFee, escalatedFee)
 //
-// The returned fee is capped at feeDefault * defaultAutoFillFeeMultiplier
-// / defaultAutoFillFeeDivisor; exceeding it yields *svcerr.HighFeeError
-// (which errors.Is(svcerr.ErrHighFee) also matches). The ceiling check
-// runs regardless of unlimited — rippled applies it after the role-aware
+// The returned fee is capped at feeDefault * mult / div (the caller's
+// fee_mult_max / fee_div_max, default 10 / 1 per rippled Tuning.h);
+// exceeding it yields *svcerr.HighFeeError (which
+// errors.Is(svcerr.ErrHighFee) also matches). The ceiling check runs
+// regardless of unlimited — rippled applies it after the role-aware
 // scale, so privileged callers still cannot exceed mult/div.
 //
 // The source account is never read — matches rippled's getTxFee
 // (TransactionSign.cpp:765-836), so callers that have already supplied
 // Sequence must not receive an account-related error from this path.
-func (s *Service) GetAutofillFee(parsedTx tx.Transaction, unlimited bool) (uint64, error) {
+func (s *Service) GetAutofillFee(parsedTx tx.Transaction, unlimited bool, mult, div int) (uint64, error) {
+	if mult < 0 || div <= 0 {
+		return 0, fmt.Errorf("autofill fee: invalid fee limit factors mult=%d div=%d", mult, div)
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -283,7 +281,7 @@ func (s *Service) GetAutofillFee(parsedTx tx.Transaction, unlimited bool) (uint6
 		}
 	}
 
-	ceiling, ok := mulDivU64(feeDefault, defaultAutoFillFeeMultiplier, defaultAutoFillFeeDivisor)
+	ceiling, ok := mulDivU64(feeDefault, uint64(mult), uint64(div))
 	if !ok {
 		return 0, fmt.Errorf("autofill fee: ceiling overflow (feeDefault=%d)", feeDefault)
 	}

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -167,7 +167,7 @@ func (m *mockAccountChannelsLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockAccountChannelsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountChannelsLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
+func (m *mockAccountChannelsLedgerService) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockAccountChannelsLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -169,7 +169,7 @@ func (m *mockAccountCurrenciesLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockAccountCurrenciesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountCurrenciesLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
+func (m *mockAccountCurrenciesLedgerService) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockAccountCurrenciesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -147,11 +147,28 @@ func (m *mockLedgerService) GetNFTSellOffers(_ context.Context, nftID [32]byte, 
 func (m *mockLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
-	return 0, errors.New("not implemented")
+func (m *mockLedgerService) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
+	// Mirror the real service: networkFee capped at feeDefault*mult/div.
+	// No load in the mock, so networkFee == feeDefault == baseFee.
+	baseFee, _, _ := m.GetCurrentFees()
+	if div <= 0 {
+		return 0, errors.New("invalid fee divisor")
+	}
+	limit := baseFee * uint64(mult) / uint64(div)
+	if baseFee > limit {
+		return 0, &svcerr.HighFeeError{Fee: baseFee, Limit: limit}
+	}
+	return baseFee, nil
 }
 func (m *mockLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {
-	return 0, errors.New("not implemented")
+	if hasTicketSequence {
+		return 0, nil
+	}
+	info, err := m.GetAccountInfo(context.Background(), account, "current")
+	if err != nil {
+		return 0, err
+	}
+	return info.Sequence, nil
 }
 func (m *mockLedgerService) IsAmendmentBlocked() bool { return m.amendmentBlocked }
 func (m *mockLedgerService) GetClosedLedgerView() (types.LedgerStateView, error) {

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -163,7 +163,7 @@ func (m *mockAccountLinesLedgerService) GetNFTSellOffers(_ context.Context, nftI
 func (m *mockAccountLinesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountLinesLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
+func (m *mockAccountLinesLedgerService) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockAccountLinesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -165,7 +165,7 @@ func (m *mockAccountNFTsLedgerService) GetNFTSellOffers(_ context.Context, nftID
 func (m *mockAccountNFTsLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockAccountNFTsLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
+func (m *mockAccountNFTsLedgerService) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockAccountNFTsLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"time"
@@ -659,9 +660,9 @@ func TestDepositAuthorizedAddressValidation(t *testing.T) {
 
 // Credential Validation Tests
 
-// TestDepositAuthorizedCredentialValidation tests credential format and duplicate
-// detection at the handler level.
-// Reference: rippled DepositAuthorized.cpp — credential parsing loop + sorted.emplace()
+// TestDepositAuthorizedCredentialValidation tests handler-level credential format
+// checks and the mapping of service-level credential failures to rpcBAD_CREDENTIALS.
+// Reference: rippled DepositAuthorized.cpp — credential parsing loop
 func TestDepositAuthorizedCredentialValidation(t *testing.T) {
 	mock := newMockDepositAuthorizedLedgerService()
 	services := newDepositAuthorizedTestServices(mock)
@@ -680,42 +681,10 @@ func TestDepositAuthorizedCredentialValidation(t *testing.T) {
 	tests := []struct {
 		name          string
 		params        map[string]any
+		serviceErr    error
 		expectedError string
 		expectedCode  int
 	}{
-		{
-			name: "Duplicate credentials — exact same hash",
-			params: map[string]any{
-				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-				"credentials":         []string{validCred1, validCred1},
-			},
-			expectedError: "duplicates in credentials.",
-			expectedCode:  types.RpcBAD_CREDENTIALS,
-		},
-		{
-			name: "Duplicate credentials — case-insensitive match",
-			params: map[string]any{
-				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-				"credentials": []string{
-					"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-					"A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2",
-				},
-			},
-			expectedError: "duplicates in credentials.",
-			expectedCode:  types.RpcBAD_CREDENTIALS,
-		},
-		{
-			name: "Duplicate credentials — three entries with duplicate",
-			params: map[string]any{
-				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-				"credentials":         []string{validCred1, validCred2, validCred1},
-			},
-			expectedError: "duplicates in credentials.",
-			expectedCode:  types.RpcBAD_CREDENTIALS,
-		},
 		{
 			name: "Credential too short",
 			params: map[string]any{
@@ -767,11 +736,70 @@ func TestDepositAuthorizedCredentialValidation(t *testing.T) {
 			expectedError: "",
 			expectedCode:  0,
 		},
+		// Ledger-side credential failures surface from the service as
+		// ErrBadCredentials wrappers; the handler maps each to
+		// rpcBAD_CREDENTIALS with rippled's exact detail message.
+		// Reference: rippled DepositAuthorized.cpp RPC::inject_error(rpcBAD_CREDENTIALS, ...)
+		{
+			name: "Credential does not exist on ledger",
+			params: map[string]any{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{validCred1},
+			},
+			serviceErr:    fmt.Errorf("%w: credentials don't exist", svcerr.ErrBadCredentials),
+			expectedError: "credentials don't exist",
+			expectedCode:  types.RpcBAD_CREDENTIALS,
+		},
+		{
+			name: "Credential not accepted",
+			params: map[string]any{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{validCred1},
+			},
+			serviceErr:    fmt.Errorf("%w: credentials aren't accepted", svcerr.ErrBadCredentials),
+			expectedError: "credentials aren't accepted",
+			expectedCode:  types.RpcBAD_CREDENTIALS,
+		},
+		{
+			name: "Credential expired",
+			params: map[string]any{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{validCred1},
+			},
+			serviceErr:    fmt.Errorf("%w: credentials are expired", svcerr.ErrBadCredentials),
+			expectedError: "credentials are expired",
+			expectedCode:  types.RpcBAD_CREDENTIALS,
+		},
+		{
+			name: "Credential belongs to another account",
+			params: map[string]any{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{validCred1},
+			},
+			serviceErr:    fmt.Errorf("%w: credentials doesn't belong to the root account", svcerr.ErrBadCredentials),
+			expectedError: "credentials doesn't belong to the root account",
+			expectedCode:  types.RpcBAD_CREDENTIALS,
+		},
+		{
+			name: "Duplicate credentials by issuer and type",
+			params: map[string]any{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{validCred1, validCred2},
+			},
+			serviceErr:    fmt.Errorf("%w: duplicates in credentials", svcerr.ErrBadCredentials),
+			expectedError: "duplicates in credentials",
+			expectedCode:  types.RpcBAD_CREDENTIALS,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mock.depositAuthorizedErr = nil
+			mock.depositAuthorizedErr = tt.serviceErr
 			mock.depositAuthorizedResult = nil
 
 			paramsJSON, _ := json.Marshal(tt.params)

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -170,7 +170,7 @@ func (m *mockDepositAuthorizedLedgerService) GetNFTSellOffers(_ context.Context,
 func (m *mockDepositAuthorizedLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockDepositAuthorizedLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
+func (m *mockDepositAuthorizedLedgerService) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockDepositAuthorizedLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -692,7 +692,7 @@ func TestDepositAuthorizedCredentialValidation(t *testing.T) {
 				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 				"credentials":         []string{"ABCD"},
 			},
-			expectedError: "Invalid field 'credentials', an array of CredentialID(hash256).",
+			expectedError: "Invalid field 'credentials', not an array of CredentialID(hash256).",
 			expectedCode:  types.RpcINVALID_PARAMS,
 		},
 		{
@@ -702,7 +702,7 @@ func TestDepositAuthorizedCredentialValidation(t *testing.T) {
 				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 				"credentials":         []string{"ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"},
 			},
-			expectedError: "Invalid field 'credentials', an array of CredentialID(hash256).",
+			expectedError: "Invalid field 'credentials', not an array of CredentialID(hash256).",
 			expectedCode:  types.RpcINVALID_PARAMS,
 		},
 		{
@@ -722,7 +722,37 @@ func TestDepositAuthorizedCredentialValidation(t *testing.T) {
 					"0000000000000000000000000000000000000000000000000000000000000009",
 				},
 			},
-			expectedError: "Invalid field 'credentials', array too long.",
+			expectedError: "Invalid field 'credentials', not array too long.",
+			expectedCode:  types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "Empty credentials array",
+			params: map[string]any{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []string{},
+			},
+			expectedError: "Invalid field 'credentials', not is non-empty array of CredentialID(hash256).",
+			expectedCode:  types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "Non-array credentials",
+			params: map[string]any{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         "not-an-array",
+			},
+			expectedError: "Invalid field 'credentials', not is non-empty array of CredentialID(hash256).",
+			expectedCode:  types.RpcINVALID_PARAMS,
+		},
+		{
+			name: "Non-string credentials entry",
+			params: map[string]any{
+				"source_account":      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"destination_account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"credentials":         []any{1, 3},
+			},
+			expectedError: "Invalid field 'credentials', not an array of CredentialID(hash256).",
 			expectedCode:  types.RpcINVALID_PARAMS,
 		},
 		{

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -166,7 +166,7 @@ func (m *mockGatewayBalancesLedgerService) GetNFTSellOffers(_ context.Context, n
 func (m *mockGatewayBalancesLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockGatewayBalancesLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
+func (m *mockGatewayBalancesLedgerService) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockGatewayBalancesLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/handlers/deposit_authorized.go
+++ b/internal/rpc/handlers/deposit_authorized.go
@@ -65,14 +65,9 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		ledgerIndex = request.LedgerIndex.String()
 	}
 
-	// Call the service with credentials for ledger-side validation.
-	// TODO: The service layer is responsible for the following ledger-side
-	// credential checks (matching rippled DepositAuthorized.cpp):
-	//   1. Credential existence — read(keylet::credential(credH)) → rpcBAD_CREDENTIALS "credentials don't exist"
-	//   2. Credential accepted — (flags & lsfAccepted) → rpcBAD_CREDENTIALS "credentials aren't accepted"
-	//   3. Credential expiry — checkExpired(sleCred, parentCloseTime) → rpcBAD_CREDENTIALS "credentials are expired"
-	//   4. Credential ownership — sleCred[sfSubject] == srcAcct → rpcBAD_CREDENTIALS "credentials doesn't belong to the root account"
-	//   5. Credential duplicates by (issuer, credentialType) — rpcBAD_CREDENTIALS "duplicates in credentials"
+	// The service performs the ledger-side checks (source/destination
+	// existence, credential existence/acceptance/expiry/ownership/duplicates,
+	// and the direct + credential-based preauth lookups).
 	result, err := ctx.Services.Ledger.GetDepositAuthorized(
 		ctx.Context,
 		request.SourceAccount,
@@ -117,10 +112,11 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	return response, nil
 }
 
-// validateCredentialsFormat validates the credentials array format at the RPC level.
-// This performs format-only checks: non-empty, max size, valid hex hashes, no duplicates.
-// Ledger-side validation (existence, acceptance, expiry, ownership) is done in the
-// service layer.
+// validateCredentialsFormat validates the credentials array format at the RPC level:
+// non-empty, max size, valid hex hashes. Ledger-side validation (existence,
+// acceptance, expiry, ownership, duplicates by issuer+type) is done in the
+// service layer, matching rippled's order — duplicate hashes that don't exist
+// on ledger report "credentials don't exist", not "duplicates in credentials".
 // Reference: rippled DepositAuthorized.cpp credential parsing loop
 func validateCredentialsFormat(credentials []string) *types.RpcError {
 	if len(credentials) == 0 {
@@ -133,7 +129,6 @@ func validateCredentialsFormat(credentials []string) *types.RpcError {
 			"Invalid field 'credentials', array too long.")
 	}
 
-	seen := make(map[string]struct{}, len(credentials))
 	for _, credStr := range credentials {
 		// Each credential must be a valid 64-char hex string (32 bytes / 256 bits)
 		if len(credStr) != 64 {
@@ -144,17 +139,6 @@ func validateCredentialsFormat(credentials []string) *types.RpcError {
 			return types.RpcErrorInvalidParams(
 				"Invalid field 'credentials', an array of CredentialID(hash256).")
 		}
-
-		// Detect duplicate credential hashes.
-		// Reference: rippled DepositAuthorized.cpp — sorted.emplace() → rpcBAD_CREDENTIALS "duplicates in credentials"
-		// Note: rippled's full duplicate detection uses (issuer, credentialType) pairs from the
-		// ledger SLE. Here we catch the simpler case of identical hash strings, which is a strict
-		// subset. The service layer performs the full (issuer, credentialType) dedup with ledger data.
-		normalized := strings.ToUpper(credStr)
-		if _, exists := seen[normalized]; exists {
-			return types.RpcErrorBadCredentials("duplicates in credentials.")
-		}
-		seen[normalized] = struct{}{}
 	}
 
 	return nil

--- a/internal/rpc/handlers/deposit_authorized.go
+++ b/internal/rpc/handlers/deposit_authorized.go
@@ -19,9 +19,9 @@ type DepositAuthorizedMethod struct{}
 
 func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var request struct {
-		SourceAccount      string   `json:"source_account"`
-		DestinationAccount string   `json:"destination_account"`
-		Credentials        []string `json:"credentials,omitempty"`
+		SourceAccount      string          `json:"source_account"`
+		DestinationAccount string          `json:"destination_account"`
+		Credentials        json.RawMessage `json:"credentials,omitempty"`
 		types.LedgerSpecifier
 	}
 
@@ -47,12 +47,16 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, err
 	}
 
-	// Validate credentials array format before calling the service.
-	// This matches rippled DepositAuthorized.cpp credential validation order.
-	if len(request.Credentials) > 0 {
-		if err := validateCredentialsFormat(request.Credentials); err != nil {
+	// Validate credentials array format before calling the service. A
+	// present-but-empty (or null / non-array) credentials field is an
+	// error, so presence must be distinguished from emptiness.
+	var credentials []string
+	if request.Credentials != nil {
+		creds, err := parseCredentialsFormat(request.Credentials)
+		if err != nil {
 			return nil, err
 		}
+		credentials = creds
 	}
 
 	if err := RequireLedgerService(ctx.Services); err != nil {
@@ -73,7 +77,7 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		request.SourceAccount,
 		request.DestinationAccount,
 		ledgerIndex,
-		request.Credentials,
+		credentials,
 	)
 	if err != nil {
 		switch {
@@ -105,43 +109,51 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	}
 
 	// Echo credentials in response if provided (matches rippled)
-	if len(request.Credentials) > 0 {
-		response["credentials"] = request.Credentials
+	if len(credentials) > 0 {
+		response["credentials"] = credentials
 	}
 
 	return response, nil
 }
 
-// validateCredentialsFormat validates the credentials array format at the RPC level:
-// non-empty, max size, valid hex hashes. Ledger-side validation (existence,
-// acceptance, expiry, ownership, duplicates by issuer+type) is done in the
-// service layer, matching rippled's order — duplicate hashes that don't exist
-// on ledger report "credentials don't exist", not "duplicates in credentials".
+// parseCredentialsFormat validates the credentials array format at the RPC
+// level: a non-empty array, max size, valid hex hashes. Ledger-side
+// validation (existence, acceptance, expiry, ownership, duplicates by
+// issuer+type) is done in the service layer, matching rippled's order —
+// duplicate hashes that don't exist on ledger report "credentials don't
+// exist", not "duplicates in credentials".
 // Reference: rippled DepositAuthorized.cpp credential parsing loop
-func validateCredentialsFormat(credentials []string) *types.RpcError {
-	if len(credentials) == 0 {
-		return types.RpcErrorInvalidParams(
-			"Invalid field 'credentials', is non-empty array of CredentialID(hash256).")
+func parseCredentialsFormat(raw json.RawMessage) ([]string, *types.RpcError) {
+	var entries []json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil || len(entries) == 0 {
+		return nil, types.RpcErrorExpectedField("credentials",
+			"is non-empty array of CredentialID(hash256)")
 	}
 
-	if len(credentials) > maxCredentialsArraySize {
-		return types.RpcErrorInvalidParams(
-			"Invalid field 'credentials', array too long.")
+	if len(entries) > maxCredentialsArraySize {
+		return nil, types.RpcErrorExpectedField("credentials", "array too long")
 	}
 
-	for _, credStr := range credentials {
+	credentials := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		var credStr string
+		if err := json.Unmarshal(entry, &credStr); err != nil {
+			return nil, types.RpcErrorExpectedField("credentials",
+				"an array of CredentialID(hash256)")
+		}
 		// Each credential must be a valid 64-char hex string (32 bytes / 256 bits)
 		if len(credStr) != 64 {
-			return types.RpcErrorInvalidParams(
-				"Invalid field 'credentials', an array of CredentialID(hash256).")
+			return nil, types.RpcErrorExpectedField("credentials",
+				"an array of CredentialID(hash256)")
 		}
 		if _, err := hex.DecodeString(credStr); err != nil {
-			return types.RpcErrorInvalidParams(
-				"Invalid field 'credentials', an array of CredentialID(hash256).")
+			return nil, types.RpcErrorExpectedField("credentials",
+				"an array of CredentialID(hash256)")
 		}
+		credentials = append(credentials, credStr)
 	}
 
-	return nil
+	return credentials, nil
 }
 
 func (m *DepositAuthorizedMethod) RequiredRole() types.Role {

--- a/internal/rpc/handlers/registry.go
+++ b/internal/rpc/handlers/registry.go
@@ -91,14 +91,12 @@ func RegisterAll(registry *types.MethodRegistry) {
 	registry.Register("amm_info", &AMMInfoMethod{})
 	registry.Register("vault_info", &VaultInfoMethod{})
 	registry.Register("get_aggregate_price", &GetAggregatePriceMethod{})
-}
 
-// RegisterWebSocketOnly registers commands that only make sense on a
-// persistent WebSocket session. The HTTP server intentionally does NOT
-// call this — clients hitting subscribe / unsubscribe over HTTP get
-// methodNotFound (matching rippled), which is a clearer discovery
-// signal than "method exists, returns notSupported".
-func RegisterWebSocketOnly(registry *types.MethodRegistry) {
+	// subscribe/unsubscribe are in the common table like rippled's
+	// Handler.cpp: over plain JSON-RPC they serve the no-infoSub gating
+	// (invalidParams / noPermission / notSupported); the WebSocket
+	// dispatch intercepts both commands before registry lookup and runs
+	// the real subscription implementation.
 	registry.Register("subscribe", &SubscribeMethod{})
 	registry.Register("unsubscribe", &UnsubscribeMethod{})
 }

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -198,7 +198,18 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	}
 	sort.Strings(response.DestinationCurrencies)
 
-	return response, nil
+	// Return a map so the server envelope flattens the fields directly
+	// into `result` like rippled; non-map results get wrapped under
+	// `result.data`, which no XRPL client understands.
+	encoded, mErr := json.Marshal(response)
+	if mErr != nil {
+		return nil, types.RpcErrorInternal("Internal error.")
+	}
+	var flat map[string]any
+	if uErr := json.Unmarshal(encoded, &flat); uErr != nil {
+		return nil, types.RpcErrorInternal("Internal error.")
+	}
+	return flat, nil
 }
 
 func (m *RipplePathFindMethod) RequiredRole() types.Role {

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -119,6 +119,21 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		return nil, rpcErr
 	}
 
+	// rippled parses domain as a hex uint256 (PathRequest::parseJson) and
+	// threads it into PermissionedDEX-restricted pathfinding. go-xrpl's
+	// pathfinder has no domain support, so a valid domain reports
+	// notSupported rather than silently returning unrestricted paths.
+	if rawDomain, ok := probe["domain"]; ok {
+		var domainStr string
+		if err := json.Unmarshal(rawDomain, &domainStr); err != nil {
+			return nil, types.RpcErrorDomainMalformed("Domain is malformed.")
+		}
+		if decoded, err := hex.DecodeString(domainStr); err != nil || len(decoded) != 32 {
+			return nil, types.RpcErrorDomainMalformed("Domain is malformed.")
+		}
+		return nil, types.RpcErrorNotSupported("domain-restricted pathfinding is not supported")
+	}
+
 	// Ledger selection: an explicit ledger_hash/ledger_index resolves a
 	// specific ledger and merges its metadata into the response, mirroring
 	// rippled's RPC::lookupLedger merge; otherwise the closed ledger is used

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -12,37 +14,42 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// ripplePathFindRequest represents the ripple_path_find RPC request params.
-type ripplePathFindRequest struct {
-	SourceAccount      string          `json:"source_account"`
-	DestinationAccount string          `json:"destination_account"`
-	DestinationAmount  json.RawMessage `json:"destination_amount"`
-	SendMax            json.RawMessage `json:"send_max,omitempty"`
-	SourceCurrencies   []struct {
-		Currency string `json:"currency"`
-		Issuer   string `json:"issuer,omitempty"`
-	} `json:"source_currencies,omitempty"`
-}
+// maxSrcCurrencies is the maximum number of explicit source_currencies
+// entries (rippled RPC::Tuning::max_src_cur).
+const maxSrcCurrencies = 18
 
 // ripplePathFindResponse represents the ripple_path_find RPC response.
-// Reference: rippled PathRequest::doUpdate() builds newStatus with these fields.
+// Reference: rippled PathRequest::doUpdate() builds newStatus with these
+// fields; the ledger fields are merged in by doRipplePathFind via
+// RPC::lookupLedger when the caller selects an explicit ledger
+// (RipplePathFind.cpp:160-174). Note rippled's final reply carries no
+// destination_tag: PathRequest::isValid sets it on jvStatus, but doUpdate
+// replaces jvStatus wholesale with newStatus, which never includes it.
 type ripplePathFindResponse struct {
 	Alternatives          []pathAlternativeJSON `json:"alternatives"`
 	DestinationAccount    string                `json:"destination_account"`
 	DestinationAmount     any                   `json:"destination_amount"`
 	DestinationCurrencies []string              `json:"destination_currencies"`
 	FullReply             bool                  `json:"full_reply"`
+	ID                    json.RawMessage       `json:"id,omitempty"`
 	SourceAccount         string                `json:"source_account"`
+	LedgerCurrentIndex    uint32                `json:"ledger_current_index,omitempty"`
+	LedgerHash            string                `json:"ledger_hash,omitempty"`
+	LedgerIndex           uint32                `json:"ledger_index,omitempty"`
+	Validated             *bool                 `json:"validated,omitempty"`
 }
 
 type pathAlternativeJSON struct {
-	PathsCanonical []any                `json:"paths_canonical"`
-	PathsComputed  [][]payment.PathStep `json:"paths_computed"`
-	SourceAmount   any                  `json:"source_amount"`
+	// DestinationAmount is only present for convert-all requests
+	// (destination_amount: -1), reporting the maximum deliverable amount.
+	DestinationAmount any                  `json:"destination_amount,omitempty"`
+	PathsCanonical    []any                `json:"paths_canonical"`
+	PathsComputed     [][]payment.PathStep `json:"paths_computed"`
+	SourceAmount      any                  `json:"source_amount"`
 }
 
 // RipplePathFindMethod handles the ripple_path_find RPC method.
-// Reference: rippled RipplePathFind.cpp
+// Reference: rippled RipplePathFind.cpp + PathRequest::parseJson/isValid.
 type RipplePathFindMethod struct{}
 
 func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
@@ -52,108 +59,133 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	}
 	defer release()
 
-	var request ripplePathFindRequest
-	if err := json.Unmarshal(params, &request); err != nil {
-		return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
-			"Invalid parameters: "+err.Error())
+	probe := map[string]json.RawMessage{}
+	if params != nil {
+		if err := json.Unmarshal(params, &probe); err != nil {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters: " + err.Error())
+		}
 	}
 
-	// Validate required fields
-	if request.SourceAccount == "" {
+	// Field validation follows rippled PathRequest::parseJson order exactly.
+	rawSrc, ok := probe["source_account"]
+	if !ok {
 		return nil, types.RpcErrorSrcActMissing("Source account not provided.")
 	}
-	if request.DestinationAccount == "" {
-		return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
-			"Missing field 'destination_account'")
+	rawDst, ok := probe["destination_account"]
+	if !ok {
+		return nil, types.RpcErrorDstActMissing("Destination account not provided.")
 	}
-	if request.DestinationAmount == nil {
-		return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
-			"Missing field 'destination_amount'")
+	rawDstAmount, ok := probe["destination_amount"]
+	if !ok {
+		return nil, types.RpcErrorDstAmtMissing("Destination amount/currency/issuer is missing.")
 	}
 
-	// Decode accounts
-	srcAccount, err := state.DecodeAccountID(request.SourceAccount)
+	srcAccount, ok := decodeAccountRaw(rawSrc)
+	if !ok {
+		return nil, types.RpcErrorSrcActMalformed("Source account is malformed.")
+	}
+	dstAccount, ok := decodeAccountRaw(rawDst)
+	if !ok {
+		return nil, types.RpcErrorDstActMalformed("Destination account is malformed.")
+	}
+
+	dstAmount, err := parsePathFindAmount(rawDstAmount)
 	if err != nil {
-		return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
-			"Invalid source_account")
-	}
-	dstAccount, err := state.DecodeAccountID(request.DestinationAccount)
-	if err != nil {
-		return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
-			"Invalid destination_account")
+		return nil, types.RpcErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
 	}
 
-	// Parse destination amount
-	dstAmount, dErr := parsePathFindAmount(request.DestinationAmount)
-	if dErr != nil {
-		return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
-			fmt.Sprintf("Invalid destination_amount: %v", dErr))
+	// destination_amount of exactly -1 selects convert-all mode.
+	// Reference: rippled PathRequest::parseJson convert_all_ check.
+	convertAll := dstAmount.Value() == "-1"
+	if !convertAll && dstAmount.Signum() <= 0 {
+		return nil, types.RpcErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
 	}
 
-	// Parse optional send_max
 	var sendMax *state.Amount
-	if request.SendMax != nil {
-		amt, smErr := parsePathFindAmount(request.SendMax)
-		if smErr != nil {
-			return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
-				fmt.Sprintf("Invalid send_max: %v", smErr))
+	if rawSendMax, hasSendMax := probe["send_max"]; hasSendMax {
+		// send_max requires destination_amount to be -1.
+		if !convertAll {
+			return nil, types.RpcErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
+		}
+		amt, smErr := parsePathFindAmount(rawSendMax)
+		if smErr != nil || (amt.Signum() <= 0 && amt.Value() != "-1") {
+			return nil, types.RpcErrorSendMaxMalformed("SendMax amount malformed.")
 		}
 		sendMax = &amt
 	}
 
-	// Parse optional source_currencies
-	var srcCurrencies []payment.Issue
-	for _, sc := range request.SourceCurrencies {
-		issue := payment.Issue{Currency: sc.Currency}
-		if sc.Issuer != "" {
-			issuerID, decErr := state.DecodeAccountID(sc.Issuer)
-			if decErr != nil {
-				return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
-					"Invalid source_currencies issuer")
+	srcCurrencies, rpcErr := parseSourceCurrencies(probe, srcAccount, sendMax)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	// Ledger selection: an explicit ledger_hash/ledger_index resolves a
+	// specific ledger and merges its metadata into the response, mirroring
+	// rippled's RPC::lookupLedger merge; otherwise the closed ledger is used
+	// with no ledger fields in the reply.
+	view, meta, rpcErr := resolvePathFindLedger(ctx, probe)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	// Existence checks. Reference: rippled PathRequest::isValid.
+	if exists, _ := view.Exists(keylet.Account(srcAccount)); !exists {
+		return nil, types.RpcErrorSrcActNotFound("Source account not found.")
+	}
+	if exists, _ := view.Exists(keylet.Account(dstAccount)); !exists {
+		// Only XRP can be sent to a non-existent account, and the payment
+		// must meet the account reserve.
+		if !dstAmount.IsNative() {
+			return nil, types.RpcErrorActNotFound("Account not found.")
+		}
+		if !convertAll {
+			_, reserveBase, _ := ctx.Services.Ledger.GetCurrentFees()
+			if dstAmount.Drops() < int64(reserveBase) {
+				return nil, types.RpcErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
 			}
-			issue.Issuer = issuerID
-		} else if sc.Currency != "XRP" && sc.Currency != "" {
-			issue.Issuer = srcAccount
-		}
-		srcCurrencies = append(srcCurrencies, issue)
-	}
-
-	view, err := ctx.Services.Ledger.GetClosedLedgerView()
-	if err != nil {
-		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
-			"No closed ledger available")
-	}
-
-	// Check destination account exists for non-XRP destination amounts.
-	// Reference: rippled PathRequest.cpp lines 199-206
-	if !dstAmount.IsNative() {
-		exists, _ := view.Exists(keylet.Account(dstAccount))
-		if !exists {
-			return nil, types.RpcErrorActNotFound("Destination account not found.")
 		}
 	}
 
-	// Run pathfinding
-	pr := pathfinder.NewPathRequest(srcAccount, dstAccount, dstAmount, sendMax, srcCurrencies, false)
+	// Run pathfinding at the production search level (rippled PATH_SEARCH).
+	pr := pathfinder.NewPathRequest(srcAccount, dstAccount, dstAmount, sendMax, srcCurrencies, convertAll)
 	result := pr.Execute(view)
+	if result.SourceCurrencyOverflow {
+		return nil, types.RpcErrorInternal("Internal error.")
+	}
 
-	// Build response matching rippled PathRequest::doUpdate() format.
-	// Reference: rippled PathRequest.cpp lines 691-777
 	response := ripplePathFindResponse{
-		DestinationAccount:    request.DestinationAccount,
+		DestinationAccount:    state.EncodeAccountIDSafe(dstAccount),
 		DestinationAmount:     formatAmountJSON(dstAmount),
 		DestinationCurrencies: result.DestinationCurrencies,
-		FullReply:             true, // rippled sets !fast; legacy path always does a full reply
-		SourceAccount:         request.SourceAccount,
+		FullReply:             true, // legacy path always does a full reply (!fast)
+		ID:                    probe["id"],
+		SourceAccount:         state.EncodeAccountIDSafe(srcAccount),
+	}
+
+	if meta != nil {
+		if meta.current {
+			response.LedgerCurrentIndex = meta.seq
+		} else {
+			response.LedgerHash = FormatLedgerHash(meta.hash)
+			response.LedgerIndex = meta.seq
+		}
+		response.Validated = &meta.validated
 	}
 
 	for _, alt := range result.Alternatives {
+		pathsComputed := alt.PathsComputed
+		if pathsComputed == nil {
+			pathsComputed = [][]payment.PathStep{}
+		}
 		jAlt := pathAlternativeJSON{
-			// paths_canonical is always an empty array for the legacy ripple_path_find API.
-			// Reference: rippled PathRequest.cpp line 653
+			// paths_canonical is always an empty array for the legacy
+			// ripple_path_find API (rippled PathRequest::findPaths).
 			PathsCanonical: []any{},
-			PathsComputed:  alt.PathsComputed,
+			PathsComputed:  pathsComputed,
 			SourceAmount:   formatAmountJSON(alt.SourceAmount),
+		}
+		if convertAll {
+			jAlt.DestinationAmount = formatAmountJSON(alt.DestinationAmount)
 		}
 		response.Alternatives = append(response.Alternatives, jAlt)
 	}
@@ -164,6 +196,7 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	if response.DestinationCurrencies == nil {
 		response.DestinationCurrencies = []string{}
 	}
+	sort.Strings(response.DestinationCurrencies)
 
 	return response, nil
 }
@@ -178,6 +211,212 @@ func (m *RipplePathFindMethod) SupportedApiVersions() []int {
 
 func (m *RipplePathFindMethod) RequiredCondition() types.Condition {
 	return types.NeedsCurrentLedger
+}
+
+// decodeAccountRaw decodes a JSON string into an AccountID. Returns false
+// for non-string values or malformed addresses.
+func decodeAccountRaw(raw json.RawMessage) ([20]byte, bool) {
+	var addr string
+	if err := json.Unmarshal(raw, &addr); err != nil {
+		return [20]byte{}, false
+	}
+	id, err := state.DecodeAccountID(addr)
+	if err != nil {
+		return [20]byte{}, false
+	}
+	return id, true
+}
+
+// parseSourceCurrencies validates the optional source_currencies array,
+// following rippled PathRequest::parseJson: max 18 entries, mandatory
+// currency, optional issuer, XRP may not carry an issuer, a missing issuer
+// defaults to the source account, and entries are reconciled against
+// send_max when present.
+func parseSourceCurrencies(
+	probe map[string]json.RawMessage,
+	srcAccount [20]byte,
+	sendMax *state.Amount,
+) ([]payment.Issue, *types.RpcError) {
+	rawSC, ok := probe["source_currencies"]
+	if !ok {
+		return nil, nil
+	}
+
+	var entries []json.RawMessage
+	if err := json.Unmarshal(rawSC, &entries); err != nil || len(entries) == 0 || len(entries) > maxSrcCurrencies {
+		return nil, types.RpcErrorSrcCurMalformed("Source currency is malformed.")
+	}
+
+	var sendMaxCurrency string
+	var sendMaxIssuer [20]byte
+	if sendMax != nil {
+		sendMaxCurrency = "XRP"
+		if !sendMax.IsNative() {
+			sendMaxCurrency = sendMax.Currency
+			sendMaxIssuer, _ = state.DecodeAccountID(sendMax.Issuer)
+		}
+	}
+
+	var srcCurrencies []payment.Issue
+	seen := make(map[payment.Issue]bool)
+	add := func(issue payment.Issue) {
+		if !seen[issue] {
+			seen[issue] = true
+			srcCurrencies = append(srcCurrencies, issue)
+		}
+	}
+
+	for _, raw := range entries {
+		var sc struct {
+			Currency *string         `json:"currency"`
+			Issuer   json.RawMessage `json:"issuer"`
+		}
+		if err := json.Unmarshal(raw, &sc); err != nil || sc.Currency == nil || !isValidCurrencyCode(*sc.Currency) {
+			return nil, types.RpcErrorSrcCurMalformed("Source currency is malformed.")
+		}
+		currency := canonCurrency(*sc.Currency)
+		isXRPCur := currency == "XRP"
+
+		var issuerID [20]byte
+		if sc.Issuer != nil && !isJSONNull(sc.Issuer) {
+			var issuerStr string
+			if err := json.Unmarshal(sc.Issuer, &issuerStr); err != nil {
+				return nil, types.RpcErrorSrcIsrMalformed("Source issuer is malformed.")
+			}
+			id, err := state.DecodeAccountID(issuerStr)
+			if err != nil {
+				return nil, types.RpcErrorSrcIsrMalformed("Source issuer is malformed.")
+			}
+			issuerID = id
+		}
+
+		if isXRPCur {
+			if issuerID != ([20]byte{}) {
+				return nil, types.RpcErrorSrcCurMalformed("Source currency is malformed.")
+			}
+		} else if issuerID == ([20]byte{}) {
+			issuerID = srcAccount
+		}
+
+		if sendMax != nil {
+			// If the currencies don't match, ignore the source currency.
+			if currency != canonCurrency(sendMaxCurrency) {
+				continue
+			}
+			// If neither issuer is the source and they are not equal, the
+			// source issuer is illegal.
+			if issuerID != srcAccount && sendMaxIssuer != srcAccount && issuerID != sendMaxIssuer {
+				return nil, types.RpcErrorSrcIsrMalformed("Source issuer is malformed.")
+			}
+			// If both are the source, use the source; otherwise use the one
+			// that's not the source.
+			if issuerID != srcAccount {
+				add(payment.Issue{Currency: currency, Issuer: issuerID})
+			} else if sendMaxIssuer != srcAccount {
+				add(payment.Issue{Currency: currency, Issuer: sendMaxIssuer})
+			} else {
+				add(payment.Issue{Currency: currency, Issuer: srcAccount})
+			}
+			continue
+		}
+
+		add(payment.Issue{Currency: currency, Issuer: issuerID})
+	}
+
+	return srcCurrencies, nil
+}
+
+// pathFindLedgerMeta carries the metadata of an explicitly selected ledger,
+// merged into the response like rippled's RPC::lookupLedger result.
+type pathFindLedgerMeta struct {
+	current   bool
+	seq       uint32
+	hash      [32]byte
+	validated bool
+}
+
+// resolvePathFindLedger selects the ledger to run pathfinding on. With no
+// ledger_hash/ledger_index the closed ledger is used (rippled's pathfinding
+// default) and no metadata is reported.
+func resolvePathFindLedger(
+	ctx *types.RpcContext,
+	probe map[string]json.RawMessage,
+) (types.LedgerStateView, *pathFindLedgerMeta, *types.RpcError) {
+	if rawHash, ok := probe["ledger_hash"]; ok && !isJSONNull(rawHash) {
+		var hashStr string
+		if err := json.Unmarshal(rawHash, &hashStr); err != nil {
+			return nil, nil, types.RpcErrorInvalidParams("ledgerHashMalformed")
+		}
+		rawBytes, err := hex.DecodeString(hashStr)
+		if err != nil || len(rawBytes) != 32 {
+			return nil, nil, types.RpcErrorInvalidParams("ledgerHashMalformed")
+		}
+		var h [32]byte
+		copy(h[:], rawBytes)
+		src, ok := ctx.Services.Ledger.(types.LedgerViewSource)
+		if !ok {
+			return nil, nil, types.RpcErrorLgrNotFound("ledgerNotFound")
+		}
+		view, reader, lerr := src.GetLedgerViewByHash(h)
+		if lerr != nil || view == nil {
+			return nil, nil, types.RpcErrorLgrNotFound("ledgerNotFound")
+		}
+		return view, &pathFindLedgerMeta{
+			seq:       reader.Sequence(),
+			hash:      reader.Hash(),
+			validated: reader.IsValidated(),
+		}, nil
+	}
+
+	if rawIdx, ok := probe["ledger_index"]; ok && !isJSONNull(rawIdx) {
+		var li types.LedgerIndex
+		if err := json.Unmarshal(rawIdx, &li); err != nil {
+			return nil, nil, types.RpcErrorInvalidParams("ledgerIndexMalformed")
+		}
+		selector := li.String()
+		switch selector {
+		case "", "current", "closed", "validated":
+			view, err := ctx.Services.Ledger.GetClosedLedgerView()
+			if err != nil {
+				return nil, nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent", "Current ledger is unavailable.")
+			}
+			info := ctx.Services.Ledger.GetServerInfo()
+			if selector == "current" {
+				return view, &pathFindLedgerMeta{
+					current: true,
+					seq:     ctx.Services.Ledger.GetCurrentLedgerIndex(),
+				}, nil
+			}
+			return view, &pathFindLedgerMeta{
+				seq:       info.ClosedLedgerSeq,
+				hash:      info.ClosedLedgerHash,
+				validated: info.HaveValidated && info.ValidatedLedgerSeq == info.ClosedLedgerSeq,
+			}, nil
+		}
+		seq, perr := strconv.ParseUint(selector, 10, 32)
+		if perr != nil {
+			return nil, nil, types.RpcErrorInvalidParams("ledgerIndexMalformed")
+		}
+		src, ok := ctx.Services.Ledger.(types.LedgerViewSource)
+		if !ok {
+			return nil, nil, types.RpcErrorLgrNotFound("ledgerNotFound")
+		}
+		view, reader, lerr := src.GetLedgerViewBySeq(uint32(seq))
+		if lerr != nil || view == nil {
+			return nil, nil, types.RpcErrorLgrNotFound("ledgerNotFound")
+		}
+		return view, &pathFindLedgerMeta{
+			seq:       reader.Sequence(),
+			hash:      reader.Hash(),
+			validated: reader.IsValidated(),
+		}, nil
+	}
+
+	view, err := ctx.Services.Ledger.GetClosedLedgerView()
+	if err != nil {
+		return nil, nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent", "Current ledger is unavailable.")
+	}
+	return view, nil, nil
 }
 
 // formatAmountJSON formats an Amount for JSON output, matching rippled's
@@ -195,9 +434,10 @@ func formatAmountJSON(amt state.Amount) any {
 	}
 }
 
-// parsePathFindAmount parses a JSON amount for path finding. A bad numeric
-// string returns an error so the caller can surface invalidParams instead of
-// silently treating malformed input as zero drops.
+// parsePathFindAmount parses a JSON amount for path finding, mirroring
+// rippled amountFromJsonNoThrow: a string is XRP drops; an object must be a
+// non-XRP issued amount with a valid issuer (XRP may not be specified as an
+// object).
 func parsePathFindAmount(raw json.RawMessage) (state.Amount, error) {
 	// Try as string first (XRP drops)
 	var strVal string
@@ -211,21 +451,26 @@ func parsePathFindAmount(raw json.RawMessage) (state.Amount, error) {
 
 	// Try as IOU object
 	var iou struct {
-		Currency string `json:"currency"`
-		Issuer   string `json:"issuer"`
-		Value    string `json:"value"`
+		Currency *string `json:"currency"`
+		Issuer   string  `json:"issuer"`
+		Value    string  `json:"value"`
 	}
 	if err := json.Unmarshal(raw, &iou); err != nil {
 		return state.Amount{}, fmt.Errorf("amount must be string or {currency,issuer,value} object")
 	}
 
-	if iou.Currency == "XRP" || iou.Currency == "" {
-		drops, err := strconv.ParseInt(iou.Value, 10, 64)
-		if err != nil {
-			return state.Amount{}, fmt.Errorf("invalid XRP amount value %q: %w", iou.Value, err)
-		}
-		return state.NewXRPAmountFromInt(drops), nil
+	if iou.Currency == nil || !isValidCurrencyCode(*iou.Currency) {
+		return state.Amount{}, fmt.Errorf("invalid currency")
+	}
+	if *iou.Currency == "" || *iou.Currency == "XRP" {
+		return state.Amount{}, fmt.Errorf("XRP may not be specified as an object")
+	}
+	if _, err := state.DecodeAccountID(iou.Issuer); err != nil {
+		return state.Amount{}, fmt.Errorf("invalid issuer")
+	}
+	if _, err := strconv.ParseFloat(iou.Value, 64); err != nil {
+		return state.Amount{}, fmt.Errorf("invalid amount value %q", iou.Value)
 	}
 
-	return state.NewIssuedAmountFromDecimalString(iou.Value, iou.Currency, iou.Issuer), nil
+	return state.NewIssuedAmountFromDecimalString(iou.Value, *iou.Currency, iou.Issuer), nil
 }

--- a/internal/rpc/handlers/sign.go
+++ b/internal/rpc/handlers/sign.go
@@ -12,13 +12,6 @@ import (
 type SignMethod struct{}
 
 func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	// Parse fee_mult_max / fee_div_max first with proper type validation,
-	// matching rippled's checkFee() in TransactionSign.cpp.
-	feeOpts, rpcErr := parseFeeOptions(params)
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
-
 	var request struct {
 		TxJson     json.RawMessage `json:"tx_json"`
 		Secret     string          `json:"secret,omitempty"`
@@ -47,7 +40,7 @@ func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any,
 		SeedHex:    request.SeedHex,
 		Passphrase: request.Passphrase,
 		KeyType:    request.KeyType,
-	}, request.Offline, ctx.Unlimited, ctx.ApiVersion, feeOpts)
+	}, request.Offline, ctx.Unlimited, ctx.ApiVersion, params)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}

--- a/internal/rpc/handlers/sign.go
+++ b/internal/rpc/handlers/sign.go
@@ -47,7 +47,7 @@ func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any,
 		SeedHex:    request.SeedHex,
 		Passphrase: request.Passphrase,
 		KeyType:    request.KeyType,
-	}, request.Offline, ctx.ApiVersion, feeOpts)
+	}, request.Offline, ctx.IsAdmin, ctx.ApiVersion, feeOpts)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}

--- a/internal/rpc/handlers/sign.go
+++ b/internal/rpc/handlers/sign.go
@@ -47,7 +47,7 @@ func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any,
 		SeedHex:    request.SeedHex,
 		Passphrase: request.Passphrase,
 		KeyType:    request.KeyType,
-	}, request.Offline, ctx.IsAdmin, ctx.ApiVersion, feeOpts)
+	}, request.Offline, ctx.Unlimited, ctx.ApiVersion, feeOpts)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 )
@@ -149,8 +151,9 @@ type signResult struct {
 //
 // The feeOpts parameter controls auto-fee behavior: if Fee is not present in
 // tx_json and auto-fill is active, the network fee is computed and checked
-// against the limit baseFee * feeOpts.Mult / feeOpts.Div.
-func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, txJSON json.RawMessage, creds signCredentials, offline bool, apiVersion int, feeOpts feeOptions) (*signResult, *types.RpcError) {
+// against the limit feeDefault * feeOpts.Mult / feeOpts.Div. unlimited
+// mirrors rippled's isUnlimited(role) load-scaling carve-out.
+func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, txJSON json.RawMessage, creds signCredentials, offline bool, unlimited bool, apiVersion int, feeOpts feeOptions) (*signResult, *types.RpcError) {
 	// Check if ledger service is available (needed for auto-filling fields)
 	if !offline && (services == nil || services.Ledger == nil) {
 		return nil, types.RpcErrorInternal("Ledger service not available")
@@ -190,38 +193,31 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 		txMap["Account"] = address
 	}
 
-	// Fill in missing fields if not offline
+	// Fill in missing fields if not offline. Order matches rippled's
+	// transactionPreProcessImpl (TransactionSign.cpp:454-505): source
+	// account existence, then Sequence, NetworkID, and Fee.
 	if !offline {
-		// Auto-fill Fee if not present, with fee_mult_max/fee_div_max limit check.
-		// This matches rippled's checkFee() in TransactionSign.cpp.
-		if _, ok := txMap["Fee"]; !ok {
-			baseFee, _, _ := services.Ledger.GetCurrentFees()
-
-			// In a full implementation, networkFee would incorporate load-based
-			// fee escalation. For now, networkFee == baseFee.
-			networkFee := baseFee
-
-			// Compute the fee limit: baseFee * mult / div
-			// This matches rippled's mulDiv(feeDefault, mult, div).
-			limit := baseFee * uint64(feeOpts.Mult) / uint64(feeOpts.Div)
-
-			if networkFee > limit {
-				return nil, types.RpcErrorHighFee(
-					fmt.Sprintf("Fee of %d exceeds the requested tx limit of %d",
-						networkFee, limit))
+		// The source account must exist in the current ledger, whether or
+		// not Sequence is supplied (rpcSRC_ACT_NOT_FOUND).
+		if _, err := services.Ledger.GetAccountInfo(ctx, address, "current"); err != nil {
+			if errors.Is(err, svcerr.ErrAccountNotFound) {
+				return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 			}
-
-			txMap["Fee"] = formatUint64AsString(networkFee)
+			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to read source account: %v", err))
 		}
 
+		// Auto-fill Sequence from the open ledger / TxQ; a present
+		// TicketSequence supplies the sequence instead (Sequence = 0).
 		if _, ok := txMap["Sequence"]; !ok {
-			// TODO: When ledger lookup is available, auto-fill from account state.
-			// For now, attempt to get account info.
-			info, err := services.Ledger.GetAccountInfo(ctx, address, "current")
+			_, hasTicket := txMap["TicketSequence"]
+			seq, err := services.Ledger.GetAutofillSequence(address, hasTicket)
 			if err != nil {
-				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account sequence: %v", err))
+				if errors.Is(err, svcerr.ErrAccountNotFound) {
+					return nil, types.RpcErrorSrcActNotFound("Source account not found.")
+				}
+				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill sequence: %v", err))
 			}
-			txMap["Sequence"] = info.Sequence
+			txMap["Sequence"] = seq
 		}
 
 		// Do NOT auto-fill LastLedgerSequence. Rippled's
@@ -240,6 +236,35 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 			if serverInfo.NetworkID > 1024 {
 				txMap["NetworkID"] = serverInfo.NetworkID
 			}
+		}
+
+		// Auto-fill Fee if not present: load-scaled, escalation-aware
+		// network fee with a feeDefault * fee_mult_max / fee_div_max
+		// ceiling. Matches rippled checkFee() → getCurrentNetworkFee().
+		if _, ok := txMap["Fee"]; !ok {
+			probe, mErr := json.Marshal(txMap)
+			if mErr != nil {
+				return nil, types.RpcErrorInternal("Failed to marshal tx_json for fee autofill")
+			}
+			fee, feeErr := services.Ledger.GetAutofillFee(probe, unlimited, feeOpts.Mult, feeOpts.Div)
+			if feeErr != nil {
+				var hfe *svcerr.HighFeeError
+				if errors.As(feeErr, &hfe) {
+					return nil, types.RpcErrorHighFee(hfe.Error())
+				}
+				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill fee: %v", feeErr))
+			}
+			txMap["Fee"] = formatUint64AsString(fee)
+		}
+	} else {
+		// Offline callers must supply Sequence and Fee themselves
+		// (rippled TransactionSign.cpp:451-452 and checkFee with
+		// doAutoFill == false).
+		if _, ok := txMap["Sequence"]; !ok {
+			return nil, types.RpcErrorMissingField("tx_json.Sequence")
+		}
+		if _, ok := txMap["Fee"]; !ok {
+			return nil, types.RpcErrorMissingField("tx_json.Fee")
 		}
 	}
 

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -149,11 +149,11 @@ type signResult struct {
 // and returns the signed tx map + blob. This is the shared logic used by both
 // the "sign" and "submit" RPC methods.
 //
-// The feeOpts parameter controls auto-fee behavior: if Fee is not present in
-// tx_json and auto-fill is active, the network fee is computed and checked
-// against the limit feeDefault * feeOpts.Mult / feeOpts.Div. unlimited
-// mirrors rippled's isUnlimited(role) load-scaling carve-out.
-func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, txJSON json.RawMessage, creds signCredentials, offline bool, unlimited bool, apiVersion int, feeOpts feeOptions) (*signResult, *types.RpcError) {
+// rawParams carries the caller's request so fee_mult_max / fee_div_max are
+// read only when Fee is actually autofilled — rippled's checkFee returns
+// before inspecting them when Fee is present or offline. unlimited mirrors
+// rippled's isUnlimited(role) load-scaling carve-out.
+func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, txJSON json.RawMessage, creds signCredentials, offline bool, unlimited bool, apiVersion int, rawParams json.RawMessage) (*signResult, *types.RpcError) {
 	// Check if ledger service is available (needed for auto-filling fields)
 	if !offline && (services == nil || services.Ledger == nil) {
 		return nil, types.RpcErrorInternal("Ledger service not available")
@@ -184,8 +184,13 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_json: %v", err))
 	}
 
-	// Verify the account matches the signing key
+	// A supplied Account must be a parseable address before anything else
+	// (rippled checkTxJsonFields → rpcSRC_ACT_MALFORMED), then match the
+	// signing key.
 	if txAccount, ok := txMap["Account"].(string); ok {
+		if !types.IsValidClassicAddress(txAccount) {
+			return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
+		}
 		if txAccount != address {
 			return nil, types.RpcErrorInvalidParams("Account in tx_json does not match signing key")
 		}
@@ -242,6 +247,10 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 		// network fee with a feeDefault * fee_mult_max / fee_div_max
 		// ceiling. Matches rippled checkFee() → getCurrentNetworkFee().
 		if _, ok := txMap["Fee"]; !ok {
+			feeOpts, rpcErr := parseFeeOptions(rawParams)
+			if rpcErr != nil {
+				return nil, rpcErr
+			}
 			probe, mErr := json.Marshal(txMap)
 			if mErr != nil {
 				return nil, types.RpcErrorInternal("Failed to marshal tx_json for fee autofill")

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -108,7 +108,10 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		if marshalErr != nil {
 			return nil, types.RpcErrorInternal("Failed to marshal tx_json for fee autofill")
 		}
-		fee, feeErr := ctx.Services.Ledger.GetAutofillFee(probe, ctx.IsAdmin)
+		// rippled's simulate autofill uses the default fee_mult_max /
+		// fee_div_max (getCurrentNetworkFee default arguments).
+		feeOpts := defaultFeeOptions()
+		fee, feeErr := ctx.Services.Ledger.GetAutofillFee(probe, ctx.IsAdmin, feeOpts.Mult, feeOpts.Div)
 		if feeErr != nil {
 			var hfe *svcerr.HighFeeError
 			if errors.As(feeErr, &hfe) {

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -111,7 +111,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		// rippled's simulate autofill uses the default fee_mult_max /
 		// fee_div_max (getCurrentNetworkFee default arguments).
 		feeOpts := defaultFeeOptions()
-		fee, feeErr := ctx.Services.Ledger.GetAutofillFee(probe, ctx.IsAdmin, feeOpts.Mult, feeOpts.Div)
+		fee, feeErr := ctx.Services.Ledger.GetAutofillFee(probe, ctx.Unlimited, feeOpts.Mult, feeOpts.Div)
 		if feeErr != nil {
 			var hfe *svcerr.HighFeeError
 			if errors.As(feeErr, &hfe) {

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -312,6 +312,11 @@ func (m *GetCountsMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 // overrides; with a severity it sets the base threshold or, when a
 // partition is given, that partition's threshold (a partition of "base"
 // sets the base threshold). Reference: rippled LogLevel.cpp
+//
+// Deliberate shape divergence: rippled's GET lists every partition sink
+// ever instantiated (Logs::partition_severities), most at the base level;
+// go-xrpl has no lazy sink registry and lists only partitions with an
+// explicit override.
 type LogLevelMethod struct{ AdminHandler }
 
 // rippledSeverityName maps a log level to rippled's severity naming

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -308,15 +308,30 @@ func (m *GetCountsMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 }
 
 // LogLevelMethod handles the log_level RPC method.
-// STUB: Accepts level changes but doesn't actually modify logging.
-//
-// TODO [admin]: Wire to actual logging framework.
-//   - Reference: rippled LogLevel.cpp
-//   - When severity is empty: return current log levels for all partitions
-//   - When severity is set: change the log level (optionally for a specific partition)
-//   - Valid levels: trace, debug, info, warning, error, fatal
-//   - Requires: Logging infrastructure with configurable levels
+// Without a severity it returns the base threshold plus any per-partition
+// overrides; with a severity it sets the base threshold or, when a
+// partition is given, that partition's threshold (a partition of "base"
+// sets the base threshold). Reference: rippled LogLevel.cpp
 type LogLevelMethod struct{ AdminHandler }
+
+// rippledSeverityName maps a log level to rippled's severity naming
+// (Logs::toString): Trace, Debug, Info, Warning, Error, Fatal.
+func rippledSeverityName(l xrpllog.Level) string {
+	switch {
+	case l <= xrpllog.LevelTrace:
+		return "Trace"
+	case l <= xrpllog.LevelDebug:
+		return "Debug"
+	case l <= xrpllog.LevelInfo:
+		return "Info"
+	case l <= xrpllog.LevelWarn:
+		return "Warning"
+	case l <= xrpllog.LevelError:
+		return "Error"
+	default:
+		return "Fatal"
+	}
+}
 
 func (m *LogLevelMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var request struct {
@@ -332,10 +347,10 @@ func (m *LogLevelMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	if request.Severity == "" {
 		global, partitions := xrpllog.GetCurrentLevels()
 		levels := map[string]string{
-			"base": xrpllog.LevelName(global),
+			"base": rippledSeverityName(global),
 		}
 		for name, lvl := range partitions {
-			levels[name] = xrpllog.LevelName(lvl)
+			levels[name] = rippledSeverityName(lvl)
 		}
 		return map[string]any{"levels": levels}, nil
 	}
@@ -343,10 +358,10 @@ func (m *LogLevelMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	// SET: parse and apply the new level
 	lvl, ok := xrpllog.ParseLevel(request.Severity)
 	if !ok {
-		return nil, types.RpcErrorInvalidParams("Invalid severity level: " + request.Severity)
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 
-	if request.Partition != "" {
+	if request.Partition != "" && !strings.EqualFold(request.Partition, "base") {
 		xrpllog.SetPartitionLevel(request.Partition, lvl)
 	} else {
 		xrpllog.SetLevel(lvl)

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -79,7 +79,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 			SeedHex:    request.SeedHex,
 			Passphrase: request.Passphrase,
 			KeyType:    request.KeyType,
-		}, request.Offline, ctx.IsAdmin, ctx.ApiVersion, feeOpts)
+		}, request.Offline, ctx.Unlimited, ctx.ApiVersion, feeOpts)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -79,7 +79,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 			SeedHex:    request.SeedHex,
 			Passphrase: request.Passphrase,
 			KeyType:    request.KeyType,
-		}, request.Offline, ctx.ApiVersion, feeOpts)
+		}, request.Offline, ctx.IsAdmin, ctx.ApiVersion, feeOpts)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -17,13 +17,6 @@ import (
 type SubmitMethod struct{}
 
 func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	// Parse fee_mult_max / fee_div_max first with proper type validation,
-	// matching rippled's checkFee() in TransactionSign.cpp.
-	feeOpts, feeErr := parseFeeOptions(params)
-	if feeErr != nil {
-		return nil, feeErr
-	}
-
 	var request struct {
 		TxBlob     string          `json:"tx_blob,omitempty"`
 		TxJson     json.RawMessage `json:"tx_json,omitempty"`
@@ -79,7 +72,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 			SeedHex:    request.SeedHex,
 			Passphrase: request.Passphrase,
 			KeyType:    request.KeyType,
-		}, request.Offline, ctx.Unlimited, ctx.ApiVersion, feeOpts)
+		}, request.Offline, ctx.Unlimited, ctx.ApiVersion, params)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -147,23 +147,14 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
 		}
 
-		// Exactly Account, SigningPubKey, and TxnSignature — no extra
-		// fields (rippled checks getCount() == 3).
-		if len(signer) != 3 {
+		// A Signer object always contains exactly Account, SigningPubKey,
+		// and TxnSignature; rippled reports one combined error for any
+		// missing or extra field (getCount() == 3).
+		account, hasAccount := signer["Account"].(string)
+		_, hasPubKey := signer["SigningPubKey"].(string)
+		_, hasSig := signer["TxnSignature"].(string)
+		if !hasAccount || account == "" || !hasPubKey || !hasSig || len(signer) != 3 {
 			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
-		}
-
-		account, ok := signer["Account"].(string)
-		if !ok || account == "" {
-			return nil, types.RpcErrorInvalidParams("Signer entry missing Account")
-		}
-
-		if _, ok := signer["SigningPubKey"].(string); !ok {
-			return nil, types.RpcErrorInvalidParams("Signer entry missing SigningPubKey")
-		}
-
-		if _, ok := signer["TxnSignature"].(string); !ok {
-			return nil, types.RpcErrorInvalidParams("Signer entry missing TxnSignature")
 		}
 
 		// Check signers are sorted by account (XRPL protocol requirement)

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -147,6 +147,12 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
 		}
 
+		// Exactly Account, SigningPubKey, and TxnSignature — no extra
+		// fields (rippled checks getCount() == 3).
+		if len(signer) != 3 {
+			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
+		}
+
 		account, ok := signer["Account"].(string)
 		if !ok || account == "" {
 			return nil, types.RpcErrorInvalidParams("Signer entry missing Account")
@@ -209,10 +215,10 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		if fh, ok := ctx.Services.Ledger.(types.FailHardSubmitter); ok {
 			result, submitErr = fh.SubmitTransactionFailHard(txJSON, txBlob)
 		} else {
-			result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON)
+			result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON, txBlob)
 		}
 	} else {
-		result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON)
+		result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON, txBlob)
 	}
 	if submitErr != nil {
 		return nil, types.RpcErrorInternal("Transaction submission failed: " + submitErr.Error())

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
@@ -79,6 +81,24 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 
 	// Get the source account address for self-signing detection later.
 	txAccount, _ := txMap["Account"].(string)
+
+	// rippled checkTxJsonFields: an Account that parseBase58<AccountID>
+	// rejects is rpcSRC_ACT_MALFORMED (TransactionSign.cpp:345-354).
+	if !types.IsValidClassicAddress(txAccount) {
+		return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
+	}
+
+	// The source account must exist in the current ledger
+	// (TransactionSign.cpp:1259-1270 → rpcSRC_ACT_NOT_FOUND). Signer-list
+	// existence, signer weights, and quorum are deliberately not checked
+	// here: rippled leaves them to the engine's checkMultiSign
+	// (tefNOT_MULTI_SIGNING / tefBAD_SIGNATURE / tefBAD_QUORUM).
+	if _, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, txAccount, "current"); err != nil {
+		if errors.Is(err, svcerr.ErrAccountNotFound) {
+			return nil, types.RpcErrorSrcActNotFound("Source account not found.")
+		}
+		return nil, types.RpcErrorInternal("Failed to read source account: " + err.Error())
+	}
 
 	// --- Post-serialization validation (rippled TransactionSign.cpp:1325-1391) ---
 
@@ -162,11 +182,6 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 
 		prevAccount = account
 	}
-
-	// TODO: Validate source account exists in ledger (needs service layer - rpcSRC_ACT_NOT_FOUND)
-	// TODO: Validate signer list exists on source account (needs service layer)
-	// TODO: Validate quorum threshold is met (needs service layer)
-	// TODO: Validate signer weights against quorum (needs service layer)
 
 	// Encode the transaction to binary
 	txBlob, encErr := binarycodec.Encode(txMap)

--- a/internal/rpc/handlers/subscribe.go
+++ b/internal/rpc/handlers/subscribe.go
@@ -6,23 +6,43 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// SubscribeMethod handles the subscribe RPC command.
-// STUB over plain JSON-RPC: mirrors rippled Subscribe.cpp's
-// "Must be a JSON-RPC call." branch — when there is no infoSub and no `url`
-// parameter, rippled returns rpcError(rpcINVALID_PARAMS). The real
-// WebSocket-bound implementation lives in rpc/websocket.go.
+// SubscribeMethod handles the subscribe RPC command over plain JSON-RPC.
+// The WebSocket-bound implementation lives in rpc/websocket.go.
 //
-// TODO [websocket]: rippled also supports HTTP+url admin subscriptions
-//
-//	(Subscribe.cpp branch on context.params.isMember(jss::url) with
-//	Role::ADMIN). Once goxrpl wires up the RPCSub callback path that
-//	branch should be served here too.
-//	- Reference: rippled Subscribe.cpp
-//	- Streams: ledger, transactions, transactions_proposed, peer_status,
-//	  consensus, server, validations, manifests, book (order book)
-//	- Account subscriptions: accounts, accounts_proposed
+// rippled additionally supports url-based (RPCSub) subscriptions on this
+// path: an admin supplies url/url_username/url_password and rippled keeps
+// a per-url InfoSub (NetworkOPs::mRpcSubMap) whose events are delivered as
+// outbound JSON-RPC "event" calls (RPCSub.cpp: per-url sequence numbers,
+// http/https with basic auth, fire-and-forget with logged failures).
+// go-xrpl does not implement RPCSub: it needs a url-keyed registry shared
+// between this handler and the WebSocket broadcast fan-out, an outbound
+// HTTP delivery loop, and the subscribe ack/snapshot building that today
+// lives on WebSocketServer — a subsystem of its own. Until then the
+// admin+url case returns notSupported; without url this matches rippled's
+// "Must be a JSON-RPC call." branch (rpcINVALID_PARAMS), and url from a
+// non-admin returns rpcNO_PERMISSION exactly as rippled does.
 type SubscribeMethod struct{ BaseHandler }
 
+// urlSubscriptionError implements the shared subscribe/unsubscribe gating
+// for plain JSON-RPC calls described on SubscribeMethod.
+func urlSubscriptionError(ctx *types.RpcContext, params json.RawMessage) *types.RpcError {
+	var request struct {
+		URL string `json:"url"`
+	}
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &request)
+	}
+
+	if request.URL == "" {
+		// Must be a JSON-RPC call (rippled: no infoSub and no url).
+		return types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	if ctx.Role != types.RoleAdmin {
+		return types.RpcErrorNoPermission("subscribe")
+	}
+	return types.RpcErrorNotSupported("url-based (RPCSub) subscriptions are not supported")
+}
+
 func (m *SubscribeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	return nil, urlSubscriptionError(ctx, params)
 }

--- a/internal/rpc/handlers/unsubscribe.go
+++ b/internal/rpc/handlers/unsubscribe.go
@@ -6,21 +6,17 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// UnsubscribeMethod handles the unsubscribe RPC command.
-// STUB over plain JSON-RPC: mirrors rippled Unsubscribe.cpp's
-// "Must be a JSON-RPC call." branch — when there is no infoSub and no `url`
-// parameter, rippled returns rpcError(rpcINVALID_PARAMS). The real
-// WebSocket-bound implementation lives in rpc/websocket.go.
+// UnsubscribeMethod handles the unsubscribe RPC command over plain
+// JSON-RPC. The WebSocket-bound implementation lives in rpc/websocket.go.
 //
-// TODO [websocket]: rippled also supports HTTP+url admin unsubscribes
-//
-//	(Unsubscribe.cpp branch on context.params.isMember(jss::url) with
-//	Role::ADMIN). Once goxrpl wires up the RPCSub callback path that
-//	branch should be served here too.
-//	- Reference: rippled Unsubscribe.cpp
-//	- Removes subscriptions created by subscribe command
+// rippled's url branch (Unsubscribe.cpp) looks up the per-url RPCSub
+// created by subscribe and removes the listed streams from it; see
+// SubscribeMethod for why go-xrpl does not implement RPCSub yet. The
+// gating here mirrors the subscribe path: no url → rpcINVALID_PARAMS
+// ("Must be a JSON-RPC call." branch), url from a non-admin →
+// rpcNO_PERMISSION, url from an admin → notSupported.
 type UnsubscribeMethod struct{ BaseHandler }
 
 func (m *UnsubscribeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	return nil, urlSubscriptionError(ctx, params)
 }

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -1019,3 +1019,23 @@ func (a *LedgerServiceAdapter) GetClosedLedgerView() (types.LedgerStateView, err
 	}
 	return l, nil
 }
+
+// GetLedgerViewBySeq returns a state view of the ledger with the given
+// sequence, plus its metadata reader.
+func (a *LedgerServiceAdapter) GetLedgerViewBySeq(seq uint32) (types.LedgerStateView, types.LedgerReader, error) {
+	l, err := a.svc.GetLedgerBySequence(seq)
+	if err != nil {
+		return nil, nil, err
+	}
+	return l, &ledgerReaderAdapter{l: l}, nil
+}
+
+// GetLedgerViewByHash returns a state view of the ledger with the given
+// hash, plus its metadata reader.
+func (a *LedgerServiceAdapter) GetLedgerViewByHash(hash [32]byte) (types.LedgerStateView, types.LedgerReader, error) {
+	l, err := a.svc.GetLedgerByHash(hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	return l, &ledgerReaderAdapter{l: l}, nil
+}

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -950,13 +950,13 @@ func (a *LedgerServiceAdapter) SimulateTransaction(txJSON []byte) (*types.Submit
 	return out, nil
 }
 
-func (a *LedgerServiceAdapter) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
+func (a *LedgerServiceAdapter) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
 	// rippled getTxFee falls back to reference_fee on any parse failure
 	// (TransactionSign.cpp:790-821). A nil parsedTx triggers the
 	// equivalent baseFee fallback in computeBaseFeeForTx so the later
 	// structural-check passes can surface the real error.
 	parsedTx, _ := tx.ParseJSON(txJSON)
-	return a.svc.GetAutofillFee(parsedTx, unlimited)
+	return a.svc.GetAutofillFee(parsedTx, unlimited, mult, div)
 }
 
 func (a *LedgerServiceAdapter) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1219,48 +1220,52 @@ func TestLogLevelMethod(t *testing.T) {
 
 	method := &handlers.LogLevelMethod{}
 
-	t.Run("Returns current log levels without params", func(t *testing.T) {
-		ctx := &types.RpcContext{
-			Context:    context.Background(),
-			Role:       types.RoleAdmin,
-			ApiVersion: types.ApiVersion1,
-			Services:   services,
-		}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
 
+	// Register a live root config so set operations take effect, restoring
+	// the unset state when the test finishes.
+	logCfg := &xrpllog.Config{Level: xrpllog.LevelInfo}
+	xrpllog.SetRootConfig(logCfg)
+	t.Cleanup(func() { xrpllog.SetRootConfig(nil) })
+
+	getLevels := func(t *testing.T) map[string]string {
+		t.Helper()
 		result, rpcErr := method.Handle(ctx, nil)
-
 		require.Nil(t, rpcErr)
-		require.NotNil(t, result)
+		levels, ok := result.(map[string]any)["levels"].(map[string]string)
+		require.True(t, ok, "levels missing from response")
+		return levels
+	}
+
+	t.Run("Returns current log levels without params", func(t *testing.T) {
+		levels := getLevels(t)
+		assert.Equal(t, "Info", levels["base"])
 	})
 
 	t.Run("Invalid severity returns error", func(t *testing.T) {
-		ctx := &types.RpcContext{
-			Context:    context.Background(),
-			Role:       types.RoleAdmin,
-			ApiVersion: types.ApiVersion1,
-			Services:   services,
-		}
-
 		params := json.RawMessage(`{"severity": "invalid_level"}`)
 		result, rpcErr := method.Handle(ctx, params)
 
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid parameters.", rpcErr.Message)
 	})
 
 	t.Run("Valid severity levels are accepted", func(t *testing.T) {
-		validLevels := []string{"trace", "debug", "info", "warning", "error", "fatal"}
+		// rippled Logs::fromString aliases, matched case-insensitively.
+		validLevels := []string{
+			"trace", "debug", "info", "information", "warn", "warning",
+			"warnings", "error", "errors", "fatal", "fatals", "WARNING",
+		}
 
 		for _, level := range validLevels {
 			t.Run("severity: "+level, func(t *testing.T) {
-				ctx := &types.RpcContext{
-					Context:    context.Background(),
-					Role:       types.RoleAdmin,
-					ApiVersion: types.ApiVersion1,
-					Services:   services,
-				}
-
 				params, _ := json.Marshal(map[string]string{"severity": level})
 				result, rpcErr := method.Handle(ctx, params)
 
@@ -1268,6 +1273,45 @@ func TestLogLevelMethod(t *testing.T) {
 				require.NotNil(t, result)
 			})
 		}
+	})
+
+	t.Run("Set base severity is reflected in get", func(t *testing.T) {
+		params := json.RawMessage(`{"severity": "debug"}`)
+		_, rpcErr := method.Handle(ctx, params)
+		require.Nil(t, rpcErr)
+
+		assert.Equal(t, "Debug", getLevels(t)["base"])
+
+		_, rpcErr = method.Handle(ctx, json.RawMessage(`{"severity": "info"}`))
+		require.Nil(t, rpcErr)
+		assert.Equal(t, "Info", getLevels(t)["base"])
+	})
+
+	t.Run("Set partition severity is reflected in get", func(t *testing.T) {
+		params := json.RawMessage(`{"severity": "trace", "partition": "Consensus"}`)
+		_, rpcErr := method.Handle(ctx, params)
+		require.Nil(t, rpcErr)
+
+		levels := getLevels(t)
+		assert.Equal(t, "Trace", levels["Consensus"])
+		assert.Equal(t, "Info", levels["base"], "partition set must not change base")
+	})
+
+	t.Run("Partition base sets the base threshold", func(t *testing.T) {
+		params := json.RawMessage(`{"severity": "warning", "partition": "BASE"}`)
+		_, rpcErr := method.Handle(ctx, params)
+		require.Nil(t, rpcErr)
+
+		// The global threshold must change; no partition override named
+		// "base" may be created (rippled treats partition "base" as the
+		// base threshold, matched case-insensitively).
+		global, partitions := xrpllog.GetCurrentLevels()
+		assert.Equal(t, xrpllog.LevelWarn, global)
+		assert.NotContains(t, partitions, "base")
+		assert.NotContains(t, partitions, "BASE")
+
+		_, rpcErr = method.Handle(ctx, json.RawMessage(`{"severity": "info"}`))
+		require.Nil(t, rpcErr)
 	})
 
 	t.Run("RequiredRole is Admin", func(t *testing.T) {

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -150,7 +150,7 @@ func (m *mockNFTOffersLedgerService) GetNFTSellOffers(_ context.Context, nftID [
 func (m *mockNFTOffersLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNFTOffersLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
+func (m *mockNFTOffersLedgerService) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockNFTOffersLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -164,7 +164,7 @@ func (m *mockNoRippleCheckLedgerService) GetNFTSellOffers(_ context.Context, nft
 func (m *mockNoRippleCheckLedgerService) SimulateTransaction(txJSON []byte) (*types.SubmitResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockNoRippleCheckLedgerService) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
+func (m *mockNoRippleCheckLedgerService) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 func (m *mockNoRippleCheckLedgerService) GetAutofillSequence(account string, hasTicketSequence bool) (uint32, error) {

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
@@ -437,6 +438,157 @@ func TestSign_OfflineMode(t *testing.T) {
 	assert.Contains(t, txJson, "TxnSignature")
 	assert.Contains(t, txJson, "SigningPubKey")
 	assert.Contains(t, txJson, "hash")
+}
+
+func TestSign_SrcActNotFound(t *testing.T) {
+	// Online signing requires the source account to exist in the current
+	// ledger. Matches rippled transactionPreProcessImpl
+	// (TransactionSign.cpp:458-465) -> rpcSRC_ACT_NOT_FOUND.
+	mock := newMockLedgerService()
+	mock.accountInfoErr = svcerr.ErrAccountNotFound
+	services := &types.ServiceContainer{Ledger: mock}
+
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	// Sequence and Fee supplied: the existence check must still fire.
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1
+		},
+		"passphrase": "masterpassphrase"
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcSRC_ACT_NOT_FOUND, err.Code)
+	assert.Equal(t, "srcActNotFound", err.ErrorString)
+	assert.Equal(t, "Source account not found.", err.Message)
+}
+
+func TestSign_AutofillSequence(t *testing.T) {
+	// Online signing with Sequence absent auto-fills it from account state.
+	mock := newMockLedgerService()
+	services := &types.ServiceContainer{Ledger: mock}
+
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10"
+		},
+		"passphrase": "masterpassphrase"
+	}`)
+	result, err := handler.Handle(ctx, params)
+	require.Nil(t, err)
+	require.NotNil(t, result)
+
+	resultMap := result.(map[string]any)
+	txJson := resultMap["tx_json"].(map[string]any)
+	// The mock account state reports Sequence 1.
+	assert.Equal(t, uint32(1), txJson["Sequence"])
+}
+
+func TestSign_Offline_MissingSequence(t *testing.T) {
+	// Offline callers must supply Sequence themselves. Matches rippled
+	// transactionPreProcessImpl (TransactionSign.cpp:451-452).
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10"
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Equal(t, "Missing field 'tx_json.Sequence'.", err.Message)
+}
+
+func TestSign_Offline_MissingFee(t *testing.T) {
+	// Offline callers must supply Fee themselves. Matches rippled
+	// checkFee with doAutoFill == false (TransactionSign.cpp:893-894).
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Sequence": 1
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Equal(t, "Missing field 'tx_json.Fee'.", err.Message)
+}
+
+func TestSign_TicketSequence_AutofillsSequenceZero(t *testing.T) {
+	// A present TicketSequence supplies the sequence: the autofilled
+	// Sequence must be 0 (rippled TransactionSign.cpp:469-483).
+	mock := newMockLedgerService()
+	services := &types.ServiceContainer{Ledger: mock}
+
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"TicketSequence": 7
+		},
+		"passphrase": "masterpassphrase"
+	}`)
+	result, err := handler.Handle(ctx, params)
+	require.Nil(t, err)
+	require.NotNil(t, result)
+
+	resultMap := result.(map[string]any)
+	txJson := resultMap["tx_json"].(map[string]any)
+	assert.Equal(t, uint32(0), txJson["Sequence"])
 }
 
 func TestSign_Metadata(t *testing.T) {

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -1343,7 +1343,7 @@ func TestSubmitMultisigned_MissingSignerAccount(t *testing.T) {
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "Account")
+	assert.Equal(t, "Signers array may only contain Signer entries.", err.Message)
 }
 
 func TestSubmitMultisigned_MissingSigningPubKey(t *testing.T) {
@@ -1378,7 +1378,7 @@ func TestSubmitMultisigned_MissingSigningPubKey(t *testing.T) {
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "SigningPubKey")
+	assert.Equal(t, "Signers array may only contain Signer entries.", err.Message)
 }
 
 func TestSubmitMultisigned_MissingTxnSignature(t *testing.T) {
@@ -1413,7 +1413,7 @@ func TestSubmitMultisigned_MissingTxnSignature(t *testing.T) {
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "TxnSignature")
+	assert.Equal(t, "Signers array may only contain Signer entries.", err.Message)
 }
 
 func TestSubmitMultisigned_SignersNotSorted(t *testing.T) {

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -701,12 +701,16 @@ func TestSign_FeeDivMax_LargeRejects(t *testing.T) {
 }
 
 func TestSign_FeeMultMax_NegativeRejectsInvalidParams(t *testing.T) {
-	// Negative fee_mult_max should return rpcINVALID_PARAMS.
-	// Matches rippled: mult < 0 -> rpcINVALID_PARAMS
+	// Negative fee_mult_max should return rpcINVALID_PARAMS when Fee is
+	// autofilled. Matches rippled: mult < 0 -> rpcINVALID_PARAMS
+	mock := newMockLedgerService()
+	services := &types.ServiceContainer{Ledger: mock}
+
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -715,12 +719,9 @@ func TestSign_FeeMultMax_NegativeRejectsInvalidParams(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
-			"Fee": "10",
-			"Sequence": 1,
-			"LastLedgerSequence": 100
+			"Sequence": 1
 		},
 		"passphrase": "masterpassphrase",
-		"offline": true,
 		"fee_mult_max": -1
 	}`)
 	_, err := handler.Handle(ctx, params)
@@ -731,12 +732,16 @@ func TestSign_FeeMultMax_NegativeRejectsInvalidParams(t *testing.T) {
 }
 
 func TestSign_FeeDivMax_ZeroRejectsInvalidParams(t *testing.T) {
-	// fee_div_max=0 should return rpcINVALID_PARAMS (not positive).
-	// Matches rippled: div <= 0 -> rpcINVALID_PARAMS
+	// fee_div_max=0 should return rpcINVALID_PARAMS (not positive) when
+	// Fee is autofilled. Matches rippled: div <= 0 -> rpcINVALID_PARAMS
+	mock := newMockLedgerService()
+	services := &types.ServiceContainer{Ledger: mock}
+
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -745,12 +750,9 @@ func TestSign_FeeDivMax_ZeroRejectsInvalidParams(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
-			"Fee": "10",
-			"Sequence": 1,
-			"LastLedgerSequence": 100
+			"Sequence": 1
 		},
 		"passphrase": "masterpassphrase",
-		"offline": true,
 		"fee_div_max": 0
 	}`)
 	_, err := handler.Handle(ctx, params)
@@ -761,11 +763,16 @@ func TestSign_FeeDivMax_ZeroRejectsInvalidParams(t *testing.T) {
 }
 
 func TestSign_FeeDivMax_NegativeRejectsInvalidParams(t *testing.T) {
-	// Negative fee_div_max should return rpcINVALID_PARAMS.
+	// Negative fee_div_max should return rpcINVALID_PARAMS when Fee is
+	// autofilled.
+	mock := newMockLedgerService()
+	services := &types.ServiceContainer{Ledger: mock}
+
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -774,12 +781,9 @@ func TestSign_FeeDivMax_NegativeRejectsInvalidParams(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
-			"Fee": "10",
-			"Sequence": 1,
-			"LastLedgerSequence": 100
+			"Sequence": 1
 		},
 		"passphrase": "masterpassphrase",
-		"offline": true,
 		"fee_div_max": -5
 	}`)
 	_, err := handler.Handle(ctx, params)
@@ -789,12 +793,16 @@ func TestSign_FeeDivMax_NegativeRejectsInvalidParams(t *testing.T) {
 }
 
 func TestSign_FeeMultMax_FloatRejectsHighFee(t *testing.T) {
-	// Float fee_mult_max should return rpcHIGH_FEE (not rpcINVALID_PARAMS).
-	// Matches rippled: isInt() false -> rpcHIGH_FEE
+	// Float fee_mult_max should return rpcHIGH_FEE (not rpcINVALID_PARAMS)
+	// when Fee is autofilled. Matches rippled: isInt() false -> rpcHIGH_FEE
+	mock := newMockLedgerService()
+	services := &types.ServiceContainer{Ledger: mock}
+
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -803,12 +811,9 @@ func TestSign_FeeMultMax_FloatRejectsHighFee(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
-			"Fee": "10",
-			"Sequence": 1,
-			"LastLedgerSequence": 100
+			"Sequence": 1
 		},
 		"passphrase": "masterpassphrase",
-		"offline": true,
 		"fee_mult_max": 1.5
 	}`)
 	_, err := handler.Handle(ctx, params)
@@ -819,11 +824,15 @@ func TestSign_FeeMultMax_FloatRejectsHighFee(t *testing.T) {
 }
 
 func TestSign_FeeMultMax_StringRejectsHighFee(t *testing.T) {
-	// String fee_mult_max should return rpcHIGH_FEE.
+	// String fee_mult_max should return rpcHIGH_FEE when Fee is autofilled.
+	mock := newMockLedgerService()
+	services := &types.ServiceContainer{Ledger: mock}
+
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
+		Services:   services,
 	}
 
 	params := json.RawMessage(`{
@@ -832,12 +841,9 @@ func TestSign_FeeMultMax_StringRejectsHighFee(t *testing.T) {
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 			"Amount": "1000000",
-			"Fee": "10",
-			"Sequence": 1,
-			"LastLedgerSequence": 100
+			"Sequence": 1
 		},
 		"passphrase": "masterpassphrase",
-		"offline": true,
 		"fee_mult_max": "ten"
 	}`)
 	_, err := handler.Handle(ctx, params)
@@ -847,15 +853,17 @@ func TestSign_FeeMultMax_StringRejectsHighFee(t *testing.T) {
 }
 
 func TestSign_FeeAlreadySet_IgnoresFeeMultMax(t *testing.T) {
-	// When Fee is already set in tx_json, fee_mult_max / fee_div_max
-	// should be ignored (the tx already has a fee).
+	// When Fee is already set in tx_json, fee_mult_max / fee_div_max are
+	// never inspected — even invalid values pass. Matches rippled checkFee
+	// returning before reading them.
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
 	}
 
-	// fee_mult_max=0 would normally reject, but Fee is provided
+	// fee_mult_max="garbage" would reject on the autofill path, but Fee
+	// is provided so it is never read.
 	params := json.RawMessage(`{
 		"tx_json": {
 			"TransactionType": "Payment",
@@ -868,10 +876,10 @@ func TestSign_FeeAlreadySet_IgnoresFeeMultMax(t *testing.T) {
 		},
 		"passphrase": "masterpassphrase",
 		"offline": true,
-		"fee_mult_max": 0
+		"fee_mult_max": "garbage"
 	}`)
 	result, err := handler.Handle(ctx, params)
-	require.Nil(t, err, "fee_mult_max should be ignored when Fee is in tx_json")
+	require.Nil(t, err, "fee_mult_max must not be read when Fee is in tx_json")
 	require.NotNil(t, result)
 }
 

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -61,7 +61,7 @@ func (m *mockLedgerServiceSimulate) SimulateTransaction(txJSON []byte) (*types.S
 	return m.simulateResult, nil
 }
 
-func (m *mockLedgerServiceSimulate) GetAutofillFee(txJSON []byte, unlimited bool) (uint64, error) {
+func (m *mockLedgerServiceSimulate) GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (uint64, error) {
 	m.feeAutofillCallCount++
 	if m.autofillFeeErr != nil {
 		return 0, m.autofillFeeErr

--- a/internal/rpc/submit_multisigned_test.go
+++ b/internal/rpc/submit_multisigned_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
@@ -286,6 +287,97 @@ func TestSubmitMultisigned_ValidationOrder_SequenceBeforeTxnSignature(t *testing
 	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, "Missing field 'tx_json.Sequence'.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_SrcActMalformed verifies that an unparseable source
+// account is rejected with rpcSRC_ACT_MALFORMED.
+// Matches rippled checkTxJsonFields: "Invalid field 'tx_json.Account'."
+func TestSubmitMultisigned_SrcActMalformed(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	services := newSubmitTestServices(mock)
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
+
+	txJSON := validMultisignedTxJSON()
+	txJSON["Account"] = "not_an_address"
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcSRC_ACT_MALFORMED, rpcErr.Code)
+	assert.Equal(t, "srcActMalformed", rpcErr.ErrorString)
+	assert.Equal(t, "Invalid field 'tx_json.Account'.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_SrcActNotFound verifies that a source account absent
+// from the current ledger is rejected with rpcSRC_ACT_NOT_FOUND.
+// Matches rippled transactionSubmitMultiSigned: the account SLE read
+// (TransactionSign.cpp:1259-1270).
+func TestSubmitMultisigned_SrcActNotFound(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	mock.accountInfoErr = svcerr.ErrAccountNotFound
+	services := newSubmitTestServices(mock)
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, validMultisignedTxJSON()))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcSRC_ACT_NOT_FOUND, rpcErr.Code)
+	assert.Equal(t, "srcActNotFound", rpcErr.ErrorString)
+	assert.Equal(t, "Source account not found.", rpcErr.Message)
+}
+
+// TestSubmitMultisigned_ValidationOrder_SrcActNotFoundBeforeTxnSignature
+// verifies that the source-account existence check fires before the
+// post-serialization TxnSignature check, matching rippled's order (the SLE
+// read at TransactionSign.cpp:1259 precedes the serialized-field checks at
+// 1325-1390).
+func TestSubmitMultisigned_ValidationOrder_SrcActNotFoundBeforeTxnSignature(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	mock.accountInfoErr = svcerr.ErrAccountNotFound
+	services := newSubmitTestServices(mock)
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
+
+	txJSON := validMultisignedTxJSON()
+	txJSON["TxnSignature"] = "DEADBEEF"
+
+	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcSRC_ACT_NOT_FOUND, rpcErr.Code)
+}
+
+// TestSubmitMultisigned_HappyPath submits a well-formed multi-signed
+// transaction against a ledger where the source account exists and asserts
+// the engine response is surfaced. Signer-list / quorum validation is left
+// to the engine (tefNOT_MULTI_SIGNING / tefBAD_QUORUM), so the RPC layer
+// accepts the submission.
+func TestSubmitMultisigned_HappyPath(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	services := newSubmitTestServices(mock)
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
+
+	txJSON := validMultisignedTxJSON()
+	// Use addresses that pass base58 decoding so binary encoding succeeds.
+	txJSON["Destination"] = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+	signer := txJSON["Signers"].([]any)[0].(map[string]any)["Signer"].(map[string]any)
+	signer["Account"] = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+
+	result, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+
+	resp, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "tesSUCCESS", resp["engine_result"])
+	assert.NotEmpty(t, resp["tx_blob"])
+	respTxJSON, ok := resp["tx_json"].(map[string]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, respTxJSON["hash"])
 }
 
 // TestSubmitMultisigned_ValidationOrder_TxnSignatureBeforeFee verifies that

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -1260,6 +1260,45 @@ func TestUnsubscribeMethodRequiresWebSocket(t *testing.T) {
 	assert.Equal(t, "invalidParams", err.ErrorString)
 }
 
+// TestSubscribeURLGating tests the url (RPCSub) branch gates over plain
+// JSON-RPC: rippled requires Role::ADMIN for url subscriptions
+// (Subscribe.cpp / Unsubscribe.cpp → rpcNO_PERMISSION); go-xrpl does not
+// implement RPCSub, so the admin case reports notSupported.
+func TestSubscribeURLGating(t *testing.T) {
+	params := json.RawMessage(`{"url": "http://localhost:8081/callback", "streams": ["ledger"]}`)
+
+	methods := map[string]types.MethodHandler{
+		"subscribe":   &handlers.SubscribeMethod{},
+		"unsubscribe": &handlers.UnsubscribeMethod{},
+	}
+
+	for name, method := range methods {
+		t.Run(name+": url from non-admin is noPermission", func(t *testing.T) {
+			ctx := &types.RpcContext{
+				Role:       types.RoleGuest,
+				ApiVersion: types.ApiVersion1,
+			}
+			result, err := method.Handle(ctx, params)
+			assert.Nil(t, result)
+			require.NotNil(t, err)
+			assert.Equal(t, types.RpcNO_PERMISSION, err.Code)
+			assert.Equal(t, "noPermission", err.ErrorString)
+		})
+
+		t.Run(name+": url from admin is notSupported", func(t *testing.T) {
+			ctx := &types.RpcContext{
+				Role:       types.RoleAdmin,
+				ApiVersion: types.ApiVersion1,
+			}
+			result, err := method.Handle(ctx, params)
+			assert.Nil(t, result)
+			require.NotNil(t, err)
+			assert.Equal(t, types.RpcNOT_SUPPORTED, err.Code)
+			assert.Equal(t, "notSupported", err.ErrorString)
+		})
+	}
+}
+
 // TestSubscribeMethodMetadata tests method metadata
 func TestSubscribeMethodMetadata(t *testing.T) {
 	method := &handlers.SubscribeMethod{}

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -507,6 +507,33 @@ func RpcErrorDstIsrMalformed(message string) *RpcError {
 	return NewRpcError(RpcDST_ISR_MALFORMED, "dstIsrMalformed", "dstIsrMalformed", message)
 }
 
+// RpcErrorDstActMissing returns an error when the destination account is not
+// provided (matches rippled rpcDST_ACT_MISSING, code 49, token
+// "dstActMissing").
+func RpcErrorDstActMissing(message string) *RpcError {
+	return NewRpcError(RpcDST_ACT_MISSING, "dstActMissing", "dstActMissing", message)
+}
+
+// RpcErrorDstActMalformed returns an error when the destination account
+// address is malformed (matches rippled rpcDST_ACT_MALFORMED, code 48, token
+// "dstActMalformed").
+func RpcErrorDstActMalformed(message string) *RpcError {
+	return NewRpcError(RpcDST_ACT_MALFORMED, "dstActMalformed", "dstActMalformed", message)
+}
+
+// RpcErrorDstAmtMissing returns an error when the destination amount is not
+// provided (matches rippled rpcDST_AMT_MISSING, code 52, token
+// "dstAmtMissing").
+func RpcErrorDstAmtMissing(message string) *RpcError {
+	return NewRpcError(RpcDST_AMT_MISSING, "dstAmtMissing", "dstAmtMissing", message)
+}
+
+// RpcErrorSendMaxMalformed returns an error when send_max is malformed
+// (matches rippled rpcSENDMAX_MALFORMED, code 64, token "sendMaxMalformed").
+func RpcErrorSendMaxMalformed(message string) *RpcError {
+	return NewRpcError(RpcSENDMAX_MALFORMED, "sendMaxMalformed", "sendMaxMalformed", message)
+}
+
 // RpcErrorBadMarket matches rippled rpcBAD_MARKET (code 42, token "badMarket"),
 // returned when taker_pays and taker_gets describe the same asset.
 // Reference: ErrorCodes.cpp:62 "No such market.".

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -646,16 +646,18 @@ type TransactionSubmitter interface {
 	// GetAutofillFee returns the Fee a transaction should carry to enter
 	// the open ledger. Mirrors rippled getCurrentNetworkFee
 	// (TransactionSign.cpp:839-877): max(scaleFeeLoad(feeDefault),
-	// escalatedFee) with a feeDefault * mult / div ceiling. On ceiling
-	// overflow handlers map to rpcINTERNAL; on exceedance the returned
-	// error is a *svcerr.HighFeeError (errors.Is(svcerr.ErrHighFee) also
-	// matches). Includes per-tx-type adjustments (multisign, AccountDelete,
-	// AMMCreate, LedgerStateFix). Never reads the source account.
+	// escalatedFee) with a feeDefault * mult / div ceiling, where mult /
+	// div are the caller's fee_mult_max / fee_div_max (default 10 / 1).
+	// On ceiling overflow handlers map to rpcINTERNAL; on exceedance the
+	// returned error is a *svcerr.HighFeeError (errors.Is(svcerr.ErrHighFee)
+	// also matches). Includes per-tx-type adjustments (multisign,
+	// AccountDelete, AMMCreate, LedgerStateFix). Never reads the source
+	// account.
 	//
 	// unlimited mirrors rippled's isUnlimited(role) carve-out: admin /
 	// identified callers skip local-only load below 4x remote. The
 	// ceiling check still applies (rippled enforces it post-scale).
-	GetAutofillFee(txJSON []byte, unlimited bool) (fee uint64, err error)
+	GetAutofillFee(txJSON []byte, unlimited bool, mult, div int) (fee uint64, err error)
 
 	// GetAutofillSequence returns the Sequence a transaction should
 	// carry. Mirrors rippled getAutofillSequence (Simulate.cpp:37-69):

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -701,6 +701,17 @@ type LedgerService interface {
 	GetNFTSellOffers(ctx context.Context, nftID [32]byte, ledgerIndex string, limit uint32, marker string) (*NFTOffersResult, error)
 }
 
+// LedgerViewSource is an optional LedgerService facet for handlers that need
+// direct state-view access to a specific ledger (e.g. ripple_path_find with
+// an explicit ledger_index/ledger_hash). The returned LedgerReader carries
+// the metadata (sequence, hash, validated) merged into the RPC response.
+// Production and rpcenv adapters implement it; mocks may omit it, in which
+// case handlers report lgrNotFound for explicit ledger selectors.
+type LedgerViewSource interface {
+	GetLedgerViewBySeq(seq uint32) (LedgerStateView, LedgerReader, error)
+	GetLedgerViewByHash(hash [32]byte) (LedgerStateView, LedgerReader, error)
+}
+
 // LedgerStateView provides low-level read access to ledger state.
 // This interface matches tx.LedgerView for pathfinding and other operations
 // that need direct state access. Any *ledger.Ledger satisfies this.

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -119,11 +119,10 @@ func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer)
 	}
 	return &WebSocketServer{
 		upgrader: websocket.Upgrader{
-			CheckOrigin: func(r *http.Request) bool {
-				// TODO: Implement proper origin checking for security
-				// For now, allow all origins (matching rippled behavior)
-				return true
-			},
+			// Accept any Origin, deliberately matching rippled: its WS
+			// server never validates the Origin header — access control
+			// is done via admin IP nets / port configuration instead.
+			CheckOrigin: func(r *http.Request) bool { return true },
 			// Don't require specific subprotocol - xrpl.js doesn't use one
 		},
 		subscriptionManager: &subscription.Manager{

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -941,14 +941,11 @@ func resolveWSClientIP(peerIP, upgradeForwardedFor string, portCtx *PortContext)
 }
 
 // RegisterAllMethods registers every RPC method available on the WebSocket
-// endpoint: the universal HTTP/WS set plus the WebSocket-only commands
-// (subscribe / unsubscribe). The HTTP server intentionally omits the
-// WebSocket-only set so clients hitting those over HTTP get
-// methodNotFound rather than "method exists, returns notSupported"
-// (#428 audit, P2).
+// endpoint. subscribe/unsubscribe are part of the common table (as in
+// rippled); the WebSocket dispatch intercepts both before registry lookup
+// and runs the real subscription implementation.
 func (ws *WebSocketServer) RegisterAllMethods() {
 	handlers.RegisterAll(ws.methodRegistry)
-	handlers.RegisterWebSocketOnly(ws.methodRegistry)
 }
 
 // GetSubscriptionManager returns the subscription manager for event publishing

--- a/internal/testing/assertions.go
+++ b/internal/testing/assertions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -270,37 +271,20 @@ func FormatBalance(drops uint64) string {
 	return fmt.Sprintf("%.6f XRP (%d drops)", xrp, drops)
 }
 
-// RequireLines asserts that an account has the expected number of trust lines.
-// This counts RippleState entries in the account's owner directory.
-func RequireLines(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+// requireOwnedEntries asserts that an account's owner directory holds the
+// expected number of entries of the given ledger entry type. The owner
+// directory mixes object types (trust lines, offers, escrows, ...), so
+// counting filters by type; for trust lines both the low and high side
+// directories reference the shared RippleState entry, so each line the
+// account participates in is counted exactly once.
+func requireOwnedEntries(t *testing.T, env *TestEnv, acc *Account, entryType uint16, label string, expected uint32) {
 	t.Helper()
 	info := env.AccountInfo(acc)
 	if info == nil {
 		if expected == 0 {
-			return // Account doesn't exist, 0 lines is correct
+			return // Account doesn't exist, 0 entries is correct
 		}
-		require.Fail(t, fmt.Sprintf("Account %s does not exist, expected %d lines", acc.Name, expected))
-		return
-	}
-	// For now, we approximate using owner count
-	// In a full implementation, we'd count only RippleState entries
-	// This is a simplification - owner count includes all owned objects
-	// TODO: Implement proper trust line counting by iterating owner directory
-	require.Equal(t, expected, info.OwnerCount,
-		"Account %s trust line count mismatch: expected %d, got %d (owner count)",
-		acc.Name, expected, info.OwnerCount)
-}
-
-// RequireOffers asserts that an account has the expected number of offers.
-// This counts Offer entries in the account's owner directory.
-func RequireOffers(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
-	t.Helper()
-	info := env.AccountInfo(acc)
-	if info == nil {
-		if expected == 0 {
-			return // Account doesn't exist, 0 offers is correct
-		}
-		require.Fail(t, fmt.Sprintf("Account %s does not exist, expected %d offers", acc.Name, expected))
+		require.Fail(t, fmt.Sprintf("Account %s does not exist, expected %d %s", acc.Name, expected, label))
 		return
 	}
 	dirKey := keylet.OwnerDir(acc.ID)
@@ -311,20 +295,33 @@ func RequireOffers(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
 		if readErr != nil || len(data) == 0 {
 			return nil
 		}
-		entryType, typeErr := state.GetLedgerEntryType(data)
+		itemType, typeErr := state.GetLedgerEntryType(data)
 		if typeErr != nil {
 			return nil
 		}
-		// Offer type = 0x006f
-		if entryType == 0x006f {
+		if itemType == entryType {
 			count++
 		}
 		return nil
 	})
 	require.NoError(t, err, "Account %s: failed to iterate owner directory", acc.Name)
 	require.Equal(t, expected, count,
-		"Account %s offer count mismatch: expected %d, got %d",
-		acc.Name, expected, count)
+		"Account %s %s count mismatch: expected %d, got %d",
+		acc.Name, label, expected, count)
+}
+
+// RequireLines asserts that an account has the expected number of trust lines.
+// This counts RippleState entries in the account's owner directory.
+func RequireLines(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+	t.Helper()
+	requireOwnedEntries(t, env, acc, uint16(entry.TypeRippleState), "trust line", expected)
+}
+
+// RequireOffers asserts that an account has the expected number of offers.
+// This counts Offer entries in the account's owner directory.
+func RequireOffers(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+	t.Helper()
+	requireOwnedEntries(t, env, acc, uint16(entry.TypeOffer), "offer", expected)
 }
 
 // RequireFlags asserts that an account has the expected flags set.

--- a/internal/testing/escrow/token_escrow_test.go
+++ b/internal/testing/escrow/token_escrow_test.go
@@ -746,3 +746,148 @@ func TestIOUEscrow_MultipleEscrows(t *testing.T) {
 	require.InDelta(t, 5500.0, postBobUSD, 0.001,
 		"bob should gain 500 from the finished escrow")
 }
+
+// --------------------------------------------------------------------------
+// TestIOUEscrow_FinishTrustLine
+// Reference: rippled EscrowToken_test.cpp testIOUFinishDoApply
+//
+// EscrowFinish auto-creates the destination's trust line only when the
+// destination itself submits the finish (createAsset); third-party
+// finishers get tecNO_LINE / tecLIMIT_EXCEEDED instead.
+// --------------------------------------------------------------------------
+
+func TestIOUEscrow_FinishTrustLine(t *testing.T) {
+	// reserveShortBob asks newFinishEnv to fund bob with one drop less than
+	// the reserve needed to add a trust line (accountReserve(0) + increment
+	// - 1, like rippled's testIOUFinishDoApply).
+	const reserveShortBob = uint64(0)
+
+	// newFinishEnv funds gw and alice, flags gw with AllowTrustLineLocking,
+	// gives alice an aliceLimit USD trust line fully funded to aliceBalance,
+	// and funds bob with bobDrops XRP and NO USD trust line.
+	newFinishEnv := func(t *testing.T, bobDrops uint64, aliceLimit string, aliceBalance float64) (*jtx.TestEnv, *jtx.Account, *jtx.Account, *jtx.Account) {
+		t.Helper()
+		env := jtx.NewTestEnv(t)
+		env.EnableFeature("TokenEscrow")
+
+		gw := jtx.NewAccount("gateway")
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+
+		if bobDrops == reserveShortBob {
+			bobDrops = env.ReserveBase() + env.ReserveIncrement() - 1
+		}
+
+		fund5000(env, gw, alice)
+		env.FundAmount(bob, bobDrops)
+		env.Close()
+
+		result := env.Submit(accountset.AccountSet(gw).AllowTrustLineLocking().Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		result = env.Submit(trustset.TrustLine(alice, "USD", gw, aliceLimit).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		result = env.Submit(payment.PayIssued(gw, alice, usd(aliceBalance, gw)).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		return env, gw, alice, bob
+	}
+
+	createEscrow := func(t *testing.T, env *jtx.TestEnv, alice, bob *jtx.Account, gw *jtx.Account, amount float64) uint32 {
+		t.Helper()
+		seq := env.Seq(alice)
+		result := env.Submit(
+			escrow.EscrowCreate(alice, bob, 0).
+				IOUAmount(usd(amount, gw)).
+				Condition(escrow.TestCondition1).
+				FinishTime(env.Now().Add(1 * time.Second)).
+				Fee(baseFee * 150).
+				Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		return seq
+	}
+
+	finish := func(env *jtx.TestEnv, submitter, owner *jtx.Account, seq uint32) jtx.TxResult {
+		return env.Submit(
+			escrow.EscrowFinish(submitter, owner, seq).
+				Condition(escrow.TestCondition1).
+				Fulfillment(escrow.TestFulfillment1).
+				Fee(baseFee * 150).
+				Build())
+	}
+
+	t.Run("InsufficientReserveToCreateLine", func(t *testing.T) {
+		// tecNO_LINE_INSUF_RESERVE: bob cannot cover the new line's reserve
+		env, gw, alice, bob := newFinishEnv(t, reserveShortBob, "10000", 10000)
+		seq := createEscrow(t, env, alice, bob, gw, 1)
+
+		jtx.RequireTxFail(t, finish(env, bob, alice, seq), "tecNO_LINE_INSUF_RESERVE")
+	})
+
+	t.Run("ThirdPartyFinishWithoutLine", func(t *testing.T) {
+		// tecNO_LINE: alice submits; the destination line is not created
+		env, gw, alice, bob := newFinishEnv(t, uint64(jtx.XRP(5000)), "10000", 10000)
+		seq := createEscrow(t, env, alice, bob, gw, 1)
+
+		jtx.RequireTxFail(t, finish(env, alice, alice, seq), "tecNO_LINE")
+		require.False(t, env.TrustLineExists(bob, gw, "USD"))
+	})
+
+	t.Run("ThirdPartyFinishLimitExceeded", func(t *testing.T) {
+		// tecLIMIT_EXCEEDED: alice submits; bob's limit < balance + amount
+		env, gw, alice, bob := newFinishEnv(t, uint64(jtx.XRP(5000)), "1000", 1000)
+		result := env.Submit(trustset.TrustLine(bob, "USD", gw, "1000").Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		seq := createEscrow(t, env, alice, bob, gw, 5)
+
+		result = env.Submit(trustset.TrustLine(bob, "USD", gw, "1").Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		jtx.RequireTxFail(t, finish(env, alice, alice, seq), "tecLIMIT_EXCEEDED")
+	})
+
+	t.Run("DestinationFinishIgnoresLimit", func(t *testing.T) {
+		// tesSUCCESS: bob submits; his limit is below balance + amount but
+		// the receiver of the funds is not limit-checked, and the limit is
+		// left unchanged.
+		env, gw, alice, bob := newFinishEnv(t, uint64(jtx.XRP(5000)), "1000", 1000)
+		result := env.Submit(trustset.TrustLine(bob, "USD", gw, "1000").Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		seq := createEscrow(t, env, alice, bob, gw, 5)
+
+		result = env.Submit(trustset.TrustLine(bob, "USD", gw, "1").Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		jtx.RequireTxSuccess(t, finish(env, bob, alice, seq))
+		env.Close()
+
+		require.InDelta(t, 1.0, env.Limit(bob, gw, "USD"), 0.0001, "bob's limit must not change")
+		require.InDelta(t, 5.0, env.BalanceIOU(bob, "USD", gw), 0.0001)
+	})
+
+	t.Run("DestinationFinishCreatesLine", func(t *testing.T) {
+		// tesSUCCESS: bob submits with no USD trust line at all; the line is
+		// auto-created with a zero limit and credited.
+		env, gw, alice, bob := newFinishEnv(t, uint64(jtx.XRP(5000)), "10000", 10000)
+		seq := createEscrow(t, env, alice, bob, gw, 1)
+
+		require.False(t, env.TrustLineExists(bob, gw, "USD"))
+		jtx.RequireTxSuccess(t, finish(env, bob, alice, seq))
+		env.Close()
+
+		require.True(t, env.TrustLineExists(bob, gw, "USD"), "destination trust line must be auto-created")
+		require.InDelta(t, 0.0, env.Limit(bob, gw, "USD"), 0.0001, "auto-created line has a zero limit")
+		require.InDelta(t, 1.0, env.BalanceIOU(bob, "USD", gw), 0.0001)
+	})
+}

--- a/internal/testing/mpt/builder.go
+++ b/internal/testing/mpt/builder.go
@@ -534,24 +534,31 @@ func (m *MPTTester) MPTAmount(amount int64) tx.Amount {
 	return state.NewMPTAmountDirect(amount, "MPT", m.issuer.Address)
 }
 
-// CheckMPTokenAmount verifies the MPTAmount balance for a holder.
-// Reference: rippled MPTTester::checkMPTokenAmount()
-func (m *MPTTester) CheckMPTokenAmount(holder *jtx.Account, expected int64) bool {
+// mptokenAmount reads the holder's MPToken balance from the ledger.
+// A missing entry reads as 0, matching rippled's accountHolds semantics.
+func (m *MPTTester) mptokenAmount(holder *jtx.Account) uint64 {
 	m.t.Helper()
-	// Read the MPToken ledger entry for this holder
 	mptID := decodeMPTID(m.id)
 	issuanceKey := keylet.MPTIssuance(mptID)
 	tokenKey := keylet.MPToken(issuanceKey.Key, holder.ID)
 
 	data, err := m.env.Ledger().Read(tokenKey)
 	if err != nil || data == nil {
-		return expected == 0 // If no entry exists, balance is 0
+		return 0
 	}
 
-	// Parse the MPTAmount field from the entry
-	// The MPToken entry contains the holder's balance
-	_ = data // TODO: Parse actual MPToken entry and check amount
-	return true
+	token, err := state.ParseMPToken(data)
+	if err != nil {
+		m.t.Fatalf("failed to parse MPToken entry: %v", err)
+	}
+	return token.MPTAmount
+}
+
+// CheckMPTokenAmount verifies the MPTAmount balance for a holder.
+// Reference: rippled MPTTester::checkMPTokenAmount()
+func (m *MPTTester) CheckMPTokenAmount(holder *jtx.Account, expected int64) bool {
+	m.t.Helper()
+	return m.mptokenAmount(holder) == uint64(expected)
 }
 
 // CheckMPTokenOutstandingAmount verifies the OutstandingAmount on the issuance.
@@ -566,15 +573,18 @@ func (m *MPTTester) CheckMPTokenOutstandingAmount(expected int64) bool {
 		return expected == 0
 	}
 
-	_ = data // TODO: Parse actual MPTokenIssuance entry and check outstanding amount
-	return true
+	issuance, err := state.ParseMPTokenIssuance(data)
+	if err != nil {
+		m.t.Fatalf("failed to parse MPTokenIssuance entry: %v", err)
+	}
+	return issuance.OutstandingAmount == uint64(expected)
 }
 
 // RequireMPTokenAmount asserts the MPTAmount balance for a holder.
 func (m *MPTTester) RequireMPTokenAmount(holder *jtx.Account, expected int64) {
 	m.t.Helper()
-	require.True(m.t, m.CheckMPTokenAmount(holder, expected),
-		"MPToken amount mismatch for holder %s: expected %d", holder.Name, expected)
+	require.Equal(m.t, uint64(expected), m.mptokenAmount(holder),
+		"MPToken amount mismatch for holder %s", holder.Name)
 }
 
 // --------------------------------------------------------------------------

--- a/internal/testing/oracle/oracle_test.go
+++ b/internal/testing/oracle/oracle_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
 	oracletest "github.com/LeJamon/go-xrpl/internal/testing/oracle"
@@ -36,6 +37,21 @@ func defaultLUT(env *jtx.TestEnv) uint32 {
 
 // baseFee returns the base fee used in the test env.
 const baseFee = uint64(10)
+
+// oracleQuoteAssets reads the oracle SLE and returns the QuoteAsset of each
+// PriceData entry in on-ledger array order.
+func oracleQuoteAssets(t *testing.T, env *jtx.TestEnv, owner *jtx.Account, docID uint32) []string {
+	t.Helper()
+	data, err := env.LedgerEntry(keylet.Oracle(owner.ID, docID))
+	require.NoError(t, err)
+	oracle, err := state.ParseOracle(data)
+	require.NoError(t, err)
+	assets := make([]string, len(oracle.PriceDataSeries))
+	for i, pd := range oracle.PriceDataSeries {
+		assets[i] = pd.QuoteAsset
+	}
+	return assets
+}
 
 // oracleExists checks if an oracle ledger entry exists.
 func oracleExists(t *testing.T, env *jtx.TestEnv, owner *jtx.Account, docID uint32) bool {
@@ -1408,8 +1424,12 @@ func TestUpdate(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		require.True(t, oracleExists(t, env, owner, 1))
 
-		// Update with same pairs — without fix, pair order should change
-		// (pairs get sorted by currency during map iteration)
+		// Without the fix, create stores the series in transaction order.
+		before := oracleQuoteAssets(t, env, owner, 1)
+		require.Equal(t, []string{"USD", "EUR"}, before)
+
+		// Update with same pairs — without fix, pair order changes because
+		// the update path always rebuilds the series sorted by token pair.
 		lut2 := lut + 1
 		result = env.Submit(oracletest.OracleSet(owner, 1, lut2).
 			AddPrice("XRP", "USD", 742, 2).
@@ -1418,8 +1438,10 @@ func TestUpdate(t *testing.T) {
 			Build())
 		jtx.RequireTxSuccess(t, result)
 
-		// TODO: Verify pair ordering changed (requires SLE parsing)
-		// Without fix, afterQuoteAsset[0] != beforeQuoteAsset[0]
+		after := oracleQuoteAssets(t, env, owner, 1)
+		require.NotEqual(t, before[0], after[0])
+		require.NotEqual(t, before[1], after[1])
+		require.Equal(t, []string{"EUR", "USD"}, after)
 	})
 
 	t.Run("FixPriceOracleOrder_Enabled", func(t *testing.T) {
@@ -1441,7 +1463,11 @@ func TestUpdate(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		require.True(t, oracleExists(t, env, owner, 1))
 
-		// Update with same pairs — with fix, pair order should be preserved
+		// With the fix, create already stores the series sorted by token
+		// pair, so the always-sorted update preserves the order.
+		before := oracleQuoteAssets(t, env, owner, 1)
+		require.Equal(t, []string{"EUR", "USD"}, before)
+
 		lut2 := lut + 1
 		result = env.Submit(oracletest.OracleSet(owner, 1, lut2).
 			AddPrice("XRP", "USD", 742, 2).
@@ -1450,8 +1476,8 @@ func TestUpdate(t *testing.T) {
 			Build())
 		jtx.RequireTxSuccess(t, result)
 
-		// TODO: Verify pair ordering preserved (requires SLE parsing)
-		// With fix, afterQuoteAsset[0] == beforeQuoteAsset[0]
+		after := oracleQuoteAssets(t, env, owner, 1)
+		require.Equal(t, before, after)
 	})
 }
 

--- a/internal/testing/pathfuzz/pathfinder_fuzz_test.go
+++ b/internal/testing/pathfuzz/pathfinder_fuzz_test.go
@@ -14,8 +14,8 @@ import (
 // maxPathQueries bounds the number of path-discovery requests per fuzz iteration.
 const maxPathQueries = 8
 
-// pathBudget bounds a single path-discovery request. Discovery searches to
-// DefaultSearchLevel (7) over the auto-discovered source currencies, but the
+// pathBudget bounds a single path-discovery request. Discovery searches at
+// level 7 over the auto-discovered source currencies, but the
 // scenario ledger is small, so a request completes in milliseconds; blowing the
 // budget means the search failed to stay bounded.
 const pathBudget = 8 * time.Second
@@ -75,9 +75,8 @@ func (sc *scenario) pathQuery(s *stream) {
 	}
 
 	for i, alt := range res.Alternatives {
-		if len(alt.PathsComputed) == 0 {
-			sc.t.Fatalf("path alternative %d has no computed paths (%s -> %s deliver %s)", i, from.Name, to.Name, fmtAmt(dst))
-		}
+		// An alternative with empty paths_computed is valid: it means the
+		// default path alone delivers the amount (rippled returns these too).
 		// A returned alternative is one RippleCalc validated as delivering the
 		// target, so its source cost must be non-negative — a negative source
 		// amount would mean the path manufactures value.
@@ -96,6 +95,7 @@ func (sc *scenario) execute(from, to *jtx.Account, dst tx.Amount, sendMax *tx.Am
 		}
 	}()
 	pr := pathfinder.NewPathRequest(from.ID, to.ID, dst, sendMax, nil, false)
+	pr.SetSearchLevel(7)
 	return pr.Execute(sc.env.Ledger())
 }
 

--- a/internal/testing/payment/freeze_amm_test.go
+++ b/internal/testing/payment/freeze_amm_test.go
@@ -1,0 +1,118 @@
+// AMM-on-frozen-trust-line tests ported from rippled's Freeze_test.cpp
+// testAMMWhenFreeze. Lives in package payment_test (not payment) because
+// the AMM builders in internal/testing/amm import this package's payment
+// builders — an in-package test importing them would form an import cycle.
+package payment_test
+
+import (
+	"testing"
+
+	xrplgoTesting "github.com/LeJamon/go-xrpl/internal/testing"
+	ammtest "github.com/LeJamon/go-xrpl/internal/testing/amm"
+	paytest "github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	trustsettx "github.com/LeJamon/go-xrpl/internal/tx/trustset"
+)
+
+// TestFreeze_AMMWhenFrozen tests AMM payments on frozen trust lines.
+// From rippled: testAMMWhenFreeze
+func TestFreeze_AMMWhenFrozen(t *testing.T) {
+	setLineFreeze := func(t *testing.T, env *xrplgoTesting.TestEnv, issuer, holder *xrplgoTesting.Account, flags uint32) {
+		t.Helper()
+		ts := trustset.TrustLine(issuer, "USD", holder, "0").BuildTrustSet()
+		ts.SetFlags(flags)
+		xrplgoTesting.RequireTxSuccess(t, env.Submit(ts))
+		env.Close()
+	}
+
+	run := func(t *testing.T, deepFreeze bool) {
+		env := xrplgoTesting.NewTestEnv(t)
+		if deepFreeze {
+			env.EnableFeature("DeepFreeze")
+		}
+
+		G1 := xrplgoTesting.NewAccount("G1")
+		A1 := xrplgoTesting.NewAccount("A1")
+		A2 := xrplgoTesting.NewAccount("A2")
+
+		env.FundAmount(G1, uint64(xrplgoTesting.XRP(10000)))
+		env.FundAmount(A1, uint64(xrplgoTesting.XRP(10000)))
+		env.FundAmount(A2, uint64(xrplgoTesting.XRP(10000)))
+		env.Close()
+
+		xrplgoTesting.RequireTxSuccess(t, env.Submit(trustset.TrustLine(A1, "USD", G1, "10000").Build()))
+		xrplgoTesting.RequireTxSuccess(t, env.Submit(trustset.TrustLine(A2, "USD", G1, "10000").Build()))
+		env.Close()
+
+		usd1000 := tx.NewIssuedAmountFromFloat64(1000, "USD", G1.Address)
+		xrplgoTesting.RequireTxSuccess(t, env.Submit(paytest.PayIssued(G1, A1, usd1000).Build()))
+		xrplgoTesting.RequireTxSuccess(t, env.Submit(paytest.PayIssued(G1, A2, usd1000).Build()))
+		env.Close()
+
+		// G1 creates an AMM with XRP(1000) and USD(1000).
+		result := env.Submit(ammtest.AMMCreate(G1,
+			tx.NewXRPAmount(xrplgoTesting.XRP(1000)), usd1000).Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Freeze G1→A1's USD line (deep freeze additionally blocks
+		// receiving USD).
+		freezeFlags := trustsettx.TrustSetFlagSetFreeze
+		clearFlags := trustsettx.TrustSetFlagClearFreeze
+		if deepFreeze {
+			freezeFlags |= trustsettx.TrustSetFlagSetDeepFreeze
+			clearFlags |= trustsettx.TrustSetFlagClearDeepFreeze
+		}
+		setLineFreeze(t, env, G1, A1, freezeFlags)
+
+		usd10 := tx.NewIssuedAmountFromFloat64(10, "USD", G1.Address)
+		usd11 := tx.NewIssuedAmountFromFloat64(11, "USD", G1.Address)
+		xrp11 := tx.NewXRPAmount(xrplgoTesting.XRP(11))
+
+		// A1 can still use XRP to make a payment through the AMM.
+		result = env.Submit(paytest.PayIssued(A1, A2, usd10).
+			PathsCurrency("USD", G1).
+			SendMax(xrp11).
+			NoDirectRipple().
+			Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+		env.Close()
+
+		// A1 cannot spend frozen USD through the AMM.
+		result = env.Submit(paytest.Pay(A1, A2, uint64(xrplgoTesting.XRP(10))).
+			PathsCurrency("XRP", nil).
+			SendMax(usd11).
+			NoDirectRipple().
+			Build())
+		xrplgoTesting.RequireTxFail(t, result, xrplgoTesting.TecPATH_DRY)
+		env.Close()
+
+		// Receiving USD: blocked only by deep freeze.
+		result = env.Submit(paytest.PayIssued(A2, A1, usd10).
+			PathsCurrency("USD", G1).
+			SendMax(xrp11).
+			NoDirectRipple().
+			Build())
+		if deepFreeze {
+			xrplgoTesting.RequireTxFail(t, result, xrplgoTesting.TecPATH_DRY)
+		} else {
+			xrplgoTesting.RequireTxSuccess(t, result)
+		}
+		env.Close()
+
+		// A1 can still receive XRP payments funded by A2's USD.
+		result = env.Submit(paytest.Pay(A2, A1, uint64(xrplgoTesting.XRP(10))).
+			PathsCurrency("XRP", nil).
+			SendMax(usd11).
+			NoDirectRipple().
+			Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+		env.Close()
+
+		setLineFreeze(t, env, G1, A1, clearFlags)
+	}
+
+	t.Run("Freeze", func(t *testing.T) { run(t, false) })
+	t.Run("DeepFreeze", func(t *testing.T) { run(t, true) })
+}

--- a/internal/testing/payment/freeze_test.go
+++ b/internal/testing/payment/freeze_test.go
@@ -710,39 +710,6 @@ func TestFreeze_CreateFrozenTrustline(t *testing.T) {
 	t.Log("Create frozen trustline test: verified")
 }
 
-// TestFreeze_AMMWhenFrozen tests AMM payments on frozen trust lines.
-// From rippled: testAMMWhenFreeze
-func TestFreeze_AMMWhenFrozen(t *testing.T) {
-	t.Skip("TODO: AMM requires AMM creation support")
-
-	env := xrplgoTesting.NewTestEnv(t)
-
-	gw := xrplgoTesting.NewAccount("gateway")
-	alice := xrplgoTesting.NewAccount("alice")
-	bob := xrplgoTesting.NewAccount("bob")
-
-	env.FundAmount(gw, uint64(xrplgoTesting.XRP(10000)))
-	env.FundAmount(alice, uint64(xrplgoTesting.XRP(10000)))
-	env.FundAmount(bob, uint64(xrplgoTesting.XRP(10000)))
-	env.Close()
-
-	// Set up trust lines
-	result := env.Submit(trustset.TrustLine(alice, "USD", gw, "10000").Build())
-	xrplgoTesting.RequireTxSuccess(t, result)
-	result = env.Submit(trustset.TrustLine(bob, "USD", gw, "10000").Build())
-	xrplgoTesting.RequireTxSuccess(t, result)
-	env.Close()
-
-	// Fund both accounts
-	usd1000 := tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address)
-	result = env.Submit(PayIssued(gw, alice, usd1000).Build())
-	xrplgoTesting.RequireTxSuccess(t, result)
-	result = env.Submit(PayIssued(gw, bob, usd1000).Build())
-	xrplgoTesting.RequireTxSuccess(t, result)
-	env.Close()
-
-	// Gateway creates AMM with XRP(1000) and USD(1000)
-	// TODO: AMM creation
-
-	t.Log("AMM when frozen test: requires AMM creation support")
-}
+// TestFreeze_AMMWhenFrozen (rippled testAMMWhenFreeze) lives in
+// freeze_amm_test.go, in package payment_test, because the AMM builders it
+// needs import this package.

--- a/internal/testing/payment/path_test.go
+++ b/internal/testing/payment/path_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	xrplgoTesting "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/rpcenv"
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
@@ -1386,28 +1387,188 @@ func TestPath_IssuesRippleClientIssue23Larger(t *testing.T) {
 	require.InDelta(t, 25.0, bobDanBal, 0.0001, "Bob should have 25 dan/USD")
 }
 
+// requireAllPathsEmpty asserts every alternative carries an empty path set
+// (the default path suffices), matching rippled's `BEAST_EXPECT(st.empty())`.
+func requireAllPathsEmpty(t *testing.T, pfResult *pathfinder.PathRequestResult) {
+	t.Helper()
+	for _, alt := range pfResult.Alternatives {
+		for _, p := range alt.PathsComputed {
+			require.Empty(t, p, "expected empty path set (default path only)")
+		}
+		require.Empty(t, alt.PathsComputed)
+	}
+}
+
+// xrpIssue is the explicit XRP source currency (rippled xrpCurrency()).
+var xrpIssue = []payment.Issue{{Currency: "XRP"}}
+
 // TestPath_PathFind01 tests Path Find: XRP -> XRP and XRP -> IOU.
 // From rippled: Path_test::path_find_01
 func TestPath_PathFind01(t *testing.T) {
-	t.Skip("TODO: Requires ripple_path_find RPC and offers")
+	env := xrplgoTesting.NewTestEnv(t)
 
-	// Test various path finding scenarios:
-	// - XRP -> XRP direct (no path needed)
-	// - XRP -> non-existent account (empty path)
-	// - XRP -> IOU via offers
-	// - XRP -> IOU via multiple hops
-	t.Log("Path find 01 test: requires RPC path finding and offers")
+	a1 := xrplgoTesting.NewAccount("A1")
+	a2 := xrplgoTesting.NewAccount("A2")
+	a3 := xrplgoTesting.NewAccount("A3")
+	g1 := xrplgoTesting.NewAccount("G1")
+	g2 := xrplgoTesting.NewAccount("G2")
+	g3 := xrplgoTesting.NewAccount("G3")
+	m1 := xrplgoTesting.NewAccount("M1")
+
+	env.FundAmount(a1, uint64(xrplgoTesting.XRP(100000)))
+	env.FundAmount(a2, uint64(xrplgoTesting.XRP(10000)))
+	for _, acc := range []*xrplgoTesting.Account{a3, g1, g2, g3, m1} {
+		env.FundAmount(acc, uint64(xrplgoTesting.XRP(1000)))
+	}
+	env.Close()
+
+	for _, tl := range []struct {
+		holder *xrplgoTesting.Account
+		cur    string
+		issuer *xrplgoTesting.Account
+		limit  string
+	}{
+		{a1, "XYZ", g1, "5000"},
+		{a1, "ABC", g3, "5000"},
+		{a2, "XYZ", g2, "5000"},
+		{a2, "ABC", g3, "5000"},
+		{a3, "ABC", a2, "1000"},
+		{m1, "XYZ", g1, "100000"},
+		{m1, "XYZ", g2, "100000"},
+		{m1, "ABC", g3, "100000"},
+	} {
+		result := env.Submit(trustset.TrustLine(tl.holder, tl.cur, tl.issuer, tl.limit).Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+	}
+	env.Close()
+
+	result := env.Submit(PayIssued(g1, a1, tx.NewIssuedAmountFromFloat64(3500, "XYZ", g1.Address)).Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	result = env.Submit(PayIssued(g3, a1, tx.NewIssuedAmountFromFloat64(1200, "ABC", g3.Address)).Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	result = env.Submit(PayIssued(g2, m1, tx.NewIssuedAmountFromFloat64(25000, "XYZ", g2.Address)).Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	result = env.Submit(PayIssued(g3, m1, tx.NewIssuedAmountFromFloat64(25000, "ABC", g3.Address)).Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	// offer(M1, G1["XYZ"](1000), G2["XYZ"](1000)): pays G1/XYZ, gets G2/XYZ
+	result = env.CreateOffer(m1,
+		tx.NewIssuedAmountFromFloat64(1000, "XYZ", g2.Address),
+		tx.NewIssuedAmountFromFloat64(1000, "XYZ", g1.Address))
+	xrplgoTesting.RequireTxSuccess(t, result)
+	// offer(M1, XRP(10000), G3["ABC"](1000)): pays XRP, gets G3/ABC
+	result = env.CreateOffer(m1,
+		tx.NewIssuedAmountFromFloat64(1000, "ABC", g3.Address),
+		tx.NewXRPAmount(xrplgoTesting.XRP(10000)))
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	t.Run("XRP to XRP", func(t *testing.T) {
+		pr := newPathRequest(a1.ID, a2.ID, tx.NewXRPAmount(xrplgoTesting.XRP(10)), nil, xrpIssue, false)
+		requireAllPathsEmpty(t, pr.Execute(env.Ledger()))
+	})
+
+	t.Run("XRP to non-existent account", func(t *testing.T) {
+		ghost := xrplgoTesting.NewAccount("A0")
+		pr := newPathRequest(a1.ID, ghost.ID, tx.NewXRPAmount(xrplgoTesting.XRP(200)), nil, xrpIssue, false)
+		requireAllPathsEmpty(t, pr.Execute(env.Ledger()))
+	})
+
+	t.Run("XRP to gateway IOU via offer", func(t *testing.T) {
+		sendAmt := tx.NewIssuedAmountFromFloat64(10, "ABC", g3.Address)
+		pr := newPathRequest(a2.ID, g3.ID, sendAmt, nil, xrpIssue, false)
+		pfResult := pr.Execute(env.Ledger())
+
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.True(t, alt.SourceAmount.IsNative())
+		require.EqualValues(t, xrplgoTesting.XRP(100), alt.SourceAmount.Drops(), "10 ABC at 10 XRP/ABC costs 100 XRP")
+		requireSamePaths(t, alt.PathsComputed,
+			[]payment.PathStep{bookStepIOU("ABC", g3)})
+	})
+
+	t.Run("XRP to user IOU via offer and gateway", func(t *testing.T) {
+		sendAmt := tx.NewIssuedAmountFromFloat64(1, "ABC", a2.Address)
+		pr := newPathRequest(a1.ID, a2.ID, sendAmt, nil, xrpIssue, false)
+		pfResult := pr.Execute(env.Ledger())
+
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.True(t, alt.SourceAmount.IsNative())
+		require.EqualValues(t, xrplgoTesting.XRP(10), alt.SourceAmount.Drops())
+		requireSamePaths(t, alt.PathsComputed,
+			[]payment.PathStep{bookStepIOU("ABC", g3), acctStep(g3)})
+	})
+
+	t.Run("XRP to user IOU via offer gateway and rippling", func(t *testing.T) {
+		sendAmt := tx.NewIssuedAmountFromFloat64(1, "ABC", a3.Address)
+		pr := newPathRequest(a1.ID, a3.ID, sendAmt, nil, xrpIssue, false)
+		pfResult := pr.Execute(env.Ledger())
+
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.True(t, alt.SourceAmount.IsNative())
+		require.EqualValues(t, xrplgoTesting.XRP(10), alt.SourceAmount.Drops())
+		requireSamePaths(t, alt.PathsComputed,
+			[]payment.PathStep{bookStepIOU("ABC", g3), acctStep(g3), acctStep(a2)})
+	})
 }
 
 // TestPath_PathFind02 tests Path Find: non-XRP -> XRP.
 // From rippled: Path_test::path_find_02
 func TestPath_PathFind02(t *testing.T) {
-	t.Skip("TODO: Requires ripple_path_find RPC and offers")
+	env := xrplgoTesting.NewTestEnv(t)
 
-	// Test path finding from IOU to XRP via offer
-	// A1 sends ABC -> A2 receives XRP
-	// Path goes through offer: ABC -> XRP
-	t.Log("Path find 02 test: requires RPC path finding and offers")
+	a1 := xrplgoTesting.NewAccount("A1")
+	a2 := xrplgoTesting.NewAccount("A2")
+	g3 := xrplgoTesting.NewAccount("G3")
+	m1 := xrplgoTesting.NewAccount("M1")
+
+	env.FundAmount(a1, uint64(xrplgoTesting.XRP(1000)))
+	env.FundAmount(a2, uint64(xrplgoTesting.XRP(1000)))
+	env.FundAmount(g3, uint64(xrplgoTesting.XRP(1000)))
+	env.FundAmount(m1, uint64(xrplgoTesting.XRP(11000)))
+	env.Close()
+
+	for _, tl := range []struct {
+		holder *xrplgoTesting.Account
+		limit  string
+	}{{a1, "1000"}, {a2, "1000"}, {m1, "100000"}} {
+		result := env.Submit(trustset.TrustLine(tl.holder, "ABC", g3, tl.limit).Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+	}
+	env.Close()
+
+	for _, p := range []struct {
+		to     *xrplgoTesting.Account
+		amount float64
+	}{{a1, 1000}, {a2, 1000}, {m1, 1200}} {
+		result := env.Submit(PayIssued(g3, p.to, tx.NewIssuedAmountFromFloat64(p.amount, "ABC", g3.Address)).Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+	}
+	env.Close()
+
+	// offer(M1, G3["ABC"](1000), XRP(10000)): pays G3/ABC, gets XRP
+	result := env.CreateOffer(m1,
+		tx.NewXRPAmount(xrplgoTesting.XRP(10000)),
+		tx.NewIssuedAmountFromFloat64(1000, "ABC", g3.Address))
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	// A1 -> A2 XRP(10) with source currency ABC: 1 ABC through G3 and the
+	// ABC/XRP book.
+	srcCurrencies := []payment.Issue{{Currency: "ABC", Issuer: a1.ID}}
+	pr := newPathRequest(a1.ID, a2.ID, tx.NewXRPAmount(xrplgoTesting.XRP(10)), nil, srcCurrencies, false)
+	pfResult := pr.Execute(env.Ledger())
+
+	require.NotEmpty(t, pfResult.Alternatives)
+	alt := pfResult.Alternatives[0]
+	require.False(t, alt.SourceAmount.IsNative())
+	require.Equal(t, "ABC", alt.SourceAmount.Currency)
+	require.InDelta(t, 1.0, alt.SourceAmount.Float64(), 0.0001)
+	requireSamePaths(t, alt.PathsComputed,
+		[]payment.PathStep{acctStep(g3), bookStepXRP()})
 }
 
 // TestPath_PathFind04 tests Bitstamp and SnapSwap liquidity with no offers.
@@ -1555,35 +1716,302 @@ func TestPath_PathFind04(t *testing.T) {
 // TestPath_PathFind05 tests non-XRP -> non-XRP, same currency.
 // From rippled: Path_test::path_find_05
 func TestPath_PathFind05(t *testing.T) {
-	t.Skip("TODO: Requires ripple_path_find RPC and offers")
+	env := xrplgoTesting.NewTestEnv(t)
 
-	// Complex trust line setup for various path scenarios:
-	// A) Borrow or repay - Source -> Destination (direct to issuer)
-	// B) Common gateway - Source -> AC -> Destination
-	// C) Gateway to gateway - Source -> OB -> Destination
-	// D) User to unlinked gateway - Source -> AC -> OB -> Destination
-	// I4) XRP bridge - Source -> AC -> OB to XRP -> OB from XRP -> AC -> Destination
-	t.Log("Path find 05 test: requires RPC path finding and offers")
+	a1 := xrplgoTesting.NewAccount("A1")
+	a2 := xrplgoTesting.NewAccount("A2")
+	a3 := xrplgoTesting.NewAccount("A3")
+	a4 := xrplgoTesting.NewAccount("A4")
+	g1 := xrplgoTesting.NewAccount("G1")
+	g2 := xrplgoTesting.NewAccount("G2")
+	g3 := xrplgoTesting.NewAccount("G3")
+	g4 := xrplgoTesting.NewAccount("G4")
+	m1 := xrplgoTesting.NewAccount("M1")
+	m2 := xrplgoTesting.NewAccount("M2")
+
+	for _, acc := range []*xrplgoTesting.Account{a1, a2, a3, g1, g2, g3, g4} {
+		env.FundAmount(acc, uint64(xrplgoTesting.XRP(1000)))
+	}
+	env.FundAmount(a4, uint64(xrplgoTesting.XRP(10000)))
+	env.FundAmount(m1, uint64(xrplgoTesting.XRP(11000)))
+	env.FundAmount(m2, uint64(xrplgoTesting.XRP(11000)))
+	env.Close()
+
+	for _, tl := range []struct {
+		holder *xrplgoTesting.Account
+		issuer *xrplgoTesting.Account
+		limit  string
+	}{
+		{a1, g1, "2000"},
+		{a2, g2, "2000"},
+		{a3, g1, "2000"},
+		{m1, g1, "100000"},
+		{m1, g2, "100000"},
+		{m2, g1, "100000"},
+		{m2, g2, "100000"},
+	} {
+		result := env.Submit(trustset.TrustLine(tl.holder, "HKD", tl.issuer, tl.limit).Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+	}
+	env.Close()
+
+	for _, p := range []struct {
+		from, to *xrplgoTesting.Account
+		amount   float64
+	}{
+		{g1, a1, 1000},
+		{g2, a2, 1000},
+		{g1, a3, 1000},
+		{g1, m1, 1200},
+		{g2, m1, 5000},
+		{g1, m2, 1200},
+		{g2, m2, 5000},
+	} {
+		result := env.Submit(PayIssued(p.from, p.to, tx.NewIssuedAmountFromFloat64(p.amount, "HKD", p.from.Address)).Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+	}
+	env.Close()
+
+	// offer(M1, G1["HKD"](1000), G2["HKD"](1000)): pays G1/HKD, gets G2/HKD
+	result := env.CreateOffer(m1,
+		tx.NewIssuedAmountFromFloat64(1000, "HKD", g2.Address),
+		tx.NewIssuedAmountFromFloat64(1000, "HKD", g1.Address))
+	xrplgoTesting.RequireTxSuccess(t, result)
+	// offer(M2, XRP(10000), G2["HKD"](1000)): pays XRP, gets G2/HKD
+	result = env.CreateOffer(m2,
+		tx.NewIssuedAmountFromFloat64(1000, "HKD", g2.Address),
+		tx.NewXRPAmount(xrplgoTesting.XRP(10000)))
+	xrplgoTesting.RequireTxSuccess(t, result)
+	// offer(M2, G1["HKD"](1000), XRP(10000)): pays G1/HKD, gets XRP
+	result = env.CreateOffer(m2,
+		tx.NewXRPAmount(xrplgoTesting.XRP(10000)),
+		tx.NewIssuedAmountFromFloat64(1000, "HKD", g1.Address))
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	hkd := func(value float64, issuer *xrplgoTesting.Account) tx.Amount {
+		return tx.NewIssuedAmountFromFloat64(value, "HKD", issuer.Address)
+	}
+	findHKD := func(src, dst *xrplgoTesting.Account, sendAmt tx.Amount) *pathfinder.PathRequestResult {
+		srcCurrencies := []payment.Issue{{Currency: "HKD", Issuer: src.ID}}
+		pr := newPathRequest(src.ID, dst.ID, sendAmt, nil, srcCurrencies, false)
+		return pr.Execute(env.Ledger())
+	}
+
+	t.Run("A) repay source issuer", func(t *testing.T) {
+		pfResult := findHKD(a1, g1, hkd(10, g1))
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.Empty(t, alt.PathsComputed)
+		require.InDelta(t, 10.0, alt.SourceAmount.Float64(), 0.0001)
+	})
+
+	t.Run("A2) repay destination issuer", func(t *testing.T) {
+		pfResult := findHKD(a1, g1, hkd(10, a1))
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.Empty(t, alt.PathsComputed)
+		require.InDelta(t, 10.0, alt.SourceAmount.Float64(), 0.0001)
+	})
+
+	t.Run("B) common gateway", func(t *testing.T) {
+		pfResult := findHKD(a1, a3, hkd(10, a3))
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.InDelta(t, 10.0, alt.SourceAmount.Float64(), 0.0001)
+		requireSamePaths(t, alt.PathsComputed,
+			[]payment.PathStep{acctStep(g1)})
+	})
+
+	t.Run("C) gateway to gateway", func(t *testing.T) {
+		pfResult := findHKD(g1, g2, hkd(10, g2))
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.InDelta(t, 10.0, alt.SourceAmount.Float64(), 0.0001)
+		requireSamePaths(t, alt.PathsComputed,
+			[]payment.PathStep{bookStepIOU("HKD", g2)},
+			[]payment.PathStep{acctStep(m1)},
+			[]payment.PathStep{acctStep(m2)},
+			[]payment.PathStep{bookStepXRP(), bookStepIOU("HKD", g2)})
+	})
+
+	t.Run("D) user to unlinked gateway", func(t *testing.T) {
+		pfResult := findHKD(a1, g2, hkd(10, g2))
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.InDelta(t, 10.0, alt.SourceAmount.Float64(), 0.0001)
+		requireSamePaths(t, alt.PathsComputed,
+			[]payment.PathStep{acctStep(g1), acctStep(m1)},
+			[]payment.PathStep{acctStep(g1), acctStep(m2)},
+			[]payment.PathStep{acctStep(g1), bookStepIOU("HKD", g2)},
+			[]payment.PathStep{acctStep(g1), bookStepXRP(), bookStepIOU("HKD", g2)})
+	})
+
+	t.Run("I4) XRP bridge", func(t *testing.T) {
+		pfResult := findHKD(a1, a2, hkd(10, a2))
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.InDelta(t, 10.0, alt.SourceAmount.Float64(), 0.0001)
+		requireSamePaths(t, alt.PathsComputed,
+			[]payment.PathStep{acctStep(g1), acctStep(m1), acctStep(g2)},
+			[]payment.PathStep{acctStep(g1), acctStep(m2), acctStep(g2)},
+			[]payment.PathStep{acctStep(g1), bookStepIOU("HKD", g2), acctStep(g2)},
+			[]payment.PathStep{acctStep(g1), bookStepXRP(), bookStepIOU("HKD", g2), acctStep(g2)})
+	})
 }
 
 // TestPath_PathFind06 tests gateway to user path.
 // From rippled: Path_test::path_find_06
 func TestPath_PathFind06(t *testing.T) {
-	t.Skip("TODO: Requires ripple_path_find RPC and offers")
+	env := xrplgoTesting.NewTestEnv(t)
 
-	// E) Gateway to user - Source -> OB -> AC -> Destination
-	// G1 pays A2 (who trusts G2) via market maker M1
-	t.Log("Path find 06 test: requires RPC path finding and offers")
+	a1 := xrplgoTesting.NewAccount("A1")
+	a2 := xrplgoTesting.NewAccount("A2")
+	a3 := xrplgoTesting.NewAccount("A3")
+	g1 := xrplgoTesting.NewAccount("G1")
+	g2 := xrplgoTesting.NewAccount("G2")
+	m1 := xrplgoTesting.NewAccount("M1")
+
+	env.FundAmount(m1, uint64(xrplgoTesting.XRP(11000)))
+	for _, acc := range []*xrplgoTesting.Account{a1, a2, a3, g1, g2} {
+		env.FundAmount(acc, uint64(xrplgoTesting.XRP(1000)))
+	}
+	env.Close()
+
+	for _, tl := range []struct {
+		holder *xrplgoTesting.Account
+		issuer *xrplgoTesting.Account
+		limit  string
+	}{
+		{a1, g1, "2000"},
+		{a2, g2, "2000"},
+		{a3, a2, "2000"},
+		{m1, g1, "100000"},
+		{m1, g2, "100000"},
+	} {
+		result := env.Submit(trustset.TrustLine(tl.holder, "HKD", tl.issuer, tl.limit).Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+	}
+	env.Close()
+
+	for _, p := range []struct {
+		from, to *xrplgoTesting.Account
+		amount   float64
+	}{
+		{g1, a1, 1000},
+		{g2, a2, 1000},
+		{g1, m1, 5000},
+		{g2, m1, 5000},
+	} {
+		result := env.Submit(PayIssued(p.from, p.to, tx.NewIssuedAmountFromFloat64(p.amount, "HKD", p.from.Address)).Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+	}
+	env.Close()
+
+	// offer(M1, G1["HKD"](1000), G2["HKD"](1000)): pays G1/HKD, gets G2/HKD
+	result := env.CreateOffer(m1,
+		tx.NewIssuedAmountFromFloat64(1000, "HKD", g2.Address),
+		tx.NewIssuedAmountFromFloat64(1000, "HKD", g1.Address))
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	// E) Gateway to user: G1 -> A2, paths through M1 or the G2/HKD book.
+	sendAmt := tx.NewIssuedAmountFromFloat64(10, "HKD", a2.Address)
+	srcCurrencies := []payment.Issue{{Currency: "HKD", Issuer: g1.ID}}
+	pr := newPathRequest(g1.ID, a2.ID, sendAmt, nil, srcCurrencies, false)
+	pfResult := pr.Execute(env.Ledger())
+
+	require.NotEmpty(t, pfResult.Alternatives)
+	alt := pfResult.Alternatives[0]
+	require.InDelta(t, 10.0, alt.SourceAmount.Float64(), 0.0001)
+	requireSamePaths(t, alt.PathsComputed,
+		[]payment.PathStep{acctStep(m1), acctStep(g2)},
+		[]payment.PathStep{bookStepIOU("HKD", g2), acctStep(g2)})
 }
 
 // TestPath_ReceiveMax tests receive max in path finding.
 // From rippled: Path_test::receive_max
 func TestPath_ReceiveMax(t *testing.T) {
-	t.Skip("TODO: Requires ripple_path_find RPC and offers")
+	setup := func(t *testing.T) (env *xrplgoTesting.TestEnv, gw, alice, bob, charlie *xrplgoTesting.Account) {
+		t.Helper()
+		env = xrplgoTesting.NewTestEnv(t)
+		gw = xrplgoTesting.NewAccount("gw")
+		alice = xrplgoTesting.NewAccount("alice")
+		bob = xrplgoTesting.NewAccount("bob")
+		charlie = xrplgoTesting.NewAccount("charlie")
+		for _, acc := range []*xrplgoTesting.Account{alice, bob, charlie, gw} {
+			env.FundAmount(acc, uint64(xrplgoTesting.XRP(10000)))
+		}
+		env.Close()
+		for _, acc := range []*xrplgoTesting.Account{alice, bob, charlie} {
+			result := env.Submit(trustset.TrustLine(acc, "USD", gw, "100").Build())
+			xrplgoTesting.RequireTxSuccess(t, result)
+		}
+		env.Close()
+		return env, gw, alice, bob, charlie
+	}
 
-	// Test XRP -> IOU receive max (find max receivable given send limit)
-	// Test IOU -> XRP receive max
-	t.Log("Receive max test: requires RPC path finding and offers")
+	t.Run("XRP to IOU receive max", func(t *testing.T) {
+		env, gw, alice, bob, charlie := setup(t)
+
+		result := env.Submit(PayIssued(gw, charlie, tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)).Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+		env.Close()
+
+		// offer(charlie, XRP(10), USD(10)): pays XRP, gets USD
+		result = env.CreateOffer(charlie,
+			tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address),
+			tx.NewXRPAmount(xrplgoTesting.XRP(10)))
+		xrplgoTesting.RequireTxSuccess(t, result)
+		env.Close()
+
+		// find_paths(alice, bob, USD(-1), sendmax XRP(100))
+		dstAmount := state.NewIssuedAmountFromDecimalString("-1", "USD", gw.Address)
+		sendMax := tx.NewXRPAmount(xrplgoTesting.XRP(100))
+		pr := newPathRequest(alice.ID, bob.ID, dstAmount, &sendMax, nil, true)
+		pfResult := pr.Execute(env.Ledger())
+
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.True(t, alt.SourceAmount.IsNative())
+		require.EqualValues(t, xrplgoTesting.XRP(10), alt.SourceAmount.Drops())
+		require.False(t, alt.DestinationAmount.IsNative())
+		require.Equal(t, "USD", alt.DestinationAmount.Currency)
+		require.InDelta(t, 10.0, alt.DestinationAmount.Float64(), 0.0001)
+		requireSamePaths(t, alt.PathsComputed,
+			[]payment.PathStep{bookStepIOU("USD", gw)})
+	})
+
+	t.Run("IOU to XRP receive max", func(t *testing.T) {
+		env, gw, alice, bob, charlie := setup(t)
+
+		result := env.Submit(PayIssued(gw, alice, tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)).Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+		env.Close()
+
+		// offer(charlie, USD(10), XRP(10)): pays USD, gets XRP
+		result = env.CreateOffer(charlie,
+			tx.NewXRPAmount(xrplgoTesting.XRP(10)),
+			tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address))
+		xrplgoTesting.RequireTxSuccess(t, result)
+		env.Close()
+
+		// find_paths(alice, bob, drops(-1), sendmax USD(100))
+		dstAmount := state.NewXRPAmountFromInt(-1)
+		sendMax := tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)
+		pr := newPathRequest(alice.ID, bob.ID, dstAmount, &sendMax, nil, true)
+		pfResult := pr.Execute(env.Ledger())
+
+		require.NotEmpty(t, pfResult.Alternatives)
+		alt := pfResult.Alternatives[0]
+		require.False(t, alt.SourceAmount.IsNative())
+		require.Equal(t, "USD", alt.SourceAmount.Currency)
+		require.InDelta(t, 10.0, alt.SourceAmount.Float64(), 0.0001)
+		require.True(t, alt.DestinationAmount.IsNative())
+		require.EqualValues(t, xrplgoTesting.XRP(10), alt.DestinationAmount.Drops())
+		requireSamePaths(t, alt.PathsComputed,
+			[]payment.PathStep{bookStepXRP()})
+	})
 }
 
 // TestPath_HybridOfferPath tests hybrid domain/open offers.

--- a/internal/testing/payment/path_test.go
+++ b/internal/testing/payment/path_test.go
@@ -3,15 +3,72 @@
 package payment
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	xrplgoTesting "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/rpcenv"
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment/pathfinder"
 	"github.com/stretchr/testify/require"
 )
+
+// acctStep builds an expected account path element (rippled stpath(account)).
+func acctStep(a *xrplgoTesting.Account) payment.PathStep {
+	return payment.PathStep{Account: a.Address}
+}
+
+// bookStepIOU builds an expected order-book path element for an issued
+// currency (rippled's IPE(issue) test helper).
+func bookStepIOU(currency string, issuer *xrplgoTesting.Account) payment.PathStep {
+	return payment.PathStep{Currency: currency, Issuer: issuer.Address}
+}
+
+// bookStepXRP builds an expected order-book path element to XRP
+// (rippled's IPE(xrpIssue())).
+func bookStepXRP() payment.PathStep {
+	return payment.PathStep{Currency: "XRP"}
+}
+
+// pathStepKey canonicalizes one path element for comparison: account hops
+// compare by account, book hops by currency+issuer. This mirrors rippled
+// STPathElement::operator==, which ignores the non-account type bits.
+func pathStepKey(s payment.PathStep) string {
+	if s.Account != "" {
+		return "a:" + s.Account
+	}
+	cur := s.Currency
+	if cur == "" || cur == "XRP" {
+		return "b:XRP"
+	}
+	return "b:" + cur + ":" + s.Issuer
+}
+
+func pathFingerprint(path []payment.PathStep) string {
+	parts := make([]string, len(path))
+	for i, s := range path {
+		parts[i] = pathStepKey(s)
+	}
+	return strings.Join(parts, " -> ")
+}
+
+// requireSamePaths asserts that got contains exactly the want paths in any
+// order, mirroring rippled's jtx `same(st, stpath(...), ...)`.
+func requireSamePaths(t *testing.T, got [][]payment.PathStep, want ...[]payment.PathStep) {
+	t.Helper()
+	gotKeys := make([]string, len(got))
+	for i, p := range got {
+		gotKeys[i] = pathFingerprint(p)
+	}
+	wantKeys := make([]string, len(want))
+	for i, p := range want {
+		wantKeys[i] = pathFingerprint(p)
+	}
+	require.ElementsMatch(t, wantKeys, gotKeys)
+}
 
 // newPathRequest builds a PathRequest at search level 7, matching rippled
 // Path_test's pathTestEnv which raises PATH_SEARCH to 7 because these
@@ -728,13 +785,76 @@ func TestPath_XRPBridge(t *testing.T) {
 // TestPath_SourceCurrenciesLimit tests RPC path finding with source currency limits.
 // From rippled: Path_test::source_currencies_limit
 func TestPath_SourceCurrenciesLimit(t *testing.T) {
-	t.Skip("TODO: Requires ripple_path_find RPC implementation")
+	env := rpcenv.New(t)
 
-	// Test RPC::Tuning::max_src_cur source currencies
-	// Test more than RPC::Tuning::max_src_cur source currencies (should error)
-	// Test RPC::Tuning::max_auto_src_cur source currencies
-	// Test more than RPC::Tuning::max_auto_src_cur source currencies (should error)
-	t.Log("Source currencies limit test: requires RPC path finding")
+	gw := xrplgoTesting.NewAccount("gateway")
+	alice := xrplgoTesting.NewAccount("alice")
+	bob := xrplgoTesting.NewAccount("bob")
+
+	env.FundAmount(gw, uint64(xrplgoTesting.XRP(10000)))
+	env.FundAmount(alice, uint64(xrplgoTesting.XRP(10000)))
+	env.FundAmount(bob, uint64(xrplgoTesting.XRP(10000)))
+	env.Close()
+
+	result := env.Submit(trustset.TrustLine(alice, "USD", gw, "100").Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	result = env.Submit(trustset.TrustLine(bob, "USD", gw, "100").Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	// rpf mirrors the rippled test's request builder: numeric 3-character
+	// currency codes "100", "101", ... as explicit source currencies.
+	rpf := func(numSrc int) map[string]any {
+		params := map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": bob.Address,
+			"destination_amount": map[string]any{
+				"currency": "USD",
+				"value":    "0.01",
+				"issuer":   bob.Address,
+			},
+		}
+		if numSrc > 0 {
+			sc := make([]map[string]any, 0, numSrc)
+			for i := 0; i < numSrc; i++ {
+				sc = append(sc, map[string]any{"currency": strconv.Itoa(i + 100)})
+			}
+			params["source_currencies"] = sc
+		}
+		return params
+	}
+
+	// RPC::Tuning::max_src_cur (18) explicit source currencies are accepted.
+	_, rpcErr := env.RPC("ripple_path_find", rpf(18))
+	require.Nil(t, rpcErr)
+
+	// More than max_src_cur is rejected.
+	_, rpcErr = env.RPC("ripple_path_find", rpf(19))
+	require.NotNil(t, rpcErr)
+	require.Equal(t, "srcCurMalformed", rpcErr.ErrorString)
+
+	// Give alice max_auto_src_cur-1 (87) sendable currencies; with XRP that
+	// makes exactly RPC::Tuning::max_auto_src_cur (88) auto-discovered
+	// source currencies, which is accepted.
+	for i := 0; i < 87; i++ {
+		cur := strconv.Itoa(i + 100)
+		result = env.Submit(trustset.TrustLine(bob, cur, alice, "100").Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+	}
+	env.Close()
+
+	_, rpcErr = env.RPC("ripple_path_find", rpf(0))
+	require.Nil(t, rpcErr)
+
+	// One more sendable currency exceeds max_auto_src_cur and fails the
+	// request (rippled PathRequest::findPaths returns false -> rpcINTERNAL).
+	result = env.Submit(trustset.TrustLine(bob, "AUD", alice, "100").Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	_, rpcErr = env.RPC("ripple_path_find", rpf(0))
+	require.NotNil(t, rpcErr)
+	require.Equal(t, "internal", rpcErr.ErrorString)
 }
 
 // TestPath_PathFindConsumeAll tests path consumption with alternatives.
@@ -886,36 +1006,163 @@ func TestPath_AlternativePathConsumeBoth(t *testing.T) {
 	require.InDelta(t, 70.0, bobGw2Bal, 0.0001, "Bob should have 70 gw2/USD")
 }
 
+// twoGatewayUSDEnv builds the shared fixture for the alternative-paths
+// transfer-rate tests: gw (no fee) and gw2 (1.1x), alice holding 70 USD
+// from each, bob trusting both.
+func twoGatewayUSDEnv(t *testing.T) (env *xrplgoTesting.TestEnv, gw, gw2, alice, bob *xrplgoTesting.Account) {
+	t.Helper()
+	env = xrplgoTesting.NewTestEnv(t)
+
+	gw = xrplgoTesting.NewAccount("gateway")
+	gw2 = xrplgoTesting.NewAccount("gateway2")
+	alice = xrplgoTesting.NewAccount("alice")
+	bob = xrplgoTesting.NewAccount("bob")
+
+	env.FundAmount(gw, uint64(xrplgoTesting.XRP(10000)))
+	env.FundAmount(gw2, uint64(xrplgoTesting.XRP(10000)))
+	env.FundAmount(alice, uint64(xrplgoTesting.XRP(10000)))
+	env.FundAmount(bob, uint64(xrplgoTesting.XRP(10000)))
+	env.Close()
+
+	env.SetTransferRate(gw2, 1_100_000_000)
+	env.Close()
+
+	result := env.Submit(trustset.TrustLine(alice, "USD", gw, "600").Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	result = env.Submit(trustset.TrustLine(alice, "USD", gw2, "800").Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	result = env.Submit(trustset.TrustLine(bob, "USD", gw, "700").Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	result = env.Submit(trustset.TrustLine(bob, "USD", gw2, "900").Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	result = env.Submit(PayIssued(gw, alice, tx.NewIssuedAmountFromFloat64(70, "USD", gw.Address)).Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	result = env.Submit(PayIssued(gw2, alice, tx.NewIssuedAmountFromFloat64(70, "USD", gw2.Address)).Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	return env, gw, gw2, alice, bob
+}
+
 // TestPath_AlternativePathsConsumeBestTransfer tests consuming best transfer rate.
 // From rippled: Path_test::alternative_paths_consume_best_transfer
 func TestPath_AlternativePathsConsumeBestTransfer(t *testing.T) {
-	t.Skip("TODO: Requires ripple_path_find RPC and transfer rate support")
+	env, gw, gw2, alice, bob := twoGatewayUSDEnv(t)
 
-	// gw2 has 1.1x transfer rate (10% fee)
-	// alice pays bob 70 USD - should use gw (no transfer fee) first
-	// Result: alice has 0 gw/USD, 70 gw2/USD; bob has 70 gw/USD, 0 gw2/USD
-	t.Log("Alternative paths consume best transfer test: requires RPC path finding")
+	// alice pays bob 70 gw/USD: only the fee-free gw line is touched.
+	result := env.Submit(PayIssued(alice, bob, tx.NewIssuedAmountFromFloat64(70, "USD", gw.Address)).Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	xrplgoTesting.RequireIOUBalance(t, env, alice, gw, "USD", 0)
+	xrplgoTesting.RequireIOUBalance(t, env, alice, gw2, "USD", 70)
+	xrplgoTesting.RequireIOUBalance(t, env, bob, gw, "USD", 70)
+	xrplgoTesting.RequireIOUBalance(t, env, bob, gw2, "USD", 0)
+	xrplgoTesting.RequireIOUBalance(t, env, gw, alice, "USD", 0)
+	xrplgoTesting.RequireIOUBalance(t, env, gw, bob, "USD", -70)
+	xrplgoTesting.RequireIOUBalance(t, env, gw2, alice, "USD", -70)
+	xrplgoTesting.RequireIOUBalance(t, env, gw2, bob, "USD", 0)
 }
 
 // TestPath_AlternativePathsConsumeBestTransferFirst tests best transfer consumed first.
 // From rippled: Path_test::alternative_paths_consume_best_transfer_first
 func TestPath_AlternativePathsConsumeBestTransferFirst(t *testing.T) {
-	t.Skip("TODO: Requires ripple_path_find RPC and transfer rate support")
+	env, gw, gw2, alice, bob := twoGatewayUSDEnv(t)
 
-	// Similar to above but tests that best quality is consumed first
-	// when paying more than one path can provide
-	t.Log("Alternative paths consume best transfer first test: requires RPC path finding")
+	// alice pays bob 77 bob/USD with sendmax 100 alice/USD via the
+	// pathfinder (rippled: paths(Account("alice")["USD"])).
+	usd77 := tx.NewIssuedAmountFromFloat64(77, "USD", bob.Address)
+	sendMax := tx.NewIssuedAmountFromFloat64(100, "USD", alice.Address)
+	srcCurrencies := []payment.Issue{{Currency: "USD", Issuer: alice.ID}}
+	pr := newPathRequest(alice.ID, bob.ID, usd77, nil, srcCurrencies, false)
+	pfResult := pr.Execute(env.Ledger())
+	require.NotEmpty(t, pfResult.Alternatives, "Pathfinder should find alternatives")
+
+	alt := pfResult.Alternatives[0]
+	requireSamePaths(t, alt.PathsComputed,
+		[]payment.PathStep{acctStep(gw)},
+		[]payment.PathStep{acctStep(gw2)})
+
+	result := env.Submit(PayIssued(alice, bob, usd77).
+		SendMax(sendMax).
+		Paths(alt.PathsComputed).
+		Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	// gw (no fee) is consumed entirely first; the remaining 7 USD goes via
+	// gw2 at the 1.1x rate, costing alice 7.7 gw2/USD.
+	xrplgoTesting.RequireIOUBalance(t, env, alice, gw, "USD", 0)
+	xrplgoTesting.RequireIOUBalanceApprox(t, env, alice, gw2, "USD", 62.3, 0.0001)
+	xrplgoTesting.RequireIOUBalance(t, env, bob, gw, "USD", 70)
+	xrplgoTesting.RequireIOUBalance(t, env, bob, gw2, "USD", 7)
+	xrplgoTesting.RequireIOUBalance(t, env, gw, alice, "USD", 0)
+	xrplgoTesting.RequireIOUBalance(t, env, gw, bob, "USD", -70)
+	xrplgoTesting.RequireIOUBalanceApprox(t, env, gw2, alice, "USD", -62.3, 0.0001)
+	xrplgoTesting.RequireIOUBalance(t, env, gw2, bob, "USD", -7)
 }
 
 // TestPath_AlternativePathsLimitReturnedPaths tests limiting returned paths to best quality.
 // From rippled: Path_test::alternative_paths_limit_returned_paths_to_best_quality
 func TestPath_AlternativePathsLimitReturnedPaths(t *testing.T) {
-	t.Skip("TODO: Requires ripple_path_find RPC implementation")
+	env := xrplgoTesting.NewTestEnv(t)
 
-	// carol has 1.1x transfer rate
-	// Set up trust lines for multiple paths (carol, dan, gw, gw2)
-	// Find paths - should return paths ordered by quality (best first)
-	t.Log("Alternative paths limit test: requires RPC path finding")
+	gw := xrplgoTesting.NewAccount("gateway")
+	gw2 := xrplgoTesting.NewAccount("gateway2")
+	alice := xrplgoTesting.NewAccount("alice")
+	bob := xrplgoTesting.NewAccount("bob")
+	carol := xrplgoTesting.NewAccount("carol")
+	dan := xrplgoTesting.NewAccount("dan")
+
+	for _, acc := range []*xrplgoTesting.Account{gw, gw2, alice, bob, carol, dan} {
+		env.FundAmount(acc, uint64(xrplgoTesting.XRP(10000)))
+	}
+	env.Close()
+
+	env.SetTransferRate(carol, 1_100_000_000)
+	env.Close()
+
+	// alice and bob trust carol, dan, gw, and gw2 for USD; dan also trusts
+	// alice and bob so he can ripple between them.
+	for _, issuer := range []*xrplgoTesting.Account{carol, dan, gw, gw2} {
+		result := env.Submit(trustset.TrustLine(alice, "USD", issuer, "800").Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+		result = env.Submit(trustset.TrustLine(bob, "USD", issuer, "800").Build())
+		xrplgoTesting.RequireTxSuccess(t, result)
+	}
+	result := env.Submit(trustset.TrustLine(dan, "USD", alice, "800").Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	result = env.Submit(trustset.TrustLine(dan, "USD", bob, "800").Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	result = env.Submit(PayIssued(gw2, alice, tx.NewIssuedAmountFromFloat64(100, "USD", gw2.Address)).Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+	result = env.Submit(PayIssued(carol, alice, tx.NewIssuedAmountFromFloat64(100, "USD", carol.Address)).Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+	result = env.Submit(PayIssued(gw, alice, tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)).Build())
+	xrplgoTesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	// find_paths(alice, bob, bob/USD(5)): exactly four single-hop paths
+	// survive the max_paths_ (4) cut, ordered by quality with carol's 1.1x
+	// rate ranking last but still included.
+	usd5 := tx.NewIssuedAmountFromFloat64(5, "USD", bob.Address)
+	pr := newPathRequest(alice.ID, bob.ID, usd5, nil, nil, false)
+	pfResult := pr.Execute(env.Ledger())
+	require.NotEmpty(t, pfResult.Alternatives, "Pathfinder should find alternatives")
+
+	alt := pfResult.Alternatives[0]
+	requireSamePaths(t, alt.PathsComputed,
+		[]payment.PathStep{acctStep(gw)},
+		[]payment.PathStep{acctStep(gw2)},
+		[]payment.PathStep{acctStep(dan)},
+		[]payment.PathStep{acctStep(carol)})
+	require.InDelta(t, 5.0, alt.SourceAmount.Float64(), 0.0001, "Source amount should be 5 alice/USD")
 }
 
 // TestPath_IssuesPathNegativeIssue5 tests Issue #5 regression.

--- a/internal/testing/payment/path_test.go
+++ b/internal/testing/payment/path_test.go
@@ -13,6 +13,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newPathRequest builds a PathRequest at search level 7, matching rippled
+// Path_test's pathTestEnv which raises PATH_SEARCH to 7 because these
+// scenarios were written for deeper search levels than the production
+// default.
+func newPathRequest(
+	src, dst [20]byte,
+	dstAmount tx.Amount,
+	sendMax *tx.Amount,
+	srcCurrencies []payment.Issue,
+	convertAll bool,
+) *pathfinder.PathRequest {
+	pr := pathfinder.NewPathRequest(src, dst, dstAmount, sendMax, srcCurrencies, convertAll)
+	pr.SetSearchLevel(7)
+	return pr
+}
+
 // TestPath_NoDirectPathNoIntermediaryNoAlternatives tests path finding with no available paths.
 // From rippled: no_direct_path_no_intermediary_no_alternatives
 func TestPath_NoDirectPathNoIntermediaryNoAlternatives(t *testing.T) {
@@ -62,7 +78,7 @@ func TestPath_DirectPathNoIntermediary(t *testing.T) {
 	// In rippled: find_paths(env, "alice", "bob", Account("bob")["USD"](5))
 	// Expects: empty path set, source_amount = alice/USD(5)
 	dstAmount := tx.NewIssuedAmountFromFloat64(5, "USD", bob.Address)
-	pr := pathfinder.NewPathRequest(alice.ID, bob.ID, dstAmount, nil, nil, false)
+	pr := newPathRequest(alice.ID, bob.ID, dstAmount, nil, nil, false)
 	pfResult := pr.Execute(env.Ledger())
 
 	// Per rippled: st.empty() — the default path suffices
@@ -177,7 +193,7 @@ func TestPath_IndirectPath(t *testing.T) {
 	// In rippled: find_paths(env, "alice", "carol", Account("carol")["USD"](5))
 	// Expects: path through bob, source_amount = alice/USD(5)
 	dstAmount := tx.NewIssuedAmountFromFloat64(5, "USD", carol.Address)
-	pr := pathfinder.NewPathRequest(alice.ID, carol.ID, dstAmount, nil, nil, false)
+	pr := newPathRequest(alice.ID, carol.ID, dstAmount, nil, nil, false)
 	pfResult := pr.Execute(env.Ledger())
 
 	// Should find at least one alternative with a path through bob
@@ -770,8 +786,8 @@ func TestPath_PathFindConsumeAll(t *testing.T) {
 	// Expected: paths = stpath("dan"), stpath("bob", "carol")
 	//           source_amount = alice/USD(110)
 	//           dest_amount = edward/USD(110)
-	dstAmount := tx.NewIssuedAmountFromFloat64(1, "USD", edward.Address)            // placeholder, convertAll replaces it
-	pr := pathfinder.NewPathRequest(alice.ID, edward.ID, dstAmount, nil, nil, true) // convertAll=true
+	dstAmount := tx.NewIssuedAmountFromFloat64(1, "USD", edward.Address) // placeholder, convertAll replaces it
+	pr := newPathRequest(alice.ID, edward.ID, dstAmount, nil, nil, true) // convertAll=true
 	pfResult := pr.Execute(env.Ledger())
 
 	require.NotEmpty(t, pfResult.Alternatives, "Pathfinder should find alternatives for convertAll")
@@ -846,7 +862,7 @@ func TestPath_AlternativePathConsumeBoth(t *testing.T) {
 	// In rippled: paths(Account("alice")["USD"]) runs the pathfinder
 	usd140 := tx.NewIssuedAmountFromFloat64(140, "USD", bob.Address)
 	srcCurrencies := []payment.Issue{{Currency: "USD", Issuer: alice.ID}}
-	pr := pathfinder.NewPathRequest(alice.ID, bob.ID, usd140, nil, srcCurrencies, false)
+	pr := newPathRequest(alice.ID, bob.ID, usd140, nil, srcCurrencies, false)
 	pfResult := pr.Execute(env.Ledger())
 	require.NotEmpty(t, pfResult.Alternatives, "Pathfinder should find alternatives")
 
@@ -953,7 +969,7 @@ func TestPath_IssuesPathNegativeIssue5(t *testing.T) {
 
 	// Pathfind alice->bob for bob/USD(25) - should find no paths
 	dstAmount1 := tx.NewIssuedAmountFromFloat64(25, "USD", bob.Address)
-	pr1 := pathfinder.NewPathRequest(alice.ID, bob.ID, dstAmount1, nil, nil, false)
+	pr1 := newPathRequest(alice.ID, bob.ID, dstAmount1, nil, nil, false)
 	pfResult1 := pr1.Execute(env.Ledger())
 	require.Empty(t, pfResult1.Alternatives,
 		"Should find no paths from alice to bob for bob/USD")
@@ -967,7 +983,7 @@ func TestPath_IssuesPathNegativeIssue5(t *testing.T) {
 
 	// Pathfind alice->bob for alice/USD(25) - should also find no paths
 	dstAmount2 := tx.NewIssuedAmountFromFloat64(25, "USD", alice.Address)
-	pr2 := pathfinder.NewPathRequest(alice.ID, bob.ID, dstAmount2, nil, nil, false)
+	pr2 := newPathRequest(alice.ID, bob.ID, dstAmount2, nil, nil, false)
 	pfResult2 := pr2.Execute(env.Ledger())
 	require.Empty(t, pfResult2.Alternatives,
 		"Should find no paths from alice to bob for alice/USD")
@@ -1024,7 +1040,7 @@ func TestPath_IssuesRippleClientIssue23Smaller(t *testing.T) {
 	// and using the discovered paths in the payment.
 	usd55 := tx.NewIssuedAmountFromFloat64(55, "USD", bob.Address)
 	srcCurrencies := []payment.Issue{{Currency: "USD", Issuer: alice.ID}}
-	pr := pathfinder.NewPathRequest(alice.ID, bob.ID, usd55, nil, srcCurrencies, false)
+	pr := newPathRequest(alice.ID, bob.ID, usd55, nil, srcCurrencies, false)
 	pfResult := pr.Execute(env.Ledger())
 	require.NotEmpty(t, pfResult.Alternatives, "Pathfinder should find at least one alternative")
 
@@ -1093,7 +1109,7 @@ func TestPath_IssuesRippleClientIssue23Larger(t *testing.T) {
 	// In rippled: paths(Account("alice")["USD"]) runs the pathfinder
 	usd50 := tx.NewIssuedAmountFromFloat64(50, "USD", bob.Address)
 	srcCurrencies := []payment.Issue{{Currency: "USD", Issuer: alice.ID}}
-	pr := pathfinder.NewPathRequest(alice.ID, bob.ID, usd50, nil, srcCurrencies, false)
+	pr := newPathRequest(alice.ID, bob.ID, usd50, nil, srcCurrencies, false)
 	pfResult := pr.Execute(env.Ledger())
 	require.NotEmpty(t, pfResult.Alternatives, "Pathfinder should find at least one alternative")
 
@@ -1201,7 +1217,7 @@ func TestPath_PathFind04(t *testing.T) {
 	t.Run("A1_to_A2", func(t *testing.T) {
 		dstAmount := tx.NewIssuedAmountFromFloat64(10, "HKD", a2.Address)
 		srcCurrencies := []payment.Issue{{Currency: "HKD", Issuer: a1.ID}}
-		pr := pathfinder.NewPathRequest(a1.ID, a2.ID, dstAmount, nil, srcCurrencies, false)
+		pr := newPathRequest(a1.ID, a2.ID, dstAmount, nil, srcCurrencies, false)
 		pfResult := pr.Execute(env.Ledger())
 
 		require.NotEmpty(t, pfResult.Alternatives, "Should find path A1->A2")
@@ -1226,7 +1242,7 @@ func TestPath_PathFind04(t *testing.T) {
 	t.Run("A2_to_A1", func(t *testing.T) {
 		dstAmount := tx.NewIssuedAmountFromFloat64(10, "HKD", a1.Address)
 		srcCurrencies := []payment.Issue{{Currency: "HKD", Issuer: a2.ID}}
-		pr := pathfinder.NewPathRequest(a2.ID, a1.ID, dstAmount, nil, srcCurrencies, false)
+		pr := newPathRequest(a2.ID, a1.ID, dstAmount, nil, srcCurrencies, false)
 		pfResult := pr.Execute(env.Ledger())
 
 		require.NotEmpty(t, pfResult.Alternatives, "Should find path A2->A1")
@@ -1251,7 +1267,7 @@ func TestPath_PathFind04(t *testing.T) {
 	t.Run("G1BS_to_A2", func(t *testing.T) {
 		dstAmount := tx.NewIssuedAmountFromFloat64(10, "HKD", a2.Address)
 		srcCurrencies := []payment.Issue{{Currency: "HKD", Issuer: g1bs.ID}}
-		pr := pathfinder.NewPathRequest(g1bs.ID, a2.ID, dstAmount, nil, srcCurrencies, false)
+		pr := newPathRequest(g1bs.ID, a2.ID, dstAmount, nil, srcCurrencies, false)
 		pfResult := pr.Execute(env.Ledger())
 
 		require.NotEmpty(t, pfResult.Alternatives, "Should find path G1BS->A2")
@@ -1275,7 +1291,7 @@ func TestPath_PathFind04(t *testing.T) {
 	t.Run("M1_to_G1BS", func(t *testing.T) {
 		dstAmount := tx.NewIssuedAmountFromFloat64(10, "HKD", g1bs.Address)
 		srcCurrencies := []payment.Issue{{Currency: "HKD", Issuer: m1.ID}}
-		pr := pathfinder.NewPathRequest(m1.ID, g1bs.ID, dstAmount, nil, srcCurrencies, false)
+		pr := newPathRequest(m1.ID, g1bs.ID, dstAmount, nil, srcCurrencies, false)
 		pfResult := pr.Execute(env.Ledger())
 
 		// Empty path set means default path handles it
@@ -1390,7 +1406,7 @@ func TestPath_PathFind(t *testing.T) {
 	// Our pathfinder may return 0 alternatives when default path suffices,
 	// which is correct — it means explicit paths are unnecessary.
 	dstAmount := tx.NewIssuedAmountFromFloat64(5, "USD", gw.Address)
-	pr := pathfinder.NewPathRequest(alice.ID, bob.ID, dstAmount, nil, nil, false)
+	pr := newPathRequest(alice.ID, bob.ID, dstAmount, nil, nil, false)
 	pfResult := pr.Execute(env.Ledger())
 
 	// Destination currencies should include USD
@@ -1503,7 +1519,7 @@ func TestPath_IndirectPathsPathFind(t *testing.T) {
 	// Pathfinder: find_paths(env, "alice", "carol", carol/USD(5))
 	// Expects: same(st, stpath("bob")), equal(sa, alice/USD(5))
 	dstAmount := tx.NewIssuedAmountFromFloat64(5, "USD", carol.Address)
-	pr := pathfinder.NewPathRequest(alice.ID, carol.ID, dstAmount, nil, nil, false)
+	pr := newPathRequest(alice.ID, carol.ID, dstAmount, nil, nil, false)
 	pfResult := pr.Execute(env.Ledger())
 
 	require.NotEmpty(t, pfResult.Alternatives, "Should find at least one path alternative")

--- a/internal/testing/rpcenv/adapter.go
+++ b/internal/testing/rpcenv/adapter.go
@@ -201,6 +201,26 @@ func (a *ledgerAdapter) GetClosedLedgerView() (types.LedgerStateView, error) {
 	return closed, nil
 }
 
+func (a *ledgerAdapter) GetLedgerViewBySeq(seq uint32) (types.LedgerStateView, types.LedgerReader, error) {
+	if closed := a.env.LastClosedLedger(); closed != nil && closed.Sequence() == seq {
+		return closed, &ledgerReaderAdapter{l: closed}, nil
+	}
+	if open := a.env.Ledger(); open != nil && open.Sequence() == seq {
+		return open, &ledgerReaderAdapter{l: open}, nil
+	}
+	return nil, nil, fmt.Errorf("rpcenv: ledger %d not available", seq)
+}
+
+func (a *ledgerAdapter) GetLedgerViewByHash(hash [32]byte) (types.LedgerStateView, types.LedgerReader, error) {
+	if closed := a.env.LastClosedLedger(); closed != nil && closed.Hash() == hash {
+		return closed, &ledgerReaderAdapter{l: closed}, nil
+	}
+	if open := a.env.Ledger(); open != nil && open.Hash() == hash {
+		return open, &ledgerReaderAdapter{l: open}, nil
+	}
+	return nil, nil, fmt.Errorf("rpcenv: ledger %x not available", hash)
+}
+
 func (a *ledgerAdapter) IsAmendmentBlocked() bool { return false }
 
 func (a *ledgerAdapter) SubmitTransaction(_ []byte, _ ...string) (*types.SubmitResult, error) {

--- a/internal/testing/rpcenv/adapter.go
+++ b/internal/testing/rpcenv/adapter.go
@@ -223,7 +223,7 @@ func (a *ledgerAdapter) GetTransactionHistory(_ context.Context, _ uint32) (*typ
 	return nil, errNotImplemented
 }
 
-func (a *ledgerAdapter) GetAutofillFee(_ []byte, _ bool) (uint64, error) {
+func (a *ledgerAdapter) GetAutofillFee(_ []byte, _ bool, _, _ int) (uint64, error) {
 	return 0, errNotImplemented
 }
 

--- a/internal/testing/rpcenv/ripple_path_find_test.go
+++ b/internal/testing/rpcenv/ripple_path_find_test.go
@@ -1,0 +1,459 @@
+package rpcenv_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/testing/rpcenv"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/require"
+)
+
+// newPathFindEnv builds the standard ripple_path_find fixture: alice and bob
+// trust gw for USD, alice holds 50 gw/USD.
+func newPathFindEnv(t *testing.T) (*rpcenv.Env, *jtx.Account, *jtx.Account, *jtx.Account) {
+	t.Helper()
+	env := rpcenv.New(t)
+
+	gw := jtx.NewAccount("gateway")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+
+	env.FundAmount(gw, uint64(jtx.XRP(10000)))
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	result := env.Submit(trustset.TrustLine(alice, "USD", gw, "1000").Build())
+	jtx.RequireTxSuccess(t, result)
+	result = env.Submit(trustset.TrustLine(bob, "USD", gw, "1000").Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	result = env.Submit(payment.PayIssued(gw, alice, tx.NewIssuedAmountFromFloat64(50, "USD", gw.Address)).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	return env, gw, alice, bob
+}
+
+// asJSONMap round-trips a handler response through JSON so tests can inspect
+// it the way a client would.
+func asJSONMap(t *testing.T, result any) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(result)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m
+}
+
+func iouAmount(value, currency, issuer string) map[string]any {
+	return map[string]any{"currency": currency, "issuer": issuer, "value": value}
+}
+
+// TestRipplePathFind_ParseErrors checks each parseJson-stage error token in
+// rippled's validation order (PathRequest::parseJson).
+func TestRipplePathFind_ParseErrors(t *testing.T) {
+	env, gw, alice, bob := newPathFindEnv(t)
+
+	usd5 := iouAmount("5", "USD", gw.Address)
+	usdAll := iouAmount("-1", "USD", gw.Address)
+
+	manySourceCurrencies := func(n int) []map[string]any {
+		sc := make([]map[string]any, 0, n)
+		for i := 0; i < n; i++ {
+			sc = append(sc, map[string]any{"currency": strconv.Itoa(i + 100)})
+		}
+		return sc
+	}
+
+	cases := []struct {
+		name      string
+		params    map[string]any
+		wantError string
+		wantCode  int
+	}{
+		{
+			name:      "missing source_account",
+			params:    map[string]any{},
+			wantError: "srcActMissing", wantCode: 66,
+		},
+		{
+			name:      "missing destination_account",
+			params:    map[string]any{"source_account": alice.Address},
+			wantError: "dstActMissing", wantCode: 49,
+		},
+		{
+			name: "missing destination_amount",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+			},
+			wantError: "dstAmtMissing", wantCode: 52,
+		},
+		{
+			name: "malformed source_account",
+			params: map[string]any{
+				"source_account":      "not-an-address",
+				"destination_account": bob.Address,
+				"destination_amount":  usd5,
+			},
+			wantError: "srcActMalformed", wantCode: 65,
+		},
+		{
+			name: "non-string source_account",
+			params: map[string]any{
+				"source_account":      42,
+				"destination_account": bob.Address,
+				"destination_amount":  usd5,
+			},
+			wantError: "srcActMalformed", wantCode: 65,
+		},
+		{
+			name: "malformed destination_account",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": "not-an-address",
+				"destination_amount":  usd5,
+			},
+			wantError: "dstActMalformed", wantCode: 48,
+		},
+		{
+			name: "unparseable destination_amount",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  "not-a-number",
+			},
+			wantError: "dstAmtMalformed", wantCode: 51,
+		},
+		{
+			name: "XRP destination_amount as object",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  iouAmount("5", "XRP", gw.Address),
+			},
+			wantError: "dstAmtMalformed", wantCode: 51,
+		},
+		{
+			name: "zero destination_amount",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  iouAmount("0", "USD", gw.Address),
+			},
+			wantError: "dstAmtMalformed", wantCode: 51,
+		},
+		{
+			name: "negative non-convert-all destination_amount",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  iouAmount("-5", "USD", gw.Address),
+			},
+			wantError: "dstAmtMalformed", wantCode: 51,
+		},
+		{
+			name: "send_max without convert-all destination_amount",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  usd5,
+				"send_max":            "100000000",
+			},
+			wantError: "dstAmtMalformed", wantCode: 51,
+		},
+		{
+			name: "zero send_max",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  usdAll,
+				"send_max":            "0",
+			},
+			wantError: "sendMaxMalformed", wantCode: 64,
+		},
+		{
+			name: "unparseable send_max",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  usdAll,
+				"send_max":            "not-a-number",
+			},
+			wantError: "sendMaxMalformed", wantCode: 64,
+		},
+		{
+			name: "empty source_currencies",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  usd5,
+				"source_currencies":   []any{},
+			},
+			wantError: "srcCurMalformed", wantCode: 69,
+		},
+		{
+			name: "source_currencies over max_src_cur",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  usd5,
+				"source_currencies":   manySourceCurrencies(19),
+			},
+			wantError: "srcCurMalformed", wantCode: 69,
+		},
+		{
+			name: "source_currencies entry without currency",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  usd5,
+				"source_currencies":   []map[string]any{{"issuer": gw.Address}},
+			},
+			wantError: "srcCurMalformed", wantCode: 69,
+		},
+		{
+			name: "source_currencies invalid currency code",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  usd5,
+				"source_currencies":   []map[string]any{{"currency": "TOOLONG"}},
+			},
+			wantError: "srcCurMalformed", wantCode: 69,
+		},
+		{
+			name: "source_currencies XRP with issuer",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  usd5,
+				"source_currencies":   []map[string]any{{"currency": "XRP", "issuer": gw.Address}},
+			},
+			wantError: "srcCurMalformed", wantCode: 69,
+		},
+		{
+			name: "source_currencies malformed issuer",
+			params: map[string]any{
+				"source_account":      alice.Address,
+				"destination_account": bob.Address,
+				"destination_amount":  usd5,
+				"source_currencies":   []map[string]any{{"currency": "USD", "issuer": "junk"}},
+			},
+			wantError: "srcIsrMalformed", wantCode: 70,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, rpcErr := env.RPC("ripple_path_find", tc.params)
+			require.NotNil(t, rpcErr, "expected %s", tc.wantError)
+			require.Equal(t, tc.wantError, rpcErr.ErrorString)
+			require.Equal(t, tc.wantCode, rpcErr.Code)
+		})
+	}
+
+	// Max allowed source_currencies (18) parses fine.
+	result, rpcErr := env.RPC("ripple_path_find", map[string]any{
+		"source_account":      alice.Address,
+		"destination_account": bob.Address,
+		"destination_amount":  usd5,
+		"source_currencies":   manySourceCurrencies(18),
+	})
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+}
+
+// TestRipplePathFind_LedgerChecks covers PathRequest::isValid: source must
+// exist, destination existence rules, and reserve enforcement for funding
+// payments.
+func TestRipplePathFind_LedgerChecks(t *testing.T) {
+	env, gw, alice, bob := newPathFindEnv(t)
+	ghost := jtx.NewAccount("ghost") // never funded
+
+	t.Run("source account not found", func(t *testing.T) {
+		_, rpcErr := env.RPC("ripple_path_find", map[string]any{
+			"source_account":      ghost.Address,
+			"destination_account": bob.Address,
+			"destination_amount":  iouAmount("5", "USD", gw.Address),
+		})
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "srcActNotFound", rpcErr.ErrorString)
+		require.Equal(t, 67, rpcErr.Code)
+	})
+
+	t.Run("IOU to non-existent destination", func(t *testing.T) {
+		_, rpcErr := env.RPC("ripple_path_find", map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": ghost.Address,
+			"destination_amount":  iouAmount("5", "USD", gw.Address),
+		})
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "actNotFound", rpcErr.ErrorString)
+		require.Equal(t, 19, rpcErr.Code)
+	})
+
+	t.Run("XRP below reserve to non-existent destination", func(t *testing.T) {
+		below := strconv.FormatUint(env.ReserveBase()-1, 10)
+		_, rpcErr := env.RPC("ripple_path_find", map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": ghost.Address,
+			"destination_amount":  below,
+		})
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "dstAmtMalformed", rpcErr.ErrorString)
+	})
+
+	t.Run("XRP at reserve to non-existent destination", func(t *testing.T) {
+		atReserve := strconv.FormatUint(env.ReserveBase(), 10)
+		result, rpcErr := env.RPC("ripple_path_find", map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": ghost.Address,
+			"destination_amount":  atReserve,
+		})
+		require.Nil(t, rpcErr)
+		resp := asJSONMap(t, result)
+		// XRP to XRP never needs explicit path steps.
+		for _, a := range resp["alternatives"].([]any) {
+			require.Empty(t, a.(map[string]any)["paths_computed"])
+		}
+	})
+}
+
+// TestRipplePathFind_LedgerSelection covers explicit ledger_index /
+// ledger_hash selection plus the merged ledger metadata fields.
+func TestRipplePathFind_LedgerSelection(t *testing.T) {
+	env, gw, alice, bob := newPathFindEnv(t)
+	closed := env.LastClosedLedger()
+	require.NotNil(t, closed)
+
+	baseParams := func() map[string]any {
+		return map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": bob.Address,
+			"destination_amount":  iouAmount("5", "USD", gw.Address),
+		}
+	}
+
+	t.Run("by ledger_index", func(t *testing.T) {
+		params := baseParams()
+		params["ledger_index"] = closed.Sequence()
+		result, rpcErr := env.RPC("ripple_path_find", params)
+		require.Nil(t, rpcErr)
+		resp := asJSONMap(t, result)
+		require.EqualValues(t, closed.Sequence(), resp["ledger_index"])
+		require.NotEmpty(t, resp["ledger_hash"])
+		require.Equal(t, true, resp["validated"])
+		require.NotEmpty(t, resp["alternatives"])
+	})
+
+	t.Run("by ledger_hash", func(t *testing.T) {
+		params := baseParams()
+		hash := closed.Hash()
+		params["ledger_hash"] = fmt.Sprintf("%X", hash[:])
+		result, rpcErr := env.RPC("ripple_path_find", params)
+		require.Nil(t, rpcErr)
+		resp := asJSONMap(t, result)
+		require.EqualValues(t, closed.Sequence(), resp["ledger_index"])
+	})
+
+	t.Run("unknown ledger_index", func(t *testing.T) {
+		params := baseParams()
+		params["ledger_index"] = 999999
+		_, rpcErr := env.RPC("ripple_path_find", params)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "lgrNotFound", rpcErr.ErrorString)
+	})
+
+	t.Run("unknown ledger_hash", func(t *testing.T) {
+		params := baseParams()
+		params["ledger_hash"] = "00000000000000000000000000000000000000000000000000000000000000AA"
+		_, rpcErr := env.RPC("ripple_path_find", params)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "lgrNotFound", rpcErr.ErrorString)
+	})
+
+	t.Run("malformed ledger_hash", func(t *testing.T) {
+		params := baseParams()
+		params["ledger_hash"] = "zz"
+		_, rpcErr := env.RPC("ripple_path_find", params)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "invalidParams", rpcErr.ErrorString)
+	})
+}
+
+// TestRipplePathFind_Success covers the happy path: response shape, id echo,
+// full_reply, destination_currencies, and source_amount.
+func TestRipplePathFind_Success(t *testing.T) {
+	env, gw, alice, bob := newPathFindEnv(t)
+
+	result, rpcErr := env.RPC("ripple_path_find", map[string]any{
+		"id":                  17,
+		"source_account":      alice.Address,
+		"destination_account": bob.Address,
+		"destination_amount":  iouAmount("5", "USD", gw.Address),
+	})
+	require.Nil(t, rpcErr)
+	resp := asJSONMap(t, result)
+
+	require.Equal(t, alice.Address, resp["source_account"])
+	require.Equal(t, bob.Address, resp["destination_account"])
+	require.Equal(t, true, resp["full_reply"])
+	require.EqualValues(t, 17, resp["id"])
+	require.NotContains(t, resp, "ledger_hash", "no ledger fields without an explicit ledger selector")
+
+	currencies, ok := resp["destination_currencies"].([]any)
+	require.True(t, ok)
+	require.Contains(t, currencies, "USD")
+	require.Contains(t, currencies, "XRP")
+
+	alternatives, ok := resp["alternatives"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, alternatives)
+
+	alt := alternatives[0].(map[string]any)
+	require.Contains(t, alt, "paths_computed")
+	require.Contains(t, alt, "paths_canonical")
+	require.NotContains(t, alt, "destination_amount", "destination_amount only present in convert-all mode")
+	srcAmt, ok := alt["source_amount"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "USD", srcAmt["currency"])
+	require.Equal(t, "5", srcAmt["value"])
+}
+
+// TestRipplePathFind_ConvertAll covers destination_amount: -1 (convert-all):
+// the alternative reports the maximum deliverable amount.
+func TestRipplePathFind_ConvertAll(t *testing.T) {
+	env, gw, alice, bob := newPathFindEnv(t)
+
+	result, rpcErr := env.RPC("ripple_path_find", map[string]any{
+		"source_account":      alice.Address,
+		"destination_account": bob.Address,
+		"destination_amount":  iouAmount("-1", "USD", gw.Address),
+	})
+	require.Nil(t, rpcErr)
+	resp := asJSONMap(t, result)
+
+	echo, ok := resp["destination_amount"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "-1", echo["value"])
+
+	alternatives, ok := resp["alternatives"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, alternatives)
+
+	alt := alternatives[0].(map[string]any)
+	srcAmt := alt["source_amount"].(map[string]any)
+	require.Equal(t, "50", srcAmt["value"], "alice can send all 50 USD")
+	dstAmt, ok := alt["destination_amount"].(map[string]any)
+	require.True(t, ok, "convert-all alternatives must report destination_amount")
+	require.Equal(t, "50", dstAmt["value"])
+}

--- a/internal/testing/testing_test.go
+++ b/internal/testing/testing_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/internal/tx/offer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -187,6 +188,40 @@ func TestXRPTxAmountFromXRP(t *testing.T) {
 	amount := XRPTxAmountFromXRP(100.0)
 	assert.True(t, amount.IsNative())
 	assert.Equal(t, int64(100000000), amount.Drops())
+}
+
+// TestRequireLinesCountsRippleStateOnly verifies that RequireLines counts
+// RippleState entries in the owner directory rather than approximating with
+// OwnerCount: an offer raises OwnerCount but must not count as a trust line,
+// and both sides of a line see it through their respective directories.
+func TestRequireLinesCountsRippleStateOnly(t *testing.T) {
+	env := NewTestEnv(t)
+	gw := NewAccount("gateway")
+	alice := NewAccount("alice")
+	env.Fund(gw)
+	env.Fund(alice)
+
+	RequireLines(t, env, alice, 0)
+	RequireOffers(t, env, alice, 0)
+
+	env.Trust(alice, USD(gw, 100))
+	RequireLines(t, env, alice, 1)
+	// The gateway's owner directory references the same RippleState entry.
+	RequireLines(t, env, gw, 1)
+
+	oc := offer.NewOfferCreate(alice.Address, XRPTxAmount(XRP(10)), USD(gw, 10))
+	oc.Fee = formatUint64(env.BaseFee())
+	seq := env.Seq(alice)
+	oc.Sequence = &seq
+	if alice.PublicKey != nil {
+		env.SignWith(oc, alice)
+	}
+	RequireTxSuccess(t, env.Submit(oc))
+
+	// Alice now owns a trust line and an offer: OwnerCount is 2 but the
+	// per-type counts must stay distinct.
+	RequireLines(t, env, alice, 1)
+	RequireOffers(t, env, alice, 1)
 }
 
 // TestNewTestEnv tests the basic TestEnv creation

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -530,9 +530,9 @@ func escrowLockIOU(view tx.LedgerView, senderID, issuerID [20]byte, amount tx.Am
 	// if absent. We intentionally skip auto-creation here because for escrow
 	// locking the sender must already hold the IOU, which requires an existing
 	// trust line. If the trust line is missing, the sender cannot have a balance
-	// to escrow, so TecNO_LINE is the correct result.
-	// TODO: EscrowFinish (unlock) will need trust line auto-creation for the
-	// destination, since the destination may not yet have a trust line to the issuer.
+	// to escrow, so TecNO_LINE is the correct result. (The unlock side does
+	// auto-create the destination's line when the destination submits the
+	// finish — see escrowUnlockIOU in token_helpers.go.)
 	trustLineKey := keylet.Line(senderID, issuerID, amount.Currency)
 	trustLineData, err := view.Read(trustLineKey)
 	if err != nil {

--- a/internal/tx/payment/pathfinder/path_request.go
+++ b/internal/tx/payment/pathfinder/path_request.go
@@ -7,14 +7,26 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// DefaultSearchLevel is the default search depth for pathfinding.
-// Matches rippled's PATH_SEARCH default (7).
-const DefaultSearchLevel = 7
+// Pathfinding search levels mirror rippled's config defaults
+// (Config.h: PATH_SEARCH_FAST=2, PATH_SEARCH=2, PATH_SEARCH_MAX=3).
+// A fast update runs at SearchLevelFast and a full update at
+// SearchLevelDefault; repeated updates never exceed SearchLevelMax
+// (PathRequest::doUpdate). Tests ported from rippled's Path_test raise
+// the level to 7, matching that suite's pathTestEnv configuration.
+const (
+	SearchLevelFast    = 2
+	SearchLevelDefault = 2
+	SearchLevelMax     = 3
+)
 
 // PathAlternative represents one possible payment path with its cost.
 type PathAlternative struct {
 	// SourceAmount is the amount the source must send.
 	SourceAmount tx.Amount
+	// DestinationAmount is the amount actually delivered. Only meaningful
+	// to report for convert-all requests, where it is the discovered
+	// maximum instead of the requested amount.
+	DestinationAmount tx.Amount
 	// PathsComputed is the set of paths found for this alternative.
 	PathsComputed [][]payment.PathStep
 }
@@ -23,6 +35,10 @@ type PathAlternative struct {
 type PathRequestResult struct {
 	Alternatives          []PathAlternative
 	DestinationCurrencies []string
+	// SourceCurrencyOverflow reports that auto-discovery found more than
+	// maxAutoSrcCur source currencies. rippled fails the whole update with
+	// rpcINTERNAL in this case (PathRequest::findPaths).
+	SourceCurrencyOverflow bool
 }
 
 // PathRequest represents a single pathfinding request.
@@ -35,6 +51,7 @@ type PathRequest struct {
 	sourceCurrencies []payment.Issue // Explicit source currencies (or auto-discovered)
 	convertAll       bool
 	maxPaths         int
+	searchLevel      int
 }
 
 // NewPathRequest creates a new path request from the given parameters.
@@ -53,7 +70,15 @@ func NewPathRequest(
 		sourceCurrencies: sourceCurrencies,
 		convertAll:       convertAll,
 		maxPaths:         maxReturnedPaths,
+		searchLevel:      SearchLevelDefault,
 	}
+}
+
+// SetSearchLevel overrides the search depth used by Execute. Mirrors
+// raising PATH_SEARCH in rippled's config (e.g. Path_test's pathTestEnv
+// uses 7).
+func (pr *PathRequest) SetSearchLevel(level int) {
+	pr.searchLevel = level
 }
 
 // Execute runs the pathfinding algorithm and returns the result.
@@ -91,6 +116,11 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 			if sameAccount && issue.Currency == dstCurrency {
 				continue
 			}
+			// More than maxAutoSrcCur auto-discovered currencies fails the
+			// whole request, matching rippled PathRequest::findPaths.
+			if len(srcCurrencies) >= maxAutoSrcCur {
+				return &PathRequestResult{SourceCurrencyOverflow: true}
+			}
 			// Build issue with source account as issuer (matching rippled)
 			var srcIssue payment.Issue
 			if issue.Currency == "XRP" || issue.Currency == "" {
@@ -99,9 +129,6 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 				srcIssue = payment.Issue{Currency: issue.Currency, Issuer: pr.srcAccount}
 			}
 			srcCurrencies = append(srcCurrencies, srcIssue)
-			if len(srcCurrencies) >= maxAutoSrcCur {
-				break
-			}
 		}
 	}
 
@@ -145,7 +172,7 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 			pr.convertAll,
 		)
 
-		if !pf.FindPaths(DefaultSearchLevel) {
+		if !pf.FindPaths(pr.searchLevel) {
 			continue
 		}
 
@@ -155,9 +182,9 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 		bestPaths, fullLiquidityPath := pf.GetBestPaths(pr.maxPaths, extraPaths, srcIssue.Issuer)
 		context[srcIssue] = bestPaths
 
-		if len(bestPaths) == 0 {
-			continue
-		}
+		// An empty path set is still tried: rippled runs rippleCalc with
+		// default paths allowed, so a working default path yields an
+		// alternative with empty paths_computed (PathRequest::findPaths).
 
 		// Validate the paths via RippleCalculate.
 		// Reference: rippled PathRequest::findPaths() line 592 — default paths ARE allowed
@@ -193,8 +220,8 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 		}
 
 		if calcResult == tx.TesSUCCESS {
-			// Re-run to get actual source amount
-			actualIn, _, _, _, _ := payment.RippleCalculate(
+			// Re-run to get actual source and delivered amounts
+			actualIn, finalOut, _, _, _ := payment.RippleCalculate(
 				ledger,
 				pr.srcAccount, pr.dstAccount,
 				effectiveDstAmount,
@@ -206,9 +233,22 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 				[32]byte{}, 0,
 			)
 
+			// Set the source amount's issuer the way rippled does
+			// (rc.actualAmountIn.setIssuer(sourceAccount)): the explicit
+			// issue account, or the source account itself for IOUs.
+			sourceAmount := payment.FromEitherAmount(actualIn)
+			if !sourceAmount.IsNative() {
+				if srcIssue.Issuer != ([20]byte{}) {
+					sourceAmount.Issuer = state.EncodeAccountIDSafe(srcIssue.Issuer)
+				} else {
+					sourceAmount.Issuer = state.EncodeAccountIDSafe(pr.srcAccount)
+				}
+			}
+
 			alt := PathAlternative{
-				SourceAmount:  payment.FromEitherAmount(actualIn),
-				PathsComputed: bestPaths,
+				SourceAmount:      sourceAmount,
+				DestinationAmount: payment.FromEitherAmount(finalOut),
+				PathsComputed:     bestPaths,
 			}
 			result.Alternatives = append(result.Alternatives, alt)
 		}

--- a/internal/tx/payment/pathfinder/pathfinder_test.go
+++ b/internal/tx/payment/pathfinder/pathfinder_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testSearchLevel mirrors rippled Path_test's pathTestEnv, which raises
+// PATH_SEARCH to 7 because these scenarios were written for deeper search
+// levels than the production default.
+const testSearchLevel = 7
+
 // Mock LedgerView
 
 // mockLedgerView is an in-memory implementation of tx.LedgerView for unit tests.
@@ -1075,7 +1080,7 @@ func TestFindPaths_ZeroDstAmount(t *testing.T) {
 		"XRP", [20]byte{}, false,
 	)
 
-	result := pf.FindPaths(DefaultSearchLevel)
+	result := pf.FindPaths(testSearchLevel)
 	require.False(t, result, "zero dst amount should return false")
 }
 
@@ -1091,7 +1096,7 @@ func TestFindPaths_SameAccountSameCurrency(t *testing.T) {
 		"XRP", [20]byte{}, false,
 	)
 
-	result := pf.FindPaths(DefaultSearchLevel)
+	result := pf.FindPaths(testSearchLevel)
 	require.False(t, result, "same account same currency should return false (no paths needed)")
 }
 
@@ -1113,7 +1118,7 @@ func TestFindPaths_SourceNotFound(t *testing.T) {
 		"USD", gwID, false,
 	)
 
-	result := pf.FindPaths(DefaultSearchLevel)
+	result := pf.FindPaths(testSearchLevel)
 	require.False(t, result, "non-existent source should return false")
 }
 
@@ -1131,7 +1136,7 @@ func TestFindPaths_XRPToXRP_NoPaths(t *testing.T) {
 		"XRP", [20]byte{}, false,
 	)
 
-	result := pf.FindPaths(DefaultSearchLevel)
+	result := pf.FindPaths(testSearchLevel)
 	// XRP-to-XRP returns true but with no explicit paths (default path only)
 	require.True(t, result, "XRP-to-XRP should succeed with default path")
 	require.Empty(t, pf.CompletePaths(), "XRP-to-XRP should find no explicit paths")
@@ -1179,7 +1184,7 @@ func TestFindPaths_IOUToSameIOU_ThroughGateway(t *testing.T) {
 		dstAmt, srcAmt, "USD", gw, false,
 	)
 
-	result := pf.FindPaths(DefaultSearchLevel)
+	result := pf.FindPaths(testSearchLevel)
 	require.True(t, result, "should find paths for IOU-to-same-IOU through gateway")
 	// There should be at least one complete path found
 	// (the specific paths depend on which patterns match — gateway is directly connected)
@@ -1249,7 +1254,7 @@ func TestFindPaths_DestNotExist_IOUFails(t *testing.T) {
 	srcAmt := state.NewIssuedAmountFromFloat64(100, "USD", gwAddr)
 
 	pf := NewPathfinder(ledger, cache, src, dst, dstAmt, srcAmt, "USD", gw, false)
-	result := pf.FindPaths(DefaultSearchLevel)
+	result := pf.FindPaths(testSearchLevel)
 	require.False(t, result, "IOU payment to non-existent destination should fail")
 }
 
@@ -1309,7 +1314,7 @@ func TestFindPaths_SourceIsEffectiveDst_DefaultPath(t *testing.T) {
 	srcAmt := state.NewIssuedAmountFromFloat64(100, "USD", gwAddr)
 
 	pf := NewPathfinder(ledger, cache, gw, bob, dstAmt, srcAmt, "USD", gw, false)
-	result := pf.FindPaths(DefaultSearchLevel)
+	result := pf.FindPaths(testSearchLevel)
 	require.True(t, result, "source is effective dst with same currency -> default path works")
 	require.Empty(t, pf.CompletePaths(), "should have no explicit paths (default path suffices)")
 }
@@ -1361,7 +1366,7 @@ func TestFindPaths_XRPToIOU_ThroughOfferBook(t *testing.T) {
 	srcAmt := state.NewXRPAmountFromInt(99999999999)
 
 	pf := NewPathfinder(ledger, cache, alice, bob, dstAmt, srcAmt, "XRP", [20]byte{}, false)
-	result := pf.FindPaths(DefaultSearchLevel)
+	result := pf.FindPaths(testSearchLevel)
 	require.True(t, result, "should find paths for XRP-to-IOU through offer book")
 
 	// The path type table for XRP-to-nonXRP includes patterns that go through books.
@@ -1634,7 +1639,7 @@ func TestFindPaths_IOUSameIOU_MultipleTrustLines(t *testing.T) {
 	srcAmt := state.NewIssuedAmountFromFloat64(200, "USD", gwAddr)
 
 	pf := NewPathfinder(ledger, cache, alice, bob, dstAmt, srcAmt, "USD", gw, false)
-	result := pf.FindPaths(DefaultSearchLevel)
+	result := pf.FindPaths(testSearchLevel)
 	require.True(t, result, "should complete pathfinding")
 
 	paths := pf.CompletePaths()
@@ -1811,7 +1816,9 @@ func TestConstants(t *testing.T) {
 	require.Equal(t, 4, maxReturnedPaths)
 	require.Equal(t, 50, maxCandidatesFromSource)
 	require.Equal(t, 10, maxCandidatesFromOther)
-	require.Equal(t, 7, DefaultSearchLevel)
+	require.Equal(t, 2, SearchLevelFast)
+	require.Equal(t, 2, SearchLevelDefault)
+	require.Equal(t, 3, SearchLevelMax)
 }
 
 func TestAddFlags(t *testing.T) {
@@ -2295,7 +2302,7 @@ func TestFindPaths_DestNotExist_XRPAllowed(t *testing.T) {
 		"XRP", [20]byte{}, false,
 	)
 
-	result := pf.FindPaths(DefaultSearchLevel)
+	result := pf.FindPaths(testSearchLevel)
 	// XRP-to-XRP pathfinding should succeed even when dest doesn't exist
 	require.True(t, result, "XRP payment to non-existent dest should not fail at pathfinding stage")
 }

--- a/internal/tx/payment/payment_mpt.go
+++ b/internal/tx/payment/payment_mpt.go
@@ -369,7 +369,10 @@ func mptDivide(amount, rate uint64) uint64 {
 // divRoundNearest divides num by den rounding to the nearest integer,
 // ties to even — the rounding rippled's STAmount/Number arithmetic
 // applies when an MPT multiply/divide result is canonicalized back to
-// an integer amount (e.g. 90/1.1 → 81.81… → 82).
+// an integer amount (e.g. 90/1.1 → 81.81… → 82). rippled additionally
+// rounds the intermediate Number mantissa to 16 significant digits,
+// a no-op for amounts ≤ 10^15; this single-stage round matches it
+// exactly in that range.
 func divRoundNearest(num, den *big.Int) uint64 {
 	q, r := new(big.Int).QuoRem(num, den, new(big.Int))
 	r.Lsh(r, 1)

--- a/internal/tx/payment/payment_mpt.go
+++ b/internal/tx/payment/payment_mpt.go
@@ -346,26 +346,42 @@ func mptMultiply(amount, rate uint64) uint64 {
 	if rate == qualityOne {
 		return amount
 	}
-	result := new(big.Int).Mul(
+	num := new(big.Int).Mul(
 		new(big.Int).SetUint64(amount),
 		new(big.Int).SetUint64(rate),
 	)
-	result.Div(result, new(big.Int).SetUint64(qualityOne))
-	return result.Uint64()
+	return divRoundNearest(num, new(big.Int).SetUint64(qualityOne))
 }
 
 // mptDivide divides amount by rate/QUALITY_ONE using big.Int to avoid overflow.
-// Reference: rippled STAmount divide() for MPT - "No rounding"
+// Reference: rippled STAmount divide() for MPT
 func mptDivide(amount, rate uint64) uint64 {
 	if rate == qualityOne {
 		return amount
 	}
-	result := new(big.Int).Mul(
+	num := new(big.Int).Mul(
 		new(big.Int).SetUint64(amount),
 		new(big.Int).SetUint64(qualityOne),
 	)
-	result.Div(result, new(big.Int).SetUint64(rate))
-	return result.Uint64()
+	return divRoundNearest(num, new(big.Int).SetUint64(rate))
+}
+
+// divRoundNearest divides num by den rounding to the nearest integer,
+// ties to even — the rounding rippled's STAmount/Number arithmetic
+// applies when an MPT multiply/divide result is canonicalized back to
+// an integer amount (e.g. 90/1.1 → 81.81… → 82).
+func divRoundNearest(num, den *big.Int) uint64 {
+	q, r := new(big.Int).QuoRem(num, den, new(big.Int))
+	r.Lsh(r, 1)
+	switch r.Cmp(den) {
+	case 1:
+		q.Add(q, big.NewInt(1))
+	case 0:
+		if q.Bit(0) == 1 {
+			q.Add(q, big.NewInt(1))
+		}
+	}
+	return q.Uint64()
 }
 
 // mptAmountToUint64 converts an Amount to a uint64 integer value.

--- a/log/log.go
+++ b/log/log.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"maps"
 	"os"
+	"strings"
 	"sync/atomic"
 )
 
@@ -108,21 +109,23 @@ func With(args ...any) Logger { return Root().With(args...) }
 // Named returns a new Logger derived from root scoped to the given partition.
 func Named(partition string) Logger { return Root().Named(partition) }
 
-// parseLevel converts a level string to a Level constant.
+// parseLevel converts a level string to a Level constant. Matching is
+// case-insensitive and accepts the same aliases as rippled's
+// Logs::fromString (information, warnings, errors, fatals).
 // Returns LevelInfo and false if the name is unrecognised.
 func parseLevel(s string) (Level, bool) {
-	switch s {
+	switch strings.ToLower(s) {
 	case "trace":
 		return LevelTrace, true
 	case "debug":
 		return LevelDebug, true
-	case "info":
+	case "info", "information":
 		return LevelInfo, true
-	case "warn", "warning":
+	case "warn", "warning", "warnings":
 		return LevelWarn, true
-	case "error":
+	case "error", "errors":
 		return LevelError, true
-	case "fatal":
+	case "fatal", "fatals":
 		return LevelFatal, true
 	default:
 		return LevelInfo, false

--- a/scripts/docsgen/rpcmethods/main.go
+++ b/scripts/docsgen/rpcmethods/main.go
@@ -1,7 +1,7 @@
 // Command rpcmethods generates docs/rpc-methods.md from the live RPC method
-// registry. It registers every method the server wires up (RegisterAll +
-// RegisterWebSocketOnly) into a fresh registry and reflects each handler's
-// required role and supported API versions. Run via `just docs-gen`.
+// registry. It registers every method the server wires up (RegisterAll)
+// into a fresh registry and reflects each handler's required role and
+// supported API versions. Run via `just docs-gen`.
 package main
 
 import (
@@ -49,14 +49,6 @@ func main() {
 	all := types.NewMethodRegistry()
 	handlers.RegisterAll(all)
 
-	wsOnly := types.NewMethodRegistry()
-	handlers.RegisterWebSocketOnly(wsOnly)
-	wsNames := map[string]bool{}
-	for _, n := range wsOnly.List() {
-		wsNames[n] = true
-		all.Register(n, mustGet(wsOnly, n))
-	}
-
 	names := all.List()
 	sort.Strings(names)
 
@@ -65,21 +57,15 @@ func main() {
 	b.WriteString("# RPC methods\n\n")
 	b.WriteString("The JSON-RPC and WebSocket methods registered by the server, generated from\n")
 	b.WriteString("the method registry (`internal/rpc/handlers`). **Role** is the minimum role a\n")
-	b.WriteString("caller needs; **API versions** are the API versions each method supports.\n")
-	b.WriteString("Methods marked WS-only are available only over a WebSocket session (the HTTP\n")
-	b.WriteString("server returns `methodNotFound` for them, matching rippled).\n\n")
+	b.WriteString("caller needs; **API versions** are the API versions each method supports.\n\n")
 	fmt.Fprintf(&b, "Total: %d methods.\n\n", len(names))
-	b.WriteString("| Method | Role | API versions | WS-only |\n")
-	b.WriteString("|--------|------|--------------|---------|\n")
+	b.WriteString("| Method | Role | API versions |\n")
+	b.WriteString("|--------|------|--------------|\n")
 
 	for _, name := range names {
 		h := mustGet(all, name)
-		ws := ""
-		if wsNames[name] {
-			ws = "✓"
-		}
-		fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n",
-			name, roleName(h.RequiredRole()), versions(h.SupportedApiVersions()), ws)
+		fmt.Fprintf(&b, "| `%s` | %s | %s |\n",
+			name, roleName(h.RequiredRole()), versions(h.SupportedApiVersions()))
 	}
 
 	if err := os.WriteFile(outPath, []byte(b.String()), 0o644); err != nil {


### PR DESCRIPTION
## Summary

Started as the multisig RPC TODO resolution; grew (by request) into a full sweep of the outstanding RPC/test TODOs in `internal/`, on one branch with one commit per concern.

### 1. Multisig RPC (`submit_multisigned`, `sign`/`sign_for` autofill)
- rippled's division of labour established from `TransactionSign.cpp`: only source-account malformed/not-found are RPC-layer checks for `submit_multisigned` — implemented with exact tokens. Signer-list existence/quorum/weights are engine checks (`Transactor::checkMultiSign`); verified goXRPL's preclaim path covers them (`tefNOT_MULTI_SIGNING`/`tefBAD_QUORUM`/…) and deleted the stale TODOs.
- `sign` autofill parity: online account-existence → `srcActNotFound`; Sequence via TxQ-aware lookup (TicketSequence→0); Fee via load-scaled, escalation-aware fee with the caller's `fee_mult_max`/`fee_div_max` threaded through the service like rippled's `getCurrentNetworkFee`; offline → missing-field errors.

### 2. RPC handler TODO sweep
- **deposit_authorized**: rippled-parity credential checks — and a **latent bug fix**: credential expiry compared Ripple-epoch `Expiration` against Unix time, falsely expiring every credential with an expiration set. Also aligned duplicate-credential detection with rippled's (issuer, type)-from-ledger semantics.
- **log_level**: full `LogLevel.cpp` parity (severity names, aliases, case-insensitivity, `partition: "base"`, real partition overrides reported — none faked).
- **WS origin**: verified rippled does not enforce Origin; TODO replaced with the parity decision.
- **subscribe/unsubscribe `url`**: exact rippled gating (`invalidParams` / `noPermission` / `notSupported`); full RPCSub delivery is a subsystem of its own → tracked in #832.
- **version**: build info (commit, time, modified) via `debug.ReadBuildInfo`.

### 3. Test-stub sweep (assertions that asserted nothing)
- **MPT builder assertions made real — exposing a latent bug fix**: MPT transfer-fee math truncated where rippled rounds to nearest (ties-to-even); partial payment with SendMax 90 at 10% must deliver 82/debit 90, we delivered 81/89. Fixed in `mptMultiply`/`mptDivide`.
- Oracle pair-ordering assertions via real SLE parsing (fixPriceOracleOrder semantics confirmed against `SetOracle.cpp`).
- Trust-line counting via owner-directory iteration (was an owner-count proxy).
- AMM freeze test ported in full (incl. DeepFreeze branches) using the existing AMM builders.

### 4. ripple_path_find parity + 9 unskipped path tests
- Handler rewritten to rippled's `PathRequest::parseJson`/`isValid` order: exact error tokens (4 new helpers), `convert_all` (`destination_amount: -1`) with per-alternative `destination_amount`, the send_max-requires-`-1` rule, `source_currencies` caps (18 explicit / 88 auto → `rpcINTERNAL` like rippled, not silent truncation), always-on destination existence checks, `ledger_index`/`ledger_hash` selection with `lookupLedger`-shaped response fields, `id` echo, `full_reply`.
- Search levels corrected: production now uses rippled's `PATH_SEARCH=2`/`MAX=3` (the previous 7 was rippled's *test* level, mislabeled as parity); tests opt into 7 like rippled's `pathTestEnv`.
- Engine fixes: alternatives with empty computed paths are returned (default-path liquidity) instead of dropped; source-amount issuer set like rippled.
- All 9 skipped path tests implemented from `Path_test.cpp` and passing — including the five offer-path cases (XRP bridge `[G1, IPE(XRP), IPE(G2.HKD), G2]` and friends), which exercised the book-aware pathfinder for the first time.

### 5. Escrow trust-line TODO — stale, behaviour verified
rippled's `escrowUnlockApplyHelper<Issue>` auto-creates the destination line only when the destination submits; goXRPL's `escrowUnlockIOU` already matches, including the `createAsset` rule and TER codes. Ported `testIOUFinishDoApply` as a pinning conformance test.

## Deliberately not in this PR
- RPCSub url-subscription delivery → #832.
- Domain/AMM pathfinding test cases (`TestPath_HybridOfferPath`, `TestPath_AMMDomainPath`) — depend on PermissionedDomain offer support; still skipped with precise reasons.

## Test plan
- [x] `gofmt` / `go vet ./internal/...` / `go build ./...` clean
- [x] Full `go test ./internal/...` green; conformance-fixture failures byte-identical to branch base (verified by diffing failure lists from a base worktree)
- [x] New: 9 multisig/sign handler tests, deposit_authorized fail+pass per check, log_level suite, 28 ripple_path_find assertions, 9 path tests, MPT rounding regression, IOU-escrow finish suite, AMM freeze suite
