### PR TITLE
fix: real fsync in nodestore, pebble iterator safety, sqlite/postgres contract parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
       - uses: golangci/golangci-lint-action@v8
         with:
           version: v2.11.3
+      # The postgres conformance suite is gated behind a build tag, so plain
+      # vet/lint never compiles it; keep it compiling.
+      - name: Vet tag-gated postgres backend
+        run: go vet -tags postgres ./storage/relationaldb/postgres/
 
   generate:
     name: Generate (ledgerfields drift check)

--- a/shamap/nodestore_family.go
+++ b/shamap/nodestore_family.go
@@ -52,11 +52,7 @@ func NewPebbleNodeStoreFamily(path string, cacheSize int) (*NodeStoreFamily, err
 		NegativeCacheTTL:     5 * time.Minute,
 		NegativeCacheMaxSize: 100000,
 	}
-	db, err := nodestore.NewKVDatabaseWithConfig(store, "pebble("+path+")", dbConfig)
-	if err != nil {
-		return nil, err
-	}
-
+	db := nodestore.NewKVDatabaseWithConfig(store, "pebble("+path+")", dbConfig)
 	return NewNodeStoreFamily(db), nil
 }
 

--- a/storage/kvstore/kvstore.go
+++ b/storage/kvstore/kvstore.go
@@ -52,5 +52,9 @@ type KeyValueStore interface {
 	Iteratee
 	Stat() (string, error)
 	Compact(start []byte, limit []byte) error
+	// Sync makes all previously written data durable. Backends whose writes
+	// are already durable (or that have no durable medium, like an in-memory
+	// store) return nil.
+	Sync() error
 	Close() error
 }

--- a/storage/kvstore/kvstoretest/conformance.go
+++ b/storage/kvstore/kvstoretest/conformance.go
@@ -35,7 +35,9 @@ func RunConformance(t *testing.T, newStore NewStoreFunc) {
 		{"EmptyValue", testEmptyValue},
 		{"ValueIsolation", testValueIsolation},
 		{"Batch", testBatch},
+		{"BatchInterleaved", testBatchInterleaved},
 		{"BatchReset", testBatchReset},
+		{"Sync", testSync},
 		{"IteratorFullScan", testIteratorFullScan},
 		{"IteratorPrefix", testIteratorPrefix},
 		{"IteratorStart", testIteratorStart},
@@ -238,6 +240,55 @@ func testBatch(t *testing.T, store kvstore.KeyValueStore) {
 	}
 }
 
