### PR TITLE
fix(rpc): amm_info account param and api_version 3 error precedence

### DIFF
--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -23,31 +27,26 @@ type AMMInfoMethod struct{ BaseHandler }
 func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var request struct {
 		types.LedgerSpecifier
-		Asset      map[string]any `json:"asset,omitempty"`
-		Asset2     map[string]any `json:"asset2,omitempty"`
-		AMMAccount string         `json:"amm_account,omitempty"`
-		Account    string         `json:"account,omitempty"`
+		Asset      json.RawMessage `json:"asset,omitempty"`
+		Asset2     json.RawMessage `json:"asset2,omitempty"`
+		AMMAccount json.RawMessage `json:"amm_account,omitempty"`
+		Account    json.RawMessage `json:"account,omitempty"`
 	}
 
 	if err := ParseParams(params, &request); err != nil {
 		return nil, err
 	}
 
-	hasAsset := request.Asset != nil
-	hasAsset2 := request.Asset2 != nil
-	hasAMMAccount := request.AMMAccount != ""
-	hasLPAccount := request.Account != ""
+	// Key presence decides which checks run (rippled goes through isMember),
+	// so null or empty values still count as supplied.
+	hasAsset := len(request.Asset) > 0
+	hasAsset2 := len(request.Asset2) > 0
+	hasAMMAccount := len(request.AMMAccount) > 0
+	hasLPAccount := len(request.Account) > 0
 
 	// asset and asset2 must come together, and exactly one of (asset pair,
 	// amm_account) must be given.
 	invalidCombination := hasAsset != hasAsset2 || hasAsset == hasAMMAccount
-
-	// For api_version < 3 the combination check runs before the per-field
-	// checks; for api_version >= 3 it runs after them, so a malformed
-	// account/amm_account takes precedence (rippled AMMInfo.cpp:108-150).
-	if ctx.ApiVersion < types.ApiVersion3 && invalidCombination {
-		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
-	}
 
 	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
@@ -57,6 +56,21 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	ledgerIndex := "validated"
 	if request.LedgerIndex != "" {
 		ledgerIndex = request.LedgerIndex.String()
+	}
+
+	// rippled resolves the ledger before validating any parameter
+	// (AMMInfo.cpp:81-84), so a missing ledger outranks every param error.
+	if seq, err := strconv.ParseUint(ledgerIndex, 10, 32); err == nil {
+		if _, lerr := ctx.Services.Ledger.GetLedgerBySequence(uint32(seq)); lerr != nil {
+			return nil, types.RpcErrorLgrNotFound("Ledger not found.")
+		}
+	}
+
+	// For api_version < 3 the combination check runs before the per-field
+	// checks; for api_version >= 3 it runs after them, so a malformed
+	// asset/account/amm_account takes precedence (rippled AMMInfo.cpp:108-150).
+	if ctx.ApiVersion < types.ApiVersion3 && invalidCombination {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 
 	var issue1Issuer, issue1Currency, issue2Issuer, issue2Currency [20]byte
@@ -80,7 +94,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		// rippled AMMInfo returns actMalformed (not invalidParams or
 		// actNotFound) both when the amm_account does not parse and when it
 		// does not exist in the ledger.
-		_, accountEntry, rpcErr := readAccountRoot(ctx, ledgerIndex, request.AMMAccount)
+		_, accountEntry, rpcErr := readAccountRoot(ctx, ledgerIndex, accountIdent(request.AMMAccount))
 		if rpcErr != nil {
 			return nil, rpcErr
 		}
@@ -101,12 +115,15 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 			return nil, types.RpcErrorInternal("Invalid AMMID in account")
 		}
 		copy(ammKey[:], ammIDBytes)
+		if ammKey == ([32]byte{}) {
+			return nil, types.RpcErrorActNotFound("Account not found.")
+		}
 	}
 
 	var lpAccountID [20]byte
 	if hasLPAccount {
 		var rpcErr *types.RpcError
-		lpAccountID, _, rpcErr = readAccountRoot(ctx, ledgerIndex, request.Account)
+		lpAccountID, _, rpcErr = readAccountRoot(ctx, ledgerIndex, accountIdent(request.Account))
 		if rpcErr != nil {
 			return nil, rpcErr
 		}
@@ -122,6 +139,9 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 
 	ammEntry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, ammKey, ledgerIndex)
 	if err != nil {
+		if errors.Is(err, svcerr.ErrLedgerNotFound) {
+			return nil, types.RpcErrorLgrNotFound("Ledger not found.")
+		}
 		return nil, types.RpcErrorActNotFound("Account not found.")
 	}
 
@@ -359,40 +379,94 @@ func toUint32(v any) uint32 {
 	return 0
 }
 
