### PR TITLE
fix(signerlist): dual-read tolerance for legacy SignerList blobs

### DIFF
--- a/internal/ledger/state/signer_list_test.go
+++ b/internal/ledger/state/signer_list_test.go
@@ -1,0 +1,118 @@
+package state
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+)
+
+// TestSerializeSignerList_MacroFieldSet asserts the serialized SignerList blob
+// carries exactly the ltSIGNER_LIST template field set (SignerEntries,
+// SignerQuorum, SignerListID, Flags, OwnerNode) and is byte-identical to a
+// hand-built rippled-canonical blob. The SLE must NOT carry a top-level
+// Account: rippled's ltSIGNER_LIST has no sfAccount and template enforcement
+// would reject one, forking account_hash on the first SignerListSet.
+func TestSerializeSignerList_MacroFieldSet(t *testing.T) {
+	addrA, _ := EncodeAccountID([20]byte{0x01})
+	addrB, _ := EncodeAccountID([20]byte{0x02})
+	entries := []SignerEntry{
+		{Account: addrA, SignerWeight: 1},
+		{Account: addrB, SignerWeight: 2},
+	}
+
+	data, err := SerializeSignerList(3, entries, 0, false, 0)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+
+	fields, err := binarycodec.DecodeBytes(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if _, ok := fields["Account"]; ok {
+		t.Errorf("SignerList must not carry a top-level Account (rippled ltSIGNER_LIST has none)")
+	}
+	for _, name := range []string{"SignerQuorum", "SignerListID", "Flags", "OwnerNode", "SignerEntries"} {
+		if _, ok := fields[name]; !ok {
+			t.Errorf("SignerList missing required field %q", name)
+		}
+	}
+	if v, _ := soeToUint64(fields["SignerListID"]); v != 0 {
+		t.Errorf("SignerListID = %v, want 0 (rippled defaultSignerListID_)", fields["SignerListID"])
+	}
+	if v, _ := soeToUint64(fields["Flags"]); v != 0 {
+		t.Errorf("Flags = %v, want 0 (soeREQUIRED, present at default)", fields["Flags"])
+	}
+
+	// Byte-lockstep: a hand-built rippled-canonical blob carrying exactly the
+	// macro field set must equal the serializer output (binarycodec orders
+	// fields by code, matching rippled's canonical STObject serialization).
+	canonical := map[string]any{
+		"LedgerEntryType": "SignerList",
+		"Flags":           uint32(0),
+		"SignerQuorum":    uint32(3),
+		"SignerListID":    uint32(0),
+		"OwnerNode":       "0",
+		"SignerEntries": []map[string]any{
+			{"SignerEntry": map[string]any{"Account": addrA, "SignerWeight": uint16(1)}},
+			{"SignerEntry": map[string]any{"Account": addrB, "SignerWeight": uint16(2)}},
+		},
+	}
+	canonHex, err := binarycodec.Encode(canonical)
+	if err != nil {
+		t.Fatalf("encode canonical: %v", err)
+	}
+	canonBytes, err := hex.DecodeString(canonHex)
+	if err != nil {
+		t.Fatalf("decode canonical hex: %v", err)
+	}
+	if !bytes.Equal(data, canonBytes) {
+		t.Errorf("SLE bytes diverge from rippled-canonical blob:\n got  %x\n want %x", data, canonBytes)
+	}
+}
+
+// TestParseSignerList_LegacyAccountBlob asserts the read path still decodes
+// legacy go-xrpl blobs that carry a top-level Account and lack SignerListID.
+// Pre-fix releases wrote them; a node reading such an entry must not error
+// (dual-read, single-write).
+func TestParseSignerList_LegacyAccountBlob(t *testing.T) {
+	addrA, _ := EncodeAccountID([20]byte{0x01})
+	addrB, _ := EncodeAccountID([20]byte{0x02})
+	legacy := map[string]any{
+		"LedgerEntryType": "SignerList",
+		"Account":         addrA,
+		"Flags":           uint32(0),
+		"SignerQuorum":    uint32(3),
+		"OwnerNode":       "0",
+		"SignerEntries": []map[string]any{
+			{"SignerEntry": map[string]any{"Account": addrA, "SignerWeight": uint16(1)}},
+			{"SignerEntry": map[string]any{"Account": addrB, "SignerWeight": uint16(2)}},
+		},
+	}
+	legacyHex, err := binarycodec.Encode(legacy)
+	if err != nil {
+		t.Fatalf("encode legacy: %v", err)
+	}
+	legacyBytes, err := hex.DecodeString(legacyHex)
+	if err != nil {
+		t.Fatalf("hex decode: %v", err)
+	}
+
+	info, err := ParseSignerList(legacyBytes)
+	if err != nil {
+		t.Fatalf("ParseSignerList must tolerate a legacy Account blob: %v", err)
+	}
+	if info.SignerQuorum != 3 {
+		t.Errorf("SignerQuorum = %d, want 3", info.SignerQuorum)
+	}
+	if len(info.SignerEntries) != 2 {
+		t.Fatalf("SignerEntries = %d, want 2", len(info.SignerEntries))
+	}
+	if info.SignerEntries[0].SignerWeight != 1 || info.SignerEntries[1].SignerWeight != 2 {
+		t.Errorf("signer weights = %d,%d, want 1,2",
+			info.SignerEntries[0].SignerWeight, info.SignerEntries[1].SignerWeight)
+	}
+}

--- a/internal/tx/ledgerfields/cmd/ledgerfieldsgen/main.go
+++ b/internal/tx/ledgerfields/cmd/ledgerfieldsgen/main.go
@@ -126,6 +126,26 @@ func generate(defs *definitions.Definitions, entry spec.Entry, outDir string) (s
 		if err != nil {
 			return "", nil, fmt.Errorf("field %s: %w", f.Name, err)
 		}
+
+		// DecodeOnly fields are tolerated on the wire but never stored, emitted,
+		// or re-encoded. Add only a consume-and-discard decode arm (mirroring the
+		// synthetic LedgerEntryType arm: MetaNever + empty BitConst) so legacy
+		// blobs decode while Encode produces the canonical field set.
+		if f.DecodeOnly {
+			er.DecodeArms[int(fi.FieldHeader.TypeCode)] = append(
+				er.DecodeArms[int(fi.FieldHeader.TypeCode)],
+				decodeArm{
+					TypeCode:  int(fi.FieldHeader.TypeCode),
+					FieldCode: int(fi.Nth),
+					XRPLType:  fi.Type,
+					GoField:   f.Name,
+					BitConst:  "",
+					GoType:    "",
+					Meta:      spec.MetaNever,
+				})
+			continue
+		}
+
 		fr, err := makeFieldRender(f, fi, entry.Name, er.BitPrefix, er.Receiver)
 		if err != nil {
 			return "", nil, fmt.Errorf("render %s: %w", f.Name, err)
@@ -412,7 +432,11 @@ func ({{ .Receiver }} *{{ .StructName }}) Decode(data []byte) error {
 				if _, err := sr.readUint64Raw(); err != nil {
 					return err
 				}
-				// {{ $arm.GoField }} is synthetic LedgerEntryType; discard
+{{- if eq $arm.GoField "LedgerEntryType" }}
+				// {{ $arm.GoField }} is synthetic; discard
+{{- else }}
+				// {{ $arm.GoField }} decoded for tolerance only; discard
+{{- end }}
 {{- else if $arm.IsBaseTenUInt64 }}
 				val, err := sr.readUint64Decimal()
 				if err != nil {
@@ -529,7 +553,11 @@ func ({{ .Receiver }} *{{ .StructName }}) Decode(data []byte) error {
 {{- range $arm := $arms }}
 			case {{ $arm.FieldCode }}:
 {{- if and (eq $arm.Meta 3) (isZero $arm.BitConst) }}
+{{- if eq $arm.GoField "LedgerEntryType" }}
 				_ = val // synthetic LedgerEntryType; discard
+{{- else }}
+				_ = val // {{ $arm.GoField }} decoded for tolerance only; discard
+{{- end }}
 {{- else if and (eq $arm.XRPLType "Amount") $arm.XRPOnly }}
 				if s, ok := val.(string); ok {
 					{{ $.Receiver }}.{{ $arm.GoField }} = s

--- a/internal/tx/ledgerfields/coverage_test.go
+++ b/internal/tx/ledgerfields/coverage_test.go
@@ -514,6 +514,11 @@ func TestGeneratedSLE_FixtureCompleteness(t *testing.T) {
 			continue
 		}
 		for _, f := range entry.Fields {
+			if f.DecodeOnly {
+				// DecodeOnly fields appear only on legacy blobs; a canonical
+				// coverage fixture never carries them.
+				continue
+			}
 			if _, set := fixture[f.Name]; !set {
 				t.Errorf("coverage fixture %q is missing field %q", entry.Name, f.Name)
 			}
@@ -538,9 +543,14 @@ func specFieldNames(name string) []string {
 		if e.Name != name {
 			continue
 		}
-		out := make([]string, len(e.Fields))
-		for i, f := range e.Fields {
-			out[i] = f.Name
+		var out []string
+		for _, f := range e.Fields {
+			if f.DecodeOnly {
+				// DecodeOnly fields are never carried on the struct or echoed
+				// by ToMap, so exclude them from the declared-field set.
+				continue
+			}
+			out = append(out, f.Name)
 		}
 		return out
 	}

--- a/internal/tx/ledgerfields/encode_test.go
+++ b/internal/tx/ledgerfields/encode_test.go
@@ -191,6 +191,71 @@ func TestRoundTrip_TypedSLE(t *testing.T) {
 	}
 }
 
+// TestSignerList_LegacyAccountDecodeTolerance verifies the typed SignerList
+// decoder tolerates a legacy go-xrpl blob that carries a top-level Account
+// (which rippled's ltSIGNER_LIST template omits). Pre-fix releases wrote such
+// blobs; a post-fix node decoding one during metadata generation must not
+// error. Re-encoding drops the legacy Account, yielding the canonical field
+// set — dual-read, single-write.
+func TestSignerList_LegacyAccountDecodeTolerance(t *testing.T) {
+	legacy := map[string]any{
+		"LedgerEntryType": "SignerList",
+		"Account":         "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Flags":           uint32(0),
+		"OwnerNode":       "0",
+		"SignerQuorum":    uint32(3),
+		"SignerEntries": []any{
+			map[string]any{
+				"SignerEntry": map[string]any{
+					"Account":      "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+					"SignerWeight": uint32(1),
+				},
+			},
+		},
+		"PreviousTxnID":     "0000000000000000000000000000000000000000000000000000000000000000",
+		"PreviousTxnLgrSeq": uint32(1),
+	}
+	legacyBytes, err := binarycodec.EncodeBytes(legacy)
+	if err != nil {
+		t.Fatalf("encode legacy blob: %v", err)
+	}
+
+	entry := New("SignerList")
+	if err := entry.Decode(legacyBytes); err != nil {
+		t.Fatalf("typed decoder must tolerate a legacy Account blob: %v", err)
+	}
+
+	got, err := entry.(interface{ Encode() ([]byte, error) }).Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	// Re-encode drops the legacy Account (the struct never carried it). The
+	// other fields round-trip unchanged, so the result equals the same legacy
+	// blob minus its top-level Account.
+	expected := map[string]any{
+		"LedgerEntryType":   "SignerList",
+		"Flags":             uint32(0),
+		"OwnerNode":         "0",
+		"SignerQuorum":      uint32(3),
+		"SignerEntries":     legacy["SignerEntries"],
+		"PreviousTxnID":     "0000000000000000000000000000000000000000000000000000000000000000",
+		"PreviousTxnLgrSeq": uint32(1),
+	}
+	want, err := binarycodec.EncodeBytes(expected)
+	if err != nil {
+		t.Fatalf("encode expected blob: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("re-encode did not drop the legacy Account:\n got  %x\n want %x", got, want)
+	}
+	if gotFields, _ := binarycodec.DecodeBytes(got); gotFields != nil {
+		if _, ok := gotFields["Account"]; ok {
+			t.Error("re-encoded SignerList still carries a top-level Account")
+		}
+	}
+}
+
 // TestHash_LeafNodeFormula pins the SLE hash to rippled's
 // sha512Half(HashPrefixLeafNode || serializedData || index) formula. The
 // generated Hash method must produce the same bytes a SHAMap account-state

--- a/internal/tx/ledgerfields/signer_list_gen.go
+++ b/internal/tx/ledgerfields/signer_list_gen.go
@@ -109,6 +109,17 @@ func (s *SignerList) Decode(data []byte) error {
 			default:
 				return newErrUnknownField("SignerList", typeCode, fieldCode)
 			}
+		case 8: // AccountID
+			val, err := sr.readAccountID()
+			if err != nil {
+				return err
+			}
+			switch fieldCode {
+			case 1:
+				_ = val // Account decoded for tolerance only; discard
+			default:
+				return newErrUnknownField("SignerList", typeCode, fieldCode)
+			}
 		case 15: // STArray
 			val, err := sr.readSTArray()
 			if err != nil {

--- a/internal/tx/ledgerfields/spec/heuristic_assumption_test.go
+++ b/internal/tx/ledgerfields/spec/heuristic_assumption_test.go
@@ -43,6 +43,12 @@ func TestEmitFinalFieldsSubsetOfEmitPreviousFields(t *testing.T) {
 			emitChangeOrigFields := extractEmitChangeOrigFields(string(data))
 
 			for _, f := range entry.Fields {
+				if f.DecodeOnly {
+					// DecodeOnly fields are consumed-and-discarded on decode and
+					// never appear in any emit method, so the heuristic does not
+					// apply to them.
+					continue
+				}
 				switch f.Meta {
 				case MetaDefault:
 					if !emitAllFields[f.Name] {

--- a/internal/tx/ledgerfields/spec/spec.go
+++ b/internal/tx/ledgerfields/spec/spec.go
@@ -45,6 +45,15 @@ type Field struct {
 	// Meta is the per-field metadata behavior. Zero value (MetaDefault)
 	// covers most fields.
 	Meta Meta
+
+	// DecodeOnly marks a field that the decoder must tolerate on incoming
+	// blobs but that is never carried on the struct, emitted into metadata,
+	// or re-encoded. It exists to read legacy blobs that an earlier go-xrpl
+	// release wrote with a non-canonical field rippled's template omits. The
+	// generator emits a consume-and-discard decode arm for it (mirroring the
+	// synthetic LedgerEntryType arm), so Decode succeeds while Encode produces
+	// the canonical field set without the legacy field.
+	DecodeOnly bool
 }
 
 // Entry describes one ledger-entry type's typed metadata layout.
@@ -224,7 +233,11 @@ var Specs = []Entry{
 		Name: "SignerList",
 		Fields: []Field{
 			// rippled's ltSIGNER_LIST has no sfAccount (ledger_entries.macro:
-			// 122-129); the field order mirrors that macro.
+			// 122-129); the field order mirrors that macro. Account is decoded
+			// for tolerance only: go-xrpl releases before the write-path fix
+			// stored an owner Account on the blob, so a node reading such a
+			// legacy entry must still decode it (then re-encode without it).
+			{Name: "Account", DecodeOnly: true},
 			{Name: "OwnerNode"},
 			{Name: "SignerQuorum"},
 			{Name: "SignerEntries"},


### PR DESCRIPTION
## Summary

- The SignerList write path already matches rippled's `ltSIGNER_LIST` template on `main` (no `sfAccount`, `sfSignerListID = 0`, `sfFlags` present at its default) after the SLE-soe alignment work. The remaining gap is on the **read** side: the typed decoder was regenerated to reject any blob carrying the legacy top-level `Account` that pre-fix go-xrpl releases wrote, so a post-fix node decoding a migrated signer list during metadata generation would error and fork.
- Adds a `DecodeOnly` field option to the ledgerfields spec: a field the decoder consumes-and-discards but never stores, emits, or re-encodes (mirroring the synthetic `LedgerEntryType` arm). `SignerList.Account` is marked `DecodeOnly`, so legacy blobs decode while `Encode` produces the canonical field set — single-write, dual-read.
- Verified against the rippled oracle: `LedgerFormats.cpp` `commonFields` makes `sfFlags` soeREQUIRED on every SLE (present at default 0), and `ledger_entries.macro:122-129` confirms `ltSIGNER_LIST` carries no `sfAccount` — so the current write path is correct and the `Flags`-always-emitted behaviour must stay.

## Test plan

- [x] Byte-lockstep: `SerializeSignerList` output is byte-identical to a hand-built rippled-canonical blob; asserts no top-level `Account`, `SignerListID = 0`, `Flags` present.
- [x] Legacy-blob decode tolerance in both `ParseSignerList` and the typed `SignerList` decoder; re-encode drops the legacy `Account`.
- [x] `just test-tx`, `internal/ledger/state`, `internal/tx/ledgerfields` (+ spec), `internal/testing/multisign` all green.
- [x] `TestConformance` failing set unchanged vs `origin/main` (241 == 241; pre-existing Vault/XChain stubs only).

Fixes #840