### PR TITLE
refactor: consolidate to_currency validation into keylet

### DIFF
--- a/internal/ledger/state/amount_json.go
+++ b/internal/ledger/state/amount_json.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // AmountFromJSON parses an RPC-parameter amount (destination_amount,
@@ -360,32 +362,15 @@ func splitAmountString(s string) []string {
 	return append(elements, cur.String())
 }
 
-// isoCurrencyCharSet is rippled's isoCharSet: the characters allowed in a
-// three-letter currency code.
-const isoCurrencyCharSet = "abcdefghijklmnopqrstuvwxyz" +
-	"ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
-	"0123456789" +
-	"<>(){}[]|?!@#$%^&*"
-
 // currencyFromJSONString ports to_currency for the non-native path: a
-// three-character ISO-like code or a 160-bit hex code.
+// three-character ISO-like code or a 160-bit hex code. The caller has already
+// handled the native ("" / "XRP") case, so this validates the form through
+// keylet and encodes with the canonical encoder.
 func currencyFromJSONString(code string) ([20]byte, error) {
-	var currency [20]byte
-	if len(code) == 3 {
-		for _, c := range code {
-			if !strings.ContainsRune(isoCurrencyCharSet, c) {
-				return [20]byte{}, errors.New("invalid currency")
-			}
-		}
-		copy(currency[12:], code)
-		return currency, nil
-	}
-	decoded, err := hex.DecodeString(code)
-	if err != nil || len(decoded) != 20 {
+	if !keylet.IsValidCurrencyCode(code) {
 		return [20]byte{}, errors.New("invalid currency")
 	}
-	copy(currency[:], decoded)
-	return currency, nil
+	return keylet.CurrencyBytes(code), nil
 }
 
 // issuerFromJSONString ports to_issuer: a 160-bit hex account or a base58

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"strings"
 	"time"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -427,49 +426,15 @@ func parseIssue(raw json.RawMessage) ([20]byte, [20]byte, error) {
 	return issuer, currency, nil
 }
 
-// isoCurrencyChars is rippled to_currency's character set for 3-letter
-// ISO-style codes (UintTypes.cpp:39-43).
-const isoCurrencyChars = "abcdefghijklmnopqrstuvwxyz" +
-	"ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
-	"0123456789" +
-	"<>(){}[]|?!@#$%^&*"
-
-// Reserved 160-bit currency values issueFromJson rejects: noCurrency ("1")
-// and badCurrency (ISO-style "XRP" spelled out in hex).
-var (
-	noCurrencyBytes  = [20]byte{19: 0x01}
-	badCurrencyBytes = [20]byte{12: 'X', 13: 'R', 14: 'P'}
-)
-
-// currencyFromString validates a currency code with to_currency's rules —
-// empty/"XRP" mean native XRP, otherwise 3 characters from the ISO set or
-// 40 hex digits — then encodes it through keylet.CurrencyBytes, the
-// canonical write-path encoder used by AMMCreate, so the keying stays
-// symmetric.
+// currencyFromString validates a currency code against to_currency's rules and
+// encodes it, treating empty/"XRP" as native XRP. It delegates to
+// keylet.ParseCurrency, which both validates the form and rejects the reserved
+// noCurrency/badCurrency sentinels.
 func currencyFromString(code string) ([20]byte, error) {
 	if code == "" || code == "XRP" {
 		return [20]byte{}, nil
 	}
-	switch len(code) {
-	case 3:
-		for i := 0; i < len(code); i++ {
-			if strings.IndexByte(isoCurrencyChars, code[i]) < 0 {
-				return [20]byte{}, errors.New("invalid character in currency code")
-			}
-		}
-	case 40:
-		if _, err := hex.DecodeString(code); err != nil {
-			return [20]byte{}, errors.New("invalid hex currency code")
-		}
-	default:
-		return [20]byte{}, errors.New("invalid currency code length")
-	}
-
-	currency := keylet.CurrencyBytes(code)
-	if currency == noCurrencyBytes || currency == badCurrencyBytes {
-		return currency, errors.New("reserved currency code")
-	}
-	return currency, nil
+	return keylet.ParseCurrency(code)
 }
 
 // ammIssue carries the asset definition decoded from the AMM SLE's

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -11,6 +11,7 @@ import (
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // xrpAccountID is the zero AccountID returned by rippled's xrpAccount()
@@ -79,11 +80,11 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, rpcErr
 	}
 
-	if !isValidCurrencyCode(paysCurrency) {
+	if !keylet.IsValidCurrencyCode(paysCurrency) {
 		return nil, types.RpcErrorSrcCurMalformed(
 			"Invalid field 'taker_pays.currency', bad currency.")
 	}
-	if !isValidCurrencyCode(getsCurrency) {
+	if !keylet.IsValidCurrencyCode(getsCurrency) {
 		return nil, types.RpcErrorDstAmtMalformed(
 			"Invalid field 'taker_gets.currency', bad currency.")
 	}
@@ -253,30 +254,6 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		response["limit"] = limit
 	}
 	return response, nil
-}
-
-// isValidCurrencyCode reports whether a currency code is acceptable per
-// rippled rules: empty or "XRP" (native), exactly 3 characters from
-// rippled's isoCharSet (UintTypes.cpp:39-43, :93-96), or exactly 40 hex
-// characters (issued-currency hex form).
-func isValidCurrencyCode(currency string) bool {
-	if currency == "" || currency == "XRP" {
-		return true
-	}
-	if len(currency) == 3 {
-		for _, c := range currency {
-			if !isIsoCurrencyChar(c) {
-				return false
-			}
-		}
-		return true
-	}
-	if len(currency) == 40 {
-		if _, err := hex.DecodeString(currency); err == nil {
-			return true
-		}
-	}
-	return false
 }
 
 // readAndValidateIssuer decodes the issuer field for one side of the book and

--- a/internal/rpc/handlers/get_aggregate_price.go
+++ b/internal/rpc/handlers/get_aggregate_price.go
@@ -373,62 +373,10 @@ func parseCurrencyParam(raw json.RawMessage) (string, error) {
 	if s == "" {
 		return "", fmt.Errorf("empty currency")
 	}
-	if !isValidCurrency(s) {
+	if !keylet.IsValidCurrencyCode(s) {
 		return "", fmt.Errorf("invalid currency")
 	}
 	return s, nil
-}
-
-// isValidCurrency validates a currency code matching rippled's to_currency().
-// Accepts:
-//   - "XRP" (system currency code)
-//   - 3-character ISO-like codes using alphanumeric + special chars
-//   - 40-character hex strings (160-bit currency)
-func isValidCurrency(code string) bool {
-	if code == "XRP" || code == "xrp" {
-		return true
-	}
-	if len(code) == 3 {
-		for _, c := range code {
-			if !isIsoCurrencyChar(c) {
-				return false
-			}
-		}
-		return true
-	}
-	// 40-character hex representation of 160-bit currency
-	if len(code) == 40 {
-		for _, c := range code {
-			if !isHexChar(c) {
-				return false
-			}
-		}
-		return true
-	}
-	return false
-}
-
-// isIsoCurrencyChar matches rippled's isoCharSet:
-// abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789<>(){}[]|?!@#$%^&*
-func isIsoCurrencyChar(c rune) bool {
-	if c >= 'a' && c <= 'z' {
-		return true
-	}
-	if c >= 'A' && c <= 'Z' {
-		return true
-	}
-	if c >= '0' && c <= '9' {
-		return true
-	}
-	switch c {
-	case '<', '>', '(', ')', '{', '}', '[', ']', '|', '?', '!', '@', '#', '$', '%', '^', '&', '*':
-		return true
-	}
-	return false
-}
-
-func isHexChar(c rune) bool {
-	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
 }
 
 // parseOracleDocumentID parses an oracle_document_id from a JSON-decoded interface value.

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -299,7 +299,7 @@ func parseSourceCurrencies(
 			Currency *string         `json:"currency"`
 			Issuer   json.RawMessage `json:"issuer"`
 		}
-		if err := json.Unmarshal(raw, &sc); err != nil || sc.Currency == nil || !isValidCurrencyCode(*sc.Currency) {
+		if err := json.Unmarshal(raw, &sc); err != nil || sc.Currency == nil || !keylet.IsValidCurrencyCode(*sc.Currency) {
 			return nil, types.RpcErrorSrcCurMalformed("Source currency is malformed.")
 		}
 		currency := canonCurrency(*sc.Currency)

--- a/internal/rpc/subscription/currency_test.go
+++ b/internal/rpc/subscription/currency_test.go
@@ -1,0 +1,66 @@
+package subscription
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+)
+
+// TestCurrencyToID pins currencyToID against rippled's to_currency: empty and
+// "XRP" are the all-zero native currency, a 3-char ISO code packs at bytes
+// 12-14, 40 hex digits are taken verbatim, and anything else is rejected.
+func TestCurrencyToID(t *testing.T) {
+	var (
+		xrpID [20]byte
+		usdID = [20]byte{12: 'U', 13: 'S', 14: 'D'}
+		hex40 = "0123456789ABCDEF0123456789ABCDEF01234567"
+		hexID [20]byte
+	)
+	if _, err := hex.Decode(hexID[:], []byte(hex40)); err != nil {
+		t.Fatalf("decoding test fixture: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		code   string
+		want   [20]byte
+		wantOK bool
+	}{
+		{"empty is native XRP", "", xrpID, true},
+		{"XRP is native XRP", "XRP", xrpID, true},
+		{"forty hex zeroes is native XRP", "0000000000000000000000000000000000000000", xrpID, true},
+		{"three-letter ISO code", "USD", usdID, true},
+		{"forty hex digits taken verbatim", hex40, hexID, true},
+		{"too short", "US", [20]byte{}, false},
+		{"bad ISO char", "US ", [20]byte{}, false},
+		{"non-hex forty chars", "ZZZZ000000000000000000000000000000000000", [20]byte{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := currencyToID(tc.code)
+			if ok != tc.wantOK {
+				t.Fatalf("currencyToID(%q) ok = %v, want %v", tc.code, ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("currencyToID(%q) = %x, want %x", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseBookSideXRP verifies an XRP book side (currency "XRP", no issuer)
+// resolves to the all-zero native currency and passes parseBookSide's XRP-ness
+// cross-check (an XRP currency must not carry an issuer).
+func TestParseBookSideXRP(t *testing.T) {
+	side := map[string]json.RawMessage{"currency": json.RawMessage(`"XRP"`)}
+	cur, iss, rpcErr := parseBookSide(side, true)
+	if rpcErr != nil {
+		t.Fatalf("parseBookSide(XRP) returned error: %v", rpcErr)
+	}
+	if cur != ([20]byte{}) {
+		t.Fatalf("parseBookSide(XRP) currency = %x, want all zero", cur)
+	}
+	if iss != ([20]byte{}) {
+		t.Fatalf("parseBookSide(XRP) issuer = %x, want all zero", iss)
+	}
+}

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -8,6 +8,7 @@ import (
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // validStreams is the exact stream-name set doSubscribe accepts
@@ -548,39 +549,10 @@ func parseBookSide(side map[string]json.RawMessage, isPays bool) (currencyID [20
 // strings) lets the XRP-ness and same-asset checks fold a currency and its
 // 40-hex encoding together, matching rippled.
 func currencyToID(currency string) (id [20]byte, ok bool) {
-	if currency == "" || currency == "XRP" {
-		return id, true
-	}
-	switch len(currency) {
-	case 3:
-		for i := range 3 {
-			if !isIsoCurrencyChar(rune(currency[i])) {
-				return [20]byte{}, false
-			}
-			id[12+i] = currency[i]
-		}
-		return id, true
-	case 40:
-		if _, err := hex.Decode(id[:], []byte(currency)); err != nil {
-			return [20]byte{}, false
-		}
-		return id, true
-	default:
+	if !keylet.IsValidCurrencyCode(currency) {
 		return [20]byte{}, false
 	}
-}
-
-func isIsoCurrencyChar(c rune) bool {
-	switch {
-	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
-		return true
-	case c == '?' || c == '!' || c == '@' || c == '#' || c == '$' ||
-		c == '%' || c == '^' || c == '&' || c == '*' || c == '<' ||
-		c == '>' || c == '(' || c == ')' || c == '{' || c == '}' ||
-		c == '[' || c == ']' || c == '|':
-		return true
-	}
-	return false
+	return keylet.CurrencyBytes(currency), true
 }
 
 // isValidDomainHex mirrors uint256::parseHex acceptance the same way the

--- a/internal/tx/amm/validate.go
+++ b/internal/tx/amm/validate.go
@@ -5,17 +5,12 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// badCurrencyBytes is the 160-bit currency rippled rejects via badCurrency():
-// the standard-form encoding of the letters "XRP" (bytes 12-14 = 'X','R','P').
-// rippled UintTypes.cpp:135 — Currency(0x5852500000000000).
-var badCurrencyBytes = [20]byte{12: 'X', 13: 'R', 14: 'P'}
-
 // invalidAMMAsset mirrors rippled invalidAMMAsset() (AMMCore.cpp:65-77): an
 // asset whose currency is the bad "XRP" 160-bit code is temBAD_CURRENCY, an XRP
 // asset paired with a non-zero issuer is temBAD_ISSUER, and — when a pair is
 // supplied — an asset matching neither member is temBAD_AMM_TOKENS.
 func invalidAMMAsset(asset tx.Asset, pair *[2]tx.Asset) tx.Result {
-	if keylet.CurrencyBytes(asset.Currency) == badCurrencyBytes {
+	if keylet.CurrencyBytes(asset.Currency) == keylet.BadCurrency {
 		return tx.TemBAD_CURRENCY
 	}
 	isXRP := isXRPAsset(asset)

--- a/keylet/currency_test.go
+++ b/keylet/currency_test.go
@@ -1,0 +1,87 @@
+package keylet
+
+import "testing"
+
+// The handlers, ledger/state, subscription, and amm packages all route their
+// currency validation through keylet (ParseCurrency / IsValidCurrencyCode /
+// CurrencyBytes) and the NoCurrency / BadCurrency sentinels. These tests pin the
+// reserved values and the validate-and-encode contract so a future change to the
+// canonical rules can't silently diverge from rippled's to_currency.
+
+func TestCurrencySentinels(t *testing.T) {
+	if NoCurrency != ([20]byte{19: 0x01}) {
+		t.Errorf("NoCurrency = %x, want trailing 0x01", NoCurrency)
+	}
+	if BadCurrency != ([20]byte{12: 'X', 13: 'R', 14: 'P'}) {
+		t.Errorf("BadCurrency = %x, want bytes 12-14 = XRP", BadCurrency)
+	}
+	// to_currency yields NoCurrency for any malformed code.
+	if got := CurrencyBytes("!!"); got != NoCurrency {
+		t.Errorf("CurrencyBytes(malformed) = %x, want NoCurrency", got)
+	}
+}
+
+func TestIsValidCurrencyCode(t *testing.T) {
+	valid := []string{
+		"",    // native
+		"XRP", // native
+		"USD", // ISO
+		"xrp", // lowercase ISO (not the native short-circuit)
+		"$%^", // ISO special chars
+		"0123456789012345678901234567890123456789", // 40 hex
+		"5852500000000000000000000000000000000000", // 40 hex spelling a reserved value (still well-formed)
+	}
+	for _, c := range valid {
+		if !IsValidCurrencyCode(c) {
+			t.Errorf("IsValidCurrencyCode(%q) = false, want true", c)
+		}
+	}
+
+	invalid := []string{
+		"US",     // too short
+		"USDD",   // too long
+		"US D",   // 3 chars but space is outside isoCharSet
+		"US\x01", // non-printable
+		"123456789012345678901234567890123456789",   // 39 hex
+		"0123456789012345678901234567890123456789Z", // 41 chars
+		"00000000000000000000000000000000000000zz",  // 40 chars but not hex
+	}
+	for _, c := range invalid {
+		if IsValidCurrencyCode(c) {
+			t.Errorf("IsValidCurrencyCode(%q) = true, want false", c)
+		}
+	}
+}
+
+func TestParseCurrency(t *testing.T) {
+	// Reserved sentinels expressed as 40-hex are well-formed but rejected.
+	const noCurrencyHex = "0000000000000000000000000000000000000001"
+	const badCurrencyHex = "0000000000000000000000005852500000000000"
+
+	rejected := []string{
+		noCurrencyHex,
+		badCurrencyHex,
+		"US",   // malformed length
+		"US D", // malformed char
+		"00000000000000000000000000000000000000zz", // malformed hex
+	}
+	for _, c := range rejected {
+		if _, err := ParseCurrency(c); err == nil {
+			t.Errorf("ParseCurrency(%q) err = nil, want error", c)
+		}
+	}
+
+	// For every accepted code ParseCurrency must agree byte-for-byte with the
+	// canonical encoder, since callers used to re-derive both halves.
+	accepted := []string{"", "XRP", "USD", "$%^", "0123456789012345678901234567890123456789"}
+	for _, c := range accepted {
+		got, err := ParseCurrency(c)
+		if err != nil {
+			t.Errorf("ParseCurrency(%q) err = %v, want nil", c, err)
+			continue
+		}
+		if want := CurrencyBytes(c); got != want {
+			t.Errorf("ParseCurrency(%q) = %x, CurrencyBytes = %x", c, got, want)
+		}
+	}
+}

--- a/keylet/keylet.go
+++ b/keylet/keylet.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 
 	"github.com/LeJamon/go-xrpl/crypto/common"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
@@ -270,7 +271,7 @@ func CurrencyBytes(currency string) [20]byte {
 	case 3:
 		for i := range 3 {
 			if !isISOCurrencyChar(currency[i]) {
-				return noCurrency
+				return NoCurrency
 			}
 		}
 		result[12] = currency[0]
@@ -278,13 +279,53 @@ func CurrencyBytes(currency string) [20]byte {
 		result[14] = currency[2]
 	case 40:
 		if _, err := hex.Decode(result[:], []byte(currency)); err != nil {
-			return noCurrency
+			return NoCurrency
 		}
 	default:
-		return noCurrency
+		return NoCurrency
 	}
 
 	return result
+}
+
+// IsValidCurrencyCode reports whether code is a well-formed currency code per
+// rippled's to_currency (UintTypes.cpp:83-107): empty or "XRP" (native), a
+// 3-character code drawn entirely from isoCharSet, or 40 hex digits. It checks
+// form only — the reserved-value codes NoCurrency and BadCurrency are
+// well-formed and report true here; use ParseCurrency to reject those.
+func IsValidCurrencyCode(code string) bool {
+	if code == "" || code == "XRP" {
+		return true
+	}
+	switch len(code) {
+	case 3:
+		for i := range len(code) {
+			if !isISOCurrencyChar(code[i]) {
+				return false
+			}
+		}
+		return true
+	case 40:
+		_, err := hex.DecodeString(code)
+		return err == nil
+	default:
+		return false
+	}
+}
+
+// ParseCurrency validates code against rippled's to_currency rules and returns
+// the 20-byte currency. It errors on malformed codes and on the reserved
+// sentinels NoCurrency and BadCurrency, giving callers a single
+// validate-and-encode entry point that stays symmetric with CurrencyBytes.
+func ParseCurrency(code string) ([20]byte, error) {
+	if !IsValidCurrencyCode(code) {
+		return [20]byte{}, errors.New("invalid currency code")
+	}
+	currency := CurrencyBytes(code)
+	if currency == NoCurrency || currency == BadCurrency {
+		return [20]byte{}, errors.New("reserved currency code")
+	}
+	return currency, nil
 }
 
 // isISOCurrencyChar reports whether c is in rippled's isoCharSet
@@ -305,9 +346,15 @@ func isISOCurrencyChar(c byte) bool {
 	return false
 }
 
-// noCurrency mirrors rippled's noCurrency() sentinel (UintTypes.cpp:126-130) —
+// NoCurrency mirrors rippled's noCurrency() sentinel (UintTypes.cpp:126-130) —
 // base_uint<160>{1} stored big-endian, distinct from xrpCurrency() = all-zeros.
-var noCurrency = [20]byte{19: 0x01}
+// to_currency yields it for any malformed code.
+var NoCurrency = [20]byte{19: 0x01}
+
+// BadCurrency mirrors rippled's badCurrency() sentinel (UintTypes.cpp:133-137) —
+// Currency(0x5852500000000000), the ISO-style spelling of the reserved system
+// code "XRP" packed at bytes 12-14.
+var BadCurrency = [20]byte{12: 'X', 13: 'R', 14: 'P'}
 
 // BookDir returns the keylet for an order book directory (base, without quality).
 // The hash order follows rippled: paysCurrency, getsCurrency, paysIssuer, getsIssuer


### PR DESCRIPTION
## Summary

Follow-up to #913 / #878. The rippled `to_currency` rules — the `isoCharSet`
membership test for 3-letter codes and the reserved `noCurrency`/`badCurrency`
sentinels — were independently re-implemented across six sites. This makes
`keylet` (which already owns the canonical encoder `CurrencyBytes`) own the
canonical *validation* too:

- **New keylet API**: `ParseCurrency(string) ([20]byte, error)` (validate +
  encode + reject reserved sentinels), `IsValidCurrencyCode(string) bool`
  (form-only), and exported sentinels `NoCurrency` / `BadCurrency`. The
  unexported `noCurrency` var was renamed to the exported `NoCurrency`.
- **Routed every duplicate through keylet**: `amm_info.currencyFromString` →
  `ParseCurrency`; `book_offers`, `ripple_path_find`, `get_aggregate_price`,
  `subscription.currencyToID`, and `state.currencyFromJSONString` →
  `IsValidCurrencyCode` (+`CurrencyBytes`); `tx/amm` `badCurrencyBytes` →
  `keylet.BadCurrency`. Deleted the redundant `isoCharSet` tables and per-package
  `isIso/ISOCurrencyChar`, `isHexChar`, and sentinel copies.
- Net **−111 LOC** across 8 files; one source of truth for the rules.

Two duplicate sites beyond the issue's list were folded in for completeness:
`subscription/manager.go` (its own `isIsoCurrencyChar`) and `tx/amm/validate.go`
(its own `badCurrencyBytes`).

### Scope note — codec sentinel left in place

The `codec/binarycodec/types` `noCurrencyBytes` copy is intentionally **not**
routed through keylet. `codec` sits *below* `keylet` in the layering (keylet
builds on the codec primitives), so making codec depend on keylet inverts that
relationship even though no hard import cycle exists today. Per the issue's
guidance this is treated as a separate decision and left as-is.

Pure refactor — no protocol-behaviour change; the consolidated paths produce
byte-identical values (each caller's reachable inputs were checked, e.g.
`get_aggregate_price` rejects `""` upstream and `amount_json`'s native case is
handled before the call).

## Test plan
- [x] `go test ./keylet/...` — new `keylet/currency_test.go` pins the sentinel
      values and the validate-and-encode contract (XRP / valid ISO / 40-hex /
      malformed / both reserved sentinels), asserting `ParseCurrency` agrees
      byte-for-byte with `CurrencyBytes`.
- [x] `go test` for all affected packages (handlers, ledger/state, subscription,
      tx/amm, codec/binarycodec) — pass.
- [x] Integration suites: `internal/testing/{amm,oracle,offer}` and
      `internal/tx/payment/pathfinder` — pass.
- [x] `go vet` + `gofmt -l` clean.

Fixes #915