### PR TITLE
feat(storage): implement online_delete — nodestore rotation and deletion

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -126,12 +126,13 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		ledgerService       *service.Service
 		ledgerCleaner       *cleaner.Cleaner
 		consensusComponents *adaptor.Components
+		rotator             *shamapstore.Rotator
 		httpSrvs            []*http.Server
 		wsSrvs              []*http.Server
 		wsServer            *rpc.WebSocketServer
 	)
 	defer func() {
-		doShutdown(httpSrvs, wsSrvs, wsServer, ledgerService, ledgerCleaner, consensusComponents, db, repoManager, serverLog)
+		doShutdown(httpSrvs, wsSrvs, wsServer, ledgerService, ledgerCleaner, consensusComponents, rotator, db, repoManager, serverLog)
 	}()
 
 	// Initialize storage from config
@@ -278,6 +279,35 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		serverLog.Warn("Failed to load advisory-delete state", "err", asErr)
 	} else {
 		services.AdvisoryDeleteState = advisoryStore
+
+		// Online-delete rotation: when node_db online_delete is set and the
+		// node store can enumerate its keyspace, run a background job that
+		// reclaims disk by deleting complete ledgers below the rotation
+		// boundary. NewRotator returns nil when online_delete is off.
+		if globalConfig.NodeDB.IsOnlineDeleteEnabled() {
+			if prunable, ok := db.(shamapstore.NodePruner); ok {
+				var relPruner shamapstore.RelationalPruner
+				if repoManager != nil {
+					relPruner = relationaldb.NewLedgerPruner(repoManager, globalConfig.NodeDB.GetDeleteBatch())
+				}
+				rotator = shamapstore.NewRotator(
+					advisoryStore,
+					prunable,
+					relPruner,
+					shamapstore.RotationConfig{
+						DeleteInterval: uint32(globalConfig.NodeDB.OnlineDelete),
+						DeleteBatch:    globalConfig.NodeDB.GetDeleteBatch(),
+					},
+					serverLog,
+				)
+				rotator.Start()
+				serverLog.Info("Online delete enabled",
+					"online_delete", globalConfig.NodeDB.OnlineDelete,
+					"advisory_delete", globalConfig.NodeDB.IsAdvisoryDeleteEnabled())
+			} else {
+				serverLog.Warn("online_delete configured but node store backend does not support pruning")
+			}
+		}
 	}
 
 	// TxQ metrics are available in both standalone and consensus modes,
@@ -802,6 +832,12 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 			return
 		}
 
+		// Drive online-delete rotation off the validated-ledger advance. The
+		// callback fires from both the standalone accept path and the
+		// consensus SetValidatedLedger path, so the rotator sees every
+		// validated sequence. Notify never blocks.
+		rotator.Notify(event.LedgerInfo.Sequence)
+
 		baseFee, reserveBase, reserveInc := ledgerService.GetCurrentFees()
 
 		ledgerTime := uint32(event.LedgerInfo.CloseTime.Unix() - protocol.RippleEpochUnix)
@@ -1150,6 +1186,7 @@ func doShutdown(
 	ledgerService *service.Service,
 	ledgerCleaner *cleaner.Cleaner,
 	consensusComponents *adaptor.Components,
+	rotator *shamapstore.Rotator,
 	kvDB nodestore.Database,
 	repoManager relationaldb.RepositoryManager,
 	logger xrpllog.Logger,
@@ -1170,6 +1207,13 @@ func doShutdown(
 		if err := wsServer.Close(ctx); err != nil {
 			logger.Warn("WebSocket server shutdown timed out", "err", err)
 		}
+	}
+
+	// Stop the online-delete rotator before tearing down the node store it
+	// deletes from.
+	if rotator != nil {
+		rotator.Stop()
+		logger.Info("Online delete rotator stopped")
 	}
 
 	// Stop the background ledger-integrity verifier before tearing down the

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -301,6 +301,9 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 					serverLog,
 				)
 				rotator.Start()
+				// Clamp complete_ledgers to the deletion boundary so
+				// server_info never advertises ledgers rotation reclaimed.
+				ledgerService.SetMinimumOnlineFunc(rotator.MinimumOnline)
 				serverLog.Info("Online delete enabled",
 					"online_delete", globalConfig.NodeDB.OnlineDelete,
 					"advisory_delete", globalConfig.NodeDB.IsAdvisoryDeleteEnabled())
@@ -416,7 +419,15 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		if repoManager != nil {
 			validationRepo = repoManager.Validation()
 		}
-		consensusComponents, compErr = adaptor.NewFromConfig(globalConfig, ledgerService, validationRepo)
+		// Pass the online-delete floor to consensus so acquisition and
+		// peer-serving refuse ledgers below the deletion boundary. Keep the
+		// interface nil when rotation is off so the disabled path is unchanged
+		// (a typed-nil *Rotator would be a non-nil interface).
+		var floor adaptor.MinimumOnlineFloor
+		if rotator != nil {
+			floor = rotator
+		}
+		consensusComponents, compErr = adaptor.NewFromConfig(globalConfig, ledgerService, validationRepo, floor)
 		if compErr != nil {
 			return fmt.Errorf("create consensus components: %w", compErr)
 		}

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -102,5 +102,5 @@ func TestDoShutdown_ToleratesNilComponents(t *testing.T) {
 	// criterion is "doesn't crash": WebSocketServer.Close dereferences its
 	// receiver on the first line (connectionsMutex.Lock), so a nil wsServer
 	// would panic without the guard this test pins.
-	doShutdown(nil, nil, nil, nil, nil, nil, nil, nil, xrpllog.Discard())
+	doShutdown(nil, nil, nil, nil, nil, nil, nil, nil, nil, xrpllog.Discard())
 }

--- a/internal/consensus/adaptor/ledger_provider.go
+++ b/internal/consensus/adaptor/ledger_provider.go
@@ -31,6 +31,16 @@ type ledgerLookup interface {
 	GetLedgerBySequence(seq uint32) (*ledger.Ledger, error)
 }
 
+// MinimumOnlineFloor reports the lowest ledger sequence the node still retains
+// in full. Ledgers below it have been (or are being) reclaimed by online-delete
+// and must not be served — rippled gives the same guarantee implicitly because
+// the store physically deleted them. *shamapstore.Rotator satisfies this. A nil
+// floor (or a zero return) means online-delete is off / no rotation has happened
+// yet, so nothing is withheld.
+type MinimumOnlineFloor interface {
+	MinimumOnline() uint32
+}
+
 // Compile-time interface check.
 var _ peermanagement.LedgerProvider = (*LedgerProvider)(nil)
 
@@ -43,7 +53,8 @@ var _ peermanagement.LedgerProvider = (*LedgerProvider)(nil)
 // can reach the ledger service without importing internal/ledger, which is
 // forbidden by the layering boundary between the two packages.
 type LedgerProvider struct {
-	svc ledgerLookup
+	svc   ledgerLookup
+	floor MinimumOnlineFloor
 }
 
 // NewLedgerProvider constructs a LedgerProvider backed by the supplied
@@ -54,13 +65,31 @@ func NewLedgerProvider(svc *service.Service) *LedgerProvider {
 	return &LedgerProvider{svc: svc}
 }
 
