### PR TITLE
feat(rpc): url-based admin subscriptions (RPCSub parity)

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -1275,6 +1275,7 @@ func (a *ledgerInfoAdapter) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
 		ReserveInc:       reserveInc,
 		ValidatedLedgers: serverInfo.CompleteLedgers,
 		NetworkID:        serverInfo.NetworkID,
+		XRPFeesEnabled:   a.ledgerService.XRPFeesEnabled(),
 	}
 }
 

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -970,6 +970,23 @@ func (s *Service) GetValidatedLedger() *ledger.Ledger {
 	return s.validatedLedger
 }
 
+// XRPFeesEnabled reports whether the XRPFees amendment is active on the
+// validated ledger. The subscribe ack uses it to gate the deprecated
+// fee_ref field, mirroring rippled's subLedger.
+func (s *Service) XRPFeesEnabled() bool {
+	s.mu.RLock()
+	validated := s.validatedLedger
+	s.mu.RUnlock()
+	if validated == nil {
+		return false
+	}
+	rules, err := ledger.LoadAmendmentsFromLedger(validated)
+	if err != nil || rules == nil {
+		return false
+	}
+	return rules.XRPFeesEnabled()
+}
+
 // GetLedgerBySequence returns a ledger by its sequence number, falling back
 // to the open ledger when its sequence matches (mirrors rippled RPCHelpers.cpp:498-508).
 func (s *Service) GetLedgerBySequence(seq uint32) (*ledger.Ledger, error) {

--- a/internal/rpc/handlers/subscribe.go
+++ b/internal/rpc/handlers/subscribe.go
@@ -7,42 +7,46 @@ import (
 )
 
 // SubscribeMethod handles the subscribe RPC command over plain JSON-RPC.
-// The WebSocket-bound implementation lives in rpc/websocket.go.
-//
-// rippled additionally supports url-based (RPCSub) subscriptions on this
-// path: an admin supplies url/url_username/url_password and rippled keeps
-// a per-url InfoSub (NetworkOPs::mRpcSubMap) whose events are delivered as
-// outbound JSON-RPC "event" calls (RPCSub.cpp: per-url sequence numbers,
-// http/https with basic auth, fire-and-forget with logged failures).
-// go-xrpl does not implement RPCSub: it needs a url-keyed registry shared
-// between this handler and the WebSocket broadcast fan-out, an outbound
-// HTTP delivery loop, and the subscribe ack/snapshot building that today
-// lives on WebSocketServer — a subsystem of its own. Until then the
-// admin+url case returns notSupported; without url this matches rippled's
-// "Must be a JSON-RPC call." branch (rpcINVALID_PARAMS), and url from a
-// non-admin returns rpcNO_PERMISSION exactly as rippled does.
+// The WebSocket-bound implementation lives in rpc/websocket.go. On this
+// path only url-based (RPCSub) subscriptions exist: an admin supplies
+// url/url_username/url_password and the url-subscription registry keeps a
+// per-url subscriber whose events are delivered as outbound JSON-RPC
+// "event" calls. Without url this is rippled's "Must be a JSON-RPC call."
+// branch (rpcINVALID_PARAMS); url from a non-admin is rpcNO_PERMISSION.
 type SubscribeMethod struct{ BaseHandler }
 
-// urlSubscriptionError implements the shared subscribe/unsubscribe gating
-// for plain JSON-RPC calls described on SubscribeMethod.
-func urlSubscriptionError(ctx *types.RpcContext, params json.RawMessage) *types.RpcError {
-	var request struct {
-		URL string `json:"url"`
-	}
+// urlSubscriptionRequest applies the shared subscribe/unsubscribe gating
+// for plain JSON-RPC calls described on SubscribeMethod and resolves the
+// url-subscription service.
+func urlSubscriptionRequest(ctx *types.RpcContext, params json.RawMessage, method string) (types.SubscriptionRequest, types.URLSubscriptionService, *types.RpcError) {
+	var request types.SubscriptionRequest
 	if len(params) > 0 {
-		_ = json.Unmarshal(params, &request)
+		if err := json.Unmarshal(params, &request); err != nil {
+			return request, nil, types.RpcErrorInvalidParams("Invalid parameters.")
+		}
 	}
 
-	if request.URL == "" {
+	if !request.HasURL() {
 		// Must be a JSON-RPC call (rippled: no infoSub and no url).
-		return types.RpcErrorInvalidParams("Invalid parameters.")
+		return request, nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 	if ctx.Role != types.RoleAdmin {
-		return types.RpcErrorNoPermission("subscribe")
+		return request, nil, types.RpcErrorNoPermission(method)
 	}
-	return types.RpcErrorNotSupported("url-based (RPCSub) subscriptions are not supported")
+	if ctx.Services == nil || ctx.Services.URLSubscriptions == nil {
+		return request, nil, types.RpcErrorNotSupported("url-based (RPCSub) subscriptions are not supported")
+	}
+	return request, ctx.Services.URLSubscriptions, nil
 }
 
 func (m *SubscribeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	return nil, urlSubscriptionError(ctx, params)
+	request, svc, rpcErr := urlSubscriptionRequest(ctx, params, "subscribe")
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	result, rpcErr := svc.Subscribe(ctx, request)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	return result, nil
 }

--- a/internal/rpc/handlers/unsubscribe.go
+++ b/internal/rpc/handlers/unsubscribe.go
@@ -8,15 +8,21 @@ import (
 
 // UnsubscribeMethod handles the unsubscribe RPC command over plain
 // JSON-RPC. The WebSocket-bound implementation lives in rpc/websocket.go.
-//
-// rippled's url branch (Unsubscribe.cpp) looks up the per-url RPCSub
-// created by subscribe and removes the listed streams from it; see
-// SubscribeMethod for why go-xrpl does not implement RPCSub yet. The
-// gating here mirrors the subscribe path: no url → rpcINVALID_PARAMS
-// ("Must be a JSON-RPC call." branch), url from a non-admin →
-// rpcNO_PERMISSION, url from an admin → notSupported.
+// Like subscribe, only the url (RPCSub) branch exists on this path: the
+// listed streams are removed from the per-url subscriber and its registry
+// entry is dropped once no stream subscriptions remain. The gating mirrors
+// the subscribe path: no url → rpcINVALID_PARAMS ("Must be a JSON-RPC
+// call." branch), url from a non-admin → rpcNO_PERMISSION.
 type UnsubscribeMethod struct{ BaseHandler }
 
 func (m *UnsubscribeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	return nil, urlSubscriptionError(ctx, params)
+	request, svc, rpcErr := urlSubscriptionRequest(ctx, params, "unsubscribe")
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	result, rpcErr := svc.Unsubscribe(ctx, request)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	return result, nil
 }

--- a/internal/rpc/rpcsub.go
+++ b/internal/rpc/rpcsub.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -131,6 +132,7 @@ func (r *URLSubscriptionRegistry) findOrCreate(request types.SubscriptionRequest
 		done:     make(chan struct{}),
 		finished: make(chan struct{}),
 	}
+	sub.conn.EncodeOutbound = sub.encodeOutbound
 	r.ws.subscriptionManager.AddConnection(sub.conn)
 	go sub.run()
 	r.subs[request.URL] = sub
@@ -185,11 +187,13 @@ func (r *URLSubscriptionRegistry) Close() {
 // does — http or https only, default ports 80/443 — and returns the
 // normalised endpoint to POST events to. The invalidParams messages match
 // rippled's verbatim ("Failed to parse url." / "Only http and https is
-// supported.").
+// supported."). An empty host ("http://") is accepted, matching rippled's
+// parseUrl host group: registration succeeds and each delivery just fails
+// harmlessly at connect.
 func parseRPCSubURL(raw string) (string, *types.RpcError) {
 	parseErr := types.RpcErrorInvalidParams("Failed to parse url.")
 	u, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || u.Hostname() == "" {
+	if err != nil || u.Scheme == "" {
 		return "", parseErr
 	}
 	scheme := strings.ToLower(u.Scheme)
@@ -224,8 +228,33 @@ type rpcSub struct {
 	username string
 	password string
 
-	// seq numbers delivered events per url, starting at 1 (RPCSub::mSeq).
-	seq uint64
+	// seq numbers events per url, starting at 1 (RPCSub::mSeq). Stamped
+	// at enqueue, so a queue-limit drop still consumes a number and the
+	// remote sees a gap. Accessed from the broadcaster goroutine via
+	// encodeOutbound, hence atomic.
+	seq atomic.Uint64
+}
+
+// encodeOutbound stamps the next per-url sequence number into a broadcast
+// event before it is queued, mirroring rippled's mSeq++ at enqueue
+// (RPCSub::send). An undecodable event is queued unchanged so the delivery
+// goroutine logs and drops it. Returns a fresh slice — the input is shared
+// across subscribers and must not be mutated.
+func (s *rpcSub) encodeOutbound(data []byte) []byte {
+	var event map[string]any
+	if err := json.Unmarshal(data, &event); err != nil {
+		return data
+	}
+	event["seq"] = s.seq.Add(1)
+	body, err := json.Marshal(map[string]any{
+		"method": "event",
+		"params": event,
+		"id":     1,
+	})
+	if err != nil {
+		return data
+	}
+	return append(body, '\n')
 }
 
 func (s *rpcSub) updateCredentials(username string, usernameSet bool, password string, passwordSet bool) {
@@ -261,29 +290,12 @@ func (s *rpcSub) run() {
 	}
 }
 
-// deliver wraps one broadcast event in the JSON-RPC call rippled's RPCSub
-// emits — {"method":"event","params":{...,"seq":N},"id":1} — and POSTs it.
-// Failures are logged and dropped (fire-and-forget), like sendThread's
-// catch-and-log around RPCCall::fromNetwork.
-func (s *rpcSub) deliver(data []byte) {
-	var event map[string]any
-	if err := json.Unmarshal(data, &event); err != nil {
-		wsLog().Error("rpcsub: undecodable broadcast event", "url", s.endpoint, "err", err)
-		return
-	}
-	s.seq++
-	event["seq"] = s.seq
-	body, err := json.Marshal(map[string]any{
-		"method": "event",
-		"params": event,
-		"id":     1,
-	})
-	if err != nil {
-		wsLog().Error("rpcsub: event marshal failed", "url", s.endpoint, "err", err)
-		return
-	}
-	body = append(body, '\n')
-
+// deliver POSTs one already-encoded event — the JSON-RPC call rippled's
+// RPCSub emits, {"method":"event","params":{...,"seq":N},"id":1}, framed
+// by encodeOutbound at enqueue. Failures are logged and dropped
+// (fire-and-forget), like sendThread's catch-and-log around
+// RPCCall::fromNetwork.
+func (s *rpcSub) deliver(body []byte) {
 	req, err := http.NewRequestWithContext(s.ctx, http.MethodPost, s.endpoint, bytes.NewReader(body))
 	if err != nil {
 		wsLog().Error("rpcsub: request build failed", "url", s.endpoint, "err", err)
@@ -291,6 +303,8 @@ func (s *rpcSub) deliver(data []byte) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	// rippled posts with this fixed User-Agent (RPCCall::createHTTPPost).
+	req.Header.Set("User-Agent", "ripple-json-rpc/v1")
 	// rippled always sends basic auth, even with empty credentials.
 	username, password := s.credentials()
 	req.SetBasicAuth(username, password)

--- a/internal/rpc/rpcsub.go
+++ b/internal/rpc/rpcsub.go
@@ -1,0 +1,305 @@
+package rpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+const (
+	// rpcSubQueueLimit bounds the per-url outbound event queue. rippled
+	// buffers RPCSub events without limit; a bound keeps a dead or slow
+	// endpoint from growing memory indefinitely. Overflowing events are
+	// dropped by Connection.TrySend (the registry never installs a
+	// Disconnect callback, so a slow endpoint is throttled, not removed —
+	// rippled keeps retrying forever too).
+	rpcSubQueueLimit = 256
+
+	// rpcSubRequestTimeout matches rippled's RPC_WEBHOOK_TIMEOUT.
+	rpcSubRequestTimeout = 30 * time.Second
+)
+
+// URLSubscriptionRegistry implements rippled's url-based (RPCSub) admin
+// subscriptions: each url maps to one long-lived subscriber registered with
+// the shared subscription manager, so stream/account/book broadcasts fan
+// out to urls exactly like they do to WebSocket connections. A per-url
+// delivery goroutine drains the subscriber's queue and POSTs every event to
+// the url as a JSON-RPC "event" call with an injected per-url sequence
+// number and basic auth.
+type URLSubscriptionRegistry struct {
+	ws     *WebSocketServer
+	client *http.Client
+	// ctx cancels in-flight deliveries on Close so shutdown isn't held
+	// hostage by a stalled endpoint.
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu     sync.Mutex
+	subs   map[string]*rpcSub
+	closed bool
+}
+
+func newURLSubscriptionRegistry(ws *WebSocketServer) *URLSubscriptionRegistry {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &URLSubscriptionRegistry{
+		ws:     ws,
+		client: &http.Client{Timeout: rpcSubRequestTimeout},
+		ctx:    ctx,
+		cancel: cancel,
+		subs:   make(map[string]*rpcSub),
+	}
+}
+
+// Subscribe finds or creates the url's subscriber, applies the requested
+// streams/accounts/books to it, and returns the subscribe ack. Mirrors
+// doSubscribe's url branch: an unparseable url or unsupported scheme is
+// rpcINVALID_PARAMS; on reuse, credentials are only updated via the
+// deprecated username/password members. The caller has already verified the
+// admin role.
+func (r *URLSubscriptionRegistry) Subscribe(ctx *types.RpcContext, request types.SubscriptionRequest) (map[string]any, *types.RpcError) {
+	sub, rpcErr := r.findOrCreate(request)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	// Like rippled, a failing stream/account/book parse leaves the freshly
+	// created registry entry in place.
+	if rpcErr := r.ws.subscriptionManager.HandleSubscribe(sub.conn, request, true); rpcErr != nil {
+		return nil, rpcErr
+	}
+	return r.ws.buildSubscribeAck(ctx, request), nil
+}
+
+// Unsubscribe removes the listed streams/accounts/books from the url's
+// subscriber and drops the registry entry once no stream subscriptions
+// remain. An unknown url is silent success (Unsubscribe.cpp:52-53).
+func (r *URLSubscriptionRegistry) Unsubscribe(ctx *types.RpcContext, request types.SubscriptionRequest) (map[string]any, *types.RpcError) {
+	r.mu.Lock()
+	sub, ok := r.subs[request.URL]
+	r.mu.Unlock()
+	if !ok {
+		return map[string]any{}, nil
+	}
+	if rpcErr := r.ws.subscriptionManager.HandleUnsubscribe(sub.conn, request, true); rpcErr != nil {
+		return nil, rpcErr
+	}
+	r.tryRemove(request.URL)
+	return map[string]any{}, nil
+}
+
+func (r *URLSubscriptionRegistry) findOrCreate(request types.SubscriptionRequest) (*rpcSub, *types.RpcError) {
+	username, password, usernameSet, passwordSet := request.URLCredentials()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil, types.RpcErrorInternal("Internal error.")
+	}
+	if sub, ok := r.subs[request.URL]; ok {
+		// Credentials on an existing url subscription are only updated via
+		// the deprecated username/password members; url_username and
+		// url_password are ignored on reuse, exactly like doSubscribe.
+		sub.updateCredentials(username, usernameSet, password, passwordSet)
+		return sub, nil
+	}
+
+	endpoint, rpcErr := parseRPCSubURL(request.URL)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	sub := &rpcSub{
+		endpoint: endpoint,
+		client:   r.client,
+		ctx:      r.ctx,
+		username: username,
+		password: password,
+		conn: &types.Connection{
+			ID:            "rpcsub:" + request.URL,
+			Subscriptions: make(map[types.SubscriptionType]types.SubscriptionConfig),
+			SendChannel:   make(chan []byte, rpcSubQueueLimit),
+			CloseChannel:  make(chan struct{}),
+		},
+		done:     make(chan struct{}),
+		finished: make(chan struct{}),
+	}
+	r.ws.subscriptionManager.AddConnection(sub.conn)
+	go sub.run()
+	r.subs[request.URL] = sub
+	return sub, nil
+}
+
+// tryRemove drops the url's registry entry once it holds no stream
+// subscriptions, mirroring NetworkOPs::tryRemoveRpcSub. Account and book
+// subscriptions don't keep the entry alive: in rippled the registry holds
+// the only strong reference, so removal destroys the subscriber and its
+// remaining subscriptions with it — here the manager connection and the
+// delivery goroutine are torn down the same way.
+func (r *URLSubscriptionRegistry) tryRemove(rawURL string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	sub, ok := r.subs[rawURL]
+	if !ok {
+		return
+	}
+	if r.ws.subscriptionManager.HasStreamSubscriptions(sub.conn.ID) {
+		return
+	}
+	delete(r.subs, rawURL)
+	r.ws.subscriptionManager.RemoveConnection(sub.conn.ID)
+	sub.stop()
+}
+
+// Close stops every url subscription, cancelling in-flight deliveries, and
+// waits for the delivery goroutines to exit.
+func (r *URLSubscriptionRegistry) Close() {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	r.closed = true
+	subs := r.subs
+	r.subs = make(map[string]*rpcSub)
+	r.mu.Unlock()
+
+	r.cancel()
+	for _, sub := range subs {
+		r.ws.subscriptionManager.RemoveConnection(sub.conn.ID)
+		sub.stop()
+	}
+	for _, sub := range subs {
+		<-sub.finished
+	}
+}
+
+// parseRPCSubURL validates a subscription url the way RPCSub's constructor
+// does — http or https only, default ports 80/443 — and returns the
+// normalised endpoint to POST events to. The invalidParams messages match
+// rippled's verbatim ("Failed to parse url." / "Only http and https is
+// supported.").
+func parseRPCSubURL(raw string) (string, *types.RpcError) {
+	parseErr := types.RpcErrorInvalidParams("Failed to parse url.")
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Hostname() == "" {
+		return "", parseErr
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", types.RpcErrorInvalidParams("Only http and https is supported.")
+	}
+	port := u.Port()
+	if port == "" {
+		if scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	} else if n, err := strconv.Atoi(port); err != nil || n < 1 || n > 65535 {
+		return "", parseErr
+	}
+	return scheme + "://" + net.JoinHostPort(u.Hostname(), port) + u.RequestURI(), nil
+}
+
+// rpcSub is one url subscription: a subscription-manager connection whose
+// send channel is drained by a delivery goroutine POSTing each event to the
+// url, one at a time and in order, like RPCSub::sendThread.
+type rpcSub struct {
+	endpoint string
+	client   *http.Client
+	ctx      context.Context
+	conn     *types.Connection
+	done     chan struct{}
+	finished chan struct{}
+
+	credMu   sync.Mutex
+	username string
+	password string
+
+	// seq numbers delivered events per url, starting at 1 (RPCSub::mSeq).
+	seq uint64
+}
+
+func (s *rpcSub) updateCredentials(username string, usernameSet bool, password string, passwordSet bool) {
+	s.credMu.Lock()
+	defer s.credMu.Unlock()
+	if usernameSet {
+		s.username = username
+	}
+	if passwordSet {
+		s.password = password
+	}
+}
+
+func (s *rpcSub) credentials() (string, string) {
+	s.credMu.Lock()
+	defer s.credMu.Unlock()
+	return s.username, s.password
+}
+
+func (s *rpcSub) stop() {
+	close(s.done)
+}
+
+func (s *rpcSub) run() {
+	defer close(s.finished)
+	for {
+		select {
+		case data := <-s.conn.SendChannel:
+			s.deliver(data)
+		case <-s.done:
+			return
+		}
+	}
+}
+
+// deliver wraps one broadcast event in the JSON-RPC call rippled's RPCSub
+// emits — {"method":"event","params":{...,"seq":N},"id":1} — and POSTs it.
+// Failures are logged and dropped (fire-and-forget), like sendThread's
+// catch-and-log around RPCCall::fromNetwork.
+func (s *rpcSub) deliver(data []byte) {
+	var event map[string]any
+	if err := json.Unmarshal(data, &event); err != nil {
+		wsLog().Error("rpcsub: undecodable broadcast event", "url", s.endpoint, "err", err)
+		return
+	}
+	s.seq++
+	event["seq"] = s.seq
+	body, err := json.Marshal(map[string]any{
+		"method": "event",
+		"params": event,
+		"id":     1,
+	})
+	if err != nil {
+		wsLog().Error("rpcsub: event marshal failed", "url", s.endpoint, "err", err)
+		return
+	}
+	body = append(body, '\n')
+
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodPost, s.endpoint, bytes.NewReader(body))
+	if err != nil {
+		wsLog().Error("rpcsub: request build failed", "url", s.endpoint, "err", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	// rippled always sends basic auth, even with empty credentials.
+	username, password := s.credentials()
+	req.SetBasicAuth(username, password)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		wsLog().Info("rpcsub: event delivery failed", "url", s.endpoint, "err", err)
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -25,6 +25,7 @@ type rpcSubEvent struct {
 	Params        map[string]any `json:"params"`
 	ID            any            `json:"id"`
 	authorization string
+	userAgent     string
 }
 
 func newRPCSubSink(t *testing.T) *rpcSubSink {
@@ -37,6 +38,7 @@ func newRPCSubSink(t *testing.T) *rpcSubSink {
 			return
 		}
 		ev.authorization = r.Header.Get("Authorization")
+		ev.userAgent = r.Header.Get("User-Agent")
 		sink.received <- ev
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"result":{},"error":null,"id":1}`))
@@ -122,6 +124,8 @@ func TestRPCSub_DeliversEvents(t *testing.T) {
 	assert.Equal(t, float64(1), ev.Params["seq"], "sequence numbers start at 1")
 	// base64(":") — empty username and password.
 	assert.Equal(t, "Basic Og==", ev.authorization)
+	// rippled posts with this fixed User-Agent (createHTTPPost).
+	assert.Equal(t, "ripple-json-rpc/v1", ev.userAgent)
 
 	ws.GetSubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
 	assert.Equal(t, float64(2), sink.next(t).Params["seq"], "sequence increments per event")
@@ -129,6 +133,44 @@ func TestRPCSub_DeliversEvents(t *testing.T) {
 	// Streams the url is not subscribed to are not delivered.
 	ws.GetSubscriptionManager().BroadcastToStream(types.SubValidations, data, nil)
 	sink.expectNone(t)
+}
+
+// TestRPCSub_DroppedEventLeavesSeqGap proves the seq is stamped at enqueue
+// (mirroring rippled's mSeq++ in send): an event dropped by the bounded
+// queue still consumes a number, so the events that do land carry a visible
+// gap rather than a silently gapless sequence. Exercises the TrySend
+// chokepoint directly with a one-slot, undrained channel so the drop is
+// deterministic.
+func TestRPCSub_DroppedEventLeavesSeqGap(t *testing.T) {
+	sub := &rpcSub{}
+	conn := &types.Connection{
+		SendChannel:    make(chan []byte, 1),
+		EncodeOutbound: sub.encodeOutbound,
+	}
+
+	data, _ := json.Marshal(map[string]any{"type": "ledgerClosed"})
+
+	require.True(t, conn.TrySend(data), "first event fits the queue (seq 1)")
+	require.False(t, conn.TrySend(data), "queue full → event dropped (seq 2 consumed)")
+	require.False(t, conn.TrySend(data), "still full → dropped (seq 3 consumed)")
+
+	// Drain the one landed event: it carries seq 1.
+	landed := decodeRPCSubEnvelope(t, <-conn.SendChannel)
+	assert.Equal(t, float64(1), landed["seq"])
+
+	// The next event that fits now carries seq 4 — the gap (2,3) is visible.
+	require.True(t, conn.TrySend(data))
+	next := decodeRPCSubEnvelope(t, <-conn.SendChannel)
+	assert.Equal(t, float64(4), next["seq"], "dropped events leave a visible gap")
+}
+
+func decodeRPCSubEnvelope(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var env struct {
+		Params map[string]any `json:"params"`
+	}
+	require.NoError(t, json.Unmarshal(body, &env))
+	return env.Params
 }
 
 // TestRPCSub_BasicAuthCredentials checks url_username/url_password are sent
@@ -173,7 +215,6 @@ func TestRPCSub_URLValidation(t *testing.T) {
 	}{
 		{"unsupported scheme", `{"url":"ftp://example.com/events"}`, "Only http and https is supported."},
 		{"empty url member", `{"url":""}`, "Failed to parse url."},
-		{"no host", `{"url":"http://"}`, "Failed to parse url."},
 		{"port out of range", `{"url":"http://example.com:99999/x"}`, "Failed to parse url."},
 		{"not a url", `{"url":"::not a url::"}`, "Failed to parse url."},
 	}
@@ -187,6 +228,23 @@ func TestRPCSub_URLValidation(t *testing.T) {
 			assert.Equal(t, tc.message, rpcErr.Message)
 		})
 	}
+}
+
+// TestRPCSub_EmptyHostAcceptedAtSubscribe mirrors rippled's parseUrl host
+// group matching the empty string: "http://" registers successfully and a
+// delivery only fails (harmlessly) at connect time, fire-and-forget.
+func TestRPCSub_EmptyHostAcceptedAtSubscribe(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+
+	result, rpcErr := subscribeURL(t, services, `{"url":"http://","streams":["ledger"]}`)
+	require.Nil(t, rpcErr, "empty-host url must register, like rippled")
+	assert.NotNil(t, result)
+	assert.Equal(t, 1, ws.GetSubscriptionManager().ConnectionCount())
+
+	// A broadcast to the unconnectable endpoint must not panic or block —
+	// the delivery goroutine logs and drops it.
+	data, _ := json.Marshal(map[string]any{"type": "ledgerClosed"})
+	ws.GetSubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
 }
 
 // TestRPCSub_UnsubscribeRemovesEntry verifies the tryRemoveRpcSub
@@ -243,7 +301,9 @@ func TestRPCSub_AccountsDontBlockRemoval(t *testing.T) {
 }
 
 // TestRPCSub_SubscribeAckCarriesLedgerInfo verifies the url path returns
-// the same subscribe ack the WebSocket path builds.
+// the same subscribe ack the WebSocket path builds, including rippled's
+// field gating: network_id is always present (even 0) and fee_ref appears
+// only while XRPFees is disabled.
 func TestRPCSub_SubscribeAckCarriesLedgerInfo(t *testing.T) {
 	ws, services := newRPCSubTestServer(t)
 	ws.SetLedgerInfoProvider(stubLedgerInfoProvider{})
@@ -256,18 +316,41 @@ func TestRPCSub_SubscribeAckCarriesLedgerInfo(t *testing.T) {
 	assert.Equal(t, uint32(42), ack["ledger_index"])
 	assert.Equal(t, "ABCD", ack["ledger_hash"])
 	assert.Equal(t, uint64(10), ack["fee_base"])
+	// network_id is emitted unconditionally, even when zero.
+	require.Contains(t, ack, "network_id")
+	assert.Equal(t, uint32(0), ack["network_id"])
+	// XRPFees disabled → deprecated fee_ref present.
+	assert.Equal(t, uint64(10), ack["fee_ref"])
 }
 
-type stubLedgerInfoProvider struct{}
+// TestRPCSub_SubscribeAckOmitsFeeRefUnderXRPFees verifies fee_ref is dropped
+// from the ack once the XRPFees amendment is enabled, mirroring rippled's
+// subLedger gate.
+func TestRPCSub_SubscribeAckOmitsFeeRefUnderXRPFees(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	ws.SetLedgerInfoProvider(stubLedgerInfoProvider{xrpFees: true})
+	sink := newRPCSubSink(t)
 
-func (stubLedgerInfoProvider) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
+	result, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	ack, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, ack, "fee_ref", "fee_ref must be omitted while XRPFees is enabled")
+	require.Contains(t, ack, "network_id")
+}
+
+type stubLedgerInfoProvider struct{ xrpFees bool }
+
+func (s stubLedgerInfoProvider) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
 	return &types.LedgerSubscribeInfo{
-		LedgerIndex: 42,
-		LedgerHash:  "ABCD",
-		LedgerTime:  735000000,
-		FeeBase:     10,
-		ReserveBase: 10000000,
-		ReserveInc:  2000000,
+		LedgerIndex:    42,
+		LedgerHash:     "ABCD",
+		LedgerTime:     735000000,
+		FeeBase:        10,
+		FeeRef:         10,
+		ReserveBase:    10000000,
+		ReserveInc:     2000000,
+		XRPFeesEnabled: s.xrpFees,
 	}
 }
 

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -1,0 +1,323 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rpcSubSink is a loopback HTTP endpoint standing in for the remote
+// JSON-RPC server a url subscription delivers to.
+type rpcSubSink struct {
+	srv      *httptest.Server
+	received chan rpcSubEvent
+}
+
+type rpcSubEvent struct {
+	Method        string         `json:"method"`
+	Params        map[string]any `json:"params"`
+	ID            any            `json:"id"`
+	authorization string
+}
+
+func newRPCSubSink(t *testing.T) *rpcSubSink {
+	t.Helper()
+	sink := &rpcSubSink{received: make(chan rpcSubEvent, 16)}
+	sink.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ev rpcSubEvent
+		if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+			t.Errorf("sink: undecodable body: %v", err)
+			return
+		}
+		ev.authorization = r.Header.Get("Authorization")
+		sink.received <- ev
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":{},"error":null,"id":1}`))
+	}))
+	t.Cleanup(sink.srv.Close)
+	return sink
+}
+
+func (s *rpcSubSink) next(t *testing.T) rpcSubEvent {
+	t.Helper()
+	select {
+	case ev := <-s.received:
+		return ev
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for url subscription event")
+		return rpcSubEvent{}
+	}
+}
+
+func (s *rpcSubSink) expectNone(t *testing.T) {
+	t.Helper()
+	select {
+	case ev := <-s.received:
+		t.Fatalf("unexpected event delivered: %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// newRPCSubTestServer builds a WebSocket server whose service container
+// carries the url-subscription registry, plus admin/guest contexts for
+// driving the plain JSON-RPC handlers.
+func newRPCSubTestServer(t *testing.T) (*WebSocketServer, *types.ServiceContainer) {
+	t.Helper()
+	services := types.NewServiceContainer(nil)
+	ws := NewWebSocketServer(time.Second, services)
+	require.NotNil(t, services.URLSubscriptions, "NewWebSocketServer must expose the url registry")
+	return ws, services
+}
+
+func adminCtx(services *types.ServiceContainer) *types.RpcContext {
+	return &types.RpcContext{
+		Role:       types.RoleAdmin,
+		IsAdmin:    true,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+}
+
+func subscribeURL(t *testing.T, services *types.ServiceContainer, params string) (any, *types.RpcError) {
+	t.Helper()
+	method := &handlers.SubscribeMethod{}
+	return method.Handle(adminCtx(services), json.RawMessage(params))
+}
+
+func unsubscribeURL(t *testing.T, services *types.ServiceContainer, params string) (any, *types.RpcError) {
+	t.Helper()
+	method := &handlers.UnsubscribeMethod{}
+	return method.Handle(adminCtx(services), json.RawMessage(params))
+}
+
+// TestRPCSub_DeliversEvents covers the core RPCSub loop: an admin url
+// subscription receives broadcasts as outbound JSON-RPC "event" calls with
+// per-url sequence numbers starting at 1 and basic auth (sent even with
+// empty credentials, like rippled's createHTTPPost).
+func TestRPCSub_DeliversEvents(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+
+	result, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	assert.NotNil(t, result)
+
+	first := map[string]any{"type": "ledgerClosed", "ledger_index": float64(7)}
+	data, err := json.Marshal(first)
+	require.NoError(t, err)
+	ws.GetSubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+
+	ev := sink.next(t)
+	assert.Equal(t, "event", ev.Method)
+	assert.Equal(t, float64(1), ev.ID)
+	assert.Equal(t, "ledgerClosed", ev.Params["type"])
+	assert.Equal(t, float64(7), ev.Params["ledger_index"])
+	assert.Equal(t, float64(1), ev.Params["seq"], "sequence numbers start at 1")
+	// base64(":") — empty username and password.
+	assert.Equal(t, "Basic Og==", ev.authorization)
+
+	ws.GetSubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	assert.Equal(t, float64(2), sink.next(t).Params["seq"], "sequence increments per event")
+
+	// Streams the url is not subscribed to are not delivered.
+	ws.GetSubscriptionManager().BroadcastToStream(types.SubValidations, data, nil)
+	sink.expectNone(t)
+}
+
+// TestRPCSub_BasicAuthCredentials checks url_username/url_password are sent
+// as basic auth, and that on reuse only the deprecated username/password
+// members update credentials (doSubscribe's reuse branch ignores
+// url_username/url_password).
+func TestRPCSub_BasicAuthCredentials(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+	urlParam := `"url":"` + sink.srv.URL + `"`
+
+	_, rpcErr := subscribeURL(t, services,
+		`{`+urlParam+`,"url_username":"alice","url_password":"secret","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+
+	data, _ := json.Marshal(map[string]any{"type": "ledgerClosed"})
+	ws.GetSubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	// base64("alice:secret")
+	assert.Equal(t, "Basic YWxpY2U6c2VjcmV0", sink.next(t).authorization)
+
+	// url_username on an existing subscription is ignored.
+	_, rpcErr = subscribeURL(t, services, `{`+urlParam+`,"url_username":"mallory"}`)
+	require.Nil(t, rpcErr)
+	ws.GetSubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	assert.Equal(t, "Basic YWxpY2U6c2VjcmV0", sink.next(t).authorization)
+
+	// The deprecated username/password members do update credentials.
+	_, rpcErr = subscribeURL(t, services, `{`+urlParam+`,"username":"bob","password":"hunter2"}`)
+	require.Nil(t, rpcErr)
+	ws.GetSubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	// base64("bob:hunter2")
+	assert.Equal(t, "Basic Ym9iOmh1bnRlcjI=", sink.next(t).authorization)
+}
+
+// TestRPCSub_URLValidation mirrors RPCSub's constructor errors, surfaced as
+// rpcINVALID_PARAMS with rippled's exact messages.
+func TestRPCSub_URLValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  string
+		message string
+	}{
+		{"unsupported scheme", `{"url":"ftp://example.com/events"}`, "Only http and https is supported."},
+		{"empty url member", `{"url":""}`, "Failed to parse url."},
+		{"no host", `{"url":"http://"}`, "Failed to parse url."},
+		{"port out of range", `{"url":"http://example.com:99999/x"}`, "Failed to parse url."},
+		{"not a url", `{"url":"::not a url::"}`, "Failed to parse url."},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, services := newRPCSubTestServer(t)
+			result, rpcErr := subscribeURL(t, services, tc.params)
+			assert.Nil(t, result)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+			assert.Equal(t, tc.message, rpcErr.Message)
+		})
+	}
+}
+
+// TestRPCSub_UnsubscribeRemovesEntry verifies the tryRemoveRpcSub
+// semantics: the registry entry is dropped once no stream subscriptions
+// remain, and an unknown url unsubscribes as silent success.
+func TestRPCSub_UnsubscribeRemovesEntry(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+	urlParam := `"url":"` + sink.srv.URL + `"`
+
+	_, rpcErr := subscribeURL(t, services, `{`+urlParam+`,"streams":["ledger","transactions"]}`)
+	require.Nil(t, rpcErr)
+	assert.Equal(t, 1, ws.GetSubscriptionManager().ConnectionCount())
+
+	// A stream remains subscribed → entry kept.
+	_, rpcErr = unsubscribeURL(t, services, `{`+urlParam+`,"streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	assert.Equal(t, 1, ws.GetSubscriptionManager().ConnectionCount())
+	ws.urlSubs.mu.Lock()
+	assert.Len(t, ws.urlSubs.subs, 1)
+	ws.urlSubs.mu.Unlock()
+
+	// Last stream gone → entry and manager connection removed.
+	_, rpcErr = unsubscribeURL(t, services, `{`+urlParam+`,"streams":["transactions"]}`)
+	require.Nil(t, rpcErr)
+	assert.Equal(t, 0, ws.GetSubscriptionManager().ConnectionCount())
+	ws.urlSubs.mu.Lock()
+	assert.Empty(t, ws.urlSubs.subs)
+	ws.urlSubs.mu.Unlock()
+
+	// Unknown url is silent success (Unsubscribe.cpp:52-53).
+	result, rpcErr := unsubscribeURL(t, services, `{"url":"http://example.com/none","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	assert.Equal(t, map[string]any{}, result)
+}
+
+// TestRPCSub_AccountsDontBlockRemoval mirrors NetworkOPs::tryRemoveRpcSub
+// only scanning the stream maps: account subscriptions alone don't keep the
+// registry entry alive — like rippled, where dropping the registry's strong
+// reference destroys the subscriber, account subscriptions and all.
+func TestRPCSub_AccountsDontBlockRemoval(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+	urlParam := `"url":"` + sink.srv.URL + `"`
+
+	_, rpcErr := subscribeURL(t, services,
+		`{`+urlParam+`,"streams":["ledger"],"accounts":["rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"]}`)
+	require.Nil(t, rpcErr)
+
+	_, rpcErr = unsubscribeURL(t, services, `{`+urlParam+`,"streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	assert.Equal(t, 0, ws.GetSubscriptionManager().ConnectionCount(),
+		"entry must be removed when only account subscriptions remain")
+}
+
+// TestRPCSub_SubscribeAckCarriesLedgerInfo verifies the url path returns
+// the same subscribe ack the WebSocket path builds.
+func TestRPCSub_SubscribeAckCarriesLedgerInfo(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	ws.SetLedgerInfoProvider(stubLedgerInfoProvider{})
+	sink := newRPCSubSink(t)
+
+	result, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	ack, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, uint32(42), ack["ledger_index"])
+	assert.Equal(t, "ABCD", ack["ledger_hash"])
+	assert.Equal(t, uint64(10), ack["fee_base"])
+}
+
+type stubLedgerInfoProvider struct{}
+
+func (stubLedgerInfoProvider) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
+	return &types.LedgerSubscribeInfo{
+		LedgerIndex: 42,
+		LedgerHash:  "ABCD",
+		LedgerTime:  735000000,
+		FeeBase:     10,
+		ReserveBase: 10000000,
+		ReserveInc:  2000000,
+	}
+}
+
+// TestRPCSub_ReuseSharesSubscriber verifies the find-or-create semantics:
+// subscribing the same url twice extends one subscriber instead of creating
+// a second, so events are not duplicated.
+func TestRPCSub_ReuseSharesSubscriber(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+	urlParam := `"url":"` + sink.srv.URL + `"`
+
+	_, rpcErr := subscribeURL(t, services, `{`+urlParam+`,"streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	_, rpcErr = subscribeURL(t, services, `{`+urlParam+`,"streams":["validations"]}`)
+	require.Nil(t, rpcErr)
+	assert.Equal(t, 1, ws.GetSubscriptionManager().ConnectionCount())
+
+	data, _ := json.Marshal(map[string]any{"type": "ledgerClosed"})
+	ws.GetSubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	assert.Equal(t, float64(1), sink.next(t).Params["seq"])
+	sink.expectNone(t)
+}
+
+// TestRPCSub_MalformedStreamKeepsEntry mirrors doSubscribe creating the
+// registry entry before parsing streams: a bad stream name errors but the
+// url remains registered for reuse.
+func TestRPCSub_MalformedStreamKeepsEntry(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+
+	_, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["nonsense"]}`)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcSTREAM_MALFORMED, rpcErr.Code)
+	assert.Equal(t, 1, ws.GetSubscriptionManager().ConnectionCount(),
+		"failed stream parse leaves the freshly created url entry, like rippled")
+}
+
+// TestRPCSub_CloseStopsDelivery verifies registry shutdown through
+// WebSocketServer.Close tears down url subscriptions.
+func TestRPCSub_CloseStopsDelivery(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+
+	_, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+
+	require.NoError(t, ws.Close(t.Context()))
+	assert.Equal(t, 0, ws.GetSubscriptionManager().ConnectionCount())
+
+	data, _ := json.Marshal(map[string]any{"type": "ledgerClosed"})
+	ws.GetSubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	sink.expectNone(t)
+}

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -1713,9 +1713,8 @@ func TestSubscribeMixedStreamsAccountsAndBooks(t *testing.T) {
 	sm.RemoveConnection(conn.ID)
 }
 
-// URL (RPCSub) subscription tests live in rpcsub_test.go: the subscription
-// manager no longer carries url state — url requests are routed to the
-// URLSubscriptionRegistry before reaching it.
+// URL (RPCSub) subscription tests live in rpcsub_test.go: url requests are
+// routed to the URLSubscriptionRegistry before reaching the manager.
 
 // TestSubscribeBookBoth_AutoSubscribesReverse exercises the
 // `both:true` shorthand: the subscription manager should register both

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -1345,8 +1345,10 @@ func TestUnsubscribeMethodRequiresWebSocket(t *testing.T) {
 
 // TestSubscribeURLGating tests the url (RPCSub) branch gates over plain
 // JSON-RPC: rippled requires Role::ADMIN for url subscriptions
-// (Subscribe.cpp / Unsubscribe.cpp → rpcNO_PERMISSION); go-xrpl does not
-// implement RPCSub, so the admin case reports notSupported.
+// (Subscribe.cpp / Unsubscribe.cpp → rpcNO_PERMISSION). The admin cases
+// here run without a url-subscription service wired (no WebSocket server),
+// which reports notSupported; the full url path is covered in
+// rpcsub_test.go.
 func TestSubscribeURLGating(t *testing.T) {
 	params := json.RawMessage(`{"url": "http://localhost:8081/callback", "streams": ["ledger"]}`)
 
@@ -1711,78 +1713,9 @@ func TestSubscribeMixedStreamsAccountsAndBooks(t *testing.T) {
 	sm.RemoveConnection(conn.ID)
 }
 
-// URL Subscription Tests
-
-// TestSubscribeWithURL tests subscribing with URL callback
-func TestSubscribeWithURL(t *testing.T) {
-	sm := newTestSubscriptionManager()
-	conn := newTestConnection("test-conn-1")
-	sm.AddConnection(conn)
-
-	request := types.SubscriptionRequest{
-		Streams:     []types.SubscriptionType{types.SubLedger},
-		URL:         "http://localhost/events",
-		URLUsername: "admin",
-		URLPassword: "password",
-	}
-
-	err := sm.HandleSubscribe(conn, request, true)
-	require.Nil(t, err)
-
-	// Verify URL subscription is stored in the URLSubscription field
-	assert.Equal(t, "http://localhost/events", conn.URLSubscription, "URL subscription should be stored")
-
-	sm.RemoveConnection(conn.ID)
-}
-
-// TestUnsubscribeWithURL tests unsubscribing a URL callback
-func TestUnsubscribeWithURL(t *testing.T) {
-	sm := newTestSubscriptionManager()
-	conn := newTestConnection("test-conn-1")
-	sm.AddConnection(conn)
-
-	// Subscribe with URL
-	subscribeRequest := types.SubscriptionRequest{
-		URL: "http://localhost/events",
-	}
-	err := sm.HandleSubscribe(conn, subscribeRequest, true)
-	require.Nil(t, err)
-
-	require.Equal(t, "http://localhost/events", conn.URLSubscription)
-
-	// Unsubscribe URL
-	unsubscribeRequest := types.SubscriptionRequest{
-		URL: "http://localhost/events",
-	}
-	err = sm.HandleUnsubscribe(conn, unsubscribeRequest, true)
-	require.Nil(t, err)
-
-	assert.Equal(t, "", conn.URLSubscription, "URL subscription should be removed")
-
-	sm.RemoveConnection(conn.ID)
-}
-
-// TestSubscribeURL_NonAdmin verifies the noPermission gate on URL
-// subscriptions matches rippled Subscribe.cpp:50-53: non-admin callers
-// asking for a URL subscription get rpcNO_PERMISSION and no state is
-// stored on the connection.
-func TestSubscribeURL_NonAdmin(t *testing.T) {
-	sm := newTestSubscriptionManager()
-	conn := newTestConnection("test-conn-1")
-	sm.AddConnection(conn)
-
-	request := types.SubscriptionRequest{
-		Streams: []types.SubscriptionType{types.SubLedger},
-		URL:     "http://localhost/events",
-	}
-
-	err := sm.HandleSubscribe(conn, request, false)
-	require.NotNil(t, err)
-	assert.Equal(t, types.RpcNO_PERMISSION, err.Code)
-	assert.Empty(t, conn.URLSubscription, "URL subscription must not be stored when gate rejects")
-
-	sm.RemoveConnection(conn.ID)
-}
+// URL (RPCSub) subscription tests live in rpcsub_test.go: the subscription
+// manager no longer carries url state — url requests are routed to the
+// URLSubscriptionRegistry before reaching it.
 
 // TestSubscribeBookBoth_AutoSubscribesReverse exercises the
 // `both:true` shorthand: the subscription manager should register both

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -80,16 +80,14 @@ func (sm *Manager) RemoveConnection(connID string) {
 }
 
 // HandleSubscribe handles a subscribe request for a connection. The
-// caller passes its current role so we can mirror the admin-only gates
-// rippled applies to URL-style server-to-server subscriptions
-// (Subscribe.cpp:50-53) and to the peer_status stream
-// (Subscribe.cpp:161-166). Non-admin callers passing `url` or
-// requesting `peer_status` are rejected with rpcNO_PERMISSION.
+// caller passes its current role so we can mirror the admin-only gate
+// rippled applies to the peer_status stream (Subscribe.cpp:161-166);
+// non-admin callers requesting `peer_status` are rejected with
+// rpcNO_PERMISSION. The url (RPCSub) branch is resolved by the caller
+// before reaching the manager: url requests are routed to the
+// URLSubscriptionRegistry, whose per-url connection is what gets
+// subscribed here.
 func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
-	if request.URL != "" && !isAdmin {
-		return types.RpcErrorNoPermission("subscribe")
-	}
-
 	w := request.WireArrays()
 
 	sm.mu.Lock()
@@ -202,11 +200,6 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 				Books: normalised,
 			}
 		}
-	}
-
-	// Handle URL subscriptions
-	if request.URL != "" {
-		conn.URLSubscription = request.URL
 	}
 
 	return nil
@@ -512,16 +505,11 @@ func isValidDomainHex(domain string) bool {
 }
 
 // HandleUnsubscribe handles an unsubscribe request for a connection.
-// The caller supplies its current admin status so the URL-style gate
-// in Unsubscribe.cpp:46-48 is honored symmetrically with the subscribe
-// path. The deprecated `rt_transactions` stream name is normalised to
+// The deprecated `rt_transactions` stream name is normalised to
 // `transactions_proposed` so a client that subscribed with the alias
-// can also unsubscribe with the alias (Unsubscribe.cpp:88-93).
+// can also unsubscribe with the alias (Unsubscribe.cpp:88-93). Like
+// HandleSubscribe, the url (RPCSub) branch is resolved by the caller.
 func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
-	if request.URL != "" && !isAdmin {
-		return types.RpcErrorNoPermission("unsubscribe")
-	}
-
 	w := request.WireArrays()
 
 	sm.mu.Lock()
@@ -634,12 +622,26 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 		}
 	}
 
-	// Handle URL unsubscription
-	if request.URL != "" {
-		conn.URLSubscription = ""
-	}
-
 	return nil
+}
+
+// HasStreamSubscriptions reports whether the connection still holds any
+// stream subscription. Account and book subscriptions don't count — this
+// mirrors NetworkOPs::tryRemoveRpcSub, which only scans the stream maps
+// when deciding whether a url subscription's registry entry can be dropped.
+func (sm *Manager) HasStreamSubscriptions(connID string) bool {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	conn := sm.Connections[connID]
+	if conn == nil {
+		return false
+	}
+	for key := range conn.Subscriptions {
+		if validStreams[key] {
+			return true
+		}
+	}
+	return false
 }
 
 // BroadcastToStream sends a message to every connection subscribed to a

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -394,6 +394,30 @@ type ServiceContainer struct {
 	// wired — the handler then returns notEnabled, matching rippled's
 	// advisoryDelete() gate.
 	AdvisoryDeleteState AdvisoryDeleteStore
+
+	// URLSubscriptions backs rippled's url-based (RPCSub) admin
+	// subscriptions: subscribe/unsubscribe requests carrying a url are
+	// routed here instead of to a per-connection subscription. Populated by
+	// the WebSocket server, which owns the registry so url subscribers share
+	// the broadcast fan-out with WebSocket connections. Nil when no
+	// WebSocket server is wired — the handlers then report notSupported.
+	URLSubscriptions URLSubscriptionService
+}
+
+// URLSubscriptionService is the url-keyed subscription registry mirroring
+// rippled's RPCSub/mRpcSubMap: each url maps to one long-lived subscriber
+// whose events are delivered as outbound JSON-RPC "event" calls with per-url
+// sequence numbers and basic auth. Callers gate on role before invoking —
+// both methods are admin-only in rippled's handlers.
+type URLSubscriptionService interface {
+	// Subscribe registers (or extends) the url subscription and returns the
+	// same ack payload a WebSocket subscriber gets (current ledger info for
+	// the ledger stream, book snapshots).
+	Subscribe(ctx *RpcContext, request SubscriptionRequest) (map[string]any, *RpcError)
+	// Unsubscribe removes the listed streams/accounts/books from the url
+	// subscription and drops the registry entry once no stream
+	// subscriptions remain. An unknown url is silent success.
+	Unsubscribe(ctx *RpcContext, request SubscriptionRequest) (map[string]any, *RpcError)
 }
 
 // AdvisoryDeleteStore is the advisory-delete state facet backing the

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -522,6 +522,13 @@ type Connection struct {
 	// persistently slow client gets torn down once, in one place.
 	Disconnect func()
 
+	// EncodeOutbound, when set, transforms each event at the single
+	// enqueue point before it is queued. url (RPCSub) subscriptions use
+	// it to stamp the per-url sequence number at enqueue, mirroring
+	// rippled's mSeq++ in send(): a number is consumed even when the
+	// bounded queue then drops the event, so the remote sees a gap.
+	EncodeOutbound func([]byte) []byte
+
 	// consecutiveDrops counts back-to-back send failures. Reset to 0
 	// on every successful TrySend.
 	consecutiveDrops atomic.Int32
@@ -536,6 +543,9 @@ type Connection struct {
 func (c *Connection) TrySend(data []byte) bool {
 	if c == nil || c.SendChannel == nil {
 		return false
+	}
+	if c.EncodeOutbound != nil {
+		data = c.EncodeOutbound(data)
 	}
 	select {
 	case c.SendChannel <- data:
@@ -613,10 +623,10 @@ type LedgerInfoProvider interface {
 
 // LedgerSubscribeInfo contains ledger info returned in the subscribe
 // response for the `ledger` stream. Field set mirrors rippled's
-// subLedger ack at NetworkOPs.cpp:4174-4189 (ledger_index, ledger_hash,
-// ledger_time, fee_ref, fee_base, reserve_base, reserve_inc,
-// network_id, validated_ledgers). The per-ledger streamed event uses
-// LedgerCloseEvent and carries additional fields (txn_count, etc.).
+// subLedger ack (NetworkOPs::subLedger): fee_ref is emitted only when
+// the XRPFees amendment is disabled, and network_id is always present.
+// The per-ledger streamed event uses LedgerCloseEvent and carries
+// additional fields (txn_count, etc.).
 type LedgerSubscribeInfo struct {
 	LedgerIndex      uint32 `json:"ledger_index"`
 	LedgerHash       string `json:"ledger_hash"`
@@ -626,7 +636,10 @@ type LedgerSubscribeInfo struct {
 	ReserveBase      uint64 `json:"reserve_base"`
 	ReserveInc       uint64 `json:"reserve_inc"`
 	ValidatedLedgers string `json:"validated_ledgers,omitempty"`
-	NetworkID        uint32 `json:"network_id,omitempty"`
+	NetworkID        uint32 `json:"network_id"`
+	// XRPFeesEnabled gates fee_ref: rippled emits the deprecated fee_ref
+	// only while the XRPFees amendment is disabled.
+	XRPFeesEnabled bool `json:"-"`
 }
 
 // ServerSubscribeInfo contains server info returned when subscribing to server stream

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -261,6 +261,12 @@ type SubscriptionRequest struct {
 	URL              string             `json:"url,omitempty"`
 	URLUsername      string             `json:"url_username,omitempty"`
 	URLPassword      string             `json:"url_password,omitempty"`
+	// Username / Password are the deprecated aliases rippled still accepts
+	// for url_username / url_password. When present they take precedence,
+	// and they alone trigger credential updates on an already-registered
+	// url subscription (doSubscribe's reuse branch only checks them).
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
 
 	// wire holds the as-received JSON of the array-valued fields, captured at
 	// decode time. The typed slices above collapse the four shapes rippled
@@ -268,6 +274,8 @@ type SubscriptionRequest struct {
 	// array — into a single nil-or-empty slice, so the subscription manager
 	// reads wire to reproduce rippled's per-shape error codes. nil when the
 	// request was built directly in Go rather than decoded from the wire.
+	// url/username/password presence is captured too: rippled branches on
+	// isMember, so an empty-string url still selects the url branch.
 	wire *wireSubscriptionArrays
 }
 
@@ -276,6 +284,9 @@ type wireSubscriptionArrays struct {
 	accounts         json.RawMessage
 	accountsProposed json.RawMessage
 	books            json.RawMessage
+	url              json.RawMessage
+	username         json.RawMessage
+	password         json.RawMessage
 }
 
 // WireSubscriptionArrays exposes the raw JSON the wire carried for the
@@ -319,6 +330,9 @@ func (r *SubscriptionRequest) UnmarshalJSON(data []byte) error {
 		accounts:         m["accounts"],
 		accountsProposed: m["accounts_proposed"],
 		books:            m["books"],
+		url:              m["url"],
+		username:         m["username"],
+		password:         m["password"],
 	}
 	_ = json.Unmarshal(m["streams"], &r.Streams)
 	_ = json.Unmarshal(m["accounts"], &r.Accounts)
@@ -327,7 +341,43 @@ func (r *SubscriptionRequest) UnmarshalJSON(data []byte) error {
 	_ = json.Unmarshal(m["url"], &r.URL)
 	_ = json.Unmarshal(m["url_username"], &r.URLUsername)
 	_ = json.Unmarshal(m["url_password"], &r.URLPassword)
+	_ = json.Unmarshal(m["username"], &r.Username)
+	_ = json.Unmarshal(m["password"], &r.Password)
 	return nil
+}
+
+// HasURL reports whether the request selects rippled's url (RPCSub) branch.
+// For wire-decoded requests this is member presence — an empty-string url
+// still takes the branch (and then fails url parsing); for Go-built requests
+// a non-empty URL stands in for presence.
+func (r *SubscriptionRequest) HasURL() bool {
+	if r.wire != nil {
+		return r.wire.url != nil
+	}
+	return r.URL != ""
+}
+
+// URLCredentials resolves the basic-auth credentials for a url subscription
+// the way doSubscribe does: url_username / url_password, overridden by the
+// deprecated username / password members when present. usernameSet and
+// passwordSet report the deprecated members' presence — on an existing url
+// subscription only those trigger credential updates.
+func (r *SubscriptionRequest) URLCredentials() (username, password string, usernameSet, passwordSet bool) {
+	username, password = r.URLUsername, r.URLPassword
+	if r.wire != nil {
+		usernameSet = r.wire.username != nil
+		passwordSet = r.wire.password != nil
+	} else {
+		usernameSet = r.Username != ""
+		passwordSet = r.Password != ""
+	}
+	if usernameSet {
+		username = r.Username
+	}
+	if passwordSet {
+		password = r.Password
+	}
+	return username, password, usernameSet, passwordSet
 }
 
 // Book request for order book subscriptions
@@ -470,8 +520,7 @@ type Connection struct {
 	// Disconnect is invoked when MaxConsecutiveDrops is reached. The
 	// WS layer populates this with its per-conn cancel func so a
 	// persistently slow client gets torn down once, in one place.
-	Disconnect      func()
-	URLSubscription string // URL for server-to-server subscriptions
+	Disconnect func()
 
 	// consecutiveDrops counts back-to-back send failures. Reset to 0
 	// on every successful TrySend.

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -48,6 +48,7 @@ type WebSocketServer struct {
 	ledgerInfoProvider  types.LedgerInfoProvider
 	connLimiter         *ConnLimiter
 	services            *types.ServiceContainer
+	urlSubs             *URLSubscriptionRegistry
 	peerSource          atomic.Pointer[types.PeerSource]
 	loadTracker         *loadtrack.Tracker
 	// pingInterval is how often pingLoop sends a keepalive ping. Settable
@@ -117,7 +118,7 @@ func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer)
 	if services != nil && services.ClientLoad == nil {
 		services.ClientLoad = types.NewClientLoadShedder()
 	}
-	return &WebSocketServer{
+	ws := &WebSocketServer{
 		upgrader: websocket.Upgrader{
 			// Accept any Origin, deliberately matching rippled: its WS
 			// server never validates the Origin header — access control
@@ -135,6 +136,15 @@ func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer)
 		loadTracker:    loadtrack.New(),
 		pingInterval:   30 * time.Second,
 	}
+	// The url (RPCSub) registry lives on the WebSocket server because url
+	// subscribers share its subscription manager's broadcast fan-out.
+	// Exposing it through the service container lets the plain JSON-RPC
+	// subscribe/unsubscribe handlers reach it.
+	ws.urlSubs = newURLSubscriptionRegistry(ws)
+	if services != nil {
+		services.URLSubscriptions = ws.urlSubs
+	}
+	return ws
 }
 
 // SetLedgerInfoProvider sets the provider used to return current ledger info
@@ -398,6 +408,28 @@ func (ws *WebSocketServer) handleSubscribe(wsConn *WebSocketConnection, ctx *typ
 		}
 	}
 
+	// url requests are server-to-server (RPCSub) subscriptions: events go
+	// to the url's subscriber, not to this WebSocket connection.
+	if request.HasURL() {
+		if !ctx.IsAdmin {
+			ws.sendError(wsConn, types.RpcErrorNoPermission("subscribe"), cmd.ID)
+			return
+		}
+		result, rpcErr := ws.urlSubs.Subscribe(ctx, request)
+		if rpcErr != nil {
+			ws.sendError(wsConn, rpcErr, cmd.ID)
+			return
+		}
+		ws.sendResponse(wsConn, types.WebSocketResponse{
+			Type:       "response",
+			ID:         cmd.ID,
+			Status:     "success",
+			Result:     result,
+			ApiVersion: ctx.ApiVersion,
+		})
+		return
+	}
+
 	conn := &types.Connection{
 		ID:            wsConn.ID,
 		Subscriptions: wsConn.subscriptions,
@@ -409,70 +441,7 @@ func (ws *WebSocketServer) handleSubscribe(wsConn *WebSocketConnection, ctx *typ
 		return
 	}
 
-	// rippled returns current ledger info in the subscribe response when
-	// the ledger stream is among the requested streams.
-	result := make(map[string]any)
-
-	if slices.Contains(request.Streams, types.SubLedger) {
-		if ws.ledgerInfoProvider != nil {
-			info := ws.ledgerInfoProvider.GetCurrentLedgerInfo()
-			if info != nil {
-				// Subscribe ack field set mirrors rippled subLedger
-				// at NetworkOPs.cpp:4174-4189. Per-ledger pubLedger
-				// events (LedgerCloseEvent) carry txn_count separately.
-				result["ledger_index"] = info.LedgerIndex
-				result["ledger_hash"] = info.LedgerHash
-				result["ledger_time"] = info.LedgerTime
-				result["fee_base"] = info.FeeBase
-				result["fee_ref"] = info.FeeRef
-				result["reserve_base"] = info.ReserveBase
-				result["reserve_inc"] = info.ReserveInc
-				if info.NetworkID > 0 {
-					result["network_id"] = info.NetworkID
-				}
-				if info.ValidatedLedgers != "" {
-					result["validated_ledgers"] = info.ValidatedLedgers
-				}
-			}
-		}
-	}
-
-	// Synthetic book-offers snapshot for any `snapshot:true` book in the
-	// request. Mirrors rippled Subscribe.cpp:339-394: when snapshot is
-	// set, the response carries `offers` (or `bids`/`asks` if `both` is
-	// set) populated by NetworkOPs::getBookPage. Reuses the ledger
-	// service's GetBookOffers — the same code path the book_offers RPC
-	// uses — so the snapshot a subscriber gets in the ack is identical
-	// to what they would have read with a separate book_offers call.
-	for _, book := range request.Books {
-		if !book.Snapshot || ctx.Services == nil || ctx.Services.Ledger == nil {
-			continue
-		}
-		var takerGets, takerPays types.CurrencySpec
-		if err := json.Unmarshal(book.TakerGets, &takerGets); err != nil {
-			continue
-		}
-		if err := json.Unmarshal(book.TakerPays, &takerPays); err != nil {
-			continue
-		}
-		gets := types.Amount{Currency: takerGets.Currency, Issuer: takerGets.Issuer}
-		pays := types.Amount{Currency: takerPays.Currency, Issuer: takerPays.Issuer}
-		if book.Both {
-			bids, _ := ws.snapshotBook(ctx, gets, pays, book.Taker)
-			asks, _ := ws.snapshotBook(ctx, pays, gets, book.Taker)
-			if bids != nil {
-				result["bids"] = appendOffers(result["bids"], bids)
-			}
-			if asks != nil {
-				result["asks"] = appendOffers(result["asks"], asks)
-			}
-			continue
-		}
-		offers, _ := ws.snapshotBook(ctx, gets, pays, book.Taker)
-		if offers != nil {
-			result["offers"] = appendOffers(result["offers"], offers)
-		}
-	}
+	result := ws.buildSubscribeAck(ctx, request)
 
 	response := types.WebSocketResponse{
 		Type:       "response",
@@ -491,6 +460,27 @@ func (ws *WebSocketServer) handleUnsubscribe(wsConn *WebSocketConnection, ctx *t
 			ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid unsubscription parameters: "+err.Error()), cmd.ID)
 			return
 		}
+	}
+
+	// See handleSubscribe: url requests target the RPCSub registry.
+	if request.HasURL() {
+		if !ctx.IsAdmin {
+			ws.sendError(wsConn, types.RpcErrorNoPermission("unsubscribe"), cmd.ID)
+			return
+		}
+		result, rpcErr := ws.urlSubs.Unsubscribe(ctx, request)
+		if rpcErr != nil {
+			ws.sendError(wsConn, rpcErr, cmd.ID)
+			return
+		}
+		ws.sendResponse(wsConn, types.WebSocketResponse{
+			Type:       "response",
+			ID:         cmd.ID,
+			Status:     "success",
+			Result:     result,
+			ApiVersion: ctx.ApiVersion,
+		})
+		return
 	}
 
 	conn := &types.Connection{
@@ -856,6 +846,76 @@ func (ws *WebSocketServer) closeConnection(wsConn *WebSocketConnection) {
 	wsLog().Debug("WebSocket connection closed", "connID", wsConn.ID)
 }
 
+// buildSubscribeAck assembles the subscribe response payload shared by the
+// WebSocket and url (RPCSub) subscribe paths: current ledger info when the
+// ledger stream is among the requested streams, and a synthetic book-offers
+// snapshot for any `snapshot:true` book.
+//
+// The ledger ack field set mirrors rippled subLedger at
+// NetworkOPs.cpp:4174-4189; per-ledger pubLedger events (LedgerCloseEvent)
+// carry txn_count separately. The snapshot block mirrors rippled
+// Subscribe.cpp:339-394: when snapshot is set, the response carries `offers`
+// (or `bids`/`asks` if `both` is set) populated by NetworkOPs::getBookPage.
+// It reuses the ledger service's GetBookOffers — the same code path the
+// book_offers RPC uses — so the snapshot a subscriber gets in the ack is
+// identical to what they would have read with a separate book_offers call.
+func (ws *WebSocketServer) buildSubscribeAck(ctx *types.RpcContext, request types.SubscriptionRequest) map[string]any {
+	result := make(map[string]any)
+
+	if slices.Contains(request.Streams, types.SubLedger) {
+		if ws.ledgerInfoProvider != nil {
+			info := ws.ledgerInfoProvider.GetCurrentLedgerInfo()
+			if info != nil {
+				result["ledger_index"] = info.LedgerIndex
+				result["ledger_hash"] = info.LedgerHash
+				result["ledger_time"] = info.LedgerTime
+				result["fee_base"] = info.FeeBase
+				result["fee_ref"] = info.FeeRef
+				result["reserve_base"] = info.ReserveBase
+				result["reserve_inc"] = info.ReserveInc
+				if info.NetworkID > 0 {
+					result["network_id"] = info.NetworkID
+				}
+				if info.ValidatedLedgers != "" {
+					result["validated_ledgers"] = info.ValidatedLedgers
+				}
+			}
+		}
+	}
+
+	for _, book := range request.Books {
+		if !book.Snapshot || ctx.Services == nil || ctx.Services.Ledger == nil {
+			continue
+		}
+		var takerGets, takerPays types.CurrencySpec
+		if err := json.Unmarshal(book.TakerGets, &takerGets); err != nil {
+			continue
+		}
+		if err := json.Unmarshal(book.TakerPays, &takerPays); err != nil {
+			continue
+		}
+		gets := types.Amount{Currency: takerGets.Currency, Issuer: takerGets.Issuer}
+		pays := types.Amount{Currency: takerPays.Currency, Issuer: takerPays.Issuer}
+		if book.Both {
+			bids, _ := ws.snapshotBook(ctx, gets, pays, book.Taker)
+			asks, _ := ws.snapshotBook(ctx, pays, gets, book.Taker)
+			if bids != nil {
+				result["bids"] = appendOffers(result["bids"], bids)
+			}
+			if asks != nil {
+				result["asks"] = appendOffers(result["asks"], asks)
+			}
+			continue
+		}
+		offers, _ := ws.snapshotBook(ctx, gets, pays, book.Taker)
+		if offers != nil {
+			result["offers"] = appendOffers(result["offers"], offers)
+		}
+	}
+
+	return result
+}
+
 // snapshotBook is the WS-side shim around the LedgerService's
 // GetBookOffers. Returns the offers slice ready to embed in the
 // subscribe ack. Errors are squashed — a snapshot failure mustn't
@@ -953,10 +1013,11 @@ func (ws *WebSocketServer) GetSubscriptionManager() *subscription.Manager {
 	return ws.subscriptionManager
 }
 
-// Close gracefully closes all active WebSocket connections and waits for
-// all per-connection goroutines (read loop, send pump, ping loop) to exit.
-// The wait is bounded by ctx so a misbehaving handler cannot stall shutdown
-// indefinitely; if ctx expires first, Close returns ctx.Err().
+// Close gracefully closes all active WebSocket connections and url (RPCSub)
+// subscriptions, waiting for all per-connection goroutines (read loop, send
+// pump, ping loop) and url delivery loops to exit. The wait is bounded by
+// ctx so a misbehaving handler cannot stall shutdown indefinitely; if ctx
+// expires first, Close returns ctx.Err().
 func (ws *WebSocketServer) Close(ctx context.Context) error {
 	ws.connectionsMutex.Lock()
 	for _, conn := range ws.connections {
@@ -976,6 +1037,7 @@ func (ws *WebSocketServer) Close(ctx context.Context) error {
 	done := make(chan struct{})
 	go func() {
 		ws.wg.Wait()
+		ws.urlSubs.Close()
 		close(done)
 	}()
 	select {

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -851,9 +851,10 @@ func (ws *WebSocketServer) closeConnection(wsConn *WebSocketConnection) {
 // ledger stream is among the requested streams, and a synthetic book-offers
 // snapshot for any `snapshot:true` book.
 //
-// The ledger ack field set mirrors rippled subLedger at
-// NetworkOPs.cpp:4174-4189; per-ledger pubLedger events (LedgerCloseEvent)
-// carry txn_count separately. The snapshot block mirrors rippled
+// The ledger ack field set mirrors rippled subLedger: fee_ref only while
+// XRPFees is disabled, network_id always present; per-ledger pubLedger
+// events (LedgerCloseEvent) carry txn_count separately. The snapshot block
+// mirrors rippled
 // Subscribe.cpp:339-394: when snapshot is set, the response carries `offers`
 // (or `bids`/`asks` if `both` is set) populated by NetworkOPs::getBookPage.
 // It reuses the ledger service's GetBookOffers — the same code path the
@@ -870,12 +871,14 @@ func (ws *WebSocketServer) buildSubscribeAck(ctx *types.RpcContext, request type
 				result["ledger_hash"] = info.LedgerHash
 				result["ledger_time"] = info.LedgerTime
 				result["fee_base"] = info.FeeBase
-				result["fee_ref"] = info.FeeRef
+				// rippled emits the deprecated fee_ref only while XRPFees
+				// is disabled; network_id is always present.
+				if !info.XRPFeesEnabled {
+					result["fee_ref"] = info.FeeRef
+				}
 				result["reserve_base"] = info.ReserveBase
 				result["reserve_inc"] = info.ReserveInc
-				if info.NetworkID > 0 {
-					result["network_id"] = info.NetworkID
-				}
+				result["network_id"] = info.NetworkID
 				if info.ValidatedLedgers != "" {
 					result["validated_ledgers"] = info.ValidatedLedgers
 				}

--- a/tasks/conformance-audit.md
+++ b/tasks/conformance-audit.md
@@ -645,3 +645,21 @@ incremental reviews instead of re-reading rippled from scratch.
 - Files cleanup-only (Phase 0 skipped Phase 1): none — Phase 1 ran (all files protocol-bearing)
 - Cleanup commit: cf791839 (services.go: dropped implementation-inventory sentence from TxTablesProvider doc; ledger_adapter.go: UseTxTables doc reduced to interface marker; +3/-6). Kept: 3 call-site ordering comments (notEnabled-precedes-validation invariant + rippled cites), RequireTxTables/UseTxTables service docs, test parity-pin comments.
 - Notes: Branch 0 commits behind origin/main at finalize (no rebase needed). Worked in existing worktree goXRPL-worktrees/issue-829, clean tree throughout. Static gates green before and after both phases: just build, just vet, just lint (0 issues). Tests delegated to CI per finalize policy. Phase 1 made zero code edits (M1 pre-existing, left as PR-comment finding). POST-FINALIZE: user requested M1+N1 fixes → tx.go rejects transaction+ctid with invalidParams "Invalid parameters." (Tx.cpp:295-298 parity) + new TestTxMethodErrorValidation/Ambiguous case; tx_query.go UseTxTables drops the RLock (single-assignment field, matches sibling readers). Targeted tests + internal/ledger/service suite + build/vet/lint re-verified green.
+
+## 2026-06-10 — PR #838 — feat/issue-832-rpcsub-url-subscriptions
+- Rippled SHA at review: 1e89286a92
+- PR URL: https://github.com/LeJamon/go-xrpl/pull/838
+- Review comment: https://github.com/LeJamon/go-xrpl/pull/838#issuecomment-4672003904
+- Files reviewed (Phase 1):
+  - internal/rpc/rpcsub.go — 2 findings (M1 empty-host url rejected where rippled's parseUrl regex accepts it — Go stricter, admin-only surface, kept; N1 seq stamped at delivery not enqueue, so bounded-queue drops are gapless/undetectable), 0 blocking
+  - internal/rpc/handlers/subscribe.go — 0 findings (gating order/codes match doSubscribe url branch; live-verified)
+  - internal/rpc/handlers/unsubscribe.go — 0 findings (silent-success unknown url, Unsubscribe.cpp:51-53; live-verified)
+  - internal/rpc/subscription/manager.go — 0 findings (HasStreamSubscriptions mirrors tryRemoveRpcSub's stream-maps-only scan, NetworkOPs.cpp:4404-4422; url state fully removed, no stale readers)
+  - internal/rpc/types/types.go — 0 findings (HasURL member-presence = isMember semantics; URLCredentials deprecated-member precedence incl. clear-to-empty, Subscribe.cpp:56-69/:97-107)
+  - internal/rpc/types/services.go — 0 findings (URLSubscriptionService interface + container wiring)
+  - internal/rpc/websocket.go — 1 finding (M2 pre-existing, surfaced: buildSubscribeAck gates network_id on >0 and emits fee_ref unconditionally; rippled subLedger NetworkOPs.cpp:4182-4188 is the inverse — verbatim extraction, not a regression; follow-up candidate), 0 blocking
+  - internal/rpc/rpcsub_test.go, internal/rpc/subscribe_test.go — 0 findings (test parity ⊇ Subscribe_test.cpp:561-644 url cases + delivery/credentials/removal coverage rippled lacks)
+- Wire-shape verify pass: DRIVEN LIVE. Standalone node + capturing HTTP sink: subscribe ack (integer ledger fields), event delivery {"method":"event","params":{...,"seq":1},"id":1} with Basic auth (alice:secret → YWxpY2U6c2VjcmV0), seq 1→2 increment, error strings verbatim ("Only http and https is supported.", "Invalid parameters."), unsubscribe stops delivery, unknown-url unsubscribe silent success. Binary freshness strings-checked ("rpcsub:" literal) before probing.
+- Files cleanup-only (Phase 0 skipped Phase 1): none — Phase 1 ran (all 9 files protocol-bearing)
+- Cleanup commit: bfe1ddfb (subscribe_test.go: one temporal "no longer carries url state" cross-reference trimmed to a durable pointer; +2/-3). Everything else kept — PR comments are rippled-cited conformance rationale (queue-bound divergence note, member-presence semantics, credential reuse rules, registry placement).
+- Notes: Branch 3 commits behind origin/main at finalize (no rebase needed). Existing worktree goXRPL-worktrees/issue-832, clean tree throughout. Static gates green before and after both phases: just build, just vet, just lint (0 issues). Tests delegated to CI per finalize policy. Phase 1 made zero code edits (M1 intentional improvement; M2 pre-existing extraction).


### PR DESCRIPTION
## Summary
- Implements rippled's url-based (RPCSub) admin subscriptions, replacing the `notSupported` stub from #831: `subscribe`/`unsubscribe` with `url` (+ `url_username`/`url_password`, and the deprecated `username`/`password` aliases) now register a per-url subscriber whose events are delivered as outbound JSON-RPC `"event"` calls (`{"method":"event","params":{...,"seq":N},"id":1}`, seq from 1, basic auth always sent, 30s timeout — RPCSub.cpp / RPCCall::fromNetwork).
- The registry lives on the WebSocket server and registers each url as a connection in the shared subscription manager, so stream/account/book broadcasts fan out to urls exactly like to WS clients; it is exposed to the HTTP handlers via the service container. The subscribe ack/snapshot building (ledger info, book snapshots) is extracted out of the WS handler and shared with the url path, and the WS `subscribe`/`unsubscribe` commands route url requests to the same registry (matching doSubscribe, which takes the url branch regardless of transport).
- Mirrors rippled's edge semantics: find-or-create by url with credential updates on reuse only via the deprecated members; `Failed to parse url.` / `Only http and https is supported.` as `invalidParams`; unknown-url unsubscribe is silent success; registry entry only removed once no *stream* subscriptions remain (`NetworkOPs::tryRemoveRpcSub`); a failed stream parse still leaves the freshly created entry. Deliberate deviation: the per-url queue is bounded (256) instead of rippled's unbounded deque, and delivery is cancellable on shutdown.

## Test plan
- [x] `go test ./internal/rpc/... -race` — new `rpcsub_test.go` covers delivery + sequencing via a loopback HTTP sink, basic-auth (incl. empty-credential `Basic Og==` and the reuse-update quirk), url validation errors, unsubscribe removal semantics, accounts-don't-block-removal, ack payload, reuse/no-duplication, and shutdown
- [x] `go build ./...`, `just lint`, `go vet`

Fixes #832
