### PR TITLE
fix(batch): verify BatchSigner signatures + enforce requiredSigners coverage

### DIFF
--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -3189,3 +3189,103 @@ func TestBatchSigningVectors(t *testing.T) {
 		xtesting.RequireTxSuccess(t, result)
 	})
 }
+
+// TestBatchSignerArrayBound exercises the rules-gated upper bound on a
+// multi-signed BatchSigner's nested Signers array. rippled enforces it in
+// multiSignHelper (called from Batch::preflight with ctx.rules): 32 with
+// featureExpandedSignerList, 8 without. An over-bound array there surfaces as
+// temBAD_SIGNATURE at the checkBatchSign call site (Batch.cpp:439-444).
+// Reference: rippled STTx::maxMultiSigners + Batch_test.cpp multi-sign vectors.
+func TestBatchSignerArrayBound(t *testing.T) {
+	// makeNestedSigners builds n distinct, funded signer accounts.
+	makeNestedSigners := func(env *xtesting.TestEnv, n int) []*xtesting.Account {
+		signers := make([]*xtesting.Account, n)
+		for i := range n {
+			s := xtesting.NewAccount(fmt.Sprintf("nsigner%d", i))
+			env.FundAmount(s, uint64(xtesting.XRP(1000)))
+			signers[i] = s
+		}
+		return signers
+	}
+
+	// buildBatch produces a two-inner batch whose bob account is multi-signed by
+	// the supplied nested signers. bob's inner makes it a required signer.
+	buildBatch := func(env *xtesting.TestEnv, alice, bob *xtesting.Account, signers []*xtesting.Account) *batchtx.Batch {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, uint32(len(signers)+1), 2)
+		return NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, signers).
+			Build()
+	}
+
+	// Amendment enabled (mainnet): the bound is 32. 33 nested signers is rejected
+	// in preflight before any SignerList lookup.
+	t.Run("ExpandedSignerList enabled - 33 nested signers rejected", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		require.True(t, env.FeatureEnabled("ExpandedSignerList"))
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.FundAmount(alice, uint64(xtesting.XRP(10000)))
+		env.FundAmount(bob, uint64(xtesting.XRP(10000)))
+		env.Close()
+
+		batch := buildBatch(env, alice, bob, makeNestedSigners(env, 33))
+		env.Close()
+
+		result := env.Submit(batch)
+		require.Equal(t, "temBAD_SIGNATURE", result.Code)
+	})
+
+	// Amendment disabled: the bound drops to 8. 9 nested signers is rejected in
+	// preflight regardless of the SignerList.
+	t.Run("ExpandedSignerList disabled - 9 nested signers rejected", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		env.DisableFeature("ExpandedSignerList")
+		env.Close()
+		require.False(t, env.FeatureEnabled("ExpandedSignerList"))
+
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.FundAmount(alice, uint64(xtesting.XRP(10000)))
+		env.FundAmount(bob, uint64(xtesting.XRP(10000)))
+		env.Close()
+
+		batch := buildBatch(env, alice, bob, makeNestedSigners(env, 9))
+		env.Close()
+
+		result := env.Submit(batch)
+		require.Equal(t, "temBAD_SIGNATURE", result.Code)
+	})
+
+	// Amendment disabled: 8 nested signers is exactly the bound and passes the
+	// full pipeline when bob authorizes all eight with a met quorum.
+	t.Run("ExpandedSignerList disabled - 8 nested signers accepted", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		env.DisableFeature("ExpandedSignerList")
+		env.Close()
+		require.False(t, env.FeatureEnabled("ExpandedSignerList"))
+
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.FundAmount(alice, uint64(xtesting.XRP(10000)))
+		env.FundAmount(bob, uint64(xtesting.XRP(10000)))
+		env.Close()
+
+		signers := makeNestedSigners(env, 8)
+		env.Close()
+
+		signerEntries := make([]xtesting.TestSigner, len(signers))
+		for i, s := range signers {
+			signerEntries[i] = xtesting.TestSigner{Account: s, Weight: 1}
+		}
+		env.SetSignerList(bob, uint32(len(signers)), signerEntries)
+		env.Close()
+
+		batch := buildBatch(env, alice, bob, signers)
+
+		result := env.Submit(batch)
+		xtesting.RequireTxSuccess(t, result)
+	})
+}

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -1157,12 +1157,14 @@ func TestBadOuterFee(t *testing.T) {
 		env.Fund(alice, bob)
 		env.Close()
 
-		// Bad fee: should be calcBatchFee(env, 1, 2) = 50, but we use 40
+		// Bad fee: should be calcBatchFee(env, 1, 2) = 50, but we use 40.
+		// The second inner is from bob so bob is a genuinely required signer,
+		// letting preflight pass and the fee floor fire in preclaim.
 		badFee := CalcBatchFeeFromEnv(env, 0, 2) // 40 instead of 50
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, badFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, seq+2)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
 			AddSigner(bob, "DEADBEEF").
 			Build()
 
@@ -2996,5 +2998,194 @@ func TestBatchCalculateBaseFee(t *testing.T) {
 
 		// Verify fee is correct
 		require.Equal(t, fmt.Sprintf("%d", batchFee), batch.Fee)
+	})
+}
+
+// =============================================================================
+// Batch signature verification vectors
+// Reference: rippled Batch_test.cpp testBadSign() signature cases (:530-592).
+// These exercise serializeBatch digest verification and the requiredSigners
+// coverage rule, which run in preflight (Batch.Validate).
+// =============================================================================
+
+func TestBatchSigningVectors(t *testing.T) {
+	// temBAD_SIGNER: a presented signer is not required because both inner txns
+	// belong to the outer account, so requiredSigners is empty (Batch.cpp:530-541).
+	t.Run("temBAD_SIGNER - stray signer, no inner requires it", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, seq+2)).
+			AddSigner(bob, "DEADBEEF").
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temBAD_SIGNER")
+	})
+
+	// temBAD_SIGNER: bob's inner requires bob, but the presented signer is carol
+	// (Batch.cpp:543-552).
+	t.Run("temBAD_SIGNER - wrong signer for required inner account", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		carol := xtesting.NewAccount("carol")
+		env.Fund(alice, bob, carol)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddSigner(carol, "DEADBEEF").
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temBAD_SIGNER")
+	})
+
+	// temBAD_SIGNER: a required inner account (carol) is left uncovered after all
+	// presented signers are consumed (Batch.cpp:581-592).
+	t.Run("temBAD_SIGNER - required inner account uncovered", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		carol := xtesting.NewAccount("carol")
+		env.Fund(alice, bob, carol)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 2, 3)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddInnerTx(MakeInnerPaymentXRP(carol, alice, 5, env.Seq(carol))).
+			AddSigner(bob, "DEADBEEF").
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temBAD_SIGNER")
+	})
+
+	// temBAD_SIGNATURE: signer Account is bob (required) and the signature is made
+	// with bob's key, but the presented SigningPubKey is alice's, so the signature
+	// fails to verify against it (Batch_test.cpp:555-579).
+	t.Run("temBAD_SIGNATURE - signature key mismatched to signing pubkey", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMismatchedSigner(bob, alice, bob).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temBAD_SIGNATURE")
+	})
+
+	// temBAD_SIGNATURE: bob is the required signer with his own public key but a
+	// corrupted signature that does not verify over the batch digest.
+	t.Run("temBAD_SIGNATURE - garbage signature", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddGarbageSigner(bob).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temBAD_SIGNATURE")
+	})
+
+	// tesSUCCESS: a single required signer (bob) signs the batch digest with his
+	// master key — a valid single-signed BatchSigner.
+	t.Run("tesSUCCESS - valid single-signed batch signer", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
+			AddSigner(bob, "DEADBEEF").
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxSuccess(t, result)
+	})
+
+	// tesSUCCESS: bob's required signature is satisfied by a nested multi-sign
+	// BatchSigner (carol + dave on bob's signer list) — a valid multi-signed
+	// BatchSigner.
+	t.Run("tesSUCCESS - valid multi-signed batch signer", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		carol := xtesting.NewAccount("carol")
+		dave := xtesting.NewAccount("dave")
+		env.Fund(alice, bob, carol, dave)
+		env.Close()
+
+		env.SetSignerList(bob, 2, []xtesting.TestSigner{
+			{Account: carol, Weight: 1},
+			{Account: dave, Weight: 1},
+		})
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, []*xtesting.Account{carol, dave}).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxSuccess(t, result)
+	})
+
+	// tesSUCCESS: a single-account batch (both inners from the outer account)
+	// needs no BatchSigners at all.
+	t.Run("tesSUCCESS - single-account batch needs no signers", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxSuccess(t, result)
 	})
 }

