### PR TITLE
chore(amendment): pre-activation gates for historical replay (RequireFullyCanonicalSig, fixQualityUpperBound, fix1515, fix1543)

### DIFF
--- a/internal/testing/escrow/escrow_test.go
+++ b/internal/testing/escrow/escrow_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/credential"
 	dp "github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
 	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/LeJamon/go-xrpl/internal/tx"
 	escrowtx "github.com/LeJamon/go-xrpl/internal/tx/escrow"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/require"
@@ -2153,4 +2154,95 @@ func toUint32(v any) uint32 {
 	default:
 		return 0
 	}
+}
+
+// TestEscrow_Fix1543FlagGate exercises both branches of the fix1543 gate on the
+// tfUniversalMask checks of EscrowCreate, EscrowFinish and EscrowCancel. With
+// fix1543 enabled (default) a stray flag is rejected with temINVALID_FLAG; with
+// it disabled the flag is ignored. Reference: rippled Escrow.cpp:124,630,1203.
+func TestEscrow_Fix1543FlagGate(t *testing.T) {
+	const strayFlag = uint32(0x00010000) // tfPassive — not a valid escrow flag
+
+	withFlag := func(txn tx.Transaction, flag uint32) tx.Transaction {
+		txn.GetCommon().SetFlags(txn.GetCommon().GetFlags() | flag)
+		return txn
+	}
+
+	t.Run("create", func(t *testing.T) {
+		run := func(t *testing.T, disable bool, expect string) {
+			env := jtx.NewTestEnv(t)
+			if disable {
+				env.DisableFeature("fix1543")
+			}
+			alice := jtx.NewAccount("alice")
+			bob := jtx.NewAccount("bob")
+			fund5000(env, alice, bob)
+			env.Close()
+
+			result := env.Submit(
+				escrow.EscrowCreate(alice, bob, xrp(1000)).
+					FinishTime(env.Now().Add(5 * time.Second)).
+					Flags(strayFlag).
+					Build())
+			require.Equal(t, expect, result.Code)
+		}
+		t.Run("enabled rejects", func(t *testing.T) { run(t, false, "temINVALID_FLAG") })
+		t.Run("disabled accepts", func(t *testing.T) { run(t, true, "tesSUCCESS") })
+	})
+
+	// For Finish/Cancel the stray-flag check (Preclaim) runs before the timing
+	// check, so an early submission against a not-yet-finishable escrow still
+	// surfaces temINVALID_FLAG when enabled, and tecNO_PERMISSION when disabled.
+	t.Run("finish", func(t *testing.T) {
+		run := func(t *testing.T, disable bool, expect string) {
+			env := jtx.NewTestEnv(t)
+			if disable {
+				env.DisableFeature("fix1543")
+			}
+			alice := jtx.NewAccount("alice")
+			bob := jtx.NewAccount("bob")
+			fund5000(env, alice, bob)
+			env.Close()
+
+			seq := env.Seq(alice)
+			jtx.RequireTxSuccess(t, env.Submit(
+				escrow.EscrowCreate(alice, bob, xrp(1000)).
+					FinishTime(env.Now().Add(100*time.Second)).
+					Build()))
+			env.Close()
+
+			fin := withFlag(escrow.EscrowFinish(bob, alice, seq).Fee(baseFee*150).Build(), strayFlag)
+			require.Equal(t, expect, env.Submit(fin).Code)
+		}
+		t.Run("enabled rejects", func(t *testing.T) { run(t, false, "temINVALID_FLAG") })
+		t.Run("disabled ignores", func(t *testing.T) { run(t, true, "tecNO_PERMISSION") })
+	})
+
+	t.Run("cancel", func(t *testing.T) {
+		run := func(t *testing.T, disable bool, expect string) {
+			env := jtx.NewTestEnv(t)
+			if disable {
+				env.DisableFeature("fix1543")
+			}
+			alice := jtx.NewAccount("alice")
+			bob := jtx.NewAccount("bob")
+			fund5000(env, alice, bob)
+			env.Close()
+
+			seq := env.Seq(alice)
+			jtx.RequireTxSuccess(t, env.Submit(
+				escrow.EscrowCreate(alice, bob, xrp(1000)).
+					Condition(escrow.TestCondition1).
+					CancelTime(env.Now().Add(100*time.Second)).
+					FinishTime(env.Now().Add(5*time.Second)).
+					Fee(baseFee*150).
+					Build()))
+			env.Close()
+
+			cancel := withFlag(escrow.EscrowCancel(bob, alice, seq).Build(), strayFlag)
+			require.Equal(t, expect, env.Submit(cancel).Code)
+		}
+		t.Run("enabled rejects", func(t *testing.T) { run(t, false, "temINVALID_FLAG") })
+		t.Run("disabled ignores", func(t *testing.T) { run(t, true, "tecNO_PERMISSION") })
+	})
 }

--- a/internal/testing/offer/crossing_limits_test.go
+++ b/internal/testing/offer/crossing_limits_test.go
@@ -57,6 +57,46 @@ func nOffers(t *testing.T, env *jtx.TestEnv, n int, acc *jtx.Account, takerPays,
 	jtx.RequireOwnerCount(t, env, acc, startOwnerCount+uint32(n))
 }
 
