### PR TITLE
refactor(peer/subsystems): fix resource decay/gossip leaks, align message framing with rippled

### DIFF
--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -36,12 +36,11 @@ var (
 	ErrEndpointBanned  = errors.New("endpoint is banned")
 
 	// Message errors
-	ErrInvalidMessage   = errors.New("invalid message")
-	ErrMessageTooLarge  = errors.New("message too large")
-	ErrUnknownMessage   = errors.New("unknown message type")
-	ErrDecodeFailed     = errors.New("failed to decode message")
-	ErrEncodeFailed     = errors.New("failed to encode message")
-	ErrDecompressFailed = errors.New("failed to decompress message")
+	ErrInvalidMessage  = errors.New("invalid message")
+	ErrMessageTooLarge = errors.New("message too large")
+	ErrUnknownMessage  = errors.New("unknown message type")
+	ErrDecodeFailed    = errors.New("failed to decode message")
+	ErrEncodeFailed    = errors.New("failed to encode message")
 
 	// Lifecycle errors
 	ErrNotRunning = errors.New("overlay not running")

--- a/internal/peermanagement/ledgersync.go
+++ b/internal/peermanagement/ledgersync.go
@@ -290,20 +290,23 @@ func (h *LedgerSyncHandler) handleGetLedger(ctx context.Context, peerID PeerID, 
 		LedgerHash: req.LedgerHash,
 	}
 
-	// Get requested data based on query type
-	if req.QueryType == message.QueryTypeLedgerHeader {
+	// Dispatch on the ledger info type (rippled's itype), the field the
+	// codec actually carries on the wire. liBASE returns the header;
+	// liAS_NODE/liTX_NODE return the requested state/transaction nodes.
+	switch req.InfoType {
+	case message.LedgerInfoBase:
 		header, err := provider.GetLedgerHeader(req.LedgerHash, req.LedgerSeq)
 		if err == nil && header != nil {
 			response.Nodes = append(response.Nodes, message.LedgerNode{NodeData: header})
 		}
-	} else if req.QueryType == message.QueryTypeAccountState {
+	case message.LedgerInfoAsNode:
 		for _, nodeID := range req.NodeIDs {
 			node, err := provider.GetAccountStateNode(req.LedgerHash, nodeID)
 			if err == nil && node != nil {
 				response.Nodes = append(response.Nodes, message.LedgerNode{NodeData: node, NodeID: nodeID})
 			}
 		}
-	} else if req.QueryType == message.QueryTypeTransactionData {
+	case message.LedgerInfoTxNode:
 		for _, nodeID := range req.NodeIDs {
 			node, err := provider.GetTransactionNode(req.LedgerHash, nodeID)
 			if err == nil && node != nil {

--- a/internal/peermanagement/ledgersync.go
+++ b/internal/peermanagement/ledgersync.go
@@ -284,10 +284,13 @@ func (h *LedgerSyncHandler) handleGetLedger(ctx context.Context, peerID PeerID, 
 		return nil
 	}
 
-	// Build response
+	// Build response. Echo the request's info type, as rippled does
+	// (ledgerData.set_type(itype)), so the reply identifies which map it
+	// answers.
 	response := &message.LedgerData{
 		LedgerSeq:  req.LedgerSeq,
 		LedgerHash: req.LedgerHash,
+		InfoType:   req.InfoType,
 	}
 
 	// Dispatch on the ledger info type (rippled's itype), the field the

--- a/internal/peermanagement/message.go
+++ b/internal/peermanagement/message.go
@@ -3,8 +3,6 @@ package peermanagement
 import (
 	"io"
 
-	"github.com/pierrec/lz4"
-
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
 
@@ -62,11 +60,8 @@ const (
 	MaxMessageSize         = message.MaxMessageSize
 )
 
-// Compression constants.
-const (
-	// MinCompressibleSize is the minimum message size worth compressing.
-	MinCompressibleSize = 70
-)
+// MinCompressibleSize is the minimum message size worth compressing.
+const MinCompressibleSize = message.MinCompressibleSize
 
 // EncodeMessage encodes a message to bytes using protobuf.
 func EncodeMessage(msg Message) ([]byte, error) {
@@ -103,67 +98,22 @@ func WriteMessageCompressed(w io.Writer, msgType MessageType, payload []byte, al
 	return message.WriteMessageCompressed(w, msgType, payload, algorithm, uncompressedSize)
 }
 
-// CompressLZ4 compresses data using LZ4.
-// Returns the compressed data or nil if compression wouldn't save space.
+// CompressLZ4 compresses data using LZ4 (see message.CompressLZ4).
 func CompressLZ4(data []byte) ([]byte, error) {
-	if len(data) < MinCompressibleSize {
-		return nil, nil
-	}
-
-	maxSize := lz4.CompressBlockBound(len(data))
-	compressed := make([]byte, maxSize)
-
-	n, err := lz4.CompressBlock(data, compressed, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if n == 0 || n >= len(data) {
-		return nil, nil
-	}
-
-	return compressed[:n], nil
+	return message.CompressLZ4(data)
 }
 
-// DecompressLZ4 decompresses LZ4 compressed data.
+// DecompressLZ4 decompresses LZ4-compressed data (see message.DecompressLZ4).
 func DecompressLZ4(compressed []byte, uncompressedSize int) ([]byte, error) {
-	if uncompressedSize <= 0 {
-		return nil, ErrDecompressFailed
-	}
-
-	decompressed := make([]byte, uncompressedSize)
-	n, err := lz4.UncompressBlock(compressed, decompressed)
-	if err != nil {
-		return nil, err
-	}
-
-	if n != uncompressedSize {
-		return nil, ErrDecompressFailed
-	}
-
-	return decompressed, nil
+	return message.DecompressLZ4(compressed, uncompressedSize)
 }
 
-// ShouldCompress returns true if the message type should be compressed.
+// ShouldCompress reports whether a message type is worth compressing.
 func ShouldCompress(msgType uint16) bool {
-	switch msgType {
-	case 2, 15, 30, 31, 32, 42, 54, 56, 60, 64:
-		return true
-	default:
-		return false
-	}
+	return message.ShouldCompress(msgType)
 }
 
 // CompressIfWorthwhile compresses data if it would be beneficial.
 func CompressIfWorthwhile(msgType uint16, data []byte) ([]byte, bool) {
-	if !ShouldCompress(msgType) || len(data) < MinCompressibleSize {
-		return data, false
-	}
-
-	compressed, err := CompressLZ4(data)
-	if err != nil || compressed == nil {
-		return data, false
-	}
-
-	return compressed, true
+	return message.CompressIfWorthwhile(msgType, data)
 }

--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -37,18 +37,25 @@ func MaxPayloadSizeForType(t MessageType) uint32 {
 		return smallMsgMax
 	case TypeManifests,
 		TypeValidatorList,
-		TypeValidatorListCollection,
 		TypeGetLedger,
-		TypeGetObjects,
 		TypeProofPathReq,
 		TypeReplayDeltaReq,
 		TypeTransaction:
 		return mediumMsgMax
-	case TypeLedgerData,
-		TypeTransactions,
-		TypeProofPathResponse,
+	case TypeProofPathResponse,
 		TypeReplayDeltaResponse:
 		return largeMsgMax
+	case TypeLedgerData,
+		TypeGetObjects,
+		TypeTransactions,
+		TypeValidatorListCollection:
+		// Bulk response types can legitimately approach rippled's single
+		// 64 MB protocol ceiling: a TMLedgerData reply fills up to
+		// softMaxReplyNodes fat nodes, and TMGetObjectByHash carries
+		// fetch-pack data on the same type as its queries. A tighter cap
+		// would tear down a peer mid-sync, so these rely on the protocol
+		// ceiling (enforced in ReadMessage) rather than a stricter limit.
+		return MaxMessageSize
 	default:
 		return defaultPerTypeMax
 	}
@@ -63,7 +70,10 @@ const (
 	// Format: 4 bytes (flags + size) + 2 bytes (type) + 4 bytes (uncompressed size)
 	HeaderSizeCompressed = 10
 
-	// MaxMessageSize is the maximum allowed message size (64 MB).
+	// MaxMessageSize is the hard protocol ceiling (rippled's single 64 MB
+	// cap). ReadMessage rejects any message whose on-wire or uncompressed
+	// claim exceeds it; the per-type caps above add stricter, type-aware
+	// hardening on top.
 	MaxMessageSize = 64 * 1024 * 1024
 
 	// MaxPayloadSizeBits is the number of bits used for payload size (26 bits).
@@ -249,8 +259,18 @@ func ReadMessage(r io.Reader) (*Header, []byte, error) {
 		return nil, nil, err
 	}
 
-	// Cap both the on-wire and uncompressed claims BEFORE allocating
-	// so a tiny LZ4 frame cannot decompress into a giant slice.
+	// Hard protocol ceiling: rippled drops any message whose on-wire or
+	// uncompressed claim exceeds a single 64 MB cap, on both fields
+	// (ProtocolMessage.h:362-367). This is the absolute upper bound; the
+	// per-type caps below add stricter, type-aware hardening.
+	if header.PayloadSize > MaxMessageSize || header.UncompressedSize > MaxMessageSize {
+		return nil, nil, fmt.Errorf("%w: exceeds protocol max %d bytes",
+			ErrMessageTooLarge, MaxMessageSize)
+	}
+
+	// Cap both the on-wire and uncompressed claims per message type
+	// BEFORE allocating so a tiny LZ4 frame cannot decompress into a
+	// giant slice.
 	maxSize := MaxPayloadSizeForType(header.MessageType)
 	if header.PayloadSize > maxSize {
 		return nil, nil, fmt.Errorf("%w: %d > %d for %s",
@@ -303,10 +323,4 @@ func BuildWireMessage(msgType MessageType, payload []byte) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
-}
-
-// PeekHeader reads and returns the header without consuming the payload.
-// Useful for determining message type and size before full read.
-func PeekHeader(buf []byte) (*Header, error) {
-	return DecodeHeader(buf)
 }

--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -35,9 +35,7 @@ func MaxPayloadSizeForType(t MessageType) uint32 {
 		TypeHaveTransactions,
 		TypeCluster:
 		return smallMsgMax
-	case TypeManifests,
-		TypeValidatorList,
-		TypeGetLedger,
+	case TypeGetLedger,
 		TypeProofPathReq,
 		TypeReplayDeltaReq,
 		TypeTransaction:
@@ -45,16 +43,22 @@ func MaxPayloadSizeForType(t MessageType) uint32 {
 	case TypeProofPathResponse,
 		TypeReplayDeltaResponse:
 		return largeMsgMax
-	case TypeLedgerData,
+	case TypeManifests,
+		TypeValidatorList,
+		TypeValidatorListCollection,
+		TypeLedgerData,
 		TypeGetObjects,
-		TypeTransactions,
-		TypeValidatorListCollection:
-		// Bulk response types can legitimately approach rippled's single
-		// 64 MB protocol ceiling: a TMLedgerData reply fills up to
-		// softMaxReplyNodes fat nodes, and TMGetObjectByHash carries
-		// fetch-pack data on the same type as its queries. A tighter cap
-		// would tear down a peer mid-sync, so these rely on the protocol
-		// ceiling (enforced in ReadMessage) rather than a stricter limit.
+		TypeTransactions:
+		// Bulk response/broadcast types can legitimately approach
+		// rippled's single 64 MB protocol ceiling, which applies no
+		// per-type cap of its own: a TMLedgerData reply fills up to
+		// softMaxReplyNodes fat nodes, TMGetObjectByHash carries
+		// fetch-pack data on the same type as its queries, a full
+		// TMManifests batches every stored manifest unsplit, and a single
+		// TMValidatorList / TMValidatorListCollection blob is bounded only
+		// by the ceiling. A tighter local cap would tear down a peer
+		// mid-sync, so these rely on the protocol ceiling (enforced in
+		// ReadMessage) rather than a stricter limit.
 		return MaxMessageSize
 	default:
 		return defaultPerTypeMax
@@ -114,7 +118,8 @@ type Header struct {
 	MessageType MessageType
 	// Compressed indicates if the message is compressed.
 	Compressed bool
-	// UncompressedSize is the original size before compression (if compressed).
+	// UncompressedSize is the original payload size before compression;
+	// for an uncompressed frame it equals PayloadSize.
 	UncompressedSize uint32
 	// Algorithm is the compression algorithm used.
 	Algorithm CompressionAlgorithm
@@ -226,12 +231,17 @@ func DecodeHeader(buf []byte) (*Header, error) {
 	// Extract message type (2 bytes)
 	h.MessageType = MessageType(binary.BigEndian.Uint16(buf[4:6]))
 
-	// For compressed messages, read uncompressed size
+	// For compressed messages, read the uncompressed size from the wire;
+	// for uncompressed frames the original size is the on-wire payload
+	// size, mirroring rippled (ProtocolMessage.h:247) so the 64 MB
+	// protocol-ceiling check sees the same value on both fields.
 	if h.Compressed {
 		if len(buf) < HeaderSizeCompressed {
 			return nil, ErrTruncatedMessage
 		}
 		h.UncompressedSize = binary.BigEndian.Uint32(buf[6:10])
+	} else {
+		h.UncompressedSize = h.PayloadSize
 	}
 
 	return h, nil

--- a/internal/peermanagement/message/codec_test.go
+++ b/internal/peermanagement/message/codec_test.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
 
@@ -228,6 +229,63 @@ func TestReadWriteMessageCompressed(t *testing.T) {
 	}
 	if !bytes.Equal(readPayload, compressed) {
 		t.Error("Compressed payload mismatch")
+	}
+}
+
+// compressedFrame builds a complete LZ4-flagged wire frame: a small
+// on-wire payload with an arbitrary uncompressed-size claim. It lets the
+// cap tests exercise ReadMessage's size gates without materializing a
+// large payload.
+func compressedFrame(t *testing.T, msgType MessageType, wirePayload []byte, uncompressedSize uint32) []byte {
+	t.Helper()
+	buf := make([]byte, HeaderSizeCompressed+len(wirePayload))
+	if err := EncodeHeader(buf, uint32(len(wirePayload)), msgType, AlgorithmLZ4, uncompressedSize); err != nil {
+		t.Fatalf("EncodeHeader: %v", err)
+	}
+	copy(buf[HeaderSizeCompressed:], wirePayload)
+	return buf
+}
+
+// TestReadMessageCaps covers the per-type cap table and the hard 64 MB
+// protocol ceiling. Bulk response types may approach the ceiling;
+// request-shaped types keep stricter hardening; nothing may exceed the
+// ceiling.
+func TestReadMessageCaps(t *testing.T) {
+	const mib = 1024 * 1024
+	wire := []byte{0x01, 0x02, 0x03}
+
+	tests := []struct {
+		name       string
+		msgType    MessageType
+		uncompSize uint32
+		wantTooBig bool
+	}{
+		// Bulk response types now permit well beyond the old 16 MiB cap.
+		{"ledgerdata_20mib_ok", TypeLedgerData, 20 * mib, false},
+		{"getobjects_20mib_ok", TypeGetObjects, 20 * mib, false},
+		{"transactions_20mib_ok", TypeTransactions, 20 * mib, false},
+		{"vlcollection_20mib_ok", TypeValidatorListCollection, 20 * mib, false},
+		// Request-shaped types keep their stricter hardening caps.
+		{"ping_20mib_rejected", TypePing, 20 * mib, true},
+		{"getledger_20mib_rejected", TypeGetLedger, 20 * mib, true},
+		// The protocol ceiling is hard even for the most permissive type.
+		{"ledgerdata_over_ceiling_rejected", TypeLedgerData, MaxMessageSize + 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frame := compressedFrame(t, tt.msgType, wire, tt.uncompSize)
+			_, _, err := ReadMessage(bytes.NewReader(frame))
+			if tt.wantTooBig {
+				if !errors.Is(err, ErrMessageTooLarge) {
+					t.Fatalf("ReadMessage err = %v, want ErrMessageTooLarge", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ReadMessage err = %v, want nil (cap should permit)", err)
+			}
+		})
 	}
 }
 

--- a/internal/peermanagement/message/codec_test.go
+++ b/internal/peermanagement/message/codec_test.go
@@ -41,6 +41,9 @@ func TestHeaderEncodeDecodeUncompressed(t *testing.T) {
 			if header.Compressed {
 				t.Error("Compressed = true, want false")
 			}
+			if header.UncompressedSize != tt.payloadSize {
+				t.Errorf("UncompressedSize = %d, want %d (equals PayloadSize for uncompressed frames)", header.UncompressedSize, tt.payloadSize)
+			}
 		})
 	}
 }
@@ -260,11 +263,15 @@ func TestReadMessageCaps(t *testing.T) {
 		uncompSize uint32
 		wantTooBig bool
 	}{
-		// Bulk response types now permit well beyond the old 16 MiB cap.
+		// Bulk response/broadcast types now permit well beyond the old
+		// 16 MiB cap, up to the protocol ceiling (rippled has no per-type
+		// cap on these).
 		{"ledgerdata_20mib_ok", TypeLedgerData, 20 * mib, false},
 		{"getobjects_20mib_ok", TypeGetObjects, 20 * mib, false},
 		{"transactions_20mib_ok", TypeTransactions, 20 * mib, false},
 		{"vlcollection_20mib_ok", TypeValidatorListCollection, 20 * mib, false},
+		{"manifests_20mib_ok", TypeManifests, 20 * mib, false},
+		{"validatorlist_20mib_ok", TypeValidatorList, 20 * mib, false},
 		// Request-shaped types keep their stricter hardening caps.
 		{"ping_20mib_rejected", TypePing, 20 * mib, true},
 		{"getledger_20mib_rejected", TypeGetLedger, 20 * mib, true},

--- a/internal/peermanagement/message/compression.go
+++ b/internal/peermanagement/message/compression.go
@@ -1,0 +1,85 @@
+package message
+
+import (
+	"errors"
+
+	"github.com/pierrec/lz4"
+)
+
+// MinCompressibleSize is the minimum message size worth compressing.
+const MinCompressibleSize = 70
+
+// ErrDecompressFailed is returned when LZ4 decompression fails or the
+// decompressed length does not match the claimed uncompressed size.
+var ErrDecompressFailed = errors.New("failed to decompress message")
+
+// CompressLZ4 compresses data using LZ4. It returns nil (and no error)
+// when the input is below MinCompressibleSize or compression would not
+// save space.
+func CompressLZ4(data []byte) ([]byte, error) {
+	if len(data) < MinCompressibleSize {
+		return nil, nil
+	}
+
+	maxSize := lz4.CompressBlockBound(len(data))
+	compressed := make([]byte, maxSize)
+
+	n, err := lz4.CompressBlock(data, compressed, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if n == 0 || n >= len(data) {
+		return nil, nil
+	}
+
+	return compressed[:n], nil
+}
+
+// DecompressLZ4 decompresses an LZ4 block whose original length is
+// uncompressedSize. It fails if the size is non-positive or the
+// decompressed length does not match the claim.
+func DecompressLZ4(compressed []byte, uncompressedSize int) ([]byte, error) {
+	if uncompressedSize <= 0 {
+		return nil, ErrDecompressFailed
+	}
+
+	decompressed := make([]byte, uncompressedSize)
+	n, err := lz4.UncompressBlock(compressed, decompressed)
+	if err != nil {
+		return nil, err
+	}
+
+	if n != uncompressedSize {
+		return nil, ErrDecompressFailed
+	}
+
+	return decompressed, nil
+}
+
+// ShouldCompress reports whether a message type is worth compressing,
+// matching the set rippled compresses.
+func ShouldCompress(msgType uint16) bool {
+	switch msgType {
+	case 2, 15, 30, 31, 32, 42, 54, 56, 60, 64:
+		return true
+	default:
+		return false
+	}
+}
+
+// CompressIfWorthwhile compresses data when the message type is
+// compressible and the payload is large enough; otherwise it returns the
+// input unchanged with false.
+func CompressIfWorthwhile(msgType uint16, data []byte) ([]byte, bool) {
+	if !ShouldCompress(msgType) || len(data) < MinCompressibleSize {
+		return data, false
+	}
+
+	compressed, err := CompressLZ4(data)
+	if err != nil || compressed == nil {
+		return data, false
+	}
+
+	return compressed, true
+}

--- a/internal/peermanagement/message/compression.go
+++ b/internal/peermanagement/message/compression.go
@@ -6,7 +6,9 @@ import (
 	"github.com/pierrec/lz4"
 )
 
-// MinCompressibleSize is the minimum message size worth compressing.
+// MinCompressibleSize is the compression size threshold: payloads at or
+// below this many bytes are left uncompressed, matching rippled's
+// `messageBytes <= 70` check (Message.cpp).
 const MinCompressibleSize = 70
 
 // ErrDecompressFailed is returned when LZ4 decompression fails or the
@@ -14,10 +16,10 @@ const MinCompressibleSize = 70
 var ErrDecompressFailed = errors.New("failed to decompress message")
 
 // CompressLZ4 compresses data using LZ4. It returns nil (and no error)
-// when the input is below MinCompressibleSize or compression would not
-// save space.
+// when the input is at or below MinCompressibleSize or compression would
+// not save space.
 func CompressLZ4(data []byte) ([]byte, error) {
-	if len(data) < MinCompressibleSize {
+	if len(data) <= MinCompressibleSize {
 		return nil, nil
 	}
 
@@ -72,7 +74,7 @@ func ShouldCompress(msgType uint16) bool {
 // compressible and the payload is large enough; otherwise it returns the
 // input unchanged with false.
 func CompressIfWorthwhile(msgType uint16, data []byte) ([]byte, bool) {
-	if !ShouldCompress(msgType) || len(data) < MinCompressibleSize {
+	if !ShouldCompress(msgType) || len(data) <= MinCompressibleSize {
 		return data, false
 	}
 

--- a/internal/peermanagement/message/compression_test.go
+++ b/internal/peermanagement/message/compression_test.go
@@ -445,13 +445,20 @@ func TestCompressionMinSize(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, compressed, "Small data should not be compressed")
 
-	// Create a message at the threshold
+	// A payload at exactly the threshold is left uncompressed, matching
+	// rippled's `messageBytes <= 70` check.
 	thresholdData := make([]byte, MinCompressibleSize)
 	rand.Read(thresholdData)
 
-	// This may or may not compress depending on content
-	_, err = CompressLZ4(thresholdData)
+	compressed, err = CompressLZ4(thresholdData)
 	require.NoError(t, err)
+	assert.Nil(t, compressed, "Data at the threshold should not be compressed")
+
+	// One byte over the threshold is eligible to compress.
+	overData := bytes.Repeat([]byte("A"), MinCompressibleSize+1)
+	compressed, err = CompressLZ4(overData)
+	require.NoError(t, err)
+	assert.NotNil(t, compressed, "Compressible data above the threshold should compress")
 }
 
 // TestCompressionIncompressible tests handling of incompressible data

--- a/internal/peermanagement/message/compression_test.go
+++ b/internal/peermanagement/message/compression_test.go
@@ -7,54 +7,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pierrec/lz4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // Reference: rippled src/test/overlay/compression_test.cpp
-
-// Compression constants (matching rippled)
-const (
-	minCompressibleSize = 70
-)
-
-// compressLZ4 compresses data using LZ4.
-// Returns the compressed data or nil if compression wouldn't save space.
-func compressLZ4(data []byte) ([]byte, error) {
-	if len(data) < minCompressibleSize {
-		return nil, nil
-	}
-
-	maxSize := lz4.CompressBlockBound(len(data))
-	compressed := make([]byte, maxSize)
-
-	n, err := lz4.CompressBlock(data, compressed, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if n == 0 || n >= len(data) {
-		return nil, nil
-	}
-
-	return compressed[:n], nil
-}
-
-// decompressLZ4 decompresses LZ4 compressed data.
-func decompressLZ4(compressed []byte, uncompressedSize int) ([]byte, error) {
-	decompressed := make([]byte, uncompressedSize)
-	n, err := lz4.UncompressBlock(compressed, decompressed)
-	if err != nil {
-		return nil, err
-	}
-
-	if n != uncompressedSize {
-		return nil, fmt.Errorf("decompression size mismatch: expected %d, got %d", uncompressedSize, n)
-	}
-
-	return decompressed, nil
-}
+//
+// These tests exercise the production CompressLZ4/DecompressLZ4 in this
+// package rather than test-local copies.
 
 // buildManifests creates test manifests similar to rippled compression_test.cpp
 // Reference: rippled compression_test.cpp buildManifests()
@@ -322,7 +282,7 @@ func testCompressionRoundtrip(t *testing.T, msg Message) {
 	require.NotEmpty(t, original, "Encoded message should not be empty")
 
 	// 2. Compress the message
-	compressed, err := compressLZ4(original)
+	compressed, err := CompressLZ4(original)
 	require.NoError(t, err, "Failed to compress message")
 
 	// Skip compression tests if data is too small or incompressible
@@ -340,7 +300,7 @@ func testCompressionRoundtrip(t *testing.T, msg Message) {
 		"Compressed size should be less than original")
 
 	// 4. Decompress
-	decompressed, err := decompressLZ4(compressed, len(original))
+	decompressed, err := DecompressLZ4(compressed, len(original))
 	require.NoError(t, err, "Failed to decompress message")
 
 	// 5. Verify decompressed matches original
@@ -367,7 +327,7 @@ func TestCompressionMultiBuffer(t *testing.T) {
 	original, err := Encode(msg)
 	require.NoError(t, err)
 
-	compressed, err := compressLZ4(original)
+	compressed, err := CompressLZ4(original)
 	require.NoError(t, err)
 	require.NotNil(t, compressed, "Message should be compressible")
 
@@ -390,7 +350,7 @@ func TestCompressionMultiBuffer(t *testing.T) {
 			}
 
 			// Decompress the reassembled data
-			decompressed, err := decompressLZ4(reassembled.Bytes(), len(original))
+			decompressed, err := DecompressLZ4(reassembled.Bytes(), len(original))
 			require.NoError(t, err)
 
 			// Verify
@@ -477,20 +437,20 @@ func TestCompressionHeaderRoundtrip(t *testing.T) {
 
 // TestCompressionMinSize tests that small messages are not compressed
 func TestCompressionMinSize(t *testing.T) {
-	// Create a message smaller than minCompressibleSize
+	// Create a message smaller than MinCompressibleSize
 	smallData := make([]byte, 50)
 	rand.Read(smallData)
 
-	compressed, err := compressLZ4(smallData)
+	compressed, err := CompressLZ4(smallData)
 	require.NoError(t, err)
 	assert.Nil(t, compressed, "Small data should not be compressed")
 
 	// Create a message at the threshold
-	thresholdData := make([]byte, minCompressibleSize)
+	thresholdData := make([]byte, MinCompressibleSize)
 	rand.Read(thresholdData)
 
 	// This may or may not compress depending on content
-	_, err = compressLZ4(thresholdData)
+	_, err = CompressLZ4(thresholdData)
 	require.NoError(t, err)
 }
 
@@ -500,7 +460,7 @@ func TestCompressionIncompressible(t *testing.T) {
 	randomData := make([]byte, 1000)
 	rand.Read(randomData)
 
-	compressed, err := compressLZ4(randomData)
+	compressed, err := CompressLZ4(randomData)
 	require.NoError(t, err)
 
 	// Random data typically doesn't compress well
@@ -517,7 +477,7 @@ func TestCompressionHighlyCompressible(t *testing.T) {
 	// Create highly compressible data (repeated patterns)
 	repeatableData := bytes.Repeat([]byte("XRPL_COMPRESS_TEST_"), 100)
 
-	compressed, err := compressLZ4(repeatableData)
+	compressed, err := CompressLZ4(repeatableData)
 	require.NoError(t, err)
 	require.NotNil(t, compressed, "Repetitive data should be compressible")
 
@@ -529,7 +489,7 @@ func TestCompressionHighlyCompressible(t *testing.T) {
 	assert.Less(t, ratio, 0.5, "Highly compressible data should compress to < 50%%")
 
 	// Verify roundtrip
-	decompressed, err := decompressLZ4(compressed, len(repeatableData))
+	decompressed, err := DecompressLZ4(compressed, len(repeatableData))
 	require.NoError(t, err)
 	assert.Equal(t, repeatableData, decompressed)
 }
@@ -544,7 +504,7 @@ func TestCompressionFullMessageFlow(t *testing.T) {
 	require.NoError(t, err)
 
 	// 3. Compress
-	compressed, err := compressLZ4(encoded)
+	compressed, err := CompressLZ4(encoded)
 	require.NoError(t, err)
 	require.NotNil(t, compressed)
 
@@ -572,7 +532,7 @@ func TestCompressionFullMessageFlow(t *testing.T) {
 	payload := wireData[HeaderSizeCompressed : HeaderSizeCompressed+int(parsedHeader.PayloadSize)]
 
 	// 8. Decompress
-	decompressed, err := decompressLZ4(payload, int(parsedHeader.UncompressedSize))
+	decompressed, err := DecompressLZ4(payload, int(parsedHeader.UncompressedSize))
 	require.NoError(t, err)
 
 	// 9. Decode message

--- a/internal/peermanagement/message/messages.go
+++ b/internal/peermanagement/message/messages.go
@@ -179,7 +179,6 @@ type GetLedger struct {
 	NodeIDs       [][]byte       `json:"node_ids,omitempty"`
 	RequestCookie uint64         `json:"request_cookie,omitempty"`
 	QueryDepth    uint32         `json:"query_depth,omitempty"`
-	QueryType     QueryType      `json:"query_type,omitempty"`
 }
 
 func (g *GetLedger) Type() MessageType { return TypeGetLedger }
@@ -259,15 +258,3 @@ type HaveTransactions struct {
 }
 
 func (h *HaveTransactions) Type() MessageType { return TypeHaveTransactions }
-
-// QueryType for GetLedger requests
-type QueryType int32
-
-const (
-	// QueryTypeLedgerHeader requests the ledger header.
-	QueryTypeLedgerHeader QueryType = 0
-	// QueryTypeAccountState requests account state nodes.
-	QueryTypeAccountState QueryType = 1
-	// QueryTypeTransactionData requests transaction nodes.
-	QueryTypeTransactionData QueryType = 2
-)

--- a/internal/peermanagement/message/serialize_proto.go
+++ b/internal/peermanagement/message/serialize_proto.go
@@ -16,6 +16,17 @@ type msgCodec struct {
 	decode   func(pb.Message) (Message, error)
 }
 
+// assertMessage type-asserts msg to the concrete type expected for its
+// MessageType. A mismatch — a Message whose Type() is registered but
+// whose Go type differs — returns an error instead of panicking.
+func assertMessage[T Message](msg Message) (T, error) {
+	m, ok := msg.(T)
+	if !ok {
+		return m, fmt.Errorf("message type %d: unexpected concrete type %T", msg.Type(), msg)
+	}
+	return m, nil
+}
+
 // codecs is the per-MessageType registry. Order in this map carries
 // no semantics — keep it sorted by MessageType constant order for
 // reviewer sanity.
@@ -23,7 +34,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeManifests: {
 		newProto: func() pb.Message { return &proto.TMManifests{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*Manifests)
+			m, err := assertMessage[*Manifests](msg)
+			if err != nil {
+				return nil, err
+			}
 			list := make([]*proto.TMManifest, len(m.List))
 			for i, manifest := range m.List {
 				list[i] = &proto.TMManifest{Stobject: manifest.STObject}
@@ -42,7 +56,10 @@ var codecs = map[MessageType]msgCodec{
 	TypePing: {
 		newProto: func() pb.Message { return &proto.TMPing{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*Ping)
+			m, err := assertMessage[*Ping](msg)
+			if err != nil {
+				return nil, err
+			}
 			pingType := proto.TMPing_PingType(m.PType)
 			return &proto.TMPing{
 				Type:     &pingType,
@@ -64,7 +81,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeCluster: {
 		newProto: func() pb.Message { return &proto.TMCluster{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*Cluster)
+			m, err := assertMessage[*Cluster](msg)
+			if err != nil {
+				return nil, err
+			}
 			nodes := make([]*proto.TMClusterNode, len(m.ClusterNodes))
 			for i, n := range m.ClusterNodes {
 				nodes[i] = &proto.TMClusterNode{
@@ -111,7 +131,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeEndpoints: {
 		newProto: func() pb.Message { return &proto.TMEndpoints{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*Endpoints)
+			m, err := assertMessage[*Endpoints](msg)
+			if err != nil {
+				return nil, err
+			}
 			eps := make([]*proto.TMEndpoints_TMEndpointv2, len(m.EndpointsV2))
 			for i, ep := range m.EndpointsV2 {
 				eps[i] = &proto.TMEndpoints_TMEndpointv2{
@@ -136,7 +159,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeTransaction: {
 		newProto: func() pb.Message { return &proto.TMTransaction{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*Transaction)
+			m, err := assertMessage[*Transaction](msg)
+			if err != nil {
+				return nil, err
+			}
 			txStatus := proto.TransactionStatus(m.Status)
 			return &proto.TMTransaction{
 				RawTransaction:   m.RawTransaction,
@@ -158,7 +184,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeGetLedger: {
 		newProto: func() pb.Message { return &proto.TMGetLedger{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*GetLedger)
+			m, err := assertMessage[*GetLedger](msg)
+			if err != nil {
+				return nil, err
+			}
 			itype := proto.TMLedgerInfoType(m.InfoType)
 			ltype := proto.TMLedgerType(m.LType)
 			return &proto.TMGetLedger{
@@ -187,7 +216,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeLedgerData: {
 		newProto: func() pb.Message { return &proto.TMLedgerData{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*LedgerData)
+			m, err := assertMessage[*LedgerData](msg)
+			if err != nil {
+				return nil, err
+			}
 			nodes := make([]*proto.TMLedgerNode, len(m.Nodes))
 			for i, n := range m.Nodes {
 				nodes[i] = &proto.TMLedgerNode{
@@ -227,7 +259,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeProposeLedger: {
 		newProto: func() pb.Message { return &proto.TMProposeSet{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*ProposeSet)
+			m, err := assertMessage[*ProposeSet](msg)
+			if err != nil {
+				return nil, err
+			}
 			return &proto.TMProposeSet{
 				ProposeSeq:          pb.Uint32(m.ProposeSeq),
 				CurrentTxHash:       m.CurrentTxHash,
@@ -256,7 +291,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeStatusChange: {
 		newProto: func() pb.Message { return &proto.TMStatusChange{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*StatusChange)
+			m, err := assertMessage[*StatusChange](msg)
+			if err != nil {
+				return nil, err
+			}
 			return &proto.TMStatusChange{
 				NewStatus:          proto.NodeStatus(m.NewStatus),
 				NewEvent:           proto.NodeEvent(m.NewEvent),
@@ -285,7 +323,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeHaveSet: {
 		newProto: func() pb.Message { return &proto.TMHaveTransactionSet{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*HaveTransactionSet)
+			m, err := assertMessage[*HaveTransactionSet](msg)
+			if err != nil {
+				return nil, err
+			}
 			txSetStatus := proto.TxSetStatus(m.Status)
 			return &proto.TMHaveTransactionSet{
 				Status: &txSetStatus,
@@ -303,7 +344,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeValidation: {
 		newProto: func() pb.Message { return &proto.TMValidation{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*Validation)
+			m, err := assertMessage[*Validation](msg)
+			if err != nil {
+				return nil, err
+			}
 			return &proto.TMValidation{Validation: m.Validation}, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
@@ -314,7 +358,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeGetObjects: {
 		newProto: func() pb.Message { return &proto.TMGetObjectByHash{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*GetObjectByHash)
+			m, err := assertMessage[*GetObjectByHash](msg)
+			if err != nil {
+				return nil, err
+			}
 			objects := make([]*proto.TMIndexedObject, len(m.Objects))
 			for i, o := range m.Objects {
 				objects[i] = &proto.TMIndexedObject{
@@ -360,7 +407,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeValidatorList: {
 		newProto: func() pb.Message { return &proto.TMValidatorList{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*ValidatorList)
+			m, err := assertMessage[*ValidatorList](msg)
+			if err != nil {
+				return nil, err
+			}
 			return &proto.TMValidatorList{
 				Manifest:  m.Manifest,
 				Blob:      m.Blob,
@@ -381,7 +431,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeSquelch: {
 		newProto: func() pb.Message { return &proto.TMSquelch{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*Squelch)
+			m, err := assertMessage[*Squelch](msg)
+			if err != nil {
+				return nil, err
+			}
 			return &proto.TMSquelch{
 				Squelch:         pb.Bool(m.Squelch),
 				ValidatorPubKey: m.ValidatorPubKey,
@@ -400,7 +453,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeValidatorListCollection: {
 		newProto: func() pb.Message { return &proto.TMValidatorListCollection{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*ValidatorListCollection)
+			m, err := assertMessage[*ValidatorListCollection](msg)
+			if err != nil {
+				return nil, err
+			}
 			blobs := make([]*proto.ValidatorBlobInfo, len(m.Blobs))
 			for i, b := range m.Blobs {
 				blobs[i] = &proto.ValidatorBlobInfo{
@@ -435,7 +491,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeProofPathReq: {
 		newProto: func() pb.Message { return &proto.TMProofPathRequest{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*ProofPathRequest)
+			m, err := assertMessage[*ProofPathRequest](msg)
+			if err != nil {
+				return nil, err
+			}
 			mapType := proto.TMLedgerMapType(m.MapType)
 			return &proto.TMProofPathRequest{
 				Key:        m.Key,
@@ -455,7 +514,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeProofPathResponse: {
 		newProto: func() pb.Message { return &proto.TMProofPathResponse{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*ProofPathResponse)
+			m, err := assertMessage[*ProofPathResponse](msg)
+			if err != nil {
+				return nil, err
+			}
 			mapType := proto.TMLedgerMapType(m.MapType)
 			return &proto.TMProofPathResponse{
 				Key:          m.Key,
@@ -481,7 +543,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeReplayDeltaReq: {
 		newProto: func() pb.Message { return &proto.TMReplayDeltaRequest{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*ReplayDeltaRequest)
+			m, err := assertMessage[*ReplayDeltaRequest](msg)
+			if err != nil {
+				return nil, err
+			}
 			return &proto.TMReplayDeltaRequest{LedgerHash: m.LedgerHash}, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
@@ -492,7 +557,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeReplayDeltaResponse: {
 		newProto: func() pb.Message { return &proto.TMReplayDeltaResponse{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*ReplayDeltaResponse)
+			m, err := assertMessage[*ReplayDeltaResponse](msg)
+			if err != nil {
+				return nil, err
+			}
 			return &proto.TMReplayDeltaResponse{
 				LedgerHash:   m.LedgerHash,
 				LedgerHeader: m.LedgerHeader,
@@ -513,7 +581,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeHaveTransactions: {
 		newProto: func() pb.Message { return &proto.TMHaveTransactions{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*HaveTransactions)
+			m, err := assertMessage[*HaveTransactions](msg)
+			if err != nil {
+				return nil, err
+			}
 			return &proto.TMHaveTransactions{Hashes: m.Hashes}, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
@@ -524,7 +595,10 @@ var codecs = map[MessageType]msgCodec{
 	TypeTransactions: {
 		newProto: func() pb.Message { return &proto.TMTransactions{} },
 		encode: func(msg Message) (pb.Message, error) {
-			m := msg.(*Transactions)
+			m, err := assertMessage[*Transactions](msg)
+			if err != nil {
+				return nil, err
+			}
 			txs := make([]*proto.TMTransaction, len(m.Transactions))
 			for i, tx := range m.Transactions {
 				txStatus := proto.TransactionStatus(tx.Status)

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -262,6 +262,19 @@ func (p *Peer) Capabilities() *PeerCapabilities {
 	return p.capabilities
 }
 
+// compressionNegotiated reports whether this connection agreed to use
+// LZ4 compression. rippled enables it only when the local node has
+// compression configured and the peer advertised it (Handshake.cpp's
+// peerFeatureEnabled against config.COMPRESSION); a compressed frame
+// outside that agreement is a protocol violation.
+func (p *Peer) compressionNegotiated() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.handshakeCfg.EnableCompression &&
+		p.capabilities != nil &&
+		p.capabilities.SupportsCompression()
+}
+
 func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -727,6 +740,14 @@ func (p *Peer) readLoop(ctx context.Context) error {
 		p.metrics.recv.addMessage(wireBytes)
 
 		if header.Compressed {
+			// rippled rejects a compressed frame outright when compression
+			// was not negotiated for the connection (ProtocolMessage.h:369-
+			// 375). A peer shipping LZ4 frames we never agreed to is a
+			// protocol violation — charge and tear the connection down.
+			if !p.compressionNegotiated() {
+				p.IncBadData("compression-unnegotiated")
+				return fmt.Errorf("peer sent a compressed frame without negotiating compression")
+			}
 			payload, err = DecompressLZ4(payload, int(header.UncompressedSize))
 			if err != nil {
 				p.IncBadData("decompress-lz4-failed")
@@ -1153,6 +1174,7 @@ func chargeForReason(reason string) resource.Charge {
 		"replay-delta-req-unnegotiated",
 		"replay-delta-resp-unnegotiated",
 		"proof-path-resp-unnegotiated",
+		"compression-unnegotiated",
 		"get-objects-ledgerhash",
 		"proposal-decode",
 		"validation-decode",

--- a/internal/peermanagement/peertls/shim/shim.c
+++ b/internal/peermanagement/peertls/shim/shim.c
@@ -207,14 +207,6 @@ int peertls_get_peer_finished(peertls_ssl* s, void* buf, int len) {
     return (int)r;
 }
 
-int peertls_shutdown(peertls_ssl* s) {
-    if (!s || !s->ssl) return PEERTLS_ERR_OTHER;
-    ERR_clear_error();
-    int rc = SSL_shutdown(s->ssl);
-    if (rc >= 0) return 0;
-    return map_ssl_error(s->ssl, rc);
-}
-
 const char* peertls_last_error(void) {
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
     static _Thread_local char buf[256];

--- a/internal/peermanagement/peertls/shim/shim.go
+++ b/internal/peermanagement/peertls/shim/shim.go
@@ -243,22 +243,3 @@ func (s *SSL) GetPeerFinished(buf []byte) int {
 	n := C.peertls_get_peer_finished(s.p, unsafe.Pointer(&buf[0]), C.int(len(buf)))
 	return int(n)
 }
-
-func (s *SSL) Shutdown() error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	rc := C.peertls_shutdown(s.p)
-	if rc == 0 {
-		return nil
-	}
-	return enrichLastError(CodeToErr(int(rc)))
-}
-
-// LastError returns the OpenSSL error string from the current thread.
-func LastError() string {
-	c := C.peertls_last_error()
-	if c == nil {
-		return ""
-	}
-	return C.GoString(c)
-}

--- a/internal/peermanagement/peertls/shim/shim.h
+++ b/internal/peermanagement/peertls/shim/shim.h
@@ -71,9 +71,6 @@ int peertls_bio_write(peertls_ssl* s, const void* buf, int len);
 int peertls_get_finished     (peertls_ssl* s, void* buf, int len);
 int peertls_get_peer_finished(peertls_ssl* s, void* buf, int len);
 
-/* Send TLS close_notify. Idempotent. */
-int peertls_shutdown(peertls_ssl* s);
-
 /* Returns a static pointer to the most recent SSL error string in this
  * thread. Only valid until the next OpenSSL call on this thread. */
 const char* peertls_last_error(void);

--- a/internal/peermanagement/peertls/tls_openssl.go
+++ b/internal/peermanagement/peertls/tls_openssl.go
@@ -46,7 +46,14 @@ func putPumpBuf(buf []byte) {
 }
 
 func Client(inner net.Conn, cfg *Config) (PeerConn, error) {
-	return newConn(inner, cfg, false)
+	// Return an explicit nil interface on error: handing back newConn's
+	// (*conn, error) directly would wrap a nil *conn in a non-nil
+	// PeerConn, so callers checking `pc != nil` would be misled.
+	c, err := newConn(inner, cfg, false)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 func NewListener(inner net.Listener, cfg *Config) net.Listener {

--- a/internal/peermanagement/resource/charge.go
+++ b/internal/peermanagement/resource/charge.go
@@ -37,8 +37,3 @@ func (c Charge) Label() string { return c.label }
 func (c Charge) String() string {
 	return fmt.Sprintf("%s ($%d)", c.label, c.cost)
 }
-
-// Scale mirrors rippled's Charge::operator*.
-func (c Charge) Scale(m int) Charge {
-	return Charge{cost: c.cost * m, label: c.label}
-}

--- a/internal/peermanagement/resource/decay.go
+++ b/internal/peermanagement/resource/decay.go
@@ -12,7 +12,7 @@ type decayingSample struct {
 }
 
 func newDecayingSample(now time.Time, windowSeconds int) decayingSample {
-	return decayingSample{windowSeconds: windowSeconds, when: now}
+	return decayingSample{windowSeconds: windowSeconds, when: now.Truncate(time.Second)}
 }
 
 func (d *decayingSample) add(v int, now time.Time) int {
@@ -33,12 +33,19 @@ func (d *decayingSample) valueAt(now time.Time) int {
 //
 // for each elapsed whole second. Elapsed > 4*window collapses to zero
 // directly, since the residual is statistically insignificant — same
-// short-circuit rippled uses. The anchor is advanced to `now` on every
-// call where `now != d.when` (mirroring DecayingSample.h:96): aging is
-// tied to whole-second ticks, and sub-second progress between calls
-// is intentionally discarded so the algorithm is invariant under
-// call-rate.
+// short-circuit rippled uses.
+//
+// rippled drives DecayingSample with a whole-second clock, so its
+// anchor only ever moves in one-second ticks. Go's wall clock is
+// nanosecond-precision: anchoring on the raw timestamp would let a
+// sub-second call swallow the fractional progress (elapsed truncates
+// to 0) while still advancing the anchor, so a peer charged more than
+// once per second would never decay. Truncating `now` to the second
+// before anchoring restores rippled's behaviour — repeated calls
+// within the same second are no-ops, and the anchor only advances on a
+// genuine second boundary.
 func (d *decayingSample) decay(now time.Time) {
+	now = now.Truncate(time.Second)
 	if now.Equal(d.when) {
 		return
 	}

--- a/internal/peermanagement/resource/manager.go
+++ b/internal/peermanagement/resource/manager.go
@@ -147,7 +147,7 @@ func (m *Manager) run() {
 // from a fresh ephemeral port inherits its prior balance — without
 // this, a misbehaving peer could bypass the blacklist by reconnecting.
 func (m *Manager) NewInboundEndpoint(addr string) *Consumer {
-	return m.acquire(KindInbound, normalizeAddr(addr, true))
+	return m.acquire(KindInbound, normalizeAddr(addr))
 }
 
 // NewOutboundEndpoint mints (or reattaches) a Consumer for an outbound
@@ -174,10 +174,7 @@ func (m *Manager) NewUnlimitedEndpoint(addr string) *Consumer {
 // trivially defeated. Uses net.SplitHostPort so IPv6 brackets and
 // bare addresses are handled correctly; falls back to the input
 // verbatim when there is no port to strip.
-func normalizeAddr(addr string, stripPort bool) string {
-	if !stripPort {
-		return addr
-	}
+func normalizeAddr(addr string) string {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		return addr
@@ -228,6 +225,16 @@ func (m *Manager) acquire(k Kind, addr string) *Consumer {
 func (m *Manager) release(e *entry) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.releaseLocked(e)
+}
+
+// releaseLocked is the body of release for callers that already hold
+// m.mu (the gossip import-expiry and import-replacement paths). It must
+// drive every refcount decrement so an entry that hits zero is marked
+// inactive and given an expiry timestamp; a raw refcount-- would strand
+// a zero-balance entry in the table forever, since periodicActivity only
+// erases entries whose whenExpires is set.
+func (m *Manager) releaseLocked(e *entry) {
 	if e.refcount == 0 {
 		return
 	}
@@ -341,6 +348,7 @@ func (m *Manager) PeriodicActivity() {
 		if !now.Before(rec.whenExpires) {
 			for _, it := range rec.items {
 				it.consumer.e.remoteBalance -= it.balance
+				m.releaseLocked(it.consumer.e)
 			}
 			delete(m.imports, origin)
 		}
@@ -377,7 +385,7 @@ func (m *Manager) ImportConsumers(origin string, g Gossip) {
 	prev := m.imports[origin]
 	next := &importRecord{whenExpires: now.Add(GossipExpiration)}
 	for _, it := range g.Items {
-		ek := key{kind: KindInbound, addr: normalizeAddr(it.Address, true)}
+		ek := key{kind: KindInbound, addr: normalizeAddr(it.Address)}
 		e, ok := m.entries[ek]
 		if !ok {
 			e = &entry{k: ek, localBalance: newDecayingSample(now, DecayWindowSeconds)}
@@ -395,8 +403,10 @@ func (m *Manager) ImportConsumers(origin string, g Gossip) {
 	if prev != nil {
 		for _, it := range prev.items {
 			it.consumer.e.remoteBalance -= it.balance
-			// Mirror the +1 we did when prev was created.
-			it.consumer.e.refcount--
+			// Mirror the +1 we did when prev was created, via release
+			// semantics so an entry that drops to zero gets an expiry
+			// timestamp instead of lingering forever.
+			m.releaseLocked(it.consumer.e)
 		}
 	}
 	m.imports[origin] = next

--- a/internal/peermanagement/resource/manager_test.go
+++ b/internal/peermanagement/resource/manager_test.go
@@ -334,3 +334,93 @@ func TestImport_ReplacesPriorContributionFromSameOrigin(t *testing.T) {
 		t.Fatalf("after re-import balance=%d want 2200 (not 3700 — prior contribution must have been subtracted)", got)
 	}
 }
+
+// TestDecay_AgesUnderSubSecondChargeRate guards against the regression
+// where decay anchored on a nanosecond clock: any charge cadence faster
+// than once per second left elapsed-seconds truncating to zero, so the
+// balance never aged and grew as a pure accumulator. With second-
+// truncated anchoring it must reach a bounded steady state instead.
+func TestDecay_AgesUnderSubSecondChargeRate(t *testing.T) {
+	m, clk := newTestManager()
+	c := m.NewInboundEndpoint("192.0.2.100")
+	defer c.Release()
+
+	const cost = 100
+	const charges = 2000 // 200 s at one charge per 100 ms
+
+	for range charges {
+		c.Charge(NewCharge(cost, "sub-second"), "")
+		clk.Advance(100 * time.Millisecond)
+	}
+
+	bal := c.Balance()
+
+	// Without decay the balance would normalize to charges*cost/window.
+	undecayed := charges * cost / DecayWindowSeconds
+	if bal >= undecayed/2 {
+		t.Fatalf("balance=%d did not decay (undecayed accumulation=%d): sub-second charges are not aging", bal, undecayed)
+	}
+	if bal <= 0 {
+		t.Fatalf("balance=%d: a continuously charged consumer must not decay to zero", bal)
+	}
+}
+
+// TestImport_ExpiryReleasesEntries guards against the gossip refcount
+// leak: when an import record expires, every entry it pinned must fall
+// back to refcount 0 and be erased after the normal grace period, not
+// linger in the table forever.
+func TestImport_ExpiryReleasesEntries(t *testing.T) {
+	m, clk := newTestManager()
+
+	g := Gossip{Items: []GossipItem{
+		{Address: "192.0.2.110", Balance: 1500},
+		{Address: "192.0.2.111", Balance: 1800},
+	}}
+	m.ImportConsumers("origin-leak", g)
+	if got := m.EntryCount(); got != 2 {
+		t.Fatalf("after import EntryCount=%d want 2", got)
+	}
+
+	// After GossipExpiration the record is dropped and its entries fall
+	// to refcount 0, but they keep the normal SecondsUntilExpiration
+	// grace window before erasure.
+	clk.Advance(GossipExpiration + time.Second)
+	m.PeriodicActivity()
+	if got := m.EntryCount(); got != 2 {
+		t.Fatalf("entries erased before grace period: EntryCount=%d want 2", got)
+	}
+
+	// Once the grace window lapses they must be gone — a leaked refcount
+	// would pin them at 1 forever.
+	clk.Advance(SecondsUntilExpiration + time.Second)
+	m.PeriodicActivity()
+	if got := m.EntryCount(); got != 0 {
+		t.Fatalf("gossip entries leaked: EntryCount=%d want 0", got)
+	}
+}
+
+// TestImport_ReplacementReleasesDroppedAddress verifies the replacement
+// path also releases through expiry semantics: an address present in a
+// prior snapshot but absent from the next must be allowed to age out,
+// not stranded as a zero-balance, never-erased entry.
+func TestImport_ReplacementReleasesDroppedAddress(t *testing.T) {
+	m, clk := newTestManager()
+
+	m.ImportConsumers("origin-r", Gossip{Items: []GossipItem{
+		{Address: "192.0.2.120", Balance: 1500},
+		{Address: "192.0.2.121", Balance: 1500},
+	}})
+	if got := m.EntryCount(); got != 2 {
+		t.Fatalf("after first import EntryCount=%d want 2", got)
+	}
+
+	// Re-import from the same origin, dropping the second address.
+	m.ImportConsumers("origin-r", Gossip{Items: []GossipItem{
+		{Address: "192.0.2.120", Balance: 1500},
+	}})
+	clk.Advance(SecondsUntilExpiration + time.Second)
+	m.PeriodicActivity()
+	if got := m.EntryCount(); got != 1 {
+		t.Fatalf("dropped gossip address leaked: EntryCount=%d want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses the audit in #901 across the four peer subsystem packages (`message`, `peertls`, `resource`).

**Correctness**
- **Resource decay stall** — `decayingSample.decay` anchored on a nanosecond clock, so any charge cadence faster than once per second left elapsed-seconds truncating to zero: the balance never aged and accumulated unbounded. Now anchors on second-truncated time, mirroring rippled's whole-second `DecayingSample` clock.
- **Gossip refcount leak** — imported entries were pinned forever: the expiry path subtracted the remote balance but never decremented the refcount, and the replacement path used a raw `refcount--` that never set `whenExpires`. Both now route through `releaseLocked()` so zero-refcount entries get an expiry and are erased.
- **GetLedger.QueryType** — the field was never encoded/decoded (wire-dead) and its constants 1/2 don't exist in the protocol (`TMQueryType` has only `qtINDIRECT`). Removed; `ledgersync.handleGetLedger` now dispatches on `InfoType` (liBASE/liAS_NODE/liTX_NODE) like the consensus router.
- **Framing caps** — bulk response types (`LedgerData`, `GetObjects`, `Transactions`, `ValidatorListCollection`) were capped below what rippled legitimately produces and would tear down a peer mid-sync; raised to the protocol ceiling. `MaxMessageSize` (rippled's single 64 MB cap) is now actually enforced in `ReadMessage` on both the on-wire and uncompressed claims.
- **Compression negotiation** — compressed frames are now rejected with a protocol error when compression was not negotiated for the connection (local config + peer advertisement), matching `ProtocolMessage.h:369-375`.

**Structure & hygiene**
- Moved `CompressLZ4`/`DecompressLZ4`/`ShouldCompress`/`MinCompressibleSize` into the `message` package; the package's compression tests now exercise the production functions instead of byte-for-byte test-local copies. The parent facade keeps thin re-export wrappers.
- Fixed the typed-nil interface return in `peertls.Client`.
- Codec table now uses checked type assertions (a generic `assertMessage[T]` helper) and returns an error instead of panicking on a `Type()`/concrete-type mismatch.
- Removed dead code: `message.PeekHeader`, `shim.SSL.Shutdown` (+ its C `peertls_shutdown`), `shim.LastError`, `resource.Charge.Scale`; dropped the always-true `stripPort` parameter from `normalizeAddr`; corrected the stale `MaxMessageSize` doc.

## Test plan
- [x] `go test ./internal/peermanagement/...` (cgo + OpenSSL) — pass
- [x] `go test ./internal/consensus/adaptor/... ./internal/testing/p2p/...` — pass (consumers of the changed APIs)
- [x] New regression tests verified to fail on the unfixed code: sub-second decay, gossip import expiry/replacement leaks, framing caps + ceiling
- [x] `go build ./...` (cgo) and `CGO_ENABLED=0 go build ./internal/peermanagement/peertls/...` (stub) — pass
- [x] `go vet ./internal/peermanagement/...` and `golangci-lint run` (changed pkgs) — clean
- [x] `go test -fuzz FuzzReadMessage` / `FuzzDecompressLZ4` (20s each) — no crashes
- [ ] `just test-docker` (live rippled handshake interop) — not run in this environment; framing changes are strictly more permissive for response types and the compression-reject path only triggers on un-negotiated compressed frames, so interop risk is low

Fixes #901