### PR TITLE
fix(rpc): default api_version to 1 and gate api_version 3 behind a beta config

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -268,6 +268,10 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 	ledgerAdapter := rpc.NewLedgerServiceAdapter(ledgerService)
 	services := types.NewServiceContainer(ledgerAdapter)
 
+	// Gate the beta RPC API (api_version 3) on the operator's beta_rpc_api
+	// knob, mirroring rippled Config::BETA_RPC_API.
+	services.BetaRPCAPI = globalConfig.BetaRPCAPI != 0
+
 	// Advisory-delete state (can_delete RPC). Available in both standalone and
 	// consensus modes; gated by node_db advisory_delete and persisted under
 	// database_path. Mirrors rippled's SHAMapStore advisory-delete state.

--- a/internal/rpc/api_version_gate_test.go
+++ b/internal/rpc/api_version_gate_test.go
@@ -71,19 +71,33 @@ func TestApiVersion_ExplicitV2(t *testing.T) {
 	}
 }
 
-// TestApiVersion_V3RejectedWithoutBeta verifies api_version:3 is rejected with
-// invalidApiVersion when beta_rpc_api is off, mirroring rippled
-// getAPIVersionNumber capping maxVersion at apiMaximumSupportedVersion.
+// TestApiVersion_V3RejectedWithoutBeta verifies api_version:3 is rejected on the
+// HTTP-single path exactly as rippled does: HTTP 400 with the bare token
+// "invalid_API_version" as the body, not a JSON-RPC result envelope
+// (ServerHandler.cpp:689 → HTTPReply(400, "invalid_API_version")).
 func TestApiVersion_V3RejectedWithoutBeta(t *testing.T) {
 	srv := versionEchoServer(t, false)
 
 	rr := postJSON(t, srv, `{"method":"ping","params":[{"api_version":3}]}`)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d\nbody: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d\nbody: %s", rr.Code, rr.Body.String())
 	}
