### PR TITLE
fix(tx): enforce per-tx field allowlist at parse — reject fields disallowed for the transaction type

### DIFF
--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -59,6 +59,19 @@ func ParseFromBinary(blob []byte) (Transaction, error) {
 		presentFields[key] = true
 	}
 
+	// Reject any codec-known field that is not allowed for this transaction
+	// type before the transaction can be applied, mirroring rippled's STTx
+	// template application. Without this a tx carrying a field disallowed for
+	// its type would be silently applied while rippled rejects it at
+	// deserialization, forking the ledger.
+	if typeName, ok := jsonMap["TransactionType"].(string); ok {
+		if txType, ok := TypeFromName(typeName); ok {
+			if err := checkTemplate(txType, presentFields); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	// Convert map to JSON bytes
 	jsonBytes, err := json.Marshal(jsonMap)
 	if err != nil {

--- a/internal/tx/template.go
+++ b/internal/tx/template.go
@@ -1,0 +1,444 @@
+package tx
+
+// fieldStyle classifies a templated field's presence requirement, mirroring
+// rippled's SOEStyle (soeREQUIRED / soeOPTIONAL / soeDEFAULT).
+type fieldStyle uint8
+
+const (
+	soeREQUIRED fieldStyle = iota
+	soeOPTIONAL
+	soeDEFAULT
+)
+
+// commonFields are the fields permitted on every transaction type, regardless
+// of the per-type template. They correspond to rippled's TxFormats commonFields
+// set that is merged into every transaction format.
+var commonFields = map[string]fieldStyle{
+	"TransactionType":    soeREQUIRED,
+	"Flags":              soeOPTIONAL,
+	"SourceTag":          soeOPTIONAL,
+	"Account":            soeREQUIRED,
+	"Sequence":           soeREQUIRED,
+	"PreviousTxnID":      soeOPTIONAL,
+	"LastLedgerSequence": soeOPTIONAL,
+	"AccountTxnID":       soeOPTIONAL,
+	"Fee":                soeREQUIRED,
+	"OperationLimit":     soeOPTIONAL,
+	"Memos":              soeOPTIONAL,
+	"SigningPubKey":      soeREQUIRED,
+	"TicketSequence":     soeOPTIONAL,
+	"TxnSignature":       soeOPTIONAL,
+	"Signers":            soeOPTIONAL,
+	"NetworkID":          soeOPTIONAL,
+	"Delegate":           soeOPTIONAL,
+}
+
+// txTemplates holds the per-transaction-type field allowlist (the unique fields
+// of each transaction format). A field is allowed on a transaction if it is in
+// commonFields or in this type's template; any other codec-known field is
+// rejected at parse time, matching rippled's applyTemplate which throws for a
+// field "found in disallowed location".
+var txTemplates = map[Type]map[string]fieldStyle{
+	TypePayment: {
+		"Destination":    soeREQUIRED,
+		"Amount":         soeREQUIRED,
+		"SendMax":        soeOPTIONAL,
+		"Paths":          soeDEFAULT,
+		"InvoiceID":      soeOPTIONAL,
+		"DestinationTag": soeOPTIONAL,
+		"DeliverMin":     soeOPTIONAL,
+		"CredentialIDs":  soeOPTIONAL,
+		"DomainID":       soeOPTIONAL,
+	},
+	TypeEscrowCreate: {
+		"Destination":    soeREQUIRED,
+		"Amount":         soeREQUIRED,
+		"Condition":      soeOPTIONAL,
+		"CancelAfter":    soeOPTIONAL,
+		"FinishAfter":    soeOPTIONAL,
+		"DestinationTag": soeOPTIONAL,
+	},
+	TypeEscrowFinish: {
+		"Owner":         soeREQUIRED,
+		"OfferSequence": soeREQUIRED,
+		"Fulfillment":   soeOPTIONAL,
+		"Condition":     soeOPTIONAL,
+		"CredentialIDs": soeOPTIONAL,
+	},
+	TypeAccountSet: {
+		"EmailHash":     soeOPTIONAL,
+		"WalletLocator": soeOPTIONAL,
+		"WalletSize":    soeOPTIONAL,
+		"MessageKey":    soeOPTIONAL,
+		"Domain":        soeOPTIONAL,
+		"TransferRate":  soeOPTIONAL,
+		"SetFlag":       soeOPTIONAL,
+		"ClearFlag":     soeOPTIONAL,
+		"TickSize":      soeOPTIONAL,
+		"NFTokenMinter": soeOPTIONAL,
+	},
+	TypeEscrowCancel: {
+		"Owner":         soeREQUIRED,
+		"OfferSequence": soeREQUIRED,
+	},
+	TypeRegularKeySet: {
+		"RegularKey": soeOPTIONAL,
+	},
+	TypeOfferCreate: {
+		"TakerPays":     soeREQUIRED,
+		"TakerGets":     soeREQUIRED,
+		"Expiration":    soeOPTIONAL,
+		"OfferSequence": soeOPTIONAL,
+		"DomainID":      soeOPTIONAL,
+	},
+	TypeOfferCancel: {
+		"OfferSequence": soeREQUIRED,
+	},
+	TypeTicketCreate: {
+		"TicketCount": soeREQUIRED,
+	},
+	TypeSignerListSet: {
+		"SignerQuorum":  soeREQUIRED,
+		"SignerEntries": soeOPTIONAL,
+	},
+	TypePaymentChannelCreate: {
+		"Destination":    soeREQUIRED,
+		"Amount":         soeREQUIRED,
+		"SettleDelay":    soeREQUIRED,
+		"PublicKey":      soeREQUIRED,
+		"CancelAfter":    soeOPTIONAL,
+		"DestinationTag": soeOPTIONAL,
+	},
+	TypePaymentChannelFund: {
+		"Channel":    soeREQUIRED,
+		"Amount":     soeREQUIRED,
+		"Expiration": soeOPTIONAL,
+	},
+	TypePaymentChannelClaim: {
+		"Channel":       soeREQUIRED,
+		"Amount":        soeOPTIONAL,
+		"Balance":       soeOPTIONAL,
+		"Signature":     soeOPTIONAL,
+		"PublicKey":     soeOPTIONAL,
+		"CredentialIDs": soeOPTIONAL,
+	},
+	TypeCheckCreate: {
+		"Destination":    soeREQUIRED,
+		"SendMax":        soeREQUIRED,
+		"Expiration":     soeOPTIONAL,
+		"DestinationTag": soeOPTIONAL,
+		"InvoiceID":      soeOPTIONAL,
+	},
+	TypeCheckCash: {
+		"CheckID":    soeREQUIRED,
+		"Amount":     soeOPTIONAL,
+		"DeliverMin": soeOPTIONAL,
+	},
+	TypeCheckCancel: {
+		"CheckID": soeREQUIRED,
+	},
+	TypeDepositPreauth: {
+		"Authorize":              soeOPTIONAL,
+		"Unauthorize":            soeOPTIONAL,
+		"AuthorizeCredentials":   soeOPTIONAL,
+		"UnauthorizeCredentials": soeOPTIONAL,
+	},
+	TypeTrustSet: {
+		"LimitAmount": soeOPTIONAL,
+		"QualityIn":   soeOPTIONAL,
+		"QualityOut":  soeOPTIONAL,
+	},
+	TypeAccountDelete: {
+		"Destination":    soeREQUIRED,
+		"DestinationTag": soeOPTIONAL,
+		"CredentialIDs":  soeOPTIONAL,
+	},
+	TypeNFTokenMint: {
+		"NFTokenTaxon": soeREQUIRED,
+		"TransferFee":  soeOPTIONAL,
+		"Issuer":       soeOPTIONAL,
+		"URI":          soeOPTIONAL,
+		"Amount":       soeOPTIONAL,
+		"Destination":  soeOPTIONAL,
+		"Expiration":   soeOPTIONAL,
+	},
+	TypeNFTokenBurn: {
+		"NFTokenID": soeREQUIRED,
+		"Owner":     soeOPTIONAL,
+	},
+	TypeNFTokenCreateOffer: {
+		"NFTokenID":   soeREQUIRED,
+		"Amount":      soeREQUIRED,
+		"Destination": soeOPTIONAL,
+		"Owner":       soeOPTIONAL,
+		"Expiration":  soeOPTIONAL,
+	},
+	TypeNFTokenCancelOffer: {
+		"NFTokenOffers": soeREQUIRED,
+	},
+	TypeNFTokenAcceptOffer: {
+		"NFTokenBuyOffer":  soeOPTIONAL,
+		"NFTokenSellOffer": soeOPTIONAL,
+		"NFTokenBrokerFee": soeOPTIONAL,
+	},
+	TypeClawback: {
+		"Amount": soeREQUIRED,
+		"Holder": soeOPTIONAL,
+	},
+	TypeAMMClawback: {
+		"Holder": soeREQUIRED,
+		"Asset":  soeREQUIRED,
+		"Asset2": soeREQUIRED,
+		"Amount": soeOPTIONAL,
+	},
+	TypeAMMCreate: {
+		"Amount":     soeREQUIRED,
+		"Amount2":    soeREQUIRED,
+		"TradingFee": soeREQUIRED,
+	},
+	TypeAMMDeposit: {
+		"Asset":      soeREQUIRED,
+		"Asset2":     soeREQUIRED,
+		"Amount":     soeOPTIONAL,
+		"Amount2":    soeOPTIONAL,
+		"EPrice":     soeOPTIONAL,
+		"LPTokenOut": soeOPTIONAL,
+		"TradingFee": soeOPTIONAL,
+	},
+	TypeAMMWithdraw: {
+		"Asset":     soeREQUIRED,
+		"Asset2":    soeREQUIRED,
+		"Amount":    soeOPTIONAL,
+		"Amount2":   soeOPTIONAL,
+		"EPrice":    soeOPTIONAL,
+		"LPTokenIn": soeOPTIONAL,
+	},
+	TypeAMMVote: {
+		"Asset":      soeREQUIRED,
+		"Asset2":     soeREQUIRED,
+		"TradingFee": soeREQUIRED,
+	},
+	TypeAMMBid: {
+		"Asset":        soeREQUIRED,
+		"Asset2":       soeREQUIRED,
+		"BidMin":       soeOPTIONAL,
+		"BidMax":       soeOPTIONAL,
+		"AuthAccounts": soeOPTIONAL,
+	},
+	TypeAMMDelete: {
+		"Asset":  soeREQUIRED,
+		"Asset2": soeREQUIRED,
+	},
+	TypeXChainCreateClaimID: {
+		"XChainBridge":     soeREQUIRED,
+		"SignatureReward":  soeREQUIRED,
+		"OtherChainSource": soeREQUIRED,
+	},
+	TypeXChainCommit: {
+		"XChainBridge":          soeREQUIRED,
+		"XChainClaimID":         soeREQUIRED,
+		"Amount":                soeREQUIRED,
+		"OtherChainDestination": soeOPTIONAL,
+	},
+	TypeXChainClaim: {
+		"XChainBridge":   soeREQUIRED,
+		"XChainClaimID":  soeREQUIRED,
+		"Destination":    soeREQUIRED,
+		"DestinationTag": soeOPTIONAL,
+		"Amount":         soeREQUIRED,
+	},
+	TypeXChainAccountCreateCommit: {
+		"XChainBridge":    soeREQUIRED,
+		"Destination":     soeREQUIRED,
+		"Amount":          soeREQUIRED,
+		"SignatureReward": soeREQUIRED,
+	},
+	TypeXChainAddClaimAttestation: {
+		"XChainBridge":             soeREQUIRED,
+		"AttestationSignerAccount": soeREQUIRED,
+		"PublicKey":                soeREQUIRED,
+		"Signature":                soeREQUIRED,
+		"OtherChainSource":         soeREQUIRED,
+		"Amount":                   soeREQUIRED,
+		"AttestationRewardAccount": soeREQUIRED,
+		"WasLockingChainSend":      soeREQUIRED,
+		"XChainClaimID":            soeREQUIRED,
+		"Destination":              soeOPTIONAL,
+	},
+	TypeXChainAddAccountCreateAttest: {
+		"XChainBridge":             soeREQUIRED,
+		"AttestationSignerAccount": soeREQUIRED,
+		"PublicKey":                soeREQUIRED,
+		"Signature":                soeREQUIRED,
+		"OtherChainSource":         soeREQUIRED,
+		"Amount":                   soeREQUIRED,
+		"AttestationRewardAccount": soeREQUIRED,
+		"WasLockingChainSend":      soeREQUIRED,
+		"XChainAccountCreateCount": soeREQUIRED,
+		"Destination":              soeREQUIRED,
+		"SignatureReward":          soeREQUIRED,
+	},
+	TypeXChainModifyBridge: {
+		"XChainBridge":           soeREQUIRED,
+		"SignatureReward":        soeOPTIONAL,
+		"MinAccountCreateAmount": soeOPTIONAL,
+	},
+	TypeXChainCreateBridge: {
+		"XChainBridge":           soeREQUIRED,
+		"SignatureReward":        soeREQUIRED,
+		"MinAccountCreateAmount": soeOPTIONAL,
+	},
+	TypeDIDSet: {
+		"DIDDocument": soeOPTIONAL,
+		"URI":         soeOPTIONAL,
+		"Data":        soeOPTIONAL,
+	},
+	TypeDIDDelete: {},
+	TypeOracleSet: {
+		"OracleDocumentID": soeREQUIRED,
+		"Provider":         soeOPTIONAL,
+		"URI":              soeOPTIONAL,
+		"AssetClass":       soeOPTIONAL,
+		"LastUpdateTime":   soeREQUIRED,
+		"PriceDataSeries":  soeREQUIRED,
+	},
+	TypeOracleDelete: {
+		"OracleDocumentID": soeREQUIRED,
+	},
+	TypeLedgerStateFix: {
+		"LedgerFixType": soeREQUIRED,
+		"Owner":         soeOPTIONAL,
+	},
+	TypeMPTokenIssuanceCreate: {
+		"AssetScale":      soeOPTIONAL,
+		"TransferFee":     soeOPTIONAL,
+		"MaximumAmount":   soeOPTIONAL,
+		"MPTokenMetadata": soeOPTIONAL,
+		"DomainID":        soeOPTIONAL,
+	},
+	TypeMPTokenIssuanceDestroy: {
+		"MPTokenIssuanceID": soeREQUIRED,
+	},
+	TypeMPTokenIssuanceSet: {
+		"MPTokenIssuanceID": soeREQUIRED,
+		"Holder":            soeOPTIONAL,
+		"DomainID":          soeOPTIONAL,
+	},
+	TypeMPTokenAuthorize: {
+		"MPTokenIssuanceID": soeREQUIRED,
+		"Holder":            soeOPTIONAL,
+	},
+	TypeCredentialCreate: {
+		"Subject":        soeREQUIRED,
+		"CredentialType": soeREQUIRED,
+		"Expiration":     soeOPTIONAL,
+		"URI":            soeOPTIONAL,
+	},
+	TypeCredentialAccept: {
+		"Issuer":         soeREQUIRED,
+		"CredentialType": soeREQUIRED,
+	},
+	TypeCredentialDelete: {
+		"Subject":        soeOPTIONAL,
+		"Issuer":         soeOPTIONAL,
+		"CredentialType": soeREQUIRED,
+	},
+	TypeNFTokenModify: {
+		"NFTokenID": soeREQUIRED,
+		"Owner":     soeOPTIONAL,
+		"URI":       soeOPTIONAL,
+	},
+	TypePermissionedDomainSet: {
+		"DomainID":            soeOPTIONAL,
+		"AcceptedCredentials": soeREQUIRED,
+	},
+	TypePermissionedDomainDelete: {
+		"DomainID": soeREQUIRED,
+	},
+	TypeDelegateSet: {
+		"Authorize":   soeREQUIRED,
+		"Permissions": soeREQUIRED,
+	},
+	TypeVaultCreate: {
+		"Asset":            soeREQUIRED,
+		"AssetsMaximum":    soeOPTIONAL,
+		"MPTokenMetadata":  soeOPTIONAL,
+		"DomainID":         soeOPTIONAL,
+		"WithdrawalPolicy": soeOPTIONAL,
+		"Data":             soeOPTIONAL,
+	},
+	TypeVaultSet: {
+		"VaultID":       soeREQUIRED,
+		"AssetsMaximum": soeOPTIONAL,
+		"DomainID":      soeOPTIONAL,
+		"Data":          soeOPTIONAL,
+	},
+	TypeVaultDelete: {
+		"VaultID": soeREQUIRED,
+	},
+	TypeVaultDeposit: {
+		"VaultID": soeREQUIRED,
+		"Amount":  soeREQUIRED,
+	},
+	TypeVaultWithdraw: {
+		"VaultID":        soeREQUIRED,
+		"Amount":         soeREQUIRED,
+		"Destination":    soeOPTIONAL,
+		"DestinationTag": soeOPTIONAL,
+	},
+	TypeVaultClawback: {
+		"VaultID": soeREQUIRED,
+		"Holder":  soeREQUIRED,
+		"Amount":  soeOPTIONAL,
+	},
+	TypeBatch: {
+		"RawTransactions": soeREQUIRED,
+		"BatchSigners":    soeOPTIONAL,
+	},
+	TypeAmendment: {
+		"LedgerSequence": soeREQUIRED,
+		"Amendment":      soeREQUIRED,
+	},
+	TypeFee: {
+		"LedgerSequence":        soeOPTIONAL,
+		"BaseFee":               soeOPTIONAL,
+		"ReferenceFeeUnits":     soeOPTIONAL,
+		"ReserveBase":           soeOPTIONAL,
+		"ReserveIncrement":      soeOPTIONAL,
+		"BaseFeeDrops":          soeOPTIONAL,
+		"ReserveBaseDrops":      soeOPTIONAL,
+		"ReserveIncrementDrops": soeOPTIONAL,
+	},
+	TypeUNLModify: {
+		"UNLModifyDisabling": soeREQUIRED,
+		"LedgerSequence":     soeREQUIRED,
+		"UNLModifyValidator": soeREQUIRED,
+	},
+}
+
+// checkTemplate enforces a transaction type's field allowlist on the set of
+// decoded field names, rejecting any codec-known field that is neither a common
+// field nor part of the type's template. This mirrors rippled's STTx template
+// application, which throws when a field is "found in disallowed location",
+// preventing such a transaction from ever reaching apply.
+//
+// fields holds the names of every field present in the decoded transaction.
+func checkTemplate(txType Type, fields map[string]bool) error {
+	template, ok := txTemplates[txType]
+	if !ok {
+		// Unknown / unregistered transaction type: no template to enforce.
+		// Type resolution is handled separately by the registry.
+		return nil
+	}
+	for name := range fields {
+		if _, ok := commonFields[name]; ok {
+			continue
+		}
+		if _, ok := template[name]; ok {
+			continue
+		}
+		return Errorf(TemMALFORMED,
+			"field %q is not allowed for transaction type %s", name, txType)
+	}
+	return nil
+}

--- a/internal/tx/template.go
+++ b/internal/tx/template.go
@@ -1,7 +1,6 @@
 package tx
 
-// fieldStyle classifies a templated field's presence requirement, mirroring
-// rippled's SOEStyle (soeREQUIRED / soeOPTIONAL / soeDEFAULT).
+// fieldStyle is a templated field's presence requirement (rippled's SOEStyle).
 type fieldStyle uint8
 
 const (
@@ -421,8 +420,6 @@ var txTemplates = map[Type]map[string]fieldStyle{
 // field nor part of the type's template. This mirrors rippled's STTx template
 // application, which throws when a field is "found in disallowed location",
 // preventing such a transaction from ever reaching apply.
-//
-// fields holds the names of every field present in the decoded transaction.
 func checkTemplate(txType Type, fields map[string]bool) error {
 	template, ok := txTemplates[txType]
 	if !ok {

--- a/internal/tx/template_registry_test.go
+++ b/internal/tx/template_registry_test.go
@@ -1,0 +1,54 @@
+package tx_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/all"
+)
+
+// TestParseFromBinary_EveryRegisteredTypeAcceptsCommonFields verifies that the
+// per-type field allowlist never rejects a transaction carrying only common
+// fields, for every transaction type registered with the engine. A registered
+// type missing a template entry, or a template that fails to admit the common
+// fields, would surface here as a spurious parse rejection.
+func TestParseFromBinary_EveryRegisteredTypeAcceptsCommonFields(t *testing.T) {
+	all.RegisterAll()
+
+	types := tx.SupportedTypes()
+	if len(types) == 0 {
+		t.Fatal("no transaction types registered")
+	}
+
+	for _, txType := range types {
+		t.Run(txType.String(), func(t *testing.T) {
+			fields := map[string]any{
+				"TransactionType": txType.String(),
+				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"Sequence":        uint32(1),
+				"Fee":             "10",
+				"SigningPubKey":   "",
+			}
+			hexStr, err := binarycodec.Encode(fields)
+			if err != nil {
+				t.Fatalf("encode %s: %v", txType, err)
+			}
+			blob, err := hex.DecodeString(hexStr)
+			if err != nil {
+				t.Fatalf("hex decode: %v", err)
+			}
+
+			// The minimal common-fields blob may still be rejected by the
+			// type's own Validate() for missing required fields, but it must
+			// never be rejected by the template allowlist for a disallowed
+			// field.
+			_, err = tx.ParseFromBinary(blob)
+			if err != nil && strings.Contains(err.Error(), "is not allowed for transaction type") {
+				t.Fatalf("common-fields blob spuriously rejected for %s: %v", txType, err)
+			}
+		})
+	}
+}

--- a/internal/tx/template_test.go
+++ b/internal/tx/template_test.go
@@ -1,0 +1,229 @@
+package tx
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+)
+
+// encodeTx encodes a field map into a binary transaction blob.
+func encodeTx(t *testing.T, fields map[string]any) []byte {
+	t.Helper()
+	hexStr, err := binarycodec.Encode(fields)
+	if err != nil {
+		t.Fatalf("binarycodec.Encode(%v): %v", fields, err)
+	}
+	blob, err := hex.DecodeString(hexStr)
+	if err != nil {
+		t.Fatalf("hex.DecodeString: %v", err)
+	}
+	return blob
+}
+
+const (
+	testAccount     = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	testDestination = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+)
+
+// baseCommon returns the common fields every transaction carries, so a tx blob
+// can be built by adding only the type-specific fields under test.
+func baseCommon(txType string) map[string]any {
+	return map[string]any{
+		"TransactionType": txType,
+		"Account":         testAccount,
+		"Sequence":        uint32(1),
+		"Fee":             "10",
+		"SigningPubKey":   "",
+	}
+}
+
+// TestParseFromBinary_DisallowedField verifies that a binary transaction
+// carrying a codec-known field that is not in its type's template is rejected
+// at parse, before it can be applied — matching rippled's STTx template
+// application ("found in disallowed location").
+func TestParseFromBinary_DisallowedField(t *testing.T) {
+	cases := []struct {
+		name          string
+		txType        string
+		disallowedKey string
+		disallowedVal any
+	}{
+		{
+			name:          "Payment carrying NFTokenID",
+			txType:        "Payment",
+			disallowedKey: "NFTokenID",
+			disallowedVal: "00000000000000000000000000000000000000000000000000000000DEADBEEF",
+		},
+		{
+			name:          "OfferCreate carrying Destination",
+			txType:        "OfferCreate",
+			disallowedKey: "Destination",
+			disallowedVal: testDestination,
+		},
+		{
+			name:          "AccountSet carrying Amount",
+			txType:        "AccountSet",
+			disallowedKey: "Amount",
+			disallowedVal: "1000000",
+		},
+		{
+			name:          "TrustSet carrying TakerPays",
+			txType:        "TrustSet",
+			disallowedKey: "TakerPays",
+			disallowedVal: "1000000",
+		},
+		{
+			name:          "EscrowFinish carrying Destination",
+			txType:        "EscrowFinish",
+			disallowedKey: "Destination",
+			disallowedVal: testDestination,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := baseCommon(tc.txType)
+			fields[tc.disallowedKey] = tc.disallowedVal
+			blob := encodeTx(t, fields)
+
+			_, err := ParseFromBinary(blob)
+			if err == nil {
+				t.Fatalf("expected parse to reject %s carrying %s, got nil error",
+					tc.txType, tc.disallowedKey)
+			}
+			re, ok := AsResultError(err)
+			if !ok {
+				t.Fatalf("expected a ResultError, got %T: %v", err, err)
+			}
+			if re.Code != TemMALFORMED {
+				t.Fatalf("expected TemMALFORMED, got %v: %v", re.Code, err)
+			}
+		})
+	}
+}
+
+// TestParseFromBinary_AllowedFields verifies that transactions carrying only
+// their own template fields plus the common fields parse successfully.
+func TestParseFromBinary_AllowedFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		fields map[string]any
+	}{
+		{
+			name: "Payment with template fields",
+			fields: func() map[string]any {
+				f := baseCommon("Payment")
+				f["Destination"] = testDestination
+				f["Amount"] = "1000000"
+				f["DestinationTag"] = uint32(42)
+				return f
+			}(),
+		},
+		{
+			name: "OfferCreate with template fields",
+			fields: func() map[string]any {
+				f := baseCommon("OfferCreate")
+				f["TakerPays"] = "1000000"
+				f["TakerGets"] = "2000000"
+				f["Expiration"] = uint32(100)
+				return f
+			}(),
+		},
+		{
+			name: "Payment with common optional fields",
+			fields: func() map[string]any {
+				f := baseCommon("Payment")
+				f["Destination"] = testDestination
+				f["Amount"] = "1000000"
+				f["SourceTag"] = uint32(7)
+				f["LastLedgerSequence"] = uint32(500)
+				f["Memos"] = []any{}
+				return f
+			}(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blob := encodeTx(t, tc.fields)
+			if _, err := ParseFromBinary(blob); err != nil {
+				t.Fatalf("expected parse to succeed, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestCheckTemplate_CommonFieldsAllowedForEveryType verifies that the field
+// allowlist never rejects a transaction that carries only common fields,
+// across every transaction type in the table. This guards against an omission
+// in a type's template that would spuriously reject otherwise-valid traffic.
+func TestCheckTemplate_CommonFieldsAllowedForEveryType(t *testing.T) {
+	present := make(map[string]bool, len(commonFields))
+	for name := range commonFields {
+		present[name] = true
+	}
+	for txType := range txTemplates {
+		if err := checkTemplate(txType, present); err != nil {
+			t.Errorf("common fields must be allowed for %s, got: %v", txType, err)
+		}
+	}
+}
+
+// TestCheckTemplate_PseudoTransactions verifies the pseudo-transaction templates
+// accept their own fields and reject foreign ones, so pseudo-tx handling is not
+// broken by the allowlist.
+func TestCheckTemplate_PseudoTransactions(t *testing.T) {
+	t.Run("EnableAmendment allowed", func(t *testing.T) {
+		present := map[string]bool{
+			"TransactionType": true,
+			"Account":         true,
+			"Sequence":        true,
+			"Fee":             true,
+			"SigningPubKey":   true,
+			"LedgerSequence":  true,
+			"Amendment":       true,
+		}
+		if err := checkTemplate(TypeAmendment, present); err != nil {
+			t.Fatalf("EnableAmendment fields must be allowed, got: %v", err)
+		}
+	})
+
+	t.Run("SetFee rejects foreign field", func(t *testing.T) {
+		present := map[string]bool{
+			"TransactionType": true,
+			"Account":         true,
+			"BaseFeeDrops":    true,
+			"Amount":          true, // not in SetFee template
+		}
+		err := checkTemplate(TypeFee, present)
+		if err == nil {
+			t.Fatal("SetFee carrying Amount must be rejected")
+		}
+		if re, ok := AsResultError(err); !ok || re.Code != TemMALFORMED {
+			t.Fatalf("expected TemMALFORMED, got: %v", err)
+		}
+	})
+
+	t.Run("UNLModify allowed", func(t *testing.T) {
+		present := map[string]bool{
+			"TransactionType":    true,
+			"Account":            true,
+			"UNLModifyDisabling": true,
+			"LedgerSequence":     true,
+			"UNLModifyValidator": true,
+		}
+		if err := checkTemplate(TypeUNLModify, present); err != nil {
+			t.Fatalf("UNLModify fields must be allowed, got: %v", err)
+		}
+	})
+}
+
+// TestCheckTemplate_UnknownTypeNotEnforced verifies that an unrecognized
+// transaction type is passed through without template enforcement (type
+// resolution is the registry's responsibility).
+func TestCheckTemplate_UnknownTypeNotEnforced(t *testing.T) {
+	if err := checkTemplate(TypeInvalid, map[string]bool{"Anything": true}); err != nil {
+		t.Fatalf("unknown type must not be template-enforced, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- goXRPL parsed transactions via `ParseFromBinary` → `FromJSON` with no per-type field template, so a binary tx whose fields are all codec-known but disallowed for its type (e.g. a Payment carrying `NFTokenID`) was silently accepted and **applied**, while rippled rejects it at STTx deserialization. If such a tx entered an agreed tx-set, goXRPL applied it and rippled skipped it — a direct ledger fork.
- Adds a table-driven per-transaction-type field allowlist (`internal/tx/template.go`): each transaction format's unique fields plus the common transaction fields, mirroring rippled's `TxFormats` commonFields merged into every format.
- Enforces the allowlist in `ParseFromBinary` before the transaction can be applied, mirroring rippled's `applyTemplate` "found in disallowed location" rejection. A disallowed field is rejected with a `temMALFORMED`-coded error, so the tx never reaches `Apply` — matching rippled, where it never deserializes into the applied set.
- The check no-ops for unknown/unregistered types (type resolution stays the registry's job) and leaves pseudo-transaction (EnableAmendment/SetFee/UNLModify) and Batch inner-transaction parsing intact — both carry only their own template fields plus common fields.

## Test plan
- [x] `just test-tx` — full transaction suite passes.
- [x] `just test-integration` — every package passes except `conformance`; its 242 pre-existing failures (Vault/XChain out-of-scope stubs, Batch open-ledger harness-gated, known Offer cases) are **byte-identical between `main` and this branch** (242 vs 242, zero diff in either direction). Zero occurrences of the new disallowed-field rejection in the conformance run, confirming no legitimate tx is rejected.
- [x] New tests (`internal/tx/template_test.go`, `internal/tx/template_registry_test.go`): a blob carrying a disallowed-but-codec-known field fails parse with `temMALFORMED` for several tx types; allowed/common fields parse; pseudo-tx templates accept their fields and reject foreign ones; and every registered tx type accepts a common-fields-only blob without spurious rejection.
- [x] `just lint` (0 issues), `go vet`, `gofmt`, `go build ./...` all clean.

Fixes #843