-// parseIssue parses an asset/issue from the JSON representation
-// Returns issuer (20 bytes), currency (20 bytes), and error
-func parseIssue(issue map[string]any) ([20]byte, [20]byte, error) {
-	var issuer [20]byte
-	var currency [20]byte
+// parseIssue parses an asset/issue object, enforcing rippled's issueFromJson
+// rules (Issue.cpp:94-145): a JSON object with a valid currency code, an
+// issuer exactly when the currency is not XRP, and no mpt_issuance_id.
+// Returns issuer (20 bytes), currency (20 bytes), and error.
+func parseIssue(raw json.RawMessage) ([20]byte, [20]byte, error) {
+	var issuer, currency [20]byte
+
+	var issue map[string]any
+	if err := json.Unmarshal(raw, &issue); err != nil {
+		return issuer, currency, errors.New("issue must be a JSON object")
+	}
+	if _, ok := issue["mpt_issuance_id"]; ok {
+		return issuer, currency, errors.New("issue must not have mpt_issuance_id")
+	}
 
 	currencyStr, ok := issue["currency"].(string)
 	if !ok {
-		return issuer, currency, fmt.Errorf("missing currency field")
+		return issuer, currency, errors.New("missing or non-string currency field")
+	}
+	currency, err := currencyFromString(currencyStr)
+	if err != nil {
+		return issuer, [20]byte{}, err
 	}
 
-	// Handle XRP (native currency)
-	if currencyStr == "XRP" {
-		// For XRP, issuer is all zeros, currency is all zeros
+	// XRP: no issuer allowed (an explicit null is tolerated, like rippled).
+	if currency == ([20]byte{}) {
+		if issuerVal, ok := issue["issuer"]; ok && issuerVal != nil {
+			return issuer, currency, errors.New("XRP must not have an issuer")
+		}
 		return issuer, currency, nil
 	}
 
-	// Handle IOU
 	issuerStr, ok := issue["issuer"].(string)
 	if !ok {
-		return issuer, currency, fmt.Errorf("missing issuer field for non-XRP currency")
+		return issuer, currency, errors.New("missing or non-string issuer field")
 	}
-
 	_, issuerBytes, err := addresscodec.DecodeClassicAddressToAccountID(issuerStr)
 	if err != nil {
 		return issuer, currency, fmt.Errorf("invalid issuer: %w", err)
 	}
 	copy(issuer[:], issuerBytes)
 
-	// state.GetCurrencyBytes is the canonical write-path encoder used by
-	// AMMCreate; routing the lookup through it keeps the keying symmetric.
-	currency = state.GetCurrencyBytes(currencyStr)
-
 	return issuer, currency, nil
+}
+
+// isoCurrencyChars is rippled to_currency's character set for 3-letter
+// ISO-style codes (UintTypes.cpp:39-43).
+const isoCurrencyChars = "abcdefghijklmnopqrstuvwxyz" +
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+	"0123456789" +
+	"<>(){}[]|?!@#$%^&*"
+
+// Reserved 160-bit currency values issueFromJson rejects: noCurrency ("1")
+// and badCurrency (ISO-style "XRP" spelled out in hex).
+var (
+	noCurrencyBytes  = [20]byte{19: 0x01}
+	badCurrencyBytes = [20]byte{12: 'X', 13: 'R', 14: 'P'}
+)
+
+// currencyFromString validates a currency code with to_currency's rules —
+// empty/"XRP" mean native XRP, otherwise 3 characters from the ISO set or
+// 40 hex digits — then encodes it through state.GetCurrencyBytes, the
+// canonical write-path encoder used by AMMCreate, so the keying stays
+// symmetric.
+func currencyFromString(code string) ([20]byte, error) {
+	if code == "" || code == "XRP" {
+		return [20]byte{}, nil
+	}
+	switch len(code) {
+	case 3:
+		for i := 0; i < len(code); i++ {
+			if strings.IndexByte(isoCurrencyChars, code[i]) < 0 {
+				return [20]byte{}, errors.New("invalid character in currency code")
+			}
+		}
+	case 40:
+		if _, err := hex.DecodeString(code); err != nil {
+			return [20]byte{}, errors.New("invalid hex currency code")
+		}
+	default:
+		return [20]byte{}, errors.New("invalid currency code length")
+	}
+
+	currency := state.GetCurrencyBytes(code)
+	if currency == noCurrencyBytes || currency == badCurrencyBytes {
+		return currency, errors.New("reserved currency code")
+	}
+	return currency, nil
 }
 
 // ammIssue carries the asset definition decoded from the AMM SLE's
@@ -439,19 +513,63 @@ func extractIssue(raw any) (ammIssue, bool) {
 	return issue, true
 }
 
-// readAccountRoot resolves a classic address to its AccountRoot entry.
-// Both a malformed address and a missing account map to actMalformed,
-// matching rippled's handling of amm_info account parameters.
-func readAccountRoot(ctx *types.RpcContext, ledgerIndex, address string) ([20]byte, *types.LedgerEntryResult, *types.RpcError) {
+// accountIdent extracts the string form of an account parameter; any
+// non-string value yields "", which never resolves to an account.
+func accountIdent(raw json.RawMessage) string {
+	var ident string
+	if err := json.Unmarshal(raw, &ident); err != nil {
+		return ""
+	}
+	return ident
+}
+
+// accountFromString resolves an account identifier the way rippled's
+// RPC::accountFromString does in non-strict mode (RPCHelpers.cpp:43-85): a
+// base58 account public key, a classic address, or — as a debugging
+// convenience — anything that parses as a generic seed, whose secp256k1
+// keypair identifies the account.
+func accountFromString(ident string) ([20]byte, bool) {
 	var accountID [20]byte
-	_, raw, err := addresscodec.DecodeClassicAddressToAccountID(address)
+	if pubKey, err := addresscodec.DecodeAccountPublicKey(ident); err == nil {
+		copy(accountID[:], addresscodec.Sha256RipeMD160(pubKey))
+		return accountID, true
+	}
+	if _, raw, err := addresscodec.DecodeClassicAddressToAccountID(ident); err == nil {
+		copy(accountID[:], raw)
+		return accountID, true
+	}
+
+	seed, ok := parseGenericSeed(ident)
+	if !ok {
+		return accountID, false
+	}
+	_, pubKeyHex, err := secp256k1.SECP256K1().DeriveKeypair(seed, false)
 	if err != nil {
+		return accountID, false
+	}
+	pubKey, err := hex.DecodeString(pubKeyHex)
+	if err != nil {
+		return accountID, false
+	}
+	copy(accountID[:], addresscodec.Sha256RipeMD160(pubKey))
+	return accountID, true
+}
+
+// readAccountRoot resolves an account identifier to its AccountRoot entry.
+// Both an unresolvable identifier and a missing account map to actMalformed,
+// matching rippled's handling of amm_info account parameters; a missing
+// ledger keeps its own error.
+func readAccountRoot(ctx *types.RpcContext, ledgerIndex, ident string) ([20]byte, *types.LedgerEntryResult, *types.RpcError) {
+	accountID, ok := accountFromString(ident)
+	if !ok {
 		return accountID, nil, types.RpcErrorActMalformed("Account malformed.")
 	}
-	copy(accountID[:], raw)
 
 	entry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, keylet.Account(accountID).Key, ledgerIndex)
 	if err != nil {
+		if errors.Is(err, svcerr.ErrLedgerNotFound) {
+			return accountID, nil, types.RpcErrorLgrNotFound("Ledger not found.")
+		}
 		return accountID, nil, types.RpcErrorActMalformed("Account malformed.")
 	}
 	return accountID, entry, nil

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -103,7 +103,6 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		copy(ammKey[:], ammIDBytes)
 	}
 
-	// account (LP holder) must parse and exist, like amm_account.
 	var lpAccountID [20]byte
 	if hasLPAccount {
 		var rpcErr *types.RpcError

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -64,14 +64,14 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		var parseErr error
 		issue1Issuer, issue1Currency, parseErr = parseIssue(request.Asset)
 		if parseErr != nil {
-			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid asset: %v", parseErr))
+			return nil, types.RpcErrorIssueMalformed()
 		}
 	}
 	if hasAsset2 {
 		var parseErr error
 		issue2Issuer, issue2Currency, parseErr = parseIssue(request.Asset2)
 		if parseErr != nil {
-			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid asset2: %v", parseErr))
+			return nil, types.RpcErrorIssueMalformed()
 		}
 	}
 

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -33,12 +33,20 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		return nil, err
 	}
 
-	hasAssets := request.Asset != nil && request.Asset2 != nil
+	hasAsset := request.Asset != nil
+	hasAsset2 := request.Asset2 != nil
 	hasAMMAccount := request.AMMAccount != ""
+	hasLPAccount := request.Account != ""
 
-	// Validate parameter combinations
-	if hasAssets == hasAMMAccount {
-		return nil, types.RpcErrorInvalidParams("Must specify either (asset + asset2) or amm_account, but not both or neither")
+	// asset and asset2 must come together, and exactly one of (asset pair,
+	// amm_account) must be given.
+	invalidCombination := hasAsset != hasAsset2 || hasAsset == hasAMMAccount
+
+	// For api_version < 3 the combination check runs before the per-field
+	// checks; for api_version >= 3 it runs after them, so a malformed
+	// account/amm_account takes precedence (rippled AMMInfo.cpp:108-150).
+	if ctx.ApiVersion < types.ApiVersion3 && invalidCombination {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 
 	if err := RequireLedgerService(ctx.Services); err != nil {
@@ -51,25 +59,30 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		ledgerIndex = request.LedgerIndex.String()
 	}
 
-	var ammKey [32]byte
-	var err error
+	var issue1Issuer, issue1Currency, issue2Issuer, issue2Currency [20]byte
+	if hasAsset {
+		var parseErr error
+		issue1Issuer, issue1Currency, parseErr = parseIssue(request.Asset)
+		if parseErr != nil {
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid asset: %v", parseErr))
+		}
+	}
+	if hasAsset2 {
+		var parseErr error
+		issue2Issuer, issue2Currency, parseErr = parseIssue(request.Asset2)
+		if parseErr != nil {
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid asset2: %v", parseErr))
+		}
+	}
 
+	var ammKey [32]byte
 	if hasAMMAccount {
 		// rippled AMMInfo returns actMalformed (not invalidParams or
 		// actNotFound) both when the amm_account does not parse and when it
 		// does not exist in the ledger.
-		_, accountID, decErr := addresscodec.DecodeClassicAddressToAccountID(request.AMMAccount)
-		if decErr != nil {
-			return nil, types.RpcErrorActMalformed("Account malformed.")
-		}
-
-		var accountIDArray [20]byte
-		copy(accountIDArray[:], accountID)
-		accountKey := keylet.Account(accountIDArray)
-
-		accountEntry, lookupErr := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, accountKey.Key, ledgerIndex)
-		if lookupErr != nil {
-			return nil, types.RpcErrorActMalformed("Account malformed.")
+		_, accountEntry, rpcErr := readAccountRoot(ctx, ledgerIndex, request.AMMAccount)
+		if rpcErr != nil {
+			return nil, rpcErr
 		}
 
 		// Decode the account to get AMMID
@@ -88,25 +101,29 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 			return nil, types.RpcErrorInternal("Invalid AMMID in account")
 		}
 		copy(ammKey[:], ammIDBytes)
-	} else {
-		// Look up AMM by asset pair
-		issue1Issuer, issue1Currency, err := parseIssue(request.Asset)
-		if err != nil {
-			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid asset: %v", err))
-		}
+	}
 
-		issue2Issuer, issue2Currency, err := parseIssue(request.Asset2)
-		if err != nil {
-			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid asset2: %v", err))
+	// account (LP holder) must parse and exist, like amm_account.
+	var lpAccountID [20]byte
+	if hasLPAccount {
+		var rpcErr *types.RpcError
+		lpAccountID, _, rpcErr = readAccountRoot(ctx, ledgerIndex, request.Account)
+		if rpcErr != nil {
+			return nil, rpcErr
 		}
+	}
 
-		ammKeylet := keylet.AMM(issue1Issuer, issue1Currency, issue2Issuer, issue2Currency)
-		ammKey = ammKeylet.Key
+	if ctx.ApiVersion >= types.ApiVersion3 && invalidCombination {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+
+	if !hasAMMAccount {
+		ammKey = keylet.AMM(issue1Issuer, issue1Currency, issue2Issuer, issue2Currency).Key
 	}
 
 	ammEntry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, ammKey, ledgerIndex)
 	if err != nil {
-		return nil, types.RpcErrorActNotFound("AMM not found")
+		return nil, types.RpcErrorActNotFound("Account not found.")
 	}
 
 	decoded, decodeErr := binarycodec.Decode(hex.EncodeToString(ammEntry.Node))
@@ -129,6 +146,13 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	}
 	if lpToken, ok := decoded["LPTokenBalance"]; ok {
 		ammResult["lp_token"] = lpToken
+		// With the account param, lp_token reports that account's LP token
+		// balance instead of the pool total (rippled AMMInfo.cpp:195-197).
+		if hasLPAccount && haveAMMAccountID {
+			if total, ok := lpToken.(map[string]any); ok {
+				ammResult["lp_token"] = ammLPHoldsJSON(ctx, ledgerIndex, ammAccountID, lpAccountID, total)
+			}
+		}
 	}
 	if tradingFee, ok := decoded["TradingFee"]; ok {
 		ammResult["trading_fee"] = tradingFee
@@ -414,6 +438,40 @@ func extractIssue(raw any) (ammIssue, bool) {
 	copy(issue.Issuer[:], issuerBytes)
 	issue.IssuerR = issuerStr
 	return issue, true
+}
+
+// readAccountRoot resolves a classic address to its AccountRoot entry.
+// Both a malformed address and a missing account map to actMalformed,
+// matching rippled's handling of amm_info account parameters.
+func readAccountRoot(ctx *types.RpcContext, ledgerIndex, address string) ([20]byte, *types.LedgerEntryResult, *types.RpcError) {
+	var accountID [20]byte
+	_, raw, err := addresscodec.DecodeClassicAddressToAccountID(address)
+	if err != nil {
+		return accountID, nil, types.RpcErrorActMalformed("Account malformed.")
+	}
+	copy(accountID[:], raw)
+
+	entry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, keylet.Account(accountID).Key, ledgerIndex)
+	if err != nil {
+		return accountID, nil, types.RpcErrorActMalformed("Account malformed.")
+	}
+	return accountID, entry, nil
+}
+
+// ammLPHoldsJSON returns the LP account's holding of the AMM's LP token as
+// an STAmount-style JSON value: the balance of the LP's trust line with the
+// AMM account, zero when the line is missing or frozen. total supplies the
+// LP token currency and issuer from the AMM SLE's LPTokenBalance.
+func ammLPHoldsJSON(ctx *types.RpcContext, ledgerIndex string, ammAccountID, lpAccountID [20]byte, total map[string]any) map[string]any {
+	currency, _ := total["currency"].(string)
+	issuer, _ := total["issuer"].(string)
+	issue := ammIssue{Currency: currency, Issuer: ammAccountID, IssuerR: issuer}
+
+	value := "0"
+	if !ammIssueFrozen(ctx, ledgerIndex, lpAccountID, issue) {
+		value = readAMMIOUBalance(ctx, ledgerIndex, lpAccountID, issue)
+	}
+	return map[string]any{"currency": currency, "issuer": issuer, "value": value}
 }
 
 // ammPoolBalanceJSON returns the AMM account's holding of an issue, formatted

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -221,6 +221,12 @@ func RpcErrorTxnNotFound(message string) *RpcError {
 	return NewRpcError(RpcTXN_NOT_FOUND, "txnNotFound", "txnNotFound", message)
 }
 
+// RpcErrorIssueMalformed matches rippled rpcISSUE_MALFORMED (code 93, token
+// "issueMalformed"), returned for an unparseable asset/asset2 issue object.
+func RpcErrorIssueMalformed() *RpcError {
+	return NewRpcError(RpcISSUE_MALFORMED, "issueMalformed", "issueMalformed", "Issue is malformed.")
+}
+
 // RpcErrorInvalidHotWallet matches rippled rpcINVALID_HOTWALLET (code 30,
 // token "invalidHotWallet", message "Invalid hotwallet.").
 func RpcErrorInvalidHotWallet() *RpcError {

--- a/internal/testing/rpcenv/amm_info_test.go
+++ b/internal/testing/rpcenv/amm_info_test.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"testing"
 
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/testing/amm"
 	"github.com/LeJamon/go-xrpl/internal/testing/rpcenv"
@@ -239,5 +240,173 @@ func TestAMMInfo_ErrorPrecedenceByApiVersion(t *testing.T) {
 			}
 			expectErr(row, types.ApiVersion3, wantCode, wantMsg)
 		}
+	})
+}
+
+// TestAMMInfo_IssueMalformedVariants covers the asset shapes rippled's
+// issueFromJson rejects with issueMalformed (Issue.cpp:94-145): an issuer
+// on XRP, invalid currency codes, mpt_issuance_id, a bad issuer address,
+// null, and non-object values.
+func TestAMMInfo_IssueMalformedVariants(t *testing.T) {
+	amm.TestAMM(t, nil, 0, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
+		env := rpcenv.Wrap(t, ammEnv.TestEnv)
+		usdAsset := map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address}
+
+		badAssets := []any{
+			map[string]any{"currency": "XRP", "issuer": ammEnv.GW.Address},
+			map[string]any{"currency": "USDX", "issuer": ammEnv.GW.Address},
+			map[string]any{"currency": "US-", "issuer": ammEnv.GW.Address},
+			map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address, "mpt_issuance_id": "00"},
+			map[string]any{"currency": "USD", "issuer": "not-an-address"},
+			map[string]any{"currency": "USD"},
+			nil,
+			"USD",
+		}
+		for _, asset := range badAssets {
+			_, rpcErr := env.RPC("amm_info", map[string]any{"asset": asset, "asset2": usdAsset})
+			if rpcErr == nil {
+				t.Fatalf("amm_info(asset=%#v): expected error, got nil", asset)
+			}
+			if rpcErr.Code != types.RpcISSUE_MALFORMED || rpcErr.Message != "Issue is malformed." {
+				t.Errorf("amm_info(asset=%#v) = %q (code=%d), want issueMalformed",
+					asset, rpcErr.Message, rpcErr.Code)
+			}
+		}
+
+		// An explicit null issuer on XRP is tolerated, like rippled.
+		result, rpcErr := env.RPC("amm_info", map[string]any{
+			"asset":  map[string]any{"currency": "XRP", "issuer": nil},
+			"asset2": usdAsset,
+		})
+		if rpcErr != nil {
+			t.Fatalf("amm_info(XRP with null issuer): %s (code=%d)", rpcErr.Message, rpcErr.Code)
+		}
+		if _, ok := result.(map[string]any)["amm"]; !ok {
+			t.Errorf("amm_info(XRP with null issuer): missing amm field: %#v", result)
+		}
+	})
+}
+
+// TestAMMInfo_IdenticalAssetPair ports rippled AMMInfo_test.cpp:53-60: a
+// well-formed pair naming the same issue twice keys no AMM → actNotFound.
+func TestAMMInfo_IdenticalAssetPair(t *testing.T) {
+	amm.TestAMM(t, nil, 0, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
+		env := rpcenv.Wrap(t, ammEnv.TestEnv)
+		usdAsset := map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address}
+
+		_, rpcErr := env.RPC("amm_info", map[string]any{"asset": usdAsset, "asset2": usdAsset})
+		if rpcErr == nil {
+			t.Fatalf("amm_info(USD/USD): expected error, got nil")
+		}
+		if rpcErr.Code != types.RpcACT_NOT_FOUND || rpcErr.Message != "Account not found." {
+			t.Errorf("amm_info(USD/USD) = %q (code=%d), want actNotFound", rpcErr.Message, rpcErr.Code)
+		}
+	})
+}
+
+// TestAMMInfo_PresenceSemantics verifies key presence drives the checks the
+// way rippled's isMember does: empty-string account params count as
+// supplied and fail account resolution instead of being ignored.
+func TestAMMInfo_PresenceSemantics(t *testing.T) {
+	amm.TestAMM(t, nil, 0, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
+		env := rpcenv.Wrap(t, ammEnv.TestEnv)
+
+		expectActMalformed := func(params map[string]any) {
+			t.Helper()
+			_, rpcErr := env.RPC("amm_info", params)
+			if rpcErr == nil {
+				t.Fatalf("amm_info(%#v): expected error, got nil", params)
+			}
+			if rpcErr.Code != types.RpcACT_MALFORMED || rpcErr.Message != "Account malformed." {
+				t.Errorf("amm_info(%#v) = %q (code=%d), want actMalformed",
+					params, rpcErr.Message, rpcErr.Code)
+			}
+		}
+
+		// Empty account with a valid pair: present, unresolvable.
+		expectActMalformed(map[string]any{
+			"asset":   map[string]any{"currency": "XRP"},
+			"asset2":  map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address},
+			"account": "",
+		})
+
+		// Empty amm_account alone is a valid combination, then fails the
+		// account check.
+		expectActMalformed(map[string]any{"amm_account": ""})
+	})
+}
+
+// TestAMMInfo_AccountIdentForms verifies the account param accepts the
+// identifier forms rippled's non-strict accountFromString does: a base58
+// account public key and a seed/passphrase (RPCHelpers.cpp:43-85).
+func TestAMMInfo_AccountIdentForms(t *testing.T) {
+	amm.TestAMM(t, nil, 0, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
+		env := rpcenv.Wrap(t, ammEnv.TestEnv)
+
+		lpToken := func(ident string) map[string]any {
+			t.Helper()
+			result, rpcErr := env.RPC("amm_info", map[string]any{
+				"asset":   map[string]any{"currency": "XRP"},
+				"asset2":  map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address},
+				"account": ident,
+			})
+			if rpcErr != nil {
+				t.Fatalf("amm_info(account=%q): %s (code=%d)", ident, rpcErr.Message, rpcErr.Code)
+			}
+			tok, ok := result.(map[string]any)["amm"].(map[string]any)["lp_token"].(map[string]any)
+			if !ok {
+				t.Fatalf("amm_info(account=%q): missing lp_token", ident)
+			}
+			return tok
+		}
+
+		byAddress := lpToken(ammEnv.Alice.Address)
+
+		alicePubKey, err := addresscodec.EncodeAccountPublicKey(ammEnv.Alice.PublicKey)
+		if err != nil {
+			t.Fatalf("encode alice public key: %v", err)
+		}
+		if got := lpToken(alicePubKey); got["value"] != byAddress["value"] {
+			t.Errorf("lp_token via public key = %#v, want %#v", got, byAddress)
+		}
+
+		// Test accounts derive from sha512half(name), the same derivation
+		// rippled applies to a passphrase identifier.
+		if got := lpToken(ammEnv.Alice.Name); got["value"] != byAddress["value"] {
+			t.Errorf("lp_token via passphrase = %#v, want %#v", got, byAddress)
+		}
+	})
+}
+
+// TestAMMInfo_LedgerNotFoundPrecedence verifies a missing ledger outranks
+// every param error, mirroring rippled's lookupLedger-first ordering
+// (AMMInfo.cpp:81-84).
+func TestAMMInfo_LedgerNotFoundPrecedence(t *testing.T) {
+	amm.TestAMM(t, nil, 0, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
+		env := rpcenv.Wrap(t, ammEnv.TestEnv)
+		bogie := jtx.NewAccount("bogie")
+
+		expectLgrNotFound := func(params map[string]any) {
+			t.Helper()
+			_, rpcErr := env.RPC("amm_info", params)
+			if rpcErr == nil {
+				t.Fatalf("amm_info(%#v): expected error, got nil", params)
+			}
+			if rpcErr.Code != types.RpcLGR_NOT_FOUND || rpcErr.Message != "Ledger not found." {
+				t.Errorf("amm_info(%#v) = %q (code=%d), want lgrNotFound",
+					params, rpcErr.Message, rpcErr.Code)
+			}
+		}
+
+		// Over an invalid combination.
+		expectLgrNotFound(map[string]any{"ledger_index": 9999999})
+
+		// Over a bad account with a valid pair.
+		expectLgrNotFound(map[string]any{
+			"ledger_index": 9999999,
+			"asset":        map[string]any{"currency": "XRP"},
+			"asset2":       map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address},
+			"account":      bogie.Address,
+		})
 	})
 }

