### PR TITLE
fix(tx): open-vs-closed view TER mutation — telFAILED_PROCESSING on open-ledger balance guards

### DIFF
--- a/internal/ledger/openledger/apply.go
+++ b/internal/ledger/openledger/apply.go
@@ -187,6 +187,7 @@ func applyOneSingle(view *ledger.Ledger, transaction tx.Transaction, blob []byte
 		SkipSignatureVerification: cfg.SkipSignatureVerification,
 		Rules:                     cfg.Rules,
 		FeeTrack:                  cfg.FeeTrack,
+		ViewOpen:                  cfg.Mode == OpenLedgerMode,
 	}
 	if retry {
 		engineConfig.ApplyFlags |= tx.TapRETRY
@@ -245,6 +246,7 @@ func ApplyTxs(view *ledger.Ledger, txs []PendingTx, retries *[]PendingTx, cfg Ap
 			SkipSignatureVerification: skipSig,
 			Rules:                     cfg.Rules,
 			FeeTrack:                  cfg.FeeTrack,
+			ViewOpen:                  cfg.Mode == OpenLedgerMode,
 		}
 		if certainRetry {
 			engineConfig.ApplyFlags |= tx.TapRETRY

--- a/internal/tx/engine.go
+++ b/internal/tx/engine.go
@@ -127,6 +127,14 @@ type EngineConfig struct {
 	// sufficient when the ledger is open."
 	OpenLedger bool
 
+	// ViewOpen mirrors rippled's view.open() for the open-ledger apply path
+	// that targets an OpenView yet leaves OpenLedger/EnforceLoadFee unset
+	// (the per-tx Submit and held/local replay applies run with tapNONE and
+	// fee adequacy disabled). It carries the view-openness signal that
+	// internal-failure TER guards consult; it does not affect fee handling.
+	// The closed-view consensus build path leaves it false.
+	ViewOpen bool
+
 	// ApplyFlags controls transaction application behavior.
 	// TapRETRY means this is not the tx's last pass: tec results from
 	// preclaim are not applied (likelyToClaimFee = false), allowing the
@@ -170,6 +178,17 @@ func (c EngineConfig) GetRules() *amendment.Rules {
 		return c.Rules
 	}
 	return amendment.AllSupportedRules()
+}
+
+// IsViewOpen reports whether this apply targets the open ledger, mirroring
+// rippled's view.open(). It is true on the direct open-ledger submission path
+// (OpenLedger), on the TxQ apply/accept paths that run with OpenLedger=false
+// yet are marked by EnforceLoadFee, and on the per-tx Submit / held-tx replay
+// applies marked by ViewOpen. It is false only on the closed-view consensus
+// build path. Internal-failure TER guards consult it to pick the
+// telFAILED_PROCESSING (open) vs tecFAILED_PROCESSING (closed) variant.
+func (c EngineConfig) IsViewOpen() bool {
+	return c.OpenLedger || c.EnforceLoadFee || c.ViewOpen
 }
 
 // LedgerView provides read/write access to ledger state

--- a/internal/tx/offer/offer_create_cross.go
+++ b/internal/tx/offer/offer_create_cross.go
@@ -140,6 +140,14 @@ func (o *OfferCreate) takerCross(
 		"takerGot", placeOffer.out,
 	)
 
+	// Open-ledger local processing holds a FAILED_PROCESSING crossing failure
+	// locally (tel: no fee, not relayed) rather than claiming a fee (tec).
+	// Defensive: the flow caps amounts at funds, so this never trips normally.
+	// Reference: rippled CreateOffer.cpp:728-729 (tecFAILED_PROCESSING && bOpenLedger).
+	if result == tx.TecFAILED_PROCESSING && ctx.Config.IsViewOpen() {
+		result = tx.TelFAILED_PROCESSING
+	}
+
 	// For offer crossing, tecPATH_DRY means no liquidity found to cross
 	// This is not an error - we just place the offer with original amounts
 	// Reference: rippled's flowCross always returns tesSUCCESS (CreateOffer.cpp line 509)

--- a/internal/tx/payment/amm_offer.go
+++ b/internal/tx/payment/amm_offer.go
@@ -214,8 +214,8 @@ func xrpTransferInSandbox(sb *PaymentSandbox, from, to [20]byte, drops int64) er
 		if err != nil {
 			return err
 		}
-		// Insufficient-balance guard, mirroring rippled accountSendXRP
-		// (View.cpp: sender balance < amount). Defensive: the flow caps the
+		// Insufficient-balance guard, mirroring rippled accountSendIOU's native
+		// path (View.cpp: sender balance < amount). Defensive: the flow caps the
 		// requested amount at the sender's funds, so this should never trip.
 		if fromAcct.Balance < uint64(drops) {
 			sb.markFundsFailure()

--- a/internal/tx/payment/amm_offer.go
+++ b/internal/tx/payment/amm_offer.go
@@ -214,6 +214,13 @@ func xrpTransferInSandbox(sb *PaymentSandbox, from, to [20]byte, drops int64) er
 		if err != nil {
 			return err
 		}
+		// Insufficient-balance guard, mirroring rippled accountSendXRP
+		// (View.cpp: sender balance < amount). Defensive: the flow caps the
+		// requested amount at the sender's funds, so this should never trip.
+		if fromAcct.Balance < uint64(drops) {
+			sb.markFundsFailure()
+			return errInsufficientFunds
+		}
 		fromAcct.Balance = fromAcct.Balance - uint64(drops)
 		fromAcct.PreviousTxnID = txHash
 		fromAcct.PreviousTxnLgrSeq = ledgerSeq

--- a/internal/tx/payment/failed_processing.go
+++ b/internal/tx/payment/failed_processing.go
@@ -1,0 +1,25 @@
+package payment
+
+import (
+	"errors"
+
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// errInsufficientFunds is the sentinel an XRP-movement primitive returns when
+// the sender's balance is below the amount being sent. It is a defensive guard:
+// the flow engine caps amounts at the sender's available funds, so it should
+// never trip during normal operation. It mirrors the insufficient-balance
+// branch in rippled's accountSendXRP / transferXRP, which there yields
+// telFAILED_PROCESSING (open view) or tecFAILED_PROCESSING (closed view).
+var errInsufficientFunds = errors.New("insufficient XRP balance")
+
+// failedProcessingResult returns the FAILED_PROCESSING TER variant appropriate
+// for this sandbox's view openness, mirroring rippled View.cpp where the guard
+// returns view.open() ? telFAILED_PROCESSING : tecFAILED_PROCESSING.
+func (s *PaymentSandbox) failedProcessingResult() tx.Result {
+	if s.IsOpenLedger() {
+		return tx.TelFAILED_PROCESSING
+	}
+	return tx.TecFAILED_PROCESSING
+}

--- a/internal/tx/payment/failed_processing.go
+++ b/internal/tx/payment/failed_processing.go
@@ -10,8 +10,8 @@ import (
 // the sender's balance is below the amount being sent. It is a defensive guard:
 // the flow engine caps amounts at the sender's available funds, so it should
 // never trip during normal operation. It mirrors the insufficient-balance
-// branch in rippled's accountSendXRP / transferXRP, which there yields
-// telFAILED_PROCESSING (open view) or tecFAILED_PROCESSING (closed view).
+// branch in rippled's accountSendIOU (native path) / transferXRP, which there
+// yields telFAILED_PROCESSING (open view) or tecFAILED_PROCESSING (closed view).
 var errInsufficientFunds = errors.New("insufficient XRP balance")
 
 // failedProcessingResult returns the FAILED_PROCESSING TER variant appropriate

--- a/internal/tx/payment/failed_processing_test.go
+++ b/internal/tx/payment/failed_processing_test.go
@@ -1,0 +1,91 @@
+package payment
+
+import (
+	"testing"
+
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// TestFailedProcessingResult_ViewOpenness verifies the FAILED_PROCESSING TER
+// is mutated by sandbox view openness, mirroring rippled View.cpp:
+// view.open() ? telFAILED_PROCESSING : tecFAILED_PROCESSING.
+func TestFailedProcessingResult_ViewOpenness(t *testing.T) {
+	view := newPaymentMockLedgerView()
+
+	closed := NewPaymentSandbox(view)
+	if got := closed.failedProcessingResult(); got != tx.TecFAILED_PROCESSING {
+		t.Fatalf("closed view: want tecFAILED_PROCESSING, got %s", got)
+	}
+
+	open := NewPaymentSandbox(view)
+	open.SetOpenLedger(true)
+	if got := open.failedProcessingResult(); got != tx.TelFAILED_PROCESSING {
+		t.Fatalf("open view: want telFAILED_PROCESSING, got %s", got)
+	}
+
+	// Child sandboxes inherit openness from the parent.
+	child := NewChildSandbox(open)
+	if !child.IsOpenLedger() {
+		t.Fatalf("child of open sandbox should report open ledger")
+	}
+	if got := child.failedProcessingResult(); got != tx.TelFAILED_PROCESSING {
+		t.Fatalf("open child: want telFAILED_PROCESSING, got %s", got)
+	}
+}
+
+// TestXRPTransfer_InsufficientFundsGuard verifies the XRP-movement primitive
+// refuses to underflow a sender whose balance is below the amount, returns the
+// sentinel, and marks the funds-failure condition on the sandbox chain.
+// Mirrors rippled accountSendXRP's sender-balance < amount branch.
+func TestXRPTransfer_InsufficientFundsGuard(t *testing.T) {
+	view := newPaymentMockLedgerView()
+	var sender, receiver [20]byte
+	sender[0] = 0x11
+	receiver[0] = 0x22
+	view.createAccount(sender, 100, 0)
+	view.createAccount(receiver, 0, 0)
+
+	sb := NewPaymentSandbox(view)
+
+	// Sending more than the sender holds must trip the guard.
+	err := xrpTransferInSandbox(sb, sender, receiver, 500)
+	if err != errInsufficientFunds {
+		t.Fatalf("over-balance transfer: want errInsufficientFunds, got %v", err)
+	}
+	if !sb.HasFundsFailure() {
+		t.Fatalf("sandbox should record a funds failure after the guard trips")
+	}
+
+	// A transfer within balance must succeed and move funds.
+	sbOK := NewPaymentSandbox(view)
+	if err := xrpTransferInSandbox(sbOK, sender, receiver, 40); err != nil {
+		t.Fatalf("within-balance transfer should succeed, got %v", err)
+	}
+	if sbOK.HasFundsFailure() {
+		t.Fatalf("a successful transfer must not mark a funds failure")
+	}
+}
+
+// TestFundsFailure_PropagatesToParent verifies a child sandbox that trips the
+// guard surfaces the condition to the accumulating parent, so the flow result
+// layer can observe it even when the child sandbox is later discarded.
+func TestFundsFailure_PropagatesToParent(t *testing.T) {
+	view := newPaymentMockLedgerView()
+	var sender, receiver [20]byte
+	sender[0] = 0x33
+	receiver[0] = 0x44
+	view.createAccount(sender, 10, 0)
+	view.createAccount(receiver, 0, 0)
+
+	parent := NewPaymentSandbox(view)
+	child := NewChildSandbox(parent)
+
+	if err := xrpTransferInSandbox(child, sender, receiver, 1000); err != errInsufficientFunds {
+		t.Fatalf("want errInsufficientFunds, got %v", err)
+	}
+	// markFundsFailure walks the parent chain, so the parent sees it even
+	// without an explicit Apply (the child may be a discarded dry strand).
+	if !parent.HasFundsFailure() {
+		t.Fatalf("parent sandbox should observe the child's funds failure")
+	}
+}

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -338,6 +338,21 @@ func Flow(
 		}
 	}
 
+	// An XRP-movement guard tripping during crossing aborts the flow with
+	// FAILED_PROCESSING, mirroring rippled's Throw<FlowException>(dr) from
+	// BookStep::consumeOffer — the whole flow is discarded, no state applied.
+	// Defensive: amounts are capped at sender funds, so this never trips in
+	// normal operation.
+	if accumSandbox.HasFundsFailure() {
+		return FlowResult{
+			In:              ZeroXRPEitherAmount(),
+			Out:             ZeroXRPEitherAmount(),
+			Sandbox:         nil,
+			RemovableOffers: nil,
+			Result:          accumSandbox.failedProcessingResult(),
+		}
+	}
+
 	// Determine final result code
 	// Reference: rippled StrandFlow.h lines 853-872:
 	//   if (!partialPayment) → tecPATH_PARTIAL (couldn't deliver full amount)
@@ -556,6 +571,9 @@ func RippleCalculate(
 	// Create PaymentSandbox from view
 	sandbox := NewPaymentSandbox(view)
 	sandbox.SetTransactionContext(txHash, ledgerSeq)
+	// Mirror rippled view.open(): the XRP-movement balance guards select the
+	// telFAILED_PROCESSING (open) vs tecFAILED_PROCESSING (closed) variant.
+	sandbox.SetOpenLedger(rcOpts.openLedger)
 
 	// Convert paths to strands
 	// opts: [0]=offerCrossing (false for payments), [1]=fix1781
@@ -636,6 +654,11 @@ type rippleCalculateOpts struct {
 	// fix1781 gates XRP endpoint loop detection in strand building.
 	// Reference: rippled XRPEndpointStep.cpp check(): ctx.view.rules().enabled(fix1781)
 	fix1781 bool
+
+	// openLedger mirrors rippled's view.open() (Payment.cpp: rcInput.isLedgerOpen
+	// = view().open()). It selects the FAILED_PROCESSING TER variant in the
+	// XRP-movement balance guards: tel (open) vs tec (closed).
+	openLedger bool
 }
 
 // WithAmendments passes amendment flags and ledger timing to RippleCalculate,
@@ -668,6 +691,16 @@ func WithAMMAmendments(fixAMMv1_1, fixAMMv1_2, fixAMMOverflowOffer bool) RippleC
 func WithFix1781(enabled bool) RippleCalculateOption {
 	return func(o *rippleCalculateOpts) {
 		o.fix1781 = enabled
+	}
+}
+
+// WithOpenLedger threads the view-openness signal (EngineConfig.IsViewOpen)
+// into the flow sandbox. When true, an XRP-movement balance guard that trips
+// yields telFAILED_PROCESSING (local hold); when false, tecFAILED_PROCESSING.
+// Reference: rippled Payment.cpp: rcInput.isLedgerOpen = view().open().
+func WithOpenLedger(open bool) RippleCalculateOption {
+	return func(o *rippleCalculateOpts) {
+		o.openLedger = open
 	}
 }
 

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -355,6 +355,7 @@ func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destI
 			rules.Enabled(amendment.FeatureFixAMMOverflowOffer),
 		),
 		WithFix1781(rules.Enabled(amendment.FeatureFix1781)),
+		WithOpenLedger(ctx.Config.IsViewOpen()),
 	}
 	// Thread domain ID to the flow engine for permissioned domain payments.
 	if p.DomainID != nil {

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -50,6 +50,18 @@ type PaymentSandbox struct {
 
 	// ledgerSeq is the current ledger sequence (for PreviousTxnLgrSeq updates)
 	ledgerSeq uint32
+
+	// openLedger mirrors rippled's view.open(): true when the transaction is
+	// being applied against the open ledger (local submission / TxQ retry),
+	// false during closed-view consensus apply. It selects the FAILED_PROCESSING
+	// TER variant (tel vs tec) in the XRP-movement balance guards.
+	openLedger bool
+
+	// fundsFailure records that an XRP-movement primitive tripped its
+	// insufficient-balance guard during this sandbox's execution. It carries the
+	// defensive FAILED_PROCESSING condition up to the flow/cross result layer,
+	// playing the role of rippled's Throw<FlowException>(telFAILED_PROCESSING).
+	fundsFailure bool
 }
 
 // DeferredCredits tracks credits that shouldn't be spendable mid-transaction.
@@ -130,6 +142,7 @@ func NewChildSandbox(parent *PaymentSandbox) *PaymentSandbox {
 		parent:             parent,
 		txHash:             txHash,
 		ledgerSeq:          ledgerSeq,
+		openLedger:         parent.openLedger,
 		view:               nil, // Use parent's view
 		modifications:      make(map[[32]byte][]byte),
 		preImages:          make(map[[32]byte][]byte),
@@ -138,6 +151,46 @@ func NewChildSandbox(parent *PaymentSandbox) *PaymentSandbox {
 		deletedFinalStates: make(map[[32]byte][]byte),
 		tab:                newDeferredCredits(),
 	}
+}
+
+// SetOpenLedger records whether this sandbox is applying against the open
+// ledger. It is set once from EngineConfig.IsViewOpen at the flow entry point
+// and propagated to child sandboxes. Mirrors rippled's view.open().
+func (s *PaymentSandbox) SetOpenLedger(open bool) {
+	s.openLedger = open
+}
+
+// IsOpenLedger reports whether this sandbox chain is applying against the open
+// ledger, walking up to the root. Mirrors rippled's view.open().
+func (s *PaymentSandbox) IsOpenLedger() bool {
+	for cur := s; cur != nil; cur = cur.parent {
+		if cur.openLedger {
+			return true
+		}
+	}
+	return false
+}
+
+// markFundsFailure records that an XRP-movement primitive could not move funds
+// because the sender's balance was insufficient. The flag is set on the whole
+// sandbox chain up to the root so it survives even when the child sandbox that
+// tripped the guard is discarded (a dry strand). This propagates the defensive
+// FAILED_PROCESSING condition to the flow/cross result layer.
+func (s *PaymentSandbox) markFundsFailure() {
+	for cur := s; cur != nil; cur = cur.parent {
+		cur.fundsFailure = true
+	}
+}
+
+// HasFundsFailure reports whether an XRP-movement guard tripped anywhere in
+// this sandbox chain.
+func (s *PaymentSandbox) HasFundsFailure() bool {
+	for cur := s; cur != nil; cur = cur.parent {
+		if cur.fundsFailure {
+			return true
+		}
+	}
+	return false
 }
 
 // newDeferredCredits creates a new DeferredCredits instance

--- a/internal/tx/payment/step_book_transfer.go
+++ b/internal/tx/payment/step_book_transfer.go
@@ -114,8 +114,12 @@ func (s *BookStep) transferXRP(sb *PaymentSandbox, from, to [20]byte, drops int6
 			return err
 		}
 
+		// Insufficient-balance guard, mirroring rippled transferXRP
+		// (View.cpp: sender balance < amount). Defensive: the flow caps the
+		// requested amount at the sender's funds, so this should never trip.
 		if int64(fromAccount.Balance) < drops {
-			return errors.New("insufficient XRP balance")
+			sb.markFundsFailure()
+			return errInsufficientFunds
 		}
 
 		// Record the credit via CreditHook BEFORE updating balance

--- a/internal/tx/payment/step_xrp.go
+++ b/internal/tx/payment/step_xrp.go
@@ -341,8 +341,8 @@ func (s *XRPEndpointStep) accountSend(sb *PaymentSandbox, drops int64) error {
 			return err
 		}
 
-		// Insufficient-balance guard, mirroring rippled accountSendXRP
-		// (View.cpp: sender balance < amount). Defensive: the flow caps the
+		// Insufficient-balance guard, mirroring rippled accountSendIOU's native
+		// path (View.cpp: sender balance < amount). Defensive: the flow caps the
 		// requested amount at the sender's funds, so this should never trip.
 		if senderRoot.Balance < uint64(drops) {
 			sb.markFundsFailure()

--- a/internal/tx/payment/step_xrp.go
+++ b/internal/tx/payment/step_xrp.go
@@ -341,6 +341,14 @@ func (s *XRPEndpointStep) accountSend(sb *PaymentSandbox, drops int64) error {
 			return err
 		}
 
+		// Insufficient-balance guard, mirroring rippled accountSendXRP
+		// (View.cpp: sender balance < amount). Defensive: the flow caps the
+		// requested amount at the sender's funds, so this should never trip.
+		if senderRoot.Balance < uint64(drops) {
+			sb.markFundsFailure()
+			return errInsufficientFunds
+		}
+
 		senderRoot.Balance -= uint64(drops)
 
 		// Serialize and update

--- a/internal/tx/result_failed_processing_test.go
+++ b/internal/tx/result_failed_processing_test.go
@@ -1,0 +1,35 @@
+package tx
+
+import "testing"
+
+// TestTelFailedProcessing_LocalHoldClassification locks the submit-path
+// contract the open-ledger FAILED_PROCESSING guard relies on: a
+// telFAILED_PROCESSING result is a local error that is NOT applied, so the
+// submit path holds it locally (retriable, kept) without claiming a fee or
+// relaying it to peers.
+//
+// The relay/keep decision in LedgerServiceAdapter.submitTransaction and the
+// localTxs push in service.SubmitTransaction both branch on result.Applied:
+// relay and fee-claim happen only when Applied is true, while a non-fail_hard
+// submission is still held. tel is never applied, so it is held but neither
+// relayed nor charged — matching rippled NetworkOPs.cpp:1674-1689.
+func TestTelFailedProcessing_LocalHoldClassification(t *testing.T) {
+	r := TelFAILED_PROCESSING
+
+	if r.IsApplied() {
+		t.Fatalf("telFAILED_PROCESSING must not be applied (no fee claimed, not relayed)")
+	}
+	if !r.IsTel() {
+		t.Fatalf("telFAILED_PROCESSING must classify as a tel (local error) code")
+	}
+	if r.IsTec() {
+		t.Fatalf("telFAILED_PROCESSING must not classify as a tec (no fee claim)")
+	}
+
+	// The closed-view variant is a tec: it claims a fee and is applied, the
+	// behaviour consensus apply must keep producing on the closed-view path.
+	c := TecFAILED_PROCESSING
+	if !c.IsTec() || !c.IsApplied() {
+		t.Fatalf("tecFAILED_PROCESSING must claim a fee and be applied on the closed-view path")
+	}
+}


### PR DESCRIPTION
## Summary

rippled mutates the `FAILED_PROCESSING` result of its XRP-movement balance guards by `view.open()`:
- `View.cpp:1917-1918` (`accountSendXRP`) and `:2386-2388` (`transferXRP`) return `view.open() ? telFAILED_PROCESSING : tecFAILED_PROCESSING`.
- `CreateOffer.cpp:728-729` maps `tecFAILED_PROCESSING → telFAILED_PROCESSING` when `bOpenLedger` (`= sb.open()`).

An open view (local processing) gets the **tel** variant — held locally, no fee claimed, not relayed — while a closed/consensus view gets **tec** (fee claimed, applied). goXRPL had **neither** the insufficient-balance guards in the XRP send/transfer primitives nor the open-vs-closed mutation.

## What changed

1. **Guards** — added the insufficient-balance guard to the three XRP-movement primitives (`XRPEndpointStep.accountSend`, `BookStep.transferXRP`, `xrpTransferInSandbox`), mirroring rippled's `accountSendXRP`/`transferXRP`. These are defensive should-never-happen paths: the flow caps amounts at the sender's funds.
2. **Propagation** — the Go step interface returns amounts, not TER codes, so the guard is surfaced through the `PaymentSandbox` chain (`markFundsFailure` / `HasFundsFailure`) up to the flow/cross result layer. This is the idiomatic equivalent of rippled's `Throw<FlowException>` from `BookStep::consumeOffer`; the failing strand sandbox can be a discarded dry strand, so the flag walks to the root.
3. **View-openness signal** — threaded explicitly through `EngineConfig.IsViewOpen()`, the faithful `view.open()` mirror. Crucially, `OpenLedger` alone is **not** `view.open()`: the TxQ apply/accept paths target the open ledger yet run with `OpenLedger=false` (rippled's `tapNONE`, marked by `EnforceLoadFee`), and the per-tx `Submit` / held-tx replay applies (`OpenLedgerMode`) set neither fee flag. `IsViewOpen()` = `OpenLedger || EnforceLoadFee || ViewOpen`, where the new `ViewOpen` field is set from `Mode == OpenLedgerMode` on those replay/submit paths and is fee-neutral. Only the closed-view consensus build path (`BuildLedgerMode`) and historical replay leave it false.
   - The Payment flow threads it via `WithOpenLedger(ctx.Config.IsViewOpen())` so the guard returns tel/tec directly.
   - CreateOffer crossing keeps rippled's shape: `flowCross` returns tec, the `CreateOffer` layer maps tec→tel on an open view.

## Safety property (consensus byte-identical)

These are defensive guards rippled documents as should-never-happen (the flow caps at sender funds). Closed-view consensus apply behaviour is unchanged: I diffed the full conformance suite (TER + state mismatch lines, per step) against clean `origin/main` — the failing set is identical (242 = 242) and every step's result is byte-for-byte the same. The only delta is one pre-existing non-deterministic harness line in `ledger/View/default` Step 98 (cross-test number-globals ordering, present on base too; isolated runs produce zero Step-98 mismatches on both trees). No genuinely-reachable closed-view guard path was found.

## tel = local hold (item d)

Verified by reading: a `telFAILED_PROCESSING` from open-ledger apply is **not applied** (`Result.IsApplied()` false), so `doApply` returns before any fee/state commit, the submit path's `relayable = Applied || terQUEUED` is false (not relayed), and `kept` is true on a non-`fail_hard` submit (retriable local hold), and the service holds it in localTxs without persisting/relaying. Matches rippled `NetworkOPs.cpp:1674-1689`. Locked with a classification test.

## Tests

- New unit tests: primitive-level guard + funds-failure propagation, view-openness → tel/tec selection (incl. the closed-view tec arm), and the tel local-hold classification contract.
- `just test-tx`, payment/offer/txq/openledger suites, `just test-core`: all green.
- `just test-integration`: all feature suites green; the only FAIL is the pre-existing conformance corpus, proven byte-identical to `origin/main`.

Fixes #858
