### PR TITLE
fix(nftoken): dual-read sfOwner in NFTokenOffer RPC-query parser

### DIFF
--- a/internal/ledger/service/nft_query.go
+++ b/internal/ledger/service/nft_query.go
@@ -407,10 +407,9 @@ func parseNFTokenOfferForQuery(data []byte) (*NFTokenOfferForQuery, error) {
 			offset++
 			if length == 20 {
 				switch fieldCode {
-				case 1: // sfAccount — pre-fix go-xrpl serialized the owner here;
-					// accepted so state written before the sfOwner fix still parses.
+				case 1: // sfAccount — legacy owner location for state written before the sfOwner fix
 					copy(offer.Owner[:], data[offset:offset+20])
-				case 2: // Owner (sfOwner — rippled's NFTokenOffer owner field)
+				case 2: // sfOwner — canonical owner field
 					copy(offer.Owner[:], data[offset:offset+20])
 				case 3: // Destination
 					copy(offer.Destination[:], data[offset:offset+20])

--- a/internal/ledger/service/nft_query.go
+++ b/internal/ledger/service/nft_query.go
@@ -407,7 +407,10 @@ func parseNFTokenOfferForQuery(data []byte) (*NFTokenOfferForQuery, error) {
 			offset++
 			if length == 20 {
 				switch fieldCode {
-				case 1: // Account/Owner
+				case 1: // sfAccount — pre-fix go-xrpl serialized the owner here;
+					// accepted so state written before the sfOwner fix still parses.
+					copy(offer.Owner[:], data[offset:offset+20])
+				case 2: // Owner (sfOwner — rippled's NFTokenOffer owner field)
 					copy(offer.Owner[:], data[offset:offset+20])
 				case 3: // Destination
 					copy(offer.Destination[:], data[offset:offset+20])

--- a/internal/ledger/service/nft_query_test.go
+++ b/internal/ledger/service/nft_query_test.go
@@ -24,10 +24,10 @@ func nftIDFromByte(seed byte) [32]byte {
 }
 
 // insertNFTokenOfferEntry serializes an NFTokenOffer ledger entry the way the
-// goXRPL apply path does (sfAccount carries the owner) and inserts it under a
-// real NFTokenOffer keylet. The returned key is what the NFT directory must
-// reference. amount is either a drops string (XRP) or a {currency,issuer,value}
-// map (IOU).
+// goXRPL apply path does (sfOwner carries the owner, matching rippled) and
+// inserts it under a real NFTokenOffer keylet. The returned key is what the NFT
+// directory must reference. amount is either a drops string (XRP) or a
+// {currency,issuer,value} map (IOU).
 func insertNFTokenOfferEntry(t *testing.T, svc *Service, ownerAddr string, seq uint32, tokenID [32]byte, amount any, flags uint32, dest string, expiration *uint32) [32]byte {
 	t.Helper()
 	_, ownerBytes, err := addresscodec.DecodeClassicAddressToAccountID(ownerAddr)
@@ -39,7 +39,7 @@ func insertNFTokenOfferEntry(t *testing.T, svc *Service, ownerAddr string, seq u
 
 	jsonObj := map[string]any{
 		"LedgerEntryType":  "NFTokenOffer",
-		"Account":          ownerAddr,
+		"Owner":            ownerAddr,
 		"Amount":           amount,
 		"NFTokenID":        strings.ToUpper(hex.EncodeToString(tokenID[:])),
 		"OwnerNode":        "0",
@@ -244,6 +244,44 @@ func TestGetNFTOffers_InvalidMarkers(t *testing.T) {
 			_, err := svc.GetNFTBuyOffers(context.Background(), nftID, "current", 2, tc.marker)
 			if !errors.Is(err, svcerr.ErrInvalidMarker) {
 				t.Fatalf("marker %q: want ErrInvalidMarker, got %v", tc.marker, err)
+			}
+		})
+	}
+}
+
+// TestParseNFTokenOfferForQuery_OwnerDualRead proves the RPC-query parser reads
+// the offer owner from rippled-canonical blobs (sfOwner) and still tolerates
+// legacy blobs written by pre-fix go-xrpl nodes (sfAccount). Dual-read, single
+// canonical write.
+func TestParseNFTokenOfferForQuery_OwnerDualRead(t *testing.T) {
+	ownerAddr, ownerID := addressFromBytes(t, 0x42)
+	tokenID := nftIDFromByte(0x10)
+
+	build := func(ownerField string) []byte {
+		t.Helper()
+		data, err := binarycodec.EncodeBytes(map[string]any{
+			"LedgerEntryType":  "NFTokenOffer",
+			ownerField:         ownerAddr,
+			"Amount":           "1000000",
+			"NFTokenID":        strings.ToUpper(hex.EncodeToString(tokenID[:])),
+			"OwnerNode":        "0",
+			"NFTokenOfferNode": "0",
+			"Flags":            uint32(1),
+		})
+		if err != nil {
+			t.Fatalf("encode (%s): %v", ownerField, err)
+		}
+		return data
+	}
+
+	for _, ownerField := range []string{"Owner", "Account"} {
+		t.Run(ownerField, func(t *testing.T) {
+			offer, err := parseNFTokenOfferForQuery(build(ownerField))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if offer.Owner != ownerID {
+				t.Fatalf("owner = %x, want %x", offer.Owner, ownerID)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- The NFTokenOffer write path, ledgerfields spec, and `state.ParseNFTokenOffer` already emit/read `sfOwner` (rippled `ltNFTOKEN_OFFER`, `NFTokenUtils.cpp:1074`) after #785's meta fix. This closes the last remaining read-path gap.
- `parseNFTokenOfferForQuery` (the parser behind `nft_buy_offers` / `nft_sell_offers`) read only fieldCode 1 (`sfAccount`), so after the write-path fix every newly-created offer surfaced an **empty owner** in those RPC responses. It now dual-reads fieldCode 2 (`sfOwner`, canonical) and fieldCode 1 (legacy pre-fix blobs), mirroring `state.ParseNFTokenOffer`.
- Test helper `insertNFTokenOfferEntry` now serializes canonical `sfOwner`; adds `TestParseNFTokenOfferForQuery_OwnerDualRead` proving both `Owner` and legacy `Account` blobs parse the owner.

## Test plan
- [x] `go test ./internal/ledger/service/` (incl. new dual-read test + all GetNFT*Offers tests)
- [x] `go test ./internal/tx/nftoken/...`
- [x] `go test ./internal/testing/nft/...` (mint → create → accept → cancel e2e + `TestNFTokenCreateSellOffer_Meta_UsesOwner` byte-lockstep SLE/meta assertion)
- [x] `go test ./internal/rpc/ -run NFT` (handler→service path)
- [x] `just test-tx` — all green, zero FAIL
- [x] Conformance NFToken: 311 pass / 18 fail (94.5%) — **identical to clean `origin/main`**, zero regressions

Fixes #841