### PR TITLE
refactor(ledger/core): structural dedup tail of #894 (amount math, trust-line create, VL/hex, CompareAccountIDs)

### DIFF
--- a/internal/ledger/service/account_query_test.go
+++ b/internal/ledger/service/account_query_test.go
@@ -28,7 +28,7 @@ func insertLineRaw(t *testing.T, svc *Service, lowAddr, highAddr, currency, rawB
 	var lowID, highID [20]byte
 	copy(lowID[:], lowBytes)
 	copy(highID[:], highBytes)
-	if state.CompareAccountIDsForLine(lowID, highID) >= 0 {
+	if state.CompareAccountIDs(lowID, highID) >= 0 {
 		t.Fatalf("lowAddr %s must sort before highAddr %s", lowAddr, highAddr)
 	}
 

--- a/internal/ledger/service/offer_query_test.go
+++ b/internal/ledger/service/offer_query_test.go
@@ -80,7 +80,7 @@ func insertTrustLine(t *testing.T, svc *Service, ownerAddr, issuerAddr, currency
 	copy(ownerID[:], ownerBytes)
 	copy(issuerID[:], issuerBytes)
 
-	ownerIsLow := state.CompareAccountIDsForLine(ownerID, issuerID) < 0
+	ownerIsLow := state.CompareAccountIDs(ownerID, issuerID) < 0
 	var lowAddr, highAddr string
 	if ownerIsLow {
 		lowAddr, highAddr = ownerAddr, issuerAddr

--- a/internal/ledger/state/amount_ops.go
+++ b/internal/ledger/state/amount_ops.go
@@ -5,14 +5,9 @@ import (
 )
 
 // CompareAccountIDs compares two 20-byte account IDs lexicographically.
-// Returns -1, 0, or 1.
+// Returns -1, 0, or 1. The "low" account in a trust line is the one that
+// sorts first.
 func CompareAccountIDs(a, b [20]byte) int {
-	return bytes.Compare(a[:], b[:])
-}
-
-// CompareAccountIDsForLine compares two account IDs for trust line ordering.
-// The "low" account is the one that sorts first lexicographically.
-func CompareAccountIDsForLine(a, b [20]byte) int {
 	return bytes.Compare(a[:], b[:])
 }
 

--- a/internal/ledger/state/amount_round.go
+++ b/internal/ledger/state/amount_round.go
@@ -2,178 +2,189 @@ package state
 
 import "math/big"
 
+// Shared big.Int constants for the muldiv-round core. Treated as immutable;
+// muldivRound only reads them.
+var (
+	bigOne     = big.NewInt(1)
+	bigTenTo14 = new(big.Int).SetUint64(100_000_000_000_000)     // 10^14
+	bigTenTo17 = new(big.Int).SetUint64(100_000_000_000_000_000) // 10^17
+)
+
+// PrepareMulDivOperand returns the absolute mantissa and exponent of a,
+// normalizing native (XRP) amounts up into the IOU mantissa range
+// [10^15, 10^16). This is the per-operand preamble every mul/div round variant
+// shares; the result sign is taken separately from a.IsNegative().
+func PrepareMulDivOperand(a Amount) (mantissa int64, exponent int) {
+	mantissa = a.Mantissa()
+	exponent = a.Exponent()
+	if a.IsNative() {
+		if mantissa < 0 {
+			mantissa = -mantissa
+		}
+		for mantissa < MinMantissa {
+			mantissa *= 10
+			exponent--
+		}
+	}
+	if mantissa < 0 {
+		mantissa = -mantissa
+	}
+	return mantissa, exponent
+}
+
+// muldivRound computes (x*y + slop) / divisor in exact big-integer arithmetic,
+// where slop is (divisor-1) when addSlop is set (round away from zero) and 0
+// otherwise. This is rippled's muldiv_round core.
+func muldivRound(x, y, divisor *big.Int, addSlop bool) uint64 {
+	n := new(big.Int).Mul(x, y)
+	if addSlop {
+		n.Add(n, new(big.Int).Sub(divisor, bigOne))
+	}
+	n.Div(n, divisor)
+	return n.Uint64()
+}
+
+// MulMantissas computes (value1*value2 + slop) / 10^14, the multiply leg of the
+// muldiv-round core. slop rounds away from zero when addSlop is set.
+func MulMantissas(value1, value2 int64, addSlop bool) uint64 {
+	return muldivRound(big.NewInt(value1), big.NewInt(value2), bigTenTo14, addSlop)
+}
+
+// DivMantissas computes (numVal*10^17 + slop) / denVal, the divide leg of the
+// muldiv-round core. slop rounds away from zero when addSlop is set.
+func DivMantissas(numVal, denVal int64, addSlop bool) uint64 {
+	return muldivRound(big.NewInt(numVal), bigTenTo17, big.NewInt(denVal), addSlop)
+}
+
+// CanonicalizeRoundIOUOverflow reduces an over-large IOU mantissa back under
+// MaxMantissa, matching rippled's canonicalizeRound overflow branch. Callers
+// apply it only when rounding away from zero (resultNegative != roundUp).
+func CanonicalizeRoundIOUOverflow(amount uint64, offset int) (uint64, int) {
+	if amount > uint64(MaxMantissa) {
+		for amount > 10*uint64(MaxMantissa) {
+			amount /= 10
+			offset++
+		}
+		amount += 9
+		amount /= 10
+		offset++
+	}
+	return amount, offset
+}
+
+// canonicalizeRoundNative converts an IOU-style mantissa/exponent to XRP drops.
+// When doRound is set (rounding away from zero) it applies rippled's native
+// canonicalizeRound loop-count rounding; otherwise it just rescales to drops.
+//
+// The no-round branch rescales by truncation where rippled's post-switchover
+// native canonicalize rounds to-nearest via Number, and the native×native
+// overflow Throw is not reproduced. Both gaps are currently unreachable: every
+// caller passes roundUp=true with positive operands, which lands in the doRound
+// branch.
+func canonicalizeRoundNative(amount uint64, offset int, doRound bool) uint64 {
+	if doRound {
+		if offset < 0 {
+			loops := 0
+			for offset < -1 {
+				amount /= 10
+				offset++
+				loops++
+			}
+			adder := uint64(10)
+			if loops >= 2 {
+				adder = 9
+			}
+			amount = (amount + adder) / 10
+		}
+		return amount
+	}
+	for offset < 0 {
+		amount /= 10
+		offset++
+	}
+	for offset > 0 {
+		amount *= 10
+		offset--
+	}
+	return amount
+}
+
+// FinalizeRoundIOU builds the signed IOU result. When useMode is set the result
+// is constructed with the given Number rounding mode (the strict variants);
+// otherwise the legacy non-mode constructor is used. A positive round-up that
+// collapsed to zero returns the minimum representable value.
+func FinalizeRoundIOU(amount uint64, offset int, resultNegative, roundUp bool, currency, issuer string, mode RoundingMode, useMode bool) Amount {
+	mantissa := int64(amount)
+	if resultNegative {
+		mantissa = -mantissa
+	}
+	var result Amount
+	if useMode {
+		result = NewIssuedAmountFromValueRounded(mantissa, offset, currency, issuer, mode)
+	} else {
+		result = NewIssuedAmountFromValue(mantissa, offset, currency, issuer)
+	}
+	if roundUp && !resultNegative && result.IsZero() {
+		return NewIssuedAmountFromValue(MinMantissa, MinExponent, currency, issuer)
+	}
+	return result
+}
+
+// finalizeRoundNative builds the signed XRP-drops result, returning 1 drop when
+// a positive round-up collapsed to zero.
+func finalizeRoundNative(amount uint64, resultNegative, roundUp bool) int64 {
+	if roundUp && !resultNegative && amount == 0 {
+		return 1
+	}
+	result := int64(amount)
+	if resultNegative {
+		result = -result
+	}
+	return result
+}
+
+// MulRoundStrict multiplies two Amounts using rippled's mulRoundStrict algorithm
+// (canonicalizeRoundStrict + NumberRoundModeGuard(towards_zero)).
 func MulRoundStrict(v1, v2 Amount, currency, issuer string, roundUp bool) Amount {
 	if v1.IsZero() || v2.IsZero() {
 		return NewIssuedAmountFromValue(0, -100, currency, issuer)
 	}
-
-	value1 := v1.Mantissa()
-	offset1 := v1.Exponent()
-	value2 := v2.Mantissa()
-	offset2 := v2.Exponent()
-
-	// Normalize native/MPT values to IOU range [10^15, 10^16)
-	if v1.IsNative() {
-		if value1 < 0 {
-			value1 = -value1
-		}
-		for value1 < MinMantissa {
-			value1 *= 10
-			offset1--
-		}
-	}
-	if v2.IsNative() {
-		if value2 < 0 {
-			value2 = -value2
-		}
-		for value2 < MinMantissa {
-			value2 *= 10
-			offset2--
-		}
-	}
-
+	value1, offset1 := PrepareMulDivOperand(v1)
+	value2, offset2 := PrepareMulDivOperand(v2)
 	resultNegative := v1.IsNegative() != v2.IsNegative()
+	addSlop := resultNegative != roundUp
 
-	// Make mantissas positive for multiplication
-	if value1 < 0 {
-		value1 = -value1
-	}
-	if value2 < 0 {
-		value2 = -value2
-	}
-
-	// muldiv_round: (value1 * value2 + rounding) / 10^14
-	// rounding = (resultNegative != roundUp) ? 10^14 - 1 : 0
-	tenTo14 := new(big.Int).SetUint64(100_000_000_000_000)  // 10^14
-	tenTo14m1 := new(big.Int).SetUint64(99_999_999_999_999) // 10^14 - 1
-	product := new(big.Int).Mul(big.NewInt(value1), big.NewInt(value2))
-	if resultNegative != roundUp {
-		product.Add(product, tenTo14m1)
-	}
-	product.Div(product, tenTo14)
-
-	amount := product.Uint64()
+	amount := MulMantissas(value1, value2, addSlop)
 	offset := offset1 + offset2 + 14
-
-	// canonicalizeRoundStrict: only when resultNegative != roundUp
-	if resultNegative != roundUp {
-		if amount > uint64(MaxMantissa) {
-			for amount > 10*uint64(MaxMantissa) {
-				amount /= 10
-				offset++
-			}
-			amount += 9
-			amount /= 10
-			offset++
-		}
+	if addSlop {
+		amount, offset = CanonicalizeRoundIOUOverflow(amount, offset)
 	}
-
-	// Create the result with Number in towards_zero mode.
-	// This affects how normalization rounds during STAmount construction.
-	mantissa := int64(amount)
-	if resultNegative {
-		mantissa = -mantissa
-	}
-	result := NewIssuedAmountFromValueRounded(mantissa, offset, currency, issuer, RoundTowardsZero)
-
-	// If roundUp and positive and result is zero, return minimum value
-	if roundUp && !resultNegative && result.IsZero() {
-		return NewIssuedAmountFromValue(MinMantissa, MinExponent, currency, issuer)
-	}
-
-	return result
+	return FinalizeRoundIOU(amount, offset, resultNegative, roundUp, currency, issuer, RoundTowardsZero, true)
 }
 
-// MulRound multiplies two Amounts using rippled's mulRound (non-strict) algorithm.
-// This is the legacy version with "slop" that uses canonicalizeRound instead of
-// canonicalizeRoundStrict. The key difference: canonicalizeRound adds 9 or 10
-// based on loop count (not actual remainder), and uses DontAffectNumberRoundMode
-// (no-op) instead of NumberRoundModeGuard(towards_zero).
-// Reference: STAmount.cpp mulRoundImpl with canonicalizeRound + DontAffectNumberRoundMode
+// MulRound multiplies two Amounts using rippled's mulRound (non-strict)
+// algorithm (canonicalizeRound + DontAffectNumberRoundMode). The non-strict
+// canonicalize adds 9 or 10 based on loop count rather than the actual
+// remainder, and installs no Number rounding-mode guard.
 func MulRound(v1, v2 Amount, currency, issuer string, roundUp bool) Amount {
 	if v1.IsZero() || v2.IsZero() {
 		return NewIssuedAmountFromValue(0, -100, currency, issuer)
 	}
-
-	value1 := v1.Mantissa()
-	offset1 := v1.Exponent()
-	value2 := v2.Mantissa()
-	offset2 := v2.Exponent()
-
-	// Normalize native/MPT values to IOU range [10^15, 10^16)
-	if v1.IsNative() {
-		if value1 < 0 {
-			value1 = -value1
-		}
-		for value1 < MinMantissa {
-			value1 *= 10
-			offset1--
-		}
-	}
-	if v2.IsNative() {
-		if value2 < 0 {
-			value2 = -value2
-		}
-		for value2 < MinMantissa {
-			value2 *= 10
-			offset2--
-		}
-	}
-
+	value1, offset1 := PrepareMulDivOperand(v1)
+	value2, offset2 := PrepareMulDivOperand(v2)
 	resultNegative := v1.IsNegative() != v2.IsNegative()
+	addSlop := resultNegative != roundUp
 
-	// Make mantissas positive for multiplication
-	if value1 < 0 {
-		value1 = -value1
-	}
-	if value2 < 0 {
-		value2 = -value2
-	}
-
-	// muldiv_round: (value1 * value2 + rounding) / 10^14
-	tenTo14 := new(big.Int).SetUint64(100_000_000_000_000)
-	tenTo14m1 := new(big.Int).SetUint64(99_999_999_999_999)
-	product := new(big.Int).Mul(big.NewInt(value1), big.NewInt(value2))
-	if resultNegative != roundUp {
-		product.Add(product, tenTo14m1)
-	}
-	product.Div(product, tenTo14)
-
-	amount := product.Uint64()
+	amount := MulMantissas(value1, value2, addSlop)
 	offset := offset1 + offset2 + 14
-
-	// canonicalizeRound (non-strict): uses loop count, NOT actual remainder.
-	// Reference: rippled STAmount.cpp canonicalizeRound lines 1432-1464
-	if resultNegative != roundUp {
-		if amount > uint64(MaxMantissa) {
-			for amount > 10*uint64(MaxMantissa) {
-				amount /= 10
-				offset++
-			}
-			amount += 9
-			amount /= 10
-			offset++
-		}
+	if addSlop {
+		amount, offset = CanonicalizeRoundIOUOverflow(amount, offset)
 	}
-
-	// DontAffectNumberRoundMode: NO guard (no-op), unlike strict which uses towards_zero
-	mantissa := int64(amount)
-	if resultNegative {
-		mantissa = -mantissa
-	}
-	result := NewIssuedAmountFromValue(mantissa, offset, currency, issuer)
-
-	// If roundUp and positive and result is zero, return minimum value
-	if roundUp && !resultNegative && result.IsZero() {
-		return NewIssuedAmountFromValue(MinMantissa, MinExponent, currency, issuer)
-	}
-
-	return result
+	return FinalizeRoundIOU(amount, offset, resultNegative, roundUp, currency, issuer, 0, false)
 }
 
-// DivRound divides two Amounts using rippled's divRound (non-strict) algorithm.
-// This is the legacy version with "slop" that uses canonicalizeRound.
-// Reference: STAmount.cpp divRoundImpl with canonicalizeRound + DontAffectNumberRoundMode
+// DivRound divides two Amounts using rippled's divRound (non-strict) algorithm
+// (canonicalizeRound + DontAffectNumberRoundMode).
 func DivRound(num, den Amount, currency, issuer string, roundUp bool) Amount {
 	if den.IsZero() {
 		panic("division by zero")
@@ -181,281 +192,22 @@ func DivRound(num, den Amount, currency, issuer string, roundUp bool) Amount {
 	if num.IsZero() {
 		return NewIssuedAmountFromValue(0, -100, currency, issuer)
 	}
-
-	numVal := num.Mantissa()
-	numOff := num.Exponent()
-	denVal := den.Mantissa()
-	denOff := den.Exponent()
-
-	if num.IsNative() {
-		if numVal < 0 {
-			numVal = -numVal
-		}
-		for numVal < MinMantissa {
-			numVal *= 10
-			numOff--
-		}
-	}
-	if den.IsNative() {
-		if denVal < 0 {
-			denVal = -denVal
-		}
-		for denVal < MinMantissa {
-			denVal *= 10
-			denOff--
-		}
-	}
-
+	numVal, numOff := PrepareMulDivOperand(num)
+	denVal, denOff := PrepareMulDivOperand(den)
 	resultNegative := num.IsNegative() != den.IsNegative()
+	addSlop := resultNegative != roundUp
 
-	if numVal < 0 {
-		numVal = -numVal
-	}
-	if denVal < 0 {
-		denVal = -denVal
-	}
-
-	// divmod with rounding: (numVal * 10^17 + rounding) / denVal
-	tenTo17 := new(big.Int).Exp(big.NewInt(10), big.NewInt(17), nil)
-	numerator := new(big.Int).Mul(big.NewInt(numVal), tenTo17)
-	if resultNegative != roundUp {
-		// Round up: add (denVal - 1) before division
-		numerator.Add(numerator, new(big.Int).Sub(big.NewInt(denVal), big.NewInt(1)))
-	}
-	quotient := new(big.Int).Div(numerator, big.NewInt(denVal))
-	amount := quotient.Uint64()
+	amount := DivMantissas(numVal, denVal, addSlop)
 	offset := numOff - denOff - 17
-
-	// canonicalizeRound (non-strict): same as MulRound
-	if resultNegative != roundUp {
-		if amount > uint64(MaxMantissa) {
-			for amount > 10*uint64(MaxMantissa) {
-				amount /= 10
-				offset++
-			}
-			amount += 9
-			amount /= 10
-			offset++
-		}
+	if addSlop {
+		amount, offset = CanonicalizeRoundIOUOverflow(amount, offset)
 	}
-
-	// DontAffectNumberRoundMode: NO guard
-	mantissa := int64(amount)
-	if resultNegative {
-		mantissa = -mantissa
-	}
-	result := NewIssuedAmountFromValue(mantissa, offset, currency, issuer)
-
-	if roundUp && !resultNegative && result.IsZero() {
-		return NewIssuedAmountFromValue(MinMantissa, MinExponent, currency, issuer)
-	}
-
-	return result
+	return FinalizeRoundIOU(amount, offset, resultNegative, roundUp, currency, issuer, 0, false)
 }
 
-// DivRoundNative divides two Amounts and returns the result as XRP drops (int64),
-// using native canonicalization matching rippled's canonicalizeRound(native=true).
-// When the output asset is native (XRP), rippled's divRoundImpl calls
-// canonicalizeRound with native=true, which uses a different rounding path
-// than the IOU overflow case. This function matches that native path exactly.
-// Reference: STAmount.cpp divRoundImpl + canonicalizeRound(native=true) lines 1434-1451
-func DivRoundNative(num, den Amount, roundUp bool) int64 {
-	if den.IsZero() {
-		panic("division by zero")
-	}
-	if num.IsZero() {
-		return 0
-	}
-
-	numVal := num.Mantissa()
-	numOff := num.Exponent()
-	denVal := den.Mantissa()
-	denOff := den.Exponent()
-
-	if num.IsNative() {
-		if numVal < 0 {
-			numVal = -numVal
-		}
-		for numVal < MinMantissa {
-			numVal *= 10
-			numOff--
-		}
-	}
-	if den.IsNative() {
-		if denVal < 0 {
-			denVal = -denVal
-		}
-		for denVal < MinMantissa {
-			denVal *= 10
-			denOff--
-		}
-	}
-
-	resultNegative := num.IsNegative() != den.IsNegative()
-
-	if numVal < 0 {
-		numVal = -numVal
-	}
-	if denVal < 0 {
-		denVal = -denVal
-	}
-
-	// divmod with rounding: (numVal * 10^17 + rounding) / denVal
-	tenTo17 := new(big.Int).SetUint64(100_000_000_000_000_000)
-	numerator := new(big.Int).Mul(big.NewInt(numVal), tenTo17)
-	if resultNegative != roundUp {
-		numerator.Add(numerator, new(big.Int).Sub(big.NewInt(denVal), big.NewInt(1)))
-	}
-	quotient := new(big.Int).Div(numerator, big.NewInt(denVal))
-	amount := quotient.Uint64()
-	offset := numOff - denOff - 17
-
-	// canonicalizeRound(native=true): use native rounding path.
-	// Reference: rippled STAmount.cpp canonicalizeRound lines 1434-1451
-	if resultNegative != roundUp {
-		if offset < 0 {
-			loops := 0
-			for offset < -1 {
-				amount /= 10
-				offset++
-				loops++
-			}
-			var adder uint64 = 10
-			if loops >= 2 {
-				adder = 9
-			}
-			amount = (amount + adder) / 10
-		}
-	} else {
-		// When resultNegative == roundUp (i.e., no rounding needed),
-		// still need to convert to drops (offset → 0).
-		for offset < 0 {
-			amount /= 10
-			offset++
-		}
-		for offset > 0 {
-			amount *= 10
-			offset--
-		}
-	}
-
-	if roundUp && !resultNegative && amount == 0 {
-		return 1
-	}
-
-	result := int64(amount)
-	if resultNegative {
-		result = -result
-	}
-	return result
-}
-
-// MulRoundNative multiplies two Amounts and returns the result as XRP drops (int64),
-// using native canonicalization matching rippled's canonicalizeRound(native=true).
-// When the output asset is native (XRP), rippled's mulRoundImpl calls
-// canonicalizeRound with native=true, which uses a different rounding path
-// than the IOU overflow case. This function matches that native path exactly.
-// Reference: STAmount.cpp mulRoundImpl + canonicalizeRound(native=true) lines 1434-1451
-//
-// Two faithfulness gaps remain, both currently unreachable (every caller passes
-// roundUp=true with positive operands): the no-round branch (resultNegative ==
-// roundUp) converts to drops by truncation where rippled's post-switchover
-// native canonicalize rounds to-nearest via Number; and rippled's native×native
-// fast path with its overflow Throw is not reproduced (the muldiv path computes
-// a silently-truncated product instead). Revisit if a roundUp=false or
-// native×native caller appears.
-func MulRoundNative(v1, v2 Amount, roundUp bool) int64 {
-	if v1.IsZero() || v2.IsZero() {
-		return 0
-	}
-
-	value1 := v1.Mantissa()
-	offset1 := v1.Exponent()
-	value2 := v2.Mantissa()
-	offset2 := v2.Exponent()
-
-	if v1.IsNative() {
-		if value1 < 0 {
-			value1 = -value1
-		}
-		for value1 < MinMantissa {
-			value1 *= 10
-			offset1--
-		}
-	}
-	if v2.IsNative() {
-		if value2 < 0 {
-			value2 = -value2
-		}
-		for value2 < MinMantissa {
-			value2 *= 10
-			offset2--
-		}
-	}
-
-	resultNegative := v1.IsNegative() != v2.IsNegative()
-
-	if value1 < 0 {
-		value1 = -value1
-	}
-	if value2 < 0 {
-		value2 = -value2
-	}
-
-	// muldiv_round: (value1 * value2 + rounding) / 10^14
-	tenTo14 := new(big.Int).SetUint64(100_000_000_000_000)
-	tenTo14m1 := new(big.Int).SetUint64(99_999_999_999_999)
-	product := new(big.Int).Mul(big.NewInt(value1), big.NewInt(value2))
-	if resultNegative != roundUp {
-		product.Add(product, tenTo14m1)
-	}
-	product.Div(product, tenTo14)
-
-	amount := product.Uint64()
-	offset := offset1 + offset2 + 14
-
-	// canonicalizeRound(native=true): use native rounding path.
-	// Reference: rippled STAmount.cpp canonicalizeRound lines 1434-1451
-	if resultNegative != roundUp {
-		if offset < 0 {
-			loops := 0
-			for offset < -1 {
-				amount /= 10
-				offset++
-				loops++
-			}
-			var adder uint64 = 10
-			if loops >= 2 {
-				adder = 9
-			}
-			amount = (amount + adder) / 10
-		}
-	} else {
-		// When resultNegative == roundUp, no special rounding needed.
-		// Still convert to drops (offset → 0).
-		for offset < 0 {
-			amount /= 10
-			offset++
-		}
-		for offset > 0 {
-			amount *= 10
-			offset--
-		}
-	}
-
-	if roundUp && !resultNegative && amount == 0 {
-		return 1
-	}
-
-	result := int64(amount)
-	if resultNegative {
-		result = -result
-	}
-	return result
-}
-
-// DivRoundStrict divides two Amounts using rippled's divRoundStrict algorithm.
-// Reference: STAmount.cpp divRoundImpl with NumberRoundModeGuard
+// DivRoundStrict divides two Amounts using rippled's divRoundStrict algorithm
+// (canonicalizeRound + NumberRoundModeGuard). The guard mode is upward when
+// rounding away from zero and downward otherwise.
 func DivRoundStrict(num, den Amount, currency, issuer string, roundUp bool) Amount {
 	if den.IsZero() {
 		panic("division by zero")
@@ -463,85 +215,59 @@ func DivRoundStrict(num, den Amount, currency, issuer string, roundUp bool) Amou
 	if num.IsZero() {
 		return NewIssuedAmountFromValue(0, -100, currency, issuer)
 	}
-
-	numVal := num.Mantissa()
-	numOffset := num.Exponent()
-	denVal := den.Mantissa()
-	denOffset := den.Exponent()
-
-	// Normalize native values to IOU range
-	if num.IsNative() {
-		if numVal < 0 {
-			numVal = -numVal
-		}
-		for numVal < MinMantissa {
-			numVal *= 10
-			numOffset--
-		}
-	}
-	if den.IsNative() {
-		if denVal < 0 {
-			denVal = -denVal
-		}
-		for denVal < MinMantissa {
-			denVal *= 10
-			denOffset--
-		}
-	}
-
+	numVal, numOff := PrepareMulDivOperand(num)
+	denVal, denOff := PrepareMulDivOperand(den)
 	resultNegative := num.IsNegative() != den.IsNegative()
+	addSlop := resultNegative != roundUp
 
-	if numVal < 0 {
-		numVal = -numVal
+	amount := DivMantissas(numVal, denVal, addSlop)
+	offset := numOff - denOff - 17
+	if addSlop {
+		amount, offset = CanonicalizeRoundIOUOverflow(amount, offset)
 	}
-	if denVal < 0 {
-		denVal = -denVal
-	}
-
-	// muldiv_round: (numVal * 10^17 + rounding) / denVal
-	// rounding = (resultNegative != roundUp) ? denVal - 1 : 0
-	tenTo17 := new(big.Int).SetUint64(100_000_000_000_000_000) // 10^17
-	bigNum := new(big.Int).Mul(big.NewInt(numVal), tenTo17)
-	bigDen := new(big.Int).SetInt64(denVal)
-	if resultNegative != roundUp {
-		bigNum.Add(bigNum, new(big.Int).Sub(bigDen, big.NewInt(1)))
-	}
-	bigResult := new(big.Int).Div(bigNum, bigDen)
-
-	amount := bigResult.Uint64()
-	offset := numOffset - denOffset - 17
-
-	// canonicalizeRound (used in divRoundImpl)
-	if resultNegative != roundUp {
-		if amount > uint64(MaxMantissa) {
-			for amount > 10*uint64(MaxMantissa) {
-				amount /= 10
-				offset++
-			}
-			amount += 9
-			amount /= 10
-			offset++
-		}
-	}
-
-	// Create result with appropriate Number rounding mode.
-	// divRoundStrict uses upward if (roundUp ^ resultNegative), else downward.
-	var mode RoundingMode
+	mode := RoundDownward
 	if roundUp != resultNegative {
 		mode = RoundUpward
-	} else {
-		mode = RoundDownward
 	}
-	mantissa := int64(amount)
-	if resultNegative {
-		mantissa = -mantissa
-	}
-	result := NewIssuedAmountFromValueRounded(mantissa, offset, currency, issuer, mode)
+	return FinalizeRoundIOU(amount, offset, resultNegative, roundUp, currency, issuer, mode, true)
+}
 
-	// If roundUp and positive and result is zero, return minimum value
-	if roundUp && !resultNegative && result.IsZero() {
-		return NewIssuedAmountFromValue(MinMantissa, MinExponent, currency, issuer)
+// DivRoundNative divides two Amounts and returns the result as XRP drops, using
+// the native canonicalizeRound path (native=true) of rippled's divRoundImpl.
+func DivRoundNative(num, den Amount, roundUp bool) int64 {
+	if den.IsZero() {
+		panic("division by zero")
 	}
+	if num.IsZero() {
+		return 0
+	}
+	numVal, numOff := PrepareMulDivOperand(num)
+	denVal, denOff := PrepareMulDivOperand(den)
+	resultNegative := num.IsNegative() != den.IsNegative()
+	addSlop := resultNegative != roundUp
 
-	return result
+	amount := DivMantissas(numVal, denVal, addSlop)
+	offset := numOff - denOff - 17
+	amount = canonicalizeRoundNative(amount, offset, addSlop)
+	return finalizeRoundNative(amount, resultNegative, roundUp)
+}
+
+// MulRoundNative multiplies two Amounts and returns the result as XRP drops,
+// using the native canonicalizeRound path (native=true) of rippled's
+// mulRoundImpl. See canonicalizeRoundNative for the two currently-unreachable
+// faithfulness gaps (no-round truncation and the missing native×native overflow
+// Throw).
+func MulRoundNative(v1, v2 Amount, roundUp bool) int64 {
+	if v1.IsZero() || v2.IsZero() {
+		return 0
+	}
+	value1, offset1 := PrepareMulDivOperand(v1)
+	value2, offset2 := PrepareMulDivOperand(v2)
+	resultNegative := v1.IsNegative() != v2.IsNegative()
+	addSlop := resultNegative != roundUp
+
+	amount := MulMantissas(value1, value2, addSlop)
+	offset := offset1 + offset2 + 14
+	amount = canonicalizeRoundNative(amount, offset, addSlop)
+	return finalizeRoundNative(amount, resultNegative, roundUp)
 }

--- a/internal/ledger/state/amount_round_golden_test.go
+++ b/internal/ledger/state/amount_round_golden_test.go
@@ -72,8 +72,8 @@ func roundGoldenOperands() []Amount {
 
 // TestAmountRoundGolden locks the byte-exact output of every mul/div round
 // variant across a grid of IOU/native, signed, and extreme-exponent operands.
-// It guards the D1 consolidation (shared muldiv/canonicalize helpers) against
-// any behavioural drift — these feed consensus-relevant exchange-rate math.
+// It guards the shared muldiv/canonicalize helpers against any behavioural
+// drift — these feed consensus-relevant exchange-rate math.
 func TestAmountRoundGolden(t *testing.T) {
 	ops := roundGoldenOperands()
 	pairs := [][2]int{
@@ -99,8 +99,8 @@ func TestAmountRoundGolden(t *testing.T) {
 	}
 }
 
-// amountRoundGoldens returns the captured byte-exact outputs of the pre-D1
-// implementation, one signature string per operand pair.
+// amountRoundGoldens returns the captured byte-exact outputs of the
+// pre-consolidation implementation, one signature string per operand pair.
 func amountRoundGoldens() []string {
 	return []string{
 		"|ru=false MS=IOU(m=3333333333333333,e=13,neg=false,zero=false) M=IOU(m=3333333333333333,e=13,neg=false,zero=false) D=IOU(m=3000000000000000,e=-14,neg=false,zero=false) DS=IOU(m=3000000000000000,e=-14,neg=false,zero=false) DN=30 MN=-3520120672398401536|ru=true MS=IOU(m=3333333333333333,e=13,neg=false,zero=false) M=IOU(m=3333333333333333,e=13,neg=false,zero=false) D=IOU(m=3000000000000001,e=-14,neg=false,zero=false) DS=IOU(m=3000000000000001,e=-14,neg=false,zero=false) DN=30 MN=33333333333333330",

--- a/internal/ledger/state/amount_round_golden_test.go
+++ b/internal/ledger/state/amount_round_golden_test.go
@@ -1,0 +1,122 @@
+package state
+
+import (
+	"fmt"
+	"testing"
+)
+
+// goldenIssuer is an arbitrary valid issuer used only to give IOU results a
+// stable currency/issuer; the rounding math never depends on its value.
+const goldenIssuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+func fmtRoundAmt(a Amount) string {
+	if a.IsNative() {
+		return fmt.Sprintf("XRP(%d)", a.Drops())
+	}
+	return fmt.Sprintf("IOU(m=%d,e=%d,neg=%v,zero=%v)", a.Mantissa(), a.Exponent(), a.IsNegative(), a.IsZero())
+}
+
+// safeAmt / safeInt capture both the value and any panic deterministically, so
+// the golden also locks overflow/divide-by-zero panic boundaries.
+func safeAmt(f func() Amount) (out string) {
+	defer func() {
+		if r := recover(); r != nil {
+			out = fmt.Sprintf("PANIC(%v)", r)
+		}
+	}()
+	return fmtRoundAmt(f())
+}
+
+func safeInt(f func() int64) (out string) {
+	defer func() {
+		if r := recover(); r != nil {
+			out = fmt.Sprintf("PANIC(%v)", r)
+		}
+	}()
+	return fmt.Sprintf("%d", f())
+}
+
+// roundGoldenRow exercises every mul/div round variant for one operand pair and
+// both roundUp directions, returning a single deterministic signature string.
+func roundGoldenRow(a, b Amount) string {
+	const cur = "USD"
+	var s string
+	for _, ru := range []bool{false, true} {
+		s += fmt.Sprintf("|ru=%v MS=%s M=%s D=%s DS=%s DN=%s MN=%s",
+			ru,
+			safeAmt(func() Amount { return MulRoundStrict(a, b, cur, goldenIssuer, ru) }),
+			safeAmt(func() Amount { return MulRound(a, b, cur, goldenIssuer, ru) }),
+			safeAmt(func() Amount { return DivRound(a, b, cur, goldenIssuer, ru) }),
+			safeAmt(func() Amount { return DivRoundStrict(a, b, cur, goldenIssuer, ru) }),
+			safeInt(func() int64 { return DivRoundNative(a, b, ru) }),
+			safeInt(func() int64 { return MulRoundNative(a, b, ru) }),
+		)
+	}
+	return s
+}
+
+func roundGoldenOperands() []Amount {
+	return []Amount{
+		NewIssuedAmountFromValue(1000000000000000, 0, "USD", goldenIssuer),    // 10^15 e0
+		NewIssuedAmountFromValue(3333333333333333, -2, "USD", goldenIssuer),   // repeating
+		NewIssuedAmountFromValue(7000000000000000, 5, "USD", goldenIssuer),    // large exp
+		NewIssuedAmountFromValue(-2500000000000000, -10, "USD", goldenIssuer), // negative
+		NewIssuedAmountFromValue(9999999999999999, 80, "USD", goldenIssuer),   // near max exp
+		NewIssuedAmountFromValue(1000000000000001, -96, "USD", goldenIssuer),  // near min exp
+		NewXRPAmountFromInt(1000000),                                          // 1 XRP
+		NewXRPAmountFromInt(7),                                                // tiny native
+		NewXRPAmountFromInt(-123456789),                                       // negative native
+		NewXRPAmountFromInt(100000000000),                                     // large native
+	}
+}
+
+// TestAmountRoundGolden locks the byte-exact output of every mul/div round
+// variant across a grid of IOU/native, signed, and extreme-exponent operands.
+// It guards the D1 consolidation (shared muldiv/canonicalize helpers) against
+// any behavioural drift — these feed consensus-relevant exchange-rate math.
+func TestAmountRoundGolden(t *testing.T) {
+	ops := roundGoldenOperands()
+	pairs := [][2]int{
+		{0, 1}, {1, 0}, {0, 2}, {2, 3}, {3, 1}, {4, 0}, {5, 0},
+		{6, 7}, {7, 6}, {8, 6}, {9, 7}, {0, 6}, {6, 0}, {3, 8}, {2, 9},
+	}
+	want := amountRoundGoldens()
+	if len(want) != 0 && len(want) != len(pairs) {
+		t.Fatalf("golden count %d != pairs %d", len(want), len(pairs))
+	}
+	for i, p := range pairs {
+		got := roundGoldenRow(ops[p[0]], ops[p[1]])
+		if len(want) == 0 {
+			t.Logf("GOLDEN[%d] = %q,", i, got)
+			continue
+		}
+		if got != want[i] {
+			t.Errorf("pair %v (%d):\n got=%s\nwant=%s", p, i, got, want[i])
+		}
+	}
+	if len(want) == 0 {
+		t.Fatal("goldens not yet captured; copy the GOLDEN lines above into amountRoundGoldens()")
+	}
+}
+
+// amountRoundGoldens returns the captured byte-exact outputs of the pre-D1
+// implementation, one signature string per operand pair.
+func amountRoundGoldens() []string {
+	return []string{
+		"|ru=false MS=IOU(m=3333333333333333,e=13,neg=false,zero=false) M=IOU(m=3333333333333333,e=13,neg=false,zero=false) D=IOU(m=3000000000000000,e=-14,neg=false,zero=false) DS=IOU(m=3000000000000000,e=-14,neg=false,zero=false) DN=30 MN=-3520120672398401536|ru=true MS=IOU(m=3333333333333333,e=13,neg=false,zero=false) M=IOU(m=3333333333333333,e=13,neg=false,zero=false) D=IOU(m=3000000000000001,e=-14,neg=false,zero=false) DS=IOU(m=3000000000000001,e=-14,neg=false,zero=false) DN=30 MN=33333333333333330",
+		"|ru=false MS=IOU(m=3333333333333333,e=13,neg=false,zero=false) M=IOU(m=3333333333333333,e=13,neg=false,zero=false) D=IOU(m=3333333333333333,e=-17,neg=false,zero=false) DS=IOU(m=3333333333333333,e=-17,neg=false,zero=false) DN=0 MN=-3520120672398401536|ru=true MS=IOU(m=3333333333333333,e=13,neg=false,zero=false) M=IOU(m=3333333333333333,e=13,neg=false,zero=false) D=IOU(m=3333333333333333,e=-17,neg=false,zero=false) DS=IOU(m=3333333333333333,e=-17,neg=false,zero=false) DN=1 MN=33333333333333330",
+		"|ru=false MS=IOU(m=7000000000000000,e=20,neg=false,zero=false) M=IOU(m=7000000000000000,e=20,neg=false,zero=false) D=IOU(m=1428571428571428,e=-21,neg=false,zero=false) DS=IOU(m=1428571428571428,e=-21,neg=false,zero=false) DN=0 MN=3509693170864619520|ru=true MS=IOU(m=7000000000000000,e=20,neg=false,zero=false) M=IOU(m=7000000000000000,e=20,neg=false,zero=false) D=IOU(m=1428571428571429,e=-21,neg=false,zero=false) DS=IOU(m=1428571428571429,e=-21,neg=false,zero=false) DN=1 MN=70000000000000000",
+		"|ru=false MS=IOU(m=-1750000000000000,e=11,neg=true,zero=false) M=IOU(m=-1750000000000000,e=11,neg=true,zero=false) D=IOU(m=-2800000000000000,e=0,neg=true,zero=false) DS=IOU(m=-2800000000000000,e=0,neg=true,zero=false) DN=-2800000000000001 MN=-175000000000000000|ru=true MS=IOU(m=-1750000000000000,e=11,neg=true,zero=false) M=IOU(m=-1750000000000000,e=11,neg=true,zero=false) D=IOU(m=-2800000000000000,e=0,neg=true,zero=false) DS=IOU(m=-2800000000000000,e=0,neg=true,zero=false) DN=-2800000000000000 MN=-170598510725431296",
+		"|ru=false MS=IOU(m=-8333333333333333,e=3,neg=true,zero=false) M=IOU(m=-8333333333333333,e=3,neg=true,zero=false) D=IOU(m=-7500000000000001,e=-24,neg=true,zero=false) DS=IOU(m=-7500000000000001,e=-24,neg=true,zero=false) DN=0 MN=-83333333333333325|ru=true MS=IOU(m=-8333333333333332,e=3,neg=true,zero=false) M=IOU(m=-8333333333333332,e=3,neg=true,zero=false) D=IOU(m=-7500000000000000,e=-24,neg=true,zero=false) DS=IOU(m=-7500000000000000,e=-24,neg=true,zero=false) DN=0 MN=-8333333333333332500",
+		"|ru=false MS=PANIC(IOUAmount overflow) M=PANIC(IOUAmount overflow) D=IOU(m=9999999999999999,e=65,neg=false,zero=false) DS=IOU(m=9999999999999999,e=65,neg=false,zero=false) DN=0 MN=0|ru=true MS=PANIC(IOUAmount overflow) M=PANIC(IOUAmount overflow) D=IOU(m=9999999999999999,e=65,neg=false,zero=false) DS=IOU(m=9999999999999999,e=65,neg=false,zero=false) DN=999999999999999900 MN=99999999999999990",
+		"|ru=false MS=IOU(m=1000000000000001,e=-81,neg=false,zero=false) M=IOU(m=1000000000000001,e=-81,neg=false,zero=false) D=IOU(m=0,e=-100,neg=false,zero=true) DS=IOU(m=0,e=-100,neg=false,zero=true) DN=0 MN=0|ru=true MS=IOU(m=1000000000000001,e=-81,neg=false,zero=false) M=IOU(m=1000000000000001,e=-81,neg=false,zero=false) D=IOU(m=1000000000000000,e=-96,neg=false,zero=false) DS=IOU(m=1000000000000000,e=-96,neg=false,zero=false) DN=1 MN=1",
+		"|ru=false MS=IOU(m=7000000000000000,e=-9,neg=false,zero=false) M=IOU(m=7000000000000000,e=-9,neg=false,zero=false) D=IOU(m=1428571428571428,e=-10,neg=false,zero=false) DS=IOU(m=1428571428571428,e=-10,neg=false,zero=false) DN=142857 MN=7000000|ru=true MS=IOU(m=7000000000000000,e=-9,neg=false,zero=false) M=IOU(m=7000000000000000,e=-9,neg=false,zero=false) D=IOU(m=1428571428571429,e=-10,neg=false,zero=false) DS=IOU(m=1428571428571429,e=-10,neg=false,zero=false) DN=142858 MN=7000000",
+		"|ru=false MS=IOU(m=7000000000000000,e=-9,neg=false,zero=false) M=IOU(m=7000000000000000,e=-9,neg=false,zero=false) D=IOU(m=7000000000000000,e=-21,neg=false,zero=false) DS=IOU(m=7000000000000000,e=-21,neg=false,zero=false) DN=0 MN=7000000|ru=true MS=IOU(m=7000000000000000,e=-9,neg=false,zero=false) M=IOU(m=7000000000000000,e=-9,neg=false,zero=false) D=IOU(m=7000000000000000,e=-21,neg=false,zero=false) DS=IOU(m=7000000000000000,e=-21,neg=false,zero=false) DN=1 MN=7000000",
+		"|ru=false MS=IOU(m=-1234567890000000,e=-1,neg=true,zero=false) M=IOU(m=-1234567890000000,e=-1,neg=true,zero=false) D=IOU(m=-1234567890000000,e=-13,neg=true,zero=false) DS=IOU(m=-1234567890000000,e=-13,neg=true,zero=false) DN=-124 MN=-123456789000001|ru=true MS=IOU(m=-1234567890000000,e=-1,neg=true,zero=false) M=IOU(m=-1234567890000000,e=-1,neg=true,zero=false) D=IOU(m=-1234567890000000,e=-13,neg=true,zero=false) DS=IOU(m=-1234567890000000,e=-13,neg=true,zero=false) DN=-123 MN=-123456789000000",
+		"|ru=false MS=IOU(m=7000000000000000,e=-4,neg=false,zero=false) M=IOU(m=7000000000000000,e=-4,neg=false,zero=false) D=IOU(m=1428571428571428,e=-5,neg=false,zero=false) DS=IOU(m=1428571428571428,e=-5,neg=false,zero=false) DN=14285714285 MN=700000000000|ru=true MS=IOU(m=7000000000000000,e=-4,neg=false,zero=false) M=IOU(m=7000000000000000,e=-4,neg=false,zero=false) D=IOU(m=1428571428571429,e=-5,neg=false,zero=false) DS=IOU(m=1428571428571429,e=-5,neg=false,zero=false) DN=14285714286 MN=700000000000",
+		"|ru=false MS=IOU(m=1000000000000000,e=6,neg=false,zero=false) M=IOU(m=1000000000000000,e=6,neg=false,zero=false) D=IOU(m=1000000000000000,e=-6,neg=false,zero=false) DS=IOU(m=1000000000000000,e=-6,neg=false,zero=false) DN=1000000000 MN=3875820019684212736|ru=true MS=IOU(m=1000000000000000,e=6,neg=false,zero=false) M=IOU(m=1000000000000000,e=6,neg=false,zero=false) D=IOU(m=1000000000000000,e=-6,neg=false,zero=false) DS=IOU(m=1000000000000000,e=-6,neg=false,zero=false) DN=1000000000 MN=10000000000000000",
+		"|ru=false MS=IOU(m=1000000000000000,e=6,neg=false,zero=false) M=IOU(m=1000000000000000,e=6,neg=false,zero=false) D=IOU(m=1000000000000000,e=-24,neg=false,zero=false) DS=IOU(m=1000000000000000,e=-24,neg=false,zero=false) DN=0 MN=3875820019684212736|ru=true MS=IOU(m=1000000000000000,e=6,neg=false,zero=false) M=IOU(m=1000000000000000,e=6,neg=false,zero=false) D=IOU(m=1000000000000000,e=-24,neg=false,zero=false) DS=IOU(m=1000000000000000,e=-24,neg=false,zero=false) DN=1 MN=10000000000000000",
+		"|ru=false MS=IOU(m=3086419725000000,e=-2,neg=false,zero=false) M=IOU(m=3086419725000000,e=-2,neg=false,zero=false) D=IOU(m=2025000018427500,e=-18,neg=false,zero=false) DS=IOU(m=2025000018427500,e=-18,neg=false,zero=false) DN=0 MN=30864197250000|ru=true MS=IOU(m=3086419725000000,e=-2,neg=false,zero=false) M=IOU(m=3086419725000000,e=-2,neg=false,zero=false) D=IOU(m=2025000018427501,e=-18,neg=false,zero=false) DS=IOU(m=2025000018427501,e=-18,neg=false,zero=false) DN=1 MN=30864197250000",
+		"|ru=false MS=IOU(m=7000000000000000,e=16,neg=false,zero=false) M=IOU(m=7000000000000000,e=16,neg=false,zero=false) D=IOU(m=7000000000000000,e=-6,neg=false,zero=false) DS=IOU(m=7000000000000000,e=-6,neg=false,zero=false) DN=7000000000 MN=4897961520886972416|ru=true MS=IOU(m=7000000000000000,e=16,neg=false,zero=false) M=IOU(m=7000000000000000,e=16,neg=false,zero=false) D=IOU(m=7000000000000000,e=-6,neg=false,zero=false) DS=IOU(m=7000000000000000,e=-6,neg=false,zero=false) DN=7000000000 MN=70000000000000000",
+	}
+}

--- a/internal/ledger/state/oracle_entry.go
+++ b/internal/ledger/state/oracle_entry.go
@@ -295,29 +295,19 @@ func parseCurrencyBytes(b []byte) string {
 	return hex.EncodeToString(b)
 }
 
-// parseVLLength parses a variable-length field length prefix.
-// Returns the length and number of bytes consumed for the prefix.
+// parseVLLength parses a variable-length field length prefix, returning the
+// payload length and the number of prefix bytes consumed. It delegates to the
+// package's canonical readVLLength; on a malformed prefix it advances a single
+// byte (legacy semantics) so the caller's field loop still makes progress.
 func parseVLLength(data []byte) (int, int) {
-	if len(data) == 0 {
-		return 0, 0
-	}
-	b1 := int(data[0])
-	if b1 <= 192 {
-		return b1, 1
-	}
-	if b1 <= 240 {
-		if len(data) < 2 {
-			return 0, 1
+	length, prefixLen, err := readVLLength(data, 0)
+	if err != nil {
+		if len(data) == 0 {
+			return 0, 0
 		}
-		b2 := int(data[1])
-		return 193 + ((b1 - 193) * 256) + b2, 2
-	}
-	if len(data) < 3 {
 		return 0, 1
 	}
-	b2 := int(data[1])
-	b3 := int(data[2])
-	return 12481 + ((b1 - 241) * 65536) + (b2 * 256) + b3, 3
+	return length, prefixLen
 }
 
 // SerializeOracle serializes an Oracle ledger entry to binary format.

--- a/internal/ledger/state/permissioned_domain_entry.go
+++ b/internal/ledger/state/permissioned_domain_entry.go
@@ -3,7 +3,6 @@ package state
 import (
 	"encoding/hex"
 	"fmt"
-	"strconv"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 )
@@ -86,7 +85,7 @@ func ParsePermissionedDomain(data []byte) (*PermissionedDomainData, error) {
 	}
 
 	if ownerNode, ok := jsonObj["OwnerNode"].(string); ok {
-		pd.OwnerNode, _ = strconv.ParseUint(ownerNode, 16, 64)
+		pd.OwnerNode = parseUint64Hex(ownerNode)
 	}
 
 	if creds, ok := jsonObj["AcceptedCredentials"].([]any); ok {

--- a/internal/tx/amm/pool.go
+++ b/internal/tx/amm/pool.go
@@ -45,7 +45,7 @@ func ammAccountHolds(view tx.LedgerView, ammAccountID [20]byte, asset tx.Asset) 
 	// Determine balance based on canonical ordering
 	// Balance is stored from low account's perspective (positive = low owes high)
 	// For AMM: if AMM is low, positive balance means AMM holds tokens
-	ammIsLow := state.CompareAccountIDsForLine(ammAccountID, issuerID) < 0
+	ammIsLow := state.CompareAccountIDs(ammAccountID, issuerID) < 0
 	balance := rs.Balance
 	if !ammIsLow {
 		balance = balance.Negate()
@@ -125,7 +125,7 @@ func ammLPHolds(view tx.LedgerView, amm *AMMData, lpAccountID [20]byte) tx.Amoun
 	// Determine balance based on canonical ordering
 	// Balance is stored from low account's perspective (positive = low owes high)
 	// For LP tokens: if LP is low, positive balance means LP holds tokens
-	lpIsLow := state.CompareAccountIDsForLine(lpAccountID, ammAccountID) < 0
+	lpIsLow := state.CompareAccountIDs(lpAccountID, ammAccountID) < 0
 	balance := rs.Balance
 	if !lpIsLow {
 		balance = balance.Negate()

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -697,7 +697,7 @@ func createTrustLineForCheckCash(ctx *tx.ApplyContext, destID, issuerID [20]byte
 	}
 	destNoRipple := destAccount.Flags&state.LsfDefaultRipple == 0
 
-	destLow := state.CompareAccountIDsForLine(destID, issuerID) < 0
+	destLow := state.CompareAccountIDs(destID, issuerID) < 0
 
 	result := tx.TrustCreate(ctx.View, tx.TrustCreateParams{
 		SrcHigh:     destLow,

--- a/internal/tx/escrow/token_helpers.go
+++ b/internal/tx/escrow/token_helpers.go
@@ -59,10 +59,10 @@ func escrowCreatePreclaimIOU(view tx.LedgerView, accountID, destID [20]byte, amo
 	// Reference: rippled lines 232-237
 	// If balance is positive, issuer must have higher address than account
 	// If balance is negative, issuer must have lower address than account
-	if rs.Balance.Signum() > 0 && state.CompareAccountIDsForLine(issuerID, accountID) < 0 {
+	if rs.Balance.Signum() > 0 && state.CompareAccountIDs(issuerID, accountID) < 0 {
 		return tx.TecNO_PERMISSION
 	}
-	if rs.Balance.Signum() < 0 && state.CompareAccountIDsForLine(issuerID, accountID) > 0 {
+	if rs.Balance.Signum() < 0 && state.CompareAccountIDs(issuerID, accountID) > 0 {
 		return tx.TecNO_PERMISSION
 	}
 
@@ -445,8 +445,8 @@ func escrowUnlockIOU(
 
 	senderIsIssuer := issuerID == senderID
 	receiverIsIssuer := issuerID == receiverID
-	recvLow := state.CompareAccountIDsForLine(receiverID, issuerID) < 0
-	issuerHigh := state.CompareAccountIDsForLine(issuerID, receiverID) > 0
+	recvLow := state.CompareAccountIDs(receiverID, issuerID) < 0
+	issuerHigh := state.CompareAccountIDs(issuerID, receiverID) > 0
 
 	// Sender should never be the issuer for a locked escrow
 	if senderIsIssuer {
@@ -757,7 +757,7 @@ func requireAuthIOU(view tx.LedgerView, issuerID, accountID [20]byte, currency s
 	// Reference: rippled — if (account > issue.account) check lsfLowAuth else lsfHighAuth
 	// When account > issuer: issuer is the LOW account → check LsfLowAuth
 	// When account < issuer: issuer is the HIGH account → check LsfHighAuth
-	if state.CompareAccountIDsForLine(accountID, issuerID) > 0 {
+	if state.CompareAccountIDs(accountID, issuerID) > 0 {
 		if rs.Flags&state.LsfLowAuth == 0 {
 			return tx.TecNO_AUTH
 		}
@@ -1032,7 +1032,7 @@ func rippleCreditEscrow(view tx.LedgerView, payerID, payeeID [20]byte, amount tx
 		return tx.TefINTERNAL
 	}
 
-	payerIsLow := state.CompareAccountIDsForLine(payerID, payeeID) < 0
+	payerIsLow := state.CompareAccountIDs(payerID, payeeID) < 0
 	if payerIsLow {
 		newBalance, err := rs.Balance.Sub(amount)
 		if err != nil {
@@ -1191,7 +1191,7 @@ func accountHoldsIOU(view tx.LedgerView, accountID, issuerID [20]byte, currency 
 	}
 
 	// Determine balance based on canonical ordering
-	accountIsLow := state.CompareAccountIDsForLine(accountID, issuerID) < 0
+	accountIsLow := state.CompareAccountIDs(accountID, issuerID) < 0
 	balance := rs.Balance
 	if !accountIsLow {
 		balance = balance.Negate()

--- a/internal/tx/escrow/token_owner_count_test.go
+++ b/internal/tx/escrow/token_owner_count_test.go
@@ -157,7 +157,7 @@ func TestEscrowTokenCreate_OwnerCountBumpGate(t *testing.T) {
 	})
 
 	t.Run("trust line finish bumps vs cancel does not", func(t *testing.T) {
-		recvLow := state.CompareAccountIDsForLine(holder, issuer) < 0
+		recvLow := state.CompareAccountIDs(holder, issuer) < 0
 
 		// Finish: bump the receiver.
 		vf := newMapView()

--- a/internal/tx/invariants/amm.go
+++ b/internal/tx/invariants/amm.go
@@ -131,7 +131,7 @@ func ammAccountHoldsForInvariant(view ReadView, ammAccountID [20]byte, asset Ass
 	// Determine balance based on canonical ordering
 	// Balance is stored from low account's perspective
 	// AMM account is always the "holder" side
-	ammIsLow := state.CompareAccountIDsForLine(ammAccountID, issuerID) < 0
+	ammIsLow := state.CompareAccountIDs(ammAccountID, issuerID) < 0
 	balance := rs.Balance
 	if !ammIsLow {
 		balance = balance.Negate()

--- a/internal/tx/invariants/predicate_residuals_test.go
+++ b/internal/tx/invariants/predicate_residuals_test.go
@@ -225,7 +225,7 @@ func TestValidAMM_CreateToleranceAbsorbsULP(t *testing.T) {
 		Account: addrHolderA, Balance: 25_000_000, Sequence: 1,
 	})
 
-	ammIsLow := state.CompareAccountIDsForLine(ammID, issuerID) < 0
+	ammIsLow := state.CompareAccountIDs(ammID, issuerID) < 0
 	bal, _ := state.NewIssuedAmountFromDecimalString("250000000", "USD", state.AccountOneAddress)
 	if !ammIsLow {
 		bal = bal.Negate()

--- a/internal/tx/nftoken/iou_helpers.go
+++ b/internal/tx/nftoken/iou_helpers.go
@@ -52,7 +52,7 @@ func checkNFTTrustlineAuthorized(view tx.LedgerView, accountID [20]byte, currenc
 	// Reference: rippled — if (id > issue.account) check lsfLowAuth else lsfHighAuth
 	// When id > issuer: issuer is the LOW account → check LsfLowAuth (issuer's auth flag)
 	// When id < issuer: issuer is the HIGH account → check LsfHighAuth (issuer's auth flag)
-	if state.CompareAccountIDsForLine(accountID, issuerID) > 0 {
+	if state.CompareAccountIDs(accountID, issuerID) > 0 {
 		if rs.Flags&state.LsfLowAuth == 0 {
 			return tx.TecNO_AUTH
 		}
@@ -203,7 +203,7 @@ func rippleCreditIOU(view tx.LedgerView, sender, receiver [20]byte, amount tx.Am
 	// Balance is stored from the low account's perspective (positive = low holds).
 	// Sending decreases the sender's holding: subtract when the sender is low,
 	// add when the sender is high.
-	senderIsLow := state.CompareAccountIDsForLine(sender, receiver) < 0
+	senderIsLow := state.CompareAccountIDs(sender, receiver) < 0
 	oldBalance := rs.Balance
 	var newBalance tx.Amount
 	if senderIsLow {
@@ -398,7 +398,7 @@ func accountIOUBalanceSignum(view tx.LedgerView, accountID [20]byte, amount tx.A
 		return 0
 	}
 
-	accountIsLow := state.CompareAccountIDsForLine(accountID, issuerID) < 0
+	accountIsLow := state.CompareAccountIDs(accountID, issuerID) < 0
 	balance := rs.Balance
 	if !accountIsLow {
 		balance = balance.Negate()
@@ -430,7 +430,7 @@ func accountHoldsIOU(view tx.LedgerView, accountID [20]byte, amount tx.Amount) t
 		return tx.NewIssuedAmount(0, 0, amount.Currency, amount.Issuer)
 	}
 
-	accountIsLow := state.CompareAccountIDsForLine(accountID, issuerID) < 0
+	accountIsLow := state.CompareAccountIDs(accountID, issuerID) < 0
 	balance := rs.Balance
 	if !accountIsLow {
 		balance = balance.Negate()
@@ -449,7 +449,7 @@ func accountHoldsIOU(view tx.LedgerView, accountID [20]byte, amount tx.Amount) t
 // NoRipple flags are set based on each account's DefaultRipple setting.
 // Reference: rippled Ledger/View.cpp rippleCredit → trustCreate
 func createTrustLineWithBalance(view tx.LedgerView, sender, receiver [20]byte, amount tx.Amount, trustLineKey keylet.Keylet) tx.Result {
-	senderIsHigh := state.CompareAccountIDsForLine(sender, receiver) > 0
+	senderIsHigh := state.CompareAccountIDs(sender, receiver) > 0
 
 	// Determine low/high accounts
 	var lowAccountID, highAccountID [20]byte

--- a/internal/tx/offer/offer_create_validate.go
+++ b/internal/tx/offer/offer_create_validate.go
@@ -250,7 +250,7 @@ func checkAcceptAsset(view tx.LedgerView, accountID, issuerID [20]byte, currency
 		}
 
 		// Check authorization based on canonical ordering
-		canonicalGT := state.CompareAccountIDsForLine(accountID, issuerID) > 0
+		canonicalGT := state.CompareAccountIDs(accountID, issuerID) > 0
 		var isAuthorized bool
 		if canonicalGT {
 			isAuthorized = (rs.Flags & state.LsfLowAuth) != 0

--- a/internal/tx/offer/offer_quality.go
+++ b/internal/tx/offer/offer_quality.go
@@ -16,13 +16,18 @@ const (
 )
 
 // offerNativeDrops finalizes a muldiv-round magnitude as XRP drops. When
-// rounding away from zero (addSlop), canon is the payment-layer native
-// canonicalize result; otherwise the magnitude is rescaled to drops by
-// truncation. A positive round-up that collapses to zero yields 1 drop.
-func offerNativeDrops(amount uint64, offset int, resultNegative, roundUp, addSlop bool, canon int64) tx.Amount {
+// rounding away from zero (addSlop) it canonicalizes via the payment-layer
+// native canonicalize — strict selects the round-mode-aware variant; otherwise
+// the magnitude is rescaled to drops by truncation. A positive round-up that
+// collapses to zero yields 1 drop.
+func offerNativeDrops(amount uint64, offset int, resultNegative, roundUp, addSlop, strict bool) tx.Amount {
 	var drops int64
 	if addSlop {
-		drops = canon
+		if strict {
+			drops = payment.CanonicalizeDropsStrict(int64(amount), offset, roundUp)
+		} else {
+			drops = payment.CanonicalizeDrops(int64(amount), offset)
+		}
 	} else {
 		drops = int64(amount)
 		for offset > 0 {
@@ -62,8 +67,7 @@ func offerDivRound(num, den tx.Amount, native bool, currency, issuer string, rou
 	amount := state.DivMantissas(numVal, denVal, addSlop)
 	offset := numOff - denOff - 17
 	if native {
-		return offerNativeDrops(amount, offset, resultNegative, roundUp, addSlop,
-			payment.CanonicalizeDrops(int64(amount), offset))
+		return offerNativeDrops(amount, offset, resultNegative, roundUp, addSlop, false)
 	}
 	if addSlop {
 		amount, offset = state.CanonicalizeRoundIOUOverflow(amount, offset)
@@ -88,8 +92,7 @@ func offerDivRoundStrict(num, den tx.Amount, native bool, currency, issuer strin
 	amount := state.DivMantissas(numVal, denVal, addSlop)
 	offset := numOff - denOff - 17
 	if native {
-		return offerNativeDrops(amount, offset, resultNegative, roundUp, addSlop,
-			payment.CanonicalizeDropsStrict(int64(amount), offset, roundUp))
+		return offerNativeDrops(amount, offset, resultNegative, roundUp, addSlop, true)
 	}
 	if addSlop {
 		amount, offset = state.CanonicalizeRoundIOUOverflow(amount, offset)
@@ -118,8 +121,7 @@ func offerMulRound(v1, v2 tx.Amount, native bool, currency, issuer string, round
 	amount := state.MulMantissas(value1, value2, addSlop)
 	offset := offset1 + offset2 + 14
 	if native {
-		return offerNativeDrops(amount, offset, resultNegative, roundUp, addSlop,
-			payment.CanonicalizeDrops(int64(amount), offset))
+		return offerNativeDrops(amount, offset, resultNegative, roundUp, addSlop, false)
 	}
 	if addSlop {
 		amount, offset = state.CanonicalizeRoundIOUOverflow(amount, offset)

--- a/internal/tx/offer/offer_quality.go
+++ b/internal/tx/offer/offer_quality.go
@@ -15,10 +15,38 @@ const (
 	maxTickSize uint8 = 15
 )
 
-// offerDivRound divides num by den using rippled's divRound (non-strict) algorithm
-// with native-aware canonicalization. When native=true, uses canonicalizeRound for
-// XRP drops; when native=false, uses IOU canonicalize.
-// Reference: rippled STAmount.cpp divRoundImpl with canonicalizeRound + DontAffectNumberRoundMode
+// offerNativeDrops finalizes a muldiv-round magnitude as XRP drops. When
+// rounding away from zero (addSlop), canon is the payment-layer native
+// canonicalize result; otherwise the magnitude is rescaled to drops by
+// truncation. A positive round-up that collapses to zero yields 1 drop.
+func offerNativeDrops(amount uint64, offset int, resultNegative, roundUp, addSlop bool, canon int64) tx.Amount {
+	var drops int64
+	if addSlop {
+		drops = canon
+	} else {
+		drops = int64(amount)
+		for offset > 0 {
+			drops *= 10
+			offset--
+		}
+		for offset < 0 {
+			drops /= 10
+			offset++
+		}
+	}
+	if drops == 0 && roundUp && !resultNegative {
+		drops = 1
+	}
+	if resultNegative {
+		drops = -drops
+	}
+	return tx.NewXRPAmount(drops)
+}
+
+// offerDivRound divides num by den using rippled's divRound (non-strict)
+// algorithm with native-aware canonicalization. The muldiv and IOU-overflow
+// canonicalize core is shared with the state package; the native (XRP-drops)
+// path and the zero-returns-zero contract are offer-layer specifics.
 func offerDivRound(num, den tx.Amount, native bool, currency, issuer string, roundUp bool) tx.Amount {
 	if den.IsZero() || num.IsZero() {
 		if native {
@@ -26,111 +54,25 @@ func offerDivRound(num, den tx.Amount, native bool, currency, issuer string, rou
 		}
 		return tx.NewIssuedAmount(0, -100, currency, issuer)
 	}
-
-	numVal := num.Mantissa()
-	numOff := num.Exponent()
-	denVal := den.Mantissa()
-	denOff := den.Exponent()
-
-	if num.IsNative() {
-		if numVal < 0 {
-			numVal = -numVal
-		}
-		for numVal < state.MinMantissa {
-			numVal *= 10
-			numOff--
-		}
-	}
-	if den.IsNative() {
-		if denVal < 0 {
-			denVal = -denVal
-		}
-		for denVal < state.MinMantissa {
-			denVal *= 10
-			denOff--
-		}
-	}
-
+	numVal, numOff := state.PrepareMulDivOperand(num)
+	denVal, denOff := state.PrepareMulDivOperand(den)
 	resultNegative := num.IsNegative() != den.IsNegative()
+	addSlop := resultNegative != roundUp
 
-	if numVal < 0 {
-		numVal = -numVal
-	}
-	if denVal < 0 {
-		denVal = -denVal
-	}
-
-	// muldiv_round: (numVal * 10^17 + rounding) / denVal
-	tenTo17 := new(big.Int).Exp(big.NewInt(10), big.NewInt(17), nil)
-	numerator := new(big.Int).Mul(big.NewInt(numVal), tenTo17)
-	if resultNegative != roundUp {
-		numerator.Add(numerator, new(big.Int).Sub(big.NewInt(denVal), big.NewInt(1)))
-	}
-	quotient := new(big.Int).Div(numerator, big.NewInt(denVal))
-	amount := quotient.Uint64()
+	amount := state.DivMantissas(numVal, denVal, addSlop)
 	offset := numOff - denOff - 17
-
-	if resultNegative != roundUp {
-		if native {
-			// canonicalizeRound for native (XRP drops)
-			drops := payment.CanonicalizeDrops(int64(amount), offset)
-			// Fallback: if rounding up produced zero, return minimum positive (1 drop).
-			// Reference: rippled STAmount.cpp divRoundImpl lines 1720-1726
-			if drops == 0 && roundUp && !resultNegative {
-				drops = 1
-			}
-			if resultNegative {
-				drops = -drops
-			}
-			return tx.NewXRPAmount(drops)
-		}
-		// canonicalizeRound for IOU
-		if amount > uint64(state.MaxMantissa) {
-			for amount > 10*uint64(state.MaxMantissa) {
-				amount /= 10
-				offset++
-			}
-			amount += 9
-			amount /= 10
-			offset++
-		}
-	} else if native {
-		// No canonicalize needed, but still need to convert to drops
-		drops := int64(amount)
-		for offset > 0 {
-			drops *= 10
-			offset--
-		}
-		for offset < 0 {
-			drops /= 10
-			offset++
-		}
-		if resultNegative {
-			drops = -drops
-		}
-		return tx.NewXRPAmount(drops)
+	if native {
+		return offerNativeDrops(amount, offset, resultNegative, roundUp, addSlop,
+			payment.CanonicalizeDrops(int64(amount), offset))
 	}
-
-	// DontAffectNumberRoundMode: NO guard
-	mantissa := int64(amount)
-	if resultNegative {
-		mantissa = -mantissa
+	if addSlop {
+		amount, offset = state.CanonicalizeRoundIOUOverflow(amount, offset)
 	}
-	result := state.NewIssuedAmountFromValue(mantissa, offset, currency, issuer)
-
-	if roundUp && !resultNegative && result.IsZero() {
-		if native {
-			return tx.NewXRPAmount(1)
-		}
-		return state.NewIssuedAmountFromValue(state.MinMantissa, state.MinExponent, currency, issuer)
-	}
-
-	return result
+	return state.FinalizeRoundIOU(amount, offset, resultNegative, roundUp, currency, issuer, 0, false)
 }
 
-// offerDivRoundStrict divides num by den using rippled's divRoundStrict algorithm
-// with native-aware canonicalization.
-// Reference: rippled STAmount.cpp divRoundImpl with canonicalizeRoundStrict + NumberRoundModeGuard
+// offerDivRoundStrict divides num by den using rippled's divRoundStrict
+// algorithm with native-aware canonicalization.
 func offerDivRoundStrict(num, den tx.Amount, native bool, currency, issuer string, roundUp bool) tx.Amount {
 	if den.IsZero() || num.IsZero() {
 		if native {
@@ -138,118 +80,29 @@ func offerDivRoundStrict(num, den tx.Amount, native bool, currency, issuer strin
 		}
 		return tx.NewIssuedAmount(0, -100, currency, issuer)
 	}
-
-	numVal := num.Mantissa()
-	numOff := num.Exponent()
-	denVal := den.Mantissa()
-	denOff := den.Exponent()
-
-	if num.IsNative() {
-		if numVal < 0 {
-			numVal = -numVal
-		}
-		for numVal < state.MinMantissa {
-			numVal *= 10
-			numOff--
-		}
-	}
-	if den.IsNative() {
-		if denVal < 0 {
-			denVal = -denVal
-		}
-		for denVal < state.MinMantissa {
-			denVal *= 10
-			denOff--
-		}
-	}
-
+	numVal, numOff := state.PrepareMulDivOperand(num)
+	denVal, denOff := state.PrepareMulDivOperand(den)
 	resultNegative := num.IsNegative() != den.IsNegative()
+	addSlop := resultNegative != roundUp
 
-	if numVal < 0 {
-		numVal = -numVal
-	}
-	if denVal < 0 {
-		denVal = -denVal
-	}
-
-	// muldiv_round: (numVal * 10^17 + rounding) / denVal
-	tenTo17 := new(big.Int).SetUint64(100_000_000_000_000_000) // 10^17
-	bigNum := new(big.Int).Mul(big.NewInt(numVal), tenTo17)
-	bigDen := new(big.Int).SetInt64(denVal)
-	if resultNegative != roundUp {
-		bigNum.Add(bigNum, new(big.Int).Sub(bigDen, big.NewInt(1)))
-	}
-	bigResult := new(big.Int).Div(bigNum, bigDen)
-
-	amount := bigResult.Uint64()
+	amount := state.DivMantissas(numVal, denVal, addSlop)
 	offset := numOff - denOff - 17
-
-	if resultNegative != roundUp {
-		if native {
-			// canonicalizeRoundStrict for native (XRP drops)
-			drops := payment.CanonicalizeDropsStrict(int64(amount), offset, roundUp)
-			// Fallback: if rounding up produced zero, return minimum positive (1 drop).
-			// Reference: rippled STAmount.cpp divRoundImpl lines 1720-1726
-			if drops == 0 && roundUp && !resultNegative {
-				drops = 1
-			}
-			if resultNegative {
-				drops = -drops
-			}
-			return tx.NewXRPAmount(drops)
-		}
-		// canonicalizeRoundStrict for IOU
-		if amount > uint64(state.MaxMantissa) {
-			for amount > 10*uint64(state.MaxMantissa) {
-				amount /= 10
-				offset++
-			}
-			amount += 9
-			amount /= 10
-			offset++
-		}
-	} else if native {
-		// No canonicalize needed (resultNegative == roundUp), just convert to drops
-		drops := int64(amount)
-		for offset > 0 {
-			drops *= 10
-			offset--
-		}
-		for offset < 0 {
-			drops /= 10
-			offset++
-		}
-		if resultNegative {
-			drops = -drops
-		}
-		return tx.NewXRPAmount(drops)
+	if native {
+		return offerNativeDrops(amount, offset, resultNegative, roundUp, addSlop,
+			payment.CanonicalizeDropsStrict(int64(amount), offset, roundUp))
 	}
-
-	var mode state.RoundingMode
+	if addSlop {
+		amount, offset = state.CanonicalizeRoundIOUOverflow(amount, offset)
+	}
+	mode := state.RoundDownward
 	if roundUp != resultNegative {
 		mode = state.RoundUpward
-	} else {
-		mode = state.RoundDownward
 	}
-	mantissa := int64(amount)
-	if resultNegative {
-		mantissa = -mantissa
-	}
-	result := state.NewIssuedAmountFromValueRounded(mantissa, offset, currency, issuer, mode)
-
-	if roundUp && !resultNegative && result.IsZero() {
-		if native {
-			return tx.NewXRPAmount(1)
-		}
-		return state.NewIssuedAmountFromValue(state.MinMantissa, state.MinExponent, currency, issuer)
-	}
-
-	return result
+	return state.FinalizeRoundIOU(amount, offset, resultNegative, roundUp, currency, issuer, mode, true)
 }
 
-// offerMulRound multiplies v1 by v2 using rippled's mulRound (non-strict) algorithm
-// with native-aware canonicalization.
-// Reference: rippled STAmount.cpp mulRoundImpl with canonicalizeRound + DontAffectNumberRoundMode
+// offerMulRound multiplies v1 by v2 using rippled's mulRound (non-strict)
+// algorithm with native-aware canonicalization.
 func offerMulRound(v1, v2 tx.Amount, native bool, currency, issuer string, roundUp bool) tx.Amount {
 	if v1.IsZero() || v2.IsZero() {
 		if native {
@@ -257,109 +110,21 @@ func offerMulRound(v1, v2 tx.Amount, native bool, currency, issuer string, round
 		}
 		return tx.NewIssuedAmount(0, -100, currency, issuer)
 	}
-
-	value1 := v1.Mantissa()
-	offset1 := v1.Exponent()
-	value2 := v2.Mantissa()
-	offset2 := v2.Exponent()
-
-	if v1.IsNative() {
-		if value1 < 0 {
-			value1 = -value1
-		}
-		for value1 < state.MinMantissa {
-			value1 *= 10
-			offset1--
-		}
-	}
-	if v2.IsNative() {
-		if value2 < 0 {
-			value2 = -value2
-		}
-		for value2 < state.MinMantissa {
-			value2 *= 10
-			offset2--
-		}
-	}
-
+	value1, offset1 := state.PrepareMulDivOperand(v1)
+	value2, offset2 := state.PrepareMulDivOperand(v2)
 	resultNegative := v1.IsNegative() != v2.IsNegative()
+	addSlop := resultNegative != roundUp
 
-	if value1 < 0 {
-		value1 = -value1
-	}
-	if value2 < 0 {
-		value2 = -value2
-	}
-
-	// muldiv_round: (value1 * value2 + rounding) / 10^14
-	tenTo14 := new(big.Int).SetUint64(100_000_000_000_000)
-	tenTo14m1 := new(big.Int).SetUint64(99_999_999_999_999)
-	product := new(big.Int).Mul(big.NewInt(value1), big.NewInt(value2))
-	if resultNegative != roundUp {
-		product.Add(product, tenTo14m1)
-	}
-	product.Div(product, tenTo14)
-
-	amount := product.Uint64()
+	amount := state.MulMantissas(value1, value2, addSlop)
 	offset := offset1 + offset2 + 14
-
-	if resultNegative != roundUp {
-		if native {
-			// canonicalizeRound for native (XRP drops)
-			drops := payment.CanonicalizeDrops(int64(amount), offset)
-			// Fallback: if rounding up produced zero, return minimum positive (1 drop).
-			// Reference: rippled STAmount.cpp mulRoundImpl lines 1624-1630:
-			//   if (roundUp && !resultNegative && !result) { amount = 1; offset = 0; }
-			if drops == 0 && roundUp && !resultNegative {
-				drops = 1
-			}
-			if resultNegative {
-				drops = -drops
-			}
-			return tx.NewXRPAmount(drops)
-		}
-		// canonicalizeRound for IOU
-		if amount > uint64(state.MaxMantissa) {
-			for amount > 10*uint64(state.MaxMantissa) {
-				amount /= 10
-				offset++
-			}
-			amount += 9
-			amount /= 10
-			offset++
-		}
-	} else if native {
-		// No canonicalize needed (resultNegative == roundUp), just convert to drops
-		drops := int64(amount)
-		for offset > 0 {
-			drops *= 10
-			offset--
-		}
-		for offset < 0 {
-			drops /= 10
-			offset++
-		}
-		if resultNegative {
-			drops = -drops
-		}
-		return tx.NewXRPAmount(drops)
+	if native {
+		return offerNativeDrops(amount, offset, resultNegative, roundUp, addSlop,
+			payment.CanonicalizeDrops(int64(amount), offset))
 	}
-
-	// DontAffectNumberRoundMode: NO guard
-	mantissa := int64(amount)
-	if resultNegative {
-		mantissa = -mantissa
+	if addSlop {
+		amount, offset = state.CanonicalizeRoundIOUOverflow(amount, offset)
 	}
-	result := state.NewIssuedAmountFromValue(mantissa, offset, currency, issuer)
-
-	if roundUp && !resultNegative && result.IsZero() {
-		if native {
-			return tx.NewXRPAmount(1)
-		}
-		return state.NewIssuedAmountFromValue(state.MinMantissa, state.MinExponent, currency, issuer)
-	}
-
-	return result
+	return state.FinalizeRoundIOU(amount, offset, resultNegative, roundUp, currency, issuer, 0, false)
 }
 
 // applyTickSize applies tick size rounding to offer amounts.

--- a/internal/tx/offer/offer_quality_golden_test.go
+++ b/internal/tx/offer/offer_quality_golden_test.go
@@ -1,0 +1,101 @@
+package offer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+const goldenIssuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+func fmtOfferAmt(a tx.Amount) string {
+	if a.IsNative() {
+		return fmt.Sprintf("XRP(%d)", a.Drops())
+	}
+	return fmt.Sprintf("IOU(m=%d,e=%d,neg=%v,zero=%v)", a.Mantissa(), a.Exponent(), a.IsNegative(), a.IsZero())
+}
+
+func safeOfferAmt(f func() tx.Amount) (out string) {
+	defer func() {
+		if r := recover(); r != nil {
+			out = fmt.Sprintf("PANIC(%v)", r)
+		}
+	}()
+	return fmtOfferAmt(f())
+}
+
+// offerGoldenRow exercises every offer mul/div round variant for one operand
+// pair, in both native and IOU output modes and both rounding directions.
+func offerGoldenRow(a, b tx.Amount) string {
+	var s string
+	for _, native := range []bool{false, true} {
+		cur, iss := "USD", goldenIssuer
+		if native {
+			cur, iss = "", ""
+		}
+		for _, ru := range []bool{false, true} {
+			s += fmt.Sprintf("|n=%v ru=%v D=%s DS=%s M=%s",
+				native, ru,
+				safeOfferAmt(func() tx.Amount { return offerDivRound(a, b, native, cur, iss, ru) }),
+				safeOfferAmt(func() tx.Amount { return offerDivRoundStrict(a, b, native, cur, iss, ru) }),
+				safeOfferAmt(func() tx.Amount { return offerMulRound(a, b, native, cur, iss, ru) }),
+			)
+		}
+	}
+	return s
+}
+
+func offerGoldenOperands() []tx.Amount {
+	return []tx.Amount{
+		tx.NewIssuedAmount(1000000000000000, 0, "USD", goldenIssuer),
+		tx.NewIssuedAmount(3333333333333333, -2, "USD", goldenIssuer),
+		tx.NewIssuedAmount(7000000000000000, -3, "USD", goldenIssuer),
+		tx.NewIssuedAmount(-2500000000000000, -10, "USD", goldenIssuer),
+		tx.NewXRPAmount(1000000),
+		tx.NewXRPAmount(7),
+		tx.NewXRPAmount(123456789),
+	}
+}
+
+// TestOfferRoundGolden locks the byte-exact output of the offer-package
+// native-aware mul/div round variants. These feed offer-crossing exchange-rate
+// math, so the D1 consolidation onto the shared state core must not drift.
+func TestOfferRoundGolden(t *testing.T) {
+	ops := offerGoldenOperands()
+	pairs := [][2]int{
+		{0, 1}, {1, 2}, {2, 3}, {3, 0}, {4, 5}, {5, 4}, {6, 4}, {0, 4}, {4, 0}, {2, 6},
+	}
+	want := offerRoundGoldens()
+	if len(want) != 0 && len(want) != len(pairs) {
+		t.Fatalf("golden count %d != pairs %d", len(want), len(pairs))
+	}
+	for i, p := range pairs {
+		got := offerGoldenRow(ops[p[0]], ops[p[1]])
+		if len(want) == 0 {
+			t.Logf("GOLDEN[%d] = %q,", i, got)
+			continue
+		}
+		if got != want[i] {
+			t.Errorf("pair %v (%d):\n got=%s\nwant=%s", p, i, got, want[i])
+		}
+	}
+	if len(want) == 0 {
+		t.Fatal("goldens not yet captured")
+	}
+}
+
+func offerRoundGoldens() []string {
+	return []string{
+		"|n=false ru=false D=IOU(m=3000000000000000,e=-14,neg=false,zero=false) DS=IOU(m=3000000000000000,e=-14,neg=false,zero=false) M=IOU(m=3333333333333333,e=13,neg=false,zero=false)|n=false ru=true D=IOU(m=3000000000000001,e=-14,neg=false,zero=false) DS=IOU(m=3000000000000001,e=-14,neg=false,zero=false) M=IOU(m=3333333333333333,e=13,neg=false,zero=false)|n=true ru=false D=XRP(30) DS=XRP(30) M=XRP(-3520120672398401536)|n=true ru=true D=XRP(30) DS=XRP(31) M=XRP(-3520120672398401536)",
+		"|n=false ru=false D=IOU(m=4761904761904761,e=-15,neg=false,zero=false) DS=IOU(m=4761904761904761,e=-15,neg=false,zero=false) M=IOU(m=2333333333333333,e=11,neg=false,zero=false)|n=false ru=true D=IOU(m=4761904761904762,e=-15,neg=false,zero=false) DS=IOU(m=4761904761904762,e=-15,neg=false,zero=false) M=IOU(m=2333333333333334,e=11,neg=false,zero=false)|n=true ru=false D=XRP(4) DS=XRP(4) M=XRP(6376379348870425600)|n=true ru=true D=XRP(5) DS=XRP(5) M=XRP(6376379348870425600)",
+		"|n=false ru=false D=IOU(m=-2800000000000000,e=-8,neg=true,zero=false) DS=IOU(m=-2800000000000000,e=-8,neg=true,zero=false) M=IOU(m=-1750000000000000,e=3,neg=true,zero=false)|n=false ru=true D=IOU(m=-2800000000000000,e=-8,neg=true,zero=false) DS=IOU(m=-2800000000000000,e=-8,neg=true,zero=false) M=IOU(m=-1750000000000000,e=3,neg=true,zero=false)|n=true ru=false D=XRP(-28000000) DS=XRP(-28000000) M=XRP(-1750000000000000000)|n=true ru=true D=XRP(-28000000) DS=XRP(-28000000) M=XRP(-1750000000000000000)",
+		"|n=false ru=false D=IOU(m=-2500000000000000,e=-25,neg=true,zero=false) DS=IOU(m=-2500000000000000,e=-25,neg=true,zero=false) M=IOU(m=-2500000000000000,e=5,neg=true,zero=false)|n=false ru=true D=IOU(m=-2500000000000000,e=-25,neg=true,zero=false) DS=IOU(m=-2500000000000000,e=-25,neg=true,zero=false) M=IOU(m=-2500000000000000,e=5,neg=true,zero=false)|n=true ru=false D=XRP(0) DS=XRP(0) M=XRP(8254417031933722624)|n=true ru=true D=XRP(0) DS=XRP(0) M=XRP(8254417031933722624)",
+		"|n=false ru=false D=IOU(m=1428571428571428,e=-10,neg=false,zero=false) DS=IOU(m=1428571428571428,e=-10,neg=false,zero=false) M=IOU(m=7000000000000000,e=-9,neg=false,zero=false)|n=false ru=true D=IOU(m=1428571428571429,e=-10,neg=false,zero=false) DS=IOU(m=1428571428571429,e=-10,neg=false,zero=false) M=IOU(m=7000000000000000,e=-9,neg=false,zero=false)|n=true ru=false D=XRP(142857) DS=XRP(142857) M=XRP(7000000)|n=true ru=true D=XRP(142858) DS=XRP(142858) M=XRP(7000000)",
+		"|n=false ru=false D=IOU(m=7000000000000000,e=-21,neg=false,zero=false) DS=IOU(m=7000000000000000,e=-21,neg=false,zero=false) M=IOU(m=7000000000000000,e=-9,neg=false,zero=false)|n=false ru=true D=IOU(m=7000000000000000,e=-21,neg=false,zero=false) DS=IOU(m=7000000000000000,e=-21,neg=false,zero=false) M=IOU(m=7000000000000000,e=-9,neg=false,zero=false)|n=true ru=false D=XRP(0) DS=XRP(0) M=XRP(7000000)|n=true ru=true D=XRP(1) DS=XRP(1) M=XRP(7000000)",
+		"|n=false ru=false D=IOU(m=1234567890000000,e=-13,neg=false,zero=false) DS=IOU(m=1234567890000000,e=-13,neg=false,zero=false) M=IOU(m=1234567890000000,e=-1,neg=false,zero=false)|n=false ru=true D=IOU(m=1234567890000000,e=-13,neg=false,zero=false) DS=IOU(m=1234567890000000,e=-13,neg=false,zero=false) M=IOU(m=1234567890000000,e=-1,neg=false,zero=false)|n=true ru=false D=XRP(123) DS=XRP(123) M=XRP(123456789000000)|n=true ru=true D=XRP(124) DS=XRP(124) M=XRP(123456789000001)",
+		"|n=false ru=false D=IOU(m=1000000000000000,e=-6,neg=false,zero=false) DS=IOU(m=1000000000000000,e=-6,neg=false,zero=false) M=IOU(m=1000000000000000,e=6,neg=false,zero=false)|n=false ru=true D=IOU(m=1000000000000000,e=-6,neg=false,zero=false) DS=IOU(m=1000000000000000,e=-6,neg=false,zero=false) M=IOU(m=1000000000000000,e=6,neg=false,zero=false)|n=true ru=false D=XRP(1000000000) DS=XRP(1000000000) M=XRP(3875820019684212736)|n=true ru=true D=XRP(1000000000) DS=XRP(1000000000) M=XRP(3875820019684212736)",
+		"|n=false ru=false D=IOU(m=1000000000000000,e=-24,neg=false,zero=false) DS=IOU(m=1000000000000000,e=-24,neg=false,zero=false) M=IOU(m=1000000000000000,e=6,neg=false,zero=false)|n=false ru=true D=IOU(m=1000000000000000,e=-24,neg=false,zero=false) DS=IOU(m=1000000000000000,e=-24,neg=false,zero=false) M=IOU(m=1000000000000000,e=6,neg=false,zero=false)|n=true ru=false D=XRP(0) DS=XRP(0) M=XRP(3875820019684212736)|n=true ru=true D=XRP(1) DS=XRP(1) M=XRP(3875820019684212736)",
+		"|n=false ru=false D=IOU(m=5670000051597000,e=-11,neg=false,zero=false) DS=IOU(m=5670000051597000,e=-11,neg=false,zero=false) M=IOU(m=8641975230000000,e=5,neg=false,zero=false)|n=false ru=true D=IOU(m=5670000051597001,e=-11,neg=false,zero=false) DS=IOU(m=5670000051597001,e=-11,neg=false,zero=false) M=IOU(m=8641975230000000,e=5,neg=false,zero=false)|n=true ru=false D=XRP(56700) DS=XRP(56700) M=XRP(-2799448464348925952)|n=true ru=true D=XRP(56700) DS=XRP(56701) M=XRP(-2799448464348925952)",
+	}
+}

--- a/internal/tx/offer/offer_quality_golden_test.go
+++ b/internal/tx/offer/offer_quality_golden_test.go
@@ -60,7 +60,7 @@ func offerGoldenOperands() []tx.Amount {
 
 // TestOfferRoundGolden locks the byte-exact output of the offer-package
 // native-aware mul/div round variants. These feed offer-crossing exchange-rate
-// math, so the D1 consolidation onto the shared state core must not drift.
+// math, so the consolidation onto the shared state core must not drift.
 func TestOfferRoundGolden(t *testing.T) {
 	ops := offerGoldenOperands()
 	pairs := [][2]int{

--- a/internal/tx/payment/amm_liquidity.go
+++ b/internal/tx/payment/amm_liquidity.go
@@ -331,7 +331,7 @@ func isTrustLineFrozenForAMM(view *PaymentSandbox, ammAccountID, issuerID [20]by
 	// The issuer's freeze flag is on their side of the trust line.
 	// Reference: rippled View.cpp isFrozen():
 	//   (issuer > account) ? lsfHighFreeze : lsfLowFreeze
-	issuerIsHigh := state.CompareAccountIDsForLine(issuerID, ammAccountID) > 0
+	issuerIsHigh := state.CompareAccountIDs(issuerID, ammAccountID) > 0
 	if issuerIsHigh {
 		return (trustLine.Flags & state.LsfHighFreeze) != 0
 	}

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -225,7 +225,7 @@ func (s *BookStep) isFrozen(sb *PaymentSandbox, account [20]byte, currency strin
 		return false
 	}
 
-	issuerIsHigh := state.CompareAccountIDsForLine(issuer, account) > 0
+	issuerIsHigh := state.CompareAccountIDs(issuer, account) > 0
 	if issuerIsHigh {
 		return (rs.Flags & state.LsfHighFreeze) != 0
 	}
@@ -370,7 +370,7 @@ func (s *BookStep) getIOUBalance(sb *PaymentSandbox, account, issuer [20]byte, c
 	}
 
 	// Balance is stored from the low account's perspective
-	accountIsLow := state.CompareAccountIDsForLine(account, issuer) < 0
+	accountIsLow := state.CompareAccountIDs(account, issuer) < 0
 
 	var balance tx.Amount
 	if accountIsLow {

--- a/internal/tx/payment/step_book_trustline.go
+++ b/internal/tx/payment/step_book_trustline.go
@@ -26,7 +26,7 @@ func (s *BookStep) creditTrustline(sb *PaymentSandbox, account, issuer [20]byte,
 		return err
 	}
 
-	accountIsLow := state.CompareAccountIDsForLine(account, issuer) < 0
+	accountIsLow := state.CompareAccountIDs(account, issuer) < 0
 
 	// Compute sender's (issuer's) balance BEFORE update, from issuer's perspective.
 	// The sender here is 'issuer' (crediting account means issuer sends to account).
@@ -67,7 +67,7 @@ func (s *BookStep) creditTrustline(sb *PaymentSandbox, account, issuer [20]byte,
 // Reference: rippled View.cpp trustCreate() lines 1329-1445
 func (s *BookStep) trustCreateForCredit(sb *PaymentSandbox, account, issuer [20]byte, amount tx.Amount, txHash [32]byte, ledgerSeq uint32) error {
 	// Determine low and high accounts
-	accountIsLow := state.CompareAccountIDsForLine(account, issuer) < 0
+	accountIsLow := state.CompareAccountIDs(account, issuer) < 0
 	var lowAccountID, highAccountID [20]byte
 	if accountIsLow {
 		lowAccountID = account
@@ -202,7 +202,7 @@ func (s *BookStep) debitTrustline(sb *PaymentSandbox, account, issuer [20]byte, 
 	}
 
 	// The "sender" is account (their balance decreases)
-	accountIsLow := state.CompareAccountIDsForLine(account, issuer) < 0
+	accountIsLow := state.CompareAccountIDs(account, issuer) < 0
 
 	// Compute sender's (account's) balance BEFORE update (from sender's perspective)
 	var saBefore tx.Amount

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -235,7 +235,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	mPriorBalance := ctx.PriorBalance()
 
 	// Determine low/high accounts (for consistent trust line ordering)
-	bHigh := state.CompareAccountIDsForLine(accountID, issuerAccountID) > 0
+	bHigh := state.CompareAccountIDs(accountID, issuerAccountID) > 0
 
 	// Get or create the trust line
 	trustLineKey := keylet.Line(accountID, issuerAccountID, t.LimitAmount.Currency)

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -407,138 +407,33 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			return tx.TecNO_LINE_INSUF_RESERVE
 		}
 
-		// Determine the LOW and HIGH account IDs
-		var lowAccountID, highAccountID [20]byte
-		if !bHigh {
-			lowAccountID = accountID
-			highAccountID = issuerAccountID
-		} else {
-			lowAccountID = issuerAccountID
-			highAccountID = accountID
+		// Create the trust line through the shared canonical creator. The sender
+		// is rippled's "account being set" (it owns the limit), so LimitIssuer ==
+		// Src; tx.TrustCreate derives low/high ordering, reserve/flag placement,
+		// the peer-DefaultRipple noRipple rule, both owner-dir inserts, and the
+		// LowNode/HighNode deletion hints. OwnerCount stays a caller concern and
+		// PreviousTxnID/PreviousTxnLgrSeq are stamped by the apply threading pass.
+		accountStr, err := state.EncodeAccountID(accountID)
+		if err != nil {
+			return tx.TefINTERNAL
 		}
-
-		// Create new RippleState
-		// Note: In RippleState, Balance.Issuer is a special "no account" address (ACCOUNT_ONE)
-		rs := &state.RippleState{
-			Balance:           tx.NewIssuedAmount(0, -100, t.LimitAmount.Currency, state.AccountOneAddress),
-			Flags:             0,
-			LowNode:           0,
-			HighNode:          0,
-			PreviousTxnID:     ctx.TxHash,
-			PreviousTxnLgrSeq: ctx.Config.LedgerSequence,
-		}
-
-		// Note: In RippleState, LowLimit.Issuer = LOW account, HighLimit.Issuer = HIGH account
-		// The "issuer" in these Amount fields refers to which account owns that limit
-		lowAccountStr, _ := state.EncodeAccountID(lowAccountID)
-		highAccountStr, _ := state.EncodeAccountID(highAccountID)
-
-		if !bHigh {
-			// Transaction sender is LOW account
-			rs.LowLimit = tx.NewIssuedAmount(limitAmount.IOU().Mantissa(), limitAmount.IOU().Exponent(), t.LimitAmount.Currency, lowAccountStr)
-			rs.HighLimit = tx.NewIssuedAmount(0, -100, t.LimitAmount.Currency, highAccountStr)
-			rs.Flags |= state.LsfLowReserve
-		} else {
-			// Transaction sender is HIGH account
-			rs.LowLimit = tx.NewIssuedAmount(0, -100, t.LimitAmount.Currency, lowAccountStr)
-			rs.HighLimit = tx.NewIssuedAmount(limitAmount.IOU().Mantissa(), limitAmount.IOU().Exponent(), t.LimitAmount.Currency, highAccountStr)
-			rs.Flags |= state.LsfHighReserve
-		}
-
-		// Handle Auth flag for new trust line
-		if bSetAuth {
-			if bHigh {
-				rs.Flags |= state.LsfHighAuth
-			} else {
-				rs.Flags |= state.LsfLowAuth
-			}
-		}
-
-		// Handle NoRipple flag from transaction
-		if bSetNoRipple && !bClearNoRipple {
-			if bHigh {
-				rs.Flags |= state.LsfHighNoRipple
-			} else {
-				rs.Flags |= state.LsfLowNoRipple
-			}
-		}
-
-		// If the peer (destination/issuer) does not have DefaultRipple,
-		// set NoRipple on the peer's side of the trust line.
-		// Reference: rippled trustCreate() in View.cpp lines 1428-1432
-		if (issuerAccount.Flags & state.LsfDefaultRipple) == 0 {
-			if bHigh {
-				// Sender is high, peer is low
-				rs.Flags |= state.LsfLowNoRipple
-			} else {
-				// Sender is low, peer is high
-				rs.Flags |= state.LsfHighNoRipple
-			}
-		}
-
-		// Handle Freeze flag for new trust line
-		if bSetFreeze && !bClearFreeze && !bNoFreeze {
-			if bHigh {
-				rs.Flags |= state.LsfHighFreeze
-			} else {
-				rs.Flags |= state.LsfLowFreeze
-			}
-		}
-
-		// Handle DeepFreeze flag for new trust line
-		if bSetDeepFreeze && !bClearDeepFreeze && !bNoFreeze {
-			if bHigh {
-				rs.Flags |= state.LsfHighDeepFreeze
-			} else {
-				rs.Flags |= state.LsfLowDeepFreeze
-			}
-		}
-
-		// Handle QualityIn/QualityOut for new trust line
-		if bQualityIn && uQualityIn != 0 {
-			if bHigh {
-				rs.HighQualityIn = uQualityIn
-			} else {
-				rs.LowQualityIn = uQualityIn
-			}
-		}
-		if bQualityOut && uQualityOut != 0 {
-			if bHigh {
-				rs.HighQualityOut = uQualityOut
-			} else {
-				rs.LowQualityOut = uQualityOut
-			}
-		}
-
-		// Add trust line to LOW account's owner directory
-		lowDirKey := keylet.OwnerDir(lowAccountID)
-		lowDirResult, err := state.DirInsert(ctx.View, lowDirKey, trustLineKey.Key, false, func(dir *state.DirectoryNode) {
-			dir.Owner = lowAccountID
+		result := tx.TrustCreate(ctx.View, tx.TrustCreateParams{
+			SrcHigh:     bHigh,
+			Src:         accountID,
+			Dst:         issuerAccountID,
+			LineKey:     trustLineKey,
+			LimitIssuer: accountID,
+			Auth:        bSetAuth,
+			NoRipple:    bSetNoRipple && !bClearNoRipple,
+			Freeze:      bSetFreeze && !bClearFreeze && !bNoFreeze,
+			DeepFreeze:  bSetDeepFreeze && !bClearDeepFreeze && !bNoFreeze,
+			Balance:     tx.NewIssuedAmount(0, -100, t.LimitAmount.Currency, state.AccountOneAddress),
+			Limit:       tx.NewIssuedAmount(limitAmount.IOU().Mantissa(), limitAmount.IOU().Exponent(), t.LimitAmount.Currency, accountStr),
+			QualityIn:   uQualityIn,
+			QualityOut:  uQualityOut,
 		})
-		if err != nil {
-			return tx.TefINTERNAL
-		}
-
-		// Add trust line to HIGH account's owner directory
-		highDirKey := keylet.OwnerDir(highAccountID)
-		highDirResult, err := state.DirInsert(ctx.View, highDirKey, trustLineKey.Key, false, func(dir *state.DirectoryNode) {
-			dir.Owner = highAccountID
-		})
-		if err != nil {
-			return tx.TefINTERNAL
-		}
-
-		// Set LowNode and HighNode on the RippleState (deletion hints)
-		rs.LowNode = lowDirResult.Page
-		rs.HighNode = highDirResult.Page
-
-		trustLineData, err := state.SerializeRippleState(rs)
-		if err != nil {
-			return tx.TefINTERNAL
-		}
-
-		if err := ctx.View.Insert(trustLineKey, trustLineData); err != nil {
-			return tx.TefINTERNAL
+		if result != tx.TesSUCCESS {
+			return result
 		}
 
 		ctx.Account.OwnerCount++

--- a/internal/tx/utils.go
+++ b/internal/tx/utils.go
@@ -54,7 +54,7 @@ func IsTrustlineFrozen(view LedgerView, accountID, issuerID [20]byte, currency s
 	// Check if the ISSUER has frozen this trust line.
 	// Reference: rippled View.cpp isFrozen() - checks the issuer's freeze flag:
 	//   (issuer > account) ? lsfHighFreeze : lsfLowFreeze
-	issuerIsHigh := state.CompareAccountIDsForLine(issuerID, accountID) > 0
+	issuerIsHigh := state.CompareAccountIDs(issuerID, accountID) > 0
 	if issuerIsHigh {
 		return (rs.Flags & state.LsfHighFreeze) != 0
 	}
@@ -95,7 +95,7 @@ func IsIndividualFrozen(view LedgerView, accountID [20]byte, asset Asset) bool {
 	// Reference: rippled View.cpp isFrozen() line 264:
 	//   sle->isFlag((issuer > account) ? lsfHighFreeze : lsfLowFreeze)
 	// The freeze flag is on the ISSUER's side of the trust line.
-	issuerIsHigh := state.CompareAccountIDsForLine(issuerID, accountID) > 0
+	issuerIsHigh := state.CompareAccountIDs(issuerID, accountID) > 0
 	if issuerIsHigh {
 		return (rs.Flags & state.LsfHighFreeze) != 0
 	}
@@ -171,7 +171,7 @@ func RequireAuth(view LedgerView, asset Asset, accountID [20]byte) Result {
 	}
 
 	// (account > issuer) ? lsfLowAuth : lsfHighAuth
-	if state.CompareAccountIDsForLine(accountID, issuerID) > 0 {
+	if state.CompareAccountIDs(accountID, issuerID) > 0 {
 		if (rs.Flags & state.LsfLowAuth) == 0 {
 			return TecNO_AUTH
 		}
@@ -454,7 +454,7 @@ func AccountFunds(view LedgerView, accountID [20]byte, amount Amount, fhZeroIfFr
 	}
 
 	// Determine balance based on canonical ordering
-	accountIsLow := state.CompareAccountIDsForLine(accountID, issuerID) < 0
+	accountIsLow := state.CompareAccountIDs(accountID, issuerID) < 0
 	balance := rs.Balance
 	if !accountIsLow {
 		balance = balance.Negate()


### PR DESCRIPTION
## Summary

Completes the structural-consolidation tail of the #894 ledger-core audit. The correctness/contract findings (H1–H3, M1–M6, L1–L2) and part of Phase D (genesis flags, ledger-hash dedup, dead code, docs) already landed in **#924**; verification confirmed every other finding was either fixed there or stale. This PR delivers the deferred dedup that #924 intentionally skipped, with no behavioural change:

- **D5** — `CompareAccountIDsForLine` was a byte-identical duplicate of `CompareAccountIDs`; dropped it and repointed all call sites.
- **D1** — the six mul/div round variants in `state/amount_round.go` and the three native-aware reimplementations in `offer/offer_quality.go` each repeated the same operand prep, muldiv-round core, and IOU/native canonicalize. Extracted one shared core in `state` (`PrepareMulDivOperand`, `Mul`/`DivMantissas`, `CanonicalizeRoundIOUOverflow`, `FinalizeRoundIOU`); the offer wrappers now keep only their native-drops path and zero-returns-zero contract. Production code −509 LOC.
- **D3 (VL/hex)** — `oracle_entry`'s `parseVLLength` now delegates to `field_walker`'s canonical `readVLLength`; `permissioned_domain_entry` uses the shared `parseUint64Hex` instead of its own `strconv.ParseUint`.
- **D2 (trustset)** — `TrustSet`'s new-line branch hand-rolled the `RippleState` construction; routed it through the shared `tx.TrustCreate` (already used by Check and Escrow). `PreviousTxnID`/`PreviousTxnLgrSeq` are stamped identically by the apply threading pass, so the serialized line is byte-for-byte unchanged.

Net **−407 LOC** across 22 files.

## Consensus-safety verification

This touches consensus-relevant amount math and trust-line creation, so every change is locked to byte-identical output:

- **D1** is guarded by golden tests (`amount_round_golden_test.go`, `offer_quality_golden_test.go`) captured from the pre-refactor implementation over signed, native, extreme-exponent, and overflow/divide-by-zero/panic inputs.
- **D2** byte-identity is reasoned from the flag-placement logic (peer-`DefaultRipple` noRipple lands on the same side) and the `ActionInsert` threading pass that stamps `PreviousTxn*` to the same values `TrustSet` set explicitly.

## Deliberately out of scope (documented, not punted lightly)

A rigorous diff of the remaining trust-line creators showed they **cannot** be folded into `tx.TrustCreate` without changing the serialized `RippleState` — a consensus divergence, not a mechanical dedup:

- `payment/step_direct`, `payment/step_book_trustline`, `amm`, `nftoken` place the `DefaultRipple`-derived noRipple flag on a different side of the line than rippled's `trustCreate`. Reconciling that is a **correctness** question (these may diverge from rippled) deserving its own change, not a refactor.
- The 11-parser → `WalkFields` regime convergence is consensus-critical with zero behavioural benefit on valid (serializer-emitted) data; converting tuned, well-covered SLE parsers en masse risks parse divergence. The shared `WalkFields`/`readVLLength` primitive remains the single source for new parsers.

## Test plan

- [x] `go vet ./internal/...` — clean
- [x] `go test ./internal/tx/...` — 23/23 packages pass
- [x] `go test ./internal/testing/...` — 43/43 packages pass
- [x] `go test ./internal/ledger/state/...` incl. D1 golden equivalence — pass
- [x] `go test ./internal/testing/{offer,amm,payment,trustset,oracle,permissioneddomain}/...` — pass
- [x] `gofmt -l` on all changed files — clean

Refs #894