--- a/internal/testing/rpcenv/amm_info_test.go
+++ b/internal/testing/rpcenv/amm_info_test.go
@@ -1,8 +1,10 @@
 package rpcenv_test
 
 import (
+	"maps"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/testing/amm"
 	"github.com/LeJamon/go-xrpl/internal/testing/rpcenv"
 
@@ -96,4 +98,133 @@ func TestAMMInfo_EndToEnd_NotFound(t *testing.T) {
 	if rpcErr == nil {
 		t.Fatalf("amm_info on missing pair: expected error, got nil")
 	}
+}
+
+// TestAMMInfo_LPAccountParam verifies that the account (LP holder) param
+// switches lp_token from the pool total to that account's LP token balance.
+// Reference: rippled AMMInfo.cpp:195-197, AMMInfo_test.cpp testSimpleRpc.
+func TestAMMInfo_LPAccountParam(t *testing.T) {
+	amm.TestAMM(t, nil, 0, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
+		env := rpcenv.Wrap(t, ammEnv.TestEnv)
+
+		base := map[string]any{
+			"asset":  map[string]any{"currency": "XRP"},
+			"asset2": map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address},
+		}
+
+		lpToken := func(params map[string]any) map[string]any {
+			t.Helper()
+			result, rpcErr := env.RPC("amm_info", params)
+			if rpcErr != nil {
+				t.Fatalf("amm_info: %s (code=%d)", rpcErr.Message, rpcErr.Code)
+			}
+			ammResult, ok := result.(map[string]any)["amm"].(map[string]any)
+			if !ok {
+				t.Fatalf("amm_info: missing amm field: %#v", result)
+			}
+			tok, ok := ammResult["lp_token"].(map[string]any)
+			if !ok {
+				t.Fatalf("amm_info: lp_token is %#v, want map", ammResult["lp_token"])
+			}
+			return tok
+		}
+
+		withAccount := func(addr string) map[string]any {
+			params := map[string]any{"account": addr}
+			maps.Copy(params, base)
+			return params
+		}
+
+		total := lpToken(base)
+
+		// alice created the AMM and holds all LP tokens, so her balance
+		// equals the pool total.
+		aliceTok := lpToken(withAccount(ammEnv.Alice.Address))
+		if aliceTok["currency"] != total["currency"] ||
+			aliceTok["issuer"] != total["issuer"] ||
+			aliceTok["value"] != total["value"] {
+			t.Errorf("lp_token for alice = %#v, want pool total %#v", aliceTok, total)
+		}
+
+		// carol holds no LP tokens: same currency/issuer, zero value.
+		carolTok := lpToken(withAccount(ammEnv.Carol.Address))
+		if carolTok["currency"] != total["currency"] || carolTok["issuer"] != total["issuer"] {
+			t.Errorf("lp_token for carol = %#v, want currency/issuer of %#v", carolTok, total)
+		}
+		if got := carolTok["value"]; got != "0" {
+			t.Errorf("lp_token.value for carol = %v, want 0", got)
+		}
+	})
+}
+
+// TestAMMInfo_ErrorPrecedenceByApiVersion ports the invalid-parameter loops
+// from rippled AMMInfo_test.cpp testErrors: the asset/amm_account combination
+// check runs before the per-field account checks for api_version < 3 and
+// after them for api_version >= 3.
+func TestAMMInfo_ErrorPrecedenceByApiVersion(t *testing.T) {
+	amm.TestAMM(t, nil, 0, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
+		env := rpcenv.Wrap(t, ammEnv.TestEnv)
+		bogie := jtx.NewAccount("bogie") // valid address, not in the ledger
+
+		xrpAsset := map[string]any{"currency": "XRP"}
+		usdAsset := map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address}
+
+		// Invalid {asset, asset2, amm_account} combinations; ammAccount fills
+		// the amm_account slot of the rows that have one.
+		invalidCombos := func(ammAccount string) []map[string]any {
+			return []map[string]any{
+				{"asset": xrpAsset},
+				{"asset2": usdAsset},
+				{"asset": xrpAsset, "amm_account": ammAccount},
+				{"asset2": usdAsset, "amm_account": ammAccount},
+				{"asset": xrpAsset, "asset2": usdAsset, "amm_account": ammAccount},
+				{},
+			}
+		}
+
+		withAccount := func(row map[string]any, account string) map[string]any {
+			params := map[string]any{"account": account}
+			maps.Copy(params, row)
+			return params
+		}
+
+		expectErr := func(params map[string]any, apiVersion int, wantCode int, wantMsg string) {
+			t.Helper()
+			_, rpcErr := env.RPCAs("amm_info", params, types.RoleAdmin, apiVersion)
+			if rpcErr == nil {
+				t.Fatalf("amm_info(%#v) v%d: expected error, got nil", params, apiVersion)
+			}
+			if rpcErr.Code != wantCode || rpcErr.Message != wantMsg {
+				t.Errorf("amm_info(%#v) v%d = %q (code=%d), want %q (code=%d)",
+					params, apiVersion, rpcErr.Message, rpcErr.Code, wantMsg, wantCode)
+			}
+		}
+
+		// Valid combination + nonexistent LP account → actMalformed.
+		expectErr(withAccount(map[string]any{
+			"asset":  xrpAsset,
+			"asset2": usdAsset,
+		}, bogie.Address), types.ApiVersion2, types.RpcACT_MALFORMED, "Account malformed.")
+
+		// Invalid combinations (amm_account = the AMM's pseudo-account).
+		for _, row := range invalidCombos(ammAcc.Address) {
+			expectErr(row, types.ApiVersion2, types.RpcINVALID_PARAMS, "Invalid parameters.")
+
+			// With a bad LP account on top: combination wins below v3, the
+			// malformed account wins from v3 on.
+			expectErr(withAccount(row, bogie.Address), types.ApiVersion2, types.RpcINVALID_PARAMS, "Invalid parameters.")
+			expectErr(withAccount(row, bogie.Address), types.ApiVersion3, types.RpcACT_MALFORMED, "Account malformed.")
+		}
+
+		// Invalid combinations with a nonexistent amm_account.
+		for _, row := range invalidCombos(bogie.Address) {
+			expectErr(row, types.ApiVersion2, types.RpcINVALID_PARAMS, "Invalid parameters.")
+
+			wantCode, wantMsg := types.RpcINVALID_PARAMS, "Invalid parameters."
+			if _, hasAMMAccount := row["amm_account"]; hasAMMAccount {
+				wantCode, wantMsg = types.RpcACT_MALFORMED, "Account malformed."
+			}
+			expectErr(row, types.ApiVersion3, wantCode, wantMsg)
+		}
+	})
 }