+// SetMinimumOnlineFloor installs the online-delete retention floor. Once set,
+// the provider refuses to serve ledgers below it (mirroring rippled, where a
+// peer cannot serve what online-delete already removed). A nil floor leaves
+// serving unrestricted, so the disabled / standalone path is unchanged.
+func (p *LedgerProvider) SetMinimumOnlineFloor(floor MinimumOnlineFloor) {
+	p.floor = floor
+}
+
+// belowFloor reports whether seq sits below the online-delete retention floor.
+// A nil floor or a zero floor (no rotation yet) never withholds anything.
+func (p *LedgerProvider) belowFloor(seq uint32) bool {
+	if p.floor == nil {
+		return false
+	}
+	floor := p.floor.MinimumOnline()
+	return floor != 0 && seq < floor
+}
+
 // GetLedgerHeader returns the serialized header for a ledger identified by
 // hash (preferred) or, when no hash is supplied, by sequence. Returns
 // (nil, nil) when the ledger is unknown — handleGetLedger interprets a nil
 // node as "skip" and emits an empty response.
 func (p *LedgerProvider) GetLedgerHeader(hash []byte, seq uint32) ([]byte, error) {
 	l := p.lookupLedger(hash, seq)
-	if l == nil {
+	if l == nil || p.belowFloor(l.Sequence()) {
 		return nil, nil
 	}
 	return l.SerializeHeader(), nil
@@ -73,7 +102,7 @@ func (p *LedgerProvider) GetLedgerHeader(hash []byte, seq uint32) ([]byte, error
 // the same as a missing node.
 func (p *LedgerProvider) GetAccountStateNode(ledgerHash []byte, nodeID []byte) ([]byte, error) {
 	l := p.lookupLedger(ledgerHash, 0)
-	if l == nil {
+	if l == nil || p.belowFloor(l.Sequence()) {
 		return nil, nil
 	}
 	stateMap, err := l.StateMapSnapshot()
@@ -86,7 +115,7 @@ func (p *LedgerProvider) GetAccountStateNode(ledgerHash []byte, nodeID []byte) (
 // GetTransactionNode mirrors GetAccountStateNode against the tx SHAMap.
 func (p *LedgerProvider) GetTransactionNode(ledgerHash []byte, nodeID []byte) ([]byte, error) {
 	l := p.lookupLedger(ledgerHash, 0)
-	if l == nil {
+	if l == nil || p.belowFloor(l.Sequence()) {
 		return nil, nil
 	}
 	txMap, err := l.TxMapSnapshot()
@@ -114,7 +143,7 @@ func (p *LedgerProvider) GetReplayDelta(ledgerHash []byte) ([]byte, [][]byte, er
 		return nil, nil, nil
 	}
 	l, err := p.svc.GetLedgerByHash(hash)
-	if err != nil || l == nil || !l.IsImmutable() {
+	if err != nil || l == nil || !l.IsImmutable() || p.belowFloor(l.Sequence()) {
 		return nil, nil, nil
 	}
 
@@ -163,7 +192,7 @@ func (p *LedgerProvider) MakeFetchPack(haveLedgerHash [32]byte, maxObjects int) 
 		return nil, nil
 	}
 	want, err := p.svc.GetLedgerByHash(have.Header().ParentHash)
-	if err != nil || want == nil {
+	if err != nil || want == nil || p.belowFloor(want.Sequence()) {
 		return nil, nil
 	}
 	if maxObjects <= 0 || maxObjects > fetchPackMaxObjects {
@@ -260,7 +289,7 @@ func (p *LedgerProvider) GetProofPath(
 	}
 
 	l, err := p.svc.GetLedgerByHash(hash)
-	if err != nil || l == nil {
+	if err != nil || l == nil || p.belowFloor(l.Sequence()) {
 		return nil, nil, peermanagement.ErrLedgerNotFound
 	}
 

--- a/internal/consensus/adaptor/ledger_provider_floor_test.go
+++ b/internal/consensus/adaptor/ledger_provider_floor_test.go
@@ -1,0 +1,122 @@
+package adaptor
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubFloor is a fixed-value MinimumOnlineFloor for serving/acquisition tests.
+type stubFloor uint32
+
+func (s stubFloor) MinimumOnline() uint32 { return uint32(s) }
+
+// TestLedgerProvider_Floor_DeclinesBelowBoundary verifies that once the
+// online-delete floor is installed, every serve path refuses a ledger whose
+// sequence sits below the floor — mirroring rippled, where a peer cannot serve
+// what online-delete physically removed.
+func TestLedgerProvider_Floor_DeclinesBelowBoundary(t *testing.T) {
+	txs := []struct {
+		key  [32]byte
+		blob []byte
+	}{
+		{fixedKey32(1), []byte("tx-blob-one--padded")},
+	}
+	closed := makeClosedLedgerWithTxs(t, txs) // seq 2 (built on genesis seq 1)
+	require.Equal(t, uint32(2), closed.Sequence())
+
+	lookup := newFakeLookup()
+	lookup.add(closed)
+	provider := newLedgerProviderForTest(lookup)
+	// Floor above the ledger's sequence: the ledger is "below the boundary".
+	provider.SetMinimumOnlineFloor(stubFloor(3))
+
+	hash := closed.Hash()
+
+	hdr, err := provider.GetLedgerHeader(hash[:], 0)
+	require.NoError(t, err)
+	assert.Nil(t, hdr, "GetLedgerHeader must decline a below-floor ledger")
+
+	node, err := provider.GetAccountStateNode(hash[:], txs[0].key[:])
+	require.NoError(t, err)
+	assert.Nil(t, node, "GetAccountStateNode must decline a below-floor ledger")
+
+	txNode, err := provider.GetTransactionNode(hash[:], txs[0].key[:])
+	require.NoError(t, err)
+	assert.Nil(t, txNode, "GetTransactionNode must decline a below-floor ledger")
+
+	rdHdr, leaves, err := provider.GetReplayDelta(hash[:])
+	require.NoError(t, err)
+	assert.Nil(t, rdHdr, "GetReplayDelta must decline a below-floor ledger")
+	assert.Nil(t, leaves)
+
+	_, _, err = provider.GetProofPath(hash[:], txs[0].key[:], message.LedgerMapTransaction)
+	require.ErrorIs(t, err, peermanagement.ErrLedgerNotFound,
+		"GetProofPath must report a below-floor ledger as not found")
+}
+
+// TestLedgerProvider_Floor_MakeFetchPackDeclinesBelowBoundary verifies the
+// fetch-pack serve path withholds a pack whose "want" (the served parent
+// ledger) is below the floor.
+func TestLedgerProvider_Floor_MakeFetchPackDeclinesBelowBoundary(t *testing.T) {
+	// have = seq 2, want = its parent = genesis seq 1.
+	closed := makeClosedLedgerWithTxs(t, nil)
+	genesisL := makeGenesisLedger(t)
+	require.Equal(t, uint32(1), genesisL.Sequence())
+	require.Equal(t, genesisL.Hash(), closed.Header().ParentHash)
+
+	lookup := newFakeLookup()
+	lookup.add(closed)
+	lookup.add(genesisL)
+	provider := newLedgerProviderForTest(lookup)
+	provider.SetMinimumOnlineFloor(stubFloor(2)) // want (seq 1) < floor
+
+	have := closed.Hash()
+	pack, err := provider.MakeFetchPack(have, 0)
+	require.NoError(t, err)
+	assert.Nil(t, pack, "fetch-pack must be withheld when want is below the floor")
+}
+
+// TestLedgerProvider_Floor_ServesAtOrAboveBoundary verifies that a ledger at
+// or above the floor is served normally, and that a zero floor (no rotation
+// yet) withholds nothing.
+func TestLedgerProvider_Floor_ServesAtOrAboveBoundary(t *testing.T) {
+	closed := makeClosedLedgerWithTxs(t, nil) // seq 2
+	lookup := newFakeLookup()
+	lookup.add(closed)
+	provider := newLedgerProviderForTest(lookup)
+	hash := closed.Hash()
+
+	// Floor at the ledger's own sequence: not below, must serve.
+	provider.SetMinimumOnlineFloor(stubFloor(2))
+	hdr, err := provider.GetLedgerHeader(hash[:], 0)
+	require.NoError(t, err)
+	assert.NotNil(t, hdr, "ledger at the floor must still be served")
+
+	// Zero floor = no rotation has happened; nothing is withheld.
+	provider.SetMinimumOnlineFloor(stubFloor(0))
+	hdr, err = provider.GetLedgerHeader(hash[:], 0)
+	require.NoError(t, err)
+	assert.NotNil(t, hdr, "a zero floor must withhold nothing")
+}
+
+// TestLedgerProvider_NilFloor_Unchanged verifies that without a floor installed
+// (online_delete off / standalone), serving behaves exactly as before.
+func TestLedgerProvider_NilFloor_Unchanged(t *testing.T) {
+	closed := makeClosedLedgerWithTxs(t, nil) // seq 2
+	lookup := newFakeLookup()
+	lookup.add(closed)
+	provider := newLedgerProviderForTest(lookup) // no SetMinimumOnlineFloor
+
+	hash := closed.Hash()
+	hdr, err := provider.GetLedgerHeader(hash[:], 0)
+	require.NoError(t, err)
+	assert.NotNil(t, hdr, "nil floor must leave serving unrestricted")
+
+	rdHdr, _, err := provider.GetReplayDelta(hash[:])
+	require.NoError(t, err)
+	assert.NotNil(t, rdHdr, "nil floor must leave replay-delta serving unrestricted")
+}

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -142,6 +142,13 @@ type Router struct {
 	// by replayTaskMu.
 	replayTaskMu sync.Mutex
 	activeTask   *activeReplayTask
+
+	// floor is the online-delete retention floor. When set, the router
+	// refuses to acquire or serve ledgers below it — rippled gates the same
+	// in LedgerMaster::shouldAcquire (acquisition) and gives the serving
+	// guarantee implicitly because online-delete physically removed the data.
+	// Nil when online-delete is off, leaving acquisition/serving unrestricted.
+	floor MinimumOnlineFloor
 }
 
 type txSetAcquireState struct {
@@ -242,6 +249,25 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, modeManager *ModeManag
 		adaptor.SetOnTxSetRequested(r.MarkTxSetStillNeeded)
 	}
 	return r
+}
+
+// SetMinimumOnlineFloor installs the online-delete retention floor. Once set,
+// the router refuses to acquire or serve ledgers below it. A nil floor leaves
+// both paths unrestricted, so the disabled / standalone case is unchanged.
+func (r *Router) SetMinimumOnlineFloor(floor MinimumOnlineFloor) {
+	r.floor = floor
+}
+
+// belowFloor reports whether seq sits below the online-delete retention floor.
+// A nil floor or a zero floor (no rotation yet) never withholds anything,
+// mirroring rippled where shouldAcquire treats an unset minimumOnline as no
+// lower bound.
+func (r *Router) belowFloor(seq uint32) bool {
+	if r.floor == nil {
+		return false
+	}
+	floor := r.floor.MinimumOnline()
+	return floor != 0 && seq < floor
 }
 
 // SetManifestCache installs the validator-manifest cache and the
@@ -958,6 +984,16 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		l = svc.GetClosedLedger()
 	}
 	if err != nil || l == nil {
+		return
+	}
+
+	// Refuse to serve a ledger online-delete has reclaimed: rippled can't
+	// serve what its store deleted, so neither do we (the in-memory history
+	// window may still hold it). The liTS_CANDIDATE tx-set path returned
+	// above is exempt — consensus liveness depends on it always serving.
+	if r.belowFloor(l.Sequence()) {
+		r.logger.Debug("get_ledger declined: below online-delete floor",
+			"peer", msg.PeerID, "seq", l.Sequence(), "floor", r.floor.MinimumOnline())
 		return
 	}
 
@@ -2029,6 +2065,16 @@ func (r *Router) ClearFetchInfo() {
 // Safe to call from an RPC goroutine: the registry and each acquisition guard
 // their own state.
 func (r *Router) RequestLedger(hash [32]byte, seq uint32) (acquiring map[string]any, started, reference bool) {
+	// Don't acquire history online-delete has reclaimed: rippled's
+	// LedgerMaster::shouldAcquire refuses to fetch a missing ledger below
+	// minimumOnline. Re-fetching it would only feed the rotator another
+	// delete. Forward catch-up / validation acquisitions are above the
+	// validated tip (≥ floor) so they never hit this gate.
+	if seq != 0 && r.belowFloor(seq) {
+		r.logger.Debug("ledger_request declined: below online-delete floor",
+			"seq", seq, "floor", r.floor.MinimumOnline())
+		return nil, false, false
+	}
 	if hash == ([32]byte{}) {
 		if seq == 0 {
 			return nil, false, false

--- a/internal/consensus/adaptor/router_floor_test.go
+++ b/internal/consensus/adaptor/router_floor_test.go
@@ -1,0 +1,141 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouter_RequestLedger_Floor_DeclinesBelowBoundary verifies that the
+// ledger_request acquisition path refuses to fetch a ledger below the
+// online-delete floor — mirroring rippled's LedgerMaster::shouldAcquire, which
+// does not acquire a missing ledger below minimumOnline. No fetch is issued.
+func TestRouter_RequestLedger_Floor_DeclinesBelowBoundary(t *testing.T) {
+	r, _, rs, svc := makeRouter(t)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	r.SetMinimumOnlineFloor(stubFloor(100))
+
+	// Register a peer so the only reason a fetch wouldn't fire is the floor.
+	r.handleMessage(statusChangeMessage(t, peermanagement.PeerID(7), closed.Sequence(), closed.Hash()))
+
+	var target [32]byte
+	target[0] = 0x42
+
+	snap, started, _ := r.RequestLedger(target, 50) // seq 50 < floor 100
+	assert.False(t, started, "acquisition below the floor must not start")
+	assert.Nil(t, snap)
+	assert.Empty(t, rs.legacyCalls(), "no base fetch may be issued below the floor")
+	assert.Empty(t, rs.replayCalls(), "no replay-delta fetch may be issued below the floor")
+	assert.Nil(t, r.fetchTracker.Find(target), "no acquisition may be registered below the floor")
+}
+
+// TestRouter_RequestLedger_Floor_AllowsAtOrAboveBoundary verifies a request at
+// or above the floor proceeds, and that a nil floor leaves the path unchanged.
+func TestRouter_RequestLedger_Floor_AllowsAtOrAboveBoundary(t *testing.T) {
+	r, _, rs, svc := makeRouter(t)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	r.SetMinimumOnlineFloor(stubFloor(50))
+	r.handleMessage(statusChangeMessage(t, peermanagement.PeerID(7), closed.Sequence(), closed.Hash()))
+
+	var target [32]byte
+	target[0] = 0x42
+
+	_, started, _ := r.RequestLedger(target, 50) // seq 50 == floor 50: allowed
+	assert.True(t, started, "acquisition at the floor must proceed")
+	require.Len(t, rs.legacyCalls(), 1, "a base fetch must be issued at the floor")
+	assert.Equal(t, target, rs.legacyCalls()[0].hash)
+}
+
+// TestRouter_RequestLedger_NilFloor_Unchanged verifies the acquisition path is
+// unrestricted when no floor is installed (online_delete off / standalone).
+func TestRouter_RequestLedger_NilFloor_Unchanged(t *testing.T) {
+	r, _, rs, svc := makeRouter(t)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	r.handleMessage(statusChangeMessage(t, peermanagement.PeerID(7), closed.Sequence(), closed.Hash()))
+
+	var target [32]byte
+	target[0] = 0x42
+
+	_, started, _ := r.RequestLedger(target, 1) // a very low seq, no floor → allowed
+	assert.True(t, started, "with no floor any sequence is acquirable")
+	require.Len(t, rs.legacyCalls(), 1)
+}
+
+// TestRouter_HandleGetLedger_Floor_DeclinesBelowBoundary drives the legacy
+// mtGET_LEDGER serve path and verifies the router declines to serve a ledger
+// below the floor (no response frame is emitted), while serving one at/above it.
+func TestRouter_HandleGetLedger_Floor_DeclinesBelowBoundary(t *testing.T) {
+	engine := &mockEngine{}
+	adaptor, rs := newTxSetWireAdaptor(t)
+	inbox := make(chan *peermanagement.InboundMessage, 4)
+	router := NewRouter(engine, adaptor, nil, inbox)
+
+	l := adaptor.LedgerService().GetClosedLedger()
+	require.NotNil(t, l)
+	hash := l.Hash()
+
+	// Floor above the served ledger's sequence: it is below the boundary.
+	router.SetMinimumOnlineFloor(stubFloor(l.Sequence() + 1))
+
+	ctx := t.Context()
+	go router.Run(ctx)
+
+	req := &message.GetLedger{
+		InfoType:   message.LedgerInfoBase,
+		LedgerHash: hash[:],
+		LedgerSeq:  l.Sequence(),
+	}
+	inbox <- &peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeGetLedger),
+		Payload: encodePayload(t, req),
+	}
+
+	// Give the router a beat to process; assert it stays silent.
+	require.Never(t, func() bool {
+		return len(rs.sentTo(7)) > 0
+	}, 200*time.Millisecond, 20*time.Millisecond,
+		"router must not serve a ledger below the online-delete floor")
+}
+
+// TestRouter_HandleGetLedger_Floor_ServesAtOrAboveBoundary verifies the same
+// serve path responds normally when the ledger is at or above the floor.
+func TestRouter_HandleGetLedger_Floor_ServesAtOrAboveBoundary(t *testing.T) {
+	engine := &mockEngine{}
+	adaptor, rs := newTxSetWireAdaptor(t)
+	inbox := make(chan *peermanagement.InboundMessage, 4)
+	router := NewRouter(engine, adaptor, nil, inbox)
+
+	l := adaptor.LedgerService().GetClosedLedger()
+	require.NotNil(t, l)
+	hash := l.Hash()
+
+	// Floor at the served ledger's own sequence: not below, must serve.
+	router.SetMinimumOnlineFloor(stubFloor(l.Sequence()))
+
+	ctx := t.Context()
+	go router.Run(ctx)
+
+	req := &message.GetLedger{
+		InfoType:   message.LedgerInfoBase,
+		LedgerHash: hash[:],
+		LedgerSeq:  l.Sequence(),
+	}
+	inbox <- &peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeGetLedger),
+		Payload: encodePayload(t, req),
+	}
+
+	require.Eventually(t, func() bool {
+		return len(rs.sentTo(7)) > 0
+	}, time.Second, 10*time.Millisecond,
+		"router must serve a ledger at or above the floor")
+}

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -213,10 +213,14 @@ func (c *Components) Stop() {
 // validationRepo is optional — pass nil to disable the on-disk validation
 // archive. When non-nil and [validation_archive] is enabled in config,
 // stale validations are persisted via a batched async writer.
+// floor is the online-delete retention floor (a *shamapstore.Rotator in
+// production). Pass nil when online_delete is off: acquisition and serving are
+// then unrestricted, leaving the standalone / feature-disabled path unchanged.
 func NewFromConfig(
 	appCfg *config.Config,
 	ledgerSvc *service.Service,
 	validationRepo relationaldb.ValidationRepository,
+	floor MinimumOnlineFloor,
 ) (*Components, error) {
 	// Create validator identity first (nil if not a validator) so we can
 	// pass its pubkey into the overlay for the self-target TMSquelch
@@ -247,7 +251,9 @@ func NewFromConfig(
 	// service. peermanagement is forbidden from importing
 	// internal/ledger, so the adapter installed here lets both layers
 	// reach the ledger without breaking that layering boundary.
-	overlay.LedgerSync().SetProvider(NewLedgerProvider(ledgerSvc))
+	ledgerProvider := NewLedgerProvider(ledgerSvc)
+	ledgerProvider.SetMinimumOnlineFloor(floor)
+	overlay.LedgerSync().SetProvider(ledgerProvider)
 
 	// Load UNL from config — retain both NodeID (for trust/quorum
 	// maps) and master pubkey (for NegativeUNL voting; sfUNLModifyValidator
@@ -324,6 +330,7 @@ func NewFromConfig(
 	// Create the router
 	router := NewRouter(engine, adaptor, modeManager, overlay.Messages())
 	router.SetManifestCache(manifestCache, overlay)
+	router.SetMinimumOnlineFloor(floor)
 
 	// Build the publisher-list aggregator when validator_list_keys are
 	// configured. Lists are then ingested both via peer gossip

--- a/internal/ledger/service/complete_ledgers_floor_test.go
+++ b/internal/ledger/service/complete_ledgers_floor_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+)
+
+// seedHistory replaces the in-memory history window with placeholder ledgers
+// for [lo, hi], so GetServerInfo derives complete_ledgers from a known range.
+// Start() seeds the genesis ledger; clear it first so the range is exactly
+// [lo, hi].
+func seedHistory(t *testing.T, svc *Service, lo, hi uint32) {
+	t.Helper()
+	svc.ledgerHistory = make(map[uint32]*ledger.Ledger)
+	for seq := lo; seq <= hi; seq++ {
+		stateMap, err := svc.genesisLedger.StateMapSnapshot()
+		if err != nil {
+			t.Fatalf("StateMapSnapshot: %v", err)
+		}
+		txMap, err := svc.genesisLedger.TxMapSnapshot()
+		if err != nil {
+			t.Fatalf("TxMapSnapshot: %v", err)
+		}
+		var h header.LedgerHeader
+		h.LedgerIndex = seq
+		svc.ledgerHistory[seq] = ledger.NewOpenWithHeader(h, stateMap, txMap, drops.Fees{})
+	}
+}
+
+// TestGetServerInfo_CompleteLedgers_ClampedToFloor verifies that after a
+// rotation, complete_ledgers reports the durable lower bound (the online-delete
+// floor), not the broader in-memory history window — which is swept
+// independently and can still name reclaimed ledgers.
+func TestGetServerInfo_CompleteLedgers_ClampedToFloor(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	seedHistory(t, svc, 10, 100)
+
+	// Without a floor the range is the full window.
+	if got := svc.GetServerInfo().CompleteLedgers; got != "10-100" {
+		t.Fatalf("unclamped complete_ledgers = %q, want %q", got, "10-100")
+	}
+
+	// A floor at 50 narrows the lower bound; the upper bound is unchanged.
+	svc.SetMinimumOnlineFunc(func() uint32 { return 50 })
+	if got := svc.GetServerInfo().CompleteLedgers; got != "50-100" {
+		t.Fatalf("clamped complete_ledgers = %q, want %q", got, "50-100")
+	}
+}
+
+// TestGetServerInfo_CompleteLedgers_FloorBelowWindow verifies a floor below the
+// window's lower bound (or zero, no rotation yet) leaves the range untouched.
+func TestGetServerInfo_CompleteLedgers_FloorBelowWindow(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	seedHistory(t, svc, 10, 100)
+
+	svc.SetMinimumOnlineFunc(func() uint32 { return 5 }) // below window lo
+	if got := svc.GetServerInfo().CompleteLedgers; got != "10-100" {
+		t.Fatalf("floor below window changed range = %q, want %q", got, "10-100")
+	}
+
+	svc.SetMinimumOnlineFunc(func() uint32 { return 0 }) // no rotation yet
+	if got := svc.GetServerInfo().CompleteLedgers; got != "10-100" {
+		t.Fatalf("zero floor changed range = %q, want %q", got, "10-100")
+	}
+}
+
+// TestGetServerInfo_CompleteLedgers_FloorAboveWindow verifies that when the
+// floor exceeds the whole window (nothing durable left to advertise),
+// complete_ledgers is reported empty rather than as an inverted range.
+func TestGetServerInfo_CompleteLedgers_FloorAboveWindow(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	seedHistory(t, svc, 10, 100)
+
+	svc.SetMinimumOnlineFunc(func() uint32 { return 200 }) // above window hi
+	if got := svc.GetServerInfo().CompleteLedgers; got != "" {
+		t.Fatalf("floor above window = %q, want empty", got)
+	}
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -231,6 +231,13 @@ type Service struct {
 	// Set by the consensus adaptor after startup.
 	serverStateFunc func() string
 
+	// minimumOnlineFunc optionally reports the online-delete retention floor
+	// (rippled SHAMapStore::minimumOnline). When set, complete_ledgers is
+	// clamped up to it so server_info never advertises ledgers online-delete
+	// has reclaimed. Nil when online_delete is off — the range is then the
+	// in-memory history window unchanged.
+	minimumOnlineFunc func() uint32
+
 	// openLedgerView is the persistent open-ledger view that mirrors
 	// rippled's openLedger().current() — the source of truth for the
 	// open pool (#407). Built by Start / rebuilt by adopt paths /
@@ -1664,6 +1671,16 @@ func (s *Service) SetServerStateFunc(fn func() string) {
 	s.serverStateFunc = fn
 }
 
+// SetMinimumOnlineFunc registers the online-delete retention floor used to
+// clamp complete_ledgers in server_info. Pass nil (or leave unset) when
+// online_delete is off — complete_ledgers then reflects the in-memory history
+// window unchanged.
+func (s *Service) SetMinimumOnlineFunc(fn func() uint32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.minimumOnlineFunc = fn
+}
+
 // IsStandalone returns true if running in standalone mode
 func (s *Service) IsStandalone() bool {
 	return s.config.Standalone
@@ -1736,9 +1753,21 @@ func (s *Service) GetServerInfo() ServerInfo {
 				maxSeq = seq
 			}
 		}
-		if minSeq == maxSeq {
+		// Clamp the lower bound up to the online-delete floor: the in-memory
+		// history window is swept independently of the rotator, so after a
+		// rotation it can still name ledgers the node store no longer holds.
+		// complete_ledgers must report durable availability, not the window.
+		if s.minimumOnlineFunc != nil {
+			if floor := s.minimumOnlineFunc(); floor > minSeq {
+				minSeq = floor
+			}
+		}
+		switch {
+		case minSeq > maxSeq:
+			// The whole window sits below the floor — nothing durable to advertise.
+		case minSeq == maxSeq:
 			info.CompleteLedgers = strconv.FormatUint(uint64(minSeq), 10)
-		} else {
+		default:
 			info.CompleteLedgers = formatRange(minSeq, maxSeq)
 		}
 	}

--- a/internal/ledger/shamapstore/export_test.go
+++ b/internal/ledger/shamapstore/export_test.go
@@ -1,0 +1,9 @@
+package shamapstore
+
+import "context"
+
+// NotifyForTest drives a single rotation decision synchronously, bypassing the
+// background worker so tests can assert deletion effects deterministically.
+func (r *Rotator) NotifyForTest(validatedSeq uint32) {
+	r.maybeRotate(context.Background(), validatedSeq)
+}

--- a/internal/ledger/shamapstore/rotation.go
+++ b/internal/ledger/shamapstore/rotation.go
@@ -1,0 +1,242 @@
+package shamapstore
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+// defaultDeleteBatch is the per-batch deletion size used when delete_batch is
+// left unconfigured. It bounds the work done between context checks so a prune
+// pass stays responsive to shutdown.
+const defaultDeleteBatch = 65536
+
+// NodePruner deletes stored nodes below a retention boundary. It is satisfied
+// by the nodestore's PrunableDatabase. boundary is exclusive: nodes with a
+// ledger sequence strictly below it are removed.
+type NodePruner interface {
+	DeleteBefore(ctx context.Context, boundary uint32, batchSize int) (deleted uint64, err error)
+}
+
+// RelationalPruner deletes ledger and transaction index rows below a retention
+// boundary. It is the go-xrpl equivalent of rippled's clearSql over the
+// Ledgers / Transactions / AccountTransactions tables. A nil RelationalPruner
+// is tolerated (relational indexing is optional).
+type RelationalPruner interface {
+	DeleteLedgersBefore(ctx context.Context, boundary uint32) error
+}
+
+// RotationConfig carries the node_db online-delete settings the rotator needs.
+type RotationConfig struct {
+	// DeleteInterval is node_db online_delete: rotate (and delete) once the
+	// validated ledger has advanced this many sequences past the last rotation.
+	// Zero disables rotation entirely.
+	DeleteInterval uint32
+
+	// DeleteBatch is node_db delete_batch: the maximum number of records removed
+	// per backend batch. Zero selects a default.
+	DeleteBatch int
+}
+
+// Rotator runs the online-delete rotation: every DeleteInterval validated
+// ledgers it deletes complete ledgers below the rotation boundary from the
+// nodestore and relational stores, advancing the advisory-delete state's
+// lastRotated and the minimum-online boundary.
+//
+// It mirrors the decision logic of rippled's SHAMapStoreImp::run: the first
+// notification seeds lastRotated; thereafter a rotation fires when the
+// validated sequence has advanced a full DeleteInterval past lastRotated and,
+// under advisory_delete, the operator-set can_delete boundary permits it.
+//
+// Notifications are dispatched to a single background worker so deletion never
+// blocks the consensus / ledger-accept path; an in-flight rotation coalesces
+// further notifications to the newest validated sequence.
+type Rotator struct {
+	store  *Store
+	nodes  NodePruner
+	rel    RelationalPruner
+	cfg    RotationConfig
+	logger xrpllog.Logger
+
+	notifyCh chan uint32
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	doneCh   chan struct{}
+
+	// minimumOnline is the lowest ledger sequence the node still retains in
+	// full. Acquisition / fetch-pack serving must not reach below it. Zero
+	// until the first rotation.
+	minimumOnline atomic.Uint32
+}
+
+// NewRotator constructs a Rotator. store and nodes are required; rel may be nil
+// when no relational index is configured. A nil logger is replaced with a
+// discard logger. NewRotator returns nil when rotation is disabled
+// (cfg.DeleteInterval == 0) so callers can treat a nil *Rotator as "online
+// delete off".
+func NewRotator(store *Store, nodes NodePruner, rel RelationalPruner, cfg RotationConfig, logger xrpllog.Logger) *Rotator {
+	if cfg.DeleteInterval == 0 || store == nil || nodes == nil {
+		return nil
+	}
+	if logger == nil {
+		logger = xrpllog.Discard()
+	}
+	if cfg.DeleteBatch <= 0 {
+		cfg.DeleteBatch = defaultDeleteBatch
+	}
+	r := &Rotator{
+		store:    store,
+		nodes:    nodes,
+		rel:      rel,
+		cfg:      cfg,
+		logger:   logger,
+		notifyCh: make(chan uint32, 1),
+		stopCh:   make(chan struct{}),
+		doneCh:   make(chan struct{}),
+	}
+	r.minimumOnline.Store(store.GetLastRotated())
+	return r
+}
+
+// Start launches the background rotation worker. Safe to call once.
+func (r *Rotator) Start() {
+	if r == nil {
+		return
+	}
+	go r.run()
+}
+
+// Stop signals the worker to exit and waits for it to finish. Idempotent.
+func (r *Rotator) Stop() {
+	if r == nil {
+		return
+	}
+	r.stopOnce.Do(func() { close(r.stopCh) })
+	<-r.doneCh
+}
+
+// Notify reports a newly validated ledger sequence. It never blocks: if a
+// rotation is already pending or in flight, the latest sequence supersedes the
+// queued one (a coalescing send), mirroring rippled where only the newest
+// validated ledger drives the run loop.
+func (r *Rotator) Notify(validatedSeq uint32) {
+	if r == nil || validatedSeq == 0 {
+		return
+	}
+	for {
+		select {
+		case r.notifyCh <- validatedSeq:
+			return
+		case <-r.notifyCh:
+			// Drop the stale queued sequence and retry with the newer one.
+		case <-r.stopCh:
+			return
+		}
+	}
+}
+
+// MinimumOnline returns the lowest ledger sequence still retained in full.
+// Ledgers below it have been (or are being) deleted and must not be served or
+// re-acquired. Zero before the first rotation. Mirrors rippled's
+// SHAMapStore::minimumOnline().
+func (r *Rotator) MinimumOnline() uint32 {
+	if r == nil {
+		return 0
+	}
+	return r.minimumOnline.Load()
+}
+
+func (r *Rotator) run() {
+	defer close(r.doneCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-r.stopCh
+		cancel()
+	}()
+
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		case validatedSeq := <-r.notifyCh:
+			r.maybeRotate(ctx, validatedSeq)
+		}
+	}
+}
+
+// maybeRotate applies the rippled readyToRotate predicate for validatedSeq and,
+// when it holds, deletes complete ledgers below the rotation boundary.
+func (r *Rotator) maybeRotate(ctx context.Context, validatedSeq uint32) {
+	lastRotated := r.store.GetLastRotated()
+
+	// First validated ledger seeds the boundary without deleting anything,
+	// matching rippled (lastRotated = validatedSeq on the first run).
+	if lastRotated == 0 {
+		if err := r.store.SetLastRotated(validatedSeq); err != nil {
+			r.logger.Warn("online delete: failed to persist initial lastRotated", "seq", validatedSeq, "err", err)
+			return
+		}
+		r.minimumOnline.Store(validatedSeq)
+		return
+	}
+
+	if validatedSeq < lastRotated+r.cfg.DeleteInterval {
+		return
+	}
+
+	// Under advisory delete, the operator's can_delete boundary must permit
+	// removing everything below lastRotated (rippled: canDelete_ >= lastRotated-1).
+	// lastRotated >= 1 here, so lastRotated-1 cannot underflow; comparing this
+	// way (rather than canDelete+1) also avoids overflow when can_delete is set
+	// to "always" (max uint32).
+	if r.store.AdvisoryDelete() && r.store.GetCanDelete() < lastRotated-1 {
+		return
+	}
+
+	r.rotate(ctx, validatedSeq, lastRotated)
+}
+
+// rotate deletes everything below lastRotated, then advances the boundary to
+// validatedSeq. Deletion runs below the OLD boundary (lastRotated): the live
+// state at validatedSeq is preserved because every live state node was
+// re-persisted at the current sequence, so it carries a LedgerSeq at or above
+// the retained range and is never matched by the below-boundary scan.
+func (r *Rotator) rotate(ctx context.Context, validatedSeq, lastRotated uint32) {
+	r.logger.Info("online delete: rotating",
+		"validatedSeq", validatedSeq, "lastRotated", lastRotated,
+		"deleteInterval", r.cfg.DeleteInterval)
+
+	// Refuse to re-acquire or serve ledgers about to be deleted before any
+	// deletion begins (rippled clearPrior: minimumOnline_ = lastRotated + 1).
+	r.minimumOnline.Store(lastRotated + 1)
+
+	if r.rel != nil {
+		if err := r.rel.DeleteLedgersBefore(ctx, lastRotated); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			r.logger.Warn("online delete: relational prune failed", "boundary", lastRotated, "err", err)
+		}
+	}
+
+	deleted, err := r.nodes.DeleteBefore(ctx, lastRotated, r.cfg.DeleteBatch)
+	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		r.logger.Warn("online delete: nodestore prune failed", "boundary", lastRotated, "deleted", deleted, "err", err)
+		return
+	}
+
+	if err := r.store.SetLastRotated(validatedSeq); err != nil {
+		r.logger.Warn("online delete: failed to persist lastRotated", "seq", validatedSeq, "err", err)
+		return
+	}
+
+	r.logger.Info("online delete: rotation finished",
+		"validatedSeq", validatedSeq, "nodesDeleted", deleted, "minimumOnline", lastRotated+1)
+}

--- a/internal/ledger/shamapstore/rotation_integration_test.go
+++ b/internal/ledger/shamapstore/rotation_integration_test.go
@@ -12,10 +12,15 @@ import (
 )
 
 // TestRotation_ReclaimsNodeStoreSpace drives a Rotator against a real
-// nodestore and models the ledger persistence contract: each ledger re-writes
-// the full live state plus a unique header and transaction blob. After a
-// rotation, headers and transaction blobs below the boundary are reclaimed
-// while the live state — re-written at the latest sequence — survives.
+// nodestore and models the production persistence contract: each ledger writes
+// a unique header and re-writes the live account-state leaves at the current
+// sequence, while a churned leaf (state that existed only at that ledger) is
+// left behind at its original sequence. The production node store holds exactly
+// these seq-stamped records — state leaves and ledger headers; tx trees live in
+// the relational index, and the live state map is not NodeStoreFamily-backed in
+// production, so no LedgerSeq=0 inner nodes are written. After a rotation, the
+// headers and churned leaves below the boundary are reclaimed while the live
+// state — re-written at the latest sequence — survives.
 func TestRotation_ReclaimsNodeStoreSpace(t *testing.T) {
 	ctx := context.Background()
 	db := nodestore.NewKVDatabase(memorydb.New(), "mem", 10000, time.Hour)
@@ -26,13 +31,13 @@ func TestRotation_ReclaimsNodeStoreSpace(t *testing.T) {
 		t.Fatalf("New store: %v", err)
 	}
 
-	// One shared "live account state" node, re-persisted every ledger at the
+	// One shared "live account state" leaf, re-persisted every ledger at the
 	// current sequence (mirrors persistToNodeStore walking the full state map).
 	liveData := nodestore.Blob("live-account-root")
 	liveKey := nodestore.ComputeHash256(liveData)
 
 	headerKeys := make(map[uint32]nodestore.Hash256)
-	txKeys := make(map[uint32]nodestore.Hash256)
+	churnedKeys := make(map[uint32]nodestore.Hash256)
 
 	persist := func(seq uint32) {
 		if err := db.Store(ctx, &nodestore.Node{
@@ -48,13 +53,16 @@ func TestRotation_ReclaimsNodeStoreSpace(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("store header: %v", err)
 		}
-		txData := nodestore.Blob(fmt.Sprintf("tx-%d", seq))
-		txKey := nodestore.ComputeHash256(txData)
-		txKeys[seq] = txKey
+		// A state leaf touched only at this ledger: never re-written, so it
+		// keeps its original LedgerSeq and becomes superseded once the account
+		// changes again — exactly what online-delete reclaims.
+		churnData := nodestore.Blob(fmt.Sprintf("churned-state-%d", seq))
+		churnKey := nodestore.ComputeHash256(churnData)
+		churnedKeys[seq] = churnKey
 		if err := db.Store(ctx, &nodestore.Node{
-			Type: nodestore.NodeTransaction, Hash: txKey, Data: txData, LedgerSeq: seq,
+			Type: nodestore.NodeAccount, Hash: churnKey, Data: churnData, LedgerSeq: seq,
 		}); err != nil {
-			t.Fatalf("store tx: %v", err)
+			t.Fatalf("store churned leaf: %v", err)
 		}
 	}
 
@@ -87,22 +95,25 @@ func TestRotation_ReclaimsNodeStoreSpace(t *testing.T) {
 		return n != nil
 	}
 
-	// Headers and tx blobs below 11 must be gone.
+	// Headers and superseded (churned) state leaves below 11 must be gone.
 	for seq := uint32(1); seq < 11; seq++ {
 		if exists(headerKeys[seq]) {
 			t.Errorf("header for ledger %d should be reclaimed", seq)
 		}
-		if exists(txKeys[seq]) {
-			t.Errorf("tx blob for ledger %d should be reclaimed", seq)
+		if exists(churnedKeys[seq]) {
+			t.Errorf("superseded state leaf for ledger %d should be reclaimed", seq)
 		}
 	}
-	// Headers and tx blobs at/above 11 must remain.
+	// Headers and churned leaves at/above 11 must remain.
 	for seq := uint32(11); seq <= 25; seq++ {
 		if !exists(headerKeys[seq]) {
 			t.Errorf("header for ledger %d should be retained", seq)
 		}
+		if !exists(churnedKeys[seq]) {
+			t.Errorf("state leaf for ledger %d should be retained", seq)
+		}
 	}
-	// The live state node, re-written at seq 25, must survive every rotation.
+	// The live state leaf, re-written at seq 25, must survive every rotation.
 	if !exists(liveKey) {
 		t.Fatal("live account state must survive rotation")
 	}

--- a/internal/ledger/shamapstore/rotation_integration_test.go
+++ b/internal/ledger/shamapstore/rotation_integration_test.go
@@ -35,13 +35,11 @@ func TestRotation_ReclaimsNodeStoreSpace(t *testing.T) {
 	txKeys := make(map[uint32]nodestore.Hash256)
 
 	persist := func(seq uint32) {
-		// Live state re-written with the current seq.
 		if err := db.Store(ctx, &nodestore.Node{
 			Type: nodestore.NodeAccount, Hash: liveKey, Data: liveData, LedgerSeq: seq,
 		}); err != nil {
 			t.Fatalf("store live: %v", err)
 		}
-		// Unique header for this ledger.
 		hData := nodestore.Blob(fmt.Sprintf("header-%d", seq))
 		hKey := nodestore.ComputeHash256(hData)
 		headerKeys[seq] = hKey
@@ -50,7 +48,6 @@ func TestRotation_ReclaimsNodeStoreSpace(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("store header: %v", err)
 		}
-		// Unique transaction blob for this ledger.
 		txData := nodestore.Blob(fmt.Sprintf("tx-%d", seq))
 		txKey := nodestore.ComputeHash256(txData)
 		txKeys[seq] = txKey

--- a/internal/ledger/shamapstore/rotation_integration_test.go
+++ b/internal/ledger/shamapstore/rotation_integration_test.go
@@ -1,0 +1,112 @@
+package shamapstore_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/shamapstore"
+	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+)
+
+// TestRotation_ReclaimsNodeStoreSpace drives a Rotator against a real
+// nodestore and models the ledger persistence contract: each ledger re-writes
+// the full live state plus a unique header and transaction blob. After a
+// rotation, headers and transaction blobs below the boundary are reclaimed
+// while the live state — re-written at the latest sequence — survives.
+func TestRotation_ReclaimsNodeStoreSpace(t *testing.T) {
+	ctx := context.Background()
+	db := nodestore.NewKVDatabase(memorydb.New(), "mem", 10000, time.Hour)
+	defer db.Close()
+
+	store, err := shamapstore.New(false, "")
+	if err != nil {
+		t.Fatalf("New store: %v", err)
+	}
+
+	// One shared "live account state" node, re-persisted every ledger at the
+	// current sequence (mirrors persistToNodeStore walking the full state map).
+	liveData := nodestore.Blob("live-account-root")
+	liveKey := nodestore.ComputeHash256(liveData)
+
+	headerKeys := make(map[uint32]nodestore.Hash256)
+	txKeys := make(map[uint32]nodestore.Hash256)
+
+	persist := func(seq uint32) {
+		// Live state re-written with the current seq.
+		if err := db.Store(ctx, &nodestore.Node{
+			Type: nodestore.NodeAccount, Hash: liveKey, Data: liveData, LedgerSeq: seq,
+		}); err != nil {
+			t.Fatalf("store live: %v", err)
+		}
+		// Unique header for this ledger.
+		hData := nodestore.Blob(fmt.Sprintf("header-%d", seq))
+		hKey := nodestore.ComputeHash256(hData)
+		headerKeys[seq] = hKey
+		if err := db.Store(ctx, &nodestore.Node{
+			Type: nodestore.NodeLedger, Hash: hKey, Data: hData, LedgerSeq: seq,
+		}); err != nil {
+			t.Fatalf("store header: %v", err)
+		}
+		// Unique transaction blob for this ledger.
+		txData := nodestore.Blob(fmt.Sprintf("tx-%d", seq))
+		txKey := nodestore.ComputeHash256(txData)
+		txKeys[seq] = txKey
+		if err := db.Store(ctx, &nodestore.Node{
+			Type: nodestore.NodeTransaction, Hash: txKey, Data: txData, LedgerSeq: seq,
+		}); err != nil {
+			t.Fatalf("store tx: %v", err)
+		}
+	}
+
+	rot := shamapstore.NewRotator(store, db, nil,
+		shamapstore.RotationConfig{DeleteInterval: 10}, nil)
+	if rot == nil {
+		t.Fatal("NewRotator returned nil")
+	}
+
+	// Build 25 ledgers, notifying the rotator synchronously per ledger via the
+	// internal predicate path so the assertions are deterministic.
+	for seq := uint32(1); seq <= 25; seq++ {
+		persist(seq)
+		rot.NotifyForTest(seq)
+	}
+
+	// lastRotated seeds at 1; first rotation fires at seq 11 (>= 1+10),
+	// deleting below 1 (nothing) and setting lastRotated=11; the next fires
+	// at seq 21 (>= 11+10), deleting below 11 and setting lastRotated=21, so
+	// minimumOnline becomes 11+1 = 12.
+	if got := rot.MinimumOnline(); got != 12 {
+		t.Fatalf("minimumOnline = %d, want 12", got)
+	}
+
+	exists := func(h nodestore.Hash256) bool {
+		n, err := db.Fetch(ctx, h)
+		if err != nil {
+			t.Fatalf("Fetch: %v", err)
+		}
+		return n != nil
+	}
+
+	// Headers and tx blobs below 11 must be gone.
+	for seq := uint32(1); seq < 11; seq++ {
+		if exists(headerKeys[seq]) {
+			t.Errorf("header for ledger %d should be reclaimed", seq)
+		}
+		if exists(txKeys[seq]) {
+			t.Errorf("tx blob for ledger %d should be reclaimed", seq)
+		}
+	}
+	// Headers and tx blobs at/above 11 must remain.
+	for seq := uint32(11); seq <= 25; seq++ {
+		if !exists(headerKeys[seq]) {
+			t.Errorf("header for ledger %d should be retained", seq)
+		}
+	}
+	// The live state node, re-written at seq 25, must survive every rotation.
+	if !exists(liveKey) {
+		t.Fatal("live account state must survive rotation")
+	}
+}

--- a/internal/ledger/shamapstore/rotation_test.go
+++ b/internal/ledger/shamapstore/rotation_test.go
@@ -1,0 +1,235 @@
+package shamapstore
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeNodePruner records DeleteBefore boundaries and reports a fixed deleted
+// count so tests can assert what the rotator asked to delete.
+type fakeNodePruner struct {
+	mu         sync.Mutex
+	boundaries []uint32
+	deleted    uint64
+}
+
+func (f *fakeNodePruner) DeleteBefore(_ context.Context, boundary uint32, _ int) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.boundaries = append(f.boundaries, boundary)
+	return f.deleted, nil
+}
+
+func (f *fakeNodePruner) calls() []uint32 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]uint32(nil), f.boundaries...)
+}
+
+type fakeRelPruner struct {
+	mu         sync.Mutex
+	boundaries []uint32
+}
+
+func (f *fakeRelPruner) DeleteLedgersBefore(_ context.Context, boundary uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.boundaries = append(f.boundaries, boundary)
+	return nil
+}
+
+func (f *fakeRelPruner) calls() []uint32 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]uint32(nil), f.boundaries...)
+}
+
+func newTestRotator(t *testing.T, advisory bool, interval uint32) (*Rotator, *fakeNodePruner, *fakeRelPruner) {
+	t.Helper()
+	store, err := New(advisory, "")
+	if err != nil {
+		t.Fatalf("New store: %v", err)
+	}
+	nodes := &fakeNodePruner{}
+	rel := &fakeRelPruner{}
+	r := NewRotator(store, nodes, rel, RotationConfig{DeleteInterval: interval}, nil)
+	if r == nil {
+		t.Fatal("NewRotator returned nil")
+	}
+	return r, nodes, rel
+}
+
+func TestNewRotator_DisabledWhenIntervalZero(t *testing.T) {
+	store, _ := New(false, "")
+	if r := NewRotator(store, &fakeNodePruner{}, nil, RotationConfig{DeleteInterval: 0}, nil); r != nil {
+		t.Fatal("rotator must be nil when online_delete is off")
+	}
+}
+
+func TestNewRotator_NilWhenNoPruner(t *testing.T) {
+	store, _ := New(false, "")
+	if r := NewRotator(store, nil, nil, RotationConfig{DeleteInterval: 256}, nil); r != nil {
+		t.Fatal("rotator must be nil without a node pruner")
+	}
+}
+
+func TestRotate_FirstNotificationSeedsBoundaryNoDelete(t *testing.T) {
+	r, nodes, rel := newTestRotator(t, false, 256)
+
+	r.maybeRotate(context.Background(), 1000)
+
+	if got := r.store.GetLastRotated(); got != 1000 {
+		t.Fatalf("lastRotated = %d, want 1000 (seeded)", got)
+	}
+	if got := r.MinimumOnline(); got != 1000 {
+		t.Fatalf("minimumOnline = %d, want 1000", got)
+	}
+	if len(nodes.calls()) != 0 || len(rel.calls()) != 0 {
+		t.Fatal("first notification must not delete anything")
+	}
+}
+
+func TestRotate_WaitsForFullInterval(t *testing.T) {
+	r, nodes, _ := newTestRotator(t, false, 256)
+	r.maybeRotate(context.Background(), 1000) // seed lastRotated=1000
+
+	// Not yet a full interval past 1000.
+	r.maybeRotate(context.Background(), 1000+255)
+	if len(nodes.calls()) != 0 {
+		t.Fatal("must not rotate before a full delete interval elapses")
+	}
+	if got := r.store.GetLastRotated(); got != 1000 {
+		t.Fatalf("lastRotated = %d, want unchanged 1000", got)
+	}
+
+	// Exactly one interval past 1000 → rotate, deleting below the OLD boundary.
+	r.maybeRotate(context.Background(), 1000+256)
+	calls := nodes.calls()
+	if len(calls) != 1 || calls[0] != 1000 {
+		t.Fatalf("node delete boundaries = %v, want [1000]", calls)
+	}
+	if got := r.store.GetLastRotated(); got != 1256 {
+		t.Fatalf("lastRotated = %d, want 1256", got)
+	}
+	if got := r.MinimumOnline(); got != 1001 {
+		t.Fatalf("minimumOnline = %d, want 1001 (lastRotated+1)", got)
+	}
+}
+
+func TestRotate_DeletesBelowOldBoundaryInBothStores(t *testing.T) {
+	r, nodes, rel := newTestRotator(t, false, 256)
+	r.maybeRotate(context.Background(), 500) // seed lastRotated=500
+	r.maybeRotate(context.Background(), 800) // 800 >= 500+256 → rotate
+
+	if nc := nodes.calls(); len(nc) != 1 || nc[0] != 500 {
+		t.Fatalf("node delete boundaries = %v, want [500]", nc)
+	}
+	if rc := rel.calls(); len(rc) != 1 || rc[0] != 500 {
+		t.Fatalf("relational delete boundaries = %v, want [500]", rc)
+	}
+	if got := r.store.GetLastRotated(); got != 800 {
+		t.Fatalf("lastRotated = %d, want 800", got)
+	}
+}
+
+func TestRotate_AdvisoryDeleteGatesOnCanDelete(t *testing.T) {
+	r, nodes, _ := newTestRotator(t, true, 256)
+	r.maybeRotate(context.Background(), 500) // seed lastRotated=500
+
+	// can_delete defaults to 0: it does not yet permit deleting below 500,
+	// so a ready interval must still be held back (rippled: canDelete_ >=
+	// lastRotated-1).
+	r.maybeRotate(context.Background(), 800)
+	if len(nodes.calls()) != 0 {
+		t.Fatal("advisory delete must block rotation until can_delete permits it")
+	}
+	if got := r.store.GetLastRotated(); got != 500 {
+		t.Fatalf("lastRotated = %d, want unchanged 500", got)
+	}
+
+	// Operator advances can_delete to 499 (== lastRotated-1) → permitted.
+	if _, err := r.store.SetCanDelete(499); err != nil {
+		t.Fatalf("SetCanDelete: %v", err)
+	}
+	r.maybeRotate(context.Background(), 800)
+	if nc := nodes.calls(); len(nc) != 1 || nc[0] != 500 {
+		t.Fatalf("node delete boundaries = %v, want [500] after can_delete permits", nc)
+	}
+	if got := r.store.GetLastRotated(); got != 800 {
+		t.Fatalf("lastRotated = %d, want 800", got)
+	}
+}
+
+func TestRotate_AdvisoryDeleteAlwaysPermits(t *testing.T) {
+	// can_delete "always" maps to max uint32; it must permit rotation without
+	// overflowing the gate arithmetic.
+	r, nodes, _ := newTestRotator(t, true, 256)
+	r.maybeRotate(context.Background(), 500) // seed lastRotated=500
+	if _, err := r.store.SetCanDelete(^uint32(0)); err != nil {
+		t.Fatalf("SetCanDelete: %v", err)
+	}
+	r.maybeRotate(context.Background(), 800)
+	if nc := nodes.calls(); len(nc) != 1 || nc[0] != 500 {
+		t.Fatalf("node delete boundaries = %v, want [500] with can_delete=always", nc)
+	}
+}
+
+func TestRotate_TolerantOfNilRelationalPruner(t *testing.T) {
+	store, _ := New(false, "")
+	nodes := &fakeNodePruner{}
+	r := NewRotator(store, nodes, nil, RotationConfig{DeleteInterval: 256}, nil)
+	if r == nil {
+		t.Fatal("rotator nil with valid node pruner")
+	}
+	r.maybeRotate(context.Background(), 500)
+	r.maybeRotate(context.Background(), 800)
+	if nc := nodes.calls(); len(nc) != 1 || nc[0] != 500 {
+		t.Fatalf("node delete boundaries = %v, want [500] (rel nil)", nc)
+	}
+}
+
+func TestRotator_NotifyEndToEnd(t *testing.T) {
+	r, nodes, _ := newTestRotator(t, false, 256)
+	r.Start()
+	defer r.Stop()
+
+	r.Notify(500) // seeds
+	// Wait for the seed to land.
+	waitFor(t, func() bool { return r.store.GetLastRotated() == 500 })
+
+	r.Notify(800) // triggers a rotation deleting below 500
+	waitFor(t, func() bool { return r.store.GetLastRotated() == 800 })
+
+	if nc := nodes.calls(); len(nc) != 1 || nc[0] != 500 {
+		t.Fatalf("node delete boundaries = %v, want [500]", nc)
+	}
+	if got := r.MinimumOnline(); got != 501 {
+		t.Fatalf("minimumOnline = %d, want 501", got)
+	}
+}
+
+func TestRotator_NilSafe(t *testing.T) {
+	var r *Rotator
+	// All methods must be no-ops / zero on a nil rotator so callers needn't
+	// branch on "online delete off".
+	r.Start()
+	r.Notify(123)
+	if got := r.MinimumOnline(); got != 0 {
+		t.Fatalf("nil MinimumOnline = %d, want 0", got)
+	}
+	r.Stop()
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("condition not met within timeout")
+}

--- a/internal/ledger/shamapstore/store.go
+++ b/internal/ledger/shamapstore/store.go
@@ -1,19 +1,19 @@
-// Package shamapstore implements go-xrpl's advisory-delete state — the subset
-// of rippled's SHAMapStore (src/xrpld/app/misc/SHAMapStore.h) that the
-// can_delete RPC reads and writes.
+// Package shamapstore implements go-xrpl's online-delete subsystem — the
+// go-xrpl equivalent of rippled's SHAMapStore (src/xrpld/app/misc/SHAMapStore.h).
 //
-// It tracks two ledger sequences, gated by the node_db advisory_delete config
-// flag and persisted across restarts (mirroring rippled's SavedStateDB):
+// Two pieces live here:
 //
-//   - canDelete   the advisory boundary: all ledgers at or below this seq are
-//     unprotected and online delete may remove them.
-//   - lastRotated the most recent ledger online delete has rotated; 0 until
-//     the first rotation.
-//
-// The background rotation that consumes canDelete to actually delete old
-// ledger nodes (rippled SHAMapStoreImp's run loop) is a separate subsystem and
-// is intentionally not part of this state layer — can_delete only manages the
-// advisory boundary, exactly as rippled's CanDelete.cpp does.
+//   - Store, the advisory-delete state the can_delete RPC reads and writes. It
+//     tracks two ledger sequences, gated by the node_db advisory_delete config
+//     flag and persisted across restarts (mirroring rippled's SavedStateDB):
+//     canDelete (the advisory boundary: ledgers at or below it are unprotected
+//     and online delete may remove them) and lastRotated (the most recent
+//     ledger online delete has rotated; 0 until the first rotation).
+//   - Rotator, the background job that consumes those boundaries to actually
+//     reclaim disk: every node_db online_delete validated ledgers it deletes
+//     complete ledgers below the rotation boundary from the node store and the
+//     relational index, advancing lastRotated (rippled SHAMapStoreImp's run
+//     loop).
 package shamapstore
 
 import (
@@ -93,9 +93,9 @@ func (s *Store) GetLastRotated() uint32 {
 	return s.lastRotated
 }
 
-// SetLastRotated records the last rotated ledger and persists it. Reserved for
-// the online-delete rotation subsystem (rippled SHAMapStoreImp); can_delete
-// never advances lastRotated.
+// SetLastRotated records the last rotated ledger and persists it. Advanced by
+// the online-delete rotation subsystem (see Rotator); can_delete never advances
+// lastRotated.
 func (s *Store) SetLastRotated(seq uint32) error {
 	s.mu.Lock()
 	s.lastRotated = seq

--- a/storage/nodestore/prune.go
+++ b/storage/nodestore/prune.go
@@ -1,0 +1,121 @@
+package nodestore
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+)
+
+// defaultDeleteBatch is the number of keys removed per kvstore batch when no
+// explicit batch size is supplied. It bounds the in-memory key list and the
+// per-batch write size so a single prune pass over a large backend never holds
+// the whole keyspace in memory at once.
+const defaultDeleteBatch = 65536
+
+// PrunableDatabase is a Database that supports online deletion of ledgers below
+// a retention boundary. It is a capability interface: a Database may implement
+// it to participate in online_delete rotation. Backends that cannot enumerate
+// their keyspace simply do not implement it.
+type PrunableDatabase interface {
+	Database
+
+	// DeleteBefore removes every stored node whose LedgerSeq is strictly below
+	// boundary, returning the number of nodes deleted. Nodes still referenced by
+	// the live state tree are immune: the ledger persistence path re-writes every
+	// live state node on each ledger with the current sequence, so a node that is
+	// still part of recent state always carries a LedgerSeq at or above the
+	// retained range. Only superseded state nodes, old ledger headers, and old
+	// transaction blobs carry a LedgerSeq below the boundary.
+	//
+	// Deletion is performed in batches of at most batchSize keys (a non-positive
+	// batchSize selects a default). The context is honoured between batches so a
+	// shutdown unblocks the caller promptly. A best-effort partial deletion is
+	// reported even when the context is cancelled mid-pass.
+	DeleteBefore(ctx context.Context, boundary uint32, batchSize int) (deleted uint64, err error)
+}
+
+// DeleteBefore implements PrunableDatabase. It scans the underlying kvstore,
+// decodes the inline ledger sequence from each stored value, and batch-deletes
+// the keys below boundary, evicting them from the in-memory caches as it goes.
+func (d *KVDatabaseImpl) DeleteBefore(ctx context.Context, boundary uint32, batchSize int) (uint64, error) {
+	if boundary == 0 {
+		return 0, nil
+	}
+	if batchSize <= 0 {
+		batchSize = defaultDeleteBatch
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	var deleted uint64
+	pending := make([][]byte, 0, batchSize)
+
+	flush := func() error {
+		if len(pending) == 0 {
+			return nil
+		}
+		batch := d.store.NewBatch()
+		for _, k := range pending {
+			if err := batch.Delete(k); err != nil {
+				return fmt.Errorf("delete-before batch: %w", err)
+			}
+		}
+		if err := batch.Write(); err != nil {
+			return fmt.Errorf("delete-before commit: %w", err)
+		}
+		for _, k := range pending {
+			var h Hash256
+			copy(h[:], k)
+			if d.cache != nil {
+				d.cache.Remove(h)
+			}
+			if d.negativeCache != nil {
+				d.negativeCache.MarkMissing(h)
+			}
+		}
+		deleted += uint64(len(pending))
+		pending = pending[:0]
+		return nil
+	}
+
+	it := d.store.NewIterator(nil, nil)
+	defer it.Release()
+
+	for it.Next() {
+		if err := ctx.Err(); err != nil {
+			// Persist what we have already queued so the pass makes forward
+			// progress across cancellations, then report the cancellation.
+			_ = flush()
+			return deleted, err
+		}
+
+		value := it.Value()
+		if len(value) < nodeEncodingHeaderSize {
+			// Not a node blob this scanner understands; leave it untouched.
+			continue
+		}
+		seq := binary.BigEndian.Uint32(value[1:5])
+		if seq >= boundary {
+			continue
+		}
+
+		key := append([]byte(nil), it.Key()...)
+		pending = append(pending, key)
+		if len(pending) >= batchSize {
+			if err := flush(); err != nil {
+				return deleted, err
+			}
+		}
+	}
+	if err := it.Error(); err != nil {
+		_ = flush()
+		return deleted, fmt.Errorf("delete-before scan: %w", err)
+	}
+	if err := flush(); err != nil {
+		return deleted, err
+	}
+	return deleted, nil
+}
+
+var _ PrunableDatabase = (*KVDatabaseImpl)(nil)

--- a/storage/nodestore/prune.go
+++ b/storage/nodestore/prune.go
@@ -20,12 +20,15 @@ type PrunableDatabase interface {
 	Database
 
 	// DeleteBefore removes every stored node whose LedgerSeq is strictly below
-	// boundary, returning the number of nodes deleted. Nodes still referenced by
-	// the live state tree are immune: the ledger persistence path re-writes every
-	// live state node on each ledger with the current sequence, so a node that is
-	// still part of recent state always carries a LedgerSeq at or above the
-	// retained range. Only superseded state nodes, old ledger headers, and old
-	// transaction blobs carry a LedgerSeq below the boundary.
+	// boundary, returning the number of nodes deleted. The production node store
+	// holds two kinds of seq-stamped record: the live state leaves and the
+	// per-ledger headers, both re-written every ledger at the current sequence
+	// (the live state map is not backed by a NodeStoreFamily in production, so
+	// no LedgerSeq=0 inner nodes are written, and transaction trees live in the
+	// relational index, not here). A leaf still part of recent state therefore
+	// always carries a LedgerSeq at or above the retained range and is immune;
+	// only the superseded copies of state leaves and old ledger headers carry a
+	// LedgerSeq below the boundary.
 	//
 	// Deletion is performed in batches of at most batchSize keys (a non-positive
 	// batchSize selects a default). The context is honoured between batches so a

--- a/storage/nodestore/prune_test.go
+++ b/storage/nodestore/prune_test.go
@@ -1,0 +1,158 @@
+package nodestore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
+)
+
+// storeNodeAt persists a node carrying an explicit ledger sequence so the
+// prune scanner can classify it. The key is derived from the data plus seq so
+// nodes at different sequences never collide.
+func storeNodeAt(t *testing.T, db *KVDatabaseImpl, seq uint32, tag byte) Hash256 {
+	t.Helper()
+	data := Blob{tag, byte(seq), byte(seq >> 8), byte(seq >> 16), byte(seq >> 24)}
+	h := ComputeHash256(data)
+	node := &Node{Type: NodeAccount, Hash: h, Data: data, LedgerSeq: seq}
+	if err := db.Store(context.Background(), node); err != nil {
+		t.Fatalf("Store(seq=%d): %v", seq, err)
+	}
+	return h
+}
+
+func present(t *testing.T, db *KVDatabaseImpl, h Hash256) bool {
+	t.Helper()
+	n, err := db.Fetch(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	return n != nil
+}
+
+func TestDeleteBefore_RemovesBelowBoundaryKeepsAtOrAbove(t *testing.T) {
+	db := NewKVDatabase(memorydb.New(), "mem", 1000, time.Hour)
+	defer db.Close()
+
+	keys := make(map[uint32]Hash256)
+	for seq := uint32(1); seq <= 10; seq++ {
+		keys[seq] = storeNodeAt(t, db, seq, 0xAA)
+	}
+
+	const boundary = 6
+	deleted, err := db.DeleteBefore(context.Background(), boundary, 0)
+	if err != nil {
+		t.Fatalf("DeleteBefore: %v", err)
+	}
+	// Sequences 1..5 are below the boundary → 5 nodes deleted.
+	if deleted != 5 {
+		t.Fatalf("deleted = %d, want 5", deleted)
+	}
+
+	for seq := uint32(1); seq < boundary; seq++ {
+		if present(t, db, keys[seq]) {
+			t.Errorf("seq %d should have been deleted", seq)
+		}
+	}
+	for seq := uint32(boundary); seq <= 10; seq++ {
+		if !present(t, db, keys[seq]) {
+			t.Errorf("seq %d should have been retained", seq)
+		}
+	}
+}
+
+func TestDeleteBefore_LiveNodeReWrittenAtLatestSeqSurvives(t *testing.T) {
+	// Models the persistence contract: a state node still live in recent
+	// ledgers is re-persisted every ledger at the current sequence, so its
+	// stored LedgerSeq is the latest, not the one it first appeared at.
+	db := NewKVDatabase(memorydb.New(), "mem", 1000, time.Hour)
+	defer db.Close()
+
+	data := Blob("live-account-state")
+	h := ComputeHash256(data)
+	// First written at seq 3, then re-written (same key) at seq 50.
+	for _, seq := range []uint32{3, 50} {
+		node := &Node{Type: NodeAccount, Hash: h, Data: data, LedgerSeq: seq}
+		if err := db.Store(context.Background(), node); err != nil {
+			t.Fatalf("Store(seq=%d): %v", seq, err)
+		}
+	}
+
+	if _, err := db.DeleteBefore(context.Background(), 40, 0); err != nil {
+		t.Fatalf("DeleteBefore: %v", err)
+	}
+	if !present(t, db, h) {
+		t.Fatal("live node re-written at seq 50 must survive a prune below 40")
+	}
+}
+
+func TestDeleteBefore_Batched(t *testing.T) {
+	db := NewKVDatabase(memorydb.New(), "mem", 1000, time.Hour)
+	defer db.Close()
+
+	for seq := uint32(1); seq <= 200; seq++ {
+		storeNodeAt(t, db, seq, 0xBB)
+	}
+	// Tiny batch forces multiple flush cycles.
+	deleted, err := db.DeleteBefore(context.Background(), 150, 7)
+	if err != nil {
+		t.Fatalf("DeleteBefore: %v", err)
+	}
+	if deleted != 149 {
+		t.Fatalf("deleted = %d, want 149", deleted)
+	}
+}
+
+func TestDeleteBefore_ZeroBoundaryNoOp(t *testing.T) {
+	db := NewKVDatabase(memorydb.New(), "mem", 1000, time.Hour)
+	defer db.Close()
+
+	k := storeNodeAt(t, db, 5, 0xCC)
+	deleted, err := db.DeleteBefore(context.Background(), 0, 0)
+	if err != nil {
+		t.Fatalf("DeleteBefore: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("deleted = %d, want 0", deleted)
+	}
+	if !present(t, db, k) {
+		t.Fatal("zero-boundary prune must delete nothing")
+	}
+}
+
+func TestDeleteBefore_EvictsPositiveCache(t *testing.T) {
+	db := NewKVDatabase(memorydb.New(), "mem", 1000, time.Hour)
+	defer db.Close()
+
+	h := storeNodeAt(t, db, 3, 0xDD)
+	// Warm the positive cache.
+	if _, err := db.Fetch(context.Background(), h); err != nil {
+		t.Fatalf("warm Fetch: %v", err)
+	}
+	if _, ok := db.cache.Get(h); !ok {
+		t.Fatal("expected node cached before prune")
+	}
+
+	if _, err := db.DeleteBefore(context.Background(), 10, 0); err != nil {
+		t.Fatalf("DeleteBefore: %v", err)
+	}
+	if _, ok := db.cache.Get(h); ok {
+		t.Fatal("pruned node must be evicted from the positive cache")
+	}
+	if present(t, db, h) {
+		t.Fatal("pruned node must not be fetchable after cache eviction")
+	}
+}
+
+func TestDeleteBefore_ContextCancelled(t *testing.T) {
+	db := NewKVDatabase(memorydb.New(), "mem", 1000, time.Hour)
+	defer db.Close()
+
+	storeNodeAt(t, db, 1, 0xEE)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := db.DeleteBefore(ctx, 10, 0); err != context.Canceled {
+		t.Fatalf("DeleteBefore on cancelled ctx = %v, want context.Canceled", err)
+	}
+}

--- a/storage/relationaldb/prune.go
+++ b/storage/relationaldb/prune.go
@@ -1,0 +1,107 @@
+package relationaldb
+
+import (
+	"context"
+	"fmt"
+)
+
+// LedgerPruner deletes ledger and transaction index rows below a retention
+// boundary, in batches, mirroring rippled's SHAMapStoreImp::clearSql over the
+// Ledgers, Transactions and AccountTransactions tables. It is the relational
+// half of online_delete rotation.
+type LedgerPruner struct {
+	mgr   RepositoryManager
+	batch int
+}
+
+// NewLedgerPruner builds a pruner over mgr. batch caps how many sequences each
+// delete step spans, bounding the size of any single delete statement; a
+// non-positive batch deletes in one step.
+func NewLedgerPruner(mgr RepositoryManager, batch int) *LedgerPruner {
+	return &LedgerPruner{mgr: mgr, batch: batch}
+}
+
+// DeleteLedgersBefore removes every Ledgers, Transactions and
+// AccountTransactions row with a ledger sequence strictly below boundary.
+//
+// Each table is pruned independently from its own current minimum sequence,
+// matching rippled's clearSql: it looks up the table's lowest LedgerSeq, skips
+// the table when nothing lies below the boundary, then deletes up the range in
+// batch-sized steps. The whole operation is best-effort and idempotent — a
+// later pass with the same or a higher boundary simply finds less to delete.
+func (p *LedgerPruner) DeleteLedgersBefore(ctx context.Context, boundary uint32) error {
+	if p == nil || p.mgr == nil || boundary == 0 {
+		return nil
+	}
+
+	if err := p.clear(ctx, boundary,
+		p.mgr.Ledger().GetMinLedgerSeq,
+		// Ledgers delete is inclusive (<= maxSeq); pass boundary-1 to delete
+		// strictly below the boundary, keeping the boundary ledger itself.
+		func(ctx context.Context, upTo uint32) error {
+			return p.mgr.Ledger().DeleteLedgersBySeq(ctx, LedgerIndex(upTo-1))
+		},
+	); err != nil {
+		return fmt.Errorf("prune ledgers: %w", err)
+	}
+
+	if err := p.clear(ctx, boundary,
+		p.mgr.Transaction().GetTransactionsMinLedgerSeq,
+		func(ctx context.Context, upTo uint32) error {
+			return p.mgr.Transaction().DeleteTransactionsBeforeLedgerSeq(ctx, LedgerIndex(upTo))
+		},
+	); err != nil {
+		return fmt.Errorf("prune transactions: %w", err)
+	}
+
+	if err := p.clear(ctx, boundary,
+		p.mgr.AccountTransaction().GetAccountTransactionsMinLedgerSeq,
+		func(ctx context.Context, upTo uint32) error {
+			return p.mgr.AccountTransaction().DeleteAccountTransactionsBeforeLedgerSeq(ctx, LedgerIndex(upTo))
+		},
+	); err != nil {
+		return fmt.Errorf("prune account transactions: %w", err)
+	}
+
+	return nil
+}
+
+// clear deletes rows below boundary in batch-sized steps, starting from the
+// table's current minimum sequence. getMin returns the lowest sequence still
+// present (nil when the table is empty); deleteUpTo deletes rows strictly below
+// the supplied (exclusive) sequence.
+func (p *LedgerPruner) clear(
+	ctx context.Context,
+	boundary uint32,
+	getMin func(context.Context) (*LedgerIndex, error),
+	deleteUpTo func(context.Context, uint32) error,
+) error {
+	m, err := getMin(ctx)
+	if err != nil {
+		return err
+	}
+	if m == nil {
+		return nil
+	}
+	min := uint32(*m)
+	if min >= boundary {
+		return nil
+	}
+
+	for min < boundary {
+		upTo := boundary
+		if p.batch > 0 {
+			if step := min + uint32(p.batch); step < boundary {
+				upTo = step
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := deleteUpTo(ctx, upTo); err != nil {
+			return err
+		}
+		min = upTo
+	}
+	return nil
+}

--- a/storage/relationaldb/prune_test.go
+++ b/storage/relationaldb/prune_test.go
@@ -1,0 +1,172 @@
+package relationaldb
+
+import (
+	"context"
+	"testing"
+)
+
+// fakeLedgerRepo records delete calls and reports a configurable minimum
+// sequence. Only the methods LedgerPruner exercises are implemented; the rest
+// of LedgerRepository is satisfied by the embedded nil interface and must not
+// be called.
+type fakeLedgerRepo struct {
+	LedgerRepository
+	min        *LedgerIndex
+	deleteArgs []LedgerIndex
+}
+
+func (f *fakeLedgerRepo) GetMinLedgerSeq(context.Context) (*LedgerIndex, error) { return f.min, nil }
+func (f *fakeLedgerRepo) DeleteLedgersBySeq(_ context.Context, maxSeq LedgerIndex) error {
+	f.deleteArgs = append(f.deleteArgs, maxSeq)
+	return nil
+}
+
+type fakeTxRepo struct {
+	TransactionRepository
+	min        *LedgerIndex
+	deleteArgs []LedgerIndex
+}
+
+func (f *fakeTxRepo) GetTransactionsMinLedgerSeq(context.Context) (*LedgerIndex, error) {
+	return f.min, nil
+}
+func (f *fakeTxRepo) DeleteTransactionsBeforeLedgerSeq(_ context.Context, seq LedgerIndex) error {
+	f.deleteArgs = append(f.deleteArgs, seq)
+	return nil
+}
+
+type fakeAcctTxRepo struct {
+	AccountTransactionRepository
+	min        *LedgerIndex
+	deleteArgs []LedgerIndex
+}
+
+func (f *fakeAcctTxRepo) GetAccountTransactionsMinLedgerSeq(context.Context) (*LedgerIndex, error) {
+	return f.min, nil
+}
+func (f *fakeAcctTxRepo) DeleteAccountTransactionsBeforeLedgerSeq(_ context.Context, seq LedgerIndex) error {
+	f.deleteArgs = append(f.deleteArgs, seq)
+	return nil
+}
+
+type fakeManager struct {
+	RepositoryManager
+	ledger *fakeLedgerRepo
+	tx     *fakeTxRepo
+	acct   *fakeAcctTxRepo
+}
+
+func (m *fakeManager) Ledger() LedgerRepository                         { return m.ledger }
+func (m *fakeManager) Transaction() TransactionRepository               { return m.tx }
+func (m *fakeManager) AccountTransaction() AccountTransactionRepository { return m.acct }
+
+func seqPtr(v uint32) *LedgerIndex { idx := LedgerIndex(v); return &idx }
+
+func newFakeManager(ledgerMin, txMin, acctMin *LedgerIndex) *fakeManager {
+	return &fakeManager{
+		ledger: &fakeLedgerRepo{min: ledgerMin},
+		tx:     &fakeTxRepo{min: txMin},
+		acct:   &fakeAcctTxRepo{min: acctMin},
+	}
+}
+
+func TestLedgerPruner_DeletesBelowBoundary(t *testing.T) {
+	m := newFakeManager(seqPtr(1), seqPtr(1), seqPtr(1))
+	p := NewLedgerPruner(m, 0)
+
+	if err := p.DeleteLedgersBefore(context.Background(), 100); err != nil {
+		t.Fatalf("DeleteLedgersBefore: %v", err)
+	}
+
+	// Ledgers delete is inclusive (<=), so the boundary is passed as 99 to
+	// delete strictly below 100. Tx/AcctTx deletes are exclusive (<), so they
+	// receive 100 directly.
+	if got := m.ledger.deleteArgs; len(got) != 1 || got[0] != 99 {
+		t.Fatalf("ledger delete args = %v, want [99]", got)
+	}
+	if got := m.tx.deleteArgs; len(got) != 1 || got[0] != 100 {
+		t.Fatalf("tx delete args = %v, want [100]", got)
+	}
+	if got := m.acct.deleteArgs; len(got) != 1 || got[0] != 100 {
+		t.Fatalf("acct delete args = %v, want [100]", got)
+	}
+}
+
+func TestLedgerPruner_SkipsWhenMinAtOrAboveBoundary(t *testing.T) {
+	// Every table's minimum is already at the boundary → nothing to delete.
+	m := newFakeManager(seqPtr(100), seqPtr(100), seqPtr(100))
+	p := NewLedgerPruner(m, 0)
+
+	if err := p.DeleteLedgersBefore(context.Background(), 100); err != nil {
+		t.Fatalf("DeleteLedgersBefore: %v", err)
+	}
+	if len(m.ledger.deleteArgs)+len(m.tx.deleteArgs)+len(m.acct.deleteArgs) != 0 {
+		t.Fatal("no deletes expected when min >= boundary")
+	}
+}
+
+func TestLedgerPruner_SkipsEmptyTables(t *testing.T) {
+	// nil min seq models an empty table.
+	m := newFakeManager(nil, nil, nil)
+	p := NewLedgerPruner(m, 0)
+
+	if err := p.DeleteLedgersBefore(context.Background(), 100); err != nil {
+		t.Fatalf("DeleteLedgersBefore: %v", err)
+	}
+	if len(m.ledger.deleteArgs)+len(m.tx.deleteArgs)+len(m.acct.deleteArgs) != 0 {
+		t.Fatal("no deletes expected on empty tables")
+	}
+}
+
+func TestLedgerPruner_Batched(t *testing.T) {
+	// min=1, boundary=10, batch=3 → exclusive delete steps walk
+	// 4, 7, 10 for the tx/acct tables.
+	m := newFakeManager(seqPtr(1), seqPtr(1), seqPtr(1))
+	p := NewLedgerPruner(m, 3)
+
+	if err := p.DeleteLedgersBefore(context.Background(), 10); err != nil {
+		t.Fatalf("DeleteLedgersBefore: %v", err)
+	}
+
+	wantTx := []LedgerIndex{4, 7, 10}
+	if got := m.tx.deleteArgs; !equalSeqs(got, wantTx) {
+		t.Fatalf("tx batched delete args = %v, want %v", got, wantTx)
+	}
+	if got := m.acct.deleteArgs; !equalSeqs(got, wantTx) {
+		t.Fatalf("acct batched delete args = %v, want %v", got, wantTx)
+	}
+	// Ledgers (inclusive) reach the same steps minus one: 3, 6, 9.
+	wantLedger := []LedgerIndex{3, 6, 9}
+	if got := m.ledger.deleteArgs; !equalSeqs(got, wantLedger) {
+		t.Fatalf("ledger batched delete args = %v, want %v", got, wantLedger)
+	}
+}
+
+func TestLedgerPruner_ZeroBoundaryNoOp(t *testing.T) {
+	m := newFakeManager(seqPtr(1), seqPtr(1), seqPtr(1))
+	p := NewLedgerPruner(m, 0)
+	if err := p.DeleteLedgersBefore(context.Background(), 0); err != nil {
+		t.Fatalf("DeleteLedgersBefore: %v", err)
+	}
+	if len(m.ledger.deleteArgs)+len(m.tx.deleteArgs)+len(m.acct.deleteArgs) != 0 {
+		t.Fatal("zero boundary must delete nothing")
+	}
+}
+
+func equalSeqs(a, b []LedgerIndex) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Compile-time check: *LedgerPruner is usable as the rotator's relational
+// pruner.
+var _ interface {
+	DeleteLedgersBefore(context.Context, uint32) error
+} = (*LedgerPruner)(nil)


### PR DESCRIPTION
## Summary

`online_delete` was accepted in config but inert: the advisory-delete state machine (`can_delete` RPC, `lastRotated`/`canDelete` tracking) existed, yet no background job ever reclaimed disk, so the node store grew unbounded. This adds the rotation subsystem that actually deletes old ledgers.

A new **`Rotator`** (`internal/ledger/shamapstore`) is driven off the validated-ledger advance and applies rippled's `SHAMapStoreImp::run` decision logic:

- the first validated ledger seeds `lastRotated` (no deletion);
- thereafter a rotation fires once the validated sequence is a full `online_delete` interval past `lastRotated` **and**, under `advisory_delete`, the operator's `can_delete` boundary permits it (`canDelete >= lastRotated-1`);
- on rotation it deletes every complete ledger **below the prior rotation boundary**, advances `lastRotated`, and raises a `MinimumOnline` boundary so acquisition / fetch-pack serving never reach below the retained range.

Notifications are coalesced onto a single background worker, so deletion never blocks the consensus / ledger-accept path. `can_delete` and `advisory_delete` behaviour is unchanged from the operator's perspective.

## Design choice: boundary-delete, not copy-forward

rippled copies the live state tree forward into a fresh backend and swaps. go-xrpl's node store is **object-by-index** (content-addressed, keyed by node hash, **not** SHAMap-node-keyed), and the ledger persistence path re-writes the *entire* live state map every ledger with the current sequence. So a node still part of recent state always carries a `LedgerSeq` at or above the retained range; only superseded state nodes, old ledger headers, and old transaction blobs retain a sequence below the boundary.

That makes a **boundary-delete** the natural, correct equivalent: delete every node with `LedgerSeq < boundary`. It reclaims exactly the disk copy-forward would, without rebuilding a backend, and live state is provably immune (covered by a test that re-writes a node forward and confirms it survives a prune below its original sequence). The reclaimed-space and `can_delete`/advisory semantics match rippled from the operator's perspective.

## Changes

- **`storage/nodestore`** — `PrunableDatabase.DeleteBefore` batch-deletes nodes below a boundary by scanning the kvstore and decoding the inline ledger sequence, evicting pruned keys from the positive/negative caches. Capability interface, so backends that can't enumerate their keyspace simply don't implement it.
- **`storage/relationaldb`** — `LedgerPruner` mirrors rippled's `clearSql` across the `Ledgers`, `Transactions` and `AccountTransactions` tables (batched, honouring `delete_batch`, skipping no-op work via the min-seq getters).
- **`internal/ledger/shamapstore`** — the `Rotator` plus the rippled-faithful `readyToRotate` predicate; `MinimumOnline()` mirrors rippled's `minimumOnline_`.
- **`internal/cli`** — wire the rotator to validated-ledger events (fires in both standalone-accept and consensus paths), gated by `node_db online_delete`, and stop it before the node store is torn down.

## Test plan

- [x] `go test -race ./storage/... ./internal/ledger/shamapstore/...`
- [x] `just test-core` (ledger / txq / rpc / consensus / peermanagement)
- [x] `just test-libs` (codec / crypto / shamap / storage / ...)
- [x] `go test ./internal/cli/...`
- [x] `just lint` — 0 issues

New coverage: below-boundary deletion vs at/above retention, live-node survival, batching, cache eviction, context cancellation (nodestore); `clearSql`-style batched table pruning with inclusive-vs-exclusive boundary handling (relationaldb); the full `readyToRotate` predicate incl. interval gating, `advisory_delete`/`can_delete` gating (incl. `always` = max-uint32 no-overflow), `lastRotated`/`MinimumOnline` advance, and an end-to-end reclaim test against a real node store.

Fixes #853