### PR TITLE
feat(ops): LoadManager-style stall watchdog

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,10 +60,11 @@ type Config struct {
 	ValidationArchive ValidationArchiveConfig `toml:"validation_archive" mapstructure:"validation_archive"`
 
 	// 7. Diagnostics
-	DebugLogfile string        `toml:"debug_logfile" mapstructure:"debug_logfile"`
-	Logging      LoggingConfig `toml:"logging" mapstructure:"logging"`
-	Insight      InsightConfig `toml:"insight" mapstructure:"insight"`
-	Perf         PerfConfig    `toml:"perf" mapstructure:"perf"`
+	DebugLogfile string         `toml:"debug_logfile" mapstructure:"debug_logfile"`
+	Logging      LoggingConfig  `toml:"logging" mapstructure:"logging"`
+	Insight      InsightConfig  `toml:"insight" mapstructure:"insight"`
+	Perf         PerfConfig     `toml:"perf" mapstructure:"perf"`
+	Watchdog     WatchdogConfig `toml:"watchdog" mapstructure:"watchdog"`
 
 	// 8. Voting
 	Voting VotingConfig `toml:"voting" mapstructure:"voting"`

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -215,6 +215,16 @@ zero_basefee_transaction_feelevel = 256000
 # perf_log = "/var/log/xrpld/perf.log"
 # log_interval = 1
 
+# Stall watchdog (optional). An out-of-band goroutine that detects a wedged
+# event loop (consensus timer or ledger close) and escalates: warn + goroutine
+# dump, fatal log, then process abort so an orchestrator can restart the node.
+# Enabled by default with rippled's 10/90/600s thresholds.
+# [watchdog]
+# disabled = false       # set true to turn the watchdog off entirely
+# warn_seconds  = 10     # log a warning once a loop is silent this long
+# fatal_seconds = 90     # escalate the periodic report to fatal
+# abort_seconds = 600    # abort the process (warn < fatal < abort required)
+
 # Crawler endpoint (optional)
 # [crawl]
 # enabled = true

--- a/config/validation.go
+++ b/config/validation.go
@@ -59,6 +59,9 @@ func ValidateConfig(config *Config) error {
 	if err := config.Perf.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("perf: %w", err))
 	}
+	if err := config.Watchdog.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("watchdog: %w", err))
+	}
 
 	// 7. Validate voting configuration
 	if err := config.Voting.Validate(); err != nil {

--- a/config/watchdog.go
+++ b/config/watchdog.go
@@ -1,0 +1,80 @@
+package config
+
+import "fmt"
+
+// WatchdogConfig represents the [watchdog] section: the out-of-band stall
+// detector that mirrors rippled's LoadManager deadlock detector. The zero value
+// is the production default — enabled with rippled's 10s/90s/600s thresholds.
+// Operators override the thresholds in seconds, or disable the detector
+// entirely with `disabled = true`.
+type WatchdogConfig struct {
+	// Disabled turns the stall watchdog off entirely (kill-switch).
+	Disabled bool `toml:"disabled" mapstructure:"disabled"`
+
+	// WarnSeconds, FatalSeconds, AbortSeconds override the rippled-matching
+	// 10/90/600 thresholds. Zero means "use the default".
+	WarnSeconds  int `toml:"warn_seconds" mapstructure:"warn_seconds"`
+	FatalSeconds int `toml:"fatal_seconds" mapstructure:"fatal_seconds"`
+	AbortSeconds int `toml:"abort_seconds" mapstructure:"abort_seconds"`
+}
+
+// Validate checks the watchdog thresholds. Disabled configs validate trivially.
+// Otherwise overrides must be non-negative and strictly ordered
+// warn < fatal < abort so escalation is monotonic.
+func (w *WatchdogConfig) Validate() error {
+	if w.Disabled {
+		return nil
+	}
+	if w.WarnSeconds < 0 || w.FatalSeconds < 0 || w.AbortSeconds < 0 {
+		return fmt.Errorf("threshold seconds must be non-negative")
+	}
+	warn, fatal, abort := w.thresholds()
+	if !(warn < fatal && fatal < abort) {
+		return fmt.Errorf("thresholds must satisfy warn < fatal < abort, got %d < %d < %d", warn, fatal, abort)
+	}
+	return nil
+}
+
+// IsEnabled reports whether the watchdog should be armed.
+func (w *WatchdogConfig) IsEnabled() bool {
+	return !w.Disabled
+}
+
+const (
+	defaultWatchdogWarnSeconds  = 10
+	defaultWatchdogFatalSeconds = 90
+	defaultWatchdogAbortSeconds = 600
+)
+
+// thresholds resolves the configured overrides against the rippled defaults.
+func (w *WatchdogConfig) thresholds() (warn, fatal, abort int) {
+	warn, fatal, abort = defaultWatchdogWarnSeconds, defaultWatchdogFatalSeconds, defaultWatchdogAbortSeconds
+	if w.WarnSeconds > 0 {
+		warn = w.WarnSeconds
+	}
+	if w.FatalSeconds > 0 {
+		fatal = w.FatalSeconds
+	}
+	if w.AbortSeconds > 0 {
+		abort = w.AbortSeconds
+	}
+	return warn, fatal, abort
+}
+
+// WarnSecondsResolved returns the effective warn threshold in seconds.
+func (w *WatchdogConfig) WarnSecondsResolved() int {
+	warn, _, _ := w.thresholds()
+	return warn
+}
+
+// FatalSecondsResolved returns the effective fatal threshold in seconds.
+func (w *WatchdogConfig) FatalSecondsResolved() int {
+	_, fatal, _ := w.thresholds()
+	return fatal
+}
+
+// AbortSecondsResolved returns the effective abort threshold in seconds.
+func (w *WatchdogConfig) AbortSecondsResolved() int {
+	_, _, abort := w.thresholds()
+	return abort
+}

--- a/config/watchdog_test.go
+++ b/config/watchdog_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWatchdogConfig_Defaults(t *testing.T) {
+	var w WatchdogConfig // zero value
+	if !w.IsEnabled() {
+		t.Fatal("zero WatchdogConfig should be enabled")
+	}
+	if err := w.Validate(); err != nil {
+		t.Fatalf("zero WatchdogConfig should validate: %v", err)
+	}
+	if w.WarnSecondsResolved() != 10 || w.FatalSecondsResolved() != 90 || w.AbortSecondsResolved() != 600 {
+		t.Fatalf("unexpected defaults: %d/%d/%d",
+			w.WarnSecondsResolved(), w.FatalSecondsResolved(), w.AbortSecondsResolved())
+	}
+}
+
+func TestWatchdogConfig_Disabled(t *testing.T) {
+	// A disabled watchdog validates even with otherwise-broken thresholds.
+	w := WatchdogConfig{Disabled: true, WarnSeconds: 99, FatalSeconds: 5}
+	if w.IsEnabled() {
+		t.Fatal("disabled watchdog reports enabled")
+	}
+	if err := w.Validate(); err != nil {
+		t.Fatalf("disabled watchdog should validate: %v", err)
+	}
+}
+
+func TestWatchdogConfig_Overrides(t *testing.T) {
+	w := WatchdogConfig{WarnSeconds: 2, FatalSeconds: 4, AbortSeconds: 8}
+	if err := w.Validate(); err != nil {
+		t.Fatalf("valid overrides rejected: %v", err)
+	}
+	if w.WarnSecondsResolved() != 2 || w.FatalSecondsResolved() != 4 || w.AbortSecondsResolved() != 8 {
+		t.Fatalf("overrides not applied")
+	}
+}
+
+func TestWatchdogConfig_PartialOverrideUsesDefaults(t *testing.T) {
+	// Only the warn override set; fatal/abort fall back to defaults.
+	w := WatchdogConfig{WarnSeconds: 5}
+	if err := w.Validate(); err != nil {
+		t.Fatalf("partial override rejected: %v", err)
+	}
+	if w.WarnSecondsResolved() != 5 || w.FatalSecondsResolved() != 90 || w.AbortSecondsResolved() != 600 {
+		t.Fatalf("partial resolve wrong: %d/%d/%d",
+			w.WarnSecondsResolved(), w.FatalSecondsResolved(), w.AbortSecondsResolved())
+	}
+}
+
+func TestWatchdogConfig_RejectsUnordered(t *testing.T) {
+	cases := []WatchdogConfig{
+		{WarnSeconds: 90, FatalSeconds: 10, AbortSeconds: 600}, // warn > fatal
+		{WarnSeconds: 10, FatalSeconds: 600, AbortSeconds: 90}, // fatal > abort
+		{WarnSeconds: 10, FatalSeconds: 10, AbortSeconds: 600}, // warn == fatal
+	}
+	for i, w := range cases {
+		if err := w.Validate(); err == nil {
+			t.Errorf("case %d: expected ordering error, got nil", i)
+		}
+	}
+}
+
+func TestWatchdogConfig_RejectsNegative(t *testing.T) {
+	w := WatchdogConfig{WarnSeconds: -1}
+	if err := w.Validate(); err == nil {
+		t.Fatal("negative threshold accepted")
+	}
+}
+
+func TestValidateConfig_IncludesWatchdog(t *testing.T) {
+	// ValidateConfig joins all section errors; assert the watchdog error is
+	// among them when its thresholds are misordered. Other sections of this
+	// bare config also fail, which is fine — we only check ours is surfaced.
+	cfg := &Config{Watchdog: WatchdogConfig{WarnSeconds: 100, FatalSeconds: 10, AbortSeconds: 600}}
+	err := ValidateConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "watchdog:") {
+		t.Fatalf("ValidateConfig did not surface the watchdog error: %v", err)
+	}
+}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -1036,10 +1036,14 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 
 	// Arm the out-of-band stall watchdog now that the server is up and
 	// servicing its event loops. Mirrors rippled arming activateStallDetector
