### PR TITLE
refactor(ledger/state): converge the two SLE-parsing regimes onto WalkFields + single VL/hex helpers

### DIFF
--- a/internal/ledger/state/account_root.go
+++ b/internal/ledger/state/account_root.go
@@ -115,7 +115,6 @@ const (
 	fieldCodeMintedNFTokens       = 43 // UInt32 - number of NFTokens minted
 	fieldCodeBurnedNFTokens       = 44 // UInt32 - number of NFTokens burned
 	fieldCodeFirstNFTokenSequence = 50 // UInt32 - first NFToken sequence (fixNFTokenRemint)
-	fieldCodeBalance              = 1  // Amount
 	fieldCodeRegularKey           = 8  // Account
 	fieldCodeAccount              = 1  // Account (different context)
 	fieldCodeNFTokenMinter        = 9  // Account - authorized NFT minter

--- a/internal/ledger/state/account_root.go
+++ b/internal/ledger/state/account_root.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -163,190 +162,97 @@ func ParseAccountRoot(data []byte) (*AccountRoot, error) {
 	}
 
 	account := &AccountRoot{}
-	ledgerEntryTypeVerified := false // Track if we've verified the LedgerEntryType
+	verified := false
 
-	// Parse the binary format
-	// XRPL uses a TLV-like format with field headers
-	offset := 0
-
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		// Parse field based on type
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return account, nil
-			}
-			value := binary.BigEndian.Uint16(data[offset : offset+2])
-			offset += 2
-			// Only check LedgerEntryType once (first UInt16 with fieldCode 1)
-			if fieldCode == fieldCodeLedgerEntryType && !ledgerEntryTypeVerified {
-				// LedgerEntryType - verify it's AccountRoot
-				if value != ledgerEntryTypeAccountRoot {
-					return nil, errors.New("not an AccountRoot entry")
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt16:
+			if f.FieldCode == fieldCodeLedgerEntryType && !verified {
+				if f.UInt16() != ledgerEntryTypeAccountRoot {
+					return errors.New("not an AccountRoot entry")
 				}
-				ledgerEntryTypeVerified = true
+				verified = true
 			}
 
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return account, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case fieldCodeFlags:
-				account.Flags = value
+				account.Flags = f.UInt32()
 			case fieldCodeSequence:
-				account.Sequence = value
+				account.Sequence = f.UInt32()
 			case 5: // PreviousTxnLgrSeq
-				account.PreviousTxnLgrSeq = value
+				account.PreviousTxnLgrSeq = f.UInt32()
 			case fieldCodeOwnerCount:
-				account.OwnerCount = value
+				account.OwnerCount = f.UInt32()
 			case fieldCodeTransferRate:
-				account.TransferRate = value
+				account.TransferRate = f.UInt32()
 			case fieldCodeMintedNFTokens:
-				account.MintedNFTokens = value
+				account.MintedNFTokens = f.UInt32()
 			case fieldCodeBurnedNFTokens:
-				account.BurnedNFTokens = value
+				account.BurnedNFTokens = f.UInt32()
 			case fieldCodeFirstNFTokenSequence:
-				account.FirstNFTokenSequence = value
+				account.FirstNFTokenSequence = f.UInt32()
 				account.HasFirstNFTSeq = true
 			case fieldCodeTicketCount:
-				account.TicketCount = value
+				account.TicketCount = f.UInt32()
 			}
 
-		case FieldTypeAmount:
-			// XRP amounts are 8 bytes, IOU amounts are 48 bytes
-			if offset+8 > len(data) {
-				return account, nil
-			}
-			// Check if it's XRP (first bit is 0) or IOU (first bit is 1)
-			if data[offset]&0x80 == 0 {
-				// XRP amount - 8 bytes
-				// The format is: top bit = 0 for XRP, next bit = positive, remaining 62 bits = drops
-				rawAmount := binary.BigEndian.Uint64(data[offset : offset+8])
-				// Clear the top bit and extract drops
-				account.Balance = rawAmount & 0x3FFFFFFFFFFFFFFF
-				offset += 8
-			} else {
-				// IOU amount - skip 48 bytes (we don't handle this in AccountRoot)
-				offset += 48
+		case stAmount:
+			// AccountRoot's only Amount is the native XRP Balance (8 bytes); a
+			// foreign IOU/MPT value is ignored.
+			if len(f.Value) == 8 {
+				account.Balance = xrpDrops(f.Value)
 			}
 
-		case FieldTypeAccount:
-			// Account IDs are variable length encoded
-			if offset >= len(data) {
-				return account, nil
-			}
-			length := int(data[offset])
-			offset++
-			if offset+length > len(data) {
-				return account, nil
-			}
-			if length == 20 {
-				var accID [20]byte
-				copy(accID[:], data[offset:offset+length])
-				addr, err := encodeAccountID(accID)
-				if err == nil {
-					if fieldCode == 1 {
+		case stAccountID:
+			if id, ok := f.AccountID(); ok {
+				if addr, err := encodeAccountID(id); err == nil {
+					switch f.FieldCode {
+					case fieldCodeAccount:
 						account.Account = addr
-					} else if fieldCode == fieldCodeRegularKey {
+					case fieldCodeRegularKey:
 						account.RegularKey = addr
-					} else if fieldCode == fieldCodeNFTokenMinter {
+					case fieldCodeNFTokenMinter:
 						account.NFTokenMinter = addr
 					}
 				}
 			}
-			offset += length
 
-		case FieldTypeBlob:
-			// Variable length blob — XRPL VL encoding
-			if offset >= len(data) {
-				return account, nil
+		case stBlob:
+			switch f.FieldCode {
+			case 2: // MessageKey
+				account.MessageKey = hex.EncodeToString(f.VLBytes())
+			case fieldCodeDomain:
+				account.Domain = string(f.VLBytes())
 			}
-			byte1 := int(data[offset])
-			offset++
-			var length int
-			if byte1 <= 192 {
-				// Single-byte encoding: length = byte1
-				length = byte1
-			} else if byte1 <= 240 {
-				// Two-byte encoding: length = 193 + ((byte1 - 193) * 256) + byte2
-				if offset >= len(data) {
-					return account, nil
-				}
-				byte2 := int(data[offset])
-				offset++
-				length = 193 + (byte1-193)*256 + byte2
-			} else {
-				// Three-byte encoding: length = 12481 + ((byte1 - 241) * 65536) + (byte2 * 256) + byte3
-				if offset+2 > len(data) {
-					return account, nil
-				}
-				byte2 := int(data[offset])
-				byte3 := int(data[offset+1])
-				offset += 2
-				length = 12481 + (byte1-241)*65536 + byte2*256 + byte3
-			}
-			if offset+length > len(data) {
-				return account, nil
-			}
-			switch fieldCode {
-			case 2: // MessageKey field
-				account.MessageKey = hex.EncodeToString(data[offset : offset+length])
-			case 7: // Domain field
-				account.Domain = string(data[offset : offset+length])
-			}
-			offset += length
 
-		case FieldTypeHash128:
-			if offset+16 > len(data) {
-				return account, nil
+		case stHash128:
+			if f.FieldCode == fieldCodeEmailHash {
+				account.EmailHash = hex.EncodeToString(f.Value)
 			}
-			if fieldCode == fieldCodeEmailHash {
-				account.EmailHash = hex.EncodeToString(data[offset : offset+16])
-			}
-			offset += 16
 
-		case FieldTypeHash256:
-			// Hash256 fields (e.g., PreviousTxnID, AccountTxnID, WalletLocator, AMMID) are 32 bytes
-			if offset+32 > len(data) {
-				return account, nil
-			}
-			switch fieldCode {
+		case stHash256:
+			switch f.FieldCode {
 			case 5: // PreviousTxnID
-				copy(account.PreviousTxnID[:], data[offset:offset+32])
-			case fieldCodeAccountTxnID: // AccountTxnID
-				copy(account.AccountTxnID[:], data[offset:offset+32])
+				account.PreviousTxnID = f.Hash256()
+			case fieldCodeAccountTxnID:
+				account.AccountTxnID = f.Hash256()
 				account.HasAccountTxnID = true
-			case fieldCodeWalletLocator: // WalletLocator
-				account.WalletLocator = hex.EncodeToString(data[offset : offset+32])
-			case fieldCodeAMMID: // AMMID - links AMM pseudo-account to AMM entry
-				copy(account.AMMID[:], data[offset:offset+32])
-			}
-			offset += 32
-
-		case 16: // UInt8
-			if offset+1 > len(data) {
-				return account, nil
-			}
-			value := data[offset]
-			offset++
-			if fieldCode == fieldCodeTickSize {
-				account.TickSize = value
+			case fieldCodeWalletLocator:
+				account.WalletLocator = hex.EncodeToString(f.Value)
+			case fieldCodeAMMID:
+				account.AMMID = f.Hash256()
 			}
 
-		default:
-			// Unknown type - can't determine size, must stop parsing
-			// This shouldn't happen for valid AccountRoot entries
-			return account, nil
+		case stUInt8:
+			if f.FieldCode == fieldCodeTickSize {
+				account.TickSize = f.UInt8()
+			}
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return account, nil

--- a/internal/ledger/state/address_helpers.go
+++ b/internal/ledger/state/address_helpers.go
@@ -17,8 +17,3 @@ func DecodeAccountID(address string) ([20]byte, error) {
 	copy(result[:], accountID)
 	return result, nil
 }
-
-// decodeAccountID is the unexported version of DecodeAccountID
-func decodeAccountID(address string) ([20]byte, error) {
-	return DecodeAccountID(address)
-}

--- a/internal/ledger/state/check_entry.go
+++ b/internal/ledger/state/check_entry.go
@@ -73,12 +73,10 @@ func ParseCheck(data []byte) (*CheckData, error) {
 		case stAmount:
 			if f.FieldCode == 9 { // SendMax
 				if len(f.Value) == 8 {
-					// XRP amount
 					check.SendMax = xrpDrops(f.Value)
 					check.IsNativeSendMax = true
 					check.SendMaxAmount = NewXRPAmountFromInt(int64(check.SendMax))
 				} else if len(f.Value) == 48 {
-					// IOU amount
 					iouAmount, err := ParseIOUAmountBinary(f.Value)
 					if err != nil {
 						return err

--- a/internal/ledger/state/check_entry.go
+++ b/internal/ledger/state/check_entry.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 
@@ -34,128 +33,75 @@ type CheckData struct {
 // ParseCheck parses a Check ledger entry from binary data
 func ParseCheck(data []byte) (*CheckData, error) {
 	check := &CheckData{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return check, nil
-			}
-			offset += 2
-
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return check, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case 3: // SourceTag
-				check.SourceTag = value
+				check.SourceTag = f.UInt32()
 				check.HasSourceTag = true
 			case 4: // Sequence
-				check.Sequence = value
+				check.Sequence = f.UInt32()
 			case 5: // PreviousTxnLgrSeq
-				check.PreviousTxnLgrSeq = value
+				check.PreviousTxnLgrSeq = f.UInt32()
 			case 10: // Expiration
-				check.Expiration = value
+				check.Expiration = f.UInt32()
 			case 14: // DestinationTag
-				check.DestinationTag = value
+				check.DestinationTag = f.UInt32()
 				check.HasDestTag = true
 			}
 
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return check, nil
-			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			offset += 8
-			switch fieldCode {
+		case stUInt64:
+			switch f.FieldCode {
 			case 4: // OwnerNode
-				check.OwnerNode = value
+				check.OwnerNode = f.UInt64()
 			case 9: // DestinationNode
-				check.DestinationNode = value
+				check.DestinationNode = f.UInt64()
 				check.HasDestNode = true
 			}
 
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return check, nil
-			}
-			switch fieldCode {
+		case stHash256:
+			switch f.FieldCode {
 			case 5: // PreviousTxnID
-				copy(check.PreviousTxnID[:], data[offset:offset+32])
+				check.PreviousTxnID = f.Hash256()
 			case 17: // InvoiceID
-				copy(check.InvoiceID[:], data[offset:offset+32])
+				check.InvoiceID = f.Hash256()
 				check.HasInvoiceID = true
 			}
-			offset += 32
 
-		case FieldTypeAmount:
-			if offset+8 > len(data) {
-				return check, nil
-			}
-			if data[offset]&0x80 == 0 {
-				// XRP amount
-				rawAmount := binary.BigEndian.Uint64(data[offset : offset+8])
-				if fieldCode == 9 { // SendMax
-					check.SendMax = rawAmount & 0x3FFFFFFFFFFFFFFF
+		case stAmount:
+			if f.FieldCode == 9 { // SendMax
+				if len(f.Value) == 8 {
+					// XRP amount
+					check.SendMax = xrpDrops(f.Value)
 					check.IsNativeSendMax = true
 					check.SendMaxAmount = NewXRPAmountFromInt(int64(check.SendMax))
-				}
-				offset += 8
-			} else {
-				// IOU amount - 48 bytes total
-				if offset+48 > len(data) {
-					return check, nil
-				}
-				if fieldCode == 9 { // SendMax
-					iouAmount, err := ParseIOUAmountBinary(data[offset : offset+48])
-					if err == nil {
-						check.SendMaxAmount = iouAmount
-						check.IsNativeSendMax = false
+				} else if len(f.Value) == 48 {
+					// IOU amount
+					iouAmount, err := ParseIOUAmountBinary(f.Value)
+					if err != nil {
+						return err
 					}
+					check.SendMaxAmount = iouAmount
+					check.IsNativeSendMax = false
 				}
-				offset += 48
 			}
 
-		case FieldTypeAccountID:
-			if offset+21 > len(data) {
-				return check, nil
-			}
-			length := data[offset]
-			offset++
-			if length == 20 {
-				switch fieldCode {
+		case stAccountID:
+			if id, ok := f.AccountID(); ok {
+				switch f.FieldCode {
 				case 1: // Account
-					copy(check.Account[:], data[offset:offset+20])
+					check.Account = id
 				case 3: // Destination
-					copy(check.DestinationID[:], data[offset:offset+20])
+					check.DestinationID = id
 				}
-				offset += 20
 			}
-
-		case FieldTypeBlob:
-			if offset >= len(data) {
-				return check, nil
-			}
-			length := int(data[offset])
-			offset++
-			if offset+length > len(data) {
-				return check, nil
-			}
-			offset += length
-
-		default:
-			return check, nil
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return check, nil

--- a/internal/ledger/state/delegate_entry.go
+++ b/internal/ledger/state/delegate_entry.go
@@ -44,7 +44,11 @@ func ParseDelegate(data []byte) (*DelegateData, error) {
 			}
 		case stArray:
 			if f.FieldCode == 29 { // Permissions
-				entry.Permissions = parseDelegatePermissions(f.Value)
+				perms, err := parseDelegatePermissions(f.Value)
+				if err != nil {
+					return err
+				}
+				entry.Permissions = perms
 			}
 		}
 		return nil
@@ -59,13 +63,13 @@ func ParseDelegate(data []byte) (*DelegateData, error) {
 // parseDelegatePermissions decodes the Permissions STArray content; each element
 // is a Permission STObject carrying a UInt32 PermissionValue. Zero values are
 // skipped.
-func parseDelegatePermissions(content []byte) []uint32 {
+func parseDelegatePermissions(content []byte) ([]uint32, error) {
 	var perms []uint32
-	_ = WalkFields(content, func(elem Field) error {
+	err := WalkFields(content, func(elem Field) error {
 		if elem.TypeCode != stObject || elem.FieldCode != 15 { // Permission
 			return nil
 		}
-		_ = WalkFields(elem.Value, func(inner Field) error {
+		return WalkFields(elem.Value, func(inner Field) error {
 			if inner.TypeCode == stUInt32 && inner.FieldCode == 52 { // PermissionValue
 				if v := inner.UInt32(); v > 0 {
 					perms = append(perms, v)
@@ -73,9 +77,8 @@ func parseDelegatePermissions(content []byte) []uint32 {
 			}
 			return nil
 		})
-		return nil
 	})
-	return perms
+	return perms, err
 }
 
 // SerializeDelegate serializes a Delegate ledger entry.

--- a/internal/ledger/state/delegate_entry.go
+++ b/internal/ledger/state/delegate_entry.go
@@ -23,97 +23,59 @@ type DelegateData struct {
 // Extracts Account, Authorize, OwnerNode, and the Permissions array.
 // Reference: rippled DelegateUtils.cpp — sfPermissions array with sfPermissionValue fields
 func ParseDelegate(data []byte) (*DelegateData, error) {
-	hexStr := hex.EncodeToString(data)
-	decoded, err := binarycodec.Decode(hexStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode Delegate: %w", err)
-	}
-
 	entry := &DelegateData{}
 
-	// Parse Account
-	if account, ok := decoded["Account"].(string); ok {
-		accountID, err := DecodeAccountID(account)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode Account: %w", err)
-		}
-		entry.Account = accountID
-	}
-
-	// Parse Authorize
-	if authorize, ok := decoded["Authorize"].(string); ok {
-		authorizeID, err := DecodeAccountID(authorize)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode Authorize: %w", err)
-		}
-		entry.Authorize = authorizeID
-	}
-
-	// Parse OwnerNode
-	if ownerNode, ok := decoded["OwnerNode"].(string); ok {
-		entry.OwnerNode = parseUint64Hex(ownerNode)
-	}
-
-	// Parse Permissions array
-	// The binary codec decodes this as:
-	//   [{"Permission": {"PermissionValue": <string_or_uint32>}}, ...]
-	// PermissionValue.ToJSON() returns a string name if known, or a uint32.
-	if perms, ok := decoded["Permissions"]; ok {
-		if permsArray, ok := perms.([]any); ok {
-			for _, permWrapper := range permsArray {
-				permMap, ok := permWrapper.(map[string]any)
-				if !ok {
-					continue
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt64:
+			if f.FieldCode == 4 { // OwnerNode
+				entry.OwnerNode = f.UInt64()
+			}
+		case stAccountID:
+			switch f.FieldCode {
+			case 1: // Account
+				if id, ok := f.AccountID(); ok {
+					entry.Account = id
 				}
-				// Unwrap the "Permission" wrapper
-				var innerMap map[string]any
-				if inner, ok := permMap["Permission"]; ok {
-					innerMap, _ = inner.(map[string]any)
-				} else {
-					innerMap = permMap
-				}
-				if innerMap == nil {
-					continue
-				}
-				// Extract PermissionValue
-				if pv, ok := innerMap["PermissionValue"]; ok {
-					permValue := parsePermissionValue(pv)
-					if permValue > 0 {
-						entry.Permissions = append(entry.Permissions, permValue)
-					}
+			case 5: // Authorize
+				if id, ok := f.AccountID(); ok {
+					entry.Authorize = id
 				}
 			}
+		case stArray:
+			if f.FieldCode == 29 { // Permissions
+				entry.Permissions = parseDelegatePermissions(f.Value)
+			}
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode Delegate: %w", err)
 	}
 
 	return entry, nil
 }
 
-// parsePermissionValue converts a decoded PermissionValue to uint32.
-// The binary codec may return:
-// - A string name (e.g., "Payment") which needs to be looked up
-// - A uint32/float64/int numeric value
-func parsePermissionValue(v any) uint32 {
-	switch val := v.(type) {
-	case string:
-		// Look up the string name in the delegatable permissions map.
-		// The definitions package maps "Payment" -> 1, etc.
-		pv, err := definitions.Get().GetDelegatablePermissionValueByName(val)
-		if err == nil {
-			return uint32(pv)
+// parseDelegatePermissions decodes the Permissions STArray content; each element
+// is a Permission STObject carrying a UInt32 PermissionValue. Zero values are
+// skipped, matching the prior parser.
+func parseDelegatePermissions(content []byte) []uint32 {
+	var perms []uint32
+	_ = WalkFields(content, func(elem Field) error {
+		if elem.TypeCode != stObject || elem.FieldCode != 15 { // Permission
+			return nil
 		}
-		return 0
-	case float64:
-		return uint32(val)
-	case int:
-		return uint32(val)
-	case uint32:
-		return val
-	case int32:
-		return uint32(val)
-	default:
-		return 0
-	}
+		_ = WalkFields(elem.Value, func(inner Field) error {
+			if inner.TypeCode == stUInt32 && inner.FieldCode == 52 { // PermissionValue
+				if v := inner.UInt32(); v > 0 {
+					perms = append(perms, v)
+				}
+			}
+			return nil
+		})
+		return nil
+	})
+	return perms
 }
 
 // SerializeDelegate serializes a Delegate ledger entry.

--- a/internal/ledger/state/delegate_entry.go
+++ b/internal/ledger/state/delegate_entry.go
@@ -58,7 +58,7 @@ func ParseDelegate(data []byte) (*DelegateData, error) {
 
 // parseDelegatePermissions decodes the Permissions STArray content; each element
 // is a Permission STObject carrying a UInt32 PermissionValue. Zero values are
-// skipped, matching the prior parser.
+// skipped.
 func parseDelegatePermissions(content []byte) []uint32 {
 	var perms []uint32
 	_ = WalkFields(content, func(elem Field) error {

--- a/internal/ledger/state/did_entry.go
+++ b/internal/ledger/state/did_entry.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"strconv"
 
@@ -48,79 +47,33 @@ func SerializeDID(did *DIDData, accountAddress string) ([]byte, error) {
 // ParseDID parses a DID ledger entry from binary data.
 func ParseDID(data []byte) (*DIDData, error) {
 	did := &DIDData{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt64:
+			if f.FieldCode == 4 { // OwnerNode
+				did.OwnerNode = f.UInt64()
+			}
+
+		case stAccountID:
+			if id, ok := f.AccountID(); ok && f.FieldCode == 1 { // Account
+				did.Account = id
+			}
+
+		case stBlob:
+			switch f.FieldCode {
+			case 5: // URI
+				did.URI = hex.EncodeToString(f.VLBytes())
+			case 26: // DIDDocument
+				did.DIDDocument = hex.EncodeToString(f.VLBytes())
+			case 27: // Data
+				did.Data = hex.EncodeToString(f.VLBytes())
+			}
 		}
-
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return did, nil
-			}
-			offset += 2
-
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return did, nil
-			}
-			offset += 4
-
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return did, nil
-			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			if fieldCode == 4 { // OwnerNode (sfOwnerNode is UInt64 field code 4)
-				did.OwnerNode = value
-			}
-			offset += 8
-
-		case FieldTypeAccountID:
-			if offset+21 > len(data) {
-				return did, nil
-			}
-			length := data[offset]
-			offset++
-			if length == 20 {
-				if fieldCode == 1 { // Account
-					copy(did.Account[:], data[offset:offset+20])
-				}
-				offset += 20
-			}
-
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return did, nil
-			}
-			offset += 32
-
-		case FieldTypeBlob:
-			if offset >= len(data) {
-				return did, nil
-			}
-			length := int(data[offset])
-			offset++
-			if offset+length > len(data) {
-				return did, nil
-			}
-			switch fieldCode {
-			case 5: // URI (nth=5 in definitions.json)
-				did.URI = hex.EncodeToString(data[offset : offset+length])
-			case 26: // DIDDocument (nth=26 in definitions.json)
-				did.DIDDocument = hex.EncodeToString(data[offset : offset+length])
-			case 27: // Data (nth=27 in definitions.json)
-				did.Data = hex.EncodeToString(data[offset : offset+length])
-			}
-			offset += length
-
-		default:
-			return did, nil
-		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return did, nil

--- a/internal/ledger/state/directory.go
+++ b/internal/ledger/state/directory.go
@@ -210,101 +210,68 @@ func SerializeDirectoryNode(dir *DirectoryNode, isBookDir bool) ([]byte, error) 
 
 // ParseDirectoryNode parses a DirectoryNode from binary data
 func ParseDirectoryNode(data []byte) (*DirectoryNode, error) {
-	hexStr := hex.EncodeToString(data)
-	jsonObj, err := binarycodec.Decode(hexStr)
-	if err != nil {
-		return nil, err
-	}
 	dir := &DirectoryNode{}
 
-	switch v := jsonObj["Flags"].(type) {
-	case uint32:
-		dir.Flags = v
-	case float64:
-		dir.Flags = uint32(v)
-	case int:
-		dir.Flags = uint32(v)
-	}
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt32:
+			switch f.FieldCode {
+			case 2: // Flags
+				dir.Flags = f.UInt32()
+			case 5: // PreviousTxnLgrSeq
+				dir.PreviousTxnLgrSeq = f.UInt32()
+			}
 
-	if rootIndex, ok := jsonObj["RootIndex"].(string); ok {
-		rootBytes, _ := hex.DecodeString(rootIndex)
-		copy(dir.RootIndex[:], rootBytes)
-	}
+		case stUInt64:
+			switch f.FieldCode {
+			case 1: // IndexNext
+				dir.IndexNext = f.UInt64()
+			case 2: // IndexPrevious
+				dir.IndexPrevious = f.UInt64()
+			case 6: // ExchangeRate
+				dir.ExchangeRate = f.UInt64()
+			}
 
-	// Handle both []string and []any for Indexes (binary codec may return either)
-	if indexes, ok := jsonObj["Indexes"].([]string); ok {
-		dir.Indexes = make([][32]byte, len(indexes))
-		for i, idxStr := range indexes {
-			idxBytes, _ := hex.DecodeString(idxStr)
-			copy(dir.Indexes[i][:], idxBytes)
-		}
-	} else if indexes, ok := jsonObj["Indexes"].([]any); ok {
-		dir.Indexes = make([][32]byte, len(indexes))
-		for i, idx := range indexes {
-			if idxStr, ok := idx.(string); ok {
-				idxBytes, _ := hex.DecodeString(idxStr)
-				copy(dir.Indexes[i][:], idxBytes)
+		case stHash256:
+			switch f.FieldCode {
+			case 8: // RootIndex
+				dir.RootIndex = f.Hash256()
+			case 10: // NFTokenID
+				dir.NFTokenID = f.Hash256()
+			case 34: // DomainID
+				dir.DomainID = f.Hash256()
+			case 5: // PreviousTxnID
+				dir.PreviousTxnID = f.Hash256()
+			}
+
+		case stHash160:
+			switch f.FieldCode {
+			case 1: // TakerPaysCurrency
+				dir.TakerPaysCurrency = f.Hash160()
+			case 2: // TakerPaysIssuer
+				dir.TakerPaysIssuer = f.Hash160()
+			case 3: // TakerGetsCurrency
+				dir.TakerGetsCurrency = f.Hash160()
+			case 4: // TakerGetsIssuer
+				dir.TakerGetsIssuer = f.Hash160()
+			}
+
+		case stAccountID:
+			if f.FieldCode == 2 { // Owner
+				if id, ok := f.AccountID(); ok {
+					dir.Owner = id
+				}
+			}
+
+		case stVector256:
+			if f.FieldCode == 1 { // Indexes
+				dir.Indexes = f.Vector256()
 			}
 		}
-	}
-
-	if indexNext, ok := jsonObj["IndexNext"].(string); ok {
-		dir.IndexNext = parseUint64Hex(indexNext)
-	}
-
-	if indexPrev, ok := jsonObj["IndexPrevious"].(string); ok {
-		dir.IndexPrevious = parseUint64Hex(indexPrev)
-	}
-
-	if owner, ok := jsonObj["Owner"].(string); ok {
-		ownerID, _ := decodeAccountID(owner)
-		dir.Owner = ownerID
-	}
-
-	// Parse book directory fields (must preserve these even if not used)
-	if exchangeRate, ok := jsonObj["ExchangeRate"].(string); ok {
-		dir.ExchangeRate = parseUint64Hex(exchangeRate)
-	}
-	if takerPaysCurrency, ok := jsonObj["TakerPaysCurrency"].(string); ok {
-		decoded, _ := hex.DecodeString(takerPaysCurrency)
-		copy(dir.TakerPaysCurrency[:], decoded)
-	}
-	if takerPaysIssuer, ok := jsonObj["TakerPaysIssuer"].(string); ok {
-		decoded, _ := hex.DecodeString(takerPaysIssuer)
-		copy(dir.TakerPaysIssuer[:], decoded)
-	}
-	if takerGetsCurrency, ok := jsonObj["TakerGetsCurrency"].(string); ok {
-		decoded, _ := hex.DecodeString(takerGetsCurrency)
-		copy(dir.TakerGetsCurrency[:], decoded)
-	}
-	if takerGetsIssuer, ok := jsonObj["TakerGetsIssuer"].(string); ok {
-		decoded, _ := hex.DecodeString(takerGetsIssuer)
-		copy(dir.TakerGetsIssuer[:], decoded)
-	}
-
-	// Parse optional Hash256 fields
-	if nfTokenID, ok := jsonObj["NFTokenID"].(string); ok {
-		decoded, _ := hex.DecodeString(nfTokenID)
-		copy(dir.NFTokenID[:], decoded)
-	}
-	if domainID, ok := jsonObj["DomainID"].(string); ok {
-		decoded, _ := hex.DecodeString(domainID)
-		copy(dir.DomainID[:], decoded)
-	}
-
-	// Threading fields — must be preserved so an in-place modify round-trips
-	// byte-identically (see SerializeDirectoryNode).
-	if prevTxnID, ok := jsonObj["PreviousTxnID"].(string); ok {
-		decoded, _ := hex.DecodeString(prevTxnID)
-		copy(dir.PreviousTxnID[:], decoded)
-	}
-	switch v := jsonObj["PreviousTxnLgrSeq"].(type) {
-	case float64:
-		dir.PreviousTxnLgrSeq = uint32(v)
-	case int:
-		dir.PreviousTxnLgrSeq = uint32(v)
-	case uint32:
-		dir.PreviousTxnLgrSeq = v
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return dir, nil
@@ -315,16 +282,6 @@ func uint64ToBytes(v uint64) []byte {
 	b := make([]byte, 8)
 	binary.BigEndian.PutUint64(b, v)
 	return b
-}
-
-// parseUint64Hex parses a hex string as uint64
-func parseUint64Hex(s string) uint64 {
-	// Pad to 16 chars
-	for len(s) < 16 {
-		s = "0" + s
-	}
-	b, _ := hex.DecodeString(s)
-	return binary.BigEndian.Uint64(b)
 }
 
 // DirInsertResult contains the result of a directory insert operation

--- a/internal/ledger/state/escrow_entry.go
+++ b/internal/ledger/state/escrow_entry.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 )
 
@@ -34,154 +33,83 @@ type EscrowData struct {
 // ParseEscrow parses an Escrow ledger entry from binary data
 func ParseEscrow(data []byte) (*EscrowData, error) {
 	escrow := &EscrowData{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return escrow, nil
-			}
-			offset += 2
-
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return escrow, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case 2: // Flags
-				escrow.Flags = value
+				escrow.Flags = f.UInt32()
 			case 3: // SourceTag
-				escrow.SourceTag = value
+				escrow.SourceTag = f.UInt32()
 				escrow.HasSourceTag = true
 			case 11: // TransferRate
-				escrow.TransferRate = value
+				escrow.TransferRate = f.UInt32()
 				escrow.HasTransferRate = true
 			case 14: // DestinationTag
-				escrow.DestinationTag = value
+				escrow.DestinationTag = f.UInt32()
 				escrow.HasDestTag = true
-			case 36: // CancelAfter (nth=36 per definitions.json)
-				escrow.CancelAfter = value
-			case 37: // FinishAfter (nth=37 per definitions.json)
-				escrow.FinishAfter = value
+			case 36: // CancelAfter
+				escrow.CancelAfter = f.UInt32()
+			case 37: // FinishAfter
+				escrow.FinishAfter = f.UInt32()
 			}
 
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return escrow, nil
-			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			offset += 8
-			switch fieldCode {
-			case 4: // OwnerNode (nth=4 per definitions.json)
-				escrow.OwnerNode = value
-			case 9: // DestinationNode (nth=9 per definitions.json)
-				escrow.DestinationNode = value
+		case stUInt64:
+			switch f.FieldCode {
+			case 4: // OwnerNode
+				escrow.OwnerNode = f.UInt64()
+			case 9: // DestinationNode
+				escrow.DestinationNode = f.UInt64()
 				escrow.HasDestNode = true
 			case 27: // IssuerNode
-				escrow.IssuerNode = value
+				escrow.IssuerNode = f.UInt64()
 				escrow.HasIssuerNode = true
 			}
 
-		case FieldTypeAmount:
-			if offset >= len(data) {
-				return escrow, nil
+		case stAmount:
+			if f.FieldCode != 1 { // sfAmount only
+				return nil
 			}
-			firstByte := data[offset]
-			// Detection order (matches binary codec):
-			// 1. bit 0x80 set -> IOU (48 bytes)
-			// 2. bit 0x20 set -> MPT (33 bytes)
-			// 3. otherwise   -> XRP (8 bytes)
-			if (firstByte & 0x80) != 0 {
-				// IOU amount: 48 bytes (8 value + 20 currency + 20 issuer)
-				if offset+48 > len(data) {
-					return escrow, nil
+			// XRP (8), MPT (33), IOU (48) are distinguished by WalkFields' own
+			// width discrimination, so len(Value) is the reliable selector.
+			switch len(f.Value) {
+			case 48: // IOU
+				if amt, err := ParseIOUAmountBinary(f.Value); err == nil {
+					escrow.IOUAmount = &amt
 				}
-				if fieldCode == 1 { // sfAmount
-					amt, err := ParseIOUAmountBinary(data[offset : offset+48])
-					if err == nil {
-						escrow.IOUAmount = &amt
-						// IsXRP stays false (default)
+			case 33: // MPT
+				if mptAmt, err := ParseMPTAmountBinary(f.Value); err == nil {
+					escrow.IOUAmount = &mptAmt
+					if raw, ok := mptAmt.MPTRaw(); ok {
+						escrow.MPTAmount = &raw
 					}
+					escrow.MPTIssuanceID = mptAmt.MPTIssuanceID()
 				}
-				offset += 48
-			} else if (firstByte & 0x20) != 0 {
-				// MPT amount: 33 bytes (1 header + 8 value + 24 issuance ID)
-				if offset+33 > len(data) {
-					return escrow, nil
-				}
-				if fieldCode == 1 { // sfAmount
-					mptAmt, err := ParseMPTAmountBinary(data[offset : offset+33])
-					if err == nil {
-						escrow.IOUAmount = &mptAmt
-						if raw, ok := mptAmt.MPTRaw(); ok {
-							escrow.MPTAmount = &raw
-						}
-						escrow.MPTIssuanceID = mptAmt.MPTIssuanceID()
-						// IsXRP stays false (default)
-					}
-				}
-				offset += 33
-			} else {
-				// XRP amount: 8 bytes
-				if offset+8 > len(data) {
-					return escrow, nil
-				}
-				rawAmount := binary.BigEndian.Uint64(data[offset : offset+8])
-				if fieldCode == 1 { // sfAmount
-					escrow.Amount = rawAmount & 0x3FFFFFFFFFFFFFFF
-					escrow.IsXRP = true
-				}
-				offset += 8
+			case 8: // XRP
+				escrow.Amount = xrpDrops(f.Value)
+				escrow.IsXRP = true
 			}
 
-		case FieldTypeAccountID:
-			if offset+21 > len(data) {
-				return escrow, nil
-			}
-			length := data[offset]
-			offset++
-			if length == 20 {
-				switch fieldCode {
+		case stAccountID:
+			if id, ok := f.AccountID(); ok {
+				switch f.FieldCode {
 				case 1: // Account
-					copy(escrow.Account[:], data[offset:offset+20])
+					escrow.Account = id
 				case 3: // Destination
-					copy(escrow.DestinationID[:], data[offset:offset+20])
+					escrow.DestinationID = id
 				}
-				offset += 20
 			}
 
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return escrow, nil
+		case stBlob:
+			if f.FieldCode == 17 { // Condition
+				escrow.Condition = hex.EncodeToString(f.VLBytes())
 			}
-			offset += 32
-
-		case FieldTypeBlob:
-			if offset >= len(data) {
-				return escrow, nil
-			}
-			length := int(data[offset])
-			offset++
-			if offset+length > len(data) {
-				return escrow, nil
-			}
-			if fieldCode == 17 { // Condition (nth=17 per definitions.json)
-				escrow.Condition = hex.EncodeToString(data[offset : offset+length])
-			}
-			offset += length
-
-		default:
-			return escrow, nil
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return escrow, nil

--- a/internal/ledger/state/fee_settings.go
+++ b/internal/ledger/state/fee_settings.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -64,97 +63,60 @@ func ParseFeeSettings(data []byte) (*FeeSettings, error) {
 	}
 
 	fee := &FeeSettings{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		// Parse field based on type
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return fee, nil
-			}
-			value := binary.BigEndian.Uint16(data[offset : offset+2])
-			offset += 2
-			if fieldCode == fieldCodeLedgerEntryType {
-				if value != ledgerEntryTypeFeeSettings {
-					return nil, errors.New("not a FeeSettings entry")
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt16:
+			if f.FieldCode == fieldCodeLedgerEntryType {
+				if f.UInt16() != ledgerEntryTypeFeeSettings {
+					return errors.New("not a FeeSettings entry")
 				}
 			}
 
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return fee, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case 5: // PreviousTxnLgrSeq
-				fee.PreviousTxnLgrSeq = value
-			case fieldCodeReferenceFeeUnits:
-				fee.ReferenceFeeUnits = value
-			case fieldCodeReserveBase:
-				fee.ReserveBase = value
-			case fieldCodeReserveIncrement:
-				fee.ReserveIncrement = value
+				fee.PreviousTxnLgrSeq = f.UInt32()
+			case int(fieldCodeReferenceFeeUnits):
+				fee.ReferenceFeeUnits = f.UInt32()
+			case int(fieldCodeReserveBase):
+				fee.ReserveBase = f.UInt32()
+			case int(fieldCodeReserveIncrement):
+				fee.ReserveIncrement = f.UInt32()
 			}
 
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return fee, nil
-			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			offset += 8
-			if fieldCode == fieldCodeBaseFee {
-				fee.BaseFee = value
+		case stUInt64:
+			if f.FieldCode == int(fieldCodeBaseFee) {
+				fee.BaseFee = f.UInt64()
 			}
 
-		case FieldTypeAmount:
-			// XRP amounts are 8 bytes
-			if offset+8 > len(data) {
-				return fee, nil
-			}
-			// Check if it's XRP (first bit is 0)
-			if data[offset]&0x80 == 0 {
-				// XRP amount - 8 bytes
-				rawAmount := binary.BigEndian.Uint64(data[offset : offset+8])
-				// Clear the top bit and extract drops
-				drops := rawAmount & 0x3FFFFFFFFFFFFFFF
-				switch fieldCode {
-				case fieldCodeBaseFeeDrops:
+		case stAmount:
+			// FeeSettings' fee amounts are native XRP (8 bytes); an IOU value
+			// (48 bytes) is foreign here and is skipped.
+			if len(f.Value) == 8 {
+				drops := xrpDrops(f.Value)
+				switch f.FieldCode {
+				case int(fieldCodeBaseFeeDrops):
 					fee.BaseFeeDrops = drops
 					fee.XRPFeesMode = true
-				case fieldCodeReserveBaseDrops:
+				case int(fieldCodeReserveBaseDrops):
 					fee.ReserveBaseDrops = drops
 					fee.XRPFeesMode = true
-				case fieldCodeReserveIncrementDrops:
+				case int(fieldCodeReserveIncrementDrops):
 					fee.ReserveIncrementDrops = drops
 					fee.XRPFeesMode = true
 				}
-				offset += 8
-			} else {
-				// IOU amount - skip 48 bytes (shouldn't appear in FeeSettings)
-				offset += 48
 			}
 
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return fee, nil
+		case stHash256:
+			if f.FieldCode == 5 { // PreviousTxnID
+				fee.PreviousTxnID = f.Hash256()
 			}
-			if fieldCode == 5 { // PreviousTxnID
-				copy(fee.PreviousTxnID[:], data[offset:offset+32])
-			}
-			offset += 32
-
-		default:
-			// Unknown type - stop parsing
-			return fee, nil
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return fee, nil

--- a/internal/ledger/state/field_value.go
+++ b/internal/ledger/state/field_value.go
@@ -8,7 +8,6 @@ import "encoding/binary"
 // hand. The variable-length accessors strip the XRPL length prefix that Value
 // retains for Blob/AccountID/Vector256 fields.
 
-// UInt8 returns a UInt8 field value.
 func (f Field) UInt8() uint8 {
 	if len(f.Value) < 1 {
 		return 0
@@ -16,7 +15,6 @@ func (f Field) UInt8() uint8 {
 	return f.Value[0]
 }
 
-// UInt16 returns a UInt16 field value.
 func (f Field) UInt16() uint16 {
 	if len(f.Value) < 2 {
 		return 0
@@ -24,7 +22,6 @@ func (f Field) UInt16() uint16 {
 	return binary.BigEndian.Uint16(f.Value)
 }
 
-// UInt32 returns a UInt32 field value.
 func (f Field) UInt32() uint32 {
 	if len(f.Value) < 4 {
 		return 0
@@ -32,7 +29,6 @@ func (f Field) UInt32() uint32 {
 	return binary.BigEndian.Uint32(f.Value)
 }
 
-// UInt64 returns a UInt64 field value.
 func (f Field) UInt64() uint64 {
 	if len(f.Value) < 8 {
 		return 0

--- a/internal/ledger/state/field_value.go
+++ b/internal/ledger/state/field_value.go
@@ -1,0 +1,111 @@
+package state
+
+import "encoding/binary"
+
+// Typed accessors for a Field decoded by WalkFields. WalkFields has already
+// delimited Value by the field's serialized type, so each accessor reads a
+// correctly-sized slice; the length guards defend only against a Field built by
+// hand. The variable-length accessors strip the XRPL length prefix that Value
+// retains for Blob/AccountID/Vector256 fields.
+
+// UInt8 returns a UInt8 field value.
+func (f Field) UInt8() uint8 {
+	if len(f.Value) < 1 {
+		return 0
+	}
+	return f.Value[0]
+}
+
+// UInt16 returns a UInt16 field value.
+func (f Field) UInt16() uint16 {
+	if len(f.Value) < 2 {
+		return 0
+	}
+	return binary.BigEndian.Uint16(f.Value)
+}
+
+// UInt32 returns a UInt32 field value.
+func (f Field) UInt32() uint32 {
+	if len(f.Value) < 4 {
+		return 0
+	}
+	return binary.BigEndian.Uint32(f.Value)
+}
+
+// UInt64 returns a UInt64 field value.
+func (f Field) UInt64() uint64 {
+	if len(f.Value) < 8 {
+		return 0
+	}
+	return binary.BigEndian.Uint64(f.Value)
+}
+
+// Hash128 returns a 16-byte Hash128 field value.
+func (f Field) Hash128() [16]byte {
+	var h [16]byte
+	copy(h[:], f.Value)
+	return h
+}
+
+// Hash160 returns a 20-byte Hash160 field value.
+func (f Field) Hash160() [20]byte {
+	var h [20]byte
+	copy(h[:], f.Value)
+	return h
+}
+
+// Hash192 returns a 24-byte Hash192 field value (e.g. MPTokenIssuanceID).
+func (f Field) Hash192() [24]byte {
+	var h [24]byte
+	copy(h[:], f.Value)
+	return h
+}
+
+// Hash256 returns a 32-byte Hash256 field value.
+func (f Field) Hash256() [32]byte {
+	var h [32]byte
+	copy(h[:], f.Value)
+	return h
+}
+
+// VLBytes returns the payload of a variable-length field (Blob, AccountID,
+// Vector256) with its XRPL length prefix removed. It returns nil when the
+// prefix is malformed, which cannot happen for a Field produced by WalkFields.
+func (f Field) VLBytes() []byte {
+	_, prefixLen, err := readVLLength(f.Value, 0)
+	if err != nil || prefixLen > len(f.Value) {
+		return nil
+	}
+	return f.Value[prefixLen:]
+}
+
+// AccountID returns the 20-byte account of an AccountID field. ok is false when
+// the payload is not exactly 20 bytes.
+func (f Field) AccountID() (id [20]byte, ok bool) {
+	p := f.VLBytes()
+	if len(p) != 20 {
+		return id, false
+	}
+	copy(id[:], p)
+	return id, true
+}
+
+// Vector256 splits a Vector256 payload into its constituent 32-byte hashes.
+func (f Field) Vector256() [][32]byte {
+	p := f.VLBytes()
+	n := len(p) / 32
+	out := make([][32]byte, n)
+	for i := range out {
+		copy(out[i][:], p[i*32:])
+	}
+	return out
+}
+
+// xrpDrops decodes the drops carried by an 8-byte native Amount value, masking
+// off the not-XRP (bit 63) and sign (bit 62) flags.
+func xrpDrops(v []byte) uint64 {
+	if len(v) < 8 {
+		return 0
+	}
+	return binary.BigEndian.Uint64(v) & 0x3FFFFFFFFFFFFFFF
+}

--- a/internal/ledger/state/mptoken_entry.go
+++ b/internal/ledger/state/mptoken_entry.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -59,129 +58,70 @@ type MPTokenData struct {
 }
 
 // ParseMPTokenIssuance parses an MPTokenIssuance ledger entry from binary data.
-// Uses the same TLV parsing pattern as ParseEscrow.
 func ParseMPTokenIssuance(data []byte) (*MPTokenIssuanceData, error) {
 	issuance := &MPTokenIssuanceData{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		switch typeCode {
-		case FieldTypeUInt8:
-			if offset+1 > len(data) {
-				return issuance, nil
-			}
-			value := data[offset]
-			offset++
-			switch fieldCode {
-			case 5: // AssetScale (nth=5)
-				issuance.AssetScale = value
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt8:
+			if f.FieldCode == 5 { // AssetScale (nth=5)
+				issuance.AssetScale = f.UInt8()
 			}
 
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return issuance, nil
-			}
-			value := binary.BigEndian.Uint16(data[offset : offset+2])
-			offset += 2
-			switch fieldCode {
-			case 1: // LedgerEntryType - skip
-			case 4: // TransferFee (nth=4)
-				issuance.TransferFee = value
+		case stUInt16:
+			if f.FieldCode == 4 { // TransferFee (nth=4)
+				issuance.TransferFee = f.UInt16()
 			}
 
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return issuance, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case 2: // Flags
-				issuance.Flags = value
+				issuance.Flags = f.UInt32()
 			case 4: // Sequence
-				issuance.Sequence = value
+				issuance.Sequence = f.UInt32()
 			case 5: // PreviousTxnLgrSeq
-				issuance.PreviousTxnLgrSeq = value
+				issuance.PreviousTxnLgrSeq = f.UInt32()
 			}
 
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return issuance, nil
-			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			offset += 8
-			switch fieldCode {
+		case stUInt64:
+			switch f.FieldCode {
 			case 4: // OwnerNode (nth=4)
-				issuance.OwnerNode = value
+				issuance.OwnerNode = f.UInt64()
 			case 24: // MaximumAmount (nth=24)
-				v := value
+				v := f.UInt64()
 				issuance.MaximumAmount = &v
 			case 25: // OutstandingAmount (nth=25)
-				issuance.OutstandingAmount = value
+				issuance.OutstandingAmount = f.UInt64()
 			case 29: // LockedAmount (nth=29)
-				v := value
+				v := f.UInt64()
 				issuance.LockedAmount = &v
 			}
 
-		case FieldTypeAccountID:
-			if offset+21 > len(data) {
-				return issuance, nil
-			}
-			length := data[offset]
-			offset++
-			if length == 20 {
-				switch fieldCode {
-				case 4: // Issuer (nth=4)
-					copy(issuance.Issuer[:], data[offset:offset+20])
+		case stAccountID:
+			if f.FieldCode == 4 { // Issuer (nth=4)
+				if id, ok := f.AccountID(); ok {
+					issuance.Issuer = id
 				}
-				offset += 20
 			}
 
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return issuance, nil
-			}
-			switch fieldCode {
+		case stHash256:
+			switch f.FieldCode {
 			case 5: // PreviousTxnID
-				copy(issuance.PreviousTxnID[:], data[offset:offset+32])
+				issuance.PreviousTxnID = f.Hash256()
 			case 34: // DomainID (nth=34)
-				domainHex := hex.EncodeToString(data[offset : offset+32])
+				domainHex := hex.EncodeToString(f.Value)
 				issuance.DomainID = &domainHex
 			}
-			offset += 32
 
-		case FieldTypeBlob:
-			if offset >= len(data) {
-				return issuance, nil
+		case stBlob:
+			if f.FieldCode == 30 { // MPTokenMetadata (nth=30)
+				issuance.MPTokenMetadata = hex.EncodeToString(f.VLBytes())
 			}
-			length := int(data[offset])
-			offset++
-			if length >= 193 {
-				// VL encoding: 2-byte length for values >= 193
-				if offset >= len(data) {
-					return issuance, nil
-				}
-				length = 193 + ((length-193)*256 + int(data[offset]))
-				offset++
-			}
-			if offset+length > len(data) {
-				return issuance, nil
-			}
-			switch fieldCode {
-			case 30: // MPTokenMetadata (nth=30)
-				issuance.MPTokenMetadata = hex.EncodeToString(data[offset : offset+length])
-			}
-			offset += length
-
-		default:
-			return issuance, nil
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return issuance, nil
@@ -244,106 +184,49 @@ func SerializeMPTokenIssuance(issuance *MPTokenIssuanceData) ([]byte, error) {
 // ParseMPToken parses an MPToken ledger entry from binary data.
 func ParseMPToken(data []byte) (*MPTokenData, error) {
 	token := &MPTokenData{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return token, nil
-			}
-			offset += 2
-
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return token, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case 2: // Flags
-				token.Flags = value
+				token.Flags = f.UInt32()
 			case 5: // PreviousTxnLgrSeq
-				token.PreviousTxnLgrSeq = value
+				token.PreviousTxnLgrSeq = f.UInt32()
 			}
 
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return token, nil
-			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			offset += 8
-			switch fieldCode {
+		case stUInt64:
+			switch f.FieldCode {
 			case 4: // OwnerNode (nth=4)
-				token.OwnerNode = value
+				token.OwnerNode = f.UInt64()
 			case 26: // MPTAmount (nth=26)
-				token.MPTAmount = value
+				token.MPTAmount = f.UInt64()
 			case 29: // LockedAmount (nth=29)
-				v := value
+				v := f.UInt64()
 				token.LockedAmount = &v
 			}
 
-		case FieldTypeAccountID:
-			if offset+21 > len(data) {
-				return token, nil
-			}
-			length := data[offset]
-			offset++
-			if length == 20 {
-				switch fieldCode {
-				case 1: // Account (nth=1)
-					copy(token.Account[:], data[offset:offset+20])
+		case stAccountID:
+			if f.FieldCode == 1 { // Account (nth=1)
+				if id, ok := f.AccountID(); ok {
+					token.Account = id
 				}
-				offset += 20
 			}
 
-		case FieldTypeHash192:
-			if offset+24 > len(data) {
-				return token, nil
+		case stHash192:
+			if f.FieldCode == 1 { // MPTokenIssuanceID (nth=1)
+				token.MPTokenIssuanceID = f.Hash192()
 			}
-			switch fieldCode {
-			case 1: // MPTokenIssuanceID (nth=1)
-				copy(token.MPTokenIssuanceID[:], data[offset:offset+24])
-			}
-			offset += 24
 
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return token, nil
+		case stHash256:
+			if f.FieldCode == 5 { // PreviousTxnID
+				token.PreviousTxnID = f.Hash256()
 			}
-			switch fieldCode {
-			case 5: // PreviousTxnID
-				copy(token.PreviousTxnID[:], data[offset:offset+32])
-			}
-			offset += 32
-
-		case FieldTypeBlob:
-			if offset >= len(data) {
-				return token, nil
-			}
-			length := int(data[offset])
-			offset++
-			if length >= 193 {
-				if offset >= len(data) {
-					return token, nil
-				}
-				length = 193 + ((length-193)*256 + int(data[offset]))
-				offset++
-			}
-			if offset+length > len(data) {
-				return token, nil
-			}
-			offset += length
-
-		default:
-			return token, nil
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return token, nil

--- a/internal/ledger/state/nftoken_page.go
+++ b/internal/ledger/state/nftoken_page.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 )
 
@@ -49,100 +48,46 @@ func ParseNFTokenPage(data []byte) (*NFTokenPageData, error) {
 	page := &NFTokenPageData{
 		NFTokens: make([]NFTokenData, 0),
 	}
-	offset := 0
 
-	var currentToken NFTokenData
-	hasToken := false
-
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return page, nil
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stHash256:
+			switch f.FieldCode {
+			case 26: // PreviousPageMin
+				page.PreviousPageMin = f.Hash256()
+			case 27: // NextPageMin
+				page.NextPageMin = f.Hash256()
 			}
-			offset += 2
 
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return page, nil
-			}
-			offset += 4
-
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return page, nil
-			}
-			switch fieldCode {
-			case 26: // PreviousPageMin (nth=26 per definitions.json)
-				copy(page.PreviousPageMin[:], data[offset:offset+32])
-			case 27: // NextPageMin (nth=27 per definitions.json)
-				copy(page.NextPageMin[:], data[offset:offset+32])
-			case 10: // NFTokenID
-				if hasToken {
-					page.NFTokens = append(page.NFTokens, currentToken)
+		case stArray:
+			// NFTokens: each element is an NFToken object carrying an NFTokenID
+			// and (optionally) a URI.
+			_ = WalkFields(f.Value, func(elem Field) error {
+				if elem.TypeCode != stObject {
+					return nil
 				}
-				copy(currentToken.NFTokenID[:], data[offset:offset+32])
-				currentToken.URI = ""
-				hasToken = true
-			}
-			offset += 32
-
-		case FieldTypeUInt64: // 3
-			if offset+8 > len(data) {
-				return page, nil
-			}
-			offset += 8
-
-		case FieldTypeBlob:
-			if offset >= len(data) {
-				return page, nil
-			}
-			length := int(data[offset])
-			offset++
-			if length > 192 {
-				if offset >= len(data) {
-					return page, nil
-				}
-				length = 193 + ((length-193)<<8 | int(data[offset]))
-				offset++
-			}
-			if offset+length > len(data) {
-				return page, nil
-			}
-			if fieldCode == 5 { // URI
-				currentToken.URI = hex.EncodeToString(data[offset : offset+length])
-			}
-			offset += length
-
-		case 8: // AccountID — 20 bytes
-			if offset+20 > len(data) {
-				return page, nil
-			}
-			offset += 20
-
-		case 14, 15:
-			// STObject (14) and STArray (15) structural markers.
-			// These include array/object start field headers (e.g., 0xFA for NFTokens)
-			// and end-of-object (0xE1) / end-of-array (0xF1) markers.
-			// They have no payload — just continue parsing inner fields.
-			continue
-
-		default:
-			if hasToken {
-				page.NFTokens = append(page.NFTokens, currentToken)
-			}
-			return page, nil
+				var tok NFTokenData
+				_ = WalkFields(elem.Value, func(inner Field) error {
+					switch inner.TypeCode {
+					case stHash256:
+						if inner.FieldCode == 10 { // NFTokenID
+							tok.NFTokenID = inner.Hash256()
+						}
+					case stBlob:
+						if inner.FieldCode == 5 { // URI
+							tok.URI = hex.EncodeToString(inner.VLBytes())
+						}
+					}
+					return nil
+				})
+				page.NFTokens = append(page.NFTokens, tok)
+				return nil
+			})
 		}
-	}
-
-	if hasToken {
-		page.NFTokens = append(page.NFTokens, currentToken)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return page, nil
@@ -156,136 +101,69 @@ func ParseNFTokenPageFromBytes(data []byte) (*NFTokenPageData, error) {
 // ParseNFTokenOffer parses an NFToken offer from binary data
 func ParseNFTokenOffer(data []byte) (*NFTokenOfferData, error) {
 	offer := &NFTokenOfferData{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return offer, nil
-			}
-			offset += 2
-
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return offer, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case 2: // Flags
-				offer.Flags = value
+				offer.Flags = f.UInt32()
 			case 10: // Expiration
-				offer.Expiration = value
+				offer.Expiration = f.UInt32()
 			}
 
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return offer, nil
+		case stUInt64:
+			switch f.FieldCode {
+			case 4: // OwnerNode
+				offer.OwnerNode = f.UInt64()
+			case 12: // NFTokenOfferNode
+				offer.NFTokenOfferNode = f.UInt64()
 			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			switch fieldCode {
-			case 4: // OwnerNode (UInt64 nth=4)
-				offer.OwnerNode = value
-			case 12: // NFTokenOfferNode (UInt64 nth=12)
-				offer.NFTokenOfferNode = value
-			}
-			offset += 8
 
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return offer, nil
+		case stHash256:
+			if f.FieldCode == 10 { // NFTokenID
+				offer.NFTokenID = f.Hash256()
 			}
-			if fieldCode == 10 { // NFTokenID
-				copy(offer.NFTokenID[:], data[offset:offset+32])
-			}
-			offset += 32
 
-		case FieldTypeAmount:
-			if offset+8 > len(data) {
-				return offer, nil
-			}
-			if data[offset]&0x80 == 0 {
-				rawAmount := binary.BigEndian.Uint64(data[offset : offset+8])
-				value := rawAmount & 0x3FFFFFFFFFFFFFFF
+		case stAmount:
+			// The sign lives in bit 62 of the first value word (1 = positive); a
+			// clear sign with a non-zero magnitude is negative.
+			raw := f.UInt64()
+			switch len(f.Value) {
+			case 8: // XRP
+				value := raw & 0x3FFFFFFFFFFFFFFF
 				offer.Amount = value
-				// XRP: bit 62 is the sign (1 = positive); a clear sign with a
-				// non-zero value is negative.
-				offer.Negative = (rawAmount&0x4000000000000000) == 0 && value != 0
-				offset += 8
-			} else {
-				// IOU amount: 8 bytes value + 20 bytes currency + 20 bytes issuer = 48 bytes
-				if offset+48 > len(data) {
-					return offer, nil
-				}
-				// IOU: bit 62 is the sign (1 = positive); a clear sign with a
-				// non-zero mantissa is negative. A zero amount is never negative.
-				rawIOU := binary.BigEndian.Uint64(data[offset : offset+8])
-				offer.Negative = rawIOU&0x4000000000000000 == 0 && rawIOU&0x3FFFFFFFFFFFFFFF != 0
-				iouAmount, err := ParseIOUAmountBinary(data[offset : offset+48])
-				if err == nil {
+				offer.Negative = (raw&0x4000000000000000) == 0 && value != 0
+			case 48: // IOU
+				offer.Negative = raw&0x4000000000000000 == 0 && raw&0x3FFFFFFFFFFFFFFF != 0
+				if iouAmount, err := ParseIOUAmountBinary(f.Value); err == nil {
 					var issuerID [20]byte
-					copy(issuerID[:], data[offset+28:offset+48])
+					copy(issuerID[:], f.Value[28:48])
 					offer.AmountIOU = &NFTIOUAmount{
 						Currency: iouAmount.Currency,
 						Issuer:   issuerID,
 						Value:    iouAmount.IOU().String(),
 					}
 				}
-				offset += 48
 			}
 
-		case FieldTypeAccountID:
-			if offset+21 > len(data) {
-				return offer, nil
-			}
-			length := data[offset]
-			offset++
-			if length == 20 {
-				switch fieldCode {
-				case 1: // sfAccount — pre-fix go-xrpl serialized the owner here;
-					// accepted so state written before the sfOwner fix still parses.
-					copy(offer.Owner[:], data[offset:offset+20])
-				case 2: // Owner (sfOwner — rippled's NFTokenOffer owner field)
-					copy(offer.Owner[:], data[offset:offset+20])
+		case stAccountID:
+			if id, ok := f.AccountID(); ok {
+				switch f.FieldCode {
+				case 1: // legacy sfAccount → Owner (pre-sfOwner-fix state)
+					offer.Owner = id
+				case 2: // sfOwner
+					offer.Owner = id
 				case 3: // Destination
-					copy(offer.Destination[:], data[offset:offset+20])
+					offer.Destination = id
 					offer.HasDestination = true
 				}
-				offset += 20
 			}
-
-		case FieldTypeBlob: // 7
-			if offset >= len(data) {
-				return offer, nil
-			}
-			length := int(data[offset])
-			offset++
-			if length > 192 {
-				if offset >= len(data) {
-					return offer, nil
-				}
-				length = 193 + ((length-193)<<8 | int(data[offset]))
-				offset++
-			}
-			if offset+length > len(data) {
-				return offer, nil
-			}
-			offset += length
-
-		case 14, 15:
-			// STObject/STArray structural markers — skip
-			continue
-
-		default:
-			return offer, nil
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return offer, nil

--- a/internal/ledger/state/nftoken_page.go
+++ b/internal/ledger/state/nftoken_page.go
@@ -62,12 +62,12 @@ func ParseNFTokenPage(data []byte) (*NFTokenPageData, error) {
 		case stArray:
 			// NFTokens: each element is an NFToken object carrying an NFTokenID
 			// and (optionally) a URI.
-			_ = WalkFields(f.Value, func(elem Field) error {
+			return WalkFields(f.Value, func(elem Field) error {
 				if elem.TypeCode != stObject {
 					return nil
 				}
 				var tok NFTokenData
-				_ = WalkFields(elem.Value, func(inner Field) error {
+				if err := WalkFields(elem.Value, func(inner Field) error {
 					switch inner.TypeCode {
 					case stHash256:
 						if inner.FieldCode == 10 { // NFTokenID
@@ -79,7 +79,9 @@ func ParseNFTokenPage(data []byte) (*NFTokenPageData, error) {
 						}
 					}
 					return nil
-				})
+				}); err != nil {
+					return err
+				}
 				page.NFTokens = append(page.NFTokens, tok)
 				return nil
 			})

--- a/internal/ledger/state/offer_entry.go
+++ b/internal/ledger/state/offer_entry.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -107,303 +106,104 @@ func parseLedgerOffer(data []byte) (*LedgerOffer, error) {
 	}
 
 	offer := &LedgerOffer{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return offer, nil
-			}
-			offset += 2
-
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return offer, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case fieldCodeFlags:
-				offer.Flags = value
+				offer.Flags = f.UInt32()
 			case 4: // Sequence
-				offer.Sequence = value
-			case 5: // PreviousTxnLgrSeq (nth=5 in sfields.macro)
-				offer.PreviousTxnLgrSeq = value
+				offer.Sequence = f.UInt32()
+			case 5: // PreviousTxnLgrSeq
+				offer.PreviousTxnLgrSeq = f.UInt32()
 			case 10: // Expiration
-				offer.Expiration = value
+				offer.Expiration = f.UInt32()
 			}
 
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return offer, nil
-			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			offset += 8
-			switch fieldCode {
-			case 3: // BookNode (nth=3 in definitions.json)
-				offer.BookNode = value
-			case 4: // OwnerNode (nth=4 in definitions.json)
-				offer.OwnerNode = value
+		case stUInt64:
+			switch f.FieldCode {
+			case 3: // BookNode
+				offer.BookNode = f.UInt64()
+			case 4: // OwnerNode
+				offer.OwnerNode = f.UInt64()
 			}
 
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return offer, nil
+		case stHash256:
+			switch f.FieldCode {
+			case 16: // BookDirectory
+				offer.BookDirectory = f.Hash256()
+			case 5: // PreviousTxnID
+				offer.PreviousTxnID = f.Hash256()
+			case 34: // DomainID (PermissionedDEX)
+				offer.DomainID = f.Hash256()
 			}
-			switch fieldCode {
-			case 16: // BookDirectory (nth=16 in definitions.json)
-				copy(offer.BookDirectory[:], data[offset:offset+32])
-			case 5: // PreviousTxnID (nth=5 in definitions.json)
-				copy(offer.PreviousTxnID[:], data[offset:offset+32])
-			case 34: // DomainID (nth=34 in definitions.json, PermissionedDEX)
-				copy(offer.DomainID[:], data[offset:offset+32])
-			}
-			offset += 32
 
-		case FieldTypeAmount:
-			// Determine if XRP (8 bytes) or IOU (48 bytes)
-			if offset >= len(data) {
-				return offer, nil
-			}
-			isIOU := (data[offset] & 0x80) != 0
-			if isIOU {
-				if offset+48 > len(data) {
-					return offer, nil
+		case stAmount:
+			var amt Amount
+			switch len(f.Value) {
+			case 48: // IOU
+				a, err := ParseIOUAmountBinary(f.Value)
+				if err != nil {
+					return nil
 				}
-				amt, err := ParseIOUAmountBinary(data[offset : offset+48])
-				if err == nil {
-					switch fieldCode {
-					case 4: // TakerPays
-						offer.TakerPays = amt
-					case 5: // TakerGets
-						offer.TakerGets = amt
-					}
-				}
-				offset += 48
-			} else {
-				if offset+8 > len(data) {
-					return offer, nil
-				}
-				drops := binary.BigEndian.Uint64(data[offset:offset+8]) & 0x3FFFFFFFFFFFFFFF
-				amt := NewXRPAmountFromInt(int64(drops))
-				switch fieldCode {
-				case 4: // TakerPays
-					offer.TakerPays = amt
-				case 5: // TakerGets
-					offer.TakerGets = amt
-				}
-				offset += 8
+				amt = a
+			case 8: // XRP
+				amt = NewXRPAmountFromInt(int64(xrpDrops(f.Value)))
+			default:
+				return nil
+			}
+			switch f.FieldCode {
+			case 4: // TakerPays
+				offer.TakerPays = amt
+			case 5: // TakerGets
+				offer.TakerGets = amt
 			}
 
-		case FieldTypeAccountID:
-			// AccountID is VL-encoded, first byte is length (should be 0x14 = 20)
-			if offset >= len(data) {
-				return offer, nil
-			}
-			length := int(data[offset])
-			offset++
-			if length != 20 || offset+20 > len(data) {
-				return offer, nil
-			}
-			var accountID [20]byte
-			copy(accountID[:], data[offset:offset+20])
-			address, _ := EncodeAccountID(accountID)
-			if fieldCode == 1 { // Account (nth=1 in definitions.json)
-				offer.Account = address
-			}
-			offset += 20
-
-		case FieldTypeArray:
-			if fieldCode == 13 { // AdditionalBooks (nth=13)
-				offset = parseAdditionalBooks(data, offset, offer)
-			} else {
-				offset = skipArray(data, offset)
+		case stAccountID:
+			if id, ok := f.AccountID(); ok && f.FieldCode == 1 {
+				offer.Account, _ = EncodeAccountID(id)
 			}
 
-		default:
-			// Unknown type - cannot determine its width, so stop parsing.
-			return offer, nil
+		case stArray:
+			if f.FieldCode == 13 { // AdditionalBooks
+				parseAdditionalBooks(f.Value, offer)
+			}
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return offer, nil
 }
 
-// parseAdditionalBooks reads the AdditionalBooks STArray starting just after its
-// field header and records the first Book's directory/node onto offer (hybrid
-// offers carry exactly one entry). It returns the offset just past the array's
-// end marker.
-func parseAdditionalBooks(data []byte, offset int, offer *LedgerOffer) int {
+// parseAdditionalBooks records the first Book entry of an AdditionalBooks
+// STArray onto offer; hybrid offers carry exactly one entry. content is the
+// array's inner bytes as delimited by WalkFields.
+func parseAdditionalBooks(content []byte, offer *LedgerOffer) {
 	first := true
-	for offset < len(data) {
-		if data[offset] == arrayEndMarker {
-			return offset + 1
+	_ = WalkFields(content, func(elem Field) error {
+		if elem.TypeCode != stObject || elem.FieldCode != 36 || !first { // Book
+			return nil
 		}
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			return offset
-		}
-		// Each entry is a Book inner object (type 14); decode its fields up to
-		// the object end marker, keeping the first entry only.
-		if typeCode == FieldTypeObject && fieldCode == 36 { // Book (nth=36)
-			var dir [32]byte
-			var node uint64
-			offset = parseInnerBook(data, offset, &dir, &node)
-			if first {
-				offer.AdditionalBookDirectory = dir
-				offer.AdditionalBookNode = node
-				first = false
+		first = false
+		_ = WalkFields(elem.Value, func(inner Field) error {
+			switch inner.TypeCode {
+			case stUInt64:
+				if inner.FieldCode == 3 { // BookNode
+					offer.AdditionalBookNode = inner.UInt64()
+				}
+			case stHash256:
+				if inner.FieldCode == 16 { // BookDirectory
+					offer.AdditionalBookDirectory = inner.Hash256()
+				}
 			}
-			continue
-		}
-		return offset
-	}
-	return offset
-}
-
-// parseInnerBook decodes a Book inner object's fields starting just after its
-// field header, until the object end marker. It returns the offset just past
-// that marker.
-func parseInnerBook(data []byte, offset int, dir *[32]byte, node *uint64) int {
-	for offset < len(data) {
-		if data[offset] == objectEndMarker {
-			return offset + 1
-		}
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			return offset
-		}
-		switch typeCode {
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return offset
-			}
-			if fieldCode == 3 { // BookNode (nth=3)
-				*node = binary.BigEndian.Uint64(data[offset : offset+8])
-			}
-			offset += 8
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return offset
-			}
-			if fieldCode == 16 { // BookDirectory (nth=16)
-				copy(dir[:], data[offset:offset+32])
-			}
-			offset += 32
-		default:
-			return offset
-		}
-	}
-	return offset
-}
-
-// skipArray advances past an unrecognized STArray, starting just after the
-// array's field header. It skips structurally — each entry is an inner object
-// whose typed fields are skipped by width and which ends at the object end
-// marker — so a payload byte that happens to equal a terminator cannot be
-// mistaken for the array end. It returns the offset just past the array end
-// marker.
-func skipArray(data []byte, offset int) int {
-	for offset < len(data) {
-		if data[offset] == arrayEndMarker {
-			return offset + 1
-		}
-		// Each array element is an inner object introduced by its field
-		// header; consume that header, then its fields up to the object end.
-		_, _, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			return offset
-		}
-		offset = skipObject(data, offset)
-	}
-	return offset
-}
-
-// skipObject advances past an inner object's fields, starting just after the
-// object's field header, until (and including) the object end marker. Typed
-// field payloads are skipped by their on-wire width so terminator bytes inside
-// a payload are never treated as the object end.
-func skipObject(data []byte, offset int) int {
-	for offset < len(data) {
-		if data[offset] == objectEndMarker {
-			return offset + 1
-		}
-		typeCode, _, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			return offset
-		}
-		offset = skipFieldValue(data, offset, typeCode)
-		if offset < 0 {
-			return len(data)
-		}
-	}
-	return offset
-}
-
-// skipFieldValue returns the offset just past a single field's payload of the
-// given type. Nested objects and arrays recurse structurally. It returns -1 if
-// the data is truncated or the type's width is unknown.
-func skipFieldValue(data []byte, offset int, typeCode byte) int {
-	switch typeCode {
-	case FieldTypeUInt16:
-		return advance(data, offset, 2)
-	case FieldTypeUInt32:
-		return advance(data, offset, 4)
-	case FieldTypeUInt64:
-		return advance(data, offset, 8)
-	case FieldTypeHash128:
-		return advance(data, offset, 16)
-	case FieldTypeHash256:
-		return advance(data, offset, 32)
-	case FieldTypeAmount:
-		if offset >= len(data) {
-			return -1
-		}
-		if data[offset]&0x80 == 0 {
-			return advance(data, offset, 8) // XRP
-		}
-		return advance(data, offset, 48) // IOU
-	case FieldTypeBlob, FieldTypeAccountID:
-		// Variable length: 1-byte (or extended) length prefix then payload.
-		if offset >= len(data) {
-			return -1
-		}
-		length := int(data[offset])
-		extra := 1
-		if length > 192 {
-			if offset+1 >= len(data) {
-				return -1
-			}
-			length = 193 + ((length-193)<<8 | int(data[offset+1]))
-			extra = 2
-		}
-		return advance(data, offset, extra+length)
-	case FieldTypeObject:
-		return skipObject(data, offset)
-	case FieldTypeArray:
-		return skipArray(data, offset)
-	default:
-		return -1
-	}
-}
-
-// advance returns offset+n, or -1 if that would run past the end of data.
-func advance(data []byte, offset, n int) int {
-	if offset+n > len(data) {
-		return -1
-	}
-	return offset + n
+			return nil
+		})
+		return nil
+	})
 }
 
 // ParseLedgerOfferFromBytes parses a LedgerOffer from binary data (exported)

--- a/internal/ledger/state/offer_entry.go
+++ b/internal/ledger/state/offer_entry.go
@@ -167,7 +167,9 @@ func parseLedgerOffer(data []byte) (*LedgerOffer, error) {
 
 		case stArray:
 			if f.FieldCode == 13 { // AdditionalBooks
-				parseAdditionalBooks(f.Value, offer)
+				if err := parseAdditionalBooks(f.Value, offer); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
@@ -182,14 +184,14 @@ func parseLedgerOffer(data []byte) (*LedgerOffer, error) {
 // parseAdditionalBooks records the first Book entry of an AdditionalBooks
 // STArray onto offer; hybrid offers carry exactly one entry. content is the
 // array's inner bytes as delimited by WalkFields.
-func parseAdditionalBooks(content []byte, offer *LedgerOffer) {
+func parseAdditionalBooks(content []byte, offer *LedgerOffer) error {
 	first := true
-	_ = WalkFields(content, func(elem Field) error {
+	return WalkFields(content, func(elem Field) error {
 		if elem.TypeCode != stObject || elem.FieldCode != 36 || !first { // Book
 			return nil
 		}
 		first = false
-		_ = WalkFields(elem.Value, func(inner Field) error {
+		return WalkFields(elem.Value, func(inner Field) error {
 			switch inner.TypeCode {
 			case stUInt64:
 				if inner.FieldCode == 3 { // BookNode
@@ -202,7 +204,6 @@ func parseAdditionalBooks(content []byte, offer *LedgerOffer) {
 			}
 			return nil
 		})
-		return nil
 	})
 }
 

--- a/internal/ledger/state/oracle_entry.go
+++ b/internal/ledger/state/oracle_entry.go
@@ -83,7 +83,11 @@ func ParseOracle(data []byte) (*OracleData, error) {
 
 		case stArray:
 			if f.FieldCode == fieldPriceDataSer { // 24
-				oracle.PriceDataSeries = parseOraclePriceDataSeries(f.Value)
+				series, err := parseOraclePriceDataSeries(f.Value)
+				if err != nil {
+					return err
+				}
+				oracle.PriceDataSeries = series
 			}
 		}
 		return nil
@@ -97,14 +101,14 @@ func ParseOracle(data []byte) (*OracleData, error) {
 
 // parseOraclePriceDataSeries decodes the PriceDataSeries STArray content (as
 // delimited by WalkFields). Each element is a PriceData STObject.
-func parseOraclePriceDataSeries(content []byte) []OraclePriceData {
+func parseOraclePriceDataSeries(content []byte) ([]OraclePriceData, error) {
 	var series []OraclePriceData
-	_ = WalkFields(content, func(elem Field) error {
+	err := WalkFields(content, func(elem Field) error {
 		if elem.TypeCode != stObject {
 			return nil
 		}
 		pd := OraclePriceData{}
-		_ = WalkFields(elem.Value, func(inner Field) error {
+		if err := WalkFields(elem.Value, func(inner Field) error {
 			switch inner.TypeCode {
 			case stUInt64:
 				if inner.FieldCode == fieldAssetPrice { // 23
@@ -126,11 +130,13 @@ func parseOraclePriceDataSeries(content []byte) []OraclePriceData {
 				}
 			}
 			return nil
-		})
+		}); err != nil {
+			return err
+		}
 		series = append(series, pd)
 		return nil
 	})
-	return series
+	return series, err
 }
 
 // parseCurrencyBytes converts 20 binary currency bytes to a string.

--- a/internal/ledger/state/oracle_entry.go
+++ b/internal/ledger/state/oracle_entry.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 
@@ -32,16 +31,8 @@ type OraclePriceData struct {
 	HasScale   bool
 }
 
-// Field codes for Oracle-specific fields
+// Field nth values for Oracle fields
 const (
-	// STObject type code
-	fieldTypeSTObject = 14
-	// STArray type code
-	fieldTypeSTArray = 15
-	// Currency type code
-	fieldTypeCurrency = 26
-
-	// Field nth values for Oracle fields
 	fieldLastUpdateTime = 15 // UInt32, nth=15
 	fieldOwnerNode      = 4  // UInt64, nth=4
 	fieldAssetPrice     = 23 // UInt64, nth=23
@@ -52,80 +43,36 @@ const (
 	fieldURI            = 5  // Blob, nth=5
 	fieldBaseAsset      = 1  // Currency, nth=1
 	fieldQuoteAsset     = 2  // Currency, nth=2
-	fieldPriceData      = 32 // STObject, nth=32
 	fieldPriceDataSer   = 24 // STArray, nth=24
 )
 
 // ParseOracle parses an Oracle ledger entry from binary data.
-// Uses the same TLV parsing pattern as ParseEscrow.
 func ParseOracle(data []byte) (*OracleData, error) {
 	oracle := &OracleData{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		switch typeCode {
-		case FieldTypeUInt16: // 1
-			if offset+2 > len(data) {
-				return oracle, nil
-			}
-			// LedgerEntryType — skip
-			offset += 2
-
-		case FieldTypeUInt32: // 2
-			if offset+4 > len(data) {
-				return oracle, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case 2: // Flags
-				oracle.Flags = value
+				oracle.Flags = f.UInt32()
 			case fieldLastUpdateTime: // 15
-				oracle.LastUpdateTime = value
+				oracle.LastUpdateTime = f.UInt32()
 			}
 
-		case FieldTypeUInt64: // 3
-			if offset+8 > len(data) {
-				return oracle, nil
-			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			offset += 8
-			switch fieldCode {
-			case fieldOwnerNode: // 4 — OwnerNode
-				oracle.OwnerNode = value
+		case stUInt64:
+			if f.FieldCode == fieldOwnerNode { // 4
+				oracle.OwnerNode = f.UInt64()
 			}
 
-		case FieldTypeAccountID: // 8
-			if offset+21 > len(data) {
-				return oracle, nil
+		case stAccountID:
+			if id, ok := f.AccountID(); ok && f.FieldCode == fieldOwner { // 2
+				oracle.Owner = id
 			}
-			length := data[offset]
-			offset++
-			if length == 20 {
-				switch fieldCode {
-				case fieldOwner: // 2 — Owner
-					copy(oracle.Owner[:], data[offset:offset+20])
-				}
-			}
-			offset += int(length)
 
-		case FieldTypeBlob: // 7
-			if offset >= len(data) {
-				return oracle, nil
-			}
-			length, bytesRead := parseVLLength(data[offset:])
-			offset += bytesRead
-			if offset+length > len(data) {
-				return oracle, nil
-			}
-			blobHex := hex.EncodeToString(data[offset : offset+length])
-			switch fieldCode {
+		case stBlob:
+			blobHex := hex.EncodeToString(f.VLBytes())
+			switch f.FieldCode {
 			case fieldProvider: // 29
 				oracle.Provider = blobHex
 			case fieldAssetClass: // 28
@@ -133,124 +80,57 @@ func ParseOracle(data []byte) (*OracleData, error) {
 			case fieldURI: // 5
 				oracle.URI = blobHex
 			}
-			offset += length
 
-		case fieldTypeSTArray: // 15 — PriceDataSeries
-			if fieldCode == fieldPriceDataSer { // 24
-				var err error
-				oracle.PriceDataSeries, offset, err = parseOraclePriceDataSeries(data, offset)
-				if err != nil {
-					return oracle, err
-				}
+		case stArray:
+			if f.FieldCode == fieldPriceDataSer { // 24
+				oracle.PriceDataSeries = parseOraclePriceDataSeries(f.Value)
 			}
-
-		case FieldTypeUInt8: // 16
-			if offset >= len(data) {
-				return oracle, nil
-			}
-			offset++ // skip UInt8 fields at top level
-
-		case FieldTypeHash256: // 5
-			if offset+32 > len(data) {
-				return oracle, nil
-			}
-			offset += 32
-
-		default:
-			// Unknown type — stop parsing
-			return oracle, nil
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return oracle, nil
 }
 
-// parseOraclePriceDataSeries parses the PriceDataSeries STArray from binary data.
-// STArray format: repeated [STObject header][fields...][object-end 0xE1] then [array-end 0xF1]
-func parseOraclePriceDataSeries(data []byte, offset int) ([]OraclePriceData, int, error) {
+// parseOraclePriceDataSeries decodes the PriceDataSeries STArray content (as
+// delimited by WalkFields). Each element is a PriceData STObject.
+func parseOraclePriceDataSeries(content []byte) []OraclePriceData {
 	var series []OraclePriceData
-
-	for offset < len(data) {
-		// Check for array end marker (0xF1)
-		if data[offset] == 0xF1 {
-			offset++
-			break
+	_ = WalkFields(content, func(elem Field) error {
+		if elem.TypeCode != stObject {
+			return nil
 		}
-
-		// Read STObject header for PriceData
-		typeCode, _, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		if typeCode != fieldTypeSTObject {
-			// Not an STObject — unexpected
-			break
-		}
-
-		// Parse the inner PriceData object fields
 		pd := OraclePriceData{}
-		for offset < len(data) {
-			// Check for object end marker (0xE1)
-			if data[offset] == 0xE1 {
-				offset++
-				break
-			}
-
-			innerType, innerField, innerOffset, innerOK := parseFieldHeader(data, offset)
-			offset = innerOffset
-			if !innerOK {
-				break
-			}
-
-			switch innerType {
-			case FieldTypeUInt64: // 3 — AssetPrice
-				if offset+8 > len(data) {
-					return series, offset, nil
-				}
-				value := binary.BigEndian.Uint64(data[offset : offset+8])
-				offset += 8
-				if innerField == fieldAssetPrice { // 23
-					pd.AssetPrice = value
+		_ = WalkFields(elem.Value, func(inner Field) error {
+			switch inner.TypeCode {
+			case stUInt64:
+				if inner.FieldCode == fieldAssetPrice { // 23
+					pd.AssetPrice = inner.UInt64()
 					pd.HasPrice = true
 				}
-
-			case FieldTypeUInt8: // 16 — Scale
-				if offset >= len(data) {
-					return series, offset, nil
-				}
-				value := data[offset]
-				offset++
-				if innerField == fieldScale { // 4
-					pd.Scale = value
+			case stUInt8:
+				if inner.FieldCode == fieldScale { // 4
+					pd.Scale = inner.UInt8()
 					pd.HasScale = true
 				}
-
-			case fieldTypeCurrency: // 26 — BaseAsset/QuoteAsset (20 bytes each)
-				if offset+20 > len(data) {
-					return series, offset, nil
-				}
-				currencyBytes := data[offset : offset+20]
-				currStr := parseCurrencyBytes(currencyBytes)
-				offset += 20
-				switch innerField {
+			case stCurrency:
+				currStr := parseCurrencyBytes(inner.Value)
+				switch inner.FieldCode {
 				case fieldBaseAsset: // 1
 					pd.BaseAsset = currStr
 				case fieldQuoteAsset: // 2
 					pd.QuoteAsset = currStr
 				}
-
-			default:
-				// Unknown field type in PriceData — skip safely
-				return series, offset, nil
 			}
-		}
-
+			return nil
+		})
 		series = append(series, pd)
-	}
-
-	return series, offset, nil
+		return nil
+	})
+	return series
 }
 
 // parseCurrencyBytes converts 20 binary currency bytes to a string.
@@ -293,31 +173,6 @@ func parseCurrencyBytes(b []byte) string {
 	}
 
 	return hex.EncodeToString(b)
-}
-
-// parseVLLength parses a variable-length field length prefix.
-// Returns the length and number of bytes consumed for the prefix.
-func parseVLLength(data []byte) (int, int) {
-	if len(data) == 0 {
-		return 0, 0
-	}
-	b1 := int(data[0])
-	if b1 <= 192 {
-		return b1, 1
-	}
-	if b1 <= 240 {
-		if len(data) < 2 {
-			return 0, 1
-		}
-		b2 := int(data[1])
-		return 193 + ((b1 - 193) * 256) + b2, 2
-	}
-	if len(data) < 3 {
-		return 0, 1
-	}
-	b2 := int(data[1])
-	b3 := int(data[2])
-	return 12481 + ((b1 - 241) * 65536) + (b2 * 256) + b3, 3
 }
 
 // SerializeOracle serializes an Oracle ledger entry to binary format.

--- a/internal/ledger/state/pay_channel.go
+++ b/internal/ledger/state/pay_channel.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 
@@ -98,114 +97,69 @@ func SerializePayChannelFromData(channel *PayChannelData) ([]byte, error) {
 // ParsePayChannel parses a PayChannel ledger entry from binary data
 func ParsePayChannel(data []byte) (*PayChannelData, error) {
 	channel := &PayChannelData{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return channel, nil
-			}
-			offset += 2
-
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return channel, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case 39: // SettleDelay (nth=39)
-				channel.SettleDelay = value
+				channel.SettleDelay = f.UInt32()
 			case 36: // CancelAfter (nth=36)
-				channel.CancelAfter = value
+				channel.CancelAfter = f.UInt32()
 			case 10: // Expiration (nth=10)
-				channel.Expiration = value
+				channel.Expiration = f.UInt32()
 			case 3: // SourceTag
-				channel.SourceTag = value
+				channel.SourceTag = f.UInt32()
 				channel.HasSourceTag = true
 			case 14: // DestinationTag
-				channel.DestinationTag = value
+				channel.DestinationTag = f.UInt32()
 				channel.HasDestTag = true
 			case 5: // PreviousTxnLgrSeq
-				channel.PreviousTxnLgrSeq = value
+				channel.PreviousTxnLgrSeq = f.UInt32()
 			}
 
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return channel, nil
-			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			offset += 8
-			switch fieldCode {
+		case stUInt64:
+			switch f.FieldCode {
 			case 4: // OwnerNode (nth=4)
-				channel.OwnerNode = value
+				channel.OwnerNode = f.UInt64()
 			case 9: // DestinationNode (nth=9)
-				channel.DestinationNode = value
+				channel.DestinationNode = f.UInt64()
 				channel.HasDestNode = true
 			}
 
-		case FieldTypeAmount:
-			if offset+8 > len(data) {
-				return channel, nil
+		case stAmount:
+			// PayChannel's Amount/Balance are native XRP (8 bytes).
+			switch f.FieldCode {
+			case 1: // Amount (nth=1)
+				channel.Amount = xrpDrops(f.Value)
+			case 2: // Balance (nth=2)
+				channel.Balance = xrpDrops(f.Value)
 			}
-			rawAmount := binary.BigEndian.Uint64(data[offset : offset+8])
-			amount := rawAmount & 0x3FFFFFFFFFFFFFFF
-			if fieldCode == 1 { // Amount (nth=1)
-				channel.Amount = amount
-			} else if fieldCode == 2 { // Balance (nth=2)
-				channel.Balance = amount
-			}
-			offset += 8
 
-		case FieldTypeAccountID:
-			if offset+21 > len(data) {
-				return channel, nil
-			}
-			length := data[offset]
-			offset++
-			if length == 20 {
-				switch fieldCode {
+		case stAccountID:
+			if id, ok := f.AccountID(); ok {
+				switch f.FieldCode {
 				case 1: // Account
-					copy(channel.Account[:], data[offset:offset+20])
+					channel.Account = id
 				case 3: // Destination
-					copy(channel.DestinationID[:], data[offset:offset+20])
+					channel.DestinationID = id
 				}
-				offset += 20
 			}
 
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return channel, nil
+		case stHash256:
+			if f.FieldCode == 5 { // PreviousTxnID
+				channel.PreviousTxnID = f.Hash256()
 			}
-			if fieldCode == 5 { // PreviousTxnID
-				copy(channel.PreviousTxnID[:], data[offset:offset+32])
-			}
-			offset += 32
 
-		case FieldTypeBlob:
-			if offset >= len(data) {
-				return channel, nil
+		case stBlob:
+			if f.FieldCode == 1 { // PublicKey (Blob, nth=1)
+				channel.PublicKey = hex.EncodeToString(f.VLBytes())
 			}
-			length := int(data[offset])
-			offset++
-			if offset+length > len(data) {
-				return channel, nil
-			}
-			if fieldCode == 1 { // PublicKey (Blob, nth=1)
-				channel.PublicKey = hex.EncodeToString(data[offset : offset+length])
-			}
-			offset += length
-
-		default:
-			return channel, nil
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return channel, nil

--- a/internal/ledger/state/permissioned_domain_entry.go
+++ b/internal/ledger/state/permissioned_domain_entry.go
@@ -3,7 +3,6 @@ package state
 import (
 	"encoding/hex"
 	"fmt"
-	"strconv"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 )
@@ -59,59 +58,64 @@ func SerializePermissionedDomain(pd *PermissionedDomainData, ownerAddress string
 
 // ParsePermissionedDomain parses a PermissionedDomain ledger entry from binary data.
 func ParsePermissionedDomain(data []byte) (*PermissionedDomainData, error) {
-	hexStr := hex.EncodeToString(data)
-	jsonObj, err := binarycodec.Decode(hexStr)
+	pd := &PermissionedDomainData{}
+
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt32:
+			if f.FieldCode == 4 { // Sequence
+				pd.Sequence = f.UInt32()
+			}
+		case stUInt64:
+			if f.FieldCode == 4 { // OwnerNode
+				pd.OwnerNode = f.UInt64()
+			}
+		case stAccountID:
+			if f.FieldCode == 2 { // Owner
+				if id, ok := f.AccountID(); ok {
+					pd.Owner = id
+				}
+			}
+		case stArray:
+			if f.FieldCode == 28 { // AcceptedCredentials
+				pd.AcceptedCredentials = parseAcceptedCredentials(f.Value)
+			}
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	pd := &PermissionedDomainData{}
+	return pd, nil
+}
 
-	if owner, ok := jsonObj["Owner"].(string); ok {
-		ownerID, err := DecodeAccountID(owner)
-		if err == nil {
-			pd.Owner = ownerID
+// parseAcceptedCredentials decodes the AcceptedCredentials STArray content; each
+// element is a Credential STObject.
+func parseAcceptedCredentials(content []byte) []PermissionedDomainCredential {
+	var creds []PermissionedDomainCredential
+	_ = WalkFields(content, func(elem Field) error {
+		if elem.TypeCode != stObject || elem.FieldCode != 33 { // Credential
+			return nil
 		}
-	}
-
-	if seq := jsonObj["Sequence"]; seq != nil {
-		switch v := seq.(type) {
-		case float64:
-			pd.Sequence = uint32(v)
-		case uint32:
-			pd.Sequence = v
-		case int:
-			pd.Sequence = uint32(v)
-		}
-	}
-
-	if ownerNode, ok := jsonObj["OwnerNode"].(string); ok {
-		pd.OwnerNode, _ = strconv.ParseUint(ownerNode, 16, 64)
-	}
-
-	if creds, ok := jsonObj["AcceptedCredentials"].([]any); ok {
-		for _, credItem := range creds {
-			credWrapper, ok := credItem.(map[string]any)
-			if !ok {
-				continue
-			}
-			credData, ok := credWrapper["Credential"].(map[string]any)
-			if !ok {
-				continue
-			}
-			var c PermissionedDomainCredential
-			if issuer, ok := credData["Issuer"].(string); ok {
-				issuerID, err := DecodeAccountID(issuer)
-				if err == nil {
-					c.Issuer = issuerID
+		var c PermissionedDomainCredential
+		_ = WalkFields(elem.Value, func(inner Field) error {
+			switch inner.TypeCode {
+			case stAccountID:
+				if inner.FieldCode == 4 { // Issuer
+					if id, ok := inner.AccountID(); ok {
+						c.Issuer = id
+					}
+				}
+			case stBlob:
+				if inner.FieldCode == 31 { // CredentialType
+					c.CredentialType = append([]byte(nil), inner.VLBytes()...)
 				}
 			}
-			if credType, ok := credData["CredentialType"].(string); ok {
-				c.CredentialType, _ = hex.DecodeString(credType)
-			}
-			pd.AcceptedCredentials = append(pd.AcceptedCredentials, c)
-		}
-	}
-
-	return pd, nil
+			return nil
+		})
+		creds = append(creds, c)
+		return nil
+	})
+	return creds
 }

--- a/internal/ledger/state/permissioned_domain_entry.go
+++ b/internal/ledger/state/permissioned_domain_entry.go
@@ -78,7 +78,11 @@ func ParsePermissionedDomain(data []byte) (*PermissionedDomainData, error) {
 			}
 		case stArray:
 			if f.FieldCode == 28 { // AcceptedCredentials
-				pd.AcceptedCredentials = parseAcceptedCredentials(f.Value)
+				creds, err := parseAcceptedCredentials(f.Value)
+				if err != nil {
+					return err
+				}
+				pd.AcceptedCredentials = creds
 			}
 		}
 		return nil
@@ -92,14 +96,14 @@ func ParsePermissionedDomain(data []byte) (*PermissionedDomainData, error) {
 
 // parseAcceptedCredentials decodes the AcceptedCredentials STArray content; each
 // element is a Credential STObject.
-func parseAcceptedCredentials(content []byte) []PermissionedDomainCredential {
+func parseAcceptedCredentials(content []byte) ([]PermissionedDomainCredential, error) {
 	var creds []PermissionedDomainCredential
-	_ = WalkFields(content, func(elem Field) error {
+	err := WalkFields(content, func(elem Field) error {
 		if elem.TypeCode != stObject || elem.FieldCode != 33 { // Credential
 			return nil
 		}
 		var c PermissionedDomainCredential
-		_ = WalkFields(elem.Value, func(inner Field) error {
+		if err := WalkFields(elem.Value, func(inner Field) error {
 			switch inner.TypeCode {
 			case stAccountID:
 				if inner.FieldCode == 4 { // Issuer
@@ -113,9 +117,11 @@ func parseAcceptedCredentials(content []byte) []PermissionedDomainCredential {
 				}
 			}
 			return nil
-		})
+		}); err != nil {
+			return err
+		}
 		creds = append(creds, c)
 		return nil
 	})
-	return creds
+	return creds, err
 }

--- a/internal/ledger/state/ripple_state.go
+++ b/internal/ledger/state/ripple_state.go
@@ -94,91 +94,59 @@ func ParseRippleState(data []byte) (*RippleState, error) {
 	}
 
 	rs := &RippleState{}
-	offset := 0
 
-	for offset < len(data) {
-		typeCode, fieldCode, newOffset, ok := parseFieldHeader(data, offset)
-		offset = newOffset
-		if !ok {
-			break
-		}
-
-		switch typeCode {
-		case FieldTypeUInt16:
-			if offset+2 > len(data) {
-				return rs, nil
-			}
-			value := binary.BigEndian.Uint16(data[offset : offset+2])
-			offset += 2
-			if fieldCode == fieldCodeLedgerEntryType {
-				if value != ledgerEntryTypeRippleState {
-					return nil, errors.New("not a RippleState entry")
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt16:
+			if f.FieldCode == fieldCodeLedgerEntryType {
+				if f.UInt16() != ledgerEntryTypeRippleState {
+					return errors.New("not a RippleState entry")
 				}
 			}
 
-		case FieldTypeUInt32:
-			if offset+4 > len(data) {
-				return rs, nil
-			}
-			value := binary.BigEndian.Uint32(data[offset : offset+4])
-			offset += 4
-			switch fieldCode {
+		case stUInt32:
+			switch f.FieldCode {
 			case fieldCodeFlags:
-				rs.Flags = value
+				rs.Flags = f.UInt32()
 			case fieldCodePrevTxnLgrSeq:
-				rs.PreviousTxnLgrSeq = value
+				rs.PreviousTxnLgrSeq = f.UInt32()
 			case fieldCodeLowQualityIn:
-				rs.LowQualityIn = value
+				rs.LowQualityIn = f.UInt32()
 			case fieldCodeLowQualityOut:
-				rs.LowQualityOut = value
+				rs.LowQualityOut = f.UInt32()
 			case fieldCodeHighQualityIn:
-				rs.HighQualityIn = value
+				rs.HighQualityIn = f.UInt32()
 			case fieldCodeHighQualityOut:
-				rs.HighQualityOut = value
+				rs.HighQualityOut = f.UInt32()
 			}
 
-		case FieldTypeUInt64:
-			if offset+8 > len(data) {
-				return rs, nil
-			}
-			value := binary.BigEndian.Uint64(data[offset : offset+8])
-			offset += 8
-			switch fieldCode {
+		case stUInt64:
+			switch f.FieldCode {
 			case fieldCodeLowNode:
-				rs.LowNode = value
+				rs.LowNode = f.UInt64()
 			case fieldCodeHighNode:
-				rs.HighNode = value
+				rs.HighNode = f.UInt64()
 			}
 
-		case FieldTypeHash256:
-			if offset+32 > len(data) {
-				return rs, nil
-			}
-			if fieldCode == fieldCodePrevTxnID {
-				copy(rs.PreviousTxnID[:], data[offset:offset+32])
-			}
-			offset += 32
-
-		case FieldTypeAmount:
-			// IOU amounts are 48 bytes
-			if offset+48 > len(data) {
-				// Try parsing as XRP (8 bytes) - should not happen for RippleState
-				if offset+8 > len(data) {
-					return rs, nil
-				}
-				offset += 8
-				continue
+		case stHash256:
+			if f.FieldCode == fieldCodePrevTxnID {
+				rs.PreviousTxnID = f.Hash256()
 			}
 
-			amt, err := ParseIOUAmountBinary(data[offset : offset+48])
+		case stAmount:
+			// RippleState's Balance/LowLimit/HighLimit are IOU amounts (48
+			// bytes); a non-IOU value is foreign here and is skipped.
+			if len(f.Value) != 48 {
+				return nil
+			}
+			amt, err := ParseIOUAmountBinary(f.Value)
 			if err != nil {
 				// A trust line whose Balance/limit fails to parse is corrupt;
 				// returning a zero amount with no error would silently diverge
 				// the trust line's state from the ledger.
-				return nil, fmt.Errorf("RippleState amount (field %d) parse failed: %w", fieldCode, err)
+				return fmt.Errorf("RippleState amount (field %d) parse failed: %w", f.FieldCode, err)
 			}
-
-			switch fieldCode {
+			switch f.FieldCode {
 			case fieldCodeRSBalance:
 				rs.Balance = amt
 			case fieldCodeLowLimit:
@@ -186,11 +154,11 @@ func ParseRippleState(data []byte) (*RippleState, error) {
 			case fieldCodeHighLimit:
 				rs.HighLimit = amt
 			}
-			offset += 48
-
-		default:
-			return rs, nil
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return rs, nil

--- a/internal/ledger/state/signer_list.go
+++ b/internal/ledger/state/signer_list.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -39,79 +40,69 @@ type SignerEntry struct {
 
 // ParseSignerList parses a SignerList ledger entry from binary data.
 func ParseSignerList(data []byte) (*SignerListInfo, error) {
-	hexStr := hex.EncodeToString(data)
-	decoded, err := binarycodec.Decode(hexStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode SignerList: %w", err)
-	}
-
 	signerList := &SignerListInfo{
 		SignerListID: 0,
 	}
 
-	if flags, ok := decoded["Flags"]; ok {
-		switch v := flags.(type) {
-		case float64:
-			signerList.Flags = uint32(v)
-		case int:
-			signerList.Flags = uint32(v)
-		case uint32:
-			signerList.Flags = v
-		}
-	}
-
-	if quorum, ok := decoded["SignerQuorum"]; ok {
-		switch v := quorum.(type) {
-		case float64:
-			signerList.SignerQuorum = uint32(v)
-		case int:
-			signerList.SignerQuorum = uint32(v)
-		case uint32:
-			signerList.SignerQuorum = v
-		}
-	}
-
-	if ownerNode, ok := decoded["OwnerNode"].(string); ok {
-		signerList.OwnerNode = parseUint64Hex(ownerNode)
-	}
-
-	if entries, ok := decoded["SignerEntries"]; ok {
-		if entriesArray, ok := entries.([]any); ok {
-			for _, entryWrapper := range entriesArray {
-				if entryMap, ok := entryWrapper.(map[string]any); ok {
-					var signerEntry map[string]any
-					if se, ok := entryMap["SignerEntry"]; ok {
-						signerEntry, _ = se.(map[string]any)
-					} else {
-						signerEntry = entryMap
-					}
-
-					if signerEntry != nil {
-						entry := AccountSignerEntry{}
-						if account, ok := signerEntry["Account"].(string); ok {
-							entry.Account = account
-						}
-						if weight, ok := signerEntry["SignerWeight"]; ok {
-							switch v := weight.(type) {
-							case float64:
-								entry.SignerWeight = uint16(v)
-							case int:
-								entry.SignerWeight = uint16(v)
-							case uint16:
-								entry.SignerWeight = v
-							}
-						}
-						if walletLocator, ok := signerEntry["WalletLocator"].(string); ok {
-							entry.WalletLocator = walletLocator
-						}
-						signerList.SignerEntries = append(signerList.SignerEntries, entry)
-					}
-				}
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt32:
+			switch f.FieldCode {
+			case 2: // Flags
+				signerList.Flags = f.UInt32()
+			case 35: // SignerQuorum
+				signerList.SignerQuorum = f.UInt32()
+			}
+		case stUInt64:
+			if f.FieldCode == 4 { // OwnerNode
+				signerList.OwnerNode = f.UInt64()
+			}
+		case stArray:
+			if f.FieldCode == 4 { // SignerEntries
+				signerList.SignerEntries = parseSignerEntries(f.Value)
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode SignerList: %w", err)
 	}
 
 	return signerList, nil
+}
+
+// parseSignerEntries decodes the SignerEntries STArray content; each element is
+// a SignerEntry STObject.
+func parseSignerEntries(content []byte) []AccountSignerEntry {
+	var entries []AccountSignerEntry
+	_ = WalkFields(content, func(elem Field) error {
+		if elem.TypeCode != stObject || elem.FieldCode != 11 { // SignerEntry
+			return nil
+		}
+		e := AccountSignerEntry{}
+		_ = WalkFields(elem.Value, func(inner Field) error {
+			switch inner.TypeCode {
+			case stAccountID:
+				if inner.FieldCode == 1 { // Account
+					if id, ok := inner.AccountID(); ok {
+						e.Account, _ = EncodeAccountID(id)
+					}
+				}
+			case stUInt16:
+				if inner.FieldCode == 3 { // SignerWeight
+					e.SignerWeight = inner.UInt16()
+				}
+			case stHash256:
+				if inner.FieldCode == 7 { // WalletLocator
+					e.WalletLocator = strings.ToUpper(hex.EncodeToString(inner.Value))
+				}
+			}
+			return nil
+		})
+		entries = append(entries, e)
+		return nil
+	})
+	return entries
 }
 
 // SerializeSignerList serializes a SignerList ledger entry.
@@ -275,24 +266,25 @@ type DepositPreauthEntry struct {
 // ParseDepositPreauth parses a DepositPreauth ledger entry from binary data.
 // Extracts Account and OwnerNode needed for removeFromLedger.
 func ParseDepositPreauth(data []byte) (*DepositPreauthEntry, error) {
-	hexStr := hex.EncodeToString(data)
-	jsonObj, err := binarycodec.Decode(hexStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode DepositPreauth: %w", err)
-	}
-
 	entry := &DepositPreauthEntry{}
 
-	if account, ok := jsonObj["Account"].(string); ok {
-		accountID, err := DecodeAccountID(account)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode Account: %w", err)
+	err := WalkFields(data, func(f Field) error {
+		switch f.TypeCode {
+		case stUInt64:
+			if f.FieldCode == 4 { // OwnerNode
+				entry.OwnerNode = f.UInt64()
+			}
+		case stAccountID:
+			if f.FieldCode == 1 { // Account
+				if id, ok := f.AccountID(); ok {
+					entry.Account = id
+				}
+			}
 		}
-		entry.Account = accountID
-	}
-
-	if ownerNode, ok := jsonObj["OwnerNode"].(string); ok {
-		entry.OwnerNode = parseUint64Hex(ownerNode)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode DepositPreauth: %w", err)
 	}
 
 	return entry, nil

--- a/internal/ledger/state/signer_list.go
+++ b/internal/ledger/state/signer_list.go
@@ -59,7 +59,11 @@ func ParseSignerList(data []byte) (*SignerListInfo, error) {
 			}
 		case stArray:
 			if f.FieldCode == 4 { // SignerEntries
-				signerList.SignerEntries = parseSignerEntries(f.Value)
+				entries, err := parseSignerEntries(f.Value)
+				if err != nil {
+					return err
+				}
+				signerList.SignerEntries = entries
 			}
 		}
 		return nil
@@ -73,14 +77,14 @@ func ParseSignerList(data []byte) (*SignerListInfo, error) {
 
 // parseSignerEntries decodes the SignerEntries STArray content; each element is
 // a SignerEntry STObject.
-func parseSignerEntries(content []byte) []AccountSignerEntry {
+func parseSignerEntries(content []byte) ([]AccountSignerEntry, error) {
 	var entries []AccountSignerEntry
-	_ = WalkFields(content, func(elem Field) error {
+	err := WalkFields(content, func(elem Field) error {
 		if elem.TypeCode != stObject || elem.FieldCode != 11 { // SignerEntry
 			return nil
 		}
 		e := AccountSignerEntry{}
-		_ = WalkFields(elem.Value, func(inner Field) error {
+		if err := WalkFields(elem.Value, func(inner Field) error {
 			switch inner.TypeCode {
 			case stAccountID:
 				if inner.FieldCode == 1 { // Account
@@ -98,11 +102,13 @@ func parseSignerEntries(content []byte) []AccountSignerEntry {
 				}
 			}
 			return nil
-		})
+		}); err != nil {
+			return err
+		}
 		entries = append(entries, e)
 		return nil
 	})
-	return entries
+	return entries, err
 }
 
 // SerializeSignerList serializes a SignerList ledger entry.


### PR DESCRIPTION
## Summary
- Converges both SLE-parsing regimes in `internal/ledger/state` onto the single `state.WalkFields` walker (added in #918): the 11 hand-rolled TLV scanners (`account_root`, `ripple_state`, `offer`, `check`, `escrow`, `pay_channel`, `mptoken` ×2, `oracle`, `did`, `nftoken` ×2, `fee_settings`) and the 4 `binarycodec.Decode`-based parsers (`directory`, `signer_list`+`deposit_preauth`, `delegate`, `permissioned_domain`) now all decode through `WalkFields` + typed `Field` accessors in the new `field_value.go`.
- Collapses the three duplicate VL-length decoders into the walker's single `readVLLength`, and removes the hex-uint64 helper (`parseUint64Hex`) and `strconv.ParseUint(…,16,64)` entirely — UInt64 fields are now read as raw bytes with no hex-string round-trip, so no hex-uint64 helper is needed at all.
- Removes the dead per-file machinery this enables: `parseVLLength` (oracle), the `skipArray`/`skipObject`/`skipFieldValue`/`advance` structural walkers (offer), `parsePermissionValue` (delegate), `decodeAccountID`, and the per-file `float64/int/uint32` type-switch boilerplate.
- Parsers now propagate truncation/corruption errors from `WalkFields` instead of returning partially-filled structs with `err == nil`, completing the M2 parser-error work from #894 — corrupt bytes are now distinguishable from valid ones.
- Net −946 LOC.

## Test plan
- [x] `go test ./internal/ledger/state/...` (round-trip + walker tests) — pass
- [x] `go test ./internal/tx/... ./internal/ledger/... ./internal/rpc/... ./internal/statecompare/... ./internal/txq/...` — pass
- [x] `go test ./internal/testing/...` (feature suites) — pass
- [x] `./scripts/conformance-summary.sh` — per-suite table **byte-identical** to `origin/main` (zero regressions across all in-scope and out-of-scope suites)
- [x] `golangci-lint run ./internal/ledger/state/...` — 0 issues; `gofmt`/`go vet` clean

Fixes #928