### PR TITLE
fix(rpc): subscribe/unsubscribe errors carry rippled tokens and codes

### DIFF
--- a/internal/rpc/subscribe_conformance_test.go
+++ b/internal/rpc/subscribe_conformance_test.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/rpc/subscription"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,17 +58,10 @@ func TestSubscribeConformanceBadMarket(t *testing.T) {
 	}
 
 	err := sm.HandleSubscribe(conn, request, true)
-	// The implementation may or may not enforce badMarket yet.
-	// If it does, verify the error message. If it doesn't, document the gap.
-	if err != nil {
-		assert.Contains(t, err.Message, "market",
-			"Error for same currency on both sides should mention 'market'")
-	} else {
-		// Current implementation allows it. This documents a conformance gap
-		// with rippled which returns badMarket / "No such market."
-		t.Log("CONFORMANCE NOTE: rippled returns badMarket when taker_pays == taker_gets; " +
-			"current implementation allows it. Consider adding validation.")
-	}
+	require.NotNil(t, err, "same asset on both sides must be rejected")
+	assert.Equal(t, types.RpcBAD_MARKET, err.Code)
+	assert.Equal(t, "badMarket", err.ErrorString)
+	assert.Equal(t, "No such market.", err.Message)
 }
 
 // TestSubscribeConformanceBadMarketXRP tests badMarket with XRP on both sides.
@@ -94,13 +88,10 @@ func TestSubscribeConformanceBadMarketXRP(t *testing.T) {
 	}
 
 	err := sm.HandleSubscribe(conn, request, true)
-	if err != nil {
-		assert.Contains(t, err.Message, "market",
-			"Error for XRP/XRP should mention 'market'")
-	} else {
-		t.Log("CONFORMANCE NOTE: rippled returns badMarket for XRP/XRP book; " +
-			"current implementation allows it.")
-	}
+	require.NotNil(t, err, "XRP/XRP book must be rejected")
+	assert.Equal(t, types.RpcBAD_MARKET, err.Code)
+	assert.Equal(t, "badMarket", err.ErrorString)
+	assert.Equal(t, "No such market.", err.Message)
 }
 
 // Unsubscribe Stops Message Delivery Tests
@@ -449,14 +440,18 @@ func TestSubscribeConformanceBookChangesStream(t *testing.T) {
 		t.Fatal("Expected to receive book_changes broadcast")
 	}
 
-	// Unsubscribe
+	// rippled's doUnsubscribe has no book_changes branch (Unsubscribe.cpp:
+	// 61-110), so unsubscribing it is rpcSTREAM_MALFORMED and the stream
+	// only drops when the connection closes. Mirror that quirk.
 	err = sm.HandleUnsubscribe(conn, types.SubscriptionRequest{
 		Streams: []types.SubscriptionType{types.SubBookChanges},
 	}, true)
-	require.Nil(t, err)
+	require.NotNil(t, err, "book_changes is not unsubscribable in rippled")
+	assert.Equal(t, types.RpcSTREAM_MALFORMED, err.Code)
+	assert.Equal(t, "malformedStream", err.ErrorString)
 
 	_, exists = conn.Subscriptions[types.SubBookChanges]
-	assert.False(t, exists, "book_changes subscription should be removed")
+	assert.True(t, exists, "book_changes subscription should remain")
 }
 
 // Concurrent Safety Tests
@@ -525,8 +520,8 @@ func TestSubscribeConformanceConcurrentAccess(t *testing.T) {
 // validates stream names the same way subscribe does.
 
 // TestSubscribeConformanceUnsubscribeInvalidStream verifies that unsubscribing
-// from an invalid stream name does not produce an error (current behavior is
-// to silently ignore via delete on a map key that doesn't exist).
+// from an invalid stream name returns rpcSTREAM_MALFORMED, like rippled
+// Unsubscribe.cpp:106-109.
 func TestSubscribeConformanceUnsubscribeInvalidStream(t *testing.T) {
 	sm := newTestSubscriptionManager()
 	conn := newTestConnection("test-conn-1")
@@ -543,9 +538,10 @@ func TestSubscribeConformanceUnsubscribeInvalidStream(t *testing.T) {
 	err = sm.HandleUnsubscribe(conn, types.SubscriptionRequest{
 		Streams: []types.SubscriptionType{"not_a_stream"},
 	}, true)
-	// Current implementation silently ignores; rippled returns malformedStream for subscribe
-	// but also silently handles unsubscribe for unknown streams in practice.
-	require.Nil(t, err, "Unsubscribing from an unknown stream should succeed silently")
+	require.NotNil(t, err, "Unsubscribing from an unknown stream should fail")
+	assert.Equal(t, types.RpcSTREAM_MALFORMED, err.Code)
+	assert.Equal(t, "malformedStream", err.ErrorString)
+	assert.Equal(t, "Stream malformed.", err.Message)
 
 	// Original subscription should remain
 	_, exists := conn.Subscriptions[types.SubLedger]
@@ -721,4 +717,209 @@ func TestSubscribeConformanceSelectiveUnsubscribe(t *testing.T) {
 		t.Fatal("Should NOT receive transactions broadcast after unsubscribing")
 	default:
 	}
+}
+
+// Per-site error envelope tests (issue #828)
+// Subscribe.cpp returns bare rpcError(code) at every validation site, so
+// the wire envelope is the ErrorCodes.cpp triple: token, code, default
+// message. These tests pin the sites not already covered above.
+
+func mustBook(t *testing.T, pays, gets map[string]any) types.BookRequest {
+	t.Helper()
+	takerPays, err := json.Marshal(pays)
+	require.NoError(t, err)
+	takerGets, err := json.Marshal(gets)
+	require.NoError(t, err)
+	return types.BookRequest{TakerPays: takerPays, TakerGets: takerGets}
+}
+
+// TestSubscribeConformanceBadTaker verifies an unparseable book taker is
+// rpcBAD_ISSUER (Subscribe.cpp:301-305).
+func TestSubscribeConformanceBadTaker(t *testing.T) {
+	sm := newTestSubscriptionManager()
+	conn := newTestConnection("test-conn-1")
+	sm.AddConnection(conn)
+	defer sm.RemoveConnection(conn.ID)
+
+	book := mustBook(t,
+		map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+		map[string]any{"currency": "XRP"})
+	book.Taker = "not_an_account"
+
+	err := sm.HandleSubscribe(conn, types.SubscriptionRequest{
+		Books: []types.BookRequest{book},
+	}, true)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcBAD_ISSUER, err.Code)
+	assert.Equal(t, "badIssuer", err.ErrorString)
+	assert.Equal(t, "Issuer account malformed.", err.Message)
+}
+
+// TestSubscribeConformanceDomain verifies the book domain parse
+// (Subscribe.cpp:308-315): a non-hex domain is rpcDOMAIN_MALFORMED, a
+// valid uint256 hex is accepted and carried onto the stored book (and its
+// both:true reverse).
+func TestSubscribeConformanceDomain(t *testing.T) {
+	const validDomain = "00000000000000000000000000000000000000000000000000000000000000AB"
+
+	t.Run("malformed domain", func(t *testing.T) {
+		sm := newTestSubscriptionManager()
+		conn := newTestConnection("test-conn-1")
+		sm.AddConnection(conn)
+		defer sm.RemoveConnection(conn.ID)
+
+		book := mustBook(t,
+			map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			map[string]any{"currency": "XRP"})
+		book.Domain = "not-hex"
+
+		err := sm.HandleSubscribe(conn, types.SubscriptionRequest{
+			Books: []types.BookRequest{book},
+		}, true)
+		require.NotNil(t, err)
+		assert.Equal(t, types.RpcDOMAIN_MALFORMED, err.Code)
+		assert.Equal(t, "domainMalformed", err.ErrorString)
+		assert.Equal(t, "Domain is malformed.", err.Message)
+	})
+
+	t.Run("valid domain accepted and kept on both sides", func(t *testing.T) {
+		sm := newTestSubscriptionManager()
+		conn := newTestConnection("test-conn-1")
+		sm.AddConnection(conn)
+		defer sm.RemoveConnection(conn.ID)
+
+		book := mustBook(t,
+			map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			map[string]any{"currency": "XRP"})
+		book.Domain = validDomain
+		book.Both = true
+
+		err := sm.HandleSubscribe(conn, types.SubscriptionRequest{
+			Books: []types.BookRequest{book},
+		}, true)
+		require.Nil(t, err)
+
+		config := conn.Subscriptions[types.SubBook]
+		require.Len(t, config.Books, 2)
+		assert.Equal(t, validDomain, config.Books[0].Domain)
+		assert.Equal(t, validDomain, config.Books[1].Domain)
+	})
+}
+
+// TestUnsubscribeConformanceErrorEnvelopes verifies the unsubscribe path
+// validates accounts and books the same way subscribe does
+// (Unsubscribe.cpp:113-245), minus the taker field it does not carry.
+func TestUnsubscribeConformanceErrorEnvelopes(t *testing.T) {
+	newConn := func(t *testing.T) (*subscription.Manager, *types.Connection) {
+		t.Helper()
+		sm := newTestSubscriptionManager()
+		conn := newTestConnection("test-conn-1")
+		sm.AddConnection(conn)
+		t.Cleanup(func() { sm.RemoveConnection(conn.ID) })
+		return sm, conn
+	}
+
+	t.Run("malformed account", func(t *testing.T) {
+		sm, conn := newConn(t)
+		err := sm.HandleUnsubscribe(conn, types.SubscriptionRequest{
+			Accounts: []string{"not_an_account"},
+		}, true)
+		require.NotNil(t, err)
+		assert.Equal(t, types.RpcACT_MALFORMED, err.Code)
+		assert.Equal(t, "actMalformed", err.ErrorString)
+		assert.Equal(t, "Account malformed.", err.Message)
+	})
+
+	t.Run("malformed accounts_proposed", func(t *testing.T) {
+		sm, conn := newConn(t)
+		err := sm.HandleUnsubscribe(conn, types.SubscriptionRequest{
+			AccountsProposed: []string{"not_an_account"},
+		}, true)
+		require.NotNil(t, err)
+		assert.Equal(t, types.RpcACT_MALFORMED, err.Code)
+		assert.Equal(t, "actMalformed", err.ErrorString)
+	})
+
+	t.Run("book with bad taker_pays currency", func(t *testing.T) {
+		sm, conn := newConn(t)
+		book := mustBook(t,
+			map[string]any{"currency": "USDX"},
+			map[string]any{"currency": "XRP"})
+		err := sm.HandleUnsubscribe(conn, types.SubscriptionRequest{
+			Books: []types.BookRequest{book},
+		}, true)
+		require.NotNil(t, err)
+		assert.Equal(t, types.RpcSRC_CUR_MALFORMED, err.Code)
+		assert.Equal(t, "srcCurMalformed", err.ErrorString)
+	})
+
+	t.Run("same-asset book is badMarket", func(t *testing.T) {
+		sm, conn := newConn(t)
+		book := mustBook(t,
+			map[string]any{"currency": "XRP"},
+			map[string]any{"currency": "XRP"})
+		err := sm.HandleUnsubscribe(conn, types.SubscriptionRequest{
+			Books: []types.BookRequest{book},
+		}, true)
+		require.NotNil(t, err)
+		assert.Equal(t, types.RpcBAD_MARKET, err.Code)
+		assert.Equal(t, "badMarket", err.ErrorString)
+	})
+
+	t.Run("malformed domain", func(t *testing.T) {
+		sm, conn := newConn(t)
+		book := mustBook(t,
+			map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			map[string]any{"currency": "XRP"})
+		book.Domain = "zz"
+		err := sm.HandleUnsubscribe(conn, types.SubscriptionRequest{
+			Books: []types.BookRequest{book},
+		}, true)
+		require.NotNil(t, err)
+		assert.Equal(t, types.RpcDOMAIN_MALFORMED, err.Code)
+		assert.Equal(t, "domainMalformed", err.ErrorString)
+	})
+
+	t.Run("taker is not validated on unsubscribe", func(t *testing.T) {
+		// Unsubscribe.cpp has no taker handling; a malformed taker must
+		// not fail the request.
+		sm, conn := newConn(t)
+		subBook := mustBook(t,
+			map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			map[string]any{"currency": "XRP"})
+		require.Nil(t, sm.HandleSubscribe(conn, types.SubscriptionRequest{
+			Books: []types.BookRequest{subBook},
+		}, true))
+
+		unsubBook := mustBook(t,
+			map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			map[string]any{"currency": "XRP"})
+		unsubBook.Taker = "not_an_account"
+		err := sm.HandleUnsubscribe(conn, types.SubscriptionRequest{
+			Books: []types.BookRequest{unsubBook},
+		}, true)
+		require.Nil(t, err)
+		assert.NotContains(t, conn.Subscriptions, types.SubBook)
+	})
+}
+
+// TestSubscribeConformanceStructuralCheckFirst pins rippled's evaluation
+// order: both sides' structure is checked before either side's currency
+// is parsed (Subscribe.cpp:238-242), so a bad taker_pays currency
+// combined with a missing taker_gets reports rpcINVALID_PARAMS, not
+// srcCurMalformed.
+func TestSubscribeConformanceStructuralCheckFirst(t *testing.T) {
+	sm := newTestSubscriptionManager()
+	conn := newTestConnection("test-conn-1")
+	sm.AddConnection(conn)
+	defer sm.RemoveConnection(conn.ID)
+
+	takerPays, _ := json.Marshal(map[string]any{"currency": "USDX"})
+	err := sm.HandleSubscribe(conn, types.SubscriptionRequest{
+		Books: []types.BookRequest{{TakerPays: takerPays}},
+	}, true)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Equal(t, "invalidParams", err.ErrorString)
+	assert.Equal(t, "Invalid parameters.", err.Message)
 }

--- a/internal/rpc/subscribe_conformance_test.go
+++ b/internal/rpc/subscribe_conformance_test.go
@@ -719,11 +719,6 @@ func TestSubscribeConformanceSelectiveUnsubscribe(t *testing.T) {
 	}
 }
 
