### PR TITLE
refactor(consensus): vote-divergence fixes, csf real-engine port, and dead-code cleanup

### DIFF
--- a/internal/consensus/adaptor/flag_ledger_vote.go
+++ b/internal/consensus/adaptor/flag_ledger_vote.go
@@ -237,15 +237,17 @@ func (a *Adaptor) runAmendmentVote(
 	stances := a.currentAmendmentStances()
 	strict := enabled[amendment.FeatureFixAmendmentMajorityCalc]
 
-	// Restrict the vote walk to amendments this server recognizes,
-	// mirroring rippled's doVoting over amendmentMap_. Without this an
-	// amendment recorded only in the parent ledger's sfMajorities but
-	// unknown to this binary (a newer protocol amendment) would wrongly
-	// emit a LostMajority pseudo-tx, forking the flag-ledger tx set from
-	// the rest of the network.
-	allFeatures := amendment.AllFeatures()
-	known := make(map[amendmentvote.Amendment]bool, len(allFeatures))
-	for _, f := range allFeatures {
+	// Restrict the vote walk to amendments this server supports,
+	// mirroring rippled's doVoting over amendmentMap_, which is seeded
+	// from the supported (Supported::yes) set only. Two divergences this
+	// closes: an amendment recorded only in the parent ledger's
+	// sfMajorities but unknown to this binary (a newer protocol
+	// amendment), and a compile-time-known but unsupported amendment —
+	// either would otherwise wrongly emit a LostMajority pseudo-tx,
+	// forking the flag-ledger tx set from the rest of the network.
+	supported := amendment.SupportedFeatures()
+	known := make(map[amendmentvote.Amendment]bool, len(supported))
+	for _, f := range supported {
 		known[f.ID] = true
 	}
 

--- a/internal/consensus/adaptor/flag_ledger_vote.go
+++ b/internal/consensus/adaptor/flag_ledger_vote.go
@@ -237,6 +237,18 @@ func (a *Adaptor) runAmendmentVote(
 	stances := a.currentAmendmentStances()
 	strict := enabled[amendment.FeatureFixAmendmentMajorityCalc]
 
+	// Restrict the vote walk to amendments this server recognizes,
+	// mirroring rippled's doVoting over amendmentMap_. Without this an
+	// amendment recorded only in the parent ledger's sfMajorities but
+	// unknown to this binary (a newer protocol amendment) would wrongly
+	// emit a LostMajority pseudo-tx, forking the flag-ledger tx set from
+	// the rest of the network.
+	allFeatures := amendment.AllFeatures()
+	known := make(map[amendmentvote.Amendment]bool, len(allFeatures))
+	for _, f := range allFeatures {
+		known[f.ID] = true
+	}
+
 	// Stash this round's tallies for `feature` RPC introspection.
 	if a.amendmentTable != nil {
 		snapshot := &amendment.LastVote{
@@ -257,6 +269,7 @@ func (a *Adaptor) runAmendmentVote(
 		Enabled:            enabled,
 		Majority:           majority,
 		Stances:            stances,
+		Known:              known,
 		StrictMajority:     strict,
 	}
 	blobs, err := amendmentvote.DoVoting(in)

--- a/internal/consensus/adaptor/flag_ledger_vote_test.go
+++ b/internal/consensus/adaptor/flag_ledger_vote_test.go
@@ -140,42 +140,61 @@ func TestExcludeNegativeUNL_EmptyNegUNLPassesThrough(t *testing.T) {
 // local stance directly.
 func TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority(t *testing.T) {
 	a := newTestAdaptorWithConfig(t, FeeVoteStance{}, nil)
-	var synthetic [32]byte
-	for i := range synthetic {
-		synthetic[i] = 0xC1
-	}
-	a.amendmentStances = map[[32]byte]amendmentvote.Stance{synthetic: amendmentvote.VoteUp}
 
 	prev := a.ledgerService.GetClosedLedger()
 	require.NotNil(t, prev)
 	wrapped := WrapLedger(prev)
+
+	// runAmendmentVote restricts the vote walk to amendment.AllFeatures()
+	// (mirroring rippled's amendmentMap_), so the target must be a real,
+	// server-known amendment — a synthetic hash the binary doesn't
+	// recognize is correctly dropped. Pick one neither already enabled
+	// nor mid-majority on the parent ledger so the GotMajority branch is
+	// the one that fires.
+	enabled, majorities, ok := a.readAmendmentsSLE(prev)
+	require.True(t, ok)
+	var target [32]byte
+	found := false
+	for _, f := range amendment.AllFeatures() {
+		if enabled[f.ID] {
+			continue
+		}
+		if _, inMaj := majorities[f.ID]; inMaj {
+			continue
+		}
+		target = f.ID
+		found = true
+		break
+	}
+	require.True(t, found, "need a known amendment not yet enabled on the test ledger")
+	a.amendmentStances = map[[32]byte]amendmentvote.Stance{target: amendmentvote.VoteUp}
 
 	val := &consensus.Validation{
 		LedgerID:   wrapped.ID(),
 		LedgerSeq:  wrapped.Seq(),
 		NodeID:     a.identity.NodeID,
 		SignTime:   time.Now(),
-		Amendments: [][32]byte{synthetic},
+		Amendments: [][32]byte{target},
 	}
 
 	blobs := a.GenerateFlagLedgerPseudoTxs(wrapped, []*consensus.Validation{val})
 
-	var found bool
+	var gotMajority bool
 	for _, blob := range blobs {
 		stx := decodeTx(t, blob)
 		if stx["TransactionType"] != "EnableAmendment" {
 			continue
 		}
-		if stringFold(stx["Amendment"]) != hex.EncodeToString(synthetic[:]) {
+		if stringFold(stx["Amendment"]) != hex.EncodeToString(target[:]) {
 			continue
 		}
 		if asUint(stx["Flags"]) == 0x00010000 {
-			found = true
+			gotMajority = true
 			break
 		}
 	}
-	assert.True(t, found,
-		"expected EnableAmendment(synthetic, GotMajority) when our single trusted validator votes for it")
+	assert.True(t, gotMajority,
+		"expected EnableAmendment(known target, GotMajority) when our single trusted validator votes for it")
 }
 
 // TestAmendmentStances_SeededFromRegistry verifies the constructor

--- a/internal/consensus/adaptor/flag_ledger_vote_test.go
+++ b/internal/consensus/adaptor/flag_ledger_vote_test.go
@@ -145,17 +145,18 @@ func TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority(t *testing.T)
 	require.NotNil(t, prev)
 	wrapped := WrapLedger(prev)
 
-	// runAmendmentVote restricts the vote walk to amendment.AllFeatures()
-	// (mirroring rippled's amendmentMap_), so the target must be a real,
-	// server-known amendment — a synthetic hash the binary doesn't
-	// recognize is correctly dropped. Pick one neither already enabled
-	// nor mid-majority on the parent ledger so the GotMajority branch is
-	// the one that fires.
+	// runAmendmentVote restricts the vote walk to
+	// amendment.SupportedFeatures() (mirroring rippled's amendmentMap_,
+	// seeded from the Supported::yes set), so the target must be a real,
+	// server-SUPPORTED amendment — a synthetic hash, or a known-but-
+	// unsupported amendment, is correctly dropped. Pick one neither
+	// already enabled nor mid-majority on the parent ledger so the
+	// GotMajority branch is the one that fires.
 	enabled, majorities, ok := a.readAmendmentsSLE(prev)
 	require.True(t, ok)
 	var target [32]byte
 	found := false
-	for _, f := range amendment.AllFeatures() {
+	for _, f := range amendment.SupportedFeatures() {
 		if enabled[f.ID] {
 			continue
 		}
@@ -166,7 +167,7 @@ func TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority(t *testing.T)
 		found = true
 		break
 	}
-	require.True(t, found, "need a known amendment not yet enabled on the test ledger")
+	require.True(t, found, "need a supported amendment not yet enabled on the test ledger")
 	a.amendmentStances = map[[32]byte]amendmentvote.Stance{target: amendmentvote.VoteUp}
 
 	val := &consensus.Validation{
@@ -195,6 +196,73 @@ func TestGenerateFlagLedgerPseudoTxs_AmendmentVoteSeedsGotMajority(t *testing.T)
 	}
 	assert.True(t, gotMajority,
 		"expected EnableAmendment(known target, GotMajority) when our single trusted validator votes for it")
+}
+
+// TestGenerateFlagLedgerPseudoTxs_UnsupportedAmendmentNotWalked pins the
+// walk-domain restriction to SUPPORTED amendments. rippled's doVoting
+// iterates amendmentMap_, which is seeded only from the Supported::yes set
+// (AmendmentTable.cpp:556); an amendment the binary knows about but does
+// not support is never voted on. With the walk built from
+// amendment.AllFeatures() instead, a known-but-unsupported amendment that
+// reaches ledger majority and loses validator support would emit a
+// spurious LostMajority pseudo-tx (and, as forced here, a GotMajority),
+// injecting an EnableAmendment rippled never would and forking the
+// flag-ledger tx set. Even a forced VoteUp stance plus a trusted
+// validation must not pull an unsupported amendment into the pseudo-tx set.
+func TestGenerateFlagLedgerPseudoTxs_UnsupportedAmendmentNotWalked(t *testing.T) {
+	a := newTestAdaptorWithConfig(t, FeeVoteStance{}, nil)
+
+	prev := a.ledgerService.GetClosedLedger()
+	require.NotNil(t, prev)
+	wrapped := WrapLedger(prev)
+
+	enabled, majorities, ok := a.readAmendmentsSLE(prev)
+	require.True(t, ok)
+
+	supported := make(map[[32]byte]bool)
+	for _, f := range amendment.SupportedFeatures() {
+		supported[f.ID] = true
+	}
+	var target [32]byte
+	found := false
+	for _, f := range amendment.AllFeatures() {
+		if supported[f.ID] {
+			continue // we deliberately want an UNsupported amendment
+		}
+		if enabled[f.ID] {
+			continue
+		}
+		if _, inMaj := majorities[f.ID]; inMaj {
+			continue
+		}
+		target = f.ID
+		found = true
+		break
+	}
+	require.True(t, found, "need an unsupported amendment not yet enabled on the test ledger")
+
+	// Force a VoteUp stance and a trusted validation for the unsupported
+	// amendment — the walk-domain restriction is the only thing that should
+	// keep it out of the pseudo-tx set.
+	a.amendmentStances = map[[32]byte]amendmentvote.Stance{target: amendmentvote.VoteUp}
+	val := &consensus.Validation{
+		LedgerID:   wrapped.ID(),
+		LedgerSeq:  wrapped.Seq(),
+		NodeID:     a.identity.NodeID,
+		SignTime:   time.Now(),
+		Amendments: [][32]byte{target},
+	}
+
+	blobs := a.GenerateFlagLedgerPseudoTxs(wrapped, []*consensus.Validation{val})
+
+	for _, blob := range blobs {
+		stx := decodeTx(t, blob)
+		if stx["TransactionType"] != "EnableAmendment" {
+			continue
+		}
+		assert.NotEqual(t, hex.EncodeToString(target[:]), stringFold(stx["Amendment"]),
+			"an unsupported amendment must never produce an EnableAmendment pseudo-tx")
+	}
 }
 
 // TestAmendmentStances_SeededFromRegistry verifies the constructor

--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -27,9 +27,12 @@ import (
 //     local view too narrow to trust
 //   - no candidates qualify
 //
-// All zero-vote paths are silent; an operator running a validator on
-// a NegativeUNL-enabled network sees neither errors nor warnings when
-// the round simply has nothing to do.
+// These normal zero-vote paths are silent — an operator on a
+// NegativeUNL-enabled network sees no errors or warnings when the round
+// simply has nothing to do. The sole exception is the impossible
+// above-window case (local count > FlagLedgerInterval), which DoVoting
+// surfaces as ErrLocalCountExceedsWindow and is logged at Error here as
+// a likely duplicate-validation bug.
 func (a *Adaptor) GenerateNegativeUNLPseudoTx(prev consensus.Ledger) [][]byte {
 	a.mu.Lock()
 	voter := a.negUNLVoter
@@ -59,7 +62,7 @@ func (a *Adaptor) GenerateNegativeUNLPseudoTx(prev consensus.Ledger) [][]byte {
 		return nil
 	}
 
-	scoreTable, ok := a.buildNegativeUNLScoreTable(concrete, historian, voter.MyID())
+	scoreTable, ok := a.buildNegativeUNLScoreTable(concrete, historian)
 	if !ok {
 		return nil
 	}
@@ -70,8 +73,8 @@ func (a *Adaptor) GenerateNegativeUNLPseudoTx(prev consensus.Ledger) [][]byte {
 	prevSeq := concrete.Sequence()
 	prevHash := concrete.Hash()
 
-	voter.PurgeNewValidators(prevSeq + 1)
-
+	// DoVoting owns the new-validator purge and the local-participation
+	// gate; don't duplicate either here.
 	blobs, err := voter.DoVoting(prevSeq, prevHash, unlKeys, state, scoreTable)
 	if err != nil {
 		if errors.Is(err, negativeunlvote.ErrLocalCountExceedsWindow) {
@@ -163,21 +166,20 @@ func (a *Adaptor) negativeUNLState(l interface {
 //     FlagLedgerInterval ledger hashes.
 //  2. For each ancestor, look up the trusted validations that named
 //     it and increment a per-NodeID counter.
-//  3. Enforce the local-node participation gate
-//     ([MinLocalValsToVote, FlagLedgerInterval]) — outside that range
-//     return ok=false so the producer abstains.
 //
-// Returns (nil, false) when the parent's skip-list is shorter than
-// FlagLedgerInterval (early ledgers) or when local participation is
-// out of range. A successful return guarantees every trusted
-// validator the Voter consults falls back to score 0 (the invariant
-// enforced inside DoVoting).
+// Returns (nil, false) only when the parent's skip-list is shorter
+// than FlagLedgerInterval (early ledgers near genesis). The
+// local-participation gate ([MinLocalValsToVote, FlagLedgerInterval])
+// is NOT enforced here — it lives solely in DoVoting, which abstains on
+// low participation and surfaces ErrLocalCountExceedsWindow on the
+// impossible above-window case so the caller can log at error severity.
+// DoVoting also restricts this table to the UNL, so an over-populated
+// table (NodeIDs that have since left the UNL) is harmless.
 func (a *Adaptor) buildNegativeUNLScoreTable(
 	prev interface {
 		SkipListHashes() ([][32]byte, error)
 	},
 	historian consensus.ValidationHistorian,
-	myID consensus.NodeID,
 ) (map[consensus.NodeID]uint32, bool) {
 	ancestors, err := prev.SkipListHashes()
 	if err != nil || uint32(len(ancestors)) < consensus.FlagLedgerInterval {
@@ -192,11 +194,6 @@ func (a *Adaptor) buildNegativeUNLScoreTable(
 		for _, v := range historian.GetTrustedValidations(consensus.LedgerID(ledgerHash)) {
 			scoreTable[v.NodeID]++
 		}
-	}
-
-	myCount := scoreTable[myID]
-	if myCount < negativeunlvote.MinLocalValsToVote || myCount > window {
-		return nil, false
 	}
 	return scoreTable, true
 }

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -136,13 +136,19 @@ func TestBuildScoreTable_RejectsShortSkipList(t *testing.T) {
 	scoreTable, ok := a.buildNegativeUNLScoreTable(
 		&stubSkipListProvider{hashes: make([][32]byte, 100)},
 		hist,
-		consensus.NodeID{},
 	)
 	assert.False(t, ok, "skip-list shorter than FlagLedgerInterval must abort")
 	assert.Nil(t, scoreTable)
 }
 
-func TestBuildScoreTable_RejectsInsufficientLocalParticipation(t *testing.T) {
+// TestBuildScoreTable_DoesNotGateOnLocalParticipation pins C2: the
+// local-participation gate ([MinLocalValsToVote, FlagLedgerInterval])
+// now lives solely in DoVoting, not in buildNegativeUNLScoreTable. The
+// builder must return the full tally regardless of the local node's
+// count — even when it is below MinLocalValsToVote — so DoVoting is the
+// single gate authority (and ErrLocalCountExceedsWindow can surface for
+// the impossible above-window case instead of being swallowed here).
+func TestBuildScoreTable_DoesNotGateOnLocalParticipation(t *testing.T) {
 	a := newTestAdaptor(t)
 
 	ancestors := make([][32]byte, consensus.FlagLedgerInterval)
@@ -153,9 +159,8 @@ func TestBuildScoreTable_RejectsInsufficientLocalParticipation(t *testing.T) {
 	myID := consensus.NodeID{0x99}
 	otherID := consensus.NodeID{0xAA}
 
-	// Seed the local node with fewer than MinLocalValsToVote (230)
-	// validations, with another validator covering every slot — the
-	// gate must fire on the local count alone, regardless of others.
+	// Local node validates fewer than MinLocalValsToVote slots. Under the
+	// old duplicated gate this aborted the build; now it must not.
 	byLedger := make(map[consensus.LedgerID][]*consensus.Validation, len(ancestors))
 	for i, h := range ancestors {
 		vals := []*consensus.Validation{{NodeID: otherID, LedgerID: consensus.LedgerID(h)}}
@@ -168,10 +173,11 @@ func TestBuildScoreTable_RejectsInsufficientLocalParticipation(t *testing.T) {
 	scoreTable, ok := a.buildNegativeUNLScoreTable(
 		&stubSkipListProvider{hashes: ancestors},
 		&stubHistorian{byLedger: byLedger},
-		myID,
 	)
-	assert.False(t, ok, "local count below MinLocalValsToVote must abort")
-	assert.Nil(t, scoreTable)
+	require.True(t, ok, "a full skip-list must build a table regardless of local participation")
+	require.NotNil(t, scoreTable)
+	assert.Less(t, scoreTable[myID], negativeunlvote.MinLocalValsToVote,
+		"local count is intentionally below the threshold; gating is DoVoting's job now")
 }
 
 func TestBuildScoreTable_TalliesAcrossAncestors(t *testing.T) {
@@ -200,9 +206,8 @@ func TestBuildScoreTable_TalliesAcrossAncestors(t *testing.T) {
 	scoreTable, ok := a.buildNegativeUNLScoreTable(
 		&stubSkipListProvider{hashes: ancestors},
 		&stubHistorian{byLedger: byLedger},
-		myID,
 	)
-	require.True(t, ok, "local participation = 256 must pass the gate")
+	require.True(t, ok, "a full skip-list of FlagLedgerInterval ancestors builds the table")
 	require.NotNil(t, scoreTable)
 
 	assert.Equal(t, consensus.FlagLedgerInterval, scoreTable[myID], "local validator scored on every ancestor")

--- a/internal/consensus/amendmentvote/vote.go
+++ b/internal/consensus/amendmentvote/vote.go
@@ -135,17 +135,19 @@ type Inputs struct {
 	// AmendmentTable.cpp:286.
 	Stances map[Amendment]Stance
 
-	// Known is the set of amendments this server recognizes — the
-	// walk domain for Decide, mirroring rippled's doVoting iterating
-	// amendmentMap_ (AmendmentTable.cpp:875). amendmentMap_ holds every
-	// compile-time-known amendment (DefaultYes/No/Obsolete alike), so a
-	// known-but-down amendment that lost ledger majority still emits
-	// LostMajority, while an amendment recorded only in the parent
-	// ledger's sfMajorities but unknown to this server never does.
-	// When nil, Decide treats every amendment appearing in
-	// Stances/Votes/Majority as known (the union walk) — appropriate
-	// only for callers whose inputs are already restricted to known
-	// amendments, e.g. focused unit tests.
+	// Known is the set of amendments this server supports — the walk
+	// domain for Decide, mirroring rippled's doVoting iterating
+	// amendmentMap_ (AmendmentTable.cpp:875). amendmentMap_ is seeded
+	// from the supported (Supported::yes) set (AmendmentTable.cpp:556),
+	// which includes DefaultYes, DefaultNo and Obsolete amendments alike
+	// but NOT unsupported ones. So a supported-but-down amendment that
+	// lost ledger majority still emits LostMajority, while an amendment
+	// that is unsupported, or recorded only in the parent ledger's
+	// sfMajorities but unknown to this server, never does. When nil,
+	// Decide treats every amendment appearing in Stances/Votes/Majority
+	// as known (the union walk) — appropriate only for callers whose
+	// inputs are already restricted to known amendments, e.g. focused
+	// unit tests.
 	Known map[Amendment]bool
 
 	// StrictMajority is true once fixAmendmentMajorityCalc is

--- a/internal/consensus/amendmentvote/vote.go
+++ b/internal/consensus/amendmentvote/vote.go
@@ -135,6 +135,19 @@ type Inputs struct {
 	// AmendmentTable.cpp:286.
 	Stances map[Amendment]Stance
 
+	// Known is the set of amendments this server recognizes — the
+	// walk domain for Decide, mirroring rippled's doVoting iterating
+	// amendmentMap_ (AmendmentTable.cpp:875). amendmentMap_ holds every
+	// compile-time-known amendment (DefaultYes/No/Obsolete alike), so a
+	// known-but-down amendment that lost ledger majority still emits
+	// LostMajority, while an amendment recorded only in the parent
+	// ledger's sfMajorities but unknown to this server never does.
+	// When nil, Decide treats every amendment appearing in
+	// Stances/Votes/Majority as known (the union walk) — appropriate
+	// only for callers whose inputs are already restricted to known
+	// amendments, e.g. focused unit tests.
+	Known map[Amendment]bool
+
 	// StrictMajority is true once fixAmendmentMajorityCalc is
 	// enabled. Selects the post-fix threshold fraction (80/100 vs
 	// 204/256) AND switches the passes-comparison from ≥ to >.
@@ -187,18 +200,33 @@ func passes(votes, threshold, trustedValidations int, strict bool) bool {
 func Decide(in Inputs) []Decision {
 	threshold := Threshold(in.TrustedValidations, in.StrictMajority)
 
-	// Walk every amendment the server is aware of (Stances ∪
-	// Votes ∪ Majority). An amendment with no Stance entry is
-	// treated as VoteAbstain.
-	seen := make(map[Amendment]struct{}, len(in.Stances)+len(in.Votes)+len(in.Majority))
-	for k := range in.Stances {
-		seen[k] = struct{}{}
-	}
-	for k := range in.Votes {
-		seen[k] = struct{}{}
-	}
-	for k := range in.Majority {
-		seen[k] = struct{}{}
+	// Walk domain: the amendments this server knows about, mirroring
+	// rippled's doVoting over amendmentMap_ (AmendmentTable.cpp:875).
+	// When Known is supplied it is authoritative — an amendment recorded
+	// only in the parent ledger's sfMajorities (in.Majority) but absent
+	// from Known is one this server doesn't recognize, and rippled emits
+	// nothing for it. Known amendments with no votes and no ledger
+	// majority produce no decision, so restricting to Known yields the
+	// same result set as walking it. When Known is nil, fall back to the
+	// union of the input maps (the caller asserts they're all known).
+	// An amendment with no Stance entry is treated as VoteAbstain.
+	var seen map[Amendment]struct{}
+	if in.Known != nil {
+		seen = make(map[Amendment]struct{}, len(in.Known))
+		for k := range in.Known {
+			seen[k] = struct{}{}
+		}
+	} else {
+		seen = make(map[Amendment]struct{}, len(in.Stances)+len(in.Votes)+len(in.Majority))
+		for k := range in.Stances {
+			seen[k] = struct{}{}
+		}
+		for k := range in.Votes {
+			seen[k] = struct{}{}
+		}
+		for k := range in.Majority {
+			seen[k] = struct{}{}
+		}
 	}
 
 	var out []Decision

--- a/internal/consensus/amendmentvote/vote_test.go
+++ b/internal/consensus/amendmentvote/vote_test.go
@@ -199,6 +199,59 @@ func TestDecide_LostMajorityFiresEvenForAbstain(t *testing.T) {
 	assert.Equal(t, TfLostMajority, got[0].Flags)
 }
 
+// TestDecide_UnknownAmendmentInMajorityIgnored pins C3: when Known is
+// supplied, an amendment recorded in the parent ledger's sfMajorities
+// (in.Majority) but absent from Known — one this server doesn't
+// recognize, e.g. a newer protocol amendment — must NEVER emit a
+// pseudo-tx, even with lost validator support. Rippled's doVoting walks
+// only amendmentMap_ (AmendmentTable.cpp:875), so it emits nothing for
+// such an amendment; emitting a spurious LostMajority would fork the
+// flag-ledger tx set from the rest of the network.
+func TestDecide_UnknownAmendmentInMajorityIgnored(t *testing.T) {
+	known := makeAmendment(0x01)
+	unknown := makeAmendment(0x02) // recorded on the ledger, but not compiled in
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{unknown: 0}, // validator support gone
+		Majority:           map[Amendment]time.Time{unknown: baseTime.Add(-time.Hour)},
+		Stances:            map[Amendment]Stance{},
+		Known:              map[Amendment]bool{known: true},
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	assert.Empty(t, got,
+		"an amendment absent from Known must never emit a pseudo-tx, even with ledger majority + lost support")
+}
+
+// TestDecide_KnownAbstainAmendmentLostMajorityFires is the companion to
+// the unknown-amendment test: a KNOWN amendment the operator abstains on
+// (absent from Stances but present in Known) that holds ledger majority
+// and loses validator support MUST still emit LostMajority — matching
+// rippled walking amendmentMap_, which includes DefaultNo amendments.
+// This is the case a naive "restrict to Stances keys" fix would wrongly
+// drop.
+func TestDecide_KnownAbstainAmendmentLostMajorityFires(t *testing.T) {
+	a := makeAmendment(0x03) // known, but the operator takes no stance
+	in := Inputs{
+		UpcomingSeq:        1024,
+		CloseTime:          baseTime,
+		MajorityTimeout:    14 * 24 * time.Hour,
+		TrustedValidations: 10,
+		Votes:              map[Amendment]int{a: 0},
+		Majority:           map[Amendment]time.Time{a: baseTime.Add(-time.Hour)},
+		Stances:            map[Amendment]Stance{}, // abstain
+		Known:              map[Amendment]bool{a: true},
+		StrictMajority:     true,
+	}
+	got := Decide(in)
+	require.Len(t, got, 1)
+	assert.Equal(t, TfLostMajority, got[0].Flags,
+		"a known abstain amendment that lost majority must still emit LostMajority")
+}
+
 func TestDecide_DeterministicOrder(t *testing.T) {
 	// Multiple amendments → output sorted by hash so the resulting
 	// tx-set hash is deterministic across map-iteration runs.

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -342,11 +342,7 @@ func (a *Archive) run() {
 
 	for {
 		select {
-		case v, ok := <-a.ch:
-			if !ok {
-				flush("channel closed")
-				return
-			}
+		case v := <-a.ch:
 			if v == nil {
 				continue
 			}
@@ -363,15 +359,16 @@ func (a *Archive) run() {
 		case <-ticker.C:
 			flush("tick")
 		case <-a.stop:
+			// Commit everything already enqueued BEFORE acking any
+			// pending flush requests: Flush's contract (data committed on
+			// return) must hold even when a Flush races Close.
 			drainPending()
-			// Service any pending flush requests so Close-then-Flush
-			// callers aren't left hanging.
+			flush("close")
 			for {
 				select {
 				case ack := <-a.flushReq:
 					close(ack)
 				default:
-					flush("close")
 					return
 				}
 			}

--- a/internal/consensus/csf/engine_adaptor.go
+++ b/internal/consensus/csf/engine_adaptor.go
@@ -1,0 +1,583 @@
+package csf
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/rcl"
+)
+
+// This file wires csf's discrete-event scheduler and network to the REAL
+// production consensus engine (internal/consensus/rcl). An EnginePeer
+// implements consensus.Adaptor backed by simulation primitives and drives
+// an rcl.Engine in ManualTick mode, so the csf suites exercise the actual
+// state machine rather than a simulation-only re-implementation. The
+// engine's clock is pinned to the scheduler's virtual time, making every
+// run fully deterministic.
+
+// simTxSet is a consensus.TxSet backed by opaque byte-blob transactions,
+// kept keyed by tx hash so the set ID is a deterministic function of
+// contents regardless of insertion order.
+type simTxSet struct {
+	txs map[consensus.TxID][]byte
+}
+
+func newSimTxSet(blobs [][]byte) *simTxSet {
+	s := &simTxSet{txs: make(map[consensus.TxID][]byte, len(blobs))}
+	for _, b := range blobs {
+		s.txs[txBlobID(b)] = append([]byte(nil), b...)
+	}
+	return s
+}
+
+func txBlobID(b []byte) consensus.TxID {
+	return consensus.TxID(sha256.Sum256(b))
+}
+
+func (s *simTxSet) sortedIDs() []consensus.TxID {
+	ids := make([]consensus.TxID, 0, len(s.txs))
+	for id := range s.txs {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return bytes.Compare(ids[i][:], ids[j][:]) < 0
+	})
+	return ids
+}
+
+func (s *simTxSet) ID() consensus.TxSetID {
+	h := sha256.New()
+	for _, id := range s.sortedIDs() {
+		h.Write(id[:])
+	}
+	var out consensus.TxSetID
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func (s *simTxSet) Txs() [][]byte {
+	out := make([][]byte, 0, len(s.txs))
+	for _, id := range s.sortedIDs() {
+		out = append(out, append([]byte(nil), s.txs[id]...))
+	}
+	return out
+}
+
+func (s *simTxSet) TxIDs() []consensus.TxID { return s.sortedIDs() }
+
+func (s *simTxSet) Contains(id consensus.TxID) bool {
+	_, ok := s.txs[id]
+	return ok
+}
+
+func (s *simTxSet) Add(tx []byte) error {
+	s.txs[txBlobID(tx)] = append([]byte(nil), tx...)
+	return nil
+}
+
+func (s *simTxSet) Remove(id consensus.TxID) error {
+	delete(s.txs, id)
+	return nil
+}
+
+func (s *simTxSet) Size() int { return len(s.txs) }
+
+func (s *simTxSet) Bytes() []byte {
+	var buf bytes.Buffer
+	for _, id := range s.sortedIDs() {
+		blob := s.txs[id]
+		var l [4]byte
+		binary.BigEndian.PutUint32(l[:], uint32(len(blob)))
+		buf.Write(l[:])
+		buf.Write(blob)
+	}
+	return buf.Bytes()
+}
+
+// simLedger is a consensus.Ledger whose ID is a pure function of its
+// construction parameters, so every peer that builds from the same parent,
+// tx-set and close time arrives at the same ledger hash without any shared
+// state — the determinism csf relies on.
+type simLedger struct {
+	id        consensus.LedgerID
+	seq       uint32
+	parentID  consensus.LedgerID
+	closeTime time.Time
+	txSetID   consensus.TxSetID
+}
+
+func buildSimLedger(parentID consensus.LedgerID, seq uint32, txSetID consensus.TxSetID, closeTime time.Time) *simLedger {
+	l := &simLedger{
+		seq:       seq,
+		parentID:  parentID,
+		closeTime: closeTime,
+		txSetID:   txSetID,
+	}
+	h := sha256.New()
+	var b [8]byte
+	binary.BigEndian.PutUint32(b[:4], l.seq)
+	h.Write(b[:4])
+	h.Write(l.parentID[:])
+	h.Write(l.txSetID[:])
+	binary.BigEndian.PutUint64(b[:], uint64(l.closeTime.UnixNano()))
+	h.Write(b[:])
+	copy(l.id[:], h.Sum(nil))
+	return l
+}
+
+func (l *simLedger) ID() consensus.LedgerID       { return l.id }
+func (l *simLedger) Seq() uint32                  { return l.seq }
+func (l *simLedger) ParentID() consensus.LedgerID { return l.parentID }
+func (l *simLedger) CloseTime() time.Time         { return l.closeTime }
+func (l *simLedger) TxSetID() consensus.TxSetID   { return l.txSetID }
+func (l *simLedger) Bytes() []byte                { return l.id[:] }
+
+// simGenesis returns the genesis ledger shared by every peer. Pure
+// function → identical across peers.
+func simGenesis() *simLedger {
+	empty := newSimTxSet(nil)
+	return buildSimLedger(consensus.LedgerID{}, 0, empty.ID(), time.Unix(0, 0).UTC())
+}
+
+// EnginePeer is a simulation node that drives a real rcl.Engine. It
+// implements consensus.Adaptor: ledger/tx storage is in-memory, network
+// broadcasts schedule delivery to peers' engines through the csf network,
+// signing/verification are no-ops (the sim trusts every message), and the
+// clock is the scheduler's virtual time.
+type EnginePeer struct {
+	id     PeerID
+	nodeID consensus.NodeID
+	sched  *Scheduler
+	net    *BasicNetwork
+	reg    *engineRegistry
+	engine *rcl.Engine
+
+	trustedSet  []consensus.NodeID
+	trustedHave map[consensus.NodeID]struct{}
+	quorum      int
+	granularity SimDuration
+
+	mu        sync.Mutex
+	opMode    consensus.OperatingMode
+	ledgers   map[consensus.LedgerID]*simLedger
+	bySeq     map[uint32]*simLedger
+	lcl       consensus.Ledger
+	validated consensus.LedgerID
+	txSets    map[consensus.TxSetID]consensus.TxSet
+	openTxs   [][]byte
+
+	// fullyValidated records, in order, the ledgers this peer crossed the
+	// trusted-validation quorum on — read after a run to assert the
+	// validation pipeline ran end to end.
+	fullyValidated []consensus.LedgerID
+}
+
+// engineRegistry resolves a PeerID to its EnginePeer so broadcasts can
+// reach the destination engine's ingress methods.
+type engineRegistry struct {
+	mu    sync.RWMutex
+	peers map[PeerID]*EnginePeer
+}
+
+func newEngineRegistry() *engineRegistry {
+	return &engineRegistry{peers: make(map[PeerID]*EnginePeer)}
+}
+
+func (r *engineRegistry) add(p *EnginePeer) {
+	r.mu.Lock()
+	r.peers[p.id] = p
+	r.mu.Unlock()
+}
+
+func (r *engineRegistry) get(id PeerID) *EnginePeer {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.peers[id]
+}
+
+// nodeIDFor derives a deterministic, unique consensus.NodeID from a PeerID.
+func nodeIDFor(id PeerID) consensus.NodeID {
+	var n consensus.NodeID
+	binary.BigEndian.PutUint32(n[:4], uint32(id)+1)
+	return n
+}
+
+// newEnginePeer constructs a peer and its engine. The engine is started in
+// ManualTick mode with the scheduler's clock; the caller wires trust and
+// begins ticking via begin().
+func newEnginePeer(
+	id PeerID,
+	sched *Scheduler,
+	net *BasicNetwork,
+	reg *engineRegistry,
+	trusted []consensus.NodeID,
+	quorum int,
+	granularity SimDuration,
+	timing consensus.Timing,
+) *EnginePeer {
+	gen := simGenesis()
+	p := &EnginePeer{
+		id:          id,
+		nodeID:      nodeIDFor(id),
+		sched:       sched,
+		net:         net,
+		reg:         reg,
+		trustedSet:  trusted,
+		trustedHave: make(map[consensus.NodeID]struct{}, len(trusted)),
+		quorum:      quorum,
+		granularity: granularity,
+		opMode:      consensus.OpModeFull,
+		ledgers:     map[consensus.LedgerID]*simLedger{gen.id: gen},
+		bySeq:       map[uint32]*simLedger{0: gen},
+		lcl:         gen,
+		txSets:      make(map[consensus.TxSetID]consensus.TxSet),
+	}
+	for _, n := range trusted {
+		p.trustedHave[n] = struct{}{}
+	}
+	cfg := rcl.Config{
+		Timing:     timing,
+		Thresholds: consensus.DefaultThresholds(),
+		Clock:      sched.NowTime,
+		ManualTick: true,
+	}
+	p.engine = rcl.NewEngine(p, cfg)
+	return p
+}
+
+// begin starts the engine, opens the first round, and schedules the
+// recurring heartbeat tick on the scheduler.
+func (p *EnginePeer) begin(ctx context.Context) error {
+	if err := p.engine.Start(ctx); err != nil {
+		return err
+	}
+	gen := p.lcl
+	round := consensus.RoundID{Seq: gen.Seq() + 1, ParentHash: gen.ID()}
+	if err := p.engine.StartRound(round, true); err != nil {
+		return err
+	}
+	p.scheduleTick()
+	return nil
+}
+
+func (p *EnginePeer) scheduleTick() {
+	p.sched.In(p.granularity, func() {
+		p.engine.TimerEntry()
+		p.scheduleTick()
+	})
+}
+
+func (p *EnginePeer) stop() { _ = p.engine.Stop() }
+
+// --- consensus.NetworkBroadcaster ---
+
+func (p *EnginePeer) deliverProposal(prop *consensus.Proposal) func(to PeerID) {
+	return func(to PeerID) {
+		if dst := p.reg.get(to); dst != nil {
+			_ = dst.engine.OnProposal(prop, uint64(p.id))
+		}
+	}
+}
+
+func (p *EnginePeer) deliverValidation(val *consensus.Validation) func(to PeerID) {
+	return func(to PeerID) {
+		if dst := p.reg.get(to); dst != nil {
+			_ = dst.engine.OnValidation(val, uint64(p.id))
+		}
+	}
+}
+
+func (p *EnginePeer) BroadcastProposal(prop *consensus.Proposal) error {
+	cp := *prop
+	p.net.Broadcast(p.id, p.deliverProposal(&cp))
+	return nil
+}
+
+func (p *EnginePeer) BroadcastValidation(val *consensus.Validation) error {
+	cp := *val
+	p.net.Broadcast(p.id, p.deliverValidation(&cp))
+	return nil
+}
+
+// RelayProposal/RelayValidation are no-ops: csf topologies the engine
+// suite uses are fully connected, so every node already received the
+// message directly from the originator's broadcast. The reduce-relay
+// bookkeeping (UpdateRelaySlot / PeersThatHave) is a production overlay
+// optimization the simulation does not model.
+func (p *EnginePeer) RelayProposal(*consensus.Proposal, uint64) error     { return nil }
+func (p *EnginePeer) RelayValidation(*consensus.Validation, uint64) error { return nil }
+func (p *EnginePeer) UpdateRelaySlot([]byte, uint64, []uint64)            {}
+func (p *EnginePeer) PeersThatHave([32]byte) []uint64                     { return nil }
+
+// RequestTxSet/RequestLedger serve the missing object from any peer that
+// holds it, scheduled through the network from a connected peer. In the
+// in-sync scenarios the suite runs these are rarely triggered, but serving
+// them keeps a lagging node able to catch up.
+func (p *EnginePeer) RequestTxSet(id consensus.TxSetID) error {
+	for _, to := range p.net.Peers(p.id) {
+		src := p.reg.get(to)
+		if src == nil {
+			continue
+		}
+		src.mu.Lock()
+		ts, ok := src.txSets[id]
+		src.mu.Unlock()
+		if !ok {
+			continue
+		}
+		txs := ts.Txs()
+		p.net.Send(to, p.id, func() { _ = p.engine.OnTxSet(id, txs) })
+		return nil
+	}
+	return nil
+}
+
+func (p *EnginePeer) RequestLedger(id consensus.LedgerID) error {
+	for _, to := range p.net.Peers(p.id) {
+		src := p.reg.get(to)
+		if src == nil {
+			continue
+		}
+		src.mu.Lock()
+		l, ok := src.ledgers[id]
+		src.mu.Unlock()
+		if !ok {
+			continue
+		}
+		blob := l.Bytes()
+		p.net.Send(to, p.id, func() { _ = p.engine.OnLedger(id, blob) })
+		return nil
+	}
+	return nil
+}
+
+// --- consensus.LedgerProvider ---
+
+func (p *EnginePeer) GetLedger(id consensus.LedgerID) (consensus.Ledger, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if l, ok := p.ledgers[id]; ok {
+		return l, nil
+	}
+	return nil, errNotFound
+}
+
+func (p *EnginePeer) GetLedgerBySeq(seq uint32) (consensus.Ledger, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if l, ok := p.bySeq[seq]; ok {
+		return l, nil
+	}
+	return nil, errNotFound
+}
+
+func (p *EnginePeer) GetLastClosedLedger() (consensus.Ledger, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lcl, nil
+}
+
+func (p *EnginePeer) GetValidatedLedgerHash() consensus.LedgerID {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.validated
+}
+
+func (p *EnginePeer) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, _ bool) (consensus.Ledger, error) {
+	l := buildSimLedger(parent.ID(), parent.Seq()+1, txSet.ID(), closeTime)
+	p.mu.Lock()
+	p.ledgers[l.id] = l
+	p.bySeq[l.seq] = l
+	if p.lcl == nil || l.seq >= p.lcl.Seq() {
+		p.lcl = l
+	}
+	p.txSets[txSet.ID()] = txSet
+	p.mu.Unlock()
+	return l, nil
+}
+
+func (p *EnginePeer) ValidateLedger(consensus.Ledger) error { return nil }
+
+func (p *EnginePeer) StoreLedger(l consensus.Ledger) error {
+	sl, ok := l.(*simLedger)
+	if !ok {
+		return nil
+	}
+	p.mu.Lock()
+	p.ledgers[sl.id] = sl
+	p.bySeq[sl.seq] = sl
+	p.mu.Unlock()
+	return nil
+}
+
+// --- consensus.TxPool ---
+
+func (p *EnginePeer) GetPendingTxs() [][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return cloneBlobs(p.openTxs)
+}
+
+func (p *EnginePeer) GetProposableTxs(consensus.Ledger) [][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return cloneBlobs(p.openTxs)
+}
+
+func (p *EnginePeer) GenerateFlagLedgerPseudoTxs(consensus.Ledger, []*consensus.Validation) [][]byte {
+	return nil
+}
+func (p *EnginePeer) GenerateNegativeUNLPseudoTx(consensus.Ledger) [][]byte { return nil }
+func (p *EnginePeer) OnUNLChange(uint32, []consensus.NodeID)                {}
+
+func (p *EnginePeer) GetTxSet(id consensus.TxSetID) (consensus.TxSet, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if ts, ok := p.txSets[id]; ok {
+		return ts, nil
+	}
+	return nil, errNotFound
+}
+
+func (p *EnginePeer) BuildTxSet(txs [][]byte) (consensus.TxSet, error) {
+	ts := newSimTxSet(txs)
+	p.mu.Lock()
+	p.txSets[ts.ID()] = ts
+	p.mu.Unlock()
+	return ts, nil
+}
+
+func (p *EnginePeer) HasTx(id consensus.TxID) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, b := range p.openTxs {
+		if txBlobID(b) == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *EnginePeer) GetTx(id consensus.TxID) ([]byte, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, b := range p.openTxs {
+		if txBlobID(b) == id {
+			return append([]byte(nil), b...), nil
+		}
+	}
+	return nil, errNotFound
+}
+
+// --- consensus.ValidatorIdentity ---
+
+func (p *EnginePeer) IsValidator() bool { return true }
+
+func (p *EnginePeer) GetValidatorKey() (consensus.NodeID, error) { return p.nodeID, nil }
+
+func (p *EnginePeer) SignProposal(prop *consensus.Proposal) error {
+	prop.NodeID = p.nodeID
+	prop.Signature = []byte{0x01}
+	return nil
+}
+
+func (p *EnginePeer) SignValidation(val *consensus.Validation) error {
+	val.NodeID = p.nodeID
+	val.Signature = []byte{0x01}
+	return nil
+}
+
+func (p *EnginePeer) VerifyProposal(*consensus.Proposal) error     { return nil }
+func (p *EnginePeer) VerifyValidation(*consensus.Validation) error { return nil }
+
+// --- consensus.TrustOracle ---
+
+func (p *EnginePeer) IsTrusted(node consensus.NodeID) bool {
+	_, ok := p.trustedHave[node]
+	return ok
+}
+
+func (p *EnginePeer) GetTrustedValidators() []consensus.NodeID {
+	out := make([]consensus.NodeID, len(p.trustedSet))
+	copy(out, p.trustedSet)
+	return out
+}
+
+func (p *EnginePeer) GetQuorum() int                     { return p.quorum }
+func (p *EnginePeer) GetNegativeUNL() []consensus.NodeID { return nil }
+
+func (p *EnginePeer) IsFeatureEnabled(string) bool                           { return true }
+func (p *EnginePeer) IsFeatureEnabledOnLedger(consensus.Ledger, string) bool { return true }
+func (p *EnginePeer) IsStandalone() bool                                     { return false }
+func (p *EnginePeer) GetCookie() uint64                                      { return uint64(p.id) + 1 }
+func (p *EnginePeer) GetServerVersion() uint64                               { return 0 }
+func (p *EnginePeer) GetLoadFee() uint32                                     { return 0 }
+func (p *EnginePeer) GetFeeVote() (uint64, uint64, uint64, bool)             { return 0, 0, 0, false }
+func (p *EnginePeer) GetAmendmentVote() [][32]byte                           { return nil }
+func (p *EnginePeer) PeerReportedLedgers() []consensus.LedgerID              { return nil }
+
+// --- consensus.TimeSource ---
+
+func (p *EnginePeer) Now() time.Time { return p.sched.NowTime() }
+
+func (p *EnginePeer) CloseTimeResolution() time.Duration { return time.Second }
+
+// AdjustCloseTime is intentionally a no-op: keeping Now() pinned to raw
+// scheduler time (no drifting offset) means every peer reads an identical
+// clock at each virtual instant, which is what makes the run deterministic
+// and lets peers agree on close times.
+func (p *EnginePeer) AdjustCloseTime(consensus.CloseTimes) {}
+
+// --- consensus.StatusEvents ---
+
+func (p *EnginePeer) GetOperatingMode() consensus.OperatingMode {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.opMode
+}
+
+func (p *EnginePeer) SetOperatingMode(mode consensus.OperatingMode) {
+	p.mu.Lock()
+	p.opMode = mode
+	p.mu.Unlock()
+}
+
+func (p *EnginePeer) OnConsensusReached(consensus.Ledger, []*consensus.Validation, time.Duration) {}
+
+func (p *EnginePeer) OnLedgerFullyValidated(ledgerID consensus.LedgerID, _ uint32) {
+	p.mu.Lock()
+	p.validated = ledgerID
+	p.fullyValidated = append(p.fullyValidated, ledgerID)
+	p.mu.Unlock()
+}
+
+func (p *EnginePeer) OnModeChange(consensus.Mode, consensus.Mode)    {}
+func (p *EnginePeer) OnPhaseChange(consensus.Phase, consensus.Phase) {}
+
+// helpers
+
+func cloneBlobs(in [][]byte) [][]byte {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([][]byte, len(in))
+	for i, b := range in {
+		out[i] = append([]byte(nil), b...)
+	}
+	return out
+}
+
+// Compile-time proof that EnginePeer is a full consensus.Adaptor.
+var _ consensus.Adaptor = (*EnginePeer)(nil)
+
+var errNotFound = errNotFoundErr{}
+
+type errNotFoundErr struct{}
+
+func (errNotFoundErr) Error() string { return "csf: object not found" }

--- a/internal/consensus/csf/engine_adaptor.go
+++ b/internal/consensus/csf/engine_adaptor.go
@@ -315,10 +315,12 @@ func (p *EnginePeer) RelayValidation(*consensus.Validation, uint64) error { retu
 func (p *EnginePeer) UpdateRelaySlot([]byte, uint64, []uint64)            {}
 func (p *EnginePeer) PeersThatHave([32]byte) []uint64                     { return nil }
 
-// RequestTxSet/RequestLedger serve the missing object from any peer that
-// holds it, scheduled through the network from a connected peer. In the
-// in-sync scenarios the suite runs these are rarely triggered, but serving
-// them keeps a lagging node able to catch up.
+// RequestTxSet serves the missing tx set from any peer that holds it,
+// scheduled through the network from a connected peer; the requester's
+// engine ingests it via OnTxSet (which uses the served blob). RequestLedger
+// is a best-effort stub: the engine's OnLedger only adopts a ledger it
+// already holds locally and ignores the served bytes, so genuine ledger
+// catch-up is not modeled by the in-sync suites that use EnginePeer today.
 func (p *EnginePeer) RequestTxSet(id consensus.TxSetID) error {
 	for _, to := range p.net.Peers(p.id) {
 		src := p.reg.get(to)
@@ -394,7 +396,11 @@ func (p *EnginePeer) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet,
 	p.mu.Lock()
 	p.ledgers[l.id] = l
 	p.bySeq[l.seq] = l
-	if p.lcl == nil || l.seq >= p.lcl.Seq() {
+	// Advance the LCL only on a strictly higher sequence: a same-seq
+	// rebuild (e.g. a fork/re-org in a partition scenario) must not
+	// side-grade the LCL to a different ledger ID, which would mask the
+	// fork from GetLastClosedLedger-based assertions.
+	if p.lcl == nil || l.seq > p.lcl.Seq() {
 		p.lcl = l
 	}
 	p.txSets[txSet.ID()] = txSet
@@ -550,11 +556,17 @@ func (p *EnginePeer) SetOperatingMode(mode consensus.OperatingMode) {
 
 func (p *EnginePeer) OnConsensusReached(consensus.Ledger, []*consensus.Validation, time.Duration) {}
 
-func (p *EnginePeer) OnLedgerFullyValidated(ledgerID consensus.LedgerID, _ uint32) {
+func (p *EnginePeer) OnLedgerFullyValidated(ledgerID consensus.LedgerID, seq uint32) {
 	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Only advance the validated tip on a strictly higher sequence so an
+	// out-of-order callback (which OnLedger guards against under load)
+	// cannot regress it.
+	if cur, ok := p.ledgers[p.validated]; ok && seq <= cur.seq {
+		return
+	}
 	p.validated = ledgerID
 	p.fullyValidated = append(p.fullyValidated, ledgerID)
-	p.mu.Unlock()
 }
 
 func (p *EnginePeer) OnModeChange(consensus.Mode, consensus.Mode)    {}

--- a/internal/consensus/csf/engine_sim_test.go
+++ b/internal/consensus/csf/engine_sim_test.go
@@ -1,0 +1,150 @@
+package csf
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+// shortSimTiming returns consensus timings compressed for simulation:
+// real consensus cadence relative scaling, but small absolute virtual
+// durations so a multi-ledger run completes in a bounded number of ticks.
+func shortSimTiming() consensus.Timing {
+	return consensus.Timing{
+		LedgerMinClose:               1 * time.Second,
+		LedgerMinConsensus:           1 * time.Second,
+		LedgerMaxConsensus:           5 * time.Second,
+		LedgerAbandonConsensus:       30 * time.Second,
+		LedgerAbandonConsensusFactor: 10,
+		LedgerIdleInterval:           1 * time.Second,
+		LedgerGranularity:            100 * time.Millisecond,
+		ProposeFreshness:             20 * time.Second,
+		ProposeInterval:              12 * time.Second,
+		ValidationFreshness:          20 * time.Second,
+	}
+}
+
+// engineSim wires N EnginePeers into a fully-connected network on a shared
+// discrete-event scheduler, each driving a real rcl.Engine.
+type engineSim struct {
+	sched *Scheduler
+	net   *BasicNetwork
+	reg   *engineRegistry
+	peers []*EnginePeer
+}
+
+func newEngineSim(numPeers int, delay SimDuration) *engineSim {
+	sched := NewScheduler()
+	net := NewBasicNetwork(sched)
+	reg := newEngineRegistry()
+
+	trusted := make([]consensus.NodeID, numPeers)
+	for i := range numPeers {
+		trusted[i] = nodeIDFor(PeerID(i))
+	}
+	// Reachable quorum for full mesh: a peer hears the other N-1 validations
+	// (and possibly its own), so N-1 is always attainable.
+	quorum := max(numPeers-1, 1)
+
+	timing := shortSimTiming()
+	peers := make([]*EnginePeer, numPeers)
+	for i := range numPeers {
+		peers[i] = newEnginePeer(PeerID(i), sched, net, reg, trusted, quorum, timing.LedgerGranularity, timing)
+		reg.add(peers[i])
+	}
+	for i := range numPeers {
+		for j := i + 1; j < numPeers; j++ {
+			net.Connect(PeerID(i), PeerID(j), delay)
+		}
+	}
+	return &engineSim{sched: sched, net: net, reg: reg, peers: peers}
+}
+
+func (s *engineSim) run(t *testing.T, until SimTime) {
+	t.Helper()
+	ctx := t.Context()
+	for _, p := range s.peers {
+		if err := p.begin(ctx); err != nil {
+			t.Fatalf("peer %d begin: %v", p.id, err)
+		}
+	}
+	s.sched.StepUntil(until)
+	for _, p := range s.peers {
+		p.stop()
+	}
+}
+
+// TestEngineSim_PeersConvergeOnLedgerChain proves the csf framework drives
+// the REAL rcl.Engine: four engine-backed peers must close several ledgers
+// and agree, byte-for-byte, on every ledger up to the lowest common
+// sequence. A fork (different ledger ID at the same seq) fails the test.
+func TestEngineSim_PeersConvergeOnLedgerChain(t *testing.T) {
+	sim := newEngineSim(4, 50*time.Millisecond)
+	sim.run(t, SimTime(20*time.Second))
+
+	minSeq := ^uint32(0)
+	for _, p := range sim.peers {
+		l, _ := p.GetLastClosedLedger()
+		if l.Seq() < minSeq {
+			minSeq = l.Seq()
+		}
+	}
+	if minSeq < 2 {
+		t.Fatalf("expected every peer to close at least 2 ledgers; lowest LCL seq = %d", minSeq)
+	}
+
+	for seq := uint32(1); seq <= minSeq; seq++ {
+		want, err := sim.peers[0].GetLedgerBySeq(seq)
+		if err != nil {
+			t.Fatalf("peer 0 missing ledger seq %d: %v", seq, err)
+		}
+		for i, p := range sim.peers {
+			got, err := p.GetLedgerBySeq(seq)
+			if err != nil {
+				t.Fatalf("peer %d missing ledger seq %d: %v", i, seq, err)
+			}
+			if got.ID() != want.ID() {
+				t.Fatalf("fork at seq %d: peer %d has %x, peer 0 has %x",
+					seq, i, got.ID(), want.ID())
+			}
+		}
+	}
+
+	// The validation pipeline must also run end to end: every peer crosses
+	// the trusted-validation quorum on at least one ledger, and they agree
+	// on the first one they fully validate.
+	var firstValidated consensus.LedgerID
+	for i, p := range sim.peers {
+		p.mu.Lock()
+		fv := append([]consensus.LedgerID(nil), p.fullyValidated...)
+		p.mu.Unlock()
+		if len(fv) == 0 {
+			t.Fatalf("peer %d fully-validated no ledger", i)
+		}
+		if i == 0 {
+			firstValidated = fv[0]
+		} else if fv[0] != firstValidated {
+			t.Fatalf("peers disagree on first fully-validated ledger: peer %d %x vs peer 0 %x",
+				i, fv[0], firstValidated)
+		}
+	}
+}
+
+// TestEngineSim_Deterministic pins that the virtual-clock-driven engine is
+// reproducible: two independent runs of the same scenario must produce the
+// identical ledger chain. This is the guarantee the engine clock seam buys
+// — no wall-clock leakage into consensus decisions.
+func TestEngineSim_Deterministic(t *testing.T) {
+	run := func() (uint32, consensus.LedgerID) {
+		sim := newEngineSim(4, 50*time.Millisecond)
+		sim.run(t, SimTime(20*time.Second))
+		l, _ := sim.peers[0].GetLastClosedLedger()
+		return l.Seq(), l.ID()
+	}
+	seq1, id1 := run()
+	seq2, id2 := run()
+	if seq1 != seq2 || id1 != id2 {
+		t.Fatalf("non-deterministic run: #1 seq=%d id=%x, #2 seq=%d id=%x", seq1, id1, seq2, id2)
+	}
+}

--- a/internal/consensus/csf/scheduler.go
+++ b/internal/consensus/csf/scheduler.go
@@ -1,6 +1,18 @@
-// Package csf provides a Consensus Simulation Framework for testing consensus algorithms.
-// It is a Go port of rippled's csf test framework, enabling deterministic discrete event
-// simulation of consensus behavior without real network or time dependencies.
+// Package csf provides a Consensus Simulation Framework: a deterministic
+// discrete-event scheduler, a simulated peer-to-peer network, a trust graph
+// and a ledger oracle for exercising consensus without real time or sockets.
+// It follows the structure of rippled's csf test harness.
+//
+// EnginePeer (engine_adaptor.go) is the real integration: it implements
+// consensus.Adaptor over these primitives and drives the PRODUCTION engine
+// (internal/consensus/rcl) in ManualTick mode with the engine's clock pinned
+// to the scheduler's virtual time, so the suite validates the real state
+// machine deterministically (see engine_sim_test.go).
+//
+// The older Peer (peer.go) carries a SIMPLIFIED inline state machine rather
+// than the real engine; it remains as a lightweight gossip/topology sandbox
+// for network scenarios (slow peers, partitions, healing) that the
+// engine-driven path does not yet cover, and is being migrated to EnginePeer.
 package csf
 
 import (

--- a/internal/consensus/events.go
+++ b/internal/consensus/events.go
@@ -36,33 +36,31 @@ const (
 	// EventLedgerAccepted fires when a new ledger is accepted.
 	EventLedgerAccepted
 
-	// EventDisputeCreated fires when a new disputed transaction is found.
-	EventDisputeCreated
-
-	// EventDisputeResolved fires when a dispute is resolved.
-	EventDisputeResolved
-
 	// EventTimerFired fires when a consensus timer expires.
 	EventTimerFired
 )
 
 func (t EventType) String() string {
-	names := map[EventType]string{
-		EventRoundStarted:       "RoundStarted",
-		EventModeChanged:        "ModeChanged",
-		EventPhaseChanged:       "PhaseChanged",
-		EventProposalReceived:   "ProposalReceived",
-		EventValidationReceived: "ValidationReceived",
-		EventConsensusReached:   "ConsensusReached",
-		EventLedgerAccepted:     "LedgerAccepted",
-		EventDisputeCreated:     "DisputeCreated",
-		EventDisputeResolved:    "DisputeResolved",
-		EventTimerFired:         "TimerFired",
+	switch t {
+	case EventRoundStarted:
+		return "RoundStarted"
+	case EventModeChanged:
+		return "ModeChanged"
+	case EventPhaseChanged:
+		return "PhaseChanged"
+	case EventProposalReceived:
+		return "ProposalReceived"
+	case EventValidationReceived:
+		return "ValidationReceived"
+	case EventConsensusReached:
+		return "ConsensusReached"
+	case EventLedgerAccepted:
+		return "LedgerAccepted"
+	case EventTimerFired:
+		return "TimerFired"
+	default:
+		return "Unknown"
 	}
-	if name, ok := names[t]; ok {
-		return name
-	}
-	return "Unknown"
 }
 
 // RoundStartedEvent is emitted when a new consensus round begins.
@@ -137,37 +135,12 @@ type LedgerAcceptedEvent struct {
 
 func (e *LedgerAcceptedEvent) Type() EventType { return EventLedgerAccepted }
 
-// DisputeCreatedEvent is emitted when a disputed transaction is found.
-type DisputeCreatedEvent struct {
-	Round     RoundID
-	TxID      TxID
-	OurVote   bool
-	Timestamp time.Time
-}
-
-func (e *DisputeCreatedEvent) Type() EventType { return EventDisputeCreated }
-
-// DisputeResolvedEvent is emitted when a dispute is resolved.
-type DisputeResolvedEvent struct {
-	Round     RoundID
-	TxID      TxID
-	Included  bool
-	YayVotes  int
-	NayVotes  int
-	Timestamp time.Time
-}
-
-func (e *DisputeResolvedEvent) Type() EventType { return EventDisputeResolved }
-
 // TimerType identifies consensus timer types.
 type TimerType int
 
 const (
 	// TimerLedgerClose fires when it's time to close the ledger.
 	TimerLedgerClose TimerType = iota
-
-	// TimerProposalExpire fires when proposals have expired.
-	TimerProposalExpire
 
 	// TimerRoundTimeout fires when a round has timed out.
 	TimerRoundTimeout

--- a/internal/consensus/ledger_timing.go
+++ b/internal/consensus/ledger_timing.go
@@ -50,10 +50,6 @@ var ledgerPossibleTimeResolutions = []uint32{10, 20, 30, 60, 90, 120}
 // unconstrained ledger (rippled's ledgerPossibleTimeResolutions[2]).
 const LedgerDefaultTimeResolution uint32 = 30
 
-// LedgerGenesisTimeResolution is the resolution used for the genesis
-// ledger (rippled's ledgerPossibleTimeResolutions[0]).
-const LedgerGenesisTimeResolution uint32 = 10
-
 // increaseLedgerTimeResolutionEvery: every N ledgers, if the prior
 // round agreed, try to step to a FINER bin (smaller seconds).
 // Matches rippled LedgerTiming.h:50.

--- a/internal/consensus/ledger_timing_test.go
+++ b/internal/consensus/ledger_timing_test.go
@@ -129,9 +129,6 @@ func TestGetNextLedgerTimeResolution_BinArray(t *testing.T) {
 	if LedgerDefaultTimeResolution != 30 {
 		t.Errorf("LedgerDefaultTimeResolution: got %d want 30", LedgerDefaultTimeResolution)
 	}
-	if LedgerGenesisTimeResolution != 10 {
-		t.Errorf("LedgerGenesisTimeResolution: got %d want 10", LedgerGenesisTimeResolution)
-	}
 	if increaseLedgerTimeResolutionEvery != 8 {
 		t.Errorf("increaseLedgerTimeResolutionEvery: got %d want 8", increaseLedgerTimeResolutionEvery)
 	}

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -148,9 +148,9 @@ type Voter struct {
 	newValidators map[consensus.NodeID]uint32 // ledger seq when added
 }
 
-// NewVoter constructs a Voter for the local node. myID must be the
-// 33-byte master pubkey representation go-xrpl uses for NodeID — the
-// same value that appears in scoreTable keys.
+// NewVoter constructs a Voter for the local node. myID is the 20-byte
+// consensus.NodeID — the calcNodeID(masterKey) digest, the same value
+// that keys the score table. The adaptor passes cfg.Identity.NodeID.
 func NewVoter(myID consensus.NodeID) *Voter {
 	return &Voter{
 		myID:          myID,
@@ -223,12 +223,15 @@ func keyToNodeID(k [33]byte) consensus.NodeID {
 // failure and falls through to no-injection rather than blocking the
 // round.
 //
-// scoreTable contract: callers may pass an under-populated table —
-// any UNL key missing from scoreTable is treated as score 0,
-// matching rippled's buildScoreTable invariant
-// (NegativeUNLVote.cpp:197-200) where every UNL member is initialized
-// to 0 before the validation-count loop. This is enforced inside
-// DoVoting; callers do not have to pre-fill themselves.
+// scoreTable contract: callers may pass a table keyed by any NodeID
+// they observed validations from — over- or under-populated. DoVoting
+// restricts it to the UNL: every UNL key missing from scoreTable is
+// treated as score 0, and every non-UNL key is dropped. This
+// reproduces rippled's buildScoreTable invariant
+// (NegativeUNLVote.cpp:197-211) where the table is seeded with exactly
+// the UNL (each at 0) and only existing keys are incremented, so the
+// score table is always a subset of the UNL. Callers need neither
+// pre-fill nor pre-filter.
 func (v *Voter) DoVoting(
 	prevLedgerSeq uint32,
 	prevLedgerHash [32]byte,
@@ -263,16 +266,19 @@ func (v *Voter) DoVoting(
 		unlNodeIDs[keyToNodeID(k)] = k
 	}
 
-	// Establish rippled's scoreTable invariant: every UNL member must
-	// have an entry, with 0 for non-validators (NegativeUNLVote.cpp:
-	// 197-200). Done on a local copy so the caller's map is not
-	// mutated.
-	filledScoreTable := make(map[consensus.NodeID]uint32, len(scoreTable)+len(unlNodeIDs))
-	maps.Copy(filledScoreTable, scoreTable)
+	// Establish rippled's scoreTable invariant: the table holds exactly
+	// the UNL members, each defaulting to 0 (NegativeUNLVote.cpp:197-211
+	// seeds the UNL with 0, then increments only keys already present).
+	// Restricting to the UNL drops any non-UNL NodeID the caller scored —
+	// a validator removed from the UNL mid-window keeps a decaying entry,
+	// and leaving it in could make it a phantom ToDisable candidate that
+	// displaces the legitimate pick (forking the flag-ledger vote) or
+	// aborts the round when the stray wins `choose` but has no master key
+	// in the lookup table. Built on a local copy so the caller's map is
+	// not mutated.
+	filledScoreTable := make(map[consensus.NodeID]uint32, len(unlNodeIDs))
 	for n := range unlNodeIDs {
-		if _, ok := filledScoreTable[n]; !ok {
-			filledScoreTable[n] = 0
-		}
+		filledScoreTable[n] = scoreTable[n]
 	}
 
 	// Resolve the effective negUNL for the upcoming flag ledger

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -239,27 +239,6 @@ func (v *Voter) DoVoting(
 	state State,
 	scoreTable map[consensus.NodeID]uint32,
 ) ([][]byte, error) {
-	// Refuse to vote if local participation is insufficient. Mirrors
-	// buildScoreTable's myValidationCount branching at
-	// NegativeUNLVote.cpp:221-244. The boundaries are exact:
-	//   < MinLocalValsToVote        → no vote (low participation)
-	//   == MinLocalValsToVote       → no vote (rippled's else branch
-	//                                 catches the boundary because the
-	//                                 else-if uses strict `>`)
-	//   > FlagLedgerInterval        → no vote AND surface
-	//                                 ErrLocalCountExceedsWindow so
-	//                                 the caller can log at error
-	//                                 severity. Rippled logs the same
-	//                                 condition with JLOG(j_.error())
-	//                                 and returns empty (no vote).
-	myCount := scoreTable[v.myID]
-	if myCount <= MinLocalValsToVote {
-		return nil, nil
-	}
-	if myCount > flagLedgerInterval {
-		return nil, fmt.Errorf("%w: %d > %d", ErrLocalCountExceedsWindow, myCount, flagLedgerInterval)
-	}
-
 	// Build the trusted-key index once.
 	unlNodeIDs := make(map[consensus.NodeID][33]byte, len(unlKeys))
 	for _, k := range unlKeys {
@@ -279,6 +258,30 @@ func (v *Voter) DoVoting(
 	filledScoreTable := make(map[consensus.NodeID]uint32, len(unlNodeIDs))
 	for n := range unlNodeIDs {
 		filledScoreTable[n] = scoreTable[n]
+	}
+
+	// Refuse to vote if local participation is insufficient. Mirrors
+	// buildScoreTable's myValidationCount branching at
+	// NegativeUNLVote.cpp:216-244, reading the local count from the
+	// UNL-restricted table just as rippled reads it from the UNL-seeded
+	// scoreTable — a local node absent from the UNL therefore counts 0
+	// and abstains. The boundaries are exact:
+	//   < MinLocalValsToVote        → no vote (low participation)
+	//   == MinLocalValsToVote       → no vote (rippled's else branch
+	//                                 catches the boundary because the
+	//                                 else-if uses strict `>`)
+	//   > FlagLedgerInterval        → no vote AND surface
+	//                                 ErrLocalCountExceedsWindow so
+	//                                 the caller can log at error
+	//                                 severity. Rippled logs the same
+	//                                 condition with JLOG(j_.error())
+	//                                 and returns empty (no vote).
+	myCount := filledScoreTable[v.myID]
+	if myCount <= MinLocalValsToVote {
+		return nil, nil
+	}
+	if myCount > flagLedgerInterval {
+		return nil, fmt.Errorf("%w: %d > %d", ErrLocalCountExceedsWindow, myCount, flagLedgerInterval)
 	}
 
 	// Resolve the effective negUNL for the upcoming flag ledger

--- a/internal/consensus/negativeunlvote/vote_test.go
+++ b/internal/consensus/negativeunlvote/vote_test.go
@@ -539,6 +539,63 @@ func TestDoVoting_ScoreTableMissingUNLMember(t *testing.T) {
 		"the silent (missing-from-scoreTable) validator must be the picked candidate")
 }
 
+// TestDoVoting_StrayNonUNLScoreDropped pins rippled's scoreTable ⊆ UNL
+// invariant (NegativeUNLVote.cpp:197-211, where the table is seeded with
+// exactly the UNL and only existing keys are incremented). A validator
+// removed from the UNL mid-window still carries a decaying score-table
+// entry; DoVoting must drop it. Leaving it in lets its score fall below
+// the low-water mark and turns it into a phantom ToDisable candidate
+// that can either displace the legitimate pick every rippled peer
+// chooses — a flag-ledger vote fork — or, when it wins `choose` but has
+// no master key in the lookup table, abort the whole round.
+func TestDoVoting_StrayNonUNLScoreDropped(t *testing.T) {
+	myKey := makeKey(0xAA)
+	weakUNL := makeKey(0xBB) // legitimate UNL member with a low score
+	v := NewVoter(keyToNodeID(myKey))
+	unl := [][33]byte{myKey, weakUNL} // the stray is deliberately NOT here
+
+	myNID := v.myID
+	weakNID := keyToNodeID(weakUNL)
+
+	// Pick a stray master key whose NodeID sorts strictly below the weak
+	// UNL member's. With an all-zero pad, choose() returns the candidate
+	// with the smallest NodeID — so if the stray were (incorrectly)
+	// retained it would WIN the toDisable pick. Since it has no master
+	// key in the lookup table, a reverted fix would then error out,
+	// aborting the round. Restricting the table to the UNL drops it.
+	var stray [33]byte
+	found := false
+	for idx := range 4096 {
+		cand := makeKeyN(idx)
+		nid := keyToNodeID(cand)
+		if nid == myNID || nid == weakNID {
+			continue
+		}
+		if compareNodeID20([20]byte(nid), [20]byte(weakNID)) < 0 {
+			stray = cand
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "test setup: need a stray NodeID below the weak member's")
+
+	var zeroPad [32]byte
+	scoreTable := map[consensus.NodeID]uint32{
+		myNID:              MinLocalValsToVote + 1,
+		weakNID:            LowWaterMark - 1, // the only legitimate toDisable
+		keyToNodeID(stray): 0,                // decayed; a phantom candidate if retained
+	}
+
+	blobs, err := v.DoVoting(1024, zeroPad, unl, State{}, scoreTable)
+	require.NoError(t, err, "a stray non-UNL score must never abort the round")
+	require.Len(t, blobs, 1, "the weak UNL member is the only eligible toDisable")
+
+	tx := decodeTx(t, blobs[0])
+	assert.EqualValues(t, 1, asUint(tx["UNLModifyDisabling"]))
+	assert.Equal(t, hex.EncodeToString(weakUNL[:]), stringFold(tx["UNLModifyValidator"]),
+		"the picked toDisable must be the UNL member, never the stray that left the UNL")
+}
+
 // makeKeyN produces a deterministic 33-byte master pubkey indexed by
 // idx. Unlike makeKey (which fills bytes 1..32 with the same byte
 // tag and so collides above 256 distinct values), makeKeyN encodes

--- a/internal/consensus/negativeunlvote/vote_test.go
+++ b/internal/consensus/negativeunlvote/vote_test.go
@@ -74,6 +74,41 @@ func TestDoVoting_RefusesWhenLocalParticipationLow(t *testing.T) {
 	assert.Nil(t, blobs, "must not vote when local participation is below MinLocalValsToVote")
 }
 
+// TestDoVoting_LocalNotInUNLAbstains pins that the participation gate
+// reads the local count from the UNL-restricted table, not the raw caller
+// table: a local node absent from the UNL counts 0 and abstains even when
+// the caller scored it above the threshold — matching rippled, whose
+// myValidationCount comes from the UNL-seeded scoreTable
+// (NegativeUNLVote.cpp:216-220). Reading the raw count instead would let a
+// non-UNL local node vote (and disable a weak member) where rippled would
+// not.
+func TestDoVoting_LocalNotInUNLAbstains(t *testing.T) {
+	myKey := makeKey(0xAA)
+	v := NewVoter(keyToNodeID(myKey))
+
+	// A UNL of four members (so the 25% toDisable cap allows one) with one
+	// weak member that WOULD be disabled if the round proceeded. myKey is
+	// deliberately absent from this UNL.
+	unl := [][33]byte{}
+	for i := range 4 {
+		unl = append(unl, makeKey(byte(0xB0+i)))
+	}
+	weak := unl[0]
+
+	scoreTable := map[consensus.NodeID]uint32{
+		v.myID: MinLocalValsToVote + 1, // high raw count, but myID ∉ UNL
+	}
+	for _, k := range unl {
+		scoreTable[keyToNodeID(k)] = HighWaterMark + 1
+	}
+	scoreTable[keyToNodeID(weak)] = LowWaterMark - 1
+
+	blobs, err := v.DoVoting(1024, [32]byte{0x07}, unl, State{}, scoreTable)
+	require.NoError(t, err)
+	assert.Nil(t, blobs,
+		"a local node absent from the UNL must abstain regardless of its raw score")
+}
+
 func TestDoVoting_NoCandidatesWhenAllParticipating(t *testing.T) {
 	myKey := makeKey(0xAA)
 	other := makeKey(0xBB)

--- a/internal/consensus/negativeunlvote/vote_test.go
+++ b/internal/consensus/negativeunlvote/vote_test.go
@@ -48,6 +48,17 @@ func fullScoreTable(myID consensus.NodeID, keys [][33]byte) map[consensus.NodeID
 	return st
 }
 
+// TestFlagLedgerIntervalMatchesConsensus guards against drift between
+// this package's compile-time flagLedgerInterval constant (duplicated so
+// the watermark thresholds can be evaluated at compile time) and the
+// canonical consensus.FlagLedgerInterval.
+func TestFlagLedgerIntervalMatchesConsensus(t *testing.T) {
+	if flagLedgerInterval != consensus.FlagLedgerInterval {
+		t.Fatalf("flagLedgerInterval (%d) drifted from consensus.FlagLedgerInterval (%d)",
+			flagLedgerInterval, consensus.FlagLedgerInterval)
+	}
+}
+
 func TestDoVoting_RefusesWhenLocalParticipationLow(t *testing.T) {
 	myKey := makeKey(0xAA)
 	other := makeKey(0xBB)

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -117,6 +117,20 @@ type Engine struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
+	// now is the wall-clock source for round/phase DURATION metrics
+	// (StartTime, roundStartTime and their elapsed-time consumers).
+	// Defaults to time.Now; the csf simulation framework injects a
+	// virtual clock so the state machine can be driven deterministically
+	// without real time. Distinct from adaptor.Now() (the offset-adjusted
+	// network clock) — see startRoundLocked for why durations need a
+	// single consistent clock.
+	now func() time.Time
+
+	// manualTick, when set, makes Start skip the internal heartbeat
+	// goroutine so an external driver (csf's discrete-event scheduler)
+	// can advance the state machine synchronously via TimerEntry.
+	manualTick bool
+
 	// Close time consensus
 	haveCloseTimeConsensus  bool
 	closeTimeAvalancheState avalancheState
@@ -343,6 +357,16 @@ const validationSetExpires = 10 * time.Minute
 type Config struct {
 	Timing     consensus.Timing
 	Thresholds consensus.Thresholds
+
+	// Clock overrides the wall-clock source for round/phase duration
+	// metrics. Nil means time.Now (production behavior, byte-identical).
+	// The csf simulation framework injects a virtual clock tied to its
+	// scheduler so consensus runs deterministically.
+	Clock func() time.Time
+
+	// ManualTick disables the internal heartbeat goroutine; the caller
+	// drives the state machine via TimerEntry instead. Used by csf.
+	ManualTick bool
 }
 
 // DefaultConfig returns the default RCL configuration.
@@ -370,9 +394,23 @@ func NewEngine(adaptor consensus.Adaptor, config Config) *Engine {
 		parms:           consensus.DefaultConsensusParms(),
 		recentProposals: make(map[consensus.NodeID][]*consensus.Proposal),
 		deadNodes:       make(map[consensus.NodeID]struct{}),
+		now:             config.Clock,
+		manualTick:      config.ManualTick,
+	}
+	if e.now == nil {
+		e.now = time.Now
 	}
 	e.modeAtomic.Store(int32(e.mode))
 	return e
+}
+
+// TimerEntry runs one heartbeat dispatch synchronously — the phase-work
+// the internal goroutine would otherwise drive each ledgerGRANULARITY.
+// Intended for ManualTick mode: an external driver (csf's scheduler)
+// advances the state machine deterministically. Mirrors rippled's
+// Consensus::timerEntry.
+func (e *Engine) TimerEntry() {
+	e.timerEntry()
 }
 
 // SetArchive wires an on-disk validation archive into the engine. May
@@ -495,9 +533,11 @@ func (e *Engine) Start(ctx context.Context) error {
 		}
 	})
 
-	// Start the main loop
-	e.wg.Add(1)
-	go e.run()
+	// Start the main loop, unless an external driver advances ticks.
+	if !e.manualTick {
+		e.wg.Add(1)
+		go e.run()
+	}
 
 	return nil
 }
@@ -567,12 +607,12 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	}
 
 	// Initialize round state.
-	// StartTime must be wall-clock (time.Now) because shouldCloseLedger
-	// reads it via time.Since at engine.go:873 — same class of bug as the
-	// roundStartTime fix below, and the same rationale applies. PhaseStart
-	// stays on adaptor.Now because its consumer (checkConvergence) reads
-	// it via adaptor.Now().Sub(), which keeps the offset-adjusted pair
-	// balanced.
+	// StartTime uses e.now() (wall-clock in production, virtual under csf)
+	// because its consumers measure elapsed time via e.now().Sub() — both
+	// ends share one clock so the difference stays meaningful, the same
+	// rationale as the roundStartTime capture below. PhaseStart stays on
+	// adaptor.Now because its consumer (checkConvergence) reads it via
+	// adaptor.Now().Sub(), which keeps the offset-adjusted pair balanced.
 	e.state = &consensus.RoundState{
 		Round:          round,
 		Mode:           e.mode,
@@ -580,7 +620,7 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 		Proposals:      make(map[consensus.NodeID]*consensus.Proposal),
 		Disputed:       make(map[consensus.TxID]*consensus.DisputedTx),
 		CloseTimes:     consensus.CloseTimes{Peers: make(map[time.Time]int)},
-		StartTime:      time.Now(),
+		StartTime:      e.now(),
 		PhaseStart:     e.adaptor.Now(),
 		HaveCorrectLCL: true,
 	}
@@ -603,16 +643,16 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	e.currentRoundTime = 0
 	e.haveCloseTimeConsensus = false
 	e.closeTimeAvalancheState = avalancheInit
-	// Internal duration metric — use the wall clock. Do NOT use
-	// adaptor.Now() here: adaptor.Now returns time.Now().Add(closeOffset),
-	// where closeOffset drifts as AdjustCloseTime pulls us toward the
-	// network's average close time. The consumers of roundStartTime
-	// measure elapsed wall time via time.Since (prevRoundTime,
-	// phaseEstablish timeout, convergePercent weighting). Mixing
-	// offset-adjusted captures with wall-clock-subtracted reads
-	// produces -closeOffset as the measured duration — exactly the
-	// negative-converge-time artifact visible in server_info.last_close.
-	e.roundStartTime = time.Now()
+	// Internal duration metric — use e.now(), NOT adaptor.Now():
+	// adaptor.Now returns time.Now().Add(closeOffset), where closeOffset
+	// drifts as AdjustCloseTime pulls us toward the network's average
+	// close time. The consumers of roundStartTime measure elapsed time via
+	// e.now().Sub() (prevRoundTime, phaseEstablish timeout, convergePercent
+	// weighting); pairing both ends on e.now() keeps the measurement
+	// consistent. Mixing an offset-adjusted capture with an e.now()-based
+	// read would produce -closeOffset as the measured duration — exactly
+	// the negative-converge-time artifact visible in server_info.last_close.
+	e.roundStartTime = e.now()
 
 	// Set phase
 	e.setPhase(consensus.PhaseOpen)
@@ -2047,7 +2087,7 @@ func (e *Engine) shouldCloseLedger() bool {
 	if e.prevLedger == nil {
 		return false
 	}
-	openTime := time.Since(e.state.StartTime)
+	openTime := e.now().Sub(e.state.StartTime)
 	timeSincePrevClose := e.adaptor.Now().Sub(e.prevLedger.CloseTime())
 
 	// Sanity check: if timeSincePrevClose or prevRoundTime are unreasonable,
@@ -2239,7 +2279,7 @@ func (e *Engine) closeLedger() {
 	// phase — mirrors rippled's result_->roundTime.reset(clock_.now()) in
 	// Consensus.h:1446, placed before propose/createDisputes. Wall-clock
 	// rationale at line 571 still applies.
-	e.roundStartTime = time.Now()
+	e.roundStartTime = e.now()
 
 	// If proposing, create and broadcast our proposal
 	if e.mode == consensus.ModeProposing {
@@ -2310,7 +2350,7 @@ func (e *Engine) closeLedger() {
 // (Consensus.h:1366-1430).
 // Caller must hold e.mu.
 func (e *Engine) phaseEstablish() {
-	roundTime := time.Since(e.roundStartTime)
+	roundTime := e.now().Sub(e.roundStartTime)
 
 	// Snapshot round time and convergence percent each tick, before the
 	// pause/accept checks, mirroring rippled's phaseEstablish which stores
@@ -2699,7 +2739,7 @@ func (e *Engine) checkConvergence() {
 		return
 	}
 
-	roundTime := time.Since(e.roundStartTime)
+	roundTime := e.now().Sub(e.roundStartTime)
 	agree, disagree := e.countAgreement()
 	total := agree + disagree
 
@@ -3245,7 +3285,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 		// StartTime is wall-clock (see startRoundLocked); use time.Since
 		// to keep the pair balanced rather than mixing offset-adjusted
 		// adaptor.Now() against it.
-		Duration:  time.Since(e.state.StartTime),
+		Duration:  e.now().Sub(e.state.StartTime),
 		Timestamp: e.adaptor.Now(),
 	})
 
@@ -3333,7 +3373,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	// in e.prevRoundTime (which is updated below). Mirrors rippled
 	// RCLConsensus.cpp:803-805 where roundTime is the local
 	// wall-clock measurement passed inline to processClosedLedger.
-	roundTime := time.Since(e.roundStartTime)
+	roundTime := e.now().Sub(e.roundStartTime)
 
 	// Notify adaptor
 	e.adaptor.OnConsensusReached(newLedger, validations, roundTime)
@@ -3619,7 +3659,7 @@ func (e *Engine) getCloseTimeNeededWeight() int {
 // as a percentage of the previous round time (min 5s).
 // Matches rippled's convergePercent_ calculation.
 func (e *Engine) convergePercent() int {
-	elapsed := time.Since(e.roundStartTime)
+	elapsed := e.now().Sub(e.roundStartTime)
 	prevRound := max(e.prevRoundTime, avMinConsensusTime)
 	return int(elapsed * 100 / prevRound)
 }

--- a/internal/consensus/rcl/engine_proposers_test.go
+++ b/internal/consensus/rcl/engine_proposers_test.go
@@ -20,7 +20,6 @@ func TestEngine_TrackerReportsProposers_ExplicitStartRound(t *testing.T) {
 
 	config := DefaultConfig()
 	config.Timing.LedgerMinClose = 5 * time.Millisecond
-	config.Timing.LedgerMaxClose = 200 * time.Millisecond
 	config.Timing.LedgerMinConsensus = 5 * time.Millisecond
 	config.Timing.LedgerMaxConsensus = 200 * time.Millisecond
 	config.Timing.LedgerAbandonConsensus = 1 * time.Second
@@ -94,7 +93,6 @@ func TestEngine_TrackerReportsProposers_TimerDriven(t *testing.T) {
 
 	config := DefaultConfig()
 	config.Timing.LedgerMinClose = 5 * time.Millisecond
-	config.Timing.LedgerMaxClose = 200 * time.Millisecond
 	config.Timing.LedgerMinConsensus = 5 * time.Millisecond
 	config.Timing.LedgerMaxConsensus = 200 * time.Millisecond
 	config.Timing.LedgerAbandonConsensus = 1 * time.Second
@@ -166,7 +164,6 @@ func TestEngine_TrackerReportsProposers_AfterWrongLedger(t *testing.T) {
 
 	config := DefaultConfig()
 	config.Timing.LedgerMinClose = 5 * time.Millisecond
-	config.Timing.LedgerMaxClose = 200 * time.Millisecond
 	config.Timing.LedgerMinConsensus = 5 * time.Millisecond
 	config.Timing.LedgerMaxConsensus = 200 * time.Millisecond
 	config.Timing.LedgerAbandonConsensus = 1 * time.Second

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -1023,7 +1023,6 @@ func TestEngine_PhaseTransitions(t *testing.T) {
 	// keep MinConsensus large enough that the establish phase cannot
 	// accept and cycle back to open before the assertion runs.
 	config.Timing.LedgerMinClose = 10 * time.Millisecond
-	config.Timing.LedgerMaxClose = 100 * time.Millisecond
 	config.Timing.LedgerMinConsensus = 200 * time.Millisecond
 	config.Timing.LedgerIdleInterval = 20 * time.Millisecond
 
@@ -1106,8 +1105,8 @@ func TestDefaultConfig(t *testing.T) {
 		t.Error("LedgerMinClose should not be zero")
 	}
 
-	if config.Timing.LedgerMaxClose == 0 {
-		t.Error("LedgerMaxClose should not be zero")
+	if config.Timing.LedgerMaxConsensus == 0 {
+		t.Error("LedgerMaxConsensus should not be zero")
 	}
 
 	if config.Thresholds.EarlyConvergencePct == 0 {
@@ -2290,7 +2289,6 @@ func TestConsensus_NoSoftTimeoutAcceptAtLedgerMaxConsensus(t *testing.T) {
 
 	config := DefaultConfig()
 	config.Timing.LedgerMaxConsensus = 15 * time.Second
-	config.Timing.LedgerMaxClose = 15 * time.Second
 	config.Timing.LedgerAbandonConsensus = 120 * time.Second
 	config.Timing.LedgerAbandonConsensusFactor = 10
 
@@ -2366,7 +2364,6 @@ func TestConsensus_AbandonHardTimeout(t *testing.T) {
 
 	config := DefaultConfig()
 	config.Timing.LedgerMaxConsensus = 15 * time.Second
-	config.Timing.LedgerMaxClose = 15 * time.Second
 	config.Timing.LedgerAbandonConsensus = 120 * time.Second
 	config.Timing.LedgerAbandonConsensusFactor = 10
 
@@ -2492,7 +2489,6 @@ func TestConsensus_AbandonRetryGate(t *testing.T) {
 
 	config := DefaultConfig()
 	config.Timing.LedgerMaxConsensus = 15 * time.Second
-	config.Timing.LedgerMaxClose = 15 * time.Second
 	config.Timing.LedgerAbandonConsensus = 120 * time.Second
 	config.Timing.LedgerAbandonConsensusFactor = 10
 

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -446,13 +446,6 @@ type Timing struct {
 	// LedgerMinClose is minimum time a ledger stays open.
 	LedgerMinClose time.Duration
 
-	// LedgerMaxClose is a legacy alias for LedgerMaxConsensus kept for
-	// source compatibility. New code should read LedgerMaxConsensus.
-	// Prior to E3 this was a go-xrpl-only 10s hard timeout that did not
-	// correspond to any rippled constant — DefaultTiming now pins it to
-	// LedgerMaxConsensus (15s) so call-sites retain matching semantics.
-	LedgerMaxClose time.Duration
-
 	// LedgerIdleInterval is time between ledgers when idle.
 	LedgerIdleInterval time.Duration
 
@@ -461,9 +454,9 @@ type Timing struct {
 	LedgerMinConsensus time.Duration
 
 	// LedgerMaxConsensus is the soft deadline for the establish phase.
-	// After this duration the engine forces acceptance (ResultTimeout)
-	// rather than waiting further. Matches rippled's ledgerMAX_CONSENSUS
-	// (ConsensusParms.h:95 = 15s).
+	// After this duration the engine moves on and forces acceptance
+	// (emitting ResultMovedOn) rather than waiting further. Matches
+	// rippled's ledgerMAX_CONSENSUS (ConsensusParms.h:95 = 15s).
 	LedgerMaxConsensus time.Duration
 
 	// LedgerAbandonConsensus is the absolute hard ceiling for a
@@ -511,7 +504,6 @@ func DefaultTiming() Timing {
 	return Timing{
 		LedgerMinClose:               2 * time.Second,
 		LedgerMaxConsensus:           15 * time.Second,
-		LedgerMaxClose:               15 * time.Second, // legacy alias, kept in sync with LedgerMaxConsensus
 		LedgerAbandonConsensus:       120 * time.Second,
 		LedgerAbandonConsensusFactor: 10,
 		LedgerMinConsensus:           1950 * time.Millisecond,
@@ -540,9 +532,6 @@ type Thresholds struct {
 	// direct equivalent in rippled.
 	EarlyConvergencePct int
 
-	// IncreaseConsensusPct is the percentage increase per round.
-	IncreaseConsensusPct int
-
 	// MinConsensusPct is the minimum percentage of trusted proposals that
 	// must agree on a tx set before consensus may be declared. This
 	// corresponds directly to rippled's minCONSENSUS_PCT = 80 (see
@@ -557,9 +546,8 @@ type Thresholds struct {
 // is a go-xrpl-local earlier gate used to flag convergence before accept.
 func DefaultThresholds() Thresholds {
 	return Thresholds{
-		EarlyConvergencePct:  50,
-		IncreaseConsensusPct: 5,
-		MinConsensusPct:      80,
+		EarlyConvergencePct: 50,
+		MinConsensusPct:     80,
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses the consensus-core review in #896 across its three phases.

**Phase A — rippled-divergence fixes (vote math + archive)**
- **C1** NegativeUNL score table is now restricted to the UNL inside `DoVoting` (rippled's `scoreTable ⊆ UNL` invariant). A validator removed from the UNL mid-window can no longer keep a decaying entry that becomes a phantom `ToDisable` candidate — which could displace the pick every rippled peer makes (forking the flag-ledger vote) or abort the round when it wins the XOR-min with no master key in the lookup table.
- **C2** Collapsed the duplicated local-participation gate: the adaptor's `buildNegativeUNLScoreTable` no longer re-checks it, so `DoVoting` is the single authority and `ErrLocalCountExceedsWindow` reaches the error log instead of being swallowed. Dropped the redundant pre-call `PurgeNewValidators`.
- **C3** Amendment voting now walks the server's **known-amendment set** (`amendment.AllFeatures()`, mirroring rippled's `amendmentMap_`). An amendment recorded only in the parent ledger's `sfMajorities` but unknown to this binary no longer emits a spurious `LostMajority` (a flag-ledger tx-set fork); a known default-no amendment that lost majority still does.
- **C4** Archive stop path commits the final batch **before** acking pending flush requests (honors Flush's committed-on-return contract under a Flush/Close race); removed the dead channel-closed branch.

**Phase B — the csf real port (D1 option a)**
- csf now drives the **production** consensus engine. New `EnginePeer` implements `consensus.Adaptor` over csf's discrete-event scheduler + simulated network, and drives an `rcl.Engine` in `ManualTick` mode with the engine's clock pinned to virtual time.
- Engine changes are **production-byte-identical** (`Config.Clock` defaults to `time.Now`, `Config.ManualTick` defaults off): the round/phase duration reads now go through an injectable `e.now()`, and an exported `TimerEntry` drives one synchronous tick.
- A four-peer sim closes a ledger chain, agrees byte-for-byte at every sequence, crosses the trusted-validation quorum, and reproduces identically across runs — so the suite validates the real state machine, not a simulation-only re-implementation.

**Phase C — dead root-package API, dedup, doc fixes**
- Deleted verified-dead `Thresholds.IncreaseConsensusPct`, `Timing.LedgerMaxClose`, `TimerProposalExpire`, and the never-published `DisputeCreatedEvent`/`DisputeResolvedEvent`. `EventType.String` map → switch. Deduped `LedgerGenesisTimeResolution` (canonical home is `genesis.GenesisTimeResolution`) + added a `flagLedgerInterval` drift-guard test. Fixed the `NewVoter` and `LedgerMaxConsensus` docs.
- **Note:** the issue suggested deleting `ResultTimeout`, but it is **not** dead — `acceptLedger`'s emission-gate test drives it (`ResultTimeout` → rippled's Expired → must emit). Kept it; corrected only the stale doc.

## Deferred (flagged for follow-up)

The remaining D1/D2/D3 items are the **full retirement of the legacy toy `Peer`** (its inline state machine, dead adaptor callbacks, never-read `ValidationParms`, fan-out duplication) and unifying `sim.go`/`sim_test.go` on `EnginePeer`. That requires the real engine to converge through network **partitions, slow-peer catch-up, and healing** — the `wrongLedger`/catch-up paths that are the historically delicate area. The full-mesh core converges deterministically (proven here); the partition/catch-up scenarios are deferred rather than ship non-deterministic tests. The package doc now states this explicitly.

## Test plan

- [x] `go test -count=1 ./internal/consensus/...` — all 9 packages green
- [x] `go vet ./internal/consensus/...` clean
- [x] `go build ./...` — whole module builds (engine `Config` change is additive)
- [x] New tests: stray-non-UNL score (C1), unknown-amendment / known-abstain-lostMajority (C3), `flagLedgerInterval` drift guard, and the four-peer engine-driven convergence + determinism sim

Fixes #896