-	// only at full start (Application.cpp:1561). The watchdog runs on its own
-	// goroutine and aborts the process if a monitored loop wedges, so a
-	// deadlocked node screams and can be restarted instead of going quiet.
-	if globalConfig.Watchdog.IsEnabled() {
+	// only at full start, and only outside standalone (ApplicationImp::run:
+	// guarded by !config_->standalone()). Standalone closes ledgers solely on
+	// the ledger_accept RPC, so an idle node produces no heartbeat and would
+	// otherwise self-abort; consensus mode drives a periodic heartbeat. The
+	// watchdog runs on its own goroutine and aborts the process if a monitored
+	// loop wedges, so a deadlocked node screams and can be restarted instead of
+	// going quiet.
+	if !standalone && globalConfig.Watchdog.IsEnabled() {
 		wdCfg := watchdog.ConfigFromSeconds(
 			globalConfig.Watchdog.WarnSecondsResolved(),
 			globalConfig.Watchdog.FatalSecondsResolved(),

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	validatorlist "github.com/LeJamon/go-xrpl/internal/validator/list"
+	"github.com/LeJamon/go-xrpl/internal/watchdog"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
@@ -1033,6 +1034,34 @@ func runServer(cmd *cobra.Command, args []string) (retErr error) {
 		}(entry.name, entry.addr, srv)
 	}
 
+	// Arm the out-of-band stall watchdog now that the server is up and
+	// servicing its event loops. Mirrors rippled arming activateStallDetector
+	// only at full start (Application.cpp:1561). The watchdog runs on its own
+	// goroutine and aborts the process if a monitored loop wedges, so a
+	// deadlocked node screams and can be restarted instead of going quiet.
+	if globalConfig.Watchdog.IsEnabled() {
+		wdCfg := watchdog.ConfigFromSeconds(
+			globalConfig.Watchdog.WarnSecondsResolved(),
+			globalConfig.Watchdog.FatalSecondsResolved(),
+			globalConfig.Watchdog.AbortSecondsResolved(),
+		)
+		wd := watchdog.New(wdCfg, nil)
+		ledgerService.SetStallPing(wd.Register("ledger"))
+		if consensusComponents != nil {
+			if sp, ok := consensusComponents.Engine.(stallPinger); ok {
+				sp.SetStallPing(wd.Register("consensus"))
+			}
+		}
+		wdCtx, cancelWatchdog := context.WithCancel(context.Background())
+		defer cancelWatchdog()
+		go wd.Run(wdCtx)
+		serverLog.Info("Stall watchdog armed",
+			"warn_s", globalConfig.Watchdog.WarnSecondsResolved(),
+			"fatal_s", globalConfig.Watchdog.FatalSecondsResolved(),
+			"abort_s", globalConfig.Watchdog.AbortSecondsResolved(),
+		)
+	}
+
 	// Add signal handling and a shared shutdown trigger
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
@@ -1102,6 +1131,14 @@ func parsePortConfig(protocol, name string, p config.PortConfig) (*rpc.PortConte
 // so a SIGHUP removal is not silently undone by the next OnChange.
 type staticValidatorReloader interface {
 	ReloadStaticValidators(validators []consensus.NodeID, masterKeys [][33]byte)
+}
+
+// stallPinger is the optional surface the stall watchdog installs on the
+// consensus engine. Kept off the core consensus.Engine interface so test
+// mocks and alternative engines need not implement it; *rcl.Engine satisfies
+// it. Mirrors the optional-extension pattern of consensus.WireableAdaptor.
+type stallPinger interface {
+	SetStallPing(ping func())
 }
 
 // reloadTrustedValidators is the SIGHUP entry point: bridge from the

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -211,6 +211,12 @@ type Engine struct {
 	// so stalls don't hide. Read via MissedHeartbeats().
 	missedHeartbeats atomic.Uint64
 
+	// stallPing, when set, is called once per run-loop iteration so the
+	// out-of-band stall watchdog can observe that this loop is still
+	// servicing its heartbeat. Carried via an atomic pointer so the run
+	// goroutine reads it lock-free; nil disables the ping.
+	stallPing atomic.Pointer[func()]
+
 	// deferBroadcasts is incremented on entry to timerEntry / StartRound
 	// (the entry points that drive proposal/validation emission under
 	// e.mu) and decremented on exit. When zero, the enqueue helpers fall
@@ -410,6 +416,18 @@ func (e *Engine) SetLedgerAncestryProvider(p LedgerAncestryProvider) {
 	if e.validationTracker != nil {
 		e.validationTracker.SetLedgerAncestryProvider(p)
 	}
+}
+
+// SetStallPing installs the out-of-band stall watchdog's heartbeat callback,
+// invoked once per run-loop iteration. Safe before or after Start; nil disables
+// it. The callback must be cheap and non-blocking — it runs inside the
+// consensus loop.
+func (e *Engine) SetStallPing(ping func()) {
+	if ping == nil {
+		e.stallPing.Store(nil)
+		return
+	}
+	e.stallPing.Store(&ping)
 }
 
 // Start begins the consensus engine.
@@ -1452,6 +1470,9 @@ func (e *Engine) run() {
 		case <-e.ctx.Done():
 			return
 		case <-e.heartbeat.C:
+			if ping := e.stallPing.Load(); ping != nil {
+				(*ping)()
+			}
 			now := time.Now()
 			if gap := now.Sub(last); gap > 2*interval {
 				missed := int64(gap/interval) - 1

--- a/internal/consensus/rcl/stall_ping_test.go
+++ b/internal/consensus/rcl/stall_ping_test.go
@@ -1,0 +1,52 @@
+package rcl
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The consensus run loop must ping the installed stall watchdog callback on
+// every heartbeat tick, so an out-of-band watchdog can observe loop liveness.
+func TestEngine_StallPingFiresFromRunLoop(t *testing.T) {
+	adaptor := newMockAdaptor()
+	cfg := DefaultConfig()
+	// Shrink the heartbeat so the test does not wait whole seconds.
+	cfg.Timing.LedgerMinClose = 10 * time.Millisecond
+	engine := NewEngine(adaptor, cfg)
+
+	var pings atomic.Int64
+	engine.SetStallPing(func() { pings.Add(1) })
+
+	if err := engine.Start(t.Context()); err != nil {
+		t.Fatalf("start engine: %v", err)
+	}
+	defer func() { _ = engine.Stop() }()
+
+	deadline := time.After(2 * time.Second)
+	for pings.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("stall ping fired %d times, expected the run loop to ping repeatedly", pings.Load())
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// A nil ping disables the callback without panicking the loop.
+func TestEngine_StallPingNilIsSafe(t *testing.T) {
+	adaptor := newMockAdaptor()
+	cfg := DefaultConfig()
+	cfg.Timing.LedgerMinClose = 10 * time.Millisecond
+	engine := NewEngine(adaptor, cfg)
+
+	engine.SetStallPing(func() {})
+	engine.SetStallPing(nil) // clear
+
+	if err := engine.Start(t.Context()); err != nil {
+		t.Fatalf("start engine: %v", err)
+	}
+	defer func() { _ = engine.Stop() }()
+
+	time.Sleep(50 * time.Millisecond) // a few ticks; must not panic
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -299,6 +300,12 @@ type Service struct {
 	// it to the TxQ's timeLeap flag (RCLConsensus.cpp:805 →
 	// FeeMetrics::update). Zero in standalone or pre-startup.
 	lastConsensusRoundTime time.Duration
+
+	// stallPing, when set, fires once per ledger close so the out-of-band
+	// stall watchdog can observe that the ledger-processing loop is making
+	// progress. Carried via an atomic pointer so it can be installed after
+	// construction without taking s.mu; nil disables it.
+	stallPing atomic.Pointer[func()]
 }
 
 // SubmittedTxEvent carries the inputs the WebSocket transactions_proposed
@@ -663,6 +670,9 @@ func (c *closedLedgerCtx) GetTransactionFeeLevels() []txq.FeeLevel {
 // slow-consensus threshold the metrics window is clamped instead of
 // advanced. Caller must hold s.mu.
 func (s *Service) processClosedLedgerLocked() {
+	if ping := s.stallPing.Load(); ping != nil {
+		(*ping)()
+	}
 	if s.txQueue == nil || s.closedLedger == nil {
 		return
 	}
@@ -670,6 +680,18 @@ func (s *Service) processClosedLedgerLocked() {
 	ctx := &closedLedgerCtx{ledger: s.closedLedger, baseFee: baseFee}
 	s.txQueue.ProcessClosedLedger(ctx, s.lastConsensusRoundTime > slowConsensusThreshold)
 	s.tickLoadFeeLocked()
+}
+
+// SetStallPing installs the out-of-band stall watchdog's heartbeat callback,
+// fired once per ledger close from processClosedLedgerLocked. Safe to call
+// after construction; nil disables it. The callback must be cheap and
+// non-blocking — it runs while s.mu is held.
+func (s *Service) SetStallPing(ping func()) {
+	if ping == nil {
+		s.stallPing.Store(nil)
+		return
+	}
+	s.stallPing.Store(&ping)
 }
 
 // slowConsensusThreshold matches rippled's `roundTime > 5s` predicate

--- a/internal/ledger/service/stall_ping_test.go
+++ b/internal/ledger/service/stall_ping_test.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+// The ledger close path must ping the installed stall watchdog callback, so the
+// out-of-band watchdog observes that ledger processing is making progress.
+func TestService_StallPingFiresOnLedgerClose(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("start service: %v", err)
+	}
+
+	var pings atomic.Int64
+	svc.SetStallPing(func() { pings.Add(1) })
+
+	if _, err := svc.AcceptLedger(context.TODO()); err != nil {
+		t.Fatalf("accept ledger: %v", err)
+	}
+	if got := pings.Load(); got == 0 {
+		t.Fatal("ledger close did not ping the stall watchdog")
+	}
+
+	// A second close pings again.
+	before := pings.Load()
+	if _, err := svc.AcceptLedger(context.TODO()); err != nil {
+		t.Fatalf("accept ledger: %v", err)
+	}
+	if pings.Load() <= before {
+		t.Fatalf("second close did not ping: %d <= %d", pings.Load(), before)
+	}
+}
+
+// Clearing the ping with nil is safe and stops further pings.
+func TestService_StallPingNilIsSafe(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("start service: %v", err)
+	}
+
+	svc.SetStallPing(func() {})
+	svc.SetStallPing(nil)
+
+	// Must not panic with no ping installed.
+	if _, err := svc.AcceptLedger(context.TODO()); err != nil {
+		t.Fatalf("accept ledger: %v", err)
+	}
+}

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -12,8 +12,11 @@
 // Behaviour mirrors rippled's LoadManager (LoadManager.cpp): warn at >=10s
 // without a heartbeat (repeated every reporting interval, with a full
 // goroutine stack dump on the first warning so the wedged loop is visible),
-// fatal log at >=90s, and process abort at >=600s after flushing logs. Only
-// the stall-detection half of LoadManager is reproduced here; the local-fee
+// fatal log at >=90s, and process abort at >=600s. The slog handlers in use are
+// synchronous, so the abort record reaches the underlying writer before exit;
+// the abort path additionally fsyncs the stdout/stderr/file descriptors so those
+// final bytes survive os.Exit, which skips deferred Sync hooks. Only the
+// stall-detection half of LoadManager is reproduced here; the local-fee
 // raise/lower half already lives in internal/feetrack.
 package watchdog
 
@@ -24,6 +27,8 @@ import (
 	"runtime"
 	"sync"
 	"time"
+
+	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
 
 const (
@@ -81,10 +86,12 @@ type Watchdog struct {
 	cfg    Config
 	logger *slog.Logger
 
-	// now and exit are injectable so tests can drive a virtual clock and
-	// observe the abort path without terminating the test process. In
-	// production now is time.Now and exit flushes logs then os.Exit(1).
+	// now, sync, and exit are injectable so tests can drive a virtual clock and
+	// observe the abort path without terminating the test process. In production
+	// now is time.Now, sync best-effort fsyncs the log descriptors, and exit is
+	// os.Exit(1). sync runs before exit on the abort path.
 	now  func() time.Time
+	sync func()
 	exit func()
 
 	// stack captures all goroutine stacks on the first warning. Injectable so
@@ -120,14 +127,15 @@ func New(cfg Config, logger *slog.Logger) *Watchdog {
 		cfg:        cfg,
 		logger:     logger.With("component", "watchdog"),
 		now:        time.Now,
+		sync:       syncLogDescriptors,
 		stack:      allGoroutineStacks,
 		heartbeats: make(map[string]time.Time),
 	}
-	w.exit = func() {
-		// Flush slog by giving any async handler a moment, then terminate so an
-		// orchestrator can restart the wedged node — rippled's LogicError abort.
-		os.Exit(1)
-	}
+	// exit terminates the process so an orchestrator can restart the wedged node
+	// — rippled's LogicError abort. The slog handlers are synchronous, so the
+	// abort record has already reached the writer; sync (called by check before
+	// exit) fsyncs the descriptors so those bytes survive os.Exit.
+	w.exit = func() { os.Exit(1) }
 	return w
 }
 
@@ -215,6 +223,8 @@ func (w *Watchdog) check(tick time.Duration) {
 				w.logger.Warn("goroutine dump", "stacks", w.stack())
 			}
 		} else {
+			// slog has no Fatal level; the level=fatal attr is the fatal marker,
+			// matching the log package's canonical "fatal" name (LevelName).
 			w.logger.Error("server loop stalled",
 				"loop", loop, "stalled_s", secs, "level", "fatal")
 		}
@@ -223,8 +233,22 @@ func (w *Watchdog) check(tick time.Duration) {
 	if silence >= w.cfg.Abort {
 		w.logger.Error("fatal server stall detected — aborting",
 			"loop", loop, "stalled_s", int64(silence/time.Second))
+		w.sync()
 		w.exit()
 	}
+}
+
+// syncLogDescriptors best-effort fsyncs the destinations the node's logs can
+// reach so the final abort record survives os.Exit, which does not flush
+// kernel-buffered file output. The slog handlers write synchronously, so by this
+// point the record is already in the writer; this only forces it to stable
+// storage. stdout/stderr cover the default and "stderr" config outputs;
+// xrpllog.Sync covers a file-backed [logging] output. All errors are ignored —
+// the process is aborting regardless.
+func syncLogDescriptors() {
+	_ = os.Stderr.Sync()
+	_ = os.Stdout.Sync()
+	_ = xrpllog.Sync()
 }
 
 // allGoroutineStacks returns a dump of every goroutine's stack — the Go

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -1,0 +1,236 @@
+// Package watchdog implements an out-of-band stall detector for the node's
+// long-running event loops.
+//
+// The consensus engine's in-band missedHeartbeats counter (rcl/engine.go)
+// cannot catch a true deadlock: it lives inside the goroutine it watches, so
+// a timerEntry that never returns to its select loop also never increments the
+// counter. This watchdog runs on its own goroutine with its own ticker. Each
+// monitored loop is handed a Pinger and stamps a heartbeat once per iteration;
+// the watchdog measures the gap between now and the most recent heartbeat of
+// every registered loop and escalates as the gap grows.
+//
+// Behaviour mirrors rippled's LoadManager (LoadManager.cpp): warn at >=10s
+// without a heartbeat (repeated every reporting interval, with a full
+// goroutine stack dump on the first warning so the wedged loop is visible),
+// fatal log at >=90s, and process abort at >=600s after flushing logs. Only
+// the stall-detection half of LoadManager is reproduced here; the local-fee
+// raise/lower half already lives in internal/feetrack.
+package watchdog
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultWarn is the rippled reportingIntervalSeconds: warn once the
+	// quietest loop has been silent this long, and repeat every interval.
+	DefaultWarn = 10 * time.Second
+
+	// DefaultFatal is the rippled stallFatalLogMessageTimeLimit: escalate the
+	// periodic report from warn to fatal once the stall reaches this long.
+	DefaultFatal = 90 * time.Second
+
+	// DefaultAbort is the rippled stallLogicErrorTimeLimit: the stall-recovery
+	// code is considered to have failed, so abort the process.
+	DefaultAbort = 600 * time.Second
+
+	// tickInterval matches rippled's 1s LoadManager cadence.
+	tickInterval = time.Second
+)
+
+// Config tunes the watchdog thresholds. The zero value is invalid; use
+// DefaultConfig and override as needed, or build one from config.WatchdogConfig.
+type Config struct {
+	// Warn is the silence threshold at which a warning is logged (and repeated).
+	Warn time.Duration
+	// Fatal is the silence threshold at which the periodic report becomes fatal.
+	Fatal time.Duration
+	// Abort is the silence threshold at which the process is aborted.
+	Abort time.Duration
+}
+
+// DefaultConfig returns the rippled-matching thresholds.
+func DefaultConfig() Config {
+	return Config{Warn: DefaultWarn, Fatal: DefaultFatal, Abort: DefaultAbort}
+}
+
+// ConfigFromSeconds builds a Config from threshold values expressed in seconds,
+// the form the [watchdog] config section stores. Non-positive values fall back
+// to the rippled defaults via New.
+func ConfigFromSeconds(warn, fatal, abort int) Config {
+	return Config{
+		Warn:  time.Duration(warn) * time.Second,
+		Fatal: time.Duration(fatal) * time.Second,
+		Abort: time.Duration(abort) * time.Second,
+	}
+}
+
+// Pinger is the tiny surface a monitored loop holds. Each loop calls Ping once
+// per iteration to record that it is still making progress.
+type Pinger func()
+
+// Watchdog tracks per-loop heartbeats and escalates when a loop goes silent.
+// It is safe for concurrent use: loops Ping from their own goroutines while the
+// Run goroutine reads heartbeats.
+type Watchdog struct {
+	cfg    Config
+	logger *slog.Logger
+
+	// now and exit are injectable so tests can drive a virtual clock and
+	// observe the abort path without terminating the test process. In
+	// production now is time.Now and exit flushes logs then os.Exit(1).
+	now  func() time.Time
+	exit func()
+
+	// stack captures all goroutine stacks on the first warning. Injectable so
+	// tests can assert it fires without parsing a real dump.
+	stack func() string
+
+	// warnedStack guards the once-per-episode goroutine dump. Only the Run
+	// goroutine touches it, so it needs no lock.
+	warnedStack bool
+
+	mu         sync.Mutex
+	heartbeats map[string]time.Time
+}
+
+// New builds a Watchdog with the given thresholds and logger. A nil logger
+// falls back to slog.Default. Thresholds that are non-positive are replaced
+// with their defaults so a partially-filled Config still produces a sane
+// watchdog.
+func New(cfg Config, logger *slog.Logger) *Watchdog {
+	if cfg.Warn <= 0 {
+		cfg.Warn = DefaultWarn
+	}
+	if cfg.Fatal <= 0 {
+		cfg.Fatal = DefaultFatal
+	}
+	if cfg.Abort <= 0 {
+		cfg.Abort = DefaultAbort
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	w := &Watchdog{
+		cfg:        cfg,
+		logger:     logger.With("component", "watchdog"),
+		now:        time.Now,
+		stack:      allGoroutineStacks,
+		heartbeats: make(map[string]time.Time),
+	}
+	w.exit = func() {
+		// Flush slog by giving any async handler a moment, then terminate so an
+		// orchestrator can restart the wedged node — rippled's LogicError abort.
+		os.Exit(1)
+	}
+	return w
+}
+
+// Register adds a loop and stamps its first heartbeat as now, so a loop that
+// has not yet ticked is treated as healthy until its first expected iteration
+// rather than tripping the moment the watchdog arms. Returns a Pinger bound to
+// that loop. Registering the same name twice returns a fresh Pinger for it.
+func (w *Watchdog) Register(loop string) Pinger {
+	w.mu.Lock()
+	w.heartbeats[loop] = w.now()
+	w.mu.Unlock()
+	return func() { w.ping(loop) }
+}
+
+func (w *Watchdog) ping(loop string) {
+	now := w.now()
+	w.mu.Lock()
+	w.heartbeats[loop] = now
+	w.mu.Unlock()
+}
+
+// stalled returns the loop with the largest silence and that silence duration.
+// A watchdog with no registered loops reports zero stall.
+func (w *Watchdog) stalled() (loop string, silence time.Duration) {
+	now := w.now()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for name, last := range w.heartbeats {
+		if d := now.Sub(last); d > silence {
+			silence, loop = d, name
+		}
+	}
+	return loop, silence
+}
+
+// Run drives the detection ticker until ctx is cancelled. It blocks, so callers
+// launch it in its own goroutine. The watchdog must already have its loops
+// registered (and ideally pinged once) before Run arms — mirroring rippled
+// arming activateStallDetector only at full start.
+func (w *Watchdog) Run(ctx context.Context) {
+	w.run(ctx, tickInterval)
+}
+
+func (w *Watchdog) run(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.check(interval)
+		}
+	}
+}
+
+// check performs one detection pass. It reports on each whole reporting-interval
+// boundary (rippled's `timeSpentStalled % reportingIntervalSeconds == 0` gate),
+// escalating from warn to a fatal-level log once the stall reaches Fatal, and
+// aborts once it reaches Abort. The first warning of an episode also dumps every
+// goroutine's stack; warnedStack resets when the loops recover below Warn so a
+// later stall dumps again.
+func (w *Watchdog) check(tick time.Duration) {
+	loop, silence := w.stalled()
+	if silence < w.cfg.Warn {
+		w.warnedStack = false
+		return
+	}
+
+	// Fire only when the elapsed-tick count is a whole multiple of the warn
+	// interval, so the report cadence is the warn interval rather than the tick.
+	// When the tick is coarser than the warn interval every pass reports.
+	warnTicks := w.cfg.Warn / tick
+	if warnTicks < 1 {
+		warnTicks = 1
+	}
+	if (silence/tick)%warnTicks == 0 {
+		secs := int64(silence / time.Second)
+		if silence < w.cfg.Fatal {
+			w.logger.Warn("server loop stalled",
+				"loop", loop, "stalled_s", secs)
+			if !w.warnedStack {
+				w.warnedStack = true
+				w.logger.Warn("goroutine dump", "stacks", w.stack())
+			}
+		} else {
+			w.logger.Error("server loop stalled",
+				"loop", loop, "stalled_s", secs, "level", "fatal")
+		}
+	}
+
+	if silence >= w.cfg.Abort {
+		w.logger.Error("fatal server stall detected — aborting",
+			"loop", loop, "stalled_s", int64(silence/time.Second))
+		w.exit()
+	}
+}
+
+// allGoroutineStacks returns a dump of every goroutine's stack — the Go
+// equivalent of rippled dumping its JobQueue at the first stall warning.
+func allGoroutineStacks() string {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return string(buf[:n])
+}

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -44,6 +44,7 @@ func newTestWatchdog(t *testing.T) (*Watchdog, *fakeClock, *bytes.Buffer, *atomi
 	w := New(Config{Warn: 10 * time.Second, Fatal: 90 * time.Second, Abort: 600 * time.Second}, logger)
 	w.now = clk.now
 	w.exit = func() { exits.Add(1) }
+	w.sync = func() {}
 	w.stack = func() string { stacks.Add(1); return "STACKDUMP" }
 	return w, clk, &logBuf, &exits, &stacks
 }
@@ -138,6 +139,43 @@ func TestWatchdog_StallEscalatesWarnFatalAbort(t *testing.T) {
 	if !bytes.Contains(logBuf.Bytes(), []byte("STACKDUMP")) {
 		t.Errorf("stack dump not logged")
 	}
+}
+
+// The abort path flushes the log descriptors before terminating, and does so in
+// that order, so the final fatal record survives os.Exit.
+func TestWatchdog_AbortFlushesBeforeExit(t *testing.T) {
+	w, clk, _, exits, _ := newTestWatchdog(t)
+	w.Register("ledger") // registered, then never pinged again.
+
+	var seq []string
+	w.sync = func() { seq = append(seq, "sync") }
+	w.exit = func() { seq = append(seq, "exit"); exits.Add(1) }
+
+	for sec := 1; sec <= 600; sec++ {
+		clk.advance(time.Second)
+		w.check(time.Second)
+		if exits.Load() > 0 {
+			break
+		}
+	}
+
+	if exits.Load() != 1 {
+		t.Fatalf("abort fired %d times, want 1", exits.Load())
+	}
+	if len(seq) != 2 || seq[0] != "sync" || seq[1] != "exit" {
+		t.Fatalf("abort order = %v, want [sync exit]", seq)
+	}
+}
+
+// The default (non-injected) sync hook is a real flush that runs without panic,
+// proving the production abort path has a live flush rather than a no-op.
+func TestWatchdog_DefaultSyncIsLive(t *testing.T) {
+	w := New(Config{}, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+	if w.sync == nil {
+		t.Fatal("default watchdog has a nil sync hook")
+	}
+	// Best-effort fsync of stdout/stderr/file; must not panic or block.
+	w.sync()
 }
 
 // The periodic report fires on every warn-interval boundary, not every tick.

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -1,0 +1,262 @@
+package watchdog
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeClock is a manually-advanced clock for deterministic stall tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Unix(0, 0)} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// newTestWatchdog builds a watchdog with second-scale thresholds, a fake clock,
+// a recording exit func, and a recording stack func, all wired through the same
+// injection points production uses.
+func newTestWatchdog(t *testing.T) (*Watchdog, *fakeClock, *bytes.Buffer, *atomic.Int32, *atomic.Int32) {
+	t.Helper()
+	clk := newFakeClock()
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	var exits, stacks atomic.Int32
+	w := New(Config{Warn: 10 * time.Second, Fatal: 90 * time.Second, Abort: 600 * time.Second}, logger)
+	w.now = clk.now
+	w.exit = func() { exits.Add(1) }
+	w.stack = func() string { stacks.Add(1); return "STACKDUMP" }
+	return w, clk, &logBuf, &exits, &stacks
+}
+
+func TestNew_DefaultsFillNonPositiveThresholds(t *testing.T) {
+	w := New(Config{}, nil)
+	if w.cfg.Warn != DefaultWarn || w.cfg.Fatal != DefaultFatal || w.cfg.Abort != DefaultAbort {
+		t.Fatalf("zero Config not defaulted: %+v", w.cfg)
+	}
+}
+
+func TestConfigFromSeconds(t *testing.T) {
+	c := ConfigFromSeconds(5, 30, 120)
+	if c.Warn != 5*time.Second || c.Fatal != 30*time.Second || c.Abort != 120*time.Second {
+		t.Fatalf("unexpected: %+v", c)
+	}
+}
+
+// A loop that keeps pinging never trips any threshold.
+func TestWatchdog_HealthyHeartbeatStaysQuiet(t *testing.T) {
+	w, clk, logBuf, exits, stacks := newTestWatchdog(t)
+	ping := w.Register("consensus")
+
+	// Advance well past the abort threshold, but ping every tick.
+	for i := 0; i < 700; i++ {
+		ping()
+		clk.advance(time.Second)
+		w.check(time.Second)
+	}
+	if exits.Load() != 0 {
+		t.Fatalf("healthy loop aborted")
+	}
+	if stacks.Load() != 0 {
+		t.Fatalf("healthy loop dumped stacks")
+	}
+	if bytes.Contains(logBuf.Bytes(), []byte("stalled")) {
+		t.Fatalf("healthy loop logged a stall: %s", logBuf.String())
+	}
+}
+
+// An unregistered (empty) watchdog reports no stall.
+func TestWatchdog_NoLoopsNeverTrips(t *testing.T) {
+	w, clk, _, exits, _ := newTestWatchdog(t)
+	for i := 0; i < 700; i++ {
+		clk.advance(time.Second)
+		w.check(time.Second)
+	}
+	if exits.Load() != 0 {
+		t.Fatalf("empty watchdog aborted")
+	}
+}
+
+// A silent loop escalates warn → fatal → abort at the right thresholds, dumping
+// goroutine stacks exactly once on the first warning.
+func TestWatchdog_StallEscalatesWarnFatalAbort(t *testing.T) {
+	w, clk, logBuf, exits, stacks := newTestWatchdog(t)
+	w.Register("ledger") // registered, then never pinged again.
+
+	var firstWarnAt, fatalAt, abortAt int
+	for sec := 1; sec <= 600; sec++ {
+		clk.advance(time.Second)
+		before := logBuf.Len()
+		exitsBefore := exits.Load()
+		w.check(time.Second)
+		line := logBuf.String()[before:]
+
+		if firstWarnAt == 0 && strings.Contains(line, "server loop stalled") &&
+			!strings.Contains(line, "level=fatal") {
+			firstWarnAt = sec
+		}
+		if fatalAt == 0 && strings.Contains(line, "level=fatal") {
+			fatalAt = sec
+		}
+		if exits.Load() > exitsBefore {
+			abortAt = sec
+			break
+		}
+	}
+
+	if firstWarnAt != 10 {
+		t.Errorf("first warn at %ds, want 10s", firstWarnAt)
+	}
+	if fatalAt != 90 {
+		t.Errorf("fatal log at %ds, want 90s", fatalAt)
+	}
+	if abortAt != 600 {
+		t.Errorf("abort at %ds, want 600s", abortAt)
+	}
+	if got := stacks.Load(); got != 1 {
+		t.Errorf("goroutine dump fired %d times, want exactly 1", got)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte("STACKDUMP")) {
+		t.Errorf("stack dump not logged")
+	}
+}
+
+// The periodic report fires on every warn-interval boundary, not every tick.
+func TestWatchdog_ReportsOnWarnIntervalBoundaries(t *testing.T) {
+	w, clk, logBuf, _, _ := newTestWatchdog(t)
+	w.Register("ledger")
+
+	warnLines := 0
+	for sec := 1; sec <= 80; sec++ {
+		clk.advance(time.Second)
+		before := logBuf.Len()
+		w.check(time.Second)
+		if strings.Contains(logBuf.String()[before:], "server loop stalled") {
+			warnLines++
+		}
+	}
+	// Boundaries at 10,20,30,40,50,60,70,80 → 8 reports.
+	if warnLines != 8 {
+		t.Fatalf("got %d warn reports over 80s, want 8", warnLines)
+	}
+}
+
+// A stall that recovers below warn re-arms the first-warn stack dump for a
+// later episode.
+func TestWatchdog_StackDumpReArmsAfterRecovery(t *testing.T) {
+	w, clk, _, _, stacks := newTestWatchdog(t)
+	ping := w.Register("ledger")
+
+	// Episode 1: stall to the first warning.
+	for sec := 1; sec <= 10; sec++ {
+		clk.advance(time.Second)
+		w.check(time.Second)
+	}
+	if stacks.Load() != 1 {
+		t.Fatalf("episode 1 dumps = %d, want 1", stacks.Load())
+	}
+
+	// Recover.
+	ping()
+	clk.advance(time.Second)
+	w.check(time.Second)
+
+	// Episode 2: stall again to the first warning.
+	for sec := 1; sec <= 10; sec++ {
+		clk.advance(time.Second)
+		w.check(time.Second)
+	}
+	if stacks.Load() != 2 {
+		t.Fatalf("episode 2 dumps = %d, want 2 (re-arm failed)", stacks.Load())
+	}
+}
+
+// The slowest of several registered loops drives the report, and the report
+// names that loop.
+func TestWatchdog_NamesSlowestLoop(t *testing.T) {
+	w, clk, logBuf, _, _ := newTestWatchdog(t)
+	fast := w.Register("consensus")
+	w.Register("ledger") // never pinged → slowest.
+
+	for sec := 1; sec <= 10; sec++ {
+		fast() // keep consensus healthy
+		clk.advance(time.Second)
+		w.check(time.Second)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte("loop=ledger")) {
+		t.Fatalf("report did not name the slowest loop: %s", logBuf.String())
+	}
+	if bytes.Contains(logBuf.Bytes(), []byte("loop=consensus")) {
+		t.Fatalf("report named the healthy loop: %s", logBuf.String())
+	}
+}
+
+// Run exits promptly on context cancellation and never aborts a healthy node.
+func TestWatchdog_RunStopsOnContextCancel(t *testing.T) {
+	w, _, _, exits, _ := newTestWatchdog(t)
+	ping := w.Register("ledger")
+	ping()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.run(ctx, time.Millisecond)
+		close(done)
+	}()
+
+	// Let a few real ticks fire; the clock is frozen at the registration time
+	// so silence stays zero and nothing trips.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+	if exits.Load() != 0 {
+		t.Fatalf("healthy run aborted")
+	}
+}
+
+// SetStallPing-style Register returns a working, concurrency-safe pinger.
+func TestWatchdog_ConcurrentPing(t *testing.T) {
+	w, clk, _, _, _ := newTestWatchdog(t)
+	ping := w.Register("ledger")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				ping()
+			}
+		}()
+	}
+	wg.Wait()
+	// After concurrent pings the loop is at the current (frozen) clock time.
+	clk.advance(5 * time.Second)
+	if _, silence := w.stalled(); silence != 5*time.Second {
+		t.Fatalf("silence = %v, want 5s", silence)
+	}
+}

--- a/log/filewriter.go
+++ b/log/filewriter.go
@@ -47,6 +47,20 @@ func (w *FileWriter) Write(p []byte) (int, error) {
 	return w.f.Write(p)
 }
 
+// Sync flushes the underlying file descriptor to stable storage on a best-effort
+// basis. It is used on the abort path so the final records survive os.Exit, which
+// does not run deferred close hooks. A missing descriptor (post-failed-reopen) is
+// a no-op; the fsync result is returned for callers that care, but the abort path
+// ignores it.
+func (w *FileWriter) Sync() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return nil
+	}
+	return w.f.Sync()
+}
+
 // Rotate closes the current descriptor and reopens the configured path, so
 // writes continue against a freshly-created file after external rotation.
 // Like rippled's closeAndReopen (Log.cpp), the reopen is always attempted: the