-// Per-site error envelope tests (issue #828)
-// Subscribe.cpp returns bare rpcError(code) at every validation site, so
-// the wire envelope is the ErrorCodes.cpp triple: token, code, default
-// message. These tests pin the sites not already covered above.
-
 func mustBook(t *testing.T, pays, gets map[string]any) types.BookRequest {
 	t.Helper()
 	takerPays, err := json.Marshal(pays)

--- a/internal/rpc/subscribe_shape_conformance_test.go
+++ b/internal/rpc/subscribe_shape_conformance_test.go
@@ -1,0 +1,167 @@
+package rpc
+
+// subscribe_shape_conformance_test.go
+//
+// Conformance for the array-field shape distinctions rippled's testSubErrors
+// (Subscribe_test.cpp:646-851) drives over the wire — present-but-empty vs
+// null vs non-array — and for parsing book currencies to their 160-bit form.
+// These cases only exist when the request is JSON-decoded, so the tests decode
+// params the way the WebSocket server does rather than building a typed struct.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const shapeTestAccount = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+// mustDecodeSubscriptionRequest decodes JSON params the way websocket.go does,
+// so the manager sees the same presence/shape information it does in
+// production. A typed SubscriptionRequest built in Go cannot express null,
+// a non-array value, or a present-but-empty array.
+func mustDecodeSubscriptionRequest(t *testing.T, params string) types.SubscriptionRequest {
+	t.Helper()
+	var req types.SubscriptionRequest
+	require.NoError(t, json.Unmarshal([]byte(params), &req))
+	return req
+}
+
+type shapeCase struct {
+	name    string
+	params  string
+	wantErr bool
+	code    int
+	token   string
+	message string
+}
+
+var subscribeShapeCases = []shapeCase{
+	// accounts (Subscribe.cpp:192-200; Subscribe_test.cpp:666-672 empty,
+	// :646-664 non-array). parseAccountIds returns an empty set for an empty
+	// array, a non-string element, or a bad id → rpcACT_MALFORMED.
+	{"empty accounts array", `{"accounts":[]}`, true, types.RpcACT_MALFORMED, "actMalformed", "Account malformed."},
+	{"null accounts", `{"accounts":null}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+	{"string accounts", `{"accounts":"notanarray"}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+	{"object accounts", `{"accounts":{}}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+	{"non-string account element", `{"accounts":[123]}`, true, types.RpcACT_MALFORMED, "actMalformed", "Account malformed."},
+	{"bad account id", `{"accounts":["notanaccount"]}`, true, types.RpcACT_MALFORMED, "actMalformed", "Account malformed."},
+	// accounts_proposed, same semantics (Subscribe.cpp:181-189).
+	{"empty accounts_proposed", `{"accounts_proposed":[]}`, true, types.RpcACT_MALFORMED, "actMalformed", "Account malformed."},
+	{"null accounts_proposed", `{"accounts_proposed":null}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+	// streams (Subscribe.cpp:118-122 non-array, :126-127 non-string entry).
+	{"non-array streams", `{"streams":"ledger"}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+	{"non-string stream entry", `{"streams":[123]}`, true, types.RpcSTREAM_MALFORMED, "malformedStream", "Stream malformed."},
+	// books (Subscribe.cpp:233-234 non-array, :238 non-object entry;
+	// Subscribe_test.cpp:675-690).
+	{"non-array books", `{"books":"x"}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+	{"non-object book entry", `{"books":[1]}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+	// Accepted shapes: an absent field, an empty books array, and valid
+	// values must all succeed.
+	{"empty params", `{}`, false, 0, "", ""},
+	{"empty books array", `{"books":[]}`, false, 0, "", ""},
+	{"valid accounts", `{"accounts":["` + shapeTestAccount + `"]}`, false, 0, "", ""},
+	{"valid stream", `{"streams":["ledger"]}`, false, 0, "", ""},
+}
+
+func TestSubscribeConformanceArrayFieldShapes(t *testing.T) {
+	for _, tc := range subscribeShapeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := newTestSubscriptionManager()
+			conn := newTestConnection("shape-conn")
+			sm.AddConnection(conn)
+			defer sm.RemoveConnection(conn.ID)
+
+			err := sm.HandleSubscribe(conn, mustDecodeSubscriptionRequest(t, tc.params), true)
+			if !tc.wantErr {
+				assert.Nil(t, err)
+				return
+			}
+			require.NotNil(t, err)
+			assert.Equal(t, tc.code, err.Code)
+			assert.Equal(t, tc.token, err.ErrorString)
+			assert.Equal(t, tc.message, err.Message)
+		})
+	}
+}
+
+// TestUnsubscribeConformanceArrayFieldShapes mirrors the subscribe shape cases
+// on the unsubscribe path, which rippled's testSubErrors(false) also exercises
+// (Unsubscribe.cpp:63-64, 113-136, 164-242).
+func TestUnsubscribeConformanceArrayFieldShapes(t *testing.T) {
+	cases := []shapeCase{
+		{"empty accounts array", `{"accounts":[]}`, true, types.RpcACT_MALFORMED, "actMalformed", "Account malformed."},
+		{"null accounts", `{"accounts":null}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+		{"string accounts", `{"accounts":"notanarray"}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+		{"empty accounts_proposed", `{"accounts_proposed":[]}`, true, types.RpcACT_MALFORMED, "actMalformed", "Account malformed."},
+		{"non-array streams", `{"streams":"ledger"}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+		{"non-string stream entry", `{"streams":[123]}`, true, types.RpcSTREAM_MALFORMED, "malformedStream", "Stream malformed."},
+		{"non-object book entry", `{"books":[1]}`, true, types.RpcINVALID_PARAMS, "invalidParams", "Invalid parameters."},
+		{"empty params", `{}`, false, 0, "", ""},
+		{"empty books array", `{"books":[]}`, false, 0, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := newTestSubscriptionManager()
+			conn := newTestConnection("shape-conn")
+			sm.AddConnection(conn)
+			defer sm.RemoveConnection(conn.ID)
+
+			err := sm.HandleUnsubscribe(conn, mustDecodeSubscriptionRequest(t, tc.params), true)
+			if !tc.wantErr {
+				assert.Nil(t, err)
+				return
+			}
+			require.NotNil(t, err)
+			assert.Equal(t, tc.code, err.Code)
+			assert.Equal(t, tc.token, err.ErrorString)
+			assert.Equal(t, tc.message, err.Message)
+		})
+	}
+}
+
+// TestSubscribeConformanceCurrencyParsedTo160Bit pins that book currencies are
+// compared as their 160-bit value (rippled to_currency + book.in == book.out),
+// not as the raw JSON string. The standard encoding of "USD" places the ISO
+// code at bytes 12-14, and a 40-hex of zeroes is the XRP currency.
+func TestSubscribeConformanceCurrencyParsedTo160Bit(t *testing.T) {
+	const gw = shapeTestAccount
+	const usdHex = "0000000000000000000000005553440000000000" // to_currency("USD")
+	const xrpHex = "0000000000000000000000000000000000000000"
+
+	subscribe := func(t *testing.T, params string) *types.RpcError {
+		t.Helper()
+		sm := newTestSubscriptionManager()
+		conn := newTestConnection("cur-conn")
+		sm.AddConnection(conn)
+		defer sm.RemoveConnection(conn.ID)
+		return sm.HandleSubscribe(conn, mustDecodeSubscriptionRequest(t, params), true)
+	}
+
+	t.Run("3-char and 40-hex form of one currency are the same market", func(t *testing.T) {
+		params := `{"books":[{"taker_pays":{"currency":"USD","issuer":"` + gw + `"},` +
+			`"taker_gets":{"currency":"` + usdHex + `","issuer":"` + gw + `"}}]}`
+		err := subscribe(t, params)
+		require.NotNil(t, err)
+		assert.Equal(t, types.RpcBAD_MARKET, err.Code)
+		assert.Equal(t, "badMarket", err.ErrorString)
+	})
+
+	t.Run("40-hex of zeroes is the XRP currency (valid market)", func(t *testing.T) {
+		params := `{"books":[{"taker_pays":{"currency":"USD","issuer":"` + gw + `"},` +
+			`"taker_gets":{"currency":"` + xrpHex + `"}}]}`
+		assert.Nil(t, subscribe(t, params))
+	})
+
+	t.Run("40-hex of zeroes with an issuer is an illegal XRP issuer", func(t *testing.T) {
+		params := `{"books":[{"taker_pays":{"currency":"USD","issuer":"` + gw + `"},` +
+			`"taker_gets":{"currency":"` + xrpHex + `","issuer":"` + gw + `"}}]}`
+		err := subscribe(t, params)
+		require.NotNil(t, err)
+		assert.Equal(t, types.RpcDST_ISR_MALFORMED, err.Code)
+		assert.Equal(t, "dstIsrMalformed", err.ErrorString)
+	})
+}

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -104,7 +104,7 @@ func TestSubscribeStreamTypes(t *testing.T) {
 
 			if tc.expectError {
 				require.NotNil(t, err, "Expected error for stream type: %s", tc.streamString)
-				assert.Contains(t, err.Message, "Unknown stream type")
+				assert.Equal(t, "malformedStream", err.ErrorString)
 			} else {
 				require.Nil(t, err, "Expected no error for stream type: %s", tc.streamString)
 
@@ -189,7 +189,10 @@ func TestSubscribeInvalidStreamName(t *testing.T) {
 
 			if tc.expectError {
 				require.NotNil(t, err, "Expected error for invalid stream: %s", tc.streamName)
-				assert.Contains(t, err.Message, "Unknown stream type")
+				// rippled Subscribe.cpp:171-174 → rpcSTREAM_MALFORMED.
+				assert.Equal(t, types.RpcSTREAM_MALFORMED, err.Code)
+				assert.Equal(t, "malformedStream", err.ErrorString)
+				assert.Equal(t, "Stream malformed.", err.Message)
 			}
 
 			sm.RemoveConnection(conn.ID)
@@ -267,55 +270,55 @@ func TestSubscribeAccountInvalidFormat(t *testing.T) {
 			name:        "invalid account - empty string",
 			account:     "",
 			expectError: true,
-			errorMsg:    "Invalid account address",
+			errorMsg:    "Account malformed.",
 		},
 		{
 			name:        "invalid account - very short",
 			account:     "rHb9CJA",
 			expectError: true,
-			errorMsg:    "Invalid account address",
+			errorMsg:    "Account malformed.",
 		},
 		{
 			name:        "invalid account - too long",
 			account:     "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyThExtraChars",
 			expectError: true,
-			errorMsg:    "Invalid account address",
+			errorMsg:    "Account malformed.",
 		},
 		{
 			name:        "invalid account - wrong prefix",
 			account:     "sHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			expectError: true,
-			errorMsg:    "Invalid account address",
+			errorMsg:    "Account malformed.",
 		},
 		{
 			name:        "invalid account - node public key format",
 			account:     "n94JNrQYkDrpt62bbSR7nVEhdyAvcJXRAsjEkFYyqRkh9SUTYEqV",
 			expectError: true,
-			errorMsg:    "Invalid account address",
+			errorMsg:    "Account malformed.",
 		},
 		{
 			name:        "invalid account - numeric string",
 			account:     "12345678901234567890123456789012345",
 			expectError: true,
-			errorMsg:    "Invalid account address",
+			errorMsg:    "Account malformed.",
 		},
 		{
 			name:        "invalid account - hex string",
 			account:     "0x1234567890ABCDEF1234567890ABCDEF12345678",
 			expectError: true,
-			errorMsg:    "Invalid account address",
+			errorMsg:    "Account malformed.",
 		},
 		{
 			name:        "invalid account - special characters",
 			account:     "rHb9CJAWyB4rj91VRWn96DkukG4bwdty!@",
 			expectError: true,
-			errorMsg:    "Invalid account address",
+			errorMsg:    "Account malformed.",
 		},
 		{
 			name:        "invalid account - contains forbidden char 0",
 			account:     "rHb0CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			expectError: true,
-			errorMsg:    "Invalid account address",
+			errorMsg:    "Account malformed.",
 		},
 	}
 
@@ -333,7 +336,10 @@ func TestSubscribeAccountInvalidFormat(t *testing.T) {
 
 			if tc.expectError {
 				require.NotNil(t, err, "Expected error for invalid account: %s", tc.account)
-				assert.Contains(t, err.Message, tc.errorMsg)
+				// rippled Subscribe.cpp:197-199 → rpcACT_MALFORMED.
+				assert.Equal(t, types.RpcACT_MALFORMED, err.Code)
+				assert.Equal(t, "actMalformed", err.ErrorString)
+				assert.Equal(t, tc.errorMsg, err.Message)
 			} else {
 				require.Nil(t, err, "Expected no error for valid account: %s", tc.account)
 			}
@@ -355,7 +361,9 @@ func TestSubscribeAccountsProposedInvalidFormat(t *testing.T) {
 
 	err := sm.HandleSubscribe(conn, request, true)
 	require.NotNil(t, err, "Expected error for invalid accounts_proposed")
-	assert.Contains(t, err.Message, "Invalid account address")
+	assert.Equal(t, types.RpcACT_MALFORMED, err.Code)
+	assert.Equal(t, "actMalformed", err.ErrorString)
+	assert.Equal(t, "Account malformed.", err.Message)
 
 	sm.RemoveConnection(conn.ID)
 }
@@ -464,14 +472,18 @@ func TestSubscribeBooksWithBoth(t *testing.T) {
 	sm.RemoveConnection(conn.ID)
 }
 
-// TestSubscribeBooksInvalidCurrency tests invalid currency in book specification
-// Based on rippled Subscribe_test.cpp srcCurMalformed error
+// TestSubscribeBooksInvalidCurrency pins the per-site book errors of
+// rippled Subscribe.cpp: taker_pays maps to the src* codes (:249-268),
+// taker_gets to the dst* codes (:271-290); missing issuer on an IOU and
+// a malformed issuer both land on the issuer-malformed code.
 func TestSubscribeBooksInvalidCurrency(t *testing.T) {
 	tests := []struct {
 		name      string
 		takerPays map[string]any
 		takerGets map[string]any
-		errorMsg  string
+		wantCode  int
+		wantError string
+		wantMsg   string
 	}{
 		{
 			name:      "missing taker_pays currency",
@@ -479,7 +491,9 @@ func TestSubscribeBooksInvalidCurrency(t *testing.T) {
 			takerGets: map[string]any{
 				"currency": "XRP",
 			},
-			errorMsg: "taker_pays: issuer required for non-XRP currency",
+			wantCode:  types.RpcSRC_CUR_MALFORMED,
+			wantError: "srcCurMalformed",
+			wantMsg:   "Source currency is malformed.",
 		},
 		{
 			name: "missing taker_gets currency",
@@ -488,7 +502,33 @@ func TestSubscribeBooksInvalidCurrency(t *testing.T) {
 				"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			},
 			takerGets: map[string]any{},
-			errorMsg:  "taker_gets: issuer required for non-XRP currency",
+			wantCode:  types.RpcDST_AMT_MALFORMED,
+			wantError: "dstAmtMalformed",
+			wantMsg:   "Destination amount/currency/issuer is malformed.",
+		},
+		{
+			name: "unparseable taker_pays currency",
+			takerPays: map[string]any{
+				"currency": "USDX",
+			},
+			takerGets: map[string]any{
+				"currency": "XRP",
+			},
+			wantCode:  types.RpcSRC_CUR_MALFORMED,
+			wantError: "srcCurMalformed",
+			wantMsg:   "Source currency is malformed.",
+		},
+		{
+			name: "unparseable taker_gets currency",
+			takerPays: map[string]any{
+				"currency": "XRP",
+			},
+			takerGets: map[string]any{
+				"currency": "USDX",
+			},
+			wantCode:  types.RpcDST_AMT_MALFORMED,
+			wantError: "dstAmtMalformed",
+			wantMsg:   "Destination amount/currency/issuer is malformed.",
 		},
 		{
 			name: "non-XRP taker_pays without issuer",
@@ -498,7 +538,9 @@ func TestSubscribeBooksInvalidCurrency(t *testing.T) {
 			takerGets: map[string]any{
 				"currency": "XRP",
 			},
-			errorMsg: "taker_pays: issuer required for non-XRP currency",
+			wantCode:  types.RpcSRC_ISR_MALFORMED,
+			wantError: "srcIsrMalformed",
+			wantMsg:   "Source issuer is malformed.",
 		},
 		{
 			name: "non-XRP taker_gets without issuer",
@@ -508,7 +550,9 @@ func TestSubscribeBooksInvalidCurrency(t *testing.T) {
 			takerGets: map[string]any{
 				"currency": "USD",
 			},
-			errorMsg: "taker_gets: issuer required for non-XRP currency",
+			wantCode:  types.RpcDST_ISR_MALFORMED,
+			wantError: "dstIsrMalformed",
+			wantMsg:   "Destination issuer is malformed.",
 		},
 		{
 			name: "invalid issuer in taker_pays",
@@ -519,7 +563,9 @@ func TestSubscribeBooksInvalidCurrency(t *testing.T) {
 			takerGets: map[string]any{
 				"currency": "XRP",
 			},
-			errorMsg: "taker_pays: invalid issuer address",
+			wantCode:  types.RpcSRC_ISR_MALFORMED,
+			wantError: "srcIsrMalformed",
+			wantMsg:   "Source issuer is malformed.",
 		},
 		{
 			name: "invalid issuer in taker_gets",
@@ -530,7 +576,36 @@ func TestSubscribeBooksInvalidCurrency(t *testing.T) {
 				"currency": "USD",
 				"issuer":   "invalid_issuer",
 			},
-			errorMsg: "taker_gets: invalid issuer address",
+			wantCode:  types.RpcDST_ISR_MALFORMED,
+			wantError: "dstIsrMalformed",
+			wantMsg:   "Destination issuer is malformed.",
+		},
+		{
+			name: "XRP taker_pays with issuer",
+			takerPays: map[string]any{
+				"currency": "XRP",
+				"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			},
+			takerGets: map[string]any{
+				"currency": "USD",
+				"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			},
+			wantCode:  types.RpcSRC_ISR_MALFORMED,
+			wantError: "srcIsrMalformed",
+			wantMsg:   "Source issuer is malformed.",
+		},
+		{
+			name: "noAccount sentinel issuer in taker_pays",
+			takerPays: map[string]any{
+				"currency": "USD",
+				"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+			},
+			takerGets: map[string]any{
+				"currency": "XRP",
+			},
+			wantCode:  types.RpcSRC_ISR_MALFORMED,
+			wantError: "srcIsrMalformed",
+			wantMsg:   "Source issuer is malformed.",
 		},
 	}
 
@@ -554,7 +629,9 @@ func TestSubscribeBooksInvalidCurrency(t *testing.T) {
 
 			err := sm.HandleSubscribe(conn, request, true)
 			require.NotNil(t, err, "Expected error for: %s", tc.name)
-			assert.Contains(t, err.Message, tc.errorMsg)
+			assert.Equal(t, tc.wantCode, err.Code)
+			assert.Equal(t, tc.wantError, err.ErrorString)
+			assert.Equal(t, tc.wantMsg, err.Message)
 
 			sm.RemoveConnection(conn.ID)
 		})
@@ -567,59 +644,50 @@ func TestSubscribeBooksInvalidCurrency(t *testing.T) {
 // must reject the same malformed currency / issuer / market shapes, otherwise
 // a subscribe books request can succeed against an order book that book_offers
 // would refuse to query.
-//
-// Subtests marked t.Skip document the cross-conformance gaps that still need
-// to be plugged in subscription.Manager — they're left wired up so the day
-// the gap closes, the skip can simply be removed.
 func TestSubscribeBooksCrossConformanceWithBookOffers(t *testing.T) {
 	type bookSpec struct {
 		takerPays map[string]any
 		takerGets map[string]any
 	}
 	tests := []struct {
-		name     string
-		skipNote string
-		book     bookSpec
+		name      string
+		book      bookSpec
+		wantError string
 	}{
 		{
 			// Book_test.cpp:1606-1618 — book_offers returns badMarket.
-			// subscribe.cpp:200 normalises both sides via makeBookSpec and
-			// would refuse this market. goxrpl's subscribe manager does NOT
-			// check this yet (#533 follow-up).
-			name:     "same currency and issuer is badMarket",
-			skipNote: "subscribe.Manager does not yet enforce badMarket (#533 follow-up)",
+			name: "same currency and issuer is badMarket",
 			book: bookSpec{
 				takerPays: map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
 				takerGets: map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
 			},
+			wantError: "badMarket",
 		},
 		{
-			// Book_test.cpp:1547-1561 — book_offers refuses XRP currency with a
-			// non-XRP issuer ("Unneeded field 'taker_pays.issuer'").
-			name:     "XRP pay with non-XRP issuer is unneeded",
-			skipNote: "subscribe.Manager treats XRP+issuer as a valid IOU (#533 follow-up)",
+			// Book_test.cpp:1547-1561 — XRP currency must not carry an
+			// issuer; Subscribe.cpp's illegal-issuer check (:258-268)
+			// reports it as srcIsrMalformed.
+			name: "XRP pay with non-XRP issuer is rejected",
 			book: bookSpec{
 				takerPays: map[string]any{"currency": "XRP", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
 				takerGets: map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
 			},
+			wantError: "srcIsrMalformed",
 		},
 		{
 			// Book_test.cpp:1505-1517 — ACCOUNT_ONE (noAccount sentinel) is
-			// rejected by book_offers with rpcSRC_ISR_MALFORMED.
-			name:     "ACCOUNT_ONE issuer is rejected",
-			skipNote: "subscribe.Manager does not yet refuse noAccount() sentinel (#533 follow-up)",
+			// rejected with rpcSRC_ISR_MALFORMED.
+			name: "ACCOUNT_ONE issuer is rejected",
 			book: bookSpec{
 				takerPays: map[string]any{"currency": "USD", "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"},
 				takerGets: map[string]any{"currency": "EUR", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
 			},
+			wantError: "srcIsrMalformed",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.skipNote != "" {
-				t.Skip(tc.skipNote)
-			}
 			sm := newTestSubscriptionManager()
 			conn := newTestConnection("test-conn-1")
 			sm.AddConnection(conn)
@@ -634,6 +702,7 @@ func TestSubscribeBooksCrossConformanceWithBookOffers(t *testing.T) {
 			}
 			err := sm.HandleSubscribe(conn, request, true)
 			require.NotNil(t, err, "subscribe should reject the same malformed shape book_offers refuses")
+			assert.Equal(t, tc.wantError, err.ErrorString)
 		})
 	}
 }
@@ -913,9 +982,12 @@ func TestSubscribeMissingTakerPays(t *testing.T) {
 		},
 	}
 
+	// rippled Subscribe.cpp:238-242 → rpcINVALID_PARAMS.
 	err := sm.HandleSubscribe(conn, request, true)
 	require.NotNil(t, err, "Expected error for missing taker_pays")
-	assert.Contains(t, err.Message, "taker_pays")
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Equal(t, "invalidParams", err.ErrorString)
+	assert.Equal(t, "Invalid parameters.", err.Message)
 
 	sm.RemoveConnection(conn.ID)
 }
@@ -940,9 +1012,12 @@ func TestSubscribeMissingTakerGets(t *testing.T) {
 		},
 	}
 
+	// rippled Subscribe.cpp:238-242 → rpcINVALID_PARAMS.
 	err := sm.HandleSubscribe(conn, request, true)
 	require.NotNil(t, err, "Expected error for missing taker_gets")
-	assert.Contains(t, err.Message, "taker_gets")
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Equal(t, "invalidParams", err.ErrorString)
+	assert.Equal(t, "Invalid parameters.", err.Message)
 
 	sm.RemoveConnection(conn.ID)
 }
@@ -966,9 +1041,13 @@ func TestSubscribeInvalidTakerPaysJSON(t *testing.T) {
 		},
 	}
 
+	// A non-object side fails rippled's structural check
+	// (Subscribe.cpp:238-242) → rpcINVALID_PARAMS.
 	err := sm.HandleSubscribe(conn, request, true)
 	require.NotNil(t, err, "Expected error for invalid taker_pays JSON")
-	assert.Contains(t, err.Message, "Invalid taker_pays")
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Equal(t, "invalidParams", err.ErrorString)
+	assert.Equal(t, "Invalid parameters.", err.Message)
 
 	sm.RemoveConnection(conn.ID)
 }
@@ -993,9 +1072,13 @@ func TestSubscribeInvalidTakerGetsJSON(t *testing.T) {
 		},
 	}
 
+	// A non-object side fails rippled's structural check
+	// (Subscribe.cpp:238-242) → rpcINVALID_PARAMS.
 	err := sm.HandleSubscribe(conn, request, true)
 	require.NotNil(t, err, "Expected error for invalid taker_gets JSON")
-	assert.Contains(t, err.Message, "Invalid taker_gets")
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Equal(t, "invalidParams", err.ErrorString)
+	assert.Equal(t, "Invalid parameters.", err.Message)
 
 	sm.RemoveConnection(conn.ID)
 }

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -1,33 +1,53 @@
 package subscription
 
 import (
+	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"sync"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// validStreams contains the set of valid stream types. Rippled accepts
-// the legacy "rt_transactions" name as an alias for "transactions_proposed"
-// (Subscribe.cpp:151-156); we accept it the same way and normalise it
-// inside HandleSubscribe.
+// validStreams is the exact stream-name set doSubscribe accepts
+// (Subscribe.cpp:130-174). Rippled accepts the legacy "rt_transactions"
+// name as an alias for "transactions_proposed" (Subscribe.cpp:151-156);
+// we accept it the same way and normalise it inside HandleSubscribe.
+// Anything else — including internal subscription keys like "accounts",
+// "book" and "path_find" — is rejected with rpcSTREAM_MALFORMED.
 var validStreams = map[types.SubscriptionType]bool{
 	types.SubLedger:               true,
 	types.SubTransactions:         true,
 	types.SubTransactionsProposed: true,
 	"rt_transactions":             true,
-	types.SubAccounts:             true,
-	types.SubBook:                 true,
 	types.SubBookChanges:          true,
 	types.SubValidations:          true,
 	types.SubManifests:            true,
 	types.SubPeerStatus:           true,
 	types.SubServer:               true,
 	types.SubConsensus:            true,
-	types.SubPath:                 true,
 }
+
+// validUnsubscribeStreams mirrors doUnsubscribe's stream switch
+// (Unsubscribe.cpp:61-110): the subscribe set minus book_changes —
+// rippled has no unsubBookChanges branch, so unsubscribing it yields
+// rpcSTREAM_MALFORMED and the stream only drops with the connection.
+var validUnsubscribeStreams = func() map[types.SubscriptionType]bool {
+	m := make(map[types.SubscriptionType]bool, len(validStreams))
+	for k := range validStreams {
+		m[k] = true
+	}
+	delete(m, types.SubBookChanges)
+	return m
+}()
+
+// xrpAccountID is the zero AccountID returned by rippled's xrpAccount();
+// noAccountID is the noAccount() sentinel (AccountID.cpp:178/:185), an
+// explicitly disallowed issuer.
+var (
+	xrpAccountID = [20]byte{}
+	noAccountID  = [20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+)
 
 // Manager manages WebSocket subscriptions
 type Manager struct {
@@ -79,10 +99,7 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 	// key so downstream broadcasts only need to consider one entry.
 	for _, stream := range request.Streams {
 		if !validStreams[stream] {
-			return &types.RpcError{
-				Code:    types.RpcINVALID_PARAMS,
-				Message: "Unknown stream type: " + string(stream),
-			}
+			return types.RpcErrorMalformedStream()
 		}
 		// peer_status is admin-only (Subscribe.cpp:161-166).
 		if stream == types.SubPeerStatus && !isAdmin {
@@ -96,13 +113,11 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 	}
 
 	if len(request.Accounts) > 0 {
-		// Validate all accounts first
+		// Any bad id fails the whole array with rpcACT_MALFORMED
+		// (Subscribe.cpp:192-199, parseAccountIds).
 		for _, acc := range request.Accounts {
 			if !isValidXRPLAddress(acc) {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: "Invalid account address: " + acc,
-				}
+				return types.RpcErrorActMalformed("Account malformed.")
 			}
 		}
 
@@ -127,13 +142,10 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 	}
 
 	if len(request.AccountsProposed) > 0 {
-		// Validate all accounts first
+		// rpcACT_MALFORMED on any bad id (Subscribe.cpp:181-188).
 		for _, acc := range request.AccountsProposed {
 			if !isValidXRPLAddress(acc) {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: "Invalid account address: " + acc,
-				}
+				return types.RpcErrorActMalformed("Account malformed.")
 			}
 		}
 		// Store in a separate subscription type (using accounts for now)
@@ -151,70 +163,8 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 		var normalised []types.BookRequest
 
 		for _, book := range request.Books {
-			// Validate taker_gets
-			if book.TakerGets == nil {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: "Missing taker_gets in book subscription",
-				}
-			}
-			// Validate taker_pays
-			if book.TakerPays == nil {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: "Missing taker_pays in book subscription",
-				}
-			}
-
-			// Parse and validate currency specs
-			var takerGets, takerPays types.CurrencySpec
-			if err := json.Unmarshal(book.TakerGets, &takerGets); err != nil {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: fmt.Sprintf("Invalid taker_gets: %v", err),
-				}
-			}
-			if err := json.Unmarshal(book.TakerPays, &takerPays); err != nil {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: fmt.Sprintf("Invalid taker_pays: %v", err),
-				}
-			}
-
-			// Validate issuer for non-XRP currencies
-			if takerGets.Currency != "XRP" && takerGets.Issuer == "" {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: "taker_gets: issuer required for non-XRP currency",
-				}
-			}
-			if takerPays.Currency != "XRP" && takerPays.Issuer == "" {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: "taker_pays: issuer required for non-XRP currency",
-				}
-			}
-
-			// Validate issuer format if provided
-			if takerGets.Issuer != "" && !isValidXRPLAddress(takerGets.Issuer) {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: "taker_gets: invalid issuer address",
-				}
-			}
-			if takerPays.Issuer != "" && !isValidXRPLAddress(takerPays.Issuer) {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: "taker_pays: invalid issuer address",
-				}
-			}
-			// Optional sfTaker — rippled Subscribe.cpp:288-299 returns
-			// rpcBAD_ISSUER when the taker is structurally invalid.
-			if book.Taker != "" && !isValidXRPLAddress(book.Taker) {
-				return &types.RpcError{
-					Code:    types.RpcINVALID_PARAMS,
-					Message: "taker: invalid taker address",
-				}
+			if rpcErr := validateBook(book, true); rpcErr != nil {
+				return rpcErr
 			}
 
 			normalised = append(normalised, book)
@@ -225,6 +175,7 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 					Snapshot:  book.Snapshot,
 					Both:      false, // already added the partner
 					Taker:     book.Taker,
+					Domain:    book.Domain,
 				}
 				normalised = append(normalised, reversed)
 			}
@@ -259,6 +210,185 @@ func isValidXRPLAddress(addr string) bool {
 	return addresscodec.IsValidClassicAddress(addr)
 }
 
+// validateBook runs the book checks rippled applies per entry
+// (Subscribe.cpp:236-326, Unsubscribe.cpp:167-245), in rippled's order so
+// a request that is malformed in several ways reports the same error both
+// implementations would pick. includeTaker is false on the unsubscribe
+// path, which carries no taker field. The final isConsistent recheck
+// (Subscribe.cpp:322-326) is subsumed: the per-side issuer checks already
+// guarantee each side is consistent, and in == out is exactly the
+// same-asset comparison below.
+func validateBook(book types.BookRequest, includeTaker bool) *types.RpcError {
+	// Both sides must be present and an object or null before either is
+	// parsed (Subscribe.cpp:238-242); a null side then fails the
+	// mandatory-currency check below, like rippled's isMember(currency)
+	// on a null value.
+	paysSide, rpcErr := bookSideObject(book.TakerPays)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	getsSide, rpcErr := bookSideObject(book.TakerGets)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	pays, paysIssuer, rpcErr := parseBookSide(paysSide, true)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	gets, getsIssuer, rpcErr := parseBookSide(getsSide, false)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	// Same asset on both sides is not a market (Subscribe.cpp:292-297).
+	if canonCurrency(pays.Currency) == canonCurrency(gets.Currency) && paysIssuer == getsIssuer {
+		return types.RpcErrorBadMarket()
+	}
+
+	// Optional taker — an unparseable account is rpcBAD_ISSUER
+	// (Subscribe.cpp:301-305).
+	if includeTaker && book.Taker != "" && !isValidXRPLAddress(book.Taker) {
+		return types.RpcErrorBadIssuer()
+	}
+
+	// Optional domain (Subscribe.cpp:308-315).
+	if book.Domain != "" && !isValidDomainHex(book.Domain) {
+		return types.RpcErrorDomainMalformed("")
+	}
+
+	return nil
+}
+
+// bookSideObject decodes one side of a book entry into its key/value
+// form, reporting rpcINVALID_PARAMS for a missing or non-object value.
+// A null side decodes to an empty map.
+func bookSideObject(raw json.RawMessage) (map[string]json.RawMessage, *types.RpcError) {
+	if raw == nil {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	var side map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &side); err != nil {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	return side, nil
+}
+
+// parseBookSide validates one side of a book entry. taker_pays maps to
+// rippled's "source" (src*) error codes, taker_gets to "destination"
+// (dst*); messages are the rpcError defaults from ErrorCodes.cpp since
+// Subscribe.cpp returns bare rpcError(code) at every site.
+func parseBookSide(side map[string]json.RawMessage, isPays bool) (spec types.CurrencySpec, issuerID [20]byte, _ *types.RpcError) {
+	curMalformed := func() *types.RpcError {
+		if isPays {
+			return types.RpcErrorSrcCurMalformed("Source currency is malformed.")
+		}
+		return types.RpcErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
+	}
+	isrMalformed := func() *types.RpcError {
+		if isPays {
+			return types.RpcErrorSrcIsrMalformed("Source issuer is malformed.")
+		}
+		return types.RpcErrorDstIsrMalformed("Destination issuer is malformed.")
+	}
+
+	// Mandatory currency (Subscribe.cpp:248-255 / :270-277).
+	rawCurrency, ok := side["currency"]
+	if !ok {
+		return spec, issuerID, curMalformed()
+	}
+	if err := json.Unmarshal(rawCurrency, &spec.Currency); err != nil {
+		return spec, issuerID, curMalformed()
+	}
+	if !isValidCurrencyCode(spec.Currency) {
+		return spec, issuerID, curMalformed()
+	}
+
+	// Optional issuer plus the illegal-issuer cross-checks: XRP must not
+	// carry an issuer, IOUs must, and the noAccount() sentinel is never
+	// allowed (Subscribe.cpp:257-268 / :279-290).
+	hasIssuer := false
+	if rawIssuer, ok := side["issuer"]; ok {
+		if err := json.Unmarshal(rawIssuer, &spec.Issuer); err != nil {
+			return spec, issuerID, isrMalformed()
+		}
+		_, idBytes, err := addresscodec.DecodeClassicAddressToAccountID(spec.Issuer)
+		if err != nil {
+			return spec, issuerID, isrMalformed()
+		}
+		copy(issuerID[:], idBytes)
+		if issuerID == noAccountID {
+			return spec, issuerID, isrMalformed()
+		}
+		hasIssuer = true
+	}
+	isXRPCurrency := spec.Currency == "" || spec.Currency == "XRP"
+	isXRPIssuer := !hasIssuer || issuerID == xrpAccountID
+	if isXRPCurrency != isXRPIssuer {
+		return spec, issuerID, isrMalformed()
+	}
+
+	return spec, issuerID, nil
+}
+
+// isValidCurrencyCode accepts what rippled's to_currency does: XRP (or
+// empty, which to_currency reads as XRP), a 3-character ISO-style code,
+// or a 40-hex Currency160.
+func isValidCurrencyCode(currency string) bool {
+	if currency == "" || currency == "XRP" {
+		return true
+	}
+	if len(currency) == 3 {
+		for _, c := range currency {
+			if !isIsoCurrencyChar(c) {
+				return false
+			}
+		}
+		return true
+	}
+	if len(currency) == 40 {
+		_, err := hex.DecodeString(currency)
+		return err == nil
+	}
+	return false
+}
+
+func isIsoCurrencyChar(c rune) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return true
+	case c == '?' || c == '!' || c == '@' || c == '#' || c == '$' ||
+		c == '%' || c == '^' || c == '&' || c == '*' || c == '<' ||
+		c == '>' || c == '(' || c == ')' || c == '{' || c == '}' ||
+		c == '[' || c == ']' || c == '|':
+		return true
+	}
+	return false
+}
+
+// canonCurrency folds the empty currency into "XRP" — to_currency reads
+// both as the XRP Currency160 — so the same-asset comparison treats them
+// as equal.
+func canonCurrency(c string) string {
+	if c == "" {
+		return "XRP"
+	}
+	return c
+}
+
+// isValidDomainHex mirrors uint256::parseHex acceptance the same way the
+// book_offers handler does: the literal "0" or exactly 64 hex digits.
+func isValidDomainHex(domain string) bool {
+	if domain == "0" {
+		return true
+	}
+	if len(domain) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(domain)
+	return err == nil
+}
+
 // HandleUnsubscribe handles an unsubscribe request for a connection.
 // The caller supplies its current admin status so the URL-style gate
 // in Unsubscribe.cpp:46-48 is honored symmetrically with the subscribe
@@ -274,6 +404,12 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 	defer sm.mu.Unlock()
 
 	for _, stream := range request.Streams {
+		// Unknown names are rpcSTREAM_MALFORMED; like rippled, streams
+		// earlier in the array are already unsubscribed when a later one
+		// fails (Unsubscribe.cpp:66-109).
+		if !validUnsubscribeStreams[stream] {
+			return types.RpcErrorMalformedStream()
+		}
 		key := stream
 		if key == "rt_transactions" {
 			key = types.SubTransactionsProposed
@@ -282,6 +418,12 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 	}
 
 	if len(request.Accounts) > 0 {
+		// rpcACT_MALFORMED on any bad id (Unsubscribe.cpp:127-135).
+		for _, acc := range request.Accounts {
+			if !isValidXRPLAddress(acc) {
+				return types.RpcErrorActMalformed("Account malformed.")
+			}
+		}
 		if existing, ok := conn.Subscriptions[types.SubAccounts]; ok {
 			accountsToRemove := make(map[string]bool)
 			for _, acc := range request.Accounts {
@@ -305,6 +447,12 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 
 	// Remove specific accounts_proposed subscriptions
 	if len(request.AccountsProposed) > 0 {
+		// rpcACT_MALFORMED on any bad id (Unsubscribe.cpp:116-124).
+		for _, acc := range request.AccountsProposed {
+			if !isValidXRPLAddress(acc) {
+				return types.RpcErrorActMalformed("Account malformed.")
+			}
+		}
 		if existing, ok := conn.Subscriptions["accounts_proposed"]; ok {
 			accountsToRemove := make(map[string]bool)
 			for _, acc := range request.AccountsProposed {
@@ -327,6 +475,14 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 	}
 
 	if len(request.Books) > 0 {
+		// Unsubscribe runs the same book validation as subscribe minus
+		// the taker field, which it does not carry (Unsubscribe.cpp:
+		// 167-245).
+		for _, book := range request.Books {
+			if rpcErr := validateBook(book, false); rpcErr != nil {
+				return rpcErr
+			}
+		}
 		delete(conn.Subscriptions, types.SubBook)
 	}
 

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -90,14 +90,19 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 		return types.RpcErrorNoPermission("subscribe")
 	}
 
+	w := request.WireArrays()
+
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// Validate and add stream subscriptions. "rt_transactions" is the
-	// deprecated alias rippled keeps around (Subscribe.cpp:151-156); we
-	// accept it and fold it into the canonical "transactions_proposed"
-	// key so downstream broadcasts only need to consider one entry.
-	for _, stream := range request.Streams {
+	// Streams. "rt_transactions" is the deprecated alias rippled keeps around
+	// (Subscribe.cpp:151-156); we fold it into the canonical
+	// "transactions_proposed" key so broadcasts consider one entry.
+	_, streams, rpcErr := resolveStreams(w.Present, w.Streams, request.Streams)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	for _, stream := range streams {
 		if !validStreams[stream] {
 			return types.RpcErrorMalformedStream()
 		}
@@ -112,88 +117,90 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 		conn.Subscriptions[key] = types.SubscriptionConfig{}
 	}
 
-	if len(request.Accounts) > 0 {
-		// Any bad id fails the whole array with rpcACT_MALFORMED
-		// (Subscribe.cpp:192-199, parseAccountIds).
-		for _, acc := range request.Accounts {
+	// accounts (Subscribe.cpp:192-200): a present-but-empty array, a non-string
+	// id, or an unparseable id all make parseAccountIds return an empty set →
+	// rpcACT_MALFORMED.
+	accountsPresent, accounts, rpcErr := resolveAccounts(w.Present, w.Accounts, request.Accounts)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	if accountsPresent {
+		if len(accounts) == 0 {
+			return types.RpcErrorActMalformed("Account malformed.")
+		}
+		for _, acc := range accounts {
 			if !isValidXRPLAddress(acc) {
 				return types.RpcErrorActMalformed("Account malformed.")
 			}
 		}
-
-		// Merge with existing accounts if already subscribed
-		existing, ok := conn.Subscriptions[types.SubAccounts]
-		accounts := request.Accounts
-		if ok {
-			// Append new accounts avoiding duplicates
+		// Merge with existing accounts, avoiding duplicates.
+		merged := accounts
+		if existing, ok := conn.Subscriptions[types.SubAccounts]; ok {
 			existingMap := make(map[string]bool)
 			for _, acc := range existing.Accounts {
 				existingMap[acc] = true
 			}
-			for _, acc := range request.Accounts {
+			for _, acc := range accounts {
 				if !existingMap[acc] {
-					accounts = append(accounts, acc)
+					merged = append(merged, acc)
 				}
 			}
 		}
 		conn.Subscriptions[types.SubAccounts] = types.SubscriptionConfig{
-			Accounts: accounts,
+			Accounts: merged,
 		}
 	}
 
-	if len(request.AccountsProposed) > 0 {
-		// rpcACT_MALFORMED on any bad id (Subscribe.cpp:181-188).
-		for _, acc := range request.AccountsProposed {
+	// accounts_proposed (Subscribe.cpp:181-189), same semantics as accounts.
+	proposedPresent, proposed, rpcErr := resolveAccounts(w.Present, w.AccountsProposed, request.AccountsProposed)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	if proposedPresent {
+		if len(proposed) == 0 {
+			return types.RpcErrorActMalformed("Account malformed.")
+		}
+		for _, acc := range proposed {
 			if !isValidXRPLAddress(acc) {
 				return types.RpcErrorActMalformed("Account malformed.")
 			}
 		}
-		// Store in a separate subscription type (using accounts for now)
 		conn.Subscriptions["accounts_proposed"] = types.SubscriptionConfig{
-			Accounts: request.AccountsProposed,
+			Accounts: proposed,
 		}
 	}
 
-	if len(request.Books) > 0 {
-		// Normalised + validated entries get accumulated here. When
-		// `both:true` is set on an entry, we additionally append the
-		// reversed pair — mirroring rippled Subscribe.cpp:330-337 which
-		// calls subBook twice (the request and its reverse) so a single
-		// subscriber sees activity on either side of the market.
+	// books (Subscribe.cpp:231-336): an empty array subscribes nothing. When
+	// `both:true` is set we append the reversed pair too, mirroring the second
+	// subBook call (Subscribe.cpp:330-337) so one subscriber sees either side.
+	// Snapshot delivery is done by the WebSocket layer (websocket.go
+	// handleSubscribe); the per-book Snapshot flag is preserved on each entry.
+	booksPresent, books, rpcErr := resolveBooks(w.Present, w.Books, request.Books)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	if booksPresent {
 		var normalised []types.BookRequest
-
-		for _, book := range request.Books {
+		for _, book := range books {
 			if rpcErr := validateBook(book, true); rpcErr != nil {
 				return rpcErr
 			}
-
 			normalised = append(normalised, book)
 			if book.Both {
-				reversed := types.BookRequest{
+				normalised = append(normalised, types.BookRequest{
 					TakerPays: book.TakerGets,
 					TakerGets: book.TakerPays,
 					Snapshot:  book.Snapshot,
-					Both:      false, // already added the partner
+					Both:      false,
 					Taker:     book.Taker,
 					Domain:    book.Domain,
-				}
-				normalised = append(normalised, reversed)
+				})
 			}
-			// Snapshot:true delivery is handled inline by the WebSocket
-			// layer (rpc/websocket.go: handleSubscribe → snapshotBook),
-			// which has access to the ServiceContainer / LedgerService.
-			// The per-book Snapshot flag is preserved on the BookRequest
-			// itself, so multi-book subscribers don't collapse to a
-			// single "last book" snapshot intent.
 		}
-
-		// Each book is recorded in Books — rippled Subscribe.cpp:328-336
-		// stores one entry per call to netOps.subBook, with no
-		// "primary book" concept. Multi-book subscribers' per-pair
-		// state lives on each BookRequest, not in connection-level
-		// scalars.
-		conn.Subscriptions[types.SubBook] = types.SubscriptionConfig{
-			Books: normalised,
+		if len(normalised) > 0 {
+			conn.Subscriptions[types.SubBook] = types.SubscriptionConfig{
+				Books: normalised,
+			}
 		}
 	}
 
@@ -208,6 +215,116 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 // isValidXRPLAddress checks if a string is a valid XRPL address
 func isValidXRPLAddress(addr string) bool {
 	return addresscodec.IsValidClassicAddress(addr)
+}
+
+// jsonIsArray reports whether a raw JSON value (already valid JSON) is an
+// array. rippled rejects every non-array shape — null, number, string,
+// bool, object — that a typed Go slice would silently collapse to nil.
+func jsonIsArray(raw json.RawMessage) bool {
+	for _, b := range raw {
+		switch b {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '[':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// wireArrayElements gives rippled's isMember/isArray view of a wire field:
+// present is false for an absent field; isArray is false for a null or
+// non-array value (the caller maps that to rpcINVALID_PARAMS); otherwise the
+// raw elements, possibly empty.
+func wireArrayElements(raw json.RawMessage) (present, isArray bool, elements []json.RawMessage) {
+	if raw == nil {
+		return false, false, nil
+	}
+	if !jsonIsArray(raw) {
+		return true, false, nil
+	}
+	_ = json.Unmarshal(raw, &elements)
+	return true, true, elements
+}
+
+// resolveStreams resolves the streams field against rippled's checks: a
+// non-array value is rpcINVALID_PARAMS (Subscribe.cpp:118-122), a non-string
+// entry rpcSTREAM_MALFORMED (Subscribe.cpp:126-127). When the request was
+// built directly in Go (not wire-decoded) the typed slice is used as-is.
+func resolveStreams(wireDecoded bool, raw json.RawMessage, typed []types.SubscriptionType) (present bool, streams []types.SubscriptionType, rpcErr *types.RpcError) {
+	if !wireDecoded {
+		return typed != nil, typed, nil
+	}
+	present, isArray, elements := wireArrayElements(raw)
+	if !present {
+		return false, nil, nil
+	}
+	if !isArray {
+		return true, nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	streams = make([]types.SubscriptionType, 0, len(elements))
+	for _, el := range elements {
+		var s string
+		if json.Unmarshal(el, &s) != nil {
+			return true, nil, types.RpcErrorMalformedStream()
+		}
+		streams = append(streams, types.SubscriptionType(s))
+	}
+	return true, streams, nil
+}
+
+// resolveAccounts resolves an accounts / accounts_proposed field to rippled's
+// parseAccountIds view (Subscribe.cpp:181-200, Unsubscribe.cpp:113-136): a
+// null or non-array value is rpcINVALID_PARAMS; a non-string element collapses
+// the set to empty (returned as a nil ids slice), which the caller — together
+// with the empty-array and bad-id cases — reports as rpcACT_MALFORMED.
+func resolveAccounts(wireDecoded bool, raw json.RawMessage, typed []string) (present bool, ids []string, rpcErr *types.RpcError) {
+	if !wireDecoded {
+		return typed != nil, typed, nil
+	}
+	present, isArray, elements := wireArrayElements(raw)
+	if !present {
+		return false, nil, nil
+	}
+	if !isArray {
+		return true, nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	ids = make([]string, 0, len(elements))
+	for _, el := range elements {
+		var s string
+		if json.Unmarshal(el, &s) != nil {
+			return true, nil, nil
+		}
+		ids = append(ids, s)
+	}
+	return true, ids, nil
+}
+
+// resolveBooks resolves the books field: a non-array value or a non-object
+// entry is rpcINVALID_PARAMS (Subscribe.cpp:233-242); an empty array yields no
+// subscriptions. Per-entry currency/issuer/market checks run in validateBook.
+func resolveBooks(wireDecoded bool, raw json.RawMessage, typed []types.BookRequest) (present bool, books []types.BookRequest, rpcErr *types.RpcError) {
+	if !wireDecoded {
+		return typed != nil, typed, nil
+	}
+	present, isArray, elements := wireArrayElements(raw)
+	if !present {
+		return false, nil, nil
+	}
+	if !isArray {
+		return true, nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	books = make([]types.BookRequest, 0, len(elements))
+	for _, el := range elements {
+		var b types.BookRequest
+		if json.Unmarshal(el, &b) != nil {
+			return true, nil, types.RpcErrorInvalidParams("Invalid parameters.")
+		}
+		books = append(books, b)
+	}
+	return true, books, nil
 }
 
 // validateBook runs the book checks rippled applies per entry
@@ -232,17 +349,19 @@ func validateBook(book types.BookRequest, includeTaker bool) *types.RpcError {
 		return rpcErr
 	}
 
-	pays, paysIssuer, rpcErr := parseBookSide(paysSide, true)
+	paysCur, paysIssuer, rpcErr := parseBookSide(paysSide, true)
 	if rpcErr != nil {
 		return rpcErr
 	}
-	gets, getsIssuer, rpcErr := parseBookSide(getsSide, false)
+	getsCur, getsIssuer, rpcErr := parseBookSide(getsSide, false)
 	if rpcErr != nil {
 		return rpcErr
 	}
 
-	// Same asset on both sides is not a market (Subscribe.cpp:292-297).
-	if canonCurrency(pays.Currency) == canonCurrency(gets.Currency) && paysIssuer == getsIssuer {
+	// Same asset on both sides is not a market (Subscribe.cpp:292-297). The
+	// comparison is on the parsed 160-bit currency and issuer, like rippled's
+	// book.in == book.out, so a currency and its 40-hex encoding match.
+	if paysCur == getsCur && paysIssuer == getsIssuer {
 		return types.RpcErrorBadMarket()
 	}
 
@@ -274,11 +393,12 @@ func bookSideObject(raw json.RawMessage) (map[string]json.RawMessage, *types.Rpc
 	return side, nil
 }
 
-// parseBookSide validates one side of a book entry. taker_pays maps to
-// rippled's "source" (src*) error codes, taker_gets to "destination"
-// (dst*); messages are the rpcError defaults from ErrorCodes.cpp since
-// Subscribe.cpp returns bare rpcError(code) at every site.
-func parseBookSide(side map[string]json.RawMessage, isPays bool) (spec types.CurrencySpec, issuerID [20]byte, _ *types.RpcError) {
+// parseBookSide validates one side of a book entry and returns its parsed
+// 160-bit currency and issuer. taker_pays maps to rippled's "source" (src*)
+// error codes, taker_gets to "destination" (dst*); messages are the rpcError
+// defaults from ErrorCodes.cpp since Subscribe.cpp returns bare rpcError(code)
+// at every site.
+func parseBookSide(side map[string]json.RawMessage, isPays bool) (currencyID [20]byte, issuerID [20]byte, _ *types.RpcError) {
 	curMalformed := func() *types.RpcError {
 		if isPays {
 			return types.RpcErrorSrcCurMalformed("Source currency is malformed.")
@@ -295,62 +415,74 @@ func parseBookSide(side map[string]json.RawMessage, isPays bool) (spec types.Cur
 	// Mandatory currency (Subscribe.cpp:248-255 / :270-277).
 	rawCurrency, ok := side["currency"]
 	if !ok {
-		return spec, issuerID, curMalformed()
+		return currencyID, issuerID, curMalformed()
 	}
-	if err := json.Unmarshal(rawCurrency, &spec.Currency); err != nil {
-		return spec, issuerID, curMalformed()
+	var currency string
+	if err := json.Unmarshal(rawCurrency, &currency); err != nil {
+		return currencyID, issuerID, curMalformed()
 	}
-	if !isValidCurrencyCode(spec.Currency) {
-		return spec, issuerID, curMalformed()
+	currencyID, ok = currencyToID(currency)
+	if !ok {
+		return currencyID, issuerID, curMalformed()
 	}
 
-	// Optional issuer plus the illegal-issuer cross-checks: XRP must not
-	// carry an issuer, IOUs must, and the noAccount() sentinel is never
-	// allowed (Subscribe.cpp:257-268 / :279-290).
+	// Optional issuer plus the illegal-issuer cross-checks: XRP must not carry
+	// an issuer, IOUs must, and the noAccount() sentinel is never allowed
+	// (Subscribe.cpp:257-268 / :279-290). XRP-ness is the all-zero 160-bit
+	// value, mirroring rippled's (!book.in.currency != !book.in.account).
 	hasIssuer := false
 	if rawIssuer, ok := side["issuer"]; ok {
-		if err := json.Unmarshal(rawIssuer, &spec.Issuer); err != nil {
-			return spec, issuerID, isrMalformed()
+		var issuer string
+		if err := json.Unmarshal(rawIssuer, &issuer); err != nil {
+			return currencyID, issuerID, isrMalformed()
 		}
-		_, idBytes, err := addresscodec.DecodeClassicAddressToAccountID(spec.Issuer)
+		_, idBytes, err := addresscodec.DecodeClassicAddressToAccountID(issuer)
 		if err != nil {
-			return spec, issuerID, isrMalformed()
+			return currencyID, issuerID, isrMalformed()
 		}
 		copy(issuerID[:], idBytes)
 		if issuerID == noAccountID {
-			return spec, issuerID, isrMalformed()
+			return currencyID, issuerID, isrMalformed()
 		}
 		hasIssuer = true
 	}
-	isXRPCurrency := spec.Currency == "" || spec.Currency == "XRP"
+	isXRPCurrency := currencyID == [20]byte{}
 	isXRPIssuer := !hasIssuer || issuerID == xrpAccountID
 	if isXRPCurrency != isXRPIssuer {
-		return spec, issuerID, isrMalformed()
+		return currencyID, issuerID, isrMalformed()
 	}
 
-	return spec, issuerID, nil
+	return currencyID, issuerID, nil
 }
 
-// isValidCurrencyCode accepts what rippled's to_currency does: XRP (or
-// empty, which to_currency reads as XRP), a 3-character ISO-style code,
-// or a 40-hex Currency160.
-func isValidCurrencyCode(currency string) bool {
+// currencyToID parses a currency code the way rippled's to_currency does
+// (UintTypes.cpp:83-107) into its 160-bit form: "", "XRP", and a 40-hex of
+// zeroes are the all-zero XRP currency; a 3-char ISO code is packed at bytes
+// 12-14; a 40-hex string is taken verbatim. ok is false for anything
+// to_currency rejects. Parsing to the 160-bit value (rather than comparing raw
+// strings) lets the XRP-ness and same-asset checks fold a currency and its
+// 40-hex encoding together, matching rippled.
+func currencyToID(currency string) (id [20]byte, ok bool) {
 	if currency == "" || currency == "XRP" {
-		return true
+		return id, true
 	}
-	if len(currency) == 3 {
-		for _, c := range currency {
-			if !isIsoCurrencyChar(c) {
-				return false
+	switch len(currency) {
+	case 3:
+		for i := range 3 {
+			if !isIsoCurrencyChar(rune(currency[i])) {
+				return [20]byte{}, false
 			}
+			id[12+i] = currency[i]
 		}
-		return true
+		return id, true
+	case 40:
+		if _, err := hex.Decode(id[:], []byte(currency)); err != nil {
+			return [20]byte{}, false
+		}
+		return id, true
+	default:
+		return [20]byte{}, false
 	}
-	if len(currency) == 40 {
-		_, err := hex.DecodeString(currency)
-		return err == nil
-	}
-	return false
 }
 
 func isIsoCurrencyChar(c rune) bool {
@@ -364,16 +496,6 @@ func isIsoCurrencyChar(c rune) bool {
 		return true
 	}
 	return false
-}
-
-// canonCurrency folds the empty currency into "XRP" — to_currency reads
-// both as the XRP Currency160 — so the same-asset comparison treats them
-// as equal.
-func canonCurrency(c string) string {
-	if c == "" {
-		return "XRP"
-	}
-	return c
 }
 
 // isValidDomainHex mirrors uint256::parseHex acceptance the same way the
@@ -400,10 +522,16 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 		return types.RpcErrorNoPermission("unsubscribe")
 	}
 
+	w := request.WireArrays()
+
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	for _, stream := range request.Streams {
+	_, streams, rpcErr := resolveStreams(w.Present, w.Streams, request.Streams)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	for _, stream := range streams {
 		// Unknown names are rpcSTREAM_MALFORMED; like rippled, streams
 		// earlier in the array are already unsubscribed when a later one
 		// fails (Unsubscribe.cpp:66-109).
@@ -417,16 +545,24 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 		delete(conn.Subscriptions, key)
 	}
 
-	if len(request.Accounts) > 0 {
-		// rpcACT_MALFORMED on any bad id (Unsubscribe.cpp:127-135).
-		for _, acc := range request.Accounts {
+	// accounts (Unsubscribe.cpp:127-135): empty array / non-string / bad id →
+	// rpcACT_MALFORMED; null or non-array → rpcINVALID_PARAMS.
+	accountsPresent, accounts, rpcErr := resolveAccounts(w.Present, w.Accounts, request.Accounts)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	if accountsPresent {
+		if len(accounts) == 0 {
+			return types.RpcErrorActMalformed("Account malformed.")
+		}
+		for _, acc := range accounts {
 			if !isValidXRPLAddress(acc) {
 				return types.RpcErrorActMalformed("Account malformed.")
 			}
 		}
 		if existing, ok := conn.Subscriptions[types.SubAccounts]; ok {
 			accountsToRemove := make(map[string]bool)
-			for _, acc := range request.Accounts {
+			for _, acc := range accounts {
 				accountsToRemove[acc] = true
 			}
 			var remainingAccounts []string
@@ -445,17 +581,23 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 		}
 	}
 
-	// Remove specific accounts_proposed subscriptions
-	if len(request.AccountsProposed) > 0 {
-		// rpcACT_MALFORMED on any bad id (Unsubscribe.cpp:116-124).
-		for _, acc := range request.AccountsProposed {
+	// accounts_proposed (Unsubscribe.cpp:116-124), same semantics as accounts.
+	proposedPresent, proposed, rpcErr := resolveAccounts(w.Present, w.AccountsProposed, request.AccountsProposed)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	if proposedPresent {
+		if len(proposed) == 0 {
+			return types.RpcErrorActMalformed("Account malformed.")
+		}
+		for _, acc := range proposed {
 			if !isValidXRPLAddress(acc) {
 				return types.RpcErrorActMalformed("Account malformed.")
 			}
 		}
 		if existing, ok := conn.Subscriptions["accounts_proposed"]; ok {
 			accountsToRemove := make(map[string]bool)
-			for _, acc := range request.AccountsProposed {
+			for _, acc := range proposed {
 				accountsToRemove[acc] = true
 			}
 			var remainingAccounts []string
@@ -474,16 +616,22 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 		}
 	}
 
-	if len(request.Books) > 0 {
-		// Unsubscribe runs the same book validation as subscribe minus
-		// the taker field, which it does not carry (Unsubscribe.cpp:
-		// 167-245).
-		for _, book := range request.Books {
+	// books run the same validation as subscribe minus the taker field, which
+	// unsubscribe does not carry (Unsubscribe.cpp:167-245); an empty array
+	// unsubscribes nothing.
+	booksPresent, books, rpcErr := resolveBooks(w.Present, w.Books, request.Books)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	if booksPresent {
+		for _, book := range books {
 			if rpcErr := validateBook(book, false); rpcErr != nil {
 				return rpcErr
 			}
 		}
-		delete(conn.Subscriptions, types.SubBook)
+		if len(books) > 0 {
+			delete(conn.Subscriptions, types.SubBook)
+		}
 	}
 
 	// Handle URL unsubscription

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -514,6 +514,20 @@ func RpcErrorBadMarket() *RpcError {
 	return NewRpcError(RpcBAD_MARKET, "badMarket", "badMarket", "No such market.")
 }
 
+// RpcErrorMalformedStream matches rippled rpcSTREAM_MALFORMED (code 71, token
+// "malformedStream", message "Stream malformed."), returned for an unknown
+// stream name in subscribe/unsubscribe.
+func RpcErrorMalformedStream() *RpcError {
+	return NewRpcError(RpcSTREAM_MALFORMED, "malformedStream", "malformedStream", "Stream malformed.")
+}
+
+// RpcErrorBadIssuer matches rippled rpcBAD_ISSUER (code 41, token "badIssuer",
+// message "Issuer account malformed."), returned when a book subscription's
+// taker does not parse as an account (Subscribe.cpp:301-305).
+func RpcErrorBadIssuer() *RpcError {
+	return NewRpcError(RpcBAD_ISSUER, "badIssuer", "badIssuer", "Issuer account malformed.")
+}
+
 // RpcErrorDomainMalformed matches rippled rpcDOMAIN_MALFORMED (code 97, token
 // "domainMalformed"), returned when a request's domain parameter does not
 // parse as a uint256 hex string. Callers pass the message rippled would emit

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -261,6 +261,73 @@ type SubscriptionRequest struct {
 	URL              string             `json:"url,omitempty"`
 	URLUsername      string             `json:"url_username,omitempty"`
 	URLPassword      string             `json:"url_password,omitempty"`
+
+	// wire holds the as-received JSON of the array-valued fields, captured at
+	// decode time. The typed slices above collapse the four shapes rippled
+	// distinguishes via isMember/isArray — absent, null, non-array, and empty
+	// array — into a single nil-or-empty slice, so the subscription manager
+	// reads wire to reproduce rippled's per-shape error codes. nil when the
+	// request was built directly in Go rather than decoded from the wire.
+	wire *wireSubscriptionArrays
+}
+
+type wireSubscriptionArrays struct {
+	streams          json.RawMessage
+	accounts         json.RawMessage
+	accountsProposed json.RawMessage
+	books            json.RawMessage
+}
+
+// WireSubscriptionArrays exposes the raw JSON the wire carried for the
+// array-valued subscription fields. Present is false when the request was not
+// decoded from JSON, in which case the manager falls back to the typed slices.
+type WireSubscriptionArrays struct {
+	Present          bool
+	Streams          json.RawMessage
+	Accounts         json.RawMessage
+	AccountsProposed json.RawMessage
+	Books            json.RawMessage
+}
+
+// WireArrays returns the raw array-field JSON captured by UnmarshalJSON.
+func (r *SubscriptionRequest) WireArrays() WireSubscriptionArrays {
+	if r.wire == nil {
+		return WireSubscriptionArrays{}
+	}
+	return WireSubscriptionArrays{
+		Present:          true,
+		Streams:          r.wire.streams,
+		Accounts:         r.wire.accounts,
+		AccountsProposed: r.wire.accountsProposed,
+		Books:            r.wire.books,
+	}
+}
+
+// UnmarshalJSON captures the raw JSON of the array-valued fields before
+// decoding the typed fields, so the subscription manager can apply rippled's
+// per-field, per-shape error codes — a typed slice cannot tell an absent field
+// from a null, an empty array, or a non-array value. Shape mismatches on the
+// array fields are tolerated here (left for the manager to report with the
+// correct code) rather than failing the whole decode; scalars decode normally.
+func (r *SubscriptionRequest) UnmarshalJSON(data []byte) error {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	r.wire = &wireSubscriptionArrays{
+		streams:          m["streams"],
+		accounts:         m["accounts"],
+		accountsProposed: m["accounts_proposed"],
+		books:            m["books"],
+	}
+	_ = json.Unmarshal(m["streams"], &r.Streams)
+	_ = json.Unmarshal(m["accounts"], &r.Accounts)
+	_ = json.Unmarshal(m["accounts_proposed"], &r.AccountsProposed)
+	_ = json.Unmarshal(m["books"], &r.Books)
+	_ = json.Unmarshal(m["url"], &r.URL)
+	_ = json.Unmarshal(m["url_username"], &r.URLUsername)
+	_ = json.Unmarshal(m["url_password"], &r.URLPassword)
+	return nil
 }
 
 // Book request for order book subscriptions

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -275,6 +275,10 @@ type BookRequest struct {
 	// when the field is absent. Validated against XRPL-address format
 	// in subscription.HandleSubscribe.
 	Taker string `json:"taker,omitempty"`
+	// Domain optionally scopes the book to a permissioned domain
+	// (Subscribe.cpp:308-320). Carried as the uint256 hex string the
+	// client sent; parse-validated in subscription.HandleSubscribe.
+	Domain string `json:"domain,omitempty"`
 }
 
 // Stream message types

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -254,3 +254,103 @@ func TestWebSocketServer_New_Concurrent(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestWebSocketSubscribeErrorWireEnvelope asserts the full wire envelope a
+// subscribe validation failure produces over a live WebSocket: rippled puts
+// the token in `error`, the numeric code in `error_code` and the
+// ErrorCodes.cpp default text in `error_message` (issue #828 regression —
+// these envelopes previously went out as `"error": ""` with code 31).
+func TestWebSocketSubscribeErrorWireEnvelope(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ws.RegisterAllMethods()
+
+	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
+	defer httpSrv.Close()
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = ws.Close(ctx)
+	}()
+
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+	client, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	tests := []struct {
+		name        string
+		request     map[string]any
+		wantError   string
+		wantCode    float64
+		wantMessage string
+	}{
+		{
+			name:        "unknown stream",
+			request:     map[string]any{"id": 1, "command": "subscribe", "streams": []string{"bogus"}},
+			wantError:   "malformedStream",
+			wantCode:    71,
+			wantMessage: "Stream malformed.",
+		},
+		{
+			name:        "malformed account",
+			request:     map[string]any{"id": 2, "command": "subscribe", "accounts": []string{"nope"}},
+			wantError:   "actMalformed",
+			wantCode:    35,
+			wantMessage: "Account malformed.",
+		},
+		{
+			name: "IOU taker_pays without issuer",
+			request: map[string]any{"id": 3, "command": "subscribe", "books": []map[string]any{{
+				"taker_pays": map[string]any{"currency": "USD"},
+				"taker_gets": map[string]any{"currency": "XRP"},
+			}}},
+			wantError:   "srcIsrMalformed",
+			wantCode:    70,
+			wantMessage: "Source issuer is malformed.",
+		},
+		{
+			name: "same-asset book",
+			request: map[string]any{"id": 4, "command": "subscribe", "books": []map[string]any{{
+				"taker_pays": map[string]any{"currency": "XRP"},
+				"taker_gets": map[string]any{"currency": "XRP"},
+			}}},
+			wantError:   "badMarket",
+			wantCode:    42,
+			wantMessage: "No such market.",
+		},
+		{
+			name:        "unsubscribe unknown stream",
+			request:     map[string]any{"id": 5, "command": "unsubscribe", "streams": []string{"bogus"}},
+			wantError:   "malformedStream",
+			wantCode:    71,
+			wantMessage: "Stream malformed.",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := client.WriteJSON(tc.request); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			client.SetReadDeadline(time.Now().Add(5 * time.Second))
+			var resp map[string]any
+			if err := client.ReadJSON(&resp); err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if got := resp["status"]; got != "error" {
+				t.Fatalf("status = %v, want error (resp %v)", got, resp)
+			}
+			if got := resp["error"]; got != tc.wantError {
+				t.Errorf("error = %v, want %q", got, tc.wantError)
+			}
+			if got := resp["error_code"]; got != tc.wantCode {
+				t.Errorf("error_code = %v, want %v", got, tc.wantCode)
+			}
+			if got := resp["error_message"]; got != tc.wantMessage {
+				t.Errorf("error_message = %v, want %q", got, tc.wantMessage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `subscription.Manager` built all 12 validation failures as inline `RpcError{Code, Message}` with no `ErrorString`, so every subscribe rejection went out as `"error": ""` with `rpcINVALID_PARAMS`. Each site now returns the code rippled's `Subscribe.cpp` uses: `malformedStream` (71) for unknown streams, `actMalformed` (35) for bad ids in `accounts`/`accounts_proposed`, `invalidParams` for missing/non-object book sides, `srcCurMalformed`/`srcIsrMalformed` (69/70) for `taker_pays`, `dstAmtMalformed`/`dstIsrMalformed` (51/53) for `taker_gets`, and `badIssuer` (41) for an unparseable `taker`. Messages are the `ErrorCodes.cpp` defaults since rippled returns bare `rpcError(code)` at every site, and evaluation order matches `Subscribe.cpp` (both sides' structural check before either currency parse, badMarket → taker → domain).
- Added the book checks that were missing entirely: illegal issuers (XRP currency with an issuer, IOU without one, the `noAccount()` sentinel), same-asset → `badMarket` (Subscribe.cpp:292-297; the `isConsistent` recheck at :322-326 is subsumed), and `domain` parse → `domainMalformed` (:308-315) via a new `BookRequest.Domain` field that previously was silently dropped.
- Swept `HandleUnsubscribe`, which shares the manager and validated nothing: unknown stream → `malformedStream`, bad accounts → `actMalformed`, books run the same validation minus the taker field (Unsubscribe.cpp:61-245). Stream-name sets now match rippled exactly — internal keys (`accounts`, `book`, `path_find`) are no longer subscribable as streams, and `book_changes` is not unsubscribable (rippled's `doUnsubscribe` has no `unsubBookChanges` branch in 2.6.2, 3.0.0, or develop).
- New helpers `RpcErrorMalformedStream`/`RpcErrorBadIssuer` in `types/errors.go`; per-site envelope tests (`error` token + `error_code` + `error_message`) following the #823 pattern, including a live-WebSocket wire-envelope test, and removal of the three `t.Skip`-documented #533 cross-conformance gaps that this closes.

## Test plan
- [x] `go test ./internal/rpc/...` (includes new `TestWebSocketSubscribeErrorWireEnvelope` asserting the wire envelope over a real WS connection)
- [x] `golangci-lint run ./internal/rpc/...`, `go vet`, `go build ./...`

Fixes #828