### PR TITLE
refactor(rpc/core): fix subscription-state bugs and WS dispatch parity gaps

### DIFF
--- a/internal/rpc/dispatch_parity_test.go
+++ b/internal/rpc/dispatch_parity_test.go
@@ -30,7 +30,6 @@ func (h *condStubHandler) RequiredCondition() types.Condition { return h.cond }
 // TestDispatchMethodEnforcesConditionMet pins H3: the shared dispatch core
 // (used by BOTH the HTTP and WebSocket transports) runs conditionMet, so a
 // not-synced node refuses a condition-requiring method on either transport.
-// Previously the WS path skipped this check.
 func TestDispatchMethodEnforcesConditionMet(t *testing.T) {
 	reg := types.NewMethodRegistry()
 	reg.Register("gated", &condStubHandler{cond: types.NeedsNetworkConnection})

--- a/internal/rpc/dispatch_parity_test.go
+++ b/internal/rpc/dispatch_parity_test.go
@@ -97,6 +97,9 @@ func TestSingleRequestParseFailuresReturn400(t *testing.T) {
 	}{
 		{"unparseable json", `{not json`, "Unable to parse request:"},
 		{"missing method", `{"params":[{}]}`, "Null method"},
+		{"null method", `{"method":null}`, "Null method"},
+		{"non-string method", `{"method":7}`, "method is not string"},
+		{"empty method", `{"method":""}`, "method is empty"},
 		{"non-array params", `{"method":"ping","params":{"x":1}}`, "params unparseable"},
 	}
 	for _, c := range cases {
@@ -108,8 +111,23 @@ func TestSingleRequestParseFailuresReturn400(t *testing.T) {
 
 			assert.Equal(t, http.StatusBadRequest, rr.Code)
 			assert.Contains(t, rr.Body.String(), c.want)
+			// rippled's HTTPReply labels even these bare-string 400 bodies
+			// application/json, not Go's http.Error text/plain (M2).
+			assert.Equal(t, "application/json; charset=UTF-8", rr.Header().Get("Content-Type"))
 		})
 	}
+}
+
+// TestLoadWarningNestedInResultOnHTTP pins M1: the HTTP envelope places
+// warning:"load" INSIDE result (rippled ServerHandler.cpp:919-920 → :938/:971),
+// not at the top level (which is the WS placement, :519).
+func TestLoadWarningNestedInResultOnHTTP(t *testing.T) {
+	body := buildXrplResponseBody(nil, map[string]any{"foo": "bar"}, nil, &JsonRpcResponseOptions{Warning: "load"})
+	result, ok := body["result"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "load", result["warning"], "HTTP load warning belongs inside result")
+	_, topLevel := body["warning"]
+	assert.False(t, topLevel, "HTTP load warning must not be emitted at the top level")
 }
 
 // TestWSCommandAliasAndMissingCommand pins M4 on the wire: `method` works as an

--- a/internal/rpc/dispatch_parity_test.go
+++ b/internal/rpc/dispatch_parity_test.go
@@ -1,0 +1,162 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// condStubHandler is a stub method handler with a configurable precondition,
+// used to exercise the shared dispatch core's conditionMet gate.
+type condStubHandler struct {
+	cond types.Condition
+}
+
+func (h *condStubHandler) Handle(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+	return map[string]any{"ok": true}, nil
+}
+func (h *condStubHandler) RequiredRole() types.Role           { return types.RoleGuest }
+func (h *condStubHandler) SupportedApiVersions() []int        { return nil }
+func (h *condStubHandler) RequiredCondition() types.Condition { return h.cond }
+
+// TestDispatchMethodEnforcesConditionMet pins H3: the shared dispatch core
+// (used by BOTH the HTTP and WebSocket transports) runs conditionMet, so a
+// not-synced node refuses a condition-requiring method on either transport.
+// Previously the WS path skipped this check.
+func TestDispatchMethodEnforcesConditionMet(t *testing.T) {
+	reg := types.NewMethodRegistry()
+	reg.Register("gated", &condStubHandler{cond: types.NeedsNetworkConnection})
+
+	t.Run("not synced is refused", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: newMockLedgerService()}, // zero serverInfo: disconnected
+		}
+		_, rpcErr := dispatchMethod(reg, nil, ctx.Services, ctx, "gated", nil, types.RpcErrorNoPermission, rpcLog())
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcNO_NETWORK, rpcErr.Code)
+		assert.Equal(t, "noNetwork", rpcErr.ErrorString)
+	})
+
+	t.Run("synced passes", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: syncedStandalone()},
+		}
+		result, rpcErr := dispatchMethod(reg, nil, ctx.Services, ctx, "gated", nil, types.RpcErrorNoPermission, rpcLog())
+		require.Nil(t, rpcErr)
+		assert.Equal(t, map[string]any{"ok": true}, result)
+	})
+}
+
+// TestResolveWSCommand pins M4's command resolution: `method` is accepted as an
+// alias for `command`, and the request is malformed (→ missingCommand) only
+// when neither is a non-empty string or both are present and disagree.
+func TestResolveWSCommand(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     map[string]any
+		want   string
+		wantOK bool
+	}{
+		{"command only", map[string]any{"command": "ping"}, "ping", true},
+		{"method alias", map[string]any{"method": "ping"}, "ping", true},
+		{"both agree", map[string]any{"command": "ping", "method": "ping"}, "ping", true},
+		{"both disagree", map[string]any{"command": "ping", "method": "pong"}, "", false},
+		{"neither", map[string]any{"id": 1}, "", false},
+		{"empty command", map[string]any{"command": ""}, "", false},
+		{"non-string command", map[string]any{"command": 7}, "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := resolveWSCommand(c.in)
+			assert.Equal(t, c.wantOK, ok)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+// TestSingleRequestParseFailuresReturn400 pins M3: a malformed single request
+// gets a plain-text HTTP 400, matching rippled (ServerHandler.cpp:629-635,
+// :769, :826), not a 200 + JSON-RPC envelope.
+func TestSingleRequestParseFailuresReturn400(t *testing.T) {
+	srv := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"unparseable json", `{not json`, "Unable to parse request:"},
+		{"missing method", `{"params":[{}]}`, "Null method"},
+		{"non-array params", `{"method":"ping","params":{"x":1}}`, "params unparseable"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/", strings.NewReader(c.body))
+			req.RemoteAddr = "10.0.0.1:1234"
+			rr := httptest.NewRecorder()
+			srv.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Contains(t, rr.Body.String(), c.want)
+		})
+	}
+}
+
+// TestWSCommandAliasAndMissingCommand pins M4 on the wire: `method` works as an
+// alias for `command`, and an unresolvable command yields a bare missingCommand
+// token that echoes the request and id (ServerHandler.cpp:446-468).
+func TestWSCommandAliasAndMissingCommand(t *testing.T) {
+	ws := NewWebSocketServer(2*time.Second, nil)
+	ws.methodRegistry.Register("ping", &stubHandler{})
+
+	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
+	defer httpSrv.Close()
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer c.Close()
+
+	roundtrip := func(send map[string]any) map[string]any {
+		require.NoError(t, c.WriteJSON(send))
+		require.NoError(t, c.SetReadDeadline(time.Now().Add(2*time.Second)))
+		var resp map[string]any
+		require.NoError(t, c.ReadJSON(&resp))
+		return resp
+	}
+
+	t.Run("method alias dispatches", func(t *testing.T) {
+		resp := roundtrip(map[string]any{"method": "ping", "id": float64(1)})
+		assert.Equal(t, "success", resp["status"])
+		assert.Equal(t, float64(1), resp["id"])
+		assert.Nil(t, resp["error"])
+	})
+
+	t.Run("missing command echoes request as bare token", func(t *testing.T) {
+		resp := roundtrip(map[string]any{"id": float64(2)})
+		assert.Equal(t, "response", resp["type"])
+		assert.Equal(t, "error", resp["status"])
+		assert.Equal(t, "missingCommand", resp["error"])
+		assert.Equal(t, float64(2), resp["id"])
+		assert.Equal(t, map[string]any{"id": float64(2)}, resp["request"])
+		// Bare token: no numeric code / message.
+		assert.NotContains(t, resp, "error_code")
+		assert.NotContains(t, resp, "error_message")
+	})
+
+	t.Run("command/method mismatch is missingCommand", func(t *testing.T) {
+		resp := roundtrip(map[string]any{"command": "ping", "method": "pong", "id": float64(3)})
+		assert.Equal(t, "error", resp["status"])
+		assert.Equal(t, "missingCommand", resp["error"])
+	})
+}

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -31,30 +31,6 @@ type LedgerCloseEvent struct {
 	Validated     bool   `json:"validated,omitempty"`      // Whether this ledger is validated
 }
 
-// NewLedgerCloseEvent creates a new LedgerCloseEvent with required fields
-func NewLedgerCloseEvent(
-	ledgerHash string,
-	ledgerIndex uint32,
-	closeTime time.Time,
-	feeBase, feeRef, reserveBase, reserveInc uint64,
-	txnCount int,
-	validatedLedgers string,
-) *LedgerCloseEvent {
-	return &LedgerCloseEvent{
-		Type:             "ledgerClosed",
-		FeeBase:          feeBase,
-		FeeRef:           feeRef,
-		LedgerHash:       ledgerHash,
-		LedgerIndex:      ledgerIndex,
-		LedgerTime:       ToRippleTime(closeTime),
-		ReserveBase:      reserveBase,
-		ReserveInc:       reserveInc,
-		TxnCount:         txnCount,
-		ValidatedLedgers: validatedLedgers,
-		Validated:        true,
-	}
-}
-
 // TransactionEvent represents a transaction notification sent to subscribers
 // This matches the rippled transaction stream message format
 type TransactionEvent struct {
@@ -73,32 +49,6 @@ type TransactionEvent struct {
 	Status              string          `json:"status,omitempty"`               // Status for proposed transactions
 	// Account subscription specific fields
 	Account string `json:"account,omitempty"` // Account that was affected (for account subscriptions)
-}
-
-// NewTransactionEvent creates a new TransactionEvent
-func NewTransactionEvent(
-	txJSON json.RawMessage,
-	meta json.RawMessage,
-	hash string,
-	ledgerIndex uint32,
-	ledgerHash string,
-	engineResult string,
-	engineResultCode int,
-	engineResultMessage string,
-	validated bool,
-) *TransactionEvent {
-	return &TransactionEvent{
-		Type:                "transaction",
-		Transaction:         txJSON,
-		Meta:                meta,
-		Hash:                hash,
-		LedgerIndex:         ledgerIndex,
-		LedgerHash:          ledgerHash,
-		EngineResult:        engineResult,
-		EngineResultCode:    engineResultCode,
-		EngineResultMessage: engineResultMessage,
-		Validated:           validated,
-	}
 }
 
 // ValidationEvent represents a validation message from a validator
@@ -164,15 +114,6 @@ type ServerStatusEvent struct {
 	LoadFactorFeeReference  int    `json:"load_factor_fee_reference,omitempty"`  // TxQ reference fee level (NetworkOPs.cpp:2345)
 	LoadFactorServer        int    `json:"load_factor_server,omitempty"`         // Server load factor
 	ServerStatus            string `json:"server_status,omitempty"`              // Operating mode (disconnected/connected/syncing/tracking/full)
-}
-
-// NewServerStatusEvent creates a new ServerStatusEvent
-func NewServerStatusEvent(loadBase, loadFactor int) *ServerStatusEvent {
-	return &ServerStatusEvent{
-		Type:       "serverStatus",
-		LoadBase:   loadBase,
-		LoadFactor: loadFactor,
-	}
 }
 
 // ConsensusEvent represents consensus phase changes
@@ -266,15 +207,6 @@ const (
 	PeerStatusShutting   = "SHUTTING"
 )
 
-// NewPeerStatusEvent creates a new PeerStatusEvent
-func NewPeerStatusEvent(action string, date uint32) *PeerStatusEvent {
-	return &PeerStatusEvent{
-		Type:   "peerStatusChange",
-		Action: action,
-		Date:   &date,
-	}
-}
-
 // OrderBookChangeEvent represents changes to an order book
 // This is sent to subscribers of specific order books
 type OrderBookChangeEvent struct {
@@ -308,15 +240,6 @@ type PathAlternative struct {
 	PathsCanonical [][]types.PathStep `json:"paths_canonical,omitempty"` // Canonical path representation
 	PathsComputed  [][]types.PathStep `json:"paths_computed,omitempty"`  // Computed paths
 	SourceAmount   json.RawMessage    `json:"source_amount"`             // Amount to send
-}
-
-// PathStep represents a step in a payment path
-type PathStepEvent struct {
-	Account  string `json:"account,omitempty"`
-	Currency string `json:"currency,omitempty"`
-	Issuer   string `json:"issuer,omitempty"`
-	Type     int    `json:"type,omitempty"`
-	TypeHex  string `json:"type_hex,omitempty"`
 }
 
 // ProposedTransactionEvent represents a proposed (unvalidated) transaction

--- a/internal/rpc/handlers/json.go
+++ b/internal/rpc/handlers/json.go
@@ -45,5 +45,5 @@ func (m *JsonMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any,
 		}
 	}
 
-	return ctx.Services.Dispatcher.ExecuteMethod(request.Method, forwardParams)
+	return ctx.Services.Dispatcher.ExecuteMethod(ctx, request.Method, forwardParams)
 }