@@ -80,4 +94,20 @@ func Rotate() error {
 		return ErrLogNotRotatable
 	}
 	return fw.Rotate()
+}
+
+// Sync flushes the root logger's file output to stable storage on a best-effort
+// basis, returning nil when logging is not file-backed (stdout/stderr writers
+// are flushed by syncing their own descriptors, not through here). It exists for
+// the abort path, where os.Exit skips deferred Close/Sync hooks.
+func Sync() error {
+	cfg := rootCfg.Load()
+	if cfg == nil {
+		return nil
+	}
+	fw, ok := cfg.Output.(*FileWriter)
+	if !ok {
+		return nil
+	}
+	return fw.Sync()
 }

--- a/log/filewriter_test.go
+++ b/log/filewriter_test.go
@@ -70,6 +70,56 @@ func TestFileWriterRotateReopenFailure(t *testing.T) {
 	}
 }
 
+func TestFileWriterSync(t *testing.T) {
+	dir := t.TempDir()
+	fw, err := NewFileWriter(filepath.Join(dir, "app.log"))
+	if err != nil {
+		t.Fatalf("NewFileWriter: %v", err)
+	}
+	if _, err := fw.Write([]byte("data\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := fw.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// After a failed reopen the descriptor is nil; Sync must no-op, not panic.
+	fw.mu.Lock()
+	_ = fw.f.Close()
+	fw.f = nil
+	fw.mu.Unlock()
+	if err := fw.Sync(); err != nil {
+		t.Errorf("Sync with no descriptor = %v, want nil", err)
+	}
+}
+
+func TestPackageSync(t *testing.T) {
+	prev := rootCfg.Load()
+	t.Cleanup(func() { rootCfg.Store(prev) })
+
+	// Unset root config → no-op.
+	rootCfg.Store(nil)
+	if err := Sync(); err != nil {
+		t.Errorf("Sync() with no root config = %v, want nil", err)
+	}
+
+	// Non-file output → no-op (stdout/stderr are synced via their own fds).
+	rootCfg.Store(&Config{Output: os.Stdout})
+	if err := Sync(); err != nil {
+		t.Errorf("Sync() with stdout = %v, want nil", err)
+	}
+
+	// File-backed output → flushes cleanly.
+	fw, err := NewFileWriter(filepath.Join(t.TempDir(), "root.log"))
+	if err != nil {
+		t.Fatalf("NewFileWriter: %v", err)
+	}
+	rootCfg.Store(&Config{Output: fw})
+	if err := Sync(); err != nil {
+		t.Errorf("Sync() with file output = %v, want nil", err)
+	}
+}
+
 func TestRotateRootConfig(t *testing.T) {
 	prev := rootCfg.Load()
 	t.Cleanup(func() { rootCfg.Store(prev) })

--- a/log/logger.go
+++ b/log/logger.go
@@ -39,12 +39,13 @@ func (l *logger) Error(msg string, args ...any) {
 	l.inner.Error(msg, args...)
 }
 
-// Fatal emits an Error record then exits. The default handlers in this
-// package (slog.NewTextHandler / slog.NewJSONHandler over os.Stdout) are
-// unbuffered, so the final record is flushed before exit. Callers that wire
-// up a buffered or async handler (e.g. file rotation behind a bufio.Writer)
-// must ensure that handler flushes on its own; defaultExit goes straight to
-// os.Exit and will not run deferred Sync hooks.
+// Fatal emits an Error record then exits. The handlers in this package
+// (slog.NewTextHandler / slog.NewJSONHandler) are unbuffered, so the final
+// record reaches the underlying writer before exit. The os-level descriptor is
+// not fsynced here: defaultExit goes straight to os.Exit and will not run
+// deferred Sync hooks. Callers that need the file-backed output flushed to
+// stable storage before aborting should call Sync first (see the abort path in
+// internal/watchdog).
 func (l *logger) Fatal(msg string, args ...any) {
 	l.inner.Error(msg, args...)
 	defaultExit()


### PR DESCRIPTION
## Summary
- Adds an **out-of-band stall watchdog** (`internal/watchdog`): a dedicated goroutine with its own ticker that tracks per-loop heartbeats and escalates as a loop goes silent — **warn at ≥10s** (with a full goroutine stack dump on the first warning), **fatal log at ≥90s**, and **process abort at ≥600s** (after logging). Mirrors rippled's `LoadManager` deadlock detector (`LoadManager.cpp:56-69, 103-173`), armed only once the server is running (`Application.cpp:1561`).
- The consensus engine's existing in-band `missedHeartbeats` counter can't catch a true deadlock — it lives inside the goroutine it monitors. This watchdog runs outside the monitored loops and only **adds pings** (observational; no loop refactor).
- Pings are wired into the two main event loops via a tiny `func()` callback handed to each loop:
  - **consensus timer loop** — `rcl.Engine.SetStallPing`, fired each heartbeat tick.
  - **ledger close loop** — `service.Service.SetStallPing`, fired each ledger close.
  The engine ping is an optional capability interface (`stallPinger`), kept off the core `consensus.Engine` so mocks/alternative engines need not implement it.
- **Config kill-switch**: new `[watchdog]` section (`disabled`, `warn_seconds`/`fatal_seconds`/`abort_seconds` overrides, defaulting to rippled's 10/90/600, validated `warn < fatal < abort`) wired into `ValidateConfig` and documented in the example config.
- The abort path is behind an injectable exit func so it is unit-tested without terminating the test process.

## Test plan
- [x] `go test ./internal/watchdog/... -race` — core: healthy heartbeats stay quiet; silent loop escalates warn→fatal→abort at exactly 10/90/600s; first-warn stack dump fires once and re-arms after recovery; names the slowest loop; `Run` stops on context cancel; concurrent pings.
- [x] `go test ./config/...` — watchdog config defaults/disabled/overrides/ordering/`ValidateConfig` integration.
- [x] `go test ./internal/consensus/rcl/... -race` & `./internal/ledger/service/... -race` — pings fire from the real run loop / ledger close; nil ping is safe.
- [x] `just test-core` — full ledger/txq/rpc/consensus/peermanagement suite green.
- [x] `just lint` — 0 issues; `gofmt`/`go vet` clean; full module builds; binary verified to embed the new wiring.

Fixes #856