### PR TITLE
fix(batch): run invariants per inner transaction; remove non-rippled Batch carve-outs

### DIFF
--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -990,6 +990,51 @@ func TestAccountActivation(t *testing.T) {
 	xtesting.RequireBalance(t, env, bob, uint64(xtesting.XRP(1001)))
 }
 
+// TestActivateTwoAccounts is the issue #846 regression: a Batch whose inner txs
+// fund TWO distinct new accounts must succeed. rippled runs each inner Payment
+// through its own invariant pass, so each pass sees exactly one account
+// creation; the outer ttBATCH pass never sees the combined two-creation delta.
+// goXRPL previously ran the shared ValidNewAccountRoot checker on the combined
+// outer delta (createdCount=2) and wrongly returned tecINVARIANT_FAILED.
+// Reference: rippled apply.cpp:189-207, InvariantCheck.cpp:964-967.
+func TestActivateTwoAccounts(t *testing.T) {
+	env := xtesting.NewTestEnv(t)
+	alice := xtesting.NewAccount("alice")
+	bob := xtesting.NewAccount("bob")
+	carol := xtesting.NewAccount("carol")
+	env.FundAmount(alice, uint64(xtesting.XRP(10000)))
+	env.Close()
+
+	xtesting.RequireAccountNotExists(t, env, bob)
+	xtesting.RequireAccountNotExists(t, env, carol)
+
+	preAlice := env.Balance(alice)
+	seq := env.Seq(alice)
+	batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+
+	// Two funding Payments to two brand-new accounts in a single batch.
+	batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1000, seq+1)).
+		AddInnerTx(MakeInnerPaymentXRP(alice, carol, 1000, seq+2)).
+		Build()
+
+	result := env.Submit(batch)
+	xtesting.RequireTxSuccess(t, result)
+	env.Close()
+
+	// Both new accounts now exist and are funded.
+	xtesting.RequireAccountExists(t, env, bob)
+	xtesting.RequireAccountExists(t, env, carol)
+
+	// Alice consumes sequences (outer + 2 inner).
+	xtesting.RequireSequence(t, env, alice, seq+3)
+
+	// Alice pays XRP(2000) + fee; bob and carol each receive XRP(1000).
+	xtesting.RequireBalance(t, env, alice, preAlice-uint64(xtesting.XRP(2000))-batchFee)
+	xtesting.RequireBalance(t, env, bob, uint64(xtesting.XRP(1000)))
+	xtesting.RequireBalance(t, env, carol, uint64(xtesting.XRP(1000)))
+}
+
 // =============================================================================
 // Test 9: testAccountSet
 // Reference: rippled Batch_test.cpp testAccountSet()

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -721,7 +721,6 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 	}
 
 	if result.IsSuccess() {
-		// All inner effects validated — commit the per-tx table to the batch view.
 		if _, err := perTxTable.Apply(); err != nil {
 			return tx.TefINTERNAL
 		}

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -691,13 +691,14 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 		result = tx.TesSUCCESS
 	}
 