--- a/internal/rpc/publisher.go
+++ b/internal/rpc/publisher.go
@@ -44,8 +44,6 @@ type EventPublisher interface {
 	GetSubscriberCount(streamType types.SubscriptionType) int
 }
 
-// Note: CurrencySpec is defined in subscription_methods.go
-
 // Publisher implements EventPublisher using subscription.Manager
 type Publisher struct {
 	manager *subscription.Manager

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -242,20 +242,22 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	// request carries a one-element array, and rippled inspects the method
 	// before deciding which shape params must take (ServerHandler.cpp:638-649).
 	var request struct {
-		Method string          `json:"method"`
+		Method json.RawMessage `json:"method"`
 		Params json.RawMessage `json:"params"`
 	}
-	// rippled answers a malformed single request with a plain-text HTTP 400,
-	// not a 200 + JSON-RPC envelope (ServerHandler.cpp:629-635, :769): an
-	// unparseable body, then a missing/null method. The batch envelope below
-	// is already byte-faithful; these single-request paths now match too.
+	// rippled answers a malformed single request with an HTTP 400, not a 200 +
+	// JSON-RPC envelope (ServerHandler.cpp:629-635, :764-808): an unparseable
+	// body, then the method field validated for the same three malformed shapes
+	// the batch path distinguishes. The bodies are application/json (rippled's
+	// HTTPReply quirk), not Go's http.Error text/plain default.
 	if err := json.Unmarshal(body, &request); err != nil {
-		http.Error(w, "Unable to parse request: "+err.Error(), http.StatusBadRequest)
+		writePlainHTTPError(w, http.StatusBadRequest, "Unable to parse request: "+err.Error())
 		return
 	}
 
-	if request.Method == "" {
-		http.Error(w, "Null method", http.StatusBadRequest)
+	method, methodErr := decodeMethodField(request.Method)
+	if methodErr != "" {
+		writePlainHTTPError(w, http.StatusBadRequest, methodErr)
 		return
 	}
 
@@ -279,7 +281,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	// missing, null, or non-array is HTTP 400 "Malformed batch request"
 	// (ServerHandler.cpp:643-647). An empty array is valid: size is 0, the loop
 	// runs zero times, and the reply is an empty array (ServerHandler.cpp:648-653).
-	if request.Method == "batch" {
+	if method == "batch" {
 		var elements []json.RawMessage
 		// A JSON null params leaves elements nil with no error, which rippled
 		// rejects as "not an array"; an empty [] unmarshals to a non-nil empty
@@ -305,9 +307,9 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	if len(request.Params) > 0 {
 		var arr []json.RawMessage
 		if err := json.Unmarshal(request.Params, &arr); err != nil {
-			// params present but not a JSON array → plain-text HTTP 400
+			// params present but not a JSON array → HTTP 400
 			// (ServerHandler.cpp:826).
-			http.Error(w, "params unparseable", http.StatusBadRequest)
+			writePlainHTTPError(w, http.StatusBadRequest, "params unparseable")
 			return
 		}
 		if len(arr) > 0 {
@@ -321,7 +323,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		applyApiVersionFromObject(ctx, params)
 	}
 
-	result, rpcErr := s.executeMethod(request.Method, params, ctx)
+	result, rpcErr := s.executeMethod(method, params, ctx)
 
 	// rippled answers an unsupported api_version on the HTTP-single path with
 	// HTTPReply(400, "invalid_API_version") — a 400 whose body is the bare
@@ -331,7 +333,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requestObj := buildRequestEcho(request.Method, params)
+	requestObj := buildRequestEcho(method, params)
 
 	s.writeXrplResponseWithOptions(w, requestObj, result, rpcErr, loadWarningOpts(ctx))
 }
@@ -346,6 +348,36 @@ func writeInvalidApiVersionHTTP(w http.ResponseWriter) {
 	if _, err := io.WriteString(w, types.InvalidApiVersionToken); err != nil {
 		rpcLog().Error("Failed to write invalid_API_version response", "err", err)
 	}
+}
+
+// writePlainHTTPError mirrors rippled's HTTPReply(status, content): a bare
+// string body labelled application/json (rippled labels even non-JSON error
+// strings that way) terminated with CRLF (JSONRPCUtil.cpp:148-158), rather
+// than Go's http.Error text/plain + LF default.
+func writePlainHTTPError(w http.ResponseWriter, status int, content string) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(status)
+	if _, err := io.WriteString(w, content+"\r\n"); err != nil {
+		rpcLog().Error("Failed to write HTTP error response", "err", err)
+	}
+}
+
+// decodeMethodField validates the HTTP-single "method" field the same way the
+// batch path does, mirroring rippled's three distinct messages
+// (ServerHandler.cpp:764-808): a missing/null method → "Null method", a
+// non-string method → "method is not string", an empty string → "method is
+// empty". On success it returns the method name and an empty errMsg.
+func decodeMethodField(raw json.RawMessage) (method string, errMsg string) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", "Null method"
+	}
+	if err := json.Unmarshal(raw, &method); err != nil {
+		return "", "method is not string"
+	}
+	if method == "" {
+		return "", "method is empty"
+	}
+	return method, ""
 }
 
 // applyApiVersionFromObject overrides ctx.ApiVersion when the given JSON object
@@ -547,7 +579,8 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 
 // dispatchMethod is the transport-agnostic dispatch core shared by the HTTP
 // (Server.executeMethod) and WebSocket (WebSocketServer.handleRPCMethod)
-// paths: registry lookup → admin gate → conditionMet → api-version → busy →
+// paths. It mirrors rippled's fillHandler gate order (RPCHandler.cpp:132-176):
+// busy → registry lookup → api-version → admin gate → conditionMet, then the
 // load gate → handle → load finalize. Hoisting it keeps the two transports
 // from drifting (the WS path previously skipped conditionMet). The only
 // transport-specific bit is the admin-gate error, supplied by adminGate.
@@ -561,9 +594,21 @@ func dispatchMethod(
 	adminGate func(string) *types.RpcError,
 	log xrpllog.Logger,
 ) (any, *types.RpcError) {
+	// rippled checks the job-queue busy gate first, before command lookup,
+	// the version check, the admin gate and conditionMet (RPCHandler.cpp:132-141).
+	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
+		return nil, rpcErr
+	}
+
 	handler, exists := registry.Get(method)
 	if !exists {
 		return nil, types.RpcErrorMethodNotFound(method)
+	}
+
+	// rippled's getHandler resolves the command together with its api-version
+	// support, before the admin gate and conditionMet (RPCHandler.cpp:160-169).
+	if rpcErr := validateApiVersion(ctx, handler); rpcErr != nil {
+		return nil, rpcErr
 	}
 
 	// Check role permissions — matches rippled RPCHandler.cpp line 166:
@@ -574,18 +619,11 @@ func dispatchMethod(
 	}
 
 	// Enforce the method's precondition, mirroring rippled's RPC::conditionMet
-	// (Handler.h:78-139).
+	// (Handler.h:78-139), after the admin gate (RPCHandler.cpp:169).
 	if rpcErr := conditionMet(handler.RequiredCondition(), ctx); rpcErr != nil {
 		return nil, rpcErr
 	}
 
-	if rpcErr := validateApiVersion(ctx, handler); rpcErr != nil {
-		return nil, rpcErr
-	}
-
-	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
-		return nil, rpcErr
-	}
 	if err := gateLoad(tracker, ctx, method, log); err != nil {
 		return nil, err
 	}
@@ -788,15 +826,16 @@ func loadWarningOpts(ctx *types.RpcContext) *JsonRpcResponseOptions {
 	return nil
 }
 