+// TestCrossingLimits_Fix1515Disabled tests the legacy (pre-fix1515) crossing
+// limit of 2000 offers. With fix1515 disabled the payment engine consumes up to
+// 2000 offers per execution instead of 1000, so a 1100-offer crossing that the
+// enabled path would cap at 1000 completes in full.
+// Reference: rippled BookStep.cpp:86-91 (maxOffersToConsume) — disabled = 2000.
+func TestCrossingLimits_Fix1515Disabled(t *testing.T) {
+	env := newEnvWithFeatures(t, []string{"fix1515"})
+
+	gw := jtx.NewAccount("gateway")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+
+	USD := func(amount float64) tx.Amount { return jtx.USD(gw, amount) }
+
+	// 1100 funded offers: more than the enabled (1000) limit, fewer than the
+	// disabled (2000) limit — so the whole book crosses in one execution.
+	const bobsOfferCount = 1100
+
+	env.FundAmount(gw, uint64(jtx.XRP(100000000)))
+	env.FundAmount(alice, uint64(jtx.XRP(100000000)))
+	env.FundAmount(bob, uint64(jtx.XRP(100000000)))
+
+	env.Trust(bob, USD(float64(bobsOfferCount)))
+	result := env.Submit(payment.PayIssued(gw, bob, USD(float64(bobsOfferCount))).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	nOffers(t, env, bobsOfferCount, bob, jtx.XRPTxAmountFromXRP(1), USD(1))
+
+	// Alice crosses Bob's entire book. Under the enabled 1000 limit she would
+	// stop at 1000; under the disabled 2000 limit she consumes all 1100.
+	result = env.Submit(OfferCreate(alice, USD(float64(bobsOfferCount)), jtx.XRPTxAmountFromXRP(float64(bobsOfferCount))).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	jtx.RequireIOUBalance(t, env, alice, gw, "USD", float64(bobsOfferCount))
+	jtx.RequireIOUBalance(t, env, bob, gw, "USD", 0)
+	jtx.RequireOwnerCount(t, env, bob, 1)
+}
+
 // TestCrossingLimits_StepLimit tests that the payment engine step limit
 // causes offer crossing to stop after consuming 1000 offers.
 // Reference: CrossingLimits_test.cpp testStepLimit (lines 30-67)

--- a/internal/testing/paychan/fix1543_flag_gate_test.go
+++ b/internal/testing/paychan/fix1543_flag_gate_test.go
@@ -1,0 +1,98 @@
+package paychan
+
+import (
+	"encoding/hex"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/require"
+)
+
+// strayPayChanFlag is a bit outside every PayChan flag mask — it is neither a
+// universal flag nor a PayChanClaim flag (tfRenew=0x00010000, tfClose=0x00020000)
+// — so it is stray for Create, Fund and Claim alike.
+const strayPayChanFlag = uint32(0x00040000)
+
+func withFlag(txn tx.Transaction, flag uint32) tx.Transaction {
+	txn.GetCommon().SetFlags(txn.GetCommon().GetFlags() | flag)
+	return txn
+}
+
+// TestPayChan_Fix1543FlagGate exercises both branches of the fix1543 gate on
+// the tfUniversalMask / tfPayChanClaimMask checks of PayChanCreate, PayChanFund
+// and PayChanClaim. With fix1543 enabled (default) a stray flag is rejected with
+// temINVALID_FLAG; with it disabled the flag is ignored.
+// Reference: rippled PayChan.cpp:177,332,443.
+func TestPayChan_Fix1543FlagGate(t *testing.T) {
+	const settleDelay = uint32(3600)
+
+	setup := func(t *testing.T, disable bool) (*jtx.TestEnv, *jtx.Account, *jtx.Account, string) {
+		t.Helper()
+		env := jtx.NewTestEnv(t)
+		if disable {
+			env.DisableFeature("fix1543")
+		}
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		createSeq := env.Seq(alice)
+		result := env.Submit(ChannelCreate(alice, bob, xrp(1000), settleDelay, alice.PublicKeyHex()).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		chanK := chanKeylet(alice, bob, createSeq)
+		return env, alice, bob, hex.EncodeToString(chanK.Key[:])
+	}
+
+	t.Run("create enabled rejects stray flag", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		txn := withFlag(ChannelCreate(alice, bob, xrp(1000), settleDelay, alice.PublicKeyHex()).Build(), strayPayChanFlag)
+		require.Equal(t, "temINVALID_FLAG", env.Submit(txn).Code)
+	})
+
+	t.Run("create disabled ignores stray flag", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		env.DisableFeature("fix1543")
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		txn := withFlag(ChannelCreate(alice, bob, xrp(1000), settleDelay, alice.PublicKeyHex()).Build(), strayPayChanFlag)
+		jtx.RequireTxSuccess(t, env.Submit(txn))
+	})
+
+	t.Run("fund enabled rejects stray flag", func(t *testing.T) {
+		env, alice, _, chanID := setup(t, false)
+		txn := withFlag(ChannelFund(alice, chanID, xrp(1000)).Build(), strayPayChanFlag)
+		require.Equal(t, "temINVALID_FLAG", env.Submit(txn).Code)
+	})
+
+	t.Run("fund disabled ignores stray flag", func(t *testing.T) {
+		env, alice, _, chanID := setup(t, true)
+		txn := withFlag(ChannelFund(alice, chanID, xrp(1000)).Build(), strayPayChanFlag)
+		jtx.RequireTxSuccess(t, env.Submit(txn))
+	})
+
+	t.Run("claim enabled rejects stray flag", func(t *testing.T) {
+		env, alice, _, chanID := setup(t, false)
+		txn := withFlag(ChannelClaim(alice, chanID).Balance(xrp(500)).Amount(xrp(500)).Build(), strayPayChanFlag)
+		require.Equal(t, "temINVALID_FLAG", env.Submit(txn).Code)
+	})
+
+	t.Run("claim disabled ignores stray flag", func(t *testing.T) {
+		env, alice, _, chanID := setup(t, true)
+		txn := withFlag(ChannelClaim(alice, chanID).Balance(xrp(500)).Amount(xrp(500)).Build(), strayPayChanFlag)
+		jtx.RequireTxSuccess(t, env.Submit(txn))
+	})
+}

--- a/internal/testing/require_fully_canonical_sig_test.go
+++ b/internal/testing/require_fully_canonical_sig_test.go
@@ -1,0 +1,100 @@
+package testing
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	rootcrypto "github.com/LeJamon/go-xrpl/crypto"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/stretchr/testify/require"
+)
+
+// secp256k1 curve order N; high-S = N - lowS.
+var secpCurveOrderN, _ = new(big.Int).SetString(
+	"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16)
+
+// flipSToHighS converts a low-S DER signature to its high-S (non-canonical but
+// still valid) counterpart by replacing s with N-s.
+func flipSToHighS(t testing.TB, sigHex string) string {
+	t.Helper()
+	sigBytes, err := hex.DecodeString(sigHex)
+	require.NoError(t, err)
+	r, s, err := rootcrypto.DERSigToRS(sigBytes)
+	require.NoError(t, err)
+	flipped := new(big.Int).Sub(secpCurveOrderN, new(big.Int).SetBytes(s))
+	return hex.EncodeToString(
+		rootcrypto.EncodeDERSignature(new(big.Int).SetBytes(r), flipped))
+}
+
+// signHighS produces a transaction signed with a high-S secp256k1 signature.
+func (e *TestEnv) signHighS(txn tx.Transaction, signer *Account) {
+	e.t.Helper()
+	e.autoFillForSigning(txn)
+	e.signReal(txn, signer)
+	common := txn.GetCommon()
+	common.TxnSignature = flipSToHighS(e.t, common.TxnSignature)
+	require.Equal(e.t, rootcrypto.CanonicityCanonical,
+		ecdsaCanonicalityOf(e.t, common.TxnSignature),
+		"prepared signature must be high-S (canonical but not fully canonical)")
+}
+
+func ecdsaCanonicalityOf(t testing.TB, sigHex string) rootcrypto.Canonicality {
+	t.Helper()
+	b, err := hex.DecodeString(sigHex)
+	require.NoError(t, err)
+	return rootcrypto.ECDSACanonicality(b)
+}
+
+// TestRequireFullyCanonicalSig_Gate exercises both branches of the
+// RequireFullyCanonicalSig amendment gate. When the amendment is enabled (or the
+// tx opts in via tfFullyCanonicalSig) a high-S signature is rejected; when it is
+// disabled and the flag is absent, the high-S signature is accepted.
+// Reference: rippled apply.cpp:78-84 + STTx::checkSingleSign.
+func TestRequireFullyCanonicalSig_Gate(t *testing.T) {
+	t.Run("enabled rejects high-S", func(t *testing.T) {
+		env := NewTestEnv(t)
+		alice := NewAccount("alice")
+		bob := NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		p := payment.NewPayment(alice.Address, bob.Address, tx.NewXRPAmount(1_000_000))
+		env.signHighS(p, alice)
+		result := env.submitWithSigVerification(p)
+		require.Equal(t, "temBAD_SIGNATURE", result.Code,
+			"high-S signature must be rejected while RequireFullyCanonicalSig is enabled")
+	})
+
+	t.Run("disabled accepts high-S", func(t *testing.T) {
+		env := NewTestEnv(t)
+		env.DisableFeature("RequireFullyCanonicalSig")
+		alice := NewAccount("alice")
+		bob := NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		p := payment.NewPayment(alice.Address, bob.Address, tx.NewXRPAmount(1_000_000))
+		env.signHighS(p, alice)
+		result := env.submitWithSigVerification(p)
+		require.Equal(t, "tesSUCCESS", result.Code,
+			"high-S signature must be accepted while RequireFullyCanonicalSig is disabled and tfFullyCanonicalSig is absent")
+	})
+
+	t.Run("disabled but tfFullyCanonicalSig rejects high-S", func(t *testing.T) {
+		env := NewTestEnv(t)
+		env.DisableFeature("RequireFullyCanonicalSig")
+		alice := NewAccount("alice")
+		bob := NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		p := payment.NewPayment(alice.Address, bob.Address, tx.NewXRPAmount(1_000_000))
+		p.SetFlags(p.GetFlags() | tx.TfFullyCanonicalSig)
+		env.signHighS(p, alice)
+		result := env.submitWithSigVerification(p)
+		require.Equal(t, "temBAD_SIGNATURE", result.Code,
+			"a tx opting in via tfFullyCanonicalSig must reject a high-S signature even with the amendment disabled")
+	})
+}

--- a/internal/tx/escrow/escrow_cancel.go
+++ b/internal/tx/escrow/escrow_cancel.go
@@ -52,7 +52,11 @@ func (e *EscrowCancel) Flatten() (map[string]any, error) {
 
 // Preclaim performs the rules-aware fix1543 flag check.
 // Reference: rippled Escrow.cpp:1203 — stray (non-universal) flags are rejected
-// only once fix1543 is active.
+// only once fix1543 is active. rippled runs this check first in preflight; the
+// gate is rules-aware and go-xrpl exposes rules only at Preclaim, so it runs
+// after the common preflight/preclaim steps. For a tx malformed in two ways this
+// can surface a different tem code than rippled; the result is tem-only (never
+// enters a ledger) so there is no consensus divergence.
 func (e *EscrowCancel) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
 	if config.GetRules().Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
 		return tx.TemINVALID_FLAG

--- a/internal/tx/escrow/escrow_cancel.go
+++ b/internal/tx/escrow/escrow_cancel.go
@@ -36,9 +36,8 @@ func (e *EscrowCancel) Validate() error {
 		return err
 	}
 
-	if err := tx.CheckFlags(e.GetFlags(), tx.TfUniversalMask); err != nil {
-		return err
-	}
+	// The tfUniversalMask flag check is gated on fix1543 and runs in Preclaim,
+	// where the amendment rules are available.
 
 	if e.Owner == "" {
 		return tx.Errorf(tx.TemMALFORMED, "Owner is required")
@@ -49,6 +48,16 @@ func (e *EscrowCancel) Validate() error {
 
 func (e *EscrowCancel) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(e)
+}
+
+// Preclaim performs the rules-aware fix1543 flag check.
+// Reference: rippled Escrow.cpp:1203 — stray (non-universal) flags are rejected
+// only once fix1543 is active.
+func (e *EscrowCancel) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+	if config.GetRules().Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
+		return tx.TemINVALID_FLAG
+	}
+	return tx.TesSUCCESS
 }
 
 // Apply applies an EscrowCancel transaction

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -59,10 +59,8 @@ func (e *EscrowCreate) Validate() error {
 		return err
 	}
 
-	// Reference: rippled Escrow.cpp preflight() fix1543 flag check
-	if err := tx.CheckFlags(e.GetFlags(), tx.TfUniversalMask); err != nil {
-		return err
-	}
+	// The tfUniversalMask flag check is gated on fix1543 and runs in Preclaim,
+	// where the amendment rules are available.
 
 	if err := tx.CheckDestRequired(e.Destination); err != nil {
 		return err
@@ -137,6 +135,12 @@ func (e *EscrowCreate) Flatten() (map[string]any, error) {
 func (e *EscrowCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
 	rules := config.GetRules()
 	closeTime := config.ParentCloseTime
+
+	// fix1543: stray (non-universal) flags are rejected only once the amendment
+	// is active. Reference: rippled Escrow.cpp:124.
+	if rules.Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
+		return tx.TemINVALID_FLAG
+	}
 
 	// Time validation against parent close time
 	// Reference: rippled Escrow.cpp:457-489

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -137,7 +137,13 @@ func (e *EscrowCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Resu
 	closeTime := config.ParentCloseTime
 
 	// fix1543: stray (non-universal) flags are rejected only once the amendment
-	// is active. Reference: rippled Escrow.cpp:124.
+	// is active. Reference: rippled Escrow.cpp:124. rippled runs this check first
+	// in preflight; the gate is rules-aware, and go-xrpl exposes rules only at
+	// Preclaim, so it runs after the common preflight/preclaim steps. The check
+	// is the first statement of Preclaim, the earliest rules-aware point. For a
+	// tx malformed in two ways this can surface a different tem code than rippled;
+	// the result is tem-only (never enters a ledger) so there is no consensus
+	// divergence.
 	if rules.Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
 		return tx.TemINVALID_FLAG
 	}

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -124,7 +124,11 @@ func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConf
 
 // Preclaim performs the rules-aware fix1543 flag check.
 // Reference: rippled Escrow.cpp:630 — stray (non-universal) flags are rejected
-// only once fix1543 is active.
+// only once fix1543 is active. rippled runs this check first in preflight; the
+// gate is rules-aware and go-xrpl exposes rules only at Preclaim, so it runs
+// after the common preflight/preclaim steps. For a tx malformed in two ways this
+// can surface a different tem code than rippled; the result is tem-only (never
+// enters a ledger) so there is no consensus divergence.
 func (e *EscrowFinish) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
 	if config.GetRules().Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
 		return tx.TemINVALID_FLAG

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -53,9 +53,8 @@ func (e *EscrowFinish) Validate() error {
 		return err
 	}
 
-	if err := tx.CheckFlags(e.GetFlags(), tx.TfUniversalMask); err != nil {
-		return err
-	}
+	// The tfUniversalMask flag check is gated on fix1543 and runs in Preclaim,
+	// where the amendment rules are available.
 
 	if e.Owner == "" {
 		return tx.Errorf(tx.TemMALFORMED, "Owner is required")
@@ -121,6 +120,16 @@ func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConf
 	}
 
 	return fee
+}
+
+// Preclaim performs the rules-aware fix1543 flag check.
+// Reference: rippled Escrow.cpp:630 — stray (non-universal) flags are rejected
+// only once fix1543 is active.
+func (e *EscrowFinish) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+	if config.GetRules().Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
+		return tx.TemINVALID_FLAG
+	}
+	return tx.TesSUCCESS
 }
 
 // ApplyOnTec implements TecApplier. When tecEXPIRED is returned, this re-runs

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -64,11 +64,10 @@ func (p *PaymentChannelClaim) Validate() error {
 		return tx.Errorf(tx.TemMALFORMED, "Channel must be a valid 256-bit hash")
 	}
 
