### PR TITLE
feat(rpc): port rippled amountFromJson as the shared RPC amount parser

### DIFF
--- a/internal/ledger/state/amount_json.go
+++ b/internal/ledger/state/amount_json.go
@@ -1,0 +1,407 @@
+package state
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// AmountFromJSON parses an RPC-parameter amount (destination_amount,
+// send_max, ...) the way rippled's amountFromJson does. Accepted forms:
+//
+//   - a JSON string: either a bare number, or up to three segments split
+//     on any of "\t\n\r ,/" as value / currency / issuer
+//   - a JSON object: {currency, issuer, value} or {mpt_issuance_id, value}
+//   - a JSON array: [value, currency, issuer]
+//   - a bare JSON number (32-bit only — rippled's Json reader classifies
+//     anything larger, fractional, or exponent-form as Real, which the
+//     parser rejects as "invalid amount type")
+//
+// Any error means the input is malformed; callers map it to their
+// method-specific error code, mirroring amountFromJsonNoThrow.
+func AmountFromJSON(raw json.RawMessage) (amt Amount, err error) {
+	// IOU normalization panics on exponent overflow the way rippled's
+	// canonicalize throws; surface it as a parse error like
+	// amountFromJsonNoThrow catching the exception.
+	defer func() {
+		if r := recover(); r != nil {
+			amt = Amount{}
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return Amount{}, fmt.Errorf("invalid amount json: %w", err)
+	}
+
+	var (
+		value         any
+		currencyField any
+		issuerField   any
+		isMPT         bool
+		isObject      bool
+		bareNumber    bool
+	)
+
+	switch jv := v.(type) {
+	case nil:
+		return Amount{}, errors.New("XRP may not be specified with a null Json value")
+	case map[string]any:
+		isObject = true
+		_, hasMPTID := jv["mpt_issuance_id"]
+		_, hasCurrency := jv["currency"]
+		_, hasIssuer := jv["issuer"]
+		if hasMPTID && (hasCurrency || hasIssuer) {
+			return Amount{}, errors.New("Invalid Asset's Json specification")
+		}
+		if !hasMPTID && !hasCurrency {
+			return Amount{}, errors.New("Invalid Asset's Json specification")
+		}
+		value = jv["value"]
+		if hasMPTID {
+			isMPT = true
+			currencyField = jv["mpt_issuance_id"]
+		} else {
+			currencyField = jv["currency"]
+			issuerField = jv["issuer"]
+		}
+	case []any:
+		value = json.Number("0")
+		if len(jv) > 0 {
+			value = jv[0]
+		}
+		if len(jv) > 1 {
+			currencyField = jv[1]
+		}
+		if len(jv) > 2 {
+			issuerField = jv[2]
+		}
+	case string:
+		elements := splitAmountString(jv)
+		if len(elements) > 3 {
+			return Amount{}, errors.New("invalid amount string")
+		}
+		value = elements[0]
+		if len(elements) > 1 {
+			currencyField = elements[1]
+		}
+		if len(elements) > 2 {
+			issuerField = elements[2]
+		}
+	case json.Number:
+		value = jv
+		bareNumber = true
+	default:
+		value = jv
+	}
+
+	currencyStr, currencyIsString := currencyField.(string)
+	native := !currencyIsString || currencyStr == "" || currencyStr == "XRP"
+
+	var (
+		mptID     string
+		currency  string
+		issuer    string
+		accountID [20]byte
+	)
+	if native {
+		if isObject {
+			return Amount{}, errors.New("XRP may not be specified as an object")
+		}
+	} else if isMPT {
+		// 192 bits: sequence (32) + issuer account (160).
+		decoded, hexErr := hex.DecodeString(currencyStr)
+		if hexErr != nil || len(decoded) != 24 {
+			return Amount{}, errors.New("invalid MPTokenIssuanceID")
+		}
+		mptID = currencyStr
+	} else {
+		cur, curErr := currencyFromJSONString(currencyStr)
+		if curErr != nil {
+			return Amount{}, curErr
+		}
+		issuerStr, issuerIsString := issuerField.(string)
+		if !issuerIsString {
+			return Amount{}, errors.New("invalid issuer")
+		}
+		id, issErr := issuerFromJSONString(issuerStr)
+		if issErr != nil {
+			return Amount{}, issErr
+		}
+		// An all-zero 160-bit code is the native currency; only the hex
+		// form can reach here with it.
+		if cur == ([20]byte{}) {
+			return Amount{}, errors.New("invalid issuer")
+		}
+		currency = currencyStr
+		accountID = id
+		issuer = EncodeAccountIDSafe(accountID)
+	}
+
+	parts, err := amountValueParts(value, bareNumber, native || isMPT)
+	if err != nil {
+		return Amount{}, err
+	}
+
+	if native {
+		drops, rangeErr := integralAmount(parts, maxNativeAmount, "Native currency amount out of range")
+		if rangeErr != nil {
+			return Amount{}, rangeErr
+		}
+		return NewXRPAmountFromInt(drops), nil
+	}
+	if isMPT {
+		units, rangeErr := integralAmount(parts, maxMPTAmount, "MPT amount out of range")
+		if rangeErr != nil {
+			return Amount{}, rangeErr
+		}
+		return NewMPTAmountWithIssuanceID(units, "", mptID), nil
+	}
+
+	mantissa, exponent := reduceIOUMantissa(parts.mantissa, parts.exponent)
+	if parts.negative {
+		mantissa = -mantissa
+	}
+	return NewIssuedAmountFromValue(mantissa, exponent, currency, issuer), nil
+}
+
+// rippled STAmount.h: cMaxNativeN (10^17 drops) and maxMPTokenAmount
+// (math.MaxInt64).
+const (
+	maxNativeAmount = uint64(100_000_000_000_000_000)
+	maxMPTAmount    = uint64(math.MaxInt64)
+)
+
+// nativeExponentLimit / mptExponentLimit mirror the canonicalize guards
+// log10(cMaxNativeN) == 17 and log10(maxMPTokenAmount) ~ 18.96.
+const (
+	nativeExponentLimit = 17
+	mptExponentLimit    = 18
+)
+
+// amountNumberParts is rippled's NumberParts: an unsigned mantissa with a
+// decimal exponent and explicit sign.
+type amountNumberParts struct {
+	mantissa uint64
+	exponent int
+	negative bool
+}
+
+// amountNumberRe is rippled partsFromString's anchored number grammar:
+// optional sign, no leading zeroes, optional fraction, optional exponent.
+var amountNumberRe = regexp.MustCompile(
+	`^([-+]?)(0|[1-9][0-9]*)(\.([0-9]+))?([eE]([+-]?)([0-9]+))?$`)
+
+// amountPartsFromString ports rippled's partsFromString.
+func amountPartsFromString(number string) (amountNumberParts, error) {
+	m := amountNumberRe.FindStringSubmatch(number)
+	if m == nil {
+		return amountNumberParts{}, fmt.Errorf("'%s' is not a number", number)
+	}
+
+	parts := amountNumberParts{negative: m[1] == "-"}
+
+	digits := m[2]
+	if m[4] != "" {
+		digits += m[4]
+		parts.exponent = -len(m[4])
+	}
+	mantissa, err := strconv.ParseUint(digits, 10, 64)
+	if err != nil {
+		return amountNumberParts{}, fmt.Errorf("'%s' is not a number", number)
+	}
+	parts.mantissa = mantissa
+
+	if m[7] != "" {
+		exp, err := strconv.Atoi(m[7])
+		if err != nil {
+			return amountNumberParts{}, fmt.Errorf("'%s' is not a number", number)
+		}
+		if m[6] == "-" {
+			parts.exponent -= exp
+		} else {
+			parts.exponent += exp
+		}
+	}
+
+	return parts, nil
+}
+
+// amountValueParts interprets the value member the way amountFromJson does:
+// 32-bit ints directly, strings through the number grammar, anything else
+// (null, bool, fractional/oversized numbers, nested containers) rejected.
+// integral reports whether the asset is XRP or MPT, which may not use a
+// fractional representation.
+func amountValueParts(value any, bareNumber, integral bool) (amountNumberParts, error) {
+	switch val := value.(type) {
+	case json.Number:
+		s := val.String()
+		if strings.ContainsAny(s, ".eE") {
+			// rippled's Json reader classifies these as Real.
+			return amountNumberParts{}, errors.New("invalid amount type")
+		}
+		i, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return amountNumberParts{}, errors.New("invalid amount type")
+		}
+		switch {
+		case i >= math.MinInt32 && i <= math.MaxInt32:
+			parts := amountNumberParts{}
+			if i < 0 {
+				parts.negative = true
+				parts.mantissa = uint64(-i)
+			} else {
+				parts.mantissa = uint64(i)
+			}
+			return parts, nil
+		case i > 0 && i <= math.MaxUint32:
+			// rippled reads the UInt branch off the enclosing value
+			// (v.asUInt(), not value.asUInt()), so a uint-range number
+			// inside an object or array throws a Json conversion error.
+			if !bareNumber {
+				return amountNumberParts{}, errors.New("Value is not convertible to UInt.")
+			}
+			return amountNumberParts{mantissa: uint64(i)}, nil
+		default:
+			// Beyond 32 bits the Json reader stores a Real.
+			return amountNumberParts{}, errors.New("invalid amount type")
+		}
+	case string:
+		parts, err := amountPartsFromString(val)
+		if err != nil {
+			return amountNumberParts{}, err
+		}
+		if integral && parts.exponent < 0 {
+			return amountNumberParts{}, errors.New("XRP and MPT must be specified as integral amount.")
+		}
+		return parts, nil
+	default:
+		return amountNumberParts{}, errors.New("invalid amount type")
+	}
+}
+
+// integralAmount scales mantissa by 10^exponent for XRP/MPT amounts,
+// enforcing rippled's canonicalize range guards.
+func integralAmount(parts amountNumberParts, maxValue uint64, rangeMsg string) (int64, error) {
+	if parts.mantissa == 0 {
+		return 0, nil
+	}
+	limit := nativeExponentLimit
+	if maxValue == maxMPTAmount {
+		limit = mptExponentLimit
+	}
+	if parts.exponent > limit {
+		return 0, errors.New(rangeMsg)
+	}
+	value := parts.mantissa
+	for i := 0; i < parts.exponent; i++ {
+		if value > maxValue {
+			return 0, errors.New(rangeMsg)
+		}
+		value *= 10
+	}
+	if value > maxValue {
+		return 0, errors.New(rangeMsg)
+	}
+	out := int64(value)
+	if parts.negative {
+		out = -out
+	}
+	return out, nil
+}
+
+// reduceIOUMantissa brings a uint64 mantissa into int64 range with a single
+// round-half-to-even step so the subsequent normalization never has to
+// round twice. Values at or below MaxMantissa pass through untouched.
+func reduceIOUMantissa(mantissa uint64, exponent int) (int64, int) {
+	if mantissa <= uint64(MaxMantissa) {
+		return int64(mantissa), exponent
+	}
+	divisor := uint64(1)
+	for mantissa/divisor > uint64(MaxMantissa) {
+		divisor *= 10
+		exponent++
+	}
+	q, r := mantissa/divisor, mantissa%divisor
+	switch {
+	case r*2 > divisor:
+		q++
+	case r*2 == divisor && q%2 == 1:
+		q++
+	}
+	return int64(q), exponent
+}
+
+// amountStringSeparators is the separator set rippled splits string
+// amounts on.
+const amountStringSeparators = "\t\n\r ,/"
+
+// splitAmountString splits on every separator occurrence without
+// compressing adjacent separators, like boost::split.
+func splitAmountString(s string) []string {
+	elements := []string{}
+	var cur strings.Builder
+	for _, r := range s {
+		if strings.ContainsRune(amountStringSeparators, r) {
+			elements = append(elements, cur.String())
+			cur.Reset()
+			continue
+		}
+		cur.WriteRune(r)
+	}
+	return append(elements, cur.String())
+}
+
+// isoCurrencyCharSet is rippled's isoCharSet: the characters allowed in a
+// three-letter currency code.
+const isoCurrencyCharSet = "abcdefghijklmnopqrstuvwxyz" +
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+	"0123456789" +
+	"<>(){}[]|?!@#$%^&*"
+
+// currencyFromJSONString ports to_currency for the non-native path: a
+// three-character ISO-like code or a 160-bit hex code.
+func currencyFromJSONString(code string) ([20]byte, error) {
+	var currency [20]byte
+	if len(code) == 3 {
+		for _, c := range code {
+			if !strings.ContainsRune(isoCurrencyCharSet, c) {
+				return [20]byte{}, errors.New("invalid currency")
+			}
+		}
+		copy(currency[12:], code)
+		return currency, nil
+	}
+	decoded, err := hex.DecodeString(code)
+	if err != nil || len(decoded) != 20 {
+		return [20]byte{}, errors.New("invalid currency")
+	}
+	copy(currency[:], decoded)
+	return currency, nil
+}
+
+// issuerFromJSONString ports to_issuer: a 160-bit hex account or a base58
+// classic address.
+func issuerFromJSONString(issuer string) ([20]byte, error) {
+	if len(issuer) == 40 {
+		decoded, err := hex.DecodeString(issuer)
+		if err == nil {
+			var id [20]byte
+			copy(id[:], decoded)
+			return id, nil
+		}
+	}
+	id, err := DecodeAccountID(issuer)
+	if err != nil {
+		return [20]byte{}, errors.New("invalid issuer")
+	}
+	return id, nil
+}

