### PR TITLE
fix(check): CheckCash native funding failure returns tecUNFUNDED_PAYMENT

### DIFF
--- a/internal/testing/check/check_test.go
+++ b/internal/testing/check/check_test.go
@@ -684,6 +684,92 @@ func TestCheck_CashXRP(t *testing.T) {
 		require.Equal(t, "tecPATH_PARTIAL", result.Code)
 		env.Close()
 	})
+
+	t.Run("BelowReserveWindowUnfunded", func(t *testing.T) {
+		// In the below-reserve window the two rippled funds checks disagree on
+		// the result code, and the doApply branch wins. The writer's preclaim
+		// available funds = max(balance - reserve(ownerCount), 0) + increment
+		// (CashCheck.cpp:177), but the doApply liquid = xrpLiquid(src, -1) =
+		// max(balance - reserve(ownerCount-1), 0) (CashCheck.cpp:304). Once the
+		// writer's balance drops below reserve(ownerCount), the preclaim term
+		// zero-clamps to just the released increment while the doApply liquid is
+		// strictly smaller, so a request that clears preclaim still fails doApply
+		// with tecUNFUNDED_PAYMENT (CashCheck.cpp:319).
+		reserveBase := env.ReserveBase()             // reserve(0)
+		reserveIncrement := env.ReserveIncrement()   // one increment
+		reserveOne := reserveBase + reserveIncrement // reserve(1), the writer holds one check
+
+		writer := jtx.NewAccount("writer847")
+		dst := jtx.NewAccount("dest847")
+		// Fund just enough to create the check (needs prior balance >= reserve(1)).
+		env.FundAmount(writer, reserveOne+uint64(jtx.XRP(10)))
+		env.Fund(dst)
+		env.Close()
+
+		// SendMax(40 XRP) leaves headroom under the preclaim available funds but
+		// above the doApply liquid we engineer below.
+		sendMax := uint64(jtx.XRP(40))
+		chkID := check.GetCheckID(writer, env.Seq(writer))
+		result := env.Submit(check.CheckCreate(writer, dst, tx.NewXRPAmount(int64(sendMax))).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		jtx.RequireOwnerCount(t, env, writer, 1)
+
+		// Burn the writer's balance below reserve(1) via a large AccountSet fee.
+		// Target balance = reserveBase + 10 XRP, which sits below reserve(1).
+		// Then:
+		//   preclaim available = max(target - reserve(1), 0) + increment = increment (50 XRP)
+		//   doApply liquid     = max(target - reserve(0), 0)             = 10 XRP
+		targetBalance := reserveBase + uint64(jtx.XRP(10))
+		burnFee := env.Balance(writer) - targetBalance
+		result = env.Submit(accountset.AccountSet(writer).Fee(burnFee).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		require.Equal(t, targetBalance, env.Balance(writer))
+
+		// Cash exactly SendMax(40 XRP). preclaim passes (40 <= 50 available) but
+		// doApply fails (doApply liquid 10 < 40), so rippled returns
+		// tecUNFUNDED_PAYMENT — not tecPATH_PARTIAL.
+		result = env.Submit(check.CheckCashAmount(dst, chkID, tx.NewXRPAmount(int64(sendMax))).Build())
+		require.Equal(t, "tecUNFUNDED_PAYMENT", result.Code,
+			"below-reserve doApply funds failure must return tecUNFUNDED_PAYMENT")
+		env.Close()
+
+		// Same window with DeliverMin(40 XRP): doApply liquid (10) < DeliverMin,
+		// so the doApply branch returns tecUNFUNDED_PAYMENT here too.
+		result = env.Submit(check.CheckCashDeliverMin(dst, chkID, tx.NewXRPAmount(int64(sendMax))).Build())
+		require.Equal(t, "tecUNFUNDED_PAYMENT", result.Code,
+			"below-reserve DeliverMin doApply funds failure must return tecUNFUNDED_PAYMENT")
+		env.Close()
+	})
+
+	t.Run("AboveReserveInsufficientStaysPathPartial", func(t *testing.T) {
+		// Above the writer's reserve the preclaim funds guard pre-empts the
+		// doApply branch, so an underfunded request returns tecPATH_PARTIAL —
+		// the division of labour rippled keeps between preclaim (CashCheck.cpp:183)
+		// and doApply (CashCheck.cpp:319). Here the writer stays above reserve(1)
+		// and both the preclaim available funds and the doApply liquid equal the
+		// same ~60 XRP, so the request fails preclaim first.
+		writer := jtx.NewAccount("writer847b")
+		dst := jtx.NewAccount("dest847b")
+		// Balance 260 XRP, owner count 1 ⇒ above reserve(1)=250 XRP.
+		env.FundAmount(writer, env.ReserveBase()+env.ReserveIncrement()+uint64(jtx.XRP(10)))
+		env.Fund(dst)
+		env.Close()
+
+		chkID := check.GetCheckID(writer, env.Seq(writer))
+		result := env.Submit(check.CheckCreate(writer, dst, tx.NewXRPAmount(jtx.XRP(200))).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Writer liquid ≈ 60 XRP (260 - reserve(0) 200, after the released check
+		// reserve). Cashing SendMax(200) exceeds it, and since the writer is above
+		// reserve(1) the preclaim guard returns tecPATH_PARTIAL.
+		result = env.Submit(check.CheckCashAmount(dst, chkID, tx.NewXRPAmount(jtx.XRP(200))).Build())
+		require.Equal(t, "tecPATH_PARTIAL", result.Code,
+			"above-reserve underfunded cash must stay tecPATH_PARTIAL")
+		env.Close()
+	})
 }
 
 // TestCheck_CashIOU tests many valid ways to cash a check for an IOU.

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -296,7 +296,6 @@ func (c *CheckCash) applyCashXRPDeliverMin(ctx *tx.ApplyContext, check *state.Ch
 		return tx.TecUNFUNDED_PAYMENT
 	}
 
-	// Delivered amount = min(sendMax, srcLiquid).
 	cashAmount := min(srcLiquid, check.SendMax)
 
 	// Set delivered_amount metadata for the DeliverMin XRP path when fix1623

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -218,15 +218,20 @@ func (c *CheckCash) applyCashXRPAmount(ctx *tx.ApplyContext, check *state.CheckD
 		return tx.TefINTERNAL
 	}
 
-	// Calculate creator's liquid XRP (balance - reserve after check deletion)
-	creatorReserve := ctx.AccountReserve(creatorAccount.OwnerCount - 1)
-	var srcLiquid uint64
-	if creatorAccount.Balance > creatorReserve {
-		srcLiquid = creatorAccount.Balance - creatorReserve
+	// Preclaim funds check: the creator's zero-clamped liquid XRP plus one
+	// released reserve increment must cover the requested amount. Mirrors
+	// rippled's accountFunds(value) + fees().increment guard, which returns
+	// tecPATH_PARTIAL when the writer is at or above their reserve.
+	// Reference: CashCheck.cpp L162-185.
+	if cashDrops > xrpAvailableFunds(creatorAccount, ctx) {
+		return tx.TecPATH_PARTIAL
 	}
 
-	if srcLiquid < cashDrops {
-		return tx.TecPATH_PARTIAL
+	// doApply funds check: xrpLiquid with the released check reserve (-1 owner
+	// count). Distinct from the preclaim guard in the below-reserve window,
+	// where rippled returns tecUNFUNDED_PAYMENT. Reference: CashCheck.cpp L304-319.
+	if xrpLiquidAfterCheck(creatorAccount, ctx) < cashDrops {
+		return tx.TecUNFUNDED_PAYMENT
 	}
 
 	// Transfer XRP
@@ -272,19 +277,27 @@ func (c *CheckCash) applyCashXRPDeliverMin(ctx *tx.ApplyContext, check *state.Ch
 		return tx.TefINTERNAL
 	}
 
-	// Calculate creator's liquid XRP (check will be deleted, so -1 owner count)
-	creatorReserve := ctx.AccountReserve(creatorAccount.OwnerCount - 1)
-	var srcLiquid uint64
-	if creatorAccount.Balance > creatorReserve {
-		srcLiquid = creatorAccount.Balance - creatorReserve
-	}
-
-	// Cash amount = min(sendMax, srcLiquid), must be >= deliverMin
-	cashAmount := min(srcLiquid, check.SendMax)
-
-	if cashAmount < deliverMinDrops {
+	// Preclaim funds check: the creator's zero-clamped liquid XRP plus one
+	// released reserve increment must cover DeliverMin. Mirrors rippled's
+	// accountFunds(value) + fees().increment guard, which returns
+	// tecPATH_PARTIAL when the writer is at or above their reserve.
+	// Reference: CashCheck.cpp L162-185.
+	if deliverMinDrops > xrpAvailableFunds(creatorAccount, ctx) {
 		return tx.TecPATH_PARTIAL
 	}
+
+	// doApply funds check: xrpLiquid with the released check reserve (-1 owner
+	// count). xrpDeliver collapses to DeliverMin for the underfunded case
+	// (min(sendMax, srcLiquid) never exceeds srcLiquid), so rippled returns
+	// tecUNFUNDED_PAYMENT when srcLiquid < DeliverMin in the below-reserve
+	// window. Reference: CashCheck.cpp L304-319.
+	srcLiquid := xrpLiquidAfterCheck(creatorAccount, ctx)
+	if srcLiquid < deliverMinDrops {
+		return tx.TecUNFUNDED_PAYMENT
+	}
+
+	// Delivered amount = min(sendMax, srcLiquid).
+	cashAmount := min(srcLiquid, check.SendMax)
 
 	// Set delivered_amount metadata for the DeliverMin XRP path when fix1623
 	// is enabled. Reference: CashCheck.cpp L322-324.
@@ -316,6 +329,36 @@ func (c *CheckCash) applyCashXRPDeliverMin(ctx *tx.ApplyContext, check *state.Ch
 	}
 
 	return tx.TesSUCCESS
+}
+
+// xrpAvailableFunds returns the check writer's preclaim-stage available XRP:
+// their zero-clamped liquid balance at the current owner count plus one
+// reserve increment, since cashing the check releases its reserve.
+// Mirrors rippled's accountFunds(value) + fees().increment for native amounts.
+// Reference: CashCheck.cpp L162-185, View.cpp xrpLiquid (zero-clamp).
+func xrpAvailableFunds(creator *state.AccountRoot, ctx *tx.ApplyContext) uint64 {
+	reserve := ctx.AccountReserve(creator.OwnerCount)
+	var liquid uint64
+	if creator.Balance > reserve {
+		liquid = creator.Balance - reserve
+	}
+	return liquid + ctx.Config.ReserveIncrement
+}
+
+// xrpLiquidAfterCheck returns the writer's zero-clamped liquid XRP computed with
+// the check's reserve already released (owner count minus one), matching
+// rippled's xrpLiquid(psb, srcId, -1). This is the amount actually available to
+// fund the transfer in doApply. Reference: CashCheck.cpp L304, View.cpp xrpLiquid.
+func xrpLiquidAfterCheck(creator *state.AccountRoot, ctx *tx.ApplyContext) uint64 {
+	ownerCount := creator.OwnerCount
+	if ownerCount > 0 {
+		ownerCount--
+	}
+	reserve := ctx.AccountReserve(ownerCount)
+	if creator.Balance > reserve {
+		return creator.Balance - reserve
+	}
+	return 0
 }
 
 // applyCashIOUAmount handles IOU check cashing for both Amount and DeliverMin.


### PR DESCRIPTION
## Summary
- The XRP `CheckCash` doApply funding-failure branches (`applyCashXRPAmount`, `applyCashXRPDeliverMin`) returned `tecPATH_PARTIAL` where rippled's `doApply` returns `tecUNFUNDED_PAYMENT` (`CashCheck.cpp:304-319`, `srcLiquid < xrpDeliver` with `xrpLiquid(src, -1)`).
- The two codes diverge only in the **below-reserve window**: rippled's preclaim guard — zero-clamped `xrpLiquid(src, 0)` plus one reserve increment (`CashCheck.cpp:162-185`) — pre-empts with `tecPATH_PARTIAL` while the writer's balance ≥ reserve(ownerCount). Once balance drops below that reserve, the preclaim term zero-clamps to just the released increment while the doApply liquid (`xrpLiquid(src, -1)`) is strictly smaller, so the doApply branch is reached and votes `tecUNFUNDED_PAYMENT`.
- Because the result code serializes into transaction metadata, replaying a mainnet CheckCash that fails funding in that window would yield a different meta blob and `transaction_hash` → fork.
- Fix: split the single XRP funds check into the two rippled stages (preclaim `tecPATH_PARTIAL`, doApply `tecUNFUNDED_PAYMENT`) via two small helpers, so the division of labour matches rippled exactly. The new `xrpLiquidAfterCheck` helper also removes a latent `OwnerCount - 1` uint32 underflow. IOU branches are unchanged.

This closes the remainder of #569 (the `delivered_amount`/fix1623 half already landed).

## Test plan
- [x] New `TestCheck_CashXRP/BelowReserveWindowUnfunded` — writer balance burned below reserve(1) via a large AccountSet fee; cashing both an exact Amount and a DeliverMin returns `tecUNFUNDED_PAYMENT`. Verified to **fail** against the pre-fix `tecPATH_PARTIAL` behaviour (negative control).
- [x] New `TestCheck_CashXRP/AboveReserveInsufficientStaysPathPartial` — above-reserve underfunded cash still returns `tecPATH_PARTIAL` (preclaim wins), preserving the rippled split.
- [x] `go test ./internal/testing/check/... ./internal/tx/check/...` green; `just test-tx` green.
- [x] `app/Check` conformance 14/14 on both baseline and this branch (no regression; the below-reserve window is not in the current fixture corpus).

Fixes #847