### PR TITLE
fix(amm,payment): enforce fixFrozenLPTokenTransfer — isLPTokenFrozen + checkFreeze AMM arm

### DIFF
--- a/internal/testing/amm/lp_token_frozen_test.go
+++ b/internal/testing/amm/lp_token_frozen_test.go
@@ -73,7 +73,6 @@ func lpFrozenEnv(t *testing.T, amendmentEnabled bool) *amm.AMMTestEnv {
 //     without it the send succeeds.
 func TestFrozenLP_DirectStep(t *testing.T) {
 	for _, enabled := range []bool{true, false} {
-		enabled := enabled
 		t.Run(label(enabled), func(t *testing.T) {
 			env := lpFrozenEnv(t, enabled)
 
@@ -111,7 +110,6 @@ func TestFrozenLP_DirectStep(t *testing.T) {
 //     not spending, LP tokens).
 func TestFrozenLP_OfferCreation(t *testing.T) {
 	for _, enabled := range []bool{true, false} {
-		enabled := enabled
 		t.Run(label(enabled), func(t *testing.T) {
 			env := lpFrozenEnv(t, enabled)
 
@@ -161,7 +159,6 @@ func TestFrozenLP_OfferCreation(t *testing.T) {
 // Reference: rippled testOfferCreation final block.
 func TestFrozenLP_OfferCreation_BuyAlwaysAllowed(t *testing.T) {
 	for _, enabled := range []bool{true, false} {
-		enabled := enabled
 		t.Run(label(enabled), func(t *testing.T) {
 			env := lpFrozenEnv(t, enabled)
 			env.FreezeTrustLine(env.GW, env.Carol, "USD")
@@ -188,7 +185,6 @@ func TestFrozenLP_OfferCreation_BuyAlwaysAllowed(t *testing.T) {
 //   - carol can always cash a check sent to her even while her USD is frozen.
 func TestFrozenLP_Check(t *testing.T) {
 	for _, enabled := range []bool{true, false} {
-		enabled := enabled
 		t.Run(label(enabled), func(t *testing.T) {
 			env := lpFrozenEnv(t, enabled)
 

--- a/internal/testing/amm/lp_token_frozen_test.go
+++ b/internal/testing/amm/lp_token_frozen_test.go
@@ -1,0 +1,238 @@
+// Assertive tests for the fixFrozenLPTokenTransfer amendment.
+//
+// Reference: rippled/src/test/app/LPTokenTransfer_test.cpp
+//
+// Each scenario is exercised with the amendment enabled (frozen underlying AMM
+// assets must zero LP-token funds / fail the payment step) and disabled (legacy
+// behaviour, frozen underlying assets are ignored for LP-token movement). The
+// test env enables every SupportedYes amendment by default, so the enabled arm
+// is the default; the disabled arm calls DisableFeature before Close().
+package amm_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/amm"
+	"github.com/LeJamon/go-xrpl/internal/testing/check"
+	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
+)
+
+const fixFrozenLPTokenTransfer = "fixFrozenLPTokenTransfer"
+
+// lpFrozenEnv builds an XRP/USD AMM with bob and carol as liquidity providers,
+// each holding 1,000,000 LP tokens, plus LP-token trust lines so LP tokens can
+// move by direct payment and offer. Mirrors the setup in rippled's
+// LPTokenTransfer_test.cpp testDirectStep/testBookStep.
+func lpFrozenEnv(t *testing.T, amendmentEnabled bool) *amm.AMMTestEnv {
+	t.Helper()
+	env := amm.NewAMMTestEnv(t)
+	if !amendmentEnabled {
+		env.DisableFeature(fixFrozenLPTokenTransfer)
+	}
+	env.FundWithIOUs(30000, 0)
+	env.TestEnv.FundAmount(env.Bob, uint64(jtx.XRP(30000)))
+	env.Trust(env.Bob, env.GW, "USD", 100000)
+	env.Close()
+	env.PayIOU(env.GW, env.Bob, "USD", 30000)
+	env.Close()
+
+	createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(10000), amm.IOUAmount(env.GW, "USD", 10000)).Build()
+	if r := env.Submit(createTx); !r.Success {
+		t.Fatalf("AMM create failed: %s - %s", r.Code, r.Message)
+	}
+	env.Close()
+
+	for _, lp := range []*jtx.Account{env.Carol, env.Bob} {
+		dep := amm.AMMDeposit(lp, amm.XRP(), env.USD).
+			LPTokenOut(amm.LPTokenAmount(env, amm.XRP(), env.USD, 1000000)).
+			LPToken().
+			Build()
+		if r := env.Submit(dep); !r.Success {
+			t.Fatalf("%s deposit failed: %s - %s", lp.Address, r.Code, r.Message)
+		}
+		env.Close()
+	}
+
+	// LP-token trust lines so the LP token can be received/sent by payment & offer.
+	for _, lp := range []*jtx.Account{env.Alice, env.Bob, env.Carol} {
+		tt := trustset.TrustSet(lp, env.LPTokenAmountFromLedger(amm.XRP(), env.USD, 2000000)).Build()
+		if r := env.Submit(tt); !r.Success {
+			t.Fatalf("%s LP-token trust set failed: %s - %s", lp.Address, r.Code, r.Message)
+		}
+	}
+	env.Close()
+	return env
+}
+
+// TestFrozenLP_DirectStep mirrors rippled LPTokenTransfer_test.cpp testDirectStep.
+//   - A frozen account can always RECEIVE LP tokens.
+//   - With the amendment, a frozen account can NOT SEND LP tokens (tecPATH_DRY);
+//     without it the send succeeds.
+func TestFrozenLP_DirectStep(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		enabled := enabled
+		t.Run(label(enabled), func(t *testing.T) {
+			env := lpFrozenEnv(t, enabled)
+
+			// Gateway freezes carol's USD.
+			env.FreezeTrustLine(env.GW, env.Carol, "USD")
+			env.Close()
+
+			lpAmt := env.LPTokenAmountFromLedger(amm.XRP(), env.USD, 5)
+
+			// bob can always send LP tokens to carol even though carol's USD is frozen.
+			if r := env.Submit(payment.PayIssued(env.Bob, env.Carol, lpAmt).Build()); !r.Success {
+				t.Fatalf("bob->carol (frozen receiver) should succeed, got %s", r.Code)
+			}
+			env.Close()
+
+			// carol sends LP tokens to bob while her USD is frozen.
+			r := env.Submit(payment.PayIssued(env.Carol, env.Bob, lpAmt).Build())
+			if enabled {
+				if r.Code != "tecPATH_DRY" {
+					t.Fatalf("with fix, frozen carol->bob must be tecPATH_DRY, got %s", r.Code)
+				}
+			} else {
+				if !r.Success {
+					t.Fatalf("without fix, frozen carol->bob must succeed, got %s", r.Code)
+				}
+			}
+		})
+	}
+}
+
+// TestFrozenLP_OfferCreation mirrors rippled testOfferCreation.
+//   - With the amendment, a frozen account can NOT create a sell offer for LP
+//     tokens (tecUNFUNDED_OFFER); without it the offer is created.
+//   - A buy offer for LP tokens can always be created (the account is acquiring,
+//     not spending, LP tokens).
+func TestFrozenLP_OfferCreation(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		enabled := enabled
+		t.Run(label(enabled), func(t *testing.T) {
+			env := lpFrozenEnv(t, enabled)
+
+			env.FreezeTrustLine(env.GW, env.Carol, "USD")
+			env.Close()
+
+			lpAmt := env.LPTokenAmountFromLedger(amm.XRP(), env.USD, 10)
+
+			// carol tries to create a passive offer SELLING LP tokens for XRP.
+			sellOffer := offerbuild.OfferCreate(env.Carol, amm.XRPAmount(10), lpAmt).Passive().Build()
+			r := env.Submit(sellOffer)
+			if enabled {
+				if r.Code != "tecUNFUNDED_OFFER" {
+					t.Fatalf("with fix, frozen carol sell offer must be tecUNFUNDED_OFFER, got %s", r.Code)
+				}
+				if got := len(env.AccountOffers(env.Carol)); got != 0 {
+					t.Fatalf("with fix, expected 0 carol offers, got %d", got)
+				}
+				env.Close()
+
+				// Unfreeze and retry: the offer is now created.
+				env.UnfreezeTrustLine(env.GW, env.Carol, "USD")
+				env.Close()
+				sellOffer2 := offerbuild.OfferCreate(env.Carol, amm.XRPAmount(10), lpAmt).Passive().Build()
+				if r := env.Submit(sellOffer2); !r.Success {
+					t.Fatalf("after unfreeze, carol sell offer must succeed, got %s", r.Code)
+				}
+				env.Close()
+				if got := len(env.AccountOffers(env.Carol)); got != 1 {
+					t.Fatalf("after unfreeze, expected 1 carol offer, got %d", got)
+				}
+			} else {
+				if !r.Success {
+					t.Fatalf("without fix, frozen carol sell offer must succeed, got %s", r.Code)
+				}
+				env.Close()
+				if got := len(env.AccountOffers(env.Carol)); got != 1 {
+					t.Fatalf("without fix, expected 1 carol offer, got %d", got)
+				}
+			}
+		})
+	}
+}
+
+// TestFrozenLP_OfferCreation_BuyAlwaysAllowed asserts a buy offer for LP tokens
+// is created even with the underlying asset frozen, for both amendment states.
+// Reference: rippled testOfferCreation final block.
+func TestFrozenLP_OfferCreation_BuyAlwaysAllowed(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		enabled := enabled
+		t.Run(label(enabled), func(t *testing.T) {
+			env := lpFrozenEnv(t, enabled)
+			env.FreezeTrustLine(env.GW, env.Carol, "USD")
+			env.Close()
+
+			lpAmt := env.LPTokenAmountFromLedger(amm.XRP(), env.USD, 10)
+			// carol BUYS LP tokens (pays XRP, receives LP tokens) — always allowed.
+			buyOffer := offerbuild.OfferCreate(env.Carol, lpAmt, amm.XRPAmount(5)).Passive().Build()
+			if r := env.Submit(buyOffer); !r.Success {
+				t.Fatalf("frozen carol buy offer must succeed, got %s", r.Code)
+			}
+			env.Close()
+			if got := len(env.AccountOffers(env.Carol)); got != 1 {
+				t.Fatalf("expected 1 carol buy offer, got %d", got)
+			}
+		})
+	}
+}
+
+// TestFrozenLP_Check mirrors rippled testCheck.
+//   - carol can always create a check funded with LP tokens whose underlying is frozen.
+//   - With the amendment, bob fails to cash that check (tecPATH_PARTIAL); without
+//     it the cash succeeds.
+//   - carol can always cash a check sent to her even while her USD is frozen.
+func TestFrozenLP_Check(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		enabled := enabled
+		t.Run(label(enabled), func(t *testing.T) {
+			env := lpFrozenEnv(t, enabled)
+
+			env.FreezeTrustLine(env.GW, env.Carol, "USD")
+			env.Close()
+
+			lpAmt := env.LPTokenAmountFromLedger(amm.XRP(), env.USD, 10)
+
+			// carol creates a check with LP tokens (her USD is frozen) — always allowed.
+			carolChkID := check.GetCheckID(env.Carol, env.TestEnv.Seq(env.Carol))
+			if r := env.Submit(check.CheckCreate(env.Carol, env.Bob, lpAmt).Build()); !r.Success {
+				t.Fatalf("carol check create must succeed, got %s", r.Code)
+			}
+			env.Close()
+
+			// bob cashes carol's check.
+			rCash := env.Submit(check.CheckCashAmount(env.Bob, carolChkID, lpAmt).Build())
+			if enabled {
+				if rCash.Code != "tecPATH_PARTIAL" {
+					t.Fatalf("with fix, bob cashing frozen-LP check must be tecPATH_PARTIAL, got %s", rCash.Code)
+				}
+			} else {
+				if !rCash.Success {
+					t.Fatalf("without fix, bob cashing frozen-LP check must succeed, got %s", rCash.Code)
+				}
+			}
+			env.Close()
+
+			// bob creates a check for carol; carol (frozen) can still RECEIVE LP tokens.
+			bobChkID := check.GetCheckID(env.Bob, env.TestEnv.Seq(env.Bob))
+			if r := env.Submit(check.CheckCreate(env.Bob, env.Carol, lpAmt).Build()); !r.Success {
+				t.Fatalf("bob check create must succeed, got %s", r.Code)
+			}
+			env.Close()
+			if r := env.Submit(check.CheckCashAmount(env.Carol, bobChkID, lpAmt).Build()); !r.Success {
+				t.Fatalf("frozen carol cashing a check (receiving LP) must succeed, got %s", r.Code)
+			}
+		})
+	}
+}
+
+func label(enabled bool) string {
+	if enabled {
+		return "amendment_enabled"
+	}
+	return "amendment_disabled"
+}

--- a/internal/tx/payment/step_direct.go
+++ b/internal/tx/payment/step_direct.go
@@ -1122,10 +1122,15 @@ func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) tx.Re
 	}
 
 	// 5. LP-token arm: a step toward an AMM pseudo-account (the LP-token issuer,
-	// i.e. dst) fails when the AMM's underlying assets are frozen for src.
+	// i.e. dst) fails when the AMM's underlying assets are frozen for src. An
+	// unresolvable AMM SLE is a corrupt-ledger invariant violation and yields
+	// tecINTERNAL, before the frozen test.
 	// Reference: rippled StepChecks.h:65-83.
 	if rules := view.Rules(); rules != nil && rules.Enabled(amendment.FeatureFixFrozenLPTokenTransfer) {
-		if frozen, isAMM := tx.LPTokenFrozenForIssuer(view, src, dst); isAMM && frozen {
+		switch tx.LPTokenFrozenForIssuer(view, src, dst) {
+		case tx.LPTokenAMMUnresolvable:
+			return tx.TecINTERNAL
+		case tx.LPTokenFrozen:
 			return tx.TerNO_LINE
 		}
 	}

--- a/internal/tx/payment/step_direct.go
+++ b/internal/tx/payment/step_direct.go
@@ -1,6 +1,7 @@
 package payment
 
 import (
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -1118,6 +1119,15 @@ func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) tx.Re
 	// Reference: rippled StepChecks.h:58-62
 	if (rs.Flags&state.LsfHighDeepFreeze) != 0 || (rs.Flags&state.LsfLowDeepFreeze) != 0 {
 		return tx.TerNO_LINE
+	}
+
+	// 5. LP-token arm: a step toward an AMM pseudo-account (the LP-token issuer,
+	// i.e. dst) fails when the AMM's underlying assets are frozen for src.
+	// Reference: rippled StepChecks.h:65-83.
+	if rules := view.Rules(); rules != nil && rules.Enabled(amendment.FeatureFixFrozenLPTokenTransfer) {
+		if frozen, isAMM := tx.LPTokenFrozenForIssuer(view, src, dst); isAMM && frozen {
+			return tx.TerNO_LINE
+		}
 	}
 
 	return tx.TesSUCCESS

--- a/internal/tx/utils.go
+++ b/internal/tx/utils.go
@@ -238,31 +238,58 @@ func issueFromField(field any) (Asset, bool) {
 	return asset, true
 }
 
+// LPTokenFreezeStatus reports the outcome of probing whether a token's issuer is
+// an AMM pseudo-account and, if so, whether its underlying pool assets are frozen
+// for the holder.
+type LPTokenFreezeStatus int
+
+const (
+	// LPTokenIssuerNotAMM means the issuer is not an AMM pseudo-account, so the
+	// LP-token freeze rules do not apply.
+	LPTokenIssuerNotAMM LPTokenFreezeStatus = iota
+	// LPTokenNotFrozen means the issuer is an AMM whose underlying assets are not
+	// frozen for the holder.
+	LPTokenNotFrozen
+	// LPTokenFrozen means the issuer is an AMM whose underlying assets are frozen
+	// for the holder.
+	LPTokenFrozen
+	// LPTokenAMMUnresolvable means the issuer carries sfAMMID but its AMM SLE
+	// cannot be read or decoded — a corrupt-ledger invariant violation. rippled's
+	// accountHolds zeroes funds here (`!sleAmm` → false); checkFreeze returns
+	// tecINTERNAL.
+	LPTokenAMMUnresolvable
+)
+
 // LPTokenFrozenForIssuer determines, for a token whose issuer is issuerID,
-// whether that issuer is an AMM pseudo-account (isAMM) and, if so, whether the
-// AMM's underlying assets are frozen for accountID (frozen). When the issuer is
-// an AMM pseudo-account but its AMM SLE cannot be resolved, frozen is reported
-// true, matching rippled's `!sleAmm` branch which zeroes the balance.
+// whether that issuer is an AMM pseudo-account and, if so, whether the AMM's
+// underlying assets are frozen for accountID. The missing/undecodable AMM SLE
+// case is reported distinctly (LPTokenAMMUnresolvable) so the accountHolds path
+// can treat it as zero funds while the checkFreeze path returns tecINTERNAL,
+// matching rippled exactly.
 // Callers must gate this on the fixFrozenLPTokenTransfer amendment.
-// Reference: rippled ledger/View.cpp accountHolds()/checkFreeze() LP-token arm.
-func LPTokenFrozenForIssuer(view LedgerView, accountID, issuerID [20]byte) (frozen, isAMM bool) {
+// Reference: rippled ledger/View.cpp accountHolds() / paths StepChecks.h
+// checkFreeze() LP-token arm.
+func LPTokenFrozenForIssuer(view LedgerView, accountID, issuerID [20]byte) LPTokenFreezeStatus {
 	acctData, err := view.Read(keylet.Account(issuerID))
 	if err != nil || acctData == nil {
-		return false, false
+		return LPTokenIssuerNotAMM
 	}
 	account, err := state.ParseAccountRoot(acctData)
 	if err != nil || !account.HasAMMID() {
-		return false, false
+		return LPTokenIssuerNotAMM
 	}
 	ammData, err := view.Read(keylet.AMMByID(account.AMMID))
 	if err != nil || ammData == nil {
-		return true, true
+		return LPTokenAMMUnresolvable
 	}
 	asset, asset2, ok := decodeAMMPoolAssets(ammData)
 	if !ok {
-		return true, true
+		return LPTokenAMMUnresolvable
 	}
-	return IsLPTokenFrozen(view, accountID, asset, asset2), true
+	if IsLPTokenFrozen(view, accountID, asset, asset2) {
+		return LPTokenFrozen
+	}
+	return LPTokenNotFrozen
 }
 
 // XRPLiquid returns the amount of XRP an account can spend (balance minus reserve).
@@ -325,9 +352,12 @@ func AccountFunds(view LedgerView, accountID [20]byte, amount Amount, fhZeroIfFr
 			return NewIssuedAmount(0, 0, amount.Currency, amount.Issuer)
 		}
 		// LP tokens count as zero funds when the underlying AMM assets are frozen.
+		// An unresolvable AMM SLE also zeroes funds here, mirroring rippled's
+		// `!sleAmm || isLPTokenFrozen(...)` → return false.
 		// Reference: rippled View.cpp accountHolds() lines 415-439.
 		if rules := view.Rules(); rules != nil && rules.Enabled(amendment.FeatureFixFrozenLPTokenTransfer) {
-			if frozen, isAMM := LPTokenFrozenForIssuer(view, accountID, issuerID); isAMM && frozen {
+			switch LPTokenFrozenForIssuer(view, accountID, issuerID) {
+			case LPTokenFrozen, LPTokenAMMUnresolvable:
 				return NewIssuedAmount(0, 0, amount.Currency, amount.Issuer)
 			}
 		}

--- a/internal/tx/utils.go
+++ b/internal/tx/utils.go
@@ -223,7 +223,6 @@ func decodeAMMPoolAssets(data []byte) (Asset, Asset, bool) {
 	return asset, asset2, true
 }
 
-// issueFromField converts a decoded binary-codec Issue map into a tx.Asset.
 func issueFromField(field any) (Asset, bool) {
 	m, ok := field.(map[string]any)
 	if !ok {

--- a/internal/tx/utils.go
+++ b/internal/tx/utils.go
@@ -1,8 +1,11 @@
 package tx
 
 import (
+	"encoding/hex"
 	"strconv"
 
+	"github.com/LeJamon/go-xrpl/amendment"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -172,6 +175,97 @@ func IsDeepFrozen(view LedgerView, accountID, issuerID [20]byte, currency string
 	return (rs.Flags & (state.LsfLowDeepFreeze | state.LsfHighDeepFreeze)) != 0
 }
 
+// isFrozenForLPToken reports whether account cannot spend the given asset because
+// the issuer globally froze it or individually froze the account's trust line.
+// This is the IOU overload of rippled's isFrozen (global freeze + issuer-side
+// individual freeze); deep freeze is intentionally not consulted, matching the
+// overload used by isLPTokenFrozen.
+// Reference: rippled ledger/View.cpp isFrozen().
+func isFrozenForLPToken(view LedgerView, accountID [20]byte, asset Asset) bool {
+	if asset.Currency == "" || asset.Currency == "XRP" {
+		return false
+	}
+	issuerID, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
+		return false
+	}
+	if accountID == issuerID {
+		return false
+	}
+	if IsGlobalFrozen(view, asset.Issuer) {
+		return true
+	}
+	return IsTrustlineFrozen(view, accountID, issuerID, asset.Currency)
+}
+
+// IsLPTokenFrozen reports whether either of an AMM pool's underlying assets is
+// frozen for the holder, in which case the holder's LP tokens must count as zero
+// funds. The caller resolves the pool assets from the LP-token issuer's AMM SLE.
+// Reference: rippled ledger/View.cpp isLPTokenFrozen().
+func IsLPTokenFrozen(view LedgerView, accountID [20]byte, asset, asset2 Asset) bool {
+	return isFrozenForLPToken(view, accountID, asset) ||
+		isFrozenForLPToken(view, accountID, asset2)
+}
+
+// decodeAMMPoolAssets extracts the sfAsset and sfAsset2 issues from a serialized
+// AMM ledger entry without depending on the amm package (which would form an
+// import cycle).
+func decodeAMMPoolAssets(data []byte) (Asset, Asset, bool) {
+	fields, err := binarycodec.Decode(hex.EncodeToString(data))
+	if err != nil {
+		return Asset{}, Asset{}, false
+	}
+	asset, ok1 := issueFromField(fields["Asset"])
+	asset2, ok2 := issueFromField(fields["Asset2"])
+	if !ok1 || !ok2 {
+		return Asset{}, Asset{}, false
+	}
+	return asset, asset2, true
+}
+
+// issueFromField converts a decoded binary-codec Issue map into a tx.Asset.
+func issueFromField(field any) (Asset, bool) {
+	m, ok := field.(map[string]any)
+	if !ok {
+		return Asset{}, false
+	}
+	asset := Asset{}
+	if currency, ok := m["currency"].(string); ok {
+		asset.Currency = currency
+	}
+	if issuer, ok := m["issuer"].(string); ok {
+		asset.Issuer = issuer
+	}
+	return asset, true
+}
+
+// LPTokenFrozenForIssuer determines, for a token whose issuer is issuerID,
+// whether that issuer is an AMM pseudo-account (isAMM) and, if so, whether the
+// AMM's underlying assets are frozen for accountID (frozen). When the issuer is
+// an AMM pseudo-account but its AMM SLE cannot be resolved, frozen is reported
+// true, matching rippled's `!sleAmm` branch which zeroes the balance.
+// Callers must gate this on the fixFrozenLPTokenTransfer amendment.
+// Reference: rippled ledger/View.cpp accountHolds()/checkFreeze() LP-token arm.
+func LPTokenFrozenForIssuer(view LedgerView, accountID, issuerID [20]byte) (frozen, isAMM bool) {
+	acctData, err := view.Read(keylet.Account(issuerID))
+	if err != nil || acctData == nil {
+		return false, false
+	}
+	account, err := state.ParseAccountRoot(acctData)
+	if err != nil || !account.HasAMMID() {
+		return false, false
+	}
+	ammData, err := view.Read(keylet.AMMByID(account.AMMID))
+	if err != nil || ammData == nil {
+		return true, true
+	}
+	asset, asset2, ok := decodeAMMPoolAssets(ammData)
+	if !ok {
+		return true, true
+	}
+	return IsLPTokenFrozen(view, accountID, asset, asset2), true
+}
+
 // XRPLiquid returns the amount of XRP an account can spend (balance minus reserve).
 // Reference: rippled ledger/View.cpp xrpLiquid()
 // ownerCountAdj allows adjusting the owner count (e.g., +1 to account for a pending new object).
@@ -230,6 +324,13 @@ func AccountFunds(view LedgerView, accountID [20]byte, amount Amount, fhZeroIfFr
 		// Check deep freeze — either side of the trust line can deep-freeze it
 		if IsDeepFrozen(view, accountID, issuerID, amount.Currency) {
 			return NewIssuedAmount(0, 0, amount.Currency, amount.Issuer)
+		}
+		// LP tokens count as zero funds when the underlying AMM assets are frozen.
+		// Reference: rippled View.cpp accountHolds() lines 415-439.
+		if rules := view.Rules(); rules != nil && rules.Enabled(amendment.FeatureFixFrozenLPTokenTransfer) {
+			if frozen, isAMM := LPTokenFrozenForIssuer(view, accountID, issuerID); isAMM && frozen {
+				return NewIssuedAmount(0, 0, amount.Currency, amount.Issuer)
+			}
 		}
 	}
 

--- a/internal/tx/utils_test.go
+++ b/internal/tx/utils_test.go
@@ -1,0 +1,90 @@
+package tx
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// TestLPTokenFrozenForIssuer_AMMUnresolvable covers the corrupt-ledger arm: an
+// issuer AccountRoot carrying sfAMMID whose referenced AMM SLE is absent. rippled
+// returns tecINTERNAL from checkFreeze here (StepChecks.h:71-72, LCOV_EXCL_LINE)
+// and zeroes funds in accountHolds (View.cpp:429-431). The status must therefore
+// be reported distinctly so the two call sites can diverge.
+func TestLPTokenFrozenForIssuer_AMMUnresolvable(t *testing.T) {
+	var issuer [20]byte
+	issuer[0] = 0xAA
+	var holder [20]byte
+	holder[0] = 0xBB
+
+	issuerAddr, err := state.EncodeAccountID(issuer)
+	if err != nil {
+		t.Fatalf("EncodeAccountID: %v", err)
+	}
+
+	var ammID [32]byte
+	ammID[0] = 0xCC // non-zero so HasAMMID() is true
+
+	acct := &state.AccountRoot{
+		Account: issuerAddr,
+		Balance: 1_000_000,
+		AMMID:   ammID,
+	}
+	acctData, err := state.SerializeAccountRoot(acct)
+	if err != nil {
+		t.Fatalf("SerializeAccountRoot: %v", err)
+	}
+
+	view := newMockBaseView()
+	view.data[keylet.Account(issuer).Key] = acctData
+	// Deliberately do NOT store keylet.AMMByID(ammID): the AMM SLE is missing.
+
+	if got := LPTokenFrozenForIssuer(view, holder, issuer); got != LPTokenAMMUnresolvable {
+		t.Fatalf("LPTokenFrozenForIssuer with missing AMM SLE = %v, want LPTokenAMMUnresolvable", got)
+	}
+}
+
+// TestLPTokenFrozenForIssuer_NotAMM confirms a plain (non-AMM) issuer reports
+// LPTokenIssuerNotAMM, leaving the freeze fast-path untouched.
+func TestLPTokenFrozenForIssuer_NotAMM(t *testing.T) {
+	var issuer [20]byte
+	issuer[0] = 0x11
+	var holder [20]byte
+	holder[0] = 0x22
+
+	issuerAddr, err := state.EncodeAccountID(issuer)
+	if err != nil {
+		t.Fatalf("EncodeAccountID: %v", err)
+	}
+
+	acct := &state.AccountRoot{
+		Account: issuerAddr,
+		Balance: 1_000_000,
+	}
+	acctData, err := state.SerializeAccountRoot(acct)
+	if err != nil {
+		t.Fatalf("SerializeAccountRoot: %v", err)
+	}
+
+	view := newMockBaseView()
+	view.data[keylet.Account(issuer).Key] = acctData
+
+	if got := LPTokenFrozenForIssuer(view, holder, issuer); got != LPTokenIssuerNotAMM {
+		t.Fatalf("LPTokenFrozenForIssuer for non-AMM issuer = %v, want LPTokenIssuerNotAMM", got)
+	}
+}
+
+// TestLPTokenFrozenForIssuer_MissingIssuer confirms a missing issuer AccountRoot
+// reports LPTokenIssuerNotAMM (rippled's `!sleIssuer` / no sleDst path).
+func TestLPTokenFrozenForIssuer_MissingIssuer(t *testing.T) {
+	var issuer [20]byte
+	issuer[0] = 0x33
+	var holder [20]byte
+	holder[0] = 0x44
+
+	view := newMockBaseView()
+	if got := LPTokenFrozenForIssuer(view, holder, issuer); got != LPTokenIssuerNotAMM {
+		t.Fatalf("LPTokenFrozenForIssuer for missing issuer = %v, want LPTokenIssuerNotAMM", got)
+	}
+}


### PR DESCRIPTION
## Summary

`fixFrozenLPTokenTransfer` was registered (`amendment/registry.go:44`) but enforced **nowhere**, so a Payment/Offer/Check moving LP tokens whose underlying AMM assets are frozen succeeded in go-xrpl where rippled fails it (zero funds / `terNO_LINE`) — a touchable mainnet ledger-fork path.

This wires the amendment into the two enforcement points rippled gates on it:

- **`AccountFunds` (accountHolds zero-if-frozen)** — `internal/tx/utils.go`. When the asset is an AMM LP token (issuer AccountRoot carries `sfAMMID`), load the AMM SLE and zero the funds if either pool asset is frozen for the holder. Mirrors rippled `View.cpp:415-439` / `isLPTokenFrozen` at `View.cpp:374`. This is the path used by offer funding (`OfferCreate` / offer crossing) and `CheckCash`.
- **`checkFreeze` (payment direct step)** — `internal/tx/payment/step_direct.go`. A step toward an AMM pseudo-account whose underlying assets are frozen returns `terNO_LINE`. Mirrors rippled `StepChecks.h:65-83`.

Both gates fire only when the amendment is enabled (`view.Rules().Enabled(...)`).

`AMMUtils.cpp:124` is a comment documenting that `ammLPHolds` deliberately does **not** do the underlying-asset freeze check (that belongs in `accountHolds`); go-xrpl's `ammLPHolds` already matches and needs no change.

A small `LPTokenFrozenForIssuer` helper does the `issuer → sfAMMID → AMM SLE → per-asset isFrozen` lookup, decoding `sfAsset`/`sfAsset2` via the binary codec to avoid an `internal/tx ↔ internal/tx/amm` import cycle. It reports `frozen=true` when the issuer is an AMM pseudo-account but its AMM SLE is unresolvable, matching rippled's `!sleAmm` branch.

## Test plan

- [x] New assertive tests in `internal/testing/amm/lp_token_frozen_test.go`, ported from rippled `LPTokenTransfer_test.cpp`, asserting exact TER codes across **both** amendment states (the env enables all SupportedYes amendments by default, so both arms are exercised):
  - DirectStep: frozen sender blocked (`tecPATH_DRY`) with the fix, allowed without; frozen receiver always allowed.
  - OfferCreation: frozen sell-offer blocked (`tecUNFUNDED_OFFER`) with the fix, allowed without; buy-offer always allowed.
  - Check: cashing a frozen-LP check blocked (`tecPATH_PARTIAL`) with the fix, allowed without; receiving via check always allowed.
- [x] Full AMM suite green (`./internal/testing/amm/...`).
- [x] `./internal/tx/...` and `./internal/testing/...` green except a pre-existing `TestConformance` failure set that is **byte-for-byte identical** to pristine `main` (241 failures both sides, zero diff) — Vault/XChain out-of-scope stubs, Batch, AMM rounding, etc., none touched by this change.

Fixes #845