+	// On success, write the sender account (with its fee/sequence/balance
+	// mutations) into the per-tx table so the inner delta is complete before the
+	// invariant pass runs. If the inner transaction deleted its own account
+	// (e.g. AccountDelete), the SLE was already erased, so leave it erased.
+	// rippled's apply preamble likewise writes the sender SLE into the
+	// perTxBatchView before doApply/checkInvariants.
 	if result.IsSuccess() {
-		// Success: update account in per-tx table and commit all changes.
-		// If the inner transaction deleted the account (e.g. AccountDelete),
-		// the account SLE was already erased from the per-tx table, so we
-		// must not try to update it — just commit the per-tx table as-is.
-		accountExists, _ := perTxTable.Exists(accountKey)
-		if accountExists {
+		if accountExists, _ := perTxTable.Exists(accountKey); accountExists {
 			updatedData, err := state.SerializeAccountRoot(account)
 			if err != nil {
 				return tx.TefINTERNAL
@@ -706,6 +707,21 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 				return tx.TefINTERNAL
 			}
 		}
+	}
+
+	// Run the inner transaction's own invariant pass against its complete,
+	// isolated delta, under the inner tx's type and result, before committing it
+	// to the batch view. Mirrors rippled, where each inner tx flows through full
+	// apply() with its own checkInvariants on its perTxBatchView (apply.cpp:
+	// 189-207). An inner invariant violation downgrades the inner result to the
+	// invariant-failed code so the inner delta is discarded below, exactly as a
+	// tec result is.
+	if result.IsSuccess() {
+		result = ctx.Engine.CheckInnerInvariants(innerTx, result, perTxTable)
+	}
+
+	if result.IsSuccess() {
+		// All inner effects validated — commit the per-tx table to the batch view.
 		if _, err := perTxTable.Apply(); err != nil {
 			return tx.TefINTERNAL
 		}

--- a/internal/tx/do_apply.go
+++ b/internal/tx/do_apply.go
@@ -663,6 +663,19 @@ func (e *Engine) payDelegatedFeeOnTable(st *applyState, table *ApplyStateTable) 
 // tecINVARIANT_FAILED on the first pass (charges fee, retries on fee-only
 // state) and tefINVARIANT_FAILED on the second pass (no-op, no fee).
 func (e *Engine) runInvariants(st *applyState, result Result) (r Result, handled bool) {
+	// Batch is checked per inner transaction, not on the combined outer delta.
+	// rippled runs each inner tx through its own apply() + checkInvariants on its
+	// own perTxBatchView (apply.cpp:189-207); the outer ttBATCH transactor's
+	// invariant pass only ever sees the batch fee/sequence delta, which never
+	// violates these checkers. goXRPL collapses the inner deltas into the outer
+	// table for combined metadata, so running the shared invariant set here would
+	// mis-count creations/deletions across inner txs (e.g. a Batch funding two
+	// accounts) — exactly the false positive issue #846 addresses. The
+	// authoritative defense is CheckInnerInvariants, run per inner tx in the
+	// batch path.
+	if st.tx.TxType() == TypeBatch {
+		return Result(0), false
+	}
 	defer func() {
 		if rec := recover(); rec != nil {
 			e.logger.Error("invariant check panic recovered, returning tecINVARIANT_FAILED",
@@ -685,6 +698,56 @@ func (e *Engine) runInvariants(st *applyState, result Result) (r Result, handled
 	_ = violation // logged in future via journal
 	return e.applyInvariantViolation(st, txDeclaredFee), true
 }
+
+// CheckInnerInvariants runs the invariant pass for a single Batch inner
+// transaction against its own delta, mirroring rippled where each inner tx
+// flows through full apply() with its own checkInvariants on its perTxBatchView
+// (apply.cpp:189-207, Transactor.cpp:1218-1238). It returns the result the inner
+// transaction should carry: the supplied result when invariants pass, or an
+// invariant-failed code when they do not.
+//
+// innerTable is the inner tx's isolated delta (the batch's perTxTable), which
+// has NOT yet been committed to the batch view. The fee charged on that delta is
+// zero for batch inner txs, since the outer Batch pays the whole batch fee. On
+// violation the caller discards the inner delta and consumes only
+// the inner sequence, so this helper does not mutate state; it reproduces
+// rippled's two-pass escalation purely to choose between tec and tef: the first
+// pass yields tecINVARIANT_FAILED, and a second pass on the (post-discard,
+// fee-only) state yields tefINVARIANT_FAILED if it still violates.
+//
+// A panic from CheckInvariants (e.g. AMM XRPLNumber overflow) is treated as a
+// violation, matching rippled's checkInvariantsHelper catch-all.
+func (e *Engine) CheckInnerInvariants(innerTx Transaction, result Result, innerTable *ApplyStateTable) (r Result) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			e.logger.Error("inner invariant check panic recovered, returning tecINVARIANT_FAILED",
+				"panic", rec)
+			r = TecINVARIANT_FAILED
+		}
+	}()
+
+	declaredFee := parseTxDeclaredFee(innerTx, innerFeeNone)
+	wrapped := wrapTxForInvariants(innerTx)
+	rules := e.rules()
+
+	if invariants.CheckInvariants(wrapped, invariants.Result(result), innerFeeNone, declaredFee, innerTable.CollectEntries(), innerTable, rules) == nil {
+		return result
+	}
+
+	// First pass violated: rippled resets to a fee-only state and re-checks.
+	// The inner tx carries no fee, so the reset state has an empty delta; a
+	// second violation there escalates to tefINVARIANT_FAILED.
+	feeOnly := NewApplyStateTable(e.view, [32]byte{}, e.config.LedgerSequence, rules)
+	if invariants.CheckInvariants(wrapped, invariants.Result(TecINVARIANT_FAILED), innerFeeNone, declaredFee, feeOnly.CollectEntries(), feeOnly, rules) != nil {
+		return TefINVARIANT_FAILED
+	}
+	return TecINVARIANT_FAILED
+}
+
+// innerFeeNone is the fee charged on a Batch inner transaction's delta. Inner
+// txs declare and pay no fee — the outer Batch transaction pays the whole batch
+// fee — so XRPNotCreated/TransactionFeeCheck see zero on the inner delta.
+const innerFeeNone uint64 = 0
 
 // applyInvariantViolation handles the tecINVARIANT_FAILED reset path: discard
 // the sandbox, charge fee/seq/ticket, then run a second invariant check on the

--- a/internal/tx/do_apply_inner_invariants_test.go
+++ b/internal/tx/do_apply_inner_invariants_test.go
@@ -1,0 +1,131 @@
+package tx
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// innerInvariantEngine builds a minimal engine over a mock base view for
+// exercising CheckInnerInvariants in isolation.
+func innerInvariantEngine(base *mockBaseView) *Engine {
+	return NewEngine(base, EngineConfig{
+		LedgerSequence: 100,
+		Rules:          amendment.AllSupportedRules(),
+	})
+}
+
+func mustAccount(t *testing.T, addr string, balance uint64, seq uint32) []byte {
+	t.Helper()
+	data, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:  addr,
+		Balance:  balance,
+		Sequence: seq,
+	})
+	if err != nil {
+		t.Fatalf("serialize account: %v", err)
+	}
+	return data
+}
+
+const (
+	innerInvSender    = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	innerInvRecipient = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+)
+
+// TestCheckInnerInvariants_LegitimateCreatePasses verifies that a single inner
+// Payment that funds a new account — debiting the sender by exactly the credited
+// amount — passes the per-inner invariant pass under the inner Payment type.
+// This is the per-inner analog of the issue #846 false positive: each inner pass
+// sees exactly one creation and a net-zero XRP delta.
+func TestCheckInnerInvariants_LegitimateCreatePasses(t *testing.T) {
+	base := newMockBaseView()
+	senderID, _ := state.DecodeAccountID(innerInvSender)
+	recipientID, _ := state.DecodeAccountID(innerInvRecipient)
+	senderKey := keylet.Account(senderID)
+	recipientKey := keylet.Account(recipientID)
+
+	// Sender starts at 10_000 drops; base reflects the pre-payment state.
+	base.data[senderKey.Key] = mustAccount(t, innerInvSender, 10_000, 1)
+
+	e := innerInvariantEngine(base)
+	table := NewApplyStateTable(base, [32]byte{}, 100, e.rules())
+
+	// Inner Payment of 1_000 drops: debit sender, create recipient with 1_000.
+	if err := table.Update(senderKey, mustAccount(t, innerInvSender, 9_000, 2)); err != nil {
+		t.Fatalf("update sender: %v", err)
+	}
+	if err := table.Insert(recipientKey, mustAccount(t, innerInvRecipient, 1_000, 100)); err != nil {
+		t.Fatalf("insert recipient: %v", err)
+	}
+
+	innerTx := NewBaseTx(TypePayment, innerInvSender)
+	if got := e.CheckInnerInvariants(innerTx, TesSUCCESS, table); got != TesSUCCESS {
+		t.Fatalf("legitimate inner create: expected tesSUCCESS, got %s", got)
+	}
+}
+
+// TestCheckInnerInvariants_XRPCreatedFails verifies that the per-inner pass
+// catches an inner delta that conjures XRP — a created account with no
+// offsetting debit on the sender. rippled's XRPNotCreated rejects this on the
+// inner tx's own perTxBatchView; goXRPL must do the same per inner tx.
+func TestCheckInnerInvariants_XRPCreatedFails(t *testing.T) {
+	base := newMockBaseView()
+	senderID, _ := state.DecodeAccountID(innerInvSender)
+	recipientID, _ := state.DecodeAccountID(innerInvRecipient)
+	senderKey := keylet.Account(senderID)
+	recipientKey := keylet.Account(recipientID)
+
+	base.data[senderKey.Key] = mustAccount(t, innerInvSender, 10_000, 1)
+
+	e := innerInvariantEngine(base)
+	table := NewApplyStateTable(base, [32]byte{}, 100, e.rules())
+
+	// Create the recipient with 1_000 drops but DO NOT debit the sender — this
+	// is +1_000 drops of XRP from nothing.
+	if err := table.Insert(recipientKey, mustAccount(t, innerInvRecipient, 1_000, 100)); err != nil {
+		t.Fatalf("insert recipient: %v", err)
+	}
+
+	innerTx := NewBaseTx(TypePayment, innerInvSender)
+	got := e.CheckInnerInvariants(innerTx, TesSUCCESS, table)
+	if got == TesSUCCESS {
+		t.Fatal("XRP-creating inner delta: expected invariant failure, got tesSUCCESS")
+	}
+	if got != TecINVARIANT_FAILED {
+		t.Fatalf("XRP-creating inner delta: expected tecINVARIANT_FAILED, got %s", got)
+	}
+}
+
+// TestCheckInnerInvariants_IllegalAccountCreatorFails verifies that the per-inner
+// pass rejects an account created by a transaction type not on the
+// ValidNewAccountRoot allow-list — proving the removed "Batch" carve-out is no
+// longer needed: each inner creation is validated under its own real type.
+func TestCheckInnerInvariants_IllegalAccountCreatorFails(t *testing.T) {
+	base := newMockBaseView()
+	senderID, _ := state.DecodeAccountID(innerInvSender)
+	recipientID, _ := state.DecodeAccountID(innerInvRecipient)
+	senderKey := keylet.Account(senderID)
+	recipientKey := keylet.Account(recipientID)
+
+	base.data[senderKey.Key] = mustAccount(t, innerInvSender, 10_000, 1)
+
+	e := innerInvariantEngine(base)
+	table := NewApplyStateTable(base, [32]byte{}, 100, e.rules())
+
+	// A net-zero XRP delta (sender debited, recipient created) but under an
+	// AccountDelete inner type, which may NOT create an account root.
+	if err := table.Update(senderKey, mustAccount(t, innerInvSender, 9_000, 2)); err != nil {
+		t.Fatalf("update sender: %v", err)
+	}
+	if err := table.Insert(recipientKey, mustAccount(t, innerInvRecipient, 1_000, 100)); err != nil {
+		t.Fatalf("insert recipient: %v", err)
+	}
+
+	innerTx := NewBaseTx(TypeAccountDelete, innerInvSender)
+	if got := e.CheckInnerInvariants(innerTx, TesSUCCESS, table); got != TecINVARIANT_FAILED {
+		t.Fatalf("illegal inner account creator: expected tecINVARIANT_FAILED, got %s", got)
+	}
+}

--- a/internal/tx/invariants/basic.go
+++ b/internal/tx/invariants/basic.go
@@ -189,21 +189,6 @@ func checkAccountRootsNotDeleted(txType string, result Result, entries []Invaria
 				Name:    "AccountRootsNotDeleted",
 				Message: fmt.Sprintf("%s may delete at most 1 AccountRoot, got %d", txType, deletedCount),
 			}
-		// A Batch may contain inner AccountDelete/AMMDelete transactions that
-		// delete account roots. In rippled, each inner tx runs through its own
-		// apply() with its own invariant check under its own tx type. In go-xrpl,
-		// the batch processes inner txns within a single engine table, so the
-		// invariant sees the combined result under the "Batch" tx type.
-		// Allow up to 1 account root deletion per batch.
-		// Reference: rippled apply.cpp applyBatchTransactions()
-		case "Batch":
-			if deletedCount <= 1 {
-				return nil
-			}
-			return &InvariantViolation{
-				Name:    "AccountRootsNotDeleted",
-				Message: fmt.Sprintf("Batch may delete at most 1 AccountRoot, got %d", deletedCount),
-			}
 		}
 	}
 
