### PR TITLE
fix(engine): run invariants on tec results with tec→tef escalation

### DIFF
--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -106,6 +106,11 @@ type TestEnv struct {
 	// ledger. Reset on Close(). Used by TxQ for fee escalation computation.
 	txInLedger uint32
 
+	// invariantViolationHook, when set, is installed on the per-submit engine
+	// to force an invariant violation. Used by invariant-escalation tests; nil
+	// for every normal submission.
+	invariantViolationHook tx.InvariantViolationHook
+
 	// closingTxTotal tracks the total transaction count including inner batch
 	// transactions. In rippled, the closed ledger's tx map includes inner
 	// batch txns as separate entries. This counter matches that behavior for
@@ -344,6 +349,14 @@ func (e *TestEnv) SetOpenLedger(open bool) {
 // distinction between apply() (direct, used for setup) and submit() (via TxQ).
 func (e *TestEnv) SetBypassTxQ(bypass bool) {
 	e.bypassTxQ = bypass
+}
+
+// SetInvariantViolationHook installs a test-only hook on every subsequently
+// submitted transaction's engine, forcing the invariant pass to report a
+// violation. Used to exercise the tec→tecINVARIANT_FAILED→tefINVARIANT_FAILED
+// escalation. Pass nil to clear it.
+func (e *TestEnv) SetInvariantViolationHook(hook tx.InvariantViolationHook) {
+	e.invariantViolationHook = hook
 }
 
 // ResetTxQMaxSize resets the TxQ's maxSize to nil (no limit).

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -492,6 +492,9 @@ func (e *TestEnv) applyDirect(txn tx.Transaction) TxResult {
 	// same account differed by 100 bytes vs rippled v2.6.2 — see
 	// TestReproByteDiff_MultiTrustSetThreading.
 	engine.SetBaseTxCount(e.txInLedger)
+	if e.invariantViolationHook != nil {
+		engine.SetInvariantViolationHookForTest(e.invariantViolationHook)
+	}
 	applyResult := engine.Apply(txn)
 
 	if applyResult.Result.IsApplied() {

--- a/internal/testing/invariants/tec_invariants_test.go
+++ b/internal/testing/invariants/tec_invariants_test.go
@@ -1,0 +1,104 @@
+// Tests for the invariant pass on the tec-recovery path.
+//
+// rippled runs checkInvariants for every applied result — tesSUCCESS AND every
+// tec claim — on the post-reset fee+cleanup state, escalating a violation to
+// tecINVARIANT_FAILED (and tefINVARIANT_FAILED on the fee-only retry).
+// Reference: rippled Transactor.cpp:1215-1243.
+package invariants_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// TestInvariant_TecResult_CleanRecovery_KeepsTec verifies that a tec result
+// whose post-recovery state is clean keeps its original tec — the new invariant
+// pass on the tec path must not introduce a false positive. A tecUNFUNDED_OFFER
+// (with offer cleanup) is the canonical case from the issue.
+func TestInvariant_TecResult_CleanRecovery_KeepsTec(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	gw := jtx.NewAccount("gw")
+	env.FundAmount(gw, uint64(jtx.XRP(1_000_000)))
+	env.Close()
+
+	alice := jtx.NewAccount("alice")
+	env.FundAmount(alice, offerbuild.Reserve(env, 0))
+	env.Close()
+
+	fee := env.BaseFee()
+	before := env.Balance(alice)
+
+	result := env.Submit(offerbuild.OfferCreate(alice, gw.IOU("USD", 1000), jtx.XRPTxAmountFromXRP(1000)).Build())
+
+	jtx.RequireTxClaimed(t, result, jtx.TecUNFUNDED_OFFER)
+	// Fee was charged, no offer placed.
+	jtx.RequireBalance(t, env, alice, before-fee)
+	jtx.RequireOwnerCount(t, env, alice, 0)
+}
+
+// TestInvariant_TecResult_EscalatesToTecINVARIANT_FAILED verifies that an
+// invariant violation surfaced on the tec-recovery delta escalates the original
+// tec to tecINVARIANT_FAILED, with the fee still claimed on the fee-only retry.
+func TestInvariant_TecResult_EscalatesToTecINVARIANT_FAILED(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	gw := jtx.NewAccount("gw")
+	env.FundAmount(gw, uint64(jtx.XRP(1_000_000)))
+	env.Close()
+
+	alice := jtx.NewAccount("alice")
+	env.FundAmount(alice, offerbuild.Reserve(env, 0))
+	env.Close()
+
+	fee := env.BaseFee()
+	before := env.Balance(alice)
+
+	// Force a violation only on the first (original-tec) pass. The fee-only
+	// retry passes cleanly, so the result settles at tecINVARIANT_FAILED.
+	env.SetInvariantViolationHook(func(result tx.Result, _ *tx.ApplyStateTable) *tx.InvariantViolationValue {
+		if result == tx.TecUNFUNDED_OFFER {
+			return tx.NewInvariantViolation("Injected", "forced tec-path violation")
+		}
+		return nil
+	})
+	defer env.SetInvariantViolationHook(nil)
+
+	result := env.Submit(offerbuild.OfferCreate(alice, gw.IOU("USD", 1000), jtx.XRPTxAmountFromXRP(1000)).Build())
+
+	jtx.RequireTxClaimed(t, result, jtx.TecINVARIANT_FAILED)
+	jtx.RequireBalance(t, env, alice, before-fee)
+}
+
+// TestInvariant_TecResult_EscalatesToTefINVARIANT_FAILED verifies that an
+// invariant violation that persists on BOTH passes escalates the original tec
+// all the way to tefINVARIANT_FAILED — the transaction is fully rejected and no
+// fee is claimed.
+func TestInvariant_TecResult_EscalatesToTefINVARIANT_FAILED(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	gw := jtx.NewAccount("gw")
+	env.FundAmount(gw, uint64(jtx.XRP(1_000_000)))
+	env.Close()
+
+	alice := jtx.NewAccount("alice")
+	env.FundAmount(alice, offerbuild.Reserve(env, 0))
+	env.Close()
+
+	before := env.Balance(alice)
+
+	// Force a violation on every pass — the fee-only retry also violates, so the
+	// result escalates to tefINVARIANT_FAILED.
+	env.SetInvariantViolationHook(func(_ tx.Result, _ *tx.ApplyStateTable) *tx.InvariantViolationValue {
+		return tx.NewInvariantViolation("Injected", "forced persistent violation")
+	})
+	defer env.SetInvariantViolationHook(nil)
+
+	result := env.Submit(offerbuild.OfferCreate(alice, gw.IOU("USD", 1000), jtx.XRPTxAmountFromXRP(1000)).Build())
+
+	if result.Code != jtx.TefINVARIANT_FAILED {
+		t.Fatalf("expected tefINVARIANT_FAILED, got %s: %s", result.Code, result.Message)
+	}
+	// tef is not a claim: no fee charged, balance unchanged.
+	jtx.RequireBalance(t, env, alice, before)
+}

--- a/internal/testing/invariants/tec_invariants_test.go
+++ b/internal/testing/invariants/tec_invariants_test.go
@@ -34,7 +34,6 @@ func TestInvariant_TecResult_CleanRecovery_KeepsTec(t *testing.T) {
 	result := env.Submit(offerbuild.OfferCreate(alice, gw.IOU("USD", 1000), jtx.XRPTxAmountFromXRP(1000)).Build())
 
 	jtx.RequireTxClaimed(t, result, jtx.TecUNFUNDED_OFFER)
-	// Fee was charged, no offer placed.
 	jtx.RequireBalance(t, env, alice, before-fee)
 	jtx.RequireOwnerCount(t, env, alice, 0)
 }

--- a/internal/tx/do_apply.go
+++ b/internal/tx/do_apply.go
@@ -438,6 +438,20 @@ func (e *Engine) applyTecRecovery(st *applyState, result Result) Result {
 		}
 	}
 
+	// Run invariant checks on the post-recovery delta BEFORE committing.
+	// rippled runs checkInvariants for every applied result — tes AND every
+	// tec claim — on the post-reset fee+cleanup state, escalating a violation
+	// to tecINVARIANT_FAILED (and tefINVARIANT_FAILED on the fee-only retry).
+	// The original tec result is passed to the checkers because their finalize
+	// branches are result-aware (e.g. AccountRootsNotDeleted only enforces on
+	// tesSUCCESS; NFTokenCountTracking / ValidClawback have result != tesSUCCESS
+	// arms).
+	// Reference: rippled Transactor.cpp:1215-1243 — applied = isTecClaim(result),
+	// then checkInvariants(result, fee) with the two-pass reset escalation.
+	if r, handled := e.runInvariantsOnTable(st, result, tecTable); handled {
+		return r
+	}
+
 	// Apply all tracked changes and generate proper metadata
 	generatedMeta, applyErr := tecTable.Apply()
 	if applyErr != nil {
@@ -676,6 +690,17 @@ func (e *Engine) runInvariants(st *applyState, result Result) (r Result, handled
 	if st.tx.TxType() == TypeBatch {
 		return Result(0), false
 	}
+	return e.runInvariantsOnTable(st, result, st.table)
+}
+
+// runInvariantsOnTable checks invariants against the supplied table — the tes
+// path passes st.table (the apply sandbox), the tec-recovery path passes its
+// tecTable (the fee + cleanup delta). result is the transaction's pre-invariant
+// result (tesSUCCESS or the original tec); it is forwarded to the checkers,
+// whose finalize branches are result-aware. Returns (result, true) when a
+// violation has been handled (escalated via applyInvariantViolation) and
+// (zero, false) when the entries pass and the caller may commit `table`.
+func (e *Engine) runInvariantsOnTable(st *applyState, result Result, table *ApplyStateTable) (r Result, handled bool) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			e.logger.Error("invariant check panic recovered, returning tecINVARIANT_FAILED",
@@ -685,9 +710,12 @@ func (e *Engine) runInvariants(st *applyState, result Result) (r Result, handled
 			handled = true
 		}
 	}()
-	invEntries := st.table.CollectEntries()
+	invEntries := table.CollectEntries()
 	txDeclaredFee := parseTxDeclaredFee(st.tx, st.fee)
-	violation := invariants.CheckInvariants(wrapTxForInvariants(st.tx), invariants.Result(result), st.fee, txDeclaredFee, invEntries, st.table, e.rules())
+	violation := invariants.CheckInvariants(wrapTxForInvariants(st.tx), invariants.Result(result), st.fee, txDeclaredFee, invEntries, table, e.rules())
+	if violation == nil && e.invariantViolationHook != nil {
+		violation = e.invariantViolationHook(result, table)
+	}
 	if violation == nil {
 		return Result(0), false
 	}
@@ -800,7 +828,11 @@ func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (
 	// If fee-only state also violates invariants, escalate to tefINVARIANT_FAILED
 	// and do NOT apply anything (transaction is completely rejected).
 	invEntries2 := invTecTable.CollectEntries()
-	if violation2 := invariants.CheckInvariants(wrapTxForInvariants(st.tx), invariants.Result(TecINVARIANT_FAILED), st.fee, txDeclaredFee, invEntries2, invTecTable, e.rules()); violation2 != nil {
+	violation2 := invariants.CheckInvariants(wrapTxForInvariants(st.tx), invariants.Result(TecINVARIANT_FAILED), st.fee, txDeclaredFee, invEntries2, invTecTable, e.rules())
+	if violation2 == nil && e.invariantViolationHook != nil {
+		violation2 = e.invariantViolationHook(TecINVARIANT_FAILED, invTecTable)
+	}
+	if violation2 != nil {
 		return TefINVARIANT_FAILED
 	}
 

--- a/internal/tx/engine.go
+++ b/internal/tx/engine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
 	"github.com/LeJamon/go-xrpl/keylet"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/protocol"
@@ -62,6 +63,11 @@ type Engine struct {
 	// its TransactionIndex, then the counter increments.
 	// Reference: rippled OpenView::txCount() = baseTxCount_ + txs_.size()
 	txCount atomic.Uint32
+
+	// invariantViolationHook, when non-nil, lets tests force an invariant
+	// violation for a given (result, table). Production always leaves it nil,
+	// so runInvariantsOnTable behaves exactly as the real checkers dictate.
+	invariantViolationHook func(result Result, table *ApplyStateTable) *invariants.InvariantViolation
 }
 
 // ApplyFlags controls transaction application behavior during consensus.
@@ -246,6 +252,31 @@ func NewEngine(view LedgerView, config EngineConfig) *Engine {
 		config: config,
 		logger: logger.Named(xrpllog.PartitionTx),
 	}
+}
+
+// InvariantViolationValue describes a detected invariant violation. Exported so
+// test hooks can construct one without importing the invariants package.
+type InvariantViolationValue = invariants.InvariantViolation
+
+// InvariantViolationHook is a test-only override that forces an invariant
+// violation for a given (result, table). It is consulted by the invariant pass
+// on both the tes and tec apply paths after the real checkers pass cleanly.
+type InvariantViolationHook = func(result Result, table *ApplyStateTable) *InvariantViolationValue
+
+// SetInvariantViolationHookForTest installs a test-only hook that forces an
+// invariant violation, used to exercise the tec→tecINVARIANT_FAILED→
+// tefINVARIANT_FAILED escalation without crafting a state that trips a real
+// checker. Production never calls this, so the hook stays nil and the real
+// checkers alone decide.
+func (e *Engine) SetInvariantViolationHookForTest(hook InvariantViolationHook) {
+	e.invariantViolationHook = hook
+}
+
+// NewInvariantViolation builds an invariant violation value for tests that drive
+// SetInvariantViolationHookForTest, without exposing the invariants package to
+// test callers.
+func NewInvariantViolation(name, message string) *invariants.InvariantViolation {
+	return &invariants.InvariantViolation{Name: name, Message: message}
 }
 
 // rules returns the amendment rules for this engine. EngineConfig.Rules


### PR DESCRIPTION
## Summary
- rippled runs `checkInvariants(result, fee)` for **every applied result** — `tesSUCCESS` and every `tec` claim — on the post-reset fee+cleanup state, escalating a violation to `tecINVARIANT_FAILED` (and `tefINVARIANT_FAILED` on the fee-only retry) (`Transactor.cpp:1215-1243`, `applied = isTecClaim(result)`). goXRPL routed every tec result through `applyTecRecovery`, which committed the recovery delta with **no** invariant check — leaving all `result != tesSUCCESS` finalize branches (NFTokenCountTracking, ValidClawback, ValidMPTIssuance, AccountRootsNotDeleted) dead for tec results and the tec cleanup writers unguarded.
- `applyTecRecovery` now runs the invariant pass on the tec-recovery delta before committing, reusing the same two-pass `tec→tecINVARIANT_FAILED→tefINVARIANT_FAILED` escalation the tes path already uses. `runInvariants` is factored into `runInvariantsOnTable(st, result, table)` so both paths share one implementation.
- The **original tec** result is forwarded to the checkers (not a synthesized `tesSUCCESS`), preserving their result-aware semantics so enabling the tec path does not introduce false positives.

## Scope
Invocation machinery only. This PR does **not** touch the Batch carve-outs in `invariants/basic.go` (#846) nor the per-checker silent continue-on-parse-error / checker predicates in `offers.go`/`trustlines.go`/`frozen.go`/`nftoken.go`/`clawback.go`/`permissioned.go` (#857).

## Test plan
- [x] `internal/testing/invariants/tec_invariants_test.go` (new): clean `tecUNFUNDED_OFFER` keeps its tec; injected first-pass violation → `tecINVARIANT_FAILED` (fee claimed); persistent violation → `tefINVARIANT_FAILED` (no fee).
- [x] `just test-tx` — all green.
- [x] `just test-integration` — only pre-existing `TestConformance` failures remain; failing-subtest set byte-identical between branch and clean `main` (241 each).

Fixes #848