-	// Validate flags - fix1543
+	// The tfPayChanClaimMask flag check is gated on fix1543 and runs in
+	// Preclaim, where the amendment rules are available. The tfClose/tfRenew
+	// conflict check below is NOT gated. Reference: rippled PayChan.cpp:443-447.
 	flags := p.GetFlags()
-	if err := tx.CheckFlags(flags, ^(tfPayChanRenew | tfPayChanClose | tx.TfUniversal)); err != nil {
-		return err
-	}
 
 	// Cannot set both tfClose and tfRenew
 	if (flags&tfPayChanClose != 0) && (flags&tfPayChanRenew != 0) {
@@ -161,6 +160,17 @@ func (p *PaymentChannelClaim) Flatten() (map[string]any, error) {
 
 func (p *PaymentChannelClaim) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
+}
+
+// Preclaim performs the rules-aware fix1543 flag check. Only the
+// tfPayChanClaimMask check is gated; the tfClose/tfRenew conflict check runs
+// unconditionally in Validate. Reference: rippled PayChan.cpp:443-447.
+func (p *PaymentChannelClaim) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+	const tfPayChanClaimMask = ^(tfPayChanRenew | tfPayChanClose | tx.TfUniversal)
+	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tfPayChanClaimMask) != 0 {
+		return tx.TemINVALID_FLAG
+	}
+	return tx.TesSUCCESS
 }
 
 // SetClose sets the close flag

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -164,7 +164,12 @@ func (p *PaymentChannelClaim) RequiredAmendments() [][32]byte {
 
 // Preclaim performs the rules-aware fix1543 flag check. Only the
 // tfPayChanClaimMask check is gated; the tfClose/tfRenew conflict check runs
-// unconditionally in Validate. Reference: rippled PayChan.cpp:443-447.
+// unconditionally in Validate. Reference: rippled PayChan.cpp:443-447. rippled
+// runs the mask check first in preflight; the gate is rules-aware and go-xrpl
+// exposes rules only at Preclaim, so it runs after the common preflight/preclaim
+// steps. For a tx malformed in two ways this can surface a different tem code
+// than rippled; the result is tem-only (never enters a ledger) so there is no
+// consensus divergence.
 func (p *PaymentChannelClaim) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
 	const tfPayChanClaimMask = ^(tfPayChanRenew | tfPayChanClose | tx.TfUniversal)
 	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tfPayChanClaimMask) != 0 {

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -57,10 +57,8 @@ func (p *PaymentChannelCreate) Validate() error {
 		return err
 	}
 
-	// Check for invalid flags (tfUniversalMask) - fix1543
-	if err := tx.CheckFlags(p.GetFlags(), tx.TfUniversal); err != nil {
-		return err
-	}
+	// The tfUniversalMask flag check is gated on fix1543 and runs in Preclaim,
+	// where the amendment rules are available.
 
 	// Destination is required
 	if err := tx.CheckDestRequired(p.Destination); err != nil {
@@ -120,6 +118,16 @@ func (p *PaymentChannelCreate) Flatten() (map[string]any, error) {
 
 func (p *PaymentChannelCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
+}
+
+// Preclaim performs the rules-aware fix1543 flag check.
+// Reference: rippled PayChan.cpp:177 — stray (non-universal) flags are rejected
+// only once fix1543 is active.
+func (p *PaymentChannelCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tx.TfUniversalMask) != 0 {
+		return tx.TemINVALID_FLAG
+	}
+	return tx.TesSUCCESS
 }
 
 // Reference: rippled PayChan.cpp PayChanCreate::doApply()

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -122,7 +122,11 @@ func (p *PaymentChannelCreate) RequiredAmendments() [][32]byte {
 
 // Preclaim performs the rules-aware fix1543 flag check.
 // Reference: rippled PayChan.cpp:177 — stray (non-universal) flags are rejected
-// only once fix1543 is active.
+// only once fix1543 is active. rippled runs this check first in preflight; the
+// gate is rules-aware and go-xrpl exposes rules only at Preclaim, so it runs
+// after the common preflight/preclaim steps. For a tx malformed in two ways this
+// can surface a different tem code than rippled; the result is tem-only (never
+// enters a ledger) so there is no consensus divergence.
 func (p *PaymentChannelCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
 	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tx.TfUniversalMask) != 0 {
 		return tx.TemINVALID_FLAG

--- a/internal/tx/paychan/payment_channel_fund.go
+++ b/internal/tx/paychan/payment_channel_fund.go
@@ -84,7 +84,11 @@ func (p *PaymentChannelFund) RequiredAmendments() [][32]byte {
 
 // Preclaim performs the rules-aware fix1543 flag check.
 // Reference: rippled PayChan.cpp:332 — stray (non-universal) flags are rejected
-// only once fix1543 is active.
+// only once fix1543 is active. rippled runs this check first in preflight; the
+// gate is rules-aware and go-xrpl exposes rules only at Preclaim, so it runs
+// after the common preflight/preclaim steps. For a tx malformed in two ways this
+// can surface a different tem code than rippled; the result is tem-only (never
+// enters a ledger) so there is no consensus divergence.
 func (p *PaymentChannelFund) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
 	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tx.TfUniversalMask) != 0 {
 		return tx.TemINVALID_FLAG

--- a/internal/tx/paychan/payment_channel_fund.go
+++ b/internal/tx/paychan/payment_channel_fund.go
@@ -43,10 +43,8 @@ func (p *PaymentChannelFund) Validate() error {
 		return err
 	}
 
-	// Check for invalid flags (tfUniversalMask) - fix1543
-	if err := tx.CheckFlags(p.GetFlags(), tx.TfUniversal); err != nil {
-		return err
-	}
+	// The tfUniversalMask flag check is gated on fix1543 and runs in Preclaim,
+	// where the amendment rules are available.
 
 	// Channel is required
 	if p.Channel == "" {
@@ -82,6 +80,16 @@ func (p *PaymentChannelFund) Flatten() (map[string]any, error) {
 
 func (p *PaymentChannelFund) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
+}
+
+// Preclaim performs the rules-aware fix1543 flag check.
+// Reference: rippled PayChan.cpp:332 — stray (non-universal) flags are rejected
+// only once fix1543 is active.
+func (p *PaymentChannelFund) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tx.TfUniversalMask) != 0 {
+		return tx.TemINVALID_FLAG
+	}
+	return tx.TesSUCCESS
 }
 
 // Reference: rippled PayChan.cpp PayChanFund::doApply()

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -473,6 +473,31 @@ func TestMaxOffersToConsume_Fix1515Gate(t *testing.T) {
 	require.Equal(t, uint32(2000), maxOffersToConsume(NewPaymentSandbox(disabledView)))
 }
 
+// TestFix1515Enabled_NilRulesGuard covers the fix1515 gate used by the BookStep
+// offer-limit branch. The nil-rules case is the rules-free pathfinding path: a
+// sandbox with no parent and no view returns nil rules, and the gate must
+// default to the active-network value (enabled) rather than panic. Both the
+// limit helper and the boolean gate must agree on that default.
+func TestFix1515Enabled_NilRulesGuard(t *testing.T) {
+	enabledView := newPaymentMockLedgerView()
+	enabledView.rules = amendment.AllSupportedRules()
+	require.True(t, fix1515Enabled(NewPaymentSandbox(enabledView)))
+
+	disabledView := newPaymentMockLedgerView()
+	disabledView.rules = amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		DisableByName("fix1515").
+		Build()
+	require.False(t, fix1515Enabled(NewPaymentSandbox(disabledView)))
+
+	// Nil-rules sandbox: parent and view both nil → Rules() == nil. The gate must
+	// default to enabled and must not panic.
+	nilRulesSandbox := &PaymentSandbox{}
+	require.Nil(t, nilRulesSandbox.Rules())
+	require.True(t, fix1515Enabled(nilRulesSandbox))
+	require.Equal(t, uint32(1000), maxOffersToConsume(nilRulesSandbox))
+}
+
 // DirectStepI Tests
 
 func TestDirectStepI_Basic(t *testing.T) {

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
 )
 
 // Test Helpers - Mock LedgerView for testing
@@ -17,6 +18,7 @@ import (
 type paymentMockLedgerView struct {
 	data       map[[32]byte][]byte
 	ownerCount map[[20]byte]uint32
+	rules      *amendment.Rules
 }
 
 func newPaymentMockLedgerView() *paymentMockLedgerView {
@@ -59,7 +61,10 @@ func (m *paymentMockLedgerView) TxExists(txID [32]byte) bool {
 }
 
 func (m *paymentMockLedgerView) Rules() *amendment.Rules {
-	return nil
+	if m.rules != nil {
+		return m.rules
+	}
+	return amendment.AllSupportedRules()
 }
 
 func (m *paymentMockLedgerView) LedgerSeq() uint32 {
@@ -388,6 +393,84 @@ func TestXRPEndpointStep_QualityUpperBound(t *testing.T) {
 	if dir != DebtDirectionIssues {
 		t.Error("expected DebtDirectionIssues")
 	}
+}
+
+// createAccountWithTransferRate creates an account carrying a non-default
+// transfer rate, used to make the legacy vs post-fix qualityUpperBound diverge.
+func (m *paymentMockLedgerView) createAccountWithTransferRate(accountID [20]byte, balanceDrops uint64, transferRate uint32) {
+	account := &state.AccountRoot{
+		Account:      state.EncodeAccountIDSafe(accountID),
+		Balance:      balanceDrops,
+		Sequence:     1,
+		TransferRate: transferRate,
+	}
+	data, _ := state.SerializeAccountRoot(account)
+	key := keylet.Account(accountID)
+	m.data[key.Key] = data
+}
+
+// TestDirectStepI_QualityUpperBound_FixQualityUpperBoundGate exercises both
+// branches of the fixQualityUpperBound gate. The legacy branch computes the
+// quality with the getRate arguments inverted relative to the post-fix branch,
+// so a source that issues with a non-unit transfer rate (and a redeeming prior
+// step) yields reciprocal qualities. Reference: rippled DirectStep.cpp:847-877.
+func TestDirectStepI_QualityUpperBound_FixQualityUpperBoundGate(t *testing.T) {
+	var alice, bob [20]byte
+	copy(alice[:], []byte("alice12345678901234"))
+	copy(bob[:], []byte("bob1234567890123456"))
+
+	// transferRate 1.25 (QualityOne * 1.25), src (alice) issues USD to bob.
+	const rate = uint32(1_250_000_000) // 1.25 in transfer-rate units (QualityOne = 1e9)
+
+	build := func(t *testing.T, fixEnabled bool) *Quality {
+		t.Helper()
+		view := newPaymentMockLedgerView()
+		if fixEnabled {
+			view.rules = amendment.AllSupportedRules()
+		} else {
+			view.rules = amendment.NewRulesBuilder().
+				FromPreset(amendment.PresetAllSupported).
+				DisableByName("fixQualityUpperBound").
+				Build()
+		}
+		view.createAccountWithTransferRate(alice, 100_000_000, rate)
+		view.createAccount(bob, 100_000_000, 0)
+		sandbox := NewPaymentSandbox(view)
+
+		// alice issues to bob (no trust line where alice is owed → DebtDirectionIssues).
+		step := NewDirectStepI(alice, bob, "USD", nil, false, false)
+		// A redeeming prior step makes the legacy branch charge the transfer rate.
+		q, _ := step.QualityUpperBound(sandbox, DebtDirectionRedeems)
+		require.NotNil(t, q)
+		return q
+	}
+
+	enabled := build(t, true)
+	disabled := build(t, false)
+
+	// Post-fix: srcQOut/dstQIn with srcQOut=QualityOne (prevStep nil) → quality 1.0.
+	// Legacy: dstQIn/srcQOut with srcQOut=transferRate → quality < 1.0.
+	// The two must therefore differ, proving the gate is wired.
+	require.NotEqual(t, enabled.Value, disabled.Value,
+		"legacy and post-fix qualityUpperBound must differ when the transfer rate is non-unit")
+	require.Less(t, disabled.Value, enabled.Value,
+		"legacy quality (dstQIn/srcQOut) must be strictly smaller than post-fix quality")
+}
+
+// TestMaxOffersToConsume_Fix1515Gate exercises both branches of the fix1515
+// offer-consumption limit: 1000 when enabled, 2000 when disabled.
+// Reference: rippled BookStep.cpp:86-91.
+func TestMaxOffersToConsume_Fix1515Gate(t *testing.T) {
+	enabledView := newPaymentMockLedgerView()
+	enabledView.rules = amendment.AllSupportedRules()
+	require.Equal(t, uint32(1000), maxOffersToConsume(NewPaymentSandbox(enabledView)))
+
+	disabledView := newPaymentMockLedgerView()
+	disabledView.rules = amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		DisableByName("fix1515").
+		Build()
+	require.Equal(t, uint32(2000), maxOffersToConsume(NewPaymentSandbox(disabledView)))
 }
 
 // DirectStepI Tests

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -26,6 +26,14 @@ func maxOffersToConsume(sb *PaymentSandbox) uint32 {
 	return 2000
 }
 
+// fix1515Enabled reports whether fix1515 governs this execution, nil-defaulting
+// to the active-network value (enabled) for rules-free contexts such as
+// pathfinding liquidity estimation, matching maxOffersToConsume's convention.
+func fix1515Enabled(sb *PaymentSandbox) bool {
+	rules := sb.Rules()
+	return rules == nil || rules.Enabled(amendment.FeatureFix1515)
+}
+
 // BookStep consumes liquidity from an order book.
 // It iterates through offers at the best quality, consuming them until
 // the requested amount is satisfied or liquidity is exhausted.
@@ -447,7 +455,7 @@ func (s *BookStep) Rev(
 
 	// Too many iterations. Reference: rippled BookStep.cpp:1096-1108.
 	if s.offersUsed_ >= s.maxOffersToConsume {
-		if !sb.Rules().Enabled(amendment.FeatureFix1515) {
+		if !fix1515Enabled(sb) {
 			// Pre-fix1515: discard this strand's liquidity entirely.
 			s.cache = &bookCache{in: s.zeroIn(), out: s.zeroOut()}
 			return s.zeroIn(), s.zeroOut()
@@ -794,7 +802,7 @@ func (s *BookStep) Fwd(
 
 	// Too many iterations. Reference: rippled BookStep.cpp:1267-1280.
 	if s.offersUsed_ >= s.maxOffersToConsume {
-		if !sb.Rules().Enabled(amendment.FeatureFix1515) {
+		if !fix1515Enabled(sb) {
 			// Pre-fix1515: discard this strand's liquidity entirely.
 			s.cache = &bookCache{in: s.zeroIn(), out: s.zeroOut()}
 			return s.zeroIn(), s.zeroOut()

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -5,11 +5,26 @@ import (
 	"errors"
 	"slices"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/amm"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
+
+// maxOffersToConsume returns the per-execution offer-consumption limit.
+// fix1515 lowered it from 2000 to 1000. Reference: rippled BookStep.cpp:86-91.
+//
+// When the sandbox has no rules (rules-free contexts such as pathfinding
+// liquidity estimation), default to the active-network limit of 1000 — the
+// value fix1515 has enforced on mainnet since activation.
+func maxOffersToConsume(sb *PaymentSandbox) uint32 {
+	rules := sb.Rules()
+	if rules == nil || rules.Enabled(amendment.FeatureFix1515) {
+		return 1000
+	}
+	return 2000
+}
 
 // BookStep consumes liquidity from an order book.
 // It iterates through offers at the best quality, consuming them until
@@ -120,11 +135,13 @@ func NewBookStep(inIssue, outIssue Issue, strandSrc, strandDst [20]byte, prevSte
 		strandDst:            strandDst,
 		prevStep:             prevStep,
 		ownerPaysTransferFee: ownerPaysTransferFee,
-		maxOffersToConsume:   1000, // fix1515 limit
-		qualityLimit:         nil,
-		inactive_:            false,
-		offersUsed_:          0,
-		cache:                nil,
+		// Re-derived from the active rules at the start of Rev/Fwd; the
+		// fix1515 value is the default until then.
+		maxOffersToConsume: 1000,
+		qualityLimit:       nil,
+		inactive_:          false,
+		offersUsed_:        0,
+		cache:              nil,
 	}
 }
 
@@ -148,6 +165,7 @@ func (s *BookStep) Rev(
 ) (EitherAmount, EitherAmount) {
 	s.cache = nil
 	s.offersUsed_ = 0
+	s.maxOffersToConsume = maxOffersToConsume(sb)
 
 	// Get transfer rates
 	// When there is no previous step (BookStep is the first step in the strand,
@@ -427,8 +445,15 @@ func (s *BookStep) Rev(
 	_ = fundedCount
 	_ = unfundedCount
 
-	// Check if we should become inactive
+	// Too many iterations. Reference: rippled BookStep.cpp:1096-1108.
 	if s.offersUsed_ >= s.maxOffersToConsume {
+		if !sb.Rules().Enabled(amendment.FeatureFix1515) {
+			// Pre-fix1515: discard this strand's liquidity entirely.
+			s.cache = &bookCache{in: s.zeroIn(), out: s.zeroOut()}
+			return s.zeroIn(), s.zeroOut()
+		}
+		// fix1515: keep the liquidity but mark the strand inactive so it is
+		// not consulted further.
 		s.inactive_ = true
 	}
 
@@ -458,6 +483,7 @@ func (s *BookStep) Fwd(
 	prevCache := s.cache
 	s.cache = nil
 	s.offersUsed_ = 0
+	s.maxOffersToConsume = maxOffersToConsume(sb)
 
 	// Get transfer rates
 	// When there is no previous step, default to DebtDirectionIssues
@@ -766,7 +792,15 @@ func (s *BookStep) Fwd(
 		tryAMMFwd(nil)
 	}
 
+	// Too many iterations. Reference: rippled BookStep.cpp:1267-1280.
 	if s.offersUsed_ >= s.maxOffersToConsume {
+		if !sb.Rules().Enabled(amendment.FeatureFix1515) {
+			// Pre-fix1515: discard this strand's liquidity entirely.
+			s.cache = &bookCache{in: s.zeroIn(), out: s.zeroOut()}
+			return s.zeroIn(), s.zeroOut()
+		}
+		// fix1515: keep the liquidity but mark the strand inactive so it is
+		// not consulted further.
 		s.inactive_ = true
 	}
 

--- a/internal/tx/payment/step_direct.go
+++ b/internal/tx/payment/step_direct.go
@@ -1,6 +1,7 @@
 package payment
 
 import (
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -300,6 +301,30 @@ func (s *DirectStepI) QualityUpperBound(v *PaymentSandbox, prevStepDir DebtDirec
 	}
 
 	srcDebtDir := s.DebtDirection(v, StrandDirectionForward)
+
+	// A nil-rules sandbox (rules-free contexts such as pathfinding liquidity
+	// estimation) defaults to the active-network post-fix computation, the
+	// behaviour fixQualityUpperBound has enforced on mainnet since activation.
+	rules := v.Rules()
+	if rules != nil && !rules.Enabled(amendment.FeatureFixQualityUpperBound) {
+		// Legacy (pre-fixQualityUpperBound) computation. Reference: rippled
+		// DirectStep.cpp:847-863.
+		var srcQOut uint32 = QualityOne
+		if Redeems(prevStepDir) && Issues(srcDebtDir) {
+			srcQOut = s.transferRate(v)
+		}
+		dstQIn := s.quality(v, true) // QualityDirection::in
+		if s.isLast && dstQIn > QualityOne {
+			dstQIn = QualityOne
+		}
+		// rippled getRate(STAmount(srcQOut), STAmount(dstQIn)) = dstQIn / srcQOut.
+		// Note the argument order is the inverse of the post-fix branch below.
+		srcQOutAmt := NewIOUEitherAmount(state.NewIssuedAmountFromValue(int64(srcQOut), 0, "", ""))
+		dstQInAmt := NewIOUEitherAmount(state.NewIssuedAmountFromValue(int64(dstQIn), 0, "", ""))
+		q := QualityFromAmounts(dstQInAmt, srcQOutAmt)
+		return &q, srcDebtDir
+	}
+
 	srcQOut, dstQIn := s.qualities(v, srcDebtDir, StrandDirectionForward)
 
 	// Quality = srcQOut / dstQIn using precise STAmount division

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -197,10 +197,16 @@ func (e *Engine) verifySignatures(tx Transaction) Result {
 	if e.config.SkipSignatureVerification {
 		return TesSUCCESS
 	}
+	// Full canonicality (low-S secp256k1) is required when RequireFullyCanonicalSig
+	// is enabled, or — independent of the amendment — when the transaction opts in
+	// via the tfFullyCanonicalSig flag.
+	// Reference: rippled apply.cpp:78-84 + STTx::checkSingleSign/checkMultiSign.
+	mustBeFullyCanonical := e.rules().RequireFullyCanonicalSigEnabled() ||
+		(tx.GetCommon().GetFlags()&TfFullyCanonicalSig) != 0
 	if IsMultiSigned(tx) {
 		// Multi-signed transactions require signer list lookup
 		lookup := &engineSignerListLookup{view: e.view}
-		if err := VerifyMultiSignature(tx, lookup); err != nil {
+		if err := VerifyMultiSignature(tx, lookup, mustBeFullyCanonical); err != nil {
 			switch err {
 			case ErrNotMultiSigning:
 				return TefNOT_MULTI_SIGNING
@@ -224,7 +230,7 @@ func (e *Engine) verifySignatures(tx Transaction) Result {
 	}
 	// Single-signed transaction — verify cryptographic signature validity.
 	// The signing key authorization (master vs regular key) is checked in preclaim.
-	if err := VerifySignature(tx); err != nil {
+	if err := VerifySignature(tx, mustBeFullyCanonical); err != nil {
 		return TemBAD_SIGNATURE
 	}
 	return TesSUCCESS

--- a/internal/tx/signature.go
+++ b/internal/tx/signature.go
@@ -72,10 +72,14 @@ func IsMultiSigned(tx Transaction) bool {
 	return len(common.Signers) > 0 && common.SigningPubKey == ""
 }
 
-// VerifySignature verifies that a transaction is properly signed
-// Returns nil if the signature is valid, or an error describing the problem
-// For multi-signed transactions, use VerifyMultiSignature instead
-func VerifySignature(tx Transaction) error {
+// VerifySignature verifies that a transaction is properly signed.
+// Returns nil if the signature is valid, or an error describing the problem.
+// For multi-signed transactions, use VerifyMultiSignature instead.
+//
+// mustBeFullyCanonical requires secp256k1 signatures to be low-S. The caller
+// derives it from the RequireFullyCanonicalSig amendment and the per-tx
+// tfFullyCanonicalSig flag (rippled apply.cpp:78-84 + STTx::checkSingleSign).
+func VerifySignature(tx Transaction, mustBeFullyCanonical bool) error {
 	common := tx.GetCommon()
 
 	// Check if this is a multi-signed transaction
@@ -107,7 +111,7 @@ func VerifySignature(tx Transaction) error {
 	}
 
 	// Verify the signature based on the key type
-	valid := verifySignatureForKey(signingPayload, common.SigningPubKey, common.TxnSignature)
+	valid := verifySignatureForKey(signingPayload, common.SigningPubKey, common.TxnSignature, mustBeFullyCanonical)
 	if !valid {
 		return ErrInvalidSignature
 	}
@@ -122,15 +126,18 @@ func VerifySignature(tx Transaction) error {
 //  3. Verifies each signature is valid for that signer
 //  4. Sums the weights and checks against the quorum
 //
-// Returns nil if all signatures are valid and the quorum is met
-func VerifyMultiSignature(tx Transaction, lookup SignerListLookup) error {
+// Returns nil if all signatures are valid and the quorum is met.
+//
+// mustBeFullyCanonical requires each secp256k1 signer signature to be low-S
+// (see VerifySignature).
+func VerifyMultiSignature(tx Transaction, lookup SignerListLookup, mustBeFullyCanonical bool) error {
 	common := tx.GetCommon()
 
 	// Verify this is actually a multi-signed transaction
 	if !IsMultiSigned(tx) {
 		if common.TxnSignature != "" {
 			// This is a single-signed transaction, use VerifySignature
-			return VerifySignature(tx)
+			return VerifySignature(tx, mustBeFullyCanonical)
 		}
 		return ErrMissingSignature
 	}
@@ -283,7 +290,7 @@ func VerifyMultiSignature(tx Transaction, lookup SignerListLookup) error {
 		}
 
 		// Verify the signature
-		valid := verifySignatureForKey(signingPayload, signer.SigningPubKey, signer.TxnSignature)
+		valid := verifySignatureForKey(signingPayload, signer.SigningPubKey, signer.TxnSignature, mustBeFullyCanonical)
 		if !valid {
 			return ErrBadSignature
 		}
@@ -319,8 +326,11 @@ func getSigningPayload(tx Transaction) (string, error) {
 	return binarycodec.EncodeForSigning(txMap)
 }
 
-// verifySignatureForKey verifies a signature using the appropriate algorithm
-func verifySignatureForKey(messageHex, pubKeyHex, signatureHex string) bool {
+// verifySignatureForKey verifies a signature using the appropriate algorithm.
+// mustBeFullyCanonical requires a secp256k1 signature to be low-S; ed25519
+// signatures are always canonical and ignore the flag. Reference: rippled
+// STTx::checkSingleSign / checkMultiSign pass fullyCanonical to verify().
+func verifySignatureForKey(messageHex, pubKeyHex, signatureHex string, mustBeFullyCanonical bool) bool {
 	// Decode the public key to determine the algorithm
 	pubKeyBytes, err := hex.DecodeString(pubKeyHex)
 	if err != nil || len(pubKeyBytes) == 0 {
@@ -351,7 +361,7 @@ func verifySignatureForKey(messageHex, pubKeyHex, signatureHex string) bool {
 	case 0x02, 0x03:
 		// SECP256K1 (compressed public key)
 		algo := secp256k1.SECP256K1()
-		return algo.Validate(msgStr, pubKeyHex, signatureHex)
+		return algo.ValidateWithCanonicality(msgStr, pubKeyHex, signatureHex, mustBeFullyCanonical)
 
 	default:
 		return false


### PR DESCRIPTION
Fixes #855.

## Summary

Four DefaultYes amendments hard-coded their **enabled** behaviour with no rules consult. All are long-active on mainnet (no live-network fork path), but the node diverged from rippled when replaying pre-activation history or running a fresh network before activation. This adds the rules-gated **disabled** branches, each with enabled- and disabled-state tests.

| Gate | Amendment | Change | Rippled reference |
|------|-----------|--------|-------------------|
| a | RequireFullyCanonicalSig | `mustBeFullyCanonical = amendment OR tfFullyCanonicalSig`, threaded through single/multi-sign verify; secp256k1 now uses `ValidateWithCanonicality` | `apply.cpp:78-84`, `STTx::checkSingleSign` (`fullyCanonical = (flags & tfFullyCanonicalSig) \|\| requireCanonicalSig`) |
| b | fixQualityUpperBound | Legacy `DirectStepI.QualityUpperBound` computation (inverted `getRate` arg order) for the disabled branch | `DirectStep.cpp:847-863` (legacy) vs `:876-877` (post-fix) |
| c | fix1515 | `maxOffersToConsume` re-derived from rules (1000 enabled / 2000 disabled) + disabled-branch discard-liquidity semantics in `BookStep` Rev/Fwd | `BookStep.cpp:86-91, 1096-1108, 1267-1280` |
| d | fix1543 | `tfUniversalMask` / `tfPayChanClaimMask` enforcement moved from context-free `Validate` to a rules-aware `Preclaim` on Escrow{Create,Finish,Cancel} and PaymentChannel{Create,Fund,Claim}; enforced only when enabled | `PayChan.cpp:177,332,443`; `Escrow.cpp:124,630,1203` |

### Incidental fix (gate d)

`PaymentChannelCreate` and `PaymentChannelFund` previously passed `tfUniversal` (not `tfUniversalMask`) to `CheckFlags`, an **inverted mask** that would reject any tx setting the universally-allowed `tfFullyCanonicalSig` bit. The rules-aware Preclaim uses the correct `tfUniversalMask`, fixing this latent bug. The unconditional `tfClose`/`tfRenew` conflict check (`temMALFORMED`, not fix1543-gated) stays in `Validate`.

### Pathfinder nil-rules guard

The pathfinder drives book/direct steps with rules-free sandboxes (`PaymentSandbox.Rules()` is nil), where `Rules().Enabled(...)` would panic — silently swallowed by the strand-flow `recover()` and surfacing as empty paths. `maxOffersToConsume` and the `QualityUpperBound` gate therefore default to the **active-network** branch when `Rules()` is nil, matching the prior hard-coded behaviour. This restored the `internal/testing/payment` path suite, which regressed before the guard was added.

## Deferred: fixSTAmountCanonicalize

Gate (e) is intentionally deferred (the issue explicitly authorizes this if disproportionately risky). rippled gates three overflow throws (`STAmount.cpp:887-896, :898, :922-931`) inside a single offset-based `canonicalize()` via the `STAmountSO` RAII switchover. go-xrpl's representation splits native XRP into a dedicated `XRPAmount{drops int64}` (no offset) and IOU into `IssuedAmount`, with no single canonicalize choke point gated by the switchover. Faithfully reproducing the **disabled** (no-throw, offset-wrap) behaviour would require modelling rippled's exact offset-normalization overflow semantics — disproportionate for a low-priority, replay-only fix. The `fixSTAmountCanonicalize` amendment remains registered (`SupportedYes`, `VoteDefaultYes`); only the switchover wiring is deferred.

## Testing

- New per-gate tests: `internal/testing/require_fully_canonical_sig_test.go` (a — 3 cases: enabled/disabled/disabled+flag), `internal/testing/paychan/fix1543_flag_gate_test.go` (d — 6 cases), `internal/testing/escrow/escrow_test.go` TestEscrow_Fix1543FlagGate (d — create/finish/cancel × enabled/disabled), `internal/testing/offer/crossing_limits_test.go` TestCrossingLimits_Fix1515Disabled (c — 1100-offer crossing), `internal/tx/payment/flow_test.go` (b legacy-vs-post-fix divergence + c limit 1000/2000). All pass.
- `just test-tx` — green.
- `just test-integration` — `internal/testing/payment` and all feature suites green. The 242 `TestConformance` failures (Vault/XChain stubs, Batch open-ledger, AMM/Number, NFToken, Offer Tiny_payments, TxQ) are **identical to clean origin/main** (diffed both directions — empty), i.e. pre-existing broad gaps unrelated to this change.
- `just vet`, `just lint` (0 issues), `just fmt` — clean.