+// testBatchInterleaved verifies that a batch replays interleaved Put/Delete
+// operations on the same key in insertion order: the last operation wins.
+func testBatchInterleaved(t *testing.T, store kvstore.KeyValueStore) {
+	b := store.NewBatch()
+	// Delete then Put: the key must be present after Write.
+	if err := b.Put([]byte("k1"), []byte("old")); err != nil {
+		t.Fatalf("batch Put k1: %v", err)
+	}
+	if err := b.Delete([]byte("k1")); err != nil {
+		t.Fatalf("batch Delete k1: %v", err)
+	}
+	if err := b.Put([]byte("k1"), []byte("new")); err != nil {
+		t.Fatalf("batch re-Put k1: %v", err)
+	}
+	// Put then Delete: the key must be absent after Write.
+	if err := b.Put([]byte("k2"), []byte("v")); err != nil {
+		t.Fatalf("batch Put k2: %v", err)
+	}
+	if err := b.Delete([]byte("k2")); err != nil {
+		t.Fatalf("batch Delete k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("batch Write: %v", err)
+	}
+
+	got, err := store.Get([]byte("k1"))
+	if err != nil || !bytes.Equal(got, []byte("new")) {
+		t.Fatalf("Get(k1) = %q, %v; want \"new\" (delete-then-put must keep the key)", got, err)
+	}
+	if has, _ := store.Has([]byte("k2")); has {
+		t.Fatal("k2 present after put-then-delete in the same batch")
+	}
+}
+
+// testSync verifies that Sync succeeds on an open store and that previously
+// written data is still readable afterwards.
+func testSync(t *testing.T, store kvstore.KeyValueStore) {
+	if err := store.Put([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	got, err := store.Get([]byte("k"))
+	if err != nil || !bytes.Equal(got, []byte("v")) {
+		t.Fatalf("Get after Sync = %q, %v; want \"v\"", got, err)
+	}
+}
+
 func testBatchReset(t *testing.T, store kvstore.KeyValueStore) {
 	b := store.NewBatch()
 	if err := b.Put([]byte("a"), []byte("1")); err != nil {
@@ -371,6 +422,23 @@ func testClosed(t *testing.T, store kvstore.KeyValueStore) {
 	if _, err := store.Stat(); !errors.Is(err, kvstore.ErrClosed) {
 		t.Fatalf("Stat on closed err = %v, want ErrClosed", err)
 	}
+	if err := store.Compact([]byte{0x00}, []byte{0xff}); !errors.Is(err, kvstore.ErrClosed) {
+		t.Fatalf("Compact on closed err = %v, want ErrClosed", err)
+	}
+	if err := store.Sync(); !errors.Is(err, kvstore.ErrClosed) {
+		t.Fatalf("Sync on closed err = %v, want ErrClosed", err)
+	}
+	it := store.NewIterator(nil, nil)
+	if it == nil {
+		t.Fatal("NewIterator on closed store returned nil")
+	}
+	if it.Next() {
+		t.Fatal("Next on closed-store iterator = true, want false")
+	}
+	if err := it.Error(); !errors.Is(err, kvstore.ErrClosed) {
+		t.Fatalf("closed-store iterator Error = %v, want ErrClosed", err)
+	}
+	it.Release()
 }
 
 func insert(t *testing.T, store kvstore.KeyValueStore, kv map[string]string) {

--- a/storage/kvstore/memorydb/memorydb.go
+++ b/storage/kvstore/memorydb/memorydb.go
@@ -86,9 +86,14 @@ func (m *MemDatabase) NewBatch() kvstore.Batch {
 // NewIterator returns an iterator over key/value pairs.
 // prefix filters keys that start with prefix.
 // start sets the starting position (relative to prefix).
+// On a closed store the returned iterator is empty and reports ErrClosed
+// via Error.
 func (m *MemDatabase) NewIterator(prefix []byte, start []byte) kvstore.Iterator {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
+	if m.closed {
+		return &memIterator{pos: -1, err: kvstore.ErrClosed}
+	}
 
 	// Collect all keys with the given prefix
 	var keys []string
@@ -132,6 +137,21 @@ func (m *MemDatabase) Stat() (string, error) {
 
 // Compact is a no-op for the in-memory store.
 func (m *MemDatabase) Compact(start []byte, limit []byte) error {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if m.closed {
+		return kvstore.ErrClosed
+	}
+	return nil
+}
+
+// Sync is a no-op: the store has no durable medium.
+func (m *MemDatabase) Sync() error {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if m.closed {
+		return kvstore.ErrClosed
+	}
 	return nil
 }
 
@@ -157,12 +177,21 @@ type kv struct {
 	val []byte
 }
 
-// memBatch implements kvstore.Batch for MemDatabase.
+// memBatch implements kvstore.Batch for MemDatabase. Operations are kept in
+// a single ordered list so interleaved Put/Delete of the same key replays in
+// insertion order, matching the pebble backend.
 type memBatch struct {
-	db      *MemDatabase
-	writes  []kv
-	deletes [][]byte
-	size    int
+	db   *MemDatabase
+	ops  []batchOp
+	size int
+}
+
+// batchOp is a single queued batch operation: a put when delete is false,
+// a deletion otherwise.
+type batchOp struct {
+	key    []byte
+	val    []byte
+	delete bool
 }
 
 // Put queues a key/value write.
@@ -171,7 +200,7 @@ func (b *memBatch) Put(key []byte, value []byte) error {
 	copy(kCopy, key)
 	vCopy := make([]byte, len(value))
 	copy(vCopy, value)
-	b.writes = append(b.writes, kv{key: kCopy, val: vCopy})
+	b.ops = append(b.ops, batchOp{key: kCopy, val: vCopy})
 	b.size += len(value)
 	return nil
 }
@@ -180,7 +209,7 @@ func (b *memBatch) Put(key []byte, value []byte) error {
 func (b *memBatch) Delete(key []byte) error {
 	kCopy := make([]byte, len(key))
 	copy(kCopy, key)
-	b.deletes = append(b.deletes, kCopy)
+	b.ops = append(b.ops, batchOp{key: kCopy, delete: true})
 	return nil
 }
 
@@ -195,21 +224,21 @@ func (b *memBatch) Write() error {
 	if b.db.closed {
 		return kvstore.ErrClosed
 	}
-	for _, w := range b.writes {
-		b.db.db[string(w.key)] = w.val
-	}
-	for _, d := range b.deletes {
-		delete(b.db.db, string(d))
+	for _, op := range b.ops {
+		if op.delete {
+			delete(b.db.db, string(op.key))
+		} else {
+			b.db.db[string(op.key)] = op.val
+		}
 	}
 	return nil
 }
 
 // Reset clears the accumulated writes.
 func (b *memBatch) Reset() {
-	// Drop the backing arrays so a one-shot large batch does not pin
+	// Drop the backing array so a one-shot large batch does not pin
 	// memory indefinitely. Subsequent Puts will reallocate as needed.
-	b.writes = nil
-	b.deletes = nil
+	b.ops = nil
 	b.size = 0
 }
 
@@ -217,6 +246,7 @@ func (b *memBatch) Reset() {
 type memIterator struct {
 	pairs []kv
 	pos   int
+	err   error
 }
 
 // Next advances the iterator and reports whether a pair is available.
@@ -242,7 +272,7 @@ func (it *memIterator) Value() []byte {
 }
 
 func (it *memIterator) Error() error {
-	return nil
+	return it.err
 }
 
 // Release frees the iterator's resources.

--- a/storage/kvstore/pebble/pebble.go
+++ b/storage/kvstore/pebble/pebble.go
@@ -15,8 +15,9 @@ import (
 
 // Store is a thin wrapper around CockroachDB/Pebble that implements kvstore.KeyValueStore.
 type Store struct {
-	db     *pebble.DB
-	closed atomic.Bool
+	db       *pebble.DB
+	closed   atomic.Bool
+	readonly bool
 }
 
 // New opens a Pebble database at the given path.
@@ -72,7 +73,7 @@ func New(path string, cache int, handles int, readonly bool) (*Store, error) {
 		return nil, fmt.Errorf("kvstore/pebble: failed to open %s: %w", path, err)
 	}
 
-	return &Store{db: db}, nil
+	return &Store{db: db, readonly: readonly}, nil
 }
 
 // Has returns true if the key exists in the store.
@@ -134,7 +135,12 @@ func (s *Store) NewBatch() kvstore.Batch {
 
 // NewIterator returns an iterator over key/value pairs with the given prefix,
 // starting from start (or the first key >= start with the prefix).
+// If the store is closed or the underlying iterator cannot be opened, the
+// returned iterator is empty and reports the failure via Error.
 func (s *Store) NewIterator(prefix []byte, start []byte) kvstore.Iterator {
+	if s.closed.Load() {
+		return &errIterator{err: kvstore.ErrClosed}
+	}
 	opts := &pebble.IterOptions{}
 	if len(prefix) > 0 {
 		opts.LowerBound = prefix
@@ -144,7 +150,10 @@ func (s *Store) NewIterator(prefix []byte, start []byte) kvstore.Iterator {
 			opts.UpperBound = upper
 		}
 	}
-	iter, _ := s.db.NewIter(opts)
+	iter, err := s.db.NewIter(opts)
+	if err != nil {
+		return &errIterator{err: err}
+	}
 	var seekKey []byte
 	if len(start) > 0 {
 		if len(prefix) > 0 {
@@ -204,15 +213,30 @@ func (s *Store) Compact(start []byte, limit []byte) error {
 	return s.db.Compact(start, limit, true)
 }
 
-// Close closes the database.
+// Sync makes all previously written data durable by appending a synced
+// record to the WAL. Writes use pebble.NoSync, so this is the only point
+// at which acknowledged writes are guaranteed to survive a crash.
+func (s *Store) Sync() error {
+	if s.closed.Load() {
+		return kvstore.ErrClosed
+	}
+	if s.readonly {
+		return nil
+	}
+	return s.db.LogData(nil, pebble.Sync)
+}
+
+// Close closes the database, flushing pending writes first. The underlying
+// handle is always closed, even if the flush fails.
 func (s *Store) Close() error {
 	if !s.closed.CompareAndSwap(false, true) {
 		return nil // already closed
 	}
-	if err := s.db.Flush(); err != nil {
-		return err
+	var flushErr error
+	if !s.readonly {
+		flushErr = s.db.Flush()
 	}
-	return s.db.Close()
+	return errors.Join(flushErr, s.db.Close())
 }
 
 // batch implements kvstore.Batch using a pebble.Batch.
@@ -292,6 +316,18 @@ func (i *iterator) Error() error {
 func (i *iterator) Release() {
 	i.iter.Close()
 }
+
+// errIterator is an empty iterator that reports a fixed error, returned when
+// an iterator cannot be opened (e.g. the store is closed).
+type errIterator struct {
+	err error
+}
+
+func (i *errIterator) Next() bool    { return false }
+func (i *errIterator) Key() []byte   { return nil }
+func (i *errIterator) Value() []byte { return nil }
+func (i *errIterator) Error() error  { return i.err }
+func (i *errIterator) Release()      {}
 
 // Ensure Store implements kvstore.KeyValueStore at compile time.
 var _ kvstore.KeyValueStore = (*Store)(nil)

--- a/storage/kvstore/pebble/pebble_test.go
+++ b/storage/kvstore/pebble/pebble_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/LeJamon/go-xrpl/storage/kvstore/pebble"
 )
 
+// The ledger-persist fsync path depends on the store exposing a real Sync;
+// keep this explicit so it can never regress to a silently-missed type assert.
+var _ interface{ Sync() error } = (*pebble.Store)(nil)
+
 func TestStoreConformance(t *testing.T) {
 	kvstoretest.RunConformance(t, func(t *testing.T) kvstore.KeyValueStore {
 		store, err := pebble.New(t.TempDir(), 0, 0, false)
@@ -49,4 +53,84 @@ func TestStorePersistence(t *testing.T) {
 	if !bytes.Equal(got, []byte("value")) {
 		t.Fatalf("Get after reopen = %q, want %q", got, "value")
 	}
+}
+
+// TestStoreSyncDurability verifies Sync succeeds after non-durable writes and
+// that the data is durable across a close/reopen cycle.
+func TestStoreSyncDurability(t *testing.T) {
+	dir := t.TempDir()
+
+	store, err := pebble.New(dir, 0, 0, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := store.Put([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	b := store.NewBatch()
+	if err := b.Put([]byte("k2"), []byte("v2")); err != nil {
+		t.Fatalf("batch Put: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("batch Write: %v", err)
+	}
+	if err := store.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := pebble.New(dir, 0, 0, false)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+	for _, kv := range [][2]string{{"k", "v"}, {"k2", "v2"}} {
+		got, err := reopened.Get([]byte(kv[0]))
+		if err != nil || !bytes.Equal(got, []byte(kv[1])) {
+			t.Fatalf("Get(%q) after reopen = %q, %v; want %q", kv[0], got, err, kv[1])
+		}
+	}
+}
+
+// TestStoreReadonly verifies Sync and Close behave on a read-only store:
+// Sync is a no-op and Close must release the handle even though Flush is
+// not possible.
+func TestStoreReadonly(t *testing.T) {
+	dir := t.TempDir()
+
+	rw, err := pebble.New(dir, 0, 0, false)
+	if err != nil {
+		t.Fatalf("open rw: %v", err)
+	}
+	if err := rw.Put([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatalf("Close rw: %v", err)
+	}
+
+	ro, err := pebble.New(dir, 0, 0, true)
+	if err != nil {
+		t.Fatalf("open readonly: %v", err)
+	}
+	got, err := ro.Get([]byte("k"))
+	if err != nil || !bytes.Equal(got, []byte("v")) {
+		t.Fatalf("Get = %q, %v; want \"v\"", got, err)
+	}
+	if err := ro.Sync(); err != nil {
+		t.Fatalf("Sync on readonly: %v", err)
+	}
+	if err := ro.Close(); err != nil {
+		t.Fatalf("Close on readonly: %v", err)
+	}
+
+	// The handle must actually be released: a subsequent open of the same
+	// directory would fail on pebble's file lock if Close leaked it.
+	again, err := pebble.New(dir, 0, 0, false)
+	if err != nil {
+		t.Fatalf("reopen after readonly close: %v", err)
+	}
+	_ = again.Close()
 }

--- a/storage/nodestore/doc.go
+++ b/storage/nodestore/doc.go
@@ -5,6 +5,6 @@
 // of the kvstore interface, with support for batched writes, LRU caching,
 // and negative caching.
 //
-// Node data is keyed by its SHA-512Half hash and encoded with type and
-// compression metadata.
+// Node data is keyed by its SHA-512Half hash and encoded with a small
+// header carrying the node type and ledger sequence (see encoding.go).
 package nodestore

--- a/storage/nodestore/errors.go
+++ b/storage/nodestore/errors.go
@@ -2,25 +2,5 @@ package nodestore
 
 import "errors"
 
-var (
-	// ErrNotFound is returned when a requested node is not present in the store.
-	ErrNotFound = errors.New("node not found")
-
-	// ErrDataCorrupt indicates that stored data is corrupted.
-	ErrDataCorrupt = errors.New("data corrupt")
-
-	// ErrBackendClosed indicates that the backend is closed.
-	ErrBackendClosed = errors.New("backend closed")
-
-	// ErrInvalidNode indicates that a node is invalid.
-	ErrInvalidNode = errors.New("invalid node")
-
-	// ErrInvalidHash indicates that a hash is invalid.
-	ErrInvalidHash = errors.New("invalid hash")
-
-	// ErrInvalidConfig indicates that the configuration is invalid.
-	ErrInvalidConfig = errors.New("invalid config")
-
-	// ErrShutdown indicates that the database is shutting down.
-	ErrShutdown = errors.New("nodestore shutdown")
-)
+// ErrDataCorrupt indicates that stored data is corrupted.
+var ErrDataCorrupt = errors.New("data corrupt")

--- a/storage/nodestore/kvstore_database.go
+++ b/storage/nodestore/kvstore_database.go
@@ -10,14 +10,6 @@ import (
 	"github.com/LeJamon/go-xrpl/storage/kvstore"
 )
 
-// asyncWorkerLimit caps goroutines spawned by FetchAsync per Database so a
-// caller dropping the result channel cannot fan-out unboundedly.
-const asyncWorkerLimit = 64
-
-func newAsyncSem() chan struct{} {
-	return make(chan struct{}, asyncWorkerLimit)
-}
-
 // DatabaseConfig holds configuration for creating a Database.
 type DatabaseConfig struct {
 	// CacheSize is the maximum number of items in the positive cache.
@@ -45,13 +37,11 @@ func DefaultDatabaseConfig() *DatabaseConfig {
 }
 
 // KVDatabaseImpl wraps a kvstore.KeyValueStore to implement the Database interface.
-// This is the new preferred implementation that uses the generic KV layer.
 type KVDatabaseImpl struct {
 	store         kvstore.KeyValueStore
 	cache         *Cache
 	negativeCache *NegativeCache
 	name          string
-	asyncSem      chan struct{}
 	stats         struct {
 		reads             uint64
 		fetchHits         uint64
@@ -71,23 +61,21 @@ func NewKVDatabase(store kvstore.KeyValueStore, name string, cacheSize int, cach
 		cache = NewCache(cacheSize, cacheTTL)
 	}
 	return &KVDatabaseImpl{
-		store:    store,
-		cache:    cache,
-		name:     name,
-		asyncSem: newAsyncSem(),
+		store: store,
+		cache: cache,
+		name:  name,
 	}
 }
 
 // NewKVDatabaseWithConfig creates a new Database from a kvstore.KeyValueStore with full configuration.
-func NewKVDatabaseWithConfig(store kvstore.KeyValueStore, name string, config *DatabaseConfig) (*KVDatabaseImpl, error) {
+func NewKVDatabaseWithConfig(store kvstore.KeyValueStore, name string, config *DatabaseConfig) *KVDatabaseImpl {
 	if config == nil {
 		config = DefaultDatabaseConfig()
 	}
 
 	db := &KVDatabaseImpl{
-		store:    store,
-		name:     name,
-		asyncSem: newAsyncSem(),
+		store: store,
+		name:  name,
 	}
 
 	if config.CacheSize > 0 {
@@ -101,7 +89,7 @@ func NewKVDatabaseWithConfig(store kvstore.KeyValueStore, name string, config *D
 		})
 	}
 
-	return db, nil
+	return db
 }
 
 // Store persists a node to the store.
@@ -187,98 +175,6 @@ func (d *KVDatabaseImpl) Fetch(ctx context.Context, hash Hash256) (*Node, error)
 	return node, nil
 }
 
-// FetchBatch satisfies hits from the positive cache in one pass, then
-// loops over misses against the kvstore (which has no multi-get
-// primitive).
-func (d *KVDatabaseImpl) FetchBatch(ctx context.Context, hashes []Hash256) ([]*Node, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	if len(hashes) == 0 {
-		return nil, nil
-	}
-
-	results := make([]*Node, len(hashes))
-	misses := make([]int, 0, len(hashes))
-
-	if d.cache != nil {
-		for i, h := range hashes {
-			if node, ok := d.cache.Get(h); ok {
-				atomic.AddUint64(&d.stats.cacheHits, 1)
-				atomic.AddUint64(&d.stats.fetchHits, 1)
-				atomic.AddUint64(&d.stats.readBytes, uint64(len(node.Data)))
-				results[i] = node
-			} else {
-				atomic.AddUint64(&d.stats.cacheMisses, 1)
-				misses = append(misses, i)
-			}
-		}
-	} else {
-		for i := range hashes {
-			misses = append(misses, i)
-		}
-	}
-
-	if len(misses) == 0 {
-		atomic.AddUint64(&d.stats.reads, uint64(len(hashes)))
-		return results, nil
-	}
-
-	for _, idx := range misses {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		h := hashes[idx]
-		atomic.AddUint64(&d.stats.reads, 1)
-
-		if d.negativeCache != nil && d.negativeCache.IsMissing(h) {
-			atomic.AddUint64(&d.stats.negativeCacheHits, 1)
-			continue
-		}
-		data, err := d.store.Get(h[:])
-		if err != nil {
-			if errors.Is(err, kvstore.ErrNotFound) {
-				if d.negativeCache != nil {
-					d.negativeCache.MarkMissing(h)
-				}
-				continue
-			}
-			return nil, fmt.Errorf("fetch batch failed: %w", err)
-		}
-		node, err := decodeNodeData(h, data)
-		if err != nil {
-			return nil, err
-		}
-		atomic.AddUint64(&d.stats.fetchHits, 1)
-		atomic.AddUint64(&d.stats.readBytes, uint64(len(node.Data)))
-		if d.cache != nil {
-			d.cache.Put(node)
-		}
-		results[idx] = node
-	}
-	return results, nil
-}
-
-// FetchAsync retrieves a node asynchronously, bounded by asyncWorkerLimit
-// in-flight workers per database.
-func (d *KVDatabaseImpl) FetchAsync(ctx context.Context, hash Hash256) <-chan Result {
-	resultCh := make(chan Result, 1)
-	select {
-	case d.asyncSem <- struct{}{}:
-	case <-ctx.Done():
-		resultCh <- Result{Err: ctx.Err()}
-		close(resultCh)
-		return resultCh
-	}
-	go func() {
-		defer func() { <-d.asyncSem }()
-		node, err := d.Fetch(ctx, hash)
-		resultCh <- Result{Node: node, Err: err}
-		close(resultCh)
-	}()
-	return resultCh
-}
-
 // StoreBatch stores multiple nodes efficiently using a batch.
 func (d *KVDatabaseImpl) StoreBatch(ctx context.Context, nodes []*Node) error {
 	select {
@@ -334,14 +230,15 @@ func (d *KVDatabaseImpl) Sweep() error {
 // Stats returns performance statistics.
 func (d *KVDatabaseImpl) Stats() Statistics {
 	stats := Statistics{
-		Reads:       atomic.LoadUint64(&d.stats.reads),
-		FetchHits:   atomic.LoadUint64(&d.stats.fetchHits),
-		CacheHits:   atomic.LoadUint64(&d.stats.cacheHits),
-		CacheMisses: atomic.LoadUint64(&d.stats.cacheMisses),
-		ReadBytes:   atomic.LoadUint64(&d.stats.readBytes),
-		Writes:      atomic.LoadUint64(&d.stats.writes),
-		WriteBytes:  atomic.LoadUint64(&d.stats.writeBytes),
-		BackendName: d.name,
+		Reads:             atomic.LoadUint64(&d.stats.reads),
+		FetchHits:         atomic.LoadUint64(&d.stats.fetchHits),
+		CacheHits:         atomic.LoadUint64(&d.stats.cacheHits),
+		CacheMisses:       atomic.LoadUint64(&d.stats.cacheMisses),
+		NegativeCacheHits: atomic.LoadUint64(&d.stats.negativeCacheHits),
+		ReadBytes:         atomic.LoadUint64(&d.stats.readBytes),
+		Writes:            atomic.LoadUint64(&d.stats.writes),
+		WriteBytes:        atomic.LoadUint64(&d.stats.writeBytes),
+		BackendName:       d.name,
 	}
 
 	if d.cache != nil {
@@ -360,15 +257,8 @@ func (d *KVDatabaseImpl) Sync(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	type syncer interface {
-		Sync() error
-	}
-	s, ok := d.store.(syncer)
-	if !ok {
-		return nil
-	}
 	done := make(chan error, 1)
-	go func() { done <- s.Sync() }()
+	go func() { done <- d.store.Sync() }()
 	select {
 	case err := <-done:
 		return err

--- a/storage/nodestore/negative_cache.go
+++ b/storage/nodestore/negative_cache.go
@@ -33,17 +33,13 @@ type NegativeCacheConfig struct {
 
 	// MaxSize is the maximum number of entries to cache (0 = unlimited).
 	MaxSize int
-
-	// SweepInterval is how often to sweep expired entries (0 = manual sweep only).
-	SweepInterval time.Duration
 }
 
 // DefaultNegativeCacheConfig returns a NegativeCacheConfig with sensible defaults.
 func DefaultNegativeCacheConfig() *NegativeCacheConfig {
 	return &NegativeCacheConfig{
-		TTL:           5 * time.Minute,
-		MaxSize:       100000, // 100k entries
-		SweepInterval: time.Minute,
+		TTL:     5 * time.Minute,
+		MaxSize: 100000, // 100k entries
 	}
 }
 
@@ -78,6 +74,12 @@ func (nc *NegativeCache) MarkMissing(hash Hash256) {
 
 	nc.mu.Lock()
 	defer nc.mu.Unlock()
+
+	// Close may have nilled the map between the flag check above and
+	// acquiring the lock.
+	if nc.entries == nil {
+		return
+	}
 
 	// Evict if at capacity
 	if nc.maxSize > 0 && len(nc.entries) >= nc.maxSize {
@@ -138,10 +140,13 @@ func (nc *NegativeCache) Remove(hash Hash256) {
 	nc.mu.Unlock()
 }
 
-// Clear removes all entries from the negative cache.
+// Clear removes all entries from the negative cache. It is a no-op on a
+// closed cache.
 func (nc *NegativeCache) Clear() {
 	nc.mu.Lock()
-	nc.entries = make(map[Hash256]time.Time)
+	if nc.entries != nil {
+		nc.entries = make(map[Hash256]time.Time)
+	}
 	nc.mu.Unlock()
 }
 
@@ -297,50 +302,4 @@ func (s NegativeCacheStats) String() string {
 		s.Insertions,
 		s.Expirations, s.Evictions,
 		s.TTL)
-}
-
-// NegativeCacheSweeper automatically sweeps expired entries from a negative cache.
-type NegativeCacheSweeper struct {
-	cache    *NegativeCache
-	interval time.Duration
-	stopCh   chan struct{}
-	wg       sync.WaitGroup
-}
-
-// NewNegativeCacheSweeper creates a new sweeper for the given cache.
-func NewNegativeCacheSweeper(cache *NegativeCache, interval time.Duration) *NegativeCacheSweeper {
-	return &NegativeCacheSweeper{
-		cache:    cache,
-		interval: interval,
-		stopCh:   make(chan struct{}),
-	}
-}
-
-// Start starts the sweeper background goroutine.
-func (s *NegativeCacheSweeper) Start() {
-	s.wg.Add(1)
-	go s.run()
-}
-
-// Stop stops the sweeper background goroutine.
-func (s *NegativeCacheSweeper) Stop() {
-	close(s.stopCh)
-	s.wg.Wait()
-}
-
-// run is the sweeper background goroutine.
-func (s *NegativeCacheSweeper) run() {
-	defer s.wg.Done()
-
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-s.stopCh:
-			return
-		case <-ticker.C:
-			s.cache.Sweep()
-		}
-	}
 }

--- a/storage/nodestore/negative_cache.go
+++ b/storage/nodestore/negative_cache.go
@@ -23,7 +23,7 @@ type NegativeCache struct {
 	}
 
 	maxSize int // Maximum number of entries (0 = unlimited)
-	closed  int64
+	closed  atomic.Bool
 }
 
 // NegativeCacheConfig holds configuration for the negative cache.
@@ -68,7 +68,7 @@ func NewNegativeCacheWithConfig(config *NegativeCacheConfig) *NegativeCache {
 
 // MarkMissing records that a node is not present in the store.
 func (nc *NegativeCache) MarkMissing(hash Hash256) {
-	if atomic.LoadInt64(&nc.closed) != 0 {
+	if nc.closed.Load() {
 		return
 	}
 
@@ -97,7 +97,7 @@ func (nc *NegativeCache) MarkMissing(hash Hash256) {
 // IsMissing checks if a node is known to be missing.
 // Returns true if the node is in the negative cache and not expired.
 func (nc *NegativeCache) IsMissing(hash Hash256) bool {
-	if atomic.LoadInt64(&nc.closed) != 0 {
+	if nc.closed.Load() {
 		return false
 	}
 
@@ -131,7 +131,7 @@ func (nc *NegativeCache) IsMissing(hash Hash256) bool {
 // Remove removes an entry from the negative cache.
 // This should be called when a node is added to the store.
 func (nc *NegativeCache) Remove(hash Hash256) {
-	if atomic.LoadInt64(&nc.closed) != 0 {
+	if nc.closed.Load() {
 		return
 	}
 
@@ -152,7 +152,7 @@ func (nc *NegativeCache) Clear() {
 
 // Sweep removes all expired entries from the cache.
 func (nc *NegativeCache) Sweep() int {
-	if atomic.LoadInt64(&nc.closed) != 0 {
+	if nc.closed.Load() {
 		return 0
 	}
 
@@ -239,7 +239,7 @@ func (nc *NegativeCache) SetMaxSize(maxSize int) {
 
 // Close closes the negative cache.
 func (nc *NegativeCache) Close() error {
-	if !atomic.CompareAndSwapInt64(&nc.closed, 0, 1) {
+	if !nc.closed.CompareAndSwap(false, true) {
 		return nil // Already closed
 	}
 

--- a/storage/nodestore/negative_cache_test.go
+++ b/storage/nodestore/negative_cache_test.go
@@ -295,47 +295,35 @@ func TestNegativeCache(t *testing.T) {
 	})
 }
 
-func TestNegativeCacheSweeper(t *testing.T) {
-	t.Run("AutomaticSweep", func(t *testing.T) {
-		cache := nodestore.NewNegativeCache(50 * time.Millisecond)
-
-		// Add some entries
-		for i := range 5 {
-			hash := nodestore.ComputeHash256(nodestore.Blob("sweeper test " + string(rune('A'+i))))
-			cache.MarkMissing(hash)
-		}
-
-		if cache.Size() != 5 {
-			t.Fatalf("expected 5 entries, got %d", cache.Size())
-		}
-
-		// Start sweeper
-		sweeper := nodestore.NewNegativeCacheSweeper(cache, 30*time.Millisecond)
-		sweeper.Start()
-
-		// Wait for entries to expire and be swept
-		time.Sleep(150 * time.Millisecond)
-
-		// Stop sweeper
-		sweeper.Stop()
-
-		// Entries should be swept
-		if cache.Size() != 0 {
-			t.Errorf("expected 0 entries after automatic sweep, got %d", cache.Size())
-		}
-	})
-
-	t.Run("StopSweeper", func(t *testing.T) {
+// TestNegativeCacheCloseRace exercises MarkMissing/Clear racing Close: a
+// goroutine that passes the closed-flag check and acquires the lock after
+// Close must not write to (or resurrect) the nilled map.
+func TestNegativeCacheCloseRace(t *testing.T) {
+	for range 50 {
 		cache := nodestore.NewNegativeCache(5 * time.Minute)
-		sweeper := nodestore.NewNegativeCacheSweeper(cache, 10*time.Millisecond)
 
-		sweeper.Start()
-		time.Sleep(50 * time.Millisecond)
-		sweeper.Stop()
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			for i := range 100 {
+				cache.MarkMissing(nodestore.ComputeHash256(nodestore.Blob{byte(i)}))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			cache.Clear()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = cache.Close()
+		}()
+		wg.Wait()
 
-		// Should not panic when stopping again or accessing cache
-		_ = cache.Size()
-	})
+		if cache.Size() != 0 {
+			t.Fatalf("expected empty cache after Close, got %d entries", cache.Size())
+		}
+	}
 }
 
 func TestNegativeCacheStats(t *testing.T) {

--- a/storage/nodestore/sync_test.go
+++ b/storage/nodestore/sync_test.go
@@ -1,0 +1,50 @@
+package nodestore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/storage/kvstore"
+	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+)
+
+// syncRecordingStore wraps a real store and records Sync invocations so the
+// test can prove Database.Sync reaches the backend instead of silently
+// no-opping.
+type syncRecordingStore struct {
+	kvstore.KeyValueStore
+	syncCalls int
+	syncErr   error
+}
+
+func (s *syncRecordingStore) Sync() error {
+	s.syncCalls++
+	return s.syncErr
+}
+
+func TestDatabaseSyncReachesBackend(t *testing.T) {
+	store := &syncRecordingStore{KeyValueStore: memorydb.New()}
+	db := nodestore.NewKVDatabase(store, "test", 10, time.Hour)
+	defer db.Close()
+
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if store.syncCalls != 1 {
+		t.Fatalf("backend Sync called %d times, want 1", store.syncCalls)
+	}
+
+	store.syncErr = errors.New("disk on fire")
+	if err := db.Sync(context.Background()); !errors.Is(err, store.syncErr) {
+		t.Fatalf("Sync err = %v, want backend error propagated", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := db.Sync(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Sync with cancelled ctx = %v, want context.Canceled", err)
+	}
+}

--- a/storage/nodestore/types.go
+++ b/storage/nodestore/types.go
@@ -50,8 +50,6 @@ const (
 	NodeAccount NodeType = 3
 	// NodeTransaction represents a transaction object
 	NodeTransaction NodeType = 4
-	// NodeDummy represents an invalid or missing object (used for negative caching)
-	NodeDummy NodeType = 512
 )
 
 // String returns the string representation of the NodeType.
@@ -65,8 +63,6 @@ func (nt NodeType) String() string {
 		return "NodeAccount"
 	case NodeTransaction:
 		return "NodeTransaction"
-	case NodeDummy:
-		return "NodeDummy"
 	default:
 		return fmt.Sprintf("NodeType(%d)", uint32(nt))
 	}
@@ -139,19 +135,13 @@ func (n *Node) IsValid() bool {
 	if n == nil {
 		return false
 	}
-	if n.Type == NodeUnknown || n.Type == NodeDummy {
+	if n.Type == NodeUnknown {
 		return false
 	}
 	if len(n.Data) == 0 {
 		return false
 	}
 	return !IsZero(n.Hash)
-}
-
-// Result represents the result of an asynchronous operation.
-type Result struct {
-	Node *Node // The retrieved node (nil if not found or error occurred)
-	Err  error // Error that occurred during the operation (nil if successful)
 }
 
 // Database defines the main interface for the NodeStore.
@@ -161,12 +151,6 @@ type Database interface {
 
 	// Fetch retrieves a node by its hash synchronously.
 	Fetch(ctx context.Context, hash Hash256) (*Node, error)
-
-	// FetchBatch retrieves multiple nodes efficiently in a single operation.
-	FetchBatch(ctx context.Context, hashes []Hash256) ([]*Node, error)
-
-	// FetchAsync retrieves a node asynchronously, returning a channel for the result.
-	FetchAsync(ctx context.Context, hash Hash256) <-chan Result
 
 	// StoreBatch stores multiple nodes efficiently in a single operation.
 	StoreBatch(ctx context.Context, nodes []*Node) error
@@ -198,17 +182,16 @@ type Database interface {
 // Statistics holds performance metrics for the NodeStore.
 type Statistics struct {
 	// Read metrics
-	Reads        uint64 // Total number of read operations
-	FetchHits    uint64 // Reads that returned a found object (cache or backend)
-	CacheHits    uint64 // Number of successful in-memory cache hits
-	CacheMisses  uint64 // Number of cache misses
-	ReadBytes    uint64 // Total bytes of found objects (cache or backend)
-	ReadDuration uint64 // Total read duration in microseconds
+	Reads             uint64 // Total number of read operations
+	FetchHits         uint64 // Reads that returned a found object (cache or backend)
+	CacheHits         uint64 // Number of successful in-memory cache hits
+	CacheMisses       uint64 // Number of cache misses
+	NegativeCacheHits uint64 // Reads short-circuited by the negative cache
+	ReadBytes         uint64 // Total bytes of found objects (cache or backend)
 
 	// Write metrics
-	Writes        uint64 // Total number of write operations
-	WriteBytes    uint64 // Total bytes written
-	WriteDuration uint64 // Total write duration in microseconds
+	Writes     uint64 // Total number of write operations
+	WriteBytes uint64 // Total bytes written
 
 	// Cache metrics
 	CacheSize    uint64 // Current number of items in cache
@@ -216,7 +199,6 @@ type Statistics struct {
 
 	// Backend metrics
 	BackendName string // Name of the storage backend
-	AsyncReads  uint64 // Number of pending async reads
 }
 
 // String returns a formatted string representation of the statistics.
@@ -230,15 +212,15 @@ func (s Statistics) String() string {
   Backend: %s
   Reads: %d (%.2f%% cache hit rate)
   Cache: %d/%d items
+  Negative Cache Hits: %d
   Writes: %d
   Read Bytes: %d
-  Write Bytes: %d
-  Async Reads: %d`,
+  Write Bytes: %d`,
 		s.BackendName,
 		s.Reads, cacheHitRate,
 		s.CacheSize, s.CacheMaxSize,
+		s.NegativeCacheHits,
 		s.Writes,
 		s.ReadBytes,
-		s.WriteBytes,
-		s.AsyncReads)
+		s.WriteBytes)
 }

--- a/storage/relationaldb/config.go
+++ b/storage/relationaldb/config.go
@@ -163,37 +163,35 @@ func (c *Config) BuildConnectionString() (string, error) {
 	}
 }
 
-// buildPostgresConnectionString builds a PostgreSQL connection string
+// buildPostgresConnectionString builds a PostgreSQL connection string,
+// URL-escaping credentials and the database name.
 func (c *Config) buildPostgresConnectionString() (string, error) {
-	// Build using url.Values for proper encoding
 	params := url.Values{}
 	params.Set("sslmode", c.SSLMode)
 	params.Set("connect_timeout", "30")
 	params.Set("application_name", "xrpl-relational-db")
 
-	// Build the DSN
-	dsn := fmt.Sprintf("postgres://%s", c.Host)
-
+	host := c.Host
 	if c.Port != 0 && c.Port != 5432 {
-		dsn += fmt.Sprintf(":%d", c.Port)
+		host = fmt.Sprintf("%s:%d", c.Host, c.Port)
 	}
 
-	dsn += "/" + c.Database
+	u := &url.URL{
+		Scheme:   "postgres",
+		Host:     host,
+		Path:     "/" + c.Database,
+		RawQuery: params.Encode(),
+	}
 
 	if c.Username != "" {
-		userInfo := c.Username
 		if c.Password != "" {
-			userInfo += ":" + c.Password
+			u.User = url.UserPassword(c.Username, c.Password)
+		} else {
+			u.User = url.User(c.Username)
 		}
-		// Insert user info into URL
-		dsn = fmt.Sprintf("postgres://%s@%s", userInfo, dsn[11:]) // Remove "postgres://" prefix
 	}
 
-	if len(params) > 0 {
-		dsn += "?" + params.Encode()
-	}
-
-	return dsn, nil
+	return u.String(), nil
 }
 
 // buildSQLiteConnectionString builds a SQLite connection string
@@ -227,61 +225,6 @@ func (c *Config) Clone() *Config {
 func (c *Config) WithConnectionString(connStr string) *Config {
 	clone := c.Clone()
 	clone.ConnectionString = connStr
-	return clone
-}
-
-// WithDatabase returns a new config with the specified database name
-func (c *Config) WithDatabase(database string) *Config {
-	clone := c.Clone()
-	clone.Database = database
-	return clone
-}
-
-// WithCredentials returns a new config with the specified credentials
-func (c *Config) WithCredentials(username, password string) *Config {
-	clone := c.Clone()
-	clone.Username = username
-	clone.Password = password
-	return clone
-}
-
-// WithHost returns a new config with the specified host
-func (c *Config) WithHost(host string) *Config {
-	clone := c.Clone()
-	clone.Host = host
-	return clone
-}
-
-// WithPort returns a new config with the specified port
-func (c *Config) WithPort(port int) *Config {
-	clone := c.Clone()
-	clone.Port = port
-	return clone
-}
-
-// WithPoolSettings returns a new config with the specified connection pool settings
-func (c *Config) WithPoolSettings(maxOpen, maxIdle int, maxLifetime, maxIdleTime time.Duration) *Config {
-	clone := c.Clone()
-	clone.MaxOpenConns = maxOpen
-	clone.MaxIdleConns = maxIdle
-	clone.ConnMaxLifetime = maxLifetime
-	clone.ConnMaxIdleTime = maxIdleTime
-	return clone
-}
-
-// WithTimeout returns a new config with the specified default timeout
-func (c *Config) WithTimeout(timeout time.Duration) *Config {
-	clone := c.Clone()
-	clone.DefaultTimeout = timeout
-	return clone
-}
-
-// WithRetrySettings returns a new config with the specified retry settings
-func (c *Config) WithRetrySettings(maxRetries int, delay, maxDelay time.Duration) *Config {
-	clone := c.Clone()
-	clone.MaxRetries = maxRetries
-	clone.RetryDelay = delay
-	clone.RetryMaxDelay = maxDelay
 	return clone
 }
 

--- a/storage/relationaldb/errors.go
+++ b/storage/relationaldb/errors.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 )
 
-// Error types for different categories of database errors
+// Sentinel errors returned by the relational database layer.
 var (
 	// Configuration errors
 	ErrMissingHost            = errors.New("database host is required")
 	ErrMissingDatabase        = errors.New("database name is required")
 	ErrMissingUsername        = errors.New("database username is required")
 	ErrInvalidPort            = errors.New("invalid database port")
-	ErrInvalidDriver          = errors.New("invalid database driver")
 	ErrInvalidMaxOpenConns    = errors.New("max open connections must be >= 0")
 	ErrInvalidMaxIdleConns    = errors.New("max idle connections must be >= 0")
 	ErrMaxIdleExceedsMaxOpen  = errors.New("max idle connections cannot exceed max open connections")
@@ -24,64 +23,15 @@ var (
 	ErrInvalidRetryMaxDelay   = errors.New("retry max delay must be >= retry delay")
 	ErrInvalidMinFreeSpace    = errors.New("minimum free space must be >= 100MB")
 
-	// Connection errors
-	ErrDatabaseClosed          = errors.New("database connection is closed")
-	ErrConnectionFailed        = errors.New("failed to connect to database")
-	ErrConnectionTimeout       = errors.New("database connection timeout")
-	ErrNoConnectionAvailable   = errors.New("no database connection available")
-	ErrTransactionInProgress   = errors.New("transaction already in progress")
-	ErrNoTransactionInProgress = errors.New("no transaction in progress")
+	// ErrDatabaseClosed is returned when an operation runs against a closed connection.
+	ErrDatabaseClosed = errors.New("database connection is closed")
 
-	// Transaction errors
-	ErrTransactionClosed       = errors.New("transaction is closed")
-	ErrTransactionRollback     = errors.New("transaction was rolled back")
-	ErrTransactionCommitFailed = errors.New("transaction commit failed")
-	ErrDeadlock                = errors.New("database deadlock detected")
-	ErrLockTimeout             = errors.New("database lock timeout")
+	// ErrTransactionClosed is returned when a transaction context is reused
+	// after Commit or Rollback.
+	ErrTransactionClosed = errors.New("transaction is closed")
 
-	// Data errors
-	ErrLedgerNotFound         = errors.New("ledger not found")
-	ErrTransactionNotFound    = errors.New("transaction not found")
-	ErrAccountNotFound        = errors.New("account not found")
-	ErrDuplicateEntry         = errors.New("duplicate entry")
-	ErrInvalidLedgerSequence  = errors.New("invalid ledger sequence")
-	ErrInvalidTransactionHash = errors.New("invalid transaction hash")
-	ErrInvalidAccountID       = errors.New("invalid account ID")
-	ErrDataCorruption         = errors.New("data corruption detected")
-	ErrInvalidDataFormat      = errors.New("invalid data format")
-
-	// Constraint errors
-	ErrConstraintViolation = errors.New("database constraint violation")
-	ErrForeignKeyViolation = errors.New("foreign key constraint violation")
-	ErrUniqueViolation     = errors.New("unique constraint violation")
-	ErrNotNullViolation    = errors.New("not null constraint violation")
-	ErrCheckViolation      = errors.New("check constraint violation")
-
-	// Resource errors
-	ErrInsufficientSpace      = errors.New("insufficient database space")
-	ErrDatabaseFull           = errors.New("database is full")
-	ErrMemoryExhausted        = errors.New("database memory exhausted")
-	ErrConnectionLimitReached = errors.New("connection limit reached")
-
-	// Query errors
-	ErrInvalidQuery   = errors.New("invalid SQL query")
-	ErrQueryTimeout   = errors.New("query execution timeout")
-	ErrQueryCancelled = errors.New("query was cancelled")
-	ErrTooManyResults = errors.New("query returned too many results")
-	ErrInvalidLimit   = errors.New("invalid query limit")
-	ErrInvalidOffset  = errors.New("invalid query offset")
-
-	// Schema errors
-	ErrSchemaVersion  = errors.New("unsupported database schema version")
-	ErrTableNotFound  = errors.New("database table not found")
-	ErrColumnNotFound = errors.New("database column not found")
-	ErrIndexNotFound  = errors.New("database index not found")
-
-	// Maintenance errors
-	ErrVacuumFailed    = errors.New("database vacuum failed")
-	ErrBackupFailed    = errors.New("database backup failed")
-	ErrRestoreFailed   = errors.New("database restore failed")
-	ErrMigrationFailed = errors.New("database migration failed")
+	// ErrLedgerNotFound is returned when a requested ledger is not stored.
+	ErrLedgerNotFound = errors.New("ledger not found")
 )
 
 // ErrorType represents different categories of database errors
@@ -94,22 +44,16 @@ const (
 	ErrorTypeConnection
 	ErrorTypeTransaction
 	ErrorTypeData
-	ErrorTypeConstraint
-	ErrorTypeResource
 	ErrorTypeQuery
 	ErrorTypeSchema
-	ErrorTypeMaintenance
 )
 
 // DatabaseError provides detailed information about database errors
 type DatabaseError struct {
-	Type      ErrorType      `json:"type"`
-	Operation string         `json:"operation"`
-	Message   string         `json:"message"`
-	Cause     error          `json:"cause,omitempty"`
-	Code      string         `json:"code,omitempty"`
-	Details   map[string]any `json:"details,omitempty"`
-	Retryable bool           `json:"retryable"`
+	Type      ErrorType `json:"type"`
+	Operation string    `json:"operation"`
+	Message   string    `json:"message"`
+	Cause     error     `json:"cause,omitempty"`
 }
 
 // Error implements the error interface
@@ -125,55 +69,6 @@ func (e *DatabaseError) Unwrap() error {
 	return e.Cause
 }
 
-// Is reports whether any error in err's chain matches target
-func (e *DatabaseError) Is(target error) bool {
-	if target == nil {
-		return false
-	}
-
-	// Check if target is a DatabaseError with the same message
-	if dbErr, ok := target.(*DatabaseError); ok {
-		return e.Message == dbErr.Message && e.Type == dbErr.Type
-	}
-
-	switch target {
-	case ErrLedgerNotFound:
-		return e.Type == ErrorTypeData && e.Code == "LEDGER_NOT_FOUND"
-	case ErrTransactionNotFound:
-		return e.Type == ErrorTypeData && e.Code == "TRANSACTION_NOT_FOUND"
-	case ErrConnectionFailed:
-		return e.Type == ErrorTypeConnection && e.Code == "CONNECTION_FAILED"
-	case ErrTransactionClosed:
-		return e.Type == ErrorTypeTransaction && e.Code == "TRANSACTION_CLOSED"
-	case ErrDuplicateEntry:
-		return e.Type == ErrorTypeConstraint && e.Code == "DUPLICATE_ENTRY"
-	case ErrInsufficientSpace:
-		return e.Type == ErrorTypeResource && e.Code == "INSUFFICIENT_SPACE"
-	}
-
-	return false
-}
-
-// WithDetail adds a detail to the error
-func (e *DatabaseError) WithDetail(key string, value any) *DatabaseError {
-	if e.Details == nil {
-		e.Details = make(map[string]any)
-	}
-	e.Details[key] = value
-	return e
-}
-
-// WithCode sets the error code
-func (e *DatabaseError) WithCode(code string) *DatabaseError {
-	e.Code = code
-	return e
-}
-
-// IsRetryable returns whether the error is retryable
-func (e *DatabaseError) IsRetryable() bool {
-	return e.Retryable
-}
-
 // NewDatabaseError creates a new DatabaseError
 func NewDatabaseError(errorType ErrorType, operation, message string, cause error) *DatabaseError {
 	return &DatabaseError{
@@ -181,7 +76,6 @@ func NewDatabaseError(errorType ErrorType, operation, message string, cause erro
 		Operation: operation,
 		Message:   message,
 		Cause:     cause,
-		Retryable: isRetryableError(errorType, cause),
 	}
 }
 
@@ -213,61 +107,4 @@ func NewQueryError(operation, message string, cause error) *DatabaseError {
 // NewSchemaError creates a schema error
 func NewSchemaError(operation, message string, cause error) *DatabaseError {
 	return NewDatabaseError(ErrorTypeSchema, operation, message, cause)
-}
-
-// isRetryableError determines if an error is retryable based on its type and cause
-func isRetryableError(errorType ErrorType, cause error) bool {
-	switch errorType {
-	case ErrorTypeConnection:
-		return true // Connection errors are usually retryable
-	case ErrorTypeTransaction:
-		if cause != nil {
-			errStr := cause.Error()
-			// Common retryable transaction errors
-			if contains(errStr, "deadlock") || contains(errStr, "timeout") ||
-				contains(errStr, "connection") || contains(errStr, "temporary") {
-				return true
-			}
-		}
-		return false
-	case ErrorTypeResource:
-		// Some resource errors might be temporary
-		if cause != nil {
-			errStr := cause.Error()
-			if contains(errStr, "temporary") || contains(errStr, "busy") {
-				return true
-			}
-		}
-		return false
-	case ErrorTypeQuery:
-		// Query timeouts might be retryable
-		if cause != nil {
-			errStr := cause.Error()
-			if contains(errStr, "timeout") || contains(errStr, "cancelled") {
-				return true
-			}
-		}
-		return false
-	default:
-		return false
-	}
-}
-
-// contains checks if a string contains a substring (case-insensitive)
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) &&
-		(s == substr ||
-			len(s) > len(substr) &&
-				(s[:len(substr)] == substr ||
-					s[len(s)-len(substr):] == substr ||
-					containsSubstring(s, substr)))
-}
-
-func containsSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/storage/relationaldb/interface.go
+++ b/storage/relationaldb/interface.go
@@ -159,7 +159,15 @@ type SystemRepository interface {
 	CloseTransactionDB(ctx context.Context) error
 }
 
-// TransactionContext represents a database transaction context with repository access
+// TransactionContext represents a database transaction context with repository access.
+//
+// Atomicity contract: Transaction() and AccountTransaction() are always bound
+// to the transaction. Ledger() is backend-dependent: PostgreSQL binds it to
+// the same transaction, but SQLite stores ledgers in a separate database file
+// and has no cross-database transactions, so the SQLite Ledger() repository
+// operates outside the transaction — its writes apply immediately and are NOT
+// rolled back. Callers needing atomic ledger writes must not rely on
+// WithTransaction for them on SQLite.
 type TransactionContext interface {
 	Commit(ctx context.Context) error
 	Rollback(ctx context.Context) error

--- a/storage/relationaldb/postgres/account_repository.go
+++ b/storage/relationaldb/postgres/account_repository.go
@@ -60,49 +60,14 @@ func (r *AccountTransactionRepository) GetAccountTransactionCount(ctx context.Co
 	return count, nil
 }
 
-// GetOldestAccountTxs returns an account's transactions oldest-first, filtered by options.
-func (r *AccountTransactionRepository) GetOldestAccountTxs(ctx context.Context, options relationaldb.AccountTxOptions) ([]relationaldb.TransactionInfo, error) {
-	// Build query based on rippled's getOldestAccountTxs logic
-	query := `SELECT t.trans_id, t.ledger_seq, t.status, t.raw_txn, t.txn_meta, at.txn_seq
-			  FROM account_transactions at
-			  INNER JOIN transactions t ON t.trans_id = at.trans_id
-			  WHERE at.account = $1`
+const accountTxSelect = `SELECT t.trans_id, t.ledger_seq, t.status, t.raw_txn, t.txn_meta, at.txn_seq
+		  FROM account_transactions at
+		  INNER JOIN transactions t ON t.trans_id = at.trans_id
+		  WHERE at.account = $1`
 
-	args := []any{options.Account.String()}
-	argCount := 1
-
-	if options.MinLedger > 0 {
-		argCount++
-		query += fmt.Sprintf(" AND at.ledger_seq >= $%d", argCount)
-		args = append(args, options.MinLedger)
-	}
-
-	if options.MaxLedger > 0 {
-		argCount++
-		query += fmt.Sprintf(" AND at.ledger_seq <= $%d", argCount)
-		args = append(args, options.MaxLedger)
-	}
-
-	query += " ORDER BY at.ledger_seq ASC, at.txn_seq ASC"
-
-	if !options.Unlimited && options.Limit > 0 {
-		argCount++
-		query += fmt.Sprintf(" LIMIT $%d", argCount)
-		args = append(args, options.Limit)
-
-		if options.Offset > 0 {
-			argCount++
-			query += fmt.Sprintf(" OFFSET $%d", argCount)
-			args = append(args, options.Offset)
-		}
-	}
-
-	rows, err := r.getExecutor().QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, relationaldb.NewQueryError("get_oldest_account_txs", "failed to query account transactions", err)
-	}
-	defer rows.Close()
-
+// scanAccountTxRows drains rows into TransactionInfo values, stamping each
+// with the queried account.
+func scanAccountTxRows(rows *sql.Rows, opName string, account relationaldb.AccountID) ([]relationaldb.TransactionInfo, error) {
 	var results []relationaldb.TransactionInfo
 
 	for rows.Next() {
@@ -111,11 +76,11 @@ func (r *AccountTransactionRepository) GetOldestAccountTxs(ctx context.Context, 
 		var txnMeta sql.NullString
 
 		if err := rows.Scan(&hashBytes, &info.LedgerSeq, &info.Status, &info.RawTxn, &txnMeta, &info.TxnSeq); err != nil {
-			return nil, relationaldb.NewQueryError("get_oldest_account_txs", "failed to scan row", err)
+			return nil, relationaldb.NewQueryError(opName, "failed to scan row", err)
 		}
 
 		copy(info.Hash[:], hashBytes)
-		copy(info.Account[:], options.Account[:])
+		copy(info.Account[:], account[:])
 		if txnMeta.Valid {
 			info.TxnMeta = []byte(txnMeta.String)
 		}
@@ -123,265 +88,129 @@ func (r *AccountTransactionRepository) GetOldestAccountTxs(ctx context.Context, 
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, relationaldb.NewQueryError("get_oldest_account_txs", "error iterating rows", err)
+		return nil, relationaldb.NewQueryError(opName, "error iterating rows", err)
+	}
+	return results, nil
+}
+
+func (r *AccountTransactionRepository) queryAccountTxs(ctx context.Context, opName string, options relationaldb.AccountTxOptions, orderDir string) ([]relationaldb.TransactionInfo, error) {
+	query := accountTxSelect
+	args := []any{options.Account.String()}
+
+	if options.MinLedger > 0 {
+		args = append(args, options.MinLedger)
+		query += fmt.Sprintf(" AND at.ledger_seq >= $%d", len(args))
 	}
 
-	return results, nil
+	if options.MaxLedger > 0 {
+		args = append(args, options.MaxLedger)
+		query += fmt.Sprintf(" AND at.ledger_seq <= $%d", len(args))
+	}
+
+	query += " ORDER BY at.ledger_seq " + orderDir + ", at.txn_seq " + orderDir
+
+	if !options.Unlimited && options.Limit > 0 {
+		args = append(args, options.Limit)
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+
+		if options.Offset > 0 {
+			args = append(args, options.Offset)
+			query += fmt.Sprintf(" OFFSET $%d", len(args))
+		}
+	}
+
+	rows, err := r.getExecutor().QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, relationaldb.NewQueryError(opName, "failed to query account transactions", err)
+	}
+	defer rows.Close()
+
+	return scanAccountTxRows(rows, opName, options.Account)
+}
+
+// GetOldestAccountTxs returns an account's transactions oldest-first, filtered by options.
+func (r *AccountTransactionRepository) GetOldestAccountTxs(ctx context.Context, options relationaldb.AccountTxOptions) ([]relationaldb.TransactionInfo, error) {
+	return r.queryAccountTxs(ctx, "get_oldest_account_txs", options, "ASC")
 }
 
 // GetNewestAccountTxs returns an account's transactions newest-first, filtered by options.
 func (r *AccountTransactionRepository) GetNewestAccountTxs(ctx context.Context, options relationaldb.AccountTxOptions) ([]relationaldb.TransactionInfo, error) {
-	// Same as GetOldestAccountTxs but with DESC order
-	query := `SELECT t.trans_id, t.ledger_seq, t.status, t.raw_txn, t.txn_meta, at.txn_seq
-			  FROM account_transactions at
-			  INNER JOIN transactions t ON t.trans_id = at.trans_id
-			  WHERE at.account = $1`
+	return r.queryAccountTxs(ctx, "get_newest_account_txs", options, "DESC")
+}
 
+func (r *AccountTransactionRepository) queryAccountTxsPage(ctx context.Context, opName string, options relationaldb.AccountTxPageOptions, orderDir string, markerCmp string) (*relationaldb.AccountTxResult, error) {
+	query := accountTxSelect
 	args := []any{options.Account.String()}
-	argCount := 1
 
 	if options.MinLedger > 0 {
-		argCount++
-		query += fmt.Sprintf(" AND at.ledger_seq >= $%d", argCount)
 		args = append(args, options.MinLedger)
+		query += fmt.Sprintf(" AND at.ledger_seq >= $%d", len(args))
 	}
 
 	if options.MaxLedger > 0 {
-		argCount++
-		query += fmt.Sprintf(" AND at.ledger_seq <= $%d", argCount)
 		args = append(args, options.MaxLedger)
+		query += fmt.Sprintf(" AND at.ledger_seq <= $%d", len(args))
 	}
 
-	query += " ORDER BY at.ledger_seq DESC, at.txn_seq DESC"
-
-	if !options.Unlimited && options.Limit > 0 {
-		argCount++
-		query += fmt.Sprintf(" LIMIT $%d", argCount)
-		args = append(args, options.Limit)
-
-		if options.Offset > 0 {
-			argCount++
-			query += fmt.Sprintf(" OFFSET $%d", argCount)
-			args = append(args, options.Offset)
-		}
+	// Marker-based pagination: for ASC pages resume after the marker (>),
+	// for DESC pages resume before it (<).
+	if options.Marker != nil {
+		args = append(args, options.Marker.LedgerSeq, options.Marker.TxnSeq)
+		seqArg, txnArg := len(args)-1, len(args)
+		query += fmt.Sprintf(" AND (at.ledger_seq %s $%d OR (at.ledger_seq = $%d AND at.txn_seq %s $%d))",
+			markerCmp, seqArg, seqArg, markerCmp, txnArg)
 	}
+
+	query += " ORDER BY at.ledger_seq " + orderDir + ", at.txn_seq " + orderDir
+
+	// Fetch one extra to determine if there are more results
+	args = append(args, options.Limit+1)
+	query += fmt.Sprintf(" LIMIT $%d", len(args))
 
 	rows, err := r.getExecutor().QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, relationaldb.NewQueryError("get_newest_account_txs", "failed to query account transactions", err)
+		return nil, relationaldb.NewQueryError(opName, "failed to query account transactions", err)
 	}
 	defer rows.Close()
 
-	var results []relationaldb.TransactionInfo
-
-	for rows.Next() {
-		var info relationaldb.TransactionInfo
-		var hashBytes []byte
-		var txnMeta sql.NullString
-
-		if err := rows.Scan(&hashBytes, &info.LedgerSeq, &info.Status, &info.RawTxn, &txnMeta, &info.TxnSeq); err != nil {
-			return nil, relationaldb.NewQueryError("get_newest_account_txs", "failed to scan row", err)
-		}
-
-		copy(info.Hash[:], hashBytes)
-		copy(info.Account[:], options.Account[:])
-		if txnMeta.Valid {
-			info.TxnMeta = []byte(txnMeta.String)
-		}
-		results = append(results, info)
+	transactions, err := scanAccountTxRows(rows, opName, options.Account)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := rows.Err(); err != nil {
-		return nil, relationaldb.NewQueryError("get_newest_account_txs", "error iterating rows", err)
+	result := &relationaldb.AccountTxResult{
+		LedgerRange: relationaldb.LedgerRange{
+			Min: options.MinLedger,
+			Max: options.MaxLedger,
+		},
+		Limit: options.Limit,
 	}
 
-	return results, nil
+	// Check if there are more results
+	if len(transactions) > int(options.Limit) {
+		// Remove the extra transaction and set marker
+		transactions = transactions[:options.Limit]
+		lastTx := transactions[len(transactions)-1]
+		result.Marker = &relationaldb.AccountTxMarker{
+			LedgerSeq: lastTx.LedgerSeq,
+			TxnSeq:    lastTx.TxnSeq,
+		}
+	}
+
+	result.Transactions = transactions
+	return result, nil
 }
 
 // GetOldestAccountTxsPage returns a marker-paginated page of an account's
 // transactions, oldest-first.
 func (r *AccountTransactionRepository) GetOldestAccountTxsPage(ctx context.Context, options relationaldb.AccountTxPageOptions) (*relationaldb.AccountTxResult, error) {
-	// Build paginated query with marker support (based on rippled's implementation)
-	query := `SELECT t.trans_id, t.ledger_seq, t.status, t.raw_txn, t.txn_meta, at.txn_seq
-			  FROM account_transactions at
-			  INNER JOIN transactions t ON t.trans_id = at.trans_id
-			  WHERE at.account = $1`
-
-	args := []any{options.Account.String()}
-	argCount := 1
-
-	if options.MinLedger > 0 {
-		argCount++
-		query += fmt.Sprintf(" AND at.ledger_seq >= $%d", argCount)
-		args = append(args, options.MinLedger)
-	}
-
-	if options.MaxLedger > 0 {
-		argCount++
-		query += fmt.Sprintf(" AND at.ledger_seq <= $%d", argCount)
-		args = append(args, options.MaxLedger)
-	}
-
-	// Add marker-based pagination
-	if options.Marker != nil {
-		argCount++
-		query += fmt.Sprintf(" AND (at.ledger_seq > $%d OR (at.ledger_seq = $%d AND at.txn_seq > $%d))",
-			argCount, argCount, argCount+1)
-		args = append(args, options.Marker.LedgerSeq, options.Marker.TxnSeq)
-		argCount++
-	}
-
-	query += " ORDER BY at.ledger_seq ASC, at.txn_seq ASC"
-
-	// Fetch one extra to determine if there are more results
-	limit := options.Limit + 1
-	argCount++
-	query += fmt.Sprintf(" LIMIT $%d", argCount)
-	args = append(args, limit)
-
-	rows, err := r.getExecutor().QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, relationaldb.NewQueryError("get_oldest_account_txs_page", "failed to query account transactions", err)
-	}
-	defer rows.Close()
-
-	var transactions []relationaldb.TransactionInfo
-
-	for rows.Next() {
-		var info relationaldb.TransactionInfo
-		var hashBytes []byte
-		var txnMeta sql.NullString
-
-		if err := rows.Scan(&hashBytes, &info.LedgerSeq, &info.Status, &info.RawTxn, &txnMeta, &info.TxnSeq); err != nil {
-			return nil, relationaldb.NewQueryError("get_oldest_account_txs_page", "failed to scan row", err)
-		}
-
-		copy(info.Hash[:], hashBytes)
-		copy(info.Account[:], options.Account[:])
-		if txnMeta.Valid {
-			info.TxnMeta = []byte(txnMeta.String)
-		}
-		transactions = append(transactions, info)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, relationaldb.NewQueryError("get_oldest_account_txs_page", "error iterating rows", err)
-	}
-
-	result := &relationaldb.AccountTxResult{
-		LedgerRange: relationaldb.LedgerRange{
-			Min: options.MinLedger,
-			Max: options.MaxLedger,
-		},
-		Limit: options.Limit,
-	}
-
-	// Check if there are more results
-	if len(transactions) > int(options.Limit) {
-		// Remove the extra transaction and set marker
-		transactions = transactions[:options.Limit]
-		lastTx := transactions[len(transactions)-1]
-		result.Marker = &relationaldb.AccountTxMarker{
-			LedgerSeq: lastTx.LedgerSeq,
-			TxnSeq:    lastTx.TxnSeq,
-		}
-	}
-
-	result.Transactions = transactions
-	return result, nil
+	return r.queryAccountTxsPage(ctx, "get_oldest_account_txs_page", options, "ASC", ">")
 }
 
 // GetNewestAccountTxsPage returns a marker-paginated page of an account's
 // transactions, newest-first.
 func (r *AccountTransactionRepository) GetNewestAccountTxsPage(ctx context.Context, options relationaldb.AccountTxPageOptions) (*relationaldb.AccountTxResult, error) {
-	// Similar to GetOldestAccountTxsPage but with DESC order and reverse marker logic
-	query := `SELECT t.trans_id, t.ledger_seq, t.status, t.raw_txn, t.txn_meta, at.txn_seq
-			  FROM account_transactions at
-			  INNER JOIN transactions t ON t.trans_id = at.trans_id
-			  WHERE at.account = $1`
-
-	args := []any{options.Account.String()}
-	argCount := 1
-
-	if options.MinLedger > 0 {
-		argCount++
-		query += fmt.Sprintf(" AND at.ledger_seq >= $%d", argCount)
-		args = append(args, options.MinLedger)
-	}
-
-	if options.MaxLedger > 0 {
-		argCount++
-		query += fmt.Sprintf(" AND at.ledger_seq <= $%d", argCount)
-		args = append(args, options.MaxLedger)
-	}
-
-	// Add marker-based pagination (reverse logic for DESC order)
-	if options.Marker != nil {
-		argCount++
-		query += fmt.Sprintf(" AND (at.ledger_seq < $%d OR (at.ledger_seq = $%d AND at.txn_seq < $%d))",
-			argCount, argCount, argCount+1)
-		args = append(args, options.Marker.LedgerSeq, options.Marker.TxnSeq)
-		argCount++
-	}
-
-	query += " ORDER BY at.ledger_seq DESC, at.txn_seq DESC"
-
-	// Fetch one extra to determine if there are more results
-	limit := options.Limit + 1
-	argCount++
-	query += fmt.Sprintf(" LIMIT $%d", argCount)
-	args = append(args, limit)
-
-	rows, err := r.getExecutor().QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, relationaldb.NewQueryError("get_newest_account_txs_page", "failed to query account transactions", err)
-	}
-	defer rows.Close()
-
-	var transactions []relationaldb.TransactionInfo
-
-	for rows.Next() {
-		var info relationaldb.TransactionInfo
-		var hashBytes []byte
-		var txnMeta sql.NullString
-
-		if err := rows.Scan(&hashBytes, &info.LedgerSeq, &info.Status, &info.RawTxn, &txnMeta, &info.TxnSeq); err != nil {
-			return nil, relationaldb.NewQueryError("get_newest_account_txs_page", "failed to scan row", err)
-		}
-
-		copy(info.Hash[:], hashBytes)
-		copy(info.Account[:], options.Account[:])
-		if txnMeta.Valid {
-			info.TxnMeta = []byte(txnMeta.String)
-		}
-		transactions = append(transactions, info)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, relationaldb.NewQueryError("get_newest_account_txs_page", "error iterating rows", err)
-	}
-
-	result := &relationaldb.AccountTxResult{
-		LedgerRange: relationaldb.LedgerRange{
-			Min: options.MinLedger,
-			Max: options.MaxLedger,
-		},
-		Limit: options.Limit,
-	}
-
-	// Check if there are more results
-	if len(transactions) > int(options.Limit) {
-		// Remove the extra transaction and set marker
-		transactions = transactions[:options.Limit]
-		lastTx := transactions[len(transactions)-1]
-		result.Marker = &relationaldb.AccountTxMarker{
-			LedgerSeq: lastTx.LedgerSeq,
-			TxnSeq:    lastTx.TxnSeq,
-		}
-	}
-
-	result.Transactions = transactions
-	return result, nil
+	return r.queryAccountTxsPage(ctx, "get_newest_account_txs_page", options, "DESC", "<")
 }
 
 // SaveAccountTransaction inserts or updates an account-transaction index entry.

--- a/storage/relationaldb/postgres/ledger_repository.go
+++ b/storage/relationaldb/postgres/ledger_repository.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strconv"
 	"time"
 
@@ -32,6 +33,43 @@ func (r *LedgerRepository) getExecutor() executor {
 		return r.tx
 	}
 	return r.db
+}
+
+const ledgerSelectCols = `ledger_hash, ledger_seq, prev_hash, account_set_hash, trans_set_hash,
+	total_coins, closing_time, prev_closing_time, close_time_res, close_flags`
+
+// scanLedgerInfo scans one ledgers row in ledgerSelectCols order. total_coins
+// is a DECIMAL scanned as a string; a malformed value is a returned error,
+// not a silent zero.
+func scanLedgerInfo(row relationaldb.RowScanner) (*relationaldb.LedgerInfo, error) {
+	var info relationaldb.LedgerInfo
+	var hashBytes, parentHashBytes, accountHashBytes, txHashBytes []byte
+	var totalCoinsStr string
+	var closingTime, prevClosingTime int64
+
+	err := row.Scan(
+		&hashBytes, &info.Sequence, &parentHashBytes, &accountHashBytes, &txHashBytes,
+		&totalCoinsStr, &closingTime, &prevClosingTime, &info.CloseTimeRes, &info.CloseFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	copy(info.Hash[:], hashBytes)
+	copy(info.ParentHash[:], parentHashBytes)
+	copy(info.AccountHash[:], accountHashBytes)
+	copy(info.TransactionHash[:], txHashBytes)
+
+	totalCoins, err := strconv.ParseInt(totalCoinsStr, 10, 64)
+	if err != nil {
+		return nil, relationaldb.NewDataError("scan_ledger_info", "malformed total_coins value", err)
+	}
+	info.TotalCoins = relationaldb.Amount(totalCoins)
+
+	// Convert rippled time format (seconds since 2000-01-01) to Go time
+	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC()
+	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
+
+	return &info, nil
 }
 
 // GetMinLedgerSeq returns the lowest ledger sequence stored, or nil if none.
@@ -68,192 +106,72 @@ func (r *LedgerRepository) GetMaxLedgerSeq(ctx context.Context) (*relationaldb.L
 
 // GetLedgerInfoBySeq returns the ledger header for the given sequence.
 func (r *LedgerRepository) GetLedgerInfoBySeq(ctx context.Context, seq relationaldb.LedgerIndex) (*relationaldb.LedgerInfo, error) {
-	query := `SELECT ledger_hash, ledger_seq, prev_hash, account_set_hash, trans_set_hash, 
-			  total_coins, closing_time, prev_closing_time, close_time_res, close_flags
-			  FROM ledgers WHERE ledger_seq = $1`
-
-	var info relationaldb.LedgerInfo
-	var hashBytes, parentHashBytes, accountHashBytes, txHashBytes []byte
-	var totalCoinsStr string
-	var closingTime, prevClosingTime int64
-
-	err := r.getExecutor().QueryRowContext(ctx, query, seq).Scan(
-		&hashBytes, &info.Sequence, &parentHashBytes, &accountHashBytes, &txHashBytes,
-		&totalCoinsStr, &closingTime, &prevClosingTime, &info.CloseTimeRes, &info.CloseFlags)
-
-	if err == sql.ErrNoRows {
+	query := `SELECT ` + ledgerSelectCols + ` FROM ledgers WHERE ledger_seq = $1`
+	row := r.getExecutor().QueryRowContext(ctx, query, seq)
+	info, err := scanLedgerInfo(row)
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, relationaldb.NewDataError("get_ledger_info_by_seq", "ledger not found", relationaldb.ErrLedgerNotFound)
 	}
 	if err != nil {
 		return nil, relationaldb.NewQueryError("get_ledger_info_by_seq", "failed to query ledger", err)
 	}
-
-	// Convert data to proper formats
-	copy(info.Hash[:], hashBytes)
-	copy(info.ParentHash[:], parentHashBytes)
-	copy(info.AccountHash[:], accountHashBytes)
-	copy(info.TransactionHash[:], txHashBytes)
-
-	// Parse total coins as decimal string to int64
-	if totalCoins, err := strconv.ParseInt(totalCoinsStr, 10, 64); err == nil {
-		info.TotalCoins = relationaldb.Amount(totalCoins)
-	}
-
-	// Convert rippled time format (seconds since 2000-01-01) to Go time
-	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC() // Add Ripple epoch offset
-	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
-
-	return &info, nil
+	return info, nil
 }
 
 // GetLedgerInfoByHash returns the ledger header for the given ledger hash.
 func (r *LedgerRepository) GetLedgerInfoByHash(ctx context.Context, hash relationaldb.Hash) (*relationaldb.LedgerInfo, error) {
-	query := `SELECT ledger_hash, ledger_seq, prev_hash, account_set_hash, trans_set_hash, 
-			  total_coins, closing_time, prev_closing_time, close_time_res, close_flags
-			  FROM ledgers WHERE ledger_hash = $1`
-
-	var info relationaldb.LedgerInfo
-	var hashBytes, parentHashBytes, accountHashBytes, txHashBytes []byte
-	var totalCoinsStr string
-	var closingTime, prevClosingTime int64
-
-	err := r.getExecutor().QueryRowContext(ctx, query, hash[:]).Scan(
-		&hashBytes, &info.Sequence, &parentHashBytes, &accountHashBytes, &txHashBytes,
-		&totalCoinsStr, &closingTime, &prevClosingTime, &info.CloseTimeRes, &info.CloseFlags)
-
-	if err == sql.ErrNoRows {
+	query := `SELECT ` + ledgerSelectCols + ` FROM ledgers WHERE ledger_hash = $1`
+	row := r.getExecutor().QueryRowContext(ctx, query, hash[:])
+	info, err := scanLedgerInfo(row)
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, relationaldb.NewDataError("get_ledger_info_by_hash", "ledger not found", relationaldb.ErrLedgerNotFound)
 	}
 	if err != nil {
 		return nil, relationaldb.NewQueryError("get_ledger_info_by_hash", "failed to query ledger", err)
 	}
-
-	// Convert data (same as GetLedgerInfoBySeq)
-	copy(info.Hash[:], hashBytes)
-	copy(info.ParentHash[:], parentHashBytes)
-	copy(info.AccountHash[:], accountHashBytes)
-	copy(info.TransactionHash[:], txHashBytes)
-
-	if totalCoins, err := strconv.ParseInt(totalCoinsStr, 10, 64); err == nil {
-		info.TotalCoins = relationaldb.Amount(totalCoins)
-	}
-
-	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC()
-	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
-
-	return &info, nil
+	return info, nil
 }
 
 // GetNewestLedgerInfo returns the most recent ledger header, or nil if none.
 func (r *LedgerRepository) GetNewestLedgerInfo(ctx context.Context) (*relationaldb.LedgerInfo, error) {
-	query := `SELECT ledger_hash, ledger_seq, prev_hash, account_set_hash, trans_set_hash, 
-			  total_coins, closing_time, prev_closing_time, close_time_res, close_flags
-			  FROM ledgers ORDER BY ledger_seq DESC LIMIT 1`
-
-	var info relationaldb.LedgerInfo
-	var hashBytes, parentHashBytes, accountHashBytes, txHashBytes []byte
-	var totalCoinsStr string
-	var closingTime, prevClosingTime int64
-
-	err := r.getExecutor().QueryRowContext(ctx, query).Scan(
-		&hashBytes, &info.Sequence, &parentHashBytes, &accountHashBytes, &txHashBytes,
-		&totalCoinsStr, &closingTime, &prevClosingTime, &info.CloseTimeRes, &info.CloseFlags)
-
-	if err == sql.ErrNoRows {
+	query := `SELECT ` + ledgerSelectCols + ` FROM ledgers ORDER BY ledger_seq DESC LIMIT 1`
+	row := r.getExecutor().QueryRowContext(ctx, query)
+	info, err := scanLedgerInfo(row)
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, relationaldb.NewQueryError("get_newest_ledger_info", "failed to query newest ledger", err)
 	}
-
-	// Convert data (same as above)
-	copy(info.Hash[:], hashBytes)
-	copy(info.ParentHash[:], parentHashBytes)
-	copy(info.AccountHash[:], accountHashBytes)
-	copy(info.TransactionHash[:], txHashBytes)
-
-	if totalCoins, err := strconv.ParseInt(totalCoinsStr, 10, 64); err == nil {
-		info.TotalCoins = relationaldb.Amount(totalCoins)
-	}
-
-	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC()
-	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
-
-	return &info, nil
+	return info, nil
 }
 
 // GetLimitedOldestLedgerInfo returns the oldest ledger header at or above minSeq.
 func (r *LedgerRepository) GetLimitedOldestLedgerInfo(ctx context.Context, minSeq relationaldb.LedgerIndex) (*relationaldb.LedgerInfo, error) {
-	query := `SELECT ledger_hash, ledger_seq, prev_hash, account_set_hash, trans_set_hash, 
-			  total_coins, closing_time, prev_closing_time, close_time_res, close_flags
-			  FROM ledgers WHERE ledger_seq >= $1 ORDER BY ledger_seq ASC LIMIT 1`
-
-	var info relationaldb.LedgerInfo
-	var hashBytes, parentHashBytes, accountHashBytes, txHashBytes []byte
-	var totalCoinsStr string
-	var closingTime, prevClosingTime int64
-
-	err := r.getExecutor().QueryRowContext(ctx, query, minSeq).Scan(
-		&hashBytes, &info.Sequence, &parentHashBytes, &accountHashBytes, &txHashBytes,
-		&totalCoinsStr, &closingTime, &prevClosingTime, &info.CloseTimeRes, &info.CloseFlags)
-
-	if err == sql.ErrNoRows {
+	query := `SELECT ` + ledgerSelectCols + ` FROM ledgers WHERE ledger_seq >= $1 ORDER BY ledger_seq ASC LIMIT 1`
+	row := r.getExecutor().QueryRowContext(ctx, query, minSeq)
+	info, err := scanLedgerInfo(row)
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, relationaldb.NewQueryError("get_limited_oldest_ledger_info", "failed to query oldest ledger with limit", err)
 	}
-
-	copy(info.Hash[:], hashBytes)
-	copy(info.ParentHash[:], parentHashBytes)
-	copy(info.AccountHash[:], accountHashBytes)
-	copy(info.TransactionHash[:], txHashBytes)
-
-	if totalCoins, err := strconv.ParseInt(totalCoinsStr, 10, 64); err == nil {
-		info.TotalCoins = relationaldb.Amount(totalCoins)
-	}
-
-	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC()
-	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
-
-	return &info, nil
+	return info, nil
 }
 
 // GetLimitedNewestLedgerInfo returns the newest ledger header at or above minSeq.
 func (r *LedgerRepository) GetLimitedNewestLedgerInfo(ctx context.Context, minSeq relationaldb.LedgerIndex) (*relationaldb.LedgerInfo, error) {
-	query := `SELECT ledger_hash, ledger_seq, prev_hash, account_set_hash, trans_set_hash, 
-			  total_coins, closing_time, prev_closing_time, close_time_res, close_flags
-			  FROM ledgers WHERE ledger_seq >= $1 ORDER BY ledger_seq DESC LIMIT 1`
-
-	var info relationaldb.LedgerInfo
-	var hashBytes, parentHashBytes, accountHashBytes, txHashBytes []byte
-	var totalCoinsStr string
-	var closingTime, prevClosingTime int64
-
-	err := r.getExecutor().QueryRowContext(ctx, query, minSeq).Scan(
-		&hashBytes, &info.Sequence, &parentHashBytes, &accountHashBytes, &txHashBytes,
-		&totalCoinsStr, &closingTime, &prevClosingTime, &info.CloseTimeRes, &info.CloseFlags)
-
-	if err == sql.ErrNoRows {
+	query := `SELECT ` + ledgerSelectCols + ` FROM ledgers WHERE ledger_seq >= $1 ORDER BY ledger_seq DESC LIMIT 1`
+	row := r.getExecutor().QueryRowContext(ctx, query, minSeq)
+	info, err := scanLedgerInfo(row)
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, relationaldb.NewQueryError("get_limited_newest_ledger_info", "failed to query newest ledger with limit", err)
 	}
-
-	copy(info.Hash[:], hashBytes)
-	copy(info.ParentHash[:], parentHashBytes)
-	copy(info.AccountHash[:], accountHashBytes)
-	copy(info.TransactionHash[:], txHashBytes)
-
-	if totalCoins, err := strconv.ParseInt(totalCoinsStr, 10, 64); err == nil {
-		info.TotalCoins = relationaldb.Amount(totalCoins)
-	}
-
-	info.CloseTime = time.Unix(closingTime+protocol.RippleEpochUnix, 0).UTC()
-	info.ParentCloseTime = time.Unix(prevClosingTime+protocol.RippleEpochUnix, 0).UTC()
-
-	return &info, nil
+	return info, nil
 }
 
 // GetHashByIndex returns the ledger hash at the given sequence.
@@ -261,7 +179,7 @@ func (r *LedgerRepository) GetHashByIndex(ctx context.Context, seq relationaldb.
 	var hashBytes []byte
 	err := r.getExecutor().QueryRowContext(ctx, "SELECT ledger_hash FROM ledgers WHERE ledger_seq = $1", seq).Scan(&hashBytes)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, relationaldb.NewDataError("get_hash_by_index", "ledger not found", relationaldb.ErrLedgerNotFound)
 	}
 	if err != nil {
@@ -279,7 +197,7 @@ func (r *LedgerRepository) GetHashesByIndex(ctx context.Context, seq relationald
 	err := r.getExecutor().QueryRowContext(ctx,
 		"SELECT ledger_hash, prev_hash FROM ledgers WHERE ledger_seq = $1", seq).Scan(&ledgerHashBytes, &parentHashBytes)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, relationaldb.NewDataError("get_hashes_by_index", "ledger not found", relationaldb.ErrLedgerNotFound)
 	}
 	if err != nil {
@@ -295,7 +213,7 @@ func (r *LedgerRepository) GetHashesByIndex(ctx context.Context, seq relationald
 // GetHashesByRange returns the ledger and parent hashes for every sequence in
 // [minSeq, maxSeq], keyed by sequence.
 func (r *LedgerRepository) GetHashesByRange(ctx context.Context, minSeq, maxSeq relationaldb.LedgerIndex) (map[relationaldb.LedgerIndex]relationaldb.LedgerHashPair, error) {
-	query := `SELECT ledger_seq, ledger_hash, prev_hash FROM ledgers 
+	query := `SELECT ledger_seq, ledger_hash, prev_hash FROM ledgers
 			  WHERE ledger_seq >= $1 AND ledger_seq <= $2 ORDER BY ledger_seq`
 
 	rows, err := r.getExecutor().QueryContext(ctx, query, minSeq, maxSeq)

--- a/storage/relationaldb/postgres/postgres_test.go
+++ b/storage/relationaldb/postgres/postgres_test.go
@@ -39,7 +39,7 @@ func setupTestDB(t *testing.T) *RepositoryManager {
 		t.Skipf("%s not set; skipping PostgreSQL integration tests", postgresDSNEnv)
 	}
 
-	cfg := relationaldb.PostgresConfig().WithConnectionString(dsn)
+	cfg := relationaldb.NewConfig().WithConnectionString(dsn)
 	rm, err := NewRepositoryManager(cfg)
 	if err != nil {
 		t.Fatalf("new repository manager: %v", err)

--- a/storage/relationaldb/postgres/repository_manager.go
+++ b/storage/relationaldb/postgres/repository_manager.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 	_ "github.com/lib/pq" // PostgreSQL driver
@@ -151,8 +152,7 @@ func (rm *RepositoryManager) WithTransaction(ctx context.Context, fn func(relati
 
 	if err := fn(tx); err != nil {
 		if rbErr := tx.Rollback(ctx); rbErr != nil {
-			// Log the rollback error but return the original error
-			return err
+			return errors.Join(err, rbErr)
 		}
 		return err
 	}

--- a/storage/relationaldb/postgres/transaction_repository.go
+++ b/storage/relationaldb/postgres/transaction_repository.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
@@ -73,7 +74,7 @@ func (r *TransactionRepository) GetTransaction(ctx context.Context, hash relatio
 	err := r.getExecutor().QueryRowContext(ctx, query, hash[:]).Scan(
 		&hashBytes, &info.LedgerSeq, &info.Status, &info.RawTxn, &txnMeta)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		if ledgerRange != nil {
 			// Check if all ledgers in range are present (rippled behavior)
 			var count int64

--- a/storage/relationaldb/postgres/transaction_repository.go
+++ b/storage/relationaldb/postgres/transaction_repository.go
@@ -76,12 +76,13 @@ func (r *TransactionRepository) GetTransaction(ctx context.Context, hash relatio
 
 	if errors.Is(err, sql.ErrNoRows) {
 		if ledgerRange != nil {
-			// Check if all ledgers in range are present (rippled behavior)
+			// Count distinct ledgers carrying a transaction in range (matches
+			// rippled's searched-all test), not ledger headers.
 			var count int64
-			countQuery := `SELECT COUNT(DISTINCT ledger_seq) FROM ledgers 
+			countQuery := `SELECT COUNT(DISTINCT ledger_seq) FROM transactions
 						   WHERE ledger_seq >= $1 AND ledger_seq <= $2`
 			if err := r.getExecutor().QueryRowContext(ctx, countQuery, ledgerRange.Min, ledgerRange.Max).Scan(&count); err != nil {
-				return nil, relationaldb.TxSearchUnknown, relationaldb.NewQueryError("get_transaction", "failed to count ledgers in range", err)
+				return nil, relationaldb.TxSearchUnknown, relationaldb.NewQueryError("get_transaction", "failed to count transactions in range", err)
 			}
 
 			expectedCount := int64(ledgerRange.Max - ledgerRange.Min + 1)

--- a/storage/relationaldb/postgres/validation_repository.go
+++ b/storage/relationaldb/postgres/validation_repository.go
@@ -3,9 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"time"
 
-	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
@@ -41,20 +39,6 @@ func (r *ValidationRepository) getExecutor() executor {
 const validationSelectCols = `ledger_seq, initial_seq, ledger_hash, node_pubkey,
 	sign_time, seen_time, flags, raw`
 
-func toXRPLEpochSeconds(t time.Time) int64 {
-	if t.IsZero() {
-		return 0
-	}
-	return t.Unix() - protocol.RippleEpochUnix
-}
-
-func fromXRPLEpochSeconds(s int64) time.Time {
-	if s == 0 {
-		return time.Time{}
-	}
-	return time.Unix(s+protocol.RippleEpochUnix, 0).UTC()
-}
-
 // Save inserts a validation record, ignoring duplicates (upsert on ledger_hash + node_pubkey).
 func (r *ValidationRepository) Save(ctx context.Context, v *relationaldb.ValidationRecord) error {
 	if v == nil {
@@ -68,7 +52,7 @@ func (r *ValidationRepository) Save(ctx context.Context, v *relationaldb.Validat
 		ON CONFLICT (ledger_hash, node_pubkey) DO NOTHING
 	`,
 		int64(v.LedgerSeq), int64(v.InitialSeq), v.LedgerHash[:], v.NodePubKey,
-		toXRPLEpochSeconds(v.SignTime), toXRPLEpochSeconds(v.SeenTime),
+		relationaldb.ToXRPLEpochSeconds(v.SignTime), relationaldb.ToXRPLEpochSeconds(v.SeenTime),
 		int64(v.Flags), v.Raw,
 	)
 	if err != nil {
@@ -108,30 +92,6 @@ func (r *ValidationRepository) SaveBatch(ctx context.Context, vs []*relationaldb
 	return nil
 }
 
-func (r *ValidationRepository) scanRow(row interface {
-	Scan(dest ...any) error
-}) (*relationaldb.ValidationRecord, error) {
-	var rec relationaldb.ValidationRecord
-	var ledgerSeq, initialSeq, signTime, seenTime int64
-	var flags int64
-	var ledgerHash []byte
-
-	if err := row.Scan(
-		&ledgerSeq, &initialSeq, &ledgerHash, &rec.NodePubKey,
-		&signTime, &seenTime, &flags, &rec.Raw,
-	); err != nil {
-		return nil, err
-	}
-
-	rec.LedgerSeq = relationaldb.LedgerIndex(ledgerSeq)
-	rec.InitialSeq = relationaldb.LedgerIndex(initialSeq)
-	copy(rec.LedgerHash[:], ledgerHash)
-	rec.SignTime = fromXRPLEpochSeconds(signTime)
-	rec.SeenTime = fromXRPLEpochSeconds(seenTime)
-	rec.Flags = uint32(flags)
-	return &rec, nil
-}
-
 // GetValidationsForLedger returns all validation records for the given ledger sequence.
 func (r *ValidationRepository) GetValidationsForLedger(ctx context.Context, seq relationaldb.LedgerIndex) ([]*relationaldb.ValidationRecord, error) {
 	rows, err := r.getExecutor().QueryContext(ctx,
@@ -143,7 +103,7 @@ func (r *ValidationRepository) GetValidationsForLedger(ctx context.Context, seq 
 
 	var result []*relationaldb.ValidationRecord
 	for rows.Next() {
-		rec, err := r.scanRow(rows)
+		rec, err := relationaldb.ScanValidationRecord(rows)
 		if err != nil {
 			return nil, relationaldb.NewQueryError("validation_get_for_ledger", "failed to scan row", err)
 		}
@@ -173,7 +133,7 @@ func (r *ValidationRepository) GetValidationsByValidator(ctx context.Context, no
 
 	var result []*relationaldb.ValidationRecord
 	for rows.Next() {
-		rec, err := r.scanRow(rows)
+		rec, err := relationaldb.ScanValidationRecord(rows)
 		if err != nil {
 			return nil, relationaldb.NewQueryError("validation_get_by_validator", "failed to scan row", err)
 		}

--- a/storage/relationaldb/sqlite/ledger_repository.go
+++ b/storage/relationaldb/sqlite/ledger_repository.go
@@ -3,16 +3,18 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
-// LedgerRepository is the SQLite-backed ledger repository.
+// LedgerRepository is the SQLite-backed ledger repository. It always operates
+// directly on ledger.db: SQLite has no cross-database transactions, so there
+// is no transaction-bound variant (see relationaldb.TransactionContext).
 type LedgerRepository struct {
 	db *sql.DB
-	tx *sql.Tx
 }
 
 // NewLedgerRepository creates a SQLite ledger repository.
@@ -20,17 +22,10 @@ func NewLedgerRepository(db *sql.DB) *LedgerRepository {
 	return &LedgerRepository{db: db}
 }
 
-func (r *LedgerRepository) getExecutor() executor {
-	if r.tx != nil {
-		return r.tx
-	}
-	return r.db
-}
-
 // GetMinLedgerSeq returns the lowest ledger sequence stored, or nil if none.
 func (r *LedgerRepository) GetMinLedgerSeq(ctx context.Context) (*relationaldb.LedgerIndex, error) {
 	var seq sql.NullInt64
-	err := r.getExecutor().QueryRowContext(ctx, "SELECT MIN(ledger_seq) FROM ledgers").Scan(&seq)
+	err := r.db.QueryRowContext(ctx, "SELECT MIN(ledger_seq) FROM ledgers").Scan(&seq)
 	if err != nil {
 		return nil, relationaldb.NewQueryError("get_min_ledger_seq", "failed to query min ledger sequence", err)
 	}
@@ -44,7 +39,7 @@ func (r *LedgerRepository) GetMinLedgerSeq(ctx context.Context) (*relationaldb.L
 // GetMaxLedgerSeq returns the highest ledger sequence stored, or nil if none.
 func (r *LedgerRepository) GetMaxLedgerSeq(ctx context.Context) (*relationaldb.LedgerIndex, error) {
 	var seq sql.NullInt64
-	err := r.getExecutor().QueryRowContext(ctx, "SELECT MAX(ledger_seq) FROM ledgers").Scan(&seq)
+	err := r.db.QueryRowContext(ctx, "SELECT MAX(ledger_seq) FROM ledgers").Scan(&seq)
 	if err != nil {
 		return nil, relationaldb.NewQueryError("get_max_ledger_seq", "failed to query max ledger sequence", err)
 	}
@@ -55,9 +50,7 @@ func (r *LedgerRepository) GetMaxLedgerSeq(ctx context.Context) (*relationaldb.L
 	return &result, nil
 }
 
-func (r *LedgerRepository) scanLedgerInfo(row interface {
-	Scan(dest ...any) error
-}) (*relationaldb.LedgerInfo, error) {
+func (r *LedgerRepository) scanLedgerInfo(row relationaldb.RowScanner) (*relationaldb.LedgerInfo, error) {
 	var info relationaldb.LedgerInfo
 	var hashBytes, parentHashBytes, accountHashBytes, txHashBytes []byte
 	var totalCoins int64
@@ -87,9 +80,9 @@ const ledgerSelectCols = `ledger_hash, ledger_seq, prev_hash, account_set_hash, 
 // GetLedgerInfoBySeq returns the ledger header for the given sequence.
 func (r *LedgerRepository) GetLedgerInfoBySeq(ctx context.Context, seq relationaldb.LedgerIndex) (*relationaldb.LedgerInfo, error) {
 	query := `SELECT ` + ledgerSelectCols + ` FROM ledgers WHERE ledger_seq = ?`
-	row := r.getExecutor().QueryRowContext(ctx, query, seq)
+	row := r.db.QueryRowContext(ctx, query, seq)
 	info, err := r.scanLedgerInfo(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, relationaldb.NewDataError("get_ledger_info_by_seq", "ledger not found", relationaldb.ErrLedgerNotFound)
 	}
 	if err != nil {
@@ -101,9 +94,9 @@ func (r *LedgerRepository) GetLedgerInfoBySeq(ctx context.Context, seq relationa
 // GetLedgerInfoByHash returns the ledger header for the given ledger hash.
 func (r *LedgerRepository) GetLedgerInfoByHash(ctx context.Context, hash relationaldb.Hash) (*relationaldb.LedgerInfo, error) {
 	query := `SELECT ` + ledgerSelectCols + ` FROM ledgers WHERE ledger_hash = ?`
-	row := r.getExecutor().QueryRowContext(ctx, query, hash[:])
+	row := r.db.QueryRowContext(ctx, query, hash[:])
 	info, err := r.scanLedgerInfo(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, relationaldb.NewDataError("get_ledger_info_by_hash", "ledger not found", relationaldb.ErrLedgerNotFound)
 	}
 	if err != nil {
@@ -115,9 +108,9 @@ func (r *LedgerRepository) GetLedgerInfoByHash(ctx context.Context, hash relatio
 // GetNewestLedgerInfo returns the most recent ledger header, or nil if none.
 func (r *LedgerRepository) GetNewestLedgerInfo(ctx context.Context) (*relationaldb.LedgerInfo, error) {
 	query := `SELECT ` + ledgerSelectCols + ` FROM ledgers ORDER BY ledger_seq DESC LIMIT 1`
-	row := r.getExecutor().QueryRowContext(ctx, query)
+	row := r.db.QueryRowContext(ctx, query)
 	info, err := r.scanLedgerInfo(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -129,9 +122,9 @@ func (r *LedgerRepository) GetNewestLedgerInfo(ctx context.Context) (*relational
 // GetLimitedOldestLedgerInfo returns the oldest ledger header at or above minSeq.
 func (r *LedgerRepository) GetLimitedOldestLedgerInfo(ctx context.Context, minSeq relationaldb.LedgerIndex) (*relationaldb.LedgerInfo, error) {
 	query := `SELECT ` + ledgerSelectCols + ` FROM ledgers WHERE ledger_seq >= ? ORDER BY ledger_seq ASC LIMIT 1`
-	row := r.getExecutor().QueryRowContext(ctx, query, minSeq)
+	row := r.db.QueryRowContext(ctx, query, minSeq)
 	info, err := r.scanLedgerInfo(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -143,9 +136,9 @@ func (r *LedgerRepository) GetLimitedOldestLedgerInfo(ctx context.Context, minSe
 // GetLimitedNewestLedgerInfo returns the newest ledger header at or above minSeq.
 func (r *LedgerRepository) GetLimitedNewestLedgerInfo(ctx context.Context, minSeq relationaldb.LedgerIndex) (*relationaldb.LedgerInfo, error) {
 	query := `SELECT ` + ledgerSelectCols + ` FROM ledgers WHERE ledger_seq >= ? ORDER BY ledger_seq DESC LIMIT 1`
-	row := r.getExecutor().QueryRowContext(ctx, query, minSeq)
+	row := r.db.QueryRowContext(ctx, query, minSeq)
 	info, err := r.scanLedgerInfo(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -157,8 +150,8 @@ func (r *LedgerRepository) GetLimitedNewestLedgerInfo(ctx context.Context, minSe
 // GetHashByIndex returns the ledger hash at the given sequence.
 func (r *LedgerRepository) GetHashByIndex(ctx context.Context, seq relationaldb.LedgerIndex) (*relationaldb.Hash, error) {
 	var hashBytes []byte
-	err := r.getExecutor().QueryRowContext(ctx, "SELECT ledger_hash FROM ledgers WHERE ledger_seq = ?", seq).Scan(&hashBytes)
-	if err == sql.ErrNoRows {
+	err := r.db.QueryRowContext(ctx, "SELECT ledger_hash FROM ledgers WHERE ledger_seq = ?", seq).Scan(&hashBytes)
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, relationaldb.NewDataError("get_hash_by_index", "ledger not found", relationaldb.ErrLedgerNotFound)
 	}
 	if err != nil {
@@ -172,9 +165,9 @@ func (r *LedgerRepository) GetHashByIndex(ctx context.Context, seq relationaldb.
 // GetHashesByIndex returns the ledger hash and its parent hash at the given sequence.
 func (r *LedgerRepository) GetHashesByIndex(ctx context.Context, seq relationaldb.LedgerIndex) (*relationaldb.LedgerHashPair, error) {
 	var ledgerHashBytes, parentHashBytes []byte
-	err := r.getExecutor().QueryRowContext(ctx,
+	err := r.db.QueryRowContext(ctx,
 		"SELECT ledger_hash, prev_hash FROM ledgers WHERE ledger_seq = ?", seq).Scan(&ledgerHashBytes, &parentHashBytes)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, relationaldb.NewDataError("get_hashes_by_index", "ledger not found", relationaldb.ErrLedgerNotFound)
 	}
 	if err != nil {
@@ -192,7 +185,7 @@ func (r *LedgerRepository) GetHashesByRange(ctx context.Context, minSeq, maxSeq 
 	query := `SELECT ledger_seq, ledger_hash, prev_hash FROM ledgers
 			  WHERE ledger_seq >= ? AND ledger_seq <= ? ORDER BY ledger_seq`
 
-	rows, err := r.getExecutor().QueryContext(ctx, query, minSeq, maxSeq)
+	rows, err := r.db.QueryContext(ctx, query, minSeq, maxSeq)
 	if err != nil {
 		return nil, relationaldb.NewQueryError("get_hashes_by_range", "failed to query ledger hashes", err)
 	}
@@ -235,7 +228,7 @@ func (r *LedgerRepository) SaveValidatedLedger(ctx context.Context, ledger *rela
 			  close_time_res = excluded.close_time_res,
 			  close_flags = excluded.close_flags`
 
-	_, err := r.getExecutor().ExecContext(ctx, query,
+	_, err := r.db.ExecContext(ctx, query,
 		ledger.Hash[:], ledger.Sequence, ledger.ParentHash[:], ledger.AccountHash[:], ledger.TransactionHash[:],
 		int64(ledger.TotalCoins), closingTime, prevClosingTime, ledger.CloseTimeRes, ledger.CloseFlags)
 	if err != nil {
@@ -246,7 +239,7 @@ func (r *LedgerRepository) SaveValidatedLedger(ctx context.Context, ledger *rela
 
 // DeleteLedgersBySeq deletes all ledgers at or below maxSeq.
 func (r *LedgerRepository) DeleteLedgersBySeq(ctx context.Context, maxSeq relationaldb.LedgerIndex) error {
-	_, err := r.getExecutor().ExecContext(ctx, "DELETE FROM ledgers WHERE ledger_seq <= ?", maxSeq)
+	_, err := r.db.ExecContext(ctx, "DELETE FROM ledgers WHERE ledger_seq <= ?", maxSeq)
 	if err != nil {
 		return relationaldb.NewQueryError("delete_ledgers_by_seq", "failed to delete ledgers", err)
 	}
@@ -258,7 +251,7 @@ func (r *LedgerRepository) GetLedgerCountMinMax(ctx context.Context) (*relationa
 	var count int64
 	var minSeq, maxSeq sql.NullInt64
 
-	err := r.getExecutor().QueryRowContext(ctx,
+	err := r.db.QueryRowContext(ctx,
 		`SELECT COUNT(*), MIN(ledger_seq), MAX(ledger_seq) FROM ledgers`).Scan(&count, &minSeq, &maxSeq)
 	if err != nil {
 		return nil, relationaldb.NewQueryError("get_ledger_count_min_max", "failed to query ledger statistics", err)
@@ -277,10 +270,10 @@ func (r *LedgerRepository) GetLedgerCountMinMax(ctx context.Context) (*relationa
 // GetKBUsedLedger returns the on-disk size of the ledger database in KB.
 func (r *LedgerRepository) GetKBUsedLedger(ctx context.Context) (uint32, error) {
 	var pageCount, pageSize int64
-	if err := r.getExecutor().QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
+	if err := r.db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
 		return 0, relationaldb.NewQueryError("get_kb_used_ledger", "failed to get page count", err)
 	}
-	if err := r.getExecutor().QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize); err != nil {
+	if err := r.db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize); err != nil {
 		return 0, relationaldb.NewQueryError("get_kb_used_ledger", "failed to get page size", err)
 	}
 	return uint32(pageCount * pageSize / 1024), nil

--- a/storage/relationaldb/sqlite/repository_manager.go
+++ b/storage/relationaldb/sqlite/repository_manager.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -98,7 +99,7 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 	}
 
 	rm.ledgerRepo = NewLedgerRepository(rm.ledgerDB)
-	rm.transactionRepo = NewTransactionRepository(rm.txDB)
+	rm.transactionRepo = NewTransactionRepository(rm.txDB, rm.ledgerDB)
 	rm.accountTransactionRepo = NewAccountTransactionRepository(rm.txDB)
 	rm.systemRepo = NewSystemRepository(rm.ledgerDB, rm.txDB)
 	rm.validationRepo = NewValidationRepository(rm.ledgerDB)
@@ -169,8 +170,13 @@ func (rm *RepositoryManager) Amendment() relationaldb.AmendmentVoteRepository {
 	return rm.amendmentVoteRepo
 }
 
-// WithTransaction runs fn inside a transaction-database transaction, committing on
-// success and rolling back on error.
+// WithTransaction runs fn inside a transaction-database transaction, committing
+// on success and rolling back on error. Only the Transaction and
+// AccountTransaction repositories are transactional: the ledger repository
+// operates on the separate ledger.db outside the transaction (SQLite has no
+// cross-database transactions), so ledger writes made through the context are
+// applied immediately and are not rolled back. See
+// relationaldb.TransactionContext for the contract.
 func (rm *RepositoryManager) WithTransaction(ctx context.Context, fn func(relationaldb.TransactionContext) error) error {
 	tx, err := rm.txDB.BeginTx(ctx, nil)
 	if err != nil {
@@ -188,7 +194,7 @@ func (rm *RepositoryManager) WithTransaction(ctx context.Context, fn func(relati
 
 	if err := fn(tc); err != nil {
 		if rbErr := tc.Rollback(ctx); rbErr != nil {
-			return err
+			return errors.Join(err, rbErr)
 		}
 		return err
 	}

--- a/storage/relationaldb/sqlite/repository_manager.go
+++ b/storage/relationaldb/sqlite/repository_manager.go
@@ -99,7 +99,7 @@ func (rm *RepositoryManager) Open(ctx context.Context) error {
 	}
 
 	rm.ledgerRepo = NewLedgerRepository(rm.ledgerDB)
-	rm.transactionRepo = NewTransactionRepository(rm.txDB, rm.ledgerDB)
+	rm.transactionRepo = NewTransactionRepository(rm.txDB)
 	rm.accountTransactionRepo = NewAccountTransactionRepository(rm.txDB)
 	rm.systemRepo = NewSystemRepository(rm.ledgerDB, rm.txDB)
 	rm.validationRepo = NewValidationRepository(rm.ledgerDB)

--- a/storage/relationaldb/sqlite/sqlite_test.go
+++ b/storage/relationaldb/sqlite/sqlite_test.go
@@ -299,14 +299,21 @@ func TestTransactionCRUD(t *testing.T) {
 }
 
 // TestTransactionRangeSearch verifies the "searched all/some" semantics on a
-// miss: the ledger count must run against ledger.db even though transactions
-// live in transaction.db.
+// miss: the count of distinct ledgers carrying a transaction in range, matching
+// rippled (COUNT(DISTINCT ledger_seq) FROM transactions).
 func TestTransactionRangeSearch(t *testing.T) {
 	rm := setupTestDB(t)
 	ctx := context.Background()
 
+	// One transaction in each of ledgers 1..5.
 	for i := uint32(1); i <= 5; i++ {
-		if err := rm.Ledger().SaveValidatedLedger(ctx, makeLedgerInfo(i), false); err != nil {
+		txInfo := &relationaldb.TransactionInfo{
+			LedgerSeq: relationaldb.LedgerIndex(i),
+			Status:    "validated",
+			RawTxn:    []byte("raw"),
+		}
+		txInfo.Hash[0] = byte(i)
+		if err := rm.Transaction().SaveTransaction(ctx, txInfo); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -314,7 +321,7 @@ func TestTransactionRangeSearch(t *testing.T) {
 	var missingHash relationaldb.Hash
 	missingHash[0] = 0xFF
 
-	// Complete range present → TxSearchAll.
+	// Every ledger in range carries a transaction → TxSearchAll.
 	_, sr, err := rm.Transaction().GetTransaction(ctx, missingHash, &relationaldb.LedgerRange{Min: 1, Max: 5})
 	if err != nil {
 		t.Fatal(err)
@@ -323,7 +330,7 @@ func TestTransactionRangeSearch(t *testing.T) {
 		t.Fatalf("expected TxSearchAll, got %d", sr)
 	}
 
-	// Range with gaps → TxSearchSome.
+	// Range extends past the transactions present → TxSearchSome.
 	_, sr, err = rm.Transaction().GetTransaction(ctx, missingHash, &relationaldb.LedgerRange{Min: 1, Max: 10})
 	if err != nil {
 		t.Fatal(err)
@@ -332,8 +339,7 @@ func TestTransactionRangeSearch(t *testing.T) {
 		t.Fatalf("expected TxSearchSome, got %d", sr)
 	}
 
-	// The range search must also work from inside a transaction context,
-	// where the ledger query crosses to the non-transactional ledger.db.
+	// The range count must also work from inside a transaction context.
 	err = rm.WithTransaction(ctx, func(tc relationaldb.TransactionContext) error {
 		_, sr, err := tc.Transaction().GetTransaction(ctx, missingHash, &relationaldb.LedgerRange{Min: 1, Max: 5})
 		if err != nil {

--- a/storage/relationaldb/sqlite/sqlite_test.go
+++ b/storage/relationaldb/sqlite/sqlite_test.go
@@ -298,6 +298,57 @@ func TestTransactionCRUD(t *testing.T) {
 	}
 }
 
+// TestTransactionRangeSearch verifies the "searched all/some" semantics on a
+// miss: the ledger count must run against ledger.db even though transactions
+// live in transaction.db.
+func TestTransactionRangeSearch(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	for i := uint32(1); i <= 5; i++ {
+		if err := rm.Ledger().SaveValidatedLedger(ctx, makeLedgerInfo(i), false); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var missingHash relationaldb.Hash
+	missingHash[0] = 0xFF
+
+	// Complete range present → TxSearchAll.
+	_, sr, err := rm.Transaction().GetTransaction(ctx, missingHash, &relationaldb.LedgerRange{Min: 1, Max: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sr != relationaldb.TxSearchAll {
+		t.Fatalf("expected TxSearchAll, got %d", sr)
+	}
+
+	// Range with gaps → TxSearchSome.
+	_, sr, err = rm.Transaction().GetTransaction(ctx, missingHash, &relationaldb.LedgerRange{Min: 1, Max: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sr != relationaldb.TxSearchSome {
+		t.Fatalf("expected TxSearchSome, got %d", sr)
+	}
+
+	// The range search must also work from inside a transaction context,
+	// where the ledger query crosses to the non-transactional ledger.db.
+	err = rm.WithTransaction(ctx, func(tc relationaldb.TransactionContext) error {
+		_, sr, err := tc.Transaction().GetTransaction(ctx, missingHash, &relationaldb.LedgerRange{Min: 1, Max: 5})
+		if err != nil {
+			return err
+		}
+		if sr != relationaldb.TxSearchAll {
+			t.Fatalf("expected TxSearchAll inside transaction, got %d", sr)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestTransactionHistory(t *testing.T) {
 	rm := setupTestDB(t)
 	ctx := context.Background()

--- a/storage/relationaldb/sqlite/transaction_context.go
+++ b/storage/relationaldb/sqlite/transaction_context.go
@@ -25,7 +25,7 @@ func NewTransactionContext(tx *sql.Tx, ledgerDB *sql.DB) *TransactionContext {
 	return &TransactionContext{
 		tx:                     tx,
 		ledgerRepo:             NewLedgerRepository(ledgerDB), // non-transactional
-		transactionRepo:        NewTransactionRepositoryWithTx(tx),
+		transactionRepo:        NewTransactionRepositoryWithTx(tx, ledgerDB),
 		accountTransactionRepo: NewAccountTransactionRepositoryWithTx(tx),
 	}
 }

--- a/storage/relationaldb/sqlite/transaction_context.go
+++ b/storage/relationaldb/sqlite/transaction_context.go
@@ -25,7 +25,7 @@ func NewTransactionContext(tx *sql.Tx, ledgerDB *sql.DB) *TransactionContext {
 	return &TransactionContext{
 		tx:                     tx,
 		ledgerRepo:             NewLedgerRepository(ledgerDB), // non-transactional
-		transactionRepo:        NewTransactionRepositoryWithTx(tx, ledgerDB),
+		transactionRepo:        NewTransactionRepositoryWithTx(tx),
 		accountTransactionRepo: NewAccountTransactionRepositoryWithTx(tx),
 	}
 }

--- a/storage/relationaldb/sqlite/transaction_repository.go
+++ b/storage/relationaldb/sqlite/transaction_repository.go
@@ -3,25 +3,32 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
 // TransactionRepository is the SQLite-backed transaction repository.
+// ledgerDB is the separate ledger database handle: the ledgers table lives in
+// ledger.db while transactions live in transaction.db, so range-search
+// queries against ledgers cannot go through the transaction executor.
 type TransactionRepository struct {
-	db *sql.DB
-	tx *sql.Tx
+	db       *sql.DB
+	tx       *sql.Tx
+	ledgerDB *sql.DB
 }
 
 // NewTransactionRepository creates a SQLite transaction repository.
-func NewTransactionRepository(db *sql.DB) *TransactionRepository {
-	return &TransactionRepository{db: db}
+func NewTransactionRepository(db, ledgerDB *sql.DB) *TransactionRepository {
+	return &TransactionRepository{db: db, ledgerDB: ledgerDB}
 }
 
 // NewTransactionRepositoryWithTx creates a SQLite transaction repository bound to
-// an existing transaction.
-func NewTransactionRepositoryWithTx(tx *sql.Tx) *TransactionRepository {
-	return &TransactionRepository{tx: tx}
+// an existing transaction on the transaction database. ledgerDB is used (outside
+// the transaction) for ledger-range searches; SQLite has no cross-database
+// transactions.
+func NewTransactionRepositoryWithTx(tx *sql.Tx, ledgerDB *sql.DB) *TransactionRepository {
+	return &TransactionRepository{tx: tx, ledgerDB: ledgerDB}
 }
 
 func (r *TransactionRepository) getExecutor() executor {
@@ -69,16 +76,16 @@ func (r *TransactionRepository) GetTransaction(ctx context.Context, hash relatio
 	err := r.getExecutor().QueryRowContext(ctx, query, hash[:]).Scan(
 		&hashBytes, &info.LedgerSeq, &info.Status, &info.RawTxn, &txnMeta)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		if ledgerRange != nil {
+			if r.ledgerDB == nil {
+				return nil, relationaldb.TxSearchUnknown, relationaldb.NewQueryError("get_transaction", "ledger database handle not configured for range search", nil)
+			}
 			var count int64
 			countQuery := `SELECT COUNT(DISTINCT ledger_seq) FROM ledgers
 						   WHERE ledger_seq >= ? AND ledger_seq <= ?`
-			// Note: ledgers table is in a different DB file. For cross-DB queries,
-			// this will only work if called outside a transaction context. Within
-			// the tx DB, we return TxSearchUnknown.
-			if err := r.getExecutor().QueryRowContext(ctx, countQuery, ledgerRange.Min, ledgerRange.Max).Scan(&count); err != nil {
-				return nil, relationaldb.TxSearchUnknown, nil
+			if err := r.ledgerDB.QueryRowContext(ctx, countQuery, ledgerRange.Min, ledgerRange.Max).Scan(&count); err != nil {
+				return nil, relationaldb.TxSearchUnknown, relationaldb.NewQueryError("get_transaction", "failed to count ledgers in range", err)
 			}
 			expectedCount := int64(ledgerRange.Max - ledgerRange.Min + 1)
 			if count == expectedCount {

--- a/storage/relationaldb/sqlite/transaction_repository.go
+++ b/storage/relationaldb/sqlite/transaction_repository.go
@@ -9,26 +9,20 @@ import (
 )
 
 // TransactionRepository is the SQLite-backed transaction repository.
-// ledgerDB is the separate ledger database handle: the ledgers table lives in
-// ledger.db while transactions live in transaction.db, so range-search
-// queries against ledgers cannot go through the transaction executor.
 type TransactionRepository struct {
-	db       *sql.DB
-	tx       *sql.Tx
-	ledgerDB *sql.DB
+	db *sql.DB
+	tx *sql.Tx
 }
 
 // NewTransactionRepository creates a SQLite transaction repository.
-func NewTransactionRepository(db, ledgerDB *sql.DB) *TransactionRepository {
-	return &TransactionRepository{db: db, ledgerDB: ledgerDB}
+func NewTransactionRepository(db *sql.DB) *TransactionRepository {
+	return &TransactionRepository{db: db}
 }
 
 // NewTransactionRepositoryWithTx creates a SQLite transaction repository bound to
-// an existing transaction on the transaction database. ledgerDB is used (outside
-// the transaction) for ledger-range searches; SQLite has no cross-database
-// transactions.
-func NewTransactionRepositoryWithTx(tx *sql.Tx, ledgerDB *sql.DB) *TransactionRepository {
-	return &TransactionRepository{tx: tx, ledgerDB: ledgerDB}
+// an existing transaction on the transaction database.
+func NewTransactionRepositoryWithTx(tx *sql.Tx) *TransactionRepository {
+	return &TransactionRepository{tx: tx}
 }
 
 func (r *TransactionRepository) getExecutor() executor {
@@ -78,14 +72,13 @@ func (r *TransactionRepository) GetTransaction(ctx context.Context, hash relatio
 
 	if errors.Is(err, sql.ErrNoRows) {
 		if ledgerRange != nil {
-			if r.ledgerDB == nil {
-				return nil, relationaldb.TxSearchUnknown, relationaldb.NewQueryError("get_transaction", "ledger database handle not configured for range search", nil)
-			}
+			// Count distinct ledgers carrying a transaction in range (matches
+			// rippled's searched-all test), not ledger headers.
 			var count int64
-			countQuery := `SELECT COUNT(DISTINCT ledger_seq) FROM ledgers
+			countQuery := `SELECT COUNT(DISTINCT ledger_seq) FROM transactions
 						   WHERE ledger_seq >= ? AND ledger_seq <= ?`
-			if err := r.ledgerDB.QueryRowContext(ctx, countQuery, ledgerRange.Min, ledgerRange.Max).Scan(&count); err != nil {
-				return nil, relationaldb.TxSearchUnknown, relationaldb.NewQueryError("get_transaction", "failed to count ledgers in range", err)
+			if err := r.getExecutor().QueryRowContext(ctx, countQuery, ledgerRange.Min, ledgerRange.Max).Scan(&count); err != nil {
+				return nil, relationaldb.TxSearchUnknown, relationaldb.NewQueryError("get_transaction", "failed to count transactions in range", err)
 			}
 			expectedCount := int64(ledgerRange.Max - ledgerRange.Min + 1)
 			if count == expectedCount {

--- a/storage/relationaldb/sqlite/validation_repository.go
+++ b/storage/relationaldb/sqlite/validation_repository.go
@@ -3,9 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	"time"
 
-	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
@@ -44,20 +42,6 @@ func (r *ValidationRepository) getExecutor() executor {
 const validationSelectCols = `ledger_seq, initial_seq, ledger_hash, node_pubkey,
 	sign_time, seen_time, flags, raw`
 
-func toXRPLEpochSeconds(t time.Time) int64 {
-	if t.IsZero() {
-		return 0
-	}
-	return t.Unix() - protocol.RippleEpochUnix
-}
-
-func fromXRPLEpochSeconds(s int64) time.Time {
-	if s == 0 {
-		return time.Time{}
-	}
-	return time.Unix(s+protocol.RippleEpochUnix, 0).UTC()
-}
-
 // Save inserts a validation record, ignoring duplicates (upsert on ledger_hash + node_pubkey).
 func (r *ValidationRepository) Save(ctx context.Context, v *relationaldb.ValidationRecord) error {
 	if v == nil {
@@ -71,7 +55,7 @@ func (r *ValidationRepository) Save(ctx context.Context, v *relationaldb.Validat
 		ON CONFLICT(ledger_hash, node_pubkey) DO NOTHING
 	`,
 		int64(v.LedgerSeq), int64(v.InitialSeq), v.LedgerHash[:], v.NodePubKey,
-		toXRPLEpochSeconds(v.SignTime), toXRPLEpochSeconds(v.SeenTime),
+		relationaldb.ToXRPLEpochSeconds(v.SignTime), relationaldb.ToXRPLEpochSeconds(v.SeenTime),
 		int64(v.Flags), v.Raw,
 	)
 	if err != nil {
@@ -114,30 +98,6 @@ func (r *ValidationRepository) SaveBatch(ctx context.Context, vs []*relationaldb
 	return nil
 }
 
-func (r *ValidationRepository) scanRow(row interface {
-	Scan(dest ...any) error
-}) (*relationaldb.ValidationRecord, error) {
-	var rec relationaldb.ValidationRecord
-	var ledgerSeq, initialSeq, signTime, seenTime int64
-	var flags int64
-	var ledgerHash []byte
-
-	if err := row.Scan(
-		&ledgerSeq, &initialSeq, &ledgerHash, &rec.NodePubKey,
-		&signTime, &seenTime, &flags, &rec.Raw,
-	); err != nil {
-		return nil, err
-	}
-
-	rec.LedgerSeq = relationaldb.LedgerIndex(ledgerSeq)
-	rec.InitialSeq = relationaldb.LedgerIndex(initialSeq)
-	copy(rec.LedgerHash[:], ledgerHash)
-	rec.SignTime = fromXRPLEpochSeconds(signTime)
-	rec.SeenTime = fromXRPLEpochSeconds(seenTime)
-	rec.Flags = uint32(flags)
-	return &rec, nil
-}
-
 // GetValidationsForLedger returns all validation records for the given ledger sequence.
 func (r *ValidationRepository) GetValidationsForLedger(ctx context.Context, seq relationaldb.LedgerIndex) ([]*relationaldb.ValidationRecord, error) {
 	rows, err := r.getExecutor().QueryContext(ctx,
@@ -149,7 +109,7 @@ func (r *ValidationRepository) GetValidationsForLedger(ctx context.Context, seq 
 
 	var result []*relationaldb.ValidationRecord
 	for rows.Next() {
-		rec, err := r.scanRow(rows)
+		rec, err := relationaldb.ScanValidationRecord(rows)
 		if err != nil {
 			return nil, relationaldb.NewQueryError("validation_get_for_ledger", "failed to scan row", err)
 		}
@@ -179,7 +139,7 @@ func (r *ValidationRepository) GetValidationsByValidator(ctx context.Context, no
 
 	var result []*relationaldb.ValidationRecord
 	for rows.Next() {
-		rec, err := r.scanRow(rows)
+		rec, err := relationaldb.ScanValidationRecord(rows)
 		if err != nil {
 			return nil, relationaldb.NewQueryError("validation_get_by_validator", "failed to scan row", err)
 		}

--- a/storage/relationaldb/validations.go
+++ b/storage/relationaldb/validations.go
@@ -3,6 +3,8 @@ package relationaldb
 import (
 	"context"
 	"time"
+
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // ValidationRecord is one row of the on-disk validation archive. Columns
@@ -53,4 +55,54 @@ type ValidationRepository interface {
 	// block the writer for an unbounded duration. Returns the number of
 	// rows actually deleted. batchSize <= 0 applies no bound.
 	DeleteOlderThanSeq(ctx context.Context, maxSeq LedgerIndex, batchSize int) (int64, error)
+}
+
+// RowScanner is the subset of *sql.Row / *sql.Rows used by the shared scan
+// helpers, so one helper serves both single-row and multi-row queries.
+type RowScanner interface {
+	Scan(dest ...any) error
+}
+
+// ToXRPLEpochSeconds converts a Go time to seconds since the XRPL epoch
+// (2000-01-01). The zero time maps to 0.
+func ToXRPLEpochSeconds(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.Unix() - protocol.RippleEpochUnix
+}
+
+// FromXRPLEpochSeconds converts seconds since the XRPL epoch (2000-01-01)
+// to a UTC Go time. 0 maps to the zero time.
+func FromXRPLEpochSeconds(s int64) time.Time {
+	if s == 0 {
+		return time.Time{}
+	}
+	return time.Unix(s+protocol.RippleEpochUnix, 0).UTC()
+}
+
+// ScanValidationRecord scans one validation archive row in the canonical
+// column order (ledger_seq, initial_seq, ledger_hash, node_pubkey, sign_time,
+// seen_time, flags, raw). Shared by the SQLite and PostgreSQL backends so the
+// two cannot drift.
+func ScanValidationRecord(row RowScanner) (*ValidationRecord, error) {
+	var rec ValidationRecord
+	var ledgerSeq, initialSeq, signTime, seenTime int64
+	var flags int64
+	var ledgerHash []byte
+
+	if err := row.Scan(
+		&ledgerSeq, &initialSeq, &ledgerHash, &rec.NodePubKey,
+		&signTime, &seenTime, &flags, &rec.Raw,
+	); err != nil {
+		return nil, err
+	}
+
+	rec.LedgerSeq = LedgerIndex(ledgerSeq)
+	rec.InitialSeq = LedgerIndex(initialSeq)
+	copy(rec.LedgerHash[:], ledgerHash)
+	rec.SignTime = FromXRPLEpochSeconds(signTime)
+	rec.SeenTime = FromXRPLEpochSeconds(seenTime)
+	rec.Flags = uint32(flags)
+	return &rec, nil
 }


### PR DESCRIPTION
## Summary
- **Durability**: `Sync() error` is now part of the `kvstore.KeyValueStore` contract — pebble implements it via a synced WAL record (`LogData(nil, pebble.Sync)`), memorydb as an explicit no-op — and `nodestore.Database.Sync` calls it directly, so the ledger-persist fsync in `internal/ledger/service/persistence.go` actually reaches disk instead of silently no-opping behind a failed type assert.
- **Panic paths / races**: `pebble.NewIterator` checks the closed flag and surfaces `NewIter` failures through `Iterator.Error()` instead of nil-dereferencing; `pebble.Close` always releases the DB handle even when `Flush` fails (and skips Flush on read-only stores); `NegativeCache.MarkMissing`/`Clear` re-check the nilled map under the lock so they can no longer panic or resurrect entries racing `Close`.
- **Backend parity**: sqlite `GetTransaction` range search ("searched all/some") now queries the `ledgers` table on `ledger.db` and propagates errors, matching postgres; memorydb batches replay interleaved Put/Delete in insertion order like pebble; closed-store `Compact`/`NewIterator`/`Sync` behave identically on both backends; the sqlite ledger-repo non-transactionality is documented on the `TransactionContext` contract; postgres `total_coins` parse errors are returned instead of silently zeroed.
- **Compile fix + CI**: the tag-gated postgres suite compiles again (`relationaldb.NewConfig().WithConnectionString`), and CI now runs `go vet -tags postgres ./storage/relationaldb/postgres/`.
- **Dedup & dead code**: postgres ledger/account repos use shared `scanLedgerInfo` / `queryAccountTxs(Page)` helpers mirroring sqlite; the XRPL-epoch and validation scan helpers moved into `relationaldb` proper; pruned unused sentinels and the dead `DatabaseError` code/retry machinery, `FetchAsync`/`FetchBatch`, `NodeDummy`, `NegativeCacheSweeper`, unused `Config.With*` builders, dead `Statistics` fields (and exposed `NegativeCacheHits`), and the always-nil error from `NewKVDatabaseWithConfig`; postgres DSNs are built with `url.URL` so credentials are escaped.
- **Tests**: new conformance cases (interleaved batch, closed-store iterator/compact/sync), a nodestore test proving `Sync` reaches the backend and propagates errors, pebble sync-durability and read-only close tests, a sqlite range-search regression test, and a NegativeCache close-race test.

## Test plan
- [x] `just test-pkg ./storage/...`
- [x] `go test -race -count=1 ./storage/...`
- [x] `go vet ./storage/...`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/` (failed on main, passes here)
- [x] `just build`
- [x] `just test-core`
- [x] `golangci-lint run ./storage/... ./shamap/...` — 0 issues

Fixes #877