--- a/internal/testing/rpcenv/amm_info_test.go
+++ b/internal/testing/rpcenv/amm_info_test.go
@@ -206,6 +206,19 @@ func TestAMMInfo_ErrorPrecedenceByApiVersion(t *testing.T) {
 			"asset2": usdAsset,
 		}, bogie.Address), types.ApiVersion2, types.RpcACT_MALFORMED, "Account malformed.")
 
+		// Unparseable asset (IOU missing its issuer) → issueMalformed on both
+		// versions when the combination is valid.
+		badAsset := map[string]any{"currency": "USD"}
+		validComboBadAsset := map[string]any{"asset": badAsset, "asset2": usdAsset}
+		expectErr(validComboBadAsset, types.ApiVersion2, types.RpcISSUE_MALFORMED, "Issue is malformed.")
+		expectErr(validComboBadAsset, types.ApiVersion3, types.RpcISSUE_MALFORMED, "Issue is malformed.")
+
+		// Unparseable asset in an invalid combination: the combination check
+		// wins below v3, the asset parse wins from v3 on.
+		invalidComboBadAsset := map[string]any{"asset": badAsset}
+		expectErr(invalidComboBadAsset, types.ApiVersion2, types.RpcINVALID_PARAMS, "Invalid parameters.")
+		expectErr(invalidComboBadAsset, types.ApiVersion3, types.RpcISSUE_MALFORMED, "Issue is malformed.")
+
 		// Invalid combinations (amm_account = the AMM's pseudo-account).
 		for _, row := range invalidCombos(ammAcc.Address) {
 			expectErr(row, types.ApiVersion2, types.RpcINVALID_PARAMS, "Invalid parameters.")


### PR DESCRIPTION
## Summary
- Implement the `account` (LP holder) parameter of `amm_info`: the address must parse and exist in the ledger (`actMalformed` otherwise, mirroring `AMMInfo.cpp:141-146`), and when given, `lp_token` reports that account's LP token trust-line balance (zero when the line is missing or frozen, per `ammLPHolds`) instead of the AMM's total `sfLPTokenBalance`.
- Restructure validation to rippled's field-by-field order: the asset/amm_account combination check runs **before** the per-field account checks for api_version < 3 and **after** them for api_version ≥ 3 (`AMMInfo.cpp:108-110` vs `148-150`), so a malformed `account`/`amm_account` wins under v3. The combination predicate now also rejects `asset` without `asset2` (and vice versa) combined with `amm_account`, exactly as rippled's `invalid()` lambda does.
- Emit rippled's default messages: `"Invalid parameters."` for the combination error and `"Account not found."` for a missing AMM.

## Test plan
- [x] Ported the `account`-param cases and both api-version precedence loops from `AMMInfo_test.cpp` (`invalidParams` / `invalidParamsBadAccount`) into `internal/testing/rpcenv/amm_info_test.go`
- [x] `go test ./internal/rpc/... ./internal/testing/rpcenv/... ./internal/testing/amm/`
- [x] `go vet` + full module build

Fixes #830