--- a/internal/ledger/state/amount_json_test.go
+++ b/internal/ledger/state/amount_json_test.go
@@ -1,0 +1,233 @@
+package state
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Reference behavior throughout: rippled amountFromJson
+// (src/libxrpl/protocol/STAmount.cpp) with partsFromString
+// (src/libxrpl/protocol/STNumber.cpp) and the STAmount_test setValue
+// corpus (src/test/protocol/STAmount_test.cpp).
+
+const (
+	testIssuer    = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	testIssuerHex = "B5F762798A53D543A014CAF8B297CFF8F2F937E8"
+	testMPTID     = "00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8"
+)
+
+func iouJSON(value, currency, issuer string) string {
+	b, _ := json.Marshal(map[string]string{
+		"currency": currency, "issuer": issuer, "value": value,
+	})
+	return string(b)
+}
+
+func TestAmountFromJSON_XRP(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		drops int64
+	}{
+		{"string drops", `"1000000"`, 1_000_000},
+		{"single drop", `"1"`, 1},
+		{"max native (1e17)", `"100000000000000000"`, 100_000_000_000_000_000},
+		{"exponent form", `"1e3"`, 1000},
+		{"explicit plus", `"+5"`, 5},
+		{"negative drops", `"-1"`, -1},
+		{"zero", `"0"`, 0},
+		{"zero with big exponent", `"0e50"`, 0},
+		{"bare int", `1000000`, 1_000_000},
+		{"bare negative int", `-1`, -1},
+		{"bare int32 max", `2147483647`, 2_147_483_647},
+		{"bare uint32 range", `3000000000`, 3_000_000_000},
+		{"bare uint32 max", `4294967295`, 4_294_967_295},
+		{"array value only", `["5"]`, 5},
+		{"empty array defaults to zero", `[]`, 0},
+		{"slash with XRP currency", `"5/XRP"`, 5},
+		{"empty currency segment", `"5/"`, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			amt, err := AmountFromJSON(json.RawMessage(tt.input))
+			if err != nil {
+				t.Fatalf("AmountFromJSON(%s): %v", tt.input, err)
+			}
+			if !amt.IsNative() {
+				t.Fatalf("AmountFromJSON(%s): want native", tt.input)
+			}
+			if amt.Drops() != tt.drops {
+				t.Fatalf("AmountFromJSON(%s) = %d drops, want %d", tt.input, amt.Drops(), tt.drops)
+			}
+		})
+	}
+}
+
+func TestAmountFromJSON_XRPErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"null", `null`},
+		{"bool", `true`},
+		{"fractional drops", `"1.1"`},
+		{"fractional via exponent", `"1e-2"`},
+		// STAmount_test: 100000000000000001 and 1000000000000000000 fail.
+		{"above max native", `"100000000000000001"`},
+		{"way above max native", `"1000000000000000000"`},
+		{"exponent overflow", `"1e18"`},
+		{"leading zero", `"01"`},
+		{"empty string", `""`},
+		{"not a number", `"abc"`},
+		{"whitespace only separators", `"1 2 3 4"`},
+		// rippled's Json reader stores these as Real -> invalid amount type.
+		{"bare fractional", `1.5`},
+		{"bare exponent form", `1e6`},
+		{"bare above uint32", `4294967296`},
+		{"bare large drops", `1000000000000`},
+		{"bare negative below int32", `-3000000000`},
+		// boost::lexical_cast overflow on the digit string.
+		{"mantissa above uint64", `"99999999999999999999999999"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := AmountFromJSON(json.RawMessage(tt.input)); err == nil {
+				t.Fatalf("AmountFromJSON(%s): want error", tt.input)
+			}
+		})
+	}
+}
+
+func TestAmountFromJSON_IOU(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		value    string
+		currency string
+	}{
+		{"object string value", iouJSON("5", "USD", testIssuer), "5", "USD"},
+		{"decimal preserved", iouJSON("1234567.89", "USD", testIssuer), "1234567.89", "USD"},
+		{"negative value", iouJSON("-1", "USD", testIssuer), "-1", "USD"},
+		{"exponent form", iouJSON("1e3", "USD", testIssuer), "1000", "USD"},
+		{"fractional exponent", iouJSON("15e-1", "USD", testIssuer), "1.5", "USD"},
+		{"underflow collapses to zero", iouJSON("1e-100", "USD", testIssuer), "0", "USD"},
+		{"hex issuer", iouJSON("5", "USD", testIssuerHex), "5", "USD"},
+		{"hex currency", iouJSON("5", "0158415500000000C1F76FF6ECB0BAC600000000", testIssuer),
+			"5", "0158415500000000C1F76FF6ECB0BAC600000000"},
+		{"symbol currency", iouJSON("5", "$$$", testIssuer), "5", "$$$"},
+		{"array form", `["5","USD","` + testIssuer + `"]`, "5", "USD"},
+		{"slash string form", `"5/USD/` + testIssuer + `"`, "5", "USD"},
+		{"comma separators", `"5,USD,` + testIssuer + `"`, "5", "USD"},
+		// One round-half-even step on the 4 digits beyond 16: ...1615 < half.
+		{"uint64-max mantissa", iouJSON("18446744073709551615", "USD", testIssuer),
+			"1844674407370955e4", "USD"},
+		{"near max IOU magnitude", iouJSON("1e85", "USD", testIssuer), "1000000000000000e70", "USD"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			amt, err := AmountFromJSON(json.RawMessage(tt.input))
+			if err != nil {
+				t.Fatalf("AmountFromJSON(%s): %v", tt.input, err)
+			}
+			if amt.IsNative() {
+				t.Fatalf("AmountFromJSON(%s): want issued", tt.input)
+			}
+			if amt.Currency != tt.currency {
+				t.Fatalf("currency = %q, want %q", amt.Currency, tt.currency)
+			}
+			if amt.Issuer != testIssuer {
+				t.Fatalf("issuer = %q, want %q", amt.Issuer, testIssuer)
+			}
+			if got := amt.Value(); got != tt.value {
+				t.Fatalf("value = %q, want %q", got, tt.value)
+			}
+		})
+	}
+}
+
+func TestAmountFromJSON_IOUObjectNumericValue(t *testing.T) {
+	// Int-range numeric values work inside objects; uint-range ones fail
+	// because rippled's UInt branch reads the enclosing value (v.asUInt()).
+	amt, err := AmountFromJSON(json.RawMessage(
+		`{"currency":"USD","issuer":"` + testIssuer + `","value":5}`))
+	if err != nil {
+		t.Fatalf("int value in object: %v", err)
+	}
+	if got := amt.Value(); got != "5" {
+		t.Fatalf("value = %q, want 5", got)
+	}
+
+	if _, err := AmountFromJSON(json.RawMessage(
+		`{"currency":"USD","issuer":"` + testIssuer + `","value":3000000000}`)); err == nil {
+		t.Fatal("uint-range value in object: want error (v.asUInt quirk)")
+	}
+	if _, err := AmountFromJSON(json.RawMessage(
+		`["3000000000","USD","` + testIssuer + `"]`)); err != nil {
+		t.Fatalf("uint-range STRING in array must parse: %v", err)
+	}
+}
+
+func TestAmountFromJSON_IOUErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"object without currency", `{"issuer":"` + testIssuer + `","value":"5"}`},
+		{"XRP as object", `{"currency":"XRP","issuer":"` + testIssuer + `","value":"5"}`},
+		{"empty currency as object", `{"currency":"","value":"5"}`},
+		{"non-string currency goes native in object", `{"currency":5,"value":"5"}`},
+		{"bad currency length", iouJSON("5", "TOOLONG", testIssuer)},
+		{"currency char outside iso set", iouJSON("5", "U-D", testIssuer)},
+		{"missing issuer", `{"currency":"USD","value":"5"}`},
+		{"bad issuer", iouJSON("5", "USD", "junk")},
+		{"all-zero hex currency", iouJSON("5", "0000000000000000000000000000000000000000", testIssuer)},
+		{"missing value", `{"currency":"USD","issuer":"` + testIssuer + `"}`},
+		{"null value", `{"currency":"USD","issuer":"` + testIssuer + `","value":null}`},
+		{"fractional numeric value", `{"currency":"USD","issuer":"` + testIssuer + `","value":1.5}`},
+		{"slash form without issuer", `"5/USD"`},
+		// Past the IOU range (max mantissa 9999999999999999 at exponent 80).
+		{"exponent overflow", iouJSON("1e97", "USD", testIssuer)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := AmountFromJSON(json.RawMessage(tt.input)); err == nil {
+				t.Fatalf("AmountFromJSON(%s): want error", tt.input)
+			}
+		})
+	}
+}
+
+func TestAmountFromJSON_MPT(t *testing.T) {
+	amt, err := AmountFromJSON(json.RawMessage(
+		`{"mpt_issuance_id":"` + testMPTID + `","value":"100"}`))
+	if err != nil {
+		t.Fatalf("MPT amount: %v", err)
+	}
+	if !amt.IsMPT() {
+		t.Fatal("want MPT amount")
+	}
+	if raw, ok := amt.MPTRaw(); !ok || raw != 100 {
+		t.Fatalf("MPTRaw = %d/%v, want 100", raw, ok)
+	}
+	if amt.MPTIssuanceID() != testMPTID {
+		t.Fatalf("issuance id = %q", amt.MPTIssuanceID())
+	}
+
+	errCases := []struct {
+		name  string
+		input string
+	}{
+		{"mpt with currency", `{"mpt_issuance_id":"` + testMPTID + `","currency":"USD","value":"1"}`},
+		{"mpt with issuer", `{"mpt_issuance_id":"` + testMPTID + `","issuer":"` + testIssuer + `","value":"1"}`},
+		{"bad issuance id", `{"mpt_issuance_id":"ABCD","value":"1"}`},
+		{"fractional mpt", `{"mpt_issuance_id":"` + testMPTID + `","value":"1.5"}`},
+		{"mpt out of range", `{"mpt_issuance_id":"` + testMPTID + `","value":"9223372036854775808"}`},
+	}
+	for _, tt := range errCases {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := AmountFromJSON(json.RawMessage(tt.input)); err == nil {
+				t.Fatalf("AmountFromJSON(%s): want error", tt.input)
+			}
+		})
+	}
+}

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"sort"
 	"strconv"
 
@@ -89,8 +88,11 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		return nil, types.RpcErrorDstActMalformed("Destination account is malformed.")
 	}
 
-	dstAmount, err := parsePathFindAmount(rawDstAmount)
-	if err != nil {
+	// MPT amounts parse (rippled accepts them at this layer too), but the
+	// pathfinder has no MPT support, so they are rejected as malformed
+	// rather than silently producing meaningless paths.
+	dstAmount, err := state.AmountFromJSON(rawDstAmount)
+	if err != nil || dstAmount.IsMPT() {
 		return nil, types.RpcErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
 	}
 
@@ -107,8 +109,8 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		if !convertAll {
 			return nil, types.RpcErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
 		}
-		amt, smErr := parsePathFindAmount(rawSendMax)
-		if smErr != nil || (amt.Signum() <= 0 && amt.Value() != "-1") {
+		amt, smErr := state.AmountFromJSON(rawSendMax)
+		if smErr != nil || amt.IsMPT() || (amt.Signum() <= 0 && amt.Value() != "-1") {
 			return nil, types.RpcErrorSendMaxMalformed("SendMax amount malformed.")
 		}
 		sendMax = &amt
@@ -458,45 +460,4 @@ func formatAmountJSON(amt state.Amount) any {
 		"issuer":   amt.Issuer,
 		"value":    amt.Value(),
 	}
-}
-
-// parsePathFindAmount parses a JSON amount for path finding, mirroring
-// rippled amountFromJsonNoThrow: a string is XRP drops; an object must be a
-// non-XRP issued amount with a valid issuer (XRP may not be specified as an
-// object).
-func parsePathFindAmount(raw json.RawMessage) (state.Amount, error) {
-	// Try as string first (XRP drops)
-	var strVal string
-	if err := json.Unmarshal(raw, &strVal); err == nil {
-		drops, err := strconv.ParseInt(strVal, 10, 64)
-		if err != nil {
-			return state.Amount{}, fmt.Errorf("invalid XRP amount %q: %w", strVal, err)
-		}
-		return state.NewXRPAmountFromInt(drops), nil
-	}
-
-	// Try as IOU object
-	var iou struct {
-		Currency *string `json:"currency"`
-		Issuer   string  `json:"issuer"`
-		Value    string  `json:"value"`
-	}
-	if err := json.Unmarshal(raw, &iou); err != nil {
-		return state.Amount{}, fmt.Errorf("amount must be string or {currency,issuer,value} object")
-	}
-
-	if iou.Currency == nil || !isValidCurrencyCode(*iou.Currency) {
-		return state.Amount{}, fmt.Errorf("invalid currency")
-	}
-	if *iou.Currency == "" || *iou.Currency == "XRP" {
-		return state.Amount{}, fmt.Errorf("XRP may not be specified as an object")
-	}
-	if _, err := state.DecodeAccountID(iou.Issuer); err != nil {
-		return state.Amount{}, fmt.Errorf("invalid issuer")
-	}
-	if _, err := strconv.ParseFloat(iou.Value, 64); err != nil {
-		return state.Amount{}, fmt.Errorf("invalid amount value %q", iou.Value)
-	}
-
-	return state.NewIssuedAmountFromDecimalString(iou.Value, *iou.Currency, iou.Issuer), nil
 }

--- a/internal/rpc/path_find_session.go
+++ b/internal/rpc/path_find_session.go
@@ -3,7 +3,6 @@ package rpc
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"sync"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -83,20 +82,23 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 			"Destination account is malformed.")
 	}
 
-	// Parse destination amount
-	dstAmount := parseSessionAmount(request.DestinationAmount)
-
-	// Check for convert_all mode (destination_amount = "-1")
-	convertAll := false
-	var strVal string
-	if json.Unmarshal(request.DestinationAmount, &strVal) == nil && strVal == "-1" {
-		convertAll = true
+	// Parse destination amount. MPT amounts parse but the pathfinder has
+	// no MPT support, so they are rejected as malformed.
+	dstAmount, amtErr := state.AmountFromJSON(request.DestinationAmount)
+	if amtErr != nil || dstAmount.IsMPT() {
+		return nil, rpctypes.RpcErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
 	}
+
+	// destination_amount of exactly -1 selects convert-all mode.
+	convertAll := dstAmount.Value() == "-1"
 
 	// Parse optional send_max
 	var sendMax *tx.Amount
 	if request.SendMax != nil {
-		amt := parseSessionAmount(request.SendMax)
+		amt, smErr := state.AmountFromJSON(request.SendMax)
+		if smErr != nil || amt.IsMPT() {
+			return nil, rpctypes.RpcErrorSendMaxMalformed("SendMax amount malformed.")
+		}
 		sendMax = &amt
 	}
 
@@ -212,29 +214,4 @@ func convertToRPCPathSteps(paths [][]payment.PathStep) [][]rpctypes.PathStep {
 		result[i] = steps
 	}
 	return result
-}
-
-// parseSessionAmount parses a JSON amount for path finding.
-func parseSessionAmount(raw json.RawMessage) tx.Amount {
-	var strVal string
-	if err := json.Unmarshal(raw, &strVal); err == nil {
-		drops, _ := strconv.ParseInt(strVal, 10, 64)
-		return state.NewXRPAmountFromInt(drops)
-	}
-
-	var iou struct {
-		Currency string `json:"currency"`
-		Issuer   string `json:"issuer"`
-		Value    string `json:"value"`
-	}
-	if err := json.Unmarshal(raw, &iou); err != nil {
-		return state.NewXRPAmountFromInt(0)
-	}
-
-	if iou.Currency == "XRP" || iou.Currency == "" {
-		drops, _ := strconv.ParseInt(iou.Value, 10, 64)
-		return state.NewXRPAmountFromInt(drops)
-	}
-
-	return state.NewIssuedAmountFromDecimalString(iou.Value, iou.Currency, iou.Issuer)
 }

--- a/internal/rpc/path_find_session.go
+++ b/internal/rpc/path_find_session.go
@@ -91,12 +91,19 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 
 	// destination_amount of exactly -1 selects convert-all mode.
 	convertAll := dstAmount.Value() == "-1"
+	if !convertAll && dstAmount.Signum() <= 0 {
+		return nil, rpctypes.RpcErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
+	}
 
 	// Parse optional send_max
 	var sendMax *tx.Amount
 	if request.SendMax != nil {
+		// send_max requires destination_amount to be -1.
+		if !convertAll {
+			return nil, rpctypes.RpcErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
+		}
 		amt, smErr := state.AmountFromJSON(request.SendMax)
-		if smErr != nil || amt.IsMPT() {
+		if smErr != nil || amt.IsMPT() || (amt.Signum() <= 0 && amt.Value() != "-1") {
 			return nil, rpctypes.RpcErrorSendMaxMalformed("SendMax amount malformed.")
 		}
 		sendMax = &amt

--- a/internal/rpc/path_find_session_test.go
+++ b/internal/rpc/path_find_session_test.go
@@ -1,0 +1,64 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The WS path_find session must enforce the same post-parse amount guards as
+// rippled's PathRequest::parseJson (and as the ripple_path_find RPC handler):
+// a non-convert-all destination_amount must be > 0, send_max requires
+// convert-all (destination_amount == -1), and a send_max must be > 0 unless it
+// is itself -1.
+func TestParseAndCreateSession_AmountGuards(t *testing.T) {
+	const acct = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+	params := func(dstAmt, sendMax string) json.RawMessage {
+		s := `{"source_account":"` + acct + `","destination_account":"` + acct +
+			`","destination_amount":` + dstAmt
+		if sendMax != "" {
+			s += `,"send_max":` + sendMax
+		}
+		return json.RawMessage(s + `}`)
+	}
+
+	reject := []struct {
+		name    string
+		dstAmt  string
+		sendMax string
+		token   string
+	}{
+		{"negative destination_amount", `"-5"`, "", "dstAmtMalformed"},
+		{"zero destination_amount", `"0"`, "", "dstAmtMalformed"},
+		{"send_max without convert-all", `"1000000"`, `"5"`, "dstAmtMalformed"},
+		{"non-positive send_max with convert-all", `"-1"`, `"0"`, "sendMaxMalformed"},
+	}
+	for _, tt := range reject {
+		t.Run(tt.name, func(t *testing.T) {
+			_, rpcErr := ParseAndCreateSession(params(tt.dstAmt, tt.sendMax), nil)
+			if rpcErr == nil || rpcErr.ErrorString != tt.token {
+				t.Fatalf("got %v, want %s", rpcErr, tt.token)
+			}
+		})
+	}
+
+	accept := []struct {
+		name    string
+		dstAmt  string
+		sendMax string
+	}{
+		{"positive destination_amount", `"1000000"`, ""},
+		{"convert-all with positive send_max", `"-1"`, `"10"`},
+	}
+	for _, tt := range accept {
+		t.Run(tt.name, func(t *testing.T) {
+			session, rpcErr := ParseAndCreateSession(params(tt.dstAmt, tt.sendMax), nil)
+			if rpcErr != nil {
+				t.Fatalf("unexpected error: %v", rpcErr)
+			}
+			if session == nil {
+				t.Fatal("want session, got nil")
+			}
+		})
+	}
+}