-	result := decodeEnvelope(t, rr.Body.Bytes())
-	if got := result["error"]; got != "invalidApiVersion" {
-		t.Fatalf("v3 without beta error = %v, want invalidApiVersion\nbody: %s", got, rr.Body.String())
+	if got := strings.TrimSpace(rr.Body.String()); got != "invalid_API_version" {
+		t.Fatalf("v3 without beta body = %q, want bare token invalid_API_version", got)
+	}
+}
+
+// TestApiVersion_TooLowRejectedHTTPSingle verifies an api_version below the
+// minimum is also a bare 400 on the HTTP-single path.
+func TestApiVersion_TooLowRejectedHTTPSingle(t *testing.T) {
+	srv := versionEchoServer(t, false)
+
+	rr := postJSON(t, srv, `{"method":"ping","params":[{"api_version":0}]}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	if got := strings.TrimSpace(rr.Body.String()); got != "invalid_API_version" {
+		t.Fatalf("v0 body = %q, want bare token invalid_API_version", got)
 	}
 }
 
@@ -128,10 +142,32 @@ func TestApiVersion_BatchV3RejectedWithoutBeta(t *testing.T) {
 		t.Fatalf("expected 2 replies, got %d", len(replies))
 	}
 
-	el0 := replies[0]["result"].(map[string]any)
-	if el0["error"] != "invalidApiVersion" {
-		t.Fatalf("batch element 0 error = %v, want invalidApiVersion", el0["error"])
+	// rippled assigns make_json_error (which itself returns {"error": {code,
+	// message}}) to the element's "error" field, yielding the rippled-faithful
+	// double-nested {request: <element>, error: {error: {code: -32606, message:
+	// "invalid_API_version"}}} — not the XRPL result envelope
+	// (ServerHandler.cpp:594-603, 692-697).
+	if _, hasResult := replies[0]["result"]; hasResult {
+		t.Fatalf("batch element 0 should have no result envelope, got %v", replies[0])
 	}
+	if replies[0]["request"] == nil {
+		t.Fatalf("batch element 0 should echo the request, got %v", replies[0])
+	}
+	outer, ok := replies[0]["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("batch element 0 error is not an object: %v", replies[0]["error"])
+	}
+	errObj, ok := outer["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("batch element 0 error.error is not a JSON-RPC object: %v", outer)
+	}
+	if errObj["code"] != float64(types.WrongVersionJSONRPCCode) {
+		t.Fatalf("batch element 0 error.error.code = %v, want %d", errObj["code"], types.WrongVersionJSONRPCCode)
+	}
+	if errObj["message"] != "invalid_API_version" {
+		t.Fatalf("batch element 0 error.error.message = %v, want invalid_API_version", errObj["message"])
+	}
+
 	el1 := replies[1]["result"].(map[string]any)
 	if got := el1["api_version"]; got != float64(types.ApiVersion2) {
 		t.Fatalf("batch element 1 api_version = %v, want %d", got, types.ApiVersion2)
@@ -181,14 +217,24 @@ func wsRoundTrip(t *testing.T, ws *WebSocketServer, request string) types.WebSoc
 }
 
 // TestApiVersion_WS_V3GatedByBeta verifies the WebSocket dispatch path enforces
-// the same beta-gated version cap as the HTTP path: v3 is rejected with
-// invalidApiVersion when beta is off and accepted when it is on.
+// the same beta-gated version cap as the HTTP path: v3 is rejected with the bare
+// token invalid_API_version (no code, no message — ServerHandler.cpp:454-455)
+// when beta is off and accepted when it is on.
 func TestApiVersion_WS_V3GatedByBeta(t *testing.T) {
 	t.Run("rejected_without_beta", func(t *testing.T) {
 		ws := versionEchoWSServer(t, false)
 		resp := wsRoundTrip(t, ws, `{"command":"ping","api_version":3}`)
-		if resp.Error != "invalidApiVersion" {
-			t.Fatalf("WS v3 without beta error = %q, want invalidApiVersion", resp.Error)
+		if resp.Error != "invalid_API_version" {
+			t.Fatalf("WS v3 without beta error = %q, want invalid_API_version", resp.Error)
+		}
+		if resp.ErrorCode != 0 {
+			t.Fatalf("WS invalid_API_version should carry no error_code, got %d", resp.ErrorCode)
+		}
+		if resp.ErrorMessage != "" {
+			t.Fatalf("WS invalid_API_version should carry no error_message, got %q", resp.ErrorMessage)
+		}
+		if resp.Status != "error" {
+			t.Fatalf("WS v3 without beta status = %q, want error", resp.Status)
 		}
 	})
 

--- a/internal/rpc/api_version_gate_test.go
+++ b/internal/rpc/api_version_gate_test.go
@@ -1,0 +1,218 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/gorilla/websocket"
+)
+
+// versionEchoServer builds an HTTP server whose single "ping" method echoes the
+// resolved api_version, so tests can assert default resolution and beta gating
+// end-to-end through ServeHTTP. The handler advertises support for all three
+// versions; the dispatch-layer cap, not the handler set, is what gates v3.
+func versionEchoServer(t *testing.T, beta bool) *Server {
+	t.Helper()
+	srv := &Server{
+		registry: types.NewMethodRegistry(),
+		timeout:  time.Second,
+		services: types.NewServiceContainer(nil),
+	}
+	srv.services.BetaRPCAPI = beta
+	srv.registry.Register("ping", &stubHandler{
+		apiVers: []int{types.ApiVersion1, types.ApiVersion2, types.ApiVersion3},
+		handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
+			return map[string]any{"api_version": ctx.ApiVersion}, nil
+		},
+	})
+	return srv
+}
+
+func postJSON(t *testing.T, srv *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	req.RemoteAddr = "10.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestApiVersion_UnspecifiedDefaultsToV1 verifies a request that omits
+// api_version is served as v1, matching rippled apiVersionIfUnspecified = 1.
+func TestApiVersion_UnspecifiedDefaultsToV1(t *testing.T) {
+	srv := versionEchoServer(t, false)
+
+	rr := postJSON(t, srv, `{"method":"ping","params":[{}]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	result := decodeEnvelope(t, rr.Body.Bytes())
+	if got := result["api_version"]; got != float64(types.ApiVersion1) {
+		t.Fatalf("unspecified api_version resolved to %v, want %d", got, types.ApiVersion1)
+	}
+}
+
+// TestApiVersion_ExplicitV2 verifies an explicit api_version:2 is honoured.
+func TestApiVersion_ExplicitV2(t *testing.T) {
+	srv := versionEchoServer(t, false)
+
+	rr := postJSON(t, srv, `{"method":"ping","params":[{"api_version":2}]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	result := decodeEnvelope(t, rr.Body.Bytes())
+	if got := result["api_version"]; got != float64(types.ApiVersion2) {
+		t.Fatalf("api_version resolved to %v, want %d", got, types.ApiVersion2)
+	}
+}
+
+// TestApiVersion_V3RejectedWithoutBeta verifies api_version:3 is rejected with
+// invalidApiVersion when beta_rpc_api is off, mirroring rippled
+// getAPIVersionNumber capping maxVersion at apiMaximumSupportedVersion.
+func TestApiVersion_V3RejectedWithoutBeta(t *testing.T) {
+	srv := versionEchoServer(t, false)
+
+	rr := postJSON(t, srv, `{"method":"ping","params":[{"api_version":3}]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	result := decodeEnvelope(t, rr.Body.Bytes())
+	if got := result["error"]; got != "invalidApiVersion" {
+		t.Fatalf("v3 without beta error = %v, want invalidApiVersion\nbody: %s", got, rr.Body.String())
+	}
+}
+
+// TestApiVersion_V3AcceptedWithBeta verifies api_version:3 is accepted when
+// beta_rpc_api is configured.
+func TestApiVersion_V3AcceptedWithBeta(t *testing.T) {
+	srv := versionEchoServer(t, true)
+
+	rr := postJSON(t, srv, `{"method":"ping","params":[{"api_version":3}]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	result := decodeEnvelope(t, rr.Body.Bytes())
+	if got := result["error"]; got != nil {
+		t.Fatalf("v3 with beta unexpectedly errored: %v\nbody: %s", got, rr.Body.String())
+	}
+	if got := result["api_version"]; got != float64(types.ApiVersion3) {
+		t.Fatalf("v3 with beta resolved to %v, want %d", got, types.ApiVersion3)
+	}
+}
+
+// TestApiVersion_BatchV3RejectedWithoutBeta verifies the same cap applies to a
+// batch element: rippled rejects an over-max version per element with
+// invalid_API_version (ServerHandler.cpp:692-697).
+func TestApiVersion_BatchV3RejectedWithoutBeta(t *testing.T) {
+	srv := versionEchoServer(t, false)
+
+	body := `{"method":"batch","params":[
+		{"method":"ping","api_version":3},
+		{"method":"ping","api_version":2}
+	]}`
+	rr := postJSON(t, srv, body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+
+	var replies []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &replies); err != nil {
+		t.Fatalf("batch reply is not a JSON array: %v\nbody: %s", err, rr.Body.String())
+	}
+	if len(replies) != 2 {
+		t.Fatalf("expected 2 replies, got %d", len(replies))
+	}
+
+	el0 := replies[0]["result"].(map[string]any)
+	if el0["error"] != "invalidApiVersion" {
+		t.Fatalf("batch element 0 error = %v, want invalidApiVersion", el0["error"])
+	}
+	el1 := replies[1]["result"].(map[string]any)
+	if got := el1["api_version"]; got != float64(types.ApiVersion2) {
+		t.Fatalf("batch element 1 api_version = %v, want %d", got, types.ApiVersion2)
+	}
+}
+
+// versionEchoWSServer registers a ping echo on a WebSocket server with the
+// given beta flag.
+func versionEchoWSServer(t *testing.T, beta bool) *WebSocketServer {
+	t.Helper()
+	ws := NewWebSocketServer(30*time.Second, types.NewServiceContainer(nil))
+	ws.services.BetaRPCAPI = beta
+	ws.methodRegistry.Register("ping", &stubHandler{
+		apiVers: []int{types.ApiVersion1, types.ApiVersion2, types.ApiVersion3},
+		handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
+			return map[string]any{"api_version": ctx.ApiVersion}, nil
+		},
+	})
+	return ws
+}
+
+func wsRoundTrip(t *testing.T, ws *WebSocketServer, request string) types.WebSocketResponse {
+	t.Helper()
+	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
+	defer httpSrv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(request)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var resp types.WebSocketResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nraw: %s", err, string(raw))
+	}
+	return resp
+}
+
+// TestApiVersion_WS_V3GatedByBeta verifies the WebSocket dispatch path enforces
+// the same beta-gated version cap as the HTTP path: v3 is rejected with
+// invalidApiVersion when beta is off and accepted when it is on.
+func TestApiVersion_WS_V3GatedByBeta(t *testing.T) {
+	t.Run("rejected_without_beta", func(t *testing.T) {
+		ws := versionEchoWSServer(t, false)
+		resp := wsRoundTrip(t, ws, `{"command":"ping","api_version":3}`)
+		if resp.Error != "invalidApiVersion" {
+			t.Fatalf("WS v3 without beta error = %q, want invalidApiVersion", resp.Error)
+		}
+	})
+
+	t.Run("accepted_with_beta", func(t *testing.T) {
+		ws := versionEchoWSServer(t, true)
+		resp := wsRoundTrip(t, ws, `{"command":"ping","api_version":3}`)
+		if resp.Error != "" {
+			t.Fatalf("WS v3 with beta unexpectedly errored: %q", resp.Error)
+		}
+		if resp.Status != "success" {
+			t.Fatalf("WS v3 with beta status = %q, want success", resp.Status)
+		}
+	})
+}
+
+// TestApiVersion_WS_UnspecifiedDefaultsToV1 verifies a WS command without
+// api_version resolves to v1.
+func TestApiVersion_WS_UnspecifiedDefaultsToV1(t *testing.T) {
+	ws := versionEchoWSServer(t, false)
+	resp := wsRoundTrip(t, ws, `{"command":"ping"}`)
+	if resp.Status != "success" {
+		t.Fatalf("WS ping status = %q, want success", resp.Status)
+	}
+	if resp.ApiVersion != types.ApiVersion1 {
+		t.Fatalf("WS unspecified api_version resolved to %d, want %d", resp.ApiVersion, types.ApiVersion1)
+	}
+}

--- a/internal/rpc/api_version_test.go
+++ b/internal/rpc/api_version_test.go
@@ -158,14 +158,16 @@ func TestApiVersionConstants(t *testing.T) {
 	assert.Equal(t, types.ApiVersion1, types.DefaultApiVersion,
 		"DefaultApiVersion should equal ApiVersion1 (rippled apiVersionIfUnspecified)")
 
-	// Cross-check with the version handler response. With beta disabled
-	// (the default), `last` is capped at MaxSupportedApiVersion (2),
-	// matching rippled setVersion when BETA_RPC_API is off.
+	// Cross-check with the version handler response under an api_version >= 2
+	// request, whose numeric branch carries the beta-gated `last`. With beta
+	// disabled (the default), `last` is capped at MaxSupportedApiVersion (2),
+	// matching rippled setVersion when BETA_RPC_API is off. v2+ emits numeric
+	// first/last and no `good` field.
 	method := &handlers.VersionMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
+		ApiVersion: types.ApiVersion2,
 	}
 	result, rpcErr := method.Handle(ctx, nil)
 	require.Nil(t, rpcErr, "version handler should not error")
@@ -180,11 +182,11 @@ func TestApiVersionConstants(t *testing.T) {
 	require.True(t, ok, "version handler should return a 'version' object")
 
 	assert.Equal(t, float64(types.ApiVersion1), versionMap["first"],
-		"version.first should match ApiVersion1")
+		"version.first should be numeric apiMinimumSupportedVersion (1)")
 	assert.Equal(t, float64(types.MaxSupportedApiVersion), versionMap["last"],
 		"version.last should be capped at MaxSupportedApiVersion when beta is off")
-	assert.Equal(t, float64(types.ApiVersion2), versionMap["good"],
-		"version.good should match ApiVersion2")
+	assert.NotContains(t, versionMap, "good",
+		"v2+ version response must not emit a `good` field")
 }
 
 // Test 2: TestApiVersionAllMethodsDeclareVersions

--- a/internal/rpc/api_version_test.go
+++ b/internal/rpc/api_version_test.go
@@ -153,11 +153,14 @@ func TestApiVersionConstants(t *testing.T) {
 	assert.LessOrEqual(t, types.DefaultApiVersion, maxAPI,
 		"DefaultApiVersion should be <= MAX_API_VERSION")
 
-	// DefaultApiVersion should match rippled's apiVersionIfUnspecified (2).
-	assert.Equal(t, types.ApiVersion2, types.DefaultApiVersion,
-		"DefaultApiVersion should equal ApiVersion2 (rippled apiVersionIfUnspecified)")
+	// DefaultApiVersion should match rippled's apiVersionIfUnspecified (1):
+	// a request that omits api_version is served as v1.
+	assert.Equal(t, types.ApiVersion1, types.DefaultApiVersion,
+		"DefaultApiVersion should equal ApiVersion1 (rippled apiVersionIfUnspecified)")
 
-	// Cross-check with the version handler response (which reports the range).
+	// Cross-check with the version handler response. With beta disabled
+	// (the default), `last` is capped at MaxSupportedApiVersion (2),
+	// matching rippled setVersion when BETA_RPC_API is off.
 	method := &handlers.VersionMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
@@ -178,8 +181,8 @@ func TestApiVersionConstants(t *testing.T) {
 
 	assert.Equal(t, float64(types.ApiVersion1), versionMap["first"],
 		"version.first should match ApiVersion1")
-	assert.Equal(t, float64(types.ApiVersion3), versionMap["last"],
-		"version.last should match ApiVersion3")
+	assert.Equal(t, float64(types.MaxSupportedApiVersion), versionMap["last"],
+		"version.last should be capped at MaxSupportedApiVersion when beta is off")
 	assert.Equal(t, float64(types.ApiVersion2), versionMap["good"],
 		"version.good should match ApiVersion2")
 }

--- a/internal/rpc/handlers/version.go
+++ b/internal/rpc/handlers/version.go
@@ -6,26 +6,41 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// VersionMethod reports the server's API version range. The upper bound
-// (`last`) tracks the beta_rpc_api config knob: BetaApiVersion when beta is
-// enabled, otherwise MaxSupportedApiVersion — matching rippled setVersion
-// (RPCHelpers.h) which caps `last` at apiBetaVersion only when BETA_RPC_API is
-// configured.
+// VersionMethod reports the server's API version range, mirroring rippled's
+// setVersion (RPCHelpers.h:211-231), whose output shape depends on the
+// resolved request api_version:
+//
+//   - api_version 1 (apiVersionIfUnspecified): first/good/last are the
+//     SemanticVersion strings firstVersion/goodVersion/lastVersion, all "1.0.0"
+//     (RPCHelpers.cpp:1001-1003).
+//   - api_version >= 2: numeric first (= apiMinimumSupportedVersion, 1) and
+//     last (apiBetaVersion when beta is on, else apiMaximumSupportedVersion),
+//     with NO `good` field.
 type VersionMethod struct{ BaseHandler }
 
-func (m *VersionMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	last := types.MaxSupportedApiVersion
-	if ctx.Services != nil && ctx.Services.BetaRPCAPI {
-		last = types.BetaApiVersion
-	}
+// semanticVersion1 is the fixed "1.0.0" SemanticVersion rippled prints for
+// first/good/last under api_version 1 (firstVersion/goodVersion/lastVersion,
+// RPCHelpers.cpp:1001-1003).
+const semanticVersion1 = "1.0.0"
 
-	response := map[string]any{
-		"version": map[string]any{
+func (m *VersionMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	var version map[string]any
+	if ctx.ApiVersion == types.ApiVersion1 {
+		version = map[string]any{
+			"first": semanticVersion1,
+			"good":  semanticVersion1,
+			"last":  semanticVersion1,
+		}
+	} else {
+		last := types.MaxSupportedApiVersion
+		if ctx.Services != nil && ctx.Services.BetaRPCAPI {
+			last = types.BetaApiVersion
+		}
+		version = map[string]any{
 			"first": types.ApiVersion1,
 			"last":  last,
-			"good":  types.ApiVersion2,
-		},
+		}
 	}
 
-	return response, nil
+	return map[string]any{"version": version}, nil
 }

--- a/internal/rpc/handlers/version.go
+++ b/internal/rpc/handlers/version.go
@@ -6,8 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-// VersionMethod handles the version RPC method.
-// Returns API version information for the server. The reported upper bound
+// VersionMethod reports the server's API version range. The upper bound
 // (`last`) tracks the beta_rpc_api config knob: BetaApiVersion when beta is
 // enabled, otherwise MaxSupportedApiVersion — matching rippled setVersion
 // (RPCHelpers.h) which caps `last` at apiBetaVersion only when BETA_RPC_API is

--- a/internal/rpc/handlers/version.go
+++ b/internal/rpc/handlers/version.go
@@ -7,16 +7,23 @@ import (
 )
 
 // VersionMethod handles the version RPC method.
-// Returns API version information for the server.
-// IMPLEMENTED: Returns the supported API version range.
-// Reference: rippled Version.h (VersionHandler)
+// Returns API version information for the server. The reported upper bound
+// (`last`) tracks the beta_rpc_api config knob: BetaApiVersion when beta is
+// enabled, otherwise MaxSupportedApiVersion — matching rippled setVersion
+// (RPCHelpers.h) which caps `last` at apiBetaVersion only when BETA_RPC_API is
+// configured.
 type VersionMethod struct{ BaseHandler }
 
 func (m *VersionMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	last := types.MaxSupportedApiVersion
+	if ctx.Services != nil && ctx.Services.BetaRPCAPI {
+		last = types.BetaApiVersion
+	}
+
 	response := map[string]any{
 		"version": map[string]any{
 			"first": types.ApiVersion1,
-			"last":  types.ApiVersion3,
+			"last":  last,
 			"good":  types.ApiVersion2,
 		},
 	}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -323,9 +323,29 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 
 	result, rpcErr := s.executeMethod(request.Method, params, ctx)
 
+	// rippled answers an unsupported api_version on the HTTP-single path with
+	// HTTPReply(400, "invalid_API_version") — a 400 whose body is the bare
+	// token, not a JSON-RPC result envelope (ServerHandler.cpp:687-690).
+	if rpcErr != nil && rpcErr.IsInvalidApiVersion() {
+		writeInvalidApiVersionHTTP(w)
+		return
+	}
+
 	requestObj := buildRequestEcho(request.Method, params)
 
 	s.writeXrplResponse(w, request.Method, requestObj, result, rpcErr)
+}
+
+// writeInvalidApiVersionHTTP mirrors rippled's HTTP-single rejection of an
+// unsupported api_version: HTTP 400 with the bare token as the response body
+// (ServerHandler.cpp:689 → HTTPReply(400, ...)). The body carries no JSON
+// envelope, matching rippled's plain-string reply.
+func writeInvalidApiVersionHTTP(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusBadRequest)
+	if _, err := io.WriteString(w, types.InvalidApiVersionToken); err != nil {
+		rpcLog().Error("Failed to write invalid_API_version response", "err", err)
+	}
 }
 
 // applyApiVersionFromObject overrides ctx.ApiVersion when the given JSON object
@@ -404,6 +424,21 @@ func (s *Server) dispatchBatchElement(el json.RawMessage, baseCtx context.Contex
 	}
 
 	result, rpcErr := s.executeMethod(method, el, ctx)
+
+	// rippled rejects an unsupported api_version per batch element with
+	// {request: <element>, error: make_json_error(wrong_version,
+	// "invalid_API_version")} — a JSON-RPC error object, not the XRPL result
+	// envelope (ServerHandler.cpp:692-697). The element is echoed raw (its own
+	// fields, no injected `command`), so redact credentials but keep the shape.
+	if rpcErr != nil && rpcErr.IsInvalidApiVersion() {
+		echo := make(map[string]any, len(elem))
+		maps.Copy(echo, elem)
+		redactCredentials(echo)
+		return map[string]any{
+			"request": echo,
+			"error":   makeBatchJSONError(types.WrongVersionJSONRPCCode, types.InvalidApiVersionToken),
+		}
+	}
 
 	echo := make(map[string]any, len(elem)+1)
 	maps.Copy(echo, elem)

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -518,12 +518,8 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 		return nil, rpcErr
 	}
 
-	supportedVersions := handler.SupportedApiVersions()
-	if len(supportedVersions) > 0 {
-		supported := slices.Contains(supportedVersions, ctx.ApiVersion)
-		if !supported {
-			return nil, types.RpcErrorInvalidApiVersion(strconv.Itoa(ctx.ApiVersion))
-		}
+	if rpcErr := validateApiVersion(ctx, handler); rpcErr != nil {
+		return nil, rpcErr
 	}
 
 	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
@@ -539,6 +535,34 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 	result, rpcErr := handler.Handle(ctx, params)
 	finalizeLoad(s.loadTracker, ctx, method, handler, rpcErr, rpcLog())
 	return result, rpcErr
+}
+
+// betaEnabled reports whether the operator turned on the beta RPC API for
+// this request. nil-safe: a request without a service container (routing-only
+// tests) is treated as non-beta.
+func betaEnabled(ctx *types.RpcContext) bool {
+	return ctx.Services != nil && ctx.Services.BetaRPCAPI
+}
+
+// validateApiVersion enforces the accepted api_version range, mirroring
+// rippled's two checks: the dispatch-layer cap (getAPIVersionNumber rejecting
+// anything above apiBetaVersion when beta is off, ServerHandler.cpp:685-695),
+// and the per-handler support set (Handler.cpp:257-263). A version above the
+// beta-gated maximum, or one the handler does not list, yields
+// invalid_API_version.
+func validateApiVersion(ctx *types.RpcContext, handler types.MethodHandler) *types.RpcError {
+	maxVersion := types.MaxSupportedApiVersion
+	if betaEnabled(ctx) {
+		maxVersion = types.BetaApiVersion
+	}
+	if ctx.ApiVersion < types.ApiVersion1 || ctx.ApiVersion > maxVersion {
+		return types.RpcErrorInvalidApiVersion(strconv.Itoa(ctx.ApiVersion))
+	}
+	supportedVersions := handler.SupportedApiVersions()
+	if len(supportedVersions) > 0 && !slices.Contains(supportedVersions, ctx.ApiVersion) {
+		return types.RpcErrorInvalidApiVersion(strconv.Itoa(ctx.ApiVersion))
+	}
+	return nil
 }
 
 // maxValidatedLedgerAge mirrors rippled's Tuning::maxValidatedLedgerAge

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -33,12 +33,30 @@ type RpcError struct {
 	// rippled's bare path writes neither error_code nor error_message, so the
 	// wire emitters omit both when this is set.
 	bareToken bool
+
+	// invalidApiVersion marks the unsupported-api_version rejection, which
+	// rippled emits at the ServerHandler transport layer — never through the
+	// error_code_i enum — with a shape that differs per transport
+	// (ServerHandler.cpp:443-468, 685-697): HTTP single is a bare-string 400,
+	// each batch element is a make_json_error JSON-RPC object, and WS is a lone
+	// `error` token. Transport writers special-case this flag so go-xrpl mirrors
+	// each path exactly without disturbing the table-driven error model.
+	invalidApiVersion bool
 }
 
 // IsBareToken reports whether this error mirrors a rippled bare-token response
-// (only the `error` field on the wire, no error_code / error_message).
+// (only the `error` field on the wire, no error_code / error_message). The
+// invalid-api_version rejection is bare on every transport that still carries
+// a JSON-RPC result envelope (WS, batch-via-result), so it counts as one.
 func (e RpcError) IsBareToken() bool {
-	return e.bareToken
+	return e.bareToken || e.invalidApiVersion
+}
+
+// IsInvalidApiVersion reports whether this error is the unsupported-api_version
+// rejection, whose wire shape rippled varies by transport (HTTP single → 400
+// bare string; batch element → make_json_error object; WS → bare token).
+func (e RpcError) IsInvalidApiVersion() bool {
+	return e.invalidApiVersion
 }
 
 func (e RpcError) Error() string {
@@ -276,8 +294,27 @@ func RpcErrorShutDown(message string) *RpcError {
 	return NewRpcError(RpcSHUT_DOWN, "shutDown", "shutDown", message)
 }
 
+// InvalidApiVersionToken is the literal rippled writes for an unsupported
+// api_version (jss::invalid_API_version). rippled emits it bare — no numeric
+// code, no message — on every transport; only the envelope differs
+// (ServerHandler.cpp:454-455, 689, 694-695).
+const InvalidApiVersionToken = "invalid_API_version"
+
+// WrongVersionJSONRPCCode is the JSON-RPC error code rippled attaches to an
+// invalid-api_version batch element via make_json_error (ServerHandler.cpp:608,
+// wrong_version = -32606).
+const WrongVersionJSONRPCCode = -32606
+
+// RpcErrorInvalidApiVersion reports an unsupported api_version. rippled rejects
+// this at the ServerHandler transport layer, never through the error_code_i
+// enum, so the token is the bare jss::invalid_API_version and the per-transport
+// wire shape is finalized by the transport writers (see IsInvalidApiVersion).
+// The internal code stays at the go-xrpl slot 38 to keep this distinct from
+// every real rippled code; it is not emitted on the wire.
 func RpcErrorInvalidApiVersion(version string) *RpcError {
-	return NewRpcError(RpcINVALID_API_VERSION, "invalidApiVersion", "invalidApiVersion", "Invalid API version: "+version)
+	e := NewRpcError(RpcINVALID_API_VERSION, InvalidApiVersionToken, InvalidApiVersionToken, "")
+	e.invalidApiVersion = true
+	return e
 }
 
 // RpcErrorNotEnabled returns rippled's rpcNOT_ENABLED (code 12, token

--- a/internal/rpc/types/errors_test.go
+++ b/internal/rpc/types/errors_test.go
@@ -182,7 +182,7 @@ func TestErrorConstructorsTokenCodePairs(t *testing.T) {
 		{RpcErrorDomainMalformed(""), "domainMalformed", 97},
 		{RpcErrorDstActNotFound("x"), "dstActNotFound", 50},
 		{RpcErrorFieldNotFoundTransaction(), "fieldNotFoundTransaction", RpcUNKNOWN},
-		{RpcErrorInvalidApiVersion("3"), "invalidApiVersion", RpcINVALID_API_VERSION},
+		{RpcErrorInvalidApiVersion("3"), "invalid_API_version", RpcINVALID_API_VERSION},
 	}
 	for _, c := range cases {
 		if c.err.ErrorString != c.token {
@@ -205,6 +205,9 @@ func TestBareTokenErrors(t *testing.T) {
 		RpcErrorUnknownOption("x"),
 		RpcErrorFieldNotFoundTransaction(),
 		RpcErrorNotStandalone("x"),
+		// rippled emits invalid_API_version bare on every transport that still
+		// carries a result envelope (WS, batch-via-result): no code, no message.
+		RpcErrorInvalidApiVersion("3"),
 	}
 	for _, e := range bare {
 		if !e.IsBareToken() {
@@ -221,5 +224,29 @@ func TestBareTokenErrors(t *testing.T) {
 		if e.IsBareToken() {
 			t.Errorf("%q must not be a bare token", e.ErrorString)
 		}
+	}
+}
+
+// TestInvalidApiVersionError pins the rippled-exact token and the transport
+// marker that drives the per-transport wire shape. rippled emits the bare
+// jss::invalid_API_version token with no numeric code or message
+// (ServerHandler.cpp:454-455, 689, 694-695).
+func TestInvalidApiVersionError(t *testing.T) {
+	e := RpcErrorInvalidApiVersion("3")
+	if e.ErrorString != InvalidApiVersionToken {
+		t.Errorf("token = %q, want %q", e.ErrorString, InvalidApiVersionToken)
+	}
+	if e.ErrorString != "invalid_API_version" {
+		t.Errorf("token = %q, want underscored rippled spelling", e.ErrorString)
+	}
+	if !e.IsInvalidApiVersion() {
+		t.Error("RpcErrorInvalidApiVersion should report IsInvalidApiVersion")
+	}
+	if e.Message != "" {
+		t.Errorf("error_message = %q, want empty (rippled omits it)", e.Message)
+	}
+	// Only the invalid-version error carries the transport marker.
+	if RpcErrorInternal("x").IsInvalidApiVersion() {
+		t.Error("unrelated error must not report IsInvalidApiVersion")
 	}
 }

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -231,6 +231,13 @@ type ServiceContainer struct {
 	// (rippled getJson at ValidatorList.cpp:1737-1744). Nil-safe.
 	NegativeUNLBase58 func() []string
 
+	// BetaRPCAPI reports whether the operator enabled the beta RPC API
+	// (beta_rpc_api config knob, rippled Config::BETA_RPC_API). When set,
+	// requests may use api_version up to BetaApiVersion; otherwise the
+	// accepted range is capped at MaxSupportedApiVersion. The `version`
+	// method reports `last` accordingly.
+	BetaRPCAPI bool
+
 	// TxQMetrics returns the current transaction-queue metrics used by
 	// server_info for the load_factor_fee_* triple. Nil until the
 	// ledger service is wired (standalone tests, pre-startup) —

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -11,10 +11,20 @@ import (
 
 // XRPL API Version constants
 const (
-	ApiVersion1       = 1
-	ApiVersion2       = 2
-	ApiVersion3       = 3
-	DefaultApiVersion = ApiVersion2
+	ApiVersion1 = 1
+	ApiVersion2 = 2
+	ApiVersion3 = 3
+	// DefaultApiVersion is the version assumed when a request omits
+	// api_version. Matches rippled's apiVersionIfUnspecified = 1
+	// (ApiVersion.h): every request expecting a v2+ response shape must
+	// set api_version explicitly.
+	DefaultApiVersion = ApiVersion1
+	// MaxSupportedApiVersion is the highest non-beta version a request may
+	// reach (rippled apiMaximumSupportedVersion).
+	MaxSupportedApiVersion = ApiVersion2
+	// BetaApiVersion is the highest version accepted only when the
+	// beta_rpc_api config knob is set (rippled apiBetaVersion).
+	BetaApiVersion = ApiVersion3
 )
 
 // Role-based access control matching rippled's Role enum (Role.h).

--- a/internal/rpc/version_test.go
+++ b/internal/rpc/version_test.go
@@ -45,10 +45,49 @@ func TestVersionReturnsVersionInfo(t *testing.T) {
 
 	assert.Equal(t, float64(types.ApiVersion1), version["first"],
 		"first should be ApiVersion1")
-	assert.Equal(t, float64(types.ApiVersion3), version["last"],
-		"last should be ApiVersion3")
+	assert.Equal(t, float64(types.MaxSupportedApiVersion), version["last"],
+		"last should be capped at MaxSupportedApiVersion when beta is disabled")
 	assert.Equal(t, float64(types.ApiVersion2), version["good"],
 		"good should be ApiVersion2")
+}
+
+// TestVersionLastTracksBetaFlag verifies that the `version` method reports
+// `last:2` when beta_rpc_api is off and `last:3` when it is on, mirroring
+// rippled setVersion which caps `last` at apiBetaVersion only with BETA_RPC_API.
+func TestVersionLastTracksBetaFlag(t *testing.T) {
+	method := &handlers.VersionMethod{}
+
+	cases := []struct {
+		name     string
+		beta     bool
+		wantLast int
+	}{
+		{"beta_disabled", false, types.MaxSupportedApiVersion},
+		{"beta_enabled", true, types.BetaApiVersion},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &types.RpcContext{
+				Context:    context.Background(),
+				Role:       types.RoleGuest,
+				ApiVersion: types.ApiVersion1,
+				Services:   &types.ServiceContainer{BetaRPCAPI: tc.beta},
+			}
+
+			result, rpcErr := method.Handle(ctx, nil)
+			require.Nil(t, rpcErr)
+
+			resultJSON, err := json.Marshal(result)
+			require.NoError(t, err)
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(resultJSON, &resp))
+
+			version := resp["version"].(map[string]any)
+			assert.Equal(t, float64(types.ApiVersion1), version["first"])
+			assert.Equal(t, float64(tc.wantLast), version["last"])
+		})
+	}
 }
 
 // TestVersionResponseStructure validates the response structure in detail.

--- a/internal/rpc/version_test.go
+++ b/internal/rpc/version_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestVersionReturnsVersionInfo tests that the version method returns API version range.
-// Based on rippled Version_test.cpp testCorrectVersionNumber() and testVersionRPCV2()
+// TestVersionReturnsVersionInfo tests the version method's api_version 1 shape:
+// first/good/last are the SemanticVersion strings "1.0.0", mirroring rippled
+// setVersion's apiVersionIfUnspecified branch (RPCHelpers.h:219-224 with
+// firstVersion/goodVersion/lastVersion = "1.0.0", RPCHelpers.cpp:1001-1003).
 func TestVersionReturnsVersionInfo(t *testing.T) {
 	method := &handlers.VersionMethod{}
 	ctx := &types.RpcContext{
@@ -38,22 +40,70 @@ func TestVersionReturnsVersionInfo(t *testing.T) {
 
 	version := resp["version"].(map[string]any)
 
-	// Verify first, last, good fields exist and have correct values
+	// api_version 1: first/good/last are SemanticVersion strings, all "1.0.0".
 	assert.Contains(t, version, "first")
 	assert.Contains(t, version, "last")
 	assert.Contains(t, version, "good")
 
-	assert.Equal(t, float64(types.ApiVersion1), version["first"],
-		"first should be ApiVersion1")
-	assert.Equal(t, float64(types.MaxSupportedApiVersion), version["last"],
-		"last should be capped at MaxSupportedApiVersion when beta is disabled")
-	assert.Equal(t, float64(types.ApiVersion2), version["good"],
-		"good should be ApiVersion2")
+	assert.Equal(t, "1.0.0", version["first"],
+		"v1 first should be the SemanticVersion string 1.0.0")
+	assert.Equal(t, "1.0.0", version["good"],
+		"v1 good should be the SemanticVersion string 1.0.0")
+	assert.Equal(t, "1.0.0", version["last"],
+		"v1 last should be the SemanticVersion string 1.0.0")
+}
+
+// TestVersionV2ShapeNumericNoGood verifies the api_version >= 2 shape: numeric
+// first (= 1) and last (beta-gated), with NO `good` field — mirroring rippled
+// setVersion's else branch (RPCHelpers.h:227-229) and Version_test.cpp
+// testVersionRPCV2.
+func TestVersionV2ShapeNumericNoGood(t *testing.T) {
+	method := &handlers.VersionMethod{}
+
+	cases := []struct {
+		name     string
+		version  int
+		beta     bool
+		wantLast int
+	}{
+		{"v2_beta_off", types.ApiVersion2, false, types.MaxSupportedApiVersion},
+		{"v2_beta_on", types.ApiVersion2, true, types.BetaApiVersion},
+		{"v3_beta_on", types.ApiVersion3, true, types.BetaApiVersion},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &types.RpcContext{
+				Context:    context.Background(),
+				Role:       types.RoleGuest,
+				ApiVersion: tc.version,
+				Services:   &types.ServiceContainer{BetaRPCAPI: tc.beta},
+			}
+
+			result, rpcErr := method.Handle(ctx, nil)
+			require.Nil(t, rpcErr)
+
+			resultJSON, err := json.Marshal(result)
+			require.NoError(t, err)
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(resultJSON, &resp))
+
+			version := resp["version"].(map[string]any)
+			assert.Equal(t, float64(types.ApiVersion1), version["first"],
+				"v2+ first should be numeric apiMinimumSupportedVersion (1)")
+			assert.Equal(t, float64(tc.wantLast), version["last"],
+				"v2+ last should be numeric, beta-gated")
+			assert.NotContains(t, version, "good",
+				"v2+ must NOT emit a `good` field")
+		})
+	}
 }
 
 // TestVersionLastTracksBetaFlag verifies that the `version` method reports
 // `last:2` when beta_rpc_api is off and `last:3` when it is on, mirroring
 // rippled setVersion which caps `last` at apiBetaVersion only with BETA_RPC_API.
+// The beta-gated `last` lives in the numeric (api_version >= 2) branch, so the
+// request is resolved at v2.
 func TestVersionLastTracksBetaFlag(t *testing.T) {
 	method := &handlers.VersionMethod{}
 
@@ -71,7 +121,7 @@ func TestVersionLastTracksBetaFlag(t *testing.T) {
 			ctx := &types.RpcContext{
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
-				ApiVersion: types.ApiVersion1,
+				ApiVersion: types.ApiVersion2,
 				Services:   &types.ServiceContainer{BetaRPCAPI: tc.beta},
 			}
 
@@ -90,14 +140,16 @@ func TestVersionLastTracksBetaFlag(t *testing.T) {
 	}
 }
 
-// TestVersionResponseStructure validates the response structure in detail.
-// Based on rippled Version_test.cpp - version result should contain "version" object with numeric fields
+// TestVersionResponseStructure validates the api_version >= 2 response
+// structure in detail: a single top-level "version" object with numeric
+// first/last and no `good` field (rippled setVersion else branch,
+// RPCHelpers.h:227-229).
 func TestVersionResponseStructure(t *testing.T) {
 	method := &handlers.VersionMethod{}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
+		ApiVersion: types.ApiVersion2,
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -115,7 +167,7 @@ func TestVersionResponseStructure(t *testing.T) {
 
 	version := resp["version"].(map[string]any)
 
-	// All version fields should be numeric
+	// v2+ first/last are numeric.
 	first, ok := version["first"].(float64)
 	assert.True(t, ok, "'first' should be a number")
 	assert.Greater(t, first, float64(0), "'first' should be positive")
@@ -124,10 +176,8 @@ func TestVersionResponseStructure(t *testing.T) {
 	assert.True(t, ok, "'last' should be a number")
 	assert.GreaterOrEqual(t, last, first, "'last' should be >= 'first'")
 
-	good, ok := version["good"].(float64)
-	assert.True(t, ok, "'good' should be a number")
-	assert.GreaterOrEqual(t, good, first, "'good' should be >= 'first'")
-	assert.LessOrEqual(t, good, last, "'good' should be <= 'last'")
+	// v2+ omits `good` entirely.
+	assert.NotContains(t, version, "good", "v2+ must not emit a `good` field")
 }
 
 // TestVersionNoParamsNeeded tests that the method works without any params.

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -695,6 +695,11 @@ func (ws *WebSocketServer) handleRPCMethod(wsConn *WebSocketConnection, ctx *typ
 		return
 	}
 
+	if rpcErr := validateApiVersion(ctx, handler); rpcErr != nil {
+		ws.sendError(wsConn, rpcErr, cmd.ID)
+		return
+	}
+
 	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
 		ws.sendError(wsConn, rpcErr, cmd.ID)
 		return


### PR DESCRIPTION
## Summary
Two coupled api-version conformance fixes, both verified against rippled v2.6.2:

- **Default when unspecified → v1.** `DefaultApiVersion` is now `ApiVersion1`, matching rippled's `apiVersionIfUnspecified = 1` (`ApiVersion.h:58`). Previously a request that omitted `api_version` was served v2 response shapes where rippled returns v1. Applied at all three entry points (HTTP single, batch, WebSocket) — the seed value, not per-handler logic, drove the divergence.
- **api_version 3 gated behind `beta_rpc_api`.** The config knob already existed end-to-end (`config.BetaRPCAPI`, parsed/validated/in example configs) but was never wired into the RPC server. It is now threaded onto `ServiceContainer.BetaRPCAPI` from the CLI (`globalConfig.BetaRPCAPI != 0`). A new shared `validateApiVersion` helper caps the accepted version at `MaxSupportedApiVersion` (2) unless beta is set, in which case `BetaApiVersion` (3) is allowed, returning rippled's `invalidApiVersion` error otherwise. The cap is enforced at the HTTP/batch dispatch (`executeMethod`) and — newly — on the WebSocket path (`handleRPCMethod`), which previously skipped version validation entirely. The `version` method now reports `last: 2` without beta and `last: 3` with it, mirroring rippled `setVersion` (`RPCHelpers.h`).

Mirrors rippled `getAPIVersionNumber` (`RPCHelpers.cpp:1006-1024`), `ServerHandler.cpp:668-697`, and `Handler.cpp:257-263`.

## Test plan
- [x] `internal/rpc/...` — new `api_version_gate_test.go` covers unspecified→v1, explicit v2, v3 rejected without beta / accepted with it, batch-element gating, and WS gating (rejected/accepted + unspecified→v1) end-to-end through `ServeHTTP` and a real WS round-trip; `version` `last` tracks the beta flag.
- [x] Updated `api_version_test.go` / `version_test.go` assertions that encoded the old (v2-default, unconditional last:3) behaviour to the rippled-conformant values.
- [x] `just test-core` (ledger / txq / rpc / consensus / peermanagement) — all green.
- [x] `just test-integration` — all green except the pre-existing `internal/testing/conformance` tx-execution failures (Vault `tecINVARIANT_FAILED`, Offer tiny-payments, NFToken transferFee), confirmed reproducible on the unmodified base `ca9b8109` and unrelated to RPC api-version.
- [x] `just build-all`, `go vet`, `gofmt`, `just lint` clean.

Fixes #849