@@ -290,13 +275,10 @@ func checkValidNewAccountRoot(txType string, result Result, entries []InvariantE
 	}
 
 	// Only a successful transaction of a permitted type may create an
-	// AccountRoot. Batch is go-xrpl's necessary carve-out: rippled runs each
-	// inner tx through its own invariant pass, but go-xrpl applies the inner
-	// txs against the same engine table, so the outer Batch result inherits
-	// the new account.
+	// AccountRoot.
 	permitted := false
 	switch txType {
-	case "Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttestation", "Batch":
+	case "Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttestation":
 		permitted = result == TesSUCCESS
 	}
 	if !permitted {
@@ -319,7 +301,7 @@ func checkValidNewAccountRoot(txType string, result Result, entries []InvariantE
 	// before that amendment, sfVaultID does not exist as a serialized field
 	// and pseudo-account semantics are not enforced.
 	if pseudo && rules != nil && rules.Enabled(amendment.FeatureSingleAssetVault) {
-		if txType != "AMMCreate" && txType != "VaultCreate" && txType != "Batch" {
+		if txType != "AMMCreate" && txType != "VaultCreate" {
 			return &InvariantViolation{
 				Name:    "ValidNewAccountRoot",
 				Message: fmt.Sprintf("pseudo-account created by a wrong transaction type %s", txType),

--- a/internal/tx/invariants/invariants_test.go
+++ b/internal/tx/invariants/invariants_test.go
@@ -69,9 +69,10 @@ func TestXRPNotCreated_StrictEquality(t *testing.T) {
 	}
 }
 
-// TestValidNewAccountRoot_PermittedTypes ensures the allow-list now covers
-// VaultCreate and the XChain attestation tx types in addition to Payment /
-// AMMCreate / Batch.
+// TestValidNewAccountRoot_PermittedTypes ensures the allow-list covers
+// Payment / AMMCreate / VaultCreate and the XChain attestation tx types.
+// Batch is NOT in the list: rippled has no ttBATCH arm (InvariantCheck.cpp:
+// 964-967) because each inner tx is invariant-checked under its own type.
 // Reference: rippled InvariantCheck.cpp:964-967.
 func TestValidNewAccountRoot_PermittedTypes(t *testing.T) {
 	rules := amendment.AllSupportedRules()
@@ -83,13 +84,15 @@ func TestValidNewAccountRoot_PermittedTypes(t *testing.T) {
 	})
 	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: nil, After: newAcct}}
 
-	for _, txType := range []string{"Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttestation", "Batch"} {
+	for _, txType := range []string{"Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttestation"} {
 		if v := checkValidNewAccountRoot(txType, TesSUCCESS, entries, view, rules); v != nil {
 			t.Errorf("%s: unexpected violation %v", txType, v)
 		}
 	}
-	if v := checkValidNewAccountRoot("OfferCreate", TesSUCCESS, entries, view, rules); v == nil {
-		t.Fatalf("OfferCreate: expected violation creating AccountRoot")
+	for _, txType := range []string{"OfferCreate", "Batch"} {
+		if v := checkValidNewAccountRoot(txType, TesSUCCESS, entries, view, rules); v == nil {
+			t.Fatalf("%s: expected violation creating AccountRoot", txType)
+		}
 	}
 }
 
@@ -136,7 +139,7 @@ func rulesWithSingleAssetVault() *amendment.Rules {
 
 // TestValidNewAccountRoot_PseudoAccountWrongTxType: when featureSingleAssetVault
 // is enabled, a pseudo-account (sfAMMID set) created by a tx type other than
-// AMMCreate / VaultCreate / Batch must violate.
+// AMMCreate / VaultCreate must violate.
 // Reference: rippled Invariants_test.cpp:965-980, InvariantCheck.cpp:973-979.
 func TestValidNewAccountRoot_PseudoAccountWrongTxType(t *testing.T) {
 	rules := rulesWithSingleAssetVault()


### PR DESCRIPTION
## Summary

rippled runs each Batch inner transaction through full `apply()` with its own
invariant pass on its own `perTxBatchView` delta (`apply.cpp:189-207`,
`Transactor.cpp:1218-1238`); the outer `ttBATCH` pass only ever sees the batch
fee/sequence delta. goXRPL instead applied inner txs with **no** invariant pass
and compensated with non-rippled `"Batch"` carve-outs in the invariant checkers,
which both **false-positived** (a Batch funding two accounts → `tecINVARIANT_FAILED`,
because the combined outer delta counted `createdCount=2`) and **false-negatived**
(no per-inner-tx invariant defense).

This change:

- **Per-inner invariant pass** — `CheckInnerInvariants` runs the full invariant set
  on each inner tx's isolated `perTxTable` delta, under the inner tx's own type and
  result, with the same two-pass `tec→tef` escalation the engine uses for outer txs.
  The inner sender SLE is now written to the per-tx table **before** the pass so the
  inner delta is complete (otherwise `XRPNotCreated` saw a phantom credit).
- **Carve-out removal** — drops the `"Batch"` arm from `AccountRootsNotDeleted` and
  the two `"Batch"` entries in `ValidNewAccountRoot`'s creation + pseudo-account
  allow-lists. rippled has no `ttBATCH` arm in either checker (`InvariantCheck.cpp:
  382-385, 964-967`).
- **Outer pass** — `runInvariants` skips the combined-delta pass for `ttBATCH`, since
  the per-inner passes are now authoritative and rippled's outer pass only sees
  fee/sequence (which never violates these checkers). The tec-result invariant path
  (`applyTecRecovery`, issue #848) is untouched.

## Test plan

- [x] `TestActivateTwoAccounts` — a Batch whose inner txs fund **two** distinct new
  accounts now succeeds (previously `tecINVARIANT_FAILED`).
- [x] Three `CheckInnerInvariants` unit tests — legitimate inner create passes;
  XRP-creating inner delta → `tecINVARIANT_FAILED`; account created by a disallowed
  inner tx type → `tecINVARIANT_FAILED`.
- [x] `invariants_test` updated to assert Batch is now rejected by
  `ValidNewAccountRoot` (matches rippled).
- [x] `just test-tx` green; full batch + invariants suites green.
- [x] `just test-integration` green except `TestConformance`, whose failing set is
  **byte-identical** (241 tests, same names) on base and branch — pre-existing
  Vault/XChain out-of-scope + harness-gated Batch failures, verified by diffing
  against a clean `origin/main` worktree.
- [x] `go vet` clean.

Fixes #846