-// buildXrplResponseBody assembles the `{"result": {...}}` envelope (plus any
-// top-level warning/forwarded fields) for a single dispatched request. It is
-// shared by the single-request writer and by each element of a batch envelope,
-// so every batch reply has the same shape as a standalone reply.
+// buildXrplResponseBody assembles the `{"result": {...}}` envelope for a single
+// dispatched request. It is shared by the single-request writer and by each
+// element of a batch envelope, so every batch reply has the same shape as a
+// standalone reply.
 func buildXrplResponseBody(request any, result any, rpcErr *types.RpcError, opts *JsonRpcResponseOptions) map[string]any {
 	response := make(map[string]any)
 
+	var resultObj map[string]any
 	if rpcErr != nil {
-		resultObj := map[string]any{
+		resultObj = map[string]any{
 			"status": "error",
 			"error":  rpcErr.ErrorString,
 		}
@@ -809,23 +848,27 @@ func buildXrplResponseBody(request any, result any, rpcErr *types.RpcError, opts
 		if request != nil {
 			resultObj["request"] = request
 		}
-		response["result"] = resultObj
+	} else if resultMap, ok := result.(map[string]any); ok {
+		resultMap["status"] = "success"
+		resultObj = resultMap
 	} else {
-		if resultMap, ok := result.(map[string]any); ok {
-			resultMap["status"] = "success"
-			response["result"] = resultMap
-		} else {
-			response["result"] = map[string]any{
-				"status": "success",
-				"data":   result,
-			}
+		resultObj = map[string]any{
+			"status": "success",
+			"data":   result,
 		}
 	}
 
 	if opts != nil {
+		// On the HTTP path rippled writes warning:"load" INTO result, before
+		// wrapping it in the envelope (ServerHandler.cpp:919-920 → :938/:971);
+		// the WS path keeps it top-level (:519) and is handled separately.
 		if opts.Warning != "" {
-			response["warning"] = opts.Warning
+			resultObj["warning"] = opts.Warning
 		}
+	}
+	response["result"] = resultObj
+
+	if opts != nil {
 		if len(opts.Warnings) > 0 {
 			response["warnings"] = opts.Warnings
 		}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -41,9 +41,9 @@ type LoadCharger interface {
 }
 
 type Server struct {
+	peerSourceHolder
 	registry    *types.MethodRegistry
 	timeout     time.Duration
-	peerSource  atomic.Pointer[types.PeerSource]
 	services    *types.ServiceContainer
 	loadTracker *loadtrack.Tracker
 
@@ -60,19 +60,27 @@ type Server struct {
 
 var _ types.MethodDispatcher = (*Server)(nil)
 
+// peerSourceHolder is the atomic peer-source slot embedded by both the HTTP
+// and WebSocket servers, exposed through the `peers` RPC. Embedding it gives
+// both the same SetPeerSource / loadPeerSource without duplicating the field
+// and methods on each server.
+type peerSourceHolder struct {
+	peerSource atomic.Pointer[types.PeerSource]
+}
+
 // SetPeerSource registers the source of per-peer entries served by the
 // `peers` RPC handler. Passing nil detaches the source so the handler
 // returns an empty list. Safe to call concurrently with reads.
-func (s *Server) SetPeerSource(src types.PeerSource) {
+func (h *peerSourceHolder) SetPeerSource(src types.PeerSource) {
 	if src == nil {
-		s.peerSource.Store(nil)
+		h.peerSource.Store(nil)
 		return
 	}
-	s.peerSource.Store(&src)
+	h.peerSource.Store(&src)
 }
 
-func (s *Server) loadPeerSource() types.PeerSource {
-	if p := s.peerSource.Load(); p != nil {
+func (h *peerSourceHolder) loadPeerSource() types.PeerSource {
+	if p := h.peerSource.Load(); p != nil {
 		return *p
 	}
 	return nil
@@ -152,7 +160,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			rpcLog().Error("rpc handler panic", "err", rec, "stack", string(debug.Stack()), "method", r.Method, "remote", r.RemoteAddr)
-			s.writeXrplError(w, "", nil, "internal", "Internal server error")
+			s.writeXrplError(w, nil, "internal", "Internal server error")
 		}
 	}()
 
@@ -193,6 +201,10 @@ func (s *Server) handleGetRequest(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	method := query.Get("command")
 
+	// Deliberate goxrpl extension: a GET with no `command` defaults to
+	// server_info. rippled has no GET form (it feeds every request body
+	// through the JSON parser); this keeps the endpoint browser-pokeable,
+	// like the permissive default CORS header above.
 	if method == "" {
 		method = "server_info"
 	}
@@ -204,19 +216,10 @@ func (s *Server) handleGetRequest(w http.ResponseWriter, r *http.Request) {
 	role := roleForRequest(peerIP, user, portCtx)
 	dispatchCtx, cancel := s.withTimeout(r.Context())
 	defer cancel()
-	ctx := &types.RpcContext{
-		Context:    dispatchCtx,
-		Role:       role,
-		ApiVersion: types.DefaultApiVersion,
-		IsAdmin:    role == types.RoleAdmin,
-		Unlimited:  role.IsUnlimited(),
-		ClientIP:   clientIP,
-		PeerSource: s.loadPeerSource(),
-		Services:   s.services,
-	}
+	ctx := newRpcContext(dispatchCtx, role, types.DefaultApiVersion, clientIP, s.loadPeerSource(), s.services)
 
 	result, rpcErr := s.executeMethod(method, nil, ctx)
-	s.writeXrplResponse(w, method, nil, result, rpcErr)
+	s.writeXrplResponseWithOptions(w, nil, result, rpcErr, loadWarningOpts(ctx))
 }
 
 func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
@@ -230,7 +233,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Request body exceeds limit", http.StatusBadRequest)
 			return
 		}
-		s.writeXrplError(w, "", nil, "internal", "Failed to read request body")
+		s.writeXrplError(w, nil, "internal", "Failed to read request body")
 		return
 	}
 
@@ -242,13 +245,17 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		Method string          `json:"method"`
 		Params json.RawMessage `json:"params"`
 	}
+	// rippled answers a malformed single request with a plain-text HTTP 400,
+	// not a 200 + JSON-RPC envelope (ServerHandler.cpp:629-635, :769): an
+	// unparseable body, then a missing/null method. The batch envelope below
+	// is already byte-faithful; these single-request paths now match too.
 	if err := json.Unmarshal(body, &request); err != nil {
-		s.writeXrplError(w, "", nil, "jsonInvalid", "Invalid JSON: "+err.Error())
+		http.Error(w, "Unable to parse request: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	if request.Method == "" {
-		s.writeXrplError(w, "", nil, "missingCommand", "Missing method field")
+		http.Error(w, "Null method", http.StatusBadRequest)
 		return
 	}
 
@@ -298,7 +305,9 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	if len(request.Params) > 0 {
 		var arr []json.RawMessage
 		if err := json.Unmarshal(request.Params, &arr); err != nil {
-			s.writeXrplError(w, request.Method, nil, "jsonInvalid", "Invalid JSON: params must be an array")
+			// params present but not a JSON array → plain-text HTTP 400
+			// (ServerHandler.cpp:826).
+			http.Error(w, "params unparseable", http.StatusBadRequest)
 			return
 		}
 		if len(arr) > 0 {
@@ -306,16 +315,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	ctx := &types.RpcContext{
-		Context:    dispatchCtx,
-		Role:       role,
-		ApiVersion: types.DefaultApiVersion,
-		IsAdmin:    role == types.RoleAdmin,
-		Unlimited:  role.IsUnlimited(),
-		ClientIP:   clientIP,
-		PeerSource: s.loadPeerSource(),
-		Services:   s.services,
-	}
+	ctx := newRpcContext(dispatchCtx, role, types.DefaultApiVersion, clientIP, s.loadPeerSource(), s.services)
 
 	if params != nil {
 		applyApiVersionFromObject(ctx, params)
@@ -333,7 +333,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 
 	requestObj := buildRequestEcho(request.Method, params)
 
-	s.writeXrplResponse(w, request.Method, requestObj, result, rpcErr)
+	s.writeXrplResponseWithOptions(w, requestObj, result, rpcErr, loadWarningOpts(ctx))
 }
 
 // writeInvalidApiVersionHTTP mirrors rippled's HTTP-single rejection of an
@@ -409,16 +409,7 @@ func (s *Server) dispatchBatchElement(el json.RawMessage, baseCtx context.Contex
 		return batchMalformedElement(elem, "method is empty")
 	}
 
-	ctx := &types.RpcContext{
-		Context:    baseCtx,
-		Role:       role,
-		ApiVersion: types.DefaultApiVersion,
-		IsAdmin:    role == types.RoleAdmin,
-		Unlimited:  role.IsUnlimited(),
-		ClientIP:   clientIP,
-		PeerSource: s.loadPeerSource(),
-		Services:   s.services,
-	}
+	ctx := newRpcContext(baseCtx, role, types.DefaultApiVersion, clientIP, s.loadPeerSource(), s.services)
 	if ver, ok := apiVersionFromBatchElement(elem); ok {
 		ctx.ApiVersion = ver
 	}
@@ -444,7 +435,7 @@ func (s *Server) dispatchBatchElement(el json.RawMessage, baseCtx context.Contex
 	maps.Copy(echo, elem)
 	redactCredentials(echo)
 	echo["command"] = method
-	return buildXrplResponseBody(echo, result, rpcErr, nil)
+	return buildXrplResponseBody(echo, result, rpcErr, loadWarningOpts(ctx))
 }
 
 // rpcMethodNotFoundCode is the JSON-RPC error code rippled attaches to malformed
@@ -502,6 +493,21 @@ func (s *Server) withTimeout(parent context.Context) (context.Context, context.C
 	return context.WithTimeout(parent, s.timeout)
 }
 
+// newRpcContext assembles an RpcContext, deriving IsAdmin / Unlimited from the
+// role so every HTTP/WS dispatch site computes them identically.
+func newRpcContext(ctx context.Context, role types.Role, apiVersion int, clientIP string, peers types.PeerSource, services *types.ServiceContainer) *types.RpcContext {
+	return &types.RpcContext{
+		Context:    ctx,
+		Role:       role,
+		ApiVersion: apiVersion,
+		IsAdmin:    role == types.RoleAdmin,
+		Unlimited:  role.IsUnlimited(),
+		ClientIP:   clientIP,
+		PeerSource: peers,
+		Services:   services,
+	}
+}
+
 // credentialKeys are request fields masked in error envelopes.
 // rippled (ServerHandler.cpp:535-542) masks only the lowercase
 // top-level keys "passphrase", "secret", "seed", "seed_hex"; goxrpl
@@ -534,8 +540,28 @@ func redactCredentials(m map[string]any) {
 
 func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types.RpcContext) (any, *types.RpcError) {
 	rpcLog().Debug("rpc", "method", method, "client", ctx.ClientIP)
+	// The HTTP admin gate returns rpcNO_PERMISSION (rippled RPCHandler.cpp:166);
+	// the WS path passes RpcErrorForbidden instead (ServerHandler.cpp:482-486).
+	return dispatchMethod(s.registry, s.loadTracker, s.services, ctx, method, params, types.RpcErrorNoPermission, rpcLog())
+}
 
-	handler, exists := s.registry.Get(method)
+// dispatchMethod is the transport-agnostic dispatch core shared by the HTTP
+// (Server.executeMethod) and WebSocket (WebSocketServer.handleRPCMethod)
+// paths: registry lookup → admin gate → conditionMet → api-version → busy →
+// load gate → handle → load finalize. Hoisting it keeps the two transports
+// from drifting (the WS path previously skipped conditionMet). The only
+// transport-specific bit is the admin-gate error, supplied by adminGate.
+func dispatchMethod(
+	registry *types.MethodRegistry,
+	tracker *loadtrack.Tracker,
+	services *types.ServiceContainer,
+	ctx *types.RpcContext,
+	method string,
+	params json.RawMessage,
+	adminGate func(string) *types.RpcError,
+	log xrpllog.Logger,
+) (any, *types.RpcError) {
+	handler, exists := registry.Get(method)
 	if !exists {
 		return nil, types.RpcErrorMethodNotFound(method)
 	}
@@ -544,7 +570,7 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 	// if (handler->role_ == Role::ADMIN && context.role != Role::ADMIN)
 	//     return rpcNO_PERMISSION;
 	if handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
-		return nil, types.RpcErrorNoPermission(method)
+		return nil, adminGate(method)
 	}
 
 	// Enforce the method's precondition, mirroring rippled's RPC::conditionMet
@@ -560,15 +586,15 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
 		return nil, rpcErr
 	}
-	if err := gateLoad(s.loadTracker, ctx, method, rpcLog()); err != nil {
+	if err := gateLoad(tracker, ctx, method, log); err != nil {
 		return nil, err
 	}
-	if s.services != nil && s.services.ClientLoad != nil {
-		s.services.ClientLoad.Begin()
-		defer s.services.ClientLoad.End()
+	if services != nil && services.ClientLoad != nil {
+		services.ClientLoad.Begin()
+		defer services.ClientLoad.End()
 	}
 	result, rpcErr := handler.Handle(ctx, params)
-	finalizeLoad(s.loadTracker, ctx, method, handler, rpcErr, rpcLog())
+	finalizeLoad(tracker, ctx, method, handler, rpcErr, log)
 	return result, rpcErr
 }
 
@@ -725,6 +751,8 @@ func finalizeLoad(tracker *loadtrack.Tracker, ctx *types.RpcContext, method stri
 		log.Warn("rpc client crossed drop threshold (post-charge)",
 			"client", ctx.ClientIP, "method", method, "balance", tracker.Balance(ctx.ClientIP))
 	case loadtrack.OutcomeWarn:
+		// Surface rippled's warning:"load" on the reply (ServerHandler.cpp:519,920).
+		ctx.LoadWarning = true
 		log.Info("rpc client over warn threshold",
 			"client", ctx.ClientIP, "method", method, "balance", tracker.Balance(ctx.ClientIP))
 	}
@@ -749,11 +777,15 @@ func loadKindFor(handler types.MethodHandler, rpcErr *types.RpcError) loadtrack.
 	return loadtrack.LoadReference
 }
 
-// writeXrplResponse writes an XRPL format JSON-RPC response. Per XRPL spec
-// result.status is "success" or "error" and warning/warnings/forwarded
-// live at the top level, not inside result.
-func (s *Server) writeXrplResponse(w http.ResponseWriter, method string, request any, result any, rpcErr *types.RpcError) {
-	s.writeXrplResponseWithOptions(w, method, request, result, rpcErr, nil)
+// loadWarningOpts returns response options carrying warning:"load" when the
+// dispatch crossed the resource warn threshold (recorded on ctx by
+// finalizeLoad), and nil otherwise. Mirrors rippled attaching
+// jr[warning]=load after the post-dispatch charge.
+func loadWarningOpts(ctx *types.RpcContext) *JsonRpcResponseOptions {
+	if ctx != nil && ctx.LoadWarning {
+		return &JsonRpcResponseOptions{Warning: "load"}
+	}
+	return nil
 }
 
 // buildXrplResponseBody assembles the `{"result": {...}}` envelope (plus any
@@ -805,7 +837,7 @@ func buildXrplResponseBody(request any, result any, rpcErr *types.RpcError, opts
 	return response
 }
 
-func (s *Server) writeXrplResponseWithOptions(w http.ResponseWriter, method string, request any, result any, rpcErr *types.RpcError, opts *JsonRpcResponseOptions) {
+func (s *Server) writeXrplResponseWithOptions(w http.ResponseWriter, request any, result any, rpcErr *types.RpcError, opts *JsonRpcResponseOptions) {
 	response := buildXrplResponseBody(request, result, rpcErr, opts)
 
 	// Stream-encode straight to the response writer through trimNewlineWriter.
@@ -862,7 +894,7 @@ func (t *trimNewlineWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func (s *Server) writeXrplError(w http.ResponseWriter, method string, request any, errorCode string, message string) {
+func (s *Server) writeXrplError(w http.ResponseWriter, request any, errorCode string, message string) {
 	resultObj := map[string]any{
 		"status":        "error",
 		"error":         errorCode,
@@ -888,16 +920,12 @@ func (s *Server) writeXrplError(w http.ResponseWriter, method string, request an
 }
 
 // ExecuteMethod implements types.MethodDispatcher, allowing the 'json' RPC
-// method to forward calls through the same method registry.
-func (s *Server) ExecuteMethod(method string, params []byte) (any, *types.RpcError) {
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.DefaultApiVersion,
-		IsAdmin:    false,
-		PeerSource: s.loadPeerSource(),
-		Services:   s.services,
-	}
+// method to forward calls through the same method registry. The caller's
+// context is reused so the forwarded method keeps the request's timeout,
+// role, client IP and api version, and is charged for load under the real
+// client IP (a fresh guest/empty-IP context previously let `json` callers
+// dodge per-IP charging and escape the request timeout).
+func (s *Server) ExecuteMethod(ctx *types.RpcContext, method string, params []byte) (any, *types.RpcError) {
 	return s.executeMethod(method, json.RawMessage(params), ctx)
 }
 

--- a/internal/rpc/subscribe_conformance_test.go
+++ b/internal/rpc/subscribe_conformance_test.go
@@ -330,15 +330,15 @@ func TestSubscribeConformanceAccountsProposedUnsubscribe(t *testing.T) {
 	require.Nil(t, err)
 
 	// Verify subscription was recorded
-	config, exists := conn.Subscriptions[types.SubscriptionType("accounts_proposed")]
+	config, exists := conn.Subscriptions[types.SubAccountsProposed]
 	require.True(t, exists, "accounts_proposed subscription should be recorded")
 	assert.Equal(t, 2, len(config.Accounts))
 
 	// Unsubscribe from accounts_proposed by removing the subscription type directly
 	// (The HandleUnsubscribe currently only handles Accounts, not AccountsProposed;
 	// this test documents the current behavior.)
-	delete(conn.Subscriptions, types.SubscriptionType("accounts_proposed"))
-	_, exists = conn.Subscriptions[types.SubscriptionType("accounts_proposed")]
+	delete(conn.Subscriptions, types.SubAccountsProposed)
+	_, exists = conn.Subscriptions[types.SubAccountsProposed]
 	assert.False(t, exists, "accounts_proposed subscription should be removed")
 }
 

--- a/internal/rpc/subscribe_conformance_test.go
+++ b/internal/rpc/subscribe_conformance_test.go
@@ -953,8 +953,8 @@ func TestSubscribeConformanceIncrementalAccounts(t *testing.T) {
 }
 
 // TestSubscribeConformanceIncrementalAccountsProposed is the accounts_proposed
-// analogue of the accounts merge (H1): the second subscribe previously
-// overwrote the first outright.
+// analogue of the accounts merge (H1): a second subscribe must accumulate onto
+// the existing set rather than overwrite it.
 func TestSubscribeConformanceIncrementalAccountsProposed(t *testing.T) {
 	sm := newTestSubscriptionManager()
 	conn := newTestConnection("test-conn-1")

--- a/internal/rpc/subscribe_conformance_test.go
+++ b/internal/rpc/subscribe_conformance_test.go
@@ -918,3 +918,140 @@ func TestSubscribeConformanceStructuralCheckFirst(t *testing.T) {
 	assert.Equal(t, "invalidParams", err.ErrorString)
 	assert.Equal(t, "Invalid parameters.", err.Message)
 }
+
+// TestSubscribeConformanceIncrementalAccounts verifies a second account
+// subscribe accumulates onto the existing set rather than replacing it (H1):
+// rippled's subAccount inserts into the connection's listener set per call,
+// so the first subscribe's account must keep receiving broadcasts and a
+// re-subscribe must not duplicate it.
+func TestSubscribeConformanceIncrementalAccounts(t *testing.T) {
+	sm := newTestSubscriptionManager()
+	conn := newTestConnection("test-conn-1")
+	sm.AddConnection(conn)
+	defer sm.RemoveConnection(conn.ID)
+
+	alice := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	bob := "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+
+	require.Nil(t, sm.HandleSubscribe(conn, types.SubscriptionRequest{Accounts: []string{alice}}, true))
+	require.Nil(t, sm.HandleSubscribe(conn, types.SubscriptionRequest{Accounts: []string{bob}}, true))
+
+	for _, acc := range []string{alice, bob} {
+		msg := []byte(`{"account":"` + acc + `"}`)
+		sm.BroadcastToAccounts(msg, []string{acc})
+		select {
+		case got := <-conn.SendChannel:
+			assert.Equal(t, msg, got)
+		default:
+			t.Fatalf("account %s should still receive broadcasts after an incremental subscribe", acc)
+		}
+	}
+
+	// Re-subscribing an existing account must not duplicate it.
+	require.Nil(t, sm.HandleSubscribe(conn, types.SubscriptionRequest{Accounts: []string{alice}}, true))
+	assert.ElementsMatch(t, []string{alice, bob}, conn.Subscriptions[types.SubAccounts].Accounts)
+}
+
+// TestSubscribeConformanceIncrementalAccountsProposed is the accounts_proposed
+// analogue of the accounts merge (H1): the second subscribe previously
+// overwrote the first outright.
+func TestSubscribeConformanceIncrementalAccountsProposed(t *testing.T) {
+	sm := newTestSubscriptionManager()
+	conn := newTestConnection("test-conn-1")
+	sm.AddConnection(conn)
+	defer sm.RemoveConnection(conn.ID)
+
+	alice := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	bob := "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+
+	require.Nil(t, sm.HandleSubscribe(conn, types.SubscriptionRequest{AccountsProposed: []string{alice}}, true))
+	require.Nil(t, sm.HandleSubscribe(conn, types.SubscriptionRequest{AccountsProposed: []string{bob}}, true))
+
+	for _, acc := range []string{alice, bob} {
+		msg := []byte(`{"account":"` + acc + `"}`)
+		sm.BroadcastToAccountsProposed(msg, []string{acc})
+		select {
+		case got := <-conn.SendChannel:
+			assert.Equal(t, msg, got)
+		default:
+			t.Fatalf("accounts_proposed %s should still receive broadcasts after an incremental subscribe", acc)
+		}
+	}
+}
+
+// TestSubscribeConformanceIncrementalBooks verifies a second book subscribe
+// accumulates onto the existing set rather than wiping it (H2): rippled calls
+// subBook once per entry, so an earlier book must keep matching broadcasts.
+func TestSubscribeConformanceIncrementalBooks(t *testing.T) {
+	sm := newTestSubscriptionManager()
+	conn := newTestConnection("test-conn-1")
+	sm.AddConnection(conn)
+	defer sm.RemoveConnection(conn.ID)
+
+	issuer := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	bookA := mustBook(t,
+		map[string]any{"currency": "USD", "issuer": issuer},
+		map[string]any{"currency": "XRP"})
+	bookB := mustBook(t,
+		map[string]any{"currency": "EUR", "issuer": issuer},
+		map[string]any{"currency": "XRP"})
+
+	require.Nil(t, sm.HandleSubscribe(conn, types.SubscriptionRequest{Books: []types.BookRequest{bookA}}, true))
+	require.Nil(t, sm.HandleSubscribe(conn, types.SubscriptionRequest{Books: []types.BookRequest{bookB}}, true))
+
+	xrp := types.CurrencySpec{Currency: "XRP"}
+	for _, pays := range []types.CurrencySpec{
+		{Currency: "USD", Issuer: issuer},
+		{Currency: "EUR", Issuer: issuer},
+	} {
+		msg := []byte(`{"book":"` + pays.Currency + `"}`)
+		sm.BroadcastToOrderBook(msg, xrp, pays)
+		select {
+		case got := <-conn.SendChannel:
+			assert.Equal(t, msg, got)
+		default:
+			t.Fatalf("book %s/XRP should still match after an incremental subscribe", pays.Currency)
+		}
+	}
+}
+
+// TestUnsubscribeConformancePerBook verifies unsubscribe removes only the named
+// book, leaving the connection's other book subscriptions intact (H2): rippled
+// calls unsubBook per entry rather than dropping the whole set.
+func TestUnsubscribeConformancePerBook(t *testing.T) {
+	sm := newTestSubscriptionManager()
+	conn := newTestConnection("test-conn-1")
+	sm.AddConnection(conn)
+	defer sm.RemoveConnection(conn.ID)
+
+	issuer := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	bookA := mustBook(t,
+		map[string]any{"currency": "USD", "issuer": issuer},
+		map[string]any{"currency": "XRP"})
+	bookB := mustBook(t,
+		map[string]any{"currency": "EUR", "issuer": issuer},
+		map[string]any{"currency": "XRP"})
+
+	require.Nil(t, sm.HandleSubscribe(conn, types.SubscriptionRequest{Books: []types.BookRequest{bookA, bookB}}, true))
+	require.Nil(t, sm.HandleUnsubscribe(conn, types.SubscriptionRequest{Books: []types.BookRequest{bookA}}, true))
+
+	xrp := types.CurrencySpec{Currency: "XRP"}
+
+	// Book A no longer matches.
+	sm.BroadcastToOrderBook([]byte(`{"book":"USD"}`), xrp, types.CurrencySpec{Currency: "USD", Issuer: issuer})
+	select {
+	case <-conn.SendChannel:
+		t.Fatal("book USD/XRP should not match after unsubscribe")
+	default:
+	}
+
+	// Book B still matches.
+	msg := []byte(`{"book":"EUR"}`)
+	sm.BroadcastToOrderBook(msg, xrp, types.CurrencySpec{Currency: "EUR", Issuer: issuer})
+	select {
+	case got := <-conn.SendChannel:
+		assert.Equal(t, msg, got)
+	default:
+		t.Fatal("book EUR/XRP should still match after unsubscribing only USD/XRP")
+	}
+}

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -3,6 +3,7 @@ package subscription
 import (
 	"encoding/hex"
 	"encoding/json"
+	"maps"
 	"sync"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -131,21 +132,10 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 				return types.RpcErrorActMalformed("Account malformed.")
 			}
 		}
-		// Merge with existing accounts, avoiding duplicates.
-		merged := accounts
-		if existing, ok := conn.Subscriptions[types.SubAccounts]; ok {
-			existingMap := make(map[string]bool)
-			for _, acc := range existing.Accounts {
-				existingMap[acc] = true
-			}
-			for _, acc := range accounts {
-				if !existingMap[acc] {
-					merged = append(merged, acc)
-				}
-			}
-		}
+		// Accumulate onto the existing subscription rather than replacing it.
+		existing := conn.Subscriptions[types.SubAccounts]
 		conn.Subscriptions[types.SubAccounts] = types.SubscriptionConfig{
-			Accounts: merged,
+			Accounts: mergeAccounts(existing.Accounts, accounts),
 		}
 	}
 
@@ -163,8 +153,11 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 				return types.RpcErrorActMalformed("Account malformed.")
 			}
 		}
+		// Accumulate, mirroring the accounts branch above (rippled's
+		// subAccount with rt=true).
+		existing := conn.Subscriptions["accounts_proposed"]
 		conn.Subscriptions["accounts_proposed"] = types.SubscriptionConfig{
-			Accounts: proposed,
+			Accounts: mergeAccounts(existing.Accounts, proposed),
 		}
 	}
 
@@ -185,19 +178,13 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 			}
 			normalised = append(normalised, book)
 			if book.Both {
-				normalised = append(normalised, types.BookRequest{
-					TakerPays: book.TakerGets,
-					TakerGets: book.TakerPays,
-					Snapshot:  book.Snapshot,
-					Both:      false,
-					Taker:     book.Taker,
-					Domain:    book.Domain,
-				})
+				normalised = append(normalised, reverseBook(book))
 			}
 		}
 		if len(normalised) > 0 {
+			existing := conn.Subscriptions[types.SubBook]
 			conn.Subscriptions[types.SubBook] = types.SubscriptionConfig{
-				Books: normalised,
+				Books: mergeBooks(existing.Books, normalised),
 			}
 		}
 	}
@@ -208,6 +195,84 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 // isValidXRPLAddress checks if a string is a valid XRPL address
 func isValidXRPLAddress(addr string) bool {
 	return addresscodec.IsValidClassicAddress(addr)
+}
+
+// mergeAccounts accumulates incoming account ids onto the existing set,
+// preserving order and skipping ids already present. rippled's subAccount
+// inserts into the connection's existing listener set across repeated
+// subscribe calls rather than replacing it, so a later subscribe must not
+// drop accounts subscribed earlier.
+func mergeAccounts(existing, incoming []string) []string {
+	merged := append([]string(nil), existing...)
+	seen := make(map[string]bool, len(existing))
+	for _, acc := range existing {
+		seen[acc] = true
+	}
+	for _, acc := range incoming {
+		if !seen[acc] {
+			seen[acc] = true
+			merged = append(merged, acc)
+		}
+	}
+	return merged
+}
+
+// reverseBook swaps a book's pays/gets sides, used to register (and
+// unregister) the opposite side of a both:true subscription.
+func reverseBook(b types.BookRequest) types.BookRequest {
+	return types.BookRequest{
+		TakerPays: b.TakerGets,
+		TakerGets: b.TakerPays,
+		Snapshot:  b.Snapshot,
+		Both:      false,
+		Taker:     b.Taker,
+		Domain:    b.Domain,
+	}
+}
+
+// bookKey identifies a book subscription by its currency pair and domain —
+// the fields that decide which broadcasts it receives. Snapshot and taker
+// are per-request and excluded so a re-subscribe doesn't register a
+// duplicate listener for the same market.
+func bookKey(b types.BookRequest) string {
+	return string(b.TakerPays) + "\x00" + string(b.TakerGets) + "\x00" + b.Domain
+}
+
+// mergeBooks accumulates incoming book subscriptions onto the existing set,
+// skipping markets already subscribed. rippled calls subBook once per entry
+// rather than replacing the whole set, so a second subscribe must not wipe
+// an earlier book.
+func mergeBooks(existing, incoming []types.BookRequest) []types.BookRequest {
+	merged := append([]types.BookRequest(nil), existing...)
+	seen := make(map[string]bool, len(existing))
+	for _, b := range existing {
+		seen[bookKey(b)] = true
+	}
+	for _, b := range incoming {
+		k := bookKey(b)
+		if !seen[k] {
+			seen[k] = true
+			merged = append(merged, b)
+		}
+	}
+	return merged
+}
+
+// removeBooks returns existing minus every market named in remove (matched
+// by bookKey), mirroring rippled's per-book unsubBook — unsubscribing a
+// market leaves the connection's other book subscriptions intact.
+func removeBooks(existing, remove []types.BookRequest) []types.BookRequest {
+	removeSet := make(map[string]bool, len(remove))
+	for _, b := range remove {
+		removeSet[bookKey(b)] = true
+	}
+	var remaining []types.BookRequest
+	for _, b := range existing {
+		if !removeSet[bookKey(b)] {
+			remaining = append(remaining, b)
+		}
+	}
+	return remaining
 }
 
 // jsonIsArray reports whether a raw JSON value (already valid JSON) is an
@@ -612,13 +677,25 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 		return rpcErr
 	}
 	if booksPresent {
+		var toRemove []types.BookRequest
 		for _, book := range books {
 			if rpcErr := validateBook(book, false); rpcErr != nil {
 				return rpcErr
 			}
+			toRemove = append(toRemove, book)
+			if book.Both {
+				toRemove = append(toRemove, reverseBook(book))
+			}
 		}
-		if len(books) > 0 {
-			delete(conn.Subscriptions, types.SubBook)
+		if len(toRemove) > 0 {
+			if existing, ok := conn.Subscriptions[types.SubBook]; ok {
+				remaining := removeBooks(existing.Books, toRemove)
+				if len(remaining) > 0 {
+					conn.Subscriptions[types.SubBook] = types.SubscriptionConfig{Books: remaining}
+				} else {
+					delete(conn.Subscriptions, types.SubBook)
+				}
+			}
 		}
 	}
 
@@ -795,7 +872,9 @@ func (sm *Manager) IsSubscribed(connID string, streamType types.SubscriptionType
 	return ok
 }
 
-// GetConnectionSubscriptions returns the subscriptions for a connection
+// GetConnectionSubscriptions returns a copy of the subscriptions for a
+// connection. A copy (not the live map) so the caller can iterate without
+// holding sm.mu while HandleSubscribe / HandleUnsubscribe mutate the original.
 func (sm *Manager) GetConnectionSubscriptions(connID string) map[types.SubscriptionType]types.SubscriptionConfig {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
@@ -803,7 +882,7 @@ func (sm *Manager) GetConnectionSubscriptions(connID string) map[types.Subscript
 	if conn == nil {
 		return nil
 	}
-	return conn.Subscriptions
+	return maps.Clone(conn.Subscriptions)
 }
 
 // GetSubscribeResponse creates a subscribe confirmation response

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -155,8 +155,8 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 		}
 		// Accumulate, mirroring the accounts branch above (rippled's
 		// subAccount with rt=true).
-		existing := conn.Subscriptions["accounts_proposed"]
-		conn.Subscriptions["accounts_proposed"] = types.SubscriptionConfig{
+		existing := conn.Subscriptions[types.SubAccountsProposed]
+		conn.Subscriptions[types.SubAccountsProposed] = types.SubscriptionConfig{
 			Accounts: mergeAccounts(existing.Accounts, proposed),
 		}
 	}
@@ -230,12 +230,39 @@ func reverseBook(b types.BookRequest) types.BookRequest {
 	}
 }
 
-// bookKey identifies a book subscription by its currency pair and domain —
-// the fields that decide which broadcasts it receives. Snapshot and taker
-// are per-request and excluded so a re-subscribe doesn't register a
-// duplicate listener for the same market.
+// bookKey identifies a book subscription by its parsed currency pair and
+// domain — the fields that decide which broadcasts it receives. Parsing to the
+// canonical 160-bit currency/issuer (rather than comparing the raw request
+// bytes) folds a currency and its 40-hex form, and the various XRP spellings,
+// onto a single key, matching rippled's Book{in,out,domain} identity
+// (Book.h:79-84). Without it a re-subscribe or unsubscribe that spells the
+// same market differently would slip past dedup/removal. Snapshot and taker
+// are per-request and excluded.
 func bookKey(b types.BookRequest) string {
+	paysCur, paysIsr, paysOK := bookSideIDs(b.TakerPays, true)
+	getsCur, getsIsr, getsOK := bookSideIDs(b.TakerGets, false)
+	if paysOK && getsOK {
+		return string(paysCur[:]) + string(paysIsr[:]) +
+			string(getsCur[:]) + string(getsIsr[:]) + "\x00" + b.Domain
+	}
+	// Fallback for inputs that fail to parse (should not occur once
+	// validateBook has accepted the entry): compare the raw request bytes.
 	return string(b.TakerPays) + "\x00" + string(b.TakerGets) + "\x00" + b.Domain
+}
+
+// bookSideIDs parses one side of a book entry into its canonical 160-bit
+// currency and issuer ids, reporting ok=false when the side is missing or
+// malformed.
+func bookSideIDs(raw json.RawMessage, isPays bool) (currencyID, issuerID [20]byte, ok bool) {
+	side, rpcErr := bookSideObject(raw)
+	if rpcErr != nil {
+		return currencyID, issuerID, false
+	}
+	currencyID, issuerID, rpcErr = parseBookSide(side, isPays)
+	if rpcErr != nil {
+		return currencyID, issuerID, false
+	}
+	return currencyID, issuerID, true
 }
 
 // mergeBooks accumulates incoming book subscriptions onto the existing set,
@@ -648,7 +675,7 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 				return types.RpcErrorActMalformed("Account malformed.")
 			}
 		}
-		if existing, ok := conn.Subscriptions["accounts_proposed"]; ok {
+		if existing, ok := conn.Subscriptions[types.SubAccountsProposed]; ok {
 			accountsToRemove := make(map[string]bool)
 			for _, acc := range proposed {
 				accountsToRemove[acc] = true
@@ -660,11 +687,11 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 				}
 			}
 			if len(remainingAccounts) > 0 {
-				conn.Subscriptions["accounts_proposed"] = types.SubscriptionConfig{
+				conn.Subscriptions[types.SubAccountsProposed] = types.SubscriptionConfig{
 					Accounts: remainingAccounts,
 				}
 			} else {
-				delete(conn.Subscriptions, "accounts_proposed")
+				delete(conn.Subscriptions, types.SubAccountsProposed)
 			}
 		}
 	}
@@ -763,7 +790,7 @@ func (sm *Manager) BroadcastToAccounts(data []byte, accounts []string) {
 // BroadcastToAccountsProposed sends a message to accounts_proposed
 // subscribers.
 func (sm *Manager) BroadcastToAccountsProposed(data []byte, accounts []string) {
-	deliver(sm.collectAccountTargets("accounts_proposed", accounts), data)
+	deliver(sm.collectAccountTargets(types.SubAccountsProposed, accounts), data)
 }
 
 func (sm *Manager) collectAccountTargets(stream types.SubscriptionType, accounts []string) []*types.Connection {

--- a/internal/rpc/subscription/manager_test.go
+++ b/internal/rpc/subscription/manager_test.go
@@ -1,0 +1,44 @@
+package subscription
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBookKeyFoldsCurrencySpellings pins M7: a market subscribed with a 3-char
+// ISO currency and the same market spelled as its 40-hex form share one
+// bookKey, so they dedup on subscribe and match on unsubscribe — mirroring
+// rippled's parsed Book{in,out} identity (Book.h:79-84) rather than a raw-byte
+// comparison. A genuinely different currency must keep a distinct key.
+func TestBookKeyFoldsCurrencySpellings(t *testing.T) {
+	const issuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	// "USD" (0x55 0x53 0x44) packed at bytes 12-14 of the 160-bit currency.
+	const hexUSD = "0000000000000000000000005553440000000000"
+
+	iso := types.BookRequest{
+		TakerPays: []byte(`{"currency":"USD","issuer":"` + issuer + `"}`),
+		TakerGets: []byte(`{"currency":"XRP"}`),
+	}
+	hex := types.BookRequest{
+		TakerPays: []byte(`{"currency":"` + hexUSD + `","issuer":"` + issuer + `"}`),
+		TakerGets: []byte(`{"currency":"XRP"}`),
+	}
+	eur := types.BookRequest{
+		TakerPays: []byte(`{"currency":"EUR","issuer":"` + issuer + `"}`),
+		TakerGets: []byte(`{"currency":"XRP"}`),
+	}
+
+	assert.Equal(t, bookKey(iso), bookKey(hex),
+		"USD and its 40-hex encoding must collapse to one bookKey")
+	assert.NotEqual(t, bookKey(iso), bookKey(eur),
+		"distinct currencies must keep distinct bookKeys")
+
+	// The fold must carry through dedup and per-book removal.
+	merged := mergeBooks([]types.BookRequest{iso}, []types.BookRequest{hex})
+	assert.Len(t, merged, 1, "re-subscribing the same market spelled differently must not duplicate")
+
+	remaining := removeBooks([]types.BookRequest{iso}, []types.BookRequest{hex})
+	assert.Empty(t, remaining, "unsubscribing the same market spelled differently must remove it")
+}

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -290,10 +290,6 @@ func RpcErrorNotStandalone(message string) *RpcError {
 	return e
 }
 
-func RpcErrorShutDown(message string) *RpcError {
-	return NewRpcError(RpcSHUT_DOWN, "shutDown", "shutDown", message)
-}
-
 // InvalidApiVersionToken is the literal rippled writes for an unsupported
 // api_version (jss::invalid_API_version). rippled emits it bare — no numeric
 // code, no message — on every transport; only the envelope differs

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -192,12 +192,11 @@ const (
 	// slot 38 to stay distinct from every real rippled code.
 	RpcINVALID_API_VERSION = 38
 
-	// RpcNOT_STANDALONE / RpcSHUT_DOWN have no rippled enum entry. rippled's
-	// ledger_accept handler emits a bare "notStandAlone" token with no numeric
-	// code (LedgerAccept.cpp:40); these map to RpcUNKNOWN (-1), rippled's
-	// "code not listed in this enumeration".
+	// RpcNOT_STANDALONE has no rippled enum entry. rippled's ledger_accept
+	// handler emits a bare "notStandAlone" token with no numeric code
+	// (LedgerAccept.cpp:40); it maps to RpcUNKNOWN (-1), rippled's "code not
+	// listed in this enumeration".
 	RpcNOT_STANDALONE = RpcUNKNOWN
-	RpcSHUT_DOWN      = RpcUNKNOWN
 )
 
 // Standard error constructors

--- a/internal/rpc/types/errors_test.go
+++ b/internal/rpc/types/errors_test.go
@@ -124,7 +124,6 @@ func TestGoxrplSpecificCodesDoNotCollide(t *testing.T) {
 	}{
 		{"RpcINVALID_API_VERSION", RpcINVALID_API_VERSION},
 		{"RpcNOT_STANDALONE", RpcNOT_STANDALONE},
-		{"RpcSHUT_DOWN", RpcSHUT_DOWN},
 	} {
 		if rippledValues[c.code] {
 			t.Errorf("%s = %d collides with a rippled error_code_i value", c.name, c.code)

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -12,9 +12,12 @@ import (
 )
 
 // MethodDispatcher allows forwarding RPC calls to the method registry.
-// Used by the 'json' RPC method to proxy calls.
+// Used by the 'json' RPC method to proxy calls. The caller's RpcContext is
+// threaded through so the forwarded method keeps the request's timeout,
+// role, client IP and api version — without it a guest could wrap a heavy
+// method in `json` to escape per-IP load charging.
 type MethodDispatcher interface {
-	ExecuteMethod(method string, params []byte) (any, *RpcError)
+	ExecuteMethod(ctx *RpcContext, method string, params []byte) (any, *RpcError)
 }
 
 // ValidatorListPublisherInfo is the per-publisher snapshot the

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -236,6 +236,7 @@ const (
 	SubTransactions         SubscriptionType = "transactions"
 	SubTransactionsProposed SubscriptionType = "transactions_proposed"
 	SubAccounts             SubscriptionType = "accounts"
+	SubAccountsProposed     SubscriptionType = "accounts_proposed"
 	SubBook                 SubscriptionType = "book"
 	SubBookChanges          SubscriptionType = "book_changes"
 	SubValidations          SubscriptionType = "validations"

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -101,6 +101,11 @@ type RpcContext struct {
 	// fixtures they need. Replaces the former package-level
 	// types.Services global.
 	Services *ServiceContainer
+	// LoadWarning is set by the post-dispatch load charge when the caller
+	// crosses the resource warn threshold. Transport writers surface it as
+	// the top-level warning:"load" field, mirroring rippled's
+	// `if (consumer.warn()) jr[warning] = load`.
+	LoadWarning bool
 }
 
 // Method handler interface - all RPC methods implement this
@@ -174,33 +179,6 @@ type LedgerSpecifier struct {
 	LedgerIndex LedgerIndex `json:"ledger_index,omitempty"` // can be number or "validated", "current", "closed"
 }
 
-// JSON-RPC 2.0 Request
-type JsonRpcRequest struct {
-	JsonRpc string          `json:"jsonrpc"`
-	Method  string          `json:"method"`
-	Params  json.RawMessage `json:"params,omitempty"`
-	ID      any             `json:"id,omitempty"`
-}
-
-// JSON-RPC 2.0 Response
-type JsonRpcResponse struct {
-	JsonRpc string    `json:"jsonrpc"`
-	Result  any       `json:"result,omitempty"`
-	Error   *RpcError `json:"error,omitempty"`
-	ID      any       `json:"id,omitempty"`
-}
-
-// Base response structure for XRPL RPC responses
-type BaseResponse struct {
-	// Standard fields present in most responses
-	Status        string `json:"status,omitempty"`
-	Type          string `json:"type,omitempty"`
-	Validated     *bool  `json:"validated,omitempty"`
-	LedgerHash    string `json:"ledger_hash,omitempty"`
-	LedgerIndex   uint32 `json:"ledger_index,omitempty"`
-	LedgerCurrent uint32 `json:"ledger_current_index,omitempty"`
-}
-
 // API Warning IDs as defined in XRPL documentation
 const (
 	WarningUnsupportedAmendmentsMajority = 1001 // Unsupported amendments have reached majority
@@ -215,12 +193,14 @@ type WarningObject struct {
 	Details map[string]any `json:"details,omitempty"` // Additional warning-specific information
 }
 
-// WebSocket specific structures
+// WebSocketCommand is assembled by the WS read loop from the decoded
+// message: Command/ID are lifted from the top level and Params holds the
+// remaining fields. It is never JSON-(un)marshalled directly, so Params
+// carries no wire tag.
 type WebSocketCommand struct {
-	Command    string          `json:"command"`
-	ID         any             `json:"id,omitempty"`
-	ApiVersion *int            `json:"api_version,omitempty"`
-	Params     json.RawMessage `json:",inline,omitempty"`
+	Command string
+	ID      any
+	Params  json.RawMessage
 }
 
 // WebSocketResponse represents an XRPL WebSocket API response
@@ -236,6 +216,10 @@ type WebSocketResponse struct {
 	Error        string          `json:"error,omitempty"`
 	ErrorCode    int             `json:"error_code,omitempty"`
 	ErrorMessage string          `json:"error_message,omitempty"`
+	// Request echoes the original command back on an error reply. rippled's
+	// WS missingCommand path returns the unparsed request alongside the
+	// error token (ServerHandler.cpp:457).
+	Request any `json:"request,omitempty"`
 }
 
 // Subscription types for WebSocket streams. Rippled's per-book stream
@@ -408,22 +392,6 @@ type BookRequest struct {
 	Domain string `json:"domain,omitempty"`
 }
 
-// Stream message types
-type StreamMessage struct {
-	Type        string          `json:"type"`
-	LedgerIndex uint32          `json:"ledger_index,omitempty"`
-	LedgerHash  string          `json:"ledger_hash,omitempty"`
-	LedgerTime  uint32          `json:"ledger_time,omitempty"`
-	FeeBase     uint32          `json:"fee_base,omitempty"`
-	FeeRef      uint32          `json:"fee_ref,omitempty"`
-	ReserveBase uint32          `json:"reserve_base,omitempty"`
-	ReserveInc  uint32          `json:"reserve_inc,omitempty"`
-	Validated   bool            `json:"validated,omitempty"`
-	Transaction json.RawMessage `json:"transaction,omitempty"`
-	Meta        json.RawMessage `json:"meta,omitempty"`
-	Account     string          `json:"account,omitempty"`
-}
-
 // Common parameter structures
 
 // Account parameter
@@ -448,9 +416,6 @@ type Currency struct {
 	Currency string `json:"currency"`
 	Issuer   string `json:"issuer,omitempty"`
 }
-
-// RawAmount can be drops (string) or IOU object (used for JSON parsing)
-type RawAmount json.RawMessage
 
 // Path specification for path finding
 type Path []PathStep
@@ -650,12 +615,4 @@ type LedgerSubscribeInfo struct {
 	// XRPFeesEnabled gates fee_ref: rippled emits the deprecated fee_ref
 	// only while the XRPFees amendment is disabled.
 	XRPFeesEnabled bool `json:"-"`
-}
-
-// ServerSubscribeInfo contains server info returned when subscribing to server stream
-type ServerSubscribeInfo struct {
-	ServerStatus string `json:"server_status"`
-	LoadBase     int    `json:"load_base"`
-	LoadFactor   int    `json:"load_factor"`
-	StandAlone   bool   `json:"stand_alone,omitempty"`
 }

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -5,6 +5,7 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"runtime/debug"
@@ -49,8 +50,8 @@ type WebSocketServer struct {
 	connLimiter         *ConnLimiter
 	services            *types.ServiceContainer
 	urlSubs             *URLSubscriptionRegistry
-	peerSource          atomic.Pointer[types.PeerSource]
-	loadTracker         *loadtrack.Tracker
+	peerSourceHolder
+	loadTracker *loadtrack.Tracker
 	// pingInterval is how often pingLoop sends a keepalive ping. Settable
 	// so concurrency tests can drive the ping path without waiting on the
 	// production cadence.
@@ -58,24 +59,6 @@ type WebSocketServer struct {
 	// wg tracks per-connection goroutines (read loop, send pump, ping loop)
 	// so Close can join them on shutdown.
 	wg sync.WaitGroup
-}
-
-// SetPeerSource registers the source of per-peer entries served by the
-// `peers` RPC handler. Passing nil detaches the source so the handler
-// returns an empty list. Safe to call concurrently with reads.
-func (ws *WebSocketServer) SetPeerSource(src types.PeerSource) {
-	if src == nil {
-		ws.peerSource.Store(nil)
-		return
-	}
-	ws.peerSource.Store(&src)
-}
-
-func (ws *WebSocketServer) loadPeerSource() types.PeerSource {
-	if p := ws.peerSource.Load(); p != nil {
-		return *p
-	}
-	return nil
 }
 
 // WebSocketConnection represents a single WebSocket connection
@@ -126,15 +109,13 @@ func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer)
 			CheckOrigin: func(r *http.Request) bool { return true },
 			// Don't require specific subprotocol - xrpl.js doesn't use one
 		},
-		subscriptionManager: &subscription.Manager{
-			Connections: make(map[string]*types.Connection),
-		},
-		methodRegistry: types.NewMethodRegistry(),
-		connections:    make(map[string]*WebSocketConnection),
-		timeout:        timeout,
-		services:       services,
-		loadTracker:    loadtrack.New(),
-		pingInterval:   30 * time.Second,
+		subscriptionManager: subscription.NewManager(),
+		methodRegistry:      types.NewMethodRegistry(),
+		connections:         make(map[string]*WebSocketConnection),
+		timeout:             timeout,
+		services:            services,
+		loadTracker:         loadtrack.New(),
+		pingInterval:        30 * time.Second,
 	}
 	// The url (RPCSub) registry lives on the WebSocket server because url
 	// subscribers share its subscription manager's broadcast fan-out.
@@ -311,6 +292,9 @@ func (ws *WebSocketServer) handleSend(wsConn *WebSocketConnection) {
 			wsConn.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 			if err := wsConn.conn.WriteMessage(websocket.TextMessage, message); err != nil {
 				wsLog().Debug("WebSocket send failed", "err", err)
+				// Close the socket so the read loop unblocks and tears the
+				// connection down now, not at the 90 s read deadline.
+				wsConn.closeSocket()
 				return
 			}
 		}
@@ -334,15 +318,19 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 		return
 	}
 
-	command, ok := cmdMap["command"].(string)
-	if !ok || command == "" {
-		ws.sendError(wsConn, types.NewRpcError(types.RpcMISSING_COMMAND, "missingCommand", "missingCommand", "Missing command field"), nil)
-		return
-	}
-
 	var id any
 	if idVal, exists := cmdMap["id"]; exists {
 		id = idVal
+	}
+
+	// rippled accepts `method` as an alias for `command`, rejecting only when
+	// neither is present (or both are present strings that disagree) with a
+	// bare missingCommand token that echoes the original request
+	// (ServerHandler.cpp:446-468).
+	command, ok := resolveWSCommand(cmdMap)
+	if !ok {
+		ws.sendMissingCommand(wsConn, cmdMap, id)
+		return
 	}
 
 	cmd := types.WebSocketCommand{
@@ -351,6 +339,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	}
 
 	delete(cmdMap, "command")
+	delete(cmdMap, "method")
 	delete(cmdMap, "id")
 
 	var apiVersion int = types.DefaultApiVersion
@@ -381,16 +370,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 		dispatchCtx, cancel = context.WithTimeout(wsConn.ctx, ws.timeout)
 		defer cancel()
 	}
-	rpcCtx := &types.RpcContext{
-		Context:    dispatchCtx,
-		Role:       role,
-		ApiVersion: apiVersion,
-		IsAdmin:    role == types.RoleAdmin,
-		Unlimited:  role.IsUnlimited(),
-		ClientIP:   clientIP,
-		PeerSource: ws.loadPeerSource(),
-		Services:   ws.services,
-	}
+	rpcCtx := newRpcContext(dispatchCtx, role, apiVersion, clientIP, ws.loadPeerSource(), ws.services)
 
 	// Handle subscription commands specially
 	switch cmd.Command {
@@ -439,13 +419,11 @@ func (ws *WebSocketServer) handleSubscribe(wsConn *WebSocketConnection, ctx *typ
 		return
 	}
 
-	conn := &types.Connection{
-		ID:            wsConn.ID,
-		Subscriptions: wsConn.subscriptions,
-		SendChannel:   wsConn.sendChannel,
-		CloseChannel:  wsConn.closeChannel,
-	}
-	if err := ws.subscriptionManager.HandleSubscribe(conn, request, ctx.IsAdmin); err != nil {
+	// wsConn.legacy is the same connection the subscription manager already
+	// tracks (created in attachConnection, before any message can arrive); it
+	// shares the subscriptions map and carries the Disconnect callback a
+	// freshly-built copy would lack.
+	if err := ws.subscriptionManager.HandleSubscribe(wsConn.legacy, request, ctx.IsAdmin); err != nil {
 		ws.sendError(wsConn, err, cmd.ID)
 		return
 	}
@@ -492,13 +470,7 @@ func (ws *WebSocketServer) handleUnsubscribe(wsConn *WebSocketConnection, ctx *t
 		return
 	}
 
-	conn := &types.Connection{
-		ID:            wsConn.ID,
-		Subscriptions: wsConn.subscriptions,
-		SendChannel:   wsConn.sendChannel,
-		CloseChannel:  wsConn.closeChannel,
-	}
-	if err := ws.subscriptionManager.HandleUnsubscribe(conn, request, ctx.IsAdmin); err != nil {
+	if err := ws.subscriptionManager.HandleUnsubscribe(wsConn.legacy, request, ctx.IsAdmin); err != nil {
 		ws.sendError(wsConn, err, cmd.ID)
 		return
 	}
@@ -669,65 +641,43 @@ func (ws *WebSocketServer) UpdatePathFindSessions(getView func() (types.LedgerSt
 			continue
 		}
 
-		select {
-		case conn.sendChannel <- data:
-		default:
-			// Channel full, skip this update
-		}
+		// Deliver through the shared TrySend so a persistently slow path-find
+		// subscriber accrues drops and is disconnected like any other outbound
+		// path, rather than silently skipping forever on a bare select/default.
+		conn.legacy.TrySend(data)
 	}
 }
 
 func (ws *WebSocketServer) handleRPCMethod(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
-	handler, exists := ws.methodRegistry.Get(cmd.Command)
-	if !exists {
-		ws.sendError(wsConn, types.RpcErrorMethodNotFound(cmd.Command), cmd.ID)
-		return
-	}
-
-	// Admin gate. Mirrors rippled ServerHandler.cpp:482-486 (WS path):
-	// when requestRole returns Role::FORBID for an admin-required command,
-	// rippled writes rpcError(rpcFORBIDDEN) before doCommand ever runs.
-	// The fallback rpcNO_PERMISSION at RPCHandler.cpp:166-167 is only
-	// reached when the outer requestRole gate let the request through.
-	if handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
-		ws.sendError(wsConn, types.RpcErrorForbidden(cmd.Command), cmd.ID)
-		return
-	}
-
-	if rpcErr := validateApiVersion(ctx, handler); rpcErr != nil {
-		ws.sendError(wsConn, rpcErr, cmd.ID)
-		return
-	}
-
-	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
-		ws.sendError(wsConn, rpcErr, cmd.ID)
-		return
-	}
-
-	if rpcErr := gateLoad(ws.loadTracker, ctx, cmd.Command, wsLog()); rpcErr != nil {
-		ws.sendError(wsConn, rpcErr, cmd.ID)
-		return
-	}
-
-	if ws.services != nil && ws.services.ClientLoad != nil {
-		ws.services.ClientLoad.Begin()
-		defer ws.services.ClientLoad.End()
-	}
-
-	result, rpcErr := handler.Handle(ctx, cmd.Params)
-	finalizeLoad(ws.loadTracker, ctx, cmd.Command, handler, rpcErr, wsLog())
+	// Shared dispatch core (registry → admin gate → conditionMet →
+	// api-version → busy/load gates → handle → finalize), identical to the
+	// HTTP path. The WS-specific admin gate returns rpcFORBIDDEN instead of
+	// rpcNO_PERMISSION (ServerHandler.cpp:482-486): when requestRole returns
+	// Role::FORBID for an admin-required command, rippled writes
+	// rpcError(rpcFORBIDDEN) before doCommand ever runs.
+	result, rpcErr := dispatchMethod(ws.methodRegistry, ws.loadTracker, ws.services, ctx, cmd.Command, cmd.Params, types.RpcErrorForbidden, wsLog())
+	opts := wsLoadWarningOpts(ctx)
 	if rpcErr != nil {
-		ws.sendError(wsConn, rpcErr, cmd.ID)
-	} else {
-		response := types.WebSocketResponse{
-			Type:       "response",
-			ID:         cmd.ID,
-			Status:     "success",
-			Result:     result,
-			ApiVersion: ctx.ApiVersion,
-		}
-		ws.sendResponse(wsConn, response)
+		ws.sendErrorWithOptions(wsConn, rpcErr, cmd.ID, opts)
+		return
 	}
+	ws.sendResponseWithOptions(wsConn, types.WebSocketResponse{
+		Type:       "response",
+		ID:         cmd.ID,
+		Status:     "success",
+		Result:     result,
+		ApiVersion: ctx.ApiVersion,
+	}, opts)
+}
+
+// wsLoadWarningOpts surfaces rippled's warning:"load" on a WS reply when the
+// dispatch crossed the resource warn threshold (recorded on ctx by
+// finalizeLoad), and returns nil otherwise.
+func wsLoadWarningOpts(ctx *types.RpcContext) *types.WebSocketResponseOptions {
+	if ctx != nil && ctx.LoadWarning {
+		return &types.WebSocketResponseOptions{Warning: "load"}
+	}
+	return nil
 }
 
 func (ws *WebSocketServer) sendResponse(wsConn *WebSocketConnection, response types.WebSocketResponse) {
@@ -746,24 +696,71 @@ func (ws *WebSocketServer) sendResponseWithOptions(wsConn *WebSocketConnection, 
 		wsLog().Error("Failed to marshal WebSocket response", "err", err)
 		return
 	}
+	ws.deliver(wsConn, data)
+}
 
-	// Route through the shared TrySend so per-request response delivery
-	// and broadcast delivery use the same consecutive-drop counter and
-	// the same disconnect-on-N-drops threshold.
+// deliver queues an already-marshalled WS frame through the shared TrySend so
+// per-request response delivery and broadcast delivery use the same
+// consecutive-drop counter and the same disconnect-on-N-drops threshold. Test
+// fixtures may build a wsConn without a legacy peer; those fall back to a
+// non-blocking channel send so unit tests stay self-contained.
+func (ws *WebSocketServer) deliver(wsConn *WebSocketConnection, data []byte) {
 	if wsConn.legacy != nil {
 		if !wsConn.legacy.TrySend(data) {
 			wsLog().Debug("WebSocket send dropped (slow consumer)", "connID", wsConn.ID)
 		}
 		return
 	}
-	// Test fixtures may build a wsConn without a legacy peer. Fall back
-	// to a non-blocking send so unit tests stay self-contained.
 	select {
 	case wsConn.sendChannel <- data:
 	case <-wsConn.ctx.Done():
 	default:
 		wsLog().Warn("WebSocket send channel full", "connID", wsConn.ID)
 	}
+}
+
+// resolveWSCommand resolves the WS command name from the incoming JSON,
+// accepting `method` as an alias for `command` (ServerHandler.cpp:446-475).
+// ok is false — meaning the caller emits missingCommand — when neither is a
+// non-empty string, or both are present strings that disagree.
+func resolveWSCommand(m map[string]any) (string, bool) {
+	cmd, cmdOK := m["command"].(string)
+	method, methodOK := m["method"].(string)
+	switch {
+	case cmdOK && methodOK:
+		if cmd != method {
+			return "", false
+		}
+		return cmd, cmd != ""
+	case cmdOK:
+		return cmd, cmd != ""
+	case methodOK:
+		return method, method != ""
+	default:
+		return "", false
+	}
+}
+
+// sendMissingCommand emits rippled's bare missingCommand reply: a lone
+// `error` token (no error_code/error_message) plus the echoed request and id
+// (ServerHandler.cpp:452-468). Credentials in the echo are redacted — a
+// deliberate goxrpl superset of rippled's raw echo.
+func (ws *WebSocketServer) sendMissingCommand(wsConn *WebSocketConnection, request map[string]any, id any) {
+	echo := make(map[string]any, len(request))
+	maps.Copy(echo, request)
+	redactCredentials(echo)
+	data, err := json.Marshal(types.WebSocketResponse{
+		Type:    "response",
+		Status:  "error",
+		Error:   "missingCommand",
+		Request: echo,
+		ID:      id,
+	})
+	if err != nil {
+		wsLog().Error("Failed to marshal missingCommand response", "err", err)
+		return
+	}
+	ws.deliver(wsConn, data)
 }
 
 func (ws *WebSocketServer) sendError(wsConn *WebSocketConnection, rpcErr *types.RpcError, id any) {
@@ -798,17 +795,7 @@ func (ws *WebSocketServer) sendErrorWithOptions(wsConn *WebSocketConnection, rpc
 		wsLog().Error("Failed to marshal WebSocket error response", "err", err)
 		return
 	}
-
-	if wsConn.legacy != nil {
-		wsConn.legacy.TrySend(data)
-		return
-	}
-	select {
-	case wsConn.sendChannel <- data:
-	case <-wsConn.ctx.Done():
-	default:
-		wsLog().Warn("WebSocket send channel full", "connID", wsConn.ID)
-	}
+	ws.deliver(wsConn, data)
 }
 
 // attachConnection is the single point at which a new WS connection
@@ -822,10 +809,11 @@ func (ws *WebSocketServer) attachConnection(wsConn *WebSocketConnection) {
 		Subscriptions: wsConn.subscriptions,
 		SendChannel:   wsConn.sendChannel,
 		CloseChannel:  wsConn.closeChannel,
-		// Subscription-manager-driven disconnect routes back through
-		// the WS cancel func so a persistently slow subscriber is torn
-		// down via the same code path as a normal close.
-		Disconnect: wsConn.cancel,
+		// Subscription-manager-driven disconnect closes the socket (not just
+		// cancels the ctx) so a persistently slow subscriber is torn down
+		// immediately — cancel alone leaves the read loop blocked in
+		// ReadMessage until the 90 s deadline.
+		Disconnect: wsConn.closeSocket,
 	}
 	wsConn.legacy = legacy
 	ws.connectionsMutex.Lock()
@@ -840,6 +828,17 @@ func (ws *WebSocketServer) detachConnection(wsConn *WebSocketConnection) {
 	delete(ws.connections, wsConn.ID)
 	ws.connectionsMutex.Unlock()
 	ws.subscriptionManager.RemoveConnection(wsConn.ID)
+}
+
+// closeSocket cancels the connection context and closes the underlying
+// socket. Closing the socket unblocks a read loop parked in ReadMessage
+// immediately, so closeConnection (and the conn-limit slot release) run
+// without waiting out the 90 s read deadline. Used by the slow-consumer
+// Disconnect callback and the send-error path; idempotent — closeConnection
+// closes again and gorilla tolerates the double close.
+func (wsConn *WebSocketConnection) closeSocket() {
+	wsConn.cancel()
+	wsConn.conn.Close()
 }
 
 func (ws *WebSocketServer) closeConnection(wsConn *WebSocketConnection) {

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -323,13 +323,26 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 		id = idVal
 	}
 
+	// Role is always derived from the socket-level peer, never from
+	// header-supplied IPs. ClientIP is the peer too, unless the peer is in this
+	// port's secure_gateway set — then we substitute the value captured at
+	// upgrade time (matches rippled WSInfoSub::forwarded_for,
+	// ServerHandler.cpp:497-501). Derived before command resolution so a
+	// malformed request can be load-charged like rippled charges it.
+	peerIP := getWebSocketClientIP(wsConn.conn)
+	clientIP := resolveWSClientIP(peerIP, wsConn.forwardedFor, wsConn.portCtx)
+	role := roleForRequest(peerIP, wsConn.user, wsConn.portCtx)
+
 	// rippled accepts `method` as an alias for `command`, rejecting only when
 	// neither is present (or both are present strings that disagree) with a
-	// bare missingCommand token that echoes the original request
-	// (ServerHandler.cpp:446-468).
+	// bare missingCommand token that echoes the original request, and charges
+	// feeMalformedRPC (ServerHandler.cpp:446-468).
 	command, ok := resolveWSCommand(cmdMap)
 	if !ok {
 		ws.sendMissingCommand(wsConn, cmdMap, id)
+		if ws.loadTracker != nil && !role.IsUnlimited() {
+			ws.loadTracker.Charge(clientIP, loadtrack.LoadMalformed)
+		}
 		return
 	}
 
@@ -355,14 +368,6 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 		cmd.Params = paramsBytes
 	}
 
-	// Role is always derived from the socket-level peer, never from
-	// header-supplied IPs. ClientIP is the peer too, unless the peer is
-	// in this port's secure_gateway set — then we substitute the value
-	// captured at upgrade time (matches rippled WSInfoSub::forwarded_for,
-	// ServerHandler.cpp:497-501).
-	peerIP := getWebSocketClientIP(wsConn.conn)
-	clientIP := resolveWSClientIP(peerIP, wsConn.forwardedFor, wsConn.portCtx)
-	role := roleForRequest(peerIP, wsConn.user, wsConn.portCtx)
 	wsLog().Debug("ws request", "cmd", cmd.Command, "remoteAddr", wsConn.conn.RemoteAddr().String(), "clientIP", clientIP, "role", role, "isAdmin", role == types.RoleAdmin)
 	dispatchCtx := wsConn.ctx
 	var cancel context.CancelFunc
@@ -749,13 +754,23 @@ func (ws *WebSocketServer) sendMissingCommand(wsConn *WebSocketConnection, reque
 	echo := make(map[string]any, len(request))
 	maps.Copy(echo, request)
 	redactCredentials(echo)
-	data, err := json.Marshal(types.WebSocketResponse{
-		Type:    "response",
-		Status:  "error",
-		Error:   "missingCommand",
-		Request: echo,
-		ID:      id,
-	})
+	resp := map[string]any{
+		"type":    "response",
+		"status":  "error",
+		"error":   "missingCommand",
+		"request": echo,
+	}
+	if id != nil {
+		resp["id"] = id
+	}
+	// rippled also lifts jsonrpc/ripplerpc/api_version to the top level of the
+	// error reply, alongside the request echo (ServerHandler.cpp:460-465).
+	for _, k := range []string{"jsonrpc", "ripplerpc", "api_version"} {
+		if v, ok := request[k]; ok {
+			resp[k] = v
+		}
+	}
+	data, err := json.Marshal(resp)
 	if err != nil {
 		wsLog().Error("Failed to marshal missingCommand response", "err", err)
 		return


### PR DESCRIPTION
## Summary

Resolves the still-valid findings from the `internal/rpc` audit (#898). A
substantial part of the audit had already been fixed in-tree since it was
written, so every finding was re-verified against the current code and against
rippled before acting; the items below are the ones that were genuinely still
present.

**Subscription state (H1, H2)**
- `HandleSubscribe` accumulates accounts onto the existing set instead of dropping prior accounts and duplicating new ones (old code stored `[B,B]` for `subscribe[A]` then `subscribe[B]`); `accounts_proposed` now merges the same way instead of overwriting.
- Book subscriptions accumulate per call instead of replacing the set; unsubscribe removes only the named books (with `both:true` reverse expansion) instead of dropping every book.

**Dispatch unification & WS parity (H3, M1, M2, M4)**
- Extract a shared `dispatchMethod` core used by both transports so they can't drift — the WS path now runs `conditionMet` (a not-synced / amendment-blocked node refuses gated methods on WS too).
- Slow-consumer `Disconnect` and the send-error path close the socket so a wedged connection tears down immediately rather than after the 90 s read deadline.
- Surface `warning: "load"` on HTTP and WS replies via the previously-dead response-options plumbing.
- Accept `method` as an alias for `command` on WS; an unresolvable command returns a bare `missingCommand` token echoing the request and id.

**HTTP envelope & json dispatcher (M3, M5)**
- Malformed single requests return plain-text HTTP 400 (`Unable to parse request: …` / `Null method` / `params unparseable`) matching rippled, instead of HTTP 200 + invented tokens.
- The `json` method threads the caller's `RpcContext` through `MethodDispatcher`, so forwarded calls keep their timeout, role and per-IP load accounting.

**Cleanup (D)**
- Remove dead types/constructors and the unused `WebSocketCommand.ApiVersion` field + bogus `inline` json tag.
- Dedup `SetPeerSource`/`loadPeerSource` into an embedded holder and the 9-field `RpcContext` literal into `newRpcContext`; reuse `wsConn.legacy` in `handle(Un)subscribe`; build the manager via `NewManager()`; route `UpdatePathFindSessions` through `TrySend`; drop unused params and a stale comment; return a copy from `GetConnectionSubscriptions`.

Test-only manager getters flagged by the audit were retained (they back existing test assertions); `GetConnectionSubscriptions` was hardened to return a copy.

## Test plan
- [x] `go test ./internal/rpc/...` (incl. `-race`) — all pass
- [x] `go test ./internal/testing/rpcenv/... ./internal/cli/...` — consumers green
- [x] `go vet ./internal/rpc/ ./internal/rpc/types/... ./internal/rpc/subscription/... ./internal/rpc/loadtrack/...` — clean
- [x] `go build ./...` — clean
- New conformance tests assert **membership** (not just length) for incremental account/book subscribe and per-book unsubscribe, so they fail on the pre-fix code; plus the shared `conditionMet` gate, the WS command-alias / `missingCommand` wire shape, and the HTTP 400 parse failures.

Fixes #898