--- a/internal/testing/rpcenv/ripple_path_find_test.go
+++ b/internal/testing/rpcenv/ripple_path_find_test.go
@@ -457,3 +457,81 @@ func TestRipplePathFind_ConvertAll(t *testing.T) {
 	require.True(t, ok, "convert-all alternatives must report destination_amount")
 	require.Equal(t, "50", dstAmt["value"])
 }
+
+// TestRipplePathFind_NonCanonicalAmountForms covers the amountFromJson
+// input forms beyond the canonical string/object ones: bare 32-bit JSON
+// numbers, separator-delimited strings, and array form.
+// Reference: rippled amountFromJson (STAmount.cpp).
+func TestRipplePathFind_NonCanonicalAmountForms(t *testing.T) {
+	env, gw, alice, bob := newPathFindEnv(t)
+
+	t.Run("bare numeric XRP destination_amount", func(t *testing.T) {
+		result, rpcErr := env.RPC("ripple_path_find", map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": bob.Address,
+			"destination_amount":  1000000,
+		})
+		require.Nil(t, rpcErr)
+		resp := asJSONMap(t, result)
+		require.Equal(t, "1000000", resp["destination_amount"])
+	})
+
+	t.Run("slash-delimited IOU destination_amount", func(t *testing.T) {
+		result, rpcErr := env.RPC("ripple_path_find", map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": bob.Address,
+			"destination_amount":  "5/USD/" + gw.Address,
+		})
+		require.Nil(t, rpcErr)
+		resp := asJSONMap(t, result)
+		alternatives := resp["alternatives"].([]any)
+		require.NotEmpty(t, alternatives)
+		srcAmt := alternatives[0].(map[string]any)["source_amount"].(map[string]any)
+		require.Equal(t, "5", srcAmt["value"])
+	})
+
+	t.Run("array-form IOU destination_amount", func(t *testing.T) {
+		result, rpcErr := env.RPC("ripple_path_find", map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": bob.Address,
+			"destination_amount":  []any{"5", "USD", gw.Address},
+		})
+		require.Nil(t, rpcErr)
+		resp := asJSONMap(t, result)
+		require.NotEmpty(t, resp["alternatives"])
+	})
+
+	t.Run("numeric -1 selects convert-all", func(t *testing.T) {
+		result, rpcErr := env.RPC("ripple_path_find", map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": bob.Address,
+			"destination_amount":  -1,
+		})
+		require.Nil(t, rpcErr)
+		resp := asJSONMap(t, result)
+		require.Equal(t, "-1", resp["destination_amount"])
+	})
+
+	t.Run("fractional bare number stays malformed", func(t *testing.T) {
+		_, rpcErr := env.RPC("ripple_path_find", map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": bob.Address,
+			"destination_amount":  1.5,
+		})
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "dstAmtMalformed", rpcErr.ErrorString)
+	})
+
+	t.Run("MPT destination_amount rejected", func(t *testing.T) {
+		_, rpcErr := env.RPC("ripple_path_find", map[string]any{
+			"source_account":      alice.Address,
+			"destination_account": bob.Address,
+			"destination_amount": map[string]any{
+				"mpt_issuance_id": "00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8",
+				"value":           "5",
+			},
+		})
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "dstAmtMalformed", rpcErr.ErrorString)
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `state.AmountFromJSON`, a faithful port of rippled's `amountFromJson` (`STAmount.cpp:1035-1160`) + `partsFromString` (`STNumber.cpp:123-176`): bare 32-bit JSON numbers, `{currency, issuer, value}` with string or numeric value, `{mpt_issuance_id, value}`, `[value, currency, issuer]` arrays, and separator-delimited strings (`"5/USD/r..."`), with the exact error behavior — including the Json-reader quirks (fractional/oversized numbers are Real → rejected; uint-range numerics parse only as bare values because rippled's UInt branch reads `v.asUInt()`), `to_issuer`'s 40-hex form, and the canonicalize range guards (XRP ≤ 1e17 drops, MPT ≤ int64 max, IOU exponent ±96/80 with round-half-even).
- Routes both path-find surfaces through it: `ripple_path_find` (replacing `parsePathFindAmount`) and the WebSocket `path_find` session (replacing `parseSessionAmount`, which silently treated malformed amounts as **zero XRP**; it now reports `dstAmtMalformed` / `sendMaxMalformed` like rippled).
- MPT amounts parse but are rejected as malformed by the path-find handlers, since the pathfinder has no MPT support — same honest-gating pattern as `domain`.
- Table tests mirror rippled's `STAmount_test` setValue corpus (`src/test/protocol/STAmount_test.cpp:162-225`), plus rpcenv integration tests for the new forms end-to-end.

Sweep notes: `book_offers` / book subscriptions parse `{currency, issuer}` *asset specs* (no value) and `channel_authorize`/`channel_verify` take string drops in rippled too — all correctly out of scope. `book_changes` parses ledger metadata, not request params.

## Test plan
- [x] `go test ./internal/ledger/state/... ./internal/rpc/... ./internal/testing/rpcenv/... ./internal/testing/payment/...`
- [x] `just vet` / `just lint` (0 issues) / `just build`

Fixes #836