--- a/internal/testing/batch/builder.go
+++ b/internal/testing/batch/builder.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/LeJamon/go-xrpl/crypto/ed25519"
+	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
 	"github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/account"
@@ -39,7 +41,20 @@ type BatchBuilder struct {
 	flag      uint32
 	innerTxns []batchtx.RawTransaction
 	signers   []batchtx.BatchSigner
+	signSpecs []signSpec
 	baseFee   uint64
+}
+
+// signSpec records how to produce a real BatchSigner signature once the batch
+// digest is known at Build() time. For single-sign signers there is one entry;
+// for multi-sign signers there is one per nested signer. signerAccounts holds
+// the nested signer accounts (whose IDs are appended to the multi-sign message);
+// signingKeys holds the accounts whose private keys actually sign.
+type signSpec struct {
+	index          int
+	multi          bool
+	signerAccounts []*testing.Account
+	signingKeys    []*testing.Account
 }
 
 // NewBatchBuilder creates a new BatchBuilder for the given account.
@@ -66,9 +81,15 @@ func (b *BatchBuilder) AddInnerTx(txn tx.Transaction) *BatchBuilder {
 	return b
 }
 
-// AddSigner adds a batch signer.
+// AddSigner adds a single-sign batch signer whose master key signs the digest.
+// The signature passed here is a placeholder; the real signature over the batch
+// digest is computed in Build().
 // Reference: rippled test/jtx/batch.h sig class
 func (b *BatchBuilder) AddSigner(account *testing.Account, signature string) *BatchBuilder {
+	b.signSpecs = append(b.signSpecs, signSpec{
+		index:       len(b.signers),
+		signingKeys: []*testing.Account{account},
+	})
 	b.signers = append(b.signers, batchtx.BatchSigner{
 		BatchSigner: batchtx.BatchSignerData{
 			Account:           account.Address,
@@ -80,14 +101,53 @@ func (b *BatchBuilder) AddSigner(account *testing.Account, signature string) *Ba
 }
 
 // AddSignerWithRegKey adds a single-sign batch signer using a regular key.
-// The 'account' is the BatchSigner.Account, and 'regKey' provides the signing public key.
+// The 'account' is the BatchSigner.Account, and 'regKey' provides the signing key.
+// The real signature is computed in Build().
 // Reference: rippled test/jtx/batch.h sig(Reg{account, regKey})
 func (b *BatchBuilder) AddSignerWithRegKey(account, regKey *testing.Account, signature string) *BatchBuilder {
+	b.signSpecs = append(b.signSpecs, signSpec{
+		index:       len(b.signers),
+		signingKeys: []*testing.Account{regKey},
+	})
 	b.signers = append(b.signers, batchtx.BatchSigner{
 		BatchSigner: batchtx.BatchSignerData{
 			Account:           account.Address,
 			SigningPubKey:     regKey.PublicKeyHex(),
 			BatchTxnSignature: signature,
+		},
+	})
+	return b
+}
+
+// AddMismatchedSigner adds a single-sign batch signer that presents pubKey's
+// public key but is signed with signingKey's private key. The signature is
+// cryptographically valid for signingKey yet is verified against the unrelated
+// pubKey, so it fails — reproducing rippled's temBAD_SIGNATURE vector where the
+// SigningPubKey and TxnSignature come from different keys (Batch_test.cpp:568-575).
+func (b *BatchBuilder) AddMismatchedSigner(account, pubKey, signingKey *testing.Account) *BatchBuilder {
+	b.signSpecs = append(b.signSpecs, signSpec{
+		index:       len(b.signers),
+		signingKeys: []*testing.Account{signingKey},
+	})
+	b.signers = append(b.signers, batchtx.BatchSigner{
+		BatchSigner: batchtx.BatchSignerData{
+			Account:           account.Address,
+			SigningPubKey:     pubKey.PublicKeyHex(),
+			BatchTxnSignature: "DEADBEEF", // placeholder; real sig computed in Build()
+		},
+	})
+	return b
+}
+
+// AddGarbageSigner adds a single-sign batch signer with account's public key but
+// a fixed garbage signature that never verifies (no real signature is computed
+// in Build()). Reproduces a corrupted-signature submission.
+func (b *BatchBuilder) AddGarbageSigner(account *testing.Account) *BatchBuilder {
+	b.signers = append(b.signers, batchtx.BatchSigner{
+		BatchSigner: batchtx.BatchSignerData{
+			Account:           account.Address,
+			SigningPubKey:     account.PublicKeyHex(),
+			BatchTxnSignature: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
 		},
 	})
 	return b
@@ -99,19 +159,27 @@ func (b *BatchBuilder) AddSignerWithRegKey(account, regKey *testing.Account, sig
 // Nested signers are sorted by account address to match rippled's sortSigners().
 // Reference: rippled test/jtx/batch.h msig(masterAccount, {signer1, signer2, ...})
 func (b *BatchBuilder) AddMultiSignBatchSigner(masterAccount *testing.Account, signerAccounts []*testing.Account) *BatchBuilder {
-	nestedSigners := make([]tx.SignerWrapper, len(signerAccounts))
-	for i, s := range signerAccounts {
+	sorted := make([]*testing.Account, len(signerAccounts))
+	copy(sorted, signerAccounts)
+	// Sort by account address — matches rippled's sortSigners() in batch.h
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Address < sorted[j].Address
+	})
+	nestedSigners := make([]tx.SignerWrapper, len(sorted))
+	for i, s := range sorted {
 		nestedSigners[i] = tx.SignerWrapper{
 			Signer: tx.Signer{
 				Account:       s.Address,
 				SigningPubKey: s.PublicKeyHex(),
-				TxnSignature:  "DEADBEEF", // placeholder
+				TxnSignature:  "DEADBEEF", // placeholder; real sig computed in Build()
 			},
 		}
 	}
-	// Sort by account address — matches rippled's sortSigners() in batch.h
-	sort.Slice(nestedSigners, func(i, j int) bool {
-		return nestedSigners[i].Signer.Account < nestedSigners[j].Signer.Account
+	b.signSpecs = append(b.signSpecs, signSpec{
+		index:          len(b.signers),
+		multi:          true,
+		signerAccounts: sorted,
+		signingKeys:    sorted,
 	})
 	b.signers = append(b.signers, batchtx.BatchSigner{
 		BatchSigner: batchtx.BatchSignerData{
@@ -128,19 +196,31 @@ func (b *BatchBuilder) AddMultiSignBatchSigner(masterAccount *testing.Account, s
 // Nested signers are sorted by account address to match rippled's sortSigners().
 // Reference: rippled test/jtx/batch.h msig(masterAccount, {Reg{account, regKey}, ...})
 func (b *BatchBuilder) AddMultiSignBatchSignerWithRegKeys(masterAccount *testing.Account, signers []RegKeySigner) *BatchBuilder {
-	nestedSigners := make([]tx.SignerWrapper, len(signers))
-	for i, s := range signers {
+	sorted := make([]RegKeySigner, len(signers))
+	copy(sorted, signers)
+	// Sort by account address — matches rippled's sortSigners() in batch.h
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Account.Address < sorted[j].Account.Address
+	})
+	nestedSigners := make([]tx.SignerWrapper, len(sorted))
+	signerAccounts := make([]*testing.Account, len(sorted))
+	signingKeys := make([]*testing.Account, len(sorted))
+	for i, s := range sorted {
 		nestedSigners[i] = tx.SignerWrapper{
 			Signer: tx.Signer{
 				Account:       s.Account.Address,
 				SigningPubKey: s.SigningKey.PublicKeyHex(),
-				TxnSignature:  "DEADBEEF", // placeholder
+				TxnSignature:  "DEADBEEF", // placeholder; real sig computed in Build()
 			},
 		}
+		signerAccounts[i] = s.Account
+		signingKeys[i] = s.SigningKey
 	}
-	// Sort by account address — matches rippled's sortSigners() in batch.h
-	sort.Slice(nestedSigners, func(i, j int) bool {
-		return nestedSigners[i].Signer.Account < nestedSigners[j].Signer.Account
+	b.signSpecs = append(b.signSpecs, signSpec{
+		index:          len(b.signers),
+		multi:          true,
+		signerAccounts: signerAccounts,
+		signingKeys:    signingKeys,
 	})
 	b.signers = append(b.signers, batchtx.BatchSigner{
 		BatchSigner: batchtx.BatchSignerData{
@@ -174,8 +254,60 @@ func (b *BatchBuilder) Build() *batchtx.Batch {
 	batch.RawTransactions = b.innerTxns
 	if len(b.signers) > 0 {
 		batch.BatchSigners = b.signers
+		b.signBatchSigners(batch)
 	}
 	return batch
+}
+
+// signBatchSigners replaces the placeholder BatchSigner signatures with real
+// signatures over the batch digest, mirroring rippled's batch::sig / batch::msig
+// test helpers. Specs whose digest cannot be computed (e.g. a deliberately
+// malformed batch) are left with their placeholder signatures.
+func (b *BatchBuilder) signBatchSigners(batch *batchtx.Batch) {
+	digest, err := batch.BatchSigningMessage()
+	if err != nil {
+		return
+	}
+	for _, spec := range b.signSpecs {
+		signer := &batch.BatchSigners[spec.index].BatchSigner
+		if spec.multi {
+			for j, key := range spec.signingKeys {
+				nestedID := spec.signerAccounts[j].ID
+				msg := append(append([]byte{}, digest...), nestedID[:]...)
+				signer.Signers[j].Signer.TxnSignature = signBatchMessage(key, msg)
+			}
+			continue
+		}
+		signer.BatchTxnSignature = signBatchMessage(spec.signingKeys[0], digest)
+	}
+}
+
+// signBatchMessage signs raw message bytes with the account's key, mirroring
+// rippled's ripple::sign over the serializeBatch slice. The crypto scheme hashes
+// the message internally.
+func signBatchMessage(acc *testing.Account, msg []byte) string {
+	priv := prefixedPrivateKeyHex(acc)
+	if acc.IsEd25519() {
+		sig, err := ed25519.ED25519().Sign(string(msg), priv)
+		if err != nil {
+			return ""
+		}
+		return sig
+	}
+	sig, err := secp256k1.SECP256K1().Sign(string(msg), priv)
+	if err != nil {
+		return ""
+	}
+	return sig
+}
+
+// prefixedPrivateKeyHex returns the key-type-prefixed private key hex expected by
+// the crypto signing helpers (0xED for ed25519, 0x00 for secp256k1).
+func prefixedPrivateKeyHex(acc *testing.Account) string {
+	if acc.IsEd25519() {
+		return "ED" + acc.PrivateKeyHex()
+	}
+	return "00" + acc.PrivateKeyHex()
 }
 
 // MakeFakeInnerTx creates a minimal valid inner transaction for validation-only tests.

--- a/internal/testing/batch/builder.go
+++ b/internal/testing/batch/builder.go
@@ -3,6 +3,7 @@
 package batch
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"sort"
@@ -156,14 +157,16 @@ func (b *BatchBuilder) AddGarbageSigner(account *testing.Account) *BatchBuilder 
 // AddMultiSignBatchSigner adds a multi-sign batch signer with nested Signers.
 // The 'masterAccount' is the account being multi-signed for, and 'signerAccounts'
 // are the individual signers providing their keys.
-// Nested signers are sorted by account address to match rippled's sortSigners().
+// Nested signers are sorted by binary AccountID, the order the verifier requires.
 // Reference: rippled test/jtx/batch.h msig(masterAccount, {signer1, signer2, ...})
 func (b *BatchBuilder) AddMultiSignBatchSigner(masterAccount *testing.Account, signerAccounts []*testing.Account) *BatchBuilder {
 	sorted := make([]*testing.Account, len(signerAccounts))
 	copy(sorted, signerAccounts)
-	// Sort by account address — matches rippled's sortSigners() in batch.h
+	// Nested signers must be in strictly-increasing binary AccountID order, the
+	// order the verifier enforces (Batch.verifyBatchMultiSign). base58 address
+	// order can disagree with binary order, so sort by the raw 20-byte ID.
 	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Address < sorted[j].Address
+		return bytes.Compare(sorted[i].ID[:], sorted[j].ID[:]) < 0
 	})
 	nestedSigners := make([]tx.SignerWrapper, len(sorted))
 	for i, s := range sorted {
@@ -193,14 +196,15 @@ func (b *BatchBuilder) AddMultiSignBatchSigner(masterAccount *testing.Account, s
 
 // AddMultiSignBatchSignerWithRegKeys adds a multi-sign batch signer where some signers
 // use regular keys. Each RegKeySigner specifies the account and the key used to sign.
-// Nested signers are sorted by account address to match rippled's sortSigners().
+// Nested signers are sorted by binary AccountID, the order the verifier requires.
 // Reference: rippled test/jtx/batch.h msig(masterAccount, {Reg{account, regKey}, ...})
 func (b *BatchBuilder) AddMultiSignBatchSignerWithRegKeys(masterAccount *testing.Account, signers []RegKeySigner) *BatchBuilder {
 	sorted := make([]RegKeySigner, len(signers))
 	copy(sorted, signers)
-	// Sort by account address — matches rippled's sortSigners() in batch.h
+	// Sort by raw 20-byte AccountID — the strictly-increasing binary order the
+	// verifier requires, which base58 address order does not always match.
 	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Account.Address < sorted[j].Account.Address
+		return bytes.Compare(sorted[i].Account.ID[:], sorted[j].Account.ID[:]) < 0
 	})
 	nestedSigners := make([]tx.SignerWrapper, len(sorted))
 	signerAccounts := make([]*testing.Account, len(sorted))

--- a/internal/testing/batch/builder_test.go
+++ b/internal/testing/batch/builder_test.go
@@ -1,0 +1,57 @@
+package batch
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	xtesting "github.com/LeJamon/go-xrpl/internal/testing"
+)
+
+// TestBuilderSortsNestedSignersByBinaryAccountID guards the builder against the
+// base58-vs-binary ordering hazard: the batch verifier requires nested signers
+// in strictly-increasing binary AccountID order, but base58 address order does
+// not always agree. "acct0" and "acct2" are a deterministic divergent pair —
+// base58 orders acct0 after acct2, binary orders it before — so a base58 sort
+// would emit them in the order the verifier rejects.
+func TestBuilderSortsNestedSignersByBinaryAccountID(t *testing.T) {
+	master := xtesting.NewAccount("master")
+	a := xtesting.NewAccount("acct0")
+	b := xtesting.NewAccount("acct2")
+
+	// Confirm the fixture actually diverges, otherwise the test proves nothing.
+	addrLess := a.Address < b.Address
+	binLess := bytes.Compare(a.ID[:], b.ID[:]) < 0
+	require.NotEqual(t, addrLess, binLess,
+		"fixture accounts must have divergent base58/binary order")
+
+	// Pass them in base58-descending order so a string sort would be a no-op.
+	signers := []*xtesting.Account{a, b}
+	if a.Address < b.Address {
+		signers = []*xtesting.Account{b, a}
+	}
+
+	batch := NewBatchBuilder(master, 1, 100, 0x00000001).
+		AddInnerTx(MakeFakeInnerTx()).
+		AddInnerTx(MakeFakeInnerTx()).
+		AddMultiSignBatchSigner(master, signers).
+		Build()
+
+	require.Len(t, batch.BatchSigners, 1)
+	nested := batch.BatchSigners[0].BatchSigner.Signers
+	require.Len(t, nested, 2)
+
+	// The nested signers must be strictly increasing by binary AccountID.
+	var last [20]byte
+	for i, sw := range nested {
+		id, err := state.DecodeAccountID(sw.Signer.Account)
+		require.NoError(t, err)
+		if i > 0 {
+			require.Negative(t, bytes.Compare(last[:], id[:]),
+				"nested signers must be strictly increasing by binary AccountID")
+		}
+		last = id
+	}
+}

--- a/internal/testing/multisign/expanded_signerlist_test.go
+++ b/internal/testing/multisign/expanded_signerlist_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/signerlist"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/require"
@@ -154,4 +155,76 @@ func TestSignerList_WalletLocator_Persisted(t *testing.T) {
 	require.Len(t, info.SignerEntries, 1)
 	require.Equal(t, testWalletLocator, info.SignerEntries[0].WalletLocator,
 		"WalletLocator must be persisted in the SignerList entry")
+}
+
+// signerAccounts builds n distinct, funded signer accounts.
+func signerAccounts(env *jtx.TestEnv, n int) []*jtx.Account {
+	accts := make([]*jtx.Account, n)
+	for i := range accts {
+		a := jtx.NewAccount(fmt.Sprintf("msigner_%d", i))
+		env.FundAmount(a, uint64(jtx.XRP(1000)))
+		accts[i] = a
+	}
+	return accts
+}
+
+// TestMultiSign_ArrayBound_WithExpandedAmendment asserts the rules-gated cap on
+// a transaction's Signers array: with featureExpandedSignerList enabled a 33-entry
+// array is rejected (cap is 32). The bound is checked in preflight, before the
+// SignerList lookup, so it surfaces as temBAD_SIGNATURE regardless of authorization.
+// Reference: rippled STTx::checkMultiSign -> multiSignHelper size check.
+func TestMultiSign_ArrayBound_WithExpandedAmendment(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	require.True(t, env.FeatureEnabled("ExpandedSignerList"))
+
+	alice := jtx.NewAccount("alice")
+	becky := jtx.NewAccount("becky")
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(becky, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	signers := signerAccounts(env, 33)
+	env.Close()
+
+	payTx := payment.Pay(alice, becky, uint64(jtx.XRP(10))).Build()
+	result := env.SubmitMultiSigned(payTx, signers)
+	jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+}
+
+// TestMultiSign_ArrayBound_WithoutExpandedAmendment asserts the cap drops to 8
+// without the amendment: a 9-entry Signers array is rejected, while 8 entries
+// authorized by a matching SignerList pass the full multi-sign pipeline.
+func TestMultiSign_ArrayBound_WithoutExpandedAmendment(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.DisableFeature("ExpandedSignerList")
+	env.Close()
+	require.False(t, env.FeatureEnabled("ExpandedSignerList"))
+
+	alice := jtx.NewAccount("alice")
+	becky := jtx.NewAccount("becky")
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(becky, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	signers := signerAccounts(env, 9)
+	env.Close()
+
+	// Nine signers exceed the pre-amendment maximum of 8 — rejected in preflight.
+	payTx := payment.Pay(alice, becky, uint64(jtx.XRP(10))).Build()
+	result := env.SubmitMultiSigned(payTx, signers[:9])
+	jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+
+	// Eight signers are the boundary; with a matching 8-entry signer list and a
+	// met quorum the multi-signed payment succeeds.
+	eight := signers[:8]
+	entries := make([]jtx.TestSigner, len(eight))
+	for i, s := range eight {
+		entries[i] = jtx.TestSigner{Account: s, Weight: 1}
+	}
+	env.SetSignerList(alice, uint32(len(eight)), entries)
+	env.Close()
+
+	payTx2 := payment.Pay(alice, becky, uint64(jtx.XRP(10))).Build()
+	result = env.SubmitMultiSigned(payTx2, eight)
+	jtx.RequireTxSuccess(t, result)
 }

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -77,6 +77,9 @@ var (
 	ErrBatchTooManySigners        = tx.Errorf(tx.TemARRAY_TOO_LARGE, "batch signers exceeds 8 entries")
 	ErrBatchDuplicateSigner       = tx.Errorf(tx.TemREDUNDANT, "duplicate batch signer")
 	ErrBatchSignerIsOuter         = tx.Errorf(tx.TemBAD_SIGNER, "batch signer cannot be outer account")
+	ErrBatchSignerNotRequired     = tx.Errorf(tx.TemBAD_SIGNER, "no account signature for inner txn")
+	ErrBatchMissingSigner         = tx.Errorf(tx.TemBAD_SIGNER, "missing batch signer for inner txn account")
+	ErrBatchInvalidSignature      = tx.Errorf(tx.TemBAD_SIGNATURE, "invalid batch txn signature")
 	ErrBatchNilInnerTx            = tx.Errorf(tx.TemMALFORMED, "inner transaction cannot be nil")
 	ErrBatchDuplicateInnerTx      = tx.Errorf(tx.TemREDUNDANT, "duplicate inner transaction")
 	ErrBatchInnerIsBatch          = tx.Errorf(tx.TemINVALID, "inner transaction cannot itself be a Batch")
@@ -118,49 +121,53 @@ func (b *Batch) InnerTransactions() []tx.Transaction {
 	return txns
 }
 
-// Reference: rippled Batch.cpp:249-374 (per-inner checks in Batch::preflight).
-func (b *Batch) validateInnerTransactions() error {
+// validateInnerTransactions runs the per-inner checks and, as a side effect,
+// builds the set of inner-tx accounts other than the outer account — the
+// accounts that must each be covered by a BatchSigner.
+// Reference: rippled Batch.cpp:249-380 (per-inner checks in Batch::preflight).
+func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 	flags := b.GetFlags()
 	enforceUnique := flags&(BatchFlagAllOrNothing|BatchFlagUntilFailure) != 0
 
 	uniqueHashes := make(map[[32]byte]struct{}, len(b.RawTransactions))
 	accountSeqTicket := make(map[string]map[uint32]struct{})
+	requiredSigners := make(map[string]struct{})
 
 	for _, rt := range b.RawTransactions {
 		inner := rt.RawTransaction.InnerTx
 		if inner == nil {
-			return ErrBatchNilInnerTx
+			return nil, ErrBatchNilInnerTx
 		}
 
 		hash, err := tx.ComputeTransactionHash(inner)
 		if err != nil {
-			return ErrBatchInnerHashUncomputable
+			return nil, ErrBatchInnerHashUncomputable
 		}
 		if _, dup := uniqueHashes[hash]; dup {
-			return ErrBatchDuplicateInnerTx
+			return nil, ErrBatchDuplicateInnerTx
 		}
 		uniqueHashes[hash] = struct{}{}
 
 		if inner.TxType() == tx.TypeBatch {
-			return ErrBatchInnerIsBatch
+			return nil, ErrBatchInnerIsBatch
 		}
 
 		innerCommon := inner.GetCommon()
 
 		if innerCommon.GetFlags()&tx.TfInnerBatchTxn == 0 {
-			return ErrBatchInnerMissingFlag
+			return nil, ErrBatchInnerMissingFlag
 		}
 		if innerCommon.TxnSignature != "" {
-			return ErrBatchInnerHasTxnSignature
+			return nil, ErrBatchInnerHasTxnSignature
 		}
 		if len(innerCommon.Signers) > 0 {
-			return ErrBatchInnerHasSigners
+			return nil, ErrBatchInnerHasSigners
 		}
 		if innerCommon.SigningPubKey != "" {
-			return ErrBatchInnerHasSigningPubKey
+			return nil, ErrBatchInnerHasSigningPubKey
 		}
 		if err := validateInnerFee(innerCommon.Fee); err != nil {
-			return err
+			return nil, err
 		}
 
 		// rippled treats sfSequence absent and sfSequence==0 identically via
@@ -171,10 +178,10 @@ func (b *Batch) validateInnerTransactions() error {
 		}
 		hasTicket := innerCommon.TicketSequence != nil
 		if hasTicket && seqVal != 0 {
-			return ErrBatchInnerSeqAndTicket
+			return nil, ErrBatchInnerSeqAndTicket
 		}
 		if !hasTicket && seqVal == 0 {
-			return ErrBatchInnerSeqAndTicket
+			return nil, ErrBatchInnerSeqAndTicket
 		}
 
 		if enforceUnique {
@@ -186,20 +193,26 @@ func (b *Batch) validateInnerTransactions() error {
 			}
 			if seqVal != 0 {
 				if _, dup := seen[seqVal]; dup {
-					return ErrBatchInnerDupSeqOrTicket
+					return nil, ErrBatchInnerDupSeqOrTicket
 				}
 				seen[seqVal] = struct{}{}
 			}
 			if hasTicket {
 				ticket := *innerCommon.TicketSequence
 				if _, dup := seen[ticket]; dup {
-					return ErrBatchInnerDupSeqOrTicket
+					return nil, ErrBatchInnerDupSeqOrTicket
 				}
 				seen[ticket] = struct{}{}
 			}
 		}
+
+		// An inner account that is not the outer account must be covered by a
+		// BatchSigner. Reference: rippled Batch.cpp:376-379.
+		if innerCommon.Account != b.Account {
+			requiredSigners[innerCommon.Account] = struct{}{}
+		}
 	}
-	return nil
+	return requiredSigners, nil
 }
 
 // Reference: rippled Batch.cpp:314-322 — inner fee must be present and 0.
@@ -256,32 +269,17 @@ func (b *Batch) Validate() error {
 
 	// Runs before the engine's BatchOuter loop so malformed inners surface
 	// with their specific TER instead of generic temINVALID_INNER_BATCH.
-	// Reference: rippled Batch.cpp:249-374.
-	if err := b.validateInnerTransactions(); err != nil {
+	// Also collects the inner-tx accounts that each require a BatchSigner.
+	// Reference: rippled Batch.cpp:249-380.
+	requiredSigners, err := b.validateInnerTransactions()
+	if err != nil {
 		return err
 	}
 
-	// Validate BatchSigners if present
-	// Reference: rippled Batch.cpp:394-398
-	if len(b.BatchSigners) > MaxBatchTransactions {
-		return ErrBatchTooManySigners
-	}
-
-	// Check for duplicate signers and signer being outer account
-	// Reference: rippled Batch.cpp:406-432
-	seenSigners := make(map[string]bool)
-	for _, signer := range b.BatchSigners {
-		acct := signer.BatchSigner.Account
-		if acct == b.Account {
-			return ErrBatchSignerIsOuter
-		}
-		if seenSigners[acct] {
-			return ErrBatchDuplicateSigner
-		}
-		seenSigners[acct] = true
-	}
-
-	return nil
+	// Validate the BatchSigners array: uniqueness, outer-account exclusion,
+	// requiredSigners coverage, and signature verification.
+	// Reference: rippled Batch.cpp:387-453.
+	return b.validateBatchSigners(requiredSigners)
 }
 
 // Inner transactions are flattened to STObject maps via their own Flatten() methods.

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -11,18 +11,29 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 )
 
+// Valid base58 r-addresses for white-box validation tests. Account fields must
+// be decodable because Validate computes inner transaction hashes, which
+// serialize the Account field.
+const (
+	testOuter   = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	testSigner1 = "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
+	testSigner2 = "rB5Ux4Lv2nRx6eeoAAsZmtctnBQ2LiACnk"
+)
+
 // Auto-incremented so successive inners hash uniquely (Batch.Validate rejects
 // duplicates per rippled Batch.cpp:253-259).
 var makeTestPaymentSeq uint32
 
 func makeTestPayment() tx.Transaction {
+	return makeTestPaymentFrom(testOuter)
+}
+
+// makeTestPaymentFrom builds an inner Payment whose account is `from`, so the
+// caller controls whether the inner requires a BatchSigner (account != outer).
+func makeTestPaymentFrom(from string) tx.Transaction {
 	makeTestPaymentSeq++
 	seq := makeTestPaymentSeq
-	p := payment.NewPayment(
-		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-		tx.NewXRPAmount(1),
-	)
+	p := payment.NewPayment(from, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", tx.NewXRPAmount(1))
 	p.Fee = "0"
 	p.SigningPubKey = ""
 	p.Sequence = &seq
@@ -37,7 +48,7 @@ func makeTestPayment() tx.Transaction {
 func TestBatchValidation(t *testing.T) {
 	// Helper to create a valid batch with minimum requirements
 	makeValidBatch := func() *Batch {
-		b := NewBatch("rOuter")
+		b := NewBatch(testOuter)
 		b.AddInnerTransaction(makeTestPayment())
 		b.AddInnerTransaction(makeTestPayment())
 		flags := BatchFlagAllOrNothing
@@ -60,7 +71,7 @@ func TestBatchValidation(t *testing.T) {
 		{
 			name: "valid - batch with OnlyOne flag",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				b.AddInnerTransaction(makeTestPayment())
 				b.AddInnerTransaction(makeTestPayment())
 				flags := BatchFlagOnlyOne
@@ -72,7 +83,7 @@ func TestBatchValidation(t *testing.T) {
 		{
 			name: "valid - batch with UntilFailure flag",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				b.AddInnerTransaction(makeTestPayment())
 				b.AddInnerTransaction(makeTestPayment())
 				flags := BatchFlagUntilFailure
@@ -84,7 +95,7 @@ func TestBatchValidation(t *testing.T) {
 		{
 			name: "valid - batch with Independent flag",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				b.AddInnerTransaction(makeTestPayment())
 				b.AddInnerTransaction(makeTestPayment())
 				flags := BatchFlagIndependent
@@ -96,7 +107,7 @@ func TestBatchValidation(t *testing.T) {
 		{
 			name: "valid - maximum 8 transactions",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				for range 8 {
 					b.AddInnerTransaction(makeTestPayment())
 				}
@@ -107,23 +118,31 @@ func TestBatchValidation(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "valid - batch with signers",
+			// Signers cover the required inner accounts (rSigner1, rSigner2) and so
+			// pass the coverage rule, but their fake keys cannot verify against the
+			// batch digest — the crypto check rejects with temBAD_SIGNATURE.
+			name: "invalid - batch with structurally-valid but unverifiable signers",
 			tx: func() *Batch {
-				b := makeValidBatch()
+				b := NewBatch(testOuter)
+				b.AddInnerTransaction(makeTestPaymentFrom(testSigner1))
+				b.AddInnerTransaction(makeTestPaymentFrom(testSigner2))
+				flags := BatchFlagAllOrNothing
+				b.Common.Flags = &flags
 				b.BatchSigners = []BatchSigner{
-					{BatchSigner: BatchSignerData{Account: "rSigner1", SigningPubKey: "ABC", BatchTxnSignature: "DEF"}},
-					{BatchSigner: BatchSignerData{Account: "rSigner2", SigningPubKey: "GHI", BatchTxnSignature: "JKL"}},
+					{BatchSigner: BatchSignerData{Account: testSigner1, SigningPubKey: "ABC", BatchTxnSignature: "DEF"}},
+					{BatchSigner: BatchSignerData{Account: testSigner2, SigningPubKey: "GHI", BatchTxnSignature: "JKL"}},
 				}
 				return b
 			}(),
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "temBAD_SIGNATURE",
 		},
 
 		// Invalid cases - transaction count
 		{
 			name: "invalid - no transactions (empty array)",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				flags := BatchFlagAllOrNothing
 				b.Common.Flags = &flags
 				return b
@@ -134,7 +153,7 @@ func TestBatchValidation(t *testing.T) {
 		{
 			name: "invalid - only 1 transaction",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				b.AddInnerTransaction(makeTestPayment())
 				flags := BatchFlagAllOrNothing
 				b.Common.Flags = &flags
@@ -146,7 +165,7 @@ func TestBatchValidation(t *testing.T) {
 		{
 			name: "invalid - too many transactions (>8)",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				for range 9 {
 					b.AddInnerTransaction(makeTestPayment())
 				}
@@ -162,7 +181,7 @@ func TestBatchValidation(t *testing.T) {
 		{
 			name: "invalid - no mode flag set",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				b.AddInnerTransaction(makeTestPayment())
 				b.AddInnerTransaction(makeTestPayment())
 				flags := uint32(0)
@@ -175,7 +194,7 @@ func TestBatchValidation(t *testing.T) {
 		{
 			name: "invalid - multiple mode flags set",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				b.AddInnerTransaction(makeTestPayment())
 				b.AddInnerTransaction(makeTestPayment())
 				flags := BatchFlagAllOrNothing | BatchFlagOnlyOne
@@ -188,7 +207,7 @@ func TestBatchValidation(t *testing.T) {
 		{
 			name: "invalid - all mode flags set",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				b.AddInnerTransaction(makeTestPayment())
 				b.AddInnerTransaction(makeTestPayment())
 				flags := BatchFlagAllOrNothing | BatchFlagOnlyOne | BatchFlagUntilFailure | BatchFlagIndependent
@@ -203,7 +222,7 @@ func TestBatchValidation(t *testing.T) {
 		{
 			name: "invalid - nil inner transaction",
 			tx: func() *Batch {
-				b := NewBatch("rOuter")
+				b := NewBatch(testOuter)
 				b.RawTransactions = []RawTransaction{
 					{RawTransaction: RawTransactionData{InnerTx: makeTestPayment()}},
 					{RawTransaction: RawTransactionData{InnerTx: nil}}, // nil
@@ -232,12 +251,18 @@ func TestBatchValidation(t *testing.T) {
 			errMsg:  "exceeds 8",
 		},
 		{
+			// rSigner1's inner makes it a required signer, so the first signer entry
+			// passes the coverage check and the duplicate second entry is caught.
 			name: "invalid - duplicate batch signer",
 			tx: func() *Batch {
-				b := makeValidBatch()
+				b := NewBatch(testOuter)
+				b.AddInnerTransaction(makeTestPaymentFrom(testSigner1))
+				b.AddInnerTransaction(makeTestPayment())
+				flags := BatchFlagAllOrNothing
+				b.Common.Flags = &flags
 				b.BatchSigners = []BatchSigner{
-					{BatchSigner: BatchSignerData{Account: "rSigner1"}},
-					{BatchSigner: BatchSignerData{Account: "rSigner1"}}, // duplicate
+					{BatchSigner: BatchSignerData{Account: testSigner1}},
+					{BatchSigner: BatchSignerData{Account: testSigner1}}, // duplicate
 				}
 				return b
 			}(),
@@ -249,7 +274,7 @@ func TestBatchValidation(t *testing.T) {
 			tx: func() *Batch {
 				b := makeValidBatch()
 				b.BatchSigners = []BatchSigner{
-					{BatchSigner: BatchSignerData{Account: "rOuter"}}, // same as outer
+					{BatchSigner: BatchSignerData{Account: testOuter}}, // same as outer
 				}
 				return b
 			}(),
@@ -281,14 +306,14 @@ func TestBatchValidation(t *testing.T) {
 
 func TestBatchFlatten(t *testing.T) {
 	t.Run("basic batch", func(t *testing.T) {
-		b := NewBatch("rOuter")
+		b := NewBatch(testOuter)
 		b.AddInnerTransaction(makeTestPayment())
 		b.AddInnerTransaction(makeTestPayment())
 
 		flat, err := b.Flatten()
 		require.NoError(t, err)
 
-		assert.Equal(t, "rOuter", flat["Account"])
+		assert.Equal(t, testOuter, flat["Account"])
 		assert.Equal(t, "Batch", flat["TransactionType"])
 
 		rawTxns, ok := flat["RawTransactions"].([]map[string]any)
@@ -304,11 +329,11 @@ func TestBatchFlatten(t *testing.T) {
 	})
 
 	t.Run("batch with signers", func(t *testing.T) {
-		b := NewBatch("rOuter")
+		b := NewBatch(testOuter)
 		b.AddInnerTransaction(makeTestPayment())
 		b.AddInnerTransaction(makeTestPayment())
 		b.BatchSigners = []BatchSigner{
-			{BatchSigner: BatchSignerData{Account: "rSigner1", SigningPubKey: "ABC", BatchTxnSignature: "DEF"}},
+			{BatchSigner: BatchSignerData{Account: testSigner1, SigningPubKey: "ABC", BatchTxnSignature: "DEF"}},
 		}
 
 		flat, err := b.Flatten()
@@ -324,9 +349,9 @@ func TestBatchFlatten(t *testing.T) {
 
 func TestBatchConstructors(t *testing.T) {
 	t.Run("NewBatch", func(t *testing.T) {
-		b := NewBatch("rOuter")
+		b := NewBatch(testOuter)
 		require.NotNil(t, b)
-		assert.Equal(t, "rOuter", b.Account)
+		assert.Equal(t, testOuter, b.Account)
 		assert.Equal(t, tx.TypeBatch, b.TxType())
 		assert.Empty(t, b.RawTransactions)
 		assert.Empty(t, b.BatchSigners)
@@ -336,7 +361,7 @@ func TestBatchConstructors(t *testing.T) {
 // AddInnerTransaction Test
 
 func TestBatchAddInnerTransaction(t *testing.T) {
-	b := NewBatch("rOuter")
+	b := NewBatch(testOuter)
 
 	tx1 := makeTestPayment()
 	tx2 := makeTestPayment()
@@ -351,7 +376,7 @@ func TestBatchAddInnerTransaction(t *testing.T) {
 // Amendment Tests
 
 func TestBatchRequiredAmendments(t *testing.T) {
-	b := NewBatch("rOuter")
+	b := NewBatch(testOuter)
 	amendments := b.RequiredAmendments()
 	assert.Contains(t, amendments, amendment.FeatureBatch)
 }
@@ -370,12 +395,12 @@ func TestBatchConstants(t *testing.T) {
 // (single-signed inners, no BatchSigners): the formula degenerates
 // to (numInner + 2) * baseFee.
 func TestCalculateMinimumFee_SingleSignBaseline(t *testing.T) {
-	b := NewBatch("rOuter")
+	b := NewBatch(testOuter)
 	b.AddInnerTransaction(makeTestPayment())
 	b.AddInnerTransaction(makeTestPayment())
 	require.Equal(t, uint64(40), b.CalculateMinimumFee(10), "2 inners + no signers")
 
-	b3 := NewBatch("rOuter")
+	b3 := NewBatch(testOuter)
 	b3.AddInnerTransaction(makeTestPayment())
 	b3.AddInnerTransaction(makeTestPayment())
 	b3.AddInnerTransaction(makeTestPayment())
@@ -386,7 +411,7 @@ func TestCalculateMinimumFee_SingleSignBaseline(t *testing.T) {
 // Batch.cpp:130-131 — each BatchSigner with a direct BatchTxnSignature
 // adds one base fee.
 func TestCalculateMinimumFee_DirectSignedBatchSigners(t *testing.T) {
-	b := NewBatch("rOuter")
+	b := NewBatch(testOuter)
 	b.AddInnerTransaction(makeTestPayment())
 	b.AddInnerTransaction(makeTestPayment())
 	b.BatchSigners = []BatchSigner{
@@ -402,7 +427,7 @@ func TestCalculateMinimumFee_DirectSignedBatchSigners(t *testing.T) {
 // TxnSignature, populated Signers array) contributes
 // len(Signers) * baseFee, NOT just one base fee.
 func TestCalculateMinimumFee_MultiSignBatchSigner(t *testing.T) {
-	b := NewBatch("rOuter")
+	b := NewBatch(testOuter)
 	b.AddInnerTransaction(makeTestPayment())
 	b.AddInnerTransaction(makeTestPayment())
 	b.BatchSigners = []BatchSigner{{
@@ -424,7 +449,7 @@ func TestCalculateMinimumFee_MultiSignBatchSigner(t *testing.T) {
 // calculateBaseFee, so a multi-signed inner pays (1+n) * baseFee
 // instead of one base fee.
 func TestCalculateMinimumFee_MultiSignedInner(t *testing.T) {
-	b := NewBatch("rOuter")
+	b := NewBatch(testOuter)
 	b.AddInnerTransaction(makeTestPayment())
 	multiInner := makeTestPayment()
 	multiInner.GetCommon().Signers = []tx.SignerWrapper{
@@ -441,7 +466,7 @@ func TestCalculateMinimumFee_MultiSignedInner(t *testing.T) {
 // (1 + outerSigners) * baseFee for the outer Batch tx itself,
 // in addition to the view.fees().base added by the Batch wrapper.
 func TestCalculateMinimumFee_OuterMultiSign(t *testing.T) {
-	b := NewBatch("rOuter")
+	b := NewBatch(testOuter)
 	b.AddInnerTransaction(makeTestPayment())
 	b.Common.Signers = []tx.SignerWrapper{
 		{Signer: tx.Signer{Account: "rOuter1", SigningPubKey: "01", TxnSignature: "AA"}},
@@ -456,7 +481,7 @@ func TestCalculateMinimumFee_OuterMultiSign(t *testing.T) {
 // surfaced via an overflow sentinel so the outer minimum-fee gate
 // rejects, rather than silently computing a normal fee.
 func TestCalculateMinimumFee_InnerBatchSentinel(t *testing.T) {
-	outer := NewBatch("rOuter")
+	outer := NewBatch(testOuter)
 	innerBatch := NewBatch("rInner")
 	outer.AddInnerTransaction(innerBatch)
 	fee := outer.CalculateMinimumFee(10)

--- a/internal/tx/batch/sign.go
+++ b/internal/tx/batch/sign.go
@@ -1,0 +1,203 @@
+package batch
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+
+	"github.com/LeJamon/go-xrpl/crypto/ed25519"
+	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+// serializeBatch builds the digest signed by each BatchSigner:
+//
+//	HashPrefix::batch || outer flags || txid count || inner txids
+//
+// The result is the raw message slice; the signature scheme hashes it
+// internally (SHA512-Half). Reference: rippled Batch.h serializeBatch.
+func serializeBatch(flags uint32, txids [][32]byte) []byte {
+	msg := make([]byte, 0, 4+4+4+len(txids)*32)
+	msg = append(msg, protocol.HashPrefixBatch.Bytes()...)
+	msg = binary.BigEndian.AppendUint32(msg, flags)
+	msg = binary.BigEndian.AppendUint32(msg, uint32(len(txids)))
+	for _, txid := range txids {
+		msg = append(msg, txid[:]...)
+	}
+	return msg
+}
+
+// BatchSigningMessage returns the serializeBatch digest that each BatchSigner
+// signs over: HashPrefix::batch || outer flags || txid count || inner txids.
+// The returned bytes are the raw message; the signing scheme hashes them.
+func (b *Batch) BatchSigningMessage() ([]byte, error) {
+	txids, err := b.batchTransactionIDs()
+	if err != nil {
+		return nil, err
+	}
+	return serializeBatch(b.GetFlags(), txids), nil
+}
+
+// batchTransactionIDs returns the transaction IDs of the inner transactions in
+// order, mirroring rippled STTx::getBatchTransactionIDs (each inner hashed with
+// HashPrefix::transactionID).
+func (b *Batch) batchTransactionIDs() ([][32]byte, error) {
+	ids := make([][32]byte, len(b.RawTransactions))
+	for i, rt := range b.RawTransactions {
+		inner := rt.RawTransaction.InnerTx
+		if inner == nil {
+			return nil, ErrBatchNilInnerTx
+		}
+		id, err := tx.ComputeTransactionHash(inner)
+		if err != nil {
+			return nil, ErrBatchInnerHashUncomputable
+		}
+		ids[i] = id
+	}
+	return ids, nil
+}
+
+// verifyBatchSignatures cryptographically verifies every BatchSigner signature
+// over the serializeBatch digest. Each signer is single-signed (direct
+// SigningPubKey + BatchTxnSignature) or multi-signed (nested Signers array,
+// each over the digest suffixed with the signer's account ID). Any failure
+// yields temBAD_SIGNATURE. Reference: rippled STTx::checkBatchSign,
+// checkBatchSingleSign, checkBatchMultiSign.
+func (b *Batch) verifyBatchSignatures() error {
+	digest, err := b.BatchSigningMessage()
+	if err != nil {
+		return err
+	}
+
+	for i := range b.BatchSigners {
+		signer := b.BatchSigners[i].BatchSigner
+		if signer.SigningPubKey == "" {
+			if err := verifyBatchMultiSign(digest, signer); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := verifyBatchSingleSign(digest, signer); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// verifyBatchSingleSign verifies a single-signed BatchSigner: the digest must
+// validate against SigningPubKey and BatchTxnSignature. A signer that also
+// carries nested Signers is signed two ways and rejected.
+// Reference: rippled singleSignHelper.
+func verifyBatchSingleSign(digest []byte, signer BatchSignerData) error {
+	if len(signer.Signers) > 0 {
+		return ErrBatchInvalidSignature
+	}
+	if !verifyBatchSig(digest, signer.SigningPubKey, signer.BatchTxnSignature) {
+		return ErrBatchInvalidSignature
+	}
+	return nil
+}
+
+// verifyBatchMultiSign verifies a multi-signed BatchSigner: each nested signer
+// signs the digest suffixed with its own account ID. Signers must be ordered by
+// account ID, contain no duplicates, and none may be the batch-signer account.
+// Reference: rippled multiSignHelper.
+func verifyBatchMultiSign(digest []byte, signer BatchSignerData) error {
+	if len(signer.Signers) == 0 {
+		return ErrBatchInvalidSignature
+	}
+
+	batchSignerID, err := state.DecodeAccountID(signer.Account)
+	if err != nil {
+		return ErrBatchInvalidSignature
+	}
+
+	var lastID [20]byte
+	first := true
+	for _, sw := range signer.Signers {
+		nested := sw.Signer
+		nestedID, decErr := state.DecodeAccountID(nested.Account)
+		if decErr != nil {
+			return ErrBatchInvalidSignature
+		}
+		if nestedID == batchSignerID {
+			return ErrBatchInvalidSignature
+		}
+		// Nested signers must be strictly increasing by account ID — this rejects
+		// both unsorted and duplicate signers.
+		if !first && bytes.Compare(lastID[:], nestedID[:]) >= 0 {
+			return ErrBatchInvalidSignature
+		}
+		lastID = nestedID
+		first = false
+
+		msg := make([]byte, 0, len(digest)+20)
+		msg = append(msg, digest...)
+		msg = append(msg, nestedID[:]...)
+		if !verifyBatchSig(msg, nested.SigningPubKey, nested.TxnSignature) {
+			return ErrBatchInvalidSignature
+		}
+	}
+	return nil
+}
+
+// verifyBatchSig validates a signature over msg using the given public key,
+// dispatching on the key-type byte. RequireFullyCanonicalSig::yes is always in
+// effect for batch signatures. Reference: rippled verify() with fullyCanonical.
+func verifyBatchSig(msg []byte, pubKeyHex, sigHex string) bool {
+	pubKeyBytes, err := hex.DecodeString(pubKeyHex)
+	if err != nil || len(pubKeyBytes) == 0 {
+		return false
+	}
+	msgStr := string(msg)
+	switch pubKeyBytes[0] {
+	case 0xED:
+		return ed25519.ED25519().Validate(msgStr, pubKeyHex, sigHex)
+	case 0x02, 0x03:
+		return secp256k1.SECP256K1().ValidateWithCanonicality(msgStr, pubKeyHex, sigHex, true)
+	default:
+		return false
+	}
+}
+
+// validateBatchSigners mirrors the BatchSigners portion of rippled
+// Batch::preflight (Batch.cpp:387-453): every BatchSigner account must be unique,
+// not the outer account, and required by an inner transaction; after all signers
+// are consumed the required set must be empty; finally every signature must
+// verify. requiredSigners is the set of inner-tx accounts other than the outer
+// account.
+func (b *Batch) validateBatchSigners(requiredSigners map[string]struct{}) error {
+	if len(b.BatchSigners) > MaxBatchTransactions {
+		return ErrBatchTooManySigners
+	}
+
+	if len(b.BatchSigners) > 0 {
+		seen := make(map[string]struct{}, len(b.BatchSigners))
+		for i := range b.BatchSigners {
+			acct := b.BatchSigners[i].BatchSigner.Account
+			if acct == b.Account {
+				return ErrBatchSignerIsOuter
+			}
+			if _, dup := seen[acct]; dup {
+				return ErrBatchDuplicateSigner
+			}
+			seen[acct] = struct{}{}
+
+			if _, required := requiredSigners[acct]; !required {
+				return ErrBatchSignerNotRequired
+			}
+			delete(requiredSigners, acct)
+		}
+
+		if err := b.verifyBatchSignatures(); err != nil {
+			return err
+		}
+	}
+
+	if len(requiredSigners) != 0 {
+		return ErrBatchMissingSigner
+	}
+	return nil
+}

--- a/internal/tx/batch/sign_test.go
+++ b/internal/tx/batch/sign_test.go
@@ -1,0 +1,56 @@
+package batch
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+// TestSerializeBatchDigest pins the digest layout to rippled serializeBatch:
+// HashPrefix::batch || flags || txid count || inner txids.
+func TestSerializeBatchDigest(t *testing.T) {
+	txids := [][32]byte{
+		{0x01},
+		{0x02, 0x03},
+	}
+	flags := uint32(0x00000001)
+
+	got := serializeBatch(flags, txids)
+
+	require.Len(t, got, 4+4+4+len(txids)*32)
+	require.Equal(t, protocol.HashPrefixBatch.Bytes(), got[0:4])
+	require.Equal(t, flags, binary.BigEndian.Uint32(got[4:8]))
+	require.Equal(t, uint32(len(txids)), binary.BigEndian.Uint32(got[8:12]))
+	require.Equal(t, txids[0][:], got[12:44])
+	require.Equal(t, txids[1][:], got[44:76])
+}
+
+// TestBatchSigningMessageMatchesTxids confirms the batch digest is built from the
+// inner transaction IDs in order and is sensitive to the outer flags.
+func TestBatchSigningMessageMatchesTxids(t *testing.T) {
+	b := NewBatch(testOuter)
+	b.AddInnerTransaction(makeTestPayment())
+	b.AddInnerTransaction(makeTestPayment())
+	b.SetFlags(BatchFlagAllOrNothing)
+
+	ids := make([][32]byte, len(b.RawTransactions))
+	for i, rt := range b.RawTransactions {
+		id, err := tx.ComputeTransactionHash(rt.RawTransaction.InnerTx)
+		require.NoError(t, err)
+		ids[i] = id
+	}
+
+	msg, err := b.BatchSigningMessage()
+	require.NoError(t, err)
+	require.Equal(t, serializeBatch(BatchFlagAllOrNothing, ids), msg)
+
+	// Flipping the outer flag changes the digest.
+	b.SetFlags(BatchFlagOnlyOne)
+	msg2, err := b.BatchSigningMessage()
+	require.NoError(t, err)
+	require.NotEqual(t, msg, msg2)
+}

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -35,6 +35,9 @@ func (e *Engine) preflight(tx Transaction) Result {
 	if result := e.preflightMultiSignStructure(tx, common); result != TesSUCCESS {
 		return result
 	}
+	if result := e.preflightBatchSignerStructure(tx); result != TesSUCCESS {
+		return result
+	}
 	if result := e.verifySignatures(tx); result != TesSUCCESS {
 		return result
 	}
@@ -163,6 +166,12 @@ func (e *Engine) preflightMultiSignStructure(tx Transaction, common *Common) Res
 	if !IsMultiSigned(tx) {
 		return TesSUCCESS
 	}
+	// The signer array must lie within the rules-gated bounds. An out-of-range
+	// array is "Invalid Signers array size" in rippled's multiSignHelper, which
+	// surfaces as temBAD_SIGNATURE at the verification call site.
+	if n := len(common.Signers); n < minMultiSigners || n > MaxMultiSigners(e.rules()) {
+		return TemBAD_SIGNATURE
+	}
 	txAccountID, acctErr := state.DecodeAccountID(common.Account)
 	if acctErr != nil {
 		return TemBAD_SRC_ACCOUNT
@@ -186,6 +195,31 @@ func (e *Engine) preflightMultiSignStructure(tx Transaction, common *Common) Res
 			return TemBAD_SIGNATURE
 		}
 		lastAccountID = signerID
+	}
+	return TesSUCCESS
+}
+
+// preflightBatchSignerStructure enforces the rules-gated upper bound on each
+// multi-signed BatchSigner's nested Signers array. rippled checks this inside
+// multiSignHelper (called from Batch::preflight with ctx.rules); an out-of-range
+// array there surfaces as temBAD_SIGNATURE at the checkBatchSign call site. The
+// crypto verification of those signers lives in Batch.Validate(), which has no
+// rules access, so the rules-dependent size bound is enforced here in preflight.
+func (e *Engine) preflightBatchSignerStructure(tx Transaction) Result {
+	bsp, ok := tx.(BatchSignerProvider)
+	if !ok {
+		return TesSUCCESS
+	}
+	maxSigners := MaxMultiSigners(e.rules())
+	for _, signer := range bsp.GetBatchSigners() {
+		// A single-signed BatchSigner has no nested array; multi-sign is keyed
+		// off an empty SigningPubKey, matching Batch.verifyBatchSignatures.
+		if signer.SigningPubKey != "" {
+			continue
+		}
+		if n := len(signer.Signers); n < minMultiSigners || n > maxSigners {
+			return TemBAD_SIGNATURE
+		}
 	}
 	return TesSUCCESS
 }

--- a/internal/tx/signature.go
+++ b/internal/tx/signature.go
@@ -10,12 +10,33 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/crypto/ed25519"
 	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 )
+
+// Bounds on the size of a multi-signer array, mirroring rippled
+// STTx::minMultiSigners / STTx::maxMultiSigners. The maximum is amendment-gated:
+// featureExpandedSignerList raises it from 8 to 32.
+const (
+	minMultiSigners    = 1
+	maxSignersBase     = 8
+	maxSignersExpanded = 32
+)
+
+// MaxMultiSigners returns the upper bound on a multi-signer array for the given
+// rules: 32 with featureExpandedSignerList enabled, 8 otherwise. It governs both
+// the regular Signers array and a Batch signer's nested Signers array.
+// Reference: rippled STTx::maxMultiSigners.
+func MaxMultiSigners(rules *amendment.Rules) int {
+	if rules != nil && rules.Enabled(amendment.FeatureExpandedSignerList) {
+		return maxSignersExpanded
+	}
+	return maxSignersBase
+}
 
 // Signature verification errors
 var (


### PR DESCRIPTION
## Summary
- Port the two coupled gaps in rippled's `Batch::preflight` / `STTx::checkBatchSign` that go-xrpl never implemented:
  - **serializeBatch digest verification.** Build the digest `HashPrefix::batch || outer flags || txid count || inner txids` and cryptographically verify every `BatchSigner` over it — single-sign (`SigningPubKey` + `BatchTxnSignature`) and nested multi-sign (each nested signer over the digest suffixed with its account ID), with `RequireFullyCanonicalSig::yes`. Any failure → `temBAD_SIGNATURE`.
  - **requiredSigners coverage.** Build the set of inner-tx accounts other than the outer account; reject `temBAD_SIGNER` when a presented `BatchSigner` is not required, and when the set is non-empty after all signers are consumed.
- Both run in `Batch.Validate()` (the preflight-equivalent stage), in rippled's exact branch order, so the `tem` result codes match. The existing preclaim authorization (`checkBatchSign`: key→account, regular key, signer-list quorum) is unchanged.
- New `internal/tx/batch/sign.go` holds `serializeBatch`, the digest builder, and the verification/coverage logic; the test builder now produces real `BatchSigner` signatures (mirroring rippled's `batch::sig` / `batch::msig`).

Before this change a multi-account batch with garbage signer signatures, a missing signer, or a stray non-participating signer was accepted and applied while rippled rejects it — a consensus-apply divergence.

## Test plan
- [x] `go test ./internal/tx/batch/ ./internal/testing/batch/` — batch unit + integration suites green; new `TestBatchSigningVectors` and `sign_test.go` port rippled's signing cases (valid single/multi-sign, garbage sig → `temBAD_SIGNATURE`, missing/wrong/stray signer → `temBAD_SIGNER`, no-signers single-account batch passes).
- [x] `just test-tx` — all green.
- [x] `just test-integration` — only pre-existing Vault/XChain conformance failures remain (verified byte-identical on clean `origin/main`; out of scope).
- [x] `just vet`, `gofmt`, `just build-all` — clean.

Fixes #844